### PR TITLE
[CodeGen][OpenCL] Limit OpenCL built-in vector lanes to 2, 3, 4, 8, 16.

### DIFF
--- a/src/target/source/codegen_opencl.cc
+++ b/src/target/source/codegen_opencl.cc
@@ -120,7 +120,7 @@ void CodeGenOpenCL::PrintType(DataType t, std::ostream& os) {  // NOLINT(*)
         break;
     }
     if (!fail && lanes == 1) return;
-    if (!fail && (lanes >= 2 && lanes <= 16)) {
+    if (!fail && ((lanes >= 2 && lanes <= 4) || lanes == 8 || lanes == 16)) {
       os << lanes;
       return;
     }
@@ -154,7 +154,7 @@ void CodeGenOpenCL::PrintType(DataType t, std::ostream& os) {  // NOLINT(*)
         break;
     }
     if (!fail && lanes == 1) return;
-    if (!fail && (lanes >= 2 && lanes <= 16)) {
+    if (!fail && ((lanes >= 2 && lanes <= 4) || lanes == 8 || lanes == 16)) {
       os << lanes;
       return;
     }


### PR DESCRIPTION
OpenCL does not support any vector lanes except for 2, 3, 4, 8 and 16.

P.273 https://www.khronos.org/registry/OpenCL/specs/opencl-2.0.pdf
![OpenCL](https://user-images.githubusercontent.com/1317792/113170937-9b5a0c00-9279-11eb-863b-15d33a29a002.png)
