### PR TITLE
Decoupling AOT from graph memory planner

### DIFF
--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -419,6 +419,11 @@ TVM_DLL Pass ConvertBlocksToOpaque();
 TVM_DLL Pass CompactBufferAllocation();
 
 /*!
+ * This pass legalizes packed calls by wrapping their arguments into TVMValues
+ */
+TVM_DLL Pass LegalizePackedCalls();
+
+/*!
  * \brief Flatten the multi-dimensional BufferLoad and BufferStore
  *        to single dimensional Load/Store. Also remove Block to
  *        ensure that the flattened TIR can not be scheduled again.

--- a/python/tvm/tir/transform/transform.py
+++ b/python/tvm/tir/transform/transform.py
@@ -451,6 +451,17 @@ def LowerTVMBuiltin():
     return _ffi_api.LowerTVMBuiltin()
 
 
+def LegalizePackedCalls():
+    """Legalize packed calls to have its arguments wrapped in TVMValues
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.LegalizePackedCalls()
+
+
 def LowerIntrin():
     """Lower target specific intrinsic calls.
 

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -269,11 +269,10 @@ class AOTExecutorCodegen : public ExprVisitor {
         continue;
       }
 
-
       auto sid_value = sids_table_[sid];
       if (!use_unpacked_api_) {
-    	// Pack the sid inside the TVMValue
-    	auto sid_array = te::Var(MakeString("sid_", sid, "_value"), DataType::Handle());
+        // Pack the sid inside the TVMValue
+        auto sid_array = te::Var(MakeString("sid_", sid, "_value"), DataType::Handle());
         tvm::PrimExpr set_tensor =
             tvm::tir::Call(DataType::Handle(), tvm::tir::builtin::tvm_struct_set(),
                            {sid_array, 0, tir::builtin::kArrData, sid_value});
@@ -281,7 +280,7 @@ class AOTExecutorCodegen : public ExprVisitor {
             tir::LetStmt(sid_array, StackAlloca("array", 1), tir::Evaluate(set_tensor)));
         buffer_vars.push_back(sid_array);
       } else {
-    	  buffer_vars.push_back(sid_value)
+        buffer_vars.push_back(sid_value);
       }
     }
     return buffer_vars;

--- a/src/tir/transforms/ir_utils.h
+++ b/src/tir/transforms/ir_utils.h
@@ -29,6 +29,8 @@
 #include <tvm/tir/expr.h>
 #include <tvm/tir/op.h>
 
+#include <limits>
+#include <string>
 #include <vector>
 
 namespace tvm {
@@ -159,6 +161,27 @@ inline int GetTempAllocaAlignment(DataType type, int32_t const_size) {
     }
   }
   return align;
+}
+
+/*!
+ * \brief Create an int32 constant
+ * \param index the value of the constant
+ * \return the PrimExpr that represents the constant
+ */
+inline PrimExpr ConstInt32(size_t index) {
+  ICHECK_LE(index, std::numeric_limits<int>::max());
+  return make_const(DataType::Int(32), static_cast<int>(index));
+}
+
+/*!
+ * \brief Allocate TVMValues on the stack
+ * \param type type of allocation
+ * \param num number of TVMValues to allocate
+ * \return PrimExpr representing the TVMValue
+ */
+inline PrimExpr StackAlloca(std::string type, size_t num) {
+  Array<PrimExpr> args = {StringImm(type), ConstInt32(num)};
+  return Call(DataType::Handle(), builtin::tvm_stack_alloca(), args);
 }
 
 /*!

--- a/src/tir/transforms/legalize_packed_calls.cc
+++ b/src/tir/transforms/legalize_packed_calls.cc
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file make_packed_call.cc
+ * \brief Rewrite packed calls in AOT so that the arguments are packed
+ */
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include <unordered_map>
+
+#include "ir_utils.h"
+
+namespace tvm {
+namespace tir {
+
+using InputMap =
+    std::unordered_map<PrimExpr, bool, runtime::ObjectPtrHash, runtime::ObjectPtrEqual>;
+/**
+ * This is a legalization pass only used in AOT. Traverse the TIR graph to legalize
+ * packed calls by making its argument wrapped in TVMValues (by using tvm_set_struct built-in)
+ */
+class PackedCallLegalizer : public StmtExprMutator {
+ public:
+  Stmt Legalize(const InputMap& params, tir::Stmt body) {
+    inputs_ = params;
+    return StmtExprMutator::VisitStmt(body);
+  }
+
+  Stmt VisitStmt_(const EvaluateNode* op) final {
+    if (tir::is_const_int(op->value)) return StmtExprMutator::VisitStmt_(op);
+    const CallNode* call = op->value.as<CallNode>();
+    // Given a packed call f(A,B,C), we need a set of new statements
+    // let A_packed = set_struct(tvm_value1, A)
+    // let B_packed = set_struct(tvm_value2, B)
+    // let C_packed = set_struct(tvm_value3, C)
+    // call_packed(f, A_packed, B_packed, C_packed)
+    std::vector<Stmt> new_stmts;
+    if (call) {
+      if (call->op.same_as(builtin::tvm_call_cpacked())) {
+        Array<PrimExpr> packed_args{call->args[0]};
+        for (unsigned i = 1; i < call->args.size(); i++) {
+          // No need to pack inputs of the prim_func
+          if (inputs_[call->args[i]] == true) {
+            packed_args.push_back(call->args[i]);
+          } else {
+            // Pack the argument inside a TVMValue
+            auto sid_array = tir::Var("tvm_value", DataType::Handle());
+            tir::Stmt set_struct_stmt = tir::Evaluate(
+                tvm::tir::Call(DataType::Handle(), tvm::tir::builtin::tvm_struct_set(),
+                               {sid_array, 0, tir::builtin::kArrData, call->args[i]}));
+            new_stmts.push_back(LetStmt(sid_array, StackAlloca("array", 1), set_struct_stmt));
+            packed_args.push_back(sid_array);
+          }
+        }
+        // Finally, evaluate the packed call and return a sequential statement
+        new_stmts.push_back(tir::Evaluate(tir::Call(call->dtype, call->op, packed_args)));
+        return tir::SeqStmt(new_stmts);
+      }
+    }
+    return StmtExprMutator::VisitStmt_(op);
+  }
+
+ private:
+  InputMap inputs_;  // Store the inputs to the primfunc that don't need to be packed.
+};
+
+namespace transform {
+
+Pass LegalizePackedCalls() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    auto* n = f.CopyOnWrite();
+
+    // Create the
+    InputMap inputs;
+    for (auto i : f->params) {
+      inputs[i] = true;
+    }
+    n->body = PackedCallLegalizer().Legalize(inputs, std::move(n->body));
+    return std::move(f);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.LegalizePackedCalls", {});
+}
+}  // namespace transform
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -34,16 +34,6 @@
 namespace tvm {
 namespace tir {
 
-inline PrimExpr ConstInt32(size_t index) {
-  ICHECK_LE(index, std::numeric_limits<int>::max());
-  return make_const(DataType::Int(32), static_cast<int>(index));
-}
-
-inline PrimExpr StackAlloca(std::string type, size_t num) {
-  Array<PrimExpr> args = {StringImm(type), ConstInt32(num)};
-  return Call(DataType::Handle(), builtin::tvm_stack_alloca(), args);
-}
-
 // Calculate the statistics of packed function.
 // These information are needed during codegen.
 class BuiltinLower : public StmtExprMutator {

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -142,7 +142,8 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
       // Recall that the arguments of a tvm_call_cpacked are passed as
       // TVMValues. But a TVMValue is only a container, that points to
       // a real buffer previously allocated. We need to signal that those
-      // buffers need to be live at the same time (i.e., cannot be overridden)
+      // buffers need to be live at the same time (i.e., cannot be overwritten during the function
+      // call)
       Array<PrimExpr> args = op->args;
       for (auto arg : args) {
         const VarNode* var = arg.as<VarNode>();
@@ -234,7 +235,12 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
   bool in_thread_env_{false};
   // The scope stack.
   std::vector<StmtEntry> scope_;
-  // This is a map to connect TVMValues to real allocations
+  // This is a map to connect TVMValues to real allocations. When we pass parameters
+  // to a tvm_call_cpacked, the data needs to be wrapped in a TVMValue. The wrapping
+  // happens through the tvm_struct_set built-in. This map is mapping the variable
+  // representing the TVMValue to the variable representing the real buffer. The live
+  // analysis needs to happen on the latter and not on the TVMValue which only acts as
+  // a container.
   std::unordered_map<const VarNode*, std::vector<const VarNode*>> value_to_alloc_;
 };
 

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -138,35 +138,6 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
     if (op->op.same_as(builtin::address_of())) {
       const LoadNode* l = op->args[0].as<LoadNode>();
       this->VisitExpr(l->index);
-    } else if (op->op.same_as(builtin::tvm_call_cpacked())) {
-      // Recall that the arguments of a tvm_call_cpacked are passed as
-      // TVMValues. But a TVMValue is only a container, that points to
-      // a real buffer previously allocated. We need to signal that those
-      // buffers need to be live at the same time (i.e., cannot be overwritten during the function
-      // call)
-      Array<PrimExpr> args = op->args;
-      for (auto arg : args) {
-        const VarNode* var = arg.as<VarNode>();
-        if (value_to_alloc_.find(var) != value_to_alloc_.end()) {
-          auto allocs = value_to_alloc_[var];
-          for (const VarNode* alloc : allocs) {
-            VisitExpr_(alloc);
-          }
-        } else {
-          this->VisitExpr(arg);
-        }
-      }
-    } else if (op->op.same_as(builtin::tvm_struct_set())) {
-      // If we are using a struct_set built-in, and we are setting
-      // a DLTensor ArrayData field, let's note down the
-      // buffers that the TVMValue refers to
-      const VarNode* var = op->args[0].as<VarNode>();
-      const VarNode* alloc = op->args[3].as<VarNode>();
-      const int field_id = op->args[2].as<IntImmNode>()->value;
-      if (var && alloc && field_id == tir::builtin::kArrData) {
-        value_to_alloc_[var].push_back(alloc);
-      }
-      StmtExprVisitor::VisitExpr_(op);
     } else {
       StmtExprVisitor::VisitExpr_(op);
     }
@@ -235,13 +206,6 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
   bool in_thread_env_{false};
   // The scope stack.
   std::vector<StmtEntry> scope_;
-  // This is a map to connect TVMValues to real allocations. When we pass parameters
-  // to a tvm_call_cpacked, the data needs to be wrapped in a TVMValue. The wrapping
-  // happens through the tvm_struct_set built-in. This map is mapping the variable
-  // representing the TVMValue to the variable representing the real buffer. The live
-  // analysis needs to happen on the latter and not on the TVMValue which only acts as
-  // a container.
-  std::unordered_map<const VarNode*, std::vector<const VarNode*>> value_to_alloc_;
 };
 
 // Verify if the statement can be run safely via inplace fashion
@@ -923,11 +887,11 @@ class StoragePlanRewriter : public StmtExprMutator {
   // symbolic free list, for non constant items.
   std::list<StorageEntry*> sym_free_list_;
   // The allocation attach map
-  std::unordered_map<const Object*, std::vector<StorageEntry*>> attach_map_;
+  std::unordered_map<const Object*, std::vector<StorageEntry*> > attach_map_;
   // The allocation assign map
   std::unordered_map<const VarNode*, StorageEntry*> alloc_map_;
   // The allocations
-  std::vector<std::unique_ptr<StorageEntry>> alloc_vec_;
+  std::vector<std::unique_ptr<StorageEntry> > alloc_vec_;
   // analyzer
   arith::Analyzer analyzer_;
 };
@@ -986,7 +950,7 @@ class VectorAllocRewriter : public StmtExprMutator {
   }
 
   // Internal access map
-  std::unordered_map<const VarNode*, std::vector<DataType>> acc_map_;
+  std::unordered_map<const VarNode*, std::vector<DataType> > acc_map_;
   // Variables to remap
   Map<tir::Var, PrimExpr> var_remap_;
   // internal analyzer

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -37,9 +37,50 @@ from tvm.contrib import utils
 from tvm.micro import export_model_library_format
 
 
+<<<<<<< HEAD
 def mangle_name(mod_name, name):
     mod_name = mangle_module_name(mod_name)
     return mod_name + "_" + name
+=======
+def convert_to_relay(
+    tflite_model_buf,
+    input_data,
+    input_node,
+):
+    """ Convert a tflite model buffer in a Relay module """
+
+    def convert_to_list(x):
+        if not isinstance(x, list):
+            x = [x]
+        return x
+
+    # TFLite.Model.Model has changed to TFLite.Model from 1.14 to 2.1
+    try:
+        import tflite.Model
+
+        tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
+    except AttributeError:
+        import tflite
+
+        tflite_model = tflite.Model.GetRootAsModel(tflite_model_buf, 0)
+    except ImportError:
+        raise ImportError("The tflite package must be installed")
+
+    input_data = convert_to_list(input_data)
+    input_node = convert_to_list(input_node)
+
+    shape_dict = {}
+    dtype_dict = {}
+    for i, e in enumerate(input_node):
+        shape_dict[e] = input_data[i].shape
+        dtype_dict[e] = input_data[i].dtype.name
+
+    mod, params = relay.frontend.from_tflite(
+        tflite_model, shape_dict=shape_dict, dtype_dict=dtype_dict
+    )
+    mod["main"] = relay.build_module.bind_params_by_name(mod["main"], params)
+    return mod, params
+>>>>>>> 7d02e64f6... Fix an issue with storage-rewrite pass and packed functions
 
 
 def subprocess_with_stdout_and_log(cmd, cwd, logfile, stdout):
@@ -221,6 +262,7 @@ def compile_and_run(
     params=None,
     workspace_byte_alignment=8,
     mod_name=None,
+    enable_op_fusion=True,
 ):
     """
     This method verifies the generated source
@@ -232,7 +274,11 @@ def compile_and_run(
     if not use_calculated_workspaces:
         cflags += "-DTVM_CRT_STACK_ALLOCATOR_ENABLE_LIFO_CHECK "
 
-    with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
+    config = {"tir.disable_vectorize": True}
+    if not enable_op_fusion:
+        config["relay.FuseOps.max_depth"] = 1
+
+    with tvm.transform.PassContext(opt_level=3, config=config):
         lib = tvm.relay.build(mod, target, target_host=target, params=params, mod_name=mod_name)
 
     tmp_path = utils.tempdir()

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -47,7 +47,7 @@ def convert_to_relay(
     input_data,
     input_node,
 ):
-    """ Convert a tflite model buffer in a Relay module """
+    """Convert a tflite model buffer in a Relay module"""
 
     def convert_to_list(x):
         if not isinstance(x, list):

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -37,11 +37,11 @@ from tvm.contrib import utils
 from tvm.micro import export_model_library_format
 
 
-<<<<<<< HEAD
 def mangle_name(mod_name, name):
     mod_name = mangle_module_name(mod_name)
     return mod_name + "_" + name
-=======
+
+
 def convert_to_relay(
     tflite_model_buf,
     input_data,
@@ -80,7 +80,6 @@ def convert_to_relay(
     )
     mod["main"] = relay.build_module.bind_params_by_name(mod["main"], params)
     return mod, params
->>>>>>> 7d02e64f6... Fix an issue with storage-rewrite pass and packed functions
 
 
 def subprocess_with_stdout_and_log(cmd, cwd, logfile, stdout):

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -465,5 +465,47 @@ def @main(%data : Tensor[(1, 3, 64, 64), uint8], %weight : Tensor[(8, 3, 5, 5), 
     )
 
 
+def test_quant_mobilenet_tfl():
+    pytest.importorskip("tflite")
+
+    import tvm.relay.testing.tf as tf_testing
+
+    tflite_model_file = tf_testing.get_workload_official(
+        "https://storage.googleapis.com/download.tensorflow.org/"
+        "models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz",
+        "mobilenet_v1_1.0_224_quant.tflite",
+    )
+    with open(tflite_model_file, "rb") as f:
+        tflite_model_buf = f.read()
+    data_shape = (1, 224, 224, 3)
+    in_min, in_max = (0, 255)
+    data = np.random.randint(in_min, high=in_max, size=data_shape, dtype="uint8")
+    mod, params = convert_to_relay(tflite_model_buf, data, "input")
+    inputs = {"input": data}
+    output_list = generate_ref_data(mod, inputs, params)
+    input_list = [inputs["input"]]
+    compile_and_run(mod, input_list, output_list, True, params)
+
+@pytest.mark.parametrize("target_options", ["--unpacked-api=0", "--unpacked-api=1"])
+def test_transpose(target_options):
+    dtype = "float32"
+    x = relay.var("x", shape=(10, 5), dtype=dtype)
+    y = relay.var("y", shape=(10, 5), dtype=dtype)
+    t = relay.var("z", shape=(), dtype=dtype)
+    a = relay.add(x, y)
+    b = relay.transpose(a)
+    z = relay.add(b, t)
+    # Check result.
+    func = relay.Function([x, y, t], z)
+    x_data = np.random.rand(10, 5).astype(dtype)
+    y_data = np.random.rand(10, 5).astype(dtype)
+    t_data = np.random.uniform(size=()).astype(dtype)
+    inputs = {"x": x_data, "y": y_data, "z": t_data}
+
+    output_list = generate_ref_data(func, inputs)
+    input_list = [inputs["x"], inputs["y"], inputs["z"]]
+    compile_and_run(func, input_list, output_list, target_options, True, enable_op_fusion=False)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -466,6 +466,9 @@ def @main(%data : Tensor[(1, 3, 64, 64), uint8], %weight : Tensor[(8, 3, 5, 5), 
 
 
 def test_quant_mobilenet_tfl():
+    """Since in AOT we pass directly the output buffer from the user, in quantized networks sharing the output buffers is not possible.
+    This is because the output data type is int8 and the intermediate buffer are int32 or int16. We use mobilenet quantized to stress this
+    situation and verify that the output buffer sharing is disabled in AOT."""
     pytest.importorskip("tflite")
 
     import tvm.relay.testing.tf as tf_testing
@@ -489,6 +492,8 @@ def test_quant_mobilenet_tfl():
 
 @pytest.mark.parametrize("target_options", ["--unpacked-api=0", "--unpacked-api=1"])
 def test_transpose(target_options):
+    """Test that non-inpleaceable operations (e.g., transpose) do not happen in-place."""
+
     dtype = "float32"
     x = relay.var("x", shape=(10, 5), dtype=dtype)
     y = relay.var("y", shape=(10, 5), dtype=dtype)

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -484,7 +484,8 @@ def test_quant_mobilenet_tfl():
     inputs = {"input": data}
     output_list = generate_ref_data(mod, inputs, params)
     input_list = [inputs["input"]]
-    compile_and_run(mod, input_list, output_list, True, params)
+    compile_and_run(mod, input_list, output_list, "--unpacked-api=0", True, params)
+
 
 @pytest.mark.parametrize("target_options", ["--unpacked-api=0", "--unpacked-api=1"])
 def test_transpose(target_options):

--- a/tests/python/unittest/test_aot_legalize_packed_call.py
+++ b/tests/python/unittest/test_aot_legalize_packed_call.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-function-docstring,missing-module-docstring
+import tvm
+from tvm.script import ty
+from tvm import te, tir
+import numpy as np
+import tvm.testing
+import pytest
+
+
+@tvm.script.tir
+class Module:
+    def tir_packed_call() -> None:
+        A = tir.var("handle")
+        B = tir.var("handle")
+        C = tir.var("handle")
+        # body
+        tir.evaluate(
+            tir.tvm_call_cpacked(
+                "tvm_test_cpacked",
+                A,
+                B,
+                C,
+                dtype="int32",
+            )
+        )
+
+
+@tvm.script.tir
+class Expected:
+    def tir_packed_call() -> None:
+        A = tir.var("handle")
+        B = tir.var("handle")
+        C = tir.var("handle")
+
+        # body
+        tvm_value_2 = tir.var("handle")
+        tvm_value_1 = tir.var("handle")
+        tvm_value_0 = tir.var("handle")
+        with tir.let(tvm_value_2, tir.tvm_stack_alloca("array", 1, dtype="handle")):
+            with tir.let(tvm_value_1, tir.tvm_stack_alloca("array", 1, dtype="handle")):
+                with tir.let(tvm_value_0, tir.tvm_stack_alloca("array", 1, dtype="handle")):
+                    tir.evaluate(tir.tvm_struct_set(tvm_value_0, 0, 1, A, dtype="handle"))
+                    tir.evaluate(tir.tvm_struct_set(tvm_value_1, 0, 1, B, dtype="handle"))
+                    tir.evaluate(tir.tvm_struct_set(tvm_value_2, 0, 1, C, dtype="handle"))
+                    tir.evaluate(
+                        tir.tvm_call_cpacked(
+                            "tvm_test_cpacked",
+                            tvm_value_0,
+                            tvm_value_1,
+                            tvm_value_2,
+                            dtype="int32",
+                        )
+                    )
+
+
+def test_aot_packed_call():
+    mod = Module()
+    expected = Expected()
+    out = tir.transform.LegalizePackedCalls()(mod)
+    tvm.ir.assert_structural_equal(expected, out, map_free_vars=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
In this PR we are decoupling AOT from the Graph Memory Planner. Since AOT has the runner expressed in TIR we can get rid of the GMP in relay and use the Storage Rewrite Pass to do memory planning on the runner function. This also sorts out the issue mentioned in #8062