### PR TITLE
[µTVM] Zephyr: Fix missing board-specific config file in build dir

### DIFF
--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -172,6 +172,17 @@ class ZephyrCompiler(tvm.micro.Compiler):
             project_dir_conf = os.path.join(self._project_dir, "prj.conf")
             if os.path.exists(project_dir_conf):
                 shutil.copy(project_dir_conf, lib_prj_conf)
+
+            # Copy board-specific Zephyr config file from the project_dir to
+            # the build lib dir so board-specific configs can be found and used by
+            # Zephyr's build system in conjunction with the generic prj.conf configs.
+            board_conf = os.path.join("boards", self._board + ".conf")
+            project_dir_board_conf = os.path.join(self._project_dir, board_conf)
+            if os.path.exists(project_dir_board_conf):
+                os.mkdir(os.path.join(output, "boards"))
+                lib_dir_board_conf = os.path.join(output, board_conf)
+                shutil.copy(project_dir_board_conf, lib_dir_board_conf)
+
         else:
             with open(lib_prj_conf, "w") as prj_conf_f:
                 prj_conf_f.write("CONFIG_CPLUSPLUS=y\n")


### PR DESCRIPTION
Hi,

Could the following small change be reviewed please?

It's necessary to make the build of the libraries (`common`, `utvm_rpc_common`, `utvm_rpc_server`, etc) be aware of board-specific config settings, like per board `CONFIG_FPU` (since some boards, like mps2, don't have a FPU and currently it's set globally in `prj.conf`). It's also necessary to move forward the following PR:
https://github.com/apache/tvm/pull/8055

Without that change, for instance, even if `CONFIG_FPU=y` is set in the board config file (like `boards/qemu_x86.conf`) the libraries are built against soft-float because `CONFIG_FPU=y` doesn't take effect and so running some models that rely on float point will fail.

This happens because currently board-specific config files (boards/*.conf) are not
copied from Zephyr project dir to the destination build dir, so
as a consequence the per board configs are not used when building
the runtime libraries, like libcommon. Hence, for instance, it's
currently not possible to set CONFIG_FPU per board since it only
takes effect when it's set in the generic 'prj.con' config file.

This commit fixes it by copying to the build dir, to each lib
dir, the proper .conf for the selected target board. For example,
if target 'qemu_x86' is selected 'qemu_x86.conf' is copied to
the boards/ dir inside the lib dirs, so Zephyr build system can
find it and combine it with configs found in the generic 'prj.conf'.

Thanks & best regards,
Gustavo