### PR TITLE
[Target] Add target host field for target specification

### DIFF
--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -134,19 +134,19 @@ class Target : public ObjectRef {
    * \param host_tag_or_config_or_host_str the string to parse for target host
    */
   TVM_DLL explicit Target(const String& tag_or_config_or_target_str,
-    const String& host_tag_or_config_or_host_str);
+                          const String& host_tag_or_config_or_host_str);
   /*!
    * \brief Construct a Target using a JSON-like configuration
    * \param config The JSON-like configuration for target
    */
   TVM_DLL explicit Target(const Map<String, ObjectRef>& config);
-   /*!
+  /*!
    * \brief Construct a Target using a JSON-like configuration
    * \param config The JSON-like configuration for target
    * \param host_config The JSON-like configuration for target host
    */
   TVM_DLL explicit Target(const Map<String, ObjectRef>& config,
-    const Map<String, ObjectRef>& host_config);
+                          const Map<String, ObjectRef>& host_config);
   /*!
    * \brief Get the current target context from thread local storage.
    * \param allow_not_defined If the context stack is empty and this is set to true, an

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -44,7 +44,7 @@ class TargetNode : public Object {
  public:
   /*! \brief The kind of the target device */
   TargetKind kind;
-  /*! \brief Target host information of the target device */
+  /*! \brief Target host information, must be Target type */
   Optional<ObjectRef> host;
   /*! \brief Tag of the the target, can be empty */
   String tag;
