### PR TITLE
[Autodiff] Deterministic gradient compute

### DIFF
--- a/src/arith/solve_linear_equation.cc
+++ b/src/arith/solve_linear_equation.cc
@@ -427,11 +427,10 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
 
   // We have to transform ranges of the old variables into relations over new variables because
   // new ranges are not enough usually.
-  for (const auto& p : system_to_solve->ranges) {
-    const Var& old_var = p.first;
-    const Range& old_range = p.second;
-    if (old_to_new_map.count(old_var)) {
-      PrimExpr express_by_new_vars = old_to_new_map[old_var];
+  for (const auto& old_var: system_to_solve->variables) {
+    if (system_to_solve->ranges.find(old_var) != system_to_solve->ranges.end()) {
+      const Range& old_range = system_to_solve->ranges.at(old_var);
+      PrimExpr express_by_new_vars = old_to_new_map.at(old_var);
       PrimExpr lower_cond = analyzer_solution.Simplify(old_range->min <= express_by_new_vars);
       PrimExpr upper_cond =
           analyzer_solution.Simplify(express_by_new_vars < old_range->min + old_range->extent);
@@ -443,6 +442,22 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
       }
     }
   }
+  // for (const auto& p : system_to_solve->ranges) {
+  //   const Var& old_var = p.first;
+  //   const Range& old_range = p.second;
+  //   if (old_to_new_map.count(old_var)) {
+  //     PrimExpr express_by_new_vars = old_to_new_map[old_var];
+  //     PrimExpr lower_cond = analyzer_solution.Simplify(old_range->min <= express_by_new_vars);
+  //     PrimExpr upper_cond =
+  //         analyzer_solution.Simplify(express_by_new_vars < old_range->min + old_range->extent);
+  //     if (!tir::is_const_int(lower_cond, 1)) {
+  //       new_relations.push_back(lower_cond);
+  //     }
+  //     if (!tir::is_const_int(upper_cond, 1)) {
+  //       new_relations.push_back(upper_cond);
+  //     }
+  //   }
+  // }
 
   // Add the rest conditions
   for (const PrimExpr& cond : rest) {

--- a/src/arith/solve_linear_equation.cc
+++ b/src/arith/solve_linear_equation.cc
@@ -427,7 +427,7 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
 
   // We have to transform ranges of the old variables into relations over new variables because
   // new ranges are not enough usually.
-  for (const auto& old_var: system_to_solve->variables) {
+  for (const auto& old_var : system_to_solve->variables) {
     if (system_to_solve->ranges.find(old_var) != system_to_solve->ranges.end()) {
       const Range& old_range = system_to_solve->ranges.at(old_var);
       PrimExpr express_by_new_vars = old_to_new_map.at(old_var);
@@ -442,22 +442,6 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
       }
     }
   }
-  // for (const auto& p : system_to_solve->ranges) {
-  //   const Var& old_var = p.first;
-  //   const Range& old_range = p.second;
-  //   if (old_to_new_map.count(old_var)) {
-  //     PrimExpr express_by_new_vars = old_to_new_map[old_var];
-  //     PrimExpr lower_cond = analyzer_solution.Simplify(old_range->min <= express_by_new_vars);
-  //     PrimExpr upper_cond =
-  //         analyzer_solution.Simplify(express_by_new_vars < old_range->min + old_range->extent);
-  //     if (!tir::is_const_int(lower_cond, 1)) {
-  //       new_relations.push_back(lower_cond);
-  //     }
-  //     if (!tir::is_const_int(upper_cond, 1)) {
-  //       new_relations.push_back(upper_cond);
-  //     }
-  //   }
-  // }
 
   // Add the rest conditions
   for (const PrimExpr& cond : rest) {

--- a/src/arith/solve_linear_inequality.cc
+++ b/src/arith/solve_linear_inequality.cc
@@ -224,7 +224,7 @@ void MoveEquality(std::vector<PrimExpr>* upper_bounds,
                   std::vector<PrimExpr>* equalities) {
   // those exist in both upper & lower bounds will be moved to equalities
   for (auto ub = upper_bounds->begin(); ub != upper_bounds->end();) {
-    auto lb = std::find(lower_bounds->begin(), lower_bounds->end(), [&](const PrimExpr& e) {
+    auto lb = std::find_if(lower_bounds->begin(), lower_bounds->end(), [&](const PrimExpr& e) {
       return StructuralEqual()(e, *ub);
     });
     if (lb != lower_bounds->end()) {

--- a/src/arith/solve_linear_inequality.cc
+++ b/src/arith/solve_linear_inequality.cc
@@ -150,10 +150,8 @@ class NormalizeComparisons : public ExprMutator {
 
 void AddInequality(std::vector<PrimExpr>* inequality_set,
                    const PrimExpr& new_ineq, Analyzer* analyzer) {
-  if (std::find(inequality_set->begin(), inequality_set->end(), new_ineq) != inequality_set->end()) {
-    return;
-  }
-  if (analyzer->CanProve(new_ineq)) {
+  if (analyzer->CanProve(new_ineq) || std::find_if(inequality_set->begin(), inequality_set->end(),
+    [&](const PrimExpr& e) { return StructuralEqual()(e, new_ineq); }) != inequality_set->end()) {
     // redundant: follows from the vranges
     // or has already been added
     return;
@@ -226,7 +224,9 @@ void MoveEquality(std::vector<PrimExpr>* upper_bounds,
                   std::vector<PrimExpr>* equalities) {
   // those exist in both upper & lower bounds will be moved to equalities
   for (auto ub = upper_bounds->begin(); ub != upper_bounds->end();) {
-    auto lb = std::find(lower_bounds->begin(), lower_bounds->end(), *ub);
+    auto lb = std::find(lower_bounds->begin(), lower_bounds->end(), [&](const PrimExpr& e) {
+      return StructuralEqual()(e, *ub);
+    });
     if (lb != lower_bounds->end()) {
       equalities->push_back(*lb);
       lower_bounds->erase(lb);

--- a/src/arith/solve_linear_inequality.cc
+++ b/src/arith/solve_linear_inequality.cc
@@ -94,11 +94,10 @@ struct ExprLess {
   }
 };
 
-void DebugPrint(
-    const std::vector<PrimExpr>& current_ineq_set,
-    const std::vector<PrimExpr>& next_ineq_set,
-    const std::vector<PrimExpr>& rest, const std::vector<std::pair<int64_t, PrimExpr>>& coef_pos,
-    const std::vector<std::pair<int64_t, PrimExpr>>& coef_neg) {
+void DebugPrint(const std::vector<PrimExpr>& current_ineq_set,
+                const std::vector<PrimExpr>& next_ineq_set, const std::vector<PrimExpr>& rest,
+                const std::vector<std::pair<int64_t, PrimExpr>>& coef_pos,
+                const std::vector<std::pair<int64_t, PrimExpr>>& coef_neg) {
   std::cout << "Current ineq set:\n[";
   for (auto& ineq : current_ineq_set) {
     std::cout << ineq << ", ";
@@ -148,10 +147,12 @@ class NormalizeComparisons : public ExprMutator {
   arith::Analyzer analyzer_;
 };
 
-void AddInequality(std::vector<PrimExpr>* inequality_set,
-                   const PrimExpr& new_ineq, Analyzer* analyzer) {
-  if (analyzer->CanProve(new_ineq) || std::find_if(inequality_set->begin(), inequality_set->end(),
-    [&](const PrimExpr& e) { return StructuralEqual()(e, new_ineq); }) != inequality_set->end()) {
+void AddInequality(std::vector<PrimExpr>* inequality_set, const PrimExpr& new_ineq,
+                   Analyzer* analyzer) {
+  if (analyzer->CanProve(new_ineq) ||
+      std::find_if(inequality_set->begin(), inequality_set->end(), [&](const PrimExpr& e) {
+        return StructuralEqual()(e, new_ineq);
+      }) != inequality_set->end()) {
     // redundant: follows from the vranges
     // or has already been added
     return;
@@ -172,12 +173,10 @@ void AddInequality(std::vector<PrimExpr>* inequality_set,
   inequality_set->push_back(new_ineq);
 }
 
-void ClassifyByPolarity(
-    const Var& var,
-    const std::vector<PrimExpr>& current_ineq_set,
-    std::vector<PrimExpr>* next_ineq_set,
-    std::vector<PrimExpr>* rest, std::vector<std::pair<int64_t, PrimExpr>>* coef_pos,
-    std::vector<std::pair<int64_t, PrimExpr>>* coef_neg, Analyzer* analyzer) {
+void ClassifyByPolarity(const Var& var, const std::vector<PrimExpr>& current_ineq_set,
+                        std::vector<PrimExpr>* next_ineq_set, std::vector<PrimExpr>* rest,
+                        std::vector<std::pair<int64_t, PrimExpr>>* coef_pos,
+                        std::vector<std::pair<int64_t, PrimExpr>>* coef_neg, Analyzer* analyzer) {
   // Take formulas from current_ineq_set and classify them according to polarity wrt var
   // and store to coef_pos and coef_neg respectively.
   for (const PrimExpr& ineq : current_ineq_set) {
@@ -219,14 +218,12 @@ void ClassifyByPolarity(
   }
 }
 
-void MoveEquality(std::vector<PrimExpr>* upper_bounds,
-                  std::vector<PrimExpr>* lower_bounds,
+void MoveEquality(std::vector<PrimExpr>* upper_bounds, std::vector<PrimExpr>* lower_bounds,
                   std::vector<PrimExpr>* equalities) {
   // those exist in both upper & lower bounds will be moved to equalities
   for (auto ub = upper_bounds->begin(); ub != upper_bounds->end();) {
-    auto lb = std::find_if(lower_bounds->begin(), lower_bounds->end(), [&](const PrimExpr& e) {
-      return StructuralEqual()(e, *ub);
-    });
+    auto lb = std::find_if(lower_bounds->begin(), lower_bounds->end(),
+                           [&](const PrimExpr& e) { return StructuralEqual()(e, *ub); });
     if (lb != lower_bounds->end()) {
       equalities->push_back(*lb);
       lower_bounds->erase(lb);

--- a/src/arith/solve_linear_inequality.cc
+++ b/src/arith/solve_linear_inequality.cc
@@ -150,8 +150,10 @@ class NormalizeComparisons : public ExprMutator {
 
 void AddInequality(std::vector<PrimExpr>* inequality_set,
                    const PrimExpr& new_ineq, Analyzer* analyzer) {
-  if (analyzer->CanProve(new_ineq) || std::find(
-      inequality_set->begin(), inequality_set->end(), new_ineq) != inequality_set->end()) {
+  if (std::find(inequality_set->begin(), inequality_set->end(), new_ineq) != inequality_set->end()) {
+    return;
+  }
+  if (analyzer->CanProve(new_ineq)) {
     // redundant: follows from the vranges
     // or has already been added
     return;

--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -413,15 +413,17 @@ class FactorOutAtomicFormulasFunctor
     auto res_b = VisitExpr(op->b);
 
     // For the And case we return the union of the sets of atomic formulas
-    std::unordered_set<PrimExpr, StructuralHash, StructuralEqual> res_set;
-    res_set.reserve(res_a.atomic_formulas.size() + res_b.atomic_formulas.size());
+    std::unordered_set<PrimExpr, StructuralHash, StructuralEqual> res_a_set;
+    res_a_set.reserve(res_a.atomic_formulas.size());
     std::copy(res_a.atomic_formulas.begin(), res_a.atomic_formulas.end(),
-              std::inserter(res_set, res_set.end()));
-    std::copy(res_b.atomic_formulas.begin(), res_b.atomic_formulas.end(),
-              std::inserter(res_set, res_set.end()));
+              std::inserter(res_a_set, res_a_set.end()));
 
-    std::vector<PrimExpr> res{res_set.begin(), res_set.end()};
-
+    std::vector<PrimExpr> res = res_a.atomic_formulas;
+    for (const auto& e : res_b.atomic_formulas) {
+      if (res_a_set.find(e) == res_a_set.end()) {
+        res.emplace_back(e);
+      }
+    }
     // And the residuals are combined with &&
     return {res, res_a.rest && res_b.rest};
   }
@@ -443,10 +445,13 @@ class FactorOutAtomicFormulasFunctor
 
     // For the Or case we intersect the sets of atomic formulas
     std::unordered_set<PrimExpr, StructuralHash, StructuralEqual> res_set;
+    std::vector<PrimExpr> res;
     res_set.reserve(std::min(res_a.atomic_formulas.size(), res_b.atomic_formulas.size()));
-    for (const auto& res_b_formula : res_b_set) {
+    res.reserve(std::min(res_a.atomic_formulas.size(), res_b.atomic_formulas.size()));
+    for (const auto& res_b_formula : res_b.atomic_formulas) {
       if (res_a_set.count(res_b_formula)) {
         res_set.insert(res_b_formula);
+        res.push_back(res_b_formula);
       }
     }
 
@@ -454,13 +459,13 @@ class FactorOutAtomicFormulasFunctor
     // which are left behind, and then combine them with the residuals into the new residual.
     std::vector<PrimExpr> new_cond_a;
     new_cond_a.reserve(res_a.atomic_formulas.size() - res_set.size());
-    for (const auto& formula : res_a_set) {
+    for (const auto& formula : res_a.atomic_formulas) {
       if (!res_set.count(formula)) new_cond_a.emplace_back(formula);
     }
 
     std::vector<PrimExpr> new_cond_b;
     new_cond_b.reserve(res_b.atomic_formulas.size() - res_set.size());
-    for (const auto& formula : res_b_set) {
+    for (const auto& formula : res_b.atomic_formulas) {
       if (!res_set.count(formula)) new_cond_b.emplace_back(formula);
     }
 
@@ -468,7 +473,6 @@ class FactorOutAtomicFormulasFunctor
     res_b.atomic_formulas = std::move(new_cond_b);
 
     PrimExpr new_rest = res_a.to_expr() || res_b.to_expr();
-    std::vector<PrimExpr> res{res_set.begin(), res_set.end()};
 
     return {res, new_rest};
   }
@@ -775,7 +779,6 @@ arith::IntConstraintsTransform SimplifyDomain(const arith::IntConstraints& iter_
   if (eliminate_div_mod) {
     transf = transf + EliminateDivModFromDomainConditions(transf->dst);
   }
-
   // TODO(sgrechanik-h): Repeating the following steps has a positive effect, however we probably
   // should find a better terminating criterion (like stop when the domain volume stops decreasing)
   // Also 2 steps seems to be slightly better than 3
@@ -786,6 +789,7 @@ arith::IntConstraintsTransform SimplifyDomain(const arith::IntConstraints& iter_
 
   return transf;
 }
+
 
 // Use the condition of a reduction op to simplify its domain (axis)
 PrimExpr SimplifyReductionDomain(const PrimExpr& expr, const Map<Var, Range>& outer_vranges) {

--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -779,6 +779,7 @@ arith::IntConstraintsTransform SimplifyDomain(const arith::IntConstraints& iter_
   if (eliminate_div_mod) {
     transf = transf + EliminateDivModFromDomainConditions(transf->dst);
   }
+
   // TODO(sgrechanik-h): Repeating the following steps has a positive effect, however we probably
   // should find a better terminating criterion (like stop when the domain volume stops decreasing)
   // Also 2 steps seems to be slightly better than 3
@@ -789,7 +790,6 @@ arith::IntConstraintsTransform SimplifyDomain(const arith::IntConstraints& iter_
 
   return transf;
 }
-
 
 // Use the condition of a reduction op to simplify its domain (axis)
 PrimExpr SimplifyReductionDomain(const PrimExpr& expr, const Map<Var, Range>& outer_vranges) {

--- a/tests/python/unittest/test_te_autodiff.py
+++ b/tests/python/unittest/test_te_autodiff.py
@@ -343,7 +343,25 @@ def test_reduction_init():
     check_grad(B, A0)
 
 
+def test_stable():
+    X = te.placeholder((32, 512, 16, 16), name="X")
+    W = te.placeholder((1024, 512, 1, 1), name="W")
+    strides, padding, dilation = 2, 0, 1
+    R = topi.nn.conv2d(X, W, strides, padding, dilation)
+    ones = topi.full_like(R, 1.0)
+    grads = te.gradient(R, [X], head=ones)
+    dag = tvm.auto_scheduler.ComputeDAG(grads)
+    repeat = 100
+    for i in range(repeat):
+        grads = te.gradient(R, [X], head=ones)
+        new_dag = tvm.auto_scheduler.ComputeDAG(grads)
+        print(dag)
+        print(new_dag)
+        assert str(dag) == str(new_dag)
+
+
 if __name__ == "__main__":
-    test_basic_operation()
-    test_topi()
-    test_stride_dilation()
+    # test_basic_operation()
+    # test_topi()
+    # test_stride_dilation()
+    test_stable()

--- a/tests/python/unittest/test_te_autodiff.py
+++ b/tests/python/unittest/test_te_autodiff.py
@@ -361,7 +361,7 @@ def test_stable():
 
 
 if __name__ == "__main__":
-    # test_basic_operation()
-    # test_topi()
-    # test_stride_dilation()
+    test_basic_operation()
+    test_topi()
+    test_stride_dilation()
     test_stable()

--- a/tests/python/unittest/test_te_autodiff.py
+++ b/tests/python/unittest/test_te_autodiff.py
@@ -343,23 +343,7 @@ def test_reduction_init():
     check_grad(B, A0)
 
 
-def test_stable():
-    X = te.placeholder((32, 512, 16, 16), name="X")
-    W = te.placeholder((1024, 512, 1, 1), name="W")
-    strides, padding, dilation = 2, 0, 1
-    R = topi.nn.conv2d(X, W, strides, padding, dilation)
-    ones = topi.full_like(R, 1.0)
-    grads = te.gradient(R, [X], head=ones)
-    dag = tvm.auto_scheduler.ComputeDAG(grads)
-    repeat = 100
-    for i in range(repeat):
-        grads = te.gradient(R, [X], head=ones)
-        new_dag = tvm.auto_scheduler.ComputeDAG(grads)
-        assert str(dag) == str(new_dag)
-
-
 if __name__ == "__main__":
     test_basic_operation()
     test_topi()
     test_stride_dilation()
-    test_stable()

--- a/tests/python/unittest/test_te_autodiff.py
+++ b/tests/python/unittest/test_te_autodiff.py
@@ -355,8 +355,6 @@ def test_stable():
     for i in range(repeat):
         grads = te.gradient(R, [X], head=ones)
         new_dag = tvm.auto_scheduler.ComputeDAG(grads)
-        print(dag)
-        print(new_dag)
         assert str(dag) == str(new_dag)
 
 


### PR DESCRIPTION
`te.gradient` may generate different (but equivalent) backward compute for a single forward, which may result in Ansor miss. This pr makes sure `te.gradient` always generates the same backward.

cc @yzhliu @comaniac 
