### PR TITLE
Fix auto scheduler crash when set with consumers is empty

### DIFF
--- a/src/auto_scheduler/search_policy/sketch_policy_rules.cc
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.cc
@@ -164,6 +164,7 @@ SketchGenerationRule::ConditionKind RuleAddCacheRead::MeetCondition(const Sketch
   // Don't cache_read a stage if it has multiple consumers
   const std::set<int>& consumers = GetConsumers(task, state, stage_id);
 
+  if (consumers.size() == 0) return ConditionKind::kSkip;
   // Don't cache_read a stage if its consumer does not need multi-level tiling
   int target_stage_id = *consumers.begin();
   if (!NeedsMultilevelTiling(task, state, target_stage_id)) {


### PR DESCRIPTION
Set with consumers is empty during preparing auto scheduler sketches for Metal device. Added check on the size of the set.
In case when the set with consumers is empty we just skip this rule.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
