### PR TITLE
[FIX] Fix RPC for the VM

### DIFF
--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -458,7 +458,7 @@ def connect(url, port, key="", session_timeout=0, session_constructor_args=None)
         Additional key to match server
 
     session_timeout : float, optional
-        The duration of the session, allows server to kill
+        The duration of the session in seconds, allows server to kill
         the connection when duration is longer than this value.
         When duration is zero, it means the request must always be kept alive.
 

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -638,7 +638,7 @@ RPCCode RPCEndpoint::HandleUntilReturnEvent(bool client_mode, RPCSession::FEncod
         if (handler_->CanCleanShutdown()) {
           return RPCCode::kShutdown;
         } else {
-          LOG(FATAL) << "Channel closes before we get neded bytes";
+          LOG(FATAL) << "Channel closes before we get needed bytes";
         }
       }
     }
@@ -795,7 +795,7 @@ void RPCEndpoint::CallFunc(RPCSession::PackedFuncHandle h, const TVMValue* arg_v
   handler_->SendPackedSeq(arg_values, arg_type_codes, num_args, true);
 
   code = HandleUntilReturnEvent(true, encode_return);
-  ICHECK(code == RPCCode::kReturn) << "code=" << static_cast<int>(code);
+  ICHECK(code == RPCCode::kReturn) << "code=" << RPCCodeToString(code);
 }
 
 void RPCEndpoint::CopyToRemote(void* from_bytes, DLTensor* to, uint64_t nbytes) {

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -188,7 +188,7 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
           // Automatically convert input DLTensors to NDArray
           DLTensor* tensor = args[i];
           std::vector<int64_t> shape;
-          for (size_t i = 0; i < tensor->ndim; i++) {
+          for (int64_t i = 0; i < tensor->ndim; i++) {
             shape.push_back(tensor->shape[i]);
           }
           NDArray ary = NDArray::Empty(shape, tensor->dtype, dev);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -181,10 +181,7 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
         Index device_type = vm_func.params_device_type[i - 1];
         Device dev = GetDevice(device_type);
 
-        if (args[i].IsObjectRef<NDArray>()) {
-          ObjectRef obj = CopyTo(args[i], dev);
-          func_args[i - 1] = obj;
-        } else {
+        if (args[i].type_code() == kTVMDLTensorHandle) {
           // Automatically convert input DLTensors to NDArray
           DLTensor* tensor = args[i];
           std::vector<int64_t> shape;
@@ -194,6 +191,9 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
           NDArray ary = NDArray::Empty(shape, tensor->dtype, dev);
           ary.CopyFrom(tensor);
           func_args[i - 1] = ary;
+        } else {
+          ObjectRef obj = CopyTo(args[i], dev);
+          func_args[i - 1] = obj;
         }
       }
       inputs_.erase(func_name);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -132,6 +132,21 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
         *rv = Invoke(func, func_args);
       }
     });
+  } else if (name == "invoke_stateful") {
+    // TODO(tkonolige, jroesch, tqchen): invoke_stateful and get_output are
+    // stop-gap measure to allow using vm over a remote connection.
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      PackedFunc invoke = GetFunction("invoke", sptr_to_self);
+      TVMRetValue rv_;
+      invoke.CallPacked(args, &rv_);
+    });
+  } else if (name == "get_output") {
+    return TypedPackedFunc<NDArray(int64_t)>([this](int64_t index) {
+      return Downcast<NDArray>(Downcast<ADT>(this->return_register_)[index]);
+    });
+  } else if (name == "get_num_outputs") {
+    return TypedPackedFunc<int64_t(void)>(
+        [this]() -> int64_t { return Downcast<ADT>(this->return_register_).size(); });
   } else if (name == "init") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       ICHECK_EQ(args.size() % 3, 0);
@@ -165,8 +180,21 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
       for (int i = 1; i < args.size(); ++i) {
         Index device_type = vm_func.params_device_type[i - 1];
         Device dev = GetDevice(device_type);
-        ObjectRef obj = CopyTo(args[i], dev);
-        func_args[i - 1] = obj;
+
+        if (args[i].IsObjectRef<NDArray>()) {
+          ObjectRef obj = CopyTo(args[i], dev);
+          func_args[i - 1] = obj;
+        } else {
+          // Automatically convert input DLTensors to NDArray
+          DLTensor* tensor = args[i];
+          std::vector<int64_t> shape;
+          for (size_t i = 0; i < tensor->ndim; i++) {
+            shape.push_back(tensor->shape[i]);
+          }
+          NDArray ary = NDArray::Empty(shape, tensor->dtype, dev);
+          ary.CopyFrom(tensor);
+          func_args[i - 1] = ary;
+        }
       }
       inputs_.erase(func_name);
       inputs_.emplace(func_name, func_args);

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -823,8 +823,9 @@ def test_vm_rpc():
     path = temp.relpath("vm_library.so")
     vm_exec.mod.export_library(path)
 
