### PR TITLE
Makes sure g_last_error is null terminated.

### DIFF
--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -38,7 +38,10 @@
 
 static char g_last_error[1024];
 
-void TVMAPISetLastError(const char* msg) { strncpy(g_last_error, msg, sizeof(g_last_error)); }
+void TVMAPISetLastError(const char* msg) {
+  strncpy(g_last_error, msg, sizeof(g_last_error) - 1);
+  g_last_error[sizeof(g_last_error) - 1] = 0;
+}
 
 __attribute__((format(printf, 1, 2))) int TVMAPIErrorf(const char* msg, ...) {
   va_list args;


### PR DESCRIPTION
This addresses GCC 10 error:

```
"src/runtime/crt/common/crt_runtime_api.c"
include/tvm/runtime/c_runtime_api.h: 在函数‘TVMAPISetLastError’中:
src/runtime/crt/common/crt_runtime_api.c:42:3: 错误：‘strncpy’ specified
bound 1024 equals destination size [-Werror=stringop-truncation]
   42 |   strncpy(g_last_error, msg, sizeof(g_last_error));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1：所有的警告都被当作是错误
```

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
