### PR TITLE
[FIX] Fix make format to work with arbitrary upstream names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ jvminstall:
 			-Dcflags="$(PKG_CFLAGS)" -Dldflags="$(PKG_LDFLAGS)" \
 			-Dcurrent_libdir="$(ROOTDIR)/$(OUTPUTDIR)" $(JVM_TEST_ARGS))
 format:
-	./tests/lint/git-clang-format.sh -i $$(git merge-base HEAD main@{$$(git config --get-regexp "remote.*.url" | grep apache | cut -d '.' -f 2)})
+	./tests/lint/git-clang-format.sh -i upstream/main
 	black .
 	cd rust; which cargo && cargo fmt --all; cd ..
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ jvminstall:
 			-Dcflags="$(PKG_CFLAGS)" -Dldflags="$(PKG_LDFLAGS)" \
 			-Dcurrent_libdir="$(ROOTDIR)/$(OUTPUTDIR)" $(JVM_TEST_ARGS))
 format:
-	./tests/lint/git-clang-format.sh -i origin/main
+	./tests/lint/git-clang-format.sh -i `git rev-parse --abbrev-ref main@{upstream}`
 	black .
 	cd rust; which cargo && cargo fmt --all; cd ..
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ jvminstall:
 			-Dcflags="$(PKG_CFLAGS)" -Dldflags="$(PKG_LDFLAGS)" \
 			-Dcurrent_libdir="$(ROOTDIR)/$(OUTPUTDIR)" $(JVM_TEST_ARGS))
 format:
-	./tests/lint/git-clang-format.sh -i `git rev-parse --abbrev-ref main@{upstream}`
+	./tests/lint/git-clang-format.sh -i $$(git merge-base HEAD main@{$$(git config --get-regexp "remote.*.url" | grep apache | cut -d '.' -f 2)})
 	black .
 	cd rust; which cargo && cargo fmt --all; cd ..
 

--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -45,7 +45,7 @@ function run_lint_step() {
                 # NOTE: need to run git status to update some docker-side cache. Otherwise,
                 # git-clang-format will fail with "The following files would be modified but have
                 # unstaged changes:"
-                cmd=( bash -c 'git status &>/dev/null && tests/lint/git-clang-format.sh -i origin/main' )
+                cmd=( bash -c 'git status &>/dev/null && tests/lint/git-clang-format.sh -i upstream/main' )
             fi
             ;;
         cpplint)
@@ -58,7 +58,7 @@ function run_lint_step() {
             if [ $inplace_fix -eq 0 ]; then
                 cmd=( tests/lint/python_format.sh )
             else
-                cmd=( tests/lint/git-black.sh -i origin/main )
+                cmd=( tests/lint/git-black.sh -i upstream/main )
             fi
             ;;
         jnilint)

--- a/tests/lint/clang_format.sh
+++ b/tests/lint/clang_format.sh
@@ -19,5 +19,5 @@
 
 # check lastest change, for squash merge into main
 ./tests/lint/git-clang-format.sh HEAD~1
-# chekc against origin/main for PRs.
-./tests/lint/git-clang-format.sh origin/main
+# check against upstream/main for PRs.
+./tests/lint/git-clang-format.sh upstream/main

--- a/tests/lint/python_format.sh
+++ b/tests/lint/python_format.sh
@@ -18,4 +18,4 @@
 
 
 ./tests/lint/git-black.sh HEAD~1
-./tests/lint/git-black.sh origin/main
+./tests/lint/git-black.sh upstream/main


### PR DESCRIPTION
make format hardcoded the upstream branch to origin/main. This patch changes it to ask git for the upstream branch.

@jroesch @tqchen 
