### PR TITLE
[BYOC][WIP][potential bug?] Figuring out annotations for let expressions

### DIFF
--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -803,15 +803,15 @@ def test_annotate_within_let():
         f = relay.Function(
             [],
             relay.Let(
-                x, relay.const(const_array, dtype="float32"),
+                x,
+                relay.const(const_array, dtype="float32"),
                 relay.Let(
-                    r, relay.nn.relu(x),
-                    relay.Let(
-                        a, relay.abs(r),
-                        relay.Let(
-                            s, relay.add(a, a),
-                            s
-                        )))))
+                    r,
+                    relay.nn.relu(x),
+                    relay.Let(a, relay.abs(r), relay.Let(s, relay.add(a, a), s)),
+                ),
+            ),
+        )
         mod = tvm.IRModule.from_expr(f)
         return mod
 
@@ -840,14 +840,13 @@ def test_annotate_within_let():
         f = relay.Function(
             [],
             relay.Let(
-                x, annotate_const,
+                x,
+                annotate_const,
                 relay.Let(
-                    r, annotate_relu,
-                    relay.Let(
-                        a, annotate_abs,
-                        relay.Let(
-                            s, annotate_sum,
-                            s)))))
+                    r, annotate_relu, relay.Let(a, annotate_abs, relay.Let(s, annotate_sum, s))
+                ),
+            ),
+        )
         mod = tvm.IRModule.from_expr(f)
         return mod
 

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -837,13 +837,18 @@ def test_annotate_within_let():
         sum_expr = relay.annotation.compiler_end(relay.add(called_a_1, called_a_2), "default")
         annotate_sum = relay.annotation.compiler_begin(sum_expr, "default")
 
+        # s appears by itself and is its own annotated region
+        s_expr = relay.annotate_compiler_begin(s, "default")
+        annotate_s  = relay.annotate_compiler_end(s_expr, "default")
+
         f = relay.Function(
             [],
             relay.Let(
                 x,
                 annotate_const,
                 relay.Let(
-                    r, annotate_relu, relay.Let(a, annotate_abs, relay.Let(s, annotate_sum, s))
+                    r, annotate_relu, relay.Let(a, annotate_abs,
+                                                relay.Let(s, annotate_sum, annotate_s)),
                 ),
             ),
         )

--- a/tests/python/relay/test_pass_annotate_target.py
+++ b/tests/python/relay/test_pass_annotate_target.py
@@ -837,9 +837,8 @@ def test_annotate_within_let():
         sum_expr = relay.annotation.compiler_end(relay.add(called_a_1, called_a_2), "default")
         annotate_sum = relay.annotation.compiler_begin(sum_expr, "default")
 
-        # s appears by itself and is its own annotated region
-        s_expr = relay.annotate_compiler_begin(s, "default")
-        annotate_s  = relay.annotate_compiler_end(s_expr, "default")
+        # s appears by itself and is the only outgoing edge of its annotated region
+        annotate_s = relay.annotate_compiler_end(s, "default")
 
         f = relay.Function(
             [],


### PR DESCRIPTION
Per the discussion [here](https://discuss.tvm.apache.org/t/confusing-behavior-with-graph-partitioning/8879), it appears there is a bug with how the annotation pass handles let expressions; in particular the let assignment seems to produce a `compiler_begin` tag without a corresponding `compiler_end` tag. In this PR, I have added a test case that demonstrates this. However, I do not know what the fix should be, if any.

@zhiics @comaniac, could you examine the behavior in this test case and determine if it is behaving as expected? For the "expected" output, I simply copied what the pass was doing, so I do not know what the specification really is (please correct me if it is documented somewhere). If a fix is needed, I would be happy to implement it, but I do not know what the expected annotations should be.

Update: Per the discussion in the TVM Discuss thread, it seems that let nodes are being incorrectly handled.