### PR TITLE
[AutoScheduler] Fix typos in feature extraction and cost model

### DIFF
--- a/python/tvm/auto_scheduler/cost_model/cost_model.py
+++ b/python/tvm/auto_scheduler/cost_model/cost_model.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-""" Cost model that estimates the performance of programs """
+""" Cost models that estimate the performance of programs """
 import ctypes
 import numpy as np
 
@@ -31,7 +31,7 @@ class CostModel(Object):
 
 @tvm._ffi.register_object("auto_scheduler.RandomModel")
 class RandomModel(CostModel):
-    """A model returns random estimation for all inputs"""
+    """A model that returns random estimation for all inputs"""
 
     def __init__(self):
         self.__init_handle_by_constructor__(_ffi_api.RandomModel)

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -86,6 +86,21 @@ class XGBModel(PythonBasedModel):
     of several samples, so we implemented a custom loss function and call it pack-sum-rmse.
     It is called "pack-sum" because we combine several samples into a "pack" and sum up
     their predictions.
+
+    Parameters
+    ----------
+    verbose_eval: int = 25
+        Print training log every `verbose_eval` iterations.
+    num_warmup_sample: int = 100
+        The minimum number of samples to start to use the trained model.
+        If the number of samples is less than this number, the model outputs random predictions.
+    seed: Optional[int]
+        The random seed
+    model_file: Optional[str]
+        If is not None, save model to this file after every update.
+    adapative_training: bool = False
+        Whether to use adapatie training, which reduces the training frequency when there are
+        too many logs.
     """
 
     def __init__(

--- a/python/tvm/auto_scheduler/feature.py
+++ b/python/tvm/auto_scheduler/feature.py
@@ -80,7 +80,7 @@ def unpack_feature(byte_arr: bytearray) -> Tuple[np.ndarray, np.ndarray, np.ndar
       ... // until i == n - 1
 
       float throughputs[sizes[n]];  // The normalized throughputs for n records
-      int   task_ids[size[n+1];   // The task ids for n records
+      int   task_ids[size[n+1]];    // The task ids for n records
 
     }
     To implement this format, we also store int as float, so we can store all numbers
@@ -135,7 +135,7 @@ def unpack_feature(byte_arr: bytearray) -> Tuple[np.ndarray, np.ndarray, np.ndar
     # unpack normalized_throughputs
     m = sizes[-2]
     normalized_throughputs = struct.unpack_from("%df" % m, byte_arr, offset=offset)
-    offset += m * SIZE_OF_INT32
+    offset += m * SIZE_OF_FLOAT32
 
     # unpack task_ids
     m = sizes[-1]
@@ -211,7 +211,7 @@ def get_per_store_features_from_measure_pairs(
 
 def get_per_store_features_from_states(
     states: List[Union[State, StateObject]], task: "SearchTask", max_n_bufs: Optional[int] = None
-) -> List[np.ndarray]:
+) -> np.ndarray:
     """Get per-store features from measurement input/result pairs
 
     Parameters
@@ -227,10 +227,6 @@ def get_per_store_features_from_states(
     -------
     features: np.ndarray
         Feature vectors
-    normalized_throughputs: np.ndarray
-        Normalized throughputs
-    task_ids: np.ndarray
-        Task ids
     """
     if isinstance(states[0], State):
         state_objects = [s.state_object for s in states]

--- a/python/tvm/autotvm/tuner/xgboost_tuner.py
+++ b/python/tvm/autotvm/tuner/xgboost_tuner.py
@@ -64,7 +64,7 @@ class XGBTuner(ModelBasedTuner):
         top-(plan_size * diversity_filter_ratio) candidates according to the cost model
         and then pick batch_size of them according to the diversity metric.
 
-    log_interval: int, optional
+    log_interval: int = 50
         The verbose level.
         If is 0, output nothing.
         Otherwise, output debug information every `verbose` iterations.

--- a/src/auto_scheduler/feature.cc
+++ b/src/auto_scheduler/feature.cc
@@ -1518,7 +1518,7 @@ void GetPerStoreFeaturesFromMeasurePairs(const Array<MeasureInput>& inputs,
  *   ... // until i == n - 1
  *
  *   float throughputs[sizes[n]];  // The normalized throughputs for n records
- *   int   task_ids[size[n+1];   // The task ids for n records
+ *   int   task_ids[size[n+1]];   // The task ids for n records
  *
  * }
  * To implement this format, we also store int as float, so we can store all numbers


### PR DESCRIPTION
Fix typos and document parameters for for  `auto_scheduler/cost_model/xgb_model.py::XGBModel`
