### PR TITLE
[AutoScheduler] Python based measure callbacks

### DIFF
--- a/include/tvm/auto_scheduler/measure.h
+++ b/include/tvm/auto_scheduler/measure.h
@@ -232,6 +232,33 @@ class MeasureCallback : public ObjectRef {
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MeasureCallback, ObjectRef, MeasureCallbackNode);
 };
 
+/*! \brief A wrapper for measure callback defined by python code
+ *  This class will call functions defined in the python */
+class PythonBasedMeasureCallbackNode : public MeasureCallbackNode {
+ public:
+  /*! \brief Pointer to the callback funcion in python */
+  PackedFunc callback_func;
+
+  static constexpr const char* _type_key = "auto_scheduler.PythonBasedMeasureCallback";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PythonBasedMeasureCallbackNode, MeasureCallbackNode);
+};
+
+/*!
+ * \brief Managed reference to PythonBasedMeasureCallbackNode.
+ * \sa PythonBasedMeasureCallbackNode
+ */
+class PythonBasedMeasureCallback : public MeasureCallback {
+ public:
+  /*!
+   * \brief The constructor.
+   * \param callback The pointer to the callback function defined in python
+   */
+  PythonBasedMeasureCallback(PackedFunc callback);
+
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PythonBasedMeasureCallback, MeasureCallback,
+                                        PythonBasedMeasureCallbackNode);
+};
+
 // The base class of ProgramBuilders and ProgramRunners.
 
 /*! \brief ProgramBuilder that builds the programs */

--- a/include/tvm/auto_scheduler/measure.h
+++ b/include/tvm/auto_scheduler/measure.h
@@ -239,6 +239,8 @@ class PythonBasedMeasureCallbackNode : public MeasureCallbackNode {
   /*! \brief Pointer to the callback funcion in python */
   PackedFunc callback_func;
 
+  void Callback(const SearchPolicy& policy, const Array<MeasureInput>& inputs,
+                const Array<MeasureResult>& results) final;
   static constexpr const char* _type_key = "auto_scheduler.PythonBasedMeasureCallback";
   TVM_DECLARE_FINAL_OBJECT_INFO(PythonBasedMeasureCallbackNode, MeasureCallbackNode);
 };
@@ -251,9 +253,9 @@ class PythonBasedMeasureCallback : public MeasureCallback {
  public:
   /*!
    * \brief The constructor.
-   * \param callback The pointer to the callback function defined in python
+   * \param callback_func The pointer to the callback function defined in python
    */
-  PythonBasedMeasureCallback(PackedFunc callback);
+  explicit PythonBasedMeasureCallback(PackedFunc callback_func);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PythonBasedMeasureCallback, MeasureCallback,
                                         PythonBasedMeasureCallbackNode);

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -92,6 +92,7 @@ class PythonBasedMeasureCallback(MeasureCallback):
         """
         raise NotImplementedError
 
+
 @tvm._ffi.register_object("auto_scheduler.MeasureInput")
 class MeasureInput(Object):
     """Store the input of a measurement.

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -75,18 +75,16 @@ class PythonBasedMeasureCallback(MeasureCallback):
     """Base class for measure callbacks implemented in python"""
 
     def __init__(self):
-        def callback_func(policy, inputs, results):
-            self.callback(policy, inputs, results)
+        def callback_func(inputs, results):
+            self.callback(inputs, results)
 
         self.__init_handle_by_constructor__(_ffi_api.PythonBasedMeasureCallback, callback_func)
 
-    def callback(self, policy, inputs, results):
+    def callback(self, inputs, results):
         """Update the cost model according to new measurement results (training data).
 
         Parameters
         ----------
-        policy: SearchPolicy
-            The search policy.
         inputs : List[auto_scheduler.measure.MeasureInput]
             The measurement inputs
         results : List[auto_scheduler.measure.MeasureResult]

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -81,7 +81,7 @@ class PythonBasedMeasureCallback(MeasureCallback):
         self.__init_handle_by_constructor__(_ffi_api.PythonBasedMeasureCallback, callback_func)
 
     def callback(self, policy, inputs, results):
-        """Update the cost model according to new measurement results (training data).
+        """The callback function.
 
         Parameters
         ----------

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -75,16 +75,18 @@ class PythonBasedMeasureCallback(MeasureCallback):
     """Base class for measure callbacks implemented in python"""
 
     def __init__(self):
-        def callback_func(inputs, results):
-            self.callback(inputs, results)
+        def callback_func(policy, inputs, results):
+            self.callback(policy, inputs, results)
 
         self.__init_handle_by_constructor__(_ffi_api.PythonBasedMeasureCallback, callback_func)
 
-    def callback(self, inputs, results):
+    def callback(self, policy, inputs, results):
         """Update the cost model according to new measurement results (training data).
 
         Parameters
         ----------
