### PR TITLE
Fix rst formatting in documentation

### DIFF
--- a/docs/deploy/arm_compute_lib.rst
+++ b/docs/deploy/arm_compute_lib.rst
@@ -15,8 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
-Relay Arm:sup:`®` Compute Library Integration
-==============================================
+Relay Arm\ :sup:`®` Compute Library Integration
+===============================================
 **Author**: `Luke Hutton <https://github.com/lhutton1>`_
 
 Introduction


### PR DESCRIPTION
Whitespace is required before ":sup:". Using backslash-escaped whitespace
prevents it from appearing in the processed document.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
