### PR TITLE
[CI] Add ACL to the CI for AArch64

### DIFF
--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -41,3 +41,7 @@ RUN bash /install/ubuntu_install_python_package.sh
 # AutoTVM deps
 COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh
 RUN bash /install/ubuntu_install_redis.sh
+
+# Arm(R) Compute Library
+COPY install/ubuntu_install_arm_compute_lib.sh /install/ubuntu_install_arm_compute_lib.sh
+RUN bash /install/ubuntu_install_arm_compute_lib.sh

--- a/tests/scripts/task_python_arm_compute_library.sh
+++ b/tests/scripts/task_python_arm_compute_library.sh
@@ -18,20 +18,13 @@
 
 set -e
 set -u
+source tests/scripts/setup-pytest-env.sh
 
-mkdir -p build
-cd build
-cp ../cmake/config.cmake .
 
-echo set\(USE_SORT ON\) >> config.cmake
-echo set\(USE_RPC ON\) >> config.cmake
-echo set\(USE_GRAPH_RUNTIME_DEBUG ON\) >> config.cmake
-echo set\(USE_MICRO ON\) >> config.cmake
-echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
-echo set\(USE_VM_PROFILER ON\) >> config.cmake
-echo set\(USE_LLVM llvm-config-8\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
-echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
-echo set\(USE_VTA_TSIM ON\) >> config.cmake
-echo set\(USE_VTA_FSIM ON\) >> config.cmake
-echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
+# Rebuild cython
+
+find . -type f -path "*.pyc" | xargs rm -f
+make cython3
+
+TVM_FFI=ctypes python3 -m pytest tests/python/contrib/test_arm_compute_lib
+


### PR DESCRIPTION
Add testing for ACL to the CI for AArch64. A PR follows
to add this to the Jenkinsfile once the docker changes land.
We also need a separate script to run the tests as the full
python integration tests are currently broken.

[I've tried this on an AArch64 Linux machine and it appears to
work ok.]

I think we'll need to bake a new docker image before the
jenkins file changes land.

@zhiics @comaniac @lhutton1 
