### PR TITLE
[TE/TIR] Fix create_prim_func to properly handle rank 0 tensors.

### DIFF
--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -101,6 +101,12 @@ BlockRealize GenerateBlockFromTensor(const te::ComputeOp& compute_op, const te::
   f_push_block_vars(compute_op->axis);
   f_push_block_vars(compute_op->reduce_axis);
 
+  // If we have a rank 0 tensor then we manifest it as a rank 1 buffer with a single element.
+  if (compute_op->axis.size() == 0) {
+    iter_vars.push_back(IterVar(Range::FromMinExtent(0, 1), Var(), IterVarType::kDataPar));
+    bindings.push_back(Var());
+  }
+
   // Step 2. Declare buffer and update op2buffers
   Buffer buffer = decl_buffer(tensor->shape, tensor->dtype, tensor->GetNameHint());
   info->tensor2buffers[tensor] = buffer;


### PR DESCRIPTION
We handle lowering rank 0 tensors by lowering them to rank 1 buffers with a single element.

@junrushao1994 @Hzfengsy @vinx13 @MasterJH5574 @tqchen 
