### PR TITLE
[RUNTIME][WEB] Cleanup logging for web runtime.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ crttest:
 	@mkdir -p build && cd build && cmake .. && $(MAKE) crttest
 
 # EMCC; Web related scripts
-EMCC_FLAGS= -std=c++11 -DDMLC_LOG_STACK_TRACE=0\
+EMCC_FLAGS= -std=c++11\
 	-Oz -s RESERVED_FUNCTION_POINTERS=2 -s MAIN_MODULE=1 -s NO_EXIT_RUNTIME=1\
 	-s TOTAL_MEMORY=1073741824\
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="['addFunction','cwrap','getValue','setValue']"\

--- a/apps/android_camera/app/src/main/jni/Application.mk
+++ b/apps/android_camera/app/src/main/jni/Application.mk
@@ -31,7 +31,7 @@ include $(config)
 APP_ABI ?= all
 APP_STL := c++_shared
 
-APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++14 -Oz -frtti
+APP_CPPFLAGS += -DTVM_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++14 -Oz -frtti
 ifeq ($(USE_OPENCL), 1)
     APP_CPPFLAGS += -DTVM_OPENCL_RUNTIME=1
 endif

--- a/apps/android_deploy/app/src/main/jni/Application.mk
+++ b/apps/android_deploy/app/src/main/jni/Application.mk
@@ -27,7 +27,7 @@ include $(config)
 
 APP_STL := c++_static
 
-APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++14 -Oz -frtti
+APP_CPPFLAGS += -DTVM_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++14 -Oz -frtti
 ifeq ($(USE_OPENCL), 1)
 	APP_CPPFLAGS += -DTVM_OPENCL_RUNTIME=1
 endif

--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -31,7 +31,7 @@ include $(config)
 APP_ABI ?= armeabi-v7a arm64-v8a x86 x86_64 mips
 APP_STL := c++_shared
 
-APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++14 -Oz -frtti
+APP_CPPFLAGS += -DTVM_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++14 -Oz -frtti
 ifeq ($(USE_OPENCL), 1)
     APP_CPPFLAGS += -DTVM_OPENCL_RUNTIME=1
 endif

--- a/include/tvm/runtime/logging.h
+++ b/include/tvm/runtime/logging.h
@@ -69,7 +69,7 @@
 /*!
  * \brief Whether or not customize the logging output.
  *  If log customize is enabled, the user must implement
- *  runtime::detail::LogFatalImpl and runtime::detail::LogMessageImpl
+ *  tvm::runtime::detail::LogFatalImpl and tvm::runtime::detail::LogMessageImpl.
  */
 #ifndef TVM_LOG_CUSTOMIZE
 #define TVM_LOG_CUSTOMIZE 0

--- a/include/tvm/runtime/logging.h
+++ b/include/tvm/runtime/logging.h
@@ -48,11 +48,31 @@
 #endif
 
 /*!
+ * \brief Whether or not enable backtrace logging during a
+ *        fatal error.
+ *
+ * \note TVM won't depend on LIBBACKTRACE or other exec_info
+ *       library when this option is disabled.
+ */
+#ifndef TVM_LOG_STACK_TRACE
+#define TVM_LOG_STACK_TRACE 1
+#endif
+
+/*!
  * \brief Whether or not use libbacktrace library
  *        for getting backtrace information
  */
 #ifndef TVM_USE_LIBBACKTRACE
 #define TVM_USE_LIBBACKTRACE 0
+#endif
+
+/*!
+ * \brief Whether or not customize the logging output.
+ *  If log customize is enabled, the user must implement
+ *  runtime::detail::LogFatalImpl and runtime::detail::LogMessageImpl
+ */
+#ifndef TVM_LOG_CUSTOMIZE
+#define TVM_LOG_CUSTOMIZE 0
 #endif
 
 // a technique that enables overriding macro names on the number of parameters. This is used
