### PR TITLE
[Relay][bugfix][error reporting] BiasAddRel does not check for a negative index being out of bounds

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -61,10 +61,10 @@ bool BiasAddRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   if (axis < 0) {
     axis = data->shape.size() + axis;
   }
-  if (axis >= static_cast<int>(data->shape.size())) {
+  if (axis >= static_cast<int>(data->shape.size()) || axis < 0) {
     reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
                                      << "The axis in bias_add must be in range for the shape; "
-                                     << "attempted to access index " << axis << " of "
+                                     << "attempted to access index " << param->axis << " of "
                                      << PrettyPrint(data->shape));
     return false;
   }

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -202,14 +202,15 @@ def test_bias_add():
 
 
 def test_bias_add_type_failure():
-    # the axis is out of range
-    try:
-        b_add = relay.nn.bias_add(relay.const(1), relay.const(2), axis=0)
-        run_infer_type(b_add)
-    except tvm._ffi.base.TVMError:
-        pass
-    else:
-        assert False
+    def assert_failure(expr):
+        try:
+            run_infer_type(expr)
+        except tvm._ffi.base.TVMError:
+            return
+        else:
+            assert False
+    for axis in (0, -1, -3, 1):
+        assert_failure(relay.nn.bias_add(relay.const(1), relay.const(2), axis=axis))
 
 
 def test_expand_dims_infer_type():

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -209,6 +209,7 @@ def test_bias_add_type_failure():
             return
         else:
             assert False
+
     for axis in (0, -1, -3, 1):
         assert_failure(relay.nn.bias_add(relay.const(1), relay.const(2), axis=axis))
 


### PR DESCRIPTION
A follow-up to #7467 on `bias_add`, I realized the type relation wasn't bounds checking on the negative side. It's not a serious error, but it's good to have an informative error message for such cases. (I happened to be looking at that type relation because I was trying to formalize it in an ILP solver 😛)

Please review @tkonolige @junrushao1994 