### PR TITLE
[CUDA] Improve injective schedule to enable half2

### DIFF
--- a/python/tvm/topi/cuda/injective.py
+++ b/python/tvm/topi/cuda/injective.py
@@ -16,6 +16,8 @@
 # under the License.
 # pylint: disable=invalid-name, unused-variable,
 """Schedule for composition of injective operator"""
+import numpy as np
+
 import tvm
 from tvm import te
 from .. import utils
@@ -36,13 +38,21 @@ def schedule_injective_from_existing(sch, out):
     sch: Schedule
          The updated schedule.
     """
+
+    def find_nearest_small_factor(num, target):
+        """Find the nearest factor of the given number that is smaller than the target."""
+        for i in range(target, 0, -1):
+            if num % i == 0:
+                return i
+        # Unreachable because i=1 must hold.
+        return -1
+
     fused = sch[out].fuse(*sch[out].op.axis)
     num_thread = tvm.target.Target.current(allow_none=False).max_num_threads
     max_block = 256
 
-    # vectorize on fp16 data type. This allows to better utilize the memory
-    # bandwidth.
-    vector_width = 4 if out.dtype == "float16" else 1
+    # Vectorize on fp16 data type to enable half2 for better memory bandwidth utilization.
+    vector_width = 2 if out.dtype == "float16" else 1
 
     is_dynamic_output = False
     for dim in out.shape:
@@ -54,6 +64,26 @@ def schedule_injective_from_existing(sch, out):
 
     try:
         const_size = utils.get_const_int(out_len)
+
+        # Adjust block and thread to make sure they are dividable so that vectorize can be
+        # correctly applied.
+        if vector_width > 1 and const_size % vector_width == 0:
+            remain_size = const_size // vector_width
+            cand_sizes = []
+            for curr_size in [num_thread, max_block]:
+                cand_sizes.append(
+                    curr_size
+                    if remain_size % curr_size == 0
+                    else find_nearest_small_factor(remain_size, curr_size)
+                )
+                remain_size //= cand_sizes[-1]
+
+            # If the product of candidate dividable (block * thread) is too small,
+            # then the performance may be worse even half2 is enabled. Note that 0.7
+            # is just a heuristic ratio and may not be optimal for all workloads.
+            if np.prod(cand_sizes) / (max_block * num_thread) >= 0.7:
+                max_block, num_thread = cand_sizes
+
         need_block_split = const_size > max_block * num_thread * vector_width
     except ValueError:
         need_block_split = False

--- a/python/tvm/topi/cuda/injective.py
+++ b/python/tvm/topi/cuda/injective.py
@@ -82,7 +82,7 @@ def schedule_injective_from_existing(sch, out):
             # then the performance may be worse even half2 is enabled. Note that 0.7
             # is just a heuristic ratio and may not be optimal for all workloads.
             if np.prod(cand_sizes) / (max_block * num_thread) >= 0.7:
-                max_block, num_thread = cand_sizes
+                num_thread, max_block = cand_sizes
 
         need_block_split = const_size > max_block * num_thread * vector_width
     except ValueError:

--- a/python/tvm/topi/cuda/injective.py
+++ b/python/tvm/topi/cuda/injective.py
@@ -68,15 +68,15 @@ def schedule_injective_from_existing(sch, out):
         # Adjust block and thread to make sure they are dividable so that vectorize can be
         # correctly applied.
         if vector_width > 1 and const_size % vector_width == 0:
-            remain_size = const_size // vector_width
+            remain_total_size = const_size // vector_width
             cand_sizes = []
-            for curr_size in [num_thread, max_block]:
+            for max_size in [num_thread, max_block]:
                 cand_sizes.append(
-                    curr_size
-                    if remain_size % curr_size == 0
-                    else find_nearest_small_factor(remain_size, curr_size)
+                    max_size
+                    if remain_total_size % max_size == 0
+                    else find_nearest_small_factor(remain_total_size, max_size)
                 )
-                remain_size //= cand_sizes[-1]
+                remain_total_size //= cand_sizes[-1]
 
             # If the product of candidate dividable (block * thread) is too small,
             # then the performance may be worse even half2 is enabled. Note that 0.7


### PR DESCRIPTION
Per discussion in https://discuss.tvm.apache.org/t/cuda-enable-half2-in-cuda-injective-schedule/10441, this PR improves the CUDA injective schedule to benefit more from `half2` when working on `float16`.

The background is that although the CUDA injective schedule does vectorize the innermost loop when working on float16, the vectorization may fail due to the if-conditions introduced by non-dividable workload and block/thread sizes. Formally, vectorization requires `prod(output_shape) % block % thread % vector_width == 0`. To make sure vectorization is effective, this PR adjusts the block and thread sizes accordingly (see the code change for details).

On the other hand, when the output shapes are weird (e.g., prime numbers), the selected block and thread sizes may be too small. For example, if the output shape is `(311, 3814)`, then factors are `(1, 2, 311, 1907, 3814)`. As a result, we may select `(block, thread) = (2, 311)` with the consideration of the maximum `(block, thread) = (256, 1024)`. In this case, we don't utilize the compute resources well even `half2` is enabled.

Ideally, we should pad the output to let the factors always be power of two, but it is too complicate and may introduce other issues. Accordingly, another heuristic introduced by this PR is that when `(select_block * select_thread) / (max_block * max_thread) < R`, then we don't apply the change and let the vectorization failed.

Here is the evaluation results when `R=0.7`.
* Workloads: FP32Mul_FP16Add, FP16Mul_FP16Add, FP16Mul, Cast, FP32Mul_FP32Add, FP32Mul.
* Output shapes: I manually assigned two shapes (768, 3072), (1, 1000) and randomly generated additional 100 shapes ranging from 1 to 4096.
* Platform: NVIDIA T4 and V100.

For each platform, I displayed the worst, the best, and the average speedup of all workloads over the current upstream.

* T4: Worst 0.91x, Best, 1.70x, Average 1.11x.
* V100: Worst 0.97x, Best 1.33x, Average 1.15x.

cc @vinx13 @wpan11nv @Laurawly @masahi 