### PR TITLE
[Vulkan][UnitTests] Compatibility fix for test_vulkan_unique()

### DIFF
--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -255,7 +255,7 @@ def test_vulkan_unique():
     dtype = "int32"
     x = relay.var("x", shape=(relay.Any(),), dtype=dtype)
     mod = tvm.IRModule()
-    [unique, _, num_unique] = relay.unique(x, is_sorted=True)
+    [unique, _, _, num_unique] = relay.unique(x, is_sorted=True)
     mod["main"] = relay.Function([x], relay.op.strided_slice(unique, begin=[0], end=num_unique))
     x_np = np.random.randint(0, high=10, size=(10,)).astype(dtype)
     res_np = np.unique(x_np)


### PR DESCRIPTION
The return values for `relay.unique` were changed in 6baccc13, updating vulkan unit tests to match.  Longer-term, once the details for parametrized unit tests (#8010) are settled, I think this is a point in favor of parametrizing a test case over multiple targets, even if it is designed to trigger a bug that only exists in one.