### PR TITLE
BYODT plays nicely with Relay parser

### DIFF
--- a/include/tvm/runtime/data_type.h
+++ b/include/tvm/runtime/data_type.h
@@ -250,7 +250,7 @@ TVM_DLL std::string GetCustomTypeName(uint8_t type_code);
 TVM_DLL bool GetCustomTypeRegistered(uint8_t type_code);
 
 /*!
- * \brief Runtime utility for parsing string of the form "custom[<typename>]"
+ * \brief Runtime utility for parsing string of the form "custom_<typename>"
  * \param s String to parse
  * \param scan pointer to parsing pointer, which is scanning across s
  * \return type code of custom type parsed
@@ -308,7 +308,7 @@ inline std::ostream& operator<<(std::ostream& os, DLDataType t) {  // NOLINT(*)
   if (t.code < DataType::kCustomBegin) {
     os << DLDataTypeCode2Str(static_cast<DLDataTypeCode>(t.code));
   } else {
-    os << "custom[" << GetCustomTypeName(t.code) << "]";
+    os << "custom_" << GetCustomTypeName(t.code);
   }
   if (t.code == kTVMOpaqueHandle) return os;
   os << static_cast<int>(t.bits);
@@ -360,7 +360,7 @@ inline DLDataType String2DLDataType(std::string s) {
   } else if (s.substr(0, 6) == "bfloat") {
     t.code = DataType::kBFloat;
     scan = s.c_str() + 6;
-  } else if (s.substr(0, 6) == "custom") {
+  } else if (s.substr(0, 7) == "custom_") {
     t.code = ParseCustomDatatype(s, &scan);
   } else {
     scan = s.c_str();

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -105,16 +105,16 @@ class DataType(ctypes.Structure):
         elif head.startswith("bfloat"):
             self.type_code = DataTypeCode.BFLOAT
             head = head[6:]
-        elif head.startswith("custom"):
+        elif head.startswith("custom_"):
             # pylint: disable=import-outside-toplevel
             import tvm.runtime._ffi_api
 
-            low, high = head.find("["), head.find("]")
-            if not low or not high or low >= high:
-                raise ValueError("Badly formatted custom type string %s" % type_str)
-            type_name = head[low + 1 : high]
-            self.type_code = tvm.runtime._ffi_api._datatype_get_type_code(type_name)
-            head = head[high + 1 :]
+            head = head[7:]
+            index_of_first_digit = [c.isdigit() for c in head].index(True)
+            type_name = head[:index_of_first_digit]
+            head = head[index_of_first_digit:]
+            self.type_code = tvm.runtime._ffi_api._datatype_get_type_code(
+                type_name)
         else:
             raise ValueError("Do not know how to handle type %s" % type_str)
         bits = int(head) if head else bits
@@ -129,7 +129,8 @@ class DataType(ctypes.Structure):
         else:
             import tvm.runtime._ffi_api
 
-            type_name = "custom[%s]" % tvm.runtime._ffi_api._datatype_get_type_name(self.type_code)
+            type_name = "custom_%s" % tvm.runtime._ffi_api._datatype_get_type_name(
+                self.type_code)
         x = "%s%d" % (type_name, self.bits)
         if self.lanes != 1:
             x += "x%d" % self.lanes

--- a/python/tvm/relay/frontend/change_datatype.py
+++ b/python/tvm/relay/frontend/change_datatype.py
@@ -42,13 +42,13 @@ class ChangeDatatype(ExprMutator):
             params = dict((p, tvm.nd.array(params[p].asnumpy().astype(dst))) for p in params)
             return mod, params
 
-        mod, params = change_dtype(mod, params, "float32", "custom[posites2]32")
+        mod, params = change_dtype(mod, params, "float32", "custom_posit32")
 
     Parameters
     ----------
     src : String
-        The source datatype name, e.g. "float" or "posites2" (but not "float32"
-        or "custom[posites2]32").
+        The source datatype name, e.g. "float" or "posit" (but not "float32"
+        or "custom_posit32").
     dst : String
         The destination datatype name, in the same format.
 

--- a/python/tvm/target/datatype.py
+++ b/python/tvm/target/datatype.py
@@ -42,8 +42,8 @@ def register(type_name, type_code):
 
     .. code-block:: python
 
-        # Register a dtype named 'posites2' under type code 130.
-        tvm.target.datatype.register('posites2', 130)
+        # Register a dtype named 'posit' under type code 130.
+        tvm.target.datatype.register('posit', 130)
 
 
     Parameters
@@ -68,8 +68,8 @@ def get_type_name(type_code):
 
     .. code-block:: python
 
-        tvm.target.datatype.register('posites2', 130)
-        assert tvm.target.datatype.get_type_name(130) == 'posites2'
+        tvm.target.datatype.register('posit', 130)
+        assert tvm.target.datatype.get_type_name(130) == 'posit'
 
     Parameters
     ----------
@@ -95,8 +95,8 @@ def get_type_code(type_name):
 
     .. code-block:: python
 
-        tvm.target.datatype.register('posites2', 130)
-        assert tvm.target.datatype.get_type_code('posites2') == 130
+        tvm.target.datatype.register('posit', 130)
+        assert tvm.target.datatype.get_type_code('posit') == 130
 
     Parameters
     ----------
@@ -118,7 +118,7 @@ def get_type_registered(type_code):
 
     .. code-block:: python
 
-        tvm.target.datatype.register('posites2', 130)
+        tvm.target.datatype.register('posit', 130)
         assert tvm.target.datatype.get_type_registered(130)
 
     Parameters
@@ -176,7 +176,7 @@ def register_op(
         The name of codegen target.
 
     src_type_name : str
-        The name of the custom datatype, e.g. posites2 (but not custom[posites2]32).
+        The name of the custom datatype, e.g. posit (but not custom_posit32).
         If op_name is not "Cast", then target type is guaranteed to be the same as src_type_name.
 
     dest_type_name : str
@@ -237,11 +237,11 @@ def register_min_func(func, type_name):
     ----------
     func : function
         Input is an integer num_bits, should return a TIR expression node that
-        represents a scalar tensor of type custom[type_name]num_bits with the minimum
+        represents a scalar tensor of type custom_<type_name><num_bits> with the minimum
         representable value.
 
     type_name : str
-        The name of the custom datatype, e.g. posites2 (but not custom[posites2]32).
+        The name of the custom datatype, e.g. posit (but not custom_posit32).
     """
     _register_func("tvm.datatype.min." + type_name, func)
 
@@ -255,11 +255,11 @@ def create_min_lower_func(extern_func_map, type_name):
         A map from bit lengths to the name of the extern "C" function to lower to.
 
     type_name : string
-        The name of the custom datatype, e.g. posites2 (but not custom[posites2]32).
+        The name of the custom datatype, e.g. posit (but not custom_posit32).
     """
 
     def lower(num_bits):
-        dtype = f"custom[{type_name}]{num_bits}"
+        dtype = f"custom_{type_name}{num_bits}"
 
         if num_bits not in extern_func_map:
             raise RuntimeError("missing minimum function for {dtype}")

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -180,9 +180,8 @@ inline std::string DType2String(const tvm::DataType dtype) {
   } else if (dtype.is_uint()) {
     os << "uint";
   } else if ((*GetPackedFunc("runtime._datatype_get_type_registered"))(dtype.code())) {
-    os << "custom["
-       << (*GetPackedFunc("runtime._datatype_get_type_name"))(dtype.code()).operator std::string()
-       << "]";
+    os << "custom_"
+       << (*GetPackedFunc("runtime._datatype_get_type_name"))(dtype.code()).operator std::string();
   } else {
     LOG(FATAL) << "Unknown type with code " << static_cast<unsigned>(dtype.code());
   }

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -61,31 +61,10 @@ bool GetCustomTypeRegistered(uint8_t type_code) {
 }
 
 uint8_t ParseCustomDatatype(const std::string& s, const char** scan) {
-  ICHECK(s.substr(0, 6) == "custom") << "Not a valid custom datatype string";
-
-  auto tmp = s.c_str();
-
-  ICHECK(s.c_str() == tmp);
-  *scan = s.c_str() + 6;
-  ICHECK(s.c_str() == tmp);
-  if (**scan != '[') LOG(FATAL) << "expected opening brace after 'custom' type in" << s;
-  ICHECK(s.c_str() == tmp);
-  *scan += 1;
-  ICHECK(s.c_str() == tmp);
-  size_t custom_name_len = 0;
-  ICHECK(s.c_str() == tmp);
-  while (*scan + custom_name_len <= s.c_str() + s.length() && *(*scan + custom_name_len) != ']')
-    ++custom_name_len;
-  ICHECK(s.c_str() == tmp);
-  if (*(*scan + custom_name_len) != ']')
-    LOG(FATAL) << "expected closing brace after 'custom' type in" << s;
-  ICHECK(s.c_str() == tmp);
-  *scan += custom_name_len + 1;
-  ICHECK(s.c_str() == tmp);
-
-  auto type_name = s.substr(7, custom_name_len);
-  ICHECK(s.c_str() == tmp);
-  return GetCustomTypeCode(type_name);
+  ICHECK(s.substr(0, 7) == "custom_") << "Not a valid custom datatype string";
+  auto index_of_first_digit = s.find_first_of("0123456789");
+  *scan = s.c_str() + index_of_first_digit;
+  return GetCustomTypeCode(s.substr(7, index_of_first_digit - 7));
 }
 
 class DeviceAPIManager {

--- a/src/target/datatype/registry.h
+++ b/src/target/datatype/registry.h
@@ -62,7 +62,7 @@ class Registry {
    * manually allocated by the user, and the user must ensure that no two custom types share the
    * same code. Generally, this should be straightforward, as the user will be manually registering
    * all of their custom types.
-   * \param type_name The name of the type, e.g. "posites2"
+   * \param type_name The name of the type, e.g. "posit"
    * \param type_code The type code, which should be greater than TVMArgTypeCode::kTVMExtEnd
    */
   void Register(const std::string& type_name, uint8_t type_code);

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -920,6 +920,37 @@ def test_tokenize_inf():
     mod = relay.transform.AnnotateSpans()(mod)
 
 
