### PR TITLE
Docker env for Arm® Ethos™-U55 Port

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -109,3 +109,13 @@ RUN bash /install/ubuntu_install_androidsdk.sh
 ENV ANDROID_HOME=/opt/android-sdk-linux/
 ENV ANDROID_NDK_HOME=/opt/android-sdk-linux/ndk/21.3.6528147/
 
+# Arm(R) Ethos(TM)-U NPU driver
+COPY install/ubuntu_install_ethosu_driver_stack.sh /install/ubuntu_install_ethosu_driver_stack.sh
+RUN bash /install/ubuntu_install_ethosu_driver_stack.sh
+
+# Install Vela compiler
+COPY install/ubuntu_install_vela.sh /install/ubuntu_install_vela.sh
+RUN bash /install/ubuntu_install_vela.sh
+
+# Update PATH
+ENV PATH /opt/arm/bin:/opt/arm/cmake/bin:/opt/arm/gcc-arm-none-eabi/bin:$PATH

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -118,4 +118,4 @@ COPY install/ubuntu_install_vela.sh /install/ubuntu_install_vela.sh
 RUN bash /install/ubuntu_install_vela.sh
 
 # Update PATH
-ENV PATH /opt/arm/bin:/opt/arm/gcc-arm-none-eabi/bin:$PATH
+ENV PATH /opt/arm/gcc-arm-none-eabi/bin:$PATH

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -118,4 +118,4 @@ COPY install/ubuntu_install_vela.sh /install/ubuntu_install_vela.sh
 RUN bash /install/ubuntu_install_vela.sh
 
 # Update PATH
-ENV PATH /opt/arm/bin:/opt/arm/cmake/bin:/opt/arm/gcc-arm-none-eabi/bin:$PATH
+ENV PATH /opt/arm/bin:/opt/arm/gcc-arm-none-eabi/bin:$PATH

--- a/docker/install/ubuntu_install_ethosu_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosu_driver_stack.sh
@@ -24,6 +24,7 @@ fvp_dir="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
 cmake_dir="/opt/arm/cmake"
 ethosu_dir="/opt/arm/ethosu"
 ethosu_driver_ver="21.05"
+cmsis_ver="5.7.0"
 
 mkdir -p /opt/arm
 
@@ -75,7 +76,6 @@ curl --retry 64 -sSL ${gcc_arm_url} | tar -C /opt/arm/gcc-arm-none-eabi --strip-
 export PATH="/opt/arm/gcc-arm-none-eabi/bin:${PATH}"
 
 # Clone Arm(R) Ethos(TM)-U NPU driver stack
-cd /
 mkdir "${ethosu_dir}"
 cd "${ethosu_dir}"
 git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver" core_driver
@@ -91,4 +91,4 @@ git checkout tags/${ethosu_driver_ver}
 cd "${ethosu_dir}"
 git clone "https://github.com/ARM-software/CMSIS_5.git" cmsis
 cd cmsis
-git checkout -f tags/5.7.0
+git checkout -f tags/${cmsis_ver}

--- a/docker/install/ubuntu_install_ethosu_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosu_driver_stack.sh
@@ -23,6 +23,7 @@ set -o pipefail
 fvp_dir="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
 cmake_dir="/opt/arm/cmake"
 ethosu_dir="/opt/arm/ethosu"
+ethosu_driver_ver="21.05"
 
 mkdir -p /opt/arm
 
@@ -79,12 +80,12 @@ mkdir "${ethosu_dir}"
 cd "${ethosu_dir}"
 git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver" core_driver
 cd core_driver
-git checkout tags/21.05
+git checkout tags/${ethosu_driver_ver}
 
 cd "${ethosu_dir}"
 git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-platform" core_platform
 cd core_platform
-git checkout tags/21.05
+git checkout tags/${ethosu_driver_ver}
 
 # Clone CMSIS
 cd "${ethosu_dir}"

