### PR TITLE
[RPC] Add explicit type cast to print.

### DIFF
--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -327,7 +327,7 @@ class TrackerSession(object):
         res += "----------------------------\n"
         for item in data["server_info"]:
             addr = item["addr"]
-            res += addr[0] + ":" + str(addr[1]) + "\t"
+            res += str(addr[0]) + ":" + str(addr[1]) + "\t"
             res += item["key"] + "\n"
             key = item["key"].split(":")[1]  # 'server:rasp3b` -> 'rasp3b'
             if key not in total_ct:


### PR DESCRIPTION
This little one liner adds a string cast to a print statement in the RPC query code. Occasionally there isn't an IP address reported by the RPC causing the string concatenate to fail due to a Nonetype. Adding a cast avoids the error and is good form in general.
