### PR TITLE
[Vulkan][Codegen] Added spvValidate check after vulkan shader generation

### DIFF
--- a/src/target/spirv/build_vulkan.cc
+++ b/src/target/spirv/build_vulkan.cc
@@ -40,11 +40,10 @@ class SPIRVTools {
   ~SPIRVTools() { spvContextDestroy(ctx_); }
   std::string BinaryToText(const std::vector<uint32_t>& bin) {
     spv_text text = nullptr;
-    spv_diagnostic diagnostic;
+    spv_diagnostic diagnostic = nullptr;
     spv_const_binary_t spv_bin{bin.data(), bin.size()};
-    spv_result_t res;
 
-    res =
+    spv_result_t res =
         spvBinaryToText(ctx_, spv_bin.code, spv_bin.wordCount,
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES | SPV_BINARY_TO_TEXT_OPTION_INDENT,
                         &text, &diagnostic);
@@ -53,10 +52,23 @@ class SPIRVTools {
                                 << " column=" << diagnostic->position.column
                                 << " index=" << diagnostic->position.index
                                 << " error:" << diagnostic->error;
+    spvDiagnosticDestroy(diagnostic);
 
     std::string ret(text->str);
     spvTextDestroy(text);
     return ret;
+  }
+
+  void ValidateShader(const std::vector<uint32_t>& bin) {
+    spv_const_binary_t spv_bin{bin.data(), bin.size()};
+
+    spv_diagnostic diagnostic = nullptr;
+    spv_result_t res = spvValidate(ctx_, &spv_bin, &diagnostic);
+
+    ICHECK_EQ(res, SPV_SUCCESS) << " index=" << diagnostic->position.index
+                                << " error:" << diagnostic->error;
+
+    spvDiagnosticDestroy(diagnostic);
   }
 
  private:
@@ -91,6 +103,8 @@ runtime::Module BuildSPIRV(IRModule mod, Target target, bool webgpu_restriction)
     std::string entry = webgpu_restriction ? "main" : f_name;
 
     VulkanShader shader = cg.BuildFunction(f, entry);
+
+    spirv_tools.ValidateShader(shader.data);
 
     if (webgpu_restriction) {
       for (auto param : f->params) {


### PR DESCRIPTION
spvValidate found the bug that was fixed in #7966, along with a few
other issues on missing capability/extension declarations.  Now that
all unit tests checked by the CI pass with it enabled, would like to
enable by default.
