### PR TITLE
[TOPI] Bugfix for topi.prod

### DIFF
--- a/python/tvm/topi/scan.py
+++ b/python/tvm/topi/scan.py
@@ -23,7 +23,7 @@ import tvm
 from ..te import extern
 from ..tir import decl_buffer, generic, ir_builder
 from .math import cast
-from .utils import get_const_int, prod
+from . import utils
 
 
 def scanop(
@@ -93,11 +93,11 @@ def scanop(
 
     if axis is None:
         axis = 0
-        cumsum_axis_len = prod(data.shape)
+        cumsum_axis_len = utils.prod(data.shape)
         shape = (cumsum_axis_len,)
     else:
         if not isinstance(axis, int):
-            axis = get_const_int(axis)
+            axis = utils.get_const_int(axis)
 
         shape = data.shape
         cumsum_axis_len = shape[axis]


### PR DESCRIPTION
Hi there,

**topi.prod** is failed to invoke the operator **topi.reducton.prod** or **topi.cpp.prod**. Actually. it invoked the function **topi.utils.prod**, see the addresses as below.
```
>>> topi.reduction.prod
<function prod at 0x7f4e78d195f0>
>>> topi.cpp.prod
<tvm.runtime.packed_func.PackedFunc object at 0x7f4e78cf7410>

>>> topi.prod
<function prod at 0x7f4e78c69440>
>>> topi.utils.prod
<function prod at 0x7f4e78c69440>
```

After investigating, I found `from utils import prod` in `topi/scan.py` overrides the operator. This PR fixes this issue. :)
```
>>> import tvm
>>> from tvm import topi
>>> topi.reduction.prod
<function prod at 0x7faabab105f0>
>>> topi.cpp.prod
<tvm.runtime.packed_func.PackedFunc object at 0x7faabaaec0f0>

>>> topi.prod
<function prod at 0x7faabab105f0>
>>> topi.utils.prod
<function prod at 0x7faabab1d440>
```