### PR TITLE
[PatternLang][Bugfix] Ensure CallNode attrs are not undefined before checking

### DIFF
--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -168,7 +168,11 @@ bool DFPatternMatcher::VisitDFPattern_(const AttrPatternNode* attr_pattern, cons
     // and replace the whole thing with a Visitor-based approach
     ReflectionVTable* reflection = ReflectionVTable::Global();
     auto attrs_node = const_cast<BaseAttrsNode*>(op->attrs.get());
-    auto attr_names = reflection->ListAttrNames(attrs_node);
+    // attrs may be undefined on non-op calls so we check first
+    std::vector<std::string> attr_names;
+    if (attrs_node) {
+      attr_names = reflection->ListAttrNames(attrs_node);
+    }
     for (auto kv : attributes) {
       std::string attr = kv.first;
       if (matches && std::find(attr_names.begin(), attr_names.end(), attr) != attr_names.end()) {

--- a/tests/python/relay/test_dataflow_pattern.py
+++ b/tests/python/relay/test_dataflow_pattern.py
@@ -389,6 +389,19 @@ def test_match_call_attr():
     y = relay.var("y")
     assert is_conv2d.match(relay.op.nn.conv2d(x, y))
 
+    # non-operator call
+    attr_dict = {"call_attr": "attr"}
+    call_has_attr = wildcard()(wildcard()).has_attr(attr_dict)
+    call_attr = tvm.ir.make_node("DictAttrs", **attr_dict)
+    a = relay.Var("a")
+    b = relay.Var("b")
+    assert call_has_attr.match(relay.Call(a, [b], attrs=call_attr))
+
+    # empty attrs should match anything
+    empty_attrs = tvm.ir.make_node("DictAttrs", **{})
+    call_has_empty_attrs = wildcard()(wildcard()).has_attr({})
+    assert call_has_empty_attrs.match(relay.Call(a, [b], attrs=empty_attrs))
+    assert call_has_empty_attrs.match(relay.Call(a, [b], attrs=call_attr))
 
 def test_no_match_call_attr():
     x = relay.var("x")
@@ -399,6 +412,21 @@ def test_no_match_call_attr():
 
     is_conv2d = is_op("nn.conv2d")(wildcard(), wildcard()).has_attr({"RandomAttr": "NCHW"})
     assert not is_conv2d.match(relay.op.nn.conv2d(x, y))
+
+    # non-operator calls
+    call_has_attr = wildcard()(wildcard()).has_attr({"call_attr": "attr"})
+    wrong_key = tvm.ir.make_node("DictAttrs", **{"wrong": "attr"})
+    wrong_value = tvm.ir.make_node("DictAttrs", **{"call_attr": "wrong"})
+    empty_attrs = tvm.ir.make_node("DictAttrs", **{})
+
+    a = relay.Var("a")
+    b = relay.Var("b")
+    # attrs left undefined
+    assert not call_has_attr.match(relay.Call(a, [b]))
+    # wrong attrs
+    assert not call_has_attr.match(relay.Call(a, [b], attrs=wrong_key))
+    assert not call_has_attr.match(relay.Call(a, [b], attrs=wrong_value))
+    assert not call_has_attr.match(relay.Call(a, [b], attrs=empty_attrs))
 
 
 def test_match_call_attr_dtype():

--- a/tests/python/relay/test_dataflow_pattern.py
+++ b/tests/python/relay/test_dataflow_pattern.py
@@ -403,6 +403,7 @@ def test_match_call_attr():
     assert call_has_empty_attrs.match(relay.Call(a, [b], attrs=empty_attrs))
     assert call_has_empty_attrs.match(relay.Call(a, [b], attrs=call_attr))
 
+
 def test_no_match_call_attr():
     x = relay.var("x")
     y = relay.var("y")


### PR DESCRIPTION
Currently, using a dataflow pattern to attempt to match attributes on a call node (for calls to ordinary Relay functions, _not_ operators) results in a segmentation fault due to attempting to access an `AttrsNode` that is not present. This PR checks if the attributes node exists first to prevent the segfault and adds unit tests for this case.

Please review @jroesch @mbrookhart 