### PR TITLE
[tvmc] Fix inconsistent usage of host_name -> hostname

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -261,7 +261,7 @@ def drive_tune(args):
                 "need to provide an RPC tracker key (--rpc-key) for remote tuning"
             )
     else:
-        rpc_host_name = None
+        rpc_hostname = None
         rpc_port = None
 
     tune_model(
@@ -271,7 +271,7 @@ def drive_tune(args):
         prior_records=args.tuning_records,
         enable_autoscheduler=args.enable_autoscheduler,
         rpc_key=args.rpc_key,
-        hostname=rpc_host_name,
+        hostname=rpc_hostname,
         port=rpc_port,
         trials=args.trials,
         target_host=args.target_host,
@@ -331,7 +331,7 @@ def tune_model(
         faster kernels for compatible model-target pairs.
     rpc_key : str, optional
         The RPC tracker key of the target device. Required when rpc_tracker is provided.
-    host_name : str, optional
+    hostname : str, optional
         The IP address of an RPC tracker, used when benchmarking remotely.
     port : int or str, optional
         The port of the RPC tracker to connect to. Defaults to 9090.

--- a/tests/python/driver/tvmc/test_autotuner.py
+++ b/tests/python/driver/tvmc/test_autotuner.py
@@ -17,6 +17,8 @@
 import pytest
 import os
 
+from unittest import mock
+
 from os import path
 
 from tvm import autotvm
@@ -153,3 +155,22 @@ def test_tune_tasks__invalid_tuner(onnx_mnist, tmpdir_factory):
 
     with pytest.raises(tvmc.common.TVMCException):
         tvmc.autotuner.tune_tasks(tasks, log_file, _get_measure_options(), "invalid_tuner", 1, 1)
+
+
+@mock.patch("tvm.driver.tvmc.autotuner.auto_scheduler.HardwareParams", return_value=None)
+@mock.patch("tvm.driver.tvmc.autotuner.tune_model", return_value=None)
+@mock.patch("tvm.driver.tvmc.frontends.load_model", return_value=None)
+def test_tune_rpc_tracker_parsing(mock_load_model, mock_tune_model, mock_auto_scheduler):
+    cli_args = mock.MagicMock()
+    cli_args.rpc_tracker = "10.0.0.1:9999"
+
+    tvmc.autotuner.drive_tune(cli_args)
+
+    mock_tune_model.assert_called_once()
+
+    # inspect the mock call, to search for specific arguments
+    _, _, kwargs = mock_tune_model.mock_calls[0]
+    assert "hostname" in kwargs
+    assert "10.0.0.1" == kwargs["hostname"]
+    assert "port" in kwargs
+    assert 9999 == kwargs["port"]


### PR DESCRIPTION
There was some inconsistent usage of `host_name` vs. `hostname` in tvmc tune.
 * This change prevents a python error when running tuning via and RPC tracker on tvmc.

cc @giuseros @mbaret @comaniac for reviews
