### PR TITLE
[BYOC][ACL] ACL migrated to v21.02

### DIFF
--- a/docker/install/ubuntu_install_arm_compute_lib.sh
+++ b/docker/install/ubuntu_install_arm_compute_lib.sh
@@ -58,8 +58,8 @@ git clone "$repo_url" "$repo_dir"
 
 cd "$repo_dir"
 
-# pin version to v20.11
-git checkout 49b8f90
+# pin version to v21.02
+git checkout "v21.02"
 
 if [ "$architecture_type" != "aarch64" ]; then
   build_type="cross_compile"


### PR DESCRIPTION
This PR switches ACL* version from v20.11 to v21.02

*ACL stands for Compute Library for the Arm® Architecture.