### PR TITLE
[Relay][Parser][Bugfix] Fix parsing hierarchical attibute names

### DIFF
--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -1372,7 +1372,6 @@ class Parser {
     Map<String, ObjectRef> kwargs;
     while (Peek()->token_type == TokenType::kIdentifier) {
       auto key = GetHierarchicalName(ParseHierarchicalName().data);
-      // auto key = Match(TokenType::kIdentifier).ToString();
       Match(TokenType::kEqual);
       // TOOD(@jroesch): syntactically what do we allow to appear in attribute right hand side.
       auto value = ParseAttributeValue();

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -1371,7 +1371,8 @@ class Parser {
     DLOG(INFO) << "Parser::ParseAttrs";
     Map<String, ObjectRef> kwargs;
     while (Peek()->token_type == TokenType::kIdentifier) {
-      auto key = Match(TokenType::kIdentifier).ToString();
+      auto key = GetHierarchicalName(ParseHierarchicalName().data);
+      // auto key = Match(TokenType::kIdentifier).ToString();
       Match(TokenType::kEqual);
       // TOOD(@jroesch): syntactically what do we allow to appear in attribute right hand side.
       auto value = ParseAttributeValue();
@@ -1545,18 +1546,7 @@ class Parser {
             auto spanned_idents = ParseHierarchicalName();
             auto idents = spanned_idents.data;
             auto span = spanned_idents.span;
-            ICHECK_NE(idents.size(), 0);
-            std::stringstream op_name;
-            int i = 0;
-            int periods = idents.size() - 1;
-            for (auto ident : idents) {
-              op_name << ident;
-              if (i < periods) {
-                op_name << ".";
-                i++;
-              }
-            }
-            return GetOp(op_name.str(), span);
+            return GetOp(GetHierarchicalName(idents), span);
           }
         }
         case TokenType::kGraph: {
@@ -1694,6 +1684,21 @@ class Parser {
     }
 
     return Spanned<Array<String>>(idents, span);
+  }
+
+  std::string GetHierarchicalName(Array<String> idents) {
+    ICHECK_NE(idents.size(), 0);
+    std::stringstream hierarchical_name;
+    int i = 0;
+    int periods = idents.size() - 1;
+    for (auto ident : idents) {
+      hierarchical_name << ident;
+      if (i < periods) {
+        hierarchical_name << ".";
+        i++;
+      }
+    }
+    return hierarchical_name.str();
   }
 
   /*! \brief Parse a shape. */

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -959,6 +959,13 @@ def test_tokenize_inf():
     mod = relay.transform.AnnotateSpans()(mod)
 
 
+def test_func_attrs():
+    attrs = tvm.ir.make_node("DictAttrs", **{"Primitive": 1, "relay.reshape_only": 1})
+    x = relay.var("x", shape=(2, 3))
+    func = relay.Function([x], relay.reshape(x, (-1,)), attrs=attrs)
+    assert_parses_as(func.astext(), func)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
#7945 introduced a new attribute `relay.reshape_only` which broke the parser due to the period in the name. This PR adds support for such kinds of attribute names.

cc @tqchen @jroesch

