### PR TITLE
[RPC] Fix cpp_rpc connection to rpc_tracker

### DIFF
--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -290,7 +290,8 @@ void CreateShared(const std::string& output, const std::vector<std::string>& fil
 }
 
 std::string BuildSharedLibrary(std::string file) {
-  if (support::EndsWith(file, ".so") || support::EndsWith(file, ".dll")) {
+  if (support::EndsWith(file, ".so") || support::EndsWith(file, ".dll") ||
+      support::EndsWith(file, ".dylib")) {
     return file;
   }
 

--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -47,7 +47,7 @@ namespace {
 std::string GenerateUntarCommand(const std::string& tar_file, const std::string& output_dir) {
   std::string untar_cmd;
   untar_cmd.reserve(512);
-#if defined(__linux__) || defined(__ANDROID__)
+#if defined(__linux__) || defined(__ANDROID__) || defined(__APPLE__)
   untar_cmd += "tar -C ";
   untar_cmd += output_dir;
   untar_cmd += " -zxf ";
@@ -224,7 +224,7 @@ std::vector<std::string> ListDir(const std::string& dirname) {
   return vec;
 }
 
-#if defined(__linux__) || defined(__ANDROID__)
+#if defined(__linux__) || defined(__ANDROID__) || defined(__APPLE__)
 /*!
  * \brief LinuxShared Creates a linux shared library
  * \param output The output file name
@@ -280,7 +280,7 @@ void WindowsShared(const std::string& output, const std::vector<std::string>& fi
  * \param files The files for building
  */
 void CreateShared(const std::string& output, const std::vector<std::string>& files) {
-#if defined(__linux__) || defined(__ANDROID__)
+#if defined(__linux__) || defined(__ANDROID__) || defined(__APPLE__)
   LinuxShared(output, files);
 #elif defined(_WIN32)
   WindowsShared(output, files);

--- a/apps/cpp_rpc/rpc_server.cc
+++ b/apps/cpp_rpc/rpc_server.cc
@@ -140,7 +140,7 @@ class RPCServer {
    * \brief ListenLoopProc The listen process.
    */
   void ListenLoopProc() {
-    TrackerClient tracker(tracker_addr_, key_, custom_addr_);
+    TrackerClient tracker(tracker_addr_, key_, custom_addr_, port_);
     while (true) {
       support::TCPSocket conn;
       support::SockAddr addr("0.0.0.0", 0);

--- a/apps/cpp_rpc/rpc_tracker_client.h
+++ b/apps/cpp_rpc/rpc_tracker_client.h
@@ -49,12 +49,17 @@ class TrackerClient {
    * \brief Constructor.
    */
   TrackerClient(const std::string& tracker_addr, const std::string& key,
-                const std::string& custom_addr)
+                const std::string& custom_addr, int port)
       : tracker_addr_(tracker_addr),
         key_(key),
         custom_addr_(custom_addr),
+        port_(port),
         gen_(std::random_device{}()),
-        dis_(0.0, 1.0) {}
+        dis_(0.0, 1.0) {
+    if (custom_addr_.empty()) {
+      custom_addr_ = "null";
+    }
+  }
   /*!
    * \brief Destructor.
    */
@@ -80,7 +85,7 @@ class TrackerClient {
 
       std::ostringstream ss;
       ss << "[" << static_cast<int>(TrackerCode::kUpdateInfo) << ", {\"key\": \"server:" << key_
-         << "\"}]";
+         << "\", \"addr\": [" << custom_addr_ << ", \"" << port_ << "\"]}]";
       tracker_sock_.SendBytes(ss.str());
 
       // Receive status and validate
@@ -105,9 +110,6 @@ class TrackerClient {
   void ReportResourceAndGetKey(int port, std::string* matchkey) {
     if (!tracker_sock_.IsClosed()) {
       *matchkey = RandomKey(key_ + ":", old_keyset_);
-      if (custom_addr_.empty()) {
-        custom_addr_ = "null";
-      }
 
       std::ostringstream ss;
       ss << "[" << static_cast<int>(TrackerCode::kPut) << ", \"" << key_ << "\", [" << port
@@ -230,6 +232,7 @@ class TrackerClient {
   std::string tracker_addr_;
   std::string key_;
   std::string custom_addr_;
+  int port_;
   support::TCPSocket tracker_sock_;
   std::set<std::string> old_keyset_;
   std::mt19937 gen_;


### PR DESCRIPTION
Fixed connection cpp_rpc application to rpc_tracker which was broken by
this commit: 0bbaf0e.
Also, made it possible to create a linux shared library on MacOS.
Without this change default tuning didn't work on MacOS.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
