### PR TITLE
[Fix] Explicitly retain `__hash__` of `StringImm`

### DIFF
--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -577,6 +577,8 @@ class StringImm(ConstExpr):
             return self.value != other.value
         return self.value != other
 
+    __hash__ = PrimExpr.__hash__
+
 
 @tvm._ffi.register_object("tir.Cast")
 class Cast(PrimExprWithOp):

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -577,7 +577,8 @@ class StringImm(ConstExpr):
             return self.value != other.value
         return self.value != other
 
-    __hash__ = PrimExpr.__hash__
+    def __hash__(self):
+        return PrimExpr.__hash__(self)
 
 
 @tvm._ffi.register_object("tir.Cast")


### PR DESCRIPTION
This is a small frontend bug that makes `StringImm` unhashable. The cause of this problem is that in Python 3 we need to explicitly retain `__hash__` if we override `__eq__` (https://docs.python.org/3.1/reference/datamodel.html#object.__hash__), and `StringImm` overrides `__eq__` but misses `__hash__`.