### PR TITLE
[AutoScheduler] Use VM to extract tasks for dynamic models

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -212,7 +212,7 @@ def traverse_to_get_io_tensors(outs):
     Returns
     -------
     io_tensors: List[Tensor]
-        The input and output tensors
+        The input and output tensors with static shape
     has_layout_free: bool
         Whether the compute DAG has layout_free placeholders
     """

--- a/python/tvm/auto_scheduler/utils.py
+++ b/python/tvm/auto_scheduler/utils.py
@@ -34,6 +34,7 @@ try:
 except ImportError:
     psutil = None
 
+import tvm
 from tvm import rpc
 from tvm.tir import expr
 from tvm.tir.transform import Simplify
@@ -91,9 +92,15 @@ def get_const_tuple(in_tuple):
     Returns
     -------
     out_tuple : Tuple[int]
-        The output.
+        The output tuple of int. The dynamic shape (Var or Any) will be -1.
     """
-    return tuple(get_const_int(x) for x in in_tuple)
+    ret = []
+    for elem in in_tuple:
+        if isinstance(elem, (tvm.tir.Var, tvm.tir.expr.Any)):
+            ret.append(elem)
+        else:
+            ret.append(get_const_int(elem))
+    return tuple(ret)
 
 
 def list_to_tuple(x):

--- a/python/tvm/auto_scheduler/utils.py
+++ b/python/tvm/auto_scheduler/utils.py
@@ -91,8 +91,8 @@ def get_const_tuple(in_tuple):
 
     Returns
     -------
