### PR TITLE
[TOPI, Relay] Support roi_align NHWC layout

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -953,6 +953,7 @@ def roi_align_strategy_cuda(attrs, inputs, out_type, target):
             name="roi_align_nchw.cuda",
         )
     else:
+        assert layout == "NHWC", "layout must be NCHW or NHWC."
         strategy.add_implementation(
             wrap_compute_roi_align(topi.vision.rcnn.roi_align_nhwc),
             wrap_topi_schedule(topi.cuda.schedule_roi_align),

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -945,12 +945,19 @@ def roi_align_strategy_cuda(attrs, inputs, out_type, target):
     """roi_align cuda strategy"""
     strategy = _op.OpStrategy()
     layout = attrs.layout
-    assert layout == "NCHW", "only support nchw for now"
-    strategy.add_implementation(
-        wrap_compute_roi_align(topi.vision.rcnn.roi_align_nchw),
-        wrap_topi_schedule(topi.cuda.schedule_roi_align),
-        name="roi_align_nchw.cuda",
-    )
+
+    if layout == "NCHW":
+        strategy.add_implementation(
+            wrap_compute_roi_align(topi.vision.rcnn.roi_align_nchw),
+            wrap_topi_schedule(topi.cuda.schedule_roi_align),
+            name="roi_align_nchw.cuda",
+        )
+    else:
+        strategy.add_implementation(
+            wrap_compute_roi_align(topi.vision.rcnn.roi_align_nhwc),
+            wrap_topi_schedule(topi.cuda.schedule_roi_align),
+            name="roi_align_nhwc.cuda",
+        )
     return strategy
 
 

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1067,6 +1067,7 @@ def roi_align_strategy(attrs, inputs, out_type, target):
             name="roi_align.generic",
         )
     else:
