### PR TITLE
check attach_stage & group in schedule.copy()

### DIFF
--- a/src/schedule/schedule_lang.cc
+++ b/src/schedule/schedule_lang.cc
@@ -390,17 +390,25 @@ Schedule Schedule::copy() const {
   }
   for (Stage s : n->stages) {
     if (s->attach_stage.defined()) {
+      CHECK(smap.find(s->attach_stage) != smap.end())
+        << s->attach_stage << " not found in " << (*this);
       s->attach_stage = smap.at(s->attach_stage);
     }
     if (s->group.defined()) {
+      CHECK(smap.find(s->group) != smap.end())
+        << s->group << " not found in " << (*this);
       s->group = smap.at(s->group);
     }
   }
   for (Stage s : n->groups) {
     if (s->attach_stage.defined()) {
+      CHECK(smap.find(s->attach_stage) != smap.end())
+        << s->attach_stage << " not found in " << (*this);
       s->attach_stage = smap.at(s->attach_stage);
     }
     if (s->group.defined()) {
+      CHECK(smap.find(s->group) != smap.end())
+        << s->group << " not found in " << (*this);
       s->group = smap.at(s->group);
     }
   }


### PR DESCRIPTION
```python
import tvm                                                                                                                                                                 

n = tvm.var("n")
m = tvm.var("m")
A = tvm.placeholder((n, m), name='A')
k = tvm.reduce_axis((0, m), "k")
 
B = tvm.compute((n,), lambda i: tvm.sum(A[i, k], axis=k), name="B")
sb = tvm.create_schedule(B.op)
 
C = tvm.compute(A.shape, lambda i,j: A[i][j] * 2, name="C")
sc = tvm.create_schedule(C.op)
 
sc[C].compute_at(sb[B], B.op.axis[0])
print(tvm.lower(sc, [A, B, C], simple_mode=True))
```

The codes above can crash the process with useless error message:

```
TVM: Initializing cython mode...
libc++abi.dylib: terminating with uncaught exception of type std::out_of_range: unordered_map::at: key not found
Abort trap: 6
```