### PR TITLE
[Relay] add ShapeFunc for tanh

### DIFF
--- a/python/tvm/relay/op/_tensor.py
+++ b/python/tvm/relay/op/_tensor.py
@@ -276,3 +276,5 @@ register_shape_func("device_copy", False, elemwise_shape_func)
 register_shape_func("clip", False, elemwise_shape_func)
 register_shape_func("log2", False, elemwise_shape_func)
 register_shape_func("sigmoid", False, elemwise_shape_func)
+register_shape_func("tanh", False, elemwise_shape_func)
+

--- a/python/tvm/relay/op/_tensor.py
+++ b/python/tvm/relay/op/_tensor.py
@@ -277,4 +277,3 @@ register_shape_func("clip", False, elemwise_shape_func)
 register_shape_func("log2", False, elemwise_shape_func)
 register_shape_func("sigmoid", False, elemwise_shape_func)
 register_shape_func("tanh", False, elemwise_shape_func)
-

--- a/python/tvm/topi/cuda/dense.py
+++ b/python/tvm/topi/cuda/dense.py
@@ -77,8 +77,8 @@ def schedule_dense_small_batch(cfg, outs):
 
 
 def _schedule_dense_small_batch(cfg, s, C):
-    A, _ = C.op.input_tensors
-    _, in_dim = get_const_tuple(A.shape)
+    A, weights = C.op.input_tensors
+    _, in_dim = get_const_tuple(weights.shape)
     cfg.define_split("tile_k", in_dim, num_outputs=2)
     if cfg.is_fallback:
         cfg["tile_k"] = SplitEntity([-1, 64] if in_dim > 64 else [1, 64])

--- a/python/tvm/topi/cuda/dense.py
+++ b/python/tvm/topi/cuda/dense.py
@@ -88,7 +88,7 @@ def _schedule_dense_small_batch(cfg, s, C):
     else:
         in_dim = None
 
-    if in_dim != None:
+    if in_dim is not None:
         cfg.define_split("tile_k", in_dim, num_outputs=2)
         if cfg.is_fallback:
             cfg["tile_k"] = SplitEntity([-1, 64] if in_dim > 64 else [1, 64])
@@ -113,7 +113,6 @@ def _schedule_dense_small_batch(cfg, s, C):
     s[CF].compute_at(s[C], tx)
     s[C].set_store_predicate(thread_x.var.equal(0))
     s[Out].set_store_predicate(thread_x.var.equal(0))
-
 
 
 @autotvm.register_topi_compute("dense_large_batch.cuda")


### PR DESCRIPTION
Enable run static lstm on relay vm by dynamic batch:
1. add ShapeFunc for tanh
2. get in_dim from weights in `_schedule_dense_small_batch ` instead of input in case input's shape's second dim is unknown.

@wweic 