### PR TITLE
[µTVM] Avoid listing links when probing serial ports

### DIFF
--- a/python/tvm/micro/transport/serial.py
+++ b/python/tvm/micro/transport/serial.py
@@ -67,7 +67,7 @@ class SerialTransport(Transport):
         if self._port_path is not None:
             port_path = self._port_path
         else:
-            ports = list(serial.tools.list_ports.grep(self._grep, include_links=True))
+            ports = list(serial.tools.list_ports.grep(self._grep))
             if len(ports) != 1:
                 raise SerialPortNotFoundError(
                     f"grep expression should find 1 serial port; found {ports!r}"


### PR DESCRIPTION
SerialTransport.open() probes automatically the device name based upon a
grep regex if a device name is not provided. The code expects to find only
a single device. Currently when it probes for the available serial ports it
includes in the list the device names that are also symbolic links.

Since _find_openocd_serial_port() always returns a serial number for a
given serial port (not the device name path) the available device names
are always probed when the openocd flash runner is used.

It's not uncommon that device drivers create symbolic links for certain
kinds of serial devices, specially those that provide a serial port plus
an additional endpoint to program the device attached, like a ST-Link
interface, etc.

As a consequence the current code fails to select the correct device name
when symbolic links exist and the openocd flash runner is used.

That commit changes the probe behavior to avoid listing symbolic links when
probing the device name for the target serial port.

Without that change the following error happens:

```
Traceback (most recent call last):
  File "./micro_tflite.py", line 255, in <module>
    with tvm.micro.Session(binary=micro_binary, flasher=flasher) as session:
  File "/home/gromero/git/tvm/python/tvm/micro/session.py ", line 127, in __enter__
    self.transport = TransportLogger(
  File "/home/gromero/git/tvm/python/tvm/micro/transport/base.py", line 79, in __enter__
    self.open()
  File "/home/gromero/git/tvm/python/tvm/micro/transport/base.py", line 207, in open
    self.child.open()
  File "/home/gromero/git/tvm/python/tvm/micro/transport/serial.py", line 72, in open
    raise SerialPortNotFoundError(
NameError: name 'SerialPortNotFoundError' is not defined

When ARM `STM32 STLink` is used by a board and the following device names are created:
```

```
gromero@gromero0:~/git/tvm$ ls -l /dev/{ttyACM0,stlinkv2-1_0}
lrwxrwxrwx 1 root root         7 Jan 12 16:10 /dev/stlinkv2-1_0 -> ttyACM0
crw-rw-rw- 1 root plugdev 166, 0 Jan 12 21:32 /dev/ttyACM0
```

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
