### PR TITLE
[Relay] Support dynamic indices size in gather_nd and scatter_nd

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -146,11 +146,18 @@ struct GatherAttrs : public tvm::AttrsNode<GatherAttrs> {
 
 struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
   Integer batch_dims;
+  Integer gather_dim;
 
   TVM_DECLARE_ATTRS(GatherAttrs, "relay.attrs.GatherNDAttrs") {
     TVM_ATTR_FIELD(batch_dims).set_default(Integer(0)).describe("The number of batch dimensions.");
+    TVM_ATTR_FIELD(gather_dim)
+        .set_default(Integer(-1))
+        .describe(
+            "The size of an indexing tuple, which is a fixed value. Only needed when the number of "
+            "indexting tuples is dynamic.");
   }
 };
+
 struct TakeAttrs : public tvm::AttrsNode<TakeAttrs> {
   Integer batch_dims;
   Integer axis;

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -146,11 +146,11 @@ struct GatherAttrs : public tvm::AttrsNode<GatherAttrs> {
 
 struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
   Integer batch_dims;
-  Integer gather_dim;
+  Integer num_indices_per_tuple;
 
   TVM_DECLARE_ATTRS(GatherAttrs, "relay.attrs.GatherNDAttrs") {
     TVM_ATTR_FIELD(batch_dims).set_default(Integer(0)).describe("The number of batch dimensions.");
-    TVM_ATTR_FIELD(gather_dim)
+    TVM_ATTR_FIELD(num_indices_per_tuple)
         .set_default(Integer(-1))
         .describe(
             "The size of an indexing tuple, which is a fixed value. Only needed when the number of "

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -146,12 +146,12 @@ struct GatherAttrs : public tvm::AttrsNode<GatherAttrs> {
 
 struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
   Integer batch_dims;
-  Integer num_indices_per_tuple;
+  Optional<Integer> index_rank;
 
   TVM_DECLARE_ATTRS(GatherAttrs, "relay.attrs.GatherNDAttrs") {
     TVM_ATTR_FIELD(batch_dims).set_default(Integer(0)).describe("The number of batch dimensions.");
-    TVM_ATTR_FIELD(num_indices_per_tuple)
-        .set_default(Integer(-1))
+    TVM_ATTR_FIELD(index_rank)
+        .set_default(NullValue<Integer>())
         .describe(
             "The size of an indexing tuple, which is a fixed value. Only needed when the number of "
             "indexting tuples is dynamic.");

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1416,8 +1416,10 @@ class GatherND(OnnxOpConverter):
     @classmethod
     def _impl_common(cls, data, indices, batch_dims=0):
         indices_dims = len(infer_shape(indices))
+        indices_shape = infer_shape(indices)
         indices = _op.transpose(indices, axes=[-1] + list(range(indices_dims - 1)))
-        return _op.gather_nd(data, indices, batch_dims)
+        gather_dim = indices_shape[-1]
+        return _op.gather_nd(data, indices, batch_dims, gather_dim)
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1418,8 +1418,8 @@ class GatherND(OnnxOpConverter):
         indices_dims = len(infer_shape(indices))
         indices_shape = infer_shape(indices)
         indices = _op.transpose(indices, axes=[-1] + list(range(indices_dims - 1)))
-        num_indices_per_tuple = indices_shape[-1]
-        return _op.gather_nd(data, indices, batch_dims, num_indices_per_tuple)
+        index_rank = indices_shape[-1]
+        return _op.gather_nd(data, indices, batch_dims, index_rank)
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1418,8 +1418,8 @@ class GatherND(OnnxOpConverter):
         indices_dims = len(infer_shape(indices))
         indices_shape = infer_shape(indices)
         indices = _op.transpose(indices, axes=[-1] + list(range(indices_dims - 1)))
-        gather_dim = indices_shape[-1]
-        return _op.gather_nd(data, indices, batch_dims, gather_dim)
+        num_indices_per_tuple = indices_shape[-1]
+        return _op.gather_nd(data, indices, batch_dims, num_indices_per_tuple)
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1077,14 +1077,14 @@ def unique_shape_func(attrs, inputs, _):
 
 
 @script
-def _gather_nd_shape(data_shape, indices_shape, batch_dims, gather_dim):
+def _gather_nd_shape(data_shape, indices_shape, batch_dims, num_indices_per_tuple):
     ndim = data_shape.shape[0]
     # using mdim = indices_shape[0] wouldn't work because a rank cannot
     # depend on a runtime shape dimension of indices tensor, even if the
     # dimension is always a known, fixed value. As a workaround, we assume that
     # the fixed gather dimension (the size of an indexing tuple) is recorded
     # in `gather_nd` op attribute.
-    mdim = gather_dim
+    mdim = num_indices_per_tuple
     kdim = indices_shape.shape[0] - 1
     out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
     for i in range(1, kdim + 1):
@@ -1100,6 +1100,6 @@ def gather_nd_shape_func(attrs, inputs, _):
     Shape func for ghater_nd operator.
     """
     batch_dims = get_const_int(attrs.batch_dims)
-    gather_dim = get_const_int(attrs.gather_dim)
-    assert gather_dim > 0, "gather_dim needs to be specified for dynamic gather_nd"
-    return [_gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(gather_dim))]
+    num_indices_per_tuple = get_const_int(attrs.num_indices_per_tuple)
+    assert num_indices_per_tuple > 0, "num_indices_per_tuple needs to be specified for dynamic gather_nd"
+    return [_gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(num_indices_per_tuple))]

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1074,3 +1074,34 @@ def unique_shape_func(attrs, inputs, _):
         return _unique_with_counts_shape(inputs[0])
     else:
         return _unique_shape(inputs[0])
+
+
+@script
+def _gather_nd_shape(data_shape, indices_shape, batch_dims, gather_dim):
+    ndim = data_shape.shape[0]
+    mdim = gather_dim
+    # using mdim = indices_shape[0] wouldn't work because a rank cannot
+    # depend on a runtime shape dimension of indices tensor, even if the
+    # dimension is always a known, fixed value. As a workaround, we assume that
+    # the fixed gather dimension (the size of an indexing tuple) is recorded
+    # in `gather_nd` op attribute.
+    err_msg = "The recorded gather dimension and the actual dimension are different"
+    assert mdim == indices_shape[0], err_msg
+    kdim = indices_shape.shape[0] - 1
+    out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
+    for i in range(1, kdim + 1):
+        out_shape[i-1] = indices_shape[i]
+    for i in range(mdim + batch_dims, ndim):
+        out_shape[kdim + i - (mdim + batch_dims)] = data_shape[i]
+    return out_shape
+
+
+@_reg.register_shape_func("gather_nd", False)
+def gather_nd_shape_func(attrs, inputs, _):
+    """
+    Shape func for ghater_nd operator.
+    """
+    batch_dims = get_const_int(attrs.batch_dimss)
+    gather_dim = get_const_int(attrs.gather_dim)
+    assert gather_dim > 0, "gather_dim needs to be specified for dynamic gather_nd"
+    return [_gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(gather_dim))]

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1077,14 +1077,14 @@ def unique_shape_func(attrs, inputs, _):
 
 
 @script
-def _gather_nd_shape(data_shape, indices_shape, batch_dims, num_indices_per_tuple):
+def _gather_nd_shape(data_shape, indices_shape, batch_dims, index_rank):
     ndim = data_shape.shape[0]
     # using mdim = indices_shape[0] wouldn't work because a rank cannot
     # depend on a runtime shape dimension of indices tensor, even if the
     # dimension is always a known, fixed value. As a workaround, we assume that
     # the fixed gather dimension (the size of an indexing tuple) is recorded
     # in gather_nd op attributes.
-    mdim = num_indices_per_tuple
+    mdim = index_rank
     kdim = indices_shape.shape[0] - 1
     out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
     for i in range(1, kdim + 1):
@@ -1100,12 +1100,12 @@ def gather_nd_shape_func(attrs, inputs, _):
     Shape func for gather_nd operator.
     """
     batch_dims = get_const_int(attrs.batch_dims)
-    num_indices_per_tuple = get_const_int(attrs.num_indices_per_tuple)
+    index_rank = get_const_int(attrs.index_rank)
 
     assert (
-        num_indices_per_tuple > 0
-    ), "num_indices_per_tuple needs to be specified for dynamic gather_nd"
+        index_rank > 0
+    ), "index_rank needs to be specified for dynamic gather_nd"
 
     return [
-        _gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(num_indices_per_tuple))
+        _gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(index_rank))
     ]

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1088,7 +1088,7 @@ def _gather_nd_shape(data_shape, indices_shape, batch_dims, num_indices_per_tupl
     kdim = indices_shape.shape[0] - 1
     out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
     for i in range(1, kdim + 1):
-        out_shape[i-1] = indices_shape[i]
+        out_shape[i - 1] = indices_shape[i]
     for i in range(mdim + batch_dims, ndim):
         out_shape[kdim + i - (mdim + batch_dims)] = data_shape[i]
     return out_shape
@@ -1101,5 +1101,11 @@ def gather_nd_shape_func(attrs, inputs, _):
     """
     batch_dims = get_const_int(attrs.batch_dims)
     num_indices_per_tuple = get_const_int(attrs.num_indices_per_tuple)
-    assert num_indices_per_tuple > 0, "num_indices_per_tuple needs to be specified for dynamic gather_nd"
-    return [_gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(num_indices_per_tuple))]
+
+    assert (
+        num_indices_per_tuple > 0
+    ), "num_indices_per_tuple needs to be specified for dynamic gather_nd"
+
+    return [
+        _gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(num_indices_per_tuple))
+    ]

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1102,10 +1102,6 @@ def gather_nd_shape_func(attrs, inputs, _):
     batch_dims = get_const_int(attrs.batch_dims)
     index_rank = get_const_int(attrs.index_rank)
 
-    assert (
-        index_rank > 0
-    ), "index_rank needs to be specified for dynamic gather_nd"
+    assert index_rank > 0, "index_rank needs to be specified for dynamic gather_nd"
 
-    return [
-        _gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(index_rank))
-    ]
+    return [_gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(index_rank))]

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1083,7 +1083,7 @@ def _gather_nd_shape(data_shape, indices_shape, batch_dims, num_indices_per_tupl
     # depend on a runtime shape dimension of indices tensor, even if the
     # dimension is always a known, fixed value. As a workaround, we assume that
     # the fixed gather dimension (the size of an indexing tuple) is recorded
-    # in `gather_nd` op attribute.
+    # in gather_nd op attributes.
     mdim = num_indices_per_tuple
     kdim = indices_shape.shape[0] - 1
     out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
@@ -1097,7 +1097,7 @@ def _gather_nd_shape(data_shape, indices_shape, batch_dims, num_indices_per_tupl
 @_reg.register_shape_func("gather_nd", False)
 def gather_nd_shape_func(attrs, inputs, _):
     """
-    Shape func for ghater_nd operator.
+    Shape func for gather_nd operator.
     """
     batch_dims = get_const_int(attrs.batch_dims)
     num_indices_per_tuple = get_const_int(attrs.num_indices_per_tuple)

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -1079,14 +1079,12 @@ def unique_shape_func(attrs, inputs, _):
 @script
 def _gather_nd_shape(data_shape, indices_shape, batch_dims, gather_dim):
     ndim = data_shape.shape[0]
-    mdim = gather_dim
     # using mdim = indices_shape[0] wouldn't work because a rank cannot
     # depend on a runtime shape dimension of indices tensor, even if the
     # dimension is always a known, fixed value. As a workaround, we assume that
     # the fixed gather dimension (the size of an indexing tuple) is recorded
     # in `gather_nd` op attribute.
-    err_msg = "The recorded gather dimension and the actual dimension are different"
-    assert mdim == indices_shape[0], err_msg
+    mdim = gather_dim
     kdim = indices_shape.shape[0] - 1
     out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
     for i in range(1, kdim + 1):
@@ -1101,7 +1099,7 @@ def gather_nd_shape_func(attrs, inputs, _):
     """
     Shape func for ghater_nd operator.
     """
-    batch_dims = get_const_int(attrs.batch_dimss)
+    batch_dims = get_const_int(attrs.batch_dims)
     gather_dim = get_const_int(attrs.gather_dim)
     assert gather_dim > 0, "gather_dim needs to be specified for dynamic gather_nd"
     return [_gather_nd_shape(inputs[0], inputs[1], convert(batch_dims), convert(gather_dim))]

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1072,7 +1072,7 @@ def gather(data, axis, indices):
     return _make.gather(data, axis, indices)
 
 
-def gather_nd(data, indices, batch_dims=0, num_indices_per_tuple=-1):
+def gather_nd(data, indices, batch_dims=0, index_rank=-1):
     """Gather elements or slices from data and store to a tensor whose shape is
     defined by indices.
 
@@ -1087,7 +1087,7 @@ def gather_nd(data, indices, batch_dims=0, num_indices_per_tuple=-1):
     batch_dims : int
         The number of batch dimensions.
 
-    num_indices_per_tuple : int
+    index_rank : int
         The size of an indexing tuple, which is a fixed value and the same as indices.shape[0]
         Only needed when other dimensions of indices are dynamic.
 
@@ -1112,7 +1112,7 @@ def gather_nd(data, indices, batch_dims=0, num_indices_per_tuple=-1):
         indices = [[1, 0]]
         relay.gather_nd(data, indices, batch_dims=1) = [[2,3],[4,5]]
     """
-    return _make.gather_nd(data, indices, batch_dims, num_indices_per_tuple)
+    return _make.gather_nd(data, indices, batch_dims, index_rank)
 
 
 def sequence_mask(data, valid_length, mask_value=0, axis=0):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1072,7 +1072,7 @@ def gather(data, axis, indices):
     return _make.gather(data, axis, indices)
 
 
-def gather_nd(data, indices, batch_dims=0, index_rank=-1):
+def gather_nd(data, indices, batch_dims=0, index_rank=None):
     """Gather elements or slices from data and store to a tensor whose shape is
     defined by indices.
 
@@ -1087,7 +1087,7 @@ def gather_nd(data, indices, batch_dims=0, index_rank=-1):
     batch_dims : int
         The number of batch dimensions.
 
-    index_rank : int
+    index_rank : int, optional
         The size of an indexing tuple, which is a fixed value and the same as indices.shape[0]
         Only needed when other dimensions of indices are dynamic.
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1072,7 +1072,7 @@ def gather(data, axis, indices):
     return _make.gather(data, axis, indices)
 
 
-def gather_nd(data, indices, batch_dims=0, gather_dim=-1):
+def gather_nd(data, indices, batch_dims=0, num_indices_per_tuple=-1):
     """Gather elements or slices from data and store to a tensor whose shape is
     defined by indices.
 
@@ -1087,7 +1087,7 @@ def gather_nd(data, indices, batch_dims=0, gather_dim=-1):
     batch_dims : int
         The number of batch dimensions.
 
-    gather_dim : int
+    num_indices_per_tuple : int
         The size of an indexing tuple, which is a fixed value and the same as indices.shape[0]
         Only needed when other dimensions of indices are dynamic.
 
@@ -1112,7 +1112,7 @@ def gather_nd(data, indices, batch_dims=0, gather_dim=-1):
         indices = [[1, 0]]
         relay.gather_nd(data, indices, batch_dims=1) = [[2,3],[4,5]]
     """
-    return _make.gather_nd(data, indices, batch_dims, gather_dim)
+    return _make.gather_nd(data, indices, batch_dims, num_indices_per_tuple)
 
 
 def sequence_mask(data, valid_length, mask_value=0, axis=0):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1072,7 +1072,7 @@ def gather(data, axis, indices):
     return _make.gather(data, axis, indices)
 
 
-def gather_nd(data, indices, batch_dims=0):
+def gather_nd(data, indices, batch_dims=0, gather_dim=-1):
     """Gather elements or slices from data and store to a tensor whose shape is
     defined by indices.
 
@@ -1086,6 +1086,10 @@ def gather_nd(data, indices, batch_dims=0):
 
     batch_dims : int
         The number of batch dimensions.
+
+    gather_dim : int
+        The size of an indexing tuple, which is a fixed value and the same as indices.shape[0]
+        Only needed when other dimensions of indices are dynamic.
 
     Returns
     -------
@@ -1108,7 +1112,7 @@ def gather_nd(data, indices, batch_dims=0):
         indices = [[1, 0]]
         relay.gather_nd(data, indices, batch_dims=1) = [[2,3],[4,5]]
     """
-    return _make.gather_nd(data, indices, batch_dims)
+    return _make.gather_nd(data, indices, batch_dims, gather_dim)
 
 
 def sequence_mask(data, valid_length, mask_value=0, axis=0):

--- a/python/tvm/topi/scatter.py
+++ b/python/tvm/topi/scatter.py
@@ -16,7 +16,7 @@
 # under the License.
 # pylint: disable=invalid-name, too-many-arguments, too-many-nested-blocks
 """Scatter operator"""
-from ..tir import decl_buffer, ir_builder, AssertStmt, StringImm, Evaluate
+from ..tir import decl_buffer, ir_builder, AssertStmt, StringImm, Evaluate, expr
 from ..te import extern, hybrid
 
 
@@ -200,20 +200,22 @@ def scatter(data, indices, updates, axis=0):
 
 
 def _verify_scatter_nd_inputs(data, indices, updates):
-    # TODO(masahi): revisit
-    return
     mdim = int(indices.shape[0])
     assert mdim <= len(data.shape), (
         f"The first dimension of the indices ({mdim}) must be less than or equal to "
         f"the length of the shape of the output ({len(shape)})."
     )
     for i in range(len(indices.shape) - 1):
+        if isinstance(indices.shape[i + 1], expr.Var) or isinstance(updates.shape[i], expr.Var):
+            continue
         assert indices.shape[i + 1] == updates.shape[i], (
             f"Dimension of indices[{i+1}] ({indices.shape[i+1]}) must equal dimension of "
             f"updates[{i}] ({updates.shape[i]})."
         )
     for i in range(mdim, len(data.shape)):
         data_ind = i - mdim + len(indices.shape) - 1
+        if isinstance(updates.shape[data_ind], expr.Var) or isinstance(data.shape[i], expr.Var):
+            continue
         assert updates.shape[data_ind] == data.shape[i], (
             f"Dimension of updates[{data_ind}] ({updates.shape[data_ind]}) must equal dimension "
             f"of out_shape[{i}] ({data.shape[i]})."

--- a/python/tvm/topi/scatter.py
+++ b/python/tvm/topi/scatter.py
@@ -200,6 +200,8 @@ def scatter(data, indices, updates, axis=0):
 
 
 def _verify_scatter_nd_inputs(data, indices, updates):
+    # TODO(masahi): revisit
+    return
     mdim = int(indices.shape[0])
     assert mdim <= len(data.shape), (
         f"The first dimension of the indices ({mdim}) must be less than or equal to "

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3373,10 +3373,11 @@ Array<te::Tensor> GatherNDCompute(const Attrs& attrs, const Array<te::Tensor>& i
   return {topi::gather_nd(inputs[0], inputs[1], param->batch_dims)};
 }
 
-Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0) {
+Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0, int gather_dim = -1) {
   static const Op& op = Op::Get("gather_nd");
   auto attrs = make_object<GatherNDAttrs>();
   attrs->batch_dims = batch_dims;
+  attrs->gather_dim = gather_dim;
   return Call(op, {data, indices}, Attrs(attrs));
 }
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3373,11 +3373,12 @@ Array<te::Tensor> GatherNDCompute(const Attrs& attrs, const Array<te::Tensor>& i
   return {topi::gather_nd(inputs[0], inputs[1], param->batch_dims)};
 }
 
-Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0, int index_rank = -1) {
+Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0,
+                  Optional<Integer> index_rank = NullValue<Integer>()) {
   static const Op& op = Op::Get("gather_nd");
   auto attrs = make_object<GatherNDAttrs>();
   attrs->batch_dims = batch_dims;
-  attrs->index_rank = Integer(index_rank);
+  attrs->index_rank = index_rank;
   return Call(op, {data, indices}, Attrs(attrs));
 }
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3373,11 +3373,11 @@ Array<te::Tensor> GatherNDCompute(const Attrs& attrs, const Array<te::Tensor>& i
   return {topi::gather_nd(inputs[0], inputs[1], param->batch_dims)};
 }
 
-Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0, int gather_dim = -1) {
+Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0, int num_indices_per_tuple = -1) {
   static const Op& op = Op::Get("gather_nd");
   auto attrs = make_object<GatherNDAttrs>();
   attrs->batch_dims = batch_dims;
-  attrs->gather_dim = gather_dim;
+  attrs->num_indices_per_tuple = num_indices_per_tuple;
   return Call(op, {data, indices}, Attrs(attrs));
 }
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3373,11 +3373,11 @@ Array<te::Tensor> GatherNDCompute(const Attrs& attrs, const Array<te::Tensor>& i
   return {topi::gather_nd(inputs[0], inputs[1], param->batch_dims)};
 }
 
-Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0, int num_indices_per_tuple = -1) {
+Expr MakeGatherND(Expr data, Expr indices, int batch_dims = 0, int index_rank = -1) {
   static const Op& op = Op::Get("gather_nd");
   auto attrs = make_object<GatherNDAttrs>();
   attrs->batch_dims = batch_dims;
-  attrs->num_indices_per_tuple = num_indices_per_tuple;
+  attrs->index_rank = Integer(index_rank);
   return Call(op, {data, indices}, Attrs(attrs));
 }
 

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -1728,5 +1728,28 @@ def test_gather_nd():
     )
 
 
+@tvm.testing.uses_gpu
+def test_scatter_nd():
+    def verify_scatter_nd(data_np, indices_np, updates_np, ref_res):
+        indices_shape = (2, relay.Any())
+        updates_shape = (relay.Any(),)
+        data = relay.var("data", shape=data_np.shape, dtype=str(data_np.dtype))
+        indices = relay.var("indices", relay.TensorType(indices_shape, str(indices_np.dtype)))
+        updates = relay.var("updates", relay.TensorType(updates_shape, str(updates_np.dtype)))
+
+        out = relay.op.scatter_nd(data, indices, updates, "add")
+
+        mod = tvm.IRModule()
+        mod["main"] = relay.Function([data, indices, updates], out)
+
+        check_result([data_np, indices_np, updates_np], mod, [ref_res])
+
+    data = np.zeros((2, 2)).astype("int64")
+    indices = np.array([[1, 1, 0], [0, 1, 0]])
+    updates = np.array([2, 3, 0])
+    out = np.array([[0, 0], [2, 3]])
+    verify_scatter_nd(data, indices, updates, out)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/utils/ref_funcs.py
+++ b/tests/python/relay/utils/ref_funcs.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import numpy as np
+
+
+def gather_nd(data_np, indices_np, batch_dims=0):
+    """gather_nd implemented using numpy"""
+    data_shape = data_np.shape
+    indices_shape = indices_np.shape
+
+    def gather_nd_batch_dims_1_ref(data, indices):
+        res = []
+        for i, row in enumerate(data):
+            indices_tuple = tuple(indices[:, i])  # the indices for the i-th batch
+            res.append(row[indices_tuple])
+        # stack on the batch dim
+        return np.stack(res, 0)
+
+    if batch_dims > 1:
+        data_np_reshape = np.reshape(data_np, (-1,) + data_shape[batch_dims:])
+        indices_np_reshape = np.reshape(
+            indices_np, (indices_shape[0], -1) + indices_shape[(batch_dims + 1) :]
+        )
+
+        ref_res = gather_nd_batch_dims_1_ref(data_np_reshape, indices_np_reshape)
+
+        out_shape = indices_shape[1 : (batch_dims + 1)] + ref_res.shape[1:]
+        ref_res = np.reshape(ref_res, out_shape)
+    elif batch_dims == 1:
+        ref_res = gather_nd_batch_dims_1_ref(data_np, indices_np)
+    else:
+        ref_res = data_np[tuple(indices_np)]
+
+    return ref_res


### PR DESCRIPTION
Added shape func for `gather_nd` op to support dynamic indices size. `scatter_nd` also works with dynamic indices after dropping some assertions check on shapes. 

please review @mbrookhart @jwfromm @comaniac @kevinthesun 

One difficulty with `gather_nd` shape func was that the rank of the output tensor depends on the runtime shape of `indices` tensor. 
At the line https://github.com/apache/tvm/blob/55a4430f507d801b7441e60d00f06c8161aea30a/python/tvm/relay/op/_transform.py#L1089,
if instead I have something like
```
mdim = indices_shape[0]  # indices_shape is a runtime shape represented as te::Tensor 
out_shape = output_tensor((kdim + ndim - (mdim + batch_dims),), "int64")
```
different errors are raised depending on the context. For example, an error occurs in the shape func for `squeeze` that follows `gather_dim`, at https://github.com/apache/tvm/blob/55a4430f507d801b7441e60d00f06c8161aea30a/python/tvm/relay/op/_transform.py#L772. That line is a python range for loop that expects the rank of a shape tensor, `inputs[0].shape[0].value`, to be a compile time fixed integer. But if the rank of the `gather_dim` output tensor is calculated like above, the rank would not be a compile time integer (because it depends on the runtime value of shape).

My workaround for this problem is based on the fact that the first axis of `indices` tensor, whose runtime size is required to compute the output rank, is actually a compile time constant as asserted at https://github.com/apache/tvm/blob/55a4430f507d801b7441e60d00f06c8161aea30a/src/relay/op/tensor/transform.cc#L3347-L3348. So I simply record this fixed value in the attribute dict and look it up inside shape func. To do this, I had to add a new attribute to `gather_dim`, which is a bit ad hoc but necessary.