### PR TITLE
[Torch] More graph rewrites for Faster RCNN / MaskRCNN

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2081,12 +2081,6 @@ class PyTorchOpConverter:
         is_float = input_type in ["float32", "float64", "float16", "bfloat16"]
         return _expr.const(is_float)
 
-    def argsort(self, inputs, input_types):
-        data = inputs[0]
-        dim = inputs[1]
-        is_descending = inputs[2]
-        return _op.argsort(data, dim, not is_descending)
-
     # Operator mappings
     def create_convert_map(self):
         self.convert_map = {

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2081,6 +2081,12 @@ class PyTorchOpConverter:
         is_float = input_type in ["float32", "float64", "float16", "bfloat16"]
         return _expr.const(is_float)
 
+    def argsort(self, inputs, input_types):
+        data = inputs[0]
+        dim = inputs[1]
+        is_descending = inputs[2]
+        return _op.argsort(data, dim, not is_descending)
+
     # Operator mappings
     def create_convert_map(self):
         self.convert_map = {

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -281,8 +281,8 @@ class PostNMSTopKRewrite(DFPatternCallback):
 
 
 def scatter_roi_align_result_pattern(levels, rois, per_level_features, scatter_res, num_scales):
-    def do_where(levels, i):
-        idx_in_level = is_op("argwhere")(is_op("equal")(levels, i))
+    def do_where(levels, _):
+        idx_in_level = is_op("argwhere")(is_op("equal")(levels, is_constant()))
         idx_in_level = is_op("split")(idx_in_level)
         idx_in_level = is_tuple_get_item(idx_in_level, 0)
         idx_in_level = is_op("squeeze")(idx_in_level)
@@ -329,7 +329,11 @@ class ScatterRewrite(DFPatternCallback):
         self.pattern = scatter_roi_align_result_pattern(self.levels, self.rois, self.per_level_features, self.scatter_res, num_scales)
 
     def callback(self, pre, post, node_map):
-        print("matched")
+        levels = node_map[self.levels][0]
+        rois = node_map[self.rois][0]
+        scatter_res = node_map[self.scatter_res][0]
+        per_level_features = [node_map[feat] for feat in self.per_level_features]
+
         return pre
 
 

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -313,7 +313,7 @@ def scatter_roi_align_result_pattern(levels, rois, per_level_features, scatter_r
         # res = res.scatter(0, index, unmerged_results[level])
         scatter_res = is_op("scatter")(scatter_res, scatter_indices, result_idx_in_level)
 
-    return scatter_res
+    return is_op("reshape")(scatter_res)
 
 
 class ScatterRewrite(DFPatternCallback):
@@ -326,14 +326,15 @@ class ScatterRewrite(DFPatternCallback):
         for _ in range(num_scales):
             self.per_level_features.append(wildcard())
 
-        self.pattern = scatter_roi_align_result_pattern(self.levels, self.rois, self.per_level_features, self.scatter_res, num_scales)
+        self.pattern = scatter_roi_align_result_pattern(
+            self.levels, self.rois, self.per_level_features, self.scatter_res, num_scales
+        )
 
     def callback(self, pre, post, node_map):
         levels = node_map[self.levels][0]
         rois = node_map[self.rois][0]
         scatter_res = node_map[self.scatter_res][0]
         per_level_features = [node_map[feat] for feat in self.per_level_features]
-
         return pre
 
 

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -343,7 +343,8 @@ class ScatterRewrite(DFPatternCallback):
         argsort_indices = op.cast(op.argsort(indices_concat), dtype="int64")
 
         # Permute rows by argsorted indices
-        return op.adv_index([roi_align_results_concat, argsort_indices])
+        permuted = op.take(roi_align_results_concat, argsort_indices, axis=0)
+        return op.reshape(permuted, [0, -1, 1, 1])
 
     def callback(self, pre, post, node_map):
         levels = node_map[self.levels][0]

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -16,13 +16,16 @@
 # under the License.
 # pylint: disable=import-outside-toplevel, unused-argument, invalid-name
 """ Common utilities used by PyTorch frontend """
+from .. import expr
 from .. import op
 from ..dataflow_pattern import (
+    wildcard,
     is_constant,
     is_op,
     rewrite,
     is_tuple,
-    wildcard,
+    is_tuple_get_item,
+    is_if,
     DFPatternCallback,
 )
 
@@ -34,6 +37,19 @@ def is_version_greater_than(ver):
     return "".join(re.findall(r"(\d+\.)(\d+\.)(\d)", torch.__version__)[0]) > "".join(
         re.findall(r"(\d+\.)(\d+\.)(\d)", ver)[0]
     )
+
+
+def dyn_strided_slice_pattern(inp, end):
+    """A pattern to detect dynamic strided slice op."""
+    zero = is_constant()
+    cast_like = is_op("cast_like")(zero, is_constant())
+    less = is_op("less")(is_constant(), cast_like)
+    shape_of = is_op("shape_of")(inp)
+    cast_like = is_op("cast_like")(shape_of, is_constant())
+    add = is_op("add")(is_constant(), cast_like)
+    where = is_op("where")(less, add, is_constant())
+
+    return is_op("dyn.strided_slice")(inp, where, end, is_constant())
 
 
 def batched_nms_pattern(boxes, scores, idxs, iou_threshold, num_boxes, indices):
@@ -73,7 +89,6 @@ def batched_nms_pattern(boxes, scores, idxs, iou_threshold, num_boxes, indices):
 
     """
     one = is_constant()
-    zero = is_constant()
 
     # Equivelent PyTorch code from above snippet
     # offsets = idxs.to(boxes) * (max_coordinate + torch.tensor(1).to(boxes))
@@ -84,17 +99,10 @@ def batched_nms_pattern(boxes, scores, idxs, iou_threshold, num_boxes, indices):
 
     # The following doesn't appear in the above Relay snippet. It is required for dynamic
     # stride_slice handling
-    cast_like = is_op("cast_like")(zero, is_constant())
-    less = is_op("less")(is_constant(), cast_like)
-    shape_of = is_op("shape_of")(mul)
-    cast_like = is_op("cast_like")(shape_of, is_constant())
-    add = is_op("add")(is_constant(), cast_like)
-    where = is_op("where")(less, add, is_constant())
     shape_of = is_op("shape_of")(mul)
     cast = is_op("cast")(shape_of)
-
     # This corresponds to offsets[:, None], where offsets is the result of multiplication
-    dyn_strided_slice = is_op("dyn.strided_slice")(mul, where, cast, is_constant())
+    dyn_strided_slice = dyn_strided_slice_pattern(mul, cast)
 
     # Add offsets to the boxes
     expand_dims = is_op("expand_dims")(dyn_strided_slice)
@@ -112,8 +120,49 @@ def batched_nms_pattern(boxes, scores, idxs, iou_threshold, num_boxes, indices):
     )
 
 
-class NMSRewrite(DFPatternCallback):
-    """A callback to rewrite nms and restore batched nms"""
+def topk_after_batch_nms_pattern(cond, true_branch, data, valid_count, indices, iou_threshold):
+    """
+    Detect the following pattern used in torchvision detection models.
+
+    def batched_nms(...):
+        if boxes.numel() == 0:
+            return torch.empty((0,), dtype=torch.int64, device=boxes.device)
+        else:
+            ...
+            return nms(boxes_for_nms, scores, iou_threshold)
+
+    keep = batched_nms(boxes, scores, lvl, self.nms_thresh)
+    keep = keep[:post_nms_top_k] # keep only topk scoring predictions
+
+    An equivalent Relay subgraph:
+
+    %1184 = if (%1117) {
+      ...
+    } else {
+      ...
+      %1172 = vision.non_max_suppression(%1167, %1168, %1171, -1, 0.7f, ...);
+      ...
+      %1183 = dyn.strided_slice(%1174, %1180, %1182, ...);
+      cast(%1183, dtype="int64")
+    };
+    %1185 = strided_slice(%1184, begin=[0], end=[1000], strides=[1]);
+
+    """
+    nms = is_op("vision.non_max_suppression")(
+        data, valid_count, indices, is_constant(), iou_threshold
+    )
+    indices = is_op("squeeze")(is_tuple_get_item(nms, 0))
+    size = is_op("squeeze")(is_tuple_get_item(nms, 1))
+    dyn_strided_slice = dyn_strided_slice_pattern(indices, size)
+    cast_i64 = is_op("cast")(dyn_strided_slice)
+
+    batched_nms_result = is_if(cond, true_branch, cast_i64)
+
+    return is_op("strided_slice")(batched_nms_result)
+
+
+class MulticlassNMSRewrite(DFPatternCallback):
+    """A callback to rewrite nms and restore batched nms."""
 
     def __init__(self):
         super().__init__()
@@ -169,10 +218,80 @@ class NMSRewrite(DFPatternCallback):
         return self.convert_batched_nms(boxes, scores, idxs, iou_thres, num_boxes, indices)
 
 
+class PostNMSTopKRewrite(DFPatternCallback):
+    """A callback to rewrite nms to exploit max_out_size parameter."""
+
+    def __init__(self):
+        super().__init__()
+        self.cond = wildcard()
+        self.true_branch = wildcard()
+        self.data = wildcard()
+        self.valid_count = wildcard()
+        self.indices = wildcard()
+        self.iou_threshold = wildcard()
+
+        self.pattern = topk_after_batch_nms_pattern(
+            self.cond,
+            self.true_branch,
+            self.data,
+            self.valid_count,
+            self.indices,
+            self.iou_threshold,
+        )
+
+    def rewrite_batch_nms_with_max_out_size(
+        self, cond, true_branch, data, valid_count, indices, iou_threshold, post_nms_topk
+    ):
+        """Use the detected post NMS topk parameter in NMS op."""
+        nms_ret = op.vision.non_max_suppression(
+            data=data,
+            valid_count=valid_count,
+            indices=indices,
+            max_output_size=post_nms_topk,
+            iou_threshold=iou_threshold,
+            force_suppress=False,
+            top_k=-1,
+            coord_start=2,
+            score_index=1,
+            id_index=0,
+            return_indices=True,
+            invalid_to_bottom=False,
+        )
+
+        size = op.squeeze(nms_ret[1], axis=[1])
+        data_slice = op.squeeze(nms_ret[0], axis=[0])
+
+        ret = op.strided_slice(data_slice, begin=expr.const([0]), end=size, slice_mode="size")
+
+        nms_result = op.cast(ret, "int64")
+
+        return expr.If(cond, true_branch, nms_result)
+
+    def callback(self, pre, post, node_map):
+        post_nms_topk = post.attrs.end[0].value
+        return self.rewrite_batch_nms_with_max_out_size(
+            node_map[self.cond][0],
+            node_map[self.true_branch][0],
+            node_map[self.data][0],
+            node_map[self.valid_count][0],
+            node_map[self.indices][0],
+            node_map[self.iou_threshold][0],
+            post_nms_topk,
+        )
+
+
 def rewrite_nms_to_batched_nms(mod):
     """Rewrite the input graph to replace non maximum surpression
     in torchvision that does not take class id into account with the one
     that avoids IOU tests between different classes.
     """
-    mod["main"] = rewrite(NMSRewrite(), mod["main"])
+    mod["main"] = rewrite(MulticlassNMSRewrite(), mod["main"])
+    return mod
+
+
+def rewrite_batched_nms_with_max_out_size(mod):
+    """Rewrite the input graph to detect slicing after batched nms and
+    use the slicing size as the parameter max_out_size in NMS.
+    """
+    mod["main"] = rewrite(PostNMSTopKRewrite(), mod["main"])
     return mod

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -26,7 +26,10 @@ import tvm
 import tvm.testing
 from tvm import relay
 from tvm.runtime.vm import VirtualMachine
-from tvm.relay.frontend.pytorch_utils import rewrite_nms_to_batched_nms
+from tvm.relay.frontend.pytorch_utils import (
+    rewrite_nms_to_batched_nms,
+    rewrite_batched_nms_with_max_out_size,
+)
 from tvm.contrib.download import download
 
 
@@ -72,7 +75,7 @@ def generate_jit_model(index):
     ]
 
     model_func = model_funcs[index]
-    model = TraceWrapper(model_func(pretrained=True, rpn_pre_nms_top_n_test=200))
+    model = TraceWrapper(model_func(pretrained=True, rpn_pre_nms_top_n_test=1000))
 
     model.eval()
     inp = torch.Tensor(np.random.uniform(0.0, 250.0, size=(1, 3, in_size, in_size)))
@@ -138,6 +141,11 @@ def test_detection_models():
 
     before = mod["main"]
     mod = rewrite_nms_to_batched_nms(mod)
+    after = mod["main"]
+    assert not tvm.ir.structural_equal(after, before)
+
+    before = mod["main"]
+    mod = rewrite_batched_nms_with_max_out_size(mod)
     after = mod["main"]
     assert not tvm.ir.structural_equal(after, before)
 

--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -29,6 +29,7 @@ from tvm.runtime.vm import VirtualMachine
 from tvm.relay.frontend.pytorch_utils import (
     rewrite_nms_to_batched_nms,
     rewrite_batched_nms_with_max_out_size,
+    rewrite_scatter_to_gather,
 )
 from tvm.contrib.download import download
 
@@ -146,6 +147,11 @@ def test_detection_models():
 
     before = mod["main"]
     mod = rewrite_batched_nms_with_max_out_size(mod)
+    after = mod["main"]
+    assert not tvm.ir.structural_equal(after, before)
+
+    before = mod["main"]
+    mod = rewrite_scatter_to_gather(mod, 4)  # num_scales is 4 for maskrcnn_resnet50_fpn
     after = mod["main"]
     assert not tvm.ir.structural_equal(after, before)
 


### PR DESCRIPTION
This PR adds two new graph rewrite to optimize Faster RCNN / MaskRCNN. Happy to split them into two PRs if preferred.

The first one is to exploit the fact that in PyTorch detection models, NMS is always followed by post NMS topk, as shown below.

https://github.com/pytorch/vision/blob/8ebfd2f5d5f1792ce2cf5a2329320f604530a68e/torchvision/models/detection/rpn.py#L272-L275

We can extract that topk parameter and use it as `max_out_size` parameter in our NMS. This brings a good speed up 4.51 milli sec -> 4.11 milli sec, and further speed up is easily expected if we had TIR while loop (cc @tqchen)

The second is to replace the repeated scatter loop in

https://github.com/pytorch/vision/blob/6315358dd06e3a2bcbe9c1e8cdaa10898ac2b308/torchvision/ops/poolers.py#L20-L29

with something like this:
```
indices_per_level = []
for level in range(num_scales):
    idx_in_level = torch.where(levels == level)[0]
    indices_per_level.append(idx_in_level)

stacked_features = torch.cat(roi_align_results, dim=0)
stacked_indices = torch.cat(indices_per_level, dim=0)
argsort_indices = torch.argort(stacked_indices)
return stacked_features[argsort_indices, :]
```
i.e., we are able to remove `torch.zeros` (which turns out very expensive, due to too much `any_dim` generated by Relay) and repeated 4D scatters (which is slow because scatters cannot be parallelized well). Instead, we can do concat, argsort, and batched gather to get equivalent result, which is much more efficient. This transformation is not at all obvious, I think this is a great example of the power of graph rewrite. It cuts more than 10 milli seconds from MaskRCNN / FasterRCNN.

Unfortunately I expect this PR is hard to review, let me know if you have any questions. I tried to give detailed comments to aid understanding. 

This concludes the series of PRs I did to optimize MaskRCNN on GPU + VM, here is the current numbers. Surprisingly, NVPTX generates much better code for the dynamic injective ops, which is one of the bottlenecks in MaskRCNN due to a certain limitation in Relay + TE (too many unnecessary `any_dim` generated). I hope we can discuss this performance result further in the forum.  

```
TVM result is obtained after auto scheduling. In MaskRCNN, there are some dynamic batch 
conv2d and conv2d transpose that cannot be tuned and hence extremely slow. 

cublas is always required to get reasonable result, since there is one big dynamic dense op
that is extremely slow with the default schedule. 

GTX 1070 ti, on an input (1, 3, 300, 300)

Faster RCNN
Torch: 0.0738 sec
TVM with cuda target + cublas: 0.0712 sec
TVM with nvptx target + cublas: 0.0708 sec

MaskRCNN
Torch: 0.115 sec
TVM with cuda target + cublas: 0.166 sec
TVM with nvptx target + cublas: 0.135 sec
```
please review @zhiics @kevinthesun @mbrookhart @jwfromm @anijain2305 @trevor-m 