### PR TITLE
Remove autotvm measure reference to removed variable.

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -579,12 +579,6 @@ def run_through_rpc(
             costs.sort()
             costs = tuple(costs[1:-1])
 
-        # check correctness of output
-        if ref_output:
-            for expected, real in zip(ref_output, args):
-                if not np.allclose(expected, real.asnumpy(), rtol=1e-4):
-                    logger.warning("Wrong Answer!")
-                    errno = MeasureErrorNo.WRONG_ANSWER
     except TVMError as exc:
         msg = str(exc)
         if "Stack trace returned" in msg:


### PR DESCRIPTION
Recently in PR #7250, we removed the `check_correctness` option from measure methods since it's now broken in many cases. In doing so, it looks like we forgot to remove one reference to `ref_output`, which can cause errors during tuning.