### PR TITLE
[Bugfix] [tir] do not simplify 'Any() - Any()' to 0

### DIFF
--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -1190,7 +1190,7 @@ class Let(PrimExprWithOp):
 
 
 @tvm._ffi.register_object("tir.Any")
-class Any(PrimExpr):
+class Any(PrimExprWithOp):
     """Any node.
 
     span : Optional[Span]

--- a/src/tir/analysis/deep_equal.cc
+++ b/src/tir/analysis/deep_equal.cc
@@ -60,7 +60,7 @@ bool ExprDeepEqual::operator()(const PrimExpr& lhs, const PrimExpr& rhs) const {
     return plhs->dtype == prhs->dtype && plhs->value == prhs->value;
   }
   if (lhs.as<AnyNode>()) {
-    return lhs.same_as(rhs);
+    return false;
   }
   return DeepCmpSEqualHandler().SEqualReduce(lhs, rhs, false);
 }

--- a/src/tir/analysis/deep_equal.cc
+++ b/src/tir/analysis/deep_equal.cc
@@ -59,7 +59,7 @@ bool ExprDeepEqual::operator()(const PrimExpr& lhs, const PrimExpr& rhs) const {
     auto* prhs = rhs.as<IntImmNode>();
     return plhs->dtype == prhs->dtype && plhs->value == prhs->value;
   }
-  if (auto* plhs = lhs.as<AnyNode>()) {
+  if (lhs.as<AnyNode>()) {
     return lhs.same_as(rhs);
   }
   return DeepCmpSEqualHandler().SEqualReduce(lhs, rhs, false);

--- a/src/tir/analysis/deep_equal.cc
+++ b/src/tir/analysis/deep_equal.cc
@@ -59,6 +59,9 @@ bool ExprDeepEqual::operator()(const PrimExpr& lhs, const PrimExpr& rhs) const {
     auto* prhs = rhs.as<IntImmNode>();
     return plhs->dtype == prhs->dtype && plhs->value == prhs->value;
   }
+  if (auto* plhs = lhs.as<AnyNode>()) {
+    return lhs.same_as(rhs);
+  }
   return DeepCmpSEqualHandler().SEqualReduce(lhs, rhs, false);
 }
 

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -296,7 +296,6 @@ def test_sub_index_simplify():
     ck.verify(x - x, 0)
     ck.verify(a - a, 0)
     ck.verify(a - b, a - b)
-    ck.verify(a - b, c - c)
     ck.verify(x * y - x, x * (y + (-1)))
     ck.verify(x * y - 10 * x, x * (y + (-10)))
     ck.verify(y * x - x * z, x * (y - z))

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -275,6 +275,7 @@ def test_add_index_simplify():
 def test_sub_index_simplify():
     ck = RewriteChecker()
     x, y, z = te.var("x"), te.var("y"), te.var("z")
+    a, b, c = tvm.tir.Any(), tvm.tir.Any(), tvm.tir.Any()
 
     ck.verify(x + y - y, x)
     ck.verify(x + y - x, y)
@@ -293,6 +294,9 @@ def test_sub_index_simplify():
 
     # mul co-efficient foldng
     ck.verify(x - x, 0)
+    ck.verify(a - a, 0)
+    ck.verify(a - b, a - b)
+    ck.verify(a - b, c - c)
     ck.verify(x * y - x, x * (y + (-1)))
     ck.verify(x * y - 10 * x, x * (y + (-10)))
     ck.verify(y * x - x * z, x * (y - z))

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -275,7 +275,7 @@ def test_add_index_simplify():
 def test_sub_index_simplify():
     ck = RewriteChecker()
     x, y, z = te.var("x"), te.var("y"), te.var("z")
-    a, b, c = tvm.tir.Any(), tvm.tir.Any(), tvm.tir.Any()
+    a, b = tvm.tir.Any(), tvm.tir.Any()
 
     ck.verify(x + y - y, x)
     ck.verify(x + y - x, y)


### PR DESCRIPTION
## To reproduce

```python
import tvm
a = tvm.tir.Any()
b = tvm.tir.Any()
c = tvm.tir.Sub(a, b)
tvm.arith.Analyzer().simplify(c)
```

With this change, `tir` considers `a` and `b` as different. However, `structural_equal` still consider them as the same.

@yzhliu @comaniac 