### PR TITLE
[Relay, ONNX] Support gather_nd batch_dims attribute for TF/ONNX

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -148,9 +148,7 @@ struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
   Integer batch_dims;
 
   TVM_DECLARE_ATTRS(GatherAttrs, "relay.attrs.GatherNDAttrs") {
-    TVM_ATTR_FIELD(batch_dims)
-      .set_default(Integer(0))
-      .describe("The number of batch dimensions.");
+    TVM_ATTR_FIELD(batch_dims).set_default(Integer(0)).describe("The number of batch dimensions.");
   }
 };
 struct TakeAttrs : public tvm::AttrsNode<TakeAttrs> {

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -145,10 +145,10 @@ struct GatherAttrs : public tvm::AttrsNode<GatherAttrs> {
 };
 
 struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
-  Integer batch_dim;
+  Integer batch_dims;
 
   TVM_DECLARE_ATTRS(GatherAttrs, "relay.attrs.GatherNDAttrs") {
-    TVM_ATTR_FIELD(batch_dim)
+    TVM_ATTR_FIELD(batch_dims)
       .set_default(Integer(0))
       .describe("The number of batch dimensions.");
   }

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -144,6 +144,15 @@ struct GatherAttrs : public tvm::AttrsNode<GatherAttrs> {
   }
 };
 
+struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
+  Integer batch_dim;
+
+  TVM_DECLARE_ATTRS(GatherAttrs, "relay.attrs.GatherNDAttrs") {
+    TVM_ATTR_FIELD(batch_dim)
+      .set_default(Integer(0))
+      .describe("The number of batch dimensions.");
+  }
+};
 struct TakeAttrs : public tvm::AttrsNode<TakeAttrs> {
   Integer batch_dims;
   Integer axis;

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -1243,8 +1243,8 @@ inline Tensor gather(const Tensor& data, int axis, const Tensor& indices,
  *
  * \return A Tensor whose op member is the gather_nd operation
  */
-inline Tensor gather_nd(const Tensor& data, const Tensor& indices, std::string name = "T_gather_nd",
-                        std::string tag = kInjective) {
+inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dim = 0,
+                        std::string name = "T_gather_nd", std::string tag = kInjective) {
   size_t ndim_d = data->shape.size();
   size_t ndim_i = indices->shape.size();
   ICHECK_GE(ndim_i, 1) << "indices tensor must have at least 1 dimensions";
@@ -1255,7 +1255,7 @@ inline Tensor gather_nd(const Tensor& data, const Tensor& indices, std::string n
   for (size_t i = 1; i < ndim_i; ++i) {
     out_shape.push_back(indices->shape[i]);
   }
-  for (size_t i = indices_dim0; i < ndim_d; ++i) {
+  for (size_t i = indices_dim0 + batch_dim; i < ndim_d; ++i) {
     out_shape.push_back(data->shape[i]);
   }
   return compute(
@@ -1267,6 +1267,9 @@ inline Tensor gather_nd(const Tensor& data, const Tensor& indices, std::string n
           indices_position.push_back(out_index[i]);
         }
         Array<PrimExpr> real_indices;
+        for (size_t i = 0; i < batch_dim; ++i) {
+          real_indices.push_back(out_index[i]);
+        }
         for (size_t i = 0; i < indices_dim0; ++i) {
           indices_position.Set(0, make_const(DataType::Int(32), i));
           if (indices->dtype.is_int()) {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -1238,12 +1238,13 @@ inline Tensor gather(const Tensor& data, int axis, const Tensor& indices,
  *
  * \param data The source array.
  * \param indices The indices of the values to extract.
+ * \param batch_dims The number of batch dimensions.
  * \param name The name of the operation.
  * \param tag The tag to mark the operation.
  *
  * \return A Tensor whose op member is the gather_nd operation
  */
-inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dim = 0,
+inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dims = 0,
                         std::string name = "T_gather_nd", std::string tag = kInjective) {
   size_t ndim_d = data->shape.size();
   size_t ndim_i = indices->shape.size();
@@ -1255,7 +1256,7 @@ inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dim
   for (size_t i = 1; i < ndim_i; ++i) {
     out_shape.push_back(indices->shape[i]);
   }
-  for (size_t i = indices_dim0 + batch_dim; i < ndim_d; ++i) {
+  for (size_t i = indices_dim0 + batch_dims; i < ndim_d; ++i) {
     out_shape.push_back(data->shape[i]);
   }
   return compute(
@@ -1267,7 +1268,7 @@ inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dim
           indices_position.push_back(out_index[i]);
         }
         Array<PrimExpr> real_indices;
-        for (size_t i = 0; i < batch_dim; ++i) {
+        for (size_t i = 0; i < batch_dims; ++i) {
           real_indices.push_back(out_index[i]);
         }
         for (size_t i = 0; i < indices_dim0; ++i) {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -1268,7 +1268,7 @@ inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dim
           indices_position.push_back(out_index[i]);
         }
         Array<PrimExpr> real_indices;
-        for (size_t i = 0; i < batch_dims; ++i) {
+        for (size_t i = 0; i < static_cast<size_t>(batch_dims); ++i) {
           real_indices.push_back(out_index[i]);
         }
         for (size_t i = 0; i < indices_dim0; ++i) {

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1413,7 +1413,8 @@ class GatherElements(OnnxOpConverter):
 class GatherND(OnnxOpConverter):
     """Operator converter for GatherND."""
 
-    def _impl_common(data, indices, batch_dims=0):
+    @classmethod
+    def _impl_common(cls, data, indices, batch_dims=0):
         indices_dims = len(infer_shape(indices))
         indices = _op.transpose(indices, axes=[-1] + list(range(indices_dims - 1)))
         return _op.gather_nd(data, indices, batch_dims)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1424,8 +1424,8 @@ class GatherND(OnnxOpConverter):
         indices_shape = infer_shape(inputs[1])
         indices_dims = len(indices_shape)
         indices = _op.transpose(inputs[1], axes=[-1] + list(range(indices_dims - 1)))
-        batch_dim = attr.get("batch_dims", 0)
-        return _op.gather_nd(inputs[0], indices, batch_dim)
+        batch_dims = attr.get("batch_dims", 0)
+        return _op.gather_nd(inputs[0], indices, batch_dims)
 
 
 class Scatter(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1413,19 +1413,19 @@ class GatherElements(OnnxOpConverter):
 class GatherND(OnnxOpConverter):
     """Operator converter for GatherND."""
 
+    def _impl_common(data, indices, batch_dims=0):
+        indices_dims = len(infer_shape(indices))
+        indices = _op.transpose(indices, axes=[-1] + list(range(indices_dims - 1)))
+        return _op.gather_nd(data, indices, batch_dims)
+
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        indices_dims = len(infer_shape(inputs[1]))
-        indices = _op.transpose(inputs[1], axes=[-1] + list(range(indices_dims - 1)))
-        return _op.gather_nd(inputs[0], indices)
+        return cls._impl_common(inputs[0], inputs[1])
 
     @classmethod
     def _impl_v12(cls, inputs, attr, params):
-        indices_shape = infer_shape(inputs[1])
-        indices_dims = len(indices_shape)
-        indices = _op.transpose(inputs[1], axes=[-1] + list(range(indices_dims - 1)))
         batch_dims = attr.get("batch_dims", 0)
-        return _op.gather_nd(inputs[0], indices, batch_dims)
+        return cls._impl_common(inputs[0], inputs[1], batch_dims)
 
 
 class Scatter(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1419,6 +1419,14 @@ class GatherND(OnnxOpConverter):
         indices = _op.transpose(inputs[1], axes=[-1] + list(range(indices_dims - 1)))
         return _op.gather_nd(inputs[0], indices)
 
+    @classmethod
+    def _impl_v12(cls, inputs, attr, params):
+        indices_shape = infer_shape(inputs[1])
+        indices_dims = len(indices_shape)
+        indices = _op.transpose(inputs[1], axes=[-1] + list(range(indices_dims - 1)))
+        batch_dim = attr.get('batch_dims', 0)
+        return _op.gather_nd(inputs[0], indices, batch_dim)
+
 
 class Scatter(OnnxOpConverter):
     """Operator converter for Scatter."""

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1424,7 +1424,7 @@ class GatherND(OnnxOpConverter):
         indices_shape = infer_shape(inputs[1])
         indices_dims = len(indices_shape)
         indices = _op.transpose(inputs[1], axes=[-1] + list(range(indices_dims - 1)))
-        batch_dim = attr.get('batch_dims', 0)
+        batch_dim = attr.get("batch_dims", 0)
         return _op.gather_nd(inputs[0], indices, batch_dim)
 
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1072,7 +1072,7 @@ def gather(data, axis, indices):
     return _make.gather(data, axis, indices)
 
 
-def gather_nd(data, indices, batch_dim=0):
+def gather_nd(data, indices, batch_dims=0):
     """Gather elements or slices from data and store to a tensor whose shape is
     defined by indices.
 
@@ -1083,6 +1083,9 @@ def gather_nd(data, indices, batch_dim=0):
 
     indices : relay.Expr
         The shape of output tensor.
+
+    batch_dims : int
+        The number of batch dimensions
 
     Returns
     -------
@@ -1101,7 +1104,7 @@ def gather_nd(data, indices, batch_dim=0):
         indices = [[0, 1], [1, 0]]
         relay.gather_nd(data, indices) = [[3, 4], [5, 6]]
     """
-    return _make.gather_nd(data, indices, batch_dim)
+    return _make.gather_nd(data, indices, batch_dims)
 
 
 def sequence_mask(data, valid_length, mask_value=0, axis=0):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1072,7 +1072,7 @@ def gather(data, axis, indices):
     return _make.gather(data, axis, indices)
 
 
-def gather_nd(data, indices):
+def gather_nd(data, indices, batch_dim=0):
     """Gather elements or slices from data and store to a tensor whose shape is
     defined by indices.
 
@@ -1101,7 +1101,7 @@ def gather_nd(data, indices):
         indices = [[0, 1], [1, 0]]
         relay.gather_nd(data, indices) = [[3, 4], [5, 6]]
     """
-    return _make.gather_nd(data, indices)
+    return _make.gather_nd(data, indices, batch_dim)
 
 
 def sequence_mask(data, valid_length, mask_value=0, axis=0):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1085,7 +1085,7 @@ def gather_nd(data, indices, batch_dims=0):
         The shape of output tensor.
 
     batch_dims : int
-        The number of batch dimensions
+        The number of batch dimensions.
 
     Returns
     -------

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1103,6 +1103,10 @@ def gather_nd(data, indices, batch_dims=0):
         data = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
         indices = [[0, 1], [1, 0]]
         relay.gather_nd(data, indices) = [[3, 4], [5, 6]]
+
+        data    = [[[0,1],[2,3]],[[4,5],[6,7]]]
+        indices = [[1, 0]]
+        relay.gather_nd(data, indices, batch_dims=1) = [[2,3],[4,5]]
     """
     return _make.gather_nd(data, indices, batch_dims)
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3371,7 +3371,7 @@ Array<te::Tensor> GatherNDCompute(const Attrs& attrs, const Array<te::Tensor>& i
 Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0) {
   static const Op& op = Op::Get("gather_nd");
   auto attrs = make_object<GatherNDAttrs>();
-  attrs->batch_dims = std::move(batch_dims);
+  attrs->batch_dims = batch_dims;
   return Call(op, {data, indices}, Attrs(attrs));
 }
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3390,12 +3390,15 @@ Optionally, batch_dims, the number of batch dimensions, can be given, whose
 default value is 0.
 
 Let B denote batch_dims, and data, indices shape be (X_0, X_1, ..., X_{N-1}),
-(M, Y_0, ..., Y_{K-1}) respectively. When B > 0, indexing will start from the B-th axis,
-and it must be the case that X_0, ... X_{B-1} == Y_0, ... Y_{B-1}.
+(M, Y_0, ..., Y_{K-1}) respectively.
 
-The output will have shape
-(Y_0, ..., Y_{B-1}, ..., Y_{K-1}, X_{M+B}, ..., X_{N-1}), where M + B <= N. If M + B == N,
-output shape will simply be (Y_0, ..., Y_{K-1}).
+When B > 0, indexing will start from the B-th axis, and it must be the case that
+X_0, ... X_{B-1} == Y_0, ... Y_{B-1}. The output will have a shape
+(X_0, ..., X_{B-1}, Y_B, ..., Y_{K-1}, X_{M+B}, ..., X_{N-1}), where M + B <= N.
+
+When B == 0 (the default case), the output shape will be (Y_0, ..., Y_{K-1}, X_M, ..., X_{N-1}).
+
+In both cases, if M + B == N, the output shape will simply be (Y_0, ..., Y_{K-1}).
 )code" TVM_ADD_FILELINE)
     .set_num_inputs(2)
     .add_argument("data", "Tensor", "The input tensor.")

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3355,7 +3355,7 @@ bool GatherNDRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 
   Array<IndexExpr> oshape;
   for (size_t i = 1; i < kdim + 1; ++i) oshape.push_back(indices->shape[i]);
-  for (size_t i = mdim->value + param->batch_dim->value; i < ndim; ++i)
+  for (size_t i = mdim->value + param->batch_dims->value; i < ndim; ++i)
     oshape.push_back(data->shape[i]);
   reporter->Assign(types[2], TensorType(oshape, data->dtype));
   return true;
@@ -3365,13 +3365,13 @@ Array<te::Tensor> GatherNDCompute(const Attrs& attrs, const Array<te::Tensor>& i
                                   const Type& out_type) {
   const auto* param = attrs.as<GatherNDAttrs>();
   ICHECK(param);
-  return {topi::gather_nd(inputs[0], inputs[1], param->batch_dim)};
+  return {topi::gather_nd(inputs[0], inputs[1], param->batch_dims)};
 }
 
-Expr MakeGatherND(Expr data, Expr indices, int batch_dim = 0) {
+Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0) {
   static const Op& op = Op::Get("gather_nd");
   auto attrs = make_object<GatherNDAttrs>();
-  attrs->batch_dim = std::move(batch_dim);
+  attrs->batch_dims = std::move(batch_dims);
   return Call(op, {data, indices}, Attrs(attrs));
 }
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1045,7 +1045,7 @@ def test_gather_nd():
     verify_gather_nd([2, 2, 2], [[0, 1], [1, 0]], [2, 2])
     verify_gather_nd([2, 2, 2], [[[0, 1]], [[1, 0]]], [2, 1, 2])
 
-    if is_version_greater_than("1.7.0"):
+    if is_version_greater_than("1.6.0"):
         verify_gather_nd([2, 2, 2], [[1], [0]], [2, 2], batch_dims=1, opset=12)
         verify_gather_nd(
             (3, 2, 2, 3, 4),

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import re
 import numpy as np
 import pytest
 import scipy
@@ -215,6 +216,12 @@ def make_constant_node(name, data_type, dims, vals):
         inputs=[],
         outputs=[name],
         value=helper.make_tensor(name=name, data_type=data_type, dims=dims, vals=vals),
+    )
+
+
+def is_version_greater_than(ver):
+    return "".join(re.findall(r"(\d+\.)(\d+\.)(\d)", onnx.__version__)[0]) > "".join(
+        re.findall(r"(\d+\.)(\d+\.)(\d)", ver)[0]
     )
 
 
@@ -1002,11 +1009,15 @@ def test_isnan():
     _test_finite_ops((2, 4, 5, 6), np.isnan, {}, "float32", "IsNaN", {})
 
 
-def verify_gather_nd(in_shape, indices, out_shape, dtype="float32"):
+def verify_gather_nd(in_shape, indices, out_shape, dtype="float32", batch_dims=0, opset=11):
     x = np.random.uniform(size=in_shape).astype(dtype)
     indices = np.array(indices, dtype="int64")
 
     y = helper.make_node("GatherND", ["in", "indices"], ["out"])
+
+    if opset >= 12:
+        batch_dims_attr = helper.make_attribute("batch_dims", batch_dims)
+        y.attribute.append(batch_dims_attr)
 
     graph = helper.make_graph(
         [y],
@@ -1024,7 +1035,7 @@ def verify_gather_nd(in_shape, indices, out_shape, dtype="float32"):
         ],
     )
     model = helper.make_model(graph, producer_name="gather_test")
-    verify_with_ort_with_inputs(model, [x, indices], [out_shape])
+    verify_with_ort_with_inputs(model, [x, indices], [out_shape], opset=opset)
 
 
 @tvm.testing.uses_gpu
@@ -1033,6 +1044,16 @@ def test_gather_nd():
     verify_gather_nd([2, 2], [[1], [0]], [2, 2])
     verify_gather_nd([2, 2, 2], [[0, 1], [1, 0]], [2, 2])
     verify_gather_nd([2, 2, 2], [[[0, 1]], [[1, 0]]], [2, 1, 2])
+
+    if is_version_greater_than("1.7.0"):
+        verify_gather_nd([2, 2, 2], [[1], [0]], [2, 2], batch_dims=1, opset=12)
+        verify_gather_nd(
+            (3, 2, 2, 3, 4),
+            np.random.randint(low=0, high=2, size=(3, 2, 3), dtype="int64"),
+            (3, 2),
+            batch_dims=2,
+            opset=12,
+        )
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1276,11 +1276,11 @@ def test_gather_nd():
 
         if batch_dims > 1:
             x_data_reshape = np.reshape(x_data, (-1,) + xshape[batch_dims:])
-            y_data_reshape = np.reshape(y_data, (yshape[0], -1) + yshape[(batch_dims + 1):])
+            y_data_reshape = np.reshape(y_data, (yshape[0], -1) + yshape[(batch_dims + 1) :])
 
             ref_res = gather_nd_batch_dims_1_ref(x_data_reshape, y_data_reshape)
 
-            out_shape = yshape[1: (batch_dims + 1)] + ref_res.shape[1:]
+            out_shape = yshape[1 : (batch_dims + 1)] + ref_res.shape[1:]
             ref_res = np.reshape(ref_res, out_shape)
         elif batch_dims == 1:
             ref_res = gather_nd_batch_dims_1_ref(x_data, y_data)

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1263,10 +1263,9 @@ def test_gather_nd():
 
         if batch_dim > 0:
             res = []
-            axes = (tuple(range(1, len(y_data.shape))) + (0,))
-            swapped = np.transpose(y_data, axes)
-            for row, ind in zip(x_data, swapped):
-                res.append(row[tuple(ind.T)])
+            for i, row in enumerate(x_data):
+                indices = y_data[:, i]  # the indices for the i-th batch
+                res.append(row[tuple(indices)])
             ref_res = np.stack(res, 0)
         else:
             ref_res = x_data[tuple(y_data)]

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1261,12 +1261,16 @@ def test_gather_nd():
         x_data = np.random.uniform(size=xshape).astype("float32")
         y_data = np.array(y_data).astype(np.int32)
 
-        if batch_dim > 0:
+        def gather_nd_batch_dim_1_ref(data, indices):
             res = []
-            for i, row in enumerate(x_data):
-                indices = y_data[:, i]  # the indices for the i-th batch
-                res.append(row[tuple(indices)])
-            ref_res = np.stack(res, 0)
+            for i, row in enumerate(data):
+                indices_tuple = tuple(indices[:, i])  # the indices for the i-th batch
+                res.append(row[indices_tuple])
+            # stack on the batch dim
+            return np.stack(res, 0)
+
+        if batch_dim > 0:
+            ref_res = gather_nd_batch_dim_1_ref(x_data, y_data)
         else:
             ref_res = x_data[tuple(y_data)]
 

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1252,10 +1252,10 @@ def test_gather(data, axis, indices, ref_res):
 
 @tvm.testing.uses_gpu
 def test_gather_nd():
-    def verify_gather_nd(xshape, yshape, y_data, batch_dim=0):
+    def verify_gather_nd(xshape, yshape, y_data, batch_dims=0):
         x = relay.var("x", relay.TensorType(xshape, "float32"))
         y = relay.var("y", relay.TensorType(yshape, "int32"))
-        z = relay.gather_nd(x, y, batch_dim)
+        z = relay.gather_nd(x, y, batch_dims)
 
         func = relay.Function([x, y], z)
 
@@ -1266,7 +1266,7 @@ def test_gather_nd():
         else:
             y_data = np.random.randint(low=0, high=2, size=yshape, dtype="int32")
 
-        def gather_nd_batch_dim_1_ref(data, indices):
+        def gather_nd_batch_dims_1_ref(data, indices):
             res = []
             for i, row in enumerate(data):
                 indices_tuple = tuple(indices[:, i])  # the indices for the i-th batch
@@ -1274,16 +1274,16 @@ def test_gather_nd():
             # stack on the batch dim
             return np.stack(res, 0)
 
-        if batch_dim > 1:
-            x_data_reshape = np.reshape(x_data, (-1,) + xshape[batch_dim:])
-            y_data_reshape = np.reshape(y_data, (yshape[0], -1) + yshape[(batch_dim + 1) :])
+        if batch_dims > 1:
+            x_data_reshape = np.reshape(x_data, (-1,) + xshape[batch_dims:])
+            y_data_reshape = np.reshape(y_data, (yshape[0], -1) + yshape[(batch_dims + 1):])
 
-            ref_res = gather_nd_batch_dim_1_ref(x_data_reshape, y_data_reshape)
+            ref_res = gather_nd_batch_dims_1_ref(x_data_reshape, y_data_reshape)
 
-            out_shape = yshape[1 : (batch_dim + 1)] + ref_res.shape[1:]
+            out_shape = yshape[1: (batch_dims + 1)] + ref_res.shape[1:]
             ref_res = np.reshape(ref_res, out_shape)
-        elif batch_dim == 1:
-            ref_res = gather_nd_batch_dim_1_ref(x_data, y_data)
+        elif batch_dims == 1:
+            ref_res = gather_nd_batch_dims_1_ref(x_data, y_data)
         else:
             ref_res = x_data[tuple(y_data)]
 


### PR DESCRIPTION
Similar to https://github.com/apache/tvm/pull/7951 that added `batch_dim` to `take` (gather) op, I added `batch_dims` option to `gather_nd` that is useful for TF/ONNX.

https://www.tensorflow.org/api_docs/python/tf/gather_nd
https://github.com/onnx/onnx/blob/master/docs/Operators.md#GatherND (Opset 12 or higher)

please review @Laurawly @mbrookhart @comaniac @yongwww 