### PR TITLE
[BugFix][TOPI] Fix the integer overflow problem of the scatter_nd op.

### DIFF
--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -801,13 +801,11 @@ def scatter_nd(data, indices, updates, mode):
         bdim = ceil_div(fused_updates_dimension, tdim)
         ib.scope_attr(bx, "thread_extent", bdim)
 
-        with ib.for_range(0, ceil_div(fused_shape, bdim)) as i:
-            # The (i * fused_updates_dimension + bx*tdim + tx < fused_shape)
-            # would cause an int32 overflow when i is a very big number.
-            # So we use "i < (fused_shape - bx*tdim - tx) / fused_updates_dimension"
-            # here to avoid the error.
-            index = tvm.tir.Div(fused_shape - bx*tdim - tx, fused_updates_dimension)
-            with ib.if_scope(i < index):
+        # Copy data into the output. This loop writes to the same portions of
+        # memory as the following loop, so we do not need a memory sync.
+        with ib.for_range(0, ceil_div(fused_shape, fused_updates_dimension), name="i") as i:
+            index = i * fused_updates_dimension + bx * tdim + tx
+            with ib.if_scope(bx * tdim + tx < fused_updates_dimension):
                 out[index] = data[index]
 
         with ib.for_range(0, fused_indices_dimension) as i:


### PR DESCRIPTION
# Problem Statement
`scatter_nd` crashes on cuda backend, when input data shape is slightly larger than usual.

# Code to reproduce
<pre>
import tvm
import numpy as np
import tvm.relay as relay

dev = tvm.cuda()
target = tvm.target.Target("cuda")

# input data:
data_np = np.zeros((32, 128, 128, 256)).astype(np.float32)
indices_np = np.random.uniform(1,5,(32, 600, 3)).astype(np.int64)
updates_np = np.random.rand(32, 600, 256).astype(np.float32)

# Construct relay input nodes:
data = relay.var("data", shape=data_np.shape, dtype=str(data_np.dtype))
indices = relay.var("indices", shape=indices_np.shape, dtype=str(indices_np.dtype))
updates = relay.var("updates", shape=updates_np.shape, dtype=str(updates_np.dtype))

# Compute indices:
indices_dim = len(indices_np.shape)
axes = list(range(indices_dim))
indices_t = relay.transpose(indices, axes[-1:] + axes[:-1])

# Construct relay scatter_nd op:
out = relay.op.scatter_nd(data, indices_t, updates, "update")
func = relay.Function([data, indices, updates], out)

# Execute scatter_nd:
intrp = relay.create_executor("debug", device=dev, target=target)
op_res = intrp.evaluate(func)(data_np, indices_np, updates_np)
</pre>

# Error Message
![image](https://user-images.githubusercontent.com/4969797/124715093-290e5d00-df35-11eb-9c06-675a52629027.png)

# Root Cause
![WeChatWorkScreenshot_4675eb72-5bcf-4a4c-8751-1b8e5f5b7bb2](https://user-images.githubusercontent.com/4969797/124723454-a938c080-df3d-11eb-9ddf-fb1c2a4f120c.png)
We can see the problem more clearly from the cuda code generated. The TIR implementation of scatter_nd would cause a int32 overflow when "i" is large, thus the if statement is always evaluate to true, and conducts a invalid memory access. 