### PR TITLE
[Relay][TOPI] Fix compute and schedule bugs for conv2d_winograd_nhwc on mali device.

### DIFF
--- a/python/tvm/relay/op/strategy/mali.py
+++ b/python/tvm/relay/op/strategy/mali.py
@@ -96,7 +96,9 @@ def conv2d_strategy_mali(attrs, inputs, out_type, target):
                 )
             if is_winograd_applicable:
                 strategy.add_implementation(
-                    wrap_compute_conv2d(topi.nn.conv2d_winograd_nhwc),
+                    wrap_compute_conv2d(
+                        topi.nn.conv2d_winograd_nhwc, need_auto_scheduler_layout=True
+                    ),
                     naive_schedule,  # this implementation should never be picked by autotvm
                     name="conv2d_nhwc.winograd",
                     plevel=15,
@@ -155,7 +157,10 @@ def conv2d_winograd_without_weight_transfrom_strategy_mali(attrs, inputs, out_ty
                 "Winograd conv2d NHWC is not enabled for mali without auto_scheduler."
             )
         strategy.add_implementation(
-            wrap_compute_conv2d(topi.nn.conv2d_winograd_nhwc_without_weight_transform),
+            wrap_compute_conv2d(
+                topi.nn.conv2d_winograd_nhwc_without_weight_transform,
+                need_auto_scheduler_layout=True,
+            ),
             naive_schedule,  # this implementation should never be picked by autotvm
             name="conv2d_nhwc_winograd_without_weight_transform",
             plevel=15,

--- a/python/tvm/topi/mali/conv2d.py
+++ b/python/tvm/topi/mali/conv2d.py
@@ -579,14 +579,29 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
 
 @conv2d_winograd_nhwc.register(["mali"])
 def conv2d_winograd_nhwc_mali(
-    data, weight, strides, padding, dilation, out_dtype, pre_computed=False
+    data,
+    weight,
+    strides,
+    padding,
+    dilation,
+    out_dtype,
+    pre_computed=False,
+    auto_scheduler_rewritten_layout="",
 ):
     """Conv2D Winograd in NHWC layout.
     This is a clean version to be used by the auto-scheduler for mali.
     """
     tile_size = _pick_tile_size(data, weight, layout="NHWC")
     return _conv2d_winograd_nhwc_impl(
-        data, weight, strides, padding, dilation, out_dtype, tile_size, pre_computed
+        data,
+        weight,
+        strides,
+        padding,
+        dilation,
+        out_dtype,
+        tile_size,
+        pre_computed,
+        auto_scheduler_rewritten_layout,
     )
 
 


### PR DESCRIPTION
This PR fix the schedule and compute bugs when running AutoScheduler om mali device. 

1. add argument `auto_scheduler_rewritten_layout=""` in conv2d_winograd_nhwc_mali;
2. add `need_auto_scheduler_layout=True` for conv2d_strategy_mali and
conv2d_winograd_without_weight_transfrom_strategy_mali.

Thank you for your time on reviewing this PR :)