### PR TITLE
[µTVM] Fix two warnings when deprecated forms are used

### DIFF
--- a/python/tvm/micro/compiler.py
+++ b/python/tvm/micro/compiler.py
@@ -96,7 +96,7 @@ class Compiler(metaclass=abc.ABCMeta):
             )
 
         target_str = next(iter(target_strs))
-        return tvm.target.create(target_str)
+        return tvm.target.Target(target_str)
 
     # Maps regexes identifying CPUs to the default toolchain prefix for that CPU.
     TOOLCHAIN_PREFIX_BY_CPU_REGEX = {

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -387,7 +387,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
             return flash_runner
 
         with open(cmake_entries["ZEPHYR_RUNNERS_YAML"]) as f:
-            doc = yaml.load(f)
+            doc = yaml.load(f, Loader=yaml.FullLoader)
         return doc["flash-runner"]
 
     def _get_device_args(self, cmake_entries):


### PR DESCRIPTION
Hi,

This patchset addresses the following two warnings on microTVM:

[0]
```
[...]
/home/gromero/git/tvm/python/tvm/micro/contrib/zephyr.py:391: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  doc = yaml.load(f)
[...]
```

[1]
```
[...]
/home/gromero/git/tvm/python/tvm/target/target.py:460: UserWarning: tvm.target.create() is being deprecated. Please use tvm.target.Target() instead
  warnings.warn("tvm.target.create() is being deprecated. Please use tvm.target.Target() instead")
[...]
```

Warning [0] is related to the deprecated form (no loader specified) of yaml.load(input), while the second one is related to the use of  deprecated tvm.target.create().

Both warnings appear  when running `micro_tflite.py`. The first one [0] when `TARGET = tvm.target.target.micro("stm32f746xx")` and the second one [1] when `TARGET = tvm.target.target.micro("host")`, which is the default target.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
