### PR TITLE
[TensorIR] [Script] adding support for opaque block

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1318,7 +1318,8 @@ constexpr const char* fragment_layout = "fragment_layout";
 constexpr const char* hand_threaded = "hand_threaded";
 
 /*!
- * \brief Mark that whether a block need to be complete access region during script parsing.
+ * \brief Mark whether the script-completer need to fill in missing access region
+ *        during script parsing.
  * \note The result should be a integer mask with range [0, 4).
  *       if (mask & 1) the read region should be detected,
  *       if (mask & 2) the write region should be detected.

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1316,6 +1316,8 @@ constexpr const char* fragment_layout = "fragment_layout";
  * \brief Mark that the kernel is hand threaded and doesn't need syncs inserted
  */
 constexpr const char* hand_threaded = "hand_threaded";
+
+constexpr const char* script_parsing_detect_access = "tir.script_parsing_detect_access";
 /*!
  * \brief Check if attr_key is a pragma key extension
  * \param attr_key The attr key to be compared

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1317,6 +1317,12 @@ constexpr const char* fragment_layout = "fragment_layout";
  */
 constexpr const char* hand_threaded = "hand_threaded";
 
+/*!
+ * \brief Mark that whether a block need to be complete access region during script parsing.
+ * \note The result should be a integer mask with range [0, 4).
+ *       if (mask & 1) the read region should be detected,
+ *       if (mask & 2) the write region should be detected.
+ */
 constexpr const char* script_parsing_detect_access = "tir.script_parsing_detect_access";
 /*!
  * \brief Check if attr_key is a pragma key extension

--- a/python/tvm/script/scope_handler.py
+++ b/python/tvm/script/scope_handler.py
@@ -304,7 +304,10 @@ class Block(WithScopeHandler):
             values: List[PrimExpr]
             if not block_info.iter_bindings:
                 values = self.context.loop_stack[-2].copy()
-                if len(values) == 0:
+                if len(block_iters) == 0:
+                    # It is an opaque block without any bindings
+                    values = []
+                elif len(values) == 0:
                     values = [tvm.tir.const(float("nan"), dtype="float32")] * len(block_iters)
                 elif len(values) != len(block_iters):
                     self.context.report_error(

--- a/python/tvm/script/scope_handler.py
+++ b/python/tvm/script/scope_handler.py
@@ -283,11 +283,12 @@ class Block(WithScopeHandler):
                 else []
             )
 
-            region_detect_mask: int = (block_info.reads is None) | ((block_info.reads is None) << 1)
+            region_detect_mask: int = (block_info.reads is None) | (
+                (block_info.writes is None) << 1
+            )
             annotations = {} if block_info.annotations is None else block_info.annotations
             if region_detect_mask != 0:
-                annotations["script_detect_access"] = region_detect_mask
-
+                annotations["tir.script_parsing_detect_access"] = region_detect_mask
             inner = tvm.tir.Block(
                 block_iters,
                 reads,

--- a/python/tvm/script/scope_handler.py
+++ b/python/tvm/script/scope_handler.py
@@ -282,6 +282,12 @@ class Block(WithScopeHandler):
                 if block_info.writes
                 else []
             )
+
+            region_detect_mask: int = (block_info.reads is None) | ((block_info.reads is None) << 1)
+            annotations = {} if block_info.annotations is None else block_info.annotations
+            if region_detect_mask != 0:
+                annotations["script_detect_access"] = region_detect_mask
+
             inner = tvm.tir.Block(
                 block_iters,
                 reads,
@@ -291,7 +297,7 @@ class Block(WithScopeHandler):
                 block_info.init,
                 block_info.alloc_buffers,
                 block_info.match_buffers,
-                block_info.annotations,
+                annotations,
                 span,
             )
             # create block var iter binding

--- a/src/tir/ir/script/script_complete.cc
+++ b/src/tir/ir/script/script_complete.cc
@@ -79,7 +79,7 @@ class ScriptCompleter : public StmtMutator {
     // Get access detection mask
     // 0 for provided region, 1 and 3 for need detect read, 2 and 3 for need detect write
     int mask = 0;
-    auto it = op->annotations.find("script_detect_access");
+    auto it = op->annotations.find(attr::script_parsing_detect_access);
     if (it != op->annotations.end()) {
       mask = Downcast<IntImm>((*it).second)->value;
     }
@@ -103,7 +103,7 @@ class ScriptCompleter : public StmtMutator {
       if (mask & 1) n->reads = reads;
       if (mask & 2) n->writes = writes;
       n->annotations = op->annotations;
-      n->annotations.erase("script_detect_access");
+      n->annotations.erase(attr::script_parsing_detect_access);
       return Block(n);
     } else {
       return std::move(block);

--- a/src/tir/ir/script/script_complete.cc
+++ b/src/tir/ir/script/script_complete.cc
@@ -76,8 +76,15 @@ class ScriptCompleter : public StmtMutator {
     for (const auto& alloc_buffer : op->alloc_buffers) {
       buffer_var_map_->erase(alloc_buffer->data);
     }
+    // Get access detection mask
+    // 0 for provided region, 1 and 3 for need detect read, 2 and 3 for need detect write
+    int mask = 0;
+    auto it = op->annotations.find("script_detect_access");
+    if (it != op->annotations.end()) {
+      mask = Downcast<IntImm>((*it).second)->value;
+    }
     // ignore root block or blocks which already has reads/writes regions
-    if (block->reads.empty() || block->writes.empty()) {
+    if (mask != 0) {
       if (op->iter_vars.empty()) {
         // non-root opaque block is not allowed
         CHECK(is_root_block)
@@ -93,8 +100,10 @@ class ScriptCompleter : public StmtMutator {
           << "ValueError: Can not auto detect buffer access region from tir.Load, tir.Store or "
              "direct access by buffer data. Please annotation the access region manually";
       auto n = CopyOnWrite(block.operator->());
-      if (n->reads.empty()) n->reads = reads;
-      if (n->writes.empty()) n->writes = writes;
+      if (mask & 1) n->reads = reads;
+      if (mask & 2) n->writes = writes;
+      n->annotations = op->annotations;
+      n->annotations.erase("script_detect_access");
       return Block(n);
     } else {
       return std::move(block);


### PR DESCRIPTION
In this PR, we add script support for opaque blocks. 

An opaque block is a block without any block iterations and we need to specify the read/write region manually. 

cc @junrushao1994 @spectrometerHBH @tqchen 