### PR TITLE
Rollback changes to SSA begin/end scope for Store in C codegen

### DIFF
--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -728,14 +728,15 @@ void CodeGenC::VisitStmt_(const StoreNode* op) {
     ICHECK(is_one(op->predicate)) << "Predicated store is not supported";
     arith::PVar<PrimExpr> base;
 
-    // The assignment below introduces side-effect, and the resulting value cannot
-    // be reused across multiple expression, thus a new scope is needed
-    int vec_scope = BeginScope();
 
     if (arith::ramp(base, 1, t.lanes()).Match(op->index)) {
       std::string value = this->PrintExpr(op->value);
       this->PrintVecStore(op->buffer_var.get(), t, base.Eval(), value);
     } else {
+      // The assignment below introduces side-effect, and the resulting value cannot
+      // be reused across multiple expression, thus a new scope is needed
+      int vec_scope = BeginScope();
+
       // store elements seperately
       std::string index = SSAGetID(PrintExpr(op->index), op->index.dtype());
       std::string value = SSAGetID(PrintExpr(op->value), op->value.dtype());
@@ -762,8 +763,8 @@ void CodeGenC::VisitStmt_(const StoreNode* op) {
         PrintVecElemLoad(value, op->value.dtype(), i, stream);
         stream << ";\n";
       }
+      EndScope(vec_scope);
     }
-    EndScope(vec_scope);
   }
 }
 

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -274,6 +274,7 @@ void CodeGenCUDA::PrintVecBinaryOp(const std::string& op, DataType t, PrimExpr l
   this->PrintIndent();
   this->PrintType(t, stream);
   stream << ' ' << sret << ";\n";
+  int ssa_scope = BeginScope();
   {
     // Unpack into individual ops.
     std::string vlhs = SSAGetID(PrintExpr(lhs), lhs.dtype());
@@ -297,6 +298,7 @@ void CodeGenCUDA::PrintVecBinaryOp(const std::string& op, DataType t, PrimExpr l
       PrintVecElemStore(sret, t, i, value_temp.str());
     }
   }
+  EndScope(ssa_scope);
   os << sret;
 }
 


### PR DESCRIPTION
Rollback changes to SSA begin/end scope for Store in C codegen. Instead, scope binary operator codegen in CUDA to fix the issue originally addressed by 5f4b9a9. cc @merrymercy can you please take a look?

This allows for register reuse on opencl codegen when unrolling and vectorizing, but still addresses the bug in the cuda codegen you originally addressed.

Thanks
