### PR TITLE
Add test_forward_index_put to __main__

### DIFF
--- a/python/tvm/auto_scheduler/feature.py
+++ b/python/tvm/auto_scheduler/feature.py
@@ -120,7 +120,7 @@ def unpack_feature(byte_arr: bytearray) -> Tuple[np.ndarray, np.ndarray, np.ndar
             tmp_vec_len = (size - 1) // n_stmts
             assert (
                 tmp_vec_len == vec_len
-            ), "The lenght of feature vector is wrong. " "Expected %d but got %d." % (
+            ), "The length of feature vector is wrong. Expected %d but got %d." % (
                 vec_len,
                 tmp_vec_len,
             )

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1957,7 +1957,7 @@ def test_custom_conversion_map():
 
 
 @tvm.testing.uses_gpu
-def test_segmentaton_models():
+def test_segmentation_models():
     class SegmentationModelWrapper(Module):
         def __init__(self, model):
             super().__init__()
@@ -3811,6 +3811,7 @@ if __name__ == "__main__":
     test_forward_unbind()
     test_forward_nonzero()
     test_forward_scatter()
+    test_forward_index_put()
     test_numel()
     test_bincount()
     test_cumsum()
@@ -3836,7 +3837,7 @@ if __name__ == "__main__":
 
     test_custom_conversion_map()
 
-    test_segmentaton_models()
+    test_segmentation_models()
     test_3d_models()
 
     # Quantization test


### PR DESCRIPTION
Fixes:
- Add `test_forward_index_put` to the __main__
- Fix typo in `test_segmentaton_models`
- Fix typo in `lenght`
