### PR TITLE
[WIP, Frontend, Tensorflow2] Added support for TensorList ops

### DIFF
--- a/python/tvm/relay/frontend/tensorflow2.py
+++ b/python/tvm/relay/frontend/tensorflow2.py
@@ -38,7 +38,8 @@ from ..loops import while_loop as _while_loop
 from .common import infer_type as _infer_type
 
 from .tensorflow_ops import _convert_map as _convert_map_common
-from .tensorflow_ops import _need_prelude_for_shape_inference
+from .tensorflow2_ops import _convert_map as _convert_map_tf2
+from .tensorflow2_ops import _need_prelude_for_shape_inference
 
 from ..ty import Any
 
@@ -325,6 +326,11 @@ class GraphProto:
                 sym = _convert_map_common[op_name](inputs, attrs, self._params, self._prelude)
             else:
                 sym = _convert_map_common[op_name](inputs, attrs, self._params, self._module.mod)
+        elif op_name in _convert_map_tf2:
+            if _need_prelude_for_shape_inference(op_name):
+                sym = _convert_map_tf2[op_name](inputs, attrs, self._params, self._prelude)
+            else:
+                sym = _convert_map_tf2[op_name](inputs, attrs, self._params, self._module.mod)
         else:
             raise NotImplementedError("Operator {} not implemented.".format(op_name))
 

--- a/python/tvm/relay/frontend/tensorflow2_ops.py
+++ b/python/tvm/relay/frontend/tensorflow2_ops.py
@@ -16,12 +16,10 @@
 # under the License.
 # pylint: disable=invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
 """Tensorflow2.x to relay converter ops and helper"""
-import warnings
-
 import tvm
-from .. import op as _op
+from tvm.relay.prelude import StaticTensorArrayOps, get_tensor_array_shape
 
-from tvm.relay.prelude import StaticTensorArrayOps, get_tensor_array_shape, TensorArrayOps
+from .. import op as _op
 from ..ty import Any
 from .common import infer_value as _infer_value
 from .common import infer_type as _infer_type

--- a/python/tvm/relay/frontend/tensorflow2_ops.py
+++ b/python/tvm/relay/frontend/tensorflow2_ops.py
@@ -1,0 +1,145 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+"""Tensorflow2.x to relay converter ops and helper"""
+import warnings
+
+import tvm
+from .. import op as _op
+
+from tvm.relay.prelude import StaticTensorArrayOps, get_tensor_array_shape, TensorArrayOps
+from ..ty import Any
+from .common import infer_value as _infer_value
+from .common import infer_type as _infer_type
+from .tensorflow_ops import _get_more_static_shape
+
+
+def _infer_type_with_prelude(val, prelude):
+    body = _infer_type(val, prelude.mod)
+    return body.checked_type
+
+
+def _need_prelude_for_shape_inference(op):
+    return "TensorList" in op or "TensorArray" in op
+
+
+def _tensorlist_reserve():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr.get("element_dtype").name
+        elem_shape = _infer_value(inputs[0], params, prelude.mod)
+        elem_shape = tuple(elem_shape.asnumpy().astype("int32").flatten())
+        assert -1 not in elem_shape, "TensorList size and element shape must be static"
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, elem_shape)
+        static_tensor_array_ops.register()
+        tensor_array_constructor = static_tensor_array_ops.get_global_var("tensor_array")
+        tensor_array = tensor_array_constructor(inputs[1])
+        return tensor_array
+
+    return _impl
+
+
+def _tensorlist_set_item():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr.get("element_dtype").name
+        input_ta = inputs[0]
+        input_ta_shape = get_tensor_array_shape(input_ta, dtype_str, prelude)
+        input_t_shape = _infer_type_with_prelude(inputs[2], prelude).shape
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_ta_shape)
+        static_tensor_array_ops.register()
+        tensor_func = static_tensor_array_ops.get_ctor("tensor_constructor")
+        v = tensor_func(inputs[2])
+        # Write tensor with more static shape
+        actual_shape = _get_more_static_shape(input_t_shape, input_ta_shape)
+        if actual_shape != input_t_shape:
+            new_shape = []
+            num_any_dim = 0
+            for dim in actual_shape:
+                if not isinstance(dim, int):
+                    num_any_dim += 1
+                new_shape.append(dim if isinstance(dim, int) else -1)
+            if num_any_dim <= 1:
+                v = tensor_func(_op.reshape(inputs[2], new_shape))
+        write_func = prelude.get_global_var_static("tensor_array_write", dtype_str, input_ta_shape)
+        out = write_func(input_ta, inputs[1], v)
+        return out
+
+    return _impl
+
+
+def _tensorlist_get_item():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr["element_dtype"].name
+        input_shape = get_tensor_array_shape(inputs[0], dtype_str, prelude)
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_shape)
+        static_tensor_array_ops.register()
+        read_func = static_tensor_array_ops.get_global_var("tensor_array_read")
+        out_tensor = read_func(inputs[0], _op.take(inputs[1], tvm.relay.const(0)))
+        get_data_func = static_tensor_array_ops.get_global_var("tensor_get_data")
+        out = get_data_func(out_tensor)
+        return out
+
+    return _impl
+
+
+def _tensorlist_stack():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr["element_dtype"].name
+        input_ta_shape = get_tensor_array_shape(inputs[0], dtype_str, prelude)
+        assert input_ta_shape is not None
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_ta_shape)
+        static_tensor_array_ops.register()
+        stack_func = prelude.get_global_var_static("tensor_array_stack", dtype_str, input_ta_shape)
+        out_tensor = stack_func(inputs[0])
+        out_shape = (Any(),) + input_ta_shape
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, out_shape)
+        static_tensor_array_ops.register()
+        get_data_func = prelude.get_global_var_static("tensor_get_data", dtype_str, out_shape)
+        out = get_data_func(out_tensor)
+
+        return out
+
+    return _impl
+
+
+def _tensorlist_from_tensor():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr["element_dtype"].name
+        input_ta_shape = _infer_type_with_prelude(inputs[0], prelude).shape
+        assert input_ta_shape is not None
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_ta_shape)
+        static_tensor_array_ops.register()
+        unstack_func = prelude.get_global_var_static(
+            "tensor_array_unstack", dtype_str, input_ta_shape
+        )
+        out = unstack_func(inputs[0])
+        return out
+
+    return _impl
+
+
+_convert_map = {
+    "TensorListFromTensor": _tensorlist_from_tensor(),
+    "TensorListGetItem": _tensorlist_get_item(),
+    "TensorListReserve": _tensorlist_reserve(),
+    "TensorListSetItem": _tensorlist_set_item(),
+    "TensorListStack": _tensorlist_stack(),
+}