--- a/docker/install/ubuntu_install_ethosu_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosu_driver_stack.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+fvp_dir="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
+cmake_dir="/opt/arm/cmake"
+ethosu_dir="/opt/arm/ethosu"
+
+mkdir -p /opt/arm
+
+tmpdir=$(mktemp -d)
+
+cleanup()
+{
+  rm -rf "$tmpdir"
+}
+
+trap cleanup 0
+
+# Ubuntu 18.04 dependencies
+apt-get update
+
+apt-get install -y \
+    bsdmainutils \
+    build-essential \
+    cpp \
+    git \
+    linux-headers-generic \
+    make \
+    python-dev \
+    python3 \
+    ssh \
+    wget \
+    xxd
+
+# Download the FVP
+mkdir -p "$fvp_dir"
+cd "$tmpdir"
+curl -sL https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/MPS3/FVP_Corstone_SSE-300_Ethos-U55_11.14_24.tgz | tar -xz
+./FVP_Corstone_SSE-300_Ethos-U55.sh --i-agree-to-the-contained-eula --no-interactive -d "$fvp_dir"
+rm -rf FVP_Corstone_SSE-300_Ethos-U55.sh license_terms
+
+# Setup cmake 3.19.5
+mkdir -p "${cmake_dir}"
+cd "$tmpdir"
+curl -sL -o cmake-3.19.5-Linux-x86_64.sh https://github.com/Kitware/CMake/releases/download/v3.19.5/cmake-3.19.5-Linux-x86_64.sh
+chmod +x cmake-3.19.5-Linux-x86_64.sh
+./cmake-3.19.5-Linux-x86_64.sh --prefix="${cmake_dir}" --skip-license
+rm cmake-3.19.5-Linux-x86_64.sh
+export PATH="${cmake_dir}/bin:${PATH}"
+
+# Install the GCC toolchain
+mkdir -p /opt/arm/gcc-arm-none-eabi/
+gcc_arm_url='https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2?revision=ca0cbf9c-9de2-491c-ac48-898b5bbc0443&la=en&hash=68760A8AE66026BCF99F05AC017A6A50C6FD832A'
+curl --retry 64 -sSL ${gcc_arm_url} | tar -C /opt/arm/gcc-arm-none-eabi --strip-components=1 -jx
+export PATH="/opt/arm/gcc-arm-none-eabi/bin:${PATH}"
+
+# Clone Arm(R) Ethos(TM)-U NPU driver stack
+cd /
+mkdir "${ethosu_dir}"
+cd "${ethosu_dir}"
+git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver" core_driver
+cd core_driver
+git checkout tags/21.05
+
+cd "${ethosu_dir}"
+git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-platform" core_platform
+cd core_platform
+git checkout tags/21.05
+
+# Clone CMSIS
+cd "${ethosu_dir}"
+git clone "https://github.com/ARM-software/CMSIS_5.git" cmsis
+cd cmsis
+git checkout -f tags/5.7.0

--- a/docker/install/ubuntu_install_vela.sh
+++ b/docker/install/ubuntu_install_vela.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+pip3 install -U setuptools
+pip3 install ethos-u-vela==2.1.1

--- a/docker/install/ubuntu_install_vela.sh
+++ b/docker/install/ubuntu_install_vela.sh
@@ -21,4 +21,7 @@ set -u
 set -o pipefail
 
 pip3 install -U setuptools
+# In a refactor between v2.1.1 and v3.0.0, find_block_configs <appropriate function name> was removed from Vela.
+# Since this is still required for the TVM port, it will be reinstated in Vela in a future release.
+# Until then, it needs to be pinned to v2.1.1.
 pip3 install ethos-u-vela==2.1.1

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -75,6 +75,16 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
             ],
         ),
     ),
+    # Provide support for Arm(R) Ethos(TM)-U NPU.
+    (
+        "ethosu",
+        (
+            "Requirements for using Arm(R) Ethos(TM)-U NPU",
+            [
+                "ethos-u-vela",
+            ],
+        ),
+    ),
     # Relay frontends.
     (
         "importer-caffe2",
@@ -205,6 +215,7 @@ CONSTRAINTS = [
         "docutils",
         "<0.17",
     ),  # Work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+    ("ethos-u-vela", "==2.1.1"),
     ("future", None),
     ("image", None),
     ("matplotlib", None),


### PR DESCRIPTION
This is the first PR for the Arm Ethos-U Integration RFC (https://github.com/apache/tvm-rfcs/pull/11)

* Added Arm® Corstone™-300 Reference System for testing
* Added Arm® Ethos™-U driver stack
* Added installation of Arm® Vela.

Co-authored-by: Manupa Karunaratne <manupa.karunaratne@arm.com>

@manupa-arm @areusch @Mousius 

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
