### PR TITLE
[BUG_FIX][TOPI] Allow topi resize to accept more options

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -839,7 +839,9 @@ class Reciprocal(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        return _expr.const(1.0) / inputs[0]
+        # Change from Matt's branch that fixes import of EA model
+        dtype = infer_type(inputs[0]).checked_type.dtype
+        return _expr.const(1.0, dtype=dtype) / inputs[0]
 
 
 class Flatten(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -839,10 +839,7 @@ class Reciprocal(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        # Change from Matt's branch that fixes import of EA model
-        dtype = infer_type(inputs[0]).checked_type.dtype
-        return _expr.const(1.0, dtype=dtype) / inputs[0]
-
+        return _expr.const(1.0) / inputs[0]
 
 class Flatten(OnnxOpConverter):
     """Operator converter for Flatten."""

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -841,6 +841,7 @@ class Reciprocal(OnnxOpConverter):
     def _impl_v1(cls, inputs, attr, params):
         return _expr.const(1.0) / inputs[0]
 
+
 class Flatten(OnnxOpConverter):
     """Operator converter for Flatten."""
 

--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -653,11 +653,7 @@ def resize(
         or 5-D with shape [batch, channel-major, in_height*scale, in_width*scale, channel-minor]
     """
     method = method.lower()
-    if method == "nearest_neighbor" and coordinate_transformation_mode != "asymmetric":
-        raise ValueError(
-            "Topi Resize does not support the combination of method %s "
-            "and coordinate_transformation_mode %s" % (method, coordinate_transformation_mode)
-        )
+
     if layout == "NHWC":
         in_n, in_h, in_w, in_c = data.shape
         if output_shape is None:

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -3353,7 +3353,7 @@ def test_resize():
         model = helper.make_model(graph, producer_name="resize_test")
 
         verify_with_ort(model, [ishape], [oshape], use_vm=True, opset=11, freeze_params=True)
-    
+
     # upsampling
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "nearest", "asymmetric")
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "linear", "asymmetric")

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -67,7 +67,7 @@ def get_tvm_output(
     graph_def, input_data, target, ctx, output_shape=None, output_dtype="float32", opset=None
 ):
     """ Generic function to execute and get tvm output"""
-    #target = "llvm"
+    target = "llvm"
 
     input_names, shape_dict = get_input_data_shape_dict(graph_def, input_data)
 
@@ -75,7 +75,7 @@ def get_tvm_output(
     with tvm.transform.PassContext(opt_level=1):
         graph, lib, params = relay.build(mod, target, params=params)
 
-    #ctx = tvm.cpu(0)
+    ctx = tvm.cpu(0)
     m = graph_runtime.create(graph, lib, ctx)
     # set inputs
     if isinstance(input_data, list):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -67,7 +67,7 @@ def get_tvm_output(
     graph_def, input_data, target, ctx, output_shape=None, output_dtype="float32", opset=None
 ):
     """ Generic function to execute and get tvm output"""
-    target = "llvm"
+    #target = "llvm"
 
     input_names, shape_dict = get_input_data_shape_dict(graph_def, input_data)
 
@@ -75,7 +75,7 @@ def get_tvm_output(
     with tvm.transform.PassContext(opt_level=1):
         graph, lib, params = relay.build(mod, target, params=params)
 
-    ctx = tvm.cpu(0)
+    #ctx = tvm.cpu(0)
     m = graph_runtime.create(graph, lib, ctx)
     # set inputs
     if isinstance(input_data, list):
@@ -3353,18 +3353,22 @@ def test_resize():
         model = helper.make_model(graph, producer_name="resize_test")
 
         verify_with_ort(model, [ishape], [oshape], use_vm=True, opset=11, freeze_params=True)
-
+    
     # upsampling
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "nearest", "asymmetric")
+    verify([1, 16, 32, 32], [1, 16, 64, 64], [], "linear", "asymmetric")
+    verify([1, 16, 32, 32], [1, 16, 64, 64], [], "nearest", "align_corners")
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "linear", "align_corners")
+    verify([1, 16, 32, 32], [1, 16, 64, 64], [], "nearest", "half_pixel")
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "linear", "half_pixel")
-    # downsampling
-    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "nearest", "asymmetric")
-    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "linear", "align_corners")
-    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "linear", "half_pixel")
+
     # scales are specified instead of sizes
     verify([1, 16, 32, 32], [], [1, 1, 2, 2], "nearest", "asymmetric")
+    verify([1, 16, 32, 32], [], [1, 1, 2, 2], "linear", "asymmetric")
+    verify([1, 16, 32, 32], [], [1, 1, 2, 2], "nearest", "align_corners")
+    verify([1, 16, 32, 32], [], [1, 1, 2, 2], "linear", "align_corners")
     verify([1, 16, 32, 32], [], [1, 1, 0.5, 0.5], "linear", "half_pixel")
+    verify([1, 16, 32, 32], [], [1, 1, 0.5, 0.5], "nearest", "half_pixel")
 
     def verify_opset_10(ishape, scales, mode):
         nodes = [

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -3362,6 +3362,14 @@ def test_resize():
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "nearest", "half_pixel")
     verify([1, 16, 32, 32], [1, 16, 64, 64], [], "linear", "half_pixel")
 
+    # downsampling
+    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "nearest", "asymmetric")
+    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "linear", "asymmetric")
+    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "nearest", "align_corners")
+    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "linear", "align_corners")
+    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "nearest", "half_pixel")
+    verify([1, 16, 32, 32], [1, 16, 16, 16], [], "linear", "half_pixel")
+
     # scales are specified instead of sizes
     verify([1, 16, 32, 32], [], [1, 1, 2, 2], "nearest", "asymmetric")
     verify([1, 16, 32, 32], [], [1, 1, 2, 2], "linear", "asymmetric")

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -67,13 +67,19 @@ def test_resize():
             for kind in ["graph", "debug"]:
                 intrp = relay.create_executor(kind, ctx=ctx, target=target)
                 op_res = intrp.evaluate(func)(x_data)
-                tvm.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=1e-4, atol=1e-5)
+                tvm.testing.assert_allclose(op_res.asnumpy(), ref_res, rtol=1e-3, atol=1e-4)
 
-    for layout in ["NHWC", "NCHW"]:
-        verify_resize((1, 4, 4, 4), 2, "bilinear", layout, "align_corners")
-        verify_resize((2, 8, 17, 20), 3, "bilinear", layout, "half_pixel")
-        verify_resize((2, 8, 17, 20), 3, "bilinear", layout, "asymmetric")
-        verify_resize((3, 4, 5, 6), 5, "nearest_neighbor", layout, "asymmetric")
+    for method in ["nearest_neighbor", "bilinear"]:
+        for coord_trans in ["asymmetric", "half_pixel", "align_corners"]:
+            for layout in ["NHWC", "NCHW"]:
+                # TODO: Topi test does not have a function to produce numpy output for resize with
+                # nearest_neighbors and align_corners. Enable when topi test has this option
+                if coord_trans == "align_corners" and method == "nearest_neighbor":
+                    continue
+                verify_resize((1, 4, 4, 4), 2, method, layout, coord_trans)
+                verify_resize((2, 8, 17, 20), 3, method, layout, coord_trans)
+                verify_resize((2, 8, 17, 20), 3, method, layout, coord_trans)
+                verify_resize((3, 4, 5, 6), 5, method, layout, coord_trans)
 
 
 def test_resize3d_infer_type():

--- a/tests/python/topi/python/test_topi_image.py
+++ b/tests/python/topi/python/test_topi_image.py
@@ -100,6 +100,7 @@ def test_resize():
                     continue
                 verify_resize(4, 16, 32, 32, 50, 50, layout, coord_trans, method=method)
 
+
 def verify_resize3d(
     batch,
     in_channel,

--- a/tests/python/topi/python/test_topi_image.py
+++ b/tests/python/topi/python/test_topi_image.py
@@ -59,6 +59,9 @@ def verify_resize(
             a_np, (out_height, out_width), layout, coord_trans
         )
     else:
+        # TODO: Nearest neighbor case doesn't do anything with coordinate transform mode, and also
+        # nearest_neighbors and align_corners combination in topi doesn't match the output of this
+        # function.
         scale_h = out_height / in_height
         scale_w = out_width / in_width
         b_np = tvm.topi.testing.upsampling_python(a_np, (scale_h, scale_w), layout)
@@ -88,16 +91,14 @@ def test_resize():
     verify_resize(4, 16, 32, 32, 50, 50, "NHWC")
     # Scale NHWC + Align Corners
     verify_resize(6, 32, 64, 64, 20, 20, "NHWC")
-    # Nearest + Fractional
-    verify_resize(4, 16, 32, 32, 50, 50, "NCHW", "asymmetric", method="nearest_neighbor")
-    verify_resize(4, 16, 32, 32, 50, 50, "NHWC", "asymmetric", method="nearest_neighbor")
-    # half_pixel
-    verify_resize(4, 16, 16, 16, 32, 32, "NCHW", "half_pixel", method="bilinear")
-    verify_resize(4, 16, 16, 16, 32, 32, "NHWC", "half_pixel", method="bilinear")
-    # Bilinear + Fractional
-    verify_resize(4, 16, 32, 32, 50, 50, "NCHW", "asymmetric", method="bilinear")
-    verify_resize(4, 16, 32, 32, 50, 50, "NHWC", "asymmetric", method="bilinear")
-
+    for method in ["nearest_neighbor", "bilinear"]:
+        for coord_trans in ["asymmetric", "half_pixel", "align_corners"]:
+            for layout in ["NCHW", "NHWC"]:
+                # TODO: When topi test has an option for align corners and nearest neighbor that
+                # produces correct results, re-enable it.
+                if coord_trans == "align_corners" and method == "nearest_neighbor":
+                    continue
+                verify_resize(4, 16, 32, 32, 50, 50, layout, coord_trans, method=method)
 
 def verify_resize3d(
     batch,


### PR DESCRIPTION
In PR #6298, we restricted the options supported by topi resize. This was incorrect and was causing failures in the onnx importer tests for resize. This PR removes the check added in #6289, and adds more tests to topi and onnx. 

Finally, the topi testing suite can't produce reference values for resize with the options nearest_neighbor and align_corners, so I skip that combo in the topi and relay op tests. However, these options work in the onnx tests, so it's not a huge concern. 

@mbrookhart Please take a look!