### PR TITLE
[FIX] Rename `to_batch` to `to_batch_matmul` in `CombineParallelDense`'s argument

### DIFF
--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -297,7 +297,7 @@ def CombineParallelConv2D(min_num_branches=3):
     return _ffi_api.CombineParallelConv2D(min_num_branches)
 
 
-def CombineParallelDense(min_num_branches=3, to_batch=True):
+def CombineParallelDense(min_num_branches=3, to_batch_matmul=True):
     """Combine multiple dense operators into one. For example:
 
     .. code-block
@@ -315,7 +315,7 @@ def CombineParallelDense(min_num_branches=3, to_batch=True):
                 |
             batch_matmul+elemwise/bcast (2,2,2)
 
-    or (if to_batch=False)
+    or (if to_batch_matmul=False)
 
     .. code-block
 
@@ -338,7 +338,7 @@ def CombineParallelDense(min_num_branches=3, to_batch=True):
     ret: tvm.transform.Pass
         The registered pass that combines parallel dense operators.
     """
-    return _ffi_api.CombineParallelDense(min_num_branches, to_batch)
+    return _ffi_api.CombineParallelDense(min_num_branches, to_batch_matmul)
 
 
 def CombineParallelBatchMatmul(min_num_branches=3):

--- a/src/relay/transforms/combine_parallel_dense.cc
+++ b/src/relay/transforms/combine_parallel_dense.cc
@@ -231,8 +231,8 @@ class ParallelDenseToDenseCombiner : public ParallelOpCombiner {
 };
 
 /*! \brief Combine parallel dense if number of branches >= min_num_branches */
-Expr CombineParallelDense(const Expr& expr, uint64_t min_num_branches, bool to_batch) {
-  if (to_batch) {
+Expr CombineParallelDense(const Expr& expr, uint64_t min_num_branches, bool to_batch_matmul) {
+  if (to_batch_matmul) {
     return ParallelDenseToBatchCombiner(min_num_branches).Combine(expr);
   } else {
     return ParallelDenseToDenseCombiner(min_num_branches).Combine(expr);

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -20,9 +20,9 @@ from tvm import relay
 from tvm.relay import transform
 
 
-def run_combine_parallel(expr, min_num_branches=3, to_batch=True):
+def run_combine_parallel(expr, min_num_branches=3, to_batch_matmul=True):
     mod = tvm.IRModule.from_expr(expr)
-    mod = transform.CombineParallelDense(min_num_branches, to_batch)(mod)
+    mod = transform.CombineParallelDense(min_num_branches, to_batch_matmul)(mod)
     return mod["main"]
 
 
@@ -226,7 +226,7 @@ def test_combine_parallel_dense_flat():
         w3 = relay.var("w3", shape=(3 * j, k))
 
         y_before = before(x, w1, w2, w3)
-        combine_pass = transform.CombineParallelDense(min_num_branches=3, to_batch=False)
+        combine_pass = transform.CombineParallelDense(min_num_branches=3, to_batch_matmul=False)
         y = run_opt_pass(y_before, combine_pass)
         y_expected = expected(x, w1, w2, w3, j)
         y_expected = run_opt_pass(y_expected, transform.InferType())
@@ -282,7 +282,7 @@ def test_combine_parallel_dense_flat_biasadd():
         b2 = relay.var("b2", shape=bias_shape2)
 
         y_before = before(x, w1, w2, b1, b2)
-        combine_pass = transform.CombineParallelDense(min_num_branches=2, to_batch=False)
+        combine_pass = transform.CombineParallelDense(min_num_branches=2, to_batch_matmul=False)
         y = run_opt_pass(y_before, combine_pass)
         y_expected = expected(x, w1, w2, b1, b2, j, bias_shape1, bias_shape2)
         y_expected = run_opt_pass(y_expected, transform.InferType())
@@ -349,7 +349,7 @@ def test_combine_parallel_dense_flat_biasadd_scale_reshape():
         scale2 = relay.var("scale2", shape=(1,))
 
         y_before = before(x, w1, w2, b1, b2, scale1, scale2, newshape1, newshape2)
-        combine_pass = transform.CombineParallelDense(min_num_branches=2, to_batch=False)
+        combine_pass = transform.CombineParallelDense(min_num_branches=2, to_batch_matmul=False)
         y = run_opt_pass(y_before, combine_pass)
         y_expected = expected(x, w1, w2, b1, b2, scale1, scale2, newshape1, newshape2, j)
         y_expected = run_opt_pass(y_expected, transform.InferType())


### PR DESCRIPTION
to match its parameter description.