+def test_custom_dtype():
+    tvm.target.datatype.register("myfloat", 150)
+
+    myfloat32 = relay.scalar_type("custom_myfloat32")
+
+    # TODO(@gussmith23) The following doesn't pass
+    # assert_parses_as(
+    #     "let %_ : Tensor[(), custom_myfloat32] = (); ()",
+    #     relay.Let(relay.Var("_", relay.TensorType(
+    #         (), "custom_myfloat32")), UNIT, UNIT),
+    # )
+
+    assert_parses_as(
+        "let %_ : Tensor[(1), custom_myfloat32] = (); ()",
+        relay.Let(relay.Var("_", relay.TensorType(
+            (1,), "custom_myfloat32")), UNIT, UNIT),
+    )
+
+    assert_parses_as(
+        "let %_ : Tensor[(1, 1), custom_myfloat32] = (); ()",
+        relay.Let(relay.Var("_", relay.TensorType(
+            (1, 1), "custom_myfloat32")), UNIT, UNIT),
+    )
+
+    assert_parses_as(
+        "let %_ : Tensor[(?, 1), custom_myfloat32] = (); ()",
+        relay.Let(relay.Var("_", relay.TensorType(
+            (tvm.tir.Any(), 1), "custom_myfloat32")), UNIT, UNIT),
+    )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/python/unittest/test_custom_datatypes.py
+++ b/tests/python/unittest/test_custom_datatypes.py
@@ -199,8 +199,8 @@ def setup_myfloat():
     register_min_func(create_min_lower_func({32: "MinCustom32"}, "myfloat"), "myfloat")
 
 
