### PR TITLE
[TOPI] Fix conv2d for small input channels

### DIFF
--- a/topi/python/topi/cuda/conv2d_nchw.py
+++ b/topi/python/topi/cuda/conv2d_nchw.py
@@ -39,12 +39,12 @@ def schedule_conv2d_small_batch(outs):
         vthread = 2
         out_filter = min(64, util.get_const_int(Filter.shape[0]))
         in_filter = util.get_const_int(Filter.shape[1])
-        opart2 = out_filter//8
+        opart2 = max(1, out_filter//8)
         ofactor = out_filter
         wfactor = block_h
-        ifactor = in_filter//4
+        ifactor = max(8, in_filter//4)
         sfactor = max(1, ofactor//(opart2*2))
-        spart = (wfactor + vthread-1) // vthread
+        spart = max(1, (wfactor + vthread-1) // vthread)
         block_x = tvm.thread_axis("blockIdx.x")
         block_y = tvm.thread_axis("blockIdx.y")
         block_z = tvm.thread_axis("blockIdx.z")


### PR DESCRIPTION
Made sure all splitting factor won't be 0 regardless of the input workloads.