### PR TITLE
doc: fix description of stop_fusion annotation

### DIFF
--- a/python/tvm/relay/op/annotation/annotation.py
+++ b/python/tvm/relay/op/annotation/annotation.py
@@ -51,7 +51,7 @@ def on_device(data, device):
 
 
 def stop_fusion(data):
-    """Annotate an expression to prevent it being fused with previous expressions.
+    """Annotate an expression to prevent it being fused with following expressions.
 
     Parameters
     ----------

--- a/src/relay/op/annotation/annotation.cc
+++ b/src/relay/op/annotation/annotation.cc
@@ -73,7 +73,7 @@ TVM_REGISTER_GLOBAL("relay.op.annotation._make.stop_fusion").set_body_typed([](E
 
 RELAY_REGISTER_OP("annotation.stop_fusion")
     .describe(
-        R"code(Annotate an expression to prevent it being fused with previous expressions.)code" TVM_ADD_FILELINE)
+        R"code(Annotate an expression to prevent it being fused with following expressions.)code" TVM_ADD_FILELINE)
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input data.")
     .add_type_rel("Identity", IdentityRel)


### PR DESCRIPTION
The annotation causes the fuse_ops pass to stop fusing once it encounteres the annotation:

https://github.com/apache/tvm/blob/b2c4f1c2cbd4c4b7ac27ac853dbad7c489784444/src/relay/transforms/fuse_ops.cc#L878

Therefore, the correct documentation should state that it stops fusing with the calls that follow, not the previous ones.

@vinx13 @tqchen 