### PR TITLE
[Relay][Pass] SimplifyCastLike/Cast and ConcretizeFullLikeRewrite rewrites for SimplifyExpr

### DIFF
--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -76,6 +76,59 @@ class SimplifyReshape : public DFPatternRewrite {
 };
 
 /*!
+ * \brief SimplifyCastLike matches the pattern of cast data to the same dtype.
+ */
+class SimplifyCastLike : public DFPatternRewrite {
+ public:
+  explicit SimplifyCastLike() {
+    data_pat_ = IsWildcard();
+    like_pat_ = IsWildcard();
+    pattern_ = IsOp("cast_like")({data_pat_, like_pat_});
+  }
+
+  Expr Callback(const Expr& pre, const Expr& post,
+                const Map<DFPattern, Array<Expr>>& node_map) const override {
+    auto data = node_map[data_pat_][0];
+    const TensorTypeNode* data_ty = data->checked_type().as<TensorTypeNode>();
+    const TensorTypeNode* like_ty = pre->checked_type().as<TensorTypeNode>();
+    if (like_ty->dtype == data_ty->dtype) {
+      return data;
+    }
+    return post;
+  }
+
+ protected:
+  DFPattern data_pat_;
+  DFPattern like_pat_;
+};
+
+/*!
+ * \brief SimplifyCast matches the pattern of cast data to the same dtype.
+ */
+class SimplifyCast : public DFPatternRewrite {
+ public:
+  explicit SimplifyCast() {
+    data_pat_ = IsWildcard();
+    pattern_ = IsOp("cast")({data_pat_});
+  }
+
+  Expr Callback(const Expr& pre, const Expr& post,
+                const Map<DFPattern, Array<Expr>>& node_map) const override {
+    const CallNode* call = pre.as<CallNode>();
+    auto attrs = call->attrs.as<CastAttrs>();
+    auto data = node_map[data_pat_][0];
+    const TensorTypeNode* data_ty = data->checked_type().as<TensorTypeNode>();
+    if (attrs->dtype == data_ty->dtype) {
+      return data;
+    }
+    return post;
+  }
+
+ protected:
+  DFPattern data_pat_;
+};
+
+/*!
  * \brief SimplifyTranspose matches the pattern of consecutive transpose op,
  *   and merges or cancels them.
  */
@@ -321,6 +374,17 @@ class ConcretizeOnesLikeRewrite : public ConcretizeLikeRewrite {
   }
 };
 
