### PR TITLE
[Relay][Passes] Iterative A-normal Traversals

### DIFF
--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -476,6 +476,10 @@ void ExpandDataflow(Expr expr, FCheckVisited fcheck_visited, FVisitLeaf fvisit_l
     }
   }
 }
+
+void ExpandANormalForm(const LetNode* op, std::function<void(const LetNode*)> pre_visit,
+                       std::function<void(const LetNode*)> post_visit);
+
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_EXPR_FUNCTOR_H_

--- a/src/relay/analysis/util.cc
+++ b/src/relay/analysis/util.cc
@@ -142,25 +142,15 @@ class TypeVarEVisitor : private MixedModeVisitor {
   }
 
   void VisitExpr_(const LetNode* op) final {
-    std::stack<const LetNode*> stack;
-    stack.push(op);
-    bool is_anormal = true;
-    while (is_anormal) {
-      const LetNode* current_op = stack.top();
-      VisitExpr(current_op->var);
-      VisitExpr(current_op->value);
-      if (const LetNode* new_op = current_op->body.as<LetNode>()) {
-        stack.push(new_op);
-      } else {
-        is_anormal = false;
-      }
-    }
-    while (stack.size()) {
-      const LetNode* current_op = stack.top();
-      stack.pop();
-      VisitExpr(current_op->body);
-      visit_counter_[current_op] += 1;
-    }
+    auto pre_visit = [this](const LetNode* op) {
+      this->VisitExpr(op->var);
+      this->VisitExpr(op->value);
+    };
+    auto post_visit = [this](const LetNode* op) {
+      this->VisitExpr(op->body);
+      this->visit_counter_[op] += 1;
+    };
+    ExpandANormalForm(op, pre_visit, post_visit);
   }
 
   void VisitExpr_(const ConstructorNode* cn) final {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -532,5 +532,27 @@ TVM_REGISTER_GLOBAL("relay.ir.Bind").set_body([](TVMArgs args, TVMRetValue* ret)
     *ret = Bind(Downcast<Type>(input), args[1]);
   }
 });
