### PR TITLE
[Hardware][Verilator] Separate Verilator dependency from Chisel dependencies

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -69,8 +69,12 @@ COPY install/ubuntu_install_universal.sh /install/ubuntu_install_universal.sh
 RUN bash /install/ubuntu_install_universal.sh
 
 # Chisel deps for TSIM
-COPY install/ubuntu_install_chisel.sh /install/ubuntu_install_chisel.sh
-RUN bash /install/ubuntu_install_chisel.sh
+COPY install/ubuntu_install_sbt.sh /install/ubuntu_install_sbt.sh
+RUN bash /install/ubuntu_install_sbt.sh
+
+# Verilator deps
+COPY install/ubuntu_install_verilator.sh /install/ubuntu_install_verilator.sh
+RUN bash /install/ubuntu_install_verilator.sh
 
 # TFLite deps
 COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh

--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -43,5 +43,9 @@ COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh
 RUN bash /install/ubuntu_install_redis.sh
 
 # Chisel deps for TSIM
-COPY install/ubuntu_install_chisel.sh /install/ubuntu_install_chisel.sh
-RUN bash /install/ubuntu_install_chisel.sh
+COPY install/ubuntu_install_sbt.sh /install/ubuntu_install_sbt.sh
+RUN bash /install/ubuntu_install_sbt.sh
+
+# Verilator deps
+COPY install/ubuntu_install_verilator.sh /install/ubuntu_install_verilator.sh
+RUN bash /install/ubuntu_install_verilator.sh

--- a/docker/install/ubuntu_install_sbt.sh
+++ b/docker/install/ubuntu_install_sbt.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+# The https:// source added below required an apt https transport
+# support.
+apt-get update && apt-get install -y apt-transport-https
+
+# Install the necessary dependencies for sbt
+echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+
+# Note: The settings in vta/hardware/chisel/project/build.properties
+# file determines required sbt version.
+apt-get update && apt-get install -y sbt=1.1.1

--- a/docker/install/ubuntu_install_verilator.sh
+++ b/docker/install/ubuntu_install_verilator.sh
@@ -20,22 +20,17 @@ set -e
 set -u
 set -o pipefail
 
-# The https:// source added below required an apt https transport
-# support.
-apt-get update && apt-get install -y apt-transport-https flex bison
+# Verilator version
+version="4.104"
 
-# Install the necessary dependencies for Chisel
-echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+# Install dependencies
+apt-get update && apt-get install -y autoconf g++ flex bison
 
-# Note: The settings in vta/hardware/chisel/project/build.properties
-# file determines required sbt version.
-apt-get update && apt-get install -y sbt=1.1.1
-
-# Install the Verilator with major version 4.0
-wget https://www.veripool.org/ftp/verilator-4.010.tgz
-tar xf verilator-4.010.tgz
-cd verilator-4.010/
+# Install Verilator
+wget "https://github.com/verilator/verilator/archive/v$version.tar.gz"
+tar xf "v$version.tar.gz"
+cd "verilator-$version"
+autoconf
 ./configure
 make -j4
 make install


### PR DESCRIPTION
Hey guys,

I am separating the Verilator dependency from Chisel dependencies, so we can reuse this for the Verilator backend (CI).

What do you think?

@tmoreau89 @liangfu 