### PR TITLE
[TEST] Another attempt to fix flaky segfaults from torch detection test 

### DIFF
--- a/tests/python/frontend/pytorch/test_object_detection.py
+++ b/tests/python/frontend/pytorch/test_object_detection.py
@@ -122,7 +122,7 @@ def test_detection_models():
         vm.set_input("main", **{input_name: data_np})
         return vm.run()
 
-    for target in ["cuda", "llvm"]:
+    for target in ["llvm"]:
         tvm_res = compile_and_run_vm(mod, params, data_np, target)
 
         # Bounding boxes
@@ -145,10 +145,12 @@ def test_detection_models():
     after = mod["main"]
     assert not tvm.ir.structural_equal(after, before)
 
-    before = mod["main"]
-    mod = rewrite_batched_nms_with_max_out_size(mod)
-    after = mod["main"]
-    assert not tvm.ir.structural_equal(after, before)
+    # TODO(masahi): It seems this rewrite causes flaky segfaults on CI
+    # See https://github.com/apache/tvm/issues/7363
+    # before = mod["main"]
+    # mod = rewrite_batched_nms_with_max_out_size(mod)
+    # after = mod["main"]
+    # assert not tvm.ir.structural_equal(after, before)
 
     before = mod["main"]
     mod = rewrite_scatter_to_gather(mod, 4)  # num_scales is 4 for maskrcnn_resnet50_fpn


### PR DESCRIPTION
See https://github.com/apache/tvm/issues/7363. The change in https://github.com/apache/tvm/pull/7365 didn't seem to fix the segfaults, so this is the other alternative for fix. I cannot reproduce this problem locally but it is quite frequent at the post-merge CI https://ci.tlcpack.ai/job/tvm/job/main/ (but not on CIs for open PRs, for some reason)

I restored the disabled rewrite in https://github.com/apache/tvm/pull/7365 and disable the other one. I can also disable both of them, to completely nuke changes from #7346 in the test.

@tqchen @zhiics 