### PR TITLE
[µTVM] Zephyr: Add MPS2-AN521 board as a test platform

### DIFF
--- a/tests/micro/zephyr/conftest.py
+++ b/tests/micro/zephyr/conftest.py
@@ -26,6 +26,7 @@ PLATFORMS = {
     "host_riscv64": ("host", "qemu_riscv64"),
     "stm32f746xx": ("stm32f746xx", "nucleo_f746zg"),
     "nrf5340dk": ("nrf5340dk", "nrf5340dk_nrf5340_cpuapp"),
+    "mps2_an521": ("mps2_an521", "mps2_an521-qemu"),
 }
 
 


### PR DESCRIPTION
Now that MPS2-AN521 board is supported as a µTVM target, add it as test
platform so tests can run against it by using:

$ pytest test_zephyr.py --microtvm-platforms=mps2_an521

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
