### PR TITLE
Fix compute library installation on AArch64

### DIFF
--- a/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
+++ b/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 set -e
-
+architecture_type = $(uname -i)
 # Install cross-compiler when not building natively.
 # Depending on the architecture selected to compile for,
 # you may need to install an alternative cross-compiler.


### PR DESCRIPTION
Missing architecture_type initialization .