### PR TITLE
Fix incorrect device name in TVMC.

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -51,7 +51,7 @@ def add_run_parser(subparsers):
     #      like 'webgpu', etc (@leandron)
     parser.add_argument(
         "--device",
-        choices=["cpu", "gpu", "cl"],
+        choices=["cpu", "cuda", "cl"],
         default="cpu",
         help="target device to run the compiled module. Defaults to 'cpu'",
     )
@@ -323,7 +323,7 @@ def run_module(
     tvmc_package: TVMCPackage
         The compiled model package object that will be run.
     device: str,
-        the device (e.g. "cpu" or "gpu") to be targeted by the RPC
+        the device (e.g. "cpu" or "cuda") to be targeted by the RPC
         session, local or remote).
     hostname : str, optional
         The hostname of the target device on which to run.
@@ -387,7 +387,7 @@ def run_module(
 
     # TODO expand to other supported devices, as listed in tvm.rpc.client (@leandron)
     logger.debug("Device is %s.", device)
-    if device == "gpu":
+    if device == "cuda":
         dev = session.cuda()
     elif device == "cl":
         dev = session.cl()

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -387,7 +387,7 @@ def run_module(
 
     # TODO expand to other supported devices, as listed in tvm.rpc.client (@leandron)
     logger.debug("Device is %s.", device)
-    if device == "cuda":
+    if device == "gpu":
         dev = session.cuda()
     elif device == "cl":
         dev = session.cl()


### PR DESCRIPTION
Small bug in TVMC where the command line flag expects `--device gpu` but the runner code expects `--device cuda`.