### PR TITLE
Prepare the topi tests for AArch64 CI.

### DIFF
--- a/tests/python/topi/python/test_topi_argwhere.py
+++ b/tests/python/topi/python/test_topi_argwhere.py
@@ -22,10 +22,7 @@ from tvm import te
 from tvm import topi
 import tvm.topi.testing
 
-_argwhere_schedule = {
-    "generic": topi.generic.schedule_argwhere,
-    "gpu": topi.cuda.schedule_argwhere,
-}
+_argwhere_schedule = {"generic": topi.generic.schedule_argwhere, "gpu": topi.cuda.schedule_argwhere}
 
 _argwhere_compute = {"llvm": topi.argwhere, "cuda": topi.cuda.argwhere}
 

--- a/tests/python/topi/python/test_topi_batch_matmul.py
+++ b/tests/python/topi/python/test_topi_batch_matmul.py
@@ -110,14 +110,12 @@ def verify_batch_matmul_int8(x_batch, y_batch, M, N, K):
     # get the test data
     a_np, b_np, c_np = get_ref_data()
 
-    def check_device(device):
-        dev = tvm.device(device, 0)
+    def check_device(target, dev):
         if device == "cuda" and not tvm.contrib.nvcc.have_int8(dev.compute_version):
             print("Skip because int8 intrinsics are not available")
             return
 
-        print("Running on target: %s" % device)
-        with tvm.target.Target(device):
+        with tvm.target.Target(target):
             out = topi.cuda.batch_matmul_int8(x, y, None, out_dtype)
             s = topi.cuda.schedule_batch_matmul_int8([out])
         a = tvm.nd.array(a_np, dev)
@@ -127,8 +125,8 @@ def verify_batch_matmul_int8(x_batch, y_batch, M, N, K):
         f(a, b, c)
         tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
 
-    for device in ["cuda"]:
-        check_device(device)
+    for target, dev in tvm.testing.enabled_targets():
+        check_device(target, dev)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/topi/python/test_topi_batch_matmul.py
+++ b/tests/python/topi/python/test_topi_batch_matmul.py
@@ -111,7 +111,7 @@ def verify_batch_matmul_int8(x_batch, y_batch, M, N, K):
     a_np, b_np, c_np = get_ref_data()
 
     def check_device(target, dev):
-        if device == "cuda" and not tvm.contrib.nvcc.have_int8(dev.compute_version):
+        if target == "cuda" and not tvm.contrib.nvcc.have_int8(dev.compute_version):
             print("Skip because int8 intrinsics are not available")
             return
 

--- a/tests/python/topi/python/test_topi_batch_matmul_tensorcore.py
+++ b/tests/python/topi/python/test_topi_batch_matmul_tensorcore.py
@@ -26,7 +26,7 @@ from tvm.contrib.pickle_memoize import memoize
 import tvm.testing
 
 _batch_matmul_implement = {
-    "gpu": (topi.cuda.batch_matmul_tensorcore, topi.cuda.schedule_batch_matmul_tensorcore),
+    "gpu": (topi.cuda.batch_matmul_tensorcore, topi.cuda.schedule_batch_matmul_tensorcore)
 }
 
 

