### PR TITLE
Turn on Compute library testing in CI for AArch64

### DIFF
--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -43,5 +43,5 @@ COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh
 RUN bash /install/ubuntu_install_redis.sh
 
 # Arm(R) Compute Library
-COPY install/ubuntu_install_arm_compute_lib.sh /install/ubuntu_install_arm_compute_lib.sh
-RUN bash /install/ubuntu_install_arm_compute_lib.sh
+COPY install/ubuntu_download_arm_compute_lib_binaries.sh /install/ubuntu_download_arm_compute_lib_binaries.sh
+RUN bash /install/ubuntu_download_arm_compute_lib_binaries.sh

--- a/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
+++ b/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
@@ -38,7 +38,7 @@ target_lib="linux-arm64-v8a-neon"
 # target_lib="${target_lib}-asserts"
 
 extract_dir="arm_compute-${compute_lib_version}-bin-linux"
-install_path="/opt/arm/acl"
+install_path="/opt/acl"
 
 tmpdir=$(mktemp -d)
 
@@ -54,6 +54,7 @@ cd "$tmpdir"
 curl -sL "${compute_lib_download_url}" -o "${compute_lib_file_name}"
 tar xzf "${compute_lib_file_name}"
 
+rm -rf "${install_path}"
 mkdir -p "${install_path}"
 cp -r "${extract_dir}/include" "${install_path}/"
 cp -r "${extract_dir}/arm_compute" "${install_path}/include/"

--- a/tests/python/contrib/test_arm_compute_lib/test_network.py
+++ b/tests/python/contrib/test_arm_compute_lib/test_network.py
@@ -56,7 +56,10 @@ def _build_and_run_network(mod, params, inputs, device, tvm_ops, acl_partitions,
 
 def _get_tflite_model(tflite_model_path, inputs_dict):
     """Convert TFlite graph to relay."""
-    import tflite.Model
+    try:
+        import tflite.Model
+    except ImportError:
+        pytest.skip("Missing Tflite support")
 
     with open(tflite_model_path, "rb") as f:
         tflite_model_buffer = f.read()
@@ -92,7 +95,10 @@ def test_vgg16():
     device = Device()
 
     def get_model():
-        from keras.applications import VGG16
+        try:
+            from keras.applications import VGG16
+        except ImportError:
+            pytest.skip("Missing Keras Package")
 
         vgg16 = VGG16(include_top=True, weights="imagenet", input_shape=(224, 224, 3), classes=1000)
         inputs = {vgg16.input_names[0]: ((1, 224, 224, 3), "float32")}
@@ -113,7 +119,10 @@ def test_mobilenet():
     device = Device()
 
     def get_model():
-        from keras.applications import MobileNet
+        try:
+            from keras.applications import MobileNet
+        except ImportError:
+            pytest.skip("Missing keras module")
 
         mobilenet = MobileNet(
             include_top=True, weights="imagenet", input_shape=(224, 224, 3), classes=1000
@@ -133,7 +142,10 @@ def test_quantized_mobilenet():
     if skip_runtime_test():
         return
 
-    import tvm.relay.testing.tf as tf_testing
+    try:
+        import tvm.relay.testing.tf as tf_testing
+    except ImportError:
+        pytest.skip("Missing Tflite support")
 
     device = Device()
 
@@ -158,7 +170,10 @@ def test_squeezenet():
     if skip_runtime_test():
         return
 
-    import tvm.relay.testing.tf as tf_testing
+    try:
+        import tvm.relay.testing.tf as tf_testing
+    except ImportError:
+        pytest.skip("Missing TF Support")
 
     device = Device()
 

--- a/tests/scripts/task_config_build_arm.sh
+++ b/tests/scripts/task_config_build_arm.sh
@@ -34,4 +34,4 @@ echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
-echo set\(USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR "/opt/arm/acl"\) >> config.cmake
+echo set\(USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR "/opt/acl"\) >> config.cmake

--- a/tests/scripts/task_config_build_arm.sh
+++ b/tests/scripts/task_config_build_arm.sh
@@ -34,4 +34,4 @@ echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
-echo set\(USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR "/opt/arm/acl") >> config.cmake
+echo set\(USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR "/opt/arm/acl"\) >> config.cmake

--- a/tests/scripts/task_config_build_arm.sh
+++ b/tests/scripts/task_config_build_arm.sh
@@ -34,3 +34,4 @@ echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
+echo set\(USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR "/opt/arm/acl") >> config.cmake


### PR DESCRIPTION
This pull request turns on compute library testing in CI by

1. Handling import errors in Compute Library Integration.
2. Setting the configuration to the right path for ACL.

This pull request allows for the AArch64 CI to pick up native
compute library testing and tests the operators being offloaded at
runtime.

@mbaret @d-smirnov @lhutton1 - could I get a review please ? 
