### PR TITLE
Add resource_handle to TVM_DLL_EXPORT_TYPED_FUNC.

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -910,9 +910,9 @@ struct PackedFuncValueConverter {
 #define TVM_DLL_EXPORT_PACKED_FUNC(ExportName, Function)                                    \
   extern "C" {                                                                              \
   TVM_DLL int ExportName(TVMValue* args, int* type_code, int num_args, TVMValue* out_value, \
-                         int* out_type_code);                                               \
+                         int* out_type_code, void* resource_handle);                        \
   int ExportName(TVMValue* args, int* type_code, int num_args, TVMValue* out_value,         \
-                 int* out_type_code) {                                                      \
+                 int* out_type_code, void* resource_handle) {                               \
     try {                                                                                   \
       ::tvm::runtime::TVMRetValue rv;                                                       \
       Function(::tvm::runtime::TVMArgs(args, type_code, num_args), &rv);                    \


### PR DESCRIPTION
 * In #5921, resource_handle was added as a parameter to
   TVMBackendPackedCFunc, which is the typedef for functions called by
   LibraryModule's function lookup.
 * It appears TVM_DLL_EXPORT_TYPED_FUNC was overlooked in that PR,
   although there don't seem to be any runtime affects known so
   far. However, making this definition proper to avoid any compiler
   warnings/debug tool problems.
 * See also https://discuss.tvm.apache.org/t/rfc-misra-c-changes-for-rpc-support/7098/9