### PR TITLE
[Tests] Fix requires_gpu

### DIFF
--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -490,7 +490,14 @@ def requires_gpu(*args):
         Function to mark
     """
     _requires_gpu = [
-        pytest.mark.skipif(not tvm.cuda().exist, reason="No GPU present"),
+        pytest.mark.skipif(
+            not tvm.cuda().exist
+            and not tvm.rocm().exist
+            and not tvm.opencl().exist
+            and not tvm.metal().exist
+            and not tvm.vulkan().exist,
+            reason="No GPU present",
+        ),
         *uses_gpu(),
     ]
     return _compose(args, _requires_gpu)


### PR DESCRIPTION
`tvm.testing.requires_gpu` currently just checks whether the node has a CUDA GPU, but its purpose should be checking if any type of GPU device exists.

cc @tkonolige @tqchen 