### PR TITLE
Add resource_handle to both TVM_DLL_EXPORT_TYPED_FUNC and TVM_DLL_EXP…

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -963,7 +963,7 @@ struct PackedFuncValueConverter {
 #define TVM_DLL_EXPORT_TYPED_FUNC(ExportName, Function)                                     \
   extern "C" {                                                                              \
   TVM_DLL int ExportName(TVMValue* args, int* type_code, int num_args, TVMValue* out_value, \
-                         int* out_type_code) {                                              \
+                         int* out_type_code, void* resource_handle) {                       \
     try {                                                                                   \
       auto f = Function;                                                                    \
       using FType = ::tvm::runtime::detail::function_signature<decltype(f)>::FType;         \


### PR DESCRIPTION
…ORT_PACKED_FUNC macros in packed_func.h. This is a patch PR for #7388.
@areusch @tqchen 
