### PR TITLE
[Makefile] Updates to top-level makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@
 	cython cython3 cyclean \
         clean
 
+.SECONDEXPANSION:
+
 # Remember the root directory, to be usable by submake invocation.
 ROOTDIR = $(CURDIR)
 
@@ -49,12 +51,19 @@ vta: $(addsuffix /vta,$(TVM_BUILD_PATH))
 cpptest: $(addsuffix /cpptest,$(TVM_BUILD_PATH))
 crttest: $(addsuffix /crttest,$(TVM_BUILD_PATH))
 
-# Set up a default config.cmake inside the build directory.
-# filter-out used to avoid circular dependency.
-%/config.cmake: | $(filter-out %/config.cmake,$(ROOTDIR)/cmake/config.cmake)
+# If there is a config.cmake in the tvm directory, preferentially use
+# it.  Otherwise, copy the default cmake/config.cmake.
+ifeq ($(wildcard config.cmake),config.cmake)
+%/config.cmake: | config.cmake
+	@echo "No config.cmake found in $(TVM_BUILD_PATH), using config.cmake in root tvm directory"
+	@mkdir -p $(@D)
+else
+# filter-out used to avoid circular dependency
+%/config.cmake: | $$(filter-out %/config.cmake,$(ROOTDIR)/cmake/config.cmake)
 	@echo "No config.cmake found in $(TVM_BUILD_PATH), using default config.cmake"
 	@mkdir -p $(@D)
 	@cp $| $@
+endif
 
 
 # Cannot use .PHONY with a pattern rule, using FORCE instead.  For

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -129,6 +129,35 @@ The configuration of TVM can be modified by editing `config.cmake` and/or by pas
       cmake .. -G Ninja
       ninja
 
+  - There is also a makefile in the top-level tvm directory that can
+    automate several of these steps.  It will create the build
+    directory, copy the default ``config.cmake`` to the build
+    directory, run cmake, then run make.
+
+    The build directory can be specified using the environment
+    variable ``TVM_BUILD_PATH``.  If ``TVM_BUILD_PATH`` is unset, the
+    makefile assumes that the ``build`` directory inside tvm should be
+    used.  Paths specified by ``TVM_BUILD_PATH`` can be either
+    absolute paths or paths relative to the base tvm directory.
+
+    If an alternate build directory is used, then the environment
+    variable ``TVM_LIBRARY_PATH`` should be set at runtime, pointing
+    to the location of the compiled ``libtvm.so`` and
+    ``libtvm_runtime.so``.  If not set, tvm will look relative to the
+    location of the tvm python module.  Unlike ``TVM_BUILD_PATH``,
+    this must be an absolute path.
+
+  .. code:: bash
+
+     # Build in the "build" directory
+     make
+
+     # Alternate location, "build_debug"
+     TVM_BUILD_PATH=build_debug make
+
+     # Use debug build
+     TVM_LIBRARY_PATH=~/tvm/build_debug python3
+
 If everything goes well, we can go to :ref:`python-package-installation`
 
 .. _build-with-conda:

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -139,6 +139,8 @@ The configuration of TVM can be modified by editing `config.cmake` and/or by pas
     makefile assumes that the ``build`` directory inside tvm should be
     used.  Paths specified by ``TVM_BUILD_PATH`` can be either
     absolute paths or paths relative to the base tvm directory.
+    ``TVM_BUILD_PATH`` can also be set to a list of space-separated
+    paths, in which case all paths listed will be built.
 
     If an alternate build directory is used, then the environment
     variable ``TVM_LIBRARY_PATH`` should be set at runtime, pointing
@@ -154,6 +156,9 @@ The configuration of TVM can be modified by editing `config.cmake` and/or by pas
 
      # Alternate location, "build_debug"
      TVM_BUILD_PATH=build_debug make
+
+     # Build both "build_release" and "build_debug"
+     TVM_BUILD_PATH="build_debug build_release" make
 
      # Use debug build
      TVM_LIBRARY_PATH=~/tvm/build_debug python3


### PR DESCRIPTION
- Renamed OUTDIR environment variable to TVM_BUILD_PATH

- Added documentation for TVM_BUILD_PATH environment variable

- Added documentation for TVM_LIBRARY_PATH environment variable

- Delegate emcc calls to the makefile in "web" directory

- Organized build rules by type (e.g. C++, java, web, formating/linting)

- Updated TVM_BUILD_PATH to allow a list of directories.  Intended for development purposes, where building both debug and release versions at once may be useful.