### PR TITLE
[Relay] Return the proper module from _build_module_no_factory

### DIFF
--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -216,7 +216,7 @@ def _build_module_no_factory(mod, target=None, target_host=None, params=None, mo
     the runtime::Module can be freely passed between language boundaries.
     """
     target, target_host = Target.check_and_update_host_consist(target, target_host)
-    return build(mod, target, params=params, mod_name=mod_name).module
+    return build(mod, target, params=params, mod_name=mod_name).get_lib()
 
 
 def build(ir_mod, target=None, target_host=None, params=None, mod_name="default"):


### PR DESCRIPTION
The `module` member is the factory itself. The module to be executed is returned by `get_lib` (which also happens to be imported into the factory module, i.e. `module.imported_modules[0] == get_lib()`).

Pinging @jroesch since he wrote that code.