### PR TITLE
[metal] Remove support of `double` type

### DIFF
--- a/src/target/source/codegen_metal.cc
+++ b/src/target/source/codegen_metal.cc
@@ -180,9 +180,6 @@ void CodeGenMetal::PrintType(DataType t, std::ostream& os) {  // NOLINT(*)
       case 32:
         os << "float";
         break;
-      case 64:
-        os << "double";
-        break;
       default:
         fail = true;
         break;


### PR DESCRIPTION
According to latest Metal spec (v2.3), `double` is still not supported.