### PR TITLE
[Vulkan][Codegen] Fixed SPIR-V scoping bug with threadIdx

### DIFF
--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -128,6 +128,7 @@ spirv::Value CodeGenSPIRV::GetThreadIndex(const IterVar& iv, const PrimExpr& ext
     auto* sizeptr = extent.as<tir::IntImmNode>();
     ICHECK(sizeptr) << "SPIRV only allows constant thread group size "
                     << " get " << extent;
+    ICHECK_GE(ts.dim_index, 0) << "vthread should have been optimized out by here";
     ICHECK_LT(ts.dim_index, 3);
     workgroup_size_[ts.dim_index] = static_cast<uint32_t>(sizeptr->value);
   } else {

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -516,9 +516,13 @@ void CodeGenSPIRV::VisitStmt_(const ForNode* op) {
   // Must get init label after making value(to make sure they are correct)
   spirv::Label init_label = builder_->CurrentLabel();
   spirv::Label head_label = builder_->NewLabel();
+  builder_->SetName(head_label, "for_loop_head");
   spirv::Label body_label = builder_->NewLabel();
+  builder_->SetName(body_label, "for_loop_body");
   spirv::Label continue_label = builder_->NewLabel();
+  builder_->SetName(continue_label, "for_loop_continue");
   spirv::Label merge_label = builder_->NewLabel();
+  builder_->SetName(merge_label, "for_loop_merge");
   builder_->MakeInst(spv::OpBranch, head_label);
 
   // Loop head
@@ -643,9 +647,10 @@ void CodeGenSPIRV::VisitStmt_(const AttrStmtNode* op) {
   if (op->attr_key == tir::attr::thread_extent) {
     IterVar iv = Downcast<IterVar>(op->node);
     if (iv->thread_tag.length() != 0) {
+      // Will throw error if rebinding same local variable to a different extent.
+      analyzer_->Bind(iv->var, Range::FromMinExtent(0, op->value));
       if (!var_map_.count(iv->var.get())) {
         var_map_[iv->var.get()] = GetThreadIndex(iv, op->value);
-        analyzer_->Bind(iv->var, Range::FromMinExtent(0, op->value));
       }
     }
   } else if (op->attr_key == tir::attr::storage_scope) {

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -595,6 +595,20 @@ class IRBuilder {
     return val;
   }
 
+  /*! \brief Get a built-in value provided by SPIR-V
+   *
+   *  \param built_in The SPIR-V built-in array to access.  For
+   *  example, spv::BuiltInLocalInvocationId to access the thread
+   *  id.
+   *
+   *  \param index The index of the built-in array to access.
+   *
+   *  \param name The name of the value being accessed.  For
+   *  example, "threadIdx.x".  This is for debug purposes, and is
+   *  used to tag the variable with OpName.
+   */
+  Value GetBuiltInValue(spv::BuiltIn built_in, uint32_t index, const std::string& name = "");
+
   /*!
    * \brief The common function to declare push constants or uniform buffer
    * \param value_types The values in the push constants or uniform buffer
@@ -642,36 +656,31 @@ class IRBuilder {
   SType t_bool_, t_int32_, t_uint32_, t_fp32_, t_void_, t_void_func_;
   /*! \brief quick cache for const one i32 */
   Value const_i32_zero_;
-  /*! \brief Cached pointer to workgroup id array
-   *
-   *  An object decorated with spv::BuildInWorkgroupId, in the global
-   *  definitions of the shader.  This is a pointer to an array of
-   *  workgroup ids.  Accessing element 0 of this array is equivalent
-   *  to cuda's blockIdx.x, element 1 is blockIdx.y, and so on.
-   */
-  Value workgroup_id_;
 
-  /*! \brief Cached map of workgroup ids
+  /*! \brief The cached values for built-in arrays
    *
-   * Values read from the workgroup_id_ array.
+   *  Maps from a tuple of spv::BuiltIn enum to the Value containing
+   *  that built-in array.  For example,
+   *  ``built_in_tbl_[spv::BuiltInLocalInvocationId]`` is the array
+   *  of invocation ids, equivalent to an array of ``threadIdx.x``,
+   *  ``threadIdx.y``, and ``threadIdx.z`` in CUDA.
+   *
+   *  These are declared in the global section of the shader.
    */
-  std::unordered_map<uint32_t, Value> workgroup_id_tbl_;
+  std::unordered_map<spv::BuiltIn, Value> built_in_tbl_;
 
-  /*! \brief Cached pointer to local id array
+  /*! \brief The cached values for built-in values
    *
-   *  An object decorated with spv::BuildInLocalInvocationId, in the
-   *  global definitions of the shader.  This is a pointer to an
-   *  array of local ids.  Accessing element 0 of this array is
-   *  equivalent to cuda's threadIdx.x, element 1 is threadIdx.y,
-   *  and so on.
-   */
-  Value local_id_;
-
-  /*! \brief Cached map of local ids
+   *  Maps from a tuple of (spv::BuiltIn enum, index) to the value
+   *  stored at that index of the built-in array.  For example,
+   *  ``built_in_tbl_[{spv::BuiltInLocalInvocationId, 0}]`` is the
+   *  first index of the invocation id, equivalent to
+   *  ``threadIdx.x`` in CUDA.
    *
-   * Values read from the local_id_ array.
+   *  These are declared in the first block of the function, in the
+   *  ``function_scope_vars_`` section.
    */
-  std::unordered_map<uint32_t, Value> local_id_tbl_;
+  std::map<std::tuple<spv::BuiltIn, uint32_t>, Value> built_in_values_tbl_;
 
   /*! \brief whether push constant is defined */
   Value push_const_;


### PR DESCRIPTION
Change is split into two commits, one which implements the fix, and one which refactors the result into a more general use.

* [Vulkan][Codegen] Fixed SPIR-V scoping bug with threadIdx

  Unlike in Cuda, where the threadIdx.x/y/z are separate built-in variables, in vulkan the built-in thread index consists of an array
that must be dereferenced.  If `te.thread_axis("threadIdx.x")` is first declared inside a scope, then that same python object is passed as the IterVar of a separate scope, this breaks the spirv scoping rules, and may result in an undefined variable.  This only applies to threadIdx/blockIdx variables, as all other variable declarations obey tir's scoping rules.

  To resolve, the threadIdx and blockIdx variables are declared at the top of the function declaration.  This makes the generated spirv code follow the same semantics as tir/cuda.

* [Vulkan][Codegen] Refactor of GetLocalID and GetWorkgroupID

  Shared behavior separated out into GetBuiltInValue.