### PR TITLE
Minor bugfix to arm_compute_lib bulid scripts

### DIFF
--- a/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
+++ b/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 set -e
-architecture_type = $(uname -i)
+architecture_type=$(uname -i)
 # Install cross-compiler when not building natively.
 # Depending on the architecture selected to compile for,
 # you may need to install an alternative cross-compiler.


### PR DESCRIPTION
existing code errors with:
```
Step 17/17 : RUN bash /install/ubuntu_download_arm_compute_lib_binaries.sh
 ---> Running in 66c2dfde768f
/install/ubuntu_download_arm_compute_lib_binaries.sh: line 20: architecture_type: command not found
```

minor spacing fix to resolve it. cc @u99127 