### PR TITLE
[TVMC] Fix to check whether a path passed to --target is strictly a file

### DIFF
--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -270,7 +270,7 @@ def target_from_cli(target):
     """
     extra_targets = []
 
-    if os.path.exists(target):
+    if os.path.isfile(target):
         with open(target) as target_file:
             logger.debug("target input is a path: %s", target)
             target = "".join(target_file.readlines())


### PR DESCRIPTION
Fix to check whether a path passed to --target is strictly a file:
* When we use file with `--target`, the validation in place was only checking whether it was a valid path. For the case in which the path is a directory, it causes a crash when tvmc then tries to open the path.
* This fix moved the check to be strictly for files, not only a valid path

This was reported in #6302.

cc @mbaret @comaniac 