### PR TITLE
DeviceType enums match dlpack

### DIFF
--- a/rust/tvm-sys/src/device.rs
+++ b/rust/tvm-sys/src/device.rs
@@ -65,14 +65,14 @@ use thiserror::Error;
 #[repr(i64)]
 pub enum DeviceType {
     CPU = 1,
-    CUDA,
-    CUDAHost,
-    OpenCL,
-    Vulkan,
-    Metal,
-    VPI,
-    ROCM,
-    ExtDev,
+    CUDA = 2,
+    CUDAHost = 3,
+    OpenCL = 4,
+    Vulkan = 7,
+    Metal = 8,
+    VPI = 9,
+    ROCM = 10,
+    ExtDev = 12,
 }
 
 impl Default for DeviceType {


### PR DESCRIPTION
@jroesch I've updated the rust `DeviceType` enum to match dlpack's definition here: https://github.com/dmlc/dlpack/blob/277508879878e0a5b5b43599b1bea11f66eb3c6c/include/dlpack/dlpack.h#L38-L71