--- a/tests/python/topi/python/test_topi_batch_to_space_nd.py
+++ b/tests/python/topi/python/test_topi_batch_to_space_nd.py
@@ -44,7 +44,7 @@ def verify_batch_to_space_nd(input_shape, block_shape, crop_begin_list, crop_end
 
     def check_device(target, dev):
         print("Running on target: %s" % target)
-        with tvm.target.create(target):
+        with tvm.target.Target(target):
             s = tvm.topi.testing.get_injective_schedule(target)(B)
         a = tvm.nd.array(a_np, dev)
         b = tvm.nd.array(np.zeros(out_shape, dtype=dtype), dev)

--- a/tests/python/topi/python/test_topi_broadcast.py
+++ b/tests/python/topi/python/test_topi_broadcast.py
@@ -290,13 +290,7 @@ def test_shift():
 
 @tvm.testing.uses_gpu
 def test_logical_single_ele():
-    def test_apply(
-        func,
-        name,
-        f_numpy,
-        indata,
-        dtype="bool",
-    ):
+    def test_apply(func, name, f_numpy, indata, dtype="bool"):
         # Build the logic and compile the function
         A = te.placeholder(shape=indata.shape, name="A", dtype=dtype)
         B = func(A)
@@ -327,13 +321,7 @@ def test_logical_single_ele():
 
 @tvm.testing.uses_gpu
 def test_bitwise_not():
-    def test_apply(
-        func,
-        name,
-        f_numpy,
-        shape,
-        dtype="int32",
-    ):
+    def test_apply(func, name, f_numpy, shape, dtype="int32"):
         # Build the logic and compile the function
         A = te.placeholder(shape=shape, name="A", dtype=dtype)
         B = func(A)
@@ -365,14 +353,7 @@ def test_bitwise_not():
 
 @tvm.testing.uses_gpu
 def test_logical_binary_ele():
-    def test_apply(
-        func,
-        name,
-        f_numpy,
-        lhs,
-        rhs,
-        dtype="bool",
-    ):
+    def test_apply(func, name, f_numpy, lhs, rhs, dtype="bool"):
         # Build the logic and compile the function
         A = te.var("A", dtype=dtype)
         B = te.var("B", dtype=dtype)

--- a/tests/python/topi/python/test_topi_conv2d_NCHWc.py
+++ b/tests/python/topi/python/test_topi_conv2d_NCHWc.py
@@ -51,6 +51,7 @@ def _transform_bias(bias, bn):
     bias = np.transpose(bias, (0, 2, 3, 1))
     return bias
 
+
 @tvm.testing.requires_llvm
 def verify_conv2d_NCHWc(
     batch,

--- a/tests/python/topi/python/test_topi_conv2d_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_int8.py
@@ -175,8 +175,7 @@ def verify_conv2d_NHWC_gemm_int8(
 
     a_np, w_np, b_np, c_np = get_ref_data()
 
-    def check_target(target):
-        dev = tvm.device(target, 0)
+    def check_target(target, dev):
         if not tvm.testing.device_enabled(target):
             print("Skip because %s is not enabled" % target)
             return
@@ -222,7 +221,8 @@ def verify_conv2d_NHWC_gemm_int8(
             func(a, w, c)
         tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
 
-    check_target("llvm")
+    for target, dev in tvm.testing.enabled_targets():
+        check_target(target, dev)
 
 
 oc_block_factor = 4

--- a/tests/python/topi/python/test_topi_conv2d_nchw.py
+++ b/tests/python/topi/python/test_topi_conv2d_nchw.py
@@ -52,15 +52,7 @@ def bias_shape(num_filter):
 
 @tvm.testing.fixture(cache_return_value=True)
 def ref_data(
-    input_shape,
-    weight_shape,
-    bias_shape,
-    dtype,
-    stride,
-    padding,
-    dilation,
-    add_bias,
-    apply_relu,
+    input_shape, weight_shape, bias_shape, dtype, stride, padding, dilation, add_bias, apply_relu
 ):
     a_np = np.random.uniform(size=input_shape).astype(dtype)
     w_np = np.random.uniform(size=weight_shape).astype(dtype)
@@ -146,15 +138,7 @@ class BaseConv2DTests:
 
     @tvm.testing.parametrize_targets("llvm")
     def test_workload_padding(
-        self,
-        target,
-        input_shape,
-        weight_shape,
-        stride,
-        padding,
-        dilation,
-        dtype,
-        ref_data,
+        self, target, input_shape, weight_shape, stride, padding, dilation, dtype, ref_data
     ):
         a_np, w_np, b_np, c_np = ref_data
         _, _, out_height, out_width = c_np.shape
@@ -282,7 +266,7 @@ class TestAsymmetricPadding(BaseConv2DTests):
 
 class TestBatchSize(BaseConv2DTests):
     in_channel, in_size, num_filter, kernel, stride, padding = tvm.testing.parameters(
-        (64, 56, 64, 3, 1, 1),
+        (64, 56, 64, 3, 1, 1)
     )
     batch = tvm.testing.parameter(1, 4, 9)
 

--- a/tests/python/topi/python/test_topi_conv2d_nhwc.py
+++ b/tests/python/topi/python/test_topi_conv2d_nhwc.py
@@ -34,14 +34,8 @@ _conv2d_nhwc_implement = {
         topi.arm_cpu.conv2d_nhwc_spatial_pack,
         topi.arm_cpu.schedule_conv2d_nhwc_spatial_pack,
     ),
-    "mali": (
-        topi.mali.conv2d_nhwc_spatial_pack,
-        topi.mali.schedule_conv2d_nhwc_spatial_pack,
-    ),
-    "bifrost": (
-        topi.mali.conv2d_nhwc_spatial_pack,
-        topi.mali.schedule_conv2d_nhwc_spatial_pack,
-    ),
+    "mali": (topi.mali.conv2d_nhwc_spatial_pack, topi.mali.schedule_conv2d_nhwc_spatial_pack),
+    "bifrost": (topi.mali.conv2d_nhwc_spatial_pack, topi.mali.schedule_conv2d_nhwc_spatial_pack),
     "hls": (topi.nn.conv2d_nhwc, topi.hls.schedule_conv2d_nhwc),
 }
 

--- a/tests/python/topi/python/test_topi_conv2d_nhwc_pack_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_nhwc_pack_int8.py
@@ -28,6 +28,7 @@ from tvm.contrib.pickle_memoize import memoize
 from tvm.topi.utils import get_const_tuple
 import tvm.testing
 
+
 def verify_conv2d_1x1_nhwc_pack_int8(
     batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation=1
 ):

--- a/tests/python/topi/python/test_topi_conv2d_winograd.py
+++ b/tests/python/topi/python/test_topi_conv2d_winograd.py
@@ -170,16 +170,7 @@ def test_conv2d_nchw():
     verify_conv2d_nchw(1, 48, 35, 48, 5, 1, "VALID", devices=["cuda"])
 
 
-def verify_conv2d_nhwc(
-    batch,
-    in_channel,
-    in_size,
-    num_filter,
-    kernel,
-    stride,
-    padding,
-    dilation=1,
-):
+def verify_conv2d_nhwc(batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation=1):
     # This version is intented to be used by the auto-scheduler,
     # so we only test the correctness of compute declaration
     # with the default naive schedule in cpu

--- a/tests/python/topi/python/test_topi_conv3d_winograd.py
+++ b/tests/python/topi/python/test_topi_conv3d_winograd.py
@@ -29,7 +29,7 @@ from tvm.topi.utils import get_const_tuple
 
 
 _conv3d_ncdhw_implement = {
-    "gpu": (topi.cuda.conv3d_ncdhw_winograd, topi.cuda.schedule_conv3d_ncdhw_winograd),
+    "gpu": (topi.cuda.conv3d_ncdhw_winograd, topi.cuda.schedule_conv3d_ncdhw_winograd)
 }
 
 

--- a/tests/python/topi/python/test_topi_deformable_conv2d.py
+++ b/tests/python/topi/python/test_topi_deformable_conv2d.py
@@ -32,7 +32,7 @@ _deformable_conv2d_nchw_implement = {
 }
 
 _deformable_conv2d_nhwc_implement = {
-    "generic": (topi.nn.deformable_conv2d_nhwc, topi.generic.schedule_deformable_conv2d_nhwc),
+    "generic": (topi.nn.deformable_conv2d_nhwc, topi.generic.schedule_deformable_conv2d_nhwc)
 }
 
 

--- a/tests/python/topi/python/test_topi_dense.py
+++ b/tests/python/topi/python/test_topi_dense.py
@@ -31,10 +31,7 @@ from common import Int8Fallback
 use_bias = tvm.testing.parameter(True, False)
 batch_size = tvm.testing.parameter(1, 2, 128)
 in_dim, out_dim = tvm.testing.parameters((1024, 1000))
-in_dtype, out_dtype = tvm.testing.parameters(
-    ("float32", "float32"),
-    ("int8", "int32"),
-)
+in_dtype, out_dtype = tvm.testing.parameters(("float32", "float32"), ("int8", "int32"))
 
 
 _dense_implementations = {
@@ -137,19 +134,9 @@ def test_dense(
 @pytest.mark.parametrize("target,in_dtype,out_dtype", [("cuda", "int8", "int32")])
 @tvm.testing.requires_gpu
 def test_dense_cuda_int8(
-    target,
-    dev,
-    batch_size,
-    in_dim,
-    out_dim,
-    use_bias,
-    dense_ref_data,
-    in_dtype,
-    out_dtype,
+    target, dev, batch_size, in_dim, out_dim, use_bias, dense_ref_data, in_dtype, out_dtype
 ):
-    implementations = [
-        (topi.cuda.dense_int8, topi.cuda.schedule_dense_int8),
-    ]
+    implementations = [(topi.cuda.dense_int8, topi.cuda.schedule_dense_int8)]
     with Int8Fallback():
         test_dense(
             target,

--- a/tests/python/topi/python/test_topi_depthwise_conv2d.py
+++ b/tests/python/topi/python/test_topi_depthwise_conv2d.py
@@ -63,7 +63,7 @@ _depthwise_conv2d_implement = {
         "gpu": [(topi.nn.depthwise_conv2d_nhwc, topi.cuda.schedule_depthwise_conv2d_nhwc)],
     },
     "NCHWc": {
-        "generic": [(topi.x86.depthwise_conv2d_NCHWc, topi.x86.schedule_depthwise_conv2d_NCHWc)],
+        "generic": [(topi.x86.depthwise_conv2d_NCHWc, topi.x86.schedule_depthwise_conv2d_NCHWc)]
     },
 }
 
@@ -158,13 +158,7 @@ def ref_data(
     if apply_relu:
         output_np = np.maximum(output_np, 0)
 
-    return (
-        input_np,
-        filter_np,
-        scale_np,
-        shift_np,
-        output_np,
-    )
+    return (input_np, filter_np, scale_np, shift_np, output_np)
 
 
 class BaseDepthwiseConv2D:
@@ -178,8 +172,7 @@ class BaseDepthwiseConv2D:
     layout = tvm.testing.parameter("NCHW", "NHWC")
 
     (batch, in_channel, in_size, channel_multiplier, kernel, stride) = tvm.testing.parameters(
-        (1, 728, 32, 1, 3, 1),
-        (4, 256, 64, 2, 5, 2),
+        (1, 728, 32, 1, 3, 1), (4, 256, 64, 2, 5, 2)
     )
     padding = tvm.testing.parameter("SAME", "VALID")
     dilation = tvm.testing.parameter(1, 2)
@@ -280,8 +273,7 @@ class BaseDepthwiseConv2D:
                     scale_tvm = tvm.nd.array(scale_np, dev)
                     shift_tvm = tvm.nd.array(shift_np, dev)
                     output_tvm = tvm.nd.array(
-                        np.zeros(shape=get_const_tuple(C.shape), dtype=C.dtype),
-                        dev,
+                        np.zeros(shape=get_const_tuple(C.shape), dtype=C.dtype), dev
                     )
 
                     f(input_tvm, filter_tvm, scale_tvm, shift_tvm, output_tvm)
@@ -361,7 +353,7 @@ class TestDepthwiseConv2D_NCHWc(BaseDepthwiseConv2D):
     # depthwise_conv2d_NCHWc currently does not support channel multiplier > 1
     layout = tvm.testing.parameter("NCHWc")
     (batch, in_channel, in_size, channel_multiplier, kernel, stride) = tvm.testing.parameters(
-        (1, 728, 32, 1, 3, 1),
+        (1, 728, 32, 1, 3, 1)
     )
 
 

--- a/tests/python/topi/python/test_topi_group_conv2d.py
+++ b/tests/python/topi/python/test_topi_group_conv2d.py
@@ -52,7 +52,7 @@ _group_conv2d_nchw_implement = {
 }
 
 _group_conv2d_nhwc_implement = {
-    "generic": (topi.nn.group_conv2d_nhwc, topi.generic.schedule_group_conv2d_nhwc),
+    "generic": (topi.nn.group_conv2d_nhwc, topi.generic.schedule_group_conv2d_nhwc)
 }
 
 

--- a/tests/python/topi/python/test_topi_math.py
+++ b/tests/python/topi/python/test_topi_math.py
@@ -72,12 +72,7 @@ def test_ewise():
             check_target(target, dev)
 
     def test_isnan(
-        low,
-        high,
-        shape=(20, 3),
-        dtype="float32",
-        check_round=False,
-        skip_name_check=False,
+        low, high, shape=(20, 3), dtype="float32", check_round=False, skip_name_check=False
     ):
         m = te.var("m")
         l = te.var("l")

--- a/tests/python/topi/python/test_topi_matmul.py
+++ b/tests/python/topi/python/test_topi_matmul.py
@@ -46,9 +46,7 @@ def verify_nn_matmul(sa, sb, transp_a, transp_b):
     b = np.random.uniform(low=-1.0, high=1.0, size=sb).astype(np.float32)
     c1 = np.matmul(np.transpose(a) if transp_a else a, np.transpose(b) if transp_b else b)
     c2 = with_tvm(
-        lambda A, B: topi.nn.matmul(A, B, transpose_a=transp_a, transpose_b=transp_b),
-        a,
-        b,
+        lambda A, B: topi.nn.matmul(A, B, transpose_a=transp_a, transpose_b=transp_b), a, b
     )
     tvm.testing.assert_allclose(c1, c2, rtol=1e-5, atol=1e-5)
 

--- a/tests/python/topi/python/test_topi_relu.py
+++ b/tests/python/topi/python/test_topi_relu.py
@@ -30,9 +30,7 @@ import tvm.testing
 
 
 m, n, dtype = tvm.testing.parameters(
-    (10, 128, "float32"),
-    (128, 64, "float16"),
-    (1024 * 100, 512, "float32"),
+    (10, 128, "float32"), (128, 64, "float16"), (1024 * 100, 512, "float32")
 )
 
 
@@ -76,9 +74,7 @@ def test_leaky_relu(size, alpha):
 
 
 x, w, axis, weight_reshape = tvm.testing.parameters(
-    ((1, 3, 2, 2), (3,), 1, (3, 1, 1)),
-    ((1, 3, 2, 2), (2,), 2, (2, 1)),
-    ((1, 3), (3,), 1, (3,)),
+    ((1, 3, 2, 2), (3,), 1, (3, 1, 1)), ((1, 3, 2, 2), (2,), 2, (2, 1)), ((1, 3), (3,), 1, (3,))
 )
 
 

--- a/tests/python/topi/python/test_topi_reorg.py
+++ b/tests/python/topi/python/test_topi_reorg.py
@@ -23,10 +23,7 @@ from tvm import te
 import tvm.topi.testing
 import tvm.testing
 
-_reorg_schedule = {
-    "generic": topi.generic.schedule_reorg,
-    "gpu": topi.cuda.schedule_reorg,
-}
+_reorg_schedule = {"generic": topi.generic.schedule_reorg, "gpu": topi.cuda.schedule_reorg}
 
 
 def verify_reorg(batch, in_size, in_channel, stride):

--- a/tests/python/topi/python/test_topi_scan.py
+++ b/tests/python/topi/python/test_topi_scan.py
@@ -58,12 +58,7 @@ def get_implementations(name, axis, dtype, exclusive):
     }
 
 
-def _run_tests(
-    dev,
-    target,
-    op_name: str = "cumsum",
-    gt_func: Callable[..., np.array] = np.cumsum,
-):
+def _run_tests(dev, target, op_name: str = "cumsum", gt_func: Callable[..., np.array] = np.cumsum):
     def check_scan(np_ref, data, axis=None, dtype=None, exclusive=False):
         implementations = get_implementations(op_name, axis, dtype, exclusive)
         fcompute, fschedule = tvm.topi.testing.dispatch(target, implementations)

--- a/tests/python/topi/python/test_topi_space_to_batch_nd.py
+++ b/tests/python/topi/python/test_topi_space_to_batch_nd.py
@@ -44,7 +44,7 @@ def verify_space_to_batch_nd(input_shape, block_shape, pad_before, pad_after, pa
 
     def check_target(target, dev):
         print("Running on target: %s" % target)
-        with tvm.target.create(target):
+        with tvm.target.Target(target):
             s = tvm.topi.testing.get_injective_schedule(target)(B)
         a = tvm.nd.array(a_np, dev)
         b = tvm.nd.array(np.zeros(out_shape, dtype=dtype), dev)

--- a/tests/python/topi/python/test_topi_sparse.py
+++ b/tests/python/topi/python/test_topi_sparse.py
@@ -72,8 +72,8 @@ def verify_dynamic_csrmv(batch, in_dim, out_dim, dtype, use_bias=True):
         tvm.testing.assert_allclose(d.numpy(), d_np, rtol=1e-4, atol=1e-4)
 
     # Unable to use the following idiom and thus restrict to llvm only.
-    #for target, dev in tvm.testing.enabled_targets():
-    for target in ['llvm']:
+    # for target, dev in tvm.testing.enabled_targets():
+    for target in ["llvm"]:
         dev = tvm.device(target, 0)
         check_device(target, dev)
 
@@ -114,7 +114,7 @@ def verify_dynamic_csrmm(batch, in_dim, out_dim, dtype, use_bias=True):
 
     # This test is not yet ready to use the idiom ,
     # for target, dev in tvm.testing.enabled_targets()
-    for target in ['llvm']:
+    for target in ["llvm"]:
         dev = tvm.device(target, 0)
         check_device(target, dev)
 
@@ -580,9 +580,9 @@ def verify_sparse_conv2d_bsr(M, H, W, N, K, BS_R, BS_C, density, layout):
         )
         tvm.testing.assert_allclose(Y_tvm.numpy(), Y_np.astype("float32"), atol=1e-4, rtol=1e-4)
 
-    #Unable to use the idiom below as the test isn't suitable for non llvm targets.
-    #for target, dev in tvm.testing.enabled_targets():
-    for target in ['llvm']:
+    # Unable to use the idiom below as the test isn't suitable for non llvm targets.
+    # for target, dev in tvm.testing.enabled_targets():
+    for target in ["llvm"]:
         dev = tvm.device(target, 0)
         check_device(target, dev)
 

--- a/tests/python/topi/python/test_topi_sparse.py
+++ b/tests/python/topi/python/test_topi_sparse.py
@@ -71,7 +71,10 @@ def verify_dynamic_csrmv(batch, in_dim, out_dim, dtype, use_bias=True):
         f(_nr, a.data, a.indices, a.indptr, b, c, d)
         tvm.testing.assert_allclose(d.numpy(), d_np, rtol=1e-4, atol=1e-4)
 
-    for target, dev in tvm.testing.enabled_targets():
+    # Unable to use the following idiom and thus restrict to llvm only.
+    #for target, dev in tvm.testing.enabled_targets():
+    for target in ['llvm']:
+        dev = tvm.device(target, 0)
         check_device(target, dev)
 
 
@@ -109,7 +112,10 @@ def verify_dynamic_csrmm(batch, in_dim, out_dim, dtype, use_bias=True):
         f(_nr, a.data, a.indices, a.indptr, b, c, d)
         tvm.testing.assert_allclose(d.numpy(), d_np, rtol=1e-2, atol=1e-2)
 
-    for target, dev in tvm.testing.enabled_targets():
+    # This test is not yet ready to use the idiom ,
+    # for target, dev in tvm.testing.enabled_targets()
+    for target in ['llvm']:
+        dev = tvm.device(target, 0)
         check_device(target, dev)
 
 
@@ -574,7 +580,10 @@ def verify_sparse_conv2d_bsr(M, H, W, N, K, BS_R, BS_C, density, layout):
         )
         tvm.testing.assert_allclose(Y_tvm.numpy(), Y_np.astype("float32"), atol=1e-4, rtol=1e-4)
 
-    for target, dev in tvm.testing.enabled_targets():
+    #Unable to use the idiom below as the test isn't suitable for non llvm targets.
+    #for target, dev in tvm.testing.enabled_targets():
+    for target in ['llvm']:
+        dev = tvm.device(target, 0)
         check_device(target, dev)
 
 

--- a/tests/python/topi/python/test_topi_transform.py
+++ b/tests/python/topi/python/test_topi_transform.py
@@ -794,7 +794,7 @@ def verify_adv_index(data_shape, index_shapes):
             print("Skip because %s is not enabled" % target)
             return
         print("Running on target: %s" % target)
-        with tvm.target.create(target):
+        with tvm.target.Target(target):
             s = tvm.topi.testing.get_injective_schedule(target)(out)
 
         func = tvm.build(s, [data] + indices + [out], target, name="adv_index")

--- a/tests/python/topi/python/test_topi_vision.py
+++ b/tests/python/topi/python/test_topi_vision.py
@@ -55,10 +55,7 @@ _roi_align_implement = {
     "gpu": (topi.vision.roi_align_nchw, topi.cuda.schedule_roi_align),
 }
 
-_roi_pool_schedule = {
-    "generic": topi.generic.schedule_roi_pool,
-    "gpu": topi.cuda.schedule_roi_pool,
-}
+_roi_pool_schedule = {"generic": topi.generic.schedule_roi_pool, "gpu": topi.cuda.schedule_roi_pool}
 
 _proposal_implement = {
     "generic": (topi.vision.rcnn.proposal, topi.generic.schedule_proposal),

--- a/tests/scripts/task_python_topi_aarch64.sh
+++ b/tests/scripts/task_python_topi_aarch64.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+
+export TVM_TEST_TARGETS="llvm -device=arm_cpu"
+./tests/scripts/task_python_topi.sh


### PR DESCRIPTION
This pull request cleans up the TOPI testuite for use on the AArch64
CI target by doing the following:

- Introducing a script to run the tests on AArch64 with a suitable
  invocation of the llvm target string by setting the TVM_TEST_TARGETS
  environment variable.

- Cleaning up the use of hard coded targets and moving the testsuite
  to testing more sensibly with the use of tvm.testing.enabled_targets.

- Cleanup the use of tvm.target.create.

Putting this up for a test run on ci_gpu and ci_cpu to see the effects
of moving TOPI test runs to AArch64 CPU before firing up the Jenkins
changes.

The motivation was from #8361 to pipeclean and add this support.


