### PR TITLE
[VM] Move param bind to OptimizeModule

### DIFF
--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -892,15 +892,6 @@ void VMCompiler::SetParam(const std::string& name, runtime::NDArray data_in) {
 }
 
 void VMCompiler::Lower(IRModule mod, const TargetsMap& targets, const tvm::Target& target_host) {
-  if (params_.size()) {
-    BaseFunc base_func = mod->Lookup("main");
-    ICHECK(base_func->IsInstance<FunctionNode>())
-        << "VM compiler expects to compile relay::Function";
-    auto f = relay::backend::BindParamsByName(Downcast<Function>(base_func), params_);
-    auto gvar = mod->GetGlobalVar("main");
-    mod->Add(gvar, f);
-  }
-
   exec_ = make_object<Executable>();
   targets_ = targets;
   target_host_ = target_host;
@@ -1007,6 +998,15 @@ transform::Sequential MemoryOpt(tvm::Target host_target, TargetsMap targets) {
 
 IRModule VMCompiler::OptimizeModule(const IRModule& mod, const TargetsMap& targets,
                                     const Target& target_host) {
+  if (params_.size()) {
+    BaseFunc base_func = mod->Lookup("main");
+    ICHECK(base_func->IsInstance<FunctionNode>())
+        << "VM compiler expects to compile relay::Function";
+    auto f = relay::backend::BindParamsByName(Downcast<Function>(base_func), params_);
+    auto gvar = mod->GetGlobalVar("main");
+    mod->Add(gvar, f);
+  }
+
   Array<Pass> pass_seqs;
   Array<runtime::String> entry_functions{"main"};
   pass_seqs.push_back(transform::RemoveUnusedFunctions(entry_functions));

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -996,7 +996,7 @@ transform::Sequential MemoryOpt(tvm::Target host_target, TargetsMap targets) {
   return transform::Sequential(pass_seqs);
 }
 
-IRModule VMCompiler::OptimizeModule(const IRModule& mod, const TargetsMap& targets,
+IRModule VMCompiler::OptimizeModule(IRModule mod, const TargetsMap& targets,
                                     const Target& target_host) {
   if (params_.size()) {
     BaseFunc base_func = mod->Lookup("main");

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -125,8 +125,7 @@ class VMCompiler : public runtime::ModuleNode {
    *
    * \return The optimized IRModule.
    */
-  IRModule OptimizeModule(const IRModule& mod, const TargetsMap& targets,
-                          const Target& target_host);
+  IRModule OptimizeModule(IRModule mod, const TargetsMap& targets, const Target& target_host);
 
   /*!
    * \brief Populate the global function names in a map where the value is used

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -678,6 +678,10 @@ def test_vm_optimize():
     comp = relay.vm.VMCompiler()
     opt_mod, _ = comp.optimize(mod, target="llvm", params=params)
 
+    free_vars = relay.analysis.free_vars(opt_mod["main"].body)
+    # Paremeters should all be bound, so the only free var is data
+    assert len(free_vars) == 1
+
 
 @tvm.testing.uses_gpu
 def test_loop_free_var():


### PR DESCRIPTION
In VM, `BindParamsByName` is run inside `VMCompiler::Lower(...)` before `OptimizeModule` gets called. So when we try to dump the optimized module like this:
```
compiler = relay.vm.VMCompiler()
opt_mod, _ = compiler.optimize(mod, target, params=params)
print(opt_mod)
``` 
param binding doesn't happen, so the "optimized graph" has parameters as arguments. This means constant folding involving parameters cannot happen, so the optimized graph looks very different (e.g. there are many `layout_transform`) from the output of `relay.optimize`, which does param binding when `relay.optimize` is called.

https://github.com/apache/tvm/blob/384714b58ed374cb1e385142b5dc4128041c945c/src/relay/backend/build_module.cc#L255-L263

This PR moves param binding in VM to `OptimizeModule`, to be consistent with the graph codegen. Now `VMCompiler.optimize(...)` returns the graph with constants properly folded.

please review @zhiics @jroesch @icemelon9 