### PR TITLE
[CUDA] Parallel Cuda Mergesort

### DIFF
--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -277,7 +277,7 @@ def _build_for_device(input_mod, target, target_host):
                 lambda f: "calling_conv" not in f.attrs
                 or f.attrs["calling_conv"].value != CallingConv.DEVICE_KERNEL_LAUNCH
             ),
-            tvm.tir.transform.Apply(lambda f: f.with_attr("target", target)),
+            tvm.tir.transform.Apply(lambda f: f.with_attr("target", target_host)),
             tvm.tir.transform.LowerTVMBuiltin(),
             tvm.tir.transform.LowerDeviceStorageAccessInfo(),
             tvm.tir.transform.LowerCustomDatatypes(),

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -450,7 +450,6 @@ def argsort_nms_thrust(data, valid_count, axis=-1, is_ascend=1, dtype="float32")
 
 
 def sort(data, axis=-1, is_ascend=1):
-    # pylint: disable=no-value-for-parameter
     """Performs sorting along the given axis and returns an array of
     sorted values with the same shape as the input data.
 
@@ -472,12 +471,12 @@ def sort(data, axis=-1, is_ascend=1):
     """
     dtype = "float32"
     value_buf = tvm.tir.decl_buffer(data.shape, data.dtype, "value_buf", data_alignment=8)
-    indices_buf = tvm.tir.decl_buffer(data.shape, dtype, "out_buf", data_alignment=8)
+    value_buf_swap = tvm.tir.decl_buffer(data.shape, data.dtype, "value_buf_swap", data_alignment=8)
     out = te.extern(
         [data.shape, data.shape],
         [data],
-        lambda ins, outs: sort_ir(ins[0], outs[0], axis, is_ascend, indices_out=outs[1]),
-        out_buffers=[value_buf, indices_buf],
+        lambda ins, outs: sort_ir(ins[0], outs[0], outs[1], axis, is_ascend),
+        out_buffers=[value_buf, value_buf_swap],
         name="sort_gpu",
         tag="sort_gpu",
     )[0]

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -450,6 +450,7 @@ def argsort_nms_thrust(data, valid_count, axis=-1, is_ascend=1, dtype="float32")
 
 
 def sort(data, axis=-1, is_ascend=1):
+    # pylint: disable=no-value-for-parameter
     """Performs sorting along the given axis and returns an array of
     sorted values with the same shape as the input data.
 

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -193,7 +193,7 @@ def sort_ir(
                     out = b <= a
                 return out
 
-            def BottomUpMerge(source, dest, source_idx, dest_idx, start, middle, end, even):
+            def bottom_up_merge(source, dest, source_idx, dest_idx, start, middle, end, even):
                 """
                 Merge the two sections of the array assigned to this thread
                 """
@@ -244,19 +244,19 @@ def sort_ir(
                     with ib.else_scope():
                         swap_values(dest, source, dest_idx, source_idx)
 
-            def MergeSort(source, dest, source_idx, dest_idx, size, width, even):
+            def mergesort(source, dest, source_idx, dest_idx, size, width, even):
                 # calculate the start, mid, and end points of this section
                 start[0] = width * tid
                 with ib.if_scope(start[0] < size):
                     middle[0] = tvm.te.min(start[0] + tvm.tir.indexdiv(width, 2), size)
                     end[0] = tvm.te.min(start[0] + width, size)
                     ## merge the start->middle and middle->end arrays
-                    BottomUpMerge(
+                    bottom_up_merge(
                         source, dest, source_idx, dest_idx, start[0], middle[0], end[0], even
                     )
 
             # Call the kernel
-            MergeSort(
+            mergesort(
                 values_out,
                 values_out_swap,
                 indices_out,

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -136,18 +136,18 @@ def sort_ir(
     source_idx = indices_out
     dest_idx = indices_out_swap
     lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(shape[axis], "float64"))), "int32"
+        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(shape[axis], "float64"))), "int64"
     )
-    with ib.for_range(0, lim) as l2_width:
+    with ib.for_range(0, lim, dtype="int64") as l2_width:
         width = 2 << l2_width
         slices = tvm.tir.indexdiv(shape[axis], (max_threads * width)) + 1
 
         with ib.new_scope():
-            i = ib.allocate("int32", (1,), name="i", scope="local")
-            j = ib.allocate("int32", (1,), name="j", scope="local")
-            start = ib.allocate("int32", (1,), name="start", scope="local")
-            middle = ib.allocate("int32", (1,), name="middle", scope="local")
-            end = ib.allocate("int32", (1,), name="end", scope="local")
+            i = ib.allocate("int64", (1,), name="i", scope="local")
+            j = ib.allocate("int64", (1,), name="j", scope="local")
+            start = ib.allocate("int64", (1,), name="start", scope="local")
+            middle = ib.allocate("int64", (1,), name="middle", scope="local")
+            end = ib.allocate("int64", (1,), name="end", scope="local")
             tx = te.thread_axis("threadIdx.x")
             bx = te.thread_axis("blockIdx.x")
             ib.scope_attr(tx, "thread_extent", nthread_tx)

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -469,7 +469,6 @@ def sort(data, axis=-1, is_ascend=1):
     out : tvm.te.Tensor
         The output of this function.
     """
