### PR TITLE
Naming of the AOT executor function

### DIFF
--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -230,6 +230,8 @@ constexpr const char* tvm_module_main = "__tvm_main__";
 constexpr const char* tvm_param_prefix = "__tvm_param__";
 /*! \brief A PackedFunc that looks up linked parameters by storage_id. */
 constexpr const char* tvm_lookup_linked_param = "_lookup_linked_param";
+/*! \brief The main AOT executor function */
+constexpr const char* tvm_run_func_prefix = "tvm__run_func";
 }  // namespace symbol
 
 // implementations of inline functions.


### PR DESCRIPTION
Spin off from PR https://github.com/apache/tvm/pull/7785 to decide the
correct name to use for the AOT main executor function

Change-Id: I62b29e809a88d797afbb0c155fdc7be80659f7cf

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
