### PR TITLE
[CI] Hotfix the CI after image update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = "tlcpack/ci-lint:v0.65"
-ci_gpu = "tlcpack/ci-gpu:v0.74"
+ci_gpu = "tlcpack/ci-gpu:v0.75"
 ci_cpu = "tlcpack/ci-cpu:v0.74"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.73"

--- a/tests/lint/git-black.sh
+++ b/tests/lint/git-black.sh
@@ -54,6 +54,10 @@ if [ -z ${FILES+x} ]; then
 fi
 echo "Files: $FILES"
 
+# required to make black's dep click to work
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
 if [[ ${INPLACE_FORMAT} -eq 1 ]]; then
     echo "Running black on Python files against revision" $1:
     CMD=( "black" "${FILES[@]}" )
@@ -61,5 +65,5 @@ if [[ ${INPLACE_FORMAT} -eq 1 ]]; then
     "${CMD[@]}"
 else
     echo "Running black in checking mode"
-    black --diff --check ${FILES[@]}
+    python3 -m black --diff --check ${FILES[@]}
 fi


### PR DESCRIPTION
- ci-gpu needs env var update to support all GPUs as per https://github.com/apache/tvm/pull/8163/
- Update git-black to resolve the encoding error due to latest black's dep

