### PR TITLE
[AutoScheduler] Improve SearchTask and ComputeDAG serialization

### DIFF
--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -173,8 +173,6 @@ class ComputeDAGNode : public Object {
    * This is used as the input of `tvm.lower` or `tvm.build`.
    */
   Array<te::Tensor> tensors;
-  /*! \brief The schedule used to create this ComputeDAG. */
-  te::Schedule sch;
   /*! \brief All used operations in topo order. */
   Array<te::Operation> ops;
   /*! \brief The number of float operations in this ComputeDAG. */
@@ -186,7 +184,6 @@ class ComputeDAGNode : public Object {
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("tensors", &tensors);
-    v->Visit("sch", &sch);
     v->Visit("ops", &ops);
     v->Visit("flop_ct", &flop_ct);
     v->Visit("init_state", &init_state);

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -173,17 +173,20 @@ class ComputeDAGNode : public Object {
    * This is used as the input of `tvm.lower` or `tvm.build`.
    */
   Array<te::Tensor> tensors;
+  /*! \brief The schedule used to create this ComputeDAG. */
+  te::Schedule sch;
   /*! \brief All used operations in topo order. */
   Array<te::Operation> ops;
   /*! \brief The number of float operations in this ComputeDAG. */
   double flop_ct;
   /*! \brief The initial state without any transform steps. */
   State init_state;
-  /*! \brief The static read-write access analyzer */
+  /*! \brief The static read-write access analyzer. */
   AccessAnalyzer access_analyzer;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("tensors", &tensors);
+    v->Visit("sch", &sch);
     v->Visit("ops", &ops);
     v->Visit("flop_ct", &flop_ct);
     v->Visit("init_state", &init_state);

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -228,9 +228,9 @@ class ComputeDAG(Object):
         return "\n".join(lines)
 
     def __getstate__(self):
-        return {"compute": SaveJSON(self.tensors), "sch": SaveJSON(self.sch)}
+        return {"tensors": SaveJSON(self.tensors)}
 
     def __setstate__(self, state):
-        self.__init_handle_by_constructor__(
-            _ffi_api.ComputeDAG, LoadJSON(state["compute"]), LoadJSON(state["sch"])
-        )
+        # Since we always use tensors to recover the ComputeDAG, we do not support
+        # (de)serialization of the ComputeDAG constructed by a schedule.
+        self.__init_handle_by_constructor__(_ffi_api.ComputeDAG, LoadJSON(state["tensors"]), None)

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -87,8 +87,6 @@ class ComputeDAG(Object):
                 "Invalid compute type: %s. ComputeDAG expects string, list of Tensor, or Schedule"
                 % type(compute_or_sche)
             )
-        self.compute = compute
-        self.sche = sche
         self.__init_handle_by_constructor__(_ffi_api.ComputeDAG, compute, sche)
 
     def get_init_state(self):
@@ -230,9 +228,9 @@ class ComputeDAG(Object):
         return "\n".join(lines)
 
     def __getstate__(self):
-        return {"compute": SaveJSON(self.compute), "sche": SaveJSON(self.sche)}
+        return {"compute": SaveJSON(self.tensors), "sch": SaveJSON(self.sch)}
 
     def __setstate__(self, state):
-        self.compute = LoadJSON(state["compute"])  # pylint: disable=assignment-from-no-return
-        self.sche = LoadJSON(state["sche"])  # pylint: disable=assignment-from-no-return
-        self.__init_handle_by_constructor__(_ffi_api.ComputeDAG, self.compute, self.sche)
+        self.__init_handle_by_constructor__(
+            _ffi_api.ComputeDAG, LoadJSON(state["compute"]), LoadJSON(state["sch"])
+        )

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -221,10 +221,6 @@ class SearchTask(Object):
             target_host = Target(target_host)
 
         self.dag = compute_dag
-        self.workload_key = workload_key
-        self.target = target
-        self.target_host = target_host
-        self.hardware_params = hardware_params
         self.__init_handle_by_constructor__(
             _ffi_api.SearchTask, compute_dag, workload_key, target, target_host, hardware_params
         )
@@ -314,13 +310,12 @@ class SearchTask(Object):
 
     def __setstate__(self, state):
         self.dag = state["dag"]
-        self.workload_key = state["workload_key"]
 
         # Register the workload if needed
         try:
-            workload = json.loads(self.workload_key)
+            workload = json.loads(state["workload_key"])
         except Exception:  # pylint: disable=broad-except
-            raise RuntimeError("Invalid workload key %s" % self.workload_key)
+            raise RuntimeError("Invalid workload key %s" % state["workload_key"])
 
         # The workload from a compute DAG does not have arguments and is not registered
         # by default so we register it here. If the workload has already been registered,
@@ -328,16 +323,13 @@ class SearchTask(Object):
         if len(workload) == 1:
             register_workload_tensors(workload[0], self.dag.tensors)
 
-        self.target = state["target"]
-        self.target_host = state["target_host"]
-        self.hardware_params = state["hardware_params"]
         self.__init_handle_by_constructor__(
             _ffi_api.SearchTask,
             self.dag,
-            self.workload_key,
-            self.target,
-            self.target_host,
-            self.hardware_params,
+            state["workload_key"],
+            state["target"],
+            state["target_host"],
+            state["hardware_params"],
         )
 
 

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -220,7 +220,6 @@ class SearchTask(Object):
         if isinstance(target_host, str):
             target_host = Target(target_host)
 
-        self.dag = compute_dag
         self.__init_handle_by_constructor__(
             _ffi_api.SearchTask, compute_dag, workload_key, target, target_host, hardware_params
         )
@@ -301,7 +300,7 @@ class SearchTask(Object):
 
     def __getstate__(self):
         return {
-            "dag": self.dag,
+            "compute_dag": self.compute_dag,
             "workload_key": self.workload_key,
             "target": self.target,
             "target_host": self.target_host,
@@ -309,8 +308,6 @@ class SearchTask(Object):
         }
 
     def __setstate__(self, state):
-        self.dag = state["dag"]
-
         # Register the workload if needed
         try:
             workload = json.loads(state["workload_key"])
@@ -321,11 +318,11 @@ class SearchTask(Object):
         # by default so we register it here. If the workload has already been registered,
         # the later registration overrides the prvious one.
         if len(workload) == 1:
-            register_workload_tensors(workload[0], self.dag.tensors)
+            register_workload_tensors(workload[0], state["compute_dag"].tensors)
 
         self.__init_handle_by_constructor__(
             _ffi_api.SearchTask,
-            self.dag,
+            state["compute_dag"],
             state["workload_key"],
             state["target"],
             state["target_host"],

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -694,6 +694,7 @@ ComputeDAG::ComputeDAG(Array<te::Tensor> tensors) {
   // Make sure it is a valid compute definition
   CheckComputeValidity(sch);
 
+  node->sch = std::move(sch);
   node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
   node->init_state = State(node->ops);
   data_ = std::move(node);
@@ -720,6 +721,7 @@ ComputeDAG::ComputeDAG(const te::Schedule& sch) {
     }
   }
   node->tensors = std::move(tensors);
+  node->sch = std::move(sch);
   node->access_analyzer = AccessAnalyzer(node->tensors);
   node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
   node->init_state = State(node->ops);
@@ -1412,11 +1414,11 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAG")
     .set_body_typed([](Optional<Array<te::Tensor>> tensors, Optional<te::Schedule> sch) {
-      if (tensors) {
-        return ComputeDAG(tensors.value());
+      if (sch) {
+        return ComputeDAG(sch.value());
       }
-      ICHECK(sch) << "Both tensors and schedule are null";
-      return ComputeDAG(sch.value());
+      ICHECK(tensors) << "Both tensors and schedule are null";
+      return ComputeDAG(tensors.value());
     });
 
 TVM_REGISTER_GLOBAL("auto_scheduler.ComputeDAGApplyStepsFromState")

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -694,7 +694,6 @@ ComputeDAG::ComputeDAG(Array<te::Tensor> tensors) {
   // Make sure it is a valid compute definition
   CheckComputeValidity(sch);
 
-  node->sch = std::move(sch);
   node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
   node->init_state = State(node->ops);
   data_ = std::move(node);
@@ -721,7 +720,6 @@ ComputeDAG::ComputeDAG(const te::Schedule& sch) {
     }
   }
   node->tensors = std::move(tensors);
-  node->sch = std::move(sch);
   node->access_analyzer = AccessAnalyzer(node->tensors);
   node->flop_ct = FlopEstimator().EstimateFlop(node->ops);
   node->init_state = State(node->ops);

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -127,8 +127,10 @@ def test_stage_order():
 
     task2 = pickle.loads(pickle.dumps(task))
     assert "test-key" in auto_scheduler.workload_registry.WORKLOAD_FUNC_REGISTRY
-    assert str(task.dag.get_init_state()) == str(task2.dag.get_init_state())
-    assert len(task.dag.get_init_state().stage_ops) == len(task2.dag.get_init_state().stage_ops)
+    assert str(task.compute_dag.get_init_state()) == str(task2.compute_dag.get_init_state())
+    assert len(task.compute_dag.get_init_state().stage_ops) == len(
+        task2.compute_dag.get_init_state().stage_ops
+    )
     assert task.workload_key == task2.workload_key
     assert str(task.target) == str(task2.target)
     assert task.hardware_params.num_cores == task2.hardware_params.num_cores

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -91,11 +91,6 @@ def test_stage_order():
         elif op.name in ["B", "C"]:
             assert stage_ops_1[idx + 1].name == "%s.shared" % op.name
 
-    # Serialize and deserialize the ComputeDAG constructed by a schedule.
-    loaded_dag = pickle.loads(pickle.dumps(dag))
-    assert str(loaded_dag.get_init_state()) == str(dag.get_init_state())
-    assert len(loaded_dag.get_init_state().stage_ops) == len(dag.get_init_state().stage_ops)
-
     # Apply the same schedule to Ansor state and it should have the same stage order
     dag = auto_scheduler.ComputeDAG([A, B, C, D, E])
     state = dag.get_init_state()
@@ -142,8 +137,8 @@ def test_invalid_compute_dag():
     failed = False
     try:
         A, B = invalid_compute_definition()
-        dag = auto_scheduler.ComputeDAG([A, B])
-    except tvm.TVMError as e:
+        auto_scheduler.ComputeDAG([A, B])
+    except tvm.TVMError:
         failed = True
 
     assert failed

--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -119,12 +119,10 @@ def test_stage_order():
     assert str(loaded_dag.get_init_state()) == str(dag.get_init_state())
     assert len(loaded_dag.get_init_state().stage_ops) == len(dag.get_init_state().stage_ops)
 
-    # Serialize and deserialize the search task.
+    # Serialize and deserialize the search task. Note that we intentionally skip hardware_params
+    # to test if the default one is serialized along with other attributes as well.
     task = auto_scheduler.SearchTask(
-        compute_dag=dag,
-        workload_key=json.dumps(("test-key",)),
-        target=tvm.target.Target("llvm"),
-        hardware_params=auto_scheduler.HardwareParams(100000, 16, 64, 0, 0, 0, 0, 0),
+        compute_dag=dag, workload_key=json.dumps(("test-key",)), target=tvm.target.Target("llvm")
     )
 
     task2 = pickle.loads(pickle.dumps(task))

--- a/tests/python/unittest/test_auto_scheduler_feature.py
+++ b/tests/python/unittest/test_auto_scheduler_feature.py
@@ -144,7 +144,7 @@ def test_gpu_feature():
     with tempfile.NamedTemporaryFile(mode="w") as f:
         f.write(json_records)
         f.flush()
-        inputs, results = auto_scheduler.RecordReader(f.name).read_lines()
+        inputs, _ = auto_scheduler.RecordReader(f.name).read_lines()
 
         inp = inputs[0]
         task = auto_scheduler.SearchTask(
@@ -155,7 +155,7 @@ def test_gpu_feature():
             ),
         )
 
-        state = task.dag.infer_bound_from_state(inputs[0].state)
+        state = task.compute_dag.infer_bound_from_state(inputs[0].state)
         fea = auto_scheduler.feature.get_per_store_features_from_states([state], task)[0]
         names = auto_scheduler.feature.get_per_store_feature_names()
 


### PR DESCRIPTION
The previous implementation of task serialization mechanism has a potential problem, which is a bit tricky so I didn't notice that before.

Previously, I defined a set of attributes in the Python object (e.g., `hardware_params`) and use them to be the state when serializing a task object in Python. However, in the case that users don't provide `hardware_params`, the SearchTask constructor in C++ invokes `GetDefaultHardwareParams` to get the default hardware parameters. These default hardware parameters aren't exposed to the Python object because of the same name attribute.

It wouldn't be a bit deal because when a task is deserialized, we follow the same process to get the default hardware parameters. However, since `GetDefaultHardwareParams` may access hardware context (e.g., CUDA context), this prevents tasks from being deserialized in parallel (with multiprocessing).

This PR removes all attributes in `SearchTask` Python object to make sure we access the up-to-date C++ object attributes when serializing a task. The only exception is `self.dag` because we need it to reconstruct a ComputeDAG.

cc @merrymercy @jcf94 