### PR TITLE
[Hotfix] Typo in Vulkan runtime change causing severe perf regression for dGPU

### DIFF
--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -245,7 +245,7 @@ class VulkanDeviceAPI final : public DeviceAPI {
     const auto& vctx = context(dev.device_id);
     auto usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-    return CreateBuffer(vctx, nbytes, usage, vctx.staging_mtype_index);
+    return CreateBuffer(vctx, nbytes, usage, vctx.compute_mtype_index);
   }
 
   void FreeDataSpace(Device dev, void* ptr) final {


### PR DESCRIPTION
I found that https://github.com/apache/tvm/pull/7833 introduced severe perf regression for vk + dGPU.  Running `cuda_gemm_square.py` on R9 nano, I found that vk result is extremely slow:

```
Device opencl                                                                                                                                       
average time cost of 10 runs = 3.57431 ms, 4806.48 GFLOPS.

Device vulkan                   
average time cost of 10 runs = 39.8278 ms, 431.354 GFLOPS.
``` 

After bisecting, I found that I had a typo in https://github.com/apache/tvm/pull/7833 resulting in using a wrong memory type for device buffers :man_facepalming: Interestingly, there is no regression for APU, so I didn't notice during development. Now this has been fixed and vk performance is great as before:
```
Device opencl
average time cost of 10 runs = 3.56969 ms, 4812.7 GFLOPS.

Device vulkan
average time cost of 10 runs = 3.04882 ms, 5634.93 GFLOPS.
```

cc @tqchen 
