### PR TITLE
Add thread_warp_size for Metal device in default target attributes

### DIFF
--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -350,6 +350,7 @@ TVM_REGISTER_TARGET_KIND("opencl", kDLOpenCL)
 TVM_REGISTER_TARGET_KIND("metal", kDLMetal)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Integer>("max_num_threads", Integer(256))
+    .add_attr_option<Integer>("thread_warp_size", Integer(16))
     .set_default_keys({"metal", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)


### PR DESCRIPTION
Recently new transpose op strategy was added for cuda which use thread_warp_size from default target attr parameters.
Since Metal fallback to cuda, it needs this parameter to be defined.
The exact value of this param is still open question, 16 should be safe enough but probably it will be changed later after experiments and more clarifications to 32.