### PR TITLE
 [TOPI] sparse_dense Op sparse_data input added 

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -937,7 +937,11 @@ struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
 
 /*! \brief Attributes for sparse_dense operator */
 struct SparseDenseAttrs : public tvm::AttrsNode<SparseDenseAttrs> {
-  TVM_DECLARE_ATTRS(SparseDenseAttrs, "relay.attrs.SparseDenseAttrs") {}
+  bool sparse_data;
+
+  TVM_DECLARE_ATTRS(SparseDenseAttrs, "relay.attrs.SparseDenseAttrs") {
+    TVM_ATTR_FIELD(sparse_data).set_default(false).describe("Indicate whether data or weight is sparse. True if data is sparse");
+    }
 };
 
 /*! \brief Attributes for sparse_transpose operator */

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -942,7 +942,9 @@ struct SparseDenseAttrs : public tvm::AttrsNode<SparseDenseAttrs> {
   TVM_DECLARE_ATTRS(SparseDenseAttrs, "relay.attrs.SparseDenseAttrs") {
     TVM_ATTR_FIELD(sparse_lhs)
         .set_default(false)
-        .describe("Indicate whether lhs or rhs matrix is sparse. True if lhs matrix is sparse");
+        .describe(
+            "Indicate whether sparse matrix is multiplied on the right or the left. If true, then "
+            "the operation is S * D^T (D dense, S sparse). If false, the operation is D * S^T");
   }
 };
 

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -940,8 +940,10 @@ struct SparseDenseAttrs : public tvm::AttrsNode<SparseDenseAttrs> {
   bool sparse_data;
 
   TVM_DECLARE_ATTRS(SparseDenseAttrs, "relay.attrs.SparseDenseAttrs") {
-    TVM_ATTR_FIELD(sparse_data).set_default(false).describe("Indicate whether data or weight is sparse. True if data is sparse");
-    }
+    TVM_ATTR_FIELD(sparse_data)
+        .set_default(false)
+        .describe("Indicate whether data or weight is sparse. True if data is sparse");
+  }
 };
 
 /*! \brief Attributes for sparse_transpose operator */

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -937,12 +937,12 @@ struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
 
 /*! \brief Attributes for sparse_dense operator */
 struct SparseDenseAttrs : public tvm::AttrsNode<SparseDenseAttrs> {
-  bool sparse_data;
+  bool sparse_lhs;
 
   TVM_DECLARE_ATTRS(SparseDenseAttrs, "relay.attrs.SparseDenseAttrs") {
-    TVM_ATTR_FIELD(sparse_data)
+    TVM_ATTR_FIELD(sparse_lhs)
         .set_default(false)
-        .describe("Indicate whether data or weight is sparse. True if data is sparse");
+        .describe("Indicate whether lhs or rhs matrix is sparse. True if lhs matrix is sparse");
   }
 };
 

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -940,9 +940,7 @@ def _sparse_tensor_dense_matmul():
         weight_indptrs = _expr.const(weight_sp.indptr, weight_sp.indptr.dtype)
         weight_indices = _expr.const(weight_sp.indices, weight_sp.indices.dtype)
 
-        ret = _op.nn.sparse_dense(
-                data, [weight_data, weight_indices, weight_indptrs], sparse_lhs
-        )
+        ret = _op.nn.sparse_dense(data, [weight_data, weight_indices, weight_indptrs], sparse_lhs)
 
         if not sparse_lhs:
             ret = _op.transpose(ret)

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -916,6 +916,13 @@ def _sparse_tensor_dense_matmul():
 
         data = inputs[3]
 
+        # By default, in tensorflow the first input ,i.e., data is sparse
+        sparse_data = True
+
+        # If both are true means First input was dense and second was sparse
+        if attr.get("adjoint_a") and attr.get("adjoint_b"):
+            sparse_data = False
+
         rows = [x[0] for x in indices_tensor]
         cols = [x[1] for x in indices_tensor]
 
@@ -923,21 +930,29 @@ def _sparse_tensor_dense_matmul():
         weight_sp = csr_matrix(
             (values_tensor, (rows, cols)), shape=tuple(dense_shape_tensor.tolist())
         )
-        weight_sp = csr_matrix(weight_sp.transpose())
+
+        if sparse_data:
+            data = _op.transpose(data)
+        else:
+            weight_sp = csr_matrix(weight_sp.transpose())
 
         weight_data = _expr.const(weight_sp.data, weight_sp.data.dtype)
         weight_indptrs = _expr.const(weight_sp.indptr, weight_sp.indptr.dtype)
         weight_indices = _expr.const(weight_sp.indices, weight_sp.indices.dtype)
 
-        ret = _op.nn.sparse_dense(data, [weight_data, weight_indices, weight_indptrs])
-
-        # If both are true means First input was dense and second was sparse
-        # TODO(ANSHUMAN87): Support other adjoint option too
-        if attr.get("adjoint_a") and attr.get("adjoint_b"):
-            ret = _op.transpose(ret)
+        if sparse_data:
+            ret = _op.nn.sparse_dense([weight_data, weight_indices, weight_indptrs], data, sparse_data=True)
         else:
