### PR TITLE
[Auto Scheduler][Auto TVM] Fix infer tile size for NHWC winograd for CUDA

### DIFF
--- a/python/tvm/topi/cuda/conv2d_alter_op.py
+++ b/python/tvm/topi/cuda/conv2d_alter_op.py
@@ -62,7 +62,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
             KH, KW, _, CO = get_const_tuple(kernel.shape)
 
             # Pre-compute weight transformation in winograd
-            tile_size = _infer_tile_size(tinfos[0], tinfos[1])
+            tile_size = _infer_tile_size(tinfos[0], tinfos[1], layout="NHWC")
 
             # HWIO -> OIHW
             kernel_transform = relay.transpose(inputs[1], axes=[3, 2, 0, 1])
@@ -159,7 +159,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
         KH, KW, _, CO = get_const_tuple(kernel.shape)
 
         # Pre-compute weight transformation in winograd
-        tile_size = _infer_tile_size(data, kernel)
+        tile_size = _infer_tile_size(data, kernel, layout="NHWC")
         kernel_transform = relay.transpose(inputs[1], axes=[3, 2, 0, 1])
         weight = relay.nn.contrib_conv2d_winograd_weight_transform(
             kernel_transform, tile_size=tile_size

--- a/python/tvm/topi/cuda/conv2d_winograd.py
+++ b/python/tvm/topi/cuda/conv2d_winograd.py
@@ -31,8 +31,12 @@ from ..nn.conv2d import conv2d_winograd_nhwc, _conv2d_winograd_nhwc_impl
 logger = logging.getLogger("conv2d_winograd")
 
 
-def _infer_tile_size(data, kernel):
-    N, CI, H, W = get_const_tuple(data.shape)
+def _infer_tile_size(data, kernel, layout="NCHW"):
+    if layout == "NCHW":
+        N, CI, H, W = get_const_tuple(data.shape)
+    else:
+        assert layout == "NHWC"
+        N, H, W, CI = get_const_tuple(data.shape)
 
     if H % 8 == 0:
         return 4


### PR DESCRIPTION
`_infer_tile_size` only works for NCHW layout correctly. We used this function wrongly for NHWC layout on AutoTVM and Auto Scheduler