-    dtype = "float32"
     value_buf = tvm.tir.decl_buffer(data.shape, data.dtype, "value_buf", data_alignment=8)
     value_buf_swap = tvm.tir.decl_buffer(data.shape, data.dtype, "value_buf_swap", data_alignment=8)
     out = te.extern(

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -1386,6 +1386,7 @@ def test_any_where():
         any_dims(2), any_dims(2), any_dims(2), (3, 4), (3, 1), (1, 4), y_np_shape_invalid=(2, 4)
     )
 
+
 # TODO(kevinthesun): enable gpu test when Thrust is available in ci.
 # @tvm.testing.uses_gpu
 def test_non_max_suppression():

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -250,9 +250,7 @@ def verify_any_argwhere(x_shape, x_np_shape, dtype="bool"):
     check_result([data], mod, expected, flatten=True)
 
 
-# TODO(zhiics) Enable argwhere gpu test after sort is fixed. Otherwise, we have
-# to use thrust to guarantee the correct results which has been tested locally.
-# @tvm.testing.uses_gpu
+@tvm.testing.uses_gpu
 def test_any_argwhere():
     verify_any_argwhere(any_dims(1), (5,))
     verify_any_argwhere(any_dims(2), (5, 5))

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -837,8 +837,7 @@ def verify_any_topk(data_shape, kval, np_dshape, dtype, const_k=False):
     check_result(in_vals, mod, ref_out)
 
 
-# TODO(kevinthesun): enable this test when Thrust is available in ci.
-# @tvm.testing.uses_gpu
+@tvm.testing.uses_gpu
 def test_any_topk():
     verify_any_topk(any_dims(1), 5, (10,), "float32")
     verify_any_topk(any_dims(2), 2, (6, 3), "int32")
@@ -1386,7 +1385,6 @@ def test_any_where():
     verify_any_where(
         any_dims(2), any_dims(2), any_dims(2), (3, 4), (3, 1), (1, 4), y_np_shape_invalid=(2, 4)
     )
-
 
 # TODO(kevinthesun): enable gpu test when Thrust is available in ci.
 # @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level6.py
+++ b/tests/python/relay/test_op_level6.py
@@ -66,9 +66,9 @@ def test_argsort():
         func = relay.Function([x], z)
         x_data = np.random.uniform(size=shape).astype("float32")
         if is_ascend:
-            ref_res = np.argsort(x_data, axis=axis)
+            ref_res = np.argsort(x_data, axis=axis, kind="stable")
         else:
-            ref_res = np.argsort(-x_data, axis=axis)
+            ref_res = np.argsort(-x_data, axis=axis, kind="stable")
 
         if is_dyn:
             backends = ["vm", "debug"]
