### PR TITLE
[TOPI][OpenCL]OpenCL accelerator support

### DIFF
--- a/apps/topi_recipe/gemm/cuda_gemm_square.py
+++ b/apps/topi_recipe/gemm/cuda_gemm_square.py
@@ -69,8 +69,8 @@ def test_gemm():
     scale = 8
     num_thread = 8
     target = tvm.target.Target.current()
-    if target.kind.max_num_threads is not None:
-        num_thread = min(isqrt(target.id.max_num_threads), num_thread)
+    if target.max_num_threads is not None:
+        num_thread = min(isqrt(target.max_num_threads), num_thread)
     block_factor = scale * num_thread
     block_x = te.thread_axis("blockIdx.x")
     thread_x = te.thread_axis((0, num_thread), "threadIdx.x")

--- a/apps/topi_recipe/gemm/cuda_gemm_square.py
+++ b/apps/topi_recipe/gemm/cuda_gemm_square.py
@@ -68,6 +68,9 @@ def test_gemm():
 
     scale = 8
     num_thread = 8
+    target = tvm.target.Target.current()
+    if target.kind.max_num_threads is not None:
+        num_thread = min(isqrt(target.id.max_num_threads), num_thread)
     block_factor = scale * num_thread
     block_x = te.thread_axis("blockIdx.x")
     thread_x = te.thread_axis((0, num_thread), "threadIdx.x")

--- a/include/tvm/topi/cuda/dense.h
+++ b/include/tvm/topi/cuda/dense.h
@@ -32,6 +32,7 @@
 #include <tvm/topi/generic/extern.h>
 #include <tvm/topi/nn/dense.h>
 #include <tvm/topi/tags.h>
