### PR TITLE
[EZ] [Typo] Add a missing override

### DIFF
--- a/src/relay/transforms/fake_quantization_to_integer.cc
+++ b/src/relay/transforms/fake_quantization_to_integer.cc
@@ -146,7 +146,7 @@ class SubgraphExtractor : public ExprVisitor {
     return subgraph;
   }
   const AffineTypeMap GetAffineTypes() { return affine_types_; }
-  void VisitExpr(const Expr& expr) {
+  void VisitExpr(const Expr& expr) override {
     if (expr.as<CallNode>() == nullptr && expr.as<OpNode>() == nullptr &&
         expr.as<TupleNode>() == nullptr) {
       is_fake_quantized_ = false;


### PR DESCRIPTION
Without this, the compiler generates a warning.

cc @mbrookhart 