### PR TITLE
[BYOC] Configurable optimize pass for PartitionGraph

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -377,7 +377,7 @@ TVM_DLL Pass EtaExpand(bool expand_constructor, bool expand_global_var);
  *
  * \return The pass.
  */
-TVM_DLL Pass PartitionGraph();
+TVM_DLL Pass PartitionGraph(runtime::PackedFunc foptimize = nullptr);
 
 /*!
  * \brief Inline the global functions marked as `inline` in a given Relay

--- a/python/tvm/relay/op/contrib/arm_compute_lib.py
+++ b/python/tvm/relay/op/contrib/arm_compute_lib.py
@@ -54,6 +54,16 @@ def partition_for_arm_compute_lib(mod, params=None):
     -------
     ret : annotated and partitioned module.
     """
+
+    def optimize(mod):
+        foptimize = tvm._ffi.get_global_func("relay.ext.arm_compute_lib.optimize")
+        if foptimize is None:
+            raise RuntimeError(
+                "Failed to get the Arm compute library optimization pass. "
+                "Did you build with USE_ARM_COMPUTE_LIB=ON?"
+            )
+        return foptimize(mod)
+
     if params:
         mod["main"] = bind_params_by_name(mod["main"], params)
 
@@ -62,7 +72,7 @@ def partition_for_arm_compute_lib(mod, params=None):
             transform.InferType(),
             transform.MergeComposite(arm_compute_lib_pattern_table()),
             transform.AnnotateTarget("arm_compute_lib"),
-            transform.PartitionGraph(),
+            transform.PartitionGraph(optimize),
         ]
     )
 

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -627,7 +627,7 @@ def EliminateCommonSubexpr(fskip=None):
 
     Parameters
     ----------
-    fskip: Callable
+    fskip: Optional[Callable]
         The callback function that decides whether an expression should be
         skipped.
 
@@ -687,7 +687,7 @@ def PartitionGraph(foptimize=None):
 
     Parameters
     ----------
-    foptimize: Callable
+    foptimize: Optional[Callable]
         The callback function that optimizes the partitioned Relay functions.
 
     Returns

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -681,16 +681,21 @@ def LambdaLift():
     return _ffi_api.LambdaLift()
 
 
-def PartitionGraph():
+def PartitionGraph(foptimize=None):
     """Partition a Relay program into regions that can be executed on different
     backends.
+
+    Parameters
+    ----------
+    foptimize: Callable
+        The callback function that optimizes the partitioned Relay functions.
 
     Returns
     -------
     ret: tvm.transform.Pass
         The registered pass that partitions the Relay program.
     """
-    return _ffi_api.PartitionGraph()
+    return _ffi_api.PartitionGraph(foptimize)
 
 
 def AnnotateTarget(targets):

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -487,7 +487,7 @@ IRModule FlattenTupleOutputs(IRModule module) {
 
 namespace transform {
 
-Pass PartitionGraph(PackedFunc foptimize) {
+Pass PartitionGraph(const PackedFunc foptimize) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> flatten_tuples = [=](IRModule m,
                                                                                  PassContext pc) {
     // There could be compiler_end annotations on tuples

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -1327,8 +1327,6 @@ def test_extern_opt():
     def Optimize(mod):
         return relay.transform.FoldConstant()(mod)
 
-    tvm.register_func("relay.ext.test_target.optimize", Optimize)
-
     x = relay.var("x", shape=(2, 2))
     y0 = relay.var("y0", shape=(2, 2))
     y1 = relay.var("y1", shape=(2, 2))
@@ -1342,7 +1340,7 @@ def test_extern_opt():
     mod = tvm.IRModule()
     mod["main"] = f
     mod = transform.InferType()(mod)
-    mod = transform.PartitionGraph()(mod)
+    mod = transform.PartitionGraph(Optimize)(mod)
 
     try:
         t0 = mod["test_target_0"]


### PR DESCRIPTION
Currently, `PartitionGraph` implicitly invokes `relay.ext.*.optimize` pass for each partitioned Relay function, but this is hard to maintain and trace. This PR adds an optional argument to `PartitionGraph` pass to make it explicit. 

cc @zhiics @masahi @lhutton1 