### PR TITLE
[Metal] Fix run metal model when non first device is selected

### DIFF
--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -206,11 +206,11 @@ void MetalWorkspace::CopyDataFromTo(const void* from, size_t from_offset, void* 
   AUTORELEASEPOOL {
     this->Init();
     Device dev = dev_from;
+    if (dev_from.device_type == kDLCPU) dev = dev_to;
     Stream* s = GetStream(stream, dev.device_id);
     if (s->HasErrorHappened()) {
       LOG(FATAL) << "Error! Some problems on GPU happaned! Cannot copy data to current stream";
     }
-    if (dev_from.device_type == kDLCPU) dev = dev_to;
     id<MTLCommandBuffer> cb = s->GetCommandBuffer();
     int from_dev_type = static_cast<int>(dev_from.device_type);
     int to_dev_type = static_cast<int>(dev_to.device_type);


### PR DESCRIPTION
In case when we select non first Metal device, we got problem in
stream, due to we used wrong device_id in CopyDataFromTo.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
