### PR TITLE
[TVMC] Runner.py Updates

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -460,10 +460,10 @@ def format_times(times):
     max_ts = np.max(times) * 1000
     min_ts = np.min(times) * 1000
 
-    header = "Execution time summary:\n{0:^10} {1:^10} {2:^15} {3:^10}".format(
+    header = "Execution time summary:\n{0:^10} {1:^10} {2:^10} {3:^10}".format(
         "mean (ms)", "max (ms)", "min (ms)", "std (ms)"
     )
-    stats = "{0:^10.5f} {1:^10.5f} {2:^10.5f} {3:^10.5f}".format(mean_ts, max_ts, min_ts, std_ts)
+    stats = "{0:^10.2f} {1:^10.2f} {2:^10.2f} {3:^10.2f}".format(mean_ts, max_ts, min_ts, std_ts)
 
     print("%s\n%s\n" % (header, stats))
     return "%s\n%s\n" % (header, stats)

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -465,5 +465,4 @@ def format_times(times):
     )
     stats = "{0:^10.2f} {1:^10.2f} {2:^10.2f} {3:^10.2f}".format(mean_ts, max_ts, min_ts, std_ts)
 
-    print("%s\n%s\n" % (header, stats))
     return "%s\n%s\n" % (header, stats)

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -287,7 +287,7 @@ def make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode):
 
 def run_module(
     module_file,
-    hostname,
+    hostname=None,
     port=9090,
     rpc_key=None,
     device,

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -118,7 +118,7 @@ def drive_run(args):
         hostname=rpc_hostname,
         port=rpc_port,
         rpc_key=args.rpc_key,
-        inputs_file=args.inputs,
+        inputs=inputs,
         fill_mode=args.fill_mode,
         repeat=args.repeat,
         profile=args.profile,
@@ -294,7 +294,7 @@ def run_module(
     hostname=None,
     port=9090,
     rpc_key=None,
-    inputs_file=None,
+    inputs=None,
     fill_mode="random",
     repeat=1,
     profile=False,
@@ -319,8 +319,8 @@ def run_module(
     rpc_key : str, optional
         The tracker key of the target device. If this is set, it
         will be assumed that remote points to a tracker.
-    inputs_file : str, optional
-        Path to an .npz file containing the inputs.
+    inputs : dict, optional
+        A dictionary that maps input names to numpy values.
     fill_mode : str, optional
         The fill-mode to use when generating data for input tensors.
         Valid options are "zeros", "ones" and "random".

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -290,7 +290,7 @@ def run_module(
     hostname,
     port=9090,
     rpc_key=None,
-    device=None,
+    device,
     inputs_file=None,
     fill_mode="random",
     repeat=1,

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -440,7 +440,7 @@ def format_times(times):
     This has the effect of producing a small table that looks like:
 
         Execution time summary:
-        mean (s)   max (s)    min (s)    std (s)
+        mean (ms)   max (ms)    min (ms)    std (ms)
         0.14310    0.16161    0.12933    0.01004
 
     Parameters
@@ -455,13 +455,15 @@ def format_times(times):
     """
 
     # timestamps
-    mean_ts = np.mean(times)
-    std_ts = np.std(times)
-    max_ts = np.max(times)
-    min_ts = np.min(times)
+    mean_ts = np.mean(times) * 1000
+    std_ts = np.std(times) * 1000
+    max_ts = np.max(times) * 1000
+    min_ts = np.min(times) * 1000
 
-    header = "Execution time summary:\n{0:^10} {1:^10} {2:^10} {3:^10}".format(
-        "mean (s)", "max (s)", "min (s)", "std (s)"
+    header = "Execution time summary:\n{0:^10} {1:^10} {2:^15} {3:^10}".format(
+        "mean (ms)", "max (ms)", "min (ms)", "std (ms)"
     )
     stats = "{0:^10.5f} {1:^10.5f} {2:^10.5f} {3:^10.5f}".format(mean_ts, max_ts, min_ts, std_ts)
+
+    print("%s\n%s\n" % (header, stats))
     return "%s\n%s\n" % (header, stats)

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -109,11 +109,11 @@ def drive_run(args):
 
     outputs, times = run_module(
         args.FILE,
+        device=args.device,
         rpc_hostname,
         rpc_port,
         args.rpc_key,
         inputs_file=args.inputs,
-        device=args.device,
         fill_mode=args.fill_mode,
         repeat=args.repeat,
         profile=args.profile,
@@ -291,7 +291,6 @@ def run_module(
     hostname=None,
     port=9090,
     rpc_key=None,
-    device=None,
     inputs_file=None,
     fill_mode="random",
     repeat=1,
@@ -317,9 +316,6 @@ def run_module(
     rpc_key : str, optional
         The tracker key of the target device. If this is set, it
         will be assumed that remote points to a tracker.
-    device: str, optional
-        the device (e.g. "cpu" or "gpu") to be targeted by the RPC
-        session, local or remote).
     inputs_file : str, optional
         Path to an .npz file containing the inputs.
     fill_mode : str, optional

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -287,10 +287,10 @@ def make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode):
 
 def run_module(
     module_file,
+    device,
     hostname=None,
     port=9090,
     rpc_key=None,
-    device,
     inputs_file=None,
     fill_mode="random",
     repeat=1,
@@ -306,16 +306,16 @@ def run_module(
     ----------
     module_file : str
         The path to the module file (a .tar file).
-    hostname : str
+    device: str,
+        the device (e.g. "cpu" or "gpu") to be targeted by the RPC
+        session, local or remote).
+    hostname : str, optional
         The hostname of the target device on which to run.
     port : int, optional
         The port of the target device on which to run.
     rpc_key : str, optional
         The tracker key of the target device. If this is set, it
         will be assumed that remote points to a tracker.
-    device: str, optional
-        the device (e.g. "cpu" or "gpu") to be targeted by the RPC
-        session, local or remote).
     inputs_file : str, optional
         Path to an .npz file containing the inputs.
     fill_mode : str, optional

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -109,10 +109,10 @@ def drive_run(args):
 
     outputs, times = run_module(
         args.FILE,
-        device=args.device,
-        rpc_hostname,
-        rpc_port,
-        args.rpc_key,
+        args.device,
+        hostname=rpc_hostname,
+        port=rpc_port,
+        rpc_key=args.rpc_key,
         inputs_file=args.inputs,
         fill_mode=args.fill_mode,
         repeat=args.repeat,

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -291,6 +291,7 @@ def run_module(
     hostname=None,
     port=9090,
     rpc_key=None,
+    device=None,
     inputs_file=None,
     fill_mode="random",
     repeat=1,
@@ -316,6 +317,9 @@ def run_module(
     rpc_key : str, optional
         The tracker key of the target device. If this is set, it
         will be assumed that remote points to a tracker.
+    device: str, optional
+        the device (e.g. "cpu" or "gpu") to be targeted by the RPC
+        session, local or remote).
     inputs_file : str, optional
         Path to an .npz file containing the inputs.
     fill_mode : str, optional

--- a/tests/python/driver/tvmc/test_runner.py
+++ b/tests/python/driver/tvmc/test_runner.py
@@ -50,7 +50,7 @@ def test_generate_tensor_data__type_unknown():
 
 
 def test_format_times__contains_header():
-    sut = tvmc.runner.format_times([.6, 1.2, .12, .42])
+    sut = tvmc.runner.format_times([0.6, 1.2, 0.12, 0.42])
     assert "std (ms)" in sut
 
 

--- a/tests/python/driver/tvmc/test_runner.py
+++ b/tests/python/driver/tvmc/test_runner.py
@@ -51,7 +51,7 @@ def test_generate_tensor_data__type_unknown():
 
 def test_format_times__contains_header():
     sut = tvmc.runner.format_times([60, 120, 12, 42])
-    assert "std (s)" in sut
+    assert "std (ms)" in sut
 
 
 def test_get_top_results_keep_results():

--- a/tests/python/driver/tvmc/test_runner.py
+++ b/tests/python/driver/tvmc/test_runner.py
@@ -50,7 +50,7 @@ def test_generate_tensor_data__type_unknown():
 
 
 def test_format_times__contains_header():
-    sut = tvmc.runner.format_times([60, 120, 12, 42])
+    sut = tvmc.runner.format_times([.6, 1.2, .12, .42])
     assert "std (ms)" in sut
 
 


### PR DESCRIPTION

This PR does three things:
1) Makes hostname optional in run_module
2) Makes device mandatory in run_module
3) Changes the runner time measurements to be in milliseconds rather than seconds (with additional test updates)

