### PR TITLE
Better grouped convolution for CPU targets

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -210,7 +210,7 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
             strategy.add_implementation(
                 wrap_compute_conv2d(topi.arm_cpu.group_conv2d_nchw, has_groups=True),
                 wrap_topi_schedule(topi.arm_cpu.schedule_group_conv2d_nchw),
-                name="group_conv2d_nchw.arm_cpu"
+                name="group_conv2d_nchw.arm_cpu",
             )
         elif layout == "NHWC":
             assert kernel_layout == "HWIO"

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -207,11 +207,10 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
     else:  # group_conv2d
         if layout == "NCHW":
             assert kernel_layout == "OIHW"
-            logger.warning("group_conv2d with layout NCHW is not optimized for arm cpu.")
             strategy.add_implementation(
-                wrap_compute_conv2d(topi.nn.group_conv2d_nchw, has_groups=True),
-                wrap_topi_schedule(topi.generic.schedule_group_conv2d_nchw),
-                name="group_conv2d_nchw.generic",
+                wrap_compute_conv2d(topi.arm_cpu.group_conv2d_nchw, has_groups=True),
+                wrap_topi_schedule(topi.arm_cpu.schedule_group_conv2d_nchw),
+                name="group_conv2d_nchw.arm_cpu"
             )
         elif layout == "NHWC":
             assert kernel_layout == "HWIO"

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -205,12 +205,10 @@ def conv2d_strategy_cpu(attrs, inputs, out_type, target):
     else:  # group_conv2d
         if layout == "NCHW":
             assert kernel_layout == "OIHW"
-            if not is_auto_scheduler_enabled():
-                logger.warning("group_conv2d is not optimized for x86 with autotvm.")
             strategy.add_implementation(
-                wrap_compute_conv2d(topi.nn.group_conv2d_nchw, has_groups=True),
-                wrap_topi_schedule(topi.generic.schedule_group_conv2d_nchw),
-                name="group_conv2d_nchw.generic",
+                wrap_compute_conv2d(topi.x86.group_conv2d_nchw, has_groups=True),
+                wrap_topi_schedule(topi.x86.schedule_group_conv2d_nchw),
+                name="group_conv2d_nchw.x86",
             )
         elif layout == "NHWC":
             assert kernel_layout == "HWIO"

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -214,11 +214,11 @@ def conv2d_strategy_cpu(attrs, inputs, out_type, target):
             assert kernel_layout == "HWIO"
             if not is_auto_scheduler_enabled():
                 logger.warning("group_conv2d is not optimized for x86 with autotvm.")
-            strategy.add_implementation(
-                wrap_compute_conv2d(topi.nn.group_conv2d_nhwc, has_groups=True),
-                wrap_topi_schedule(topi.generic.schedule_group_conv2d_nhwc),
-                name="group_conv2d_nhwc.generic",
-            )
+                strategy.add_implementation(
+                    wrap_compute_conv2d(topi.nn.group_conv2d_nhwc, has_groups=True),
+                    wrap_topi_schedule(topi.generic.schedule_group_conv2d_nhwc),
+                    name="group_conv2d_nhwc.generic",
+                )
         else:
             raise RuntimeError("Unsupported group_conv2d layout {}".format(layout))
     return strategy

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -214,11 +214,11 @@ def conv2d_strategy_cpu(attrs, inputs, out_type, target):
             assert kernel_layout == "HWIO"
             if not is_auto_scheduler_enabled():
                 logger.warning("group_conv2d is not optimized for x86 with autotvm.")
-                strategy.add_implementation(
-                    wrap_compute_conv2d(topi.nn.group_conv2d_nhwc, has_groups=True),
-                    wrap_topi_schedule(topi.generic.schedule_group_conv2d_nhwc),
-                    name="group_conv2d_nhwc.generic",
-                )
+            strategy.add_implementation(
+                wrap_compute_conv2d(topi.nn.group_conv2d_nhwc, has_groups=True),
+                wrap_topi_schedule(topi.generic.schedule_group_conv2d_nhwc),
+                name="group_conv2d_nhwc.generic",
+            )
         else:
             raise RuntimeError("Unsupported group_conv2d layout {}".format(layout))
     return strategy

--- a/python/tvm/topi/arm_cpu/__init__.py
+++ b/python/tvm/topi/arm_cpu/__init__.py
@@ -26,3 +26,4 @@ from .bitserial_conv2d import *
 from .bitserial_dense import *
 from .injective import *
 from . import cortex_m7
+from .group_conv2d import *

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import tvm
 from tvm import autotvm
 from tvm import te

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+# pylint: disable=no-value-for-parameter,import-outside-toplevel
 """Grouped Spatial Pack Convolution (Group Conv2D) schedule on ARM"""
 
 import tvm
@@ -43,8 +45,8 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
-                        layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups,
+                        out_dtype, layout='NCHW'):
     """
     Get default schedule config for the workload
     """
@@ -63,7 +65,7 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
 
 def _fallback_schedule(cfg, wkl):
     simd_width = 4 # assume ARM SIMD Width is 4
-    pad_top, pad_left, pad_bottom, pad_right = wkl.padt, wkl.padl, wkl.padb, wkl.padr
+    pad_left, pad_right = wkl.padl, wkl.padr
     stride_w = wkl.wstride
     out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
     groups = wkl.groups
@@ -158,8 +160,8 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
     oc_bn = cfg['tile_oc'].size[-1]
     ic_bn = cfg['tile_ic'].size[-1]
     # pack data
-    do_pad = (hpad != 0 or wpad != 0)
-    if do_pad:
+    DOPAD = (hpad != 0 or wpad != 0)
+    if DOPAD:
         data_pad = pad(data,
                        (0, 0, pad_top, pad_left),
                        (0, 0, pad_bottom, pad_right),
@@ -270,13 +272,13 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
     # no stride and padding info here
     padding = infer_pad(data, data_pad)
     hpad, wpad = padding
-    do_pad = (hpad != 0 or wpad != 0)
+    DOPAD = (hpad != 0 or wpad != 0)
 
     _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if do_pad:
+    if DOPAD:
         s[A0].compute_inline()
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -152,7 +152,8 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     # If no config was set, we can fallback to default config.
     if cfg.is_fallback:
-        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width), dtype=data.dtype),
+        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
+                                                dtype=data.dtype),
                             te.placeholder((out_channel, in_channel // groups, k_height, k_width),
                                            dtype=kernel.dtype),
                             strides, padding, groups, out_dtype)
@@ -265,7 +266,6 @@ def schedule_group_conv2d_nchwc(cfg, outs):
 def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
                         conv_out, output, last):
     """Schedule GSPC"""
-    # fetch schedule
     ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
                                       cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
 

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -19,15 +19,16 @@
 import tvm
 from tvm import autotvm
 from tvm import te
+from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
+
 from ..util import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
-from ..nn.conv2d import group_conv2d_nchw
 from ..nn.util import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
-from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
+
 
 
 def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups,
@@ -62,9 +63,9 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
 
 def _fallback_schedule(cfg, wkl):
     simd_width = 4 # assume ARM SIMD Width is 4
-    pt, pl, pb, pr = wkl.padt, wkl.padl, wkl.padb, wkl.padr
+    pad_top, pad_left, pad_bottom, pad_right = wkl.padt, wkl.padl, wkl.padb, wkl.padr
     stride_w = wkl.wstride
-    out_width = (wkl.width + pl + pr - wkl.wkernel) // stride_w + 1
+    out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
     groups = wkl.groups
     kernels_per_group = wkl.out_filter // groups
     kernel_depth = wkl.in_filter // groups
@@ -100,6 +101,10 @@ def _fallback_schedule(cfg, wkl):
 @autotvm.register_topi_compute("group_conv2d_nchw.arm_cpu")
 def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
                                    dilation, groups, out_dtype='float32'):
+    """
+    Compute group conv2d with NCHW layout, using GSPC algorithm.
+    https://arxiv.org/abs/2006.09791
+    """
     assert isinstance(dilation, int) or len(dilation) == 2
     if isinstance(dilation, int):
         dilation_h, dilation_w = dilation, dilation
@@ -108,16 +113,16 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
     if isinstance(padding, int):
-        pt, pl, pb, pr = padding, padding, padding, padding
+        pad_top, pad_left, pad_bottom, pad_right = padding, padding, padding, padding
     elif len(padding) == 2:
-        HPAD, WPAD = padding
-        pt, pb = HPAD, HPAD
-        pl, pr = WPAD, WPAD
+        hpad, wpad = padding
+        pad_top, pad_bottom = hpad, hpad
+        pad_left, pad_right = wpad, wpad
     else:
-        pt, pl, pb, pr = padding
+        pad_top, pad_left, pad_bottom, pad_right = padding
 
-    HPAD = pt + pb
-    WPAD = pl + pr
+    hpad = pad_top + pad_bottom
+    wpad = pad_left + pad_right
 
     assert isinstance(strides, int) or len(strides) == 2
     if isinstance(strides, int):
@@ -128,13 +133,13 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
     batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
     out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
 
-    pad_height = in_height + pt + pb
-    pad_width = in_width + pl + pr
+    pad_height = in_height + pad_top + pad_bottom
+    pad_width = in_width + pad_left + pad_right
 
     dilated_kernel_h = (k_height - 1) * dilation_h + 1
     dilated_kernel_w = (k_width - 1) * dilation_w + 1
-    out_height = (in_height + pt + pb - dilated_kernel_h) // stride_h + 1
-    out_width = (in_width + pl + pr - dilated_kernel_w) // stride_w + 1
+    out_height = (in_height + pad_top + pad_bottom - dilated_kernel_h) // stride_h + 1
+    out_width = (in_width + pad_left + pad_right - dilated_kernel_w) // stride_w + 1
 
     kernels_per_group = out_channel // groups
 
@@ -153,11 +158,11 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
     oc_bn = cfg['tile_oc'].size[-1]
     ic_bn = cfg['tile_ic'].size[-1]
     # pack data
-    DOPAD = (HPAD != 0 or WPAD != 0)
-    if DOPAD:
+    do_pad = (hpad != 0 or wpad != 0)
+    if do_pad:
         data_pad = pad(data,
-                       (0, 0, pt, pl),
-                       (0, 0, pb, pr),
+                       (0, 0, pad_top, pad_left),
+                       (0, 0, pad_bottom, pad_right),
                        name="data_pad")
     else:
         data_pad = data
@@ -245,12 +250,9 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
 
-            _, c, h, w = get_const_tuple(data.shape)
-            _, x, kh, kw = get_const_tuple(kernel.shape)
-
             args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
                     output, outs[0]]
-            schedule_conv_sp_grouped(*args)
+            _schedule_gspc_nchw(*args)
 
         scheduled_ops.append(op)
 
@@ -258,25 +260,25 @@ def schedule_group_conv2d_nchwc(cfg, outs):
     return s
 
 
-def schedule_conv_sp_grouped(s, cfg, data, data_pad, data_vec, kernel_vec,
-                             conv_out, output, last,
-                             **kwargs):
+def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
+                        conv_out, output, last):
+    """Schedule GSPC"""
     # fetch schedule
     ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
                                       cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
 
     # no stride and padding info here
     padding = infer_pad(data, data_pad)
-    HPAD, WPAD = padding
-    DOPAD = (HPAD != 0 or WPAD != 0)
+    hpad, wpad = padding
+    do_pad = (hpad != 0 or wpad != 0)
 
-    A, W = data, kernel_vec
+    _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if DOPAD:
+    if do_pad:
         s[A0].compute_inline()
