### PR TITLE
[Bugfix] Preserve IRModule type definition and imports in NameMangleExtFuncs

### DIFF
--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -509,7 +509,7 @@ class NameMangleExtFuncs : public MixedModeMutator {
 
     // Walk the tree and mangle the functions. Then replace compiler functions
     // with mangled functions in the module
-    IRModule new_module;
+    IRModule new_module = IRModule({}, module_->type_definitions, module_->Imports());
     for (const auto& pair : glob_funcs) {
       if (auto* fn = pair.second.as<FunctionNode>()) {
         auto func = GetRef<Function>(fn);

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -1440,7 +1440,7 @@ def test_extern_opt():
 
 
 def test_preserve_type_import():
-    """Test to make sure type definition and imports are preserved during the BYOC pipeline"""
+    """Test to make sure type definition and imports are preserved during the BYOC pipeline."""
     from tvm.relay.prelude import Prelude, StaticTensorArrayOps
 
     def run(dtype, shape):

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -1439,8 +1439,8 @@ def test_extern_opt():
     tvm.testing.assert_allclose(t0.body.data.numpy(), expected, rtol=1e-5, atol=1e-5)
 
 
-# Test to make sure type definition and imports are preserved during the BYOC pipeline
-def test_static_tensor_array_gather_partition():
+def test_preserve_type_import():
+    """Test to make sure type definition and imports are preserved during the BYOC pipeline"""
     from tvm.relay.prelude import Prelude, StaticTensorArrayOps
 
     def run(dtype, shape):

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -1439,6 +1439,34 @@ def test_extern_opt():
     tvm.testing.assert_allclose(t0.body.data.numpy(), expected, rtol=1e-5, atol=1e-5)
 
 
+# Test to make sure type definition and imports are preserved during the BYOC pipeline
+def test_static_tensor_array_gather_partition():
+    from tvm.relay.prelude import Prelude, StaticTensorArrayOps
+
+    def run(dtype, shape):
+        mod = tvm.IRModule()
+        p = Prelude(mod)
+        static_tensor_array_ops = StaticTensorArrayOps(p, dtype, shape)
+        static_tensor_array_ops.register()
+
+        tensor_array = p.get_global_var_static("tensor_array", dtype, shape)
+        tensor = p.get_tensor_ctor_static("tensor_constructor", dtype, shape)
+        write = p.get_global_var_static("tensor_array_write", dtype, shape)
+        gather = p.get_global_var_static("tensor_array_gather", dtype, shape)
+        v = relay.var("v")
+        indice = relay.var("indice")
+        init_tensor_array = tensor_array(relay.const(3))
+        tensor_array1 = write(init_tensor_array, relay.const(0), tensor(v))
+        tensor_array2 = write(tensor_array1, relay.const(1), tensor(v))
+        tensor_array3 = write(tensor_array2, relay.const(2), tensor(v))
+        out = gather(tensor_array3, indice)
+        mod["main"] = relay.Function([v, indice], out)
+        mod = transform.RemoveUnusedFunctions()(mod)
+        mod = transform.PartitionGraph()(mod)
+
+    run("float32", [2, 3])
+
+
 if __name__ == "__main__":
     test_multi_node_compiler()
     test_extern_ccompiler_single_op()
@@ -1460,3 +1488,4 @@ if __name__ == "__main__":
     test_flatten_tuple_output()
     test_tuple_output_exec()
     test_extern_opt()
+    test_static_tensor_array_gather_partition()

--- a/tests/python/relay/test_tensor_array.py
+++ b/tests/python/relay/test_tensor_array.py
@@ -780,32 +780,5 @@ def test_static_tensor_get_data():
     run("int32", [2, 3])
 
 
-@tvm.testing.uses_gpu
-def test_static_tensor_array_gather_partition():
-    def run(dtype, shape):
-        mod = tvm.IRModule()
-        p = Prelude(mod)
-        static_tensor_array_ops = StaticTensorArrayOps(p, dtype, shape)
-        static_tensor_array_ops.register()
-
-        tensor_array = p.get_global_var_static("tensor_array", dtype, shape)
-        tensor = p.get_tensor_ctor_static("tensor_constructor", dtype, shape)
-        write = p.get_global_var_static("tensor_array_write", dtype, shape)
-        gather = p.get_global_var_static("tensor_array_gather", dtype, shape)
-        v = relay.var("v")
-        indice = relay.var("indice")
-        init_tensor_array = tensor_array(relay.const(3))
-        tensor_array1 = write(init_tensor_array, relay.const(0), tensor(v))
-        tensor_array2 = write(tensor_array1, relay.const(1), tensor(v))
-        tensor_array3 = write(tensor_array2, relay.const(2), tensor(v))
-        out = gather(tensor_array3, indice)
-        mod["main"] = relay.Function([v, indice], out)
-        from tvm.relay.op.contrib.tensorrt import partition_for_tensorrt
-
-        mod, config = partition_for_tensorrt(mod, params=None, remove_no_mac_subgraphs=True)
-
-    run("float32", [2, 3])
-
-
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
When calling graph_partition pass on tensoraay ops, it fails with error```Check failed: (it != type_definitions.end()) is false: There is no definition of static_tensor_float32_any_2_3_t``` This is introduced by #8014.

This fix imports type definations from old module when craeting a new module in NameMangleExtFuncs.



cc @comaniac
