### PR TITLE
Use new SBT Debian Repo before bintray is shutdown

### DIFF
--- a/docker/install/ubuntu_install_sbt.sh
+++ b/docker/install/ubuntu_install_sbt.sh
@@ -25,7 +25,7 @@ set -o pipefail
 apt-get update && apt-get install -y apt-transport-https
 
 # Install the necessary dependencies for sbt
-echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 
 # Note: The settings in vta/hardware/chisel/project/build.properties

--- a/docker/install/ubuntu_install_sbt.sh
+++ b/docker/install/ubuntu_install_sbt.sh
@@ -25,7 +25,8 @@ set -o pipefail
 apt-get update && apt-get install -y apt-transport-https
 
 # Install the necessary dependencies for sbt
-echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 
 # Note: The settings in vta/hardware/chisel/project/build.properties


### PR DESCRIPTION
We started seeing issues with building the TVM Docker images, and they stemmed from the SBT (Scala Build Tool) installation which was using bintray instead of a later SBT Debian URL. Thankfully bintray were just running some brown outs before they turn the service off on May 1st:
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

So I took the Scala repo URL from here:
https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html

Which is the suggested SBT URL as they may change the backend again in future:
https://github.com/sbt/sbt/issues/6294

@leandron 
