### PR TITLE
[µTVM] Add TVMPlatformGenerateRandom, a non-cryptographic random number generator.

### DIFF
--- a/include/tvm/runtime/crt/platform.h
+++ b/include/tvm/runtime/crt/platform.h
@@ -97,6 +97,25 @@ tvm_crt_error_t TVMPlatformTimerStart();
  */
 tvm_crt_error_t TVMPlatformTimerStop(double* elapsed_time_seconds);
 
+/*! \brief Fill a buffer with random data.
+ *
+ * Cryptographically-secure random data is NOT required. This function is intended for use
+ * cases such as filling autotuning input tensors and choosing the nonce used for microTVM RPC.
+ *
+ * This function does not need to be implemented for inference tasks. It is used only by
+ * AutoTVM and the RPC server. When not implemented, an internal weak-linked stub is provided.
+ *
+ * Please take care that across successive resets, this function returns different sequences of
+ * values. If e.g. the random number generator is seeded with the same value, it may make it
+ * difficult for a host to detect device resets during autotuning or host-driven inference.
+ *
+ * \param buffer Pointer to the 0th byte to write with random data. `num_bytes` of random data
+ * should be written here.
+ * \param num_bytes Number of bytes to write.
+ * \return kTvmErrorNoError if successful; a descriptive error code otherwise.
+ */
+tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/include/tvm/runtime/crt/rpc_common/session.h
+++ b/include/tvm/runtime/crt/rpc_common/session.h
@@ -78,9 +78,9 @@ class Session {
   /*! \brief An invalid nonce value that typically indicates an unknown nonce. */
   static constexpr const uint8_t kInvalidNonce = 0;
 
-  Session(uint8_t initial_session_nonce, Framer* framer, FrameBuffer* receive_buffer,
+  Session(Framer* framer, FrameBuffer* receive_buffer,
           MessageReceivedFunc message_received_func, void* message_received_func_context)
-      : local_nonce_{initial_session_nonce},
+      : local_nonce_{kInvalidNonce},
         session_id_{0},
         state_{State::kReset},
         receiver_{this},
@@ -99,9 +99,11 @@ class Session {
 
   /*!
    * \brief Send a session terminate message, usually done at startup to interrupt a hanging remote.
+   * \param initial_session_nonce Initial nonce that should be used on the first session start
+   *      message. Callers should ensure this is different across device resets.
    * \return kTvmErrorNoError on success, or an error code otherwise.
    */
-  tvm_crt_error_t Initialize();
+  tvm_crt_error_t Initialize(uint8_t initial_session_nonce);
 
   /*!
    * \brief Terminate any previously-established session.

--- a/include/tvm/runtime/crt/rpc_common/session.h
+++ b/include/tvm/runtime/crt/rpc_common/session.h
@@ -78,8 +78,8 @@ class Session {
   /*! \brief An invalid nonce value that typically indicates an unknown nonce. */
   static constexpr const uint8_t kInvalidNonce = 0;
 
-  Session(Framer* framer, FrameBuffer* receive_buffer,
-          MessageReceivedFunc message_received_func, void* message_received_func_context)
+  Session(Framer* framer, FrameBuffer* receive_buffer, MessageReceivedFunc message_received_func,
+          void* message_received_func_context)
       : local_nonce_{kInvalidNonce},
         session_id_{0},
         state_{State::kReset},

--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -509,3 +509,9 @@ release_and_return : {
 }
   return err;
 }
+
+// Default implementation, overridden by the platform runtime.
+__attribute__((weak))
+tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes){
+  return kTvmErrorFunctionCallNotImplemented;
+}

--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -511,7 +511,6 @@ release_and_return : {
 }
 
 // Default implementation, overridden by the platform runtime.
-__attribute__((weak))
-tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes){
+__attribute__((weak)) tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
   return kTvmErrorFunctionCallNotImplemented;
 }

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -95,7 +95,7 @@ tvm_crt_error_t TVMPlatformTimerStop(double* elapsed_time_seconds) {
   return kTvmErrorNoError;
 }
 
-static_assert(RAND_MAX >= (1 << 8));
+static_assert(RAND_MAX >= (1 << 8), "RAND_MAX is smaller than acceptable");
 unsigned int random_seed = 0;
 tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
   if (random_seed == 0) {

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -26,6 +26,7 @@
 #include <tvm/runtime/crt/logging.h>
 #include <tvm/runtime/crt/memory.h>
 #include <tvm/runtime/crt/utvm_rpc_server.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <chrono>
@@ -95,9 +96,13 @@ tvm_crt_error_t TVMPlatformTimerStop(double* elapsed_time_seconds) {
 }
 
 static_assert(RAND_MAX >= (1 << 8));
+unsigned int random_seed = 0;
 tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
+  if (random_seed == 0) {
+    random_seed = (unsigned int) time(NULL);
+  }
   for (size_t i = 0; i < num_bytes; ++i) {
-    int random = rand();
+    int random = rand_r(&random_seed);
     buffer[i] = (uint8_t)random;
   }
 

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -93,6 +93,16 @@ tvm_crt_error_t TVMPlatformTimerStop(double* elapsed_time_seconds) {
   g_utvm_timer_running = 0;
   return kTvmErrorNoError;
 }
+
+static_assert(RAND_MAX >= (1 << 8));
+tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
+  for (size_t i = 0; i < num_bytes; ++i) {
+    int random = rand();
+    buffer[i] = (uint8_t) random;
+  }
+
+  return kTvmErrorNoError;
+}
 }
 
 uint8_t memory[512 * 1024];

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -98,7 +98,7 @@ static_assert(RAND_MAX >= (1 << 8));
 tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
   for (size_t i = 0; i < num_bytes; ++i) {
     int random = rand();
-    buffer[i] = (uint8_t) random;
+    buffer[i] = (uint8_t)random;
   }
 
   return kTvmErrorNoError;

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -22,11 +22,11 @@
  * \brief main entry point for host subprocess-based CRT
  */
 #include <inttypes.h>
