### PR TITLE
[WIP/RFC] Add TVM dependencies to pyproject.toml

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -218,13 +218,6 @@ set(USE_ETHOSN OFF)
 # otherwise use ETHOSN_HW (OFF) to use the software test infrastructure
 set(USE_ETHOSN_HW OFF)
 
-# Build ANTLR parser for Relay text format
-# Possible values:
-# - ON: enable ANTLR by searching default locations (cmake find_program for antlr4 and /usr/local for jar)
-# - OFF: disable ANTLR
-# - /path/to/antlr-*-complete.jar: path to specific ANTLR jar file
-set(USE_ANTLR OFF)
-
 # Whether use Relay debug mode
 set(USE_RELAY_DEBUG OFF)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,12 +66,6 @@ typed_ast = "^1.4"
 # AutoTVM
 xgboost = {version = "^1.1", optional = true}
 
-# Dev dependencies (lint, testing, and docs)
-autodocsumm = "^0.1.13"
-cpplint = "^1.5"
-pylint = "^2.4"
-pytest = "^6"
-
 #############
 # Importers #
 #############
@@ -117,6 +111,7 @@ importer-coreml = ["coremltools"]
 importer-darknet = ["opencv-python"]
 importer-keras = ["tensorflow", "tensorflow-estimator"]
 importer-onnx = ["onnx", "onnxruntime", "torch", "torchvision", "future"]
+importer-pytorch = ["torch", "torchvision", "future"]
 importer-tensorflow = ["tensorflow", "tensorflow-estimator"]
 importer-tflite = ["tlfite", "tensorflow", "tensorflow-estimator"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,97 @@ exclude = '''
   )/
 )
 '''
+[tool.poetry]
+name = "incubator-tvm"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+attrs = "^19"
+decorator = "^4.4"
+numpy = "~1.19"
+psutil = "^5"
+scipy = "^1.4"
+python = "^3.7"
+tornado = "^6"
+tvm = {path = "python"}
+typed_ast = "^1.4"
+
+# AutoTVM
+xgboost = {version = "^1.1", optional = true}
+
+# Dev dependencies (lint, testing, and docs)
+autodocsumm = "^0.1.13"
+cpplint = "^1.5"
+pylint = "^2.4"
+pytest = "^6"
+
+#############
+# Importers #
+#############
+
+# NOTE: Caffe frontend dependency is from torch package.
+
+# CoreML
+coremltools = {version = "^3.3", optional = true}
+
+# Darknet
+opencv-python = {version = "^4.2", optional = true}
+cffi = {version = "^1.14", optional = true}
+
+# NOTE: Keras provided by tensorflow package.
+# If TF version conflict, maybe try: keras = "2.3.1"
+
+# MXNet frontend
+mxnet = {version = "^1.6.0", optional = true}
+
+# ONNX frontend
+onnx = {version = "1.6.0", optional = true}
+onnxruntime = {version = "1.0.0", optional = true}
+
+# Pytorch (also used by ONNX)
+torch = {version = "1.4.0", optional = true}
+torchvision = {version = "0.5.0", optional = true}
+# NOTE: torch depends on a number of other packages, but unhelpfully, does not expose that in the
+# wheel!!!
+future = {version = "*", optional = true}
+
+# Tensorflow frontend
+tensorflow = {version = "^2.1", optional = true}
+tensorflow-estimator = {version = "^2.1", optional = true}
+
+# TFLite frontend
+tflite = {version = "2.1.0", optional = true}
+
+
+[tool.poetry.extras]
+xgboost = ["xgboost"]
+importer-caffe2 = ["torch"]
+importer-coreml = ["coremltools"]
+importer-darknet = ["opencv-python"]
+importer-keras = ["tensorflow", "tensorflow-estimator"]
+importer-onnx = ["onnx", "onnxruntime", "torch", "torchvision", "future"]
+importer-tensorflow = ["tensorflow", "tensorflow-estimator"]
+importer-tflite = ["tlfite", "tensorflow", "tensorflow-estimator"]
+
+[tool.poetry.dev-dependencies]
+autodocsumm = "^0.1"
+black = "^19.10b0"
+sphinx = "^3.0"
+sphinx-gallery = "^0.4"
+sphinx-rtd-theme = "^0.4"
+matplotlib = "^3.2"
+Image = "^1.5"
+recommonmark = "^0.6"
+pillow = "< 7"
+pyformat = "^0.7"
+pylint = "^2.4"
+pytest = "^5.4"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.autopep8]
+max_line_length = 100

--- a/python/setup.py
+++ b/python/setup.py
@@ -67,14 +67,26 @@ def get_lib_list():
     """Get list of paths to DSO libraries that should be included in an installation."""
     global LIB_LIST
     if LIB_LIST is None:
