### PR TITLE
Added missing include file

### DIFF
--- a/apps/howto_deploy/tvm_runtime_pack.cc
+++ b/apps/howto_deploy/tvm_runtime_pack.cc
@@ -41,6 +41,7 @@
 #include "../../src/runtime/cpu_device_api.cc"
 #include "../../src/runtime/file_utils.cc"
 #include "../../src/runtime/library_module.cc"
+#include "../../src/runtime/logging.cc"
 #include "../../src/runtime/module.cc"
 #include "../../src/runtime/ndarray.cc"
 #include "../../src/runtime/object.cc"


### PR DESCRIPTION
Followed the instructions from _junrushao1994_ it seems an include file is missing in **apps/how_to_deploy/tvm_runtime_pack.cc**

Note that there are several warnings generated due to duplicated macro definitions during the compile process. However, the build is successful and the example works as expected.