### PR TITLE
clean standalone CRT files in microTVM VM rebuild script

### DIFF
--- a/apps/microtvm/reference-vm/zephyr/rebuild-tvm.sh
+++ b/apps/microtvm/reference-vm/zephyr/rebuild-tvm.sh
@@ -31,4 +31,5 @@ sed -i 's/USE_MICRO OFF/USE_MICRO ON/' config.cmake
 sed -i 's/USE_GRAPH_RUNTIME_DEBUG OFF/USE_GRAPH_RUNTIME_DEBUG ON/' config.cmake
 sed -i 's/USE_LLVM OFF/USE_LLVM ON/' config.cmake
 cmake ..
+rm -rf standalone_crt host_standalone_crt  # remove stale generated files
 make -j4


### PR DESCRIPTION
This PR fixes a small bug where the microTVM Virtual Machine provisioning would fail when a PR deletes a CRT header or source file, and the user had previously built a microTVM VM at an older revision.