### PR TITLE
[Target] Allow 'true' and 'false' strings in conversions to integer

### DIFF
--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -210,7 +210,14 @@ ObjectRef TargetInternal::ParseType(const std::string& str,
     // Parsing integer
     int v;
     if (!(is >> v)) {
-      throw Error(": Cannot parse into type \"Integer\" from string: " + str);
+      // Bool is a subclass of IntImm, so allow textual boolean values.
+      if (str == "True" || str == "true") {
+        v = 1;
+      } else if (str == "False" || str == "false") {
+        v = 0;
+      } else {
+        throw Error(": Cannot parse into type \"Integer\" from string: " + str);
+      }
     }
     return Integer(v);
   } else if (info.type_index == String::ContainerType::_GetOrAllocRuntimeTypeIndex()) {

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -28,6 +28,7 @@
 #include <tvm/tir/expr.h>
 
 #include <algorithm>
+#include <cctype>
 #include <stack>
 
 #include "../runtime/object_internal.h"

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -210,7 +210,7 @@ ObjectRef TargetInternal::ParseType(const std::string& str,
     // Parsing integer
     int v;
     if (!(is >> v)) {
-      std::string lower;
+      std::string lower(str.size(), '\x0');
       std::transform(str.begin(), str.end(), lower.begin(),
                      [](unsigned char c) { return std::tolower(c); });
       // Bool is a subclass of IntImm, so allow textual boolean values.

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -210,10 +210,13 @@ ObjectRef TargetInternal::ParseType(const std::string& str,
     // Parsing integer
     int v;
     if (!(is >> v)) {
+      std::string lower;
+      std::transform(str.begin(), str.end(), lower.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
       // Bool is a subclass of IntImm, so allow textual boolean values.
-      if (str == "True" || str == "true") {
+      if (lower == "true") {
         v = 1;
-      } else if (str == "False" || str == "false") {
+      } else if (lower == "false") {
         v = 0;
       } else {
         throw Error(": Cannot parse into type \"Integer\" from string: " + str);

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -299,5 +299,16 @@ def test_check_and_update_host_consist_3():
     assert target.host == host
 
 
+def test_target_attr_bool_value():
+    target0 = Target("llvm --link-params=True")
+    assert target0.attrs["link-params"] == 1
+    target1 = Target("llvm --link-params=true")
+    assert target1.attrs["link-params"] == 1
+    target2 = Target("llvm --link-params=False")
+    assert target2.attrs["link-params"] == 0
+    target3 = Target("llvm --link-params=false")
+    assert target3.attrs["link-params"] == 0
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
This will allow `Bool` attributes to take `true`/`false` values instead of 0 and 1 only.