### PR TITLE
Add flag to build static version of TVM runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,15 @@ file(GLOB RUNTIME_SRCS
 )
 
 if(BUILD_FOR_HEXAGON)
-  # Add file implementing posix_memalign.
+  # Add file implementing posix_memalign when building the runtime as
+  # a shared library.
+  # This function is actually defined in the static libc, but when linking
+  # a shared library, libc is not linked into it. Some runtime systems
+  # don't implement posix_runtime, which causes runtime failires.
+  # To avoid this issue, Hexagon runtime contains an implementation of
+  # posix_memalign, but it should only be used with the dynamic TVM
+  # runtime, since it would cause multiple definition errors with the
+  # static one.
   if(NOT BUILD_STATIC_RUNTIME)
     list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon_posix.cc)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ tvm_option(USE_FALLBACK_STL_MAP "Use TVM's POD compatible Map" OFF)
 tvm_option(USE_ETHOSN "Build with Arm Ethos-N" OFF)
 tvm_option(INDEX_DEFAULT_I64 "Defaults the index datatype to int64" ON)
 tvm_option(USE_LIBBACKTRACE "Build libbacktrace to supply linenumbers on stack traces" AUTO)
+tvm_option(BUILD_STATIC_RUNTIME "Build static version of libtvm_runtime" OFF)
 
 # 3rdparty libraries
 tvm_option(DLPACK_PATH "Path to DLPACK" "3rdparty/dlpack/include")
@@ -277,7 +278,9 @@ file(GLOB RUNTIME_SRCS
 
 if(BUILD_FOR_HEXAGON)
   # Add file implementing posix_memalign.
-  list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon_posix.cc)
+  if(NOT BUILD_STATIC_RUNTIME)
+    list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon_posix.cc)
+  endif()
 
   add_definitions(-D_MACH_I32=int)
 endif()
@@ -403,7 +406,17 @@ add_library(tvm_runtime_objs OBJECT ${RUNTIME_SRCS})
 
 add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs> $<TARGET_OBJECTS:tvm_runtime_objs>)
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
-add_library(tvm_runtime SHARED $<TARGET_OBJECTS:tvm_runtime_objs>)
+if(BUILD_STATIC_RUNTIME)
+  add_library(tvm_runtime STATIC $<TARGET_OBJECTS:tvm_runtime_objs>)
+  set(NOTICE_MULTILINE
+    "You have build static version of the TVM runtime library. Make "
+    "sure to use --whole-archive when linking it into your project.")
+  string(CONCAT NOTICE ${NOTICE_MULTILINE})
+  add_custom_command(TARGET tvm_runtime POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow --bold ${NOTICE})
+else()
+  add_library(tvm_runtime SHARED $<TARGET_OBJECTS:tvm_runtime_objs>)
+endif()
 set_property(TARGET tvm_runtime APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
 target_compile_definitions(tvm_objs PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 target_compile_definitions(tvm_runtime_objs PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -284,3 +284,15 @@ set(USE_BNNS OFF)
 # - ON: enable libbacktrace
 # - OFF: disable libbacktrace
 set(USE_LIBBACKTRACE AUTO)
+
+# Whether to build static libtvm_runtime.a, the default is to build the dynamic
+# version: libtvm_runtime.so.
+#
+# The static runtime library needs to be linked into executables with the linker
+# option --whole-archive (or its equivalent). The reason is that the TVM registry
+# mechanism relies on global constructors being executed at program startup.
+# Global constructors alone are not sufficient for the linker to consider a
+# library member to be used, and some of such library members (object files) may
+# not be included in the final executable. This would make the corresponding
+# runtime functions to be unavailable to the program.
+set(BUILD_STATIC_RUNTIME OFF)


### PR DESCRIPTION
Setting `BUILD_STATIC_RUNTIME` to `ON` (default: `OFF`) will cause a static `libtvm_runtime.a` to be built.

This library will then need to be linked into other projects with `--whole-archive` linker option, or otherwise the linker may remove functions that are not used at the time of linking. Since code using the runtime can be generated at runtime, function that appear to be unused at the link time may be used later at run time.
