### PR TITLE
[AutoScheduler] Querying and sampling in task extraction

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -283,10 +283,13 @@ def auto_schedule_topi(outs):
     key = register_workload_tensors(dag.workload_key(), io_tensors)
     target = tvm.target.Target.current()
 
+    dispatch_ctx = DispatchContext.current
+    state = dispatch_ctx.query(target, key, has_complex_op, dag)
+    schedule = None
+
     env = TracingEnvironment.current
     if env is None:
         # in the final build mode
-        state = DispatchContext.current.query(target, key, has_complex_op, dag)
         if state is None:
             return None
 
@@ -303,8 +306,6 @@ def auto_schedule_topi(outs):
             LayoutRewriteOption.get_target_default(target, True) != LayoutRewriteOption.NO_REWRITE
             and has_layout_free
         ):
-            dispatch_ctx = DispatchContext.current
-            state = dispatch_ctx.query(target, key, has_complex_op, dag)
             if state is None:
                 return None
 
@@ -316,7 +317,7 @@ def auto_schedule_topi(outs):
     else:
         raise ValueError("Invalid tracing mode: " + env.tracing_mode)
 
-    return None
+    return schedule
 
 
 def tensor_no_check_call(self, *indices):


### PR DESCRIPTION
This PR deals with the case that we may want to extract tuning tasks from a JIT model that compiles each subgraph when first time executing the model graph. In this case, we need at least one valid schedule (for GPU) to make sure we can visit the whole graph and collect all tasks, but this may not be the case especially for the backward model.

The above puzzle forms a chicken egg problem -- we don't have valid schedules so we need to extract tasks to tune, but we need at least one valid schedule in order to extract tasks. This PR solves this puzzle by sampling one valid schedule during task extraction:

```python
    env_sample = auto_scheduler.ApplyHistoryBestOrSample("temp.log", num_measure=2)
    env_tracing_task = auto_scheduler.relay_integration.TracingEnvironment(
        auto_scheduler.relay_integration.TracingMode.EXTRACT_COMPLEX_TASK_ONLY
    )
    with env_sample:
        with env_tracing_task:
            # Run the JIT model.
```

The idea is once we found that there's no valid schedule of the task being collected, we immediately sample a valid schedule and use it for the current subgraph. In this way, we guarantee the graph can be visited from beginning to the end.

cc @merrymercy 