### PR TITLE
[µTVM] Zephyr: Add STM32F746 disco board as a test platform

### DIFF
--- a/tests/micro/zephyr/conftest.py
+++ b/tests/micro/zephyr/conftest.py
@@ -24,7 +24,8 @@ PLATFORMS = {
     "host": ("host", "qemu_x86"),
     "host_riscv32": ("host", "qemu_riscv32"),
     "host_riscv64": ("host", "qemu_riscv64"),
-    "stm32f746xx": ("stm32f746xx", "nucleo_f746zg"),
+    "stm32f746xx_nucleo": ("stm32f746xx", "nucleo_f746zg"),
+    "stm32f746xx_disco": ("stm32f746xx", "stm32f746g_disco"),
     "nrf5340dk": ("nrf5340dk", "nrf5340dk_nrf5340_cpuapp"),
 }
 


### PR DESCRIPTION
Add STM32F746 Discovery board as test platform so tests can run against
it by using:

$ pytest test_zephyr.py --microtvm-platforms=stm32f746xx_disco

Since that board has the same MCU identifier as the ST Nucleo board,
the test platform identifier for Nucleo board is renamed and a
suffix _nucleo is added to differentiate it from the ST Disco board.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
