### PR TITLE
Fix missing round(), floor(), ceil() for target C lowering

### DIFF
--- a/src/target/intrin_rule.cc
+++ b/src/target/intrin_rule.cc
@@ -77,6 +77,12 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.ldexp").set_body(DispatchPureExtern
 
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.sqrt").set_body(DispatchPureExtern<FloatSuffix>);
 
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.floor").set_body(DispatchPureExtern<FloatSuffix>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.ceil").set_body(DispatchPureExtern<FloatSuffix>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.round").set_body(DispatchPureExtern<FloatSuffix>);
+
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.rsqrt")
     .set_body([](const TVMArgs& args, TVMRetValue* rv) {
       PrimExpr e = args[0];

--- a/tests/python/unittest/test_target_codegen_c_host.py
+++ b/tests/python/unittest/test_target_codegen_c_host.py
@@ -30,12 +30,12 @@ def test_add():
     s = te.create_schedule(C.op)
 
     def check_c():
-        mhost = tvm.build(s, [A, B, C], "c", name="fadd")
+        mhost = tvm.build(s, [A, B, C], "c", name="test_fadd")
         temp = utils.tempdir()
         path_dso = temp.relpath("temp.so")
         mhost.export_library(path_dso)
         m = tvm.runtime.load_module(path_dso)
-        fadd = m["fadd"]
+        fadd = m["test_fadd"]
         ctx = tvm.cpu(0)
         # launch the kernel.
         n = nn
@@ -73,14 +73,14 @@ def test_add_pipeline():
         )
         binds = {A: Ab}
         # BUILD and invoke the kernel.
-        f1 = tvm.lower(s, [A, B, C], name="fadd_pipeline")
+        f1 = tvm.lower(s, [A, B, C], name="test_fadd_pipeline")
         mhost = tvm.build(f1, target="c")
 
         temp = utils.tempdir()
         path_dso = temp.relpath("temp.so")
         mhost.export_library(path_dso)
         m = tvm.runtime.load_module(path_dso)
-        fadd = m["fadd_pipeline"]
+        fadd = m["test_fadd_pipeline"]
         ctx = tvm.cpu(0)
         # launch the kernel.
         n = nn
@@ -103,12 +103,12 @@ def test_reinterpret():
     s = te.create_schedule(B.op)
 
     def check_c():
-        mhost = tvm.build(s, [A, B], "c", name="reinterpret")
+        mhost = tvm.build(s, [A, B], "c", name="test_reinterpret")
         temp = utils.tempdir()
         path_dso = temp.relpath("temp.so")
         mhost.export_library(path_dso)
         m = tvm.runtime.load_module(path_dso)
-        fadd = m["reinterpret"]
+        fadd = m["test_reinterpret"]
         ctx = tvm.cpu(0)
         n = nn
         a = tvm.nd.array(np.random.randint(-(2 ** 30), 2 ** 30, size=n).astype(A.dtype), ctx)
@@ -119,7 +119,82 @@ def test_reinterpret():
     check_c()
 
 
+def test_ceil():
+    nn = 1024
+    n = tvm.runtime.convert(nn)
+    A = te.placeholder((n,), name="A", dtype="float32")
+    B = te.compute(A.shape, lambda *i: tvm.tir.call_intrin("float32", "tir.ceil", A(*i)), name="B")
+    s = te.create_schedule(B.op)
+
+    def check_c():
+        mhost = tvm.build(s, [A, B], "c", name="test_ceil")
+        temp = utils.tempdir()
+        path_dso = temp.relpath("temp.so")
+        mhost.export_library(path_dso)
+        m = tvm.runtime.load_module(path_dso)
+        fceil = m["test_ceil"]
+        ctx = tvm.cpu(0)
+        n = nn
+        a = tvm.nd.array(np.random.rand(n).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.zeros(n, dtype=B.dtype), ctx)
+        fceil(a, b)
+        tvm.testing.assert_allclose(b.asnumpy(), (np.ceil(a.asnumpy()).view("float32")))
+
+    check_c()
+
+
+def test_floor():
+    nn = 1024
+    n = tvm.runtime.convert(nn)
+    A = te.placeholder((n,), name="A", dtype="float32")
+    B = te.compute(A.shape, lambda *i: tvm.tir.call_intrin("float32", "tir.floor", A(*i)), name="B")
+    s = te.create_schedule(B.op)
+
+    def check_c():
+        mhost = tvm.build(s, [A, B], "c", name="test_floor")
+        temp = utils.tempdir()
+        path_dso = temp.relpath("temp.so")
+        mhost.export_library(path_dso)
+        m = tvm.runtime.load_module(path_dso)
+        ffloor = m["test_floor"]
+        ctx = tvm.cpu(0)
+        n = nn
+        a = tvm.nd.array(np.random.rand(n).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.zeros(n, dtype=B.dtype), ctx)
+        ffloor(a, b)
+        tvm.testing.assert_allclose(b.asnumpy(), (np.floor(a.asnumpy()).view("float32")))
+
+    check_c()
+
+
+def test_round():
+    nn = 1024
+    n = tvm.runtime.convert(nn)
+    A = te.placeholder((n,), name="A", dtype="float32")
+    B = te.compute(A.shape, lambda *i: tvm.tir.call_intrin("float32", "tir.round", A(*i)), name="B")
+    s = te.create_schedule(B.op)
+
+    def check_c():
+        mhost = tvm.build(s, [A, B], "c", name="test_round")
+        temp = utils.tempdir()
+        path_dso = temp.relpath("temp.so")
+        mhost.export_library(path_dso)
+        m = tvm.runtime.load_module(path_dso)
+        fround = m["test_round"]
+        ctx = tvm.cpu(0)
+        n = nn
+        a = tvm.nd.array(np.random.rand(n).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.zeros(n, dtype=B.dtype), ctx)
+        fround(a, b)
+        tvm.testing.assert_allclose(b.asnumpy(), (np.round(a.asnumpy()).view("float32")))
+
+    check_c()
+
+
 if __name__ == "__main__":
     test_add()
     test_add_pipeline()
     test_reinterpret()
+    test_ceil()
+    test_floor()
+    test_round()


### PR DESCRIPTION

* Trying to lower quantized C target some simple nets reveal missing **round**, **floor**, **ceil** translation.

```
   with relay.build_config(opt_level=3):
      graph, c_mod, c_params = relay.build(mod, target='c', params=params)
```
* Network looks like the one below, notice for example the ```round``` operations:

```
#[version = "0.0.5"]
def @main(%input_3: Tensor[(1, 1, 129, 124), float32]) -> Tensor[(?, 8), float32] {
  %0 = dyn.image.resize(%input_3, meta[relay.Constant][0] /* ty=Tensor[(2), int64] */, size=[]) /* ty=Tensor[(1, 1, ?, ?), float32] */;
  %1 = multiply(%0, 16f /* ty=float32 */) /* ty=Tensor[(1, 1, ?, ?), float32] */;
  %2 = round(%1) /* ty=Tensor[(1, 1, ?, ?), float32] */;
  .....
  .....
```

* The errors encountered:

```
TVMError: Unresolved call Op(tir.round)
TVMError: Unresolved call Op(tir.floor)
TVMError: Unresolved call Op(tir.ceil)
```

--------

* This simple patch address the issue.

@jroesch @masashi @mdw-octoml Please help me review.

Thank you !



