### PR TITLE
[SPIR-V] Fix pushconstants offset calculation for 32 bit values

### DIFF
--- a/src/target/spirv/ir_builder.cc
+++ b/src/target/spirv/ir_builder.cc
@@ -222,7 +222,14 @@ Value IRBuilder::DeclarePushConstant(const std::vector<SType>& value_types) {
     DataType t = value_types[i].type;
     uint32_t nbits = t.bits() * t.lanes();
     ICHECK_EQ(nbits % 8, 0);
-    offset += nbits / 8;
+    uint32_t bytes = (nbits / 8);
+    if (t.bits() == 32) {
+      // In our Vulkan runtime, each push constant always occupies 64 bit.
+      offset += bytes * 2;
+    } else {
+      ICHECK_EQ(t.bits(), 64);
+      offset += bytes;
+    }
   }
   // Decorate push constants as UBO
   this->Decorate(spv::OpDecorate, struct_type, spv::DecorationBlock);

--- a/tests/python/unittest/test_target_codegen_spirv.py
+++ b/tests/python/unittest/test_target_codegen_spirv.py
@@ -72,24 +72,6 @@ def test_bool_load():
     tvm.testing.assert_allclose(b.asnumpy(), ref)
 
 
-def check_result(
-    args,
-    mod,
-    expected,
-    flatten=False,
-    assert_shape=False,
-    only_vm=False,
-    targets=None,
-):
-    for kind in ["debug", "vm"]:
-        targets = targets or tvm.testing.enabled_targets()
-        for tgt, ctx in targets:
-            ex = relay.create_executor(kind, mod=mod, ctx=ctx, target=tgt)
-            result = ex.evaluate()(*args)
-            for r, e in zip(result, expected):
-                tvm.testing.assert_allclose(r, e, atol=2e-6)
-
-
 def test_pushconstants():
     # This will have three 32 bit pushconstants
     dtype = "float32"

--- a/tests/python/unittest/test_target_codegen_spirv.py
+++ b/tests/python/unittest/test_target_codegen_spirv.py
@@ -73,10 +73,13 @@ def test_bool_load():
 
 
 def test_pushconstants():
+    if not tvm.testing.device_enabled("vulkan"):
+        return
+
     def check_mod(mod, x_np, res_np):
-        tgt = "vulkan"
-        ctx = tvm.context("vulkan", 0)
-        ex = relay.create_executor("vm", mod=mod, ctx=ctx, target=tgt)
+        target = "vulkan"
+        ctx = tvm.context(target, 0)
+        ex = relay.create_executor("vm", mod=mod, ctx=ctx, target=target)
         res = ex.evaluate()(x_np).asnumpy()
         tvm.testing.assert_allclose(res, res_np, atol=1e-5)
 
@@ -92,7 +95,7 @@ def test_pushconstants():
 
     # One 64 bit and one 32 bit constants
     dtype = "int32"
-    x = relay.var("x", shape=(5,), dtype=dtype)
+    x = relay.var("x", shape=(relay.Any(),), dtype=dtype)
     mod = tvm.IRModule()
     mod["main"] = relay.Function([x], relay.cumsum(x))
     x_np = np.random.randint(0, high=10, size=(10,)).astype(dtype)

--- a/tests/python/unittest/test_target_codegen_spirv.py
+++ b/tests/python/unittest/test_target_codegen_spirv.py
@@ -97,9 +97,9 @@ def test_pushconstants():
     dtype = "int32"
     x = relay.var("x", shape=(relay.Any(),), dtype=dtype)
     mod = tvm.IRModule()
-    mod["main"] = relay.Function([x], relay.cumsum(x))
+    mod["main"] = relay.Function([x], relay.argsort(x))
     x_np = np.random.randint(0, high=10, size=(10,)).astype(dtype)
-    res_np = np.cumsum(x_np)
+    res_np = np.argsort(x_np)
 
     check_mod(mod, x_np, res_np)
 


### PR DESCRIPTION
I found a cool bug from https://github.com/apache/tvm/pull/7572: It only works when pushconstants are one or more 64 bit values. https://github.com/apache/tvm/pull/7572 didn't change the codegen but load offset needs to be adjusted for 32 bit values (since all pushconstants occupy 64 bit after https://github.com/apache/tvm/pull/7572). In particular, dynamic shape workload requires passing the shape size as 32 bit pushconstants, so currently VK/SPIR-V backend is completely broken for dynamic shape. 

I updated load offset calculation and now dynamic shape started working with VK/SPIR-V.  Dynamic shape sort, which involves mixed 32 and 64 bit pushconstants, is also working using a patch from https://github.com/apache/tvm/pull/7607. But one test I added, dynamic cumsum, is still not working for some reason. 

cc @tqchen @vinx13 I'm not sure if Metal backend has this problem.