### PR TITLE
[Torch] Restore class-aware NMS for detection models by graph rewrite

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1857,18 +1857,18 @@ class PyTorchOpConverter:
         scores = inputs[1]
         iou_threshold = inputs[2]
 
-        num_boxes = _op.shape_of(scores)
-
         # TVM NMS assumes score > 0
         scores = scores - _op.min(scores) + _op.const(1.0)
+
+        num_boxes = _op.shape_of(scores)
+        # PyTorch NMS doesn't have score_threshold, so no need to run get_valid_count
+        indices = _op.transform.arange(_op.squeeze(num_boxes), dtype="int32")
+        indices = _op.expand_dims(indices, 0, 1)
+
         # Generate data with shape (1, num_anchors, 5)
         scores = AttrCvt(op_name="expand_dims", extras={"axis": -1, "num_newaxis": 1})([scores], {})
         data = _op.concatenate([scores, boxes], -1)
         data = _op.expand_dims(data, 0, 1)
-        # PyTorch NMS doesn't have score_threshold, so no need to run get_valid_count
-        indices = _op.transform.arange(_op.squeeze(num_boxes), dtype="int32")
-        indices = _op.expand_dims(indices, 0, 1)
-        ct = num_boxes
 
         # Perform Non-Maximum Suppression,
         # PyTorch NMS doesn't have parameter top_k and max_output_size
