### PR TITLE
[Relay] Remove in-place modification of attributes in layout transform

### DIFF
--- a/src/relay/op/dyn/nn/upsampling.h
+++ b/src/relay/op/dyn/nn/upsampling.h
@@ -41,7 +41,7 @@ InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
                                                       const Array<Layout>& old_in_layouts,
                                                       const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<T>();
-  CHECK(attrs_ptr);
+  ICHECK(attrs_ptr);
   ObjectPtr<T> params = make_object<T>(*attrs_ptr);
 
   if (new_in_layouts.defined()) {

--- a/src/relay/op/dyn/nn/upsampling.h
+++ b/src/relay/op/dyn/nn/upsampling.h
@@ -62,7 +62,7 @@ InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
   Layout inferred_layout(params->layout);
   Layout param_layout("NCHW");
   return InferCorrectLayoutOutput(
-      {{inferred_layout, param_layout, param_layout}, {inferred_layout}}, Attrs(params));
+      {inferred_layout, param_layout, param_layout}, {inferred_layout}, Attrs(params));
 }
 
 }  // namespace dyn

--- a/src/relay/op/dyn/nn/upsampling.h
+++ b/src/relay/op/dyn/nn/upsampling.h
@@ -61,8 +61,8 @@ InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
 
   Layout inferred_layout(params->layout);
   Layout param_layout("NCHW");
-  return InferCorrectLayoutOutput(
-      {inferred_layout, param_layout, param_layout}, {inferred_layout}, Attrs(params));
+  return InferCorrectLayoutOutput({inferred_layout, param_layout, param_layout}, {inferred_layout},
+                                  Attrs(params));
 }
 
 }  // namespace dyn

--- a/src/relay/op/dyn/nn/upsampling.h
+++ b/src/relay/op/dyn/nn/upsampling.h
@@ -36,12 +36,14 @@ namespace relay {
 namespace dyn {
 
 template <typename T>
-Array<Array<Layout> > UpsamplingInferCorrectLayout(const Attrs& attrs,
-                                                   const Array<Layout>& new_in_layouts,
-                                                   const Array<Layout>& old_in_layouts,
-                                                   const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  T* params = const_cast<T*>(attrs.as<T>());
+InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
+                                                      const Array<Layout>& new_in_layouts,
+                                                      const Array<Layout>& old_in_layouts,
+                                                      const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<T>();
+  CHECK(attrs_ptr);
+  ObjectPtr<T> params = make_object<T>(*attrs_ptr);
+
   if (new_in_layouts.defined()) {
     ICHECK_GT(new_in_layouts.size(), 0);
 
@@ -59,7 +61,9 @@ Array<Array<Layout> > UpsamplingInferCorrectLayout(const Attrs& attrs,
 
   Layout inferred_layout(params->layout);
   Layout param_layout("NCHW");
-  return Array<Array<Layout> >{{inferred_layout, param_layout, param_layout}, {inferred_layout}};
+  return InferCorrectLayoutOutput(
+      Array<Array<Layout> >{{inferred_layout, param_layout, param_layout}, {inferred_layout}},
+      Attrs(params));
 }
 
 }  // namespace dyn

--- a/src/relay/op/dyn/nn/upsampling.h
+++ b/src/relay/op/dyn/nn/upsampling.h
@@ -62,8 +62,7 @@ InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
   Layout inferred_layout(params->layout);
   Layout param_layout("NCHW");
   return InferCorrectLayoutOutput(
-      Array<Array<Layout> >{{inferred_layout, param_layout, param_layout}, {inferred_layout}},
-      Attrs(params));
+      {{inferred_layout, param_layout, param_layout}, {inferred_layout}}, Attrs(params));
 }
 
 }  // namespace dyn

--- a/src/relay/op/image/dilation2d.cc
+++ b/src/relay/op/image/dilation2d.cc
@@ -41,8 +41,7 @@ InferCorrectLayoutOutput Dilation2DInferCorrectLayout(const Attrs& attrs,
   const T* params = attrs.as<T>();
 
   return InferCorrectLayoutOutput(
-      Array<Array<Layout> >{{params->data_layout, params->kernel_layout}, {params->data_layout}},
-      attrs);
+      {{params->data_layout, params->kernel_layout}, {params->data_layout}}, attrs);
 }
 
 // Positional relay function to create dilation2d operator

--- a/src/relay/op/image/dilation2d.cc
+++ b/src/relay/op/image/dilation2d.cc
@@ -39,9 +39,8 @@ InferCorrectLayoutOutput Dilation2DInferCorrectLayout(const Attrs& attrs,
                                                       const Array<Layout>& old_in_layouts,
                                                       const Array<tvm::relay::Type>& old_in_types) {
   const T* params = attrs.as<T>();
-
-  return InferCorrectLayoutOutput(
-      {{params->data_layout, params->kernel_layout}, {params->data_layout}}, attrs);
+  return InferCorrectLayoutOutput({params->data_layout, params->kernel_layout},
+                                  {params->data_layout}, attrs);
 }
 
 // Positional relay function to create dilation2d operator

--- a/src/relay/op/image/dilation2d.cc
+++ b/src/relay/op/image/dilation2d.cc
@@ -34,13 +34,15 @@ namespace relay {
 TVM_REGISTER_NODE_TYPE(Dilation2DAttrs);
 
 template <typename T>
-Array<Array<Layout> > Dilation2DInferCorrectLayout(const Attrs& attrs,
-                                                   const Array<Layout>& new_in_layouts,
-                                                   const Array<Layout>& old_in_layouts,
-                                                   const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput Dilation2DInferCorrectLayout(const Attrs& attrs,
+                                                      const Array<Layout>& new_in_layouts,
+                                                      const Array<Layout>& old_in_layouts,
+                                                      const Array<tvm::relay::Type>& old_in_types) {
   const T* params = attrs.as<T>();
 
-  return Array<Array<Layout> >{{params->data_layout, params->kernel_layout}, {params->data_layout}};
+  return InferCorrectLayoutOutput(
+      Array<Array<Layout> >{{params->data_layout, params->kernel_layout}, {params->data_layout}},
+      attrs);
 }
 
 // Positional relay function to create dilation2d operator

--- a/src/relay/op/image/resize.cc
+++ b/src/relay/op/image/resize.cc
@@ -55,8 +55,7 @@ InferCorrectLayoutOutput ResizeInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};
-  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
+  return InferCorrectLayoutOutput({params->layout}, {params->layout}, Attrs(params));
 }
 
 bool ResizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/image/resize.cc
+++ b/src/relay/op/image/resize.cc
@@ -34,12 +34,13 @@ namespace relay {
 TVM_REGISTER_NODE_TYPE(ResizeAttrs);
 
 template <typename T>
-Array<Array<Layout> > ResizeInferCorrectLayout(const Attrs& attrs,
-                                               const Array<Layout>& new_in_layouts,
-                                               const Array<Layout>& old_in_layouts,
-                                               const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  T* params = const_cast<T*>(attrs.as<T>());
+InferCorrectLayoutOutput ResizeInferCorrectLayout(const Attrs& attrs,
+                                                  const Array<Layout>& new_in_layouts,
+                                                  const Array<Layout>& old_in_layouts,
+                                                  const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<T>();
+  CHECK(attrs_ptr);
+  ObjectPtr<T> params = make_object<T>(*attrs_ptr);
 
   if (new_in_layouts.defined()) {
     ICHECK_EQ(new_in_layouts.size(), 1);
@@ -54,8 +55,8 @@ Array<Array<Layout> > ResizeInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  Layout inferred_layout(params->layout);
-  return Array<Array<Layout> >{{inferred_layout}, {inferred_layout}};
+  Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};
+  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
 }
 
 bool ResizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -44,8 +44,7 @@ InferCorrectLayoutOutput BinaryConv2DInferCorrectLayout(
   // We always make other operators to fit the layouts of convolution layers
   // So this inference ignores all inputs
   return InferCorrectLayoutOutput(
-      Array<Array<Layout>>{{params->data_layout, params->kernel_layout}, {params->data_layout}},
-      attrs);
+      {{params->data_layout, params->kernel_layout}, {params->data_layout}}, attrs);
 }
 
 bool BitPackRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -43,8 +43,8 @@ InferCorrectLayoutOutput BinaryConv2DInferCorrectLayout(
 
   // We always make other operators to fit the layouts of convolution layers
   // So this inference ignores all inputs
-  return InferCorrectLayoutOutput(
-      {{params->data_layout, params->kernel_layout}, {params->data_layout}}, attrs);
+  return InferCorrectLayoutOutput({params->data_layout, params->kernel_layout},
+                                  {params->data_layout}, attrs);
 }
 
 bool BitPackRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -36,15 +36,16 @@ namespace relay {
 TVM_REGISTER_NODE_TYPE(BitPackAttrs);
 
 template <typename T>
-Array<Array<Layout>> BinaryConv2DInferCorrectLayout(const Attrs& attrs,
-                                                    const Array<Layout>& new_in_layouts,
-                                                    const Array<Layout>& old_in_layouts,
-                                                    const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput BinaryConv2DInferCorrectLayout(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
   const T* params = attrs.as<T>();
 
   // We always make other operators to fit the layouts of convolution layers
   // So this inference ignores all inputs
-  return Array<Array<Layout>>{{params->data_layout, params->kernel_layout}, {params->data_layout}};
+  return InferCorrectLayoutOutput(
+      Array<Array<Layout>>{{params->data_layout, params->kernel_layout}, {params->data_layout}},
+      attrs);
 }
 
 bool BitPackRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -117,8 +117,7 @@ with the layer input to produce a tensor of outputs.
     .add_argument("weight", "Tensor", "The weight tensor.")
     .set_support_level(2)
     .add_type_rel("Conv2D", Conv2DRel<Conv2DAttrs>)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>)
-    .set_attr<FInferLayout>("FInferLayout", ConvInferLayout<Conv2DAttrs>);
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>);
 
 // relay.nn.conv3d
 TVM_REGISTER_NODE_TYPE(Conv3DAttrs);
@@ -507,8 +506,7 @@ RELAY_REGISTER_OP("nn.contrib_conv2d_NCHWc")
     .add_argument("weight", "Tensor", "The weight tensor.")
     .set_support_level(10)
     .add_type_rel("Conv2DNCHWc", Conv2DWinogradRel<Conv2DAttrs>)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>)
-    .set_attr<FInferLayout>("FInferLayout", ConvInferLayout<Conv2DAttrs>);
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>);
 
 // Positional relay function to create depthwise conv2d NCHWc operator
 // used by frontend FFI.

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -117,7 +117,8 @@ with the layer input to produce a tensor of outputs.
     .add_argument("weight", "Tensor", "The weight tensor.")
     .set_support_level(2)
     .add_type_rel("Conv2D", Conv2DRel<Conv2DAttrs>)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>);
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>)
+    .set_attr<FInferLayout>("FInferLayout", ConvInferLayout<Conv2DAttrs>);
 
 // relay.nn.conv3d
 TVM_REGISTER_NODE_TYPE(Conv3DAttrs);
@@ -506,7 +507,8 @@ RELAY_REGISTER_OP("nn.contrib_conv2d_NCHWc")
     .add_argument("weight", "Tensor", "The weight tensor.")
     .set_support_level(10)
     .add_type_rel("Conv2DNCHWc", Conv2DWinogradRel<Conv2DAttrs>)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>);
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>)
+    .set_attr<FInferLayout>("FInferLayout", ConvInferLayout<Conv2DAttrs>);
 
 // Positional relay function to create depthwise conv2d NCHWc operator
 // used by frontend FFI.

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -1247,12 +1247,9 @@ InferCorrectLayoutOutput DeformableConvInferCorrectLayout(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types) {
   const AttrType* params = attrs.as<AttrType>();
-
-  // Layout of {data, offet, kernel}, {out}
-  Array<Array<Layout>> inferred_layout{
+  return InferCorrectLayoutOutput(
       {params->data_layout, params->data_layout, params->kernel_layout},
-      {params->out_layout == "" ? params->data_layout : params->out_layout}};
-  return InferCorrectLayoutOutput(inferred_layout, attrs);
+      {params->out_layout == "" ? params->data_layout : params->out_layout}, attrs);
 }
 
 template <typename T>
@@ -1261,13 +1258,11 @@ InferCorrectLayoutOutput ConvInferCorrectLayout(const Attrs& attrs,
                                                 const Array<Layout>& old_in_layouts,
                                                 const Array<tvm::relay::Type>& old_in_types) {
   const T* params = attrs.as<T>();
-
   // We always make other operators to fit the layouts of convolution layers
   // So this inference ignores all inputs
-  Array<Array<Layout>> inferred_layout{
+  return InferCorrectLayoutOutput(
       {params->data_layout, params->kernel_layout},
-      {params->out_layout == "" ? params->data_layout : params->out_layout}};
-  return InferCorrectLayoutOutput(inferred_layout, attrs);
+      {params->out_layout == "" ? params->data_layout : params->out_layout}, attrs);
 }
 
 }  // namespace relay

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -1243,19 +1243,20 @@ bool DeformableConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& 
 }
 
 template <typename AttrType>
