### PR TITLE
[Frontend] Check LLVM enabled/installed

### DIFF
--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -527,6 +527,7 @@ def infer_value(input_val, params, mod=None):
     assert all(
         var.name_hint in params.keys() for var in analysis.free_vars(input_val)
     ), "All inputs to infer must be available in params."
+    assert tvm.runtime.enabled("llvm"), "LLVM must be enabled to infer value."
     try:
         # TODO(kevinthesun): Use VM for all cases.
         # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
- Some ops(ex:view) call infer_value when converting a model into Relay IR.
- If LLVM is not enabled, it leads to segmentation fault.
- infer_value() (tvm/python/tvm/relay/frontend/common.py) uses tvm.relay.build and it assumes a LLVM target.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
@tqchen 