### PR TITLE
[Relay][bugfix] Do not allow an empty match block to type check

### DIFF
--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -314,7 +314,6 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
       auto err = Diagnostic::Error(op->span);
       err << "match expression has no clauses and cannot satisfy a type";
       this->EmitFatal(err);
-      return Type();
     }
 
     Type dtype = GetType(op->data);

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -310,6 +310,13 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
   void VisitPattern_(const PatternWildcardNode* wc, const Type& t) {}
 
   Type VisitExpr_(const MatchNode* op) final {
+    if (op->clauses.size() == 0) {
+      auto err = Diagnostic::Error(op->span);
+      err << "match expression has no clauses and cannot satisfy a type";
+      this->EmitFatal(err);
+      return Type();
+    }
+
     Type dtype = GetType(op->data);
     for (const auto& c : op->clauses) {
       VisitPattern(c->lhs, dtype);

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -416,6 +416,21 @@ def test_dynamic_function():
     assert mod["main"].params[0].checked_type == s_tt
 
 
+@pytest.mark.xfail(raises=tvm.error.TVMError)
+def test_empty_match():
+    # If `complete` is true, the completeness checker will lead to a failure;
+    # however, if the match is incomplete, it will be an error at run time
+    # and should not be allowed to pass the type checker
+    func = relay.Function(
+        [], relay.Match(relay.const(1), [], complete=False), ret_type=relay.scalar_type("float32")
+    )
+
+    mod = tvm.IRModule()
+    mod["main"] = func
+    # the type check should fail
+    mod = transform.InferType()(mod)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -416,7 +416,6 @@ def test_dynamic_function():
     assert mod["main"].params[0].checked_type == s_tt
 
 
-@pytest.mark.xfail(raises=tvm.error.TVMError)
 def test_empty_match():
     # If `complete` is true, the completeness checker will lead to a failure;
     # however, if the match is incomplete, it will be an error at run time
@@ -425,10 +424,11 @@ def test_empty_match():
         [], relay.Match(relay.const(1), [], complete=False), ret_type=relay.scalar_type("float32")
     )
 
-    mod = tvm.IRModule()
-    mod["main"] = func
-    # the type check should fail
-    mod = transform.InferType()(mod)
+    with pytest.raises(tvm.error.TVMError):
+        mod = tvm.IRModule()
+        mod["main"] = func
+        # the type check should fail
+        mod = transform.InferType()(mod)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the type checker returns an `IncompleteTypeNode` for a match expression that has no clauses. This means the incomplete type node can be unified with another type and be valid even though a match expression with no clauses has no defined semantics and shouldn't be permitted. I think it would be sensible for the type checker to disallow match expressions with no clauses.

Incidentally, the match completeness checker would normally prevent an empty match expression, but they can still pass the type checker if the `complete` flag is set to off. Hence a function like this would type check even though it makes no sense: `def @main() ->  fn () ->   fn (  ()) ->   bool {   match? 1 {}}`

This PR checks for empty match expressions and produces a type checking error. Bug discovered by fuzzing thanks to @Flandini

Please review @jroesch @MarisaKirisame 

(Aside: Maybe we should define semantics for missing an incomplete match -- I believe we had an idea for a fatal error expression before, so maybe that could be a better fix.)