### PR TITLE
[Torch] Simplify contiguous

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -991,8 +991,7 @@ class PyTorchOpConverter:
         return _op.nn.relu(data)
 
     def contiguous(self, inputs, input_types):
-        data = inputs[0]
-        return _op.tensor.copy(data)
+        return inputs[0]
 
     def batch_norm(self, inputs, input_types):
         data = inputs[0]


### PR DESCRIPTION
`contiguous` in PyTorch creates a continguous tensor which is required for some future operators such as `view`. However, it is not a case in Relay. As a result, it is safe to simply bypass this op in PyTorch frontend.

cc @alexwong @masahi @apivovarov 