### PR TITLE
Fix RelayVM for 32-bit platforms

### DIFF
--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -252,11 +252,7 @@ void Executable::SaveConstantSection(dmlc::Stream* strm) {
   }
 
   // Save the const to device mapping.
-  std::vector<size_t> const_device_type;
-  for (auto dev_type : this->const_device_type) {
-    const_device_type.push_back(static_cast<size_t>(dev_type));
-  }
-  strm->Write(const_device_type);
+  strm->Write(this->const_device_type);
 }
 
 void Executable::SavePrimitiveOpNames(dmlc::Stream* strm) {
@@ -525,12 +521,10 @@ void Executable::LoadConstantSection(dmlc::Stream* strm) {
   }
 
   // Load the const to device mapping.
-  std::vector<size_t> const_device_type;
+  std::vector<Index> const_device_type;
   STREAM_CHECK(strm->Read(&const_device_type), "constant");
   ICHECK_EQ(size, const_device_type.size());
-  for (auto dev : const_device_type) {
-    this->const_device_type.push_back(static_cast<Index>(dev));
-  }
+  this->const_device_type = const_device_type;
 }
 
 void Executable::LoadPrimitiveOpNames(dmlc::Stream* strm) {

--- a/src/runtime/vm/serialize_utils.h
+++ b/src/runtime/vm/serialize_utils.h
@@ -24,13 +24,14 @@
 #ifndef TVM_RUNTIME_VM_SERIALIZE_UTILS_H_
 #define TVM_RUNTIME_VM_SERIALIZE_UTILS_H_
 
-#include <dmlc/common.h>
 #include <dmlc/memory_io.h>
 #include <tvm/runtime/vm/executable.h>
 
 #include <functional>
 #include <string>
 #include <vector>
+
+#include "../../support/utils.h"
 
 namespace tvm {
 namespace runtime {
@@ -40,9 +41,9 @@ namespace vm {
 constexpr uint64_t kTVMVMBytecodeMagic = 0xD225DE2F4214151D;
 
 template <typename T>
-static inline size_t VectorHash(size_t key, const std::vector<T>& values) {
+static inline uint64_t VectorHash(uint64_t key, const std::vector<T>& values) {
   for (const auto& it : values) {
-    key = dmlc::HashCombine(key, it);
+    key = support::HashCombine(key, it);
   }
   return key;
 }
@@ -122,7 +123,7 @@ struct VMInstructionSerializer {
    * instruction.
    */
   Index Hash() const {
-    size_t key = static_cast<size_t>(opcode);
+    uint64_t key = static_cast<uint64_t>(opcode);
     key = VectorHash(key, fields);
     return key;
   }

--- a/src/support/utils.h
+++ b/src/support/utils.h
@@ -162,6 +162,15 @@ inline size_t HashCombine(size_t key, size_t value) {
   return key ^ (value + 0x9e3779b9 + (key << 6) + (key >> 2));
 }
 
+/*!
+ * \brief hash an object and combines uint64_t key with previous keys
+ */
+template <typename T>
+inline uint64_t HashCombine(uint64_t key, const T& value) {
+  std::hash<T> hash_func;
+  return key ^ (hash_func(value) + 0x9e3779b9 + (key << 6) + (key >> 2));
+}
+
 }  // namespace support
 }  // namespace tvm
 #endif  // TVM_SUPPORT_UTILS_H_


### PR DESCRIPTION
RelayVM runtime used platform dependent type `size_t` for code serialization and hashcode calculation.
As a result compiled models did not work on 32-bit platforms such as ARMv7.

Related Discussion: https://discuss.tvm.apache.org/t/relayvm-on-armv7-fails-cannot-find-function-in-module/9309