### PR TITLE
[Relay][PRNG] Add uniform distribution generator wrt threefry PRNG

### DIFF
--- a/include/tvm/relay/attrs/random.h
+++ b/include/tvm/relay/attrs/random.h
@@ -43,7 +43,8 @@ struct UniformAttrs : public tvm::AttrsNode<UniformAttrs> {
 
   TVM_DECLARE_ATTRS(UniformAttrs, "relay.attrs.UniformAttrs") {
     TVM_ATTR_FIELD(out_shape).describe("Shape of random numbers to generate");
-    TVM_ATTR_FIELD(out_dtype).set_default(NullValue<DataType>())
+    TVM_ATTR_FIELD(out_dtype)
+        .set_default(NullValue<DataType>())
         .describe("Data type of the generated numbers");
   }
 };

--- a/include/tvm/relay/attrs/random.h
+++ b/include/tvm/relay/attrs/random.h
@@ -37,6 +37,17 @@ struct ThreefryGenerateAttrs : public tvm::AttrsNode<ThreefryGenerateAttrs> {
   }
 };
 
+struct UniformAttrs : public tvm::AttrsNode<UniformAttrs> {
+  Array<Integer> out_shape;
+  DataType out_dtype;
+
+  TVM_DECLARE_ATTRS(UniformAttrs, "relay.attrs.UniformAttrs") {
+    TVM_ATTR_FIELD(out_shape).describe("Shape of random numbers to generate");
+    TVM_ATTR_FIELD(out_dtype).set_default(NullValue<DataType>())
+        .describe("Data type of the generated numbers");
+  }
+};
+
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_ATTRS_RANDOM_H_

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -562,3 +562,8 @@ class BatchToSpaceNDAttrs(Attrs):
 @tvm._ffi.register_object("relay.attrs.ThreefryGenerateAttrs")
 class ThreefryGenerateAttrs(Attrs):
     """Attributes used in ThreefryGenerateAttrs operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.UniformAttrs")
+class UniformAttrs(Attrs):
+    """Attributes used in UniformAttrs operators"""

--- a/python/tvm/relay/op/random/_kernel.py
+++ b/python/tvm/relay/op/random/_kernel.py
@@ -27,3 +27,7 @@ register_strategy("random.threefry_generate", strategy.threefry_generate_strateg
 register_pattern("random.threefry_generate", OpPattern.OPAQUE)
 register_strategy("random.threefry_split", strategy.threefry_split_strategy)
 register_pattern("random.threefry_split", OpPattern.OPAQUE)
+
+# Distribution
+register_strategy("random.uniform", strategy.uniform_strategy)
+register_pattern("random.uniform", OpPattern.OPAQUE)

--- a/python/tvm/relay/op/random/kernel.py
+++ b/python/tvm/relay/op/random/kernel.py
@@ -147,7 +147,7 @@ def uniform(key, shape, dtype="float32", low=0.0, high=1.0):
     .. code-block:: python
 
         key = threefry_key(0)
-        random_values = uniform(key, (100,), low=0, high=10)
+        key, random_values = uniform(key, (100,), low=0, high=10)
 
     Parameters
     ----------

--- a/python/tvm/relay/op/random/kernel.py
+++ b/python/tvm/relay/op/random/kernel.py
@@ -134,7 +134,7 @@ def threefry_split(key):
     return _make.threefry_split(key)
 
 
-def uniform(key, shape, dtype="float32", low=0., high=1.):
+def uniform(key, shape, dtype="float32", low=0.0, high=1.0):
     """Draw samples from a uniform distribution.
 
     Samples are uniformly distributed over the half-open interval [low, high)

--- a/python/tvm/relay/op/random/kernel.py
+++ b/python/tvm/relay/op/random/kernel.py
@@ -173,6 +173,9 @@ def uniform(key, shape, dtype="float32", low=0.0, high=1.0):
 
     Returns
     -------
+    new_key : relay.Expr
+        New random key to pass to future uses of random functions.
+
     random_values : relay.Expr
         The generated uniform distributed random numbers.
     """

--- a/python/tvm/relay/op/random/kernel.py
+++ b/python/tvm/relay/op/random/kernel.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 import sys
 import numpy as np
 
-from ...expr import Constant
+from ...expr import Constant, Expr, const
 from .... import nd
 from . import _make
 
@@ -132,3 +132,52 @@ def threefry_split(key):
         :py:func:`threefry_generate`.
     """
     return _make.threefry_split(key)
