### PR TITLE
[Vulkan][Unittests] Add parametrization to vulkan unit tests.

### DIFF
--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -414,7 +414,7 @@ def _get_targets(target_str=None):
 
 
 DEFAULT_TEST_TARGETS = (
-    "llvm;cuda;opencl;metal;rocm;vulkan;nvptx;"
+    "llvm;cuda;opencl;metal;rocm;vulkan -from_device=0;nvptx;"
     "llvm -device=arm_cpu;opencl -device=mali,aocl_sw_emu"
 )
 


### PR DESCRIPTION
This also switches to using `vulkan -from_device=0` by default, and marks tests as `pytest.xfail` if the device does not support the
functionality being tested.