### PR TITLE
Install rules for TVM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,10 +156,9 @@ add_library(libtvm SHARED ${COMPILER_SRCS} ${RUNTIME_SRCS})
 add_library(libtvm_runtime SHARED ${RUNTIME_SRCS})
 target_link_libraries(libtvm ${TVM_LINKER_LIBS} ${TVM_RUNTIME_LINKER_LIBS})
 target_link_libraries(libtvm_runtime  ${TVM_RUNTIME_LINKER_LIBS})
-install(TARGETS libtvm DESTINATION lib)
 install(TARGETS libtvm_runtime DESTINATION lib)
 install(
-  DIRECTORY "include/." DESTINATION "include"
+  DIRECTORY "include/tvm/runtime/." DESTINATION "include/tvm/runtime"
   FILES_MATCHING
   PATTERN "*.h"
 )

--- a/Makefile
+++ b/Makefile
@@ -208,11 +208,9 @@ doc:
 	doxygen docs/Doxyfile
 
 install: lib/libtvm.so lib/libtvm_runtime.so lib/libtvm.a
-	mkdir -p include
-	cp -R include/tvm $(DESTDIR)$(PREFIX)/include
-	cp lib/libtvm.so $(DESTDIR)$(PREFIX)/lib
+	mkdir -p $(DESTDIR)$(PREFIX)/include/tvm/runtime
+	cp -R include/tvm/runtime/. $(DESTDIR)$(PREFIX)/include/tvm/runtime
 	cp lib/libtvm_runtime.so $(DESTDIR)$(PREFIX)/lib
-	cp lib/libtvm.a $(DESTDIR)$(PREFIX)/lib
 
 # Cython build
 cython:


### PR DESCRIPTION
I implemented both cmake and make install rules.

One thing that these install rules do NOT do is install HalideIR,
dmlc-core and dlpack, which in practice are necessary to make use of
these headers.  Probably it would make sense to install the HalideIR
headers, since TVM is in the business of compiling those source files,
and not dlpack, which is a header only library.  I am uncertain about
dmlc-core however.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>