### PR TITLE
[BugFix]: Convert tuple to int

### DIFF
--- a/python/tvm/topi/testing/conv2d_hwcn_python.py
+++ b/python/tvm/topi/testing/conv2d_hwcn_python.py
@@ -73,5 +73,5 @@ def conv2d_hwcn_python(a_np, w_np, stride, padding):
                 else:
                     apad = at[n, c]
                 out = scipy.signal.convolve2d(apad, np.rot90(np.rot90(wt[f, c])), mode="valid")
-                bt[n, f] += out[::stride, ::stride]
+                bt[n, f] += out[::stride_h, ::stride_w]
     return bt.transpose((2, 3, 1, 0))

--- a/tests/python/topi/python/test_topi_conv2d_hwcn.py
+++ b/tests/python/topi/python/test_topi_conv2d_hwcn.py
@@ -95,16 +95,25 @@ def verify_conv2d_hwcn(batch, in_channel, in_size, num_filter, kernel, stride, p
 
 @tvm.testing.requires_gpu
 def test_conv2d_hwcn():
-    verify_conv2d_hwcn(1, 256, 32, 256, 3, 1, "SAME")
+    verify_conv2d_hwcn(1, 256, 32, 128, 3, 1, "SAME")
     verify_conv2d_hwcn(1, 256, 32, 256, 3, 1, "SAME")
     verify_conv2d_hwcn(4, 128, 16, 128, 5, 2, "SAME")
     verify_conv2d_hwcn(4, 128, 16, 256, 5, 2, "SAME")
-    verify_conv2d_hwcn(1, 256, 32, 256, 3, 1, "VALID")
+    verify_conv2d_hwcn(1, 256, 32, 128, 3, 1, "VALID")
     verify_conv2d_hwcn(1, 256, 32, 256, 3, 1, "VALID")
     verify_conv2d_hwcn(4, 128, 16, 128, 5, 2, "VALID")
     verify_conv2d_hwcn(4, 128, 16, 256, 5, 2, "VALID")
     # dilation = 2
     verify_conv2d_hwcn(1, 256, 32, 256, 3, 1, "SAME", dilation=2)
+    # Pass stride as tuple
+    verify_conv2d_hwcn(1, 256, 32, 128, 3, (1, 1), "SAME")
+    verify_conv2d_hwcn(1, 256, 32, 256, 3, (1, 1), "SAME")
+    verify_conv2d_hwcn(4, 128, 16, 128, 5, (2, 2), "SAME")
+    verify_conv2d_hwcn(4, 128, 16, 256, 5, (2, 2), "SAME")
+    verify_conv2d_hwcn(1, 256, 32, 128, 3, (1, 1), "VALID")
+    verify_conv2d_hwcn(1, 256, 32, 256, 3, (1, 1), "VALID")
+    verify_conv2d_hwcn(4, 128, 16, 128, 5, (2, 2), "VALID")
+    verify_conv2d_hwcn(4, 128, 16, 256, 5, (2, 2), "VALID")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If param stride is tuple, like (1, 1), errors would occur like following:

`
File "xxx/python/tvm/topi/testing/conv2d_hwcn_python.py", line 76, in conv2d_hwcn_python
bt[n, f] += out[::stride, ::stride]
TypeError: slice indices must be integers or None or have an __index__ method
`

Because tuple has not been handled correctly in line: 52