### PR TITLE
Fix TVM compile without LLVM

### DIFF
--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -119,7 +119,7 @@ runtime::Module CreateMetadataModule(
 #ifdef TVM_LLVM_VERSION
       crt_exportable_modules.push_back(target_module);
       target_module = CreateLLVMCrtMetadataModule(crt_exportable_modules, target);
-#else  // TVM_LLVM_VERSION
+#else   // TVM_LLVM_VERSION
       LOG(FATAL) << "TVM was not built with LLVM enabled.";
 #endif  // TVM_LLVM_VERSION
     }

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -116,8 +116,12 @@ runtime::Module CreateMetadataModule(
       crt_exportable_modules.push_back(target_module);
       target_module = CreateCSourceCrtMetadataModule(crt_exportable_modules, target);
     } else if (target->kind->name == "llvm") {
+#ifdef TVM_LLVM_VERSION
       crt_exportable_modules.push_back(target_module);
       target_module = CreateLLVMCrtMetadataModule(crt_exportable_modules, target);
+#else  // TVM_LLVM_VERSION
+      LOG(FATAL) << "TVM was not built with LLVM enabled.";
+#endif  // TVM_LLVM_VERSION
     }
   } else {
     if (!non_crt_exportable_modules.empty()) {


### PR DESCRIPTION
#7398 introduced an compilation error when using `USE_LLVM=OFF`. Fix by adding preprocessor if guard.

```
tvm/src/target/metadata_module.cc:120:23: error: ‘CreateLLVMCrtMetadataModule’ was not declared in this scope                                                   
       target_module = CreateLLVMCrtMetadataModule(crt_exportable_modules, target); 
``` 