### PR TITLE
[MAINTAINER] add masahi as reviewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 - [Nick Hynes](https://github.com/nhynes) SGX and secured computing
 
 ## Reviewers
+- [Masahiro Masuda](https://github.com/masahi)
 - [Pariksheet Pinjari](https://github.com/PariksheetPinjari909)
 - [Eddie Yan](https://github.com/eqy)
 - [Lianmin Zheng](https://github.com/merrymercy)


### PR DESCRIPTION
This PR adds @masahi as a reviewer of TVM. Masa has been active in contributing to Intel and AMD GPU backends. He helped bring the first AMD GPU backend into alive, he also contributed the first external operator mechanism for TOPI

- [Contributions by masahi](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Amasahi++is%3Amerged+)
- [Code reviews activities that masahi involves in](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Amasahi+)