### PR TITLE
[µTVM] Raise a better error when project_dir does not exist

### DIFF
--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -103,7 +103,8 @@ class ZephyrCompiler(tvm.micro.Compiler):
             # Raise this error instead of a potentially-more-cryptic compiler error due to a missing
             # prj.conf.
             raise ProjectNotFoundError(
-                f"project_dir supplied to ZephyrCompiler does not exist: {project_dir}")
+                f"project_dir supplied to ZephyrCompiler does not exist: {project_dir}"
+            )
 
         self._board = board
         if west_cmd is None:

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -58,6 +58,10 @@ class SubprocessEnv(object):
         return subprocess.check_output(cmd, env=env, **kw)
 
 
+class ProjectNotFoundError(Exception):
+    """Raised when the project_dir supplied to ZephyrCompiler does not exist."""
+
+
 class FlashRunnerNotSupported(Exception):
     """Raised when the FLASH_RUNNER for a project isn't supported by this Zephyr adapter."""
 
@@ -95,6 +99,12 @@ class ZephyrCompiler(tvm.micro.Compiler):
             If given, additional environment variables present when invoking west, cmake, or make.
         """
         self._project_dir = project_dir
+        if not os.path.exists(project_dir):
+            # Raise this error instead of a potentially-more-cryptic compiler error due to a missing
+            # prj.conf.
+            raise ProjectNotFoundError(
+                f"project_dir supplied to ZephyrCompiler does not exist: {project_dir}")
+
         self._board = board
         if west_cmd is None:
             self._west_cmd = [sys.executable, "-mwest.app.main"]


### PR DESCRIPTION
Found this problem while fixing the µTVM documentation. If `project_dir` (specified to `ZephyrCompiler` constructor) points to a non-existent directory, you get a cryptic compiler error.
