### PR TITLE
[TOPI][CUDA] Improve the performance of scatter_nd

### DIFF
--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -823,10 +823,12 @@ def scatter_nd(data, indices, updates, mode):
                     with ib.if_scope(j < fused_updates_dimension):
                         offset = fused_updates_dimension
                         index = j  # This is x_M, .. x_{N-1} part of the index into out.
-                        # Build up the indices[0, y_0, .. y_{K-1}], .. indices[M-1, y_0, .. y_{K-1}] part
-                        # of the index into out.
+                        # Build up the
+                        # indices[0, y_0, .. y_{K-1}], ... indices[M-1, y_0, .. y_{K-1}]
+                        # part of the index into out.
                         for l in reversed(range(indices_ptr.shape[0].value)):
-                            # indices[i * l * fused_indices_dimension] = indices[l, y_0, ... y_{k-1}]
+                            # indices[i * l * fused_indices_dimension] = indices[l, y_0,
+                            #                                                   ... y_{k-1}]
                             index += offset * indices[i + l * fused_indices_dimension]
                             offset *= data_ptr.shape[l]
                         out[index] += updates[i * fused_updates_dimension + j]
@@ -844,8 +846,8 @@ def scatter_nd(data, indices, updates, mode):
                 with ib.if_scope(j < fused_updates_dimension):
                     offset = fused_updates_dimension
                     index = j  # This is x_M, .. x_{N-1} part of the index into out.
-                    # Build up the indices[0, y_0, .. y_{K-1}], .. indices[M-1, y_0, .. y_{K-1}] part
-                    # of the index into out.
+                    # Build up the indices[0, y_0, .. y_{K-1}], .. indices[M-1, y_0, .. y_{K-1}]
+                    # part of the index into out.
                     up_index = by * fused_updates_dimension + j
                     for l in reversed(range(indices_ptr.shape[0].value)):
                         # indices[by * l * fused_indices_dimension] = indices[l, y_0, ... y_{k-1}]

--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -812,7 +812,7 @@ def scatter_nd(data, indices, updates, mode):
                 out[index] = data[index]
 
         with ib.new_scope():
-            if updates.dtype == 'int64' and mode == 'add':
+            if updates.dtype == "int64" and mode == "add":
                 bdim_x = ceil_div(fused_updates_dimension, tdim)
                 bx = te.thread_axis("blockIdx.x")
                 tx = te.thread_axis("threadIdx.x")
@@ -843,7 +843,7 @@ def scatter_nd(data, indices, updates, mode):
                 j = bx * tdim + tx
                 with ib.if_scope(j < fused_updates_dimension):
                     offset = fused_updates_dimension
-                    index = j # This is x_M, .. x_{N-1} part of the index into out.
+                    index = j  # This is x_M, .. x_{N-1} part of the index into out.
                     # Build up the indices[0, y_0, .. y_{K-1}], .. indices[M-1, y_0, .. y_{K-1}] part
                     # of the index into out.
                     up_index = by * fused_updates_dimension + j

--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -835,8 +835,10 @@ def scatter_nd(data, indices, updates, mode):
             else:
                 bdim_x = ceil_div(fused_updates_dimension, tdim)
                 bdim_y = fused_indices_dimension
-                bx = te.thread_axis("blockIdx.x")
-                by = te.thread_axis("blockIdx.y")
+                # In case of large input sizes, bim_y might be too large.
+                # So it could be moved to blockIdx.x position, which holds larger scales.
+                bx = te.thread_axis("blockIdx.y")
+                by = te.thread_axis("blockIdx.x")
                 tx = te.thread_axis("threadIdx.x")
                 ib.scope_attr(bx, "thread_extent", bdim_x)
                 ib.scope_attr(by, "thread_extent", bdim_y)

--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -854,7 +854,7 @@ def scatter_nd(data, indices, updates, mode):
                 bdim_x = fused_indices_dimension
                 bdim_y = ceil_div(fused_updates_dimension, tdim)
                 # In case of large input sizes, fused_indices_dimension might be too large.
-                # So it could be moved to blockIdx.x position, which holds larger scales.
+                # So we use blockIdx.x because holds larger scales.
                 bx = te.thread_axis("blockIdx.x")
                 by = te.thread_axis("blockIdx.y")
                 tx = te.thread_axis("threadIdx.x")

--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -813,7 +813,7 @@ def scatter_nd(data, indices, updates, mode):
         # For now, atomic is not supported by target "vulkan", "metal", or "cuda" with "int64"
         # So we fallback to normal algorithm, using "+=" rather than atomic_add
 
-        # TODO:
+        # TODO (CaptainDuke):
         # Since multiple threads compete for the same write index, which leads to
         # non-determinstic output for update mode. We could add a new attribute
         # "allow_non_deterministic" to scatter_nd op, which is False by default.

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1884,7 +1884,7 @@ def test_scatter_nd(target, dev):
     ):
         data = relay.var("data", shape=data_np.shape, dtype=str(data_np.dtype))
         indices_vars = [
-            relay.var("ind{i}", shape=v.shape, dtype=str(v.dtype)) for i, v in enumerate(indices_np)
+            relay.var("ind%d"%i, shape=v.shape, dtype=str(v.dtype)) for i, v in enumerate(indices_np)
         ]
         updates = relay.var("updates", shape=updates_np.shape, dtype=str(updates_np.dtype))
 

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1884,7 +1884,8 @@ def test_scatter_nd(target, dev):
     ):
         data = relay.var("data", shape=data_np.shape, dtype=str(data_np.dtype))
         indices_vars = [
-            relay.var("ind%d"%i, shape=v.shape, dtype=str(v.dtype)) for i, v in enumerate(indices_np)
+            relay.var("ind%d" % i, shape=v.shape, dtype=str(v.dtype))
+            for i, v in enumerate(indices_np)
         ]
         updates = relay.var("updates", shape=updates_np.shape, dtype=str(updates_np.dtype))
 


### PR DESCRIPTION
1. Split into 2 kernels, one does the "Init" and another does the "Update".
   Thus they can have different Grid/Block configurations to better utilize
   SMs.
2. Use atomic_add instead of direct assignment, which could avoid the race
   condtion when multiple indices point to the same location of the output
   tensor. With this moidification, it's safe now to use more CUDA threads
   to gain more parallelism.

Detail discussion: https://discuss.tvm.apache.org/t/topi-cuda-scatter-nd-has-a-very-poor-performance-on-cuda-backend-1000x-slower-than-hand-written-cuda-code/10426
