### PR TITLE
[PyLint] Minor updates to pass pylint locally.

### DIFF
--- a/python/tvm/script/diagnostics.py
+++ b/python/tvm/script/diagnostics.py
@@ -17,8 +17,9 @@
 """Bridge from synr's (the library used for parsing the python AST)
    DiagnosticContext to TVM's diagnostics
 """
-import tvm
 from synr import DiagnosticContext, ast
+
+import tvm
 from tvm.ir.diagnostics import DiagnosticContext as TVMCtx
 from tvm.ir.diagnostics import get_renderer, DiagnosticLevel, Diagnostic
 

--- a/python/tvm/topi/random/kernel.py
+++ b/python/tvm/topi/random/kernel.py
@@ -15,9 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 """Pseudorandom number kernels."""
+import numpy as np
+
 import tvm
 import tvm.topi
-import numpy as np
+
 from ... import tir
 from ...tir import ir_builder
 


### PR DESCRIPTION
With either the ci_lint docker image, or the matched version of pylint==2.4.4, I get two lint errors running locally that didn't show up in the CI.  This commit fixes those two, both of which are import orderings.