### PR TITLE
Fix graph_tuner ancestor duplication

### DIFF
--- a/python/tvm/autotvm/graph_tuner/utils/traverse_graph.py
+++ b/python/tvm/autotvm/graph_tuner/utils/traverse_graph.py
@@ -211,7 +211,8 @@ def get_direct_ancestor(node_list, visited_dict, target_ops, node_idx, input_nam
         else:
             tmp = get_direct_ancestor(node_list, visited_dict, target_ops, item_idx[0], input_names)
             for tmp_item in tmp:
-                node_direct_ancestor.append(tmp_item)
+                if tmp_item not in node_direct_ancestor:
+                    node_direct_ancestor.append(tmp_item)
     visited_dict[node_idx] = node_direct_ancestor
     return node_direct_ancestor
 

--- a/tests/python/unittest/test_autotvm_graph_tuner_utils.py
+++ b/tests/python/unittest/test_autotvm_graph_tuner_utils.py
@@ -109,6 +109,16 @@ def test_get_direct_ancestor():
     out = get_direct_ancestor(node_list, visited_dict, target_ops, 5, input_names)
     assert out == [0], "Output mismatch: expecting [0] but got %s." % str(out)
 
+    # non-regression test
+    out = relay.add(relay.log(data), relay.sqrt(data))
+    net = relay.Function(relay.analysis.free_vars(out), out)
+    net = bind_inputs(net, {"data": (1, 16, 224, 224)})
+    node_list = []
+    node_dict = {}
+    expr2graph(net, target_ops, node_dict, node_list)
+    out = get_direct_ancestor(node_list, visited_dict, target_ops, 3, input_names)
+    assert out == [0], "Output mismatch: expecting [0] but got %s." % str(out)
+
 
 def test_get_in_nodes():
     data = relay.var("data")


### PR DESCRIPTION
A diamond dependency currently generates a duplication of ancestors:
```
  A
 / \
B   C
 \ /
  D
```
under some conditions, this scenario leads to the following dictionnary
entry: "D":[A, A] instead of "D":[A].

This results in failures when subsequently trying to transpose node
states based on this data.
