### PR TITLE
[rust] convert error msg to string for panic macro

### DIFF
--- a/rust/tvm-macros/src/util.rs
+++ b/rust/tvm-macros/src/util.rs
@@ -43,6 +43,6 @@ pub(crate) fn attr_to_str(attr: &syn::Attribute) -> syn::LitStr {
             ..
         })) => s,
         Ok(m) => panic!("Expected a string literal, got {:?}", m),
-        Err(e) => panic!(e),
+        Err(e) => panic!("{}", e),
     }
 }

--- a/rust/tvm-rt/src/object/object_ptr.rs
+++ b/rust/tvm-rt/src/object/object_ptr.rs
@@ -109,7 +109,7 @@ impl Object {
             let mut index = 0;
             unsafe {
                 if TVMObjectTypeKey2Index(cstring.as_ptr(), &mut index) != 0 {
-                    panic!(crate::get_last_error())
+                    panic!("{}", crate::get_last_error())
                 }
             }
             return index;

--- a/rust/tvm/src/ir/diagnostics/codespan.rs
+++ b/rust/tvm/src/ir/diagnostics/codespan.rs
@@ -191,7 +191,7 @@ fn renderer(state: &mut DiagnosticState, diag_ctx: DiagnosticContext) {
     let config = codespan_reporting::term::Config::default();
     for diagnostic in diag_ctx.diagnostics.clone() {
         match source_map.source_map.get(&diagnostic.span.source_name) {
-            Err(err) => panic!(err),
+            Err(err) => panic!("{}", err),
             Ok(source) => {
                 state.add_source(source);
                 let diagnostic = state.to_diagnostic(diagnostic);


### PR DESCRIPTION
This PR converts error msg to string for panic marco in Rust. This reduces compiler warnings when running `cargo build`.