### PR TITLE
Don't run non-tvm_op GraphRuntime nodes in Debug Runtime over RPC.

### DIFF
--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -110,6 +110,9 @@ class GraphRuntimeDebug : public GraphRuntime {
   }
 
   double RunOpRPC(int index, int number, int repeat, int min_repeat_ms) {
+    // Right now we expect either "tvm_op" for nodes which run PackedFunc or "null" for nodes which
+    // represent inputs/parameters to the graph. Other types may be supported in the future, but
+    // consideration would be needed as to how to do that over RPC before we support it here.
     if (nodes_[index].op_type != "tvm_op") {
       CHECK_EQ(nodes_[index].op_type, "null")
           << "Don't know how to run op type " << nodes_[index].op_type

--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -110,6 +110,16 @@ class GraphRuntimeDebug : public GraphRuntime {
   }
 
   double RunOpRPC(int index, int number, int repeat, int min_repeat_ms) {
+    if (nodes_[index].op_type != "tvm_op") {
+      CHECK_EQ(nodes_[index].op_type, "null")
+          << "Don't know how to run op type " << nodes_[index].op_type
+          << " remotely over RPC right now";
+
+      // NOTE: GraphRuntimeDebug expects graph nodes to have an "op" attribute of "tvm_op" or "null"
+      // and "null" is a placeholder node for a parameter or input.
+      return 0;
+    }
+
     const TVMContext& ctx = data_entry_[entry_id(index, 0)]->ctx;
     TVMOpParam param = nodes_[index].param;
     std::string name = param.func_name;


### PR DESCRIPTION
 * These are filtered out in SetupOpExecs for normal debug runtime operation.
 * Fixes use of debug runtime with µTVM.

@tmoreau89 @tqchen @jroesch @tkonolige 