### PR TITLE
[TIR][SPIR-V] Fix computing clz on int64 input for vulkan

### DIFF
--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -758,7 +758,8 @@ def clz(x):
     Parameters
     ----------
     x : PrimExpr
-        Input argument. The result is undefined if the input is 0.
+        Input 32 or 64 bit integer.
+        The result is undefined if the input is 0.
 
     Returns
     -------

--- a/src/target/spirv/intrin_rule_spirv.cc
+++ b/src/target/spirv/intrin_rule_spirv.cc
@@ -33,24 +33,30 @@ namespace spirv {
 using tir::FLowerIntrinsic;
 
 // num_signature means number of arguments used to query signature
-
 template <unsigned id>
-PrimExpr CallGLSLIntrin(const PrimExpr& e) {
+PrimExpr CallGLSLIntrin(PrimExpr e, const Array<PrimExpr>& args) {
   const tir::CallNode* call = e.as<tir::CallNode>();
   ICHECK(call != nullptr);
   Array<PrimExpr> cargs;
   // intrin id.
   cargs.push_back(IntImm(DataType::UInt(32), id));
 
-  for (PrimExpr arg : call->args) {
+  for (PrimExpr arg : args) {
     cargs.push_back(arg);
   }
   return tir::Call(call->dtype, tir::builtin::call_spirv_pure_glsl450(), cargs);
 }
 
 template <unsigned id>
-inline PrimExpr DispatchGLSLPureIntrin(const PrimExpr& e) {
-  return CallGLSLIntrin<id>(e);
+PrimExpr CallGLSLIntrin(PrimExpr e) {
+  const tir::CallNode* call = e.as<tir::CallNode>();
+  ICHECK(call != nullptr);
+  return CallGLSLIntrin<id>(e, call->args);
+}
+
+template <unsigned id>
+inline void DispatchGLSLPureIntrin(const TVMArgs& targs, TVMRetValue* rv) {
+  *rv = CallGLSLIntrin<id>(targs[0]);
 }
 
 TVM_REGISTER_OP("tir.floor")
@@ -98,7 +104,20 @@ TVM_REGISTER_OP("tir.clz").set_attr<FLowerIntrinsic>(
       ICHECK(call != nullptr);
       ICHECK_EQ(call->args.size(), 1);
       PrimExpr arg = call->args[0];
-      PrimExpr msb = CallGLSLIntrin<GLSLstd450FindUMsb>(e);
+      PrimExpr msb;
+      if (arg.dtype().bits() == 64) {
+        // SPIR-V FindUMsb intrinsic only supports 32 bit input
+        auto int32 = DataType::Int(32);
+        PrimExpr arg_hi32 = tvm::tir::Cast(int32, arg >> 32);
+        PrimExpr arg_lo32 = tvm::tir::Cast(int32, arg);
+        PrimExpr msb_hi = CallGLSLIntrin<GLSLstd450FindUMsb>(targs[0], {arg_hi32});
+        PrimExpr msb_lo = CallGLSLIntrin<GLSLstd450FindUMsb>(targs[0], {arg_lo32});
+        msb = tvm::if_then_else(arg_hi32 == 0, msb_lo, msb_hi + 32);
+      } else if (arg.dtype().bits() == 32) {
+        msb = CallGLSLIntrin<GLSLstd450FindUMsb>(targs[0]);
+      } else {
+        LOG(FATAL) << "SPIR-V clz only supports a 32 bit or 64 bit integer.";
+      }
       return PrimExpr(arg.dtype().bits() - 1) - msb;
     });
 

--- a/src/target/spirv/intrin_rule_spirv.cc
+++ b/src/target/spirv/intrin_rule_spirv.cc
@@ -55,8 +55,8 @@ PrimExpr CallGLSLIntrin(PrimExpr e) {
 }
 
 template <unsigned id>
-inline void DispatchGLSLPureIntrin(const TVMArgs& targs, TVMRetValue* rv) {
-  *rv = CallGLSLIntrin<id>(targs[0]);
+inline PrimExpr DispatchGLSLPureIntrin(const PrimExpr& e) {
+  return CallGLSLIntrin<id>(e);
 }
 
 TVM_REGISTER_OP("tir.floor")
@@ -110,11 +110,11 @@ TVM_REGISTER_OP("tir.clz").set_attr<FLowerIntrinsic>(
         auto int32 = DataType::Int(32);
         PrimExpr arg_hi32 = tvm::tir::Cast(int32, arg >> 32);
         PrimExpr arg_lo32 = tvm::tir::Cast(int32, arg);
-        PrimExpr msb_hi = CallGLSLIntrin<GLSLstd450FindUMsb>(targs[0], {arg_hi32});
-        PrimExpr msb_lo = CallGLSLIntrin<GLSLstd450FindUMsb>(targs[0], {arg_lo32});
+        PrimExpr msb_hi = CallGLSLIntrin<GLSLstd450FindUMsb>(e, {arg_hi32});
+        PrimExpr msb_lo = CallGLSLIntrin<GLSLstd450FindUMsb>(e, {arg_lo32});
         msb = tvm::if_then_else(arg_hi32 == 0, msb_lo, msb_hi + 32);
       } else if (arg.dtype().bits() == 32) {
-        msb = CallGLSLIntrin<GLSLstd450FindUMsb>(targs[0]);
+        msb = CallGLSLIntrin<GLSLstd450FindUMsb>(e);
       } else {
         LOG(FATAL) << "SPIR-V clz only supports a 32 bit or 64 bit integer.";
       }

--- a/tests/python/unittest/test_tir_intrin.py
+++ b/tests/python/unittest/test_tir_intrin.py
@@ -170,7 +170,12 @@ def test_clz():
             dev = tvm.device(target, 0)
             n = 10
 
-            for high in [10, 100, 1000, 10000, 100000, 1000000]:
+            highs = [10, 100, 1000, 10000, 100000, 1000000]
+
+            if dtype == "int64":
+                highs.append((1 << 63) - 1)
+
+            for high in highs:
                 a_np = np.random.randint(1, high=high, size=(n,)).astype(dtype)
                 a = tvm.nd.array(a_np, dev)
                 b = tvm.nd.array(np.zeros((n,)).astype("int32"), dev)


### PR DESCRIPTION
It turns out SPIR-V `FindUMsb` intrisic we use for `clz` on vulkan supports only 32 bit input. 
https://www.khronos.org/registry/spir-v/specs/1.0/GLSL.std.450.html

On AMD there is no error if we try to run `FindUMsb` on int64, but @zxybazh found that on NV it doesn't work. Support int64 MSB by separately computing 32 bit MSB for high and low half and combine the result appropriately. A bonus point if you know how to do better :slightly_smiling_face: 

@zxybazh @junrushao1994 @tqchen 