### PR TITLE
Replace RuntimeError in _lookup_task with deferred error.

### DIFF
--- a/python/tvm/autotvm/task/task.py
+++ b/python/tvm/autotvm/task/task.py
@@ -277,9 +277,9 @@ class MissingTask(TaskTemplate):
 
     def __call__(self, *args, **kwargs):
         raise RuntimeError(
-            f"Attempting to invoke unknown task {self._taskname}."
+            f"Attempting to invoke a missing task {self._taskname}."
             "It is possible that the function is registered in a "
-            "Python module that is not imported in this run."
+            "Python module that is not imported in this run, or the log is out-of-date."
         )
 
 

--- a/python/tvm/autotvm/task/task.py
+++ b/python/tvm/autotvm/task/task.py
@@ -40,11 +40,11 @@ from .space import ConfigSpace
 def _lookup_task(name):
     task = TASK_TABLE.get(name)
     if task is None:
-        raise RuntimeError(
-            f"Could not find a registered function for the task {name}. It is "
-            "possible that the function is registered in a python file which was "
-            "not imported in this run."
-        )
+        # Unable to find the given task. This might be because we are
+        # creating a task based on a name that has not been imported.
+        # Rather than raising an exception here, we return a dummy
+        # task which cannot be invoked.
+        task = MissingTask(name)
     return task
 
 
@@ -262,6 +262,24 @@ class TaskTemplate(object):
                 queue.extend(input_tensors)
                 hash_set.update(input_tensors)
         return inputs
+
+
+class MissingTask(TaskTemplate):
+    """
+    Dummy task template for a task lookup which cannot be resolved.
+    This can occur if the task being requested from _lookup_task()
+    has not been imported in this run.
+    """
+
+    def __init__(self, taskname: str):
+        super().__init__()
+        self._taskname = taskname
+
+    def __call__(self, *args, **kwargs):
+        raise RuntimeError(
+            f"Attempting to invoke unknown task {self._taskname}."
+            "It is possible that the function is registered in a "
+            "Python module that is not imported in this run.")
 
 
 def _register_task_compute(name, func=None):

--- a/python/tvm/autotvm/task/task.py
+++ b/python/tvm/autotvm/task/task.py
@@ -279,7 +279,8 @@ class MissingTask(TaskTemplate):
         raise RuntimeError(
             f"Attempting to invoke unknown task {self._taskname}."
             "It is possible that the function is registered in a "
-            "Python module that is not imported in this run.")
+            "Python module that is not imported in this run."
+        )
 
 
 def _register_task_compute(name, func=None):


### PR DESCRIPTION
This allows unknown tasks to be created (e.g., when parsing autotvm log files) but not invoked.

This change is needed to allow one to read an autotvm log file created by a build of TVM with a different set of registered tasks than the build in which the script reading the log file is using. For example if one has a log file created by a TVM build with CUDA tasks, but reads the log file on a TVM build without CUDA enabled (e.g., running on a different OS without CUDA support).

The change should be safe in the sense that it raises a RuntimeError if the missing task is actually invoked, but the metadata associated with the task can still exist, allowing the log file to be parsed and analyzed.