### PR TITLE
[THRUST] Faster multi dimensional argsort by segmented sort

### DIFF
--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -813,11 +813,9 @@ def non_max_suppression(
     if (
         target
         and target.kind.name == "cuda"
-        and tvm.get_global_func("tvm.contrib.thrust.sort_nms", allow_missing=True)
+        and tvm.get_global_func("tvm.contrib.thrust.sort", allow_missing=True)
     ):
-        sort_tensor = argsort_thrust(
-            score_tensor, valid_count=None, axis=1, is_ascend=False, dtype=valid_count_dtype
-        )
+        sort_tensor = argsort_thrust(score_tensor, axis=1, is_ascend=False, dtype=valid_count_dtype)
     else:
         sort_tensor = argsort(score_tensor, axis=1, is_ascend=False, dtype=valid_count_dtype)
 

--- a/src/runtime/contrib/thrust/thrust.cu
+++ b/src/runtime/contrib/thrust/thrust.cu
@@ -22,7 +22,9 @@
  */
 
 #include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
 #include <thrust/sort.h>
+#include <thrust/gather.h>
 
 #include <tvm/runtime/registry.h>
 #include <dlpack/dlpack.h>
@@ -46,14 +48,13 @@ void thrust_sort(DLTensor* input,
   thrust::device_ptr<DataType> values_ptr(static_cast<DataType *>(out_values->data));
   thrust::device_ptr<IndicesType> indices_ptr(static_cast<IndicesType *>(out_indices->data));
 
-  int n_iter = 1;
-  for (int i = 0; i < input->ndim - 1; ++i) {
-    n_iter *= input->shape[i];
+  size_t size = 1;
+  for (int i = 0; i < input->ndim; ++i) {
+    size *= input->shape[i];
   }
+  thrust::copy(data_ptr, data_ptr + size, values_ptr);
 
-  thrust::copy(data_ptr, data_ptr + n_iter * n_values, values_ptr);
-
-  for (int i = 0 ; i < n_iter; ++i) {
+  if (input->ndim == 1 || (input->ndim == 2 && input->shape[0] == 1)) {
     thrust::sequence(indices_ptr, indices_ptr + n_values);
     if (is_ascend) {
       thrust::sort_by_key(values_ptr, values_ptr + n_values, indices_ptr);
@@ -61,8 +62,36 @@ void thrust_sort(DLTensor* input,
       thrust::sort_by_key(values_ptr, values_ptr + n_values, indices_ptr,
                           thrust::greater<DataType>());
     }
-    values_ptr += n_values;
-    indices_ptr += n_values;
+  } else {
+    // segmented sort by key
+    thrust::device_vector<int64_t> argsort_order(size);
+    thrust::sequence(argsort_order.begin(), argsort_order.begin() + size);
+
+    auto do_sort_by_key = [n_values, is_ascend](auto keys_ptr, auto values_ptr) {
+      if (is_ascend) {
+        thrust::stable_sort_by_key(keys_ptr, keys_ptr + n_values, values_ptr);
+      } else {
+        thrust::stable_sort_by_key(keys_ptr, keys_ptr + n_values, values_ptr,
+                                   thrust::greater<DataType>());
+      }
+    }; // NOLINT(*)
+
+    do_sort_by_key(values_ptr, argsort_order.begin());
+
+    auto counting_iter = thrust::counting_iterator<int64_t>(0);
+    auto linear_index_to_sort_axis_index = [n_values] __host__ __device__(int64_t i) {
+      return i % n_values;
+    }; // NOLINT(*)
+    auto init_indices_iter = thrust::make_transform_iterator(counting_iter, linear_index_to_sort_axis_index);
+    thrust::gather(argsort_order.begin(), argsort_order.end(), init_indices_iter, indices_ptr);
+
+    thrust::device_vector<int> segment_ids(size);
+    auto linear_index_to_segment_id = [n_values] __host__ __device__(int64_t i) {
+      return i / n_values;
+    }; // NOLINT(*)
+    thrust::transform(argsort_order.begin(), argsort_order.end(), segment_ids.begin(), linear_index_to_segment_id);
+
+    do_sort_by_key(segment_ids.begin(), thrust::make_zip_iterator(thrust::make_tuple(values_ptr, indices_ptr)));
   }
 }
 
@@ -73,57 +102,58 @@ void thrust_sort_common(DLTensor* input,
                         int sort_len,
                         std::string data_dtype,
                         std::string out_dtype) {
-  if (data_dtype == "float32") {
-    if (out_dtype == "int32") {
-      thrust_sort<float, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "int64") {
-      thrust_sort<float, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float32") {
-      thrust_sort<float, float>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float64") {
-      thrust_sort<float, double>(input, values_out, indices_out, is_ascend, sort_len);
-    } else {
-      LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
-    }
-  } else if (data_dtype == "float64") {
-    if (out_dtype == "int32") {
-      thrust_sort<double, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "int64") {
-      thrust_sort<double, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float32") {
-      thrust_sort<double, float>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float64") {
-      thrust_sort<double, double>(input, values_out, indices_out, is_ascend, sort_len);
-    } else {
-      LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
-    }
-  } else if (data_dtype == "int32") {
-    if (out_dtype == "int32") {
-      thrust_sort<int32_t, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "int64") {
-      thrust_sort<int32_t, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float32") {
-      thrust_sort<int32_t, float>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float64") {
-      thrust_sort<int32_t, double>(input, values_out, indices_out, is_ascend, sort_len);
-    } else {
-      LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
-    }
-  }  else if (data_dtype == "int64") {
-    if (out_dtype == "int32") {
-      thrust_sort<int64_t, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "int64") {
-      thrust_sort<int64_t, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float32") {
-      thrust_sort<int64_t, float>(input, values_out, indices_out, is_ascend, sort_len);
-    } else if (out_dtype == "float64") {
-      thrust_sort<int64_t, double>(input, values_out, indices_out, is_ascend, sort_len);
-    } else {
-      LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
-    }
-  } else {
-    LOG(FATAL) << "Unsupported input dtype: " << data_dtype;
-  }
+  thrust_sort<float, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
+  // if (data_dtype == "float32") {
+  //   if (out_dtype == "int32") {
+
+  //   } else if (out_dtype == "int64") {
+  //     thrust_sort<float, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float32") {
+  //     thrust_sort<float, float>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float64") {
+  //     thrust_sort<float, double>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else {
+  //     LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
+  //   }
+  // } else if (data_dtype == "float64") {
+  //   if (out_dtype == "int32") {
+  //     thrust_sort<double, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "int64") {
+  //     thrust_sort<double, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float32") {
+  //     thrust_sort<double, float>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float64") {
+  //     thrust_sort<double, double>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else {
+  //     LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
+  //   }
+  // } else if (data_dtype == "int32") {
+  //   if (out_dtype == "int32") {
+  //     thrust_sort<int32_t, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "int64") {
+  //     thrust_sort<int32_t, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float32") {
+  //     thrust_sort<int32_t, float>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float64") {
+  //     thrust_sort<int32_t, double>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else {
+  //     LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
+  //   }
+  // }  else if (data_dtype == "int64") {
+  //   if (out_dtype == "int32") {
+  //     thrust_sort<int64_t, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "int64") {
+  //     thrust_sort<int64_t, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float32") {
+  //     thrust_sort<int64_t, float>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else if (out_dtype == "float64") {
+  //     thrust_sort<int64_t, double>(input, values_out, indices_out, is_ascend, sort_len);
+  //   } else {
+  //     LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
+  //   }
+  // } else {
+  //   LOG(FATAL) << "Unsupported input dtype: " << data_dtype;
+  // }
 }
 
 TVM_REGISTER_GLOBAL("tvm.contrib.thrust.sort")

--- a/src/runtime/contrib/thrust/thrust.cu
+++ b/src/runtime/contrib/thrust/thrust.cu
@@ -54,7 +54,8 @@ void thrust_sort(DLTensor* input,
   }
   thrust::copy(data_ptr, data_ptr + size, values_ptr);
 
-  if (input->ndim == 1 || (input->ndim == 2 && input->shape[0] == 1)) {
+  if (size == static_cast<size_t>(input->shape[input->ndim - 1])) {
+    // A fast path for single segment case
     thrust::sequence(indices_ptr, indices_ptr + n_values);
     if (is_ascend) {
       thrust::sort_by_key(values_ptr, values_ptr + n_values, indices_ptr);

--- a/src/runtime/contrib/thrust/thrust.cu
+++ b/src/runtime/contrib/thrust/thrust.cu
@@ -41,12 +41,11 @@ void thrust_sort(DLTensor* input,
                  DLTensor* out_values,
                  DLTensor* out_indices,
                  bool is_ascend,
-                 const std::function<int(int)> &get_sort_len) {
+                 int n_values) {
   thrust::device_ptr<DataType> data_ptr(static_cast<DataType *>(input->data));
   thrust::device_ptr<DataType> values_ptr(static_cast<DataType *>(out_values->data));
   thrust::device_ptr<IndicesType> indices_ptr(static_cast<IndicesType *>(out_indices->data));
 
-  int n_values = input->shape[input->ndim - 1];
   int n_iter = 1;
   for (int i = 0; i < input->ndim - 1; ++i) {
     n_iter *= input->shape[i];
@@ -55,7 +54,6 @@ void thrust_sort(DLTensor* input,
   thrust::copy(data_ptr, data_ptr + n_iter * n_values, values_ptr);
 
   for (int i = 0 ; i < n_iter; ++i) {
-    n_values = get_sort_len(i);
     thrust::sequence(indices_ptr, indices_ptr + n_values);
     if (is_ascend) {
       thrust::sort_by_key(values_ptr, values_ptr + n_values, indices_ptr);
@@ -72,54 +70,54 @@ void thrust_sort_common(DLTensor* input,
                         DLTensor* values_out,
                         DLTensor* indices_out,
                         bool is_ascend,
-                        const std::function<int(int)> &get_sort_len,
+                        int sort_len,
                         std::string data_dtype,
                         std::string out_dtype) {
   if (data_dtype == "float32") {
     if (out_dtype == "int32") {
-      thrust_sort<float, int32_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<float, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "int64") {
-      thrust_sort<float, int64_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<float, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float32") {
-      thrust_sort<float, float>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<float, float>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float64") {
-      thrust_sort<float, double>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<float, double>(input, values_out, indices_out, is_ascend, sort_len);
     } else {
       LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
     }
   } else if (data_dtype == "float64") {
     if (out_dtype == "int32") {
-      thrust_sort<double, int32_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<double, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "int64") {
-      thrust_sort<double, int64_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<double, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float32") {
-      thrust_sort<double, float>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<double, float>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float64") {
-      thrust_sort<double, double>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<double, double>(input, values_out, indices_out, is_ascend, sort_len);
     } else {
       LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
     }
   } else if (data_dtype == "int32") {
     if (out_dtype == "int32") {
-      thrust_sort<int32_t, int32_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int32_t, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "int64") {
-      thrust_sort<int32_t, int64_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int32_t, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float32") {
-      thrust_sort<int32_t, float>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int32_t, float>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float64") {
-      thrust_sort<int32_t, double>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int32_t, double>(input, values_out, indices_out, is_ascend, sort_len);
     } else {
       LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
     }
   }  else if (data_dtype == "int64") {
     if (out_dtype == "int32") {
-      thrust_sort<int64_t, int32_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int64_t, int32_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "int64") {
-      thrust_sort<int64_t, int64_t>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int64_t, int64_t>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float32") {
-      thrust_sort<int64_t, float>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int64_t, float>(input, values_out, indices_out, is_ascend, sort_len);
     } else if (out_dtype == "float64") {
-      thrust_sort<int64_t, double>(input, values_out, indices_out, is_ascend, get_sort_len);
+      thrust_sort<int64_t, double>(input, values_out, indices_out, is_ascend, sort_len);
     } else {
       LOG(FATAL) << "Unsupported output dtype: " << out_dtype;
     }
@@ -127,25 +125,6 @@ void thrust_sort_common(DLTensor* input,
     LOG(FATAL) << "Unsupported input dtype: " << data_dtype;
   }
 }
-
-TVM_REGISTER_GLOBAL("tvm.contrib.thrust.sort_nms")
-.set_body([](TVMArgs args, TVMRetValue* ret) {
-  ICHECK_GE(args.num_args, 5);
-  DLTensor* input = args[0];
-  DLTensor* valid_count = args[1];
-  DLTensor* values_out = args[2];
-  DLTensor* indices_out = args[3];
-  bool is_ascend = args[4];
-
-  auto data_dtype = DLDataType2String(input->dtype);
-  auto out_dtype = DLDataType2String(indices_out->dtype);
-
-  thrust::device_ptr<int> valid_count_ptr(static_cast<int *>(valid_count->data));
-  auto get_sort_len = [&valid_count_ptr](int i) { return valid_count_ptr[i]; };
-  thrust_sort_common(input, values_out, indices_out, is_ascend, get_sort_len,
-                     data_dtype, out_dtype);
-});
-
 
 TVM_REGISTER_GLOBAL("tvm.contrib.thrust.sort")
 .set_body([](TVMArgs args, TVMRetValue* ret) {
@@ -159,8 +138,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.thrust.sort")
   auto out_dtype = DLDataType2String(indices_out->dtype);
 
   int n_values = input->shape[input->ndim - 1];
-  auto get_sort_len = [=](int i) { return n_values; };
-  thrust_sort_common(input, values_out, indices_out, is_ascend, get_sort_len,
+  thrust_sort_common(input, values_out, indices_out, is_ascend, n_values,
                      data_dtype, out_dtype);
 });
 


### PR DESCRIPTION
Current implementation of thrust argsort, when given multi dimensional inputs to sort along the inner most axis, is very inefficient: it does `n_iter` calls to thrust sort. See

https://github.com/apache/tvm/blob/bad149ed8a555444d813537608ee5cea9e95e97e/src/runtime/contrib/thrust/thrust.cu#L50-L65

When the outer dimension is large, the performance of thrust argsort is far from optimal. In particular, the thrust numbers shown in the TIR mergesort PR https://github.com/apache/tvm/pull/7099 do not reflect the true performance thrust can achieve. 

This PR replaces `n_iter` calls to thrust argsort with one **segmented sort by key**. Since thrust doesn't provide API to do segmented sort, I used a neat back-to-back stable-sort-by-key trick explained in https://groups.google.com/forum/#!topic/thrust-users/BoLsxO6b4FY. My implementation is a bit more complicated because we need to do segmented sort **by key**, not just segmented sort. 

Here are the numbers I get using the same benchmark script used in https://github.com/apache/tvm/pull/7099, measured on GTX 1070 ti. When the outer dimension is small (like 2, 2, 2000 case), my change makes it slower due to the overhead from two calls to `stable_sort_by_key`. But other than that, it is much faster than one we have now.

Also, I removed `tvm.contrib.thrust.sort_nms` and `argsort_nms_thrust`, since they are not used anymore.

please review @kazum @Laurawly 
(cc @mbrookhart when you are back, this should be exciting for you!) 

| Shape         | current thrust | after this PR | TIR mergesort  |
|---------------|---------|--------|-------|
| (2000, 2, 2)  | 0.17    | 0.29   | 1.63  |
| (2, 2000, 2)  | 0.17    | 0.31   | 1.62  |
| (2, 2, 2000)  | 0.16    | 0.30   | 1.62  |
| (4000, 2, 2)  | 0.18   | 0.30  | 3.80  |
| (2, 4000, 2)  | 0.18   | 0.30   | 3.24  |
| (2, 2, 4000)  | 0.17    | 0.30   | 3.92  |
| (2, 12000, 2) | 0.52  | 0.59  | 12.96 |
| (2, 2, 12000) | 0.57   | 0.58   | 11.40 |
| (12000, 2, 2) | 0.63  | 0.59   | 11.77 |
| (2000, 8, 8)  | 2.55  | 0.90   | 4.08 |
| (8, 2000, 8)  | 2.43  | 0.81   | 3.56  |
| (8, 8, 2000)  | 2.47   | 0.88   | 3.02  |
| (4000, 8, 8)  | 2.55  | 1.43   | 9.37  |
| (8, 4000, 8)  | 2.54  | 1.42   | 9.68 |
| (8, 8, 4000)  | 2.53  | 1.41   | 6.14  |
| (12000, 8, 8) | 14.72 | 3.32  | 39.37 |
| (8, 12000, 8) | 13.79 | 3.24  | 40.27 |
| (8, 8, 12000) | 13.29 | 3.19  | 25.87 |
