### PR TITLE
[TVMC] Fix PyTorch support

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -49,7 +49,12 @@ def add_tune_parser(subparsers):
         type=int,
         help="minimum number of trials before early stopping",
     )
-
+    parser.add_argument(
+        "--input-shape",
+        type=common.parse_input_shapes,
+        metavar="INPUT_SHAPE,[INPUT_SHAPE]...",
+        help="for PyTorch, e.g. '(1,3,224,224)'",
+    )
     # There is some extra processing required to define the actual default value
     # for --min-repeat-ms. This is done in `drive_tune`.
     parser.add_argument(
@@ -235,7 +240,7 @@ def drive_tune(args):
             )
 
     target = common.target_from_cli(args.target)
-    mod, params = frontends.load_model(args.FILE, args.model_format)
+    mod, params = frontends.load_model(args.FILE, args.model_format, args.input_shape)
 
     # min_repeat_ms should be:
     # a. the value provided by the user, if any, or

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -60,6 +60,12 @@ def add_compile_parser(subparsers):
         help="comma separarated list of formats to export, e.g. 'asm,ll,relay' ",
     )
     parser.add_argument(
+        "--input-shape",
+        type=common.parse_input_shapes,
+        metavar="INPUT_SHAPE,[INPUT_SHAPE]...",
+        help="for PyTorch, e.g. '(1,3,224,224)'",
+    )
+    parser.add_argument(
         "--model-format",
         choices=frontends.get_frontend_names(),
         help="specify input model format",
@@ -108,6 +114,7 @@ def drive_compile(args):
         args.FILE,
         args.target,
         args.dump_code,
+        args.input_shape,
         None,
         args.model_format,
         args.tuning_records,
@@ -125,6 +132,7 @@ def compile_model(
     path,
     target,
     dump_code=None,
+    input_shape=None,
     target_host=None,
     model_format=None,
     tuning_records=None,
@@ -146,6 +154,8 @@ def compile_model(
     dump_code : list, optional
         Dump the generated code for the specified source types, on
         the requested target.
+    input_shape : list, optional
+        Shape of the input tensor for PyTorch models
     target_host : str, optional
         The target of the host machine if host-side code
         needs to be generated.
@@ -172,7 +182,7 @@ def compile_model(
 
     """
     dump_code = [x.strip() for x in dump_code.split(",")] if dump_code else None
-    mod, params = frontends.load_model(path, model_format)
+    mod, params = frontends.load_model(path, model_format, input_shape)
 
     if alter_layout:
         mod = common.convert_graph_layout(mod, alter_layout)

--- a/tests/python/driver/tvmc/test_common.py
+++ b/tests/python/driver/tvmc/test_common.py
@@ -149,3 +149,31 @@ def test_tracker_host_port_from_cli__only_hostname__default_port_is_9090():
 
     assert expected_host == actual_host
     assert expected_port == actual_port
+
+
+def test_parse_input_shapes__no_numbers():
+    input_str = "(a,b,c,d)"
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_input_shapes(input_str)
+
+
+def test_parse_input_shapes__no_brackets():
+    input_str = "1, 3, 224, 224"
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_input_shapes(input_str)
+
+
+def test_parse_input_shapes__bad_input():
+    input_str = "[1, 3, 224, 224]"
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_input_shapes(input_str)
+
+
+def test_parse_input_shapes__turn_into_list():
+    input_str = "(1, 3, 224, 224),(1,4)"
+    output_str = tvmc.common.parse_input_shapes(input_str)
+
+    assert output_str == [[1, 3, 224, 224], [1, 4]]

--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -179,4 +179,24 @@ def test_load_model___wrong_language__to_pytorch(tflite_mobilenet_v1_1_quant):
     pytest.importorskip("torch")
 
     with pytest.raises(RuntimeError) as e:
-        tvmc.frontends.load_model(tflite_mobilenet_v1_1_quant, model_format="pytorch")
+        tvmc.frontends.load_model(
+            tflite_mobilenet_v1_1_quant, model_format="pytorch", input_shape=[[1, 3, 224, 224]]
+        )
+
+
+def test_load_model__pytorch__no_inputs():
+    # some CI environments wont offer pytorch, so skip in case it is not present
+    pytest.importorskip("torch")
+
+    with pytest.raises(TVMCException):
+        tvmc.frontends.load_model("a_model.pth", model_format="pytorch", input_shape=None)
+
+
+def test_load_model__tflite__with_inputs():
+    # some CI environments wont offer pytorch, so skip in case it is not present
+    pytest.importorskip("tflite")
+
+    with pytest.raises(TVMCException):
+        tvmc.frontends.load_model(
+            "a_model.tflite", model_format="tflite", input_shape=[[1, 3, 224, 224]]
+        )


### PR DESCRIPTION
A PyTorch model could not be compiled through tvmc because the shape
of the input tensor could not be deduced from the model after it has been
saved. We've added an --input-shape parameter to tvmc compile and
tvmc tune that allows the inputs to be specified for PyTorch models.

