### PR TITLE
[µTVM] Remove need for -mcpu=native

### DIFF
--- a/python/tvm/micro/compiler.py
+++ b/python/tvm/micro/compiler.py
@@ -106,6 +106,12 @@ class Compiler(metaclass=abc.ABCMeta):
     }
 
     def _autodetect_toolchain_prefix(self, target):
+        # Treat absence of -mcpu as if -mcpu=native is specified. The gcc shipped with OS X
+        # complains if -mcpu=native is given, so this approach allows model targets to avoid
+        # specifying this flag e.g. for tutorials.
+        if "mcpu" not in target.attrs:
+            return self.TOOLCHAIN_PREFIX_BY_CPU_REGEX["native"]
+
         matches = []
         for regex, prefix in self.TOOLCHAIN_PREFIX_BY_CPU_REGEX.items():
             if re.match(regex, target.attrs["mcpu"]):

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -232,7 +232,7 @@ def micro(model="unknown", options=None):
         Additional options
     """
     trans_table = {
-        "host": ["-mcpu=native"],
+        "host": [],
         "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
     }
     opts = _merge_opts(

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -347,7 +347,7 @@ def test_crt_link_params():
         mod, param_init = _make_mod_and_params(dtype)
         rand_input = _make_random_tensor(dtype, INPUT_SHAPE)
         main_func = mod["main"]
-        target = "c -mcpu=native --system-lib --runtime=c --link-params"
+        target = "c --system-lib --runtime=c --link-params"
         with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
             graph_json, lib, params = tvm.relay.build(mod, target, params=param_init)
             assert set(params.keys()) == {"p0", "p1"}  # NOTE: op folded


### PR DESCRIPTION
Fixes x86 builds on OS X (I.e. as done by `tests/python/unittest/test_crt.py`). We may need to revisit this compiler auto-select logic at some point as well, since `-mcpu` may not always be the best way to specify a target ISA. However, I'd like to ideally defer that past Project-level API from the [M2 roadmap](https://discuss.tvm.apache.org/t/tvm-microtvm-m2-roadmap/8821).