### PR TITLE
[MIPS] Fix CALL16 reloc at 0x290 not against global symbol

### DIFF
--- a/src/tir/transforms/make_packed_api.cc
+++ b/src/tir/transforms/make_packed_api.cc
@@ -229,7 +229,7 @@ PrimFunc MakePackedAPI(PrimFunc&& func, int num_unpacked_args) {
   //
   // For example, for auto broadcasting, checks are required to guarantee that
   // either 0 or the original stride will be correctly used. Checks here have
-  // to use the args that may have no let bining yet. Therefore, hoisting let
+  // to use the args that may have no let binding yet. Therefore, hoisting let
   // binding for args before buffer declaration is needed.
   for (const auto& kv : var_def) {
     binder.Bind(kv.second, kv.first, kv.first->name_hint, true);


### PR DESCRIPTION
When I compiled test model for MIPS platform I faced the following error during export_library (linkage):
`mips-linux-gnu/bin/ld: /tmp/tmptd3u21a0/lib.o: CALL16 reloc at 0x290 not against global symbol`
 
Issue details:
TVM generated model has non-global `$xxx_compute_` functions. For example: `$fused_nn_contrib_conv2d_NCHWc_add_compute_`, `$fused_nn_global_avg_pool2d_compute_`, etc.

These functions are not marked as `.globl` in model assembly.
At the same time the functions are not marked as static too (`llvm::Function::Create` uses `PrivateLinkage` but not `InternalLinkage`).

It confuses MIPS codegen and in the assembly it calls `$xxx_compute_` functions using the approach which is used for global prototype functions call (`call16` approach).

MIPS has different approaches to call static and global prototype functions:
- global function prototypes called using `call16(my_fn) + .reloc R_MIPS_JALR + jalr`
- static functions called using simple `jal my_fn`
 
The issue is not visible on x86 / ARM because their assembly uses “call my_fn” / “bl my_fn” to call functions/subroutines regardless of their type.

This PR solves the issue by using InternalLinkage when `$xxx_compute_` functions are created. It makes them static (STB_LOCAL in the case of ELF).
[LLVM Linkage Types](https://llvm.org/docs/LangRef.html#linkage-types)
