### PR TITLE
[TVMC] Allow direct numpy inputs to run_module

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -107,6 +107,8 @@ def drive_run(args):
 
     rpc_hostname, rpc_port = common.tracker_host_port_from_cli(args.rpc_tracker)
 
+    inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode="random")
+
     outputs, times = run_module(
         args.FILE,
         rpc_hostname,
@@ -292,7 +294,6 @@ def run_module(
     rpc_key=None,
     device=None,
     inputs_file=None,
-    fill_mode="random",
     repeat=1,
     profile=False,
 ):
@@ -379,7 +380,7 @@ def run_module(
         module.load_params(params)
 
         shape_dict, dtype_dict = get_input_info(graph, params)
-        inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode)
+        # inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode)
 
         logger.debug("setting inputs to the module")
         module.set_input(**inputs_dict)

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -107,14 +107,18 @@ def drive_run(args):
 
     rpc_hostname, rpc_port = common.tracker_host_port_from_cli(args.rpc_tracker)
 
-    inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode="random")
+    # inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode="random")
+    try:
+        inputs = np.load(inputs_file) if inputs_file else {}  # this is now a numpy array
+    except IOError as ex:
+        raise TVMCException("Error loading inputs file: %s" % ex)
 
     outputs, times = run_module(
         args.FILE,
         rpc_hostname,
         rpc_port,
         args.rpc_key,
-        inputs_file=args.inputs,
+        inputs=inputs,
         device=args.device,
         fill_mode=args.fill_mode,
         repeat=args.repeat,
@@ -248,11 +252,6 @@ def make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode):
         Complete inputs dictionary - {input_name: np.array}.
     """
     logger.debug("creating inputs dict")
-
-    try:
-        inputs = np.load(inputs_file) if inputs_file else {}
-    except IOError as ex:
-        raise TVMCException("Error loading inputs file: %s" % ex)
 
     # First check all the keys in inputs exist in the graph
     for input_name in inputs:

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -107,9 +107,8 @@ def drive_run(args):
 
     rpc_hostname, rpc_port = common.tracker_host_port_from_cli(args.rpc_tracker)
 
-    # inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode="random")
     try:
-        inputs = np.load(inputs_file) if inputs_file else {}  # this is now a numpy array
+        inputs = np.load(args.inputs) if args.inputs else {}
     except IOError as ex:
         raise TVMCException("Error loading inputs file: %s" % ex)
 
@@ -227,7 +226,7 @@ def generate_tensor_data(shape, dtype, fill_mode):
     return tensor
 
 
-def make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode):
+def make_inputs_dict(inputs, shape_dict, dtype_dict, fill_mode):
     """Make the inputs dictionary for a graph.
 
     Use data from 'inputs' where specified. For input tensors
@@ -236,8 +235,8 @@ def make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode):
 
     Parameters
     ----------
-    inputs_file : str
-        Path to a .npz file containing the inputs.
+    inputs : dict
+        A dictionary that maps input names to numpy values.
     shape_dict : dict
         Shape dictionary - {input_name: tuple}.
     dtype_dict : dict
@@ -252,6 +251,9 @@ def make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode):
         Complete inputs dictionary - {input_name: np.array}.
     """
     logger.debug("creating inputs dict")
+
+    if inputs is None:
+        inputs = {}
 
     # First check all the keys in inputs exist in the graph
     for input_name in inputs:
@@ -292,7 +294,8 @@ def run_module(
     port=9090,
     rpc_key=None,
     device=None,
-    inputs_file=None,
+    inputs=None,
+    fill_mode="random",
     repeat=1,
     profile=False,
 ):
@@ -316,8 +319,8 @@ def run_module(
     device: str, optional
         the device (e.g. "cpu" or "gpu") to be targeted by the RPC
         session, local or remote).
-    inputs_file : str, optional
-        Path to an .npz file containing the inputs.
+    inputs : dict, optional
+        A dictionary that maps input names to numpy values.
     fill_mode : str, optional
         The fill-mode to use when generating data for input tensors.
         Valid options are "zeros", "ones" and "random".
@@ -379,7 +382,7 @@ def run_module(
         module.load_params(params)
 
         shape_dict, dtype_dict = get_input_info(graph, params)
-        # inputs_dict = make_inputs_dict(inputs_file, shape_dict, dtype_dict, fill_mode)
+        inputs_dict = make_inputs_dict(inputs, shape_dict, dtype_dict, fill_mode)
 
         logger.debug("setting inputs to the module")
         module.set_input(**inputs_dict)

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -226,7 +226,7 @@ def generate_tensor_data(shape, dtype, fill_mode):
     return tensor
 
 
-def make_inputs_dict(inputs, shape_dict, dtype_dict, fill_mode):
+def make_inputs_dict(shape_dict, dtype_dict, inputs=None, fill_mode="random"):
     """Make the inputs dictionary for a graph.
 
     Use data from 'inputs' where specified. For input tensors
@@ -235,13 +235,13 @@ def make_inputs_dict(inputs, shape_dict, dtype_dict, fill_mode):
 
     Parameters
     ----------
-    inputs : dict
-        A dictionary that maps input names to numpy values.
     shape_dict : dict
         Shape dictionary - {input_name: tuple}.
     dtype_dict : dict
         dtype dictionary - {input_name: dtype}.
-    fill_mode : str
+    inputs : dict, optional
+        A dictionary that maps input names to numpy values.
+    fill_mode : str, optional
         The fill-mode to use when generating tensor data.
         Can be either "zeros", "ones" or "random".
 
@@ -382,7 +382,7 @@ def run_module(
         module.load_params(params)
 
         shape_dict, dtype_dict = get_input_info(graph, params)
-        inputs_dict = make_inputs_dict(inputs, shape_dict, dtype_dict, fill_mode)
+        inputs_dict = make_inputs_dict(shape_dict, dtype_dict, inputs, fill_mode)
 
         logger.debug("setting inputs to the module")
         module.set_input(**inputs_dict)

--- a/tests/python/driver/tvmc/test_runner.py
+++ b/tests/python/driver/tvmc/test_runner.py
@@ -73,9 +73,11 @@ def test_run_tflite_module__with_profile__valid_input(
     # some CI environments wont offer TFLite, so skip in case it is not present
     pytest.importorskip("tflite")
 
+    inputs = np.load(imagenet_cat)
+
     outputs, times = tvmc.run(
         tflite_compiled_module_as_tarfile,
-        inputs_file=imagenet_cat,
+        inputs=inputs,
         hostname=None,
         device="cpu",
         profile=True,


### PR DESCRIPTION
When using TVMC from python it more convenient to pass numpy arrays as inputs rather than saved files. This PR moves the file reading into drive_run to maintain the existing behavior for command line TVMC while making the python API cleaner. 