### PR TITLE
Mini syntax error due to misplaced comma

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -209,7 +209,7 @@ setup(
     distclass=BinaryDistribution,
     url="https://github.com/apache/tvm",
     ext_modules=config_cython(),
-    **setup_kwargs,
+    **setup_kwargs
 )
 
 


### PR DESCRIPTION
While trying to compile TVM, I came across this tiny syntax error. If you consider it important enough, please accept this fix.


