### PR TITLE
Enable StackVM in AutoTVM

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -489,9 +489,7 @@ class _WrappedBuildFunc:
         tic = time.time()
         try:
             output_format = "stackvm" if self.build_func is None else self.build_func.output_format
-            filename = os.path.join(
-                tmp_dir, "tmp_func_%0x.%s" % (getrandbits(64), output_format)
-            )
+            filename = os.path.join(tmp_dir, "tmp_func_%0x.%s" % (getrandbits(64), output_format))
             # TODO(tvm-team) consider linline _build_func_common
             func, arg_info = _build_func_common(measure_input, **kwargs)
             func.export_library(filename, self.build_func)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -81,6 +81,7 @@ class LocalBuilder(Builder):
     build_func: callable or str
         If is 'default', use default build function
         If is 'ndk', use function for android ndk
+        If id 'stackvm', use function for stackvm
         If is callable, use it as custom build function, expect lib_format field.
     """
 
@@ -459,8 +460,8 @@ class _WrappedBuildFunc:
 
     Parameters
     ----------
-    build_func : The compilation function
-        We expect fcompile to contain an attr "output_format"
+    build_func : The compilation function, optional
+        We expect fcompile to contain an attr "output_format" or None.
 
     Returns
     -------

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -92,6 +92,8 @@ class LocalBuilder(Builder):
                 build_func = tar.tar
             elif build_func == "ndk":
                 build_func = ndk.create_shared
+            elif build_func == "stackvm":
+                build_func = None
             else:
                 raise ValueError("Invalid build_func" + build_func)
         self.build_func = _WrappedBuildFunc(build_func)
@@ -467,7 +469,7 @@ class _WrappedBuildFunc:
     """
 
     def __init__(self, build_func):
-        if not hasattr(build_func, "output_format"):
+        if build_func is not None and not hasattr(build_func, "output_format"):
             raise AttributeError("Expect build_func to have the attribute output_format.")
         self.build_func = build_func
 
@@ -485,8 +487,9 @@ class _WrappedBuildFunc:
         """
         tic = time.time()
         try:
+            output_format = "stackvm" if self.build_func is None else self.build_func.output_format
             filename = os.path.join(
-                tmp_dir, "tmp_func_%0x.%s" % (getrandbits(64), self.build_func.output_format)
+                tmp_dir, "tmp_func_%0x.%s" % (getrandbits(64), output_format)
             )
             # TODO(tvm-team) consider linline _build_func_common
             func, arg_info = _build_func_common(measure_input, **kwargs)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -94,7 +94,7 @@ class LocalBuilder(Builder):
             elif build_func == "ndk":
                 build_func = ndk.create_shared
             elif build_func == "stackvm":
-                build_func = stackvm.stackvm
+                build_func = stackvm.build
             else:
                 raise ValueError("Invalid build_func" + build_func)
         self.build_func = _WrappedBuildFunc(build_func)

--- a/python/tvm/contrib/stackvm.py
+++ b/python/tvm/contrib/stackvm.py
@@ -18,11 +18,7 @@
 """Dummy StackVM build function."""
 # pylint: disable=invalid-name
 from __future__ import absolute_import as _abs
-import os
 import shutil
-import subprocess
-from . import utils
-from .._ffi.base import py_str
 
 
 def stackvm(output, files):
@@ -40,7 +36,7 @@ def stackvm(output, files):
     if len(files) == 0:
         raise RuntimeError("StackVM artifact must be provided")
     if len(files) > 1:
-        "Unexpected multiple StackVM artifacts"
+        raise RuntimeError("Unexpected multiple StackVM artifacts")
 
     shutil.copy(files[0], output)
 

--- a/python/tvm/contrib/stackvm.py
+++ b/python/tvm/contrib/stackvm.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Dummy StackVM build function."""
+# pylint: disable=invalid-name
+from __future__ import absolute_import as _abs
+import os
+import shutil
+import subprocess
+from . import utils
+from .._ffi.base import py_str
+
+
+def stackvm(output, files):
+    """Simply copy StackVM output to the destination.
+
+    Parameters
+    ----------
+    output : str
+        The target StackVM file.
+
+    files : list
+        A single self-contained StackVM module file.
+    """
+
+    if len(files) == 0:
+        raise RuntimeError("StackVM artifact must be provided")
+    if len(files) > 1:
+        "Unexpected multiple StackVM artifacts"
+
+    shutil.copy(files[0], output)
+
+# assign output format
+stackvm.output_format = "stackvm"

--- a/python/tvm/contrib/stackvm.py
+++ b/python/tvm/contrib/stackvm.py
@@ -44,5 +44,6 @@ def stackvm(output, files):
 
     shutil.copy(files[0], output)
 
+
 # assign output format
 stackvm.output_format = "stackvm"

--- a/python/tvm/contrib/stackvm.py
+++ b/python/tvm/contrib/stackvm.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import as _abs
 import shutil
 
 
-def stackvm(output, files):
+def build(output, files):
     """Simply copy StackVM output to the destination.
 
     Parameters
@@ -42,4 +42,4 @@ def stackvm(output, files):
 
 
 # assign output format
-stackvm.output_format = "stackvm"
+build.output_format = "stackvm"


### PR DESCRIPTION
It turns out in my edge use case StackVM is rather useful because it's minimum. I think it can help if tuning via StackVM can be officially supported.