### PR TITLE
[TE] Bugfix for reduction that involves multi-outs with where cond

### DIFF
--- a/src/te/operation/compute_op.cc
+++ b/src/te/operation/compute_op.cc
@@ -57,14 +57,9 @@ TVM_REGISTER_NODE_TYPE(ComputeOpNode);
 static void VerifyComputeOp(const ComputeOpNode* op);
 
 inline bool ReduceEqual(const tir::ReduceNode* a, const tir::ReduceNode* b) {
-  StructuralEqual expr_equal;
-  return (a->combiner.same_as(b->combiner)) &&
-         (a->source.same_as(b->source)) &&
-         (a->axis.same_as(b->axis)) &&
-         (a->condition.same_as(b->condition) ||
-          expr_equal(a->condition, b->condition)) &&
-         ((a->init.empty() && b->init.empty()) ||
-          (a->init.same_as(b->init)));
+  return (a->combiner.same_as(b->combiner)) && (a->source.same_as(b->source)) &&
+         (a->axis.same_as(b->axis)) && StructuralEqual()(a->condition, b->condition) &&
+         ((a->init.empty() && b->init.empty()) || (a->init.same_as(b->init)));
 }
 
 int ComputeOpNode::num_outputs() const { return body.size(); }

--- a/src/te/operation/compute_op.cc
+++ b/src/te/operation/compute_op.cc
@@ -57,9 +57,14 @@ TVM_REGISTER_NODE_TYPE(ComputeOpNode);
 static void VerifyComputeOp(const ComputeOpNode* op);
 
 inline bool ReduceEqual(const tir::ReduceNode* a, const tir::ReduceNode* b) {
-  return (a->combiner.same_as(b->combiner)) && (a->source.same_as(b->source)) &&
-         (a->axis.same_as(b->axis)) && (a->condition.same_as(b->condition)) &&
-         ((a->init.empty() && b->init.empty()) || (a->init.same_as(b->init)));
+  StructuralEqual expr_equal;
+  return (a->combiner.same_as(b->combiner)) &&
+         (a->source.same_as(b->source)) &&
+         (a->axis.same_as(b->axis)) &&
+         (a->condition.same_as(b->condition) ||
+          expr_equal(a->condition, b->condition)) &&
+         ((a->init.empty() && b->init.empty()) ||
+          (a->init.same_as(b->init)));
 }
 
 int ComputeOpNode::num_outputs() const { return body.size(); }

--- a/tests/python/unittest/test_te_tensor.py
+++ b/tests/python/unittest/test_te_tensor.py
@@ -110,6 +110,24 @@ def test_tensor_reduce():
     assert str(C_loaded) == str(C)
 
 
+def test_tensor_reduce_multiout_with_cond():
+    def fcombine(x, y):
+        return x[0] + y[0], x[1] + y[1]
+
+    def fidentity(t0, t1):
+        return tvm.tir.const(0, t0), tvm.tir.const(1, t1)
+
+    mysum = te.comm_reducer(fcombine, fidentity, name="mysum")
+
+    m = te.var("m")
+    n = te.var("n")
+    idx = te.placeholder((m, n), name="idx", dtype="int32")
+    val = te.placeholder((m, n), name="val", dtype="int32")
+    k = te.reduce_axis((0, n), "k")
+    cond = te.floormod(k, 2) == 0
+    T0, T1 = te.compute((m,), lambda i: mysum((idx[i, k], val[i, k]), axis=k, where=cond), name="T")
+
+
 def test_tensor_compute1():
     m = 1024
     factor = 16
@@ -384,21 +402,25 @@ def test_tensor_scalar():
 
 
 if __name__ == "__main__":
+    test_tensor()
     test_rank_zero()
-    test_tensor_inputs()
-    test_tensor_reduce_multi_axis()
     test_conv1d()
     test_tensor_slice()
-    test_tensor()
+    test_tensor_reduce_multi_axis()
+    test_tensor_comm_reducer()
+    test_tensor_comm_reducer_overload()
+    test_tensor_reduce()
+    test_tensor_reduce_multiout_with_cond()
     test_tensor_compute1()
     test_tensor_compute2()
-    test_tensor_reduce()
     test_tensor_scan()
     test_scan_multi_out()
     test_extern()
     test_extern_multi_out()
     test_tuple_inputs()
     test_tuple_with_different_deps()
+    test_tensor_inputs()
     test_tensor_pool()
-    test_tensor_scalar()
     test_tensor_scalar_mixed()
+    test_tensor_scalar()
+

--- a/tests/python/unittest/test_te_tensor.py
+++ b/tests/python/unittest/test_te_tensor.py
@@ -423,4 +423,3 @@ if __name__ == "__main__":
     test_tensor_pool()
     test_tensor_scalar_mixed()
     test_tensor_scalar()
-


### PR DESCRIPTION
Hi All,
There is a bug if you specified the where condition in comm_reducer that involves multiple outputs because the cond for each output has a different address.
Fix:
1. Using deep equal to compare conditions when verify compute operation.
2. Invoking test cases that do not be executed before.

before the fix, the condition is not equal.
```
Traceback (most recent call last):
  File "tests/python/unittest/test_te_tensor.py", line 413, in <module>
    test_tensor_reduce_multiout_with_cond()
  File "tests/python/unittest/test_te_tensor.py", line 128, in test_tensor_reduce_multiout_with_cond
    T0, T1 = te.compute((m,), lambda i: mysum((idx[i, k], val[i, k]), axis=k, where=cond), name="T")
  File "~/apache/tvm/python/tvm/te/operation.py", line 126, in compute
    op_node = _ffi_api.ComputeOp(name, tag, attrs, dim_var, body)
  File "~/apache/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  [bt] (8) ~/apache/tvm/build/libtvm.so(tvm::runtime::PackedFunc::CallPacked(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x55) [0x7f969208c2d5]
  [bt] (7) ~/apache/tvm/build/libtvm.so(std::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x71) [0x7f9691ef9501]
  [bt] (6) ~/apache/tvm/build/libtvm.so(+0x21b8837) [0x7f9692327837]
  [bt] (5) ~/apache/tvm/build/libtvm.so(+0x21b9529) [0x7f9692328529]
  [bt] (4) ~/apache/tvm/build/libtvm.so(+0x21b9797) [0x7f9692328797]
  [bt] (3) ~/apache/tvm/build/libtvm.so(tvm::te::ComputeOp::ComputeOp(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, tvm::runtime::Map<tvm::runtime::String, tvm::runtime::ObjectRef, void, void>, tvm::runtime::Array<tvm::tir::IterVar, void>, tvm::runtime::Array<tvm::PrimExpr, void>)+0x3b7) [0x7f969231fe37]
  [bt] (2) ~/apache/tvm/build/libtvm.so(+0x21b0ee6) [0x7f969231fee6]
  [bt] (1) ~/apache/tvm/build/libtvm.so(+0x21b82d3) [0x7f96923272d3]
  [bt] (0) ~/apache/tvm/build/libtvm.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x40) [0x7f9691e53bc0]
  File "~/apache/tvm/src/te/operation/compute_op.cc", line 534
TVMError: 
---------------------------------------------------------------
An internal invariant was violated during the execution of TVM.
Please read TVM's error reporting guidelines.
More details can be found here: https://discuss.tvm.ai/t/error-reporting/7793.
---------------------------------------------------------------
  Check failed: ReduceEqual(reduce, reduce_) == false: The Reduce inputs of ComputeOp should have the same attribute except value_index
```