### PR TITLE
[Frontend, pytorch] Vc/pytorch lstm

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2539,23 +2539,21 @@ class PyTorchOpConverter:
                 for i in range(0, len(_weights), 2 * weights_num):
                     fw_weights = []
                     rev_weights = []
-                    for j in range(weights_num + 2):
-                        if j in (2, 3):
-                            fw_weights.append(None)
-                            rev_weights.append(None)
-                        else:
-                            fw_weights.append(_weights[i + j])
-                            rev_weights.append(_weights[i + j + weights_num])
+                    k = i + weights_num
+                    if has_proj:
+                        fw_weights = [_weights[i], _weights[i + 1], None, None, _weights[i + 2]]
+                        rev_weights = [_weights[k], _weights[k + 1], None, None, _weights[k + 2]]
+                    else:
+                        fw_weights = [_weights[i], _weights[i + 1], None, None]
+                        rev_weights = [_weights[k], _weights[k + 1], None, None]
                     weights.append((fw_weights, rev_weights))
             else:
                 assert len(_weights) % weights_num == 0, "got an incorrect number of LSTM weights"
                 for i in range(0, len(_weights), weights_num):
-                    fw_weights = []
-                    for j in range(weights_num + 2):
-                        if j in (2, 3):
-                            fw_weights.append(None)
-                        else:
-                            fw_weights.append(_weights[i + j])
+                    if has_proj:
+                        fw_weights = [_weights[i], _weights[i + 1], None, None, _weights[i + 2]]
+                    else:
+                        fw_weights = [_weights[i], _weights[i + 1], None, None]
                     weights.append(fw_weights)
         assert (
             len(weights) == num_layers
@@ -2567,7 +2565,7 @@ class PyTorchOpConverter:
         X_dtype = input_types[0]
         X_shape = _infer_shape(X)  # (seq_num, batch, feature_size)
 
-        hidden_size = _infer_shape(_weights[2])[-1] / 4
+        hidden_size = _infer_shape(_weights[0])[0] / 4
         batch_size = X_shape[1]
 
         # Initialize hidden states if not provided.

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2347,9 +2347,9 @@ class PyTorchOpConverter:
             gates = _op.nn.dense(x_t, weights[0]) + _op.nn.dense(H_t, weights[1])    # (batch, 4 * hidden_size)
             # Add biases
             if weights[2] is not None:
-                gates += weights[2] # TODO: (batch, 4 * hidden_size) + (4 * hidden_size)
+                gates += weights[2]
             if weights[3] is not None:
-                gates += weights[3] # TODO: (batch, 4 * hidden_size) + (4 * hidden_size)
+                gates += weights[3]
             i, f, c, o = _op.split(gates, 4, axis=-1)   # (batch, hidden_size)
 
             i = f_act(i)
@@ -2365,16 +2365,50 @@ class PyTorchOpConverter:
             outputs_list.append(H)  # [seq_num, (batch, hidden_size)]
         hidden_outputs = (H_t, C_t)
 
-        return (_op.stack(outputs_list, 0), hidden_outputs)
+        return (outputs_list, hidden_outputs)
 
-    def bidir_lstm_cell(self, input, hidden, weights):
-        raise NotImplementedError("Bidirectional LSTMs have not been supported yet!")
+    def bidir_lstm_cell(self, input_seq, hidden_pair, weights_pair):
+        fw_outputs = self.lstm_cell(input_seq, hidden_pair[0], weights_pair[0])
+
+        input_seq.reverse() # [seq_num, (batch, hidden_size)]
+        rev_outputs = self.lstm_cell(input_seq, hidden_pair[1], weights_pair[1])
+
+        return _op.concatenate([_op.stack(fw_outputs[0], 0), _op.stack(rev_outputs[0], 1)], -1), (fw_outputs[1], rev_outputs[1])
+
+    def lstm_layers(self, input, hiddens, weights, bidirectional, dtype, dropout_p = 0.0):
+        hidden_layers_num = len(hiddens)
+        assert len(weights) == hidden_layers_num
+
+        # split input sequence to samples set
+        input = self.unbind((input, 0), dtype) # [seq_num, (batch, feature_size)]
+        output_hiddens = []
+        for k in range(hidden_layers_num):
+            hiddens_input = hiddens[k]
+            weights_input = weights[k]
+
+            outputs = self.bidir_lstm_cell(input, hiddens_input, weights_input) if bidirectional else self.lstm_cell(input, hiddens_input, weights_input)
+
+            output_hiddens.append(outputs[1])
+            input = outputs[0]  # [seq_num, (batch, feature_size)] or [seq_num, (batch, 2*feature_size)] for bidirectional
+
+            if dropout_p != 0 and k < hidden_layers_num - 1: # TODO (vvchernov): in pytorch implementation train is also checked
+                # input = _op.dropout(input, dropout_p)
+                raise NotImplementedError("Dropout for LSTM has not been supported yet!")
+        final_hiddens = []
+        if bidirectional:
+            for i in range(hidden_layers_num):
+                final_hiddens.append(output_hiddens[i][0])
+                final_hiddens.append(output_hiddens[i][1])
+        else:
+            final_hiddens = output_hiddens
+
+        return _op.stack(input, 0), final_hiddens
 
     def lstm(self, inputs, input_types):
         # Description of LSTM in pytorch: https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html
         # https://github.com/pytorch/pytorch/blob/70c8daf43946b53af6493d058899ef952d27d339/aten/src/ATen/native/RNN.cpp#L1396 and dependencies were used
-        # TODO: support dropout
-        # TODO: support bidirectional LSTM
+        # TODO (vvchernov): support dropout
+        # TODO (vvchernov): test bidirectional LSTM regime
         assert len(inputs) == 9, 'Input of size 9 is expected'
         # Unpack inputs, note that if optional and not provided then value will be None.
         _X = inputs[0]
@@ -2412,25 +2446,38 @@ class PyTorchOpConverter:
 
         weights = []
         if has_biases:
-            assert len(_weights) % 4 == 0, 'got an incorrect number of LSTM weights'
-            for i in range(0, len(_weights), 4):
-                weights.append((_weights[i], _weights[i+1], _weights[i+2], _weights[i+3]))
+            if bidirectional:
+                assert len(_weights) % 8 == 0, 'got an incorrect number of LSTM weights'
+                for i in range(0, len(_weights), 8):
+                    weights.append(((_weights[i], _weights[i+1], _weights[i+2], _weights[i+3]),
+                                    (_weights[i+4], _weights[i+5], _weights[i+6], _weights[i+7])))
+            else:
+                assert len(_weights) % 4 == 0, 'got an incorrect number of LSTM weights'
+                for i in range(0, len(_weights), 4):
+                    weights.append((_weights[i], _weights[i+1], _weights[i+2], _weights[i+3]))
         else:
-            assert len(_weights) % 2 == 0, 'got an incorrect number of LSTM weights'
-            for i in range(0, len(_weights), 2):
-                weights.append((_weights[i], _weights[i+1], None, None))
+            if bidirectional:
+                assert len(_weights) % 4 == 0, 'got an incorrect number of LSTM weights'
+                for i in range(0, len(_weights), 4):
+                    weights.append(((_weights[i], _weights[i+1], None, None),
+                                    (_weights[i+2], _weights[i+3], None, None)))
+            else:
+                assert len(_weights) % 2 == 0, 'got an incorrect number of LSTM weights'
+                for i in range(0, len(_weights), 2):
+                    weights.append((_weights[i], _weights[i+1], None, None))
+        assert len(weights) == num_layers, 'For stacked LSTM number of weights tuples should be the same as number of layers!'
 
         X = _op.transpose(_X, (1, 0, 2)) if batch_first else _X
-        X_dtype = input_types[0] # _infer_type(X).checked_type.dtype # TODO: which data type should be used? from input or weights (use weights[0][0])?
+        X_dtype = input_types[0] # _infer_type(X).checked_type.dtype # TODO (vvchernov): which data type should be used? from input or weights (use weights[0][0])?
         X_shape = _infer_shape(X)   # (seq_num, batch, feature_size)
 
         hidden_size = _infer_shape(weights[0][1])[-1]
         batch_size = X_shape[1]
 
-        # Initialize state if not provided.
-        hidden_layers_num = num_directions * num_layers
+        # Initialize hidden states if not provided.
         layers_h = []
         layers_c = []
+        hidden_layers_num = num_directions * num_layers
         if h_0 is None:
             h_0 = _op.zeros((batch_size, hidden_size), X_dtype)
             for i in range(hidden_layers_num):
@@ -2445,37 +2492,25 @@ class PyTorchOpConverter:
             layers_c = self.unbind((c_0, 0), X_dtype)
 
         hiddens = []
-        for i in range(hidden_layers_num):
-            hiddens.append((layers_h[i], layers_c[i]))
+        for i in range(num_layers):
+            if bidirectional:
+                hiddens.append(((layers_h[2*i], layers_c[2*i]), (layers_h[2*i+1], layers_c[2*i+1])))
+            else:
+                hiddens.append((layers_h[i], layers_c[i]))
 
-        input = X # (seq_num, batch, feature_size)
-        final_hiddens = []
-        assert len(weights) == hidden_layers_num, 'For stacked LSTM number of weights tuples should be the same as number of layers!'
-        for k in range(hidden_layers_num):
-            hiddens_input = hiddens[k]
-            weights_input = weights[k]
-            # split input sequence to samples set
-            input = self.unbind((input, 0), X_dtype) # [seq_num, (batch, feature_size)]
+        outputs = self.lstm_layers(X, hiddens, weights, bidirectional, dtype=X_dtype, dropout_p=dropout_p)
 
-            outputs = self.bidir_lstm_cell(input, hiddens_input, weights_input) if bidirectional else self.lstm_cell(input, hiddens_input, weights_input)
-
-            final_hiddens.append(outputs[1])
-            input = outputs[0]  # (seq_num, batch, hidden_size)
-
-            if dropout_p != 0 and k < hidden_layers_num - 1: # TODO: in pytorch implementation train is also checked
-                raise NotImplementedError("Dropout for LSTM has not been supported yet!")
-        output = input  # (seq_num, batch, hidden_size)
+        output = outputs[0]  # (seq_num, batch, hidden_size) or (seq_num, batch, 2*feature_size) for bidirectional
 
         hy = []
         cy = []
-        for hidden in final_hiddens:
+        for hidden in outputs[1]:
             hy.append(hidden[0])
             cy.append(hidden[1])
 
         if batch_first:
             output = _op.transpose(output, (1, 0, 2))
 
-        #return _expr.TupleWrapper(_expr.Tuple((output, _op.stack(hy, 0), _op.stack(cy, 0))), 3)
         return (output, _op.stack(hy, 0), _op.stack(cy, 0))
 
     # Operator mappings

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2340,17 +2340,18 @@ class PyTorchOpConverter:
         h_act = _op.tanh
 
         # Input hiddens
-        H_t = hidden[0] # (batch, hidden_size)
-        C_t = hidden[1] # (batch, hidden_size)
+        H_t = hidden[0]  # (batch, hidden_size)
+        C_t = hidden[1]  # (batch, hidden_size)
         for x_t in input_seqs:
             # x_t shape = (batch, feature size)
-            gates = _op.nn.dense(x_t, weights[0]) + _op.nn.dense(H_t, weights[1])    # (batch, 4 * hidden_size)
+            # gates shape = (batch, 4 * hidden_size)
+            gates = _op.nn.dense(x_t, weights[0]) + _op.nn.dense(H_t, weights[1])
             # Add biases
             if weights[2] is not None:
                 gates += weights[2]
             if weights[3] is not None:
                 gates += weights[3]
-            i, f, c, o = _op.split(gates, 4, axis=-1)   # (batch, hidden_size)
+            i, f, c, o = _op.split(gates, 4, axis=-1)  # (batch, hidden_size)
 
             i = f_act(i)
             f = f_act(f)
@@ -2374,32 +2375,40 @@ class PyTorchOpConverter:
         _op.reverse_sequence
         seq_len = len(input_seq)
         for i in range(seq_len):
-            rev_input_seq.append(input_seq[seq_len - 1 - i])    # [seq_num, (batch, hidden_size)]
+            rev_input_seq.append(input_seq[seq_len - 1 - i])  # [seq_num, (batch, hidden_size)]
         rev_outputs = self.lstm_cell(rev_input_seq, hidden_pair[1], weights_pair[1])
 
         final_outputs = []  # [seq_num, (batch, 2 * hidden_size)]
         for j in range(seq_len):
-            final_outputs.append(_op.concatenate([ fw_outputs[0][j], rev_outputs[0][seq_len - 1 - j] ], -1))
+            final_outputs.append(
+                _op.concatenate([fw_outputs[0][j], rev_outputs[0][seq_len - 1 - j]], -1)
+            )
 
         return final_outputs, (fw_outputs[1], rev_outputs[1])
 
-    def lstm_layers(self, input, hiddens, weights, bidirectional, dtype, dropout_p = 0.0):
+    def lstm_layers(self, input, hiddens, weights, bidirectional, dtype, dropout_p=0.0):
         hidden_layers_num = len(hiddens)
         assert len(weights) == hidden_layers_num
 
         # split input sequence to samples set
-        input_seqs = self.unbind((input, 0), dtype) # [seq_num, (batch, feature_size)]
+        input_seqs = self.unbind((input, 0), dtype)  # [seq_num, (batch, feature_size)]
         output_hiddens = []
         for k in range(hidden_layers_num):
             hiddens_input = hiddens[k]
             weights_input = weights[k]
 
-            outputs = self.bidir_lstm_cell(input_seqs, hiddens_input, weights_input) if bidirectional else self.lstm_cell(input_seqs, hiddens_input, weights_input)
+            outputs = (
+                self.bidir_lstm_cell(input_seqs, hiddens_input, weights_input)
+                if bidirectional
+                else self.lstm_cell(input_seqs, hiddens_input, weights_input)
+            )
 
             output_hiddens.append(outputs[1])
-            input_seqs = outputs[0]  # [seq_num, (batch, feature_size)] or [seq_num, (batch, 2*feature_size)] for bidirectional
+            # input_seqs shape = [seq_num, (batch, feature_size)] or [seq_num, (batch, 2*feature_size)] for bidirectional
+            input_seqs = outputs[0]
 
-            if dropout_p != 0 and k < hidden_layers_num - 1: # TODO (vvchernov): in pytorch implementation train is also checked
+            # TODO (vvchernov): in pytorch implementation train is also checked (see https://github.com/pytorch/pytorch/blob/70c8daf43946b53af6493d058899ef952d27d339/aten/src/ATen/native/RNN.cpp#L1054)
+            if dropout_p != 0 and k < hidden_layers_num - 1:
                 # for input in input_seqs:
                 #     input = _op.dropout(input, dropout_p)
                 raise NotImplementedError("Dropout for LSTM has not been supported yet!")
@@ -2417,14 +2426,13 @@ class PyTorchOpConverter:
         # Description of LSTM in pytorch: https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html
         # https://github.com/pytorch/pytorch/blob/70c8daf43946b53af6493d058899ef952d27d339/aten/src/ATen/native/RNN.cpp#L1396 and dependencies were used
         # TODO (vvchernov): support dropout
-        # TODO (vvchernov): test bidirectional LSTM regime
-        assert len(inputs) == 9, 'Input of size 9 is expected'
+        assert len(inputs) == 9, "Input of size 9 is expected"
         # Unpack inputs, note that if optional and not provided then value will be None.
         _X = inputs[0]
         # _X shape (seq_num, batch, feature_size) or (batch, seq_num, feature_size)
 
         hidden_states = inputs[1]
-        assert len(hidden_states) == 2, 'lstm expects two hidden states'
+        assert len(hidden_states) == 2, "lstm expects two hidden states"
         h_0 = hidden_states[0]
         c_0 = hidden_states[1]
         # H0 C0 shape (hidden_layers_num, batch, hidden_size)
@@ -2443,7 +2451,7 @@ class PyTorchOpConverter:
         # Scalar inputs
         has_biases = inputs[3]
         num_layers = inputs[4]
-        dropout_p = inputs[5]   # dropout probability, if 0.0 it means there is no dropout
+        dropout_p = inputs[5]  # dropout probability, if 0.0 it means there is no dropout
         # train = inputs[6]
         bidirectional = inputs[7]
         batch_first = inputs[8]
@@ -2455,29 +2463,40 @@ class PyTorchOpConverter:
         weights = []
         if has_biases:
             if bidirectional:
-                assert len(_weights) % 8 == 0, 'got an incorrect number of LSTM weights'
+                assert len(_weights) % 8 == 0, "got an incorrect number of LSTM weights"
                 for i in range(0, len(_weights), 8):
-                    weights.append(((_weights[i], _weights[i+1], _weights[i+2], _weights[i+3]),
-                                    (_weights[i+4], _weights[i+5], _weights[i+6], _weights[i+7])))
+                    weights.append(
+                        (
+                            (_weights[i], _weights[i + 1], _weights[i + 2], _weights[i + 3]),
+                            (_weights[i + 4], _weights[i + 5], _weights[i + 6], _weights[i + 7]),
+                        )
+                    )
             else:
-                assert len(_weights) % 4 == 0, 'got an incorrect number of LSTM weights'
+                assert len(_weights) % 4 == 0, "got an incorrect number of LSTM weights"
                 for i in range(0, len(_weights), 4):
-                    weights.append((_weights[i], _weights[i+1], _weights[i+2], _weights[i+3]))
+                    weights.append((_weights[i], _weights[i + 1], _weights[i + 2], _weights[i + 3]))
         else:
             if bidirectional:
-                assert len(_weights) % 4 == 0, 'got an incorrect number of LSTM weights'
+                assert len(_weights) % 4 == 0, "got an incorrect number of LSTM weights"
                 for i in range(0, len(_weights), 4):
-                    weights.append(((_weights[i], _weights[i+1], None, None),
-                                    (_weights[i+2], _weights[i+3], None, None)))
+                    weights.append(
+                        (
+                            (_weights[i], _weights[i + 1], None, None),
+                            (_weights[i + 2], _weights[i + 3], None, None),
+                        )
+                    )
             else:
-                assert len(_weights) % 2 == 0, 'got an incorrect number of LSTM weights'
+                assert len(_weights) % 2 == 0, "got an incorrect number of LSTM weights"
                 for i in range(0, len(_weights), 2):
-                    weights.append((_weights[i], _weights[i+1], None, None))
-        assert len(weights) == num_layers, 'For stacked LSTM number of weights tuples should be the same as number of layers!'
+                    weights.append((_weights[i], _weights[i + 1], None, None))
+        assert (
+            len(weights) == num_layers
+        ), "For stacked LSTM number of weights tuples should be the same as number of layers!"
 
         X = _op.transpose(_X, (1, 0, 2)) if batch_first else _X
-        X_dtype = input_types[0] # _infer_type(X).checked_type.dtype # TODO (vvchernov): which data type should be used? from input or weights (use weights[0][0])?
-        X_shape = _infer_shape(X)   # (seq_num, batch, feature_size)
+        # TODO (vvchernov): Which data type should be used? from input or weights (use _weights[0])? Also _infer_type(X).checked_type.dtype can be used
+        X_dtype = input_types[0]
+        X_shape = _infer_shape(X)  # (seq_num, batch, feature_size)
 
         hidden_size = _infer_shape(_weights[1])[-1]
         batch_size = X_shape[1]
@@ -2502,13 +2521,18 @@ class PyTorchOpConverter:
         hiddens = []
         for i in range(num_layers):
             if bidirectional:
-                hiddens.append(((layers_h[2*i], layers_c[2*i]), (layers_h[2*i+1], layers_c[2*i+1])))
+                hiddens.append(
+                    ((layers_h[2 * i], layers_c[2 * i]), (layers_h[2 * i + 1], layers_c[2 * i + 1]))
+                )
             else:
                 hiddens.append((layers_h[i], layers_c[i]))
 
-        outputs = self.lstm_layers(X, hiddens, weights, bidirectional, dtype=X_dtype, dropout_p=dropout_p)
+        outputs = self.lstm_layers(
+            X, hiddens, weights, bidirectional, dtype=X_dtype, dropout_p=dropout_p
+        )
 
-        output = outputs[0]  # (seq_num, batch, hidden_size) or (seq_num, batch, 2*feature_size) for bidirectional
+        # output shape = (seq_num, batch, hidden_size) or (seq_num, batch, 2*feature_size) for bidirectional
+        output = outputs[0]
 
         hy = []
         cy = []

--- a/tests/python/frontend/pytorch/test_lstms.py
+++ b/tests/python/frontend/pytorch/test_lstms.py
@@ -71,7 +71,8 @@ class LSTM_Model(nn.Module):
                                 proj_size=proj_size,
                                 batch_first=batch_first).to(device)
         else:
