### PR TITLE
[frontend][keras] Add support for TimeDistributed

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1470,7 +1470,11 @@ def from_keras(model, shape=None, layout="NCHW"):
                     inexpr = inexpr[0]
                 outs.extend(
                     keras_op_to_relay(
-                        inexpr, keras_layer, scope + keras_layer.name + ":" + str(node_idx), etab, layout
+                        inexpr,
+                        keras_layer,
+                        scope + keras_layer.name + ":" + str(node_idx),
+                        etab,
+                        layout
                     )
                 )
         return outs

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -65,7 +65,9 @@ def _convert_recurrent_activation(inexpr, keras_layer):
     return _convert_activation(inexpr, act_type, None, None, None)
 
 
-def _convert_activation(inexpr, keras_layer, _, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_activation(
+        inexpr, keras_layer, _, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     if isinstance(keras_layer, str):
         act_type = keras_layer
     else:
@@ -233,7 +235,9 @@ def _convert_permute(inexpr, keras_layer, _, input_shape=None, data_layout=None)
     return _op.transpose(inexpr, axes=(0,) + keras_layer.dims)
 
 
-def _convert_embedding(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_embedding(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     indices = inexpr
     weightList = keras_layer.get_weights()
     weight = etab.new_const(weightList[0])
@@ -242,7 +246,9 @@ def _convert_embedding(inexpr, keras_layer, etab, input_shape=None, data_layout=
     return out
 
 
-def _convert_dense(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_dense(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     weightList = keras_layer.get_weights()
     weight = etab.new_const(weightList[0].transpose([1, 0]))
     params = {"weight": weight, "units": weightList[0].shape[1]}
@@ -603,7 +609,9 @@ def _convert_separable_convolution(inexpr, keras_layer, etab, input_shape=None, 
     return out
 
 
-def _convert_flatten(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_flatten(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -711,7 +719,9 @@ def _convert_pooling3d(inexpr, keras_layer, etab, input_shape=None, data_layout=
     return _op.transpose(out, axes=(0, 2, 3, 4, 1))
 
 
-def _convert_global_pooling3d(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_global_pooling3d(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -731,7 +741,9 @@ def _convert_global_pooling3d(inexpr, keras_layer, etab, input_shape=None, data_
     return _convert_flatten(out, keras_layer, etab, input_shape, data_layout)
 
 
-def _convert_upsample(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_upsample(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -762,7 +774,9 @@ def _convert_upsample(inexpr, keras_layer, etab, input_shape=None, data_layout=N
     return out
 
 
-def _convert_upsample3d(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_upsample3d(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -778,7 +792,9 @@ def _convert_upsample3d(inexpr, keras_layer, etab, input_shape=None, data_layout
     return out
 
 
-def _convert_cropping(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_cropping(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     crop_type = type(keras_layer).__name__
     if input_shape is None:
@@ -835,7 +851,9 @@ def _convert_batchnorm(inexpr, keras_layer, etab, input_shape=None, data_layout=
     return result
 
 
-def _convert_padding(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_padding(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -912,7 +930,9 @@ def _convert_padding3d(inexpr, keras_layer, etab, input_shape=None, data_layout=
     return out
 
 
-def _convert_concat(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_concat(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if input_shape is None:
         input_shape = keras_layer.input_shape
@@ -946,7 +966,9 @@ def _convert_reshape(inexpr, keras_layer, etab, input_shape=None, data_layout=No
     return _op.reshape(inexpr, newshape=shape)
 
 
-def _convert_lstm(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_lstm(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if input_shape is None:
         input_shape = keras_layer.input_shape
@@ -987,7 +1009,9 @@ def _convert_lstm(inexpr, keras_layer, etab, input_shape=None, data_layout=None)
     return [out, next_h, next_c]
 
 
-def _convert_simple_rnn(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_simple_rnn(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if not isinstance(inexpr, list):
         buf = np.zeros((1, keras_layer.units), "float32")
@@ -1011,7 +1035,9 @@ def _convert_simple_rnn(inexpr, keras_layer, etab, input_shape=None, data_layout
     return [output, output]
 
 
-def _convert_gru(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_gru(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if not isinstance(inexpr, list):
         buf = np.zeros((1, keras_layer.units), "float32")
@@ -1054,7 +1080,9 @@ def _convert_gru(inexpr, keras_layer, etab, input_shape=None, data_layout=None):
     return [output, output]
 
 
-def _convert_repeat_vector(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_repeat_vector(
+        inexpr, keras_layer, etab, input_shape=None, data_layout=None
+): # pylint: disable=unused-argument
     if input_shape is None:
         input_shape = keras_layer.input_shape
     input_shape = list(input_shape)
@@ -1182,21 +1210,22 @@ def _convert_time_distributed(inexpr, keras_layer, etab, input_shape=None, data_
 
     # for NDHWC, inner data layout will drop the D
     inner_data_layout = None
-    if data_layout == 'NDHWC':
-        inner_data_layout = 'NHWC'
+    if data_layout == "NDHWC":
+        inner_data_layout = "NHWC"
 
     # some code duplication from keras_op_to_relay
     # but it's useful to avoid cluttering the etab
     inner_layer_op_name = type(keras_layer.layer).__name__
     if inner_layer_op_name not in _convert_map:
         raise tvm.error.OpNotImplemented(
-            ("The inner layer for TimeDistributed {}"
-             + " is not supported for frontend Keras.").format(
+            (
+                "The inner layer for TimeDistributed {} is not supported for frontend Keras."
+            ).format(
                 inner_layer_op_name))
 
     conversion_func = lambda expr: _convert_map[inner_layer_op_name](
-        expr, inner_layer, etab,
-        input_shape=inner_input_shape, data_layout=inner_data_layout)
+        expr, inner_layer, etab, input_shape=inner_input_shape, data_layout=inner_data_layout
+    )
 
     split_dim = input_shape[1]
     split_input = _op.split(inexpr, split_dim, 1)
@@ -1206,22 +1235,23 @@ def _convert_time_distributed(inexpr, keras_layer, etab, input_shape=None, data_
         split_shape[0] = 1
     split_shape[1] = 1
 
-    split_var = new_var('time_distributed_split',
-                        type_annotation=TupleType([
-                            TensorType(split_shape, dtype="float32")
-                            for i in range(split_dim)
-                        ]))
+    split_var = new_var(
+        'time_distributed_split',
+        type_annotation=TupleType(
+            [TensorType(split_shape, dtype="float32") for i in range(split_dim)]
+        ),
+    )
 
     # For each split, squeeze away the second dimension,
     # apply the inner layer.
     # Afterwards, combine the transformed splits back along
     # the second dimension using stack
-    splits = [conversion_func(
-        _op.squeeze(_expr.TupleGetItem(split_var, i), axis=[1]))
-              for i in range(split_dim)]
+    splits = [
+        conversion_func(_op.squeeze(_expr.TupleGetItem(split_var, i), axis=[1]))
+        for i in range(split_dim)
+    ]
 
-    return _expr.Let(split_var, split_input.astuple(),
-                     _op.stack(splits, axis=1))
+    return _expr.Let(split_var, split_input.astuple(), _op.stack(splits, axis=1))
 
 
 def _default_skip(inexpr, keras_layer, _):  # pylint: disable=unused-argument
@@ -1295,7 +1325,7 @@ _convert_map = {
     "SpatialDropout2D": _default_skip,
     "SpatialDropout1D": _default_skip,
     "GaussianDropout": _default_skip,
-    "GaussianNoise": _default_skip
+    "GaussianNoise": _default_skip,
 }
 
 

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -67,7 +67,7 @@ def _convert_recurrent_activation(inexpr, keras_layer):
 
 def _convert_activation(
     inexpr, keras_layer, _, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     if isinstance(keras_layer, str):
         act_type = keras_layer
     else:
@@ -250,7 +250,7 @@ def _convert_embedding(
 
 def _convert_dense(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     weightList = keras_layer.get_weights()
     weight = etab.new_const(weightList[0].transpose([1, 0]))
     params = {"weight": weight, "units": weightList[0].shape[1]}
@@ -613,7 +613,7 @@ def _convert_separable_convolution(inexpr, keras_layer, etab, input_shape=None, 
 
 def _convert_flatten(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -626,7 +626,7 @@ def _convert_flatten(
 
 def _convert_pooling(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -725,7 +725,7 @@ def _convert_pooling3d(inexpr, keras_layer, etab, input_shape=None, data_layout=
 
 def _convert_global_pooling3d(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -747,7 +747,7 @@ def _convert_global_pooling3d(
 
 def _convert_upsample(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -780,7 +780,7 @@ def _convert_upsample(
 
 def _convert_upsample3d(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -798,7 +798,7 @@ def _convert_upsample3d(
 
 def _convert_cropping(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     crop_type = type(keras_layer).__name__
     if input_shape is None:
@@ -857,7 +857,7 @@ def _convert_batchnorm(inexpr, keras_layer, etab, input_shape=None, data_layout=
 
 def _convert_padding(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -891,7 +891,7 @@ def _convert_padding(
 
 def _convert_padding3d(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -938,7 +938,7 @@ def _convert_padding3d(
 
 def _convert_concat(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if input_shape is None:
         input_shape = keras_layer.input_shape
@@ -974,7 +974,7 @@ def _convert_reshape(inexpr, keras_layer, etab, input_shape=None, data_layout=No
 
 def _convert_lstm(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if input_shape is None:
         input_shape = keras_layer.input_shape
@@ -1017,7 +1017,7 @@ def _convert_lstm(
 
 def _convert_simple_rnn(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if not isinstance(inexpr, list):
         buf = np.zeros((1, keras_layer.units), "float32")
@@ -1043,7 +1043,7 @@ def _convert_simple_rnn(
 
 def _convert_gru(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     _check_data_format(keras_layer)
     if not isinstance(inexpr, list):
         buf = np.zeros((1, keras_layer.units), "float32")
@@ -1088,7 +1088,7 @@ def _convert_gru(
 
 def _convert_repeat_vector(
     inexpr, keras_layer, etab, input_shape=None, data_layout=None
-):  # pylint: disable=unused_argument
+):  # pylint: disable=unused-argument
     if input_shape is None:
         input_shape = keras_layer.input_shape
     input_shape = list(input_shape)

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1163,7 +1163,7 @@ def _convert_l2_normalize(inexpr, keras_layer, data_layout):
     return _op.nn.l2_normalize(inexpr, eps=1e-12, axis=axis)
 
 
-def _convert_lambda(inexpr, keras_layer, etab, data_layout):
+def _convert_lambda(inexpr, keras_layer, _, data_layout):
     fcode = keras_layer.function.__code__
     # Convert l2_normalize
     if (

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -632,13 +632,11 @@ def _convert_pooling(
 
     if pool_type == "GlobalMaxPooling2D":
         return _convert_flatten(
-            _op.nn.global_max_pool2d(inexpr, **global_pool_params),
-            keras_layer, etab, data_layout
+            _op.nn.global_max_pool2d(inexpr, **global_pool_params), keras_layer, etab, data_layout
         )
     if pool_type == "GlobalAveragePooling2D":
         return _convert_flatten(
-            _op.nn.global_avg_pool2d(inexpr, **global_pool_params),
-            keras_layer, etab, data_layout
+            _op.nn.global_avg_pool2d(inexpr, **global_pool_params), keras_layer, etab, data_layout
         )
     pool_h, pool_w = keras_layer.pool_size
     stride_h, stride_w = keras_layer.strides

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -66,8 +66,10 @@ def _convert_recurrent_activation(inexpr, keras_layer):
 
 
 def _convert_activation(
-    inexpr, keras_layer, _, input_shape=None, data_layout=None
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
 ):  # pylint: disable=unused-argument
+    if data_layout is None:
+        data_layout = etab.data_layout
     if isinstance(keras_layer, str):
         act_type = keras_layer
     else:

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1474,7 +1474,7 @@ def from_keras(model, shape=None, layout="NCHW"):
                         keras_layer,
                         scope + keras_layer.name + ":" + str(node_idx),
                         etab,
-                        layout
+                        layout,
                     )
                 )
         return outs

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -342,7 +342,7 @@ def _convert_convolution1d(inexpr, keras_layer, etab, data_layout, input_shape=N
     else:
         out = _op.nn.conv1d(data=inexpr, **params)
 
-    channel_axis = -1 if etab.data_layout == "NWC" else 1
+    channel_axis = -1 if data_layout == "NWC" else 1
     if keras_layer.use_bias:
         bias = etab.new_const(weightList[1])
         out = _op.nn.bias_add(out, bias, channel_axis)

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -353,7 +353,7 @@ def _convert_convolution1d(inexpr, keras_layer, etab, data_layout, input_shape=N
     else:
         act_type = keras_layer.activation.__name__
     if act_type != "linear":
-        out = _convert_activation(out, act_type, etab)
+        out = _convert_activation(out, act_type, etab, data_layout)
 
     return out
 

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1163,7 +1163,7 @@ def _convert_l2_normalize(inexpr, keras_layer, etab, data_layout):
     return _op.nn.l2_normalize(inexpr, eps=1e-12, axis=axis)
 
 
-def _convert_lambda(inexpr, keras_layer, etab):
+def _convert_lambda(inexpr, keras_layer, etab, data_layout):
     fcode = keras_layer.function.__code__
     # Convert l2_normalize
     if (
@@ -1171,7 +1171,7 @@ def _convert_lambda(inexpr, keras_layer, etab):
         and len(fcode.co_names) > 0
         and fcode.co_names[-1] == "l2_normalize"
     ):
-        return _convert_l2_normalize(inexpr, keras_layer, etab)
+        return _convert_l2_normalize(inexpr, keras_layer, etab, data_layout)
     raise tvm.error.OpNotImplemented(
         "Function {} used in Lambda layer is not supported in frontend Keras.".format(
             fcode.co_names

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -66,8 +66,8 @@ def _convert_recurrent_activation(inexpr, keras_layer):
 
 
 def _convert_activation(
-        inexpr, keras_layer, _, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, _, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     if isinstance(keras_layer, str):
         act_type = keras_layer
     else:
@@ -183,7 +183,9 @@ def _convert_advanced_activation(inexpr, keras_layer, etab, input_shape=None, da
     )
 
 
-def _convert_merge(inexpr, keras_layer, _, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_merge(
+    inexpr, keras_layer, _, input_shape=None, data_layout=None
+):  # pylint: disable=unused-argument
     merge_type = type(keras_layer).__name__
     ret = inexpr[0]
     if merge_type == "Dot":
@@ -236,8 +238,8 @@ def _convert_permute(inexpr, keras_layer, _, input_shape=None, data_layout=None)
 
 
 def _convert_embedding(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused-argument
     indices = inexpr
     weightList = keras_layer.get_weights()
     weight = etab.new_const(weightList[0])
@@ -247,8 +249,8 @@ def _convert_embedding(
 
 
 def _convert_dense(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     weightList = keras_layer.get_weights()
     weight = etab.new_const(weightList[0].transpose([1, 0]))
     params = {"weight": weight, "units": weightList[0].shape[1]}
@@ -610,8 +612,8 @@ def _convert_separable_convolution(inexpr, keras_layer, etab, input_shape=None, 
 
 
 def _convert_flatten(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -622,7 +624,7 @@ def _convert_flatten(
     return _op.nn.batch_flatten(inexpr)
 
 
-def _convert_pooling(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_pooling(inexpr, keras_layer, etab, input_shape=None, data_layout=None):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -720,8 +722,8 @@ def _convert_pooling3d(inexpr, keras_layer, etab, input_shape=None, data_layout=
 
 
 def _convert_global_pooling3d(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -742,8 +744,8 @@ def _convert_global_pooling3d(
 
 
 def _convert_upsample(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -775,8 +777,8 @@ def _convert_upsample(
 
 
 def _convert_upsample3d(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -793,8 +795,8 @@ def _convert_upsample3d(
 
 
 def _convert_cropping(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     crop_type = type(keras_layer).__name__
     if input_shape is None:
@@ -852,8 +854,8 @@ def _convert_batchnorm(inexpr, keras_layer, etab, input_shape=None, data_layout=
 
 
 def _convert_padding(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -885,7 +887,7 @@ def _convert_padding(
     return _op.nn.pad(data=inexpr, pad_width=((0, 0), (top, bottom), (left, right), (0, 0)))
 
 
-def _convert_padding3d(inexpr, keras_layer, etab, input_shape=None, data_layout=None): # pylint: disable=unused-argument
+def _convert_padding3d(inexpr, keras_layer, etab, input_shape=None, data_layout=None):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -931,8 +933,8 @@ def _convert_padding3d(inexpr, keras_layer, etab, input_shape=None, data_layout=
 
 
 def _convert_concat(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if input_shape is None:
         input_shape = keras_layer.input_shape
@@ -967,8 +969,8 @@ def _convert_reshape(inexpr, keras_layer, etab, input_shape=None, data_layout=No
 
 
 def _convert_lstm(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if input_shape is None:
         input_shape = keras_layer.input_shape
@@ -1010,8 +1012,8 @@ def _convert_lstm(
 
 
 def _convert_simple_rnn(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if not isinstance(inexpr, list):
         buf = np.zeros((1, keras_layer.units), "float32")
@@ -1036,8 +1038,8 @@ def _convert_simple_rnn(
 
 
 def _convert_gru(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if not isinstance(inexpr, list):
         buf = np.zeros((1, keras_layer.units), "float32")
@@ -1081,8 +1083,8 @@ def _convert_gru(
 
 
 def _convert_repeat_vector(
-        inexpr, keras_layer, etab, input_shape=None, data_layout=None
-): # pylint: disable=unused-argument
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     if input_shape is None:
         input_shape = keras_layer.input_shape
     input_shape = list(input_shape)
@@ -1218,10 +1220,10 @@ def _convert_time_distributed(inexpr, keras_layer, etab, input_shape=None, data_
     inner_layer_op_name = type(keras_layer.layer).__name__
     if inner_layer_op_name not in _convert_map:
         raise tvm.error.OpNotImplemented(
-            (
-                "The inner layer for TimeDistributed {} is not supported for frontend Keras."
-            ).format(
-                inner_layer_op_name))
+            "The inner layer for TimeDistributed {} is not supported for frontend Keras.".format(
+                inner_layer_op_name
+            )
+        )
 
     conversion_func = lambda expr: _convert_map[inner_layer_op_name](
         expr, inner_layer, etab, input_shape=inner_input_shape, data_layout=inner_data_layout
@@ -1236,7 +1238,7 @@ def _convert_time_distributed(inexpr, keras_layer, etab, input_shape=None, data_
     split_shape[1] = 1
 
     split_var = new_var(
-        'time_distributed_split',
+        "time_distributed_split",
         type_annotation=TupleType(
             [TensorType(split_shape, dtype="float32") for i in range(split_dim)]
         ),

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -624,7 +624,9 @@ def _convert_flatten(
     return _op.nn.batch_flatten(inexpr)
 
 
-def _convert_pooling(inexpr, keras_layer, etab, input_shape=None, data_layout=None):  # pylint: disable=unused_argument
+def _convert_pooling(
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout
@@ -887,7 +889,9 @@ def _convert_padding(
     return _op.nn.pad(data=inexpr, pad_width=((0, 0), (top, bottom), (left, right), (0, 0)))
 
 
-def _convert_padding3d(inexpr, keras_layer, etab, input_shape=None, data_layout=None):  # pylint: disable=unused_argument
+def _convert_padding3d(
+    inexpr, keras_layer, etab, input_shape=None, data_layout=None
+):  # pylint: disable=unused_argument
     _check_data_format(keras_layer)
     if data_layout is None:
         data_layout = etab.data_layout

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1078,7 +1078,7 @@ def _convert_repeat_vector(
     return out
 
 
-def _convert_l2_normalize(inexpr, keras_layer, etab, data_layout):
+def _convert_l2_normalize(inexpr, keras_layer, _, data_layout):
     l2_normalize_is_loaded = False
     param_list = []
     for i in dis.get_instructions(keras_layer.function):
@@ -1391,7 +1391,7 @@ def from_keras(model, shape=None, layout="NCHW"):
         input_shape = shape[input_name] if shape is not None and input_name in shape else None
         etab.set_expr(input_name, new_var(input_name, shape=input_shape))
 
-    def _convert_layer(keras_layer, etab, data_layout, scope=""):
+    def _convert_layer(keras_layer, etab, scope=""):
         inbound_nodes = (
             keras_layer.inbound_nodes
             if hasattr(keras_layer, "inbound_nodes")
@@ -1520,7 +1520,7 @@ def from_keras(model, shape=None, layout="NCHW"):
         if isinstance(keras_layer, input_layer_class):
             _convert_input_layer(keras_layer)
         else:
-            _convert_layer(keras_layer, etab, layout)
+            _convert_layer(keras_layer, etab)
 
     # model._output_coordinates contains out_node(oc[0]), node_index(oc[1]) and tensor_index(oc[2])
     # Get all output nodes in etab using the name made from above values.

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -233,7 +233,9 @@ def _convert_merge(
     return ret
 
 
-def _convert_permute(inexpr, keras_layer, _, input_shape=None, data_layout=None):
+def _convert_permute(
+    inexpr, keras_layer, _, input_shape=None, data_layout=None
+):  # pylint: disable=unused-argument
     return _op.transpose(inexpr, axes=(0,) + keras_layer.dims)
 
 

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1078,7 +1078,7 @@ def _convert_repeat_vector(
     return out
 
 
-def _convert_l2_normalize(inexpr, keras_layer, _, data_layout):
+def _convert_l2_normalize(inexpr, keras_layer, data_layout):
     l2_normalize_is_loaded = False
     param_list = []
     for i in dis.get_instructions(keras_layer.function):
@@ -1171,7 +1171,7 @@ def _convert_lambda(inexpr, keras_layer, etab, data_layout):
         and len(fcode.co_names) > 0
         and fcode.co_names[-1] == "l2_normalize"
     ):
-        return _convert_l2_normalize(inexpr, keras_layer, etab, data_layout)
+        return _convert_l2_normalize(inexpr, keras_layer, data_layout)
     raise tvm.error.OpNotImplemented(
         "Function {} used in Lambda layer is not supported in frontend Keras.".format(
             fcode.co_names

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -652,6 +652,7 @@ if __name__ == "__main__":
         sut.test_forward_sequential(keras=k)
         sut.test_forward_pool(keras=k)
         sut.test_forward_conv(keras=k)
+        sut.test_forward_conv1d(keras=k)
         sut.test_forward_batch_norm(keras=k)
         sut.test_forward_upsample(keras=k, interpolation="nearest")
         sut.test_forward_upsample(keras=k, interpolation="bilinear")

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -625,6 +625,14 @@ class TestKeras:
             verify_keras_frontend(keras_model, layout="NHWC")
 
 
+    def test_forward_time_distributed(self, keras):
+        inputs = keras.Input(shape=(10, 128, 128, 3))
+        conv_2d_layer = keras.layers.Conv2D(64, (3, 3))
+        time_distributed = keras.layers.TimeDistributed(conv_2d_layer)(inputs)
+        keras_model = keras.models.Model(inputs, time_distributed)
+        verify_keras_frontend(keras_model, layout="NDHWC")
+
+
 if __name__ == "__main__":
     for k in [keras, tf_keras]:
         sut = TestKeras()
@@ -662,3 +670,4 @@ if __name__ == "__main__":
         sut.test_forward_embedding(keras=k)
         sut.test_forward_repeat_vector(keras=k)
         sut.test_forward_l2_normalize(keras=k)
+        sut.test_forward_time_distributed(keras=k)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -624,7 +624,6 @@ class TestKeras:
             verify_keras_frontend(keras_model, layout="NCHW")
             verify_keras_frontend(keras_model, layout="NHWC")
 
-
     def test_forward_time_distributed(self, keras):
         conv2d_inputs = keras.Input(shape=(10, 128, 128, 3))
         conv_2d_layer = keras.layers.Conv2D(64, (3, 3))

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -628,12 +628,16 @@ class TestKeras:
     def test_forward_time_distributed(self, keras):
         conv2d_inputs = keras.Input(shape=(10, 128, 128, 3))
         conv_2d_layer = keras.layers.Conv2D(64, (3, 3))
-        conv2d_model = keras.models.Model(conv2d_inputs, keras.layers.TimeDistributed(conv_2d_layer)(conv2d_inputs))
+        conv2d_model = keras.models.Model(
+            conv2d_inputs, keras.layers.TimeDistributed(conv_2d_layer)(conv2d_inputs)
+        )
         verify_keras_frontend(conv2d_model, layout="NDHWC")
 
-        dense_inputs = keras.Input(shape=(5,1))
+        dense_inputs = keras.Input(shape=(5, 1))
         dense_layer = keras.layers.Dense(1)
-        dense_model = keras.models.Model(dense_inputs, keras.layers.TimeDistributed(dense_layer)(dense_inputs))
+        dense_model = keras.models.Model(
+            dense_inputs, keras.layers.TimeDistributed(dense_layer)(dense_inputs)
+        )
         verify_keras_frontend(dense_model, need_transpose=False)
 
 

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -626,11 +626,15 @@ class TestKeras:
 
 
     def test_forward_time_distributed(self, keras):
-        inputs = keras.Input(shape=(10, 128, 128, 3))
+        conv2d_inputs = keras.Input(shape=(10, 128, 128, 3))
         conv_2d_layer = keras.layers.Conv2D(64, (3, 3))
-        time_distributed = keras.layers.TimeDistributed(conv_2d_layer)(inputs)
-        keras_model = keras.models.Model(inputs, time_distributed)
-        verify_keras_frontend(keras_model, layout="NDHWC")
+        conv2d_model = keras.models.Model(conv2d_inputs, keras.layers.TimeDistributed(conv_2d_layer)(conv2d_inputs))
+        verify_keras_frontend(conv2d_model, layout="NDHWC")
+
+        dense_inputs = keras.Input(shape=(5,1))
+        dense_layer = keras.layers.Dense(1)
+        dense_model = keras.models.Model(dense_inputs, keras.layers.TimeDistributed(dense_layer)(dense_inputs))
+        verify_keras_frontend(dense_model, need_transpose=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is an attempt to support the [`TimeDistributed`](https://keras.io/api/layers/recurrent_layers/time_distributed/) layer in the Keras frontend. Because `TimeDistributed` takes a layer as an argument, I had to modify the existing conversion functions to take parameters instead of making assumptions about the Keras model or `etab` data structure. Perhaps it might be better not to attempt to reuse the existing conversion functions and special-case the different possible arguments to `TimeDistributed` -- I would be glad to take any suggestions on this.

I would also be interested to know what you might advise as to further test cases for `TimeDistributed`; I went by the example from the documentation and another use-case I found that used `TimeDistributed` with `Dense`.

@jroesch I am not entirely sure who would be the best person to review a change to the Keras frontend and would appreciate any advice