### PR TITLE
[FIX] Add GetFullType to print the type of a container and its contents

### DIFF
--- a/include/tvm/node/container.h
+++ b/include/tvm/node/container.h
@@ -137,6 +137,15 @@ class MapNode : public Object {
    */
   static ObjectPtr<MapNode> Empty() { return make_object<MapNode>(); }
 
+  std::string GetFullType() const override {
+    if (size() > 0) {
+      return "Map[" + begin()->first->GetFullType() + ", " + begin()->second->GetFullType() + "]";
+    } else {
+      // If this map contains no elements, we don't know the type of what it contains.
+      return "Map[]";
+    }
+  }
+
  protected:
   /*!
    * \brief Create the map using contents from the given iterators.

--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -407,6 +407,15 @@ class ArrayNode : public Object, public InplaceArrayBase<ArrayNode, ObjectRef> {
     return p;
   }
 
+  std::string GetFullType() const override {
+    if (size() > 0) {
+      return "Array[" + (*begin())->GetFullType() + "]";
+    } else {
+      // If this array contains no elements, we don't know the type of what it contains.
+      return "Array[]";
+    }
+  }
+
   static constexpr const uint32_t _type_index = TypeIndex::kRuntimeArray;
   static constexpr const char* _type_key = "Array";
   TVM_DECLARE_FINAL_OBJECT_INFO(ArrayNode, Object);

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -175,6 +175,12 @@ class TVM_DLL Object {
    */
   std::string GetTypeKey() const { return TypeIndex2Key(type_index_); }
   /*!
+   * \return The full type of the object including the types of the items it contains.
+   * \note this operation is expensive, but provides a more detailed type than
+   * GetTypeKey for error reporting.
+   */
+  virtual std::string GetFullType() const;
+  /*!
    * \return A hash value of the return of GetTypeKey.
    */
   size_t GetTypeKeyHash() const { return TypeIndex2KeyHash(type_index_); }

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1404,7 +1404,7 @@ inline TObjectRef TVMPODValue_::AsObjectRef() const {
     Object* ptr = static_cast<Object*>(value_.v_handle);
     ICHECK(ObjectTypeChecker<TObjectRef>::Check(ptr))
         << "Expect " << ObjectTypeChecker<TObjectRef>::TypeName() << " but get "
-        << ptr->GetTypeKey();
+        << ptr->GetFullType();
     return TObjectRef(GetObjectPtr<Object>(ptr));
   } else if (type_code_ == kTVMObjectRValueRefArg) {
     Object* ptr = *static_cast<Object**>(value_.v_handle);

--- a/src/runtime/object.cc
+++ b/src/runtime/object.cc
@@ -217,6 +217,8 @@ uint32_t Object::TypeKey2Index(const std::string& key) {
   return TypeContext::Global()->TypeKey2Index(key);
 }
 
+std::string Object::GetFullType() const { return GetTypeKey(); }
+
 TVM_REGISTER_GLOBAL("runtime.ObjectPtrHash").set_body_typed([](ObjectRef obj) {
   return static_cast<int64_t>(ObjectPtrHash()(obj));
 });


### PR DESCRIPTION
I've added a new function `GetFullType` on all object that prints the type of the object along with the types of objects it contains. I've only updated on assert to use it so far, I'll update the rest in a subsequent PR. Here is an example of how it improves error messages:
```
# before
Check failed: ObjectTypeChecker<TObjectRef>::Check(ptr) == false: Expect Array[Operation] but get Array
# after
Check failed: ObjectTypeChecker<TObjectRef>::Check(ptr) == false: Expect Array[Operation] but get Array[Tensor]
```


Note that because I've added a virtual function to Object, I'm now seeing all these warnings:
```
../src/runtime/vm/memory_manager.cc: In function ‘void tvm::runtime::vm::BufferDeleter(tvm::runtime::Object*)’:
../src/runtime/vm/memory_manager.cc:42:3: warning: deleting object of polymorphic class type ‘tvm::runtime::NDArray::Container’ which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
   42 |   delete ptr;
```
I believe this warning is valid, but was not caused by this PR. We have already been calling non-virtual destructors on polymorphic classes. Maybe we should fix this in a separate PR?

@jroesch @tqchen @junrushao1994 @rkimball 