### PR TITLE
[Bugfix] Visit each input param of the function in ExprVisitor visit_function

### DIFF
--- a/python/tvm/relay/expr_functor.py
+++ b/python/tvm/relay/expr_functor.py
@@ -152,8 +152,10 @@ class ExprVisitor(ExprFunctor):
         self.visit(let.value)
         self.visit(let.body)
 
-    def visit_function(self, f):
-        self.visit(f.body)
+    def visit_function(self, fn):
+        for x in fn.params:
+            self.visit(x)
+        self.visit(fn.body)
 
     def visit_if(self, i):
         self.visit(i.cond)


### PR DESCRIPTION
In the `ExprMutator` the `visit_function` https://github.com/apache/tvm/blob/main/python/tvm/relay/expr_functor.py#L203will visit each input param while in `ExprVisitor` it doesn't https://github.com/apache/tvm/blob/main/python/tvm/relay/expr_functor.py#L155.

This PR added visitation for each input param in `ExprVisitor`'s `visit_function`.

cc @comaniac 