### PR TITLE
Add support for using the VM across the RPC boundary. 

### DIFF
--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -135,7 +135,17 @@ class Executable : public ModuleNode {
    *
    * \return The runtime module that contains the hardware dependent code.
    */
-  runtime::Module GetLib() const { return lib; }
+  runtime::Module GetLib() const { return this->imports_[0]; }
+
+  void SetLib(const runtime::Module& lib) {
+    ICHECK(lib.defined())
+      << "library can not be null";
+
+    ICHECK_EQ(this->imports().size(), 0)
+      << "can only import the library once";
+
+    this->Import(lib);
+  }
 
   /*!
    * \brief Get the arity of the VM Fucntion.
@@ -156,9 +166,6 @@ class Executable : public ModuleNode {
 
   const char* type_key() const final { return "VMExecutable"; }
 
-  /*! \brief The runtime module/library that contains both the host and also the device
-   * code when executing on non-CPU devices. */
-  runtime::Module lib;
   /*! \brief The global constant pool. */
   std::vector<ObjectRef> constants;
   /*! \brief A map from globals (as strings) to their index in the function map. */

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -64,11 +64,16 @@ class Executable : public ModuleNode {
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   /*!
-   * \brief Save the entire executable to a binary stream.
-   * \param stream The binary stream to save to.
+   * \brief Write the Executable to the binary stream in serialized form.
+   * \param stream The binary stream to save the executable to.
    */
   void SaveToBinary(dmlc::Stream* stream) final;
 
+  /*!
+   * \brief Write the Executable to the provided path as a file contianing its serialized content.
+   * \param path The path to write the serialized data to.
+   * \param format The format of the serialized blob.
+   */
   void SaveToFile(const std::string& path, const std::string& format) final;
 
   /*!
@@ -135,18 +140,35 @@ class Executable : public ModuleNode {
    *
    * \return The runtime module that contains the hardware dependent code.
    */
-  runtime::Module GetLib() const { return this->imports_[0]; }
+  runtime::Module GetLib() const {
+    ICHECK_EQ(this->imports_.size(), 1)
+      << "The kernel library must be imported as the only module in an Executable";
 
+    return this->imports_[0];
+  }
+
+  /*!
+   * \brief Set the `lib` module in an executable.
+   *
+   * This allows us to do partial initialization in the case of (de|ser)ialization cases.
+   * This method also ensures correct initialization of library ensuring we only Import a
+   * single library.
+   *
+   * NB: This also provides some abstraction over how libraries are stored as there are plans
+   * to iterate on the way runtime::Module works in the backend of the compiler.
+   */
   void SetLib(const runtime::Module& lib) {
-    ICHECK(lib.defined()) << "library can not be null";
+    ICHECK(lib.defined())
+      << "the provided library can not be null";
 
-    ICHECK_EQ(this->imports().size(), 0) << "can only import the library once";
+    ICHECK_EQ(this->imports().size(), 0)
+      << "you can only import one device specific library";
 
     this->Import(lib);
   }
 
   /*!
-   * \brief Get the arity of the VM Fucntion.
+   * \brief Get the arity of the VMFunction.
    * \param func Function name.
    * \return The number of parameters.
    */

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -140,12 +140,7 @@ class Executable : public ModuleNode {
    *
    * \return The runtime module that contains the hardware dependent code.
    */
-  runtime::Module GetLib() const {
-    ICHECK_EQ(this->imports_.size(), 1)
-        << "The kernel library must be imported as the only module in an Executable";
-
-    return this->imports_[0];
-  }
+  runtime::Module GetLib() const;
 
   /*!
    * \brief Set the `lib` module in an executable.

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -64,6 +64,14 @@ class Executable : public ModuleNode {
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   /*!
+   * \brief Save the entire executable to a binary stream.
+   * \param stream The binary stream to save to.
+   */
+  void SaveToBinary(dmlc::Stream* stream) final;
+
+  void SaveToFile(const std::string& path, const std::string& format) final;
+
+  /*!
    * \brief Serialize the executable into global section, constant section, and
    * code section.
    *
@@ -125,7 +133,7 @@ class Executable : public ModuleNode {
    * \brief Get the `lib` module in an executable. Users have the flexibility to call
    * `export_library` from the frontend to save the library to disk.
    *
-   * \return The runtime module that contains the hardwre dependent code.
+   * \return The runtime module that contains the hardware dependent code.
    */
   runtime::Module GetLib() const { return lib; }
 

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -157,15 +157,7 @@ class Executable : public ModuleNode {
    * NB: This also provides some abstraction over how libraries are stored as there are plans
    * to iterate on the way runtime::Module works in the backend of the compiler.
    */
-  void SetLib(const runtime::Module& lib) {
-    ICHECK(lib.defined())
-      << "the provided library can not be null";
-
-    ICHECK_EQ(this->imports().size(), 0)
-      << "you can only import one device specific library";
-
-    this->Import(lib);
-  }
+  void SetLib(const runtime::Module& lib);
 
   /*!
    * \brief Get the arity of the VMFunction.

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -138,11 +138,9 @@ class Executable : public ModuleNode {
   runtime::Module GetLib() const { return this->imports_[0]; }
 
   void SetLib(const runtime::Module& lib) {
-    ICHECK(lib.defined())
-      << "library can not be null";
+    ICHECK(lib.defined()) << "library can not be null";
 
-    ICHECK_EQ(this->imports().size(), 0)
-      << "can only import the library once";
+    ICHECK_EQ(this->imports().size(), 0) << "can only import the library once";
 
     this->Import(lib);
   }

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -142,7 +142,7 @@ class Executable : public ModuleNode {
    */
   runtime::Module GetLib() const {
     ICHECK_EQ(this->imports_.size(), 1)
-      << "The kernel library must be imported as the only module in an Executable";
+        << "The kernel library must be imported as the only module in an Executable";
 
     return this->imports_[0];
   }

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -269,10 +269,13 @@ class Module(object):
         return self._collect_from_import_tree(is_dso_exportable)
 
     def export_library(self, file_name, fcompile=None, addons=None, workspace_dir=None, **kwargs):
-        """Export the module and its imported device code one library.
+        """
+        Export the module and all imported modules into a single device library.
 
-        This function only works on host llvm modules.
-        It will pack all the imported modules
+        This function only works on host LLVM modules, other runtime::Module
+        subclasses DO NOT work with this API. If you do in fact have an LLVM
+        module, this API will pack the module with all imported modules into
+        a single binary library which can be used with TVM.
 
         Parameters
         ----------

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -272,7 +272,7 @@ class Module(object):
         """
         Export the module and all imported modules into a single device library.
 
-        This function only works on hos LLVM modules, other runtime::Module
+        This function only works on host LLVM modules, other runtime::Module
         subclasses will work with this API but they must support implement
         the save and load mechanisms of modules completely including saving
         from streams and files. This will pack your non-shared library module
@@ -285,8 +285,12 @@ class Module(object):
 
         fcompile : function(target, file_list, kwargs), optional
             The compilation function to use create the final library object during
-            export. For example this is used to link together all produced artifacts
+            export.
+
+            For example, when fcompile=_cc.create_shared, or when it is not supplied but
+            module is "llvm," this is used to link all produced artifacts
             into a final dynamic library.
+
             This behavior is controlled by the type of object exported.
             If fcompile has attribute object_format, will compile host library
             to that format. Otherwise, will use default format "o".

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -272,10 +272,11 @@ class Module(object):
         """
         Export the module and all imported modules into a single device library.
 
-        This function only works on host LLVM modules, other runtime::Module
-        subclasses DO NOT work with this API. If you do in fact have an LLVM
-        module, this API will pack the module with all imported modules into
-        a single binary library which can be used with TVM.
+        This function only works on hos LLVM modules, other runtime::Module
+        subclasses will work with this API but they must support implement
+        the save and load mechanisms of modules completely including saving
+        from streams and files. This will pack your non-shared library module
+        into a single shared library which can later be loaded by TVM.
 
         Parameters
         ----------
@@ -283,13 +284,16 @@ class Module(object):
             The name of the shared library.
 
         fcompile : function(target, file_list, kwargs), optional
-            Compilation function to use create dynamic library.
+            The compilation function to use create the final library object during
+            export. For example this is used to link together all produced artifacts
+            into a final dynamic library.
+            This behavior is controlled by the type of object exported.
             If fcompile has attribute object_format, will compile host library
             to that format. Otherwise, will use default format "o".
 
         workspace_dir : str, optional
-            the path to a directory used to create intermediary
-            artifacts for the process exporting of the library.
+            The path of the directory used to create the intermediate
+            artifacts when exporting the module.
             If this is not provided a temporary dir will be created.
 
         kwargs : dict, optional

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -300,6 +300,26 @@ class VirtualMachine(object):
     POOLED_ALLOCATOR = 2
 
     def __init__(self, exe, device, memory_cfg=None):
+        """
+        Construct a VirtualMachine wrapper class which provides a simple
+        interface over the raw C++ Module based API.
+
+        Parameters
+        ----------
+        exe: Union[Executable, Module]
+            The executable either with the wrapper Python type or the raw runtime.Module.
+
+        device: Union[Device, List[Device]]
+            The device, or devices on which to execute the VM code.
+
+        memory_cfg: Optional[str]
+            The allocator behavior to use for the VM.
+
+        Returns
+        -------
+        vm: VirtualMachine
+            A VM wrapper object.
+        """
         if not isinstance(exe, Executable) and not isinstance(exe, Module):
             raise TypeError(
                 "exe is expected to be the type of Executable, "

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -309,6 +309,14 @@ class VirtualMachine(object):
         exe: Union[Executable, Module]
             The executable either with the wrapper Python type or the raw runtime.Module.
 
+            In most cases this will be the Python wrapper class tvm.runtime.vm.Executable but
+            if you instead get the underlying runtime.Module subclass (i.e `exe.mod`) you
+            can directly pass it to this method.
+
+            This case can occur when doing things such as RPC where TVM's module APIs
+            return the raw modules, not the wrapped modules. This constructor will
+            handle this internally.
+
         device: Union[Device, List[Device]]
             The device, or devices on which to execute the VM code.
 

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -309,7 +309,7 @@ class VirtualMachine(object):
         if not isinstance(exe, Executable):
             exe = Executable(exe)
 
-        self.module = exe.mod["create_vm"]()
+        self.module = exe.mod["vm_load_executable"]()
         self._exec = exe
         self._init = self.module["init"]
         self._invoke = self.module["invoke"]

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -1155,19 +1155,20 @@ void VMCompiler::Codegen() {
 
   auto compile_engine = CompileEngine::Global();
   auto ext_mods = compile_engine->LowerExternalFunctions();
+  runtime::Module lib;
   if (funcs.size() > 0) {
     Map<String, IRModule> build_funcs;
     for (const auto& i : funcs) {
       build_funcs.Set(i.first, i.second);
     }
-    exec_->lib = tvm::build(build_funcs, target_host_);
+    lib = tvm::build(build_funcs, target_host_);
   } else {
     // There is no function handled by TVM. We create a virtual main module
     // to make sure a DSO module will be also available.
-    exec_->lib = codegen::CSourceModuleCreate(";", "", Array<String>{});
+    lib = codegen::CSourceModuleCreate(";", "", Array<String>{});
   }
-  exec_->lib = codegen::CreateMetadataModule(params_, exec_->lib, ext_mods, target_host_);
-  exec_->Import(exec_->lib);
+  lib = codegen::CreateMetadataModule(params_, lib, ext_mods, target_host_);
+  exec_->SetLib(lib);
 }
 
 ExprDeviceMap VMCompiler::AnalyzeContext() const {

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -1167,6 +1167,7 @@ void VMCompiler::Codegen() {
     exec_->lib = codegen::CSourceModuleCreate(";", "", Array<String>{});
   }
   exec_->lib = codegen::CreateMetadataModule(params_, exec_->lib, ext_mods, target_host_);
+  exec_->Import(exec_->lib);
 }
 
 ExprDeviceMap VMCompiler::AnalyzeContext() const {

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -114,8 +114,8 @@ Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream) {
       }
     }
     LOG(FATAL) << "Binary was created using " << type_key
-               << " but a loader of that name is not registered. Available loaders are "
-               << loaders << ". Perhaps you need to recompile with this runtime enabled.";
+               << " but a loader of that name is not registered. Available loaders are " << loaders
+               << ". Perhaps you need to recompile with this runtime enabled.";
   }
 
   return (*f)(static_cast<void*>(stream));

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -113,10 +113,9 @@ Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream) {
         loaders += name.substr(loadkey.size());
       }
     }
-    ICHECK(f != nullptr)
-        << "Binary was created using " << type_key
-        << " but a loader of that name is not registered. Available loaders are " << loaders
-        << ". Perhaps you need to recompile with this runtime enabled.";
+    ICHECK(f != nullptr) << "Binary was created using " << type_key
+                         << " but a loader of that name is not registered. Available loaders are "
+                         << loaders << ". Perhaps you need to recompile with this runtime enabled.";
   }
 
   return (*f)(static_cast<void*>(stream));

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -99,6 +99,29 @@ void InitContextFunctions(std::function<void*(const char*)> fgetsymbol) {
 #undef TVM_INIT_CONTEXT_FUNC
 }
 
+Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream) {
+  std::string loadkey = "runtime.module.loadbinary_";
+  std::string fkey = loadkey + type_key;
+  const PackedFunc* f = Registry::Get(fkey);
+  if (f == nullptr) {
+    std::string loaders = "";
+    for (auto name : Registry::ListNames()) {
+      if (name.rfind(loadkey, 0) == 0) {
+        if (loaders.size() > 0) {
+          loaders += ", ";
+        }
+        loaders += name.substr(loadkey.size());
+      }
+    }
+    ICHECK(f != nullptr)
+        << "Binary was created using " << type_key
+        << " but a loader of that name is not registered. Available loaders are " << loaders
+        << ". Perhaps you need to recompile with this runtime enabled.";
+  }
+
+  return (*f)(static_cast<void*>(stream));
+}
+
 /*!
  * \brief Load and append module blob to module list
  * \param mblob The module blob.
@@ -133,25 +156,7 @@ runtime::Module ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib) {
       ICHECK(stream->Read(&import_tree_row_ptr));
       ICHECK(stream->Read(&import_tree_child_indices));
     } else {
-      std::string loadkey = "runtime.module.loadbinary_";
-      std::string fkey = loadkey + tkey;
-      const PackedFunc* f = Registry::Get(fkey);
-      if (f == nullptr) {
-        std::string loaders = "";
-        for (auto name : Registry::ListNames()) {
-          if (name.rfind(loadkey, 0) == 0) {
-            if (loaders.size() > 0) {
-              loaders += ", ";
-            }
-            loaders += name.substr(loadkey.size());
-          }
-        }
-        ICHECK(f != nullptr)
-            << "Binary was created using " << tkey
-            << " but a loader of that name is not registered. Available loaders are " << loaders
-            << ". Perhaps you need to recompile with this runtime enabled.";
-      }
-      Module m = (*f)(static_cast<void*>(stream));
+      auto m = LoadModuleFromBinary(tkey, stream);
       modules.emplace_back(m);
     }
   }

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -106,16 +106,16 @@ Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream) {
   if (f == nullptr) {
     std::string loaders = "";
     for (auto name : Registry::ListNames()) {
-      if (name.rfind(loadkey, 0) == 0) {
+      if (name.find(loadkey, 0) == 0) {
         if (loaders.size() > 0) {
           loaders += ", ";
         }
         loaders += name.substr(loadkey.size());
       }
     }
-    ICHECK(f != nullptr) << "Binary was created using " << type_key
-                         << " but a loader of that name is not registered. Available loaders are "
-                         << loaders << ". Perhaps you need to recompile with this runtime enabled.";
+    LOG(FATAL) << "Binary was created using " << type_key
+               << " but a loader of that name is not registered. Available loaders are "
+               << loaders << ". Perhaps you need to recompile with this runtime enabled.";
   }
 
   return (*f)(static_cast<void*>(stream));

--- a/src/runtime/library_module.h
+++ b/src/runtime/library_module.h
@@ -32,6 +32,9 @@
 
 namespace tvm {
 namespace runtime {
+
+Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream);
+
 /*!
  * \brief Library is the common interface
  *  for storing data in the form of shared libaries.

--- a/src/runtime/library_module.h
+++ b/src/runtime/library_module.h
@@ -29,6 +29,7 @@
 #include <tvm/runtime/module.h>
 
 #include <functional>
+#include <string>
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/library_module.h
+++ b/src/runtime/library_module.h
@@ -33,6 +33,14 @@
 namespace tvm {
 namespace runtime {
 
+/*! \brief Load a module with the given type key directly from the stream.
+ *  This function wraps the registry mechanism used to store type based deserializers
+ *  for each runtime::Module sub-class.
+ *
+ * \param type_key The type key of the serialized module.
+ * \param stream A pointer to the stream containing the serialized module.
+ * \return module The deserialized module.
+*/
 Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream);
 
 /*!

--- a/src/runtime/library_module.h
+++ b/src/runtime/library_module.h
@@ -41,7 +41,7 @@ namespace runtime {
  * \param type_key The type key of the serialized module.
  * \param stream A pointer to the stream containing the serialized module.
  * \return module The deserialized module.
-*/
+ */
 Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream);
 
 /*!

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -484,7 +484,6 @@ void LoadHeader(dmlc::Stream* strm) {
 }
 
 runtime::Module Executable::Load(const std::string& code, const runtime::Module lib) {
-  std::cout << "code: " << code.size() << std::endl;
   auto exec = make_object<Executable>();
 
   // Support null-initialization of lib, to enable initialization during

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -483,17 +483,26 @@ void LoadHeader(dmlc::Stream* strm) {
   STREAM_CHECK(version == TVM_VERSION, "version");
 }
 
+void Executable::SetLib(const runtime::Module& lib) {
+    ICHECK(lib.defined())
+      << "the provided library can not be null";
+
+    ICHECK_EQ(this->imports_.size(), 0)
+        << "A VMExecutable should never have more than one import inside an the executable, \n"
+        << "the first import should *always* be the library containing"
+        << "the platform specific kernel code";
+
+    this->Import(lib);
+  }
+
+
 runtime::Module Executable::Load(const std::string& code, const runtime::Module lib) {
   auto exec = make_object<Executable>();
 
   // Support null-initialization of lib, to enable initialization during
   // deserialization before we have we have deserialized the imports.
   if (lib.defined()) {
-    ICHECK_EQ(exec->imports_.size(), 0)
-        << "A VMExecutable should never have more than one import inside an the executable, \n"
-        << "the first import should *always* be the library containing"
-        << "the platform specific kernel code";
-    exec->Import(lib);
+    exec->SetLib(lib);
   }
 
   exec->code_ = code;

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -37,9 +37,9 @@
 #include <utility>
 #include <vector>
 
-#include "serialize_utils.h"
-#include "../library_module.h"
 #include "../file_utils.h"
+#include "../library_module.h"
+#include "serialize_utils.h"
 
 namespace tvm {
 namespace runtime {
@@ -491,9 +491,9 @@ runtime::Module Executable::Load(const std::string& code, const runtime::Module 
   // deserialization before we have we have deserialized the imports.
   if (lib.defined()) {
     ICHECK_EQ(exec->imports_.size(), 0)
-      << "A VMExecutable should never have more than one import inside an the executable, \n"
-      << "the first import should *always* be the library containing"
-      << "the platform specific kernel code";
+        << "A VMExecutable should never have more than one import inside an the executable, \n"
+        << "the first import should *always* be the library containing"
+        << "the platform specific kernel code";
     exec->Import(lib);
   }
 
@@ -789,8 +789,7 @@ void Executable::SaveToBinary(dmlc::Stream* stream) {
   std::string code(code_bytes.data, code_bytes.size);
   stream->Write(code);
 
-  ICHECK(this->imports()[0].defined())
-    << "the library must be imported before serialization";
+  ICHECK(this->imports()[0].defined()) << "the library must be imported before serialization";
 }
 
 Module ExecutableLoadBinary(void* strm) {
@@ -809,10 +808,9 @@ void Executable::SaveToFile(const std::string& path, const std::string& format) 
   SaveBinaryToFile(path, data);
 }
 
-TVM_REGISTER_GLOBAL("runtime.module.loadbinary_VMExecutable")
-    .set_body_typed(ExecutableLoadBinary);
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_VMExecutable").set_body_typed(ExecutableLoadBinary);
 
-  // Load module from module.
+// Load module from module.
 Module ExecutableLoadFile(const std::string& file_name, const std::string& format) {
   std::string data;
   LoadBinaryFromFile(file_name, &data);

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -484,17 +484,15 @@ void LoadHeader(dmlc::Stream* strm) {
 }
 
 void Executable::SetLib(const runtime::Module& lib) {
-    ICHECK(lib.defined())
-      << "the provided library can not be null";
+  ICHECK(lib.defined()) << "the provided library can not be null";
 
-    ICHECK_EQ(this->imports_.size(), 0)
-        << "A VMExecutable should never have more than one import inside an the executable, \n"
-        << "the first import should *always* be the library containing"
-        << "the platform specific kernel code";
+  ICHECK_EQ(this->imports_.size(), 0)
+      << "A VMExecutable should never have more than one import inside an the executable, \n"
+      << "the first import should *always* be the library containing"
+      << "the platform specific kernel code";
 
-    this->Import(lib);
-  }
-
+  this->Import(lib);
+}
 
 runtime::Module Executable::Load(const std::string& code, const runtime::Module lib) {
   auto exec = make_object<Executable>();

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -483,6 +483,17 @@ void LoadHeader(dmlc::Stream* strm) {
   STREAM_CHECK(version == TVM_VERSION, "version");
 }
 
+runtime::Module Executable::GetLib() const {
+  ICHECK_LE(this->imports_.size(), 1)
+      << "The kernel library must be imported as the only module in an Executable";
+
+  if (this->imports().size() == 0) {
+    return Module(nullptr);
+  } else {
+    return this->imports_[0];
+  }
+}
+
 void Executable::SetLib(const runtime::Module& lib) {
   ICHECK(lib.defined()) << "the provided library can not be null";
 

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -281,23 +281,11 @@ void VirtualMachine::LoadExecutable(const Executable* exec) {
   ICHECK(exec) << "The executable is not created yet.";
   exec_ = exec;
 
-  runtime::Module lib;
-  if (exec_->lib.defined()) {
-    lib = exec_->lib;
-  } else {
-    ICHECK(exec_->imports().size() > 0)
-      << "fix";
-    lib = exec_->imports()[0];
-  }
+  runtime::Module lib = exec_->GetLib();
 
-  // Get the list of packed functions.
-  ICHECK(!exec->primitive_map.empty())
-      << "runtime module primitive map is empty"
-      << "\n";
-
-  ICHECK(lib.operator->())
-      << "library is null"
-      << "\n";
+  ICHECK(exec->primitive_map.empty() || lib.operator->())
+      << "If the executable has declared primitive functions, the"
+      << "generated kernel library must non-be null.";
 
   for (const auto& it : exec_->primitive_map) {
     const auto& packed_name = it.first;

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -281,11 +281,24 @@ void VirtualMachine::LoadExecutable(const Executable* exec) {
   ICHECK(exec) << "The executable is not created yet.";
   exec_ = exec;
 
-  runtime::Module lib = exec_->lib;
+  runtime::Module lib;
+  if (exec_->lib.defined()) {
+    lib = exec_->lib;
+  } else {
+    ICHECK(exec_->imports().size() > 0)
+      << "fix";
+    lib = exec_->imports()[0];
+  }
+
   // Get the list of packed functions.
-  ICHECK(exec->primitive_map.empty() || lib.operator->())
-      << "runtime module should have been built for primitive functions"
+  ICHECK(!exec->primitive_map.empty())
+      << "runtime module primitive map is empty"
       << "\n";
+
+  ICHECK(lib.operator->())
+      << "library is null"
+      << "\n";
+
   for (const auto& it : exec_->primitive_map) {
     const auto& packed_name = it.first;
     auto packed_index = static_cast<size_t>(it.second);

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -801,6 +801,7 @@ def test_constant_shape_with_external_codegen():
     opt_mod, _ = comp.optimize(mod, target="llvm")
     assert "shape_func" in opt_mod.astext(False)
 
+
 def test_vm_rpc():
     target = "llvm"
     target_host = "llvm"
@@ -824,6 +825,7 @@ def test_vm_rpc():
     input_tensor = tvm.nd.array(np_input, ctx)
     out = vm_factory.invoke("main", [input_tensor])
     np.testing.assert_allclose(out.asnumpy(), np_input + np_input)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -803,27 +803,43 @@ def test_constant_shape_with_external_codegen():
 
 
 def test_vm_rpc():
+    """
+    This test checks to make sure you can export a VMExecutable,
+    upload it to a remote machine using RPC and then execute it
+    on the other machine.
+    """
     target = "llvm"
     target_host = "llvm"
 
+    # Build a IRModule.
     x = relay.var("x", shape=(10, 1))
     f = relay.Function([x], x + x)
     mod = IRModule.from_expr(f)
+
+    # Compile to VMExecutable.
     vm_exec = vm.compile(mod, target=target, target_host=target_host)
 
+    # Export to Disk
     temp = utils.tempdir()
     path = temp.relpath("vm_library.so")
     vm_exec.mod.export_library(path)
 
+    # Use LocalRPC for testing.
     remote = rpc.LocalSession()
+
+    # Upload the serialized Executable.
     remote.upload(path)
+    # Get a handle to remote Executable.
     rexec = remote.load_module("vm_library.so")
 
     ctx = remote.cpu()
+    # Build a VM out of the executable and context.
     vm_factory = runtime.vm.VirtualMachine(rexec, ctx)
     np_input = np.random.uniform(size=(10, 1)).astype("float32")
     input_tensor = tvm.nd.array(np_input, ctx)
+    # Invoke its "main" function.
     out = vm_factory.invoke("main", [input_tensor])
+    # Check the result.
     np.testing.assert_allclose(out.asnumpy(), np_input + np_input)
 
 


### PR DESCRIPTION
Refactor some of the internals of VM in order to enable use across the RPC boundary. I need to remove the use of the `lib` field to instead use the imports completely still.

cc @zhiics @adelbertc @tmoreau89 @tkonolige @jwfromm @michalpiszczek 