### PR TITLE
[ROCM][TOPI] AutoTVM support for MFMA tensorization available on AMD gfx908

### DIFF
--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -168,3 +168,32 @@ def callback_rocm_bitcode_path(rocdl_dir=None):
             raise RuntimeError("could not find bitcode " + n)
 
     return tvm.runtime.convert(bitcode_files)
+
+def parse_compute_version(compute_version):
+    """Parse compute capability string to divide major and minor version
+
+    Parameters
+    ----------
+    compute_version : str
+        GFX version of a GPU (e.g. "6.0")
+
+    Returns
+    -------
+    major : int
+        major version number
+    minor : int
+        minor version number
+    """
+    split_ver = compute_version.split(".")
+    try:
+        major = int(split_ver[0])
+        minor = int(split_ver[1])
+        return major, minor
+    except (IndexError, ValueError) as err:
+        raise RuntimeError("Compute version parsing error: " + str(err))
+
+def support_mfma(device):
+    major, minor = parse_compute_version(device.compute_version)
+    if major >= 9 and minor >= 8:
+        return True
+    return False

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -169,6 +169,7 @@ def callback_rocm_bitcode_path(rocdl_dir=None):
 
     return tvm.runtime.convert(bitcode_files)
 
+
 def parse_compute_version(compute_version):
     """Parse compute capability string to divide major and minor version
 
@@ -191,6 +192,7 @@ def parse_compute_version(compute_version):
         return major, minor
     except (IndexError, ValueError) as err:
         raise RuntimeError("Compute version parsing error: " + str(err))
+
 
 def support_mfma(device):
     major, minor = parse_compute_version(device.compute_version)

--- a/python/tvm/relay/op/strategy/rocm.py
+++ b/python/tvm/relay/op/strategy/rocm.py
@@ -198,7 +198,7 @@ def dense_strategy_rocm(attrs, inputs, out_type, target):
         data, weights = inputs
         b, i = get_const_tuple(data.shape)
         o, _ = get_const_tuple(weights.shape)
-        if (b % 16 == 0 and o % 16 == 0 and i % 16 == 0):
+        if b % 16 == 0 and o % 16 == 0 and i % 16 == 0:
             strategy.add_implementation(
                 wrap_compute_dense(topi.rocm.dense_mfma),
                 wrap_topi_schedule(topi.rocm.schedule_dense_mfma),
@@ -230,7 +230,7 @@ def batch_matmul_strategy_rocm(attrs, inputs, out_type, target):
         A, B = inputs
         _, M, K = get_const_tuple(A.shape)
         _, _, N = get_const_tuple(B.shape)
-        if (M % 16 == 0 and N % 16 == 0 and K % 16 == 0):
+        if M % 16 == 0 and N % 16 == 0 and K % 16 == 0:
             strategy.add_implementation(
                 wrap_compute_batch_matmul(topi.rocm.batch_matmul_mfma),
                 wrap_topi_schedule(topi.rocm.schedule_batch_matmul_mfma),

--- a/python/tvm/relay/op/strategy/rocm.py
+++ b/python/tvm/relay/op/strategy/rocm.py
@@ -21,11 +21,11 @@ from tvm import topi
 from tvm.auto_scheduler import is_auto_scheduler_enabled
 from tvm.te import SpecializedCondition
 from tvm.contrib.thrust import can_use_rocthrust
+from tvm.contrib import rocm
 
 from .generic import *
 from .. import op as _op
 from .cuda import judge_winograd, naive_schedule
-from tvm.contrib import rocm
 
 
 @schedule_lrn.register("rocm")

--- a/python/tvm/topi/rocm/__init__.py
+++ b/python/tvm/topi/rocm/__init__.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import as _abs
 
 from .batch_matmul import *
+from .batch_matmul_mfma import *
 from .conv2d import *
 from .dense import *
 from .dense_mfma import *

--- a/python/tvm/topi/rocm/__init__.py
+++ b/python/tvm/topi/rocm/__init__.py
@@ -22,4 +22,5 @@ from __future__ import absolute_import as _abs
 from .batch_matmul import *
 from .conv2d import *
 from .dense import *
+from .dense_mfma import *
 from .nn import *

--- a/python/tvm/topi/rocm/batch_matmul_mfma.py
+++ b/python/tvm/topi/rocm/batch_matmul_mfma.py
@@ -19,7 +19,7 @@
 from __future__ import absolute_import as _abs
 from tvm import te
 import tvm.autotvm as autotvm
-from ..util import traverse_inline, get_const_tuple
+from ..utils import traverse_inline, get_const_tuple
 from .tensor_intrin import (
     intrin_mfma_load_matrix,
     intrin_mfma_store_matrix,

--- a/python/tvm/topi/rocm/batch_matmul_mfma.py
+++ b/python/tvm/topi/rocm/batch_matmul_mfma.py
@@ -17,10 +17,8 @@
 # pylint: disable=invalid-name, too-many-locals, too-many-statements, unused-argument
 """Compute and Schedule definition for dense tensorcore with cuda backend"""
 from __future__ import absolute_import as _abs
-import tvm
 from tvm import te
 import tvm.autotvm as autotvm
-from .. import tag
 from ..util import traverse_inline, get_const_tuple
 from .tensor_intrin import (
     intrin_mfma_load_matrix,
@@ -47,7 +45,7 @@ def batch_matmul_mfma(cfg, x, y, out_shape=None):
     output : tvm.te.Tensor
         3-D with shape [batch, M, N]
     """
-    batch, M, K = get_const_tuple(x.shape)
+    batch, M, _ = get_const_tuple(x.shape)
     _, N, _ = get_const_tuple(y.shape)
     if out_shape is not None:
         assert out_shape[0] == batch, "Input and output batch sizes must match"
@@ -98,7 +96,6 @@ def batch_matmul_mfma_rocm(A, B):
 def _schedule_batch_matmul_mfma(cfg, s, C):
     """Schedule batch_matmul operator using MFMA"""
     A, B = s[C].op.input_tensors
-    batch, M, N = get_const_tuple(C.shape)
 
     s[A].compute_inline()
     s[B].compute_inline()

