### PR TITLE
[CI][DOCKER] Fix cuda11 nvidia-docker support for non-Tesla gpus

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -114,6 +114,10 @@ ENV C_INCLUDE_PATH=/usr/local/cuda/include:${C_INCLUDE_PATH}
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compat:${LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/compat:${LD_LIBRARY_PATH}
 
+# Ensure the local libcuda have higher priority than the /usr/local/cuda/compact
+# since the compact libcuda does not work on non-Tesla gpus
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:${LD_LIBRARY_PATH}
+
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}
 ENV PATH=/node_modules/.bin:${PATH}
 ENV VULKAN_SDK=/usr


### PR DESCRIPTION
Starting cuda11, libcuda can be linked to a version of libcuda in
/usr/local/cuda/compact. The particular linked library
does not work for non-Tesla GPUs, causing "no CUDA capable devices found"
even though nvidia-smi shows available GPUs.

This PR makes makes sure we always prioritize linking
/usr/lib/x86_64-linux-gnu/libcuda.so.1

so the nvidia docker cuda11 images works for non-Tesla GPU envs.
