### PR TITLE
Move Micro TVM top level page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ For Developers
    contribute/index
    deploy/index
    dev/how_to
+   microtvm/index
    errors
    faq
 
@@ -76,7 +77,6 @@ For Developers
    :hidden:
    :caption: MISC
 
-   microtvm/index
    vta/index
 
 


### PR DESCRIPTION
The micro TVM page was moved during a recent docs update. This
patch moves the top level index to the former location.
