### PR TITLE
Get tvmc version from tvm

### DIFF
--- a/python/tvm/driver/tvmc/main.py
+++ b/python/tvm/driver/tvmc/main.py
@@ -23,7 +23,7 @@ import argparse
 import logging
 import sys
 
-import pkg_resources
+import tvm
 
 from tvm.driver.tvmc.common import TVMCException
 
@@ -75,8 +75,7 @@ def _main(argv):
     logging.getLogger("TVMC").setLevel(40 - args.verbose * 10)
 
     if args.version:
-        version = pkg_resources.get_distribution("tvm").version
-        sys.stdout.write("%s\n" % version)
+        sys.stdout.write("%s\n" % tvm.__version__)
         return 0
 
     if not hasattr(args, "func"):


### PR DESCRIPTION
In TVMC we currently collect the version from the installed version of the "tvm" package. As we also distribute TVM packaged as "tlcpack", this change makes the version to be collected consistently, no matter how TVM is installed, by using the tvm.__version__ variable, rather than pkg_resources.