### PR TITLE
fix doc examples & easy install

### DIFF
--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -15,9 +15,10 @@ def find_lib_path():
     """
     use_runtime = os.environ.get("TVM_USE_RUNTIME_LIB", False)
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    root_path = os.path.join(curr_path, '../')
     api_path = os.path.join(curr_path, '../../../lib/')
     cmake_build_path = os.path.join(curr_path, '../../../build/Release/')
-    dll_path = [curr_path, api_path, cmake_build_path]
+    dll_path = [curr_path, root_path, api_path, cmake_build_path]
     if os.name == 'nt':
         vs_configuration = 'Release'
         if platform.architecture()[0] == '64bit':

--- a/tutorials/python/scan.py
+++ b/tutorials/python/scan.py
@@ -56,7 +56,7 @@ s[s_init].bind(xi, thread_x)
 xo, xi = s[s_update].split(s_update.op.axis[1], factor=num_thread)
 s[s_update].bind(xo, block_x)
 s[s_update].bind(xi, thread_x)
-print(tvm.lower(s, [X, s_scan], with_api_wrapper=False))
+print(tvm.lower(s, [X, s_scan], simple_mode=True))
 
 ######################################################################
 # Build and Verify
@@ -101,7 +101,7 @@ s_scan = tvm.scan(s_init, s_update_s2, s_state, inputs=[X])
 s = tvm.create_schedule(s_scan.op)
 xo, xi = s[s_update_s2].split(s_update_s2.op.axis[1], factor=32)
 s[s_update_s1].compute_at(s[s_update_s2], xo)
-print(tvm.lower(s, [X, s_scan], with_api_wrapper=False))
+print(tvm.lower(s, [X, s_scan], simple_mode=True))
 
 ######################################################################
 # Multiple States
@@ -124,7 +124,7 @@ s_scan1, s_scan2 = tvm.scan([s_init1, s_init2],
                             [s_update1, s_update2],
                             [s_state1, s_state2], inputs=[X])
 s = tvm.create_schedule(s_scan1.op)
-print(tvm.lower(s, [X, s_scan1, s_scan2], with_api_wrapper=False))
+print(tvm.lower(s, [X, s_scan1, s_scan2], simple_mode=True))
 
 ######################################################################
 # Summary


### PR DESCRIPTION
On my mac laptop, the `libtvm.so` is installed to `/Users/lewis/.local/lib/python3.5/site-packages/tvm-0.1.0-py3.5-macosx-10.6-x86_64.egg/tvm/`, while the search paths are,

```
List of candidates:
/Users/lewis/.local/lib/python3.5/site-packages/tvm-0.1.0-py3.5-macosx-10.6-x86_64.egg/tvm/_ffi/libtvm.so
/Users/lewis/.local/lib/python3.5/site-packages/tvm-0.1.0-py3.5-macosx-10.6-x86_64.egg/tvm/_ffi/../../../lib/libtvm.so
/Users/lewis/.local/lib/python3.5/site-packages/tvm-0.1.0-py3.5-macosx-10.6-x86_64.egg/tvm/_ffi/../../../build/Release/libtvm.so
```