### PR TITLE
[OpenCL] Refactor cl_program generation

### DIFF
--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -329,14 +329,14 @@ class OpenCLModuleNode : public ModuleNode {
   std::mutex build_lock_;
   // The OpenCL source.
   std::string source_;
-  // the binary data
-  cl_program program_{nullptr};
-  // build info
-  std::vector<bool> device_built_flag_;
+  // Mapping from primitive name to cl program for each device.
+  std::unordered_map<std::string, std::vector<cl_program>> programs_;
   // kernel id cache
   std::unordered_map<std::string, KTRefEntry> kid_map_;
   // kernels build so far.
   std::vector<cl_kernel> kernels_;
+  // parsed kernel data
+  std::unordered_map<std::string, std::string> parsed_kernels_;
 };
 
 }  // namespace runtime

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -315,6 +315,13 @@ class OpenCLModuleNode : public ModuleNode {
   cl_kernel InstallKernel(cl::OpenCLWorkspace* w, cl::OpenCLThreadEntry* t,
                           const std::string& func_name, const KTRefEntry& e);
 
+  /*
+   * \brief Splits the provided serialized source file into separate
+   * source for each kernel primitive.
+   * \param source The serialized program source file (fmt: cl)
+   */
+  std::unordered_map<std::string, std::string> SplitKernels(std::string source) const;
+
  private:
   // The workspace, need to keep reference to use it in destructor.
   // In case of static destruction order problem.

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -319,6 +319,7 @@ class OpenCLModuleNode : public ModuleNode {
    * \brief Splits the provided serialized source file into separate
    * source for each kernel primitive.
    * \param source The serialized program source file (fmt: cl)
+   * \return Mapping from primitive name to kernel source
    */
   std::unordered_map<std::string, std::string> SplitKernels(std::string source) const;
 

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -105,12 +105,11 @@ OpenCLModuleNode::~OpenCLModuleNode() {
   for (cl_kernel k : kernels_) {
     OPENCL_CALL(clReleaseKernel(k));
   }
-  if (programs_.size()) {
-    for (auto& kv : programs_) {
-      for (auto& program : kv.second) {
-        if (program) {
-          OPENCL_CALL(clReleaseProgram(program));
-        }
+  // free the programs
+  for (auto& kv : programs_) {
+    for (auto& program : kv.second) {
+      if (program) {
+        OPENCL_CALL(clReleaseProgram(program));
       }
     }
   }
@@ -187,6 +186,8 @@ void OpenCLModuleNode::Init() {
     kid_map_[key] = e;
   }
 
+  // Use function delimiters to parse the serialized source
+  // into separate source files for each kernel primitive
   std::string source = GetSource("cl");
   if (source.size()) {
     std::string del{"// Function: "};

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -252,7 +252,7 @@ std::unordered_map<std::string, std::string> OpenCLModuleNode::SplitKernels(
     ICHECK(begin != std::string::npos) << "The OpenCL module expects a kernel delimited "
                                        << "source from code generation, but no kernel "
                                        << "delimiter was found.";
-    while (true) {
+    for (size_t num_kernels = 0; num_kernels < workspace_->num_registered_kernels; num_kernels++) {
       begin += del.size();
       end = source.find('\n', begin);
       std::string func_name = source.substr(begin, end - begin);
@@ -270,6 +270,8 @@ std::unordered_map<std::string, std::string> OpenCLModuleNode::SplitKernels(
       }
     }
   }
+  ICHECK_EQ(workspace_->num_registered_kernels, split_kernels.size())
+      << "The number of registered kernels does not match number of parsed kernel sources";
   return split_kernels;
 }
 

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -105,8 +105,14 @@ OpenCLModuleNode::~OpenCLModuleNode() {
   for (cl_kernel k : kernels_) {
     OPENCL_CALL(clReleaseKernel(k));
   }
-  if (program_) {
-    OPENCL_CALL(clReleaseProgram(program_));
+  if (programs_.size()) {
+    for (auto& kv : programs_) {
+      for (auto& program : kv.second) {
+        if (program) {
+          OPENCL_CALL(clReleaseProgram(program));
+        }
+      }
+    }
   }
 }
 
@@ -166,7 +172,6 @@ std::string OpenCLModuleNode::GetSource(const std::string& format) {
 void OpenCLModuleNode::Init() {
   workspace_ = GetGlobalWorkspace();
   workspace_->Init();
-  device_built_flag_.resize(workspace_->devices.size(), false);
   // initialize the kernel id, need to lock global table.
   std::lock_guard<std::mutex> lock(workspace_->mu);
   for (const auto& kv : fmap_) {
@@ -181,28 +186,53 @@ void OpenCLModuleNode::Init() {
     e.version = workspace_->timestamp++;
     kid_map_[key] = e;
   }
+
+  std::string source = GetSource("cl");
+  if (source.size()) {
+    std::string del{"// Function: "};
+    size_t end;
+    size_t begin = source.find(del);
+    ICHECK(begin != std::string::npos) << "The OpenCL module expects a kernel delimited "
+                                       << "source from code generation, but no kernel "
+                                       << "delimiter was found.";
+    while (true) {
+      begin += del.size();
+      end = source.find('\n', begin);
+      std::string func_name = source.substr(begin, end-begin);
+      begin = ++end;
+      // std::string::substr returns either start of next kernel
+      // or std::string::npos, in the latter case substr returns
+      // all characters until the end of the source string.
+      end = source.find(del, begin);
+      std::string func_source = source.substr(begin, (end == std::string::npos) ? end : end-begin);
+      parsed_kernels_.insert({func_name, func_source});
+      begin = end;
+      if (end == std::string::npos) { break; }
+    }
+  }
+  for (auto& kv : parsed_kernels_) {
+    programs_.insert({kv.first, std::vector<cl_program>(workspace_->devices.size(), nullptr)});
+  }
 }
 
 cl_kernel OpenCLModuleNode::InstallKernel(cl::OpenCLWorkspace* w, cl::OpenCLThreadEntry* t,
                                           const std::string& func_name, const KTRefEntry& e) {
   std::lock_guard<std::mutex> lock(build_lock_);
   int device_id = t->device.device_id;
-  if (!device_built_flag_[device_id]) {
+  if (programs_[func_name][device_id] == nullptr) {
     // create program
     if (fmt_ == "cl") {
-      if (program_ == nullptr) {
-        const char* s = data_.c_str();
-        size_t len = data_.length();
-        cl_int err;
-        program_ = clCreateProgramWithSource(w->context, 1, &s, &len, &err);
-        OPENCL_CHECK_ERROR(err);
-      }
+      const char* s = parsed_kernels_[func_name].c_str();
+      size_t len = parsed_kernels_[func_name].length();
+      cl_int err;
+      programs_[func_name][device_id] = clCreateProgramWithSource(w->context, 1, &s, &len, &err);
+      OPENCL_CHECK_ERROR(err);
     } else if (fmt_ == "xclbin" || fmt_ == "awsxclbin" || fmt_ == "aocx") {
       const unsigned char* s = (const unsigned char*)data_.c_str();
       size_t len = data_.length();
       cl_int err;
       cl_device_id dev = w->devices[device_id];
-      program_ = clCreateProgramWithBinary(w->context, 1, &dev, &len, &s, NULL, &err);
+      programs_[func_name][device_id] = clCreateProgramWithBinary(w->context, 1, &dev, &len, &s, NULL, &err);
       OPENCL_CHECK_ERROR(err);
     } else {
       LOG(FATAL) << "Unknown OpenCL format " << fmt_;
@@ -210,20 +240,19 @@ cl_kernel OpenCLModuleNode::InstallKernel(cl::OpenCLWorkspace* w, cl::OpenCLThre
     // build program
     cl_int err;
     cl_device_id dev = w->devices[device_id];
-    err = clBuildProgram(program_, 1, &dev, nullptr, nullptr, nullptr);
+    err = clBuildProgram(programs_[func_name][device_id], 1, &dev, nullptr, nullptr, nullptr);
     if (err != CL_SUCCESS) {
       size_t len;
       std::string log;
-      clGetProgramBuildInfo(program_, dev, CL_PROGRAM_BUILD_LOG, 0, nullptr, &len);
+      clGetProgramBuildInfo(programs_[func_name][device_id], dev, CL_PROGRAM_BUILD_LOG, 0, nullptr, &len);
       log.resize(len);
-      clGetProgramBuildInfo(program_, dev, CL_PROGRAM_BUILD_LOG, len, &log[0], nullptr);
-      LOG(FATAL) << "OpenCL build error for device=" << dev << log;
+      clGetProgramBuildInfo(programs_[func_name][device_id], dev, CL_PROGRAM_BUILD_LOG, len, &log[0], nullptr);
+      LOG(FATAL) << "OpenCL build error for device=" << dev << "\n" << log;
     }
-    device_built_flag_[device_id] = true;
   }
   // build kernel
   cl_int err;
-  cl_kernel kernel = clCreateKernel(program_, func_name.c_str(), &err);
+  cl_kernel kernel = clCreateKernel(programs_[func_name][device_id], func_name.c_str(), &err);
   OPENCL_CHECK_ERROR(err);
   t->kernel_table[e.kernel_id].kernel = kernel;
   t->kernel_table[e.kernel_id].version = e.version;

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -198,16 +198,19 @@ void OpenCLModuleNode::Init() {
     while (true) {
       begin += del.size();
       end = source.find('\n', begin);
-      std::string func_name = source.substr(begin, end-begin);
+      std::string func_name = source.substr(begin, end - begin);
       begin = ++end;
       // std::string::substr returns either start of next kernel
       // or std::string::npos, in the latter case substr returns
       // all characters until the end of the source string.
       end = source.find(del, begin);
-      std::string func_source = source.substr(begin, (end == std::string::npos) ? end : end-begin);
+      std::string func_source =
+          source.substr(begin, (end == std::string::npos) ? end : end - begin);
       parsed_kernels_.insert({func_name, func_source});
       begin = end;
-      if (end == std::string::npos) { break; }
+      if (end == std::string::npos) {
+        break;
+      }
     }
   }
   for (auto& kv : parsed_kernels_) {
@@ -232,7 +235,8 @@ cl_kernel OpenCLModuleNode::InstallKernel(cl::OpenCLWorkspace* w, cl::OpenCLThre
       size_t len = data_.length();
       cl_int err;
       cl_device_id dev = w->devices[device_id];
-      programs_[func_name][device_id] = clCreateProgramWithBinary(w->context, 1, &dev, &len, &s, NULL, &err);
+      programs_[func_name][device_id] =
+          clCreateProgramWithBinary(w->context, 1, &dev, &len, &s, NULL, &err);
       OPENCL_CHECK_ERROR(err);
     } else {
       LOG(FATAL) << "Unknown OpenCL format " << fmt_;
@@ -244,9 +248,11 @@ cl_kernel OpenCLModuleNode::InstallKernel(cl::OpenCLWorkspace* w, cl::OpenCLThre
     if (err != CL_SUCCESS) {
       size_t len;
       std::string log;
-      clGetProgramBuildInfo(programs_[func_name][device_id], dev, CL_PROGRAM_BUILD_LOG, 0, nullptr, &len);
+      clGetProgramBuildInfo(programs_[func_name][device_id], dev, CL_PROGRAM_BUILD_LOG, 0, nullptr,
+                            &len);
       log.resize(len);
-      clGetProgramBuildInfo(programs_[func_name][device_id], dev, CL_PROGRAM_BUILD_LOG, len, &log[0], nullptr);
+      clGetProgramBuildInfo(programs_[func_name][device_id], dev, CL_PROGRAM_BUILD_LOG, len,
+                            &log[0], nullptr);
       LOG(FATAL) << "OpenCL build error for device=" << dev << "\n" << log;
     }
   }


### PR DESCRIPTION
I have encountered a few pathological bugs in the opencl compiler provided on the snapdragon android platform (e.g. opencl compiler hung for 5+ hours in call to clBuildProgram, and non-deterministic emission of `cl_a6x_cmdbuf_mgr_submit_ibs`). I've isolated them into a minimal reproducible example, and find that they occur only when all kernels are created from a single cl_program. If instead a cl_program is created for each kernel, these issues are avoided. 

This PR proposes the addition of a kernel primitive delimiter to be added to the OpenCL code generation, and for the OpenCL module runtime to utilize this delimiter to build and cache separate cl_programs for each generated kernel source.