### PR TITLE
[BugFix] Print doubles with precision 17 in SaveJSON and TVM script printer

### DIFF
--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -214,8 +214,8 @@ class JSONAttrGetter : public AttrVisitor {
 
   void Visit(const char* key, double* value) final {
     std::ostringstream s;
-    // Type <double> have approximately 16 decimal digits
-    s.precision(16);
+    // Save 17 decimal digits for type <double> to avoid precision loss during loading JSON
+    s.precision(17);
     s << (*value);
     node_->attrs[key] = s.str();
   }

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -232,6 +232,9 @@ class TVMScriptPrinter : public StmtFunctor<Doc(const Stmt&)>,
   static Doc PrintConstScalar(DataType dtype, const T* data) {
     Doc doc;
     std::ostringstream os;
+    if (dtype.is_float() || dtype.is_float16() || dtype.is_bfloat16()) {
+      os.precision(17);
+    }
     os << data[0];
     if (dtype == DataType::Int(32)) {
       doc << Doc::Text(os.str());

--- a/tests/python/unittest/test_node_reflection.py
+++ b/tests/python/unittest/test_node_reflection.py
@@ -43,6 +43,16 @@ def test_infinity_value():
     _test_infinity_value(float("-inf"), "float32")
 
 
+def _test_minmax_value(value):
+    json_str = tvm.ir.save_json(value)
+    tvm.ir.assert_structural_equal(value, tvm.ir.load_json(json_str))
+
+
+def test_minmax_value():
+    _test_minmax_value(tvm.tir.min_value("float32"))
+    _test_minmax_value(tvm.tir.max_value("float32"))
+
+
 def test_make_smap():
     # save load json
     x = tvm.tir.const(1, "int32")
@@ -160,3 +170,4 @@ if __name__ == "__main__":
     test_pass_config()
     test_dict()
     test_infinity_value()
+    test_minmax_value()


### PR DESCRIPTION
This PR fixes a bug in SaveLoad, which didn't save enough digits for double value and may cause precision loss when loading the value from JSON again. Besides, this PR adds a regression test for the precision loss case.

Before this PR, double value is saved with precision 16. However, actually we should save at least 17 digits to avoid precision loss, according to [IEEE 754-1985 standard](https://standards.ieee.org/standard/754-1985.html):

> When rounding to nearest conversion from binary to decimal and back to binary shall be the identity as long as the
decimal string is carried to the maximum precision specified in Table 2, namely, 9 digits for single and 17 digits for
double.

### Reference

* "IEEE Standard for Binary Floating-Point Arithmetic," in ANSI/IEEE Std 754-1985 , vol., no., pp.1-20, 12 Oct. 1985, doi: 10.1109/IEEESTD.1985.82928.

cc @tqchen @junrushao1994