### PR TITLE
[Torch] Pool ops, convert strides and pool_size to int

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -841,6 +841,16 @@ class PyTorchOpConverter:
         dilation = inputs[4]
         ceil_mode = int(inputs[5])
 
+        if isinstance(pool_size, list):
+            for i in range(len(pool_size)):
+                if isinstance(pool_size[i], _expr.Constant):
+                    pool_size[i] = int(_infer_value_simulated(pool_size[i], {}).asnumpy())
+
+        if isinstance(strides, list):
+            for i in range(len(strides)):
+                if isinstance(strides[i], _expr.Constant):
+                    strides[i] = int(_infer_value_simulated(strides[i], {}).asnumpy())
+
         if dilation != [1, 1]:
             msg = "MaxPool2d with dilation %s is not implemented" % (str(dilation))
             raise NotImplementedError(msg)
@@ -1321,6 +1331,16 @@ class PyTorchOpConverter:
         padding = inputs[3]
         ceil_mode = int(inputs[4])
         count_include_pad = int(inputs[5])
+
+        if isinstance(pool_size, list):
+            for i in range(len(pool_size)):
+                if isinstance(pool_size[i], _expr.Constant):
+                    pool_size[i] = int(_infer_value_simulated(pool_size[i], {}).asnumpy())
+
+        if isinstance(strides, list):
+            for i in range(len(strides)):
+                if isinstance(strides[i], _expr.Constant):
+                    strides[i] = int(_infer_value_simulated(strides[i], {}).asnumpy())
 
         def func(x):
             return _op.nn.avg_pool2d(

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -832,24 +832,22 @@ class PyTorchOpConverter:
         output_size = inputs[1]
         return _op.nn.adaptive_avg_pool3d(data, output_size=output_size)
 
+    @staticmethod
+    def convert_const_list(data):
+        if isinstance(data, list):
+            for i,_ in enumerate(data):
+                if isinstance(data[i], _expr.Expr):
+                    data[i] = int(_infer_value_simulated(data[i], {}).asnumpy())
+        return data
+
     def maxpool_2d(self, inputs, input_types):
         data = inputs[0]
 
-        pool_size = inputs[1]
-        strides = inputs[2] if inputs[2] else pool_size
+        pool_size = self.convert_const_list(inputs[1])
+        strides = self.convert_const_list(inputs[2] if inputs[2] else pool_size)
         padding = inputs[3]
         dilation = inputs[4]
         ceil_mode = int(inputs[5])
-
-        if isinstance(pool_size, list):
-            for i in range(len(pool_size)):
-                if isinstance(pool_size[i], _expr.Constant):
-                    pool_size[i] = int(_infer_value_simulated(pool_size[i], {}).asnumpy())
-
-        if isinstance(strides, list):
-            for i in range(len(strides)):
-                if isinstance(strides[i], _expr.Constant):
-                    strides[i] = int(_infer_value_simulated(strides[i], {}).asnumpy())
 
         if dilation != [1, 1]:
             msg = "MaxPool2d with dilation %s is not implemented" % (str(dilation))
@@ -1326,21 +1324,11 @@ class PyTorchOpConverter:
     def avg_pool2d(self, inputs, input_types):
         data = inputs[0]
 
-        pool_size = inputs[1]
-        strides = inputs[2] if inputs[2] else pool_size
+        pool_size = self.convert_const_list(inputs[1])
+        strides = self.convert_const_list(inputs[2] if inputs[2] else pool_size)
         padding = inputs[3]
         ceil_mode = int(inputs[4])
         count_include_pad = int(inputs[5])
-
-        if isinstance(pool_size, list):
-            for i in range(len(pool_size)):
-                if isinstance(pool_size[i], _expr.Constant):
-                    pool_size[i] = int(_infer_value_simulated(pool_size[i], {}).asnumpy())
-
-        if isinstance(strides, list):
-            for i in range(len(strides)):
-                if isinstance(strides[i], _expr.Constant):
-                    strides[i] = int(_infer_value_simulated(strides[i], {}).asnumpy())
 
         def func(x):
             return _op.nn.avg_pool2d(

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -835,7 +835,7 @@ class PyTorchOpConverter:
     @staticmethod
     def convert_const_list(data):
         if isinstance(data, list):
-            for i,_ in enumerate(data):
+            for i, _ in enumerate(data):
                 if isinstance(data[i], _expr.Expr):
                     data[i] = int(_infer_value_simulated(data[i], {}).asnumpy())
         return data

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -747,6 +747,7 @@ def test_forward_maxpool2d():
     verify_model(MaxPool2DWithIndices().float().eval(), input_data=input_data)
     verify_model(MaxPool2DWithIntStrides().float().eval(), input_data=input_data)
 
+
 @tvm.testing.uses_gpu
 def test_forward_maxpool1d():
     torch.set_grad_enabled(False)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -736,8 +736,16 @@ def test_forward_maxpool2d():
             output, indices = self.pool(args[0])
             return output
 
-    verify_model(MaxPool2DWithIndices().float().eval(), input_data=input_data)
+    class MaxPool2DWithIntStrides(Module):
+        def forward(self, *args):
+            # Makes kernel_size and strides a Relay expr to test converting back to int
+            x_shape = args[0].shape
+            kernel_size = [torch.tensor(x_shape[1]).int(), torch.tensor(x_shape[1]).int()]
+            strides = [torch.tensor(x_shape[0]).int(), torch.tensor(x_shape[0]).int()]
+            return torch.nn.functional.max_pool2d(args[0], kernel_size=[4, 4], stride=strides)
 
+    verify_model(MaxPool2DWithIndices().float().eval(), input_data=input_data)
+    verify_model(MaxPool2DWithIntStrides().float().eval(), input_data=input_data)
 
 @tvm.testing.uses_gpu
 def test_forward_maxpool1d():


### PR DESCRIPTION
Was working on a SVDD model and ran into some issues with pool operators. 

```
  File "tests/python/frontend/pytorch/test_svdd.py", line 39, in <module>
    mod, params = relay.frontend.from_pytorch(model, shape_dict)
  File "/home/ubuntu/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 3160, in from_pytorch
    ret = converter.convert_operators(_get_operator_nodes(graph.nodes()), outputs, ret_name)[0]
  File "/home/ubuntu/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 2582, in convert_operators
    inputs, _get_input_types(op_node, outputs, default_dtype=self.default_dtype)
  File "/home/ubuntu/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 1338, in avg_pool2d
    return func(data)
  File "/home/ubuntu/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 1332, in func
    count_include_pad=count_include_pad,
  File "/home/ubuntu/tvm/tvm/python/tvm/relay/op/nn/nn.py", line 1026, in avg_pool2d
    return _make.avg_pool2d(data, pool_size, strides, padding, layout, ceil_mode, count_include_pad)
  File "/home/ubuntu/tvm/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  [bt] (4) /home/ubuntu/tvm/tvm/build/libtvm.so(TVMFuncCall+0x5b) [0x7f6ec5b4f8db]
  [bt] (3) /home/ubuntu/tvm/tvm/build/libtvm.so(+0xe41916) [0x7f6ec564d916]
  [bt] (2) /home/ubuntu/tvm/tvm/build/libtvm.so(tvm::runtime::TVMMovableArgValueWithContext_::operator tvm::runtime::Array<tvm::PrimExpr, void><tvm::runtime::Array<tvm::PrimExpr, void> >() const+0x67) [0x7f6ec4df0217]
  [bt] (1) /home/ubuntu/tvm/tvm/build/libtvm.so(tvm::runtime::Array<tvm::PrimExpr, void> tvm::runtime::TVMPODValue_::AsObjectRef<tvm::runtime::Array<tvm::PrimExpr, void> >() const+0x438) [0x7f6ec4df00a8]
  [bt] (0) /home/ubuntu/tvm/tvm/build/libtvm.so(+0x5d5612) [0x7f6ec4de1612]
  File "/home/ubuntu/tvm/tvm/include/tvm/runtime/packed_func.h", line 687
TVMError: In function relay.op.nn._make.avg_pool2d: error while converting argument 2: [10:04:02] /home/ubuntu/tvm/tvm/include/tvm/runtime/packed_func.h:1564: 
---------------------------------------------------------------
An internal invariant was violated during the execution of TVM.
Please read TVM's error reporting guidelines.
More details can be found here: https://discuss.tvm.ai/t/error-reporting/7793.
---------------------------------------------------------------
  Check failed: !checked_type.defined() == false: Expected Array[PrimExpr], but got Array[index 0: relay.Constant]
```

I found that if the PT graph has aten::Int as the input value for either strides or pool_size, then we get above.

```
 %125 : int = aten::Int(%124)
 %126 : int[] = prim::ListConstruct(%116, %119)
 %127 : int[] = prim::ListConstruct(%122, %125)
 %128 : int[] = prim::ListConstruct(%111, %111)
 %x.6 : Tensor = aten::avg_pool2d(%x.5, %126, %127, %128, %108, %107, %106)

```
This fixes that case by converting relay constants to ints. @masahi 