### PR TITLE
[CI] add the --net=host cmd line arg to the docker/bash.it script

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -20,6 +20,8 @@
 #
 # Start a bash, mount /workspace to be current directory.
 #
+# Usage: bash.sh <CONTAINER_TYPE> [-i] [--net=host] <CONTAINER_NAME>  <COMMAND>
+#
 # Usage: docker/bash.sh <CONTAINER_NAME>
 #     Starts an interactive session
 #
@@ -38,8 +40,14 @@ if [ "$1" == "-i" ]; then
     shift
 fi
 
+CI_DOCKER_EXTRA_PARAMS=( )
+if [[ "$1" == "--net=host" ]]; then
+    CI_DOCKER_EXTRA_PARAMS+=('--net=host')
+    shift 1
+fi
+
 if [ "$#" -lt 1 ]; then
-    echo "Usage: docker/bash.sh [-i] <CONTAINER_NAME> [COMMAND]"
+    echo "Usage: docker/bash.sh [-i] [--net=host] <CONTAINER_NAME> [COMMAND]"
     exit -1
 fi
 
@@ -48,16 +56,15 @@ if [ -z "${DOCKER_IMAGE_NAME}" ]; then
     DOCKER_IMAGE_NAME=("$1")
 fi
 
-CI_DOCKER_EXTRA_PARAMS=( )
 if [ "$#" -eq 1 ]; then
     COMMAND="bash"
     interactive=1
     if [[ $(uname) == "Darwin" ]]; then
         # Docker's host networking driver isn't supported on macOS.
         # Use default bridge network and expose port for jupyter notebook.
-        CI_DOCKER_EXTRA_PARAMS=( "${CI_DOCKER_EXTRA_PARAMS[@]}" "-p 8888:8888" )
+        CI_DOCKER_EXTRA_PARAMS+=( "${CI_DOCKER_EXTRA_PARAMS[@]}" "-p 8888:8888" )
     else
-        CI_DOCKER_EXTRA_PARAMS=( "${CI_DOCKER_EXTRA_PARAMS[@]}" "--net=host" )
+        CI_DOCKER_EXTRA_PARAMS+=( "${CI_DOCKER_EXTRA_PARAMS[@]}" "--net=host" )
     fi
 else
     shift 1


### PR DESCRIPTION
introduce the ``--net=host`` command line argument to the ``docker/bash.sh``. This is already available
for https://github.com/apache/tvm/blob/main/docker/build.sh#L71 
Without this change it is not possible to have an arbitrary command executed through ``docker?bash.sh``
and have interactivity enabled since the following section https://github.com/apache/tvm/blob/main/docker/bash.sh#L52
imposes running ``bash`` and overwrites the value of ``COMMAND``.
With this change, one would be able to have bridged host networking in addition to executing an
arbitrary command.

on another note, i think it would be quite helpful to check if e.g ``CI_DOCKER_EXTRA_PARAMS`` is defined 
as an environment variable, then ``docker/bash.sh`` would append variables, so the calling sequence would be:

````bash
    export CI_DOCKER_EXTRA_PARAMS="--net=host -v foo:bar .... some_other_docker_flags"
    ./docker/bash.sh -i tvm.ci_cpu SOME_COMMANDS_HERE
````
