### PR TITLE
[FIX,Debug Graph Runtime] Insert TVMSynchronize for accurate profiling on GPUs

### DIFF
--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -148,9 +148,10 @@ class GraphRuntimeDebug : public GraphRuntime {
   }
 
   double RunOpHost(int index) {
+    const TVMContext& ctx = data_entry_[entry_id(index, 0)]->ctx;
+    TVMSynchronize(ctx.device_type, ctx.device_id, nullptr);
     auto op_tbegin = std::chrono::high_resolution_clock::now();
     op_execs_[index]();
-    const TVMContext& ctx = data_entry_[entry_id(index, 0)]->ctx;
     TVMSynchronize(ctx.device_type, ctx.device_id, nullptr);
     auto op_tend = std::chrono::high_resolution_clock::now();
     double op_duration =


### PR DESCRIPTION
When timing code in the debug graph runtime, we need to synchronize the CPU and GPU before calling the GPU to ensure that there aren't any already running kernels.

@areusch @hlu1 @tqchen 