### PR TITLE
Remove check_correctness in AutoTVM, which is busted

### DIFF
--- a/tests/python/unittest/test_autotvm_measure.py
+++ b/tests/python/unittest/test_autotvm_measure.py
@@ -60,36 +60,8 @@ def test_task_tuner_without_measurement_spawn():
     p.join()
 
 
-def test_check_correctness():
-    task, target = get_sample_task()
-
-    measure_option = autotvm.measure_option(
-        builder=autotvm.LocalBuilder(), runner=autotvm.LocalRunner(check_correctness=True)
-    )
-
-    def _callback_correct(tuner, measure_inputs, measure_results):
-        for _, res in zip(measure_inputs, measure_results):
-            assert res.error_no == 0
-
-    tuner = autotvm.tuner.RandomTuner(task)
-    tuner.tune(n_trial=2, measure_option=measure_option, callbacks=[_callback_correct])
-
-    # a bad template
-    n = 128
-    target = tvm.target.Target("llvm -device=bad_device")
-    task = autotvm.task.create("testing/bad_matmul", args=(n, n, n, "float32"), target=target)
-
-    def _callback_wrong(tuner, measure_inputs, measure_results):
-        for _, res in zip(measure_inputs, measure_results):
-            assert res.error_no == MeasureErrorNo.WRONG_ANSWER
-
-    tuner = autotvm.tuner.RandomTuner(task)
-    tuner.tune(n_trial=2, measure_option=measure_option, callbacks=[_callback_wrong])
-
-
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
     test_task_tuner_without_measurement()
     test_task_tuner_without_measurement_spawn()
-    test_check_correctness()

--- a/vta/scripts/tune_conv2d.py
+++ b/vta/scripts/tune_conv2d.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
                 port=int(tracker_port),
                 number=5,
                 timeout=60,
-                check_correctness=True,
+                # check_correctness=True, # TODO: re-enable when check_correctness works again.
             ),
         )
 

--- a/vta/scripts/tune_conv2d_transpose.py
+++ b/vta/scripts/tune_conv2d_transpose.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
                 port=int(tracker_port),
                 number=5,
                 timeout=60,
-                check_correctness=True,
+                # check_correctness=True, # TODO: re-enable when check_correctness works again.
             ),
         )
 

--- a/vta/scripts/tune_dense.py
+++ b/vta/scripts/tune_dense.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
                 port=int(tracket_port),
                 number=5,
                 timeout=60,
-                check_correctness=True,
+                # check_correctness=True, # TODO: re-enable when check_correctness works again.
             ),
         )
 

--- a/vta/scripts/tune_group_conv2d.py
+++ b/vta/scripts/tune_group_conv2d.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
                 port=int(tracker_port),
                 number=5,
                 timeout=60,
-                check_correctness=True,
+                # check_correctness=True, # TODO: re-enable when check_correctness works again.
             ),
         )
 

--- a/vta/scripts/tune_resnet.py
+++ b/vta/scripts/tune_resnet.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
                 min_repeat_ms=150,
                 repeat=opt.measurements,
                 timeout=60,
-                check_correctness=True,
+                # check_correctness=True, # TODO: re-enable when check_correctness works again.
             ),
         ),
     }

--- a/vta/tests/python/integration/test_benchmark_gemm.py
+++ b/vta/tests/python/integration/test_benchmark_gemm.py
@@ -182,7 +182,7 @@ def test_gemm():
 
             def run_test(header, print_ir):
                 cost = run_schedule(
-                    mock.dma_copy, mock.dma_copy, env.gemm, mock.alu, mock.dma_copy, print_ir, False
+                    mock.dma_copy, mock.dma_copy, env.gemm, mock.alu, mock.dma_copy, print_ir
                 )
                 gops = (num_ops / cost.mean) / float(10 ** 9)
                 print(header)
@@ -197,7 +197,7 @@ def test_gemm():
 
             def run_test(header, print_ir):
                 cost = run_schedule(
-                    mock.dma_copy, mock.dma_copy, mock.gemm, env.alu, mock.dma_copy, print_ir, False
+                    mock.dma_copy, mock.dma_copy, mock.gemm, env.alu, mock.dma_copy, print_ir
                 )
                 gops = (num_ops / cost.mean) / float(10 ** 9)
                 print(header)
@@ -213,7 +213,7 @@ def test_gemm():
 
             def run_test(header, print_ir):
                 cost = run_schedule(
-                    env.dma_copy, mock.dma_copy, mock.gemm, mock.alu, mock.dma_copy, print_ir, False
+                    env.dma_copy, mock.dma_copy, mock.gemm, mock.alu, mock.dma_copy, print_ir
                 )
                 gops = (num_ops / cost.mean) / float(10 ** 9)
                 bandwith = (batch_size * channel * env.INP_WIDTH / cost.mean) / float(10 ** 9)
