### PR TITLE
#7058 [Tutorial] Import errors in deploy_detection.py and deploy_classification.py

### DIFF
--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import, print_function
 
 import argparse, json, os, requests, sys, time
 from io import BytesIO
-from os.path import join, isfile, dirname, pardir
+from os.path import join, isfile
 from PIL import Image
 
 from mxnet.gluon.model_zoo import vision
@@ -56,14 +56,9 @@ from tvm.contrib import graph_runtime, utils, download
 from tvm.contrib.debugger import debug_runtime
 from tvm.relay import transform
 
-os.chdir(dirname(os.path.abspath(__file__)))
-os.chdir(join(pardir, pardir, pardir))
-sys.path.append(os.getcwd())
-
 import vta
-from vta.python.vta.testing import simulator
-from vta.python.vta.top import graphpack as graph_pack
-from vta.python import vta
+from vta.testing import simulator
+from vta.top import graph_pack
 
 # Make sure that TVM was compiled with RPC=1
 assert tvm.runtime.enabled("rpc")
@@ -183,7 +178,7 @@ with autotvm.tophub.context(target):
                 mod = relay.quantize.quantize(mod, params=params)
             # Perform graph packing and constant folding for VTA target
             assert env.BLOCK_IN == env.BLOCK_OUT
-            relay_prog = graph_pack.graph_pack(
+            relay_prog = graph_pack(
                 mod["main"],
                 env.BATCH,
                 env.BLOCK_OUT,

--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -57,8 +57,9 @@ from tvm.contrib.debugger import debug_runtime
 from tvm.relay import transform
 
 import vta
-from vta.testing import simulator
-from vta.top import graph_pack
+from vta.python.vta.testing import simulator
+from vta.python.vta.top import graphpack as graph_pack
+from vta.python import vta
 
 # Make sure that TVM was compiled with RPC=1
 assert tvm.runtime.enabled("rpc")
@@ -178,7 +179,7 @@ with autotvm.tophub.context(target):
                 mod = relay.quantize.quantize(mod, params=params)
             # Perform graph packing and constant folding for VTA target
             assert env.BLOCK_IN == env.BLOCK_OUT
-            relay_prog = graph_pack(
+            relay_prog = graph_pack.graph_pack(
                 mod["main"],
                 env.BATCH,
                 env.BLOCK_OUT,

--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import, print_function
 
 import argparse, json, os, requests, sys, time
 from io import BytesIO
-from os.path import join, isfile
+from os.path import join, isfile, dirname, pardir
 from PIL import Image
 
 from mxnet.gluon.model_zoo import vision
@@ -55,6 +55,10 @@ from tvm import rpc, autotvm, relay
 from tvm.contrib import graph_runtime, utils, download
 from tvm.contrib.debugger import debug_runtime
 from tvm.relay import transform
+
+os.chdir(dirname(os.path.abspath(__file__)))
+os.chdir(join(pardir, pardir, pardir))
+sys.path.append(os.getcwd())
 
 import vta
 from vta.python.vta.testing import simulator

--- a/vta/tutorials/frontend/legacy/deploy_detection.py
+++ b/vta/tutorials/frontend/legacy/deploy_detection.py
@@ -58,10 +58,11 @@ import vta
 from tvm import rpc, autotvm, relay
 from tvm.relay.testing import yolo_detection, darknet
 from tvm.relay.testing.darknet import __darknetffi__
-from tvm.contrib import graph_runtime, graph_runtime, util
+from tvm.contrib import graph_runtime, graph_runtime, utils
 from tvm.contrib.download import download_testdata
-from vta.testing import simulator
-from vta.top import graph_pack
+from vta.python.vta.testing import simulator
+from vta.python.vta.top import graphpack as graph_pack
+from vta.python import vta
 
 # Make sure that TVM was compiled with RPC=1
 assert tvm.runtime.enabled("rpc")
@@ -123,7 +124,7 @@ device = "vta"
 target = env.target if device == "vta" else env.target_vta_cpu
 
 pack_dict = {
-    "yolov3-tiny": ["nn.max_pool2d", "cast", 4, 185],
+    "yolov3-tiny": ["nn.max_pool2d", "cast", 4, 186],
 }
 
 # Name of Darknet model to compile
@@ -219,7 +220,7 @@ with autotvm.tophub.context(target):
             ):
                 mod = relay.quantize.quantize(mod, params=params)
             # Perform graph packing and constant folding for VTA target
-            mod = graph_pack(
+            mod = graph_pack.graph_pack(
                 mod["main"],
                 env.BATCH,
                 env.BLOCK_OUT,

--- a/vta/tutorials/frontend/legacy/deploy_detection.py
+++ b/vta/tutorials/frontend/legacy/deploy_detection.py
@@ -58,7 +58,7 @@ import vta
 from tvm import rpc, autotvm, relay
 from tvm.relay.testing import yolo_detection, darknet
 from tvm.relay.testing.darknet import __darknetffi__
-from tvm.contrib import graph_runtime, graph_runtime, utils
+from tvm.contrib import graph_runtime, utils
 from tvm.contrib.download import download_testdata
 from vta.testing import simulator
 from vta.top import graph_pack

--- a/vta/tutorials/frontend/legacy/deploy_detection.py
+++ b/vta/tutorials/frontend/legacy/deploy_detection.py
@@ -53,12 +53,6 @@ import os
 import time
 import matplotlib.pyplot as plt
 import numpy as np
-from os.path import join, dirname, pardir
-
-os.chdir(dirname(os.path.abspath(__file__)))
-os.chdir(join(pardir, pardir, pardir, pardir))
-sys.path.append(os.getcwd())
-
 import tvm
 import vta
 from tvm import rpc, autotvm, relay
@@ -66,9 +60,8 @@ from tvm.relay.testing import yolo_detection, darknet
 from tvm.relay.testing.darknet import __darknetffi__
 from tvm.contrib import graph_runtime, graph_runtime, utils
 from tvm.contrib.download import download_testdata
-from vta.python.vta.testing import simulator
-from vta.python.vta.top import graphpack as graph_pack
-from vta.python import vta
+from vta.testing import simulator
+from vta.top import graph_pack
 
 # Make sure that TVM was compiled with RPC=1
 assert tvm.runtime.enabled("rpc")
@@ -226,7 +219,7 @@ with autotvm.tophub.context(target):
             ):
                 mod = relay.quantize.quantize(mod, params=params)
             # Perform graph packing and constant folding for VTA target
-            mod = graph_pack.graph_pack(
+            mod = graph_pack(
                 mod["main"],
                 env.BATCH,
                 env.BLOCK_OUT,

--- a/vta/tutorials/frontend/legacy/deploy_detection.py
+++ b/vta/tutorials/frontend/legacy/deploy_detection.py
@@ -53,6 +53,12 @@ import os
 import time
 import matplotlib.pyplot as plt
 import numpy as np
+from os.path import join, dirname, pardir
+
+os.chdir(dirname(os.path.abspath(__file__)))
+os.chdir(join(pardir, pardir, pardir, pardir))
+sys.path.append(os.getcwd())
+
 import tvm
 import vta
 from tvm import rpc, autotvm, relay
@@ -132,7 +138,7 @@ pack_dict = {
 # to start and end the graph packing relay pass: in other words
 # where to start and finish offloading to VTA.
 # the number 4 indicate the the ``start_pack`` index is 4, the
-# number 185 indicate the ``stop_pack index`` is 185, by using
+# number 186 indicate the ``stop_pack index`` is 186, by using
 # name and index number, here we can located to correct place
 # where to start/end when there are multiple ``nn.max_pool2d``
 # or ``cast``, print(mod.astext(show_meta_data=False)) can help


### PR DESCRIPTION
I ran into import errors while following the ~~VTA tutorial for 'Deploy Pretrained Vision Model from MxNet on VTA'~~ under Ubuntu 18.04.5 LTS and Docker images created with Dockerfile.ci_cpu. Scripts launched from tvm base directory.

~~File: tvm/vta/tutorials/frontend/deploy_classification.py
In line 59 to 61:~~


~~import vta
from vta.testing import simulator
 from vta.top import graph_pack~~

~~Import paths have changed and function call for graph_pack in line 181.~~

~~Changed to:~~

~~import vta
from vta.python.vta.testing import simulator
from vta.python.vta.top import graphpack as graph_pack
from vta.python import vta~~

~~and in line 181~~

~~relay_prog = graph_pack.graph_pack(~~

Issue in file tvm/vta/tutorials/frontend/legacy/deploy_detection.py

Line 61:

       from tvm.contrib import graph_runtime, graph_runtime, util

Changed to:

       from tvm.contrib import graph_runtime, graph_runtime, utils


Also layer id for stop layer 'cast' changed from 185 to 186 in line 126 and in the comment.
