### PR TITLE
Fix prelu bug in pytorch frontend

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -754,9 +754,13 @@ class PyTorchOpConverter:
         return _op.nn.relu(data)
 
     def prelu(self, inputs, input_types):
+        # Reference: https://pytorch.org/docs/stable/generated/torch.nn.PReLU.html#torch.nn.PReLU
         data = inputs[0]
-        alpha = inputs[1]
-        return _op.nn.prelu(data, alpha)
+        dim = self.get_dims(data)
+        ndims = len(dim)
+        axis = 0 if ndims == 1 else 1
+        alpha = _op.broadcast_to(inputs[1], (dim[axis]))
+        return _op.nn.prelu(data, alpha, axis)
 
     def leaky_relu(self, inputs, input_types):
         data = inputs[0]

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -642,7 +642,12 @@ def test_forward_prelu():
     torch.set_grad_enabled(False)
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
+    
     verify_model(torch.nn.PReLU(num_parameters=3).eval(), input_data=input_data)
+    # Test when input_channel > 1 and num_parameters = 1 
+    verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=input_data)
+    # Test input dims < 2
+    verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=torch.randn(2))
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -78,9 +78,7 @@ def load_torchvision(model_name):
             input_data[:, channel] /= std[channel]
 
         if model_name.startswith("googlenet"):
-            model = getattr(torchvision.models, model_name)(
-                pretrained=True, aux_logits=True
-            )
+            model = getattr(torchvision.models, model_name)(pretrained=True, aux_logits=True)
         else:
             model = getattr(torchvision.models, model_name)(pretrained=True)
         model = model.float().eval()
@@ -214,15 +212,11 @@ def verify_model(
     mod, params = relay.frontend.from_pytorch(trace, input_shapes, custom_convert_map)
     for arg in mod["main"].params[: len(input_names)]:
         assert arg.name_hint in input_names
-    compiled_input = dict(
-        zip(input_names, [inp.clone().cpu().numpy() for inp in baseline_input])
-    )
+    compiled_input = dict(zip(input_names, [inp.clone().cpu().numpy() for inp in baseline_input]))
 
     with tvm.transform.PassContext(opt_level=3):
         for target, dev in tvm.testing.enabled_targets():
-            relay_graph, relay_lib, relay_params = relay.build(
-                mod, target=target, params=params
-            )
+            relay_graph, relay_lib, relay_params = relay.build(mod, target=target, params=params)
             relay_model = graph_executor.create(relay_graph, relay_lib, dev)
             relay_model.set_input(**relay_params)
             for name, inp in compiled_input.items():
@@ -233,9 +227,7 @@ def verify_model(
                 compiled_output = relay_model.get_output(i).numpy()
 
                 assert_shapes_match(baseline_output, compiled_output)
-                tvm.testing.assert_allclose(
-                    baseline_output, compiled_output, rtol=rtol, atol=atol
-                )
+                tvm.testing.assert_allclose(baseline_output, compiled_output, rtol=rtol, atol=atol)
 
     if expected_ops:
 
@@ -628,9 +620,7 @@ def test_forward_concatenate():
 
     class Concatenate1(Module):
         def forward(self, *args):
-            return torch.cat(
-                [args[0][:, 0].unsqueeze(1), args[0][:, 1].unsqueeze(1)], 1
-            )
+            return torch.cat([args[0][:, 0].unsqueeze(1), args[0][:, 1].unsqueeze(1)], 1)
 
     class Concatenate2(Module):
         def forward(self, *args):
@@ -658,9 +648,7 @@ def test_forward_prelu():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
     verify_model(torch.nn.PReLU(num_parameters=3).eval(), input_data=input_data)
-    # Test when num parameters = 1 and input channel > 1
     verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=input_data)
-    # Test when num parameters = 1 and input channel = 1
     verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=torch.randn(2))
 
 
@@ -725,9 +713,7 @@ def test_forward_softplus():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
     verify_model(torch.nn.Softplus().eval(), input_data=input_data)
-    verify_model(
-        torch.nn.Softplus(beta=1.5, threshold=20).eval(), input_data=input_data
-    )
+    verify_model(torch.nn.Softplus(beta=1.5, threshold=20).eval(), input_data=input_data)
     verify_model(torch.nn.Softplus(beta=5, threshold=10).eval(), input_data=input_data)
 
 
