### PR TITLE
[AutoTVM-FIX] avoid unexpected value(1) of search space when get length for uninitiated search space

### DIFF
--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -836,7 +836,7 @@ class ConfigSpace(object):
         return [Axis(None, i) for i in range(space_class.get_num_output(axes, policy, **kwargs))]
 
     def __len__(self):
-        if self._length is None:
+        if self._length is None and len(self.space_map.values()) != 0:
             self._length = int(np.prod([len(x) for x in self.space_map.values()]))
         return self._length
 

--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -836,7 +836,9 @@ class ConfigSpace(object):
         return [Axis(None, i) for i in range(space_class.get_num_output(axes, policy, **kwargs))]
 
     def __len__(self):
-        if self._length is None and len(self.space_map.values()) != 0:
+        if not self.space_map:
+            return 0
+        if self._length is None:
             self._length = int(np.prod([len(x) for x in self.space_map.values()]))
         return self._length
 


### PR DESCRIPTION
When _length is None, then initiate it to current search space length, it's almost good most of times, however if user/developer get len of search space when space is empty, then a unreasonable _length 1 will be produced( the result of empty list for np.prod is 1), so it's better for adding an extra condition such as " len(self.space_map.values()) != 0" . :)

https://github.com/apache/tvm/issues/7155#issue-773379193

@comaniac 
