### PR TITLE
[AutoScheduler] Fix for zero-rank output

### DIFF
--- a/src/auto_scheduler/search_policy/sketch_policy.h
+++ b/src/auto_scheduler/search_policy/sketch_policy.h
@@ -87,6 +87,8 @@ struct SketchParamKey {
   static constexpr const char* disable_change_compute_location = "disable_change_compute_location";
 };
 
+class SketchPolicy;
+
 /*!
  * \brief The search policy that searches in a hierarchical search space defined by sketches.
  * The policy randomly samples programs from the space defined by sketches
@@ -166,6 +168,11 @@ class SketchPolicyNode : public SearchPolicyNode {
 
   /*! \brief The cached sketches */
   Array<State> sketch_cache_;
+
+  /*! \brief The minimul output population of SampleInitPopulation */
+  int sample_init_min_pop_;
+
+  friend class SketchPolicy;
 };
 
 /*!

--- a/src/auto_scheduler/search_policy/utils.h
+++ b/src/auto_scheduler/search_policy/utils.h
@@ -609,12 +609,11 @@ inline State FuseAllOuterSpaceIterators(const State& state, int stage_id, Iterat
     to_fuse.push_back(it);
   }
 
-  ICHECK(!to_fuse.empty());
   State tmp_s = state;
-  if (to_fuse.size() > 1) {
-    *fused_iter = tmp_s.fuse(stage_id, to_fuse);
-  } else {
+  if (to_fuse.size() == 1) {
     *fused_iter = to_fuse[0];
+  } else {
+    *fused_iter = tmp_s.fuse(stage_id, to_fuse);
   }
   return tmp_s;
 }

--- a/src/auto_scheduler/transform_step.cc
+++ b/src/auto_scheduler/transform_step.cc
@@ -538,14 +538,24 @@ Iterator FuseStepNode::ApplyToState(State* state) const {
   Iterator new_it =
       Iterator(new_name, range, new_iter_kind, IteratorAnnotation::kNone, &orig_iters);
   Array<Iterator> new_iters;
-  new_iters.insert(new_iters.end(), stage->iters.begin(), stage->iters.begin() + fused_ids.front());
-  new_iters.push_back(new_it);
-  new_iters.insert(new_iters.end(), stage->iters.begin() + fused_ids.back() + 1,
-                   stage->iters.end());
+
+  if (fused_ids.empty()) {
+    new_iters.push_back(new_it);
+  } else {
+    new_iters.insert(new_iters.end(), stage->iters.begin(),
+                     stage->iters.begin() + fused_ids.front());
+    new_iters.push_back(new_it);
+    new_iters.insert(new_iters.end(), stage->iters.begin() + fused_ids.back() + 1,
+                     stage->iters.end());
+  }
 
   StateNode* pstate = state->CopyOnWrite();
   pstate->stages.Set(stage_id,
                      Stage(stage->op, stage->op_type, new_iters, stage->compute_at, stage->attrs));
+
+  if (fused_ids.empty()) {
+    return new_it;
+  }
 
   // Two vectors are used to represent the iterator relation before and after fuse
   // The original iterators in AttachMap will be updated with the new iterators
@@ -583,9 +593,13 @@ IterVar FuseStepNode::ApplyToSchedule(Array<te::Stage>* stages,
   stage.fuse(to_fuse, &fused_axis);
 
   Array<IterVar> new_axes;
-  new_axes.insert(new_axes.end(), axes.begin(), axes.begin() + fused_ids.front());
-  new_axes.push_back(fused_axis);
-  new_axes.insert(new_axes.end(), axes.begin() + fused_ids.back() + 1, axes.end());
+  if (fused_ids.empty()) {
+    new_axes.push_back(fused_axis);
+  } else {
+    new_axes.insert(new_axes.end(), axes.begin(), axes.begin() + fused_ids.front());
+    new_axes.push_back(fused_axis);
+    new_axes.insert(new_axes.end(), axes.begin() + fused_ids.back() + 1, axes.end());
+  }
 
   stage_to_axes->Set(stage, std::move(new_axes));
   stages->Set(stage_id, std::move(stage));
@@ -683,9 +697,12 @@ void PragmaStepNode::ApplyToSchedule(Array<te::Stage>* stages,
     }
     ICHECK_LT(pos, pragma_type.size()) << "max step value not found.";
     int value = atoi(pragma_type.c_str() + pos + 1);
-    stage.pragma(axes[iter_id], "auto_unroll_max_step", value);
-    stage.pragma(axes[iter_id], "unroll_explicit", true);
+    if (iter_id < static_cast<int>(axes.size())) {
+      stage.pragma(axes[iter_id], "auto_unroll_max_step", value);
+      stage.pragma(axes[iter_id], "unroll_explicit", true);
+    }
   } else {
+    ICHECK_LT(iter_id, axes.size());
     stage.pragma(axes[iter_id], pragma_type);
   }
   stages->Set(stage_id, std::move(stage));

--- a/tests/python/unittest/test_auto_scheduler_common.py
+++ b/tests/python/unittest/test_auto_scheduler_common.py
@@ -146,6 +146,23 @@ def invalid_compute_definition():
 
 
 @auto_scheduler.register_workload
+def zero_rank_reduce_auto_scheduler_test(N):
+    A = tvm.te.placeholder((N,), name="A")
+    k = tvm.te.reduce_axis((0, N), name="k")
+    B = tvm.te.compute((), lambda: tvm.te.sum(A[k], k), name="B")
+
+    return [A, B]
+
+
+@auto_scheduler.register_workload
+def zero_rank_compute_auto_scheduler_test(N):
+    A = tvm.te.placeholder((N,), name="A")
+    B = tvm.te.compute((), lambda: A[0], name="B")
+
+    return [A, B]
+
+
+@auto_scheduler.register_workload
 def conv2d_winograd_nhwc_auto_scheduler_test(
     N, H, W, CI, CO, kernel_size=3, stride=1, padding=0, dilation=1
 ):

--- a/tests/python/unittest/test_auto_scheduler_sketch_generation.py
+++ b/tests/python/unittest/test_auto_scheduler_sketch_generation.py
@@ -32,6 +32,7 @@ from test_auto_scheduler_common import (
     softmax_nm_auto_scheduler_test,
     softmax_abcd_auto_scheduler_test,
     conv2d_winograd_nhwc_auto_scheduler_test,
+    zero_rank_reduce_auto_scheduler_test,
 )
 
 
@@ -252,6 +253,12 @@ def test_cpu_conv2d_winograd_sketch():
     assert sketches[1] != sketches[2]
 
 
+def test_cpu_zero_rank_sketch():
+    sketches = generate_sketches(zero_rank_reduce_auto_scheduler_test, (128,), "llvm")
+    """ 2 rfactor sketches + 1 multi-level tiling sketches """
+    assert len(sketches) == 3
+
+
 @tvm.testing.requires_cuda
 def test_cuda_matmul_sketch():
     sketches = generate_sketches(matmul_auto_scheduler_test, (512, 512, 512), "cuda")
@@ -385,6 +392,13 @@ def test_cuda_conv2d_winograd_sketch():
     assert_is_not_tiled(sketches[0].stages[12])
 
 
+@tvm.testing.requires_cuda
+def test_cuda_zero_rank_sketch():
+    sketches = generate_sketches(zero_rank_reduce_auto_scheduler_test, (128,), "cuda")
+    """ 1 cross thread reuction sketch + 1 multi-level tiling sketch """
+    assert len(sketches) == 2
+
+
 if __name__ == "__main__":
     test_cpu_matmul_sketch()
     test_cpu_conv2d_bn_relu_sketch()
@@ -392,9 +406,11 @@ if __name__ == "__main__":
     test_cpu_min_sketch()
     test_cpu_softmax_sketch()
     test_cpu_conv2d_winograd_sketch()
+    test_cpu_zero_rank_sketch()
     test_cuda_matmul_sketch()
     test_cuda_conv2d_bn_relu_sketch()
     test_cuda_max_pool2d_sketch()
     test_cuda_min_sketch()
     test_cuda_softmax_sketch()
     test_cuda_conv2d_winograd_sketch()
+    test_cuda_zero_rank_sketch()


### PR DESCRIPTION
- Fix auto-scheduler to handle output with zero rank.  Related workload and errors: https://discuss.tvm.apache.org/t/autoscheduler-and-vm/8750/18
- Keep the target population of `SampleInitPopualtion` across multiple rounds of search. So we can reuse the target value from previous search round instead of wasting time on reducing it from a large value every round.