### PR TITLE
[Arith] Simplify cast

### DIFF
--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -1214,7 +1214,6 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const CastNode* op) {
   }
   // normalize
   PrimExpr value = this->CanonicalMutate(op->value);
-  PrimExpr ret;
   // PushCastToChildren
   if (value.as<SumExprNode>()) {
     SumExpr se = Downcast<SumExpr>(value);

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -1209,7 +1209,8 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const CastNode* op) {
       se.CopyOnWrite()->CastTo(op->dtype);
       ret = se;
     }
-  } else {
+  }
+  if (!ret.defined()) {
     ret = Rewriter::VisitExpr_(op);
   }
   return ret;

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -1220,19 +1220,17 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const CastNode* op) {
     SumExpr se = Downcast<SumExpr>(value);
     if (se->CanPushCastToChildren(op->dtype, analyzer_)) {
       se.CopyOnWrite()->PushCastToChildren(op->dtype);
-      ret = se;
+      return std::move(se);
     }
-  } else if (value.as<SplitExprNode>()) {
+  }
+  if (value.as<SplitExprNode>()) {
     SplitExpr se = Downcast<SplitExpr>(value);
     if (se->CanPushCastToChildren(op->dtype, analyzer_)) {
       se.CopyOnWrite()->PushCastToChildren(op->dtype);
-      ret = se;
+      return std::move(se);
     }
   }
