### PR TITLE
Refactor compile_engine to introduce TETranslator

### DIFF
--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -255,7 +255,7 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
 
 
 @tvm._ffi.register_func("relay.backend.lower_call")
-def lower_call(call, inputs, target):
+def lower_call(call, inputs, target, no_trace=False):
     """Lower the call expression to op implementation and tensor outputs."""
     assert isinstance(call.op, tvm.ir.Op)
     op = call.op
@@ -283,7 +283,7 @@ def lower_call(call, inputs, target):
     env = autotvm.task.TaskExtractEnv.current
     reenable_tracing = False
     if env is not None and env.tracing:
-        if env.wanted_relay_ops is not None and op not in env.wanted_relay_ops:
+        if (env.wanted_relay_ops is not None and op not in env.wanted_relay_ops) or no_trace:
             env.tracing = False
             reenable_tracing = True
 
@@ -410,3 +410,7 @@ def get():
         The compile engine.
     """
     return _backend._CompileEngineGlobal()
+
+
+def translate_to_te(prim_func, target):
+    return _backend._TranslateToTE(prim_func, target)

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -306,7 +306,6 @@ class ScheduleGetter : public ExprVisitor {
       }
     }
     cache_node->schedule = std::move(schedule);
-    ;
     return CachedFunc(cache_node);
   }
 

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -187,7 +187,7 @@ class TETranslator : public backend::MemoizedExprTranslator<Array<te::Tensor>> {
       const auto* copy_input = inputs[0].operator->();
       outputs.push_back(te::Tensor(copy_input->shape, copy_input->dtype, te::Operation(), 0));
     } else {
-      LoweredOutput lowered_out = (*flower_call)(GetRef<Call>(call_node), inputs, target_, false);
+      LoweredOutput lowered_out = (*flower_call)(GetRef<Call>(call_node), inputs, target_, true);
       outputs = lowered_out->outputs;
     }
 
@@ -322,6 +322,7 @@ class ScheduleGetter : public ExprVisitor {
     int count_tuple = 0;
     Array<te::Tensor> inputs;
     for (Expr arg : call_node->args) {
+      VisitExpr(arg);
       if (const auto* ttype = arg->checked_type().as<TensorTypeNode>()) {
         tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype);
         inputs.push_back(tensor);
@@ -350,7 +351,7 @@ class ScheduleGetter : public ExprVisitor {
       readable_name_stream_ << "__copy";
       return;
     }
-    LoweredOutput lowered_out = (*flower_call)(GetRef<Call>(call_node), inputs, target_, true);
+    LoweredOutput lowered_out = (*flower_call)(GetRef<Call>(call_node), inputs, target_, false);
     OpImplementation impl = lowered_out->implementation;
 
     int op_pattern = fpattern[op];

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -189,7 +189,6 @@ class TETranslator : public backend::MemoizedExprTranslator<Array<te::Tensor>> {
     } else {
       LoweredOutput lowered_out = (*flower_call)(GetRef<Call>(call_node), inputs, target_, false);
       outputs = lowered_out->outputs;
-      impl = lowered_out->implementation;
     }
 
     if (outputs.size() != 1) {

--- a/src/relay/backend/compile_engine.h
+++ b/src/relay/backend/compile_engine.h
@@ -69,6 +69,27 @@ class LoweredOutput : public ObjectRef {
   TVM_DEFINE_OBJECT_REF_METHODS(LoweredOutput, ObjectRef, LoweredOutputNode);
 };
 
+/*! \brief Node container to represent a Tensor Expression graph. */
+struct TEGraphNode : public Object {
+  /* \brief The inputs to the graph */
+  tvm::Array<te::Tensor> inputs;
+  /* \brief The outputs to the graph */
+  tvm::Array<te::Tensor> outputs;
+
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("inputs", &inputs);
+    v->Visit("outputs", &outputs);
+  }
+
+  static constexpr const char* _type_key = "relay.TEGraph";
+  TVM_DECLARE_FINAL_OBJECT_INFO(TEGraphNode, Object);
+};
+
+class TEGraph : public ObjectRef {
+ public:
+  TVM_DEFINE_OBJECT_REF_METHODS(TEGraph, ObjectRef, TEGraphNode);
+};
+
 /*! \brief Node container to represent a cached function. */
 struct CachedFuncNode : public Object {
   /* \brief compiled target */

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -58,7 +58,7 @@ TVM_REGISTER_GLOBAL("test.strategy")
 
 TVM_REGISTER_GLOBAL("relay.backend.lower_call")
     .set_body_typed([](const relay::Call& call, const Array<te::Tensor>& inputs,
-                       const Target& target) {
+                       const Target& target, bool no_trace = false) {
       static auto fstrategy = Op::GetAttrMap<relay::FTVMStrategy>("FTVMStrategy");
       Op op = Downcast<Op>(call->op);
       auto out_type = call->checked_type();


### PR DESCRIPTION
This PR refactors the compile_engine to expose a Relay -> TE translator as a standalone component. See the RFC [here](https://discuss.tvm.apache.org/t/rfc-refactor-the-compile-engine-to-expose-a-relay-te-translator/8417).

TODO
- [ ] Agree on names for the API
- [ ] Add further tests for just the TETranslator