### PR TITLE
[Docker][QEMU] Remove QEMU Install

### DIFF
--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -26,7 +26,7 @@ RUN bash /install/ubuntu_install_core.sh
 
 COPY install/ubuntu1804_install_python_venv.sh /install/ubuntu1804_install_python_venv.sh
 RUN bash /install/ubuntu1804_install_python_venv.sh
-ENV PATH=/opt/tvm-venv/bin:$PATH
+ENV PATH=/opt/tvm-venv/bin:/opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
 
 COPY install/ubuntu_install_python_package.sh /install/ubuntu_install_python_package.sh
 RUN bash /install/ubuntu_install_python_package.sh
@@ -55,10 +55,6 @@ RUN bash /install/ubuntu_install_tensorflow.sh
 # TFLite deps
 COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh
 RUN bash /install/ubuntu_install_tflite.sh
-
-# QEMU deps
-COPY install/ubuntu_install_qemu.sh /install/ubuntu_install_qemu.sh
-RUN bash /install/ubuntu_install_qemu.sh
 
 # Zephyr SDK deps
 COPY install/ubuntu_install_zephyr.sh /install/ubuntu_install_zephyr.sh


### PR DESCRIPTION
Zephyr SDK has binary files for different qemu versions which are developed by Zephyr and we can use them for our qemu tests. We just need to add the binary path to PATH to enable them.
Zephyr SDK also has more qemu versions which enable us to test other boards such as [cortex-r5](https://docs.zephyrproject.org/latest/boards/arm/qemu_cortex_r5/doc/index.html).

I have rebuilt the docker image and it passes all tests.

cc @areusch @leandron 