### PR TITLE
[TEST] Fix test_topi_batch_matmul_tensorcore.py:test_batch_matmul requirement

### DIFF
--- a/tests/python/topi/python/test_topi_batch_matmul_tensorcore.py
+++ b/tests/python/topi/python/test_topi_batch_matmul_tensorcore.py
@@ -63,7 +63,7 @@ def verify_batch_matmul(x_batch, y_batch, M, N, K):
     check_device("cuda")
 
 
-@tvm.testing.uses_gpu
+@tvm.testing.requires_tensorcore
 def test_batch_matmul():
     verify_batch_matmul(1, 1, 16, 16, 32)
     verify_batch_matmul(5, 5, 16, 16, 32)


### PR DESCRIPTION
`test_topi_batch_matmul_tensorcore.py:test_batch_matmul` currently sets a requirement to "uses_gpu", which causes it to fail on cpu-only machine.

This patch changes it to be "requires_tensorcore", as per discussion on issue #7277 

cc @tqchen @tkonolige
