### PR TITLE
[BYOC][Verilator] Refactor Verilator runtime

### DIFF
--- a/src/relay/backend/contrib/verilator/codegen.cc
+++ b/src/relay/backend/contrib/verilator/codegen.cc
@@ -84,25 +84,16 @@ struct VerilatorOptionsNode : public tvm::AttrsNode<VerilatorOptionsNode> {
   int profiler_cycle_counter_id;
 
   TVM_DECLARE_ATTRS(VerilatorOptionsNode, "ext.attrs.VerilatorOptionsNode") {
-    TVM_ATTR_FIELD(lib_path)
-      .describe("the design library path")
-      .set_default("libverilator.so");
-    TVM_ATTR_FIELD(reset_cycles)
-      .describe("the number of reset cycles")
-      .set_default(1);
-    TVM_ATTR_FIELD(profiler_enable)
-      .describe("enable profiler")
-      .set_default(false);
-    TVM_ATTR_FIELD(profiler_cycle_counter_id)
-      .describe("profiler cycle counter id")
-      .set_default(0);
+    TVM_ATTR_FIELD(lib_path).describe("the design library path").set_default("libverilator.so");
+    TVM_ATTR_FIELD(reset_cycles).describe("the number of reset cycles").set_default(1);
+    TVM_ATTR_FIELD(profiler_enable).describe("enable profiler").set_default(false);
+    TVM_ATTR_FIELD(profiler_cycle_counter_id).describe("profiler cycle counter id").set_default(0);
   }
 };
 
 class VerilatorOptions : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(VerilatorOptions, Attrs,
-                                            VerilatorOptionsNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(VerilatorOptions, Attrs, VerilatorOptionsNode);
 };
 
 TVM_REGISTER_NODE_TYPE(VerilatorOptionsNode);

--- a/src/relay/backend/contrib/verilator/codegen.cc
+++ b/src/relay/backend/contrib/verilator/codegen.cc
@@ -76,7 +76,7 @@ class VerilatorJSONSerializer : public backend::contrib::JSONSerializer {
   }
 };
 
