### PR TITLE
[microTVM] Add Nucleo stm32l4r5zi board to zephyr

### DIFF
--- a/apps/microtvm/zephyr/aot_demo/boards/nucleo_l4r5zi.conf
+++ b/apps/microtvm/zephyr/aot_demo/boards/nucleo_l4r5zi.conf
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This file is specific to the STM32L4R5ZI Nucleo board.
+
+# For intrinsics used by generated optimized operators.
+CONFIG_CMSIS_DSP=y
+
+# For AOT runtime which requires lots of function call.
+CONFIG_MAIN_STACK_SIZE=3000
+
+# For random number generation.
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+# For debugging.
+CONFIG_LED=y

--- a/apps/microtvm/zephyr/aot_demo/src/zephyr_uart.c
+++ b/apps/microtvm/zephyr/aot_demo/src/zephyr_uart.c
@@ -77,5 +77,13 @@ uint32_t TVMPlatformWriteSerial(const char* data, uint32_t size) {
 void TVMPlatformUARTInit() {
   // Claim console device.
   g_microtvm_uart = device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_console)));
+  const struct uart_config config = {
+    .baudrate = 115200,
+    .parity = UART_CFG_PARITY_NONE,
+    .stop_bits = UART_CFG_STOP_BITS_1,
+    .data_bits = UART_CFG_DATA_BITS_8,
+    .flow_ctrl = UART_CFG_FLOW_CTRL_NONE
+  };
+  uart_configure(g_microtvm_uart, &config);
   uart_rx_init(&uart_rx_rbuf, g_microtvm_uart);
 }

--- a/apps/microtvm/zephyr/aot_demo/src/zephyr_uart.c
+++ b/apps/microtvm/zephyr/aot_demo/src/zephyr_uart.c
@@ -77,13 +77,11 @@ uint32_t TVMPlatformWriteSerial(const char* data, uint32_t size) {
 void TVMPlatformUARTInit() {
   // Claim console device.
   g_microtvm_uart = device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_console)));
-  const struct uart_config config = {
-    .baudrate = 115200,
-    .parity = UART_CFG_PARITY_NONE,
-    .stop_bits = UART_CFG_STOP_BITS_1,
-    .data_bits = UART_CFG_DATA_BITS_8,
-    .flow_ctrl = UART_CFG_FLOW_CTRL_NONE
-  };
+  const struct uart_config config = {.baudrate = 115200,
+                                     .parity = UART_CFG_PARITY_NONE,
+                                     .stop_bits = UART_CFG_STOP_BITS_1,
+                                     .data_bits = UART_CFG_DATA_BITS_8,
+                                     .flow_ctrl = UART_CFG_FLOW_CTRL_NONE};
   uart_configure(g_microtvm_uart, &config);
   uart_rx_init(&uart_rx_rbuf, g_microtvm_uart);
 }

--- a/apps/microtvm/zephyr/host_driven/boards/nucleo_l4r5zi.conf
+++ b/apps/microtvm/zephyr/host_driven/boards/nucleo_l4r5zi.conf
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This file is specific to the STM32L4R5ZI Nucleo board.
+
+# For intrinsics used by generated optimized operators.
+CONFIG_CMSIS_DSP=y
+
+# For operations that stack allocates a large float array.
+CONFIG_MAIN_STACK_SIZE=1536
+
+# For random number generation.
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+# For debugging.
+CONFIG_LED=y

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -408,6 +408,7 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
     BOARD_USB_FIND_KW = {
         "nucleo_f746zg": {"idVendor": 0x0483, "idProduct": 0x374B},
         "stm32f746g_disco": {"idVendor": 0x0483, "idProduct": 0x374B},
+        "nucleo_l4r5zi": {"idVendor": 0x0483, "idProduct": 0x374B},
     }
 
     def openocd_serial(self, cmake_entries):

