### PR TITLE
[TIR] fix storage rewrite index remap

### DIFF
--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -506,7 +506,7 @@ class StoragePlanRewriter : public StmtExprMutator {
   // Remap the index
   PrimExpr RemapIndex(DataType dtype, PrimExpr index, StorageEntry* e) {
     if (e->bits_offset == 0) return index;
-    uint64_t elem_bits = dtype.bits() * dtype.lanes();
+    uint64_t elem_bits = dtype.bits();
     ICHECK_EQ(e->bits_offset % elem_bits, 0U);
     return make_const(index.dtype(), e->bits_offset / elem_bits) + index;
   }


### PR DESCRIPTION
This is a fix trial for https://github.com/apache/tvm/issues/8308 where the storage rewrite pass remap the index of a vectorized load.

The offset computation should be based on the actual allocated buffer's datatype rather than the load/store op's result datatype. 

For example, if a float32*1024 ramp load is relocated to offset `4096b` of a float buffer, the offset expr should be `+4096/bits_of(float32)` rather than `+4096/bits_of(float32*1024)`

cc @vinx13 @masahi