@@ -763,13 +749,9 @@ def test_forward_maxpool2d():
     input_data = torch.rand(input_shape).float()
 
     verify_model(torch.nn.MaxPool2d(kernel_size=[1, 1]).eval(), input_data)
-    verify_model(
-        torch.nn.MaxPool2d(kernel_size=[2, 2], dilation=[2, 3]).eval(), input_data
-    )
+    verify_model(torch.nn.MaxPool2d(kernel_size=[2, 2], dilation=[2, 3]).eval(), input_data)
     verify_model(torch.nn.MaxPool2d(kernel_size=[10, 10]).eval(), input_data)
-    verify_model(
-        torch.nn.MaxPool2d(kernel_size=[4, 4], padding=2, stride=2).eval(), input_data
-    )
+    verify_model(torch.nn.MaxPool2d(kernel_size=[4, 4], padding=2, stride=2).eval(), input_data)
 
     # A functional variant (default strides = None case)
     class MaxPool2D(Module):
@@ -796,9 +778,7 @@ def test_forward_maxpool2d():
                 torch.tensor(x_shape[1]).int(),
             ]
             strides = [torch.tensor(x_shape[0]).int(), torch.tensor(x_shape[0]).int()]
-            return torch.nn.functional.max_pool2d(
-                args[0], kernel_size=[4, 4], stride=strides
-            )
+            return torch.nn.functional.max_pool2d(args[0], kernel_size=[4, 4], stride=strides)
 
     verify_model(MaxPool2DWithIndices().float().eval(), input_data=input_data)
     verify_model(MaxPool2DWithIntStrides().float().eval(), input_data=input_data)
@@ -813,9 +793,7 @@ def test_forward_maxpool1d():
     verify_model(torch.nn.MaxPool1d(kernel_size=1).eval(), input_data)
     verify_model(torch.nn.MaxPool1d(kernel_size=2, dilation=[1]).eval(), input_data)
     verify_model(torch.nn.MaxPool1d(kernel_size=10).eval(), input_data)
-    verify_model(
-        torch.nn.MaxPool1d(kernel_size=4, padding=2, stride=2).eval(), input_data
-    )
+    verify_model(torch.nn.MaxPool1d(kernel_size=4, padding=2, stride=2).eval(), input_data)
 
     # A functional variant (default strides = None case)
     class MaxPool1D(Module):
@@ -832,9 +810,7 @@ def test_forward_maxpool3d():
     input_data = torch.rand(input_shape).float()
 
     verify_model(torch.nn.MaxPool3d(kernel_size=[1, 1, 1]).eval(), input_data)