+        assert layout == "NHWC", "layout must be NCHW or NHWC."
         strategy.add_implementation(
             wrap_compute_roi_align(topi.vision.rcnn.roi_align_nhwc),
             wrap_topi_schedule(topi.generic.schedule_roi_align),

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1039,7 +1039,6 @@ def wrap_compute_roi_align(topi_compute):
     """wrap roi_align topi compute"""
 
     def _compute_roi_align(attrs, inputs, out_type):
-        assert attrs.layout == "NCHW"
         pooled_size = get_const_tuple(attrs.pooled_size)
         mode = bytes(attrs.mode, "utf-8")
         return [
@@ -1061,12 +1060,18 @@ def roi_align_strategy(attrs, inputs, out_type, target):
     """roi_align generic strategy"""
     strategy = _op.OpStrategy()
     layout = attrs.layout
-    assert layout == "NCHW", "only support nchw for now"
-    strategy.add_implementation(
-        wrap_compute_roi_align(topi.vision.rcnn.roi_align_nchw),
-        wrap_topi_schedule(topi.generic.schedule_roi_align),
-        name="roi_align.generic",
-    )
+    if layout == "NCHW":
+        strategy.add_implementation(
+            wrap_compute_roi_align(topi.vision.rcnn.roi_align_nchw),
+            wrap_topi_schedule(topi.generic.schedule_roi_align),
+            name="roi_align.generic",
+        )
+    else:
+        strategy.add_implementation(
+            wrap_compute_roi_align(topi.vision.rcnn.roi_align_nhwc),
+            wrap_topi_schedule(topi.generic.schedule_roi_align),
+            name="roi_align.generic",
+        )
     return strategy
 
 

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -476,19 +476,25 @@ def sparse_dense_strategy_cpu(attrs, inputs, out_type, target):
     return strategy
 
 
-# @roi_align_strategy.register("cpu")
-# def roi_align_strategy_cpu(attrs, inputs, out_type, target):
-#     """roi_align x86 strategy"""
-#     strategy = _op.OpStrategy()
-#     layout = attrs.layout
-#     assert layout == "NCHW", "only support nchw for now"
-#     if layout == "NHWC":
-#         strategy.add_implementation(
-#             wrap_compute_roi_align(topi.x86.roi_align_nchw),
-#             wrap_topi_schedule(topi.generic.schedule_roi_align),
-#             name="roi_align.x86",
-#         )
-#     return strategy
+@roi_align_strategy.register("cpu")
+def roi_align_strategy_cpu(attrs, inputs, out_type, target):
+    """roi_align x86 strategy"""
+    strategy = _op.OpStrategy()
+    layout = attrs.layout
+    if layout == "NCHW":
+        strategy.add_implementation(
+            wrap_compute_roi_align(topi.x86.roi_align_nchw),
+            wrap_topi_schedule(topi.generic.schedule_roi_align),
+            name="roi_align.x86",
+        )
+    else:
+        assert layout == "NHWC", "layout must be NCHW or NHWC."
+        strategy.add_implementation(
+            wrap_compute_roi_align(topi.vision.rcnn.roi_align_nhwc),
+            wrap_topi_schedule(topi.generic.schedule_roi_align),
+            name="roi_align.x86",
+        )
+    return strategy
 
 
 @bitserial_conv2d_strategy.register("cpu")

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -476,18 +476,19 @@ def sparse_dense_strategy_cpu(attrs, inputs, out_type, target):
     return strategy
 
 
-@roi_align_strategy.register("cpu")
-def roi_align_strategy_cpu(attrs, inputs, out_type, target):
-    """roi_align x86 strategy"""
-    strategy = _op.OpStrategy()
-    layout = attrs.layout
-    assert layout == "NCHW", "only support nchw for now"
-    strategy.add_implementation(
-        wrap_compute_roi_align(topi.x86.roi_align_nchw),
-        wrap_topi_schedule(topi.generic.schedule_roi_align),
-        name="roi_align.x86",
-    )
-    return strategy
+# @roi_align_strategy.register("cpu")
+# def roi_align_strategy_cpu(attrs, inputs, out_type, target):
+#     """roi_align x86 strategy"""
+#     strategy = _op.OpStrategy()
+#     layout = attrs.layout
+#     assert layout == "NCHW", "only support nchw for now"
+#     if layout == "NHWC":
+#         strategy.add_implementation(
+#             wrap_compute_roi_align(topi.x86.roi_align_nchw),
+#             wrap_topi_schedule(topi.generic.schedule_roi_align),
+#             name="roi_align.x86",
+#         )
+#     return strategy
 
 
 @bitserial_conv2d_strategy.register("cpu")

--- a/python/tvm/relay/op/vision/_vision.py
+++ b/python/tvm/relay/op/vision/_vision.py
@@ -86,7 +86,7 @@ def nms_shape_func(attrs, inputs, _):
 
 
 @script
-def _roi_align_shape_func(data_shape, rois_shape, pooled_size):
+def _roi_align_shape_func_nchw(data_shape, rois_shape, pooled_size):
     out = output_tensor((4,), "int64")
     out[0] = rois_shape[0]
     out[1] = data_shape[1]
@@ -95,6 +95,20 @@ def _roi_align_shape_func(data_shape, rois_shape, pooled_size):
     return out
 
 
+@script
+def _roi_align_shape_func_nhwc(data_shape, rois_shape, pooled_size):
+    out = output_tensor((4,), "int64")
+    out[0] = rois_shape[0]
+    out[1] = int64(pooled_size[0])
+    out[2] = int64(pooled_size[1])
+    out[3] = data_shape[3]
+    return out
+
+
 @reg.register_shape_func("vision.roi_align", False)
 def roi_align_shape_func(attrs, inputs, _):
-    return [_roi_align_shape_func(inputs[0], inputs[1], convert(attrs.pooled_size))]
+    if attrs.layout == "NCHW":
+        return [_roi_align_shape_func_nchw(inputs[0], inputs[1], convert(attrs.pooled_size))]
+    else:
+        assert attrs.layout == "NHWC"
+        return [_roi_align_shape_func_nhwc(inputs[0], inputs[1], convert(attrs.pooled_size))]

--- a/python/tvm/relay/op/vision/_vision.py
+++ b/python/tvm/relay/op/vision/_vision.py
@@ -110,5 +110,5 @@ def roi_align_shape_func(attrs, inputs, _):
     if attrs.layout == "NCHW":
         return [_roi_align_shape_func_nchw(inputs[0], inputs[1], convert(attrs.pooled_size))]
     else:
-        assert attrs.layout == "NHWC"
+        assert attrs.layout == "NHWC", "layout must be NCHW or NHWC."
         return [_roi_align_shape_func_nhwc(inputs[0], inputs[1], convert(attrs.pooled_size))]

--- a/python/tvm/relay/op/vision/_vision.py
+++ b/python/tvm/relay/op/vision/_vision.py
@@ -109,6 +109,5 @@ def _roi_align_shape_func_nhwc(data_shape, rois_shape, pooled_size):
 def roi_align_shape_func(attrs, inputs, _):
     if attrs.layout == "NCHW":
         return [_roi_align_shape_func_nchw(inputs[0], inputs[1], convert(attrs.pooled_size))]
-    else:
-        assert attrs.layout == "NHWC", "layout must be NCHW or NHWC."
-        return [_roi_align_shape_func_nhwc(inputs[0], inputs[1], convert(attrs.pooled_size))]
+    assert attrs.layout == "NHWC", "layout must be NCHW or NHWC."
+    return [_roi_align_shape_func_nhwc(inputs[0], inputs[1], convert(attrs.pooled_size))]

--- a/python/tvm/topi/testing/__init__.py
+++ b/python/tvm/topi/testing/__init__.py
@@ -39,7 +39,7 @@ from .upsampling_python import upsampling_python, upsampling3d_python
 from .bilinear_resize_python import bilinear_resize_python
 from .trilinear_resize3d_python import trilinear_resize3d_python
 from .reorg_python import reorg_python
-from .roi_align_python import roi_align_nchw_python
+from .roi_align_python import roi_align_nchw_python, roi_align_nhwc_python
 from .roi_pool_python import roi_pool_nchw_python
 from .lrn_python import lrn_python
 from .l2_normalize_python import l2_normalize_python

--- a/python/tvm/topi/testing/roi_align_python.py
+++ b/python/tvm/topi/testing/roi_align_python.py
@@ -123,9 +123,9 @@ def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
     else:
         pooled_size_h, pooled_size_w = pooled_size
 
-    num_roi = rois_np.shape[0]
-    b_np = np.zeros((num_roi, channel, pooled_size, pooled_size), dtype=a_np.dtype)
-    roi_align_common(
+    b_np = np.zeros((rois_np.shape[0], channel, pooled_size_h, pooled_size_w), dtype=a_np.dtype)
+
+    return roi_align_common(
         a_np,
         b_np,
         rois_np,
@@ -141,8 +141,6 @@ def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
         "NCHW",
     )
 
-    return b_np
-
 
 def roi_align_nhwc_python(a_np, rois_np, pooled_size, spatial_scale, sample_ratio, mode=b"avg"):
     """Roi align in python"""
@@ -151,68 +149,26 @@ def roi_align_nhwc_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
     assert avg_mode or max_mode, "Mode must be average or max. Please pass a valid mode."
     _, height, width, channel = a_np.shape
     num_roi = rois_np.shape[0]
-    b_np = np.zeros((num_roi, pooled_size, pooled_size, channel), dtype=a_np.dtype)
+
     if isinstance(pooled_size, int):
         pooled_size_h = pooled_size_w = pooled_size
     else:
         pooled_size_h, pooled_size_w = pooled_size
 
-    def _bilinear(n, y, x, c):
-        if y < -1 or y > height or x < -1 or x > width:
-            return 0
+    b_np = np.zeros((num_roi, pooled_size_h, pooled_size_w, channel), dtype=a_np.dtype)
 
-        y = min(max(y, 0), height - 1)
-        x = min(max(x, 0), width - 1)
-
-        y_low = int(math.floor(y))
-        x_low = int(math.floor(x))
-        y_high = y_low + 1
-        x_high = x_low + 1
-
-        wy_h = y - y_low
-        wx_h = x - x_low
-        wy_l = 1 - wy_h
-        wx_l = 1 - wx_h
-
-        val = 0
-        for wx, xp in zip((wx_l, wx_h), (x_low, x_high)):
-            for wy, yp in zip((wy_l, wy_h), (y_low, y_high)):
-                if 0 <= yp < height and 0 <= xp < width:
-                    val += wx * wy * a_np[n, yp, xp, c]
-        return val
-
-    for i in range(num_roi):
-        roi = rois_np[i]
-        batch_index = int(roi[0])
-        roi_start_w, roi_start_h, roi_end_w, roi_end_h = roi[1:] * spatial_scale
-        roi_h = max(roi_end_h - roi_start_h, 1.0)
-        roi_w = max(roi_end_w - roi_start_w, 1.0)
-
-        bin_h = roi_h / pooled_size_h
-        bin_w = roi_w / pooled_size_w
-
-        if sample_ratio > 0:
-            roi_bin_grid_h = roi_bin_grid_w = int(sample_ratio)
-        else:
-            roi_bin_grid_h = int(math.ceil(roi_h / pooled_size))
-            roi_bin_grid_w = int(math.ceil(roi_w / pooled_size))
-
-        count = roi_bin_grid_h * roi_bin_grid_w
-
-        for c in range(channel):
-            for ph in range(pooled_size_h):
-                for pw in range(pooled_size_w):
-                    if avg_mode:
-                        total = 0.0
-                    if max_mode:
-                        total = float("-inf")
-                    for iy in range(roi_bin_grid_h):
-                        for ix in range(roi_bin_grid_w):
-                            y = roi_start_h + ph * bin_h + (iy + 0.5) * bin_h / roi_bin_grid_h
-                            x = roi_start_w + pw * bin_w + (ix + 0.5) * bin_w / roi_bin_grid_w
-                            if avg_mode:
-                                total += _bilinear(batch_index, y, x, c) / count
-                            if max_mode:
-                                total = max(total, _bilinear(batch_index, y, x, c))
-                    b_np[i, ph, pw, c] = total
-    return b_np
+    return roi_align_common(
+        a_np,
+        b_np,
+        rois_np,
+        channel,
+        pooled_size_h,
+        pooled_size_w,
+        spatial_scale,
+        sample_ratio,
+        avg_mode,
+        max_mode,
+        height,
+        width,
+        "NHWC",
+    )

--- a/python/tvm/topi/testing/roi_align_python.py
+++ b/python/tvm/topi/testing/roi_align_python.py
@@ -63,6 +63,7 @@ def roi_align_common(
     width,
     layout,
 ):
+    """Common code used by roi align NCHW and NHWC"""
     num_roi = rois_np.shape[0]
 
     for i in range(num_roi):
@@ -113,7 +114,7 @@ def roi_align_common(
 
 
 def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_ratio, mode=b"avg"):
-    """Roi align in python"""
+    """Roi align NCHW in python"""
     avg_mode = mode in (b"avg", "avg", 0)
     max_mode = mode in (b"max", "max", 1)
     assert avg_mode or max_mode, "Mode must be average or max. Please pass a valid mode."
@@ -143,7 +144,7 @@ def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
 
 
 def roi_align_nhwc_python(a_np, rois_np, pooled_size, spatial_scale, sample_ratio, mode=b"avg"):
-    """Roi align in python"""
+    """Roi align NHWC in python"""
     avg_mode = mode in (b"avg", "avg", 0)
     max_mode = mode in (b"max", "max", 1)
     assert avg_mode or max_mode, "Mode must be average or max. Please pass a valid mode."

--- a/python/tvm/topi/testing/roi_align_python.py
+++ b/python/tvm/topi/testing/roi_align_python.py
@@ -92,3 +92,77 @@ def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
                                 total = max(total, _bilinear(batch_index, c, y, x))
                     b_np[i, c, ph, pw] = total
     return b_np
+
+
+def roi_align_nhwc_python(a_np, rois_np, pooled_size, spatial_scale, sample_ratio, mode=b"avg"):
+    """Roi align in python"""
+    avg_mode = mode in (b"avg", "avg", 0)
+    max_mode = mode in (b"max", "max", 1)
+    assert avg_mode or max_mode, "Mode must be average or max. Please pass a valid mode."
+    _, height, width, channel = a_np.shape
+    num_roi = rois_np.shape[0]
+    b_np = np.zeros((num_roi, pooled_size, pooled_size, channel), dtype=a_np.dtype)
+    if isinstance(pooled_size, int):
+        pooled_size_h = pooled_size_w = pooled_size
+    else:
+        pooled_size_h, pooled_size_w = pooled_size
+
+    def _bilinear(n, y, x, c):
+        if y < -1 or y > height or x < -1 or x > width:
+            return 0
+
+        y = min(max(y, 0), height - 1)
+        x = min(max(x, 0), width - 1)
+
+        y_low = int(math.floor(y))
+        x_low = int(math.floor(x))
+        y_high = y_low + 1
+        x_high = x_low + 1
+
+        wy_h = y - y_low
+        wx_h = x - x_low
+        wy_l = 1 - wy_h
+        wx_l = 1 - wx_h
+
+        val = 0
+        for wx, xp in zip((wx_l, wx_h), (x_low, x_high)):
+            for wy, yp in zip((wy_l, wy_h), (y_low, y_high)):
+                if 0 <= yp < height and 0 <= xp < width:
+                    val += wx * wy * a_np[n, yp, xp, c]
+        return val
+
+    for i in range(num_roi):
+        roi = rois_np[i]
+        batch_index = int(roi[0])
+        roi_start_w, roi_start_h, roi_end_w, roi_end_h = roi[1:] * spatial_scale
+        roi_h = max(roi_end_h - roi_start_h, 1.0)
+        roi_w = max(roi_end_w - roi_start_w, 1.0)
+
+        bin_h = roi_h / pooled_size_h
+        bin_w = roi_w / pooled_size_w
+
+        if sample_ratio > 0:
+            roi_bin_grid_h = roi_bin_grid_w = int(sample_ratio)
+        else:
+            roi_bin_grid_h = int(math.ceil(roi_h / pooled_size))
+            roi_bin_grid_w = int(math.ceil(roi_w / pooled_size))
+
+        count = roi_bin_grid_h * roi_bin_grid_w
+
+        for c in range(channel):
+            for ph in range(pooled_size_h):
+                for pw in range(pooled_size_w):
+                    if avg_mode:
+                        total = 0.0
+                    if max_mode:
+                        total = float("-inf")
+                    for iy in range(roi_bin_grid_h):
+                        for ix in range(roi_bin_grid_w):
+                            y = roi_start_h + ph * bin_h + (iy + 0.5) * bin_h / roi_bin_grid_h
+                            x = roi_start_w + pw * bin_w + (ix + 0.5) * bin_w / roi_bin_grid_w
+                            if avg_mode:
+                                total += _bilinear(batch_index, y, x, c) / count
+                            if max_mode:
+                                total = max(total, _bilinear(batch_index, y, x, c))
+                    b_np[i, ph, pw, c] = total
+    return b_np

--- a/python/tvm/topi/testing/roi_align_python.py
+++ b/python/tvm/topi/testing/roi_align_python.py
@@ -20,42 +20,50 @@ import math
 import numpy as np
 
 
-def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_ratio, mode=b"avg"):
-    """Roi align in python"""
-    avg_mode = mode in (b"avg", "avg", 0)
-    max_mode = mode in (b"max", "max", 1)
-    assert avg_mode or max_mode, "Mode must be average or max. Please pass a valid mode."
-    _, channel, height, width = a_np.shape
-    num_roi = rois_np.shape[0]
-    b_np = np.zeros((num_roi, channel, pooled_size, pooled_size), dtype=a_np.dtype)
-    if isinstance(pooled_size, int):
-        pooled_size_h = pooled_size_w = pooled_size
-    else:
-        pooled_size_h, pooled_size_w = pooled_size
+def _bilinear(a_np, n, c, y, x, height, width, layout):
+    if y < -1 or y > height or x < -1 or x > width:
+        return 0
 
-    def _bilinear(n, c, y, x):
-        if y < -1 or y > height or x < -1 or x > width:
-            return 0
+    y = min(max(y, 0), height - 1)
+    x = min(max(x, 0), width - 1)
 
-        y = min(max(y, 0), height - 1)
-        x = min(max(x, 0), width - 1)
+    y_low = int(math.floor(y))
+    x_low = int(math.floor(x))
+    y_high = y_low + 1
+    x_high = x_low + 1
 
-        y_low = int(math.floor(y))
-        x_low = int(math.floor(x))
-        y_high = y_low + 1
-        x_high = x_low + 1
+    wy_h = y - y_low
+    wx_h = x - x_low
+    wy_l = 1 - wy_h
+    wx_l = 1 - wx_h
 
-        wy_h = y - y_low
-        wx_h = x - x_low
-        wy_l = 1 - wy_h
-        wx_l = 1 - wx_h
-
-        val = 0
-        for wx, xp in zip((wx_l, wx_h), (x_low, x_high)):
-            for wy, yp in zip((wy_l, wy_h), (y_low, y_high)):
-                if 0 <= yp < height and 0 <= xp < width:
+    val = 0
+    for wx, xp in zip((wx_l, wx_h), (x_low, x_high)):
+        for wy, yp in zip((wy_l, wy_h), (y_low, y_high)):
+            if 0 <= yp < height and 0 <= xp < width:
+                if layout == "NCHW":
                     val += wx * wy * a_np[n, c, yp, xp]
-        return val
+                else:
+                    val += wx * wy * a_np[n, yp, xp, c]
+    return val
+
+
+def roi_align_common(
+    a_np,
+    b_np,
+    rois_np,
+    channel,
+    pooled_size_h,
+    pooled_size_w,
+    spatial_scale,
+    sample_ratio,
+    avg_mode,
+    max_mode,
+    height,
+    width,
+    layout,
+):
+    num_roi = rois_np.shape[0]
 
     for i in range(num_roi):
         roi = rois_np[i]
@@ -70,8 +78,8 @@ def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
         if sample_ratio > 0:
             roi_bin_grid_h = roi_bin_grid_w = int(sample_ratio)
         else:
-            roi_bin_grid_h = int(math.ceil(roi_h / pooled_size))
-            roi_bin_grid_w = int(math.ceil(roi_w / pooled_size))
+            roi_bin_grid_h = int(math.ceil(roi_h / pooled_size_h))
+            roi_bin_grid_w = int(math.ceil(roi_w / pooled_size_w))
 
         count = roi_bin_grid_h * roi_bin_grid_w
 
@@ -87,10 +95,52 @@ def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_rati
                             y = roi_start_h + ph * bin_h + (iy + 0.5) * bin_h / roi_bin_grid_h
                             x = roi_start_w + pw * bin_w + (ix + 0.5) * bin_w / roi_bin_grid_w
                             if avg_mode:
-                                total += _bilinear(batch_index, c, y, x) / count
+                                total += (
+                                    _bilinear(a_np, batch_index, c, y, x, height, width, layout)
+                                    / count
+                                )
                             if max_mode:
-                                total = max(total, _bilinear(batch_index, c, y, x))
-                    b_np[i, c, ph, pw] = total
+                                total = max(
+                                    total,
+                                    _bilinear(a_np, batch_index, c, y, x, height, width, layout),
+                                )
+
+                    if layout == "NCHW":
+                        b_np[i, c, ph, pw] = total
+                    else:
+                        b_np[i, ph, pw, c] = total
+    return b_np
+
+
+def roi_align_nchw_python(a_np, rois_np, pooled_size, spatial_scale, sample_ratio, mode=b"avg"):
+    """Roi align in python"""
+    avg_mode = mode in (b"avg", "avg", 0)
+    max_mode = mode in (b"max", "max", 1)
+    assert avg_mode or max_mode, "Mode must be average or max. Please pass a valid mode."
+    _, channel, height, width = a_np.shape
+    if isinstance(pooled_size, int):
+        pooled_size_h = pooled_size_w = pooled_size
+    else:
+        pooled_size_h, pooled_size_w = pooled_size
+
+    num_roi = rois_np.shape[0]
+    b_np = np.zeros((num_roi, channel, pooled_size, pooled_size), dtype=a_np.dtype)
+    roi_align_common(
+        a_np,
+        b_np,
+        rois_np,
+        channel,
+        pooled_size_h,
+        pooled_size_w,
+        spatial_scale,
+        sample_ratio,
+        avg_mode,
+        max_mode,
+        height,
+        width,
+        "NCHW",
+    )
+
     return b_np
 
 

--- a/python/tvm/topi/vision/rcnn/roi_align.py
+++ b/python/tvm/topi/vision/rcnn/roi_align.py
@@ -126,13 +126,13 @@ def roi_align_nchw(data, rois, pooled_size, spatial_scale, mode, sample_ratio=-1
     )
 
 
-def roi_align_nhwc(data, rois, pooled_size, spatial_scale, sample_ratio=-1):
+def roi_align_nhwc(data, rois, pooled_size, spatial_scale, mode, sample_ratio=-1):
     """ROI align operator in NHWC layout.
 
     Parameters
     ----------
     data : tvm.te.Tensor
-        4-D with shape [batch, channel, height, width]
+        4-D with shape [batch, height, width, channel]
 
     rois : tvm.te.Tensor
         2-D with shape [num_roi, 5]. The last dimension should be in format of
@@ -145,14 +145,21 @@ def roi_align_nhwc(data, rois, pooled_size, spatial_scale, sample_ratio=-1):
         Ratio of input feature map height (or w) to raw image height (or w). Equals the reciprocal
         of total stride in convolutional layers, which should be in range (0.0, 1.0]
 
+    mode : int or str
+        There are two modes, average and max. For the average mode, you can pass b'avg' or 0, and
+        for the max mode, you can pass b'max' or 1.
+
     sample_ratio : int
         Optional sampling ratio of ROI align, using adaptive size by default.
 
     Returns
     -------
     output : tvm.te.Tensor
-        4-D with shape [num_roi, channel, pooled_size, pooled_size]
+        4-D with shape [num_roi, pooled_size, pooled_size, channel]
     """
+    avg_mode = mode in (b"avg", 0)
+    max_mode = mode in (b"max", 1)
+    assert avg_mode or max_mode, "Mode must be avg or max. Please pass in a valid mode."
     dtype = rois.dtype
     _, height, width, channel = get_const_tuple(data.shape)
     num_roi, _ = get_const_tuple(rois.shape)
@@ -196,18 +203,28 @@ def roi_align_nhwc(data, rois, pooled_size, spatial_scale, sample_ratio=-1):
         rw = te.reduce_axis((0, roi_bin_grid_w))
         roi_start_h += ph * bin_h
         roi_start_w += pw * bin_w
-        return te.sum(
+        if avg_mode:
+            return te.sum(
+                _bilinear(
+                    batch_index,
+                    roi_start_h + (rh + 0.5) * bin_h / roi_bin_grid_h,
+                    roi_start_w + (rw + 0.5) * bin_w / roi_bin_grid_w,
+                    c
+                )
+                / count,
+                axis=[rh, rw],
+            )
+        # max mode
+        return te.max(
             _bilinear(
                 batch_index,
                 roi_start_h + (rh + 0.5) * bin_h / roi_bin_grid_h,
                 roi_start_w + (rw + 0.5) * bin_w / roi_bin_grid_w,
-                c,
-            )
-            / count,
+                c
+            ),
             axis=[rh, rw],
         )
 
-    print("nhwc roi align called")
     return te.compute(
-        (num_roi, pooled_size_h, pooled_size_w, channel, ), _sample, tag="pool,roi_align_nhwc"
+        (num_roi, pooled_size_h, pooled_size_w, channel), _sample, tag="pool,roi_align_nchw"
     )

--- a/python/tvm/topi/vision/rcnn/roi_align.py
+++ b/python/tvm/topi/vision/rcnn/roi_align.py
@@ -19,7 +19,7 @@
 import tvm
 from tvm import te
 from ...utils import get_const_tuple
-from ...cpp.utils import bilinear_sample_nchw
+from ...cpp.utils import bilinear_sample_nchw, bilinear_sample_nhwc
 
 
 def roi_align_nchw(data, rois, pooled_size, spatial_scale, mode, sample_ratio=-1):
@@ -123,4 +123,91 @@ def roi_align_nchw(data, rois, pooled_size, spatial_scale, mode, sample_ratio=-1
 
     return te.compute(
         (num_roi, channel, pooled_size_h, pooled_size_w), _sample, tag="pool,roi_align_nchw"
+    )
+
+
+def roi_align_nhwc(data, rois, pooled_size, spatial_scale, sample_ratio=-1):
+    """ROI align operator in NHWC layout.
+
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+        4-D with shape [batch, channel, height, width]
+
+    rois : tvm.te.Tensor
+        2-D with shape [num_roi, 5]. The last dimension should be in format of
+        [batch_index, w_start, h_start, w_end, h_end]
+
+    pooled_size : int or list/tuple of two ints
+        output size, or [out_height, out_width]
+
+    spatial_scale : float
+        Ratio of input feature map height (or w) to raw image height (or w). Equals the reciprocal
+        of total stride in convolutional layers, which should be in range (0.0, 1.0]
+
+    sample_ratio : int
+        Optional sampling ratio of ROI align, using adaptive size by default.
+
+    Returns
+    -------
+    output : tvm.te.Tensor
+        4-D with shape [num_roi, channel, pooled_size, pooled_size]
+    """
+    dtype = rois.dtype
+    _, height, width, channel = get_const_tuple(data.shape)
+    num_roi, _ = get_const_tuple(rois.shape)
+
+    if isinstance(pooled_size, int):
+        pooled_size_h = pooled_size_w = pooled_size
+    else:
+        pooled_size_h, pooled_size_w = pooled_size
+
+    def _bilinear(i, y, x, c):
+        outside = tvm.tir.any(y < -1.0, x < -1.0, y > height, x > width)
+        y = tvm.te.min(tvm.te.max(y, 0.0), height - 1)
+        x = tvm.te.min(tvm.te.max(x, 0.0), width - 1)
+        val = bilinear_sample_nhwc(data, (i, y, x, c), height - 1, width - 1)
+        return tvm.tir.if_then_else(outside, 0.0, val)
+
+    def _sample(i, ph, pw, c):
+        roi = rois[i]
+        batch_index = roi[0].astype("int32")
+        roi_start_w, roi_start_h, roi_end_w, roi_end_h = roi[1], roi[2], roi[3], roi[4]
+        roi_start_h *= spatial_scale
+        roi_end_h *= spatial_scale
+        roi_start_w *= spatial_scale
+        roi_end_w *= spatial_scale
+
+        # force malformed ROIs to be 1x1
+        roi_h = tvm.te.max(roi_end_h - roi_start_h, tvm.tir.const(1.0, dtype))
+        roi_w = tvm.te.max(roi_end_w - roi_start_w, tvm.tir.const(1.0, dtype))
+
+        bin_h = roi_h / pooled_size_h
+        bin_w = roi_w / pooled_size_w
+
+        if sample_ratio > 0:
+            roi_bin_grid_h = roi_bin_grid_w = tvm.tir.const(sample_ratio, "int32")
+        else:
+            roi_bin_grid_h = te.ceil(roi_h / pooled_size_h).astype("int32")
+            roi_bin_grid_w = te.ceil(roi_w / pooled_size_w).astype("int32")
+
+        count = roi_bin_grid_h * roi_bin_grid_w
+        rh = te.reduce_axis((0, roi_bin_grid_h))
+        rw = te.reduce_axis((0, roi_bin_grid_w))
+        roi_start_h += ph * bin_h
+        roi_start_w += pw * bin_w
+        return te.sum(
+            _bilinear(
+                batch_index,
+                roi_start_h + (rh + 0.5) * bin_h / roi_bin_grid_h,
+                roi_start_w + (rw + 0.5) * bin_w / roi_bin_grid_w,
+                c,
+            )
+            / count,
+            axis=[rh, rw],
+        )
+
+    print("nhwc roi align called")
+    return te.compute(
+        (num_roi, pooled_size_h, pooled_size_w, channel, ), _sample, tag="pool,roi_align_nhwc"
     )

--- a/tests/python/topi/python/test_topi_vision.py
+++ b/tests/python/topi/python/test_topi_vision.py
@@ -49,16 +49,10 @@ _multibox_detection_implement = {
     "gpu": (topi.cuda.multibox_detection, topi.cuda.schedule_multibox_detection),
 }
 
-_roi_align_implement_nchw = {
+_roi_align_implement = {
     "generic": (topi.vision.roi_align_nchw, topi.generic.schedule_roi_align),
     "cpu": (topi.x86.roi_align_nchw, topi.generic.schedule_roi_align),
     "gpu": (topi.vision.roi_align_nchw, topi.cuda.schedule_roi_align),
-}
-
-_roi_align_implement = {
-    "generic": (topi.vision.roi_align_nhwc, topi.generic.schedule_roi_align),
-    "cpu": (topi.vision.roi_align_nhwc, topi.generic.schedule_roi_align),
-    "gpu": (topi.vision.roi_align_nhwc, topi.cuda.schedule_roi_align),
 }
 
 _roi_pool_schedule = {
@@ -480,62 +474,6 @@ def verify_roi_align(
         check_device(device)
 
 
-def verify_roi_align(
-    batch, in_channel, in_size, num_roi, pooled_size, spatial_scale, sample_ratio, mode
-):  # For mode, 0 = avg, 1 = max
-    a_shape = (batch, in_size, in_size, in_channel)
-    rois_shape = (num_roi, 5)
-
-    a = te.placeholder(a_shape)
-    rois = te.placeholder(rois_shape)
-
-    @memoize("topi.tests.test_topi_vision.verify_roi_align")
-    def get_ref_data():
-        a_np = np.random.uniform(-1, 1, size=a_shape).astype("float32")
-        rois_np = np.random.uniform(-1, 1, size=rois_shape).astype("float32") * in_size
-        rois_np[:, 0] = np.random.randint(low=0, high=batch, size=num_roi)
-        b_np = tvm.topi.testing.roi_align_nhwc_python(
-            a_np,
-            rois_np,
-            pooled_size=pooled_size,
-            spatial_scale=spatial_scale,
-            sample_ratio=sample_ratio,
-            mode=mode,
-        )
-
-        return a_np, rois_np, b_np
-
-    a_np, rois_np, b_np = get_ref_data()
-
-    def check_device(device):
-        ctx = tvm.context(device, 0)
-        if not tvm.testing.device_enabled(device):
-            print("Skip because %s is not enabled" % device)
-            return
-        with tvm.target.Target(device):
-            fcompute, fschedule = tvm.topi.testing.dispatch(device, _roi_align_implement)
-            b = fcompute(
-                a,
-                rois,
-                pooled_size=pooled_size,
-                spatial_scale=spatial_scale,
-                sample_ratio=sample_ratio,
-                mode=mode,
-            )
-            s = fschedule(b)
-
-        tvm_a = tvm.nd.array(a_np, ctx)
-        tvm_rois = tvm.nd.array(rois_np, ctx)
-        tvm_b = tvm.nd.array(np.zeros(get_const_tuple(b.shape), dtype=b.dtype), ctx=ctx)
-        f = tvm.build(s, [a, rois, b], device)
-        f(tvm_a, tvm_rois, tvm_b)
-        tvm_val = tvm_b.asnumpy()
-        tvm.testing.assert_allclose(tvm_val, b_np, rtol=1e-3, atol=1e-4)
-
-    for device in ["llvm", "cuda", "opencl"]:
-        check_device(device)
-
-
 @tvm.testing.uses_gpu
 def test_roi_align():
     verify_roi_align(1, 16, 32, 64, 7, 1.0, -1, 0)
@@ -686,10 +624,10 @@ def test_proposal():
 
 
 if __name__ == "__main__":
-    # test_get_valid_counts()
-    # test_multibox_prior()
-    # test_multibox_detection()
+    test_get_valid_counts()
+    test_multibox_prior()
+    test_multibox_detection()
     test_roi_align()
-    # test_roi_pool()
-    # test_proposal()
-    # test_non_max_suppression()
+    test_roi_pool()
+    test_proposal()
+    test_non_max_suppression()


### PR DESCRIPTION
I've been working on optimizing MaskRCNN/FasterRCNN, one I thing I found was that Ansor generates better code for NHWC layout (see https://discuss.tvm.apache.org/t/autoscheduler-why-no-winograd-for-nchw-layout/9139). So I'm looking at improving NHWC end to end support / performance.

`roi_align` only supports NCHW layout, so `layout_transform` is inserted before/after each `roi_align`. This layout transform turned out expensive on GPU, so I added NHWC impl to `roi_align` to remove `layout_transform`. This cuts Faster RCNN runtime by 8 milli second.

Now, with Ansor NHWC tuning + `roi_align` improvement in this PR, we are beating pytorch by a large margin:
```
TVM NHWC(Ansor) + cublas: 0.0589 milli sec
PyTorch: 0.0738 milli sec
```

please review @kevinthesun @anijain2305 @comaniac @jwfromm @mbrookhart @electriclilies 