### PR TITLE
[crt] fix heap corruption from bad allocation

### DIFF
--- a/src/runtime/crt/graph_runtime/graph_runtime.c
+++ b/src/runtime/crt/graph_runtime/graph_runtime.c
@@ -967,7 +967,7 @@ int TVMGraphRuntime_SetupStorage(TVMGraphRuntime* runtime) {
   }
 
   // Allocate the space.
-  err = TVMPlatformMemoryAllocate(sizeof(TVMNDArray) * pool_entry_count, alloc_ctx,
+  err = TVMPlatformMemoryAllocate(sizeof(TVMGraphRuntimeStorageEntry) * pool_entry_count, alloc_ctx,
                                   (void**)&runtime->storage_pool);
   if (err != kTvmErrorNoError) {
     fprintf(stderr, "memory allocate error: %08x", err);


### PR DESCRIPTION
The type of runtime->storage_pool was changed at some point from TVMNDArray to TVMGraphRuntimeStorageEntry. This change was not reflected in the call to the allocation for its buffer. If this unclaimed space is allocated to something else, data corruption will happen.

@areusch 