### PR TITLE
[Graph Debug Executor] Add exception for profile with remote devices

### DIFF
--- a/python/tvm/contrib/debugger/debug_executor.py
+++ b/python/tvm/contrib/debugger/debug_executor.py
@@ -25,6 +25,7 @@ import tvm._ffi
 from tvm._ffi.base import string_types
 from tvm.contrib import graph_executor
 from . import debug_result
+from tvm.rpc import base
 
 _DUMP_ROOT_PREFIX = "tvmdbg_"
 _DUMP_PATH_PREFIX = "_tvmdbg_"
@@ -105,6 +106,7 @@ class GraphModuleDebug(graph_executor.GraphModule):
         self._profile = module["profile"]
         graph_executor.GraphModule.__init__(self, module)
         self._create_debug_env(graph_json_str, device)
+        self._device = device[0]
 
     def _format_device(self, device):
         return str(device[0]).upper().replace("(", ":").replace(")", "")
@@ -281,6 +283,9 @@ class GraphModuleDebug(graph_executor.GraphModule):
         timing_results : str
             Per-operator and whole graph timing results in a table format.
         """
+        if self._device.device_type > base.RPC_SESS_MASK:
+            raise NotImplementedError("Profile not suppored for remote devices.")
+
         if input_dict:
             self.set_input(**input_dict)
 

--- a/python/tvm/contrib/debugger/debug_executor.py
+++ b/python/tvm/contrib/debugger/debug_executor.py
@@ -24,8 +24,8 @@ import tvm._ffi
 
 from tvm._ffi.base import string_types
 from tvm.contrib import graph_executor
-from . import debug_result
 from tvm.rpc import base
+from . import debug_result
 
 _DUMP_ROOT_PREFIX = "tvmdbg_"
 _DUMP_PATH_PREFIX = "_tvmdbg_"

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -173,7 +173,7 @@ def test_graph_executor():
 
 
 @tvm.testing.requires_micro
-@pytest.mark.xfail
+@pytest.mark.xfail(raises=NotImplementedError)
 def test_debug_graph_executor_profile():
     """Test use of the graph debug executor profile operation with microTVM."""
     import tvm.micro

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -25,6 +25,7 @@ pytest.importorskip("pty")
 import sys
 import subprocess
 import textwrap
+import csv
 
 import numpy as np
 import pytest
@@ -169,6 +170,46 @@ def test_graph_executor():
 
         out = graph_mod.get_output(0)
         assert (out.numpy() == np.array([6, 10])).all()
+
+
+@tvm.testing.requires_micro
+@pytest.mark.xfail
+def test_debug_graph_executor_profile():
+    """Test use of the graph debug executor profile operation with microTVM."""
+    import tvm.micro
+
+    workspace = tvm.micro.Workspace(debug=True)
+    relay_mod = tvm.parser.fromtext(
+        """
+      #[version = "0.0.5"]
+      def @main(%a : Tensor[(1, 2), uint8], %b : Tensor[(1, 2), uint8]) {
+          %0 = %a + %b;
+          %0
+      }"""
+    )
+
+    with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
+        factory = tvm.relay.build(relay_mod, target=TARGET)
+
+    with _make_session(workspace, factory.get_lib()) as sess:
+        debug_g_mod = tvm.micro.create_local_debug_executor(
+            factory.get_graph_json(), sess.get_system_lib(), sess.device
+        )
+        A_data = tvm.nd.array(np.array([2, 3], dtype="uint8"), device=sess.device)
+        B_data = tvm.nd.array(np.array([4, 7], dtype="uint8"), device=sess.device)
+        input_dict = {"a": A_data, "b": B_data}
+        timing_results = debug_g_mod.profile(**input_dict).csv()
+        assert len(timing_results) > 0
+
+        # Convert CSV to list
+        lines = timing_results.splitlines()
+        reader = csv.reader(lines)
+        parsed_csv = list(reader)
+
+        # Check Percent value for first op
+        assert "Percent" in parsed_csv[0]
+        percent_ind = parsed_csv[0].index("Percent")
+        assert float(parsed_csv[1][percent_ind]) > 0
 
 
 @tvm.testing.requires_micro


### PR DESCRIPTION
This PR:
- Adds exception for profile function when using a remote device
- Adds a test for profile with microTVM device which has xfail status for now until we fix this issue.

cc @areusch 