### PR TITLE
[Relay] Allow printing annotation in the Relay text printer for var

### DIFF
--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -219,6 +219,7 @@ Doc RelayTextPrinter::AllocVar(const Var& var) {
   if (var->type_annotation.defined()) {
     val << ": " << Print(var->type_annotation);
   }
+  val << PrintOptionalInfo(var);
   return val;
 }
 


### PR DESCRIPTION
We want to print out some extra annotation information for a variable. So want to enable the annotation info for variables in the relay printer.