+
 #include <algorithm>
 
 namespace tvm {

--- a/include/tvm/topi/cuda/dense.h
+++ b/include/tvm/topi/cuda/dense.h
@@ -98,6 +98,8 @@ inline Schedule schedule_dense(const Target& target, const Array<Tensor>& outs) 
 
   auto _schedule = [&](const Tensor& dense) {
     auto num_thread = 64;
+    // Adapting to device
+    num_thread = std::min((int)target->GetAttr<Integer>("max_num_threads").value(), num_thread);
     auto k = dense->op.as<ComputeOpNode>()->reduce_axis[0];
     IterVar ko, kf;
     s[dense].split(k, num_thread, &ko, &kf);

--- a/include/tvm/topi/cuda/dense.h
+++ b/include/tvm/topi/cuda/dense.h
@@ -32,6 +32,7 @@
 #include <tvm/topi/generic/extern.h>
 #include <tvm/topi/nn/dense.h>
 #include <tvm/topi/tags.h>
+#include <algorithm>
 
 namespace tvm {
 namespace topi {
@@ -99,7 +100,8 @@ inline Schedule schedule_dense(const Target& target, const Array<Tensor>& outs) 
   auto _schedule = [&](const Tensor& dense) {
     auto num_thread = 64;
     // Adapting to device
-    num_thread = std::min((int)target->GetAttr<Integer>("max_num_threads").value(), num_thread);
+    int max_device_threads = target->GetAttr<Integer>("max_num_threads").value();
+    num_thread = std::min(max_device_threads, num_thread);
     auto k = dense->op.as<ComputeOpNode>()->reduce_axis[0];
     IterVar ko, kf;
     s[dense].split(k, num_thread, &ko, &kf);

--- a/include/tvm/topi/cuda/normalization.h
+++ b/include/tvm/topi/cuda/normalization.h
@@ -46,6 +46,9 @@ inline Schedule schedule_lrn(const Array<Tensor>& outs) {
   }
   Schedule s = create_schedule(out_ops);
   int num_thread = 64;
+  // Adapting to device
+  //num_thread = std::min((int)target->GetAttr<Integer>("max_num_threads").value(), num_thread);
+
   IterVar block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
   IterVar thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");
   Tensor lrn = outs[0];

--- a/include/tvm/topi/cuda/normalization.h
+++ b/include/tvm/topi/cuda/normalization.h
@@ -46,8 +46,9 @@ inline Schedule schedule_lrn(const Array<Tensor>& outs) {
   }
   Schedule s = create_schedule(out_ops);
   int num_thread = 64;
-  // Adapting to device
-  //num_thread = std::min((int)target->GetAttr<Integer>("max_num_threads").value(), num_thread);
+  // Adapting to device FIXME: Target is unreachable here
+  // int max_device_threads = target->GetAttr<Integer>("max_num_threads").value();
+  // num_thread = std::min(max_device_threads, num_thread);
 
   IterVar block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
   IterVar thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");

--- a/include/tvm/topi/cuda/pooling.h
+++ b/include/tvm/topi/cuda/pooling.h
@@ -122,6 +122,8 @@ inline Schedule schedule_global_pool(const Target& target, const Array<Tensor>& 
 
   auto _schedule = [&](const Tensor& pool) {
     auto num_thread = 8;
+    // Adapting to device
+    num_thread = std::min((int)std::sqrt((int)target->GetAttr<Integer>("max_num_threads").value()), num_thread);
     auto block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
     auto block_y = tvm::te::thread_axis(Range(), "blockIdx.y");
     auto thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");

--- a/include/tvm/topi/cuda/pooling.h
+++ b/include/tvm/topi/cuda/pooling.h
@@ -30,6 +30,7 @@
 #include <tvm/topi/detail/array_utils.h>
 #include <tvm/topi/detail/fuse.h>
 #include <tvm/topi/tags.h>
+
 #include <algorithm>
 
 namespace tvm {

--- a/include/tvm/topi/cuda/pooling.h
+++ b/include/tvm/topi/cuda/pooling.h
@@ -30,6 +30,7 @@
 #include <tvm/topi/detail/array_utils.h>
 #include <tvm/topi/detail/fuse.h>
 #include <tvm/topi/tags.h>
+#include <algorithm>
 
 namespace tvm {
 namespace topi {
@@ -123,7 +124,8 @@ inline Schedule schedule_global_pool(const Target& target, const Array<Tensor>& 
   auto _schedule = [&](const Tensor& pool) {
     auto num_thread = 8;
     // Adapting to device
-    num_thread = std::min((int)std::sqrt((int)target->GetAttr<Integer>("max_num_threads").value()), num_thread);
+    int max_device_threads = target->GetAttr<Integer>("max_num_threads").value();
+    num_thread = std::min(static_cast<int>(std::sqrt(max_device_threads)), num_thread);
     auto block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
     auto block_y = tvm::te::thread_axis(Range(), "blockIdx.y");
     auto thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");

--- a/include/tvm/topi/cuda/reduction.h
+++ b/include/tvm/topi/cuda/reduction.h
@@ -29,6 +29,7 @@
 #include <tvm/te/schedule_pass.h>
 #include <tvm/topi/detail/fuse.h>
 #include <tvm/topi/tags.h>
+
 #include <algorithm>
 
 namespace tvm {

--- a/include/tvm/topi/cuda/reduction.h
+++ b/include/tvm/topi/cuda/reduction.h
@@ -29,6 +29,7 @@
 #include <tvm/te/schedule_pass.h>
 #include <tvm/topi/detail/fuse.h>
 #include <tvm/topi/tags.h>
+#include <algorithm>
 
 namespace tvm {
 namespace topi {
@@ -76,7 +77,8 @@ Schedule ScheduleReduce(const Target& target, Operation op, Schedule sch,
       num_thread = 16;
     }
     // Adapting to device
-    num_thread = std::min((int)std::sqrt((int)target->GetAttr<Integer>("max_num_threads").value()), num_thread);
+    int max_device_threads = target->GetAttr<Integer>("max_num_threads").value();
+    num_thread = std::min(static_cast<int>(std::sqrt(max_device_threads)), num_thread);
     block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
     thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");
     thread_y = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.y");

--- a/include/tvm/topi/cuda/reduction.h
+++ b/include/tvm/topi/cuda/reduction.h
@@ -75,6 +75,8 @@ Schedule ScheduleReduce(const Target& target, Operation op, Schedule sch,
       // Don't know why.
       num_thread = 16;
     }
+    // Adapting to device
+    num_thread = std::min((int)std::sqrt((int)target->GetAttr<Integer>("max_num_threads").value()), num_thread);
     block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
     thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");
     thread_y = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.y");

--- a/include/tvm/topi/cuda/softmax.h
+++ b/include/tvm/topi/cuda/softmax.h
@@ -29,6 +29,7 @@
 #include <tvm/te/schedule_pass.h>
 #include <tvm/topi/detail/fuse.h>
 #include <tvm/topi/tags.h>
+
 #include <algorithm>
 
 namespace tvm {

--- a/include/tvm/topi/cuda/softmax.h
+++ b/include/tvm/topi/cuda/softmax.h
@@ -29,6 +29,7 @@
 #include <tvm/te/schedule_pass.h>
 #include <tvm/topi/detail/fuse.h>
 #include <tvm/topi/tags.h>
+#include <algorithm>
 
 namespace tvm {
 namespace topi {
@@ -73,7 +74,8 @@ inline Schedule schedule_softmax(const Target& target, const Array<Tensor>& outs
 
   int num_thread = 64;
   // Adapting to device
-  num_thread = std::min((int)target->GetAttr<Integer>("max_num_threads").value(), num_thread);
+  int max_device_threads = target->GetAttr<Integer>("max_num_threads").value();
+  num_thread = std::min(max_device_threads, num_thread);
   auto block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
   auto thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");
 

--- a/include/tvm/topi/cuda/softmax.h
+++ b/include/tvm/topi/cuda/softmax.h
@@ -72,6 +72,8 @@ inline Schedule schedule_softmax(const Target& target, const Array<Tensor>& outs
   }
 
   int num_thread = 64;
+  // Adapting to device
+  num_thread = std::min((int)target->GetAttr<Integer>("max_num_threads").value(), num_thread);
   auto block_x = tvm::te::thread_axis(Range(), "blockIdx.x");
   auto thread_x = tvm::te::thread_axis(Range(0, num_thread), "threadIdx.x");
 

--- a/python/tvm/topi/cuda/conv2d_winograd.py
+++ b/python/tvm/topi/cuda/conv2d_winograd.py
@@ -129,8 +129,8 @@ def schedule_winograd_cuda(cfg, s, output, pre_computed):
     """Schedule winograd template"""
     # get number of threads available from target
     target = tvm.target.Target.current()
-    if target.id.max_num_threads is not None:
-        num_thread = min(target.kind.max_num_threads, 128)
+    if target.max_num_threads is not None:
+        num_thread = min(target.max_num_threads, 128)
     else:
         num_thread = 128
 

--- a/python/tvm/topi/cuda/pooling.py
+++ b/python/tvm/topi/cuda/pooling.py
@@ -16,11 +16,11 @@
 # under the License.
 # pylint: disable=invalid-name, unused-variable, unused-argument
 """Schedule for pooling operators"""
+from math import sqrt, floor
 import tvm
 from tvm import te
 from .. import tag
 from ..util import traverse_inline
-from math import sqrt, floor
 
 
 def schedule_adaptive_pool(outs, layout='NCHW'):

--- a/python/tvm/topi/cuda/pooling.py
+++ b/python/tvm/topi/cuda/pooling.py
@@ -20,6 +20,7 @@ import tvm
 from tvm import te
 from .. import tag
 from ..util import traverse_inline
+from math import sqrt, floor
 
 
 def schedule_adaptive_pool(outs, layout='NCHW'):
@@ -40,7 +41,12 @@ def schedule_adaptive_pool(outs, layout='NCHW'):
     s = te.create_schedule([x.op for x in outs])
 
     def _schedule(Pool):
-        num_thread = 8
+        #Adapt thread number between default value and maximum number of threads available
+        target = tvm.target.Target.current()
+        if target.max_num_threads is not None:
+            num_thread = min(floor(sqrt(target.max_num_threads)), 8)
+        else:
+            num_thread = 8
         block_x = te.thread_axis("blockIdx.x")
         block_y = te.thread_axis("blockIdx.y")
         thread_x = te.thread_axis((0, num_thread), "threadIdx.x")

--- a/python/tvm/topi/cuda/reduction.py
+++ b/python/tvm/topi/cuda/reduction.py
@@ -43,8 +43,8 @@ def _schedule_reduce(op, sch, is_idx_reduce=False):
         target = tvm.target.Target.current()
 
         #Adapt number of threads to device
-        if target.id.max_num_threads is not None:
-            num_thread = min(num_thread, target.id.max_num_threads)
+        if target.max_num_threads is not None:
+            num_thread = min(num_thread, target.max_num_threads)
         block_x = te.thread_axis("blockIdx.x")
         thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
         thread_y = te.thread_axis((0, num_thread), "threadIdx.y")

--- a/python/tvm/topi/cuda/reduction.py
+++ b/python/tvm/topi/cuda/reduction.py
@@ -41,7 +41,7 @@ def _schedule_reduce(op, sch, is_idx_reduce=False):
             # don't know why
             num_thread = 16
         target = tvm.target.Target.current()
-        
+
         #Adapt number of threads to device
         if target.id.max_num_threads is not None:
             num_thread = min(num_thread, target.id.max_num_threads)

--- a/python/tvm/topi/cuda/reduction.py
+++ b/python/tvm/topi/cuda/reduction.py
@@ -40,6 +40,11 @@ def _schedule_reduce(op, sch, is_idx_reduce=False):
             # without it, CL_INVALID_WORK_GROUP_SIZE occurred when running test_topi_reduce.py
             # don't know why
             num_thread = 16
+        target = tvm.target.Target.current()
+        
+        #Adapt number of threads to device
+        if target.id.max_num_threads is not None:
+            num_thread = min(num_thread, target.id.max_num_threads)
         block_x = te.thread_axis("blockIdx.x")
         thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
         thread_y = te.thread_axis((0, num_thread), "threadIdx.y")

--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -115,6 +115,10 @@ def schedule_softmax(outs):
 
     else:
         num_thread = 64
+        # Adapt num_thread to device
+        if tgt.max_num_threads is not None:
+            num_thread = min(tgt.max_num_threads, num_thread)
+
         block_x = te.thread_axis("blockIdx.x")
         thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
 

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -216,7 +216,8 @@ class OpenCLWorkspace : public DeviceAPI {
   // Initialzie the device.
   void Init(const std::string& type_key, const std::string& device_type,
             const std::string& platform_name = "");
-  virtual void Init() { Init("opencl", "gpu"); }
+  // Find accelerator first, TODO: Make a proper way to chose between device types
+  virtual void Init() { Init("opencl", "accelerator"); }
   // Check whether the context is OpenCL or not.
   virtual bool IsOpenCLDevice(TVMContext ctx) { return ctx.device_type == kDLOpenCL; }
   // get the queue of the context

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -246,6 +246,10 @@ void OpenCLWorkspace::Init(const std::string& type_key, const std::string& devic
       continue;
     }
     std::vector<cl_device_id> devices_matched = cl::GetDeviceIDs(platform_id, device_type);
+    if ((devices_matched.size() == 0) && (device_type == "accelerator")) {
+      LOG(WARNING) << "Using GPU OpenCL device";
+      devices_matched = cl::GetDeviceIDs(platform_id, "gpu");
+    }
     if ((devices_matched.size() == 0) && (device_type == "gpu")) {
       LOG(WARNING) << "Using CPU OpenCL device";
       devices_matched = cl::GetDeviceIDs(platform_id, "cpu");


### PR DESCRIPTION
As TVM supports OpenCL and OpenCL supports accelerators in the same way as GPU or CPU devices, I think TVM should accept generic accelerators too. 

I made minor changes to the OpenCL c++ part in order to make TVM recognize accelerator devices. However it may deserve another pull request to overhaul the present system in order to allow the user to explicitly chose between which device type to use.
In addition I noticed that CUDA, and therefore OpenCL, schedules used sometimes hardcoded constants for the number of threads. While it is acceptable for GPU that have many threads available, it is not for generic accelerators that may have a small number of threads (as low as 16 for example). I tried to make these constants more flexible by using the max_num_threads of the target kind.