-    out_tuple : Tuple[int]
-        The output tuple of int. The dynamic shape (Var or Any) will be -1.
+    out_tuple : Tuple[Union[int,tvm.tir.Var,tvm.tir.Any]]
+        The output tuple of int. The dynamic shape variables (Var or Any) will be preserved.
     """
     ret = []
     for elem in in_tuple:

--- a/python/tvm/te/tensor.py
+++ b/python/tvm/te/tensor.py
@@ -85,11 +85,12 @@ class Tensor(DataProducer, _expr.ExprOp):
                 return _expr.EqualOp(self, other)
             return False
         if self.ndim == 0 and other.ndim == 0:
-            raise ValueError(
-                "Equal == comparison among rank-0 tensor is ambiguous, "
-                "use Tensor.equal for content expression equvalence, "
-                "use Tensor.same_as for exact reference comparison"
-            )
+            return self.same_as(other)
+            # raise ValueError(
+            #     "Equal == comparison among rank-0 tensor is ambiguous, "
+            #     "use Tensor.equal for content expression equvalence, "
+            #     "use Tensor.same_as for exact reference comparison"
+            # )
         return _ffi_api.TensorEqual(self, other)
 
     @property

--- a/python/tvm/te/tensor.py
+++ b/python/tvm/te/tensor.py
@@ -85,12 +85,11 @@ class Tensor(DataProducer, _expr.ExprOp):
                 return _expr.EqualOp(self, other)
             return False
         if self.ndim == 0 and other.ndim == 0:
-            return self.same_as(other)
-            # raise ValueError(
-            #     "Equal == comparison among rank-0 tensor is ambiguous, "
-            #     "use Tensor.equal for content expression equvalence, "
-            #     "use Tensor.same_as for exact reference comparison"
-            # )
+            raise ValueError(
+                "Equal == comparison among rank-0 tensor is ambiguous, "
+                "use Tensor.equal for content expression equvalence, "
+                "use Tensor.same_as for exact reference comparison"
+            )
         return _ffi_api.TensorEqual(self, other)
 
     @property

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1397,8 +1397,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
                    << select->false_value << ")= " << '(' << preduce->source[0] << ','
                    << preduce->source[1] << ")\n";
               } else {
-                ss << "UnsupportedReduce(" << combiner << ")\n";
-                //LOG(FATAL) << "Unsupported reduction operator" << combiner;
+                ss << "reduce" << combiner << "\n";
               }
             } else {
               ss << " = " << pop->body[k] << "\n";

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -1397,7 +1397,8 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
                    << select->false_value << ")= " << '(' << preduce->source[0] << ','
                    << preduce->source[1] << ")\n";
               } else {
-                LOG(FATAL) << "Unsupported reduction operator" << combiner;
+                ss << "UnsupportedReduce(" << combiner << ")\n";
+                //LOG(FATAL) << "Unsupported reduction operator" << combiner;
               }
             } else {
               ss << " = " << pop->body[k] << "\n";

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -157,8 +157,7 @@ class ScheduleGetter : public backend::MemoizedExprTranslator<Array<te::Tensor>>
             runtime::Registry::Get("auto_scheduler.relay_integration.auto_schedule_topi_compute");
         ICHECK(fauto_schedule != nullptr)
             << "auto_scheduler.relay_integration.auto_schedule_topi_compute is not registered";
-        bool has_complex_op = anchor_op_pattern_ >= kCommReduce;
-        ObjectRef obj = (*fauto_schedule)(tensor_outs, has_complex_op);
+        ObjectRef obj = (*fauto_schedule)(tensor_outs);
         if (obj.defined()) {
           schedule = Downcast<te::Schedule>(obj);
         }

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -224,8 +224,9 @@ def test_task_extraction():
     # Every Relay function becomes a task regardless what ops in its body.
     verify_task_extraction(get_simple_func(), 1, True)
 
-    # "relay.shape_of" has TOpPattern=kOpaque so it is defined as a "complex" op.
-    verify_task_extraction(get_shape_of_func(), 1)
+    # The Relay function without any reduce op is considered as a simple task.
+    verify_task_extraction(get_shape_of_func(), 0)
+    verify_task_extraction(get_shape_of_func(), 1, True)
 
     # The Relay function with dynamic shape inputs/outputs will not be extracted.
     verify_task_extraction(get_func_with_dynamic_shape(), 0)

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -180,7 +180,6 @@ def test_task_extraction():
         out = relay.max(data)
         return relay.Function(relay.analysis.free_vars(out), out)
 
-
     def get_func_with_control_flow():
         data = relay.var("data", shape=(1, 3, 224, 224))
         weight = relay.var("weight", shape=(32, 3, 3, 3))

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -132,6 +132,17 @@ def test_task_extraction():
     dtype = "float32"
     target = tvm.target.Target("llvm")
 
+    def verify_task_extraction(func, expected_task, include_simple_tasks=False):
+        mod = tvm.IRModule.from_expr(func)
+        tasks, task_weights = auto_scheduler.extract_tasks(
+            mod["main"], None, target, include_simple_tasks=include_simple_tasks
+        )
+
+        for t in tasks:
+            print(t.compute_dag)
+        assert len(tasks) == expected_task
+        assert len(task_weights) == expected_task
+
     def get_func():
         data = relay.var("data", shape=(ishape), dtype=dtype)
         weight1 = relay.var("weight1", shape=(w1shape), dtype=dtype)
@@ -161,6 +172,24 @@ def test_task_extraction():
         out = relay.image.affine_grid(data, (150, 150))
         return relay.Function([data], out)
 
+    def get_shape_of_func():
+        data = relay.var("data", shape=(relay.Any(), 28, 28), dtype="float32")
+        out = relay.shape_of(data)
+        return relay.Function([data], out)
+
+    def get_func_with_control_flow():
+        data = relay.var("data", shape=(1, 3, 224, 224))
+        weight = relay.var("weight", shape=(32, 3, 3, 3))
+        eq1 = relay.var("e1", shape=[], dtype="float32")
+        eq2 = relay.var("e2", shape=[], dtype="float32")
+        eq = relay.equal(eq1, eq2)
+
+        true_branch = relay.zeros(shape=(1, 32, 222, 222), dtype="float32")
+        false_branch = relay.nn.conv2d(data, weight, kernel_size=(3, 3), channels=32)
+        ife = relay.If(eq, true_branch, false_branch)
+        out = relay.erf(ife)
+        return relay.Function([data, weight, eq1, eq2], out)
+
     def get_func_with_unsupported_op():
         def get_postproc_func():
             data = relay.var("data", shape=((1, 3, 6)), dtype=dtype)
@@ -180,48 +209,26 @@ def test_task_extraction():
         out = relay.Call(get_postproc_func(), [nms])
         return relay.Function([cls_prob, loc_pred, anchors], out)
 
-    func = get_func()
-    mod = tvm.IRModule.from_expr(func)
-    tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], None, target)
-
     # Relay FuseOps puts two conv2ds to separate functions and results in two tasks.
-    assert len(tasks) == 2
-    assert len(task_weights) == 2
-
-    func = get_fused_func()
-    mod = tvm.IRModule.from_expr(func)
-    tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], None, target)
+    verify_task_extraction(get_func(), 2)
 
     # By setting the function to primitive, Relay FuseOps will not break it and result in one task.
-    assert len(tasks) == 1
-    assert len(task_weights) == 1
-
-    func = get_simple_func()
-    mod = tvm.IRModule.from_expr(func)
-    tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], None, target)
+    verify_task_extraction(get_fused_func(), 1)
 
     # The Relay function without complex ops will not form a task by default.
-    assert len(tasks) == 0
-    assert len(task_weights) == 0
-
-    tasks, task_weights = auto_scheduler.extract_tasks(
-        mod["main"], None, target, include_simple_tasks=True
-    )
+    verify_task_extraction(get_simple_func(), 0)
 
     # Every Relay function becomes a task regardless what ops in its body.
-    assert len(tasks) == 1
-    assert len(task_weights) == 1
+    verify_task_extraction(get_simple_func(), 1, True)
+
+    # "relay.shape_of" has TOpPattern=kOpaque so it is defined as a "complex" op.
+    verify_task_extraction(get_shape_of_func(), 1)
+
+    # The Conv2D in the Relay function with control flow could still be a task.
+    verify_task_extraction(get_func_with_control_flow(), 1)
 
     # Func1 (with NMS) -> Func2 (injective).
-    func = get_func_with_unsupported_op()
-    mod = tvm.IRModule.from_expr(func)
-    tasks, task_weights = auto_scheduler.extract_tasks(
-        mod["main"], None, target, include_simple_tasks=True
-    )
-
-    # The function with NMS should fail, but the other function with ReLU should be a task.
-    assert len(tasks) == 1
-    assert len(task_weights) == 1
+    verify_task_extraction(get_func_with_unsupported_op(), 1, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Discussion: https://discuss.tvm.apache.org/t/autoscheduler-and-vm/8750

Remaining issues to auto-schedule PyTorch Mask R-CNN but not handled in this PR:

1. There are still lots of extracted tasks only contain a shape_of op. This is because shape_of has TOpPattern kOpaque which is one target of auto_scheduler task extraction. The problem is other ops with this pattern may be tunable (e.g., softmax).
2. Although the source tensor of shape_of in Mask R-CNN has dynamic shape (e.g., (Any, 28, 28)), it cannot be detected by checking I/O tensors, because it has no input tensors, and the shape of its output tensor is (3,) which is static.
3. When extracting tasks for a NCHW model on x86, Conv2D NCHWc compute will be selected. However, we should provide the general NCHW compute to auto_scheduler for tuning.

cc @merrymercy @masahi @jcf94 