### PR TITLE
fix duplicated symbol bug in external codegen

### DIFF
--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -651,10 +651,10 @@ class CompileEngineImpl : public CompileEngineNode {
                                       << AsText(src_func, false);
 
         std::string sn = symbol_name.value();
-        if (cached_symbol.count(sn)) {
+        if (!cached_symbol.count(sn)) {
           cached_symbol[sn] = code_gen_name;
         } else {
-          ICHECK_NE(sn, code_gen_name)
+          ICHECK_NE(cached_symbol[sn], code_gen_name)
               << "Found duplicated symbol: " << sn << " for: " << code_gen_name;
         }
 


### PR DESCRIPTION
the original purpose of the code is that the same symbol_name can only be registered once for each external codegen。

but the actual result is that the name of symbol_name can’t be same with code_gen_name, for example, we can’t set global_symbol name with “ccompiler” for relay.ext.ccompiler.

and the code logic is error, because cached_symbol.count(sn) is always 0, so the if sentence is always false。

cc @zhiics 