+            ret = _op.nn.sparse_dense(data, [weight_data, weight_indices, weight_indptrs])
+            ret = _op.transpose(ret)
+
+        # Case 1. If both are true means first input was dense and second was sparse
+        # Case 2. If both are false means first input was sparse and second was dense
+        # TODO(ANSHUMAN87): Support other adjoint option too
+        if not ((attr.get("adjoint_a") and attr.get("adjoint_b")) or ((not attr.get("adjoint_a")) and (not attr.get("adjoint_b")))):
             raise tvm.error.OpAttributeUnImplemented(
                 "Only tf.sparse.sparse_dense_matmul() with adjoint_a=True and adjoint_b=True"
+                "or with adjoint_a=False and adjoint_b=False"
                 " is supported, but adjoint_a={} and adjoint_b={} was supplied.".format(
                     attr.get("adjoint_a"), attr.get("adjoint_b")
                 )

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -941,7 +941,9 @@ def _sparse_tensor_dense_matmul():
         weight_indices = _expr.const(weight_sp.indices, weight_sp.indices.dtype)
 
         if sparse_data:
-            ret = _op.nn.sparse_dense([weight_data, weight_indices, weight_indptrs], data, sparse_data=True)
+            ret = _op.nn.sparse_dense(
+                [weight_data, weight_indices, weight_indptrs], data, sparse_data=True
+            )
         else:
             ret = _op.nn.sparse_dense(data, [weight_data, weight_indices, weight_indptrs])
             ret = _op.transpose(ret)
@@ -949,7 +951,10 @@ def _sparse_tensor_dense_matmul():
         # Case 1. If both are true means first input was dense and second was sparse
         # Case 2. If both are false means first input was sparse and second was dense
         # TODO(ANSHUMAN87): Support other adjoint option too
-        if not ((attr.get("adjoint_a") and attr.get("adjoint_b")) or ((not attr.get("adjoint_a")) and (not attr.get("adjoint_b")))):
+        if not (
+            (attr.get("adjoint_a") and attr.get("adjoint_b"))
+            or ((not attr.get("adjoint_a")) and (not attr.get("adjoint_b")))
+        ):
             raise tvm.error.OpAttributeUnImplemented(
                 "Only tf.sparse.sparse_dense_matmul() with adjoint_a=True and adjoint_b=True"
                 "or with adjoint_a=False and adjoint_b=False"

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -69,7 +69,7 @@ reg.register_pattern("nn.batch_matmul", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 @reg.register_compute("nn.sparse_dense")
 def compute_sparse_dense(attrs, inputs, out_type):
     """Compute definition of sparse_dense"""
-    return [topi.nn.sparse_dense(inputs[0], inputs[1], inputs[2], inputs[3])]
+    return [topi.nn.sparse_dense(inputs[0], inputs[1], inputs[2], inputs[3], attrs["sparse_data"])]
 
 
 reg.register_strategy("nn.sparse_dense", strategy.sparse_dense_strategy)

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -69,7 +69,7 @@ reg.register_pattern("nn.batch_matmul", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 @reg.register_compute("nn.sparse_dense")
 def compute_sparse_dense(attrs, inputs, out_type):
     """Compute definition of sparse_dense"""
-    return [topi.nn.sparse_dense(inputs[0], inputs[1], inputs[2], inputs[3], attrs["sparse_data"])]
+    return [topi.nn.sparse_dense(inputs[0], inputs[1], inputs[2], inputs[3], attrs["sparse_lhs"])]
 
 
 reg.register_strategy("nn.sparse_dense", strategy.sparse_dense_strategy)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -2000,17 +2000,17 @@ def sparse_dense(dense_mat, sparse_mat, sparse_lhs=False):
     a dense matrix and `sparse_mat` is a sparse (either BSR or CSR) namedtuple with
     fields `data`, `indices`, and `indptr`.
 
-    .. math::
+    \if sparse_lhs=False:
+        .. math::
 
-       if sparse_lhs=True
+            \mbox{sparse_dense}(dense_mat, sparse_mat)[m, n]
+            = \mbox{matmul}(D, \mbox{as_dense}(S)^T)[m, n]
 
-        \mbox{sparse_dense}(dense_mat, sparse_mat)[m, n]
-        = \mbox{matmul}(D, \mbox{as_dense}(S)^T)[m, n]
+    \if sparse_lhs=True:
+        .. math::
 
-       if sparse_lhs=False
-
-        \mbox{sparse_dense}(dense_mat, sparse_mat)[m, n]
-        = \mbox{matmul}(\mbox{as_dense}(S), (D)^T)[m, n]
+            \mbox{sparse_dense}(dense_mat, sparse_mat)[m, n]
+            = \mbox{matmul}(\mbox{as_dense}(S), (D)^T)[m, n]
 
     where `as_dense` returns dense equivalent of the given S(sparse matrix)
     while performing matmul with given D(dense matrix).

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -2021,7 +2021,7 @@ def sparse_dense(data, weight, sparse_lhs=False):
         The sparse weight matrix for the matrix multiplication.
 
     sparse_lhs : bool, optional
-        Indicates whether lhs or rhs matrix is sparse.
+        Indicates whether lhs or rhs matrix is sparse. Default value is False.
 
     Returns
     -------

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1993,7 +1993,7 @@ def batch_matmul(x, y):
     return _make.batch_matmul(x, y)
 
 
-def sparse_dense(data, weight):
+def sparse_dense(data, weight, sparse_data=False):
     r"""
     Computes the matrix multiplication of `data` and `weight`, where `data` is
     a dense matrix and `weight` is a sparse (either BSR or CSR) namedtuple with
@@ -2025,8 +2025,13 @@ def sparse_dense(data, weight):
         The computed result.
     """
     if hasattr(weight, "indices"):
-        return _make.sparse_dense(data, weight.data, weight.indices, weight.indptr)
-    return _make.sparse_dense(data, weight[0], weight[1], weight[2])
+        return _make.sparse_dense(data, weight.data, weight.indices, weight.indptr, sparse_data)
+    elif isinstance(weight, (tuple, list)):
+        return _make.sparse_dense(data, weight[0], weight[1], weight[2], sparse_data)
+    elif hasattr(data, "indices"):
+        return _make.sparse_dense(data.data, data.indices, data.indptr, weight, sparse_data)
+    else:
+        return _make.sparse_dense(data[0], data[1], data[2], weight, sparse_data)
 
 
 def sparse_transpose(x):

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1993,6 +1993,7 @@ def batch_matmul(x, y):
     return _make.batch_matmul(x, y)
 
 
+# pylint: disable=no-else-return,inconsistent-return-statements
 def sparse_dense(data, weight, sparse_data=False):
     r"""
     Computes the matrix multiplication of `data` and `weight`, where `data` is

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1994,7 +1994,7 @@ def batch_matmul(x, y):
 
 
 # pylint: disable=no-else-return,inconsistent-return-statements
-def sparse_dense(data, weight, sparse_data=False):
+def sparse_dense(data, weight, sparse_lhs=False):
     r"""
     Computes the matrix multiplication of `data` and `weight`, where `data` is
     a dense matrix and `weight` is a sparse (either BSR or CSR) namedtuple with
@@ -2020,19 +2020,18 @@ def sparse_dense(data, weight, sparse_data=False):
     weight : Union[namedtuple, Tuple[ndarray, ndarray, ndarray]].
         The sparse weight matrix for the matrix multiplication.
 
+    sparse_lhs : bool, optional
+        Indicates whether lhs or rhs matrix is sparse.
+
     Returns
     -------
     result: tvm.relay.Expr
         The computed result.
     """
     if hasattr(weight, "indices"):
-        return _make.sparse_dense(data, weight.data, weight.indices, weight.indptr, sparse_data)
-    elif isinstance(weight, (tuple, list)):
-        return _make.sparse_dense(data, weight[0], weight[1], weight[2], sparse_data)
-    elif hasattr(data, "indices"):
-        return _make.sparse_dense(data.data, data.indices, data.indptr, weight, sparse_data)
+        return _make.sparse_dense(data, weight.data, weight.indices, weight.indptr, sparse_lhs)
     else:
-        return _make.sparse_dense(data[0], data[1], data[2], weight, sparse_data)
+        return _make.sparse_dense(data, weight[0], weight[1], weight[2], sparse_lhs)
 
 
 def sparse_transpose(x):

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1994,17 +1994,26 @@ def batch_matmul(x, y):
 
 
 # pylint: disable=no-else-return,inconsistent-return-statements
-def sparse_dense(data, weight, sparse_lhs=False):
+def sparse_dense(dense_mat, sparse_mat, sparse_lhs=False):
     r"""
-    Computes the matrix multiplication of `data` and `weight`, where `data` is
-    a dense matrix and `weight` is a sparse (either BSR or CSR) namedtuple with
+    Computes the matrix multiplication of `dense_mat` and `sparse_mat`, where `dense_mat` is
+    a dense matrix and `sparse_mat` is a sparse (either BSR or CSR) namedtuple with
     fields `data`, `indices`, and `indptr`.
 
     .. math::
 
-        \mbox{sparse_dense}(data, weight)[m, n] = \mbox{matmul}(x, \mbox{as_dense}(weight)^T)[m, n]
+       if sparse_lhs=True
 
-    where `as_dense` returns dense equivalent of the given sparse matrix.
+        \mbox{sparse_dense}(dense_mat, sparse_mat)[m, n]
+        = \mbox{matmul}(D, \mbox{as_dense}(S)^T)[m, n]
+
+       if sparse_lhs=False
+
+        \mbox{sparse_dense}(dense_mat, sparse_mat)[m, n]
+        = \mbox{matmul}(\mbox{as_dense}(S), (D)^T)[m, n]
+
+    where `as_dense` returns dense equivalent of the given S(sparse matrix)
+    while performing matmul with given D(dense matrix).
 
     See
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html
@@ -2014,11 +2023,11 @@ def sparse_dense(data, weight, sparse_lhs=False):
 
     Parameters
     ----------
-    data : tvm.relay.Expr
-        The input data for the matrix multiplication
+    dense_mat : tvm.relay.Expr
+        The input dense matrix for the matrix multiplication
 
-    weight : Union[namedtuple, Tuple[ndarray, ndarray, ndarray]].
-        The sparse weight matrix for the matrix multiplication.
+    sparse_mat : Union[namedtuple, Tuple[ndarray, ndarray, ndarray]].
+        The input sparse matrix for the matrix multiplication.
 
     sparse_lhs : bool, optional
         Indicates whether lhs or rhs matrix is sparse. Default value is False.
@@ -2028,10 +2037,14 @@ def sparse_dense(data, weight, sparse_lhs=False):
     result: tvm.relay.Expr
         The computed result.
     """
-    if hasattr(weight, "indices"):
-        return _make.sparse_dense(data, weight.data, weight.indices, weight.indptr, sparse_lhs)
+    if hasattr(sparse_mat, "indices"):
+        return _make.sparse_dense(
+            dense_mat, sparse_mat.data, sparse_mat.indices, sparse_mat.indptr, sparse_lhs
+        )
     else:
-        return _make.sparse_dense(data, weight[0], weight[1], weight[2], sparse_lhs)
+        return _make.sparse_dense(
+            dense_mat, sparse_mat[0], sparse_mat[1], sparse_mat[2], sparse_lhs
+        )
 
 
 def sparse_transpose(x):

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -706,7 +706,7 @@ def wrap_compute_sparse_dense(topi_compute):
     """wrap sparse dense topi compute"""
 
     def _compute_sparse_dense(attrs, inputs, out_type):
-        return [topi_compute(inputs[0], inputs[1], inputs[2], inputs[3], attrs["sparse_data"])]
+        return [topi_compute(inputs[0], inputs[1], inputs[2], inputs[3], attrs["sparse_lhs"])]
 
     return _compute_sparse_dense
 

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -706,7 +706,7 @@ def wrap_compute_sparse_dense(topi_compute):
     """wrap sparse dense topi compute"""
 
     def _compute_sparse_dense(attrs, inputs, out_type):
-        return [topi_compute(inputs[0], inputs[1], inputs[2], inputs[3])]
+        return [topi_compute(inputs[0], inputs[1], inputs[2], inputs[3], attrs["sparse_data"])]
 
     return _compute_sparse_dense
 

--- a/python/tvm/topi/cuda/sparse.py
+++ b/python/tvm/topi/cuda/sparse.py
@@ -65,10 +65,11 @@ def schedule_sparse_dense(outs):
     # pylint:disable=invalid-name
     s = te.create_schedule([x.op for x in outs])
 
+    # TODO(ANSHUMAN87): Add for sparse_dense_bsrmm_v1 also
     def _callback(op):
-        if op.tag == "sparse_dense_bsrmm":
+        if op.tag == "sparse_dense_bsrmm_v2":
             y_bsrmm = op.input_tensors[0]
-            assert y_bsrmm.op.tag == "sparse_dense_bsrmm_block"
+            assert y_bsrmm.op.tag == "sparse_dense_bsrmm_block_v2"
             out = s.outputs[0].output(0)
 
             if op not in s.outputs:
@@ -362,6 +363,7 @@ def _alter_sparse_dense_layout(_attrs, inputs, _tinfos, _out_type):
     sparse_dense implementation for one that operates on a padded matrix. We
     also padd the matrix.
     """
+    # TODO(ANSHUMAN87): Handle for sparse_data case too
     if (
         isinstance(inputs[1], relay.Constant)
         and isinstance(inputs[2], relay.Constant)

--- a/python/tvm/topi/cuda/sparse.py
+++ b/python/tvm/topi/cuda/sparse.py
@@ -363,7 +363,7 @@ def _alter_sparse_dense_layout(_attrs, inputs, _tinfos, _out_type):
     sparse_dense implementation for one that operates on a padded matrix. We
     also padd the matrix.
     """
-    # TODO(ANSHUMAN87): Handle for sparse_data case too
+    # TODO(ANSHUMAN87): Handle for sparse_lhs case too
     if (
         isinstance(inputs[1], relay.Constant)
         and isinstance(inputs[2], relay.Constant)

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -57,6 +57,7 @@ def sparse_dense_v2(data, weight_data, weight_indices, weight_indptr):
         func = _sparse_dense_bsrmm_v2
     return func(data, weight_data, weight_indices, weight_indptr)
 
+
 def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
     """
     Computes sparse-dense matrix multiplication of
@@ -90,6 +91,7 @@ def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
     if len(data_data.shape) == 3:
         func = _sparse_dense_bsrmm_v1
     return func(data_data, data_indices, data_indptr, weight)
+
 
 def sparse_dense(input_1, input_2, input_3, input_4, sparse_data=False):
     """
@@ -145,6 +147,7 @@ def sparse_dense(input_1, input_2, input_3, input_4, sparse_data=False):
     else:
         return sparse_dense_v2(input_1, input_2, input_3, input_4)
 
+
 def _sparse_dense_csrmm_v1(data_data, data_indices, data_indptr, weight):
     oshape = (get_const_tuple(data_indptr.shape)[0] - 1, get_const_tuple(weight.shape)[0])
 
@@ -160,6 +163,7 @@ def _sparse_dense_csrmm_v1(data_data, data_indices, data_indptr, weight):
 
     return te.compute(oshape, f, tag="sparse_dense_csrmm_v1")
 
+
 def _sparse_dense_csrmm_v2(data, weight_data, weight_indices, weight_indptr):
     oshape = (get_const_tuple(data.shape)[0], get_const_tuple(weight_indptr.shape)[0] - 1)
 
@@ -174,6 +178,7 @@ def _sparse_dense_csrmm_v2(data, weight_data, weight_indices, weight_indptr):
         return te.sum(a_val * weight_val, axis=elem_idx)
 
     return te.compute(oshape, f, tag="sparse_dense_csrmm_v2")
+
 
 def _sparse_dense_bsrmm_v1(data_data, data_indices, data_indptr, weight):
     (k, m) = get_const_tuple(weight.shape)
@@ -196,12 +201,15 @@ def _sparse_dense_bsrmm_v1(data_data, data_indices, data_indptr, weight):
     idxd = tvm.tir.indexdiv
     idxm = tvm.tir.indexmod
 
-    bsrmm_block = te.compute((num_blocks, bs_r, k), _compute_block, tag="sparse_dense_bsrmm_block_v1")
+    bsrmm_block = te.compute(
+        (num_blocks, bs_r, k), _compute_block, tag="sparse_dense_bsrmm_block_v1"
+    )
     return te.compute(
         (num_blocks * bs_r, k),
         lambda m, n: bsrmm_block[idxd(n, bs_r), idxm(n, bs_r), m],
         tag="sparse_dense_bsrmm_v1",
     )
+
 
 def _sparse_dense_bsrmm_v2(data, weight_data, weight_indices, weight_indptr):
     (m, _) = get_const_tuple(data.shape)
@@ -224,12 +232,15 @@ def _sparse_dense_bsrmm_v2(data, weight_data, weight_indices, weight_indptr):
     idxd = tvm.tir.indexdiv
     idxm = tvm.tir.indexmod
 
-    bsrmm_block = te.compute((m, num_blocks, bs_r), _compute_block, tag="sparse_dense_bsrmm_block_v2")
+    bsrmm_block = te.compute(
+        (m, num_blocks, bs_r), _compute_block, tag="sparse_dense_bsrmm_block_v2"
+    )
     return te.compute(
         (m, num_blocks * bs_r),
         lambda m, n: bsrmm_block[m, idxd(n, bs_r), idxm(n, bs_r)],
         tag="sparse_dense_bsrmm_v2",
     )
+
 
 def sparse_transpose(sparse_data, sparse_indices, sparse_indptr):
     """

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -23,7 +23,7 @@ from tvm import te
 from ..utils import get_const_tuple
 
 
-def sparse_dense(data, weight_data, weight_indices, weight_indptr):
+def sparse_dense_v2(data, weight_data, weight_indices, weight_indptr):
     """
     Computes sparse-dense matrix multiplication of `data` and
     `(weight_data, weight_indices, weight_indptr).T`
@@ -52,13 +52,115 @@ def sparse_dense(data, weight_data, weight_indices, weight_indptr):
     """
     assert len(weight_data.shape) in (1, 3)
     if len(weight_data.shape) == 1:
-        func = _sparse_dense_csrmm
+        func = _sparse_dense_csrmm_v2
     if len(weight_data.shape) == 3:
-        func = _sparse_dense_bsrmm
+        func = _sparse_dense_bsrmm_v2
     return func(data, weight_data, weight_indices, weight_indptr)
 
+def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
+    """
+    Computes sparse-dense matrix multiplication of
+    `(data_data, data_indices, data_indptr)` and `weight.T`
 
-def _sparse_dense_csrmm(data, weight_data, weight_indices, weight_indptr):
+    Parameters
+    ----------
+    data_data:
+        1-D with shape [nnz] (CSR) or
+        3-D with shape [num_blocks, bs_r, bs_c] (BSR)
+
+    data_indices:
+        1-D with shape [nnz] (CSR) or
+        1-D with shape [num_blocks] (BSR)
+
+    data_indptr:
+        1-D with shape [M + 1] (CSR) or
+        1-D with shape [(M + 1) // bs_r] (BSR)
+
+    weight:
+        2-D with shape [N, K], float32 when weight is dense
+
+    Returns
+    -------
+    output : tvm.te.Tensor
+        2-D with shape [M, N]
+    """
+    assert len(data_data.shape) in (1, 3)
+    if len(data_data.shape) == 1:
+        func = _sparse_dense_csrmm_v1
+    if len(data_data.shape) == 3:
+        func = _sparse_dense_bsrmm_v1
+    return func(data_data, data_indices, data_indptr, weight)
+
+def sparse_dense(input_1, input_2, input_3, input_4, sparse_data=False):
+    """
+    Computes sparse-dense matrix multiplication of `data` and
+    `(weight_data, weight_indices, weight_indptr).T`
+    or
+    Computes sparse-dense matrix multiplication of
+    `(data_data, data_indices, data_indptr)` and `weight.T`
+
+    Parameters
+    ----------
+    input_1 : tvm.te.Tensor
+        data:
+        2-D with shape [M, K], float32 when input data is dense or
+
+        data_data:
+        1-D with shape [nnz] (CSR) or
+        3-D with shape [num_blocks, bs_r, bs_c] (BSR)
+
+    input_2 : tvm.te.Tensor
+        weight_data:
+        1-D with shape [nnz] (CSR) or
+        3-D with shape [num_blocks, bs_r, bs_c] (BSR) or
+
+        data_indices:
+        1-D with shape [nnz] (CSR) or
+        1-D with shape [num_blocks] (BSR)
+
+    input_3 : tvm.te.Tensor
+        weight_indices:
+        1-D with shape [nnz] (CSR) or
+        1-D with shape [num_blocks] (BSR) or
+
+        data_indptr:
+        1-D with shape [M + 1] (CSR) or
+        1-D with shape [(M + 1) // bs_r] (BSR)
+
+    input_4 : tvm.te.Tensor
+        weight_indptr:
+        1-D with shape [N + 1] (CSR) or
+        1-D with shape [(N + 1) // bs_r] (BSR)
+
+        weight:
+        2-D with shape [N, K], float32 when weight is dense
+
+    Returns
+    -------
+    output : tvm.te.Tensor
+        2-D with shape [M, N]
+    """
+    if sparse_data:
+        return sparse_dense_v1(input_1, input_2, input_3, input_4)
+    else:
+        return sparse_dense_v2(input_1, input_2, input_3, input_4)
+
+def _sparse_dense_csrmm_v1(data_data, data_indices, data_indptr, weight):
+    oshape = (get_const_tuple(data_indptr.shape)[0] - 1, get_const_tuple(weight.shape)[0])
+
+    def f(row, i):
+        row_start = data_indptr[row]
+        row_end = data_indptr[row + 1]
+        row_elems = row_end - row_start
+        elem_idx = te.reduce_axis((0, row_elems), name="elem_idx")
+        elem = row_start + elem_idx
+        a_val = data_data[elem]
+        weight_val = weight[i, data_indices[elem]]
+        return te.sum(a_val * weight_val, axis=elem_idx)
+
+    return te.compute(oshape, f, tag="sparse_dense_csrmm_v1")
+
+def _sparse_dense_csrmm_v2(data, weight_data, weight_indices, weight_indptr):
     oshape = (get_const_tuple(data.shape)[0], get_const_tuple(weight_indptr.shape)[0] - 1)
 
     def f(i, row):
@@ -71,10 +173,37 @@ def _sparse_dense_csrmm(data, weight_data, weight_indices, weight_indptr):
         weight_val = data[i, weight_indices[elem]]
         return te.sum(a_val * weight_val, axis=elem_idx)
 
-    return te.compute(oshape, f, tag="sparse_dense_csrmm")
+    return te.compute(oshape, f, tag="sparse_dense_csrmm_v2")
 
+def _sparse_dense_bsrmm_v1(data_data, data_indices, data_indptr, weight):
+    (k, m) = get_const_tuple(weight.shape)
+    (l, bs_r, bs_c) = get_const_tuple(data_data.shape)
+    (num_blocks_plus_1,) = get_const_tuple(data_indptr.shape)
+    num_blocks = num_blocks_plus_1 - 1
 
-def _sparse_dense_bsrmm(data, weight_data, weight_indices, weight_indptr):
+    def _compute_block(nb_j, j, i):
+        row_start = data_indptr[nb_j]
+        row_end = data_indptr[nb_j + 1]
+        row_elems = row_end - row_start
+        elem_idx = te.reduce_axis((0, row_elems), name="elem_idx")
+        block_offset = row_start + elem_idx
+        c = te.reduce_axis((0, bs_c), name="c")
+        block_j = data_indices[block_offset]
+        block_ij_val = data_data[block_offset][j][c]
+        x_val = weight[i, bs_c * block_j + c]
+        return te.sum(block_ij_val * x_val, axis=[elem_idx, c])
+
+    idxd = tvm.tir.indexdiv
+    idxm = tvm.tir.indexmod
+
+    bsrmm_block = te.compute((num_blocks, bs_r, k), _compute_block, tag="sparse_dense_bsrmm_block_v1")
+    return te.compute(
+        (num_blocks * bs_r, k),
+        lambda m, n: bsrmm_block[idxd(n, bs_r), idxm(n, bs_r), m],
+        tag="sparse_dense_bsrmm_v1",
+    )
+
+def _sparse_dense_bsrmm_v2(data, weight_data, weight_indices, weight_indptr):
     (m, _) = get_const_tuple(data.shape)
     (_, bs_r, bs_c) = get_const_tuple(weight_data.shape)
     (num_blocks_plus_1,) = get_const_tuple(weight_indptr.shape)
@@ -95,13 +224,12 @@ def _sparse_dense_bsrmm(data, weight_data, weight_indices, weight_indptr):
     idxd = tvm.tir.indexdiv
     idxm = tvm.tir.indexmod
 
-    bsrmm_block = te.compute((m, num_blocks, bs_r), _compute_block, tag="sparse_dense_bsrmm_block")
+    bsrmm_block = te.compute((m, num_blocks, bs_r), _compute_block, tag="sparse_dense_bsrmm_block_v2")
     return te.compute(
         (m, num_blocks * bs_r),
         lambda m, n: bsrmm_block[m, idxd(n, bs_r), idxm(n, bs_r)],
-        tag="sparse_dense_bsrmm",
+        tag="sparse_dense_bsrmm_v2",
     )
-
 
 def sparse_transpose(sparse_data, sparse_indices, sparse_indptr):
     """

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -78,7 +78,7 @@ def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
         1-D with shape [(M + 1) // bs_r] (BSR)
 
     weight:
-        2-D with shape [N, K], float32 when weight is dense
+        2-D with shape [N, K], float32
 
     Returns
     -------

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -94,7 +94,7 @@ def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
 
 
 # pylint: disable=no-else-return,inconsistent-return-statements
-def sparse_dense(input_1, input_2, input_3, input_4, sparse_data=False):
+def sparse_dense(dense_data, sparse_data, sparse_indices, sparse_indptr, sparse_lhs=False):
     """
     Computes sparse-dense matrix multiplication of `data` and
     `(weight_data, weight_indices, weight_indptr).T`
@@ -104,49 +104,34 @@ def sparse_dense(input_1, input_2, input_3, input_4, sparse_data=False):
 
     Parameters
     ----------
-    input_1 : tvm.te.Tensor
+    dense_data : tvm.te.Tensor
         data:
         2-D with shape [M, K], float32 when input data is dense or
 
-        data_data:
-        1-D with shape [nnz] (CSR) or
-        3-D with shape [num_blocks, bs_r, bs_c] (BSR)
-
-    input_2 : tvm.te.Tensor
-        weight_data:
+    sparse_data : tvm.te.Tensor
         1-D with shape [nnz] (CSR) or
         3-D with shape [num_blocks, bs_r, bs_c] (BSR) or
 
-        data_indices:
-        1-D with shape [nnz] (CSR) or
-        1-D with shape [num_blocks] (BSR)
-
-    input_3 : tvm.te.Tensor
-        weight_indices:
+    sparse_indices : tvm.te.Tensor
         1-D with shape [nnz] (CSR) or
         1-D with shape [num_blocks] (BSR) or
 
-        data_indptr:
-        1-D with shape [M + 1] (CSR) or
-        1-D with shape [(M + 1) // bs_r] (BSR)
-
-    input_4 : tvm.te.Tensor
-        weight_indptr:
+    sparse_indptr : tvm.te.Tensor
         1-D with shape [N + 1] (CSR) or
         1-D with shape [(N + 1) // bs_r] (BSR)
 
-        weight:
-        2-D with shape [N, K], float32 when weight is dense
+    sparse_lhs : bool, optional
+        Indicates whether lhs or rhs matrix is sparse.
 
     Returns
     -------
     output : tvm.te.Tensor
         2-D with shape [M, N]
     """
-    if sparse_data:
-        return sparse_dense_v1(input_1, input_2, input_3, input_4)
+    if sparse_lhs:
+        return sparse_dense_v1(sparse_data, sparse_indices, sparse_indptr, dense_data)
     else:
-        return sparse_dense_v2(input_1, input_2, input_3, input_4)
+        return sparse_dense_v2(dense_data, sparse_data, sparse_indices, sparse_indptr)
 
 
 def _sparse_dense_csrmm_v1(data_data, data_indices, data_indptr, weight):

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -166,7 +166,7 @@ def _sparse_dense_csrmm_v2(data, weight_data, weight_indices, weight_indptr):
 
 
 def _sparse_dense_bsrmm_v1(data_data, data_indices, data_indptr, weight):
-    (k, _) = get_const_tuple(weight.shape)
+    (m, _) = get_const_tuple(weight.shape)
     (_, bs_r, bs_c) = get_const_tuple(data_data.shape)
     (num_blocks_plus_1,) = get_const_tuple(data_indptr.shape)
     num_blocks = num_blocks_plus_1 - 1
@@ -187,11 +187,11 @@ def _sparse_dense_bsrmm_v1(data_data, data_indices, data_indptr, weight):
     idxm = tvm.tir.indexmod
 
     bsrmm_block = te.compute(
-        (num_blocks, bs_r, k), _compute_block, tag="sparse_dense_bsrmm_block_v1"
+        (num_blocks, bs_r, m), _compute_block, tag="sparse_dense_bsrmm_block_v1"
     )
     return te.compute(
-        (num_blocks * bs_r, k),
-        lambda m, n: bsrmm_block[idxd(n, bs_r), idxm(n, bs_r), m],
+        (num_blocks * bs_r, m),
+        lambda m, n: bsrmm_block[idxd(m, bs_r), idxm(m, bs_r), n],
         tag="sparse_dense_bsrmm_v1",
     )
 

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -97,31 +97,30 @@ def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
 def sparse_dense(dense_data, sparse_data, sparse_indices, sparse_indptr, sparse_lhs=False):
     """
     Computes sparse-dense matrix multiplication of `data` and
-    `(weight_data, weight_indices, weight_indptr).T`
+    `(weight_data, weight_indices, weight_indptr).T`, if sparse_lhs=False
     or
     Computes sparse-dense matrix multiplication of
-    `(data_data, data_indices, data_indptr)` and `weight.T`
+    `(data_data, data_indices, data_indptr)` and `weight.T`, if sparse_lhs=True
 
     Parameters
     ----------
     dense_data : tvm.te.Tensor
-        data:
-        2-D with shape [M, K], float32 when input data is dense or
+        2-D with shape [M, K], float32
 
     sparse_data : tvm.te.Tensor
         1-D with shape [nnz] (CSR) or
-        3-D with shape [num_blocks, bs_r, bs_c] (BSR) or
+        3-D with shape [num_blocks, bs_r, bs_c] (BSR)
 
     sparse_indices : tvm.te.Tensor
         1-D with shape [nnz] (CSR) or
-        1-D with shape [num_blocks] (BSR) or
+        1-D with shape [num_blocks] (BSR)
 
     sparse_indptr : tvm.te.Tensor
         1-D with shape [N + 1] (CSR) or
         1-D with shape [(N + 1) // bs_r] (BSR)
 
     sparse_lhs : bool, optional
-        Indicates whether lhs or rhs matrix is sparse.
+        Indicates whether lhs or rhs matrix is sparse. Default value is False.
 
     Returns
     -------

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -93,6 +93,7 @@ def sparse_dense_v1(data_data, data_indices, data_indptr, weight):
     return func(data_data, data_indices, data_indptr, weight)
 
 
+# pylint: disable=no-else-return,inconsistent-return-statements
 def sparse_dense(input_1, input_2, input_3, input_4, sparse_data=False):
     """
     Computes sparse-dense matrix multiplication of `data` and
@@ -181,8 +182,8 @@ def _sparse_dense_csrmm_v2(data, weight_data, weight_indices, weight_indptr):
 
 
 def _sparse_dense_bsrmm_v1(data_data, data_indices, data_indptr, weight):
-    (k, m) = get_const_tuple(weight.shape)
-    (l, bs_r, bs_c) = get_const_tuple(data_data.shape)
+    (k, _) = get_const_tuple(weight.shape)
+    (_, bs_r, bs_c) = get_const_tuple(data_data.shape)
     (num_blocks_plus_1,) = get_const_tuple(data_indptr.shape)
     num_blocks = num_blocks_plus_1 - 1
 

--- a/src/relay/op/nn/sparse.cc
+++ b/src/relay/op/nn/sparse.cc
@@ -39,6 +39,35 @@ TVM_REGISTER_NODE_TYPE(SparseDenseAttrs);
 bool SparseDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                     const TypeReporter& reporter) {
   ICHECK_EQ(types.size(), 5);
+  const auto* param = attrs.as<SparseDenseAttrs>();
+  ICHECK(param != nullptr);
+
+  if (param->sparse_data) {
+        const auto* weight = types[3].as<TensorTypeNode>();
+      const auto* data_data = types[0].as<TensorTypeNode>();
+      ICHECK(data_data->shape.size() == 1 || data_data->shape.size() == 3);
+      const auto* data_indptr = types[2].as<TensorTypeNode>();
+      if (weight == nullptr) return false;
+
+      if (data_data->shape.size() == 1) {
+        // CSR case.
+        Array<IndexExpr> oshape({data_indptr->shape[0] - 1, weight->shape[0]});
+        reporter->Assign(types[4], TensorType(oshape, weight->dtype));
+        return true;
+      }
+
+      if (data_data->shape.size() == 3) {
+        // BSR case.
+        Array<IndexExpr> oshape(
+            {(data_indptr->shape[0] - 1) * data_data->shape[1], weight->shape[0]});
+        reporter->Assign(types[4], TensorType(oshape, weight->dtype));
+        return true;
+      }
+      LOG(FATAL) << "Unknown data ndim for nn.sparse_dense, should be 1 (CSR) or 3 (BSR)";
+      return false;
+  
+  }else {
+  
   const auto* data = types[0].as<TensorTypeNode>();
   const auto* weight_data = types[1].as<TensorTypeNode>();
   ICHECK(weight_data->shape.size() == 1 || weight_data->shape.size() == 3);
@@ -61,22 +90,24 @@ bool SparseDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   }
   LOG(FATAL) << "Unknown weight ndim for nn.sparse_dense, should be 1 (CSR) or 3 (BSR)";
   return false;
+  }
 }
 
 // Positional relay function to create dense operator used by frontend FFI.
-Expr MakeSparseDense(Expr data, Expr weight_data, Expr weight_indices, Expr weight_indptr) {
+Expr MakeSparseDense(Expr data, Expr weight_data, Expr weight_indices, Expr weight_indptr, bool sparse_data) {
   auto attrs = make_object<SparseDenseAttrs>();
+  attrs->sparse_data = std::move(sparse_data);
   static const Op& op = Op::Get("nn.sparse_dense");
   return Call(op, {data, weight_data, weight_indices, weight_indptr}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relay.op.nn._make.sparse_dense")
     .set_body([](const TVMArgs& args, TVMRetValue* rv) {
-      runtime::detail::unpack_call<Expr, 4>(MakeSparseDense, args, rv);
+      runtime::detail::unpack_call<Expr, 5>(MakeSparseDense, args, rv);
     });
 
 RELAY_REGISTER_OP("nn.sparse_dense")
-    .describe(R"code(Applies a sparse linear transformation: :math:`Y = XW^T` with W sparse.
+    .describe(R"code(Applies a sparse linear transformation: :math:`Y = XW^T` with either X or W sparse.
 
 - **data**: `(x1, x2, ..., xn, input_dim)`
 - **weight**: `(units, input_dim)`
@@ -85,10 +116,10 @@ RELAY_REGISTER_OP("nn.sparse_dense")
 )code" TVM_ADD_FILELINE)
     .set_attrs_type<SparseDenseAttrs>()
     .set_num_inputs(4)
-    .add_argument("data", "nD Tensor", "Input data.")
-    .add_argument("weight_data", "1D Tensor", "Weight data matrix.")
-    .add_argument("weight_indices", "1D Tensor", "Weight indices matrix.")
-    .add_argument("weight_indptr", "1D Tensor", "Weight indptr matrix.")
+    .add_argument("input_tensor1", "nD Tensor", "Input data if dense, otherwise data_data matrix if sparse.")
+    .add_argument("input_tensor2", "nD Tensor", "Weight_data matrix or data_indices matrix.")
+    .add_argument("input_tensor3", "nD Tensor", "Weight_indices matrix or data_indptr matrix.")
+    .add_argument("input_tensor4", "nD Tensor", "Weight_indptr matrix or weight matrix if dense.")
     .set_support_level(1)
     .add_type_rel("SparseDense", SparseDenseRel);
 

--- a/src/relay/transforms/convert_sparse_dense.cc
+++ b/src/relay/transforms/convert_sparse_dense.cc
@@ -103,8 +103,10 @@ class DenseToSparseDenseMutator : public ExprRewriter {
           Var weight_data(prefix + ".data", ws_data_type);
           Var weight_indices(prefix + ".indices", ws_indices_type);
           Var weight_indptr(prefix + ".indptr", ws_indptr_type);
+          auto attrs = make_object<SparseDenseAttrs>();
 
-          return Call(sparse_dense_op_, {data, weight_data, weight_indices, weight_indptr});
+          return Call(sparse_dense_op_, {data, weight_data, weight_indices, weight_indptr},
+                      Attrs(attrs));
         }
       }
     }

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1794,9 +1794,15 @@ def test_forward_sparse_dense_matmul():
     #
     # ------------------------------------------------------------------
 
-    # TODO(ANSHUMAN87): False case for flip need to be supported
-    # _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 4], [4, 3], "float32")
-    _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 5], [4, 3], "float32", True)
+    _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 4], [4, 3], "float32")
+    _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 3], [3, 3], "float32")
+    _test_sparse_dense_matmul(
+        [[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [5, 5], [5, 5], "float32"
+    )
+    _test_sparse_dense_matmul(
+        [[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [7, 9], [9, 5], "float32"
+    )
+    _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [4, 3], [3, 4], "float32", True)
     _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 3], [3, 3], "float32", True)
     _test_sparse_dense_matmul(
         [[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [5, 5], [5, 5], "float32", True

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1796,12 +1796,8 @@ def test_forward_sparse_dense_matmul():
 
     _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 4], [4, 3], "float32")
     _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 3], [3, 3], "float32")
-    _test_sparse_dense_matmul(
-        [[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [5, 5], [5, 5], "float32"
-    )
-    _test_sparse_dense_matmul(
-        [[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [7, 9], [9, 5], "float32"
-    )
+    _test_sparse_dense_matmul([[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [5, 5], [5, 5], "float32")
+    _test_sparse_dense_matmul([[0, 0], [1, 3], [4, 3]], [3.0, 6.0, 9.0], [7, 9], [9, 5], "float32")
     _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [4, 3], [3, 4], "float32", True)
     _test_sparse_dense_matmul([[0, 0], [1, 2]], [4.0, 8.0], [3, 3], [3, 3], "float32", True)
     _test_sparse_dense_matmul(


### PR DESCRIPTION
Change Summary:
  Current sparse_dense Op in Topi support only weight as sparse input.
This PR add support for data also to be as sparse input.
So, in either case any one can be a sparse and other one will be dense.

This is a follow up PR from #6685

cc @tkonolige , @siju-samuel !
