### PR TITLE
[Codegen][CUDA] Fix make_int4x cuda codegen vectorize

### DIFF
--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -212,13 +212,18 @@ std::string CodeGenC::GetBufferRef(DataType t, const VarNode* buffer, PrimExpr i
       PrintType(t.element_of(), os);
       os << "*)";
     }
-    os << vid << " + (";
-    PrintExpr(index, os);
-    os << ")";
     if (t.bits() == 4 || (t.bits() == 1 && t.is_int())) {
-      os << " / " << (32 / t.bits());
+      os << vid << ") + (";
+      PrintExpr(index, os);
+      os << ")";
+      os << " / " << t.lanes();
+      os << ")[0]";
+    } else {
+      os << vid << " + (";
+      PrintExpr(index, os);
+      os << ")";
+      os << "))[0]";
     }
-    os << "))[0]";
   }
   return os.str();
 }

--- a/tests/python/unittest/test_target_codegen_cuda.py
+++ b/tests/python/unittest/test_target_codegen_cuda.py
@@ -215,14 +215,21 @@ def test_cuda_make_int4():
         y, x = s[A].op.axis
         s[A].vectorize(x)
         s[A].bind(y, bx)
-        fun = tvm.build(s, [A], "cuda", name="make_int4x8")
+        kernel_name = "make_int4x" + str(lanes)
+        fun = tvm.build(s, [A], "cuda", name=kernel_name)
         np_a = np.full((n, lanes), value, dtype="int8")
         a = tvm.nd.empty((n, lanes), dtype, dev)
         fun(a)
         np.testing.assert_equal(a.numpy(), np_a)
 
+    check_cuda(64, 1, 4)
+    check_cuda(64, 7, 4)
     check_cuda(64, 1, 8)
     check_cuda(64, 7, 8)
+    check_cuda(64, 1, 16)
+    check_cuda(64, 7, 16)
+    check_cuda(64, 1, 32)
+    check_cuda(64, 7, 32)
 
 
 @tvm.testing.requires_gpu


### PR DESCRIPTION
Added support for int4x32 int4x16 int4x4 in BroadcastNode.

In the int4x4 testcase, the IR is:
```
primfn(compute_1: handle) -> ()
  attr = {"global_symbol": "main", "tir.noalias": True}
  buffers = {compute: Buffer(compute_2: Pointer(int4), int4, [64, 4], [])}
  buffer_map = {compute_1: compute} {
  attr [IterVar(blockIdx.x: int32, (nullptr), "ThreadIndex", "blockIdx.x")] "thread_extent" = 64;
  compute_2[ramp((blockIdx.x*4), 1, 4)] = broadcast(1i4, 4)
}
```
Before the fix in codegen_c.cc, the codegen cuda is:
```
extern "C" __global__ void make_int4x4_kernel0(int* __restrict__ compute) {
  ((int16_t*)(compute + ((((int)blockIdx.x) * 4)) / 8))[0] = (int16_t)4369;
}
```
For int16_t, this index `(((int)blockIdx.x) * 4)) / 8` is a bug. 
After the fix in codegen_c.cc, the codegen cuda is:
```
extern "C" __global__ void make_int4x4_kernel0(int* __restrict__ compute) {
  ((int16_t*)(compute) + ((((int)blockIdx.x) * 4)) / 4)[0] = (int16_t)4369;
}
```
Could you please help review this fix? @vinx13 @Hzfengsy 