### PR TITLE
[Relay] Make more passes iterative on a-normal graphs.

### DIFF
--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -333,6 +333,11 @@ class Call : public Expr {
 class Let;
 /*! \brief A binding of a sub-network. */
 class LetNode : public ExprNode {
+ protected:
+  // LetNode uses own deleter to indirectly call non-recursive destructor
+  Object::FDeleter saved_deleter_;
+  static void Deleter_(Object* ptr);
+
  public:
   /*! \brief The variable we bind to */
   Var var;
@@ -364,10 +369,16 @@ class LetNode : public ExprNode {
 
   static constexpr const char* _type_key = "relay.Let";
   TVM_DECLARE_FINAL_OBJECT_INFO(LetNode, ExprNode);
+  friend class Let;
 };
 
 class Let : public Expr {
  public:
+  /*!
+   * \brief The destructor
+   */
+  ~Let();
+
   /*!
    * \brief The constructor
    * \param var The variable that is bound to.

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -276,9 +276,6 @@ inline void Dismantle(const Expr& expr) {
     }
   };
   fpush_to_stack(expr);
-  int i = 0;
-  int j = 0;
-  int k = 0;
   while (stack.size() > 0) {
     const auto& node = stack.top().first;
     if (stack.top().second) {
@@ -286,16 +283,13 @@ inline void Dismantle(const Expr& expr) {
       // +1 ref in stack/deque;
       if (node.use_count() < 3) {
         if (auto* op = const_cast<CallNode*>(node.as<CallNode>())) {
-          k++;
           op->args = Array<Expr>();
         } else if (auto* op = const_cast<LetNode*>(node.as<LetNode>())) {
-          j++;
           op->body = Expr();
         }
       }
       // eject
       stack.pop();
-      i++;
     } else {
       stack.top().second = true;
       // special handling
@@ -310,7 +304,6 @@ inline void Dismantle(const Expr& expr) {
           // Call node isn't, clear the args and assume we'll get the body
           // on other branches
           if (auto* op = const_cast<CallNode*>(node.as<CallNode>())) {
-            k++;
             op->args = Array<Expr>();
           }
         }
@@ -334,15 +327,12 @@ inline void Dismantle(const Expr& expr) {
           // Let node isn't, clear the body and assume we'll get the body
           // on other branches
           if (auto* op = const_cast<LetNode*>(node.as<LetNode>())) {
-            j++;
             op->body = Expr();
           }
         }
       }
     }
   }
-  std::cout << "Dismantler visited " << i << " nodes and dismanted " << j << " LetNodes and " << k
-            << " CallNodes" << std::endl;
 }
 /*
  * Non-recursive destructor
@@ -374,8 +364,6 @@ Let::~Let() {
   // attempt to dismantle if referenced one or zero times
   if (this->use_count() < 2) {
     Dismantle(*this);
-  } else {
-    std::cout << "failed to call Dismantle, use_count " << this->use_count() << std::endl;
   }
 }
 
@@ -385,7 +373,6 @@ Let::~Let() {
 void LetNode::Deleter_(Object* ptr) {
   auto p = reinterpret_cast<LetNode*>(ptr);
   // create Let reference in order to invoke ~Let
-  std::cout << "in LetNode Deleter" << std::endl;
   auto c = GetRef<Let>(p);
   // Call the saved deleter
   p->deleter_ = p->saved_deleter_;

--- a/tests/cpp/relay_dismantler_test.cc
+++ b/tests/cpp/relay_dismantler_test.cc
@@ -57,24 +57,24 @@ TEST(Relay, OutOfStack_add) {
 }
 
 TEST(Relay, OutOfStack_anormal_add) {
-  // auto foo = [] {
-  auto add_op = relay::Op::Get("add");
-  auto c_data = tvm::runtime::NDArray::Empty({1}, {kDLFloat, 32, 1}, {kDLCPU, 0});
-  auto c1 = relay::Constant(c_data);
-  auto y1 = relay::Var("y", Type());
-  Expr body;
-  for (int i = 0; i < 1e6; i++) {
-    if (!body.as<ExprNode>()) {
-      body = Downcast<Expr>(y1);
+  auto foo = [] {
+    auto add_op = relay::Op::Get("add");
+    auto c_data = tvm::runtime::NDArray::Empty({1}, {kDLFloat, 32, 1}, {kDLCPU, 0});
+    auto c1 = relay::Constant(c_data);
+    auto y1 = relay::Var("y", Type());
+    Expr body;
+    for (int i = 0; i < 1e6; i++) {
+      if (!body.as<ExprNode>()) {
+        body = Downcast<Expr>(y1);
+      }
+      auto y0 = relay::Var("y", Type());
+      body = relay::Let(y1, relay::Call(add_op, {y0, c1}), body);
+      y1 = y0;
     }
-    auto y0 = relay::Var("y", Type());
-    body = relay::Let(y1, relay::Call(add_op, {y0, c1}), body);
-    y1 = y0;
-  }
-  body = relay::Let(y1, relay::Call(add_op, {c1, c1}), body);
-  relay::Function func = relay::Function({}, body, relay::Type(), {});
-  //};
-  // ASSERT_EXIT((foo(), exit(0)), ::testing::ExitedWithCode(0), ".*");
+    body = relay::Let(y1, relay::Call(add_op, {c1, c1}), body);
+    relay::Function func = relay::Function({}, body, relay::Type(), {});
+  };
+  ASSERT_EXIT((foo(), exit(0)), ::testing::ExitedWithCode(0), ".*");
 }
 
 TEST(Relay, OutOfStack_cast) {

--- a/tests/cpp/relay_dismantler_test.cc
+++ b/tests/cpp/relay_dismantler_test.cc
@@ -56,6 +56,27 @@ TEST(Relay, OutOfStack_add) {
   ASSERT_EXIT((foo(), exit(0)), ::testing::ExitedWithCode(0), ".*");
 }
 
+TEST(Relay, OutOfStack_anormal_add) {
+  // auto foo = [] {
+  auto add_op = relay::Op::Get("add");
+  auto c_data = tvm::runtime::NDArray::Empty({1}, {kDLFloat, 32, 1}, {kDLCPU, 0});
+  auto c1 = relay::Constant(c_data);
+  auto y1 = relay::Var("y", Type());
+  Expr body;
+  for (int i = 0; i < 1e6; i++) {
+    if (!body.as<ExprNode>()) {
+      body = Downcast<Expr>(y1);
+    }
+    auto y0 = relay::Var("y", Type());
+    body = relay::Let(y1, relay::Call(add_op, {y0, c1}), body);
+    y1 = y0;
+  }
+  body = relay::Let(y1, relay::Call(add_op, {c1, c1}), body);
+  relay::Function func = relay::Function({}, body, relay::Type(), {});
+  //};
+  // ASSERT_EXIT((foo(), exit(0)), ::testing::ExitedWithCode(0), ".*");
+}
+
 TEST(Relay, OutOfStack_cast) {
   auto foo = [] {
     auto cast_op = relay::Op::Get("cast");


### PR DESCRIPTION
@jroesch @d-smirnov 

I've been playing around with some absurdly large models recently (50k-400k nodes), and I've hit a few stack overflows in passes and deleting said graphs. This isn't a full fix for all of the pass bugs I've hit, but it's a step.

This provides iterative traversals for a-normal graphs in the Renamer pass and the Dependency Graph pass.

It also provides methods for dismantling large a-normal graphs on deletion.


