### PR TITLE
[Docker] Fix ordering of tf and tflite installs in ci_qemu

### DIFF
--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -48,13 +48,13 @@ RUN bash /install/ubuntu_install_redis.sh
 COPY install/ubuntu_install_java.sh /install/ubuntu_install_java.sh
 RUN bash /install/ubuntu_install_java.sh
 
-# TFLite deps
-COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh
-RUN bash /install/ubuntu_install_tflite.sh
-
 # TensorFlow deps
 COPY install/ubuntu_install_tensorflow.sh /install/ubuntu_install_tensorflow.sh
 RUN bash /install/ubuntu_install_tensorflow.sh
+
+# TFLite deps
+COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh
+RUN bash /install/ubuntu_install_tflite.sh
 
 # QEMU deps
 COPY install/ubuntu_install_qemu.sh /install/ubuntu_install_qemu.sh


### PR DESCRIPTION
Similar to #8312, the recently merged #8306 required tflite to be installed after tf.  However, #8306 did not correct the ordering in the dockerfiles.  After this and #8312, all dockerfiles should be up to date with the correct ordering.
