### PR TITLE
[TensorIR] add TIRTextPrinter support for Block and BlockRealize

### DIFF
--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -310,6 +310,7 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc VisitStmt_(const ForNode* op) override;
   Doc VisitStmt_(const WhileNode* op) override;
   Doc VisitStmt_(const PrefetchNode* op) override;
+  Doc VisitStmt_(const BlockRealizeNode* op) override;
   Doc VisitStmtDefault_(const Object* op) override;
 
   Doc VisitType_(const PrimTypeNode* node) override;
@@ -324,6 +325,7 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc PrintBuffer(const BufferNode* op);
   Doc BufferNode2Doc(const BufferNode* op, Doc doc);
   Doc PrintString(const StringObj* op) { return Doc::StrLiteral(op->data); }
+  Doc PrintBufferRegion(const BufferRegionNode* op);
 
   /*!
    * \brief special method to print out data type

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -66,6 +66,8 @@ Doc TIRTextPrinter::Print(const ObjectRef& node) {
     return PrintBuffer(node.as<BufferNode>());
   } else if (node->IsInstance<StringObj>()) {
     return PrintString(node.as<StringObj>());
+  } else if (node->IsInstance<BufferRegionNode>()) {
+    return PrintBufferRegion(node.as<BufferRegionNode>());
   } else {
     return this->meta_->GetMetaNode(node);
   }
@@ -215,6 +217,22 @@ Doc TIRTextPrinter::BufferNode2Doc(const BufferNode* buf, Doc doc) {
     doc << ", type=" << Doc::StrLiteral("auto");
   }
   return doc << ")";
+}
+
+Doc TIRTextPrinter::PrintBufferRegion(const BufferRegionNode* op) {
+  Doc doc;
+  doc << Print(op->buffer) << "[";
+  for (size_t i = 0; i < op->region.size(); ++i) {
+    if (i != 0) doc << ", ";
+    const auto& range = op->region[i];
+    if (!is_one(range->extent)) {
+      doc << Print(range->min) << ":" << Print(range->min + range->extent);
+    } else {
+      doc << Print(range->min);
+    }
+  }
+  doc << "]";
+  return doc;
 }
 
 Doc TIRTextPrinter::VisitExprDefault_(const Object* op) {
@@ -503,6 +521,92 @@ Doc TIRTextPrinter::VisitStmt_(const WhileNode* op) {
 Doc TIRTextPrinter::VisitStmt_(const PrefetchNode* op) {
   Doc doc;
   doc << "prefetch(" << Print(op->buffer) << ", " << Print(op->bounds) << ")";
+  return doc;
+}
+
+Doc TIRTextPrinter::VisitStmt_(const BlockRealizeNode* op) {
+  const auto* block_op = op->block.as<BlockNode>();
+  // print block name and block vars
+  Doc doc;
+  doc << "block([";
+  std::vector<Doc> block_var_docs;
+  for (const auto& iter_var : block_op->iter_vars) {
+    Doc block_var_doc;
+    if (is_zero(iter_var->dom->min) && iter_var->iter_type == kDataPar) {
+      block_var_doc << Print(iter_var->dom->extent);
+    } else {
+      block_var_doc << "tir.";
+      switch (iter_var->iter_type) {
+        case kDataPar:
+          block_var_doc << "range";
+          break;
+        case kCommReduce:
+          block_var_doc << "reduce_axis";
+          break;
+        case kOrdered:
+          block_var_doc << "scan_axis";
+          break;
+        case kOpaque:
+          block_var_doc << "opaque_axis";
+          break;
+        default:
+          LOG(FATAL) << "Unknown block var iter type";
+          break;
+      }
+      block_var_doc << "(" << Print(iter_var->dom->min) << ", "
+                    << Print(iter_var->dom->min + iter_var->dom->extent) << ")";
+    }
+    block_var_docs.push_back(block_var_doc);
+  }
+  doc << PrintSep(block_var_docs, Doc::Text(", ")) << "], ";
+  doc << Doc::StrLiteral(block_op->name_hint) << ")";
+  std::vector<Doc> block_var_names;
+  for (const auto& iter_var : block_op->iter_vars) {
+    Doc block_var_name;
+    AllocVar(iter_var->var);
+    block_var_names.push_back(Print(iter_var->var));
+  }
+  if (!block_var_names.empty()) {
+    doc << " as [" << PrintSep(block_var_names, Doc::Text(", ")) << "]";
+  }
+  doc << " {";
+  Doc block_attr_doc;
+  // print predicate, binding, read/write tensor region, annotations
+  if (!is_one(op->predicate)) {
+    block_attr_doc << Doc::NewLine() << "where(" << Print(op->predicate) << ")";
+  }
+  for (size_t i = 0; i < block_op->iter_vars.size(); ++i)
+    block_attr_doc << Doc::NewLine() << "bind(" << Print(block_op->iter_vars[i]->var) << ", "
+                   << Print(op->iter_values[i]) << ")";
+  block_attr_doc << Doc::NewLine() << "tir.reads(" << Print(block_op->reads) << ")";
+  block_attr_doc << Doc::NewLine() << "tir.writes(" << Print(block_op->writes) << ")";
+  if (!block_op->annotations.empty()) {
+    std::vector<Doc> attr_docs;
+    for (const auto& it : block_op->annotations) {
+      attr_docs.push_back(Doc::StrLiteral(it.first) << ": " << Print(it.second));
+    }
+    block_attr_doc << Doc::NewLine() << "tir.attrs({" << PrintSep(attr_docs, Doc::Text(", "))
+                   << "})";
+  }
+  // print body
+  Doc body;
+  body << Doc::NewLine();
+  for (const auto& alloc_buf : block_op->alloc_buffers) {
+    body << AllocBuf(alloc_buf) << " = alloc_buffer(" << PrintDType(alloc_buf->dtype)
+         << Print(alloc_buf->shape) << ")" << Doc::NewLine();
+  }
+  for (const auto& match_buf : block_op->match_buffers) {
+    body << AllocBuf(match_buf->buffer) << " = match_buffer_region(" << Print(match_buf->source)
+         << ")" << Doc::NewLine();
+  }
+  if (block_op->init.defined()) {
+    Doc init_block;
+    init_block << "with init()";
+    init_block << PrintBody(block_op->init.value());
+    body << init_block << Doc::NewLine();
+  }
+  body << Print(block_op->body);
+  doc << Doc::Indent(2, block_attr_doc << body);
   return doc;
 }
 

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -223,7 +223,9 @@ Doc TIRTextPrinter::PrintBufferRegion(const BufferRegionNode* op) {
   Doc doc;
   doc << Print(op->buffer) << "[";
   for (size_t i = 0; i < op->region.size(); ++i) {
-    if (i != 0) doc << ", ";
+    if (i != 0) {
+      doc << ", ";
+    }
     const auto& range = op->region[i];
     if (!is_one(range->extent)) {
       doc << Print(range->min) << ":" << Print(range->min + range->extent);

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -440,9 +440,20 @@ def test_block_blockrealize():
     assert block_realize.predicate == tvm.tir.const(True, "bool")
     assert block_realize.block == block
 
-    # make sure we can print
+    # make sure we can print using ReprPrinter
     str(block)
     str(block_realize)
+    # make sure we can print using TIRTextPrinter
+    func = tvm.tir.PrimFunc([], block_realize)
+    output = func.astext()
+    assert output.find("meta[tir.BlockRealise]") == -1
+    assert output.find("bind") != -1
+    assert output.find("reads") != -1
+    assert output.find("writes") != -1
+    assert output.find("alloc_buffer") != -1
+    assert output.find("match_buffer_region") != -1
+    assert output.find("attr") != -1
+    assert output.find("with init()") != -1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, there are three printers for TIR: 
1. ReprPrinter: Text printer for stmt node. (e.g. `print(for_loop)`)
2. TIRTextPrinter: Text printer for function or module. (e.g. `print(prim_func)`)
3. TVMScriptPrinter: Python syntax printer for function or module.

Note that TIRTextPrinter and TVMScriptPrinter are designed for round-trip printing and parsing, which may contain necessary info for reconstructing the AST (TIRTextPrinter is designed for it but has not supported now). In this PR, I add TIRTextPrinter support for Block and BlockRealize. Then all three printers and one parser (TVMScriptParser) support TensorIR.

Example
```
#[version = "0.0.5"]
primfn() -> () {
  block([16, tir.reduce_axis(0, 16)], "block") as [vx, vy] {
    bind(vx, x)
    bind(vy, y)
    tir.reads([buffer[vx, vy]])
    tir.writes([buffer_2[vx]])
    tir.attrs({"attr_key": "attr_value"})
    buffer_4 = alloc_buffer(float32[16, 16])
    buffer_5 = match_buffer_region(buffer[0:16, 0:16])
    with init() {
      buffer_2[vx] = 0f32
    }
    buffer_2[vx] = (buffer_2[vx] + buffer[vx, vy])
}
```

cc @tqchen @junrushao1994 