### PR TITLE
[Topi] Fix arm_cpu bitserial schedule with elemwise ops.

### DIFF
--- a/python/tvm/topi/arm_cpu/bitserial_conv2d.py
+++ b/python/tvm/topi/arm_cpu/bitserial_conv2d.py
@@ -409,13 +409,10 @@ def schedule_bitserial_conv2d_nhwc(cfg, outs):
     s = te.create_schedule([x.op for x in outs])
 
     def _callback(op):
-        """Traverse operators from computation graph"""
-        # inline all one-to-one-mapping operators except the last stage (output)
         if "spatial_bitserial_conv_nhwc" in op.tag:
             output = op.output(0)
             conv_out = op.input_tensors[0]
             kernel_vec = conv_out.op.input_tensors[0]
-            kernel_q = kernel_vec.op.input_tensors[0]
             data_vec = conv_out.op.input_tensors[1]
             data_q = data_vec.op.input_tensors[0]
             data = data_q.op.input_tensors[0]

--- a/python/tvm/topi/arm_cpu/bitserial_conv2d.py
+++ b/python/tvm/topi/arm_cpu/bitserial_conv2d.py
@@ -21,7 +21,6 @@ import tvm
 from tvm import te
 from tvm import autotvm
 from tvm import relay
-from .. import tag
 from ..nn.pad import pad
 from ..nn.bitserial_conv2d import bitserial_conv2d_legalize
 from ..nn.bitserial_util import bitpack, binary_op_multiplier

--- a/python/tvm/topi/arm_cpu/bitserial_conv2d.py
+++ b/python/tvm/topi/arm_cpu/bitserial_conv2d.py
@@ -26,7 +26,7 @@ from ..nn.pad import pad
 from ..nn.bitserial_conv2d import bitserial_conv2d_legalize
 from ..nn.bitserial_util import bitpack, binary_op_multiplier
 from ..nn.utils import get_pad_tuple
-from ..utils import get_const_int, get_const_tuple
+from ..utils import get_const_int, get_const_tuple, traverse_inline
 
 
 def _kernel_vec_spatial_pack_nhwc(kernel, kernel_bits, VC, use_bitpack=True):
@@ -397,7 +397,7 @@ def _schedule_spatial_conv2d_nhwc(
     s[last].reorder(n, oh, ow, co, vh, vw, vc)
     s[last].vectorize(vc)
     if last != output:
-        s[last].compute_inline()
+        s[output].compute_inline()
 
     s[conv_out].compute_at(s[last], co)
     s[last].parallel(oh)
@@ -408,18 +408,10 @@ def _schedule_spatial_conv2d_nhwc(
 def schedule_bitserial_conv2d_nhwc(cfg, outs):
     """Arm cpu schedule for bitserial conv2d"""
     s = te.create_schedule([x.op for x in outs])
-    scheduled_ops = []
 
-    def traverse(op):
+    def _callback(op):
         """Traverse operators from computation graph"""
         # inline all one-to-one-mapping operators except the last stage (output)
-        if tag.is_broadcast(op.tag):
-            if op not in s.outputs:
-                s[op].compute_inline()
-            for tensor in op.input_tensors:
-                if isinstance(tensor.op, te.tensor.ComputeOp) and tensor.op not in scheduled_ops:
-                    traverse(tensor.op)
-
         if "spatial_bitserial_conv_nhwc" in op.tag:
             output = op.output(0)
             conv_out = op.input_tensors[0]
@@ -437,9 +429,8 @@ def schedule_bitserial_conv2d_nhwc(cfg, outs):
             _schedule_spatial_conv2d_nhwc(
                 cfg, s, data_pad, data_vec, kernel_vec, conv_out, output, outs[0], unipolar
             )
-        scheduled_ops.append(op)
 
-    traverse(outs[0].op)
+    traverse_inline(s, outs[0].op, _callback)
     return s
 
 

--- a/tests/python/topi/python/test_topi_bitserial_conv2d_rasp.py
+++ b/tests/python/topi/python/test_topi_bitserial_conv2d_rasp.py
@@ -43,6 +43,7 @@ def verify_bitserial_conv2d_nhwc(
     activation_bits,
     weight_bits,
     unipolar,
+    use_relu=False,
 ):
     in_height = in_width = in_size
     input_type = "uint32"
@@ -55,6 +56,8 @@ def verify_bitserial_conv2d_nhwc(
         B = topi.arm_cpu.bitserial_conv2d_nhwc(
             A, W, stride, padding, activation_bits, weight_bits, "uint8", out_dtype, unipolar
         )
+        if use_relu:
+            B = topi.nn.relu(B)
         s = topi.arm_cpu.schedule_bitserial_conv2d_nhwc([B])
 
     func = tvm.build(s, [A, W, B], device)
@@ -110,6 +113,8 @@ def test_bitserial_conv2d():
 
     verify_bitserial_conv2d_nhwc(1, in_size, ic, oc, k, stride, pad, 1, 1, True)
     verify_bitserial_conv2d_nhwc(1, in_size, ic, oc, k, stride, pad, 2, 1, True)
+
+    verify_bitserial_conv2d_nhwc(1, in_size, ic, oc, k, stride, pad, 2, 1, True, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As noted in #7909, the arm bitserial_conv2d schedule has issues with fused elemwise operators. This turned out to be due to a simple mistake that this PR corrects. 