### PR TITLE
[Relay][Frontend][ONNX] Raise error when user provides an input not in the onnx graph.

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2914,7 +2914,7 @@ class GraphProto:
             else:
                 self._num_input += 1
                 if i_name in self._shape:
-                    i_shape = self._shape[i_name]
+                    i_shape = self._shape.pop(i_name)
                 else:
                     if "?" in str(i_shape):
                         warning_msg = (
@@ -2929,6 +2929,11 @@ class GraphProto:
                     dtype = d_type
                 self._nodes[i_name] = new_var(i_name, shape=i_shape, dtype=dtype)
             self._inputs[i_name] = self._nodes[i_name]
+        assert (
+            len(self._shape) == 0
+        ), "User specified the shape for inputs that weren't found in the graph: " + str(
+            self._shape
+        )
         # get list of unsupported ops
         convert_map = _get_convert_map(opset)
         unsupported_ops = set()


### PR DESCRIPTION
There was recently some discussion about how the onnx importer should handle being passed a shape dict that contains inputs not found in the onnx graph. Currently, the importer will just ignore these inputs. However, this could lead to user confusion if they make a simple typo and are expecting different behavior than what they get. This PR adds checking for inputs in the shape dict that arent part of the graph and informs the user if it finds any. Overall, this should provide a more clear experience.

I added a test to confirm the behavior works as described and found that one of our onnx tests (test_pad) was actually providing gratuitous input information.