--- a/python/tvm/topi/rocm/batch_matmul_mfma.py
+++ b/python/tvm/topi/rocm/batch_matmul_mfma.py
@@ -1,0 +1,259 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, too-many-locals, too-many-statements, unused-argument
+"""Compute and Schedule definition for dense tensorcore with cuda backend"""
+from __future__ import absolute_import as _abs
+import tvm
+from tvm import te
+import tvm.autotvm as autotvm
+from .. import tag
+from ..util import traverse_inline, get_const_tuple
+from .tensor_intrin import (
+    intrin_mfma_load_matrix,
+    intrin_mfma_store_matrix,
+    intrin_mfma_gemm,
+)
+
+@autotvm.register_topi_compute("batch_matmul_mfma.rocm")
+def batch_matmul_mfma(cfg, x, y, out_shape=None):
+    """Computes matrix multiplication of `x` and `y` when
+    `x` and `y` are batched matrices via Matrix FMA on ROCM.
+
+    Parameters
+    ----------
+    cfg : ConfigSpace
+        Autotvm tuning config
+    x : tvm.te.Tensor
+        3-D with shape [batch, M, K]
+    y : tvm.te.Tensor
+        3-D with shape [batch, N, K]
+    Returns
+    -------
+    output : tvm.te.Tensor
+        3-D with shape [batch, M, N]
+    """
+    batch, M, K = get_const_tuple(x.shape)
+    _, N, _ = get_const_tuple(y.shape)
+    if out_shape is not None:
+        assert out_shape[0] == batch, "Input and output batch sizes must match"
+        assert out_shape[1] == M and out_shape[2] == N, "Invalid output shape"
+    matmul = batch_matmul_mfma_rocm(x, y)
+    return matmul
+
+
+@autotvm.register_topi_schedule("batch_matmul_mfma.rocm")
+def schedule_batch_matmul_mfma(cfg, outs):
+    """Schedule batch_matmul operator using MFMA"""
+    outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
+    s = te.create_schedule([x.op for x in outs])
+
+    def _callback(op):
+        if op.tag == "batch_matmul_mfma":
+            _schedule_batch_matmul_mfma(cfg, s, op.output(0))
+
+    traverse_inline(s, outs[0].op, _callback)
+    return s
+
+
+def batch_matmul_mfma_rocm(A, B):
+    """Batch Matmul MFMA operator on ROCM"""
+    assert len(A.shape) == 3 and len(B.shape) == 3, "only support 3-dim batch_matmul"
+
+    batch, M, K = get_const_tuple(A.shape)
+    # B is transposed by default in relay
+    _, N, _ = get_const_tuple(B.shape)
+
+    assert (M % 16 == 0 and N % 16 == 0 and K % 16 == 0), "M, N, and K each must be a multiple of 16"
+    A_16 = te.compute((batch, M, K), lambda b, i, j: A[b, i, j].astype("float16"))
+    B_16 = te.compute((batch, N, K), lambda b, i, j: B[b, i, j].astype("float16"))
+
+    k = te.reduce_axis((0, K), name="k")
+    C = te.compute(
+        (batch, M, N),
+        lambda b, i, j: te.sum(
+            A_16[b, i, k].astype("float") * B_16[b, j, k].astype("float"), axis=[k]
+        ),
+        name="T_batch_matmul",
+        tag="batch_matmul_mfma",
+    )
+
+    return C
+
+
+def _schedule_batch_matmul_mfma(cfg, s, C):
+    """Schedule batch_matmul operator using MFMA"""
+    A, B = s[C].op.input_tensors
+    batch, M, N = get_const_tuple(C.shape)
+
+    s[A].compute_inline()
+    s[B].compute_inline()
+
+    # Explicit memory access
+    AS = s.cache_read(A, "shared", [C])
+    BS = s.cache_read(B, "shared", [C])
+    AF = s.cache_read(AS, "local", [C])
+    BF = s.cache_read(BS, "local", [C])
+    CF = s.cache_write(C, "local")
+    CS = s.cache_read(CF, "shared", [C])
+
+    # # Support op fusion
+    # if C.op not in s.outputs:
+    #     s[C].compute_inline()
+    #     C = s.outputs[0].output(0)
+
+    cfg.define_knob("block_row_warps", [1, 2, 4])
+    cfg.define_knob("block_col_warps", [1, 2, 4])
+    cfg.define_knob("warp_row_tiles", [1, 2, 4])
+    cfg.define_knob("warp_col_tiles", [1, 2, 4])
+    cfg.define_knob("chunk", [1, 2, 4, 8])
+    cfg.define_knob("offset", [0, 8])
+    cfg.define_knob("offsetCS", [0, 8])
+    cfg.define_knob("vec", [1, 2, 4, 8])
+
+    warp_size = 64
+    mfma_m = 16
+    mfma_n = 16
+    mfma_k = 16
+    block_row_warps = cfg["block_row_warps"].val
+    block_col_warps = cfg["block_col_warps"].val
+    warp_row_tiles = cfg["warp_row_tiles"].val
+    warp_col_tiles = cfg["warp_col_tiles"].val
+    chunk = cfg["chunk"].val
+    offset = cfg["offset"].val
+    offsetCS = cfg["offsetCS"].val
+    vec = cfg["vec"].val
+
+    # Define the stride for tensorization
+    AS_align = chunk * mfma_k + offset
+    BS_align = chunk * mfma_k + offset
+    CS_align = warp_col_tiles * block_col_warps * mfma_n + offsetCS
+    AS_stride = [AS_align, 1]
+    BS_stride = [BS_align, 1]
+    AF_stride = [mfma_k, 1]
+    BF_stride = [mfma_k, 1]
+    CF_stride = [warp_col_tiles * mfma_n, 1]
+    CS_stride = [CS_align, 1]
+
+    block_x = te.thread_axis("blockIdx.x")
+    block_y = te.thread_axis("blockIdx.y")
+    block_z = te.thread_axis("blockIdx.z")
+    thread_x = te.thread_axis("threadIdx.x")
+    thread_y = te.thread_axis("threadIdx.y")
+    thread_z = te.thread_axis("threadIdx.z")
+
+    # Schedule for batch_matmul computation
+    block_factor_row = mfma_m * warp_row_tiles * block_row_warps
+    block_factor_col = mfma_n * warp_col_tiles * block_col_warps
+    # b, o = C.op.axis
+    b, i, j = s[C].op.axis
+    block_i, i = s[C].split(i, factor=block_factor_row)
+    block_j, j = s[C].split(j, factor=block_factor_col)
+    s[C].reorder(block_i, block_j, i, j)
+    t = s[C].fuse(i, j)
+    t, vi = s[C].split(t, factor=vec)
+    t, tx = s[C].split(t, factor=warp_size)
+    t, ty = s[C].split(t, factor=block_row_warps)
+    t, tz = s[C].split(t, factor=block_col_warps)
+    s[C].bind(b, block_z)
+    s[C].bind(block_i, block_x)
+    s[C].bind(block_j, block_y)
+    s[C].bind(tz, thread_z)
+    s[C].bind(ty, thread_y)
+    s[C].bind(tx, thread_x)
+    s[C].vectorize(vi)
+
+    # Schedule for fragment store
+    s[CS].compute_at(s[C], block_j)
+    _, _m, _n = CS.op.axis
+    s[CS].storage_align(_m, CS_align - 1, CS_align)
+    _m, _mi = s[CS].split(_m, factor=mfma_m)
+    _n, _ni = s[CS].split(_n, factor=mfma_n)
+    _m, _mo = s[CS].split(_m, factor=warp_row_tiles)
+    _n, _no = s[CS].split(_n, factor=warp_col_tiles)
+    s[CS].reorder(_m, _n, _mo, _no, _mi, _ni)
+    # s[CS].compute_at(s[C], block_j)
+    # bb, oo = CS.op.axis
+    # s[CS].storage_align(bb, CS_align - 1, CS_align)
+    # bb, bbi = s[CS].split(bb, factor=mfma_m)
+    # oo, ooi = s[CS].split(oo, factor=mfma_n)
+    # bb, bbii = s[CS].split(bb, factor=warp_row_tiles)
+    # oo, ooii = s[CS].split(oo, factor=warp_col_tiles)
+    # s[CS].reorder(bb, oo, bbii, ooii, bbi, ooi)
+
+    # Schedule for gemm computation
+    s[CF].compute_at(s[CS], _n)
+    b, warp_i, warp_j = CF.op.axis
+    warp_i, _ii = s[CF].split(warp_i, factor=mfma_m)
+    warp_j, _jj = s[CF].split(warp_j, factor=mfma_n)
+    (k,) = CF.op.reduce_axis
+    k, _k = s[CF].split(k, factor=mfma_k)
+    ko, ki = s[CF].split(k, factor=chunk)
+    s[CF].reorder(ko, ki, warp_i, warp_j, _ii, _jj, _k)
+
+    # Schedule for tensorized matrix_A load
+    s[AF].compute_at(s[CF], ki)
+    _, _ma, _ka = AF.op.axis
+    _ma, _mai = s[AF].split(_ma, factor=mfma_m)
+    _ka, _kai = s[AF].split(_ka, factor=mfma_k)
+    s[AF].reorder(_ma, _ka, _mai, _kai)
+
+    # Schedule for tensorized matrix_B load
+    s[BF].compute_at(s[CF], ki)
+    _, _nb, _kb = BF.op.axis
+    _nb, _nbi = s[BF].split(_nb, factor=mfma_n)
+    _kb, _kbi = s[BF].split(_kb, factor=mfma_k)
+    s[BF].reorder(_nb, _kb, _nbi, _kbi)
+
+    # Schedule for A's(B's) shared memory load
+    def shared_shedule(stage, strides):
+        # New thread axes to avoid LLVM bug,
+        # llvm/lib/Transforms/Utils/LCSSA.cpp:380:
+        # bool llvm::formLCSSA(...): Assertion `L.isLCSSAForm(DT)' failed.`
+        thread_x = te.thread_axis("threadIdx.x")
+        thread_y = te.thread_axis("threadIdx.y")
+        thread_z = te.thread_axis("threadIdx.z")
+        s[stage].compute_at(s[CF], ko)
+        _, xo, yo = stage.op.axis
+        s[stage].storage_align(xo, strides - 1, strides)
+        t = s[stage].fuse(xo, yo)
+        t, vi = s[stage].split(t, factor=vec)
+        t, tx = s[stage].split(t, factor=warp_size)
+        t, ty = s[stage].split(t, factor=block_row_warps)
+        _, tz = s[stage].split(t, factor=block_col_warps)
+        s[stage].bind(ty, thread_y)
+        s[stage].bind(tz, thread_z)
+        s[stage].bind(tx, thread_x)
+        s[stage].vectorize(vi)
+
+    shared_shedule(AS, AS_align)
+    shared_shedule(BS, BS_align)
+
+    def mfma_compute(M, N, K):
+        A = te.placeholder((M, K), name="A", dtype="float16")
+        B = te.placeholder((K, N), name="B", dtype="float16")
+        k = te.reduce_axis((0, K), name="k")
+        return A, B, te.compute(
+            (M, N),
+            lambda i, j: te.sum(A[i, k].astype("float") * B[j, k].astype("float") , axis=[k]),
+            name="C"
+        )
+
+    # Lower the inner loop nest down to MFMA hardware intrinsics
+    s[AF].tensorize(_mai, intrin_mfma_load_matrix((mfma_m, mfma_n, mfma_k), "A", strides_src=AS_stride, strides_dst=AF_stride))
+    s[BF].tensorize(_nbi, intrin_mfma_load_matrix((mfma_m, mfma_n, mfma_k), "BT", strides_src=BS_stride, strides_dst=BF_stride))
+    s[CF].tensorize(_ii, intrin_mfma_gemm((mfma_m, mfma_n, mfma_k), mfma_compute, input_scope="local", strides_A=AF_stride, strides_B=BF_stride, strides_C=CF_stride))
+    s[CS].tensorize(_mi, intrin_mfma_store_matrix(shape=(mfma_m, mfma_n, mfma_k), strides_src=CF_stride, strides_dst=CS_stride))

