### PR TITLE
Allow Custom Measure Batch Method

### DIFF
--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -128,7 +128,7 @@ class Tuner(object):
             configs = self.next_batch(min(n_parallel, n_trial - i))
 
             inputs = [MeasureInput(self.task.target, self.task, config) for config in configs]
-            results = measure_batch(inputs)
+            results = self.measure_batch(inputs) if hasattr(self, 'measure_batch') else measure_batch(inputs)
 
             # keep best config
             for k, (inp, res) in enumerate(zip(inputs, results)):


### PR DESCRIPTION
TVM's builtin measure batch implemention sometimes doesn't meet custom needs.
For example, we have natively more-precise method to get the time cost from special hardware,
or the case that this method method to evaluate has to be reimplemented fully by custom protocol.

So this small patch can simply solve this problem without letting users to make a big change on tvm internal codes.