### PR TITLE
[TVMC][FIX] Compiler supports input with a slash

### DIFF
--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -396,7 +396,7 @@ def parse_shape_string(inputs_string):
     """
 
     # Create a regex pattern that extracts each separate input mapping.
-    pattern = r"\w+\:\s*\[\-?\d+(?:\,\s*\-?\d+)*\]"
+    pattern = r"(?:\w+\/)?\w+\:\s*\[\-?\d+(?:\,\s*\-?\d+)*\]"
     input_mappings = re.findall(pattern, inputs_string)
     if not input_mappings:
         raise argparse.ArgumentTypeError(

--- a/tests/python/driver/tvmc/test_tvmc_common.py
+++ b/tests/python/driver/tvmc/test_tvmc_common.py
@@ -177,6 +177,11 @@ def test_shape_parser():
     shape_dict = tvmc.common.parse_shape_string(shape_string)
     # Convert to strings to allow comparison with Any.
     assert str(shape_dict) == "{'input': [?, 3, 224, 224]}"
+    # Check that multiple valid gpu inputs are parsed correctly.
+    shape_string = "gpu_0/data_0:[1, -1,224,224] gpu_1/data_1:[7, 7]"
+    shape_dict = tvmc.common.parse_shape_string(shape_string)
+    expected = "{'gpu_0/data_0': [1, ?, 224, 224], 'gpu_1/data_1': [7, 7]}"
+    assert str(shape_dict) == expected
 
     # Check that invalid pattern raises expected error.
     shape_string = "input:[a,10]"
@@ -184,6 +189,22 @@ def test_shape_parser():
         tvmc.common.parse_shape_string(shape_string)
     # Check that input with invalid separators raises error.
     shape_string = "input:5,10 input2:10,10"
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_shape_string(shape_string)
+    # Check that input with a invalid slash raises error.
+    shape_string = "gpu_0/data_0:5,10 /:10,10"
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_shape_string(shape_string)
+    # Check that input with a invalid slash raises error.
+    shape_string = "gpu_0/data_0:5,10 data/:10,10"
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_shape_string(shape_string)
+    # Check that input with a invalid slash raises error.
+    shape_string = "gpu_0/data_0:5,10 /data:10,10"
+    with pytest.raises(argparse.ArgumentTypeError):
+        tvmc.common.parse_shape_string(shape_string)
+    # Check that input with invalid slashes raises error.
+    shape_string = "gpu_0/invalid/data_0:5,10 data_1:10,10"
     with pytest.raises(argparse.ArgumentTypeError):
         tvmc.common.parse_shape_string(shape_string)
 


### PR DESCRIPTION
Hi, community,

When I use TVMC to compile a model trained on GPU, the name of input have a slash, such as `"gpu_0/data_0": Var(gpu_0/data_0, ty=TensorType([1, 3, 224, 224], float32))`, TVMC complains that cannot find such inputs in the graph, shows as below.
```bash
Traceback (most recent call last):
  File "/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "~/tvm/python/tvm/driver/tvmc/__main__.py", line 24, in <module>
    tvmc.main.main()
  File "~/tvm/python/tvm/driver/tvmc/main.py", line 94, in main
    sys.exit(_main(sys.argv[1:]))
  File "~/tvm/python/tvm/driver/tvmc/main.py", line 87, in _main
    return args.func(args)
  File "~/tvm/python/tvm/driver/tvmc/compiler.py", line 140, in drive_compile
    tvmc_model = frontends.load_model(args.FILE, args.model_format, args.input_shapes)
  File "~/tvm/python/tvm/driver/tvmc/frontends.py", line 376, in load_model
    mod, params = frontend.load(path, shape_dict, **kwargs)
  File "~/tvm/python/tvm/driver/tvmc/frontends.py", line 171, in load
    return relay.frontend.from_onnx(model, shape=shape_dict, **kwargs)
  File "~/tvm/python/tvm/relay/frontend/onnx.py", line 3605, in from_onnx
    mod, params = g.from_onnx(graph, opset)
  File "~/tvm/python/tvm/relay/frontend/onnx.py", line 3355, in from_onnx
    self._shape
AssertionError: User specified the shape for inputs that weren't found in the graph: {'data_0': [1, 3, 224, 224]}
```
This PR updates the RE to match such input name. :)