### PR TITLE
[Vulkan] Add device capabilities to Target, use in codegen

### DIFF
--- a/cmake/modules/Vulkan.cmake
+++ b/cmake/modules/Vulkan.cmake
@@ -18,10 +18,6 @@
 # Be compatible with older version of CMake
 find_vulkan(${USE_VULKAN})
 
-# Extra Vulkan runtime options, exposed for advanced users.
-tvm_option(USE_VULKAN_VALIDATION "Enable Vulkan API validation layers" OFF
-  IF USE_VULKAN)
-
 if(USE_VULKAN)
   if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Cannot find Vulkan, USE_VULKAN=" ${USE_VULKAN})
@@ -34,9 +30,4 @@ if(USE_VULKAN)
   list(APPEND COMPILER_SRCS ${COMPILER_VULKAN_SRCS})
   list(APPEND TVM_LINKER_LIBS ${Vulkan_SPIRV_TOOLS_LIBRARY})
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${Vulkan_LIBRARY})
-
-  if(USE_VULKAN_VALIDATION)
-    message(STATUS "Build with Vulkan API validation")
-    add_definitions(-DUSE_VULKAN_VALIDATION=1)
-  endif()
 endif(USE_VULKAN)

--- a/cmake/modules/Vulkan.cmake
+++ b/cmake/modules/Vulkan.cmake
@@ -19,10 +19,6 @@
 find_vulkan(${USE_VULKAN})
 
 # Extra Vulkan runtime options, exposed for advanced users.
-tvm_option(USE_VULKAN_IMMEDIATE_MODE "Use Vulkan Immediate mode
-(KHR_push_descriptor extension)" ON IF USE_VULKAN)
-tvm_option(USE_VULKAN_DEDICATED_ALLOCATION "Use Vulkan dedicated allocations" ON
-IF USE_VULKAN)
 tvm_option(USE_VULKAN_VALIDATION "Enable Vulkan API validation layers" OFF
   IF USE_VULKAN)
 
@@ -39,14 +35,6 @@ if(USE_VULKAN)
   list(APPEND TVM_LINKER_LIBS ${Vulkan_SPIRV_TOOLS_LIBRARY})
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${Vulkan_LIBRARY})
 
