### PR TITLE
[TEST] Make sure there is no tie in scores in TF combined NMS test

### DIFF
--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -3427,8 +3427,14 @@ def _test_forward_combined_nms(
     clip_boxes=False,
     dtype="float32",
 ):
+    def get_random_scores(size, dtype):
+        size1d = np.prod(size)
+        scores = np.linspace(0, 1, num=size1d)
+        np.random.shuffle(scores)
+        return scores.reshape(size).astype(dtype)
+
     boxes = np.random.uniform(-1, 2, size=bx_shape).astype(dtype)
-    scores = np.random.uniform(size=score_shape).astype(dtype)
+    scores = get_random_scores(score_shape, dtype)
     max_output_size = np.int32(out_size)
     tf.reset_default_graph()
     in_data_1 = tf.placeholder(dtype, boxes.shape, name="in_data_1")


### PR DESCRIPTION
This should remove flaky-ness discussed in https://github.com/apache/tvm/issues/8140.

The flaky output from the workload `(1, 64, 20, 4)`, which uses a different code path than others, seems more frequent. For now I haven't disable it to see if the uniqueness of scores would also fix it. I've run this test 1000 times with this fix and I haven't got an error. 

@trevor-m @mbrookhart 