### PR TITLE
[Tensorize]Fix tensorize error while reusing compute

### DIFF
--- a/src/te/operation/tensorize.cc
+++ b/src/te/operation/tensorize.cc
@@ -184,8 +184,7 @@ class TensorIntrinMatcher final : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const ReduceNode* op) final {
     PrimExpr expr = StmtExprMutator::VisitExpr_(op);
-    if (expr.same_as(GetRef<PrimExpr>(op)))
-      return expr;
+    if (expr.same_as(GetRef<PrimExpr>(op))) return expr;
     op = expr.as<ReduceNode>();
     Array<IterVar> axis;
     for (size_t i = 0; i < op->axis.size(); ++i) {

--- a/src/te/operation/tensorize.cc
+++ b/src/te/operation/tensorize.cc
@@ -327,6 +327,9 @@ void VerifyTensorizeBody(const ComputeOpNode* self, const Stage& stage,
   ana.Bind(compute_intrin_iter_space);
 
   for (size_t i = 0; i < body.size(); ++i) {
+    if (self->body[i].same_as(intrin_compute->body[i])) {
+      continue;
+    }
     PrimExpr lhs = ana.Simplify(body[i]);
     // run substitution because the intrin body could depend on outer loop vars.
     PrimExpr rhs = ana.Simplify(Substitute(intrin_compute->body[i], value_map));

--- a/tests/python/unittest/test_te_schedule_tensorize.py
+++ b/tests/python/unittest/test_te_schedule_tensorize.py
@@ -381,6 +381,7 @@ def test_tensorize_reuse_compute():
     def get_intrin():
         def _intrin_func(ins, outs):
             return tvm.tir.call_packed("fakeadd", ins[0], ins[1], outs[0])
+
         return tvm.te.decl_tensor_intrin(c.op, _intrin_func)
 
     s = tvm.te.create_schedule([c.op])


### PR DESCRIPTION
After https://github.com/apache/tvm/pull/7497, this snippet fails:
```python
def test_tensorize_reuse_compute():
    def get_compute_args():
        l = 2
        a = tvm.te.placeholder([l], name="a")
        b = tvm.te.placeholder([l], name="b")
        return a, b, tvm.te.compute([l], lambda i: a[i] + b[i])

    a, b, c = get_compute_args()

    def get_intrin():
        def _intrin_func(ins, outs):
            return tvm.tir.call_packed("fakeadd", ins[0], ins[1], outs[0])
        return tvm.te.decl_tensor_intrin(c.op, _intrin_func)

    s = tvm.te.create_schedule([c.op])
    s[c].tensorize(c.op.axis[0], get_intrin())
    tvm.lower(s, (a, b, c))
```
```
Check failed: (expr_equal(lhs, rhs)) is false: Failed to match the compute with TensorIntrin tensor_intrin's declaration  provided= (a[i] + b[i]), intrin=  (a[i] + b[i])
```

When using the same compute body in both `decl_tensor_intrin` and `create_schedule`, after this [`Substitute`](https://github.com/apache/tvm/pull/7497/files#diff-3977bce777d6d58e0c864652b5ca4f493dcffafd1bd204c3925b3104be7fede2R332), some nodes' address changed, and then check failed.

I haven't figured out why this happens when reusing compute body, but I think we can drop the comparison if the two `expr`s are exactly the same one.