### PR TITLE
[LLVM] FixedVectorType is only available in v120, not v110.

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -420,7 +420,7 @@ llvm::Type* CodeGenLLVM::DTypeToLLVMType(const DataType& dtype) const {
     }
   }
   if (dtype.lanes() != 1) {
-#if TVM_LLVM_VERSION >= 110
+#if TVM_LLVM_VERSION > 110
     return llvm::FixedVectorType::get(etype, dtype.lanes());
 #else
     return llvm::VectorType::get(etype, dtype.lanes());
@@ -560,7 +560,7 @@ std::unique_ptr<CodeGenLLVM::DebugInfo> CodeGenLLVM::CreateDebugInfo(llvm::Modul
 }
 
 llvm::Value* CodeGenLLVM::CreateBroadcast(llvm::Value* value, int lanes) {
-#if TVM_LLVM_VERSION >= 110
+#if TVM_LLVM_VERSION > 110
   llvm::Type* type = llvm::FixedVectorType::get(value->getType(), lanes);
 #else
   llvm::Type* type = llvm::VectorType::get(value->getType(), lanes);

--- a/src/target/llvm/codegen_x86_64.cc
+++ b/src/target/llvm/codegen_x86_64.cc
@@ -140,7 +140,7 @@ llvm::Value* CodeGenX86_64::CallVectorIntrin(llvm::Intrinsic::ID id, size_t intr
         split_args.push_back(v);
       }
     }
-#if TVM_LLVM_VERSION >= 110
+#if TVM_LLVM_VERSION > 110
     llvm::Type* type = llvm::FixedVectorType::get(result_ty->getScalarType(), intrin_lanes);
 #else
     llvm::Type* type = llvm::VectorType::get(result_ty->getScalarType(), intrin_lanes);


### PR DESCRIPTION
Fix for TVM build errors with rocm-3.7 and llvm 11.0,
```
/tvm/src/target/llvm/codegen_x86_64.cc: In member function 'llvm::Value* tvm::codegen::CodeGenX86_64::CallVectorIntrin(llvm::Intrinsic::ID, size_t, llvm::Type*, const std::vector<llvm::Value*, std::allocator<llvm::Value*> >&)':
/home/csullivan/projects/incubator-tvm/src/target/llvm/codegen_x86_64.cc:144:30: error: 'llvm::FixedVectorType' has not been declared
     llvm::Type* type = llvm::FixedVectorType::get(result_ty->getScalarType(), intrin_lanes);```