### PR TITLE
[crt] fix shift out of type bounds

### DIFF
--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -209,8 +209,9 @@ int SystemLibraryCreate(TVMValue* args, int* type_codes, int num_args, TVMValue*
 
 static TVMFunctionHandle EncodeFunctionHandle(tvm_module_index_t module_index,
                                               tvm_function_index_t function_index) {
-  return (TVMFunctionHandle)((uintptr_t)(
-      ((module_index | 0x8000) << (sizeof(tvm_function_index_t) * 8)) | (function_index | 0x8000)));
+  return (TVMFunctionHandle)(
+      (((uintptr_t)(module_index | 0x8000) << (sizeof(tvm_function_index_t) * 8)) |
+       (function_index | 0x8000)));
 }
 
 static int DecodeFunctionHandle(TVMFunctionHandle handle, tvm_module_index_t* module_index,

--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -366,7 +366,7 @@ int TVMCFuncSetReturn(TVMRetValueHandle ret, TVMValue* value, int* type_code, in
 }
 
 int TVMFuncFree(TVMFunctionHandle func) {
-  // A no-op, since we don't actually allocate anything in GetFunction
+  // A no-op, since we don't actually allocate anything in GetFunction.
   return 0;
 }
 


### PR DESCRIPTION
When running with "-fsanitize=undefined" I got the following error:

    tvm/src/runtime/crt/common/crt_runtime_api.c:213:32: runtime error: left shift of 32770 by 16 places cannot be represented in type 'int'

The expression "module_index | 0x8000" is of type "int" and needs to be casted to unsigned before the shift.

@areusch 