### PR TITLE
[IR][Pass][Instrument] Pass instrument framework

### DIFF
--- a/include/tvm/ir/instrument.h
+++ b/include/tvm/ir/instrument.h
@@ -68,28 +68,13 @@ namespace instrument {
  */
 class PassInstrumentNode : public Object {
  public:
-  /*! \brief Name of this pass instrument object. */
-  String name;
-
-  /*! \brief Callback for instrumentation environment set up. */
-  runtime::TypedPackedFunc<void()> set_up_callback;
-  /*! \brief Callback for instrumentation environment clean up. */
-  runtime::TypedPackedFunc<void()> tear_down_callback;
-
-  /*! \brief Callback to run before a pass. */
-  runtime::TypedPackedFunc<bool(const IRModule&, const transform::PassInfo&)>
-      run_before_pass_callback;
-  /*! \brief Callback to run after a pass. */
-  runtime::TypedPackedFunc<void(const IRModule&, const transform::PassInfo&)>
-      run_after_pass_callback;
-
-  void VisitAttrs(AttrVisitor* v) { v->Visit("name", &name); }
+  virtual ~PassInstrumentNode() {}
 
   /*! \brief Set up environment for instrumentation. */
-  void SetUp() const;
+  virtual void SetUp() const = 0;
 
   /*! \brief Clean up instrumentation environment. */
-  void TearDown() const;
+  virtual void TearDown() const = 0;
 
   /*!
    * \brief Instrument before pass run, determine whether to run the pass or not.
@@ -98,7 +83,7 @@ class PassInstrumentNode : public Object {
    *
    * \return true to run the pass; false to skip the pass.
    */
-  bool RunBeforePass(const IRModule& mod, const transform::PassInfo& info) const;
+  virtual bool RunBeforePass(const IRModule& mod, const transform::PassInfo& info) const = 0;
 
   /*!
    * \brief Instrument after pass run.
@@ -106,7 +91,9 @@ class PassInstrumentNode : public Object {
    * \param mod The module that an optimization pass runs on.
    * \param info The pass information.
    */
-  void RunAfterPass(const IRModule& mod, const transform::PassInfo& info) const;
+  virtual void RunAfterPass(const IRModule& mod, const transform::PassInfo& info) const = 0;
+
+  void VisitAttrs(AttrVisitor* v) {}
 
   static constexpr const char* _type_key = "instrument.PassInstrument";
   TVM_DECLARE_BASE_OBJECT_INFO(PassInstrumentNode, Object);
@@ -118,21 +105,6 @@ class PassInstrumentNode : public Object {
  */
 class PassInstrument : public ObjectRef {
  public:
-  /*!
-   * \brief Constructor
-   * \param name Name for this instrumentation.
-   */
-  TVM_DLL PassInstrument(String name);
-
-  /*!
-   * \brief mutable accessor.
-   * \return mutable access pointer.
-   */
-  PassInstrumentNode* operator->() {
-    ICHECK(get() != nullptr);
-    return static_cast<PassInstrumentNode*>(get_mutable());
-  }
-
   TVM_DEFINE_OBJECT_REF_METHODS(PassInstrument, ObjectRef, PassInstrumentNode);
 };
 

--- a/include/tvm/ir/instrument.h
+++ b/include/tvm/ir/instrument.h
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/ir/instrument.h
+ *
+ * This file implements a pass instrument infrastructure, inspired from LLVM and MLIR.
+ * It inserts instrumentation points between passes run.
+ *
+ * Within a pass context (tvm::transfom::PassContext), the instrumentation call sequence will like:
+ *
+ *   Instrument SetUp
+ *
+ *     if (Instrument Before Pass)
+ *       Pass Run
+ *       Instrument After Pass
+ *
+ *     if (Instrument Before Pass)
+ *       Pass Run
+ *       Instrument After Pass
+ *
+ *   Instrument TearDown
+ *
+ *
+ * Instrument point before pass can determine particular pass is disable or not depends on the
+ * callback registered.
+ */
+#ifndef TVM_IR_INSTRUMENT_H_
+#define TVM_IR_INSTRUMENT_H_
+
+#include <tvm/node/reflection.h>
+#include <tvm/runtime/container.h>
+
+#include <utility>
+#include <vector>
+
+namespace tvm {
+
+class IRModule;
+
+// Forward class for PassInstrumentNode methods
+namespace transform {
+class PassInfo;
+}  // namespace transform
+
+namespace instrument {
+
+/*!
+ * \brief A callback type for set up or clean up instrument environment.
+ */
+using InstrumentEnvFunc = runtime::TypedPackedFunc<void()>;
+
+/*!
+ * \brief A callback template for instrumenting before/after environment.
+ * \tparam RetTy the return type of callback.
+ */
+template <typename RetTy = void>
+using PassInstrumentFunc =
+    runtime::TypedPackedFunc<RetTy(const IRModule&, const transform::PassInfo&)>;
+
+/*!
+ * \brief PassInstrumentNode forms an instrument implementation.
+ * It provides API for users to register callbacks at different instrument point.
+ * \sa PassInstrument
+ */
+class PassInstrumentNode : public Object {
+ public:
+  /*! \brief Name of this pass instrument object. */
+  String name;
+
+  /*! \brief Callback for instrumentation environment set up. */
+  InstrumentEnvFunc set_up_callback;
+  /*! \brief Callback for instrumentation environment clean up. */
+  InstrumentEnvFunc tear_down_callback;
+
+  /*! \brief Callback to run before a pass. */
+  PassInstrumentFunc</* RetTy */ bool> run_before_pass_callback;
+  /*! \brief Callback to run after a pass. */
+  PassInstrumentFunc<> run_after_pass_callback;
+
+  /*!
+   * \brief Register a callback to run at set up point.
+   *
+   * \param callback The set up function.
+   */
+  void RegisterSetUpCallback(InstrumentEnvFunc callback) { set_up_callback = std::move(callback); }
+
+  /*
+   * \brief Register a callback to run at clean up point.
+   *
+   * \param callback The clean up function.
+   */
+  void RegisterTearDownCallback(InstrumentEnvFunc callback) {
+    tear_down_callback = std::move(callback);
+  }
+
+  /*!
+   * \brief Register a callback to run before pass run.
+   *
+   * \param callback The function to run before pass: return false to skip pass; return true to
+   * run pass.
+   */
+  void RegisterRunBeforePassCallback(PassInstrumentFunc<bool> callback) {
+    run_before_pass_callback = std::move(callback);
+  }
+
+  /*!
+   * \brief Register a callback to run after pass run.
+   *
+   * \param callback The function to run after pass.
+   */
+  void RegisterRunAfterPassCallback(PassInstrumentFunc<> callback) {
+    run_after_pass_callback = std::move(callback);
+  }
+
+  void VisitAttrs(AttrVisitor* v) { v->Visit("name", &name); }
+
+  /*! \brief Set up environment for instrumentation. */
+  void SetUp() const;
+
+  /*! \brief Clean up instrumentation environment. */
+  void TearDown() const;
+
+  /*!
+   * \brief Instrument before pass run, determine whether to run the pass or not.
+   * \param mod The module that an optimization pass runs on.
+   * \param info The pass information.
+   *
+   * \return true to run the pass; false to skip the pass.
+   */
+  bool RunBeforePass(const IRModule& mod, const transform::PassInfo& info) const;
+
+  /*!
+   * \brief Instrument after pass run.
+   *
+   * \param mod The module that an optimization pass runs on.
+   * \param info The pass information.
+   */
+  void RunAfterPass(const IRModule& mod, const transform::PassInfo& info) const;
+
+  static constexpr const char* _type_key = "instrument.PassInstrument";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PassInstrumentNode, Object);
+};
+
+/*!
+ * \brief Managed reference class for PassInstrumentNode
+ * \sa PassInstrumentNode
+ */
+class PassInstrument : public ObjectRef {
+ public:
+  /*!
+   * \brief Constructor
+   * \param name Name for this instrumentation.
+   */
+  TVM_DLL PassInstrument(String name);
+
+  /*!
+   * \brief mutable accessor.
+   * \return mutable access pointer.
+   */
+  PassInstrumentNode* operator->() {
+    ICHECK(get() != nullptr);
+    return static_cast<PassInstrumentNode*>(get_mutable());
+  }
+
+  TVM_DEFINE_OBJECT_REF_METHODS(PassInstrument, ObjectRef, PassInstrumentNode);
+};
+
+/*!
+ * \brief PassInstrumentorNode collects a set of PassInstrument implementations, invokes the
+ * implementations' methods at different instrument points.
+ * \sa PassInstrumentor
+ */
+class PassInstrumentorNode : public Object {
+ public:
+  Array<PassInstrument> pass_instruments;
+
+  void VisitAttrs(AttrVisitor* v) { v->Visit("pass_instruments", &pass_instruments); }
+
+  /*! \brief Set up environment for instrument implementations. */
+  void SetUp() const;
+
+  /*! \brief Clean up environment for instrument implementations. */
+  void TearDown() const;
+
+  /*!
+   * \brief Instrument before pass run, determine whether to run the pass or not.
+   *
+   * \param mod The module that an optimization pass runs on.
+   * \param info The pass information.
+   *
+   * \return true to run the pass; false to skip the pass.
+   */
+  bool RunBeforePass(const IRModule& mod, const transform::PassInfo& info) const;
+
+  /*!
+   * \brief Instrument after pass run.
+   *
+   * \param mod The module that an optimization pass runs on.
+   * \param info The pass information.
+   *
+   * \return true to run the pass; false to skip the pass.
+   */
+  void RunAfterPass(const IRModule& mod, const transform::PassInfo& info) const;
+
+  static constexpr const char* _type_key = "instrument.PassInstrumentor";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PassInstrumentorNode, Object);
+};
+
+/*!
+ * \brief Managed reference class for PassInstrumentorNode
+ * \sa PassInstrumentorNode
+ */
+class PassInstrumentor : public ObjectRef {
+ public:
+  /*!
+   * \brief Constructor
+   * \param pass_instruments A set of instrument implementations.
+   */
+  TVM_DLL PassInstrumentor(Array<PassInstrument> pass_instruments);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(PassInstrumentor, ObjectRef, PassInstrumentorNode);
+};
+
+}  // namespace instrument
+}  // namespace tvm
+
+#endif  // TVM_IR_INSTRUMENT_H_

--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -58,6 +58,7 @@
 
 #include <tvm/ir/diagnostic.h>
 #include <tvm/ir/error.h>
+#include <tvm/ir/instrument.h>
 #include <tvm/ir/module.h>
 #include <tvm/runtime/container.h>
 #include <tvm/support/with.h>
@@ -67,15 +68,6 @@
 
 namespace tvm {
 namespace transform {
-
-// Forward declare for TraceFunc.
-class PassInfo;
-
-/*!
- * \brief A callback for tracing passes, useful for debugging and logging.
- */
-using TraceFunc =
-    runtime::TypedPackedFunc<void(const IRModule& ir_module, const PassInfo& ctx, bool is_before)>;
 
 /*!
  * \brief PassContextNode contains the information that a pass can rely on,
@@ -95,8 +87,9 @@ class PassContextNode : public Object {
   mutable Optional<DiagnosticContext> diag_ctx;
   /*! \brief Pass specific configurations. */
   Map<String, ObjectRef> config;
-  /*! \brief Trace function to be invoked before and after each pass. */
-  TraceFunc trace_func;
+
+  /*! \brief Instrumentor contains a list of instrument implementations. */
+  instrument::PassInstrumentor pass_instrumentor;
 
   PassContextNode() = default;
 
@@ -189,12 +182,32 @@ class PassContext : public ObjectRef {
   TVM_DLL static PassContext Current();
 
   /*!
-   * \brief Apply the tracing functions of the context to the module, with the info.
-   * \param module The IRModule to trace.
-   * \param info The pass information.
-   * \param is_before Indicated whether the tracing is before or after a pass.
+   * \brief Set up for all the instrument implementations.
    */
-  TVM_DLL void Trace(const IRModule& module, const PassInfo& info, bool is_before) const;
+  TVM_DLL void InstrumentSetUp() const;
+
+  /*!
+   * \brief Clean up for all the instrument implementations.
+   */
+  TVM_DLL void InstrumentTearDown() const;
+
+  /*!
+   * \brief Call intrument implementatations before a pass run.
+   *
+   * \param mod The module that an optimization pass runs on.
+   * \param info The pass information.
+   *
+   * \return false: the pass is skipped; true: the pass runs.
+   */
+  TVM_DLL bool InstrumentBeforePass(const IRModule& mod, const PassInfo& info) const;
+
+  /*!
+   * \brief Call instrument implementations after a pass run.
+   *
+   * \param mod The module that an optimization pass runs on.
+   * \param info The pass information.
+   */
+  TVM_DLL void InstrumentAfterPass(const IRModule& mod, const PassInfo& info) const;
 
   /*!
    * \brief Check whether a pass is enabled.
@@ -275,7 +288,7 @@ class PassInfoNode : public Object {
   TVM_DECLARE_FINAL_OBJECT_INFO(PassInfoNode, Object);
 };
 
-/*
+/*!
  * \brief Managed reference class for PassInfoNode
  * \sa PassInfoNode
  */

--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -88,8 +88,8 @@ class PassContextNode : public Object {
   /*! \brief Pass specific configurations. */
   Map<String, ObjectRef> config;
 
-  /*! \brief Instrumentor contains a list of instrument implementations. */
-  instrument::PassInstrumentor pass_instrumentor;
+  /*! \brief A list of pass instrument implementations. */
+  Array<instrument::PassInstrument> instruments;
 
   PassContextNode() = default;
 

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -40,6 +40,7 @@ from . import error
 # tvm.ir
 from .ir import IRModule
 from .ir import transform
+from .ir import instrument
 from .ir import container
 from . import ir
 
@@ -66,7 +67,6 @@ from . import support
 
 # Contrib initializers
 from .contrib import rocm as _rocm, nvcc as _nvcc, sdaccel as _sdaccel
-
 
 # NOTE: This file should be python2 compatible so we can
 # raise proper error message when user run the package using

--- a/python/tvm/ir/__init__.py
+++ b/python/tvm/ir/__init__.py
@@ -31,4 +31,5 @@ from .attrs import Attrs, DictAttrs, make_node
 from .container import Array, Map
 
 from . import transform
+from . import instrument
 from . import diagnostics

--- a/python/tvm/ir/_ffi_instrument_api.py
+++ b/python/tvm/ir/_ffi_instrument_api.py
@@ -14,28 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import tvm
-import tvm.relay
-from tvm.relay import op
+"""FFI APIs for tvm.instrument"""
+import tvm._ffi
 
-
-def test_pass_profiler():
-    x, y, z = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xyz"]
-    e1 = op.add(x, y)
-    e2 = op.subtract(x, z)
-    e3 = op.multiply(e1, e1 / e2)
-    mod = tvm.IRModule.from_expr(e3 + e2)
-
-    tvm.transform.enable_pass_profiling()
-
-    mod = tvm.relay.transform.AnnotateSpans()(mod)
-    mod = tvm.relay.transform.ToANormalForm()(mod)
-    mod = tvm.relay.transform.InferType()(mod)
-
-    profiles = tvm.transform.render_pass_profiles()
-    assert "AnnotateSpans" in profiles
-    assert "ToANormalForm" in profiles
-    assert "InferType" in profiles
-
-    tvm.transform.clear_pass_profiles()
-    tvm.transform.disable_pass_profiling()
+tvm._ffi._init_api("instrument", __name__)

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -103,21 +103,21 @@ def pass_instrument(pi_cls=None):
                 self.skip_pass_name = skip_pass_name
 
             # Uncomment to customize
-            # def set_up():
+            # def set_up(self):
             #    pass
 
             # Uncomment to customize
-            # def tear_down():
+            # def tear_down(self):
             #    pass
 
             # If pass name contains keyword, skip it by return False. (return True: not skip)
-            def run_before_pass(mod, pass_info):
+            def run_before_pass(self, mod, pass_info):
                 if self.skip_pass_name in pass_info.name:
                     return False
                 return True
 
             # Uncomment to customize
-            # def run_after_pass(mod, pass_info):
+            # def run_after_pass(self, mod, pass_info):
             #    pass
 
         skip_annotate = SkipPass("AnnotateSpans")

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -64,7 +64,7 @@ def _wrap_class_pass_instrument(pi_cls):
             # reister instance's run_before_pass, run_after_pass, set_up and tear_down method
             # to it if present.
             self.__init_handle_by_constructor__(
-                _ffi_instrument_api.PassInstrument,
+                _ffi_instrument_api.NamedPassInstrument,
                 pi_cls.__name__,
                 create_method("run_before_pass"),
                 create_method("run_after_pass"),

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,unused-argument
+"""Common pass instrumentation across IR variants."""
+import tvm._ffi
+import tvm.runtime
+
+from . import _ffi_instrument_api
+
+
+@tvm._ffi.register_object("instrument.PassInstrument")
+class PassInstrument(tvm.runtime.Object):
+    """A pass instrument implementation.
+
+    Parameters
+    ----------
+    name : str
+        The name for this instrument implementation.
+
+    Examples
+    --------
+
+    .. code-block:: python
+        pi = tvm.instrument.PassInstrument("print-before-after")
+
+        @pi.register_set_up
+        def set_up():
+          pass
+
+        @pi.register_tear_down
+        def tear_down():
+          pass
+
+        @pi.register_run_before_pass
+        def run_before_pass(mod, info):
+          print("Before pass: " + info.name)
+          print(mod)
+          return True
+
+        @pi.register_run_after_pass
+        def run_after_pass(mod, info):
+          print("After pass: " + info.name)
+          print(mod)
+
+
+    See Also
+    --------
+    instrument.PassInstrumentor
+    """
+
+    def __init__(self, name):
+        self.__init_handle_by_constructor__(_ffi_instrument_api.PassInstrument, name)
+
+    def register_set_up(self, callback):
+        _ffi_instrument_api.RegisterSetUpCallback(self, callback)
+
+    def register_tear_down(self, callback):
+        _ffi_instrument_api.RegisterTearDownCallback(self, callback)
+
+    def register_run_before_pass(self, callback):
+        _ffi_instrument_api.RegisterRunBeforePassCallback(self, callback)
+
+    def register_run_after_pass(self, callback):
+        _ffi_instrument_api.RegisterRunAfterPassCallback(self, callback)
+
+
+@tvm._ffi.register_object("instrument.PassInstrumentor")
+class PassInstrumentor(tvm.runtime.Object):
+    """A pass instrumentor collects a set of pass instrument implementations.
+
+    Parameters
+    ----------
+    pass_instruments : List[tvm.instrument.PassInstrument]
+        List of instrumentation to run within pass context
+
+    Examples
+    --------
+    .. code-block:: python
+
+        passes_mem = #... Impl of memory instrument
+        passes_time = tvm.instrument.PassesTimeInstrument()
+
+        with tvm.transform.PassContext(
+            pass_instrumentor=tvm.instrument.PassInstrumentor([passes_mem, passes_time])):
+            tvm.relay.build(mod, 'llvm')
+
+            print(passes_time.rendor())
+
+    See Also
+    -------
+    instrument.PassInstrument
+    instrument.PassesTimeInstrument
+    """
+
+    def __init__(self, pass_instruments):
+        self.__init_handle_by_constructor__(_ffi_instrument_api.PassInstrumentor, pass_instruments)
+
+
+@tvm._ffi.register_object("instrument.PassInstrument")
+class PassesTimeInstrument(tvm.runtime.Object):
+    """A wrapper to create a passes time instrument that implemented in C++"""
+
+    def __init__(self):
+        self.__init_handle_by_constructor__(_ffi_instrument_api.MakePassesTimeInstrument)
+
+    @staticmethod
+    def render():
+        """Retrieve rendered time profile result
+        Returns
+        -------
+        string : string
+            The rendered string result of time profiles
+        """
+        return _ffi_instrument_api.RenderTimePassProfiles()

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=invalid-name,unused-argument
 """Common pass instrumentation across IR variants."""
-import types
 import inspect
 import functools
 
@@ -62,7 +61,8 @@ def _wrap_class_pass_instrument(pi_cls):
                 return None
 
             # create runtime pass instrument object
-            # reister instance's run_before_pass, run_after_pass, set_up and tear_down method to it if present.
+            # reister instance's run_before_pass, run_after_pass, set_up and tear_down method
+            # to it if present.
             self.__init_handle_by_constructor__(
                 _ffi_instrument_api.PassInstrument,
                 pi_cls.__name__,
@@ -129,7 +129,6 @@ def pass_instrument(pi_cls=None):
         if not inspect.isclass(pi_cls):
             raise TypeError("pi_cls must be a class")
 
-        name = pi_cls.__name__
         return _wrap_class_pass_instrument(pi_cls)
 
     if pi_cls:

--- a/python/tvm/ir/transform.py
+++ b/python/tvm/ir/transform.py
@@ -65,8 +65,8 @@ class PassContext(tvm.runtime.Object):
     disabled_pass : Optional[Union[List[str], Set[str], Tuple[str]]]
         The list of passes that are disabled.
 
-    pass_instrumentor : Optional[tvm.instrument.PassInstrumentor]
-        The pass instrumentor that collects pass instrument implementations
+    instruments : Optional[Union[List[PassInstrument], Set[PassInstrument], Tuple[PassInstrument]]]
+        The list of pass instrument implementations.
 
     config : Optional[Dict[str, Object]]
         Additional configurations for specific passes.
@@ -77,7 +77,7 @@ class PassContext(tvm.runtime.Object):
         opt_level=2,
         required_pass=None,
         disabled_pass=None,
-        pass_instrumentor=None,
+        instruments=None,
         config=None,
     ):
         required = list(required_pass) if required_pass else []
@@ -88,9 +88,13 @@ class PassContext(tvm.runtime.Object):
         if not isinstance(disabled, (list, tuple)):
             raise TypeError("disabled_pass is expected to be the type of " + "list/tuple/set.")
 
+        instruments = list(instruments) if instruments else []
+        if not isinstance(instruments, (list, tuple)):
+            raise TypeError("disabled_pass is expected to be the type of " + "list/tuple/set.")
+
         config = config if config else None
         self.__init_handle_by_constructor__(
-            _ffi_transform_api.PassContext, opt_level, required, disabled, pass_instrumentor, config
+            _ffi_transform_api.PassContext, opt_level, required, disabled, instruments, config
         )
 
     def __enter__(self):

--- a/python/tvm/ir/transform.py
+++ b/python/tvm/ir/transform.py
@@ -65,12 +65,20 @@ class PassContext(tvm.runtime.Object):
     disabled_pass : Optional[Union[List[str], Set[str], Tuple[str]]]
         The list of passes that are disabled.
 
+    pass_instrumentor : Optional[tvm.instrument.PassInstrumentor]
+        The pass instrumentor that collects pass instrument implementations
+
     config : Optional[Dict[str, Object]]
         Additional configurations for specific passes.
     """
 
     def __init__(
-        self, opt_level=2, required_pass=None, disabled_pass=None, trace=None, config=None
+        self,
+        opt_level=2,
+        required_pass=None,
+        disabled_pass=None,
+        pass_instrumentor=None,
+        config=None,
     ):
         required = list(required_pass) if required_pass else []
         if not isinstance(required, (list, tuple)):
@@ -82,7 +90,7 @@ class PassContext(tvm.runtime.Object):
 
         config = config if config else None
         self.__init_handle_by_constructor__(
-            _ffi_transform_api.PassContext, opt_level, required, disabled, trace, config
+            _ffi_transform_api.PassContext, opt_level, required, disabled, pass_instrumentor, config
         )
 
     def __enter__(self):
@@ -189,6 +197,7 @@ def _wrap_class_module_pass(pass_cls, pass_info):
             # initialize handle in cass pass_cls creation failed.fg
             self.handle = None
             inst = pass_cls(*args, **kwargs)
+
             # it is important not to capture self to
             # avoid a cyclic dependency
             def _pass_func(mod, ctx):

--- a/src/ir/instrument.cc
+++ b/src/ir/instrument.cc
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/ir/instrument.cc
+ * \brief Infrastructure for instrumentation.
+ */
+#include <dmlc/thread_local.h>
+#include <tvm/ir/instrument.h>
+#include <tvm/ir/transform.h>
+#include <tvm/node/repr_printer.h>
+#include <tvm/runtime/registry.h>
+
+#include <stack>
+
+namespace tvm {
+namespace instrument {
+
+PassInstrument::PassInstrument(String name) {
+  auto pi = make_object<PassInstrumentNode>();
+  pi->name = std::move(name);
+  data_ = std::move(pi);
+}
+
+void PassInstrumentNode::SetUp() const {
+  if (set_up_callback != nullptr) {
+    set_up_callback();
+  }
+}
+
+void PassInstrumentNode::TearDown() const {
+  if (tear_down_callback != nullptr) {
+    tear_down_callback();
+  }
+}
+
+bool PassInstrumentNode::RunBeforePass(const IRModule& ir_module,
+                                       const transform::PassInfo& pass_info) const {
+  if (run_before_pass_callback == nullptr) {
+    return true;
+  }
+
+  return run_before_pass_callback(ir_module, pass_info);
+}
+
+void PassInstrumentNode::RunAfterPass(const IRModule& ir_module,
+                                      const transform::PassInfo& pass_info) const {
+  if (run_after_pass_callback != nullptr) {
+    run_after_pass_callback(ir_module, pass_info);
+  }
+}
+
+PassInstrumentor::PassInstrumentor(Array<PassInstrument> pass_instruments) {
+  auto n = make_object<PassInstrumentorNode>();
+  n->pass_instruments = std::move(pass_instruments);
+  data_ = std::move(n);
+}
+
+void PassInstrumentorNode::SetUp() const {
+  for (PassInstrument pi : pass_instruments) {
+    pi->SetUp();
+  }
+}
+
+void PassInstrumentorNode::TearDown() const {
+  for (PassInstrument pi : pass_instruments) {
+    pi->TearDown();
+  }
+}
+
+bool PassInstrumentorNode::RunBeforePass(const IRModule& ir_module,
+                                         const transform::PassInfo& pass_info) const {
+  for (PassInstrument pi : pass_instruments) {
+    if (!pi->RunBeforePass(ir_module, pass_info)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void PassInstrumentorNode::RunAfterPass(const IRModule& ir_module,
+                                        const transform::PassInfo& pass_info) const {
+  for (PassInstrument pi : pass_instruments) {
+    pi->RunAfterPass(ir_module, pass_info);
+  }
+}
+
+TVM_REGISTER_NODE_TYPE(PassInstrumentNode);
+
+TVM_REGISTER_GLOBAL("instrument.PassInstrument").set_body_typed([](String name) {
+  return PassInstrument(name);
+});
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<PassInstrumentNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      auto* node = static_cast<const PassInstrumentNode*>(ref.get());
+      p->stream << node->name;
+    });
+
+TVM_REGISTER_NODE_TYPE(PassInstrumentorNode);
+
+TVM_REGISTER_GLOBAL("instrument.PassInstrumentor")
+    .set_body_typed([](Array<PassInstrument> pass_instruments) {
+      return PassInstrumentor(pass_instruments);
+    });
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<PassInstrumentorNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      auto* node = static_cast<const PassInstrumentorNode*>(ref.get());
+
+      p->stream << "\n PassInstrumentor [";
+      for (PassInstrument pi : node->pass_instruments) {
+        p->stream << pi << " ";
+      }
+      p->stream << "] \n";
+    });
+
+TVM_REGISTER_GLOBAL("instrument.RegisterSetUpCallback")
+    .set_body_typed([](PassInstrument pass_instrument, InstrumentEnvFunc callback) {
+      pass_instrument->RegisterSetUpCallback(callback);
+    });
+
+TVM_REGISTER_GLOBAL("instrument.RegisterTearDownCallback")
+    .set_body_typed([](PassInstrument pass_instrument, InstrumentEnvFunc callback) {
+      pass_instrument->RegisterTearDownCallback(callback);
+    });
+
+TVM_REGISTER_GLOBAL("instrument.RegisterRunBeforePassCallback")
+    .set_body_typed([](PassInstrument pass_instrument, PassInstrumentFunc<bool> callback) {
+      pass_instrument->RegisterRunBeforePassCallback(callback);
+    });
+
+TVM_REGISTER_GLOBAL("instrument.RegisterRunAfterPassCallback")
+    .set_body_typed([](PassInstrument pass_instrument, PassInstrumentFunc<> callback) {
+      pass_instrument->RegisterRunAfterPassCallback(callback);
+    });
+
+/*! \brief PassProfile stores profiling information for a given pass and its sub-passes. */
+struct PassProfile {
+  // TODO(@altanh): expose PassProfile through TVM Object API
+  using Clock = std::chrono::steady_clock;
+  using Duration = std::chrono::duration<double, std::micro>;
+  using Time = std::chrono::time_point<Clock>;
+
+  /*! \brief The name of the pass being profiled. */
+  String name;
+  /*! \brief The time when the pass was entered. */
+  Time start;
+  /*! \brief The time when the pass completed. */
+  Time end;
+  /*! \brief The total duration of the pass, i.e. end - start. */
+  Duration duration;
+  /*! \brief PassProfiles for all sub-passes invoked during the execution of the pass. */
+  std::vector<PassProfile> children;
+
+  explicit PassProfile(String name)
+      : name(name), start(Clock::now()), end(Clock::now()), children() {}
+
+  /*! \brief Gets the PassProfile of the currently executing pass. */
+  static PassProfile* Current();
+  /*! \brief Pushes a new PassProfile with the given pass name. */
+  static void EnterPass(String name);
+  /*! \brief Pops the current PassProfile. */
+  static void ExitPass();
+};
+
+struct PassProfileThreadLocalEntry {
+  /*! \brief The placeholder top-level PassProfile. */
+  PassProfile root;
+  /*! \brief The stack of PassProfiles for nested passes currently running. */
+  std::stack<PassProfile*> profile_stack;
+
+  PassProfileThreadLocalEntry() : root("root") {}
+};
+
+/*! \brief Thread local store to hold the pass profiling data. */
+typedef dmlc::ThreadLocalStore<PassProfileThreadLocalEntry> PassProfileThreadLocalStore;
+
+void PassProfile::EnterPass(String name) {
+  PassProfile* cur = PassProfile::Current();
+  cur->children.emplace_back(name);
+  PassProfileThreadLocalStore::Get()->profile_stack.push(&cur->children.back());
+}
+
+void PassProfile::ExitPass() {
+  PassProfile* cur = PassProfile::Current();
+  ICHECK_NE(cur->name, "root") << "mismatched enter/exit for pass profiling";
+  cur->end = PassProfile::Clock::now();
+  cur->duration = std::chrono::duration_cast<PassProfile::Duration>(cur->end - cur->start);
+  PassProfileThreadLocalStore::Get()->profile_stack.pop();
+}
+
+PassProfile* PassProfile::Current() {
+  PassProfileThreadLocalEntry* entry = PassProfileThreadLocalStore::Get();
+  if (!entry->profile_stack.empty()) {
+    return entry->profile_stack.top();
+  } else {
+    return &entry->root;
+  }
+}
+
+String RenderPassProfiles() {
+  PassProfileThreadLocalEntry* entry = PassProfileThreadLocalStore::Get();
+  CHECK(entry->profile_stack.empty()) << "cannot print pass profile while still in a pass!";
+
+  if (entry->root.children.empty()) {
+    LOG(WARNING) << "no passes have been profiled, did you enable pass profiling?";
+    return String();
+  }
+
+  // (depth, parent_duration, pass)
+  std::stack<std::tuple<size_t, PassProfile::Duration, PassProfile*>> profiles;
+
+  // push top level passes
+  PassProfile::Duration top_dur(0);
+  for (auto it = entry->root.children.begin(); it != entry->root.children.end(); ++it) {
+    top_dur += it->duration;
+  }
+  for (auto it = entry->root.children.rbegin(); it != entry->root.children.rend(); ++it) {
+    profiles.push(std::make_tuple(0, top_dur, &*it));
+  }
+
+  std::ostringstream os;
+  os << std::fixed;
+
+  while (profiles.size() > 0) {
+    size_t depth;
+    PassProfile::Duration parent_duration;
+    PassProfile* profile;
+    std::tie(depth, parent_duration, profile) = profiles.top();
+    profiles.pop();
+
+    // indent depth
+    for (size_t i = 0; i < depth; ++i) {
+      os << "\t";
+    }
+
+    // calculate time spent in pass itself (excluding sub-passes), and push children
+    PassProfile::Duration self_duration = profile->duration;
+    for (auto it = profile->children.rbegin(); it != profile->children.rend(); ++it) {
+      self_duration -= it->duration;
+      profiles.push(std::make_tuple(depth + 1, profile->duration, &*it));
+    }
+
+    double parent_pct = profile->duration.count() / parent_duration.count() * 100.0;
+    double total_pct = profile->duration.count() / top_dur.count() * 100.0;
+
+    os << profile->name << ": ";
+    os << std::setprecision(0);
+    os << profile->duration.count() << "us [" << self_duration.count() << "us] ";
+    os << std::setprecision(2) << "(" << total_pct << "%; " << parent_pct << "%)\n";
+  }
+
+  return os.str();
+}
+
+TVM_REGISTER_GLOBAL("instrument.RenderTimePassProfiles").set_body_typed(RenderPassProfiles);
+
+TVM_REGISTER_GLOBAL("instrument.MakePassesTimeInstrument").set_body_typed([]() {
+  auto pi = PassInstrument("PassesTimeInstrument");
+
+  // No set up function for this time instrumentation.
+
+  pi->RegisterTearDownCallback([]() { PassProfileThreadLocalStore::Get()->root.children.clear(); });
+
+  pi->RegisterRunBeforePassCallback([](const IRModule&, const transform::PassInfo& pass_info) {
+    PassProfile::EnterPass(pass_info->name);
+    return true;
+  });
+
+  pi->RegisterRunAfterPassCallback(
+      [](const IRModule&, const transform::PassInfo&) { PassProfile::ExitPass(); });
+
+  return pi;
+});
+
+}  // namespace instrument
+}  // namespace tvm

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -58,12 +58,14 @@ typedef dmlc::ThreadLocalStore<PassContextThreadLocalEntry> RelayPassContextThre
 void PassContext::EnterWithScope() {
   PassContextThreadLocalEntry* entry = RelayPassContextThreadLocalStore::Get();
   entry->context_stack.push(*this);
+  InstrumentSetUp();
 }
 
 void PassContext::ExitWithScope() {
   PassContextThreadLocalEntry* entry = RelayPassContextThreadLocalStore::Get();
   ICHECK(!entry->context_stack.empty());
   ICHECK(entry->context_stack.top().same_as(*this));
+  InstrumentTearDown();
   entry->context_stack.pop();
 }
 
@@ -162,169 +164,54 @@ void PassContext::RegisterConfigOption(const char* key, uint32_t value_type_inde
 
 PassContext PassContext::Create() { return PassContext(make_object<PassContextNode>()); }
 
-void PassContext::Trace(const IRModule& module, const PassInfo& info, bool is_before) const {
+void PassContext::InstrumentSetUp() const {
   auto pass_ctx_node = this->operator->();
-  if (pass_ctx_node->trace_func != nullptr) {
-    pass_ctx_node->trace_func(module, info, is_before);
+  if (pass_ctx_node->pass_instrumentor.defined()) {
+    pass_ctx_node->pass_instrumentor->SetUp();
   }
 }
 
-class ModulePass;
-
-/*! \brief PassProfile stores profiling information for a given pass and its sub-passes. */
-struct PassProfile {
-  // TODO(@altanh): expose PassProfile through TVM Object API
-  using Clock = std::chrono::steady_clock;
-  using Duration = std::chrono::duration<double, std::micro>;
-  using Time = std::chrono::time_point<Clock>;
-
-  /*! \brief The name of the pass being profiled. */
-  String name;
-  /*! \brief The time when the pass was entered. */
-  Time start;
-  /*! \brief The time when the pass completed. */
-  Time end;
-  /*! \brief The total duration of the pass, i.e. end - start. */
-  Duration duration;
-  /*! \brief PassProfiles for all sub-passes invoked during the execution of the pass. */
-  std::vector<PassProfile> children;
-
-  explicit PassProfile(String name)
-      : name(name), start(Clock::now()), end(Clock::now()), children() {}
-
-  /*! \brief Gets the PassProfile of the currently executing pass. */
-  static PassProfile* Current();
-  /*! \brief Pushes a new PassProfile with the given pass name. */
-  static void EnterPass(String name);
-  /*! \brief Pops the current PassProfile. */
-  static void ExitPass();
-};
-
-struct PassProfileThreadLocalEntry {
-  /*! \brief The placeholder top-level PassProfile. */
-  PassProfile root;
-  /*! \brief The stack of PassProfiles for nested passes currently running. */
-  std::stack<PassProfile*> profile_stack;
-  /*! \brief Whether or not pass profiling is active. */
-  bool active;
-
-  PassProfileThreadLocalEntry() : root("root"), active(false) {}
-};
-
-/*! \brief Thread local store to hold the pass profiling data. */
-typedef dmlc::ThreadLocalStore<PassProfileThreadLocalEntry> PassProfileThreadLocalStore;
-
-void PassProfile::EnterPass(String name) {
-  if (!PassProfileThreadLocalStore::Get()->active) return;
-  PassProfile* cur = PassProfile::Current();
-  cur->children.emplace_back(name);
-  PassProfileThreadLocalStore::Get()->profile_stack.push(&cur->children.back());
+void PassContext::InstrumentTearDown() const {
+  auto pass_ctx_node = this->operator->();
+  if (pass_ctx_node->pass_instrumentor.defined()) {
+    pass_ctx_node->pass_instrumentor->TearDown();
+  }
 }
 
-void PassProfile::ExitPass() {
-  if (!PassProfileThreadLocalStore::Get()->active) return;
-  PassProfile* cur = PassProfile::Current();
-  ICHECK_NE(cur->name, "root") << "mismatched enter/exit for pass profiling";
-  cur->end = std::move(PassProfile::Clock::now());
-  cur->duration = std::chrono::duration_cast<PassProfile::Duration>(cur->end - cur->start);
-  PassProfileThreadLocalStore::Get()->profile_stack.pop();
+bool PassContext::InstrumentBeforePass(const IRModule& ir_module, const PassInfo& pass_info) const {
+  auto pass_ctx_node = this->operator->();
+  if (pass_ctx_node->pass_instrumentor.defined()) {
+    if (!pass_ctx_node->pass_instrumentor->RunBeforePass(ir_module, pass_info)) {
+      return false;
+    }
+  }
+  return true;
 }
 
-PassProfile* PassProfile::Current() {
-  PassProfileThreadLocalEntry* entry = PassProfileThreadLocalStore::Get();
-  if (!entry->profile_stack.empty()) {
-    return entry->profile_stack.top();
-  } else {
-    return &entry->root;
+void PassContext::InstrumentAfterPass(const IRModule& ir_module, const PassInfo& pass_info) const {
+  auto pass_ctx_node = this->operator->();
+  if (pass_ctx_node->pass_instrumentor.defined()) {
+    pass_ctx_node->pass_instrumentor->RunAfterPass(ir_module, pass_info);
   }
 }
 
 IRModule Pass::operator()(IRModule mod) const {
   const PassNode* node = operator->();
   ICHECK(node != nullptr);
-  PassProfile::EnterPass(node->Info()->name);
+  // PassProfile::EnterPass(node->Info()->name);
   auto ret = node->operator()(std::move(mod));
-  PassProfile::ExitPass();
+  // PassProfile::ExitPass();
   return std::move(ret);
 }
 
 IRModule Pass::operator()(IRModule mod, const PassContext& pass_ctx) const {
   const PassNode* node = operator->();
   ICHECK(node != nullptr);
-  PassProfile::EnterPass(node->Info()->name);
+  // PassProfile::EnterPass(node->Info()->name);
   auto ret = node->operator()(std::move(mod), pass_ctx);
-  PassProfile::ExitPass();
+  // PassProfile::ExitPass();
   return std::move(ret);
 }
-
-String RenderPassProfiles() {
-  PassProfileThreadLocalEntry* entry = PassProfileThreadLocalStore::Get();
-  CHECK(entry->profile_stack.empty()) << "cannot print pass profile while still in a pass!";
-
-  if (entry->root.children.empty()) {
-    LOG(WARNING) << "no passes have been profiled, did you enable pass profiling?";
-    return String();
-  }
-
-  // (depth, parent_duration, pass)
-  std::stack<std::tuple<size_t, PassProfile::Duration, PassProfile*>> profiles;
-
-  // push top level passes
-  PassProfile::Duration top_dur(0);
-  for (auto it = entry->root.children.begin(); it != entry->root.children.end(); ++it) {
-    top_dur += it->duration;
-  }
-  for (auto it = entry->root.children.rbegin(); it != entry->root.children.rend(); ++it) {
-    profiles.push(std::make_tuple(0, top_dur, &*it));
-  }
-
-  std::ostringstream os;
-  os << std::fixed;
-
-  while (profiles.size() > 0) {
-    size_t depth;
-    PassProfile::Duration parent_duration;
-    PassProfile* profile;
-    std::tie(depth, parent_duration, profile) = profiles.top();
-    profiles.pop();
-
-    // indent depth
-    for (size_t i = 0; i < depth; ++i) {
-      os << "\t";
-    }
-
-    // calculate time spent in pass itself (excluding sub-passes), and push children
-    PassProfile::Duration self_duration = profile->duration;
-    for (auto it = profile->children.rbegin(); it != profile->children.rend(); ++it) {
-      self_duration -= it->duration;
-      profiles.push(std::make_tuple(depth + 1, profile->duration, &*it));
-    }
-
-    double parent_pct = profile->duration.count() / parent_duration.count() * 100.0;
-    double total_pct = profile->duration.count() / top_dur.count() * 100.0;
-
-    os << profile->name << ": ";
-    os << std::setprecision(0);
-    os << profile->duration.count() << "us [" << self_duration.count() << "us] ";
-    os << std::setprecision(2) << "(" << total_pct << "%; " << parent_pct << "%)\n";
-  }
-
-  return os.str();
-}
-
-TVM_REGISTER_GLOBAL("transform.render_pass_profiles").set_body_typed(RenderPassProfiles);
-
-TVM_REGISTER_GLOBAL("transform.clear_pass_profiles").set_body_typed([]() {
-  PassProfileThreadLocalStore::Get()->root.children.clear();
-});
-
-TVM_REGISTER_GLOBAL("transform.enable_pass_profiling").set_body_typed([]() {
-  PassProfileThreadLocalStore::Get()->active = true;
-});
-
-TVM_REGISTER_GLOBAL("transform.disable_pass_profiling").set_body_typed([]() {
-  PassProfileThreadLocalStore::Get()->active = false;
-});
 
 /*!
  * \brief Module-level passes are designed to implement global
@@ -464,12 +351,19 @@ IRModule ModulePassNode::operator()(IRModule mod, const PassContext& pass_ctx) c
       << "The diagnostic context was set at the top of this block this is a bug.";
 
   const PassInfo& pass_info = Info();
+  ICHECK(mod.defined()) << "The input module must be set.";
+
+  if (!pass_ctx.InstrumentBeforePass(mod, pass_info)) {
+    DLOG(INFO) << "Skipping function pass : " << pass_info->name
+               << " with opt level: " << pass_info->opt_level;
+
+    pass_ctx->diag_ctx = previous;
+    return mod;
+  }
+
   DLOG(INFO) << "Executing module pass : " << pass_info->name
              << " with opt level: " << pass_info->opt_level;
 
-  ICHECK(mod.defined()) << "The input module must be set.";
-
-  pass_ctx.Trace(mod, pass_info, true);
   mod = pass_func(std::move(mod), pass_ctx);
 
   ICHECK(mod.defined()) << "The return value of a module pass must be set.";
@@ -480,7 +374,7 @@ IRModule ModulePassNode::operator()(IRModule mod, const PassContext& pass_ctx) c
   pass_ctx->diag_ctx.value().Render();
   pass_ctx->diag_ctx = previous;
 
-  pass_ctx.Trace(mod, pass_info, false);
+  pass_ctx.InstrumentAfterPass(mod, pass_info);
   return mod;
 }
 
@@ -621,13 +515,14 @@ TVM_REGISTER_NODE_TYPE(PassContextNode);
 
 TVM_REGISTER_GLOBAL("transform.PassContext")
     .set_body_typed([](int opt_level, Array<String> required, Array<String> disabled,
-                       TraceFunc trace_func, Optional<Map<String, ObjectRef>> config) {
+                       instrument::PassInstrumentor pass_instrumentor,
+                       Optional<Map<String, ObjectRef>> config) {
       auto pctx = PassContext::Create();
       pctx->opt_level = opt_level;
 
       pctx->required_pass = std::move(required);
       pctx->disabled_pass = std::move(disabled);
-      pctx->trace_func = std::move(trace_func);
+      pctx->pass_instrumentor = std::move(pass_instrumentor);
       if (config.defined()) {
         pctx->config = config.value();
       }

--- a/src/relay/ir/transform.cc
+++ b/src/relay/ir/transform.cc
@@ -130,10 +130,16 @@ IRModule FunctionPassNode::operator()(IRModule mod, const PassContext& pass_ctx)
 
   ICHECK(mod.defined());
 
+  if (!pass_ctx.InstrumentBeforePass(mod, pass_info)) {
+    DLOG(INFO) << "Skipping function pass : " << pass_info->name
+               << " with opt level: " << pass_info->opt_level;
+
+    pass_ctx->diag_ctx = previous;
+    return mod;
+  }
+
   DLOG(INFO) << "Executing function pass : " << pass_info->name
              << " with opt level: " << pass_info->opt_level;
-
-  pass_ctx.Trace(mod, pass_info, true);
 
   // Execute the pass function and return a new module.
   IRModule updated_mod =
@@ -159,7 +165,7 @@ IRModule FunctionPassNode::operator()(IRModule mod, const PassContext& pass_ctx)
   pass_ctx->diag_ctx.value().Render();
   pass_ctx->diag_ctx = previous;
 
-  pass_ctx.Trace(updated_mod, pass_info, false);
+  pass_ctx.InstrumentAfterPass(updated_mod, pass_info);
 
   // TODO(@jroesch): move away from eager type checking for performance reasons
   // make issue.

--- a/src/tir/ir/transform.cc
+++ b/src/tir/ir/transform.cc
@@ -87,9 +87,11 @@ PrimFuncPass::PrimFuncPass(
 
 // Perform Module -> Module optimizations at the PrimFunc level.
 IRModule PrimFuncPassNode::operator()(IRModule mod, const PassContext& pass_ctx) const {
-  const PassInfo& pass_info = Info();
+  // const PassInfo& pass_info = Info();
   ICHECK(mod.defined());
-  pass_ctx.Trace(mod, pass_info, true);
+  if (!pass_ctx.InstrumentBeforePass(mod, pass_info)) {
+    return mod;
+  }
   std::vector<ObjectRef> deleted_list;
   IRModuleNode* mod_ptr = mod.CopyOnWrite();
   auto* func_dict = mod_ptr->functions.CopyOnWrite();
@@ -112,7 +114,7 @@ IRModule PrimFuncPassNode::operator()(IRModule mod, const PassContext& pass_ctx)
   for (const auto& gv : deleted_list) {
     func_dict->erase(gv);
   }
-  pass_ctx.Trace(mod, pass_info, false);
+  pass_ctx.InstrumentAfterPass(mod, pass_info);
   return mod;
 }
 

--- a/tests/python/relay/test_pass_annotation.py
+++ b/tests/python/relay/test_pass_annotation.py
@@ -28,7 +28,7 @@ import tvm.testing
 
 
 @tvm.instrument.pass_instrument
-class Trace():
+class Trace:
     def run_before_pass(module, pass_info):
         if pass_info.name == "ManifestAlloc":
             pass  # import pdb; pdb.set_trace()

--- a/tests/python/relay/test_pass_annotation.py
+++ b/tests/python/relay/test_pass_annotation.py
@@ -29,11 +29,11 @@ import tvm.testing
 
 @tvm.instrument.pass_instrument
 class Trace:
-    def run_before_pass(module, pass_info):
+    def run_before_pass(self, module, pass_info):
         if pass_info.name == "ManifestAlloc":
             pass  # import pdb; pdb.set_trace()
 
-    def run_after_pass(module, pass_info):
+    def run_after_pass(self, module, pass_info):
         if pass_info.name == "ManifestAlloc":
             pass  # import pdb; pdb.set_trace()
 

--- a/tests/python/relay/test_pass_annotation.py
+++ b/tests/python/relay/test_pass_annotation.py
@@ -28,7 +28,7 @@ import tvm.testing
 
 
 @tvm.instrument.pass_instrument
-class Trace:
+class Trace():
     def run_before_pass(module, pass_info):
         if pass_info.name == "ManifestAlloc":
             pass  # import pdb; pdb.set_trace()

--- a/tests/python/relay/test_pass_annotation.py
+++ b/tests/python/relay/test_pass_annotation.py
@@ -32,6 +32,7 @@ class Trace:
     def run_before_pass(self, module, pass_info):
         if pass_info.name == "ManifestAlloc":
             pass  # import pdb; pdb.set_trace()
+        return True
 
     def run_after_pass(self, module, pass_info):
         if pass_info.name == "ManifestAlloc":

--- a/tests/python/relay/test_pass_instrument.py
+++ b/tests/python/relay/test_pass_instrument.py
@@ -1,0 +1,190 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import tvm.relay
+from tvm.relay import op
+from tvm.ir.instrument import PassesTimeInstrument, PassInstrument, PassInstrumentor
+
+
+def test_pass_time_instrument():
+    x, y, z = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xyz"]
+    e1 = op.add(x, y)
+    e2 = op.subtract(x, z)
+    e3 = op.multiply(e1, e1 / e2)
+    mod = tvm.IRModule.from_expr(e3 + e2)
+
+    time_instrument = PassesTimeInstrument()
+    with tvm.transform.PassContext(pass_instrumentor=PassInstrumentor([time_instrument])):
+        mod = tvm.relay.transform.AnnotateSpans()(mod)
+        mod = tvm.relay.transform.ToANormalForm()(mod)
+        mod = tvm.relay.transform.InferType()(mod)
+
+        profiles = time_instrument.render()
+        assert "AnnotateSpans" in profiles
+        assert "ToANormalForm" in profiles
+        assert "InferType" in profiles
+
+
+def test_custom_instrument(capsys):
+    x, y, z = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xyz"]
+    e1 = op.add(x, y)
+    e2 = op.subtract(x, z)
+    e3 = op.multiply(e1, e1 / e2)
+    mod = tvm.IRModule.from_expr(e3 + e2)
+
+    def custom_pi():
+        pi = PassInstrument("MyTest")
+
+        @pi.register_set_up
+        def set_up():
+            print("set up")
+
+        @pi.register_tear_down
+        def tear_down():
+            print("tear down")
+
+        @pi.register_run_before_pass
+        def run_before_pass(mod, info):
+            print("run before " + info.name)
+            return True
+
+        @pi.register_run_after_pass
+        def run_after_pass(mod, info):
+            print("run after " + info.name)
+
+        return pi
+
+    with tvm.transform.PassContext(pass_instrumentor=PassInstrumentor([custom_pi()])):
+        mod = tvm.relay.transform.InferType()(mod)
+
+    output = "set up\n" "run before InferType\n" "run after InferType\n" "tear down\n"
+    assert capsys.readouterr().out == output
+
+
+def test_disable_pass(capsys):
+    x, y, z = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xyz"]
+    e1 = op.add(x, y)
+    e2 = op.subtract(x, z)
+    e3 = op.multiply(e1, e1 / e2)
+    mod = tvm.IRModule.from_expr(e3 + e2)
+
+    def custom_pi():
+        pi = PassInstrument("MyTest")
+
+        @pi.register_run_before_pass
+        def run_before_pass(mod, info):
+            # Only run pass name contains "InferType"
+            if "InferType" not in info.name:
+                return False
+
+            print(info.name)
+            return True
+
+        return pi
+
+    with tvm.transform.PassContext(pass_instrumentor=PassInstrumentor([custom_pi()])):
+        mod = tvm.relay.transform.AnnotateSpans()(mod)
+        mod = tvm.relay.transform.ToANormalForm()(mod)
+        mod = tvm.relay.transform.InferType()(mod)
+
+    assert capsys.readouterr().out == "InferType\n"
+
+
+def test_multiple_instrument(capsys):
+    x, y, z = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xyz"]
+    e1 = op.add(x, y)
+    e2 = op.subtract(x, z)
+    e3 = op.multiply(e1, e1 / e2)
+    mod = tvm.IRModule.from_expr(e3 + e2)
+
+    def custom_pi(skip_pass_name):
+        def create_custom_pi():
+            pi = PassInstrument("Don't care")
+
+            @pi.register_run_before_pass
+            def run_before_pass(mod, info):
+                if skip_pass_name in info.name:
+                    return False
+
+                return True
+
+            return pi
+
+        return create_custom_pi()
+
+    skip_annotate = custom_pi("AnnotateSpans")
+    skip_anf = custom_pi("ToANormalForm")
+
+    print_pass_name = PassInstrument("PrintPassName")
+
+    @print_pass_name.register_run_before_pass
+    def run_before_pass(mod, info):
+        print(info.name)
+        return True
+
+    with tvm.transform.PassContext(
+        pass_instrumentor=PassInstrumentor([skip_annotate, skip_anf, print_pass_name])
+    ):
+        mod = tvm.relay.transform.AnnotateSpans()(mod)
+        mod = tvm.relay.transform.ToANormalForm()(mod)
+        mod = tvm.relay.transform.InferType()(mod)
+
+    assert capsys.readouterr().out == "InferType\n"
+
+
+def test_instrument_pass_counts(capsys):
+    x, y, z = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xyz"]
+    e1 = op.add(x, y)
+    e2 = op.subtract(x, z)
+    e3 = op.multiply(e1, e1 / e2)
+    mod = tvm.IRModule.from_expr(e3 + e2)
+
+    class PassesCounter(PassInstrument):
+        def __init__(self):
+            super().__init__("PassesCounter")
+            super().register_set_up(self.__set_up)
+            super().register_tear_down(self.__tear_down)
+            super().register_run_before_pass(self.__run_before_pass)
+            super().register_run_after_pass(self.__run_after_pass)
+            self.__clear()
+
+        def __clear(self):
+            self.run_before_count = 0
+            self.run_after_count = 0
+
+        def __set_up(self):
+            self.__clear()
+
+        def __tear_down(self):
+            self.__clear()
+
+        def __run_before_pass(self, mod, info):
+            self.run_before_count = self.run_before_count + 1
+            return True
+
+        def __run_after_pass(self, mod, info):
+            self.run_after_count = self.run_after_count + 1
+
+    passes_counter = PassesCounter()
+    with tvm.transform.PassContext(pass_instrumentor=PassInstrumentor([passes_counter])):
+        tvm.relay.build(mod, "llvm")
+        assert passes_counter.run_after_count != 0
+        assert passes_counter.run_after_count == passes_counter.run_before_count
+
+    # Out of pass context scope, should be reset
+    assert passes_counter.run_before_count == 0
+    assert passes_counter.run_after_count == 0

--- a/tests/python/relay/test_pass_instrument.py
+++ b/tests/python/relay/test_pass_instrument.py
@@ -17,7 +17,7 @@
 import tvm
 import tvm.relay
 from tvm.relay import op
-from tvm.ir.instrument import PassesTimeInstrument, PassInstrument, pass_instrument
+from tvm.ir.instrument import PassesTimeInstrument, pass_instrument
 
 
 def test_pass_time_instrument():

--- a/tests/python/relay/test_pass_manager.py
+++ b/tests/python/relay/test_pass_manager.py
@@ -536,14 +536,13 @@ def test_print_ir(capfd):
 
 __TRACE_COUNTER__ = 0
 
-pi = _instrument.PassInstrument("my_instrument")
 
-
-@pi.register_run_before_pass
-def _tracer(module, info):
-    global __TRACE_COUNTER__
-    __TRACE_COUNTER__ += 1
-    return True
+@tvm.instrument.pass_instrument
+class MyInstrument:
+    def run_before_pass(self, module, info):
+        global __TRACE_COUNTER__
+        __TRACE_COUNTER__ += 1
+        return True
 
 
 def test_print_debug_callback():
@@ -566,9 +565,7 @@ def test_print_debug_callback():
     assert __TRACE_COUNTER__ == 0
     mod = tvm.IRModule({"main": func})
 
-    with tvm.transform.PassContext(
-        opt_level=3, pass_instrumentor=_instrument.PassInstrumentor([pi])
-    ):
+    with tvm.transform.PassContext(opt_level=3, instruments=[MyInstrument()]):
         mod = seq(mod)
 
     # TODO(@jroesch): when we remove new fn pass behavior we need to remove


### PR DESCRIPTION
This commit provides utilities to instrument passes:
  1. Add a new namespace tvm.instrument
  2. Introduce PassInstrument and PassInstrumentor to PassContext

     Example
     ---------
    passes_mem = #... Impl of memory instrument
    passes_time = tvm.instrument.PassesTimeInstrument()

    with tvm.transform.PassContext(
       pass_instrumentor=PassInstrumentor([passes_mem, passes_time])):

       tvm.relay.build(mod, 'llvm')

       passes_mem.rendor()
       passes_time.rendor()

  3. Integrate existing PassContext::Trace() and timing profile

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

Hi @altanh @tqchen:
    I tried to integrate current passes profile mechanisms and make it more extendable, usage is as the commit's code example.  Many parts are inspired by LLVM and MLIR.
   
   How do you think? 
  
   This is my first attempt to TVM :),   I have read through the guideline, but it there are stilling something wrong, please let me know. 
  
Regards,
Zack    