### PR TITLE
[µTMV] apps: Fix Zephyr code example for STM32F746 boards

### DIFF
--- a/apps/microtvm/zephyr/demo_runtime/boards/stm32f746g_disco.conf
+++ b/apps/microtvm/zephyr/demo_runtime/boards/stm32f746g_disco.conf
@@ -15,16 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# This file is specific to the STM32F746 Nucleo board.
+# This file is specific to the STM32F746G Discovery board.
 
 # For intrinsics used by generated optimized operators.
 CONFIG_CMSIS_DSP=y
 
-# For operations that stack allocates a large float array.
-CONFIG_MAIN_STACK_SIZE=1536
-
 # For random number generation.
 CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
 
 # For debugging.
-CONFIG_LED=y
+CONFIG_LED=n

--- a/apps/microtvm/zephyr/demo_runtime/src/main.c
+++ b/apps/microtvm/zephyr/demo_runtime/src/main.c
@@ -214,15 +214,11 @@ tvm_crt_error_t TVMPlatformTimerStop(double* elapsed_time_seconds) {
 }
 
 // Ring buffer used to store data read from the UART on rx interrupt.
-#if BOARD == qemu_x86
 #define RING_BUF_SIZE_BYTES 4 * 1024
-#else
-#define RING_BUF_SIZE_BYTES 1 * 1024
-#endif
 RING_BUF_DECLARE(uart_rx_rbuf, RING_BUF_SIZE_BYTES);
 
 // Small buffer used to read data from the UART into the ring buffer.
-static uint8_t uart_data[32];
+static uint8_t uart_data[8];
 
 // UART interrupt callback.
 void uart_irq_cb(const struct device* dev, void* user_data) {

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -134,6 +134,7 @@ ALLOW_SPECIFIC_FILE = {
     "apps/microtvm/zephyr/demo_runtime/boards/nrf5340dk_nrf5340_cpuapp.conf",
     "apps/microtvm/zephyr/demo_runtime/boards/nucleo_f746zg.conf",
     "apps/microtvm/zephyr/demo_runtime/boards/qemu_x86.conf",
+    "apps/microtvm/zephyr/demo_runtime/boards/stm32f746g_disco.conf",
     "apps/microtvm/zephyr/demo_runtime/qemu-hack/qemu-system-i386",
     # microTVM Virtual Machines
     "apps/microtvm/reference-vm/zephyr/Vagrantfile",

--- a/tutorials/micro/micro_tflite.py
+++ b/tutorials/micro/micro_tflite.py
@@ -224,7 +224,7 @@ opts = tvm.micro.default_options(
 #     from tvm.micro.contrib import zephyr
 #
 #     repo_root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], encoding='utf-8').strip()
-#     project_dir = f"{repo_root}/tests/micro/qemu/zephyr-runtime"
+#     project_dir = os.path.join(repo_root, "apps", "microtvm", "zephyr", "demo_runtime")
 #     compiler = zephyr.ZephyrCompiler(
 #         project_dir=project_dir,
 #         board=BOARD if "stm32f746" in str(TARGET) else "qemu_x86",


### PR DESCRIPTION
Hi,

Could the following changes be reviewed please?

They aim to make microTVM (HEAD) work again for STM32F746 disco board.

Commit c39a6e25d "Clean up uTVM demo runtime, add ONNX model test and
tutorial (#7557)" changed the location of the Zephyr code example to
apps/ so this commit updates the tutorial examples under tutorials/micro
to reflect the new location where src/main.c resides.

Since commit c39a6e25d also split Zephyr configuration per boards,
under project's boards/, this commits also adds a proper config for the
STM32F746 Discovery board and fixes a nit in the comment in
boards/nucleo_f746zg.conf. It also removes CONFIG_MAIN_STACK_SIZE=50 for
disco and nucleo boards since the MCUs for both boads are Cortex-m7
based, not Contex-m33.

For the new boards/stm32f746g_disco.conf board config file

CONFIG_TEST_RANDOM_GENERATOR=y is set

otherwise when CONFIG_ENTROPY_GENERATOR=y linkage will fail with:

rand32.h:33: undefined reference to `z_impl_sys_rand32_get'

Finally this commit sets the UART ring buffer size back to 512 bytes,
only for disco and nucleo boards, otherwise the new value introduced
by commit c39a6e25d makes noinit section not fitting the SRAM region
on these devices, so linkage fails with:

ld: zephyr_prebuilt.elf section `noinit' will not fit in region `SRAM'
ld: section .intList VMA [0000000020050000,00000000200500e7] overlaps section noinit VMA [000000002004f5d8,0000000020050317]
ld: region `SRAM' overflowed by 792 bytes

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks and best regards,
Gustavo
