### PR TITLE
[TFLite] Fixed strided_slice size after nms into TFLite frontend

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -3093,7 +3093,7 @@ class OperatorConverter(object):
         valid_count = ret[0]
         # keep only the top 'max_detections' rows
         ret = _op.strided_slice(
-            ret[1], [0, 0, 0], [batch_size, custom_options["max_detections"], anchor_boxes]
+            ret[1], [0, 0, 0], [batch_size, custom_options["max_detections"], 6]
         )
         # the output needs some reshaping to match tflite
         ret = _op.split(ret, 6, axis=2)


### PR DESCRIPTION
Fixed the strided_slice size after [get_valid_counts](https://tvm.apache.org/docs/api/python/relay/vision.html#tvm.relay.vision.get_valid_counts).
It returns the data.1 shaped [batch_size, num_anchors, 6].