### PR TITLE
[Relay][Strategy] Allow cuda cross compilation without physical device.

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -287,8 +287,8 @@ def have_tensorcore(compute_version=None, target=None):
         else:
             if target is None or "arch" not in target.attrs:
                 warnings.warn(
-                    "Cannot find cuda architecture, try specifying it by adding '-arch=sm_xx'"
-                    "to your target. Tensorcore schedules will be disabled."
+                    "Tensorcore will be disabled due to no CUDA architecture specified."
+                    "Try specifying it by adding '-arch=sm_xx' to your target."
                 )
                 return False
             compute_version = target.attrs["arch"]

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -284,8 +284,8 @@ def have_tensorcore(compute_version=None):
         else:
             compute_version = AutotvmGlobalScope.current.cuda_target_arch
             # Compute version will be in the form "sm_{major}{minor}"
-            major, minor = compute_version.split('_')[1]
-            compute_version = major + '.' + minor
+            major, minor = compute_version.split("_")[1]
+            compute_version = major + "." + minor
     major, _ = parse_compute_version(compute_version)
 
     if major == 7:

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -23,7 +23,6 @@ import os
 import warnings
 
 import tvm._ffi
-from tvm.autotvm.env import AutotvmGlobalScope
 from tvm.runtime import ndarray as nd
 
 from . import utils
@@ -270,24 +269,29 @@ def have_int8(compute_version):
     return False
 
 
-def have_tensorcore(compute_version=None):
+def have_tensorcore(compute_version=None, target=None):
     """Either TensorCore support is provided in the compute capability or not
 
     Parameters
     ----------
-    compute_version : str
-        compute capability of a GPU (e.g. "7.0")
+    compute_version : str, optional
+        compute capability of a GPU (e.g. "7.0").
+
+    target : tvm.target.Target, optional
+        The compilation target, will be used to determine arch if compute_version
+        isn't specified.
     """
     if compute_version is None:
         if tvm.gpu(0).exist:
             compute_version = tvm.gpu(0).compute_version
         else:
-            compute_version = AutotvmGlobalScope.current.cuda_target_arch
-            if compute_version is None:
+            if target is None or "arch" not in target.attrs:
                 warnings.warn(
-                    "Cannot find cuda architecture. Tensorcore schedules will be disabled."
+                    "Cannot find cuda architecture, try specifying it by adding '-arch=sm_xx'"
+                    "to your target. Tensorcore schedules will be disabled."
                 )
                 return False
+            compute_version = target.attrs["arch"]
             # Compute version will be in the form "sm_{major}{minor}"
             major, minor = compute_version.split("_")[1]
             compute_version = major + "." + minor

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -283,6 +283,11 @@ def have_tensorcore(compute_version=None):
             compute_version = tvm.gpu(0).compute_version
         else:
             compute_version = AutotvmGlobalScope.current.cuda_target_arch
+            if compute_version is None:
+                warnings.warn(
+                    "Cannot find cuda architecture. Tensorcore schedules will be disabled."
+                )
+                return False
             # Compute version will be in the form "sm_{major}{minor}"
             major, minor = compute_version.split("_")[1]
             compute_version = major + "." + minor

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -23,6 +23,7 @@ import os
 import warnings
 
 import tvm._ffi
+from tvm.autotvm.env import AutotvmGlobalScope
 from tvm.runtime import ndarray as nd
 
 from . import utils
@@ -269,7 +270,7 @@ def have_int8(compute_version):
     return False
 
 
-def have_tensorcore(compute_version):
+def have_tensorcore(compute_version=None):
     """Either TensorCore support is provided in the compute capability or not
 
     Parameters
@@ -277,7 +278,16 @@ def have_tensorcore(compute_version):
     compute_version : str
         compute capability of a GPU (e.g. "7.0")
     """
+    if compute_version is None:
+        if tvm.gpu(0).exist:
+            compute_version = tvm.gpu(0).compute_version
+        else:
+            compute_version = AutotvmGlobalScope.current.cuda_target_arch
+            # Compute version will be in the form "sm_{major}{minor}"
+            major, minor = compute_version.split('_')[1]
+            compute_version = major + '.' + minor
     major, _ = parse_compute_version(compute_version)
