### PR TITLE
Fix typo in a comment

### DIFF
--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -148,7 +148,7 @@ class AOTExecutorCodegen : public ExprVisitor {
 
   /*!
    * \brief Utility function to return a parameter associated with an expression
-   * \param expr Relay Expression assicated with the parameter
+   * \param expr Relay Expression associated with the parameter
    * \return Variable that represents the DLTensor associated with the parameters
    */
   tir::Var PackParam(Expr expr) {


### PR DESCRIPTION
Fix typo in a comment about AOT executor.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

