### PR TITLE
[Frontend] Speed up Fold Constant

### DIFF
--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -493,7 +493,7 @@ def infer_type(node, mod=None):
 
 def fold_constant(node, mod=None):
     if mod is None:
-        mod = IRModule.from_expr(node)
+        mod = IRModule()
     return _transform.FoldConstantExpr(node, mod)
 
 


### PR DESCRIPTION
@masahi 

This utiliy was creating a new IRModule from the provided expression if the provided module was None. This isn't strictly necessary, the use cases are correct if we pass in an empty IRModule. The WellFormed check inside IRModule.from_expr was actually taking a lot of the time when importing large ONNX models. This change gets me a 2.6x speedup on importing the large NLP model I'm playing with today.