### PR TITLE
[RUNTIME][BUGFIX] Fix DSO module problem when its parent get destructed.

### DIFF
--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -125,10 +125,11 @@ Module LoadModuleFromBinary(const std::string& type_key, dmlc::Stream* stream) {
  * \brief Load and append module blob to module list
  * \param mblob The module blob.
  * \param lib The library.
- *
- * \return Root Module.
+ * \param root_module the output root module
+ * \param dso_ctx_addr the output dso module
  */
-runtime::Module ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib) {
+void ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib, runtime::Module* root_module,
+                       runtime::ModuleNode** dso_ctx_addr = nullptr) {
   ICHECK(mblob != nullptr);
   uint64_t nbytes = 0;
   for (size_t i = 0; i < sizeof(nbytes); ++i) {
@@ -143,14 +144,20 @@ runtime::Module ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib) {
   std::vector<Module> modules;
   std::vector<uint64_t> import_tree_row_ptr;
   std::vector<uint64_t> import_tree_child_indices;
+  int num_dso_module = 0;
+
   for (uint64_t i = 0; i < size; ++i) {
     std::string tkey;
     ICHECK(stream->Read(&tkey));
     // Currently, _lib is for DSOModule, but we
-    // don't have loadbinary function for it currently
+    // need to be handled specially
     if (tkey == "_lib") {
       auto dso_module = Module(make_object<LibraryModuleNode>(lib));
+      *dso_ctx_addr = dso_module.operator->();
+      ++num_dso_module;
       modules.emplace_back(dso_module);
+      ICHECK_EQ(num_dso_module, 1U) << "Multiple dso module detected, please upgrade tvm "
+                                    << " to the latest before exporting the module";
     } else if (tkey == "_import_tree") {
       ICHECK(stream->Read(&import_tree_row_ptr));
       ICHECK(stream->Read(&import_tree_child_indices));
@@ -159,6 +166,7 @@ runtime::Module ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib) {
       modules.emplace_back(m);
     }
   }
+
   // if we are using old dll, we don't have import tree
   // so that we can't reconstruct module relationship using import tree
   if (import_tree_row_ptr.empty()) {
@@ -167,7 +175,8 @@ runtime::Module ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib) {
     for (const auto& m : modules) {
       module_import_addr->emplace_back(m);
     }
-    return Module(n);
+    *dso_ctx_addr = n.get();
+    *root_module = Module(n);
   } else {
     for (size_t i = 0; i < modules.size(); ++i) {
       for (size_t j = import_tree_row_ptr[i]; j < import_tree_row_ptr[i + 1]; ++j) {
@@ -177,11 +186,11 @@ runtime::Module ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib) {
         module_import_addr->emplace_back(modules[child_index]);
       }
     }
+    ICHECK(!modules.empty());
+    // invariance: root module is always at location 0.
+    // The module order is collected via DFS
+    *root_module = modules[0];
   }
-  ICHECK(!modules.empty());
-  // invariance: root module is always at location 0.
-  // The module order is collected via DFS
-  return modules[0];
 }
 
 Module CreateModuleFromLibrary(ObjectPtr<Library> lib) {
@@ -190,17 +199,20 @@ Module CreateModuleFromLibrary(ObjectPtr<Library> lib) {
   // Load the imported modules
   const char* dev_mblob =
       reinterpret_cast<const char*>(lib->GetSymbol(runtime::symbol::tvm_dev_mblob));
+
   Module root_mod;
+  runtime::ModuleNode* dso_ctx_addr = nullptr;
   if (dev_mblob != nullptr) {
-    root_mod = ProcessModuleBlob(dev_mblob, lib);
+    ProcessModuleBlob(dev_mblob, lib, &root_mod, &dso_ctx_addr);
   } else {
     // Only have one single DSO Module
     root_mod = Module(n);
+    dso_ctx_addr = root_mod.operator->();
   }
 
   // allow lookup of symbol from root (so all symbols are visible).
   if (auto* ctx_addr = reinterpret_cast<void**>(lib->GetSymbol(runtime::symbol::tvm_module_ctx))) {
-    *ctx_addr = root_mod.operator->();
+    *ctx_addr = dso_ctx_addr;
   }
 
   return root_mod;

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -149,8 +149,8 @@ void ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib, runtime::Modul
   for (uint64_t i = 0; i < size; ++i) {
     std::string tkey;
     ICHECK(stream->Read(&tkey));
-    // Currently, _lib is for DSOModule, but we
-    // need to be handled specially
+    // "_lib" serves as a placeholder in the module import tree to indicate where
+    // to place the DSOModule
     if (tkey == "_lib") {
       auto dso_module = Module(make_object<LibraryModuleNode>(lib));
       *dso_ctx_addr = dso_module.operator->();
@@ -186,7 +186,8 @@ void ProcessModuleBlob(const char* mblob, ObjectPtr<Library> lib, runtime::Modul
         module_import_addr->emplace_back(modules[child_index]);
       }
     }
-    ICHECK(!modules.empty());
+
+    ICHECK(!modules.empty()) << "modules cannot be empty when import tree is present";
     // invariance: root module is always at location 0.
     // The module order is collected via DFS
     *root_module = modules[0];

--- a/src/runtime/stackvm/stackvm_module.cc
+++ b/src/runtime/stackvm/stackvm_module.cc
@@ -74,9 +74,7 @@ class StackVMModuleNode : public runtime::ModuleNode {
       ICHECK_EQ(im->imports().size(), 0U) << "Only support simply one-level hierarchy";
       std::string tkey = im->type_key();
       strm->Write(tkey);
-      LOG(INFO) << "save " << tkey;
       im->SaveToBinary(strm);
-      LOG(INFO) << "FInish save " << tkey;
     }
     SaveBinaryToFile(file_name, data);
   }

--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -75,21 +75,26 @@ class ModuleSerializer {
     if (has_import_tree) {
       // we will append one key for _import_tree
       // The layout is the same as before: binary_size, key, logic, key, logic...
-      sz = mod_vec_.size() + 1;
+      sz = mod_group_vec_.size() + 1;
     } else {
       // Keep the old behaviour
       sz = mod_->imports().size();
     }
     stream->Write(sz);
 
-    for (auto m : mod_vec_) {
-      std::string mod_type_key = m->type_key();
-      if (!DSOExportable(m)) {
+    for (const auto& group : mod_group_vec_) {
+      CHECK_NE(group.size(), 0);
+      if (!DSOExportable(group[0])) {
+        ICHECK_EQ(group.size(), 1U);
+        std::string mod_type_key = group[0]->type_key();
         stream->Write(mod_type_key);
-        m->SaveToBinary(stream);
-      } else if (has_import_tree) {
-        mod_type_key = "_lib";
-        stream->Write(mod_type_key);
+        group[0]->SaveToBinary(stream);
+      } else {
+        // DSOExportable: do not need binary
+        if (has_import_tree) {
+          std::string mod_type_key = "_lib";
+          stream->Write(mod_type_key);
+        }
       }
     }
 
@@ -110,32 +115,100 @@ class ModuleSerializer {
 
   // invariance: root module is always at location 0.
   // The module order is collected via DFS
+  // This function merges all the DSO exportable module into
+  // a single one as this is also what happens in the final hierachy
   void CreateModuleIndex() {
     std::unordered_set<const runtime::ModuleNode*> visited{mod_.operator->()};
     std::vector<runtime::ModuleNode*> stack{mod_.operator->()};
     uint64_t module_index = 0;
 
-    while (!stack.empty()) {
-      runtime::ModuleNode* n = stack.back();
-      stack.pop_back();
-      mod2index_[n] = module_index++;
-      mod_vec_.emplace_back(n);
-      for (runtime::Module m : n->imports()) {
+    auto fpush_imports_to_stack = [&](runtime::ModuleNode* node) {
+      for (runtime::Module m : node->imports()) {
         runtime::ModuleNode* next = m.operator->();
         if (visited.count(next) == 0) {
           visited.insert(next);
           stack.push_back(next);
         }
       }
+    };
+
+    std::vector<runtime::ModuleNode*> dso_exportable_boundary;
+
+    // Create module index that merges all dso module into a single group.
+    //
+    // Do a two phase visit, to ensure dso module's index
+    // is always bigger than a parent of any dso module
+    // and smaller than children of any dso module.
+    //
+    // Error will be raised in CreateImportTree
+    // if merging dso module causes a cycle in the import tree
+
+    // Phase 0: only expand non-dso-module and record the boundary.
+    while (!stack.empty()) {
+      runtime::ModuleNode* n = stack.back();
+      stack.pop_back();
+      if (DSOExportable(n)) {
+        // do not recursively expand dso modules
+        // we will expand in phase 1
+        dso_exportable_boundary.emplace_back(n);
+      } else {
+        // expand the non-dso modules
+        mod2index_[n] = module_index++;
+        mod_group_vec_.emplace_back(std::vector<runtime::ModuleNode*>({n}));
+        fpush_imports_to_stack(n);
+      }
+    }
+    if (dso_exportable_boundary.size() == 0) return;
+
+    // create the slot for dso exportable modules
+    uint64_t dso_module_index = module_index++;
+    mod_group_vec_.emplace_back(std::vector<runtime::ModuleNode*>());
+
+    stack = std::move(dso_exportable_boundary);
+
+    // Phase 1: expand the children of dso modules.
+    while (!stack.empty()) {
+      runtime::ModuleNode* n = stack.back();
+      stack.pop_back();
+
+      if (DSOExportable(n)) {
+        mod_group_vec_[dso_module_index].emplace_back(n);
+        mod2index_[n] = dso_module_index;
+      } else {
+        mod2index_[n] = module_index++;
+        mod_group_vec_.emplace_back(std::vector<runtime::ModuleNode*>({n}));
+      }
+      fpush_imports_to_stack(n);
     }
   }
 
   void CreateImportTree() {
-    for (auto m : mod_vec_) {
-      for (runtime::Module im : m->imports()) {
-        uint64_t mod_index = mod2index_[im.operator->()];
-        import_tree_child_indices_.push_back(mod_index);
+    std::vector<int64_t> child_indices;
+
+    for (size_t parent_index = 0; parent_index < mod_group_vec_.size(); ++parent_index) {
+      child_indices.clear();
+      for (const auto* m : mod_group_vec_[parent_index]) {
+        for (runtime::Module im : m->imports()) {
+          uint64_t mod_index = mod2index_.at(im.operator->());
+          // skip cycle when dso modules are merged together
+          if (mod_index != parent_index) {
+            child_indices.emplace_back(mod_index);
+          }
+        }
       }
+      // sort and unique the merged indices
+      std::sort(child_indices.begin(), child_indices.end());
+      auto unique_end = std::unique(child_indices.begin(), child_indices.end());
+
+      // Check cycles due to merging dso exportable modules.
+      if (child_indices.size() != 0) {
+        CHECK_LT(parent_index, child_indices[0])
+            << "RuntimeError: Cannot export due to multiple dso-exportables "
+            << "that cannot be merged without creating a cycle in the import tree";
+      }
+      // insert the child indices
+      import_tree_child_indices_.insert(import_tree_child_indices_.end(), child_indices.begin(),
+                                        unique_end);
       import_tree_row_ptr_.push_back(import_tree_child_indices_.size());
     }
   }
@@ -147,8 +220,8 @@ class ModuleSerializer {
   runtime::Module mod_;
   // construct module to index
   std::unordered_map<runtime::ModuleNode*, size_t> mod2index_;
-  // index -> module
-  std::vector<runtime::ModuleNode*> mod_vec_;
+  // index -> module group
+  std::vector<std::vector<runtime::ModuleNode*>> mod_group_vec_;
   std::vector<uint64_t> import_tree_row_ptr_{0};
   std::vector<uint64_t> import_tree_child_indices_;
 };

--- a/tests/python/unittest/test_runtime_module_export.py
+++ b/tests/python/unittest/test_runtime_module_export.py
@@ -89,12 +89,13 @@ def test_mod_export():
             assert obj_format == ".tar"
             file_name = "deploy_lib.tar"
         path_lib = temp.relpath(file_name)
-        synthetic_gpu_lib.imported_modules[0].import_module(synthetic_llvm_cpu_lib)
+        synthetic_gpu_lib.import_module(synthetic_llvm_cpu_lib)
         synthetic_gpu_lib.export_library(path_lib)
         loaded_lib = tvm.runtime.load_module(path_lib)
         assert loaded_lib.type_key == "library"
         assert loaded_lib.imported_modules[0].type_key == "cuda"
-        assert loaded_lib.imported_modules[0].imported_modules[0].type_key == "library"
+        #  dso modules are merged together
+        assert len(loaded_lib.imported_modules) == 1
 
     def verify_multi_dso_mod_export(obj_format):
         for device in ["llvm"]:
@@ -102,16 +103,12 @@ def test_mod_export():
                 print("skip because %s is not enabled..." % device)
                 return
 
-        synthetic_mod, synthetic_params = relay.testing.synthetic.get_workload()
-        with tvm.transform.PassContext(opt_level=3):
-            _, synthetic_cpu_lib, _ = relay.build_module.build(
-                synthetic_mod, "llvm", params=synthetic_params
-            )
-
         A = te.placeholder((1024,), name="A")
         B = te.compute(A.shape, lambda *i: A(*i) + 1.0, name="B")
         s = te.create_schedule(B.op)
-        f = tvm.build(s, [A, B], "llvm", name="myadd")
+        mod0 = tvm.build(s, [A, B], "llvm", name="myadd0")
+        mod1 = tvm.build(s, [A, B], "llvm", name="myadd1")
+
         from tvm.contrib import utils
 
         temp = utils.tempdir()
@@ -121,11 +118,13 @@ def test_mod_export():
             assert obj_format == ".tar"
             file_name = "deploy_lib.tar"
         path_lib = temp.relpath(file_name)
-        synthetic_cpu_lib.import_module(f)
-        synthetic_cpu_lib.export_library(path_lib)
+
+        mod0.import_module(mod1)
+        mod0.export_library(path_lib)
         loaded_lib = tvm.runtime.load_module(path_lib)
         assert loaded_lib.type_key == "library"
-        assert loaded_lib.imported_modules[0].type_key == "library"
+        # dso modules are merged
+        assert len(loaded_lib.imported_modules) == 0
 
     def verify_json_import_dso(obj_format):
         for device in ["llvm"]:
@@ -215,8 +214,8 @@ def test_mod_export():
         synthetic_cpu_lib.export_library(path_lib, fcompile=False, **kwargs)
         loaded_lib = tvm.runtime.load_module(path_lib)
         assert loaded_lib.type_key == "library"
-        assert loaded_lib.imported_modules[0].type_key == "library"
-        assert loaded_lib.imported_modules[1].type_key == "library"
+        # dso modules are merged
+        assert len(loaded_lib.imported_modules) == 0
 
     for obj_format in [".so", ".tar"]:
         verify_gpu_mod_export(obj_format)


### PR DESCRIPTION
Previouslyw we set the context of the DSO module to be the root module.
This can cause problem when the root module is not the dso module and
get destructued early (but we still need the dso module).

This PR makes the following change to fix the problem.

- Merge multiple DSO modules to one during export.
- Set the context to be the (only one) dso module.
- Updated testcase to cover the problem.

The enhancement creates some restrictions on the dso import hierachy
(all dso modules needs to be merged without a cycle). This is the case
for our applications. The merged dso is also more consistent
as the library itself is merged.
