### PR TITLE
fix compiling warning in simplify_expr.h

### DIFF
--- a/src/relay/transforms/simplify_expr.h
+++ b/src/relay/transforms/simplify_expr.h
@@ -74,7 +74,7 @@ class DFPatternRewriteComposer {
 
   inline Array<DFPatternCallback> MakeCallbacks() const {
     Array<DFPatternCallback> callbacks;
-    for (const auto rewrite : rewrites_) {
+    for (const auto& rewrite : rewrites_) {
       callbacks.push_back(rewrite->MakeCallback());
     }
     return callbacks;


### PR DESCRIPTION
I got compiling warnings by clang++ on my machine:
```
In file included from /home/syfeng/tvm-upstream/src/relay/transforms/simplify_expr.cc:25:
/home/syfeng/tvm-upstream/src/relay/transforms/simplify_expr.h:77:21: warning: loop variable 'rewrite' of type 'const std::shared_ptr<tvm::relay::DFPatternRewrite>' creates a copy from type 'const std::shared_ptr<tvm::relay::DFPatternRewrite>' [-Wrange-loop-construct]
    for (const auto rewrite : rewrites_) {
                    ^
/home/syfeng/tvm-upstream/src/relay/transforms/simplify_expr.h:77:10: note: use reference type 'const std::shared_ptr<tvm::relay::DFPatternRewrite> &' to prevent copying
    for (const auto rewrite : rewrites_) {
         ^~~~~~~~~~~~~~~~~~~~
                    &
```

And my compiler info :
```bash
$ clang++ -v
clang version 10.0.0-4ubuntu1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/9
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/9
Candidate multilib: .;@m64
Selected multilib: .;@m64
Found CUDA installation: /usr/local/cuda-11.2, version 7.0
```

cc @tqchen @junrushao1994 @jroesch 