### PR TITLE
CI Migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: cpp
 
 os:
-  - linux
+# - linux
   - osx
 
 osx_image: xcode8


### PR DESCRIPTION
This PR verifies https://github.com/dmlc/tvm/pull/152  that migrates most flow from travis to jenkins

- We will have GPU and example tests enabled by default
- The Travis CI is temporary disabled because we run out of private builds, will keep some of the iOS build on travis when we go public