### PR TITLE
[TOPI] Parallelize GPU NMS inner loop

### DIFF
--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -530,12 +530,15 @@ def nms_ir(
         def nms_inner_loop(ib, j):
             # the box j is valid, invalidate other boxes that overlap with j above iou_threshold
 
-            # When return_indices is False, no need to populate box_indices
-            if return_indices:
-                # Only one thread needs to this write
-                with ib.if_scope(tx == 0):
-                    orig_idx = sorted_index[i * num_anchors + j]
-                    box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
+            # # When return_indices is False, no need to populate box_indices
+            # if return_indices:
+            #     # Only one thread needs to this write
+            #     with ib.if_scope(tx == 0):
+            #         orig_idx = sorted_index[i * num_anchors + j]
+            #         box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
+
+            orig_idx = sorted_index[i * num_anchors + j]
+            box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
 
             num_valid_boxes_local[0] += 1
 
@@ -593,8 +596,8 @@ def nms_ir(
                     with ib.else_scope():
                         nms_inner_loop(ib, j)
 
-            with ib.if_scope(tx == 0):
-                num_valid_boxes[i] = num_valid_boxes_local[0]
+            # with ib.if_scope(tx == 0):
+            num_valid_boxes[i] = num_valid_boxes_local[0]
 
         with ib.else_scope():
             num_valid_boxes[i] = 0

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -533,15 +533,9 @@ def nms_ir(
 
             # When return_indices is False, no need to populate box_indices
             if return_indices:
-                orig_idx = sorted_index[i * num_anchors + j]
-                box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
-
-            # TODO(masahi): Want to do this instead of above, but the following is eliminated
-            # during codegen
-            # # Only one thread needs to this write
-            # with ib.if_scope(tx == 0):
-            #     orig_idx = sorted_index[i * num_anchors + j]
-            #     box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
+                with ib.if_scope(tx + 0 == 0):
+                    orig_idx = sorted_index[i * num_anchors + j]
+                    box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
 
             num_valid_boxes_local[0] += 1
 
@@ -593,11 +587,8 @@ def nms_ir(
                     with ib.else_scope():
                         nms_inner_loop(ib, j)
 
-            num_valid_boxes[i] = num_valid_boxes_local[0]
-            # TODO(masahi): Want to do this instead of above, but the following is eliminated
-            # during codegen
-            # with ib.if_scope(tx == 0):
-            #     num_valid_boxes[i] = num_valid_boxes_local[0]
+            with ib.if_scope(tx + 0 == 0):
+                num_valid_boxes[i] = num_valid_boxes_local[0]
 
         with ib.else_scope():
             num_valid_boxes[i] = 0

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -513,17 +513,14 @@ def nms_ir(
     with ib.new_scope():
         nthread_by = batch_size
         nthread_tx = max_threads
-        nthread_bx = ceil_div(num_anchors, max_threads)
 
         by = te.thread_axis("blockIdx.y")
         tx = te.thread_axis("threadIdx.x")
-        bx = te.thread_axis("blockIdx.x")
-        ib.scope_attr(by, "thread_extent", nthread_by)
         ib.scope_attr(by, "thread_extent", nthread_by)
         ib.scope_attr(tx, "thread_extent", nthread_tx)
 
         i = by
-        k = bx * nthread_tx + tx
+
         base_idx = i * num_anchors * box_data_length
         num_valid_boxes_local = ib.allocate(
             "int32", (1,), name="num_valid_boxes_local", scope="local"
@@ -531,43 +528,49 @@ def nms_ir(
         num_valid_boxes_local[0] = 0
 
         def nms_inner_loop(ib, j):
-            # box j is valid, invalidate other boxes that overlap with j above iou_threshold
+            # the box j is valid, invalidate other boxes that overlap with j above iou_threshold
 
             # When return_indices is False, no need to populate box_indices
             if return_indices:
                 # Only one thread needs to this write
-                with ib.if_scope(k == 0):
+                with ib.if_scope(tx == 0):
                     orig_idx = sorted_index[i * num_anchors + j]
                     box_indices[i, num_valid_boxes_local[0]] = indices[i, orig_idx]
 
             num_valid_boxes_local[0] += 1
 
             offset_j = j * box_data_length
-            offset_k = k * box_data_length
+            num_iter_per_thread = ceil_div(num_anchors - (j + 1), nthread_tx)
 
-            with ib.if_scope(
-                tvm.tir.all(
-                    j < k,
-                    out[base_idx + offset_k + score_index] > 0,
-                    tvm.tir.any(id_index < 0, out[base_idx + offset_k + id_index] >= 0),
-                    tvm.tir.any(
-                        force_suppress > 0,
-                        id_index < 0,
-                        out[base_idx + offset_k + id_index] == out[base_idx + offset_j + id_index],
-                    ),
-                )
-            ):
-                iou = calculate_overlap(
-                    out,
-                    base_idx + offset_j + coord_start,
-                    base_idx + offset_k + coord_start,
-                )
-                with ib.if_scope(iou >= iou_threshold):
-                    out[base_idx + offset_k + score_index] = -1.0
-                    with ib.if_scope(id_index >= 0):
-                        out[base_idx + offset_k + id_index] = -1.0
+            with ib.for_range(0, num_iter_per_thread) as _k:
+                k = j + 1 + _k * nthread_tx + tx
+                offset_k = k * box_data_length
 
-            ib.emit(tvm.tir.Call(None, "tir.tvm_storage_sync", tvm.runtime.convert(["shared"])))
+                with ib.if_scope(
+                    tvm.tir.all(
+                        k < num_anchors,
+                        out[base_idx + offset_k + score_index] > 0, # is the box k still valid?
+                        tvm.tir.any(id_index < 0, out[base_idx + offset_k + id_index] >= 0),
+                        tvm.tir.any(
+                            force_suppress > 0,
+                            id_index < 0,
+                            out[base_idx + offset_k + id_index]
+                            == out[base_idx + offset_j + id_index],
+                        ),
+                    )
+                ):
+                    iou = calculate_overlap(
+                        out,
+                        base_idx + offset_j + coord_start,
+                        base_idx + offset_k + coord_start,
+                    )
+                    with ib.if_scope(iou >= iou_threshold):
+                        # invalidate the box k
+                        out[base_idx + offset_k + score_index] = -1.0
+                        with ib.if_scope(id_index >= 0):
+                            out[base_idx + offset_k + id_index] = -1.0
+
+                ib.emit(tvm.tir.Call(None, "tir.tvm_storage_sync", tvm.runtime.convert(["shared"])))
 
         if isinstance(max_output_size, int):
             max_output_size = tvm.tir.const(max_output_size)
@@ -590,7 +593,8 @@ def nms_ir(
                     with ib.else_scope():
                         nms_inner_loop(ib, j)
 
-            num_valid_boxes[i] = num_valid_boxes_local[0]
+            with ib.if_scope(tx == 0):
+                num_valid_boxes[i] = num_valid_boxes_local[0]
 
         with ib.else_scope():
             num_valid_boxes[i] = 0


### PR DESCRIPTION
This is a follow-up to https://github.com/apache/tvm/pull/7136. I found a simple way to parallelize the inner loop of GPU NMS, which is currently done in a sequential way since https://github.com/apache/tvm/pull/6839 and hence extremely slow if the number of input box is large. This change brings massive speedup on object detection models from PyTorch and Gluon, as shown below. 

```
GPU NMS workload from PyTorch MaskRCNN (4500 boxes)
Before: 2.1 sec
After: 5.78 milli sec 

Workload from Gluon SSD
Before: 12.5 milli sec
After: 0.206 milli sec
```

Before I explain what I did, here is how currently we do the sequential, O(N ** 2) triangle loop. This is done by a single thread.
```
# The outer loop goes through boxes sorted by their score.
for j in range(nboxes):
    # The inner loop check if box j does not overlap with all other preceding boxes k
    for k in range(j):
        if box k is valid:
            do IOU test between j and k and possibly invalidate j
```

My parallelization instead does the above triangle in the following way:
```
for j in range(nboxes):
   if j is still valid:
        for k in range(j + 1, nboxes) in parallel:
             do IOU test between j and k and possibly invalidate box k
   # Flush IOU test results from the inner loop to global memory before continuing to the next loop
   # So that other threads can also see them
   syncthreads() 
``` 
The idea is, at the start of the inner loop, box j is assumed to be a valid box, and the inner loop invalidates other succeeding boxes that have high overlap with the newly found valid box j. The inner loop can be trivially done in parallel and the number of IOU tests reduces to O(# selected boxes * N). 

Now, the inner loop is done in parallel and the other loop is sequential. All threads need to do the outer loop in a lock step: The results of checking if box j is still valid must be consistent across all threads. Since we cannot do global sync inside kernels, I use only one thread block for parallelization and use `__syncthreads()` after each inner loop.

I have one more PR coming to optimize GPU NMS IR further.

please review @Laurawly @kevinthesun @zhiics @vinx13 