### PR TITLE
apps: microtvm: Disable `CONFIG_FPU ` for Zephyr runtime

### DIFF
--- a/apps/microtvm/zephyr/aot_demo/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/apps/microtvm/zephyr/aot_demo/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -29,3 +29,6 @@ CONFIG_TEST_RANDOM_GENERATOR=y
 
 # For debugging.
 CONFIG_LED=y
+
+# For models with floating point.
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr/aot_demo/boards/qemu_x86.conf
+++ b/apps/microtvm/zephyr/aot_demo/boards/qemu_x86.conf
@@ -23,3 +23,6 @@ CONFIG_TIMER_RANDOM_GENERATOR=y
 
 # Default stack size is 1k, this is required for debug mode. 
 CONFIG_MAIN_STACK_SIZE=2000
+
+# For models with floating point.
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr/aot_demo/prj.conf
+++ b/apps/microtvm/zephyr/aot_demo/prj.conf
@@ -28,8 +28,5 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 CONFIG_CPLUSPLUS=y
 CONFIG_NEWLIB_LIBC=y
 
-# For models with floating point.
-CONFIG_FPU=y
-
 # For TVMPlatformAbort().
 CONFIG_REBOOT=y

--- a/apps/microtvm/zephyr/host_driven/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/apps/microtvm/zephyr/host_driven/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -29,3 +29,6 @@ CONFIG_TEST_RANDOM_GENERATOR=y
 
 # For debugging.
 CONFIG_LED=y
+
+# For models with floating point.
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr/host_driven/boards/nucleo_f746zg.conf
+++ b/apps/microtvm/zephyr/host_driven/boards/nucleo_f746zg.conf
@@ -28,3 +28,6 @@ CONFIG_ENTROPY_GENERATOR=y
 
 # For debugging.
 CONFIG_LED=y
+
+# For models with floating point.
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr/host_driven/boards/qemu_riscv32.conf
+++ b/apps/microtvm/zephyr/host_driven/boards/qemu_riscv32.conf
@@ -24,6 +24,9 @@ CONFIG_TIMER_RANDOM_GENERATOR=y
 # Default is 512, raised here for operations with large floating point data.
 CONFIG_MAIN_STACK_SIZE=2048
 
+# For models with floating point.
+CONFIG_FPU=y
+
 # For floating point operations. It has exception on floating point operations
 # without this flag.
 CONFIG_FPU_SHARING=y

--- a/apps/microtvm/zephyr/host_driven/boards/qemu_riscv64.conf
+++ b/apps/microtvm/zephyr/host_driven/boards/qemu_riscv64.conf
@@ -23,3 +23,6 @@ CONFIG_TIMER_RANDOM_GENERATOR=y
 
 # Default 512, for operations with large floating point data. 
 CONFIG_MAIN_STACK_SIZE=2048
+
+# For models with floating point.
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr/host_driven/boards/stm32f746g_disco.conf
+++ b/apps/microtvm/zephyr/host_driven/boards/stm32f746g_disco.conf
@@ -26,3 +26,6 @@ CONFIG_TEST_RANDOM_GENERATOR=y
 
 # For debugging.
 CONFIG_LED=n
+
+# For models with floating point.
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr/host_driven/prj.conf
+++ b/apps/microtvm/zephyr/host_driven/prj.conf
@@ -28,8 +28,5 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 CONFIG_CPLUSPLUS=y
 CONFIG_NEWLIB_LIBC=y
 
-# For models with floating point.
-CONFIG_FPU=y
-
 # For TVMPlatformAbort().
 CONFIG_REBOOT=y


### PR DESCRIPTION
`CONFIG_FPU` was being enabled by default for every platform,
regardless of whether or not the platform using the sample app actually
had a HW FPU unit. As a result, FPU instructions may be included on
platforms that aren't able to support them, or in a best-case scenario
we will get a warning about the confllct during builds, which pollutes
the CI output, in a worst-case scenario a fault.
    
This change removes the `CONFIG_FPU=y` setting from being set at the
application level, since this flag should be set at the chip level for
any platform that has an FPU.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>