### PR TITLE
Revert "[AutoTVM-FIX] avoid unexpected value(1) of search space when get length for uninitiated search space"

### DIFF
--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -836,8 +836,6 @@ class ConfigSpace(object):
         return [Axis(None, i) for i in range(space_class.get_num_output(axes, policy, **kwargs))]
 
     def __len__(self):
-        if not self.space_map:
-            return 0
         if self._length is None:
             self._length = int(np.prod([len(x) for x in self.space_map.values()]))
         return self._length


### PR DESCRIPTION
Reverts apache/tvm#7175 because it broke the graph tuner.
see comments https://github.com/apache/tvm/pull/7175#issuecomment-757051844