### PR TITLE
[AOT] Name mangling in AOT

### DIFF
--- a/apps/microtvm/zephyr/aot_demo/src/main.c
+++ b/apps/microtvm/zephyr/aot_demo/src/main.c
@@ -41,7 +41,7 @@
 #define WORKSPACE_SIZE (270 * 1024)
 
 static uint8_t g_aot_memory[WORKSPACE_SIZE];
-extern tvm_model_t network;
+extern tvm_model_t tvmgen_default_network;
 tvm_workspace_t app_workspace;
 
 // Wakeup sequence used to wake up QEMU on the host.
@@ -205,7 +205,7 @@ void main(void) {
 
   double elapsed_time = 0;
   TVMPlatformTimerStart();
-  int ret_val = tvm_runtime_run(&network, inputs, outputs);
+  int ret_val = tvm_runtime_run(&tvmgen_default_network, inputs, outputs);
   TVMPlatformTimerStop(&elapsed_time);
 
   if (ret_val != 0) {

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -231,7 +231,7 @@ constexpr const char* tvm_param_prefix = "__tvm_param__";
 /*! \brief A PackedFunc that looks up linked parameters by storage_id. */
 constexpr const char* tvm_lookup_linked_param = "_lookup_linked_param";
 /*! \brief The main AOT executor function */
-constexpr const char* tvm_run_func_prefix = "tvm__run_func";
+constexpr const char* tvm_run_func_suffix = "run_model";
 }  // namespace symbol
 
 // implementations of inline functions.

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -35,7 +35,7 @@ class UnsupportedInModelLibraryFormatError(Exception):
     """Raised when export_model_library_format does not support the given Module tree."""
 
 
-def _populate_codegen_dir(mod, codegen_dir: str):
+def _populate_codegen_dir(mod, codegen_dir: str, module_name: str = None):
     """Populate the codegen sub-directory as part of a Model Library Format export.
 
     Parameters
@@ -44,6 +44,9 @@ def _populate_codegen_dir(mod, codegen_dir: str):
         Module which should be written to codegen_dir.
     codegen_dir : str
         Path to the codegen directory on disk.
+    module_name: Optional[str]
+        Name used to prefix the generated source files
+
     """
     dso_modules = mod._collect_dso_modules()
     dso_module_handles = [m.handle.value for m in dso_modules]
@@ -55,17 +58,19 @@ def _populate_codegen_dir(mod, codegen_dir: str):
 
     mod_indices = {"lib": 0, "src": 0}
     host_codegen_dir = os.path.join(codegen_dir, "host")
+    lib_name = f"{module_name}_lib" if module_name else "lib"
+
     for dso_mod in dso_modules:
         if dso_mod.type_key == "c":
             index = mod_indices["src"]
             mod_indices["src"] += 1
             parent_dir = os.path.join(host_codegen_dir, "src")
-            file_name = os.path.join(parent_dir, f"lib{index}.c")
+            file_name = os.path.join(parent_dir, f"{lib_name}{index}.c")
         elif dso_mod.type_key == "llvm":
             index = mod_indices["lib"]
             mod_indices["lib"] += 1
             parent_dir = os.path.join(host_codegen_dir, "lib")
-            file_name = os.path.join(parent_dir, f"lib{index}.o")
+            file_name = os.path.join(parent_dir, f"{lib_name}{index}.o")
         else:
             assert (
                 False
@@ -98,7 +103,6 @@ def _build_sid_map(graph_json):
         A list with one entry per storage id describing that memory.
     """
     graph = json.loads(graph_json)
-
     seen_storage_ids = set()
     memory_map = []
     for node_id, storage_id in enumerate(graph["attrs"]["storage_id"][1]):
@@ -227,7 +231,7 @@ def export_model_library_format(mod: executor_factory.ExecutorFactoryModule, fil
     runtime = ["aot"] if is_aot else ["graph"]
 
     metadata = {
-        "version": 2,
+        "version": 3,
         "model_name": mod.libmod_name,
         "export_datetime": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%SZ"),
         "memory": _build_memory_map(mod),
@@ -240,7 +244,7 @@ def export_model_library_format(mod: executor_factory.ExecutorFactoryModule, fil
 
     codegen_dir_path = tempdir.relpath("codegen")
     os.mkdir(codegen_dir_path)
-    _populate_codegen_dir(mod.lib, codegen_dir_path)
+    _populate_codegen_dir(mod.lib, codegen_dir_path, mod.libmod_name)
 
     parameters_dir_path = tempdir.relpath("parameters")
     os.mkdir(parameters_dir_path)

--- a/python/tvm/relay/backend/compile_engine.py
+++ b/python/tvm/relay/backend/compile_engine.py
@@ -26,6 +26,7 @@ from tvm.ir.transform import PassContext
 from tvm.runtime import Object
 from tvm.support import libinfo
 from tvm.target import Target
+from ..backend.utils import mangle_module_name
 from .. import function as _function
 from .. import ty as _ty
 from . import _backend
@@ -328,7 +329,7 @@ class CompileEngine(Object):
     def __init__(self):
         raise RuntimeError("Cannot construct a CompileEngine")
 
-    def lower(self, source_func, target=None):
+    def lower(self, source_func, target=None, mod_name="default"):
         """Lower a source_func to a CachedFunc.
 
         Parameters
@@ -346,8 +347,9 @@ class CompileEngine(Object):
         """
         # pylint: disable=broad-except, import-outside-toplevel
         try:
+            mod_name = mangle_module_name(mod_name)
             key = _get_cache_key(source_func, target)
-            return _backend._CompileEngineLower(self, key)
+            return _backend._CompileEngineLower(self, key, mod_name)
         except Exception:
             import traceback
 

--- a/python/tvm/relay/backend/graph_executor_codegen.py
+++ b/python/tvm/relay/backend/graph_executor_codegen.py
@@ -37,6 +37,7 @@ from tvm.runtime.ndarray import empty
 from tvm.relay import _build_module
 from tvm.target import Target
 from tvm.tir import expr as _expr
+from .utils import mangle_module_name
 
 
 class GraphExecutorCodegen(object):
@@ -80,7 +81,8 @@ class GraphExecutorCodegen(object):
         params : Dict[str, tvm.nd.NDArray]
             Additional constant parameters.
         """
-        self._codegen(func)
+        default_mod_name = mangle_module_name("default")
+        self._codegen(func, default_mod_name)
         graph_json = self._get_graph_json()
         lowered_func = self._get_irmodule()
         param_names = self._list_params_name()

--- a/python/tvm/relay/backend/utils.py
+++ b/python/tvm/relay/backend/utils.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utility backend functions."""
+
+
+def _is_valid_modname(mod_name):
+    """Determine if mod_name is a valid string to use inside function names"""
+    if mod_name:
+        try:
+            mod_name.encode("ascii")
+            return True
+        except UnicodeEncodeError:
+            return False
+
+    return True
+
+
+def mangle_module_name(mod_name):
+    if not _is_valid_modname(mod_name):
+        raise ValueError(mod_name + " contains invalid characters")
+    if mod_name:
+        return "tvmgen_" + mod_name
+    return "tvmgen"

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -28,6 +28,7 @@ from tvm import relay, te
 from tvm.runtime import ndarray as _nd
 
 from . import _ffi_api
+from ..backend.utils import mangle_module_name
 
 
 def build_config(opt_level=2, required_pass=None, disabled_pass=None, trace=None):
@@ -713,7 +714,7 @@ def LambdaLift():
     return _ffi_api.LambdaLift()
 
 
-def PartitionGraph():
+def PartitionGraph(mod_name="default"):
     """Partition a Relay program into regions that can be executed on different
     backends.
 
@@ -722,7 +723,8 @@ def PartitionGraph():
     ret: tvm.transform.Pass
         The registered pass that partitions the Relay program.
     """
-    return _ffi_api.PartitionGraph()
+    mod_name = mangle_module_name(mod_name)
+    return _ffi_api.PartitionGraph(mod_name)
 
 
 def AnnotateTarget(targets, include_non_call_ops=True):

--- a/src/relay/backend/compile_engine.h
+++ b/src/relay/backend/compile_engine.h
@@ -199,9 +199,10 @@ class CompileEngineNode : public Object {
   /*!
    * \brief Get lowered result.
    * \param key The key to the cached function.
+   * \param mod_name The module name to mangle the functions
    * \return The result.
    */
-  virtual CachedFunc Lower(const CCacheKey& key) = 0;
+  virtual CachedFunc Lower(const CCacheKey& key, std::function<String(String)> mangle_fn) = 0;
   /*!
    * \brief Just in time compile to get a PackedFunc.
    * \param key The key to the cached function.

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -550,7 +550,8 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
     }
 
     CCacheKey key(func, target);
-    auto cfunc = engine_->Lower(key);
+    auto mangle_fn = [](String name) { return name; };
+    auto cfunc = engine_->Lower(key, mangle_fn);
 
     auto op_index = -1;
     if (func->GetAttr<String>(attr::kCompiler).defined()) {

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -41,6 +41,14 @@
 namespace tvm {
 namespace runtime {
 
+inline String get_name_mangled(const String& module_name, const String& name) {
+  std::stringstream ss;
+  ICHECK(module_name.defined());
+  ICHECK(name.defined());
+  ss << module_name << "_" << name;
+  return ss.str();
+}
+
 /*!
  * \brief Structure that can be optionally used by the executor codegen
  */
@@ -53,6 +61,8 @@ class MetadataNode : public Object {
   /*! \brief the executor to be used to run the model */
   String executor = kTvmExecutorGraph;
 
+  String mod_name = "";
+
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "MetadataObj";
   TVM_DECLARE_FINAL_OBJECT_INFO(MetadataNode, Object);
@@ -63,11 +73,12 @@ class MetadataNode : public Object {
  */
 class Metadata : public ObjectRef {
  public:
-  TVM_DLL Metadata(int num_inputs, int num_outputs, String executor) {
+  TVM_DLL Metadata(int num_inputs, int num_outputs, String executor, String mod_name) {
     auto n = make_object<MetadataNode>();
     n->num_inputs = num_inputs;
     n->num_outputs = num_outputs;
     n->executor = executor;
+    n->mod_name = mod_name;
     data_ = std::move(n);
   }
 

--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -42,6 +42,8 @@ class CodeGenCHost final : public CodeGenC {
 
   void AddFunction(const PrimFunc& f);
 
+  void DefineModuleName();
+
   /*! \brief Add linked parameters, if they are present. */
   void DeclareParameters(Map<String, LinkedParam> params);
   void LinkParameters(Map<String, LinkedParam> params);

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -192,8 +192,8 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
           << "}\n";
   }
 
-  void GenerateEntrypointForUnpackedAPI() {
-    code_ << "TVM_DLL int32_t " << ::tvm::runtime::symbol::tvm_run_func_prefix << "(";
+  void GenerateEntrypointForUnpackedAPI(const std::string& run_func) {
+    code_ << "TVM_DLL int32_t " << run_func << "(";
     int total_args = (metadata_->num_inputs + metadata_->num_outputs);
     for (int i = 0; i < total_args; ++i) {
       code_ << "arg" << i;
@@ -205,7 +205,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     code_ << "static int32_t " << ::tvm::runtime::symbol::tvm_module_main;
     code_ << "(void* args, void* type_code, int num_args, void* out_value, void* "
              "out_type_code, void* resource_handle) {\n";
-    code_ << "return " << ::tvm::runtime::symbol::tvm_run_func_prefix << "(";
+    code_ << "return " << run_func << "(";
     for (int i = 0; i < metadata_->num_inputs; ++i) {
       code_ << "((DLTensor*)(((TVMValue*)args)[" << i << "].v_handle))[0].data,";
     }
@@ -220,30 +220,33 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     code_ << "}\n";
   }
 
-  void GenerateEntrypointForPackedAPI() {
-    code_ << "TVM_DLL int32_t " << ::tvm::runtime::symbol::tvm_run_func_prefix;
+  void GenerateEntrypointForPackedAPI(const std::string& run_func) {
+    code_ << "TVM_DLL int32_t " << run_func;
     code_ << "(void* args, void* type_code, int num_args, void* out_value, void* "
              "out_type_code, void* resource_handle);\n";
     code_ << "static int32_t " << ::tvm::runtime::symbol::tvm_module_main;
     code_ << "(void* args, void* type_code, int num_args, void* out_value, void* "
              "out_type_code, void* resource_handle) {\n";
-    code_ << "return " << ::tvm::runtime::symbol::tvm_run_func_prefix;
+    code_ << "return " << run_func;
     code_ << "(args, type_code, num_args, out_value, out_type_code, resource_handle);\n";
     code_ << "}\n";
   }
 
   void GenerateAOTDescriptor() {
+    const std::string run_func = ::tvm::runtime::symbol::tvm_run_func_suffix;
+    const std::string run_func_mangled = runtime::get_name_mangled(metadata_->mod_name, run_func);
+    const std::string network_mangled = runtime::get_name_mangled(metadata_->mod_name, "network");
     code_ << "#include \"tvm/runtime/crt/internal/aot_executor/aot_executor.h\"\n";
     code_ << "#include \"tvm/runtime/c_runtime_api.h\"\n";
     code_ << "#ifdef __cplusplus\n";
     code_ << "extern \"C\"\n";
     code_ << "#endif\n";
     if (target_->GetAttr<Bool>("unpacked-api").value_or(Bool(false))) {
-      GenerateEntrypointForUnpackedAPI();
+      GenerateEntrypointForUnpackedAPI(run_func_mangled);
     } else {
-      GenerateEntrypointForPackedAPI();
+      GenerateEntrypointForPackedAPI(run_func_mangled);
     }
-    code_ << "const tvm_model_t network = {\n"
+    code_ << "const tvm_model_t " << network_mangled << " = {\n"
           << "    .run_func = &" << ::tvm::runtime::symbol::tvm_module_main << ",\n"
           << "    .num_input_tensors = " << metadata_->num_inputs << ",\n"
           << "    .num_output_tensors = " << metadata_->num_outputs << ", \n"

--- a/tests/cpp/microtvm_runtime_standalone_test.cc
+++ b/tests/cpp/microtvm_runtime_standalone_test.cc
@@ -92,7 +92,7 @@ TEST(MicroStandaloneRuntime, BuildModule) {
 
   Target llvm_tgt = Target("llvm");
   targets.Set(0, llvm_tgt);
-  build_f(func, targets, llvm_tgt, runtime::kTvmExecutorGraph);
+  build_f(func, targets, llvm_tgt, runtime::kTvmExecutorGraph, "");
   std::string json = json_f();
   tvm::runtime::Module mod = mod_f();
   std::string o_fname = std::tmpnam(nullptr);

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -120,7 +120,7 @@ TEST(Relay, BuildModule) {
   targets.Set(0, llvm_tgt);
   auto relay_mod = tvm::IRModule::FromExpr(func);
   ICHECK(relay_mod.defined()) << "Module must be defined";
-  build_f(relay_mod, targets, llvm_tgt, runtime::kTvmExecutorGraph);
+  build_f(relay_mod, targets, llvm_tgt, runtime::kTvmExecutorGraph, "");
   std::string json = json_f();
   tvm::runtime::Module mod = mod_f();
   // run

--- a/tests/python/contrib/test_bnns/test_conv2d_patterns.py
+++ b/tests/python/contrib/test_bnns/test_conv2d_patterns.py
@@ -57,7 +57,7 @@ def test_pattern_conv2d_with_bias_add():
         res = relay.nn.bias_add(res, b, axis=axis)
 
         mod = partition(res)
-        bias_is_fused = is_op_fused(mod["bnns_0"], "nn.bias_add")
+        bias_is_fused = is_op_fused(mod["tvmgen_default_bnns_0"], "nn.bias_add")
 
         assert bias_is_fused if axis == 1 else not bias_is_fused
 
@@ -73,7 +73,7 @@ def test_pattern_conv2d_with_add():
         res = relay.add(res, b)
 
         mod = partition(res)
-        bias_is_fused = is_op_fused(mod["bnns_0"], "add")
+        bias_is_fused = is_op_fused(mod["tvmgen_default_bnns_0"], "add")
 
         assert bias_is_fused == should_be_fused
 
@@ -102,6 +102,6 @@ def test_pattern_conv2d_with_non_cons_bias():
     res = relay.nn.bias_add(res, b, axis=1)
 
     mod = partition(res)
-    bias_is_fused = is_op_fused(mod["bnns_0"], "nn.bias_add")
+    bias_is_fused = is_op_fused(mod["tvmgen_default_bnns_0"], "nn.bias_add")
 
     assert not bias_is_fused

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -122,7 +122,7 @@ def test_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"bfb5a50607edb50009c58ae9d4287e4d"}
+    _compile_hash = {"5d3cee6ecc488c40ecf533c5cbacc534"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
         _compile_hash = {"896c28b4f06341ea638ead3a593e1aed"}
     if tei.get_ethosn_api_version() == 2011:
@@ -148,7 +148,7 @@ def test_inception_v3():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"96116d7e6c7385de0688074a3f889983"}
+    _compile_hash = {"1bc66e83c3de5a9773a719b179c65b1a"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
         _compile_hash = {"551cde850c6ef960d19be4f317fb8e68"}
     if tei.get_ethosn_api_version() == 2011:
@@ -173,7 +173,7 @@ def test_inception_v4():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"b34aec2a48c591818761ed6b42c133e5"}
+    _compile_hash = {"578b8ee279911b49912a77a64f5ff620"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
         _compile_hash = {"30f078bd42757e8686eafa1f28d0d352"}
     if tei.get_ethosn_api_version() == 2011:
@@ -198,7 +198,7 @@ def test_ssd_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"c312edfc9a946ed4dc7c049d472dae6e", "3183f0fa5eba8f6b9557d14eaf47842d"}
+    _compile_hash = {"cd335229a2052f30273f127a233bd319", "95dedc29d911cdc6b28207ca08e42470"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
         _compile_hash = {"deee52e136327436411fc725624ae2ea", "6526509d3cbee014e38c79e22bb29d7f"}
     if tei.get_ethosn_api_version() == 2011:

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -1183,9 +1183,9 @@ def test_dynamic_offload():
         var1 = relay.var("tensorrt_0_i0", shape=(data_shape), dtype="float32")
         kernel_trt = relay.var("tensorrt_0_i1", shape=(k_shape), dtype="float32")
         out1 = relay.nn.conv2d(var1, kernel_trt, channels=k_shape[0], kernel_size=k_shape[2:4])
-        f1 = GlobalVar("tensorrt_0")
+        f1 = GlobalVar("tvmgen_default_tensorrt_0")
         func = relay.Function([var1, kernel_trt], out1)
-        func = set_func_attr(func, "tensorrt", "tensorrt_0")
+        func = set_func_attr(func, "tensorrt", "tvmgen_default_tensorrt_0")
         mod[f1] = func
         mod = relay.transform.InferType()(mod)
 
@@ -1408,7 +1408,7 @@ def test_empty_subgraph():
     var1 = relay.var("tensorrt_0_i0", shape=(x_shape), dtype="float32")
     f1 = GlobalVar("tensorrt_0")
     func = relay.Function([var1], var1)
-    func = set_func_attr(func, "tensorrt", "tensorrt_0")
+    func = set_func_attr(func, "tensorrt", "tvmgen_default_tensorrt_0")
     mod[f1] = func
     mod = relay.transform.InferType()(mod)
 

--- a/tests/python/contrib/test_vitis_ai/test_vitis_ai_codegen.py
+++ b/tests/python/contrib/test_vitis_ai/test_vitis_ai_codegen.py
@@ -269,7 +269,6 @@ def test_annotate():
 
         with tvm.transform.PassContext(opt_level=3):
             mod = opt_pass(mod)
-
         return mod
 
     def expected():
@@ -289,8 +288,8 @@ def test_annotate():
         func0 = relay.Function(
             [data0, weight0, bn_gamma0, bn_beta0, bn_mmean0, bn_mvar0], bn.astuple()
         )
-        func0 = set_func_attr(func0, "vitis_ai", "vitis_ai_0")
-        gv0 = relay.GlobalVar("vitis_ai_0")
+        func0 = set_func_attr(func0, "vitis_ai", "tvmgen_default_vitis_ai_0")
+        gv0 = relay.GlobalVar("tvmgen_default_vitis_ai_0")
         mod = tvm.IRModule()
         mod[gv0] = func0
         mod = relay.transform.InferType()(mod)

--- a/tests/python/relay/aot/aot_test.mk
+++ b/tests/python/relay/aot/aot_test.mk
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# Makefile to build ethosu_test_runner
 # Setup build environment
 #
 AOT_ROOT ?= $(TVM_ROOT)/src/runtime/crt/aot
@@ -47,7 +46,7 @@ CRT_SRCS = $(shell find $(CRT_ROOT))
 
 aot_test_runner: $(build_dir)/aot_test_runner
 
-source_libs= $(wildcard $(build_dir)/../codegen/host/src/lib*.c)
+source_libs= $(wildcard $(build_dir)/../codegen/host/src/*.c)
 lib_objs =$(source_libs:.c=.o) 
 
 $(build_dir)/aot_test_runner: $(build_dir)/test.c  $(build_dir)/aot_executor.o  $(source_libs) $(build_dir)/stack_allocator.o $(build_dir)/crt_backend_api.o

--- a/tests/python/relay/test_json_runtime.py
+++ b/tests/python/relay/test_json_runtime.py
@@ -104,8 +104,8 @@ def test_conv2d():
         out = relay.nn.conv2d(data0, weight0, kernel_size=(3, 3), padding=(1, 1))
 
         func = relay.Function([data0, weight0], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -139,8 +139,8 @@ def test_conv2d():
         out = relay.nn.conv2d(data0, weight0, kernel_size=(3, 3), padding=(1, 1), groups=32)
 
         func = relay.Function([data0, weight0], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -183,8 +183,8 @@ def test_add():
         out = relay.add(data0, data1)
 
         func = relay.Function([data0, data1], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -226,8 +226,8 @@ def test_relu():
         out = relay.nn.relu(data0)
 
         func = relay.Function([data0], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -276,8 +276,8 @@ def test_dense():
         out = relay.nn.dense(a, b)
 
         func = relay.Function([a, b], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -325,8 +325,8 @@ def test_bn():
         out = bn[0]
 
         func = relay.Function([data, gamma, beta, moving_mean, moving_var], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -471,8 +471,8 @@ def test_composite():
         arg_2 = relay.var("arg_2", shape=w1shape, dtype=dtype)
         call = relay.Call(func, [arg_1, arg_2])
         p_func = relay.Function([arg_1, arg_2], call)
-        p_func = set_func_attr(p_func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        p_func = set_func_attr(p_func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = p_func
         mod = transform.InferType()(mod)
@@ -521,8 +521,8 @@ def test_composite():
         arg_3 = relay.var("arg_3", shape=bshape, dtype=dtype)
         call = relay.Call(func, [arg_1, arg_2, arg_3])
         p_func = relay.Function([arg_1, arg_2, arg_3], call)
-        p_func = set_func_attr(p_func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        p_func = set_func_attr(p_func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = p_func
         mod = transform.InferType()(mod)

--- a/tests/python/relay/test_name_mangling.py
+++ b/tests/python/relay/test_name_mangling.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+import tvm
+import tvm.testing
+import tvm.relay as relay
+import tvm.relay.backend.utils as utils
+import pytest
+
+
+def test_mangle_mod_name():
+    assert utils.mangle_module_name("default") == "tvmgen_default"
+    assert utils.mangle_module_name("ccompiler") == "tvmgen_ccompiler"
+    assert utils.mangle_module_name("1234"), "tvmgen_1234"
+    assert utils.mangle_module_name(""), "tvmgen"
+    assert utils.mangle_module_name(None), "tvmgen"
+
+    with pytest.raises(ValueError):
+        utils.mangle_module_name("\u018e")
+        utils.mangle_module_name("\xf1")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relay/test_op_fast_math.py
+++ b/tests/python/relay/test_op_fast_math.py
@@ -41,7 +41,7 @@ def test_fastmath(target, dev):
             graph, lib, params = relay.build(mod, target=target, params=None)
 
         # Check that the op related to fast math have been convered to function in lib
-        func_name = "fused_" + name
+        func_name = "tvmgen_default_fused_" + name
         # When there're multiple targets in tvm.testing.parametrize_targets, the function
         # built will have a "_1" in function name
         assert func_name in graph

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -339,8 +339,8 @@ def test_extern_ccompiler_default_ops():
         add = x0 + y0
         # Function that uses C compiler
         func = relay.Function([x0, y0], add)
-        func = set_func_attr(func, "ccompiler", "ccompiler_0")
-        glb_0 = relay.GlobalVar("ccompiler_0")
+        func = set_func_attr(func, "ccompiler", "tvmgen_default_ccompiler_0")
+        glb_0 = relay.GlobalVar("tvmgen_default_ccompiler_0")
         mod[glb_0] = func
         add_call = relay.Call(glb_0, [x, y])
         # Function that uses default compiler. Ops are fused in this function.
@@ -416,8 +416,8 @@ def test_extern_dnnl():
         out = relay.add(depthwise_conv2d_1, depthwise_conv2d_2)
 
         func = relay.Function([data0, input0], out)
-        func = set_func_attr(func, "dnnl", "dnnl_0")
-        glb_var = relay.GlobalVar("dnnl_0")
+        func = set_func_attr(func, "dnnl", "tvmgen_default_dnnl_0")
+        glb_var = relay.GlobalVar("tvmgen_default_dnnl_0")
         mod = tvm.IRModule()
         mod[glb_var] = func
         mod = transform.InferType()(mod)
@@ -532,8 +532,8 @@ def test_function_lifting():
 
         bn = relay.nn.batch_norm(data0, bn_gamma, bn_beta, bn_mmean, bn_mvar)
         func0 = relay.Function([data0, bn_gamma, bn_beta, bn_mmean, bn_mvar], bn.astuple())
-        func0 = set_func_attr(func0, "test_compiler", "test_compiler_2")
-        gv0 = relay.GlobalVar("test_compiler_2")
+        func0 = set_func_attr(func0, "test_compiler", "tvmgen_default_test_compiler_2")
+        gv0 = relay.GlobalVar("tvmgen_default_test_compiler_2")
         mod[gv0] = func0
         mod = transform.InferType()(mod)
 
@@ -544,8 +544,8 @@ def test_function_lifting():
             data=data1, weight=weight1, kernel_size=(3, 3), channels=16, padding=(1, 1)
         )
         func1 = relay.Function([data1, weight1], conv)
-        func1 = set_func_attr(func1, "test_compiler", "test_compiler_0")
-        gv1 = relay.GlobalVar("test_compiler_0")
+        func1 = set_func_attr(func1, "test_compiler", "tvmgen_default_test_compiler_0")
+        gv1 = relay.GlobalVar("tvmgen_default_test_compiler_0")
         mod[gv1] = func1
         mod = transform.InferType()(mod)
 
@@ -613,7 +613,7 @@ def test_function_lifting_inline():
 
         bn = relay.nn.batch_norm(data0, bn_gamma, bn_beta, bn_mmean, bn_mvar)
         func0 = relay.Function([data0, bn_gamma, bn_beta, bn_mmean, bn_mvar], bn.astuple())
-        func0 = set_func_attr(func0, "test_compiler", "test_compiler_0")
+        func0 = set_func_attr(func0, "test_compiler", "tvmgen_default_test_compiler_0")
 
         # main function
         data = relay.var("data", relay.TensorType((1, 16, 224, 224), "float32"))
@@ -643,8 +643,8 @@ def test_constant_propagation():
         add = x0 + y0
         # Function that uses C compiler
         func = relay.Function([y0], add)
-        func = set_func_attr(func, "ccompiler", "ccompiler_0")
-        glb_0 = relay.GlobalVar("ccompiler_0")
+        func = set_func_attr(func, "ccompiler", "tvmgen_default_ccompiler_0")
+        glb_0 = relay.GlobalVar("tvmgen_default_ccompiler_0")
         mod[glb_0] = func
         mod = relay.transform.InferType()(mod)
         add_call = relay.Call(glb_0, [y])
@@ -733,8 +733,8 @@ def test_multiple_outputs():
         tuple_o = relay.Tuple((relu_o, bn_o[1], bn_o[2]))
 
         func0 = relay.Function([data, weight, bn_gamma, bn_beta, bn_mean, bn_var], tuple_o)
-        func0 = set_func_attr(func0, "test_target", "test_target_0")
-        gv0 = relay.GlobalVar("test_target_0")
+        func0 = set_func_attr(func0, "test_target", "tvmgen_default_test_target_0")
+        gv0 = relay.GlobalVar("tvmgen_default_test_target_0")
         mod[gv0] = func0
         mod = relay.transform.InferType()(mod)
 
@@ -796,8 +796,8 @@ def test_mixed_single_multiple_outputs():
         f1_O_2 = relay.nn.relu(f1_O_1)
         f1_out = relay.Tuple((f1_O_2, f1_O_1))
         func1 = relay.Function([f1_cb1], f1_out)
-        func1 = set_func_attr(func1, "test_target", "test_target_0")
-        gv1 = relay.GlobalVar("test_target_0")
+        func1 = set_func_attr(func1, "test_target", "tvmgen_default_test_target_0")
+        gv1 = relay.GlobalVar("tvmgen_default_test_target_0")
         mod[gv1] = func1
         mod = relay.transform.InferType()(mod)
 
@@ -806,8 +806,8 @@ def test_mixed_single_multiple_outputs():
         f2_cb4 = relay.var("test_target_1_i1", shape=(10, 10))
         f2_O_3 = relay.add(f2_cb3, f2_cb4)
         func0 = relay.Function([f2_cb3, f2_cb4], f2_O_3)
-        func0 = set_func_attr(func0, "test_target", "test_target_1")
-        gv0 = relay.GlobalVar("test_target_1")
+        func0 = set_func_attr(func0, "test_target", "tvmgen_default_test_target_1")
+        gv0 = relay.GlobalVar("tvmgen_default_test_target_1")
         mod[gv0] = func0
         mod = relay.transform.InferType()(mod)
 
@@ -955,8 +955,8 @@ def test_multiple_use_of_an_output():
         mul = log * sub
         # The partitioned graph contains log, subtract, and multiply
         func = relay.Function([x0, y0], mul)
-        func = set_func_attr(func, "ccompiler", "ccompiler_0")
-        glb_0 = relay.GlobalVar("ccompiler_0")
+        func = set_func_attr(func, "ccompiler", "tvmgen_default_ccompiler_0")
+        glb_0 = relay.GlobalVar("tvmgen_default_ccompiler_0")
         mod[glb_0] = func
         mod = transform.InferType()(mod)
 
@@ -977,8 +977,8 @@ def test_multiple_use_of_an_output():
         i0 = relay.var("i0", shape=(8, 8))
         log = relay.log(i0)
         func = relay.Function([i0], log)
-        func = set_func_attr(func, "ccompiler", "ccompiler_0")
-        glb_0 = relay.GlobalVar("ccompiler_0")
+        func = set_func_attr(func, "ccompiler", "tvmgen_default_ccompiler_0")
+        glb_0 = relay.GlobalVar("tvmgen_default_ccompiler_0")
         mod[glb_0] = func
         mod = transform.InferType()(mod)
 
@@ -987,8 +987,8 @@ def test_multiple_use_of_an_output():
         y0 = relay.var("y0", shape=(8, 8))
         sub = x0 - y0
         func = relay.Function([x0, y0], sub)
-        func = set_func_attr(func, "ccompiler", "ccompiler_1")
-        glb_1 = relay.GlobalVar("ccompiler_1")
+        func = set_func_attr(func, "ccompiler", "tvmgen_default_ccompiler_1")
+        glb_1 = relay.GlobalVar("tvmgen_default_ccompiler_1")
         mod[glb_1] = func
         mod = transform.InferType()(mod)
 
@@ -1063,8 +1063,8 @@ def test_duplicate_outputs():
         func0 = func0.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
         func0 = func0.with_attr("Inline", tvm.tir.IntImm("int32", 1))
         func0 = func0.with_attr("Compiler", target)
-        func0 = func0.with_attr("global_symbol", target + "_0")
-        gv0 = relay.GlobalVar(target + "_0")
+        func0 = func0.with_attr("global_symbol", "tvmgen_default_" + target + "_0")
+        gv0 = relay.GlobalVar("tvmgen_default_" + target + "_0")
         mod[gv0] = func0
         mod = transform.InferType()(mod)
 
@@ -1140,8 +1140,8 @@ def test_duplicate_merge_and_tuplegetitem():
         func0 = func0.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
         func0 = func0.with_attr("Inline", tvm.tir.IntImm("int32", 1))
         func0 = func0.with_attr("Compiler", target)
-        func0 = func0.with_attr("global_symbol", target + "_0")
-        gv0 = relay.GlobalVar(target + "_0")
+        func0 = func0.with_attr("global_symbol", "tvmgen_default_" + target + "_0")
+        gv0 = relay.GlobalVar("tvmgen_default_" + target + "_0")
         mod[gv0] = func0
         mod = transform.InferType()(mod)
 
@@ -1216,7 +1216,7 @@ def test_constant_tuples():
 
     partitioned = seq(create_graph())
 
-    concat = partitioned["const_tuples_0"].body
+    concat = partitioned["tvmgen_default_const_tuples_0"].body
     assert type(concat.args[1]) == relay.Tuple
     assert type(concat.args[2]) == relay.Tuple
     assert type(concat.args[3]) == relay.Constant
@@ -1266,8 +1266,8 @@ def test_flatten_tuple_output():
         func0 = func0.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
         func0 = func0.with_attr("Inline", tvm.tir.IntImm("int32", 1))
         func0 = func0.with_attr("Compiler", target)
-        func0 = func0.with_attr("global_symbol", target + "_0")
-        gv0 = relay.GlobalVar(target + "_0")
+        func0 = func0.with_attr("global_symbol", "tvmgen_default_" + target + "_0")
+        gv0 = relay.GlobalVar("tvmgen_default_" + target + "_0")
         mod[gv0] = func0
         mod = transform.InferType()(mod)
 
@@ -1349,7 +1349,7 @@ def test_extern_opt():
     mod = transform.PartitionGraph()(mod)
 
     try:
-        t0 = mod["test_target_0"]
+        t0 = mod["tvmgen_default_test_target_0"]
     except:
         raise KeyError("test_target_0 not found")
 

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -85,7 +85,7 @@ def test_export_model_library_format_c(target):
 
         with open(os.path.join(extract_dir, "metadata.json")) as json_f:
             metadata = json.load(json_f)
-            assert metadata["version"] == 2
+            assert metadata["version"] == 3
             assert metadata["model_name"] == "add"
             export_datetime = datetime.datetime.strptime(
                 metadata["export_datetime"], "%Y-%m-%d %H:%M:%SZ"
@@ -115,8 +115,8 @@ def test_export_model_library_format_c(target):
                 in metadata["memory"]["functions"]["operator_functions"][0]["function_name"]
             )
 
-        assert os.path.exists(os.path.join(extract_dir, "codegen", "host", "src", "lib0.c"))
-        assert os.path.exists(os.path.join(extract_dir, "codegen", "host", "src", "lib1.c"))
+        assert os.path.exists(os.path.join(extract_dir, "codegen", "host", "src", "add_lib0.c"))
+        assert os.path.exists(os.path.join(extract_dir, "codegen", "host", "src", "add_lib1.c"))
 
         if executor == "graph":
             validate_graph_json(extract_dir, factory)
@@ -165,7 +165,7 @@ def test_export_model_library_format_llvm():
 
         with open(os.path.join(extract_dir, "metadata.json")) as json_f:
             metadata = json.load(json_f)
-            assert metadata["version"] == 2
+            assert metadata["version"] == 3
             assert metadata["model_name"] == "add"
             export_datetime = datetime.datetime.strptime(
                 metadata["export_datetime"], "%Y-%m-%d %H:%M:%SZ"
@@ -194,7 +194,7 @@ def test_export_model_library_format_llvm():
                 in metadata["memory"]["functions"]["operator_functions"][0]["function_name"]
             )
 
-        assert os.path.exists(os.path.join(extract_dir, "codegen", "host", "lib", "lib0.o"))
+        assert os.path.exists(os.path.join(extract_dir, "codegen", "host", "lib", "add_lib0.o"))
 
         validate_graph_json(extract_dir, factory)
 
@@ -244,7 +244,7 @@ def test_export_model_library_format_workspace(target):
 
     with open(os.path.join(extract_dir, "metadata.json")) as json_f:
         metadata = json.load(json_f)
-        assert metadata["version"] == 2
+        assert metadata["version"] == 3
         assert metadata["model_name"] == "qnn_conv2d"
         export_datetime = datetime.datetime.strptime(
             metadata["export_datetime"], "%Y-%m-%d %H:%M:%SZ"


### PR DESCRIPTION
Mini-RFC is here: https://discuss.tvm.apache.org/t/mini-rfc-name-mangling-in-aot

With this change we'll mangle the name of global symbols so that we can bundle
together multiple models in the same application.

The relay.build interface has been left unchanged, which means I am
resuing mod_name as a prefix for all functions. 
* If mod_name is None then `tvmgen_` prefix is used
* If mod_name is specified then `tvmgen_mod_name_` prefix is used

I refactored the aot test utils and added some tests for multiple
models.

Change-Id: I310af75c24e422861aeaceb3c3cd4cd602071df5
