### PR TITLE
Bug fix for debug builds in micro_session.cc

### DIFF
--- a/src/runtime/micro/micro_session.cc
+++ b/src/runtime/micro/micro_session.cc
@@ -148,9 +148,10 @@ class MicroTransportChannel : public RPCChannel {
             ::std::max(::std::chrono::microseconds{0},
                        ::std::chrono::duration_cast<::std::chrono::microseconds>(
                            end_time - ::std::chrono::steady_clock::now()))};
-        chunk = frecv_(kReceiveBufferSizeBytes, iter_timeout.count()).operator std::string();
+        chunk =
+            frecv_(size_t(kReceiveBufferSizeBytes), iter_timeout.count()).operator std::string();
       } else {
-        chunk = frecv_(kReceiveBufferSizeBytes, nullptr).operator std::string();
+        chunk = frecv_(size_t(kReceiveBufferSizeBytes), nullptr).operator std::string();
       }
       pending_chunk_ = chunk;
       if (pending_chunk_.size() == 0) {


### PR DESCRIPTION
* kReceiveBufferSizeBytes is declared but not defined (as it is a static constexpr)
* If the build decides not to inline kReceiveBufferSizeBytes, we will encounter a linking error.
* This was seen as an issue in the Debug builds.

Discuss : https://discuss.tvm.apache.org/t/ci-c-standard-for-the-tvm-project/8508/3

cc: @areusch @tqchen 
