### PR TITLE
[Runtime] Fix GraphRuntime.load_params to allow passing parameters that are not an input

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -200,7 +200,9 @@ void GraphRuntime::LoadParams(const std::string& param_blob) {
 void GraphRuntime::LoadParams(dmlc::Stream* strm) {
   Map<String, NDArray> params = ::tvm::runtime::LoadParams(strm);
   for (auto& p : params) {
-    uint32_t eid = this->entry_id(input_nodes_[GetInputIndex(p.first)], 0);
+    int in_idx = GetInputIndex(p.first);
+    if (in_idx < 0) continue;
+    uint32_t eid = this->entry_id(input_nodes_[in_idx], 0);
     data_entry_[eid].CopyFrom(p.second);
   }
 }

--- a/tests/python/unittest/test_runtime_graph.py
+++ b/tests/python/unittest/test_runtime_graph.py
@@ -20,6 +20,7 @@ from tvm import te, runtime
 import numpy as np
 import json
 from tvm import rpc
+from tvm import relay
 from tvm.contrib import utils, graph_runtime
 
 
@@ -82,8 +83,6 @@ def test_graph_simple():
         np.testing.assert_equal(out.asnumpy(), a + 1)
 
     def check_sharing():
-        from tvm import relay
-
         x = relay.var("x", shape=(1, 10))
         y = relay.var("y", shape=(1, 10))
         z = relay.add(x, y)
@@ -120,5 +119,26 @@ def test_graph_simple():
     check_sharing()
 
 
+def test_load_unexpected_params():
+    # Test whether graph_runtime.load_params works if parameters
+    # are provided that are not an expected input.
+    mod = tvm.IRModule()
+    params = {}
+    x = relay.var("x", shape=(1, 10))
+    y = relay.var("y", shape=(1, 10))
+    z = relay.add(x, y)
+    mod["main"] = relay.Function([x, y], z)
+
+    graph_module = relay.build(mod, target="llvm", params=params)
+    rt_mod = tvm.contrib.graph_runtime.create(
+        graph_module.get_json(), graph_module.get_lib(), tvm.cpu(0)
+    )
+
+    new_params = graph_module.get_params()
+    new_params.update({"y_unknown": np.ones((1,)).astype("float32")})
+    rt_mod.load_params(runtime.save_param_dict(new_params))
+
+
 if __name__ == "__main__":
     test_graph_simple()
+    test_load_unexpected_params()


### PR DESCRIPTION
Fix for `TVMArrayCopyFromTo` error that happens when parameters that are not expected inputs are loaded using GraphRuntime::LoadParams. See the added test cases for a BYOC flow example that exposes this issue. @tkonolige @junrushao1994 @areusch 


```
tvm._ffi.base.TVMError: Traceback (most recent call last):
E             [bt] (8) /workspace/build/libtvm.so(tvm::runtime::PackedFunc::CallPacked(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x30) [0x7f018b8c7c46]
E             [bt] (7) /workspace/build/libtvm.so(std::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x5a) [0x7f018b75c66c]
E             [bt] (6) /workspace/build/libtvm.so(+0x2d38962) [0x7f018ca30962]
E             [bt] (5) /workspace/build/libtvm.so(+0x2d35f66) [0x7f018ca2df66]
E             [bt] (4) /workspace/build/libtvm.so(tvm::runtime::GraphRuntime::LoadParams(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0x46) [0x7f018ca2a742]
E             [bt] (3) /workspace/build/libtvm.so(tvm::runtime::GraphRuntime::LoadParams(dmlc::Stream*)+0x157) [0x7f018ca2a8dd]
E             [bt] (2) /workspace/build/libtvm.so(tvm::runtime::NDArray::CopyFrom(tvm::runtime::NDArray const&)+0x158) [0x7f018ca32b7c]
E             [bt] (1) /workspace/build/libtvm.so(tvm::runtime::NDArray::CopyFromTo(DLTensor const*, DLTensor*, void*)+0x120) [0x7f018c9b1876]
E             [bt] (0) /workspace/build/libtvm.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x4e) [0x7f018b6cc6fa]
E             File "/workspace/src/runtime/ndarray.cc", line 230
E           TVMError: 
E           ---------------------------------------------------------------
E           An internal invariant was violated during the execution of TVM.
E           Please read TVM's error reporting guidelines.
E           More details can be found here: https://discuss.tvm.ai/t/error-reporting/7793.
E           ---------------------------------------------------------------
E           
E             Check failed: from_size == to_size (4 vs. 40) : TVMArrayCopyFromTo: The size must exactly match

```
