### PR TITLE
[BYOC][TVMC] bugfix: disabled_pass -> disable_pass

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -127,7 +127,7 @@ def drive_compile(args):
         None,
         args.tuning_records,
         args.desired_layout,
-        args.disabled_pass,
+        args.disable_pass,
     )
 
     if dumps:


### PR DESCRIPTION
This PR fixes typo in `tvmc compile` command line disabled_pass -> disable_pass


Change-Id: I22d24a2e219103485a6a1519ce6256a104103ebb