### PR TITLE
[VM] Fix the shape function of conv & Add dynamic support for conv2d nhwc

### DIFF
--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -984,8 +984,8 @@ def _conv_shape_func_nhwc_hwio(dshape, kshape, strides, padding, dilation):
     out[dshape.shape[0] - 1] = kshape[kshape.shape[0] - 1]
 
     for i in const_range(dshape.shape[0] - 2):
-        dilated_k_1 = (kshape[i] - 1) * dilation[i] + 1
-        out[i + 1] = (dshape[i + 1] + 2 * padding[i] - dilated_k_1) // strides[i] + 1
+        dilated_k = (kshape[i] - 1) * dilation[i] + 1
+        out[i + 1] = (dshape[i + 1] + 2 * padding[i] - dilated_k) // strides[i] + 1
     return out
 
 
@@ -997,8 +997,8 @@ def _conv_shape_func_nhwc_hwoi(dshape, kshape, strides, padding, dilation):
     out[dshape.shape[0] - 1] = kshape[kshape.shape[0] - 2]
 
     for i in const_range(dshape.shape[0] - 2):
-        dilated_k_1 = (kshape[i] - 1) * dilation[i] + 1
-        out[i + 1] = (dshape[i + 1] + 2 * padding[i] - dilated_k_1) // strides[i] + 1
+        dilated_k = (kshape[i] - 1) * dilation[i] + 1
+        out[i + 1] = (dshape[i + 1] + 2 * padding[i] - dilated_k) // strides[i] + 1
     return out
 
 

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -1017,14 +1017,11 @@ def conv_shape_func(attrs, inputs, _):
         shape_func = _conv_shape_func_nhwc_hwoi
     else:
         raise ValueError(
-            "Unsupported data/kernel layout: %s, %s" % (
-                attrs["data_layout"], attrs["kernel_layout"]
-            )
+            "Unsupported data/kernel layout: %s, %s"
+            % (attrs["data_layout"], attrs["kernel_layout"])
         )
 
-    return [
-        shape_func(inputs[0], inputs[1], convert(strides), convert(padding), convert(dilation))
-    ]
+    return [shape_func(inputs[0], inputs[1], convert(strides), convert(padding), convert(dilation))]
 
 
 reg.register_shape_func("nn.conv1d", False, conv_shape_func)

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -1008,7 +1008,7 @@ def conv_shape_func(attrs, inputs, _):
     padding = get_const_tuple(attrs.padding)
     dilation = get_const_tuple(attrs.dilation)
 
