### PR TITLE
Improve op_type missing message

### DIFF
--- a/include/tvm/ir/op.h
+++ b/include/tvm/ir/op.h
@@ -146,7 +146,7 @@ class OpNode : public RelayExprNode {
   // Internal function to compute if it is primitive op
   bool IsPrimitiveOp_() const {
     const auto& fn_ty = this->op_type;
-    ICHECK(fn_ty.get() != nullptr);
+    ICHECK(fn_ty.get() != nullptr) << "op_type of " << this->name << "is not registered";
     if (fn_ty->type_constraints.size() != 1) return false;
     const TypeRelationNode* rel = fn_ty->type_constraints[0].as<TypeRelationNode>();
     if (rel == nullptr) return false;


### PR DESCRIPTION
Improve the error message when `op_type` is missing for the target op.

cc @yzhliu 