### PR TITLE
Rename gpu to cuda, and bump dlpack to v0.5

### DIFF
--- a/apps/topi_recipe/broadcast/test_broadcast_map.py
+++ b/apps/topi_recipe/broadcast/test_broadcast_map.py
@@ -65,8 +65,8 @@ def test_broadcast_to(in_shape, out_shape):
     data_npy = np.random.uniform(size=in_shape).astype(A.dtype)
     out_npy = np.broadcast_to(data_npy, out_shape)
 
-    data_nd = tvm.nd.array(data_npy, tvm.gpu())
-    out_nd = tvm.nd.array(np.empty(out_shape).astype(B.dtype), tvm.gpu())
+    data_nd = tvm.nd.array(data_npy, tvm.cuda())
+    out_nd = tvm.nd.array(np.empty(out_shape).astype(B.dtype), tvm.cuda())
     for _ in range(2):
         fcuda(data_nd, out_nd)
     tvm.testing.assert_allclose(out_nd.asnumpy(), out_npy)
@@ -116,9 +116,9 @@ def test_broadcast_binary_op(lhs_shape, rhs_shape, typ="add"):
         out_npy = np.maximum(lhs_npy, rhs_npy)
     elif typ == "minimum":
         out_npy = np.minimum(lhs_npy, rhs_npy)
-    lhs_nd = tvm.nd.array(lhs_npy, tvm.gpu())
-    rhs_nd = tvm.nd.array(rhs_npy, tvm.gpu())
-    out_nd = tvm.nd.array(np.empty(out_npy.shape).astype(B.dtype), tvm.gpu())
+    lhs_nd = tvm.nd.array(lhs_npy, tvm.cuda())
+    rhs_nd = tvm.nd.array(rhs_npy, tvm.cuda())
+    out_nd = tvm.nd.array(np.empty(out_npy.shape).astype(B.dtype), tvm.cuda())
     for _ in range(2):
         fcuda(lhs_nd, rhs_nd, out_nd)
     tvm.testing.assert_allclose(out_nd.asnumpy(), out_npy)

--- a/apps/topi_recipe/reduce/test_reduce_map.py
+++ b/apps/topi_recipe/reduce/test_reduce_map.py
@@ -78,8 +78,8 @@ def test_reduce_map(in_shape, axis, keepdims, type="sum", test_id=0):
     else:
         raise NotImplementedError
 
-    data_tvm = tvm.nd.array(in_npy, device=tvm.gpu())
-    out_tvm = tvm.nd.empty(shape=out_npy.shape, device=tvm.gpu())
+    data_tvm = tvm.nd.array(in_npy, device=tvm.cuda())
+    out_tvm = tvm.nd.empty(shape=out_npy.shape, device=tvm.cuda())
 
     for _ in range(2):
         fcuda(data_tvm, out_tvm)

--- a/apps/topi_recipe/rnn/lstm.py
+++ b/apps/topi_recipe/rnn/lstm.py
@@ -171,7 +171,7 @@ def lstm():
     def check_device(target):
         num_step = n_num_step
         flstm = tvm.build(s, [Xi2h, Wh2h, scan_h, scan_c], target)
-        dev = tvm.gpu(0) if target == "cuda" else tvm.cl(0)
+        dev = tvm.cuda(0) if target == "cuda" else tvm.cl(0)
         # launch the kernel.
         scan_h_np = np.zeros((num_step, batch_size, num_hidden)).astype("float32")
         scan_c_np = np.zeros((num_step, batch_size, num_hidden)).astype("float32")

--- a/apps/topi_recipe/rnn/matexp.py
+++ b/apps/topi_recipe/rnn/matexp.py
@@ -140,7 +140,7 @@ def rnn_matexp():
             }
         ):
             f = tvm.build(s, [s_scan, Whh], target)
-        dev = tvm.gpu(0) if target == "cuda" else tvm.cl(0)
+        dev = tvm.cuda(0) if target == "cuda" else tvm.cl(0)
         # launch the kernel.
         res_np = np.zeros((n_num_step, n_batch_size, n_num_hidden)).astype("float32")
         Whh_np = np.zeros((n_num_hidden, n_num_hidden)).astype("float32")
@@ -160,16 +160,16 @@ def rnn_matexp():
         print("Time cost=%g" % tgap)
         # correctness
         if not SKIP_CHECK:
-            res_gpu = res_a.asnumpy()
+            res_cuda = res_a.asnumpy()
             res_cmp = np.ones_like(res_np).astype("float64")
             Whh_np = Whh_np.astype("float64")
             for t in range(1, n_num_step):
                 res_cmp[t][:] = np.dot(res_cmp[t - 1], Whh_np)
             for i in range(n_num_step):
                 for j in range(n_num_hidden):
-                    if abs(res_cmp[i, 0, j] - res_gpu[i, 0, j]) > 1e-5:
-                        print("%d, %d: %g vs %g" % (i, j, res_cmp[i, 0, j], res_gpu[i, 0, j]))
-            tvm.testing.assert_allclose(res_gpu, res_cmp, rtol=1e-3)
+                    if abs(res_cmp[i, 0, j] - res_cuda[i, 0, j]) > 1e-5:
+                        print("%d, %d: %g vs %g" % (i, j, res_cmp[i, 0, j], res_cuda[i, 0, j]))
+            tvm.testing.assert_allclose(res_cuda, res_cmp, rtol=1e-3)
 
     check_device("cuda")
 

--- a/docs/deploy/tensorrt.rst
+++ b/docs/deploy/tensorrt.rst
@@ -124,7 +124,7 @@ have to be built.
 
 .. code:: python
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     loaded_lib = tvm.runtime.load_module('compiled.so')
     gen_module = tvm.contrib.graph_executor.GraphModule(loaded_lib['default'](dev))
     input_data = np.random.uniform(0, 1, input_shape).astype(dtype)

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -144,7 +144,7 @@ The main goal of TVM's runtime is to provide a minimal API for loading and execu
     import tvm
     # Example runtime execution program in python, with type annotated
     mod: tvm.runtime.Module = tvm.runtime.load_module("compiled_artifact.so")
-    arr: tvm.runtime.NDArray = tvm.nd.array([1, 2, 3], device=tvm.gpu(0))
+    arr: tvm.runtime.NDArray = tvm.nd.array([1, 2, 3], device=tvm.cuda(0))
     fun: tvm.runtime.PackedFunc = mod["addone"]
     fun(a)
     print(a.asnumpy())
@@ -164,8 +164,8 @@ The above example only deals with a simple `addone` function. The code snippet b
    import tvm
    # Example runtime execution program in python, with types annotated
    factory: tvm.runtime.Module = tvm.runtime.load_module("resnet18.so")
-   # Create a stateful graph execution module for resnet18 on gpu(0)
-   gmod: tvm.runtime.Module = factory["resnet18"](tvm.gpu(0))
+   # Create a stateful graph execution module for resnet18 on cuda(0)
+   gmod: tvm.runtime.Module = factory["resnet18"](tvm.cuda(0))
    data: tvm.runtime.NDArray = get_input_data()
    # set input
    gmod["set_input"](0, data)

--- a/golang/src/device.go
+++ b/golang/src/device.go
@@ -61,13 +61,13 @@ func CPU(index int32) Device {
     return Device{KDLCPU, index}
 }
 
