### PR TITLE
Allow install-dev to include all necessary header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,13 @@ endif()
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dmlc-core/CMakeLists.txt)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/dmlc-core/include)
+  if (INSTALL_DEV)
+    install(
+      DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dmlc-core/include/." DESTINATION "include"
+      FILES_MATCHING
+      PATTERN "*.h"
+    )
+  endif()
 elseif(DMLC_CORE_PATH)
   include_directories(${DMLC_CORE_PATH}/include)
 endif()
@@ -151,6 +158,21 @@ if (INSTALL_DEV)
   install(TARGETS tvm DESTINATION lib)
   install(
     DIRECTORY "include/." DESTINATION "include"
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
+  install(
+    DIRECTORY "topi/include/." DESTINATION "include"
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
+  install(
+    DIRECTORY "HalideIR/src/." DESTINATION "include/HalideIR"
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
+  install(
+    DIRECTORY "dlpack/include/." DESTINATION "include"
     FILES_MATCHING
     PATTERN "*.h"
   )


### PR DESCRIPTION
The dev installation doesn't contain all the necessary headers of certain subdirectories. This installs them when the dev option is enabled.