### PR TITLE
Add missing annotation for requires_gpu in test_topi_dense.py 

### DIFF
--- a/tests/python/topi/python/test_topi_dense.py
+++ b/tests/python/topi/python/test_topi_dense.py
@@ -135,6 +135,7 @@ def test_dense(
 
 
 @pytest.mark.parametrize("target,in_dtype,out_dtype", [("cuda", "int8", "int32")])
+@tvm.testing.requires_gpu
 def test_dense_cuda_int8(
     target,
     dev,


### PR DESCRIPTION
Add missing Requires GPU on this test as this fails when topi tests are run on CPUs without GPUs.