### PR TITLE
Add Compute Library tests to Jenkins for AArch64 CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,6 +282,7 @@ stage('Unit Test') {
         timeout(time: max_time, unit: 'MINUTES') {
           sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
+          sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
           junit "build/pytest-results/*.xml"
           // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
         }


### PR DESCRIPTION
Now that we have hardware testing on by default, Actually run this.
