### PR TITLE
[TVMC] Add composite target passes for compilation and tuning

### DIFF
--- a/python/tvm/driver/tvmc/composite_target.py
+++ b/python/tvm/driver/tvmc/composite_target.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Provides support to composite target on TVMC.
+"""
+import logging
+
+from tvm.relay.op.contrib.arm_compute_lib import partition_for_arm_compute_lib
+from tvm.relay.op.contrib.ethosn import partition_for_ethosn
+
+from .common import TVMCException
+
+
+# pylint: disable=invalid-name
+logger = logging.getLogger("TVMC")
+
+# Global dictionary to map targets with the configuration key
+# to be used in the PassContext (if any), and a function
+# responsible for partitioning to that target.
+REGISTERED_CODEGEN = {
+    "acl": {
+        "config_key": None,
+        "pass_pipeline": partition_for_arm_compute_lib,
+    },
+    "ethos-n77": {
+        "config_key": "relay.ext.ethos-n.options",
+        "pass_pipeline": partition_for_ethosn,
+    },
+}
+
+
+def get_codegen_names():
+    """Return a list of all registered codegens.
+
+    Returns
+    -------
+    list of str
+        all registered targets
+    """
+    return list(REGISTERED_CODEGEN.keys())
+
+
+def get_codegen_by_target(name):
+    """Return a codegen entry by name.
+
+    Returns
+    -------
+    dict
+        requested target information
+    """
+    try:
+        return REGISTERED_CODEGEN[name]
+    except KeyError:
+        raise TVMCException("Composite target %s is not defined in TVMC." % name)

--- a/tests/python/driver/tvmc/test_composite_target.py
+++ b/tests/python/driver/tvmc/test_composite_target.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import argparse
+import os
+import shutil
+
+from inspect import isfunction
+from os import path
+
+import pytest
+
+import tvm
+
+from tvm.driver import tvmc
+
+from tvm.driver.tvmc.common import TVMCException
+
+
+def test_get_codegen_names():
+    names = tvmc.composite_target.get_codegen_names()
+
+    assert "ethos-n77" in names
+    assert len(names) > 0
+
+
+def test_valid_codegen():
+    codegen = tvmc.composite_target.get_codegen_by_target("acl")
+
+    assert codegen is not None
+    assert codegen["pass_pipeline"] is not None
+
+
+def test_invalid_codegen():
+    with pytest.raises(TVMCException):
+        _ = tvmc.composite_target.get_codegen_by_target("invalid")
+
+
+def test_all_codegens_contain_pass_pipeline():
+    for name in tvmc.composite_target.get_codegen_names():
+        codegen = tvmc.composite_target.get_codegen_by_target(name)
+        assert "pass_pipeline" in codegen, f"{name} does not contain a pass_pipeline"
+        assert isfunction(codegen["pass_pipeline"])
+
+
+def test_all_pass_pipelines_are_functions():
+    for name in tvmc.composite_target.get_codegen_names():
+        codegen = tvmc.composite_target.get_codegen_by_target(name)
+        assert isfunction(codegen["pass_pipeline"]), f"pass_pipeline for {name} is not a function"


### PR DESCRIPTION
This adds composite target integration on TVMC.

 * Extends `--target` syntax to cover multiple targets for compilation and tuning
 * Add a new `tvm.driver.tvmc.composite_target` module to implement custom codegen passes into TVMC
 * Provide implementation to integrate TVMC with Codegen for Arm Ethos-N NPU

Change-Id: Iaee53fe22f0c14eb4e4c8ec47e72bade0c5e32cc

cc @mshawcroft @comaniac @mbaret 