### PR TITLE
[Frontend][Keras] Fix Dense with 3d inputs

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -250,7 +250,7 @@ def _convert_dense(inexpr, keras_layer, etab):
             raise tvm.error.OpAttributeInvalid(
                 "Input shape {} is not valid for operator Dense.".format(input_shape)
             )
-        inexpr = _op.squeeze(inexpr, axis=0)
+        inexpr = _op.squeeze(inexpr, axis=[0])
     out = _op.nn.dense(data=inexpr, **params)
     if keras_layer.use_bias:
         bias = etab.new_const(weightList[1])

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -200,7 +200,7 @@ class TestKeras:
         verify_keras_frontend(keras_model)
         # RNN dense
         data = keras.layers.Input(shape=(1, 1, 32))
-        x = keras.layers.Dense(32, activation="relu", kernel_initializer="uniform")(x)
+        x = keras.layers.Dense(32, activation="relu", kernel_initializer="uniform")(data)
         keras_model = keras.models.Model(data, x)
         verify_keras_frontend(keras_model)
 

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -199,10 +199,10 @@ class TestKeras:
         keras_model = keras.models.Model(data, x)
         verify_keras_frontend(keras_model)
         # RNN dense
-        data = keras.layers.Input(shape=(1, 1, 32))
+        data = keras.layers.Input(shape=(1, 32))
         x = keras.layers.Dense(32, activation="relu", kernel_initializer="uniform")(data)
         keras_model = keras.models.Model(data, x)
-        verify_keras_frontend(keras_model)
+        verify_keras_frontend(keras_model, need_transpose=False)
 
     def test_forward_permute(self, keras):
         data = keras.layers.Input(shape=(2, 3, 4))

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -198,6 +198,11 @@ class TestKeras:
         x = keras.layers.Dense(10, activation="relu", kernel_initializer="uniform")(x)
         keras_model = keras.models.Model(data, x)
         verify_keras_frontend(keras_model)
+        # RNN dense
+        data = keras.layers.Input(shape=(1, 1, 32))
+        x = keras.layers.Dense(32, activation="relu", kernel_initializer="uniform")(x)
+        keras_model = keras.models.Model(data, x)
+        verify_keras_frontend(keras_model)
 
     def test_forward_permute(self, keras):
         data = keras.layers.Input(shape=(2, 3, 4))


### PR DESCRIPTION
Squeeze takes a list of ints, but keras frontend had a case where it used a single int which caused the following error:

```
TVMError: In function relay.op._make.squeeze: error while converting argument 1: [18:39:52] /home/ubuntu/incubator-tvm/include/tvm/runtime/packed_func.h:1618: ----------------------------------
-----------------------------         
An internal invariant was violated during the execution of TVM.
Please read TVM's error reporting guidelines.   
More details can be found here: https://discuss.tvm.ai/t/error-reporting/7793.
---------------------------------------------------------------
                                                 
  Check failed: type_code_ == kTVMObjectHandle: expected Object but got int
```