### PR TITLE
[AutoSchedule] Compatibility improvement with XGBoost v1.3.0

### DIFF
--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -513,7 +513,10 @@ def custom_callback(
     # pylint: disable=import-outside-toplevel
     from xgboost.core import EarlyStopException
     from xgboost.callback import _fmt_metric
-    from xgboost.training import aggcv
+    try:
+        from xgboost.training import aggcv
+    except ImportError:
+        from xgboost.callback import _aggcv as aggcv
 
     state = {}
     metric_shortname = metric.split("-")[1]

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -513,6 +513,7 @@ def custom_callback(
     # pylint: disable=import-outside-toplevel
     from xgboost.core import EarlyStopException
     from xgboost.callback import _fmt_metric
+
     try:
         from xgboost.training import aggcv
     except ImportError:


### PR DESCRIPTION
In XGBoost v1.3.0, the aggcv function has been moved from [training.py](https://github.com/dmlc/xgboost/blob/release_1.2.0/python-package/xgboost/training.py#L337) to [callback.py](https://github.com/dmlc/xgboost/blob/release_1.3.0/python-package/xgboost/callback.py#L297), the PR addresses the compatibility issue between the versions.

cc @comaniac @merrymercy 