-  if (!ret.defined()) {
-    ret = Rewriter::VisitExpr_(op);
-  }
-  return ret;
+  return Rewriter::VisitExpr_(op);
 }
 
 PrimExpr CanonicalSimplifier::operator()(const PrimExpr& expr) {

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -805,11 +805,6 @@ SplitExpr CanonicalSimplifier::Impl::SplitDivConst(SplitExpr lhs, int64_t cval, 
   return lhs;
 }
 
-// SplitExpr CanonicalSimplifier::Impl::CastSplitExpr(DataType dtype, SplitExpr value) {
-//   value.CopyOnWrite()->index = cast(dtype, value->index);
-//   return value;
-// }
-
 PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const DivNode* op) {
   if (!IsIndexType(op->dtype)) {
     return Rewriter::VisitExpr_(op);

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -79,7 +79,7 @@ inline PrimExpr DivImpl(PrimExpr a, PrimExpr b, DivMode mode) {
 
 bool CheckCastImpl(DataType dtype, PrimExpr value, Analyzer* analyzer) {
   if (!IsIndexType(dtype)) {
-     return false;
+    return false;
   }
   ConstIntBound bound = analyzer->const_int_bound(value);
   int64_t ubound = Downcast<IntImm>(max_value(dtype))->value;

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -162,22 +162,21 @@ class SplitExprNode : public CanonicalExprNode {
       return true;  // upcast is safe
     }
     PrimExpr res = this->index;
-    DataType dtype = this->dtype;
     if (this->scale == 0) {
       return true;
     }
     CHECK_CAST(dtype, res)
     if (this->upper_factor != SplitExprNode::kPosInf) {
-      res = ModImpl(res, make_const(dtype, this->upper_factor), div_mode);
+      res = ModImpl(res, make_const(this->dtype, this->upper_factor), div_mode);
       CHECK_CAST(dtype, res)
     }
     if (this->lower_factor != 1) {
-      res = DivImpl(res, make_const(dtype, this->lower_factor), div_mode);
+      res = DivImpl(res, make_const(this->dtype, this->lower_factor), div_mode);
       CHECK_CAST(dtype, res)
     }
     if (this->scale != 1) {
-      ICHECK(!dtype.is_uint() || this->scale > 0);
-      res = res * make_const(dtype, this->scale);
+      ICHECK(!this->dtype.is_uint() || this->scale > 0);
+      res = res * make_const(this->dtype, this->scale);
       CHECK_CAST(dtype, res)
     }
     return true;

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -127,7 +127,11 @@ class SplitExprNode : public CanonicalExprNode {
   PrimExpr Normalize() const final { return NormalizeWithScale(1); }
 
   void MulToSelf(int64_t scale) { this->scale *= scale; }
-  void CastTo(DataType dtype) { this->index = cast(dtype, this->index); }
+
+  void CastTo(DataType dtype) {
+    this->index = cast(dtype, this->index);
+    this->dtype = dtype;
+  }
 
   inline bool IndexEqual(const SplitExpr& other) const;
   inline bool DivModeCompatibleTo(DivMode mode) const;
@@ -264,6 +268,7 @@ class SumExprNode : public CanonicalExprNode {
     for (auto& arg : args) {
       arg.CopyOnWrite()->CastTo(dtype);
     }
+    this->dtype = dtype;
   }
 
   static constexpr const char* _type_key = "arith.SumExpr";

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -91,9 +91,9 @@ bool CheckCastImpl(DataType dtype, PrimExpr value, Analyzer* analyzer) {
   return false;
 }
 
-#define TVM_CHECK_CANONICAL_SIMPLIFY_CAST(DTYPE, VALUE)  \
-  if (!CheckCastImpl(DTYPE, VALUE, analyzer)) {          \
-    return false;                                        \
+#define TVM_CHECK_CANONICAL_SIMPLIFY_CAST(DTYPE, VALUE) \
+  if (!CheckCastImpl(DTYPE, VALUE, analyzer)) {         \
+    return false;                                       \
   }
 
 /*!

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -78,21 +78,23 @@ inline PrimExpr DivImpl(PrimExpr a, PrimExpr b, DivMode mode) {
 }
 
 bool CheckCastImpl(DataType dtype, PrimExpr value, Analyzer* analyzer) {
-    if (!IsIndexType(dtype)) {
-      return false;
-    }
-    ConstIntBound bound = analyzer->const_int_bound(value);
-    int64_t ubound = Downcast<IntImm>(max_value(dtype))->value;
-    int64_t lbound = Downcast<IntImm>(min_value(dtype))->value;
-    if (value.dtype().bits() <= dtype.bits() ||  // upcast is safe
-        (bound->max_value <= ubound && bound->min_value >= lbound)) {
-      return true;
-    }
-    return false;
+  if (!IsIndexType(dtype)) {
+     return false;
+  }
+  ConstIntBound bound = analyzer->const_int_bound(value);
+  int64_t ubound = Downcast<IntImm>(max_value(dtype))->value;
+  int64_t lbound = Downcast<IntImm>(min_value(dtype))->value;
+  if (value.dtype().bits() <= dtype.bits() ||  // upcast is safe
+      (bound->max_value <= ubound && bound->min_value >= lbound)) {
+    return true;
+  }
+  return false;
 }
 
-#define CHECK_CAST(DTYPE, VALUE) \
-  if (!CheckCastImpl(DTYPE, VALUE, analyzer))  { return false; }
+#define CHECK_CAST(DTYPE, VALUE)                \
+  if (!CheckCastImpl(DTYPE, VALUE, analyzer)) { \
+    return false;                               \
+  }
 
 /*!
  * \brief Internal "Split normal form" of expression.
@@ -354,7 +356,9 @@ class SumExprNode : public CanonicalExprNode {
       CHECK_CAST(dtype, res)
     }
     for (const auto& arg : args) {
-      if (!arg->CheckCast(dtype, analyzer)) { return false; }
+      if (!arg->CheckCast(dtype, analyzer)) {
+        return false;
+      }
     }
     return true;
   }
@@ -1208,7 +1212,6 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const CastNode* op) {
   }
   return Rewriter::VisitExpr_(op);
 }
-
 
 PrimExpr CanonicalSimplifier::operator()(const PrimExpr& expr) {
   return impl_->CanonicalSimplify(expr);

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -78,12 +78,12 @@ inline PrimExpr DivImpl(PrimExpr a, PrimExpr b, DivMode mode) {
 }
 
 /*!
-  * \brief check if value fits in dtype
-  * \param value The value to be analyzed
-  * \param dtype The target dtype
-  * \param analyzer The analyzer
-  * \return whether value fits in dtype
-  */
+ * \brief check if value fits in dtype
+ * \param value The value to be analyzed
+ * \param dtype The target dtype
+ * \param analyzer The analyzer
+ * \return whether value fits in dtype
+ */
 bool CastIsSafe(DataType dtype, PrimExpr value, Analyzer* analyzer) {
   if (!IsIndexType(dtype)) {
     return false;

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -1196,20 +1196,23 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const CastNode* op) {
   }
   // normalize
   PrimExpr value = this->CanonicalMutate(op->value);
+  PrimExpr ret;
   if (value.as<SumExprNode>()) {
     SumExpr se = Downcast<SumExpr>(value);
     if (se->CheckCast(op->dtype, analyzer_)) {
       se.CopyOnWrite()->CastTo(op->dtype);
-      return se;
+      ret = se;
     }
   } else if (value.as<SplitExprNode>()) {
     SplitExpr se = Downcast<SplitExpr>(value);
     if (se->CheckCast(op->dtype, analyzer_)) {
       se.CopyOnWrite()->CastTo(op->dtype);
-      return se;
+      ret = se;
     }
+  } else {
+    ret = Rewriter::VisitExpr_(op);
   }
-  return Rewriter::VisitExpr_(op);
+  return ret;
 }
 
 PrimExpr CanonicalSimplifier::operator()(const PrimExpr& expr) {

--- a/tests/python/unittest/test_arith_canonical_simplify.py
+++ b/tests/python/unittest/test_arith_canonical_simplify.py
@@ -330,7 +330,7 @@ def test_simplify_cast():
     # cast(i32, i + j - 100)
     i = te.var("i", dtype="int64")
     j = te.var("j", dtype="int64")
-    ck.analyzer.update(i, tvm.arith.ConstIntBound(0, 2**31 - 1))
+    ck.analyzer.update(i, tvm.arith.ConstIntBound(0, 2 ** 31 - 1))
     ck.analyzer.update(j, tvm.arith.ConstIntBound(0, 10))
     res = tcast("int32", i + j - 100)
     ck.verify(res, res)
@@ -339,12 +339,13 @@ def test_simplify_cast():
     axis = te.var("axis", dtype="int64")
     ck.analyzer.update(axis, tvm.arith.ConstIntBound(0, 42))
     res = (
-        tcast("int32", flm(axis, tvm.tir.const(7, "int64"))
-            * tvm.tir.const(2, "int64")
-            + tvm.tir.const(1, "int64"))
+        tcast(
+            "int32",
+            flm(axis, tvm.tir.const(7, "int64")) * tvm.tir.const(2, "int64")
+            + tvm.tir.const(1, "int64"),
+        )
         + tvm.tir.const(1, "int32")
-        - tcast("int32", flm(axis, tvm.tir.const(7, "int64"))
-            * tvm.tir.const(2, "int64"))
+        - tcast("int32", flm(axis, tvm.tir.const(7, "int64")) * tvm.tir.const(2, "int64"))
     )
     ck.verify(res, 2)
 

--- a/tests/python/unittest/test_arith_canonical_simplify.py
+++ b/tests/python/unittest/test_arith_canonical_simplify.py
@@ -24,6 +24,7 @@ class CanonicalChecker:
 
     def verify(self, data, expected):
         res = self.analyzer.canonical_simplify(data)
+        print(res)
         expected = tvm.runtime.convert(expected)
         assert tvm.ir.structural_equal(res, expected), "\ndata={}\nres={}\nexpected={}".format(
             data, res, expected
@@ -310,6 +311,14 @@ def test_complex_cases():
     ck.verify(res3, tdiv((x * 1024) + y, 256) - tdiv(y, 256) - (x * 4))
 
 
+def test_simplify_cast():
+    ck = CanonicalChecker()
+    i = te.var("i", dtype="int32")
+    tcast = tvm.tir.Cast
+    res = tcast("int64", i + j + 1) - tcast("int64", i)
+    ck.verify(res, 1)
+
+
 if __name__ == "__main__":
     test_floormod_simplify()
     test_mul_sum_simplify()
@@ -321,3 +330,4 @@ if __name__ == "__main__":
     test_split_index_simplify()
     test_canonical_mixed()
     test_complex_cases()
+    test_simplify_cast()


### PR DESCRIPTION
Follow up of #6691 
Simplify `cast(i32, c * 2 + 1) + 1 - cast(i32, c * 2)` to `2` by first transforming to `cast(i32, c * 2) + cast(i32, 1) + 1 - cast(i32, c * 2)`
