### PR TITLE
[CODEGEN/RUNTIME] Cross Compile Test

### DIFF
--- a/python/tvm/contrib/cc_compiler.py
+++ b/python/tvm/contrib/cc_compiler.py
@@ -4,13 +4,15 @@ from __future__ import absolute_import as _abs
 import sys
 import subprocess
 
-def create_shared(path_target, objects,
-                  options=None, cc="g++"):
+def create_shared(output,
+                  objects,
+                  options=None,
+                  cc="g++"):
     """Create shared library.
 
     Parameters
     ----------
-    path_target : str
+    output : str
         The target shared library.
 
     objects : list
@@ -19,19 +21,25 @@ def create_shared(path_target, objects,
     options : str
         The additional options.
 
-    cc : str
+    cc : str, optional
         The compile string.
     """
     cmd = [cc]
     cmd += ["-shared"]
+
     if sys.platform == "darwin":
         cmd += ["-undefined", "dynamic_lookup"]
-    cmd += ["-o", path_target]
-    cmd += objects
+    cmd += ["-o", output]
+
+    if isinstance(objects, str):
+        cmd += [objects]
+    else:
+        cmd += objects
+
     if options:
         cmd += options
-    args = ' '.join(cmd)
 
+    args = ' '.join(cmd)
     proc = subprocess.Popen(
         args, shell=True,
         stdout=subprocess.PIPE,
@@ -39,6 +47,6 @@ def create_shared(path_target, objects,
     (out, _) = proc.communicate()
 
     if proc.returncode != 0:
-        sys.stderr.write("Compilation error:\n")
-        sys.stderr.write(out)
-        sys.stderr.flush()
+        msg = "Compilation error:\n"
+        msg += out
+        raise RuntimeError(msg)

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -17,7 +17,7 @@ namespace codegen {
 runtime::Module Build(const Array<LoweredFunc>& funcs,
                       const std::string& target) {
   std::string mode = target;
-  size_t pos = mode.find("-");
+  size_t pos = mode.find(' ');
   if (pos != std::string::npos) {
     mode = mode.substr(0, pos);
   }

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -14,7 +14,7 @@ namespace tvm {
 namespace codegen {
 
 void CodeGenLLVM::Init(const std::string& module_name,
-                       const std::string& target_triple,
+                       llvm::TargetMachine* tm,
                        llvm::LLVMContext* ctx) {
   InitializeLLVM();
   static_assert(sizeof(TVMValue) == sizeof(double), "invariant");
@@ -81,17 +81,14 @@ void CodeGenLLVM::Init(const std::string& module_name,
           t_int64_, t_int64_, t_f_tvm_par_for_lambda_->getPointerTo(), t_void_p_}
         , false),
       llvm::Function::ExternalLinkage, "TVMBackendParallelFor", module_.get());
-  this->InitTarget(target_triple);
+  this->InitTarget(tm);
   // initialize builder
   builder_.reset(new IRBuilder(*ctx));
   this->InitGlobalContext();
 }
 
-void CodeGenLLVM::InitTarget(const std::string& target) {
-  llvm::TargetMachine* tm;
-  std::string target_triple;
-  std::tie(tm, target_triple) = GetLLVMTarget(target);
-  module_->setTargetTriple(target_triple);
+void CodeGenLLVM::InitTarget(llvm::TargetMachine* tm) {
+  module_->setTargetTriple(tm->getTargetTriple().str());
   module_->setDataLayout(tm->createDataLayout());
   data_layout_.reset(new llvm::DataLayout(module_.get()));
 }

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -31,11 +31,11 @@ class CodeGenLLVM :
   /*!
    * \brief Initialize the code generator with given context
    * \param module_name The name of the module.
-   * \param target_triple The target triple, can be empty.
+   * \param tm Target machine model
    * \param ctx The context.
    */
   void Init(const std::string& module_name,
-            const std::string& target_triple,
+            llvm::TargetMachine* tm,
             llvm::LLVMContext* ctx);
   /*!
    * \brief Compile and add function f to the current module.
@@ -208,7 +208,7 @@ class CodeGenLLVM :
   // return the end block after the check
   llvm::BasicBlock* CheckCallSuccess(llvm::Value* retcode);
   // Initialize target
-  void InitTarget(const std::string& target);
+  void InitTarget(llvm::TargetMachine* tm);
   // Add a function to set global module context
   void InitGlobalContext();
   // add alias information.

--- a/src/codegen/llvm/llvm_common.h
+++ b/src/codegen/llvm/llvm_common.h
@@ -51,11 +51,11 @@ void InitializeLLVM();
 
 /*!
  * \brief Get target machine from target_str string.
- * \param target_str Target triple string, can have llvm- prefix, can be empty.
- * \return Pair of target machine and target triple.
+ * \param target_str Target string, in format "llvm -target=xxx -mcpu=xxx"
+ * \return target machine
  */
-std::pair<llvm::TargetMachine*, std::string>
-GetLLVMTarget(const std::string& target_str);
+llvm::TargetMachine*
+GetLLVMTargetMachine(const std::string& target_str);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/tests/python/unittest/test_codegen_cross_llvm.py
+++ b/tests/python/unittest/test_codegen_cross_llvm.py
@@ -1,0 +1,69 @@
+"""Test cross compilation"""
+import tvm
+import os
+import struct
+from tvm.contrib import util, cc_compiler as cc, rpc
+import numpy as np
+
+def test_llvm_add_pipeline():
+    nn = 1024
+    n = tvm.convert(nn)
+    A = tvm.placeholder((n,), name='A')
+    B = tvm.placeholder((n,), name='B')
+    C = tvm.compute(A.shape, lambda *i: A(*i) + B(*i), name='C')
+    s = tvm.create_schedule(C.op)
+    xo, xi = s[C].split(C.op.axis[0], factor=4)
+    s[C].parallel(xo)
+    s[C].vectorize(xi)
+
+    def verify_elf(path, e_machine):
+        with open(path, "rb") as fi:
+            arr = fi.read(20)
+            assert struct.unpack('ccc', arr[1:4]) == (b'E',b'L',b'F')
+            endian = struct.unpack('b', arr[0x5:0x6])[0]
+            endian = '<' if endian == 1 else '>'
+            assert struct.unpack(endian + 'h', arr[0x12:0x14])[0] == e_machine
+
+    def build_i386():
+        temp = util.tempdir()
+        target = "llvm -target=i386-pc-linux-gnu"
+        f = tvm.build(s, [A, B, C], target)
+        path = temp.relpath("myadd.o")
+        f.save(path)
+        verify_elf(path, 0x03)
+
+    def build_arm():
+        temp = util.tempdir()
+        target = "llvm -target=arm-none-linux-gnueabihf"
+        f = tvm.build(s, [A, B, C], target)
+        path = temp.relpath("myadd.o")
+        f.save(path)
+        verify_elf(path, 0x28)
+        # Do a RPC verification, launch kernel on Arm Board if available.
+        host = os.environ.get('TVM_RPC_ARM_HOST', None)
+        remote = None
+        if host:
+            port = int(os.environ['TVM_RPC_ARM_PORT'])
+            try:
+                remote = rpc.connect(host, port)
+            except tvm.TVMError as e:
+                pass
+
+        if remote:
+            remote.upload(path)
+            farm = remote.load_module("myadd.o")
+            ctx = remote.cpu(0)
+            n = nn
+            a = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), ctx)
+            b = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), ctx)
+            c = tvm.nd.array(np.zeros(n, dtype=C.dtype), ctx)
+            farm(a, b, c)
+            np.testing.assert_allclose(
+                c.asnumpy(), a.asnumpy() + b.asnumpy())
+            print("Verification finish on remote..")
+
+    build_i386()
+    build_arm()
+
+if __name__ == "__main__":
+    test_llvm_add_pipeline()


### PR DESCRIPTION
This PR gives a basic example for cross compile test workflow, see https://github.com/tqchen/tvm/blob/master/tests/python/unittest/test_codegen_cross_llvm.py#L34

The workflow
- Compile TVM with runtime only on the target board
   - Add ```BUILD_TARGETS = lib/libtvm_runtime.so``` to config.mk
   - Add TVM_USE_RUNTIME_LIB=1 to environment variable
   - ```python -m tvm.exec.rpc_server```
- Build target with specific flag
- Save the .o file to the path
- Upload the .o file to the remote RPC server, this case it is an arm board
    - In this example we do the shared library creation on remote use gcc
    - Optionally, we can use local cross compile tool to generate the .so file, and upload the shared library
- Use tvm rpc to run the tests