### PR TITLE
[Relay] Modify create_executor to pass params

### DIFF
--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -544,6 +544,10 @@ def create_executor(kind="debug", mod=None, device=None, target="llvm", params=N
     target : :py:class:`tvm.Target`
         The corresponding context
 
+    params : dict of str to NDArray
+         Input parameters to the graph that do not change
+         during inference time.
+
     Returns
     -------
     executor : :py:class:`~tvm.relay.backend.interpreter.Executor`
@@ -555,10 +559,9 @@ def create_executor(kind="debug", mod=None, device=None, target="llvm", params=N
     else:
         device = _nd.device(str(target), 0)
 
-    # print("params " + params)
     if params is not None:
-     mod = IRModule.from_expr(bind_params_by_name(mod["main"], params))
-    
+        mod = IRModule.from_expr(bind_params_by_name(mod["main"], params))
+
     if isinstance(target, str):
         target = Target(target)
     if kind == "debug":

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -511,7 +511,7 @@ class GraphExecutor(_interpreter.Executor):
         return _graph_wrapper
 
 
-def create_executor(kind="debug", mod=None, device=None, target="llvm"):
+def create_executor(kind="debug", mod=None, device=None, target="llvm", params=None):
     """Factory function to create an executor.
 
     Example
@@ -555,6 +555,10 @@ def create_executor(kind="debug", mod=None, device=None, target="llvm"):
     else:
         device = _nd.device(str(target), 0)
 
+    # print("params " + params)
+    if params is not None:
+     mod = IRModule.from_expr(bind_params_by_name(mod["main"], params))
+    
     if isinstance(target, str):
         target = Target(target)
     if kind == "debug":


### PR DESCRIPTION
Following the forum discussion (https://discuss.tvm.apache.org/t/questions-about-tvm-executors-and-its-apis/10289/3) and the tutorials https://tvm.apache.org/docs/tutorials/frontend/from_keras.html#sphx-glr-tutorials-frontend-from-keras-py and https://tvm.apache.org/docs/tutorials/frontend/from_onnx.html#compile-the-model-with-relay there is some performance mismatch between the two apis. 

This [repo](https://github.com/mikepapadim/tvm_issue) captures the performance issue. 

It seems when one uses the relay API as in the example below, `params` are not passed properly to the TIR and all optimizations regarding constants (i.e., constant folding) are prevented. Therefore, this leads to a performance mismatch with the `relay.vm.compile(mod, target=target, params=params)` .

Example usage:
```
vm_executor = relay.create_executor("vm", mod, tvm.cpu(0), target)
vm_executor.evaluate()(input_data, **params)
```
This PR modifies the above to accept: 
```
vm_executor = relay.create_executor("vm", mod, tvm.cpu(0), target, params)
vm_executor.evaluate()(input_data)
```

With this modification ```relay.vm.compile``` and ```relay.create_executor``` generate the same bytecodes while applying the same opts.


@jroesch  @tqchen @YuchenJin @ZihengJiang 