@@ -152,13 +172,15 @@ TVM_DLL std::string Backtrace();
 /*! \brief Base error type for TVM. Wraps a string message. */
 class Error : public ::dmlc::Error {  // for backwards compatibility
  public:
-  /*! \brief Construct an error.
+  /*!
+   * \brief Construct an error.
    * \param s The message to be displayed with the error.
    */
   explicit Error(const std::string& s) : ::dmlc::Error(s) {}
 };
 
-/*! \brief Error type for errors from CHECK, ICHECK, and LOG(FATAL). This error
+/*!
+ * \brief Error type for errors from CHECK, ICHECK, and LOG(FATAL). This error
  * contains a backtrace of where it occured.
  */
 class InternalError : public Error {
@@ -214,10 +236,60 @@ class InternalError : public Error {
   std::string full_message_;  // holds the full error string
 };
 
+/*! \brief Internal implementation */
 namespace detail {
-#ifndef TVM_LOG_CUSTOMIZE
+// Provide support for customized logging.
+#if TVM_LOG_CUSTOMIZE
+/*!
+ * \brief Custom implementations of LogFatal.
+ *
+ * \sa TVM_LOG_CUSTOMIZE
+ */
+TVM_DLL void LogFatalImpl(const std::string& file, int lineno, const std::string& message);
 
-/*! \brief Class to accumulate an error message and throw it. Do not use
+/*!
+ * \brief Custom implementations of LogMessage.
+ *
+ * \sa TVM_LOG_CUSTOMIZE
+ */
+TVM_DLL void LogMessageImpl(const std::string& file, int lineno, const std::string& message);
+
+/*!
+ * \brief Class to accumulate an error message and throw it. Do not use
+ * directly, instead use LOG(FATAL).
+ */
+class LogFatal {
+ public:
+  LogFatal(const std::string& file, int lineno) : file_(file), lineno_(lineno) {}
+  ~LogFatal() TVM_THROW_EXCEPTION { LogFatalImpl(file_, lineno_, stream_.str()); }
+  std::ostringstream& stream() { return stream_; }
+
+ private:
+  std::ostringstream stream_;
+  std::string file_;
+  int lineno_;
+};
+
+/*!
+ * \brief Class to accumulate an log message. Do not use directly, instead use
+ * LOG(INFO), LOG(WARNING), LOG(ERROR).
+ */
+class LogMessage {
+ public:
+  LogMessage(const std::string& file, int lineno) : file_(file), lineno_(lineno) {}
+  ~LogMessage() { LogMessageImpl(file_, lineno_, stream_.str()); }
+  std::ostringstream& stream() { return stream_; }
+
+ private:
+  std::string file_;
+  int lineno_;
+  std::ostringstream stream_;
+};
+
+#else
+
+/*!
+ * \brief Class to accumulate an error message and throw it. Do not use
  * directly, instead use LOG(FATAL).
  */
 class LogFatal {
@@ -239,7 +311,8 @@ class LogFatal {
   int lineno_;
 };
 
-/*! \brief Class to accumulate an log message. Do not use directly, instead use
+/*!
+ * \brief Class to accumulate an log message. Do not use directly, instead use
  * LOG(INFO), LOG(WARNING), LOG(ERROR).
  */
 class LogMessage {
@@ -253,34 +326,6 @@ class LogMessage {
   std::ostringstream& stream() { return stream_; }
 
  private:
-  std::ostringstream stream_;
-};
-#else
-// Custom implementations of LogFatal and LogMessage that allow the user to
-// override handling of the message. The user must implement LogFatalImpl and LogMessageImpl
-void LogFatalImpl(const std::string& file, int lineno, const std::string& message);
-class LogFatal {
- public:
-  LogFatal(const std::string& file, int lineno) : file_(file), lineno_(lineno) {}
-  ~LogFatal() TVM_THROW_EXCEPTION { LogFatalImpl(file_, lineno_, stream_.str()); }
-  std::ostringstream& stream() { return stream_; }
-
- private:
-  std::ostringstream stream_;
-  std::string file_;
-  int lineno_;
-};
-
-void LogMessageImpl(const std::string& file, int lineno, const std::string& message);
-class LogMessage {
- public:
-  LogMessage(const std::string& file, int lineno) : file_(file), lineno_(lineno) {}
-  ~LogMessage() { LogMessageImpl(file_, lineno_, stream_.str()); }
-  std::ostringstream& stream() { return stream_; }
-
- private:
-  std::string file_;
-  int lineno_;
   std::ostringstream stream_;
 };
 #endif

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#if TVM_LOG_STACK_TRACE
 #if TVM_USE_LIBBACKTRACE
 
 #include <backtrace.h>
@@ -150,4 +151,15 @@ std::string Backtrace() { return dmlc::StackTrace(); }
 }  // namespace runtime
 }  // namespace tvm
 
-#endif
+#endif  // TVM_USE_LIBBACKTRACE
+#else
+
+#include <string>
+
+namespace tvm {
+namespace runtime {
+// stacktrace logging is completely disabled
+std::string Backtrace() { return ""; }
+}  // namespace runtime
+}  // namespace tvm
+#endif  // TVM_LOG_STACK_TRACE

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -16,18 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <tvm/runtime/logging.h>
+
+#include <string>
 
 #if TVM_LOG_STACK_TRACE
 #if TVM_USE_LIBBACKTRACE
 
 #include <backtrace.h>
 #include <cxxabi.h>
-#include <tvm/runtime/logging.h>
 
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <string>
 #include <vector>
 
 namespace tvm {
@@ -142,8 +143,6 @@ std::string Backtrace() {
 
 #include <dmlc/logging.h>
 
-#include <string>
-
 namespace tvm {
 namespace runtime {
 // Fallback to the dmlc implementation when backtrace is not available.
@@ -153,8 +152,6 @@ std::string Backtrace() { return dmlc::StackTrace(); }
 
 #endif  // TVM_USE_LIBBACKTRACE
 #else
-
-#include <string>
 
 namespace tvm {
 namespace runtime {

--- a/web/apps/node/example.js
+++ b/web/apps/node/example.js
@@ -31,7 +31,8 @@ const wasmSource = fs.readFileSync(path.join(wasmPath, "tvmjs_runtime.wasm"));
 // the async version of the API.
 tvmjs.instantiate(wasmSource, new EmccWASI())
 .then((tvm) => {
+    const log_info = tvm.getGlobalFunc("testing.log_info_str");
+    log_info("hello world");
     // List all the global functions from the runtime.
     console.log("Runtime functions using EmccWASI\n", tvm.listGlobalFuncNames());
 });
-

--- a/web/emcc/tvmjs_support.cc
+++ b/web/emcc/tvmjs_support.cc
@@ -25,14 +25,10 @@
  */
 
 // configurations for tvm logging
-#define DMLC_LOG_CUSTOMIZE 0
-#define DMLC_LOG_STACK_TRACE 0
-#define DMLC_LOG_DEBUG 0
-#define DMLC_LOG_NODATE 1
-#define DMLC_LOG_FATAL_THROW 0
+#define TVM_LOG_STACK_TRACE 0
 #define TVM_LOG_DEBUG 0
+#define TVM_LOG_CUSTOMIZE 1
 #define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
-#define TVM_USE_LIBBACKTRACE 0
 
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/container.h>

--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -23,14 +23,10 @@
  */
 
 // configurations for tvm logging
-#define DMLC_LOG_CUSTOMIZE 0
-#define DMLC_LOG_STACK_TRACE 0
-#define DMLC_LOG_DEBUG 0
-#define DMLC_LOG_NODATE 1
-#define DMLC_LOG_FATAL_THROW 0
+#define TVM_LOG_STACK_TRACE 0
 #define TVM_LOG_DEBUG 0
+#define TVM_LOG_CUSTOMIZE 1
 #define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
-#define TVM_USE_LIBBACKTRACE 0
 
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/logging.h>
@@ -40,9 +36,11 @@
 #include "src/runtime/file_utils.cc"
 #include "src/runtime/graph/graph_runtime.cc"
 #include "src/runtime/library_module.cc"
+#include "src/runtime/logging.cc"
 #include "src/runtime/module.cc"
 #include "src/runtime/ndarray.cc"
 #include "src/runtime/object.cc"
+#include "src/runtime/profiling.cc"
 #include "src/runtime/registry.cc"
 #include "src/runtime/rpc/rpc_channel.cc"
 #include "src/runtime/rpc/rpc_endpoint.cc"
@@ -67,9 +65,29 @@ int TVMBackendParallelBarrier(int task_id, TVMParallelGroupEnv* penv) { return 0
 // --- Environment PackedFuncs for testing ---
 namespace tvm {
 namespace runtime {
+namespace detail {
+// Override logging mechanism
+void LogFatalImpl(const std::string& file, int lineno, const std::string& message) {
+  std::cerr << "[FATAL] " << file << ":" << lineno << ": " << message << std::endl;
+  abort();
+}
+
+void LogMessageImpl(const std::string& file, int lineno, const std::string& message) {
+  std::cout << "[INFO] " << file << ":" << lineno << ": " << message << std::endl;
+}
+
+}  // namespace detail
 
 TVM_REGISTER_GLOBAL("testing.echo").set_body([](TVMArgs args, TVMRetValue* ret) {
   *ret = args[0];
+});
+
+TVM_REGISTER_GLOBAL("testing.log_info_str").set_body([](TVMArgs args, TVMRetValue* ret) {
+  LOG(INFO) << args[0].operator String();
+});
+
+TVM_REGISTER_GLOBAL("testing.log_fatal_str").set_body([](TVMArgs args, TVMRetValue* ret) {
+  LOG(FATAL) << args[0].operator String();
 });
 
 TVM_REGISTER_GLOBAL("testing.add_one").set_body_typed([](int x) { return x + 1; });

--- a/web/emcc/webgpu_runtime.cc
+++ b/web/emcc/webgpu_runtime.cc
@@ -23,12 +23,10 @@
  */
 
 // configurations for tvm logging
+#define TVM_LOG_STACK_TRACE 0
 #define TVM_LOG_DEBUG 0
+#define TVM_LOG_CUSTOMIZE 1
 #define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
-#define TVM_BACKTRACE_DISABLED 1
-#define TVM_LOG_DEBUG 0
-#define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
-#define TVM_USE_LIBBACKTRACE 0
 
 #include <dmlc/thread_local.h>
 #include <tvm/runtime/c_runtime_api.h>
@@ -45,18 +43,6 @@
 
 namespace tvm {
 namespace runtime {
-namespace detail {
-// Override logging mechanism
-void LogFatalImpl(const std::string& file, int lineno, const std::string& message) {
-  std::cerr << file << ":" << lineno << ": " << message << std::endl;
-  abort();
-}
-
-void LogMessageImpl(const std::string& file, int lineno, const std::string& message) {
-  std::cerr << file << ":" << lineno << ": " << message << std::endl;
-}
-
-}  // namespace detail
 
 /*! \brief Thread local workspace */
 class WebGPUThreadEntry {

--- a/web/tests/node/test_packed_func.js
+++ b/web/tests/node/test_packed_func.js
@@ -122,3 +122,9 @@ test("NDArrayCbArg", () => {
   fcheck(x);
   assert(use_count(x) == 1);
 });
+
+test("Logging", () => {
+  const log_info = tvm.getGlobalFunc("testing.log_info_str");
+  log_info("helow world")
+  log_info.dispose();
+});


### PR DESCRIPTION
The log(info) stops working for web runtime due to the usage of time
function.

- Introduce TVM_LOG_CUSTOMIZE anf TVM_LOG_STACK_TRACE.
- Reorganize the log customization code to wasm_runtime(so non-gpu usecase can apply).
- Update the testcase to cover the logging.