--- a/python/tvm/topi/rocm/dense_mfma.py
+++ b/python/tvm/topi/rocm/dense_mfma.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import as _abs
 from tvm import te
 import tvm.autotvm as autotvm
 from .. import tag
-from ..util import traverse_inline, get_const_tuple
+from ..utils import traverse_inline, get_const_tuple
 from .tensor_intrin import (
     intrin_mfma_load_matrix,
     intrin_mfma_store_matrix,

--- a/python/tvm/topi/rocm/dense_mfma.py
+++ b/python/tvm/topi/rocm/dense_mfma.py
@@ -17,7 +17,6 @@
 # pylint: disable=invalid-name, too-many-locals, too-many-statements, unused-argument
 """Compute and Schedule definition for dense tensorcore with cuda backend"""
 from __future__ import absolute_import as _abs
-import tvm
 from tvm import te
 import tvm.autotvm as autotvm
 from .. import tag
@@ -85,8 +84,6 @@ def dense_mfma_rocm(data, weight, bias=None, out_dtype=None):
 def _schedule_dense_mfma(cfg, s, C):
     """Schedule dense operator using MFMA"""
     A, B = s[C].op.input_tensors
-    batch, out_dim = get_const_tuple(C.shape)
-    out_dtype = C.dtype
     s[A].compute_inline()
     s[B].compute_inline()
 

--- a/python/tvm/topi/rocm/dense_mfma.py
+++ b/python/tvm/topi/rocm/dense_mfma.py
@@ -1,0 +1,402 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, too-many-locals, too-many-statements, unused-argument
+"""Compute and Schedule definition for dense tensorcore with cuda backend"""
+from __future__ import absolute_import as _abs
+import tvm
+from tvm import te
+import tvm.autotvm as autotvm
+from .. import tag
+from ..util import traverse_inline, get_const_tuple
+
+@autotvm.register_topi_compute("dense_mfma.rocm")
+def dense_mfma(cfg, data, weight, bias=None, out_dtype=None):
+    """Dense MFMA operator on ROCM"""
+    matmul = dense_mfma_rocm(data, weight, bias, out_dtype)
+    return matmul
+
+
+@autotvm.register_topi_schedule("dense_mfma.rocm")
+def schedule_dense_mfma(cfg, outs):
+    """Schedule dense operator using MFMA"""
+    outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
+    s = te.create_schedule([x.op for x in outs])
+
+    def _callback(op):
+        if op.tag == "dense_mfma":
+            _schedule_dense_mfma(cfg, s, op.output(0))
+
+    traverse_inline(s, outs[0].op, _callback)
+    return s
+
+
+def dense_mfma_rocm(data, weight, bias=None, out_dtype=None):
+    """Dense MFMA operator on ROCM"""
+    assert len(data.shape) == 2 and len(weight.shape) == 2, "only support 2-dim dense"
+    if bias is not None:
+        assert len(bias.shape) == 1
+    if out_dtype is None:
+        out_dtype = data.dtype
+    batch, in_dim = get_const_tuple(data.shape)
+    out_dim, _ = get_const_tuple(weight.shape)
+    assert (batch % 16 == 0 and in_dim % 16 == 0 and out_dim % 16 == 0), "batch, in_dim, and out_dim each must be a multiple of 16"
+    k = te.reduce_axis((0, in_dim), name="k")
+    data_16 = te.compute((batch, in_dim), lambda b, i: data[b, i].astype("float16"))
+    weight_16 = te.compute((out_dim, in_dim), lambda o, i: weight[o, i].astype("float16"))
+    matmul = te.compute(
+        (batch, out_dim),
+        lambda i, j: te.sum(
+            data_16[i, k].astype(out_dtype) * weight_16[j, k].astype(out_dtype), axis=k
+        ),
+        name="T_dense",
+        tag="dense_mfma",
+    )
+    if bias is not None:
+        matmul = te.compute(
+            (batch, out_dim),
+            lambda i, j: matmul[i, j] + bias[j].astype(out_dtype),
+            tag=tag.BROADCAST,
+        )
+    return matmul
+
+
+def _schedule_dense_mfma(cfg, s, C):
+    """Schedule dense operator using MFMA"""
+    A, B = s[C].op.input_tensors
+    batch, out_dim = get_const_tuple(C.shape)
+    out_dtype = C.dtype
+    s[A].compute_inline()
+    s[B].compute_inline()
+
+    # Explicit memory access
+    AS = s.cache_read(A, "shared", [C])
+    BS = s.cache_read(B, "shared", [C])
+    AF = s.cache_read(AS, "local", [C])
+    BF = s.cache_read(BS, "local", [C])
+    CF = s.cache_write(C, "local")
+    CS = s.cache_read(CF, "shared", [C])
+
+    # fallback support
+    # target = tvm.target.Target.current()
+    # if cfg.is_fallback:
+    #     ref_log = autotvm.tophub.load_reference_log(
+    #         target.kind.name, target.model, "dense_mfma.rocm"
+    #     )
+    #     cfg.fallback_with_reference_log(ref_log)
+
+    # Deal with op fusion, such as bias and relu
+    if C.op not in s.outputs:
+        s[C].compute_inline()
+        C = s.outputs[0].output(0)
+
+    # create tuning space
+    cfg.define_knob("block_row_warps", [1, 2, 4])
+    cfg.define_knob("block_col_warps", [1, 2, 4])
+    cfg.define_knob("warp_row_tiles", [1, 2, 4])
+    cfg.define_knob("warp_col_tiles", [1, 2, 4])
+    cfg.define_knob("chunk", [1, 2, 4, 8])
+    cfg.define_knob("offset", [0, 8])
+    cfg.define_knob("offsetCS", [0, 8])
+    cfg.define_knob("vec", [1, 2, 4, 8])
+
+    warp_size = 64
+    wmma_m = 16
+    wmma_n = 16
+    wmma_k = 16
+    block_row_warps = cfg["block_row_warps"].val
+    block_col_warps = cfg["block_col_warps"].val
+    warp_row_tiles = cfg["warp_row_tiles"].val
+    warp_col_tiles = cfg["warp_col_tiles"].val
+    chunk = cfg["chunk"].val
+    offset = cfg["offset"].val
+    offsetCS = cfg["offsetCS"].val
+    vec = cfg["vec"].val
+
+    # Define the stride of intrin functions
+    AS_align = chunk * wmma_k + offset
+    BS_align = chunk * wmma_k + offset
+    CS_align = warp_col_tiles * block_col_warps * wmma_n + offsetCS
+    AS_stride = [AS_align, 1]
+    BS_stride = [BS_align, 1]
+    AF_stride = [wmma_k, 1]
+    BF_stride = [wmma_k, 1]
+    CF_stride = [warp_col_tiles * wmma_n, 1]
+    CS_stride = [CS_align, 1]
+
+    block_x = te.thread_axis("blockIdx.x")
+    block_y = te.thread_axis("blockIdx.y")
+    thread_x = te.thread_axis("threadIdx.x")
+    thread_y = te.thread_axis("threadIdx.y")
+    thread_z = te.thread_axis("threadIdx.z")
+
+    # Schedule for dense computation
+    block_factor_b = wmma_m * warp_row_tiles * block_row_warps
+    block_factor_o = wmma_n * warp_col_tiles * block_col_warps
+    b, o = C.op.axis
+    block_i, bc = s[C].split(b, factor=block_factor_b)
+    block_j, oc = s[C].split(o, factor=block_factor_o)
+    s[C].reorder(block_i, block_j, bc, oc)
+    t = s[C].fuse(bc, oc)
+    t, vi = s[C].split(t, factor=vec)
+    t, tx = s[C].split(t, factor=warp_size)
+    t, ty = s[C].split(t, factor=block_row_warps)
+    t, tz = s[C].split(t, factor=block_col_warps)
+    s[C].bind(block_i, block_x)
+    s[C].bind(block_j, block_y)
+    s[C].bind(tz, thread_z)
+    s[C].bind(ty, thread_y)
+    s[C].bind(tx, thread_x)
+    s[C].vectorize(vi)
+
+    # Schedule for wmma store
+    s[CS].compute_at(s[C], block_j)
+    bb, oo = CS.op.axis
+    s[CS].storage_align(bb, CS_align - 1, CS_align)
+    bb, bbi = s[CS].split(bb, factor=wmma_m)
+    oo, ooi = s[CS].split(oo, factor=wmma_n)
+    bb, bbii = s[CS].split(bb, factor=warp_row_tiles)
+    oo, ooii = s[CS].split(oo, factor=warp_col_tiles)
+    s[CS].reorder(bb, oo, bbii, ooii, bbi, ooi)
+
+    # Schedule for wmma computation
+    s[CF].compute_at(s[CS], oo)
+    warp_i, warp_j = CF.op.axis
+    warp_i, _ii = s[CF].split(warp_i, factor=wmma_m)
+    warp_j, _jj = s[CF].split(warp_j, factor=wmma_n)
+    (k,) = CF.op.reduce_axis
+    k, _k = s[CF].split(k, factor=wmma_k)
+    ko, ki = s[CF].split(k, factor=chunk)
+    s[CF].reorder(ko, ki, warp_i, warp_j, _ii, _jj, _k)
+
+    # Schedule for  wmma_matrix_a load
+    s[AF].compute_at(s[CF], ki)
+    b, i = AF.op.axis
+    b, b_ii = s[AF].split(b, factor=wmma_m)
+    i, i_jj = s[AF].split(i, factor=wmma_k)
+    s[AF].reorder(b, i, b_ii, i_jj)
+
+    # Schedule for  wmma_matrix_b load
+    s[BF].compute_at(s[CF], ki)
+    o, i = BF.op.axis
+    o, o_ii = s[BF].split(o, factor=wmma_n)
+    i, i_ii = s[BF].split(i, factor=wmma_k)
+    s[BF].reorder(o, i, o_ii, i_ii)
+
+    # Schedule for A's(B's) shared memory load
+    def shared_shedule(stage, strides):
+        thread_x = te.thread_axis("threadIdx.x")
+        thread_y = te.thread_axis("threadIdx.y")
+        thread_z = te.thread_axis("threadIdx.z")
+        s[stage].compute_at(s[CF], ko)
+        xo, yo = stage.op.axis
+        s[stage].storage_align(xo, strides - 1, strides)
+        t = s[stage].fuse(xo, yo)
+        t, vi = s[stage].split(t, factor=vec)
+        t, tx = s[stage].split(t, factor=warp_size)
+        t, ty = s[stage].split(t, factor=block_row_warps)
+        _, tz = s[stage].split(t, factor=block_col_warps)
+        s[stage].bind(ty, thread_y)
+        s[stage].bind(tz, thread_z)
+        s[stage].bind(tx, thread_x)
+        s[stage].vectorize(vi)
+
+    shared_shedule(AS, AS_align)
+    shared_shedule(BS, BS_align)
+
+
+    # shape = (wmma_m, wmma_n, wmma_k)
+    # in_dtype = "float16"
+    # AL_gemm = te.placeholder((wmma_m, wmma_k), name="AL_gemm", dtype=in_dtype)
+    # BL_gemm = te.placeholder((wmma_n, wmma_k), name="BL_gemm", dtype=in_dtype)
+    # k_gemm = te.reduce_axis((0, wmma_k), name="k_gemm")
+    # CL_compute = te.compute(
+    #     (wmma_m, wmma_n),
+    #     lambda ii, jj: te.sum(
+    #         AL_gemm[ii, k_gemm].astype(out_dtype) * BL_gemm[jj, k_gemm].astype(out_dtype),
+    #         axis=k_gemm,
+    #     ),
+    #     name="CL_compute",
+    # )
+
+    # lower the computation loops down to MFMA hardware intrinsics
+    # by mapping the dense MFMA to tensor intrinsics
+    s[AF].tensorize(b_ii, intrin_mfma_load_matrix((wmma_m, wmma_n, wmma_k), "A", strides_src=AS_stride, strides_dst=AF_stride))
+    s[BF].tensorize(o_ii, intrin_mfma_load_matrix((wmma_m, wmma_n, wmma_k), "A", strides_src=BS_stride, strides_dst=BF_stride))
+    s[CF].tensorize(_ii, intrin_mfma_gemm(shape=(wmma_m, wmma_n, wmma_k), dtype="float16", input_scope="local", strides_A=AF_stride, strides_B=BF_stride, strides_C=CF_stride))
+    s[CS].tensorize(bbi, intrin_mfma_store_matrix(shape=(wmma_m, wmma_n, wmma_k), strides_src=CF_stride, strides_dst=CS_stride))
+
+
+    # s[AF].tensorize(
+    #     b_ii,
+    #     intrin_wmma_load_matrix_A(
+    #         AF_stride, AS_stride, shape, "row_major", (wmma_m, wmma_k), (wmma_m, wmma_k), "float16"
+    #     ),
+    # )
+    # s[BF].tensorize(
+    #     o_ii,
+    #     intrin_wmma_load_matrix_W(
+    #         BF_stride, BS_stride, shape, "col_major", (wmma_n, wmma_k), (wmma_n, wmma_k), "float16"
+    #     ),
+    # )
+    # s[CF].tensorize(
+    #     _ii, intrin_wmma_gemm(AL_gemm, BL_gemm, CL_compute, AF_stride, BF_stride, CF_stride, shape)
+    # )
+    # s[CS].tensorize(
+    #     bbi,
+    #     intrin_wmma_store_matrix(
+    #         CS_stride, CF_stride, shape, out_dtype, (wmma_m, wmma_n), (wmma_m, wmma_n)
+    #     ),
+    # )
+
+def intrin_mfma_load_matrix(shape, matrix, thread=None, strides_src=None, strides_dst=None):
+    M, N, K = shape
+    if matrix == "A":
+        row, col = M, K
+    elif matrix == "B":
+        row, col = K, N
+    output_shape = (row, col)
+
+    A = te.placeholder(output_shape, name=matrix, dtype="float16")
+    BA = tvm.tir.decl_buffer(
+        A.shape, A.dtype, scope="shared", offset_factor=1, strides=strides_src
+    )
+
+    C = te.compute(output_shape, lambda i, j: A[i, j], name="C")
+
+    BC = tvm.tir.decl_buffer(
+        C.shape, C.dtype, scope="local", offset_factor=1, strides=strides_dst
+    )
+
+    def intrin_func(ins, outs):
+        ib = tvm.tir.ir_builder.create()
+
+        BA = ins[0]
+        BC = outs[0]
+
+        tx = thread
+        if tx == None:
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(tx, "thread_extent", 64)
+
+        blk_td = tx % 16
+        offset = tx // 16
+        # TODO(csullivan): Using offset works, but using tx directly does not, fix this
+        if matrix == "A":
+            for blk_id in range(0,4):
+                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_td, blk_id*4 + offset], "float16")))
+        elif matrix == "B":
+            for blk_id in range(0,4):
+                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_id*4 + offset, blk_td], "float16")))
+        return ib.get()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
+
+def intrin_mfma_store_matrix(shape, thread=None, strides_src=None, strides_dst=None):
+    M, N, K = shape
+    A = te.placeholder((M, N), name="A", dtype="float32")
+    BA = tvm.tir.decl_buffer(
+        A.shape, A.dtype, scope="local", offset_factor=1, strides=strides_src
+    )
+    C = te.compute((M, N), lambda i, j: A[i, j], name="C")
+    BC = tvm.tir.decl_buffer(
+        C.shape, C.dtype, scope="shared", offset_factor=1, strides=strides_dst
+    )
+
+    def intrin_func(ins, outs):
+        ib = tvm.tir.ir_builder.create()
+        BA = ins[0]
+        BC = outs[0]
+        tx = thread
+        if tx == None:
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(tx, "thread_extent", 64)
+        vec_width = 4
+        blk_id = tx // 16
+        blk_td = tx % 16
+
+        # TODO(csullivan): Consider TVM change to BufferVar.__getitem__
+        # to convert int to const for quality of life when using vector types.
+        ib.emit(BC.vstore([blk_td, blk_id*vec_width], BA.vload([0, 0], "float32x4")))
+
+        return ib.get()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
+
+def intrin_mfma_gemm(shape, dtype, input_scope, strides_A=None, strides_B=None, strides_C=None):
+    M, N, K = shape
+
+    # TODO(csullivan):Replace below with a function to get the correct
+    # llvm function based on shape and type
+    assert M == 16
+    assert N == 16
+    assert K == 16
+    mfma_instr_name = "llvm.amdgcn.mfma.f32.16x16x16f16"
+    llvm_id = tvm.target.codegen.llvm_lookup_intrinsic_id(mfma_instr_name)
+    assert llvm_id != 0
+
+    A = te.placeholder((M, K), name="A", dtype="float16")
+    B = te.placeholder((K, N), name="B", dtype="float16")
+    k = te.reduce_axis((0, K), name="k")
+    C = te.compute(
+        (M, N),
+        lambda i, j: te.sum(A[i, k].astype("float") * B[j, k].astype("float") , axis=[k]),
+        name="C"
+    )
+
+    Ab = tvm.tir.decl_buffer(
+        A.shape, A.dtype, name="Ab", scope=input_scope, offset_factor=1, strides=strides_A
+    )
+    Bb = tvm.tir.decl_buffer(
+        B.shape, B.dtype, name="Bb", scope=input_scope, offset_factor=1, strides=strides_B
+    )
+    Cb = tvm.tir.decl_buffer(
+        C.shape, C.dtype, name="Cb", scope="local", offset_factor=1, strides=strides_C
+    )
+
+    def intrin_func(ins, outs):
+        Ab, Bb = ins
+        (Cb,) = outs
+
+        def init():
+            ib = tvm.tir.ir_builder.create()
+            ib.emit(Cb.vstore([0, 0], tvm.tir.const(0, "float32x4")))
+            return ib.get()
+
+        def update():
+            # Each thread is responsible for 4 values along the reduction axis for a single (m, n) pixel
+            ib = tvm.tir.ir_builder.create()
+            a_vec = Ab.vload([0, 0], "float16x4")
+            b_vec = Bb.vload([0, 0], "float16x4")
+            c_vec = Cb.vload([0, 0], "float32x4")
+            args_6 = tvm.tir.const(6, "uint32")
+            # Transpose inputs (equivalent to switching the order in this packed layout)
+            # in order to ensure row-major order on the output with coalesced vector writes.
+            gemm = tvm.tir.call_llvm_pure_intrin(
+                "float32x4",
+                mfma_instr_name,
+                args_6,
+                b_vec,
+                a_vec,
+                c_vec,
+                0,0,0
+            )
+            ib.emit(Cb.vstore([0, 0], gemm))
+            return ib.get()
+
+        return update(), init(), update()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: Ab, B: Bb, C: Cb})

