### PR TITLE
[ONNX] Onnx node tests

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1349,8 +1349,8 @@ class Minimum(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        if not isinstance(inputs, (list, onnx_input)) or len(inputs) < 2:
-            raise ValueError("Expect minimum 2 inputs")
+        if len(inputs) == 1:
+            return inputs[0]
         _min = inputs[0]
         for i in range(1, len(inputs)):
             _min = AttrCvt("minimum")([_min, inputs[i]], {})
@@ -1504,7 +1504,7 @@ class ArgMax(OnnxOpConverter):
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
         if "select_last_index" in attr:
-            raise ONNXAttrError("select_last_index not supported in ArgMax")
+            raise NotImplementedError("select_last_index not supported in ArgMax")
         axis = attr.get("axis", 0)
         keepdims = attr.get("keepdims", True)
         attr = {"axis": axis, "keepdims": keepdims}
@@ -1517,7 +1517,7 @@ class ArgMin(OnnxOpConverter):
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
         if "select_last_index" in attr:
-            raise ONNXAttrError("select_last_index not supported in ArgMax")
+            raise NotImplementedError("select_last_index not supported in ArgMin")
         axis = attr.get("axis", 0)
         keepdims = attr.get("keepdims", True)
         attr = {"axis": axis, "keepdims": keepdims}
@@ -1612,7 +1612,7 @@ class Constant(OnnxOpConverter):
     @classmethod
     def _impl_v9(cls, inputs, attr, params):
         if "value" not in attr:
-            raise "No Value in Constant"
+            raise tvm.errors.OpAttributeRequired("no value in Constant")
         np_value = get_numpy(attr.pop("value"))
         dtype = np_value.dtype.name
         value = _expr.const(np_value, dtype)
@@ -2102,7 +2102,7 @@ class TopK(OnnxOpConverter):
         largest = attr.get("largest", 1)
 
         if largest == 0:
-            raise ValueError("TVM only supports finding TopK largest elements")
+            raise NotImplementedError("TVM only supports finding TopK largest elements")
 
         return _op.topk(inputs[0], inputs[1], axis=axis, dtype="int64")
 
@@ -2147,7 +2147,7 @@ class RoiAlign(OnnxOpConverter):
         batch_indices = inputs[2]
         mode = attr.get("mode", b"avg")
         if mode not in (b"avg", b"max"):
-            raise ValueError("RoiAlign in Relay only uses avg and max modes")
+            raise NotImplementedError("RoiAlign in Relay only uses avg and max modes")
         output_height = attr.get("output_height", 1)
         output_width = attr.get("output_width", 1)
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -103,10 +103,9 @@ def get_numpy(tensor_proto):
 def get_type(elem_type):
     """Converts onnx integer datatype to numpy datatype"""
     try:
-        from onnx import TensorProto
+        from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
     except ImportError as e:
         raise ImportError("Unable to import onnx which is required {}".format(e))
-    from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
 
     return str(TENSOR_TYPE_TO_NP_TYPE[elem_type])
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -41,10 +41,6 @@ from .common import infer_type, get_name
 __all__ = ["from_onnx"]
 
 
-class ONNXAttrError(Exception):
-    pass
-
-
 class onnx_input:
     """ Dual purpose list or dictionary access object."""
 
@@ -2464,8 +2460,10 @@ class NonMaxSuppression(OnnxOpConverter):
         dtype = infer_type(boxes).checked_type.dtype
 
         if "center_point_box" in attr:
-            if  attr["center_point_box"] != 0:
-                raise NotImplementedError("Only support center_point_box = 0 in ONNX NonMaxSuprresion")
+            if attr["center_point_box"] != 0:
+                raise NotImplementedError(
+                    "Only support center_point_box = 0 in ONNX NonMaxSuprresion"
+                )
 
         if iou_threshold is None:
             iou_threshold = _expr.const(0.0, dtype="float32")

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1054,7 +1054,7 @@ class Upsample(OnnxOpConverter):
 
         # in 3d case, we use the purely static op
         if dims == 5:
-            if isinstance(scales, _expr.Call):
+            if isinstance(scales, _expr.Expr):
                 scale_h = _op.take(scales, _op.const(3))
                 scale_w = _op.take(scales, _op.const(4))
                 scale_d = _op.take(scales, _op.const(1))
@@ -1070,7 +1070,7 @@ class Upsample(OnnxOpConverter):
             )
         # in 2d case, use dynamic op
         else:
