### PR TITLE
[GO] Fix go bindings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ stage('Build') {
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
-          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
           junit "build/pytest-results/*.xml"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ stage('Build') {
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
+          // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
           junit "build/pytest-results/*.xml"
         }

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -25,7 +25,7 @@ NATIVE_SRC = tvm_runtime_pack.cc
 GOPATH=$(CURDIR)/gopath
 GOPATHDIR=${GOPATH}/src/${TARGET}/
 CGO_CPPFLAGS="-I. -I${TVM_BASE}/ -I${TVM_BASE}/3rdparty/dmlc-core/include -I${TVM_BASE}/include -I${TVM_BASE}/3rdparty/dlpack/include/"
-CGO_CXXFLAGS="-std=c++14 -DDMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h> -DTVM_BACKTRACE_DISABLED=1"
+CGO_CXXFLAGS="-std=c++14 -DDMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h> -DTVM_USE_LIBBACKTRACE=0"
 CGO_CFLAGS="-I${TVM_BASE}"
 CGO_LDFLAGS="-ldl -lm"
 

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -25,7 +25,7 @@ NATIVE_SRC = tvm_runtime_pack.cc
 GOPATH=$(CURDIR)/gopath
 GOPATHDIR=${GOPATH}/src/${TARGET}/
 CGO_CPPFLAGS="-I. -I${TVM_BASE}/ -I${TVM_BASE}/3rdparty/dmlc-core/include -I${TVM_BASE}/include -I${TVM_BASE}/3rdparty/dlpack/include/"
-CGO_CXXFLAGS="-std=c++14 -DDMLC_USE_LOGGING_LIBRARY=\<tvm/runtime/logging.h\>"
+CGO_CXXFLAGS="-std=c++14 -DDMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h> -DTVM_BACKTRACE_DISABLED=1"
 CGO_CFLAGS="-I${TVM_BASE}"
 CGO_LDFLAGS="-ldl -lm"
 

--- a/golang/src/tvm_runtime_pack.cc
+++ b/golang/src/tvm_runtime_pack.cc
@@ -22,9 +22,11 @@
  * \file tvm_runtime_pack.cc
  */
 #include "src/runtime/c_runtime_api.cc"
+#include "src/runtime/container.cc"
 #include "src/runtime/cpu_device_api.cc"
 #include "src/runtime/file_utils.cc"
 #include "src/runtime/library_module.cc"
+#include "src/runtime/logging.cc"
 #include "src/runtime/module.cc"
 #include "src/runtime/ndarray.cc"
 #include "src/runtime/object.cc"


### PR DESCRIPTION
Fixes #7683.

The go bindings are using a **very** brittle approach to vendoring TVM. They build their own version of the tvm_runtime by just `#include`ing all the runtime files. This does not correctly link to dependencies and breaks every time a new runtime file is added. The go bindings should really just link directly to libtvm_runtime.so. Then would could avoid issues like this in the future. @srkreddy1238 could you submit a PR for this?

@leandron @srkreddy1238 @tqchen