### PR TITLE
[AutoScheduler][Relay] Control compile engine cache via PassContext

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -108,7 +108,6 @@ def extract_tasks(
         The weight (i.e. the number of appearance) of extracted tasks
     """
     # pylint: disable=import-outside-toplevel
-    from tvm import relay
 
     if isinstance(target, str):
         target = tvm.target.Target(target)
@@ -126,12 +125,6 @@ def extract_tasks(
         build_thread.start()
         build_thread.join()
 
-    # query the compile engine to get the number of occurrence of all tasks
-    engine = relay.backend.compile_engine.get()
-    use_count_dict = {}
-    for k, v in engine.items():
-        use_count_dict[k] = v.use_count
-
     # create search tasks
     tasks = []
     weights = []
@@ -148,9 +141,6 @@ def extract_tasks(
             )
         )
         weights.append(weight)
-
-    # clean the cached lowering results
-    engine.clear()
 
     return tasks, weights
 

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -280,7 +280,6 @@ def auto_schedule_topi(outs):
         An initial schdule in the tracing mode.
     """
     # pylint: disable=import-outside-toplevel
-    from tvm import relay
 
     io_tensors, has_layout_free, has_complex_op = traverse_to_get_io_tensors(outs)
     if not io_tensors:  # The compute includes dynamic shapes which are not supported yet.

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -701,7 +701,9 @@ class CompileEngineImpl : public CompileEngineNode {
     } else {
       value = CCacheValue(make_object<CCacheValueNode>());
       value->use_count = 0;
-      cache_[key] = value;
+      if (!backend::IsCompileEngineCacheDisabled()) {
+        cache_[key] = value;
+      }
     }
     cur_ccache_key_ = key;
 
@@ -832,6 +834,7 @@ CompileEngine& CompileEngine::Global() {
 }
 
 TVM_REGISTER_PASS_CONFIG_OPTION("relay.backend.use_auto_scheduler", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("relay.backend.disable_compile_engine_cache", Bool);
 
 TVM_REGISTER_GLOBAL("relay.backend._make_LoweredOutput")
     .set_body_typed([](tvm::Array<te::Tensor> outputs, OpImplementation impl) {

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -303,6 +303,15 @@ inline bool IsAutoSchedulerEnabled() {
       .value();
 }
 
+/*!
+ * \brief Return whether the compile engine cache is disabled in the pass context.
+ */
+inline bool IsCompileEngineCacheDisabled() {
+  return transform::PassContext::Current()
+      ->GetConfig<Bool>("relay.backend.disable_compile_engine_cache", Bool(false))
+      .value();
+}
+
 }  // namespace backend
 }  // namespace relay
 }  // namespace tvm


### PR DESCRIPTION
Use PassContext to disable the compile engine cache, so that we can maintain all required information (i.e., in the `TracingEnvironment`).

cc @merrymercy @jcf94 @zhiics @icemelon9 