+class ConcretizeFullLikeRewrite : public ConcretizeLikeRewrite {
+ public:
+  ConcretizeFullLikeRewrite() : ConcretizeLikeRewrite(Op::Get("full_like")) {}
+
+  Expr Concretize(const Map<DFPattern, Array<Expr>>& node_map, Array<Integer> shape,
+                  DataType dtype) const override {
+    // `like_pat_` here is `fill_value`
+    return MakeFull(node_map[like_pat_][0], shape, dtype);
+  }
+};
+
 class ConcretizeReshapeLikeRewrite : public ConcretizeLikeRewrite {
  public:
   ConcretizeReshapeLikeRewrite() : ConcretizeLikeRewrite(Op::Get("reshape_like")) {}
@@ -439,12 +503,15 @@ Expr SimplifyExpr(const Expr& expr, const IRModule& mod) {
   DFPatternRewriteComposer composer;
   composer.AddRewrite<ConcretizeZerosLikeRewrite>();
   composer.AddRewrite<ConcretizeOnesLikeRewrite>();
+  composer.AddRewrite<ConcretizeFullLikeRewrite>();
   composer.AddRewrite<ConcretizeReshapeLikeRewrite>();
   composer.AddRewrite<ConcretizeCollapseSumLikeRewrite>();
   composer.AddRewrite<ConcretizeBroadcastToLikeRewrite>();
   composer.AddRewrite<EliminateIdentityRewrite>();
   composer.AddRewrite<SimplifyReshape>();
   composer.AddRewrite<SimplifyTranspose>();
+  composer.AddRewrite<SimplifyCastLike>();
+  composer.AddRewrite<SimplifyCast>();
   composer.AddRewrite<FullElementwise>();
   return RewritePatterns(composer.MakeCallbacks(), expr, mod);
 }

--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -80,7 +80,7 @@ class SimplifyReshape : public DFPatternRewrite {
  */
 class SimplifyCastLike : public DFPatternRewrite {
  public:
-  explicit SimplifyCastLike() {
+  SimplifyCastLike() {
     data_pat_ = IsWildcard();
     like_pat_ = IsWildcard();
     pattern_ = IsOp("cast_like")({data_pat_, like_pat_});
@@ -107,7 +107,7 @@ class SimplifyCastLike : public DFPatternRewrite {
  */
 class SimplifyCast : public DFPatternRewrite {
  public:
-  explicit SimplifyCast() {
+  SimplifyCast() {
     data_pat_ = IsWildcard();
     pattern_ = IsOp("cast")({data_pat_});
   }

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -236,6 +236,27 @@ def test_eliminate_identity():
         check(id_op(const, x), id_op(op_like(x), x))
 
 
+def test_simplify_cast_like():
+    dtype = "int32"
+    data = relay.var("data", shape=(3, 4, 5), dtype=dtype)
+    dtype_like = relay.var("dtype_like", shape=(2, 2, 2), dtype=dtype)
+    expr = relay.cast_like(data, dtype_like)
+
+    expected = run_infer_type(data)
+    actual = run_opt_pass(expr, relay.transform.SimplifyExpr())
+    assert tvm.ir.structural_equal(actual, expected)
+
+
+def test_simplify_cast():
+    dtype = "int32"
+    data = relay.var("data", shape=(3, 4, 5), dtype=dtype)
+    expr = relay.cast(data, dtype)
+
+    expected = run_infer_type(data)
+    actual = run_opt_pass(expr, relay.transform.SimplifyExpr())
+    assert tvm.ir.structural_equal(actual, expected)
+
+
 def test_concretize_reshape_like():
     data = relay.var("data", shape=(2, 3, 4), dtype="float32")
     shape_like = relay.var("shape_like", shape=(6, 2, 2), dtype="float32")
@@ -272,6 +293,17 @@ def test_concretize_ones_like():
     expr = relay.ones_like(shape_like)
 
     expected = run_infer_type(relay.ones((3, 4, 5), dtype))
+    actual = run_opt_pass(expr, relay.transform.SimplifyExpr())
+    assert tvm.ir.structural_equal(actual, expected)
+
+
+def test_concretize_full_like():
+    dtype = "int32"
+    shape_like = relay.var("shape_like", shape=(3, 4, 5), dtype=dtype)
+    fill_value = relay.var("fill", relay.TensorType((), "float32"))
+    expr = relay.full_like(shape_like, fill_value)
+
+    expected = run_infer_type(relay.full(fill_value, (3, 4, 5), dtype))
     actual = run_opt_pass(expr, relay.transform.SimplifyExpr())
     assert tvm.ir.structural_equal(actual, expected)
 

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -236,25 +236,18 @@ def test_eliminate_identity():
         check(id_op(const, x), id_op(op_like(x), x))
 
 
-def test_simplify_cast_like():
-    dtype = "int32"
-    data = relay.var("data", shape=(3, 4, 5), dtype=dtype)
-    dtype_like = relay.var("dtype_like", shape=(2, 2, 2), dtype=dtype)
-    expr = relay.cast_like(data, dtype_like)
-
-    expected = run_infer_type(data)
-    actual = run_opt_pass(expr, relay.transform.SimplifyExpr())
-    assert tvm.ir.structural_equal(actual, expected)
-
-
 def test_simplify_cast():
     dtype = "int32"
     data = relay.var("data", shape=(3, 4, 5), dtype=dtype)
-    expr = relay.cast(data, dtype)
+    expr1 = relay.cast(data, dtype)
+    dtype_like = relay.var("dtype_like", shape=(2, 2, 2), dtype=dtype)
+    expr2 = relay.cast_like(data, dtype_like)
 
     expected = run_infer_type(data)
-    actual = run_opt_pass(expr, relay.transform.SimplifyExpr())
-    assert tvm.ir.structural_equal(actual, expected)
+    actual1 = run_opt_pass(expr1, relay.transform.SimplifyExpr())
+    assert tvm.ir.structural_equal(actual1, expected)
+    actual2 = run_opt_pass(expr2, relay.transform.SimplifyExpr())
+    assert tvm.ir.structural_equal(actual2, expected)
 
 
 def test_concretize_reshape_like():


### PR DESCRIPTION
- `ConcretizeFullLikeRewrite`: `full_like` -> `full` when known shape
- `SimplifyCastLike/Cast`: `cast(data, dtype)` or `cast_like(data, dtype_like)` -> `data`, when the input and output have the same dtype

@yzhliu @comaniac @altanh 