### PR TITLE
[RPC] Bugfix. Removed server forcing IPv4 protocol

### DIFF
--- a/python/tvm/rpc/base.py
+++ b/python/tvm/rpc/base.py
@@ -57,12 +57,10 @@ class TrackerCode(object):
 
 RPC_SESS_MASK = 128
 
-
+# Use "127.0.0.1" or "::1" if there is a need to force ip4 or ip6
+# connection for "localhost".
 def get_addr_family(addr):
     res = socket.getaddrinfo(addr[0], addr[1], 0, 0, socket.IPPROTO_TCP)
-    for info in res:
-        if info[0] == socket.AF_INET:
-            return info[0]
     return res[0][0]
 
 


### PR DESCRIPTION
 Removed forcing IPv4 protocol from python RPC server implementation
to be in correspondence with the RPC client implementation which is
used `platform default`. This had led to situation when "localhost"
was translated as 127.0.0.1 for the server (IPv4 protocol was used),
but the client translated it as "::1" and was trying to connect to
server using IPv6 protocol and was getting "ECONNREFUSED 111 Connection refused".
