### PR TITLE
[Executor][Bugfix] Properly return and unflatten outputs from GraphExecutor

### DIFF
--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -19,7 +19,6 @@ Construct the necessary state for the TVM graph runtime
 from a Relay expression.
 """
 import warnings
-import copy
 import numpy as np
 
 from tvm.ir import IRModule

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -414,7 +414,7 @@ class GraphExecutor(_interpreter.Executor):
             gmodule.run()
             flattened = []
             for i in range(gmodule.get_num_outputs()):
-                flattened.append(gmodule.get_output(i))
+                flattened.append(gmodule.get_output(i).copyto(_nd.cpu(0)))
             unflattened, _ = _unflatten(flattened, ret_type, 0)
             return unflattened
 

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -401,20 +401,19 @@ class GraphExecutor(_interpreter.Executor):
                 prefix = prefix[1:]
             data[prefix[0]] = value
 
-        def _build_index(ty, prefix, structure, index_map, cur_index=0):
-            if isinstance(ty, _ty.TensorType):
+        def _build_index(cur_type, prefix, structure, index_map, cur_index=0):
+            if isinstance(cur_type, _ty.TensorType):
                 index_map[cur_index] = prefix
                 _write_prefix(structure, prefix, None)
                 return structure, index_map, cur_index + 1
-            elif isinstance(ty, _ty.TupleType):
-                _write_prefix(structure, prefix, [None] * len(ty.fields))
-                for i, field_ty in enumerate(ty.fields):
+            if isinstance(cur_type, _ty.TupleType):
+                _write_prefix(structure, prefix, [None] * len(cur_type.fields))
+                for i, field_type in enumerate(cur_type.fields):
                     structure, index_map, cur_index = _build_index(
-                        field_ty, prefix + [i], structure, index_map, cur_index=cur_index
+                        field_type, prefix + [i], structure, index_map, cur_index=cur_index
                     )
                 return structure, index_map, cur_index
-            else:
-                raise ValueError("Return type", ret_type, "contains unsupported type", ty)
+            raise ValueError("Return type", ret_type, "contains unsupported type", cur_type)
 
         # output_structure has the unflattened structure of outputs according to ret_type
         # index_map takes the flattened index to a list of indices indexing into output_structure


### PR DESCRIPTION
Previously, if a graph module returned nested tuples (which end up being flattened per #6809), the GraphExecutor would not unflatten the result and instead naively returned only the first `k` of the flattened outputs (where `k = original top-level tuple size`). This PR fixes the output behavior of GraphExecutor to be the same as the VMExecutor ,by returning the outputs unflattened into nested lists respecting the original return type structure.

cc @masahi @jroesch 

~~I'm not super happy with the unflattening code, let me know if there's an easier/cleaner approach.~~
Edit: I think it's clean enough now