### PR TITLE
[VM] add removeUnusedFunctions pass in vm memoryopt

### DIFF
--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -978,6 +978,9 @@ void VMCompiler::Lower(IRModule mod, const TargetsMap& targets, const tvm::Targe
 
 transform::Sequential MemoryOpt(tvm::Target host_target, TargetsMap targets) {
   Array<Pass> pass_seqs;
+  // Remove unused functions
+  Array<runtime::String> entry_functions{"main"};
+  pass_seqs.push_back(transform::RemoveUnusedFunctions(entry_functions));
   // Manifest the allocations.
   pass_seqs.push_back(transform::ManifestAlloc(host_target, targets));
 

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -29,6 +29,7 @@ from tvm.relay import testing
 from tvm.contrib import utils
 from tvm import rpc
 import tvm.testing
+from tvm.relay.transform import InferType
 
 
 def check_result(args, expected_result, mod=None):
@@ -185,6 +186,29 @@ def test_multiple_ifs():
     res = vmobj_to_list(vm.evaluate()(False))
     assert res == [1, 0]
 
+@tvm.testing.uses_gpu
+def test_unused_function():
+    cond = relay.const(True)
+    mod = tvm.IRModule()
+    then_name = relay.GlobalVar("times_2")
+    # define unused function
+    else_name = relay.GlobalVar("times_3")
+    t1 = relay.TensorType((2,2), dtype="float32")
+    x1 = relay.var("x1", t1, dtype="float32")
+    x2 = relay.var("x2", t1, dtype="float32")
+    f2 = relay.multiply(x1, relay.const(2.0))
+    f3 = relay.multiply(x2, relay.const(3.0))
+    mod[then_name] = relay.Function([x1], f2)
+    mod[else_name] = relay.Function([x2], f3)
+    mod = InferType()(mod)
+    x3 = relay.var("x3", t1, dtype="float32")
+    # put unused function in else branch 
+    f = relay.If(cond, then_name(x3), else_name(x3))
+    mod["main"] = relay.Function([x3], f)
+    x_data = np.random.rand(2, 2).astype("float32")
+    y_data = x_data * 2
+
+    check_result([x_data], y_data, mod=mod)
 
 @tvm.testing.uses_gpu
 def test_simple_call():

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -186,6 +186,7 @@ def test_multiple_ifs():
     res = vmobj_to_list(vm.evaluate()(False))
     assert res == [1, 0]
 
+
 @tvm.testing.uses_gpu
 def test_unused_function():
     cond = relay.const(True)
@@ -193,7 +194,7 @@ def test_unused_function():
     then_name = relay.GlobalVar("times_2")
     # define unused function
     else_name = relay.GlobalVar("times_3")
-    t1 = relay.TensorType((2,2), dtype="float32")
+    t1 = relay.TensorType((2, 2), dtype="float32")
     x1 = relay.var("x1", t1, dtype="float32")
     x2 = relay.var("x2", t1, dtype="float32")
     f2 = relay.multiply(x1, relay.const(2.0))
@@ -202,13 +203,14 @@ def test_unused_function():
     mod[else_name] = relay.Function([x2], f3)
     mod = InferType()(mod)
     x3 = relay.var("x3", t1, dtype="float32")
-    # put unused function in else branch 
+    # put unused function in else branch
     f = relay.If(cond, then_name(x3), else_name(x3))
     mod["main"] = relay.Function([x3], f)
     x_data = np.random.rand(2, 2).astype("float32")
     y_data = x_data * 2
 
     check_result([x_data], y_data, mod=mod)
+
 
 @tvm.testing.uses_gpu
 def test_simple_call():


### PR DESCRIPTION
If unused function presents like a cond branch never been accessed, memory allocation pass will throw erros since it is not presented in context_analysis map like errors shows below:

```
TVMError: Check failed: (it != context_analysis_map_.end()) is false: Cannot find expr in the context analysis map:
E           #[version = "0.0.5"]
E           free_var %x2: Tensor[(2, 2), float32];
E           %0 = fn (%p0: Tensor[(2, 2), float32], Primitive=1) -> Tensor[(2, 2), float32] {
E             multiply(%p0, 3f /* ty=float32 */) /* ty=Tensor[(2, 2), float32] */
E           };
E           %0(%x2) /* ty=Tensor[(2, 2), float32] */
```

Add RemoveUnusedFunctions pass before memory allocation to avoid this issue.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
