### PR TITLE
[Relay][Frontend][Onnx] Fix GEMM converter when C is not a parameter.

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -534,13 +534,8 @@ class Gemm(OnnxOpConverter):
         out = _op.nn.dense(inputs[0], inputs[1], units=channels)
 
         if len(inputs) == 3:
-            # skip (beta * C) if zero
-            C_array = params[inputs[2].name_hint].asnumpy()
-            if (beta == 0.0) or np.array_equal(C_array, np.array([0])):
-                return out
-        else:
-            return out
-        return _op.nn.bias_add(out, _expr.const(beta) * inputs[2])
+            return _op.nn.bias_add(out, _expr.const(beta) * inputs[2])
+        return out
 
 
 class MatMul(OnnxOpConverter):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1008,29 +1008,36 @@ def test_onehot():
         tvm.testing.assert_allclose(out_np, tvm_out, rtol=1e-5, atol=1e-5)
 
 
-@tvm.testing.uses_gpu
-def test_gemm():
-    a_shape = (4, 3)
-    b_shape = (3, 4)
+def verify_gemm(a_shape, b_shape, c_shape=None, freeze_params=False):
     out_shape = [a_shape[0], b_shape[1]]
-
     a_array = np.random.uniform(size=a_shape).astype("float32")
-    b_array = np.random.uniform(size=b_shape).astype("float32")
+    b_array = np.random.uniform(size=b_shape).astype("float32")    
+    input_names = ["a", "b"]
+    input_nodes = [helper.make_tensor_value_info("a", TensorProto.FLOAT, list(a_shape)),
+                   helper.make_tensor_value_info("b", TensorProto.FLOAT, list(b_shape))]
+    input_values = [a_array, b_array]
+    if c_shape is not None:
+        c_array = np.random.uniform(size=c_shape).astype("float32")    
+        input_names.append("c")
+        input_nodes.append(helper.make_tensor_value_info("c", TensorProto.FLOAT, list(c_shape)))
+        input_values.append(c_array)
 
-    gemm_node = helper.make_node("Gemm", ["a", "b"], ["out"])
+    gemm_node = helper.make_node("Gemm", input_names, ["out"])
 
     graph = helper.make_graph(
         [gemm_node],
         "gemm_test",
-        inputs=[
-            helper.make_tensor_value_info("a", TensorProto.FLOAT, list(a_shape)),
-            helper.make_tensor_value_info("b", TensorProto.FLOAT, list(b_shape)),
-        ],
+        inputs=input_nodes,
         outputs=[helper.make_tensor_value_info("out", TensorProto.FLOAT, list(out_shape))],
     )
 
     model = helper.make_model(graph, producer_name="gemm_test")
-    verify_with_ort_with_inputs(model, [a_array, b_array])
+    verify_with_ort_with_inputs(model, input_values, freeze_params=freeze_params)
+
+
+@tvm.testing.uses_gpu
+def test_gemm():
+    verify_gemm(a_shape=(4, 3), b_shape=(3, 4))
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1011,13 +1011,15 @@ def test_onehot():
 def verify_gemm(a_shape, b_shape, c_shape=None, freeze_params=False):
     out_shape = [a_shape[0], b_shape[1]]
     a_array = np.random.uniform(size=a_shape).astype("float32")
-    b_array = np.random.uniform(size=b_shape).astype("float32")    
+    b_array = np.random.uniform(size=b_shape).astype("float32")
     input_names = ["a", "b"]
-    input_nodes = [helper.make_tensor_value_info("a", TensorProto.FLOAT, list(a_shape)),
-                   helper.make_tensor_value_info("b", TensorProto.FLOAT, list(b_shape))]
+    input_nodes = [
+        helper.make_tensor_value_info("a", TensorProto.FLOAT, list(a_shape)),
+        helper.make_tensor_value_info("b", TensorProto.FLOAT, list(b_shape)),
+    ]
     input_values = [a_array, b_array]
     if c_shape is not None:
-        c_array = np.random.uniform(size=c_shape).astype("float32")    
+        c_array = np.random.uniform(size=c_shape).astype("float32")
         input_names.append("c")
         input_nodes.append(helper.make_tensor_value_info("c", TensorProto.FLOAT, list(c_shape)))
         input_values.append(c_array)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1038,6 +1038,8 @@ def verify_gemm(a_shape, b_shape, c_shape=None, freeze_params=False):
 @tvm.testing.uses_gpu
 def test_gemm():
     verify_gemm(a_shape=(4, 3), b_shape=(3, 4))
+    verify_gemm(a_shape=(4, 3), b_shape=(3, 4), c_shape=(4,))
+    verify_gemm(a_shape=(4, 3), b_shape=(3, 4), c_shape=(4,), freeze_params=True)
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
The change made to the Onnx gemm converter in #7489 assumes that the value of C will always be a parameter. When it is a constant or an expression, the special case handling will fail. This very tiny PR makes the handling of C more general and adds test cases that would otherwise fail.
