### PR TITLE
[RPC] microtvm: fix RPC large transfer size issue

### DIFF
--- a/apps/bundle_deploy/crt_config/crt_config.h
+++ b/apps/bundle_deploy/crt_config/crt_config.h
@@ -45,4 +45,7 @@
 /*! Size of the global function registry, in bytes. */
 #define TVM_CRT_GLOBAL_FUNC_REGISTRY_SIZE_BYTES 200
 
+/*! Maximum packet size, in bytes, including the length header. */
+#define TVM_CRT_MAX_PACKET_SIZE_BYTES 512
+
 #endif  // TVM_RUNTIME_CRT_CONFIG_H_

--- a/src/runtime/crt/host/crt_config.h
+++ b/src/runtime/crt/host/crt_config.h
@@ -51,9 +51,6 @@
 /*! \brief Maximum length of a PackedFunc function name. */
 #define TVM_CRT_MAX_FUNCTION_NAME_LENGTH_BYTES 30
 
-/*! Size of the global function for max RPC transfer, in bytes. */
-#define TVM_CRT_RPC_MAX_TRANSFER_SIZE_BYTES 2048
-
 // #define TVM_CRT_FRAMER_ENABLE_LOGS
 
 #endif  // TVM_RUNTIME_CRT_HOST_CRT_CONFIG_H_

--- a/src/runtime/crt/host/crt_config.h
+++ b/src/runtime/crt/host/crt_config.h
@@ -43,7 +43,7 @@
 #define TVM_CRT_MAX_REGISTERED_MODULES 2
 
 /*! Size of the global function registry, in bytes. */
-#define TVM_CRT_GLOBAL_FUNC_REGISTRY_SIZE_BYTES 256
+#define TVM_CRT_GLOBAL_FUNC_REGISTRY_SIZE_BYTES 512
 
 /*! Maximum packet size, in bytes, including the length header. */
 #define TVM_CRT_MAX_PACKET_SIZE_BYTES 8 * 1024

--- a/src/runtime/crt/host/crt_config.h
+++ b/src/runtime/crt/host/crt_config.h
@@ -46,10 +46,13 @@
 #define TVM_CRT_GLOBAL_FUNC_REGISTRY_SIZE_BYTES 256
 
 /*! Maximum packet size, in bytes, including the length header. */
-#define TVM_CRT_MAX_PACKET_SIZE_BYTES 64000
+#define TVM_CRT_MAX_PACKET_SIZE_BYTES 8 * 1024
 
 /*! \brief Maximum length of a PackedFunc function name. */
 #define TVM_CRT_MAX_FUNCTION_NAME_LENGTH_BYTES 30
+
+/*! Size of the global function for max RPC transfer, in bytes. */
+#define TVM_CRT_RPC_MAX_TRANSFER_SIZE_BYTES 2048
 
 // #define TVM_CRT_FRAMER_ENABLE_LOGS
 

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -110,7 +110,7 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
 }
 }
 
-uint8_t memory[512 * 1024];
+uint8_t memory[2048 * 1024];
 
 static char** g_argv = NULL;
 

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -110,7 +110,7 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
 }
 }
 
-uint8_t memory[1024 * 1024];
+uint8_t memory[512 * 1024];
 
 static char** g_argv = NULL;
 
@@ -135,10 +135,13 @@ int main(int argc, char** argv) {
   CHECK_EQ(TVMGraphExecutorModule_Register(), kTvmErrorNoError,
            "failed to register GraphExecutor TVMModule");
 #endif
-  
-  int error = TVMFuncRegisterGlobal("tvm.testing.reset_server", (TVMFunctionHandle)&testonly_reset_server, 0);
+
+  int error = TVMFuncRegisterGlobal("tvm.testing.reset_server",
+                                    (TVMFunctionHandle)&testonly_reset_server, 0);
   if (error) {
-    fprintf(stderr, "utvm runtime: internal error (error#: %d) registering global packedfunc; exiting\n", error);
+    fprintf(stderr,
+            "utvm runtime: internal error (error#: %x) registering global packedfunc; exiting\n",
+            error);
     return 2;
   }
 

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -110,7 +110,7 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
 }
 }
 
