### PR TITLE
[CUDA][TOPI] Fix CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES with NMS for certain GPUs

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -216,6 +216,47 @@ def callback_libdevice_path(arch):
         return ""
 
 
+def get_target_compute_version(target=None):
+    """Utility function to get compute capability of compilation target.
+
+    Looks for the arch in three different places, first in the target attributes, then the global
+    scope, and finally the GPU device (if it exists).
+
+    Parameters
+    ----------
+    target : tvm.target.Target, optional
+        The compilation target
+
+    Returns
+    -------
+    compute_version : str
+        compute capability of a GPU (e.g. "8.0")
+    """
+    # 1. Target
+    if target:
+        if "arch" in target.attrs:
+            compute_version = target.attrs["arch"]
+            major, minor = compute_version.split("_")[1]
+            return major + "." + minor
+
+    # 2. Global scope
+    from tvm.autotvm.env import AutotvmGlobalScope
+
+    if AutotvmGlobalScope.current.cuda_target_arch:
+        major, minor = AutotvmGlobalScope.current.cuda_target_arch.split("_")[1]
+        return major + "." + minor
+
+    # 3. GPU
+    if tvm.gpu(0).exist:
+        return tvm.gpu(0).compute_version
+
+    warnings.warn(
+        "No CUDA architecture was specified or GPU detected."
+        "Try specifying it by adding '-arch=sm_xx' to your target."
+    )
+    return None
+
+
 def parse_compute_version(compute_version):
     """Parse compute capability string to divide major and minor version
 

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -240,7 +240,7 @@ def get_target_compute_version(target=None):
             return major + "." + minor
 
     # 2. Global scope
-    from tvm.autotvm.env import AutotvmGlobalScope
+    from tvm.autotvm.env import AutotvmGlobalScope  # pylint: disable=import-outside-toplevel
 
     if AutotvmGlobalScope.current.cuda_target_arch:
         major, minor = AutotvmGlobalScope.current.cuda_target_arch.split("_")[1]

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -19,6 +19,7 @@
 """Non-maximum suppression operator"""
 import tvm
 from tvm import te
+from tvm.contrib import nvcc
 from tvm.contrib.thrust import can_use_thrust, can_use_rocthrust
 from tvm.tir import if_then_else
 from .sort import argsort, argsort_thrust
@@ -493,12 +494,11 @@ def nms_ir(
         nthread_by = batch_size
         nthread_tx = max_threads
 
-        # Some cuda architectures have smaller limit of 32K for cudaDevAttrMaxRegistersPerBlock, vs 64K for most GPUs.
-        # Since this kernel uses many registers (around 35), the limit will be exceeded with 1024 threads.
+        # Some cuda architectures have smaller limit of 32K for cudaDevAttrMaxRegistersPerBlock
+        # vs 64K for most GPUs. Since this kernel uses many registers (around 35), the limit will
+        # be exceeded with 1024 threads.
         target = tvm.target.Target.current(allow_none=False)
         if target.kind.name == "cuda":
-            from tvm.contrib import nvcc
-
             if nvcc.get_target_compute_version(target) in ["3.2", "5.3", "6.2"]:
                 nthread_tx = 512
 

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -53,6 +53,29 @@ def atomic_add(x, y):
     return tvm.tir.call_intrin(y.dtype, "tir.atomic_add", x, y)
 
 
+def get_cuda_arch(target):
+    target = tvm.target.Target.current(allow_none=False)
+    if target.kind.name != "cuda":
+        return None
+    # 1. Target -arch=sm_xx
+    if "arch" in target.attrs:
+        compute_version = target.attrs["arch"]
+        major, minor = compute_version.split("_")[1]
+        compute_version = major + "." + minor
+
+    # 2. Global scope
+    from tvm.autotvm.env import AutotvmGlobalScope
+
+    if AutotvmGlobalScope.current.cuda_target_arch:
+        arch = AutotvmGlobalScope.current.cuda_target_arch.split("_")[1]
+        return arch[0] + "." + arch[1]
+
+    # 3. GPU
+    if tvm.gpu(0).exist:
+        return tvm.gpu(0).compute_version
+    return None
+
+
 def get_valid_boxes_ir(data, valid_boxes, score_threshold, id_index, score_index):
     """Low level IR to identify bounding boxes given a score threshold.
 
@@ -491,7 +514,9 @@ def nms_ir(
 
     with ib.new_scope():
         nthread_by = batch_size
-        nthread_tx = max_threads
+        # Some cuda architectures have smaller limit of 32K for cudaDevAttrMaxRegistersPerBlock, vs 64K for most GPUs.
+        # Since this kernel uses many registers (around 35), the limit will be exceeded with 1024 threads.
+        nthread_tx = 512 if get_cuda_arch() in ["3.2", "5.3", "6.2"] else max_threads
 
         by = te.thread_axis("blockIdx.y")
         tx = te.thread_axis("threadIdx.x")


### PR DESCRIPTION
Recent changes to NMS cuda implementation introduced this error for one of the kernels when running on certain GPUs such as Jetson TX1, TX2, and Nano.

```
Check failed: ret == 0 (-1 vs. 0) : TVMError: CUDALaunch Error: CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES                                                                                            
 grid=(1,1,1),  block=(1024,1,1)                                                                                                                                                                
// func_name=fused_vision_non_max_suppression_4_kernel2
```

I found that those particular GPUs have a limit of 32K for `Maximum number of 32-bit registers per thread block` while most other GPUs have a limit of 64K. I found that the current code is using around 35 registers, which means with 1024 threads per block it will exceed the 32K limit.

```
ptxas info    : 0 bytes gmem
ptxas info    : Compiling entry function 'fused_vision_non_max_suppression_4_kernel2' for 'sm_62'
ptxas info    : Function properties for fused_vision_non_max_suppression_4_kernel2
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 35 registers, 376 bytes cmem[0], 12 bytes cmem[2]
```

## Proposed solution

This PR will instead use 512 threads per block for this kernel so that the register limit is not exceeded.
Alternatively, we could have modified the code to use less registers. However, I don't know how to do that without impacting the performance. If anyone has any ideas, please let me know.

Also, would it make sense to move `get_cuda_arch()` to a different file so that it can be used as a helper function in other parts of TVM codebase? Since the cuda architecture can be specified in three different places, it seems that it could be useful. Please let me know your thoughts.