-    groups, batch, ic_chunk, ih, ic_block, iw = s[A1].op.axis
+    groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
     s[A1].parallel(parallel_axis)

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -1,0 +1,342 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+# pylint: disable=no-value-for-parameter,import-outside-toplevel
+"""Grouped Spatial Pack Convolution (Group Conv2D) schedule on ARM"""
+
+import tvm
+from tvm import autotvm
+from tvm import te
+from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
+
+from ..utils import get_const_tuple
+from ..nn.pad import pad
+from .. import tag
+
+from ..nn.utils import infer_pad
+from ..nn.conv2d import _get_workload as _get_conv2d_workload
+
+
+
+
+def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups,
+                      out_dtype):
+    """Compute group_conv2d with NCHW layout"""
+    return group_conv2d_nchw_spatial_pack(data, kernel, strides, padding,
+                                          dilation, groups, out_dtype)
+
+
+def schedule_group_conv2d_nchw(outs):
+    """Compute group_conv2d with NCHW layout"""
+    return schedule_group_conv2d_nchwc(outs)
+
+
+def _get_default_config(cfg, data, kernel, strides, padding, groups,
+                        out_dtype, layout='NCHW'):
+    """
+    Get default schedule config for the workload
+    """
+    static_data_shape = []
+    for dim in get_const_tuple(data.shape):
+        if isinstance(dim, tvm.tir.Var):
+            static_data_shape.append(1)
+        else:
+            static_data_shape.append(dim)
+    data = te.placeholder(static_data_shape, dtype=data.dtype)
+
+    wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype,
+                               layout)
+    _fallback_schedule(cfg, wkl)
+
+
+def _fallback_schedule(cfg, wkl):
+    simd_width = 4 # assume ARM SIMD Width is 4
+    pad_left, pad_right = wkl.padl, wkl.padr
+    stride_w = wkl.wstride
+    out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
+    groups = wkl.groups
+    kernels_per_group = wkl.out_filter // groups
+    kernel_depth = wkl.in_filter // groups
+
+    oc_bn = 1
+    for bn in range(simd_width, 0, -1):
+        if kernels_per_group % bn == 0:
+            oc_bn = bn
+            break
+    if oc_bn > kernels_per_group:
+        oc_bn = kernels_per_group
+
+    ic_bn = 1
+    for bn in range(oc_bn, 0, -1):
+        if kernel_depth % bn == 0:
+            ic_bn = bn
+            break
+    if ic_bn > kernel_depth:
+        ic_bn = kernel_depth
+
+    reg_n = 1
+    for n in range(31, 0, -1):
+        if out_width % n == 0:
+            reg_n = n
+            break
+
+    cfg["tile_ic"] = SplitEntity([wkl.in_filter // ic_bn, ic_bn])
+    cfg["tile_oc"] = SplitEntity([wkl.out_filter // oc_bn, oc_bn])
+    cfg["tile_ow"] = SplitEntity([out_width // reg_n, reg_n])
+    cfg["unroll_kw"] = OtherOptionEntity(False)
+
+
+@autotvm.register_topi_compute("group_conv2d_nchw.arm_cpu")
+def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
+                                   dilation, groups, out_dtype='float32'):
+    """
+    Compute group conv2d with NCHW layout, using GSPC algorithm.
+    https://arxiv.org/abs/2006.09791
+    """
+    assert isinstance(dilation, int) or len(dilation) == 2
+    if isinstance(dilation, int):
+        dilation_h, dilation_w = dilation, dilation
+    else:
+        dilation_h, dilation_w = dilation
+
+    assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
+    if isinstance(padding, int):
+        pad_top, pad_left, pad_bottom, pad_right = padding, padding, padding, padding
+    elif len(padding) == 2:
+        hpad, wpad = padding
+        pad_top, pad_bottom = hpad, hpad
+        pad_left, pad_right = wpad, wpad
+    else:
+        pad_top, pad_left, pad_bottom, pad_right = padding
+
+    hpad = pad_top + pad_bottom
+    wpad = pad_left + pad_right
+
+    assert isinstance(strides, int) or len(strides) == 2
+    if isinstance(strides, int):
+        stride_h, stride_w = strides, strides
+    else:
+        stride_h, stride_w = strides
+
+    batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
+    out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
+
+    pad_height = in_height + pad_top + pad_bottom
+    pad_width = in_width + pad_left + pad_right
+
+    dilated_kernel_h = (k_height - 1) * dilation_h + 1
+    dilated_kernel_w = (k_width - 1) * dilation_w + 1
+    out_height = (in_height + pad_top + pad_bottom - dilated_kernel_h) // stride_h + 1
+    out_width = (in_width + pad_left + pad_right - dilated_kernel_w) // stride_w + 1
+
+    kernels_per_group = out_channel // groups
+
+    cfg.define_split("tile_ic", in_channel, num_outputs=2)
+    cfg.define_split("tile_oc", out_channel, num_outputs=2)
+    cfg.define_split("tile_ow", out_width, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
+    cfg.define_knob("unroll_kw", [True, False])
+
+    # If no config was set, we can fallback to default config.
+    if cfg.is_fallback:
+        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
+                                                dtype=data.dtype),
+                            te.placeholder((out_channel, in_channel // groups, k_height, k_width),
+                                           dtype=kernel.dtype),
+                            strides, padding, groups, out_dtype)
+
+    oc_bn = cfg['tile_oc'].size[-1]
+    ic_bn = cfg['tile_ic'].size[-1]
+    # pack data
+    DOPAD = (hpad != 0 or wpad != 0)
+    if DOPAD:
+        data_pad = pad(data,
+                       (0, 0, pad_top, pad_left),
+                       (0, 0, pad_bottom, pad_right),
+                       name="data_pad")
+    else:
+        data_pad = data
+
+    shape = (groups, batch_size, kernel_depth // ic_bn,
+             pad_height, ic_bn, pad_width)
+
+    data_vec = te.compute(shape,
+                          lambda g, n, C, h, c, w:
+                          data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
+                          name='data_vec')
+
+    # pack kernel
+    shape = (groups, kernels_per_group//oc_bn, kernel_depth//ic_bn,
+             k_height, k_width, ic_bn, oc_bn)
+    kernel_vec = te.compute(shape,
+                            lambda g, out_channel, in_channel, h, w, ci, co:
+                            kernel[(out_channel * oc_bn + co + g * kernels_per_group),
+                                   in_channel * ic_bn + ci, h, w],
+                            name='kernel_vec')
+
+    # convolution
+    oshape = (groups, batch_size, kernels_per_group//oc_bn,
+              out_height, out_width, oc_bn)
+    unpack_shape = (batch_size, out_channel, out_height, out_width)
+
+    ic = te.reduce_axis((0, (kernel_depth)), name='ic')
+    kh = te.reduce_axis((0, k_height), name='kh')
+    kw = te.reduce_axis((0, k_width), name='kw')
+    idxmod = tvm.tir.indexmod
+    idxdiv = tvm.tir.indexdiv
+
+    conv = te.compute(oshape, lambda g, n, oc_chunk, oh, ow, oc_block:
+                      te.sum(data_vec[g, n, idxdiv(ic, ic_bn),
+                                      oh * stride_h + kh * dilation_h,
+                                      idxmod(ic, ic_bn),
+                                      ow * stride_w + kw * dilation_w].astype(out_dtype) *
+                             kernel_vec[g, oc_chunk, idxdiv(ic, ic_bn),
+                                        kh, kw, idxmod(ic, ic_bn),
+                                        oc_block].astype(out_dtype),
+                             axis=[ic, kh, kw]), name='conv')
+
+    unpack = te.compute(unpack_shape,
+                        lambda n, c, h, w:
+                        conv[idxdiv(c, kernels_per_group), n,
+                             idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
+                             h, w,
+                             idxmod(idxmod(c, oc_bn), kernels_per_group)]
+                        .astype(out_dtype),
+                        name='output_unpack',
+                        tag='group_conv2d_nchw')
+    return unpack
+
+
+@autotvm.register_topi_schedule("group_conv2d_nchw.arm_cpu")
+def schedule_group_conv2d_nchwc(cfg, outs):
+    """Create schedule for tensors"""
+    s = te.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
+    def traverse(op):
+        """Traverse operators from computation graph"""
+        # inline all one-to-one-mapping operators except the last stage (output)
+        if tag.is_broadcast(op.tag):
+            if op not in s.outputs:
+                s[op].compute_inline()
+            for tensor in op.input_tensors:
+                if isinstance(tensor.op, tvm.te.ComputeOp) and tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+
+        if 'group_conv2d_nchw' in op.tag:
+            output = op.output(0)
+
+            if "tile_ic" not in cfg:
+                return
+            conv_out = op.input_tensors[0]
+            kernel_vec = conv_out.op.input_tensors[1]
+            kernel = kernel_vec.op.input_tensors[0]
+            if isinstance(kernel.op, tvm.te.ComputeOp) and "dilate" in kernel.op.tag:
+                s[kernel].compute_inline()
+            data_vec = conv_out.op.input_tensors[0]
+            data = data_vec.op.input_tensors[0]
+            data_pad = None
+            if isinstance(data.op, tvm.te.ComputeOp) and "pad" in data.op.tag:
+                data_pad = data
+                data = data_pad.op.input_tensors[0]
+
+            args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
+                    output, outs[0]]
+            _schedule_gspc_nchw(*args)
+
+        scheduled_ops.append(op)
+
+    traverse(outs[0].op)
+    return s
+
+
+def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
+                        conv_out, output, last):
+    """Schedule GSPC"""
+    ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
+                                      cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
+
+    # no stride and padding info here
+    padding = infer_pad(data, data_pad)
+    hpad, wpad = padding
+    DOPAD = (hpad != 0 or wpad != 0)
+
+    _, W = data, kernel_vec
+    A0, A1 = data_pad, data_vec
+
+    # schedule data
+    if DOPAD:
+        s[A0].compute_inline()
+    groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
+
+    parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
+    s[A1].parallel(parallel_axis)
+
+    # schedule kernel pack
+    groups, oc_chunk, ic_chunk, oh, ow, ic_block, oc_block = s[W].op.axis
+    s[W].reorder(oc_chunk, oh, ic_chunk, ow, ic_block, oc_block)
+
+    if oc_bn > 1:
+        s[W].vectorize(oc_block)
+
+    parallel_axis = s[W].fuse(groups, oc_chunk, oh)
+    s[W].parallel(parallel_axis)
+
+    # schedule conv
+    C, O0, O = conv_out, output, last
+    CC = s.cache_write(C, 'global')
+
+    _, _, oc_chunk, oh, ow, oc_block = s[C].op.axis
+
+    ow_chunk, ow_block = s[C].split(ow, factor=reg_n)
+
+    s[C].reorder(oc_chunk, oh, ow_chunk, ow_block, oc_block)
+    s[C].fuse(oc_chunk, oh)
+    s[C].vectorize(oc_block)
+
+    groups, batch, oc_chunk, oh, ow, oc_block = s[CC].op.axis
+
+    ic, kh, kw = s[CC].op.reduce_axis
+    ow_chunk, ow_block = s[CC].split(ow, factor=reg_n)
+    ic_chunk, ic_block = s[CC].split(ic, factor=ic_bn)
+
+    if unroll_kw:
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, ic_block, kw,
+                      ow_block, oc_block)
+        s[CC].unroll(kw)
+    else:
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block,
+                      ow_block, oc_block)
+
+    parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
+    s[CC].parallel(parallel_axis)
+
+    s[CC].vectorize(oc_block)
+
+    s[CC].unroll(ow_block)
+
+    if O0 != O:
+        s[O0].compute_inline()
+
+    batch, oc, oh, ow = s[O].op.axis
+    ow_chunk, ow_block = s[O].split(ow, factor=reg_n)
+    oc_chunk, oc_block = s[O].split(oc, factor=oc_bn)
+
+    s[O].reorder(batch, oc_chunk, oh, ow_chunk, ow_block, oc_block)
+    parallel_axis = s[O].fuse(oc_chunk, oh)
+    s[O].vectorize(oc_block)
+    s[O].parallel(parallel_axis)
+    return s

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -32,12 +32,11 @@ from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
 
 
-
-def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups,
-                      out_dtype):
+def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups, out_dtype):
     """Compute group_conv2d with NCHW layout"""
-    return group_conv2d_nchw_spatial_pack(data, kernel, strides, padding,
-                                          dilation, groups, out_dtype)
+    return group_conv2d_nchw_spatial_pack(
+        data, kernel, strides, padding, dilation, groups, out_dtype
+    )
 
 
 def schedule_group_conv2d_nchw(outs):
@@ -45,8 +44,7 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups,
-                        out_dtype, layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, layout='NCHW'):
     """
     Get default schedule config for the workload
     """
@@ -58,13 +56,12 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups,
             static_data_shape.append(dim)
     data = te.placeholder(static_data_shape, dtype=data.dtype)
 
-    wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype,
-                               layout, asymmetric_pad=True)
+    wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype, layout)
     _fallback_schedule(cfg, wkl)
 
 
 def _fallback_schedule(cfg, wkl):
-    simd_width = 4 # assume ARM SIMD Width is 4
+    simd_width = 4  # assume ARM SIMD Width is 4
     pad_left, pad_right = wkl.padl, wkl.padr
     stride_w = wkl.wstride
     out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
@@ -101,8 +98,9 @@ def _fallback_schedule(cfg, wkl):
 
 
 @autotvm.register_topi_compute("group_conv2d_nchw.arm_cpu")