--- a/python/tvm/topi/rocm/dense_mfma.py
+++ b/python/tvm/topi/rocm/dense_mfma.py
@@ -22,6 +22,11 @@ from tvm import te
 import tvm.autotvm as autotvm
 from .. import tag
 from ..util import traverse_inline, get_const_tuple
+from .tensor_intrin import (
+    intrin_mfma_load_matrix,
+    intrin_mfma_store_matrix,
+    intrin_mfma_gemm,
+)
 
 @autotvm.register_topi_compute("dense_mfma.rocm")
 def dense_mfma(cfg, data, weight, bias=None, out_dtype=None):
@@ -211,146 +216,18 @@ def _schedule_dense_mfma(cfg, s, C):
     shared_shedule(AS, AS_align)
     shared_shedule(BS, BS_align)
 
+    def mfma_compute(M, N, K):
+        A = te.placeholder((M, K), name="A", dtype="float16")
+        B = te.placeholder((K, N), name="B", dtype="float16")
+        k = te.reduce_axis((0, K), name="k")
+        return A, B, te.compute(
+            (M, N),
+            lambda i, j: te.sum(A[i, k].astype("float") * B[j, k].astype("float") , axis=[k]),
+            name="C"
+        )
+
     # Lower the inner loop nest down to MFMA hardware intrinsics
     s[AF].tensorize(b_ii, intrin_mfma_load_matrix((mfma_m, mfma_n, mfma_k), "A", strides_src=AS_stride, strides_dst=AF_stride))
