### PR TITLE
Default value for graph_runtime Init lookup_linked_param_func

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -66,10 +66,11 @@ void GraphRuntime::Run() {
  * processor.
  * \param ctxs The context of the host and devices where graph nodes will be
  * executed on.
- * \param lookup_linked_param_func Linked parameter lookup function.
+ * \param lookup_linked_param_func Linked parameter lookup function. Default is nullptr.
  */
 void GraphRuntime::Init(const std::string& graph_json, tvm::runtime::Module module,
-                        const std::vector<TVMContext>& ctxs, PackedFunc lookup_linked_param_func) {
+                        const std::vector<TVMContext>& ctxs,
+                        const PackedFunc lookup_linked_param_func) {
   std::istringstream is(graph_json);
   dmlc::JSONReader reader(&is);
   this->Load(&reader);

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -93,11 +93,12 @@ class TVM_DLL GraphRuntime : public ModuleNode {
    *  executed on.
    * \param lookup_linked_param_func If given, a PackedFunc invoked to lookup linked parameters
    *  by storage_id. If not given, linked parameters are looked-up using an internal implementation,
-   *  which is not compatible with RPCModules.
+   *  which is not compatible with RPCModules. Default is nullptr.
    */
 
   void Init(const std::string& graph_json, tvm::runtime::Module module,
-            const std::vector<TVMContext>& ctxs, const PackedFunc lookup_linked_param_func);
+            const std::vector<TVMContext>& ctxs,
+            const PackedFunc lookup_linked_param_func = nullptr);
 
   /*!
    * \brief Get the input index given the name of input.


### PR DESCRIPTION
In previous TVM version GraphRuntime `Init` method had 3 parameters.
- `graph_json` The execution graph
- `module` The module containing the compiled functions
- `ctxs` The context of the host and devices

Now `Init` method has one additional parameter:
- `lookup_linked_param_func` If given, a PackedFunc invoked to lookup

In most of the cases this parameter is set to nullptr.

To keep GraphRuntime API backward compatibility we can make new parameter `lookup_linked_param_func` optional by setting its default value to `nullptr`.