+        policy: auto_scheduler.search_policy.SearchPolicy
+            The search policy.
         inputs : List[auto_scheduler.measure.MeasureInput]
             The measurement inputs
         results : List[auto_scheduler.measure.MeasureResult]

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -70,6 +70,30 @@ class MeasureCallback(Object):
     """ The base class of measurement callback functions. """
 
 
+@tvm._ffi.register_object("auto_scheduler.PythonBasedMeasureCallback")
+class PythonBasedMeasureCallback(MeasureCallback):
+    """Base class for measure callbacks implemented in python"""
+
+    def __init__(self):
+        def callback_func(policy, inputs, results):
+            self.callback(policy, inputs, results)
+
+        self.__init_handle_by_constructor__(_ffi_api.PythonBasedMeasureCallback, callback_func)
+
+    def callback(self, policy, inputs, results):
+        """Update the cost model according to new measurement results (training data).
+
+        Parameters
+        ----------
+        policy: SearchPolicy
+            The search policy.
+        inputs : List[auto_scheduler.measure.MeasureInput]
+            The measurement inputs
+        results : List[auto_scheduler.measure.MeasureResult]
+            The measurement results
+        """
+        raise NotImplementedError
+
 @tvm._ffi.register_object("auto_scheduler.MeasureInput")
 class MeasureInput(Object):
     """Store the input of a measurement.

--- a/src/auto_scheduler/measure.cc
+++ b/src/auto_scheduler/measure.cc
@@ -36,6 +36,7 @@ TVM_REGISTER_NODE_TYPE(MeasureInputNode);
 TVM_REGISTER_NODE_TYPE(BuildResultNode);
 TVM_REGISTER_NODE_TYPE(MeasureResultNode);
 TVM_REGISTER_OBJECT_TYPE(MeasureCallbackNode);
+TVM_REGISTER_OBJECT_TYPE(PythonBasedMeasureCallbackNode);
 TVM_REGISTER_OBJECT_TYPE(ProgramRunnerNode);
 TVM_REGISTER_OBJECT_TYPE(ProgramBuilderNode);
 TVM_REGISTER_OBJECT_TYPE(ProgramMeasurerNode);
@@ -358,6 +359,11 @@ TVM_REGISTER_GLOBAL("auto_scheduler.MeasureResult")
     .set_body_typed([](Array<PrimExpr> costs, int error_no, String error_msg, double all_cost,
                        double timestamp) {
       return MeasureResult(costs, error_no, error_msg, all_cost, timestamp);
+    });
+
+TVM_REGISTER_GLOBAL("auto_scheduler.PythonBasedMeasureCallback")
+    .set_body_typed([](PackedFunc callback_func) {
+      return PythonBasedMeasureCallback(callback_func);
     });
 
 TVM_REGISTER_GLOBAL("auto_scheduler.ProgramMeasurer")

--- a/src/auto_scheduler/measure.cc
+++ b/src/auto_scheduler/measure.cc
@@ -184,6 +184,19 @@ Array<MeasureResult> RPCRunnerNode::Run(const Array<MeasureInput>& inputs,
   return Array<MeasureResult>();
 }
 
+/********** MeasureCallback **********/
+PythonBasedMeasureCallback::PythonBasedMeasureCallback(PackedFunc callback_func) {
+  auto node = make_object<PythonBasedMeasureCallbackNode>();
+  node->callback_func = std::move(callback_func);
+  data_ = std::move(node);
+}
+
+void PythonBasedMeasureCallbackNode::Callback(const SearchPolicy& policy,
+                                              const Array<MeasureInput>& inputs,
+                                              const Array<MeasureResult>& results) {
+  callback_func(inputs, results);
+}
+
 /********** ProgramMeasurer **********/
 ProgramMeasurer::ProgramMeasurer(ProgramBuilder builder, ProgramRunner runner,
                                  Optional<Array<MeasureCallback>> callbacks, int verbose,

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -22,11 +22,14 @@ from tvm import auto_scheduler, relay
 
 from test_auto_scheduler_task_extraction import get_network
 
+
 class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
     """A simple Python-based callback for testing."""
+
     def callback(self, inputs, results):
         for inp, res in zip(inputs, results):
             print(inp, res)
+
 
 def tune_network(network, target):
     # Extract tasks

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -23,15 +23,6 @@ from tvm import auto_scheduler, relay
 from test_auto_scheduler_task_extraction import get_network
 
 
-class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
-    """A simple Python-based callback for testing."""
-
-    def callback(self, policy, inputs, results):
-        assert isinstance(policy, auto_scheduler.search_policy.SketchPolicy)
-        for inp, res in zip(inputs, results):
-            print(policy, inp, res)
-
-
 def tune_network(network, target):
     # Extract tasks
     mod, params = get_network(network)

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -26,9 +26,10 @@ from test_auto_scheduler_task_extraction import get_network
 class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
     """A simple Python-based callback for testing."""
 
-    def callback(self, inputs, results):
+    def callback(self, policy, inputs, results):
+        assert isinstance(policy, auto_scheduler.search_policy.SketchPolicy)
         for inp, res in zip(inputs, results):
-            print(inp, res)
+            print(policy, inp, res)
 
 
 def tune_network(network, target):

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -50,7 +50,7 @@ def tune_network(network, target):
             early_stopping=1,
             runner=measure_ctx.runner,
             builder=auto_scheduler.LocalBuilder(timeout=60),
-            measure_callbacks=[auto_scheduler.RecordToFile(log_file), CustomMeasureCallback()],
+            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
         )
         tuner.tune(tune_option, search_policy="sketch.random")
         del measure_ctx

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -24,7 +24,7 @@ from test_auto_scheduler_task_extraction import get_network
 
 class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
     """A simple Python-based callback for testing."""
-    def callback(self, policy, inputs, results):
+    def callback(self, inputs, results):
         for inp, res in zip(inputs, results):
             print(inp, res)
 

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -22,6 +22,11 @@ from tvm import auto_scheduler, relay
 
 from test_auto_scheduler_task_extraction import get_network
 
+class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
+    """A simple Python-based callback for testing."""
+    def callback(self, policy, inputs, results):
+        for inp, res in zip(inputs, results):
+            print(inp, res)
 
 def tune_network(network, target):
     # Extract tasks
@@ -41,7 +46,7 @@ def tune_network(network, target):
             early_stopping=1,
             runner=measure_ctx.runner,
             builder=auto_scheduler.LocalBuilder(timeout=60),
-            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
+            measure_callbacks=[auto_scheduler.RecordToFile(log_file), CustomMeasureCallback()],
         )
         tuner.tune(tune_option, search_policy="sketch.random")
         del measure_ctx

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -34,7 +34,7 @@ class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
     """A simple Python-based callback for testing."""
 
     def callback(self, policy, inputs, results):
-        assert isinstance(policy, auto_scheduler.search_policy.SketchPolicy)
+        assert isinstance(policy, auto_scheduler.search_policy.SearchPolicy)
         for inp, res in zip(inputs, results):
             assert isinstance(inp, auto_scheduler.MeasureInput)
             assert isinstance(res, auto_scheduler.MeasureResult)

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -29,6 +29,14 @@ from tvm import auto_scheduler
 from test_auto_scheduler_common import matmul_auto_scheduler_test, PropagatingThread
 import multiprocessing
 
+class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
+    """A simple Python-based callback for testing."""
+
+    def callback(self, policy, inputs, results):
+        assert isinstance(policy, auto_scheduler.search_policy.SketchPolicy)
+        for inp, res in zip(inputs, results):
+            assert isinstance(inp, auto_scheduler.MeasureInput)
+            assert isinstance(res, auto_scheduler.MeasureResult)
 
 def search_common(
     workload=matmul_auto_scheduler_test,
@@ -68,7 +76,7 @@ def search_common(
             early_stopping=1,
             runner=runner,
             verbose=2,
-            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
+            measure_callbacks=[auto_scheduler.RecordToFile(log_file), CustomMeasureCallback()],
         )
         task.tune(tuning_options=tuning_options, search_policy=search_policy)
         sch, args = task.apply_best(log_file)

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -29,6 +29,7 @@ from tvm import auto_scheduler
 from test_auto_scheduler_common import matmul_auto_scheduler_test, PropagatingThread
 import multiprocessing
 
+
 class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
     """A simple Python-based callback for testing."""
 
@@ -37,6 +38,7 @@ class CustomMeasureCallback(auto_scheduler.measure.PythonBasedMeasureCallback):
         for inp, res in zip(inputs, results):
             assert isinstance(inp, auto_scheduler.MeasureInput)
             assert isinstance(res, auto_scheduler.MeasureResult)
+
 
 def search_common(
     workload=matmul_auto_scheduler_test,


### PR DESCRIPTION
The current auto_scheduler callbacks can only be implemented in C++. This PR exposes the interface of measure callbacks to Python so that people can plug in their own callback functions easily.

~~Note: looks like I cannot pass the `SearchPolicy` node to the `PackedFunc`. Specifically, `callback_func(policy, inputs, results);` results in the type mismatching error. This also prevents us from introducing the Python API for `SearchCallback`. Any advise is appreciated.~~

cc @merrymercy @jcf94 