### PR TITLE
[Backend][Verilator] Multiple fixes

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -232,7 +232,7 @@ set(USE_TENSORRT_RUNTIME OFF)
 # Whether use VITIS-AI codegen
 set(USE_VITIS_AI OFF)
 
-# Build Verilator codegen and runtime, example located in 3rdparty/hw-widgets
+# Build Verilator codegen and runtime, example located in 3rdparty/vta-hw/apps/verilator
 set(USE_VERILATOR_HW OFF)
 
 # Build ANTLR parser for Relay text format

--- a/cmake/modules/contrib/Verilator.cmake
+++ b/cmake/modules/contrib/Verilator.cmake
@@ -16,10 +16,11 @@
 # under the License.
 
 if(USE_VERILATOR_HW STREQUAL "ON")
+  execute_process(COMMAND make --directory ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/vta-hw/apps/verilator)
   file(GLOB VERILATOR_RELAY_CONTRIB_SRC src/relay/backend/contrib/verilator/codegen.cc)
   list(APPEND COMPILER_SRCS ${VERILATOR_RELAY_CONTRIB_SRC})
   list(APPEND COMPILER_SRCS ${JSON_RELAY_CONTRIB_SRC})
-  find_library(EXTERN_LIBRARY_VERILATOR NAMES verilator PATHS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/hw-widgets)
+  find_library(EXTERN_LIBRARY_VERILATOR NAMES verilator PATHS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/vta-hw/apps/verilator)
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${EXTERN_LIBRARY_VERILATOR})
   file(GLOB VERILATOR_CONTRIB_SRC src/runtime/contrib/verilator/verilator_runtime.cc)
   list(APPEND RUNTIME_SRCS ${VERILATOR_CONTRIB_SRC})


### PR DESCRIPTION
The following PR fixes certain things to make the Verilator backend to work, including:

* Bumping `vta-hw` version
* Fix path to Verilator library
* Automatically build Verilator library when using the backend
* Update comments

@tmoreau89 