### PR TITLE
[WIP][Relay][BBNF] Lift nodes used across scope for basic block normal form

### DIFF
--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -84,8 +84,9 @@ std::pair<NodeScopeMap, ExprSet> CalcScope(const DependencyGraph& dg) {
         // filter out exprs whose scope do not matter
         Expr expr = node_to_expr[n];
         if (!expr.as<OpNode>()) {
-          // only variables can be used across scope boundaries
-          if (s != original_s || (crosses_scopes && !expr.as<VarNode>())) {
+          // only variables and constants can be used across scope boundaries
+          bool must_lift = !expr.as<VarNode>() && !expr.as<ConstantNode>();
+          if (s != original_s || (crosses_scopes && must_lift)) {
             lifted_exprs.insert(expr);
           }
         }

--- a/tests/python/relay/test_analysis_basic_block_normal_form.py
+++ b/tests/python/relay/test_analysis_basic_block_normal_form.py
@@ -212,8 +212,7 @@ def test_higher_order_nested():
 
 @pytest.mark.xfail(raises=tvm.error.TVMError)
 def test_unbound_cross_scope():
-  source = \
-    """
+    source = """
     #[version = "0.0.5"]
     def @main(%x: int, %y: int) {
         %0 = add(%x, %y);
@@ -225,13 +224,12 @@ def test_unbound_cross_scope():
         }
     }
     """
-  prog = tvm.parser.fromtext(source)["main"]
-  check_basic_block_normal_form(prog)
+    prog = tvm.parser.fromtext(source)["main"]
+    check_basic_block_normal_form(prog)
 
 
 def test_bound_cross_scope():
-  source = \
-    """
+    source = """
     #[version = "0.0.5"]
     def @main(%x: int, %y: int) {
         let %v0 = add(%x, %y);
@@ -243,8 +241,8 @@ def test_bound_cross_scope():
         }
     }
     """
-  prog = tvm.parser.fromtext(source)["main"]
-  check_basic_block_normal_form(prog)
+    prog = tvm.parser.fromtext(source)["main"]
+    check_basic_block_normal_form(prog)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_analysis_basic_block_normal_form.py
+++ b/tests/python/relay/test_analysis_basic_block_normal_form.py
@@ -225,7 +225,7 @@ def test_unbound_cross_scope():
         }
     }
     """
-  prog = tvm.parser.fromtext(source)
+  prog = tvm.parser.fromtext(source)["main"]
   check_basic_block_normal_form(prog)
 
 

--- a/tests/python/relay/test_analysis_basic_block_normal_form.py
+++ b/tests/python/relay/test_analysis_basic_block_normal_form.py
@@ -210,5 +210,42 @@ def test_higher_order_nested():
     check_basic_block_normal_form(top)
 
 
+@pytest.mark.xfail(raises=tvm.error.TVMError)
+def test_unbound_cross_scope():
+  source = \
+    """
+    #[version = "0.0.5"]
+    def @main(%x: int, %y: int) {
+        %0 = add(%x, %y);
+        %1 = less(%0, 0);
+        if (%1) {
+            multiply(%0, %x)
+        } else {
+            multiply(%0, %y)
+        }
+    }
+    """
+  prog = tvm.parser.fromtext(source)
+  check_basic_block_normal_form(prog)
+
+
+def test_bound_cross_scope():
+  source = \
+    """
+    #[version = "0.0.5"]
+    def @main(%x: int, %y: int) {
+        let %v0 = add(%x, %y);
+        %0 = less(%v0, 0);
+        if (%0) {
+            multiply(%v0, %x)
+        } else {
+            multiply(%v0, %y)
+        }
+    }
+    """
+  prog = tvm.parser.fromtext(source)["main"]
+  check_basic_block_normal_form(prog)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/test_pass_to_basic_block_normal_form.py
+++ b/tests/python/relay/test_pass_to_basic_block_normal_form.py
@@ -407,6 +407,7 @@ def test_if():
           multiply(%v1, 1f /* ty=float32 */) /* ty=float32 */
         }
         """
+        # FIXME: BBNF requirements D1 & D2 imply these consts must be let bound
         one = relay.const(1, dtype="float32")
         two = relay.const(2, dtype="float32")
         v1 = relay.var("v1")

--- a/tests/python/relay/test_pass_to_basic_block_normal_form.py
+++ b/tests/python/relay/test_pass_to_basic_block_normal_form.py
@@ -491,8 +491,7 @@ def test_higher_order_nested():
 
 
 def test_lift_cross_scope():
-  source_pre = \
-    """
+    source_pre = """
     #[version = "0.0.5"]
     def @main(%x: int, %y: int) {
         %0 = add(%x, %y);
@@ -504,8 +503,7 @@ def test_lift_cross_scope():
         }
     }
     """
-  source_expected = \
-    """
+    source_expected = """
     #[version = "0.0.5"]
     def @main(%x: int, %y: int) {
         let %v0 = add(%x, %y);
@@ -517,11 +515,11 @@ def test_lift_cross_scope():
         }
     }
     """
-  pre = tvm.parser.fromtext(source_pre)["main"]
-  expected = tvm.parser.fromtext(source_expected)["main"]
-  result = run_opt_pass(pre, [transform.ToBasicBlockNormalForm(), transform.InferType()])
-  assert tvm.ir.structural_equal(result, expected)
-  check_basic_block_normal_form(result)
+    pre = tvm.parser.fromtext(source_pre)["main"]
+    expected = tvm.parser.fromtext(source_expected)["main"]
+    result = run_opt_pass(pre, [transform.ToBasicBlockNormalForm(), transform.InferType()])
+    assert tvm.ir.structural_equal(result, expected)
+    check_basic_block_normal_form(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, the following program was considered valid BBNF (by the BBNF checker)
```
#[version = "0.0.5"]
def @main(%x: int, %y: int) {
    %0 = add(%x, %y);     /* block0 */
    %1 = less(%0, 0);     /* block0 */
    if (%1) {             /* block0 */
        multiply(%0, %x)  /* block1 */
    } else {
        multiply(%0, %y)  /* block2 */
    }
}
```
Note that `%0` is used in multiple blocks, which per D2 of the [RFC](https://discuss.tvm.apache.org/t/basic-block-normal-form/5908) means it must be let-bound to a variable.

This PR disallows this behavior, with an exception for Constant nodes (they are treated like variables).

cc @eric-haibin-lin @MarisaKirisame @mbrookhart 