### PR TITLE
[Fix][Runtime] Use flatBuffersBuffer_ in EdgeTPURuntime::Init()

### DIFF
--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.cc
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.cc
@@ -35,8 +35,14 @@ void EdgeTPURuntime::Init(const std::string& tflite_model_bytes, Device dev) {
   const char* buffer = tflite_model_bytes.c_str();
   size_t buffer_size = tflite_model_bytes.size();
   // Load compiled model as a FlatBufferModel
+
+  // According to tflite_runtime.cc, the buffer for tflite::FlatBufferModel
+  // should be allocated on flatBuffersBuffer_ to make share it must be kept alive
+  // for interpreters.
+  flatBuffersBuffer_ = std::unique_ptr<char[]>(new char[buffer_size]);
+  std::memcpy(flatBuffersBuffer_.get(), buffer, buffer_size);
   std::unique_ptr<tflite::FlatBufferModel> model =
-      tflite::FlatBufferModel::BuildFromBuffer(buffer, buffer_size);
+      tflite::FlatBufferModel::BuildFromBuffer(flatBuffersBuffer_.get(), buffer_size);
   // Build resolver
   tflite::ops::builtin::BuiltinOpResolver resolver;
   // Init EdgeTPUContext object

--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -68,9 +68,13 @@ def skipped_test_tflite_runtime():
         server = rpc.Server("127.0.0.1")
         remote = rpc.connect(server.host, server.port)
         dev = remote.cpu(0)
+        if target_edgetpu:
+            runtime_target = "edge_tpu"
+        else:
+            runtime_target = "cpu"
 
         with open(tflite_model_path, "rb") as model_fin:
-            runtime = tflite_runtime.create(model_fin.read(), dev)
+            runtime = tflite_runtime.create(model_fin.read(), dev, runtime_target)
             runtime.set_input(0, tvm.nd.array(tflite_input, dev))
             runtime.invoke()
             out = runtime.get_output(0)

--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -23,6 +23,8 @@ from tvm.contrib import utils, tflite_runtime
 
 # import tflite_runtime.interpreter as tflite
 
+# NOTE: This script was tested on tensorflow/tflite (v2.4.1)
+
 
 def skipped_test_tflite_runtime():
     def get_tflite_model_path(target_edgetpu):


### PR DESCRIPTION
This PR fixes a bug in `EdgeTPURuntime::Init()`, in which `flatBuffersBuffer_` is not used for initializing `FlatBufferModel`.
This bug causes a SEGV during `TFLiteRuntime::Invoke()`.

This PR also includes a small modification on tests/python/contrib/test_edgetpu_runtime.py to clarify we should pass "edge_tpu" for `tflite_runtime.create()` when using edgetpus.