-    verify_model(
-        torch.nn.MaxPool3d(kernel_size=[2, 2, 2], dilation=[1, 2, 3]).eval(), input_data
-    )
+    verify_model(torch.nn.MaxPool3d(kernel_size=[2, 2, 2], dilation=[1, 2, 3]).eval(), input_data)
     verify_model(torch.nn.MaxPool3d(kernel_size=[10, 10, 10]).eval(), input_data)
     verify_model(
         torch.nn.MaxPool3d(kernel_size=[4, 4, 4], padding=2, stride=2).eval(),
@@ -916,9 +892,7 @@ def test_forward_avgpool3d():
             return torch.nn.functional.avg_pool3d(args[0], kernel_size=[10, 10, 10])
 
     input_data = torch.rand(input_shape).float()
-    verify_model(
-        torch.nn.AvgPool3d(kernel_size=[10, 10, 10]).eval(), input_data=input_data
-    )
+    verify_model(torch.nn.AvgPool3d(kernel_size=[10, 10, 10]).eval(), input_data=input_data)
     verify_model(AvgPool3D1().float().eval(), input_data=input_data)
     verify_model(
         torch.nn.AvgPool3d(kernel_size=5, stride=2, padding=2).eval(),
@@ -1015,9 +989,7 @@ def test_forward_conv():
 @pytest.mark.parametrize("in_channels", [3], ids=lambda x: "in_channels=" + str(x))
 @pytest.mark.parametrize("out_channels", [5], ids=lambda x: "out_channels=" + str(x))
 @pytest.mark.parametrize("kernel_size", [3], ids=lambda x: "kernel_size=" + str(x))
-@pytest.mark.parametrize(
-    "output_padding", [0, 1, 2], ids=lambda x: "output_padding=" + str(x)
-)
+@pytest.mark.parametrize("output_padding", [0, 1, 2], ids=lambda x: "output_padding=" + str(x))
 @pytest.mark.parametrize("groups", [1], ids=lambda x: "groups=" + str(x))
 @pytest.mark.parametrize("bias", [True, False], ids=lambda x: "bias=" + str(x))
 def test_forward_conv_transpose(
@@ -1985,9 +1957,7 @@ def test_forward_nms():
         boxes = torch.rand(num_boxes, box_len, dtype=torch.float) * 0.5
         boxes[:, 2] += boxes[:, 0]
         boxes[:, 3] += boxes[:, 1]
-        scores = torch.from_numpy(
-            np.random.uniform(-1, 1, size=(num_boxes,)).astype(np.float32)
-        )
+        scores = torch.from_numpy(np.random.uniform(-1, 1, size=(num_boxes,)).astype(np.float32))
         return boxes, scores
 
     targets = ["llvm", "cuda"]
@@ -2059,15 +2029,11 @@ def test_conv3d_transpose():
             inp,
         ),
         verify_model(
-            torch.nn.ConvTranspose3d(
-                in_channels=8, out_channels=20, kernel_size=1
-            ).eval(),
+            torch.nn.ConvTranspose3d(in_channels=8, out_channels=20, kernel_size=1).eval(),
             inp,
         )
         verify_model(
-            torch.nn.ConvTranspose3d(
-                in_channels=8, out_channels=5, kernel_size=1, stride=2
-            ).eval(),
+            torch.nn.ConvTranspose3d(in_channels=8, out_channels=5, kernel_size=1, stride=2).eval(),
             inp,
         )
 
@@ -2155,9 +2121,7 @@ def test_custom_conversion_map():
             ],
             dtype=torch.float,
         )
-        roi_align = torchvision.ops.RoIAlign(
-            pool_size, spatial_scale=1, sampling_ratio=-1
-        )
+        roi_align = torchvision.ops.RoIAlign(pool_size, spatial_scale=1, sampling_ratio=-1)
         return roi_align.eval(), [x, rois]
 
     def convert_roi_align():
