### PR TITLE
Do not allow exceptions in destructors

### DIFF
--- a/python/tvm/_ffi/_ctypes/ndarray.py
+++ b/python/tvm/_ffi/_ctypes/ndarray.py
@@ -79,7 +79,10 @@ class NDArrayBase(object):
 
     def __del__(self):
         if not self.is_view and _LIB:
-            check_call(_LIB.TVMArrayFree(self.handle))
+            try:
+                _LIB.TVMObjectFree(self.handle)
+            except:  # pylint: disable=bare-except
+                pass
 
     @property
     def _tvm_handle(self):

--- a/python/tvm/_ffi/_ctypes/ndarray.py
+++ b/python/tvm/_ffi/_ctypes/ndarray.py
@@ -83,7 +83,10 @@ class NDArrayBase(object):
             try:
                 _LIB.TVMObjectFree(self.handle)
             except Exception as e:
-                print(e.message, file=sys.stderr)
+                if hasattr(e, "message"):
+                    print(e.message, file=sys.stderr)
+                else:
+                    print(e, file=sys.stderr)
 
     @property
     def _tvm_handle(self):

--- a/python/tvm/_ffi/_ctypes/ndarray.py
+++ b/python/tvm/_ffi/_ctypes/ndarray.py
@@ -82,6 +82,7 @@ class NDArrayBase(object):
         if not self.is_view and _LIB:
             try:
                 _LIB.TVMObjectFree(self.handle)
+            # pylint: disable=broad-except
             except Exception as e:
                 if hasattr(e, "message"):
                     print(e.message, file=sys.stderr)

--- a/python/tvm/_ffi/_ctypes/ndarray.py
+++ b/python/tvm/_ffi/_ctypes/ndarray.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name
 """Runtime NDArray api"""
 import ctypes
+import sys
 from ..base import _LIB, check_call, c_str
 from ..runtime_ctypes import TVMArrayHandle
 from .types import RETURN_SWITCH, C_TO_PY_ARG_SWITCH, _wrap_arg_func, _return_handle
@@ -81,8 +82,8 @@ class NDArrayBase(object):
         if not self.is_view and _LIB:
             try:
                 _LIB.TVMObjectFree(self.handle)
-            except:  # pylint: disable=bare-except
-                pass
+            except Exception as e:
+                print(e.message, file=sys.stderr)
 
     @property
     def _tvm_handle(self):

--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name
 """Runtime Object api"""
 import ctypes
+import sys
 from ..base import _LIB, check_call
 from .types import ArgTypeCode, RETURN_SWITCH, C_TO_PY_ARG_SWITCH, _wrap_arg_func
 from .ndarray import _register_ndarray, NDArrayBase
@@ -108,8 +109,8 @@ class ObjectBase(object):
         if _LIB is not None:
             try:
                 _LIB.TVMObjectFree(self.handle)
-            except:  # pylint: disable=bare-except
-                pass
+            except Exception as e:
+                print(e.message, file=sys.stderr)
 
     def __init_handle_by_constructor__(self, fconstructor, *args):
         """Initialize the handle by calling constructor function.

--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -109,6 +109,7 @@ class ObjectBase(object):
         if _LIB is not None:
             try:
                 _LIB.TVMObjectFree(self.handle)
+            # pylint: disable=broad-except
             except Exception as e:
                 if hasattr(e, "message"):
                     print("Exception:", e.message, file=sys.stderr)

--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -106,7 +106,10 @@ class ObjectBase(object):
 
     def __del__(self):
         if _LIB is not None:
-            check_call(_LIB.TVMObjectFree(self.handle))
+            try:
+                _LIB.TVMObjectFree(self.handle)
+            except:  # pylint: disable=bare-except
+                pass
 
     def __init_handle_by_constructor__(self, fconstructor, *args):
         """Initialize the handle by calling constructor function.

--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -110,7 +110,10 @@ class ObjectBase(object):
             try:
                 _LIB.TVMObjectFree(self.handle)
             except Exception as e:
