### PR TITLE
Check for presence of LLVM configuration.

### DIFF
--- a/cmake/modules/contrib/ArmComputeLib.cmake
+++ b/cmake/modules/contrib/ArmComputeLib.cmake
@@ -27,6 +27,10 @@ if(USE_ARM_COMPUTE_LIB)
     if(NOT USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR)
         list(APPEND COMPILER_SRCS ${ACL_RUNTIME_MODULE})
     endif()
+    if(NOT DEFINED TVM_LLVM_VERSION)
+      message(FATAL_ERROR "Support for offloading to Compute library for the Arm Architecture requires LLVM Support")
+    endif()
+
     message(STATUS "Build with Arm Compute Library support...")
 endif()
 

--- a/cmake/modules/contrib/EthosN.cmake
+++ b/cmake/modules/contrib/EthosN.cmake
@@ -20,6 +20,10 @@
 if(NOT USE_ETHOSN STREQUAL "OFF")
   find_ethosn(${USE_ETHOSN})
 
+  if(NOT DEFINED TVM_LLVM_VERSION)
+      message(FATAL_ERROR "Support for offloading to Ethos-N requires LLVM Support")
+  endif()
+
   if(NOT ETHOSN_FOUND)
     message(FATAL_ERROR "Cannot find Ethos-N, USE_ETHOSN=" ${USE_ETHOSN})
 


### PR DESCRIPTION
LLVM is a pre-requisite for configuring Compute Library
and offloading to Ethos-N NPU.

Better to get the error message at build time rather
than debugging SEGVs in testsuites.

@Leo-arm , @mbaret , @d-smirnov 
