### PR TITLE
Fix GraphRuntime with -link-params over RPC

### DIFF
--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -187,7 +187,7 @@ def lookup_remote_linked_param(mod, storage_id, template_tensor, ctx):
         return None
 
     return get_global_func("tvm.rpc.NDArrayFromRemoteOpaqueHandle")(
-        mod, remote_data, template_tensor, ctx, lambda: None
+        mod, remote_data, template_tensor, ctx, None
     )
 
 

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -378,7 +378,7 @@ def test_crt_link_params():
             }
             flasher = compiler.flasher(**flasher_kw)
             with tvm.micro.Session(binary=micro_binary, flasher=flasher) as sess:
-                graph_rt = tvm.micro.session.create_remote_graph_runtime(
+                graph_rt = tvm.micro.session.create_local_graph_runtime(
                     graph_json, sess.get_system_lib(), sess.context
                 )
 

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -378,8 +378,9 @@ def test_crt_link_params():
             }
             flasher = compiler.flasher(**flasher_kw)
             with tvm.micro.Session(binary=micro_binary, flasher=flasher) as sess:
-                rpc_lib = sess.get_system_lib()
-                graph_rt = tvm.contrib.graph_runtime.create(graph_json, rpc_lib, sess.context)
+                graph_rt = tvm.micro.session.create_remote_graph_runtime(
+                    graph_json, sess.get_system_lib(), sess.context
+                )
 
                 # NOTE: not setting params here.
                 graph_rt.set_input("rand_input", rand_input)


### PR DESCRIPTION
NDArray handle is passed incorrectly. Unit test didn't properly exercise this case--fixed test and bug.