### PR TITLE
Bring back GraphRuntimeFactory loader for now.

### DIFF
--- a/src/runtime/graph_executor/graph_executor_factory.cc
+++ b/src/runtime/graph_executor/graph_executor_factory.cc
@@ -206,5 +206,16 @@ TVM_REGISTER_GLOBAL("tvm.graph_executor_factory.create")
 TVM_REGISTER_GLOBAL("runtime.module.loadbinary_GraphExecutorFactory")
     .set_body_typed(GraphExecutorFactoryModuleLoadBinary);
 
+Module GraphRuntimeFactoryModuleLoadBinary(void* strm) {
+  LOG(WARNING) << "You are loading a module which was built with GraphRuntimeFactory. "
+               << "GraphRuntime has been renamed to GraphExecutor, and support for loading "
+               << "GraphRuntimeFactory modules will be removed after the next TVM release. "
+               << "Please rebuild the module before then to avoid breakage.";
+  return GraphExecutorFactoryModuleLoadBinary(strm);
+}
+
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_GraphRuntimeFactory")
+    .set_body_typed(GraphRuntimeFactoryModuleLoadBinary);
+
 }  // namespace runtime
 }  // namespace tvm


### PR DESCRIPTION
 * Address issue #7822.

In PR #7653 , we renamed GraphRuntime to GraphExecutor, but this broke loading modules which contained GraphRuntimeFactory (e.g. those generated before this change). Bringing back that loader function with a deprecation warning until next release.

@tqchen @JC1DA
