### PR TITLE
[docs] Set USE_LLVM OFF when build VTA on pynq board

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -113,7 +113,7 @@ set(USE_MICRO_STANDALONE_RUNTIME OFF)
 # - OFF: disable llvm, note this will disable CPU codegen
 #        which is needed for most cases
 # - /path/to/llvm-config: enable specific LLVM when multiple llvm-dev is available.
-set(USE_LLVM ON)
+set(USE_LLVM OFF)
 
 #---------------------------------------------
 # Contrib libraries


### PR DESCRIPTION
Refer to this commit : #6944 

The Default value of USE_LLVM flag had been changed

```cmake
set(USE_LLVM OFF)
set(USE_LLVM ON)
```

But the VTA build tutorial didn't follow it , FPGA board don't need compile llvm .

```bash
-- Build VTA runtime with target: pynq
CMake Error at cmake/utils/FindLLVM.cmake:47 (find_package):
  Could not find a package configuration file provided by "LLVM" with any of
  the following names:

    LLVMConfig.cmake
    llvm-config.cmake

  Add the installation prefix of "LLVM" to CMAKE_PREFIX_PATH or set
  "LLVM_DIR" to a directory containing one of the above files.  If "LLVM"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  cmake/modules/LLVM.cmake:31 (find_llvm)
  CMakeLists.txt:345 (include)

```
Please cc, @tqchen @areusch @tmoreau89 