### PR TITLE
[Pre-commit] Add pre-commit configuration to perform minimal checks locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# https://pre-commit.com/
+#
+#   How to configure:
+#       $ pip install pre-commit
+#       $ pre-commit install
+#   How to prevent running it:
+#       $ git commit --no-verify
+
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.5.0
@@ -23,6 +31,7 @@ repos:
         - id: check-merge-conflict
         - id: check-yaml
         - id: end-of-file-fixer
+        - id: trailing-whitespace
     - repo: local
       hooks:
         -   id: run-file-types

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,17 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# https://pre-commit.com/
+# Pre-commit hook
+# See documentation at: https://pre-commit.com/
 #
-#   How to configure:
-#       $ pip install pre-commit
-#       $ pre-commit install
-#   How to prevent running it:
-#       $ git commit --no-verify
+# Pre-commit hook to run the sanity checks from Jenkins locally.
+#
+# Requirements:
+#   - How to configure:
+#        $ pip install pre-commit
+#        $ pre-commit install
+#   - How to prevent running it:
+#        $ git commit --no-verify
+#
+# Working versions required:
+#   $ pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1
+#
 
+default_language_version:
+    python: python3.8
+fail_fast: True
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.5.0
+      rev: v2.3.0
       hooks:
         - id: check-added-large-files
         - id: check-merge-conflict
@@ -34,33 +45,40 @@ repos:
         - id: trailing-whitespace
     - repo: local
       hooks:
-        -   id: run-file-types
-            name: Checking File Types...
-            entry: python3 tests/lint/check_file_type.py
+        -   id: run-unit-tests
+            name: Running Minimal Unit-Tests ...
+            entry: python -m pytest -v tests/python/all-platform-minimal-test
             language: system
-            always_run: true
-            pass_filenames: false
-        -   id: run-headers-check
-            name: Checking ASF License Headers...
-            entry: tests/lint/check_asf_header.sh --local
-            language: system
+            verbose: false
             always_run: true
             pass_filenames: false
         -   id: run-black
-            name: Checking Black ...
+            name: Running Black...
             entry: tests/lint/python_format.sh
             language: system
             always_run: true
-            pass_filenames: false
-        -   id: run-python-linting
-            name: Checking Python Linting ...
-            entry: tests/lint/pylint.sh
+        -   id: run-file-types
+            name: Checking File Types...
+            entry: python3 tests/lint/check_file_type.py
+            language: python
+            always_run: true
+        -   id: run-headers-check
+            name: Checking ASF License Headers ...
+            entry: tests/lint/check_asf_header.sh --local
             language: system
             always_run: true
-            pass_filenames: false
+        -   id: run-headers-check
+            name: Linting the C++ code ...
+            entry: tests/lint/cpplint.sh
+            language: system
+            always_run: False
+        -   id: run-clang-format
+            name: Checking Clang format ...
+            entry: tests/lint/clang_format.sh
+            language: system
+            always_run: False
         -   id: run-mypy
-            name: Type Checking with MyPy ...
+            name: Type Checking with MyPY ...
             entry: tests/scripts/task_mypy.sh
             language: system
             always_run: true
-            pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.5.0
+      hooks:
+        - id: check-added-large-files
+        - id: check-merge-conflict
+        - id: check-yaml
+        - id: end-of-file-fixer
+    - repo: local
+      hooks:
+        -   id: run-file-types
+            name: Checking File Types...
+            entry: python3 tests/lint/check_file_type.py
+            language: system
+            always_run: true
+            pass_filenames: false
+        -   id: run-headers-check
+            name: Checking ASF License Headers...
+            entry: tests/lint/check_asf_header.sh --local
+            language: system
+            always_run: true
+            pass_filenames: false
+        -   id: run-black
+            name: Checking Black ...
+            entry: tests/lint/python_format.sh
+            language: system
+            always_run: true
+            pass_filenames: false
+        -   id: run-python-linting
+            name: Checking Python Linting ...
+            entry: tests/lint/pylint.sh
+            language: system
+            always_run: true
+            pass_filenames: false
+        -   id: run-mypy
+            name: Type Checking with MyPy ...
+            entry: tests/scripts/task_mypy.sh
+            language: system
+            always_run: true
+            pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.5.0


### PR DESCRIPTION
This PR adds a pre-commit hook configuration file.
This configuration aims to encourage running the sanity checks on Jenkins, locally prior to committing. 

How to install:
```pip install pre-commit```
```pre-commit install```


This pre-commit configuration will run the following checks on each `git commit`:
```
Check for added large files..........................(no files to check)Skipped
Check for merge conflicts............................(no files to check)Skipped
Check Yaml...........................................(no files to check)Skipped
Fix End of Files.....................................(no files to check)Skipped
Trim Trailing Whitespace.............................(no files to check)Skipped
Running Minimal Unit-Tests ..............................................Passed
Running Black............................................................Passed
Checking File Types......................................................Passed
Checking ASF License Headers ............................................Passed
Linting the C++ code ................................(no files to check)Skipped
Checking Clang format ...............................(no files to check)Skipped
Type Checking with MyPY .................................................Passed
```

Also, as WIP branches tend to fail tests on early stages of development the above-mentioned checks can be prevented with:
``` git commit --no-verify ``` or ```git commit -n ```

**Requirements**: pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1 pre-commit==2.3.0

@hogepodge @areusch @jroesch @jcf94 