### PR TITLE
Fix deprecated use of numpy.asscalar.

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -391,10 +391,10 @@ class PyTorchOpConverter:
         stride = inputs[4]
 
         target_begin, is_begin_const = try_infer_value(
-            inputs[2], lambda ret: np.asscalar(ret.astype(np.int))
+            inputs[2], lambda ret: ret.astype(np.int).item(0)
         )
         target_end, is_end_const = try_infer_value(
-            inputs[3], lambda ret: np.asscalar(ret.astype(np.int))
+            inputs[3], lambda ret: ret.astype(np.int).item(0)
         )
 
         # A fast path when slicing is nop.
@@ -1306,7 +1306,7 @@ class PyTorchOpConverter:
         for i, shape in enumerate(shape_inp):
             if isinstance(shape, _expr.Expr):
                 val = _infer_value_simulated(shape, {})
-                new_shape[i] = np.asscalar(val.numpy())
+                new_shape[i] = val.numpy().item(0)
 
         return _op.transform.reshape(data, new_shape)
 

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -460,7 +460,7 @@ def _get_numpy(relay_const_scalar):
 
 
 def _get_scalar(relay_const_scalar):
-    return np.asscalar(_get_numpy(relay_const_scalar))
+    return _get_numpy(relay_const_scalar).item(0)
 
 
 def _do_bias_and_requantize(

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -3496,7 +3496,7 @@ def get_scalar_from_constant(expr):
     assert value.dtype == np.dtype(np.int32) or value.dtype == np.dtype(
         np.float32
     ), "value must be float32/int32"
-    return np.asscalar(value)
+    return value.item(0)
 
 
 def get_tensor_from_constant(expr):

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -91,7 +91,7 @@ def get_scalar_from_constant(expr):
     assert value.dtype == np.dtype(np.int32) or value.dtype == np.dtype(
         np.float32
     ), "value must be float32/int32"
-    return np.asscalar(value)
+    return value.item(0)
 
 
 # Helper function for lowering in the abscence of fast Int8 arithmetic units.


### PR DESCRIPTION
Replace use of numpy.asscalar with the use of .item .

numpy.asscalar is deprecated as per numpy 1.16 , replace that with the use of .item . See https://numpy.org/doc/stable/reference/generated/numpy.asscalar.html

regards
Ramana

