### PR TITLE
[microTVM] make RVM memory and number of cores variable

### DIFF
--- a/apps/microtvm/reference-vm/zephyr/Vagrantfile
+++ b/apps/microtvm/reference-vm/zephyr/Vagrantfile
@@ -18,6 +18,18 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "tlcpack/microtvm-zephyr-2.5"
 
+  if ENV.has_key?("RVM_NUM_CORES")
+    num_cores = ENV["RVM_NUM_CORES"]
+  else
+    num_cores = 2
+  end
+
+  if ENV.has_key?("RVM_RAM_BYTES")
+    ram_bytes = ENV["RVM_RAM_BYTES"]
+  else
+    ram_bytes = 2048
+  end
+
   tvm_home = "../../../.."
   dirs_to_mount = [Pathname.new(Pathname.new(tvm_home).expand_path())]
   if ENV.has_key?("TVM_PROJECT_DIR") then
@@ -40,6 +52,8 @@ Vagrant.configure("2") do |config|
   vm_name = "microtvm-#{Time.now.tv_sec}"
   config.vm.provider "virtualbox" do |vb, overrides|
     vb.name = vm_name
+    vb.cpus = num_cores
+    vb.memory = ram_bytes
     vb.customize ["modifyvm", :id, "--usb", "on"]
     vb.customize ["modifyvm", :id, "--usbehci", "on"]
     vb.customize ["modifyvm", :id, "--usbxhci", "on"]
@@ -50,6 +64,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "parallels" do |prl, overrides|
     prl.name = vm_name
+    prl.cpus = num_cores
+    prl.memory = ram_bytes
     prl.update_guest_tools = true
     prl.customize ["set", :id, "--support-usb30", "on"]
     dirs_to_mount.each do |d|
@@ -58,6 +74,8 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider "vmware_desktop" do |vm, overrides|
+    vm.cpus = num_cores
+    vm.memory = ram_bytes
     vm.vmx["usb_xhci.present"] = "TRUE"
     vm.vmx["usb.present"] = "TRUE"
     vm.vmx["ehci.present"] = "TRUE"

--- a/apps/microtvm/reference-vm/zephyr/Vagrantfile
+++ b/apps/microtvm/reference-vm/zephyr/Vagrantfile
@@ -18,14 +18,14 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "tlcpack/microtvm-zephyr-2.5"
 
-  if ENV.has_key?("RVM_NUM_CORES")
-    num_cores = ENV["RVM_NUM_CORES"]
+  if ENV.has_key?("TVM_RVM_NUM_CORES")
+    num_cores = ENV["TVM_RVM_NUM_CORES"]
   else
     num_cores = 2
   end
 
-  if ENV.has_key?("RVM_RAM_BYTES")
-    ram_bytes = ENV["RVM_RAM_BYTES"]
+  if ENV.has_key?("TVM_RVM_RAM_BYTES")
+    ram_bytes = ENV["TVM_RVM_RAM_BYTES"]
   else
     ram_bytes = 2048
   end


### PR DESCRIPTION
With this change we can set the memory size and number of cores for RVM with `vagrant up` command. I kept default values for them so that we don't require to change the tutorials.