-    s[BF].tensorize(o_ii, intrin_mfma_load_matrix((mfma_m, mfma_n, mfma_k), "A", strides_src=BS_stride, strides_dst=BF_stride))
-    s[CF].tensorize(_ii, intrin_mfma_gemm(shape=(mfma_m, mfma_n, mfma_k), dtype="float16", input_scope="local", strides_A=AF_stride, strides_B=BF_stride, strides_C=CF_stride))
+    s[BF].tensorize(o_ii, intrin_mfma_load_matrix((mfma_m, mfma_n, mfma_k), "W", strides_src=BS_stride, strides_dst=BF_stride))
+    s[CF].tensorize(_ii, intrin_mfma_gemm((mfma_m, mfma_n, mfma_k), mfma_compute, input_scope="local", strides_A=AF_stride, strides_B=BF_stride, strides_C=CF_stride))
     s[CS].tensorize(bbi, intrin_mfma_store_matrix(shape=(mfma_m, mfma_n, mfma_k), strides_src=CF_stride, strides_dst=CS_stride))
-
-def intrin_mfma_load_matrix(shape, matrix, thread=None, strides_src=None, strides_dst=None):
-    M, N, K = shape
-    if matrix == "A":
-        row, col = M, K
-    elif matrix == "B":
-        row, col = K, N
-    output_shape = (row, col)
-
-    A = te.placeholder(output_shape, name=matrix, dtype="float16")
-    BA = tvm.tir.decl_buffer(
-        A.shape, A.dtype, scope="shared", offset_factor=1, strides=strides_src
-    )
-
-    C = te.compute(output_shape, lambda i, j: A[i, j], name="C")
-
-    BC = tvm.tir.decl_buffer(
-        C.shape, C.dtype, scope="local", offset_factor=1, strides=strides_dst
-    )
-
-    def intrin_func(ins, outs):
-        ib = tvm.tir.ir_builder.create()
-
-        BA = ins[0]
-        BC = outs[0]
-
-        tx = thread
-        if tx == None:
-            tx = te.thread_axis("threadIdx.x")
-            ib.scope_attr(tx, "thread_extent", 64)
-
-        blk_td = tx % 16
-        offset = tx // 16
-        # TODO(csullivan): Using offset works, but using tx directly does not, fix this
-        if matrix == "A":
-            for blk_id in range(0,4):
-                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_td, blk_id*4 + offset], "float16")))
-        elif matrix == "B":
-            for blk_id in range(0,4):
-                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_id*4 + offset, blk_td], "float16")))
-        return ib.get()
-
-    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
-
-def intrin_mfma_store_matrix(shape, thread=None, strides_src=None, strides_dst=None):
-    M, N, K = shape
-    A = te.placeholder((M, N), name="A", dtype="float32")
-    BA = tvm.tir.decl_buffer(
-        A.shape, A.dtype, scope="local", offset_factor=1, strides=strides_src
-    )
-    C = te.compute((M, N), lambda i, j: A[i, j], name="C")
-    BC = tvm.tir.decl_buffer(
-        C.shape, C.dtype, scope="shared", offset_factor=1, strides=strides_dst
-    )
-
-    def intrin_func(ins, outs):
-        ib = tvm.tir.ir_builder.create()
-        BA = ins[0]
-        BC = outs[0]
-        tx = thread
-        if tx == None:
-            tx = te.thread_axis("threadIdx.x")
-            ib.scope_attr(tx, "thread_extent", 64)
-        vec_width = 4
-        blk_id = tx // 16
-        blk_td = tx % 16
-
-        # TODO(csullivan): Consider TVM change to BufferVar.__getitem__
-        # to convert int to const for quality of life when using vector types.
-        ib.emit(BC.vstore([blk_td, blk_id*vec_width], BA.vload([0, 0], "float32x4")))
-
-        return ib.get()
-
-    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
-
-def intrin_mfma_gemm(shape, dtype, input_scope, strides_A=None, strides_B=None, strides_C=None):
-    M, N, K = shape
-
-    # TODO(csullivan):Replace below with a function to get the correct
-    # llvm function based on shape and type
-    assert M == 16
-    assert N == 16
-    assert K == 16
-    mfma_instr_name = "llvm.amdgcn.mfma.f32.16x16x16f16"
-    llvm_id = tvm.target.codegen.llvm_lookup_intrinsic_id(mfma_instr_name)
-    assert llvm_id != 0
-
-    A = te.placeholder((M, K), name="A", dtype="float16")
-    B = te.placeholder((K, N), name="B", dtype="float16")
-    k = te.reduce_axis((0, K), name="k")
-    C = te.compute(
-        (M, N),
-        lambda i, j: te.sum(A[i, k].astype("float") * B[j, k].astype("float") , axis=[k]),
-        name="C"
-    )
-
-    Ab = tvm.tir.decl_buffer(
-        A.shape, A.dtype, name="Ab", scope=input_scope, offset_factor=1, strides=strides_A
-    )
-    Bb = tvm.tir.decl_buffer(
-        B.shape, B.dtype, name="Bb", scope=input_scope, offset_factor=1, strides=strides_B
-    )
-    Cb = tvm.tir.decl_buffer(
-        C.shape, C.dtype, name="Cb", scope="local", offset_factor=1, strides=strides_C
-    )
-
-    def intrin_func(ins, outs):
-        Ab, Bb = ins
-        (Cb,) = outs
-
-        def init():
-            ib = tvm.tir.ir_builder.create()
-            ib.emit(Cb.vstore([0, 0], tvm.tir.const(0, "float32x4")))
-            return ib.get()
-
-        def update():
-            ib = tvm.tir.ir_builder.create()
-            a_vec = Ab.vload([0, 0], "float16x4")
-            b_vec = Bb.vload([0, 0], "float16x4")
-            c_vec = Cb.vload([0, 0], "float32x4")
-            args_6 = tvm.tir.const(6, "uint32")
-            # Transpose inputs in order to ensure row-major order on the output for
-            # coalesced vector writes.
-            gemm = tvm.tir.call_llvm_pure_intrin(
-                "float32x4",
-                mfma_instr_name,
-                args_6,
-                b_vec,
-                a_vec,
-                c_vec,
-                0,0,0
-            )
-            ib.emit(Cb.vstore([0, 0], gemm))
-            return ib.get()
-
-        return update(), init(), update()
-
-    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: Ab, B: Bb, C: Cb})

