### PR TITLE
Organize CodeOwners File

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,58 +26,30 @@
 # We normally recommend committers to shepherd code in their area of expertise.
 *        @apache/tvm-committers
 
+# Order is important; the last matching pattern takes the most precedence.
+# The sub modules should be ordered first by depth.
+# Making sure we append new sub-module rules after exisiting modules rules.
 
-# automation related
-**/auto_scheduler/**  @merrymercy @jcf94 @comaniac @junrushao1994 @vinx13
-**/autotvm/**  @merrymercy @jcf94 @comaniac @junrushao1994 @vinx13
+##############################
+# Top-level Fallbacks
+##############################
+include/**  @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
+src/** @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
+apps/** @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
+python/** @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
 
-# TIR
-**/tir/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+# Thirdparty license audit
+3rdparty/**  @tqchen @jroesch
+licenses/**  @tqchen @jroesch
 
-# TE
-**/te/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+# JVM language
+jvm/**   @yzhliu
 
-# Target
-**/target/**  @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi
+# Golang
+golang/** @srkreddy1238
 
-# ARITH and simplifier
-**/arith/** @tqchen @junrushao1994 @vinx13
-
-# parser
-**/parser/** @jroesch @slyubomirsky
-
-# Runtime
-**/runtime/**  @vinx13 @tqchen @FronzenGene @liangfu @areusch @tmoreau89 @ajtulloch @masahi @kazum @ZihengJiang  @junrushao1994
-
-# micro TVM
-**/micro/** @areusch @liangfu @tmoreau89
-
-
-# VTA
-vta/**    @tmoreau89 @vegaluisjose
-
-
-# relay
-**/relay/** @jroesch @slyubomirsky @icemelon9 @MarisaKirisame @ZihengJiang @yzhliu @vinx13 @mbrookhart @jwfromm @zhiics @anijain2305 @wweic @eqy @junrushao1994
-
-
-# quantization and QNN
-**/qnn/**  @jwfromm @anijain2305 @ZihengJiang
-
-
-# BYOC
-src/relay/backend/contrib/** @zhiics @trevor-m @comaniac @mbaret
-
-
-# TOPI
-**/topi/**  @Laurawly @Huyuwei @kevinthesun @jwfromm @vinx13 @masahi @FronzenGene @yzhliu @mbrookhart @ZihengJiang @jcf94 
-
-# frontends
-python/tvm/relay/frontend/**  @jwfromm @mbrookhart @srkreddy1238 @siju-samuel @Huyuwei @hlu1 @kazum @PariksheetPinjari909
-
-
-# TVMC
-python/tvm/driver/tvmc/**  @leandron
+# WASM
+web/** @tqchen @jroesch
 
 # Docker
 docker/** @areusch @leandron @jroesch
@@ -91,30 +63,96 @@ cmake/** @jroesch @tqchen @areusch @junrushao1994 @comaniac
 # rust bindings
 rust/** @jroesch @nhynes @nhynes
 
+# vta
+vta/**    @tmoreau89 @vegaluisjose
+
 # docs
 docs/**  @comaniac @junrushao1994 @tqchen @jroesch @areusch @yzhliu @merrymercy @icemelon9
 tutorials/**  @comaniac @junrushao1994 @tqchen @jroesch @areusch @yzhliu @merrymercy @icemelon9
 
-# Tests
+# tests
 tests/**  @comaniac @junrushao1994 @tqchen @jroesch @areusch @yzhliu @merrymercy @icemelon9
 
-# JVM language
-jvm/**   @yzhliu
+##############################
+# Specific modules
+##############################
 
-# Golang
-golang/** @srkreddy1238
+# automation related
+src/auto_scheduler/**  @merrymercy @jcf94 @comaniac @junrushao1994 @vinx13
+include/tvm/auto_scheduler/**  @merrymercy @jcf94 @comaniac @junrushao1994 @vinx13
+python/tvm/auto_scheduler/**  @merrymercy @jcf94 @comaniac @junrushao1994 @vinx13
+
+python/tvm/autotvm/**  @merrymercy @jcf94 @comaniac @junrushao1994 @vinx13
+
+# node system and reflection
+src/node/**      @junrushao1994 @vinx13 @tqchen @jroesch @comaniac
+include/tvm/node/**      @junrushao1994 @vinx13 @tqchen @jroesch @comaniac
+
+# ir: Common IR
+src/ir/**      @junrushao1994 @vinx13 @tqchen @jroesch @comaniac
+include/tvm/ir/**      @junrushao1994 @vinx13 @tqchen @jroesch @comaniac
+python/tvm/ir/**      @junrushao1994 @vinx13 @tqchen @jroesch @comaniac
+
+# tir
+src/tir/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+include/tvm/tir/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+python/tvm/tir/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+
+# te
+src/te/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+include/tvm/te/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+python/tvm/te/**      @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi @were
+
+# target
+src/target/**  @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi
+include/tvm/target/**  @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi
+python/tvm/target/**  @junrushao1994 @vinx13 @tqchen @kparzysz-quic @ZihengJiang @masahi
+
+# arith: Arithmetic module and simplifiers
+src/arith/** @tqchen @junrushao1994 @vinx13
+include/tvm/arith/** @tqchen @junrushao1994 @vinx13
+python/tvm/arith/** @tqchen @junrushao1994 @vinx13
+
+# parser
+src/parser/** @jroesch @slyubomirsky
+
+# runtime
+src/runtime/**  @vinx13 @tqchen @FronzenGene @liangfu @areusch @tmoreau89 @ajtulloch @masahi @kazum @ZihengJiang  @junrushao1994
+include/tvm/runtime/**  @vinx13 @tqchen @FronzenGene @liangfu @areusch @tmoreau89 @ajtulloch @masahi @kazum @ZihengJiang  @junrushao1994
+python/tvm/runtime/**  @vinx13 @tqchen @FronzenGene @liangfu @areusch @tmoreau89 @ajtulloch @masahi @kazum @ZihengJiang  @junrushao1994
+
+# runtime/micro
+src/runtime/micro/** @areusch @liangfu @tmoreau89
+src/runtime/crt/** @areusch @liangfu @tmoreau89
+include/tvm/runtime/crt/** @areusch @liangfu @tmoreau89
+include/tvm/runtime/micro/** @areusch @liangfu @tmoreau89
+python/tvm/micro/** @areusch @liangfu @tmoreau89
+
+# relay
+src/relay/** @jroesch @slyubomirsky @icemelon9 @MarisaKirisame @ZihengJiang @yzhliu @vinx13 @mbrookhart @jwfromm @zhiics @anijain2305 @wweic @eqy @junrushao1994
+include/tvm/relay/** @jroesch @slyubomirsky @icemelon9 @MarisaKirisame @ZihengJiang @yzhliu @vinx13 @mbrookhart @jwfromm @zhiics @anijain2305 @wweic @eqy @junrushao1994
+python/tvm/relay/** @jroesch @slyubomirsky @icemelon9 @MarisaKirisame @ZihengJiang @yzhliu @vinx13 @mbrookhart @jwfromm @zhiics @anijain2305 @wweic @eqy @junrushao1994
 
 
-# WASM
-web/** @tqchen @jroesch
+# relay/qnn
+src/relay/qnn/**  @jwfromm @anijain2305 @ZihengJiang
+inlcude/tvm/relay/qnn/**  @jwfromm @anijain2305 @ZihengJiang
+python/tvm/relay/qnn/**  @jwfromm @anijain2305 @ZihengJiang
+
+# relay/backend/contrib: BYOC
+src/relay/backend/contrib/** @zhiics @trevor-m @comaniac @mbaret
+
+# relay/frontends
+python/tvm/relay/frontend/**  @jwfromm @mbrookhart @srkreddy1238 @siju-samuel @Huyuwei @hlu1 @kazum @PariksheetPinjari909
+
+# topi: Operator definitions
+src/topi/**  @Laurawly @Huyuwei @kevinthesun @jwfromm @vinx13 @masahi @FronzenGene @yzhliu @mbrookhart @ZihengJiang @jcf94
+include/tvm/topi/**  @Laurawly @Huyuwei @kevinthesun @jwfromm @vinx13 @masahi @FronzenGene @yzhliu @mbrookhart @ZihengJiang @jcf94
+python/tvm/topi/**  @Laurawly @Huyuwei @kevinthesun @jwfromm @vinx13 @masahi @FronzenGene @yzhliu @mbrookhart @ZihengJiang @jcf94
 
 
-# Fallbacks
-include/**  @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
-src/** @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
-apps/** @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
-python/** @tqchen @jroesch @yzhliu @icemelon9 @junrushao1994 @comaniac @zhiics
+# tvm/driver/
+python/tvm/driver/**  @leandron @jwfromm @tqchen @jroesch
 
-# Thirdparty license audit
-3rdparty/**  @tqchen @jroesch
-licenses/**  @tqchen @jroesch
+# tvm/driver/tvmc
+python/tvm/driver/tvmc/**  @leandron @jwfromm


### PR DESCRIPTION
- Order is important; the last matching pattern takes the most precedence.
- Explicit list all the prefix so the pattern matches the folder prefix patterns