-        read_libinfo()
-        lib_path = LIBINFO["find_lib_path"]()
-        LIB_LIST = [lib_path[0]]
-        if LIB_LIST[0].find("runtime") == -1:
-            for name in lib_path[1:]:
-                if name.find("runtime") != -1:
-                    LIB_LIST.append(name)
-                    break
+        if sys.platform == "linux":
+            so_ext = "so"
+        elif sys.platform == "darwin":
+            so_ext = "dylib"
+        elif sys.platform in ("win32", "cygwin"):
+            so_ext = "dll"
+        else:
+            assert False, f"sys.platform {sys.platform} is not supported"
+        LIB_LIST = [
+            "../build/libtvm_runtime.{so_ext}",
+            "../build/libtvm.{so_ext}",
+        ]
+        # read_libinfo()
+        # lib_path = LIBINFO["find_lib_path"]()
+        # LIB_LIST = [lib_path[0]]
+        # if LIB_LIST[0].find("runtime") == -1:
+        #     for name in lib_path[1:]:
+        #         if name.find("runtime") != -1:
+        #             LIB_LIST.append(name)
+        #             break
 
     return LIB_LIST
 

--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -40,7 +40,7 @@ def split_env_var(env_var, split):
     return []
 
 
-def find_lib_path(name=None, search_path=None, optional=False):
+def find_lib_path(name=None, search_path=None, optional=False, from_setup_py=False):
     """Find dynamic library files.
 
     Parameters
@@ -70,22 +70,29 @@ def find_lib_path(name=None, search_path=None, optional=False):
     if os.environ.get("TVM_LIBRARY_PATH", None):
         dll_path.append(os.environ["TVM_LIBRARY_PATH"])
 
-    if sys.platform.startswith("linux"):
-        dll_path.extend(split_env_var("LD_LIBRARY_PATH", ":"))
-        dll_path.extend(split_env_var("PATH", ":"))
-    elif sys.platform.startswith("darwin"):
-        dll_path.extend(split_env_var("DYLD_LIBRARY_PATH", ":"))
-        dll_path.extend(split_env_var("PATH", ":"))
-    elif sys.platform.startswith("win32"):
-        dll_path.extend(split_env_var("PATH", ";"))
+    if not from_setup_py:
+        if sys.platform.startswith("linux"):
+            dll_path.extend(split_env_var("LD_LIBRARY_PATH", ":"))
+            dll_path.extend(split_env_var("PATH", ":"))
+        elif sys.platform.startswith("darwin"):
+            dll_path.extend(split_env_var("DYLD_LIBRARY_PATH", ":"))
+            dll_path.extend(split_env_var("PATH", ":"))
+        elif sys.platform.startswith("win32"):
+            dll_path.extend(split_env_var("PATH", ";"))
 
-    # Pip lib directory
-    dll_path.append(os.path.join(ffi_dir, ".."))
-    # Default cmake build directory
-    dll_path.append(os.path.join(source_dir, "build"))
+        # Pip lib directory
+        dll_path.append(os.path.join(ffi_dir, ".."))
+    else:
+        # Default cmake build directory
+        source_build_dir = os.path.join(source_dir, "build")
+        source_git_dir = os.path.join(source_dir, ".git")
+        if os.path.exists(source_git_dir):   # User is in development flow
+            if os.path.isdir(source_build_dir);
+                cmake_config = os.path.join(source_build_dir, "cmake.config")
+                if not os.path.exists(cmake_config):
+
+                dll_path.append(
     dll_path.append(os.path.join(source_dir, "build", "Release"))
-    # Default make build directory
-    dll_path.append(os.path.join(source_dir, "lib"))
 
     dll_path.append(install_lib_dir)
 

--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -40,7 +40,7 @@ def split_env_var(env_var, split):
     return []
 
 
-def find_lib_path(name=None, search_path=None, optional=False, from_setup_py=False):
+def find_lib_path(name=None, search_path=None, optional=False):
     """Find dynamic library files.
 
     Parameters