-def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
-                                   dilation, groups, out_dtype='float32'):
+def group_conv2d_nchw_spatial_pack(
+        cfg, data, kernel, strides, padding, dilation, groups, out_dtype='float32'
+):
     """
     Compute group conv2d with NCHW layout, using GSPC algorithm.
     https://arxiv.org/abs/2006.09791
@@ -152,71 +150,101 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     # If no config was set, we can fallback to default config.
     if cfg.is_fallback:
-        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
-                                                dtype=data.dtype),
-                            te.placeholder((out_channel, in_channel // groups, k_height, k_width),
-                                           dtype=kernel.dtype),
-                            strides, padding, groups, out_dtype)
+        _get_default_config(
+            cfg,
+            te.placeholder((batch_size, in_channel, in_height, in_width), dtype=data.dtype),
+            te.placeholder(
+                (out_channel, in_channel // groups, k_height, k_width), dtype=kernel.dtype
+            ),
+            strides,
+            padding,
+            groups,
+            out_dtype,
+        )
 
-    oc_bn = cfg['tile_oc'].size[-1]
-    ic_bn = cfg['tile_ic'].size[-1]
+    oc_bn = cfg["tile_oc"].size[-1]
+    ic_bn = cfg["tile_ic"].size[-1]
+
     # pack data
-    DOPAD = (hpad != 0 or wpad != 0)
+    DOPAD = hpad != 0 or wpad != 0
     if DOPAD:
-        data_pad = pad(data,
-                       (0, 0, pad_top, pad_left),
-                       (0, 0, pad_bottom, pad_right),
-                       name="data_pad")
+        data_pad = pad(
+            data, (0, 0, pad_top, pad_left), (0, 0, pad_bottom, pad_right), name="data_pad"
+        )
     else:
         data_pad = data
 
-    shape = (groups, batch_size, kernel_depth // ic_bn,
-             pad_height, ic_bn, pad_width)
+    shape = (groups, batch_size, kernel_depth // ic_bn, pad_height, ic_bn, pad_width)
 
-    data_vec = te.compute(shape,
-                          lambda g, n, C, h, c, w:
-                          data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
-                          name='data_vec')
+    data_vec = te.compute(
+        shape,
+        lambda g, n, C, h, c, w: data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
+        name="data_vec",
+    )
 
     # pack kernel
-    shape = (groups, kernels_per_group//oc_bn, kernel_depth//ic_bn,
-             k_height, k_width, ic_bn, oc_bn)
-    kernel_vec = te.compute(shape,
-                            lambda g, out_channel, in_channel, h, w, ci, co:
-                            kernel[(out_channel * oc_bn + co + g * kernels_per_group),
-                                   in_channel * ic_bn + ci, h, w],
-                            name='kernel_vec')
+    shape = (
+        groups,
+        kernels_per_group // oc_bn,
+        kernel_depth // ic_bn,
+        k_height,
+        k_width,
+        ic_bn,
+        oc_bn,
+    )
+
+    kernel_vec = te.compute(
+        shape,
+        lambda g, out_channel, in_channel, h, w, ci, co: kernel[
+            (out_channel * oc_bn + co + g * kernels_per_group), in_channel * ic_bn + ci, h, w
+        ],
+        name="kernel_vec",
+    )
 
     # convolution
-    oshape = (groups, batch_size, kernels_per_group//oc_bn,
-              out_height, out_width, oc_bn)
+    oshape = (groups, batch_size, kernels_per_group//oc_bn, out_height, out_width, oc_bn)
     unpack_shape = (batch_size, out_channel, out_height, out_width)
 
-    ic = te.reduce_axis((0, (kernel_depth)), name='ic')
-    kh = te.reduce_axis((0, k_height), name='kh')
-    kw = te.reduce_axis((0, k_width), name='kw')
+    ic = te.reduce_axis((0, (kernel_depth)), name="ic")
+    kh = te.reduce_axis((0, k_height), name="kh")
+    kw = te.reduce_axis((0, k_width), name="kw")
+
     idxmod = tvm.tir.indexmod
     idxdiv = tvm.tir.indexdiv
 
-    conv = te.compute(oshape, lambda g, n, oc_chunk, oh, ow, oc_block:
-                      te.sum(data_vec[g, n, idxdiv(ic, ic_bn),
-                                      oh * stride_h + kh * dilation_h,
-                                      idxmod(ic, ic_bn),
-                                      ow * stride_w + kw * dilation_w].astype(out_dtype) *
-                             kernel_vec[g, oc_chunk, idxdiv(ic, ic_bn),
-                                        kh, kw, idxmod(ic, ic_bn),
-                                        oc_block].astype(out_dtype),
-                             axis=[ic, kh, kw]), name='conv')
+    conv = te.compute(
+        oshape,
+        lambda g, n, oc_chunk, oh, ow, oc_block: te.sum(
+            data_vec[
+                g,
+                n,
+                idxdiv(ic, ic_bn),
+                oh * stride_h + kh * dilation_h,
+                idxmod(ic, ic_bn),
+                ow * stride_w + kw * dilation_w,
+            ].astype(out_dtype)
+            * kernel_vec[
+                g, oc_chunk, idxdiv(ic, ic_bn), kh, kw, idxmod(ic, ic_bn), oc_block
+            ].astype(out_dtype),
+            axis=[ic, kh, kw],
+        ),
+        name="conv",
+    )
 
-    unpack = te.compute(unpack_shape,
-                        lambda n, c, h, w:
-                        conv[idxdiv(c, kernels_per_group), n,
-                             idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
-                             h, w,
-                             idxmod(idxmod(c, oc_bn), kernels_per_group)]
-                        .astype(out_dtype),
-                        name='output_unpack',
-                        tag='group_conv2d_nchw')
+    unpack = te.compute(
+        unpack_shape,
+        lambda n, c, h, w: conv[
+            idxdiv(c, kernels_per_group),
+            n,
+            idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
+            h,
+            w,
+            idxmod(idxmod(c, oc_bn), kernels_per_group),
+        ].astype(out_dtype),
+        name="output_unpack",
+        tag="group_conv2d_nchw",
+    )
+
     return unpack
 
 
@@ -236,7 +264,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 if isinstance(tensor.op, tvm.te.ComputeOp) and tensor.op not in scheduled_ops:
                     traverse(tensor.op)
 
-        if 'group_conv2d_nchw' in op.tag:
+        if "group_conv2d_nchw" in op.tag:
             output = op.output(0)
 
             if "tile_ic" not in cfg:
@@ -253,8 +281,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
 
-            args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
-                    output, outs[0]]
+            args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, output, outs[0]]
             _schedule_gspc_nchw(*args)
 
         scheduled_ops.append(op)
@@ -263,16 +290,20 @@ def schedule_group_conv2d_nchwc(cfg, outs):
     return s
 
 
-def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
-                        conv_out, output, last):
+def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, output, last):
     """Schedule GSPC"""
-    ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
-                                      cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
+    ic_bn, oc_bn, reg_n, unroll_kw = (
+        cfg["tile_ic"].size[-1],
+        cfg["tile_oc"].size[-1],
+        cfg["tile_ow"].size[-1],
+        cfg["unroll_kw"].val,
+    )
+
 
     # no stride and padding info here
     padding = infer_pad(data, data_pad)
     hpad, wpad = padding
-    DOPAD = (hpad != 0 or wpad != 0)
+    DOPAD = hpad != 0 or wpad != 0
 
     _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
@@ -297,7 +328,7 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
 
     # schedule conv
     C, O0, O = conv_out, output, last
-    CC = s.cache_write(C, 'global')
+    CC = s.cache_write(C, "global")
 
     _, _, oc_chunk, oh, ow, oc_block = s[C].op.axis
 
@@ -314,12 +345,10 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
     ic_chunk, ic_block = s[CC].split(ic, factor=ic_bn)
 
     if unroll_kw:
-        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, ic_block, kw,
-                      ow_block, oc_block)
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, ic_block, kw, ow_block, oc_block)
         s[CC].unroll(kw)
     else:
-        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block,
-                      ow_block, oc_block)
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block, ow_block, oc_block)
 
     parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
     s[CC].parallel(parallel_axis)

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -1,36 +1,15 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
-# pylint: disable=no-value-for-parameter,import-outside-toplevel
-"""Grouped Spatial Pack Convolution (Group Conv2D) schedule on ARM"""
-
 import tvm
 from tvm import autotvm
 from tvm import te
-from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
-
-from ..utils import get_const_tuple
+from ..util import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
-from ..nn.utils import infer_pad
+from ..nn.conv2d import group_conv2d_nchw
+from ..nn.util import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
-
+from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
 
 def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups,
@@ -45,8 +24,8 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups,
-                        out_dtype, layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
+                        layout='NCHW'):
     """
     Get default schedule config for the workload
     """
@@ -65,28 +44,24 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups,
 
 def _fallback_schedule(cfg, wkl):
     simd_width = 4 # assume ARM SIMD Width is 4
-    pad_left, pad_right = wkl.padl, wkl.padr
-    stride_w = wkl.wstride
-    out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
-    groups = wkl.groups
-    kernels_per_group = wkl.out_filter // groups
-    kernel_depth = wkl.in_filter // groups
-
+    HPAD, WPAD = wkl.hpad, wkl.wpad
+    HSTR, WSTR = wkl.hstride, wkl.wstride
+    out_width = (wkl.width + 2 * WPAD - wkl.wkernel) // WSTR + 1
+    G = wkl.groups
+    KPG = wkl.out_filter // G
+    CPG = wkl.in_filter // G
     oc_bn = 1
+
     for bn in range(simd_width, 0, -1):
-        if kernels_per_group % bn == 0:
+        if KPG % bn == 0:
             oc_bn = bn
             break
-    if oc_bn > kernels_per_group:
-        oc_bn = kernels_per_group
 
     ic_bn = 1
     for bn in range(oc_bn, 0, -1):
-        if kernel_depth % bn == 0:
+        if CPG % bn == 0:
             ic_bn = bn
             break
-    if ic_bn > kernel_depth:
-        ic_bn = kernel_depth
 
     reg_n = 1
     for n in range(31, 0, -1):
@@ -103,10 +78,6 @@ def _fallback_schedule(cfg, wkl):
 @autotvm.register_topi_compute("group_conv2d_nchw.arm_cpu")
 def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
                                    dilation, groups, out_dtype='float32'):
-    """
-    Compute group conv2d with NCHW layout, using GSPC algorithm.
-    https://arxiv.org/abs/2006.09791
-    """
     assert isinstance(dilation, int) or len(dilation) == 2
     if isinstance(dilation, int):
         dilation_h, dilation_w = dilation, dilation
@@ -115,94 +86,87 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
     if isinstance(padding, int):
-        pad_top, pad_left, pad_bottom, pad_right = padding, padding, padding, padding
+        HPAD, WPAD = padding, padding
     elif len(padding) == 2:
-        hpad, wpad = padding
-        pad_top, pad_bottom = hpad, hpad
-        pad_left, pad_right = wpad, wpad
+        HPAD, WPAD = padding
     else:
-        pad_top, pad_left, pad_bottom, pad_right = padding
-
-    hpad = pad_top + pad_bottom
-    wpad = pad_left + pad_right
+        HPAD, _, WPAD, _ = padding
 
     assert isinstance(strides, int) or len(strides) == 2
     if isinstance(strides, int):
-        stride_h, stride_w = strides, strides
+        HSTR, WSTR = strides, strides
     else:
-        stride_h, stride_w = strides
+        HSTR, WSTR = strides
 
-    batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
-    out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
+    N, CI, IH, IW = get_const_tuple(data.shape)
+    CO, CIG, KH, KW = get_const_tuple(kernel.shape)
 
-    pad_height = in_height + pad_top + pad_bottom
-    pad_width = in_width + pad_left + pad_right
+    pad_height = IH + 2 * HPAD
+    pad_width = IW + 2 * WPAD
 
-    dilated_kernel_h = (k_height - 1) * dilation_h + 1
-    dilated_kernel_w = (k_width - 1) * dilation_w + 1
-    out_height = (in_height + pad_top + pad_bottom - dilated_kernel_h) // stride_h + 1
-    out_width = (in_width + pad_left + pad_right - dilated_kernel_w) // stride_w + 1
+    dilated_kernel_h = (KH - 1) * dilation_h + 1
+    dilated_kernel_w = (KW - 1) * dilation_w + 1
+    OH = (IH + 2 * HPAD - dilated_kernel_h) // HSTR + 1
+    OW = (IW + 2 * WPAD - dilated_kernel_w) // WSTR + 1
 
-    kernels_per_group = out_channel // groups
+    G = groups
+    KPG = CO // G
+    CPG = CI // G
 
-    cfg.define_split("tile_ic", in_channel, num_outputs=2)
-    cfg.define_split("tile_oc", out_channel, num_outputs=2)
-    cfg.define_split("tile_ow", out_width, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
+    cfg.define_split("tile_ic", CI, num_outputs=2)
+    cfg.define_split("tile_oc", CO, num_outputs=2)
+    cfg.define_split("tile_ow", OW, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
     cfg.define_knob("unroll_kw", [True, False])
 
     # If no config was set, we can fallback to default config.
     if cfg.is_fallback:
-        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
-                                                dtype=data.dtype),
-                            te.placeholder((out_channel, in_channel // groups, k_height, k_width),
+        _get_default_config(cfg, te.placeholder((N, CI, IH, IW), dtype=data.dtype),
+                            te.placeholder((N, CI // G, KH, KW),
                                            dtype=kernel.dtype),
                             strides, padding, groups, out_dtype)
 
     oc_bn = cfg['tile_oc'].size[-1]
     ic_bn = cfg['tile_ic'].size[-1]
     # pack data
-    DOPAD = (hpad != 0 or wpad != 0)
+    DOPAD = (HPAD != 0 or WPAD != 0)
     if DOPAD:
-        data_pad = pad(data,
-                       (0, 0, pad_top, pad_left),
-                       (0, 0, pad_bottom, pad_right),
-                       name="data_pad")
+        data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
     else:
         data_pad = data
 
-    shape = (groups, batch_size, kernel_depth // ic_bn,
+    shape = (G, N, CPG // ic_bn,
              pad_height, ic_bn, pad_width)
 
     data_vec = te.compute(shape,
                           lambda g, n, C, h, c, w:
-                          data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
+                          data_pad[n, C * ic_bn + c + CPG * g, h, w],
                           name='data_vec')
 
     # pack kernel
-    shape = (groups, kernels_per_group//oc_bn, kernel_depth//ic_bn,
-             k_height, k_width, ic_bn, oc_bn)
+    shape = (G, KPG//oc_bn, CPG//ic_bn,
+             KH, KW, ic_bn, oc_bn)
     kernel_vec = te.compute(shape,
-                            lambda g, out_channel, in_channel, h, w, ci, co:
-                            kernel[(out_channel * oc_bn + co + g * kernels_per_group),
-                                   in_channel * ic_bn + ci, h, w],
+                            lambda g, CO, CI, h, w, ci, co:
+                            kernel[(CO * oc_bn + co + g * KPG),
+                                   CI * ic_bn + ci, h, w],
                             name='kernel_vec')
 
     # convolution
-    oshape = (groups, batch_size, kernels_per_group//oc_bn,
-              out_height, out_width, oc_bn)
-    unpack_shape = (batch_size, out_channel, out_height, out_width)
+    oshape = (G, N, KPG//oc_bn,
+              OH, OW, oc_bn)
+    unpack_shape = (N, CO, OH, OW)
 
-    ic = te.reduce_axis((0, (kernel_depth)), name='ic')
-    kh = te.reduce_axis((0, k_height), name='kh')
-    kw = te.reduce_axis((0, k_width), name='kw')
+    ic = te.reduce_axis((0, (CPG)), name='ic')
+    kh = te.reduce_axis((0, KH), name='kh')
+    kw = te.reduce_axis((0, KW), name='kw')
     idxmod = tvm.tir.indexmod
     idxdiv = tvm.tir.indexdiv
 
     conv = te.compute(oshape, lambda g, n, oc_chunk, oh, ow, oc_block:
                       te.sum(data_vec[g, n, idxdiv(ic, ic_bn),
-                                      oh * stride_h + kh * dilation_h,
+                                      oh*HSTR+kh*dilation_h,
                                       idxmod(ic, ic_bn),
-                                      ow * stride_w + kw * dilation_w].astype(out_dtype) *
+                                      ow*WSTR+kw*dilation_w].astype(out_dtype) *
                              kernel_vec[g, oc_chunk, idxdiv(ic, ic_bn),
                                         kh, kw, idxmod(ic, ic_bn),
                                         oc_block].astype(out_dtype),
@@ -210,10 +174,10 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     unpack = te.compute(unpack_shape,
                         lambda n, c, h, w:
-                        conv[idxdiv(c, kernels_per_group), n,
-                             idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
+                        conv[idxdiv(c, KPG), n,
+                             idxmod(idxdiv(c, oc_bn), (KPG // oc_bn)),
                              h, w,
-                             idxmod(idxmod(c, oc_bn), kernels_per_group)]
+                             idxmod(idxmod(c, oc_bn), KPG)]
                         .astype(out_dtype),
                         name='output_unpack',
                         tag='group_conv2d_nchw')
@@ -253,9 +217,12 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
 
+            _, c, h, w = get_const_tuple(data.shape)
+            _, x, kh, kw = get_const_tuple(kernel.shape)
+
             args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
                     output, outs[0]]
-            _schedule_gspc_nchw(*args)
+            schedule_conv_sp_grouped(*args)
 
         scheduled_ops.append(op)
 
@@ -263,24 +230,25 @@ def schedule_group_conv2d_nchwc(cfg, outs):
     return s
 
 
-def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
-                        conv_out, output, last):
-    """Schedule GSPC"""
+def schedule_conv_sp_grouped(s, cfg, data, data_pad, data_vec, kernel_vec,
+                             conv_out, output, last,
+                             **kwargs):
+    # fetch schedule
     ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
                                       cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
 
     # no stride and padding info here
     padding = infer_pad(data, data_pad)
-    hpad, wpad = padding
-    DOPAD = (hpad != 0 or wpad != 0)
+    HPAD, WPAD = padding
+    DOPAD = (HPAD != 0 or WPAD != 0)
 
-    _, W = data, kernel_vec
+    A, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
     if DOPAD:
         s[A0].compute_inline()
-    groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
+    groups, batch, ic_chunk, ih, ic_block, iw = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
     s[A1].parallel(parallel_axis)

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -31,7 +31,6 @@ from ..nn.util import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
 
-
 def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups, out_dtype):
     """Compute group_conv2d with NCHW layout"""
     return group_conv2d_nchw_spatial_pack(
@@ -44,7 +43,7 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, layout="NCHW"):
     """
     Get default schedule config for the workload
     """
@@ -99,7 +98,7 @@ def _fallback_schedule(cfg, wkl):
 
 @autotvm.register_topi_compute("group_conv2d_nchw.arm_cpu")
 def group_conv2d_nchw_spatial_pack(
-        cfg, data, kernel, strides, padding, dilation, groups, out_dtype='float32'
+    cfg, data, kernel, strides, padding, dilation, groups, out_dtype="float32"
 ):
     """
     Compute group conv2d with NCHW layout, using GSPC algorithm.
