### PR TITLE
Rev ci-qemu container to v0.04

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ ci_gpu = "tlcpack/ci-gpu:v0.72"
 ci_cpu = "tlcpack/ci-cpu:v0.73"
 ci_wasm = "tlcpack/ci-wasm:v0.70"
 ci_i386 = "tlcpack/ci-i386:v0.72-t0"
-ci_qemu = "tlcpack/ci-qemu:v0.03"
+ci_qemu = "tlcpack/ci-qemu:v0.04"
 ci_arm = "tlcpack/ci-arm:v0.03"
 // <--- End of regex-scanned config.
 


### PR DESCRIPTION
ci-qemu v0.04 now tracks Zephyr v2.5-branch, which allows us to pickup bugfixes. 

passed ci-jenkins-staging enough: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-7936/6/pipeline/46

@mehrdadh @gromero @tmoreau89 