### PR TITLE
[Docker] Update tensorflow/tflite/xgboost versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,9 @@ conda/pkg
 .envrc
 *.nix
 
+# Docker files
+.sudo_as_admin_successful
+
 # Downloaded models/datasets
 .tvm_test_data
 .dgl

--- a/docker/install/ubuntu_install_redis.sh
+++ b/docker/install/ubuntu_install_redis.sh
@@ -21,4 +21,4 @@ set -u
 set -o pipefail
 
 apt-get update && apt-get install -y redis-server
-pip3 install xgboost>=1.1.0 psutil
+pip3 install "xgboost>=1.1.0" psutil

--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -20,7 +20,4 @@ set -e
 set -u
 set -o pipefail
 
-# h5py is pinned to minor than 3 due to issues with
-# tensorflow:
-# https://github.com/tensorflow/tensorflow/issues/44467
-pip3 install tensorflow==2.3.1 keras==2.4.3 "h5py<3.0"
+pip3 install tensorflow==2.4.2


### PR DESCRIPTION
- Updated tensorflow version to 2.4.2, required following update to cuda 11.0.  Based on https://www.tensorflow.org/install/source#gpu, the 2.4 branch of tensorflow should be used with cuda 11.0.
    
- Removed pinned version of h5py, no longer needed with tensorflow 2.4.x
    
  https://github.com/tensorflow/tensorflow/issues/44467#issuecomment-720631688
    
- Updated tflite version to 2.4.2.  Also, tflite install script now reads the installed version of tensorflow, to keep the version matched in the future.

- Previously, due to missing quotes, installed most recent version of xgboost, piping the results to a file named '=1.1.0'.  Now, installs xgboost at least at version 1.1.0.