### PR TITLE
[VM, Profiling] Add function attribute for shape func for profiling

### DIFF
--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -490,6 +490,9 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
       argument_registers.push_back(reg->second);
     }
 
+    // Extract functions attrs
+    op_attrs[op_index] = func->attrs->dict;
+
     Emit(Instruction::InvokePacked(op_index, argument_registers.size(), outputs.size(),
                                    argument_registers));
   }

--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -105,6 +105,10 @@ void VirtualMachineDebug::InvokePacked(Index packed_index, const PackedFunc& fun
     }
 
     std::unordered_map<std::string, ObjectRef> metrics;
+
+    ICHECK(exec_->op_attrs.find(packed_index) != exec_->op_attrs.end())
+        << packed_index_map_[packed_index] << " not found in op attrs";
+
     auto& op_attrs = exec_->op_attrs.at(packed_index);
     for (auto p : op_attrs) {
       if (std::string(p.first).find("layout") != std::string::npos) {


### PR DESCRIPTION
https://github.com/apache/tvm/pull/7894 forgot to add func attributes for shape func, and so the profiler crashes at https://github.com/apache/tvm/blob/301ce490c23c95aa4ed3cfd735ba7b42f69e97e7/src/runtime/vm/profiler/vm.cc#L108 when it tries to run a shape func on dynamic workloads.

cc @tkonolige @junrushao1994 