### PR TITLE
[Relay][PatternLang] Fuzzy Function Matching

### DIFF
--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -730,7 +730,8 @@ class PatternGrouper {
           auto node = matcher_->expr_graph_.node_map_.at(kv.first);
           for (auto* output : node->outputs_) {
             // and the node is used by nodes outside of the group
-            if (memo.count(output->ref_) == 0) {
+            if (memo.count(output->ref_) == 0 &&
+                !matcher_->expr_graph_.node_map_.at(expr)->Dominates(output)) {
               // Exit because nodes in this pattern's body are used outside the pattern
               // fusing it would be invalid
               return;

--- a/src/relay/ir/indexed_graph.h
+++ b/src/relay/ir/indexed_graph.h
@@ -27,6 +27,7 @@
 #include <tvm/relay/dataflow_pattern.h>
 
 #include <memory>
+#include <stack>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -74,6 +75,27 @@ class IndexedGraph {
     Node* dominator_parent_;
     /*! \brief The nodes this node dominates */
     std::vector<Node*> dominator_children_;
+
+    bool Dominates(const Node* other) {
+      std::stack<const Node*> stack;
+      std::unordered_set<const Node*> visited;
+      stack.push(this);
+      while (!stack.empty()) {
+        const Node* current = stack.top();
+        stack.pop();
+        for (auto node : current->dominator_children_) {
+          if (visited.count(node) == 0) {
+            if (other == node) {
+              return true;
+            } else {
+              stack.push(node);
+            }
+            visited.insert(node);
+          }
+        }
+      }
+      return false;
+    }
   };
   /*! \brief Construct the domination tree inside IndexedGraph */
   void PostDom() {


### PR DESCRIPTION
@comaniac @masahi 

I recently ran into a situation where I needed to match based on a function signature, but not necessarily on the function body. To support that, I made some changes to the pattern matcher to allow matching and rewriting functions as long as everything in the match is completely dominated by the pattern.

This works for rewriting, but I haven't been able to get the partitioner to work properly on these tests, so I added a unit test but skipped it with a TODO.

What do you guys think?