### PR TITLE
[VM] Per-input, data dependence specification for shape func

### DIFF
--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -85,7 +85,7 @@ using TNonComputational = bool;
 /*!
  * \brief Mark the operator whether output shape is data dependant.
  */
-using TShapeDataDependant = bool;
+using TShapeDataDependant = Array<Integer>;
 
 /*!
  * \brief Computation description interface.

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -83,9 +83,9 @@ using TOpIsStateful = bool;
 using TNonComputational = bool;
 
 /*!
- * \brief Mark the operator whether output shape is data dependant.
+ * \brief Mark the operator whether output shape is data dependent.
  */
-using TShapeDataDependant = Array<Integer>;
+using TShapeDataDependent = Array<Integer>;
 
 /*!
  * \brief Computation description interface.

--- a/python/tvm/relay/op/dyn/_transform.py
+++ b/python/tvm/relay/op/dyn/_transform.py
@@ -32,11 +32,8 @@ _reg.register_injective_schedule("dyn.sparse_to_dense")
 
 
 @script
-def _reshape_shape_func_input_data(data, newshape, ndim):
+def _reshape_shape_func_input_data(data_shape, newshape, ndim):
     out = output_tensor((ndim,), "int64")
-    data_shape = allocate((len(data.shape),), "int64")
-    for x in const_range(len(data.shape)):
-        data_shape[x] = int64(data.shape[x])
     src_idx = 0
     dst_idx = 0
     infer_idx = -1
@@ -87,7 +84,7 @@ def _reshape_shape_func_input_data(data, newshape, ndim):
     return out
 
 
-@_reg.register_shape_func("dyn.reshape", True)
+@_reg.register_shape_func("dyn.reshape", [False, True])
 def dynamic_reshape_shape_func(attrs, inputs, out_ndims):
     return [_reshape_shape_func_input_data(*inputs, out_ndims[0])]
 

--- a/python/tvm/relay/op/dyn/_transform.py
+++ b/python/tvm/relay/op/dyn/_transform.py
@@ -150,36 +150,36 @@ def one_hot_shape_func(attrs, inputs, _):
 
 
 @script
-def _strided_slice_shape_func_input_data(data, begin, end, strides, slice_mode):
-    ndim = len(data.shape)
+def _strided_slice_shape_func_input_data(data_shape, begin, end, strides, slice_mode):
+    ndim = len(data_shape)
     out = output_tensor((ndim,), "int64")
     for i in const_range(ndim):
         cbegin = int64(0)
-        cend = int64(data.shape[i])
+        cend = int64(data_shape[i])
         cstride = int64(1)
         if strides.shape[0] > i:
             cstride = int64(strides[i])
         if begin.shape[0] > i:
             cbegin = int64(begin[i])
             if cbegin < 0:
-                cbegin += int64(data.shape[i])
+                cbegin += int64(data_shape[i])
         if end.shape[0] <= i:
-            cend = int64(data.shape[i])
+            cend = int64(data_shape[i])
         elif slice_mode != 0:
             cstride = int64(1)
             if end[i] < 0:
-                cend = int64(data.shape[i])
+                cend = int64(data_shape[i])
             else:
                 cend = cbegin + int64(end[i])
         else:
-            if end[i] > data.shape[i]:
-                cend = int64(data.shape[i])
-            elif end[i] < -data.shape[i]:
+            if end[i] > data_shape[i]:
+                cend = int64(data_shape[i])
+            elif end[i] < -data_shape[i]:
                 cend = int64(-1)
             else:
                 cend = int64(end[i])
                 if cend < 0:
-                    cend += int64(data.shape[i])
+                    cend += int64(data_shape[i])
         assert cstride != 0, "Strides can't be zero."
         if cstride < 0:
             slice_range = cbegin - cend
@@ -192,7 +192,7 @@ def _strided_slice_shape_func_input_data(data, begin, end, strides, slice_mode):
     return out
 
 
-@_reg.register_shape_func("dyn.strided_slice", True)
+@_reg.register_shape_func("dyn.strided_slice", [False, True, True, True])
 def strided_slice_shape_func(attrs, inputs, _):
     """
     Shape func for strided_slice

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -374,7 +374,7 @@ def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
     level : int
         The priority level
     """
-    get(op_name).set_attr("TShapeDataDependant", data_dependant, level)
+    get(op_name).set_attr("TShapeDataDependant", [int(data_dependant)], level)
     return tvm.ir.register_op_attr(op_name, "FShapeFunc", shape_func, level)
 
 

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -365,7 +365,9 @@ def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
         The name of the op.
 
     data_dependant : bool or list of bool
-        Whether the shape function depends on input data.
+        Whether the shape function depends on input data. If this is a list of bool,
+        the length of the list must be the same as the number of arguments of this op.
+        The list specifies per-input data dependence of the op.
 
     shape_func : function (attrs: Attrs, inputs: List[Tensor], out_ndims: List[IndexExpr])
                  -> shape_tensors: List<Tensor>

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -364,7 +364,7 @@ def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
     op_name : str
         The name of the op.
 
-    data_dependant : bool
+    data_dependant : bool or list of bool
         Whether the shape function depends on input data.
 
     shape_func : function (attrs: Attrs, inputs: List[Tensor], out_ndims: List[IndexExpr])

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -374,7 +374,9 @@ def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
     level : int
         The priority level
     """
-    get(op_name).set_attr("TShapeDataDependant", [int(data_dependant)], level)
+    if not isinstance(data_dependant, list):
+        data_dependant = [data_dependant]
+    get(op_name).set_attr("TShapeDataDependant", data_dependant, level)
     return tvm.ir.register_op_attr(op_name, "FShapeFunc", shape_func, level)
 
 

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -356,7 +356,7 @@ def register_gradient(op_name, fgradient=None, level=10):
     return tvm.ir.register_op_attr(op_name, "FPrimalGradient", fgradient, level)
 
 
-def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
+def register_shape_func(op_name, data_dependent, shape_func=None, level=10):
     """Register operator shape function for an op.
 
     Parameters
@@ -364,7 +364,7 @@ def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
     op_name : str
         The name of the op.
 
-    data_dependant : bool or list of bool
+    data_dependent : bool or list of bool
         Whether the shape function depends on input data. If this is a list of bool,
         the length of the list must be the same as the number of arguments of this op.
         The list specifies per-input data dependence of the op.
@@ -376,9 +376,9 @@ def register_shape_func(op_name, data_dependant, shape_func=None, level=10):
     level : int
         The priority level
     """
-    if not isinstance(data_dependant, list):
-        data_dependant = [data_dependant]
-    get(op_name).set_attr("TShapeDataDependant", data_dependant, level)
+    if not isinstance(data_dependent, list):
+        data_dependent = [data_dependent]
+    get(op_name).set_attr("TShapeDataDependent", data_dependent, level)
     return tvm.ir.register_op_attr(op_name, "FShapeFunc", shape_func, level)
 
 

--- a/python/tvm/relay/transform/memory_alloc.py
+++ b/python/tvm/relay/transform/memory_alloc.py
@@ -204,7 +204,11 @@ class ManifestAllocPass(ExprMutator):
         is_inputs = []
         input_pos = 0
         cpu_ctx = nd.cpu(0)
+
+        print(func)
+
         for i, (arg, state) in enumerate(zip(new_args, input_states)):
+            print(i, state)
             state = int(state)
             # Pass Shapes
             if state == 2:

--- a/python/tvm/relay/transform/memory_alloc.py
+++ b/python/tvm/relay/transform/memory_alloc.py
@@ -204,7 +204,6 @@ class ManifestAllocPass(ExprMutator):
         is_inputs = []
         input_pos = 0
         cpu_ctx = nd.cpu(0)
-
         for i, (arg, state) in enumerate(zip(new_args, input_states)):
             state = int(state)
             # Pass Shapes

--- a/python/tvm/relay/transform/memory_alloc.py
+++ b/python/tvm/relay/transform/memory_alloc.py
@@ -205,10 +205,7 @@ class ManifestAllocPass(ExprMutator):
         input_pos = 0
         cpu_ctx = nd.cpu(0)
 
-        print(func)
-
         for i, (arg, state) in enumerate(zip(new_args, input_states)):
-            print(i, state)
             state = int(state)
             # Pass Shapes
             if state == 2:

--- a/src/relay/analysis/util.cc
+++ b/src/relay/analysis/util.cc
@@ -490,7 +490,7 @@ bool IsDataDependant(const CallNode* call) {
     }
   }
 
-  for (auto req: tshape_data_dependant[op]) {
+  for (auto req : tshape_data_dependant[op]) {
     if (req->value != 0) return true;
   }
   return false;

--- a/src/relay/analysis/util.cc
+++ b/src/relay/analysis/util.cc
@@ -490,8 +490,10 @@ bool IsDataDependant(const CallNode* call) {
     }
   }
 
-  Array<Integer> reqs = tshape_data_dependant[op];
-  return reqs[0]->value != 0;
+  for (auto req: tshape_data_dependant[op]) {
+    if (req->value != 0) return true;
+  }
+  return false;
 }
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/analysis/util.cc
+++ b/src/relay/analysis/util.cc
@@ -490,7 +490,8 @@ bool IsDataDependant(const CallNode* call) {
     }
   }
 
-  return tshape_data_dependant[op];
+  Array<Integer> reqs = tshape_data_dependant[op];
+  return reqs[0]->value != 0;
 }
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/analysis/util.cc
+++ b/src/relay/analysis/util.cc
@@ -473,24 +473,24 @@ bool IsDynamic(const Type& ty) {
 
 TVM_REGISTER_GLOBAL("relay.ir.IsDynamic").set_body_typed(IsDynamic);
 
-bool IsDataDependant(const CallNode* call) {
-  static auto tshape_data_dependant = Op::GetAttrMap<TShapeDataDependant>("TShapeDataDependant");
+bool IsDataDependent(const CallNode* call) {
+  static auto tshape_data_dependent = Op::GetAttrMap<TShapeDataDependent>("TShapeDataDependent");
   Op op = Downcast<Op>(call->op);
 
-  if (!tshape_data_dependant.count(op)) {
+  if (!tshape_data_dependent.count(op)) {
     return false;
   }
 
   if (op->name == "strided_slice") {
     if (const auto* attrs = call->attrs.as<StridedSliceAttrs>()) {
       if (attrs->begin && attrs->end && attrs->strides) {
-        // not data dependant if begin, end and strides exist
+        // not data dependent if begin, end and strides exist
         return false;
       }
     }
   }
 
-  for (auto req : tshape_data_dependant[op]) {
+  for (auto req : tshape_data_dependent[op]) {
     if (req->value != 0) return true;
   }
   return false;

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -440,10 +440,8 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
       ICHECK(data_dependants_.size());
       auto dep_spec = data_dependants_per_input_.back();
       auto index = param_to_index_[var];
-      LOG(INFO) << dep_spec.size() << ", " << index;
       ICHECK(dep_spec.size() > index);
-      // bool data_dependant = dep_spec[index];
-      bool data_dependant = data_dependants_.back();
+      bool data_dependant = dep_spec[index];
       if (data_dependant) {
         param_states_[var] |= kNeedInputData;
         return param_data_[var];

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -527,13 +527,12 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
     Array<Integer> dep_spec = tshape_data_dependant[op];
     if (dep_spec.size() == 1 && call_node->args.size() > 1) {
       for (size_t i = 1; i < call_node->args.size(); ++i) {
-	dep_spec.push_back(dep_spec[0]);
+        dep_spec.push_back(dep_spec[0]);
       }
     } else {
       ICHECK_EQ(dep_spec.size(), call_node->args.size());
     }
     data_dependants_per_input_.push_back(dep_spec);
-    LOG(INFO) << op->name << ", " << dep_spec;
 
     // Visit all inputs
     Array<te::Tensor> inputs;

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -336,7 +336,7 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
   MakeShapeFunc() {}
 
   std::pair<te::Schedule, CachedFunc> Create(const Function& prim_func) {
-    for (auto param: prim_func->params) {
+    for (auto param : prim_func->params) {
       param_states_[param] = kNoNeed;
       Array<tvm::te::Tensor> data_inputs;
       Array<tvm::te::Tensor> shape_inputs;
@@ -524,8 +524,6 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
       for (size_t i = 1; i < call_node->args.size(); ++i) {
         dep_spec.push_back(dep_spec[0]);
       }
-    } else {
-      // ICHECK_EQ(dep_spec.size(), call_node->args.size());
     }
 
     // Visit all inputs
@@ -607,8 +605,9 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
   std::unordered_map<Expr, Array<te::Tensor>, ObjectPtrHash, ObjectPtrEqual> param_data_;
   /*! \brief Map from parameter to list of shape placeholder */
   std::unordered_map<Expr, Array<te::Tensor>, ObjectPtrHash, ObjectPtrEqual> param_shapes_;
