### PR TITLE
[CUBLAS] Remove deprecated CUBLAS_TENSOR_OP_MATH flag

### DIFF
--- a/src/runtime/contrib/cublas/cublas.cc
+++ b/src/runtime/contrib/cublas/cublas.cc
@@ -39,7 +39,7 @@ inline void CUBLASTryEnableTensorCore(cublasHandle_t hdl) {
   // TensorCores are only supported in cublas 9.0 or higher
   int version;
   CHECK_CUBLAS_ERROR(cublasGetVersion(hdl, &version));
-  if (version >= 9000) CHECK_CUBLAS_ERROR(cublasSetMathMode(hdl, CUBLAS_TENSOR_OP_MATH));
+  if (version >= 9000) CHECK_CUBLAS_ERROR(cublasSetMathMode(hdl, CUBLAS_DEFAULT_MATH));
 }
 
 struct CublasHgemmOp {


### PR DESCRIPTION
This flag is causes CUBLAS to use tensor cores on all operations. With f32 or f64 operations, this leads to loss of accuracy.

#7995

Supersedes #8108.
@areusch @comaniac 