+
+
+def uniform(key, shape, dtype="float32", low=0., high=1.):
+    """Draw samples from a uniform distribution.
+
+    Samples are uniformly distributed over the half-open interval [low, high)
+    (includes low, but excludes high). In other words, any value within the
+    given interval is equally likely to be drawn by uniform.
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        key = threefry_key(0)
+        random_values = uniform(key, (100,), low=0, high=10)
+
+    Parameters
+    ----------
+    key : relay.Expr
+        key that uniquely determines the random values. Multiple uses with the
+        same generator will generate the same random values. This generator should be
+        treated as an opaque pointer. You can create one from calling
+        :py:func:`threefry_key`, :py:func:`threefry_split`, or
+        :py:func:`threefry_generate`. **Do not use this generator again after calling
+        this function.**
+
+    shape : Sequence[int]
+        Desired outputs shape of random numbers.
+
+    dtype : str
+        Desired outputs type of random numbers.
+
+    low : float or relay.Expr, optional
+        Lower bound of the uniform distribution.
+
+    high : float or relay.Expr, optional
+        Upper bound of the uniform distribution.
+
+    Returns
+    -------
+    random_values : relay.Expr
+        The generated uniform distributed random numbers.
+    """
+    if not isinstance(low, Expr):
+        low = const(low, dtype=dtype)
+    if not isinstance(high, Expr):
+        high = const(high, dtype=dtype)
+    return _make.uniform(key, low, high, shape, dtype)

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1500,7 +1500,7 @@ def wrap_compute_uniform(topi_compute):
     """Wrap uniform topi compute"""
 
     def _compute_uniform(attrs, inputs, _):
-        return [topi_compute(inputs[0], inputs[1], inputs[2], attrs.out_shape, attrs.out_dtype)]
+        return list(topi_compute(inputs[0], inputs[1], inputs[2], attrs.out_shape, attrs.out_dtype))
 
     return _compute_uniform
 

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1495,6 +1495,29 @@ def threefry_split_strategy(attrs, inputs, out_type, target):
     return strategy
 
 
+# uniform
+def wrap_compute_uniform(topi_compute):
+    """Wrap uniform topi compute"""
+
+    def _compute_uniform(attrs, inputs, _):
+        return [topi_compute(inputs[0], inputs[1], inputs[2],
+                             attrs.out_shape, attrs.out_dtype)]
+
+    return _compute_uniform
+
+
+@override_native_generic_func("uniform_strategy")
+def uniform_strategy(attrs, inputs, out_type, target):
+    """uniform generic strategy"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_uniform(topi.random.uniform),
+        wrap_topi_schedule(topi.generic.schedule_extern),
+        name="uniform.generic",
+    )
+    return strategy
+
+
 def wrap_compute_scanop(topi_compute):
     """Wrap scanop style topi compute"""
 

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1500,8 +1500,7 @@ def wrap_compute_uniform(topi_compute):
     """Wrap uniform topi compute"""
 
     def _compute_uniform(attrs, inputs, _):
-        return [topi_compute(inputs[0], inputs[1], inputs[2],
-                             attrs.out_shape, attrs.out_dtype)]
+        return [topi_compute(inputs[0], inputs[1], inputs[2], attrs.out_shape, attrs.out_dtype)]
 
     return _compute_uniform
 

--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -504,6 +504,7 @@ def uniform(gen, low, high, out_shape, out_dtype):
         Tensor of random numbers with shape `out_shape` and type `out_dtype`.
     """
     new_gen, random_bits = threefry_generate(gen, out_shape)
+    assert out_dtype in ("float32", "float64")
     if out_dtype == "float32":
         random_dtype = "uint32"
         nbits = 32

--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -504,7 +504,9 @@ def uniform(gen, low, high, out_shape, out_dtype):
         Tensor of random numbers with shape `out_shape` and type `out_dtype`.
     """
     new_gen, random_bits = threefry_generate(gen, out_shape)
-    assert out_dtype in ("float32", "float64")
+    assert out_dtype in ("float32", "float64"), (
+        "Only support float32 or float64 for now, got %s" % out_dtype
+    )
     if out_dtype == "float32":
         random_dtype = "uint32"
         nbits = 32

--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -512,11 +512,8 @@ def uniform(gen, low, high, out_shape, out_dtype):
         standard_uniform = bits.astype(out_dtype) / float(1 << nfraction)
         return standard_uniform
 
-    standard_uniform_values = tvm.te.compute(
-        out_shape, lambda *i : uniform_scalar(random_bits(*i)))
+    standard_uniform_values = tvm.te.compute(out_shape, lambda *i: uniform_scalar(random_bits(*i)))
 
-    uniform_values = tvm.topi.add(
-                        tvm.topi.multiply(standard_uniform_values, high - low),
-                        low)
+    uniform_values = tvm.topi.add(tvm.topi.multiply(standard_uniform_values, high - low), low)
 
     return uniform_values

--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -497,6 +497,9 @@ def uniform(gen, low, high, out_shape, out_dtype):
 
     Returns
     -------
+    new_gen : ThreefryKey
+        New generator state that is distinct from `gen`.
+
     out : Tensor[out_shape, out_dtype]
         Tensor of random numbers with shape `out_shape` and type `out_dtype`.
     """