--- a/python/tvm/topi/rocm/tensor_intrin.py
+++ b/python/tvm/topi/rocm/tensor_intrin.py
@@ -22,7 +22,7 @@ from tvm import te
 
 def intrin_mfma_load_matrix(shape, matrix, thread=None, strides_src=None, strides_dst=None):
     M, N, K = shape
-    if matrix in ("A", "W"):
+    if matrix in ("A", "BT", "W"):
         row, col = M, K
     elif matrix == "B":
         row, col = K, N
@@ -53,7 +53,7 @@ def intrin_mfma_load_matrix(shape, matrix, thread=None, strides_src=None, stride
         blk_td = tx % 16
         offset = tx // 16
         # TODO(csullivan): Using offset works, but using tx directly does not, fix this
-        if matrix in ("A", "W"):
+        if matrix in ("A", "BT", "W"):
             for blk_id in range(0,4):
                 ib.emit(BC.vstore([0, blk_id], BA.vload([blk_td, blk_id*4 + offset], "float16")))
         elif matrix == "B":

--- a/python/tvm/topi/rocm/tensor_intrin.py
+++ b/python/tvm/topi/rocm/tensor_intrin.py
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unnecessary-lambda, too-many-arguments
+"""MFMA Tensor intrinsics for GFX908."""
+import tvm
+from tvm import te
+
+
+def intrin_mfma_load_matrix(shape, matrix, thread=None, strides_src=None, strides_dst=None):
+    M, N, K = shape
+    if matrix in ("A", "W"):
+        row, col = M, K
+    elif matrix == "B":
+        row, col = K, N
+    output_shape = (row, col)
+
+    A = te.placeholder(output_shape, name=matrix, dtype="float16")
+    BA = tvm.tir.decl_buffer(
+        A.shape, A.dtype, scope="shared", offset_factor=1, strides=strides_src
+    )
+
+    C = te.compute(output_shape, lambda i, j: A[i, j], name="C")
+
+    BC = tvm.tir.decl_buffer(
+        C.shape, C.dtype, scope="local", offset_factor=1, strides=strides_dst
+    )
+
+    def intrin_func(ins, outs):
+        ib = tvm.tir.ir_builder.create()
+
+        BA = ins[0]
+        BC = outs[0]
+
+        tx = thread
+        if tx == None:
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(tx, "thread_extent", 64)
+
+        blk_td = tx % 16
+        offset = tx // 16
+        # TODO(csullivan): Using offset works, but using tx directly does not, fix this
+        if matrix in ("A", "W"):
+            for blk_id in range(0,4):
+                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_td, blk_id*4 + offset], "float16")))
+        elif matrix == "B":
+            for blk_id in range(0,4):
+                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_id*4 + offset, blk_td], "float16")))
+        return ib.get()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
+
+def intrin_mfma_store_matrix(shape, thread=None, strides_src=None, strides_dst=None):
+    M, N, K = shape
+    A = te.placeholder((M, N), name="A", dtype="float32")
+    BA = tvm.tir.decl_buffer(
+        A.shape, A.dtype, scope="local", offset_factor=1, strides=strides_src
+    )
+    C = te.compute((M, N), lambda i, j: A[i, j], name="C")
+    BC = tvm.tir.decl_buffer(
+        C.shape, C.dtype, scope="shared", offset_factor=1, strides=strides_dst
+    )
+
+    def intrin_func(ins, outs):
+        ib = tvm.tir.ir_builder.create()
+        BA = ins[0]
+        BC = outs[0]
+        tx = thread
+        if tx == None:
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(tx, "thread_extent", 64)
+        vec_width = 4
+        blk_id = tx // 16
+        blk_td = tx % 16
+
+        # TODO(csullivan): Consider TVM change to BufferVar.__getitem__
+        # to convert int to const for quality of life when using vector types.
+        ib.emit(BC.vstore([blk_td, blk_id*vec_width], BA.vload([0, 0], "float32x4")))
+
+        return ib.get()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
+
+def intrin_mfma_gemm(shape, te_mfma_compute, input_scope, strides_A=None, strides_B=None, strides_C=None):
+    M, N, K = shape
+
+    # TODO(csullivan):Replace below with a function to get the correct
+    # llvm function based on shape and type
+    assert M == 16
+    assert N == 16
+    assert K == 16
+    mfma_instr_name = "llvm.amdgcn.mfma.f32.16x16x16f16"
+    llvm_id = tvm.target.codegen.llvm_lookup_intrinsic_id(mfma_instr_name)
+    assert llvm_id != 0
+
+    A, B, C = te_mfma_compute(*shape)
+
+    Ab = tvm.tir.decl_buffer(
+        A.shape, A.dtype, name="Ab", scope=input_scope, offset_factor=1, strides=strides_A
+    )
+    Bb = tvm.tir.decl_buffer(
+        B.shape, B.dtype, name="Bb", scope=input_scope, offset_factor=1, strides=strides_B
+    )
+    Cb = tvm.tir.decl_buffer(
+        C.shape, C.dtype, name="Cb", scope="local", offset_factor=1, strides=strides_C
+    )
+
+    def intrin_func(ins, outs):
+        Ab, Bb = ins
+        (Cb,) = outs
+
+        def init():
+            ib = tvm.tir.ir_builder.create()
+            ib.emit(Cb.vstore([0, 0], tvm.tir.const(0, "float32x4")))
+            return ib.get()
+
+        def update():
+            ib = tvm.tir.ir_builder.create()
+            a_vec = Ab.vload([0, 0], "float16x4")
+            b_vec = Bb.vload([0, 0], "float16x4")
+            c_vec = Cb.vload([0, 0], "float32x4")
+            args_6 = tvm.tir.const(6, "uint32")
+            # Transpose inputs in order to ensure row-major order on the output for
+            # coalesced vector writes.
+            gemm = tvm.tir.call_llvm_pure_intrin(
+                "float32x4",
+                mfma_instr_name,
+                args_6,
+                b_vec,
+                a_vec,
+                c_vec,
+                0,0,0
+            )
+            ib.emit(Cb.vstore([0, 0], gemm))
+            return ib.get()
+
+        return update(), init(), update()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: Ab, B: Bb, C: Cb})

