### PR TITLE
[FIX] Fix wrong log of tir pass VerifyMemory

### DIFF
--- a/src/tir/analysis/verify_memory.cc
+++ b/src/tir/analysis/verify_memory.cc
@@ -170,7 +170,7 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
 /// Interface of VerifyMemory pass
 std::vector<String> VerifyMemory_(const PrimFunc& func) {
   auto target = func->GetAttr<Target>(tvm::attr::kTarget);
-  ICHECK(target.defined()) << "LowerWarpMemory: Require the target attribute";
+  ICHECK(target.defined()) << "VerifyMemory: Require the target attribute";
 
   if (func->GetAttr<Integer>(tvm::attr::kCallingConv, Integer(CallingConv::kDefault)) ==
       CallingConv::kDefault) {


### PR DESCRIPTION
Tir pass `VerifyMemory` gives a log information `LowerWarpMemory: Require the target attribute`, while `LowerWarpMemory` is actual another tir pass.

@YuchenJin @junrushao1994  @tqchen 