### PR TITLE
[PRNG] Add check to PRNG to make sure that unsigned integer arithmetic is wrapping

### DIFF
--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -453,8 +453,8 @@ def threefry_test_wrapping(target, ctx):
         irb = ir_builder.create()
         out = irb.buffer_ptr(out_ptr)
         if "gpu" in target.keys:
-            tx = tvm.te.thread_axis("threadIdx.x")
-            irb.scope_attr(tx, "thread_extent", 1)
+            thread_x = tvm.te.thread_axis("threadIdx.x")
+            irb.scope_attr(thread_x, "thread_extent", 1)
         out[0] = tvm.tir.const(0xFFFFFFFFFFFFFFFF, "uint64") + tvm.tir.const(1, "uint64")
         return irb.get()
 
@@ -463,7 +463,6 @@ def threefry_test_wrapping(target, ctx):
         [out.shape], [], lambda ins, outs: gen_ir(outs[0]), dtype="uint64", out_buffers=[out]
     )
     s = tvm.te.create_schedule([f.op])
-    p = tvm.te.placeholder((1,), "uint64")
     out_ary = tvm.nd.array(np.ones((1,), "uint64"), ctx)
     tvm.build(s, [f], target=target)(out_ary)
     return out_ary.asnumpy()[0] == 0

--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -459,7 +459,9 @@ def threefry_test_wrapping(target, ctx):
         return irb.get()
 
     out = tvm.tir.decl_buffer((1,), dtype="uint64")
-    f = tvm.te.extern([out.shape], [], lambda ins, outs: gen_ir(outs[0]), dtype="uint64", out_buffers=[out])
+    f = tvm.te.extern(
+        [out.shape], [], lambda ins, outs: gen_ir(outs[0]), dtype="uint64", out_buffers=[out]
+    )
     s = tvm.te.create_schedule([f.op])
     p = tvm.te.placeholder((1,), "uint64")
     out_ary = tvm.nd.array(np.ones((1,), "uint64"), ctx)

--- a/tests/python/topi/python/test_topi_prng.py
+++ b/tests/python/topi/python/test_topi_prng.py
@@ -111,6 +111,14 @@ def test_threefry_generate(target, ctx):
     ).any(), "Overflowing counter with no space left in path should change state"
 
 
+@tvm.testing.parametrize_targets
+def test_threefry_wrapping(target, ctx):
+    assert tvm.topi.random.threefry_test_wrapping(
+        target, ctx
+    ), f"{target} does not suppport wrapping unsigned integer arithmetic"
+
+
 if __name__ == "__main__":
     test_threefry_split(tvm.target.Target("llvm"), tvm.context("cpu"))
     test_threefry_generate(tvm.target.Target("llvm"), tvm.context("cpu"))
+    test_threefry_wrapping(tvm.target.Target("llvm"), tvm.context("cpu"))


### PR DESCRIPTION
This PR adds a simple test to `threefry_generate` to make sure that unsigned integer arithmetic is wrapping. We have no guarantee of wrapping on our platforms, so this is the best we can do. I've added the test to `threefry_generate` as it should be called before other threefry functions and it should called infrequently.

@altanh @antinucleon @junrushao1994 @eric-haibin-lin @MarisaKirisame