### PR TITLE
[TVMC] Allow manual shape specification in tvmc

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -212,8 +212,8 @@ def add_tune_parser(subparsers):
     parser.add_argument("FILE", help="path to the input model file")
     parser.add_argument(
         "--input-shapes",
-        help="specify non-generic shapes for model to run, format is"
-        "name:num1xnum2x...xnumN,name2:num1xnum2xnum3",
+        help="specify non-generic shapes for model to run, format is "
+        '"input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]"',
         type=common.parse_shape_string,
         default=None,
     )
@@ -242,7 +242,7 @@ def drive_tune(args):
             )
 
     target = common.target_from_cli(args.target)
-    mod, params = frontends.load_model(args.FILE, args.model_format, shape_dict=args.shapes)
+    mod, params = frontends.load_model(args.FILE, args.model_format, shape_dict=args.input_shapes)
 
     # min_repeat_ms should be:
     # a. the value provided by the user, if any, or

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -211,7 +211,7 @@ def add_tune_parser(subparsers):
     #     or URL, for example.
     parser.add_argument("FILE", help="path to the input model file")
     parser.add_argument(
-        "--shapes",
+        "--input-shapes",
         help="specify non-generic shapes for model to run, format is"
         "name:num1xnum2x...xnumN,name2:num1xnum2xnum3",
         type=common.parse_shape_string,

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -210,6 +210,13 @@ def add_tune_parser(subparsers):
     #     can be improved in future to add integration with a modelzoo
     #     or URL, for example.
     parser.add_argument("FILE", help="path to the input model file")
+    parser.add_argument(
+        "--shapes",
+        help="specify non-generic shapes for model to run, format is"
+        "name:num1xnum2x...xnumN,name2:num1xnum2xnum3",
+        type=common.parse_shape_string,
+        default=None,
+    )
 
 
 def drive_tune(args):
@@ -235,7 +242,7 @@ def drive_tune(args):
             )
 
     target = common.target_from_cli(args.target)
-    mod, params = frontends.load_model(args.FILE, args.model_format)
+    mod, params = frontends.load_model(args.FILE, args.model_format, shape_dict=args.shapes)
 
     # min_repeat_ms should be:
     # a. the value provided by the user, if any, or

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -161,16 +161,16 @@ def parse_shape_string(inputs_string):
     if not input_mappings:
         raise argparse.ArgumentTypeError(
             "--input-shapes argument must be of the form "
-            "\"input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]\""
+            '"input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]"'
         )
     shape_dict = {}
     for mapping in input_mappings:
         # Remove whitespace.
         mapping = mapping.replace(" ", "")
         # Split mapping into name and shape.
-        name, shape_string = mapping.split(':')
+        name, shape_string = mapping.split(":")
         # Convert shape string into a list of integers or Anys if negative.
-        shape = [int(x) if int(x) > 0 else relay.Any() for x in shape_string.strip('][').split(',')]
+        shape = [int(x) if int(x) > 0 else relay.Any() for x in shape_string.strip("][").split(",")]
         # Add parsed mapping to shape dictionary.
         shape_dict[name] = shape
 

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -146,8 +146,8 @@ def parse_shape_string(inputs_string):
     Parameters
     ----------
     inputs_string: str
-        A string of the form "input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]" that indicates
-        the desired shape for specific model inputs.
+        A string of the form "input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]" that 
+        indicates the desired shape for specific model inputs.
 
     Returns
     -------

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -146,7 +146,7 @@ def parse_shape_string(inputs_string):
     Parameters
     ----------
     inputs_string: str
-        A string of the form "input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]" that 
+        A string of the form "input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]" that
         indicates the desired shape for specific model inputs.
 
     Returns

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -146,7 +146,7 @@ def parse_shape_string(inputs_string):
     Parameters
     ----------
     inputs_string: str
-        A string of the form "name:num1xnum2x...xnumN,name2:num1xnum2xnum3" that indicates
+        A string of the form "input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]" that indicates
         the desired shape for specific model inputs.
 
     Returns
