### PR TITLE
[CI] Ignore invalid git tags when running "git describe" in version.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -62,10 +62,13 @@ def git_describe_version():
     local_ver: str
         Local version (with additional label appended to pub_ver).
 
-    Note
-    ----
-    We follow PEP 440's convention of public version
-    and local versions.
+    Notes
+    -----
+    - We follow PEP 440's convention of public version
+      and local versions.
+    - Only tags conforming to vMAJOR.MINOR.REV (e.g. "v0.7.0")
+      are considered in order to generate the version string.
+      See the use of `--match` in the `git` command below.
 
     Here are some examples:
 
@@ -77,7 +80,7 @@ def git_describe_version():
       after the most recent tag(v0.7.0),
       the git short hash tag of the current commit is 0d07a329e.
     """
-    cmd = ["git", "describe", "--tags"]
+    cmd = ["git", "describe", "--tags", "--match", "v[0-9]*.[0-9]*.[0-9]*"]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=PROJ_ROOT)
     (out, _) = proc.communicate()
 


### PR DESCRIPTION
Ignore invalid git tags when running `git describe` in `version.py`.

* When using version.py, the presence of tags not conforming with vMAJOR.MINOR.REV can potentially cause `version.py` to fallback to the default release tag (currently `0.8.dev0`)

* This change makes `version.py` ignore tags that do not conform with vMAJOR.MINOR.REV by using "git describe --match ...".

* Also adds a bit of documentation as a note.

cc @tqchen @areusch 
