### PR TITLE
[Tuning] Allow multiprocessing spawn to work (on macOS llvm at least)

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -639,8 +639,8 @@ def default_module_loader(pre_load_function=None):
 
     Returns
     -------
-    ModuleLoader :
-        A function that can be passed as module_loader to run_through_rpc.
+    DefaultModuleLoader :
+        A callable that can be passed as module_loader to run_through_rpc.
     """
 
     # This was a function with a closure before but that couldn't be pickled!

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -605,7 +605,9 @@ def run_through_rpc(
     return MeasureResult(costs, errno, tstamp - tic + build_result.time_cost, tstamp)
 
 
-class default_module_loader:
+class DefaultModuleLoader:
+    """See default_module_loader(). A pickleable emulation of the original function closure."""
+
     def __init__(self, pre_load_function=None) -> None:
         self.pre_load_function = pre_load_function
 
@@ -626,7 +628,6 @@ class default_module_loader:
             remote.remove("")
 
 
-'''
 def default_module_loader(pre_load_function=None):
     """Returns a default function that can be passed as module_loader to run_through_rpc.
 
@@ -642,24 +643,8 @@ def default_module_loader(pre_load_function=None):
         A function that can be passed as module_loader to run_through_rpc.
     """
 
-    @contextlib.contextmanager
-    def default_module_loader_mgr(remote_kwargs, build_result):
-        remote = request_remote(**remote_kwargs)
-        if pre_load_function is not None:
-            pre_load_function(remote, build_result)
-
-        remote.upload(build_result.filename)
-        try:
-            yield remote, remote.load_module(os.path.split(build_result.filename)[1])
-
-        finally:
-            # clean up remote files
-            remote.remove(build_result.filename)
-            remote.remove(os.path.splitext(build_result.filename)[0] + ".so")
-            remote.remove("")
-
-    return default_module_loader_mgr
-'''
+    # This was a function with a closure before but that couldn't be pickled!
+    return DefaultModuleLoader(pre_load_function)
 
 
 def request_remote(device_key, host=None, port=None, priority=1, timeout=60):

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -644,6 +644,7 @@ def default_module_loader(pre_load_function=None):
     """
 
     # This was a function with a closure before but that couldn't be pickled!
+    # We need pickle to work for using python's multiprocessing on some platforms.
     return DefaultModuleLoader(pre_load_function)
 
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -198,8 +198,7 @@ class Target(Object):
                 new_target[tgt] = mod
             target = new_target
         else:
-            target = Target(target)
-            target.host = host
+            target = Target(target, host)
             host = target.host
         return target, host
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -15,14 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Target data structure."""
+import json
 import os
 import re
-import json
 import warnings
-import tvm._ffi
 
-from tvm.runtime import Object
+import tvm._ffi
 from tvm._ffi import register_func as _register_func
+from tvm.runtime import Object
+
 from . import _ffi_api
 
 
@@ -197,7 +198,8 @@ class Target(Object):
                 new_target[tgt] = mod
             target = new_target
         else:
-            target = Target(target, host)
+            target = Target(target)
+            target.host = host
             host = target.host
         return target, host
 

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -418,20 +418,6 @@ Target::Target(const Map<String, ObjectRef>& config) {
 
 Target::Target(Target target, Target host) {
   ObjectPtr<TargetNode> n = make_object<TargetNode>(*target.get());
-
-  // It's ok to add a host to target with a defined host if it's the exact same target.
-  // We do a check if target's host and the the parameter host are the same pointers.
-  // However, for multiprocessing in python some methods involve serializing and
-  // reserializing objects which breaks pointer equality. Therefore we need
-  // a method of seeing if the two objects are similar. This does not exist
-  // so we see if the human readable strings of the targets are the same.
-  CHECK(!n->host.defined() || n->host.same_as(host) ||
-
-        // TODO (AndrewZhaoLuo): create a deep equality for TargetNodes
-        n->host.as<TargetNode>()->str() == host.as<TargetNode>()->str())
-      << "ValueError: Adding a host to a target whose host field has been defined";
-
-  // add target host into host field
   n->host = std::move(host);
   data_ = std::move(n);
 }

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -418,8 +418,19 @@ Target::Target(const Map<String, ObjectRef>& config) {
 
 Target::Target(Target target, Target host) {
   ObjectPtr<TargetNode> n = make_object<TargetNode>(*target.get());
-  CHECK(!n->host.defined() || n->host.same_as(host))
+
+  // It's ok to add a host to target with a defined host if it's the exact same target.
+  // We do a check if target's host and the the parameter host are the same pointers.
+  // However, for multiprocessing in python some methods involve serializing and
+  // reserializing objects which breaks pointer equality. Therefore we need
+  // a method of seeing if the two objects are similar. This does not exist
+  // so we see if the human readable strings of the targets are the same.
+  CHECK(!n->host.defined() || n->host.same_as(host) ||
+
+        // TODO (AndrewZhaoLuo): create a deep equality for TargetNodes
+        n->host.as<TargetNode>()->str() == host.as<TargetNode>()->str())
       << "ValueError: Adding a host to a target whose host field has been defined";
+
   // add target host into host field
   n->host = std::move(host);
   data_ = std::move(n);

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -211,17 +211,6 @@ def test_target_host_single_string_with_tag():
     assert tgt.host.attrs["registers_per_block"] == 32768
 
 
-def test_target_host_warning():
-    """
-    Confirm that constructing a target with invalid
-    attributes fails as expected.
-    """
-    with pytest.raises(
-        ValueError, match="Adding a host to a target whose host field has been defined"
-    ):
-        tvm.target.Target("cuda --host nvidia/jetson-nano", "llvm")
-
-
 def test_target_host_merge_0():
     tgt = tvm.target.Target(tvm.target.Target("cuda --host nvidia/jetson-nano"), None)
     assert tgt.kind.name == "cuda"

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -16,9 +16,10 @@
 # under the License.
 import json
 import sys
+
 import pytest
 import tvm
-from tvm.target import cuda, rocm, mali, intel_graphics, arm_cpu, vta, bifrost, Target
+from tvm.target import Target, arm_cpu, bifrost, cuda, intel_graphics, mali, rocm, vta
 
 
 @tvm.target.generic_func
@@ -240,10 +241,10 @@ def test_target_host_merge_1():
 
 
 def test_target_host_merge_2():
-    with pytest.raises(
-        ValueError, match="Adding a host to a target whose host field has been defined"
-    ):
-        tvm.target.Target(tvm.target.Target("cuda --host llvm"), tvm.target.Target("llvm"))
+    """Test picking the same host is ok."""
+    tgt = tvm.target.Target(tvm.target.Target("cuda --host llvm"), tvm.target.Target("llvm"))
+    assert tgt.kind.name == "cuda"
+    assert tgt.host.kind.name == "llvm"
 
 
 @pytest.mark.skip(reason="Causing infinite loop because of pytest and handle issue")


### PR DESCRIPTION
With this we can use the default (and safer) multiprocessing method "spawn" for macOS and Windows rather than "fork" for tuning. More details here: https://discuss.tvm.apache.org/t/why-is-auto-tuning-with-resnet-failing-at-task-1/10316/12

cc @hogepodge @tkonolige @leandron 