--- a/src/relay/op/random/kernel.cc
+++ b/src/relay/op/random/kernel.cc
@@ -97,7 +97,8 @@ bool UniformRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     oshape.push_back(x);
   }
   DataType out_dtype = param->out_dtype;
-
+  // we are supporting float32 and float64 at the moment.
+  ICHECK(out_dtype.is_float() && (out_dtype.bits() == 32 || out_dtype.bits() == 64));
   reporter->Assign(types[0], ThreefryKeyType());
   reporter->Assign(types[1], TensorType({}, out_dtype));
   reporter->Assign(types[2], TensorType({}, out_dtype));

--- a/src/relay/op/random/kernel.cc
+++ b/src/relay/op/random/kernel.cc
@@ -90,7 +90,7 @@ TVM_REGISTER_NODE_TYPE(UniformAttrs);
 bool UniformRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                 const TypeReporter& reporter) {
   const UniformAttrs* param = attrs.as<UniformAttrs>();
-  ICHECK_EQ(types.size(), 4) << "Uniform should have three input and one output";
+  ICHECK_EQ(types.size(), 4) << "Uniform should have three inputs and one output";
 
   std::vector<IndexExpr> oshape;
   for (auto& x : param->out_shape) {

--- a/src/relay/op/random/kernel.cc
+++ b/src/relay/op/random/kernel.cc
@@ -90,7 +90,7 @@ TVM_REGISTER_NODE_TYPE(UniformAttrs);
 bool UniformRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                 const TypeReporter& reporter) {
   const UniformAttrs* param = attrs.as<UniformAttrs>();
-  ICHECK_EQ(types.size(), 4) << "ThreefryGenerate should have one input and one output";
+  ICHECK_EQ(types.size(), 4) << "Uniform should have three input and one output";
 
   std::vector<IndexExpr> oshape;
   for (auto& x : param->out_shape) {
@@ -102,7 +102,7 @@ bool UniformRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   reporter->Assign(types[1], TensorType({}, out_dtype));
   reporter->Assign(types[2], TensorType({}, out_dtype));
   // generate returns the next key and an array of random values
-  reporter->Assign(types[3], TensorType(oshape, out_dtype));
+  reporter->Assign(types[3], TupleType({ThreefryKeyType(), TensorType(oshape, out_dtype)}));
   return true;
 }
 

--- a/src/relay/op/random/kernel.cc
+++ b/src/relay/op/random/kernel.cc
@@ -98,7 +98,12 @@ bool UniformRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   }
   DataType out_dtype = param->out_dtype;
   // we are supporting float32 and float64 at the moment.
-  ICHECK(out_dtype.is_float() && (out_dtype.bits() == 32 || out_dtype.bits() == 64));
+  if (!(out_dtype.is_float() && (out_dtype.bits() == 32 || out_dtype.bits() == 64))) {
+    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
+                                     << "We only support generating uniform random value of "
+                                     << "type float32 or float64, got " << out_dtype << ".");
+    return false;
+  }
   reporter->Assign(types[0], ThreefryKeyType());
   reporter->Assign(types[1], TensorType({}, out_dtype));
   reporter->Assign(types[2], TensorType({}, out_dtype));

--- a/src/relay/op/random/kernel.cc
+++ b/src/relay/op/random/kernel.cc
@@ -85,5 +85,46 @@ RELAY_REGISTER_OP("random.threefry_split")
     .add_argument("key", "Tensor", "Input Threefry key")
     .add_type_rel("ThreefrySplit", ThreefrySplitRel);
 
