### PR TITLE
Fix compile time and runtime errors of EdgeTPURuntime

### DIFF
--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.h
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.h
@@ -44,6 +44,14 @@ namespace runtime {
 class EdgeTPURuntime : public TFLiteRuntime {
  public:
   /*!
+   * \brief Destructor of EdgeTPURuntime.
+   * 
+   * NOTE: tflite::Interpreter member should be destruct before the EdgeTpuContext member destruction.
+   * If the order is reverse, occurs SEGV in the destructor of tflite::Interpreter.
+   */
+  ~EdgeTPURuntime() { interpreter_.reset(); }
+
+  /*!
    * \return The type key of the executor.
    */
   const char* type_key() const final { return "EdgeTPURuntime"; }

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.h
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.h
@@ -30,9 +30,8 @@
 #include <memory>
 #include <string>
 
-#include "edgetpu.h"
-
 #include "../tflite/tflite_runtime.h"
+#include "edgetpu.h"
 
 namespace tvm {
 namespace runtime {
@@ -47,9 +46,9 @@ class EdgeTPURuntime : public TFLiteRuntime {
  public:
   /*!
    * \brief Destructor of EdgeTPURuntime.
-   * 
-   * NOTE: tflite::Interpreter member should be destruct before the EdgeTpuContext member destruction.
-   * If the order is reverse, occurs SEGV in the destructor of tflite::Interpreter.
+   *
+   * NOTE: tflite::Interpreter member should be destruct before the EdgeTpuContext member
+   * destruction. If the order is reverse, occurs SEGV in the destructor of tflite::Interpreter.
    */
   ~EdgeTPURuntime() { interpreter_.reset(); }
 

--- a/src/runtime/contrib/edgetpu/edgetpu_runtime.h
+++ b/src/runtime/contrib/edgetpu/edgetpu_runtime.h
@@ -30,6 +30,8 @@
 #include <memory>
 #include <string>
 
+#include "edgetpu.h"
+
 #include "../tflite/tflite_runtime.h"
 
 namespace tvm {


### PR DESCRIPTION
Fixed the errors of EdgeTPURuntime

* Fixed compile error by the omission include "edgetpu.h"
* Fixed SEGV in EdgeTPURuntime destructor.
  * It occurs if with destruction by the order EdgeTPUContext -> tflite::Interpreter. It maybe due to implementation of iflite::Interpreter. So, fixed to destruct by the reverse order by using EdgeTPUContext destructor.