--- a/tests/python/unittest/test_amd_xdlops.py
+++ b/tests/python/unittest/test_amd_xdlops.py
@@ -1,0 +1,289 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# 'License'); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import tvm.testing
+from tvm import te
+import numpy as np
+from tvm import relay
+
+
+def intrin_mfma_load_matrix(shape, matrix, thread=None, strides=None):
+    M, N, K = shape
+    if matrix == "A":
+        row, col = M, K
+        src_strides, dst_strides = strides, None
+    elif matrix == "B":
+        row, col = K, N
+        src_strides, dst_strides = strides, None
+    output_shape = (row, col)
+
+    A = te.placeholder(output_shape, name=matrix, dtype="float16")
+    BA = tvm.tir.decl_buffer(A.shape, A.dtype, scope="global", offset_factor=1, strides=src_strides)
+
+    C = te.compute(output_shape, lambda i, j: A[i, j], name="C")
+
+    BC = tvm.tir.decl_buffer(C.shape, C.dtype, scope="local", offset_factor=1, strides=dst_strides)
+
+    def intrin_func(ins, outs):
+        ib = tvm.tir.ir_builder.create()
+
+        BA = ins[0]
+        BC = outs[0]
+
+        tx = thread
+        if tx == None:
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(tx, "thread_extent", 64)
+
+        blk_td = tx % 16
+        offset = tx // 16
+        # TODO(csullivan): Using offset works, but using tx directly does not, fix this
+        if matrix == "A":
+            for blk_id in range(0, 4):
+                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_td, blk_id * 4 + offset], "float16")))
+        elif matrix == "B":
+            for blk_id in range(0, 4):
+                ib.emit(BC.vstore([0, blk_id], BA.vload([blk_id * 4 + offset, blk_td], "float16")))
+        return ib.get()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
+
+
+def intrin_mfma_store_matrix(shape, thread=None, strides=None):
+    M, N, K = shape
+    A = te.placeholder((M, N), name="A", dtype="float32")
+    BA = tvm.tir.decl_buffer(A.shape, A.dtype, scope="local", offset_factor=1)
+    C = te.compute((M, N), lambda i, j: A[i, j], name="C")
+    BC = tvm.tir.decl_buffer(C.shape, C.dtype, scope="global", offset_factor=1, strides=strides)
+
+    def intrin_func(ins, outs):
+        ib = tvm.tir.ir_builder.create()
+        BA = ins[0]
+        BC = outs[0]
+        tx = thread
+        if tx == None:
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(tx, "thread_extent", 64)
+        vec_width = 4
+        blk_id = tx // 16
+        blk_td = tx % 16
+
+        # TODO(csullivan): Consider TVM change to BufferVar.__getitem__
+        # to convert int to const for quality of life when using vector types.
+        ib.emit(BC.vstore([blk_td, blk_id * vec_width], BA.vload([0, 0], "float32x4")))
+
+        return ib.get()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: BA, C: BC})
+
+
+def intrin_mfma_gemm(shape, dtype, input_scope):
+    M, N, K = shape
+
+    # TODO(csullivan):Replace below with a function to get the correct
+    # llvm function based on shape and type
+    assert M == 16
+    assert N == 16
+    assert K == 16
+    mfma_instr_name = "llvm.amdgcn.mfma.f32.16x16x16f16"
+    llvm_id = tvm.target.codegen.llvm_lookup_intrinsic_id(mfma_instr_name)
+    assert llvm_id != 0
+
+    A = te.placeholder((M, K), name="A", dtype="float16")
+    B = te.placeholder((K, N), name="B", dtype="float16")
+    k = te.reduce_axis((0, K), name="k")
+    C = te.compute(
+        (M, N),
+        lambda i, j: te.sum(A[i, k].astype("float") * B[k, j].astype("float"), axis=[k]),
+        name="C",
+    )
+
+    Ab = tvm.tir.decl_buffer(A.shape, A.dtype, name="Ab", scope=input_scope, offset_factor=1)
+    Bb = tvm.tir.decl_buffer(B.shape, B.dtype, name="Bb", scope=input_scope, offset_factor=1)
+    Cb = tvm.tir.decl_buffer(C.shape, C.dtype, name="Cb", scope="local")
+
+    def intrin_func(ins, outs):
+        Ab, Bb = ins
+        (Cb,) = outs
+
+        def init():
+            ib = tvm.tir.ir_builder.create()
+            ib.emit(Cb.vstore([0, 0], tvm.tir.const(0, "float32x4")))
+            return ib.get()
+
+        def update():
+            # Each thread is responsible for 4 values along the reduction axis for a single (m, n) pixel
+            ib = tvm.tir.ir_builder.create()
+            a_vec = Ab.vload([0, 0], "float16x4")
+            b_vec = Bb.vload([0, 0], "float16x4")
+            c_vec = Cb.vload([0, 0], "float32x4")
+            args_6 = tvm.tir.const(6, "uint32")
+            # Transpose inputs (equivalent to switching the order in this packed layout)
+            # in order to ensure row-major order on the output with coalesced vector writes.
+            gemm = tvm.tir.call_llvm_pure_intrin(
+                "float32x4", mfma_instr_name, args_6, b_vec, a_vec, c_vec, 0, 0, 0
+            )
+            ib.emit(Cb.vstore([0, 0], gemm))
+            return ib.get()
+
+        return update(), init(), update()
+
+    return te.decl_tensor_intrin(C.op, intrin_func, binds={A: Ab, B: Bb, C: Cb})
+
+
+def schedule(s, A, B, C):
+    warp_size = 64
+    block_row_warps = 2
+    block_col_warps = 4
+    warp_row_tiles = 16
+    warp_col_tiles = 16
+    chunk = 4
+
+    block_x = te.thread_axis("blockIdx.x")
+    block_y = te.thread_axis("blockIdx.y")
+    block_z = te.thread_axis("blockIdx.z")
+    thread_x = te.thread_axis("threadIdx.x")
+
+    AF = s.cache_read(A, "local", [C])
+    BF = s.cache_read(B, "local", [C])
+    CF = s.cache_write(C, "local")
+
+    b, i, j = s[C].op.axis
+    i, ii = s[C].split(i, factor=warp_row_tiles)
+    block_i, i = s[C].split(i, factor=block_row_warps)
+    j, jj = s[C].split(j, factor=warp_col_tiles)
+    block_j, j = s[C].split(j, factor=block_col_warps)
+    s[C].reorder(block_i, block_j, i, j, ii, jj)
+    s[C].bind(b, block_z)
+    s[C].bind(block_i, block_x)
+    s[C].bind(block_j, block_y)
+
+    s[CF].compute_at(s[C], j)
+    b, _i, _j = s[CF].op.axis
+    (_k,) = s[CF].op.reduce_axis
+    _ko, _ki = s[CF].split(_k, factor=warp_col_tiles)
+    s[CF].reorder(_ko, _i, _j, _ki)
+
+    s[AF].compute_at(s[CF], _ko)
+    ba, _m, _ka = AF.op.axis
+    _kao, _kai = s[AF].split(_ka, factor=warp_col_tiles)
+    s[AF].reorder(ba, _kao, _m, _kai)
+
+    s[BF].compute_at(s[CF], _ko)
+    bb, _kb, _n = BF.op.axis
+    _kbo, _kbi = s[BF].split(_kb, factor=warp_row_tiles)
+    s[BF].reorder(bb, _kbo, _n, _kbi)
+
+    s[AF].tensorize(_m, intrin_mfma_load_matrix((16, 16, 16), "A", strides=(A.shape[2], 1)))
+    s[BF].tensorize(_n, intrin_mfma_load_matrix((16, 16, 16), "B", strides=(B.shape[2], 1)))
+    s[CF].tensorize(_i, intrin_mfma_gemm(shape=(16, 16, 16), dtype="float16", input_scope="local"))
+    s[C].tensorize(ii, intrin_mfma_store_matrix(shape=(16, 16, 16), strides=(B.shape[2], 1)))
+
+    return s
+
+
+def test_amd_xdlops_tensorization_explicit_schedule(target="rocm -mcpu=gfx908"):
+    batch_size, m, n, k = 32, 32, 32, 32
+    assert m % 16 == 0
+    assert n % 16 == 0
+    assert k % 16 == 0
+    mm, nn, kk = m, n, k
+    A = te.placeholder((batch_size, mm, kk), name="A", dtype="float16")
+    B = te.placeholder((batch_size, kk, nn), name="B", dtype="float16")
+    k1 = te.reduce_axis((0, kk), name="k1")
+    C = te.compute(
+        (batch_size, mm, nn),
+        lambda b, i, j: te.sum(
+            A[b, i, k1].astype("float") * B[b, k1, j].astype("float"), axis=[k1]
+        ),
+        name="Fragment_C",
+    )
+    s = te.create_schedule(C.op)
+    s = schedule(s, A, B, C)
+
+    func = tvm.build(s, [A, B, C], target, name="intrinsic")
+    dev = tvm.rocm(0)
+    a_np = np.random.uniform(size=(batch_size, mm, kk)).astype(A.dtype)
+    b_np = np.random.uniform(size=(batch_size, kk, nn)).astype(B.dtype)
+    a = tvm.nd.array(a_np, dev)
+    b = tvm.nd.array(b_np, dev)
+    c = tvm.nd.array(np.zeros((batch_size, mm, nn), dtype=C.dtype), dev)
+    func(a, b, c)
+    evaluator = func.time_evaluator(func.entry_name, dev, number=3)
+
+    func(a, b, c)
+    c_np = c.asnumpy()
+    np_result = np.matmul(a_np.astype(C.dtype), b_np.astype(C.dtype))
+    np.testing.assert_allclose(c_np, np_result, rtol=1e-4, atol=1e-4)
+
+
+def run_relay_func(func, inputs, target):
+    with tvm.transform.PassContext(opt_level=3):
+        graph, lib, params = relay.build(func, target)
+
+    from tvm.contrib import graph_executor
+
+    dev = tvm.rocm(0)
+    m = graph_executor.create(graph, lib, dev)
+    for (name, data) in inputs.items():
+        m.set_input(name, tvm.nd.array(data))
+
+    m.run()
+    tvm_output = m.get_output(0)
+    return tvm_output.asnumpy()
+
+
+def test_amd_xdlops_tensorization_batch_matmul(target):
+    batch_size, m, n, k = 32, 32, 32, 32
+    A = relay.var("A", shape=(batch_size, m, k), dtype="float32")
+    B = relay.var("B", shape=(batch_size, n, k), dtype="float32")
+    C = relay.nn.batch_matmul(A, B)
+    f = relay.Function(relay.analysis.free_vars(C), C)
+    a_np = np.random.uniform(size=(batch_size, m, k)).astype("float32")
+    b_np = np.random.uniform(size=(batch_size, n, k)).astype("float32")
+
+    c_np = run_relay_func(f, {"A": a_np, "B": b_np}, target)
+    np_result = np.matmul(a_np.astype("float16"), b_np.transpose((0, 2, 1)).astype("float16"))
+    np.testing.assert_allclose(c_np, np_result, rtol=1e-3, atol=1e-3)
+
+
+def test_amd_xdlops_tensorization_dense(target):
+    batch, inp, out = 32, 32, 32
+    A = relay.var("A", shape=(batch, inp), dtype="float32")
+    B = relay.var("B", shape=(out, inp), dtype="float32")
+    C = relay.nn.dense(A, B)
+    f = relay.Function(relay.analysis.free_vars(C), C)
+    a_np = np.random.uniform(size=(batch, inp)).astype("float32")
+    b_np = np.random.uniform(size=(out, inp)).astype("float32")
+
+    c_np = run_relay_func(f, {"A": a_np, "B": b_np}, target)
+    np_result = np.matmul(a_np.astype("float16"), b_np.transpose((1, 0)).astype("float16"))
+    np.testing.assert_allclose(c_np, np_result, rtol=1e-3, atol=1e-3)
+
+
+def test_amd_xdlops():
+    target = "rocm -mcpu=gfx908"
+    if not tvm.testing.device_enabled(target):
+        print("skip because %s is not enabled.." % target)
+        return
+    test_amd_xdlops_tensorization_explicit_schedule(target=target)
+    test_amd_xdlops_tensorization_batch_matmul(target=target)
+    test_amd_xdlops_tensorization_dense(target=target)
+
+
+if __name__ == "__main__":
+    test_amd_xdlops()


### PR DESCRIPTION
This PR adds TOPI schedules for dense and batch matmul that target the AMDGCN XDLOP `llvm.amdgcn.mfma.f32.16x16x16f16` which performs M=N=K=16 matrix compute.