### PR TITLE
Mark zephyr install world-writable in docker image to unblock #7995.

### DIFF
--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -41,25 +41,18 @@ sudo apt-get update
 
 sudo apt-get install -y cmake
 
-#mkdir /opt/west
-#python3.6 -mvenv /opt/west  # NOTE: include .6 to make a python3.6 link for west/cmake.
-#/opt/west/bin/pip3 install west
 pip3 install west
-
-#cat <<EOF | tee /usr/local/bin/west >/dev/null
-##!/bin/bash -e
-#
-#source /opt/west/bin/activate
-#export ZEPHYR_BASE=/opt/zephyrproject/zephyr
-#west "\$@"
-#EOF
-#chmod a+x /usr/local/bin/west
 
 # Init ZephyrProject
 ZEPHYR_PROJECT_PATH=/opt/zephyrproject
 ZEPHYR_INIT_SCRIPT=$(find -name "ubuntu_init_zephyr_project.sh")
 bash ${ZEPHYR_INIT_SCRIPT} ${ZEPHYR_PROJECT_PATH} v2.5-branch
 cd ${ZEPHYR_PROJECT_PATH}
+
+# As part of the build process, Zephyr needs to touch some symlinks in zephyr/misc/generated/syscalls_links (this path is relative to the
+# build directory for a project). Mark the zephyr installation world-writable since this is a docker
+# container
+chmod -R o+w ${ZEPHYR_PROJECT_PATH}
 
 # This step is required because of the way docker/bash.sh works. It sets the user home directory to
 # /workspace (or the TVM root, anyhow), and this means that zephyr expects a ~/.cache directory to be


### PR DESCRIPTION
Unclear what happened here, but upon rebuilding ci-qemu, lots of:
```
:~/tests/micro/zephyr/test_zephyr_qemu_x86_workspace/2021-05-13T17-30-31/build/utvm_rpc_server/__tvm_build$ make
cmake -E touch_nocreate: failed to update "zephyr/misc/generated/syscalls_links/include_usb_class".
zephyr/CMakeFiles/parse_syscalls_target.dir/build.make:521: recipe for target 'zephyr/misc/generated/syscalls_links/include_usb_class' failed
make[2]: *** [zephyr/misc/generated/syscalls_links/include_usb_class] Error 1
CMakeFiles/Makefile2:2048: recipe for target 'zephyr/CMakeFiles/parse_syscalls_target.dir/all' failed
make[1]: *** [zephyr/CMakeFiles/parse_syscalls_target.dir/all] Error 2
Makefile:90: recipe for target 'all' failed
make: *** [all] Error 2
```

marking Zephyr world-writable, which should resolve the need for make to touch the syscalls dependencies. This isn't strictly ideal, since a test could make modifications to Zephyr and corrupt following tests, but we have this issue everywhere and I believe Zephyr assumes it is writable when building.

Also remove some commented lines in the install script.