### PR TITLE
[FFI] Improve error messages when array/map types do not match in function calls

### DIFF
--- a/include/tvm/node/container.h
+++ b/include/tvm/node/container.h
@@ -1447,35 +1447,6 @@ inline Map<K, V> Merge(Map<K, V> lhs, const Map<K, V>& rhs) {
 namespace tvm {
 namespace runtime {
 // Additional overloads for PackedFunc checking.
-template <typename T>
-struct ObjectTypeChecker<Array<T>> {
-  static Optional<String> CheckAndGetMismatch(const Object* ptr) {
-    if (ptr == nullptr) return NullOpt;
-    if (!ptr->IsInstance<ArrayNode>()) return String(ptr->GetTypeKey());
-    const ArrayNode* n = static_cast<const ArrayNode*>(ptr);
-    for (size_t i = 0; i < n->size(); i++) {
-      const ObjectRef& p = (*n)[i];
-      Optional<String> check_subtype = ObjectTypeChecker<T>::CheckAndGetMismatch(p.get());
-      if (check_subtype.defined()) {
-        return String("Array[index " + std::to_string(i) + ": " + check_subtype.value() + "]");
-      }
-    }
-    return NullOpt;
-  }
-  static bool Check(const Object* ptr) {
-    if (ptr == nullptr) return true;
-    if (!ptr->IsInstance<ArrayNode>()) return false;
-    const ArrayNode* n = static_cast<const ArrayNode*>(ptr);
-    for (const ObjectRef& p : *n) {
-      if (!ObjectTypeChecker<T>::Check(p.get())) {
-        return false;
-      }
-    }
-    return true;
-  }
-  static std::string TypeName() { return "Array[" + ObjectTypeChecker<T>::TypeName() + "]"; }
-};
-
 template <typename K, typename V>
 struct ObjectTypeChecker<Map<K, V>> {
   static Optional<String> CheckAndGetMismatch(const Object* ptr) {

--- a/include/tvm/node/container.h
+++ b/include/tvm/node/container.h
@@ -1457,8 +1457,7 @@ struct ObjectTypeChecker<Array<T>> {
       const ObjectRef& p = (*n)[i];
       Optional<String> check_subtype = ObjectTypeChecker<T>::CheckAndGetMismatch(p.get());
       if (check_subtype.defined()) {
-        return String("Array[index " + std::to_string(i) + ": " + check_subtype.value() +
-                                "]");
+        return String("Array[index " + std::to_string(i) + ": " + check_subtype.value() + "]");
       }
     }
     return NullOpt;

--- a/include/tvm/node/container.h
+++ b/include/tvm/node/container.h
@@ -1451,13 +1451,13 @@ template <typename T>
 struct ObjectTypeChecker<Array<T>> {
   static Optional<String> CheckAndGetMismatch(const Object* ptr) {
     if (ptr == nullptr) return NullOpt;
-    if (!ptr->IsInstance<ArrayNode>()) return Optional<String>(ptr->GetTypeKey());
+    if (!ptr->IsInstance<ArrayNode>()) return String(ptr->GetTypeKey());
     const ArrayNode* n = static_cast<const ArrayNode*>(ptr);
     for (size_t i = 0; i < n->size(); i++) {
       const ObjectRef& p = (*n)[i];
       Optional<String> check_subtype = ObjectTypeChecker<T>::CheckAndGetMismatch(p.get());
       if (check_subtype.defined()) {
-        return Optional<String>("Array[index " + std::to_string(i) + ": " + check_subtype.value() +
+        return String("Array[index " + std::to_string(i) + ": " + check_subtype.value() +
                                 "]");
       }
     }
@@ -1481,7 +1481,7 @@ template <typename K, typename V>
 struct ObjectTypeChecker<Map<K, V>> {
   static Optional<String> CheckAndGetMismatch(const Object* ptr) {
     if (ptr == nullptr) return NullOpt;
-    if (!ptr->IsInstance<MapNode>()) return Optional<String>(ptr->GetTypeKey());
+    if (!ptr->IsInstance<MapNode>()) return String(ptr->GetTypeKey());
     const MapNode* n = static_cast<const MapNode*>(ptr);
     for (const auto& kv : *n) {
       Optional<String> key_type = ObjectTypeChecker<K>::CheckAndGetMismatch(kv.first.get());
@@ -1491,7 +1491,7 @@ struct ObjectTypeChecker<Map<K, V>> {
             key_type.defined() ? std::string(key_type.value()) : ObjectTypeChecker<K>::TypeName();
         std::string value_name = value_type.defined() ? std::string(value_type.value())
                                                       : ObjectTypeChecker<V>::TypeName();
-        return Optional<String>("Map[" + key_name + ", " + value_name + "]");
+        return String("Map[" + key_name + ", " + value_name + "]");
       }
     }
     return NullOpt;

--- a/include/tvm/node/container.h
+++ b/include/tvm/node/container.h
@@ -1455,7 +1455,7 @@ struct ObjectTypeChecker<Array<T>> {
     const ArrayNode* n = static_cast<const ArrayNode*>(ptr);
     for (size_t i = 0; i < n->size(); i++) {
       const ObjectRef& p = (*n)[i];
-      auto check_subtype = ObjectTypeChecker<T>::Check(p.get());
+      auto check_subtype = ObjectTypeChecker<T>::Mismatch(p.get());
       if (static_cast<bool>(check_subtype)) {
         return Optional<String>("Array[index " + std::to_string(i) + ": " + check_subtype.value() +
                                 "]");
@@ -1473,8 +1473,8 @@ struct ObjectTypeChecker<Map<K, V>> {
     if (!ptr->IsInstance<MapNode>()) return Optional<String>(ptr->GetTypeKey());
     const MapNode* n = static_cast<const MapNode*>(ptr);
     for (const auto& kv : *n) {
-      Optional<String> key_type = ObjectTypeChecker<K>::Check(kv.first.get());
-      Optional<String> value_type = ObjectTypeChecker<K>::Check(kv.first.get());
+      Optional<String> key_type = ObjectTypeChecker<K>::Mismatch(kv.first.get());
+      Optional<String> value_type = ObjectTypeChecker<K>::Mismatch(kv.first.get());
       if (static_cast<bool>(key_type) || static_cast<bool>(value_type)) {
         std::string key_name = static_cast<bool>(key_type) ? std::string(key_type.value())
                                                            : ObjectTypeChecker<K>::TypeName();

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -385,7 +385,7 @@ struct ObjectTypeChecker {
    * \return An Optional containing the actual type of the pointer if it does not match the
    *         template type. If the Optional does not contain a value, then the types match.
    */
-  static Optional<String> Mistmatch(const Object* ptr) {
+  static Optional<String> Mismatch(const Object* ptr) {
     using ContainerType = typename T::ContainerType;
     if (ptr == nullptr) {
       if (T::_type_is_nullable) {

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1491,8 +1491,7 @@ inline bool TVMPODValue_::IsObjectRef() const {
   }
   // NOTE: we don't pass NDArray and runtime::Module as RValue ref.
   if (type_code_ == kTVMObjectRValueRefArg) {
-    return
-        ObjectTypeChecker<TObjectRef>::Check(*static_cast<Object**>(value_.v_handle));
+    return ObjectTypeChecker<TObjectRef>::Check(*static_cast<Object**>(value_.v_handle));
   }
   return (std::is_base_of<ContainerType, NDArray::ContainerType>::value &&
           type_code_ == kTVMNDArrayHandle) ||

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -392,13 +392,13 @@ struct ObjectTypeChecker {
       if (T::_type_is_nullable) {
         return NullOpt;
       } else {
-        return Optional<String>("nullptr");
+        return String("nullptr");
       }
     }
     if (ptr->IsInstance<ContainerType>()) {
       return NullOpt;
     } else {
-      return Optional<String>(ptr->GetTypeKey());
+      return String(ptr->GetTypeKey());
     }
   }
   /*!
@@ -406,7 +406,7 @@ struct ObjectTypeChecker {
    * \param ptr The object to check the type of.
    * \return Whether or not the template type matches the objects type.
    */
-  static Optional<String> Check(const Object* ptr) {
+  static bool Check(const Object* ptr) {
     using ContainerType = typename T::ContainerType;
     if (ptr == nullptr) {
       if (T::_type_is_nullable) {
@@ -1492,7 +1492,7 @@ inline bool TVMPODValue_::IsObjectRef() const {
   // NOTE: we don't pass NDArray and runtime::Module as RValue ref.
   if (type_code_ == kTVMObjectRValueRefArg) {
     return
-        ObjectTypeChecker<TObjectRef>::Check(*static_cast<Object**>(value_.v_handle)));
+        ObjectTypeChecker<TObjectRef>::Check(*static_cast<Object**>(value_.v_handle));
   }
   return (std::is_base_of<ContainerType, NDArray::ContainerType>::value &&
           type_code_ == kTVMNDArrayHandle) ||

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -379,10 +379,26 @@ inline const char* ArgTypeCode2Str(int type_code);
  */
 template <typename T>
 struct ObjectTypeChecker {
-  static bool Check(const Object* ptr) {
+  /*!
+   * \brief Check if an object matches the template type.
+   * \param ptr The object to check the type of.
+   * \return An Optional containing the actual type of the pointer if it does not match the
+   *         template type. If the Optional does not contain a value, then the types match.
+   */
+  static Optional<String> Mistmatch(const Object* ptr) {
     using ContainerType = typename T::ContainerType;
-    if (ptr == nullptr) return T::_type_is_nullable;
-    return ptr->IsInstance<ContainerType>();
+    if (ptr == nullptr) {
+      if (T::_type_is_nullable) {
+        return Optional<String>();
+      } else {
+        return Optional<String>("nullptr");
+      }
+    }
+    if (ptr->IsInstance<ContainerType>()) {
+      return Optional<String>();
+    } else {
+      return Optional<String>(ptr->GetTypeKey());
+    }
   }
   static std::string TypeName() {
     using ContainerType = typename T::ContainerType;
@@ -1457,14 +1473,16 @@ inline bool TVMPODValue_::IsObjectRef() const {
   }
   // NOTE: we don't pass NDArray and runtime::Module as RValue ref.
   if (type_code_ == kTVMObjectRValueRefArg) {
-    return ObjectTypeChecker<TObjectRef>::Check(*static_cast<Object**>(value_.v_handle));
+    return !static_cast<bool>(
+        ObjectTypeChecker<TObjectRef>::Mismatch(*static_cast<Object**>(value_.v_handle)));
   }
   return (std::is_base_of<ContainerType, NDArray::ContainerType>::value &&
           type_code_ == kTVMNDArrayHandle) ||
          (std::is_base_of<ContainerType, Module::ContainerType>::value &&
           type_code_ == kTVMModuleHandle) ||
          (type_code_ == kTVMObjectHandle &&
-          ObjectTypeChecker<TObjectRef>::Check(static_cast<Object*>(value_.v_handle)));
+          !static_cast<bool>(
+              ObjectTypeChecker<TObjectRef>::Mismatch(static_cast<Object*>(value_.v_handle))));
 }
 
 template <typename TObjectRef>
@@ -1499,15 +1517,17 @@ inline TObjectRef TVMPODValue_::AsObjectRef() const {
   if (type_code_ == kTVMObjectHandle) {
     // normal object type check.
     Object* ptr = static_cast<Object*>(value_.v_handle);
-    CHECK(ObjectTypeChecker<TObjectRef>::Check(ptr))
-        << "Expected " << ObjectTypeChecker<TObjectRef>::TypeName() << " but got "
-        << ptr->GetTypeKey();
+    auto checked_type = ObjectTypeChecker<TObjectRef>::Mismatch(ptr);
+    CHECK(!static_cast<bool>(checked_type))
+        << "Expected " << ObjectTypeChecker<TObjectRef>::TypeName() << ", but got "
+        << checked_type.value();
     return TObjectRef(GetObjectPtr<Object>(ptr));
   } else if (type_code_ == kTVMObjectRValueRefArg) {
     Object* ptr = *static_cast<Object**>(value_.v_handle);
-    CHECK(ObjectTypeChecker<TObjectRef>::Check(ptr))
-        << "Expected " << ObjectTypeChecker<TObjectRef>::TypeName() << " but got "
-        << ptr->GetTypeKey();
+    auto checked_type = ObjectTypeChecker<TObjectRef>::Mismatch(ptr);
+    CHECK(!static_cast<bool>(checked_type))
+        << "Expected " << ObjectTypeChecker<TObjectRef>::TypeName() << ", but got "
+        << checked_type.value();
     return TObjectRef(GetObjectPtr<Object>(ptr));
   } else if (std::is_base_of<ContainerType, NDArray::ContainerType>::value &&
              type_code_ == kTVMNDArrayHandle) {
@@ -1556,7 +1576,7 @@ template <typename T, typename>
 inline TVMMovableArgValue_::operator T() const {
   if (type_code_ == kTVMObjectRValueRefArg) {
     auto** ref = static_cast<Object**>(value_.v_handle);
-    if (ObjectTypeChecker<T>::Check(*ref)) {
+    if (!static_cast<bool>(ObjectTypeChecker<T>::Mismatch(*ref))) {
       return T(ObjectPtr<Object>::MoveFromRValueRefArg(ref));
     }
   }

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -49,7 +49,7 @@ PrimExpr PrimExpr::FromObject_(ObjectRef ref) {
   if (auto* ptr = ref.as<runtime::StringObj>()) {
     return tir::StringImm(GetRef<runtime::String>(ptr));
   }
-  ICHECK(ObjectTypeChecker<PrimExpr>::Check(ref.get()))
+  ICHECK(!static_cast<bool>(ObjectTypeChecker<PrimExpr>::Mismatch(ref.get())))
       << "Expect type " << ObjectTypeChecker<PrimExpr>::TypeName() << " but get "
       << ref->GetTypeKey();
   return Downcast<PrimExpr>(ref);

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -49,9 +49,9 @@ PrimExpr PrimExpr::FromObject_(ObjectRef ref) {
   if (auto* ptr = ref.as<runtime::StringObj>()) {
     return tir::StringImm(GetRef<runtime::String>(ptr));
   }
-  ICHECK(!static_cast<bool>(ObjectTypeChecker<PrimExpr>::Mismatch(ref.get())))
-      << "Expect type " << ObjectTypeChecker<PrimExpr>::TypeName() << " but get "
-      << ref->GetTypeKey();
+  Optional<String> actual_type = ObjectTypeChecker<PrimExpr>::CheckAndGetMismatch(ref.get());
+  ICHECK(!actual_type.defined()) << "Expected type " << ObjectTypeChecker<PrimExpr>::TypeName()
+                                 << " but got " << actual_type.value();
   return Downcast<PrimExpr>(ref);
 }
 


### PR DESCRIPTION
This PR fixes error messages that arise when a runtime array does not have the correct element types for a function. For example:
```
# before
Check failed: ObjectTypeChecker<TObjectRef>::Check(ptr) == false: Expect Array[Operation] but get Array
# after
Check failed: ObjectTypeChecker<TObjectRef>::Check(ptr) == false: Expect Array[Operation] but get Array[index 0: Tensor]
```

Note that because runtime `Array`s are not homogenous, specific elements can fail the type checking. I've added which element fails to the errors message along with its type. This can also happen for `Map`s, but I could not figure out a good way to print which element mismatches (because the elements are unordered and I worry printing the key may take too much space).

This is a replacement for #7309 that returns the mismatched type when a runtime object cannot be converted.

@jroesch @tqchen @junrushao1994 @rkimball