### PR TITLE
[Codegen] Remove compile_enginer header

### DIFF
--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -221,20 +221,20 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
       device_context_map.insert({expr, dev});
     }
 
-    auto lowered_module = tec::LowerTE(mod, targets_, device_context_map, memory_plan_, mod_name_,
-                                       [this](Function func) {
-                                         // We need to maintain the constant map for external
-                                         // functions so we pass this processing function which
-                                         // allows us to process each function as we lower it.
-                                         if (func->GetAttr<String>(attr::kCompiler).defined()) {
-                                           UpdateConstants(func, &params_);
-                                         }
+    auto lowered_module = tec::LowerTE(
+        mod, targets_, device_context_map, memory_plan_, mod_name_, [this](Function func) {
+          // We need to maintain the constant map for external
+          // functions so we pass this processing function which
+          // allows us to process each function as we lower it.
+          if (func->GetAttr<String>(attr::kCompiler).defined()) {
+            UpdateConstants(func, &params_);
+          }
 
-                                         // TODO(@areusch, @jroesch): We should refactor this to
-                                         // execute as a further pass, instead writing data to the
-                                         // lowering process directly.
-                                         tec::UpdateFunctionMetadata(func, this->function_metadata_);
-                                       });
+          // TODO(@areusch, @jroesch): We should refactor this to
+          // execute as a further pass, instead writing data to the
+          // lowering process directly.
+          tec::UpdateFunctionMetadata(func, this->function_metadata_);
+        });
 
     function_metadata_.Set(runtime::symbol::tvm_module_main, lowered_module.main_func_info);
     auto main_module = lowered_module.main_module;

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -36,7 +36,6 @@
 #include <string>
 #include <vector>
 
-#include "compile_engine.h"
 #include "te_compiler.h"
 #include "utils.h"
 
@@ -184,7 +183,7 @@ class GraphOpNode : public GraphNode {
  */
 class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<GraphNodeRef>> {
  public:
-  GraphExecutorCodegen(runtime::Module* mod, const TargetMap& targets) : mod_(mod) {
+  GraphExecutorCodegen(runtime::Module* mod, const tec::TargetMap& targets) : mod_(mod) {
     targets_ = targets;
   }
 
@@ -234,7 +233,7 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
                                          // TODO(@areusch, @jroesch): We should refactor this to
                                          // execute as a further pass, instead writing data to the
                                          // lowering process directly.
-                                         UpdateFunctionMetadata(func, this->function_metadata_);
+                                         tec::UpdateFunctionMetadata(func, this->function_metadata_);
                                        });
 
     function_metadata_.Set(runtime::symbol::tvm_module_main, lowered_module.main_func_info);
@@ -580,7 +579,7 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
   /*! \brief variable map */
   std::unordered_map<const Object*, std::vector<GraphNodeRef>> var_map_;
   /*! \brief target device */
-  TargetMap targets_;
+  tec::TargetMap targets_;
   /*!
    * \brief parameters (i.e. ConstantNodes found in the graph).
    * These are take as inputs to the GraphExecutor.
@@ -609,7 +608,7 @@ class GraphExecutorCodegenModule : public runtime::ModuleNode {
                                     << "runtime::Module mod and Map<int, Target> targets";
         void* mod = args[0];
         Map<Integer, tvm::Target> tmp = args[1];
-        TargetMap targets;
+        tec::TargetMap targets;
         for (const auto& it : tmp) {
           auto dev_type = it.first.as<tir::IntImmNode>();
           ICHECK(dev_type);


### PR DESCRIPTION
`compile_engine.h` doesn't need to be included after the compile engine refactoring (if we add `tec` namespace in some places).

cc @jroesch @electriclilies 