### PR TITLE
[Codegen] Fix assertion errors in llvm backend when using llvm debug build

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -794,28 +794,45 @@ void CodeGenCPU::DefineFunctionRegistry(Array<String> func_names) {
   std::vector<llvm::Constant*> funcs;
   for (auto sym : func_names) {
     symbols.push_back(sym);
-    llvm::GlobalVariable* sym_func = new llvm::GlobalVariable(
-        *module_, ftype_tvm_backend_packed_c_func_, true, llvm::GlobalValue::ExternalLinkage,
-        nullptr, sym.operator std::string());
+    auto *sym_func = llvm::Function::Create(
+        ftype_tvm_backend_packed_c_func_, 
+        llvm::GlobalValue::ExternalLinkage, 
+        sym.operator std::string(), 
+        *module_);  
+
     funcs.emplace_back(sym_func);
   }
-  llvm::DataLayout layout(module_.get());
   llvm::ArrayType* t_tvm_crt_func_ptrs =
       llvm::ArrayType::get(ftype_tvm_backend_packed_c_func_->getPointerTo(), funcs.size());
+  llvm::DataLayout layout(module_.get());
+  
   llvm::GlobalVariable* func_registry_ptrs = new llvm::GlobalVariable(
       *module_, t_tvm_crt_func_ptrs, true, llvm::GlobalValue::InternalLinkage,
       llvm::ConstantArray::get(t_tvm_crt_func_ptrs, funcs), "_tvm_func_registry_ptrs");
+ 
   uint64_t align = layout.getTypeAllocSize(ftype_tvm_backend_packed_c_func_->getPointerTo());
 #if TVM_LLVM_VERSION >= 100
   func_registry_ptrs->setAlignment(llvm::Align(align));
 #else
   func_registry_ptrs->setAlignment(align);
 #endif
+  llvm::Constant* indices[] = {llvm::ConstantInt::getSigned(
+               llvm::IntegerType::get(*ctx_, 32),
+               0
+             ),llvm::ConstantInt::getSigned(
+               llvm::IntegerType::get(*ctx_, 32),
+               0
+             )};
   llvm::GlobalVariable* func_registry = new llvm::GlobalVariable(
       *module_, t_tvm_crt_func_registry_, true, llvm::GlobalVariable::InternalLinkage,
       llvm::ConstantStruct::get(
           t_tvm_crt_func_registry_,
-          {GetConstString(::tvm::target::GenerateFuncRegistryNames(symbols)), func_registry_ptrs}),
+          {GetConstString(::tvm::target::GenerateFuncRegistryNames(symbols)), 
+           llvm::ConstantExpr::getBitCast(
+             func_registry_ptrs, 
+             ftype_tvm_backend_packed_c_func_->getPointerTo()
+             )
+          }),
       "_tvm_crt_func_registry");
   llvm::GlobalVariable* module = new llvm::GlobalVariable(
       *module_, t_tvm_crt_module_, true, llvm::GlobalValue::InternalLinkage,

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -796,7 +796,7 @@ void CodeGenCPU::DefineFunctionRegistry(Array<String> func_names) {
     symbols.push_back(sym);
     auto* sym_func =
         llvm::Function::Create(ftype_tvm_backend_packed_c_func_, llvm::GlobalValue::ExternalLinkage,
-                               sym.operator std::string(), *module_);
+                               sym.operator std::string(), module_.get());
 
     funcs.emplace_back(sym_func);
   }

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -794,45 +794,33 @@ void CodeGenCPU::DefineFunctionRegistry(Array<String> func_names) {
   std::vector<llvm::Constant*> funcs;
   for (auto sym : func_names) {
     symbols.push_back(sym);
-    auto *sym_func = llvm::Function::Create(
-        ftype_tvm_backend_packed_c_func_, 
-        llvm::GlobalValue::ExternalLinkage, 
-        sym.operator std::string(), 
-        *module_);  
+    auto* sym_func =
+        llvm::Function::Create(ftype_tvm_backend_packed_c_func_, llvm::GlobalValue::ExternalLinkage,
+                               sym.operator std::string(), *module_);
 
     funcs.emplace_back(sym_func);
   }
   llvm::ArrayType* t_tvm_crt_func_ptrs =
       llvm::ArrayType::get(ftype_tvm_backend_packed_c_func_->getPointerTo(), funcs.size());
   llvm::DataLayout layout(module_.get());
-  
+
   llvm::GlobalVariable* func_registry_ptrs = new llvm::GlobalVariable(
       *module_, t_tvm_crt_func_ptrs, true, llvm::GlobalValue::InternalLinkage,
       llvm::ConstantArray::get(t_tvm_crt_func_ptrs, funcs), "_tvm_func_registry_ptrs");
- 
+
   uint64_t align = layout.getTypeAllocSize(ftype_tvm_backend_packed_c_func_->getPointerTo());
 #if TVM_LLVM_VERSION >= 100
   func_registry_ptrs->setAlignment(llvm::Align(align));
 #else
   func_registry_ptrs->setAlignment(align);
 #endif
-  llvm::Constant* indices[] = {llvm::ConstantInt::getSigned(
-               llvm::IntegerType::get(*ctx_, 32),
-               0
-             ),llvm::ConstantInt::getSigned(
-               llvm::IntegerType::get(*ctx_, 32),
-               0
-             )};
   llvm::GlobalVariable* func_registry = new llvm::GlobalVariable(
       *module_, t_tvm_crt_func_registry_, true, llvm::GlobalVariable::InternalLinkage,
       llvm::ConstantStruct::get(
           t_tvm_crt_func_registry_,
-          {GetConstString(::tvm::target::GenerateFuncRegistryNames(symbols)), 
-           llvm::ConstantExpr::getBitCast(
-             func_registry_ptrs, 
-             ftype_tvm_backend_packed_c_func_->getPointerTo()
-             )
-          }),
+          {GetConstString(::tvm::target::GenerateFuncRegistryNames(symbols)),
+           llvm::ConstantExpr::getBitCast(func_registry_ptrs,
+                                          ftype_tvm_backend_packed_c_func_->getPointerTo())}),
       "_tvm_crt_func_registry");
   llvm::GlobalVariable* module = new llvm::GlobalVariable(
       *module_, t_tvm_crt_module_, true, llvm::GlobalValue::InternalLinkage,


### PR DESCRIPTION
When running on an llvm-11 build assertion enabled I get the following errors:
`
python: /local/gerum/speech_recognition/external/hannah-tvm/external/pulp-llvm/llvm/lib/IR/Globals.cpp:369: llvm::GlobalVariable::GlobalVariable(llvm::Module&, llvm::Type*, bool, llvm::GlobalValue::LinkageTypes, llvm::Constant*, const llvm::Twine&, llvm::GlobalVariable*, llvm::GlobalValue::ThreadLocalMode, unsigned int, bool): Assertion `!Ty->isFunctionTy() && PointerType::isValidElementType(Ty) && "invalid type for global variable"' failed.
`
This patch should fix these errors. 

The error should be reproducible with: 

`
tgt = "llvm  -runtime=c -system-lib"

n = te.var("n")
A = te.placeholder((n,), name="A")
B = te.placeholder((n,), name="B")
C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")

s = te.create_schedule(C.op)


fadd = tvm.build(s, [A, B, C], tgt, name="myadd")
`

