### PR TITLE
[DOCKER] Fix: install script regarding get-pip.py during docker build

### DIFF
--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -34,7 +34,7 @@ apt-get install -y python-pip python-dev python3.6 python3.6-dev
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python3
 
 # Install pip
-cd /tmp && wget -q https://bootstrap.pypa.io/2.7/get-pip.py && python2 get-pip.py && python3.6 get-pip.py
+cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python3.6 get-pip.py
 
 # Pin pip version
 pip3 install pip==19.3.1

--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -34,7 +34,7 @@ apt-get install -y python-pip python-dev python3.6 python3.6-dev
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python3
 
 # Install pip
-cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python2 get-pip.py && python3.6 get-pip.py
+cd /tmp && wget -q https://bootstrap.pypa.io/2.7/get-pip.py && python2 get-pip.py && python3.6 get-pip.py
 
 # Pin pip version
 pip3 install pip==19.3.1


### PR DESCRIPTION
Replaced the URL of `get-pip.py` from 

[https://bootstrap.pypa.io/get-pip.py](https://bootstrap.pypa.io/get-pip.py) 

to 

[https://bootstrap.pypa.io/2.7/get-pip.py](https://bootstrap.pypa.io/2.7/get-pip.py)

, as the old one doesn't support python 2.7 any more and triggers below error during the building of `Dockerfile.demo_android`. 

> ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6.

Other than this, the whole docker building procedure works OK.

@leandron Could you please help to review? Thanks.
