### PR TITLE
Fix #6954 uTVM, fix when building the runtime for native hardware

### DIFF
--- a/python/tvm/micro/compiler.py
+++ b/python/tvm/micro/compiler.py
@@ -139,9 +139,11 @@ class Compiler(metaclass=abc.ABCMeta):
         opts = []
         # TODO use march for arm(https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html)?
         if target.attrs.get("mcpu"):
-            opts.append(f'-march={target.attrs["mcpu"]}')
+            opts.append(f'-mcpu={target.attrs["mcpu"]}')
         if target.attrs.get("mfpu"):
             opts.append(f'-mfpu={target.attrs["mfpu"]}')
+        if target.attrs.get("march"):
+            opts.append(f'-march={target.attrs["march"]}')
 
         return opts
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -233,7 +233,7 @@ def micro(model="unknown", options=None):
     """
     trans_table = {
         "host": ["-mcpu=native"],
-        "stm32f746xx": ["-mcpu=cortex-m7"],
+        "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
     }
     opts = _merge_opts(
         trans_table[model] + ["-runtime=c", "--system-lib", f"-model={model}"], options

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -219,6 +219,7 @@ TVM_REGISTER_TARGET_KIND("c", kDLCPU)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<String>("runtime")
     .add_attr_option<String>("mcpu")
+    .add_attr_option<String>("march")
     .set_default_keys({"cpu"});
 
 TVM_REGISTER_TARGET_KIND("cuda", kDLGPU)


### PR DESCRIPTION
with -march= is missing.

This fix:
1) adds support for march
2) picks a senable setting for f746 discovery

There is an interesting downside to this fix involving scheduling that likely needs discussion.
In the microcontroller world we really should be setting ex: -march=armv7e-m depending on what
cortex-m is being used.

-mcpu isn't as important when it comes to a command line compiler.

Signed-off-by: Tom Gall <tom.gall@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
