### PR TITLE
Fix warning showed with GCC10

### DIFF
--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -72,7 +72,7 @@ TEST(IRF, ExprTransform) {
   try {
     f(z - 1, 2);
     LOG(FATAL) << "should fail";
-  } catch (dmlc::Error) {
+  } catch (dmlc::Error&) {
   }
 }
 


### PR DESCRIPTION
catching polymorphic type 'struct dmlc::Error' by value

This will close https://github.com/apache/tvm/issues/7319