### PR TITLE
[SPIR-V] Add SPIR-V lowering for While node

### DIFF
--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -93,6 +93,7 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
   // stmt
   void VisitStmt_(const StoreNode* op) override;
   void VisitStmt_(const ForNode* op) override;
+  void VisitStmt_(const WhileNode* op) override;
   void VisitStmt_(const IfThenElseNode* op) override;
   void VisitStmt_(const AllocateNode* op) override;
   void VisitStmt_(const AttrStmtNode* op) override;

--- a/tests/python/unittest/test_tir_ir_builder.py
+++ b/tests/python/unittest/test_tir_ir_builder.py
@@ -405,6 +405,7 @@ def test_while_mandel():
     check_target("llvm", mandel_ir_cpu)
     check_target("npvtx", mandel_ir_gpu)
     check_target("cuda", mandel_ir_gpu)
+    check_target("vulkan", mandel_ir_gpu)
 
 
 def test_while_binary_search():
@@ -493,6 +494,7 @@ def test_while_binary_search():
     check_target("llvm", searchsorted_ir_cpu)
     check_target("cuda", searchsorted_ir_gpu)
     check_target("nvptx", searchsorted_ir_gpu)
+    check_target("vulkan", searchsorted_ir_gpu)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A follow-up to https://github.com/apache/tvm/pull/7425 adding WhileNode support in SPIR-V lowering. It is a simplified from existing ForNode lowering https://github.com/apache/tvm/blob/7340c02d0efe0f5eb5692fb9f4cc7573c5d056cb/src/target/spirv/codegen_spirv.cc#L476, removing phi stuff, and loop var init/extent related code. Hopefully it is self  explanatory. 

Mandelbrot set and binary search test cases from https://github.com/apache/tvm/pull/7425 is working with VK now.

@tqchen @junrushao1994 @vinx13 @jroesch 