### PR TITLE
Fix compilation errors with clang 11

### DIFF
--- a/src/runtime/hexagon/hexagon_module.cc
+++ b/src/runtime/hexagon/hexagon_module.cc
@@ -379,7 +379,7 @@ void HexagonModuleNode::RemapArgs(const TVMArgs& args, std::vector<TVMValue>& va
       case kTVMNDArrayHandle:
       case kTVMDLTensorHandle: {
         DLTensor* t = static_cast<DLTensor*>(a);
-        assert(TVMDeviceExtType(t->device.device_type) == kDLHexagon);
+        ICHECK(TVMDeviceExtType(t->device.device_type) == kDLHexagon);
         TVMValue v;
         v.v_handle = CreateRemoteTensor(t);
         remote_tensors.push_back(v.v_handle);

--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -191,8 +191,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
       if (op->args[1]->dtype.is_float()) {
 #if TVM_LLVM_VERSION >= 90
 #if TVM_LLVM_VERSION >= 130
-        return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
-                                         llvm::MaybeAlign::MaybeAlign(),
+        return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1, llvm::MaybeAlign(),
                                          llvm::AtomicOrdering::Monotonic);
 #else
         return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
@@ -203,8 +202,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
 #endif
       }
 #if TVM_LLVM_VERSION >= 130
-      return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,
-                                       llvm::MaybeAlign::MaybeAlign(),
+      return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1, llvm::MaybeAlign(),
                                        llvm::AtomicOrdering::Monotonic);
 #else
       return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -239,8 +239,7 @@ llvm::Value* CodeGenNVPTX::CreateIntrinsic(const CallNode* op) {
     if (op->args[1]->dtype.is_float()) {
 #if TVM_LLVM_VERSION >= 90
 #if TVM_LLVM_VERSION >= 130
-      return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
-                                       llvm::MaybeAlign::MaybeAlign(),
+      return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1, llvm::MaybeAlign(),
                                        llvm::AtomicOrdering::Monotonic);
 #else
       return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, v0, v1,
@@ -251,8 +250,7 @@ llvm::Value* CodeGenNVPTX::CreateIntrinsic(const CallNode* op) {
 #endif
     }
 #if TVM_LLVM_VERSION >= 130
-    return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,
-                                     llvm::MaybeAlign::MaybeAlign(),
+    return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1, llvm::MaybeAlign(),
                                      llvm::AtomicOrdering::Monotonic);
 #else
     return builder_->CreateAtomicRMW(llvm::AtomicRMWInst::Add, v0, v1,


### PR DESCRIPTION
- Replace `llvm::MaybeAlign::MaybeAlign()` with `llvm::MaybeAlign()`.
- Use `ICHECK` instead of `assert` in hexagon_module.cc.