### PR TITLE
build: Do not ASF check files not under version control

### DIFF
--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -31,7 +31,7 @@ echo "Checking file types..."
 python3 tests/lint/check_file_type.py
 
 echo "Checking ASF license headers..."
-tests/lint/check_asf_header.sh
+tests/lint/check_asf_header.sh --local
 
 echo "Linting the C++ code..."
 tests/lint/cpplint.sh


### PR DESCRIPTION
The current behaviour of checking all files in the tree irrespective
of whether they are under version control means that it is not
possible to run the toplevel build and test in the same tree twice
because the second invocation will observe build products from the
first invocation and those will fail the check.  Since we already have
the logic in place to filter the header check down to just the files
under version control, simply enabling that filter is the most
straight forward route to allowing these script to be re-executed
multiple times.

