### PR TITLE
[AutoScheduler] Fix layout rewrite for iterator with extent=1

### DIFF
--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -873,7 +873,14 @@ std::string GetNewLayout(const State& state, const int stage_id, const Stage& st
       ori_iter_name = new_axis_names[i];
     }
     if (placeholder_axis_names.count(ori_iter_name)) {
-      os << iter->range->extent << ori_iter_name;
+      PrimExpr extent;
+      if (iter->range.defined()) {
+        extent = iter->range->extent;
+      } else {
+        // This iter is simplified by InferBound, so it must have a length of one.
+        extent = 1;
+      }
+      os << extent << ori_iter_name;
       new_names.push_back(ori_iter_name);
     }
   }

--- a/tests/python/unittest/test_auto_scheduler_layout_rewrite.py
+++ b/tests/python/unittest/test_auto_scheduler_layout_rewrite.py
@@ -49,6 +49,21 @@ def test_apply_steps_with_layout_rewrite():
     assert bufs[1].shape[1] == 512
 
 
+def test_apply_steps_with_layout_rewrite_corner_case():
+    A, B, C = matmul_auto_scheduler_test(1, 1, 1)
+    dag = auto_scheduler.ComputeDAG([A, B, C])
+
+    s = dag.get_init_state()
+
+    s.compute_root(C)
+    i_j_fused = s.fuse(C, [s[C].iters[0], s[C].iters[1]])
+    s.parallel(C, i_j_fused)
+
+    _, bufs = dag.apply_steps_from_state(
+        s, layout_rewrite=auto_scheduler.LayoutRewriteOption.REWRITE_FOR_PRE_TRANSFORMED
+    )
+
+
 @tvm.testing.requires_llvm
 def test_correctness_layout_rewrite_rewrite_for_preTransformed():
     N = 128
@@ -169,5 +184,6 @@ def test_correctness_layout_rewrite_insert_transform_stage():
 
 if __name__ == "__main__":
     test_apply_steps_with_layout_rewrite()
+    test_apply_steps_with_layout_rewrite_corner_case()
     test_correctness_layout_rewrite_rewrite_for_preTransformed()
     test_correctness_layout_rewrite_insert_transform_stage()


### PR DESCRIPTION
This is a bug in the layout rewrite. When the extent of an iterator is one, it will be simplified and we will get segment fault when we access `iter->extent`. This PR adds a check to handle this case.