### PR TITLE
Add logging to diagnose flaky ci-qemu test

### DIFF
--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -18,6 +18,7 @@
 
 set -e
 set -u
+set -x  # NOTE(areusch): Adding to diagnose flaky timeouts
 
 source tests/scripts/setup-pytest-env.sh
 


### PR DESCRIPTION
Seems like occasionally ci-qemu gets stuck until 4 hour timeout. Adding logging statements to figure out which command is hanging.