-uint8_t memory[2048 * 1024];
+uint8_t memory[1024 * 1024];
 
 static char** g_argv = NULL;
 

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -135,10 +135,10 @@ int main(int argc, char** argv) {
   CHECK_EQ(TVMGraphExecutorModule_Register(), kTvmErrorNoError,
            "failed to register GraphExecutor TVMModule");
 #endif
-
-  if (TVMFuncRegisterGlobal("tvm.testing.reset_server", (TVMFunctionHandle)&testonly_reset_server,
-                            0)) {
-    fprintf(stderr, "utvm runtime: internal error registering global packedfunc; exiting\n");
+  
+  int error = TVMFuncRegisterGlobal("tvm.testing.reset_server", (TVMFunctionHandle)&testonly_reset_server, 0);
+  if (error) {
+    fprintf(stderr, "utvm runtime: internal error (error#: %d) registering global packedfunc; exiting\n", error);
     return 2;
   }
 

--- a/src/runtime/minrpc/rpc_reference.h
+++ b/src/runtime/minrpc/rpc_reference.h
@@ -30,6 +30,9 @@ namespace runtime {
 /*! \brief The current RPC procotol version. */
 constexpr const char* kRPCProtocolVer = "0.8.0";
 
+// When tvm.rpc.server.GetCRTMaxPacketSize global function is not registered.
+const uint64_t kRPCMaxTransferSizeBytesDefault = 128 * 1024;
+
 /*! \brief The RPC code */
 enum class RPCCode : int {
   kNone,

--- a/src/runtime/minrpc/rpc_reference.h
+++ b/src/runtime/minrpc/rpc_reference.h
@@ -31,7 +31,7 @@ namespace runtime {
 constexpr const char* kRPCProtocolVer = "0.8.0";
 
 // When tvm.rpc.server.GetCRTMaxPacketSize global function is not registered.
-const uint64_t kRPCMaxTransferSizeBytesDefault = 128 * 1024;
+const uint64_t kRPCMaxTransferSizeBytesDefault = UINT64_MAX;
 
 /*! \brief The RPC code */
 enum class RPCCode : int {

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -981,7 +981,7 @@ class RPCClientSession : public RPCSession, public DeviceAPI {
     RPCCode code = RPCCode::kCopyToRemote;
     uint64_t overhead = RemoteCopyCalculatePacketOverheadSize(remote_to, code, nbytes);
     uint64_t rpc_max_size = GetRPCMaxTransferSize();
-    ICHECK_GT(rpc_max_size - overhead, 0) << "CopyToRemote: Invalid block size!";
+    ICHECK_GT(rpc_max_size, overhead) << "CopyToRemote: Invalid block size!";
     const uint64_t block_size = rpc_max_size - overhead;
     uint64_t block_count = 0;
     const uint64_t num_blocks = nbytes / block_size;
@@ -1007,7 +1007,7 @@ class RPCClientSession : public RPCSession, public DeviceAPI {
     RPCCode code = RPCCode::kCopyFromRemote;
     uint64_t overhead = RemoteCopyCalculatePacketOverheadSize(remote_from, code, nbytes);
     uint64_t rpc_max_size = GetRPCMaxTransferSize();
-    ICHECK_GT(rpc_max_size - overhead, 0) << "CopyFromRemote: Invalid block size!";
+    ICHECK_GT(rpc_max_size, overhead) << "CopyFromRemote: Invalid block size!";
     const uint64_t block_size = rpc_max_size - overhead;
     uint64_t block_count = 0;
     const uint64_t num_blocks = nbytes / block_size;

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -980,14 +980,14 @@ class RPCClientSession : public RPCSession, public DeviceAPI {
     uint64_t overhead = RemoteCopyCalculatePacketOverheadSize(remote_to, code, nbytes);
     const uint64_t block_size = GetRPCMaxTransferSize() - overhead;
     uint64_t block_count = 0;
-    uint64_t num_blocks = nbytes / block_size;
+    const uint64_t num_blocks = nbytes / block_size;
 
     for (block_count = 0; block_count < num_blocks; block_count++) {
       remote_to->byte_offset = block_count * block_size;
       endpoint_->CopyToRemote(local_from_bytes, remote_to, block_size);
     }
 
-    uint64_t remainder_bytes = nbytes % block_size;
+    const uint64_t remainder_bytes = nbytes % block_size;
     if (remainder_bytes != 0) {
       remote_to->byte_offset = block_count * block_size;
       endpoint_->CopyToRemote(local_from_bytes, remote_to, remainder_bytes);

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -48,9 +48,6 @@ const int kRPCSuccess = kRPCMagic + 0;
 // cannot found matched key in server
 const int kRPCMismatch = kRPCMagic + 2;
 
-// When tvm.rpc.server.GetCRTMaxPacketSize global function is not registered.
-const uint64_t kRPCMaxTransferSizeBytesDefault = 128 * 1024;
-
 /*! \brief Enumeration code for the RPC tracker */
 enum class TrackerCode : int {
   kFail = -1,

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -48,8 +48,8 @@ const int kRPCSuccess = kRPCMagic + 0;
 // cannot found matched key in server
 const int kRPCMismatch = kRPCMagic + 2;
 
-// When tvm.rpc.server.GetTransferMaxSize global function is not registered.
-const int kRPCMaxTransferSizeDefault = 128000;
+// When tvm.rpc.server.GetCRTMaxPacketSize global function is not registered.
+const uint64_t kRPCMaxTransferSizeBytesDefault = 128 * 1024;
 
 /*! \brief Enumeration code for the RPC tracker */
 enum class TrackerCode : int {
@@ -207,6 +207,15 @@ template <typename... Args>
 inline TVMRetValue RPCEndpoint::SysCallRemote(RPCCode code, Args&&... args) {
   return syscall_remote_(static_cast<int>(code), std::forward<Args>(args)...);
 }
+
+/*!
+ * \brief Calculates overhead size of a CopyToRemote packet.
+ * \param to DLTensor to copy.
+ * \param code RPCCode for this transfer.
+ * \param nbytes Number of bytes to transfer.
+ */
+uint64_t RemoteCopyCalculatePacketOverheadSize(DLTensor* tensor, RPCCode code, uint64_t nbytes);
+
 }  // namespace runtime
 }  // namespace tvm
 #endif  // TVM_RUNTIME_RPC_RPC_ENDPOINT_H_

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -48,6 +48,9 @@ const int kRPCSuccess = kRPCMagic + 0;
 // cannot found matched key in server
 const int kRPCMismatch = kRPCMagic + 2;
 
+// When tvm.rpc.server.GetTransferMaxSize global function is not registered.
+const int kRPCMaxTransferSizeDefault = 128000;
+
 /*! \brief Enumeration code for the RPC tracker */
 enum class TrackerCode : int {
   kFail = -1,

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -210,6 +210,7 @@ inline TVMRetValue RPCEndpoint::SysCallRemote(RPCCode code, Args&&... args) {
  * \param to DLTensor to copy.
  * \param code RPCCode for this transfer.
  * \param nbytes Number of bytes to transfer.
+ * \return The remote-copy packet overhead size.
  */
 uint64_t RemoteCopyCalculatePacketOverheadSize(DLTensor* tensor, RPCCode code, uint64_t nbytes);
 


### PR DESCRIPTION
This PR:
- Changes CopyToRemote and CopyFromRemote functions to handle smaller buffer size on hosts like microTVM devices.
- Adds a global packed function to set the RPC max transfer size. 
- Increases memory size for CRT host main file to handle larger models.