@@ -129,24 +129,10 @@ class Target : public ObjectRef {
    */
   TVM_DLL explicit Target(const String& tag_or_config_or_target_str);
   /*!
-   * \brief Construct a Target given a string
-   * \param tag_or_config_or_target_str the string to parse for target
-   * \param host_tag_or_config_or_host_str the string to parse for target host
-   */
-  TVM_DLL explicit Target(const String& tag_or_config_or_target_str,
-                          const String& host_tag_or_config_or_host_str);
-  /*!
    * \brief Construct a Target using a JSON-like configuration
    * \param config The JSON-like configuration for target
    */
   TVM_DLL explicit Target(const Map<String, ObjectRef>& config);
-  /*!
-   * \brief Construct a Target using a JSON-like configuration
-   * \param config The JSON-like configuration for target
-   * \param host_config The JSON-like configuration for target host
-   */
-  TVM_DLL explicit Target(const Map<String, ObjectRef>& config,
-                          const Map<String, ObjectRef>& host_config);
   /*!
    * \brief Get the current target context from thread local storage.
    * \param allow_not_defined If the context stack is empty and this is set to true, an
@@ -158,6 +144,8 @@ class Target : public ObjectRef {
   TVM_DLL explicit Target(Target target, Target host);
   /*!
    * \brief Construct a Target given target and host
+   * \param target The Target typed object with host field undefined for target
+   * \param host The Target typed object for target host
    * \return The Target with given target and host context information
    */
   TVM_DLL static tvm::Target Current(bool allow_not_defined = true);

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -141,15 +141,14 @@ class Target : public ObjectRef {
    * \return The target that is the current context. The target may not be defined if
    * allow_not_defined is true.
    */
-  TVM_DLL explicit Target(Target target, Target host);
+  TVM_DLL static tvm::Target Current(bool allow_not_defined = true);
   /*!
    * \brief Construct a Target given target and host
    * \param target The Target typed object with host field undefined for target
    * \param host The Target typed object for target host
    * \return The Target with given target and host context information
    */
-  TVM_DLL static tvm::Target Current(bool allow_not_defined = true);
-
+  TVM_DLL explicit Target(Target target, Target host);
   TVM_DEFINE_OBJECT_REF_METHODS(Target, ObjectRef, TargetNode);
 
  private:

--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -376,7 +376,8 @@ inline TargetKindRegEntry& TargetKindRegEntry::set_name() {
           .add_attr_option<String>("tag")                         \
           .add_attr_option<String>("device")                      \
           .add_attr_option<String>("model")                       \
-          .add_attr_option<Array<String>>("libs")
+          .add_attr_option<Array<String>>("libs")                 \
+          .add_attr_option<Target>("host")
 
 }  // namespace tvm
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -88,7 +88,7 @@ class Target(Object):
                 hardware or software floating-point operations.
             host : Union[str, Dict[str, Any]] (optional)
                 Description for target host. Can be recursive. Similar to tag_or_str_or_dict.
-        host_tag_or_str_or_dict : Union[str, Dict[str, Any]]
+        host_tag_or_str_or_dict : Optional[Union[str, Dict[str, Any]]]
             Similar to tag_or_str_or_dict but for target host. Can be one of a literal
             target host string, a json string describing a configuration, or a dictionary of
             configuration options. When using a dictionary or json string to configure target,
@@ -97,10 +97,8 @@ class Target(Object):
         if not isinstance(tag_or_str_or_dict, (dict, str, Target)):
             raise ValueError("target has to be a string or dictionary.")
         if host_tag_or_str_or_dict is not None:
-            if not isinstance(host_tag_or_str_or_dict, (dict, str, Target)):
-                raise ValueError("target host has to be a string or dictionary.")
             self.__init_handle_by_constructor__(
-                _ffi_api.Target, tag_or_str_or_dict, host_tag_or_str_or_dict
+                _ffi_api.Target, Target(tag_or_str_or_dict), Target(host_tag_or_str_or_dict)
             )
         else:
             self.__init_handle_by_constructor__(_ffi_api.Target, tag_or_str_or_dict)

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -99,10 +99,9 @@ class Target(Object):
         if host_tag_or_str_or_dict is not None:
             if not isinstance(host_tag_or_str_or_dict, (dict, str, Target)):
                 raise ValueError("target host has to be a string or dictionary.")
-            else:
-                self.__init_handle_by_constructor__(
-                    _ffi_api.Target, tag_or_str_or_dict, host_tag_or_str_or_dict
-                )
+            self.__init_handle_by_constructor__(
+                _ffi_api.Target, tag_or_str_or_dict, host_tag_or_str_or_dict
+            )
         else:
             self.__init_handle_by_constructor__(_ffi_api.Target, tag_or_str_or_dict)
 

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -365,8 +365,7 @@ Target::Target(const String& tag_or_config_or_target_str) {
 Target::Target(const String& tag_or_config_or_target_str,
                const String& host_tag_or_config_or_host_str) {
   ObjectPtr<TargetNode> n = make_object<TargetNode>(
-    *Target(Target(tag_or_config_or_target_str),
-            Target(host_tag_or_config_or_host_str)).get());
+      *Target(Target(tag_or_config_or_target_str), Target(host_tag_or_config_or_host_str)).get());
   data_ = std::move(n);
 }
 
@@ -381,10 +380,9 @@ Target::Target(const Map<String, ObjectRef>& config) {
   data_ = std::move(target);
 }
 
-Target::Target(const Map<String, ObjectRef>& config,
-    const Map<String, ObjectRef>& host_config) {
-  ObjectPtr<TargetNode> n = make_object<TargetNode>(
-    *Target(Target(config), Target(host_config)).get());
+Target::Target(const Map<String, ObjectRef>& config, const Map<String, ObjectRef>& host_config) {
+  ObjectPtr<TargetNode> n =
+      make_object<TargetNode>(*Target(Target(config), Target(host_config)).get());
   data_ = std::move(n);
 }
 
@@ -481,7 +479,7 @@ void TargetInternal::ConstructorDispatcher(TVMArgs args, TVMRetValue* rv) {
     }
     return;
   } else if (args.num_args == 2) {
-    const auto& argt = args[0], argh = args[1];
+    const auto &argt = args[0], &argh = args[1];
     auto func = PackedFunc(ConstructorDispatcher);
     *rv = Target(func(argt).AsObjectRef<Target>(), func(argh).AsObjectRef<Target>());
     return;

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -375,8 +375,8 @@ Target::Target(const Map<String, ObjectRef>& config) {
 
 Target::Target(Target target, Target host) {
   ObjectPtr<TargetNode> n = make_object<TargetNode>(*target.get());
-  CHECK(!n->host.defined()) <<
-    "ValueError: Adding a host to a target whose host field has been defined";
+  CHECK(!n->host.defined())
+      << "ValueError: Adding a host to a target whose host field has been defined";
   // add target host into host field
   n->host = std::move(host);
   data_ = std::move(n);
@@ -476,7 +476,7 @@ void TargetInternal::ConstructorDispatcher(TVMArgs args, TVMRetValue* rv) {
     return;
   }
   LOG(FATAL) << "ValueError: Invalid number of arguments. Expect 1 or 2, but gets: "
-    << args.num_args;
+             << args.num_args;
 }
 
 ObjectPtr<Object> TargetInternal::FromString(const String& tag_or_config_or_target_str) {

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -219,7 +219,6 @@ TVM_REGISTER_TARGET_KIND("llvm", kDLCPU)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<String>("runtime")
     .add_attr_option<Bool>("link-params", Bool(false))
-    .add_attr_option<Target>("host")
     .set_default_keys({"cpu"});
 
 TVM_REGISTER_TARGET_KIND("c", kDLCPU)
@@ -228,7 +227,6 @@ TVM_REGISTER_TARGET_KIND("c", kDLCPU)
     .add_attr_option<String>("runtime")
     .add_attr_option<String>("mcpu")
     .add_attr_option<String>("march")
-    .add_attr_option<Target>("host")
     .set_default_keys({"cpu"});
 
 TVM_REGISTER_TARGET_KIND("cuda", kDLGPU)
@@ -240,7 +238,6 @@ TVM_REGISTER_TARGET_KIND("cuda", kDLGPU)
     .add_attr_option<Integer>("shared_memory_per_block")
     .add_attr_option<Integer>("registers_per_block")
     .add_attr_option<Integer>("max_threads_per_block")
-    .add_attr_option<Target>("host")
     .set_default_keys({"cuda", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("nvptx", kDLGPU)
@@ -249,7 +246,6 @@ TVM_REGISTER_TARGET_KIND("nvptx", kDLGPU)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(1024))
     .add_attr_option<Integer>("thread_warp_size", Integer(32))
-    .add_attr_option<Target>("host")
     .set_default_keys({"cuda", "gpu"})
     .set_attrs_preprocessor(UpdateNVPTXAttrs);
 
@@ -259,7 +255,6 @@ TVM_REGISTER_TARGET_KIND("rocm", kDLROCM)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(256))
     .add_attr_option<Integer>("thread_warp_size", Integer(64))
-    .add_attr_option<Target>("host")
     .set_default_keys({"rocm", "gpu"})
     .set_attrs_preprocessor(UpdateROCmAttrs);
 
@@ -267,40 +262,33 @@ TVM_REGISTER_TARGET_KIND("opencl", kDLOpenCL)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(256))
     .add_attr_option<Integer>("thread_warp_size")
-    .add_attr_option<Target>("host")
     .set_default_keys({"opencl", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("metal", kDLMetal)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(256))
-    .add_attr_option<Target>("host")
     .set_default_keys({"metal", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(256))
-    .add_attr_option<Target>("host")
     .set_default_keys({"vulkan", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("webgpu", kDLWebGPU)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(256))
-    .add_attr_option<Target>("host")
     .set_default_keys({"webgpu", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("sdaccel", kDLOpenCL)
     .add_attr_option<Bool>("system-lib")
-    .add_attr_option<Target>("host")
     .set_default_keys({"sdaccel", "hls"});
 
 TVM_REGISTER_TARGET_KIND("aocl", kDLAOCL)
     .add_attr_option<Bool>("system-lib")
-    .add_attr_option<Target>("host")
     .set_default_keys({"aocl", "hls"});
 
 TVM_REGISTER_TARGET_KIND("aocl_sw_emu", kDLAOCL)
     .add_attr_option<Bool>("system-lib")
-    .add_attr_option<Target>("host")
     .set_default_keys({"aocl", "hls"});
 
 TVM_REGISTER_TARGET_KIND("hexagon", kDLHexagon)
@@ -309,23 +297,18 @@ TVM_REGISTER_TARGET_KIND("hexagon", kDLHexagon)
     .add_attr_option<String>("mtriple")
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Array<String>>("llvm-options")
-    .add_attr_option<Target>("host")
     .set_default_keys({"hexagon"});
 
 TVM_REGISTER_TARGET_KIND("stackvm", kDLCPU)  // line break
-    .add_attr_option<Bool>("system-lib")
-    .add_attr_option<Target>("host");
+    .add_attr_option<Bool>("system-lib");
 
 TVM_REGISTER_TARGET_KIND("ext_dev", kDLExtDev)  // line break
-    .add_attr_option<Bool>("system-lib")
-    .add_attr_option<Target>("host");
+    .add_attr_option<Bool>("system-lib");
 
 TVM_REGISTER_TARGET_KIND("hybrid", kDLCPU)  // line break
-    .add_attr_option<Bool>("system-lib")
-    .add_attr_option<Target>("host");
+    .add_attr_option<Bool>("system-lib");
 
 TVM_REGISTER_TARGET_KIND("composite", kDLCPU)
-    .add_attr_option<Target>("host")
     .add_attr_option<Array<Target>>("devices");
 
 /**********  Registry  **********/

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -210,6 +210,15 @@ def test_target_host_single_string_with_tag():
     assert tgt.host.attrs["registers_per_block"] == 32768
 
 
+def test_target_host_warning():
+    """
+    Confirm that constructing a target with invalid
+    attributes fails as expected.
+    """
+    with pytest.raises(ValueError):
+        tgt = tvm.target.Target("cuda --host nvidia/jetson-nano", "llvm")
+
+
 if __name__ == "__main__":
     test_target_dispatch()
     test_target_string_parse()

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -193,6 +193,23 @@ def test_target_host_single_dict():
     assert tgt.host.attrs["registers_per_block"] == 32768
 
 
+def test_target_host_single_string():
+    tgt = tvm.target.Target("cuda --host llvm")
+    assert tgt.kind.name == "cuda"
+    assert tgt.host.kind.name == "llvm"
+
+
+def test_target_host_single_string_with_tag():
+    tgt = tvm.target.Target("cuda --host nvidia/jetson-nano")
+    assert tgt.kind.name == "cuda"
+    assert tgt.host.kind.name == "cuda"
+    assert tgt.host.attrs["arch"] == "sm_53"
+    assert tgt.host.attrs["shared_memory_per_block"] == 49152
+    assert tgt.host.attrs["max_threads_per_block"] == 1024
+    assert tgt.host.attrs["thread_warp_size"] == 32
+    assert tgt.host.attrs["registers_per_block"] == 32768
+
+
 if __name__ == "__main__":
     test_target_dispatch()
     test_target_string_parse()


### PR DESCRIPTION
As mentioned, adding support for target specification with a host (can be two strings, two configs, or a single config with `host` field), like `target("cuda", "llvm")`. The field is currently called `host`, creating some conflicts with previous field name `target_host` in `composite` type of target. While the PR is backward compatible, a lot of legacy code should be changed into the new API for better readbility and simplicity.