### PR TITLE
[TIR][REFACTOR] Enforce allocate to use the correct var pointer hint.

### DIFF
--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -1241,7 +1241,7 @@ inline void DivAmbiguityError(const TA& a) {
                 "please call div, indexdiv/indexmod, "
                 "floordiv/floormod or truncdiv/truncmod directly "
                 "to avoid ambiguity in the code. "
-                "Checkout these functions in expr_operator.h.");
+                "Checkout these functions in tir/op.h.");
 }
 
 // The following code are not intended to be used in the codebase.

--- a/python/tvm/script/scope_handler.py
+++ b/python/tvm/script/scope_handler.py
@@ -35,7 +35,7 @@ class ScopeHandler:
     def signature(self):
         return "tir." + self.func.__name__, get_param_list(self.func)
 
-    def enter_scope(self, node, context):
+    def enter_scope(self, node, context, arg_list, span):
         pass
 
     def exit_scope(self, node, context, arg_list, span):
@@ -86,7 +86,7 @@ class Allocate(WithScopeHandler):
         super().__init__(allocate, concise_scope=True, def_symbol=True)
         self.buffer_var = None
 
-    def enter_scope(self, node, context):
+    def enter_scope(self, node, context, arg_list, span):
         # define buffer vars in symbol table
         if isinstance(node, ast.With):
             names = WithScopeHandler.get_optional_var_names(node, context)
@@ -98,7 +98,12 @@ class Allocate(WithScopeHandler):
         else:
             raise Exception("Internal Bug")
 
-        self.buffer_var = tvm.te.var(name, "handle", span=from_synr_span(node.lhs.id.span))
+        def setup_buffer_var(extents, dtype, scope, condition=True, span=None):
+            """Setup buffer var for a given type."""
+            buffer_ptr_type = tvm.ir.PointerType(tvm.ir.PrimType(dtype))
+            self.buffer_var = tvm.tir.Var(name, buffer_ptr_type, span)
+
+        setup_buffer_var(*arg_list, span=from_synr_span(node.lhs.id.span))
         context.update_symbol(name, self.buffer_var)
 
 
@@ -187,7 +192,7 @@ class ForScopeHandler(ScopeHandler):
         super().__init__(func)
         self.loop_vars = None
 
-    def enter_scope(self, node, context):
+    def enter_scope(self, node, context, arg_list, span):
         assert isinstance(node, ast.For)
 
         loop_var_names = list()

