### PR TITLE
[Ansor] Add HW param for Vulkan tuning

### DIFF
--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -107,10 +107,24 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
       LOG(FATAL) << "No default hardware parameters for opencl target device: " << target_device;
     }
   } else if (device_type == kDLVulkan) {
-    int max_shared_memory_per_block = 48000;
-    int max_local_memory_per_block = INT32_MAX;  // skip the check on local memory
-    int max_threads_per_block = 256;
-    int warp_size = 64;
+    auto ctx = TVMContext{static_cast<DLDeviceType>(device_type), 0};
+    auto device_name = "device_api.vulkan";
+    auto func = tvm::runtime::Registry::Get(device_name);
+    ICHECK(func != nullptr) << "Cannot find Vulkan device_api in registry";
+    auto device_api = static_cast<tvm::runtime::DeviceAPI*>(((*func)()).operator void*());
+
+    tvm::runtime::TVMRetValue ret;
+    device_api->GetAttr(ctx, tvm::runtime::DeviceAttrKind::kMaxSharedMemoryPerBlock, &ret);
+    int max_shared_memory_per_block = ret;
+
+    int max_local_memory_per_block = INT32_MAX;
+
+    device_api->GetAttr(ctx, tvm::runtime::DeviceAttrKind::kMaxThreadsPerBlock, &ret);
+    int max_threads_per_block = ret;
+
+    device_api->GetAttr(ctx, tvm::runtime::DeviceAttrKind::kWarpSize, &ret);
+    int warp_size = ret;
+
     int max_vthread_extent = warp_size / 4;
     return HardwareParams(-1, 16, 64, max_shared_memory_per_block, max_local_memory_per_block,
                           max_threads_per_block, max_vthread_extent, warp_size);

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -106,6 +106,14 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
       auto target_device = target->GetAttr<String>("device", "");
       LOG(FATAL) << "No default hardware parameters for opencl target device: " << target_device;
     }
+  } else if (device_type == kDLVulkan) {
+    int max_shared_memory_per_block = 48000;
+    int max_local_memory_per_block = INT32_MAX;  // skip the check on local memory
+    int max_threads_per_block = 256;
+    int warp_size = 64;
+    int max_vthread_extent = warp_size / 4;
+    return HardwareParams(-1, 16, 64, max_shared_memory_per_block, max_local_memory_per_block,
+                          max_threads_per_block, max_vthread_extent, warp_size);
   } else {
     LOG(FATAL) << "No default hardware parameters for target: " << target;
   }

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -125,7 +125,8 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
     device_api->GetAttr(ctx, tvm::runtime::DeviceAttrKind::kWarpSize, &ret);
     int warp_size = ret;
 
-    int max_vthread_extent = warp_size / 4;
+    int max_vthread_extent = std::max(1, warp_size / 4);
+
     return HardwareParams(-1, 16, 64, max_shared_memory_per_block, max_local_memory_per_block,
                           max_threads_per_block, max_vthread_extent, warp_size);
   } else {


### PR DESCRIPTION
This introduces support for VK backend in ansor. Also added a proper way to query the warp size using VK api, since it can be different for each platform (AMD uses 64 while others 32 etc).

please review @comaniac @FrozenGene @merrymercy @tmoreau89 