### PR TITLE
[TIR][Printer] Fix SelectNode TIRTextPrinter bracket mismatch

### DIFF
--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -301,7 +301,7 @@ Doc TIRTextPrinter::VisitExpr_(const NotNode* op) {
 Doc TIRTextPrinter::VisitExpr_(const SelectNode* op) {
   Doc doc;
   doc << "select(" << Print(op->condition) << ", " << Print(op->true_value) << ", "
-      << Print(op->false_value);
+      << Print(op->false_value) << ")";
   return doc;
 }
 


### PR DESCRIPTION
1.TIRTextPrinter::VisitExpr_(const SelectNode* op) print miss matching closing parenthesis. When tvm::PrettyPrint is used, it will cause semantic misunderstanding.
 such as:
Correct form:
`(select((axis_k_w < 1), 0h, buffer1[((((axis_k_w*128)) + axis_c_in.inner) - 128)])*buffer2[((((axis_k_w*4096)) + (axis_c_in.inner*64)))])`

Now Print Form(wrong):
`(select((axis_k_w < 1), 0h, buffer1[((((axis_k_w*128)) + axis_c_in.inner) - 128)]*buffer2[((((axis_k_w*4096)) + (axis_c_in.inner*64)))])`

2.Same as the `src/tir/ir/expr.cc` printing  form
```
TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
    .set_dispatch<SelectNode>([](const ObjectRef& node, ReprPrinter* p) {
      auto* op = static_cast<const SelectNode*>(node.get());
      p->stream << "select(";
      p->Print(op->condition);
      p->stream << ", ";
      p->Print(op->true_value);
      p->stream << ", ";
      p->Print(op->false_value);
      p->stream << ")";
    });
```
@tqchen @yzhliu  Would you please have a look at this? Thanks very much.