### PR TITLE
memory planning: add offset to planning output and respect it in graph executor

### DIFF
--- a/include/tvm/runtime/crt/graph_executor.h
+++ b/include/tvm/runtime/crt/graph_executor.h
@@ -47,6 +47,7 @@ typedef struct TVMGraphExecutorGraphAttr {
   uint32_t storage_num_not_alloctaed;
   uint32_t* storage_id;
   uint32_t* device_index;
+  uint32_t* offset;
   char* dltype;  // "int8", "int16", "float32"
   uint32_t dltype_count;
   int64_t* shape;

--- a/src/relay/backend/graph_plan_memory.cc
+++ b/src/relay/backend/graph_plan_memory.cc
@@ -200,8 +200,8 @@ class StorageAllocator : public StorageAllocaBaseVisitor {
     prototype_ = StorageAllocaInit(&arena_).GetInitTokenMap(func);
     this->Run(func);
 
-    // The value of smap contains two integer arrays where the first array
-    // contains the planned storage ids and the second holds the device types.
+    // The value of smap contains four integer arrays:
+    // The planned storage ids, device types, storage sizes and offsets within the storages.
     Map<Expr, Array<IntegerArray> > smap;
     int num_annotated_nodes = 0;
     int num_nodes = 0;
@@ -210,6 +210,7 @@ class StorageAllocator : public StorageAllocaBaseVisitor {
       std::vector<Integer> storage_ids;
       std::vector<Integer> device_types;
       std::vector<Integer> sid_sizes_byte;
+      std::vector<Integer> offsets;
       for (StorageToken* tok : kv.second) {
         if (tok->device_type) {
           num_annotated_nodes++;
@@ -218,9 +219,10 @@ class StorageAllocator : public StorageAllocaBaseVisitor {
         storage_ids.push_back(tok->storage_id);
         device_types.push_back(tok->device_type);
         sid_sizes_byte.push_back(GetMemorySize(tok));
+        offsets.push_back(0);  // Not yet implemented.
       }
       smap.Set(GetRef<Expr>(kv.first),
-               Array<IntegerArray>({storage_ids, device_types, sid_sizes_byte}));
+               Array<IntegerArray>({storage_ids, device_types, sid_sizes_byte, offsets}));
     }
     // Either all or none of the nodes should be annotated.
     if (num_annotated_nodes != 0 && num_annotated_nodes != num_nodes) {

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -276,6 +276,7 @@ class TVM_DLL GraphExecutor : public ModuleNode {
     size_t storage_num_not_alloctaed{0};
     std::vector<int> storage_id;
     std::vector<int> device_index;
+    std::vector<int> offset;
     std::vector<std::string> dltype;
     std::vector<std::vector<int64_t>> shape;
     // The graph attribute fields.
@@ -318,6 +319,14 @@ class TVM_DLL GraphExecutor : public ModuleNode {
           ICHECK_EQ(type, "list_int");
           ICHECK(reader->NextArrayItem());
           reader->Read(&device_index);
+          ICHECK(!reader->NextArrayItem());
+        } else if (key == "offset") {
+          reader->BeginArray();
+          ICHECK(reader->NextArrayItem());
+          reader->Read(&type);
+          ICHECK_EQ(type, "list_int");
+          ICHECK(reader->NextArrayItem());
+          reader->Read(&offset);
           ICHECK(!reader->NextArrayItem());
         } else {
           reader->BeginArray();

--- a/tests/python/relay/test_backend_graph_executor.py
+++ b/tests/python/relay/test_backend_graph_executor.py
@@ -134,11 +134,13 @@ def test_plan_memory():
     storage_ids = set()
     device_types = set()
     storage_sizes = {}
+    offsets = {}
     for k, v in smap.items():
-        assert len(v) == 3
+        assert len(v) == 4
         for x in v[0]:
             storage_ids.add(x.value)
             storage_sizes[x.value] = v[2]
+            offsets[x.value] = v[3]
         for x in v[1]:
             device_types.add(x.value)
 
@@ -148,6 +150,7 @@ def test_plan_memory():
     assert len(storage_ids) == 4
     assert len(device_types) == 1
     assert len(storage_sizes) == 4
+    assert len(offsets) == 4
 
     # Check the specific size of each sid
     assert (
@@ -156,6 +159,10 @@ def test_plan_memory():
         and storage_sizes[2][0] == 4
         and storage_sizes[3][0] == 40
     )
+
+    # Currently, the offsets are fixed to zero.
+    for offset in offsets.values():
+        assert offset == 0
 
 
 def test_reshape_nop():

--- a/tests/python/relay/test_pass_annotation.py
+++ b/tests/python/relay/test_pass_annotation.py
@@ -265,16 +265,20 @@ def test_conv_network():
         smap = relay.backend._backend.GraphPlanMemory(func)
         storage_ids = []
         device_types = []
+        offsets = []
         for _, storage_dev_type in smap.items():
-            assert len(storage_dev_type) == 3
+            assert len(storage_dev_type) == 4
             for sid in storage_dev_type[0]:
                 storage_ids.append(sid.value)
             for did in storage_dev_type[1]:
                 device_types.append(did.value)
+            for offset in storage_dev_type[3]:
+                offsets.append(offset)
         assert len(storage_ids) == 10
         assert len(set(storage_ids)) == 8
         assert len(set(device_types)) == 2
         assert set(device_types) == {1, 2}
+        assert len(offsets) = 10
 
     def test_manual_annotation():
         annotated_func = annotated()


### PR DESCRIPTION
This adds the possibility to specify an offset for the results of memory planning, such that buffers can be placed at other positions than the base address. This way we can also partially overlap buffers to enable the most optimal buffer placements.

More details in this discussion: https://discuss.tvm.apache.org/t/discussion-alignment-memory-planning/9730