### PR TITLE
[CI] Disable ASF header checking on untracked files

### DIFF
--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -31,7 +31,7 @@ echo "Checking file types..."
 python3 tests/lint/check_file_type.py
 
 echo "Checking ASF license headers..."
-tests/lint/check_asf_header.sh
+tests/lint/check_asf_header.sh --local
 
 echo "Linting the C++ code..."
 tests/lint/cpplint.sh


### PR DESCRIPTION
* This patch will disable checking for ASF header in untracked
  files that are never going to make its way into the repo.
* That would help developers to have their untracked local files.

cc: @tqchen 