### PR TITLE
[Frontend][Keras] Make keras reshape less restrictive

### DIFF
--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -350,6 +350,16 @@ class TestKeras:
         x = keras.layers.Reshape(target_shape=(4, 4))(data)
         keras_model = keras.models.Model(data, x)
         verify_keras_frontend(keras_model, need_transpose=False)
+        # "non-square" target shape
+        data = keras.layers.Input(shape=(15,))
+        x = keras.layers.Reshape(target_shape=(5, 3))(data)
+        keras_model = keras.models.Model(data, x)
+        verify_keras_frontend(keras_model, need_transpose=False)
+        # modify channel dim
+        data = keras.layers.Input(shape=(3, 2, 4))
+        x = keras.layers.Reshape(target_shape=(3, 8))(data)
+        keras_model = keras.models.Model(data, x)
+        verify_keras_frontend(keras_model)
 
     def test_forward_crop(self, keras):
         data = keras.layers.Input(shape=(32, 32, 3))


### PR DESCRIPTION
The previous implementation of reshape in the Keras frontend attempted to map the target shape, which is specified in NHWC format, to NCHW format. However, this approach had many limitations of what reshapes can be supported and introduced some complicated logic.

Instead, I am proposing to just transpose input to NHWC, apply the unmodified reshape, then transpose back to NCHW. This is simpler and can support more reshapes which are valid in keras.

I added some test cases for reshapes which were not supported in the previous implementation, but are now possible.