### PR TITLE
lower case spell errors in tutorials

### DIFF
--- a/tutorials/get_started/autotvm_matmul.py
+++ b/tutorials/get_started/autotvm_matmul.py
@@ -86,7 +86,7 @@ from tvm import autotvm
 
 def matmul_basic(N, L, M, dtype):
 
-    a = te.placeholder((n, l), name="a", dtype=dtype)
+    a = te.placeholder((N, L), name="a", dtype=dtype)
     B = te.placeholder((L, M), name="B", dtype=dtype)
 
     k = te.reduce_axis((0, L), name="k")


### PR DESCRIPTION
When I read documents (get_started in tutorials), I find out two lower case errors in https://tvm.apache.org/docs/tutorials/get_started/autotvm_matmul.html#sphx-glr-tutorials-get-started-autotvm-matmul-py . It may cause compile erros in python and needs to fix. So I find its source code in tvm.