### PR TITLE
[UnitTests] Automatic parametrization over targets, with explicit opt-out

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,13 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import tvm.testing
+import pytest
 from pytest import ExitCode
+
+import tvm
+import tvm.testing
 
 
 def pytest_configure(config):
     print("enabled targets:", "; ".join(map(lambda x: x[0], tvm.testing.enabled_targets())))
     print("pytest marker:", config.option.markexpr)
+
+
+@pytest.fixture
+def dev(target):
+    return tvm.device(target)
+
+
+def pytest_generate_tests(metafunc):
+    tvm.testing._auto_parametrize_target(metafunc)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,7 @@ def pytest_generate_tests(metafunc):
 
 def pytest_collection_modifyitems(config, items):
     tvm.testing._count_num_fixture_uses(items)
+    tvm.testing._remove_global_fixture_definitions(items)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,11 @@ def dev(target):
 
 def pytest_generate_tests(metafunc):
     tvm.testing._auto_parametrize_target(metafunc)
+    tvm.testing._parametrize_correlated_parameters(metafunc)
+
+
+def pytest_collection_modifyitems(config, items):
+    tvm.testing._count_num_fixture_uses(items)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -823,13 +823,6 @@ def parametrize_targets(*args):
     >>> @tvm.testing.parametrize_targets("llvm", "cuda")
     >>> def test_mytest(target, dev):
     >>>     ...  # do something
-
-    Or
-
-    >>> @tvm.testing.parametrize_targets
-    >>> def test_mytest(target, dev):
-    >>>     ...  # do something
-
     """
 
     def wrap(targets):

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -61,6 +61,7 @@ import os
 import sys
 import time
 import pytest
+import _pytest
 import numpy as np
 import tvm
 import tvm.arith
@@ -1184,7 +1185,9 @@ def _remove_global_fixture_definitions(items):
     for module in modules:
         for name in dir(module):
             obj = getattr(module, name)
-            if hasattr(obj, "_pytestfixturefunction"):
+            if hasattr(obj, "_pytestfixturefunction") and isinstance(
+                obj._pytestfixturefunction, _pytest.fixtures.FixtureFunctionMarker
+            ):
                 delattr(module, name)
 
 

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -1048,7 +1048,7 @@ def _parametrize_correlated_parameters(metafunc):
             metafunc.parametrize(names, value_sets, indirect=True)
 
 
-def fixture(func=None, *, cache=False):
+def fixture(func=None, *, cache_return_value=False):
     """Convenience function to define pytest fixtures.
 
     This should be used as a decorator to mark functions that set up
@@ -1061,13 +1061,13 @@ def fixture(func=None, *, cache=False):
 
     By default, the setup will be performed once for each unit test
     that uses a fixture, to ensure that unit tests are independent.
-    If the setup is expensive to perform, then the cache=True argument
-    can be passed to cache the setup.  The fixture function will be
-    run only once (or once per parameter, if used with
-    tvm.testing.parameter), and the same return value will be passed
-    to all tests that use it.  If the environment variable
-    TVM_TEST_DISABLE_CACHE is set to a non-zero value, it will disable
-    this feature and no caching will be performed.
+    If the setup is expensive to perform, then the
+    cache_return_value=True argument can be passed to cache the setup.
+    The fixture function will be run only once (or once per parameter,
+    if used with tvm.testing.parameter), and the same return value
+    will be passed to all tests that use it.  If the environment
+    variable TVM_TEST_DISABLE_CACHE is set to a non-zero value, it
+    will disable this feature and no caching will be performed.
 
     Example
     -------
@@ -1091,7 +1091,7 @@ def fixture(func=None, *, cache=False):
 
     Or
 
-    >>> @tvm.testing.fixture(cache=True)
+    >>> @tvm.testing.fixture(cache_return_value=True)
     >>> def expensive_setup():
     >>>     time.sleep(10) # Setup code here
     >>>     return 5
