### PR TITLE
[LANG] Introduce Scan, bugfix Canonical

### DIFF
--- a/python/tvm/tensor.py
+++ b/python/tvm/tensor.py
@@ -75,11 +75,16 @@ class Operation(NodeBase):
         return _api_internal._OpGetOutput(self, index)
 
 @register_node
+class PlaceholderOp(Operation):
+    """Placeholder operation."""
+    pass
+
+@register_node
 class ComputeOp(Operation):
     """Compute operation."""
     pass
 
 @register_node
-class PlaceholderOp(Operation):
-    """Placeholder operation."""
+class ScanOp(Operation):
+    """Scan operation."""
     pass

--- a/src/api/api_lang.cc
+++ b/src/api/api_lang.cc
@@ -173,6 +173,15 @@ TVM_REGISTER_API(_ComputeOp)
                                args[2]);
   });
 
+TVM_REGISTER_API(_ScanOp)
+.set_body([](TVMArgs args,  TVMRetValue* ret) {
+    *ret = ScanOpNode::make(args[0],
+                            args[1],
+                            args[2],
+                            args[3],
+                            args[4]);
+  });
+
 TVM_REGISTER_API(_OpGetOutput)
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
     *ret = args[0].operator Operation().output(

--- a/src/arithmetic/canonical.cc
+++ b/src/arithmetic/canonical.cc
@@ -365,7 +365,7 @@ class Canonical::Internal : public IRMutator {
                   const ComExpr& sumb,
                   int bscale) {
     std::shared_ptr<ComExprNode> n = std::make_shared<ComExprNode>();
-    n->base = suma->base + sumb->base;
+    n->base = suma->base + sumb->base * bscale;
     // merge of suma and sumb;
     size_t i = 0, j = 0;
     while (i < suma->elem.size() && j < sumb->elem.size()) {
@@ -417,7 +417,7 @@ class Canonical::Internal : public IRMutator {
   // convert sum to expr
   Expr Sum2Expr(const ComExpr& com, Type t) {
     Expr vsum;
-    if (com->base != 0) {
+    if (com->base > 0) {
       vsum = make_const(t, com->base);
     }
     for (const ComExprEntry& e : com->elem) {
@@ -431,6 +431,13 @@ class Canonical::Internal : public IRMutator {
         } else {
           vsum = v;
         }
+      }
+    }
+    if (com->base < 0) {
+      if (vsum.defined()) {
+        vsum = Sub::make(vsum, make_const(t, -com->base));
+      } else {
+        vsum = make_const(t, com->base);
       }
     }
     for (const ComExprEntry& e : com->elem) {

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -168,7 +168,7 @@ MakeNVRTC(Array<LoweredFunc> funcs) {
     const auto& f = PackedFunc::GetGlobal("tvm_callback_cuda_postproc");
     code = f(code).operator std::string();
   }
-    LOG(INFO) << code;
+
   std::string ptx;
   if (PackedFunc::GlobalExist("tvm_callback_cuda_compile")) {
     const auto& f = PackedFunc::GetGlobal("tvm_callback_cuda_compile");

--- a/src/codegen/codegen_cuda.h
+++ b/src/codegen/codegen_cuda.h
@@ -42,7 +42,7 @@ class CodeGenCUDA : public CodeGenC {
  private:
   // magic number to add pragma unroll to it.
   // used to generate code that is compact but still unrolls.
-  int max_auto_unroll_{8};
+  int max_auto_unroll_{1025};
 };
 
 }  // namespace codegen

--- a/src/lang/operation.cc
+++ b/src/lang/operation.cc
@@ -5,6 +5,7 @@
 #include <tvm/operation.h>
 #include <tvm/tensor.h>
 #include <tvm/ir.h>
+#include <tvm/ir_pass.h>
 #include <memory>
 
 namespace tvm {
@@ -119,5 +120,91 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
 });
 
 TVM_REGISTER_NODE_TYPE(ComputeOpNode);
+
+// Scan
+inline bool prove_equal(Expr lhs, Expr rhs) {
+  return is_zero(ir::Simplify(lhs - rhs));
+}
+
+int ScanOpNode::num_outputs() const {
+  return update.size();
+}
+Array<IterVar> ScanOpNode::root_iter_vars() const {
+  return Array<IterVar>{scan_axis};
+}
+
+Type ScanOpNode::output_dtype(size_t i) const {
+  return update[i]->dtype;
+}
+
+Array<Expr> ScanOpNode::output_shape(size_t i) const {
+  CHECK_LT(i, state_placeholder.size());
+  return state_placeholder[i]->shape;
+}
+
+Operation ScanOpNode::make(std::string name,
+                           IterVar axis,
+                           Array<Tensor> init,
+                           Array<Tensor> update,
+                           Array<Tensor> state_placeholder) {
+  auto n = std::make_shared<ScanOpNode>();
+  CHECK_EQ(init.size(), update.size());
+  CHECK_EQ(init.size(), state_placeholder.size());
+
+  for (size_t i = 0; i < init.size(); ++i) {
+    CHECK_EQ(init[i]->dtype, state_placeholder[i]->dtype);
+    CHECK_EQ(init[i]->dtype, update[i]->dtype);
+    CHECK(can_prove(init[i]->shape[0] == axis->dom->min))
+        << "init.shape[0] need to match scan_axis.dom.min";
+    CHECK(prove_equal(
+        state_placeholder[i]->shape[0], axis->dom->min + axis->dom->extent))
+        << "shate_placeholder.shape[0] need to match"
+        << " scan_axis.dom.min + scan_axis.dom.extent";
+    CHECK_EQ(state_placeholder[i].ndim(), init[i].ndim())
+        << "The dimension of init need to match state_placeholder";
+    CHECK_EQ(update[i].ndim() + 1, state_placeholder[i].ndim())
+        << "The update.ndim need to be state_placeholder.ndim - 1";
+    for (size_t k = 0;  k < update[i].ndim(); ++k) {
+      CHECK(prove_equal(
+          update[i]->shape[k], state_placeholder[i]->shape[k + 1]));
+      // setup spatial axis
+      std::ostringstream spatial_name;
+      spatial_name << name << ".out" << i << ".i" << k + 1;
+      n->spatial_axis_.push_back(
+          IterVar(Range::make_with_min_extent(0, update[i]->shape[k]),
+                  spatial_name.str()));
+    }
+    for (size_t k = 1;  k < init[i].ndim(); ++k) {
+      CHECK(prove_equal(
+          init[i]->shape[k], state_placeholder[i]->shape[k]));
+    }
+  }
+
+  n->name = name;
+  n->scan_axis = axis;
+  n->init = init;
+  n->update = update;
+  n->state_placeholder = state_placeholder;
+  return Operation(n);
+}
+
+Array<Tensor> Scan(IterVar scan_axis,
+                   Array<Tensor> init,
+                   Array<Tensor> update,
+                   Array<Tensor> state_placeholder,
+                   std::string name) {
+  Operation op = ScanOpNode::make(
+      name, scan_axis, init, update, state_placeholder);
+  Array<Tensor> res;
+  for (int i = 0; i < op->num_outputs(); ++i) {
+    res.push_back(op.output(i));
+  }
+  return res;
+}
+
+TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
+.set_dispatch<ScanOpNode>([](const ScanOpNode *op, IRPrinter *p) {
+    p->stream << "scan(" << op->name << ", " << op << ")";
+});
 
 }  // namespace tvm

--- a/src/pass/inject_virtual_thread.cc
+++ b/src/pass/inject_virtual_thread.cc
@@ -191,20 +191,16 @@ class VTInjector : public IRMutator {
   }
   // Attribute
   Stmt Mutate_(const AttrStmt* op, const Stmt& s) final {
-    if (op->type_key == attr::scope) {
-      return Mutate(op->body);
+    Expr value = Mutate(op->value);
+    if (visit_touched_var_) {
+      return InjectVTLoop(s, true);
     } else {
-      Expr value = Mutate(op->value);
-      if (visit_touched_var_) {
-        return InjectVTLoop(s, true);
+      Stmt body = Mutate(op->body);
+      if (value.same_as(op->value) &&
+          body.same_as(op->body)) {
+        return s;
       } else {
-        Stmt body = Mutate(op->body);
-        if (value.same_as(op->value) &&
-            body.same_as(op->body)) {
-          return s;
-        } else {
-          return AttrStmt::make(op->node, op->type_key, value, body);
-        }
+        return AttrStmt::make(op->node, op->type_key, value, body);
       }
     }
   }

--- a/src/pass/storage_flatten.cc
+++ b/src/pass/storage_flatten.cc
@@ -11,40 +11,6 @@
 namespace tvm {
 namespace ir {
 
-// key of function buffer
-struct TensorKey {
-  FunctionRef f;
-  int value_index;
-
-  inline bool operator==(const TensorKey& other) const {
-    return f == other.f && value_index == other.value_index;
-  }
-  inline std::string GetName() const {
-    if (f->num_outputs() == 1) return f->func_name();
-    std::ostringstream os;
-    os << f->func_name() << ".v" << value_index;
-    return os.str();
-  }
-};
-
-}  // namespace ir
-}  // namespace tvm
-
-namespace std {
-template <>
-struct hash<::tvm::ir::TensorKey> {
-  std::size_t operator()(const ::tvm::ir::TensorKey& k) const {
-    size_t lhs = k.f.hash();
-    size_t rhs = static_cast<size_t>(k.value_index);
-    lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
-    return lhs;
-  }
-};
-}  // namespace std
-
-namespace tvm {
-namespace ir {
-
 using Halide::Internal::Region;
 using runtime::StorageScope;
 using runtime::ThreadScope;

--- a/src/schedule/schedule_lang.cc
+++ b/src/schedule/schedule_lang.cc
@@ -146,6 +146,8 @@ Stage& Stage::fuse(IterVar inner, IterVar outer, IterVar* p_target) {  // NOLINT
 
 Stage& Stage::reorder(const Array<IterVar>& order) {  // NOLINT(*)
   StageNode* self = operator->();
+  CHECK(!self->op.as<ScanOpNode>())
+      << "Cannot reorder axis of scan";
   ArrayNode* all_vars = self->all_iter_vars.CopyOnWrite();
   ArrayNode* leaf_vars = self->leaf_iter_vars.CopyOnWrite();
   std::vector<size_t> pos;

--- a/tests/python/integration/test_scan.py
+++ b/tests/python/integration/test_scan.py
@@ -1,0 +1,54 @@
+import tvm
+import numpy as np
+
+def test_scan():
+    m = tvm.Var("m")
+    n = tvm.Var("n")
+    t = tvm.IterVar((1, m), name="t")
+    X = tvm.placeholder((m, n), name="X")
+    s_state = tvm.placeholder((m, n))
+    s_init = tvm.compute((1, n), lambda _, i: X[0, i])
+    s_update = tvm.compute((n,), lambda i: s_state[t-1, i] + X[t, i])
+    res = tvm.scan(t, s_init, s_update, s_state)
+
+    # schedule
+    s = tvm.Schedule(res.op)
+    num_thread = 256
+    block_x = tvm.IterVar(thread_tag="blockIdx.x")
+    thread_x = tvm.IterVar((0, num_thread), thread_tag="threadIdx.x")
+    _, x = s[s_init].split(s_init.op.axis[1], factor=num_thread, outer=block_x)
+    _, x = s[s_init].split(x, outer=thread_x)
+    _, x = s[s_update].split(s_update.op.axis[0], factor=num_thread, outer=block_x)
+    _, x = s[s_update].split(x, outer=thread_x)
+
+    # one line to build the function.
+    def check_device(target):
+        codes = []
+        fscan = tvm.build(s, [X, res],
+                          target, record_codes=codes,
+                          name="myscan")
+        if target == "cuda":
+            ctx = tvm.gpu(0)
+        else:
+            ctx = tvm.cl(0)
+        if not ctx.enabled:
+            return
+
+        for c in codes[1:]:
+            print(c)
+        # launch the kernel.
+        n = 1024
+        m = 10
+        a_np = np.random.uniform(size=(m, n)).astype(res.dtype)
+        a = tvm.nd.array(a_np, ctx)
+        b = tvm.nd.array(np.zeros((m, n), dtype=res.dtype), ctx)
+        fscan(a, b)
+        np.testing.assert_allclose(
+            b.asnumpy(), np.cumsum(a_np, axis=0))
+
+    tvm.init_opencl()
+    check_device("cuda")
+
+
+if __name__ == "__main__":
+    test_scan()

--- a/tests/python/unittest/test_lang_tensor.py
+++ b/tests/python/unittest/test_lang_tensor.py
@@ -34,6 +34,20 @@ def test_tensor_reduce():
     assert(str(C_loaded) == str(C))
 
 
+def test_tensor_scan():
+    m = tvm.Var("m")
+    n = tvm.Var("n")
+    t = tvm.IterVar((1, m), "t")
+    x = tvm.placeholder((m, n))
+    s = tvm.placeholder((m, n))
+    res = tvm.scan(t,
+                   tvm.compute((1, n), lambda _, i: x[0, i]),
+                   tvm.compute((n,), lambda i: s[t-1, i] + x[t, i]),
+                   s)
+    assert tuple(res.shape) == (m, n)
+
+
 if __name__ == "__main__":
     test_tensor()
     test_tensor_reduce()
+    test_tensor_scan()

--- a/tests/python/unittest/test_pass_simplify.py
+++ b/tests/python/unittest/test_pass_simplify.py
@@ -18,9 +18,15 @@ def test_simplify():
                                         tvm.make.Load(dtype, Ab.data, i + 4) + 1,
                                         (j + 1) * 4 - 4 * j + i),
                          None)))
-    print(stmt)
     stmt = tvm.ir_pass.CanonicalSimplify(stmt)
-    print(stmt)
+
+
+def test_basic():
+    m = tvm.Var('m')
+    ret = tvm.ir_pass.CanonicalSimplify(tvm.make.Evaluate(m-1))
+    assert str(ret.value) == "(m - 1)"
+
 
 if __name__ == "__main__":
+    test_basic()
     test_simplify()

--- a/tests/python/unittest/test_schedule_schedule_ops.py
+++ b/tests/python/unittest/test_schedule_schedule_ops.py
@@ -6,13 +6,11 @@ def test_schedule0():
     l = tvm.Var('l')
     A = tvm.placeholder((m, l), name='A')
     A1 = tvm.compute((m, l), lambda i, j: A[i, j], name='A1')
-
     s = tvm.Schedule(A1.op)
 
     bounds = tvm.schedule.InferBound(s)
     assert isinstance(bounds, tvm.collections.Map)
     stmt = tvm.schedule.ScheduleOps(s, bounds)
-    print(stmt)
 
 def test_schedule1():
     m = tvm.Var('m')
@@ -25,7 +23,7 @@ def test_schedule1():
     bounds = tvm.schedule.InferBound(s)
     assert isinstance(bounds, tvm.collections.Map)
     stmt = tvm.schedule.ScheduleOps(s, bounds)
-    print(stmt)
+
 
 def test_schedule2():
     m = tvm.Var('m')
@@ -40,25 +38,45 @@ def test_schedule2():
     bounds = tvm.schedule.InferBound(s)
     assert isinstance(bounds, tvm.collections.Map)
     stmt = tvm.schedule.ScheduleOps(s, bounds)
+
+
+def test_schedule_scan():
+    m = tvm.Var("m")
+    n = tvm.Var("n")
+    l = tvm.Var("l")
+    t = tvm.IterVar((1, m), name="t")
+    x = tvm.compute((m, n), lambda i, j: tvm.const(1, "float32"), name="x")
+    s_state = tvm.placeholder((m, n))
+    s_init = tvm.compute((1, n), lambda _, i: x[0, i])
+    s_update = tvm.compute((n,), lambda i: s_state[t-1, i] + x[t, i])
+    res = tvm.scan(t, s_init, s_update, s_state)
+
+    assert tuple(res.shape) == (m, n)
+    s = tvm.Schedule(res.op)
+    s.normalize()
+    bounds = tvm.schedule.InferBound(s)
+    assert(bounds[res.op.scan_axis].min.value == 1)
+    stmt = tvm.schedule.ScheduleOps(s, bounds)
     print(stmt)
 
-def test_auto_inline():
-  m = tvm.Var('m')
-  n = tvm.Var('n')
-  A = tvm.placeholder((m, n), name='A')
-  B = tvm.placeholder((m, n), name='B')
-  C = tvm.placeholder((m, n), name='C')
-  T1 = tvm.compute((m, n), lambda i, j:  A(i, j) * B(i, j), name='T1')
-  T2 = tvm.compute((m, n), lambda i, j: T1(i, j) + C(i, j), name='T2')
 
-  s = tvm.Schedule(T2.op)
-  tvm.schedule.AutoInlineElemWise(s)
-  bounds = tvm.schedule.InferBound(s)
-  stmt = tvm.schedule.ScheduleOps(s, bounds)
-  print(stmt)
+def test_auto_inline():
+    m = tvm.Var('m')
+    n = tvm.Var('n')
+    A = tvm.placeholder((m, n), name='A')
+    B = tvm.placeholder((m, n), name='B')
+    C = tvm.placeholder((m, n), name='C')
+    T1 = tvm.compute((m, n), lambda i, j:  A(i, j) * B(i, j), name='T1')
+    T2 = tvm.compute((m, n), lambda i, j: T1(i, j) + C(i, j), name='T2')
+
+    s = tvm.Schedule(T2.op)
+    tvm.schedule.AutoInlineElemWise(s)
+    bounds = tvm.schedule.InferBound(s)
+    stmt = tvm.schedule.ScheduleOps(s, bounds)
 
 
 if __name__ == "__main__":
+    test_schedule_scan()
     test_schedule0()
     test_schedule1()
     test_schedule2()


### PR DESCRIPTION
## Introduce the scan operator
The following code compute the cumsum of X
```python
def my_cumsum():
   m = tvm.Var("m")
    n = tvm.Var("n")
    t = tvm.IterVar((1, m), name="t")
    X = tvm.placeholder((m, n), name="X")
    s_state = tvm.placeholder((m, n))
    s_init = tvm.compute((1, n), lambda _, i: X[0, i])
    s_update = tvm.compute((n,), lambda i: s_state[t-1, i] + X[t, i])
    res = tvm.scan(t, s_init, s_update, s_state)
```

### Known Limitations to be Improved
- There is no checking yet on the scan reference to state, should always ensure only refer to previous timestamp
- Do not yet allow subslice result of scan, need to add fix point detection to allow subslice axis that are simple(only refers to itself during recursion)

## Bug Fix in Canonical
Previously did not multiple constant by -1 during sub, making ```m-1``` to ```m+1```, added a regression test.

