### PR TITLE
[Texture support][Part 4] Add CollectStorageInfo and CollectBufferBinds relay passes for Adreno GPU 

### DIFF
--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file deivce_annotation.cc
+ * \brief
+ *
+ */
+
+#include <tvm/relay/expr.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/transform.h>
+#include <tvm/tir/expr.h>
+#include <tvm/relay/attrs/nn.h>
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace tvm {
+namespace relay {
+
+class StorageInfo {
+ public:
+  static Map<Expr, String> GetStorageMap(const Expr& expr) {
+    StorageInfo storage_info;
+    storage_info.pre_visitor_ = PreDfsOrderVisitor();
+    storage_info.pre_visitor_.Visit(expr);
+    for (auto& it : storage_info.pre_visitor_.storage_scope_) {
+      storage_info.storage_map_.Set(GetRef<Expr>(it.first), String(it.second));
+    }
+    return storage_info.storage_map_;
+  }
+
+ private:
+  class PreDfsOrderVisitor : private ExprVisitor {
+   public:
+    void Visit(const Expr& expr) {
+      if (const auto* fn = expr.as<FunctionNode>()) {
+        this->VisitExpr(fn->body);
+        for (const auto& param : fn->params) {
+          this->VisitExpr(param);
+        }
+      } else {
+        this->VisitExpr(expr);
+      }
+    }
+
+   private:
+    void BackwardPropagateConsumerScope(const ExprNode* expr) {
+      auto consumer_scopes_it = consumer_storage_scopes_.find(expr);
+      if (consumer_scopes_it != consumer_storage_scopes_.end())
+      {
+        bool all_consumers_support_texture = true;
+        for (auto& consumer_scope : consumer_scopes_it->second) {
+          if (consumer_scope != "texture") {
+            all_consumers_support_texture = false;
+          }
+        }
+        if (all_consumers_support_texture)
+        {
+          storage_scope_[expr] = "texture";
+        }
+      }
+    }
+
+    void VisitExpr_(const ConstantNode* cn) final {
+      BackwardPropagateConsumerScope(cn);
+    }
+
+    void VisitExpr_(const CallNode* call) final {
+      // Check the contents of this primitive function
+      if (const auto* fn = call->op.as<FunctionNode>()) {
+        if (fn->HasNonzeroAttr(attr::kPrimitive)) {
+          primitive_supports_texture_ = false;
+          Visit(call->op);
+          if (primitive_supports_texture_)
+          {
+            storage_scope_[call] = "texture";
+            for (auto& arg : call->args) {
+              consumer_storage_scopes_[arg.get()].push_back("texture");
+            }
+          }
+        }
+      }
+
+      if (call->attrs.as<Conv2DAttrs>()) {
+        primitive_supports_texture_ = true;
+      }
+      for (auto& arg : call->args) {
+        Visit(arg);
+      }
+    }
+
+    void VisitExpr_(const VarNode* vn) final {
+      BackwardPropagateConsumerScope(vn);
+    }
+
+    bool primitive_supports_texture_ = false;
+    std::unordered_map<const ExprNode*, std::string> storage_scope_;
+    std::unordered_map<const ExprNode*, std::vector<std::string>> consumer_storage_scopes_;
+    friend StorageInfo;
+  };
+
+  PreDfsOrderVisitor pre_visitor_;
+  Map<Expr, String> storage_map_;
+};
+
+Map<Expr, String> CollectStorageInfo(const Expr& expr) { return StorageInfo::GetStorageMap(expr); }
+
+TVM_REGISTER_GLOBAL("relay.analysis.CollectStorageInfo").set_body_typed(CollectStorageInfo);
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -107,8 +107,11 @@ class StorageInfo {
         }
       }
 
-      if (call->attrs.as<Conv2DAttrs>()) {
-        primitive_supports_texture_ = true;
+      if (auto attrs = call->attrs.as<Conv2DAttrs>()) {
+        if (attrs->data_layout == "NCHW4c" && attrs->kernel_layout == "OIHW4o")
+        {
+          primitive_supports_texture_ = true;
+        }
       }
       for (auto& arg : call->args) {
         Visit(arg);

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -99,23 +99,18 @@ class StorageInfo {
         if (fn->HasNonzeroAttr(attr::kPrimitive)) {
           primitive_supports_texture_ = false;
           Visit(call->op);
-          if (primitive_supports_texture_)
-          {
+          if (primitive_supports_texture_) {
             storage_scope_[call] = "texture";
           }
-          else
-          {
-            storage_scope_[call] = "global";
-          }
           for (auto& arg : call->args) {
-            consumer_storage_scopes_[arg.get()].push_back(storage_scope_[call]);
+            std::string scope = storage_scope_.count(call) ? storage_scope_[call] : "global";
+            consumer_storage_scopes_[arg.get()].push_back(scope);
           }
         }
       }
 
       if (auto attrs = call->attrs.as<Conv2DAttrs>()) {
-        if (attrs->data_layout == "NCHW4c" && attrs->kernel_layout == "OIHW4o")
-        {
+        if (attrs->data_layout == "NCHW4c" && attrs->kernel_layout == "OIHW4o") {
           primitive_supports_texture_ = true;
         }
       }

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -129,7 +129,7 @@ class StorageInfo {
         const ExprNode* producer = kv.first;
         std::string legal_scope = GetConsumerScope(kv.second);
         if (storage_scope_.count(producer)) {
-          if (storage_scope_[producer] != legal_scope) {
+          if (storage_scope_[producer].find(legal_scope) == std::string::npos) {
             storage_scope_[producer] = legal_scope;
           }
         }

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -171,9 +171,15 @@ Array<tir::Buffer> CollectBufferBinds(const Call& call, const Map<Expr, runtime:
   ICHECK_EQ(call->args.size(), primfn->params.size()) << "Call arguments and function parameters do not match";
 
   auto make_buffer = [&storage_map](const Expr& expr, const TensorTypeNode* ttype, const std::string& name, size_t index = 0) {
-    String scope = GetStorageScope(expr, storage_map, index);
+    //String scope = GetStorageScope(expr, storage_map, index);
+    auto storage_info = Downcast<Array<String>>(storage_map[expr][2]);
+    std::string scope = "";
+    if (storage_info.size()) {
+      scope = storage_info[index];
+    }
+
     PrimType storage_type(ttype->dtype);
-    tir::Var var = scope == "texture" ? tir::Var(name, TextureType(storage_type)) : tir::Var(name, PointerType(storage_type));
+    tir::Var var = GetStorageScope(expr, storage_map, index) == "texture" ? tir::Var(name, TextureType(storage_type)) : tir::Var(name, PointerType(storage_type));
     return tir::Buffer(var, ttype->dtype, ttype->shape, Array<PrimExpr>{}, Integer(0), name, scope, -1, 0, tir::BufferType::kDefault);
   };
 

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -65,21 +65,21 @@ class StorageInfo {
     }
 
    private:
+    std::string GetConsumerScope(const std::vector<std::string>& consumer_scopes) const {
+      std::string ref_scope = consumer_scopes.front();
+      for (auto& consumer_scope : consumer_scopes) {
+        if (consumer_scope != ref_scope) {
+          return "global";
+        }
+      }
+      return ref_scope;
+    }
+
     void BackwardPropagateConsumerScope(const ExprNode* expr) {
       auto consumer_scopes_it = consumer_storage_scopes_.find(expr);
       if (consumer_scopes_it != consumer_storage_scopes_.end())
       {
-        bool all_consumers_support_texture = true;
-        for (auto& consumer_scope : consumer_scopes_it->second) {
-          if (consumer_scope != "texture") {
-            all_consumers_support_texture = false;
-            break;
-          }
-        }
-        if (all_consumers_support_texture)
-        {
-          storage_scope_[expr] = "texture";
-        }
+        storage_scope_[expr] = GetConsumerScope(consumer_scopes_it->second);
       }
     }
 
@@ -130,21 +130,7 @@ class StorageInfo {
         // same storage type. If not, default to global scope
         // for the producer
         if (kv.second.size() > 1) {
-          bool all_consumers_support_texture = true;
-          for (auto& consumer_scope : kv.second) {
-            if (consumer_scope != "texture") {
-              all_consumers_support_texture = false;
-              break;
-            }
-          }
-          if (all_consumers_support_texture)
-          {
-            storage_scope_[producer] = "texture";
-          }
-          else
-          {
-            storage_scope_[producer] = "global";
-          }
+          storage_scope_[producer] = GetConsumerScope(kv.second);
         }
       }
     }

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -75,16 +75,22 @@ class StorageInfo {
       return ref_scope;
     }
 
-    void BackwardPropagateConsumerScope(const ExprNode* expr) {
+    void BackwardPropagateConsumerScope(const ExprNode* expr, std::string scope_suffix = "") {
       auto consumer_scopes_it = consumer_storage_scopes_.find(expr);
       if (consumer_scopes_it != consumer_storage_scopes_.end())
       {
         storage_scope_[expr] = GetConsumerScope(consumer_scopes_it->second);
+        if (storage_scope_[expr] == "texture")
+        {
+          if (!scope_suffix.empty()) {
+            storage_scope_[expr] += (":" + scope_suffix);
+          }
+        }
       }
     }
 
     void VisitExpr_(const ConstantNode* cn) final {
-      BackwardPropagateConsumerScope(cn);
+      BackwardPropagateConsumerScope(cn, "weight");
     }
 
     void VisitExpr_(const CallNode* call) final {

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -71,6 +71,7 @@ class StorageInfo {
         for (auto& consumer_scope : consumer_scopes_it->second) {
           if (consumer_scope != "texture") {
             all_consumers_support_texture = false;
+            break;
           }
         }
         if (all_consumers_support_texture)
@@ -93,9 +94,13 @@ class StorageInfo {
           if (primitive_supports_texture_)
           {
             storage_scope_[call] = "texture";
-            for (auto& arg : call->args) {
-              consumer_storage_scopes_[arg.get()].push_back("texture");
-            }
+          }
+          else
+          {
+            storage_scope_[call] = "global";
+          }
+          for (auto& arg : call->args) {
+            consumer_storage_scopes_[arg.get()].push_back(storage_scope_[call]);
           }
         }
       }

--- a/src/relay/transforms/adreno_memory_annotation.cc
+++ b/src/relay/transforms/adreno_memory_annotation.cc
@@ -66,6 +66,7 @@ class StorageInfo {
 
    private:
     std::string GetConsumerScope(const std::vector<std::string>& consumer_scopes) const {
+      if (!consumer_scopes.size()) { return "global"; }
       std::string ref_scope = consumer_scopes.front();
       for (auto& consumer_scope : consumer_scopes) {
         if (consumer_scope != ref_scope) {
@@ -126,12 +127,11 @@ class StorageInfo {
     void LegalizeProducerStorage() {
       for (auto& kv : consumer_storage_scopes_) {
         const ExprNode* producer = kv.first;
-        // For any producers which have multiple consumers we
-        // must ensure that all of those consumers expect the
-        // same storage type. If not, default to global scope
-        // for the producer
-        if (kv.second.size() > 1) {
-          storage_scope_[producer] = GetConsumerScope(kv.second);
+        std::string legal_scope = GetConsumerScope(kv.second);
+        if (storage_scope_.count(producer)) {
+          if (storage_scope_[producer] != legal_scope) {
+            storage_scope_[producer] = legal_scope;
+          }
         }
       }
     }

--- a/src/relay/transforms/annotate_texture_storage.cc
+++ b/src/relay/transforms/annotate_texture_storage.cc
@@ -18,8 +18,21 @@
  */
 
 /*!
- * \file deivce_annotation.cc
- * \brief
+ * \file annotate_texture_storage.cc
+ * \brief Collection of target specific relay passes which
+ * storage scope related information.
+ *
+ *  - CollectStorageInfo returns a mapping from relay expr
+ *    to a list of output storage scopes for each output.
+ *    These scopes are used during memory planning as well
+ *    as downstream when doing codegen (see CollectBufferBinds)
+ *    and in the graph runtime when doing runtime dataspace
+ *    allocations.
+ *
+ *  - CollectBufferBinds returns an array of tir::Buffer given
+ *    the storage info yielded from CollectStogrageInfo. These
+ *    buffers are bound to tensors created by the compile engine
+ *    and are used as binds when calling tvm::lower/build.
  *
  */
 

--- a/src/relay/transforms/annotate_texture_storage.cc
+++ b/src/relay/transforms/annotate_texture_storage.cc
@@ -88,7 +88,7 @@ class StorageInfo : private ExprVisitor{
 
   void VisitExpr_(const CallNode* call) final {
     // Check the contents of this primitive function
-    if (IsAdrenoExpr(GetRef<Expr>(call))) {
+    if (DeviceSupportsTextureStorage(GetRef<Expr>(call))) {
       if (const auto* fn = call->op.as<FunctionNode>()) {
         if (fn->HasNonzeroAttr(attr::kPrimitive)) {
           primitive_supports_texture_ = false;
@@ -183,7 +183,7 @@ class StorageInfo : private ExprVisitor{
     }
   }
 
-  bool IsAdrenoExpr(const Expr& expr) {
+  bool DeviceSupportsTextureStorage(const Expr& expr) {
     Target target;
     Integer dev_id{-1};
     if (device_ids_.count(expr) && targets_.count(device_ids_[expr])) {
@@ -196,6 +196,7 @@ class StorageInfo : private ExprVisitor{
     }
     ICHECK(dev_id->value != -1) << "Error inferring target device, device mapping and targets do not match";
     Optional<String> t_device = target->GetAttr<String>("device");
+    // Currently only `target = opencl --device=adreno` supports texture storage
     if (target->kind->device_type == kDLOpenCL && t_device.defined()) {
       if (t_device.value() == "adreno") { return true; }
     }

--- a/src/relay/transforms/annotate_texture_storage.cc
+++ b/src/relay/transforms/annotate_texture_storage.cc
@@ -35,6 +35,7 @@
 
 namespace tvm {
 namespace relay {
+namespace {
 
 class StorageInfo : private ExprVisitor{
  public:
@@ -231,7 +232,7 @@ class StorageInfo : private ExprVisitor{
   /*! \brief device id to target mapping  */
   Map<Integer, Target> targets_;
   /*! \brief Temporary state for marking whether a visited function
-             primitive supports texture storage scope */
+   *         primitive supports texture storage scope */
   bool primitive_supports_texture_ = false;
   /*! \brief expr storage scope mapping for each output  */
   std::unordered_map<const ExprNode*, std::vector<std::string>> storage_scope_;
@@ -239,7 +240,6 @@ class StorageInfo : private ExprVisitor{
   std::unordered_map<const ExprNode*, std::vector<std::string>> consumer_storage_scopes_;
 };
 
-namespace {
 String GetStorageScope(const Expr& expr, const Map<Expr, runtime::ADT>& storage_map, size_t output_index) {
   if (!storage_map.count(expr)) { return String{}; }
   auto storage_info = Downcast<Array<String>>(storage_map[expr][2]);


### PR DESCRIPTION
This PR adds a target specific implementation of CollectStorageInfo and CollectBufferBinds for the `opencl --device=adreno` target. 

**CollectStorageInfo**
- Returns a storage mapping for the outputs of each Expr in a Relay function. For Adreno, the output storage is set to "texture" for primitive functions containing a Conv2d with data and kernel layouts of NCHW4c and OIHW4o, respectively, are.
- The output storage scope for Constants and Vars is inferred from the output storage scope of their consumers. 
- A legalization step occurs that ensures that the output of any primitive function is set to global scope if one or more of its consumers requires global scope for its output. This legalization step occurs after the storage scopes have been collected and therefore is not transitive so that the global scope does not propagate toward the inputs.
- An additional legalization step occurs to ensure that the global outputs of the relay Function are marked as global scope. This can be removed if CopyFromTo will support passing shape information for the source and destination tensors, or if texture memory reuse is disabled
  - The key issue is that the allocated texture space being read from for a output tensor may be a pool, in which case pitch region and row pitch will be required to correctly read the texture from the pool to the host. The region and pitch information can be inferred from the shape of the src and dst tensors if provided to CopyToFrom. 

**CollectBufferBinds**
- Translates the storage scopes information provided by the memory planner (and ultimately the above CollectStorageInfo pass) to tir::Buffers that can be bound to te::Tensors when lowering Relay primitive functions. These buffers are provided to CompileEngine and used in `tvm::lower/build` via the binds field. If the provided buffers have texture scope, the TIR TextureFlattening pass will handle lowering the multidimensional accesses to two dimensions.

See RFC here: https://discuss.tvm.apache.org/t/rfc-texture-memory-support/9467