### PR TITLE
[AutoTVM][AutoScheduler] Add workaround to alter op layout bug in task extraction.

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -68,7 +68,6 @@ def call_all_topi_funcs(mod, params, target):
             # TODO(jwfromm) Remove this once AlterOpLayout bug that mutates
             # source module is fixed. Until then, create a clone.
             mod_clone = deepcopy(mod)
-            params_clone = deepcopy(params)
             opt_mod, _ = relay.optimize(mod_clone, target, params)
             grc = graph_executor_codegen.GraphExecutorCodegen(None, target)
             grc.codegen(opt_mod["main"])
@@ -78,10 +77,9 @@ def call_all_topi_funcs(mod, params, target):
                 "Fallback to VMCompiler."
             )
             mod_clone = deepcopy(mod)
-            params_clone = deepcopy(params)
             compiler = relay.vm.VMCompiler()
             if params:
-                compiler.set_params(params_clone)
+                compiler.set_params(params)
             mod_clone = (
                 tvm.IRModule.from_expr(mod_clone)
                 if isinstance(mod_clone, relay.Function)

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -22,6 +22,7 @@ Decorator and utilities for the integration with TOPI and Relay
 """
 import threading
 import logging
+from copy import deepcopy
 
 import tvm
 from tvm.autotvm.task.dispatcher import DispatchContext, FallbackContext
@@ -53,7 +54,11 @@ def _lower(mod, target, params):
     # If failed to compile, then fallback to use VM compiler.
     # TODO: Currently VM compiler is likely to stack overflow for large models.
     try:
-        opt_mod, _ = relay.optimize(mod, target, params)
+        # TODO(jwfromm) Remove this once AlterOpLayout bug that mutates
+        # source module is fixed. Until then, create a clone.
+        mod_clone = deepcopy(mod)
+        params_clone = deepcopy(params)
+        opt_mod, _ = relay.optimize(mod_clone, target, params_clone)
         grc = graph_executor_codegen.GraphExecutorCodegen(None, target)
         grc.codegen(opt_mod["main"])
     except tvm.TVMError as e:
@@ -61,10 +66,12 @@ def _lower(mod, target, params):
             "Get errors with GraphExecutorCodegen for task extraction. "
             "Fallback to VMCompiler. Error details:\n%s" % str(e)
         )
+        mod_clone = deepcopy(mod)
+        params_clone = deepcopy(params)
         compiler = relay.vm.VMCompiler()
         if params:
-            compiler.set_params(params)
-        compiler.lower(mod, target=target)
+            compiler.set_params(params_clone)
+        compiler.lower(mod_clone, target=target)
 
 
 def extract_from_program(mod, params, target, target_host=None, ops=None):

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -57,8 +57,7 @@ def _lower(mod, target, params):
         # TODO(jwfromm) Remove this once AlterOpLayout bug that mutates
         # source module is fixed. Until then, create a clone.
         mod_clone = deepcopy(mod)
-        params_clone = deepcopy(params)
-        opt_mod, _ = relay.optimize(mod_clone, target, params_clone)
+        opt_mod, _ = relay.optimize(mod_clone, target, params)
         grc = graph_executor_codegen.GraphExecutorCodegen(None, target)
         grc.codegen(opt_mod["main"])
     except tvm.TVMError as e:
@@ -67,10 +66,9 @@ def _lower(mod, target, params):
             "Fallback to VMCompiler. Error details:\n%s" % str(e)
         )
         mod_clone = deepcopy(mod)
-        params_clone = deepcopy(params)
         compiler = relay.vm.VMCompiler()
         if params:
-            compiler.set_params(params_clone)
+            compiler.set_params(params)
         compiler.lower(mod_clone, target=target)
 
 


### PR DESCRIPTION
There's been a long-known issue where sometimes during alter_op_layout, the source IRModule is mutated. Sometimes this can cause errors during task extraction. One example model where the issue pops up is [yolov3-tiny](https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/tiny-yolov3). An easy workaround to avoid this bug is making a copy of the input module before applying optimization passes. This PR adds a copy step to both autotvm and auto_scheduler. I'm not sure what tests to add since the bug is extremely difficult to pin down. It does trigger with the above linked yolo model though.
