### PR TITLE
[Relay][Bugfix] Fix off-by-one error in BiasAddRel, use new reporting

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -61,8 +61,14 @@ bool BiasAddRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   if (axis < 0) {
     axis = data->shape.size() + axis;
   }
-  ICHECK_LE(axis, static_cast<int>(data->shape.size()))
-      << "axis " << param->axis << " is out of range";
+  if (axis >= static_cast<int>(data->shape.size())) {
+    reporter->GetDiagCtx().EmitFatal(
+                                     Diagnostic::Error(reporter->GetSpan())
+                                     << "The axis in bias_add must be in range for the shape; "
+                                     << "attempted to access index "
+                                     << axis << " of " << PrettyPrint(data->shape));
+    return false;
+  }
 
   // assign output type
   reporter->Assign(types[1], TensorType({data->shape[axis]}, data->dtype));

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -62,11 +62,10 @@ bool BiasAddRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     axis = data->shape.size() + axis;
   }
   if (axis >= static_cast<int>(data->shape.size())) {
-    reporter->GetDiagCtx().EmitFatal(
-                                     Diagnostic::Error(reporter->GetSpan())
+    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
                                      << "The axis in bias_add must be in range for the shape; "
-                                     << "attempted to access index "
-                                     << axis << " of " << PrettyPrint(data->shape));
+                                     << "attempted to access index " << axis << " of "
+                                     << PrettyPrint(data->shape));
     return false;
   }
 

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -201,6 +201,18 @@ def test_bias_add():
             np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=rtol)
 
 
+@pytest.mark.xfail
+def test_bias_add_type_failure():
+    # the axis is out of range
+    try:
+        b_add = relay.nn.bias_add(relay.const(1), relay.const(2), axis=0)
+        run_infer_type(b_add)
+    except tvm._ffi.base.TVMError:
+        pass
+    else:
+        assert False
+
+
 def test_expand_dims_infer_type():
     for dtype in ["float16", "float32"]:
         n, t, d = te.size_var("n"), te.size_var("t"), 100
@@ -484,6 +496,7 @@ def test_bitserial_dense():
 if __name__ == "__main__":
     test_concatenate()
     test_bias_add()
+    test_bias_add_type_failure()
     test_unary_op()
     test_binary_op()
     test_expand_dims_infer_type()

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -201,7 +201,6 @@ def test_bias_add():
             np.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=rtol)
 
 
-@pytest.mark.xfail
 def test_bias_add_type_failure():
     # the axis is out of range
     try:


### PR DESCRIPTION
As noted in issue #7466, I noticed an off-by-one error in the assertions for `BiasAddRel` and also saw an opportunity to use the new error reporting. Not a huge error, but it probably doesn't hurt to have more graceful error reporting where possible.

Requesting review from the last couple of people to change that file: @kevinthesun @tkonolige 