+
+void ExpandANormalForm(const LetNode* op, std::function<void(const LetNode*)> pre_visit,
+                       std::function<void(const LetNode*)> post_visit) {
+  std::stack<const LetNode*> stack;
+  stack.push(op);
+  bool is_anormal = true;
+  while (is_anormal) {
+    const LetNode* current_op = stack.top();
+    pre_visit(current_op);
+    if (const LetNode* new_op = current_op->body.as<LetNode>()) {
+      stack.push(new_op);
+    } else {
+      is_anormal = false;
+    }
+  }
+  while (stack.size()) {
+    const LetNode* current_op = stack.top();
+    stack.pop();
+    post_visit(current_op);
+  }
+}
+
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/transforms/de_duplicate.cc
+++ b/src/relay/transforms/de_duplicate.cc
@@ -66,13 +66,14 @@ Expr DeDup(const Expr& e) {
       std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> new_vars;
       auto pre_visit = [this, &new_vars](const LetNode* op) {
         Expr expr = GetRef<Expr>(op);
-        new_vars[expr] = Fresh(op->var);
+        new_vars[expr] = this->Fresh(op->var);
         // Rely on the Memoizer to cache pre-visit values
-        VisitExpr(op->value);
+        this->VisitExpr(op->value);
       };
       auto post_visit = [this, &new_vars](const LetNode* op) {
         Expr expr = GetRef<Expr>(op);
-        memo_[expr] = Let(new_vars[expr], VisitExpr(op->value), VisitExpr(op->body));
+        this->memo_[expr] =
+            Let(new_vars[expr], this->VisitExpr(op->value), this->VisitExpr(op->body));
       };
       ExpandANormalForm(op, pre_visit, post_visit);
       return memo_[GetRef<Expr>(op)];

--- a/src/relay/transforms/fold_constant.cc
+++ b/src/relay/transforms/fold_constant.cc
@@ -96,7 +96,7 @@ class ConstantFolder : public MixedModeMutator {
       // Rely on the Memoizer to cache pre-visit values
       Expr value = this->Mutate(op->value);
       if (value.as<ConstantNode>()) {
-        memo_[op->var] = value;
+        this->memo_[op->var] = value;
       } else {
         this->Mutate(op->var);
       }
@@ -106,14 +106,14 @@ class ConstantFolder : public MixedModeMutator {
       // Rely on the Memoizer to cache pre-visit values
       Expr value = this->Mutate(op->value);
       if (value.as<ConstantNode>()) {
-        memo_[expr] = this->Mutate(op->body);
+        this->memo_[expr] = this->Mutate(op->body);
       } else {
         Var var = Downcast<Var>(this->Mutate(op->var));
         Expr body = this->Mutate(op->body);
         if (var.same_as(op->var) && value.same_as(op->value) && body.same_as(op->body)) {
-          memo_[expr] = expr;
+          this->memo_[expr] = expr;
         } else {
-          memo_[expr] = Let(var, value, body);
+          this->memo_[expr] = Let(var, value, body);
         }
       }
     };

--- a/src/relay/transforms/fold_constant.cc
+++ b/src/relay/transforms/fold_constant.cc
@@ -92,19 +92,48 @@ class ConstantFolder : public MixedModeMutator {
   using MixedModeMutator::VisitExpr_;
 
   Expr VisitExpr_(const LetNode* op) final {
-    Expr value = this->Mutate(op->value);
-    if (value.as<ConstantNode>()) {
-      memo_[op->var] = value;
-      return this->Mutate(op->body);
-    } else {
-      Var var = Downcast<Var>(this->Mutate(op->var));
-      Expr body = this->Mutate(op->body);
-      if (var.same_as(op->var) && value.same_as(op->value) && body.same_as(op->body)) {
-        return GetRef<Expr>(op);
+    std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> new_vars;
+    std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> new_values;
+    std::stack<const LetNode*> stack;
+    stack.push(op);
+    bool is_anormal = true;
+    while (is_anormal) {
+      const LetNode* current_op = stack.top();
+      Expr current_expr = GetRef<Expr>(current_op);
+
+      Expr value = this->Mutate(current_op->value);
+      new_values[current_expr] = value;
+      if (value.as<ConstantNode>()) {
+        memo_[current_op->var] = value;
       } else {
-        return Let(var, value, body);
+        new_vars[current_expr] = Downcast<Var>(this->Mutate(current_op->var));
+      }
+
+      if (const LetNode* new_op = current_op->body.as<LetNode>()) {
+        stack.push(new_op);
+      } else {
+        is_anormal = false;
       }
     }
+    while (stack.size()) {
+      const LetNode* current_op = stack.top();
+      Expr current_expr = GetRef<Expr>(current_op);
+      stack.pop();
+      Expr value = new_values[current_expr];
+      if (value.as<ConstantNode>()) {
+        memo_[current_expr] = this->Mutate(current_op->body);
+      } else {
+        Var var = new_vars[current_expr];
+        Expr body = this->Mutate(current_op->body);
+        if (var.same_as(current_op->var) && value.same_as(current_op->value) &&
+            body.same_as(current_op->body)) {
+          memo_[current_expr] = current_expr;
+        } else {
+          memo_[current_expr] = Let(var, value, body);
+        }
+      }
+    }
+    return memo_[GetRef<Expr>(op)];
   }
 
   bool inside_primitive = false;

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -832,6 +832,8 @@ class FuseMutator : private MixedModeMutator {
   }
 
  private:
+  using MixedModeMutator::VisitExpr_;
+
   /*! \brief Temporary information from each group. */
   struct GroupInfo {
    public:

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -320,12 +320,12 @@ class IndexedForwardGraph::Creator : private ExprVisitor {
       this->Update(op->var, nullptr, kOpaque);
       this->Update(op->value, nullptr, kOpaque);
       this->Update(op->body, nullptr, kOpaque);
-      VisitExpr(op->var);
-      VisitExpr(op->value);
+      this->VisitExpr(op->var);
+      this->VisitExpr(op->value);
     };
     auto post_visit = [this](const LetNode* op) {
-      VisitExpr(op->body);
-      visit_counter_[op] += 1;
+      this->VisitExpr(op->body);
+      this->visit_counter_[op] += 1;
       this->AddNode(op);
     };
     ExpandANormalForm(op, pre_visit, post_visit);
@@ -932,15 +932,15 @@ class FuseMutator : private MixedModeMutator {
     };
     auto post_visit = [this](const LetNode* op) {
       // Rely on the Memoizer to cache pre-visit values
-      Var var = Downcast<Var>(VisitExpr(op->var));
-      Expr value = VisitExpr(op->value);
+      Var var = Downcast<Var>(this->VisitExpr(op->var));
+      Expr value = this->VisitExpr(op->value);
       // Visit body and cache the op
-      Expr body = VisitExpr(op->body);
+      Expr body = this->VisitExpr(op->body);
       auto expr = GetRef<Expr>(op);
       if (var.same_as(op->var) && value.same_as(op->value) && body.same_as(op->body)) {
-        memo_[expr] = expr;
+        this->memo_[expr] = expr;
       } else {
-        memo_[expr] = Let(var, value, body);
+        this->memo_[expr] = Let(var, value, body);
       }
     };
     ExpandANormalForm(op, pre_visit, post_visit);

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -341,46 +341,33 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
   Type VisitExpr_(const OpNode* op) final { return op->op_type; }
 
   Type VisitExpr_(const LetNode* let) final {
-    std::stack<const LetNode*> stack;
-    stack.push(let);
-    bool is_anormal = true;
-    while (is_anormal) {
-      const LetNode* current_op = stack.top();
-      const Expr current_expr = GetRef<Expr>(current_op);
+    auto pre_visit = [this](const LetNode* op) {
       // if the definition is a function literal, permit recursion
-      bool is_functional_literal = current_op->value.as<FunctionNode>() != nullptr;
+      bool is_functional_literal = op->value.as<FunctionNode>() != nullptr;
       Type let_type = IncompleteType(Kind::kType);
 
       if (is_functional_literal) {
-        let_type = GetType(current_op->var);
-        type_map_[current_op->var].checked_type = let_type;
+        let_type = GetType(op->var);
+        type_map_[op->var].checked_type = let_type;
       }
 
-      if (current_op->var->type_annotation.defined()) {
-        let_type = Unify(let_type, current_op->var->type_annotation, current_op->span);
+      if (op->var->type_annotation.defined()) {
+        let_type = Unify(let_type, op->var->type_annotation, op->span);
       }
 
-      Type vtype = GetType(current_op->value);
-      let_type = Unify(let_type, vtype, current_op->span);
+      Type vtype = GetType(op->value);
+      let_type = Unify(let_type, vtype, op->span);
 
-      ICHECK(is_functional_literal || !type_map_.count(current_op->var));
+      ICHECK(is_functional_literal || !type_map_.count(op->var));
       // NOTE: no scoping is necessary because var are unique in program
-      type_map_[current_op->var].checked_type = let_type;
-
-      if (const LetNode* new_op = current_op->body.as<LetNode>()) {
-        stack.push(new_op);
-      } else {
-        is_anormal = false;
-      }
-    }
-    while (stack.size()) {
-      const LetNode* current_op = stack.top();
-      Expr current_expr = GetRef<Expr>(current_op);
-      stack.pop();
-      memo_[current_expr] = GetType(current_op->body);
-      type_map_[current_expr].checked_type = memo_[current_expr];
-    }
-
+      type_map_[op->var].checked_type = let_type;
+    };
+    auto post_visit = [this](const LetNode* op) {
+      Expr expr = GetRef<Expr>(op);
+      memo_[expr] = GetType(op->body);
+      type_map_[expr].checked_type = memo_[expr];
+    };
+    ExpandANormalForm(let, pre_visit, post_visit);
     return memo_[GetRef<Expr>(let)];
   }
 
@@ -625,32 +612,18 @@ class TypeInferencer::Resolver : public MixedModeMutator, PatternMutator {
   Expr Rewrite_(const CallNode* op, const Expr& post) final { return AttachCheckedType(op, post); }
 
   Expr VisitExpr_(const LetNode* op) final {
-    std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> new_vars;
-    std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> new_values;
-    std::stack<const LetNode*> stack;
-    stack.push(op);
-    bool is_anormal = true;
-    while (is_anormal) {
-      const LetNode* current_op = stack.top();
-      const Expr current_expr = GetRef<Expr>(current_op);
-      new_vars[current_expr] = Downcast<Var>(VisitExpr(current_op->var));
-      new_values[current_expr] = VisitExpr(current_op->value);
-      if (const LetNode* new_op = current_op->body.as<LetNode>()) {
-        stack.push(new_op);
-      } else {
-        is_anormal = false;
-      }
-    }
-    while (stack.size()) {
-      const LetNode* current_op = stack.top();
-      Expr current_expr = GetRef<Expr>(current_op);
-      stack.pop();
-      Var var = new_vars[current_expr];
-      Expr value = new_values[current_expr];
-      Expr body = VisitExpr(current_op->body);
-      memo_[current_expr] = AttachCheckedType(current_op, Let(var, value, body));
-    }
-
+    auto pre_visit = [this](const LetNode* op) {
+      this->VisitExpr(op->var);
+      this->VisitExpr(op->value);
+    };
+    auto post_visit = [this](const LetNode* op) {
+      Expr expr = GetRef<Expr>(op);
+      Var var = Downcast<Var>(VisitExpr(op->var));
+      Expr value = VisitExpr(op->value);
+      Expr body = VisitExpr(op->body);
+      memo_[expr] = AttachCheckedType(op, Let(var, value, body));
+    };
+    ExpandANormalForm(op, pre_visit, post_visit);
     return memo_[GetRef<Expr>(op)];
   }
 
@@ -802,25 +775,15 @@ struct AllCheckTypePopulated : MixedModeVisitor {
     return ExprVisitor::VisitExpr(e);
   }
   void VisitExpr_(const LetNode* op) final {
-    std::stack<const LetNode*> stack;
-    stack.push(op);
-    bool is_anormal = true;
-    while (is_anormal) {
-      const LetNode* current_op = stack.top();
-      VisitExpr(current_op->var);
-      VisitExpr(current_op->value);
-      if (const LetNode* new_op = current_op->body.as<LetNode>()) {
-        stack.push(new_op);
-      } else {
-        is_anormal = false;
-      }
-    }
-    while (stack.size()) {
-      const LetNode* current_op = stack.top();
-      stack.pop();
-      VisitExpr(current_op->body);
-      visit_counter_[current_op] += 1;
-    }
+    auto pre_visit = [this](const LetNode* op) {
+      this->VisitExpr(op->var);
+      this->VisitExpr(op->value);
+    };
+    auto post_visit = [this](const LetNode* op) {
+      this->VisitExpr(op->body);
+      this->visit_counter_[op] += 1;
+    };
+    ExpandANormalForm(op, pre_visit, post_visit);
   }
 };
 

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -787,6 +787,7 @@ Expr TypeInferencer::Infer(GlobalVar var, Function function) {
 }
 
 struct AllCheckTypePopulated : MixedModeVisitor {
+  using MixedModeVisitor::VisitExpr_;
   void DispatchExprVisit(const Expr& e) {
     if (e.as<OpNode>()) {
       return;

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -347,25 +347,25 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
       Type let_type = IncompleteType(Kind::kType);
 
       if (is_functional_literal) {
-        let_type = GetType(op->var);
-        type_map_[op->var].checked_type = let_type;
+        let_type = this->GetType(op->var);
+        this->type_map_[op->var].checked_type = let_type;
       }
 
       if (op->var->type_annotation.defined()) {
-        let_type = Unify(let_type, op->var->type_annotation, op->span);
+        let_type = this->Unify(let_type, op->var->type_annotation, op->span);
       }
 
-      Type vtype = GetType(op->value);
-      let_type = Unify(let_type, vtype, op->span);
+      Type vtype = this->GetType(op->value);
+      let_type = this->Unify(let_type, vtype, op->span);
 
-      ICHECK(is_functional_literal || !type_map_.count(op->var));
+      ICHECK(is_functional_literal || !this->type_map_.count(op->var));
       // NOTE: no scoping is necessary because var are unique in program
-      type_map_[op->var].checked_type = let_type;
+      this->type_map_[op->var].checked_type = let_type;
     };
     auto post_visit = [this](const LetNode* op) {
       Expr expr = GetRef<Expr>(op);
-      memo_[expr] = GetType(op->body);
-      type_map_[expr].checked_type = memo_[expr];
+      this->memo_[expr] = this->GetType(op->body);
+      this->type_map_[expr].checked_type = this->memo_[expr];
     };
     ExpandANormalForm(let, pre_visit, post_visit);
     return memo_[GetRef<Expr>(let)];
@@ -618,10 +618,10 @@ class TypeInferencer::Resolver : public MixedModeMutator, PatternMutator {
     };
     auto post_visit = [this](const LetNode* op) {
       Expr expr = GetRef<Expr>(op);
-      Var var = Downcast<Var>(VisitExpr(op->var));
-      Expr value = VisitExpr(op->value);
-      Expr body = VisitExpr(op->body);
-      memo_[expr] = AttachCheckedType(op, Let(var, value, body));
+      Var var = Downcast<Var>(this->VisitExpr(op->var));
+      Expr value = this->VisitExpr(op->value);
+      Expr body = this->VisitExpr(op->body);
+      this->memo_[expr] = this->AttachCheckedType(op, Let(var, value, body));
     };
     ExpandANormalForm(op, pre_visit, post_visit);
     return memo_[GetRef<Expr>(op)];


### PR DESCRIPTION
On very large models, we can have ASTs that stack overflow because we recursively traverse tens of thousands of chained Let nodes. In A-normal form, we can simply iterate over that chain instead.

These changes find every pass that segfaults with a stack overflow in ONNX SSD-Mobilenet (~20k nodes) and hijacks the visitor to do iterative traversals over chains of lets. This lets me run that model without setting `ulimit -s unlimited` by significantly reducing the stack size.

I also needed to convert FuseOps to mixed mode.

Thanks!

cc @jroesch @tqchen @tristan-arm @altanh @zhiics @masahi @kevinthesun 