-Array<Array<Layout> > DeformableConvInferCorrectLayout(
+InferCorrectLayoutOutput DeformableConvInferCorrectLayout(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types) {
   const AttrType* params = attrs.as<AttrType>();
 
   // Layout of {data, offet, kernel}, {out}
-  return Array<Array<Layout> >{
+  Array<Array<Layout>> inferred_layout{
       {params->data_layout, params->data_layout, params->kernel_layout},
       {params->out_layout == "" ? params->data_layout : params->out_layout}};
+  return InferCorrectLayoutOutput(inferred_layout, attrs);
 }
 
 template <typename T>
-Array<Array<Layout> > ConvInferCorrectLayout(const Attrs& attrs,
+InferCorrectLayoutOutput ConvInferCorrectLayout(const Attrs& attrs,
                                              const Array<Layout>& new_in_layouts,
                                              const Array<Layout>& old_in_layouts,
                                              const Array<tvm::relay::Type>& old_in_types) {
@@ -1263,26 +1264,10 @@ Array<Array<Layout> > ConvInferCorrectLayout(const Attrs& attrs,
 
   // We always make other operators to fit the layouts of convolution layers
   // So this inference ignores all inputs
-  return Array<Array<Layout> >{
-      {params->data_layout, params->kernel_layout},
-      {params->out_layout == "" ? params->data_layout : params->out_layout}};
-}
-
-template <typename T>
-InferCorrectLayoutOutput ConvInferLayout(const Attrs& attrs,
-                                             const Array<Layout>& new_in_layouts,
-                                             const Array<Layout>& old_in_layouts,
-                                             const Array<tvm::relay::Type>& old_in_types) {
-  const T* attrs_ptr = attrs.as<T>();
-  CHECK(attrs_ptr);
-  ObjectPtr<T> params = make_object<T>(*attrs_ptr);
-
-  // We always make other operators to fit the layouts of convolution layers
-  // So this inference ignores all inputs
   Array<Array<Layout>> inferred_layout{
       {params->data_layout, params->kernel_layout},
       {params->out_layout == "" ? params->data_layout : params->out_layout}};
-  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
+  return InferCorrectLayoutOutput(inferred_layout, attrs);
 }
 
 }  // namespace relay

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -1257,9 +1257,9 @@ InferCorrectLayoutOutput DeformableConvInferCorrectLayout(
 
 template <typename T>
 InferCorrectLayoutOutput ConvInferCorrectLayout(const Attrs& attrs,
-                                             const Array<Layout>& new_in_layouts,
-                                             const Array<Layout>& old_in_layouts,
-                                             const Array<tvm::relay::Type>& old_in_types) {
+                                                const Array<Layout>& new_in_layouts,
+                                                const Array<Layout>& old_in_layouts,
+                                                const Array<tvm::relay::Type>& old_in_types) {
   const T* params = attrs.as<T>();
 
   // We always make other operators to fit the layouts of convolution layers

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -1268,6 +1268,23 @@ Array<Array<Layout> > ConvInferCorrectLayout(const Attrs& attrs,
       {params->out_layout == "" ? params->data_layout : params->out_layout}};
 }
 
+template <typename T>
+InferCorrectLayoutOutput ConvInferLayout(const Attrs& attrs,
+                                             const Array<Layout>& new_in_layouts,
+                                             const Array<Layout>& old_in_layouts,
+                                             const Array<tvm::relay::Type>& old_in_types) {
+  const T* attrs_ptr = attrs.as<T>();
+  CHECK(attrs_ptr);
+  ObjectPtr<T> params = make_object<T>(*attrs_ptr);
+
+  // We always make other operators to fit the layouts of convolution layers
+  // So this inference ignores all inputs
+  Array<Array<Layout>> inferred_layout{
+      {params->data_layout, params->kernel_layout},
+      {params->out_layout == "" ? params->data_layout : params->out_layout}};
+  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
+}
+
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_OP_NN_CONVOLUTION_H_

--- a/src/relay/op/nn/correlation.cc
+++ b/src/relay/op/nn/correlation.cc
@@ -37,13 +37,12 @@ namespace relay {
 // relay.nn.correlation
 TVM_REGISTER_NODE_TYPE(CorrelationAttrs);
 
-Array<Array<Layout>> CorrelationInferCorrectLayout(const Attrs& attrs,
-                                                   const Array<Layout>& new_in_layouts,
-                                                   const Array<Layout>& old_in_layouts,
-                                                   const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput CorrelationInferCorrectLayout(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
   const auto* params = attrs.as<CorrelationAttrs>();
   Layout layout{params->layout};
-  return Array<Array<Layout>>{{layout, layout}, {layout}};
+  return InferCorrectLayoutOutput(Array<Array<Layout>>{{layout, layout}, {layout}}, attrs);
 }
 
 // Positional relay function to create correlation operator

--- a/src/relay/op/nn/correlation.cc
+++ b/src/relay/op/nn/correlation.cc
@@ -42,7 +42,7 @@ InferCorrectLayoutOutput CorrelationInferCorrectLayout(
     const Array<tvm::relay::Type>& old_in_types) {
   const auto* params = attrs.as<CorrelationAttrs>();
   Layout layout{params->layout};
-  return InferCorrectLayoutOutput({{layout, layout}, {layout}}, attrs);
+  return InferCorrectLayoutOutput({layout, layout}, {layout}, attrs);
 }
 
 // Positional relay function to create correlation operator

--- a/src/relay/op/nn/correlation.cc
+++ b/src/relay/op/nn/correlation.cc
@@ -42,7 +42,7 @@ InferCorrectLayoutOutput CorrelationInferCorrectLayout(
     const Array<tvm::relay::Type>& old_in_types) {
   const auto* params = attrs.as<CorrelationAttrs>();
   Layout layout{params->layout};
-  return InferCorrectLayoutOutput(Array<Array<Layout>>{{layout, layout}, {layout}}, attrs);
+  return InferCorrectLayoutOutput({{layout, layout}, {layout}}, attrs);
 }
 
 // Positional relay function to create correlation operator

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -284,7 +284,7 @@ InferCorrectLayoutOutput PReluInferCorrectLayout(const Attrs& attrs,
   if (new_in_layouts.defined()) {
     ICHECK_EQ(new_in_layouts.size(), 2U);
   }
-  return InferCorrectLayoutOutput({{data_layout, Layout("C")}, {data_layout}}, attrs);
+  return InferCorrectLayoutOutput({data_layout, Layout("C")}, {data_layout}, attrs);
 }
 
 // Positional relay function to create prelu operator used by frontend FFI.
@@ -629,9 +629,8 @@ InferCorrectLayoutOutput BatchNormInferCorrectLayout(const Attrs& attrs,
   }
   // BN has 5 inputs, 3 outputs. The last 4 inputs and last 2 outputs have "C" layout.
   Layout c_layout = Layout("C");
-
-  return InferCorrectLayoutOutput(
-      {{ret, c_layout, c_layout, c_layout, c_layout}, {ret, c_layout, c_layout}}, Attrs(param));
+  return InferCorrectLayoutOutput({ret, c_layout, c_layout, c_layout, c_layout},
+                                  {ret, c_layout, c_layout}, Attrs(param));
 }
 
 bool BatchNormRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -603,7 +603,9 @@ InferCorrectLayoutOutput BatchNormInferCorrectLayout(const Attrs& attrs,
                                                      const Array<Layout>& new_in_layouts,
                                                      const Array<Layout>& old_in_layouts,
                                                      const Array<tvm::relay::Type>& old_in_types) {
-  BatchNormAttrs* param = const_cast<BatchNormAttrs*>(attrs.as<BatchNormAttrs>());
+  const auto* attrs_ptr = attrs.as<BatchNormAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<BatchNormAttrs> param = make_object<BatchNormAttrs>(*attrs_ptr);
 
   Array<Array<IndexExpr>> old_in_shapes;
   for (auto old_in_t : old_in_types) {
@@ -632,7 +634,7 @@ InferCorrectLayoutOutput BatchNormInferCorrectLayout(const Attrs& attrs,
   return InferCorrectLayoutOutput(
       Array<Array<Layout>>{{ret, c_layout, c_layout, c_layout, c_layout},
                            {ret, c_layout, c_layout}},
-      attrs);
+      Attrs(param));
 }
 
 bool BatchNormRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -284,8 +284,7 @@ InferCorrectLayoutOutput PReluInferCorrectLayout(const Attrs& attrs,
   if (new_in_layouts.defined()) {
     ICHECK_EQ(new_in_layouts.size(), 2U);
   }
-  return InferCorrectLayoutOutput(Array<Array<Layout>>{{data_layout, Layout("C")}, {data_layout}},
-                                  attrs);
+  return InferCorrectLayoutOutput({{data_layout, Layout("C")}, {data_layout}}, attrs);
 }
 
 // Positional relay function to create prelu operator used by frontend FFI.
@@ -632,9 +631,7 @@ InferCorrectLayoutOutput BatchNormInferCorrectLayout(const Attrs& attrs,
   Layout c_layout = Layout("C");
 
   return InferCorrectLayoutOutput(
-      Array<Array<Layout>>{{ret, c_layout, c_layout, c_layout, c_layout},
-                           {ret, c_layout, c_layout}},
-      Attrs(param));
+      {{ret, c_layout, c_layout, c_layout, c_layout}, {ret, c_layout, c_layout}}, Attrs(param));
 }
 
 bool BatchNormRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -483,6 +483,7 @@ RELAY_REGISTER_OP("nn.relu")
     .set_support_level(1)
     .add_type_rel("Identity", IdentityRel)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
+    .set_attr<FInferLayout>("FInferLayout", ElemwiseArbitraryLayout2)
     .set_attr<FTVMCompute>("FTVMCompute", [](const Attrs& attrs, const Array<te::Tensor>& inputs,
                                              const Type& out_type) {
       return Array<te::Tensor>{topi::relu(inputs[0], 0.0f)};

--- a/src/relay/op/nn/pad.cc
+++ b/src/relay/op/nn/pad.cc
@@ -114,8 +114,7 @@ InferCorrectLayoutOutput PadInferCorrectLayout(const Attrs& attrs,
 
   // The pad value is always a scalar
   Layout ret_pad_value = Layout("1");
-  Array<Array<Layout>> inferred_layout{{ret_data, ret_pad_value}, {ret_data}};
-  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
+  return InferCorrectLayoutOutput({ret_data, ret_pad_value}, {ret_data}, Attrs(params));
 }
 
 bool PadRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/op/nn/pad.cc
+++ b/src/relay/op/nn/pad.cc
@@ -111,7 +111,6 @@ InferCorrectLayoutOutput PadInferCorrectLayout(const Attrs& attrs, const Array<L
     }
   }
 
-  LOG(INFO) << "pad :" << is_layout_modified << ", " << params->pad_width;
   // The pad value is always a scalar
   Layout ret_pad_value = Layout("1");
   Array<Array<Layout>> inferred_layout{{ret_data, ret_pad_value}, {ret_data}};

--- a/src/relay/op/nn/pad.cc
+++ b/src/relay/op/nn/pad.cc
@@ -109,10 +109,89 @@ Array<Array<Layout>> PadInferCorrectLayout(const Attrs& attrs, const Array<Layou
       ret_data = Layout::Undef();
     }
   }
-
+  LOG(INFO) << "pad :" << is_layout_modified << ", " << params->pad_width;
   // The pad value is always a scalar
   Layout ret_pad_value = Layout("1");
   return Array<Array<Layout>>{{ret_data, ret_pad_value}, {ret_data}};
+}
+
+InferCorrectLayoutOutput PadInferLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
+                                           const Array<Layout>& old_in_layouts,
+                                           const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<PadAttrs>();
+  CHECK(attrs_ptr);
+  ObjectPtr<PadAttrs> params = make_object<PadAttrs>(*attrs_ptr);
+
+  Layout ret_data;
+  // If new_in_layouts are defined, this code tries to modify the layout.
+  bool is_layout_modified = new_in_layouts.defined();
+  if (new_in_layouts.defined()) {
+    // Create a map of axis to param_width. For the new layout, a new param_width is generated using
+    // the map. The new layout is rejected, if the padding is happening along the axis which was
+    // split.
+
+    // 1) Create a map from axis to param_width using old layout.
+    std::map<std::string, tvm::Array<Integer>> axis_pad_width;
+    int index_counter = 0;
+    ICHECK_EQ(new_in_layouts.size(), 2);
+    ICHECK_EQ(old_in_layouts.size(), 2);
+    for (auto iter_var : old_in_layouts[0]->axes) {
+      const auto& old_layout_axis = LayoutAxis::Get(iter_var);
+      axis_pad_width.emplace(old_layout_axis.name(), params->pad_width[index_counter]);
+      index_counter++;
+    }
+
+    // 2) Create new pad width by walking over the new layout and using the map.
+    tvm::Array<tvm::Array<Integer>> new_pad_width;
+    for (auto iter_var : new_in_layouts[0]->axes) {
+      const auto& new_layout_axis = LayoutAxis::Get(iter_var);
+      auto axis_name = new_layout_axis.name();
+      if (axis_pad_width.count(axis_name) != 0 && new_layout_axis.IsPrimal()) {
+        // This is primal axis. So, directly use the original pad_width.
+        new_pad_width.push_back(axis_pad_width.at(axis_name));
+      } else {
+        // This is the axis that got split. So, check that pad_width was [0, 0] originally.
+        const auto& dual_axis = new_layout_axis.ToPrimal();
+        auto dual_axis_name = dual_axis.name();
+        ICHECK(axis_pad_width.count(dual_axis_name))
+            << "Missing axis " << dual_axis << " in " << old_in_layouts[0].name();
+        new_pad_width.push_back(axis_pad_width.at(dual_axis_name));
+
+        // If any pad_width element is not zero, do not change the layout.
+        for (auto width : axis_pad_width.at(dual_axis_name)) {
+          if (auto* width_imm = width.as<IntImmNode>()) {
+            if (width_imm->value != 0) {
+              is_layout_modified = false;
+            }
+          } else {
+            is_layout_modified = false;
+          }
+        }
+      }
+    }
+
+    // If the above conditions satisfied, we can set the newly created pad_width and use the new
+    // layout.
+    if (is_layout_modified) {
+      ret_data = new_in_layouts[0];
+      params->pad_width = new_pad_width;
+    }
+  }
+
+  if (!is_layout_modified) {
+    if (old_in_layouts.defined()) {
+      ICHECK_EQ(old_in_layouts.size(), 2);
+      ret_data = old_in_layouts[0];
+    } else {
+      ret_data = Layout::Undef();
+    }
+  }
+
+  LOG(INFO) << "pad :" << is_layout_modified << ", " << params->pad_width;
+  // The pad value is always a scalar
+  Layout ret_pad_value = Layout("1");
+  Array<Array<Layout>> inferred_layout{{ret_data, ret_pad_value}, {ret_data}};
+  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
 }
 
 bool PadRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
@@ -202,6 +281,7 @@ RELAY_REGISTER_OP("nn.pad")
     .set_support_level(2)
     .add_type_rel("Pad", PadRel)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", PadInferCorrectLayout)
+    .set_attr<FInferLayout>("FInferLayout", PadInferLayout)
     .set_attr<TOpPattern>("TOpPattern", kInjective)
     .set_attr<FTVMCompute>("FTVMCompute", PadCompute);
 

--- a/src/relay/op/nn/pad.cc
+++ b/src/relay/op/nn/pad.cc
@@ -39,9 +39,10 @@ namespace relay {
 // relay.nn.pad
 TVM_REGISTER_NODE_TYPE(PadAttrs);
 
-InferCorrectLayoutOutput PadInferCorrectLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
-                                           const Array<Layout>& old_in_layouts,
-                                           const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput PadInferCorrectLayout(const Attrs& attrs,
+                                               const Array<Layout>& new_in_layouts,
+                                               const Array<Layout>& old_in_layouts,
+                                               const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<PadAttrs>();
   CHECK(attrs_ptr);
   ObjectPtr<PadAttrs> params = make_object<PadAttrs>(*attrs_ptr);

--- a/src/relay/op/nn/pad.cc
+++ b/src/relay/op/nn/pad.cc
@@ -39,83 +39,7 @@ namespace relay {
 // relay.nn.pad
 TVM_REGISTER_NODE_TYPE(PadAttrs);
 
-Array<Array<Layout>> PadInferCorrectLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
-                                           const Array<Layout>& old_in_layouts,
-                                           const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  PadAttrs* params = const_cast<PadAttrs*>(attrs.as<PadAttrs>());
-
-  Layout ret_data;
-  // If new_in_layouts are defined, this code tries to modify the layout.
-  bool is_layout_modified = new_in_layouts.defined();
-  if (new_in_layouts.defined()) {
-    // Create a map of axis to param_width. For the new layout, a new param_width is generated using
-    // the map. The new layout is rejected, if the padding is happening along the axis which was
-    // split.
-
-    // 1) Create a map from axis to param_width using old layout.
-    std::map<std::string, tvm::Array<Integer>> axis_pad_width;
-    int index_counter = 0;
-    ICHECK_EQ(new_in_layouts.size(), 2);
-    ICHECK_EQ(old_in_layouts.size(), 2);
-    for (auto iter_var : old_in_layouts[0]->axes) {
-      const auto& old_layout_axis = LayoutAxis::Get(iter_var);
-      axis_pad_width.emplace(old_layout_axis.name(), params->pad_width[index_counter]);
-      index_counter++;
-    }
-
-    // 2) Create new pad width by walking over the new layout and using the map.
-    tvm::Array<tvm::Array<Integer>> new_pad_width;
-    for (auto iter_var : new_in_layouts[0]->axes) {
-      const auto& new_layout_axis = LayoutAxis::Get(iter_var);
-      auto axis_name = new_layout_axis.name();
-      if (axis_pad_width.count(axis_name) != 0 && new_layout_axis.IsPrimal()) {
-        // This is primal axis. So, directly use the original pad_width.
-        new_pad_width.push_back(axis_pad_width.at(axis_name));
-      } else {
-        // This is the axis that got split. So, check that pad_width was [0, 0] originally.
-        const auto& dual_axis = new_layout_axis.ToPrimal();
-        auto dual_axis_name = dual_axis.name();
-        ICHECK(axis_pad_width.count(dual_axis_name))
-            << "Missing axis " << dual_axis << " in " << old_in_layouts[0].name();
-        new_pad_width.push_back(axis_pad_width.at(dual_axis_name));
-
-        // If any pad_width element is not zero, do not change the layout.
-        for (auto width : axis_pad_width.at(dual_axis_name)) {
-          if (auto* width_imm = width.as<IntImmNode>()) {
-            if (width_imm->value != 0) {
-              is_layout_modified = false;
-            }
-          } else {
-            is_layout_modified = false;
-          }
-        }
-      }
-    }
-
-    // If the above conditions satisfied, we can set the newly created pad_width and use the new
-    // layout.
-    if (is_layout_modified) {
-      ret_data = new_in_layouts[0];
-      params->pad_width = new_pad_width;
-    }
-  }
-
-  if (!is_layout_modified) {
-    if (old_in_layouts.defined()) {
-      ICHECK_EQ(old_in_layouts.size(), 2);
-      ret_data = old_in_layouts[0];
-    } else {
-      ret_data = Layout::Undef();
-    }
-  }
-  LOG(INFO) << "pad :" << is_layout_modified << ", " << params->pad_width;
-  // The pad value is always a scalar
-  Layout ret_pad_value = Layout("1");
-  return Array<Array<Layout>>{{ret_data, ret_pad_value}, {ret_data}};
-}
-
-InferCorrectLayoutOutput PadInferLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
+InferCorrectLayoutOutput PadInferCorrectLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
                                            const Array<Layout>& old_in_layouts,
                                            const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<PadAttrs>();
@@ -281,7 +205,6 @@ RELAY_REGISTER_OP("nn.pad")
     .set_support_level(2)
     .add_type_rel("Pad", PadRel)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", PadInferCorrectLayout)
-    .set_attr<FInferLayout>("FInferLayout", PadInferLayout)
     .set_attr<TOpPattern>("TOpPattern", kInjective)
     .set_attr<FTVMCompute>("FTVMCompute", PadCompute);
 

--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -55,8 +55,7 @@ InferCorrectLayoutOutput PoolInferCorrectLayout(const Attrs& attrs,
     params->layout = new_in_layouts[0].name();
   }
 
-  Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};
-  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
+  return InferCorrectLayoutOutput({params->layout}, {params->layout}, Attrs(params));
 }
 
 IndexExpr calculate_pool_dimension(IndexExpr in_dimension, IndexExpr pad_amount,

--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -41,9 +41,10 @@ TVM_REGISTER_NODE_TYPE(MaxPool2DAttrs);
 TVM_REGISTER_NODE_TYPE(AvgPool2DAttrs);
 
 template <typename T>
-InferCorrectLayoutOutput PoolInferCorrectLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
-                                         const Array<Layout>& old_in_layouts,
-                                         const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput PoolInferCorrectLayout(const Attrs& attrs,
+                                                const Array<Layout>& new_in_layouts,
+                                                const Array<Layout>& old_in_layouts,
+                                                const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<T>();
   CHECK(attrs_ptr);
   ObjectPtr<T> params = make_object<T>(*attrs_ptr);

--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -52,6 +52,7 @@ Array<Array<Layout> > PoolInferCorrectLayout(const Attrs& attrs,
     // Set the pool with the new layout.
     ICHECK_EQ(new_in_layouts.size(), 1);
     params->layout = new_in_layouts[0].name();
+    LOG(INFO) << "New layout: " << params->layout;
   }
 
   Layout inferred_layout(params->layout);
@@ -70,6 +71,8 @@ InferCorrectLayoutOutput PoolInferLayout(const Attrs& attrs, const Array<Layout>
     // Set the pool with the new layout.
     ICHECK_EQ(new_in_layouts.size(), 1);
     params->layout = new_in_layouts[0].name();
+    LOG(INFO) << "New layout: " << params->layout;
+    LOG(INFO) << params->pool_size;
   }
 
   Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};

--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -41,26 +41,7 @@ TVM_REGISTER_NODE_TYPE(MaxPool2DAttrs);
 TVM_REGISTER_NODE_TYPE(AvgPool2DAttrs);
 
 template <typename T>
-Array<Array<Layout> > PoolInferCorrectLayout(const Attrs& attrs,
-                                             const Array<Layout>& new_in_layouts,
-                                             const Array<Layout>& old_in_layouts,
-                                             const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  T* params = const_cast<T*>(attrs.as<T>());
-
-  if (new_in_layouts.defined()) {
-    // Set the pool with the new layout.
-    ICHECK_EQ(new_in_layouts.size(), 1);
-    params->layout = new_in_layouts[0].name();
-    LOG(INFO) << "New layout: " << params->layout;
-  }
-
-  Layout inferred_layout(params->layout);
-  return Array<Array<Layout> >{{inferred_layout}, {inferred_layout}};
-}
-
-template <typename T>
-InferCorrectLayoutOutput PoolInferLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
+InferCorrectLayoutOutput PoolInferCorrectLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
                                          const Array<Layout>& old_in_layouts,
                                          const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<T>();
@@ -71,8 +52,6 @@ InferCorrectLayoutOutput PoolInferLayout(const Attrs& attrs, const Array<Layout>
     // Set the pool with the new layout.
     ICHECK_EQ(new_in_layouts.size(), 1);
     params->layout = new_in_layouts[0].name();
-    LOG(INFO) << "New layout: " << params->layout;
-    LOG(INFO) << params->pool_size;
   }
 
   Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};
@@ -231,7 +210,6 @@ RELAY_REGISTER_OP("nn.max_pool2d")
     .set_support_level(2)
     .add_type_rel("MaxPool2D", Pool2DRel<MaxPool2DAttrs>)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", PoolInferCorrectLayout<MaxPool2DAttrs>)
-    .set_attr<FInferLayout>("FInferLayout", PoolInferLayout<MaxPool2DAttrs>)
     .set_attr<FTVMCompute>("FTVMCompute", Pool2DCompute<MaxPool2DAttrs, topi::nn::kMaxPool>);
 
 // AvgPool2D

--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -46,7 +46,7 @@ InferCorrectLayoutOutput PoolInferCorrectLayout(const Attrs& attrs,
                                                 const Array<Layout>& old_in_layouts,
                                                 const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<T>();
-  CHECK(attrs_ptr);
+  ICHECK(attrs_ptr);
   ObjectPtr<T> params = make_object<T>(*attrs_ptr);
 
   if (new_in_layouts.defined()) {

--- a/src/relay/op/nn/upsampling.h
+++ b/src/relay/op/nn/upsampling.h
@@ -35,12 +35,13 @@ namespace tvm {
 namespace relay {
 
 template <typename T>
-Array<Array<Layout> > UpsamplingInferCorrectLayout(const Attrs& attrs,
-                                                   const Array<Layout>& new_in_layouts,
-                                                   const Array<Layout>& old_in_layouts,
-                                                   const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  T* params = const_cast<T*>(attrs.as<T>());
+InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
+                                                      const Array<Layout>& new_in_layouts,
+                                                      const Array<Layout>& old_in_layouts,
+                                                      const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<T>();
+  CHECK(attrs_ptr);
+  ObjectPtr<T> params = make_object<T>(*attrs_ptr);
 
   if (new_in_layouts.defined()) {
     ICHECK_EQ(new_in_layouts.size(), 1);
@@ -57,8 +58,8 @@ Array<Array<Layout> > UpsamplingInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  Layout inferred_layout(params->layout);
-  return Array<Array<Layout> >{{inferred_layout}, {inferred_layout}};
+  Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};
+  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
 }
 
 }  // namespace relay

--- a/src/relay/op/nn/upsampling.h
+++ b/src/relay/op/nn/upsampling.h
@@ -40,7 +40,7 @@ InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
                                                       const Array<Layout>& old_in_layouts,
                                                       const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<T>();
-  CHECK(attrs_ptr);
+  ICHECK(attrs_ptr);
   ObjectPtr<T> params = make_object<T>(*attrs_ptr);
 
   if (new_in_layouts.defined()) {

--- a/src/relay/op/nn/upsampling.h
+++ b/src/relay/op/nn/upsampling.h
@@ -58,8 +58,7 @@ InferCorrectLayoutOutput UpsamplingInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  Array<Array<Layout>> inferred_layout{{params->layout}, {params->layout}};
-  return InferCorrectLayoutOutput(inferred_layout, Attrs(params));
+  return InferCorrectLayoutOutput({params->layout}, {params->layout}, Attrs(params));
 }
 
 }  // namespace relay

--- a/src/relay/op/op_common.h
+++ b/src/relay/op/op_common.h
@@ -60,7 +60,8 @@ namespace relay {
       .add_type_rel("Identity", IdentityRel)                                   \
       .set_attr<TOpPattern>("TOpPattern", kElemWise)                           \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                         \
-      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
+      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout) \
+      .set_attr<FInferLayout>("FInferLayout", ElemwiseArbitraryLayout2)
 
 /*! Quick helper macro
  * - Expose a positional make function to construct the node.
@@ -84,7 +85,8 @@ namespace relay {
       .add_type_rel("Broadcast", BroadcastRel)                                          \
       .set_attr<TOpPattern>("TOpPattern", kBroadcast)                                   \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                                  \
-      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout)
+      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout) \
+      .set_attr<FInferLayout>("FInferLayout", BinaryBroadcastLayout2)
 
 // Comparisons
 #define RELAY_REGISTER_CMP_OP(OpName)                                                   \
@@ -99,7 +101,8 @@ namespace relay {
       .add_type_rel("BroadcastComp", BroadcastCompRel)                                  \
       .set_attr<TOpPattern>("TOpPattern", kBroadcast)                                   \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                                  \
-      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout)
+      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout) \
+      .set_attr<FInferLayout>("FInferLayout", BinaryBroadcastLayout2)
 
 /*! \brief A helper class for matching and rewriting operators. */
 template <typename R>

--- a/src/relay/op/op_common.h
+++ b/src/relay/op/op_common.h
@@ -60,8 +60,7 @@ namespace relay {
       .add_type_rel("Identity", IdentityRel)                                   \
       .set_attr<TOpPattern>("TOpPattern", kElemWise)                           \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                         \
-      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout) \
-      .set_attr<FInferLayout>("FInferLayout", ElemwiseArbitraryLayout2)
+      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
 
 /*! Quick helper macro
  * - Expose a positional make function to construct the node.
@@ -85,8 +84,7 @@ namespace relay {
       .add_type_rel("Broadcast", BroadcastRel)                                          \
       .set_attr<TOpPattern>("TOpPattern", kBroadcast)                                   \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                                  \
-      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout) \
-      .set_attr<FInferLayout>("FInferLayout", BinaryBroadcastLayout2)
+      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout)
 
 // Comparisons
 #define RELAY_REGISTER_CMP_OP(OpName)                                                   \
@@ -101,8 +99,7 @@ namespace relay {
       .add_type_rel("BroadcastComp", BroadcastCompRel)                                  \
       .set_attr<TOpPattern>("TOpPattern", kBroadcast)                                   \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                                  \
-      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout) \
-      .set_attr<FInferLayout>("FInferLayout", BinaryBroadcastLayout2)
+      .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout)
 
 /*! \brief A helper class for matching and rewriting operators. */
 template <typename R>

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -189,8 +189,7 @@ InferCorrectLayoutOutput ReduceInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  return InferCorrectLayoutOutput(Array<Array<Layout>>{{inferred_in}, {inferred_out}},
-                                  Attrs(params));
+  return InferCorrectLayoutOutput({{inferred_in}, {inferred_out}}, Attrs(params));
 }
 
 template <typename F>

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -189,7 +189,7 @@ InferCorrectLayoutOutput ReduceInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  return InferCorrectLayoutOutput({{inferred_in}, {inferred_out}}, Attrs(params));
+  return InferCorrectLayoutOutput({inferred_in}, {inferred_out}, Attrs(params));
 }
 
 template <typename F>

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -115,12 +115,13 @@ Array<Integer> GetExcludeAxes(size_t indim, const Array<Integer>& inaxis) {
 }
 
 // Return the modified layout for AlterOpLayout pass.
-Array<Array<Layout>> ReduceInferCorrectLayout(const Attrs& attrs,
-                                              const Array<Layout>& new_in_layouts,
-                                              const Array<Layout>& old_in_layouts,
-                                              const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  ReduceAttrs* params = const_cast<ReduceAttrs*>(attrs.as<ReduceAttrs>());
+InferCorrectLayoutOutput ReduceInferCorrectLayout(const Attrs& attrs,
+                                                  const Array<Layout>& new_in_layouts,
+                                                  const Array<Layout>& old_in_layouts,
+                                                  const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<ReduceAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<ReduceAttrs> params = make_object<ReduceAttrs>(*attrs_ptr);
 
   // Get the reduce axes.
   Array<Array<IndexExpr>> old_in_shapes;
@@ -188,7 +189,8 @@ Array<Array<Layout>> ReduceInferCorrectLayout(const Attrs& attrs,
     }
   }
 
-  return Array<Array<Layout>>{{inferred_in}, {inferred_out}};
+  return InferCorrectLayoutOutput(Array<Array<Layout>>{{inferred_in}, {inferred_out}},
+                                  Attrs(params));
 }
 
 template <typename F>

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -486,7 +486,7 @@ InferCorrectLayoutOutput TransposeInferCorrectLayout(const Attrs& attrs,
     return InferCorrectLayoutOutput(
         Array<Array<Layout>>({{Layout(in_layout_str)}, {Layout(out_layout_str)}}), new_attrs);
   }
-  return InferCorrectLayoutOutput(Array<Array<Layout>>({{Layout::Undef()}, {Layout::Undef()}}),
+  return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}},
                                   new_attrs);
 }
 
