### PR TITLE
[AutoScheduler] Add layout rewrite support for dense and batch matmul on CPU

### DIFF
--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -303,6 +303,14 @@ class ComputeDAG : public ObjectRef {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ComputeDAGNode);
 };
 
+/*!
+ *  \brief Get the orginal shape from a rewritten layout string.
+ *  \param rewritten_layout The layout after auto-scheduler's layout rewrite.
+ *  \param axis_names Specifiy the names of axes.
+ *  \return shape The original shape.
+ */
+Array<PrimExpr> GetShapeFromRewrittenLayout(String rewritten_layout, Array<String> axis_names);
+
 }  // namespace auto_scheduler
 }  // namespace tvm
 

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -120,7 +120,7 @@ struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
   tvm::String data_layout;
   tvm::String kernel_layout;
   tvm::String out_layout;
-  std::string auto_scheduler_rewritten_layout;
+  std::string auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Conv2DAttrs, "relay.attrs.Conv2DAttrs") {
@@ -924,6 +924,7 @@ struct AvgPool3DAttrs : public tvm::AttrsNode<AvgPool3DAttrs> {
 /*! \brief Attributes for dense operator */
 struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
   IndexExpr units;
+  std::string auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(DenseAttrs, "relay.attrs.DenseAttrs") {
@@ -934,6 +935,13 @@ struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
         .set_default(NullValue<DataType>())
         .describe("Output data type, set to explicit type under mixed precision setting");
   }
+};
+
+/*! \brief Attributes for batch matmul operator */
+struct BatchMatmulAttrs : public tvm::AttrsNode<BatchMatmulAttrs> {
+  std::string auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+
+  TVM_DECLARE_ATTRS(BatchMatmulAttrs, "relay.attrs.BatchMatmulAttrs") {}
 };
 
 /*! \brief Attributes for sparse_dense operator */

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -120,7 +120,7 @@ struct Conv2DAttrs : public tvm::AttrsNode<Conv2DAttrs> {
   tvm::String data_layout;
   tvm::String kernel_layout;
   tvm::String out_layout;
-  std::string auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Conv2DAttrs, "relay.attrs.Conv2DAttrs") {
@@ -924,7 +924,7 @@ struct AvgPool3DAttrs : public tvm::AttrsNode<AvgPool3DAttrs> {
 /*! \brief Attributes for dense operator */
 struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
   IndexExpr units;
-  std::string auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(DenseAttrs, "relay.attrs.DenseAttrs") {
@@ -939,7 +939,7 @@ struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
 
 /*! \brief Attributes for batch matmul operator */
 struct BatchMatmulAttrs : public tvm::AttrsNode<BatchMatmulAttrs> {
-  std::string auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
 
   TVM_DECLARE_ATTRS(BatchMatmulAttrs, "relay.attrs.BatchMatmulAttrs") {}
 };

--- a/python/tvm/auto_scheduler/__init__.py
+++ b/python/tvm/auto_scheduler/__init__.py
@@ -31,7 +31,7 @@ from . import utils
 from . import workload_registry
 
 # Shortcut
-from .compute_dag import ComputeDAG, LayoutRewriteOption
+from .compute_dag import ComputeDAG, LayoutRewriteOption, get_shape_from_rewritten_layout
 from .cost_model import RandomModel, XGBModel
 from .dispatcher import DispatchContext, ApplyHistoryBest
 from .measure import (

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -234,3 +234,21 @@ class ComputeDAG(Object):
         # Since we always use tensors to recover the ComputeDAG, we do not support
         # (de)serialization of the ComputeDAG constructed by a schedule.
         self.__init_handle_by_constructor__(_ffi_api.ComputeDAG, LoadJSON(state["tensors"]), None)
+
+
+def get_shape_from_rewritten_layout(rewritten_layout, axis_names):
+    """Get the orginal shape from a rewritten layout string.
+
+    Parameters
+    ----------
+    rewritten_layout: str
+        The layout after rewrite
+    axis_names: List[str]
+        Specify the order of axes by names
+
+    Returns
+    -------
+    shape: List[PrimExpr]
+        The original shape
+    """
+    return _ffi_api.GetShapeFromRewrittenLayout(rewritten_layout, axis_names)

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -199,7 +199,6 @@ def wrap_compute_conv2d(
         data_layout = attrs.get_str("data_layout")
         out_layout = attrs.get_str("out_layout")
         out_dtype = attrs.out_dtype
-        auto_scheduler_rewritten_layout = get_auto_scheduler_rewritten_layout(attrs)
         out_dtype = inputs[0].dtype if out_dtype in ("same", "") else out_dtype
         args = [inputs[0], inputs[1], strides, padding, dilation]
         if has_groups:
@@ -210,7 +209,7 @@ def wrap_compute_conv2d(
             args.append(out_layout)
         args.append(out_dtype)
         if need_auto_scheduler_layout:
-            args.append(auto_scheduler_rewritten_layout)
+            args.append(get_auto_scheduler_rewritten_layout(attrs))
         return [topi_compute(*args)]
 
     return _compute_conv2d
@@ -684,14 +683,17 @@ def dilation2d_strategy(attrs, inputs, out_type, target):
 
 
 # dense
-def wrap_compute_dense(topi_compute):
+def wrap_compute_dense(topi_compute, need_auto_scheduler_layout=False):
     """wrap dense topi compute"""
 
     def _compute_dense(attrs, inputs, out_type):
         """Compute definition of dense"""
         out_dtype = attrs.out_dtype
         out_dtype = inputs[0].dtype if out_dtype == "" else out_dtype
-        return [topi_compute(inputs[0], inputs[1], None, out_dtype)]
+        args = [inputs[0], inputs[1], None, out_dtype]
+        if need_auto_scheduler_layout:
+            args.append(get_auto_scheduler_rewritten_layout(attrs))
+        return [topi_compute(*args)]
 
     return _compute_dense
 
@@ -710,11 +712,14 @@ def dense_strategy(attrs, inputs, out_type, target):
 
 
 # batch_matmul
-def wrap_compute_batch_matmul(topi_compute):
+def wrap_compute_batch_matmul(topi_compute, need_auto_scheduler_layout=False):
     """wrap batch_matmul topi compute"""
 
     def _compute_batch_matmul(attrs, inputs, out_type):
-        return [topi_compute(inputs[0], inputs[1], out_type.shape)]
+        args = [inputs[0], inputs[1], out_type.shape]
+        if need_auto_scheduler_layout:
+            args.append(get_auto_scheduler_rewritten_layout(attrs))
+        return [topi_compute(*args)]
 
     return _compute_batch_matmul
 

--- a/python/tvm/topi/nn/batch_matmul.py
+++ b/python/tvm/topi/nn/batch_matmul.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Binary Neural Network (BNN) Operators"""
+"""Batch matrix multiplication"""
 # pylint: disable=invalid-name
-from tvm import te
+from tvm import te, auto_scheduler
 from ..utils import get_const_tuple
 
 
@@ -44,7 +44,6 @@ def batch_matmul(x, y, oshape=None, auto_scheduler_rewritten_layout=""):
     output : tvm.te.Tensor
         3-D with shape [batch, M, N]
     """
-    assert len(x.shape) == 3 and len(y.shape) == 3, "only support 3-dim batch_matmul"
     x_shape = get_const_tuple(x.shape)
     if auto_scheduler_rewritten_layout:
         # Infer shape for the rewritten layout
@@ -54,6 +53,7 @@ def batch_matmul(x, y, oshape=None, auto_scheduler_rewritten_layout=""):
         auto_scheduler.remove_index_check(y)
     else:
         y_shape = get_const_tuple(y.shape)
+    assert len(x_shape) == 3 and len(y_shape) == 3, "only support 3-dim batch_matmul"
 
     XB = x_shape[0]
     YB = y_shape[0]
@@ -65,8 +65,15 @@ def batch_matmul(x, y, oshape=None, auto_scheduler_rewritten_layout=""):
         batch = te.max(XB, YB)
         N = y.shape[1]
         oshape = (batch, M, N)
-    return te.compute(
+
+    output = te.compute(
         oshape,
         lambda b, i, j: te.sum(x[b if XB != 1 else 0, i, k] * y[b if YB != 1 else 0, j, k], axis=k),
         tag="batch_matmul",
+        attrs={"layout_free_placeholders": [y]},
     )
+
+    if auto_scheduler_rewritten_layout:
+        output = auto_scheduler.rewrite_compute_body(output, auto_scheduler_rewritten_layout)
+
+    return output

--- a/python/tvm/topi/nn/dense.py
+++ b/python/tvm/topi/nn/dense.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 """TVM operator fully connected compute."""
-from tvm import te
+from tvm import te, auto_scheduler
 from .. import tag
 
 
-def dense(data, weight, bias=None, out_dtype=None):
+def dense(data, weight, bias=None, out_dtype=None, auto_scheduler_rewritten_layout=""):
     """The default implementation of dense in topi.
 
     Parameters
@@ -30,30 +30,44 @@ def dense(data, weight, bias=None, out_dtype=None):
     weight : tvm.te.Tensor
         2-D with shape [out_dim, in_dim]
 
-    bias : tvm.te.Tensor, optional
+    bias : Optional[tvm.te.Tensor]
         1-D with shape [out_dim]
 
-    out_dtype : str
+    out_dtype : Optional[str]
         The output type. This is used for mixed precision.
+
+    auto_scheduler_rewritten_layout: str = ""
+        The layout after auto-scheduler's layout rewrite pass.
 
     Returns
     -------
     output : tvm.te.Tensor
         2-D with shape [batch, out_dim]
     """
-    assert len(data.shape) == 2 and len(weight.shape) == 2, "only support 2-dim dense"
+    assert len(data.shape) == 2, "only support 2-dim dense"
     if bias is not None:
         assert len(bias.shape) == 1
     if out_dtype is None:
         out_dtype = data.dtype
     batch, in_dim = data.shape
-    out_dim, _ = weight.shape
+
+    if auto_scheduler_rewritten_layout:
+        # Infer shape for the rewritten layout
+        out_dim, red_dim = auto_scheduler.get_shape_from_rewritten_layout(
+            auto_scheduler_rewritten_layout, ["j", "k"]
+        )
+        auto_scheduler.remove_index_check(weight)
+    else:
+        out_dim, red_dim = weight.shape
+    assert in_dim == red_dim
+
     k = te.reduce_axis((0, in_dim), name="k")
     matmul = te.compute(
         (batch, out_dim),
         lambda i, j: te.sum(data[i, k].astype(out_dtype) * weight[j, k].astype(out_dtype), axis=k),
         name="T_dense",
         tag="dense",
+        attrs={"layout_free_placeholders": [weight]},
     )
     if bias is not None:
         matmul = te.compute(
@@ -61,4 +75,8 @@ def dense(data, weight, bias=None, out_dtype=None):
             lambda i, j: matmul[i, j] + bias[j].astype(out_dtype),
             tag=tag.BROADCAST,
         )
+
+    if auto_scheduler_rewritten_layout:
+        matmul = auto_scheduler.rewrite_compute_body(matmul, auto_scheduler_rewritten_layout)
+
     return matmul

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1418,18 +1418,17 @@ Array<PrimExpr> GetShapeFromRewrittenLayout(String rewritten_layout, Array<Strin
 
   Array<PrimExpr> ret(axis_names.size(), 1);
 
+  size_t ct = 0;
   for (size_t i = 0; i < axis_names.size(); ++i) {
-    bool found = false;
     for (size_t j = 0; j < extracted_names.size(); ++j) {
       if (axis_names[i] == extracted_names[j]) {
         ret.Set(i, ret[i] * shape[j]);
-        found = true;
+        ct++;
       }
     }
-
-    ICHECK(found) << "Cannot find axis " << axis_names[i] << " in layout string \""
-                  << rewritten_layout << "\"";
   }
+
+  CHECK_EQ(ct, extracted_names.size()) << "The number or names of axes do not match";
 
   return ret;
 }

--- a/src/relay/op/make_op.h
+++ b/src/relay/op/make_op.h
@@ -46,6 +46,8 @@ Expr MakeConcatenate(Expr data, int axis);
 
 Expr MakeDense(Expr data, Expr weight, IndexExpr units, DataType out_dtype);
 
+Expr MakeBatchMatmul(Expr lhs, Expr rhs);
+
 Expr MakeExpandDims(Expr data, int axis, int num_newaxis);
 
 Expr MakeFull(Expr fill_value, Array<Integer> shape, DataType dtype);

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -24,6 +24,7 @@
 
 #include "nn.h"
 
+#include <tvm/auto_scheduler/compute_dag.h>
 #include <tvm/relay/attrs/image.h>
 #include <tvm/relay/attrs/nn.h>
 #include <tvm/relay/op.h>
@@ -853,31 +854,41 @@ bool BatchMatmulRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   const auto* x = types[0].as<TensorTypeNode>();
   const auto* y = types[1].as<TensorTypeNode>();
   if (x == nullptr || y == nullptr) return false;
-  ICHECK(x->shape.size() == 3 && y->shape.size() == 3);
+
+  const auto* param = attrs.as<BatchMatmulAttrs>();
+  Array<PrimExpr> y_shape;
+  if (param->auto_scheduler_rewritten_layout.size() == 0) {
+    y_shape = y->shape;
+  } else {
+    y_shape = auto_scheduler::GetShapeFromRewrittenLayout(param->auto_scheduler_rewritten_layout,
+                                                          {"b", "j", "k"});
+  }
+
+  ICHECK(x->shape.size() == 3 && y_shape.size() == 3);
   bool is_dyn = false;
   Array<tvm::PrimExpr> oshape;
   for (size_t i = 0; i < 3; ++i) {
-    if (x->shape[i].as<tir::AnyNode>() != nullptr || y->shape[i].as<tir::AnyNode>() != nullptr) {
+    if (x->shape[i].as<tir::AnyNode>() != nullptr || y_shape[i].as<tir::AnyNode>() != nullptr) {
       is_dyn = true;
       oshape.push_back(Any());
     } else {
       if (i == 0) {
-        oshape.push_back(max(x->shape[i], y->shape[i]));
+        oshape.push_back(max(x->shape[i], y_shape[i]));
       } else {
         oshape.push_back(x->shape[i]);
       }
     }
   }
   if (!is_dyn) {
-    ICHECK(reporter->AssertEQ(x->shape[0], y->shape[0]) || reporter->AssertEQ(x->shape[0], 1) ||
-           reporter->AssertEQ(y->shape[0], 1))
+    ICHECK(reporter->AssertEQ(x->shape[0], y_shape[0]) || reporter->AssertEQ(x->shape[0], 1) ||
+           reporter->AssertEQ(y_shape[0], 1))
         << "BatchDot: batch dimensions don't match, "
-        << " x shape=" << x->shape << ", y shape=" << y->shape;
-    ICHECK(reporter->AssertEQ(x->shape[2], y->shape[2]))
+        << " x shape=" << x->shape << ", y shape=" << y_shape;
+    ICHECK(reporter->AssertEQ(x->shape[2], y_shape[2]))
         << "BatchDot: shapes of x and y is inconsistent, "
-        << " x shape=" << x->shape << ", y shape=" << y->shape;
+        << " x shape=" << x->shape << ", y shape=" << y_shape;
 
-    oshape.Set(2, y->shape[1]);
+    oshape.Set(2, y_shape[1]);
   }
 
   // assign output type

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -845,6 +845,8 @@ If the input has size k on axis 1, then both gamma and beta have shape (k,).
     .add_type_rel("GroupNorm", GroupNormRel);
 
 // relay.nn.batch_matmul
+TVM_REGISTER_NODE_TYPE(BatchMatmulAttrs);
+
 bool BatchMatmulRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                     const TypeReporter& reporter) {
   ICHECK_EQ(types.size(), 3);
@@ -885,8 +887,9 @@ bool BatchMatmulRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
 
 // Positional relay function to create batch_matmul operator used by frontend FFI.
 Expr MakeBatchMatmul(Expr x, Expr y) {
+  auto attrs = make_object<BatchMatmulAttrs>();
   static const Op& op = Op::Get("nn.batch_matmul");
-  return Call(op, {x, y}, Attrs(), {});
+  return Call(op, {x, y}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relay.op.nn._make.batch_matmul").set_body_typed(MakeBatchMatmul);

--- a/src/relay/op/nn/nn.h
+++ b/src/relay/op/nn/nn.h
@@ -57,7 +57,15 @@ bool DenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     // data dtype as the weight dtype. However if weight dtype is explicitly
     // present we will use that.
     auto weight_dtype = (weight == nullptr ? data->dtype : weight->dtype);
-    reporter->Assign(types[1], TensorType(wshape, weight_dtype));
+    if (param->auto_scheduler_rewritten_layout.size() == 0) {
+      // Normal case: assign result to reporter
+      reporter->Assign(types[1], TensorType(wshape, weight_dtype));
+    } else {
+      // If the layout is rewritten by auto-scheduler,
+      // we just forcly apply the layout provided by auto-scheduler and
+      // skip the normal inference logic.
+      {}  // do nothing
+    }
     oshape.Set((oshape.size() - 1), param->units);
   } else {
     if (weight == nullptr) return false;

--- a/src/relay/transforms/auto_scheduler_layout_rewrite.cc
+++ b/src/relay/transforms/auto_scheduler_layout_rewrite.cc
@@ -163,7 +163,7 @@ TVM_REGISTER_GLOBAL("relay.attrs.get_auto_scheduler_rewritten_layout")
       } else {
         LOG(FATAL) << "Unhandled attribute: " << attrs;
       }
-      return std::string();
+      return tvm::String();
     });
 
 }  // namespace transform

--- a/src/relay/transforms/auto_scheduler_layout_rewrite.cc
+++ b/src/relay/transforms/auto_scheduler_layout_rewrite.cc
@@ -83,6 +83,12 @@ class FuncMutator : public ExprMutator {
       Attrs updated_attrs;
       if (auto pattr = call->attrs.as<Conv2DAttrs>()) {
         updated_attrs = CopyAttrsWithNewLayout(pattr, new_layout);
+      } else if (auto pattr = call->attrs.as<DenseAttrs>()) {
+        updated_attrs = CopyAttrsWithNewLayout(pattr, new_layout);
+      } else if (auto pattr = call->attrs.as<BatchMatmulAttrs>()) {
+        updated_attrs = CopyAttrsWithNewLayout(pattr, new_layout);
+      } else {
+        LOG(FATAL) << "Unhandled attribute: " << call->attrs;
       }
       new_n = Call(call->op, updated_args, updated_attrs);
     }
@@ -93,7 +99,7 @@ class FuncMutator : public ExprMutator {
   std::deque<std::string> ori_layouts_queue_;
   std::deque<std::string> new_layouts_queue_;
 
-  std::vector<std::string> target_ops_{"nn.conv2d"};
+  std::vector<std::string> target_ops_{"nn.conv2d", "nn.dense", "nn.batch_matmul"};
 };
 
 Expr AutoSchedulerLayoutRewriter::VisitExpr_(const CallNode* n) {
@@ -150,6 +156,12 @@ TVM_REGISTER_GLOBAL("relay.attrs.get_auto_scheduler_rewritten_layout")
     .set_body_typed([](const Attrs& attrs) {
       if (attrs->IsInstance<Conv2DAttrs>()) {
         return attrs.as<Conv2DAttrs>()->auto_scheduler_rewritten_layout;
+      } else if (attrs->IsInstance<DenseAttrs>()) {
+        return attrs.as<DenseAttrs>()->auto_scheduler_rewritten_layout;
+      } else if (attrs->IsInstance<BatchMatmulAttrs>()) {
+        return attrs.as<BatchMatmulAttrs>()->auto_scheduler_rewritten_layout;
+      } else {
+        LOG(FATAL) << "Unhandled attribute: " << attrs;
       }
       return std::string();
     });

--- a/src/relay/transforms/combine_parallel_batch_matmul.cc
+++ b/src/relay/transforms/combine_parallel_batch_matmul.cc
@@ -70,16 +70,15 @@ class ParallelBatchMatmulCombiner : public ParallelOpCombiner {
   }
 
   Call MakeCombinedOp(const Group& branches) {
-    const Op& batch_matmul = Op::Get("nn.batch_matmul");
     Expr data = branches[0][0]->args[0];
 
     Array<Expr> weights;
     for (const auto& branch : branches) {
-      auto batch_matmul = branch[0];
-      weights.push_back(batch_matmul->args[1]);
+      auto call = branch[0];
+      weights.push_back(call->args[1]);
     }
     Expr new_weight = MakeConcatenate(Tuple(weights), 1);
-    return Call(batch_matmul, {data, new_weight}, {}, {});
+    return Downcast<Call>(MakeBatchMatmul(data, new_weight));
   }
 
   bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) { return true; }

--- a/src/relay/transforms/combine_parallel_op_batch.h
+++ b/src/relay/transforms/combine_parallel_op_batch.h
@@ -95,7 +95,7 @@ class ParallelOpBatchCombiner : public ParallelOpCombiner {
    * \param branches branches that are to be combined
    * \return new call with branches combined as batch op by stacking args
    */
-  Call MakeCombinedOp(const Group& branches) final;
+  virtual Call MakeCombinedOp(const Group& branches);
 
   /*
    * \brief Checks if argument of op following combined ops are able to be combined

--- a/tests/python/relay/test_auto_scheduler_layout_rewrite.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite.py
@@ -82,7 +82,7 @@ def get_relay_dense(m=128, n=128, k=128):
     return mod, data, weight
 
 
-def get_relay_batchmm(batch=8, m=512, n=512, k=512):
+def get_relay_batchmm(batch=4, m=128, n=128, k=128):
     dtype = "float32"
     d = relay.var("data", shape=(batch, m, k), dtype=dtype)
     w = relay.var("weight", shape=(batch, n, k), dtype=dtype)
@@ -132,7 +132,7 @@ def tune_and_check(mod, data, weight):
         actual_output = compile_and_run()
         expected_output = compile_and_run(disabled_pass={"AutoSchedulerLayoutRewrite"})
 
-        tvm.testing.assert_allclose(actual_output, expected_output, rtol=1e-4)
+        tvm.testing.assert_allclose(actual_output, expected_output, rtol=1e-4, atol=1e-4)
 
 
 def test_conv2d():

--- a/tests/python/relay/test_auto_scheduler_layout_rewrite.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite.py
@@ -23,6 +23,7 @@ import tvm
 from tvm import relay, auto_scheduler
 from tvm.contrib import graph_runtime
 import tvm.testing
+from tvm.testing import PropagatingThread
 
 
 def get_np_array(var, dtype):
@@ -64,6 +65,28 @@ def get_relay_conv2d(
         data_layout=layout,
         kernel_layout=kernel_layout,
     )
+    mod = tvm.IRModule()
+    mod["main"] = relay.Function([d, w], y)
+    data, weight = get_np_array(d, dtype), get_np_array(w, dtype)
+    return mod, data, weight
+
+
+def get_relay_dense(m=128, n=128, k=128):
+    dtype = "float32"
+    d = relay.var("data", shape=(m, k), dtype=dtype)
+    w = relay.var("weight", shape=(n, k), dtype=dtype)
+    y = relay.nn.dense(d, w, units=n)
+    mod = tvm.IRModule()
+    mod["main"] = relay.Function([d, w], y)
+    data, weight = get_np_array(d, dtype), get_np_array(w, dtype)
+    return mod, data, weight
+
+
+def get_relay_batchmm(batch=8, m=512, n=512, k=512):
+    dtype = "float32"
+    d = relay.var("data", shape=(batch, m, k), dtype=dtype)
+    w = relay.var("weight", shape=(batch, n, k), dtype=dtype)
+    y = relay.nn.batch_matmul(d, w)
     mod = tvm.IRModule()
     mod["main"] = relay.Function([d, w], y)
     data, weight = get_np_array(d, dtype), get_np_array(w, dtype)
@@ -113,9 +136,29 @@ def tune_and_check(mod, data, weight):
 
 
 def test_conv2d():
+    # wrap the search in a new thread to avoid the conflict
+    # between python's multiprocessing and tvm's thread pool
     mod, data, weight = get_relay_conv2d(kh=1, kw=1)
-    tune_and_check(mod, data, weight)
+    t = PropagatingThread(target=tune_and_check, args=(mod, data, weight))
+    t.start()
+    t.join()
+
+
+def test_dense():
+    mod, data, weight = get_relay_dense()
+    t = PropagatingThread(target=tune_and_check, args=(mod, data, weight))
+    t.start()
+    t.join()
+
+
+def test_batch_matmul():
+    mod, data, weight = get_relay_batchmm()
+    t = PropagatingThread(target=tune_and_check, args=(mod, data, weight))
+    t.start()
+    t.join()
 
 
 if __name__ == "__main__":
     test_conv2d()
+    test_dense()
+    test_batch_matmul()

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -286,8 +286,6 @@ def test_combine_parallel_dense_flat_biasadd():
         y = run_opt_pass(y_before, combine_pass)
         y_expected = expected(x, w1, w2, b1, b2, j, bias_shape1, bias_shape2)
         y_expected = run_opt_pass(y_expected, transform.InferType())
-        print(y.astext(False))
-        print(y_expected.astext(False))
         tvm.ir.assert_structural_equal(y, y_expected, map_free_vars=True)
 
     check(3, 5, 4, (), ())

--- a/tests/python/unittest/test_auto_scheduler_common.py
+++ b/tests/python/unittest/test_auto_scheduler_common.py
@@ -16,9 +16,6 @@
 # under the License.
 
 """Common functions for auto_scheduler test cases"""
-
-import threading
-
 import tvm
 from tvm import te, auto_scheduler
 from tvm import topi
@@ -251,18 +248,3 @@ def get_tiled_matmul():
     )
 
     return dag, s0
-
-
-class PropagatingThread(threading.Thread):
-    def run(self):
-        self.exc = None
-        try:
-            self.ret = self._target(*self._args, **self._kwargs)
-        except BaseException as e:
-            self.exc = e
-
-    def join(self):
-        super(PropagatingThread, self).join()
-        if self.exc:
-            raise self.exc
-        return self.ret

--- a/tests/python/unittest/test_auto_scheduler_search_policy.py
+++ b/tests/python/unittest/test_auto_scheduler_search_policy.py
@@ -24,9 +24,10 @@ import tempfile
 
 import tvm
 import tvm.testing
+from tvm.testing import PropagatingThread
 from tvm import auto_scheduler
 
-from test_auto_scheduler_common import matmul_auto_scheduler_test, PropagatingThread
+from test_auto_scheduler_common import matmul_auto_scheduler_test
 import multiprocessing
 
 


### PR DESCRIPTION
- Add layout rewrite support for dense and batch matmul
- Use a general function `get_shape_from_rewritten_layout` to simplify the shape inference