### PR TITLE
[PASS] Improve graph fusion

### DIFF
--- a/apps/graph_executor/src/graph_pass.cc
+++ b/apps/graph_executor/src/graph_pass.cc
@@ -275,8 +275,9 @@ nnvm::Graph GraphFuse(nnvm::Graph g) {
         tensor_vec[eid] = out[index];
       }
     } else {
-      int master = master_vec[root_id];
       fe.outputs = out;
+      int master = master_vec[root_id];
+      CHECK_GE(master, 0);
       fe.schedule = fschedule[idx[master].source->op()](
           inode.source->attrs, fe.outputs, target);
       std::ostringstream os;


### PR DESCRIPTION
- `ref_count` should consider graph outputs. If an intermediate tensor is an input of another node also the graph output, it should not be fused.
- For schedule, use master's schedule instead of group output node's schedule