### PR TITLE
[µTVM]: Zephyr: Add mps2_an521 board to the CI

### DIFF
--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -23,4 +23,5 @@ set -x  # NOTE(areusch): Adding to diagnose flaky timeouts
 source tests/scripts/setup-pytest-env.sh
 
 make cython3
-run_pytest ctypes python-microtvm-zephyr tests/micro/zephyr
+run_pytest ctypes python-microtvm-zephyr tests/micro/zephyr --microtvm-platforms=host
+run_pytest ctypes python-microtvm-zephyr tests/micro/zephyr --microtvm-platforms=mps2_an521


### PR DESCRIPTION
Since Arm reference board mps2_an521 is now added as a test platform to
test µTVM with Zephyr and that test platform runs by default emulated,
plus Zephyr docker images were updated to use Zephyr v2.5-branch, add
the mps2_an521 board as a platform to be automatically used by the CI.

That change will allow testing µTVM on top of Zephyr running on a
Cortex-m33 MCU. Currently only a x86 VM is used for that kind of test.
This will help ensure that there is no regression on Arm-based MCUs.

That commit also adds explicitly the parameter --microtvm-platforms=host
to the current test (x86) to ease reading about which test platforms are
triggered in the CI ('host' is the default platform when that parameter
is ommited, so nothing changes for tests on the x86 VM).

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