--- a/tests/python/frontend/tensorflow2/test_functional_models.py
+++ b/tests/python/frontend/tensorflow2/test_functional_models.py
@@ -447,5 +447,109 @@ def test_stateless_while_2var():
     run_model_graph(StatelessWhile2Var, outputs=["Identity:output:0"])
 
 
+def test_tensorlist():
+    class TensorList(tf.Module):
+        def get_input(self):
+            in_tens = np.ones((2, 3), dtype="float32")
+            in_tens[1, :] = np.zeros((3,), dtype="float32")
+            return in_tens
+
+        @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3), dtype=tf.float32)])
+        def func(self, x):
+            elem_shape = (3,)
+            dtype = tf.float32
+            tl = tf.raw_ops.TensorListReserve(
+                element_shape=elem_shape, num_elements=2, element_dtype=dtype
+            )
+            tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=0, item=x[0, :])
+            tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=1, item=x[1, :])
+            output = tf.raw_ops.TensorListGetItem(
+                input_handle=tl, index=0, element_shape=elem_shape, element_dtype=dtype
+            )
+            return output
+
+    run_model_graph(TensorList)
+    run_func_graph(TensorList, runtime="vm")
+
+
+def test_tensorlist_stack():
+    class TensorListStack(tf.Module):
+        def get_input(self):
+            in_tens = np.ones((2, 3), dtype="float32")
+            in_tens[1] = np.zeros((3,), dtype="float32")
+            return in_tens
+
+        """2D array as input"""
+
+        @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3), dtype=tf.float32)])
+        def func(self, x):
+            elem_shape = (3,)
+            dtype = tf.float32
+            tl = tf.raw_ops.TensorListReserve(
+                element_shape=elem_shape, num_elements=2, element_dtype=dtype
+            )
+            tl = tf.raw_ops.TensorListFromTensor(tensor=x, element_shape=elem_shape)
+            output = tf.raw_ops.TensorListStack(
+                input_handle=tl, element_shape=elem_shape, element_dtype=dtype
+            )
+            return output
+
+    run_model_graph(TensorListStack)
+    run_func_graph(TensorListStack, runtime="vm")
+
+
+def test_tensorlist_2d():
+    class TensorList2D(tf.Module):
+        def get_input(self):
+            in_tens = np.ones((2, 3, 4), dtype="float32")
+            in_tens[1, :, :] = np.zeros((3, 4), dtype="float32")
+            return in_tens
+
+        """2D array as input"""
+
+        @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3, 4), dtype=tf.float32)])
+        def func(self, x):
+            elem_shape = (3, 4)
+            dtype = tf.float32
+            tl = tf.raw_ops.TensorListReserve(
+                element_shape=elem_shape, num_elements=2, element_dtype=dtype
+            )
+            tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=0, item=x[0, :, :])
+            tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=1, item=x[1, :, :])
+            output = tf.raw_ops.TensorListGetItem(
+                input_handle=tl, index=0, element_shape=elem_shape, element_dtype=dtype
+            )
+            return output
+
+    run_model_graph(TensorList2D)
+    run_func_graph(TensorList2D, runtime="vm")
+
+
+def test_tensorlist_stack_2d():
+    class TensorListStack2D(tf.Module):
+        def get_input(self):
+            in_tens = np.ones((2, 3, 4), dtype="float32")
+            in_tens[1, :, :] = np.zeros((3, 4), dtype="float32")
+            return in_tens
+
+        """2D array as input"""
+
+        @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3, 4), dtype=tf.float32)])
+        def func(self, x):
+            elem_shape = (3, 4)
+            dtype = tf.float32
+            tl = tf.raw_ops.TensorListReserve(
+                element_shape=elem_shape, num_elements=2, element_dtype=dtype
+            )
+            tl = tf.raw_ops.TensorListFromTensor(tensor=x, element_shape=elem_shape)
+            output = tf.raw_ops.TensorListStack(
+                input_handle=tl, element_shape=elem_shape, element_dtype=dtype
+            )
+            return output
+
+    run_model_graph(TensorListStack2D)
+    run_func_graph(TensorListStack2D, runtime="vm")
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/frontend/tensorflow2/test_sequential_models.py
+++ b/tests/python/frontend/tensorflow2/test_sequential_models.py
@@ -109,5 +109,48 @@ def test_maxpool_batchnorm_model():
     run_sequential_model(maxpool_batchnorm_model, input_shape=(1, 32, 32, 3))
 
 