-def setup_posites2():
-    """Set up tests for posites2
+def setup_posit():
+    """Set up tests for posit
     Currently, this registers some custom datatypes using the Bring Your
     Own Datatypes framework.
     """
@@ -214,7 +214,7 @@ def setup_posites2():
     # You can pick a code for your datatype arbitrarily, as long as it is
     # greater than 128 and has not already been chosen.
 
-    register("posites2", 132)
+    register("posit", 132)
 
     register_op(
         create_lower_func(
@@ -227,7 +227,7 @@ def setup_posites2():
         "Cast",
         "llvm",
         "float",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func(
@@ -239,20 +239,20 @@ def setup_posites2():
         ),
         "Cast",
         "llvm",
-        "posites2",
+        "posit",
         "float",
     )
     register_op(
         create_lower_func({32: "Posit32es2Add", 16: "Posit16es2Add", 8: "Posit8es2Add"}),
         "Add",
         "llvm",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func({32: "Posit32es2Sub", 16: "Posit16es2Sub", 8: "Posit8es2Sub"}),
         "Sub",
         "llvm",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func(
@@ -260,49 +260,49 @@ def setup_posites2():
         ),
         "FloatImm",
         "llvm",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func({32: "Posit32es2Mul", 16: "Posit16es2Mul", 8: "Posit8es2Mul"}),
         "Mul",
         "llvm",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func({32: "Posit32es2Div", 16: "Posit16es2Div", 8: "Posit8es2Div"}),
         "Div",
         "llvm",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func({32: "Posit32es2Max", 16: "Posit16es2Max", 8: "Posit8es2Max"}),
         "Max",
         "llvm",
-        "posites2",
+        "posit",
     )
     register_op(
         create_lower_func({32: "Posit32es2Sqrt", 16: "Posit16es2Sqrt", 8: "Posit8es2Sqrt"}),
         "Call",
         "llvm",
-        "posites2",
+        "posit",
         intrinsic_name="tir.sqrt",
     )
-    register_op(lower_ite, "Call", "llvm", "posites2", intrinsic_name="tir.if_then_else")
+    register_op(lower_ite, "Call", "llvm", "posit", intrinsic_name="tir.if_then_else")
     register_op(
-        lower_call_pure_extern, "Call", "llvm", "posites2", intrinsic_name="tir.call_pure_extern"
+        lower_call_pure_extern, "Call", "llvm", "posit", intrinsic_name="tir.call_pure_extern"
     )
     register_op(
         create_lower_func({32: "Posit32es2Exp", 16: "Posit16es2Exp", 8: "Posit8es2Exp"}),
         "Call",
         "llvm",
-        "posites2",
+        "posit",
         intrinsic_name="tir.exp",
     )
     register_op(
         create_lower_func({32: "Posit32es2Log", 16: "Posit16es2Log", 8: "Posit8es2Log"}),
         "Call",
         "llvm",
-        "posites2",
+        "posit",
         intrinsic_name="tir.log",
     )
     register_op(
@@ -311,22 +311,22 @@ def setup_posites2():
         ),
         "Call",
         "llvm",
-        "posites2",
+        "posit",
         intrinsic_name="tir.sigmoid",
     )
     register_op(
         create_lower_func({32: "Posit32es2Tanh", 16: "Posit16es2Tanh", 8: "Posit8es2Tanh"}),
         "Call",
         "llvm",
-        "posites2",
+        "posit",
         intrinsic_name="tir.tanh",
     )
 
     register_min_func(
         create_min_lower_func(
-            {32: "MinPosit32es2", 16: "MinPosit16es2", 8: "MinPosit8es2"}, "posites2"
+            {32: "MinPosit32es2", 16: "MinPosit16es2", 8: "MinPosit8es2"}, "posit"
         ),
-        "posites2",
+        "posit",
     )
 
 
@@ -513,14 +513,14 @@ def run_batchnorm(src_dtype, dst_dtype, rtol=1e-6, atol=1e-6):
 
 def test_myfloat():
     setup_myfloat()
-    run_ops("float32", "custom[myfloat]32", rtol=1e-6, atol=1e-6)
-    run_conv2d("float32", "custom[myfloat]32", rtol=1e-6, atol=1e-6)
-    run_batchnorm("float32", "custom[myfloat]32", rtol=1e-6, atol=1e-6)
+    run_ops("float32", "custom_myfloat32", rtol=1e-6, atol=1e-6)
+    run_conv2d("float32", "custom_myfloat32", rtol=1e-6, atol=1e-6)
+    run_batchnorm("float32", "custom_myfloat32", rtol=1e-6, atol=1e-6)
 
     # mxnet python package not available
     # run_model(get_mobilenet, (get_cat_image((224, 224)), ),
     #           'float32',
-    #           'custom[myfloat]32')
+    #           'custom_myfloat32')
 
 
 def _has_posit():
@@ -528,24 +528,20 @@ def _has_posit():
 
 
 @pytest.mark.skipif(not _has_posit(), reason="compiled with USE_BYODT_POSIT flag OFF")
-def test_posites2():
-    setup_posites2()
-    run_ops("float32", "custom[posites2]8", rtol=1, atol=1)
-    run_ops("float32", "custom[posites2]16", rtol=0.01, atol=1)
-    run_ops("float32", "custom[posites2]32", rtol=1e-6, atol=1e-6)
+def test_posit():
+    setup_posit()
+    run_ops("float32", "custom_posit8", rtol=1, atol=1)
+    run_ops("float32", "custom_posit16", rtol=0.01, atol=1)
+    run_ops("float32", "custom_posit32", rtol=1e-6, atol=1e-6)
 
-    run_conv2d("float32", "custom[posites2]8", rtol=1, atol=1)
-    run_conv2d("float32", "custom[posites2]16", rtol=0.01, atol=1)
-    run_conv2d("float32", "custom[posites2]32")
+    run_conv2d("float32", "custom_posit8", rtol=1, atol=1)
+    run_conv2d("float32", "custom_posit16", rtol=0.01, atol=1)
+    run_conv2d("float32", "custom_posit32")
 
-    run_batchnorm("float32", "custom[posites2]8", rtol=1, atol=1)
-    run_batchnorm("float32", "custom[posites2]16", rtol=0.01, atol=1)
-    run_batchnorm("float32", "custom[posites2]32", rtol=1e-4, atol=1e-4)
+    run_batchnorm("float32", "custom_posit8", rtol=1, atol=1)
+    run_batchnorm("float32", "custom_posit16", rtol=0.01, atol=1)
+    run_batchnorm("float32", "custom_posit32", rtol=1e-4, atol=1e-4)
     # Expected posit8 might be faster, but it's not.
-    # run_model(get_mobilenet, (get_cat_image((224, 224)), ), 'float32', 'custom[posit8]8')
-    # run_model(get_mobilenet, (get_cat_image((224, 224)), ), 'float32', 'custom[posit32]32')
-    # run_model(get_inception, (get_cat_image((229, 229)), ), 'float32', 'custom[posit32]32')
-    # run_model(get_resnet, (get_cat_image((224, 224)), ), 'float32', 'custom[posit32]32')
 
     # can't run cifar-10 sizes because dimensions
     # don't match pretrained weights
@@ -553,10 +549,10 @@ def test_posites2():
     # runs on the order of minutes...
     # run_model(get_inception, (get_cat_image((229, 229)), ),
     #           'float32',
-    #           'custom[posites2]32')
+    #           'custom_posit32')
     # run_model(get_resnet, (get_cat_image((224, 224)), ),
     #           'float32',
-    #           'custom[posites2]32')
+    #           'custom_posit32')
 
 
 if __name__ == "__main__":

--- a/tutorials/dev/bring_your_own_datatypes.py
+++ b/tutorials/dev/bring_your_own_datatypes.py
@@ -94,13 +94,13 @@ print("z: {}".format(z_output))
 #
 # We use the same input variables ``x`` and ``y`` as above, but before adding ``x + y``, we first cast both ``x`` and ``y`` to a custom datatype via the ``relay.cast(...)`` call.
 #
-# Note how we specify the custom datatype: we indicate it using the special ``custom[...]`` syntax.
+# Note how we specify the custom datatype: we indicate it using the special ``custom_<typename>`` syntax.
 # Additionally, note the "32" after the datatype: this is the bitwidth of the custom datatype. This tells TVM that each instance of ``myfloat`` is 32 bits wide.
 
 try:
     with tvm.transform.PassContext(config={"tir.disable_vectorize": True}):
-        x_myfloat = relay.cast(x, dtype="custom[myfloat]32")
-        y_myfloat = relay.cast(y, dtype="custom[myfloat]32")
+        x_myfloat = relay.cast(x, dtype="custom_myfloat32")
+        y_myfloat = relay.cast(y, dtype="custom_myfloat32")
         z_myfloat = x_myfloat + y_myfloat
         z = relay.cast(z_myfloat, dtype="float32")
 except tvm.TVMError as e:
@@ -119,8 +119,8 @@ tvm.target.datatype.register("myfloat", 150)
 # See ``TVMTypeCode::kCustomBegin`` in `include/tvm/runtime/c_runtime_api.h <https://github.com/apache/tvm/blob/main/include/tvm/runtime/data_type.h>`_.
 # Now we can generate our program again:
 
-x_myfloat = relay.cast(x, dtype="custom[myfloat]32")
-y_myfloat = relay.cast(y, dtype="custom[myfloat]32")
+x_myfloat = relay.cast(x, dtype="custom_myfloat32")
+y_myfloat = relay.cast(y, dtype="custom_myfloat32")
 z_myfloat = x_myfloat + y_myfloat
 z = relay.cast(z_myfloat, dtype="float32")
 program = relay.Function([x, y], z)
@@ -286,7 +286,7 @@ def convert_ndarray(dst_dtype, array):
 from tvm.relay.frontend.change_datatype import ChangeDatatype
 
 src_dtype = "float32"
-dst_dtype = "custom[myfloat]32"
+dst_dtype = "custom_myfloat32"
 
 module = relay.transform.InferType()(module)
 


### PR DESCRIPTION
cc @sahooora -- try this patch and see if it works! (Make sure you read below -- there's a change you'll have to make to your `dtype` strings.)

Closes #8046.

Previously, there were no Bring Your Own Datatypes parser tests included in the Relay parser tests, so when the Relay parser changed recently, BYODT's parsing broke. This change fixes the parser and adds a test to prevent similar breakage in the future.

- BYODT datatypes now use the format `custom_<typename><bits>x<lanes>` rather than `custom[<typename>]<bits>x<lanes>`

There's a commented-out test that doesn't yet work. I want to get that working. Additionally, I need to search for other places where we need to make this syntax change.