### PR TITLE
[microTVM] Add Arduino CLI support to ci-qemu

### DIFF
--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -66,6 +66,10 @@ COPY install/ubuntu_init_zephyr_project.sh /install/ubuntu_init_zephyr_project.s
 RUN bash /install/ubuntu_install_zephyr.sh
 ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
 
+# Arduino deps
+COPY install/ubuntu_install_arduino.sh /install/ubuntu_install_arduino.sh
+RUN bash /install/ubuntu_install_arduino.sh
+
 # Install ONNX
 COPY install/ubuntu_install_onnx.sh /install/ubuntu_install_onnx.sh
 RUN bash /install/ubuntu_install_onnx.sh

--- a/docker/install/ubuntu_install_arduino.sh
+++ b/docker/install/ubuntu_install_arduino.sh
@@ -26,9 +26,6 @@ apt-get install -y ca-certificates
 # Install arduino-cli latest version
 wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s
 
-# Board manager URLs
-SPRESENSE_URL=https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json
-
 # Install supported cores from those URLS
-arduino-cli core install SPRESENSE:spresense --additional-urls ${SPRESENSE_URL}
 arduino-cli core install arduino:mbed_nano
+arduino-cli core install arduino:sam

--- a/docker/install/ubuntu_install_arduino.sh
+++ b/docker/install/ubuntu_install_arduino.sh
@@ -26,9 +26,9 @@ apt-get install -y ca-certificates
 # Install arduino-cli latest version
 wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s
 
-# Board manager URLs, separated by semicolons
-BOARD_MANAGER_URLS=https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json
+# Board manager URLs
+SPRESENSE_URL=https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json
 
 # Install supported cores from those URLS
-arduino-cli core install SPRESENSE:spresense --additional-urls ${BOARD_MANAGER_URLS}
-arduino-cli core install arduino:mbed_nano --additional-urls ${BOARD_MANAGER_URLS}
+arduino-cli core install SPRESENSE:spresense --additional-urls ${SPRESENSE_URL}
+arduino-cli core install arduino:mbed_nano

--- a/docker/install/ubuntu_install_arduino.sh
+++ b/docker/install/ubuntu_install_arduino.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update --fix-missing
+apt-get install -y ca-certificates
+
+# Install arduino-cli
+ARDUINO_SDK_VERSION=0.18.3
+wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s ${ARDUINO_SDK_VERSION}
+
+# Board manager URLs, separated by semicolons
+BOARD_MANAGER_URLS=https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json
+
+# Install supported cores from those URLS
+arduino-cli core install SPRESENSE:spresense --additional-urls ${BOARD_MANAGER_URLS}
+arduino-cli core install arduino:mbed_nano --additional-urls ${BOARD_MANAGER_URLS}

--- a/docker/install/ubuntu_install_arduino.sh
+++ b/docker/install/ubuntu_install_arduino.sh
@@ -24,9 +24,8 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update --fix-missing
 apt-get install -y ca-certificates
 
-# Install arduino-cli
-ARDUINO_SDK_VERSION=0.18.3
-wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s ${ARDUINO_SDK_VERSION}
+# Install arduino-cli latest version
+wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s
 
 # Board manager URLs, separated by semicolons
 BOARD_MANAGER_URLS=https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json

--- a/docker/install/ubuntu_install_arduino.sh
+++ b/docker/install/ubuntu_install_arduino.sh
@@ -21,7 +21,6 @@ set -u
 set -o pipefail
 
 export DEBIAN_FRONTEND=noninteractive
-apt-get update --fix-missing
 apt-get install -y ca-certificates
 
 # Install arduino-cli latest version


### PR DESCRIPTION
When merging Arduino support from #8493, we'd like to be able to add unit tests. Since no simulators exist for any of the boards we currently support, we will only be able to test project generation and compilation.

Specifically, this PR adds an `ubuntu_install_arduino.sh` script that installs `arduino-cli` via `wget` (as recommended) and then downloads the SDKs for two of the boards we support.