### PR TITLE
Allow microTVM Reference VM to be launched when TVM is a submodule.

### DIFF
--- a/apps/microtvm/reference-vm/zephyr/Vagrantfile
+++ b/apps/microtvm/reference-vm/zephyr/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   if git_file.ftype() == "file" then
     gitdir_match = Regexp.new('^gitdir: (?<gitdir>.*/.git).*\n$', Regexp::MULTILINE).match(git_file.read())
     if !gitdir_match.nil? then
-      dirs_to_mount.append(Pathname.new(gitdir_match.named_captures["gitdir"]))
+      dirs_to_mount.append(Pathname.new(tvm_home).realpath.join(gitdir_match.named_captures["gitdir"]))
       puts "NOTE: also configuring git-worktree gitdir: %s" % [dirs_to_mount[-1]]
     end
   end


### PR DESCRIPTION
@mehrdadh @kwmaeng91 @tmoreau89 

This PR fixes up some paths to allow use of the microTVM reference VM when the tvm repo is a submodule of an enclosing project repo.