### PR TITLE
[FIX,TUTORIALS] Import tvm.testing in tutorials that use it

### DIFF
--- a/tutorials/autotvm/tune_conv2d_cuda.py
+++ b/tutorials/autotvm/tune_conv2d_cuda.py
@@ -55,6 +55,7 @@ import numpy as np
 import tvm
 from tvm import te, topi, testing
 from tvm.topi.testing import conv2d_nchw_python
+import tvm.testing
 
 from tvm import autotvm
 

--- a/tutorials/autotvm/tune_simple_template.py
+++ b/tutorials/autotvm/tune_simple_template.py
@@ -59,7 +59,8 @@ import sys
 
 import numpy as np
 import tvm
-from tvm import te, testing
+from tvm import te
+import tvm.testing
 
 # the module is called `autotvm`
 from tvm import autotvm

--- a/tutorials/frontend/using_external_lib.py
+++ b/tutorials/frontend/using_external_lib.py
@@ -37,6 +37,7 @@ import numpy as np
 from tvm.contrib import graph_runtime as runtime
 from tvm import relay
 from tvm.relay import testing
+import tvm.testing
 
 ######################################################################
 # Create a simple network

--- a/tutorials/get_started/relay_quick_start.py
+++ b/tutorials/get_started/relay_quick_start.py
@@ -44,6 +44,7 @@ from tvm.relay import testing
 import tvm
 from tvm import te
 from tvm.contrib import graph_runtime
+import tvm.testing
 
 ######################################################################
 # Define Neural Network in Relay

--- a/tutorials/language/extern_op.py
+++ b/tutorials/language/extern_op.py
@@ -35,6 +35,7 @@ import tvm
 from tvm import te
 import numpy as np
 from tvm.contrib import cblas
+import tvm.testing
 
 if not tvm.get_global_func("tvm.contrib.cblas.matmul", allow_missing=True):
     raise Exception("Not compiled with cblas support; can't build this tutorial")

--- a/tutorials/language/tensorize.py
+++ b/tutorials/language/tensorize.py
@@ -36,6 +36,7 @@ from __future__ import absolute_import, print_function
 
 import tvm
 from tvm import te
+import tvm.testing
 import numpy as np
 
 ######################################################################

--- a/tutorials/optimize/opt_matmul_auto_tensorcore.py
+++ b/tutorials/optimize/opt_matmul_auto_tensorcore.py
@@ -50,6 +50,7 @@ from tvm import te
 
 from tvm import autotvm
 from tvm.contrib import nvcc
+import tvm.testing
 
 
 def matmul_nn(A, B, L, dtype="float16", layout="NN"):


### PR DESCRIPTION
Fixes the issue encountered here: https://discuss.tvm.apache.org/t/attributeerror-module-tvm-has-no-attribute-testing/8834