### PR TITLE
[uTVM] fix missing memory runtime lib

### DIFF
--- a/python/tvm/micro/build.py
+++ b/python/tvm/micro/build.py
@@ -52,7 +52,7 @@ class Workspace:
 
 
 # Required C runtime libraries, in link order.
-CRT_RUNTIME_LIB_NAMES = ["utvm_rpc_server", "utvm_rpc_common", "common"]
+CRT_RUNTIME_LIB_NAMES = ["utvm_rpc_server", "utvm_rpc_common", "common", "memory"]
 
 
 TVM_ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))


### PR DESCRIPTION
memory.c was split off into its separate directory, but it was not added here

@areusch @tqchen 