@@ -2263,15 +2227,13 @@ def verify_model_vm(input_model, ishapes, idtype=None, idata=None, targets=["llv
     else:
         if idtype == torch.bool:
             input_data = [
-                torch.Tensor.bool(torch.randint(low=0, high=2, size=shape))
-                for shape in ishapes
+                torch.Tensor.bool(torch.randint(low=0, high=2, size=shape)) for shape in ishapes
             ]
         # Torch dtype can be float, complex, int, or Bool. Complex not supported, so if not float or Bool,
         # dtype must be int!
         elif not idtype.is_floating_point:
             input_data = [
-                torch.randint(low=0, high=10, size=shape, dtype=idtype)
-                for shape in ishapes
+                torch.randint(low=0, high=10, size=shape, dtype=idtype) for shape in ishapes
             ]
         else:
             input_data = [torch.randn(shape, dtype=idtype) for shape in ishapes]
@@ -2300,16 +2262,12 @@ def verify_model_vm(input_model, ishapes, idtype=None, idata=None, targets=["llv
             # handle multiple outputs
             for i in range(len(pt_result)):
                 tvm_res = vm_res[i].numpy()
-                tvm.testing.assert_allclose(
-                    tvm_res, pt_result[i].numpy(), rtol=1e-5, atol=1e-5
-                )
+                tvm.testing.assert_allclose(tvm_res, pt_result[i].numpy(), rtol=1e-5, atol=1e-5)
         elif not isinstance(pt_result, torch.Tensor):
             tvm_res = vm_res.numpy().item()
             assert pt_result == tvm_res
         else:
-            tvm.testing.assert_allclose(
-                vm_res.numpy(), pt_result.numpy(), rtol=1e-5, atol=1e-5
-            )
+            tvm.testing.assert_allclose(vm_res.numpy(), pt_result.numpy(), rtol=1e-5, atol=1e-5)
 
 
 @tvm.testing.uses_gpu
@@ -2701,14 +2659,10 @@ def test_forward_embedding():
     verify_model(torch.nn.Embedding(10, 3).float().eval(), input_data=input_data)
 
     input_data = torch.randint(0, 4, [2, 3, 4]).long()
-    verify_model(
-        torch.nn.Embedding(4, 5, sparse=False).float().eval(), input_data=input_data
-    )
+    verify_model(torch.nn.Embedding(4, 5, sparse=False).float().eval(), input_data=input_data)
 
     input_data = torch.randint(0, 4, [2, 3, 4]).long()
-    verify_model(
-        torch.nn.Embedding(4, 5, sparse=True).float().eval(), input_data=input_data
-    )
+    verify_model(torch.nn.Embedding(4, 5, sparse=True).float().eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu
@@ -3585,14 +3539,10 @@ def test_forward_nonzero():
 def test_forward_scatter():
     # integer cannot be traced
     def test_fn_scatter(dim):
-        return lambda data, index, src: torch.scatter(
-            data, dim=dim, index=index, src=src
-        )
+        return lambda data, index, src: torch.scatter(data, dim=dim, index=index, src=src)
 
     def test_fn_scatter_add(dim):
-        return lambda data, index, src: torch.scatter_add(
-            data, dim=dim, index=index, src=src
-        )
+        return lambda data, index, src: torch.scatter_add(data, dim=dim, index=index, src=src)
 
     in_data = torch.zeros(3, 5)
     in_index = torch.tensor([[0, 1, 2, 0, 0], [2, 0, 0, 1, 2]])
@@ -3639,9 +3589,7 @@ def test_forward_index_put():
     zidx = torch.tensor([0, 1, 1, 2, 0])
     values = torch.tensor([2.0, 4.0, 7.0, 9.0, 1.0])
 
-    verify_trace_model(
-        test_fn_index_put3a(), [in_data, xidx, yidx, zidx, values], targets
-    )
+    verify_trace_model(test_fn_index_put3a(), [in_data, xidx, yidx, zidx, values], targets)
 
 
 def test_numel():
@@ -3757,9 +3705,7 @@ def test_forward_pretrained_bert_base_uncased():
 
     target = "llvm"
     with tvm.transform.PassContext(opt_level=3):
-        relay_graph, relay_lib, relay_params = relay.build(
-            mod, target=target, params=params
-        )
+        relay_graph, relay_lib, relay_params = relay.build(mod, target=target, params=params)
 
     ######################################################################
     # Execute on TVM
@@ -3899,9 +3845,7 @@ def test_masked_fill():
 
 
 def test_transformer():
-    model = torch.nn.Transformer(
-        d_model=256, nhead=8, num_encoder_layers=6, num_decoder_layers=6
-    )
+    model = torch.nn.Transformer(d_model=256, nhead=8, num_encoder_layers=6, num_decoder_layers=6)
     model = model.eval()
     src = torch.rand((10, 32, 256))
     tgt = torch.rand((20, 32, 256))

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -642,7 +642,6 @@ def test_forward_prelu():
     torch.set_grad_enabled(False)
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
-    
     verify_model(torch.nn.PReLU(num_parameters=3).eval(), input_data=input_data)
     # Test when input_channel > 1 and num_parameters = 1 
     verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=input_data)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -643,7 +643,7 @@ def test_forward_prelu():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
     verify_model(torch.nn.PReLU(num_parameters=3).eval(), input_data=input_data)
-    # Test when input_channel > 1 and num_parameters = 1 
+    # Test when input_channel > 1 and num_parameters = 1
     verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=input_data)
     # Test input dims < 2
     verify_model(torch.nn.PReLU(num_parameters=1).eval(), input_data=torch.randn(2))


### PR DESCRIPTION
This PR tries to fix PReLU bug mentioned in https://github.com/apache/tvm/issues/8184
Reference: https://pytorch.org/docs/stable/generated/torch.nn.PReLU.html#torch.nn.PReLU

In short, there are two situations we need to consider:
1. When input dims < 2. PReLU in Pytorch can deal with this, while in TVM the default axis of `tvm.relay.nn.prelu` is set to 1, we will encounter an error when directly calling this function.
2. When input dims >= 2, input channel > 1 and num_parameters = 1. In this case will need to do a broadcasting on the alpha parameter.

@masahi  Please take a look at this PR, thanks!

