### PR TITLE
[microTVM] Add wait to QEMU Setup  

### DIFF
--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -670,7 +670,10 @@ class ZephyrQemuTransport(Transport):
             **self.kwargs,
             stdout=subprocess.PIPE,
         )
-        self._wait_for_qemu()
+        try:
+            self._wait_for_qemu()
+        except Exception as error:
+            raise error
 
         if self.qemu_debugger is not None:
             self.qemu_debugger.start()
@@ -738,7 +741,8 @@ class ZephyrQemuTransport(Transport):
 
             if item == ZephyrQemuMakeResult.QEMU_STARTED:
                 break
-            elif item in [ZephyrQemuMakeResult.QEMU_STARTED, ZephyrQemuMakeResult.EOF]:
+
+            if item in [ZephyrQemuMakeResult.MAKE_FAILED, ZephyrQemuMakeResult.EOF]:
                 raise RuntimeError("QEMU setup failed.")
             else:
                 raise ValueError(f"{item} not expected.")

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -30,6 +30,8 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
+import queue
 
 import yaml
 
@@ -630,6 +632,8 @@ class ZephyrQemuTransport(Transport):
         self.fd_transport = None
         self.pipe_dir = None
         self.qemu_debugger = qemu_debugger
+        self._queue = queue.Queue()
+        self._qemu_ready_msg = "Qready"
 
     def timeouts(self):
         return TransportTimeouts(
@@ -658,7 +662,9 @@ class ZephyrQemuTransport(Transport):
             ["make", "run", f"QEMU_PIPE={self.pipe}"],
             cwd=self.base_dir,
             **self.kwargs,
+            stdout=subprocess.PIPE,
         )
+        self._wait_for_qemu()
 
         if self.qemu_debugger is not None:
             self.qemu_debugger.start()
@@ -702,6 +708,21 @@ class ZephyrQemuTransport(Transport):
         if self.fd_transport is None:
             raise TransportClosedError()
         return self.fd_transport.write(data, timeout_sec)
+
+    def _qemu_check_stdout(self):
+        for line in self.proc.stdout:
+            line = str(line)
+            _LOG.debug(line)
+            if "[QEMU] CPU" in line:
+                self._queue.put(self._qemu_ready_msg)
+                return
+
+    def _wait_for_qemu(self):
+        threading.Thread(target=self._qemu_check_stdout, daemon=True).start()
+        while True:
+            item = self._queue.get()
+            if item == self._qemu_ready_msg:
+                return True
 
 
 class ZephyrDebugger(debugger.GdbDebugger):

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -744,8 +744,8 @@ class ZephyrQemuTransport(Transport):
 
             if item in [ZephyrQemuMakeResult.MAKE_FAILED, ZephyrQemuMakeResult.EOF]:
                 raise RuntimeError("QEMU setup failed.")
-            else:
-                raise ValueError(f"{item} not expected.")
+
+            raise ValueError(f"{item} not expected.")
 
 
 class ZephyrDebugger(debugger.GdbDebugger):

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -729,7 +729,7 @@ class ZephyrQemuTransport(Transport):
                 pattern = r"recipe for target (\w*) failed"
                 if re.search(pattern, line, re.IGNORECASE):
                     self._queue.put(ZephyrQemuMakeResult.MAKE_FAILED)
-        self._queue.put("EOF")
+        self._queue.put(ZephyrQemuMakeResult.EOF)
 
     def _wait_for_qemu(self):
         threading.Thread(target=self._qemu_check_stdout, daemon=True).start()

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -220,9 +220,9 @@ def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
     shape = (10,)
     dtype = "float32"
 
-    this_dir = os.path.dirname(__file__)
-    tvm_source_dir = os.path.join(this_dir, "..", "..", "..")
-    runtime_path = os.path.join(tvm_source_dir, "apps", "microtvm", "zephyr", "aot_demo")
+    this_dir = pathlib.Path(__file__).parent
+    tvm_source_dir = this_dir / ".." / ".." / ".."
+    runtime_path = tvm_source_dir / "apps" / "microtvm" / "zephyr" / "aot_demo"
 
     # Construct Relay program.
     x = relay.var("x", relay.TensorType(shape=shape, dtype=dtype))
@@ -249,13 +249,8 @@ def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
     # Remove a file to create make failure.
     os.remove(file_path)
     transport = session_kw["flasher"].flash(session_kw["binary"])
-    try:
+    with pytest.raises(RuntimeError):
         transport.open()
-    except RuntimeError:
-        # RuntimeError is expected.
-        pass
-    except Exception:
-        assert False
 
 
 if __name__ == "__main__":

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -249,8 +249,9 @@ def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
     # Remove a file to create make failure.
     os.remove(file_path)
     transport = session_kw["flasher"].flash(session_kw["binary"])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         transport.open()
+    assert "QEMU setup failed" in str(excinfo.value)
 
 
 if __name__ == "__main__":

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -118,6 +118,8 @@ def _create_header_file(tensor_name, npy_data, output_path):
             header_file.write(f"uint8_t {tensor_name}[] = ")
         elif npy_data.dtype == "float32":
             header_file.write(f"float {tensor_name}[] = ")
+        else:
+            raise ValueError("Data type not expected.")
 
         header_file.write("{")
         for i in np.ndindex(npy_data.shape):
@@ -209,6 +211,51 @@ def test_tflite(platform, west_cmd, skip_build, tvm_debug):
     time = int(result_line[2])
     logging.info(f"Result: {result}\ttime: {time} ms")
     assert result == 8
+
+
+def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
+    """Testing QEMU make fail."""
+    model, zephyr_board = PLATFORMS[platform]
+    build_config = {"skip_build": skip_build, "debug": tvm_debug}
+    shape = (10,)
+    dtype = "float32"
+
+    this_dir = os.path.dirname(__file__)
+    tvm_source_dir = os.path.join(this_dir, "..", "..", "..")
+    runtime_path = os.path.join(tvm_source_dir, "apps", "microtvm", "zephyr", "aot_demo")
+
+    # Construct Relay program.
+    x = relay.var("x", relay.TensorType(shape=shape, dtype=dtype))
+    xx = relay.multiply(x, x)
+    z = relay.add(xx, relay.const(np.ones(shape=shape, dtype=dtype)))
+    func = relay.Function([x], z)
+
+    target = tvm.target.target.micro(model, options=["-link-params=1", "--executor=aot"])
+    with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
+        lowered = relay.build(func, target)
+
+    # Generate input/output header files
+    model_files_path = os.path.join(runtime_path, "include")
+    _create_header_file((f"input_data"), np.zeros(shape=shape, dtype=dtype), model_files_path)
+    _create_header_file("output_data", np.zeros(shape=shape, dtype=dtype), model_files_path)
+
+    session_kw = _build_session_kw(
+        model, target, zephyr_board, west_cmd, lowered.lib, runtime_path, build_config
+    )
+
+    file_path = os.path.join(session_kw["binary"].base_dir, "zephyr/CMakeFiles/run.dir/build.make")
+    assert os.path.isfile(file_path), f"[{file_path}] does not exist."
+
+    # Remove a file to create make failure.
+    os.remove(file_path)
+    transport = session_kw["flasher"].flash(session_kw["binary"])
+    try:
+        transport.open()
+    except RuntimeError:
+        # RuntimeError is expected.
+        pass
+    except Exception:
+        assert False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In some cases where the Zephyr project would rebuild itself, qemu would setup and wait for message from the microtvm target, however the microtvm target is not ready yet since these are happening in different processes. In this PR we add a wait to qemu to make sure they happen synchronously.

cc @areusch  