### PR TITLE
Revert "Actually add Compute Library tests to the Jenkins File (#8394)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,7 +282,6 @@ stage('Unit Test') {
         timeout(time: max_time, unit: 'MINUTES') {
           sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
-          sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
           junit "build/pytest-results/*.xml"
           // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
         }

--- a/tests/scripts/task_python_arm_compute_library.sh
+++ b/tests/scripts/task_python_arm_compute_library.sh
@@ -27,4 +27,5 @@ source tests/scripts/setup-pytest-env.sh
 find . -type f -path "*.pyc" | xargs rm -f
 make cython3
 
-run_pytest ctypes python-arm_compute_lib tests/python/contrib/test_arm_compute_lib
+echo "Temporarily suspended while we understand flakiness with #8117"
+#run_pytest ctypes python-arm_compute_lib tests/python/contrib/test_arm_compute_lib


### PR DESCRIPTION
This reverts commit a00d21156ea749d65c9a59b3a79dac501723086b till we
can understand why this is failing in CI but not on developer machines.

@tqchen @leandron @masahi 

Sorry about the breakage but here's a revert if that can be merged asap.