### PR TITLE
[TVMC] Allow options on --target to contain dots.

### DIFF
--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -133,7 +133,7 @@ def tokenize_target(target):
 
     target_pattern = (
         r"(\-{0,2}[\w\-]+\=?"
-        r"(?:[\w\+\-]+(?:,[\w\+\-])*|[\'][\w\+\-,\s]+[\']|[\"][\w\+\-,\s]+[\"])*|,)"
+        r"(?:[\w\+\-\.]+(?:,[\w\+\-\.])*|[\'][\w\+\-,\s\.]+[\']|[\"][\w\+\-,\s\.]+[\"])*|,)"
     )
 
     return re.findall(target_pattern, target)
@@ -223,6 +223,11 @@ def parse_target(target):
                 else:
                     opt = opt[1:] if opt.startswith("-") else opt
                     opt_name, opt_value = opt.split("=", maxsplit=1)
+
+                    # remove quotes from the value: quotes are only parsed if they match,
+                    # so it is safe to assume that if the string starts with quote, it ends
+                    # with quote.
+                    opt_value = opt_value[1:-1] if opt_value[0] in ('"', "'") else opt_value
             except ValueError:
                 raise ValueError(f"Error when parsing '{opt}'")
 

--- a/tests/python/driver/tvmc/test_tvmc_common.py
+++ b/tests/python/driver/tvmc/test_tvmc_common.py
@@ -273,3 +273,24 @@ def test_parse_multiple_target_with_opts():
     assert "myopt" in targets[0]["opts"]
     assert "value" == targets[0]["opts"]["myopt"]
     assert "llvm" == targets[1]["name"]
+
+
+def test_parse_multiple_separators_on_target():
+    targets = tvmc.common.parse_target("foo -option1=+v1.0x,+value,+bar")
+
+    assert len(targets) == 1
+    assert "+v1.0x,+value,+bar" == targets[0]["opts"]["option1"]
+
+
+def test_parse_single_quoted_multiple_separators_on_target():
+    targets = tvmc.common.parse_target("foo -option1='+v1.0x,+value'")
+
+    assert len(targets) == 1
+    assert "+v1.0x,+value" == targets[0]["opts"]["option1"]
+
+
+def test_parse_double_quoted_multiple_separators_on_target():
+    targets = tvmc.common.parse_target('foo -option1="+v1.0x,+value"')
+
+    assert len(targets) == 1
+    assert "+v1.0x,+value" == targets[0]["opts"]["option1"]


### PR DESCRIPTION
Allow options on --target to contain dots. 
 * Allow `tvmc compile --target=***` options to accept dots
 * Adds testing for dot separator in quoted and unquoted values
 * Add an "unquoting" conditional so that quoted and unquoted strings look the same when parsed

cc @u99127 @comaniac @giuseros  for reviews when possible.