-                print(e.message, file=sys.stderr)
+                if hasattr(e, "message"):
+                    print("Exception:", e.message, file=sys.stderr)
+                else:
+                    print("Exception:", e, file=sys.stderr)
 
     def __init_handle_by_constructor__(self, fconstructor, *args):
         """Initialize the handle by calling constructor function.

--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -214,7 +214,10 @@ class PackedFuncBase(object):
             try:
                 _LIB.TVMObjectFree(self.handle)
             except Exception as e:
-                print(e.message, file=sys.stderr)
+                if hasattr(e, "message"):
+                    print(e.message, file=sys.stderr)
+                else:
+                    print(e, file=sys.stderr)
 
     def __call__(self, *args):
         """Call the function with positional arguments

--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -210,8 +210,10 @@ class PackedFuncBase(object):
 
     def __del__(self):
         if not self.is_global and _LIB is not None:
-            if _LIB.TVMFuncFree(self.handle) != 0:
-                raise get_last_ffi_error()
+            try:
+                _LIB.TVMObjectFree(self.handle)
+            except:  # pylint: disable=bare-except
+                pass
 
     def __call__(self, *args):
         """Call the function with positional arguments

--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -213,6 +213,7 @@ class PackedFuncBase(object):
         if not self.is_global and _LIB is not None:
             try:
                 _LIB.TVMObjectFree(self.handle)
+            # pylint: disable=broad-except
             except Exception as e:
                 if hasattr(e, "message"):
                     print(e.message, file=sys.stderr)

--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -18,6 +18,7 @@
 # pylint: disable=invalid-name, protected-access, too-many-branches, global-statement, unused-import
 """Function configuration API."""
 import ctypes
+import sys
 import traceback
 from numbers import Number, Integral
 
@@ -212,8 +213,8 @@ class PackedFuncBase(object):
         if not self.is_global and _LIB is not None:
             try:
                 _LIB.TVMObjectFree(self.handle)
-            except:  # pylint: disable=bare-except
-                pass
+            except Exception as e:
+                print(e.message, file=sys.stderr)
 
     def __call__(self, *args):
         """Call the function with positional arguments

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -20,6 +20,7 @@
 import os
 import ctypes
 import struct
+import sys
 from collections import namedtuple
 
 import tvm._ffi
@@ -48,8 +49,8 @@ class Module(object):
         if _LIB is not None:
             try:
                 _LIB.TVMObjectFree(self.handle)
-            except:  # pylint: disable=bare-except
-                pass
+            except Exception as e:
+                print(e.message, file=sys.stderr)
 
     def __hash__(self):
         return ctypes.cast(self.handle, ctypes.c_void_p).value

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -45,7 +45,11 @@ class Module(object):
         self.entry_name = "__tvm_main__"
 
     def __del__(self):
-        check_call(_LIB.TVMModFree(self.handle))
+        if _LIB is not None:
+            try:
+                _LIB.TVMObjectFree(self.handle)
+            except:  # pylint: disable=bare-except
+                pass
 
     def __hash__(self):
         return ctypes.cast(self.handle, ctypes.c_void_p).value

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -50,7 +50,10 @@ class Module(object):
             try:
                 _LIB.TVMObjectFree(self.handle)
             except Exception as e:
-                print(e.message, file=sys.stderr)
+                if hasattr(e, "message"):
+                    print(e.message, file=sys.stderr)
+                else:
+                    print(e, file=sys.stderr)
 
     def __hash__(self):
         return ctypes.cast(self.handle, ctypes.c_void_p).value

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -49,6 +49,7 @@ class Module(object):
         if _LIB is not None:
             try:
                 _LIB.TVMObjectFree(self.handle)
+            # pylint: disable=broad-except
             except Exception as e:
                 if hasattr(e, "message"):
                     print(e.message, file=sys.stderr)


### PR DESCRIPTION
Exceptions raised in destructors are ignored and a warning message is displayed. Catch exceptions raised and prevent them from propagating.

Raising exceptions in the ObjectBase destructor was causing stack overflow in the unit test `tests/python/unittest/test_auto_scheduler_cost_model.py` if xgboost was not installed in both windows and linux. This PR eliminates the stack overflow in that case.