@@ -202,7 +201,7 @@ def group_conv2d_nchw_spatial_pack(
     )
 
     # convolution
-    oshape = (groups, batch_size, kernels_per_group//oc_bn, out_height, out_width, oc_bn)
+    oshape = (groups, batch_size, kernels_per_group // oc_bn, out_height, out_width, oc_bn)
     unpack_shape = (batch_size, out_channel, out_height, out_width)
 
     ic = te.reduce_axis((0, (kernel_depth)), name="ic")
@@ -298,7 +297,6 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
         cfg["tile_ow"].size[-1],
         cfg["unroll_kw"].val,
     )
-
 
     # no stride and padding info here
     padding = infer_pad(data, data_pad)

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -23,11 +23,11 @@ from tvm import autotvm
 from tvm import te
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
-from ..util import get_const_tuple
+from ..utils import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
-from ..nn.util import infer_pad
+from ..nn.utils import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
 
@@ -62,8 +62,8 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, 
 def _fallback_schedule(cfg, wkl):
     simd_width = 4  # assume ARM SIMD Width is 4
     pad_left, pad_right = wkl.padl, wkl.padr
-    stride_w = wkl.wstride
-    out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
+    stride_w = wkl.stride_w
+    out_width = (wkl.width + pad_left + pad_right - wkl.kernel_w) // stride_w + 1
     groups = wkl.groups
     kernels_per_group = wkl.out_filter // groups
     kernel_depth = wkl.in_filter // groups

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -303,7 +303,11 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if data_pad is not None and isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
+    if (
+        data_pad is not None
+        and isinstance(data_pad.op, tvm.te.ComputeOp)
+        and "pad" in data_pad.op.tag
+    ):
         s[A0].compute_inline()
 
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -27,7 +27,6 @@ from ..utils import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
-from ..nn.utils import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
 
@@ -298,17 +297,13 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
         cfg["unroll_kw"].val,
     )
 
-    # no stride and padding info here
-    padding = infer_pad(data, data_pad)
-    hpad, wpad = padding
-    DOPAD = hpad != 0 or wpad != 0
-
     _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if DOPAD:
+    if isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
         s[A0].compute_inline()
+
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -23,7 +23,7 @@ from tvm import autotvm
 from tvm import te
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
-from ..util import get_const_tuple
+from ..utils import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+# pylint: disable=no-value-for-parameter,import-outside-toplevel
 """Grouped Spatial Pack Convolution (Group Conv2D) schedule on ARM"""
 
 import tvm

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -303,7 +303,7 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
+    if data_pad is not None and isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
         s[A0].compute_inline()
 
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis

--- a/python/tvm/topi/arm_cpu/group_conv2d.py
+++ b/python/tvm/topi/arm_cpu/group_conv2d.py
@@ -1,29 +1,7 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
-# pylint: disable=no-value-for-parameter,import-outside-toplevel
-"""Grouped Spatial Pack Convolution (Group Conv2D) schedule on ARM"""
-
 import tvm
 from tvm import autotvm
 from tvm import te
-from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
-
-from ..utils import get_const_tuple
+from ..util import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
@@ -68,20 +46,17 @@ def _fallback_schedule(cfg, wkl):
     kernel_depth = wkl.in_filter // groups
 
     oc_bn = 1
+
     for bn in range(simd_width, 0, -1):
-        if kernels_per_group % bn == 0:
+        if KPG % bn == 0:
             oc_bn = bn
             break
-    if oc_bn > kernels_per_group:
-        oc_bn = kernels_per_group
 
     ic_bn = 1
     for bn in range(oc_bn, 0, -1):
-        if kernel_depth % bn == 0:
+        if CPG % bn == 0:
             ic_bn = bn
             break
-    if ic_bn > kernel_depth:
-        ic_bn = kernel_depth
 
     reg_n = 1
     for n in range(31, 0, -1):
