### PR TITLE
Remove warning which is adding too much noise

### DIFF
--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -255,15 +255,15 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
             and msg not in autotvm.task.DispatchContext.warning_messages
         ):
             autotvm.task.DispatchContext.warning_messages.add(msg)
-            if autotvm_logger.level == logging.DEBUG:  # only print if in debug mode
-                autotvm_logger.warning(msg)
-            else:
-                global _first_warning
-                if _first_warning == True:
-                    _first_warning = False
-                    info_msg = "One or more operators have not been tuned. Please tune your model "
-                    "for better performance or use DEBUG logging level to see more details."
-                    autotvm_logger.warning(info_msg)
+            global _first_warning
+            if _first_warning:
+                _first_warning = False
+                info_msg = (
+                    "One or more operators have not been tuned. Please tune your model "
+                    "for better performance. Use DEBUG logging level to see more details."
+                )
+                autotvm_logger.warning(info_msg)
+            autotvm_logger.debug(msg)
 
     logger.info(
         "Using %s for %s based on highest priority (%s)",

--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -253,7 +253,6 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
             and msg not in autotvm.task.DispatchContext.warning_messages
         ):
             autotvm.task.DispatchContext.warning_messages.add(msg)
-            autotvm_logger.warning(msg)
     logger.info(
         "Using %s for %s based on highest priority (%s)",
         best_plevel_impl.name,

--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -246,8 +246,8 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
     # Use the implementation with highest plevel
     if workloads[best_plevel_impl] is not None:
         msg = (
-            "Cannot find config for target=%s, workload=%s. A fallback configuration "
-            "is used, which may bring great performance regression."
+            "Cannot find tuning records for:\n    target=%s\n    key=%s\n"
+            "TVM will apply a default schedule which may negatively impact performance."
             % (target, workloads[best_plevel_impl])
         )
         if (


### PR DESCRIPTION
Remove warning message

WARNING  autotvm:compile_engine.py:256 Cannot find config for target=llvm -keys=cpu -link-params=0, workload=('conv2d_NCHWc.x86', ('TENSOR', (1, 1, 32, 32), 'float32'), ('TENSOR', (8, 1, 5, 5), 'float32'), (1, 1), (0, 0, 0, 0), (1, 1), 'NCHW', 'NCHW', 'float32'). A fallback configuration is used, which may bring great performance regression.

