### PR TITLE
[Docs] Fix docs of threefry_split and threefry_generate

### DIFF
--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -212,8 +212,8 @@ def threefry_generate(gen, out_shape):
     Parameters
     ----------
     gen : Tensor[10, uint64]
-        Generator state. Can be create with :py:func:`tvm.relay.threefry_key`. This should not be
-        reused in another function, otherwise random numbers will be repeated.
+        Generator state. Can be create with :py:func:`tvm.relay.random.threefry_key`. This should
+        not be reused in another function, otherwise random numbers will be repeated.
 
     out_shape : Sequence[int]
         Output shape of the random numbers. Product of all dimensions must be a multiple of 4.
@@ -352,8 +352,8 @@ def threefry_split(gen):
     Parameters
     ----------
     gen : Tensor[10, uint64]
-        Generator state. Can be create with :py:func:`tvm.relay.threefry_key`. This should not be
-        reused in another function, otherwise random numbers will be repeated.
+        Generator state. Can be create with :py:func:`tvm.relay.random.threefry_key`. This should
+        not be reused in another function, otherwise random numbers will be repeated.
 
     Returns
     -------


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

This PR fixed the docs of the `threefry_split` and `threefry_generate`, so that they are now pointing to the correct module path of `threefry_key`.

Thank you for your time on reviewing this PR.