### PR TITLE
Fix Bug in Bilinear Interpolation and Add Deform Conv to PT FrontEnd

### DIFF
--- a/include/tvm/topi/detail/tensor_utils.h
+++ b/include/tvm/topi/detail/tensor_utils.h
@@ -63,7 +63,6 @@ inline bool is_empty_shape(const Array<PrimExpr>& x) {
  *
  * \return The interpolated value in the given index.
  */
-
 inline PrimExpr bilinear_sample_nchw(const Tensor& input, const Array<PrimExpr>& indices,
                                      const PrimExpr max_y, const PrimExpr max_x) {
   auto batch_id = indices[0];

--- a/include/tvm/topi/detail/tensor_utils.h
+++ b/include/tvm/topi/detail/tensor_utils.h
@@ -26,6 +26,7 @@
 
 #include <tvm/te/operation.h>
 
+#include <vector>
 namespace tvm {
 namespace topi {
 namespace detail {

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1852,6 +1852,34 @@ class PyTorchOpConverter:
     def index(self, inputs, input_types):
         data = inputs[0]
         indices = inputs[1]
+        indices_infered = self.infer_type(indices[0])
+        if indices_infered.dtype == "bool":
+            len_data_shape = len(self.infer_shape(data))
+            len_indices_shape = len(self.infer_shape(indices[0]))
+            if len_indices_shape == 0:
+                return data
+
+            assert len_data_shape >= len_indices_shape
+
+            if len_data_shape > len_indices_shape:
+                shape_len_diff = len_data_shape - len_indices_shape
+                ones = _op.ones(shape_len_diff, dtype="int32")
+                new_indices_shape = _op.concatenate((_op.shape_of(indices[0]), ones), axis=0)
+                strided_shapes = _op.strided_slice(
+                    _op.shape_of(data), begin=[len_indices_shape], end=[-1], slice_mode="size"
+                )
+                result_shape = _op.concatenate((_expr.const([-1]), strided_shapes), axis=0)
+            else:
+                new_indices_shape = _op.shape_of(indices[0])
+                result_shape = _expr.const([-1])
+
+            new_indices = _op.cast_like(_op.reshape(indices[0], new_indices_shape), data)
+            inter_result = _op.reshape(_op.multiply(data, new_indices), (-1,))
+            reshaped_data = _op.reshape(data, (-1,))
+            result = _op.reshape(_op.take(reshaped_data, _op.argwhere(inter_result)), result_shape)
+
+            return result
+
         return _op.adv_index([data] + indices)
 
     def meshgrid(self, inputs, input_types):
@@ -1927,6 +1955,32 @@ class PyTorchOpConverter:
             boxes -= _expr.const(0.5 / spatial_scale)
 
         return _op.vision.roi_align(data, boxes, output_size, spatial_scale, sample_ratio)
+
+    def deform_conv2d(self, inputs, input_types):
+        data = inputs[0]
+        weight = inputs[1]
+        offset = inputs[2]
+        strides = (inputs[4], inputs[5])
+        padding = (inputs[6], inputs[7])
+        dilation = (inputs[8], inputs[9])
+        groups = inputs[10]
+        deformable_groups = inputs[11]
+        weight_shape = self.infer_shape(weight)
+        output_channels = weight_shape[0]
+        kernel_size = (weight_shape[2], weight_shape[3])
+
+        return _op.nn.deformable_conv2d(
+            data,
+            offset,
+            weight,
+            strides,
+            padding,
+            dilation,
+            deformable_groups,
+            groups,
+            output_channels,
+            kernel_size,
+        )
 
     def unbind(self, inputs, input_types):
         data = inputs[0]
@@ -2292,6 +2346,7 @@ class PyTorchOpConverter:
             "torchvision::nms": self.nms,
             "aten::logsumexp": self.logsumexp,
             "torchvision::roi_align": self.roi_align,
+            "torchvision::deform_conv2d": self.deform_conv2d,
             "aten::unbind": self.unbind,
             "aten::__and__": self.logical_and,
             "aten::logical_and": self.logical_and,

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1852,34 +1852,6 @@ class PyTorchOpConverter:
     def index(self, inputs, input_types):
         data = inputs[0]
         indices = inputs[1]
-        indices_infered = self.infer_type(indices[0])
-        if indices_infered.dtype == "bool":
-            len_data_shape = len(self.infer_shape(data))
-            len_indices_shape = len(self.infer_shape(indices[0]))
-            if len_indices_shape == 0:
-                return data
-
-            assert len_data_shape >= len_indices_shape
-
-            if len_data_shape > len_indices_shape:
-                shape_len_diff = len_data_shape - len_indices_shape
-                ones = _op.ones(shape_len_diff, dtype="int32")
-                new_indices_shape = _op.concatenate((_op.shape_of(indices[0]), ones), axis=0)
-                strided_shapes = _op.strided_slice(
-                    _op.shape_of(data), begin=[len_indices_shape], end=[-1], slice_mode="size"
-                )
-                result_shape = _op.concatenate((_expr.const([-1]), strided_shapes), axis=0)
-            else:
-                new_indices_shape = _op.shape_of(indices[0])
-                result_shape = _expr.const([-1])
-
-            new_indices = _op.cast_like(_op.reshape(indices[0], new_indices_shape), data)
-            inter_result = _op.reshape(_op.multiply(data, new_indices), (-1,))
-            reshaped_data = _op.reshape(data, (-1,))
-            result = _op.reshape(_op.take(reshaped_data, _op.argwhere(inter_result)), result_shape)
-
-            return result
-
         return _op.adv_index([data] + indices)
 
     def meshgrid(self, inputs, input_types):

--- a/python/tvm/topi/testing/deformable_conv2d_python.py
+++ b/python/tvm/topi/testing/deformable_conv2d_python.py
@@ -17,9 +17,9 @@
 # pylint: disable=invalid-name, too-many-locals, too-many-arguments
 """Deformable convolution in python"""
 import itertools
+import math
 import numpy as np
 from tvm.topi.nn.utils import get_pad_tuple
-import math
 
 
 def deformable_conv2d_nchw_python(

--- a/python/tvm/topi/vision/rcnn/roi_align.py
+++ b/python/tvm/topi/vision/rcnn/roi_align.py
@@ -60,8 +60,8 @@ def roi_align_nchw(data, rois, pooled_size, spatial_scale, sample_ratio=-1):
 
     def _bilinear(i, c, y, x):
         outside = tvm.tir.any(y < -1.0, x < -1.0, y > height, x > width)
-        y = tvm.te.max(y, 0.0)
-        x = tvm.te.max(x, 0.0)
+        y = tvm.te.min(tvm.te.max(y, 0.0), height - 1)
+        x = tvm.te.min(tvm.te.max(x, 0.0), width - 1)
         val = bilinear_sample_nchw(data, (i, c, y, x), height - 1, width - 1)
         return tvm.tir.if_then_else(outside, 0.0, val)
 

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -837,11 +837,31 @@ def test_deformable_conv2d():
     test_infer_type(1, 4, 16, 4, 4, 1, "NHWC")
     test_infer_type(2, 4, 16, 4, 1, 2, "NHWC")
 
-    def test_run(batch, in_channel, size, out_channel, deformable_groups, groups):
+    def test_run(batch, in_channel, size, out_channel, deformable_groups, groups, layout):
         kernel_size = (3, 3)
-        data_shape = (batch, in_channel, size, size)
-        offset_shape = (batch, 2 * kernel_size[0] * kernel_size[1] * deformable_groups, size, size)
-        kernel_shape = (out_channel, in_channel // groups, kernel_size[0], kernel_size[1])
+        if layout == "NCHW":
+            kernel_layout = "OIHW"
+            data_shape = (batch, in_channel, size, size)
+            kernel_shape = (out_channel, in_channel // groups, kernel_size[0], kernel_size[1])
+            out_shape = (batch, out_channel, size, size)
+            offset_shape = (
+                batch,
+                2 * kernel_size[0] * kernel_size[1] * deformable_groups,
+                out_shape[2],
+                out_shape[3],
+            )
+        else:
+            kernel_layout = "HWIO"
+            data_shape = (batch, size, size, in_channel)
+            kernel_shape = (kernel_size[0], kernel_size[1], in_channel // groups, out_channel)
+            out_shape = (batch, size, size, out_channel)
+            offset_shape = (
+                batch,
+                out_shape[1],
+                out_shape[2],
+                2 * kernel_size[0] * kernel_size[1] * deformable_groups,
+            )
+
         dtype = "float32"
         data = relay.var("data", shape=data_shape, dtype=dtype)
         offset = relay.var("offset")
@@ -853,6 +873,8 @@ def test_deformable_conv2d():
             strides=(1, 1),
             padding=(1, 1),
             dilation=(1, 1),
+            data_layout=layout,
+            kernel_layout=kernel_layout,
             kernel_size=kernel_size,
             deformable_groups=deformable_groups,
             groups=groups,
@@ -862,25 +884,40 @@ def test_deformable_conv2d():
         data = np.random.uniform(size=data_shape).astype(dtype)
         offset = np.random.uniform(size=offset_shape).astype(dtype)
         kernel = np.random.uniform(size=kernel_shape).astype(dtype)
-        ref_res = tvm.topi.testing.deformable_conv2d_nchw_python(
-            data,
-            offset,
-            kernel,
-            stride=(1, 1),
-            padding=(1, 1),
-            dilation=(1, 1),
-            deformable_groups=deformable_groups,
-            groups=groups,
-        )
-
+        if layout == "NCHW":
+            ref_res = tvm.topi.testing.deformable_conv2d_nchw_python(
+                data,
+                offset,
+                kernel,
+                stride=(1, 1),
+                padding=(1, 1),
+                dilation=(1, 1),
+                deformable_groups=deformable_groups,
+                groups=groups,
+            )
+        else:
+            ref_res = tvm.topi.testing.deformable_conv2d_nhwc_python(
+                data,
+                offset,
+                kernel,
+                stride=(1, 1),
+                padding=(1, 1),
+                dilation=(1, 1),
+                deformable_groups=deformable_groups,
+                groups=groups,
+            )
         for target, ctx in tvm.testing.enabled_targets():
+            if target == "cuda" and layout == "NHWC":
+                continue  # Cannot run NHWC layout on cuda target, only on llvm
             for kind in ["graph", "debug"]:
                 intrp1 = relay.create_executor(kind, ctx=ctx, target=target)
                 op_res1 = intrp1.evaluate(func)(data, offset, kernel)
                 tvm.testing.assert_allclose(op_res1.asnumpy(), ref_res, rtol=1e-5, atol=1e-5)
 
-    test_run(1, 4, 16, 4, 1, 1)
-    test_run(2, 4, 16, 4, 4, 1)
+    test_run(1, 4, 16, 4, 1, 1, "NCHW")
+    test_run(1, 4, 16, 4, 1, 1, "NHWC")
+    test_run(2, 4, 16, 4, 4, 1, "NCHW")
+    test_run(2, 4, 16, 4, 4, 1, "NHWC")
 
 
 @tvm.testing.uses_gpu
@@ -1210,6 +1247,10 @@ def test_batch_to_space_nd():
 
 
 if __name__ == "__main__":
+    test_deformable_conv2d()
+    import sys
+
+    sys.exit()
     test_resize_infer_type()
     test_resize()
     test_resize3d_infer_type()

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -1247,10 +1247,6 @@ def test_batch_to_space_nd():
 
 
 if __name__ == "__main__":
-    test_deformable_conv2d()
-    import sys
-
-    sys.exit()
     test_resize_infer_type()
     test_resize()
     test_resize3d_infer_type()


### PR DESCRIPTION
This PR adds deform_conv to PT Frontend. It also fixes a bug in bilinear interpolation which was causing wrong output with deformable convolutions from PT framework. The "bug" occurs when one or more the interpolation index(y, x) is outside one or more of the boundary points `(y_max, x_max)`, but within `(y_max + 1, x_max + 1)`. In the current implementation both interpolation source points are on the boundary even if the point is closer to one or more of `(y_max+1, x_max+1)`.  In the corrected version, the first point is on the boundary and the second point value is 0 which is more logically sound and matches with how [frameworks have implemented it.](https://github.com/pytorch/vision/blob/master/test/test_ops.py#L222) 
PS : It might seem that this is a corner case, but it really changes the accuracy by a lot 
For e.g: Without this change , the relative and absolute tolerances are around 1 and 1e-2 with tolerances being more than 1e-2 for 25-40% of the output elements in deformable convolution. 

Since ROI align is dependent on this change, I have made the corresponding necessary changes in ROIAlign and verified that it works like before as expected. 