### PR TITLE
Revert "[ONNX][NMS] init the NMS output tensor with 1s and then slice them away after the loop"

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2629,10 +2629,10 @@ class NonMaxSuppression(OnnxOpConverter):
 
         # Call the second loop, rework outputs into correct form
         init_count = _op.const(np.array([0]).astype("int64"), dtype="int64")
-        init_out = _op.const(np.array([1, 1, 1]).reshape([1, 3]).astype("int64"), dtype="int64")
+        init_out = _op.const(np.array([]).reshape([0, 3]).astype("int64"), dtype="int64")
         loop_vals = outer_loop(init_count, B, C, onnx_output, nms_size_output, init_out)
-        loop_out = _expr.TupleGetItem(loop_vals, 5)
-        return _op.strided_slice(loop_out, [1, 0], shape_of(loop_out), [1, 1])
+
+        return _expr.TupleGetItem(loop_vals, 5)
 
 
 # compatible operators that do NOT require any conversion.


### PR DESCRIPTION
Reverts apache/tvm#7666 in favor of #7672 