### PR TITLE
[Relay] Enforce static dim for non-concat axis if one or more tensors have static dim

### DIFF
--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -116,21 +116,16 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       }
     }
     int non_any_size = static_cast<int>(non_any.size());
-    if (i != axis) {
+    if (i != axis && non_any_size > 0) {
       for (int k = 1; k < non_any_size; k++) {
         if (reporter->AssertEQ(non_any[0], non_any[k])) continue;
         throw Error(
             "relay.concatenate requires all tensors have the same shape "
             "on non-concatenating axes");
       }
-      if (non_any_size > 0) {
-        // For non-concat axes, enforce static shape constraint
-        oshape[i] = non_any[0];
-      } else {
-        oshape[i] = Any();
-      }
+      // For non-concat axes, enforce static shape constraint
+      oshape[i] = non_any[0];
     } else if (non_any_size != data_length) {
-      // For concat axis, if there is one any among input dims, the output dim is dynamic.
       oshape[i] = Any();
     }
   }

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -116,13 +116,16 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       }
     }
     int non_any_size = static_cast<int>(non_any.size());
-    if (non_any_size != data_length) oshape[i] = Any();
     if (i != axis) {
       for (int k = 1; k < non_any_size; k++) {
         if (reporter->AssertEQ(non_any[0], non_any[k])) continue;
         throw Error(
             "relay.concatenate requires all tensors have the same shape "
             "on non-concatenating axes");
+      }
+      if (non_any_size > 0) {
+        // For non concat-axes, enforce static shape constraint
+        oshape[i] = non_any[0];
       }
     }
   }

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -129,6 +129,9 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       } else {
         oshape[i] = Any();
       }
+    } else if (non_any_size != data_length) {
+      // For concat axis, if there is one any among input dims, the output dim is dynamic.
+      oshape[i] = Any();
     }
   }
 

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -124,8 +124,10 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
             "on non-concatenating axes");
       }
       if (non_any_size > 0) {
-        // For non concat-axes, enforce static shape constraint
+        // For non-concat axes, enforce static shape constraint
         oshape[i] = non_any[0];
+      } else {
+        oshape[i] = Any();
       }
     }
   }

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -151,7 +151,7 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       // However, if the concat axis is static, the output shape would become static while
       // the input could be partially static/dynamic. To prevent runtime segfaults due to the lack
       // of runtime input shape checking for such cases, static shape constraint is only enforced
-      // when the output shape is dynamic.
+      // when the output concat axis is dynamic.
       //
       // Examples (both concat on the first axis):
       // * [(?, 3), (?, ?)] -> (?, 3)

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -129,7 +129,7 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       continue;
     }
     std::vector<IndexExpr> non_any;
-    for (int j = 0; j < data_length; ++j) {
+    for (size_t j = 0; j < data_length; ++j) {
       const auto& e = input_tensors[j];
       if (!e->shape[i].as<AnyNode>()) {
         non_any.push_back(e->shape[i]);

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -208,6 +208,16 @@ def test_any_concat():
     ref = np.concatenate(x_np, axis=0)
     check_result(x_np, mod, ref)
 
+    x = [relay.var("x", shape=(relay.Any(), 3), dtype="float32") for _ in range(3)]
+    x.append(relay.var("x", shape=(relay.Any(), relay.Any()), dtype="float32"))
+    z = relay.op.concatenate(x, axis=0)
+    mod = tvm.IRModule()
+    mod["main"] = relay.Function(x, z)
+    typed_mod = relay.transform.InferType()(mod)
+    assert typed_mod["main"].body.checked_type == relay.TensorType(
+        (relay.Any(), 3), dtype="float32"
+    )
+
 
 def verify_any_reshape(x_shape, newshape, x_np_shape, out_shape, variable_newshape=False):
     x = relay.var("x", shape=x_shape, dtype="float32")

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -208,15 +208,26 @@ def test_any_concat():
     ref = np.concatenate(x_np, axis=0)
     check_result(x_np, mod, ref)
 
+    def test_oshape(in_vars, axis, oshape):
+        z = relay.op.concatenate(in_vars, axis=axis)
+        mod = tvm.IRModule()
+        mod["main"] = relay.Function(in_vars, z)
+        typed_mod = relay.transform.InferType()(mod)
+        assert typed_mod["main"].body.checked_type == relay.TensorType(oshape, dtype="float32")
+
     x = [relay.var("x", shape=(relay.Any(), 3), dtype="float32") for _ in range(3)]
     x.append(relay.var("x", shape=(relay.Any(), relay.Any()), dtype="float32"))
-    z = relay.op.concatenate(x, axis=0)
-    mod = tvm.IRModule()
-    mod["main"] = relay.Function(x, z)
-    typed_mod = relay.transform.InferType()(mod)
-    assert typed_mod["main"].body.checked_type == relay.TensorType(
-        (relay.Any(), 3), dtype="float32"
-    )
+
+    test_oshape(x, 0, (relay.Any(), 3))
+    test_oshape(x, 1, (relay.Any(), relay.Any()))
+
+    # [(1, 3), (1, ?)] -> (2, ?)
+    x = [
+        relay.var("x", shape=(1, 3), dtype="float32"),
+        relay.var("x", shape=(1, relay.Any()), dtype="float32"),
+    ]
+    test_oshape(x, 0, (2, relay.Any()))
+    test_oshape(x, 1, (1, relay.Any()))
 
 
 def verify_any_reshape(x_shape, newshape, x_np_shape, out_shape, variable_newshape=False):


### PR DESCRIPTION
Currently, the concat type relation assigns output shape Any() to non-concat axes if there is even one `Any` in corresponding input tensor shapes. But it is clear that for non-concat axes, if there is one or more static dim in input tensors, the input static dims and the output dim must all be the same static value.

For example, after this PR, the typing for the concat op with concat axis == 0 changes as follows:

* Current: [(?, 3), (?, ?)] -> (?, ?)
* After this PR: [(?, 3), (?, ?)] -> (?, 3)

This, together with https://github.com/apache/tvm/pull/7479, removes all unnecessary `any_dim` from PyTorch MaskRCNN, and significantly simplifies dynamic injective kernels. Below is an example of super-complicated and slow dynamic injective op, due to too many `any_dim`. This has been the bottleneck in PyTorch MaskRCNN, but after this PR, it becomes reasonable and no longer bottleneck.

* Before https://gist.github.com/masahi/c412ed75bf596dd627ce93a9cb578901
* After https://gist.github.com/masahi/d3db22563b3864baf7e7813ed7c6e0e1

Thanks to this optimization, PyTorch MaskRCNN runs **30 milli seconds** (!!) faster now.

please review @kevinthesun @anijain2305 @mbrookhart @jwfromm 