### PR TITLE
[TOPI][SPIRV] Cast to float32 not float64 before log2 in sort/scan

### DIFF
--- a/python/tvm/topi/cuda/scan.py
+++ b/python/tvm/topi/cuda/scan.py
@@ -23,7 +23,7 @@ from tvm import te
 from tvm.contrib.thrust import can_use_rocthrust, can_use_thrust
 
 from .. import tag
-from ..math import cast
+from ..math import cast, ceil_log2
 from ..transform import expand_dims, reshape, squeeze, transpose
 from ..utils import ceil_div, get_const_int, prod, swap
 from .injective import schedule_injective_from_existing
@@ -103,9 +103,8 @@ def exclusive_scan_ir(data, output, reduction=None, binop=tvm.tir.generic.add, i
 
         # The following algorithm performs parallel exclusive scan
         # Up Sweep of exclusive scan
-        lim = tvm.tir.generic.cast(
-            tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(scan_axis_size, "float64"))), "int64"
-        )
+        lim = ceil_log2(scan_axis_size)
+
         with ib.for_range(0, lim, dtype="int64") as l2_width:
             width = 2 << l2_width
 

--- a/python/tvm/topi/cuda/scan.py
+++ b/python/tvm/topi/cuda/scan.py
@@ -105,7 +105,7 @@ def exclusive_scan_ir(data, output, reduction=None, binop=tvm.tir.generic.add, i
         size_cast_dtype = "float64"
         target = tvm.target.Target.current()
 
-        if "vulkan" in str(target) and isinstance(scan_axis_size, tvm.tir.expr.Var):
+        if "vulkan" in str(target) and not isinstance(scan_axis_size, tvm.tir.expr.IntImm):
             # SPIRV seems to have an issue with float64 intrinsic
             # TODO(masahi): Eliminate this concern by adding TIR level CSE
             msg = """

--- a/python/tvm/topi/cuda/scan.py
+++ b/python/tvm/topi/cuda/scan.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name, too-many-locals, too-many-statements
 "Scan related operators"
 from typing import Callable, Optional, Union
+import logging
 
 import tvm
 from tvm import te
@@ -101,10 +102,24 @@ def exclusive_scan_ir(data, output, reduction=None, binop=tvm.tir.generic.add, i
         nthread_bx = ceil_div(scan_axis_size, max_threads)
         nthread_by = batch_size
 
+        size_cast_dtype = "float64"
+        target = tvm.target.Target.current()
+
+        if "vulkan" in str(target) and isinstance(scan_axis_size, tvm.tir.expr.Var):
+            # SPIRV seems to have an issue with float64 intrinsic
+            # TODO(masahi): Eliminate this concern by adding TIR level CSE
+            msg = """
+            Casting the dynamic input size to float32 before computing log2 in exclusive scan.
+            This could result in a wrong output if the runtime value of the input size is very large.
+            """
+            logging.warning(msg)
+            size_cast_dtype = "float32"
+
         # The following algorithm performs parallel exclusive scan
         # Up Sweep of exclusive scan
         lim = tvm.tir.generic.cast(
-            tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(scan_axis_size, "float32"))), "int64"
+            tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(scan_axis_size, size_cast_dtype))),
+            "int64",
         )
         with ib.for_range(0, lim, dtype="int64") as l2_width:
             width = 2 << l2_width

--- a/python/tvm/topi/cuda/scan.py
+++ b/python/tvm/topi/cuda/scan.py
@@ -104,7 +104,7 @@ def exclusive_scan_ir(data, output, reduction=None, binop=tvm.tir.generic.add, i
         # The following algorithm performs parallel exclusive scan
         # Up Sweep of exclusive scan
         lim = tvm.tir.generic.cast(
-            tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(scan_axis_size, "float64"))), "int64"
+            tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(scan_axis_size, "float32"))), "int64"
         )
         with ib.for_range(0, lim, dtype="int64") as l2_width:
             width = 2 << l2_width

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -23,7 +23,7 @@ from .injective import schedule_injective_from_existing
 from ..transform import strided_slice, transpose
 from .. import tag
 from ..utils import ceil_div, swap
-from ..math import cast
+from ..math import cast, ceil_log2
 
 
 def _schedule_sort(outs):
@@ -238,9 +238,7 @@ def _sort_common(
         return out
 
     # Sort the lower levels of the merge using odd-even sort, it's fast for small inputs
-    lower_lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(block_size, "float64"))), "int64"
-    )
+    lower_lim = ceil_log2(block_size)
 
     _odd_even_sort(
         ib,
@@ -254,9 +252,7 @@ def _sort_common(
         values_swap,
     )
 
-    upper_lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float64"))), "int64"
-    )
+    upper_lim = ceil_log2(size)
 
     def get_merge_begin(source, base_idx, aCount, bCount, aStart, bStart, diag, step_count):
         first = ib.allocate("int64", (1,), name="first", scope="local")

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -239,7 +239,7 @@ def _sort_common(
 
     # Sort the lower levels of the merge using odd-even sort, it's fast for small inputs
     lower_lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(block_size, "float32"))), "int64"
+        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(block_size, "float64"))), "int64"
     )
 
     _odd_even_sort(
@@ -255,7 +255,7 @@ def _sort_common(
     )
 
     upper_lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float32"))), "int64"
+        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float64"))), "int64"
     )
 
     def get_merge_begin(source, base_idx, aCount, bCount, aStart, bStart, diag, step_count):

--- a/python/tvm/topi/cuda/sort.py
+++ b/python/tvm/topi/cuda/sort.py
@@ -239,7 +239,7 @@ def _sort_common(
 
     # Sort the lower levels of the merge using odd-even sort, it's fast for small inputs
     lower_lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(block_size, "float64"))), "int64"
+        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(block_size, "float32"))), "int64"
     )
 
     _odd_even_sort(
@@ -255,7 +255,7 @@ def _sort_common(
     )
 
     upper_lim = tvm.tir.generic.cast(
-        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float64"))), "int64"
+        tvm.tir.ceil(tvm.tir.log2(tvm.tir.generic.cast(size, "float32"))), "int64"
     )
 
     def get_merge_begin(source, base_idx, aCount, bCount, aStart, bStart, diag, step_count):

--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -745,7 +745,20 @@ def fast_erf(x):
 
 
 def ceil_log2(x):
-    """TODO"""
+    """Compute integer ceil log2 with a special code path for vulkan
+    SPIR-V does not support log2 on fp64. Instead, we compute integer ceil_log2 via clz
+    intrinsic when the target is vulkan.
+
+    Parameters
+    ----------
+    x : tvm.te.Tensor
+        Input argument.
+
+    Returns
+    -------
+    y : tvm.te.Tensor
+        The result.
+    """
     if not isinstance(x, tvm.tir.PrimExpr):
         x = tvm.tir.const(x)
 
@@ -753,7 +766,6 @@ def ceil_log2(x):
         return tvm.tir.ceil(tvm.tir.log2(x))
 
     if "vulkan" in tvm.target.Target.current().kind.name:
-        # SPIR-V does not support log2 on fp64. Instead, we compute ceil_log2 via clz
         clz = tvm.tir.clz(x)
         bits = int(x.dtype[-2:])
         ceil_log2 = tvm.tir.if_then_else(x & (x - 1) == 0, bits - clz - 1, bits - clz)

--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -768,11 +768,11 @@ def ceil_log2(x):
     if "vulkan" in tvm.target.Target.current().kind.name:
         clz = tvm.tir.clz(x)
         bits = int(x.dtype[-2:])
-        ceil_log2 = tvm.tir.if_then_else(x & (x - 1) == 0, bits - clz - 1, bits - clz)
+        res = tvm.tir.if_then_else(x & (x - 1) == 0, bits - clz - 1, bits - clz)
 
-        if ceil_log2.dtype != x.dtype:
-            return cast(ceil_log2, x.dtype)
+        if res.dtype != x.dtype:
+            return cast(res, x.dtype)
 
-        return ceil_log2
+        return res
 
     return cast(tvm.tir.ceil(tvm.tir.log2(cast(x, "float64"))), x.dtype)

--- a/tests/python/unittest/test_target_codegen_spirv.py
+++ b/tests/python/unittest/test_target_codegen_spirv.py
@@ -104,6 +104,16 @@ def test_pushconstants():
 
     check_mod(mod, x_np, res_np)
 
+    # One 64 bit and one 32 bit constants
+    dtype = "int32"
+    x = relay.var("x", shape=(relay.Any(),), dtype=dtype)
+    mod = tvm.IRModule()
+    mod["main"] = relay.Function([x], relay.cumsum(x))
+    x_np = np.random.randint(0, high=10, size=(10,)).astype(dtype)
+    res_np = np.cumsum(x_np)
+
+    check_mod(mod, x_np, res_np)
+
 
 def test_unique():
     if not tvm.testing.device_enabled("vulkan"):


### PR DESCRIPTION
This fixes TIR scan + dynamic input shape on VK / SPIRV. I debugged this problem by doing scan on 2 elements, so that up/downsweep run only one iteration.

I found that when `scan_axis_size` is dynamic whose runtime value is 2, the value of `lim` is 0 instead of expected 1. Surprisingly this issue was fixed by casting `scan_axis_size` to float32 instead of 64. I realized that generally GPUs (especially low ends) don't have great support for fp64, so I think this is better.

Now dynamic cumsum, argwhere etc are working with VK.

@mbrookhart 