--- a/python/tvm/micro/contrib/zephyr.py
+++ b/python/tvm/micro/contrib/zephyr.py
@@ -406,9 +406,9 @@ class ZephyrFlasher(tvm.micro.compiler.Flasher):
 
     # kwargs passed to usb.core.find to find attached boards for the openocd flash runner.
     BOARD_USB_FIND_KW = {
+        "nucleo_l4r5zi": {"idVendor": 0x0483, "idProduct": 0x374B},
         "nucleo_f746zg": {"idVendor": 0x0483, "idProduct": 0x374B},
         "stm32f746g_disco": {"idVendor": 0x0483, "idProduct": 0x374B},
-        "nucleo_l4r5zi": {"idVendor": 0x0483, "idProduct": 0x374B},
     }
 
     def openocd_serial(self, cmake_entries):

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -281,9 +281,9 @@ def intel_graphics(model="unknown", options=None):
 
 MICRO_SUPPORTED_MODELS = {
     "host": [],
-    "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
-    "nrf5340dk": ["-mcpu=cortex-m33"],
     "mps2_an521": ["-mcpu=cortex-m33"],
+    "nrf5340dk": ["-mcpu=cortex-m33"],
+    "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
     "stm32l4r5zi": ["-mcpu=cortex-m4"],
 }
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -284,6 +284,7 @@ MICRO_SUPPORTED_MODELS = {
     "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
     "nrf5340dk": ["-mcpu=cortex-m33"],
     "mps2_an521": ["-mcpu=cortex-m33"],
+    "stm32l4r5zi": ["-mcpu=cortex-m4"],
 }
 
 

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -144,6 +144,7 @@ ALLOW_SPECIFIC_FILE = {
     "apps/microtvm/zephyr/host_driven/boards/nucleo_f746zg.conf",
     "apps/microtvm/zephyr/host_driven/boards/stm32f746g_disco.conf",
     "apps/microtvm/zephyr/host_driven/boards/mps2_an521.conf",
+    "apps/microtvm/zephyr/host_driven/boards/nucleo_l4r5zi.conf",
     "apps/microtvm/zephyr/host_driven/qemu-hack",
     "apps/microtvm/zephyr/aot_demo/prj.conf",
     "apps/microtvm/zephyr/aot_demo/boards/qemu_x86.conf",
@@ -153,6 +154,7 @@ ALLOW_SPECIFIC_FILE = {
     "apps/microtvm/zephyr/aot_demo/boards/nucleo_f746zg.conf",
     "apps/microtvm/zephyr/aot_demo/boards/stm32f746g_disco.conf",
     "apps/microtvm/zephyr/aot_demo/boards/mps2_an521.conf",
+    "apps/microtvm/zephyr/aot_demo/boards/nucleo_l4r5zi.conf",
     "apps/microtvm/zephyr/aot_demo/qemu-hack",
     # microTVM Virtual Machines
     "apps/microtvm/reference-vm/zephyr/Vagrantfile",

--- a/tests/micro/zephyr/conftest.py
+++ b/tests/micro/zephyr/conftest.py
@@ -27,6 +27,7 @@ PLATFORMS = {
     "stm32f746xx_nucleo": ("stm32f746xx", "nucleo_f746zg"),
     "stm32f746xx_disco": ("stm32f746xx", "stm32f746g_disco"),
     "nrf5340dk": ("nrf5340dk", "nrf5340dk_nrf5340_cpuapp"),
+    "stm32l4r5zi_nucleo": ("stm32l4r5zi", "nucleo_l4r5zi"),
     "mps2_an521": ("mps2_an521", "mps2_an521-qemu"),
 }
 

--- a/tests/micro/zephyr/conftest.py
+++ b/tests/micro/zephyr/conftest.py
@@ -59,12 +59,7 @@ def pytest_addoption(parser):
 
 
 def pytest_generate_tests(metafunc):
-    parametrized_args = [
-        arg.strip()
-        for mark in metafunc.definition.iter_markers("parametrize")
-        for arg in mark.args[0].split(",")
-    ]
-    if "platform" not in parametrized_args:
+    if "platform" in metafunc.fixturenames:
         metafunc.parametrize("platform", metafunc.config.getoption("microtvm_platforms").split(","))
 
 

--- a/tests/micro/zephyr/conftest.py
+++ b/tests/micro/zephyr/conftest.py
@@ -59,7 +59,12 @@ def pytest_addoption(parser):
 
 
 def pytest_generate_tests(metafunc):
-    if "platform" in metafunc.fixturenames:
+    parametrized_args = [
+        arg.strip()
+        for mark in metafunc.definition.iter_markers("parametrize")
+        for arg in mark.args[0].split(",")
+    ]
+    if "platform" not in parametrized_args:
         metafunc.parametrize("platform", metafunc.config.getoption("microtvm_platforms").split(","))
 
 

--- a/tests/micro/zephyr/conftest.py
+++ b/tests/micro/zephyr/conftest.py
@@ -24,11 +24,11 @@ PLATFORMS = {
     "host": ("host", "qemu_x86"),
     "host_riscv32": ("host", "qemu_riscv32"),
     "host_riscv64": ("host", "qemu_riscv64"),
-    "stm32f746xx_nucleo": ("stm32f746xx", "nucleo_f746zg"),
-    "stm32f746xx_disco": ("stm32f746xx", "stm32f746g_disco"),
-    "nrf5340dk": ("nrf5340dk", "nrf5340dk_nrf5340_cpuapp"),
-    "stm32l4r5zi_nucleo": ("stm32l4r5zi", "nucleo_l4r5zi"),
     "mps2_an521": ("mps2_an521", "mps2_an521-qemu"),
+    "nrf5340dk": ("nrf5340dk", "nrf5340dk_nrf5340_cpuapp"),
+    "stm32f746xx_disco": ("stm32f746xx", "stm32f746g_disco"),
+    "stm32f746xx_nucleo": ("stm32f746xx", "nucleo_f746zg"),
+    "stm32l4r5zi_nucleo": ("stm32l4r5zi", "nucleo_l4r5zi"),
 }
 
 

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -213,8 +213,10 @@ def test_tflite(platform, west_cmd, skip_build, tvm_debug):
     assert result == 8
 
 
-@pytest.mark.parametrize("platform", ["host", "mps2_an521"])
 def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
+    if platform not in ["host", "mps2_an521"]:
+        pytest.skip(msg="Only for QEMU targets.")
+
     """Testing QEMU make fail."""
     model, zephyr_board = PLATFORMS[platform]
     build_config = {"skip_build": skip_build, "debug": tvm_debug}

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -214,9 +214,6 @@ def test_tflite(platform, west_cmd, skip_build, tvm_debug):
 
 
 def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
-    if platform not in ["host", "mps2_an521"]:
-        pytest.skip(msg="Only for QEMU targets.")
-
     """Testing QEMU make fail."""
     model, zephyr_board = PLATFORMS[platform]
     build_config = {"skip_build": skip_build, "debug": tvm_debug}

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -213,6 +213,7 @@ def test_tflite(platform, west_cmd, skip_build, tvm_debug):
     assert result == 8
 
 
+@pytest.mark.parametrize("platform", ["host", "mps2_an521"])
 def test_qemu_make_fail(platform, west_cmd, skip_build, tvm_debug):
     """Testing QEMU make fail."""
     model, zephyr_board = PLATFORMS[platform]


### PR DESCRIPTION
This PR:
- adds stm32l4r5zi as another target to micro targets
- adds stm32l4r5zi config files for zephyr test and zephyr AOT test

cc @areusch @gromero 