-    # Use LocalRPC for testing.
-    remote = rpc.LocalSession()
+    # Use local rpc server for testing.
+    server = rpc.Server("localhost", key="x")
+    remote = rpc.connect(server.host, server.port, key="x")
 
     # Upload the serialized Executable.
     remote.upload(path)
@@ -837,7 +838,7 @@ def test_vm_rpc():
     np_input = np.random.uniform(size=(10, 1)).astype("float32")
     input_tensor = tvm.nd.array(np_input, ctx)
     # Invoke its "main" function.
-    out = vm_factory.invoke("main", [input_tensor])
+    out = vm_factory.invoke("main", input_tensor)
     # Check the result.
     np.testing.assert_allclose(out.asnumpy(), np_input + np_input)
 

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -825,7 +825,7 @@ def test_vm_rpc():
 
     # Use local rpc server for testing.
     server = rpc.Server("localhost", key="x")
-    remote = rpc.connect(server.host, server.port, key="x")
+    remote = rpc.connect(server.host, server.port, key="x", session_timeout=10)
 
     # Upload the serialized Executable.
     remote.upload(path)
@@ -841,6 +841,9 @@ def test_vm_rpc():
     out = vm_factory.invoke("main", input_tensor)
     # Check the result.
     np.testing.assert_allclose(out.asnumpy(), np_input + np_input)
+
+    server.terminate()
+    del server
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -16,6 +16,7 @@
 # under the License.
 import numpy as np
 import pytest
+import time
 
 import tvm
 from tvm import runtime
@@ -827,6 +828,7 @@ def test_vm_rpc():
     # Server must use popen so it doesn't inherit the current process state. It
     # will crash otherwise.
     server = rpc.Server("localhost", port=9120, use_popen=True)
+    time.sleep(2)
     remote = rpc.connect(server.host, server.port, session_timeout=10)
 
     # Upload the serialized Executable.

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -29,10 +29,6 @@ from tvm.contrib import utils
 from tvm import rpc
 import tvm.testing
 
-# Something contaminates global state in this file so that the python rpc
-# server hangs. We run each test in its own process to avoid this issue.
-pytestmark = pytest.mark.forked
-
 
 def check_result(args, expected_result, mod=None):
     """

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -29,6 +29,10 @@ from tvm.contrib import utils
 from tvm import rpc
 import tvm.testing
 
+# Something contaminates global state in this file so that the python rpc
+# server hangs. We run each test in its own process to avoid this issue.
+pytestmark = pytest.mark.forked
+
 
 def check_result(args, expected_result, mod=None):
     """

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -826,7 +826,7 @@ def test_vm_rpc():
     # Use local rpc server for testing.
     # Server must use popen so it doesn't inherit the current process state. It
     # will crash otherwise.
-    server = rpc.Server("localhost", use_popen=True)
+    server = rpc.Server("localhost", port=9120, use_popen=True)
     remote = rpc.connect(server.host, server.port, session_timeout=10)
 
     # Upload the serialized Executable.

--- a/tests/python/unittest/test_runtime_profiling.py
+++ b/tests/python/unittest/test_runtime_profiling.py
@@ -33,7 +33,7 @@ def test_vm(target, dev):
     vm = profiler_vm.VirtualMachineProfiler(exe, dev)
 
     data = np.random.rand(1, 1, 28, 28).astype("float32")
-    report = vm.profile([data], func_name="main")
+    report = vm.profile(data, func_name="main")
     assert "fused_nn_softmax" in report
     assert "Total time" in report
 

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -67,7 +67,7 @@ run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib
 
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
-    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay --forked
+    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay
 
 # Command line driver test
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-driver tests/python/driver

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -65,8 +65,9 @@ if python -c "import tvm; from tvm.relay.op.contrib.ethosn import ethosn_availab
 fi
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib
 
+# forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
-    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay
+    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay --forked
 
 # Command line driver test
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-driver tests/python/driver


### PR DESCRIPTION
- Adds a stateful interface for the VM because there is no way to return an ADT using rpc. The stateful interface is similar to the graph runtime: `invoke_stateful` followed by `get_outputs`.
- Automatically copy DLTensor inputs into local NDArrays.
- Validate that the return values from an RPC call are sendable.
- Correct check in VM initialization to handle remote cpu devices correctly.

@tmoreau89 