### PR TITLE
[CodeGenC] Fix bugs when calling extern functions

### DIFF
--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -444,6 +444,10 @@ def load_module(path, fmt=""):
     This function will automatically call
     cc.create_shared if the path is in format .o or .tar
     """
+    if os.path.isfile(path):
+        path = os.path.realpath(path)
+    else:
+        raise ValueError("cannot find file %s" % path)
 
     # c++ compiler/linker
     cc = os.environ.get("CXX", "g++")

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -960,11 +960,19 @@ void CodeGenC::VisitStmt_(const EvaluateNode* op) {
       return;
     } else if (call->op.same_as(builtin::tvm_struct_set())) {
       ICHECK_EQ(call->args.size(), 4);
+      int kind = call->args[2].as<IntImmNode>()->value;
+      std::string ref = GetStructRef(call->args[3].dtype(), call->args[0], call->args[1], kind);
       std::string value = PrintExpr(call->args[3]);
-      std::string ref = GetStructRef(call->args[3].dtype(), call->args[0], call->args[1],
-                                     call->args[2].as<IntImmNode>()->value);
+      std::string cast;
+      if (kind == builtin::kArrShape || kind == builtin::kArrStrides) {
+        // cast void* to int64_t*
+        cast = call->args[3]->dtype.is_handle() ? "(int64_t*)" : "";
+      } else if (kind == builtin::kArrDeviceType) {
+        // cast int to enum
+        cast = "(DLDeviceType)";
+      }
       this->PrintIndent();
-      this->stream << ref << " = " << value << ";\n";
+      this->stream << ref << " = " << cast << value << ";\n";
       return;
     }
   }

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -964,7 +964,7 @@ void CodeGenC::VisitStmt_(const EvaluateNode* op) {
       std::string ref = GetStructRef(call->args[3].dtype(), call->args[0], call->args[1], kind);
       std::string value = PrintExpr(call->args[3]);
       std::string cast;
-      if (kind == builtin::kArrShape || kind == builtin::kArrStrides) {
+      if (kind == builtin::kArrStrides) {
         // cast void* to int64_t*
         cast = call->args[3]->dtype.is_handle() ? "(int64_t*)" : "";
       } else if (kind == builtin::kArrDeviceType) {

--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -24,10 +24,9 @@
 #ifndef TVM_TARGET_SOURCE_CODEGEN_C_HOST_H_
 #define TVM_TARGET_SOURCE_CODEGEN_C_HOST_H_
 
-#include <set>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "codegen_c.h"
 #include "tvm/target/codegen.h"

--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "codegen_c.h"
 #include "tvm/target/codegen.h"
@@ -63,8 +64,8 @@ class CodeGenCHost final : public CodeGenC {
 
  private:
   std::string module_name_;
-  /* \brief tracks declared global variables which live despite GetUniqueName */
-  std::set<std::string> declared_globals_;
+  /* \brief mapping global packed func to the unique name */
+  std::unordered_map<std::string, std::string> declared_globals_;
   /* \brief names of the functions declared in this module */
   Array<String> function_names_;
   /*! \brief whether to emit asserts in the resulting C code */

--- a/tests/python/contrib/test_cblas.py
+++ b/tests/python/contrib/test_cblas.py
@@ -59,7 +59,8 @@ def verify_matmul_add(m, l, n, lib, transa=False, transb=False, dtype="float32")
         dev = tvm.cpu(0)
         name = "test_matmul_add"
         f = tvm.build(s, [A, B, D, bias], target, name=name)
-        if target == "c": f = compile(f, name)
+        if target == "c":
+            f = compile(f, name)
         a = tvm.nd.array(np.random.uniform(size=ashape).astype(A.dtype), dev)
         b = tvm.nd.array(np.random.uniform(size=bshape).astype(B.dtype), dev)
         d = tvm.nd.array(np.zeros((n, m), dtype=D.dtype), dev)
@@ -191,7 +192,8 @@ def verify_batch_matmul(
         dev = tvm.cpu(0)
         name = "test_batch_matmul"
         f = tvm.build(s, [A, B, D], target, name=name)
-        if target == "c": f = compile(f, name)
+        if target == "c":
+            f = compile(f, name)
         a = tvm.nd.array(np.random.uniform(size=ashape).astype(A.dtype), dev)
         b = tvm.nd.array(np.random.uniform(size=bshape).astype(B.dtype), dev)
         d = tvm.nd.array(np.zeros((batch, n, m), dtype=D.dtype), dev)

--- a/tests/python/contrib/test_cblas.py
+++ b/tests/python/contrib/test_cblas.py
@@ -42,6 +42,13 @@ def verify_matmul_add(m, l, n, lib, transa=False, transb=False, dtype="float32")
             b = b.transpose()
         return np.dot(a, b) + bb
 
+    def compile(f, name="test_matmul_add", ext=".so"):
+        path = name + ext
+        f.export_library(path)
+        mod = tvm.runtime.load_module(path)
+        f = mod[name]
+        return f
+
     def verify(target="llvm"):
         if not tvm.testing.device_enabled(target):
             print("skip because %s is not enabled..." % target)
@@ -50,7 +57,9 @@ def verify_matmul_add(m, l, n, lib, transa=False, transb=False, dtype="float32")
             print("skip because extern function is not available")
             return
         dev = tvm.cpu(0)
-        f = tvm.build(s, [A, B, D, bias], target)
+        name = "test_matmul_add"
+        f = tvm.build(s, [A, B, D, bias], target, name=name)
+        if target == "c": f = compile(f, name)
         a = tvm.nd.array(np.random.uniform(size=ashape).astype(A.dtype), dev)
         b = tvm.nd.array(np.random.uniform(size=bshape).astype(B.dtype), dev)
         d = tvm.nd.array(np.zeros((n, m), dtype=D.dtype), dev)
@@ -60,7 +69,8 @@ def verify_matmul_add(m, l, n, lib, transa=False, transb=False, dtype="float32")
             d.asnumpy(), get_numpy(a.asnumpy(), b.asnumpy(), bb, transa, transb), rtol=1e-5
         )
 
-    verify()
+    verify("llvm")
+    verify("c")
 
 
 def test_matmul_add():
@@ -164,6 +174,13 @@ def verify_batch_matmul(
             b = b.transpose(0, 2, 1)
         return tvm.topi.testing.batch_matmul(a, b)
 
+    def compile(f, name="test_batch_matmul", ext=".so"):
+        path = name + ext
+        f.export_library(path)
+        mod = tvm.runtime.load_module(path)
+        f = mod[name]
+        return f
+
     def verify(target="llvm"):
         if not tvm.testing.device_enabled(target):
             print("skip because %s is not enabled..." % target)
@@ -172,7 +189,9 @@ def verify_batch_matmul(
             print("skip because extern function is not available")
             return
         dev = tvm.cpu(0)
-        f = tvm.build(s, [A, B, D], target)
+        name = "test_batch_matmul"
+        f = tvm.build(s, [A, B, D], target, name=name)
+        if target == "c": f = compile(f, name)
         a = tvm.nd.array(np.random.uniform(size=ashape).astype(A.dtype), dev)
         b = tvm.nd.array(np.random.uniform(size=bshape).astype(B.dtype), dev)
         d = tvm.nd.array(np.zeros((batch, n, m), dtype=D.dtype), dev)
@@ -181,7 +200,8 @@ def verify_batch_matmul(
             d.asnumpy(), get_numpy(a.asnumpy(), b.asnumpy(), transa, transb), rtol=1e-5
         )
 
-    verify()
+    verify("llvm")
+    verify("c")
 
 
 def test_batch_matmul():

--- a/tests/python/unittest/test_target_codegen_c_host.py
+++ b/tests/python/unittest/test_target_codegen_c_host.py
@@ -204,11 +204,10 @@ def test_call_packed():
     def check_global_packed_func():
         fname = "fake.func"
         A, body = fake_func(fname)
-
         func1 = tvm.tir.PrimFunc([A], body).with_attr("global_symbol", "func1")
         B, body = fake_func()
         func2 = tvm.tir.PrimFunc([B], body).with_attr("global_symbol", "func2")
-        mod = tvm.IRModule({"fake_func1": func1, "fake_func2": func2,})
+        mod = tvm.IRModule({"fake_func1": func1, "fake_func2": func2})
         fcode = tvm.build(mod, None, "c")
         src = fcode.get_source()
 

--- a/tests/python/unittest/test_target_codegen_c_host.py
+++ b/tests/python/unittest/test_target_codegen_c_host.py
@@ -191,6 +191,43 @@ def test_round():
     check_c()
 
 
+def test_call_packed():
+    def fake_func(fname="fake.func"):
+        ib = tvm.tir.ir_builder.create()
+        A = ib.pointer("float32", name="A")
+        fake_func1 = tvm.tir.call_packed(fname, A[0])
+
+        ib.emit(fake_func1)
+        body = ib.get()
+        return A, body
+
+    def check_global_packed_func():
+        fname = "fake.func"
+        A, body = fake_func(fname)
+
+        func1 = tvm.tir.PrimFunc([A], body).with_attr("global_symbol", "func1")
+        B, body = fake_func()
+        func2 = tvm.tir.PrimFunc([B], body).with_attr("global_symbol", "func2")
+        mod = tvm.IRModule({"fake_func1": func1, "fake_func2": func2,})
+        fcode = tvm.build(mod, None, "c")
+        src = fcode.get_source()
+
+        # there are two locations calling the packed func
+        assert src.count(fname) == 2
+
+        suffix = "_packed"
+        packed_func_name = fname + suffix
+        # func name will be standardized by GetUniqueName and not exists anymore
+        assert src.find(packed_func_name) == -1
+
+        packed_func_real_name = "_".join(fname.split(".")) + suffix
+        func_declaration = "static void* %s = NULL;" % packed_func_real_name
+        # src only has 1 valid declaration
+        assert src.count(func_declaration) == 1
+
+    check_global_packed_func()
+
+
 if __name__ == "__main__":
     test_add()
     test_add_pipeline()
@@ -198,3 +235,4 @@ if __name__ == "__main__":
     test_ceil()
     test_floor()
     test_round()
+    test_call_packed()


### PR DESCRIPTION
This PR fixes some issues reported at #7596 
* Change `declared_globals_` to a unordered_map to tracks global packed funcs and their unique names. A test case is added accordingly.
* Cast the data type of some variables in DLTensor to fix the complainings of GCC, such as `int -> enum`
* Update cblas tests for C target.