### PR TITLE
[torch] Use try_infer_value for clamp min/max

### DIFF
--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2622,10 +2622,17 @@ def test_forward_clamp():
         def forward(self, *args):
             return torch.clamp(args[0], max=1.0)
 
+    class Clamp_MinExpr_MaxConstant(Module):
+        def forward(self, *args):
+            h, w = args[0].shape[2:]
+            amin = h / 100.0
+            return torch.clamp(args[0], min=amin, max=w)
+
     input_data = torch.rand(input_shape).float()
     verify_model(Clamp1().float().eval(), input_data=input_data)
     verify_model(Clamp2().float().eval(), input_data=input_data)
     verify_model(Clamp3().float().eval(), input_data=input_data)
+    verify_model(Clamp_MinExpr_MaxConstant().float().eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
In some cases `torch.clamp(min,max)` operator has `min` and `max` parameters which are Constant or Expr.
This PR adds support for the cases when `min` and `max` parameters are `Constant` or `Expr` which can be infered.

Related Discussion: https://discuss.tvm.apache.org/t/relay-clip-operator-with-dynamic-min-max-fails/9466

@masahi 