### PR TITLE
[Frontend, Tensorflow] Support for broadcasting in batch_matmul when shapes differ

### DIFF
--- a/python/tvm/relay/frontend/tensorflow_ops.py
+++ b/python/tvm/relay/frontend/tensorflow_ops.py
@@ -1159,13 +1159,11 @@ def _batch_matmul():
 
             input_x = _op.reshape(input_x, newshape=new_shape_x)
             input_y = _op.reshape(input_y, newshape=new_shape_y)
-
+        elif len(orig_shape_y) < 3:
+            input_y = _op.reshape(input_y, (1, orig_shape_y[-2], orig_shape_y[-1]))
         adj_x = attr["adj_x"]
         adj_y = attr["adj_y"]
         input_x = _op.transpose(input_x, axes=[0, 2, 1]) if adj_x else input_x
-        shape_y = _infer_shape(input_y, mod)
-        if len(shape_y) < 3:
-            input_y = _op.reshape(input_y, (1, orig_shape_y[-2], orig_shape_y[-1]))
         input_y = _op.transpose(input_y, axes=[0, 2, 1]) if not adj_y else input_y
         ret = get_relay_op("batch_matmul")(input_x, input_y)
 

--- a/python/tvm/relay/frontend/tensorflow_ops.py
+++ b/python/tvm/relay/frontend/tensorflow_ops.py
@@ -1141,7 +1141,11 @@ def _batch_matmul():
             if is_static:
                 num_outer_elts = np.prod(outer_dims)
                 new_shape_x = (num_outer_elts, orig_shape_x[-2], orig_shape_x[-1])
-                new_shape_y = (num_outer_elts, orig_shape_y[-2], orig_shape_y[-1])
+                ndim_y = len(orig_shape_y)
+                if ndim_y > 2:
+                    new_shape_y = (num_outer_elts, orig_shape_y[-2], orig_shape_y[-1])
+                elif ndim_y == 2:
+                    new_shape_y = (1, orig_shape_y[-2], orig_shape_y[-1])
             else:  # handle dynamic shape (dyn.reshape op)
                 shape_of_x = list_shape_of(inputs[0], ndim)
                 shape_of_y = list_shape_of(inputs[1], ndim)
@@ -1154,11 +1158,7 @@ def _batch_matmul():
                 new_shape_y = _op.concatenate(_op.Tuple(new_shape_y), axis=0)
 
             input_x = _op.reshape(input_x, newshape=new_shape_x)
-
-            if np.prod(orig_shape_y) < np.prod(new_shape_y):
-                input_y = _op.broadcast_to(input_y, new_shape_y)
-            else:
-                input_y = _op.reshape(input_y, newshape=new_shape_y)
+            input_y = _op.reshape(input_y, newshape=new_shape_y)
 
         adj_x = attr["adj_x"]
         adj_y = attr["adj_y"]

--- a/python/tvm/relay/frontend/tensorflow_ops.py
+++ b/python/tvm/relay/frontend/tensorflow_ops.py
@@ -1132,6 +1132,7 @@ def _batch_matmul():
         orig_shape_x = _infer_shape(input_x, mod)
         orig_shape_y = _infer_shape(input_y, mod)
         ndim = len(orig_shape_x)
+        ndim_y = len(orig_shape_y)
 
         is_static = not check_symbolic_shape(orig_shape_x)
 
@@ -1141,7 +1142,6 @@ def _batch_matmul():
             if is_static:
                 num_outer_elts = np.prod(outer_dims)
                 new_shape_x = (num_outer_elts, orig_shape_x[-2], orig_shape_x[-1])
-                ndim_y = len(orig_shape_y)
                 if ndim_y > 2:
                     new_shape_y = (num_outer_elts, orig_shape_y[-2], orig_shape_y[-1])
                 elif ndim_y == 2:
@@ -1159,7 +1159,7 @@ def _batch_matmul():
 
             input_x = _op.reshape(input_x, newshape=new_shape_x)
             input_y = _op.reshape(input_y, newshape=new_shape_y)
-        elif len(orig_shape_y) < 3:
+        elif ndim_y == 2:
             input_y = _op.reshape(input_y, (1, orig_shape_y[-2], orig_shape_y[-1]))
         adj_x = attr["adj_x"]
         adj_y = attr["adj_y"]

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1843,6 +1843,9 @@ def test_forward_batch_matmul():
     _test_batch_matmul((1, 2, 3, 4, 5, 6), (1, 2, 3, 4, 6, 5), "float32", True, True)
     _test_batch_matmul((3, 4, 5, 6), (3, 4, 5, 6), "int32", True, False)
     _test_batch_matmul((2, 3, 4, 2, 3, 4, 5, 6), (2, 3, 4, 2, 3, 4, 5, 6), "float32", False, True)
+    _test_batch_matmul((1, 8, 64, 2), (2, 1), "float32", False, False)
+    _test_batch_matmul((1, 8, 8, 64), (64, 1), "float32", False, False)
+    _test_batch_matmul((1, 8, 64), (64, 1), "float32", False, False)
 
 
 @tvm.testing.requires_cuda
@@ -1868,6 +1871,20 @@ def test_forward_batch_matmul_dynamic():
         (None, None, None, 6, 5),
         (2, 3, 4, 5, 6),
         (2, 3, 4, 6, 5),
+        "float32",
+    )
+    _test_batch_matmul_dynamic(
+        (None, None, None, 5, 6),
+        (6, None),
+        (2, 3, 4, 5, 6),
+        (6, 1),
+        "float32",
+    )
+    _test_batch_matmul_dynamic(
+        (None, 5, 6),
+        (6, None),
+        (24, 5, 6),
+        (6, 1),
         "float32",
     )
 


### PR DESCRIPTION
Current implementation of `batch_matmul` in TF frontend is not able to handle cases where the shape of the second input differs from the first and a broadcast is needed to complete the operation. Also, in the current logic it always assumed that the shape of second input `shape_y` is atleast of length 3. This is not the case is some TF2 models like [efficientdet](https://tfhub.dev/tensorflow/efficientdet/d0/1). This PR handles these use cases. 

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