@@ -1876,7 +1876,7 @@ class PyTorchOpConverter:
         top_k = max_out_size = -1
         nms_ret = get_relay_op("non_max_suppression")(
             data=data,
-            valid_count=ct,
+            valid_count=num_boxes,
             indices=indices,
             max_output_size=max_out_size,
             iou_threshold=iou_threshold,

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -16,6 +16,8 @@
 # under the License.
 # pylint: disable=import-outside-toplevel
 """ Common utilities used by PyTorch frontend """
+from .. import op
+from ..dataflow_pattern import *
 
 
 def is_version_greater_than(ver):
@@ -25,3 +27,98 @@ def is_version_greater_than(ver):
     return "".join(re.findall(r"(\d+\.)(\d+\.)(\d)", torch.__version__)[0]) > "".join(
         re.findall(r"(\d+\.)(\d+\.)(\d)", ver)[0]
     )
+
+
+def batched_nms_pattern(boxes, scores, idxs, iou_threshold):
+    one = is_constant()
+    zero = is_constant()
+
+    # %1796 = expand_dims(%1795, axis=-1);
+    score_expand_dims = is_op("expand_dims")(scores)
+
+    # %1824 = cast(%1823, dtype="float32");
+    cast = is_op("cast")(idxs)
+    mx = is_op("max")(boxes)
+    add = is_op("add")(mx, one)
+    mul = is_op("multiply")(cast, add)
+
+    # %1828 = cast_like(0, meta[op.Constant][127]);
+    cast_like = is_op("cast_like")(zero, is_constant())
+    less = is_op("less")(is_constant(), cast_like)
+    shape_of = is_op("shape_of")(mul)
+    cast_like = is_op("cast_like")(shape_of, is_constant())
+    add = is_op("add")(is_constant(), cast_like)
+    where = is_op("where")(less, add, is_constant())
+    shape_of = is_op("shape_of")(mul)
+    cast = is_op("cast")(shape_of)
+
+    # %1836 = dyn.strided_slice(%1827, %1833, %1835, meta[op.Constant][128], begin=None, end=None, strides=None);
+    dyn_strided_slice = is_op("dyn.strided_slice")(mul, where, cast, is_constant())
+
+    expand_dims = is_op("expand_dims")(dyn_strided_slice)
+    add = is_op("add")(boxes, expand_dims)
+    tup = is_tuple([score_expand_dims, add])
+    concat = is_op("concatenate")(tup)
+    expand_dims = is_op("expand_dims")(concat)
+
+    # %1842 = vision.get_valid_counts(%1841, -1f, meta[op.attrs.GetValidCountsAttrs][1]);
+    get_valid_counts_out = is_op("vision.get_valid_counts")(expand_dims, is_constant())
+    data = is_tuple_get_item(get_valid_counts_out, 1)
+    valid_counts = is_tuple_get_item(get_valid_counts_out, 0)
+    indices = is_tuple_get_item(get_valid_counts_out, 2)
+
+    # %1169 = vision.non_max_suppression(%1166, %1167, %1168, -1, 0.7f, meta[op.attrs.NonMaximumSuppressionAttrs][0]);
+    return is_op("vision.non_max_suppression")(
+        data, valid_counts, indices, is_constant(), iou_threshold
+    )
+
+
+def convert_batched_nms(boxes, scores, idxs, iou_thres):
+    scores = op.expand_dims(scores, axis=-1, num_newaxis=1)
+    idxs = op.expand_dims(idxs, axis=-1, num_newaxis=1)
+    idxs = op.cast(idxs, "float32")
+    data = op.concatenate([idxs, scores, boxes], -1)
+    data = op.expand_dims(data, 0, 1)
+    ct, data, indices = op.vision.get_valid_counts(
+        data, score_threshold=-1.0, id_index=0, score_index=1
+    )
+    top_k = max_out_size = -1
+    out = op.vision.non_max_suppression(
+        data=data,
+        valid_count=ct,
+        indices=indices,
+        max_output_size=max_out_size,
+        iou_threshold=iou_thres,
+        force_suppress=True,
+        top_k=top_k,
+        coord_start=1,
+        score_index=1,
+        id_index=0,
+        return_indices=True,
+        invalid_to_bottom=False,
+    )
+    return out.tuple_value
+
+
+class NMSRewrite(DFPatternCallback):
+    def __init__(self):
+        super().__init__()
+        # exprs I want to extract
+        self.boxes = wildcard()
+        self.scores = wildcard()
+        self.idxs = wildcard()
+        self.iou_threshold = wildcard()
+        self.pattern = batched_nms_pattern(self.boxes, self.scores, self.idxs, self.iou_threshold)
+
+    def callback(self, _, node_map):
+        print("matched")
+        boxes = node_map[self.boxes][0]
+        scores = node_map[self.scores][0]
+        idxs = node_map[self.idxs][0]
+        iou_thres = node_map[self.iou_threshold][0]
+        return convert_batched_nms(boxes, scores, idxs, iou_thres)
+
+
+def rewrite_nms_to_batched_nms(mod):
+    mod["main"] = rewrite(NMSRewrite(), mod["main"])
+    return mod

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=import-outside-toplevel
+# pylint: disable=import-outside-toplevel, unused-argument
 """ Common utilities used by PyTorch frontend """
 from .. import op
 from ..dataflow_pattern import *
@@ -110,8 +110,7 @@ class NMSRewrite(DFPatternCallback):
         self.iou_threshold = wildcard()
         self.pattern = batched_nms_pattern(self.boxes, self.scores, self.idxs, self.iou_threshold)
 
-    def callback(self, _, node_map):
-        print("matched")
+    def callback(self, pre, post, node_map):
         boxes = node_map[self.boxes][0]
         scores = node_map[self.scores][0]
         idxs = node_map[self.idxs][0]

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -17,7 +17,15 @@
 # pylint: disable=import-outside-toplevel, unused-argument
 """ Common utilities used by PyTorch frontend """
 from .. import op
-from ..dataflow_pattern import *
+from ..dataflow_pattern import (
+    is_constant,
+    is_op,
+    rewrite,
+    is_tuple,
+    is_tuple_get_item,
+    wildcard,
+    DFPatternCallback,
+)
 
 
 def is_version_greater_than(ver):
@@ -79,7 +87,7 @@ class NMSRewrite(DFPatternCallback):
 
     def __init__(self):
         super().__init__()
-        # exprs I want to extract
+        # exprs to extract
         self.boxes = wildcard()
         self.scores = wildcard()
         self.idxs = wildcard()
@@ -102,7 +110,7 @@ class NMSRewrite(DFPatternCallback):
             indices=indices,
             max_output_size=max_out_size,
             iou_threshold=iou_thres,
-            force_suppress=True,
+            force_suppress=False,
             top_k=top_k,
             coord_start=2,
             score_index=1,

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -104,7 +104,7 @@ class NMSRewrite(DFPatternCallback):
             iou_threshold=iou_thres,
             force_suppress=True,
             top_k=top_k,
-            coord_start=1,
+            coord_start=2,
             score_index=1,
             id_index=0,
             return_indices=True,

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -26,6 +26,7 @@ import tvm
 import tvm.testing
 from tvm import relay
 from tvm.runtime.vm import VirtualMachine
+from tvm.relay.frontend.pytorch_utils import rewrite_nms_to_batched_nms
 from tvm.contrib.download import download
 
 
@@ -108,15 +109,17 @@ def test_detection_models():
     with torch.no_grad():
         pt_res = scripted_model(data)
 
-    for target in ["llvm", "cuda"]:
-        with tvm.transform.PassContext(opt_level=3):
+    def compile_and_run_vm(mod, params, data_np):
+        with tvm.transform.PassContext(opt_level=3, disabled_pass=["FoldScaleAxis"]):
             vm_exec = relay.vm.compile(mod, target=target, params=params)
 
-        ctx = tvm.context(target, 0)
+        ctx = tvm.cpu()
         vm = VirtualMachine(vm_exec, ctx)
-
         vm.set_input("main", **{input_name: data_np})
-        tvm_res = vm.run()
+        return vm.run()
+
+    for target in ["cuda", "llvm"]:
+        tvm_res = compile_and_run_vm(mod, params, data_np)
 
         # Bounding boxes
         tvm.testing.assert_allclose(
@@ -132,3 +135,14 @@ def test_detection_models():
         score_threshold = 0.9
         print("Num boxes:", pt_res[0].cpu().numpy().shape[0])
         print("Num valid boxes:", np.sum(pt_res[1].cpu().numpy() >= score_threshold))
+
+    before = mod["main"]
+    mod = rewrite_nms_to_batched_nms(mod)
+    after = mod["main"]
+    assert not tvm.ir.structural_equal(after, before)
+
+    tvm_res_after_rewrite = compile_and_run_vm(mod, params, data_np)
+
+    # Results should be equivalent after rewriting
+    for res1, res2 in zip(tvm_res, tvm_res_after_rewrite):
+        tvm.testing.assert_allclose(res1, res2)

--- a/tutorials/frontend/deploy_object_detection_pytorch.py
+++ b/tutorials/frontend/deploy_object_detection_pytorch.py
@@ -42,7 +42,7 @@ be unstable.
 
 import tvm
 from tvm import relay
-from tvm import relay
+from tvm.relay.frontend.pytorch_utils import rewrite_nms_to_batched_nms
 from tvm.runtime.vm import VirtualMachine
 from tvm.contrib.download import download
 
@@ -114,6 +114,14 @@ img = np.expand_dims(img, axis=0)
 input_name = "input0"
 shape_list = [(input_name, input_shape)]
 mod, params = relay.frontend.from_pytorch(script_module, shape_list)
+
+######################################################################
+# Rewrite the graph for more performance
+# -------------------------
+# We provide a graph rewrite utility to replace the costly non maximum
+# surpression in torchvision that does not take class id into account
+# with more efficient one.
+mod = rewrite_nms_to_batched_nms(mod)
 
 ######################################################################
 # Compile with Relay VM

--- a/tutorials/frontend/deploy_object_detection_pytorch.py
+++ b/tutorials/frontend/deploy_object_detection_pytorch.py
@@ -42,7 +42,7 @@ be unstable.
 
 import tvm
 from tvm import relay
-from tvm.relay.frontend.pytorch_utils import rewrite_nms_to_batched_nms
+from tvm import relay
 from tvm.runtime.vm import VirtualMachine
 from tvm.contrib.download import download
 
@@ -114,14 +114,6 @@ img = np.expand_dims(img, axis=0)
 input_name = "input0"
 shape_list = [(input_name, input_shape)]
 mod, params = relay.frontend.from_pytorch(script_module, shape_list)
-
-######################################################################
-# Rewrite the graph for more performance
-# -------------------------
-# We provide a graph rewrite utility to replace the costly non maximum
-# surpression in torchvision that does not take class id into account
-# with more efficient one.
-mod = rewrite_nms_to_batched_nms(mod)
 
 ######################################################################
 # Compile with Relay VM


### PR DESCRIPTION
NMS used by PyTorch detection model actually performs multiclass NMS in one go, by adding different offsets to boxes from different classes so that two boxes from different classes never overlap. See 

https://github.com/pytorch/vision/blob/3d60f498e71ba63b428edb184c9ac38fa3737fa6/torchvision/ops/boxes.py#L80-L89

But this means most of O(N**2) IOU tests we do in the NMS triangle loop are useless. The goal of this PR is to restore class indices which is one of the inputs to `batched_nms` function above and perform class-aware NMS for TVM-compiled detection models. 

I did this by pattern matching and rewriting after model import. Specifically, I pattern match against [this subgraph](https://github.com/masahi/torchscript-to-tvm/blob/master/nms-perf-issue/maskrcnn_relay.txt#L1153-L1177) corresponding to PyTorch `batched_nms` used by maskrcnn / faster rcnn.

Unfortunately, this optimization didn't yield speedup I hoped: On GPU it only makes 70ms faster, and on CPU it actually makes it slightly slower (?) for some reason. I haven't looked into why it is not going much faster. 

nvprof output from running MaskRCNN on GPU

Before
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name                                                                                            
 GPU activities:   56.57%  711.34ms         2  355.67ms  15.296ms  696.05ms  fused_vision_non_max_suppression_kernel2                                                        
                   17.38%  218.54ms         1  218.54ms  218.54ms  218.54ms  fused_nn_dense_add_nn_relu_kernel0
```

After

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name                                                                                            
 GPU activities:   54.52%  645.28ms         2  322.64ms  15.498ms  629.78ms  fused_vision_non_max_suppression_kernel2                                                        
                   18.44%  218.27ms         1  218.27ms  218.27ms  218.27ms  fused_nn_dense_add_nn_relu_kernel0     
```

On CPU, the output from VM profiler:

Before
```
#OpName                         #InvokeCount    #Duration(us): Sum/Mean/Min/Max
...
fused_vision_non_max_suppression        2               7902.54/3951.27/339.03/7563.51
```

After
```
#OpName                         #InvokeCount    #Duration(us): Sum/Mean/Min/Max
fused_vision_non_max_suppression        2               8129.3/4064.65/304.878/7824.42
```
So performance wise this change doesn't matter much, but I hope this also serves as a non trivial use of pattern matching and rewrite.

cc @kevinthesun @mbrookhart @zhiics @t-vi What do you think?