@@ -111,39 +86,36 @@ def group_conv2d_nchw_spatial_pack(
 
     assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
     if isinstance(padding, int):
-        pad_top, pad_left, pad_bottom, pad_right = padding, padding, padding, padding
+        HPAD, WPAD = padding, padding
     elif len(padding) == 2:
-        hpad, wpad = padding
-        pad_top, pad_bottom = hpad, hpad
-        pad_left, pad_right = wpad, wpad
+        HPAD, WPAD = padding
     else:
-        pad_top, pad_left, pad_bottom, pad_right = padding
-
-    hpad = pad_top + pad_bottom
-    wpad = pad_left + pad_right
+        HPAD, _, WPAD, _ = padding
 
     assert isinstance(strides, int) or len(strides) == 2
     if isinstance(strides, int):
-        stride_h, stride_w = strides, strides
+        HSTR, WSTR = strides, strides
     else:
-        stride_h, stride_w = strides
+        HSTR, WSTR = strides
 
-    batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
-    out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
+    N, CI, IH, IW = get_const_tuple(data.shape)
+    CO, CIG, KH, KW = get_const_tuple(kernel.shape)
 
-    pad_height = in_height + pad_top + pad_bottom
-    pad_width = in_width + pad_left + pad_right
+    pad_height = IH + 2 * HPAD
+    pad_width = IW + 2 * WPAD
 
-    dilated_kernel_h = (k_height - 1) * dilation_h + 1
-    dilated_kernel_w = (k_width - 1) * dilation_w + 1
-    out_height = (in_height + pad_top + pad_bottom - dilated_kernel_h) // stride_h + 1
-    out_width = (in_width + pad_left + pad_right - dilated_kernel_w) // stride_w + 1
+    dilated_kernel_h = (KH - 1) * dilation_h + 1
+    dilated_kernel_w = (KW - 1) * dilation_w + 1
+    OH = (IH + 2 * HPAD - dilated_kernel_h) // HSTR + 1
+    OW = (IW + 2 * WPAD - dilated_kernel_w) // WSTR + 1
 
-    kernels_per_group = out_channel // groups
+    G = groups
+    KPG = CO // G
+    CPG = CI // G
 
-    cfg.define_split("tile_ic", in_channel, num_outputs=2)
-    cfg.define_split("tile_oc", out_channel, num_outputs=2)
-    cfg.define_split("tile_ow", out_width, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
+    cfg.define_split("tile_ic", CI, num_outputs=2)
+    cfg.define_split("tile_oc", CO, num_outputs=2)
+    cfg.define_split("tile_ow", OW, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
     cfg.define_knob("unroll_kw", [True, False])
 
     # If no config was set, we can fallback to default config.
@@ -297,7 +269,7 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
         cfg["unroll_kw"].val,
     )
 
-    _, W = data, kernel_vec
+    A, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data

--- a/python/tvm/topi/nn/conv2d.py
+++ b/python/tvm/topi/nn/conv2d.py
@@ -174,14 +174,10 @@ def _get_workload(data, kernel, stride, padding, dilation, out_dtype, data_layou
     else:
         KH, KW, CIG, CO = get_const_tuple(kernel.shape)
 
-<<<<<<< HEAD
     pt, pl, pb, pr = get_pad_tuple(padding, (get_const_int(KH), get_const_int(KW)))
     dilation_h, dilation_w = (
         dilation if isinstance(dilation, (tuple, list)) else (dilation, dilation)
     )
-=======
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, (get_const_int(KH), get_const_int(KW)))
->>>>>>> c57bd780a (Update conv2d.py)
     GRPS = CI // CIG
     if isinstance(stride, (tuple, list)):
         HSTR, WSTR = stride

--- a/python/tvm/topi/nn/conv2d.py
+++ b/python/tvm/topi/nn/conv2d.py
@@ -174,10 +174,14 @@ def _get_workload(data, kernel, stride, padding, dilation, out_dtype, data_layou
     else:
         KH, KW, CIG, CO = get_const_tuple(kernel.shape)
 
+<<<<<<< HEAD
     pt, pl, pb, pr = get_pad_tuple(padding, (get_const_int(KH), get_const_int(KW)))
     dilation_h, dilation_w = (
         dilation if isinstance(dilation, (tuple, list)) else (dilation, dilation)
     )
+=======
+    HPAD, WPAD, _, _ = get_pad_tuple(padding, (get_const_int(KH), get_const_int(KW)))
+>>>>>>> c57bd780a (Update conv2d.py)
     GRPS = CI // CIG
     if isinstance(stride, (tuple, list)):
         HSTR, WSTR = stride

--- a/python/tvm/topi/x86/__init__.py
+++ b/python/tvm/topi/x86/__init__.py
@@ -41,3 +41,4 @@ from .sparse import *
 from .conv2d_alter_op import *
 from .dense_alter_op import *
 from .scatter import *
+from .group_conv2d import *

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import tvm
 from tvm import autotvm
 from tvm import te

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+# pylint: disable=no-value-for-parameter,import-outside-toplevel
 """Grouped Spatial Pack Convolution (Group Conv2D) schedule on x86"""
 
 import tvm
@@ -42,8 +44,8 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
-                        layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups,
+                        out_dtype, layout='NCHW'):
     """
     Get default schedule config for the workload
     """
@@ -62,7 +64,7 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
 
 def _fallback_schedule(cfg, wkl):
     simd_width = get_fp32_len()
-    pad_top, pad_left, pad_bottom, pad_right = wkl.padt, wkl.padl, wkl.padb, wkl.padr
+    pad_left, pad_right = wkl.padl, wkl.padr
     stride_w = wkl.wstride
     out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
     groups = wkl.groups
@@ -149,7 +151,8 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     # If no config was set, we can fallback to default config.
     if cfg.is_fallback:
-        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width), dtype=data.dtype),
+        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
+                                                dtype=data.dtype),
                             te.placeholder((out_channel, in_channel // groups, k_height, k_width),
                                            dtype=kernel.dtype),
                             strides, padding, groups, out_dtype)
@@ -157,8 +160,8 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
     oc_bn = cfg['tile_oc'].size[-1]
     ic_bn = cfg['tile_ic'].size[-1]
     # pack data
-    do_pad = (hpad != 0 or wpad != 0)
-    if do_pad:
+    DOPAD = (hpad != 0 or wpad != 0)
+    if DOPAD:
         data_pad = pad(data,
                        (0, 0, pad_top, pad_left),
                        (0, 0, pad_bottom, pad_right),
@@ -260,7 +263,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
 
 
 def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
-                  conv_out, output, last):
+                        conv_out, output, last):
     """Schedule GSPC"""
     # fetch schedule
     ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
@@ -269,14 +272,16 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
     # no stride and padding info here
     padding = infer_pad(data, data_pad)
     hpad, wpad = padding
-    do_pad = (hpad != 0 or wpad != 0)
+    DOPAD = (hpad != 0 or wpad != 0)
 
     _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if do_pad:
+    if DOPAD:
         s[A0].compute_inline()
+        # s[A0].compute_at(s[A1])
+
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
@@ -319,7 +324,10 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
                       ow_block, oc_block)
 
     parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
+    # s[A1].compute_at(CC, parallel_axis)
     s[CC].parallel(parallel_axis)
+
+
 
     s[CC].vectorize(oc_block)
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -265,7 +265,6 @@ def schedule_group_conv2d_nchwc(cfg, outs):
 def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
                         conv_out, output, last):
     """Schedule GSPC"""
-    # fetch schedule
     ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
                                       cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
 
@@ -280,7 +279,6 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
     # schedule data
     if DOPAD:
         s[A0].compute_inline()
-        # s[A0].compute_at(s[A1])
 
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
@@ -324,10 +322,8 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
                       ow_block, oc_block)
 
     parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
-    # s[A1].compute_at(CC, parallel_axis)
+
     s[CC].parallel(parallel_axis)
-
-
 
     s[CC].vectorize(oc_block)
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Grouped Spatial Pack Convolution (Group Conv2D) schedule on x86"""
 
 import tvm
 from tvm import autotvm
@@ -56,34 +57,34 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype,
     data = te.placeholder(static_data_shape, dtype=data.dtype)
 
     wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype,
-                               layout)
+                               layout, asymmetric_pad=True)
     _fallback_schedule(cfg, wkl)
 
 
 def _fallback_schedule(cfg, wkl):
     simd_width = get_fp32_len()
-    HPAD, WPAD = wkl.hpad, wkl.wpad
-    HSTR, WSTR = wkl.hstride, wkl.wstride
-    out_width = (wkl.width + 2 * WPAD - wkl.wkernel) // WSTR + 1
-    G = wkl.groups
-    KPG = wkl.out_filter // G
-    CPG = wkl.in_filter // G
+    pt, pl, pb, pr = wkl.padt, wkl.padl, wkl.padb, wkl.padr
+    stride_w = wkl.wstride
+    out_width = (wkl.width + pl + pr - wkl.wkernel) // stride_w + 1
+    groups = wkl.groups
+    kernels_per_group = wkl.out_filter // groups
+    kernel_depth = wkl.in_filter // groups
 
     oc_bn = 1
     for bn in range(simd_width, 0, -1):
-        if KPG % bn == 0:
+        if kernels_per_group % bn == 0:
             oc_bn = bn
             break
-    if oc_bn > KPG:
-        oc_bn = KPG
+    if oc_bn > kernels_per_group:
+        oc_bn = kernels_per_group
 
     ic_bn = 1
     for bn in range(oc_bn, 0, -1):
-        if CPG % bn == 0:
+        if kernel_depth % bn == 0:
             ic_bn = bn
             break
-    if ic_bn > CPG:
-        ic_bn = CPG
+    if ic_bn > kernel_depth:
+        ic_bn = kernel_depth
 
     reg_n = 1
     for n in range(31, 0, -1):
@@ -108,42 +109,45 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
     if isinstance(padding, int):
-        HPAD, WPAD = padding, padding
+        pt, pl, pb, pr = padding, padding, padding, padding
     elif len(padding) == 2:
         HPAD, WPAD = padding
+        pt, pb = HPAD, HPAD
+        pl, pr = WPAD, WPAD
     else:
-        HPAD, _, WPAD, _ = padding
+        pt, pl, pb, pr = padding
+
+    HPAD = pt + pb
+    WPAD = pl + pr
 
     assert isinstance(strides, int) or len(strides) == 2
     if isinstance(strides, int):
-        HSTR, WSTR = strides, strides
+        stride_h, stride_w = strides, strides
     else:
-        HSTR, WSTR = strides
+        stride_h, stride_w = strides
 
-    N, CI, IH, IW = get_const_tuple(data.shape)
-    CO, CIG, KH, KW = get_const_tuple(kernel.shape)
+    batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
+    out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
 
-    pad_height = IH + 2 * HPAD
-    pad_width = IW + 2 * WPAD
+    pad_height = in_height + pt + pb
+    pad_width = in_width + pl + pr
 
-    dilated_kernel_h = (KH - 1) * dilation_h + 1
-    dilated_kernel_w = (KW - 1) * dilation_w + 1
-    OH = (IH + 2 * HPAD - dilated_kernel_h) // HSTR + 1
-    OW = (IW + 2 * WPAD - dilated_kernel_w) // WSTR + 1
+    dilated_kernel_h = (k_height - 1) * dilation_h + 1
+    dilated_kernel_w = (k_width - 1) * dilation_w + 1
+    out_height = (in_height + pt + pb - dilated_kernel_h) // stride_h + 1
+    out_width = (in_width + pl + pr - dilated_kernel_w) // stride_w + 1
 
-    G = groups
-    KPG = CO // G
-    CPG = CI // G
+    kernels_per_group = out_channel // groups
 
-    cfg.define_split("tile_ic", CI, num_outputs=2)
-    cfg.define_split("tile_oc", CO, num_outputs=2)
-    cfg.define_split("tile_ow", OW, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
+    cfg.define_split("tile_ic", in_channel, num_outputs=2)
+    cfg.define_split("tile_oc", out_channel, num_outputs=2)
+    cfg.define_split("tile_ow", out_width, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
     cfg.define_knob("unroll_kw", [True, False])
 
     # If no config was set, we can fallback to default config.
     if cfg.is_fallback:
-        _get_default_config(cfg, te.placeholder((N, CI, IH, IW), dtype=data.dtype),
-                            te.placeholder((CO, CI // G, KH, KW),
+        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width), dtype=data.dtype),
+                            te.placeholder((out_channel, in_channel // groups, k_height, k_width),
                                            dtype=kernel.dtype),
                             strides, padding, groups, out_dtype)
 
@@ -152,43 +156,46 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
     # pack data
     DOPAD = (HPAD != 0 or WPAD != 0)
     if DOPAD:
-        data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
+        data_pad = pad(data,
+                       (0, 0, pt, pl),
+                       (0, 0, pb, pr),
+                       name="data_pad")
     else:
         data_pad = data
 
-    shape = (G, N, CPG // ic_bn,
+    shape = (groups, batch_size, kernel_depth // ic_bn,
              pad_height, ic_bn, pad_width)
 
     data_vec = te.compute(shape,
                           lambda g, n, C, h, c, w:
-                          data_pad[n, C * ic_bn + c + CPG * g, h, w],
+                          data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
                           name='data_vec')
 
     # pack kernel
-    shape = (G, KPG//oc_bn, CPG//ic_bn,
-             KH, KW, ic_bn, oc_bn)
+    shape = (groups, kernels_per_group//oc_bn, kernel_depth//ic_bn,
+             k_height, k_width, ic_bn, oc_bn)
     kernel_vec = te.compute(shape,
-                            lambda g, CO, CI, h, w, ci, co:
-                            kernel[(CO * oc_bn + co + g * KPG),
-                                   CI * ic_bn + ci, h, w],
+                            lambda g, out_channel, in_channel, h, w, ci, co:
+                            kernel[(out_channel * oc_bn + co + g * kernels_per_group),
+                                   in_channel * ic_bn + ci, h, w],
                             name='kernel_vec')
 
     # convolution
-    oshape = (G, N, KPG//oc_bn,
-              OH, OW, oc_bn)
-    unpack_shape = (N, CO, OH, OW)
+    oshape = (groups, batch_size, kernels_per_group//oc_bn,
+              out_height, out_width, oc_bn)
+    unpack_shape = (batch_size, out_channel, out_height, out_width)
 
-    ic = te.reduce_axis((0, (CPG)), name='ic')
-    kh = te.reduce_axis((0, KH), name='kh')
-    kw = te.reduce_axis((0, KW), name='kw')
+    ic = te.reduce_axis((0, (kernel_depth)), name='ic')
+    kh = te.reduce_axis((0, k_height), name='kh')
+    kw = te.reduce_axis((0, k_width), name='kw')
     idxmod = tvm.tir.indexmod
     idxdiv = tvm.tir.indexdiv
 
     conv = te.compute(oshape, lambda g, n, oc_chunk, oh, ow, oc_block:
                       te.sum(data_vec[g, n, idxdiv(ic, ic_bn),
-                                      oh*HSTR+kh*dilation_h,
+                                      oh * stride_h + kh * dilation_h,
                                       idxmod(ic, ic_bn),
-                                      ow*WSTR+kw*dilation_w].astype(out_dtype) *
+                                      ow * stride_w + kw * dilation_w].astype(out_dtype) *
                              kernel_vec[g, oc_chunk, idxdiv(ic, ic_bn),
                                         kh, kw, idxmod(ic, ic_bn),
                                         oc_block].astype(out_dtype),
@@ -196,10 +203,10 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     unpack = te.compute(unpack_shape,
                         lambda n, c, h, w:
-                        conv[idxdiv(c, KPG), n,
-                             idxmod(idxdiv(c, oc_bn), (KPG // oc_bn)),
+                        conv[idxdiv(c, kernels_per_group), n,
+                             idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
                              h, w,
-                             idxmod(idxmod(c, oc_bn), KPG)]
+                             idxmod(idxmod(c, oc_bn), kernels_per_group)]
                         .astype(out_dtype),
                         name='output_unpack',
                         tag='group_conv2d_nchw')
@@ -239,9 +246,6 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
 
-            _, c, h, w = get_const_tuple(data.shape)
-            _, x, kh, kw = get_const_tuple(kernel.shape)
-
             args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
                     output, outs[0]]
             schedule_conv_sp_grouped(*args)
@@ -253,8 +257,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
 
 
 def schedule_conv_sp_grouped(s, cfg, data, data_pad, data_vec, kernel_vec,
-                             conv_out, output, last,
-                             **kwargs):
+                             conv_out, output, last):
     # fetch schedule
     ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
                                       cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
@@ -264,13 +267,13 @@ def schedule_conv_sp_grouped(s, cfg, data, data_pad, data_vec, kernel_vec,
     HPAD, WPAD = padding
     DOPAD = (HPAD != 0 or WPAD != 0)
 
-    A, W = data, kernel_vec
+    _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
     if DOPAD:
         s[A0].compute_inline()
-    groups, batch, ic_chunk, ih, ic_block, iw = s[A1].op.axis
+    groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
     s[A1].parallel(parallel_axis)

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -99,7 +99,7 @@ def _fallback_schedule(cfg, wkl):
 
 @autotvm.register_topi_compute("group_conv2d_nchw.x86")
 def group_conv2d_nchw_spatial_pack(
-        cfg, data, kernel, strides, padding, dilation, groups, out_dtype="float32"
+    cfg, data, kernel, strides, padding, dilation, groups, out_dtype="float32"
 ):
     """
     Compute group conv2d with NCHW layout, using GSPC algorithm.
