### PR TITLE
[lint] Fix C-style cast linting errors

### DIFF
--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -1222,7 +1222,7 @@ inline Tensor gather(const Tensor& data, int axis, const Tensor& indices,
         }
         Array<PrimExpr> real_indices;
         for (size_t i = 0; i < ndim_i; ++i) {
-          if (i == (size_t)axis) {
+          if (i == static_cast<size_t>(axis)) {
             real_indices.push_back(indices(indices_position));
           } else {
             real_indices.push_back(indices_position[i]);

--- a/src/relay/analysis/context_analysis.cc
+++ b/src/relay/analysis/context_analysis.cc
@@ -115,7 +115,7 @@ class DeviceDomain {
   struct Hash {
     size_t operator()(const DeviceDomainPtr& domain) const {
       if (domain->IsEmptyDomain()) {
-        return (size_t)(domain.get());
+        return static_cast<size_t>(reinterpret_cast<uintptr_t>(domain.get()));
       } else {
         size_t const h1(std::hash<int>()(static_cast<int>(domain->device_.device_type)));
         size_t const h2(std::hash<int>()(domain->device_.device_id));

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -3278,7 +3278,7 @@ bool GatherRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   std::vector<IndexExpr> oshape;
   oshape.reserve(ndim_data);
   for (size_t i = 0; i < ndim_data; ++i) {
-    if (i == (size_t)axis) {
+    if (i == static_cast<size_t>(axis)) {
       const int64_t* indice_shape_i = tir::as_const_int(indices->shape[i]);
       ICHECK_GE(*indice_shape_i, 1);
     } else {

--- a/src/runtime/crt/utvm_rpc_common/write_stream.cc
+++ b/src/runtime/crt/utvm_rpc_common/write_stream.cc
@@ -38,7 +38,7 @@ tvm_crt_error_t WriteStream::WriteAll(uint8_t* data, size_t data_size_bytes,
       return kTvmErrorWriteStreamShortWrite;
     } else if (to_return < 0) {
       return (tvm_crt_error_t)to_return;
-    } else if (to_return > 0 && ((size_t)to_return) > data_size_bytes) {
+    } else if (to_return > 0 && (static_cast<size_t>(to_return)) > data_size_bytes) {
       return kTvmErrorWriteStreamLongWrite;
     }
 


### PR DESCRIPTION
`cpplint` recently released version 1.5.5, which points 4 violations in our code base, all related to C-style casting.

cc @areusch @manupa-arm 