### PR TITLE
 [AutoScheduler] Fix the type inference for conv2d

### DIFF
--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -226,7 +226,16 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   } else {
     // use weight to infer the conv shape.
     if (weight == nullptr) return false;
-    auto wshape = trans_kernel_layout.ForwardShape(weight->shape);
+
+    Array<PrimExpr> wshape;
+    if (param->auto_scheduler_rewritten_layout.size() == 0) {
+      wshape = weight->shape;
+    } else {
+      // works for the default kernel layout "HWIO"
+      ICHECK_EQ(param->kernel_layout, "HWIO");
+      wshape = auto_scheduler::GetShapeFromRewrittenLayout(param->auto_scheduler_rewritten_layout,
+                                                           {"ry", "rx", "rc", "ff"});
+    }
     if (param->kernel_size.defined()) {
       ICHECK_EQ(param->kernel_size.size(), 2);
 

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -236,6 +236,8 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
       wshape = auto_scheduler::GetShapeFromRewrittenLayout(param->auto_scheduler_rewritten_layout,
                                                            {"ry", "rx", "rc", "ff"});
     }
+
+    wshape = trans_kernel_layout.ForwardShape(wshape);
     if (param->kernel_size.defined()) {
       ICHECK_EQ(param->kernel_size.size(), 2);
 


### PR DESCRIPTION
Affects some pretty standard convnets like Resnet imported from ONNX in NCHW that are converted with alteroplayout pass to NHWC to get better perf on Ansor.

Similar fix to #7475