### PR TITLE
[Fix] deployment code fails with USE_FALLBACK_STL_MAP=0

### DIFF
--- a/apps/howto_deploy/Makefile
+++ b/apps/howto_deploy/Makefile
@@ -19,7 +19,7 @@
 TVM_ROOT=$(shell cd ../..; pwd)
 DMLC_CORE=${TVM_ROOT}/3rdparty/dmlc-core
 
-PKG_CFLAGS = -std=c++14 -O2 -fPIC\
+PKG_CFLAGS = -std=c++14 -O2 -fPIC -DUSE_FALLBACK_STL_MAP=1\
 	-I${TVM_ROOT}/include\
 	-I${DMLC_CORE}/include\
 	-I${TVM_ROOT}/3rdparty/dlpack/include


### PR DESCRIPTION
I met the following error (the same as #7683 ) when trying to build `apps/howto_deploy` project:
```
/usr/bin/ld: lib/libtvm_runtime_pack.o: in function `tvm::runtime::DenseMapNode::TrySpareListHead(tvm::runtime::DenseMapNode::ListNode, tvm::runtime::ObjectRef const&, tvm::runtime::DenseMapNode::ListNode*)':
tvm_runtime_pack.cc:(.text._ZN3tvm7runtime12DenseMapNode16TrySpareListHeadENS1_8ListNodeERKNS0_9ObjectRefEPS2_[_ZN3tvm7runtime12DenseMapNode16TrySpareListHeadENS1_8ListNodeERKNS0_9ObjectRefEPS2_]+0xcf): undefined reference to `tvm::runtime::DenseMapNode::kNextProbeLocation'
/usr/bin/ld: lib/libtvm_runtime_pack.o: in function `tvm::runtime::DenseMapNode::TryInsert(tvm::runtime::ObjectRef const&, tvm::runtime::DenseMapNode::ListNode*)':
tvm_runtime_pack.cc:(.text._ZN3tvm7runtime12DenseMapNode9TryInsertERKNS0_9ObjectRefEPNS1_8ListNodeE[_ZN3tvm7runtime12DenseMapNode9TryInsertERKNS0_9ObjectRefEPNS1_8ListNodeE]+0x19e): undefined reference to `tvm::runtime::DenseMapNode::kNextProbeLocation
```
Setting the `USE_FALLBACK_STL_MAP=1` fixes the problem for me. However I'm not sure why it cannot find reference to `kNextProbeLocation`, I think there is some problem with container code, is there a more fundamental solution?

cc @junrushao1994 @tqchen 