@@ -289,8 +289,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
     return s
 
 
-def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
-                        conv_out, output, last):
+def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, output, last):
     """Schedule GSPC"""
     ic_bn, oc_bn, reg_n, unroll_kw = (
         cfg["tile_ic"].size[-1],

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -23,12 +23,12 @@ from tvm import autotvm
 from tvm import te
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
-from .util import get_fp32_len
-from ..util import get_const_tuple
+from .utils import get_fp32_len
+from ..utils import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
-from ..nn.util import infer_pad
+from ..nn.utils import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
 
@@ -63,8 +63,8 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, 
 def _fallback_schedule(cfg, wkl):
     simd_width = get_fp32_len()
     pad_left, pad_right = wkl.padl, wkl.padr
-    stride_w = wkl.wstride
-    out_width = (wkl.width + pad_left + pad_right - wkl.wkernel) // stride_w + 1
+    stride_w = wkl.stride_w
+    out_width = (wkl.width + pad_left + pad_right - wkl.kernel_w) // stride_w + 1
     groups = wkl.groups
     kernels_per_group = wkl.out_filter // groups
     kernel_depth = wkl.in_filter // groups

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -32,11 +32,11 @@ from ..nn.util import infer_pad
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
 
 
-def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups,
-                      out_dtype):
+def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups, out_dtype):
     """Compute group_conv2d with NCHW layout"""
-    return group_conv2d_nchw_spatial_pack(data, kernel, strides, padding,
-                                          dilation, groups, out_dtype)
+    return group_conv2d_nchw_spatial_pack(
+        data, kernel, strides, padding, dilation, groups, out_dtype
+    )
 
 
 def schedule_group_conv2d_nchw(outs):
@@ -44,8 +44,7 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups,
-                        out_dtype, layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, layout='NCHW'):
     """
     Get default schedule config for the workload
     """
@@ -57,8 +56,7 @@ def _get_default_config(cfg, data, kernel, strides, padding, groups,
             static_data_shape.append(dim)
     data = te.placeholder(static_data_shape, dtype=data.dtype)
 
-    wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype,
-                               layout, asymmetric_pad=True)
+    wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype, layout)
     _fallback_schedule(cfg, wkl)
 
 
@@ -100,8 +98,9 @@ def _fallback_schedule(cfg, wkl):
 
 
 @autotvm.register_topi_compute("group_conv2d_nchw.x86")
-def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
-                                   dilation, groups, out_dtype='float32'):
+def group_conv2d_nchw_spatial_pack(
+        cfg, data, kernel, strides, padding, dilation, groups, out_dtype='float32'
+):
     """
     Compute group conv2d with NCHW layout, using GSPC algorithm.
     https://arxiv.org/abs/2006.09791
@@ -151,71 +150,100 @@ def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
 
     # If no config was set, we can fallback to default config.
     if cfg.is_fallback:
-        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
-                                                dtype=data.dtype),
-                            te.placeholder((out_channel, in_channel // groups, k_height, k_width),
-                                           dtype=kernel.dtype),
-                            strides, padding, groups, out_dtype)
+        _get_default_config(
+            cfg,
+            te.placeholder((batch_size, in_channel, in_height, in_width), dtype=data.dtype),
+            te.placeholder(
+                (out_channel, in_channel // groups, k_height, k_width), dtype=kernel.dtype
+            ),
+            strides,
+            padding,
+            groups,
+            out_dtype,
+        )
 
-    oc_bn = cfg['tile_oc'].size[-1]
-    ic_bn = cfg['tile_ic'].size[-1]
+    oc_bn = cfg["tile_oc"].size[-1]
+    ic_bn = cfg["tile_ic"].size[-1]
+
     # pack data
-    DOPAD = (hpad != 0 or wpad != 0)
+    DOPAD = hpad != 0 or wpad != 0
     if DOPAD:
-        data_pad = pad(data,
-                       (0, 0, pad_top, pad_left),
-                       (0, 0, pad_bottom, pad_right),
-                       name="data_pad")
+        data_pad = pad(
+            data, (0, 0, pad_top, pad_left), (0, 0, pad_bottom, pad_right), name="data_pad"
+        )
     else:
         data_pad = data
 
-    shape = (groups, batch_size, kernel_depth // ic_bn,
-             pad_height, ic_bn, pad_width)
+    shape = (groups, batch_size, kernel_depth // ic_bn, pad_height, ic_bn, pad_width)
 
-    data_vec = te.compute(shape,
-                          lambda g, n, C, h, c, w:
-                          data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
-                          name='data_vec')
+    data_vec = te.compute(
+        shape,
+        lambda g, n, C, h, c, w: data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
+        name="data_vec",
+    )
 
     # pack kernel
-    shape = (groups, kernels_per_group//oc_bn, kernel_depth//ic_bn,
-             k_height, k_width, ic_bn, oc_bn)
-    kernel_vec = te.compute(shape,
-                            lambda g, out_channel, in_channel, h, w, ci, co:
-                            kernel[(out_channel * oc_bn + co + g * kernels_per_group),
-                                   in_channel * ic_bn + ci, h, w],
-                            name='kernel_vec')
+    shape = (
+        groups,
+        kernels_per_group // oc_bn,
+        kernel_depth // ic_bn,
+        k_height,
+        k_width,
+        ic_bn,
+        oc_bn,
+    )
+
+    kernel_vec = te.compute(
+        shape,
+        lambda g, out_channel, in_channel, h, w, ci, co: kernel[
+            (out_channel * oc_bn + co + g * kernels_per_group), in_channel * ic_bn + ci, h, w
+        ],
+        name="kernel_vec",
+    )
 
     # convolution
-    oshape = (groups, batch_size, kernels_per_group//oc_bn,
-              out_height, out_width, oc_bn)
+    oshape = (groups, batch_size, kernels_per_group//oc_bn, out_height, out_width, oc_bn)
     unpack_shape = (batch_size, out_channel, out_height, out_width)
 
-    ic = te.reduce_axis((0, (kernel_depth)), name='ic')
-    kh = te.reduce_axis((0, k_height), name='kh')
-    kw = te.reduce_axis((0, k_width), name='kw')
+    ic = te.reduce_axis((0, (kernel_depth)), name="ic")
+    kh = te.reduce_axis((0, k_height), name="kh")
+    kw = te.reduce_axis((0, k_width), name="kw")
+
     idxmod = tvm.tir.indexmod
     idxdiv = tvm.tir.indexdiv
+    conv = te.compute(
+        oshape,
+        lambda g, n, oc_chunk, oh, ow, oc_block: te.sum(
+            data_vec[
+                g,
+                n,
+                idxdiv(ic, ic_bn),
+                oh * stride_h + kh * dilation_h,
+                idxmod(ic, ic_bn),
+                ow * stride_w + kw * dilation_w,
+            ].astype(out_dtype)
+            * kernel_vec[
+                g, oc_chunk, idxdiv(ic, ic_bn), kh, kw, idxmod(ic, ic_bn), oc_block
+            ].astype(out_dtype),
+            axis=[ic, kh, kw],
+        ),
+        name="conv",
+    )
 
-    conv = te.compute(oshape, lambda g, n, oc_chunk, oh, ow, oc_block:
-                      te.sum(data_vec[g, n, idxdiv(ic, ic_bn),
-                                      oh * stride_h + kh * dilation_h,
-                                      idxmod(ic, ic_bn),
-                                      ow * stride_w + kw * dilation_w].astype(out_dtype) *
-                             kernel_vec[g, oc_chunk, idxdiv(ic, ic_bn),
-                                        kh, kw, idxmod(ic, ic_bn),
-                                        oc_block].astype(out_dtype),
-                             axis=[ic, kh, kw]), name='conv')
+    unpack = te.compute(
+        unpack_shape,
+        lambda n, c, h, w: conv[
+            idxdiv(c, kernels_per_group),
+            n,
+            idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
+            h,
+            w,
+            idxmod(idxmod(c, oc_bn), kernels_per_group),
+        ].astype(out_dtype),
+        name="output_unpack",
+        tag="group_conv2d_nchw",
+    )
 
-    unpack = te.compute(unpack_shape,
-                        lambda n, c, h, w:
-                        conv[idxdiv(c, kernels_per_group), n,
-                             idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
-                             h, w,
-                             idxmod(idxmod(c, oc_bn), kernels_per_group)]
-                        .astype(out_dtype),
-                        name='output_unpack',
-                        tag='group_conv2d_nchw')
     return unpack
 
 
@@ -235,7 +263,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 if isinstance(tensor.op, tvm.te.ComputeOp) and tensor.op not in scheduled_ops:
                     traverse(tensor.op)
 
-        if 'group_conv2d_nchw' in op.tag:
+        if "group_conv2d_nchw" in op.tag:
             output = op.output(0)
 
             if "tile_ic" not in cfg:
@@ -252,8 +280,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
 
-            args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
-                    output, outs[0]]
+            args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, output, outs[0]]
             _schedule_gspc_nchw(*args)
 
         scheduled_ops.append(op)
@@ -265,13 +292,18 @@ def schedule_group_conv2d_nchwc(cfg, outs):
 def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
                         conv_out, output, last):
     """Schedule GSPC"""
-    ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
-                                      cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
+    ic_bn, oc_bn, reg_n, unroll_kw = (
+        cfg["tile_ic"].size[-1],
+        cfg["tile_oc"].size[-1],
+        cfg["tile_ow"].size[-1],
+        cfg["unroll_kw"].val,
+    )
+
 
     # no stride and padding info here
     padding = infer_pad(data, data_pad)
     hpad, wpad = padding
-    DOPAD = (hpad != 0 or wpad != 0)
+    DOPAD = hpad != 0 or wpad != 0
 
     _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
@@ -297,7 +329,7 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
 
     # schedule conv
     C, O0, O = conv_out, output, last
-    CC = s.cache_write(C, 'global')
+    CC = s.cache_write(C, "global")
 
     _, _, oc_chunk, oh, ow, oc_block = s[C].op.axis
 
@@ -314,12 +346,10 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
     ic_chunk, ic_block = s[CC].split(ic, factor=ic_bn)
 
     if unroll_kw:
-        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, ic_block, kw,
-                      ow_block, oc_block)
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, ic_block, kw, ow_block, oc_block)
         s[CC].unroll(kw)
     else:
-        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block,
-                      ow_block, oc_block)
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block, ow_block, oc_block)
 
     parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -44,7 +44,7 @@ def schedule_group_conv2d_nchw(outs):
     return schedule_group_conv2d_nchwc(outs)
 
 
-def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, layout='NCHW'):
+def _get_default_config(cfg, data, kernel, strides, padding, groups, out_dtype, layout="NCHW"):
     """
     Get default schedule config for the workload
     """
@@ -99,7 +99,7 @@ def _fallback_schedule(cfg, wkl):
 
 @autotvm.register_topi_compute("group_conv2d_nchw.x86")
 def group_conv2d_nchw_spatial_pack(
-        cfg, data, kernel, strides, padding, dilation, groups, out_dtype='float32'
+        cfg, data, kernel, strides, padding, dilation, groups, out_dtype="float32"
 ):
     """
     Compute group conv2d with NCHW layout, using GSPC algorithm.