+
     if major == 7:
         return True
 

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -197,7 +197,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
             if judge_winograd_autotvm:
                 if (
                     target.kind.name == "cuda"
-                    and nvcc.have_tensorcore(tvm.gpu(0).compute_version)
+                    and nvcc.have_tensorcore()
                     and judge_winograd_tensorcore
                 ):
                     strategy.add_implementation(
@@ -215,7 +215,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                     )
             if (
                 target.kind.name == "cuda"
-                and nvcc.have_tensorcore(tvm.gpu(0).compute_version)
+                and nvcc.have_tensorcore()
                 and (
                     (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
                     or (N % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
@@ -436,7 +436,7 @@ def conv2d_winograd_without_weight_transfrom_strategy_cuda(attrs, inputs, out_ty
         )
         if (
             target.kind.name == "cuda"
-            and nvcc.have_tensorcore(tvm.gpu(0).compute_version)
+            and nvcc.have_tensorcore()
             and judge_winograd_tensorcore
         ):
             strategy.add_implementation(
@@ -563,7 +563,7 @@ def conv3d_strategy_cuda(attrs, inputs, out_type, target):
         N, _, _, _, _ = get_const_tuple(data.shape)
         _, _, _, CI, CO = get_const_tuple(kernel.shape)
         if target.kind.name == "cuda":
-            if nvcc.have_tensorcore(tvm.gpu(0).compute_version):
+            if nvcc.have_tensorcore():
                 if (
                     (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
                     or (N % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
@@ -679,7 +679,7 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
                 plevel=5,
             )
         if target.kind.name == "cuda":
-            if nvcc.have_tensorcore(tvm.gpu(0).compute_version):
+            if nvcc.have_tensorcore():
                 if (
                     (i % 16 == 0 and b % 16 == 0 and o % 16 == 0)
                     or (i % 16 == 0 and b % 8 == 0 and o % 32 == 0)

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -197,7 +197,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
             if judge_winograd_autotvm:
                 if (
                     target.kind.name == "cuda"
-                    and nvcc.have_tensorcore()
+                    and nvcc.have_tensorcore(target=target)
                     and judge_winograd_tensorcore
                 ):
                     strategy.add_implementation(
@@ -215,7 +215,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                     )
             if (
                 target.kind.name == "cuda"
-                and nvcc.have_tensorcore()
+                and nvcc.have_tensorcore(target=target)
                 and (
                     (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
                     or (N % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
@@ -434,7 +434,11 @@ def conv2d_winograd_without_weight_transfrom_strategy_cuda(attrs, inputs, out_ty
             kernel.dtype,
             pre_flag=True,
         )
-        if target.kind.name == "cuda" and nvcc.have_tensorcore() and judge_winograd_tensorcore:
+        if (
+            target.kind.name == "cuda"
+            and nvcc.have_tensorcore(target=target)
+            and judge_winograd_tensorcore
+        ):
             strategy.add_implementation(
                 wrap_compute_conv2d(
                     topi.cuda.conv2d_nhwc_winograd_tensorcore_without_weight_transform
@@ -559,7 +563,7 @@ def conv3d_strategy_cuda(attrs, inputs, out_type, target):
         N, _, _, _, _ = get_const_tuple(data.shape)
         _, _, _, CI, CO = get_const_tuple(kernel.shape)
         if target.kind.name == "cuda":
-            if nvcc.have_tensorcore():
+            if nvcc.have_tensorcore(target=target):
                 if (
                     (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)
                     or (N % 8 == 0 and CI % 16 == 0 and CO % 32 == 0)
@@ -675,7 +679,7 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
                 plevel=5,
             )
         if target.kind.name == "cuda":
-            if nvcc.have_tensorcore():
+            if nvcc.have_tensorcore(target=target):
                 if (
                     (i % 16 == 0 and b % 16 == 0 and o % 16 == 0)
                     or (i % 16 == 0 and b % 8 == 0 and o % 32 == 0)

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -434,11 +434,7 @@ def conv2d_winograd_without_weight_transfrom_strategy_cuda(attrs, inputs, out_ty
             kernel.dtype,
             pre_flag=True,
         )
-        if (
-            target.kind.name == "cuda"
-            and nvcc.have_tensorcore()
-            and judge_winograd_tensorcore
-        ):
+        if target.kind.name == "cuda" and nvcc.have_tensorcore() and judge_winograd_tensorcore:
             strategy.add_implementation(
                 wrap_compute_conv2d(
                     topi.cuda.conv2d_nhwc_winograd_tensorcore_without_weight_transform


### PR DESCRIPTION
The recent addition of tensorcore schedules has broken TVM's ability to compile for cuda on a machine without a GPU. This is because the strategy registration for tensorcores calls `tvm.gpu(0).compute_version`, which fails when no gpu is present. I've changed the behavior of `nvcc.have_tensorcore` to check `AutotvmGlobalScope.current.cuda_target_arch` when a GPU isn't present. This allows a user to call something like `tvm.autotvm.measure.measure_methods.set_cuda_target_arch("sm_62")` to specify a cuda cross compilation target on a machine without a GPU and build correctly.

I'm not sure how to test this since it would require a CPU node that's built with the cuda toolkit. Let me know if you have an opinion on tests to add to prevent an error like this from sneaking in again.