### PR TITLE
[CI] Install curl in the context of ubuntu_install_nodejs.sh

### DIFF
--- a/docker/install/ubuntu_install_nodejs.sh
+++ b/docker/install/ubuntu_install_nodejs.sh
@@ -21,6 +21,10 @@ set -u
 set -o pipefail
 
 apt-get update
+# Please do not remove 'curl' package installation from here, as this
+# script runs in some images (e.g. ci_lint) that keep a very mininal
+# set of packages installed by default.
+apt-get install -y curl
 
 # The node install script fetched and executed here will update the
 # apt source list, hence the second apt-get update is necessary.


### PR DESCRIPTION
Make sure that curl is installed, as this script is used on ci_lint, which does not need all the packages installed by ubuntu_install_core.sh

This partially undo what is done in #8310, that causes an unexpected failure when rebuilding `ci_lint`

cc @mbrookhart @u99127 for reviews