@@ -161,16 +161,16 @@ def parse_shape_string(inputs_string):
     if not input_mappings:
         raise argparse.ArgumentTypeError(
             "--input-shapes argument must be of the form "
-            '"input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]"'
+            "\"input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]\""
         )
     shape_dict = {}
     for mapping in input_mappings:
         # Remove whitespace.
         mapping = mapping.replace(" ", "")
         # Split mapping into name and shape.
-        name, shape_string = mapping.split(":")
+        name, shape_string = mapping.split(':')
         # Convert shape string into a list of integers or Anys if negative.
-        shape = [int(x) if int(x) > 0 else relay.Any() for x in shape_string.strip("][").split(",")]
+        shape = [int(x) if int(x) > 0 else relay.Any() for x in shape_string.strip('][').split(',')]
         # Add parsed mapping to shape dictionary.
         shape_dict[name] = shape
 

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -36,41 +36,6 @@ from .main import register_parser
 logger = logging.getLogger("TVMC")
 
 
-def parse_shape(inputs):
-    """Parse an input shape dictionary string to a usable dictionary.
-
-    Parameters
-    ----------
-    inputs: str
-        A string of the form "name:num1xnum2x...xnumN,name2:num1xnum2xnum3" that indicates
-        the desired shape for specific model inputs.
-
-    Returns
-    -------
-    shape_dict: dict
-        A dictionary mapping input names to their shape for use in relay frontend converters.
-    """
-    d = {}
-    # Break apart each specific input string
-    inputs = inputs.split(",")
-    for string in inputs:
-        # Split name from shape string.
-        string = string.split(":")
-        shapelist = []
-        # Separate each dimension in the shape.
-        string[1] = string[1].split("x")
-        # Parse each dimension into an integer.
-        for x in string[1]:
-            x = int(x)
-            # Negative numbers are converted to dynamic axes.
-            if x < 0:
-                x = relay.Any()
-            shapelist.append(x)
-        # Assign dictionary key value pair.
-        d[string[0]] = shapelist
-    return d
-
-
 @register_parser
 def add_compile_parser(subparsers):
     """ Include parser for 'compile' subcommand """
@@ -126,7 +91,7 @@ def add_compile_parser(subparsers):
         "--shapes",
         help="specify non-generic shapes for model to run, format is"
         "name:num1xnum2x...xnumN,name2:num1xnum2xnum3",
-        type=parse_shape,
+        type=common.parse_shape_string,
         default=None,
     )
 

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -89,8 +89,8 @@ def add_compile_parser(subparsers):
     parser.add_argument("FILE", help="path to the input model file")
     parser.add_argument(
         "--input-shapes",
-        help="specify non-generic shapes for model to run, format is"
-        "name:num1xnum2x...xnumN,name2:num1xnum2xnum3",
+        help="specify non-generic shapes for model to run, format is "
+        '"input_name:[dim1,dim2,...,dimn] input_name2:[dim1,dim2]"',
         type=common.parse_shape_string,
         default=None,
     )
@@ -119,7 +119,7 @@ def drive_compile(args):
         args.model_format,
         args.tuning_records,
         args.desired_layout,
