### PR TITLE
[TE] Fix bug in AutoInlineElemWise and implement AutoInlineBroadcast

### DIFF
--- a/include/tvm/te/schedule_pass.h
+++ b/include/tvm/te/schedule_pass.h
@@ -42,6 +42,13 @@ namespace te {
 void AutoInlineElemWise(Schedule sch);
 
 /*!
+ * \brief To automatically inline the broadcast operations.
+ *
+ * \param sch The schedule to be inlined.
+ */
+void AutoInlineBroarcast(Schedule sch);
+
+/*!
  * \brief To automatically inline operations with injective writes
  *   (i.e. writes without reduction or sequential loops). Note
  *   that in this case, guarantees about contiguity, transpose, stride,


### PR DESCRIPTION
Hi Community,

When I try to use the auto inline functions, I found that one for element-wise is not working due to the wrong **VisitExpr_**, it should be **ProducerLoadNode** not **CallNode**. And I also implement the broadcast one by simply checking the **tag**, cause ops in Topi has the specified tag.

@comaniac @ZihengJiang @tqchen Please help to review, thanks!