### PR TITLE
[CI] Added llvm-12 to ubuntu1804_install_llvm.sh

### DIFF
--- a/docker/install/ubuntu1804_install_llvm.sh
+++ b/docker/install/ubuntu1804_install_llvm.sh
@@ -36,10 +36,15 @@ echo deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main\
 echo deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main\
      >> /etc/apt/sources.list.d/llvm.list
 
+echo deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main\
+     >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main\
+     >> /etc/apt/sources.list.d/llvm.list
+
 echo deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\
      >> /etc/apt/sources.list.d/llvm.list
 echo deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\
      >> /etc/apt/sources.list.d/llvm.list
 
 wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-apt-get update && apt-get install -y llvm-9 llvm-10 llvm-11 clang-9 libclang-9-dev clang-10 libclang-10-dev clang-11 libclang-11-dev
+apt-get update && apt-get install -y llvm-9 llvm-10 llvm-11 llvm-12 clang-9 libclang-9-dev clang-10 libclang-10-dev clang-11 libclang-11-dev clang-12 libclang-12-dev


### PR DESCRIPTION
This PR adds llvm-12 to ubuntu1804_install_llvm.sh. This is needed as llvm, prior to 11.1.0, contains an issue which affects X86 backend and virtually prevents some cases of vectorization done in TVM (https://github.com/llvm/llvm-project/commit/c7b54a196e1363cbe43122f01a728cd71fa1686a).  

To reproduce this issue locally one can use following publicly available network https://github.com/ARM-software/ML-zoo/blob/master/models/keyword_spotting/ds_cnn_small/tflite_int8/ds_cnn_s_quantized.tflite
Command line:
`tvmc compile --target llvm ds_cnn_s_quantized.tflite `
will fail in attempt to perform `combineMul ` on `t20: v12i32 = mul nsw t19, t6` due to missing MVT of v6i32 (which in fact should be EVT, not MVT) on llvm versions prior 11.1.0