### PR TITLE
docker/bash.sh: lookup docker image in Jenkinsfile

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -27,6 +27,11 @@
 #     Execute command in the docker image, default non-interactive
 #     With -i, execute interactively.
 #
+
+set -e
+
+source "$(dirname $0)/dev_common.sh" || exit 2
+
 interactive=0
 if [ "$1" == "-i" ]; then
     interactive=1
@@ -38,7 +43,10 @@ if [ "$#" -lt 1 ]; then
     exit -1
 fi
 
-DOCKER_IMAGE_NAME=("$1")
+DOCKER_IMAGE_NAME=$(lookup_image_spec "$1")
+if [ -z "${DOCKER_IMAGE_NAME}" ]; then
+    DOCKER_IMAGE_NAME=("$1")
+fi
 
 CI_DOCKER_EXTRA_PARAMS=( )
 if [ "$#" -eq 1 ]; then
@@ -105,7 +113,7 @@ if [[ "${DOCKER_IMAGE_NAME}" == *"demo_vitis_ai"* && -d "/dev/shm" && -d "/opt/x
     for i in ${RENDER_DRIVER} ;
     do
         DOCKER_DEVICES+="--device=$i "
-    done  
+    done
 fi
 
 # Add ROCm devices and set ROCM_ENABLED=1 which is used in the with_the_same_user script

--- a/docker/dev_common.sh
+++ b/docker/dev_common.sh
@@ -28,13 +28,39 @@ INVOCATION_PWD="$(pwd)"
 GIT_TOPLEVEL=$(cd $(dirname ${BASH_SOURCE[0]}) && git rev-parse --show-toplevel)
 
 
+function filter_jenkinsfile() {
+    local echo_on=0;
+    while read line; do
+        if [ "${line}" == "// NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->" ]; then
+            echo_on=1
+        elif [ "${line}" == "// <--- End of regex-scanned config." ]; then
+            break
+        elif [ ${echo_on} -eq 1 ]; then
+            echo "$line"
+        fi
+    done
+}
+
+
+function lookup_image_spec() {
+    img_line=$(cat "${GIT_TOPLEVEL}/Jenkinsfile" | filter_jenkinsfile | grep -E "^${1} = ")
+    if [ -n "${img_line}" ]; then
+        img_spec=$(echo "${img_line}" | sed -E "s/${1} = \"([^\"]*)\"/\1/")
+        has_similar_docker_image=1
+        docker inspect "${1}" &>/dev/null || has_similar_docker_image=0
+        if [ ${has_similar_docker_image} -ne 0 ]; then
+            echo "WARNING: resolved docker image through Jenkinsfile to \"${img_spec}\"" >&2
+        fi
+        echo "${img_spec}"
+    fi
+}
+
+
 function run_docker() {
     image_name="$1"  # Name of the Jenkinsfile var to find
     shift
 
-    image_spec=$(cat "${GIT_TOPLEVEL}/Jenkinsfile" | \
-                     grep -E "^${image_name} = " | \
-                     sed -E "s/${image_name} = \"([^\"]*)\"/\1/")
+    image_spec=$(lookup_image_spec "${image_name}")
     if [ -z "${image_spec}" ]; then
         echo "${image_name}: not found in ${GIT_TOPLEVEL}/Jenkinsfile" >&2
         exit 2


### PR DESCRIPTION
 * This PR makes it possible to type
   `docker/bash.sh ci_cpu tests/scripts/task_config_build_cpu.sh`
   and the same version of ci_cpu as is used in Jenkins will be
   used to run the command.
