### PR TITLE
[TFLite] Bugfix - ensure pad calcalution to be in int32

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -3210,7 +3210,7 @@ def get_pad_value(data, kernel, stride):
     """
 
     out = int(math.ceil(float(data) / float(stride)))
-    pad = max(0, (out - 1) * stride + kernel - data)
+    pad = max(0, (out - 1) * int(stride) + int(kernel) - int(data))
     pad_before = pad // 2
     pad_after = pad - pad_before
     return pad_before, pad_after

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -305,6 +305,8 @@ Doc RelayTextPrinter::ScalarLiteral(DataType dtype, const T& value) {
   std::ostringstream os;
   if (dtype == DataType::Int(32)) {
     os << value;
+  } else if (dtype == DataType::Int(64)) {
+    os << value << "i64";
   } else if (dtype == DataType::Float(32)) {
     os << value << 'f';
   } else if (dtype == DataType::Float(64)) {


### PR DESCRIPTION
@kevinthesun @zhiics @giuseros 

TFLite prequantized Resent model was failing to compile. I found that the pad calculation introduce int64 datatype in the shape of max pool2d, that later causes issues with tensorization. Int64 was introduced because of the calculation between python int and np.int32, which results in np.int64. This PR ensures that all the padding calculations happen in python int.

Additionally, I have added a small check to print i64 in AsText. This helped in identifying which op was introducing the int64 datatype.