### PR TITLE
Reorder dynamic to static and simplify inference, lower DynamicToStatic Opt Level

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -278,10 +278,11 @@ class RelayBuildModule : public runtime::ModuleNode {
       pass_seqs.push_back(transform::Legalize());
     }
 
+    pass_seqs.push_back(transform::SimplifyInference());
+
     // Convert Dynamic ops to static versions
     pass_seqs.push_back(transform::DynamicToStatic());
 
-    pass_seqs.push_back(transform::SimplifyInference());
     PackedFunc fskip = PackedFunc([](TVMArgs args, TVMRetValue* rv) {
       Expr expr = args[0];
       *rv = false;

--- a/src/relay/transforms/dynamic_to_static.cc
+++ b/src/relay/transforms/dynamic_to_static.cc
@@ -260,7 +260,7 @@ Pass DynamicToStatic() {
       [=](Function f, IRModule m, PassContext pc) {
         return Downcast<Function>(DynamicToStatic(f, m));
       };
-  return CreateFunctionPass(pass_func, 1, "DynamicToStatic", {});
+  return CreateFunctionPass(pass_func, 2, "DynamicToStatic", {});
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.DynamicToStatic").set_body_typed([]() {

--- a/src/relay/transforms/dynamic_to_static.cc
+++ b/src/relay/transforms/dynamic_to_static.cc
@@ -260,7 +260,7 @@ Pass DynamicToStatic() {
       [=](Function f, IRModule m, PassContext pc) {
         return Downcast<Function>(DynamicToStatic(f, m));
       };
-  return CreateFunctionPass(pass_func, 3, "DynamicToStatic", {});
+  return CreateFunctionPass(pass_func, 1, "DynamicToStatic", {});
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.DynamicToStatic").set_body_typed([]() {

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -322,6 +322,16 @@ def test_dropout():
         yy = run_infer_type(y)
         assert yy.checked_type == input_ty
 
+    in_np = np.random.random([4,5,6]).astype("float32")
+    x = relay.const(in_np)
+    y = relay.nn.dropout(x, rate=0.5)
+    func = relay.Function([], y)
+    for target, ctx in tvm.testing.enabled_targets():
+        for backend in ["debug", "graph"]:
+            intrp = relay.create_executor("debug", ctx=ctx, target=target)
+            op_res = intrp.evaluate(func)()
+            tvm.testing.assert_allclose(op_res.asnumpy(), in_np, rtol=0.01)
+            
 
 def test_batch_norm():
     for dtype in ["float16", "float32"]:

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -322,7 +322,7 @@ def test_dropout():
         yy = run_infer_type(y)
         assert yy.checked_type == input_ty
 
-    in_np = np.random.random([4,5,6]).astype("float32")
+    in_np = np.random.random([4, 5, 6]).astype("float32")
     x = relay.const(in_np)
     y = relay.nn.dropout(x, rate=0.5)
     func = relay.Function([], y)
@@ -331,7 +331,7 @@ def test_dropout():
             intrp = relay.create_executor("debug", ctx=ctx, target=target)
             op_res = intrp.evaluate(func)()
             tvm.testing.assert_allclose(op_res.asnumpy(), in_np, rtol=0.01)
-            
+
 
 def test_batch_norm():
     for dtype in ["float16", "float32"]:


### PR DESCRIPTION
Add a dropout unit test.

Fixes #7201 and #7200 

cc @tqchen @merrymercy @luyaor

Thanks for reporting the issues, @luyaor