### PR TITLE
[Relay][Frontend][Onnx] Auto extract onnx input shapes when possible.

### DIFF
--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -161,16 +161,7 @@ class OnnxFrontend(Frontend):
         # pylint: disable=E1101
         model = onnx.load(path)
 
-        # pylint: disable=E1101
-        name = model.graph.input[0].name
-
-        # pylint: disable=E1101
-        proto_shape = model.graph.input[0].type.tensor_type.shape.dim
-        shape = [d.dim_value for d in proto_shape]
-
-        shape_dict = {name: shape}
-
-        return relay.frontend.from_onnx(model, shape_dict)
+        return relay.frontend.from_onnx(model)
 
 
 class TensorflowFrontend(Frontend):


### PR DESCRIPTION
Onnx has shapes associated with each input in the graph. In many cases, there is no need for users to specify those shapes since we can simply pull them out. In the onnx importer today, however, an error is thrown whenever shapes aren't explicitly provided. This PR changes that behavior and should make the importer much more user friendly. If an input shape can be extracted and is static, it does not need to be passed in as a shape dictionary. If there are unknown shapes, the importer will raise a warning but continue assuming they're dynamic.