### PR TITLE
Fix metal backward compatibility

### DIFF
--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -83,8 +83,11 @@ class MetalModuleNode final :public runtime::ModuleNode {
     if (e.lib == nil) {
       if (fmt_ == "metal") {
         MTLCompileOptions *opts = [MTLCompileOptions alloc];
-        opts.languageVersion = MTLLanguageVersion2_0;
-        opts.fastMathEnabled = YES;
+        // Use the default setting for now.
+        // by default most recent version is used.
+        // opts.languageVersion = MTLLanguageVersion2_0;
+        // opts.fastMathEnabled = YES;
+        opts = nil;
         e.lib = [
             w->devices[device_id]
              newLibraryWithSource:[NSString stringWithUTF8String:data_.c_str()]

--- a/tests/python/integration/test_ewise.py
+++ b/tests/python/integration/test_ewise.py
@@ -98,8 +98,8 @@ def test_popcount():
         check_device("llvm")
         check_device("cuda")
         check_device("opencl")
-        check_device("metal")
         if dtype == "uint32":
+            check_device("metal")
             check_device("vulkan")
     run('uint32')
     run('uint64')
@@ -146,9 +146,10 @@ def test_add():
                 c.asnumpy(), a.asnumpy() + b.asnumpy(), rtol=1e-6)
 
         check_device("opencl")
-        check_device("metal")
         check_device("cuda")
-        check_device("vulkan")
+        if dtype == "float32":
+            check_device("metal")
+            check_device("vulkan")
 
     run("float32")
     run("int32")


### PR DESCRIPTION
cc @antinucleon 

The new code cannot run on my laptop without metal2. It would be great if there is a runtime API in metal to get the latest version. if now, we can accept a env argument that set the metal version and only set options when that is available