### PR TITLE
[Contrib] Added default non-verbose to download_testdata(), pass to download()

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -178,7 +178,7 @@ def download_package(tophub_location, package_name):
 
     download_url = "{0}/{1}".format(tophub_location, package_name)
     logger.info("Download pre-tuned parameters package from %s", download_url)
-    download(download_url, Path(rootpath, package_name), True, verbose=0)
+    download(download_url, Path(rootpath, package_name), overwrite=True)
 
 
 # global cache for load_reference_log

--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -19,6 +19,7 @@
 import logging
 import os
 from pathlib import Path
+import shutil
 import tempfile
 import time
 
@@ -110,7 +111,13 @@ def download(url, path, overwrite=False, size_compare=False, retries=3):
 
                 urllib2.urlretrieve(url, download_loc, reporthook=_download_progress)
                 LOG.debug("")
-                download_loc.rename(path)
+                try:
+                    download_loc.rename(path)
+                except OSError:
+                    # Prefer a move, but if the tempdir and final
+                    # location are in different drives, fall back to a
+                    # copy.
+                    shutil.copy2(download_loc, path)
                 return
 
             except Exception as err:


### PR DESCRIPTION
Intent is to make this utility easier to use in one-off debugging scripts, where extra print statements may make it harder to track down bugs.  Did a small bit of cleanup as well, while I was in the file.

- Use tempfile.TemporaryDirectory instead of explicit cleanup.

- Pass through verbose/retries arguments if replacing a corrupted copy.