### PR TITLE
[Relay to Onnx Conversion] Fixed relay.var initialization

### DIFF
--- a/tests/python/contrib/test_onnx.py
+++ b/tests/python/contrib/test_onnx.py
@@ -89,7 +89,7 @@ def test_bias_add():
         bshape = (2,)
         rtol = 1e-2 if dtype == "float16" else 1e-5
         x = relay.var("x", shape=xshape, dtype=dtype)
-        bias = relay.var("bias", dtype=dtype)
+        bias = relay.var("bias", shape=bshape, dtype=dtype)
         z = relay.nn.bias_add(x, bias)
         func = relay.Function([x, bias], z)
 


### PR DESCRIPTION
* Fixed issue in bias variable initialization, by passing arg name (shape)
* This occurs in test_biasadd method while testing relay to onnx conversion

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
