### PR TITLE
[LANG/SCHEDULE] Reduction factor, predicate in reduction.

### DIFF
--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -40,6 +40,8 @@ using Halide::Internal::as_const_uint;
 using Halide::Internal::const_true;
 using Halide::Internal::const_false;
 using Halide::Internal::is_no_op;
+using Halide::likely;
+using Halide::likely_if_innermost;
 
 inline Type TVMShapeIndexType() {
   if (std::is_signed<tvm_index_t>::value) {

--- a/include/tvm/ir.h
+++ b/include/tvm/ir.h
@@ -41,7 +41,7 @@ struct Reduce : public ExprNode<Reduce> {
   /*! \brief construct expr from op and rdom */
   static Expr make(std::string op, Expr src,
                    Array<IterVar> rdom,
-                   Expr condition = make_const(Bool(1), true));
+                   Expr condition = const_true());
 
   void VisitAttrs(AttrVisitor* v) final {
     v->Visit("dtype", &type);

--- a/include/tvm/schedule.h
+++ b/include/tvm/schedule.h
@@ -211,6 +211,18 @@ class Schedule : public NodeRef {
    */
   Tensor cache_write(const Tensor& tensor, const std::string& scope);
   /*!
+   * \brief Factor a reduction axis in tensor's schedule to be an explicit axis.
+   * This will create a new stage that generated the new tensor with axis
+   * as the first dimension. The tensor's body wil be rewriten as a reduction
+   * over the factored tensor.
+   *
+   * \param tensor The tensor to be factored.
+   * \param axis The reduction axis in tensor's schedule to be factored.
+   * \return The created factored tensor.
+   */
+  Tensor rfactor(const Tensor& tensor,
+                 const IterVar& axis);
+  /*!
    * \brief Normalize the schedule.
    *  This is needed before bound inference.
    *  Insert necessary RebaseNode to make sure all leaf_iter_vars

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -19,4 +19,4 @@ from .ndarray import cpu, gpu, opencl, cl, vpi
 
 from ._base import TVMError
 from .api import *
-from .build import build
+from .build import build, lower

--- a/python/tvm/api.py
+++ b/python/tvm/api.py
@@ -372,7 +372,7 @@ def reduce_axis(dom, name="rv"):
     return _IterVar(dom, name, 2)
 
 
-def sum(expr, axis):
+def sum(expr, axis, where=None):
     """Create a sum expression over axis
 
     Parameters
@@ -382,13 +382,16 @@ def sum(expr, axis):
 
     axis : IterVar
         The reduction IterVar axis
+
+    where : optional, Expr
+        Filtering predicate of the reduction.
     """
     axis = axis if isinstance(axis, list) else [axis]
-    x = _make.Reduce("Add", expr, axis)
+    x = _make.Reduce("Add", expr, axis, where)
     return x
 
 
-def min(lhs, rhs=None, axis=None):
+def min(lhs, rhs=None, axis=None, where=None):
     """Create a min expression.
 
     Parameters
@@ -401,6 +404,9 @@ def min(lhs, rhs=None, axis=None):
 
     axis : IterVar, optional
         The reduction IterVar axis
+
+    where : optional, Expr
+        Filtering predicate of the reduction.
     """
     if rhs and axis:
         raise ValueError("Can only take one argument, rhs or axis")
@@ -409,11 +415,11 @@ def min(lhs, rhs=None, axis=None):
     if rhs:
         return _make.Min(lhs, rhs)
     axis = axis if isinstance(axis, list) else [axis]
-    x = _make.Reduce("Min", expr, axis)
+    x = _make.Reduce("Min", expr, axis, where)
     return x
 
 
-def max(lhs, rhs=None, axis=None):
+def max(lhs, rhs=None, axis=None, where=None):
     """Create a max expression.
 
     Parameters
@@ -426,6 +432,9 @@ def max(lhs, rhs=None, axis=None):
 
     axis : IterVar, optional
         The reduction IterVar axis
+
+    where : optional, Expr
+        Filtering predicate of the reduction.
     """
     if rhs and axis:
         raise ValueError("Can only take one argument, rhs or axis")
@@ -434,7 +443,7 @@ def max(lhs, rhs=None, axis=None):
     if rhs:
         return _make.Max(lhs, rhs)
     axis = axis if isinstance(axis, list) else [axis]
-    x = _make.Reduce("Max", expr, axis)
+    x = _make.Reduce("Max", expr, axis, where)
     return x
 
 

--- a/python/tvm/schedule.py
+++ b/python/tvm/schedule.py
@@ -87,6 +87,27 @@ class Schedule(NodeBase):
         """
         return _api_internal._ScheduleCacheWrite(self, tensor, scope)
 
+    def rfactor(self, tensor, axis):
+        """ Factor a reduction axis in tensor's schedule to be an explicit axis.
+
+        This will create a new stage that generated the new tensor with axis
+        as the first dimension. The tensor's body wil be rewriten as a reduction
+        over the factored tensor.
+
+        Parameters
+        ----------
+        tensor : Tensor
+            The tensor to be factored.
+        axis : IterVar
+            The reduction axis in the schedule to be factored.
+
+        Returns
+        -------
+        tfactor : Tensor
+            The created factored tensor.
+        """
+        return _api_internal._ScheduleRFactor(self, tensor, axis)
+
 
 @register_node
 class Stage(NodeBase):
@@ -114,8 +135,6 @@ class Stage(NodeBase):
             The inner variable of iteration.
         """
         if outer is not None:
-            if outer.thread_tag == '':
-                raise ValueError("split by outer must have special thread_tag")
             inner = _api_internal._StageSplitByOuter(self, parent, outer, factor)
         else:
             if factor is None:

--- a/src/api/api_ir.cc
+++ b/src/api/api_ir.cc
@@ -89,7 +89,7 @@ TVM_REGISTER_API(_make_Allocate)
       *ret = Node::make(a, b);                               \
     })
 
-REGISTER_MAKE3(Reduce);
+REGISTER_MAKE4(Reduce);
 REGISTER_MAKE4(AttrStmt);
 
 REGISTER_MAKE2(IntImm);

--- a/src/api/api_lang.cc
+++ b/src/api/api_lang.cc
@@ -318,4 +318,10 @@ TVM_REGISTER_API(_ScheduleCacheWrite)
         .cache_write(args[1], args[2]);
   });
 
+TVM_REGISTER_API(_ScheduleRFactor)
+.set_body([](TVMArgs args, TVMRetValue* ret) {
+    *ret = args[0].operator Schedule()
+        .rfactor(args[1], args[2]);
+  });
+
 }  // namespace tvm

--- a/src/codegen/codegen_c.cc
+++ b/src/codegen/codegen_c.cc
@@ -526,8 +526,8 @@ void CodeGenC::VisitExpr_(const Load* op, std::ostream& os) {  // NOLINT(*)
 void CodeGenC::VisitStmt_(const Store* op) {
   Type t = op->value.type();
   if (t.lanes() == 1) {
-    this->PrintIndent();
     std::string value = this->PrintExpr(op->value);
+    this->PrintIndent();
     this->PrintBufferRef(op->buffer_var.get(), t, op->index, stream);
     stream << " = " << value << ";\n";
   } else {

--- a/src/lang/ir.cc
+++ b/src/lang/ir.cc
@@ -28,7 +28,7 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
   p->print(op->source);
   p->stream << ", axis=" << op->axis;
   if (!is_const(op->condition, 1)) {
-    p->stream << ", condition=" << op->condition;
+    p->stream << ", where=" << op->condition;
   }
   p->stream << ")";
 });
@@ -44,6 +44,9 @@ Expr Reduce::make(std::string op, Expr source,
   for (size_t i = 0; i < axis.size(); ++i) {
     CHECK_EQ(axis[i]->iter_type, kCommReduce)
         << "Can only take axis created by reduce_axis";
+  }
+  if (!condition.defined()) {
+    condition = const_true();
   }
   auto n = std::make_shared<Reduce>();
   CHECK(source.defined());

--- a/src/lang/operation.cc
+++ b/src/lang/operation.cc
@@ -1,6 +1,0 @@
-/*!
- *  Copyright (c) 2016 by Contributors
- * \file operation.cc
- */
-#include <tvm/operation.h>
-#include <tvm/tensor.h>

--- a/src/schedule/message_passing.cc
+++ b/src/schedule/message_passing.cc
@@ -1,0 +1,343 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file message_passing.cc
+ * \brief The message passing domain.
+ */
+#include <tvm/arithmetic.h>
+#include <tvm/ir.h>
+#include <tvm/ir_pass.h>
+#include "./message_passing.h"
+
+namespace tvm {
+namespace schedule {
+
+using namespace arith;
+
+// result = ceil((a / b)), both a and b are positive integer
+inline Expr DivCeil(Expr a, Expr b) {
+  return ir::Simplify((a + b - 1) / b);
+}
+
+inline bool prove_equal(Expr lhs, Expr rhs) {
+  return is_zero(ir::Simplify(lhs - rhs));
+}
+
+void PassDownDomain(const Stage& stage,
+                    std::unordered_map<IterVar, Range>* p_state,
+                    bool allow_missing) {
+  auto& state = *p_state;
+  // forwar iteration on relations
+  for (IterVarRelation rel : stage->relations) {
+    if (const SplitNode* r = rel.as<SplitNode>()) {
+      if (!state.count(r->parent)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      CHECK(!state.count(r->inner));
+      const Range& range_parent = state.at(r->parent);
+      if (r->factor.defined()) {
+        state[r->inner] = Range::make_with_min_extent(0, r->factor);
+        if (r->outer->dom.defined()) {
+          state[r->outer] = r->outer->dom;
+        } else {
+          if (!state.count(r->outer)) {
+            state[r->outer] = Range::make_with_min_extent(
+                0, DivCeil(range_parent->extent, r->factor));
+          } else {
+            Expr outer_ext = DivCeil(range_parent->extent, r->factor);
+            Range outer_rng = state.at(r->outer);
+            bool match = is_zero(outer_rng->min);
+            if (!prove_equal(outer_ext, outer_rng->extent)) match = false;
+            CHECK(match)
+                << r->outer
+                << "IterVar is used in two places as outer scope,"
+                << " cannot prove their extents are the same "
+                << outer_ext << " vs " << outer_rng->extent;
+          }
+        }
+      } else {
+        CHECK(r->outer->dom.defined());
+        state[r->outer] = r->outer->dom;
+        state[r->inner] = Range::make_with_min_extent(
+            0, DivCeil(range_parent->extent, r->outer->dom->extent));
+      }
+    } else if (const FuseNode* r = rel.as<FuseNode>()) {
+      if (!state.count(r->outer) || !state.count(r->inner)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      const Range& range_outer = state.at(r->outer);
+      const Range& range_inner = state.at(r->inner);
+      state[r->fused] = Range::make_with_min_extent(
+          0, range_outer->extent * range_inner->extent);
+    } else if (const RebaseNode* r = rel.as<RebaseNode>()) {
+      if (!state.count(r->parent)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      state[r->rebased] = Range::make_with_min_extent(
+          0, state.at(r->parent)->extent);
+    } else {
+      LOG(FATAL) << "unknown relation type";
+    }
+  }
+}
+
+void PassUpIndex(const Stage& stage,
+                 const Map<IterVar, Range>& dom_map,
+                 std::unordered_map<IterVar, Expr>* p_state,
+                 bool allow_missing) {
+  auto& state = *p_state;
+  for (size_t i = stage->relations.size(); i != 0; --i) {
+    IterVarRelation rel = stage->relations[i - 1];
+    if (const SplitNode* s = rel.as<SplitNode>()) {
+      if (!state.count(s->outer) || !state.count(s->inner)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      Expr outer = state.at(s->outer);
+      Expr inner = state.at(s->inner);
+      Expr factor = dom_map.at(s->inner)->extent;
+      Expr parent_min = dom_map.at(s->parent)->min;
+      state[s->parent] = inner + outer * factor;
+      // add min if they exist
+      if (!is_zero(parent_min)) {
+        state[s->parent] = state[s->parent] + parent_min;
+      }
+    } else if (const FuseNode* s = rel.as<FuseNode>()) {
+      if (!state.count(s->fused)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      Expr value = state.at(s->fused);
+      Expr factor = dom_map.at(s->inner)->extent;
+      Expr outer_min = dom_map.at(s->outer)->min;
+      Expr inner_min = dom_map.at(s->inner)->min;
+      state[s->outer] = value / factor;
+      state[s->inner] = value % factor;
+      // add min if they exist
+      if (!is_zero(outer_min)) {
+        state[s->outer] = state[s->outer] + outer_min;
+      }
+      if (!is_zero(inner_min)) {
+        state[s->inner] = state[s->inner] + inner_min;
+      }
+    } else if (const RebaseNode* s = rel.as<RebaseNode>()) {
+      if (!state.count(s->rebased)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      Expr value = state.at(s->rebased);
+      Expr parent_min = dom_map.at(s->parent)->min;
+      // add min if they exist
+      if (!is_zero(parent_min)) {
+        state[s->parent] = value + parent_min;
+      } else {
+        state[s->parent] = value;
+      }
+    } else {
+      LOG(FATAL) << "unknown relation type";
+    }
+  }
+}
+
+// Domain message passing.
+void PassUpDomain(const SplitNode* s,
+                  const std::unordered_map<IterVar, Range>& dom_map,
+                  const IntSet& outer,
+                  const IntSet& inner,
+                  IntSet* parent) {
+  if (dom_map.count(s->outer) &&
+      dom_map.count(s->inner) &&
+      dom_map.count(s->parent) &&
+      outer.match_range(dom_map.at(s->outer)) &&
+      inner.match_range(dom_map.at(s->inner))) {
+    *parent = IntSet::range(dom_map.at(s->parent));
+    return;
+  }
+  Expr factor = dom_map.at(s->inner)->extent;
+  Expr parent_min = dom_map.at(s->parent)->min;
+  CHECK(outer.defined());
+  CHECK(inner.defined());
+  CHECK(factor.defined());
+  *parent = EvalSet(
+      s->outer->var * factor + s->inner->var + parent_min,
+      {{s->outer, outer}, {s->inner, inner}});
+}
+
+void PassUpDomain(const FuseNode* s,
+                  const std::unordered_map<IterVar, Range>& dom_map,
+                  const IntSet& fused,
+                  IntSet* outer,
+                  IntSet* inner) {
+  CHECK(dom_map.count(s->outer));
+  CHECK(dom_map.count(s->inner));
+  CHECK(dom_map.count(s->fused));
+
+  if (fused.match_range(dom_map.at(s->fused))) {
+    *outer = IntSet::range(dom_map.at(s->outer));
+    *inner = IntSet::range(dom_map.at(s->inner));
+    return;
+  }
+  Expr outer_min = dom_map.at(s->outer)->min;
+  Expr inner_min = dom_map.at(s->inner)->min;
+
+  if (fused.is_single_point()) {
+    Expr value = fused.point_value();
+    Expr factor = dom_map.at(s->inner)->extent;
+    Expr v_outer  = value / factor;
+    Expr v_inner  = value % factor;
+    if (!is_zero(outer_min)) v_outer = v_outer + outer_min;
+    if (!is_zero(inner_min)) v_inner = v_inner + inner_min;
+    *outer = IntSet::single_point(v_outer);
+    *inner = IntSet::single_point(v_inner);
+  } else {
+    LOG(WARNING) << "use fallback inference rule in fuse";
+    // simply use the entire set, this rule can be enhanced.
+    *outer = IntSet::range(dom_map.at(s->outer));
+    *inner = IntSet::range(dom_map.at(s->inner));
+    return;
+  }
+}
+
+void PassUpDomain(const RebaseNode* s,
+                  const std::unordered_map<IterVar, Range>& dom_map,
+                  const IntSet& rebased,
+                  IntSet* parent) {
+  CHECK(dom_map.count(s->parent));
+  if (rebased.match_range(dom_map.at(s->rebased))) {
+    *parent = IntSet::range(dom_map.at(s->parent));
+    return;
+  }
+  Expr parent_min = dom_map.at(s->parent)->min;
+  *parent = EvalSet(s->rebased->var + parent_min,
+                    {{s->rebased, rebased}});
+}
+
+void PassUpDomain(const Stage& stage,
+                  const std::unordered_map<IterVar, Range>& dom_map,
+                  std::unordered_map<IterVar, IntSet>* p_state) {
+  auto& state = *p_state;
+  for (size_t i = stage->relations.size(); i != 0; --i) {
+    IterVarRelation rel = stage->relations[i - 1];
+    if (const SplitNode* r = rel.as<SplitNode>()) {
+      IntSet parent;
+      PassUpDomain(r, dom_map,
+                   state.at(r->outer), state.at(r->inner),
+                   &parent);
+      state[r->parent] = parent;
+    } else if (const FuseNode* r = rel.as<FuseNode>()) {
+      IntSet outer, inner;
+      PassUpDomain(r, dom_map,
+                   state.at(r->fused),
+                   &outer, &inner);
+      state[r->outer] = outer;
+      state[r->inner] = inner;
+    } else if (const RebaseNode* r = rel.as<RebaseNode>()) {
+      IntSet parent;
+      PassUpDomain(r, dom_map,
+                   state.at(r->rebased),
+                   &parent);
+      state[r->parent] = parent;
+    } else {
+      LOG(FATAL) << "unknown relation type";
+    }
+  }
+}
+
+// Pass up bit mask with or relation.
+void PassUpBitMaskOr(const Stage& stage,
+                     std::unordered_map<IterVar, int>* p_state,
+                     bool allow_missing) {
+  auto& state = *p_state;
+  for (size_t i = stage->relations.size(); i != 0; --i) {
+    IterVarRelation rel = stage->relations[i - 1];
+    if (const SplitNode* s = rel.as<SplitNode>()) {
+      if (!state.count(s->inner) && !state.count(s->outer)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      int res = 0;
+      if (!state.count(s->parent)) res |= state[s->parent];
+      if (!state.count(s->inner)) res |= state[s->inner];
+      if (!state.count(s->outer)) res |= state[s->outer];
+      state[s->parent] = res;
+    } else if (const FuseNode* s = rel.as<FuseNode>()) {
+      if (!state.count(s->fused)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      if (!state.count(s->outer)) {
+        state[s->outer] = state[s->fused];
+      } else {
+        state[s->outer] |= state[s->fused];
+      }
+      if (!state.count(s->inner)) {
+        state[s->inner] = state[s->fused];
+      } else {
+        state[s->inner] |= state[s->fused];
+      }
+    } else if (const RebaseNode* s = rel.as<RebaseNode>()) {
+      if (!state.count(s->rebased)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      if (!state.count(s->parent)) {
+        state[s->parent] = state[s->rebased];
+      } else {
+        state[s->parent] |= state[s->rebased];
+      }
+    } else {
+      LOG(FATAL) << "unknown relation type";
+    }
+  }
+}
+
+void PassDownBitMaskOr(const Stage& stage,
+                       std::unordered_map<IterVar, int>* p_state,
+                       bool allow_missing) {
+  auto& state = *p_state;
+  for (IterVarRelation rel : stage->relations) {
+    if (const SplitNode* s = rel.as<SplitNode>()) {
+      if (!state.count(s->parent)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      if (!state.count(s->outer)) {
+        state[s->outer] = state.at(s->parent);
+      } else {
+        state[s->outer] |= state.at(s->parent);
+      }
+      if (!state.count(s->inner)) {
+        state[s->inner] = state.at(s->parent);
+      } else {
+        state[s->inner] |= state.at(s->parent);
+      }
+    } else if (const FuseNode* s = rel.as<FuseNode>()) {
+      if (!state.count(s->outer) && !state.count(s->inner)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      int res = 0;
+      if (state.count(s->outer)) res |= state.at(s->outer);
+      if (state.count(s->inner)) res |= state.at(s->inner);
+      if (state.count(s->fused)) res |= state.at(s->fused);
+      state[s->fused] = res;
+    } else if (const RebaseNode* s = rel.as<RebaseNode>()) {
+      if (!state.count(s->parent)) {
+        CHECK(allow_missing);
+        continue;
+      }
+      if (!state.count(s->rebased)) {
+        state[s->rebased] = state.at(s->parent);
+      } else {
+        state[s->rebased] |= state.at(s->parent);
+      }
+    } else {
+      LOG(FATAL) << "unknown relation type";
+    }
+  }
+}
+
+}  // namespace schedule
+}  // namespace tvm

--- a/src/schedule/message_passing.h
+++ b/src/schedule/message_passing.h
@@ -1,0 +1,81 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file message_passing.h
+ * \brief Common utilities to do message passing
+ *  on the schedule hyper graph.
+ */
+#ifndef TVM_SCHEDULE_MESSAGE_PASSING_H_
+#define TVM_SCHEDULE_MESSAGE_PASSING_H_
+
+#include <tvm/expr.h>
+#include <tvm/schedule.h>
+#include <tvm/operation.h>
+#include <tvm/arithmetic.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace tvm {
+namespace schedule {
+/*!
+ * \brief Downward inference of domain of each IterVar.
+ *  Caller set the range of the root, then the function
+ *  propagates it towards the leaves.
+ *
+ * \param stage The stage to operate on.
+ * \param p_state The state of the message passing.
+ * \param allow_missing Whether allow missing value.
+ */
+void PassDownDomain(
+    const Stage& stage,
+    std::unordered_map<IterVar, Range>* p_state,
+    bool allow_missing = false);
+
+/*!
+ * \param Upward inference of index of each IterVar.
+ *  given index assignement of the leaves,
+ *
+ * \param stage The stage to operate on.
+ * \param dom_map The domain map of each iteration variable's domain.
+ * \param p_state The index state of each IterVar.
+ * \param allow_missing Whether allow missing value.
+ */
+void PassUpIndex(const Stage& stage,
+                 const Map<IterVar, Range>& dom_map,
+                 std::unordered_map<IterVar, Expr>* p_state,
+                 bool allow_missing = false);
+
+/*!
+ * \param Upward inference of domain set of each IterVar.
+ *  given domain assignment of the leaves,
+ *
+ * \param stage The stage to operate on.
+ * \param dom_map The domain map of each iteration variable's maximum domain.
+ * \param p_state The index state of each IterVar.
+ */
+void PassUpDomain(const Stage& stage,
+                  const std::unordered_map<IterVar, Range>& dom_map,
+                  std::unordered_map<IterVar, IntSet>* p_state);
+
+/*!
+ * \brief Upward message passing of bitmask with or relation.
+ * \param stage The stage to operate on.
+ * \param p_state The index state of each IterVar.
+ * \param allow_missing Whether allow missing value.
+ */
+void PassUpBitMaskOr(const Stage& stage,
+                     std::unordered_map<IterVar, int>* p_state,
+                     bool allow_missing = false);
+
+/*!
+ * \brief Downward message passing of bitmask with or relation.
+ * \param stage The stage to operate on.
+ * \param p_state The index state of each IterVar.
+ * \param allow_missing Whether allow missing value.
+ */
+void PassDownBitMaskOr(const Stage& stage,
+                       std::unordered_map<IterVar, int>* p_state,
+                       bool allow_missing = false);
+}  // namespace schedule
+}  // namespace tvm
+#endif  // TVM_SCHEDULE_MESSAGE_PASSING_H_

--- a/tests/python/integration/test_reduce.py
+++ b/tests/python/integration/test_reduce.py
@@ -7,7 +7,7 @@ def test_sum():
     m = tvm.Var('m')
     A = tvm.placeholder((n, m), name='A')
     k = tvm.reduce_axis((0, m))
-    B = tvm.compute((n,), lambda i: tvm.sum(A[i, k], axis=k), name='B')
+    B = tvm.compute((n,), lambda i: tvm.sum(A[i, k], axis=k, where=(i>1)), name='B')
     # schedule
     s = tvm.Schedule(B.op)
     # create iter var and assign them tags.
@@ -28,14 +28,17 @@ def test_sum():
                          args=[A, B],
                          target=device, target_host=host,
                          name="mysum")
+        print(fsum.imported_modules[0].get_source())
         # launch the kernel.
         n = 1028
         m = 129
         a = tvm.nd.array(np.random.uniform(size=(n, m)).astype(A.dtype), ctx)
         b  = tvm.nd.array(np.zeros(n, dtype=B.dtype), ctx)
         fsum(a, b)
+        res = np.sum(a.asnumpy(), axis=1)
+        res[:2] = 0
         np.testing.assert_allclose(
-            b.asnumpy(), np.sum(a.asnumpy(), axis=1), rtol=1e-4)
+            b.asnumpy(), res, rtol=1e-4)
 
     if tvm.module.enabled("opencl"):
         tvm.module.init_opencl()
@@ -43,5 +46,38 @@ def test_sum():
     check_device("cuda")
     check_device("opencl")
 
+
+def test_rfactor():
+    n = tvm.convert(1027)
+    A = tvm.placeholder((n,), name='A')
+    k = tvm.reduce_axis((0, n))
+    B = tvm.compute((1,), lambda i: tvm.sum(A[k], axis=k, where=(i>1)), name='B')
+    kf = tvm.reduce_axis((0, 4))
+    # schedule
+    s = tvm.Schedule(B.op)
+    _, ki = s[B].split(k, outer=kf)
+    BF = s.rfactor(B, kf)
+    s[BF].parallel(BF.op.axis[0])
+    # one line to build the function.
+    def check_target(target="llvm"):
+        if not tvm.codegen.enabled(target):
+            return
+        ctx = tvm.cpu(0)
+        fapi = tvm.lower(s, args=[A, B])
+        fsum = tvm.build(fapi,
+                         target=target,
+                         name="mysum")
+        # launch the kernel.
+        n = 1027
+        a = tvm.nd.array(np.random.uniform(size=(n,)).astype(A.dtype), ctx)
+        b  = tvm.nd.array(np.zeros(1, dtype=B.dtype), ctx)
+        fsum(a, b)
+        res = np.sum(a.asnumpy(), axis=0)
+        np.testing.assert_allclose(
+            b.asnumpy(), res, rtol=1e-4)
+
+    check_target()
+
 if __name__ == "__main__":
+    test_rfactor()
     test_sum()


### PR DESCRIPTION
Support rfactor that factors reduction into temporal stage and then reduction.

```python
n = tvm.convert(1027)
A = tvm.placeholder((n,), name='A')
k = tvm.reduce_axis((0, n))
B = tvm.compute((1,), lambda i: tvm.sum(A[k], axis=k, where=(i>1)), name='B')
kf = tvm.reduce_axis((0, 4))
# schedule
s = tvm.Schedule(B.op)
_, ki = s[B].split(k, outer=kf)
BF = s.rfactor(B, kf)
s[BF].parallel(BF.op.axis[0])
```

The original reduction is ```B = sum(A, axis=1)```. rfactor changes it two two stage reduction

```python
BF = sum(A.pad_reshape(4,  n/4), axis=1)
B = sum(B, axis=0)
```
pad_reshape will include predicate to guard that the index won't exceed bound. This allows further manipulation of BF's first factored axis, for example parallelize over the factored dimension
