### PR TITLE
[Runtime][Object] Add Object::unique()

### DIFF
--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -185,7 +185,11 @@ class TVM_DLL Object {
    */
   template <typename TargetType>
   inline bool IsInstance() const;
-
+  /*!
+   * \return Weather the cell has only one reference
+   * \note We use stl style naming to be consistent with known API in shared_ptr.
+   */
+  inline bool unique() const;
   /*!
    * \brief Get the type key of the corresponding index from runtime.
    * \param tindex The type index.
@@ -830,6 +834,8 @@ inline bool Object::IsInstance() const {
     return false;
   }
 }
+
+inline bool Object::unique() const { return use_count() == 1; }
 
 template <typename ObjectType>
 inline const ObjectType* ObjectRef::as() const {


### PR DESCRIPTION
This PR exposes an API to check if an object is uniquely referenced. It is a prerequisite to the M1b stage on our TensorIR upstreaming #7527.