### PR TITLE
[Fix] fix multibox_transform race condition

### DIFF
--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -344,11 +344,22 @@ def transform_loc_ir(
         out_base_idx = i * num_anchors * 6 + tid * 6
         out_loc[out_base_idx] = cls_id[tid] - 1.0
         out_loc[out_base_idx + 1] = score[tid]
-        out_loc[out_base_idx + 2], out_loc[out_base_idx + 3], out_loc[out_base_idx + 4], \
-            out_loc[out_base_idx + 5] = transform_loc(loc_pred, tid * 4,
-                                                      anchor, j * 4, clip, variances[0],
-                                                      variances[1], variances[2],
-                                                      variances[3])
+        (
+            out_loc[out_base_idx + 2],
+            out_loc[out_base_idx + 3],
+            out_loc[out_base_idx + 4],
+            out_loc[out_base_idx + 5],
+        ) = transform_loc(
+            loc_pred,
+            tid * 4,
+            anchor,
+            j * 4,
+            clip,
+            variances[0],
+            variances[1],
+            variances[2],
+            variances[3],
+        )
 
     return ib.get()
 

--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -341,47 +341,14 @@ def transform_loc_ir(
         i = idxd(tid, num_anchors)
         j = idxm(tid, num_anchors)
 
-        with ib.if_scope(cls_id[tid] > 0):
-            with ib.if_scope(tid == 0):
-                out_base_idx = i * num_anchors * 6
-                out_loc[out_base_idx] = cls_id[tid] - 1.0
-                out_loc[out_base_idx + 1] = score[tid]
-                (
-                    out_loc[out_base_idx + 2],
-                    out_loc[out_base_idx + 3],
-                    out_loc[out_base_idx + 4],
-                    out_loc[out_base_idx + 5],
-                ) = transform_loc(
-                    loc_pred,
-                    tid * 4,
-                    anchor,
-                    j * 4,
-                    clip,
-                    variances[0],
-                    variances[1],
-                    variances[2],
-                    variances[3],
-                )
-            with ib.else_scope():
-                out_base_idx = i * num_anchors * 6 + temp_valid_count[tid - 1] * 6
-                out_loc[out_base_idx] = cls_id[tid] - 1.0
-                out_loc[out_base_idx + 1] = score[tid]
-                (
-                    out_loc[out_base_idx + 2],
-                    out_loc[out_base_idx + 3],
-                    out_loc[out_base_idx + 4],
-                    out_loc[out_base_idx + 5],
-                ) = transform_loc(
-                    loc_pred,
-                    tid * 4,
-                    anchor,
-                    j * 4,
-                    clip,
-                    variances[0],
-                    variances[1],
-                    variances[2],
-                    variances[3],
-                )
+        out_base_idx = i * num_anchors * 6 + tid * 6
+        out_loc[out_base_idx] = cls_id[tid] - 1.0
+        out_loc[out_base_idx + 1] = score[tid]
+        out_loc[out_base_idx + 2], out_loc[out_base_idx + 3], out_loc[out_base_idx + 4], \
+            out_loc[out_base_idx + 5] = transform_loc(loc_pred, tid * 4,
+                                                      anchor, j * 4, clip, variances[0],
+                                                      variances[1], variances[2],
+                                                      variances[3])
 
     return ib.get()
 

--- a/python/tvm/topi/vision/ssd/multibox.py
+++ b/python/tvm/topi/vision/ssd/multibox.py
@@ -238,7 +238,8 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
                 out_loc[i, valid_count[i], 4] = out_coord[2]
                 out_loc[i, valid_count[i], 5] = out_coord[3]
                 valid_count[i] += 1
-
+        for j in range(valid_count[i], num_anchors):
+            out_loc[i, j, 0] = -1.0
     return out_loc, valid_count
 
 


### PR DESCRIPTION
This fix is proposed by @alec-anyvision, and this PR should solve the race condition mentioned here #6631.

In a very rare condition I have seen a couple of times that the outputs were inconsistent from time to time, this was unlikely to be caught as the memory is usually initialized as 0 and those are invalid boxes.

Usually I could reproduce it when `multibox_transform_loc` is called after some unrelated code/tests which could potentially used the same memory.

cc @Laurawly  @zhiics 