### PR TITLE
[UnitTests] Added cuDNN to default test targets

### DIFF
--- a/python/tvm/testing.py
+++ b/python/tvm/testing.py
@@ -70,6 +70,7 @@ import tvm.arith
 import tvm.tir
 import tvm.te
 import tvm._ffi
+
 from tvm.contrib import nvcc
 from tvm.error import TVMError
 
@@ -740,24 +741,22 @@ def requires_rpc(*args):
 
 def _target_to_requirement(target):
     if isinstance(target, str):
-        target_kind = target.split()[0]
-    else:
-        target_kind = target.kind.name
+        target = tvm.target.Target(target)
 
     # mapping from target to decorator
-    if target_kind == "cuda":
+    if target.kind.name == "cuda":
         return requires_cuda()
-    if target_kind == "rocm":
+    if target.kind.name == "rocm":
         return requires_rocm()
-    if target_kind == "vulkan":
+    if target.kind.name == "vulkan":
         return requires_vulkan()
-    if target_kind == "nvptx":
+    if target.kind.name == "nvptx":
         return requires_nvptx()
-    if target_kind == "metal":
+    if target.kind.name == "metal":
         return requires_metal()
-    if target_kind == "opencl":
+    if target.kind.name == "opencl":
         return requires_opencl()
-    if target_kind == "llvm":
+    if target.kind.name == "llvm":
         return requires_llvm()
     return []
 

--- a/python/tvm/topi/cuda/conv2d.py
+++ b/python/tvm/topi/cuda/conv2d.py
@@ -86,14 +86,13 @@ def conv2d_cudnn(
     # handle dilation
     stride_h, stride_w = (strides, strides) if isinstance(strides, int) else strides
     dilation_h, dilation_w = (dilation, dilation) if isinstance(dilation, int) else dilation
+    KH_dilated = (KH - 1) * dilation_h + 1
+    KW_dilated = (KW - 1) * dilation_h + 1
 
-    if (
-        isinstance(padding, (list, tuple))
-        and len(padding) == 4
-        and (padding[0] != padding[2] or padding[1] != padding[3])
-    ):
+    pt, pl, pb, pr = get_pad_tuple(padding, (KH_dilated, KW_dilated))
+    if (pt != pb) or (pl != pr):
         raise ValueError("Cudnn doesn't support asymmetric padding.")
-    pt, pl, pb, pr = get_pad_tuple(padding, (KH, KW))
+
     OH = (H + pt + pb - KH) // stride_h + 1
     OW = (W + pl + pr - KW) // stride_w + 1
 

--- a/tests/python/topi/python/test_topi_batch_matmul.py
+++ b/tests/python/topi/python/test_topi_batch_matmul.py
@@ -85,7 +85,8 @@ def verify_batch_matmul(x_batch, y_batch, M, N, K, dynamic=False, debug=False):
         tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
 
     for target, dev in tvm.testing.enabled_targets():
-        if dynamic and (target == "cuda" or target == "nvptx"):
+        target_kind = tvm.target.Target(target).kind.name
+        if dynamic and target_kind in ["cuda", "nvptx", "vulkan", "opencl"]:
             print("Dynamic batch matmul test is skippped on %s" % target)
             continue
 

--- a/tests/python/topi/python/test_topi_conv2d_nchw.py
+++ b/tests/python/topi/python/test_topi_conv2d_nchw.py
@@ -104,6 +104,10 @@ class BaseConv2DTests:
         pad_top, pad_left, pad_bottom, pad_right = get_pad_tuple(padding, (kernel, kernel))
         padding_sum = pad_top + pad_left + pad_bottom + pad_right
 
+        has_asymmetric_padding = (pad_top != pad_bottom) or (pad_left != pad_right)
+        if is_cudnn_target and has_asymmetric_padding:
+            pytest.xfail("CuDNN does not support asymmetric padding")
+
         a_np, w_np, b_np, c_np = ref_data
 
         A = te.placeholder(a_np.shape, name="A", dtype=dtype)


### PR DESCRIPTION
Some unit tests explicitly test cudnn in addition to tvm.testing.enabled_targets().  This moved the cudnn checks into the same framework as all other targets, and adds it to the default list of targets to be run.  Also, added `@tvm.testing.requires_cudnn` for tests specific to cudnn.

In principle, this should pass CI, since any non-cudnn tests can fall back to the cuda implementation, but "should" is a bit of a magic word.