### PR TITLE
[µTVM] Clone Zephyr 2.5.0 from maintenance branch

### DIFF
--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -55,7 +55,7 @@ pip3 install west
 #EOF
 #chmod a+x /usr/local/bin/west
 
-west init --mr v2.5.0 /opt/zephyrproject
+west init --mr v2.5-branch /opt/zephyrproject
 cd /opt/zephyrproject
 west update
 


### PR DESCRIPTION
Clone Zephyr 2.5.0 from maintenance branch 'v2.5-branch' instead of from
release tag 'v2.5.0'. The maintenance branch is stable and includes all
the most recent fixes backported to Zephyr 2.5.0.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
