### PR TITLE
[BYOC][Verilator] change runtime registry function name

### DIFF
--- a/src/relay/backend/contrib/verilator/codegen.cc
+++ b/src/relay/backend/contrib/verilator/codegen.cc
@@ -115,7 +115,7 @@ runtime::Module VerilatorCompiler(const ObjectRef& ref) {
 
   auto lib_name = cfg.value()->lib;
 
-  const auto* pf = runtime::Registry::Get("runtime.VerilatorJSONRuntimeCreate");
+  const auto* pf = runtime::Registry::Get("runtime.verilator_runtime_create");
   CHECK(pf != nullptr) << "Cannot find JSON runtime module to create";
   auto mod = (*pf)(lib_name, func_name, graph_json, params);
   return mod;

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -154,7 +154,7 @@ runtime::Module VerilatorJSONRuntimeCreate(String lib_name, String symbol_name, 
   return runtime::Module(n);
 }
 
-TVM_REGISTER_GLOBAL("runtime.VerilatorJSONRuntimeCreate")
+TVM_REGISTER_GLOBAL("runtime.verilator_runtime_create")
     .set_body_typed(VerilatorJSONRuntimeCreate);
 
 TVM_REGISTER_GLOBAL("runtime.module.loadbinary_verilator_json")

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -154,8 +154,7 @@ runtime::Module VerilatorJSONRuntimeCreate(String lib_name, String symbol_name, 
   return runtime::Module(n);
 }
 
-TVM_REGISTER_GLOBAL("runtime.verilator_runtime_create")
-    .set_body_typed(VerilatorJSONRuntimeCreate);
+TVM_REGISTER_GLOBAL("runtime.verilator_runtime_create").set_body_typed(VerilatorJSONRuntimeCreate);
 
 TVM_REGISTER_GLOBAL("runtime.module.loadbinary_verilator_json")
     .set_body_typed(JSONRuntimeBase::LoadFromBinary<VerilatorJSONRuntime>);

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -143,7 +143,7 @@ class VerilatorJSONRuntime : public JSONRuntimeBase {
   VerilatorHandle device_{nullptr};
   /* The verilator library handle. */
   VerilatorLibrary* lib_{nullptr};
-  /* The verilator add function handle */
+  /* The verilator vadd function handle. */
   VerilatorAddFunc vadd_func_{nullptr};
 };
 


### PR DESCRIPTION
I think snake case is more common throughout the codebase than camel case for registering functions

@tmoreau89 @liangfu 