@@ -233,7 +233,7 @@ def test_gemm():
 
             def run_test(header, print_ir):
                 cost = run_schedule(
-                    mock.dma_copy, env.dma_copy, mock.gemm, mock.alu, mock.dma_copy, print_ir, False
+                    mock.dma_copy, env.dma_copy, mock.gemm, mock.alu, mock.dma_copy, print_ir
                 )
                 gops = (num_ops / cost.mean) / float(10 ** 9)
                 bandwith = (channel * channel * env.WGT_WIDTH / cost.mean) / float(10 ** 9)
@@ -253,7 +253,7 @@ def test_gemm():
 
             def run_test(header, print_ir):
                 cost = run_schedule(
-                    mock.dma_copy, mock.dma_copy, mock.gemm, mock.alu, env.dma_copy, print_ir, False
+                    mock.dma_copy, mock.dma_copy, mock.gemm, mock.alu, env.dma_copy, print_ir
                 )
                 gops = (num_ops / cost.mean) / float(10 ** 9)
                 bandwith = (batch_size * channel * env.OUT_WIDTH / cost.mean) / float(10 ** 9)

--- a/vta/tests/python/integration/test_benchmark_gemm.py
+++ b/vta/tests/python/integration/test_benchmark_gemm.py
@@ -59,7 +59,7 @@ def test_gemm():
         )  # relu
         res = te.compute(res_shape, lambda *i: res_min(*i).astype(env.inp_dtype), name="res")
 
-        def verify(s, check_correctness=True):
+        def verify(s):
             mod = vta.build(s, [data, weight, res], "ext_dev", env.target_host, name="gemm")
             temp = utils.tempdir()
             mod.save(temp.relpath("gemm.o"))
@@ -102,11 +102,9 @@ def test_gemm():
             res_unpack = res_arr.asnumpy().reshape(
                 batch_size // env.BATCH, channel // env.BLOCK_OUT, env.BATCH, env.BLOCK_OUT
             )
-            if check_correctness:
-                tvm.testing.assert_allclose(res_unpack, res_ref)
             return cost
 
-        def run_schedule(load_inp, load_wgt, gemm, alu, store_out, print_ir, check_correctness):
+        def run_schedule(load_inp, load_wgt, gemm, alu, store_out, print_ir):
             s = te.create_schedule(res.op)
             s[data_buf].set_scope(env.inp_scope)
             s[weight_buf].set_scope(env.wgt_scope)
@@ -156,13 +154,13 @@ def test_gemm():
 
             if print_ir:
                 print(tvm.lower(s, [data, weight, res], simple_mode=True))
-            return verify(s, check_correctness)
+            return verify(s)
 
         def gemm_normal(print_ir):
             mock = env.mock
             print("----- GEMM GOPS End-to-End Test-------")
 
-            def run_test(header, print_ir, check_correctness):
+            def run_test(header, print_ir):
                 cost = run_schedule(
                     env.dma_copy,
                     env.dma_copy,
@@ -170,14 +168,13 @@ def test_gemm():
                     env.alu,
                     env.dma_copy,
                     print_ir,
-                    check_correctness,
                 )
                 gops = (num_ops / cost.mean) / float(10 ** 9)
                 print(header)
                 print("\tTime cost = %g sec/op, %g GOPS" % (cost.mean, gops))
 
             with vta.build_config():
-                run_test("NORMAL", print_ir, True)
+                run_test("NORMAL", print_ir)
 
         def gemm_unittest(print_ir):
             mock = env.mock

--- a/vta/tutorials/autotvm/tune_relay_vta.py
+++ b/vta/tutorials/autotvm/tune_relay_vta.py
@@ -215,7 +215,7 @@ tuning_option = {
             port=tracker_port,
             number=5,
             timeout=60,
-            check_correctness=True,
+            # check_correctness=True, # TODO: re-enable when check_correctness works again.
         ),
     ),
 }


### PR DESCRIPTION
In porting up the µTVM AutoTVM code, seems that `check_correctness` assumes that each AutoTVM task is instantiated on the `llvm` builder with the same input shape as is used on the target. Even in tuning a conv2d for x86, I see conv2d_NCHWc used with AutoTVM trying different combinations of `C` and `c`. I don't think this approach is viable and from chatting with a few people it seems like it was a debug tool that might just be deprecated now. I propose we remove until we have something more dependable via AutoScheduling or AutoTIR.

@merrymercy @tqchen @jwfromm @junrushao1994 @tmoreau89 