### PR TITLE
[Doc][AutoScheduler] Improve hyperlinks in tutorials

### DIFF
--- a/tutorials/auto_scheduler/tune_network_cuda.py
+++ b/tutorials/auto_scheduler/tune_network_cuda.py
@@ -306,7 +306,7 @@ print("Mean inference time (std dev): %.2f ms (%.2f ms)" % (np.mean(prof_res), n
 #    in function :code:`run_tuning`. Say,
 #    :code:`tuner = auto_scheduler.TaskScheduler(tasks, task_weights, load_log_file=log_file)`
 # 4. If you have multiple target GPUs, you can use all of them for measurements to
-#    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-rpc-tracker>`
+#    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-scale-up-rpc-tracker>`
 #    to learn how to use the RPC Tracker and RPC Server.
 #    To use the RPC Tracker in auto-scheduler, replace the runner in :code:`TuningOptions`
 #    with :any:`auto_scheduler.RPCRunner`.

--- a/tutorials/auto_scheduler/tune_network_mali.py
+++ b/tutorials/auto_scheduler/tune_network_mali.py
@@ -147,8 +147,7 @@ log_file = "%s-%s-B%d-%s.json" % (network, layout, batch_size, target.kind.name)
 
 #################################################################
 # Start an RPC Tracker and Register Devices to the Tracker
-# -----------------------------------------------------
-#
+# --------------------------------------------------------
 # Please refer to the "Start RPC Tracker" and "Register Devices to RPC Tracker" setions
 # in this :ref:`tutorial <tutorials-autotvm-start-rpc-tracker>` to start an RPC tracker
 # and register devices to the tracker.

--- a/tutorials/auto_scheduler/tune_network_mali.py
+++ b/tutorials/auto_scheduler/tune_network_mali.py
@@ -135,8 +135,6 @@ def get_network(name, batch_size, layout="NHWC", dtype="float32"):
 network = "mobilenet"
 batch_size = 1
 layout = "NHWC"
-# Replace this with the device key in your tracker
-device_key = "rk3399"
 # Set this to True if you use ndk tools for cross compiling
 use_ndk = True
 # Path to cross compiler
@@ -145,6 +143,19 @@ target_host = tvm.target.Target("llvm -mtriple=aarch64-linux-gnu")
 target = tvm.target.Target("opencl -device=mali")
 dtype = "float32"
 log_file = "%s-%s-B%d-%s.json" % (network, layout, batch_size, target.kind.name)
+
+
+#################################################################
+# Start an RPC Tracker and Register Devices to the Tracker
+# -----------------------------------------------------
+#
+# Please refer to the "Start RPC Tracker" and "Register Devices to RPC Tracker" setions
+# in this :ref:`tutorial <tutorials-autotvm-start-rpc-tracker>` to start an RPC tracker
+# and register devices to the tracker.
+
+# Replace this with the device key in your tracker
+device_key = "rk3399"
+
 
 #################################################################
 # Extract Search Tasks
@@ -339,9 +350,14 @@ def tune_and_evaluate():
 # 1. During the tuning, the auto-scheduler needs to compile many programs and
 #    extract feature from them. This part is CPU-intensive,
 #    so a high-performance CPU with many cores is recommended for faster search.
-# 2. If you have multiple target devices, you can use all of them for measurements to
-#    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-rpc-tracker>`
+# 2. You can use :code:`python3 -m tvm.auto_scheduler.measure_record --mode distill --i log.json`
+#    to distill the large log file and only save the best useful records.
+# 3. You can resume a search from the previous log file. You just need to
+#    add a new argument :code:`load_log_file` when creating the task scheduler
+#    in function :code:`run_tuning`. Say,
+#    :code:`tuner = auto_scheduler.TaskScheduler(tasks, task_weights, load_log_file=log_file)`
+# 4. If you have multiple target CPUs, you can use all of them for measurements to
+#    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-scale-up-rpc-tracker>`
 #    to learn how to use the RPC Tracker and RPC Server.
 #    To use the RPC Tracker in auto-scheduler, replace the runner in :code:`TuningOptions`
 #    with :any:`auto_scheduler.RPCRunner`.
-#

--- a/tutorials/auto_scheduler/tune_network_mali.py
+++ b/tutorials/auto_scheduler/tune_network_mali.py
@@ -355,7 +355,7 @@ def tune_and_evaluate():
 #    add a new argument :code:`load_log_file` when creating the task scheduler
 #    in function :code:`run_tuning`. Say,
 #    :code:`tuner = auto_scheduler.TaskScheduler(tasks, task_weights, load_log_file=log_file)`
-# 4. If you have multiple target CPUs, you can use all of them for measurements to
+# 4. If you have multiple target GPUs, you can use all of them for measurements to
 #    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-scale-up-rpc-tracker>`
 #    to learn how to use the RPC Tracker and RPC Server.
 #    To use the RPC Tracker in auto-scheduler, replace the runner in :code:`TuningOptions`

--- a/tutorials/auto_scheduler/tune_network_x86.py
+++ b/tutorials/auto_scheduler/tune_network_x86.py
@@ -305,7 +305,7 @@ print("Mean inference time (std dev): %.2f ms (%.2f ms)" % (np.mean(prof_res), n
 #    in function :code:`run_tuning`. Say,
 #    :code:`tuner = auto_scheduler.TaskScheduler(tasks, task_weights, load_log_file=log_file)`
 # 4. If you have multiple target CPUs, you can use all of them for measurements to
-#    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-rpc-tracker>`
+#    parallelize the measurements. Check this :ref:`section <tutorials-autotvm-scale-up-rpc-tracker>`
 #    to learn how to use the RPC Tracker and RPC Server.
 #    To use the RPC Tracker in auto-scheduler, replace the runner in :code:`TuningOptions`
 #    with :any:`auto_scheduler.RPCRunner`.

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -148,7 +148,7 @@ def get_network(name, batch_size):
 #   INFO:RPCTracker:bind to 0.0.0.0:9190
 
 #################################################################
-# Register devices to RPC Tracker
+# Register Devices to RPC Tracker
 # -----------------------------------
 # Now we can register our devices to the tracker. The first step is to
 # build the TVM runtime for the ARM devices.

--- a/tutorials/autotvm/tune_relay_cuda.py
+++ b/tutorials/autotvm/tune_relay_cuda.py
@@ -311,12 +311,12 @@ def tune_and_evaluate(tuning_opt):
 #
 #   Finally, always feel free to ask our community for help on https://discuss.tvm.apache.org
 
+#################################################################
+# .. _tutorials-autotvm-scale-up-rpc-tracker:
 
 #################################################################
 # Scale up measurement by using multiple devices
 # ----------------------------------------------
-# .. _tutorials-autotvm-rpc-tracker:
-#
 # If you have multiple devices, you can use all of them for measurement.
 # TVM uses the RPC Tracker to manage distributed devices.
 # The RPC Tracker is a centralized controller node. We can register all devices to
@@ -337,8 +337,8 @@ def tune_and_evaluate(tuning_opt):
 #
 #   INFO:RPCTracker:bind to 0.0.0.0:9190
 #
-# Then open another new terminal for the RPC server. We need to start one server
-# for each dedicated device. We use a string key to distinguish the types of devices.
+# Then open another new terminal for the RPC server. We need to start one dedicated server
+# for each device. We use a string key to distinguish the types of devices.
 # You can pick a name you like.
 # (Note: For rocm backend, there are some internal errors with the compiler,
 # we need to add `--no-fork` to the argument list.)

--- a/tutorials/autotvm/tune_relay_mobile_gpu.py
+++ b/tutorials/autotvm/tune_relay_mobile_gpu.py
@@ -121,6 +121,9 @@ def get_network(name, batch_size):
 
 
 #################################################################
+# .. _tutorials-autotvm-start-rpc-tracker:
+
+#################################################################
 # Start RPC Tracker
 # -----------------
 # TVM uses RPC session to communicate with ARM boards.
@@ -147,7 +150,7 @@ def get_network(name, batch_size):
 #   INFO:RPCTracker:bind to 0.0.0.0:9190
 
 #################################################################
-# Register devices to RPC Tracker
+# Register Devices to RPC Tracker
 # -----------------------------------
 # Now we can register our devices to the tracker. The first step is to
 # build the TVM runtime for the ARM devices.


### PR DESCRIPTION
- Add a section to introduce RPC tracker in the Mali tutorial. This section simply points to related autotvm tutorials.
- Improve hyperlinks in the tutorials.