### PR TITLE
[TFLite] Strided slice handling of shrink_axis_mask improved

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1583,13 +1583,18 @@ class OperatorConverter(object):
 
         # Create final output shape.
         final_output = []
+        final_len = len(fshape_indices)
         for gather_index in fshape_indices:
             if gather_index == -1:
                 final_output.append(1)
+                final_len += 1
             elif gather_index == -2:
-                pass
+                final_len -= 1
             else:
                 final_output.append(out_shape[gather_index])
+
+        if final_len == 0:
+            return _op.squeeze(out, axis=tuple(range(len(fshape_indices))))
 
         if not final_output:
             return out

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -74,6 +74,9 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=1e-7):
     compares the `abs(actual-desired)` with `atol+rtol*abs(desired)`.  Since we
     often allow `desired` to be close to zero, we generally want non-zero `atol`.
     """
+    actual = np.asanyarray(actual)
+    desired = np.asanyarray(desired)
+    np.testing.assert_allclose(actual.shape, desired.shape)
     np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol, verbose=True)
 
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -583,6 +583,24 @@ def _test_stridedslice(
 def test_forward_stridedslice():
     """test StridedSlice"""
     for quantized in [False, True]:
+        _test_stridedslice(
+            (1, 3, 3),
+            [0, 0, 0],
+            [3, 3, 3],
+            [1, 1, 1],
+            "float32",
+            shrink_axis_mask=7,
+            quantized=quantized,
+        )
+        _test_stridedslice(
+            (1, 3, 3),
+            [0, 0, 0],
+            [3, 3, 3],
+            [1, 1, 1],
+            "float32",
+            shrink_axis_mask=5,
+            quantized=quantized,
+        )
         _test_stridedslice((2), [1], [1], [1], "float32", shrink_axis_mask=1, quantized=quantized)
         _test_stridedslice(
             (3, 4, 3), [1, -1, 0], [4, -5, 3], [2, -1, 1], "float32", quantized=quantized

--- a/tests/python/integration/test_dot.py
+++ b/tests/python/integration/test_dot.py
@@ -27,7 +27,7 @@ def test_dot():
     A = te.placeholder((n,), name="A")
     B = te.placeholder((n,), name="B")
     k = te.reduce_axis((0, n), "k")
-    C = te.compute((1,), lambda _: te.sum(A[k] * B[k], axis=k), name="C")
+    C = te.compute((), lambda: te.sum(A[k] * B[k], axis=k), name="C")
     s = te.create_schedule(C.op)
 
     def verify(target):
@@ -36,7 +36,7 @@ def test_dot():
         ctx = tvm.cpu(0)
         a = tvm.nd.array(np.random.uniform(size=(nn,)).astype(A.dtype), ctx)
         b = tvm.nd.array(np.random.uniform(size=(nn,)).astype(B.dtype), ctx)
-        c = tvm.nd.array(np.zeros((1,), dtype=C.dtype), ctx)
+        c = tvm.nd.array(np.zeros((), dtype=C.dtype), ctx)
         f(a, b, c)
         tvm.testing.assert_allclose(c.asnumpy(), np.dot(a.asnumpy(), b.asnumpy()), rtol=1e-4)
 


### PR DESCRIPTION
1. Added removal of dimensions if result is a scalar
to mimic TensorFlow behaviour. E.g.:
    tf.strided_slice([1,2,3], [0], [1], [1], shrink_axis_mask=0)
    <tf.Tensor: shape=(1,), dtype=int32, numpy=array([1], dtype=int32)>

    tf.strided_slice([[[1,2,3],[4,5,6],[7,8,9]]], [0, 0, 0], [3, 3, 3], [1, 1, 1], shrink_axis_mask=7)
    <tf.Tensor: shape=(), dtype=int32, numpy=1>

2. Added extra check to assert_allclose to check shape equalities
as np.testing.assert_allclose() does not distinguish between cases like:

    np.testing.assert_allclose(1, np.array(1))
    np.testing.assert_allclose(1, np.array([1]))
    np.testing.assert_allclose(np.array(1), np.array([1]))