### PR TITLE
[AutoTVM] Compatibility improvement with XGBoost v1.3.0

### DIFF
--- a/python/tvm/autotvm/tuner/xgboost_cost_model.py
+++ b/python/tvm/autotvm/tuner/xgboost_cost_model.py
@@ -469,7 +469,11 @@ def custom_callback(
     # pylint: disable=import-outside-toplevel
     from xgboost.core import EarlyStopException
     from xgboost.callback import _fmt_metric
-    from xgboost.training import aggcv
+
+    try:
+        from xgboost.training import aggcv
+    except ImportError:
+        from xgboost.callback import _aggcv as aggcv
 
     state = {}
     metric_shortname = metric.split("-")[1]


### PR DESCRIPTION
In XGBoost v1.3.0, the aggcv function has been moved from training.py to callback.py, the PR addresses the compatibility issue between the versions.

Following #7069

cc @comaniac @merrymercy