### PR TITLE
[Fix] Update stale relay.Module API in docs/comments

### DIFF
--- a/docs/dev/pass_infra.rst
+++ b/docs/dev/pass_infra.rst
@@ -478,7 +478,7 @@ Users can build a pass through decoration like the following:
        x = relay.var("x", tp)
        gv = relay.GlobalVar("abs")
        func = relay.Function([x], relay.abs(x))
-       new_mod = relay.Module({gv: func})
+       new_mod = tvm.IRModule({gv: func})
        new_mod.update(mod)
        return new_mod
 
@@ -494,7 +494,7 @@ function.
 
 .. code:: python
 
-    mod = relay.Module()
+    mod = tvm.IRModule()
     mod = module_pass(mod)
 
 Correspondingly, we also offer such functionality for ``function_pass``. For

--- a/docs/langref/relay_expr.rst
+++ b/docs/langref/relay_expr.rst
@@ -432,7 +432,7 @@ This definition would result in a module entry mapping the identifier :code:`@ac
 with the parameters, return type, and body above. Any reference to the identifier :code:`@ackermann` elsewhere in the
 code could then look up the identifier in the module and replace the function definition as needed.
 
-See :py:class:`~tvm.relay.Module` for the definition and documentation of a module.
+See :py:class:`~tvm.IRModule` for the definition and documentation of a module.
 
 Constant
 ========

--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -44,14 +44,14 @@ def convert_graph_layout(mod, desired_layout):
 
     Parameters
     ----------
-    mod : tvm.relay.Module
+    mod : tvm.IRModule
         The relay module to convert.
     desired_layout : str
         The layout to convert to.
 
     Returns
     -------
-    mod : tvm.relay.Module
+    mod : tvm.IRModule
         The converted module.
     """
 

--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -68,7 +68,7 @@ class Frontend(ABC):
 
         Returns
         -------
-        mod : tvm.relay.Module
+        mod : tvm.IRModule
             The produced relay module.
         params : dict
             The parameters (weights) for the relay module.

--- a/python/tvm/relay/analysis/analysis.py
+++ b/python/tvm/relay/analysis/analysis.py
@@ -370,7 +370,7 @@ def extract_fused_functions(mod):
 
     Parameters
     ----------
-    mod : tvm.relay.IRModule
+    mod : tvm.IRModule
 
     Returns
     -------

--- a/python/tvm/relay/frontend/caffe.py
+++ b/python/tvm/relay/frontend/caffe.py
@@ -771,7 +771,7 @@ def from_caffe(init_net, predict_net, shape_dict, dtype_dict):
 
     Returns
     -------
-    mod : tvm.relay.Module
+    mod : tvm.IRModule
         The relay module for compilation.
 
     params : dict of str to tvm.NDArray

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3268,7 +3268,7 @@ def from_pytorch(script_module, input_infos, custom_convert_map=None, default_dt
 
     Returns
     -------
-    mod : tvm.relay.Module
+    mod : tvm.IRModule
         The module that optimizations will be performed on.
 
     params : dict of str to tvm.runtime.NDArray


### PR DESCRIPTION
`tvm.relay.Module` has been changed to `tvm.IRModule`, so updated the old API in docs and comments.