### PR TITLE
[FIX] Detect like cores by looking at scaling_max_freq instead of cpuinfo_max_freq

### DIFF
--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -185,7 +185,7 @@ class ThreadGroup::Impl {
       int64_t cur_freq = 0;
 #if defined(__linux__) || defined(__ANDROID__)
       std::ostringstream filepath;
-      filepath << "/sys/devices/system/cpu/cpu" << i << "/cpufreq/cpuinfo_max_freq";
+      filepath << "/sys/devices/system/cpu/cpu" << i << "/cpufreq/scaling_max_freq";
       std::ifstream ifs(filepath.str());
       if (!ifs.fail()) {
         if (!(ifs >> cur_freq)) {


### PR DESCRIPTION
On my AMD 3950X, `/sys/devices/systen/cpu/cpu*/cpufreq/cpuinfo_max_freq` is not the same across all cores. If I look at `scaling_max_freq` instead, then I see that all cores are the same frequency (as expected). This probably still won't work correctly across all platforms, but I don't think there is an easier, quick way to do the detection. Maybe we should think about using pytorch's cpuinfo library (https://github.com/pytorch/cpuinfo).

@tqchen @FrozenGene 