### PR TITLE
[Relay] Add TypeRelationFn for Tuple

### DIFF
--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -56,7 +56,8 @@ Doc RelayTextPrinter::PrintOptionalInfo(const Expr& expr) {
   Doc doc;
   // default annotations
   if (annotate_ == nullptr) {
-    if ((expr.as<ConstantNode>() || expr.as<CallNode>()) && expr->checked_type_.defined()) {
+    if ((expr.as<ConstantNode>() || expr.as<CallNode>() || expr.as<IfNode>()) &&
+        expr->checked_type_.defined()) {
       doc << " /* ty=" << Print(expr->checked_type()) << " */";
     }
   } else {

--- a/src/relay/op/memory/memory.cc
+++ b/src/relay/op/memory/memory.cc
@@ -171,7 +171,6 @@ bool AllocTensorRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
     ICHECK(alloc_attrs->assert_shape.defined())
         << "the assert_shape must be set when const_shape is not";
     alloc_type = TensorType(alloc_attrs->assert_shape, alloc_attrs->dtype);
-    return true;
   }
 
   reporter->Assign(types[3], alloc_type);


### PR DESCRIPTION
This PR is to fix a type inference issue:
In Following IR, meta[relay.Constant][0] is a relay.Const with type TensorType([1, 4], "float32")
```
free_var %f: fn () -> bool;
%0 = %f() /* ty=bool */;
%1 = if (%0) {
  meta[relay.Constant][0] /* ty=Tensor[(?, ?), float32] */
} else {
  free_var %v0: Tensor[(2), float32];
  dyn.full(0 /* ty=int32 */, %v0, shape=None, dtype="float32") /* ty=Tensor[(?, ?), float32] */
} /* ty=Tensor[(?, ?), float32] */;
%2 = (%1,);
concatenate(%2) /* ty=Tensor[(1, 4), float32] */
```
the inferred type of `concatenate` is `Tensor[(1, 4), float32]`, but it should be Tensor[(?, ?), float32] because the type of `If` is Tensor[(?, ?), float32]

With this PR:
```
free_var %f: fn () -> bool;
%0 = %f() /* ty=bool */;
%1 = if (%0) {
  meta[relay.Constant][0] /* ty=Tensor[(?, ?), float32] */
} else {
  free_var %v0: Tensor[(2), float32];
  dyn.full(0 /* ty=int32 */, %v0, shape=None, dtype="float32") /* ty=Tensor[(?, ?), float32] */
} /* ty=Tensor[(?, ?), float32] */;
%2 = (%1,);
concatenate(%2) /* ty=Tensor[(?, ?), float32] */
```

#3589 tried to add this TypeRelationFn but it isn't merged. @jroesch @icemelon9 @MarisaKirisame  Could you please take a look?