### PR TITLE
[Tophub] Race condition fixed in folder creation

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -23,8 +23,9 @@ TVM will download these parameters for you when you call relay.build.
 # pylint: disable=invalid-name
 
 import logging
-import os
+from os import getenv
 import sys
+from pathlib import Path
 
 from .task import ApplyHistoryBest
 from ..target import Target
@@ -42,7 +43,7 @@ AUTOTVM_TOPHUB_DEFAULT_LOC = "https://raw.githubusercontent.com/tlc-pack/tophub/
 AUTOTVM_TOPHUB_NONE_LOC = "NONE"
 
 # root path to store TopHub files
-AUTOTVM_TOPHUB_ROOT_PATH = os.path.join(os.path.expanduser("~"), ".tvm", "tophub")
+AUTOTVM_TOPHUB_ROOT_PATH = Path(Path("~").expanduser(), ".tvm", "tophub")
 
 # the version of each package
 PACKAGE_VERSION = {
@@ -74,7 +75,7 @@ def _alias(name):
 
 
 def _get_tophub_location():
-    location = os.getenv(AUTOTVM_TOPHUB_LOC_VAR, None)
+    location = getenv(AUTOTVM_TOPHUB_LOC_VAR, None)
     return AUTOTVM_TOPHUB_DEFAULT_LOC if location is None else location
 
 
@@ -117,7 +118,7 @@ def context(target, extra_files=None):
                     continue
 
                 filename = "%s_%s.log" % (name, PACKAGE_VERSION[name])
-                best_context.load(os.path.join(AUTOTVM_TOPHUB_ROOT_PATH, filename))
+                best_context.load(Path(AUTOTVM_TOPHUB_ROOT_PATH, filename))
                 break  # only load one file to avoid some fallback template mismatch problem
 
     if extra_files:
@@ -146,7 +147,7 @@ def check_backend(tophub_location, backend):
 
     version = PACKAGE_VERSION[backend]
     package_name = "%s_%s.log" % (backend, version)
-    if os.path.isfile(os.path.join(AUTOTVM_TOPHUB_ROOT_PATH, package_name)):
+    if Path(AUTOTVM_TOPHUB_ROOT_PATH, package_name).is_file():
         return True
 
     # pylint: disable=import-outside-toplevel
@@ -173,19 +174,12 @@ def download_package(tophub_location, package_name):
     package_name: str
         The name of package
     """
-    rootpath = AUTOTVM_TOPHUB_ROOT_PATH
-
-    if not os.path.isdir(rootpath):
-        # make directory
-        splits = os.path.split(rootpath)
-        for j in range(1, len(splits) + 1):
-            path = os.path.join(*splits[:j])
-            if not os.path.isdir(path):
-                os.mkdir(path)
+    rootpath = Path(AUTOTVM_TOPHUB_ROOT_PATH)
+    rootpath.mkdir(parents=True, exist_ok=True)
 
     download_url = "{0}/{1}".format(tophub_location, package_name)
     logger.info("Download pre-tuned parameters package from %s", download_url)
-    download(download_url, os.path.join(rootpath, package_name), True, verbose=0)
+    download(download_url, Path(rootpath, package_name), True, verbose=0)
 
 
 # global cache for load_reference_log
@@ -209,7 +203,7 @@ def load_reference_log(backend, model, workload_name):
     backend = _alias(backend)
     version = PACKAGE_VERSION[backend]
     package_name = "%s_%s.log" % (backend, version)
-    filename = os.path.join(AUTOTVM_TOPHUB_ROOT_PATH, package_name)
+    filename = Path(AUTOTVM_TOPHUB_ROOT_PATH, package_name)
 
     global REFERENCE_LOG_CACHE
     key = (backend, model, workload_name)
@@ -218,11 +212,11 @@ def load_reference_log(backend, model, workload_name):
         tmp = []
         # If TOPHUB_LOCATION is not AUTOTVM_TOPHUB_NONE_LOC,
         # Download the config file from tophub if not exists.
-        if not os.path.exists(filename):
+        if not Path(filename).exists():
             tophub_location = _get_tophub_location()
             if tophub_location != AUTOTVM_TOPHUB_NONE_LOC:
                 download_package(tophub_location, package_name)
-        if os.path.isfile(filename):  # in case download failed
+        if Path(filename).is_file():  # in case download failed
             find = False
             inp = None
             counts = {}

--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Helper utility for downloading"""
-import os
+from pathlib import Path
+from os import environ
 import sys
 import time
 import uuid
@@ -49,11 +50,12 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
     # pylint: disable=import-outside-toplevel
     import urllib.request as urllib2
 
-    if os.path.isfile(path) and not overwrite:
+    path = Path(path).resolve()
+    if path.exists() and path.is_file() and not overwrite:
         if size_compare:
             import requests
 
-            file_size = os.path.getsize(path)
+            file_size = path.stat().st_size
             res_head = requests.head(url)
             res_get = requests.get(url, stream=True)
             if "Content-Length" not in res_head.headers:
@@ -71,11 +73,10 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
 
     # Stateful start time
     start_time = time.time()
-    dirpath = os.path.dirname(path)
-    if dirpath and not os.path.isdir(dirpath):
-        os.makedirs(dirpath)
+    dirpath = path.parent
+    dirpath.mkdir(parents=True, exist_ok=True)
     random_uuid = str(uuid.uuid4())
-    tempfile = os.path.join(dirpath, random_uuid)
+    tempfile = Path(dirpath, random_uuid)
 
     def _download_progress(count, block_size, total_size):
         # pylint: disable=unused-argument
@@ -109,8 +110,8 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
         except Exception as err:
             retries -= 1
             if retries == 0:
-                if os.path.exists(tempfile):
-                    os.remove(tempfile)
+                if tempfile.exists():
+                    tempfile.unlink()
                 raise err
             print(
                 "download failed due to {}, retrying, {} attempt{} left".format(
@@ -119,11 +120,11 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
             )
 
 
-if "TEST_DATA_ROOT_PATH" in os.environ:
-    TEST_DATA_ROOT_PATH = os.environ.get("TEST_DATA_ROOT_PATH")
+if "TEST_DATA_ROOT_PATH" in environ:
+    TEST_DATA_ROOT_PATH = environ.get("TEST_DATA_ROOT_PATH")
 else:
-    TEST_DATA_ROOT_PATH = os.path.join(os.path.expanduser("~"), ".tvm_test_data")
-os.makedirs(TEST_DATA_ROOT_PATH, exist_ok=True)
+    TEST_DATA_ROOT_PATH = Path(Path("~").expanduser(), ".tvm_test_data")
+TEST_DATA_ROOT_PATH.mkdir(parents=True, exist_ok=True)
 
 
 def download_testdata(url, relpath, module=None, overwrite=False):
@@ -151,9 +152,9 @@ def download_testdata(url, relpath, module=None, overwrite=False):
     elif isinstance(module, str):
         module_path = module
     elif isinstance(module, (list, tuple)):
-        module_path = os.path.join(*module)
+        module_path = Path(*module)
     else:
         raise ValueError("Unsupported module: " + module)
-    abspath = os.path.join(TEST_DATA_ROOT_PATH, module_path, relpath)
+    abspath = Path(TEST_DATA_ROOT_PATH, module_path, relpath)
     download(url, abspath, overwrite=overwrite, size_compare=False)
     return abspath

--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -157,4 +157,4 @@ def download_testdata(url, relpath, module=None, overwrite=False):
         raise ValueError("Unsupported module: " + module)
     abspath = Path(TEST_DATA_ROOT_PATH, module_path, relpath)
     download(url, abspath, overwrite=overwrite, size_compare=False)
-    return abspath
+    return str(abspath)


### PR DESCRIPTION
Tophub download routines switched to Pathlib's `Path.mkdir`
in order to avoid race conditions in creation of folders.

