### PR TITLE
Added MaybeAlign to CreateAtomicRMW calls to fix build for LLVM13

### DIFF
--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -190,14 +190,26 @@ class CodeGenAMDGPU : public CodeGenLLVM {
       llvm::Value* v1 = MakeValue(op->args[1]);
       if (op->args[1]->dtype.is_float()) {
 #if TVM_LLVM_VERSION >= 90
+#if TVM_LLVM_VERSION >= 130
+        return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
+                                         llvm::MaybeAlign::MaybeAlign(),
+                                         llvm::AtomicOrdering::Monotonic);
+#else
         return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
                                          llvm::AtomicOrdering::Monotonic);
+#endif
 #else
         LOG(FATAL) << "Floating point atomic requires LLVM 9 or newer";
 #endif
       }
+#if TVM_LLVM_VERSION >= 130
+      return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,
+                                       llvm::MaybeAlign::MaybeAlign(),
+                                       llvm::AtomicOrdering::Monotonic);
+#else
       return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,
                                        llvm::AtomicOrdering::Monotonic);
+#endif
     }
     return CodeGenLLVM::CreateIntrinsic(op);
   }

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -238,14 +238,26 @@ llvm::Value* CodeGenNVPTX::CreateIntrinsic(const CallNode* op) {
     llvm::Value* v1 = MakeValue(op->args[1]);
     if (op->args[1]->dtype.is_float()) {
 #if TVM_LLVM_VERSION >= 90
+#if TVM_LLVM_VERSION >= 130
+      return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
+                                       llvm::MaybeAlign::MaybeAlign(),
+                                       llvm::AtomicOrdering::Monotonic);
+#else
       return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
                                        llvm::AtomicOrdering::Monotonic);
+#endif
 #else
       LOG(FATAL) << "Floating point atomic requires LLVM 9 or newer";
 #endif
     }
+#if TVM_LLVM_VERSION >= 130
+    return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,
+                                     llvm::MaybeAlign::MaybeAlign(),
+                                     llvm::AtomicOrdering::Monotonic);
+#else
     return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,
                                      llvm::AtomicOrdering::Monotonic);
+#endif
   }
   return CodeGenLLVM::CreateIntrinsic(op);
 }


### PR DESCRIPTION
See issue https://github.com/apache/tvm/issues/7576 and PR https://github.com/apache/tvm/pull/7578
Fixes build for me on Win10.

@masahi
(Interesting, it is now running on Jenkins!)