### PR TITLE
use the latest tag instead of the master branch of papi in the ci

### DIFF
--- a/docker/install/ubuntu_install_papi.sh
+++ b/docker/install/ubuntu_install_papi.sh
@@ -27,7 +27,7 @@ apt-get install -y linux-tools-common linux-tools-generic
 
 cd /
 git clone https://bitbucket.org/icl/papi.git
-cd papi && git checkout 1ab84fe6d
+cd papi && git checkout 1ab84fe6d && cd src
 cd papi/src
 export PAPI_CUDA_ROOT=/usr/local/cuda
 ./configure --with-components="$1"

--- a/docker/install/ubuntu_install_papi.sh
+++ b/docker/install/ubuntu_install_papi.sh
@@ -26,7 +26,7 @@ apt-get update --fix-missing
 apt-get install -y linux-tools-common linux-tools-generic
 
 cd /
-git clone https://bitbucket.org/icl/papi.git
+git clone -b stable-6.0 --single-branch https://bitbucket.org/icl/papi.git
 cd papi/src
 export PAPI_CUDA_ROOT=/usr/local/cuda
 ./configure --with-components="$1"

--- a/docker/install/ubuntu_install_papi.sh
+++ b/docker/install/ubuntu_install_papi.sh
@@ -26,7 +26,8 @@ apt-get update --fix-missing
 apt-get install -y linux-tools-common linux-tools-generic
 
 cd /
-git clone -b stable-6.0 --single-branch https://bitbucket.org/icl/papi.git
+git clone https://bitbucket.org/icl/papi.git
+cd papi && git checkout 1ab84fe6d
 cd papi/src
 export PAPI_CUDA_ROOT=/usr/local/cuda
 ./configure --with-components="$1"


### PR DESCRIPTION
The CI docker build tvm.ci_cpu fails with the current master of papi
https://github.com/apache/tvm/blob/main/docker/install/ubuntu_install_papi.sh#L29
the offending papi commit is
https://bitbucket.org/icl/papi/commits/1f48bb789bb8a42e7f1e3faec4e49487af14bf46
apparently the papi CI is broken too
![image](https://user-images.githubusercontent.com/3264637/121599848-ee9fc600-ca43-11eb-9bc5-7a7f502115d0.png)

i tried to build the docker ci_cpu while going back in the commits on the master branch of papi
and i think the safest to use is the use the latest papi stable tag.

with this patch the tvm ci_cpu docker container builds successfully.

![image](https://user-images.githubusercontent.com/3264637/121600111-4ccca900-ca44-11eb-968f-807c87a65730.png)