+TVM_REGISTER_NODE_TYPE(UniformAttrs);
+
+bool UniformRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+                const TypeReporter& reporter) {
+  const UniformAttrs* param = attrs.as<UniformAttrs>();
+  ICHECK_EQ(types.size(), 4) << "ThreefryGenerate should have one input and one output";
+
+  std::vector<IndexExpr> oshape;
+  for (auto& x : param->out_shape) {
+    oshape.push_back(x);
+  }
+  DataType out_dtype = param->out_dtype;
+
+  reporter->Assign(types[0], ThreefryKeyType());
+  reporter->Assign(types[1], TensorType({}, out_dtype));
+  reporter->Assign(types[2], TensorType({}, out_dtype));
+  // generate returns the next key and an array of random values
+  reporter->Assign(types[3], TensorType(oshape, out_dtype));
+  return true;
+}
+
+Expr MakeUniform(Expr key, Expr low, Expr high, Array<Integer> out_shape, DataType out_dtype) {
+  auto attrs = make_object<UniformAttrs>();
+  attrs->out_shape = out_shape;
+  attrs->out_dtype = out_dtype;
+  static const Op& op = Op::Get("random.uniform");
+  return Call(op, {key, low, high}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relay.op.random._make.uniform").set_body_typed(MakeUniform);
+
+RELAY_REGISTER_OP("random.uniform")
+    .describe(
+        R"doc(Generate an array of random numbers under uniform distribution.)doc" TVM_ADD_FILELINE)
+    .set_num_inputs(3)
+    .set_attrs_type<UniformAttrs>()
+    .add_argument("key", "Tensor", "Input Threefry key")
+    .add_argument("low", "Tensor", "Lower bound of the distribution")
+    .add_argument("high", "Tensor", "Higher bound of the distribution")
+    .add_type_rel("Uniform", UniformRel);
+
 }  // namespace relay
 }  // namespace tvm

--- a/tests/python/relay/test_prng.py
+++ b/tests/python/relay/test_prng.py
@@ -105,15 +105,17 @@ def test_threefry_split_infer():
 
 def test_uniform_infer():
     oshape = (12,)
-    odtype = "float32"
-    gen_type = tvm.relay.TensorType(oshape, dtype=odtype)
-    expected_type = gen_type
+    odtypes = ["float32", "float64"]
+    for odtype in odtypes:
+        key_type = tvm.relay.TensorType([10], dtype="uint64")
+        gen_type = tvm.relay.TensorType(oshape, dtype=odtype)
+        expected_type = tvm.relay.TupleType([key_type, gen_type])
 
-    key = tvm.relay.random.threefry_key(1)
-    out_keys = tvm.relay.random.uniform(key, oshape, odtype)
-    f = tvm.relay.Function([], out_keys)
-    f = run_infer_type(f)
-    assert tvm.ir.structural_equal(f.ret_type, expected_type)
+        key = tvm.relay.random.threefry_key(1)
+        rand1 = tvm.relay.random.uniform(key, oshape, odtype)
+        f = tvm.relay.Function([], rand1)
+        f = run_infer_type(f)
+        assert tvm.ir.structural_equal(f.ret_type, expected_type)
 
 
 @pytest.mark.xfail(raises=tvm.error.TVMError)

--- a/tests/python/relay/test_prng.py
+++ b/tests/python/relay/test_prng.py
@@ -103,6 +103,19 @@ def test_threefry_split_infer():
     assert tvm.ir.structural_equal(f.ret_type, expected_type)
 
 
+def test_uniform_infer():
+    oshape = (12,)
+    odtype = "float32"
+    gen_type = tvm.relay.TensorType(oshape, dtype=odtype)
+    expected_type = gen_type
+
+    key = tvm.relay.random.threefry_key(1)
+    out_keys = tvm.relay.random.uniform(key, oshape, odtype)
+    f = tvm.relay.Function([], out_keys)
+    f = run_infer_type(f)
+    assert tvm.ir.structural_equal(f.ret_type, expected_type)
+
+
 @pytest.mark.xfail(raises=tvm.error.TVMError)
 def test_threefry_generate_infer_fail():
     # xfail: key size should be 10

--- a/tests/python/topi/python/test_topi_prng.py
+++ b/tests/python/topi/python/test_topi_prng.py
@@ -49,12 +49,12 @@ def uniform(target, dev, gen, low, high, size, dtype):
     high_placeholder = tvm.te.placeholder(high.shape, name="high", dtype=dtype)
     print(low_placeholder)
     print(high_placeholder)
-    out_placeholder = tvm.topi.random.uniform(gen_placeholder, low_placeholder,
-                                              high_placeholder, size, dtype)
+    out_placeholder = tvm.topi.random.uniform(
+        gen_placeholder, low_placeholder, high_placeholder, size, dtype
+    )
     print(out_placeholder)
     s = tvm.topi.generic.schedule_extern([out_placeholder])
