### PR TITLE
Fix AttributeError when TEST_DATA_ROOT_PATH is set

### DIFF
--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -121,7 +121,7 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
 
 
 if "TEST_DATA_ROOT_PATH" in environ:
-    TEST_DATA_ROOT_PATH = environ.get("TEST_DATA_ROOT_PATH")
+    TEST_DATA_ROOT_PATH = Path(environ.get("TEST_DATA_ROOT_PATH"))
 else:
     TEST_DATA_ROOT_PATH = Path(Path("~").expanduser(), ".tvm_test_data")
 TEST_DATA_ROOT_PATH.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Hello Community,

Nice to meet you! I have been playing TVM for a while. It's an exciting project:)
I encountered an error while using download API with TEST_DATA_ROOT_PATH set, so try to fix it.

Initiate a Path object from TEST_DATA_ROOT_PATH to fix the error:
AttributeError: 'str' object has no attribute 'mkdir'

You might want to take a look :)

Thanks!

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

@tqchen 