### PR TITLE
[TOPI] [INTEL GRAPHICS] Fix conv2d_nchw for opencl intel graphics

### DIFF
--- a/python/tvm/topi/intel_graphics/conv2d.py
+++ b/python/tvm/topi/intel_graphics/conv2d.py
@@ -580,7 +580,7 @@ def _schedule_cl_spatialpack(s, op):
     temp = s[conv].op.input_tensors[0]
     kernel_vec = s[conv].op.input_tensors[1]
     kernel = s[kernel_vec].op.input_tensors[0]
-    temp_W = s.cache_read(temp, "warp", [conv])
+    temp_W = s.cache_read(temp, "shared", [conv])
     conv_L = s.cache_write(conv, "local")
 
     kernel_L = s.cache_read(kernel_vec, "local", [conv_L])

--- a/tests/python/topi/python/test_topi_conv2d_nchw.py
+++ b/tests/python/topi/python/test_topi_conv2d_nchw.py
@@ -148,6 +148,8 @@ def verify_conv2d_nchw(
 
     if use_cudnn:
         check_target("cuda -model=unknown -libs=cudnn")
+    if ("opencl", tvm.device("opencl")) in tvm.testing.enabled_targets():
+        check_target("opencl -device=intel_graphics")
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
I got 0% of accurqacy with target="opencl -device=intel_graphics" on IrisXe. I found severtal issue (using warp instead of shared scope for variables) but fixed only for conv2d_nchw. conv2d_nchwc is still buggy

Also enabled generic tvm topi tests on conv2d_nchw. Before the fix, test failed on the first workload, after the fix, the test still fails on workload with dilation != 1, but this is by intel graphics copnv2d_implementation - dilation is not supported for it. Will disable test or fix conv2d_nchw