### PR TITLE
Fix _get_yolo_detections

### DIFF
--- a/python/tvm/relay/testing/yolo_detection.py
+++ b/python/tvm/relay/testing/yolo_detection.py
@@ -103,8 +103,8 @@ def _get_yolo_detections(l, im_shape, net_shape, thresh, relative, dets):
             l["biases"],
             np.asarray(l["mask"])[location[0]],
             location,
-            data.shape[2],
             data.shape[3],
+            data.shape[2],
             net_shape[0],
             net_shape[1],
         )
@@ -139,10 +139,10 @@ def _get_region_detections(l, im_shape, net_shape, thresh, relative, dets):
                     l["biases"],
                     n,
                     location,
-                    data.shape[2],
                     data.shape[3],
                     data.shape[2],
                     data.shape[3],
+                    data.shape[2],
                 )
                 objectness = scale if scale > thresh else 0
                 if objectness:


### PR DESCRIPTION
This PR fixes darknet yolo bbox calculation in case network heigh and width are not equal.
I have custom darknet yolo model with shape `[1,1,224,384]`
Without this fix the boxes calculation gets outside of the image boundaries.
tvm_output contains layer_out["output"]. Its shape format is `[_,_,h,w]` (variable `data` in this PR)
But `_get_box` method signature uses  `lw, lh` parameters sequence. `_get_box(data, biases, n, location, lw, lh, w, h)`.
The fix maps `lw` to `data[3]` and `lh` to `data[2]`.
The problem was not detected earlier because vanilla yolov2 and yolov3 models network usually have the same Height and Width. For example `[1,3,416,416]` or `[1,3,608,608]`