### PR TITLE
[Auto Scheduler] Add target host to measure record

### DIFF
--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -163,6 +163,9 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     writer->WriteArrayItem(std::string(data.workload_key));
     writer->WriteArrayItem(data.target->str());
     writer->WriteArrayItem(*data.hardware_params.get());
+    if (data.target_host.defined()) {
+      writer->WriteArrayItem(data.target_host->str());
+    }
     writer->EndArray();
   }
   inline static void Read(dmlc::JSONReader* reader, ::tvm::auto_scheduler::SearchTaskNode* data) {
@@ -181,8 +184,13 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     s = reader->NextArrayItem();
     if (s) {
       reader->Read(hardware_params_node.get());
-      s = reader->NextArrayItem();
       data->hardware_params = ::tvm::auto_scheduler::HardwareParams(hardware_params_node);
+    }
+    s = reader->NextArrayItem();
+    if (s) {
+      reader->Read(&str_value);
+      data->target_host = ::tvm::Target(str_value);
+      s = reader->NextArrayItem();
       ICHECK(!s);
     }
   }

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -184,14 +184,14 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     s = reader->NextArrayItem();
     if (s) {
       reader->Read(hardware_params_node.get());
-      data->hardware_params = ::tvm::auto_scheduler::HardwareParams(hardware_params_node);
-    }
-    s = reader->NextArrayItem();
-    if (s) {
-      reader->Read(&str_value);
-      data->target_host = ::tvm::Target(str_value);
       s = reader->NextArrayItem();
-      ICHECK(!s);
+      data->hardware_params = ::tvm::auto_scheduler::HardwareParams(hardware_params_node);
+      if (s) {
+        reader->Read(&str_value);
+        data->target_host = ::tvm::Target(str_value);
+        s = reader->NextArrayItem();
+        ICHECK(!s);
+      }
     }
   }
 };

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -279,7 +279,7 @@ namespace auto_scheduler {
 TVM_REGISTER_OBJECT_TYPE(RecordToFileNode);
 TVM_REGISTER_OBJECT_TYPE(RecordReaderNode);
 
-const std::string AUTO_SCHEDULER_LOG_VERSION = "v0.3";  // NOLINT(*)
+const std::string AUTO_SCHEDULER_LOG_VERSION = "v0.4";  // NOLINT(*)
 
 RecordToFile::RecordToFile(String filename) {
   auto node = make_object<RecordToFileNode>();

--- a/tests/python/unittest/test_auto_scheduler_measure.py
+++ b/tests/python/unittest/test_auto_scheduler_measure.py
@@ -249,6 +249,27 @@ def test_measure_local_builder_rpc_runner_spawn():
     p.start()
     p.join()
 
+@tvm.testing.requires_llvm
+def test_measure_target_host():
+    task = auto_scheduler.SearchTask(
+        func=matmul_auto_scheduler_test, args=(512, 512, 512), target="llvm",
+        target_host="llvm -mtriple=aarch64-linux-gnu"
+    )
+
+    inp = auto_scheduler.measure.MeasureInput(task, task.compute_dag.init_state)
+    res = auto_scheduler.measure.MeasureResult([0.1], 0, "", 0.2, 1)
+
+    with tempfile.NamedTemporaryFile() as fp:
+        auto_scheduler.save_records(fp.name, [inp], [res])
+
+        log_reader = auto_scheduler.RecordReader(fp.name)
+        inputs, results = log_reader.read_lines()
+        assert len(inputs) == 1
+
+        raw_inp = inputs[0]
+
+        recovered_inp = auto_scheduler.measure.recover_measure_input(raw_inp)
+        assert str(recovered_inp.task.target_host) == str(inp.task.target_host)
 
 if __name__ == "__main__":
     test_record_split_reorder_fuse_annotation()
@@ -258,3 +279,4 @@ if __name__ == "__main__":
     test_recover_measure_input()
     test_measure_local_builder_runner()
     test_measure_local_builder_rpc_runner()
+    test_measure_target_host()

--- a/tests/python/unittest/test_auto_scheduler_measure.py
+++ b/tests/python/unittest/test_auto_scheduler_measure.py
@@ -249,6 +249,7 @@ def test_measure_local_builder_rpc_runner_spawn():
     p.start()
     p.join()
 
+
 @tvm.testing.requires_llvm
 def test_measure_target_host():
     task = auto_scheduler.SearchTask(

--- a/tests/python/unittest/test_auto_scheduler_measure.py
+++ b/tests/python/unittest/test_auto_scheduler_measure.py
@@ -253,8 +253,10 @@ def test_measure_local_builder_rpc_runner_spawn():
 @tvm.testing.requires_llvm
 def test_measure_target_host():
     task = auto_scheduler.SearchTask(
-        func=matmul_auto_scheduler_test, args=(512, 512, 512), target="llvm",
-        target_host="llvm -mtriple=aarch64-linux-gnu"
+        func=matmul_auto_scheduler_test,
+        args=(512, 512, 512),
+        target="llvm",
+        target_host="llvm -mtriple=aarch64-linux-gnu",
     )
 
     inp = auto_scheduler.measure.MeasureInput(task, task.compute_dag.init_state)
@@ -271,6 +273,7 @@ def test_measure_target_host():
 
         recovered_inp = auto_scheduler.measure.recover_measure_input(raw_inp)
         assert str(recovered_inp.task.target_host) == str(inp.task.target_host)
+
 
 if __name__ == "__main__":
     test_record_split_reorder_fuse_annotation()


### PR DESCRIPTION
We don't append target host to measure record serialization / deserialization currently, which works well on x86 host machine / target is simply arm cpu. However, it will have problem for more complex deployment. Say we want to on our x86 server machine cross compile for arm machine's mali GPU, whose target host is arm cpu, but target is mali GPU.

So we should add target host to measure record if `target_host` is not `nullptr`.