-    if (attrs["data_layout"] == "NCHW" and attrs["kernel_layout"] == "OIHW"):
+    if attrs["data_layout"] == "NCHW" and attrs["kernel_layout"] == "OIHW":
         return [
             _conv_shape_func_nchw(
                 inputs[0],

--- a/python/tvm/topi/arm_cpu/conv2d_spatial_pack.py
+++ b/python/tvm/topi/arm_cpu/conv2d_spatial_pack.py
@@ -273,7 +273,8 @@ def conv2d_spatial_pack_nhwc(cfg, data, kernel, strides, padding, dilation, out_
     data_pad = nn.pad(data, [0, pad_top, pad_left, 0], [0, pad_down, pad_right, 0])
 
     # ==================== define configuration space ====================
-    n, oc, oh, ow = cfg.axis(N), cfg.axis(OC), cfg.axis(OH), cfg.axis(OW)
+    n = cfg.axis(N) if isinstance(N, int) else cfg.axis(1)
+    oc, oh, ow = cfg.axis(OC), cfg.axis(OH), cfg.axis(OW)
     ic, kh, kw = cfg.reduce_axis(IC), cfg.reduce_axis(KH), cfg.reduce_axis(KW)
 
     if num_tile == 2:  # for arm cpu

--- a/python/tvm/topi/arm_cpu/conv2d_spatial_pack.py
+++ b/python/tvm/topi/arm_cpu/conv2d_spatial_pack.py
@@ -273,6 +273,7 @@ def conv2d_spatial_pack_nhwc(cfg, data, kernel, strides, padding, dilation, out_
     data_pad = nn.pad(data, [0, pad_top, pad_left, 0], [0, pad_down, pad_right, 0])
 
     # ==================== define configuration space ====================
+    # If it has dynamic shape in batch, we fix the split factor to 1
     n = cfg.axis(N) if isinstance(N, int) else cfg.axis(1)
     oc, oh, ow = cfg.axis(OC), cfg.axis(OH), cfg.axis(OW)
     ic, kh, kw = cfg.reduce_axis(IC), cfg.reduce_axis(KH), cfg.reduce_axis(KW)

--- a/python/tvm/topi/cuda/conv2d_nhwc.py
+++ b/python/tvm/topi/cuda/conv2d_nhwc.py
@@ -47,20 +47,11 @@ def schedule_conv2d_nhwc_direct(cfg, s, Conv):
     dynamic_batch = isinstance(s[output].op.axis[0].dom.extent, tvm.tir.expr.Var)
 
     # Schedule for autotvm
-    if dynamic_batch:
-        cfg.define_knob("tile_n", [1])
-    else:
-        cfg.define_knob("tile_n", [2, 4, 8])
+    cfg.define_knob("tile_n", [1] if dynamic_batch else [2, 4, 8])
     cfg.define_knob("tile_c", [2, 4, 8])
-    if dynamic_batch:
-        cfg.define_knob("num_thread_n", [1])
-    else:
-        cfg.define_knob("num_thread_n", [4, 8, 16])
+    cfg.define_knob("num_thread_n", [1] if dynamic_batch else [4, 8, 16])
     cfg.define_knob("num_thread_c", [4, 8, 16])
-    if dynamic_batch:
-        cfg.define_knob("vthread_n", [1])
-    else:
-        cfg.define_knob("vthread_n", [1, 2])
+    cfg.define_knob("vthread_n", [1] if dynamic_batch else [1, 2])
     cfg.define_knob("vthread_c", [1, 2])
     cfg.define_knob("step", [16, 3, 32, 64])
 

--- a/python/tvm/topi/cuda/conv2d_nhwc.py
+++ b/python/tvm/topi/cuda/conv2d_nhwc.py
@@ -43,12 +43,24 @@ def schedule_conv2d_nhwc_direct(cfg, s, Conv):
     AL = s.cache_read(AA, "local", [OL])
     WL = s.cache_read(WW, "local", [OL])
 
+    # Currently Conv2d NHWC only support dynamic shpe in batch
+    dynamic_batch = isinstance(s[output].op.axis[0].dom.extent, tvm.tir.expr.Var)
+
     # Schedule for autotvm
-    cfg.define_knob("tile_n", [2, 4, 8])
+    if dynamic_batch:
+        cfg.define_knob("tile_n", [1])
+    else:
+        cfg.define_knob("tile_n", [2, 4, 8])
     cfg.define_knob("tile_c", [2, 4, 8])
-    cfg.define_knob("num_thread_n", [4, 8, 16])
+    if dynamic_batch:
+        cfg.define_knob("num_thread_n", [1])
+    else:
+        cfg.define_knob("num_thread_n", [4, 8, 16])
     cfg.define_knob("num_thread_c", [4, 8, 16])
-    cfg.define_knob("vthread_n", [1, 2])
+    if dynamic_batch:
+        cfg.define_knob("vthread_n", [1])
+    else:
+        cfg.define_knob("vthread_n", [1, 2])
     cfg.define_knob("vthread_c", [1, 2])
     cfg.define_knob("step", [16, 3, 32, 64])
 

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -578,18 +578,6 @@ def test_any_conv2d():
         data_layout="NHWC",
         kernel_layout="HWIO",
     )
-    verify_any_conv2d(
-        (relay.Any(), 224, 224, 64),
-        (3, 3, 64, 64),
-        (1, 1),
-        (1, 1),
-        (1, 1),
-        (1, 224, 224, 64),
-        (1, 224, 224, 64),
-        data_layout="NHWC",
-        kernel_layout="HWIO",
-        use_cudnn=True,
-    )
 
 
 def verify_any_conv2d_NCHWc(

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -511,7 +511,8 @@ def verify_any_conv2d(
         padding,
         dilation,
         kernel_size=kernel_shape[2:4] if kernel_layout == "OIHW" else kernel_shape[0:2],
-        data_layout=data_layout, kernel_layout=kernel_layout,
+        data_layout=data_layout,
+        kernel_layout=kernel_layout,
     )
     mod["main"] = relay.Function([data, kernel], y)
     data_np = np.random.uniform(size=static_data_shape).astype(dtype)

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -496,13 +496,23 @@ def verify_any_conv2d(
     dilation,
     static_data_shape,
     ref_out_shape,
+    data_layout="NCHW",
+    kernel_layout="OIHW",
     use_cudnn=False,
 ):
     mod = tvm.IRModule()
     dtype = "float32"
     data = relay.var("data", shape=data_shape, dtype=dtype)
     kernel = relay.var("kernel", shape=kernel_shape, dtype=dtype)
-    y = relay.nn.conv2d(data, kernel, strides, padding, dilation, kernel_size=kernel_shape[2:4])
+    y = relay.nn.conv2d(
+        data,
+        kernel,
+        strides,
+        padding,
+        dilation,
+        kernel_size=kernel_shape[2:4] if kernel_layout == "OIHW" else kernel_shape[0:2],
+        data_layout=data_layout, kernel_layout=kernel_layout,
+    )
     mod["main"] = relay.Function([data, kernel], y)
     data_np = np.random.uniform(size=static_data_shape).astype(dtype)
     kernel_np = np.random.uniform(size=kernel_shape).astype(dtype)

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -545,6 +545,40 @@ def test_any_conv2d():
         (1, 64, 224, 224),
         use_cudnn=True,
     )
+    verify_any_conv2d(
+        (relay.Any(), 224, 224, 64),
+        (3, 3, 64, 64),
+        (1, 1),
+        (1, 1),
+        (1, 1),
+        (1, 224, 224, 64),
+        (1, 224, 224, 64),
+        data_layout="NHWC",
+        kernel_layout="HWIO",
+    )
+    verify_any_conv2d(
+        (relay.Any(), 224, 224, 64),
+        (3, 3, 64, 64),
+        (1, 1),
+        (1, 1),
+        (2, 2),
+        (2, 224, 224, 64),
+        (2, 222, 222, 64),
+        data_layout="NHWC",
+        kernel_layout="HWIO",
+    )
+    verify_any_conv2d(
+        (relay.Any(), 224, 224, 64),
+        (3, 3, 64, 64),
+        (1, 1),
+        (1, 1),
+        (1, 1),
+        (1, 224, 224, 64),
+        (1, 224, 224, 64),
+        data_layout="NHWC",
+        kernel_layout="HWIO",
+        use_cudnn=True,
+    )
 
 
 def verify_any_conv2d_NCHWc(


### PR DESCRIPTION
Just a small bug fix when using vm with conv2d_nhwc. Also add the shape function for `nn.fast_softmax.`

cc @comaniac 