### PR TITLE
Remove clang-7 compiler pin for vulkan

### DIFF
--- a/tests/scripts/task_config_build_gpu_vulkan.sh
+++ b/tests/scripts/task_config_build_gpu_vulkan.sh
@@ -29,5 +29,4 @@ echo set\(USE_VULKAN ON\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_LIBBACKTRACE OFF\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER clang-7\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake


### PR DESCRIPTION
 * Breaks build with new 18.04 ci-gpu docker container.

```
[  1%] Building CXX object CMakeFiles/tvm_runtime_objs.dir/src/runtime/builtin_fp16.cc.o
/bin/sh: 1: clang-7: not found
make[2]: *** [CMakeFiles/tvm_runtime_objs.dir/src/runtime/builtin_fp16.cc.o] Error 127
CMakeFiles/tvm_runtime_objs.dir/build.make:62: recipe for target 'CMakeFiles/tvm_runtime_objs.dir/src/runtime/builtin_fp16.cc.o' failed
```

@tkonolige @tqchen 