### PR TITLE
Improve XGBTuner document

### DIFF
--- a/python/tvm/autotvm/tuner/xgboost_tuner.py
+++ b/python/tvm/autotvm/tuner/xgboost_tuner.py
@@ -56,7 +56,7 @@ class XGBTuner(ModelBasedTuner):
 
     num_threads: int, optional
         The number of threads.
-        
+
     optimizer: str or ModelOptimizer, optional
         If is 'sa', use a default simulated annealing optimizer.
         Otherwise it should be a ModelOptimizer object.


### PR DESCRIPTION
Just minor things about documentation, I just realize it from when I read official document and `optimizer` parameter is included in the same line as `num_threads`. Maybe, it good to fix this, so I open this PR

@merrymercy
