### PR TITLE
Change const to used dtype if it is passed in

### DIFF
--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -509,7 +509,9 @@ def const(value, dtype=None):
         )
 
     if isinstance(value, (_np.ndarray, _np.generic)):
-        value = _nd.array(value.astype(dtype))
+        if dtype is not None:
+            value = value.astype(dtype)
+        value = _nd.array(value)
 
     if not isinstance(value, _nd.NDArray):
         raise ValueError("value has to be scalar or NDArray")

--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -502,18 +502,14 @@ def const(value, dtype=None):
     if isinstance(value, (_base.numeric_types, (bool, list))):
         value = _np.array(value, dtype=dtype)
 
-    if dtype:
-        value = value.astype(dtype)
-    else:
+    if not dtype:
         # when dtype is None: int maps to "int32", float maps to "float32"
-        map_dtype = {_np.dtype("int64"): _np.int32, _np.dtype("float64"): _np.float32}.get(
+        dtype = {_np.dtype("int64"): _np.int32, _np.dtype("float64"): _np.float32}.get(
             value.dtype, None
         )
-        if map_dtype:
-            value = value.astype(map_dtype)
 
     if isinstance(value, (_np.ndarray, _np.generic)):
-        value = _nd.array(value)
+        value = _nd.array(value.astype(dtype))
 
     if not isinstance(value, _nd.NDArray):
         raise ValueError("value has to be scalar or NDArray")

--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -488,7 +488,7 @@ def const(value, dtype=None):
         The constant value.
 
     dtype: str, optional
-        The data type of the value.
+        The data type of the resulting constant.
 
     Note
     ----
@@ -502,7 +502,9 @@ def const(value, dtype=None):
     if isinstance(value, (_base.numeric_types, (bool, list))):
         value = _np.array(value, dtype=dtype)
 
-    if not dtype:
+    if dtype:
+        value = value.astype(dtype)
+    else:
         # when dtype is None: int maps to "int32", float maps to "float32"
         map_dtype = {_np.dtype("int64"): _np.int32, _np.dtype("float64"): _np.float32}.get(
             value.dtype, None

--- a/tests/python/relay/test_const.py
+++ b/tests/python/relay/test_const.py
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import tvm
+import numpy as np
 from tvm import relay
 from tvm.relay.frontend.common import infer_type
 from tvm.relay import op as _op
-import numpy as np
 
 
 def test_const_dtype():
@@ -28,3 +29,12 @@ def test_const_dtype():
 
     # strides needs to be autoconverted to int64 on Windows
     assert infer_type(strides).checked_type.dtype == np.dtype(np.int64)
+
+    a = tvm.nd.array(np.random.randint(0, high=255, size=(2, 3), dtype="uint8"))
+    a = _op.const(a, dtype="uint8")
+    aa = a.data.asnumpy()
+    assert aa.dtype == np.dtype(np.uint8)
+
+    b = _op.const(1, dtype="int8")
+    bb = b.data.asnumpy()
+    assert bb.dtype == np.dtype(np.int8)

--- a/tests/python/relay/test_const.py
+++ b/tests/python/relay/test_const.py
@@ -23,7 +23,7 @@ import numpy as np
 
 def test_const_dtype():
     strides = (1, 1)
-    np_array = np.array(strides)
+    np_array = np.array(strides).astype("int32")
     strides = _op.const(np_array, dtype="int64")
 
     # strides needs to be autoconverted to int64 on Windows

--- a/tests/python/relay/test_const.py
+++ b/tests/python/relay/test_const.py
@@ -38,3 +38,7 @@ def test_const_dtype():
     b = _op.const(1, dtype="int8")
     bb = b.data.asnumpy()
     assert bb.dtype == np.dtype(np.int8)
+
+    kshape = (3, 10, 3, 3)
+    w = relay.const(np.zeros(kshape, dtype="float32"))
+    assert w.data.asnumpy().dtype == np.dtype(np.float32)

--- a/tests/python/relay/test_const.py
+++ b/tests/python/relay/test_const.py
@@ -20,6 +20,7 @@ from tvm.relay.frontend.common import infer_type
 from tvm.relay import op as _op
 import numpy as np
 
+
 def test_const_dtype():
     strides = (1, 1)
     np_array = np.array(strides)

--- a/tests/python/relay/test_const.py
+++ b/tests/python/relay/test_const.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from tvm import relay
+from tvm.relay.frontend.common import infer_type
+from tvm.relay import op as _op
+import numpy as np
+
+def test_const_dtype():
+    strides = (1, 1)
+    np_array = np.array(strides)
+    strides = _op.const(np_array, dtype="int64")
+
+    # strides needs to be autoconverted to int64 on Windows
+    assert infer_type(strides).checked_type.dtype == np.dtype(np.int64)


### PR DESCRIPTION
If dtype is passed then the value is autoconverted to dtype. Windows defaults python integers to int32 while linux defaults to int64. This causes issues in the onnx frontend where constants are created with dtype=int64 but on Windows they would result in int32 constants and break the importer.

https://discuss.tvm.apache.org/t/onnx-frontend-giving-an-error-when-working-a-simple-model-with-tvm/8742