-  /*! \brief Stack of data dependencies for shape function */
+  /*! \brief Stack of data dependencies for shape function, specified per op */
   std::vector<bool> data_dependants_;
+  /*! \brief Stack of data dependencies for shape function, specified per each op input */
   std::vector<bool> data_dependants_per_input_;
   /*! \brief Scalars used in the shape function */
   Array<te::Tensor> scalars_;

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -561,7 +561,6 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
     // Call shape function
     auto outputs = fshape_func[op](call_node->attrs, inputs, out_ndims);
     data_dependants_.pop_back();
-    data_dependants_per_input_.pop_back();
     readable_name_stream_ << "_" << op->name;
     return outputs;
   }

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -520,7 +520,7 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
     data_dependents_.push_back(IsDataDependent(call_node));
 
     Array<Integer> dep_spec = tshape_data_dependent[op];
-    if (dep_spec.size() == 1 && call_node->args.size() > 1) {
+    if (dep_spec.size() == 1) {
       for (size_t i = 1; i < call_node->args.size(); ++i) {
         dep_spec.push_back(dep_spec[0]);
       }

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -241,7 +241,7 @@ class IndexedForwardGraph::Creator : private ExprVisitor {
     OpPatternKind op_pattern = kOpaque;
     if (const OpNode* opnode = call->op.as<OpNode>()) {
       auto op = GetRef<Op>(opnode);
-      if (IsDynamic(call->checked_type()) && IsDataDependant(call)) {
+      if (IsDynamic(call->checked_type()) && IsDataDependent(call)) {
         // output of a shape func can't be fed to a data-dependent shape func
         op_pattern = kOpaque;
       } else {

--- a/src/relay/transforms/pass_utils.h
+++ b/src/relay/transforms/pass_utils.h
@@ -90,11 +90,11 @@ Expr TypeSubst(const Expr& expr, const tvm::Map<TypeVar, Type>& subst_map);
 bool IsDynamic(const Type& ty);
 
 /*!
- * \brief Check if call is data dependant.
+ * \brief Check if call is data dependent.
  * \param call The call to be checked.
- * \return Whether the call is data dependant.
+ * \return Whether the call is data dependent.
  */
-bool IsDataDependant(const CallNode* call);
+bool IsDataDependent(const CallNode* call);
 
 /*!
  * \brief Make arbitrary transformation preserve the out most function.

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -105,7 +105,9 @@ TEST(Relay, BuildModule) {
   }
   auto fgeneric = GenericFunc::Get("test.strategy_generic").set_default(*fs);
   (*reg)("add", "FTVMStrategy", fgeneric, 10);
-  (*reg)("add", "TShapeDataDependant", {0}, 10);
+  Array<Integer> dep;
+  dep.push_back(0);
+  (*reg)("add", "TShapeDataDependant", dep, 10);
   // build
   auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");
   tvm::runtime::Module build_mod = (*pfb)();

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -107,7 +107,7 @@ TEST(Relay, BuildModule) {
   (*reg)("add", "FTVMStrategy", fgeneric, 10);
   Array<Integer> dep;
   dep.push_back(0);
-  (*reg)("add", "TShapeDataDependant", dep, 10);
+  (*reg)("add", "TShapeDataDependent", dep, 10);
   // build
   auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");
   tvm::runtime::Module build_mod = (*pfb)();

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -105,7 +105,7 @@ TEST(Relay, BuildModule) {
   }
   auto fgeneric = GenericFunc::Get("test.strategy_generic").set_default(*fs);
   (*reg)("add", "FTVMStrategy", fgeneric, 10);
-  (*reg)("add", "TShapeDataDependant", false, 10);
+  (*reg)("add", "TShapeDataDependant", {0}, 10);
   // build
   auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");
   tvm::runtime::Module build_mod = (*pfb)();


### PR DESCRIPTION
## Motivation
Currently, shape functions are executed on CPU, even if the model is running on GPU. Each shape function is declared with `data_dependent` flag, specifying whether or not the shape function needs the input tensors themselves or only the shapes of input tensors, to compute output shape:
https://github.com/apache/tvm/blob/9e766d9e6c0c999be0aa1dbfd890edb702472c93/python/tvm/relay/op/op.py#L359-L368

When an op's `data_dependent` is true, VM will do device to host memcpy of entire tensors before running that op's shape func on CPU. In particular, since `dyn.strided_slice` has `data_dependent` True, VM would do device to host memcpy of a to-be-sliced tensor for every `dyn.strided_sllice` invocation, which can be highly expensive if the tensor is big.
https://github.com/apache/tvm/blob/9e766d9e6c0c999be0aa1dbfd890edb702472c93/python/tvm/relay/op/dyn/_transform.py#L195

In fact, one of the bottlenecks of running PyTorch MaskRCNN on GPU is this repeated device to host memcpy, as shown in the profiler output below. Most of them is for `dyn.strided_slice` shape func. `CUDA memcpy HtoD` is also very slow, but this is necessary to send large parameters once to GPU.
```
==2531== Profiling application: python maskrcnn_test.py                                                                                                                      
==2531== Profiling result:                                                                                                                                                   
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name                                                                                            
 GPU activities:   16.59%  32.814ms        58  565.76us  30.112us  1.0854ms  fused_expand_dims_concatenate_1_kernel0                                                         
                    9.37%  18.524ms       475  38.998us     544ns  5.3433ms  [CUDA memcpy HtoD]                                                                              
                    9.09%  17.983ms         4  4.4957ms  4.4597ms  4.5401ms  fused_nn_conv2d_add_nn_relu_20_kernel0                                                          
                    8.77%  17.350ms         1  17.350ms  17.350ms  17.350ms  fused_nn_conv2d_transpose_add_nn_relu_kernel0                                                   
                    7.54%  14.912ms      2283  6.5310us     672ns  7.8311ms  [CUDA memcpy DtoH]                                                                              
                    4.33%  8.5701ms         1  8.5701ms  8.5701ms  8.5701ms  fused_nn_conv2d_add_5_kernel0                                                                   
                    4.27%  8.4386ms         1  8.4386ms  8.4386ms  8.4386ms  fused_nn_conv2d_add_nn_relu_16_kernel0 
                    2.68%  5.3057ms         2  2.6528ms  399.20us  4.9065ms  sgemm_128x128x8_NT_vec                      
```

But if we think about it, these expensive copyings are completely useless: shape func of `dyn.strided_slice` only needs data shape. But since other arguments `begin, end, strides` require their tensor values, `dyn.strided_slice` needs to declare its `data_dependant` flag to be True. This issue can be resolved if we let each op declare its data dependence per input.

## Proposed solution
Luckily, decisions to insert device-to-host memcpy before shape func is already done per each input separately, as shown below: 
https://github.com/apache/tvm/blob/4c4888bc19ff17d0de8de57b2c6876ffbf6f0fde/python/tvm/relay/transform/memory_alloc.py#L207-L221

So all we need to do is to have a way to specify per-input data dependence for each op, and send these information to `ManifestAllocPass` above. This PR enables such specification like this:

```
@_reg.register_shape_func("dyn.strided_slice", [False, True, True, True])
```

I've also updated `compile_engine.cc` accordingly to send per-input data dep information to `ManifestAllocPass`. The change I made is minimum necessary to achieve my goal, so it can be improved. With this PR, I was able to remove all expensive device-to-host memcpy, and it cuts GPU MaskRCNN runtime by 14 millisecond. More importantly, the purpose of this PR is to let people aware of this problem, and decide the best solution.

please review @icemelon9 @zhiics @kevinthesun @mbrookhart 