### PR TITLE
[RUNTIME] Add function name to PackedFunc and TypedPackedFunc

### DIFF
--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -65,7 +65,7 @@ class Registry {
    * \param f The body of the function.
    */
   Registry& set_body(PackedFunc::FType f) {  // NOLINT(*)
-    return set_body(PackedFunc(f));
+    return set_body(PackedFunc(f, name_));
   }
   /*!
    * \brief set the body of the function to the given function.
@@ -93,7 +93,7 @@ class Registry {
   template <typename FLambda>
   Registry& set_body_typed(FLambda f) {
     using FType = typename detail::function_signature<FLambda>::FType;
-    return set_body(TypedPackedFunc<FType>(std::move(f)).packed());
+    return set_body(TypedPackedFunc<FType>(std::move(f), name_).packed());
   }
   /*!
    * \brief set the body of the function to be the passed method pointer.
@@ -122,7 +122,7 @@ class Registry {
       // call method pointer
       return (target.*f)(params...);
     };
-    return set_body(TypedPackedFunc<R(T, Args...)>(fwrap));
+    return set_body(TypedPackedFunc<R(T, Args...)>(fwrap, name_));
   }
 
   /*!
@@ -152,7 +152,7 @@ class Registry {
       // call method pointer
       return (target.*f)(params...);
     };
-    return set_body(TypedPackedFunc<R(const T, Args...)>(fwrap));
+    return set_body(TypedPackedFunc<R(const T, Args...)>(fwrap, name_));
   }
 
   /*!
@@ -194,7 +194,7 @@ class Registry {
       // call method pointer
       return (target->*f)(params...);
     };
-    return set_body(TypedPackedFunc<R(TObjectRef, Args...)>(fwrap));
+    return set_body(TypedPackedFunc<R(TObjectRef, Args...)>(fwrap, name_));
   }
 
   /*!
@@ -236,7 +236,7 @@ class Registry {
       // call method pointer
       return (target->*f)(params...);
     };
-    return set_body(TypedPackedFunc<R(TObjectRef, Args...)>(fwrap));
+    return set_body(TypedPackedFunc<R(TObjectRef, Args...)>(fwrap, name_));
   }
 
   /*!

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -181,7 +181,7 @@ TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValu
     }
     return PackedFunc();
   };
-  *ret = TypedPackedFunc<PackedFunc(std::string)>(f);
+  *ret = TypedPackedFunc<PackedFunc(std::string)>(f, "arith.CreateAnalyzer");
 });
 
 }  // namespace arith

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -58,6 +58,7 @@ struct Registry::Manager {
 
 Registry& Registry::set_body(PackedFunc f) {  // NOLINT(*)
   func_ = f;
+  f.name_ = name_;
   return *this;
 }
 

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -58,7 +58,7 @@ struct Registry::Manager {
 
 Registry& Registry::set_body(PackedFunc f) {  // NOLINT(*)
   func_ = f;
-  f.name_ = name_;
+  func_.set_name(name_);
   return *this;
 }
 


### PR DESCRIPTION
This PR adds a `name` field to both `PackedFunc` and `TypedPackedFunc`. This name defaults to `<anonymous>`, but I've also added code that sets the name for `TVM_REGISTER_GLOBAL().set_body()` and `TVM_REGISTER_GLOBAL().set_body_typed()`. With this change, the error messages for incorrect number of arguments is now a lot more clear: it prints the function name in the error message.

I'm not sure if the approach I am using here makes sense. I'd like feedback on whether or not this is the correct direction to go.

@tqchen @jroesch @junrushao1994 
