### PR TITLE
[TOPI][Vulkan, Metal] Avoid passing int64 scalar arg to VK/Metal runtime

### DIFF
--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -198,12 +198,13 @@ def _sort_common(
             bottom_up_merge(source, dest, source_idx, dest_idx, start[0], middle[0], end[0], even)
 
     lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float64"))), "int64"
+        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float64"))), "int32"
     )
-    with ib.for_range(0, lim, dtype="int64") as l2_width:
+    with ib.for_range(0, lim, dtype="int32") as l2_width:
         width = 2 << l2_width
         # Define and launch the cuda kernel
         with ib.new_scope():
+            width = tvm.tir.generic.cast(width, "int64")
             i = ib.allocate("int64", (1,), name="i", scope="local")
             j = ib.allocate("int64", (1,), name="j", scope="local")
             start = ib.allocate("int64", (1,), name="start", scope="local")

--- a/src/target/spirv/intrin_rule_spirv.cc
+++ b/src/target/spirv/intrin_rule_spirv.cc
@@ -64,6 +64,8 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.exp").set_body(DispatchGLSLPureIntri
 
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.log").set_body(DispatchGLSLPureIntrin<GLSLstd450Log>);
 
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.log2").set_body(DispatchGLSLPureIntrin<GLSLstd450Log2>);
+
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.sqrt").set_body(DispatchGLSLPureIntrin<GLSLstd450Sqrt>);
 
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.vulkan.pow").set_body(DispatchGLSLPureIntrin<GLSLstd450Pow>);

--- a/tests/python/topi/python/test_topi_vision.py
+++ b/tests/python/topi/python/test_topi_vision.py
@@ -112,7 +112,7 @@ def verify_get_valid_counts(dshape, score_threshold, id_index, score_index):
         tvm.testing.assert_allclose(tvm_out2.asnumpy(), np_out2, rtol=1e-3)
         tvm.testing.assert_allclose(tvm_out3.asnumpy(), np_out3, rtol=1e-3)
 
-    for device in ["llvm", "cuda", "opencl"]:
+    for device in ["llvm", "cuda", "opencl", "vulkan"]:
         check_device(device)
 
 


### PR DESCRIPTION
I hit the error below when running TIR sort/scan on Vulkan backend:
https://github.com/apache/tvm/blob/1831c17998b29f3797f364410980809bfef554ca/src/runtime/pack_args.h#L186 

This is because unlike most other kernels, TIR sort/scan needs to pass an integer scalar from host to GPU, to realize multipass kernel launches:
https://github.com/apache/tvm/blob/1e0d3569b94f650243f4d0ac204d196e3be8b0aa/python/tvm/topi/cuda/sort.py#L203-L206

Currently, `width` argument, which is int64 scalar, is passed to GPU backend runtime. But VK/Metal runtime use the calling convention that is different from the one used in CUDA/OpenCL (search for `PackFuncNonBufferArg`) and VK/Metal runtime don't support passing 64 bit scalar, see:
https://github.com/apache/tvm/blob/1831c17998b29f3797f364410980809bfef554ca/src/runtime/pack_args.h#L41-L49

https://github.com/apache/tvm/blob/1831c17998b29f3797f364410980809bfef554ca/src/runtime/vulkan/vulkan.cc#L1047

The fix to this problem is simply to pass int32 scalar instead, and does cast to int64 inside GPU kernel. This enabled TIR scan tests to pass on Vulkan. It also fixed the runtime error that happened while running TIR sort, but the sort result is still not correct on Vulkan. I suspect there is an issue in our SPIR-V codegen. 