+#include <time.h>
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/crt/logging.h>
 #include <tvm/runtime/crt/memory.h>
 #include <tvm/runtime/crt/utvm_rpc_server.h>
-#include <time.h>
 #include <unistd.h>
 
 #include <chrono>
@@ -99,7 +99,7 @@ static_assert(RAND_MAX >= (1 << 8));
 unsigned int random_seed = 0;
 tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
   if (random_seed == 0) {
-    random_seed = (unsigned int) time(NULL);
+    random_seed = (unsigned int)time(NULL);
   }
   for (size_t i = 0; i < num_bytes; ++i) {
     int random = rand_r(&random_seed);

--- a/src/runtime/crt/utvm_rpc_common/session.cc
+++ b/src/runtime/crt/utvm_rpc_common/session.cc
@@ -95,7 +95,10 @@ tvm_crt_error_t Session::StartSession() {
   return to_return;
 }
 
-tvm_crt_error_t Session::Initialize() { return TerminateSession(); }
+tvm_crt_error_t Session::Initialize(uint8_t initial_session_nonce) {
+  local_nonce_ = initial_session_nonce;
+  return TerminateSession();
+}
 
 tvm_crt_error_t Session::TerminateSession() {
   SetSessionId(0, 0);

--- a/src/runtime/crt/utvm_rpc_server/rpc_server.cc
+++ b/src/runtime/crt/utvm_rpc_server/rpc_server.cc
@@ -123,7 +123,7 @@ class MicroRPCServer {
   void Initialize() {
     uint8_t initial_session_nonce = Session::kInvalidNonce;
     tvm_crt_error_t error =
-      TVMPlatformGenerateRandom(&initial_session_nonce, sizeof(initial_session_nonce));
+        TVMPlatformGenerateRandom(&initial_session_nonce, sizeof(initial_session_nonce));
     CHECK_EQ(kTvmErrorNoError, error, "generating random session id");
     CHECK_EQ(kTvmErrorNoError, session_.Initialize(initial_session_nonce), "rpc server init");
   }

--- a/src/runtime/crt/utvm_rpc_server/rpc_server.cc
+++ b/src/runtime/crt/utvm_rpc_server/rpc_server.cc
@@ -112,7 +112,7 @@ class MicroRPCServer {
                  utvm_rpc_channel_write_t write_func, void* write_func_ctx)
       : receive_buffer_{receive_storage, receive_storage_size_bytes},
         framer_{&send_stream_},
-        session_{0xa5, &framer_, &receive_buffer_, &HandleCompleteMessageCb, this},
+        session_{&framer_, &receive_buffer_, &HandleCompleteMessageCb, this},
         io_{&session_, &receive_buffer_},
         unframer_{session_.Receiver()},
         rpc_server_{&io_},
@@ -120,7 +120,13 @@ class MicroRPCServer {
 
   void* operator new(size_t count, void* ptr) { return ptr; }
 
-  void Initialize() { CHECK_EQ(kTvmErrorNoError, session_.Initialize(), "rpc server init"); }
+  void Initialize() {
+    uint8_t initial_session_nonce = Session::kInvalidNonce;
+    tvm_crt_error_t error =
+      TVMPlatformGenerateRandom(&initial_session_nonce, sizeof(initial_session_nonce));
+    CHECK_EQ(kTvmErrorNoError, error, "generating random session id");
+    CHECK_EQ(kTvmErrorNoError, session_.Initialize(initial_session_nonce), "rpc server init");
+  }
 
   /*! \brief Process one message from the receive buffer, if possible.
    *
@@ -242,7 +248,7 @@ void TVMLogf(const char* format, ...) {
   } else {
     tvm::runtime::micro_rpc::SerialWriteStream write_stream;
     tvm::runtime::micro_rpc::Framer framer{&write_stream};
-    tvm::runtime::micro_rpc::Session session{0xa5, &framer, nullptr, nullptr, nullptr};
+    tvm::runtime::micro_rpc::Session session{&framer, nullptr, nullptr, nullptr};
     tvm_crt_error_t err =
         session.SendMessage(tvm::runtime::micro_rpc::MessageType::kLog,
                             reinterpret_cast<uint8_t*>(log_buffer), num_bytes_logged);

--- a/src/runtime/micro/micro_session.cc
+++ b/src/runtime/micro/micro_session.cc
@@ -172,7 +172,7 @@ class MicroTransportChannel : public RPCChannel {
     // confusion.
     unsigned int seed = random_seed.load();
     if (seed == 0) {
-      seed = (unsigned int) time(NULL);
+      seed = (unsigned int)time(NULL);
     }
     uint8_t initial_nonce = 0;
     for (int i = 0; i < kNumRandRetries && initial_nonce == 0; ++i) {

--- a/tests/micro/qemu/test_zephyr.py
+++ b/tests/micro/qemu/test_zephyr.py
@@ -199,6 +199,4 @@ def test_relay(platform):
 
 
 if __name__ == "__main__":
-    import logging
-    logging.basicConfig(level=logging.DEBUG)
     sys.exit(pytest.main([os.path.dirname(__file__)] + sys.argv[1:]))

--- a/tests/micro/qemu/test_zephyr.py
+++ b/tests/micro/qemu/test_zephyr.py
@@ -199,4 +199,6 @@ def test_relay(platform):
 
 
 if __name__ == "__main__":
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
     sys.exit(pytest.main([os.path.dirname(__file__)] + sys.argv[1:]))

--- a/tests/micro/qemu/zephyr-runtime/prj.conf
+++ b/tests/micro/qemu/zephyr-runtime/prj.conf
@@ -29,3 +29,7 @@ CONFIG_FPU=y
 
 # For TVMPlatformAbort().
 CONFIG_REBOOT=y
+
+# For TVMPlatformGenerateRandom(). Remember, these values do not need to be truly random.
+CONFIG_TEST_RANDOM_GENERATOR=y
+CONFIG_TIMER_RANDOM_GENERATOR=y

--- a/tests/micro/qemu/zephyr-runtime/src/main.c
+++ b/tests/micro/qemu/zephyr-runtime/src/main.c
@@ -26,6 +26,7 @@
 #include <drivers/uart.h>
 #include <kernel.h>
 #include <power/reboot.h>
+#include <random/rand32.h>
 #include <stdio.h>
 #include <sys/printk.h>
 #include <sys/ring_buffer.h>
@@ -158,6 +159,25 @@ tvm_crt_error_t TVMPlatformTimerStop(double* elapsed_time_seconds) {
   }
 
   g_utvm_timer_running = 0;
+  return kTvmErrorNoError;
+}
+
+tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
+  while (num_bytes > 0) {
+    uint32_t random = sys_rand32_get();
+    if (num_bytes > sizeof(random)) {
+      *((uint32_t*) buffer) = random;
+      num_bytes -= sizeof(random);
+      buffer += sizeof(random);
+      continue;
+    }
+
+    for (int i = 0; i < num_bytes; ++i) {
+      buffer[i] = ((uint8_t*) &random)[i];
+    }
+    num_bytes = 0;
+  }
+
   return kTvmErrorNoError;
 }
 

--- a/tests/micro/qemu/zephyr-runtime/src/main.c
+++ b/tests/micro/qemu/zephyr-runtime/src/main.c
@@ -166,14 +166,14 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
   while (num_bytes > 0) {
     uint32_t random = sys_rand32_get();
     if (num_bytes > sizeof(random)) {
-      *((uint32_t*) buffer) = random;
+      *((uint32_t*)buffer) = random;
       num_bytes -= sizeof(random);
       buffer += sizeof(random);
       continue;
     }
 
     for (int i = 0; i < num_bytes; ++i) {
-      buffer[i] = ((uint8_t*) &random)[i];
+      buffer[i] = ((uint8_t*)&random)[i];
     }
     num_bytes = 0;
   }

--- a/tests/micro/qemu/zephyr-runtime/src/main.c
+++ b/tests/micro/qemu/zephyr-runtime/src/main.c
@@ -172,12 +172,11 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
     memcpy(&buffer[i * sizeof(random)], &random, sizeof(random));
   }
 
-  // Fill any leftover tail which is smaller than `random.
-  size_t full_blocks_end = num_full_blocks * sizeof(random);
-  size_t num_tail_bytes = num_bytes - full_blocks_end;
+  // Fill any leftover tail which is smaller than `random`.
+  size_t num_tail_bytes = num_bytes % sizeof(random);
   if (num_tail_bytes > 0) {
     random = sys_rand32_get();
-    memcpy(&buffer[full_blocks_end], &random, num_tail_bytes);
+    memcpy(&buffer[num_bytes - num_tail_bytes], &random, num_tail_bytes);
   }
 
   return kTvmErrorNoError;


### PR DESCRIPTION
 * This change is preparation to support autotuning in microTVM. It
   also cleans up a loose end in the microTVM RPC server
   implementation.
 * Randomness is needed in two places of the CRT:
    1. to initialize the Session nonce, which provides a more robust
       way to detect reboots and ensure that messages are not confused
       across them.
    2. to fill input tensors when timing AutoTVM operators (once
       AutoTVM support lands in the next PR).

 * This change adds TVMPlatformGenerateRandom, a platform function for
   generating non-cryptographic random data, to service those needs.