-// GPU returns the Device object for GPU target on given index
-func GPU(index int32) Device {
+// CUDA returns the Device object for CUDA target on given index
+func CUDA(index int32) Device {
     return Device{kDLCUDA, index}
 }
 
-// CPUPinned returns the Device object for CPUPinned target on given index
-func CPUPinned(index int32) Device {
+// CUDAHost returns the Device object for CUDAHost target on given index
+func CUDAHost(index int32) Device {
     return Device{kDLCUDAHost, index}
 }
 

--- a/golang/src/device.go
+++ b/golang/src/device.go
@@ -29,10 +29,10 @@ import "C"
 
 // KDLCPU is golang enum correspond to TVM device type kDLCPU.
 var KDLCPU                  = int32(C.kDLCPU)
-// KDLGPU is golang enum correspond to TVM device type kDLGPU.
-var KDLGPU                  = int32(C.kDLGPU)
-// KDLCPUPinned is golang enum correspond to TVM device type kDLCPUPinned.
-var KDLCPUPinned            = int32(C.kDLCPUPinned)
+// kDLCUDA is golang enum correspond to TVM device type kDLCUDA.
+var kDLCUDA                  = int32(C.kDLCUDA)
+// kDLCUDAHost is golang enum correspond to TVM device type kDLCUDAHost.
+var kDLCUDAHost            = int32(C.kDLCUDAHost)
 // KDLOpenCL is golang enum correspond to TVM device type kDLOpenCL.
 var KDLOpenCL               = int32(C.kDLOpenCL)
 // KDLMetal is golang enum correspond to TVM device type kDLMetal.
@@ -63,12 +63,12 @@ func CPU(index int32) Device {
 
 // GPU returns the Device object for GPU target on given index
 func GPU(index int32) Device {
-    return Device{KDLGPU, index}
+    return Device{kDLCUDA, index}
 }
 
 // CPUPinned returns the Device object for CPUPinned target on given index
 func CPUPinned(index int32) Device {
-    return Device{KDLCPUPinned, index}
+    return Device{kDLCUDAHost, index}
 }
 
 // OpenCL returns the Device object for OpenCL target on given index

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -231,10 +231,10 @@ inline const char* DeviceName(int type) {
   switch (type) {
     case kDLCPU:
       return "cpu";
-    case kDLGPU:
-      return "gpu";
-    case kDLCPUPinned:
-      return "cpu_pinned";
+    case kDLCUDA:
+      return "cuda";
+    case kDLCUDAHost:
+      return "cuda_host";
     case kDLOpenCL:
       return "opencl";
     case kDLSDAccel:

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -30,7 +30,7 @@ from ._ffi import register_object, register_func, register_extension, get_global
 # top-level alias
 # tvm.runtime
 from .runtime.object import Object
-from .runtime.ndarray import device, cpu, gpu, opencl, cl, vulkan, metal, mtl
+from .runtime.ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
 from .runtime.ndarray import vpi, rocm, ext_dev, micro_dev, hexagon
 from .runtime import ndarray as nd
 

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -164,7 +164,7 @@ class Device(ctypes.Structure):
     _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
     MASK2STR = {
         1: "cpu",
-        2: "gpu",
+        2: "cuda",
         4: "opencl",
         5: "aocl",
         6: "sdaccel",
@@ -182,7 +182,6 @@ class Device(ctypes.Structure):
         "stackvm": 1,
         "cpu": 1,
         "c": 1,
-        "gpu": 2,
         "cuda": 2,
         "nvptx": 2,
         "cl": 4,

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -249,8 +249,8 @@ def get_target_compute_version(target=None):
         return major + "." + minor
 
     # 3. GPU
-    if tvm.gpu(0).exist:
-        return tvm.gpu(0).compute_version
+    if tvm.cuda(0).exist:
+        return tvm.cuda(0).compute_version
 
     warnings.warn(
         "No CUDA architecture was specified or GPU detected."
@@ -331,8 +331,8 @@ def have_tensorcore(compute_version=None, target=None):
         isn't specified.
     """
     if compute_version is None:
-        if tvm.gpu(0).exist:
-            compute_version = tvm.gpu(0).compute_version
+        if tvm.cuda(0).exist:
+            compute_version = tvm.cuda(0).compute_version
         else:
             if target is None or "arch" not in target.attrs:
                 warnings.warn(

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -26,7 +26,7 @@ from .profiling import Report
 
 # function exposures
 from .object_generic import convert_to_object, convert, const
-from .ndarray import device, cpu, gpu, opencl, cl, vulkan, metal, mtl
+from .ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
 from .ndarray import vpi, rocm, ext_dev, micro_dev
 from .module import load_module, enabled, system_lib
 from .container import String

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name, unused-import, redefined-outer-name
 """Runtime NDArray API"""
 import ctypes
+import warnings
 import numpy as np
 import tvm._ffi
 
@@ -254,8 +255,7 @@ def device(dev_type, dev_id=0):
     .. code-block:: python
 
       assert tvm.device("cpu", 1) == tvm.cpu(1)
-      assert tvm.device("gpu", 0) == tvm.gpu(0)
-      assert tvm.device("cuda", 0) == tvm.gpu(0)
+      assert tvm.device("cuda", 0) == tvm.cuda(0)
     """
     if isinstance(dev_type, string_types):
         if "-device=micro_dev" in dev_type:
@@ -362,8 +362,8 @@ def cpu(dev_id=0):
     return Device(1, dev_id)
 
 
-def gpu(dev_id=0):
-    """Construct a GPU device
+def cuda(dev_id=0):
+    """Construct a CUDA GPU device
 
     Parameters
     ----------
@@ -375,6 +375,27 @@ def gpu(dev_id=0):
     dev : Device
         The created device
     """
+    return Device(2, dev_id)
+
+
+def gpu(dev_id=0):
+    """Construct a CUDA GPU device
+
+        deprecated:: 0.9.0
+        Use :py:func:`tvm.cuda` instead.
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    warnings.warn(
+        "Please use tvm.cuda() instead of tvm.gpu(). tvm.gpu() is going to be deprecated in 0.9.0",
+    )
     return Device(2, dev_id)
 
 

--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -464,9 +464,9 @@ def _compose(args, decs):
 
 
 def uses_gpu(*args):
-    """Mark to differentiate tests that use the GPU is some capacity.
+    """Mark to differentiate tests that use the GPU in some capacity.
 
-    These tests will be run on CPU-only test nodes and on test nodes with GPUS.
+    These tests will be run on CPU-only test nodes and on test nodes with GPUs.
     To mark a test that must have a GPU present to run, use
     :py:func:`tvm.testing.requires_gpu`.
 
@@ -490,7 +490,7 @@ def requires_gpu(*args):
         Function to mark
     """
     _requires_gpu = [
-        pytest.mark.skipif(not tvm.gpu().exist, reason="No GPU present"),
+        pytest.mark.skipif(not tvm.cuda().exist, reason="No GPU present"),
         *uses_gpu(),
     ]
     return _compose(args, _requires_gpu)
@@ -499,7 +499,7 @@ def requires_gpu(*args):
 def requires_cuda(*args):
     """Mark a test as requiring the CUDA runtime.
 
-    This also marks the test as requiring a gpu.
+    This also marks the test as requiring a cuda gpu.
 
     Parameters
     ----------
@@ -618,7 +618,7 @@ def requires_tensorcore(*args):
     _requires_tensorcore = [
         pytest.mark.tensorcore,
         pytest.mark.skipif(
-            not tvm.gpu().exist or not nvcc.have_tensorcore(tvm.gpu(0).compute_version),
+            not tvm.cuda().exist or not nvcc.have_tensorcore(tvm.cuda(0).compute_version),
             reason="No tensorcore present",
         ),
         *requires_gpu(),

--- a/python/tvm/topi/cuda/conv2d_alter_op.py
+++ b/python/tvm/topi/cuda/conv2d_alter_op.py
@@ -225,7 +225,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
 
     if topi_tmpl == "conv2d_HWNCnc_tensorcore.cuda":
         assert data_layout == "HWNC" and kernel_layout == "HWOI"
-        assert float(tvm.gpu(0).compute_version) >= 7.5
+        assert float(tvm.cuda(0).compute_version) >= 7.5
         H, W, N, CI = get_const_tuple(data.shape)
         KH, KW, CO, _ = get_const_tuple(kernel.shape)
 

--- a/python/tvm/topi/cuda/nms.py
+++ b/python/tvm/topi/cuda/nms.py
@@ -878,7 +878,7 @@ def non_max_suppression(
         np_valid_count = np.array([4])
         s = topi.generic.schedule_nms(out)
         f = tvm.build(s, [data, valid_count, out], "cuda")
-        dev = tvm.gpu(0)
+        dev = tvm.cuda(0)
         tvm_data = tvm.nd.array(np_data, dev)
         tvm_valid_count = tvm.nd.array(np_valid_count, dev)
         tvm_out = tvm.nd.array(np.zeros(dshape, dtype=data.dtype), dev)

--- a/rust/tvm-sys/src/device.rs
+++ b/rust/tvm-sys/src/device.rs
@@ -101,8 +101,8 @@ impl Display for DeviceType {
             "{}",
             match self {
                 DeviceType::CPU => "cpu",
-                DeviceType::GPU => "gpu",
-                DeviceType::CPUPinned => "cpu_pinned",
+                DeviceType::GPU => "cuda",
+                DeviceType::CPUPinned => "cuda_host",
                 DeviceType::OpenCL => "opencl",
                 DeviceType::Vulkan => "vulkan",
                 DeviceType::Metal => "metal",
@@ -210,7 +210,7 @@ macro_rules! impl_tvm_device {
 
 impl_tvm_device!(
     DLDeviceType_kDLCPU: [cpu, llvm, stackvm],
-    DLDeviceType_kDLGPU: [gpu, cuda, nvptx],
+    DLDeviceType_kDLCUDA: [gpu, cuda, nvptx],
     DLDeviceType_kDLOpenCL: [cl],
     DLDeviceType_kDLMetal: [metal],
     DLDeviceType_kDLVPI: [vpi],

--- a/rust/tvm-sys/src/device.rs
+++ b/rust/tvm-sys/src/device.rs
@@ -66,7 +66,7 @@ use thiserror::Error;
 pub enum DeviceType {
     CPU = 1,
     GPU,
-    CPUPinned,
+    CUDAHost,
     OpenCL,
     Vulkan,
     Metal,
@@ -102,7 +102,7 @@ impl Display for DeviceType {
             match self {
                 DeviceType::CPU => "cpu",
                 DeviceType::GPU => "cuda",
-                DeviceType::CPUPinned => "cuda_host",
+                DeviceType::CUDAHost => "cuda_host",
                 DeviceType::OpenCL => "opencl",
                 DeviceType::Vulkan => "vulkan",
                 DeviceType::Metal => "metal",

--- a/rust/tvm-sys/src/value.rs
+++ b/rust/tvm-sys/src/value.rs
@@ -86,7 +86,7 @@ macro_rules! impl_tvm_device {
 
 impl_tvm_device!(
     DLDeviceType_kDLCPU: [cpu, llvm, stackvm],
-    DLDeviceType_kDLGPU: [gpu, cuda, nvptx],
+    DLDeviceType_kDLCUDA: [gpu, cuda, nvptx],
     DLDeviceType_kDLOpenCL: [cl],
     DLDeviceType_kDLMetal: [metal],
     DLDeviceType_kDLVPI: [vpi],

--- a/src/auto_scheduler/search_policy/utils.h
+++ b/src/auto_scheduler/search_policy/utils.h
@@ -53,7 +53,7 @@ inline bool IsCPUTask(const SearchTask& task) {
 
 /*! \brief Return whether the search task is targeting a GPU. */
 inline bool IsGPUTask(const SearchTask& task) {
-  return (task)->target->kind->device_type == kDLGPU ||
+  return (task)->target->kind->device_type == kDLCUDA ||
          (task)->target->kind->device_type == kDLOpenCL ||
          (task)->target->kind->device_type == kDLVulkan ||
          (task)->target->kind->device_type == kDLMetal ||
@@ -63,7 +63,7 @@ inline bool IsGPUTask(const SearchTask& task) {
 
 /*! \brief Return whether the search task is targeting a CUDA GPU. */
 inline bool IsCUDATask(const SearchTask& task) {
-  return (task)->target->kind->device_type == kDLGPU;
+  return (task)->target->kind->device_type == kDLCUDA;
 }
 
 /*! \brief Return whether the search task is targeting a OpenCL GPU. */

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -59,9 +59,9 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
     return HardwareParams(tvm::runtime::threading::MaxConcurrency(), 64, 64, 0, 0, 0, 0, 0);
   } else if (device_type == kDLCUDA || device_type == kDLROCM) {
     auto dev = Device{static_cast<DLDeviceType>(device_type), 0};
-    auto device_name = device_type == kDLCUDA ? "device_api.gpu" : "device_api.rocm";
+    auto device_name = device_type == kDLCUDA ? "device_api.cuda" : "device_api.rocm";
     auto func = tvm::runtime::Registry::Get(device_name);
-    ICHECK(func != nullptr) << "Cannot find GPU device_api in registry";
+    ICHECK(func != nullptr) << "Cannot find CUDA device_api in registry";
     auto device_api = static_cast<tvm::runtime::DeviceAPI*>(((*func)()).operator void*());
 
     tvm::runtime::TVMRetValue ret;

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -57,9 +57,9 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
   const auto device_type = target->kind->device_type;
   if (device_type == kDLCPU) {
     return HardwareParams(tvm::runtime::threading::MaxConcurrency(), 64, 64, 0, 0, 0, 0, 0);
-  } else if (device_type == kDLGPU || device_type == kDLROCM) {
+  } else if (device_type == kDLCUDA || device_type == kDLROCM) {
     auto dev = Device{static_cast<DLDeviceType>(device_type), 0};
-    auto device_name = device_type == kDLGPU ? "device_api.gpu" : "device_api.rocm";
+    auto device_name = device_type == kDLCUDA ? "device_api.gpu" : "device_api.rocm";
     auto func = tvm::runtime::Registry::Get(device_name);
     ICHECK(func != nullptr) << "Cannot find GPU device_api in registry";
     auto device_api = static_cast<tvm::runtime::DeviceAPI*>(((*func)()).operator void*());

--- a/src/contrib/tf_op/tvm_dso_op_kernels.cc
+++ b/src/contrib/tf_op/tvm_dso_op_kernels.cc
@@ -69,7 +69,7 @@ class TensorAsBuf {
     if (device_type == kDLCPU) {
       memcpy(origin_buf, buf + offset, size);
 #ifdef TF_TVMDSOOP_ENABLE_GPU
-    } else if (device_type == kDLGPU) {
+    } else if (device_type == kDLCUDA) {
       cudaMemcpy(origin_buf, buf + offset, size, cudaMemcpyDeviceToDevice);
 #endif
     } else {
@@ -85,7 +85,7 @@ class TensorAsBuf {
     if (device_type == kDLCPU) {
       memcpy(buf + offset, origin_buf, size);
 #ifdef TF_TVMDSOOP_ENABLE_GPU
-    } else if (device_type == kDLGPU) {
+    } else if (device_type == kDLCUDA) {
       cudaMemcpy(buf + offset, origin_buf, size, cudaMemcpyDeviceToDevice);
 #endif
     } else {
@@ -192,7 +192,7 @@ class TVMDSOOpTrait<CPUDevice> {
 template <>
 class TVMDSOOpTrait<GPUDevice> {
  public:
-  static const int device_type = kDLGPU;
+  static const int device_type = kDLCUDA;
 
   static int device_id(OpKernelContext* context) {
     auto device_base = context->device();

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -429,7 +429,7 @@ class RelayBuildModule : public runtime::ModuleNode {
   Target CreateDefaultTarget(int device_type) {
     std::string name = runtime::DeviceName(device_type);
     if (name == "cpu") return Target("llvm");
-    if (name == "gpu") return Target("cuda");
+    if (name == "cuda") return Target("cuda");
     return Target(name);
   }
 

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -234,7 +234,7 @@ std::vector<int64_t> ToAllocTensorShape(NDArray shape) {
 Target CreateDefaultTarget(int device_type) {
   std::string name = runtime::DeviceName(device_type);
   if (name == "cpu") return Target("llvm");
-  if (name == "gpu") return Target("cuda");
+  if (name == "cuda") return Target("cuda");
   return Target(name);
 }
 

--- a/src/runtime/contrib/cudnn/cudnn_utils.cc
+++ b/src/runtime/contrib/cudnn/cudnn_utils.cc
@@ -96,7 +96,7 @@ const void* CuDNNDataType::GetConst<1>(cudnnDataType_t type) {
 
 CuDNNThreadEntry::CuDNNThreadEntry() {
   auto stream = runtime::CUDAThreadEntry::ThreadLocal()->stream;
-  auto func = runtime::Registry::Get("device_api.gpu");
+  auto func = runtime::Registry::Get("device_api.cuda");
   void* ret = (*func)();
   cuda_api = static_cast<runtime::DeviceAPI*>(ret);
   CUDNN_CALL(cudnnCreate(&handle));

--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -248,13 +248,13 @@ void TensorRTBuilder::CleanUp() {
 void TensorRTBuilder::AllocateDeviceBuffer(nvinfer1::ICudaEngine* engine, const std::string& name,
                                            std::vector<runtime::NDArray>* device_buffers) {
   const uint32_t entry_id = entry_id_map_[name];
-  if (data_entry_[entry_id]->device.device_type != kDLGPU) {
+  if (data_entry_[entry_id]->device.device_type != kDLCUDA) {
     const int binding_index = engine->getBindingIndex(name.c_str());
     ICHECK_NE(binding_index, -1);
     std::vector<int64_t> shape(data_entry_[entry_id]->shape,
                                data_entry_[entry_id]->shape + data_entry_[entry_id]->ndim);
     device_buffers->at(binding_index) =
-        runtime::NDArray::Empty(shape, data_entry_[entry_id]->dtype, {kDLGPU, 0});
+        runtime::NDArray::Empty(shape, data_entry_[entry_id]->dtype, {kDLCUDA, 0});
   }
 }
 

--- a/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
@@ -135,7 +135,7 @@ class TensorRTRuntime : public JSONRuntimeBase {
           const std::string name = nodes_[nid].GetOpName() + "_" + std::to_string(j);
           int binding_index = engine->getBindingIndex(name.c_str());
           ICHECK_NE(binding_index, -1);
-          if (data_entry_[eid]->device.device_type == kDLGPU) {
+          if (data_entry_[eid]->device.device_type == kDLCUDA) {
             bindings[binding_index] = data_entry_[eid]->data;
           } else {
             device_buffers[binding_index].CopyFrom(data_entry_[eid]);
@@ -150,7 +150,7 @@ class TensorRTRuntime : public JSONRuntimeBase {
       const std::string& name = engine_and_context.outputs[i];
       int binding_index = engine->getBindingIndex(name.c_str());
       ICHECK_NE(binding_index, -1);
-      if (data_entry_[eid]->device.device_type == kDLGPU) {
+      if (data_entry_[eid]->device.device_type == kDLCUDA) {
         bindings[binding_index] = data_entry_[eid]->data;
       } else {
         bindings[binding_index] = device_buffers[binding_index]->data;
@@ -173,7 +173,7 @@ class TensorRTRuntime : public JSONRuntimeBase {
       const std::string& name = engine_and_context.outputs[i];
       int binding_index = engine->getBindingIndex(name.c_str());
       ICHECK_NE(binding_index, -1);
-      if (data_entry_[eid]->device.device_type != kDLGPU) {
+      if (data_entry_[eid]->device.device_type != kDLCUDA) {
         device_buffers[binding_index].CopyTo(const_cast<DLTensor*>(data_entry_[eid]));
       }
     }

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -126,7 +126,7 @@ bool RuntimeEnabled(const std::string& target) {
   if (target == "cpu") {
     return true;
   } else if (target == "cuda" || target == "gpu") {
-    f_name = "device_api.gpu";
+    f_name = "device_api.cuda";
   } else if (target == "cl" || target == "opencl" || target == "sdaccel") {
     f_name = "device_api.opencl";
   } else if (target == "mtl" || target == "metal") {

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -231,8 +231,8 @@ void NDArray::CopyFromTo(const DLTensor* from, DLTensor* to, TVMStreamHandle str
   ICHECK_EQ(from_size, to_size) << "TVMArrayCopyFromTo: The size must exactly match";
 
   ICHECK(from->device.device_type == to->device.device_type || from->device.device_type == kDLCPU ||
-         to->device.device_type == kDLCPU || from->device.device_type == kDLCPUPinned ||
-         to->device.device_type == kDLCPUPinned)
+         to->device.device_type == kDLCPU || from->device.device_type == kDLCUDAHost ||
+         to->device.device_type == kDLCUDAHost)
       << "Can not copy across different device types directly";
 
   // Use the device that is *not* a cpu device to get the correct device

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -152,7 +152,7 @@ Map<String, ObjectRef> UpdateNVPTXAttrs(Map<String, ObjectRef> attrs) {
   } else {
     // Use the compute version of the first CUDA GPU instead
     TVMRetValue version;
-    if (!DetectDeviceFlag({kDLGPU, 0}, runtime::kComputeVersion, &version)) {
+    if (!DetectDeviceFlag({kDLCUDA, 0}, runtime::kComputeVersion, &version)) {
       LOG(WARNING) << "Unable to detect CUDA version, default to \"-mcpu=sm_20\" instead";
       arch = 20;
     } else {
@@ -230,7 +230,7 @@ TVM_REGISTER_TARGET_KIND("c", kDLCPU)
     .add_attr_option<String>("executor")
     .set_default_keys({"cpu"});
 
-TVM_REGISTER_TARGET_KIND("cuda", kDLGPU)
+TVM_REGISTER_TARGET_KIND("cuda", kDLCUDA)
     .add_attr_option<String>("mcpu")
     .add_attr_option<String>("arch")
     .add_attr_option<Bool>("system-lib")
@@ -241,7 +241,7 @@ TVM_REGISTER_TARGET_KIND("cuda", kDLGPU)
     .add_attr_option<Integer>("max_threads_per_block")
     .set_default_keys({"cuda", "gpu"});
 
-TVM_REGISTER_TARGET_KIND("nvptx", kDLGPU)
+TVM_REGISTER_TARGET_KIND("nvptx", kDLCUDA)
     .add_attr_option<String>("mcpu")
     .add_attr_option<String>("mtriple")
     .add_attr_option<Bool>("system-lib")

--- a/src/te/schedule/schedule_postproc_rewrite_for_tensor_core.cc
+++ b/src/te/schedule/schedule_postproc_rewrite_for_tensor_core.cc
@@ -1089,7 +1089,7 @@ Stmt SchedulePostProcRewriteForTensorCore(Stmt stmt, Schedule schedule,
   }
 
   // Check if current runtime support GPU CUDA
-  Device dev{kDLGPU, 0};
+  Device dev{kDLCUDA, 0};
   auto api = tvm::runtime::DeviceAPI::Get(dev, true);
   if (api == nullptr) {
     return stmt;

--- a/src/tir/analysis/verify_memory.cc
+++ b/src/tir/analysis/verify_memory.cc
@@ -149,7 +149,7 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
 
   /// Check if a given DLDeviceType/TVMDeviceExtType value denotes GPU device.
   static bool IsGPUDevice(int dev_type) {
-    return kDLGPU == dev_type || kDLOpenCL == dev_type || kDLVulkan == dev_type ||
+    return kDLCUDA == dev_type || kDLOpenCL == dev_type || kDLVulkan == dev_type ||
            kDLMetal == dev_type || kDLROCM == dev_type || kOpenGL == dev_type;
   }
   /// Check if a given DLDeviceType/TVMDeviceExtType value denotes FPGA device.

--- a/tests/cpp/build_module_test.cc
+++ b/tests/cpp/build_module_test.cc
@@ -166,7 +166,7 @@ TEST(BuildModule, Heterogeneous) {
   // Initialize graph executor.
   int cpu_dev_ty = static_cast<int>(kDLCPU);
   int cpu_dev_id = 0;
-  int gpu_dev_ty = static_cast<int>(kDLGPU);
+  int gpu_dev_ty = static_cast<int>(kDLCUDA);
   int gpu_dev_id = 0;
 
   const runtime::PackedFunc* graph_executor =

--- a/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
+++ b/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
@@ -101,10 +101,10 @@ def test_empty_array():
 
 def test_device():
     def test_device_func(dev):
-        assert tvm.gpu(7) == dev
+        assert tvm.cuda(7) == dev
         return tvm.cpu(0)
 
-    x = test_device_func(tvm.gpu(7))
+    x = test_device_func(tvm.cuda(7))
     assert x == tvm.cpu(0)
     x = tvm.opencl(10)
     x = tvm.testing.device_test(x, x.device_type, x.device_id)

--- a/tests/python/contrib/test_cublas.py
+++ b/tests/python/contrib/test_cublas.py
@@ -35,7 +35,7 @@ def verify_matmul_add(in_dtype, out_dtype, rtol=1e-5):
         if not tvm.get_global_func("tvm.contrib.cublas.matmul", True):
             print("skip because extern function is not available")
             return
-        dev = tvm.gpu(0)
+        dev = tvm.cuda(0)
         f = tvm.build(s, [A, B, C], target)
         a = tvm.nd.array(np.random.uniform(0, 128, size=(n, l)).astype(A.dtype), dev)
         b = tvm.nd.array(np.random.uniform(0, 128, size=(l, m)).astype(B.dtype), dev)
@@ -70,7 +70,7 @@ def verify_matmul_add_igemm(in_dtype, out_dtype, rtol=1e-5):
         if not tvm.get_global_func("tvm.contrib.cublaslt.matmul", True):
             print("skip because extern function is not available")
             return
-        dev = tvm.gpu(0)
+        dev = tvm.cuda(0)
         f = tvm.build(s, [A, B, C], target)
         a_old = np.random.uniform(0, 128, size=(n, l))
         b_old = np.random.uniform(0, 128, size=(l, m))
@@ -126,7 +126,7 @@ def verify_batch_matmul(in_dtype, out_dtype, rtol=1e-5):
         if not tvm.get_global_func("tvm.contrib.cublas.matmul", True):
             print("skip because extern function is not available")
             return
-        dev = tvm.gpu(0)
+        dev = tvm.cuda(0)
         f = tvm.build(s, [A, B, C], target)
         a = tvm.nd.array(np.random.uniform(size=(j, n, l)).astype(A.dtype), dev)
         b = tvm.nd.array(np.random.uniform(size=(j, l, m)).astype(B.dtype), dev)

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -41,7 +41,7 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0, groups=1):
     if not tvm.get_global_func("tvm.contrib.cudnn.conv.output_shape", True):
         print("skip because cudnn is not enabled...")
         return
-    if data_dtype == "float16" and not have_fp16(tvm.gpu(0).compute_version):
+    if data_dtype == "float16" and not have_fp16(tvm.cuda(0).compute_version):
         print("Skip because gpu does not have fp16 support")
         return
 
@@ -71,7 +71,7 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0, groups=1):
     s = te.create_schedule(Y.op)
 
     # validation
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     f = tvm.build(s, [X, W, Y], "cuda --host=llvm", name="conv2d")
     x_np = np.random.uniform(-1, 1, xshape).astype(data_dtype)
     w_np = np.random.uniform(-1, 1, wshape).astype(data_dtype)
@@ -149,7 +149,7 @@ def verify_conv3d(data_dtype, conv_dtype, tensor_format=0, groups=1):
     s = te.create_schedule(Y.op)
 
     # validation
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     f = tvm.build(s, [X, W, Y], target="cuda --host=llvm", name="conv3d")
     x_np = np.random.uniform(-1, 1, xshape).astype(data_dtype)
     w_np = np.random.uniform(-1, 1, wshape).astype(data_dtype)
@@ -177,7 +177,7 @@ def verify_softmax(shape, axis, dtype="float32"):
     B = cudnn.softmax(A, axis)
     s = te.create_schedule([B.op])
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     a_np = np.random.uniform(size=shape).astype(dtype)
     b_np = tvm.topi.testing.softmax_python(a_np)
     a = tvm.nd.array(a_np, dev)
@@ -192,7 +192,7 @@ def verify_softmax_4d(shape, dtype="float32"):
     B = cudnn.softmax(A, axis=1)
     s = te.create_schedule([B.op])
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     n, c, h, w = shape
     a_np = np.random.uniform(size=shape).astype(dtype)
     b_np = tvm.topi.testing.softmax_python(a_np.transpose(0, 2, 3, 1).reshape(h * w, c))

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -35,7 +35,7 @@ from tvm.relay.op.contrib import tensorrt
 
 def skip_codegen_test():
     """Skip test if TensorRT and CUDA codegen are not present"""
-    if not tvm.runtime.enabled("cuda") or not tvm.gpu(0).exist:
+    if not tvm.runtime.enabled("cuda") or not tvm.cuda(0).exist:
         print("Skip because CUDA is not enabled.")
         return True
     if not tvm.get_global_func("relay.ext.tensorrt", True):
@@ -45,7 +45,7 @@ def skip_codegen_test():
 
 
 def skip_runtime_test():
-    if not tvm.runtime.enabled("cuda") or not tvm.gpu(0).exist:
+    if not tvm.runtime.enabled("cuda") or not tvm.cuda(0).exist:
         print("Skip because CUDA is not enabled.")
         return True
     if not tensorrt.is_tensorrt_runtime_enabled():
@@ -143,10 +143,10 @@ def run_and_verify_model(model):
             with tvm.transform.PassContext(
                 opt_level=3, config={"relay.ext.tensorrt.options": config}
             ):
-                exec = relay.create_executor(mode, mod=mod, device=tvm.gpu(0), target="cuda")
+                exec = relay.create_executor(mode, mod=mod, device=tvm.cuda(0), target="cuda")
         else:
             with tvm.transform.PassContext(opt_level=3):
-                exec = relay.create_executor(mode, mod=mod, device=tvm.gpu(0), target="cuda")
+                exec = relay.create_executor(mode, mod=mod, device=tvm.cuda(0), target="cuda")
 
         res = exec.evaluate()(i_data, **params) if not skip_runtime_test() else None
         return res
@@ -199,12 +199,12 @@ def test_tensorrt_simple():
                     opt_level=3, config={"relay.ext.tensorrt.options": config}
                 ):
                     relay_exec = relay.create_executor(
-                        mode, mod=mod, device=tvm.gpu(0), target="cuda"
+                        mode, mod=mod, device=tvm.cuda(0), target="cuda"
                     )
             else:
                 with tvm.transform.PassContext(opt_level=3):
                     relay_exec = relay.create_executor(
-                        mode, mod=mod, device=tvm.gpu(0), target="cuda"
+                        mode, mod=mod, device=tvm.cuda(0), target="cuda"
                     )
             if not skip_runtime_test():
                 result_dict[result_key] = relay_exec.evaluate()(x_data, y_data, z_data)
@@ -247,7 +247,7 @@ def test_tensorrt_not_compatible():
     mod, config = tensorrt.partition_for_tensorrt(mod)
     for mode in ["graph", "vm"]:
         with tvm.transform.PassContext(opt_level=3, config={"relay.ext.tensorrt.options": config}):
-            exec = relay.create_executor(mode, mod=mod, device=tvm.gpu(0), target="cuda")
+            exec = relay.create_executor(mode, mod=mod, device=tvm.cuda(0), target="cuda")
             if not skip_runtime_test():
                 results = exec.evaluate()(x_data)
 
@@ -273,7 +273,7 @@ def test_tensorrt_serialize_graph_executor():
         return graph, lib, params
 
     def run_graph(graph, lib, params):
-        mod_ = graph_executor.create(graph, lib, device=tvm.gpu(0))
+        mod_ = graph_executor.create(graph, lib, device=tvm.cuda(0))
         mod_.load_params(params)
         mod_.run(data=i_data)
         res = mod_.get_output(0)
@@ -330,7 +330,7 @@ def test_tensorrt_serialize_vm():
 
     def run_vm(code, lib):
         vm_exec = tvm.runtime.vm.Executable.load_exec(code, lib)
-        vm = VirtualMachine(vm_exec, tvm.gpu(0))
+        vm = VirtualMachine(vm_exec, tvm.cuda(0))
         result = vm.invoke("main", data=i_data)
         return result
 
@@ -1415,7 +1415,7 @@ def test_empty_subgraph():
     x_data = np.random.uniform(-1, 1, x_shape).astype("float32")
     for mode in ["graph", "vm"]:
         with tvm.transform.PassContext(opt_level=3):
-            exec = relay.create_executor(mode, mod=mod, device=tvm.gpu(0), target="cuda")
+            exec = relay.create_executor(mode, mod=mod, device=tvm.cuda(0), target="cuda")
             if not skip_runtime_test():
                 results = exec.evaluate()(x_data)
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1240,7 +1240,7 @@ def test_type_as():
         check_fp16 = False
         try:
             # Only check half precision on supported hardwares.
-            if have_fp16(tvm.gpu(0).compute_version):
+            if have_fp16(tvm.cuda(0).compute_version):
                 check_fp16 = True
         except Exception as e:
             # If GPU is not enabled in TVM, skip the fp16 test.

--- a/tests/python/nightly/quantization/test_quantization_accuracy.py
+++ b/tests/python/nightly/quantization/test_quantization_accuracy.py
@@ -93,7 +93,7 @@ def get_model(model_name, batch_size, qconfig, target=None, original=False, simu
 
 
 def eval_acc(
-    model, dataset, batch_fn, target=tvm.target.cuda(), device=tvm.gpu(), log_interval=100
+    model, dataset, batch_fn, target=tvm.target.cuda(), device=tvm.cuda(), log_interval=100
 ):
     with tvm.transform.PassContext(opt_level=3):
         graph, lib, params = relay.build(model, target)

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -508,7 +508,7 @@ def verify_any_conv2d(
 
     targets = None
     if use_cudnn and tvm.get_global_func("tvm.contrib.cudnn.conv.output_shape", True):
-        targets = [("cuda -libs=cudnn", tvm.gpu(0))]
+        targets = [("cuda -libs=cudnn", tvm.cuda(0))]
 
     check_result([data_np, kernel_np], mod, ref_out_shape, assert_shape=True, targets=targets)
 
@@ -811,7 +811,7 @@ def verify_any_dense(
 
     targets = None
     if use_cublas and tvm.get_global_func("tvm.contrib.cublas.matmul", True):
-        targets = [("cuda -libs=cublas", tvm.gpu(0))]
+        targets = [("cuda -libs=cublas", tvm.cuda(0))]
 
     check_result([data_np, weight_np], mod, ref_out_shape, assert_shape=True, targets=targets)
 

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -69,7 +69,7 @@ def tune_network(network, target):
 
         # Check the correctness
         def get_output(data, lib):
-            dev = tvm.gpu()
+            dev = tvm.cuda()
             module = graph_executor.GraphModule(lib["default"](dev))
             module.set_input("data", data)
             module.run()

--- a/tests/python/relay/test_cpp_build_module.py
+++ b/tests/python/relay/test_cpp_build_module.py
@@ -65,7 +65,7 @@ def test_basic_build():
 def test_fp16_build():
     dtype = "float16"
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     if dtype == "float16" and not have_fp16(dev.compute_version):
         print("skip because gpu does not support fp16")
         return

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -67,7 +67,7 @@ def test_unary_op():
                 if (
                     dtype == "float16"
                     and target == "cuda"
-                    and not have_fp16(tvm.gpu(0).compute_version)
+                    and not have_fp16(tvm.cuda(0).compute_version)
                 ):
                     continue
                 intrp = relay.create_executor("graph", device=dev, target=target)
@@ -129,7 +129,7 @@ def test_binary_op():
                 if (
                     dtype == "float16"
                     and target == "cuda"
-                    and not have_fp16(tvm.gpu(0).compute_version)
+                    and not have_fp16(tvm.cuda(0).compute_version)
                 ):
                     continue
                 intrp = relay.create_executor("graph", device=dev, target=target)
@@ -158,7 +158,7 @@ def test_expand_dims():
             if (
                 dtype == "float16"
                 and target == "cuda"
-                and not have_fp16(tvm.gpu(0).compute_version)
+                and not have_fp16(tvm.cuda(0).compute_version)
             ):
                 continue
             data = np.random.uniform(size=dshape).astype(dtype)
@@ -193,7 +193,7 @@ def test_bias_add():
             if (
                 dtype == "float16"
                 and target == "cuda"
-                and not have_fp16(tvm.gpu(0).compute_version)
+                and not have_fp16(tvm.cuda(0).compute_version)
             ):
                 continue
             intrp = relay.create_executor("graph", device=dev, target=target)
@@ -314,7 +314,7 @@ def test_concatenate():
             if (
                 dtype == "float16"
                 and target == "cuda"
-                and not have_fp16(tvm.gpu(0).compute_version)
+                and not have_fp16(tvm.cuda(0).compute_version)
             ):
                 continue
             intrp1 = relay.create_executor("graph", device=dev, target=target)

--- a/tests/python/topi/python/test_topi_relu.py
+++ b/tests/python/topi/python/test_topi_relu.py
@@ -35,7 +35,7 @@ def verify_relu(m, n, dtype="float32"):
     b_np = a_np * (a_np > 0)
 
     def check_target(target, dev):
-        if dtype == "float16" and target == "cuda" and not have_fp16(tvm.gpu(0).compute_version):
+        if dtype == "float16" and target == "cuda" and not have_fp16(tvm.cuda(0).compute_version):
             print("Skip because %s does not have fp16 support" % target)
             return
         print("Running on target: %s" % target)

--- a/tests/python/topi/python/test_topi_tensor.py
+++ b/tests/python/topi/python/test_topi_tensor.py
@@ -95,7 +95,7 @@ def verify_vectorization(n, m, dtype):
         if not tvm.testing.device_enabled(targeta):
             print("Skip because %s is not enabled" % targeta)
             return
-        if dtype == "float16" and targeta == "cuda" and not have_fp16(tvm.gpu(0).compute_version):
+        if dtype == "float16" and targeta == "cuda" and not have_fp16(tvm.cuda(0).compute_version):
             print("Skip because gpu does not have fp16 support")
             return
         with tvm.target.Target(targeta):

--- a/tests/python/unittest/test_runtime_graph_cuda_graph.py
+++ b/tests/python/unittest/test_runtime_graph_cuda_graph.py
@@ -73,7 +73,7 @@ def test_graph_simple():
 
     def check_verify():
         mlib = tvm.build(s, [A, B], "cuda", name="myadd")
-        dev = tvm.gpu(0)
+        dev = tvm.cuda(0)
         try:
             mod = cuda_graph_executor.create(graph, mlib, dev)
         except ValueError:

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -97,7 +97,7 @@ def test_gpu():
     with relay.build_config(opt_level=3):
         complied_graph_lib = relay.build_module.build(mod, "cuda", params=params)
     data = np.random.uniform(-1, 1, size=input_shape(mod)).astype("float32")
-    dev = tvm.gpu()
+    dev = tvm.cuda()
 
     # raw api
     gmod = complied_graph_lib["default"](dev)
@@ -190,7 +190,7 @@ def test_mod_export():
         # test the robustness wrt to parent module destruction
         def setup_gmod():
             loaded_lib = tvm.runtime.load_module(path_lib)
-            dev = tvm.gpu()
+            dev = tvm.cuda()
             return loaded_lib["default"](dev)
 
         gmod = setup_gmod()
@@ -378,7 +378,7 @@ def test_remove_package_params():
             fo.write(runtime.save_param_dict(complied_graph_lib.get_params()))
         loaded_lib = tvm.runtime.load_module(path_lib)
         data = np.random.uniform(-1, 1, size=input_shape(mod)).astype("float32")
-        dev = tvm.gpu(0)
+        dev = tvm.cuda(0)
 
         # raw api
         gmod = loaded_lib["default"](dev)
@@ -559,7 +559,7 @@ def test_cuda_graph_executor():
         complied_graph_lib = relay.build_module.build(mod, "cuda", params=params)
     data = np.random.uniform(-1, 1, size=input_shape(mod)).astype("float32")
 
-    dev = tvm.gpu()
+    dev = tvm.cuda()
     try:
         gmod = complied_graph_lib["cuda_graph_create"](dev)
     except:

--- a/tests/python/unittest/test_target_codegen_blob.py
+++ b/tests/python/unittest/test_target_codegen_blob.py
@@ -57,7 +57,7 @@ def test_synthetic():
 
     loaded_lib = tvm.runtime.load_module(path_lib)
     data = np.random.uniform(-1, 1, size=input_shape).astype("float32")
-    dev = tvm.gpu()
+    dev = tvm.cuda()
     module = graph_executor.GraphModule(loaded_lib["default"](dev))
     module.set_input("data", data)
     module.run()
@@ -68,7 +68,7 @@ def test_synthetic():
 
 @tvm.testing.uses_gpu
 def test_cuda_lib():
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     for device in ["llvm", "cuda"]:
         if not tvm.testing.device_enabled(device):
             print("skip because %s is not enabled..." % device)

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -810,7 +810,7 @@ def test_llvm_gpu_lower_atomic():
         s = tvm.te.create_schedule(C.op)
         f = tvm.build(s, [A], target="nvptx")
 
-        dev = tvm.gpu()
+        dev = tvm.cuda()
         a = tvm.nd.array(np.zeros((size,)).astype(A.dtype), dev)
         f(a)
         ref = np.zeros((size,)).astype(A.dtype)

--- a/tests/python/unittest/test_te_schedule_postproc_rewrite_for_tensor_core.py
+++ b/tests/python/unittest/test_te_schedule_postproc_rewrite_for_tensor_core.py
@@ -100,7 +100,7 @@ def tensor_core_matmul(warp_tile_m=16, m=64, n=32, l=96):
 
     func = tvm.build(s, [A, B, C], "cuda")
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     a_np = np.random.uniform(size=(n, l)).astype(A.dtype)
     b_np = np.random.uniform(size=(l, m)).astype(B.dtype)
     c_np = np.zeros((n, m), dtype=np.float32)
@@ -195,7 +195,7 @@ def tensor_core_batch_matmul(warp_tile_m=16, m=64, n=32, l=96, batch=2):
 
     func = tvm.build(s, [A, B, C], "cuda")
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     a_np = np.random.uniform(size=(batch, n, l)).astype(A.dtype)
     b_np = np.random.uniform(size=(batch, l, m)).astype(B.dtype)
     c_np = np.zeros((batch, n, m), dtype=np.float32)

--- a/tests/python/unittest/test_te_schedule_tensor_core.py
+++ b/tests/python/unittest/test_te_schedule_tensor_core.py
@@ -256,7 +256,7 @@ def test_tensor_core_batch_matmal():
 
     func = tvm.build(s, [A, B, C], "cuda")
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     a_np = np.random.uniform(size=(batch_size, nn, ll, 32, 16)).astype(A.dtype)
     b_np = np.random.uniform(size=(batch_size, ll, mm, 16, 8)).astype(B.dtype)
     a = tvm.nd.array(a_np, dev)
@@ -432,7 +432,7 @@ def test_tensor_core_batch_conv():
 
     func = tvm.build(s, [A, W, Conv], "cuda")
 
-    dev = tvm.gpu(0)
+    dev = tvm.cuda(0)
     a_np = np.random.uniform(size=data_shape).astype(A.dtype)
     w_np = np.random.uniform(size=kernel_shape).astype(W.dtype)
     a = tvm.nd.array(a_np, dev)

--- a/tests/python/unittest/test_tir_transform_lower_warp_memory.py
+++ b/tests/python/unittest/test_tir_transform_lower_warp_memory.py
@@ -92,7 +92,7 @@ def test_lower_warp_memory_correct_indices():
 @tvm.testing.requires_cuda
 def test_lower_warp_memory_cuda_end_to_end():
     def check_cuda(dtype):
-        if dtype == "float16" and not have_fp16(tvm.gpu(0).compute_version):
+        if dtype == "float16" and not have_fp16(tvm.cuda(0).compute_version):
             print("Skip because gpu does not have fp16 support")
             return
 
@@ -114,7 +114,7 @@ def test_lower_warp_memory_cuda_end_to_end():
             xo, xi = s[AA].split(s[AA].op.axis[0], 32)
             s[AA].bind(xi, tx)
 
-            dev = tvm.gpu(0)
+            dev = tvm.cuda(0)
             func = tvm.build(s, [A, B], "cuda")
             A_np = np.array(list(range(m)), dtype=dtype)
             B_np = np.array(
@@ -141,7 +141,7 @@ def test_lower_warp_memory_cuda_end_to_end():
 @tvm.testing.requires_cuda
 def test_lower_warp_memory_cuda_half_a_warp():
     def check_cuda(dtype):
-        if dtype == "float16" and not have_fp16(tvm.gpu(0).compute_version):
+        if dtype == "float16" and not have_fp16(tvm.cuda(0).compute_version):
             print("Skip because gpu does not have fp16 support")
             return
 
@@ -181,7 +181,7 @@ def test_lower_warp_memory_cuda_half_a_warp():
             _, x = AA.op.axis
             s[AA].bind(x, tx)
 
-            dev = tvm.gpu(0)
+            dev = tvm.cuda(0)
             func = tvm.build(s, [A, B], "cuda")
             A_np = np.array([list(range(i, m + i)) for i in range(n)], dtype=dtype)
             B_np = np.array([list(range(1 + i, m + i)) + [i] for i in range(n)], dtype=dtype)
@@ -198,7 +198,7 @@ def test_lower_warp_memory_cuda_half_a_warp():
 @tvm.testing.requires_cuda
 def test_lower_warp_memory_cuda_2_buffers():
     def check_cuda(dtype):
-        if dtype == "float16" and not have_fp16(tvm.gpu(0).compute_version):
+        if dtype == "float16" and not have_fp16(tvm.cuda(0).compute_version):
             print("Skip because gpu does not have fp16 support")
             return
 
@@ -228,7 +228,7 @@ def test_lower_warp_memory_cuda_2_buffers():
             s[BB].bind(xo, bx)
             s[BB].bind(xi, tx)
 
-            dev = tvm.gpu(0)
+            dev = tvm.cuda(0)
             func = tvm.build(s, [A, B, C], "cuda")
             AB_np = np.array(list(range(m)), dtype=dtype)
             C_np = np.array(list(range(1, m)) + [0], dtype=dtype) * 2

--- a/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
+++ b/tutorials/auto_scheduler/tune_conv2d_layer_cuda.py
@@ -145,7 +145,7 @@ bias_np = np.random.uniform(size=(1, CO, 1, 1)).astype(np.float32)
 conv_np = conv2d_nchw_python(data_np, weight_np, strides, padding)
 out_np = np.maximum(conv_np + bias_np, 0.0)
 
-dev = tvm.gpu()
+dev = tvm.cuda()
 data_tvm = tvm.nd.array(data_np, device=dev)
 weight_tvm = tvm.nd.array(weight_np, device=dev)
 bias_tvm = tvm.nd.array(bias_np, device=dev)

--- a/tutorials/autotvm/tune_conv2d_cuda.py
+++ b/tutorials/autotvm/tune_conv2d_cuda.py
@@ -230,7 +230,7 @@ a_np = np.random.uniform(size=(N, CI, H, W)).astype(np.float32)
 w_np = np.random.uniform(size=(CO, CI, KH, KW)).astype(np.float32)
 c_np = conv2d_nchw_python(a_np, w_np, strides, padding)
 
-dev = tvm.gpu()
+dev = tvm.cuda()
 a_tvm = tvm.nd.array(a_np, device=dev)
 w_tvm = tvm.nd.array(w_np, device=dev)
 c_tvm = tvm.nd.empty(c_np.shape, device=dev)

--- a/tutorials/frontend/deploy_sparse.py
+++ b/tutorials/frontend/deploy_sparse.py
@@ -105,7 +105,7 @@ seq_len = 128
 # TVM platform identifier. Note that best cpu performance can be achieved by setting -mcpu
 # appropriately for your specific machine. CUDA and ROCm are also supported.
 target = "llvm"
-# Which device to run on. Should be one of tvm.cpu() or tvm.gpu().
+# Which device to run on. Should be one of tvm.cpu() or tvm.cuda().
 dev = tvm.cpu()
 # If true, then a sparse variant of the network will be run and
 # benchmarked.

--- a/tutorials/frontend/from_caffe2.py
+++ b/tutorials/frontend/from_caffe2.py
@@ -107,7 +107,7 @@ import tvm
 from tvm import te
 from tvm.contrib import graph_executor
 
-# context x86 CPU, use tvm.gpu(0) if you run on GPU
+# context x86 CPU, use tvm.cuda(0) if you run on GPU
 dev = tvm.cpu(0)
 # create a runtime executor module
 m = graph_executor.GraphModule(lib["default"](dev))

--- a/tutorials/frontend/from_keras.py
+++ b/tutorials/frontend/from_keras.py
@@ -96,7 +96,7 @@ shape_dict = {"input_1": data.shape}
 mod, params = relay.frontend.from_keras(keras_resnet50, shape_dict)
 # compile the model
 target = "cuda"
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 with tvm.transform.PassContext(opt_level=3):
     executor = relay.build_module.create_executor("graph", mod, dev, target)
 

--- a/tutorials/frontend/from_mxnet.py
+++ b/tutorials/frontend/from_mxnet.py
@@ -106,7 +106,7 @@ with tvm.transform.PassContext(opt_level=3):
 # Now, we would like to reproduce the same forward computation using TVM.
 from tvm.contrib import graph_executor
 
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 dtype = "float32"
 m = graph_executor.GraphModule(lib["default"](dev))
 # set inputs

--- a/tutorials/frontend/from_tensorflow.py
+++ b/tutorials/frontend/from_tensorflow.py
@@ -72,7 +72,7 @@ label_map_url = os.path.join(repo_base, label_map)
 # Use these commented settings to build for cuda.
 # target = tvm.target.Target("cuda", host="llvm")
 # layout = "NCHW"
-# dev = tvm.gpu(0)
+# dev = tvm.cuda(0)
 target = tvm.target.Target("llvm", host="llvm")
 layout = None
 dev = tvm.cpu(0)

--- a/tutorials/get_started/relay_quick_start.py
+++ b/tutorials/get_started/relay_quick_start.py
@@ -107,7 +107,7 @@ with tvm.transform.PassContext(opt_level=opt_level):
 # Now we can create graph executor and run the module on Nvidia GPU.
 
 # create random input
-dev = tvm.gpu()
+dev = tvm.cuda()
 data = np.random.uniform(-1, 1, size=data_shape).astype("float32")
 # create module
 module = graph_executor.GraphModule(lib["default"](dev))

--- a/tutorials/language/reduction.py
+++ b/tutorials/language/reduction.py
@@ -137,7 +137,7 @@ print(fcuda.imported_modules[0].get_source())
 # Verify the correctness of result kernel by comparing it to numpy.
 #
 nn = 128
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 a = tvm.nd.array(np.random.uniform(size=(nn, nn)).astype(A.dtype), dev)
 b = tvm.nd.array(np.zeros(nn, dtype=B.dtype), dev)
 fcuda(a, b)

--- a/tutorials/language/scan.py
+++ b/tutorials/language/scan.py
@@ -83,7 +83,7 @@ print(tvm.lower(s, [X, s_scan], simple_mode=True))
 # numpy to verify the correctness of the result.
 #
 fscan = tvm.build(s, [X, s_scan], "cuda", name="myscan")
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 n = 1024
 m = 10
 a_np = np.random.uniform(size=(m, n)).astype(s_scan.dtype)

--- a/tutorials/optimize/opt_conv_cuda.py
+++ b/tutorials/optimize/opt_conv_cuda.py
@@ -238,7 +238,7 @@ s[WW].vectorize(fi)  # vectorize memory load
 #
 
 func = tvm.build(s, [A, W, B], "cuda")
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 a_np = np.random.uniform(size=(in_size, in_size, in_channel, batch)).astype(A.dtype)
 w_np = np.random.uniform(size=(kernel, kernel, in_channel, out_channel)).astype(W.dtype)
 a = tvm.nd.array(a_np, dev)

--- a/tutorials/optimize/opt_conv_tensorcore.py
+++ b/tutorials/optimize/opt_conv_tensorcore.py
@@ -392,7 +392,7 @@ print(tvm.lower(s, [A, W, Conv], simple_mode=True))
 # Since TensorCores are only supported in NVIDIA GPU with Compute Capability 7.0 or higher, it may not
 # be able to run on our build server
 
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 if nvcc.have_tensorcore(dev.compute_version):
     with tvm.transform.PassContext(config={"tir.UnrollLoop": {"auto_max_step": 16}}):
         func = tvm.build(s, [A, W, Conv], "cuda")

--- a/tutorials/topi/intro_topi.py
+++ b/tutorials/topi/intro_topi.py
@@ -99,7 +99,7 @@ print(sg.stages)
 # We can test the correctness by comparing with :code:`numpy` result as follows
 #
 func = tvm.build(sg, [a, b, g], "cuda")
-dev = tvm.gpu(0)
+dev = tvm.cuda(0)
 a_np = np.random.uniform(size=(x, y, y)).astype(a.dtype)
 b_np = np.random.uniform(size=(y, y)).astype(b.dtype)
 g_np = np.sum(np.add(a_np + b_np, a_np * b_np) / 2.0)


### PR DESCRIPTION
This PR implements the RFC: https://discuss.tvm.apache.org/t/rfc-rename-gpu-to-cuda/9928. The main purpose is to clearly distinguish between the general GPU devices and CUDA-enabled GPUs by renaming some `gpu` to `cuda` in the codebase.

- [DLPack](https://github.com/dmlc/dlpack) has recently done such [renaming](https://github.com/dmlc/dlpack/issues/67), so this PR bumps dlpack to v0.5.
- The API `tvm.gpu(0)` is changed to `tvm.cuda(0)`, but we keep the old `tvm.gpu()` API for another release cycle.

@tqchen @junrushao1994 