### PR TITLE
Fix typo in include/tvm/runtime/crt/crt.h and NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1635,7 +1635,7 @@ Rust language support in TVM includes two parts. 1. The frontend wraps the curre
 * [topi] enable fp16 sort for arm (#4084)
 * Add OpenOCD Low-Level Device (RISC-V Support) (#3756)
 * Add wave 32 bc for AMD ROCm backend (#3984)
-* [RUTNIME] Support C++ RPC (#4281)
+* [RUNTIME] Support C++ RPC (#4281)
 * [TOPI][OP] Support Faster-RCNN Proposal OP on CPU (#4297)
 * [TVM][RUNTIME] A minimum example to generate external library wrappers for DSOModule (#4280)
 

--- a/include/tvm/runtime/crt/crt.h
+++ b/include/tvm/runtime/crt/crt.h
@@ -36,7 +36,7 @@ extern "C" {
  * \brief Initialize various data structures used by the runtime.
  * Prior to calling this, any initialization needed to support TVMPlatformMemory* functions should
  * be completed.
- * \return An error code describing the outcome of intialization. Generally, initialization
+ * \return An error code describing the outcome of initialization. Generally, initialization
  *     is only expected to fail due to a misconfiguration.
  */
 tvm_crt_error_t TVMInitializeRuntime();

--- a/include/tvm/runtime/crt/crt.h
+++ b/include/tvm/runtime/crt/crt.h
@@ -34,7 +34,7 @@ extern "C" {
 
 /*!
  * \brief Initialize various data structures used by the runtime.
- * Prior to calling this, any initialization needed to support TVMPlatformMemory* functions shoudl
+ * Prior to calling this, any initialization needed to support TVMPlatformMemory* functions should
  * be completed.
  * \return An error code describing the outcome of intialization. Generally, initialization
  *     is only expected to fail due to a misconfiguration.

--- a/include/tvm/runtime/crt/crt.h
+++ b/include/tvm/runtime/crt/crt.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /*!
- * \brief Initialize various data structures used by the rutnime.
+ * \brief Initialize various data structures used by the runtime.
  * Prior to calling this, any initialization needed to support TVMPlatformMemory* functions shoudl
  * be completed.
  * \return An error code describing the outcome of intialization. Generally, initialization


### PR DESCRIPTION
Fix typo in include/tvm/runtime/crt/crt.h and NEWS.md
```
- rutnime -> runtime
```
