### PR TITLE
[Bugfix] fix android rpc app undefined reference problem

### DIFF
--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -34,6 +34,7 @@
 #define TVM_LOG_CUSTOMIZE 1
 
 #include "../src/runtime/c_runtime_api.cc"
+#include "../src/runtime/container.cc"
 #include "../src/runtime/cpu_device_api.cc"
 #include "../src/runtime/dso_library.cc"
 #include "../src/runtime/file_utils.cc"


### PR DESCRIPTION
Hi I meet the same problem as this [link](https://discuss.tvm.apache.org/t/failed-to-build-android-rpc/10410).
And I found it is caused by missing include /src/runtime/container.cc