### PR TITLE
[TIR][TRANSFORM] Return value support in tir.tvm_call_packed

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -334,11 +334,14 @@ TVM_DLL const Op& tvm_stack_make_array();
 /*!
  * \brief See pesudo code
  *
- *  int tvm_call_packed(name, TVMValue* args) {
+ *  return_type tvm_call_packed(name, TVMValue* args) {
+ *     TVMValue ret_value;
+ *     int ret_code;
  *     ModuleNode* env = GetCurrentEnv();
  *     const PackedFunc* f = env->GetFuncFromEnv(name);
- *     (*f)(args, type_code_of(args), len(args));
- *     return 0;
+ *     (*f)(args, type_code_of(args), len(args), &ret_value, &ret_code);
+ *     // return type can be int, float, handle.
+ *     return cast(return_type, ret_value.v_return_type);
  *  }
  */
 TVM_DLL const Op& tvm_call_packed();
@@ -346,11 +349,12 @@ TVM_DLL const Op& tvm_call_packed();
 /*!
  * \brief See pesudo code
  *
- *  int tvm_call_trace_packed(name, TVMValue* args) {
+ *  return_type tvm_call_trace_packed(name, TVMValue* args) {
  *     ModuleNode* env = GetCurrentEnv();
  *     const PackedFunc* f = env->GetFuncFromEnv(name);
  *     (*f)(args, type_code_of(args), len(args));
- *     return 0;
+ *     // return type can be int, float, handle.
+ *     return cast(return_type, ret_value.v_return_type);
  *  }
  */
 TVM_DLL const Op& tvm_call_trace_packed();
@@ -372,16 +376,18 @@ TVM_DLL const Op& tvm_thread_context();
  * \brief Lowered version of call packed, the space of value and
  *  type codes are explicitly allocated.
  *
- *  int tvm_call_packed_lowered(name,
- *                              TVMValue* value_stack,
- *                              int* tcode_stack,
- *                              int begin,
- *                              int end) {
+ *  return_type tvm_call_packed_lowered(name,
+ *                                      TVMValue* value_stack,
+ *                                      int* tcode_stack,
+ *                                      int begin,
+ *                                      int end) {
  *     ModuleNode* env = GetCurrentEnv();
  *     const PackedFunc* f = env->GetFuncFromEnv(name);
  *     f->CallPacked(TVMArgs(value_stack[begin:end],
  *                           tcode_stack[begin:end]),
  *                   TVMRetValue(value_stack + end, tcode_stack + end));
+ *     // return type can be int, float, handle.
+ *     return cast(return_type, load_return_from(tcode_stack + end))
  *  }
  */
 TVM_DLL const Op& tvm_call_packed_lowered();
@@ -391,16 +397,18 @@ TVM_DLL const Op& tvm_call_packed_lowered();
  *  type codes are explicitly allocated. The return value is the
  *  (end - 1) value on the stack.
  *
- *  int tvm_call_trace_packed_lowered(name,
- *                                    TVMValue* value_stack,
- *                                    int* tcode_stack,
- *                                    int begin,
- *                                    int end) {
+ *  return_type tvm_call_trace_packed_lowered(name,
+ *                                            TVMValue* value_stack,
+ *                                            int* tcode_stack,
+ *                                            int begin,
+ *                                            int end) {
  *     ModuleNode* env = GetCurrentEnv();
  *     const PackedFunc* f = env->GetFuncFromEnv(name);
  *     f->CallPacked(TVMArgs(value_stack[begin:end],
  *                           tcode_stack[begin:end]),
  *                   TVMRetValue(value_stack + end, tcode_stack + end));
+ *     // return type can be int, float, handle.
+ *     return cast(return_type, load_return_from(tcode_stack + end))
  *  }
  */
 TVM_DLL const Op& tvm_call_trace_packed_lowered();

--- a/python/tvm/tir/ir_builder.py
+++ b/python/tvm/tir/ir_builder.py
@@ -374,6 +374,26 @@ class IRBuilder(object):
 
         return WithScope(None, _exit_cb)
 
+    def let(self, var_name, value):
+        """Create a new let stmt binding.
+
+        Parameters
+        ----------
+        var_name : str
+            The name of the variable
+
+        value : PrimExpr
+            The value to be bound
+
+        Returns
+        -------
+        var : tvm.tir.Var
+           The var that can be in for future emits.
+        """
+        var = _expr.Var(var_name, dtype=value.dtype)
+        self.emit(lambda x: _stmt.LetStmt(var, value, x))
+        return var
+
     def allocate(self, dtype, shape, name="buf", scope=None):
         """Create a allocate statement.
 


### PR DESCRIPTION
This PR fixes the return value support in tir.tvm_call_packed

- Clarified the semantics of the intrinsics
- Fix a problem when lowering call packed with nested scopes(let bindings)
- Added regression tests to cover the changes

