### PR TITLE
Require explicit version for llvm_config. Update doc build requirements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ else
 endif
 
 # llvm configuration
-LLVM_CONFIG=llvm-config
-
 ifeq ($(USE_LLVM), 1)
 	LLVM_VERSION=$(shell $(LLVM_CONFIG) --version| cut -b 1,3)
 	LLVM_INCLUDE=$(filter -I%, $(shell $(LLVM_CONFIG) --cxxflags))

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -2,4 +2,4 @@ The documentation of tvm is generated with recommonmark and sphinx.
 
 - pip install sphinx>=1.5.5 sphinx-gallery sphinx_rtd_theme matplotlib Image recommonmark
 - Build tvm first in the root folder.
-- You can build it locally by typing "make html" in this folder.
+- To build locally, you need to enable USE_CUDA, USE_OPENCL, USE_LLVM in config.mk and then type "make html" in this folder.

--- a/make/config.mk
+++ b/make/config.mk
@@ -38,8 +38,9 @@ USE_OPENCL = 0
 USE_METAL = 0
 
 # whether build with LLVM support
-# This requires llvm-config to be in your PATH
 # Requires LLVM version >= 4.0
+# Set LLVM_CONFIG to your version
+# LLVM_CONFIG = llvm-config-4.0
 USE_LLVM = 0
 
 #---------------------------------------------


### PR DESCRIPTION
Seems better to set LLVM_CONFIG version explicitly. Also, doc html build currently requires llvm and opencl.

https://bugs.launchpad.net/ubuntu/+source/llvm/+bug/768143