### PR TITLE
Change default hostname in rpc_tracker

### DIFF
--- a/python/tvm/rpc/base.py
+++ b/python/tvm/rpc/base.py
@@ -60,6 +60,9 @@ RPC_SESS_MASK = 128
 
 def get_addr_family(addr):
     res = socket.getaddrinfo(addr[0], addr[1], 0, 0, socket.IPPROTO_TCP)
+    for info in res:
+        if info[0] == socket.AF_INET:
+            return info[0]
     return res[0][0]
 
 


### PR DESCRIPTION
This change fix problem with version of IP protocol on MacOS.

Previous the `rpc_tracker` and `query_rpc_tracker` were not able connect to
each other with default hostnames.
The root cause was in method `socket.getaddrinfo`. In `rpc_tracker` the
default hostname was "0.0.0.0" and `getaddrinfo` returned IPv4 type. In
`query_rpc_tracker` the default hastname is "localhost" and `getaddrinfo`
on MacOS returns IPv6 type. Note: on Linux both have IPv4 type.
These tools worked by different protocols and this is why
`query_rpc_tracker` wasn't able connect to `rpc_tracker`.

Now the default hostnames are the same. So it works fine on MacOS.

@tqchen, @jroesch Could you please review it?