+def test_tensorlist_stack_model():
+    class TensorArrayStackLayer(tf.keras.layers.Layer):
+        def __init__(self):
+            super().__init__()
+
+        def call(self, inputs):
+            inputs = tf.squeeze(inputs)
+            outputs = tf.TensorArray(
+                tf.float32, size=inputs.shape[0], infer_shape=False, element_shape=inputs.shape[1:]
+            )
+            outputs = outputs.unstack(inputs)
+
+            return outputs.stack()
+
+    shape = (3, 32)
+    model = tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=shape, batch_size=1), TensorArrayStackLayer()]
+    )
+    return model
+
+
+def test_tensorlist_read_model():
+    class TensorArrayReadLayer(tf.keras.layers.Layer):
+        def __init__(self):
+            super().__init__()
+
+        def call(self, inputs):
+            inputs = tf.squeeze(inputs)
+            outputs = tf.TensorArray(
+                tf.float32, size=inputs.shape[0], infer_shape=False, element_shape=inputs.shape[1:]
+            )
+            for i in range(inputs.shape[0]):
+                outputs = outputs.write(i, inputs[i, :])
+
+            return outputs.read(0)
+
+    shape = (3, 32)
+    model = tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=shape, batch_size=1), TensorArrayReadLayer()]
+    )
+    return model
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR adds support for `TensorList` ops in TF2 frontend parser. Ops like `TensorListFromTensor`, `TensorListGetItem` etc are common in graphdef of TF2 OD models like Faster-RCNN etc. 

This PR is in line with the original plan of supporting tensorflow2 parser in TVM frontend as in the discussion #4102 Exact commit plan [here](https://github.com/apache/tvm/issues/4102#issuecomment-784456088).

Co-authored-by: David Huang <davhuan@amazon.com>
Co-authored-by: Rohan Mukherjee <mukrohan@amazon.com>
Co-authored-by: Xingyu Zhou <zhoxingy@amazon.com>
Co-authored-by: Srinidhi Goud <srinidhi.goud29@gmail.com>
Co-authored-by: Xiao <weix@amazon.com>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
