### PR TITLE
Fix relay.testing.darknet convert_image

### DIFF
--- a/python/tvm/relay/testing/darknet.py
+++ b/python/tvm/relay/testing/darknet.py
@@ -31,7 +31,7 @@ from cffi import FFI
 def convert_image(image):
     """Convert the image with numpy."""
     imagex = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    imagex = np.array(image)
+    imagex = np.array(imagex)
     imagex = imagex.transpose((2, 0, 1))
     imagex = np.divide(imagex, 255.0)
     imagex = np.flip(imagex, 0)


### PR DESCRIPTION
Fix `relay.testing.darknet` `convert_image()`

Looks like the bug was introduced here https://github.com/apache/tvm/pull/4883

@vizero1 