### PR TITLE
[Backport-0.7][Android] missing header for GraphRuntimeFactory in android_rpc

### DIFF
--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -42,6 +42,7 @@
 #include "../src/runtime/dso_library.cc"
 #include "../src/runtime/file_util.cc"
 #include "../src/runtime/graph/graph_runtime.cc"
+#include "../src/runtime/graph/graph_runtime_factory.cc"
 #include "../src/runtime/library_module.cc"
 #include "../src/runtime/module.cc"
 #include "../src/runtime/ndarray.cc"


### PR DESCRIPTION
This PR is a backport of #6648 for v0.7

cc @yzhliu @qiangxu1996