### PR TITLE
[Relay][Training] fix first-order AD tuple/projection expr duplication

### DIFF
--- a/src/relay/transforms/first_order_gradient.cc
+++ b/src/relay/transforms/first_order_gradient.cc
@@ -174,11 +174,14 @@ struct FirstOrderReverseAD : ExprFunctor<ADValue(const Expr&)> {
   }
 
   ADValue VisitExpr_(const TupleGetItemNode* op) final {
-    Expr e = GetRef<Expr>(op);
     ADValue tup = VisitExpr(op->tuple);
-    auto tt = op->tuple->checked_type().as<TupleTypeNode>();
+    TupleType tt = Downcast<TupleType>(op->tuple->checked_type());
     size_t idx = op->index;
-    auto ret = std::make_shared<ADTensor>(ll, e, diag_ctx);
+    // reconstruct projection using let-bound variable to avoid duplicating input tuple
+    TupleGetItem orig = TupleGetItem(tup->get<ADTensor>().forward, idx);
+    orig->checked_type_ = op->checked_type();
+    auto ret = std::make_shared<ADTensor>(ll, orig, diag_ctx);
+    // for orig = pi(tup, i), pi_grad(tup, i, g) = G where pi(G, i) = g and pi(G, j) = 0 for j != i
     backprop_actions.push_back([tup, tt, idx, ret](LetList* ll) {
       auto& ad_tup = tup->get<ADTensor>();
       std::vector<Expr> updated_grads;
@@ -193,16 +196,26 @@ struct FirstOrderReverseAD : ExprFunctor<ADValue(const Expr&)> {
   }
 
   ADValue VisitExpr_(const TupleNode* op) final {
-    Expr e = GetRef<Expr>(op);
-    std::vector<ADValue> fields;
+    auto tt = Downcast<TupleType>(op->checked_type());
+    std::vector<ADValue> ad_fields;
+    std::vector<Expr> field_bindings;
     for (const auto& f : op->fields) {
-      fields.push_back(VisitExpr(f));
+      ADValue f_ad = VisitExpr(f);
+      if (!dynamic_cast<ADTensor*>(f_ad.get())) {
+        diag_ctx.EmitFatal(Diagnostic::Error(f->span)
+                           << "first-order AD only supports (nested) tuples of tensors");
+      }
+      ad_fields.push_back(f_ad);
+      field_bindings.push_back(f_ad->get<ADTensor>().forward);
     }
-    auto tt = op->checked_type().as<TupleTypeNode>();
-    auto ret = std::make_shared<ADTensor>(ll, e, diag_ctx);
-    backprop_actions.push_back([fields, tt, ret](LetList* ll) {
-      for (size_t i = 0; i < fields.size(); ++i) {
-        auto& ad_field = fields[i]->get<ADTensor>();
+    // reconstruct tuple using let-bound variables to avoid duplication
+    auto orig = Tuple(field_bindings);
+    orig->checked_type_ = tt;
+    auto ret = std::make_shared<ADTensor>(ll, orig, diag_ctx);
+    // for orig = tuple(x1, ..., xn), tuple_grad(x1, ..., xn, G) = [pi(G, 1), ..., pi(G, n)]
+    backprop_actions.push_back([ad_fields, tt, ret](LetList* ll) {
+      for (size_t i = 0; i < ad_fields.size(); ++i) {
+        auto& ad_field = ad_fields[i]->get<ADTensor>();
         ad_field.reverse =
             LiftedAdd(tt->fields[i], ad_field.reverse, GetField(ret->reverse, i), ll);
       }


### PR DESCRIPTION
Tuples constructions and projections were not handled correctly (in particular, they were not reconstructed using the let bindings of their inputs) which led to expression duplication. Often the CSE pass is able to eliminate this erroneous duplication when first-order AD was paired with ToGNF but sometimes it can't (which we observed in BERT training, leading to many duplicated matmuls).

cc @MarisaKirisame @jroesch 