-/*! \brief Attributes to store the compiler options for Verilator */
+/*! \brief Attributes to store options for Verilator */
 struct VerilatorOptionsNode : public tvm::AttrsNode<VerilatorOptionsNode> {
   String lib_path;
   int reset_cycles;

--- a/src/relay/backend/contrib/verilator/codegen.cc
+++ b/src/relay/backend/contrib/verilator/codegen.cc
@@ -122,7 +122,7 @@ runtime::Module VerilatorBackend(const ObjectRef& ref) {
     cfg = AttrsWithDefaultValues<VerilatorOptions>();
   }
 
-  n->LoadLibrary(cfg.value()->lib_path);
+  n->SetLibrary(cfg.value()->lib_path);
   n->SetResetCycles(cfg.value()->reset_cycles);
 
   if (cfg.value()->profiler_enable) {

--- a/src/runtime/contrib/verilator/verilator_device.h
+++ b/src/runtime/contrib/verilator/verilator_device.h
@@ -31,24 +31,51 @@ namespace tvm {
 namespace runtime {
 namespace contrib {
 
+/*! \brief Verilator device resource context  */
 typedef void* VerilatorHandle;
 
-/* allocate Verilator object */
+/*!
+ * \brief Allocate a verilator device resource handle
+ * \return The verilator device handle.
+ */
 extern "C" TVM_DLL VerilatorHandle VerilatorAlloc();
 
-/* deallocate Verilator object */
+/*!
+ * \brief Free a verilator device handle
+ * \param handle The verilator device handle to be freed.
+ */
 extern "C" TVM_DLL void VerilatorDealloc(VerilatorHandle handle);
 
-/* read Verilator register or memory */
+/*!
+ * \brief Read verilator register or memory
+ * \param handle The verilator device handle.
+ * \param id The register or memory identifier.
+ * \param addr The register or memory address (word-level).
+ * \return The value of register or memory.
+ */
 extern "C" TVM_DLL int VerilatorRead(VerilatorHandle handle, int id, int addr);
 
-/* write Verilator register or memory */
+/*!
+ * \brief Write verilator register or memory
+ * \param handle The verilator device handle.
+ * \param id The register or memory identifier.
+ * \param addr The register or memory address (word-level).
+ * \param value The value of register or memory.
+ */
 extern "C" TVM_DLL void VerilatorWrite(VerilatorHandle handle, int id, int addr, int value);
 
-/* reset Verilator for n clock cycles */
+/*!
+ * \brief Reset Verilator for n clock cycles
+ * \param handle The verilator device handle.
+ * \param n The number of reset cycles.
+ */
 extern "C" TVM_DLL void VerilatorReset(VerilatorHandle handle, int n);
 
-/* run Verilator for n clock cycles */
+/*!
+ * \brief Run Verilator for n clock cycles
+ * \param handle The verilator device handle.
+ * \param n The number of run cycles.
+ */
 extern "C" TVM_DLL void VerilatorRun(VerilatorHandle handle, int n);
 
 }  // namespace contrib

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -22,6 +22,8 @@
  * \brief A runtime for Verilator.
  */
 
+#include "verilator_runtime.h"
+
 #include <dlfcn.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/registry.h>
@@ -35,7 +37,6 @@
 #include "../json/json_runtime.h"
 #include "verilator_device.h"
 #include "verilator_kernel.h"
-#include "verilator_runtime.h"
 
 namespace tvm {
 namespace runtime {
@@ -54,21 +55,19 @@ VerilatorLibrary::~VerilatorLibrary() {
 
 void VerilatorLibrary::Load(const std::string& name) {
   lib_handle_ = dlopen(name.c_str(), RTLD_LAZY | RTLD_LOCAL);
-  ICHECK(lib_handle_ != nullptr)
-      << "Failed to load dynamic shared library " << name << " " << dlerror();
+  ICHECK(lib_handle_ != nullptr) << "Failed to load dynamic shared library " << name << " "
+                                 << dlerror();
 }
 
 void* VerilatorLibrary::GetSymbol(const char* name) { return dlsym(lib_handle_, name); }
 
-void VerilatorProfiler::Clear() {
-  cycle_counter = 0;
-}
+void VerilatorProfiler::Clear() { cycle_counter = 0; }
 
 std::string VerilatorProfiler::AsJSON() {
   std::ostringstream os;
   os << "{\n"
      << " \"cycle_counter\":" << cycle_counter << "\n"
-     <<"}\n";
+     << "}\n";
   return os.str();
 }
 
@@ -82,17 +81,11 @@ void VerilatorRuntime::LoadLibrary(const std::string& lib_name) {
   lib_->Load(lib_name);
 }
 
-void VerilatorRuntime::SetResetCycles(const int cycles) {
-  reset_cycles_ = cycles;
-}
+void VerilatorRuntime::SetResetCycles(const int cycles) { reset_cycles_ = cycles; }
 
-void VerilatorRuntime::EnableProfiler() {
-  prof_enable_ = true;
-}
+void VerilatorRuntime::EnableProfiler() { prof_enable_ = true; }
 
-void VerilatorRuntime::SetProfilerCycleCounterId(const int id) {
-  prof_cycle_counter_id_ = id;
-}
+void VerilatorRuntime::SetProfilerCycleCounterId(const int id) { prof_cycle_counter_id_ = id; }
 
 void VerilatorRuntime::Init(const Array<NDArray>& consts) {
   // get symbols
@@ -154,15 +147,13 @@ void VerilatorRuntime::Run() {
   }
 }
 
-TVM_REGISTER_GLOBAL("verilator.profiler_clear")
-.set_body([](TVMArgs args, TVMRetValue* rv) {
-    VerilatorProfiler::ThreadLocal()->Clear();
-  });
+TVM_REGISTER_GLOBAL("verilator.profiler_clear").set_body([](TVMArgs args, TVMRetValue* rv) {
+  VerilatorProfiler::ThreadLocal()->Clear();
+});
 
-TVM_REGISTER_GLOBAL("verilator.profiler_status")
-.set_body([](TVMArgs args, TVMRetValue* rv) {
-    *rv = VerilatorProfiler::ThreadLocal()->AsJSON();
-  });
+TVM_REGISTER_GLOBAL("verilator.profiler_status").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = VerilatorProfiler::ThreadLocal()->AsJSON();
+});
 
 }  // namespace contrib
 }  // namespace runtime

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -63,14 +63,26 @@ void VerilatorRuntime::LoadLibrary(const std::string& lib_name) {
   lib_->Init(lib_name);
 }
 
+void VerilatorRuntime::SetResetCycles(const int cycles) {
+  reset_cycles_ = cycles;
+}
+
+void VerilatorRuntime::EnableProfiler() {
+  prof_enable_ = true;
+}
+
+void VerilatorRuntime::SetProfilerCycleCounterId(const int id) {
+  prof_cycle_counter_id_ = id;
+}
+
 void VerilatorRuntime::Init(const Array<NDArray>& consts) {
   // get symbols
   auto alloc_func = reinterpret_cast<VerilatorAllocFunc>(lib_->GetSymbol("VerilatorAlloc"));
   ICHECK(alloc_func != nullptr);
   auto reset_func = reinterpret_cast<VerilatorResetFunc>(lib_->GetSymbol("VerilatorReset"));
   ICHECK(reset_func != nullptr);
-  vadd_func_ = reinterpret_cast<VerilatorAddFunc>(lib_->GetSymbol("verilator_add"));
-  ICHECK(vadd_func_ != nullptr);
+  add_func_ = reinterpret_cast<VerilatorAddFunc>(lib_->GetSymbol("verilator_add"));
+  ICHECK(add_func_ != nullptr);
 
   // alloc device
   device_ = (*alloc_func)();
@@ -106,7 +118,7 @@ void VerilatorRuntime::Run() {
       if ("add" == op_name) {
         auto entry = node.GetInputs()[0];
         auto shape = nodes_[entry.id_].GetOpShape()[entry.index_];
-        (*vadd_func_)(device_, in_ptr[0], in_ptr[1], out_ptr[0], shape[0], shape[1]);
+        (*add_func_)(device_, in_ptr[0], in_ptr[1], out_ptr[0], shape[0], shape[1]);
       } else {
         LOG(FATAL) << "Unsupported op: " << op_name;
       }

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -45,22 +45,25 @@ using namespace tvm::runtime;
 using namespace tvm::runtime::contrib;
 using namespace tvm::runtime::json;
 
+VerilatorLibrary::~VerilatorLibrary() {
+  if (lib_handle_) {
+    dlclose(lib_handle_);
+    lib_handle_ = nullptr;
+  }
+}
+
 void VerilatorLibrary::Load(const std::string& name) {
   lib_handle_ = dlopen(name.c_str(), RTLD_LAZY | RTLD_LOCAL);
   ICHECK(lib_handle_ != nullptr)
       << "Failed to load dynamic shared library " << name << " " << dlerror();
 }
 
-void* VerilatorLibrary::GetSymbol_(const char* name) { return dlsym(lib_handle_, name); }
+void* VerilatorLibrary::GetSymbol(const char* name) { return dlsym(lib_handle_, name); }
 
-void VerilatorLibrary::Unload() {
-  dlclose(lib_handle_);
-  lib_handle_ = nullptr;
-}
 
 void VerilatorRuntime::LoadLibrary(const std::string& lib_name) {
   lib_ = new VerilatorLibrary();
-  lib_->Init(lib_name);
+  lib_->Load(lib_name);
 }
 
 void VerilatorRuntime::SetResetCycles(const int cycles) {

--- a/src/runtime/contrib/verilator/verilator_runtime.cc
+++ b/src/runtime/contrib/verilator/verilator_runtime.cc
@@ -19,7 +19,7 @@
 
 /*!
  * \file src/runtime/contrib/verilator/verilator_runtime.cc
- * \brief A simple JSON runtime for Verilator.
+ * \brief A runtime for Verilator.
  */
 
 #include <dlfcn.h>
@@ -35,129 +35,84 @@
 #include "../json/json_runtime.h"
 #include "verilator_device.h"
 #include "verilator_kernel.h"
+#include "verilator_runtime.h"
 
 namespace tvm {
 namespace runtime {
 namespace contrib {
 
-typedef VerilatorHandle (*VerilatorAllocFunc)();
-typedef void (*VerilatorResetFunc)(VerilatorHandle, int);
-typedef void (*VerilatorAddFunc)(VerilatorHandle, int*, int*, int*, int, int);
-
 using namespace tvm::runtime;
+using namespace tvm::runtime::contrib;
 using namespace tvm::runtime::json;
 
-class VerilatorLibrary : public Library {
- public:
-  ~VerilatorLibrary() {
-    if (lib_handle_) Unload();
+void VerilatorLibrary::Load(const std::string& name) {
+  lib_handle_ = dlopen(name.c_str(), RTLD_LAZY | RTLD_LOCAL);
+  ICHECK(lib_handle_ != nullptr)
+      << "Failed to load dynamic shared library " << name << " " << dlerror();
+}
+
+void* VerilatorLibrary::GetSymbol_(const char* name) { return dlsym(lib_handle_, name); }
+
+void VerilatorLibrary::Unload() {
+  dlclose(lib_handle_);
+  lib_handle_ = nullptr;
+}
+
+void VerilatorRuntime::LoadLibrary(const std::string& lib_name) {
+  lib_ = new VerilatorLibrary();
+  lib_->Init(lib_name);
+}
+
+void VerilatorRuntime::Init(const Array<NDArray>& consts) {
+  // get symbols
+  auto alloc_func = reinterpret_cast<VerilatorAllocFunc>(lib_->GetSymbol("VerilatorAlloc"));
+  ICHECK(alloc_func != nullptr);
+  auto reset_func = reinterpret_cast<VerilatorResetFunc>(lib_->GetSymbol("VerilatorReset"));
+  ICHECK(reset_func != nullptr);
+  vadd_func_ = reinterpret_cast<VerilatorAddFunc>(lib_->GetSymbol("verilator_add"));
+  ICHECK(vadd_func_ != nullptr);
+
+  // alloc device
+  device_ = (*alloc_func)();
+
+  // reset for 10 cycles
+  (*reset_func)(device_, 10);
+
+  CHECK_EQ(consts.size(), const_idx_.size())
+      << "The number of input constants must match the number of required.";
+
+  // Setup constants entries for weights.
+  SetupConstants(consts);
+}
+
+void VerilatorRuntime::Run() {
+  std::vector<int*> in_ptr;
+  std::vector<int*> out_ptr;
+  for (size_t i = 0; i < input_nodes_.size(); ++i) {
+    uint32_t eid = EntryID(input_nodes_[i], 0);
+    int* data = static_cast<int*>(data_entry_[eid]->data);
+    in_ptr.push_back(data);
   }
-  void Init(const std::string& name) { Load(name); }
-
-  void* GetSymbol(const char* name) final { return GetSymbol_(name); }
-
- private:
-  // Library handle
-  void* lib_handle_{nullptr};
-  // load the library
-  void Load(const std::string& name) {
-    lib_handle_ = dlopen(name.c_str(), RTLD_LAZY | RTLD_LOCAL);
-    ICHECK(lib_handle_ != nullptr)
-        << "Failed to load dynamic shared library " << name << " " << dlerror();
+  for (size_t i = 0; i < outputs_.size(); ++i) {
+    uint32_t eid = EntryID(outputs_[i]);
+    int* data = static_cast<int*>(data_entry_[eid]->data);
+    out_ptr.push_back(data);
   }
-
-  void* GetSymbol_(const char* name) { return dlsym(lib_handle_, name); }
-
-  void Unload() {
-    dlclose(lib_handle_);
-    lib_handle_ = nullptr;
-  }
-};
-
-class VerilatorJSONRuntime : public JSONRuntimeBase {
- public:
-  VerilatorJSONRuntime(const std::string& symbol_name, const std::string& graph_json,
-                       const Array<String> const_names)
-      : JSONRuntimeBase(symbol_name, graph_json, const_names) {}
-
-  const char* type_key() const { return "verilator_json"; }
-
-  void LoadLibrary(const std::string& lib_name) {
-    lib_ = new VerilatorLibrary();
-    lib_->Init(lib_name);
-  }
-
-  void Init(const Array<NDArray>& consts) override {
-    // get symbols
-    auto alloc_func = reinterpret_cast<VerilatorAllocFunc>(lib_->GetSymbol("VerilatorAlloc"));
-    ICHECK(alloc_func != nullptr);
-    auto reset_func = reinterpret_cast<VerilatorResetFunc>(lib_->GetSymbol("VerilatorReset"));
-    ICHECK(reset_func != nullptr);
-    vadd_func_ = reinterpret_cast<VerilatorAddFunc>(lib_->GetSymbol("verilator_add"));
-    ICHECK(vadd_func_ != nullptr);
-
-    // alloc device
-    device_ = (*alloc_func)();
-
-    // reset for 10 cycles
-    (*reset_func)(device_, 10);
-
-    CHECK_EQ(consts.size(), const_idx_.size())
-        << "The number of input constants must match the number of required.";
-
-    // Setup constants entries for weights.
-    SetupConstants(consts);
-  }
-
-  void Run() override {
-    std::vector<int*> in_ptr;
-    std::vector<int*> out_ptr;
-    for (size_t i = 0; i < input_nodes_.size(); ++i) {
-      uint32_t eid = EntryID(input_nodes_[i], 0);
-      int* data = static_cast<int*>(data_entry_[eid]->data);
-      in_ptr.push_back(data);
-    }
-    for (size_t i = 0; i < outputs_.size(); ++i) {
-      uint32_t eid = EntryID(outputs_[i]);
-      int* data = static_cast<int*>(data_entry_[eid]->data);
-      out_ptr.push_back(data);
-    }
-    for (size_t nid = 0; nid < nodes_.size(); ++nid) {
-      const auto& node = nodes_[nid];
-      if (node.GetOpType() == "kernel") {
-        CHECK_EQ(node.GetOpType(), "kernel");
-        auto op_name = node.GetOpName();
-        if ("add" == op_name) {
-          auto entry = node.GetInputs()[0];
-          auto shape = nodes_[entry.id_].GetOpShape()[entry.index_];
-          (*vadd_func_)(device_, in_ptr[0], in_ptr[1], out_ptr[0], shape[0], shape[1]);
-        } else {
-          LOG(FATAL) << "Unsupported op: " << op_name;
-        }
+  for (size_t nid = 0; nid < nodes_.size(); ++nid) {
+    const auto& node = nodes_[nid];
+    if (node.GetOpType() == "kernel") {
+      CHECK_EQ(node.GetOpType(), "kernel");
+      auto op_name = node.GetOpName();
+      if ("add" == op_name) {
+        auto entry = node.GetInputs()[0];
+        auto shape = nodes_[entry.id_].GetOpShape()[entry.index_];
+        (*vadd_func_)(device_, in_ptr[0], in_ptr[1], out_ptr[0], shape[0], shape[1]);
+      } else {
+        LOG(FATAL) << "Unsupported op: " << op_name;
       }
     }
   }
-
- private:
-  /* The verilator device handle. */
-  VerilatorHandle device_{nullptr};
-  /* The verilator library handle. */
-  VerilatorLibrary* lib_{nullptr};
-  /* The verilator vadd function handle. */
-  VerilatorAddFunc vadd_func_{nullptr};
-};
-
-runtime::Module VerilatorJSONRuntimeCreate(String lib_name, String symbol_name, String graph_json,
-                                           const Array<String>& const_names) {
-  auto n = make_object<VerilatorJSONRuntime>(symbol_name, graph_json, const_names);
-  n->LoadLibrary(lib_name);
-  return runtime::Module(n);
 }
-
-TVM_REGISTER_GLOBAL("runtime.verilator_runtime_create").set_body_typed(VerilatorJSONRuntimeCreate);
-
-TVM_REGISTER_GLOBAL("runtime.module.loadbinary_verilator_json")
-    .set_body_typed(JSONRuntimeBase::LoadFromBinary<VerilatorJSONRuntime>);
 
 }  // namespace contrib
 }  // namespace runtime

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -22,6 +22,9 @@
  * \brief A runtime for Verilator.
  */
 
+#ifndef TVM_RUNTIME_CONTRIB_VERILATOR_VERILATOR_RUNTIME_H_
+#define TVM_RUNTIME_CONTRIB_VERILATOR_VERILATOR_RUNTIME_H_
+
 #include <dlfcn.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/registry.h>
@@ -78,7 +81,7 @@ class VerilatorProfiler {
 class VerilatorRuntime : public JSONRuntimeBase {
  public:
   VerilatorRuntime(const std::string& symbol_name, const std::string& graph_json,
-                       const Array<String> const_names)
+                   const Array<String> const_names)
       : JSONRuntimeBase(symbol_name, graph_json, const_names) {}
 
   const char* type_key() const { return "verilator"; }
@@ -115,3 +118,4 @@ class VerilatorRuntime : public JSONRuntimeBase {
 }  // namespace contrib
 }  // namespace runtime
 }  // namespace tvm
+#endif  // TVM_RUNTIME_CONTRIB_VERILATOR_VERILATOR_RUNTIME_H_

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/runtime/contrib/verilator/verilator_runtime.h
+ * \brief A runtime for Verilator.
+ */
+
+#include <dlfcn.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/registry.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "../../library_module.h"
+#include "../json/json_node.h"
+#include "../json/json_runtime.h"
+#include "verilator_device.h"
+#include "verilator_kernel.h"
+
+namespace tvm {
+namespace runtime {
+namespace contrib {
+
+using namespace tvm::runtime;
+using namespace tvm::runtime::contrib;
+using namespace tvm::runtime::json;
+
+typedef VerilatorHandle (*VerilatorAllocFunc)();
+typedef void (*VerilatorResetFunc)(VerilatorHandle, int);
+typedef void (*VerilatorAddFunc)(VerilatorHandle, int*, int*, int*, int, int);
+
+class VerilatorLibrary : public Library {
+ public:
+  ~VerilatorLibrary() {
+    if (lib_handle_) Unload();
+  }
+  void Init(const std::string& name) { Load(name); }
+
+  void* GetSymbol(const char* name) final { return GetSymbol_(name); }
+
+ private:
+  void Load(const std::string& name);
+
+  void* GetSymbol_(const char* name);
+
+  void Unload();
+
+  void* lib_handle_{nullptr};
+};
+
+class VerilatorRuntime : public JSONRuntimeBase {
+ public:
+  VerilatorRuntime(const std::string& symbol_name, const std::string& graph_json,
+                       const Array<String> const_names)
+      : JSONRuntimeBase(symbol_name, graph_json, const_names) {}
+
+  const char* type_key() const { return "verilator"; }
+
+  void LoadLibrary(const std::string& lib_name);
+
+  void Init(const Array<NDArray>& consts) override;
+
+  void Run() override;
+
+ private:
+  /* Device handle */
+  VerilatorHandle device_{nullptr};
+  /* Library handle */
+  VerilatorLibrary* lib_{nullptr};
+  /* Vadd */
+  VerilatorAddFunc vadd_func_{nullptr};
+};
+
+}  // namespace contrib
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -61,6 +61,20 @@ class VerilatorLibrary : public Library {
   void* lib_handle_{nullptr};
 };
 
+class VerilatorProfiler {
+ public:
+  /*! \brief clear the profiler */
+  void Clear();
+
+  std::string AsJSON();
+
+  static VerilatorProfiler* ThreadLocal();
+
+ private:
+  /*! \brief the number of cycle counter */
+  uint32_t cycle_counter{0};
+};
+
 class VerilatorRuntime : public JSONRuntimeBase {
  public:
   VerilatorRuntime(const std::string& symbol_name, const std::string& graph_json,

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -93,7 +93,7 @@ class VerilatorRuntime : public JSONRuntimeBase {
   /* Library handle. */
   VerilatorLibrary* lib_{nullptr};
   /* Add operator. */
-  VerilatorAddFunc add_func_{nullptr};
+  VerilatorAddFunc add_op_{nullptr};
   /* Number of reset cycles. */
   int reset_cycles_{1};
   /* Profiler status. */

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -77,17 +77,29 @@ class VerilatorRuntime : public JSONRuntimeBase {
 
   void LoadLibrary(const std::string& lib_name);
 
+  void SetResetCycles(const int cycles);
+
+  void EnableProfiler();
+
+  void SetProfilerCycleCounterId(const int id);
+
   void Init(const Array<NDArray>& consts) override;
 
   void Run() override;
 
  private:
-  /* Device handle */
+  /* Device handle. */
   VerilatorHandle device_{nullptr};
-  /* Library handle */
+  /* Library handle. */
   VerilatorLibrary* lib_{nullptr};
-  /* Vadd */
-  VerilatorAddFunc vadd_func_{nullptr};
+  /* Add operator. */
+  VerilatorAddFunc add_func_{nullptr};
+  /* Number of reset cycles. */
+  int reset_cycles_{1};
+  /* Profiler status. */
+  bool prof_enable_{false};
+  /* Profiler cycle counter id. */
+  int prof_cycle_counter_id_{0};
 };
 
 }  // namespace contrib

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -48,6 +48,7 @@ using namespace tvm::runtime::contrib;
 using namespace tvm::runtime::json;
 
 typedef VerilatorHandle (*VerilatorAllocFunc)();
+typedef void (*VerilatorDeallocFunc)(VerilatorHandle);
 typedef void (*VerilatorResetFunc)(VerilatorHandle, int);
 typedef void (*VerilatorAddFunc)(VerilatorHandle, int*, int*, int*, int, int);
 typedef int (*VerilatorReadFunc)(VerilatorHandle, int, int);
@@ -88,10 +89,12 @@ class VerilatorRuntime : public JSONRuntimeBase {
                    const Array<String> const_names)
       : JSONRuntimeBase(symbol_name, graph_json, const_names) {}
 
+  ~VerilatorRuntime();
+
   const char* type_key() const { return "verilator"; }
 
-  /*! \brief load verilator library */
-  void LoadLibrary(const std::string& lib_name);
+  /*! \brief set verilator library */
+  void SetLibrary(const std::string& lib_name);
 
   /*! \brief set the number of reset cycles */
   void SetResetCycles(const int cycles);
@@ -109,6 +112,8 @@ class VerilatorRuntime : public JSONRuntimeBase {
   void Run() override;
 
  private:
+  /*! \brief the verilator library path */
+  String lib_path_;
   /*! \brief the verilator device */
   VerilatorHandle device_{nullptr};
   /*! \brief the verilator library */

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -56,12 +56,14 @@ class VerilatorLibrary : public Library {
  public:
   ~VerilatorLibrary();
 
+  /*! \brief load library */
   void Load(const std::string& name);
 
+  /*! \brief get symbol from libray */
   void* GetSymbol(const char* name) final;
 
  private:
-  /* Library handle. */
+  /*! \brief the library handle */
   void* lib_handle_{nullptr};
 };
 
@@ -73,8 +75,10 @@ class VerilatorProfiler {
   /*! \brief clear the profiler */
   void Clear();
 
+  /*! \brief get profiler data */
   std::string AsJSON();
 
+  /*! \brief profiler constructor */
   static VerilatorProfiler* ThreadLocal();
 };
 
@@ -86,32 +90,40 @@ class VerilatorRuntime : public JSONRuntimeBase {
 
   const char* type_key() const { return "verilator"; }
 
+  /*! \brief load verilator library */
   void LoadLibrary(const std::string& lib_name);
 
+  /*! \brief set the number of reset cycles */
   void SetResetCycles(const int cycles);
 
+  /*! \brief enable profiler */
   void EnableProfiler();
 
+  /*! \brief set cycle counter register id */
   void SetProfilerCycleCounterId(const int id);
 
+  /*! \brief init verilator runtime */
   void Init(const Array<NDArray>& consts) override;
 
+  /*! \brief run verilator runtime */
   void Run() override;
 
  private:
-  /* Device handle. */
+  /*! \brief the verilator device */
   VerilatorHandle device_{nullptr};
-  /* Library handle. */
+  /*! \brief the verilator library */
   VerilatorLibrary* lib_{nullptr};
+  /*! \brief the verilator profiler */
   VerilatorProfiler* prof_{nullptr};
+  /*! \brief the verilator read function */
   VerilatorReadFunc read_{nullptr};
-  /* Add operator. */
+  /*! \brief the verilator add op function */
   VerilatorAddFunc add_op_{nullptr};
-  /* Number of reset cycles. */
+  /*! \brief the verilator reset cycles */
   int reset_cycles_{1};
-  /* Profiler status. */
+  /*! \brief the verilator profiler status */
   bool prof_enable_{false};
-  /* Profiler cycle counter id. */
+  /*! \brief the verilator profiler cycle counter id */
   int prof_cycle_counter_id_{0};
 };
 

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -47,6 +47,7 @@ using namespace tvm::runtime::json;
 typedef VerilatorHandle (*VerilatorAllocFunc)();
 typedef void (*VerilatorResetFunc)(VerilatorHandle, int);
 typedef void (*VerilatorAddFunc)(VerilatorHandle, int*, int*, int*, int, int);
+typedef int (*VerilatorReadFunc)(VerilatorHandle, int, int);
 
 class VerilatorLibrary : public Library {
  public:
@@ -63,16 +64,15 @@ class VerilatorLibrary : public Library {
 
 class VerilatorProfiler {
  public:
+  /*! \brief the number of cycle counter */
+  uint32_t cycle_counter{0};
+
   /*! \brief clear the profiler */
   void Clear();
 
   std::string AsJSON();
 
   static VerilatorProfiler* ThreadLocal();
-
- private:
-  /*! \brief the number of cycle counter */
-  uint32_t cycle_counter{0};
 };
 
 class VerilatorRuntime : public JSONRuntimeBase {
@@ -100,6 +100,8 @@ class VerilatorRuntime : public JSONRuntimeBase {
   VerilatorHandle device_{nullptr};
   /* Library handle. */
   VerilatorLibrary* lib_{nullptr};
+  VerilatorProfiler* prof_{nullptr};
+  VerilatorReadFunc read_{nullptr};
   /* Add operator. */
   VerilatorAddFunc add_op_{nullptr};
   /* Number of reset cycles. */

--- a/src/runtime/contrib/verilator/verilator_runtime.h
+++ b/src/runtime/contrib/verilator/verilator_runtime.h
@@ -50,20 +50,14 @@ typedef void (*VerilatorAddFunc)(VerilatorHandle, int*, int*, int*, int, int);
 
 class VerilatorLibrary : public Library {
  public:
-  ~VerilatorLibrary() {
-    if (lib_handle_) Unload();
-  }
-  void Init(const std::string& name) { Load(name); }
+  ~VerilatorLibrary();
 
-  void* GetSymbol(const char* name) final { return GetSymbol_(name); }
-
- private:
   void Load(const std::string& name);
 
-  void* GetSymbol_(const char* name);
+  void* GetSymbol(const char* name) final;
 
-  void Unload();
-
+ private:
+  /* Library handle. */
   void* lib_handle_{nullptr};
 };
 

--- a/tests/python/contrib/test_verilator/infrastructure.py
+++ b/tests/python/contrib/test_verilator/infrastructure.py
@@ -104,9 +104,7 @@ def compile_module(mod):
 
     opts = {"lib_path": lib}
 
-    with tvm.transform.PassContext(
-        opt_level=3, config={"relay.ext.verilator.options": opts}
-    ):
+    with tvm.transform.PassContext(opt_level=3, config={"relay.ext.verilator.options": opts}):
         exe = relay.vm.compile(mod, target="llvm", params=None)
         code, lib = exe.save()
         return runtime.vm.Executable.load_exec(code, lib)

--- a/tests/python/contrib/test_verilator/infrastructure.py
+++ b/tests/python/contrib/test_verilator/infrastructure.py
@@ -102,8 +102,10 @@ def compile_module(mod):
     if not os.path.isfile(lib):
         compile_hardware()
 
+    opts = {"lib_path": lib, "reset_cycles": 3}
+
     with tvm.transform.PassContext(
-        opt_level=3, config={"relay.ext.verilator.options": {"lib": lib}}
+        opt_level=3, config={"relay.ext.verilator.options": opts}
     ):
         exe = relay.vm.compile(mod, target="llvm", params=None)
         code, lib = exe.save()

--- a/tests/python/contrib/test_verilator/infrastructure.py
+++ b/tests/python/contrib/test_verilator/infrastructure.py
@@ -102,7 +102,7 @@ def compile_module(mod):
     if not os.path.isfile(lib):
         compile_hardware()
 
-    opts = {"lib_path": lib, "reset_cycles": 3}
+    opts = {"lib_path": lib}
 
     with tvm.transform.PassContext(
         opt_level=3, config={"relay.ext.verilator.options": opts}


### PR DESCRIPTION
This PR refactors the Verilator runtime to support multiple options, including enabling a profiler for hardware designs that support performance counters. Also, I added some documentation to header files.

After this gets merged, my next goal is to update the Verilator app in VTA to showcase how this profiling information can be used when running actual models.

@tmoreau89 @liangfu 
