### PR TITLE
[ONNX] use checked_type instead of type_annotation

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1753,7 +1753,7 @@ class LSTM(RNN):
         P = inputs[7]
 
         num_directions = infer_shape(W)[0]
-        W_dtype = infer_type(W).type_annotation.dtype
+        W_dtype = infer_type(W).checked_type.dtype
 
         if num_directions != 1:
             raise NotImplementedError("Bidirectional LSTMs not yet supported.")
@@ -1865,7 +1865,7 @@ class GRU(RNN):
         linear_before_reset = attr.get("linear_before_reset", 0)
 
         num_directions = infer_shape(W)[0]
-        W_dtype = infer_type(W).type_annotation.dtype
+        W_dtype = infer_type(W).checked_type.dtype
 
         if num_directions != 1:
             raise NotImplementedError("Bidirectional GRUs not yet supported.")


### PR DESCRIPTION
@jwfromm I recently ran into an error where the W input to an LSTM was not a variable, so this type_annotation call failed, so I switched it to the more generic checked_type. Updating the test to hit this case is complicated, do you want to see a regression test for this?