### PR TITLE
[Bugfix][Relay] Crash in match_exhaustion.cc when given an empty tuple pattern or constructor with no args

### DIFF
--- a/src/relay/analysis/match_exhaustion.cc
+++ b/src/relay/analysis/match_exhaustion.cc
@@ -125,7 +125,7 @@ class CandidateChecker : public PatternFunctor<MatchResult(const Pattern&, const
 };
 
 // Returns list of arrays corresponding to Cartesian product of input list.
-// Note: CartesianProduct({}) = {}
+// Note: CartesianProduct({}) = {{}}
 Array<Array<Pattern>> CartesianProduct(Array<Array<Pattern>> fields) {
   // the only combination of 0 fields is 0 fields
   if (fields.size() == 0) {

--- a/src/relay/analysis/match_exhaustion.cc
+++ b/src/relay/analysis/match_exhaustion.cc
@@ -124,9 +124,14 @@ class CandidateChecker : public PatternFunctor<MatchResult(const Pattern&, const
   }
 };
 
-// Returns list of arrays corresponding to Cartesian product of input list
+// Returns list of arrays corresponding to Cartesian product of input list.
+// Note: CartesianProduct({}) = {}
 Array<Array<Pattern>> CartesianProduct(Array<Array<Pattern>> fields) {
-  ICHECK_NE(fields.size(), 0);
+  // the only combination of 0 fields is 0 fields
+  if (fields.size() == 0) {
+    return {{}};
+  }
+
   Array<Pattern> field_vals = fields[fields.size() - 1];
   Array<Array<Pattern>> ret;
 
@@ -197,7 +202,7 @@ Array<Pattern> ExpandWildcardsConstructor(const PatternConstructor& clause_ctor,
 
   auto ctor_cand = Downcast<PatternConstructor>(cand);
 
-  // for constructors, we will expand the wildcards in any field that is an ADT.
+  // expand all fields' wildcards
   Array<Array<Pattern>> values_by_field;
   for (size_t i = 0; i < ctor_cand->constructor->inputs.size(); i++) {
     values_by_field.push_back(
@@ -217,7 +222,7 @@ Array<Pattern> ExpandWildcardsConstructor(const PatternConstructor& clause_ctor,
 // Returns a list of all possible expansions.
 Array<Pattern> ExpandWildcardsTuple(const PatternTuple& clause_tuple, const Pattern& cand,
                                     const IRModule& mod) {
-  // for a wildcard node, create constructor nodes with wildcards for all args.
+  // for a wildcard node, create tuple with wildcards for all args.
   if (cand.as<PatternWildcardNode>()) {
     Array<Pattern> args;
     for (auto inp : clause_tuple->patterns) {
@@ -228,7 +233,7 @@ Array<Pattern> ExpandWildcardsTuple(const PatternTuple& clause_tuple, const Patt
 
   auto tuple_cand = Downcast<PatternTuple>(cand);
 
-  // for constructors, we will expand the wildcards in any field that is an ADT.
+  // expand all members' patterns
   Array<Array<Pattern>> values_by_field;
   for (size_t i = 0; i < tuple_cand->patterns.size(); i++) {
     values_by_field.push_back(

--- a/tests/python/relay/test_pass_unmatched_cases.py
+++ b/tests/python/relay/test_pass_unmatched_cases.py
@@ -420,5 +420,36 @@ def @shallow_opt[A](%a: Arith[A]) -> Arith[A] {
     # fromtext parse the module, then checked it (which include strictness checking).
 
 
+def no_arg_ctor_pattern():
+    code = """
+#[version = "0.0.5"]
+type List[A] {
+    Cons(A, List[A]),
+    Nil,
+}
+
+def @no_arg_ctor_match(%a: List[()]) -> int {
+    match (%a) {
+        Nil => 1,
+        _ => 2,
+    }
+}
+"""
+    tvm.parser.fromtext(code)
+
+
+def test_empty_tuple_pattern():
+    code = """
+#[version = "0.0.5"]
+def @empty_tup_match(%a: ()) -> int {
+    match (%a) {
+        () => 1,
+        _ => 2,
+    }
+}
+"""
+    tvm.parser.fromtext(code)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/test_pass_unmatched_cases.py
+++ b/tests/python/relay/test_pass_unmatched_cases.py
@@ -420,7 +420,7 @@ def @shallow_opt[A](%a: Arith[A]) -> Arith[A] {
     # fromtext parse the module, then checked it (which include strictness checking).
 
 
-def no_arg_ctor_pattern():
+def test_expanding_ctor_with_no_args():
     code = """
 #[version = "0.0.5"]
 type List[A] {
@@ -428,22 +428,37 @@ type List[A] {
     Nil,
 }
 
-def @no_arg_ctor_match(%a: List[()]) -> int {
+def @expand_on_nil_match(%a: List[(List[()],)]) -> int {
     match (%a) {
-        Nil => 1,
+        Cons((Nil), Nil) => 1,
         _ => 2,
     }
 }
 """
+    # exhausion checks:
+    # * hits Cons((Nil), Nil), expands to Cons(*, *), Nil()
+    # Nil() fails Cons((Nil), Nil), passes _
+    # Cons(*, *) hits Cons((Nil), Nil), expands to Cons((*), Cons(*, *)), Cons((*), Nil())
+    # Cons((*), Cons(*, *)) fails Cons((Nil), Nil), passes _
+    # Cons((*), Nil()) hits Cons((Nil), Nil), expands to Cons((Nil), Nil), Cons((Cons(*, *)), Nil)
+    # Cons((Nil), Nil) passes the first pattern
+    # Cons((Cons(*, *)), Nil) fails the first pattern, passes _
+    # Note Nil() is passed to ExpandWildcardsConstructor many times in the above!
     tvm.parser.fromtext(code)
 
 
-def test_empty_tuple_pattern():
+def test_expanding_empty_tuple():
+    # same principle as above, but with empty tuple
     code = """
 #[version = "0.0.5"]
-def @empty_tup_match(%a: ()) -> int {
+type List[A] {
+    Cons(A, List[A]),
+    Nil,
+}
+
+def @expand_on_empty_tuple_match(%a: (List[()], ())) -> int {
     match (%a) {
-        () => 1,
+        (Cons((), Nil), ()) => 1,
         _ => 2,
     }
 }


### PR DESCRIPTION
This PR adds two test cases that previously caused match exhaustion to crash due to a bad decision in implementing `CartesianProduct`. These cases happen when an empty tuple or constructor with no fields (e.g., `Nil()`) needs to be expanded -- the Cartesian product used for wildcard expansion assumed that it would have at least one field to expand. This was silly of me, since there is exactly one expansion of zero fields: `{∅}`.

I added a base case to `CartesianProduct` and regression tests.

Please review @MarisaKirisame @jroesch. (Test case found through fuzzing.)