### PR TITLE
[TVMSCRIPT] Support tir.abs node in tvm script

### DIFF
--- a/python/tvm/script/intrin.py
+++ b/python/tvm/script/intrin.py
@@ -121,6 +121,11 @@ def floormod(x, y, span):
 
 
 @register
+def abs(x, span):
+    return tvm.tir.abs(x, span)
+
+
+@register
 def load(dtype, var, index, predicate=None, span=None):
     return tvm.tir.Load(dtype, var, index, predicate, span)
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2946,6 +2946,20 @@ def test_minmax():
     tvm.ir.assert_structural_equal(func, rt_func)
 
 
+@tvm.script.tir
+def abs(a: ty.handle) -> None:
+    A = tir.match_buffer(a, (128, 128), "float32")
+
+    with tir.block([128, 128], "A") as [vi, vj]:
+        A[vi, vj] = tir.abs(A[vi, vj])
+
+
+def test_abs():
+    func = abs
+    rt_func = tvm.script.from_source(tvm.script.asscript(func, True))
+    tvm.ir.assert_structural_equal(func, rt_func)
+
+
 if __name__ == "__main__":
     test_opt_gemm_normalize()
     test_opt_gemm_mod_host()
@@ -2962,3 +2976,4 @@ if __name__ == "__main__":
     test_for_thread_binding()
     test_block_elements()
     test_opaque_block()
+    test_abs()


### PR DESCRIPTION
support tir.abs
Tvm script call tir.abs() report error: Unregistered function tir.abs
tvm.tir.op.Op only resgister tir.fabs op in tvm/src/tir/op/op.cc , but register tir.abs PackFunc through TVM_REGISTER_GLOBAL("tir.abs").set_body_typed(tvm::abs); , so we add it in intrin.py to call this PackFunc

@Hzfengsy Would you please have a look at this? Thanks very much.