### PR TITLE
Improve tensor mismatch ICHECK message

### DIFF
--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -47,7 +47,7 @@ PrimExpr Tensor::operator()(Array<Var> indices) const {
 PrimExpr Tensor::operator()(Array<PrimExpr> indices) const {
   if (ndim() != 0) {
     ICHECK_EQ(ndim(), indices.size()) << "Tensor dimension mismatch in read"
-                                      << "ndim = " << ndim() << ", indices.size=" << indices.size();
+                                      << " ndim = " << ndim() << ", indices.size=" << indices.size();
   }
 
   return ProducerLoad((*this), indices);

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -46,8 +46,8 @@ PrimExpr Tensor::operator()(Array<Var> indices) const {
 
 PrimExpr Tensor::operator()(Array<PrimExpr> indices) const {
   if (ndim() != 0) {
-    ICHECK_EQ(ndim(), indices.size()) << "Tensor dimension mismatch in read"
-                                      << " ndim = " << ndim() << ", indices.size=" << indices.size();
+    ICHECK_EQ(ndim(), indices.size()) << "Tensor dimension mismatch in read "
+                                      << "ndim = " << ndim() << ", indices.size=" << indices.size();
   }
 
   return ProducerLoad((*this), indices);


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

The current ICHECK message as below looks a little misleading for `readndim = 1`, as the space right after `read` is missing.

> Check failed: ndim() == indices.size() (1 vs. 0) : Tensor dimension mismatch in readndim = 1, indices.size=0