### PR TITLE
Fix a memory leak in SetParams

### DIFF
--- a/src/runtime/graph_executor/graph_executor_factory.h
+++ b/src/runtime/graph_executor/graph_executor_factory.h
@@ -112,8 +112,8 @@ class TVM_DLL GraphExecutorFactory : public runtime::ModuleNode {
     }
     std::sort(std::begin(keys), std::end(keys),
               [&](const std::string& lhs, const std::string& rhs) -> bool {
-                auto lhs_size = GetDataSize(value[lhs].ToDLPack()->dl_tensor);
-                auto rhs_size = GetDataSize(value[rhs].ToDLPack()->dl_tensor);
+                auto lhs_size = GetDataSize(*value[lhs].operator->());
+                auto rhs_size = GetDataSize(*value[rhs].operator->());
                 return lhs_size > rhs_size;
               });
     for (const auto& key : keys) {

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -130,9 +130,9 @@ TEST(Relay, BuildModule) {
   auto set_input_f = run_mod.GetFunction("set_input_zero_copy", false);
   auto run_f = run_mod.GetFunction("run", false);
   auto get_output_f = run_mod.GetFunction("get_output", false);
-  set_input_f("a", &A.ToDLPack()->dl_tensor);
-  set_input_f("b", &B.ToDLPack()->dl_tensor);
-  set_input_f("c", &C.ToDLPack()->dl_tensor);
+  set_input_f("a", const_cast<DLTensor*>(A.operator->()));
+  set_input_f("b", const_cast<DLTensor*>(B.operator->()));
+  set_input_f("c", const_cast<DLTensor*>(C.operator->()));
   run_f();
   tvm::runtime::NDArray Y = get_output_f(0);
   auto pY = (float*)Y->data;
@@ -155,7 +155,7 @@ TEST(Relay, BuildModule) {
   for (int i = 0; i < 6; ++i) {
     pC2[i] = i + 4;
   }
-  set_input_f("c", &C2.ToDLPack()->dl_tensor);
+  set_input_f("c", const_cast<DLTensor*>(C2.operator->()));
   run_f();
   tvm::runtime::NDArray Y3 = get_output_f(0);
   auto pY3 = (float*)Y3->data;

--- a/tests/cpp/utvm_runtime_standalone_test.cc
+++ b/tests/cpp/utvm_runtime_standalone_test.cc
@@ -111,12 +111,12 @@ TEST(MicroStandaloneRuntime, BuildModule) {
   auto* handle = UTVMRuntimeCreate(json.c_str(), json.size(), dsoModule);
   ASSERT_NE(handle, nullptr);
 
-  UTVMRuntimeSetInput(handle, 0, &A.ToDLPack()->dl_tensor);
-  UTVMRuntimeSetInput(handle, 1, &B.ToDLPack()->dl_tensor);
-  UTVMRuntimeSetInput(handle, 2, &C.ToDLPack()->dl_tensor);
+  UTVMRuntimeSetInput(handle, 0, const_cast<DLTensor*>(A.operator->()));
+  UTVMRuntimeSetInput(handle, 1, const_cast<DLTensor*>(B.operator->()));
+  UTVMRuntimeSetInput(handle, 2, const_cast<DLTensor*>(C.operator->()));
   UTVMRuntimeRun(handle);
   auto Y = tvm::runtime::NDArray::Empty({2, 3}, {kDLFloat, 32, 1}, {kDLCPU, 0});
-  UTVMRuntimeGetOutput(handle, 0, &Y.ToDLPack()->dl_tensor);
+  UTVMRuntimeGetOutput(handle, 0, const_cast<DLTensor*>(Y.operator->()));
   auto* pY = (float*)Y->data;
   for (int i = 0; i < 6; ++i) {
     CHECK_LT(fabs(pY[i] - (i + (i + 1) + (i + 2))), 1e-4);


### PR DESCRIPTION
ToDLPack creates a DLManagedTensor instance, but nobody deletes this in
proper way. We can use operator-> for getting access to DLTensor.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
