### PR TITLE
[UnitTests] Removed unnecessary file creation from unit tests.

### DIFF
--- a/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
@@ -146,7 +146,7 @@ def tune_and_check(mod, data, weight):
         log_file = fp.name
 
         # Tune tasks
-        tuner = auto_scheduler.TaskScheduler(tasks, task_weights)
+        tuner = auto_scheduler.TaskScheduler(tasks, task_weights, callbacks=[])
         tune_option = auto_scheduler.TuningOptions(
             num_measure_trials=1,
             num_measures_per_round=1,

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -37,7 +37,7 @@ def tune_network(network, target):
 
         # Tuning
         measure_ctx = auto_scheduler.LocalRPCMeasureContext(timeout=60)
-        tuner = auto_scheduler.TaskScheduler(tasks, task_weights)
+        tuner = auto_scheduler.TaskScheduler(tasks, task_weights, callbacks=[])
         tune_option = auto_scheduler.TuningOptions(
             num_measure_trials=100,
             num_measures_per_round=2,

--- a/tests/python/unittest/test_auto_scheduler_task_scheduler.py
+++ b/tests/python/unittest/test_auto_scheduler_task_scheduler.py
@@ -50,7 +50,7 @@ def test_task_scheduler_round_robin():
             num_measures_per_round=1,
             measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
         )
-        task_scheduler = auto_scheduler.TaskScheduler(tasks, strategy="round-robin")
+        task_scheduler = auto_scheduler.TaskScheduler(tasks, strategy="round-robin", callbacks=[])
         task_scheduler.tune(tune_option, search_policy="sketch.random")
 
         # Check the result of round robin
@@ -66,7 +66,7 @@ def test_task_scheduler_round_robin():
 
         # test continuous tuning (restoring the status)
         task_scheduler = auto_scheduler.TaskScheduler(
-            tasks, strategy="round-robin", load_log_file=log_file
+            tasks, strategy="round-robin", load_log_file=log_file, callbacks=[]
         )
         tune_option = auto_scheduler.TuningOptions(
             num_measure_trials=len(tasks),
@@ -116,7 +116,9 @@ def test_task_scheduler_gradient():
             num_measures_per_round=1,
             measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
         )
-        task_scheduler = auto_scheduler.TaskScheduler(tasks, objective_func=objective_func)
+        task_scheduler = auto_scheduler.TaskScheduler(
+            tasks, objective_func=objective_func, callbacks=[]
+        )
 
         # Forcely rewrite the initial values.
         # This can make this test more stable on the slow CI machines

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -275,7 +275,7 @@ def test_c_link_params():
             assert set(lib.params.keys()) == {"p0", "p1"}  # NOTE: op folded
 
             src = lib.lib.get_source()
-            lib.lib.save("test.c", "c")
+            lib.lib.save(temp_dir.relpath("test.c"), "c")
             c_dtype = _get_c_datatype(dtype)
             src_lines = src.split("\n")
             param = lib.params["p0"].asnumpy().reshape(np.prod(KERNEL_SHAPE))
@@ -302,7 +302,6 @@ def test_c_link_params():
                 i += 1
 
             assert cursor == np.prod(param.shape)
-            temp = utils.tempdir()
 
             # Need a unique name per library to avoid dlopen caching the lib load.
             lib_path = temp_dir.relpath(f"test-{dtype}-linked.so")


### PR DESCRIPTION
Some of the unit tests produced output when run, even for a successful test.  Edited these tests to either write to a temporary directory (`test.c` written by test_link_params), or to suppress the file creation entirely (`total_latency.tsv`, created by default callback of `TaskScheduler`).