### PR TITLE
[CI][Docker] set environment variables for UTF-8, to prevent errors when running `black`

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -43,3 +43,7 @@ RUN bash /install/ubuntu1804_install_clang_format.sh
 
 COPY install/ubuntu_install_nodejs.sh /install/ubuntu_install_nodejs.sh
 RUN bash /install/ubuntu_install_nodejs.sh
+
+# To prevent `black` command line errors caused by ASCII encoding
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8


### PR DESCRIPTION
Updates ci_lint image to use UTF-8 encoding.

 * Sets environment shell encoding to UTF-8

 * This prevents the black formatting tool to exit with the following error:
   "RuntimeError: Click will abort further execution because Python was
    configured to use ASCII as encoding for the environment"