### PR TITLE
[CMake][Minor] Update CMake warning flags

### DIFF
--- a/cmake/modules/ClangFlags.cmake
+++ b/cmake/modules/ClangFlags.cmake
@@ -52,7 +52,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       -Wno-shorten-64-to-32
       -Wno-covered-switch-default
       -Wno-unused-exception-parameter
-      -Wno-return-std-move-in-c++11
+      -Wno-return-std-move
       -Wno-over-aligned
       -Wno-undef
       -Wno-inconsistent-missing-destructor-override

--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -371,8 +371,9 @@ TVM_DLL Pass ConvertBlocksToOpaque();
 /*!
  * \brief Compact the buffer access region by removing the buffer regions that are not accessed,
  *        i.e. narrowing the buffer shape and adjust the access region if necessary.
- * \example
- *  Before narrowing, `B` is a `[16, 16]` buffer, but only a skinny vector `B[i, 0:16]` is accessed.
+ *
+ * Before narrowing, `B` is a `[16, 16]` buffer, but only a skinny vector `B[i, 0:16]` is accessed.
+ *
  *  \code
  *
  *  for i in range(0, 16):

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -242,9 +242,9 @@ class IterMapRewriter : public ExprMutator {
    *    either 1) follow inclusion relation or 2) have no intersection
    *
    *    For Example, x = i0*30 + i1*15 + i2*3 + i3,
-   *    1) [i0*2 + i1 < 3, i2*3 + i3 < 5] is valid, since {i0, i1} \intersect {i2, i3} = empty set.
+   *    1) [i0*2 + i1 < 3, i2*3 + i3 < 5] is valid, since {i0, i1} \\intersect {i2, i3} = empty set.
    *    2) [i0*2 + i1 < 3, i1*5 + i2 < 5] is not valid,
-   *       since {i0, i1} \intersect {i1, i2} = {i1}, i0 \in {i0, i1}, i0 \notin {i1, i2}
+   *       since {i0, i1} \\intersect {i1, i2} = {i1}, i0 \\in {i0, i1}, i0 \\notin {i1, i2}
    * \return whether the predicates are valid;
    */
   bool CheckConstraints() const {


### PR DESCRIPTION
Reported by @Hzfengsy.

`-Wno-return-std-move-in-c++11` cannot be recognized by clang++-13 any more, and this PR updates it to `-Wno-return-std-move `.

BTW, we still have some warnings that the "\example" command is not recognized by clang++ (`-Wdocumentation-unknown-command`), not sure which command we should use in this case.

CC: @tqchen @rkimball 