### PR TITLE
Change a, n, l to A, N, L in tutorials/get_started/autotvm_matmul.py

### DIFF
--- a/tutorials/get_started/autotvm_matmul.py
+++ b/tutorials/get_started/autotvm_matmul.py
@@ -86,7 +86,7 @@ from tvm import autotvm
 
 def matmul_basic(N, L, M, dtype):
 
-    a = te.placeholder((n, l), name="a", dtype=dtype)
+    A = te.placeholder((N, L), name="A", dtype=dtype)
     B = te.placeholder((L, M), name="B", dtype=dtype)
 
     k = te.reduce_axis((0, L), name="k")


### PR DESCRIPTION
When I read docuemnts in https://tvm.apache.org/docs/tutorials/get_started/autotvm_matmul.html#sphx-glr-tutorials-get-started-autotvm-matmul-py, I find a lower case errors. To compile correctly in Python, we need to change change a, n, l to A, N, L.
