### PR TITLE
[Relay][ONNX][Frontend] Fix issue when group attribute isnt defined in convtranspose.

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -446,7 +446,7 @@ class ConvTranspose(OnnxOpConverter):
         # get number of channels
         channels = infer_channels(inputs[1], True)
         attr["channels"] = channels
-        groups = attr.pop("group")
+        groups = attr.get("group", 1)
         attr["groups"] = groups
         # infer pads for auto_pad
         data = inputs[0]


### PR DESCRIPTION
The convtranspose importer incorrectly was assuming that the group attribute will always be defined. Instead, it is supposed to default to 1 when not provided. This 1-liner handles it properly. I also cleaned up some code duplication in the convtranspose test.