### PR TITLE
Make the TVM targets list available in Python

### DIFF
--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -197,6 +197,11 @@ class TargetKindRegEntry {
   /*! \brief Set name of the TargetKind to be the same as registry if it is empty */
   inline TargetKindRegEntry& set_name();
   /*!
+   * \brief List all the entry names in the registry.
+   * \return The entry names.
+   */
+  TVM_DLL static Array<String> ListAllNames();
+  /*!
    * \brief Register or get a new entry.
    * \param target_kind_name The name of the TargetKind.
    * \return the corresponding entry.

--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -200,7 +200,7 @@ class TargetKindRegEntry {
    * \brief List all the entry names in the registry.
    * \return The entry names.
    */
-  TVM_DLL static Array<String> ListAllNames();
+  TVM_DLL static Array<String> ListTargetKinds();
   /*!
    * \brief Register or get a new entry.
    * \param target_kind_name The name of the TargetKind.

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -148,9 +148,9 @@ class Target(Object):
         return list(self.attrs.get("libs", []))
 
     @staticmethod
-    def names():
+    def list_kinds():
         """Returns the list of available target names."""
-        return list(_ffi_api.ListAllNames())
+        return list(_ffi_api.ListTargetKinds())
 
 
 # TODO(@tvm-team): Deprecate the helper functions below. Encourage the usage of config dict instead.

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -147,6 +147,11 @@ class Target(Object):
     def libs(self):
         return list(self.attrs.get("libs", []))
 
+    @staticmethod
+    def names():
+        """Returns the list of available target names."""
+        return list(_ffi_api.ListAllNames())
+
 
 # TODO(@tvm-team): Deprecate the helper functions below. Encourage the usage of config dict instead.
 

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -45,7 +45,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 using TargetKindRegistry = AttrRegistry<TargetKindRegEntry, TargetKind>;
 
-Array<String> TargetKindRegEntry::ListAllNames() {
+Array<String> TargetKindRegEntry::ListTargetKinds() {
   return TargetKindRegistry::Global()->ListAllNames();
 }
 
@@ -314,6 +314,6 @@ TVM_REGISTER_TARGET_KIND("composite", kDLCPU)
 
 /**********  Registry  **********/
 
-TVM_REGISTER_GLOBAL("target.ListAllNames").set_body_typed(TargetKindRegEntry::ListAllNames);
+TVM_REGISTER_GLOBAL("target.ListTargetKinds").set_body_typed(TargetKindRegEntry::ListTargetKinds);
 
 }  // namespace tvm

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -23,6 +23,7 @@
  */
 #include <tvm/ir/expr.h>
 #include <tvm/runtime/device_api.h>
+#include <tvm/runtime/registry.h>
 #include <tvm/target/target.h>
 #include <tvm/target/target_kind.h>
 
@@ -43,6 +44,10 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 /**********  Registry-related code  **********/
 
 using TargetKindRegistry = AttrRegistry<TargetKindRegEntry, TargetKind>;
+
+Array<String> TargetKindRegEntry::ListAllNames() {
+  return TargetKindRegistry::Global()->ListAllNames();
+}
 
 TargetKindRegEntry& TargetKindRegEntry::RegisterOrGet(const String& target_kind_name) {
   return TargetKindRegistry::Global()->RegisterOrGet(target_kind_name);
@@ -306,5 +311,9 @@ TVM_REGISTER_TARGET_KIND("hybrid", kDLCPU)  // line break
 TVM_REGISTER_TARGET_KIND("composite", kDLCPU)
     .add_attr_option<Target>("target_host")
     .add_attr_option<Array<Target>>("devices");
+
+/**********  Registry  **********/
+
+TVM_REGISTER_GLOBAL("target.ListAllNames").set_body_typed(TargetKindRegEntry::ListAllNames);
 
 }  // namespace tvm

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -152,8 +152,8 @@ TEST(TargetCreation, DeduplicateKeys) {
   ICHECK_EQ(target->GetAttr<Bool>("link-params"), false);
 }
 
-TEST(TargetKindRegistryListAllNames, Basic) {
-  Array<String> names = TargetKindRegEntry::ListAllNames();
+TEST(TargetKindRegistryListTargetKinds, Basic) {
+  Array<String> names = TargetKindRegEntry::ListTargetKinds();
   ICHECK_EQ(names.empty(), false);
   ICHECK_EQ(std::count(std::begin(names), std::end(names), "llvm"), 1);
 }

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -152,6 +152,12 @@ TEST(TargetCreation, DeduplicateKeys) {
   ICHECK_EQ(target->GetAttr<Bool>("link-params"), false);
 }
 
+TEST(TargetKindRegistryListAllNames, Basic) {
+  Array<String> names = TargetKindRegEntry::ListAllNames();
+  ICHECK_EQ(names.empty(), false);
+  ICHECK_EQ(std::count(std::begin(names), std::end(names), "llvm"), 1);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   testing::FLAGS_gtest_death_test_style = "threadsafe";

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -151,6 +151,13 @@ def test_target_tag_1():
     assert tgt.attrs["registers_per_block"] == 32768
 
 
+def test_target_names():
+    targets = tvm.target.Target.names()
+    assert len(targets) != 0
+    assert "llvm" in targets
+    assert all(isinstance(target_name, str) for target_name in targets)
+
+
 if __name__ == "__main__":
     test_target_dispatch()
     test_target_string_parse()
@@ -158,3 +165,4 @@ if __name__ == "__main__":
     test_target_config()
     test_config_map()
     test_composite_target()
+    test_target_names()

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -151,8 +151,8 @@ def test_target_tag_1():
     assert tgt.attrs["registers_per_block"] == 32768
 
 
-def test_target_names():
-    targets = tvm.target.Target.names()
+def test_list_kinds():
+    targets = tvm.target.Target.list_kinds()
     assert len(targets) != 0
     assert "llvm" in targets
     assert all(isinstance(target_name, str) for target_name in targets)
@@ -165,4 +165,4 @@ if __name__ == "__main__":
     test_target_config()
     test_config_map()
     test_composite_target()
-    test_target_names()
+    test_list_kinds()


### PR DESCRIPTION
This PR allows to get the names of the available targets in Python 