### PR TITLE
[TIR] Add TIR While node

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -862,6 +862,53 @@ class For : public Stmt {
 };
 
 /*!
+ * \brief A While loop
+ *
+ * \code
+ *
+ *  while (condition)
+ *    body
+ *
+ * \endcode
+ */
+class WhileNode : public StmtNode {
+ public:
+  /*! \brief The minimum value of iteration. */
+  PrimExpr condition;
+  /*! \brief The body of the for loop. */
+  Stmt body;
+
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("condition", &condition);
+    v->Visit("body", &body);
+    v->Visit("span", &span);
+  }
+
+  bool SEqualReduce(const WhileNode* other, SEqualReducer equal) const {
+    return equal.DefEqual(condition, other->condition) && equal.DefEqual(body, other->body);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce.DefHash(condition);
+    hash_reduce.DefHash(body);
+  }
+
+  static constexpr const char* _type_key = "tir.While";
+  TVM_DECLARE_FINAL_OBJECT_INFO(WhileNode, StmtNode);
+};
+
+/*!
+ * \brief Managed reference to WhileNode.
+ * \sa WhileNode
+ */
+class While : public Stmt {
+ public:
+  TVM_DLL While(PrimExpr condition, Stmt body, Span span = Span());
+
+  TVM_DEFINE_OBJECT_REF_METHODS(While, Stmt, WhileNode);
+};
+
+/*!
  * \brief A prefetch hint for a buffer
  */
 class PrefetchNode : public StmtNode {

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -873,9 +873,9 @@ class For : public Stmt {
  */
 class WhileNode : public StmtNode {
  public:
-  /*! \brief The minimum value of iteration. */
+  /*! \brief The termination condition. */
   PrimExpr condition;
-  /*! \brief The body of the for loop. */
+  /*! \brief The body of the while loop. */
   Stmt body;
 
   void VisitAttrs(AttrVisitor* v) {

--- a/include/tvm/tir/stmt_functor.h
+++ b/include/tvm/tir/stmt_functor.h
@@ -112,6 +112,7 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
     IR_STMT_FUNCTOR_DISPATCH(AttrStmtNode);
     IR_STMT_FUNCTOR_DISPATCH(IfThenElseNode);
     IR_STMT_FUNCTOR_DISPATCH(ForNode);
+    IR_STMT_FUNCTOR_DISPATCH(WhileNode);
     IR_STMT_FUNCTOR_DISPATCH(AllocateNode);
     IR_STMT_FUNCTOR_DISPATCH(StoreNode);
     IR_STMT_FUNCTOR_DISPATCH(AssertStmtNode);

--- a/include/tvm/tir/stmt_functor.h
+++ b/include/tvm/tir/stmt_functor.h
@@ -86,6 +86,7 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
   virtual R VisitStmt_(const AttrStmtNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const IfThenElseNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const ForNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
+  virtual R VisitStmt_(const WhileNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const AllocateNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const StoreNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmt_(const BufferStoreNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
@@ -152,6 +153,7 @@ class TVM_DLL StmtVisitor : protected StmtFunctor<void(const Stmt&)> {
   void VisitStmt_(const IfThenElseNode* op) override;
   void VisitStmt_(const LetStmtNode* op) override;
   void VisitStmt_(const ForNode* op) override;
+  void VisitStmt_(const WhileNode* op) override;
   void VisitStmt_(const AllocateNode* op) override;
   void VisitStmt_(const StoreNode* op) override;
   void VisitStmt_(const BufferStoreNode* op) override;
@@ -245,6 +247,7 @@ class TVM_DLL StmtMutator : protected StmtFunctor<Stmt(const Stmt&)> {
   Stmt VisitStmt_(const IfThenElseNode* op) override;
   Stmt VisitStmt_(const LetStmtNode* op) override;
   Stmt VisitStmt_(const ForNode* op) override;
+  Stmt VisitStmt_(const WhileNode* op) override;
   Stmt VisitStmt_(const AllocateNode* op) override;
   Stmt VisitStmt_(const StoreNode* op) override;
   Stmt VisitStmt_(const BufferStoreNode* op) override;

--- a/python/tvm/tir/ir_builder.py
+++ b/python/tvm/tir/ir_builder.py
@@ -263,6 +263,14 @@ class IRBuilder(object):
 
         return WithScope(loop_var, _exit_cb)
 
+    def while_loop(self, condition):
+        """TODO"""
+        self._seq_stack.append([])
+        def _exit_cb():
+            self.emit(_stmt.While(condition, self._pop_seq()))
+
+        return WithScope(None, _exit_cb)
+
     def if_scope(self, cond):
         """Create an if scope.
 

--- a/python/tvm/tir/ir_builder.py
+++ b/python/tvm/tir/ir_builder.py
@@ -264,7 +264,27 @@ class IRBuilder(object):
         return WithScope(loop_var, _exit_cb)
 
     def while_loop(self, condition):
-        """TODO"""
+        """Create a while loop scope.
+
+        Parameters
+        ----------
+        condition : Expr
+            The termination condition.
+
+        Returns
+        -------
+        loop_scope : With.Scope of Var
+            The while scope.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            ib = tvm.tir.ir_builder.create()
+            iterations = ib.allocate("int32", (1,), name="iterations", scope="local")
+            with ib.while_loop(iterations[0] < 10):
+                iterations[0] += 1
+        """
         self._seq_stack.append([])
 
         def _exit_cb():

--- a/python/tvm/tir/ir_builder.py
+++ b/python/tvm/tir/ir_builder.py
@@ -266,6 +266,7 @@ class IRBuilder(object):
     def while_loop(self, condition):
         """TODO"""
         self._seq_stack.append([])
+
         def _exit_cb():
             self.emit(_stmt.While(condition, self._pop_seq()))
 

--- a/python/tvm/tir/stmt.py
+++ b/python/tvm/tir/stmt.py
@@ -161,7 +161,19 @@ class For(Stmt):
 
 @tvm._ffi.register_object("tir.While")
 class While(Stmt):
-    """TODO"""
+    """While node.
+
+    Parameters
+    ----------
+    condition : PrimExpr
+        The termination condition.
+
+    body : Stmt
+        The body statement.
+
+    span : Optional[Span]
+        The location of this itervar in the source code.
+    """
 
     def __init__(self, condition, body, span=None):
         self.__init_handle_by_constructor__(

--- a/python/tvm/tir/stmt.py
+++ b/python/tvm/tir/stmt.py
@@ -158,6 +158,7 @@ class For(Stmt):
             span,
         )
 
+
 @tvm._ffi.register_object("tir.While")
 class While(Stmt):
     """TODO"""

--- a/python/tvm/tir/stmt.py
+++ b/python/tvm/tir/stmt.py
@@ -158,6 +158,18 @@ class For(Stmt):
             span,
         )
 
+@tvm._ffi.register_object("tir.While")
+class While(Stmt):
+    """TODO"""
+
+    def __init__(self, condition, body, span=None):
+        self.__init_handle_by_constructor__(
+            _ffi_api.While,
+            condition,
+            body,
+            span,
+        )
+
 
 @tvm._ffi.register_object("tir.Store")
 class Store(Stmt):

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -308,6 +308,7 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc VisitStmt_(const SeqStmtNode* op) override;
   Doc VisitStmt_(const EvaluateNode* op) override;
   Doc VisitStmt_(const ForNode* op) override;
+  Doc VisitStmt_(const WhileNode* op) override;
   Doc VisitStmt_(const PrefetchNode* op) override;
   Doc VisitStmtDefault_(const Object* op) override;
 

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -494,6 +494,13 @@ Doc TIRTextPrinter::VisitStmt_(const ForNode* op) {
   return doc;
 }
 
+Doc TIRTextPrinter::VisitStmt_(const WhileNode* op) {
+  Doc doc;
+  doc << "while (" << Print(op->condition) << ")";
+  doc << PrintBody(op->body);
+  return doc;
+}
+
 Doc TIRTextPrinter::VisitStmt_(const PrefetchNode* op) {
   Doc doc;
   doc << "prefetch(" << Print(op->buffer) << ", " << Print(op->bounds) << ")";

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1328,6 +1328,20 @@ void CodeGenLLVM::VisitStmt_(const ForNode* op) {
                   llvm::ConstantInt::getSigned(GetLLVMType(op->extent), 1), op->loop_var, op->body);
 }
 
+void CodeGenLLVM::VisitStmt_(const WhileNode* op) {
+  using llvm::BasicBlock;
+  BasicBlock* while_cond = BasicBlock::Create(*ctx_, "while_cond", function_);
+  BasicBlock* while_body = BasicBlock::Create(*ctx_, "while_body", function_);
+  BasicBlock* while_merge = BasicBlock::Create(*ctx_, "while_merge", function_);
+  builder_->CreateBr(while_cond);
+  builder_->SetInsertPoint(while_cond);
+  builder_->CreateCondBr(MakeValue(op->condition), while_body, while_merge);
+  builder_->SetInsertPoint(while_body);
+  this->VisitStmt(op->body);
+  builder_->CreateBr(while_cond);
+  builder_->SetInsertPoint(while_merge);
+}
+
 void CodeGenLLVM::VisitStmt_(const IfThenElseNode* op) {
   using llvm::BasicBlock;
   llvm::Value* cond = MakeValue(op->condition);

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -152,6 +152,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   // stmt
   void VisitStmt_(const StoreNode* op) override;
   void VisitStmt_(const ForNode* op) override;
+  void VisitStmt_(const WhileNode* op) override;
   void VisitStmt_(const IfThenElseNode* op) override;
   void VisitStmt_(const AllocateNode* op) override;
   void VisitStmt_(const AttrStmtNode* op) override;

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -728,7 +728,6 @@ void CodeGenC::VisitStmt_(const StoreNode* op) {
     ICHECK(is_one(op->predicate)) << "Predicated store is not supported";
     arith::PVar<PrimExpr> base;
 
-
     if (arith::ramp(base, 1, t.lanes()).Match(op->index)) {
       std::string value = this->PrintExpr(op->value);
       this->PrintVecStore(op->buffer_var.get(), t, base.Eval(), value);
@@ -895,6 +894,16 @@ void CodeGenC::VisitStmt_(const ForNode* op) {
   int for_scope = BeginScope();
   PrintStmt(op->body);
   this->EndScope(for_scope);
+  PrintIndent();
+  stream << "}\n";
+}
+
+void CodeGenC::VisitStmt_(const WhileNode* op) {
+  PrintIndent();
+  stream << "while (" << PrintExpr(op->condition) << ") {\n";
+  int while_scope = BeginScope();
+  PrintStmt(op->body);
+  this->EndScope(while_scope);
   PrintIndent();
   stream << "}\n";
 }

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -150,6 +150,7 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
   void VisitStmt_(const LetStmtNode* op) override;
   void VisitStmt_(const StoreNode* op) override;
   void VisitStmt_(const ForNode* op) override;
+  void VisitStmt_(const WhileNode* op) override;
   void VisitStmt_(const IfThenElseNode* op) override;
   void VisitStmt_(const AllocateNode* op) override;
   void VisitStmt_(const AttrStmtNode* op) override;

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -201,6 +201,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 While::While(PrimExpr condition, Stmt body, Span span) {
   ICHECK(condition.defined());
   ICHECK(condition.dtype().is_scalar());
+  ICHECK(condition.as<tir::IntImmNode>() == nullptr) << "The condition should not be trivial.";
   ICHECK(body.defined());
 
   ObjectPtr<WhileNode> node = make_object<WhileNode>();

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -197,6 +197,37 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
       p->stream << "}\n";
     });
 
+// While
+While::While(PrimExpr condition, Stmt body, Span span) {
+  ICHECK(condition.defined());
+  ICHECK(condition.dtype().is_scalar());
+  ICHECK(body.defined());
+
+  ObjectPtr<WhileNode> node = make_object<WhileNode>();
+  node->condition = std::move(condition);
+  node->body = std::move(body);
+  node->span = std::move(span);
+  data_ = std::move(node);
+}
+
+TVM_REGISTER_GLOBAL("tir.While").set_body_typed([](PrimExpr condition, Stmt body, Span span) {
+  return While(condition, body, span);
+});
+
+TVM_REGISTER_NODE_TYPE(WhileNode);
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<WhileNode>([](const ObjectRef& node, ReprPrinter* p) {
+      auto* op = static_cast<const WhileNode*>(node.get());
+      p->PrintIndent();
+      p->stream << "while(" << op->condition << "){\n";
+      p->indent += 2;
+      p->Print(op->body);
+      p->indent -= 2;
+      p->PrintIndent();
+      p->stream << "}\n";
+    });
+
 // Store
 Store::Store(Var buffer_var, PrimExpr value, PrimExpr index, PrimExpr predicate, Span span) {
   ICHECK(value.defined());

--- a/src/tir/transforms/coproc_sync.cc
+++ b/src/tir/transforms/coproc_sync.cc
@@ -429,6 +429,11 @@ class CoProcInstDepDetector : public StmtVisitor {
     }
   }
 
+  void VisitStmt_(const WhileNode* op) final {
+    // TODO(masahi): Do we need a special handling for While nodes?
+    LOG(FATAL) << "WhileNode not supported in CoProcSync.";
+  }
+
   // insert before is stored in reverse order
   // the first element is closest to the node.
   std::unordered_map<const Object*, std::vector<Stmt> > insert_before_;

--- a/src/tir/transforms/inject_virtual_thread.cc
+++ b/src/tir/transforms/inject_virtual_thread.cc
@@ -333,6 +333,12 @@ class VTInjector : public StmtExprMutator {
     }
   }
 
+  // While
+  Stmt VisitStmt_(const WhileNode* op) final {
+    // TODO(masahi): Do we need a special handling for While nodes?
+    return StmtMutator::VisitStmt_(op);
+  }
+
   // Seq
   Stmt VisitStmt_(const SeqStmtNode* op) final {
     ICHECK_EQ(max_loop_depth_, 0);

--- a/src/tir/transforms/inject_virtual_thread.cc
+++ b/src/tir/transforms/inject_virtual_thread.cc
@@ -335,8 +335,9 @@ class VTInjector : public StmtExprMutator {
 
   // While
   Stmt VisitStmt_(const WhileNode* op) final {
-    // TODO(masahi): Do we need a special handling for While nodes?
-    return StmtMutator::VisitStmt_(op);
+    // TODO(masahi): What should we do for While nodes?
+    LOG(FATAL) << "WhileNode in InjectVirtualThread not supported yet";
+    return Stmt();
   }
 
   // Seq

--- a/src/tir/transforms/lift_attr_scope.cc
+++ b/src/tir/transforms/lift_attr_scope.cc
@@ -157,6 +157,12 @@ class AttrScopeLifter : public StmtMutator {
     }
   }
 
+  Stmt VisitStmt_(const WhileNode* op) final {
+    // TODO(masahi): Do we need a special handling for While nodes?
+    LOG(FATAL) << "WhileNode not supported in LiftAttrScope.";
+    return Stmt();
+  }
+
  private:
   // value comparison that also compares content of int constant
   static bool ValueSame(const PrimExpr& a, const PrimExpr& b) {

--- a/src/tir/transforms/storage_access.cc
+++ b/src/tir/transforms/storage_access.cc
@@ -180,6 +180,19 @@ void StorageAccessVisitor::VisitStmt_(const IfThenElseNode* op) {
   --condition_counter_;
 }
 
+void StorageAccessVisitor::VisitStmt_(const WhileNode* op) {
+  ++condition_counter_;
+  this->VisitExpr(op->condition);
+  scope_.push_back(std::vector<StmtEntry>());
+  this->VisitStmt(op->body);
+  StmtEntry s;
+  s.stmt = op;
+  s.access = Summarize(std::move(scope_.back()), nullptr);
+  scope_.pop_back();
+  scope_.back().emplace_back(std::move(s));
+  --condition_counter_;
+}
+
 void StorageAccessVisitor::VisitExpr_(const CallNode* op) {
   if (op->op.same_as(builtin::address_of())) {
     const LoadNode* l = op->args[0].as<LoadNode>();

--- a/src/tir/transforms/storage_access.h
+++ b/src/tir/transforms/storage_access.h
@@ -84,6 +84,7 @@ class StorageAccessVisitor : public StmtExprVisitor {
   void VisitStmt_(const AttrStmtNode* op) final;
   void VisitStmt_(const ForNode* op) final;
   void VisitStmt_(const IfThenElseNode* op) final;
+  void VisitStmt_(const WhileNode* op) final;
   void VisitExpr_(const CallNode* op) final;
 
  protected:

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -352,16 +352,7 @@ class StoragePlanRewriter : public StmtExprMutator {
     // start rewrite
     stmt = operator()(std::move(stmt));
     if (attach_map_.count(nullptr)) {
-      std::vector<Stmt> nest;
-      for (StorageEntry* e : attach_map_.at(nullptr)) {
-        // ICHECK_EQ(e->scope.rank, 0);
-        if (e->new_alloc.defined()) {
-          nest.emplace_back(AttrStmt(e->alloc_var, attr::storage_scope,
-                                     StringImm(e->scope.to_string()), Evaluate(0)));
-          nest.push_back(e->new_alloc);
-        }
-      }
-      stmt = MergeNest(nest, stmt);
+      return MakeAttach(attach_map_.at(nullptr), stmt);
     }
     return stmt;
   }

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -432,6 +432,7 @@ class StoragePlanRewriter : public StmtExprMutator {
       return StmtExprMutator::VisitStmt_(op);
     }
   }
+
   Stmt VisitStmt_(const ForNode* op) final {
     ICHECK(op->kind != ForKind::kVectorized) << "VectorizeLoop before LiftStorageAlloc";
     // remake all the allocation at the attach scope.
@@ -441,18 +442,6 @@ class StoragePlanRewriter : public StmtExprMutator {
       op = stmt.as<ForNode>();
       return For(op->loop_var, op->min, op->extent, op->kind, MakeAttach(svec, op->body),
                  op->thread_binding, op->annotations);
-    } else {
-      return StmtExprMutator::VisitStmt_(op);
-    }
-  }
-
-  Stmt VisitStmt_(const WhileNode* op) final {
-    // remake all the allocation at the attach scope.
-    if (attach_map_.count(op)) {
-      auto& svec = attach_map_[op];
-      Stmt stmt = StmtExprMutator::VisitStmt_(op);
-      op = stmt.as<WhileNode>();
-      return While(op->condition, MakeAttach(svec, op->body));
     } else {
       return StmtExprMutator::VisitStmt_(op);
     }

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -192,6 +192,8 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
 
   void VisitStmt_(const ForNode* op) final { VisitNewScope(op); }
 
+  void VisitStmt_(const WhileNode* op) final { VisitNewScope(op); }
+
   void VisitStmt_(const AssertStmtNode* op) final { VisitNewScope(op); }
 
   // linearized access sequence.

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -246,6 +246,8 @@ class InplaceOpVerifier : public StmtExprVisitor {
       VisitStmt_(static_cast<const ForNode*>(stmt));
     } else if (stmt->IsInstance<IfThenElseNode>()) {
       VisitStmt_(static_cast<const IfThenElseNode*>(stmt));
+    } else if (stmt->IsInstance<WhileNode>()) {
+      VisitStmt_(static_cast<const WhileNode*>(stmt));
     } else if (stmt->IsInstance<StoreNode>()) {
       VisitStmt_(static_cast<const StoreNode*>(stmt));
     } else {

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -446,6 +446,18 @@ class StoragePlanRewriter : public StmtExprMutator {
     }
   }
 
+  Stmt VisitStmt_(const WhileNode* op) final {
+    // remake all the allocation at the attach scope.
+    if (attach_map_.count(op)) {
+      auto& svec = attach_map_[op];
+      Stmt stmt = StmtExprMutator::VisitStmt_(op);
+      op = stmt.as<WhileNode>();
+      return While(op->condition, MakeAttach(svec, op->body));
+    } else {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+  }
+
   Stmt VisitStmt_(const AllocateNode* op) final { return this->VisitStmt(op->body); }
 
  private:

--- a/src/tir/transforms/vectorize_loop.cc
+++ b/src/tir/transforms/vectorize_loop.cc
@@ -388,6 +388,11 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
       return IfThenElse(condition, then_case, else_case);
     }
   }
+  // While
+  Stmt VisitStmt_(const WhileNode* op) final {
+    LOG(FATAL) << "A while loop inside a vectorized loop not supported.";
+    return Stmt();
+  }
   // LetStmt
   Stmt VisitStmt_(const LetStmtNode* op) final {
     PrimExpr value = this->VisitExpr(op->value);
@@ -441,7 +446,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   }
   // ProducerStore
   Stmt VisitStmt_(const ProducerStoreNode* op) final {
-    LOG(FATAL) << "ProducerProvide is cannot appear in a TIR PrimFunc";
+    LOG(FATAL) << "ProducerProvide cannot appear in a TIR PrimFunc";
     return Stmt();
   }
 

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -495,53 +495,6 @@ def test_while_binary_search():
     check_target("nvptx", searchsorted_ir_gpu)
 
 
-def test_vectorize_while_fail():
-    """A while loop inside a vectorized loop should fail."""
-
-    n = 64
-    num_iter = 10
-
-    def test_ir(A, B, C):
-        ib = tvm.tir.ir_builder.create()
-        n = C.shape[0]
-        A = ib.buffer_ptr(A)
-        B = ib.buffer_ptr(B)
-        C = ib.buffer_ptr(C)
-        i = ib.allocate("int32", (1,), name="i", scope="local")
-        i[0] = 0
-
-        with ib.for_range(0, n) as j:
-            C[j] = 0.0
-
-        with ib.for_range(0, n, kind="vectorize") as j:
-            with ib.while_loop(i[0] < num_iter):
-                C[j] += A[j] + B[j]
-                i[0] += 1
-
-        return ib.get()
-
-    dtype = "float32"
-    A = te.placeholder((n,), name="A", dtype=dtype)
-    B = te.placeholder((n,), name="B", dtype=dtype)
-
-    C = te.extern(
-        (n,),
-        [A, B],
-        lambda ins, outs: test_ir(ins[0], ins[1], outs[0]),
-        name="while_vectorize",
-        dtype=dtype,
-    )
-    s = te.create_schedule(C.op)
-
-    try:
-        tvm.lower(s, [A, B, C], "llvm")
-        assert False
-    except tvm.error.TVMError as e:
-        error_msg = str(e).split("\n")[-1]
-        expected = "A while loop inside a vectorized loop not supported"
-        assert expected in error_msg
-
-
 if __name__ == "__main__":
     test_prefetch()
     test_if()
@@ -552,4 +505,3 @@ if __name__ == "__main__":
     test_while_collatz()
     test_while_mandel()
     test_while_binary_search()
-    test_vectorize_while_fail()

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -173,7 +173,7 @@ def test_gpu():
     check_target("cuda")
 
 
-def test_while():
+def test_while_mandel():
     n = 160
     shape = (n * 2, n)
     t = 300
@@ -290,7 +290,11 @@ def test_while():
     check_target("cuda", mandel_ir_gpu)
 
 
-def test_binary_search():
+def test_collatz():
+    pass
+
+
+def test_while_binary_search():
     def binary_search(ib, n, i, Aptr, Bptr, Cptr):
         lo = ib.allocate("int32", (1,), name="lo", scope="local")
         hi = ib.allocate("int32", (1,), name="hi", scope="local")
@@ -384,5 +388,6 @@ if __name__ == "__main__":
     test_for()
     test_cpu()
     test_gpu()
-    test_while()
-    test_binary_search()
+    test_while_mandel()
+    test_while_collatz()
+    test_while_binary_search()

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -419,7 +419,7 @@ def test_while_binary_search():
         v = Bptr[i]
 
         with ib.while_loop(lo[0] < hi[0]):
-            mid = lo[0] + tvm.tir.floordiv(hi[0] - lo[0], 2).astype("int32")
+            mid = lo[0] + (hi[0] - lo[0] >> 1)
             with ib.if_scope(Aptr[mid] < v):
                 lo[0] = mid + 1
             with ib.else_scope():

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -535,6 +535,7 @@ def test_vectorize_while_fail():
 
     try:
         tvm.lower(s, [A, B, C], "llvm")
+        assert False
     except tvm.error.TVMError as e:
         error_msg = str(e).split("\n")[-1]
         expected = "A while loop inside a vectorized loop not supported"

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -243,8 +243,6 @@ def test_binary_search():
         s = te.create_schedule(C.op)
 
         with tvm.transform.PassContext(opt_level=3, disabled_pass=["HoistIfThenElse"]):
-            print(tvm.lower(s, [A, B, C], simple_mode=True))
-            return
             func = tvm.build(s, [A, B, C], target)
 
         ctx = tvm.context(target, 0)
@@ -259,14 +257,14 @@ def test_binary_search():
         tvm.testing.assert_allclose(c.asnumpy(), ref)
 
     check_target("llvm", searchsorted_ir_cpu)
-    # check_target("cuda", searchsorted_ir_gpu)
-    # check_target("nvptx", searchsorted_ir_gpu)
+    check_target("cuda", searchsorted_ir_gpu)
+    check_target("nvptx", searchsorted_ir_gpu)
 
 
 if __name__ == "__main__":
-    # test_prefetch()
-    # test_if()
-    # test_for()
-    # test_cpu()
-    # test_gpu()
+    test_prefetch()
+    test_if()
+    test_for()
+    test_cpu()
+    test_gpu()
     test_binary_search()

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -173,6 +173,94 @@ def test_gpu():
     check_target("cuda")
 
 
+def test_while():
+    n = 160
+    shape = (n * 2, n)
+    t = 300
+
+    def mandel_ref():
+        def complex_sqr(z):
+            return np.array([z[0] ** 2 - z[1] ** 2, z[1] * z[0] * 2])
+
+        pixels = np.zeros(shape)
+
+        for i in range(pixels.shape[0]):
+            for j in range(pixels.shape[1]):
+                c = np.array([-0.8, np.cos(t) * 0.2])
+                z = np.array([i / n - 1, j / n - 0.5]) * 2
+                iterations = 0
+
+                while np.linalg.norm(z) < 20 and iterations < 50:
+                    z = complex_sqr(z) + c
+                    iterations += 1
+
+                pixels[i, j] = 1 - iterations * 0.02
+
+        return pixels
+
+    def mandel(ib, i, j, pixels):
+        c = ib.allocate("float32", (2,), name="c", scope="local")
+        z = ib.allocate("float32", (2,), name="z", scope="local")
+        tmp = ib.allocate("float32", (1,), name="1", scope="local")
+        iterations = ib.allocate("int32", (1,), name="iterations", scope="local")
+
+        c[0] = -0.8
+        c[1] = float(np.cos(t)) * 0.2
+        z[0] = (i / float(n) - 1) * 2
+        z[1] = (j / float(n) - 0.5) * 2
+        iterations[0] = 0
+
+        def norm(z):
+            return tvm.tir.sqrt(z[0] * z[0] + z[1] * z[1])
+
+        with ib.while_loop(tvm.tir.all(norm(z) < 20, iterations[0] < 50)):
+            tmp[0] = z[0]
+            z[0] = z[0] * z[0] - z[1] * z[1] + c[0]
+            z[1] = z[1] * tmp[0] * 2 + c[1]
+            iterations[0] += 1
+
+        pixels[i, j] = 1 - iterations[0] * 0.02
+
+    def mandel_ir_cpu(C):
+        ib = tvm.tir.ir_builder.create()
+        ny = C.shape[0]
+        nx = C.shape[1]
+        C = ib.buffer_ptr(C)
+
+        with ib.for_range(0, ny, name="i", kind="parallel") as i:
+            with ib.for_range(0, nx, name="j") as j:
+                mandel(ib, i, j, C)
+
+        body = ib.get()
+
+        return body
+
+    ref = mandel_ref()
+
+    def check_target(target, ir):
+        if not tvm.testing.device_enabled(target):
+            return
+
+        C = te.extern(
+            shape,
+            [],
+            lambda ins, outs: ir(outs[0]),
+            name="mandel_ir",
+            dtype="float32",
+        )
+        s = te.create_schedule(C.op)
+
+        with tvm.transform.PassContext(opt_level=3):
+            func = tvm.build(s, [C], target)
+
+        ctx = tvm.context(target, 0)
+        c = tvm.nd.array(np.zeros(shape, dtype=C.dtype), ctx)
+        func(c)
+        tvm.testing.assert_allclose(c.asnumpy(), ref)
+
+    check_target("llvm", mandel_ir_cpu)
+
+
 def test_binary_search():
     def binary_search(ib, n, i, Aptr, Bptr, Cptr):
         lo = ib.allocate("int32", (1,), name="lo", scope="local")
@@ -182,7 +270,7 @@ def test_binary_search():
         hi[0] = n
         v = Bptr[i]
 
-        with ib.while_loop(lo[0] < hi[0]) as _:
+        with ib.while_loop(lo[0] < hi[0]):
             mid = lo[0] + tvm.tir.floordiv(hi[0] - lo[0], 2).astype("int32")
             with ib.if_scope(Aptr[mid] < v):
                 lo[0] = mid + 1
@@ -242,7 +330,7 @@ def test_binary_search():
         )
         s = te.create_schedule(C.op)
 
-        with tvm.transform.PassContext(opt_level=3, disabled_pass=["HoistIfThenElse"]):
+        with tvm.transform.PassContext(opt_level=3):
             func = tvm.build(s, [A, B, C], target)
 
         ctx = tvm.context(target, 0)
@@ -262,9 +350,10 @@ def test_binary_search():
 
 
 if __name__ == "__main__":
-    test_prefetch()
-    test_if()
-    test_for()
-    test_cpu()
-    test_gpu()
+    # test_prefetch()
+    # test_if()
+    # test_for()
+    # test_cpu()
+    # test_gpu()
+    test_while()
     test_binary_search()

--- a/tests/python/unittest/test_tir_transform_storage_rewrite.py
+++ b/tests/python/unittest/test_tir_transform_storage_rewrite.py
@@ -297,17 +297,23 @@ def test_parallel_alloc():
 
     assert isinstance(body.body.body.body.body, tvm.tir.Allocate)
 
-    ib = tvm.tir.ir_builder.create()
-    n = te.var("n")
-    with ib.for_range(0, n, name="i", kind="parallel") as i:
-        j = ib.allocate("int32", 1, name="j", scope="global")
-        j[0] = 0
-        with ib.while_loop(j[0] < 10):
-            A = ib.allocate("float32", n, name="A", scope="global")
-            A[j[0]] = A[j[0]] + 2
-            j[0] += j[0] + 1
 
-    body = ib.get()
+def test_while_alloc():
+    def get_mod(kind="serial"):
+        ib = tvm.tir.ir_builder.create()
+        n = te.var("n")
+        with ib.for_range(0, n, name="i", kind=kind) as i:
+            j = ib.allocate("int32", 1, name="j", scope="global")
+            j[0] = 0
+            with ib.while_loop(j[0] < 10):
+                A = ib.allocate("float32", n, name="A", scope="global")
+                A[j[0]] = A[j[0]] + 2
+                j[0] += j[0] + 1
+
+        body = ib.get()
+        return tvm.IRModule.from_expr(tvm.tir.PrimFunc([n], body))
+
+    mod = get_mod(kind="parallel")
     # parallel (i, 0, n) {
     #   // attr [j] storage_scope = "global"
     #   allocate j[int32 * 1]
@@ -319,10 +325,7 @@ def test_parallel_alloc():
     #     j[0] = (j[0] + (j[0] + 1))
     #   }
     # }
-
-    mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([n], body))
     body = tvm.tir.transform.StorageRewrite()(mod)["main"].body
-
     # parallel (i, 0, n) {
     #   // attr [j] storage_scope = "global"
     #   allocate j[int32 * 1]
@@ -336,6 +339,33 @@ def test_parallel_alloc():
     # }
     assert isinstance(body.body.body, tvm.tir.Allocate)  # j
     assert isinstance(body.body.body.body.body, tvm.tir.Allocate)  # A
+
+    mod = get_mod(kind="serial")
+    # for (i, 0, n) {
+    #   // attr [j] storage_scope = "global"
+    #   allocate j[int32 * 1]
+    #   j[0] = 0
+    #   while((j[0] < 10)){
+    #     // attr [A] storage_scope = "global"
+    #     allocate A[float32 * n]
+    #     A[j[0]] = (A[j[0]] + 2f)
+    #     j[0] = (j[0] + (j[0] + 1))
+    #   }
+    # }
+    body = tvm.tir.transform.StorageRewrite()(mod)["main"].body
+    # // attr [j] storage_scope = "global"
+    # allocate j[int32 * 1]
+    # // attr [A] storage_scope = "global"
+    # allocate A[float32 * n]
+    # for (i, 0, n) {
+    #   j[0] = 0
+    #   while((j[0] < 10)){
+    #     A[j[0]] = (A[j[0]] + 2f)
+    #     j[0] = (j[0] + (j[0] + 1))
+    #   }
+    # }
+    assert isinstance(body.body, tvm.tir.Allocate)  # j
+    assert isinstance(body.body.body.body, tvm.tir.Allocate)  # A
 
 
 def test_inplace_rule2(scope_tb="local_TB2", max_bits=1024 * 1024 * 1024):
@@ -616,6 +646,7 @@ if __name__ == "__main__":
     test_alloc_different_dtypes()
     test_inplace_rule()
     test_parallel_alloc()
+    test_while_alloc()
     test_storage_combine()
     test_storage_share_gpu()
     test_inplace_rule2()


### PR DESCRIPTION
This is an implementation of TIR While node as discussed in RFC https://discuss.tvm.apache.org/t/rfc-add-while-loop-node-to-tir/9028. It supercedes my earlier attempt in https://github.com/apache/tvm/pull/7385.

The PR consists of
* IR node definition + boilerplate
* Minimal changes to TIR transform passes (so far only modifies `storage_rewrite.cc`, everything else uses the default visitor)
* LLVM and C source codegen
* Various test cases
* Update CUDA NMS to use while loop

Hybrid script support etc are left for future work.

Now we can write binary search succinctly as follows:
```
lo[0] = 0
hi[0] = n
v = B[i]

with ib.while_loop(lo[0] < hi[0]):
    mid = lo[0] + (hi[0] - lo[0] >> 1)
    with ib.if_scope(A[mid] < v):
        lo[0] = mid + 1
    with ib.else_scope():
        hi[0] = mid

C[i] = lo[0]
```
As another nice use of while loop, I added a test that draws a useless mandelbrot set :slightly_smiling_face:  

![mandel](https://user-images.githubusercontent.com/1776403/107367035-2cd2ba80-6b22-11eb-89d0-b757ae5a4ca2.png)

@tqchen @junrushao1994 @vinx13 @mbrookhart @zhiics @kevinthesun @anijain2305 @trevor-m 