-            print('WARNING: projection is not supported for torch version less than 1.8.0!')
+            if proj_size > 0:
+                print('WARNING: projection is not supported for torch version less than 1.8.0!')
             self.lstm = nn.LSTM(input_size=model_feature_size,
                                 hidden_size=model_hidden_size,
                                 num_layers=layer_num,

--- a/tests/python/frontend/pytorch/test_lstms.py
+++ b/tests/python/frontend/pytorch/test_lstms.py
@@ -1,0 +1,265 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# 'License'); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import numpy as np
+import torch
+import onnx
+import argparse
+import sys
+import shutil
+
+from tvm import relay
+from tvm.contrib import graph_executor
+
+from pathlib import Path
+from torch import nn
+
+## Model parameters
+model_feature_size = 5
+model_hidden_size = 10
+model_num_layers = 2
+seqs_length = 15
+projection_size = 5
+batch_size = 3
+
+
+def check_torch_version_for_proj_in_lstm():
+    '''
+    proj_size parameter is supported in torch.nn.LSTM layer started from 1.8.0 torch version
+    '''
+    me = False
+
+    version = torch.__version__
+    major, minor, micro = version.split('.')
+    
+    if int(major) > 1:
+        me =True
+    elif int(major) == 1:
+        if int(minor) >= 8:
+            me = True
+
+    return me
+
+class LSTM_Model(nn.Module):
+    def __init__(self, device, batch_first = False, layer_num = 1, bidirectional = False, proj_size = 0, rnd_weights_init=False):
+        super().__init__()
+
+        self.device = device
+        self.batch_first = batch_first
+
+        # Network defition
+        if check_torch_version_for_proj_in_lstm():
+            self.lstm = nn.LSTM(input_size=model_feature_size,
+                                hidden_size=model_hidden_size,
+                                num_layers=layer_num,
+                                bidirectional = bidirectional,
+                                proj_size=proj_size,
+                                batch_first=batch_first).to(device)
+        else:
+            print('WARNING: projection is not supported for torch version less than 1.8.0!')
+            self.lstm = nn.LSTM(input_size=model_feature_size,
+                                hidden_size=model_hidden_size,
+                                num_layers=layer_num,
+                                bidirectional = bidirectional,
+                                batch_first=batch_first).to(device)
+
+        if rnd_weights_init:
+            self.gen_rnd_weights()
+
+    def forward(self, input, hidden_init=None):
+        '''
+        Computes the embeddings of a batch of utterance spectrograms.
+
+        :param input: batch of data as a tensor of shape (batch_size, n_frames, n_channels) 
+        :param hidden_init: initial hidden state of the LSTM as a tensor of shape (num_layers, 
+        batch_size, hidden_size). Will default to a tensor of zeros if None.
+        :return: the embeddings as a tensor of shape (batch_size, embedding_size)
+        '''
+        # Pass the input through the LSTM layers and retrieve all outputs, the final hidden state
+        # and the final cell state.
+        out, (hidden, cell) = self.lstm(input, hidden_init)
+
+        return out
+
+    def gen_rnd_weights(self):
+        '''
+        Generate random weigths for the model
+        For first weights group:
+            Wi (4*model_hidden_size, model_feature_size)
+            Wh (4*model_hidden_size, model_hidden_size)
+            Bi (4*model_hidden_size)
+            Bh (4*model_hidden_size)
+        For first bidirectional weights group:
+            Wi (4*model_hidden_size, model_feature_size)
+            Wh (4*model_hidden_size, model_hidden_size)
+            Bi (4*model_hidden_size)
+            Bh (4*model_hidden_size)
+        For other weights group:
+            Wi (4*model_hidden_size, model_hidden_size)
+            Wh (4*model_hidden_size, model_hidden_size)
+            Bi (4*model_hidden_size)
+            Bh (4*model_hidden_size)
+        '''
+        for weight_group in self.lstm.all_weights:
+            for weight in weight_group:
+                weight.data = torch.rand(weight.shape)
+
+    def get_dummy_input(self):
+        shape = [seqs_length, batch_size, model_feature_size]
+        if self.batch_first:
+            shape = [batch_size, seqs_length, model_feature_size]
+        res = torch.rand(shape)
+
+        return res, shape
+
+def compare(input, gold_data, epsilon = 1e-6):
+    remain = np.abs(gold_data - input)
+    err = np.max(remain)
+    if err < epsilon:
+        print('SUCCESS: RESULTS ARE THE SAME WITH MAX ERROR {} AND EPSILON {}'.format(err, epsilon))
+    else:
+        print('WARNING: RESULTS ARE NOT THE SAME WITH ERROR {}'.format(err))
+
+
+if __name__ == '__main__':
+    class MyFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+        pass
+
+    parser = argparse.ArgumentParser(
+        description='It constructs neural network which conists of LSTM layer only. '
+        'But the layer can be different types and adjusted by special parameters (see https://pytorch.org/docs/1.8.0/generated/torch.nn.LSTM.html?highlight=lstm#torch.nn.LSTM). '
+        'There are several types: unidirectional, bidirectional, projection, stacked, stacked bidirectional, stacked projection bidirectional',
+        formatter_class=MyFormatter
+    )
+    parser.add_argument('-t', '--lstm_type', type=str, default='uni', help=\
+        'Type of lstm layer for test. There are several options: uni (unidirectional), b (bidirectional), '
+        'p (projection), s (stacked), sb (stacked bidirectional), spb (stacked projection bidirectional)')
+    parser.add_argument('-f', '--format', type=str, default='ts', help=\
+        'Format of the model. There are two options: \'ts\'(TorchScript) and \'onnx\'(ONNX). The first one is used by default')
+    parser.add_argument('-l', '--layer_num', type=int, default=model_num_layers, help=\
+        'Number of LSTM layers. It is useded for stacked LSTM')
+    parser.add_argument('-p', '--projection_size', type=int, default=projection_size, help=\
+        'Projection size is used in LSTM with projection')
+    parser.add_argument('-b', '--batch_first', action='store_true', default=False, help=\
+        'Batch first parameter used for LSTM layer initialization')
+    parser.add_argument('-w', '--rnd_weights', action='store_true', default=False, help=\
+        'Generate random weights and biases for the model. NOTE: By default All the weights and biases are initialized from '
+        '\mathcal{U}(-\sqrt{k}, \sqrt{k}), where k = \frac{1}{\text{hidden\_size}}')
+    parser.add_argument('-o', '--out_dir', type=Path, default=argparse.SUPPRESS, help=\
+        'Path to directory for saving of intermediate results. NOTE: At the end the directory is removed with all dependencies inside')
+
+    args = parser.parse_args()
+    if not hasattr(args, 'out_dir'):
+        args.out_dir = Path.cwd().joinpath('output')
+        args.out_dir.mkdir(exist_ok=True, parents=True)
+
+    device = torch.device('cpu')
+    hidden_layers_num = 1
+    model = None
+    if args.lstm_type == 'uni':
+        model = LSTM_Model(device, batch_first = args.batch_first, rnd_weights_init=args.rnd_weights)
+    elif args.lstm_type == 'b':
+        model = LSTM_Model(device, batch_first = args.batch_first, bidirectional=True, rnd_weights_init=args.rnd_weights)
+        hidden_layers_num = 2
+    elif args.lstm_type == 'p':
+        model = LSTM_Model(device, batch_first = args.batch_first, proj_size=args.projection_size, rnd_weights_init=args.rnd_weights)
+    elif args.lstm_type == 's':
+        model = LSTM_Model(device, batch_first = args.batch_first, layer_num=args.layer_num, rnd_weights_init=args.rnd_weights)
+        hidden_layers_num = args.layer_num
+    elif args.lstm_type == 'sb':
+        model = LSTM_Model(device, batch_first = args.batch_first, bidirectional=True, layer_num=args.layer_num, rnd_weights_init=args.rnd_weights)
+        hidden_layers_num = 2 * args.layer_num
+    elif args.lstm_type == 'spb':
+        model = LSTM_Model(device, batch_first = args.batch_first, bidirectional=True, layer_num=args.layer_num, proj_size=args.projection_size, rnd_weights_init=args.rnd_weights)
+        hidden_layers_num = 2 * args.layer_num
+    else:
+        print('LSTM type {} is not supported here!'.format(args.lstm_type))
+        sys.exit()
+
+    model.eval()
+
+    # Get golden output from original model
+    input_hidden_shape = (hidden_layers_num, batch_size, model_hidden_size)
+    dummy_input, input_shape = model.get_dummy_input()
+    golden_output_batch = model.forward(dummy_input.to(device)).detach().cpu().numpy()
+
+    dtype = 'float32'
+    h_zeros = np.zeros(input_hidden_shape, dtype=dtype)
+    c_zeros = np.zeros(input_hidden_shape, dtype=dtype)
+
+    tvm_output = None
+    if args.format == 'ts':
+        #out_fpath = args.out_dir.joinpath('model_{}.pt'.format(args.lstm_type))
+        # Use torch.jit.trace to generate a torch.jit.ScriptModule via tracing.
+        traced_script_module = torch.jit.trace(model, dummy_input).eval()
+
+        # Save the TorchScript model
+        #traced_script_module.save(str(out_fpath))
+
+        #Import model to Relay
+        shape_list = [('input', input_shape)] #, ('h0', internal_tensor_shape), ('c0', internal_tensor_shape)]
+        mod, params = relay.frontend.from_pytorch(traced_script_module, shape_list)
+
+        # Model compilation by tvm
+        target = tvm.target.Target('llvm', host='llvm')
+        dev = tvm.cpu(0)
+        with tvm.transform.PassContext(opt_level=3):
+            lib = relay.build(mod, target=target, params=params)
+    elif args.format == 'onnx':
+        onnx_fpath = args.out_dir.joinpath('model_{}.onnx'.format(args.lstm_type))
+
+        with torch.no_grad():
+            h0 = torch.rand(input_hidden_shape)
+            c0 = torch.rand(input_hidden_shape)
+            input_names = ['input', 'h0', 'c0']
+
+            # default export (without dynamic input)
+            torch.onnx.export(model, (dummy_input, (h0, c0)), onnx_fpath, input_names = input_names)
+        
+        onnx_model = onnx.load(onnx_fpath)
+
+        #Import model to Relay
+        shape_dict = {'input': input_shape,
+                      'h0': input_hidden_shape,
+                      'c0': input_hidden_shape}
+        mod, params = relay.frontend.from_onnx(onnx_model, shape_dict)
+
+        # Model compilation by tvm
+        target = 'llvm'
+        dev = tvm.cpu(0)
+        with tvm.transform.PassContext(opt_level=1):
+            lib = relay.build(mod, target=target, params=params)
+    else:
+        print("ERROR: {} format is unsupported".format(args.format))
+
+    # Inference of the model with given input data
+    m = graph_executor.GraphModule(lib['default'](dev))
+
+    # Set inputs
+    m.set_input(input = tvm.nd.array(dummy_input.numpy().astype(dtype)),
+                h0 = tvm.nd.array(h_zeros),
+                c0 = tvm.nd.array(c_zeros))
+    # Execute
+    m.run()
+    # Get outputs (converted to numpy array)
+    tvm_output = m.get_output(0).numpy()
+
+    compare(tvm_output, golden_output_batch)
+
+    # Remove output directory with tmp files
+    shutil.rmtree(args.out_dir)

--- a/tests/python/frontend/pytorch/test_lstms.py
+++ b/tests/python/frontend/pytorch/test_lstms.py
@@ -3,14 +3,14 @@
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
-# 'License'); you may not use this file except in compliance
+# "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
-# 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
@@ -39,24 +39,33 @@ batch_size = 3
 
 
 def check_torch_version_for_proj_in_lstm():
-    '''
+    """
     proj_size parameter is supported in torch.nn.LSTM layer started from 1.8.0 torch version
-    '''
+    """
     me = False
 
     version = torch.__version__
-    major, minor, micro = version.split('.')
-    
+    major, minor, micro = version.split(".")
+
     if int(major) > 1:
-        me =True
+        me = True
     elif int(major) == 1:
         if int(minor) >= 8:
             me = True
 
     return me
 
+
 class LSTM_Model(nn.Module):
-    def __init__(self, device, batch_first = False, layer_num = 1, bidirectional = False, proj_size = 0, rnd_weights_init=False):
+    def __init__(
+        self,
+        device,
+        batch_first=False,
+        layer_num=1,
+        bidirectional=False,
+        proj_size=0,
+        rnd_weights_init=False,
+    ):
         super().__init__()
 
         self.device = device
@@ -64,33 +73,36 @@ class LSTM_Model(nn.Module):
 
         # Network defition
         if check_torch_version_for_proj_in_lstm():
-            self.lstm = nn.LSTM(input_size=model_feature_size,
-                                hidden_size=model_hidden_size,
-                                num_layers=layer_num,
-                                bidirectional = bidirectional,
-                                proj_size=proj_size,
-                                batch_first=batch_first).to(device)
+            self.lstm = nn.LSTM(
+                input_size=model_feature_size,
+                hidden_size=model_hidden_size,
+                num_layers=layer_num,
+                bidirectional=bidirectional,
+                proj_size=proj_size,
+                batch_first=batch_first,
+            ).to(device)
         else:
             if proj_size > 0:
-                print('WARNING: projection is not supported for torch version less than 1.8.0!')
-            self.lstm = nn.LSTM(input_size=model_feature_size,
-                                hidden_size=model_hidden_size,
-                                num_layers=layer_num,
-                                bidirectional = bidirectional,
-                                batch_first=batch_first).to(device)
+                print("WARNING: projection is not supported for torch version less than 1.8.0!")
+            self.lstm = nn.LSTM(
+                input_size=model_feature_size,
+                hidden_size=model_hidden_size,
+                num_layers=layer_num,
+                bidirectional=bidirectional,
+                batch_first=batch_first,
+            ).to(device)
 
         if rnd_weights_init:
             self.gen_rnd_weights()
 
     def forward(self, input, hidden_init=None):
-        '''
-        Computes the embeddings of a batch of utterance spectrograms.
+        """
+        Computes the output tensor after input inference along LSTM layer.
 
-        :param input: batch of data as a tensor of shape (batch_size, n_frames, n_channels) 
-        :param hidden_init: initial hidden state of the LSTM as a tensor of shape (num_layers, 
-        batch_size, hidden_size). Will default to a tensor of zeros if None.
-        :return: the embeddings as a tensor of shape (batch_size, embedding_size)
-        '''
+        :param input: batch of data as a tensor of shape (seqs_length, batch_size, model_feature_size) or (batch_size, seqs_length, model_feature_size) if self.batch_first = True
+        :param hidden_init: initial hidden state of the LSTM as a tensor of shape (num_layers, batch_size, hidden_size). Will default to a tensor of zeros if None.
+        :return: the output tensor of shape (batch_size, model_hidden_size)
+        """
         # Pass the input through the LSTM layers and retrieve all outputs, the final hidden state
         # and the final cell state.
         out, (hidden, cell) = self.lstm(input, hidden_init)
@@ -98,7 +110,7 @@ class LSTM_Model(nn.Module):
         return out
 
     def gen_rnd_weights(self):
-        '''
+        """
         Generate random weigths for the model
         For first weights group:
             Wi (4*model_hidden_size, model_feature_size)
@@ -115,7 +127,7 @@ class LSTM_Model(nn.Module):
             Wh (4*model_hidden_size, model_hidden_size)
             Bi (4*model_hidden_size)
             Bh (4*model_hidden_size)
-        '''
+        """
         for weight_group in self.lstm.all_weights:
             for weight in weight_group:
                 weight.data = torch.rand(weight.shape)
@@ -128,68 +140,137 @@ class LSTM_Model(nn.Module):
 
         return res, shape
 
-def compare(input, gold_data, epsilon = 1e-6):
+
+def compare(input, gold_data, epsilon=1e-6):
     remain = np.abs(gold_data - input)
     err = np.max(remain)
     if err < epsilon:
-        print('SUCCESS: RESULTS ARE THE SAME WITH MAX ERROR {} AND EPSILON {}'.format(err, epsilon))
+        print("SUCCESS: RESULTS ARE THE SAME WITH MAX ERROR {} AND EPSILON {}".format(err, epsilon))
     else:
-        print('WARNING: RESULTS ARE NOT THE SAME WITH ERROR {}'.format(err))
+        print("WARNING: RESULTS ARE NOT THE SAME WITH ERROR {}".format(err))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+
     class MyFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
         pass
 
     parser = argparse.ArgumentParser(
-        description='It constructs neural network which conists of LSTM layer only. '
-        'But the layer can be different types and adjusted by special parameters (see https://pytorch.org/docs/1.8.0/generated/torch.nn.LSTM.html?highlight=lstm#torch.nn.LSTM). '
-        'There are several types: unidirectional, bidirectional, projection, stacked, stacked bidirectional, stacked projection bidirectional',
-        formatter_class=MyFormatter
+        description="It constructs neural network which conists of LSTM layer only. "
+        "But the layer can be different types and adjusted by special parameters (see https://pytorch.org/docs/1.8.0/generated/torch.nn.LSTM.html?highlight=lstm#torch.nn.LSTM). "
+        "There are several types: unidirectional, bidirectional, projection, stacked, stacked bidirectional, stacked projection bidirectional",
+        formatter_class=MyFormatter,
     )
-    parser.add_argument('-t', '--lstm_type', type=str, default='uni', help=\
-        'Type of lstm layer for test. There are several options: uni (unidirectional), b (bidirectional), '
-        'p (projection), s (stacked), sb (stacked bidirectional), spb (stacked projection bidirectional)')
-    parser.add_argument('-f', '--format', type=str, default='ts', help=\
-        'Format of the model. There are two options: \'ts\'(TorchScript) and \'onnx\'(ONNX). The first one is used by default')
-    parser.add_argument('-l', '--layer_num', type=int, default=model_num_layers, help=\
-        'Number of LSTM layers. It is useded for stacked LSTM')
-    parser.add_argument('-p', '--projection_size', type=int, default=projection_size, help=\
-        'Projection size is used in LSTM with projection')
-    parser.add_argument('-b', '--batch_first', action='store_true', default=False, help=\
-        'Batch first parameter used for LSTM layer initialization')
-    parser.add_argument('-w', '--rnd_weights', action='store_true', default=False, help=\
-        'Generate random weights and biases for the model. NOTE: By default All the weights and biases are initialized from '
-        '\mathcal{U}(-\sqrt{k}, \sqrt{k}), where k = \frac{1}{\text{hidden\_size}}')
-    parser.add_argument('-o', '--out_dir', type=Path, default=argparse.SUPPRESS, help=\
-        'Path to directory for saving of intermediate results. NOTE: At the end the directory is removed with all dependencies inside')
+    parser.add_argument(
+        "-t",
+        "--lstm_type",
+        type=str,
+        default="uni",
+        help="Type of lstm layer for test. There are several options: uni (unidirectional), b (bidirectional), "
+        "p (projection), s (stacked), sb (stacked bidirectional), spb (stacked projection bidirectional)",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        default="ts",
+        help='Format of the model. There are two options: "ts"(TorchScript) and "onnx"(ONNX). The first one is used by default',
+    )
+    parser.add_argument(
+        "-l",
+        "--layer_num",
+        type=int,
+        default=model_num_layers,
+        help="Number of LSTM layers. It is useded for stacked LSTM",
+    )
+    parser.add_argument(
+        "-p",
+        "--projection_size",
+        type=int,
+        default=projection_size,
+        help="Projection size is used in LSTM with projection",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_first",
+        action="store_true",
+        default=False,
+        help="Batch first parameter used for LSTM layer initialization",
+    )
+    parser.add_argument(
+        "-w",
+        "--rnd_weights",
+        action="store_true",
+        default=False,
+        help="Generate random weights and biases for the model. NOTE: By default All the weights and biases are initialized from "
+        "\mathcal{U}(-\sqrt{k}, \sqrt{k}), where k = \frac{1}{\text{hidden\_size}}",
+    )
+    parser.add_argument(
+        "-o",
+        "--out_dir",
+        type=Path,
+        default=argparse.SUPPRESS,
+        help="Path to directory for saving of intermediate results. NOTE: At the end the directory is removed with all dependencies inside",
+    )
 
     args = parser.parse_args()
-    if not hasattr(args, 'out_dir'):
-        args.out_dir = Path.cwd().joinpath('output')
+    if not hasattr(args, "out_dir"):
+        args.out_dir = Path.cwd().joinpath("output")
         args.out_dir.mkdir(exist_ok=True, parents=True)
 
-    device = torch.device('cpu')
+    device = torch.device("cpu")
     hidden_layers_num = 1
     model = None
-    if args.lstm_type == 'uni':
-        model = LSTM_Model(device, batch_first = args.batch_first, rnd_weights_init=args.rnd_weights)
-    elif args.lstm_type == 'b':
-        model = LSTM_Model(device, batch_first = args.batch_first, bidirectional=True, rnd_weights_init=args.rnd_weights)
+    if args.lstm_type == "uni":
+        model = LSTM_Model(
+            device,
+            batch_first=args.batch_first,
+            rnd_weights_init=args.rnd_weights,
+        )
+    elif args.lstm_type == "b":
+        model = LSTM_Model(
+            device,
+            batch_first=args.batch_first,
+            bidirectional=True,
+            rnd_weights_init=args.rnd_weights,
+        )
         hidden_layers_num = 2
-    elif args.lstm_type == 'p':
-        model = LSTM_Model(device, batch_first = args.batch_first, proj_size=args.projection_size, rnd_weights_init=args.rnd_weights)
-    elif args.lstm_type == 's':
-        model = LSTM_Model(device, batch_first = args.batch_first, layer_num=args.layer_num, rnd_weights_init=args.rnd_weights)
+    elif args.lstm_type == "p":
+        model = LSTM_Model(
+            device,
+            batch_first=args.batch_first,
+            proj_size=args.projection_size,
+            rnd_weights_init=args.rnd_weights,
+        )
+    elif args.lstm_type == "s":
+        model = LSTM_Model(
+            device,
+            batch_first=args.batch_first,
+            layer_num=args.layer_num,
+            rnd_weights_init=args.rnd_weights,
+        )
         hidden_layers_num = args.layer_num
-    elif args.lstm_type == 'sb':
-        model = LSTM_Model(device, batch_first = args.batch_first, bidirectional=True, layer_num=args.layer_num, rnd_weights_init=args.rnd_weights)
+    elif args.lstm_type == "sb":
+        model = LSTM_Model(
+            device,
+            batch_first=args.batch_first,
+            bidirectional=True,
+            layer_num=args.layer_num,
+            rnd_weights_init=args.rnd_weights,
+        )
         hidden_layers_num = 2 * args.layer_num
-    elif args.lstm_type == 'spb':
-        model = LSTM_Model(device, batch_first = args.batch_first, bidirectional=True, layer_num=args.layer_num, proj_size=args.projection_size, rnd_weights_init=args.rnd_weights)
+    elif args.lstm_type == "spb":
+        model = LSTM_Model(
+            device,
+            batch_first=args.batch_first,
+            bidirectional=True,
+            layer_num=args.layer_num,
+            proj_size=args.projection_size,
+            rnd_weights_init=args.rnd_weights,
+        )
         hidden_layers_num = 2 * args.layer_num
     else:
-        print('LSTM type {} is not supported here!'.format(args.lstm_type))
+        print("LSTM type {} is not supported here!".format(args.lstm_type))
         sys.exit()
 
     model.eval()
@@ -199,49 +280,43 @@ if __name__ == '__main__':
     dummy_input, input_shape = model.get_dummy_input()
     golden_output_batch = model.forward(dummy_input.to(device)).detach().cpu().numpy()
 
-    dtype = 'float32'
+    dtype = "float32"
     h_zeros = np.zeros(input_hidden_shape, dtype=dtype)
     c_zeros = np.zeros(input_hidden_shape, dtype=dtype)
 
     tvm_output = None
-    if args.format == 'ts':
-        #out_fpath = args.out_dir.joinpath('model_{}.pt'.format(args.lstm_type))
+    if args.format == "ts":
         # Use torch.jit.trace to generate a torch.jit.ScriptModule via tracing.
         traced_script_module = torch.jit.trace(model, dummy_input).eval()
 
-        # Save the TorchScript model
-        #traced_script_module.save(str(out_fpath))
-
-        #Import model to Relay
-        shape_list = [('input', input_shape)] #, ('h0', internal_tensor_shape), ('c0', internal_tensor_shape)]
+        # Import model to Relay
+        shape_list = [("input", input_shape)]
         mod, params = relay.frontend.from_pytorch(traced_script_module, shape_list)
 
         # Model compilation by tvm
-        target = tvm.target.Target('llvm', host='llvm')
+        target = tvm.target.Target("llvm", host="llvm")
         dev = tvm.cpu(0)
         with tvm.transform.PassContext(opt_level=3):
             lib = relay.build(mod, target=target, params=params)
-    elif args.format == 'onnx':
-        onnx_fpath = args.out_dir.joinpath('model_{}.onnx'.format(args.lstm_type))
+    elif args.format == "onnx":
+        onnx_fpath = args.out_dir.joinpath("model_{}.onnx".format(args.lstm_type))
 
         with torch.no_grad():
             h0 = torch.rand(input_hidden_shape)
             c0 = torch.rand(input_hidden_shape)
-            input_names = ['input', 'h0', 'c0']
+            input_names = ["input", "h0", "c0"]
 
             # default export (without dynamic input)
-            torch.onnx.export(model, (dummy_input, (h0, c0)), onnx_fpath, input_names = input_names)
-        
+            torch.onnx.export(model, (dummy_input, (h0, c0)), onnx_fpath, input_names=input_names)
+
         onnx_model = onnx.load(onnx_fpath)
 
-        #Import model to Relay
-        shape_dict = {'input': input_shape,
-                      'h0': input_hidden_shape,
-                      'c0': input_hidden_shape}
+        # Import model to Relay
+        shape_dict = {"input": input_shape, "h0": input_hidden_shape, "c0": input_hidden_shape}
         mod, params = relay.frontend.from_onnx(onnx_model, shape_dict)
 
         # Model compilation by tvm
-        target = 'llvm'
+        target = "llvm"
         dev = tvm.cpu(0)
         with tvm.transform.PassContext(opt_level=1):
             lib = relay.build(mod, target=target, params=params)
@@ -249,12 +324,14 @@ if __name__ == '__main__':
         print("ERROR: {} format is unsupported".format(args.format))
 
     # Inference of the model with given input data
-    m = graph_executor.GraphModule(lib['default'](dev))
+    m = graph_executor.GraphModule(lib["default"](dev))
 
     # Set inputs
-    m.set_input(input = tvm.nd.array(dummy_input.numpy().astype(dtype)),
-                h0 = tvm.nd.array(h_zeros),
-                c0 = tvm.nd.array(c_zeros))
+    m.set_input(
+        input=tvm.nd.array(dummy_input.numpy().astype(dtype)),
+        h0=tvm.nd.array(h_zeros),
+        c0=tvm.nd.array(c_zeros),
+    )
     # Execute
     m.run()
     # Get outputs (converted to numpy array)


### PR DESCRIPTION
1. LSTM layer was supported for pytorch frontend (see https://github.com/apache/tvm/issues/6474)
2. Tests for different types of LSTM (unidirectional, bidirectional, stacked, with projection and their combinations) were implemented. Tests are performed for pytorch model and onnx model converted from pytorch
