### PR TITLE
[Fix] remove self-include in runtime/container.h

### DIFF
--- a/include/tvm/runtime/container.h
+++ b/include/tvm/runtime/container.h
@@ -29,7 +29,6 @@
 #endif
 
 #include <dmlc/logging.h>
-#include <tvm/runtime/container.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/memory.h>
 #include <tvm/runtime/object.h>


### PR DESCRIPTION
This is a small fix.
` runtime/container.h` includes itself, which results in cycle in include-mapping.
