### PR TITLE
[CMake] use wrong flag name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,9 +375,9 @@ add_library(tvm_objs OBJECT ${COMPILER_SRCS} ${RUNTIME_SRCS})
 add_library(tvm_runtime_objs OBJECT ${RUNTIME_SRCS})
 
 add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs>)
-set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAGS}")
+set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
 add_library(tvm_runtime SHARED $<TARGET_OBJECTS:tvm_runtime_objs>)
-set_property(TARGET tvm_runtime APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAGS}")
+set_property(TARGET tvm_runtime APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
 
 if(USE_MICRO)
   # NOTE: cmake doesn't track dependencies at the file level across subdirectories. For the


### PR DESCRIPTION
assign value to TVM_VISIBILITY_FLAG at L147 but use TVM_VISIBILITY_FLAGS, which add a S postfix
