### PR TITLE
[Vulkan] Support uniform buffer object for passing many scalar arguments (Take 2)

### DIFF
--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -205,6 +205,46 @@ VulkanBuffer* CreateBuffer(const VulkanContext& vctx, VkBufferCreateInfo info,
   return pbuf;
 }
 
+void CopyFromHostToDevice(VkDevice device, const void* from, size_t from_offset, void* to,
+                          size_t to_offset, size_t size, int vk_device_id, int cpu_device_id,
+                          bool coherent_staging) {
+  const auto* to_buf = static_cast<const VulkanBuffer*>(to);
+  VulkanStagingBuffer* temp = VulkanThreadEntry::ThreadLocal()->StagingBuffer(vk_device_id, size);
+  memcpy(temp->host_addr, static_cast<const char*>(from) + from_offset, size);
+  // host side flush if access is not coherent.
+  // so writes from CPU is visible to GPU
+  if (!coherent_staging) {
+    VkMappedMemoryRange mrange;
+    mrange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+    mrange.pNext = nullptr;
+    mrange.memory = temp->memory;
+    mrange.offset = 0;
+    mrange.size = VK_WHOLE_SIZE;  // size;
+    VULKAN_CALL(vkFlushMappedMemoryRanges(device, 1, &mrange));
+  }
+
+  VulkanThreadEntry::ThreadLocal()->Stream(cpu_device_id)->Launch([&](VulkanStreamState* state) {
+    // 0: barrier(host->transfer)
+    VkMemoryBarrier barrier_info;
+    barrier_info.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    barrier_info.pNext = nullptr;
+    barrier_info.srcAccessMask = 0;
+    barrier_info.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    vkCmdPipelineBarrier(state->cmd_buffer_, VK_PIPELINE_STAGE_HOST_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &barrier_info, 0, nullptr, 0,
+                         nullptr);
+    // 1: copy
+    VkBufferCopy copy_info;
+    copy_info.srcOffset = 0;
+    copy_info.dstOffset = to_offset;
+    copy_info.size = size;
+    vkCmdCopyBuffer(state->cmd_buffer_, temp->buffer, to_buf->buffer, 1, &copy_info);
+  });
+  // TODO(tulloch): should we instead make the staging buffer a property of the
+  // Stream? This would allow us to elide synchronizations here.
+  VulkanThreadEntry::ThreadLocal()->Stream(cpu_device_id)->Synchronize();
+}
+
 class VulkanDeviceAPI final : public DeviceAPI {
  public:
   VulkanDeviceAPI();
@@ -308,44 +348,8 @@ class VulkanDeviceAPI final : public DeviceAPI {
       memcpy(static_cast<char*>(to) + to_offset, static_cast<char*>(temp->host_addr), size);
     } else if (from_dev_type == kDLCPU && to_dev_type == kDLVulkan) {
       const auto& vctx = context(dev_to.device_id);
-      const auto* to_buf = static_cast<const VulkanBuffer*>(to);
-      VulkanStagingBuffer* temp =
-          VulkanThreadEntry::ThreadLocal()->StagingBuffer(dev_to.device_id, size);
-      memcpy(temp->host_addr, static_cast<const char*>(from) + from_offset, size);
-      // host side flush if access is not coherent.
-      // so writes from CPU is visible to GPU
-      if (!vctx.coherent_staging) {
-        VkMappedMemoryRange mrange;
-        mrange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
-        mrange.pNext = nullptr;
-        mrange.memory = temp->memory;
-        mrange.offset = 0;
-        mrange.size = VK_WHOLE_SIZE;  // size;
-        VULKAN_CALL(vkFlushMappedMemoryRanges(vctx.device, 1, &mrange));
-      }
-
-      VulkanThreadEntry::ThreadLocal()
-          ->Stream(dev_from.device_id)
-          ->Launch([&](VulkanStreamState* state) {
-            // 0: barrier(host->transfer)
-            VkMemoryBarrier barrier_info;
-            barrier_info.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-            barrier_info.pNext = nullptr;
-            barrier_info.srcAccessMask = 0;
-            barrier_info.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            vkCmdPipelineBarrier(state->cmd_buffer_, VK_PIPELINE_STAGE_HOST_BIT,
-                                 VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &barrier_info, 0, nullptr, 0,
-                                 nullptr);
-            // 1: copy
-            VkBufferCopy copy_info;
-            copy_info.srcOffset = 0;
-            copy_info.dstOffset = to_offset;
-            copy_info.size = size;
-            vkCmdCopyBuffer(state->cmd_buffer_, temp->buffer, to_buf->buffer, 1, &copy_info);
-          });
-      // TODO(tulloch): should we instead make the staging buffer a property of the
-      // Stream? This would allow us to elide synchronizations here.
-      VulkanThreadEntry::ThreadLocal()->Stream(dev_from.device_id)->Synchronize();
+      CopyFromHostToDevice(vctx.device, from, from_offset, to, to_offset, size, dev_to.device_id,
+                           dev_from.device_id, vctx.coherent_staging);
     } else {
       LOG(FATAL) << "Expect copy from/to Vulkan or between Vulkan"
                  << ", from=" << from_dev_type << ", to=" << to_dev_type;
@@ -824,9 +828,9 @@ class VulkanModuleNode final : public runtime::ModuleNode {
         vkDestroyShaderModule(vctx.device, pe->shader, nullptr);
         // UBO
         if (pe->ubo.vk_buf) {
-	  if (pe->ubo.host_buf) {
-	    vkUnmapMemory(vctx.device, pe->ubo.vk_buf->memory);
-	  }
+          if (pe->ubo.host_buf) {
+            vkUnmapMemory(vctx.device, pe->ubo.vk_buf->memory);
+          }
           vkDestroyBuffer(vctx.device, pe->ubo.vk_buf->buffer, nullptr);
           vkFreeMemory(vctx.device, pe->ubo.vk_buf->memory, nullptr);
           delete pe->ubo.vk_buf;
@@ -990,9 +994,11 @@ class VulkanModuleNode final : public runtime::ModuleNode {
       auto prop = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
       auto info = MakeBufferCreateInfo(vctx, nbytes_scalars, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
       auto mem_type_index = FindMemoryType(vctx, info, prop);
-      if (mem_type_index == -1) {
-	// If host visible memory is not found, use a normal storage buffer
-        ubo.vk_buf = CreateBuffer(vctx, info, vctx.compute_mtype_index);
+      if (true || mem_type_index == -1) {
+        // If host visible memory is not found, use a normal storage buffer
+        auto usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        ubo.vk_buf = CreateBuffer(vctx, MakeBufferCreateInfo(vctx, nbytes_scalars, usage),
+                                  vctx.compute_mtype_index);
       } else {
         ubo.vk_buf = CreateBuffer(vctx, info, mem_type_index);
         vkMapMemory(vctx.device, ubo.vk_buf->memory, 0, nbytes_scalars, 0, &(ubo.host_buf));
@@ -1159,7 +1165,6 @@ void VulkanWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
   const size_t nbytes_scalars = num_pack_args_ * sizeof(ArgUnion64);
   bool use_ubo = num_pack_args_ != 0 && nbytes_scalars > m_->MaxPushConstantsSize();
   if (use_ubo) {
-    CHECK(pipeline->ubo.host_buf) << "The UBO host buffer is not allocated";
     VkDescriptorBufferInfo binfo;
     binfo.buffer = pipeline->ubo.vk_buf->buffer;
     binfo.offset = 0;
@@ -1224,12 +1229,17 @@ void VulkanWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
     vkUpdateDescriptorSets(vctx.device, write_descriptor_sets.size(), write_descriptor_sets.data(),
                            0, 0);
   };
-  const auto& deferred_kernel = [this, pipeline, wl, pack_args_storage, use_ubo,
-                                 nbytes_scalars](VulkanStreamState* state) {
+  bool coherent_staging = vctx.coherent_staging;
+  VkDevice device = vctx.device;
+  const auto& deferred_kernel = [this, pipeline, wl, pack_args_storage, use_ubo, nbytes_scalars,
+                                 device_id, coherent_staging, device](VulkanStreamState* state) {
     if (use_ubo && pipeline->ubo.host_buf) {
       memcpy(pipeline->ubo.host_buf, pack_args_storage.data(), nbytes_scalars);
     } else if (use_ubo) {
-      // TODO
+      // TODO(masahi): Is this ok
+      int cpu_device_id = 0;
+      CopyFromHostToDevice(device, pack_args_storage.data(), 0, pipeline->ubo.vk_buf, 0,
+                           nbytes_scalars, cpu_device_id, device_id, coherent_staging);
     }
 
     vkCmdBindPipeline(state->cmd_buffer_, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -122,8 +122,8 @@ struct VulkanPipeline {
 
 typedef dmlc::ThreadLocalStore<VulkanThreadEntry> VulkanThreadStore;
 
-int FindMemoryType(const VulkanContext& vctx, VkBufferCreateInfo info,
-                   VkMemoryPropertyFlags req_prop) {
+uint32_t FindMemoryType(const VulkanContext& vctx, VkBufferCreateInfo info,
+                        VkMemoryPropertyFlags req_prop) {
   VkBuffer buffer;
   VULKAN_CALL(vkCreateBuffer(vctx.device, &info, nullptr, &buffer));
 
@@ -139,8 +139,8 @@ int FindMemoryType(const VulkanContext& vctx, VkBufferCreateInfo info,
     }
     type_bits >>= 1;
   }
-  LOG(INFO) << "Requested memory type not found";
-  return -1;
+  LOG(FATAL) << "Requested memory type not found";
+  return 0;
 }
 
 VkBufferCreateInfo MakeBufferCreateInfo(const VulkanContext& vctx, size_t nbytes,
@@ -1087,8 +1087,7 @@ VulkanHostVisibleBuffer* GetOrAllocate(
 VulkanStagingBuffer* VulkanThreadEntry::StagingBuffer(int device_id, size_t size) {
   const auto& vctx = VulkanDeviceAPI::Global()->context(device_id);
   auto usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-  auto buf = GetOrAllocate(device_id, size, usage, vctx.staging_mtype_index, &staging_buffers_);
-  return buf;
+  return GetOrAllocate(device_id, size, usage, vctx.staging_mtype_index, &staging_buffers_);
 }
 
 void VulkanThreadEntry::AllocateUniformBuffer(int device_id, size_t size) {

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -1087,7 +1087,6 @@ VulkanStagingBuffer* VulkanThreadEntry::StagingBuffer(int device_id, size_t size
   const auto& vctx = VulkanDeviceAPI::Global()->context(device_id);
   auto usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
   auto buf = GetOrAllocate(device_id, size, usage, vctx.staging_mtype_index, staging_buffers_);
-  memset(buf->host_addr, 0, size);
   return buf;
 }
 

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -1134,6 +1134,15 @@ VulkanStagingBuffer* VulkanThreadEntry::StagingBuffer(int device_id, size_t size
   return buf;
 }
 
+void VulkanThreadEntry::AllocateUniformBuffer(int device_id, size_t size) {
+  const auto& vctx = VulkanDeviceAPI::Global()->context(device_id);
+  auto prop = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  auto info = MakeBufferCreateInfo(vctx, size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+  auto mem_type_index = FindMemoryType(vctx, info, prop);
+  GetOrAllocate(device_id, size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_type_index,
+                uniform_buffers_);
+}
+
 VulkanThreadEntry::VulkanThreadEntry()
     : pool(std::make_unique<WorkspacePool>(static_cast<DLDeviceType>(kDLVulkan),
                                            VulkanDeviceAPI::Global())) {

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -110,13 +110,16 @@ struct VulkanPipeline {
 
 typedef dmlc::ThreadLocalStore<VulkanThreadEntry> VulkanThreadStore;
 
-uint32_t FindMemoryType(VkDevice logical_device, VkPhysicalDevice phy_device, VkBuffer buffer,
-                        VkMemoryPropertyFlags req_prop) {
+int FindMemoryType(const VulkanContext& vctx, VkBufferCreateInfo info,
+                   VkMemoryPropertyFlags req_prop) {
+  VkBuffer buffer;
+  VULKAN_CALL(vkCreateBuffer(vctx.device, &info, nullptr, &buffer));
+
   VkMemoryRequirements mem_reqs;
-  vkGetBufferMemoryRequirements(logical_device, buffer, &mem_reqs);
+  vkGetBufferMemoryRequirements(vctx.device, buffer, &mem_reqs);
   uint32_t type_bits = mem_reqs.memoryTypeBits;
   VkPhysicalDeviceMemoryProperties phy_mem_prop;
-  vkGetPhysicalDeviceMemoryProperties(phy_device, &phy_mem_prop);
+  vkGetPhysicalDeviceMemoryProperties(vctx.phy_device, &phy_mem_prop);
   for (uint32_t i = 0; i < phy_mem_prop.memoryTypeCount; i++) {
     if ((type_bits & 1) == 1 &&
         (phy_mem_prop.memoryTypes[i].propertyFlags & req_prop) == req_prop) {
@@ -124,11 +127,12 @@ uint32_t FindMemoryType(VkDevice logical_device, VkPhysicalDevice phy_device, Vk
     }
     type_bits >>= 1;
   }
-  LOG(FATAL) << "Requested memory type not found";
-  return 0;
+  LOG(INFO) << "Requested memory type not found";
+  return -1;
 }
 
-VulkanBuffer* CreateBuffer(const VulkanContext& vctx, size_t nbytes, VkBufferUsageFlags usage) {
+VkBufferCreateInfo MakeBufferCreateInfo(const VulkanContext& vctx, size_t nbytes,
+                                        VkBufferUsageFlags usage) {
   VkBufferCreateInfo info;
   info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
   info.pNext = nullptr;
@@ -138,17 +142,14 @@ VulkanBuffer* CreateBuffer(const VulkanContext& vctx, size_t nbytes, VkBufferUsa
   info.pQueueFamilyIndices = &(vctx.queue_family_index);
   info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
   info.usage = usage;
+  return info;
+}
+
+VulkanBuffer* CreateBuffer(const VulkanContext& vctx, VkBufferCreateInfo info,
+                           uint32_t mem_type_index) {
   // create buffer
   VkBuffer buffer;
   VULKAN_CALL(vkCreateBuffer(vctx.device, &info, nullptr, &buffer));
-
-  uint32_t mem_type_index = vctx.compute_mtype_index;
-
-  if (usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
-    // Find a memory type that supports UBO
-    auto prop = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    mem_type_index = FindMemoryType(vctx.device, vctx.phy_device, buffer, prop);
-  }
 
   // bind to memory
   bool dedicated_allocation = false;
@@ -179,7 +180,7 @@ VulkanBuffer* CreateBuffer(const VulkanContext& vctx, size_t nbytes, VkBufferUsa
     VkMemoryAllocateInfo minfo;
     minfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     minfo.pNext = nullptr;
-    minfo.allocationSize = nbytes;
+    minfo.allocationSize = info.size;
     minfo.memoryTypeIndex = mem_type_index;
     VULKAN_CALL(vkAllocateMemory(vctx.device, &minfo, nullptr, &memory));
   } else {
@@ -226,7 +227,8 @@ class VulkanDeviceAPI final : public DeviceAPI {
     const auto& vctx = context(dev.device_id);
     auto usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-    return CreateBuffer(vctx, nbytes, usage);
+    auto info = MakeBufferCreateInfo(vctx, nbytes, usage);
+    return CreateBuffer(vctx, info, vctx.compute_mtype_index);
   }
 
   void FreeDataSpace(Device dev, void* ptr) final {
@@ -982,8 +984,16 @@ class VulkanModuleNode final : public runtime::ModuleNode {
     if (nbytes_scalars > max_push_constants_) {
       // Allocate, bind and map UBO
       UniformBuffer& ubo = pe->ubo;
-      ubo.vk_buf = CreateBuffer(vctx, nbytes_scalars, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
-      vkMapMemory(vctx.device, ubo.vk_buf->memory, 0, nbytes_scalars, 0, &(ubo.host_buf));
+      // Find a memory type that supports UBO
+      auto prop = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+      auto info = MakeBufferCreateInfo(vctx, nbytes_scalars, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+      auto mem_type_index = FindMemoryType(vctx, info, prop);
+      if (mem_type_index == -1) {
+        ubo.vk_buf = CreateBuffer(vctx, info, vctx.compute_mtype_index);
+      } else {
+        ubo.vk_buf = CreateBuffer(vctx, info, mem_type_index);
+        vkMapMemory(vctx.device, ubo.vk_buf->memory, 0, nbytes_scalars, 0, &(ubo.host_buf));
+      }
     }
 
     if (vctx.UseImmediate()) {

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -1060,7 +1060,8 @@ VulkanThreadEntry* VulkanThreadEntry::ThreadLocal() { return VulkanThreadStore::
 
 VulkanHostVisibleBuffer* GetOrAllocate(
     int device_id, size_t size, VkBufferUsageFlags usage, uint32_t mem_type_index,
-    std::unordered_map<size_t, std::unique_ptr<VulkanHostVisibleBuffer>>& buffers) {
+    std::unordered_map<size_t, std::unique_ptr<VulkanHostVisibleBuffer>>* buffers_ptr) {
+  auto& buffers = *buffers_ptr;
   if (!buffers[device_id]) {
     buffers[device_id] = std::make_unique<VulkanHostVisibleBuffer>();
   }
@@ -1086,7 +1087,7 @@ VulkanHostVisibleBuffer* GetOrAllocate(
 VulkanStagingBuffer* VulkanThreadEntry::StagingBuffer(int device_id, size_t size) {
   const auto& vctx = VulkanDeviceAPI::Global()->context(device_id);
   auto usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-  auto buf = GetOrAllocate(device_id, size, usage, vctx.staging_mtype_index, staging_buffers_);
+  auto buf = GetOrAllocate(device_id, size, usage, vctx.staging_mtype_index, &staging_buffers_);
   return buf;
 }
 
@@ -1096,7 +1097,7 @@ void VulkanThreadEntry::AllocateUniformBuffer(int device_id, size_t size) {
   auto info = MakeBufferCreateInfo(vctx, size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
   auto mem_type_index = FindMemoryType(vctx, info, prop);
   GetOrAllocate(device_id, size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_type_index,
-                uniform_buffers_);
+                &uniform_buffers_);
 }
 
 VulkanUniformBuffer* VulkanThreadEntry::GetUniformBuffer(int device_id, size_t size) {

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -854,7 +854,7 @@ class VulkanModuleNode final : public runtime::ModuleNode {
       // create shader
       auto sit = smap_.find(func_name);
       ICHECK(sit != smap_.end());
-      pe->use_ubo = sit->second.flag & (1 << kUSE_UBO);
+      pe->use_ubo = sit->second.flag & (1 << ShaderMetaDataFlagMask::kUseUBO);
       const std::vector<uint32_t>& data = sit->second.data;
       VkShaderModuleCreateInfo shader_cinfo;
       shader_cinfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -45,6 +45,14 @@ static constexpr const int kVulkanMaxNumDevice = 8;
 /*! \brief TVM Vulkan binary pack magic number */
 static constexpr const int kVulkanModuleMagic = 0x02700027;
 
+struct VulkanStagingBuffer {
+  VkDevice device{nullptr};
+  VkBuffer buffer{VK_NULL_HANDLE};
+  VkDeviceMemory memory{VK_NULL_HANDLE};
+  void* host_addr{nullptr};
+  size_t size{0};
+};
+
 class VulkanThreadEntry {
  public:
   VulkanThreadEntry();

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -155,8 +155,9 @@ VkBufferCreateInfo MakeBufferCreateInfo(const VulkanContext& vctx, size_t nbytes
   return info;
 }
 
-VulkanBuffer* CreateBuffer(const VulkanContext& vctx, VkBufferCreateInfo info,
+VulkanBuffer* CreateBuffer(const VulkanContext& vctx, size_t nbytes, VkBufferUsageFlags usage,
                            uint32_t mem_type_index) {
+  auto info = MakeBufferCreateInfo(vctx, nbytes, usage);
   // create buffer
   VkBuffer buffer;
   VULKAN_CALL(vkCreateBuffer(vctx.device, &info, nullptr, &buffer));
@@ -213,12 +214,6 @@ VulkanBuffer* CreateBuffer(const VulkanContext& vctx, VkBufferCreateInfo info,
   pbuf->memory = memory;
   pbuf->buffer = buffer;
   return pbuf;
-}
-
-VulkanBuffer* CreateBuffer(const VulkanContext& vctx, size_t nbytes, VkBufferUsageFlags usage,
-                           uint32_t mem_type_index) {
-  auto info = MakeBufferCreateInfo(vctx, nbytes, usage);
-  return CreateBuffer(vctx, info, mem_type_index);
 }
 
 class VulkanDeviceAPI final : public DeviceAPI {

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -142,6 +142,9 @@ struct VulkanContext {
   bool UseImmediate() const { return descriptor_template_khr_functions.get() != nullptr; }
 };
 
+/*! \brief returns maximum push constant sizes in bytes for the target platform */
+uint32_t GetMaxPushConstantsSize();
+
 }  // namespace vulkan
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -37,7 +37,8 @@ namespace vulkan {
 
 const int kMaxPushConstantsBytes = 128;
 
-enum ShaderMetaDataKind { kUSE_UBO = 0 };
+/*! \brief A mask used when we attach additional information to shaders */
+enum ShaderMetaDataFlagMask { kUseUBO = 0 };
 
 inline const char* VKGetErrorString(VkResult error) {
   switch (error) {

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -35,7 +35,7 @@ namespace tvm {
 namespace runtime {
 namespace vulkan {
 
-#define kMaxPushConstantsBytes 128
+const int kMaxPushConstantsBytes = 128;
 
 enum ShaderMetaDataKind { kUSE_UBO = 0 };
 

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -37,6 +37,8 @@ namespace vulkan {
 
 #define kMaxPushConstantsBytes 128
 
+enum ShaderMetaDataKind { kUSE_UBO = 0 };
+
 inline const char* VKGetErrorString(VkResult error) {
   switch (error) {
     case VK_SUCCESS:

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -35,6 +35,8 @@ namespace tvm {
 namespace runtime {
 namespace vulkan {
 
+#define kMaxPushConstantsBytes 128
+
 inline const char* VKGetErrorString(VkResult error) {
   switch (error) {
     case VK_SUCCESS:
@@ -133,9 +135,6 @@ struct VulkanContext {
 
   bool UseImmediate() const { return descriptor_template_khr_functions.get() != nullptr; }
 };
-
-/*! \brief returns maximum push constant sizes in bytes for the target platform */
-uint32_t GetMaxPushConstantsSize();
 
 }  // namespace vulkan
 }  // namespace runtime

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -105,14 +105,6 @@ struct VulkanGetBufferMemoryRequirements2Functions {
   PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR{nullptr};
 };
 
-struct VulkanStagingBuffer {
-  VkDevice device{nullptr};
-  VkBuffer buffer{VK_NULL_HANDLE};
-  VkDeviceMemory memory{VK_NULL_HANDLE};
-  void* host_addr{nullptr};
-  size_t size{0};
-};
-
 struct VulkanContext {
   // phyiscal device
   VkPhysicalDevice phy_device{nullptr};

--- a/src/target/spirv/build_vulkan.cc
+++ b/src/target/spirv/build_vulkan.cc
@@ -88,10 +88,9 @@ runtime::Module BuildSPIRV(IRModule mod, Target target, bool webgpu_restriction)
         << "CodeGenSPIRV: Expect PrimFunc to have the global_symbol attribute";
 
     std::string f_name = global_symbol.value();
-
-    VulkanShader shader;
     std::string entry = webgpu_restriction ? "main" : f_name;
-    shader.data = cg.BuildFunction(f, entry);
+
+    VulkanShader shader = cg.BuildFunction(f, entry);
 
     if (webgpu_restriction) {
       for (auto param : f->params) {

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -85,7 +85,7 @@ runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
         var_map_[pod_args[i].get()] = value;
       }
     } else {
-      shader.flag |= 1 << runtime::vulkan::kUSE_UBO;
+      shader.flag |= 1 << runtime::vulkan::ShaderMetaDataFlagMask::kUseUBO;
       // If we need to pass more arguments than push constants could handle, we use UBO.
       spirv::Value ptr = builder_->DeclareUniformBuffer(value_types, num_buffer);
       for (size_t i = 0; i < pod_args.size(); ++i) {

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -77,7 +77,7 @@ runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
     for (size_t i = 0; i < pod_args.size(); ++i) {
       value_types.push_back(builder_->GetSType(pod_args[i].dtype()));
     }
-    if (pod_args.size() * sizeof(runtime::ArgUnion64) <= kMaxPushConstantsBytes) {
+    if (pod_args.size() * sizeof(runtime::ArgUnion64) <= runtime::vulkan::kMaxPushConstantsBytes) {
       spirv::Value ptr = builder_->DeclarePushConstant(value_types);
       for (size_t i = 0; i < pod_args.size(); ++i) {
         spirv::Value value =

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -70,13 +70,14 @@ runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
   spirv::Value func_ptr = builder_->NewFunction();
   builder_->StartFunction(func_ptr);
 
+  runtime::VulkanShader shader;
+
   if (pod_args.size() != 0) {
     std::vector<spirv::SType> value_types;
     for (size_t i = 0; i < pod_args.size(); ++i) {
       value_types.push_back(builder_->GetSType(pod_args[i].dtype()));
     }
-    const auto max_push_constants = runtime::vulkan::GetMaxPushConstantsSize();
-    if (pod_args.size() * sizeof(runtime::ArgUnion64) <= max_push_constants) {
+    if (pod_args.size() * sizeof(runtime::ArgUnion64) <= kMaxPushConstantsBytes) {
       spirv::Value ptr = builder_->DeclarePushConstant(value_types);
       for (size_t i = 0; i < pod_args.size(); ++i) {
         spirv::Value value =
@@ -98,7 +99,7 @@ runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
   builder_->MakeInst(spv::OpFunctionEnd);
 
   builder_->CommitKernelFunction(func_ptr, name);
-  runtime::VulkanShader shader;
+
   shader.data = builder_->Finalize();
   return shader;
 }

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -85,6 +85,7 @@ runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
         var_map_[pod_args[i].get()] = value;
       }
     } else {
+      shader.flag |= 1 << runtime::vulkan::kUSE_UBO;
       // If we need to pass more arguments than push constants could handle, we use UBO.
       spirv::Value ptr = builder_->DeclareUniformBuffer(value_types, num_buffer);
       for (size_t i = 0; i < pod_args.size(); ++i) {

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -32,11 +32,12 @@
 
 #include "../../runtime/pack_args.h"
 #include "../../runtime/vulkan/vulkan_common.h"
+#include "../../runtime/vulkan/vulkan_shader.h"
 
 namespace tvm {
 namespace codegen {
 
-std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::string& name) {
+runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::string& name) {
   this->InitFuncState();
   ICHECK(f->HasNonzeroAttr(tir::attr::kNoAlias)) << "SPIRV only takes restricted memory model";
   std::vector<Var> pod_args;
@@ -97,8 +98,9 @@ std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
   builder_->MakeInst(spv::OpFunctionEnd);
 
   builder_->CommitKernelFunction(func_ptr, name);
-
-  return builder_->Finalize();
+  runtime::VulkanShader shader;
+  shader.data = builder_->Finalize();
+  return shader;
 }
 
 void CodeGenSPIRV::InitFuncState() {

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "../../runtime/thread_storage_scope.h"
+#include "../../runtime/vulkan/vulkan_shader.h"
 #include "ir_builder.h"
 
 namespace tvm {
@@ -55,7 +56,7 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
    * \param name The name of the target function.
    * \return The final spirv module.
    */
-  virtual std::vector<uint32_t> BuildFunction(const PrimFunc& f, const std::string& name);
+  virtual runtime::VulkanShader BuildFunction(const PrimFunc& f, const std::string& name);
   /*!
    * \brief Create Value for expression e
    * \param e The expression to be created value for.

--- a/src/target/spirv/ir_builder.cc
+++ b/src/target/spirv/ir_builder.cc
@@ -205,8 +205,8 @@ Value IRBuilder::BufferArgument(const SType& value_type, uint32_t descriptor_set
   return val;
 }
 
-Value IRBuilder::DeclarePushConstant(const std::vector<SType>& value_types) {
-  ICHECK_EQ(push_const_.id, 0);
+Value IRBuilder::DeclareStorageVariable(const std::vector<SType>& value_types,
+                                        spv::StorageClass storage_class, ValueKind kind) {
   SType struct_type;
   struct_type.id = id_counter_++;
   struct_type.type = DataType::Handle();
@@ -226,24 +226,41 @@ Value IRBuilder::DeclarePushConstant(const std::vector<SType>& value_types) {
     ICHECK_EQ(nbits % 8, 0);
     uint32_t bytes = (nbits / 8);
     if (t.bits() == 32) {
-      // In our Vulkan runtime, each push constant always occupies 64 bit.
+      // In our Vulkan runtime, each scalar argument always occupies 64 bit.
       offset += bytes * 2;
     } else {
       ICHECK_EQ(t.bits(), 64);
       offset += bytes;
     }
   }
-  // Decorate push constants as UBO
   this->Decorate(spv::OpDecorate, struct_type, spv::DecorationBlock);
 
-  SType ptr_type = GetPointerType(struct_type, spv::StorageClassPushConstant);
-  Value val = NewValue(ptr_type, kPushConstantPtr);
-  ib_.Begin(spv::OpVariable).AddSeq(ptr_type, val, spv::StorageClassPushConstant).Commit(&global_);
+  SType ptr_type = GetPointerType(struct_type, storage_class);
+  Value val = NewValue(ptr_type, kind);
+  ib_.Begin(spv::OpVariable).AddSeq(ptr_type, val, storage_class).Commit(&global_);
   return val;
+}
+
+Value IRBuilder::DeclarePushConstant(const std::vector<SType>& value_types) {
+  ICHECK_EQ(push_const_.id, 0);
+  return DeclareStorageVariable(value_types, spv::StorageClassPushConstant, kPushConstantPtr);
 }
 
 Value IRBuilder::GetPushConstant(Value ptr_push_const, const SType& v_type, uint32_t index) {
   SType ptr_vtype = this->GetPointerType(v_type, spv::StorageClassPushConstant);
+  Value ptr = this->MakeValue(spv::OpAccessChain, ptr_vtype, ptr_push_const,
+                              IntImm(t_int32_, static_cast<int64_t>(index)));
+  return this->MakeValue(spv::OpLoad, v_type, ptr);
+}
+
+Value IRBuilder::DeclareUniformBuffer(const std::vector<SType>& value_types, uint32_t binding) {
+  Value val = DeclareStorageVariable(value_types, spv::StorageClassUniform, kUniformPtr);
+  this->Decorate(spv::OpDecorate, val, spv::DecorationBinding, binding);
+  return val;
+}
+
+Value IRBuilder::GetUniform(Value ptr_push_const, const SType& v_type, uint32_t index) {
+  SType ptr_vtype = this->GetPointerType(v_type, spv::StorageClassUniform);
   Value ptr = this->MakeValue(spv::OpAccessChain, ptr_vtype, ptr_push_const,
                               IntImm(t_int32_, static_cast<int64_t>(index)));
   return this->MakeValue(spv::OpLoad, v_type, ptr);

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -60,7 +60,8 @@ enum ValueKind {
   kStructArrayPtr,
   kPushConstantPtr,
   kFunction,
-  kExtInst
+  kExtInst,
+  kUniformPtr
 };
 
 /*! \brief Represent the SPIRV Value */
@@ -473,6 +474,7 @@ class IRBuilder {
    * \param The argument type.
    */
   Value BufferArgument(const SType& value_type, uint32_t descriptor_set, uint32_t binding);
+
   /*!
    * \brief Declare POD arguments through push constants.
    *
@@ -488,6 +490,23 @@ class IRBuilder {
    * \return the value of push constant
    */
   Value GetPushConstant(Value ptr_push_const, const SType& v_type, uint32_t index);
+
+  /*!
+   * \brief Declare POD arguments through uniform buffer.
+   *
+   * \note Only call this function once!
+   * \param value_types The values in the uniform buffer
+   * \param binding The binding locaiton in descriptor set
+   * \return reference to self.
+   */
+  Value DeclareUniformBuffer(const std::vector<SType>& value_types, uint32_t binding);
+  /*!
+   * \brief Get i-th uniform constant
+   * \param v_type The value type
+   * \param index The uniform index
+   * \return the value of uniform constant
+   */
+  Value GetUniform(Value ptr_ubo, const SType& v_type, uint32_t index);
   /*!
    * \brief Declare a new function
    * \return The created function ID.
@@ -555,6 +574,17 @@ class IRBuilder {
     val.flag = flag;
     return val;
   }
+
+  /*!
+   * \brief The common function to declare push constants or uniform buffer
+   * \param value_types The values in the push constants or uniform buffer
+   * \param storage_class An enum defined by SPIR-V indicating push constant or uniform
+   * \param kind An enum indicating push constant or uniform
+   * \return The created new label
+   */
+  Value DeclareStorageVariable(const std::vector<SType>& value_types,
+                               spv::StorageClass storage_class, ValueKind kind);
+
   // get constant given value encoded in uint64_t
   Value GetConst_(const SType& dtype, const uint64_t* pvalue);
   // declare type


### PR DESCRIPTION
A follow up to https://github.com/apache/tvm/pull/7717 per discussion https://github.com/apache/tvm/pull/7717#issuecomment-817316477

All issues raised have been addressed. Now one UBO is allocated per `VulkanThreadEntry`, in a similar way as staging buffer. 

We always allocate UBO in a host visible memory. @tqchen asked if we can assume that we can always find such memory. Actually we are already making such assumption when allocating staging buffer here https://github.com/apache/tvm/blob/be87d56de011b4f18a3984ddff1da21c0675dac0/src/runtime/vulkan/vulkan.cc#L658

I did find a slide https://gpuopen.com/wp-content/uploads/2016/05/Most-common-mistakes-in-Vulkan-apps.pdf where it says "At least one memory type is host-visible & host-coherent" (page 19) but so far I'm not finding the official statement in the spec.


Since the way we allocate and use UBO is similar to staging buffer, I refactored vk runtime code to cleanly support both cases.

please review @tqchen @tmoreau89 @ajtulloch 