-    f = tvm.build(s, [gen_placeholder, low_placeholder, high_placeholder,
-                      out_placeholder])
+    f = tvm.build(s, [gen_placeholder, low_placeholder, high_placeholder, out_placeholder])
     rands = tvm.nd.array(np.zeros(size, dtype=dtype))
     f(tvm.nd.array(gen), tvm.nd.array(low), tvm.nd.array(high), rands)
     return rands.asnumpy()
@@ -143,8 +143,7 @@ def test_uniform(target, dev):
     dtype = "float32"
     low = np.array(5.0, dtype=dtype)
     high = np.array(10.0, dtype=dtype)
-    rands = uniform(
-        target, dev, gen, low, high, (m, n), "float32")
+    rands = uniform(target, dev, gen, low, high, (m, n), "float32")
     assert abs(np.mean(rands) - 7.5) < 1e-1
     assert abs(np.min(rands) - 5.0) < 1e-3
     assert abs(np.max(rands) - 10.0) < 1e-3

--- a/tests/python/topi/python/test_topi_prng.py
+++ b/tests/python/topi/python/test_topi_prng.py
@@ -47,12 +47,9 @@ def uniform(target, dev, gen, low, high, size, dtype):
     gen_placeholder = tvm.te.placeholder(gen.shape, name="gen", dtype="uint64")
     low_placeholder = tvm.te.placeholder(low.shape, name="low", dtype=dtype)
     high_placeholder = tvm.te.placeholder(high.shape, name="high", dtype=dtype)
-    print(low_placeholder)
-    print(high_placeholder)
     out_placeholder = tvm.topi.random.uniform(
         gen_placeholder, low_placeholder, high_placeholder, size, dtype
     )
-    print(out_placeholder)
     s = tvm.topi.generic.schedule_extern([out_placeholder])
     f = tvm.build(s, [gen_placeholder, low_placeholder, high_placeholder, out_placeholder])
     rands = tvm.nd.array(np.zeros(size, dtype=dtype))

--- a/tests/python/topi/python/test_topi_prng.py
+++ b/tests/python/topi/python/test_topi_prng.py
@@ -147,8 +147,8 @@ def test_uniform(target, dev):
         new_gen, rands = uniform(target, dev, gen, low, high, (m, n), dtype)
         assert (gen != new_gen).any()
         assert abs(np.mean(rands) - 7.5) < 1e-1
-        assert abs(np.min(rands) - 5.0) < 1e-3
-        assert abs(np.max(rands) - 10.0) < 1e-3
+        assert np.min(rands) >= 5.0
+        assert np.max(rands) <= 10.0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a uniform distribution generator using the  threefry PRNG introduced in #7083. We would need uniform to develop the training phase dropout as the following roadmap:

```
uniform -> bernoulli -> dropout
```

The algorithm used is basically the same as the one used in jax: using the random bits generated from `threefry_generate` as the fraction section of the float32 or float64. To be specific, I use the last 23 bits of the random bits for float32 and last 52 for float64. There is one different from the jax implementation. In jax, they used a bitcast to turn uint into float:

```python
# jax implementation
def _uniform(key, shape, dtype, minval, maxval) -> jnp.ndarray:
  ...
  bits = _random_bits(key, nbits, shape)

  # The strategy here is to randomize only the mantissa bits with an exponent of
  # 1 (after applying the bias), then shift and scale to the desired range. The
  # bit-level transformation we use relies on Numpy and XLA having bit-for-bit
  # equivalent float representations, which might not be true on all platforms.
  float_bits = lax.bitwise_or(
      lax.shift_right_logical(bits, np.array(nbits - nmant, lax.dtype(bits))),
      np.array(1., dtype).view(_UINT_DTYPES[nbits]))
  floats = lax.bitcast_convert_type(float_bits, dtype) - np.array(1., dtype)
  return lax.max(
      minval,
      lax.reshape(floats * (maxval - minval) + minval, shape.positional))
```

However, as I haven't found the bitcast in te or topi, I use a divide to cast the type, which may be slower:

```python
    def uniform_scalar(bits):
        bits = bits >> (nbits - nfraction)
        standard_uniform = bits.astype(out_dtype) / float(1 << nfraction)
        return standard_uniform
```

Thank you for your time on reviewing this PR. I may not be familiar enough with the tvm codebase at the moment, so I'm sorry for breaking any conventions in the community and I'd love to fix them :).

Gently ping @tqchen @altanh @tkonolige 