-        args.shapes,
+        args.input_shapes,
     )
 
     if dumps:

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -104,7 +104,8 @@ def add_compile_parser(subparsers):
     parser.add_argument("FILE", help="path to the input model file")
     parser.add_argument(
         "--shapes",
-        help="",
+        help="specify non-generic shapes for model to run, format is"
+        "name:num1xnum2xnum3,name2:num1xnum2xnum3",
         type=parse_shape,
         default=None,
     )

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -88,7 +88,7 @@ def add_compile_parser(subparsers):
     #     or URL, for example.
     parser.add_argument("FILE", help="path to the input model file")
     parser.add_argument(
-        "--shapes",
+        "--input-shapes",
         help="specify non-generic shapes for model to run, format is"
         "name:num1xnum2x...xnumN,name2:num1xnum2xnum3",
         type=common.parse_shape_string,
@@ -168,8 +168,8 @@ def compile_model(
         pass doesn't currently guarantee the whole of the graph will
         be converted to the chosen layout.
     shape_dict: dict, optional
-        A mapping between input names and their shape. This is useful
-        to override the default values in a model if needed.
+        A mapping from input names to their shape. When present,
+        the default shapes in the model will be overwritten.
 
     Returns
     -------

--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -54,13 +54,15 @@ class Frontend(ABC):
         """File suffixes (extensions) used by this frontend"""
 
     @abstractmethod
-    def load(self, path):
+    def load(self, path, shape_dict=None):
         """Load a model from a given path.
 
         Parameters
         ----------
         path: str
             Path to a file
+        shape_dict: dict, optional
+            A dictionary mapping input names to shapes.
 
         Returns
         -------
@@ -99,7 +101,7 @@ class KerasFrontend(Frontend):
     def suffixes():
         return ["h5"]
 
-    def load(self, path):
+    def load(self, path, shape_dict=None):
         # pylint: disable=C0103
         tf, keras = import_keras()
 
@@ -125,8 +127,10 @@ class KerasFrontend(Frontend):
                 )
 
         inputs = [np.random.uniform(size=shape, low=-1.0, high=1.0) for shape in in_shapes]
-        shape_dict = {name: x.shape for (name, x) in zip(model.input_names, inputs)}
-        return relay.frontend.from_keras(model, shape_dict, layout="NHWC")
+        input_shapes = {name: x.shape for (name, x) in zip(model.input_names, inputs)}
+        if shape_dict is not None:
+            input_shapes.update(shape_dict)
+        return relay.frontend.from_keras(model, input_shapes, layout="NHWC")
 
     def is_sequential_p(self, model):
         _, keras = import_keras()
@@ -154,14 +158,14 @@ class OnnxFrontend(Frontend):
     def suffixes():
         return ["onnx"]
 
-    def load(self, path):
+    def load(self, path, shape_dict = None):
         # pylint: disable=C0415
         import onnx
 
         # pylint: disable=E1101
         model = onnx.load(path)
 
-        return relay.frontend.from_onnx(model)
+        return relay.frontend.from_onnx(model, shape = shape_dict)
 
 
 class TensorflowFrontend(Frontend):
@@ -175,7 +179,7 @@ class TensorflowFrontend(Frontend):
     def suffixes():
         return ["pb"]
 
-    def load(self, path):
+    def load(self, path, shape_dict=None):
         # pylint: disable=C0415
         import tensorflow as tf
         import tvm.relay.testing.tf as tf_testing
@@ -188,7 +192,7 @@ class TensorflowFrontend(Frontend):
         graph_def = tf_testing.ProcessGraphDefParam(graph_def)
 
         logger.debug("parse TensorFlow model and convert into Relay computation graph")
-        return relay.frontend.from_tensorflow(graph_def)
+        return relay.frontend.from_tensorflow(graph_def, shape=shape_dict)
 
 
 class TFLiteFrontend(Frontend):
@@ -215,7 +219,7 @@ class TFLiteFrontend(Frontend):
     def suffixes():
         return ["tflite"]
 
-    def load(self, path):
+    def load(self, path, shape_dict=None):
         # pylint: disable=C0415
         import tflite.Model as model
 
@@ -238,11 +242,13 @@ class TFLiteFrontend(Frontend):
             raise TVMCException("input file not tflite version 3")
 
         logger.debug("tflite_input_type")
-        shape_dict, dtype_dict = TFLiteFrontend._input_type(tflite_model)
+        input_shapes, dtype_dict = TFLiteFrontend._input_type(tflite_model)
+        if shape_dict is not None:
+            input_shapes.update(shape_dict)
 
         logger.debug("parse TFLite model and convert into Relay computation graph")
         mod, params = relay.frontend.from_tflite(
-            tflite_model, shape_dict=shape_dict, dtype_dict=dtype_dict
+            tflite_model, shape_dict=input_shapes, dtype_dict=dtype_dict
         )
         return mod, params
 
@@ -285,7 +291,7 @@ class PyTorchFrontend(Frontend):
         # Torch Script is a zip file, but can be named pth
         return ["pth", "zip"]
 
-    def load(self, path):
+    def load(self, path, shape_dict=None):
         # pylint: disable=C0415
         import torch
 
@@ -296,6 +302,15 @@ class PyTorchFrontend(Frontend):
 
         traced_model.eval()  # Switch to inference mode
         input_shapes = [("input{}".format(idx), shape) for idx, shape in enumerate(shapes)]
+
+        # Update input shapes with manual override and prevent duplication.
+        if shape_dict is not None:
+            input_shape_dict = {}
+            for name, shape in input_shapes:
+                input_shape_dict[name] = shape
+            input_shape_dict.update(shape_dict)
+            # Convert back to list for torch importer.
+            input_shapes = list(input_shape_dict.items())
 
         logger.debug("parse Torch model and convert into Relay computation graph")
         return relay.frontend.from_pytorch(traced_model, input_shapes)
@@ -378,7 +393,7 @@ def guess_frontend(path):
     raise TVMCException("failed to infer the model format. Please specify --model-format")
 
 
-def load_model(path, model_format=None):
+def load_model(path, model_format=None, shape_dict = None):
     """Load a model from a supported framework and convert it
     into an equivalent relay representation.
 
@@ -389,6 +404,8 @@ def load_model(path, model_format=None):
     model_format : str, optional
         The underlying framework used to create the model.
         If not specified, this will be inferred from the file type.
+    shape_dict : dict, optional
+        A mapping between input names and their desired shape.
 
     Returns
     -------
@@ -404,6 +421,6 @@ def load_model(path, model_format=None):
     else:
         frontend = guess_frontend(path)
 
-    mod, params = frontend.load(path)
+    mod, params = frontend.load(path, shape_dict)
 
     return mod, params

--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -295,11 +295,11 @@ class PyTorchFrontend(Frontend):
         # pylint: disable=C0415
         import torch
 
-        traced_model = torch.jit.load(path)
-        traced_model.eval()  # Switch to inference mode
-
         if shape_dict is None:
             raise TVMCException("--input-shapes must be specified for %s" % self.name())
+
+        traced_model = torch.jit.load(path)
+        traced_model.eval()  # Switch to inference mode
 
         # Convert shape dictionary to list for Pytorch frontend compatibility
         input_shapes = list(shape_dict.items())

--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -158,14 +158,14 @@ class OnnxFrontend(Frontend):
     def suffixes():
         return ["onnx"]
 
-    def load(self, path, shape_dict = None):
+    def load(self, path, shape_dict=None):
         # pylint: disable=C0415
         import onnx
 
         # pylint: disable=E1101
         model = onnx.load(path)
 
-        return relay.frontend.from_onnx(model, shape = shape_dict)
+        return relay.frontend.from_onnx(model, shape=shape_dict)
 
 
 class TensorflowFrontend(Frontend):
@@ -393,7 +393,7 @@ def guess_frontend(path):
     raise TVMCException("failed to infer the model format. Please specify --model-format")
 
 
-def load_model(path, model_format=None, shape_dict = None):
+def load_model(path, model_format=None, shape_dict=None):
     """Load a model from a supported framework and convert it
     into an equivalent relay representation.
 

--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -62,7 +62,7 @@ class Frontend(ABC):
         path: str
             Path to a file
         shape_dict: dict, optional
-            A dictionary mapping input names to shapes.
+            Mapping from input names to their shapes.
 
         Returns
         -------
@@ -299,7 +299,7 @@ class PyTorchFrontend(Frontend):
         traced_model.eval()  # Switch to inference mode
 
         if shape_dict is None:
-            raise TVMCException("--shapes must be specified for {}".format(self.name()))
+            raise TVMCException("--input-shapes must be specified for %s" % self.name())
 
         # Convert shape dictionary to list for Pytorch frontend compatibility
         input_shapes = list(shape_dict.items())
@@ -397,7 +397,7 @@ def load_model(path, model_format=None, shape_dict=None):
         The underlying framework used to create the model.
         If not specified, this will be inferred from the file type.
     shape_dict : dict, optional
-        A mapping between input names and their desired shape.
+        Mapping from input names to their shapes.
 
     Returns
     -------

--- a/tests/python/driver/tvmc/conftest.py
+++ b/tests/python/driver/tvmc/conftest.py
@@ -100,6 +100,23 @@ def keras_resnet50(tmpdir_factory):
 
 
 @pytest.fixture(scope="session")
+def pytorch_resnet18(tmpdir_factory):
+    try:
+        import torch
+        import torchvision.models as models
+    except ImportError:
+        # Not all environments provide Pytorch, so skip if that's the case.
+        return ""
+    model = models.resnet18()
+    model_file_name = "{}/{}".format(tmpdir_factory.mktemp("data"), "resnet18.pth")
+    # Trace model into torchscript.
+    traced_cpu = torch.jit.trace(model, torch.randn(1, 3, 224, 224))
+    torch.jit.save(traced_cpu, model_file_name)
+
+    return model_file_name
+
+
+@pytest.fixture(scope="session")
 def onnx_resnet50():
     base_url = "https://github.com/onnx/models/raw/master/vision/classification/resnet/model"
     file_to_download = "resnet50-v2-7.onnx"

--- a/tests/python/driver/tvmc/test_common.py
+++ b/tests/python/driver/tvmc/test_common.py
@@ -21,6 +21,7 @@ from os import path
 import pytest
 
 import tvm
+from tvm import relay
 from tvm.driver import tvmc
 
 
@@ -164,6 +165,11 @@ def test_shape_parser():
     shape_string = "input:10X10X10, input2:20X20X20X20"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     assert shape_dict == {"input": [10, 10, 10], "input2": [20, 20, 20, 20]}
+    # Check that negative dimensions parse to Any correctly.
+    shape_string = "input:-1x3x224x224"
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    # Convert to strings to allow comparison with Any.
+    assert str(shape_dict) == "{'input': [?, 3, 224, 224]}"
 
     # Check that invalid pattern raises expected error.
     shape_string = "input:ax10"

--- a/tests/python/driver/tvmc/test_common.py
+++ b/tests/python/driver/tvmc/test_common.py
@@ -149,3 +149,27 @@ def test_tracker_host_port_from_cli__only_hostname__default_port_is_9090():
 
     assert expected_host == actual_host
     assert expected_port == actual_port
+
+
+def test_shape_parser():
+    # Check that a valid input is parsed correctly
+    shape_string = "input:10x10x10"
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    assert shape_dict == {"input": [10, 10, 10]}
+    # Check that multiple valid input shapes are parse correctly
+    shape_string = "input:10x10x10,input2:20x20x20x20"
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    assert shape_dict == {"input": [10, 10, 10], "input2": [20, 20, 20, 20]}
+    # Check that alternate syntax parses correctly
+    shape_string = "input:10X10X10, input2:20X20X20X20"
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    assert shape_dict == {"input": [10, 10, 10], "input2": [20, 20, 20, 20]}
+
+    # Check that invalid pattern raises expected error.
+    shape_string = "input:ax10"
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_shape_string(shape_string)
+    # Check that input with invalid separators raises error.
+    shape_string = "input:5,10 input2:10,10"
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_shape_string(shape_string)

--- a/tests/python/driver/tvmc/test_common.py
+++ b/tests/python/driver/tvmc/test_common.py
@@ -154,25 +154,28 @@ def test_tracker_host_port_from_cli__only_hostname__default_port_is_9090():
 
 def test_shape_parser():
     # Check that a valid input is parsed correctly
-    shape_string = "input:10x10x10"
+    shape_string = "input:[10,10,10]"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     assert shape_dict == {"input": [10, 10, 10]}
     # Check that multiple valid input shapes are parse correctly
-    shape_string = "input:10x10x10,input2:20x20x20x20"
+    shape_string = "input:[10,10,10] input2:[20,20,20,20]"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     assert shape_dict == {"input": [10, 10, 10], "input2": [20, 20, 20, 20]}
     # Check that alternate syntax parses correctly
-    shape_string = "input:10X10X10, input2:20X20X20X20"
+    shape_string = "input: [10, 10, 10] input2: [20, 20, 20, 20]"
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    assert shape_dict == {"input": [10, 10, 10], "input2": [20, 20, 20, 20]}
+    shape_string = "input:[10,10,10],input2:[20,20,20,20]"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     assert shape_dict == {"input": [10, 10, 10], "input2": [20, 20, 20, 20]}
     # Check that negative dimensions parse to Any correctly.
-    shape_string = "input:-1x3x224x224"
+    shape_string = "input:[-1,3,224,224]"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     # Convert to strings to allow comparison with Any.
     assert str(shape_dict) == "{'input': [?, 3, 224, 224]}"
 
     # Check that invalid pattern raises expected error.
-    shape_string = "input:ax10"
+    shape_string = "input:[a,10]"
     with pytest.raises(argparse.ArgumentTypeError):
         tvmc.common.parse_shape_string(shape_string)
     # Check that input with invalid separators raises error.

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -54,6 +54,8 @@ def verify_compile_tflite_module(model, shape_dict=None):
 
 
 def test_compile_tflite_module(tflite_mobilenet_v1_1_quant):
+    # some CI environments wont offer flute, so skip in case it is not present
+    pytest.importorskip("tflite")
     # Check default compilation.
     verify_compile_tflite_module(tflite_mobilenet_v1_1_quant)
     # Check with manual shape override

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -43,11 +43,7 @@ def verify_compile_tflite_module(model, shape_dict=None):
     pytest.importorskip("tflite")
 
     graph, lib, params, dumps = tvmc.compiler.compile_model(
-        model,
-        target="llvm",
-        dump_code="ll",
-        alter_layout="NCHW",
-        shape_dict=shape_dict
+        model, target="llvm", dump_code="ll", alter_layout="NCHW", shape_dict=shape_dict
     )
 
     # check for output types
@@ -64,6 +60,7 @@ def test_compile_tflite_module(tflite_mobilenet_v1_1_quant):
     shape_string = "input:1x224x224x3"
     shape_dict = tvmc.compiler.parse_shape(shape_string)
     verify_compile_onnx_module(tflite_mobilenet_v1_1_quant, shape_dict)
+
 
 # This test will be skipped if the AArch64 cross-compilation toolchain is not installed.
 @pytest.mark.skipif(

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -58,8 +58,8 @@ def test_compile_tflite_module(tflite_mobilenet_v1_1_quant):
     verify_compile_tflite_module(tflite_mobilenet_v1_1_quant)
     # Check with manual shape override
     shape_string = "input:1x224x224x3"
-    shape_dict = tvmc.compiler.parse_shape(shape_string)
-    verify_compile_onnx_module(tflite_mobilenet_v1_1_quant, shape_dict)
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    verify_compile_tflite_module(tflite_mobilenet_v1_1_quant, shape_dict)
 
 
 # This test will be skipped if the AArch64 cross-compilation toolchain is not installed.
@@ -141,7 +141,7 @@ def test_compile_onnx_module(onnx_resnet50):
     verify_compile_onnx_module(onnx_resnet50)
     # Test with manual shape dict
     shape_string = "data:1x3x200x200"
-    shape_dict = tvmc.compiler.parse_shape(shape_string)
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
     verify_compile_onnx_module(onnx_resnet50, shape_dict)
 
 

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -54,12 +54,12 @@ def verify_compile_tflite_module(model, shape_dict=None):
 
 
 def test_compile_tflite_module(tflite_mobilenet_v1_1_quant):
-    # some CI environments wont offer flute, so skip in case it is not present
+    # some CI environments wont offer tflite, so skip in case it is not present
     pytest.importorskip("tflite")
     # Check default compilation.
     verify_compile_tflite_module(tflite_mobilenet_v1_1_quant)
     # Check with manual shape override
-    shape_string = "input:1x224x224x3"
+    shape_string = "input:[1,224,224,3]"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     verify_compile_tflite_module(tflite_mobilenet_v1_1_quant, shape_dict)
 
@@ -142,7 +142,7 @@ def test_compile_onnx_module(onnx_resnet50):
     # Test default compilation
     verify_compile_onnx_module(onnx_resnet50)
     # Test with manual shape dict
-    shape_string = "data:1x3x200x200"
+    shape_string = "data:[1,3,200,200]"
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     verify_compile_onnx_module(onnx_resnet50, shape_dict)
 

--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -174,9 +174,26 @@ def test_load_model___wrong_language__to_onnx(tflite_mobilenet_v1_1_quant):
         tvmc.frontends.load_model(tflite_mobilenet_v1_1_quant, model_format="onnx")
 
 
+def test_load_model__pth(pytorch_resnet18):
+    # some CI environments wont offer torch, so skip in case it is not present
+    pytest.importorskip("torch")
+
+    mod, params = tvmc.frontends.load_model(
+        pytorch_resnet18, shape_dict={"input": [1, 3, 224, 224]}
+    )
+    assert type(mod) is IRModule
+    assert type(params) is dict
+    # check whether one known value is part of the params dict
+    assert "layer1.0.conv1.weight" in params.keys()
+
+
 def test_load_model___wrong_language__to_pytorch(tflite_mobilenet_v1_1_quant):
     # some CI environments wont offer pytorch, so skip in case it is not present
     pytest.importorskip("torch")
 
     with pytest.raises(RuntimeError) as e:
-        tvmc.frontends.load_model(tflite_mobilenet_v1_1_quant, model_format="pytorch")
+        tvmc.frontends.load_model(
+            tflite_mobilenet_v1_1_quant,
+            model_format="pytorch",
+            shape_dict={"input": [1, 3, 224, 224]},
+        )

--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -177,6 +177,7 @@ def test_load_model___wrong_language__to_onnx(tflite_mobilenet_v1_1_quant):
 def test_load_model__pth(pytorch_resnet18):
     # some CI environments wont offer torch, so skip in case it is not present
     pytest.importorskip("torch")
+    pytest.importorskip("torchvision")
 
     mod, params = tvmc.frontends.load_model(
         pytorch_resnet18, shape_dict={"input": [1, 3, 224, 224]}

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -20,9 +20,9 @@
 set +u
 
 if [[ ! -z $CI_PYTEST_ADD_OPTIONS ]]; then
-    export PYTEST_ADDOPTS="-v $CI_PYTEST_ADD_OPTIONS $PYTEST_ADDOPTS"
+    export PYTEST_ADDOPTS="-s -v $CI_PYTEST_ADD_OPTIONS $PYTEST_ADDOPTS"
 else
-    export PYTEST_ADDOPTS="-v $PYTEST_ADDOPTS"
+    export PYTEST_ADDOPTS="-s -v $PYTEST_ADDOPTS"
 fi
 set -u
 


### PR DESCRIPTION
Currently tvmc does not allow users to overriding specific shapes (such as batch sizes) and instead uses what is defined within the model file. In most cases this is most practical, but in there are some cases that would benefit from additional flexibility i.e. undefined shape sizes, fiddling with batch sizes. This PR adds support for manually specifying input shapes. :) 