### PR TITLE
[VTA] Infinite recursive device_api.ext_dev call fix

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -103,7 +103,8 @@ elseif(PYTHON)
       # Rules for Pynq v2.4
       find_library(__cma_lib NAMES cma PATH /usr/lib)
     elseif(${VTA_TARGET} STREQUAL "de10nano")  # DE10-Nano rules
-      file(GLOB FPGA_RUNTIME_SRCS ${VTA_HW_PATH}/src/de10nano/*.cc ${VTA_HW_PATH}/src/*.cc)
+      file(GLOB DE10_FPGA_RUNTIME_SRCS ${VTA_HW_PATH}/src/de10nano/*.cc ${VTA_HW_PATH}/src/*.cc)
+      list(APPEND FPGA_RUNTIME_SRCS ${DE10_FPGA_RUNTIME_SRCS})
     elseif(${VTA_TARGET} STREQUAL "intelfocl")  # Intel OpenCL for FPGA rules
       file(GLOB FOCL_SRC ${VTA_HW_PATH}/src/oclfpga/*.cc)
       list(APPEND FPGA_RUNTIME_SRCS ${FOCL_SRC})


### PR DESCRIPTION
#3843 fixed the infinite recursive call for the Xilinx boards, but didn't fix it for the intel boards. This fixes it for the DE10 (same missing symbol problem with same fix).