@@ -2241,7 +2241,7 @@ InferCorrectLayoutOutput SqueezeInferCorrectLayout(const Attrs& attrs,
   }
   inferred_output = Layout(kept_axes);
 
-  return InferCorrectLayoutOutput(Array<Array<Layout>>{{inferred_input}, {inferred_output}},
+  return InferCorrectLayoutOutput({{inferred_input}, {inferred_output}},
                                   Attrs(params));
 }
 

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -486,8 +486,7 @@ InferCorrectLayoutOutput TransposeInferCorrectLayout(const Attrs& attrs,
     return InferCorrectLayoutOutput(
         Array<Array<Layout>>({{Layout(in_layout_str)}, {Layout(out_layout_str)}}), new_attrs);
   }
-  return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}},
-                                  new_attrs);
+  return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, new_attrs);
 }
 
 Array<te::Tensor> TransposeCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
@@ -2241,8 +2240,7 @@ InferCorrectLayoutOutput SqueezeInferCorrectLayout(const Attrs& attrs,
   }
   inferred_output = Layout(kept_axes);
 
-  return InferCorrectLayoutOutput({{inferred_input}, {inferred_output}},
-                                  Attrs(params));
+  return InferCorrectLayoutOutput({{inferred_input}, {inferred_output}}, Attrs(params));
 }
 
 RELAY_REGISTER_OP("squeeze")

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -483,10 +483,15 @@ InferCorrectLayoutOutput TransposeInferCorrectLayout(const Attrs& attrs,
       ICHECK_LT(axis->value, in_layout_str.length());
       out_layout_str += in_layout_str[axis->value];
     }