@@ -1102,7 +1102,7 @@ def fixture(func=None, *, cache=False):
     """
 
     force_disable_cache = bool(int(os.environ.get("TVM_TEST_DISABLE_CACHE", "0")))
-    cache = cache and not force_disable_cache
+    cache_return_value = cache_return_value and not force_disable_cache
 
     # Deliberately at function scope, so that caching can track how
     # many times the fixture has been used.  If used, the cache gets
@@ -1110,7 +1110,7 @@ def fixture(func=None, *, cache=False):
     scope = "function"
 
     def wraps(func):
-        if cache:
+        if cache_return_value:
             func = _fixture_cache(func)
         func = pytest.fixture(func, scope=scope)
         return func

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -728,13 +728,18 @@ def _pytest_target_params(targets, excluded_targets=None, known_failing_targets=
 
         target_marks = []
         for t in _get_targets():
+            # Excluded targets aren't included in the params at all.
             if t["target_kind"] not in excluded_targets:
-                extra_marks = [
-                    pytest.mark.skipif(
-                        t["target_kind"] in known_failing_targets,
-                        reason='Known failing test for target "{}"'.format(t["target_kind"]),
+
+                # Known failing targets are included, but are marked
+                # as expected to fail.
+                extra_marks = []
+                if t["target_kind"] in known_failing_targets:
+                    extra_marks.append(
+                        pytest.mark.xfail(
+                            reason='Known failing test for target "{}"'.format(t["target_kind"])
+                        )
                     )
-                ]
                 target_marks.append((t["target"], extra_marks))
 
     else:

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -1171,6 +1171,23 @@ def _count_num_fixture_uses(items):
                 fixturedef.func.num_tests_use_this += 1
 
 
+def _remove_global_fixture_definitions(items):
+    # Helper function, removes fixture definitions from the global
+    # variables of the modules they were defined in.  This is intended
+    # to improve readability of error messages by giving a NameError
+    # if a test function accesses a pytest fixture but doesn't include
+    # it as an argument.  Should be called from
+    # pytest_collection_modifyitems().
+
+    modules = set(item.module for item in items)
+
+    for module in modules:
+        for name in dir(module):
+            obj = getattr(module, name)
+            if hasattr(obj, "_pytestfixturefunction"):
+                delattr(module, name)
+
+
 def identity_after(x, sleep):
     """Testing function to return identity after sleep
 

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -763,8 +763,13 @@ def _auto_parametrize_target(metafunc):
 
     """
     if "target" in metafunc.fixturenames:
-        mark = metafunc.definition.get_closest_marker("parametrize")
-        if not mark or "target" not in mark.args[0]:
+        parametrized_args = [
+            arg.strip()
+            for mark in metafunc.definition.iter_markers("parametrize")
+            for arg in mark.args[0].split(",")
+        ]
+
+        if "target" not in parametrized_args:
             # Check if the function is marked with either excluded or
             # known failing targets.
             excluded_targets = getattr(metafunc.function, "tvm_excluded_targets", [])

--- a/tests/python/topi/python/test_topi_relu.py
+++ b/tests/python/topi/python/test_topi_relu.py
@@ -29,14 +29,13 @@ import pytest
 import tvm.testing
 
 
-@pytest.mark.parametrize(
-    "m, n, dtype",
-    [
-        (10, 128, "float32"),
-        (128, 64, "float16"),
-        (1024 * 100, 512, "float32"),
-    ],
+m, n, dtype = tvm.testing.parameters(
+    (10, 128, "float32"),
+    (128, 64, "float16"),
+    (1024 * 100, 512, "float32"),
 )
+
+
 def test_relu(target, dev, m, n, dtype):
     A = te.placeholder((m, n), name="A", dtype=dtype)
     B = topi.nn.relu(A)
@@ -58,9 +57,11 @@ def test_relu(target, dev, m, n, dtype):
     tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
 
 
-@pytest.mark.parametrize("m, alpha", [(100, 0.1)])
-def test_leaky_relu(m, alpha):
-    A = te.placeholder((m,), name="A")
+size, alpha = tvm.testing.parameters((100, 0.1))
+
+
+def test_leaky_relu(size, alpha):
+    A = te.placeholder((size,), name="A")
     B = topi.nn.leaky_relu(A, alpha)
     s = te.create_schedule([B.op])
 
@@ -74,14 +75,13 @@ def test_leaky_relu(m, alpha):
     tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "x, w, axis, weight_reshape",
-    [
-        ((1, 3, 2, 2), (3,), 1, (3, 1, 1)),
-        ((1, 3, 2, 2), (2,), 2, (2, 1)),
-        ((1, 3), (3,), 1, (3,)),
-    ],
+x, w, axis, weight_reshape = tvm.testing.parameters(
+    ((1, 3, 2, 2), (3,), 1, (3, 1, 1)),
+    ((1, 3, 2, 2), (2,), 2, (2, 1)),
+    ((1, 3), (3,), 1, (3,)),
 )
+
+
 def test_prelu(x, w, axis, weight_reshape):
     X = te.placeholder((x), name="X")
     W = te.placeholder((w), name="W")

--- a/tests/python/topi/python/test_topi_relu.py
+++ b/tests/python/topi/python/test_topi_relu.py
@@ -87,13 +87,11 @@ def verify_prelu(x, w, axis, weight_reshape):
     tvm.testing.assert_allclose(b.numpy(), out_np, rtol=1e-5)
 
 
-@tvm.testing.parametrize_targets
 def test_relu(target, dev):
     verify_relu(target, dev, 10, 128, "float32")
     verify_relu(target, dev, 128, 64, "float16")
 
 
-@tvm.testing.parametrize_targets
 def test_schedule_big_array(target, dev):
     verify_relu(target, dev, 1024 * 100, 512)
 

--- a/tests/python/unittest/test_tvm_testing_features.py
+++ b/tests/python/unittest/test_tvm_testing_features.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import sys
+
+import pytest
+
+import tvm.testing
+
+# This file tests features in tvm.testing, such as verifying that
+# cached fixtures are run an appropriate number of times.  As a
+# result, the order of the tests is important.  Use of --last-failed
+# or --failed-first while debugging this file is not advised.
+
+
+class TestTargetAutoParametrization:
+    targets_used = []
+    devices_used = []
+    enabled_targets = [target for target, dev in tvm.testing.enabled_targets()]
+    enabled_devices = [dev for target, dev in tvm.testing.enabled_targets()]
+
+    def test_target_parametrization(self, target):
+        assert target in self.enabled_targets
+        self.targets_used.append(target)
+
+    def test_device_parametrization(self, dev):
+        assert dev in self.enabled_devices
+        self.devices_used.append(dev)
+
+    def test_all_targets_used(self):
+        assert self.targets_used == self.enabled_targets
+        assert self.devices_used == self.enabled_devices
+
+    targets_with_explicit_list = []
+
+    @tvm.testing.parametrize_targets("llvm")
+    def test_explicit_list(self, target):
+        assert target == "llvm"
+        self.targets_with_explicit_list.append(target)
+
+    def test_no_repeats_in_explicit_list(self):
+        assert self.targets_with_explicit_list == ["llvm"]
+
+    targets_with_exclusion = []
+
+    @tvm.testing.exclude_targets("llvm")
+    def test_exclude_target(self, target):
+        assert "llvm" not in target
+        self.targets_with_exclusion.append(target)
+
+    def test_all_nonexcluded_targets_ran(self):
+        assert self.targets_with_exclusion == [
+            target for target in self.enabled_targets if not target.startswith("llvm")
+        ]
+
+    run_targets_with_known_failure = []
+
+    @tvm.testing.known_failing_targets("llvm")
+    def test_known_failing_target(self, target):
+        # This test runs for all targets, but intentionally fails for
+        # llvm.  The behavior is working correctly if this test shows
+        # up as an expected failure, xfail.
+        self.run_targets_with_known_failure.append(target)
+        assert "llvm" not in target
+
+    def test_all_targets_ran(self):
+        assert self.run_targets_with_known_failure == self.enabled_targets
+
+
+class TestJointParameter:
+    param1_vals = [1, 2, 3]
+    param2_vals = ["a", "b", "c"]
+
+    independent_usages = 0
+    param1 = tvm.testing.parameter(*param1_vals)
+    param2 = tvm.testing.parameter(*param2_vals)
+
+    joint_usages = 0
+    joint_param_vals = list(zip(param1_vals, param2_vals))
+    joint_param1, joint_param2 = tvm.testing.parameters(*joint_param_vals)
+
+    def test_using_independent(self, param1, param2):
+        type(self).independent_usages += 1
+
+    def test_independent(self):
+        assert self.independent_usages == len(self.param1_vals) * len(self.param2_vals)
+
+    def test_using_joint(self, joint_param1, joint_param2):
+        type(self).joint_usages += 1
+        assert (joint_param1, joint_param2) in self.joint_param_vals
+
+    def test_joint(self):
+        assert self.joint_usages == len(self.joint_param_vals)
+
+
+class TestFixtureCaching:
+    param1_vals = [1, 2, 3]
+    param2_vals = ["a", "b", "c"]
+
+    param1 = tvm.testing.parameter(*param1_vals)
+    param2 = tvm.testing.parameter(*param2_vals)
+
+    uncached_calls = 0
+    cached_calls = 0
+
+    @tvm.testing.fixture
+    def uncached_fixture(self, param1):
+        type(self).uncached_calls += 1
+        return 2 * param1
+
+    def test_use_uncached(self, param1, param2, uncached_fixture):
+        assert 2 * param1 == uncached_fixture
+
+    def test_uncached_count(self):
+        assert self.uncached_calls == len(self.param1_vals) * len(self.param2_vals)
+
+    @tvm.testing.fixture(cache_return_value=True)
+    def cached_fixture(self, param1):
+        type(self).cached_calls += 1
+        return 3 * param1
+
+    def test_use_cached(self, param1, param2, cached_fixture):
+        assert 3 * param1 == cached_fixture
+
+    def test_cached_count(self):
+        cache_disabled = bool(int(os.environ.get("TVM_TEST_DISABLE_CACHE", "0")))
+        if cache_disabled:
+            assert self.cached_calls == len(self.param1_vals) * len(self.param2_vals)
+        else:
+            assert self.cached_calls == len(self.param1_vals)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
Implemented features for the python tests to automatically parametrize over enabled targets, and to explicitly list the targets that were skipped.  PR includes testing framework changes, along with changes to a single test file (`test_topi_relu.py`) as a proof of concept.

~~[Link to RFC](https://discuss.tvm.apache.org/t/rfc-parametrized-unit-tests/9946)~~ [Link to RFC on tvm-rfcs](https://github.com/apache/tvm-rfcs/pull/7), documenting differences in the testing style, advantages of the proposed style, and changes needed to use the new style.