### PR TITLE
[Torch] Remove unused conversion

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1877,9 +1877,6 @@ class PyTorchOpConverter:
         assert len(inputs) == 1
         return _op.cast(inputs[0], "float32")
 
-    def mm(self, inputs, input_types):
-        return _op.nn.dense(inputs[0], inputs[1])
-
     def bitwise_not(self, inputs, input_types):
         data = inputs[0]
         # The input tensor must be of integral or Boolean types.

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1878,7 +1878,7 @@ class PyTorchOpConverter:
         return _op.cast(inputs[0], "float32")
 
     def mm(self, inputs, input_types):
-        return _op.nn.dense(inputs[0], inputs[1])
+        return _op.nn.dense(inputs[0], _op.transpose(inputs[1]))
 
     def bitwise_not(self, inputs, input_types):
         data = inputs[0]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1878,7 +1878,7 @@ class PyTorchOpConverter:
         return _op.cast(inputs[0], "float32")
 
     def mm(self, inputs, input_types):
-        return _op.nn.dense(inputs[0], _op.transpose(inputs[1]))
+        return _op.nn.dense(inputs[0], inputs[1])
 
     def bitwise_not(self, inputs, input_types):
         data = inputs[0]

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3853,15 +3853,6 @@ def test_masked_select():
         verify_trace_model(test_fn, [x, mask], ["llvm", "cuda", "nvptx"])
 
 
-def test_mm():
-    def test_fn(x, y):
-        return torch.mm(x, y)
-
-    x = torch.randn((100, 200))
-    y = torch.randn((200, 100))
-    verify_trace_model(test_fn, [x, y], ["llvm", "cuda"])
-
-
 def test_unique():
     def test_fn(is_sorted, return_inverse, return_counts):
         return lambda x: torch.unique(x, is_sorted, return_inverse, return_counts)
@@ -4044,7 +4035,6 @@ if __name__ == "__main__":
     test_hard_swish()
     test_hard_sigmoid()
     test_forward_nll_loss()
-    test_mm()
 
     # Model tests
     test_resnet18()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3853,6 +3853,15 @@ def test_masked_select():
         verify_trace_model(test_fn, [x, mask], ["llvm", "cuda", "nvptx"])
 
 
+def test_mm():
+    def test_fn(x, y):
+        return torch.mm(x, y)
+
+    x = torch.randn((100, 200))
+    y = torch.randn((200, 100))
+    verify_trace_model(test_fn, [x, y], ["llvm", "cuda"])
+
+
 def test_unique():
     def test_fn(is_sorted, return_inverse, return_counts):
         return lambda x: torch.unique(x, is_sorted, return_inverse, return_counts)
@@ -4035,6 +4044,7 @@ if __name__ == "__main__":
     test_hard_swish()
     test_hard_sigmoid()
     test_forward_nll_loss()
+    test_mm()
 
     # Model tests
     test_resnet18()


### PR DESCRIPTION
Fixes https://github.com/apache/tvm/issues/8392

~~This could have been a source of accuracy issues. For some reason I don't get shape errors without transpose, only accuracy errors.~~

Actually it turns out this is a dead code...

@comaniac @jcf94 @tqchen 