### PR TITLE
Add retry to sockets on EINTR error

### DIFF
--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -78,12 +78,12 @@ namespace support {
 template <typename FUNC>
 ssize_t RetryCallOnEINTR(FUNC f) {
   size_t retry_count = 8;
-  ssize_t rc = f();
-  while (--retry_count && rc == -1 && errno == EINTR) {
-    rc = f();
+  ssize_t rc = -1;
+  while (--retry_count && (rc = f()) == -1 && errno == EINTR) {
   }
   return rc;
 }
+
 
 /*!
  * \brief Get current host name.


### PR DESCRIPTION
Long-running system calls like socket recv or send may be interrupted and should be retried. If a call is interrupted errno is set to EINTR. Added retry_call which retries a call in hopes of reducing the occurrence of this error.