### PR TITLE
[FIX] Make HashCombine stable across platforms

### DIFF
--- a/src/support/utils.h
+++ b/src/support/utils.h
@@ -166,21 +166,33 @@ inline int Execute(std::string cmd, std::string* err_msg) {
 
 /*!
  * \brief Combine two hash values into a single one.
+ *
+ * This hash function is stable across platforms.
+ *
  * \param key The left operand.
  * \param value The right operand.
  * \return the combined result.
  */
 inline size_t HashCombine(size_t key, size_t value) {
+  // XXX: do not use std::hash in this function. This hash must be stable
+  // across different platforms and std::hash is implementation dependent.
   return key ^ (value + 0x9e3779b9 + (key << 6) + (key >> 2));
 }
 
 /*!
  * \brief hash an object and combines uint64_t key with previous keys
+ *
+ * This hash function is stable across platforms.
+ *
+ * \param key The left operand.
+ * \param value The right operand.
+ * \return the combined result.
  */
-template <typename T>
+template <typename T, std::enable_if_t<std::is_convertible<T, uint64_t>::value, bool> = true>
 inline uint64_t HashCombine(uint64_t key, const T& value) {
-  std::hash<T> hash_func;
-  return key ^ (hash_func(value) + 0x9e3779b9 + (key << 6) + (key >> 2));
+  // XXX: do not use std::hash in this function. This hash must be stable
+  // across different platforms and std::hash is implementation dependent.
+  return key ^ (uint64_t(value) + 0x9e3779b9 + (key << 6) + (key >> 2));
 }
 
 }  // namespace support

--- a/src/support/utils.h
+++ b/src/support/utils.h
@@ -165,21 +165,6 @@ inline int Execute(std::string cmd, std::string* err_msg) {
 #endif  // __hexagon__
 
 /*!
- * \brief Combine two hash values into a single one.
- *
- * This hash function is stable across platforms.
- *
- * \param key The left operand.
- * \param value The right operand.
- * \return the combined result.
- */
-inline size_t HashCombine(size_t key, size_t value) {
-  // XXX: do not use std::hash in this function. This hash must be stable
-  // across different platforms and std::hash is implementation dependent.
-  return key ^ (value + 0x9e3779b9 + (key << 6) + (key >> 2));
-}
-
-/*!
  * \brief hash an object and combines uint64_t key with previous keys
  *
  * This hash function is stable across platforms.

--- a/tests/cpp/support_test.cc
+++ b/tests/cpp/support_test.cc
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include "../../src/support/hexdump.h"
+#include "../../src/support/utils.h"
 
 namespace tvm {
 namespace test {
@@ -41,6 +42,18 @@ TEST(HexDumpTests, Unaligned) {
       "0010   01 23 45 67 89 ab cd ef 01                       .#Eg.....\n",
       ::tvm::support::HexDump("\x01\x23\x45\x67\x89\xab\xcd\xef\x01\x23\x45\x67\x89\xab\xcd\xef"
                               "\x01\x23\x45\x67\x89\xab\xcd\xef\x01"));
+}
+
+TEST(HashTests, HashStability) {
+  size_t a = 345292;
+  int b = 795620;
+  EXPECT_EQ(::tvm::support::HashCombine(a, b), 2677237020);
+  uint64_t c = 12345;
+  int d = 987654432;
+  EXPECT_EQ(::tvm::support::HashCombine(c, d), 3642871070);
+  size_t e = 1010101;
+  size_t f = 3030303;
+  EXPECT_EQ(::tvm::support::HashCombine(e, f), 2722928432);
 }
 
 }  // namespace test


### PR DESCRIPTION
PR #7605 inadvertatly broke cross platform hashing when when it switched size_t to uint64_t. This cause a different specialization of HashCombine to be used. Unfortunately the new specialization used std::hash which is
implementation dependent. I've added tests to make sure this doesn't happen again.

@tmoreau89 
