### PR TITLE
[Fix] CI QEMU Install libpython3.8

### DIFF
--- a/docker/install/ubuntu_install_qemu.sh
+++ b/docker/install/ubuntu_install_qemu.sh
@@ -47,3 +47,6 @@ cd qemu-5.1.0
 ./configure --target-list=aarch64-softmmu,arm-softmmu,i386-softmmu,riscv32-softmmu,riscv64-softmmu,x86_64-softmmu
 make -j2
 sudo make install
+
+# For debugging with qemu
+apt-get install libpython3.8

--- a/docker/install/ubuntu_install_qemu.sh
+++ b/docker/install/ubuntu_install_qemu.sh
@@ -49,4 +49,4 @@ make -j2
 sudo make install
 
 # For debugging with qemu
-apt-get install libpython3.8
+apt-get -y install libpython3.8


### PR DESCRIPTION
The microtvm debug shell fails without `libpython3.8` when you test it with QEMU.
I have built the ci_qemu with these changes and it passes `test_zephyr.py`.