### PR TITLE
Auto-tuning a Convolutional Network for ARM CPU (tutorial error, bug reports) 

### DIFF
--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -295,7 +295,7 @@ def tune_tasks(
             if os.path.isfile(tmp_log_file):
                 tuner_obj.load_history(autotvm.record.load_from_file(tmp_log_file))
 
-        # do tuning
+        # process tuning
         tsk_trial = min(n_trial, len(tsk.config_space))
         tuner_obj.tune(
             n_trial=tsk_trial,

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -278,6 +278,10 @@ def tune_tasks(
             tuner_obj = XGBTuner(tsk, loss_type="rank")
         elif tuner == "xgb_knob":
             tuner_obj = XGBTuner(tsk, loss_type="rank", feature_type="knob")
+        elif tuner == 'xgb_itervar':
+            tuner_obj = XGBTuner(tsk, loss_type="rank", feature_type="itervar")
+        elif tuner == 'xgb_curve':
+            tuner_obj = XGBTuner(tsk, loss_type="rank", feature_type="curve")
         elif tuner == "ga":
             tuner_obj = GATuner(tsk, pop_size=50)
         elif tuner == "random":

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -278,9 +278,9 @@ def tune_tasks(
             tuner_obj = XGBTuner(tsk, loss_type="rank")
         elif tuner == "xgb_knob":
             tuner_obj = XGBTuner(tsk, loss_type="rank", feature_type="knob")
-        elif tuner == 'xgb_itervar':
+        elif tuner == "xgb_itervar":
             tuner_obj = XGBTuner(tsk, loss_type="rank", feature_type="itervar")
-        elif tuner == 'xgb_curve':
+        elif tuner == "xgb_curve":
             tuner_obj = XGBTuner(tsk, loss_type="rank", feature_type="curve")
         elif tuner == "ga":
             tuner_obj = GATuner(tsk, pop_size=50)


### PR DESCRIPTION
issue link : https://github.com/apache/tvm/issues/8067


It is a problem when using RPC session to connect Raspberry Pi and GPU server to proceed autoTVM.

There was a problem with tuning on autoTVM.

As in the tutorial example, creating xgbtuner causes problems.

I looked up tvm-API to solve the problem and found this sentence.
‘For cross-device or cross-operator tuning, you can use ‘curve’ only.’

However, the tutorial creates an xgbtuner that does not have a curve option.

In addition, the tutorial doesn't even have code to create xgbtuner with curve options.

Although it is an autoTVM tutorial for ARM CPU using RPC session, it seems strange that there is no curve option when creating xgbtuner.

So I made all the feature_type options available by xgbtuner and experimented.
Of the 3 options knob, itervar, and curve, only knob option does not fail and works well!

Question
The API says to use the curve option when using xgb, but in reality, it is strange that the knob option, not the curve option, works!
