### PR TITLE
[RPC] Replace timestamp with counter

### DIFF
--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -112,7 +112,7 @@ class Scheduler(object):
 
 
 class PriorityScheduler(Scheduler):
-    """Priority based scheduler, FIFO"""
+    """Priority based scheduler, FIFO based on request order"""
 
     def __init__(self, key):
         self._key = key

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -44,6 +44,7 @@ List of available APIs:
 import heapq
 import logging
 import socket
+import threading
 import multiprocessing
 import errno
 import struct
@@ -111,11 +112,12 @@ class Scheduler(object):
 
 
 class PriorityScheduler(Scheduler):
-    """Priority based scheduler, FIFO based on time"""
+    """Priority based scheduler, FIFO"""
 
     def __init__(self, key):
         self._key = key
         self._request_cnt = 0
+        self._lock = threading.Lock()
         self._values = []
         self._requests = []
 
@@ -134,8 +136,9 @@ class PriorityScheduler(Scheduler):
         self._schedule()
 
     def request(self, user, priority, callback):
-        heapq.heappush(self._requests, (-priority, self._request_cnt, callback))
-        self._request_cnt += 1
+        with self._lock:
+            heapq.heappush(self._requests, (-priority, self._request_cnt, callback))
+            self._request_cnt += 1
         self._schedule()
 
     def remove(self, value):

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -42,7 +42,6 @@ List of available APIs:
 # pylint: disable=invalid-name
 
 import heapq
-import time
 import logging
 import socket
 import multiprocessing
@@ -116,6 +115,7 @@ class PriorityScheduler(Scheduler):
 
     def __init__(self, key):
         self._key = key
+        self._request_cnt = 0
         self._values = []
         self._requests = []
 
@@ -134,7 +134,8 @@ class PriorityScheduler(Scheduler):
         self._schedule()
 
     def request(self, user, priority, callback):
-        heapq.heappush(self._requests, (-priority, time.time(), callback))
+        heapq.heappush(self._requests, (-priority, self._request_cnt, callback))
+        self._request_cnt += 1
         self._schedule()
 
     def remove(self, value):


### PR DESCRIPTION
When tuning workload using AutoTVM, we may encounter an exception saying `< not supported between instances of function and function`. The reason is we currently put RPC requests in the format of `(-priority, time.time(), callback)`. When two requests with the same `priority` and `time.time()`, then heap pop throws the error of trying to compare two callbacks. Although it seems rare to have the same timestamp for two requests, one of my colleagues encounters an exception repeatedly when tuning a task using AutoTVM on V100 GPU. As a result, I try to use a counter to replace the timestamp so that we guarantee there's no duplication. Not sure if we need thread locking here to make sure thread safe, tho.

cc @tqchen @FrozenGene 