### PR TITLE
[Doc] Fix sphinx doc style for unordered list

### DIFF
--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -30,7 +30,7 @@ set -o pipefail
 #
 echo "Addtiional setup in" ${CI_IMAGE_NAME}
 
-python3 -m pip install --user tlcpack-sphinx-addon==0.2.0 synr==0.3.0
+python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.3.0
 
 # Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().


### PR DESCRIPTION
TVM documentation hides all bullets for unordered list, https://github.com/tlc-pack/tlcpack-sphinx-addon/pull/3 fixed the issue.
This PR bumps the version of tlcpack-sphinx-addon from 0.2.0 to 0.2.1.

cc @tqchen @masahi 