### PR TITLE
[Torch] Remove unnecessary reshapes for batch_matmul

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1584,7 +1584,6 @@ class PyTorchOpConverter:
             
             if len(b_shape) != 3:
                 b = _op.reshape(inputs_1, [-1, b_shape[-2], b_shape[-1]])
-                need_reshape = True
             else:
                 b = inputs_1
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1594,8 +1594,7 @@ class PyTorchOpConverter:
             output = _op.nn.batch_matmul(a, b)
             # Reshape output to original dimensions.
             if need_reshape:
-                desired_shape = [*a_shape[:-2], a_shape[-2], b_shape[-1]]
-                return _op.reshape(output, desired_shape)
+                return _op.reshape(output, [*a_shape[:-2], a_shape[-2], b_shape[-1]])
             return output
 
         # Otherwise a simple dense op will get the job done.

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1581,7 +1581,7 @@ class PyTorchOpConverter:
                 need_reshape_output = True
             else:
                 a = inputs_0
-            
+
             # Transpose matrix dimensions of b.
             trans_axes = list(range(len(b_shape)))
             trans_axes[-2], trans_axes[-1] = trans_axes[-1], trans_axes[-2]

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -201,7 +201,6 @@ def verify_model(model_name, input_data=[], custom_convert_map={}, rtol=1e-5, at
     input_names = ["input{}".format(idx) for idx, inp in enumerate(baseline_input)]
     input_shapes = list(zip(input_names, [inp.shape for inp in baseline_input]))
     mod, params = relay.frontend.from_pytorch(trace, input_shapes, custom_convert_map)
-    print(relay.transform.InferType()(mod)["main"])
     for arg in mod["main"].params[: len(input_names)]:
         assert arg.name_hint in input_names
     compiled_input = dict(zip(input_names, [inp.clone().cpu().numpy() for inp in baseline_input]))

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -201,6 +201,7 @@ def verify_model(model_name, input_data=[], custom_convert_map={}, rtol=1e-5, at
     input_names = ["input{}".format(idx) for idx, inp in enumerate(baseline_input)]
     input_shapes = list(zip(input_names, [inp.shape for inp in baseline_input]))
     mod, params = relay.frontend.from_pytorch(trace, input_shapes, custom_convert_map)
+    print(relay.transform.InferType()(mod)["main"])
     for arg in mod["main"].params[: len(input_names)]:
         assert arg.name_hint in input_names
     compiled_input = dict(zip(input_names, [inp.clone().cpu().numpy() for inp in baseline_input]))


### PR DESCRIPTION
This PR removes unnecessary reshape ops in the PyTorch frontend when converting to batch_matmul. This should help the performance of NLP models such as BERT.

cc @siju-samuel @masahi 
