### PR TITLE
Fix bulleted lists in TVM documentation

### DIFF
--- a/docker/install/ubuntu_install_sphinx.sh
+++ b/docker/install/ubuntu_install_sphinx.sh
@@ -20,4 +20,5 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install sphinx sphinx-gallery==0.4.0 autodocsumm sphinx_rtd_theme sphinx_autodoc_annotation matplotlib Image "commonmark>=0.7.3" "docutils>=0.11"
+# NOTE: install docutils < 0.17 to work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+pip3 install sphinx sphinx-gallery==0.4.0 autodocsumm sphinx_rtd_theme sphinx_autodoc_annotation matplotlib Image "commonmark>=0.7.3" "docutils>=0.11" "docutils<0.17"

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -3,7 +3,7 @@ TVM Documentations
 This folder contains the source of TVM documents
 
 - A hosted version of doc is at https://tvm.apache.org/docs
-- pip install "sphinx>=1.5.5" sphinx-gallery sphinx_rtd_theme matplotlib Image recommonmark "Pillow<7" "autodocsumm<0.2.0" tlcpack-sphinx-addon
+- pip install "sphinx>=1.5.5" sphinx-gallery sphinx_rtd_theme matplotlib Image recommonmark "Pillow<7" "autodocsumm<0.2.0" tlcpack-sphinx-addon "docutils<0.17"
 - (Versions 0.2.0 to 0.2.2 of autodocsumm are incompatible with sphinx>=3.4, https://github.com/Chilipp/autodocsumm/pull/42 )
 - Build tvm first in the root folder.
 - Run the following command

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -201,7 +201,10 @@ CONSTRAINTS = [
     ("coremltools", None),
     ("cpplint", None),
     ("decorator", None),
-    ("docutils", None),
+    (
+        "docutils",
+        "<0.17",
+    ),  # Work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
     ("future", None),
     ("image", None),
     ("matplotlib", None),


### PR DESCRIPTION
 * These currently do not render due to
 https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 * Breakage was likely caused due to https://github.com/apache/tvm/issues/7995

cc @tkonolige @jroesch @tqchen @hogepodge 