### PR TITLE
[RUNTIME] Add clear() function in tvm::Map class

### DIFF
--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -2980,6 +2980,13 @@ class Map : public ObjectRef {
   }
   /*! \return whether array is empty */
   bool empty() const { return size() == 0; }
+  /*! \brief Release reference to all the elements */
+  void clear() {
+    MapNode* n = GetMapNode();
+    if (n != nullptr) {
+      data_ = MapNode::Empty();
+    }
+  }
   /*!
    * \brief set the Map.
    * \param key The index key.

--- a/tests/cpp/container_test.cc
+++ b/tests/cpp/container_test.cc
@@ -313,6 +313,16 @@ TEST(Map, Mutate) {
   ICHECK(it == dict2.end());
 }
 
+TEST(Map, Clear) {
+  using namespace tvm;
+  Var x("x");
+  auto z = max(x + 1 + 2, 100);
+  Map<PrimExpr, PrimExpr> dict{{x, z}, {z, 2}};
+  ICHECK(dict.size() == 2);
+  dict.clear();
+  ICHECK(dict.size() == 0);
+}
+
 TEST(Map, Iterator) {
   using namespace tvm;
   PrimExpr a = 1, b = 2;


### PR DESCRIPTION
std::map and std::unordered_map have the clear() member function to clear the contents.

tvm::Array also has the clear() member function.

In order to be consistent with tvm::Array/std::map/std::unordered_map, we add the clear() member function in tvm::Map class used existing function implementation

@tqchen @yzhliu Would you please have a look at this? Thanks very much.
