### PR TITLE
[Torch] Fix PyTorch NMS conversion for negative scores

### DIFF
--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1675,10 +1675,10 @@ def test_forward_nms():
         boxes = torch.rand(num_boxes, box_len, dtype=torch.float) * 0.5
         boxes[:, 2] += boxes[:, 0]
         boxes[:, 3] += boxes[:, 1]
-        scores = torch.rand(num_boxes, dtype=torch.float)
+        scores = torch.from_numpy(np.random.uniform(-1, 1, size=(num_boxes,)).astype(np.float32))
         return boxes, scores
 
-    targets = ["llvm"]  # dynamic nms does not work on gpu
+    targets = ["llvm", "cuda"]
 
     for num_boxes, iou_thres in [(10, 0.3), (100, 0.5), (500, 0.9)]:
         in_boxes, in_scores = _gen_rand_inputs(num_boxes)

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -86,6 +86,15 @@ def generate_jit_model(index):
         return script_module
 
 
+def count_valid_scores(scores, score_threshold):
+    num_valid_scores = 0
+    for score in scores:
+        if score >= score_threshold:
+            num_valid_scores += 1
+        else:
+            return num_valid_scores
+
+
 def test_detection_models():
     img = "test_street_small.jpg"
     img_url = (
@@ -128,3 +137,7 @@ def test_detection_models():
         )
         # Class ids
         np.testing.assert_equal(pt_res[2].cpu().numpy(), tvm_res[2].asnumpy())
+
+        score_threshold = 0.9
+        print("Num boxes:", pt_res[0].cpu().numpy().shape[0])
+        print("Num valid boxes:", count_valid_scores(pt_res[1].cpu().numpy(), score_threshold))

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -86,15 +86,6 @@ def generate_jit_model(index):
         return script_module
 
 
-def count_valid_scores(scores, score_threshold):
-    num_valid_scores = 0
-    for score in scores:
-        if score >= score_threshold:
-            num_valid_scores += 1
-        else:
-            return num_valid_scores
-
-
 def test_detection_models():
     img = "test_street_small.jpg"
     img_url = (
@@ -140,4 +131,4 @@ def test_detection_models():
 
         score_threshold = 0.9
         print("Num boxes:", pt_res[0].cpu().numpy().shape[0])
-        print("Num valid boxes:", count_valid_scores(pt_res[1].cpu().numpy(), score_threshold))
+        print("Num valid boxes:", np.sum(pt_res[1].cpu().numpy() >= score_threshold))

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -71,7 +71,7 @@ def generate_jit_model(index):
     ]
 
     model_func = model_funcs[index]
-    model = TraceWrapper(model_func(pretrained=True, rpn_post_nms_top_n_test=200))
+    model = TraceWrapper(model_func(pretrained=True, rpn_pre_nms_top_n_test=200))
 
     model.eval()
     inp = torch.Tensor(np.random.uniform(0.0, 250.0, size=(1, 3, in_size, in_size)))

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -23,6 +23,7 @@ import cv2
 
 import tvm
 
+import tvm.testing
 from tvm import relay
 from tvm.runtime.vm import VirtualMachine
 from tvm.contrib.download import download
@@ -94,46 +95,36 @@ def test_detection_models():
     download(img_url, img)
 
     input_shape = (1, 3, in_size, in_size)
-    target = "llvm"
+
     input_name = "input0"
     shape_list = [(input_name, input_shape)]
-    score_threshold = 0.9
 
     scripted_model = generate_jit_model(1)
     mod, params = relay.frontend.from_pytorch(scripted_model, shape_list)
 
-    with tvm.transform.PassContext(opt_level=3, disabled_pass=["FoldScaleAxis"]):
-        vm_exec = relay.vm.compile(mod, target=target, params=params)
-
-    ctx = tvm.cpu()
-    vm = VirtualMachine(vm_exec, ctx)
     data = process_image(img)
-    pt_res = scripted_model(data)
-    data = data.detach().numpy()
-    vm.set_input("main", **{input_name: data})
-    tvm_res = vm.run()
+    data_np = data.detach().numpy()
 
-    # Note: due to accumulated numerical error, we can't directly compare results
-    # with pytorch output. Some boxes might have a quite tiny difference in score
-    # and the order can become different. We just measure how many valid boxes
-    # there are for input image.
-    pt_scores = pt_res[1].detach().numpy().tolist()
-    tvm_scores = tvm_res[1].asnumpy().tolist()
-    num_pt_valid_scores = num_tvm_valid_scores = 0
+    with torch.no_grad():
+        pt_res = scripted_model(data)
 
-    for score in pt_scores:
-        if score >= score_threshold:
-            num_pt_valid_scores += 1
-        else:
-            break
+    for target in ["llvm", "cuda"]:
+        with tvm.transform.PassContext(opt_level=3):
+            vm_exec = relay.vm.compile(mod, target=target, params=params)
 
-    for score in tvm_scores:
-        if score >= score_threshold:
-            num_tvm_valid_scores += 1
-        else:
-            break
+        ctx = tvm.context(target, 0)
+        vm = VirtualMachine(vm_exec, ctx)
 
-    assert num_pt_valid_scores == num_tvm_valid_scores, (
-        "Output mismatch: Under score threshold {}, Pytorch has {} valid "
-        "boxes while TVM has {}.".format(score_threshold, num_pt_valid_scores, num_tvm_valid_scores)
-    )
+        vm.set_input("main", **{input_name: data_np})
+        tvm_res = vm.run()
+
+        # Bounding boxes
+        tvm.testing.assert_allclose(
+            pt_res[0].cpu().numpy(), tvm_res[0].asnumpy(), rtol=1e-5, atol=1e-5
+        )
+        # Scores
+        tvm.testing.assert_allclose(
+            pt_res[1].cpu().numpy(), tvm_res[1].asnumpy(), rtol=1e-5, atol=1e-5
+        )
+        # Class ids
+        np.testing.assert_equal(pt_res[2].cpu().numpy(), tvm_res[2].asnumpy())

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -71,7 +71,7 @@ def generate_jit_model(index):
     ]
 
     model_func = model_funcs[index]
-    model = TraceWrapper(model_func(pretrained=True))
+    model = TraceWrapper(model_func(pretrained=True, rpn_post_nms_top_n_test=200))
 
     model.eval()
     inp = torch.Tensor(np.random.uniform(0.0, 250.0, size=(1, 3, in_size, in_size)))


### PR DESCRIPTION
While investigating GPU NMS performance on MaskRCNN workload, I found that PyTorch NMS can have negative scores in its input. In that case, converted Relay model produces a wrong result for the two reasons:

* GPU NMS IR treats negative scores as invalid.
* Our frontend is using `get_valid_counts` even though PyTorch doesn't have `score_threshold` parameter. We are arbitrary using -1 as a `score_threshold`, which is not correct.

The issue is fixed by adding an offset to the scores appropriately and removing a call to `get_valid_counts`.  

please review @yongwww @kevinthesun @zhiics @t-vi 