### PR TITLE
[BYOC] [ACL] Migrated to v21.05

### DIFF
--- a/docker/install/ubuntu_install_arm_compute_lib.sh
+++ b/docker/install/ubuntu_install_arm_compute_lib.sh
@@ -58,8 +58,8 @@ git clone "$repo_url" "$repo_dir"
 
 cd "$repo_dir"
 
-# pin version to v21.02
-git checkout "v21.02"
+# pin version to v21.05
+git checkout "v21.05"
 
 if [ "$architecture_type" != "aarch64" ]; then
   build_type="cross_compile"


### PR DESCRIPTION
This PR changes ACL version to v21.05

*ACL stands for "Compute Library for the Arm® Architecture"


@areusch Please assist with rebuilding of ci-image