### PR TITLE
[Relay]Frontend][Onnx] Remove pop that interferes with nested loops.

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3081,7 +3081,7 @@ class GraphProto:
                 self._nodes[i_name] = new_var(i_name, shape=i_shape, dtype=dtype)
             self._inputs[i_name] = self._nodes[i_name]
         # Only check user inputs in the outer-most graph scope.
-        if self._old_manager == None:
+        if self._old_manager is None:
             assert all(
                 [name in self._input_names for name in self._shape.keys()]
             ), "User specified the shape for inputs that weren't found in the graph: " + str(

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3080,11 +3080,13 @@ class GraphProto:
                     dtype = d_type
                 self._nodes[i_name] = new_var(i_name, shape=i_shape, dtype=dtype)
             self._inputs[i_name] = self._nodes[i_name]
-        assert all(
-            [name in self._input_names for name in self._shape.keys()]
-        ), "User specified the shape for inputs that weren't found in the graph: " + str(
-            self._shape
-        )
+        # Only check user inputs in the outer-most graph scope.
+        if self._old_manager == None:
+            assert all(
+                [name in self._input_names for name in self._shape.keys()]
+            ), "User specified the shape for inputs that weren't found in the graph: " + str(
+                self._shape
+            )
         # get list of unsupported ops
         convert_map = _get_convert_map(opset)
         unsupported_ops = set()

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2981,6 +2981,7 @@ class GraphProto:
         self._num_input = 0
         self._num_param = 0
         self._shape = shape if shape else {}
+        self._input_names = []
         self._dtype = dtype
         self.opset = None
         self._freeze_params = freeze_params
@@ -3062,8 +3063,9 @@ class GraphProto:
                 continue
             else:
                 self._num_input += 1
+                self._input_names.append(i_name)
                 if i_name in self._shape:
-                    i_shape = self._shape.pop(i_name)
+                    i_shape = self._shape[i_name]
                 else:
                     if "?" in str(i_shape):
                         warning_msg = (
@@ -3078,8 +3080,8 @@ class GraphProto:
                     dtype = d_type
                 self._nodes[i_name] = new_var(i_name, shape=i_shape, dtype=dtype)
             self._inputs[i_name] = self._nodes[i_name]
-        assert (
-            len(self._shape) == 0
+        assert all(
+            [name in self._input_names for name in self._shape.keys()]
         ), "User specified the shape for inputs that weren't found in the graph: " + str(
             self._shape
         )


### PR DESCRIPTION
PR #7699 introduced a check for user provided shapes that arent found in the input graph. My implementation used `pop`, which it turns out can cause issues in nested loops. Unfortunately, its difficult to write a test case that triggers this error, but we should avoid pop in general. This PR replaces the pop based approach with a much safer way to check the same condition.
