### PR TITLE
[SPIRV] Support Bool buffer argument

### DIFF
--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -45,13 +45,15 @@ std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
       if (auto* ptr = arg->type_annotation.as<PointerTypeNode>()) {
         auto* prim = ptr->element_type.as<PrimTypeNode>();
         ICHECK(prim);
-        DataType value_type = prim->dtype;
-        if (value_type == DataType::UInt(1)) {
-          value_type = DataType::UInt(8);
+        DataType value_storage_type = prim->dtype;
+        if (value_storage_type == DataType::UInt(1)) {
+          // We need a physically addressable buffer type to support boolean tensors.
+          // The loaded byte is cast to bool inside the LoadNode visitor below.
+          value_storage_type = DataType::UInt(8);
         }
         spirv::Value arg_value =
-            builder_->BufferArgument(builder_->GetSType(value_type), 0, num_buffer);
-        storage_info_[arg.get()].UpdateContentType(value_type);
+            builder_->BufferArgument(builder_->GetSType(value_storage_type), 0, num_buffer);
+        storage_info_[arg.get()].UpdateContentType(value_storage_type);
         var_map_[arg.get()] = arg_value;
       } else {
         LOG(FATAL) << "require all handles to be typed";
@@ -376,6 +378,7 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const LoadNode* op) {
     spirv::Value ptr = builder_->StructArrayAccess(ptr_type, buffer, index);
     spirv::Value loaded = builder_->MakeValue(spv::OpLoad, content_type, ptr, mask);
     if (op->dtype == DataType::UInt(1)) {
+      // A bool tensor is backed by a byte buffer, we cast to bool here.
       auto bool_ty = builder_->GetSType(DataType::UInt(1));
       return builder_->Cast(bool_ty, loaded);
     } else {

--- a/tests/python/unittest/test_target_codegen_spirv.py
+++ b/tests/python/unittest/test_target_codegen_spirv.py
@@ -21,17 +21,14 @@ from tvm.topi.math import cast
 import numpy as np
 
 
-tx = te.thread_axis("threadIdx.x")
-ty = te.thread_axis("threadIdx.y")
-bx = te.thread_axis("blockIdx.x")
-by = te.thread_axis("blockIdx.y")
-
-
 def test_bool_load():
     def do_copy(A, B, n):
         ib = tvm.tir.ir_builder.create()
         A = ib.buffer_ptr(A)
         B = ib.buffer_ptr(B)
+
+        tx = te.thread_axis("threadIdx.x")
+        bx = te.thread_axis("blockIdx.x")
 
         max_threads = 32
         ib.scope_attr(bx, "thread_extent", tvm.tir.indexdiv(n + max_threads - 1, max_threads))

--- a/tests/python/unittest/test_target_codegen_spirv.py
+++ b/tests/python/unittest/test_target_codegen_spirv.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import tvm.testing
+from tvm import te
+from tvm.topi.math import cast
+import numpy as np
+
+
+tx = te.thread_axis("threadIdx.x")
+ty = te.thread_axis("threadIdx.y")
+bx = te.thread_axis("blockIdx.x")
+by = te.thread_axis("blockIdx.y")
+
+
+def test_bool_load():
+    def searchsorted_ir_gpu(A, B, n):
+        ib = tvm.tir.ir_builder.create()
+        A = ib.buffer_ptr(A)
+        B = ib.buffer_ptr(B)
+
+        max_threads = 32
+        ib.scope_attr(bx, "thread_extent", tvm.tir.indexdiv(n + max_threads - 1, max_threads))
+        ib.scope_attr(tx, "thread_extent", max_threads)
+        tid = bx * max_threads + tx
+
+        with ib.if_scope(tid < n):
+            B[tid] = cast(A[tid], "int32")
+
+        return ib.get()
+
+    n = 1024
+    in_dtype = "bool"
+    A = te.placeholder((n,), name="A", dtype=in_dtype)
+    B = te.placeholder((n,), name="B", dtype="int32")
+
+    target = "vulkan"
+
+    if not tvm.testing.device_enabled(target):
+        return
+
+    B = te.extern(
+        A.shape,
+        [A],
+        lambda ins, outs: searchsorted_ir_gpu(ins[0], outs[0], n),
+        name="searchsorted_ir",
+        dtype="int32",
+    )
+    s = te.create_schedule(B.op)
+
+    with tvm.transform.PassContext(opt_level=3):
+        func = tvm.build(s, [A, B], target)
+
+    ctx = tvm.context(target, 0)
+    a_np = np.random.uniform(size=n) > 0.5
+    a_np = a_np.astype(in_dtype)
+    b_np = np.zeros((n,), dtype="int32")
+    a = tvm.nd.array(a_np, ctx)
+    b = tvm.nd.array(b_np, ctx)
+    func(a, b)
+    ref = a_np.astype(np.int32)
+    tvm.testing.assert_allclose(b.asnumpy(), ref)
+
+
+if __name__ == "__main__":
+    test_bool_load()


### PR DESCRIPTION
[SPIR-V spec](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpTypeBool) says we cannot physically address boolean buffers, but right now we are generating code like this:

```
%_runtimearr_bool = OpTypeRuntimeArray %bool
...
%_ptr_StorageBuffer_bool = OpTypePointer StorageBuffer %bool
...
         %36 = OpInBoundsAccessChain %_ptr_StorageBuffer_bool %16 %int_0 %24
         %37 = OpLoad %bool %36 None
```
This is generating garbage outputs. Actually we hit an error at https://github.com/apache/tvm/blob/1831c17998b29f3797f364410980809bfef554ca/src/target/spirv/ir_builder.cc#L130-L131 so boolean buffers are not supported at all.

I updated SPIR-V codegen to make a char buffer when the input is a bool tensor, and add cast to bool after loading the char.

If this change looks good, I should probably update the visitor for storing bool buffer output as well.

This enables running the cumsum test on a boolean flag array, which is explicitly disabled for vulkan in https://github.com/apache/tvm/pull/7572 due to the lack of this fix. 

@tqchen @tmoreau89 @jwfromm 

