### PR TITLE
[Vulkan] Broke out implicit device requirements into SPIRVSupport

### DIFF
--- a/src/target/spirv/build_vulkan.cc
+++ b/src/target/spirv/build_vulkan.cc
@@ -75,7 +75,7 @@ runtime::Module BuildSPIRV(IRModule mod, Target target, bool webgpu_restriction)
 
   mod = tir::transform::PointerValueTypeRewrite()(std::move(mod));
 
-  CodeGenSPIRV cg;
+  CodeGenSPIRV cg(target);
 
   for (auto kv : mod->functions) {
     ICHECK(kv.second->IsInstance<PrimFuncNode>()) << "CodeGenSPIRV: Can only take PrimFunc";

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -37,6 +37,8 @@
 namespace tvm {
 namespace codegen {
 
+CodeGenSPIRV::CodeGenSPIRV(Target target) : spirv_support_(target) {}
+
 runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::string& name) {
   this->InitFuncState();
   ICHECK(f->HasNonzeroAttr(tir::attr::kNoAlias)) << "SPIRV only takes restricted memory model";
@@ -44,7 +46,8 @@ runtime::VulkanShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::
   uint32_t num_buffer = 0;
 
   // Currently, all storage and uniform buffer arguments are passed as
-  // a single descriptor set at index 0.
+  // a single descriptor set at index 0.  If ever non-zero, must
+  // ensure it is less than maxBoundDescriptorSets.
   const uint32_t descriptor_set = 0;
 
   for (Var arg : f->params) {
@@ -114,7 +117,7 @@ void CodeGenSPIRV::InitFuncState() {
   var_map_.clear();
   storage_info_.clear();
   analyzer_.reset(new arith::Analyzer());
-  builder_.reset(new spirv::IRBuilder());
+  builder_.reset(new spirv::IRBuilder(spirv_support_));
   builder_->InitHeader();
 }
 

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -25,6 +25,7 @@
 #define TVM_TARGET_SPIRV_CODEGEN_SPIRV_H_
 
 #include <tvm/arith/analyzer.h>
+#include <tvm/target/target.h>
 #include <tvm/tir/analysis.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/function.h>
@@ -38,6 +39,7 @@
 #include "../../runtime/thread_storage_scope.h"
 #include "../../runtime/vulkan/vulkan_shader.h"
 #include "ir_builder.h"
+#include "spirv_support.h"
 
 namespace tvm {
 namespace codegen {
@@ -50,6 +52,14 @@ using namespace tir;
 class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
                      public StmtFunctor<void(const Stmt&)> {
  public:
+  /*!
+   * \brief Initialize the codegen based on a specific target.
+   *
+   * \param target The target for which code should be generated.  The
+   * device_type for this target must be kDLVulkan.
+   */
+  CodeGenSPIRV(Target target);
+
   /*!
    * \brief Compile and add function f to the current module.
    * \param f The function to be added.
@@ -131,6 +141,8 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
   spirv::Value GetThreadIndex(const IterVar& iv, const PrimExpr& extent);
   spirv::Value CreateStorageSync(const CallNode* op);
   void Scalarize(const PrimExpr& e, std::function<void(int i, spirv::Value v)> f);
+  // SPIRV-related capabilities of the target
+  SPIRVSupport spirv_support_;
   // The builder
   std::unique_ptr<spirv::IRBuilder> builder_;
   // Work group size of three

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -30,12 +30,15 @@
 // clang-format off
 #include <algorithm>
 #include <map>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include <spirv.hpp>
 // clang-format on
+
+#include "spirv_support.h"
 
 namespace tvm {
 namespace codegen {
@@ -268,6 +271,14 @@ class InstrBuilder {
  */
 class IRBuilder {
  public:
+  /*!
+   * \brief Initialize the codegen based on a specific feature set.
+   *
+   * \param support The features in SPIRV that are supported by the
+   * target device.
+   */
+  explicit IRBuilder(const SPIRVSupport& support);
+
   /*! \brief Initialize header */
   void InitHeader();
   /*! \brief Initialize the predefined contents */
@@ -278,29 +289,21 @@ class IRBuilder {
    * \return The finalized binary instruction.
    */
   Value ExtInstImport(const std::string& name) {
+    auto it = ext_inst_tbl_.find(name);
+    if (it != ext_inst_tbl_.end()) {
+      return it->second;
+    }
     Value val = NewValue(SType(), kExtInst);
-    ib_.Begin(spv::OpExtInstImport).AddSeq(val, name).Commit(&header_);
+    ib_.Begin(spv::OpExtInstImport).AddSeq(val, name).Commit(&extended_instruction_section_);
+    ext_inst_tbl_[name] = val;
     return val;
   }
   /*!
    * \brief Get the final binary built from the builder
    * \return The finalized binary instruction.
    */
-  std::vector<uint32_t> Finalize() {
-    std::vector<uint32_t> data;
-    // set bound
-    const int kBoundLoc = 3;
-    header_[kBoundLoc] = id_counter_;
-    data.insert(data.end(), header_.begin(), header_.end());
-    data.insert(data.end(), entry_.begin(), entry_.end());
-    data.insert(data.end(), exec_mode_.begin(), exec_mode_.end());
-    data.insert(data.end(), debug_.begin(), debug_.end());
-    data.insert(data.end(), decorate_.begin(), decorate_.end());
-    data.insert(data.end(), global_.begin(), global_.end());
-    data.insert(data.end(), func_header_.begin(), func_header_.end());
-    data.insert(data.end(), function_.begin(), function_.end());
-    return data;
-  }
+  std::vector<uint32_t> Finalize();
+
   /*!
    * \brief Create new label
    * \return The created new label
@@ -599,6 +602,19 @@ class IRBuilder {
   Value GetConst_(const SType& dtype, const uint64_t* pvalue);
   // declare type
   SType DeclareType(const DataType& dtype);
+
+  // Declare the appropriate SPIR-V capabilities and extensions to use
+  // this data type.
+  void AddCapabilityFor(const DataType& dtype);
+
+  /*! \brief SPIRV-related capabilities of the target
+   *
+   * This SPIRVSupport object is owned by the same CodeGenSPIRV
+   * object that owns the IRBuilder.  Therefore, safe to use a
+   * reference as the CodeGenSPIRV will live longer.
+   */
+  const SPIRVSupport& spirv_support_;
+
   /*! \brief internal instruction builder  */
   InstrBuilder ib_;
   /*! \brief Current label */
@@ -623,9 +639,22 @@ class IRBuilder {
   std::map<std::pair<uint32_t, spv::StorageClass>, SType> pointer_type_tbl_;
   /*! \brief map from constant int to its value */
   std::map<std::pair<uint32_t, uint64_t>, Value> const_tbl_;
-  /*! \brief Header segment, include import */
+  /*! \brief map from name of a ExtInstImport to its value */
+  std::map<std::string, Value> ext_inst_tbl_;
+
+  /*! \brief Header segment
+   *
+   * 5 words long, described in "First Words of Physical Layout"
+   * section of SPIR-V documentation.
+   */
   std::vector<uint32_t> header_;
-  /*! \brief engtry point segment */
+  /*! \brief SPIR-V capabilities used by this module. */
+  std::set<spv::Capability> capabilities_used_;
+  /*! \brief SPIR-V extensions used by this module. */
+  std::set<std::string> extensions_used_;
+  /*! \brief entry point segment */
+  std::vector<uint32_t> extended_instruction_section_;
+  /*! \brief entry point segment */
   std::vector<uint32_t> entry_;
   /*! \brief Header segment */
   std::vector<uint32_t> exec_mode_;

--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file spirv_support
+ *
+ * \brief Utility for determining which spirv capabilities a TVM
+ * target supports.
+ */
+
+#include "spirv_support.h"
+
+#include <spirv.hpp>
+
+namespace tvm {
+namespace codegen {
+
+SPIRVSupport::SPIRVSupport(tvm::Target target) {
+  ICHECK_EQ(target->kind->device_type, kDLVulkan)
+      << "SPIRVSupport can only be checked for vulkan device type";
+
+  // Currently, this codifies the assumptions that were present and
+  // implicit in previous implementations.  In the future, this will
+  // pull information from the specified `Target`.
+
+  supports_storage_buffer_storage_class = (SPV_VERSION >= 0x10300);
+  supports_storage_buffer_8bit_access = true;
+  supports_storage_buffer_16bit_access = true;
+  supports_float16 = true;
+  supports_int8 = true;
+  supports_int16 = true;
+  supports_int64 = true;
+}
+
+}  // namespace codegen
+}  // namespace tvm

--- a/src/target/spirv/spirv_support.h
+++ b/src/target/spirv/spirv_support.h
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file spirv_support
+ *
+ * \brief Utility for determining which spirv capabilities a TVM
+ * target supports.
+ */
+#ifndef TVM_TARGET_SPIRV_SPIRV_SUPPORT_H_
+#define TVM_TARGET_SPIRV_SPIRV_SUPPORT_H_
+
+#include <tvm/target/target.h>
+
+namespace tvm {
+namespace codegen {
+
+/*! \brief Represents which support a Vulkan driver has that are relevant to codegen */
+struct SPIRVSupport {
+  /*! \brief Determine spirv capabilities from a vulkan target.
+   */
+  explicit SPIRVSupport(Target target);
+
+  /*!
+   * \brief The supported subgroup operations
+   *
+   * Vulkan extension: VK_KHR_driver_properties
+   * Minimum vulkan version: 1.1
+   * Vulkan struct: VkPhysicalDeviceSubgroupProperties
+   * Device property: supportedOperations
+   *
+   * Requires vulkan 1.1 or higher to use.  If the
+   * VK_KHR_driver_properties extension is not present in order to
+   * query this value, or if the driver does not support vulkan 1.0,
+   * then this value will be set to 0.
+   *
+   */
+  uint32_t supported_subgroup_operations{0};
+
+  /*!
+   * \brief The maximum size (bytes) of push constants
+   *
+   * Vulkan struct: VkPhysicalDeviceLimits
+   * Device property: maxPushConstantsSize
+   *
+   * The maxPushConstantsSize from VkPhysicalDeviceLimits.
+   * Default value is from Vulkan spec, "Required Limits" table.
+   * Implementations may have a larger limit.
+   */
+  uint32_t max_push_constants_size{128};
+
+  /*!
+   * \brief The maximum size (bytes) of a uniform buffer.
+   *
+   * Vulkan struct: VkPhysicalDeviceLimits
+   * Device property: maxUniformBufferRange
+   *
+   * Default value is from Vulkan spec, "Required Limits" table.
+   * Implementations may have a larger limit.
+   */
+  uint32_t max_uniform_buffer_range{16384};
+
+  /*!
+   * \brief The maximum size (bytes) of a storage buffer.
+   *
+   * Vulkan struct: VkPhysicalDeviceLimits
+   * Device property: maxStorageBufferRange
+   *
+   * Default value is from Vulkan spec, "Required Limits" table.
+   * Implementations may have a larger limit.
+   */
+  uint32_t max_storage_buffer_range{1 << 27};
+
+  /*!
+   * \brief The maximum number of storage buffers accessible by a single shader.
+   *
+   * Vulkan struct: VkPhysicalDeviceLimits
+   * Device property: maxPerStageDescriptorStorageBuffers
+   *
+   * Default value is from Vulkan spec, "Required Limits" table.
+   * Implementations may have a larger limit, frequently much larger.
+   * (e.g. GTX 1080 has max of 2^20)
+   */
+  uint32_t max_per_stage_descriptor_storage_buffers{4};
+
+  /*!
+   * \brief Whether the driver supports StorageClassStorageBuffer
+   *
+   * Vulkan extension: VK_KHR_storage_buffer_storage_class
+   * Device property: N/A
+   * SPV Extension: SPV_KHR_storage_buffer_storage_class
+   * SPV Capability: N/A
+   *
+   * If support is present, access push constants and UBO as
+   * block-decorated StorageClassStorageBuffer.  Otherwise, access as
+   * buffer-block-decorated StorageClassUniform.  SPIRV 1.3 deprecated
+   * BufferBlock, so this should always be true drivers that support
+   * SPIRV 1.3.
+   *
+   */
+  bool supports_storage_buffer_storage_class{false};
+
+  /*!
+   * \brief Whether the driver supports reading/writing to 16-bit values
+   *
+   * Vulkan extension: VK_KHR_8bit_storage
+   * Vulkan struct: VkPhysicalDevice8BitStorageFeaturesKHR
+   * Device property: storageBuffer8BitAccess
+   * SPV extension: SPV_KHR_8bit_storage
+   * SPV Capability: StorageBuffer8BitAccess
+   *
+   * If support is present, can read/write 8-bit values, but doesn't
+   * necessarily provide 8-bit operations.
+   *
+   * If support is present, will declare StorageBuffer8BitAccess as
+   * needed.  If support is not present, will throw error if a
+   * PrimFunc calls for this functionality.  Unlike
+   * StorageUniform16BitAccess, no fallback to
+   * "StorageUniformBufferBlock8" is needed, as VK_KHR_8bit_storage
+   * requires VK_KHR_storage_buffer_storage_class to also be present.
+   *
+   */
+  bool supports_storage_buffer_8bit_access{false};
+
+  /*!
+   * \brief Whether the driver supports reading/writing to 16-bit values
+   *
+   * Vulkan extension: VK_KHR_16bit_storage
+   * Vulkan struct: VkPhysicalDevice16BitStorageFeaturesKHR
+   * Device property: storageBuffer16BitAccess
+   * SPV extension: SPV_KHR_16bit_storage
+   * SPV Capability: StorageBuffer16BitAccess, StorageUniformBufferBlock16
+   *
+   * If support is present, can read/write 16-bit values, but doesn't
+   * necessarily provide 16-bit operations.
+   *
+   * If support is present, will declare either
+   * StorageBuffer16BitAccess or StorageUniformBufferBlock16 as
+   * needed, selecting based on the value of
+   * supports_StorageBufferStorageClass.  If support is not present,
+   * will throw error if a PrimFunc calls for this functionality.
+   */
+  bool supports_storage_buffer_16bit_access{false};
+
+  /*!
+   * \brief Whether the driver supports operations involving 16-bit floats
+   *
+   * Vulkan extension: VK_KHR_shader_float16_int8
+   * Vulkan struct: VkPhysicalDeviceShaderFloat16Int8FeaturesKHR
+   * Device Property: shaderFloat16
+   * SPV Extension name: N/A
+   * SPV Capability: Float16, Float16Buffer
+   *
+   * If support is present, can perform 16-bit float operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to create a 16-bit float.
+   */
+  bool supports_float16{false};
+
+  /*!
+   * \brief Whether the driver supports operations involving 16-bit floats
+   *
+   * Vulkan extension: N/A
+   * Vulkan struct: VkPhysicalDeviceFeatures
+   * Device Property: shaderFloat64
+   * SPV Extension name: N/A
+   * SPV Capability: Float64
+   *
+   * If support is present, can perform 64-bit float operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to create a 64-bit float.
+   */
+  bool supports_float64{false};
+
+  /*!
+   * \brief Whether the driver supports operations involving 8-bit ints
+   *
+   * Vulkan extension: VK_KHR_shader_float16_int8
+   * Vulkan struct: VkPhysicalDeviceShaderFloat16Int8FeaturesKHR
+   * Device Property: shaderInt8
+   * SPV Extension name: N/A
+   * SPV Capability: Int8
+   *
+   * If support is present, can perform 8-bit int operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to create a 8-bit int.
+   */
+  bool supports_int8{false};
+
+  /*!
+   * \brief Whether the driver supports operations involving 8-bit ints
+   *
+   * Vulkan extension: N/A
+   * Vulkan struct: VkPhysicalDeviceFeatures
+   * Device Property: shaderInt16
+   * SPV Extension name: N/A
+   * SPV Capability: Int16
+   *
+   * If support is present, can perform 16-bit int operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to create a 16-bit int.
+   */
+  bool supports_int16{false};
+
+  /*!
+   * \brief Whether the driver supports operations involving 64-bit ints
+   *
+   * Vulkan extension: N/A
+   * Vulkan struct: VkPhysicalDeviceFeatures
+   * Device Property: shaderInt64
+   * SPV Extension name: N/A
+   * SPV Capability: Int64
+   *
+   * If support is present, can perform 64-bit int operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to create a 64-bit int.
+   */
+  bool supports_int64{false};
+};
+
+}  // namespace codegen
+}  // namespace tvm
+#endif  // TVM_TARGET_SPIRV_SPIRV_SUPPORT_H_


### PR DESCRIPTION
Codifies the current requirements that are implicit in the shaders
built by CodeGenSPIRV (e.g. can read from 8-bit buffers).  The next
steps for this development are (1) to query driver/device support
information from the device, (2) to pass these query parameters
through the Target, and (3) to ensure correct shader generation even
when features are not supported.

Step (3) will require exposing the target properties to relay
optimization passes.

