### PR TITLE
Correctly build with -runtime=c without -system-lib

### DIFF
--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -436,7 +436,7 @@ def build(inputs, args=None, target=None, target_host=None, name="default_functi
         target_host = Target(target_host)
     if (
         target_host.attrs.get("runtime", tvm.runtime.String("c++")) == "c"
-        and target_host.attrs.get("system-lib", 0).value == 1
+        and target_host.attrs.get("system-lib", 0) == 1
     ):
         if target_host.kind.name == "c":
             create_csource_crt_metadata_module = tvm._ffi.get_global_func(


### PR DESCRIPTION
This is just a little inconsistency I noticed when trying to run the following script:

```
import tvm
import tvm.testing
from tvm import te
import numpy as np
from tvm.contrib import cc

tgt = "llvm  -runtime=c"

n = te.var("n")
A = te.placeholder((n,), name="A")
B = te.placeholder((n,), name="B")
C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")

s = te.create_schedule(C.op)


fadd = tvm.build(s, [A, B, C], tgt, name="myadd")
```
