### PR TITLE
[RUNTIME] Fast path for single thread run to allow app level threading

### DIFF
--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -365,9 +365,11 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool").set_body([](TVMArgs args, TVMRe
 int TVMBackendParallelLaunch(FTVMParallelLambda flambda, void* cdata, int num_task) {
   int num_workers = tvm::runtime::threading::MaxConcurrency();
   if (num_workers == 1) {
+    std::atomic<int32_t> sync_counter{0};
     TVMParallelGroupEnv env;
     env.num_task = 1;
-    (*flambda)(1, &env, cdata);
+    env.sync_handle = &sync_counter;
+    (*flambda)(0, &env, cdata);
     return 0;
   } else {
 #if !TVM_THREADPOOL_USE_OPENMP

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -363,21 +363,28 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool").set_body([](TVMArgs args, TVMRe
 }  // namespace tvm
 
 int TVMBackendParallelLaunch(FTVMParallelLambda flambda, void* cdata, int num_task) {
-#if !TVM_THREADPOOL_USE_OPENMP
-  int res = tvm::runtime::ThreadPool::ThreadLocal()->Launch(flambda, cdata, num_task, 1);
-  return res;
-#else
   int num_workers = tvm::runtime::threading::MaxConcurrency();
-  if (num_task == 0) num_task = num_workers;
-  omp_set_num_threads(num_task);
-#pragma omp parallel num_threads(num_task)
-  {
+  if (num_workers == 1) {
     TVMParallelGroupEnv env;
-    env.num_task = num_task;
-    (*flambda)(omp_get_thread_num(), &env, cdata);
-  }
-  return 0;
+    env.num_task = 1;
+    (*flambda)(1, &env, cdata);
+    return 0;
+  } else {
+#if !TVM_THREADPOOL_USE_OPENMP
+    int res = tvm::runtime::ThreadPool::ThreadLocal()->Launch(flambda, cdata, num_task, 1);
+    return res;
+#else
+    if (num_task == 0) num_task = num_workers;
+    omp_set_num_threads(num_task);
+#pragma omp parallel num_threads(num_task)
+    {
+      TVMParallelGroupEnv env;
+      env.num_task = num_task;
+      (*flambda)(omp_get_thread_num(), &env, cdata);
+    }
+    return 0;
 #endif
+  }
 }
 
 int TVMBackendParallelBarrier(int task_id, TVMParallelGroupEnv* penv) {


### PR DESCRIPTION
@jwfromm @tqchen 

Seems using TVM's own thread pool doesn't allow running multiple independent instance of mods concurrently across different cores with `TVM_NUM_THREADS=1`. All threads run on a single core for some reason.

Need to figure out what `SetAffinity` function is doing
https://github.com/apache/tvm/blob/1831c17998b29f3797f364410980809bfef554ca/src/runtime/threading_backend.cc#L100