### PR TITLE
Fix ordering of tf and tflite installs in ci_cpu

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -79,13 +79,13 @@ RUN bash /install/ubuntu_install_sbt.sh
 COPY install/ubuntu_install_verilator.sh /install/ubuntu_install_verilator.sh
 RUN bash /install/ubuntu_install_verilator.sh
 
-# TFLite deps
-COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh
-RUN bash /install/ubuntu_install_tflite.sh
-
 # TensorFlow deps
 COPY install/ubuntu_install_tensorflow.sh /install/ubuntu_install_tensorflow.sh
 RUN bash /install/ubuntu_install_tensorflow.sh
+
+# TFLite deps
+COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh
+RUN bash /install/ubuntu_install_tflite.sh
 
 # Compute Library
 COPY install/ubuntu_download_arm_compute_lib_binaries.sh /install/ubuntu_download_arm_compute_lib_binaries.sh


### PR DESCRIPTION
The recently merged #8306  introduced a depedencyfor tflite installation that tf must be installed first.However, that PR did not correct the ordering in ci_cpu which does not have that ordering.

cc : @leandron @mbrookhart @Lunderberg 