@@ -86,6 +86,7 @@ def test_argsort():
             verify_argsort((2, 3, 4), axis=0, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
             verify_argsort((1, 4, 6), axis=1, is_ascend=True, dtype=dtype, is_dyn=is_dyn)
             verify_argsort((3, 5, 6), axis=-1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
+            verify_argsort((3, 2000, 6), axis=1, is_ascend=False, dtype=dtype)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level6.py
+++ b/tests/python/relay/test_op_level6.py
@@ -53,6 +53,8 @@ def test_sort():
         verify_sort((2, 3, 4), axis=0, is_ascend=False, is_dyn=is_dyn)
         verify_sort((1, 4, 6), axis=1, is_ascend=True, is_dyn=is_dyn)
         verify_sort((3, 5, 6), axis=-1, is_ascend=False, is_dyn=is_dyn)
+        verify_sort((3, 2000, 6), axis=1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
+        verify_sort((1, 122640), axis=1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
 
 
 @tvm.testing.uses_gpu
@@ -86,7 +88,8 @@ def test_argsort():
             verify_argsort((2, 3, 4), axis=0, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
             verify_argsort((1, 4, 6), axis=1, is_ascend=True, dtype=dtype, is_dyn=is_dyn)
             verify_argsort((3, 5, 6), axis=-1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
-            verify_argsort((3, 2000, 6), axis=1, is_ascend=False, dtype=dtype)
+            verify_argsort((3, 2000, 6), axis=1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
+            verify_argsort((1, 122640), axis=1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level6.py
+++ b/tests/python/relay/test_op_level6.py
@@ -53,8 +53,8 @@ def test_sort():
         verify_sort((2, 3, 4), axis=0, is_ascend=False, is_dyn=is_dyn)
         verify_sort((1, 4, 6), axis=1, is_ascend=True, is_dyn=is_dyn)
         verify_sort((3, 5, 6), axis=-1, is_ascend=False, is_dyn=is_dyn)
-        verify_sort((3, 2000, 6), axis=1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
-        verify_sort((1, 122640), axis=1, is_ascend=False, dtype=dtype, is_dyn=is_dyn)
+        verify_sort((3, 2000, 6), axis=1, is_ascend=False, is_dyn=is_dyn)
+        verify_sort((1, 122640), axis=1, is_ascend=False, is_dyn=is_dyn)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/topi/python/test_topi_argwhere.py
+++ b/tests/python/topi/python/test_topi_argwhere.py
@@ -66,9 +66,7 @@ def verify_argwhere(data_shape):
         check_device(target, ctx)
 
 
-# TODO(zhiics) Enable argwhere gpu test after sort is fixed. Otherwise, we have
-# to use thrust to guarantee the correct results which has been tested locally.
-# @tvm.testing.uses_gpu
+@tvm.testing.uses_gpu
 def test_argwhere():
     verify_argwhere((1,))
     verify_argwhere((100,))

--- a/tests/python/topi/python/test_topi_argwhere.py
+++ b/tests/python/topi/python/test_topi_argwhere.py
@@ -60,9 +60,6 @@ def verify_argwhere(data_shape):
         tvm.testing.assert_allclose(args[-1].asnumpy(), np.array(np_out))
 
     for target, ctx in tvm.testing.enabled_targets():
-        # TODO(zhiics) Enable argwhere gpu test after sort is fixed.
-        if ctx.device_type != 1:
-            continue
         check_device(target, ctx)
 
 


### PR DESCRIPTION
@Laurawly @zhiics @icemelon9 @csullivan @tkonolige 

There have been many complaints recently about stability and performance of the tir-based cuda sort kernel. I've spent a couple of days this week getting a cuda version of Parallel Mergesort. It's a stable sort, so it fixes the flakiness we've seen with argsort and argwhere, it changes the threading to support dynamic shapes, and it increases the performance significantly over the previous kernel.

This PR only addresses the core sort_ir function, extending this to other versions sort in this file is future work. 

I tested performance on a variety of shapes using this [script](https://gist.github.com/mbrookhart/c4730cbec48eaa4afcbf86d875847f9f) and obtained these numbers on my 1070TI. It's not as fast as Thrust, as expected, but it's much closer for all shapes tested here, and even manages to beat thrust on a few. (times are in milliseconds)

Thanks!

| Shape         | main    | thrust | this  |
|---------------|---------|--------|-------|
| (2000, 2, 2)  | 7.77    | 0.58   | 1.67  |
| (2, 2000, 2)  | 4.8     | 0.7    | 1.59  |
| (2, 2, 2000)  | 3.24    | 0.63   | 1.54  |
| (4000, 2, 2)  | 25.53   | 0.65   | 4.05  |
| (2, 4000, 2)  | 13.78   | 0.62   | 3.3   |
| (2, 2, 4000)  | 9.85    | 0.63   | 4.04  |
| (2, 12000, 2) | 369.99  | 0.68   | 13.87 |
| (2, 2, 12000) | 86.55   | 0.66   | 11.11 |
| (12000, 2, 2) | 486.65  | 0.66   | 13.69 |
| (2000, 8, 8)  | 259.21  | 10.4   | 4.22  |
| (8, 2000, 8)  | 111.14  | 8.45   | 3.43  |
| (8, 8, 2000)  | 50.37   | 9.05   | 3.05  |
| (4000, 8, 8)  | 671.53  | 8.24   | 9.58  |
| (8, 4000, 8)  | 368.59  | 8.47   | 10.12 |
| (8, 8, 4000)  | 171.18  | 8.74   | 6.27  |
| (12000, 8, 8) | 3571.97 | 15.22  | 42.99 |
| (8, 12000, 8) | 3517.72 | 15.07  | 45.84 |
| (8, 8, 12000) | 1417.97 | 15.03  | 27.57 |