### PR TITLE
[TIR] An analysis pass to calculate workspace size for primfuncs

### DIFF
--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -178,6 +178,12 @@ Array<Array<BufferRegion>> GetBlockAccessRegion(const Block& block,
  */
 TVM_DLL size_t CalculateExprComplexity(const PrimExpr& expr);
 
+/*!
+ * \brief Calculate the workspace size in bytes needed by the TIR allocates inside the TIR PrimFunc
+ * \param func The TIR PrimFunc for which the workspace size to be calculated
+ */
+TVM_DLL int CalculateWorkspaceBytes(const PrimFunc& func);
+
 // Pass variants of verification analysis
 // directly throws RuntimeError when verification fails.
 namespace transform {

--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -182,7 +182,7 @@ TVM_DLL size_t CalculateExprComplexity(const PrimExpr& expr);
  * \brief Calculate the workspace size in bytes needed by the TIR allocates inside the TIR PrimFunc
  * \param func The TIR PrimFunc for which the workspace size to be calculated
  */
-TVM_DLL int CalculateWorkspaceBytes(const PrimFunc& func);
+TVM_DLL size_t CalculateWorkspaceBytes(const PrimFunc& func);
 
 // Pass variants of verification analysis
 // directly throws RuntimeError when verification fails.

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -132,9 +132,9 @@ class TVMScriptParser(Transformer):
         ast.BuiltinOp.Div: tvm.tir.Div,
         ast.BuiltinOp.FloorDiv: tvm.tir.FloorDiv,
         ast.BuiltinOp.Mod: tvm.tir.FloorMod,
-        ast.BuiltinOp.BitOr: operator.or_,
-        ast.BuiltinOp.BitAnd: operator.and_,
-        ast.BuiltinOp.BitXor: operator.xor,
+        ast.BuiltinOp.BitOr: lambda lhs, rhs, span: operator.or_(lhs, rhs),
+        ast.BuiltinOp.BitAnd: lambda lhs, rhs, span: operator.and_(lhs, rhs),
+        ast.BuiltinOp.BitXor: lambda lhs, rhs, span: operator.xor(lhs, rhs),
         ast.BuiltinOp.GT: tvm.tir.GT,
         ast.BuiltinOp.GE: tvm.tir.GE,
         ast.BuiltinOp.LT: tvm.tir.LT,
@@ -146,8 +146,8 @@ class TVMScriptParser(Transformer):
     }
 
     _unaryop_maker = {
-        ast.BuiltinOp.USub: operator.neg,
-        ast.BuiltinOp.Invert: operator.invert,
+        ast.BuiltinOp.USub: lambda rhs, span: operator.neg(rhs),
+        ast.BuiltinOp.Invert: lambda rhs, span: operator.invert(rhs),
         ast.BuiltinOp.Not: tvm.tir.Not,
     }
 

--- a/python/tvm/script/scope_handler.py
+++ b/python/tvm/script/scope_handler.py
@@ -80,8 +80,8 @@ class WithScopeHandler(ScopeHandler):
         self.def_symbol = def_symbol
 
     @staticmethod
-    def get_optional_var_names(node, context):
-        """Get list of names from ast.With's optional_vars"""
+    def get_optional_vars(node, context):
+        """Get a list ast.With's optional_vars"""
         assert isinstance(
             node, ast.With
         ), f"WithScopeHandler expected ast.With but got {type(node)}"
@@ -93,13 +93,13 @@ class WithScopeHandler(ScopeHandler):
                         f"Invalid optional var definition, expected Var but got {type(var)}",
                         node.span,
                     )
-            var_names = [var.id.name for var in node.lhs]
+            vars = node.lhs
         else:
             context.report_error(
                 f"Invalid optional var definition, expected list of Var but got {type(node.lhs)}",
                 node.span,
             )
-        return var_names
+        return vars
 
 
 @register
@@ -127,12 +127,14 @@ class Allocate(WithScopeHandler):
     ):
         # define buffer vars in symbol table
         if isinstance(node, ast.With):
-            names = WithScopeHandler.get_optional_var_names(node, context)
-            if len(names) != 1:
+            vars = WithScopeHandler.get_optional_vars(node, context)
+            if len(vars) != 1:
                 context.report_error("Unexpected number of vars", node.span)
-            name = names[0]
+            name = vars[0].id.name
+            var_span = vars[0].id.span
         elif isinstance(node, ast.Assign):
             name = node.lhs.id.name
+            var_span = node.lhs.id.span
         else:
             raise Exception("Internal Bug")
 
@@ -141,7 +143,7 @@ class Allocate(WithScopeHandler):
             buffer_ptr_type = tvm.ir.PointerType(tvm.ir.PrimType(dtype))
             self.buffer_var = tvm.tir.Var(name, buffer_ptr_type, span)
 
