### PR TITLE
[Docs] Corrected typo in googletest build instructions.

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -316,7 +316,7 @@ tests in TVM. The easiest way to install GTest is from source.
        cd googletest
        mkdir build
        cd build
-       cmake -DMAKE_SHARED_LIBS=ON ..
+       cmake -DBUILD_SHARED_LIBS=ON ..
        make
        sudo make install
 


### PR DESCRIPTION
Incorrectly specified "MAKE_SHARED_LIBS" option instead of "BUILD_SHARED_LIBS".  In future, perhaps googletest should be pulled into 3rdparty submodules to minimize the setup of a dev environment.