### PR TITLE
[TensorRT, BYOC] Handling a corner case in TRT RemoveDropout pass

### DIFF
--- a/python/tvm/relay/op/contrib/tensorrt.py
+++ b/python/tvm/relay/op/contrib/tensorrt.py
@@ -22,7 +22,7 @@ import tvm
 from tvm import relay
 from tvm.relay import transform
 from tvm.relay.build_module import bind_params_by_name
-from tvm.relay.expr import Call, Constant, Tuple, GlobalVar, Var, TupleGetItem
+from tvm.relay.expr import Call, Constant, Tuple, GlobalVar, Var, TupleGetItem, Let
 from tvm.relay.expr_functor import ExprMutator, ExprVisitor
 
 logger = logging.getLogger("TensorRT")
@@ -1032,6 +1032,8 @@ class RemoveDropout(ExprMutator):
     def visit_tuple_getitem(self, op):
         visit = super().visit_tuple_getitem(op)
         if visit.index != 0:
+            return visit
+        if isinstance(visit.tuple_value, Call) and isinstance(visit.tuple_value.op, Let):
             return visit
         if (
             isinstance(visit.tuple_value, Call)

--- a/python/tvm/relay/op/contrib/tensorrt.py
+++ b/python/tvm/relay/op/contrib/tensorrt.py
@@ -22,7 +22,8 @@ import tvm
 from tvm import relay
 from tvm.relay import transform
 from tvm.relay.build_module import bind_params_by_name
-from tvm.relay.expr import Call, Constant, Tuple, GlobalVar, Var, TupleGetItem, Let
+from tvm.relay.expr import Call, Constant, Tuple, GlobalVar, Var, TupleGetItem
+from tvm.ir import Op
 from tvm.relay.expr_functor import ExprMutator, ExprVisitor
 
 logger = logging.getLogger("TensorRT")
@@ -1033,10 +1034,9 @@ class RemoveDropout(ExprMutator):
         visit = super().visit_tuple_getitem(op)
         if visit.index != 0:
             return visit
-        if isinstance(visit.tuple_value, Call) and isinstance(visit.tuple_value.op, Let):
-            return visit
         if (
             isinstance(visit.tuple_value, Call)
+            and isinstance(visit.tuple_value.op, Op)
             and visit.tuple_value.op.name == "nn.dropout"
             and visit.index == 0
         ):


### PR DESCRIPTION
This commit handles a corner case in TRT RemoveDropout pass. This avoids an error like below

```
File "/home/ubuntu/workspace/tvm/python/tvm/runtime/object.py", line 65, in __getattr__
    raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
AttributeError: relay.Let object has no attributed name
During handling of the above exception, another exception occurred:
AttributeError: <class 'tvm.relay.expr.Let'> has no attribute name 
```
