### PR TITLE
[Relay][Quantization] Extend FakeQuantizationToInteger to more ops

### DIFF
--- a/include/tvm/ir/affine_type.h
+++ b/include/tvm/ir/affine_type.h
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/ir/affine_type.h
+ * \brief Quantized Tensor Types.
+ */
+#ifndef TVM_IR_AFFINE_TYPE_H_
+#define TVM_IR_AFFINE_TYPE_H_
+
+#include <tvm/ir/expr.h>
+#include <tvm/ir/type.h>
+
+namespace tvm {
+
+/*!
+ * \brief AffineType representation
+ * \sa AffineType
+ */
+class AffineTypeNode : public Object {
+ public:
+  /*!
+   * \brief Span that points to the original source code.
+   *        Reserved debug information.
+   */
+  mutable Span span;
+
+  static constexpr const char* _type_key = "AffineType";
+  static constexpr const bool _type_has_method_sequal_reduce = true;
+  static constexpr const bool _type_has_method_shash_reduce = true;
+  TVM_DECLARE_BASE_OBJECT_INFO(AffineTypeNode, Object);
+};
+
+/*!
+ * \brief Managed reference to AffineTypeNode.
+ * \sa AffineTypeNode
+ */
+class AffineType : public ObjectRef {
+ public:
+  TVM_DEFINE_OBJECT_REF_METHODS(AffineType, ObjectRef, AffineTypeNode);
+};
+
+/*!
+ * \brief TensorAffineType representation
+ * \sa TensorAffineType
+ *
+ *  This Type represents a quantized integer tensor that can be converted
+ *  back to real space via the x_real = scale * (x_quant - zero_point)
+ */
+class TensorAffineTypeNode : public AffineTypeNode {
+ public:
+  /*! \brief The scale of this type */
+  RelayExpr scale;
+  /*! \brief The zero point of this type */
+  RelayExpr zero_point;
+  /*! \brief The data type of this type */
+  DataType dtype;
+
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("scale", &scale);
+    v->Visit("zero_point", &zero_point);
+    v->Visit("dtype", &dtype);
+  }
+
+  bool SEqualReduce(const TensorAffineTypeNode* other, SEqualReducer equal) const {
+    equal->MarkGraphNode();
+    return equal(scale, other->scale) && equal(zero_point, other->zero_point) &&
+           equal(dtype, other->dtype);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce->MarkGraphNode();
+    hash_reduce(scale);
+    hash_reduce(zero_point);
+    hash_reduce(dtype);
+  }
+
+  static constexpr const char* _type_key = "TensorAffineType";
+  TVM_DECLARE_BASE_OBJECT_INFO(TensorAffineTypeNode, AffineTypeNode);
+};
+
+/*!
+ * \brief Managed reference to AffineTypes.
+ * \sa AffineTypeNode
+ */
+class TensorAffineType : public AffineType {
+ public:
+  TVM_DLL TensorAffineType(RelayExpr scale, RelayExpr zero_point, DataType dtype);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(TensorAffineType, AffineType, TensorAffineTypeNode);
+};
+
+/*!
+ * \brief TupleAffineType representation
+ * \sa TupleAffineType
+ */
+class TupleAffineTypeNode : public AffineTypeNode {
+ public:
+  /*! \brief The types of this tuple*/
+  Array<TensorAffineType> types;
+
+  void VisitAttrs(tvm::AttrVisitor* v) { v->Visit("types", &types); }
+
+  bool SEqualReduce(const TupleAffineTypeNode* other, SEqualReducer equal) const {
+    equal->MarkGraphNode();
+    return equal(types, other->types);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce->MarkGraphNode();
+    hash_reduce(types);
+  }
+
+  static constexpr const char* _type_key = "TupleAffineType";
+  TVM_DECLARE_BASE_OBJECT_INFO(TupleAffineTypeNode, AffineTypeNode);
+};
+
+/*!
+ * \brief Managed reference to TupleAffineTypes.
+ * \sa TupleAffineType
+ */
+class TupleAffineType : public AffineType {
+ public:
+  TVM_DLL TupleAffineType(Array<TensorAffineType> types);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(TupleAffineType, AffineType, TupleAffineTypeNode);
+};
+
+}  // namespace tvm
+#endif  // TVM_IR_AFFINE_TYPE_H_

