### PR TITLE
Fix stack overflow when partially-__init__ Node raises exception.

### DIFF
--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -106,6 +106,11 @@ class ObjectBase(object):
 
     def __del__(self):
         if _LIB is not None:
+            try:
+                handle = self.handle
+            except AttributeError:
+                return
+
             check_call(_LIB.TVMObjectFree(self.handle))
 
     def __init_handle_by_constructor__(self, fconstructor, *args):

--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -111,7 +111,7 @@ class ObjectBase(object):
             except AttributeError:
                 return
 
-            check_call(_LIB.TVMObjectFree(self.handle))
+            check_call(_LIB.TVMObjectFree(handle))
 
     def __init_handle_by_constructor__(self, fconstructor, *args):
         """Initialize the handle by calling constructor function.

--- a/python/tvm/runtime/object.py
+++ b/python/tvm/runtime/object.py
@@ -57,7 +57,7 @@ class Object(ObjectBase):
 
     def __getattr__(self, name):
         if name in self.__slots__:
-            raise AttributeError(f'{name} is not set')
+            raise AttributeError(f"{name} is not set")
 
         try:
             return _ffi_node_api.NodeGetAttr(self, name)

--- a/python/tvm/runtime/object.py
+++ b/python/tvm/runtime/object.py
@@ -56,6 +56,9 @@ class Object(ObjectBase):
         return sorted([fnames(i) for i in range(size)] + class_names)
 
     def __getattr__(self, name):
+        if name in self.__slots__:
+            raise AttributeError(f'{name} is not set')
+
         try:
             return _ffi_node_api.NodeGetAttr(self, name)
         except AttributeError:


### PR DESCRIPTION
 * If a Node subclass raises an exception and ctypes is in use before
   __init_handle_by_constructor__ is called (or self.handle is
   otherwise set), a Python stack overflow could result. This is
   because the unset handle slot causes self.handle accesses to
   fallback on the getattr(self, 'handle') method, invoking
   NodeGetAttr.
 * Then I believe this causes an infinite loop.
 * The fix is to make Node.__getattr__ raise AttributeError for all
   attributes in __slots__, then make __del__ tolerant to missing
   self.handle.
 * I don't believe cython is affected because it implements a
   descriptor to access its underlying chandle and that shouldn't be unset.
