### PR TITLE
[AMP] Add default op attribute registration to __init__.py

### DIFF
--- a/python/tvm/relay/transform/__init__.py
+++ b/python/tvm/relay/transform/__init__.py
@@ -19,4 +19,4 @@
 # transformation passes
 from .transform import *
 from .recast import recast
-from . import fake_quantization_to_integer
+from . import fake_quantization_to_integer, mixed_precision

--- a/python/tvm/relay/transform/__init__.py
+++ b/python/tvm/relay/transform/__init__.py
@@ -16,8 +16,9 @@
 # under the License.
 # pylint: disable=wildcard-import, redefined-builtin, invalid-name
 """The Relay IR namespace containing transformations."""
+# transformation passes
+from .transform import *
 from . import fake_quantization_to_integer, mixed_precision
 from .recast import recast
 
-# transformation passes
-from .transform import *
+

--- a/python/tvm/relay/transform/__init__.py
+++ b/python/tvm/relay/transform/__init__.py
@@ -20,5 +20,3 @@
 from .transform import *
 from .recast import recast
 from . import fake_quantization_to_integer, mixed_precision
-
-

--- a/python/tvm/relay/transform/__init__.py
+++ b/python/tvm/relay/transform/__init__.py
@@ -18,7 +18,7 @@
 """The Relay IR namespace containing transformations."""
 # transformation passes
 from .transform import *
-from . import fake_quantization_to_integer, mixed_precision
 from .recast import recast
+from . import fake_quantization_to_integer, mixed_precision
 
 

--- a/python/tvm/relay/transform/__init__.py
+++ b/python/tvm/relay/transform/__init__.py
@@ -16,7 +16,8 @@
 # under the License.
 # pylint: disable=wildcard-import, redefined-builtin, invalid-name
 """The Relay IR namespace containing transformations."""
+from . import fake_quantization_to_integer, mixed_precision
+from .recast import recast
+
 # transformation passes
 from .transform import *
-from .recast import recast
-from . import fake_quantization_to_integer, mixed_precision

--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -141,7 +141,7 @@ def register_func_to_op_list(list_ops: List):
     return decorator
 
 
-def get_generic_out_dtypes(call_node: relay.Call, mixed_precision_type: str) -> List[str]:
+def get_generic_out_dtypes(call_node: "relay.Call", mixed_precision_type: str) -> List[str]:
     """A function which returns output dtypes in a way which works for most ops.
 
     Parameters
@@ -174,15 +174,15 @@ def get_generic_out_dtypes(call_node: relay.Call, mixed_precision_type: str) -> 
 # Take in CallNodes and a DType and returns a conversion type,
 # an accumulation dtype, and an output_dtype.
 @register_func_to_op_list(list_ops=DEFAULT_ALWAYS_LIST)
-def generic_always_op(call_node: relay.Call, mixed_precision_type: str) -> List:
+def generic_always_op(call_node: "relay.Call", mixed_precision_type: str) -> List:
     return [MIXED_PRECISION_ALWAYS] + get_generic_out_dtypes(call_node, mixed_precision_type)
 
 
 @register_func_to_op_list(list_ops=DEFAULT_FOLLOW_LIST)
-def generic_follow_op(call_node: relay.Call, mixed_precision_type: str) -> List:
+def generic_follow_op(call_node: "relay.Call", mixed_precision_type: str) -> List:
     return [MIXED_PRECISION_FOLLOW] + get_generic_out_dtypes(call_node, mixed_precision_type)
 
 
 @register_func_to_op_list(list_ops=DEFAULT_NEVER_LIST)
-def generic_never_op(call_node: relay.Call, mixed_precision_type: str) -> List:
+def generic_never_op(call_node: "relay.Call", mixed_precision_type: str) -> List:
     return [MIXED_PRECISION_NEVER] + get_generic_out_dtypes(call_node, mixed_precision_type)

--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -18,7 +18,6 @@
 """Default behavior for ops in mixed_precision pass. Import this file to use."""
 from typing import List
 
-from tvm import relay
 from tvm.relay.op import register_mixed_precision_conversion
 
 # MIXED_PRECISION_ALWAYS ops should always be done in lower precision due to the speed and memory


### PR DESCRIPTION
This will make it so when we do `from tvm.relay.transform import ToMixedPrecision` we will also by default import the default op attributes for the pass. This will hopefully avoid people suffering from errors where they did not import the op attribute file for now.