### PR TITLE
[Python] allow Module exits without del

### DIFF
--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -45,7 +45,8 @@ class Module(object):
         self.entry_name = "__tvm_main__"
 
     def __del__(self):
-        check_call(_LIB.TVMModFree(self.handle))
+        if _LIB:
+            check_call(_LIB.TVMModFree(self.handle))
 
     def __hash__(self):
         return ctypes.cast(self.handle, ctypes.c_void_p).value


### PR DESCRIPTION
I have seen this error for multiple of times :

```
Exception ignored in: <object repr() failed>
Traceback (most recent call last):
  File "/home/developer/tvm/python/tvm/runtime/module.py", line 48, in __del__
AttributeError: 'NoneType' object has no attribute 'TVMModFree'
```

Not sure what's the cause of it, seems pretty random, and it doesn't really have any negative impact, just throw error at the end of the program, we can still get correct results.

I found a similar fix here #583, this PR is basically the same as it.