### PR TITLE
[AutoScheduler] Add task.desc for its function name

### DIFF
--- a/include/tvm/auto_scheduler/search_task.h
+++ b/include/tvm/auto_scheduler/search_task.h
@@ -113,6 +113,8 @@ class SearchTaskNode : public Object {
   ComputeDAG compute_dag;
   /*! \brief The workload key for the compute declaration. */
   String workload_key;
+  /*! \brief The description string of this task. */
+  String desc;
   /*! \brief The target device of this search task. */
   Target target;
   /*! \brief The target host device of this search task. */
@@ -127,6 +129,7 @@ class SearchTaskNode : public Object {
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("compute_dag", &compute_dag);
     v->Visit("workload_key", &workload_key);
+    v->Visit("desc", &desc);
     v->Visit("target", &target);
     v->Visit("target_host", &target_host);
     v->Visit("hardware_params", &hardware_params);
@@ -153,10 +156,11 @@ class SearchTask : public ObjectRef {
    * \param hardware_params Hardware parameters used in this search task.
    * \param layout_rewrite_option The layout rewrite option used for measuring programs.
    * \param task_input_names Names of some user defined input data used in program measuring.
+   * \param desc The description string of this task.
    */
   SearchTask(ComputeDAG compute_dag, String workload_key, Target target, Target target_host,
              Optional<HardwareParams> hardware_params, LayoutRewriteOption layout_rewrite_option,
-             Array<String> task_input_names);
+             Array<String> task_input_names, String desc = "");
 
   TVM_DEFINE_OBJECT_REF_METHODS(SearchTask, ObjectRef, SearchTaskNode);
 };

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -357,6 +357,8 @@ class SearchTask(Object):
     task_inputs_save_to_file : bool = False
         Whether to save the data to a local file as well. This can be reused to resume the last
         tuning process.
+    desc: str = ""
+        The description string of this task.
 
     Examples
     --------
@@ -387,6 +389,7 @@ class SearchTask(Object):
         task_inputs=None,
         task_inputs_overwrite=False,
         task_inputs_save_to_file=False,
+        desc="",
     ):
         assert (
             func is not None or workload_key is not None
@@ -429,6 +432,7 @@ class SearchTask(Object):
             hardware_params,
             layout_rewrite_option,
             task_input_names,
+            desc,
         )
 
     def tune(self, tuning_options, search_policy=None):
@@ -520,6 +524,7 @@ class SearchTask(Object):
             "hardware_params": self.hardware_params,
             "layout_rewrite_option": self.layout_rewrite_option,
             "task_input_names": self.task_input_names,
+            "desc": self.desc,
         }
 
     def __setstate__(self, state):
@@ -548,6 +553,7 @@ class SearchTask(Object):
             state["hardware_params"],
             state["layout_rewrite_option"],
             state["task_input_names"],
+            state["desc"],
         )
 
 

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -138,11 +138,13 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
 
 SearchTask::SearchTask(ComputeDAG compute_dag, String workload_key, Target target,
                        Target target_host, Optional<HardwareParams> hardware_params,
-                       LayoutRewriteOption layout_rewrite_option, Array<String> task_input_names) {
+                       LayoutRewriteOption layout_rewrite_option, Array<String> task_input_names,
+                       String desc) {
   CheckAndUpdateHostConsistency(&target, &target_host);
   auto node = make_object<SearchTaskNode>();
   node->compute_dag = std::move(compute_dag);
   node->workload_key = std::move(workload_key);
+  node->desc = std::move(desc);
   node->target = std::move(target);
   node->target_host = std::move(target_host);
   if (hardware_params) {
@@ -168,10 +170,10 @@ TVM_REGISTER_GLOBAL("auto_scheduler.HardwareParams")
 TVM_REGISTER_GLOBAL("auto_scheduler.SearchTask")
     .set_body_typed([](ComputeDAG compute_dag, String workload_key, Target target,
                        Target target_host, Optional<HardwareParams> hardware_params,
-                       int layout_rewrite_option, Array<String> task_input_names) {
+                       int layout_rewrite_option, Array<String> task_input_names, String desc) {
       CheckAndUpdateHostConsistency(&target, &target_host);
       return SearchTask(compute_dag, workload_key, target, target_host, hardware_params,
-                        LayoutRewriteOption(layout_rewrite_option), task_input_names);
+                        LayoutRewriteOption(layout_rewrite_option), task_input_names, desc);
     });
 
 }  // namespace auto_scheduler


### PR DESCRIPTION
This PR adds an optional field `desc` to AutoScheduler's `SearchTask`. When extracting the tasks, this field will be used to store the Relay function name it was extracted from (e.g., `fused_nn.conv2d`). This would be useful if users only want to tune some tasks in a network. For example:

```python
tasks, weights = extract_tasks(...)
for task, weight in zip(tasks, weights):
  if "conv2d" not in task.desc:
    # throw away this task
```

This is also useful if users are interested in what function the compute DAG represents.

cc @merrymercy @jcf94 @FrozenGene 