--- a/python/tvm/ir/__init__.py
+++ b/python/tvm/ir/__init__.py
@@ -21,6 +21,7 @@ from .base import structural_equal, assert_structural_equal, structural_hash
 from .type import Type, TypeKind, PrimType, PointerType, TypeVar, GlobalTypeVar, TupleType
 from .type import TypeConstraint, FuncType, IncompleteType, RelayRefType
 from .tensor_type import TensorType
+from .affine_type import TensorAffineType, TupleAffineType
 from .type_relation import TypeCall, TypeRelation
 from .expr import BaseExpr, PrimExpr, RelayExpr, GlobalVar, Range
 from .op import Op, register_op_attr, register_intrin_lowering

--- a/python/tvm/ir/affine_type.py
+++ b/python/tvm/ir/affine_type.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Types for quantized Tensors."""
+import tvm._ffi
+
+from .base import Node
+from . import _ffi_api
+
+
+class AffineType(Node):
+    """The base class of Affine Types."""
+
+    def __eq__(self, other):
+        """Compare two types for structural equivalence."""
+        return bool(tvm.ir.structural_equal(self, other))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+@tvm._ffi.register_object("TensorAffineType")
+class TensorAffineType(AffineType):
+    """The quantized type of a tensor, with scale, zero point, and datatype
+
+    The real space value is calculated as x = x_q * scale + zero_point
+
+    Parameters
+    ----------
+    scale: Expr
+        The scale
+
+    zero_point: Expr
+        The zero_point
+
+    dtype : str
+        The content data type.
+    """
+
+    def __init__(self, scale, zero_point, dtype):
+        self.__init_handle_by_constructor__(_ffi_api.TensorAffineType, scale, zero_point, dtype)
+
+
+@tvm._ffi.register_object("TupleAffineType")
+class TupleAffineType(AffineType):
+    """Affine types of a node with multiple outputs
+
+    Parameters
+    ----------
+    types : List[TensorAffineType]
+        The shape of the Tensor
+
+    """
+
+    def __init__(self, types):
+        self.__init_handle_by_constructor__(_ffi_api.TupleAffineType, types)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1008,7 +1008,7 @@ class Pad(OnnxOpConverter):
         if len(inputs) == 3:
             value = fold_constant(_op.take(inputs[2], _op.const(0)))
         else:
-            value = 0
+            value = 0.0
 
         pad_width_expr = fold_constant(_op.transpose(_op.reshape(pads, (2, -1))))
         pad_mode = attr.get("mode", b"constant").decode("utf-8")

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -101,7 +101,7 @@ def bias_add(expr, type_map):
             b_t.zero_point,
             in_scale,
             in_zero_point,
-            out_dtype=xt.dtype,
+            out_dtype=x_t.dtype,
         )
     out = relay.op.nn.bias_add(x, b, **expr.attrs)
     return [out, x_t]

--- a/src/ir/affine_type.cc
+++ b/src/ir/affine_type.cc
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/ir/affine_type.cc
+ * \brief The Type information for quantized nodes.
+ */
+#include <tvm/ir/affine_type.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/op.h>
+
+namespace tvm {
+
+using tvm::ReprPrinter;
+using namespace tvm::runtime;
+
+TensorAffineType::TensorAffineType(RelayExpr scale, RelayExpr zero_point, DataType dtype) {
+  ObjectPtr<TensorAffineTypeNode> n = make_object<TensorAffineTypeNode>();
+  n->scale = std::move(scale);
+  n->zero_point = std::move(zero_point);
+  n->dtype = std::move(dtype);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(TensorAffineTypeNode);
+
+TVM_REGISTER_GLOBAL("ir.TensorAffineType")
+    .set_body_typed([](RelayExpr scale, RelayExpr zero_point, DataType dtype) {
+      return TensorAffineType(scale, zero_point, dtype);
+    });
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<TensorAffineTypeNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      auto* node = static_cast<const TensorAffineTypeNode*>(ref.get());
+      p->stream << "TensorAffineType(" << node->scale << ", " << node->zero_point << ", "
+                << node->dtype << ")";
+    });
+
+TupleAffineType::TupleAffineType(Array<TensorAffineType> types) {
+  ObjectPtr<TupleAffineTypeNode> n = make_object<TupleAffineTypeNode>();
+  n->types = std::move(types);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(TupleAffineTypeNode);
+
+TVM_REGISTER_GLOBAL("ir.TupleAffineType").set_body_typed([](Array<TensorAffineType> types) {
+  return TupleAffineType(types);
+});
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<TupleAffineTypeNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      auto* node = static_cast<const TupleAffineTypeNode*>(ref.get());
+      p->stream << "TupleAffineType([";
+      for (size_t i = 0; i < node->types.size(); ++i) {
+        p->stream << node->types[i];
+        if (i < node->types.size() - 1) {
+          p->stream << ", ";
+        }
+      }
+      p->stream << "])";
+    });
+
+}  // namespace tvm

--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -51,14 +51,20 @@ bool QuantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 
   const auto* quantize_attrs = attrs.as<QuantizeAttrs>();
   int axis = quantize_attrs->axis;
-  axis = (axis < 0) ? data->shape.size() + axis : axis;
-  ICHECK_LT(axis, static_cast<int>(data->shape.size()))
-      << "axis " << quantize_attrs->axis << " is out of range";
+  auto rank = static_cast<int>(data->shape.size());
+  axis = (axis < 0) ? ((rank > 0) ? data->shape.size() + axis : 0) : axis;
+  ICHECK_LT(axis, rank > 0 ? rank : 1) << "axis " << quantize_attrs->axis << " is out of range";
   ICHECK_GE(axis, 0) << "axis " << quantize_attrs->axis << " is out of range";
 
+  PrimExpr axis_shape;
+  if (rank > 0) {
+    axis_shape = data->shape[axis];
+  } else {
+    axis_shape = Integer(1);
+  }
   // Check and assign types for scale and zero points.
-  AssignType(types[1], DataType::Float(32), data->shape[axis], reporter);  // scale
-  AssignType(types[2], DataType::Int(32), data->shape[axis], reporter);    // zero point
+  AssignType(types[1], DataType::Float(32), axis_shape, reporter);  // scale
+  AssignType(types[2], DataType::Int(32), axis_shape, reporter);    // zero point
 
   const Array<tvm::PrimExpr> oshape = data->shape;
   const DataType out_dtype = quantize_attrs->out_dtype;

--- a/src/relay/transforms/fake_quantization_to_integer.cc
+++ b/src/relay/transforms/fake_quantization_to_integer.cc
@@ -23,9 +23,13 @@
  * to actual integer operations.
  */
 
+#include <tvm/ir/affine_type.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/transform.h>
+
+namespace tvm {
+namespace relay {
 
 /* Description of FakeQuantizationToInteger
  *
@@ -63,65 +67,6 @@
  * rewritten subgraph and the processing continues
  */
 
-namespace tvm {
-namespace relay {
-
-/*!
- * \brief AffineType representation
- * \sa AffineType
- */
-class AffineTypeNode : public Object {
- public:
-  /*! \brief The scale of this type */
-  Expr scale;
-  /*! \brief The zero point of this type */
-  Expr zero_point;
-  /*! \brief The data type of this type */
-  DataType dtype;
-
-  void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("scale", &scale);
-    v->Visit("zero_point", &zero_point);
-    v->Visit("dtype", &dtype);
-  }
-
-  bool SEqualReduce(const AffineTypeNode* other, SEqualReducer equal) const {
-    equal->MarkGraphNode();
-    return equal(scale, other->scale) && equal(zero_point, other->zero_point) &&
-           equal(dtype, other->dtype);
-  }
-
-  void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce->MarkGraphNode();
-    hash_reduce(scale);
-    hash_reduce(zero_point);
-    hash_reduce(dtype);
-  }
-
-  static constexpr const bool _type_has_method_sequal_reduce = true;
-  static constexpr const bool _type_has_method_shash_reduce = true;
-  static constexpr const char* _type_key = "AffineTypeNode";
-  TVM_DECLARE_BASE_OBJECT_INFO(AffineTypeNode, Object);
-};
-
-/*!
- * \brief Managed reference to AffineTypes.
- * \sa AffineTypeNode
- */
-class AffineType : public ObjectRef {
- public:
-  TVM_DLL AffineType(Expr scale, Expr zero_point, DataType dtype) {
-    ObjectPtr<AffineTypeNode> n = make_object<AffineTypeNode>();
-    n->scale = std::move(scale);
-    n->zero_point = std::move(zero_point);
-    n->dtype = std::move(dtype);
-    data_ = std::move(n);
-  }
-  TVM_DEFINE_OBJECT_REF_METHODS(AffineType, ObjectRef, AffineTypeNode);
-};
-
-TVM_REGISTER_NODE_TYPE(AffineTypeNode);
-
 using ExprSet = std::unordered_set<Expr, ObjectPtrHash, ObjectPtrEqual>;
 using ExprMap = std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual>;
 using AffineTypeMap = Map<Expr, AffineType>;
@@ -148,7 +93,8 @@ class SubgraphExtractor : public ExprVisitor {
   const AffineTypeMap GetAffineTypes() { return affine_types_; }
   void VisitExpr(const Expr& expr) override {
     if (expr.as<CallNode>() == nullptr && expr.as<OpNode>() == nullptr &&
-        expr.as<TupleNode>() == nullptr) {
+        expr.as<TupleNode>() == nullptr && expr.as<TupleGetItemNode>() == nullptr &&
+        expr.as<ConstantNode>() == nullptr) {
       is_fake_quantized_ = false;
     } else {
       ExprVisitor::VisitExpr(expr);
@@ -162,13 +108,14 @@ class SubgraphExtractor : public ExprVisitor {
       VisitExpr(call_node->args[0]);
       // Collect type of quantize ops
       affine_types_.Set(GetRef<Expr>(call_node),
-                        AffineType(call_node->args[1], call_node->args[2],
-                                   call_node->checked_type().as<TensorTypeNode>()->dtype));
+                        TensorAffineType(call_node->args[1], call_node->args[2],
+                                         call_node->checked_type().as<TensorTypeNode>()->dtype));
     } else if (call_node->op == dequantize_op_) {
       // Collect type of dequantize ops
-      affine_types_.Set(GetRef<Expr>(call_node),
-                        AffineType(call_node->args[1], call_node->args[2],
-                                   call_node->args[0]->checked_type().as<TensorTypeNode>()->dtype));
+      affine_types_.Set(
+          GetRef<Expr>(call_node),
+          TensorAffineType(call_node->args[1], call_node->args[2],
+                           call_node->args[0]->checked_type().as<TensorTypeNode>()->dtype));
     } else {
       // run normally on everything else.
       ExprVisitor::VisitExpr_(call_node);
@@ -226,18 +173,37 @@ class SubgraphMutator : public ExprMutator {
       // Call the rewrite
       Array<ObjectRef> vals = fqfq[op](expr, affine_types_);
       // Save teh outputs of the rewrite
-      ICHECK(vals.size() == 4)
+      ICHECK(vals.size() == 2)
           << "got the wrong number of returned arguments from FTVMFakeQuantizationToInteger for "
           << AsText(op, false);
       out = Downcast<Expr>(vals[0]);
-      affine_types_.Set(out, AffineType(Downcast<Expr>(vals[1]), Downcast<Expr>(vals[2]),
-                                        DataType(String2DLDataType(Downcast<String>(vals[3])))));
+      affine_types_.Set(out, Downcast<AffineType>(vals[1]));
     } else {
       ICHECK(false) << "When rewriting a fake quantized graph, found an invalid node "
                     << AsText(GetRef<Expr>(call_node), false);
     }
     return out;
   }
+
+  Expr VisitExpr_(const TupleNode* node) {
+    Expr expr = ExprMutator::VisitExpr_(node);
+    auto new_node = expr.as<TupleNode>();
+    Array<TensorAffineType> types;
+    for (Expr field : new_node->fields) {
+      ICHECK(affine_types_[field].as<TensorAffineTypeNode>());
+      types.push_back(Downcast<TensorAffineType>(affine_types_[field]));
+    }
+    affine_types_.Set(expr, TupleAffineType(types));
+    return expr;
+  }
+
+  Expr VisitExpr_(const TupleGetItemNode* node) {
+    Expr expr = ExprMutator::VisitExpr_(node);
+    auto tuple_type = affine_types_[expr.as<TupleGetItemNode>()->tuple].as<TupleAffineTypeNode>();
+    affine_types_.Set(expr, tuple_type->types[node->index]);
+    return expr;
+  }
+
   ExprSet subgraph_;
   AffineTypeMap affine_types_;
   AffineType out_type_;

--- a/tests/python/relay/test_op_qnn_quantize.py
+++ b/tests/python/relay/test_op_qnn_quantize.py
@@ -88,6 +88,20 @@ def test_float32_to_int8():
     )
 
 
+def test_scalar_float32_to_int8():
+    data = np.array(-63.5).astype("float32")
+    output = np.array(-128).astype("int8")
+    quant_args = {"out_zero_point": np.int32(-1), "out_scale": np.float32(0.5)}
+    quantize_test_driver(
+        in_dtype="float32",
+        quant_args=quant_args,
+        axis=-1,
+        out_dtype="int8",
+        in_data=data,
+        verify_output_data=output,
+    )
+
+
 def test_channelwise_axis_0():
     data = (
         np.array([-63.5, -63, -62.5, -62, -61.5, 30, 31, 31.5, 31.75, 32])
@@ -163,6 +177,7 @@ def test_dynamic_quantize():
 if __name__ == "__main__":
     test_float32_to_uint8()
     test_float32_to_int8()
+    test_scalar_float32_to_int8()
     test_channelwise_axis_0()
     test_channelwise_axis_1()
     test_dynamic_quantize()

--- a/tests/python/relay/test_op_qnn_requantize.py
+++ b/tests/python/relay/test_op_qnn_requantize.py
@@ -92,6 +92,24 @@ def test_same_scale():
         verify(mod, (golden_data, golden_output))
 
 
+def test_scalar_same_scale():
+    # Have same scales, everything within range
+    golden_data = np.array(-10).astype("int32")
+    golden_output = golden_data
+
+    for rounding in roundings:
+        mod = get_mod(
+            data_shape=(),
+            data_dtype="int32",
+            out_dtype="int8",
+            input_scale=0.5,
+            output_scale=0.5,
+            rounding=rounding,
+        )
+        assert "right_shift" not in mod.astext()
+        verify(mod, (golden_data, golden_output))
+
+
 def test_downscale():
     for rounding in roundings:
         mod = get_mod(
@@ -437,6 +455,7 @@ def test_per_channel_different_scale():
 
 if __name__ == "__main__":
     test_same_scale()
+    test_scalar_same_scale()
     test_downscale()
     test_upscale()
     test_non_power_of_two()

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -46,10 +46,10 @@ def test_fake_quantize_conv():
         mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
         ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-        result = ex.evaluate()(x_np, w_np).asnumpy()
+        result = ex.evaluate()(x_np, w_np).numpy()
 
         ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-        result2 = ex.evaluate()(x_np, w_np).asnumpy()
+        result2 = ex.evaluate()(x_np, w_np).numpy()
 
         assert np.array_equal(result, result2)
 
@@ -76,10 +76,10 @@ def test_fake_transpose_quantize_conv():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np, w_np).asnumpy()
+    result = ex.evaluate()(x_np, w_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np, w_np).asnumpy()
+    result2 = ex.evaluate()(x_np, w_np).numpy()
 
     assert np.array_equal(result, result2)
 
@@ -109,10 +109,10 @@ def test_fake_transpose_quantize_conv_bias_add():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np, w_np, bias_np).asnumpy()
+    result = ex.evaluate()(x_np, w_np, bias_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np, w_np, bias_np).asnumpy()
+    result2 = ex.evaluate()(x_np, w_np, bias_np).numpy()
 
     assert np.array_equal(result, result2)
 
@@ -135,10 +135,10 @@ def test_fake_quantize_maxpool():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).asnumpy()
+    result = ex.evaluate()(x_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).asnumpy()
+    result2 = ex.evaluate()(x_np).numpy()
 
     assert np.array_equal(result, result2)
 
@@ -161,10 +161,10 @@ def test_fake_quantize_avgpool():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).asnumpy()
+    result = ex.evaluate()(x_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).asnumpy()
+    result2 = ex.evaluate()(x_np).numpy()
 
     assert np.all(np.abs(result - result2) <= 1)
 
@@ -187,10 +187,10 @@ def test_fake_quantize_reshape():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).asnumpy()
+    result = ex.evaluate()(x_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).asnumpy()
+    result2 = ex.evaluate()(x_np).numpy()
 
     assert np.array_equal(result, result2)
 
@@ -214,10 +214,10 @@ def test_fake_quantize_transpose_reshape():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).asnumpy()
+    result = ex.evaluate()(x_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).asnumpy()
+    result2 = ex.evaluate()(x_np).numpy()
 
     assert np.array_equal(result, result2)
 
@@ -246,10 +246,10 @@ def test_fake_quantize_concat():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(*inputs_np).asnumpy()
+    result = ex.evaluate()(*inputs_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(*inputs_np).asnumpy()
+    result2 = ex.evaluate()(*inputs_np).numpy()
 
     assert np.array_equal(result, result2)
 
@@ -271,9 +271,9 @@ def test_fake_quantize_clip():
     mod2 = tvm.relay.transform.FoldConstant()(mod2)
 
     ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).asnumpy()
+    result = ex.evaluate()(x_np).numpy()
 
     ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).asnumpy()
+    result2 = ex.evaluate()(x_np).numpy()
 
     assert np.array_equal(result, result2)

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -22,6 +22,27 @@ import tvm
 from tvm import relay
 
 
+def compare_fq_to_int(expr, args, allow_rounding_error=False):
+    mod = tvm.IRModule.from_expr(expr)
+    mod = tvm.relay.transform.InferType()(mod)
+
+    mod_int = tvm.relay.transform.FakeQuantizationToInteger()(mod)
+    assert not tvm.ir.structural_equal(mod, mod_int)
+
+    mod_int = tvm.relay.transform.FoldConstant()(mod_int)
+
+    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
+    result = ex.evaluate()(*args).numpy()
+
+    ex = relay.create_executor("vm", mod=mod_int, device=tvm.cpu(), target="llvm")
+    result_int = ex.evaluate()(*args).numpy()
+
+    if allow_rounding_error:
+        assert np.all(np.abs(result - result_int) <= 1)
+    else:
+        assert np.array_equal(result, result_int)
+
+
 def test_fake_quantize_conv():
     for out_dtype in ["int8", "uint8"]:
         x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
@@ -35,23 +56,29 @@ def test_fake_quantize_conv():
         )
         op = relay.qnn.op.quantize(op, one, zero, out_dtype=out_dtype)
 
-        mod = tvm.IRModule.from_expr(op)
-        mod = tvm.relay.transform.InferType()(mod)
-
         x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
         w_np = np.random.randint(-128, 127, size=[16, 3, 5, 5], dtype="int8")
 
-        mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-        assert not tvm.ir.structural_equal(mod, mod2)
-        mod2 = tvm.relay.transform.FoldConstant()(mod2)
+        compare_fq_to_int(op, [x_np, w_np])
 
-        ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-        result = ex.evaluate()(x_np, w_np).numpy()
 
-        ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-        result2 = ex.evaluate()(x_np, w_np).numpy()
+def test_fake_quantize_dense():
+    for out_dtype in ["int8", "uint8"]:
+        x = relay.var("x", shape=[128, 64], dtype="int8")
+        w = relay.var("w", shape=[256, 64], dtype="int8")
+        one = relay.const(1.0)
+        zero = relay.const(0)
 
-        assert np.array_equal(result, result2)
+        op = relay.op.nn.dense(
+            relay.qnn.op.dequantize(x, relay.const(2.0), zero),
+            relay.qnn.op.dequantize(w, relay.const(0.5), zero),
+        )
+        op = relay.qnn.op.quantize(op, one, zero, out_dtype=out_dtype)
+
+        x_np = np.random.randint(-128, 127, size=[128, 64], dtype="int8")
+        w_np = np.random.randint(-128, 127, size=[256, 64], dtype="int8")
+
+        compare_fq_to_int(op, [x_np, w_np])
 
 
 def test_fake_transpose_quantize_conv():
@@ -65,23 +92,10 @@ def test_fake_transpose_quantize_conv():
     op = relay.op.nn.conv2d(x, relay.qnn.op.dequantize(w, relay.const(0.5), zero))
     op = relay.qnn.op.quantize(op, one, zero)
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
-
     x_np = np.random.randint(-128, 127, size=[1, 224, 224, 3], dtype="int8")
     w_np = np.random.randint(-128, 127, size=[16, 3, 5, 5], dtype="int8")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
-
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np, w_np).numpy()
-
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np, w_np).numpy()
-
-    assert np.array_equal(result, result2)
+    compare_fq_to_int(op, [x_np, w_np])
 
 
 def test_fake_transpose_quantize_conv_bias_add():
@@ -97,24 +111,11 @@ def test_fake_transpose_quantize_conv_bias_add():
     op = relay.op.nn.bias_add(op, relay.qnn.op.dequantize(bias, one, zero))
     op = relay.qnn.op.quantize(op, one, zero)
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
-
     x_np = np.random.randint(-128, 127, size=[1, 224, 224, 3], dtype="int8")
     w_np = np.random.randint(-128, 127, size=[16, 3, 5, 5], dtype="int8")
     bias_np = np.random.randint(-32768, 32767, size=[16], dtype="int32")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
-
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np, w_np, bias_np).numpy()
-
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np, w_np, bias_np).numpy()
-
-    assert np.array_equal(result, result2)
+    compare_fq_to_int(op, [x_np, w_np, bias_np])
 
 
 def test_fake_quantize_maxpool():
@@ -125,22 +126,9 @@ def test_fake_quantize_maxpool():
     op = relay.op.nn.max_pool2d(x, [3, 3])
     op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
-
     x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
-
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).numpy()
-
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).numpy()
-
-    assert np.array_equal(result, result2)
+    compare_fq_to_int(op, [x_np])
 
 
 def test_fake_quantize_avgpool():
@@ -151,22 +139,9 @@ def test_fake_quantize_avgpool():
     op = relay.op.nn.avg_pool2d(x, [3, 3])
     op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
-
     x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
-
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).numpy()
-
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).numpy()
-
-    assert np.all(np.abs(result - result2) <= 1)
+    compare_fq_to_int(op, [x_np], True)
 
 
 def test_fake_quantize_reshape():
@@ -177,22 +152,81 @@ def test_fake_quantize_reshape():
     op = relay.op.reshape(x, [1, 3, -1])
     op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
+def test_fake_quantize_expand_dims():
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+
+    zero = relay.const(0)
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), zero)
+    op = relay.op.expand_dims(x, axis=1)
+    op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
 
     x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
+    compare_fq_to_int(op, [x_np])
 
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).numpy()
 
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).numpy()
+def test_fake_quantize_squeeze():
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
 
-    assert np.array_equal(result, result2)
+    zero = relay.const(0)
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), zero)
+    op = relay.op.squeeze(x, axis=[0])
+    op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
+
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
+def test_fake_quantize_strided_slice():
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+
+    zero = relay.const(0)
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), zero)
+    op = relay.op.strided_slice(x, begin=[0, 0, 0, 0], end=[1, 1, 112, 112])
+    op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
+
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
+def test_fake_quantize_split():
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+
+    zero = relay.const(0)
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), zero)
+    op = relay.op.split(x, axis=3, indices_or_sections=2)
+    op = relay.qnn.op.quantize(op[0], relay.const(2.0), zero)
+
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+    op = relay.op.split(x, axis=3, indices_or_sections=[56, 112, 168])
+    op = relay.qnn.op.quantize(op[1], relay.const(2.0), zero)
+
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
+def test_fake_quantize_batch_flatten():
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+
+    zero = relay.const(0)
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), zero)
+    op = relay.op.nn.batch_flatten(x)
+    op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
+
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
 
 
 def test_fake_quantize_transpose_reshape():
@@ -204,22 +238,9 @@ def test_fake_quantize_transpose_reshape():
     op = relay.op.reshape(op, [3, -1])
     op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
-
     x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
-
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).numpy()
-
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).numpy()
-
-    assert np.array_equal(result, result2)
+    compare_fq_to_int(op, [x_np])
 
 
 def test_fake_quantize_concat():
@@ -234,24 +255,11 @@ def test_fake_quantize_concat():
     concat = relay.op.concatenate(inputs, axis=1)
     out = relay.qnn.op.quantize(concat, relay.const(3.5), zero)
 
-    mod = tvm.IRModule.from_expr(out)
-    mod = tvm.relay.transform.InferType()(mod)
-
     inputs_np = []
     for i in range(4):
         inputs_np.append(np.random.randint(-128, 127, size=[1, 4], dtype="int8"))
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
-
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(*inputs_np).numpy()
-
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(*inputs_np).numpy()
-
-    assert np.array_equal(result, result2)
+    compare_fq_to_int(out, inputs_np)
 
 
 def test_fake_quantize_clip():
@@ -261,19 +269,49 @@ def test_fake_quantize_clip():
     op = relay.op.clip(x, 0, 6)
     op = relay.qnn.op.quantize(op, relay.const(2.0), relay.const(114), out_dtype="uint8")
 
-    mod = tvm.IRModule.from_expr(op)
-    mod = tvm.relay.transform.InferType()(mod)
-
     x_np = np.random.randint(0, 255, size=[1, 3, 224, 224], dtype="uint8")
 
-    mod2 = tvm.relay.transform.FakeQuantizationToInteger()(mod)
-    assert not tvm.ir.structural_equal(mod, mod2)
-    mod2 = tvm.relay.transform.FoldConstant()(mod2)
+    compare_fq_to_int(op, [x_np])
 
-    ex = relay.create_executor("vm", mod=mod, device=tvm.cpu(), target="llvm")
-    result = ex.evaluate()(x_np).numpy()
 
-    ex = relay.create_executor("vm", mod=mod2, device=tvm.cpu(), target="llvm")
-    result2 = ex.evaluate()(x_np).numpy()
+@pytest.mark.parametrize("operator", [relay.op.add, relay.op.multiply])
+def test_fake_quantize_binary(operator):
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+    x = relay.qnn.op.dequantize(x, relay.const(0.1), relay.const(10))
 
-    assert np.array_equal(result, result2)
+    y = relay.var("y", shape=[1, 3, 224, 224], dtype="int8")
+    y = relay.qnn.op.dequantize(y, relay.const(0.2), relay.const(-10))
+
+    op = operator(x, y)
+    op = relay.qnn.op.quantize(op, relay.const(20.0), relay.const(0), out_dtype="int8")
+
+    x_np = np.random.randint(-25, 25, size=[1, 3, 224, 224], dtype="int8")
+    y_np = np.random.randint(-25, 25, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np, y_np])
+
+
+@pytest.mark.parametrize("operator", [relay.op.add, relay.op.multiply])
+def test_fake_quantize_binary_const(operator):
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+    x = relay.qnn.op.dequantize(x, relay.const(0.1), relay.const(10))
+
+    y = relay.const(1.0)
+
+    op = operator(x, y)
+    op = relay.qnn.op.quantize(op, relay.const(20.0), relay.const(0), out_dtype="int8")
+
+    x_np = np.random.randint(-25, 25, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
+def test_fake_quantize_pad():
+    x = relay.var("x", shape=[1, 383, 128], dtype="int8")
+    x = relay.qnn.op.dequantize(x, relay.const(1.0), relay.const(10))
+    op = relay.op.nn.pad(x, [[0, 0], [0, 1], [0, 0]], 0.0)
+    op = relay.qnn.op.quantize(op, relay.const(1.0), relay.const(10), out_dtype="int8")
+
+    x_np = np.random.randint(-25, 25, size=[1, 383, 128], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])


### PR DESCRIPTION
Adding more ops to support QAT BERT. I also refactored the tests for easier extensions.

I marked this as WIP because the result isn't matching tflite, I need to do some more comparisons over the next day or two  to isolate the problem. 

I'm opening the PR now because supporting ops with multiple outputs required refactoring how I handle quantization specific types. Bringing it into the make ir namespace allows me to do what I need to do, but it also opens up a question of where or not this could be more used more generally in other places for quantization?

cc @jroesch @masahi @anijain2305 @jwfromm