### PR TITLE
[SCHEDULE] Refactor bound inference logic

### DIFF
--- a/include/tvm/schedule_pass.h
+++ b/include/tvm/schedule_pass.h
@@ -22,7 +22,7 @@ namespace schedule {
  * \param sch The root schedule to infer all the bounds.
  * \return the result bound of the iteration Variable
  */
-Map<IterVar, Range> InferBound(Schedule sch);
+Map<IterVar, Range> InferBound(const Schedule& sch);
 
 /*!
  * \brief Schedule s' dependent operations.

--- a/src/arithmetic/int_set.h
+++ b/src/arithmetic/int_set.h
@@ -103,6 +103,9 @@ IntSet EvalSet(Expr e,
  */
 IntSet EvalSet(Range r,
                const Map<IterVar, IntSet>& dom_map);
+IntSet EvalSet(Range r,
+               const std::unordered_map<const Variable*, IntSet>& dom_map);
+
 
 /*!
  * \brief Create an union set of all sets


### PR DESCRIPTION
The new inference logic uses a relax approach, to relax the bound of direct consumers.
- This avoids the bound prop by indirect dependencies
- This ensures there is no OOB error when reading from the internal estimated buffer