### PR TITLE
[FIX] Fix howto_deploy

### DIFF
--- a/apps/howto_deploy/Makefile
+++ b/apps/howto_deploy/Makefile
@@ -22,7 +22,8 @@ DMLC_CORE=${TVM_ROOT}/3rdparty/dmlc-core
 PKG_CFLAGS = -std=c++14 -O2 -fPIC\
 	-I${TVM_ROOT}/include\
 	-I${DMLC_CORE}/include\
-	-I${TVM_ROOT}/3rdparty/dlpack/include
+	-I${TVM_ROOT}/3rdparty/dlpack/include\
+	-DDMLC_USE_LOGGING_LIBRARY=\<tvm/runtime/logging.h\>
 
 PKG_LDFLAGS = -L${TVM_ROOT}/build -ldl -pthread
 

--- a/apps/howto_deploy/tvm_runtime_pack.cc
+++ b/apps/howto_deploy/tvm_runtime_pack.cc
@@ -37,7 +37,9 @@
  *  You need to remember to change it to point to the right file.
  *
  */
+#define TVM_USE_LIBBACKTRACE 0
 #include "../../src/runtime/c_runtime_api.cc"
+#include "../../src/runtime/container.cc"
 #include "../../src/runtime/cpu_device_api.cc"
 #include "../../src/runtime/file_utils.cc"
 #include "../../src/runtime/library_module.cc"


### PR DESCRIPTION
We were missing files in tvm_runtime_pack.cc.

Manually packing the runtime files has led to many issues when adding new features. We should probably figure out a better way to do it.

@tqchen 