@@ -70,29 +70,22 @@ def find_lib_path(name=None, search_path=None, optional=False, from_setup_py=Fal
     if os.environ.get("TVM_LIBRARY_PATH", None):
         dll_path.append(os.environ["TVM_LIBRARY_PATH"])
 
-    if not from_setup_py:
-        if sys.platform.startswith("linux"):
-            dll_path.extend(split_env_var("LD_LIBRARY_PATH", ":"))
-            dll_path.extend(split_env_var("PATH", ":"))
-        elif sys.platform.startswith("darwin"):
-            dll_path.extend(split_env_var("DYLD_LIBRARY_PATH", ":"))
-            dll_path.extend(split_env_var("PATH", ":"))
-        elif sys.platform.startswith("win32"):
-            dll_path.extend(split_env_var("PATH", ";"))
+    if sys.platform.startswith("linux"):
+        dll_path.extend(split_env_var("LD_LIBRARY_PATH", ":"))
+        dll_path.extend(split_env_var("PATH", ":"))
+    elif sys.platform.startswith("darwin"):
+        dll_path.extend(split_env_var("DYLD_LIBRARY_PATH", ":"))
+        dll_path.extend(split_env_var("PATH", ":"))
+    elif sys.platform.startswith("win32"):
+        dll_path.extend(split_env_var("PATH", ";"))
 
-        # Pip lib directory
-        dll_path.append(os.path.join(ffi_dir, ".."))
-    else:
-        # Default cmake build directory
-        source_build_dir = os.path.join(source_dir, "build")
-        source_git_dir = os.path.join(source_dir, ".git")
-        if os.path.exists(source_git_dir):   # User is in development flow
-            if os.path.isdir(source_build_dir);
-                cmake_config = os.path.join(source_build_dir, "cmake.config")
-                if not os.path.exists(cmake_config):
-
-                dll_path.append(
+    # Pip lib directory
+    dll_path.append(os.path.join(ffi_dir, ".."))
+    # Default cmake build directory
+    dll_path.append(os.path.join(source_dir, "build"))
     dll_path.append(os.path.join(source_dir, "build", "Release"))
+    # Default make build directory
+    dll_path.append(os.path.join(source_dir, "lib"))
 
     dll_path.append(install_lib_dir)
 

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -34,7 +34,6 @@ echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-10\) >> config.cmake
 echo set\(USE_NNPACK ON\) >> config.cmake
 echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
-echo set\(USE_ANTLR ON\) >> config.cmake
 echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu.sh
+++ b/tests/scripts/task_config_build_gpu.sh
@@ -39,7 +39,6 @@ echo set\(USE_GRAPH_RUNTIME ON\) >> config.cmake
 echo set\(USE_STACKVM_RUNTIME ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME_DEBUG ON\) >> config.cmake
 echo set\(USE_VM_PROFILER ON\) >> config.cmake
-echo set\(USE_ANTLR ON\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_BLAS openblas\) >> config.cmake

--- a/tests/scripts/task_config_build_wasm.sh
+++ b/tests/scripts/task_config_build_wasm.sh
@@ -30,7 +30,6 @@ echo set\(USE_STANDALONE_CRT ON\) >> config.cmake
 echo set\(USE_GRAPH_RUNTIME_DEBUG ON\) >> config.cmake
 echo set\(USE_VM_PROFILER ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-11\) >> config.cmake
-echo set\(USE_ANTLR ON\) >> config.cmake
 echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake


### PR DESCRIPTION
Still a WIP, posting for people to take a look at. This should maybe become an RFC, happy to write one up. I just needed a `pyproject.toml` for a project I'm working on now so I'm posting it.

It's really hard to reproducibly use TVM outside the docker containers, and depending on what hardware you have at work/home (are they different now?), you can't always run the docker container you need to (I.e. ci-gpu). Clearly documenting our python dependencies will help.

I think *just* checking this in as-is would be bad because:
 - I'm just copying dependencies from one place to another. There isn't anything to enforce that our docker images, and therefore our CI, actually uses the selected versions
 - That aside, it would be great to generate a constraints file or some other log *outside* the docker images, so that you can have a clear record of e.g. which version of `pylint` is used to lint without needing to pull the container.
 - In order to actually use `poetry`, I had to hack `setup.py` to hardcode the library location. Maybe we should just do this. Right now if you have `libtvm_runtime.so` in `PATH` then it just uses that one--very bad in development! The reason for this is that dependency tracking tools installing packages in editable mode really want to run something like `python setup.py egg_info` to determine the library version, and unless you've built tvm, poetry will just crash trying to do anything. that's a bad developer experience.
 - Making `pyproject.toml` the authoritative source of dependencies (I.e. rewriting the docker/install scripts to install only using `poetry`) would be bad because non-users of poetry would have to transcribe the dependencies into e.g. `requirements.txt`. Yes, tools exist to do this; we should do it for them.

Here are some future things I'd like to do to address these issues:
- [ ] Write a script that uses e.g. dephell to auto-generate `python/requirements.txt` and `python/requirements-<extra>.txt` for each extra section included.
- [ ] Write a unit test that asserts that `python/requirements*.txt` is in sync with `pyproject.toml`.
- [ ] Make it easy to install all extras in one command (likely needs output from previous script)
- [ ] Rewrite `docker/install/ubuntu_install_<extra>.sh` to just run `poetry install -E <extra>`.
- [ ] Add `poetry lock` to the docker build process and export the generated lockfile somehow...
- [ ] Decide what to do about `setup.py` library location hack.

Here's why I think we should use something other than requirements.txt as the authoritative source of dependencies:
 - In order to ensure a smooth user experience, we do have to pin our dependencies to *some* degree. Here, I've pinned to the package minor or major version where that made sense.
 - However, of course pinning is bad unless you update your pinned deps. so some dependency management tool provides that capability. I'm not at all attached to poetry as the tool to use for that, but it can facilitate it.
