### PR TITLE
[Cuda][Codegen] Check for cuda include dir in /usr/include.

### DIFF
--- a/src/target/opt/build_cuda_on.cc
+++ b/src/target/opt/build_cuda_on.cc
@@ -67,6 +67,10 @@ std::string FindCUDAIncludePath() {
   if (stat(cuda_include_path.c_str(), &st) == 0) {
     return cuda_include_path;
   }
+
+  if (stat("/usr/include/cuda.h", &st) == 0) {
+    return "/usr/include";
+  }
 #endif
   LOG(FATAL) << "Cannot find cuda include path."
              << "CUDA_PATH is not set or CUDA is not installed in the default installation path."


### PR DESCRIPTION
Currently, on linux platforms, only checks for cuda install directory in /usr/local/cuda/include.  The `nvidia-cuda-dev` package of Ubuntu 20.04 installs at /usr/include, so it would be good to check that location as well.
