### PR TITLE
[BugFix][Relay] Fix type relation for batch_matmul

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -940,9 +940,8 @@ bool BatchMatmulRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
     ICHECK(reporter->AssertEQ(x->shape[2], y_shape[2]))
         << "BatchDot: shapes of x and y is inconsistent, "
         << " x shape=" << x->shape << ", y shape=" << y_shape;
-
-    oshape.Set(2, y_shape[1]);
   }
+  oshape.Set(2, y_shape[1]);
 
   DataType out_dtype = param->out_dtype;
   if (out_dtype.bits() == 0) {

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -359,8 +359,9 @@ def test_batch_matmul():
     verify_batch_matmul((30, 16, 32), (30, 20, 32), (30, 16, 20))
 
 
-def verify_dynamic_batch_matmul(x_shape, y_shape, out_shape,
-                                x_var_shape, y_var_shape, dtype="float32"):
+def verify_dynamic_batch_matmul(
+    x_shape, y_shape, out_shape, x_var_shape, y_var_shape, dtype="float32"
+):
     x = relay.var("x", relay.TensorType(x_var_shape, dtype))
     y = relay.var("y", relay.TensorType(y_var_shape, dtype))
     z = relay.nn.batch_matmul(x, y)
@@ -382,22 +383,30 @@ def verify_dynamic_batch_matmul(x_shape, y_shape, out_shape,
 # @tvm.testing.uses_gpu
 def test_dynamic_batch_matmul():
     verify_dynamic_batch_matmul(
-        (1, 16, 32), (1, 16, 32), (1, 16, 16), (1, 16, 32), (relay.Any(),) * 3)
+        (1, 16, 32), (1, 16, 32), (1, 16, 16), (1, 16, 32), (relay.Any(),) * 3
+    )
     verify_dynamic_batch_matmul(
-        (5, 16, 32), (5, 16, 32), (5, 16, 16), (5, 16, 32), (relay.Any(),) * 3)
+        (5, 16, 32), (5, 16, 32), (5, 16, 16), (5, 16, 32), (relay.Any(),) * 3
+    )
     verify_dynamic_batch_matmul(
-        (5, 16, 32), (5, 20, 32), (5, 16, 20), (5, 16, 32), (relay.Any(),) * 3)
+        (5, 16, 32), (5, 20, 32), (5, 16, 20), (5, 16, 32), (relay.Any(),) * 3
+    )
     verify_dynamic_batch_matmul(
-        (30, 16, 32), (30, 20, 32), (30, 16, 20), (30, 16, 32), (relay.Any(),) * 3)
+        (30, 16, 32), (30, 20, 32), (30, 16, 20), (30, 16, 32), (relay.Any(),) * 3
+    )
 
     verify_dynamic_batch_matmul(
-        (1, 16, 32), (1, 16, 32), (1, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32))
+        (1, 16, 32), (1, 16, 32), (1, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32)
+    )
     verify_dynamic_batch_matmul(
-        (5, 16, 32), (5, 16, 32), (5, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32))
+        (5, 16, 32), (5, 16, 32), (5, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32)
+    )
     verify_dynamic_batch_matmul(
-        (5, 16, 32), (5, 20, 32), (5, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32))
+        (5, 16, 32), (5, 20, 32), (5, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32)
+    )
     verify_dynamic_batch_matmul(
-        (30, 16, 32), (30, 20, 32), (30, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32))
+        (30, 16, 32), (30, 20, 32), (30, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32)
+    )
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -359,9 +359,10 @@ def test_batch_matmul():
     verify_batch_matmul((30, 16, 32), (30, 20, 32), (30, 16, 20))
 
 
-def verify_dynamic_batch_matmul(x_shape, y_shape, out_shape, dtype="float32"):
-    x = relay.var("x", relay.TensorType(x_shape, dtype))
-    y = relay.var("y", relay.TensorType((relay.Any(),) * len(y_shape), dtype))
+def verify_dynamic_batch_matmul(x_shape, y_shape, out_shape,
+                                x_var_shape, y_var_shape, dtype="float32"):
+    x = relay.var("x", relay.TensorType(x_var_shape, dtype))
+    y = relay.var("y", relay.TensorType(y_var_shape, dtype))
     z = relay.nn.batch_matmul(x, y)
 
     func = relay.Function([x, y], z)
@@ -380,10 +381,23 @@ def verify_dynamic_batch_matmul(x_shape, y_shape, out_shape, dtype="float32"):
 # TODO(mbrookhart): enable once VM supports heterogenous execution
 # @tvm.testing.uses_gpu
 def test_dynamic_batch_matmul():
-    verify_dynamic_batch_matmul((1, 16, 32), (1, 16, 32), (1, 16, 16))
-    verify_dynamic_batch_matmul((5, 16, 32), (5, 16, 32), (5, 16, 16))
-    verify_dynamic_batch_matmul((5, 16, 32), (5, 20, 32), (5, 16, 20))
-    verify_dynamic_batch_matmul((30, 16, 32), (30, 20, 32), (30, 16, 20))
+    verify_dynamic_batch_matmul(
+        (1, 16, 32), (1, 16, 32), (1, 16, 16), (1, 16, 32), (relay.Any(),) * 3)
+    verify_dynamic_batch_matmul(
+        (5, 16, 32), (5, 16, 32), (5, 16, 16), (5, 16, 32), (relay.Any(),) * 3)
+    verify_dynamic_batch_matmul(
+        (5, 16, 32), (5, 20, 32), (5, 16, 20), (5, 16, 32), (relay.Any(),) * 3)
+    verify_dynamic_batch_matmul(
+        (30, 16, 32), (30, 20, 32), (30, 16, 20), (30, 16, 32), (relay.Any(),) * 3)
+
+    verify_dynamic_batch_matmul(
+        (1, 16, 32), (1, 16, 32), (1, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32))
+    verify_dynamic_batch_matmul(
+        (5, 16, 32), (5, 16, 32), (5, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32))
+    verify_dynamic_batch_matmul(
+        (5, 16, 32), (5, 20, 32), (5, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32))
+    verify_dynamic_batch_matmul(
+        (30, 16, 32), (30, 20, 32), (30, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32))
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
I find the current implementation of `relay.nn.batch_matmul` will fail given input tensors with shape `(Any(), M, K)` and `(Any(), N, K)`.  This is caused by the wrong implementation of `batch_matmul`'s type relation. When the input tensor has a dynamic shape but not all dimensions are dynamic, this relation function will use `x`'s shape directly and output wrong results.

For example, given `x` with shape `(Any(), 16, 32)` and `y` with shape `(Any(), 16, 32)`, the output shape of current implementation is `(Any(), 16, 32)`.