### PR TITLE
Remove minimum seed constraint on XGB Tuner

### DIFF
--- a/python/tvm/autotvm/tuner/xgboost_cost_model.py
+++ b/python/tvm/autotvm/tuner/xgboost_cost_model.py
@@ -258,9 +258,6 @@ class XGBoostCostModel(CostModel):
                 xs.append(x)
                 ys.append(y)
 
-        if len(xs) < 500:  # no enough samples
-            return False
-
         xs, ys = np.array(xs), np.array(ys)
         x_train = xs
         y_train = ys


### PR DESCRIPTION
Here we remove 500 minimum sample constraint for seeding the XGB Tuner. This constraint caused the XGBoost tuner to silently disregard data from when `load_history` is invoked.

@merrymercy @tkonolige 