-    return InferCorrectLayoutOutput(
-        Array<Array<Layout>>({{Layout(in_layout_str)}, {Layout(out_layout_str)}}), new_attrs);
+    try {
+      return InferCorrectLayoutOutput({{Layout(in_layout_str)}, {Layout(out_layout_str)}},
+                                      new_attrs);
+    } catch (const tvm::Error& e) {
+      // If the layout string is invalid for any reason, give up.
+      return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, attrs);
+    }
   }
-  return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, new_attrs);
+  return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, attrs);
 }
 
 Array<te::Tensor> TransposeCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -484,14 +484,13 @@ InferCorrectLayoutOutput TransposeInferCorrectLayout(const Attrs& attrs,
       out_layout_str += in_layout_str[axis->value];
     }
     try {
-      return InferCorrectLayoutOutput({{Layout(in_layout_str)}, {Layout(out_layout_str)}},
-                                      new_attrs);
+      return InferCorrectLayoutOutput({Layout(in_layout_str)}, {Layout(out_layout_str)}, new_attrs);
     } catch (const tvm::Error& e) {
       // If the layout string is invalid for any reason, give up.
-      return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, attrs);
+      return InferCorrectLayoutOutput({Layout::Undef()}, {Layout::Undef()}, attrs);
     }
   }
-  return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, attrs);
+  return InferCorrectLayoutOutput({Layout::Undef()}, {Layout::Undef()}, attrs);
 }
 
 Array<te::Tensor> TransposeCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
@@ -2245,7 +2244,7 @@ InferCorrectLayoutOutput SqueezeInferCorrectLayout(const Attrs& attrs,
   }
   inferred_output = Layout(kept_axes);
 
-  return InferCorrectLayoutOutput({{inferred_input}, {inferred_output}}, Attrs(params));
+  return InferCorrectLayoutOutput({inferred_input}, {inferred_output}, Attrs(params));
 }
 
 RELAY_REGISTER_OP("squeeze")
@@ -2501,7 +2500,7 @@ InferCorrectLayoutOutput StridedSliceInferCorrectLayout(
   ICHECK_GE(old_in_shapes.size(), 1);
 
   auto layout = old_in_layouts[0];
-  InferCorrectLayoutOutput out_default{{{Layout::Undef()}, {Layout::Undef()}}, attrs};
+  InferCorrectLayoutOutput out_default{{Layout::Undef()}, {Layout::Undef()}, attrs};
 
   if (layout.defined() && new_in_layouts.defined()) {
     ICHECK_GE(new_in_layouts.size(), 1);
@@ -2673,9 +2672,9 @@ InferCorrectLayoutOutput StridedSliceInferCorrectLayout(
       params->begin = new_begin;
       params->end = new_end;
     }
-    return InferCorrectLayoutOutput({{layout}, {layout}}, Attrs(params));
+    return InferCorrectLayoutOutput({layout}, {layout}, Attrs(params));
   }
-  return InferCorrectLayoutOutput({{layout}, {layout}}, attrs);
+  return InferCorrectLayoutOutput({layout}, {layout}, attrs);
 }
 
 Array<te::Tensor> StridedSliceCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
@@ -3003,16 +3002,16 @@ InferCorrectLayoutOutput SliceLikeInferCorrectLayout(const Attrs& attrs,
     }
     if (!new_axes.empty()) {
       params->axes = std::move(new_axes);
-      return InferCorrectLayoutOutput({{new_layout, new_layout}, {new_layout}}, Attrs(params));
+      return InferCorrectLayoutOutput({new_layout, new_layout}, {new_layout}, Attrs(params));
     }
   }
 
   if (old_in_layouts.defined()) {
     ICHECK_EQ(old_in_layouts.size(), 2);
-    return InferCorrectLayoutOutput({{old_in_layouts[0], old_in_layouts[1]}, {old_in_layouts[1]}},
+    return InferCorrectLayoutOutput({old_in_layouts[0], old_in_layouts[1]}, {old_in_layouts[1]},
                                     attrs);
   }
-  return InferCorrectLayoutOutput({{Layout::Undef(), Layout::Undef()}, {Layout::Undef()}}, attrs);
+  return InferCorrectLayoutOutput({Layout::Undef(), Layout::Undef()}, {Layout::Undef()}, attrs);
 }
 
 Array<te::Tensor> SliceLikeCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -418,13 +418,13 @@ bool TransposeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   return true;
 }
 
