### PR TITLE
[Bugfix] Fix broadcast type func with incomplete type

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2355,7 +2355,7 @@ bool BroadCastToRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
 
   DataType out_dtype;
   if (auto ttype = types[0].as<TensorTypeNode>()) {
-    out_dtype = types[0].as<TensorTypeNode>()->dtype;
+    out_dtype = ttype->dtype;
   } else {
     ICHECK(types[0].as<IncompleteTypeNode>())
         << "Broadcast: expect to be TensorType but get " << types[0];

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2353,7 +2353,15 @@ bool BroadCastToRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   const InitOpAttrs* param = attrs.as<InitOpAttrs>();
   ICHECK(param);
 
-  DataType out_dtype = types[0].as<TensorTypeNode>()->dtype;
+  DataType out_dtype;
+  if (auto ttype = types[0].as<TensorTypeNode>()) {
+    out_dtype = types[0].as<TensorTypeNode>()->dtype;
+  } else {
+    ICHECK(types[0].as<IncompleteTypeNode>())
+        << "Broadcast: expect to be TensorType but get " << types[0];
+    return false;
+  }
+
   std::vector<IndexExpr> oshape;
 
   const Array<Integer>& cshape_array = param->shape.value();


### PR DESCRIPTION
Reported by https://discuss.tvm.apache.org/t/incomplete-type-in-broadcasttorel-while-doing-mergecomposite/10439, the broadcast type function cannot deal with IncompleteType. This PR fixes this issue using the similar approach used by other type functions.

cc @electriclilies @mbrookhart 