### PR TITLE
[CUDA][THRUST] Enforce -libs=thrust to allow thrust offload

### DIFF
--- a/apps/topi_recipe/gemm/cuda_gemm_square.py
+++ b/apps/topi_recipe/gemm/cuda_gemm_square.py
@@ -21,6 +21,7 @@ import os
 from tvm.contrib import nvcc
 from tvm.contrib import spirv
 import numpy as np
+import tvm.testing
 
 TASK = "gemm"
 USE_MANUAL_CODE = False

--- a/python/tvm/contrib/thrust.py
+++ b/python/tvm/contrib/thrust.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utilities for thrust"""
+from tvm._ffi import get_global_func
+
+
+def can_use_thrust(target, func_name):
+    return (
+        target.kind.name in ["cuda", "nvptx"]
+        and "thrust" in target.libs
+        and get_global_func(func_name, allow_missing=True)
+    )
+
+
+def can_use_rocthrust(target, func_name):
+    return (
+        target.kind.name == "rocm"
+        and "thrust" in target.libs
+        and get_global_func(func_name, allow_missing=True)
+    )

--- a/python/tvm/contrib/thrust.py
+++ b/python/tvm/contrib/thrust.py
@@ -15,10 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 """Utilities for thrust"""
+import logging
+
 from tvm._ffi import get_global_func
 
 
+def maybe_warn(target, func_name):
+    if get_global_func(func_name, allow_missing=True) and not "thrust" in target.libs:
+        logging.warning("TVM is built with thrust but thrust is not used.")
+    if "thrust" in target.libs and get_global_func(func_name, allow_missing=True) is None:
+        logging.warning("thrust is requested but TVM is not built with thrust.")
+
+
 def can_use_thrust(target, func_name):
+    maybe_warn(target, func_name)
     return (
         target.kind.name in ["cuda", "nvptx"]
         and "thrust" in target.libs
@@ -27,6 +37,7 @@ def can_use_thrust(target, func_name):
 
 
 def can_use_rocthrust(target, func_name):
+    maybe_warn(target, func_name)
     return (
         target.kind.name == "rocm"
         and "thrust" in target.libs

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -708,7 +708,7 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
                         name="dense_tensorcore.cuda",
                         plevel=20,
                     )
-    if target.kind.name in ["cuda", "nvptx"]  and "cublas" in target.libs:
+    if target.kind.name in ["cuda", "nvptx"] and "cublas" in target.libs:
         strategy.add_implementation(
             wrap_compute_dense(topi.cuda.dense_cublas),
             wrap_topi_schedule(topi.cuda.schedule_dense_cublas),

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -354,9 +354,6 @@ def judge_winograd(
     OH = (H + pt + pb - KH) // stride_h + 1
     OW = (W + pl + pr - KW) // stride_w + 1
     nH, nW = (OH + tile_size - 1) // tile_size, (OW + tile_size - 1) // tile_size
-
-    if not isinstance(N, int):
-        return False, False, False
     P = N * nH * nW
 
     judge_winograd_tensorcore = (
@@ -708,7 +705,7 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
                         name="dense_tensorcore.cuda",
                         plevel=20,
                     )
-    if target.kind.name in ["cuda", "nvptx"] and "cublas" in target.libs:
+    if target.kind.name == "cuda" and "cublas" in target.libs:
         strategy.add_implementation(
             wrap_compute_dense(topi.cuda.dense_cublas),
             wrap_topi_schedule(topi.cuda.schedule_dense_cublas),

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -20,6 +20,7 @@ from tvm import topi
 from tvm.auto_scheduler import is_auto_scheduler_enabled
 from tvm.te import SpecializedCondition
 from tvm.contrib import nvcc
+from tvm.contrib.thrust import can_use_thrust
 from tvm._ffi import get_global_func
 from .generic import *
 from .. import op as _op
@@ -791,9 +792,7 @@ def scatter_cuda(attrs, inputs, out_type, target):
     rank = len(inputs[0].shape)
 
     with SpecializedCondition(rank == 1):
-        if target.kind.name == "cuda" and get_global_func(
-            "tvm.contrib.thrust.stable_sort_by_key", allow_missing=True
-        ):
+        if can_use_thrust(target, "tvm.contrib.thrust.stable_sort_by_key"):
             strategy.add_implementation(
                 wrap_compute_scatter(topi.cuda.scatter_via_sort),
                 wrap_topi_schedule(topi.cuda.schedule_scatter_via_sort),
@@ -838,9 +837,7 @@ def sort_strategy_cuda(attrs, inputs, out_type, target):
         wrap_topi_schedule(topi.cuda.schedule_sort),
         name="sort.cuda",
     )
-    if target.kind.name == "cuda" and get_global_func(
-        "tvm.contrib.thrust.sort", allow_missing=True
-    ):
+    if can_use_thrust(target, "tvm.contrib.thrust.sort"):
         strategy.add_implementation(
             wrap_compute_sort(topi.cuda.sort_thrust),
             wrap_topi_schedule(topi.cuda.schedule_sort),
@@ -859,9 +856,7 @@ def argsort_strategy_cuda(attrs, inputs, out_type, target):
         wrap_topi_schedule(topi.cuda.schedule_argsort),
         name="argsort.cuda",
     )
-    if target.kind.name == "cuda" and get_global_func(
-        "tvm.contrib.thrust.sort", allow_missing=True
-    ):
+    if can_use_thrust(target, "tvm.contrib.thrust.sort"):
         strategy.add_implementation(
             wrap_compute_argsort(topi.cuda.argsort_thrust),
             wrap_topi_schedule(topi.cuda.schedule_argsort),
@@ -880,9 +875,7 @@ def topk_strategy_cuda(attrs, inputs, out_type, target):
         wrap_topi_schedule(topi.cuda.schedule_topk),
         name="topk.cuda",
     )
-    if target.kind.name == "cuda" and get_global_func(
-        "tvm.contrib.thrust.sort", allow_missing=True
-    ):
+    if can_use_thrust(target, "tvm.contrib.thrust.sort"):
         strategy.add_implementation(
             wrap_compute_topk(topi.cuda.topk_thrust),
             wrap_topi_schedule(topi.cuda.schedule_topk),

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -21,7 +21,6 @@ from tvm.auto_scheduler import is_auto_scheduler_enabled
 from tvm.te import SpecializedCondition
 from tvm.contrib import nvcc
 from tvm.contrib.thrust import can_use_thrust
-from tvm._ffi import get_global_func
 from .generic import *
 from .. import op as _op
 

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -354,6 +354,9 @@ def judge_winograd(
     OH = (H + pt + pb - KH) // stride_h + 1
     OW = (W + pl + pr - KW) // stride_w + 1
     nH, nW = (OH + tile_size - 1) // tile_size, (OW + tile_size - 1) // tile_size
+
+    if not isinstance(N, int):
+        return False, False, False
     P = N * nH * nW
 
     judge_winograd_tensorcore = (
@@ -705,7 +708,7 @@ def dense_strategy_cuda(attrs, inputs, out_type, target):
                         name="dense_tensorcore.cuda",
                         plevel=20,
                     )
-    if target.kind.name == "cuda" and "cublas" in target.libs:
+    if target.kind.name in ["cuda", "nvptx"]  and "cublas" in target.libs:
         strategy.add_implementation(
             wrap_compute_dense(topi.cuda.dense_cublas),
             wrap_topi_schedule(topi.cuda.schedule_dense_cublas),

--- a/python/tvm/topi/cuda/conv2d_nhwc.py
+++ b/python/tvm/topi/cuda/conv2d_nhwc.py
@@ -129,4 +129,4 @@ def schedule_conv2d_nhwc_direct(cfg, s, Conv):
 
     N, OH, OW, CO = get_const_tuple(output.shape)
     KH, KW, CI, _ = get_const_tuple(kernel.shape)
-    # cfg.add_flop(2 * N * OH * OW * CO * CI * KH * KW)
+    cfg.add_flop(2 * N * OH * OW * CO * CI * KH * KW)

--- a/python/tvm/topi/cuda/conv2d_nhwc.py
+++ b/python/tvm/topi/cuda/conv2d_nhwc.py
@@ -129,4 +129,4 @@ def schedule_conv2d_nhwc_direct(cfg, s, Conv):
 
     N, OH, OW, CO = get_const_tuple(output.shape)
     KH, KW, CI, _ = get_const_tuple(kernel.shape)
-    cfg.add_flop(2 * N * OH * OW * CO * CI * KH * KW)
+    # cfg.add_flop(2 * N * OH * OW * CO * CI * KH * KW)

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -21,7 +21,6 @@ import tvm
 from tvm import te
 from tvm.contrib.thrust import can_use_thrust, can_use_rocthrust
 from tvm.tir import if_then_else
-
 from .sort import argsort, argsort_thrust
 from .scan import exclusive_scan
 from ..utils import ceil_div

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -19,9 +19,10 @@
 """Non-maximum suppression operator"""
 import tvm
 from tvm import te
-
+from tvm.contrib.thrust import can_use_thrust, can_use_rocthrust
 from tvm.tir import if_then_else
-from .sort import argsort, argsort_thrust, is_thrust_available
+
+from .sort import argsort, argsort_thrust
 from .scan import exclusive_scan
 from ..utils import ceil_div
 
@@ -610,8 +611,10 @@ def _get_sorted_indices(data, data_buf, score_index, score_shape):
     )
 
     target = tvm.target.Target.current()
-    # TODO(masahi): Check -libs=thrust option
-    if target and target.kind.name in ["cuda", "rocm"] and is_thrust_available():
+    if target and (
+        can_use_thrust(target, "tvm.contrib.thrust.sort")
+        or can_use_rocthrust(target, "tvm.contrib.thrust.sort")
+    ):
         sort_tensor = argsort_thrust(score_tensor, axis=1, is_ascend=False, dtype="int32")
     else:
         sort_tensor = argsort(score_tensor, axis=1, is_ascend=False, dtype="int32")

--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -21,7 +21,7 @@ from tvm import te, autotvm
 from ..scatter import _verify_scatter_nd_inputs
 from ..generic import schedule_extern
 from .nms import atomic_add
-from .sort import stable_sort_by_key_thrust, is_thrust_available
+from .sort import stable_sort_by_key_thrust
 from ..utils import prod, ceil_div
 
 
@@ -565,7 +565,6 @@ def scatter_via_sort(cfg, data, indices, updates, axis=0):
     if axis < 0:
         axis += len(data.shape)
     assert axis == 0 and len(data.shape) == 1, "sorting based scatter only supported for 1d input"
-    assert is_thrust_available(), "Thrust is required for this op"
 
     cfg.add_flop(1)  # A dummy value to satisfy AutoTVM
 

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -18,7 +18,6 @@
 """Sort related operators """
 import tvm
 from tvm import te
-from tvm._ffi import get_global_func
 
 from .injective import schedule_injective_from_existing
 from ..transform import strided_slice, transpose

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -879,10 +879,3 @@ def stable_sort_by_key_thrust(keys, values, for_scatter=False):
         tag="stable_sort_by_key",
     )
     return out[0], out[1]
-
-
-def is_thrust_available():
-    """
-    Test if thrust based sorting ops are available.
-    """
-    return get_global_func("tvm.contrib.thrust.sort", allow_missing=True) is not None

--- a/tests/python/contrib/test_thrust.py
+++ b/tests/python/contrib/test_thrust.py
@@ -17,16 +17,16 @@
 import tvm
 import tvm.testing
 from tvm import te
-from tvm.topi.cuda import stable_sort_by_key_thrust, is_thrust_available
+from tvm.topi.cuda import stable_sort_by_key_thrust
 from tvm.topi.cuda.scan import exclusive_scan, scan_thrust, schedule_scan
+from tvm.contrib.thrust import can_use_thrust, can_use_rocthrust
 import numpy as np
 
 
-def test_stable_sort_by_key():
-    if not is_thrust_available():
-        print("skip because thrust is not enabled...")
-        return
+thrust_check_func = {"cuda": can_use_thrust, "rocm": can_use_rocthrust}
 
+
+def test_stable_sort_by_key():
     size = 6
     keys = te.placeholder((size,), name="keys", dtype="int32")
     values = te.placeholder((size,), name="values", dtype="int32")
@@ -38,74 +38,73 @@ def test_stable_sort_by_key():
             print("Skip because %s is not enabled" % target)
             continue
 
-        target += " -libs=thrust"
-        ctx = tvm.context(target, 0)
-        s = te.create_schedule([keys_out.op, values_out.op])
-        f = tvm.build(s, [keys, values, keys_out, values_out], target)
+        with tvm.target.Target(target + " -libs=thrust") as tgt:
+            if not thrust_check_func[target](tgt, "tvm.contrib.thrust.stable_sort_by_key"):
+                print("skip because thrust is not enabled...")
+                return
 
-        keys_np = np.array([1, 4, 2, 8, 2, 7], np.int32)
-        values_np = np.random.randint(0, 10, size=(size,)).astype(np.int32)
-        keys_np_out = np.zeros(keys_np.shape, np.int32)
-        values_np_out = np.zeros(values_np.shape, np.int32)
-        keys_in = tvm.nd.array(keys_np, ctx)
-        values_in = tvm.nd.array(values_np, ctx)
-        keys_out = tvm.nd.array(keys_np_out, ctx)
-        values_out = tvm.nd.array(values_np_out, ctx)
-        f(keys_in, values_in, keys_out, values_out)
+            ctx = tvm.context(target, 0)
+            s = te.create_schedule([keys_out.op, values_out.op])
+            f = tvm.build(s, [keys, values, keys_out, values_out], target)
 
-        ref_keys_out = np.sort(keys_np)
-        ref_values_out = np.array([values_np[i] for i in np.argsort(keys_np)])
-        tvm.testing.assert_allclose(keys_out.asnumpy(), ref_keys_out, rtol=1e-5)
-        tvm.testing.assert_allclose(values_out.asnumpy(), ref_values_out, rtol=1e-5)
+            keys_np = np.array([1, 4, 2, 8, 2, 7], np.int32)
+            values_np = np.random.randint(0, 10, size=(size,)).astype(np.int32)
+            keys_np_out = np.zeros(keys_np.shape, np.int32)
+            values_np_out = np.zeros(values_np.shape, np.int32)
+            keys_in = tvm.nd.array(keys_np, ctx)
+            values_in = tvm.nd.array(values_np, ctx)
+            keys_out = tvm.nd.array(keys_np_out, ctx)
+            values_out = tvm.nd.array(values_np_out, ctx)
+            f(keys_in, values_in, keys_out, values_out)
+
+            ref_keys_out = np.sort(keys_np)
+            ref_values_out = np.array([values_np[i] for i in np.argsort(keys_np)])
+            tvm.testing.assert_allclose(keys_out.asnumpy(), ref_keys_out, rtol=1e-5)
+            tvm.testing.assert_allclose(values_out.asnumpy(), ref_values_out, rtol=1e-5)
 
 
 def test_exclusive_scan():
-    if not is_thrust_available():
-        print("skip because thrust is not enabled...")
-        return
-
     for target in ["cuda", "rocm"]:
         if not tvm.testing.device_enabled(target):
             print("Skip because %s is not enabled" % target)
             continue
 
-        target += " -libs=thrust"
-        for ishape in [(10,), (10, 10), (10, 10, 10)]:
-            values = te.placeholder(ishape, name="values", dtype="int32")
+        with tvm.target.Target(target + " -libs=thrust") as tgt:
+            if not thrust_check_func[target](tgt, "tvm.contrib.thrust.sum_scan"):
+                print("skip because thrust is not enabled...")
+                return
 
-            with tvm.target.Target(target):
+            for ishape in [(10,), (10, 10), (10, 10, 10)]:
+                values = te.placeholder(ishape, name="values", dtype="int32")
+
                 scan, reduction = exclusive_scan(values, return_reduction=True)
                 s = schedule_scan([scan, reduction])
 
-            ctx = tvm.context(target, 0)
-            f = tvm.build(s, [values, scan, reduction], target)
+                ctx = tvm.context(target, 0)
+                f = tvm.build(s, [values, scan, reduction], target)
 
-            values_np = np.random.randint(0, 10, size=ishape).astype(np.int32)
-            values_np_out = np.zeros(values_np.shape, np.int32)
+                values_np = np.random.randint(0, 10, size=ishape).astype(np.int32)
+                values_np_out = np.zeros(values_np.shape, np.int32)
 
-            if len(ishape) == 1:
-                reduction_shape = ()
-            else:
-                reduction_shape = ishape[:-1]
+                if len(ishape) == 1:
+                    reduction_shape = ()
+                else:
+                    reduction_shape = ishape[:-1]
 
-            reduction_np_out = np.zeros(reduction_shape, np.int32)
+                reduction_np_out = np.zeros(reduction_shape, np.int32)
 
-            values_in = tvm.nd.array(values_np, ctx)
-            values_out = tvm.nd.array(values_np_out, ctx)
-            reduction_out = tvm.nd.array(reduction_np_out, ctx)
-            f(values_in, values_out, reduction_out)
+                values_in = tvm.nd.array(values_np, ctx)
+                values_out = tvm.nd.array(values_np_out, ctx)
+                reduction_out = tvm.nd.array(reduction_np_out, ctx)
+                f(values_in, values_out, reduction_out)
 
-            ref_values_out = np.cumsum(values_np, axis=-1, dtype="int32") - values_np
-            tvm.testing.assert_allclose(values_out.asnumpy(), ref_values_out, rtol=1e-5)
-            ref_reduction_out = np.sum(values_np, axis=-1)
-            tvm.testing.assert_allclose(reduction_out.asnumpy(), ref_reduction_out, rtol=1e-5)
+                ref_values_out = np.cumsum(values_np, axis=-1, dtype="int32") - values_np
+                tvm.testing.assert_allclose(values_out.asnumpy(), ref_values_out, rtol=1e-5)
+                ref_reduction_out = np.sum(values_np, axis=-1)
+                tvm.testing.assert_allclose(reduction_out.asnumpy(), ref_reduction_out, rtol=1e-5)
 
 
 def test_inclusive_scan():
-    if not is_thrust_available():
-        print("skip because thrust is not enabled...")
-        return
-
     out_dtype = "int64"
 
     for target in ["cuda", "rocm"]:
@@ -113,25 +112,28 @@ def test_inclusive_scan():
             print("Skip because %s is not enabled" % target)
             continue
 
-        target += " -libs=thrust"
-        for ishape in [(10,), (10, 10)]:
-            values = te.placeholder(ishape, name="values", dtype="int32")
+        with tvm.target.Target(target + " -libs=thrust") as tgt:
+            if not thrust_check_func[target](tgt, "tvm.contrib.thrust.sum_scan"):
+                print("skip because thrust is not enabled...")
+                return
 
-            with tvm.target.Target(target):
+            for ishape in [(10,), (10, 10)]:
+                values = te.placeholder(ishape, name="values", dtype="int32")
+
                 scan = scan_thrust(values, out_dtype, exclusive=False)
                 s = tvm.te.create_schedule([scan.op])
 
-            ctx = tvm.context(target, 0)
-            f = tvm.build(s, [values, scan], target)
+                ctx = tvm.context(target, 0)
+                f = tvm.build(s, [values, scan], target)
 
-            values_np = np.random.randint(0, 10, size=ishape).astype(np.int32)
-            values_np_out = np.zeros(values_np.shape, out_dtype)
-            values_in = tvm.nd.array(values_np, ctx)
-            values_out = tvm.nd.array(values_np_out, ctx)
-            f(values_in, values_out)
+                values_np = np.random.randint(0, 10, size=ishape).astype(np.int32)
+                values_np_out = np.zeros(values_np.shape, out_dtype)
+                values_in = tvm.nd.array(values_np, ctx)
+                values_out = tvm.nd.array(values_np_out, ctx)
+                f(values_in, values_out)
 
-            ref_values_out = np.cumsum(values_np, axis=-1, dtype=out_dtype)
-            tvm.testing.assert_allclose(values_out.asnumpy(), ref_values_out, rtol=1e-5)
+                ref_values_out = np.cumsum(values_np, axis=-1, dtype=out_dtype)
+                tvm.testing.assert_allclose(values_out.asnumpy(), ref_values_out, rtol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tutorials/frontend/deploy_ssd_gluoncv.py
+++ b/tutorials/frontend/deploy_ssd_gluoncv.py
@@ -94,6 +94,10 @@ def build(target):
 
 ######################################################################
 # Create TVM runtime and do inference
+# .. note::
+#
+#   Use target = "cuda -libs" to enable thrust based sort, if you
+#   enabled thrust during cmake by -DUSE_THRUST=ON.
 
 
 def run(lib, ctx):


### PR DESCRIPTION
Currently, thrust offload is done in a rather ad hoc way, unlike other libs such as cudnn which requires using `-libs=cudnn` in addition to `-DUSE_CUDNN=ON`. 

This PR enforces a requirement `-libs=thrust` to enable thrust offload, to make it consistent with other libs. It also makes it easier to compare performance of thrust and TIR sort. @mbrookhart is working on a new TIR sort implementation, based on [mergepath](https://arxiv.org/pdf/1406.2628.pdf), that is competitive or even faster than thrust, so hopefully we don't have to depend on thrust in the near future.

NOTE: If you want to use thrust, you must update your code to add `-libs=thrust` after this PR.

@tkonolige @mbrookhart @csullivan @jwfromm @zhiics @kevinthesun @anijain2305 @trevor-m @Laurawly 