@@ -202,7 +202,7 @@ def group_conv2d_nchw_spatial_pack(
     )
 
     # convolution
-    oshape = (groups, batch_size, kernels_per_group//oc_bn, out_height, out_width, oc_bn)
+    oshape = (groups, batch_size, kernels_per_group // oc_bn, out_height, out_width, oc_bn)
     unpack_shape = (batch_size, out_channel, out_height, out_width)
 
     ic = te.reduce_axis((0, (kernel_depth)), name="ic")
@@ -298,7 +298,6 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
         cfg["tile_ow"].size[-1],
         cfg["unroll_kw"].val,
     )
-
 
     # no stride and padding info here
     padding = infer_pad(data, data_pad)

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -1,0 +1,343 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+# pylint: disable=no-value-for-parameter,import-outside-toplevel
+"""Grouped Spatial Pack Convolution (Group Conv2D) schedule on x86"""
+
+import tvm
+from tvm import autotvm
+from tvm import te
+from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
+
+from .utils import get_fp32_len
+from ..utils import get_const_tuple
+from ..nn.pad import pad
+from .. import tag
+
+from ..nn.utils import infer_pad
+from ..nn.conv2d import _get_workload as _get_conv2d_workload
+
+
+def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups,
+                      out_dtype):
+    """Compute group_conv2d with NCHW layout"""
+    return group_conv2d_nchw_spatial_pack(data, kernel, strides, padding,
+                                          dilation, groups, out_dtype)
+
+
+def schedule_group_conv2d_nchw(outs):
+    """Compute group_conv2d with NCHW layout"""
+    return schedule_group_conv2d_nchwc(outs)
+
+
+def _get_default_config(cfg, data, kernel, strides, padding, groups,
+                        out_dtype, layout='NCHW'):
+    """
+    Get default schedule config for the workload
+    """
+    static_data_shape = []
+    for dim in get_const_tuple(data.shape):
+        if isinstance(dim, tvm.tir.Var):
+            static_data_shape.append(1)
+        else:
+            static_data_shape.append(dim)
+    data = te.placeholder(static_data_shape, dtype=data.dtype)
+
+    wkl = _get_conv2d_workload(data, kernel, strides, padding, out_dtype,
+                               layout)
+    _fallback_schedule(cfg, wkl)
+
+
+def _fallback_schedule(cfg, wkl):
+    simd_width = get_fp32_len()
+    hpad = wkl.hpad
+    stride_w = wkl.wstride
+    out_width = (wkl.width + 2*hpad - wkl.wkernel) // stride_w + 1
+    groups = wkl.groups
+    kernels_per_group = wkl.out_filter // groups
+    kernel_depth = wkl.in_filter // groups
+
+    oc_bn = 1
+    for bn in range(simd_width, 0, -1):
+        if kernels_per_group % bn == 0:
+            oc_bn = bn
+            break
+    if oc_bn > kernels_per_group:
+        oc_bn = kernels_per_group
+
+    ic_bn = 1
+    for bn in range(oc_bn, 0, -1):
+        if kernel_depth % bn == 0:
+            ic_bn = bn
+            break
+    if ic_bn > kernel_depth:
+        ic_bn = kernel_depth
+
+    reg_n = 1
+    for n in range(31, 0, -1):
+        if out_width % n == 0:
+            reg_n = n
+            break
+
+    cfg["tile_ic"] = SplitEntity([wkl.in_filter // ic_bn, ic_bn])
+    cfg["tile_oc"] = SplitEntity([wkl.out_filter // oc_bn, oc_bn])
+    cfg["tile_ow"] = SplitEntity([out_width // reg_n, reg_n])
+    cfg["unroll_kw"] = OtherOptionEntity(False)
+
+
+@autotvm.register_topi_compute("group_conv2d_nchw.x86")
+def group_conv2d_nchw_spatial_pack(cfg, data, kernel, strides, padding,
+                                   dilation, groups, out_dtype='float32'):
+    """
+    Compute group conv2d with NCHW layout, using GSPC algorithm.
+    https://arxiv.org/abs/2006.09791
+    """
+    assert isinstance(dilation, int) or len(dilation) == 2
+    if isinstance(dilation, int):
+        dilation_h, dilation_w = dilation, dilation
+    else:
+        dilation_h, dilation_w = dilation
+
+    assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
+    if isinstance(padding, int):
+        pad_top, pad_left, pad_bottom, pad_right = padding, padding, padding, padding
+    elif len(padding) == 2:
+        hpad, wpad = padding
+        pad_top, pad_bottom = hpad, hpad
+        pad_left, pad_right = wpad, wpad
+    else:
+        pad_top, pad_left, pad_bottom, pad_right = padding
+
+    hpad = pad_top + pad_bottom
+    wpad = pad_left + pad_right
+
+    assert isinstance(strides, int) or len(strides) == 2
+    if isinstance(strides, int):
+        stride_h, stride_w = strides, strides
+    else:
+        stride_h, stride_w = strides
+
+    batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
+    out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
+
+    pad_height = in_height + pad_top + pad_bottom
+    pad_width = in_width + pad_left + pad_right
+
+    dilated_kernel_h = (k_height - 1) * dilation_h + 1
+    dilated_kernel_w = (k_width - 1) * dilation_w + 1
+    out_height = (in_height + pad_top + pad_bottom - dilated_kernel_h) // stride_h + 1
+    out_width = (in_width + pad_left + pad_right - dilated_kernel_w) // stride_w + 1
+
+    kernels_per_group = out_channel // groups
+
+    cfg.define_split("tile_ic", in_channel, num_outputs=2)
+    cfg.define_split("tile_oc", out_channel, num_outputs=2)
+    cfg.define_split("tile_ow", out_width, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
+    cfg.define_knob("unroll_kw", [True, False])
+
+    # If no config was set, we can fallback to default config.
+    if cfg.is_fallback:
+        _get_default_config(cfg, te.placeholder((batch_size, in_channel, in_height, in_width),
+                                                dtype=data.dtype),
+                            te.placeholder((out_channel, in_channel // groups, k_height, k_width),
+                                           dtype=kernel.dtype),
+                            strides, padding, groups, out_dtype)
+
+    oc_bn = cfg['tile_oc'].size[-1]
+    ic_bn = cfg['tile_ic'].size[-1]
+    # pack data
+    DOPAD = (hpad != 0 or wpad != 0)
+    if DOPAD:
+        data_pad = pad(data,
+                       (0, 0, pad_top, pad_left),
+                       (0, 0, pad_bottom, pad_right),
+                       name="data_pad")
+    else:
+        data_pad = data
+
+    shape = (groups, batch_size, kernel_depth // ic_bn,
+             pad_height, ic_bn, pad_width)
+
+    data_vec = te.compute(shape,
+                          lambda g, n, C, h, c, w:
+                          data_pad[n, C * ic_bn + c + kernel_depth * g, h, w],
+                          name='data_vec')
+
+    # pack kernel
+    shape = (groups, kernels_per_group//oc_bn, kernel_depth//ic_bn,
+             k_height, k_width, ic_bn, oc_bn)
+    kernel_vec = te.compute(shape,
+                            lambda g, out_channel, in_channel, h, w, ci, co:
+                            kernel[(out_channel * oc_bn + co + g * kernels_per_group),
+                                   in_channel * ic_bn + ci, h, w],
+                            name='kernel_vec')
+
+    # convolution
+    oshape = (groups, batch_size, kernels_per_group//oc_bn,
+              out_height, out_width, oc_bn)
+    unpack_shape = (batch_size, out_channel, out_height, out_width)
+
+    ic = te.reduce_axis((0, (kernel_depth)), name='ic')
+    kh = te.reduce_axis((0, k_height), name='kh')
+    kw = te.reduce_axis((0, k_width), name='kw')
+    idxmod = tvm.tir.indexmod
+    idxdiv = tvm.tir.indexdiv
+
+    conv = te.compute(oshape, lambda g, n, oc_chunk, oh, ow, oc_block:
+                      te.sum(data_vec[g, n, idxdiv(ic, ic_bn),
+                                      oh * stride_h + kh * dilation_h,
+                                      idxmod(ic, ic_bn),
+                                      ow * stride_w + kw * dilation_w].astype(out_dtype) *
+                             kernel_vec[g, oc_chunk, idxdiv(ic, ic_bn),
+                                        kh, kw, idxmod(ic, ic_bn),
+                                        oc_block].astype(out_dtype),
+                             axis=[ic, kh, kw]), name='conv')
+
+    unpack = te.compute(unpack_shape,
+                        lambda n, c, h, w:
+                        conv[idxdiv(c, kernels_per_group), n,
+                             idxmod(idxdiv(c, oc_bn), (kernels_per_group // oc_bn)),
+                             h, w,
+                             idxmod(idxmod(c, oc_bn), kernels_per_group)]
+                        .astype(out_dtype),
+                        name='output_unpack',
+                        tag='group_conv2d_nchw')
+    return unpack
+
+
+@autotvm.register_topi_schedule("group_conv2d_nchw.x86")
+def schedule_group_conv2d_nchwc(cfg, outs):
+    """Create schedule for tensors"""
+    s = te.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
+    def traverse(op):
+        """Traverse operators from computation graph"""
+        # inline all one-to-one-mapping operators except the last stage (output)
+        if tag.is_broadcast(op.tag):
+            if op not in s.outputs:
+                s[op].compute_inline()
+            for tensor in op.input_tensors:
+                if isinstance(tensor.op, tvm.te.ComputeOp) and tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+
+        if 'group_conv2d_nchw' in op.tag:
+            output = op.output(0)
+
+            if "tile_ic" not in cfg:
+                return
+            conv_out = op.input_tensors[0]
+            kernel_vec = conv_out.op.input_tensors[1]
+            kernel = kernel_vec.op.input_tensors[0]
+            if isinstance(kernel.op, tvm.te.ComputeOp) and "dilate" in kernel.op.tag:
+                s[kernel].compute_inline()
+            data_vec = conv_out.op.input_tensors[0]
+            data = data_vec.op.input_tensors[0]
+            data_pad = None
+            if isinstance(data.op, tvm.te.ComputeOp) and "pad" in data.op.tag:
+                data_pad = data
+                data = data_pad.op.input_tensors[0]
+
+            args = [s, cfg, data, data_pad, data_vec, kernel_vec, conv_out,
+                    output, outs[0]]
+            _schedule_gspc_nchw(*args)
+
+        scheduled_ops.append(op)
+
+    traverse(outs[0].op)
+    return s
+
+
+def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec,
+                        conv_out, output, last):
+    """Schedule GSPC"""
+    ic_bn, oc_bn, reg_n, unroll_kw = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
+                                      cfg["tile_ow"].size[-1], cfg["unroll_kw"].val)
+
+    # no stride and padding info here
+    padding = infer_pad(data, data_pad)
+    hpad, wpad = padding
+    DOPAD = (hpad != 0 or wpad != 0)
+
+    _, W = data, kernel_vec
+    A0, A1 = data_pad, data_vec
+
+    # schedule data
+    if DOPAD:
+        s[A0].compute_inline()
+
+    groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
+
+    parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
+    s[A1].parallel(parallel_axis)
+
+    # schedule kernel pack
+    groups, oc_chunk, ic_chunk, oh, ow, ic_block, oc_block = s[W].op.axis
+    s[W].reorder(oc_chunk, oh, ic_chunk, ow, ic_block, oc_block)
+
+    if oc_bn > 1:
+        s[W].vectorize(oc_block)
+
+    parallel_axis = s[W].fuse(groups, oc_chunk, oh)
+    s[W].parallel(parallel_axis)
+
+    # schedule conv
+    C, O0, O = conv_out, output, last
+    CC = s.cache_write(C, 'global')
+
+    _, _, oc_chunk, oh, ow, oc_block = s[C].op.axis
+
+    ow_chunk, ow_block = s[C].split(ow, factor=reg_n)
+
+    s[C].reorder(oc_chunk, oh, ow_chunk, ow_block, oc_block)
+    s[C].fuse(oc_chunk, oh)
+    s[C].vectorize(oc_block)
+
+    groups, batch, oc_chunk, oh, ow, oc_block = s[CC].op.axis
+
+    ic, kh, kw = s[CC].op.reduce_axis
+    ow_chunk, ow_block = s[CC].split(ow, factor=reg_n)
+    ic_chunk, ic_block = s[CC].split(ic, factor=ic_bn)
+
+    if unroll_kw:
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, ic_block, kw,
+                      ow_block, oc_block)
+        s[CC].unroll(kw)
+    else:
+        s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block,
+                      ow_block, oc_block)
+
+    parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
+
+    s[CC].parallel(parallel_axis)
+
+    s[CC].vectorize(oc_block)
+
+    s[CC].unroll(ow_block)
+
+    if O0 != O:
+        s[O0].compute_inline()
+
+    batch, oc, oh, ow = s[O].op.axis
+    ow_chunk, ow_block = s[O].split(ow, factor=reg_n)
+    oc_chunk, oc_block = s[O].split(oc, factor=oc_bn)
+
+    s[O].reorder(batch, oc_chunk, oh, ow_chunk, ow_block, oc_block)
+    parallel_axis = s[O].fuse(oc_chunk, oh)
+    s[O].vectorize(oc_block)
+    s[O].parallel(parallel_axis)
+    return s

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -112,16 +112,16 @@ def group_conv2d_nchw_spatial_pack(
 
     assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
     if isinstance(padding, int):
-        pt, pl, pb, pr = padding, padding, padding, padding
+        pad_top, pad_left, pad_bottom, pad_right = padding, padding, padding, padding
     elif len(padding) == 2:
-        HPAD, WPAD = padding
-        pt, pb = HPAD, HPAD
-        pl, pr = WPAD, WPAD
+        hpad, wpad = padding
+        pad_top, pad_bottom = hpad, hpad
+        pad_left, pad_right = wpad, wpad
     else:
-        pt, pl, pb, pr = padding
+        pad_top, pad_left, pad_bottom, pad_right = padding
 
-    HPAD = pt + pb
-    WPAD = pl + pr
+    hpad = pad_top + pad_bottom
+    wpad = pad_left + pad_right
 
     assert isinstance(strides, int) or len(strides) == 2
     if isinstance(strides, int):
@@ -132,13 +132,13 @@ def group_conv2d_nchw_spatial_pack(
     batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
     out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
 
-    pad_height = in_height + pt + pb
-    pad_width = in_width + pl + pr
+    pad_height = in_height + pad_top + pad_bottom
+    pad_width = in_width + pad_left + pad_right
 
     dilated_kernel_h = (k_height - 1) * dilation_h + 1
     dilated_kernel_w = (k_width - 1) * dilation_w + 1
-    out_height = (in_height + pt + pb - dilated_kernel_h) // stride_h + 1
-    out_width = (in_width + pl + pr - dilated_kernel_w) // stride_w + 1
+    out_height = (in_height + pad_top + pad_bottom - dilated_kernel_h) // stride_h + 1
+    out_width = (in_width + pad_left + pad_right - dilated_kernel_w) // stride_w + 1
 
     kernels_per_group = out_channel // groups
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -304,7 +304,6 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
     # schedule data
     if isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
         s[A0].compute_inline()
-        # s[A0].compute_at(s[A1])
 
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
@@ -346,10 +345,8 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
         s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block, ow_block, oc_block)
 
     parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
-    # s[A1].compute_at(CC, parallel_axis)
+
     s[CC].parallel(parallel_axis)
-
-
 
     s[CC].vectorize(oc_block)
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -276,6 +276,7 @@ def schedule_group_conv2d_nchwc(cfg, outs):
                 s[kernel].compute_inline()
             data_vec = conv_out.op.input_tensors[0]
             data = data_vec.op.input_tensors[0]
+            data_pad = None
             if isinstance(data.op, tvm.te.ComputeOp) and "pad" in data.op.tag:
                 data_pad = data
                 data = data_pad.op.input_tensors[0]

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+# pylint: disable=no-value-for-parameter,import-outside-toplevel
 """Grouped Spatial Pack Convolution (Group Conv2D) schedule on x86"""
 
 import tvm
@@ -302,6 +304,8 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
     # schedule data
     if isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
         s[A0].compute_inline()
+        # s[A0].compute_at(s[A1])
+
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
@@ -342,7 +346,10 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
         s[CC].reorder(oc_chunk, oh, ow_chunk, ic_chunk, kh, kw, ic_block, ow_block, oc_block)
 
     parallel_axis = s[CC].fuse(groups, batch, oc_chunk, oh)
+    # s[A1].compute_at(CC, parallel_axis)
     s[CC].parallel(parallel_axis)
+
+
 
     s[CC].vectorize(oc_block)
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -303,7 +303,11 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if data_pad is not None and isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
+    if (
+        data_pad is not None
+        and isinstance(data_pad.op, tvm.te.ComputeOp)
+        and "pad" in data_pad.op.tag
+    ):
         s[A0].compute_inline()
 
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Grouped Spatial Pack Convolution (Group Conv2D) schedule on x86"""
 
 import tvm
 from tvm import autotvm
@@ -69,19 +70,19 @@ def _fallback_schedule(cfg, wkl):
 
     oc_bn = 1
     for bn in range(simd_width, 0, -1):
-        if KPG % bn == 0:
+        if kernels_per_group % bn == 0:
             oc_bn = bn
             break
-    if oc_bn > KPG:
-        oc_bn = KPG
+    if oc_bn > kernels_per_group:
+        oc_bn = kernels_per_group
 
     ic_bn = 1
     for bn in range(oc_bn, 0, -1):
-        if CPG % bn == 0:
+        if kernel_depth % bn == 0:
             ic_bn = bn
             break
-    if ic_bn > CPG:
-        ic_bn = CPG
+    if ic_bn > kernel_depth:
+        ic_bn = kernel_depth
 
     reg_n = 1
     for n in range(31, 0, -1):
@@ -111,36 +112,39 @@ def group_conv2d_nchw_spatial_pack(
 
     assert isinstance(padding, int) or len(padding) == 2 or len(padding) == 4
     if isinstance(padding, int):
-        HPAD, WPAD = padding, padding
+        pt, pl, pb, pr = padding, padding, padding, padding
     elif len(padding) == 2:
         HPAD, WPAD = padding
+        pt, pb = HPAD, HPAD
+        pl, pr = WPAD, WPAD
     else:
-        HPAD, _, WPAD, _ = padding
+        pt, pl, pb, pr = padding
+
+    HPAD = pt + pb
+    WPAD = pl + pr
 
     assert isinstance(strides, int) or len(strides) == 2
     if isinstance(strides, int):
-        HSTR, WSTR = strides, strides
+        stride_h, stride_w = strides, strides
     else:
-        HSTR, WSTR = strides
+        stride_h, stride_w = strides
 
-    N, CI, IH, IW = get_const_tuple(data.shape)
-    CO, CIG, KH, KW = get_const_tuple(kernel.shape)
+    batch_size, in_channel, in_height, in_width = get_const_tuple(data.shape)
+    out_channel, kernel_depth, k_height, k_width = get_const_tuple(kernel.shape)
 
-    pad_height = IH + 2 * HPAD
-    pad_width = IW + 2 * WPAD
+    pad_height = in_height + pt + pb
+    pad_width = in_width + pl + pr
 
-    dilated_kernel_h = (KH - 1) * dilation_h + 1
-    dilated_kernel_w = (KW - 1) * dilation_w + 1
-    OH = (IH + 2 * HPAD - dilated_kernel_h) // HSTR + 1
-    OW = (IW + 2 * WPAD - dilated_kernel_w) // WSTR + 1
+    dilated_kernel_h = (k_height - 1) * dilation_h + 1
+    dilated_kernel_w = (k_width - 1) * dilation_w + 1
+    out_height = (in_height + pt + pb - dilated_kernel_h) // stride_h + 1
+    out_width = (in_width + pl + pr - dilated_kernel_w) // stride_w + 1
 
-    G = groups
-    KPG = CO // G
-    CPG = CI // G
+    kernels_per_group = out_channel // groups
 
-    cfg.define_split("tile_ic", CI, num_outputs=2)
-    cfg.define_split("tile_oc", CO, num_outputs=2)
-    cfg.define_split("tile_ow", OW, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
+    cfg.define_split("tile_ic", in_channel, num_outputs=2)
+    cfg.define_split("tile_oc", out_channel, num_outputs=2)
+    cfg.define_split("tile_ow", out_width, num_outputs=2, filter=lambda y: y.size[-1] <= 64)
     cfg.define_knob("unroll_kw", [True, False])
 
     # If no config was set, we can fallback to default config.
@@ -292,13 +296,13 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
         cfg["unroll_kw"].val,
     )
 
-    A, W = data, kernel_vec
+    _, W = data, kernel_vec
     A0, A1 = data_pad, data_vec
 
     # schedule data
     if isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
         s[A0].compute_inline()
-    groups, batch, ic_chunk, ih, ic_block, iw = s[A1].op.axis
+    groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis
 
     parallel_axis = s[A1].fuse(batch, ic_chunk, ih)
     s[A1].parallel(parallel_axis)

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -303,7 +303,7 @@ def _schedule_gspc_nchw(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, 
     A0, A1 = data_pad, data_vec
 
     # schedule data
-    if isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
+    if data_pad is not None and isinstance(data_pad.op, tvm.te.ComputeOp) and "pad" in data_pad.op.tag:
         s[A0].compute_inline()
 
     groups, batch, ic_chunk, ih, ic_block, _ = s[A1].op.axis

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -23,8 +23,8 @@ from tvm import autotvm
 from tvm import te
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
-from .util import get_fp32_len
-from ..util import get_const_tuple
+from .utils import get_fp32_len
+from ..utils import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -18,14 +18,14 @@
 import tvm
 from tvm import autotvm
 from tvm import te
+from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
+
 from .util import get_fp32_len
 from ..util import get_const_tuple
 from ..nn.pad import pad
 from .. import tag
 
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
-
-from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
 
 def group_conv2d_nchw(data, kernel, strides, padding, dilation, groups, out_dtype):
@@ -67,16 +67,21 @@ def _fallback_schedule(cfg, wkl):
 
     oc_bn = 1
 
+    oc_bn = 1
     for bn in range(simd_width, 0, -1):
         if KPG % bn == 0:
             oc_bn = bn
             break
+    if oc_bn > KPG:
+        oc_bn = KPG
 
     ic_bn = 1
     for bn in range(oc_bn, 0, -1):
         if CPG % bn == 0:
             ic_bn = bn
             break
+    if ic_bn > CPG:
+        ic_bn = CPG
 
     reg_n = 1
     for n in range(31, 0, -1):


### PR DESCRIPTION
This pull request is to replace the current grouped direct convolution algorithm on x86 and Arm targets, with the faster Grouped Spatial Pack Convolutions (GSPC) algorithm.

Here's a performance comparison graph for ResNet34 on a single big core of a Hikey 970 as we increase the number of groups:
![tvm_PR_hikey_1thr_ResNet34_tex](https://user-images.githubusercontent.com/16022573/88482105-1f276000-cf57-11ea-94a5-69a28c37ffef.png)

Note that in the untuned case the current depthwise convolution outperforms GSPC, thus I have omitted it from the pull request.

This is my first proper full request to TVM, so I may be have some issues I haven't spotted, or style problems.

In short, this commit adds identical GSPC compute definitions and schedules for x86 and arm_cpu targets for grouped convolutions, as well as updating the Relay operator strategy for each.