### PR TITLE
Add MicroTVM support for the STM32F746 Discovery board

### DIFF
--- a/docs/microtvm/index.rst
+++ b/docs/microtvm/index.rst
@@ -42,6 +42,7 @@ flexible and portable to other processors such as RISC-V and does not require Ze
 demos run against QEMU and the following hardware:
 
 * `STM Nucleo-F746ZG <https://www.st.com/en/evaluation-tools/nucleo-f746zg.html>`_
+* `STM STM32F746 Discovery <https://www.st.com/en/evaluation-tools/32f746gdiscovery.html>`_
 * `nRF 5340 Preview Development Kit <https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-PDK>`_
 
 

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -352,6 +352,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
     # kwargs passed to usb.core.find to find attached boards for the openocd flash runner.
     BOARD_USB_FIND_KW = {
         "nucleo_f746zg": {"idVendor": 0x0483, "idProduct": 0x374B},
+        "stm32f746g_disco": {"idVendor": 0x0483, "idProduct": 0x374B},
     }
 
     def openocd_serial(self, cmake_entries):


### PR DESCRIPTION
This one line patch adds support for the ST STM32F746 Discovery board with µTVM.

Signed-off-by: Tom Gall <tom.gall@linaro.org>

