### PR TITLE
[Vulkan] Implement sync for SyncThread("warp")

### DIFF
--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -35,6 +35,10 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   ICHECK_EQ(target->kind->device_type, kDLVulkan)
       << "SPIRVSupport can only be checked for vulkan device type";
 
+  if (target->GetAttr<Integer>("vulkan_api_version")) {
+    vulkan_api_version = target->GetAttr<Integer>("vulkan_api_version").value();
+  }
+
   if (target->GetAttr<Integer>("supported_subgroup_operations")) {
     supported_subgroup_operations =
         target->GetAttr<Integer>("supported_subgroup_operations").value();

--- a/src/target/spirv/spirv_support.h
+++ b/src/target/spirv/spirv_support.h
@@ -27,6 +27,7 @@
 #define TVM_TARGET_SPIRV_SPIRV_SUPPORT_H_
 
 #include <tvm/target/target.h>
+#include <vulkan/vulkan_core.h>
 
 namespace tvm {
 namespace codegen {
@@ -36,6 +37,19 @@ struct SPIRVSupport {
   /*! \brief Determine spirv capabilities from a vulkan target.
    */
   explicit SPIRVSupport(Target target);
+
+  /*! \brief The Vulkan API version supported by the device.
+   *
+   *  Vulkan struct: VkPhysicalDeviceProperties
+   *  Device property: apiVersion
+   *
+   *  If VK_KHR_driver_properties is present, will also check the
+   *  driver conformance version.  If the version advertised does not
+   *  pass the Vulkan conformance test, vulkan_api_version will be the
+   *  latest Vulkan version that does pass the conformance test
+   *  instead.
+   */
+  uint32_t vulkan_api_version{VK_MAKE_VERSION(1, 0, 0)};
 
   /*!
    * \brief The supported subgroup operations

--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -425,7 +425,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     while (reduce_align > 1) {
       reduce_align = reduce_align >> 1;
       in_warp_seq.emplace_back(freduce(reduce_align));
-      seq.emplace_back(SyncThread("warp"));
+      in_warp_seq.emplace_back(SyncThread("warp"));
     }
     if (in_warp_seq.size() != 0) {
       Stmt warp_body = SeqStmt::Flatten(in_warp_seq);


### PR DESCRIPTION
Add sync if a SyncThread("warp") node is present.  The sync is done at spv::ScopeSubgroup if supported (Vulkan 1.1+), and at spv::ScopeWorkgroup otherwise.