### PR TITLE
[TVMC] rename composite target "acl"

### DIFF
--- a/python/tvm/driver/tvmc/composite_target.py
+++ b/python/tvm/driver/tvmc/composite_target.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("TVMC")
 # to be used in the PassContext (if any), and a function
 # responsible for partitioning to that target.
 REGISTERED_CODEGEN = {
-    "acl": {
+    "compute-library": {
         "config_key": None,
         "pass_pipeline": partition_for_arm_compute_lib,
     },

--- a/tests/python/driver/tvmc/test_common.py
+++ b/tests/python/driver/tvmc/test_common.py
@@ -258,10 +258,10 @@ def test_parse_single_target_with_opts():
 
 
 def test_parse_multiple_target():
-    targets = tvmc.common.parse_target("acl, llvm -device=arm_cpu --system-lib")
+    targets = tvmc.common.parse_target("compute-library, llvm -device=arm_cpu --system-lib")
 
     assert len(targets) == 2
-    assert "acl" == targets[0]["name"]
+    assert "compute-library" == targets[0]["name"]
     assert "llvm" == targets[1]["name"]
 
 

--- a/tests/python/driver/tvmc/test_composite_target.py
+++ b/tests/python/driver/tvmc/test_composite_target.py
@@ -38,7 +38,7 @@ def test_get_codegen_names():
 
 
 def test_valid_codegen():
-    codegen = tvmc.composite_target.get_codegen_by_target("acl")
+    codegen = tvmc.composite_target.get_codegen_by_target("compute-library")
 
     assert codegen is not None
     assert codegen["pass_pipeline"] is not None


### PR DESCRIPTION
In TVMC, renames the `acl` composite target to point to the specific library it represents: `compute-library` ([ref](https://github.com/ARM-software/ComputeLibrary)). It was pointed before that `acl` is quite a common acronym e.g. https://github.com/apache/tvm/pull/5916, so I'm moving it to the official name.

This PR just renames the mnemonic and adjust tests.

cc @u99127 @mbaret @comaniac 