-        setup_buffer_var(*arg_list, span=tvm_span_from_synr(node.lhs.id.span))
+        setup_buffer_var(*arg_list, span=tvm_span_from_synr(var_span))
         context.update_symbol(name, self.buffer_var, node)
 
 
@@ -347,8 +349,8 @@ class Block(WithScopeHandler):
             node, ast.With
         ), f"BlockScopeHandler expected to work on ast.With but got {type(node)}"
 
-        var_names = WithScopeHandler.get_optional_var_names(node, context)
-        self.block_vars = [tvm.te.var(name) for name in var_names]
+        vars = WithScopeHandler.get_optional_vars(node, context)
+        self.block_vars = [tvm.te.var(var.id.name) for var in vars]
         for block_var in self.block_vars:
             context.update_symbol(block_var.name, block_var, node)
 

--- a/python/tvm/tir/analysis/analysis.py
+++ b/python/tvm/tir/analysis/analysis.py
@@ -129,3 +129,7 @@ def get_block_access_region(block, buffer_var_map):
             - third: opaque regions
     """
     return _ffi_api.get_block_access_region(block, buffer_var_map)
+
+
+def calculate_workspace_bytes(func):
+    return _ffi_api.calculate_workspace_bytes(func)

--- a/src/tir/analysis/calculate_workspace.cc
+++ b/src/tir/analysis/calculate_workspace.cc
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tir/analysis/calculate_workspace.cc
+ * \brief Calculate any intermediary memory required by PrimFuncs.
+ */
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/stmt_functor.h>
+
+namespace tvm {
+namespace tir {
+
+class WorkspaceCalculator : public StmtExprVisitor {
+ public:
+  WorkspaceCalculator() = default;
+  int operator()(const PrimFunc& func);
+
+ private:
+  void VisitStmt_(const AllocateNode* op) override;
+  int CalculateExtentsSize(const AllocateNode* op);
+  int current_size = 0;
+  int max_size = 0;
+};
+
+int WorkspaceCalculator::operator()(const PrimFunc& func) {
+  this->VisitStmt(func->body);
+  return this->max_size;
+}
+
+int WorkspaceCalculator::CalculateExtentsSize(const AllocateNode* op) {
+  int element_size_bytes = op->dtype.bytes();
+  int num_elements = 1;
+  for (const auto& ext : op->extents) {
+    num_elements *= Downcast<IntImm>(ext)->value;
+  }
+  return num_elements * element_size_bytes;
+}
+
+void WorkspaceCalculator::VisitStmt_(const AllocateNode* op) {
+  auto size = CalculateExtentsSize(op);
+  current_size += size;
+  if (current_size > max_size) {
+    max_size = current_size;
+  }
+  StmtExprVisitor::VisitStmt(op->body);
+  current_size -= size;
+}
+
+int CalculateWorkspaceBytes(const PrimFunc& func) {
+  WorkspaceCalculator wc;
+  return wc(func);
+}
+
+TVM_REGISTER_GLOBAL("tir.analysis.calculate_workspace_bytes")
+    .set_body_typed(CalculateWorkspaceBytes);
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/analysis/calculate_workspace.cc
+++ b/src/tir/analysis/calculate_workspace.cc
@@ -70,7 +70,7 @@ size_t CalculateWorkspaceBytes(const PrimFunc& func) {
   return wc(func);
 }
 
-TVM_REGISTER_GLOBAL("tir.analysis.calculate_workspace_bytes").set_body_typed([=](PrimFunc func) {
+TVM_REGISTER_GLOBAL("tir.analysis.calculate_workspace_bytes").set_body_typed([](PrimFunc func) {
   return static_cast<int>(CalculateWorkspaceBytes(func));
 });
 

--- a/tests/python/unittest/test_tir_analysis_calculate_workspace.py
+++ b/tests/python/unittest/test_tir_analysis_calculate_workspace.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import numpy as np
+
+import tvm
+from tvm import tir, script
+from tvm.ir import Range
+from tvm.script import ty
+
+
+# fmt: off
+@tvm.script.tir
+def primfunc_global_allocates(placeholder_144: ty.handle, placeholder_145: ty.handle, placeholder_146: ty.handle, T_cast_48: ty.handle) -> None:
+    # function attr dict
+    tir.func_attr({"global_symbol": "fused_nn_conv2d_add_cast_fixed_point_multiply_clip_cast_cast_13", "tir.noalias": True})
+    placeholder_147 = tir.match_buffer(placeholder_144, [1, 14, 14, 512], dtype="int16", elem_offset=0, align=128, offset_factor=1)
+    placeholder_148 = tir.match_buffer(placeholder_145, [3, 3, 512, 1], dtype="int16", elem_offset=0, align=128, offset_factor=1)
+    placeholder_149 = tir.match_buffer(placeholder_146, [1, 1, 1, 512], dtype="int32", elem_offset=0, align=128, offset_factor=1)
+    T_cast_49 = tir.match_buffer(T_cast_48, [1, 14, 14, 512], dtype="int16", elem_offset=0, align=128, offset_factor=1)
+    # body
+    PaddedInput_22 = tir.allocate([131072], "int16", "global")
+    DepthwiseConv2d_9 = tir.allocate([100352], "int32", "global")
+    for i1_29, i2_39, i3_40 in tir.grid(16, 16, 512):
+        PaddedInput_22[(((i1_29*8192) + (i2_39*512)) + i3_40)] = tir.if_then_else(((((1 <= i1_29) and (i1_29 < 15)) and (1 <= i2_39)) and (i2_39 < 15)), tir.load("int16", placeholder_147.data, ((((i1_29*7168) + (i2_39*512)) + i3_40) - 7680)), tir.int16(0), dtype="int16")
+    for i_9, j_9, c_9 in tir.grid(14, 14, 512):
+        DepthwiseConv2d_9[(((i_9*7168) + (j_9*512)) + c_9)] = 0
+        for di_9, dj_9 in tir.grid(3, 3):
+            DepthwiseConv2d_9[(((i_9*7168) + (j_9*512)) + c_9)] = (tir.load("int32", DepthwiseConv2d_9, (((i_9*7168) + (j_9*512)) + c_9)) + (tir.load("int16", PaddedInput_22, (((((i_9*8192) + (di_9*8192)) + (j_9*512)) + (dj_9*512)) + c_9)).astype("int32")*tir.load("int16", placeholder_148.data, (((di_9*1536) + (dj_9*512)) + c_9)).astype("int32")))
+    for ax1_27, ax2_28, ax3_30 in tir.grid(14, 14, 512):
+        DepthwiseConv2d_9[(((ax1_27*7168) + (ax2_28*512)) + ax3_30)] = (tir.load("int32", DepthwiseConv2d_9, (((ax1_27*7168) + (ax2_28*512)) + ax3_30)) + tir.load("int32", placeholder_149.data, ax3_30))
+    for i1_30, i2_40, i3_41 in tir.grid(14, 14, 512):
+        DepthwiseConv2d_9[(((i1_30*7168) + (i2_40*512)) + i3_41)] = tir.q_multiply_shift(tir.load("int32", DepthwiseConv2d_9, (((i1_30*7168) + (i2_40*512)) + i3_41)), 1269068532, 31, -4, dtype="int32")
+    for i1_31, i2_41, i3_42 in tir.grid(14, 14, 512):
+        DepthwiseConv2d_9[(((i1_31*7168) + (i2_41*512)) + i3_42)] = tir.max(tir.max(tir.load("int32", DepthwiseConv2d_9, (((i1_31*7168) + (i2_41*512)) + i3_42)), 255), 0)
+    for ax1_28, ax2_29, ax3_31 in tir.grid(14, 14, 512):
+        PaddedInput_22[(((ax1_28*7168) + (ax2_29*512)) + ax3_31)] = tir.load("int32", DepthwiseConv2d_9, (((ax1_28*7168) + (ax2_29*512)) + ax3_31)).astype("uint8")
+    for ax1_29, ax2_30, ax3_32 in tir.grid(14, 14, 512):
+        T_cast_49.data[(((ax1_29*7168) + (ax2_30*512)) + ax3_32)] = tir.load("uint8", PaddedInput_22, (((ax1_29*7168) + (ax2_30*512)) + ax3_32)).astype("int16")
+# fmt: on
+
+
+# fmt: off
+@tvm.script.tir
+def primfunc_local_allocates(placeholder_162: ty.handle, placeholder_163: ty.handle, placeholder_164: ty.handle, T_cast_76: ty.handle) -> None:
+    # function attr dict
+    tir.func_attr({"global_symbol": "fused_nn_conv2d_add_cast_fixed_point_multiply_clip_cast_cast_9", "tir.noalias": True})
+    placeholder_165 = tir.match_buffer(placeholder_162, [1, 14, 14, 512], dtype="int16", elem_offset=0, align=128, offset_factor=1)
+    placeholder_166 = tir.match_buffer(placeholder_163, [3, 3, 512, 1], dtype="int16", elem_offset=0, align=128, offset_factor=1)
+    placeholder_167 = tir.match_buffer(placeholder_164, [1, 1, 1, 512], dtype="int32", elem_offset=0, align=128, offset_factor=1)
+    T_cast_77 = tir.match_buffer(T_cast_76, [1, 14, 14, 512], dtype="int16", elem_offset=0, align=128, offset_factor=1)
+    # body
+    PaddedInput_25 = tir.allocate([1, 16, 16, 512], "int16", "global")
+    for i1_35, i2_46, i3_47 in tir.grid(16, 16, 512):
+        PaddedInput_25[(((i1_35*8192) + (i2_46*512)) + i3_47)] = tir.if_then_else(((((1 <= i1_35) and (i1_35 < 15)) and (1 <= i2_46)) and (i2_46 < 15)), tir.load("int16", placeholder_165.data, ((((i1_35*7168) + (i2_46*512)) + i3_47) - 7680)), tir.int16(0), dtype="int16")
+    T_add_11 = tir.allocate([1, 14, 14, 512], "int32", "global")
+    with tir.allocate([1, 14, 14, 512], "int32", "global") as DepthwiseConv2d_11:
+        for i_11, j_11, c_11 in tir.grid(14, 14, 512):
+            DepthwiseConv2d_11[(((i_11*7168) + (j_11*512)) + c_11)] = 0
+            for di_11, dj_11 in tir.grid(3, 3):
+                DepthwiseConv2d_11[(((i_11*7168) + (j_11*512)) + c_11)] = (tir.load("int32", DepthwiseConv2d_11, (((i_11*7168) + (j_11*512)) + c_11)) + (tir.load("int16", PaddedInput_25, (((((i_11*8192) + (di_11*8192)) + (j_11*512)) + (dj_11*512)) + c_11)).astype("int32")*tir.load("int16", placeholder_166.data, (((di_11*1536) + (dj_11*512)) + c_11)).astype("int32")))
+        for ax1_44, ax2_45, ax3_47 in tir.grid(14, 14, 512):
+            T_add_11[(((ax1_44*7168) + (ax2_45*512)) + ax3_47)] = (tir.load("int32", DepthwiseConv2d_11, (((ax1_44*7168) + (ax2_45*512)) + ax3_47)) + tir.load("int32", placeholder_167.data, ax3_47))
+    compute_22 = tir.allocate([1, 14, 14, 512], "int32", "global")
+    with tir.allocate([1, 14, 14, 512], "int32", "global") as T_cast_78:
+        for ax1_45, ax2_46, ax3_48 in tir.grid(14, 14, 512):
+            T_cast_78[(((ax1_45*7168) + (ax2_46*512)) + ax3_48)] = tir.load("int32", T_add_11, (((ax1_45*7168) + (ax2_46*512)) + ax3_48))
+        for i1_36, i2_47, i3_48 in tir.grid(14, 14, 512):
+            compute_22[(((i1_36*7168) + (i2_47*512)) + i3_48)] = tir.q_multiply_shift(tir.load("int32", T_cast_78, (((i1_36*7168) + (i2_47*512)) + i3_48)), 1948805937, 31, -5, dtype="int32")
+    T_cast_79 = tir.allocate([1, 14, 14, 512], "uint8", "global")
+    with tir.allocate([1, 14, 14, 512], "int32", "global") as compute_23:
+        for i1_37, i2_48, i3_49 in tir.grid(14, 14, 512):
+            compute_23[(((i1_37*7168) + (i2_48*512)) + i3_49)] = tir.max(tir.max(tir.load("int32", compute_22, (((i1_37*7168) + (i2_48*512)) + i3_49)), 255), 0)
+        for ax1_46, ax2_47, ax3_49 in tir.grid(14, 14, 512):
+            T_cast_79[(((ax1_46*7168) + (ax2_47*512)) + ax3_49)] = tir.load("int32", compute_23, (((ax1_46*7168) + (ax2_47*512)) + ax3_49)).astype("uint8")
+    for ax1_47, ax2_48, ax3_50 in tir.grid(14, 14, 512):
+        T_cast_77.data[(((ax1_47*7168) + (ax2_48*512)) + ax3_50)] = tir.load("uint8", T_cast_79, (((ax1_47*7168) + (ax2_48*512)) + ax3_50)).astype("int16")
+# fmt: on
+
+
+def test_global_allocates():
+    primfunc = primfunc_global_allocates
+    assert tvm.tir.analysis.calculate_workspace_bytes(primfunc) == 663552
+
+
+def test_local_allocates():
+    primfunc = primfunc_local_allocates
+    assert tvm.tir.analysis.calculate_workspace_bytes(primfunc) == 1566720
+
+
+if __name__ == "__main__":
+    test_global_allocates()
+    test_local_allocates()


### PR DESCRIPTION
This commit introduces functionality to query the workspace sizeas required by a tir primfunc by looking at tir.allocates inside of it.
I needed to do a small fix for tvmscript parser and scope handler to make the test cases work.




