### PR TITLE
[METAL] Fix problem with convolution unrolling

### DIFF
--- a/python/tvm/topi/cuda/conv2d_direct.py
+++ b/python/tvm/topi/cuda/conv2d_direct.py
@@ -48,6 +48,8 @@ def schedule_direct_cuda(cfg, s, conv):
             target.kind.name, target.model, "conv2d_nchw.cuda"
         )
         cfg.fallback_with_reference_log(ref_log)
+        if target.kind.name == "metal":
+            cfg["auto_unroll_max_step"].val = 128
     ##### space definition end #####
 
     pad_data, kernel = s[conv].op.input_tensors


### PR DESCRIPTION
I wasn't able to run inception-v2 model on iPad Air. Model was
successfully compiled but when I run the model, I got the following
error: `Compute function exceeds available temporary registers`

The problem occurs due to the generated kernel for one convolution was
more than 4000 lines long. It happened due to unrolling.

As a solution, decrease value of `auto_unroll_max_step`.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
