### PR TITLE
[BYOC][NNAPI]: Add testing package to ci_cpu image

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -102,3 +102,10 @@ RUN bash /install/ubuntu_install_ethosn_driver_stack.sh
 # Vitis-AI PyXIR CI deps
 COPY install/ubuntu_install_vitis_ai_packages_ci.sh /install/ubuntu_install_vitis_ai_packages_ci.sh
 RUN bash /install/ubuntu_install_vitis_ai_packages_ci.sh
+
+# Android SDK
+COPY install/ubuntu_install_androidsdk.sh /install/ubuntu_install_androidsdk.sh
+RUN bash /install/ubuntu_install_androidsdk.sh
+ENV ANDROID_HOME=/opt/android-sdk-linux/
+ENV ANDROID_NDK_HOME=/opt/android-sdk-linux/ndk/21.3.6528147/
+


### PR DESCRIPTION
This commit adds Android SDK to the ci_cpu image for supporting tests of Android NNAPI BYOC.

See also: 
+ [\[RFC\]\[BYOC\] Android NNAPI Integration](https://discuss.tvm.apache.org/t/rfc-byoc-android-nnapi-integration/9072)
+ PR #8076 

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
