### PR TITLE
[µTVM] Demote session traffic logs to DEBUG log level

### DIFF
--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -124,7 +124,7 @@ class Session:
             self.transport_context_manager = self.flasher.flash(self.binary)
 
         self.transport = TransportLogger(
-            self.session_name, self.transport_context_manager, level=logging.INFO
+            self.session_name, self.transport_context_manager, level=logging.DEBUG
         ).__enter__()
 
         try:


### PR DESCRIPTION
INFO log level was aggressive to begin with, and an override exists.

@tqchen 