### PR TITLE
[Vulkan] Workaround for zero size allocation

### DIFF
--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -120,6 +120,10 @@ class VulkanDeviceAPI final : public DeviceAPI {
   std::vector<uint32_t> GetComputeQueueFamilies(VkPhysicalDevice phy_dev);
   void* AllocDataSpace(TVMContext ctx, size_t nbytes, size_t alignment,
                        DLDataType type_hint) final {
+    if (nbytes == 0) {
+      // Vulkan seems to have issues if we return nullptr on zero size alloc
+      nbytes = 1;
+    }
     const auto& vctx = context(ctx.device_id);
     VkBufferCreateInfo info;
     info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;


### PR DESCRIPTION
It seems we get segfault from Vulkan if a request to allocate 0 size is made. Returning nullptr in such case works for other backend, but VK seems to have issues. This workaround was confirmed to be effective. 

Running NMS tests in `test_any.py` serves as the test case. Without this it would segfault.

@tmoreau89 @mbrookhart @tqchen 