### PR TITLE
[GraphRuntime] remove print from GetInputIndex

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -96,7 +96,6 @@ int GraphRuntime::GetInputIndex(const std::string& name) {
   if (it != input_map_.end()) {
     return it->second;
   }
-  LOG(WARNING) << "Warning: cannot find \"" << name << "\" among input";
   return -1;
 }
 /*!


### PR DESCRIPTION
Remove print statement from `GetInputIndex` API in GraphRuntime. The function already returns -1 when the input isnt found so the print statement is unnecessary and degrades performance at runtime. 
FYI @trevor-m @zhiics 