### PR TITLE
Fixes #6960 - strncpy destination size warning

### DIFF
--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -38,7 +38,7 @@
 
 static char g_last_error[1024];
 
-void TVMAPISetLastError(const char* msg) { strncpy(g_last_error, msg, sizeof(g_last_error)); }
+void TVMAPISetLastError(const char* msg) { strncpy(g_last_error, msg, sizeof(g_last_error-1)); }
 
 __attribute__((format(printf, 1, 2))) int TVMAPIErrorf(const char* msg, ...) {
   va_list args;

--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -38,7 +38,7 @@
 
 static char g_last_error[1024];
 
-void TVMAPISetLastError(const char* msg) { strncpy(g_last_error, msg, sizeof(g_last_error-1)); }
+void TVMAPISetLastError(const char* msg) { strncpy(g_last_error, msg, (sizeof(g_last_error)-1)); }
 
 __attribute__((format(printf, 1, 2))) int TVMAPIErrorf(const char* msg, ...) {
   va_list args;


### PR DESCRIPTION
The destination of the strncpy has to be larger then the source, otherwise
specified bound 1024 equals destination size [-Werror=stringop-truncation]
will occur.

Signed-off-by: Tom Gall <tom.gall@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
