### PR TITLE
[BNNS] Changed BNNS tests to support RPC tracker

### DIFF
--- a/tests/python/contrib/test_bnns/infrastructure.py
+++ b/tests/python/contrib/test_bnns/infrastructure.py
@@ -85,11 +85,12 @@ class Device:
     def __init__(self, connection_type):
         """Keep remote device for lifetime of object."""
         self.connection_type = connection_type
-        if (self.connection_type == Device.ConnectionType.TRACKER
+        if (
+            self.connection_type == Device.ConnectionType.TRACKER
             and not Device.is_tracker_compatible()
         ):
             raise Exception(
-                'Can\'t create Device instance. No environment variables set for the RPC Tracker'
+                "Can't create Device instance. No environment variables set for the RPC Tracker"
             )
 
         if self.connection_type == Device.ConnectionType.TRACKER:

--- a/tests/python/contrib/test_bnns/infrastructure.py
+++ b/tests/python/contrib/test_bnns/infrastructure.py
@@ -85,12 +85,18 @@ class Device:
     def __init__(self, connection_type):
         """Keep remote device for lifetime of object."""
         self.connection_type = connection_type
-        if self.connection_type == Device.ConnectionType.TRACKER and not Device.is_tracker_compatible():
-            raise Exception('Can\'t create Device instance. No environment variables set for the RPC Tracker')
+        if (self.connection_type == Device.ConnectionType.TRACKER
+            and not Device.is_tracker_compatible()
+        ):
+            raise Exception(
+                'Can\'t create Device instance. No environment variables set for the RPC Tracker'
+            )
 
         if self.connection_type == Device.ConnectionType.TRACKER:
             self.target = "llvm -mtriple=arm64-apple-darwin"
-            self.fcompile = lambda output, objects, **kwargs: xcode.create_dylib(output, objects, arch="arm64", sdk="iphoneos")
+            self.fcompile = lambda output, objects, **kwargs: xcode.create_dylib(
+                output, objects, arch="arm64", sdk="iphoneos"
+            )
         else:
             self.target = "llvm"
             self.fcompile = None
@@ -101,6 +107,7 @@ class Device:
     def is_tracker_compatible(cls):
         def ok(attr):
             return attr is not None
+
         return ok(cls.host) and ok(cls.port) and ok(cls.device_key)
 
     def _get_remote(self):
@@ -128,8 +135,8 @@ def get_run_modes():
 
 
 def skip_complexity_test(f):
-    skip = os.environ.get('TVM_RUN_COMPLEXITY_TEST') is None
-    return pytest.mark.skipif(skip, reason='Disabled because of huge complexity')(f)
+    skip = os.environ.get("TVM_RUN_COMPLEXITY_TEST") is None
+    return pytest.mark.skipif(skip, reason="Disabled because of huge complexity")(f)
 
 
 def check_test_parameters(mode):

--- a/tests/python/contrib/test_bnns/infrastructure.py
+++ b/tests/python/contrib/test_bnns/infrastructure.py
@@ -200,7 +200,7 @@ def build_and_run(
 
 def update_lib(lib, device, fcompile):
     """Export the library to the remote/local device."""
-    lib_name = "mod.so"
+    lib_name = "mod.dylib"
     temp = utils.tempdir()
     lib_path = temp.relpath(lib_name)
     lib.export_library(lib_path, fcompile=fcompile)

--- a/tests/python/contrib/test_bnns/test_conv2d.py
+++ b/tests/python/contrib/test_bnns/test_conv2d.py
@@ -152,6 +152,7 @@ def test_conv2d(mode):
 
 @pytest.mark.parametrize("mode", get_run_modes())
 def test_conv2d_dw(mode):
+    check_test_parameters(mode)
     np.random.seed(0)
     shape = [4, 5, 5]
 
@@ -162,6 +163,7 @@ def test_conv2d_dw(mode):
 
 @pytest.mark.parametrize("mode", get_run_modes())
 def test_conv2d_with_oc1(mode):
+    check_test_parameters(mode)
     np.random.seed(0)
     shape = [3, 5, 5]
 

--- a/tests/python/contrib/test_bnns/test_conv2d.py
+++ b/tests/python/contrib/test_bnns/test_conv2d.py
@@ -25,7 +25,7 @@ from .infrastructure import (
     get_run_modes,
     check_test_parameters,
     compare_inference_with_ref,
-    generate_trials
+    generate_trials,
 )
 
 # TODO: Missed cases

--- a/tests/python/contrib/test_bnns/test_conv2d_patterns.py
+++ b/tests/python/contrib/test_bnns/test_conv2d_patterns.py
@@ -105,3 +105,10 @@ def test_pattern_conv2d_with_non_cons_bias():
     bias_is_fused = is_op_fused(mod["bnns_0"], "nn.bias_add")
 
     assert not bias_is_fused
+
+
+if __name__ == '__main__':
+    test_pattern_conv2d_with_bias_add()
+    test_pattern_conv2d_with_add()
+    test_pattern_conv2d_with_non_cons_weights()
+    test_pattern_conv2d_with_non_cons_bias()

--- a/tests/python/contrib/test_bnns/test_conv2d_patterns.py
+++ b/tests/python/contrib/test_bnns/test_conv2d_patterns.py
@@ -107,7 +107,7 @@ def test_pattern_conv2d_with_non_cons_bias():
     assert not bias_is_fused
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_pattern_conv2d_with_bias_add()
     test_pattern_conv2d_with_add()
     test_pattern_conv2d_with_non_cons_weights()

--- a/tests/python/contrib/test_bnns/test_matmul.py
+++ b/tests/python/contrib/test_bnns/test_matmul.py
@@ -17,19 +17,15 @@
 """BNNS integration dense tests."""
 
 import numpy as np
-import math
 import pytest
 import tvm
 from tvm import relay
-from tvm import testing
 from .infrastructure import (
     Device,
-    skip_runtime_test,
-    skip_codegen_test,
-    verify_codegen,
+    get_run_modes,
+    check_test_parameters,
     build_and_run,
-    verify,
-    generate_trials,
+    verify
 )
 
 
@@ -50,9 +46,11 @@ def _get_model(a_shape, b_shape, dtype, var_names, is_a_constant=False, is_b_con
     return out, params
 
 
-@pytest.mark.skipif(skip_runtime_test(), reason="Skip because BNNS codegen is not available")
-def test_matmul():
-    device = Device()
+@pytest.mark.parametrize("mode", get_run_modes())
+def test_matmul(mode):
+    check_test_parameters(mode)
+
+    device = Device(mode)
     np.random.seed(0)
     dtype = "float32"
 
@@ -110,4 +108,5 @@ def test_matmul():
 
 
 if __name__ == "__main__":
-    test_matmul()
+    for _mode in get_run_modes():
+        test_matmul(_mode)

--- a/tests/python/contrib/test_bnns/test_matmul.py
+++ b/tests/python/contrib/test_bnns/test_matmul.py
@@ -20,13 +20,7 @@ import numpy as np
 import pytest
 import tvm
 from tvm import relay
-from .infrastructure import (
-    Device,
-    get_run_modes,
-    check_test_parameters,
-    build_and_run,
-    verify
-)
+from .infrastructure import Device, get_run_modes, check_test_parameters, build_and_run, verify
 
 
 def _get_model(a_shape, b_shape, dtype, var_names, is_a_constant=False, is_b_constant=False):

--- a/tests/python/contrib/test_bnns/test_onnx_topologies.py
+++ b/tests/python/contrib/test_bnns/test_onnx_topologies.py
@@ -33,11 +33,11 @@ from .infrastructure import (
     get_run_modes,
     check_test_parameters,
     build_and_run,
-    verify
+    verify,
 )
 
 
-DTYPE = 'float32'
+DTYPE = "float32"
 INPUT_SHAPE = [1, 3, 224, 224]
 
 BASE_MODEL_URL = "https://github.com/onnx/models/raw/master/"
@@ -66,7 +66,7 @@ def get_model_url(model_name):
 
 
 def get_name_from_url(url):
-    return url[url.rfind("/") + 1:].strip()
+    return url[url.rfind("/") + 1 :].strip()
 
 
 def find_of_download(model_name):

--- a/tests/python/contrib/test_bnns/test_onnx_topologies.py
+++ b/tests/python/contrib/test_bnns/test_onnx_topologies.py
@@ -16,33 +16,39 @@
 # under the License.
 """BNNS pattern detection check"""
 
+import onnx
 import pytest
-
-import tvm
-from tvm import relay
-from tvm.relay import transform
-from tvm.contrib import utils, graph_executor
-from tvm.contrib.download import download_testdata
-from tvm.relay.op.contrib.bnns import partition_for_bnns
-
+import itertools
 import numpy as np
 
-pytest.importorskip("onnx")
+import tvm
+import tvm.testing
+from tvm import relay
+from tvm.relay import transform
+from tvm.contrib.download import download_testdata
 
-bnns_is_absent = tvm.get_global_func("relay.ext.bnns", True) is None
+from .infrastructure import (
+    Device,
+    skip_complexity_test,
+    get_run_modes,
+    check_test_parameters,
+    build_and_run,
+    verify
+)
 
-TARGET = "llvm"
+
+DTYPE = 'float32'
 INPUT_SHAPE = [1, 3, 224, 224]
 
 BASE_MODEL_URL = "https://github.com/onnx/models/raw/master/"
 MODEL_URL_COLLECTION = {
-    "BERT": "text/machine_comprehension/bert-squad/model/bertsquad-10.onnx",
+    # "BERT": "text/machine_comprehension/bert-squad/model/bertsquad-10.onnx",
     "MobileNet-v2": "vision/classification/mobilenet/model/mobilenetv2-7.onnx",
     "ResNet50-v1": "vision/classification/resnet/model/resnet50-v1-7.onnx",
     "ResNet50-v2": "vision/classification/resnet/model/resnet50-v2-7.onnx",
-    "SqueezeNet-v1.1": "vision/classification/squeezenet/model/squeezenet1.1-7.onnx",
-    "SqueezeNet-v1.0": "vision/classification/squeezenet/model/squeezenet1.0-7.onnx",
-    "Inception-v1": "vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-7.onnx",
+    # "SqueezeNet-v1.1": "vision/classification/squeezenet/model/squeezenet1.1-7.onnx",
+    # "SqueezeNet-v1.0": "vision/classification/squeezenet/model/squeezenet1.0-7.onnx",
+    # "Inception-v1": "vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-7.onnx",
     "Inception-v2": "vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-7.onnx",
 }
 
@@ -60,7 +66,7 @@ def get_model_url(model_name):
 
 
 def get_name_from_url(url):
-    return url[url.rfind("/") + 1 :].strip()
+    return url[url.rfind("/") + 1:].strip()
 
 
 def find_of_download(model_name):
@@ -73,10 +79,12 @@ def get_model(model_name):
     model_path = find_of_download(model_name)
     onnx_model = onnx.load(model_path)
     input_names = get_onnx_input_name(onnx_model)
+    input_shape_dict = {}
     input_dict = {}
     for name in input_names:
-        input_dict[name] = INPUT_SHAPE  # TODO: hardcode
-    mod, params = relay.frontend.from_onnx(onnx_model, input_dict, freeze_params=True)
+        input_shape_dict[name] = INPUT_SHAPE  # TODO: hardcode
+        input_dict[name] = tvm.nd.array(np.random.uniform(0, 127, INPUT_SHAPE).astype(DTYPE))
+    mod, params = relay.frontend.from_onnx(onnx_model, input_shape_dict, freeze_params=True)
     return mod, params, input_dict
 
 
@@ -99,42 +107,41 @@ def simplify_model(mod):
     return seq(mod)
 
 
-def process(model_name):
-    temp = utils.tempdir()
+def process(mode, model_name):
+    check_test_parameters(mode)
+
+    device = Device(mode)
     model, params, input_dict = get_model(model_name)
+    with tvm.transform.PassContext(opt_level=3):
+        model = simplify_model(model)
 
-    def run(mod, target, simplify=True, with_bnns=False):
-        with tvm.transform.PassContext(opt_level=3):
-            if simplify:
-                mod = simplify_model(mod)
-            if with_bnns:
-                mod = partition_for_bnns(mod)
-            graph_module = relay.build(mod, target=target, target_host=target, params=params)
+    outputs = []
+    for enable_bnns in [False, True]:
+        outputs.append(
+            build_and_run(
+                model,
+                input_dict,
+                1,
+                params,
+                device,
+                enable_bnns=enable_bnns,
+            )[0]
+        )
 
-        lib_name = "deploy.tar"
-        path_dso = temp.relpath(lib_name)
-        graph_module.export_library(path_dso)
-
-        dev = tvm.cpu(0)
-        loaded_lib = tvm.runtime.load_module(path_dso)
-
-        module = graph_executor.GraphModule(loaded_lib["default"](dev))
-        module.run()
-        return module.get_output(0).numpy()
-
-    res_llvm = run(model, TARGET, simplify=True, with_bnns=False)
-    res_bnns = run(model, TARGET, simplify=True, with_bnns=True)
-
-    tvm.testing.assert_allclose(
-        res_llvm,
-        res_bnns,
-        atol=0.002,
-        rtol=0.007,
-    )
+    verify(outputs, atol=0.002, rtol=0.007)
 
 
-@pytest.mark.skip(reason="Manually disabled because of huge complexity")
-@pytest.mark.skipif(bnns_is_absent, reason="BNNS runtime is absent")
 @pytest.mark.parametrize("model_name", MODEL_URL_COLLECTION.keys())
-def test_topology(model_name):
-    process(model_name)
+@pytest.mark.parametrize("mode", get_run_modes())
+@skip_complexity_test
+def test_topology(mode, model_name):
+    process(mode, model_name)
+
+
+def main():
+    for mode, model_name in itertools.product(get_run_modes(), MODEL_URL_COLLECTION.keys()):
+        test_topology(mode, model_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/contrib/test_bnns/test_onnx_topologies.py
+++ b/tests/python/contrib/test_bnns/test_onnx_topologies.py
@@ -16,7 +16,6 @@
 # under the License.
 """BNNS pattern detection check"""
 
-import onnx
 import pytest
 import itertools
 import numpy as np
@@ -35,6 +34,9 @@ from .infrastructure import (
     build_and_run,
     verify,
 )
+
+
+pytest.importorskip("onnx")
 
 
 DTYPE = "float32"

--- a/tests/python/contrib/test_bnns/test_onnx_topologies.py
+++ b/tests/python/contrib/test_bnns/test_onnx_topologies.py
@@ -36,7 +36,7 @@ from .infrastructure import (
 )
 
 
-pytest.importorskip("onnx")
+onnx = pytest.importorskip("onnx")
 
 
 DTYPE = "float32"


### PR DESCRIPTION
This patch introduces RPC Tracker support for BNNS tests. This allows to run tests on connected devices (iphone, ipad) using RPC.

Also contains:

- Infrastructure refactor for the Device class
- Applying the Device class to all tests that were written for BNNS.

Additionally, these changes allow integrating these tests into CI when setting special environment variables.