### PR TITLE
[TOPI][CUDA] Fix 0 valid boxes case for NMS when return_indices=False

### DIFF
--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -474,7 +474,9 @@ def nms_ir(
                     box_indices[i * num_anchors + j] = -1
 
         with ib.else_scope():
-            with ib.if_scope(j < valid_count[i]):
+            # Need to copy all boxes if not using return_indices
+            bounds = valid_count[i] if return_indices else num_anchors
+            with ib.if_scope(j < bounds):
                 src_offset = base_src_idx + j * box_data_length
 
                 with ib.for_range(0, 4, kind="unroll") as k:


### PR DESCRIPTION
When return_indices is False, the values of all boxes, scores must be set to -1 when they are invalid. The current code was not doing this, resulting in uninitialized memory being returned in the op output.

Example output before fix, showing how output is incorrect for first inference and then is still incorrect but with different random output for second inference (due to unitialized memory being used). The input data is the same for all executions.
```
mx top 10 score [-1. -1. -1. -1. -1. -1. -1. -1. -1. -1.]
tvm top 10 score [0. 0. 0. ... 0. 0. 0.]
tvm top 10 score [1.0032198 1.0016742 1.0015179 ... 1.0053984 1.0051595 1.0052176]
```

With fix
```
mx top 10 score [-1. -1. -1. -1. -1. -1. -1. -1. -1. -1.]
tvm top 10 score [-1. -1. -1. ... -1. -1. -1.]
tvm top 10 score [-1. -1. -1. ... -1. -1. -1.]
```