### PR TITLE
[FIX,VM] Fix get_outputs on the vm with a single output

### DIFF
--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -142,11 +142,21 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
     });
   } else if (name == "get_output") {
     return TypedPackedFunc<NDArray(int64_t)>([this](int64_t index) {
-      return Downcast<NDArray>(Downcast<ADT>(this->return_register_)[index]);
+      if (this->return_register_.as<ADTObj>()) {
+        return Downcast<NDArray>(Downcast<ADT>(this->return_register_)[index]);
+      } else {
+        return Downcast<NDArray>(this->return_register_);
+      }
     });
   } else if (name == "get_num_outputs") {
-    return TypedPackedFunc<int64_t(void)>(
-        [this]() -> int64_t { return Downcast<ADT>(this->return_register_).size(); });
+    return TypedPackedFunc<int64_t(void)>([this]() -> int64_t {
+      // single output is an NDArray not an ADT
+      if (this->return_register_.as<ADTObj>()) {
+        return Downcast<ADT>(this->return_register_).size();
+      } else {
+        return 1;
+      }
+    });
   } else if (name == "init") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       ICHECK_EQ(args.size() % 3, 0);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -145,6 +145,8 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
       if (this->return_register_.as<ADTObj>()) {
         return Downcast<NDArray>(Downcast<ADT>(this->return_register_)[index]);
       } else {
+        CHECK_EQ(index, 0) << "VM output contains only one item, but you are trying to get the "
+                           << index << "th.";
         return Downcast<NDArray>(this->return_register_);
       }
     });


### PR DESCRIPTION
The VM uses an ADT for multiple outputs and an NDArray for a single output. The single output case was not being handled.

@tmoreau89