### PR TITLE
[Frontend][Relay][Onnx] Allow If shortcut when condition is constant and available.

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2278,6 +2278,15 @@ class If(OnnxOpConverter):
         with else_graph:
             else_expr = else_graph.from_onnx(else_branch, graph_scope.opset, get_output_expr=True)
 
+        # If the condition is an available boolean constant, there's no need to
+        # insert an If statement, just directly return the proper branch.
+        if cond.name_hint in params and params[cond.name_hint].dtype is bool:
+            cond_value = bool(params[cond.name_hint].asnumpy())
+            if cond_value:
+                return then_expr
+            else:
+                return else_expr
+
         # Add constants from both branches to parent graph.
         graph_scope._params.update(then_graph._params)
         then_free_vars = analysis.free_vars(then_expr)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4061,3 +4061,4 @@ if __name__ == "__main__":
     test_loop()
     test_size()
     test_maxunpool()
+    test_if()


### PR DESCRIPTION
I found a goofy model exported from tensorflow that has a ton of If statements but all of their conditions were constant False values. There's no reason for us to insert an If when we know the value of condition so I've added a check in the onnx importer for this case.