### PR TITLE
[autodiff] change `truncdiv` to `div` in EliminateDivModMutator

### DIFF
--- a/src/te/autodiff/ad_simplify.cc
+++ b/src/te/autodiff/ad_simplify.cc
@@ -545,7 +545,7 @@ class EliminateDivModMutator : public ExprMutator {
       }
     }
 
-    return truncdiv(VisitExpr(op->a), VisitExpr(op->b));
+    return div(VisitExpr(op->a), VisitExpr(op->b));
   }
 
   virtual PrimExpr VisitExpr_(const ModNode* op) {


### PR DESCRIPTION
With this change, I can use `te.gradient` on `roi_align`. Otherwise, there will be:

```
TVMError:
---------------------------------------------------------------
An internal invariant was violated during the execution of TVM.
Please read TVM's error reporting guidelines.
More details can be found here: https://discuss.tvm.ai/t/error-reporting/7793.
---------------------------------------------------------------
  Check failed: (a.dtype().is_int() || a.dtype().is_uint()) is false: ((float32(rv) + 0.5f)*(max((placeholder[i, 4] - placeholder[i, 2]), 1f)*0.142857f))
Stack trace:
  File "../3rdparty/tvm/src/tir/op/op.cc", line 343
  [bt] (0) 1   libtvm.dylib                        0x00000001275ea4ce tvm::runtime::Backtrace() + 30
  [bt] (1) 2   libtvm.dylib                        0x00000001245cc7c5 tvm::runtime::detail::LogFatal::Entry::Finalize() + 149
  [bt] (2) 3   libtvm.dylib                        0x00000001245cc71d tvm::runtime::detail::LogFatal::~LogFatal() + 29
  [bt] (3) 4   libtvm.dylib                        0x00000001245ca465 tvm::runtime::detail::LogFatal::~LogFatal() + 21
  [bt] (4) 5   libtvm.dylib                        0x00000001255a7e1e tvm::truncdiv(tvm::PrimExpr, tvm::PrimExpr, tvm::Span) + 318
  [bt] (5) 6   libtvm.dylib                        0x0000000125017b46 tvm::te::EliminateDivModMutator::VisitExpr_(tvm::tir::DivNode const*) + 1670
  [bt] (6) 7   libtvm.dylib                        0x000000012462f59f tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>::InitVTable()::'lambda9'(tvm::runtime::ObjectRef const&, tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>*)::operator()(tvm::runtime::ObjectRef const&, tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>*) const + 79
  [bt] (7) 8   libtvm.dylib                        0x000000012462f544 tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>::InitVTable()::'lambda9'(tvm::runtime::ObjectRef const&, tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>*)::__invoke(tvm::runtime::ObjectRef const&, tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>*) + 36
  [bt] (8) 9   libtvm.dylib                        0x0000000124629740 tvm::NodeFunctor<tvm::PrimExpr (tvm::runtime::ObjectRef const&, tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>*)>::operator()(tvm::runtime::ObjectRef const&, tvm::tir::ExprFunctor<tvm::PrimExpr (tvm::PrimExpr const&)>*) const + 464
```

@yzhliu 