-            if isinstance(scales, _expr.Call):
+            if isinstance(scales, _expr.Expr):
                 scale_h = _op.take(scales, _op.const(3))
                 scale_w = _op.take(scales, _op.const(4))
             else:

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -905,10 +905,13 @@ def strided_slice(data, begin, end, strides=None, slice_mode="end"):
             end = const(list(end))
         if isinstance(strides, (tuple, list)):
             strides = const(list(strides))
-        normalized_begin = _make.where(
+        begin = _make.where(
             begin < cast_like(const(0), begin), begin + cast_like(shape_of(data), begin), begin
         )
-        return _dyn_make.strided_slice(data, normalized_begin, end, strides, slice_mode)
+        begin = _make.where(
+            begin >= cast_like(shape_of(data), begin), cast_like(shape_of(data), begin), begin
+        )
+        return _dyn_make.strided_slice(data, begin, end, strides, slice_mode)
     return _make.strided_slice(data, begin, end, strides, slice_mode)
 
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -24,7 +24,6 @@ import pytest
 import tvm.topi.testing
 import tvm
 from tvm import relay
-from tvm.relay.frontend.onnx import ONNXAttrError
 from tvm.contrib import graph_runtime
 import scipy
 import tvm.testing

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4080,51 +4080,170 @@ def test_cumsum():
     verify_cumsum(data, 1, 0, 1, type="int32")
     verify_cumsum(data, 1, 1, 1, type="int32")
 
+
 from onnx import numpy_helper
+
 f = onnx.__file__
 import glob
+
 onnx_test_folders = sorted(glob.glob("/".join(f.split("/")[0:-1]) + "/backend/test/data/node/*/"))
+
+unsupported_onnx_tests = [
+    "test_basic_convinteger/",
+    "test_bitshift_left_uint16/",
+    "test_bitshift_left_uint32/",
+    "test_bitshift_left_uint64/",
+    "test_bitshift_left_uint8/",
+    "test_bitshift_right_uint16/",
+    "test_bitshift_right_uint32/",
+    "test_bitshift_right_uint64/",
+    "test_bitshift_right_uint8/",
+    "test_cast_DOUBLE_to_FLOAT16/",
+    "test_cast_FLOAT16_to_DOUBLE/",
+    "test_cast_FLOAT16_to_FLOAT/",
+    "test_cast_FLOAT_to_FLOAT16/",
+    "test_cast_FLOAT_to_STRING/",
+    "test_cast_STRING_to_FLOAT/",
+    "test_compress_0/",
+    "test_compress_1/",
+    "test_compress_default_axis/",
+    "test_compress_negative_axis/",
+    "test_convinteger_with_padding/",
+    "test_convtranspose_dilations/",
+    "test_convtranspose_output_shape/",
+    "test_cumsum_1d/",
+    "test_cumsum_1d_exclusive/",
+    "test_cumsum_1d_reverse/",
+    "test_cumsum_1d_reverse_exclusive/",
+    "test_cumsum_2d_axis_0/",
+    "test_cumsum_2d_axis_1/",
+    "test_cumsum_2d_negative_axis/",
+    "test_dequantizelinear/",
+    "test_det_2d/",
+    "test_det_nd/",
+    "test_dynamicquantizelinear/",
+    "test_dynamicquantizelinear_expanded/",
+    "test_dynamicquantizelinear_max_adjusted/",
+    "test_dynamicquantizelinear_max_adjusted_expanded/",
+    "test_dynamicquantizelinear_min_adjusted/",
+    "test_dynamicquantizelinear_min_adjusted_expanded/",
+    "test_eyelike_populate_off_main_diagonal/",
+    "test_eyelike_with_dtype/",
+    "test_eyelike_without_dtype/",
+    "test_hardmax_axis_0/",
+    "test_hardmax_axis_1/",
+    "test_hardmax_axis_2/",
+    "test_hardmax_default_axis/",
+    "test_hardmax_example/",
+    "test_hardmax_negative_axis/",
+    "test_hardmax_one_hot/",
+    "test_isinf_negative/",
+    "test_isinf_positive/",
+    "test_lstm_defaults/",
+    "test_lstm_with_initial_bias/",
+    "test_lstm_with_peepholes/",
+    "test_matmulinteger/",
+    "test_maxpool_2d_dilations/",
+    "test_maxpool_2d_same_lower/",
+    "test_maxpool_2d_same_upper/",
+    "test_maxpool_with_argmax_2d_precomputed_pads/",
+    "test_maxpool_with_argmax_2d_precomputed_strides/",
+    "test_maxunpool_export_with_output_shape/",
+    "test_mvn/",
+    "test_nonmaxsuppression_center_point_box_format/",
+    "test_qlinearconv/",
+    "test_qlinearmatmul_2D/",
+    "test_qlinearmatmul_3D/",
+    "test_quantizelinear/",
+    "test_range_float_type_positive_delta_expanded/",
+    "test_range_int32_type_negative_delta_expanded/",
+    "test_resize_downsample_scales_cubic/",
+    "test_resize_downsample_scales_cubic_A_n0p5_exclude_outside/",
+    "test_resize_downsample_scales_cubic_align_corners/",
+    "test_resize_downsample_scales_linear/",
+    "test_resize_downsample_scales_nearest/",
+    "test_resize_downsample_sizes_cubic/",
+    "test_resize_downsample_sizes_linear_pytorch_half_pixel/",
+    "test_resize_downsample_sizes_nearest/",
+    "test_resize_downsample_sizes_nearest_tf_half_pixel_for_nn/",
+    "test_resize_tf_crop_and_resize/",
+    "test_resize_upsample_scales_cubic/",
+    "test_resize_upsample_scales_cubic_A_n0p5_exclude_outside/",
+    "test_resize_upsample_scales_cubic_align_corners/",
+    "test_resize_upsample_scales_cubic_asymmetric/",
+    "test_resize_upsample_scales_linear/",
+    "test_resize_upsample_sizes_cubic/",
+    "test_resize_upsample_sizes_nearest_ceil_half_pixel/",
+    "test_resize_upsample_sizes_nearest_floor_align_corners/",
+    "test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric/",
+    "test_reversesequence_batch/",
+    "test_reversesequence_time/",
+    "test_rnn_seq_length/",
+    "test_roialign/",
+    "test_round/",
+    "test_scan9_sum/",
+    "test_scan_sum/",
+    "test_scatternd/",
+    "test_selu_default/",
+    "test_shrink_hard/",
+    "test_shrink_soft/",
+    "test_simple_rnn_defaults/",
+    "test_simple_rnn_with_initial_bias/",
+    "test_slice_neg_steps/",
+    "test_slice_start_out_of_bounds/",
+    "test_strnormalizer_export_monday_casesensintive_lower/",
+    "test_strnormalizer_export_monday_casesensintive_nochangecase/",
+    "test_strnormalizer_export_monday_casesensintive_upper/",
+    "test_strnormalizer_export_monday_empty_output/",
+    "test_strnormalizer_export_monday_insensintive_upper_twodim/",
+    "test_strnormalizer_nostopwords_nochangecase/",
+    "test_tfidfvectorizer_tf_batch_onlybigrams_skip0/",
+    "test_tfidfvectorizer_tf_batch_onlybigrams_skip5/",
+    "test_tfidfvectorizer_tf_batch_uniandbigrams_skip5/",
+    "test_tfidfvectorizer_tf_only_bigrams_skip0/",
+    "test_tfidfvectorizer_tf_onlybigrams_levelempty/",
+    "test_tfidfvectorizer_tf_onlybigrams_skip5/",
+    "test_tfidfvectorizer_tf_uniandbigrams_skip5/",
+    "test_top_k_smallest/",
+    "test_unique_not_sorted_without_axis/",
+    "test_unique_sorted_with_axis/",
+    "test_unique_sorted_with_axis_3d/",
+    "test_unique_sorted_with_negative_axis/",
+    "test_unique_sorted_without_axis/",
+    "test_unsqueeze_unsorted_axes/",
+    "test_upsample_nearest/",
+]
+
 
 @pytest.mark.parametrize("test", onnx_test_folders)
 def test_onnx_nodes(test):
-    failures = 0
-    #if "gather" not in test:
-    #    continue
-    print(test)
-    if ("cast" in test and "FLOAT16" in test) or "test_slice_start_out_of_bounds" in test: 
-        print("FAILURE: SKIPPING due to segfault")
-        pytest.skip()
-    try:
-        onnx_model = onnx.load(test + "/model.onnx")
-        inputs = []
-        outputs = []
-        for dataset in glob.glob(test + "/*/"):
-            tensors = sorted(glob.glob(dataset + "/*.pb"))
-            for tensor in tensors:
-                new_tensor = onnx.TensorProto()
-                with open(tensor, 'rb') as f:
-                    new_tensor.ParseFromString(f.read())
-                if "input" in tensor.split('/')[-1]:
-                    inputs.append(numpy_helper.to_array(new_tensor))
-                elif "output" in tensor.split('/')[-1]:
-                    outputs.append(numpy_helper.to_array(new_tensor))
-                else:
-                    print(tensor)
-                    raise
-            tvm_val =  get_tvm_output_with_vm(onnx_model, inputs, "llvm", tvm.cpu(0))
-            if len(outputs) == 1:
-                tvm.testing.assert_allclose(outputs[0], tvm_val, rtol=1e-5, atol=1e-5)
+    for failure in unsupported_onnx_tests:
+        if failure in test:
+            pytest.skip()
+            break
+    onnx_model = onnx.load(test + "/model.onnx")
+    inputs = []
+    outputs = []
+    for dataset in glob.glob(test + "/*/"):
+        tensors = sorted(glob.glob(dataset + "/*.pb"))
+        for tensor in tensors:
+            new_tensor = onnx.TensorProto()
+            with open(tensor, "rb") as f:
+                new_tensor.ParseFromString(f.read())
+            if "input" in tensor.split("/")[-1]:
+                inputs.append(numpy_helper.to_array(new_tensor))
+            elif "output" in tensor.split("/")[-1]:
+                outputs.append(numpy_helper.to_array(new_tensor))
             else:
-                for output, val in zip(outputs, tvm_val):
-                    tvm.testing.assert_allclose(output, val, rtol=1e-5, atol=1e-5)
-    except tvm.error.OpNotImplemented as e:
-        print("WARNING, missing Op:", e)
-        pytest.skip()
-    except NotImplementedError as e:
-        print("WARNING, missing implementation in Op:", e)
-        pytest.skip()
-    except Exception as e:
-        raise e
+                print(tensor)
+                raise
+        tvm_val = get_tvm_output_with_vm(onnx_model, inputs, "llvm", tvm.cpu(0))
+        if len(outputs) == 1:
+            tvm.testing.assert_allclose(outputs[0], tvm_val, rtol=1e-5, atol=1e-5)
+        else:
+            for output, val in zip(outputs, tvm_val):
+                tvm.testing.assert_allclose(output, val, rtol=1e-5, atol=1e-5)
+
 
 def test_wrong_input():
     node = helper.make_node(

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4088,6 +4088,8 @@ def test_onnx_nodes():
     tests = sorted(glob.glob("/".join(f.split("/")[0:-1]) + "/backend/test/data/node/*/"))
     failures = 0
     for n, test in enumerate(tests):
+        #if "cumsum" not in test:
+        #    continue
         print(n, test)
         if ("cast" in test and "FLOAT16" in test) or "test_slice_start_out_of_bounds" in test: 
             print("FAILURE: SKIPPING due to segfault")
@@ -4102,9 +4104,9 @@ def test_onnx_nodes():
                     new_tensor = onnx.TensorProto()
                     with open(tensor, 'rb') as f:
                         new_tensor.ParseFromString(f.read())
-                    if "input" in tensor:
+                    if "input" in tensor.split('/')[-1]:
                         inputs.append(numpy_helper.to_array(new_tensor))
-                    elif "output" in tensor:
+                    elif "output" in tensor.split('/')[-1]:
                         outputs.append(numpy_helper.to_array(new_tensor))
                     else:
                         print(tensor)
@@ -4118,7 +4120,8 @@ def test_onnx_nodes():
         except Exception as e:
             print("------------------TEST FAILURE--------------------")
             print(e)
-    raise
+            #raise e
+    #raise
 
 def test_wrong_input():
     node = helper.make_node(

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4088,8 +4088,6 @@ def test_onnx_nodes():
     tests = sorted(glob.glob("/".join(f.split("/")[0:-1]) + "/backend/test/data/node/*/"))
     failures = 0
     for n, test in enumerate(tests):
-        #if "cumsum" not in test:
-        #    continue
         print(n, test)
         if ("cast" in test and "FLOAT16" in test) or "test_slice_start_out_of_bounds" in test: 
             print("FAILURE: SKIPPING due to segfault")
@@ -4117,6 +4115,10 @@ def test_onnx_nodes():
                 else:
                     for output, val in zip(outputs, tvm_val):
                         tvm.testing.assert_allclose(output, val, rtol=1e-5, atol=1e-5)
+        except tvm.error.OpNotImplemented as e:
+            print("WARNING, missing Op:", e)
+        except NotImplementedError as e:
+            print("WARNING, missing implementation:", e)
         except Exception as e:
             print("------------------TEST FAILURE--------------------")
             print(e)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4088,6 +4088,8 @@ def test_onnx_nodes():
     tests = sorted(glob.glob("/".join(f.split("/")[0:-1]) + "/backend/test/data/node/*/"))
     failures = 0
     for n, test in enumerate(tests):
+        #if "gather" not in test:
+        #    continue
         print(n, test)
         if ("cast" in test and "FLOAT16" in test) or "test_slice_start_out_of_bounds" in test: 
             print("FAILURE: SKIPPING due to segfault")
@@ -4118,12 +4120,11 @@ def test_onnx_nodes():
         except tvm.error.OpNotImplemented as e:
             print("WARNING, missing Op:", e)
         except NotImplementedError as e:
-            print("WARNING, missing implementation:", e)
+            print("WARNING, missing implementation in Op:", e)
         except Exception as e:
             print("------------------TEST FAILURE--------------------")
             print(e)
             #raise e
-    #raise
 
 def test_wrong_input():
     node = helper.make_node(

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4244,8 +4244,7 @@ def test_onnx_nodes(test):
             elif "output" in tensor.split("/")[-1]:
                 outputs.append(numpy_helper.to_array(new_tensor))
             else:
-                print(tensor)
-                raise
+                raise ImportError(str(tensor) + " not labeled as an import or an output")
         tvm_val = get_tvm_output_with_vm(onnx_model, inputs, "llvm", tvm.cpu(0))
         if len(outputs) == 1:
             tvm.testing.assert_allclose(outputs[0], tvm_val, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
We've been hitting a lot of errors running models with ONNX, that has led to a lot of piecewise fixes. This is an attempt to fix the importer more broadly by running the tests onnx ships with pip https://github.com/onnx/onnx/tree/master/onnx/backend/test/data/node

These files contain an onnx graph, input arrays, and expected outputs, so we can test directly against the canonical onnx tests. This PR provides a method to import these tests as parameterized unit tests, execute them, and skip any we know currently fail. I also fixed a lot of low hanging fruit to reduce the number of skipped unit tests.

Future PRs will work to fix the currently skipped tests, and then extend this to GPU.

For reference, this is the pytest result on my system, testing against ONNX 1.6, which is what we have in CI:

`434 passed, 123 skipped, 83 deselected, 1185 warnings in 32.40s`

This adds a lot of tests, but they are all small, so the runtime is actually pretty minuscule, and it improves our ONNX import coverage dramatically.

cc @jwfromm @masahi @jroesch @electriclilies @adelbertc 