### PR TITLE
[UnitTests] Minor fixes to unit tests for cudnn/vulkan targets

### DIFF
--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -98,6 +98,7 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0, groups=1):
 
 
 @tvm.testing.requires_gpu
+@requires_cudnn
 def test_conv2d():
     verify_conv2d("float32", "float32", tensor_format=0)
     verify_conv2d("float16", "float32", tensor_format=1)
@@ -171,6 +172,7 @@ def verify_conv3d(data_dtype, conv_dtype, tensor_format=0, groups=1):
 
 
 @tvm.testing.requires_gpu
+@requires_cudnn
 def test_conv3d():
     verify_conv3d("float32", "float32", tensor_format=0)
     verify_conv3d("float32", "float32", tensor_format=0, groups=2)

--- a/tests/python/unittest/test_target_codegen_device.py
+++ b/tests/python/unittest/test_target_codegen_device.py
@@ -45,7 +45,7 @@ def test_large_uint_imm():
         assert a.numpy()[0] == value + 3
 
     check_target("cuda")
-    check_target("vulkan")
+    check_target("vulkan -from_device=0")
 
 
 @tvm.testing.requires_gpu


### PR DESCRIPTION
- Marked tests as @requires_cudnn to avoid failure on platforms without cudnn.

- Replaced target "vulkan" with "vulkan -from_device=0"