### PR TITLE
[AutoScheduler] Update layout rewrite option setting for measuring

### DIFF
--- a/include/tvm/auto_scheduler/measure_record.h
+++ b/include/tvm/auto_scheduler/measure_record.h
@@ -34,7 +34,7 @@
 namespace tvm {
 namespace auto_scheduler {
 
-const std::string AUTO_SCHEDULER_LOG_VERSION = "v0.4";  // NOLINT(*)
+const std::string AUTO_SCHEDULER_LOG_VERSION = "v0.5";  // NOLINT(*)
 
 /*! \brief Callback for logging the input and results of measurements to file */
 class RecordToFileNode : public MeasureCallbackNode {

--- a/include/tvm/auto_scheduler/measure_record.h
+++ b/include/tvm/auto_scheduler/measure_record.h
@@ -34,7 +34,7 @@
 namespace tvm {
 namespace auto_scheduler {
 
-const std::string AUTO_SCHEDULER_LOG_VERSION = "v0.5";  // NOLINT(*)
+const std::string AUTO_SCHEDULER_LOG_VERSION = "v0.4";  // NOLINT(*)
 
 /*! \brief Callback for logging the input and results of measurements to file */
 class RecordToFileNode : public MeasureCallbackNode {

--- a/include/tvm/auto_scheduler/search_task.h
+++ b/include/tvm/auto_scheduler/search_task.h
@@ -118,8 +118,8 @@ class SearchTaskNode : public Object {
   Target target_host;
   /*! \brief Hardware parameters used in this search task. */
   HardwareParams hardware_params;
-  /*! \brief */
-  int layout_rewrite_option;
+  /*! \brief Layout rewrite option used during program measuring. */
+  LayoutRewriteOption layout_rewrite_option;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("compute_dag", &compute_dag);
@@ -149,7 +149,7 @@ class SearchTask : public ObjectRef {
    * \param hardware_params Hardware parameters used in this search task.
    */
   SearchTask(ComputeDAG compute_dag, String workload_key, Target target, Target target_host,
-             Optional<HardwareParams> hardware_params, int layout_rewrite_option);
+             Optional<HardwareParams> hardware_params, LayoutRewriteOption layout_rewrite_option);
 
   TVM_DEFINE_OBJECT_REF_METHODS(SearchTask, ObjectRef, SearchTaskNode);
 };

--- a/include/tvm/auto_scheduler/search_task.h
+++ b/include/tvm/auto_scheduler/search_task.h
@@ -118,6 +118,8 @@ class SearchTaskNode : public Object {
   Target target_host;
   /*! \brief Hardware parameters used in this search task. */
   HardwareParams hardware_params;
+  /*! \brief */
+  int layout_rewrite_option;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("compute_dag", &compute_dag);
@@ -125,6 +127,7 @@ class SearchTaskNode : public Object {
     v->Visit("target", &target);
     v->Visit("target_host", &target_host);
     v->Visit("hardware_params", &hardware_params);
+    v->Visit("layout_rewrite_option", &layout_rewrite_option);
   }
 
   static constexpr const char* _type_key = "auto_scheduler.SearchTask";
@@ -146,7 +149,7 @@ class SearchTask : public ObjectRef {
    * \param hardware_params Hardware parameters used in this search task.
    */
   SearchTask(ComputeDAG compute_dag, String workload_key, Target target, Target target_host,
-             Optional<HardwareParams> hardware_params);
+             Optional<HardwareParams> hardware_params, int layout_rewrite_option);
 
   TVM_DEFINE_OBJECT_REF_METHODS(SearchTask, ObjectRef, SearchTaskNode);
 };

--- a/include/tvm/auto_scheduler/search_task.h
+++ b/include/tvm/auto_scheduler/search_task.h
@@ -147,6 +147,7 @@ class SearchTask : public ObjectRef {
    * \param target The target device of this search task.
    * \param target_host The target host device of this search task.
    * \param hardware_params Hardware parameters used in this search task.
+   * \param layout_rewrite_option The default layout rewrite option used during program measuring.
    */
   SearchTask(ComputeDAG compute_dag, String workload_key, Target target, Target target_host,
              Optional<HardwareParams> hardware_params, LayoutRewriteOption layout_rewrite_option);

--- a/include/tvm/auto_scheduler/search_task.h
+++ b/include/tvm/auto_scheduler/search_task.h
@@ -118,7 +118,7 @@ class SearchTaskNode : public Object {
   Target target_host;
   /*! \brief Hardware parameters used in this search task. */
   HardwareParams hardware_params;
-  /*! \brief Layout rewrite option used during program measuring. */
+  /*! \brief The layout rewrite option used for measuring programs. */
   LayoutRewriteOption layout_rewrite_option;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
@@ -147,7 +147,7 @@ class SearchTask : public ObjectRef {
    * \param target The target device of this search task.
    * \param target_host The target host device of this search task.
    * \param hardware_params Hardware parameters used in this search task.
-   * \param layout_rewrite_option The default layout rewrite option used during program measuring.
+   * \param layout_rewrite_option The layout rewrite option used for measuring programs.
    */
   SearchTask(ComputeDAG compute_dag, String workload_key, Target target, Target target_host,
              Optional<HardwareParams> hardware_params, LayoutRewriteOption layout_rewrite_option);

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -51,7 +51,7 @@ class LayoutRewriteOption:
 
     @staticmethod
     def get_target_default(target, in_relay_integration=False):
-        """ Get the default layout rewrite option for the specified target.
+        """Get the default layout rewrite option for the specified target.
         Currently we only enable layout rewrite for cpu / mali backend for now
 
         Parameters
@@ -70,10 +70,14 @@ class LayoutRewriteOption:
         if target.kind.name == "llvm" or (
             "device" in target.attrs and target.attrs["device"] == "mali"
         ):
-            layout_rewrite_option = LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED \
-                if in_relay_integration else LayoutRewriteOption.INSERT_TRANSFORM_STAGE
+            layout_rewrite_option = (
+                LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED
+                if in_relay_integration
+                else LayoutRewriteOption.INSERT_TRANSFORM_STAGE
+            )
 
         return layout_rewrite_option
+
 
 @tvm._ffi.register_object("auto_scheduler.ComputeDAG")
 class ComputeDAG(Object):

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -49,6 +49,31 @@ class LayoutRewriteOption:
     # so this option must be used along with `AutoSchedulerLayoutRewrite` pass in Relay.
     REWRITE_FOR_PRE_TRANSFORMED = 2
 
+    @staticmethod
+    def get_target_default(target, in_relay_integration=False):
+        """ Get the default layout rewrite option for the specified target.
+        Currently we only enable layout rewrite for cpu / mali backend for now
+
+        Parameters
+        ----------
+        target: tvm.target.Target
+            The compilation target.
+        in_relay_integration: bool
+            If this check is ask for relay integration.
+
+        Returns
+        -------
+        layout_rewrite_option: LayoutRewriteOption
+            The default layout rewrite option for the specified target.
+        """
+        layout_rewrite_option = LayoutRewriteOption.NO_REWRITE
+        if target.kind.name == "llvm" or (
+            "device" in target.attrs and target.attrs["device"] == "mali"
+        ):
+            layout_rewrite_option = LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED \
+                if in_relay_integration else LayoutRewriteOption.INSERT_TRANSFORM_STAGE
+
+        return layout_rewrite_option
 
 @tvm._ffi.register_object("auto_scheduler.ComputeDAG")
 class ComputeDAG(Object):

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -32,7 +32,12 @@ from .workload_registry import workload_key_to_tensors
 
 
 class LayoutRewriteOption:
-    """Options for applying layout rewrite."""
+    """
+    Options for applying layout rewrite.
+
+    The NO_REWRITE and INSERT_TRANSFORM_STAGE is expected to be used when tuning a dependent op,
+    and the REWRITE_FOR_PRE_TRANSFORMED is expected to be used when tuning ops inside a network.
+    """
 
     # Do not perform layout rewrite
     NO_REWRITE = 0

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -35,7 +35,7 @@ class LayoutRewriteOption:
     """
     Options for applying layout rewrite.
 
-    The NO_REWRITE and INSERT_TRANSFORM_STAGE is expected to be used when tuning a dependent op,
+    The NO_REWRITE and INSERT_TRANSFORM_STAGE are expected to be used when tuning a standalone op,
     and the REWRITE_FOR_PRE_TRANSFORMED is expected to be used when tuning ops inside a network.
     """
 

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -186,6 +186,7 @@ def recover_measure_input(inp, rebuild_state=False):
         target=task.target,
         target_host=task.target_host,
         hardware_params=task.hardware_params,
+        layout_rewrite_option=task.layout_rewrite_option
     )
 
     if rebuild_state:
@@ -551,7 +552,7 @@ def _timed_func(inp_serialized, build_func, verbose):
 
     try:
         sch, args = task.compute_dag.apply_steps_from_state(
-            inp.state, layout_rewrite=LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED
+            inp.state, layout_rewrite=task.layout_rewrite_option
         )
     # pylint: disable=broad-except
     except Exception:

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -186,7 +186,7 @@ def recover_measure_input(inp, rebuild_state=False):
         target=task.target,
         target_host=task.target_host,
         hardware_params=task.hardware_params,
-        layout_rewrite_option=task.layout_rewrite_option
+        layout_rewrite_option=task.layout_rewrite_option,
     )
 
     if rebuild_state:

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -53,7 +53,6 @@ from .utils import (
     make_traceback_info,
     request_remote,
 )
-from .compute_dag import LayoutRewriteOption
 from .workload_registry import (
     serialize_workload_registry_entry,
     deserialize_workload_registry_entry,

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -126,7 +126,8 @@ def extract_tasks(
                 target=target,
                 target_host=target_host,
                 hardware_params=hardware_params,
-                # In default, try to apply layout rewrite to improve the performance
+                # When auto scheduler is used in end to end network, try to apply layout rewrite
+                # to improve the overall performance
                 layout_rewrite_option=LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED
             )
         )

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -149,8 +149,9 @@ def extract_tasks(
                 hardware_params=hardware_params,
                 # When auto scheduler is used in end to end network, try to apply layout rewrite
                 # to improve the overall performance
-                layout_rewrite_option=LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED \
-                    if enable_layout_rewrite(target) else LayoutRewriteOption.NO_REWRITE
+                layout_rewrite_option=LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED
+                if enable_layout_rewrite(target)
+                else LayoutRewriteOption.NO_REWRITE,
             )
         )
         weights.append(use_count_dict[ccache_key] + 1)

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -281,8 +281,10 @@ def auto_schedule_topi(outs, has_complex_op):
         schedule = te.create_schedule([x.op for x in outs])
     elif env.tracing_mode == TracingMode.PREPARE_LAYOUT_REWRITE:
         # in prepare_layout_rewrite mode
-        if LayoutRewriteOption.get_target_default(target, True) != LayoutRewriteOption.NO_REWRITE \
-            and has_layout_free:
+        if (
+            LayoutRewriteOption.get_target_default(target, True) != LayoutRewriteOption.NO_REWRITE
+            and has_layout_free
+        ):
             dispatch_ctx = DispatchContext.current
             state = dispatch_ctx.query(target, key, has_complex_op, dag)
             if state is None:

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -77,11 +77,10 @@ def enable_layout_rewrite(target):
     """
     # only enable layout rewrite for cpu / mali backend
     enable_layout_rewrite_targets = ["cpu", "mali"]
-    enable_layout_rewrite = any(
+    return any(
         enable_layout_rewrite_target in target.keys
         for enable_layout_rewrite_target in enable_layout_rewrite_targets
     )
-    return enable_layout_rewrite
 
 
 def extract_tasks(

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -33,7 +33,7 @@ from tvm.runtime import convert_to_object
 from tvm.te.tensor import ComputeOp, PlaceholderOp, Tensor
 from tvm.tir import expr as _expr
 from . import _ffi_api
-from .compute_dag import ComputeDAG
+from .compute_dag import ComputeDAG, LayoutRewriteOption
 from .dispatcher import DispatchContext
 from .search_task import SearchTask
 from .workload_registry import register_workload_tensors
@@ -126,6 +126,8 @@ def extract_tasks(
                 target=target,
                 target_host=target_host,
                 hardware_params=hardware_params,
+                # In default, try to apply layout rewrite to improve the performance
+                layout_rewrite_option=LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED
             )
         )
         weights.append(use_count_dict[ccache_key] + 1)

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -180,10 +180,10 @@ class SearchTask(Object):
         Hardware parameters used in this search task.
     layout_rewrite_option : LayoutRewriteOption = LayoutRewriteOption.NO_REWRITE
         The default layout rewrite option used during program measuring.
-        Cost model will adjust the auto scheduler to find a better schedule for the specified
-        layout rewrite option.
-        It's excepted to use NO_REWRITE or INSERT_TRANSFORM_STAGE when tuning a dependent op, and
-        to use REWRITE_FOR_PRE_TRANSFORMED when tuning ops inside a network for better performance.
+        Auto_scheduler will find a better schedule for the specified layout rewrite option.
+        The NO_REWRITE and INSERT_TRANSFORM_STAGE are expected to be used when tuning a standalone
+        op, and the REWRITE_FOR_PRE_TRANSFORMED is expected to be used when tuning ops inside a
+        network.
 
     Examples
     --------

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -230,7 +230,7 @@ class SearchTask(Object):
         if layout_rewrite_option is None:
             layout_rewrite_option = LayoutRewriteOption.NO_REWRITE
             if target.kind.name == "llvm" or \
-                ("device" in target.attrs.keys and target.attrs["device"] == "mali"):
+                ("device" in target.attrs and target.attrs["device"] == "mali"):
                 layout_rewrite_option = LayoutRewriteOption.INSERT_TRANSFORM_STAGE
 
         self.__init_handle_by_constructor__(

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -179,7 +179,8 @@ class SearchTask(Object):
     hardware_params : Optional[HardwareParams]
         Hardware parameters used in this search task.
     layout_rewrite_option : Optional[LayoutRewriteOption]
-        The default layout rewrite option used during program measuring.
+        The layout rewrite option used during program measuring. If None, the
+        INSERT_TRANSFORM_STAGE will be used for cpu and mali gpu, else NO_REWRITE will be used.
         Auto_scheduler will find a better schedule for the specified layout rewrite option.
         The NO_REWRITE and INSERT_TRANSFORM_STAGE are expected to be used when tuning a standalone
         op, and the REWRITE_FOR_PRE_TRANSFORMED is expected to be used when tuning ops inside a

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -179,8 +179,8 @@ class SearchTask(Object):
     hardware_params : Optional[HardwareParams]
         Hardware parameters used in this search task.
     layout_rewrite_option : Optional[LayoutRewriteOption]
-        The layout rewrite option used during program measuring. If None, the
-        INSERT_TRANSFORM_STAGE will be used for cpu and mali gpu, else NO_REWRITE will be used.
+        The layout rewrite option used for measuring programs. If None, the default value will be
+        set depending on the specified target.
         Auto_scheduler will find a better schedule for the specified layout rewrite option.
         The NO_REWRITE and INSERT_TRANSFORM_STAGE are expected to be used when tuning a standalone
         op, and the REWRITE_FOR_PRE_TRANSFORMED is expected to be used when tuning ops inside a
@@ -228,13 +228,6 @@ class SearchTask(Object):
         if isinstance(target_host, str):
             target_host = Target(target_host)
 
-        if layout_rewrite_option is None:
-            layout_rewrite_option = LayoutRewriteOption.NO_REWRITE
-            if target.kind.name == "llvm" or (
-                "device" in target.attrs and target.attrs["device"] == "mali"
-            ):
-                layout_rewrite_option = LayoutRewriteOption.INSERT_TRANSFORM_STAGE
-
         self.__init_handle_by_constructor__(
             _ffi_api.SearchTask,
             compute_dag,
@@ -242,7 +235,7 @@ class SearchTask(Object):
             target,
             target_host,
             hardware_params,
-            layout_rewrite_option,
+            layout_rewrite_option or LayoutRewriteOption.get_target_default(target),
         )
 
     def tune(self, tuning_options, search_policy=None):

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -210,7 +210,7 @@ class SearchTask(Object):
         target=None,
         target_host=None,
         hardware_params=None,
-        layout_rewrite_option=None
+        layout_rewrite_option=None,
     ):
         assert (
             func is not None or workload_key is not None
@@ -229,13 +229,19 @@ class SearchTask(Object):
 
         if layout_rewrite_option is None:
             layout_rewrite_option = LayoutRewriteOption.NO_REWRITE
-            if target.kind.name == "llvm" or \
-                ("device" in target.attrs and target.attrs["device"] == "mali"):
+            if target.kind.name == "llvm" or (
+                "device" in target.attrs and target.attrs["device"] == "mali"
+            ):
                 layout_rewrite_option = LayoutRewriteOption.INSERT_TRANSFORM_STAGE
 
         self.__init_handle_by_constructor__(
-            _ffi_api.SearchTask, compute_dag, workload_key, target, target_host, hardware_params,
-            layout_rewrite_option
+            _ffi_api.SearchTask,
+            compute_dag,
+            workload_key,
+            target,
+            target_host,
+            hardware_params,
+            layout_rewrite_option,
         )
 
     def tune(self, tuning_options, search_policy=None):
@@ -263,7 +269,7 @@ class SearchTask(Object):
            The name of the log file.
         layout_rewrite_option : Optional[LayoutRewriteOption]
            The layout rewrite option.
-           
+
 
         Returns
         -------
@@ -318,7 +324,7 @@ class SearchTask(Object):
             "target": self.target,
             "target_host": self.target_host,
             "hardware_params": self.hardware_params,
-            "layout_rewrite_option": self.layout_rewrite_option
+            "layout_rewrite_option": self.layout_rewrite_option,
         }
 
     def __setstate__(self, state):
@@ -341,7 +347,7 @@ class SearchTask(Object):
             state["target"],
             state["target_host"],
             state["hardware_params"],
-            state["layout_rewrite_option"]
+            state["layout_rewrite_option"],
         )
 
 

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -178,6 +178,7 @@ class SearchTask(Object):
         The target host device of this search task.
     hardware_params : Optional[HardwareParams]
         Hardware parameters used in this search task.
+    layout_rewrite_option : LayoutRewriteOption = LayoutRewriteOption.NO_REWRITE
 
     Examples
     --------
@@ -204,6 +205,7 @@ class SearchTask(Object):
         target=None,
         target_host=None,
         hardware_params=None,
+        layout_rewrite_option=LayoutRewriteOption.NO_REWRITE
     ):
         assert (
             func is not None or workload_key is not None
@@ -221,7 +223,8 @@ class SearchTask(Object):
             target_host = Target(target_host)
 
         self.__init_handle_by_constructor__(
-            _ffi_api.SearchTask, compute_dag, workload_key, target, target_host, hardware_params
+            _ffi_api.SearchTask, compute_dag, workload_key, target, target_host, hardware_params,
+            layout_rewrite_option
         )
 
     def tune(self, tuning_options, search_policy=None):
@@ -305,6 +308,7 @@ class SearchTask(Object):
             "target": self.target,
             "target_host": self.target_host,
             "hardware_params": self.hardware_params,
+            "layout_rewrite_option": self.layout_rewrite_option
         }
 
     def __setstate__(self, state):
@@ -327,6 +331,7 @@ class SearchTask(Object):
             state["target"],
             state["target_host"],
             state["hardware_params"],
+            state["layout_rewrite_option"]
         )
 
 

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1023,7 +1023,10 @@ ComputeDAG ComputeDAG::RewriteLayout(Array<Step>* transform_steps,
             }
             original_compute_op = op;
             CHECK(!new_compute_op.defined());
-            new_compute_op = te::ComputeOp(pop->name, pop->tag, pop->attrs, pop->axis, new_body);
+            auto new_attrs = pop->attrs;
+            new_attrs.Set("ori_placeholder_layout", tvm::String(origin_layout));
+            new_attrs.Set("new_placeholder_layout", tvm::String(new_layout));
+            new_compute_op = te::ComputeOp(pop->name, pop->tag, new_attrs, pop->axis, new_body);
           }
         }
       }

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -997,11 +997,20 @@ ComputeDAG ComputeDAG::RewriteLayout(Array<Step>* transform_steps,
             transform_steps->Set(i, std::move(step));
           }
         }
+
+        // Add schedule for the new added transform stage
         Array<Integer> to_fuse;
-        for (size_t i = 0; i < new_shape.size() - 1; i++) {
-          to_fuse.push_back(i);
+
+        if (new_shape.size() >= 5) {
+          to_fuse.push_back(0);
+          to_fuse.push_back(1);
+          to_fuse.push_back(2);
+          transform_steps->push_back(FuseStep(stage_id, to_fuse));
+        } else if (new_shape.size() >= 3) {
+          to_fuse.push_back(0);
+          to_fuse.push_back(1);
+          transform_steps->push_back(FuseStep(stage_id, to_fuse));
         }
-        transform_steps->push_back(FuseStep(stage_id, to_fuse));
         transform_steps->push_back(AnnotationStep(stage_id, 0, IteratorAnnotation::kParallel));
       }
 

--- a/src/auto_scheduler/feature.cc
+++ b/src/auto_scheduler/feature.cc
@@ -1398,7 +1398,8 @@ void GetPerStoreFeaturesFromFile(const std::string& filename, int max_lines, int
       // rebuild task
       Array<te::Tensor> tensors = (*workload_key_to_tensors)(workload_key);
       task = SearchTask(ComputeDAG(tensors), workload_key, cur_inp->task->target,
-                        cur_inp->task->target_host, cur_inp->task->hardware_params);
+                        cur_inp->task->target_host, cur_inp->task->hardware_params,
+                        cur_inp->task->layout_rewrite_option);
       task_id = task_cache.size();
 
       // compute min cost for each task
@@ -1465,7 +1466,8 @@ void GetPerStoreFeaturesFromMeasurePairs(const Array<MeasureInput>& inputs,
         // rebuild task for incomplete measure pairs read from file
         Array<te::Tensor> tensors = (*workload_key_to_tensors)(workload_key);
         task = SearchTask(ComputeDAG(tensors), workload_key, inputs[i]->task->target,
-                          inputs[i]->task->target_host, inputs[i]->task->hardware_params);
+                          inputs[i]->task->target_host, inputs[i]->task->hardware_params,
+                          inputs[i]->task->layout_rewrite_option);
       }
       task_id = task_cache.size();
 

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -162,7 +162,7 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     writer->BeginArray(false);
     writer->WriteArrayItem(std::string(data.workload_key));
     writer->WriteArrayItem(data.target->str());
-    writer->WriteArrayItem(data.layout_rewrite_option);
+    writer->WriteArrayItem(static_cast<int>(data.layout_rewrite_option));
     writer->WriteArrayItem(*data.hardware_params.get());
     if (data.target_host.defined()) {
       writer->WriteArrayItem(data.target_host->str());
@@ -172,6 +172,7 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
   inline static void Read(dmlc::JSONReader* reader, ::tvm::auto_scheduler::SearchTaskNode* data) {
     bool s;
     std::string str_value;
+    int int_value;
     auto hardware_params_node = ::tvm::make_object<::tvm::auto_scheduler::HardwareParamsNode>();
     reader->BeginArray();
     s = reader->NextArrayItem();
@@ -184,7 +185,8 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     data->target = ::tvm::Target(str_value);
     s = reader->NextArrayItem();
     ICHECK(s);
-    reader->Read(&(data->layout_rewrite_option));
+    reader->Read(&int_value);
+    data->layout_rewrite_option = ::tvm::auto_scheduler::LayoutRewriteOption(int_value);
     s = reader->NextArrayItem();
     if (s) {
       reader->Read(hardware_params_node.get());

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -166,6 +166,8 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     writer->WriteArrayItem(*data.hardware_params.get());
     if (data.target_host.defined()) {
       writer->WriteArrayItem(data.target_host->str());
+    } else {
+      writer->WriteArrayItem("");
     }
     writer->EndArray();
   }
@@ -184,10 +186,6 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     reader->Read(&str_value);
     data->target = ::tvm::Target(str_value);
     s = reader->NextArrayItem();
-    ICHECK(s);
-    reader->Read(&int_value);
-    data->layout_rewrite_option = ::tvm::auto_scheduler::LayoutRewriteOption(int_value);
-    s = reader->NextArrayItem();
     if (s) {
       reader->Read(hardware_params_node.get());
       s = reader->NextArrayItem();
@@ -195,6 +193,10 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
       if (s) {
         reader->Read(&str_value);
         data->target_host = ::tvm::Target(str_value);
+        s = reader->NextArrayItem();
+        ICHECK(s);
+        reader->Read(&int_value);
+        data->layout_rewrite_option = ::tvm::auto_scheduler::LayoutRewriteOption(int_value);
         s = reader->NextArrayItem();
         ICHECK(!s);
       }

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -162,6 +162,7 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     writer->BeginArray(false);
     writer->WriteArrayItem(std::string(data.workload_key));
     writer->WriteArrayItem(data.target->str());
+    writer->WriteArrayItem(data.layout_rewrite_option);
     writer->WriteArrayItem(*data.hardware_params.get());
     if (data.target_host.defined()) {
       writer->WriteArrayItem(data.target_host->str());
@@ -181,6 +182,9 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     ICHECK(s);
     reader->Read(&str_value);
     data->target = ::tvm::Target(str_value);
+    s = reader->NextArrayItem();
+    ICHECK(s);
+    reader->Read(&(data->layout_rewrite_option));
     s = reader->NextArrayItem();
     if (s) {
       reader->Read(hardware_params_node.get());

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -167,7 +167,7 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     if (data.target_host.defined()) {
       writer->WriteArrayItem(data.target_host->str());
     } else {
-      writer->WriteArrayItem("");
+      writer->WriteArrayItem(std::string(""));
     }
     writer->EndArray();
   }

--- a/src/auto_scheduler/measure_record.cc
+++ b/src/auto_scheduler/measure_record.cc
@@ -162,13 +162,13 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
     writer->BeginArray(false);
     writer->WriteArrayItem(std::string(data.workload_key));
     writer->WriteArrayItem(data.target->str());
-    writer->WriteArrayItem(static_cast<int>(data.layout_rewrite_option));
     writer->WriteArrayItem(*data.hardware_params.get());
     if (data.target_host.defined()) {
       writer->WriteArrayItem(data.target_host->str());
     } else {
       writer->WriteArrayItem(std::string(""));
     }
+    writer->WriteArrayItem(static_cast<int>(data.layout_rewrite_option));
     writer->EndArray();
   }
   inline static void Read(dmlc::JSONReader* reader, ::tvm::auto_scheduler::SearchTaskNode* data) {
@@ -192,7 +192,9 @@ struct Handler<::tvm::auto_scheduler::SearchTaskNode> {
       data->hardware_params = ::tvm::auto_scheduler::HardwareParams(hardware_params_node);
       if (s) {
         reader->Read(&str_value);
-        data->target_host = ::tvm::Target(str_value);
+        if (!str_value.empty()) {
+          data->target_host = ::tvm::Target(str_value);
+        }
         s = reader->NextArrayItem();
         ICHECK(s);
         reader->Read(&int_value);

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -114,7 +114,7 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
 
 SearchTask::SearchTask(ComputeDAG compute_dag, String workload_key, Target target,
                        Target target_host, Optional<HardwareParams> hardware_params,
-                       int layout_rewrite_option) {
+                       LayoutRewriteOption layout_rewrite_option) {
   auto node = make_object<SearchTaskNode>();
   node->compute_dag = std::move(compute_dag);
   node->workload_key = std::move(workload_key);
@@ -144,7 +144,7 @@ TVM_REGISTER_GLOBAL("auto_scheduler.SearchTask")
                        Target target_host, Optional<HardwareParams> hardware_params,
                        int layout_rewrite_option) {
       return SearchTask(compute_dag, workload_key, target, target_host, hardware_params,
-                        layout_rewrite_option);
+                        LayoutRewriteOption(layout_rewrite_option));
     });
 
 }  // namespace auto_scheduler

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -113,7 +113,8 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
 }
 
 SearchTask::SearchTask(ComputeDAG compute_dag, String workload_key, Target target,
-                       Target target_host, Optional<HardwareParams> hardware_params) {
+                       Target target_host, Optional<HardwareParams> hardware_params,
+                       int layout_rewrite_option) {
   auto node = make_object<SearchTaskNode>();
   node->compute_dag = std::move(compute_dag);
   node->workload_key = std::move(workload_key);
@@ -125,6 +126,7 @@ SearchTask::SearchTask(ComputeDAG compute_dag, String workload_key, Target targe
     node->hardware_params =
         HardwareParamsNode::GetDefaultHardwareParams(node->target, node->target_host);
   }
+  node->layout_rewrite_option = layout_rewrite_option;
   data_ = std::move(node);
 }
 
@@ -139,8 +141,10 @@ TVM_REGISTER_GLOBAL("auto_scheduler.HardwareParams")
 
 TVM_REGISTER_GLOBAL("auto_scheduler.SearchTask")
     .set_body_typed([](ComputeDAG compute_dag, String workload_key, Target target,
-                       Target target_host, Optional<HardwareParams> hardware_params) {
-      return SearchTask(compute_dag, workload_key, target, target_host, hardware_params);
+                       Target target_host, Optional<HardwareParams> hardware_params,
+                       int layout_rewrite_option) {
+      return SearchTask(compute_dag, workload_key, target, target_host, hardware_params,
+                        layout_rewrite_option);
     });
 
 }  // namespace auto_scheduler


### PR DESCRIPTION
AutoScheduler uses a cost model to guide the search search.

We now have NO_REWRITE, INSERT_TRANSFORM_STAGE, REWRITE_FOR_PRE_TRANSFORMED three options when applying schedule from AutoScheduler.
In my tests, if we set REWRITE_FOR_PRE_TRANSFORMED in program measuring, the final schedule we get will trend to perform better in REWRITE_FOR_PRE_TRANSFORMED mode. Though this schedule also works in other options, it will not perform the best performance if we would like to get a kernel with NO_REWRITE.

This PR:
1. Add a layout rewrite option for SearchTask, which will be passed to program measuring.
2. This option will be set to NO_REWRITE in default, and REWRITE_FOR_PRE_TRANSFORMED when working in a end to end network task.
3. Update the schedule for the inserted transform stage in option INSERT_TRANSFORM_STAGE, according to `python/tvm/topi/x86/injective.py`.

cc @merrymercy @comaniac 