### PR TITLE
[Relay][Pass] Update SimplifyTranspose to correctly simplify rank changing layout transforms

### DIFF
--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -31,9 +31,9 @@
 #include <tvm/runtime/logging.h>
 
 #include <limits>
-#include <utility>
-
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "../op/tensor/transform.h"
 #include "pattern_utils.h"

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -741,6 +741,7 @@ class TypeInferencer::Resolver : public MixedModeMutator, PatternMutator {
 Expr TypeInferencer::Infer(GlobalVar var, Function function) {
   // Set the current function being type checked.
   this->current_func_ = var;
+
   // Step 1: Populate the constraints.
   GetType(function);
 

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -741,7 +741,6 @@ class TypeInferencer::Resolver : public MixedModeMutator, PatternMutator {
 Expr TypeInferencer::Infer(GlobalVar var, Function function) {
   // Set the current function being type checked.
   this->current_func_ = var;
-
   // Step 1: Populate the constraints.
   GetType(function);
 

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -108,7 +108,7 @@ def test_simplify_transpose():
 
     # Test a series of transpose and rank changing layout_transform
     def before4():
-        '''
+        """
         Simplify transpose->layout_transform and its inverse.
 
         Input:
@@ -116,7 +116,7 @@ def test_simplify_transpose():
 
         Simplified:
         NHWC -> NCHW4c -> op -> NCHW4c -> NHWC
-        '''
+        """
         x = relay.var("x", shape=(1, 56, 56, 128), dtype="float32")
         y = relay.transpose(x, axes=[0, 3, 1, 2])
         y = relay.layout_transform(y, "NCHW", "NCHW4c")
@@ -133,7 +133,7 @@ def test_simplify_transpose():
         return relay.Function([x], y)
 
     def before5():
-        '''
+        """
         Simplify layout_transform->layout_transform and its inverse.
 
         Input:
@@ -141,7 +141,7 @@ def test_simplify_transpose():
 
         Simplified:
         NHWC -> NCHW4c -> op -> NCHW4c -> NHWC
-        '''
+        """
         x = relay.var("x", shape=(1, 56, 56, 128), dtype="float32")  # NHWC
         y = relay.layout_transform(x, "NHWC", "NCHW")  # To NCHW
         y = relay.layout_transform(y, "NCHW", "NCHW4c")  # To NCHW4c
@@ -158,7 +158,7 @@ def test_simplify_transpose():
         return relay.Function([x], y)
 
     def before6():
-        '''
+        """
         Remove trivial layout_transform->layout_transform.
 
         Input:
@@ -166,7 +166,7 @@ def test_simplify_transpose():
 
         Simplified:
         NHWC -> op
-        '''
+        """
 
         x = relay.var("x", shape=(1, 128, 56, 56), dtype="float32")
         y = relay.layout_transform(x, "NCHW", "NHWC")
@@ -180,7 +180,7 @@ def test_simplify_transpose():
         return relay.Function([x], y)
 
     def before7():
-        '''
+        """
         Remove trivial layout_transform->layout_transform.
 
         Input:
@@ -188,7 +188,7 @@ def test_simplify_transpose():
 
         Simplified:
         NCHW4c -> op
-        '''
+        """
         x = relay.var("x", shape=(1, 32, 56, 56, 4), dtype="float32")
         y = relay.layout_transform(x, "NCHW4c", "NCHW8c")
         y = relay.layout_transform(y, "NCHW8c", "NCHW4c")
@@ -201,7 +201,7 @@ def test_simplify_transpose():
         return relay.Function([x], y)
 
     def before8():
-        '''
+        """
         Simplify layout_transform->layout_transform with rank contraction and expansion
 
         Input:
@@ -209,7 +209,7 @@ def test_simplify_transpose():
 
         Simplified:
         NCHW4c -> NCHW8c -> op
-        '''
+        """
         x = relay.var("x", shape=(1, 32, 56, 56, 4), dtype="float32")
         y = relay.layout_transform(x, "NCHW4c", "NCHW")
         y = relay.layout_transform(y, "NCHW", "NCHW8c")
@@ -223,7 +223,7 @@ def test_simplify_transpose():
         return relay.Function([x], y)
 
     def before9():
-        '''
+        """
         Remove trivial layout_transform->layout_transform.
 
         Input:
@@ -231,7 +231,7 @@ def test_simplify_transpose():
 
         Simplified:
         NCHW -> op
-        '''
+        """
         x = relay.var("x", shape=(1, 128, 56, 56), dtype="float32")
         y = relay.layout_transform(x, "NCHW", "NCHW4c")
         y = relay.layout_transform(y, "NCHW4c", "NCHW")
@@ -244,7 +244,7 @@ def test_simplify_transpose():
         return relay.Function([x], y)
 
     def before10():
-        '''
+        """
         Simplify layout_transform->layout_transform without rank change to transpose.
 
         Input:
@@ -252,7 +252,7 @@ def test_simplify_transpose():
 
         Simplified:
         NCHW -> CHWN -> op
-        '''
+        """
         x = relay.var("x", shape=(1, 128, 56, 56), dtype="float32")
         y = relay.layout_transform(x, "NCHW", "NHWC")
         y = relay.layout_transform(y, "NHWC", "CHWN")


### PR DESCRIPTION
This PR adds support to SimplifyTranspose to simplify consecutive transpose<->layout_transform operations when the layout transform involves a rank expansion or contraction. The added unit test fails on main because the current SimplifyTranspose only doesn't consider the case when the layout transform and transpose may act on tensors of different rank. As an example, 

`NCHW4c -> LayoutTransform -> NCHW -> Transpose -> NHWC` 

now simplifies to 

 `NCHW4c -> LayoutTransform ->  NHWC`. 

The reverse, rank expansion, is also supported.