### PR TITLE
[NVCC] Bugfix nvcc command tool that relies on the compile time env

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -91,7 +91,7 @@ def compile_cuda(code, target="ptx", arch=None, options=None, path_target=None):
 
     # NOTE: ccbin option can be used to tell nvcc where to find the c++ compiler
     # just in case it is not in the path. On Windows it is not in the path by default.
-    # However, we cannot we canont use TVM_CXX_COMPILER_PATH because the runtime env.
+    # However, we cannot use TVM_CXX_COMPILER_PATH because the runtime env.
     # Because it is hard to do runtime compiler detection, we require nvcc is configured
     # correctly by default.
     # if cxx_compiler_path != "":

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -89,11 +89,13 @@ def compile_cuda(code, target="ptx", arch=None, options=None, path_target=None):
     cmd += ["-o", file_target]
     cmd += [temp_code]
 
-    cxx_compiler_path = tvm.support.libinfo().get("TVM_CXX_COMPILER_PATH")
-    if cxx_compiler_path != "":
-        # This tells nvcc where to find the c++ compiler just in case it is not in the path.
-        # On Windows it is not in the path by default.
-        cmd += ["-ccbin", cxx_compiler_path]
+    # NOTE: ccbin option can be used to tell nvcc where to find the c++ compiler
+    # just in case it is not in the path. On Windows it is not in the path by default.
+    # However, we cannot we canont use TVM_CXX_COMPILER_PATH because the runtime env.
+    # Because it is hard to do runtime compiler detection, we require nvcc is configured
+    # correctly by default.
+    # if cxx_compiler_path != "":
+    #    cmd += ["-ccbin", cxx_compiler_path]
 
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 


### PR DESCRIPTION
TVM_CXX_COMPILER_PATH indicates the env in compilation and do not guarantee to exist in runtime. Right now it becomes a problem if when build on centos(manylinux wheel) and run on ubuntu