### PR TITLE
[AutoScheduler] Make RecordReader error-free

### DIFF
--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -63,9 +63,9 @@ class RecordReader(Object):
     """
 
     def __init__(self, filename):
-        # a set to prevent print duplicated message
         if not os.path.exists(filename):
-            raise FileExistsError("%s does not exists!" % filename)
+            logger.warning("%s does not exist!" % filename)
+        # a set to prevent print duplicated message
         self.messages = set()
         self.__init_handle_by_constructor__(_ffi_api.RecordReader, filename)
 

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -45,9 +45,7 @@ class RecordToFile(MeasureCallback):
     """
 
     def __init__(self, filename):
-        dirname = os.path.dirname(filename)
-        if dirname == "":
-            dirname = "."
+        dirname = os.path.dirname(os.path.abspath(filename))
         if not os.path.exists(dirname):
             os.makedirs(dirname)
         self.__init_handle_by_constructor__(_ffi_api.RecordToFile, filename)
@@ -209,9 +207,7 @@ def save_records(filename, inputs, results):
     results: List[MeasureResults]
         The MeasureResults to be written.
     """
-    dirname = os.path.dirname(filename)
-    if dirname == "":
-        dirname = "."
+    dirname = os.path.dirname(os.path.abspath(filename))
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     _ffi_api.SaveRecords(filename, inputs, results)
@@ -295,9 +291,7 @@ def distill_record_file(in_file, out_file):
 
     context = load_records(in_file)
 
-    dirname = os.path.dirname(out_file)
-    if dirname == "":
-        dirname = "."
+    dirname = os.path.dirname(os.path.abspath(out_file))
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -46,8 +46,8 @@ class RecordToFile(MeasureCallback):
 
     def __init__(self, filename):
         dirname = os.path.dirname(filename)
-        if dirname == '':
-            dirname = '.'
+        if dirname == "":
+            dirname = "."
         if not os.path.exists(dirname):
             os.makedirs(dirname)
         self.__init_handle_by_constructor__(_ffi_api.RecordToFile, filename)
@@ -210,8 +210,8 @@ def save_records(filename, inputs, results):
         The MeasureResults to be written.
     """
     dirname = os.path.dirname(filename)
-    if dirname == '':
-        dirname = '.'
+    if dirname == "":
+        dirname = "."
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     _ffi_api.SaveRecords(filename, inputs, results)
@@ -296,8 +296,8 @@ def distill_record_file(in_file, out_file):
     context = load_records(in_file)
 
     dirname = os.path.dirname(out_file)
-    if dirname == '':
-        dirname = '.'
+    if dirname == "":
+        dirname = "."
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -45,6 +45,11 @@ class RecordToFile(MeasureCallback):
     """
 
     def __init__(self, filename):
+        dirname = os.path.dirname(filename)
+        if dirname == '':
+            dirname = '.'
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         self.__init_handle_by_constructor__(_ffi_api.RecordToFile, filename)
 
 
@@ -61,8 +66,9 @@ class RecordReader(Object):
 
     def __init__(self, filename):
         # a set to prevent print duplicated message
+        if not os.path.exists(filename):
+            raise FileExistsError('%s does not exists!' % filename)
         self.messages = set()
-
         self.__init_handle_by_constructor__(_ffi_api.RecordReader, filename)
 
     def check_workload_key(self, inputs):
@@ -203,6 +209,11 @@ def save_records(filename, inputs, results):
     results: List[MeasureResults]
         The MeasureResults to be written.
     """
+    dirname = os.path.dirname(filename)
+    if dirname == '':
+        dirname = '.'
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
     _ffi_api.SaveRecords(filename, inputs, results)
 
 
@@ -283,6 +294,13 @@ def distill_record_file(in_file, out_file):
     from .dispatcher import ApplyHistoryBest
 
     context = load_records(in_file)
+
+    dirname = os.path.dirname(out_file)
+    if dirname == '':
+        dirname = '.'
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+
     if os.path.isfile(out_file):
         out_context = load_records(out_file)
         context = itertools.chain(context, out_context)

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -67,7 +67,7 @@ class RecordReader(Object):
     def __init__(self, filename):
         # a set to prevent print duplicated message
         if not os.path.exists(filename):
-            raise FileExistsError('%s does not exists!' % filename)
+            raise FileExistsError("%s does not exists!" % filename)
         self.messages = set()
         self.__init_handle_by_constructor__(_ffi_api.RecordReader, filename)
 

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -64,7 +64,7 @@ class RecordReader(Object):
 
     def __init__(self, filename):
         if not os.path.exists(filename):
-            logger.warning("%s does not exist!" % filename)
+            logger.warning("%s does not exist!", filename)
         # a set to prevent print duplicated message
         self.messages = set()
         self.__init_handle_by_constructor__(_ffi_api.RecordReader, filename)


### PR DESCRIPTION
Fix the bugs in the auto-scheduler record:
Previously, the log file would not be created if its directory does not exist. Moreover, there is not any error information. I created the corresponding directories when saving the records.
Besides, the RecordReader could open a non-existent file without any error information. I raise the `FileExistsError` when the file does not exist.
@merrymercy 