-  if(USE_VULKAN_IMMEDIATE_MODE)
-    message(STATUS "Build with Vulkan immediate mode")
-    add_definitions(-DUSE_VULKAN_IMMEDIATE_MODE=1)
-  endif()
-  if(USE_VULKAN_DEDICATED_ALLOCATION)
-    message(STATUS "Build with Vulkan dedicated allocation")
-    add_definitions(-DUSE_VULKAN_DEDICATED_ALLOCATION=1)
-  endif()
   if(USE_VULKAN_VALIDATION)
     message(STATUS "Build with Vulkan API validation")
     add_definitions(-DUSE_VULKAN_VALIDATION=1)

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -376,7 +376,7 @@ class Device(ctypes.Structure):
             The version of the SDK
 
         """
-        return self._GetDeviceAttr(self.device_type, self.device_id, 12)
+        return self._GetDeviceAttr(self.device_type, self.device_id, 11)
 
     @property
     def driver_version(self):

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -730,20 +730,21 @@ VulkanDeviceAPI::VulkanDeviceAPI() {
     std::vector<VkLayerProperties> inst_layer_prop(inst_layer_prop_count);
     VULKAN_CALL(vkEnumerateInstanceLayerProperties(&inst_layer_prop_count, inst_layer_prop.data()));
     std::vector<const char*> l;
-    for (const auto& lp : inst_layer_prop) {
-      // TODO(tulloch): add CMAKE options.
-      (void)lp;  // suppress unused variable warning.
-#ifdef USE_VULKAN_VALIDATION
-      if (std::strcmp(lp.layerName, "VK_LAYER_LUNARG_standard_validation") == 0) {
-        l.push_back("VK_LAYER_LUNARG_standard_validation");
+
+    const char* enable = std::getenv("TVM_VULKAN_ENABLE_VALIDATION_LAYERS");
+    bool validation_enabled = enable && *enable;
+    if (validation_enabled) {
+      for (const auto& lp : inst_layer_prop) {
+        if (std::strcmp(lp.layerName, "VK_LAYER_LUNARG_standard_validation") == 0) {
+          l.push_back("VK_LAYER_LUNARG_standard_validation");
+        }
+        if (std::strcmp(lp.layerName, "VK_LAYER_LUNARG_parameter_validation") == 0) {
+          l.push_back("VK_LAYER_LUNARG_parameter_validation");
+        }
+        if (std::strcmp(lp.layerName, "VK_LAYER_KHRONOS_validation") == 0) {
+          l.push_back("VK_LAYER_KHRONOS_validation");
+        }
       }
-      if (std::strcmp(lp.layerName, "VK_LAYER_LUNARG_parameter_validation") == 0) {
-        l.push_back("VK_LAYER_LUNARG_parameter_validation");
-      }
-      if (std::strcmp(lp.layerName, "VK_LAYER_KHRONOS_validation") == 0) {
-        l.push_back("VK_LAYER_KHRONOS_validation");
-      }
-#endif
     }
     return l;
   }();

--- a/src/runtime/vulkan/vulkan.cc
+++ b/src/runtime/vulkan/vulkan.cc
@@ -432,6 +432,8 @@ class VulkanDeviceAPI final : public DeviceAPI {
     return context_[device_id];
   }
 
+  Target GenerateTarget(size_t device_id) const { return context(device_id).target; }
+
  private:
   std::vector<const char*> find_enabled_extensions(
       const std::vector<VkExtensionProperties>& ext_prop,
@@ -848,7 +850,6 @@ VulkanDeviceAPI::VulkanDeviceAPI() {
     }();
 
     ctx.target = GetDeviceDescription(instance_, phy_dev, instance_extensions, device_extensions);
-    std::cout << "Target: " << ctx.target << std::endl;
 
     {
       // Enable all features we may use that a device supports.
@@ -1578,6 +1579,10 @@ TVM_REGISTER_GLOBAL("runtime.module.loadbinary_vulkan").set_body_typed(VulkanMod
 TVM_REGISTER_GLOBAL("device_api.vulkan").set_body([](TVMArgs args, TVMRetValue* rv) {
   DeviceAPI* ptr = VulkanDeviceAPI::Global();
   *rv = static_cast<void*>(ptr);
+});
+
+TVM_REGISTER_GLOBAL("device_api.vulkan.generate_target").set_body_typed([](int device_id) {
+  return VulkanDeviceAPI::Global()->GenerateTarget(device_id);
 });
 
 }  // namespace vulkan

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -24,6 +24,7 @@
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/packed_func.h>
+#include <tvm/target/target.h>
 #include <vulkan/vulkan.h>
 
 #include <memory>
@@ -130,8 +131,11 @@ struct VulkanGetBufferMemoryRequirements2Functions {
 struct VulkanContext {
   // physical device
   VkPhysicalDevice phy_device{nullptr};
+
   // Phyiscal device property
   VkPhysicalDeviceProperties phy_device_prop;
+  // Target that best represents this physical device
+  Target target;
   // Memory type index for staging.
   uint32_t staging_mtype_index{0};
   // whether staging is coherent

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -87,10 +87,10 @@ inline const char* VKGetErrorString(VkResult error) {
  * \brief Protected Vulkan call
  * \param func Expression to call.
  */
-#define VULKAN_CHECK_ERROR(__e)                                      \
-  {                                                                  \
-    ICHECK(__e == VK_SUCCESS) << "Vulan Error, code=" << __e << ": " \
-                              << vulkan::VKGetErrorString(__e);      \
+#define VULKAN_CHECK_ERROR(__e)                                       \
+  {                                                                   \
+    ICHECK(__e == VK_SUCCESS) << "Vulkan Error, code=" << __e << ": " \
+                              << vulkan::VKGetErrorString(__e);       \
   }
 
 #define VULKAN_CALL(func)    \
@@ -100,6 +100,18 @@ inline const char* VKGetErrorString(VkResult error) {
   }
 
 struct VulkanDescriptorTemplateKHRFunctions {
+  explicit VulkanDescriptorTemplateKHRFunctions(VkDevice device) {
+    vkCreateDescriptorUpdateTemplateKHR = (PFN_vkCreateDescriptorUpdateTemplateKHR)ICHECK_NOTNULL(
+        vkGetDeviceProcAddr(device, "vkCreateDescriptorUpdateTemplateKHR"));
+    vkDestroyDescriptorUpdateTemplateKHR = (PFN_vkDestroyDescriptorUpdateTemplateKHR)ICHECK_NOTNULL(
+        vkGetDeviceProcAddr(device, "vkDestroyDescriptorUpdateTemplateKHR"));
+    vkUpdateDescriptorSetWithTemplateKHR = (PFN_vkUpdateDescriptorSetWithTemplateKHR)ICHECK_NOTNULL(
+        vkGetDeviceProcAddr(device, "vkUpdateDescriptorSetWithTemplateKHR"));
+    vkCmdPushDescriptorSetWithTemplateKHR =
+        (PFN_vkCmdPushDescriptorSetWithTemplateKHR)ICHECK_NOTNULL(
+            vkGetDeviceProcAddr(device, "vkCmdPushDescriptorSetWithTemplateKHR"));
+  }
+
   PFN_vkCreateDescriptorUpdateTemplateKHR vkCreateDescriptorUpdateTemplateKHR{nullptr};
   PFN_vkDestroyDescriptorUpdateTemplateKHR vkDestroyDescriptorUpdateTemplateKHR{nullptr};
   PFN_vkUpdateDescriptorSetWithTemplateKHR vkUpdateDescriptorSetWithTemplateKHR{nullptr};
@@ -107,6 +119,11 @@ struct VulkanDescriptorTemplateKHRFunctions {
 };
 
 struct VulkanGetBufferMemoryRequirements2Functions {
+  explicit VulkanGetBufferMemoryRequirements2Functions(VkDevice device) {
+    vkGetBufferMemoryRequirements2KHR = (PFN_vkGetBufferMemoryRequirements2KHR)ICHECK_NOTNULL(
+        vkGetDeviceProcAddr(device, "vkGetBufferMemoryRequirements2KHR"));
+  }
+
   PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR{nullptr};
 };
 

--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -128,7 +128,7 @@ struct VulkanGetBufferMemoryRequirements2Functions {
 };
 
 struct VulkanContext {
-  // phyiscal device
+  // physical device
   VkPhysicalDevice phy_device{nullptr};
   // Phyiscal device property
   VkPhysicalDeviceProperties phy_device_prop;
@@ -153,7 +153,7 @@ struct VulkanContext {
   // Queue family index.
   VkQueueFamilyProperties queue_prop;
 
-  bool UseImmediate() const { return descriptor_template_khr_functions.get() != nullptr; }
+  bool UseImmediate() const { return descriptor_template_khr_functions != nullptr; }
 };
 
 }  // namespace vulkan

--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -35,17 +35,45 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   ICHECK_EQ(target->kind->device_type, kDLVulkan)
       << "SPIRVSupport can only be checked for vulkan device type";
 
-  // Currently, this codifies the assumptions that were present and
-  // implicit in previous implementations.  In the future, this will
-  // pull information from the specified `Target`.
-
-  supports_storage_buffer_storage_class = (SPV_VERSION >= 0x10300);
-  supports_storage_buffer_8bit_access = true;
-  supports_storage_buffer_16bit_access = true;
-  supports_float16 = true;
-  supports_int8 = true;
-  supports_int16 = true;
-  supports_int64 = true;
+  if (target->GetAttr<Integer>("supported_subgroup_operations")) {
+    supported_subgroup_operations =
+        target->GetAttr<Integer>("supported_subgroup_operations").value();
+  }
+  if (target->GetAttr<Integer>("max_push_constants_size")) {
+    max_push_constants_size = target->GetAttr<Integer>("max_push_constants_size").value();
+  }
+  if (target->GetAttr<Integer>("max_uniform_buffer_range")) {
+    max_uniform_buffer_range = target->GetAttr<Integer>("max_uniform_buffer_range").value();
+  }
+  if (target->GetAttr<Integer>("max_storage_buffer_range")) {
+    max_storage_buffer_range = target->GetAttr<Integer>("max_storage_buffer_range").value();
+  }
+  if (target->GetAttr<Integer>("max_per_stage_descriptor_storage_buffer")) {
+    max_per_stage_descriptor_storage_buffers =
+        target->GetAttr<Integer>("max_per_stage_descriptor_storage_buffer").value();
+  }
+  if (target->GetAttr<Bool>("supports_storage_buffer_storage_class")) {
+    supports_storage_buffer_storage_class =
+        target->GetAttr<Bool>("supports_storage_buffer_storage_class").value();
+  }
+  if (target->GetAttr<Bool>("supports_8bit_buffer")) {
+    supports_storage_buffer_8bit_access = target->GetAttr<Bool>("supports_8bit_buffer").value();
+  }
+  if (target->GetAttr<Bool>("supports_16bit_buffer")) {
+    supports_storage_buffer_16bit_access = target->GetAttr<Bool>("supports_16bit_buffer").value();
+  }
+  if (target->GetAttr<Bool>("supports_float16")) {
+    supports_float16 = target->GetAttr<Bool>("supports_float16").value();
+  }
+  if (target->GetAttr<Bool>("supports_int8")) {
+    supports_int8 = target->GetAttr<Bool>("supports_int8").value();
+  }
+  if (target->GetAttr<Bool>("supports_int16")) {
+    supports_int16 = target->GetAttr<Bool>("supports_int16").value();
+  }
+  if (target->GetAttr<Bool>("supports_int64")) {
+    supports_int64 = target->GetAttr<Bool>("supports_int64").value();
+  }
 }
 
 }  // namespace codegen

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -284,6 +284,8 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Bool>("supports_8bit_buffer")
     .add_attr_option<Bool>("supports_16bit_buffer")
     .add_attr_option<Bool>("supports_storage_buffer_storage_class")
+    .add_attr_option<Bool>("supports_push_descriptor")
+    .add_attr_option<Bool>("supports_dedicated_allocation")
     .add_attr_option<Integer>("supported_subgroup_operations")
     // Physical device limits
     .add_attr_option<Integer>("max_num_threads", Integer(256))

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -273,8 +273,35 @@ TVM_REGISTER_TARGET_KIND("metal", kDLMetal)
 
 TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Bool>("system-lib")
+    // Feature support
+    .add_attr_option<Bool>("supports_float16")
+    .add_attr_option<Bool>("supports_float32", Bool(true))
+    .add_attr_option<Bool>("supports_float64")
+    .add_attr_option<Bool>("supports_int8")
+    .add_attr_option<Bool>("supports_int16")
+    .add_attr_option<Bool>("supports_int32", Bool(true))
+    .add_attr_option<Bool>("supports_int64")
+    .add_attr_option<Bool>("supports_8bit_buffer")
+    .add_attr_option<Bool>("supports_16bit_buffer")
+    .add_attr_option<Bool>("supports_storage_buffer_storage_class")
+    .add_attr_option<Integer>("supported_subgroup_operations")
+    // Physical device limits
     .add_attr_option<Integer>("max_num_threads", Integer(256))
     .add_attr_option<Integer>("thread_warp_size", Integer(1))
+    .add_attr_option<Integer>("max_block_size_x")
+    .add_attr_option<Integer>("max_block_size_y")
+    .add_attr_option<Integer>("max_block_size_z")
+    .add_attr_option<Integer>("max_push_constants_size")
+    .add_attr_option<Integer>("max_uniform_buffer_range")
+    .add_attr_option<Integer>("max_storage_buffer_range")
+    .add_attr_option<Integer>("max_per_stage_descriptor_storage_buffer")
+    .add_attr_option<Integer>("max_shared_memory_per_block")
+    // Other device properties
+    .add_attr_option<String>("device_name")
+    .add_attr_option<Integer>("driver_version")
+    .add_attr_option<Integer>("vulkan_api_version")
+    .add_attr_option<Integer>("max_spirv_version")
+    // Tags
     .set_default_keys({"vulkan", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("webgpu", kDLWebGPU)


### PR DESCRIPTION
The end-to-end goal of this PR is to be able to specify all vulkan capabilities in the Target, initialize vulkan such that we can legally use those capabilities, then pass the device description to the SPIRVSupport struct.  This is broken down into the following subchanges, each of which is implemented in a separate commit for readability.

- Enable instance/device extensions.  Vulkan requires that extensions be explicitly enabled if used.  Has explicitly list out which extensions are required (currently none) and which are optional.

- Extract device information using `vkGetPhysicalDeviceProperties` and `vkGetPhysicalDeviceFeatures`, determine which Vulkan capabilities are supported, pack into a Target.

- Query instance-supported apiVersion before creating instance. Vulkan requires no functions beyond the specified apiVersion be used.

- Query support for dedicated allocation and push descriptors along with the rest of the device support.  Move the options to disable their use from compile-time variables to environment variables `TVM_VULKAN_DISABLE_PUSH_DESCRIPTOR` and `TVM_VULKAN_DISABLE_DEDICATED_ALLOCATION`.

- Move option for vulkan validation layers to environment variable, to enable faster use as a debug tool.  If `TVM_VULKAN_ENABLE_VALIDATION_LAYERS` is a non-empty string, validation layers will be enabled.

- Explicitly enable vulkan features in device creation.  Vulkan requires that features be explicitly enabled before use.  For each feature that the device supports and a shader might use, declare it in the call to `vkCreateDevice`.

- Avoid repeated queries for device attributes, implementing `VulkanDeviceAPI::GetAttr` based on the per-device values stored in the Target.  This pulls all logic for querying device parameters is in a single location.

- Implement "from_device" flag for the vulkan target.  With the number of device capabilities that may or may not be supported by a vulkan driver, it can be tedious to input them.  Specifying "-from_device=0" now indicates that any unspecified values should be read from the device.

- Read vulkan device capabilities/limits from Target.  Previously, the codegen assumed that all device features were present.  Now, the codegen reads device capabilities from the Target, and throws an error if codegen would require use of an unsupported feature.
