### PR TITLE
Prevent host Vulkan SDK blocking cross-compilation

### DIFF
--- a/cmake/modules/Vulkan.cmake
+++ b/cmake/modules/Vulkan.cmake
@@ -27,10 +27,10 @@ tvm_option(USE_VULKAN_VALIDATION "Enable Vulkan API validation layers" OFF
   IF USE_VULKAN)
 
 if(USE_VULKAN)
-  include_directories(SYSTEM ${Vulkan_INCLUDE_DIRS})
   if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Cannot find Vulkan, USE_VULKAN=" ${USE_VULKAN})
   endif()
+  include_directories(SYSTEM ${Vulkan_INCLUDE_DIRS})
   message(STATUS "Build with Vulkan support")
   file(GLOB RUNTIME_VULKAN_SRCS src/runtime/vulkan/vulkan.cc)
   file(GLOB COMPILER_VULKAN_SRCS src/target/spirv/*.cc)

--- a/cmake/modules/Vulkan.cmake
+++ b/cmake/modules/Vulkan.cmake
@@ -26,13 +26,8 @@ IF USE_VULKAN)
 tvm_option(USE_VULKAN_VALIDATION "Enable Vulkan API validation layers" OFF
   IF USE_VULKAN)
 
-if(Vulkan_FOUND)
-  # always set the includedir
-  # avoid global retrigger of cmake
-  include_directories(SYSTEM ${Vulkan_INCLUDE_DIRS})
-endif(Vulkan_FOUND)
-
 if(USE_VULKAN)
+  include_directories(SYSTEM ${Vulkan_INCLUDE_DIRS})
   if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Cannot find Vulkan, USE_VULKAN=" ${USE_VULKAN})
   endif()


### PR DESCRIPTION
The moved code is blocking cross-compilation with NDK. When the host system has Vulkan SDK installed while Vulkan support for cross-compilation is opted out, the current build script still attempts to include those directories that could never be found:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
_glsl_std
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
_libspirv
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
_spirv
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc
   used as include directory in directory C:/Users/PENGUINLIONG/Repositories/tvm/apps/cpp_rpc

CMake Error in CMakeLists.txt:
  Found relative path while evaluating include directories of "tvm_objs":

    "_libspirv-NOTFOUND"


CMake Error in CMakeLists.txt:
  Found relative path while evaluating include directories of
  "tvm_runtime_objs":

    "_libspirv-NOTFOUND"



CMake Error in apps/cpp_rpc/CMakeLists.txt:
  Found relative path while evaluating include directories of "tvm_rpc":

    "_libspirv-NOTFOUND"



-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
ninja: error: loading 'build.ninja': ϵͳҲ
```