-Array<Array<Layout>> TransposeInferCorrectLayout(const Attrs& attrs,
-                                                 const Array<Layout>& new_in_layouts,
-                                                 const Array<Layout>& old_in_layouts,
-                                                 const Array<tvm::relay::Type>& old_in_types) {
-  // Discard "const" qualifier.
-  auto* params = const_cast<TransposeAttrs*>(attrs.as<TransposeAttrs>());
-  ICHECK(params != nullptr);
+InferCorrectLayoutOutput TransposeInferCorrectLayout(const Attrs& attrs,
+                                                     const Array<Layout>& new_in_layouts,
+                                                     const Array<Layout>& old_in_layouts,
+                                                     const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<TransposeAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<TransposeAttrs> params = make_object<TransposeAttrs>(*attrs_ptr);
 
   std::string in_layout_str = "";
   std::string out_layout_str = "";
@@ -477,19 +477,17 @@ Array<Array<Layout>> TransposeInferCorrectLayout(const Attrs& attrs,
   }
 
   // Infer the output layout string based on the input layout and the axes.
+  Attrs new_attrs(params);
   if (in_layout_str != "") {
     for (auto axis : params->axes) {
       ICHECK_LT(axis->value, in_layout_str.length());
       out_layout_str += in_layout_str[axis->value];
     }
-    try {
-      return Array<Array<Layout>>({{Layout(in_layout_str)}, {Layout(out_layout_str)}});
-    } catch (const tvm::Error& e) {
-      // If the layout string is invalid for any reason, give up.
-      return Array<Array<Layout>>({{Layout::Undef()}, {Layout::Undef()}});
-    }
+    return InferCorrectLayoutOutput(
+        Array<Array<Layout>>({{Layout(in_layout_str)}, {Layout(out_layout_str)}}), new_attrs);
   }
-  return Array<Array<Layout>>({{Layout::Undef()}, {Layout::Undef()}});
+  return InferCorrectLayoutOutput(Array<Array<Layout>>({{Layout::Undef()}, {Layout::Undef()}}),
+                                  new_attrs);
 }
 
 Array<te::Tensor> TransposeCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
@@ -2182,12 +2180,13 @@ Array<te::Tensor> SqueezeCompute(const Attrs& attrs, const Array<te::Tensor>& in
   return {topi::squeeze(inputs[0], param->axis)};
 }
 
-Array<Array<Layout>> SqueezeInferCorrectLayout(const Attrs& attrs,
-                                               const Array<Layout>& new_in_layouts,
-                                               const Array<Layout>& old_in_layouts,
-                                               const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  SqueezeAttrs* params = const_cast<SqueezeAttrs*>(attrs.as<SqueezeAttrs>());
+InferCorrectLayoutOutput SqueezeInferCorrectLayout(const Attrs& attrs,
+                                                   const Array<Layout>& new_in_layouts,
+                                                   const Array<Layout>& old_in_layouts,
+                                                   const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<SqueezeAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<SqueezeAttrs> params = make_object<SqueezeAttrs>(*attrs_ptr);
 
   Layout inferred_input = new_in_layouts.defined() ? new_in_layouts[0] : old_in_layouts[0];
   Layout inferred_output = inferred_input;
@@ -2242,7 +2241,8 @@ Array<Array<Layout>> SqueezeInferCorrectLayout(const Attrs& attrs,
   }
   inferred_output = Layout(kept_axes);
 
-  return Array<Array<Layout>>{{inferred_input}, {inferred_output}};
+  return InferCorrectLayoutOutput(Array<Array<Layout>>{{inferred_input}, {inferred_output}},
+                                  Attrs(params));
 }
 
 RELAY_REGISTER_OP("squeeze")
@@ -2483,10 +2483,9 @@ bool StridedSliceRel(const Array<Type>& types, int num_inputs, const Attrs& attr
   return true;
 }
 
-Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
-                                                    const Array<Layout>& new_in_layouts,
-                                                    const Array<Layout>& old_in_layouts,
-                                                    const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput StridedSliceInferCorrectLayout(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
   Array<Array<IndexExpr>> old_in_shapes;
   for (auto old_in_t : old_in_types) {
     ICHECK(old_in_t.as<TensorTypeNode>());
@@ -2499,14 +2498,17 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
   ICHECK_GE(old_in_shapes.size(), 1);
 
   auto layout = old_in_layouts[0];
+  InferCorrectLayoutOutput out_default{{{Layout::Undef()}, {Layout::Undef()}}, attrs};
+
   if (layout.defined() && new_in_layouts.defined()) {
     ICHECK_GE(new_in_layouts.size(), 1);
     auto new_layout = new_in_layouts[0];
     auto shape = old_in_shapes[0];
 
-    // NOTE: Discard "const" qualifier here.
-    auto* params = const_cast<StridedSliceAttrs*>(attrs.as<StridedSliceAttrs>());
-    ICHECK(params != nullptr);
+    const auto* attrs_ptr = attrs.as<StridedSliceAttrs>();
+    ICHECK(attrs_ptr);
+    ObjectPtr<StridedSliceAttrs> params = make_object<StridedSliceAttrs>(*attrs_ptr);
+
     Array<Integer> begin, end, strides;
     if (params->begin && params->end && params->strides) {
       for (Integer i : params->strides.value()) {
@@ -2535,7 +2537,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
         new_layout_name.rfind(old_layout_name, 0) != 0) {
       if (old_layout_name.size() != new_layout_name.size()) {
         // Not support NHW4c -> NCHW
-        return {{Layout::Undef()}, {Layout::Undef()}};
+        return out_default;
       } else {
         if (params->axes) {
           auto axes = params->axes.value();
@@ -2555,7 +2557,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
           for (size_t i = 0; i < new_layout_name.size(); ++i) {
             auto index = layout.IndexOf(new_layout[i]);
             if (index == -1) {
-              return {{Layout::Undef()}, {Layout::Undef()}};
+              return out_default;
             }
 
             size_t new_index = static_cast<size_t>(index);
@@ -2600,7 +2602,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
           const LayoutAxis& axis = layout[old_idx];
           if (!axis.IsPrimal()) {
             // original layout that contains splitted axes is not supported
-            return {{Layout::Undef()}, {Layout::Undef()}};
+            return out_default;
           }
 
           auto factor = new_layout.FactorOf(axis);
@@ -2613,7 +2615,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
             int64_t ed = end[i];
             if (bg % factor || ed % factor) {
               // transform to original layout
-              return {{Layout::Undef()}, {Layout::Undef()}};
+              return out_default;
             }
             new_begin.push_back(IntImm(begin[0]->dtype, (bg / factor)));
             new_end.push_back(IntImm(end[0]->dtype, (ed / factor)));
@@ -2626,7 +2628,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
           const LayoutAxis& axis = layout[i];
           if (!axis.IsPrimal()) {
             // original layout that contains splitted axes is not supported
-            return {{Layout::Undef()}, {Layout::Undef()}};
+            return out_default;
           }
           auto factor = new_layout.FactorOf(axis);
           if (factor == -1) {
@@ -2637,7 +2639,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
               auto stride = strides[i];
               // arbitrary stride is not supported
               if (stride.defined() && stride->value != 1) {
-                return {{Layout::Undef()}, {Layout::Undef()}};
+                return out_default;
               }
             }
             int64_t bg = begin[i].defined() ? begin[i]->value : 0;
@@ -2656,7 +2658,7 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
 
             if (bg % factor || ed % factor) {
               // transform to original layout
-              return {{Layout::Undef()}, {Layout::Undef()}};
+              return out_default;
             }
             new_begin.push_back(IntImm(begin[0]->dtype, (bg / factor)));
             new_end.push_back(IntImm(end[0]->dtype, (ed / factor)));
@@ -2668,8 +2670,9 @@ Array<Array<Layout>> StridedSliceInferCorrectLayout(const Attrs& attrs,
       params->begin = new_begin;
       params->end = new_end;
     }
+    return InferCorrectLayoutOutput({{layout}, {layout}}, Attrs(params));
   }
-  return {{layout}, {layout}};
+  return InferCorrectLayoutOutput({{layout}, {layout}}, attrs);
 }
 
 Array<te::Tensor> StridedSliceCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
@@ -2968,10 +2971,10 @@ Expr MakeSliceLike(Expr data, Expr shape_like, Array<Integer> axes) {
   return Call(op, {data, shape_like}, Attrs(attrs), {});
 }
 
-Array<Array<Layout>> SliceLikeInferCorrectLayout(const Attrs& attrs,
-                                                 const Array<Layout>& new_in_layouts,
-                                                 const Array<Layout>& old_in_layouts,
-                                                 const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput SliceLikeInferCorrectLayout(const Attrs& attrs,
+                                                     const Array<Layout>& new_in_layouts,
+                                                     const Array<Layout>& old_in_layouts,
+                                                     const Array<tvm::relay::Type>& old_in_types) {
   Array<Integer> new_axes;
   if (old_in_layouts.defined() && new_in_layouts.defined()) {
     ICHECK_EQ(new_in_layouts.size(), 2);
@@ -2982,9 +2985,9 @@ Array<Array<Layout>> SliceLikeInferCorrectLayout(const Attrs& attrs,
     auto old_layout = old_in_layouts[0];
     auto new_layout = new_in_layouts[0];
 
-    // Discard "const" qualifier.
-    auto* params = const_cast<SliceLikeAttrs*>(attrs.as<SliceLikeAttrs>());
-    ICHECK(params != nullptr);
+    const auto* attrs_ptr = attrs.as<SliceLikeAttrs>();
+    ICHECK(attrs_ptr);
+    ObjectPtr<SliceLikeAttrs> params = make_object<SliceLikeAttrs>(*attrs_ptr);
 
     for (auto axis : params->axes) {
       auto new_axis = new_layout.IndexOf(old_layout[axis->value]);
@@ -2997,15 +3000,16 @@ Array<Array<Layout>> SliceLikeInferCorrectLayout(const Attrs& attrs,
     }
     if (!new_axes.empty()) {
       params->axes = std::move(new_axes);
-      return Array<Array<Layout>>({{new_layout, new_layout}, {new_layout}});
+      return InferCorrectLayoutOutput({{new_layout, new_layout}, {new_layout}}, Attrs(params));
     }
   }
 
   if (old_in_layouts.defined()) {
     ICHECK_EQ(old_in_layouts.size(), 2);
-    return {{old_in_layouts[0], old_in_layouts[1]}, {old_in_layouts[1]}};
+    return InferCorrectLayoutOutput({{old_in_layouts[0], old_in_layouts[1]}, {old_in_layouts[1]}},
+                                    attrs);
   }
-  return Array<Array<Layout>>({{Layout::Undef(), Layout::Undef()}, {Layout::Undef()}});
+  return InferCorrectLayoutOutput({{Layout::Undef(), Layout::Undef()}, {Layout::Undef()}}, attrs);
 }
 
 Array<te::Tensor> SliceLikeCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -218,11 +218,11 @@ static inline InferCorrectLayoutOutput ConcatenateLayout(
     }
 
     if (ret.ndim() <= axis || !ret[axis].IsPrimal()) {
-      return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, attrs);
+      return InferCorrectLayoutOutput({Layout::Undef()}, {Layout::Undef()}, attrs);
     }
   }
 
-  return InferCorrectLayoutOutput({Array<Layout>(old_in_layouts.size(), ret), {ret}}, Attrs(param));
+  return InferCorrectLayoutOutput(Array<Layout>(old_in_layouts.size(), ret), {ret}, Attrs(param));
 }
 
 /*!

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -172,7 +172,9 @@ static inline InferCorrectLayoutOutput ConcatenateLayout(const Attrs& attrs,
                                                      const Array<Layout>& new_in_layouts,
                                                      const Array<Layout>& old_in_layouts,
                                                      const Array<tvm::relay::Type>& old_in_types) {
-  ConcatenateAttrs* param = const_cast<ConcatenateAttrs*>(attrs.as<ConcatenateAttrs>());
+  const auto* attrs_ptr = attrs.as<ConcatenateAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<ConcatenateAttrs> param = make_object<ConcatenateAttrs>(*attrs_ptr);
 
   Array<Array<IndexExpr>> old_in_shapes;
   ICHECK_EQ(old_in_types.size(), 1);
@@ -221,7 +223,7 @@ static inline InferCorrectLayoutOutput ConcatenateLayout(const Attrs& attrs,
     }
   }
 
-  return InferCorrectLayoutOutput({Array<Layout>(old_in_layouts.size(), ret), {ret}}, attrs);
+  return InferCorrectLayoutOutput({Array<Layout>(old_in_layouts.size(), ret), {ret}}, Attrs(param));
 }
 
 /*!

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "../make_op.h"
+#include "../../transforms/infer_layout_utils.h"
 
 namespace tvm {
 namespace relay {
@@ -167,7 +168,7 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   return true;
 }
 
-static inline Array<Array<Layout>> ConcatenateLayout(const Attrs& attrs,
+static inline InferCorrectLayoutOutput ConcatenateLayout(const Attrs& attrs,
                                                      const Array<Layout>& new_in_layouts,
                                                      const Array<Layout>& old_in_layouts,
                                                      const Array<tvm::relay::Type>& old_in_types) {
@@ -216,11 +217,11 @@ static inline Array<Array<Layout>> ConcatenateLayout(const Attrs& attrs,
     }
 
     if (ret.ndim() <= axis || !ret[axis].IsPrimal()) {
-      return Array<Array<Layout>>{{Layout::Undef()}, {Layout::Undef()}};
+      return InferCorrectLayoutOutput({{Layout::Undef()}, {Layout::Undef()}}, attrs);
     }
   }
 
-  return Array<Array<Layout>>{Array<Layout>(old_in_layouts.size(), ret), {ret}};
+  return InferCorrectLayoutOutput({Array<Layout>(old_in_layouts.size(), ret), {ret}}, attrs);
 }
 
 /*!

--- a/src/relay/op/tensor/transform.h
+++ b/src/relay/op/tensor/transform.h
@@ -35,8 +35,8 @@
 #include <utility>
 #include <vector>
 
-#include "../make_op.h"
 #include "../../transforms/infer_layout_utils.h"
+#include "../make_op.h"
 
 namespace tvm {
 namespace relay {
@@ -168,10 +168,9 @@ bool ConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   return true;
 }
 
-static inline InferCorrectLayoutOutput ConcatenateLayout(const Attrs& attrs,
-                                                     const Array<Layout>& new_in_layouts,
-                                                     const Array<Layout>& old_in_layouts,
-                                                     const Array<tvm::relay::Type>& old_in_types) {
+static inline InferCorrectLayoutOutput ConcatenateLayout(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<ConcatenateAttrs>();
   ICHECK(attrs_ptr);
   ObjectPtr<ConcatenateAttrs> param = make_object<ConcatenateAttrs>(*attrs_ptr);

--- a/src/relay/op/vision/rcnn_op.cc
+++ b/src/relay/op/vision/rcnn_op.cc
@@ -61,18 +61,17 @@ bool ROIAlignRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 }
 
 template <typename T>
-Array<Array<Layout> > ROIAlignInferCorrectLayout(const Attrs& attrs,
-                                                 const Array<Layout>& new_in_layouts,
-                                                 const Array<Layout>& old_in_layouts,
-                                                 const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  T* params = const_cast<T*>(attrs.as<T>());
+InferCorrectLayoutOutput ROIAlignInferCorrectLayout(const Attrs& attrs,
+                                                    const Array<Layout>& new_in_layouts,
+                                                    const Array<Layout>& old_in_layouts,
+                                                    const Array<tvm::relay::Type>& old_in_types) {
+  const T* params = attrs.as<T>();
   Layout data_layout = params->layout;
 
   // Layout inference needs to define the layout for all inputs and output data layouts.
   // For roi_align, the second inputs is 2-D tensor with shape [num_roi, 5].
   // So, we set the layout as "N5".
-  return Array<Array<Layout> >{{data_layout, Layout("N5")}, {data_layout}};
+  return InferCorrectLayoutOutput({{data_layout, Layout("N5")}, {data_layout}}, attrs);
 }
 
 Expr MakeROIAlign(Expr data, Expr rois, Array<IndexExpr> pooled_size, double spatial_scale,
@@ -135,18 +134,17 @@ bool ROIPoolRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 }
 
 template <typename T>
-Array<Array<Layout> > ROIPoolInferCorrectLayout(const Attrs& attrs,
-                                                const Array<Layout>& new_in_layouts,
-                                                const Array<Layout>& old_in_layouts,
-                                                const Array<tvm::relay::Type>& old_in_types) {
-  // NOTE: Discard "const" qualifier here.
-  T* params = const_cast<T*>(attrs.as<T>());
+InferCorrectLayoutOutput ROIPoolInferCorrectLayout(const Attrs& attrs,
+                                                   const Array<Layout>& new_in_layouts,
+                                                   const Array<Layout>& old_in_layouts,
+                                                   const Array<tvm::relay::Type>& old_in_types) {
+  const T* params = attrs.as<T>();
   Layout data_layout = params->layout;
 
   // Layout inference needs to define the layout for all inputs and output data layouts.
   // For roi_pool, the second inputs is 2-D tensor with shape [num_roi, 5].
   // So, we set the layout as "N5".
-  return Array<Array<Layout> >{{data_layout, Layout("N5")}, {data_layout}};
+  return InferCorrectLayoutOutput({{data_layout, Layout("N5")}, {data_layout}}, attrs);
 }
 
 Expr MakeROIPool(Expr data, Expr rois, Array<IndexExpr> pooled_size, double spatial_scale,

--- a/src/relay/op/vision/rcnn_op.cc
+++ b/src/relay/op/vision/rcnn_op.cc
@@ -71,7 +71,7 @@ InferCorrectLayoutOutput ROIAlignInferCorrectLayout(const Attrs& attrs,
   // Layout inference needs to define the layout for all inputs and output data layouts.
   // For roi_align, the second inputs is 2-D tensor with shape [num_roi, 5].
   // So, we set the layout as "N5".
-  return InferCorrectLayoutOutput({{data_layout, Layout("N5")}, {data_layout}}, attrs);
+  return InferCorrectLayoutOutput({data_layout, Layout("N5")}, {data_layout}, attrs);
 }
 
 Expr MakeROIAlign(Expr data, Expr rois, Array<IndexExpr> pooled_size, double spatial_scale,
@@ -144,7 +144,7 @@ InferCorrectLayoutOutput ROIPoolInferCorrectLayout(const Attrs& attrs,
   // Layout inference needs to define the layout for all inputs and output data layouts.
   // For roi_pool, the second inputs is 2-D tensor with shape [num_roi, 5].
   // So, we set the layout as "N5".
-  return InferCorrectLayoutOutput({{data_layout, Layout("N5")}, {data_layout}}, attrs);
+  return InferCorrectLayoutOutput({data_layout, Layout("N5")}, {data_layout}, attrs);
 }
 
 Expr MakeROIPool(Expr data, Expr rois, Array<IndexExpr> pooled_size, double spatial_scale,

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -120,19 +120,18 @@ InferCorrectLayoutOutput QnnConcatenateLayout(const Attrs& attrs,
   // Use Relay Concatenate Infer Correct layout to infer the layouts for data tensors.
   auto concat_new_layout =
       ConcatenateLayout(attrs, relay_new_in_layouts, relay_old_in_layouts, {old_in_types[0]});
-  auto layouts = concat_new_layout->inferred_layout;
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout. Total number of these tensors are 2 * num of data
   // tensors (scale and zero point for each input data tensor) + 2 for the output data tensor.
   Layout channel_layout = Layout("C");
-  Array<Layout> input_layouts = layouts[0];
+  Array<Layout> input_layouts = concat_new_layout->input_layouts;
 
   for (size_t i = 0; i < 2 * num_input_tensors + 2; i++) {
     input_layouts.push_back(channel_layout);
   }
-  Array<Layout> output_layouts = layouts[1];
-  return InferCorrectLayoutOutput({input_layouts, output_layouts}, concat_new_layout->new_attrs);
+  Array<Layout> output_layouts = concat_new_layout->output_layouts;
+  return InferCorrectLayoutOutput(input_layouts, output_layouts, concat_new_layout->new_attrs);
 }
 
 Expr MakeQnnConcatenate(Expr data, Expr input_scales, Expr input_zero_points, Expr output_scale,

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -96,9 +96,10 @@ bool QnnConcatenateRel(const Array<Type>& types, int num_inputs, const Attrs& at
   return ConcatenateRel<ConcatenateAttrs>(tensor_types, 2, attrs, reporter);
 }
 
-Array<Array<Layout>> QnnConcatenateLayout(const Attrs& attrs, const Array<Layout>& new_in_layouts,
-                                          const Array<Layout>& old_in_layouts,
-                                          const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput QnnConcatenateLayout(const Attrs& attrs,
+                                              const Array<Layout>& new_in_layouts,
+                                              const Array<Layout>& old_in_layouts,
+                                              const Array<tvm::relay::Type>& old_in_types) {
   // Collect the layouts and types to reuse Relay Concatenate Infer Correct Layout.
   ICHECK_EQ(old_in_types.size(), 5);
   auto input_tuple_type = old_in_types[0].as<TupleTypeNode>();
@@ -118,7 +119,7 @@ Array<Array<Layout>> QnnConcatenateLayout(const Attrs& attrs, const Array<Layout
 
   // Use Relay Concatenate Infer Correct layout to infer the layouts for data tensors.
   auto layouts =
-      ConcatenateLayout(attrs, relay_new_in_layouts, relay_old_in_layouts, {old_in_types[0]});
+      ConcatenateLayout(attrs, relay_new_in_layouts, relay_old_in_layouts, {old_in_types[0]})->inferred_layout;
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout. Total number of these tensors are 2 * num of data
@@ -130,7 +131,7 @@ Array<Array<Layout>> QnnConcatenateLayout(const Attrs& attrs, const Array<Layout
     input_layouts.push_back(channel_layout);
   }
   Array<Layout> output_layouts = layouts[1];
-  return {input_layouts, output_layouts};
+  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
 }
 
 Expr MakeQnnConcatenate(Expr data, Expr input_scales, Expr input_zero_points, Expr output_scale,

--- a/src/relay/qnn/op/concatenate.cc
+++ b/src/relay/qnn/op/concatenate.cc
@@ -118,8 +118,9 @@ InferCorrectLayoutOutput QnnConcatenateLayout(const Attrs& attrs,
   }
 
   // Use Relay Concatenate Infer Correct layout to infer the layouts for data tensors.
-  auto layouts =
-      ConcatenateLayout(attrs, relay_new_in_layouts, relay_old_in_layouts, {old_in_types[0]})->inferred_layout;
+  auto concat_new_layout =
+      ConcatenateLayout(attrs, relay_new_in_layouts, relay_old_in_layouts, {old_in_types[0]});
+  auto layouts = concat_new_layout->inferred_layout;
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout. Total number of these tensors are 2 * num of data
@@ -131,7 +132,7 @@ InferCorrectLayoutOutput QnnConcatenateLayout(const Attrs& attrs,
     input_layouts.push_back(channel_layout);
   }
   Array<Layout> output_layouts = layouts[1];
-  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
+  return InferCorrectLayoutOutput({input_layouts, output_layouts}, concat_new_layout->new_attrs);
 }
 
 Expr MakeQnnConcatenate(Expr data, Expr input_scales, Expr input_zero_points, Expr output_scale,

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -88,13 +88,14 @@ bool QnnConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   return Conv2DRel<Conv2DAttrs>(tensor_types, 3, attrs, reporter);
 }
 
-Array<Array<Layout>> QnnConvInferCorrectLayout(const Attrs& attrs,
-                                               const Array<Layout>& new_in_layouts,
-                                               const Array<Layout>& old_in_layouts,
-                                               const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput QnnConvInferCorrectLayout(const Attrs& attrs,
+                                                   const Array<Layout>& new_in_layouts,
+                                                   const Array<Layout>& old_in_layouts,
+                                                   const Array<tvm::relay::Type>& old_in_types) {
   // Use Relay Conv2D Infer correct layout.
   auto layouts =
-      ConvInferCorrectLayout<Conv2DAttrs>(attrs, new_in_layouts, old_in_layouts, old_in_types);
+      ConvInferCorrectLayout<Conv2DAttrs>(attrs, new_in_layouts, old_in_layouts, old_in_types)
+          ->inferred_layout;
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout.
@@ -102,7 +103,7 @@ Array<Array<Layout>> QnnConvInferCorrectLayout(const Attrs& attrs,
   Array<Layout> input_layouts = {layouts[0][0],  layouts[0][1],  channel_layout,
                                  channel_layout, channel_layout, channel_layout};
   Array<Layout> output_layouts = layouts[1];
-  return {input_layouts, output_layouts};
+  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
 }
 
 bool is_depthwise(const Conv2DAttrs* param) {

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -93,17 +93,20 @@ InferCorrectLayoutOutput QnnConvInferCorrectLayout(const Attrs& attrs,
                                                    const Array<Layout>& old_in_layouts,
                                                    const Array<tvm::relay::Type>& old_in_types) {
   // Use Relay Conv2D Infer correct layout.
-  auto layouts =
-      ConvInferCorrectLayout<Conv2DAttrs>(attrs, new_in_layouts, old_in_layouts, old_in_types)
-          ->inferred_layout;
+  auto conv_new_layouts =
+      ConvInferCorrectLayout<Conv2DAttrs>(attrs, new_in_layouts, old_in_layouts, old_in_types);
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout.
   Layout channel_layout = Layout("C");
-  Array<Layout> input_layouts = {layouts[0][0],  layouts[0][1],  channel_layout,
-                                 channel_layout, channel_layout, channel_layout};
-  Array<Layout> output_layouts = layouts[1];
-  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
+  Array<Layout> input_layouts = {conv_new_layouts->input_layouts[0],
+                                 conv_new_layouts->input_layouts[1],
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout};
+  Array<Layout> output_layouts = conv_new_layouts->output_layouts;
+  return InferCorrectLayoutOutput(input_layouts, output_layouts, attrs);
 }
 
 bool is_depthwise(const Conv2DAttrs* param) {

--- a/src/relay/qnn/op/convolution_transpose.cc
+++ b/src/relay/qnn/op/convolution_transpose.cc
@@ -66,18 +66,21 @@ inline Expr MakeQnnConv2DTranspose(Expr data, Expr weight, Expr input_zero_point
 InferCorrectLayoutOutput QnnConvTransposeInferCorrectLayout(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types) {
-  // Use Relay Conv2D Infer correct layout.
-  auto layouts = ConvInferCorrectLayout<Conv2DTransposeAttrs>(attrs, new_in_layouts, old_in_layouts,
-                                                              old_in_types)
-                     ->inferred_layout;
+  // Use Relay Conv2D transpose Infer correct layout.
+  auto conv_transpose_new_layouts = ConvInferCorrectLayout<Conv2DTransposeAttrs>(
+      attrs, new_in_layouts, old_in_layouts, old_in_types);
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout.
   Layout channel_layout = Layout("C");
-  Array<Layout> input_layouts = {layouts[0][0],  layouts[0][1],  channel_layout,
-                                 channel_layout, channel_layout, channel_layout};
-  Array<Layout> output_layouts = layouts[1];
-  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
+  Array<Layout> input_layouts = {conv_transpose_new_layouts->input_layouts[0],
+                                 conv_transpose_new_layouts->input_layouts[1],
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout};
+  Array<Layout> output_layouts = conv_transpose_new_layouts->output_layouts;
+  return InferCorrectLayoutOutput(input_layouts, output_layouts, attrs);
 }
 
 bool QnnConv2DTransposeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/qnn/op/convolution_transpose.cc
+++ b/src/relay/qnn/op/convolution_transpose.cc
@@ -63,12 +63,13 @@ inline Expr MakeQnnConv2DTranspose(Expr data, Expr weight, Expr input_zero_point
               Attrs(attrs), {});
 }
 
-Array<Array<Layout>> QnnConvTransposeInferCorrectLayout(
+InferCorrectLayoutOutput QnnConvTransposeInferCorrectLayout(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types) {
   // Use Relay Conv2D Infer correct layout.
   auto layouts = ConvInferCorrectLayout<Conv2DTransposeAttrs>(attrs, new_in_layouts, old_in_layouts,
-                                                              old_in_types);
+                                                              old_in_types)
+                     ->inferred_layout;
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as channel layout.
@@ -76,7 +77,7 @@ Array<Array<Layout>> QnnConvTransposeInferCorrectLayout(
   Array<Layout> input_layouts = {layouts[0][0],  layouts[0][1],  channel_layout,
                                  channel_layout, channel_layout, channel_layout};
   Array<Layout> output_layouts = layouts[1];
-  return {input_layouts, output_layouts};
+  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
 }
 
 bool QnnConv2DTransposeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/qnn/op/op_common.h
+++ b/src/relay/qnn/op/op_common.h
@@ -154,16 +154,21 @@ inline InferCorrectLayoutOutput QnnBinaryBroadcastLayout(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types) {
   // Use Relay Binary Broadcast Infer correct layout.
-  auto layouts =
-      BinaryBroadcastLayout(attrs, new_in_layouts, old_in_layouts, old_in_types)->inferred_layout;
+  auto layouts = BinaryBroadcastLayout(attrs, new_in_layouts, old_in_layouts, old_in_types);
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as C.
   Layout channel_layout = Layout("C");
-  Array<Layout> input_layouts = {layouts[0][0],  layouts[0][1],  channel_layout, channel_layout,
-                                 channel_layout, channel_layout, channel_layout, channel_layout};
-  Array<Layout> output_layouts = layouts[1];
-  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
+  Array<Layout> input_layouts = {layouts->input_layouts[0],
+                                 layouts->input_layouts[1],
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout,
+                                 channel_layout};
+  Array<Layout> output_layouts = layouts->output_layouts;
+  return InferCorrectLayoutOutput(input_layouts, output_layouts, attrs);
 }
 
 static inline bool QnnBroadcastRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/qnn/op/op_common.h
+++ b/src/relay/qnn/op/op_common.h
@@ -150,12 +150,12 @@ inline Expr RequantizeOrUpcast(const Expr& expr, const Expr& expr_scale,
 }
 
 /*! \brief Infer layout for QNN binary broadcast operators */
-inline Array<Array<Layout> > QnnBinaryBroadcastLayout(const Attrs& attrs,
-                                                      const Array<Layout>& new_in_layouts,
-                                                      const Array<Layout>& old_in_layouts,
-                                                      const Array<tvm::relay::Type>& old_in_types) {
+inline InferCorrectLayoutOutput QnnBinaryBroadcastLayout(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
   // Use Relay Binary Broadcast Infer correct layout.
-  auto layouts = BinaryBroadcastLayout(attrs, new_in_layouts, old_in_layouts, old_in_types);
+  auto layouts =
+      BinaryBroadcastLayout(attrs, new_in_layouts, old_in_layouts, old_in_types)->inferred_layout;
 
   // Fill the layouts of remaining input tensors - scales and zero points. The layouts of these
   // tensors can be treated as C.
@@ -163,7 +163,7 @@ inline Array<Array<Layout> > QnnBinaryBroadcastLayout(const Attrs& attrs,
   Array<Layout> input_layouts = {layouts[0][0],  layouts[0][1],  channel_layout, channel_layout,
                                  channel_layout, channel_layout, channel_layout, channel_layout};
   Array<Layout> output_layouts = layouts[1];
-  return {input_layouts, output_layouts};
+  return InferCorrectLayoutOutput({input_layouts, output_layouts}, attrs);
 }
 
 static inline bool QnnBroadcastRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -108,7 +108,7 @@ InferCorrectLayoutOutput RequantizeInferCorrectLayout(const Attrs& attrs,
     output_layouts = {undef};
   }
 
-  return InferCorrectLayoutOutput({input_layouts, output_layouts}, Attrs(param));
+  return InferCorrectLayoutOutput(input_layouts, output_layouts, Attrs(param));
 }
 
 // Lowering of qnn.requantize op

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -36,11 +36,13 @@ namespace qnn {
 
 TVM_REGISTER_NODE_TYPE(RequantizeAttrs);
 
-Array<Array<Layout>> RequantizeInferCorrectLayout(const Attrs& attrs,
-                                                  const Array<Layout>& new_in_layouts,
-                                                  const Array<Layout>& old_in_layouts,
-                                                  const Array<tvm::relay::Type>& old_in_types) {
-  RequantizeAttrs* param = const_cast<RequantizeAttrs*>(attrs.as<RequantizeAttrs>());
+InferCorrectLayoutOutput RequantizeInferCorrectLayout(const Attrs& attrs,
+                                                      const Array<Layout>& new_in_layouts,
+                                                      const Array<Layout>& old_in_layouts,
+                                                      const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<RequantizeAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<RequantizeAttrs> param = make_object<RequantizeAttrs>(*attrs_ptr);
 
   Array<Array<IndexExpr>> old_in_shapes;
   for (auto old_in_t : old_in_types) {
@@ -106,7 +108,7 @@ Array<Array<Layout>> RequantizeInferCorrectLayout(const Attrs& attrs,
     output_layouts = {undef};
   }
 
-  return Array<Array<Layout>>{input_layouts, output_layouts};
+  return InferCorrectLayoutOutput({input_layouts, output_layouts}, Attrs(param));
 }
 
 // Lowering of qnn.requantize op

--- a/src/relay/transforms/alter_op_layout.cc
+++ b/src/relay/transforms/alter_op_layout.cc
@@ -116,8 +116,7 @@ Expr AlterOpLayout(const Expr& expr) {
   AlterTransformMemorizer alterMemorizer(make_object<AlterTransformMemorizerNode>());
   auto fcontext = [&](const Call& call) -> ObjectRef { return alterMemorizer; };
 
-  // return ForwardRewrite(expr, LayoutRewriter<AlterTransformMemorizer>, fcontext);
-  return ForwardRewrite(expr, LayoutRewriter2<AlterTransformMemorizer>, fcontext);
+  return ForwardRewrite(expr, LayoutRewriter<AlterTransformMemorizer>, fcontext);
 }
 
 }  // namespace alter_op_layout

--- a/src/relay/transforms/alter_op_layout.cc
+++ b/src/relay/transforms/alter_op_layout.cc
@@ -71,7 +71,8 @@ class AlterTransformMemorizer : public TransformMemorizer {
    * \param new_args The traversed/recursed args to the call.
    * \return The new Call after calling the packed func.
    */
-  Call CallWithNewLayouts(const Call& ref_call, Attrs new_attrs, const std::vector<Expr>& new_args) override {
+  Call CallWithNewLayouts(const Call& ref_call, Attrs new_attrs,
+                          const std::vector<Expr>& new_args) override {
     static auto falter_layout = Op::GetAttrMap<FTVMAlterOpLayout>("FTVMAlterOpLayout");
     Op op = Downcast<Op>(ref_call->op);
 
@@ -85,8 +86,7 @@ class AlterTransformMemorizer : public TransformMemorizer {
       }
       // TODO(@kevinthesun, @icemelon9): This won't work if inputs/outputs are dynamic shapes.
       //   Probably we need to disable the AlterOpLayout when compiling dynamic models.
-      Expr altered_value =
-          falter_layout[op](new_attrs, new_args, tinfos, ref_call->checked_type());
+      Expr altered_value = falter_layout[op](new_attrs, new_args, tinfos, ref_call->checked_type());
       if (altered_value.defined()) {
         new_e = altered_value;
         modified = true;

--- a/src/relay/transforms/alter_op_layout.cc
+++ b/src/relay/transforms/alter_op_layout.cc
@@ -68,6 +68,7 @@ class AlterTransformMemorizer : public TransformMemorizer {
    * \brief Defines the call transformation for AlterOpLayout pass. The new layouts are defined by
    * used for different targets using a packed func.
    * \param ref_call The original call.
+   * \param new_attrs Updated attributes consistent with new layouts.
    * \param new_args The traversed/recursed args to the call.
    * \return The new Call after calling the packed func.
    */
@@ -102,7 +103,6 @@ class AlterTransformMemorizer : public TransformMemorizer {
   }
 
   using TransformMemorizer::CallWithNewLayouts;
-
   using ContainerType = AlterTransformMemorizerNode;
 };
 

--- a/src/relay/transforms/convert_layout.cc
+++ b/src/relay/transforms/convert_layout.cc
@@ -78,6 +78,7 @@ class ConvertTransformMemorizer : public TransformMemorizer {
    * \brief Defines the call transformation for ConvertLayout pass. The new layouts should be the
    * desired layout as specified by the user.
    * \param ref_call The original call.
+   * \param new_attrs Updated attributes consistent with new layouts.
    * \param new_args The traversed/recursed args to the call.
    * \return The new Call after calling the packed func.
    */
@@ -124,7 +125,6 @@ class ConvertTransformMemorizer : public TransformMemorizer {
   }
 
   using TransformMemorizer::CallWithNewLayouts;
-
   using ContainerType = ConvertTransformMemorizerNode;
 };
 

--- a/src/relay/transforms/convert_layout.cc
+++ b/src/relay/transforms/convert_layout.cc
@@ -81,7 +81,8 @@ class ConvertTransformMemorizer : public TransformMemorizer {
    * \param new_args The traversed/recursed args to the call.
    * \return The new Call after calling the packed func.
    */
-  Call CallWithNewLayouts(const Call& ref_call, Attrs new_attrs, const std::vector<Expr>& new_args) override {
+  Call CallWithNewLayouts(const Call& ref_call, Attrs new_attrs,
+                          const std::vector<Expr>& new_args) override {
     static auto fconvert_layout = Op::GetAttrMap<FTVMConvertOpLayout>("FTVMConvertOpLayout");
     Op op = Downcast<Op>(ref_call->op);
     Expr new_e;
@@ -104,8 +105,7 @@ class ConvertTransformMemorizer : public TransformMemorizer {
         }
 
         Array<String> op_desired_layouts = desired_layouts.at(op->name);
-        Expr altered_value =
-            fconvert_layout[op](new_attrs, new_args, tinfos, op_desired_layouts);
+        Expr altered_value = fconvert_layout[op](new_attrs, new_args, tinfos, op_desired_layouts);
         if (altered_value.defined()) {
           new_e = altered_value;
           modified = true;

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -144,6 +144,28 @@ inline Array<Array<Layout>> ElemwiseArbitraryLayout(const Attrs& attrs,
   return Array<Array<Layout>>{Array<Layout>(old_in_layouts.size(), ret), {ret}};
 }
 
+inline InferCorrectLayoutOutput ElemwiseArbitraryLayout2(const Attrs& attrs,
+                                                    const Array<Layout>& new_in_layouts,
+                                                    const Array<Layout>& old_in_layouts,
+                                                    const Array<tvm::relay::Type>& old_in_types) {
+  Layout ret;
+
+  if (new_in_layouts.defined()) {
+    ICHECK_GE(new_in_layouts.size(), 1);
+    ret = new_in_layouts[0];
+  } else {
+    for (size_t i = 0; i < old_in_layouts.size(); ++i) {
+      if (old_in_layouts[i].defined()) {
+        ret = old_in_layouts[i];
+        break;
+      }
+    }
+  }
+
+  Array<Array<Layout>> inferred_layout{Array<Layout>(old_in_layouts.size(), ret), {ret}};
+  return InferCorrectLayoutOutput(inferred_layout, attrs);
+}
+
 /*! \brief Infer layout for binary broadcast operators */
 inline Array<Array<Layout>> BinaryBroadcastLayout(const Attrs& attrs,
                                                   const Array<Layout>& new_in_layouts,
@@ -220,6 +242,14 @@ inline Array<Array<Layout>> BinaryBroadcastLayout(const Attrs& attrs,
     }
     return Array<Array<Layout>>{layouts, {ret}};
   }
+}
+
+inline InferCorrectLayoutOutput BinaryBroadcastLayout2(const Attrs& attrs,
+                                                  const Array<Layout>& new_in_layouts,
+                                                  const Array<Layout>& old_in_layouts,
+                                                  const Array<tvm::relay::Type>& old_in_types) {
+  auto inferred_layout = BinaryBroadcastLayout(attrs, new_in_layouts, old_in_layouts, old_in_types);
+  return InferCorrectLayoutOutput(inferred_layout, attrs);
 }
 
 /*!

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <tuple>
+#include <utility>
 
 #include "pattern_utils.h"
 

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -100,6 +100,28 @@ using FInferCorrectLayout = runtime::TypedPackedFunc<Array<Array<Layout>>(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types)>;
 
+class InferCorrectLayoutOutputNode : public Object {
+ public:
+  Array<Array<Layout>> inferred_layout;
+  Attrs new_attrs;
+  TVM_DECLARE_BASE_OBJECT_INFO(InferCorrectLayoutOutputNode, Object);
+};
+
+class InferCorrectLayoutOutput : public ObjectRef {
+ public:
+  InferCorrectLayoutOutput(Array<Array<Layout>> inferred_layout, Attrs new_attrs) {
+    auto n = make_object<InferCorrectLayoutOutputNode>();
+    n->inferred_layout = inferred_layout;
+    n->new_attrs = new_attrs;
+    data_ = n;
+  }
+  TVM_DEFINE_OBJECT_REF_METHODS(InferCorrectLayoutOutput, ObjectRef, InferCorrectLayoutOutputNode);
+};
+
+using FInferLayout = runtime::TypedPackedFunc<InferCorrectLayoutOutput(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types)>;
+
 /*! \brief take arbitrary input layout and copy to output */
 inline Array<Array<Layout>> ElemwiseArbitraryLayout(const Attrs& attrs,
                                                     const Array<Layout>& new_in_layouts,

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -139,7 +139,6 @@ inline InferCorrectLayoutOutput ElemwiseArbitraryLayout(
   return InferCorrectLayoutOutput(inferred_layout, attrs);
 }
 
-/*! \brief Infer layout for binary broadcast operators */
 inline Array<Array<Layout>> BinaryBroadcastLayoutHelper(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
     const Array<tvm::relay::Type>& old_in_types) {
@@ -216,6 +215,7 @@ inline Array<Array<Layout>> BinaryBroadcastLayoutHelper(
   }
 }
 
+/*! \brief Infer layout for binary broadcast operators */
 inline InferCorrectLayoutOutput BinaryBroadcastLayout(const Attrs& attrs,
                                                       const Array<Layout>& new_in_layouts,
                                                       const Array<Layout>& old_in_layouts,

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -87,23 +87,26 @@ inline Layout AdjustSubordinateFactors(const Layout& src_layout, const Layout& o
 
 /*
  * \brief An output structure to hold results from FInferCorrectLayout calls.
- * \tparam inferred_layout An array of two elements, inferred input layouts and
- *                         inferred output layouts.
- * \tparam new_attrs Updated attributes consistent with inferred layouts
+ * \tparam input_layouts Inferred input layouts.
+ * \tparam output_layouts Inferred output layouts.
+ * \tparam new_attrs Updated attributes consistent with inferred layouts.
  */
 class InferCorrectLayoutOutputNode : public Object {
  public:
-  Array<Array<Layout>> inferred_layout;
+  Array<Layout> input_layouts;
+  Array<Layout> output_layouts;
   Attrs new_attrs;
   TVM_DECLARE_BASE_OBJECT_INFO(InferCorrectLayoutOutputNode, Object);
 };
 
 class InferCorrectLayoutOutput : public ObjectRef {
  public:
-  InferCorrectLayoutOutput(Array<Array<Layout>> inferred_layout, Attrs new_attrs) {
+  InferCorrectLayoutOutput(Array<Layout> input_layouts, Array<Layout> output_layouts,
+                           Attrs new_attrs) {
     auto n = make_object<InferCorrectLayoutOutputNode>();
-    n->inferred_layout = inferred_layout;
-    n->new_attrs = new_attrs;
+    n->input_layouts = std::move(input_layouts);
+    n->output_layouts = std::move(output_layouts);
+    n->new_attrs = std::move(new_attrs);
     data_ = n;
   }
   TVM_DEFINE_OBJECT_REF_METHODS(InferCorrectLayoutOutput, ObjectRef, InferCorrectLayoutOutputNode);
@@ -141,8 +144,7 @@ inline InferCorrectLayoutOutput ElemwiseArbitraryLayout(
     }
   }
 
-  Array<Array<Layout>> inferred_layout{Array<Layout>(old_in_layouts.size(), ret), {ret}};
-  return InferCorrectLayoutOutput(inferred_layout, attrs);
+  return InferCorrectLayoutOutput({ret}, {ret}, attrs);
 }
 
 inline Array<Array<Layout>> BinaryBroadcastLayoutHelper(
@@ -228,7 +230,7 @@ inline InferCorrectLayoutOutput BinaryBroadcastLayout(const Attrs& attrs,
                                                       const Array<tvm::relay::Type>& old_in_types) {
   auto inferred_layout =
       BinaryBroadcastLayoutHelper(attrs, new_in_layouts, old_in_layouts, old_in_types);
-  return InferCorrectLayoutOutput(inferred_layout, attrs);
+  return InferCorrectLayoutOutput(inferred_layout[0], inferred_layout[1], attrs);
 }
 
 }  //  namespace relay

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -89,7 +89,7 @@ inline Layout AdjustSubordinateFactors(const Layout& src_layout, const Layout& o
  * \brief An output structure to hold results from FInferCorrectLayout calls.
  * \tparam inferred_layout An array of two elements, inferred input layouts and
  *                         inferred output layouts.
- * \tparam new_attrs Updated attributes consistent with new inferred layouts
+ * \tparam new_attrs Updated attributes consistent with inferred layouts
  */
 class InferCorrectLayoutOutputNode : public Object {
  public:

--- a/src/relay/transforms/infer_layout_utils.h
+++ b/src/relay/transforms/infer_layout_utils.h
@@ -85,6 +85,12 @@ inline Layout AdjustSubordinateFactors(const Layout& src_layout, const Layout& o
   return Layout(new_layout);
 }
 
+/*
+ * \brief An output structure to hold results from FInferCorrectLayout calls.
+ * \tparam inferred_layout An array of two elements, inferred input layouts and
+ *                         inferred output layouts.
+ * \tparam new_attrs Updated attributes consistent with new inferred layouts
+ */
 class InferCorrectLayoutOutputNode : public Object {
  public:
   Array<Array<Layout>> inferred_layout;
@@ -111,8 +117,8 @@ class InferCorrectLayoutOutput : public ObjectRef {
  *                       any operators.
  * \param old_in_layouts The layouts of input arguments before alter_op_layout.
  * \param old_in_types The types of old input arguments.
- * \return infered_layout An array of two elements that are inferred input layouts and
- *                        inferred output layouts.
+ * \return infer_layout_output Inferred layouts and updated attributes stored in
+ *                             InferCorrectLayoutOutput above.
  */
 using FInferCorrectLayout = runtime::TypedPackedFunc<InferCorrectLayoutOutput(
     const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -220,7 +220,7 @@ static inline std::tuple<InferCorrectLayoutOutput, bool> InferCorrectLayouts(
     const Array<tvm::relay::Type>& old_in_types) {
   static auto finfer_layout = Op::GetAttrMap<FInferCorrectLayout>("FInferCorrectLayout");
   auto null_res = std::make_tuple(
-      InferCorrectLayoutOutput({Array<Layout>(nullptr), Array<Layout>(nullptr), Attrs(nullptr)}),
+      InferCorrectLayoutOutput(Array<Layout>(nullptr), Array<Layout>(nullptr), Attrs(nullptr)),
       false);
   if (!call->op.as<OpNode>()) {
     return null_res;
@@ -229,9 +229,9 @@ static inline std::tuple<InferCorrectLayoutOutput, bool> InferCorrectLayouts(
   Op op = Downcast<Op>(call->op);
   if (finfer_layout.count(op)) {
     auto out = finfer_layout[op](call->attrs, new_in_layouts, old_in_layouts, old_in_types);
-    for (auto x : {out->input_layouts, out->output_layouts}) {
-      for (auto y : x) {
-        if (!y.defined()) {  // inference fails
+    for (auto inferred_layouts : {out->input_layouts, out->output_layouts}) {
+      for (auto layout : inferred_layouts) {
+        if (!layout.defined()) {  // inference fails
           return null_res;
         }
       }

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -153,7 +153,10 @@ class TransformMemorizer : public ObjectRef {
    * \param new_args The traversed/recursed args to the call.
    * \return The new Call after calling the packed func.
    */
-  virtual Call CallWithNewLayouts(const Call& ref_call, const std::vector<Expr>& new_args) = 0;
+  virtual Call CallWithNewLayouts(const Call& ref_call, Attrs new_attrs, const std::vector<Expr>& new_args) = 0;
+  virtual Call CallWithNewLayouts(const Call& ref_call, const std::vector<Expr>& new_args) {
+    return CallWithNewLayouts(ref_call, ref_call->attrs, new_args);
+  }
   using ContainerType = TransformMemorizerNode;
 };
 
@@ -203,6 +206,36 @@ class LayoutAlternatedExpr : public ObjectRef {
 
   using ContainerType = LayoutAlternatedExprNode<TransformMemorizerT>;
 };
+
+static inline std::tuple<InferCorrectLayoutOutput, bool> InferCorrectLayouts2(
+    const Call& call, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
+  static auto finfer_layout = Op::GetAttrMap<FInferLayout>("FInferLayout");
+  auto null_res = std::make_tuple(
+      InferCorrectLayoutOutput({Array<Layout>(nullptr), Array<Layout>(nullptr)}, Attrs(nullptr)),
+      false);
+  if (!call->op.as<OpNode>()) {
+    return null_res;
+  }
+
+  Op op = Downcast<Op>(call->op);
+  if (finfer_layout.count(op)) {
+    auto out = finfer_layout[op](call->attrs, new_in_layouts, old_in_layouts, old_in_types);
+    Array<Array<Layout>> inferred_layouts = out->inferred_layout;
+    ICHECK_EQ(inferred_layouts.size(), 2)
+        << "FInferCorrectLayout should return an array with size of 2";
+    for (auto x : inferred_layouts) {
+      for (auto y : x) {
+        if (!y.defined()) {  // inference fails
+          return null_res;
+        }
+      }
+    }
+    return std::make_tuple(out, true);
+  } else {
+    return null_res;
+  }
+}
 
 /*
  * \brief Used with ForwardRewrite to transform the expr. The input args are same as
@@ -296,6 +329,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   bool success = false;
   std::tie(old_in, old_out, success) =
       InferCorrectLayouts(ref_call, Array<Layout>(nullptr), old_in, types);
+  LOG(INFO) << "success1?: " << success;
   if (!success) {
     return Expr(nullptr);
   }
@@ -315,6 +349,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
     std::tie(new_in2, new_out, success) = InferCorrectLayouts(new_call, new_in, old_in, types);
+    LOG(INFO) << "success2?: " << success;
     if (!success) {
       return Expr(nullptr);
     }
@@ -366,6 +401,167 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
     rnode->value = Call(new_call->op, transformed_args, new_call->attrs, {}, ref_call->span);
     rnode->old_layout = old_out[0];
     rnode->new_layout = new_out[0];
+    LOG(INFO) << "ref_call: " << AsText(ref_call,false);
+    LOG(INFO) << "rnode->old_layout: "  << rnode->old_layout;
+    LOG(INFO) << "rnode->new_layout: "  << rnode->new_layout;
+
+    rnode->memorizer = memorizer;
+    return Expr(rnode);
+  }
+}
+
+template <class TransformMemorizerT>
+Expr LayoutRewriter2(const Call& ref_call, const Array<Expr>& new_args, const ObjectRef& ctx) {
+  std::vector<LayoutAlternatedExpr<TransformMemorizerT>> inputs;
+  std::vector<Expr> normal_new_args;
+
+  // NOTE: discard the "const" qualifier
+  // TransformMemorizer memorizer = Downcast<TransformMemorizer>(ctx);
+  // TransformMemorizerT* ctx_transformer =
+  // static_cast<TransformMemorizerT*>(memorizer.operator->());
+  TransformMemorizerT memorizer = Downcast<TransformMemorizerT>(ctx);
+
+  // fill incomplete state and flatten tuple
+  auto push_back_one_arg = [&inputs, memorizer](Expr arg) {
+    // We always expect LayoutAlternatedExpr<TransformMemorizerT>.
+    // This is used to convert the normal Expr to LayoutAlternatedExpr<TransformMemorizerT>.
+    if (const LayoutAlternatedExprNode<TransformMemorizerT>* inp =
+            arg.as<LayoutAlternatedExprNode<TransformMemorizerT>>()) {
+      inputs.push_back(GetRef<LayoutAlternatedExpr<TransformMemorizerT>>(inp));
+      return inp->value;
+    } else {
+      auto inode = make_object<LayoutAlternatedExprNode<TransformMemorizerT>>();
+      inode->value = arg;
+      inode->memorizer = memorizer;
+      inputs.push_back(LayoutAlternatedExpr<TransformMemorizerT>(inode));
+      return arg;
+    }
+  };
+
+  for (auto new_arg : new_args) {
+    // NOTE: do not support nested tuple
+    if (new_arg->IsInstance<TupleNode>()) {
+      Tuple tuple_new_arg = Downcast<Tuple>(new_arg);
+      std::vector<Expr> fields;
+      for (auto x : tuple_new_arg->fields) {
+        Expr tmp = push_back_one_arg(x);
+        fields.push_back(tmp);
+      }
+      normal_new_args.push_back(Tuple(fields));
+    } else {
+      Expr tmp = push_back_one_arg(new_arg);
+      normal_new_args.push_back(tmp);
+    }
+  }
+
+  // If there is no FInferCorrectLayout for the type, then we just assume the layout is correct.
+  static auto finfer_layout = Op::GetAttrMap<FInferCorrectLayout>("FInferCorrectLayout");
+  if (Op::HasAttrMap("FTVMAlterOpLayout")) {
+    static auto falter_layout = Op::GetAttrMap<FTVMAlterOpLayout>("FTVMAlterOpLayout");
+    if (ref_call->op.as<OpNode>()) {
+      Op op = Downcast<Op>(ref_call->op);
+      if (falter_layout.count(op) && !finfer_layout.count(op)) {
+        return memorizer.CallWithNewLayouts(ref_call, normal_new_args);
+      }
+    }
+  }
+
+  // old_in, new_in = state[inputs]
+  Array<Layout> old_in, old_out, new_in, new_out, new_in2;
+  for (auto inp : inputs) {
+    old_in.push_back(inp->old_layout);
+    new_in.push_back(inp->new_layout);
+  }
+
+  // Collect input types to pass on to Infer Correct Layout.
+  tvm::Array<tvm::relay::Type> types;
+  for (auto arg : ref_call->args) {
+    types.push_back(arg->checked_type());
+  }
+
+  bool success = false;
+  InferCorrectLayoutOutput infer_out;
+  std::tie(infer_out, success) =
+      InferCorrectLayouts2(ref_call, Array<Layout>(nullptr), old_in, types);
+  LOG(INFO) << "success1?: " << success;
+  old_in = infer_out->inferred_layout[0];
+  old_out = infer_out->inferred_layout[1];
+  if (!success) {
+    return Expr(nullptr);
+  }
+  ICHECK_EQ(old_in.size(), new_in.size());
+
+  // if new_in == 'undef':  new_in = old_in
+  for (size_t i = 0; i < new_in.size(); ++i) {
+    if (!new_in[i].defined()) {
+      new_in.Set(i, old_in[i]);
+    }
+  }
+
+  // new_op = alter(op)
+  Call new_call = memorizer.CallWithNewLayouts(ref_call, infer_out->new_attrs, normal_new_args);
+
+  // new_in2, new_out = op.infer(new_in)
+  if (new_call->op->IsInstance<OpNode>()) {
+    success = false;
+    std::tie(infer_out, success) = InferCorrectLayouts2(new_call, new_in, old_in, types);
+    LOG(INFO) << "success2?: " << success;
+    new_in2 = infer_out->inferred_layout[0];
+    new_out = infer_out->inferred_layout[1];
+    if (!success) {
+      return Expr(nullptr);
+    }
+  } else {
+    return Expr(nullptr);
+  }
+
+  ICHECK_EQ(new_out.size(), old_out.size())
+      << "The number of output nodes should keep the same during alter_op_layout";
+  ICHECK_EQ(new_in.size(), new_in2.size())
+      << "The number of input nodes should keep the same during alter_op_layout";
+
+  // if (new_in != new_in2): insert transform (new_in -> new_in2)
+  Array<Expr> transformed_args;
+  size_t pt = 0;
+  for (auto arg : new_call->args) {
+    if (arg->IsInstance<TupleNode>()) {  // unflatten tuple
+      Tuple tuple_arg = Downcast<Tuple>(arg);
+      std::vector<Expr> transformed_tuple_arg;
+      for (auto arg_item : tuple_arg->fields) {
+        transformed_tuple_arg.push_back(memorizer.Transform(arg_item, new_in[pt], new_in2[pt]));
+        pt++;
+      }
+      transformed_args.push_back(Tuple(transformed_tuple_arg));
+    } else {
+      transformed_args.push_back(memorizer.Transform(arg, new_in[pt], new_in2[pt]));
+      pt++;
+    }
+  }
+  ICHECK_EQ(pt, inputs.size());
+
+  // state[node] = (old_out, new_out)
+  // (handle tuple output)
+  if (ref_call->checked_type()->IsInstance<TupleTypeNode>()) {
+    Expr tuple_output = Call(new_call->op, transformed_args, infer_out->new_attrs);
+    Array<Expr> fields;
+    for (size_t i = 0; i < new_out.size(); ++i) {
+      auto rnode = make_object<LayoutAlternatedExprNode<TransformMemorizerT>>();
+      rnode->value = TupleGetItem(tuple_output, i);
+      rnode->old_layout = old_out[i];
+      rnode->new_layout = new_out[i];
+      rnode->memorizer = memorizer;
+      fields.push_back(Expr(rnode));
+    }
+    return Tuple(fields);
+  } else {
+    auto rnode = make_object<LayoutAlternatedExprNode<TransformMemorizerT>>();
+    ICHECK_EQ(new_out.size(), 1);
+    rnode->value = Call(new_call->op, transformed_args, infer_out->new_attrs, {}, ref_call->span);
+    rnode->old_layout = old_out[0];
+    rnode->new_layout = new_out[0];
+    LOG(INFO) << "ref_call: " << AsText(ref_call,false);
+    LOG(INFO) << "rnode->old_layout: "  << rnode->old_layout;
+    LOG(INFO) << "rnode->new_layout: "  << rnode->new_layout;
     rnode->memorizer = memorizer;
     return Expr(rnode);
   }

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -316,7 +316,6 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   InferCorrectLayoutOutput infer_out;
   std::tie(infer_out, success) =
       InferCorrectLayouts(ref_call, Array<Layout>(nullptr), old_in, types);
-  LOG(INFO) << "success1?: " << success;
   old_in = infer_out->inferred_layout[0];
   old_out = infer_out->inferred_layout[1];
   if (!success) {
@@ -338,7 +337,6 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
     std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in, old_in, types);
-    LOG(INFO) << "success2?: " << success;
     new_in2 = infer_out->inferred_layout[0];
     new_out = infer_out->inferred_layout[1];
     if (!success) {
@@ -392,9 +390,6 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
     rnode->value = Call(new_call->op, transformed_args, infer_out->new_attrs, {}, ref_call->span);
     rnode->old_layout = old_out[0];
     rnode->new_layout = new_out[0];
-    LOG(INFO) << "ref_call: " << AsText(ref_call, false);
-    LOG(INFO) << "rnode->old_layout: " << rnode->old_layout;
-    LOG(INFO) << "rnode->new_layout: " << rnode->new_layout;
     rnode->memorizer = memorizer;
     return Expr(rnode);
   }

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1320,15 +1320,15 @@ def test_alter_op_dense():
         y = relay.Function(analysis.free_vars(y), y)
         return y
 
-    for target, _ in tvm.testing.enabled_targets():
-        with tvm.target.Target(target):
-            with TempOpAttr(
-                "nn.dense", "FTVMAlterOpLayout", topi.x86.dense_alter_op._alter_dense_layout
-            ):
-                a = before()
-                a = run_opt_pass(a, transform.AlterOpLayout())
-                b = run_opt_pass(expected(), transform.InferType())
-                assert tvm.ir.structural_equal(a, b)
+    target = "llvm"
+    with tvm.target.Target(target):
+        with TempOpAttr(
+            "nn.dense", "FTVMAlterOpLayout", topi.x86.dense_alter_op._alter_dense_layout
+        ):
+            a = before()
+            a = run_opt_pass(a, transform.AlterOpLayout())
+            b = run_opt_pass(expected(), transform.InferType())
+            assert tvm.ir.structural_equal(a, b)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1331,6 +1331,29 @@ def test_alter_op_dense():
             assert tvm.ir.structural_equal(a, b)
 
 
+def test_not_inplace_modify():
+    def func():
+        x = relay.var("x", shape=(1, 64, 56, 56))
+        weight = relay.var("weight", shape=(64, 64, 3, 3))
+        y = relay.nn.conv2d(x, weight, channels=64, kernel_size=(3, 3), padding=(1, 1))
+        y = relay.nn.relu(y)
+        y = relay.nn.max_pool2d(y, pool_size=[2, 2], strides=[2, 2], padding=[0, 0, 0, 0])
+        y = relay.Function([x, weight], y)
+        return y
+
+    def alter_conv2d(attrs, inputs, tinfos, out_type):
+        data, weight = inputs
+        new_attrs = dict(attrs)
+        new_attrs["data_layout"] = "NCHW16c"
+        new_attrs["kernel_layout"] = "OIHW16i"
+        return relay.nn.conv2d(data, weight, **new_attrs)
+
+    with TempOpAttr("nn.conv2d", "FTVMAlterOpLayout", alter_conv2d):
+        before = func()
+        run_opt_pass(before, [transform.AlterOpLayout()])
+        assert before.body.attrs.layout == "NCHW"
+
+
 if __name__ == "__main__":
     test_alter_op()
     test_alter_return_none()
@@ -1354,3 +1377,4 @@ if __name__ == "__main__":
     test_alter_op_with_global_var()
     test_alter_op_dense()
     test_alter_layout_strided_slice_axes_nhwc()
+    test_not_inplace_modify()


### PR DESCRIPTION
There have been recurring problems of `AlterOpLayout` pass modifying its input module in-place, see for example https://github.com/apache/tvm/issues/6624, https://github.com/apache/tvm/issues/7979.

The root cause was the use of `const_cast` used in many of `InferCorrectLayout` functions, followed by in-place modification of attributes to update for the new layouts:
https://github.com/apache/tvm/blob/813136401a11a49d6c15e6013c34dd822a5c4ff6/src/relay/op/nn/upsampling.h#L42-L43

This PR refactors layout transform passes so that `const_cast` is no longer required. Each `InferCorrectLayout` function simply creates and returns updated attributes in addition to inferred layouts. The main change is in `src/relay/transforms/transform_layout.h`.

This fixes https://github.com/apache/tvm/issues/6624, but there are apparently other problems with `AlterOpLayout` not related to in-place modification, so leave https://github.com/apache/tvm/issues/7979 open for now.

Please review @anijain2305 @comaniac @mbrookhart @jwfromm 