### PR TITLE
[Vulkan] Remove some interface block decoration

### DIFF
--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <tuple>
 #include <spirv.hpp>
 // clang-format on
 

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -432,10 +432,12 @@ class IRBuilder {
    * \param value_type the content value type.
    * \param num_elems number of elements in array
    *   num_elems = 0 means runtime array with BufferBlock Decoration
+   * \param interface_block if this array type for interface blocks(input, output, uniform,
+   *   storage buffer).
    *
    * \return The corresponding spirv type.
    */
-  SType GetStructArrayType(const SType& value_type, uint32_t num_elems);
+  SType GetStructArrayType(const SType& value_type, uint32_t num_elems, bool interface_block);
   /*!
    * \brief Get a struct array access with a given index.
    * \param ptr_type The pointer type.
@@ -634,7 +636,7 @@ class IRBuilder {
   /*! \brief map from type code to the type */
   std::unordered_map<uint32_t, SType> pod_type_tbl_;
   /*! \brief map from value to array type */
-  std::map<std::pair<uint32_t, uint32_t>, SType> struct_array_type_tbl_;
+  std::map<std::tuple<uint32_t, uint32_t, bool>, SType> struct_array_type_tbl_;
   /*! \brief map from value to its pointer type */
   std::map<std::pair<uint32_t, spv::StorageClass>, SType> pointer_type_tbl_;
   /*! \brief map from constant int to its value */

--- a/tests/python/integration/test_ewise.py
+++ b/tests/python/integration/test_ewise.py
@@ -40,6 +40,9 @@ def test_exp():
         if not tvm.testing.device_enabled(host):
             return
         dev = tvm.device(device, 0)
+        if not tvm.testing.device_enabled(device):
+            print("skip because %s is not enabled.." % device)
+            return
         fexp = tvm.build(s, [A, B], device, host, name="myexp")
         dev = tvm.device(device, 0)
         # launch the kernel.


### PR DESCRIPTION
From [spir-v decoration](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#Decoration)
> Block
> Apply only to a structure type to establish it is a non-SSBO-like shader-interface block.

And [interface block(GLSL)](https://www.khronos.org/opengl/wiki/Interface_Block_(GLSL))
> An Interface Block is a group of GLSL input, output, uniform, or storage buffer variables. These blocks have special syntax and semantics that can be applied to them.

I guess that `StructArrayType`s of shared memory (or shared variables in GLSL) and local memory are not required to be decorated with `Block`.
After applying this patch, this [issue](https://discuss.tvm.apache.org/t/vulkan-windows-test-gemm-py-failed/10033) seems solved to me.