--- a/python/tvm/tir/buffer.py
+++ b/python/tvm/tir/buffer.py
@@ -247,9 +247,10 @@ def decl_buffer(
         shape_dtype = shape[0].dtype if hasattr(shape[0], "dtype") else "int32"
         elem_offset = Var("%s_elem_offset" % name, shape_dtype)
     if data is None:
-        # store bool as i8
-        storage_dtype = "int8" if dtype == "bool" else dtype
-        data = Var(name, PointerType(PrimType(storage_dtype)), span)
+        # Bool is represented as uint1 in the IR, but stored as int8
+        storage_type = PrimType(dtype)
+        storage_type = PrimType("int8") if storage_type.dtype == "bool" else storage_type
+        data = Var(name, PointerType(storage_type), span)
     return _ffi_api.Buffer(
         data,
         dtype,

--- a/python/tvm/tir/buffer.py
+++ b/python/tvm/tir/buffer.py
@@ -247,7 +247,9 @@ def decl_buffer(
         shape_dtype = shape[0].dtype if hasattr(shape[0], "dtype") else "int32"
         elem_offset = Var("%s_elem_offset" % name, shape_dtype)
     if data is None:
-        data = Var(name, PointerType(PrimType(dtype)), span)
+        # store bool as i8
+        storage_dtype = "int8" if dtype == "bool" else dtype
+        data = Var(name, PointerType(PrimType(storage_dtype)), span)
     return _ffi_api.Buffer(
         data,
         dtype,

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -69,7 +69,8 @@ Target DefaultTargetHost(Target target) {
 
 tir::Buffer BufferWithOffsetAlignment(Array<PrimExpr> shape, DataType dtype, std::string name,
                                       int data_alignment, int offset_factor, bool compact) {
-  auto data = tir::Var(name, PointerType(PrimType(dtype)));
+  DataType storage_dtype = (dtype == DataType::Bool() ? DataType::Int(8) : dtype);
+  auto data = tir::Var(name, PointerType(PrimType(storage_dtype)));
   bool has_any = false;
   if (!compact) {
     for (const auto& it : shape) {

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -583,7 +583,8 @@ void CodeGenCUDA::VisitStmt_(const AllocateNode* op) {
   const VarNode* buffer = op->buffer_var.as<VarNode>();
   auto it = alloc_storage_scope_.find(buffer);
   ICHECK(it != alloc_storage_scope_.end())
-      << "Cannot find alloc storage scope for buffer " << op->buffer_var;
+      << "Buffer " << op->buffer_var << " is missing an AttrStmt with a \"storage_scope\" key";
+
   std::string scope = it->second;
   if (scope.find("wmma.") == 0) {
     if (scope == "wmma.matrix_a" || scope == "wmma.matrix_b") {

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -581,7 +581,10 @@ void CodeGenCUDA::VisitStmt_(const AllocateNode* op) {
   int32_t constant_size = op->constant_allocation_size();
   ICHECK_GT(constant_size, 0) << "Can only handle constant size stack allocation for now";
   const VarNode* buffer = op->buffer_var.as<VarNode>();
-  std::string scope = alloc_storage_scope_.at(buffer);
+  auto it = alloc_storage_scope_.find(buffer);
+  ICHECK(it != alloc_storage_scope_.end())
+      << "Cannot find alloc storage scope for buffer " << op->buffer_var;
+  std::string scope = it->second;
   if (scope.find("wmma.") == 0) {
     if (scope == "wmma.matrix_a" || scope == "wmma.matrix_b") {
       ICHECK(op->dtype == DataType::Float(16) || op->dtype == DataType::Int(8) ||

--- a/src/te/operation/cross_thread_reduction.cc
+++ b/src/te/operation/cross_thread_reduction.cc
@@ -145,7 +145,8 @@ Stmt MakeCrossThreadReduction(const ComputeOpNode* self, const Stage& stage,
     Array<PrimExpr> lhs;
     for (size_t i = 0; i < size; ++i) {
       DataType t = reduces[i]->dtype;
-      normal_res_handles.emplace_back("normal_reduce_temp" + std::to_string(i), DataType::Handle());
+      normal_res_handles.emplace_back("normal_reduce_temp" + std::to_string(i),
+                                      PointerType(PrimType(t)));
       lhs.push_back(Load(t, normal_res_handles[i], 0, const_true(t.lanes())));
     }
     Array<PrimExpr> init_value = combiner->identity_element;
@@ -175,7 +176,8 @@ Stmt MakeCrossThreadReduction(const ComputeOpNode* self, const Stage& stage,
   freduce_args.push_back(const_true(1));
   std::vector<Var> res_handles(size);
   for (size_t idx = 0; idx < size; ++idx) {
-    res_handles[idx] = Var("reduce_temp" + std::to_string(idx), DataType::Handle());
+    DataType dtype = reduces[idx]->dtype;
+    res_handles[idx] = Var("reduce_temp" + std::to_string(idx), PointerType(PrimType(dtype)));
     freduce_args.push_back(res_handles[idx]);
   }
 

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -274,9 +274,11 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 // Allocate
 Allocate::Allocate(Var buffer_var, DataType dtype, Array<PrimExpr> extents, PrimExpr condition,
                    Stmt body, Span span) {
-  ICHECK(IsPointerType(buffer_var->type_annotation, dtype))
-      << "Allocate: buffer_var expect to have the right pointer type annotation"
-      << " annotation=" << buffer_var->type_annotation << ", dtype=" << dtype;
+  CHECK(IsPointerType(buffer_var->type_annotation, dtype))
+      << "The allocated data type (" << dtype
+      << ") does not match the type annotation of the buffer " << buffer_var << " ("
+      << buffer_var->type_annotation
+      << "). The data type should be an element of the pointer type.";
 
   for (size_t i = 0; i < extents.size(); ++i) {
     ICHECK(extents[i].defined());

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -274,9 +274,10 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 // Allocate
 Allocate::Allocate(Var buffer_var, DataType dtype, Array<PrimExpr> extents, PrimExpr condition,
                    Stmt body, Span span) {
-  // TODO(tvm-team): Add invariant check to make sure
-  // IsPointerPType(buffer_var->type_annotation, dtype)
-  // once we fix the allocate tvm script printing.
+  ICHECK(IsPointerType(buffer_var->type_annotation, dtype))
+      << "Allocate: buffer_var expect to have the right pointer type annotation"
+      << " annotation=" << buffer_var->type_annotation << ", dtype=" << dtype;
+
   for (size_t i = 0; i < extents.size(); ++i) {
     ICHECK(extents[i].defined());
     ICHECK(extents[i].dtype().is_scalar());

--- a/src/tir/transforms/lower_custom_datatypes.cc
+++ b/src/tir/transforms/lower_custom_datatypes.cc
@@ -44,14 +44,14 @@ class CustomDatatypesLowerer : public StmtExprMutator {
  public:
   explicit CustomDatatypesLowerer(const std::string& target) : target_(target) {}
 
-  inline PrimExpr VisitExpr_(const CastNode* op) final {
+  PrimExpr VisitExpr_(const CastNode* op) final {
     auto type_code = op->dtype.code();
     auto src_type_code = op->value.dtype().code();
     // If either datatype is a registered custom datatype, we must lower.
-    bool toBeLowered = datatype::Registry::Global()->GetTypeRegistered(type_code) ||
-                       datatype::Registry::Global()->GetTypeRegistered(src_type_code);
+    bool to_be_lowered = datatype::Registry::Global()->GetTypeRegistered(type_code) ||
+                         datatype::Registry::Global()->GetTypeRegistered(src_type_code);
     PrimExpr expr = StmtExprMutator::VisitExpr_(op);
-    if (toBeLowered) {
+    if (to_be_lowered) {
       auto lower = datatype::GetCastLowerFunc(target_, type_code, src_type_code);
       ICHECK(lower) << "Cast lowering function for target " << target_ << " destination type "
                     << static_cast<unsigned>(type_code) << " source type "
@@ -61,7 +61,7 @@ class CustomDatatypesLowerer : public StmtExprMutator {
     return expr;
   }
 
-  inline PrimExpr VisitExpr_(const FloatImmNode* imm) final {
+  PrimExpr VisitExpr_(const FloatImmNode* imm) final {
     auto type_code = imm->dtype.code();
     auto e = GetRef<PrimExpr>(imm);
     if (datatype::Registry::Global()->GetTypeRegistered(type_code)) {
@@ -73,35 +73,86 @@ class CustomDatatypesLowerer : public StmtExprMutator {
     return e;
   }
 
-  inline Stmt VisitStmt_(const AllocateNode* allocate) final {
-    bool toBeLowered = datatype::Registry::Global()->GetTypeRegistered(allocate->dtype.code());
-    Stmt stmt = StmtExprMutator::VisitStmt_(allocate);
-    allocate = stmt.as<AllocateNode>();
+  PrimExpr VisitExpr_(const VarNode* op) final {
+    Var var = GetRef<Var>(op);
 
-    if (toBeLowered) {
-      auto new_allocate_type = DataType::UInt(allocate->dtype.bits(), allocate->dtype.lanes());
-      return Allocate(allocate->buffer_var, new_allocate_type, allocate->extents,
-                      allocate->condition, allocate->body);
+    auto itr = var_remap_.find(var);
+    if (itr != var_remap_.end()) {
+      return itr->second;
+    } else {
+      return std::move(var);
     }
-    return stmt;
   }
 
-  inline PrimExpr VisitExpr_(const LoadNode* load) final {
-    bool toBeLowered = datatype::Registry::Global()->GetTypeRegistered(load->dtype.code());
+  Stmt VisitStmt_(const AllocateNode* allocate) final {
+    bool to_be_lowered = datatype::Registry::Global()->GetTypeRegistered(allocate->dtype.code());
+
+    if (to_be_lowered) {
+      auto new_allocate_type = DataType::UInt(allocate->dtype.bits(), allocate->dtype.lanes());
+      auto new_buffer_var =
+          Var(allocate->buffer_var->name_hint, PointerType(PrimType(new_allocate_type)));
+      var_remap_[allocate->buffer_var] = new_buffer_var;
+
+      Stmt stmt = StmtExprMutator::VisitStmt_(allocate);
+      allocate = stmt.as<AllocateNode>();
+
+      return Allocate(new_buffer_var, new_allocate_type, allocate->extents, allocate->condition,
+                      allocate->body);
+    } else {
+      return StmtExprMutator::VisitStmt_(allocate);
+    }
+  }
+
+  PrimExpr VisitExpr_(const LoadNode* load) final {
+    bool to_be_lowered = datatype::Registry::Global()->GetTypeRegistered(load->dtype.code());
     PrimExpr expr = StmtExprMutator::VisitExpr_(load);
     load = expr.as<LoadNode>();
-    if (toBeLowered) {
+    if (to_be_lowered) {
       auto new_load_type = DataType::UInt(load->dtype.bits());
-      return Load(new_load_type, load->buffer_var, load->index, load->predicate);
+      auto buffer_var = load->buffer_var;
+      auto it = var_remap_.find(buffer_var);
+      if (it != var_remap_.end()) {
+        buffer_var = it->second;
+      }
+      return Load(new_load_type, buffer_var, load->index, load->predicate);
     }
     return expr;
   }
 
-  inline PrimExpr VisitExpr_(const CallNode* call) final {
-    bool toBeLowered = datatype::Registry::Global()->GetTypeRegistered(call->dtype.code());
+  Stmt VisitStmt_(const StoreNode* op) final {
+    Stmt ret = StmtExprMutator::VisitStmt_(op);
+    op = ret.as<StoreNode>();
+
+    auto it = var_remap_.find(op->buffer_var);
+    if (it != var_remap_.end()) {
+      return Store(it->second, op->value, op->index, op->predicate);
+    } else {
+      return ret;
+    }
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode* op) final {
+    Stmt ret = StmtExprMutator::VisitStmt_(op);
+    op = ret.as<AttrStmtNode>();
+    // Due to legacy reasons, some attr node can contain
+    // information(e.g. alignment) of buffer variables.
+    // remap these vars when needed
+    // TODO(tvm-team): remove the rewriting once the buffer var
+    // attrs are being refactored into the corresponding definition node
+    if (const auto* var_node = op->node.as<VarNode>()) {
+      auto it = var_remap_.find(GetRef<Var>(var_node));
+      if (it != var_remap_.end()) {
+        return AttrStmt(it->second, op->attr_key, op->value, op->body);
+      }
+    }
+    return ret;
+  }
+
+  PrimExpr VisitExpr_(const CallNode* call) final {
+    bool to_be_lowered = datatype::Registry::Global()->GetTypeRegistered(call->dtype.code());
     PrimExpr expr = StmtExprMutator::VisitExpr_(call);
     call = expr.as<CallNode>();
-    if (toBeLowered) {
+    if (to_be_lowered) {
       auto op = call->op.as<OpNode>();
       ICHECK(op != nullptr) << "Lowering non-intrinsic Calls not implemented";
       auto lower = datatype::GetIntrinLowerFunc(target_, op->name, call->dtype.code());
@@ -113,38 +164,42 @@ class CustomDatatypesLowerer : public StmtExprMutator {
     return expr;
   }
 
-#define DEFINE_MUTATE(OP, NodeName)                                                \
-  inline PrimExpr VisitExpr_(const NodeName* op) final {                           \
-    auto type_code = op->dtype.code();                                             \
-    bool toBeLowered = datatype::Registry::Global()->GetTypeRegistered(type_code); \
-    PrimExpr expr = StmtExprMutator::VisitExpr_(op);                               \
-    op = expr.as<NodeName>();                                                      \
-    if (toBeLowered) {                                                             \
-      auto lower = datatype::Get##OP##LowerFunc(target_, type_code);               \
-      ICHECK(lower) << #OP " lowering function for target " << target_ << " type " \
-                    << static_cast<unsigned>(type_code) << " not found";           \
-      return (*lower)(expr);                                                       \
-    }                                                                              \
-    return expr;                                                                   \
+#define TVM_DEFINE_MUTATE_CUSTOM_DTYPE(OP, NodeName)                                 \
+  PrimExpr VisitExpr_(const NodeName* op) final {                                    \
+    auto type_code = op->dtype.code();                                               \
+    bool to_be_lowered = datatype::Registry::Global()->GetTypeRegistered(type_code); \
+    PrimExpr expr = StmtExprMutator::VisitExpr_(op);                                 \
+    op = expr.as<NodeName>();                                                        \
+    if (to_be_lowered) {                                                             \
+      auto lower = datatype::Get##OP##LowerFunc(target_, type_code);                 \
+      ICHECK(lower) << #OP " lowering function for target " << target_ << " type "   \
+                    << static_cast<unsigned>(type_code) << " not found";             \
+      return (*lower)(expr);                                                         \
+    }                                                                                \
+    return expr;                                                                     \
   }
 
-  DEFINE_MUTATE(Add, AddNode);
-  DEFINE_MUTATE(Sub, SubNode);
-  DEFINE_MUTATE(Mul, MulNode);
-  DEFINE_MUTATE(Div, DivNode);
-  DEFINE_MUTATE(Mod, ModNode);
-  DEFINE_MUTATE(Min, MinNode);
-  DEFINE_MUTATE(Max, MaxNode);
-  DEFINE_MUTATE(EQ, EQNode);
-  DEFINE_MUTATE(NE, NENode);
-  DEFINE_MUTATE(LT, LTNode);
-  DEFINE_MUTATE(LE, LENode);
-  DEFINE_MUTATE(GT, GTNode);
-  DEFINE_MUTATE(GE, GENode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Add, AddNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Sub, SubNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Mul, MulNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Div, DivNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Mod, ModNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Min, MinNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(Max, MaxNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(EQ, EQNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(NE, NENode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(LT, LTNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(LE, LENode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(GT, GTNode);
+  TVM_DEFINE_MUTATE_CUSTOM_DTYPE(GE, GENode);
   // Later changes may need to add more mutate functions as we support workloads with more ops.
+
+#undef TVM_DEFINE_MUTATE_CUSTOM_DTYPE
 
  private:
   std::string target_;
+  // remap buffer vars
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectPtrEqual> var_remap_;
 };
 
 namespace transform {

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -114,8 +114,9 @@ TEST(IRF, StmtVisitor) {
   auto fmaketest = [&]() {
     auto z = x + 1;
     Stmt body = Evaluate(z);
-    Var buffer("b", DataType::Handle());
-    return Allocate(buffer, DataType::Float(32), {z, z}, const_true(), body);
+    DataType dtype = DataType::Float(32);
+    Var buffer("b", PointerType(PrimType(dtype)));
+    return Allocate(buffer, dtype, {z, z}, const_true(), body);
   };
   v(fmaketest());
   ICHECK_EQ(v.count, 3);
@@ -140,8 +141,9 @@ TEST(IRF, StmtMutator) {
   auto fmakealloc = [&]() {
     auto z = x + 1;
     Stmt body = Evaluate(z);
-    Var buffer("b", DataType::Handle());
-    return Allocate(buffer, DataType::Float(32), {1, z}, const_true(), body);
+    DataType dtype = DataType::Float(32);
+    Var buffer("b", PointerType(PrimType(dtype)));
+    return Allocate(buffer, dtype, {1, z}, const_true(), body);
   };
 
   auto fmakeif = [&]() {

--- a/tests/python/unittest/test_tir_constructor.py
+++ b/tests/python/unittest/test_tir_constructor.py
@@ -154,6 +154,7 @@ def test_stmt_constructor():
     assert x.index.value == 10
     assert x.value.value == 1
 
+    buffer_var = tvm.tir.Var("buf", tvm.ir.PointerType(tvm.ir.PrimType("float32")))
     x = tvm.tir.Allocate(buffer_var, "float32", [10], tvm.tir.const(1, "uint1"), nop)
     assert isinstance(x, tvm.tir.Allocate)
     assert x.dtype == "float32"


### PR DESCRIPTION
This is a refactoring step to cleanup legacy issue of opaque buffer
var without ptr type information. Now all the allocation comes with the right
pointer data type. Places touched:

- TVMScript Parser: add the right info to get the correct pointer type.
- Cross thread all reduce: set the right pointer type.
- Storage rewrite: setup the right pointer type.
- Custom dtype: remap the variables with new pointer type.

