### PR TITLE
[Relay][Parser] Support slash in identifier.

### DIFF
--- a/src/parser/tokenizer.h
+++ b/src/parser/tokenizer.h
@@ -62,7 +62,9 @@ bool IsNumeric(char c) {
          !IsWhitespace(c);
 }
 
-bool IsIdentLetter(char c) { return '_' == c || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); }
+bool IsIdentLetter(char c) {
+  return '_' == c || c == '/' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
+}
 
 bool IsIdent(char c) { return IsIdentLetter(c) || IsDigit(c); }
 

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -289,6 +289,8 @@ def test_slash_in_identifier():
     y = relay.var("base/y")
     z = x + y
     txt = astext(z)
+    assert "base/x" in txt
+    assert "base/y" in txt
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -285,5 +285,12 @@ def test_optional_info():
     assert txt.count("/* ty=int32 */") == 3
 
 
+def test_slash_in_identifier():
+    x = relay.var("base/x")
+    y = relay.var("base/y")
+    z = x + y
+    txt = astext(z)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Variables from tensorflow may contains '/' in name (x/y/z).

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

@tqchen @jroesch please help to review this change, which found in tensorflow model

Thanks a lot :)

Regards,
Zack