### PR TITLE
Refactor Dynamic to Static

### DIFF
--- a/src/relay/transforms/dynamic_to_static.cc
+++ b/src/relay/transforms/dynamic_to_static.cc
@@ -52,7 +52,11 @@ Expr PrepareInput(const Expr& expr) {
 std::vector<Expr> PrepareArgs(const CallNode* call_node) {
   std::vector<Expr> args;
   for (auto arg : call_node->args) {
-    args.emplace_back(PrepareInput(arg));
+    if (arg.as<ConstantNode>()) {
+      args.emplace_back(arg);
+    } else {
+      args.emplace_back(PrepareInput(arg));
+    }
   }
   return args;
 }

--- a/tests/python/relay/test_pass_dynamic_to_static.py
+++ b/tests/python/relay/test_pass_dynamic_to_static.py
@@ -232,11 +232,10 @@ def test_dynamic_to_static_zeros_ones():
 
             func = run_infer_type(relay.Function([x], y))
             func2 = run_opt_pass(
-                run_opt_pass(func, transform.DynamicToStatic()), transform.InferType()
+                run_opt_pass(func, transform.DynamicToStatic()), transform.InferType(),
             )
 
             zz = func2.body
-            assert isinstance(zz, relay.Constant)
             assert zz.checked_type == relay.ty.TensorType(shape, dtype)
 
             x_data = np.random.uniform(low=1, high=1, size=shape)

--- a/tests/python/relay/test_pass_dynamic_to_static.py
+++ b/tests/python/relay/test_pass_dynamic_to_static.py
@@ -232,7 +232,8 @@ def test_dynamic_to_static_zeros_ones():
 
             func = run_infer_type(relay.Function([x], y))
             func2 = run_opt_pass(
-                run_opt_pass(func, transform.DynamicToStatic()), transform.InferType(),
+                run_opt_pass(func, transform.DynamicToStatic()),
+                transform.InferType(),
             )
 
             zz = func2.body
@@ -515,6 +516,46 @@ def test_dyn_to_static_sparse_to_dense():
         [0, 1, 4], [3.1, 3.1, 3.1], 3.5, [5], [3.1, 3.1, 3.5, 3.5, 3.1]
     )  # floats
     verify_sparse_to_dense(1, 3, None, [5], [0, 3, 0, 0, 0])  # default value not specified
+
+
+@tvm.testing.uses_gpu
+def test_dynamic_to_static_dynamic_rank():
+    def verify_full(fill_value, fill_shape, dtype):
+        x = relay.var("x", relay.scalar_type(dtype))
+        y = relay.var("y", relay.TensorType(fill_shape, "int64"))
+        shape = relay.shape_of(y)
+        shape = relay.strided_slice(shape, [0], relay.shape_of(shape))
+        z = relay.full(x, shape, dtype)
+
+        func = relay.Function([x, y], z)
+        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+
+        zz = func2.body
+        assert isinstance(zz, relay.Call)
+        assert zz.op == relay.op.get("full")
+
+        ref_res = np.full(fill_shape, fill_value).astype(dtype)
+        y_data = np.random.uniform(low=-1, high=1, size=fill_shape).astype("int64")
+        verify_func(func2, [fill_value, y_data], ref_res)
+
+    verify_full(4, (1, 2, 3, 4), "int32")
+    verify_full(4.0, (1, 2, 8, 10), "float32")
+
+
+@tvm.testing.uses_gpu
+def test_dynamic_to_static_dynamic_if():
+    x = relay.var("x", relay.TensorType((2, 2), "int64"))
+    cond = relay.const(1)
+    iff = relay.If(cond, relay.reshape(x, [1, 4]), relay.reshape(x, (4, 1)))
+
+    func = relay.Function([x], iff)
+    func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+
+    zz = func2.body
+    assert isinstance(zz, relay.Call)
+    assert zz.op == relay.op.get("reshape")
+    x_data = np.random.uniform(low=-1, high=1, size=(2, 2)).astype("int64")
+    verify_func(func2, [x_data], x_data.reshape(1, 4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I recently spent a lot of time fighting dynamic rank issues in a kind of crazy ONNX model. Fixing it required doing incremental dynamic-to-static before type inference. This PR basically changes the logic of dynamic to static from this:

```
infer type on the whole function
constant fold the whole function
then go find dynamic ops who's inputs are constant
    replace them with static ops
Rinse and repeat
```

to this:
```
go find dynamic ops
    infer type and constant fold their inputs
    If the inputs are now constant, replace them with static ops
```

This has the advantage that it can analyze those crazy dynamic rank and control flow graphs and simplify them, but it has the disadvantage that it's slower than the previous version because we call infertype and constant folding many more times.

Performance checking shows that this takes a BERT compile from ~15 seconds to ~60 seconds. This should be fixable when incremental type inference becomes available.

Thanks,
Matthew

cc @masahi @jroesch @tmoreau89 @jwfromm @electriclilies 