### PR TITLE
[TOPI] Fix `nn.pool*d` issue with 'vectorize' function and add unit tests

### DIFF
--- a/python/tvm/topi/testing/poolnd_python.py
+++ b/python/tvm/topi/testing/poolnd_python.py
@@ -90,8 +90,16 @@ def poolnd_python(
     count_include_pad: bool = True,
     ceil_mode: bool = False,
     dtype: str = "float32",
+    channel_last: bool = False,
 ) -> np.array:
     """Ground truth pooling operator impelmented in numpy."""
+    if channel_last:
+        # Transpose data
+        new_shape = [i for i in range(np_data.ndim)]
+        last_dim = new_shape.pop()
+        new_shape.insert(1, last_dim)
+        np_data = np_data.transpose(new_shape)
+
     out_shape = [np_data.shape[0], np_data.shape[1]]
     for dim in range(2, len(np_data.shape)):
         i = dim - 2
@@ -158,4 +166,10 @@ def poolnd_python(
         else:
             raise ValueError("Pool type {} is not supported".format(pool_type))
 
+    if channel_last:
+        # Transpose back data
+        new_shape = [i for i in range(np_data.ndim)]
+        new_shape.remove(1)
+        new_shape.append(1)
+        ret_np = ret_np.transpose(new_shape)
     return ret_np

--- a/python/tvm/topi/testing/poolnd_python.py
+++ b/python/tvm/topi/testing/poolnd_python.py
@@ -32,46 +32,44 @@ def _get_supported_layout(dims: int):
     assert dims in [3, 4, 5], f"{dims}-dimensional tensor is not supported"
     if dims == 3:
         return "NCW"
-    elif dims == 4:
+    if dims == 4:
         return "NCHW"
-    elif dims == 5:
-        return "NCDHW"
+    # dims == 5
+    return "NCDHW"
 
 
 def _convert_to_layout(
-    input: np.ndarray,
+    input_tensor: np.ndarray,
     layout: str,
 ) -> np.ndarray:
     """
     Converts back to original layout after the algorithm is finished
     """
-    supported_layout = _get_supported_layout(input.ndim)
+    supported_layout = _get_supported_layout(input_tensor.ndim)
     if layout is not None and supported_layout != layout:
         # Generate transpose list
         transpose_list = []
         for d in layout:
             transpose_list.append(supported_layout.index(d))
-        return input.transpose(transpose_list)
-    else:
-        return input
+        return input_tensor.transpose(transpose_list)
+    return input_tensor
 
 
 def _convert_from_layout(
-    input: np.ndarray,
+    input_tensor: np.ndarray,
     layout: str,
 ) -> np.ndarray:
     """
     Converts tensor to one of suppored layouts
     """
-    supported_layout = _get_supported_layout(input.ndim)
+    supported_layout = _get_supported_layout(input_tensor.ndim)
     if layout is not None and supported_layout != layout:
         # Generate transpose list
         transpose_list = []
         for d in supported_layout:
             transpose_list.append(layout.index(d))
-        return input.transpose(transpose_list)
-    else:
-        return input
+        return input_tensor.transpose(transpose_list)
+    return input_tensor
 
 
 def get_slice(

--- a/python/tvm/topi/x86/pooling.py
+++ b/python/tvm/topi/x86/pooling.py
@@ -26,8 +26,8 @@ def _parallel_sch(sch, oshape, do_vectorize=False):
         reorder_axis = [fused_axis]
         for i in range(num_parallel_axis, len(sch.op.axis) - 1):
             reorder_axis.append(sch.op.axis[i])
-        kw, kh = sch.op.reduce_axis
-        fuse_k = sch.fuse(kw, kh)
+        k = sch.op.reduce_axis
+        fuse_k = sch.fuse(*k)
         c = sch.op.axis[len(sch.op.axis) - 1]
         reorder_axis += [fuse_k, c]
         sch.reorder(*reorder_axis)
@@ -83,7 +83,7 @@ def schedule_pool(outs, layout):
     def _schedule(PaddedInput, Pool):
         if isinstance(PaddedInput.op, te.tensor.ComputeOp):
             s[PaddedInput].compute_inline()
-        do_vectorize = layout[-1] not in "HWhw"
+        do_vectorize = layout[-1] not in "DHWdhw"
         _parallel_sch(s[Pool], outs[0].shape, do_vectorize)
 
     def traverse(OP):

--- a/tests/python/topi/python/test_topi_pooling.py
+++ b/tests/python/topi/python/test_topi_pooling.py
@@ -305,7 +305,6 @@ def verify_poolnd(
 
     padding_before = padding[:n]
     padding_after = padding[n:]
-    channel_last = layout[-1] == 'C'
     ref_np = tvm.topi.testing.poolnd_python(
         input_np,
         kernel,
@@ -316,7 +315,7 @@ def verify_poolnd(
         pool_type,
         count_include_pad,
         ceil_mode,
-        channel_last=channel_last,
+        layout=layout,
     )
 
     np.testing.assert_equal(tuple(output_shape), tuple(ref_np.shape))

--- a/tests/python/topi/python/test_topi_pooling.py
+++ b/tests/python/topi/python/test_topi_pooling.py
@@ -365,24 +365,10 @@ def verify_pool3d(
 def test_pool3d():
     """test cases of pool3d"""
     verify_pool3d(
-        [1, 16, 32, 32, 32],
-        [2, 2, 2],
-        [2, 2, 2],
-        [1, 1, 1],
-        [0, 0, 0, 0, 0, 0],
-        "avg",
-        False,
-        True,
+        [1, 16, 32, 32, 32], [2, 2, 2], [2, 2, 2], [1, 1, 1], [0, 0, 0, 0, 0, 0], "avg", False, True
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [1, 1, 1],
-        [1, 1, 2, 2, 2, 1],
-        "avg",
-        False,
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [1, 1, 1], [1, 1, 2, 2, 2, 1], "avg", False, True
     )
     verify_pool3d(
         [1, 16, 32, 32, 32],
@@ -415,42 +401,17 @@ def test_pool3d():
         False,
     )
     verify_pool3d(
-        [1, 16, 32, 32, 32],
-        [2, 2, 2],
-        [2, 2, 2],
-        [1, 1, 1],
-        [0, 0, 0, 0, 0, 0],
-        "max",
-        False,
+        [1, 16, 32, 32, 32], [2, 2, 2], [2, 2, 2], [1, 1, 1], [0, 0, 0, 0, 0, 0], "max", False
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [1, 1, 1],
-        [2, 2, 1, 1, 1, 2],
-        "max",
-        False,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [1, 1, 1], [2, 2, 1, 1, 1, 2], "max", False
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [1, 1, 1],
-        [2, 2, 1, 1, 1, 2],
-        "max",
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [1, 1, 1], [2, 2, 1, 1, 1, 2], "max", True
     )
 
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [1, 1, 1],
-        [2, 1, 0, 5, 4, 3],
-        "avg",
-        False,
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [1, 1, 1], [2, 1, 0, 5, 4, 3], "avg", False, True
     )
     verify_pool3d(
         [1, 16, 32, 32, 32],
@@ -463,34 +424,15 @@ def test_pool3d():
         False,
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [1, 1, 1],
-        [1, 0, 5, 4, 3, 2],
-        "max",
-        False,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [1, 1, 1], [1, 0, 5, 4, 3, 2], "max", False
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [1, 1, 1],
-        [3, 2, 1, 0, 5, 4],
-        "max",
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [1, 1, 1], [3, 2, 1, 0, 5, 4], "max", True
     )
 
     # Test non-1 dilation
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [3, 3, 3],
-        [2, 1, 0, 5, 4, 3],
-        "avg",
-        False,
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [3, 3, 3], [2, 1, 0, 5, 4, 3], "avg", False, True
     )
     verify_pool3d(
         [1, 16, 32, 32, 32],
@@ -503,22 +445,10 @@ def test_pool3d():
         False,
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [2, 1, 3],
-        [1, 0, 5, 4, 3, 2],
-        "max",
-        False,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [2, 1, 3], [1, 0, 5, 4, 3, 2], "max", False
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [2, 2, 3],
-        [3, 2, 1, 0, 5, 4],
-        "max",
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [2, 2, 3], [3, 2, 1, 0, 5, 4], "max", True
     )
     # Test channel last layouts
     verify_pool3d(
@@ -652,14 +582,7 @@ def test_pool3d():
 
     # Test non-1 dilation
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [3, 3, 3],
-        [2, 1, 0, 5, 4, 3],
-        "avg",
-        False,
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [3, 3, 3], [2, 1, 0, 5, 4, 3], "avg", False, True
     )
     verify_pool3d(
         [1, 16, 32, 32, 32],
@@ -672,27 +595,23 @@ def test_pool3d():
         False,
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [2, 1, 3],
-        [1, 0, 5, 4, 3, 2],
-        "max",
-        False,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [2, 1, 3], [1, 0, 5, 4, 3, 2], "max", False
     )
     verify_pool3d(
-        [1, 16, 31, 31, 31],
-        [3, 3, 3],
-        [3, 3, 3],
-        [2, 2, 3],
-        [3, 2, 1, 0, 5, 4],
-        "max",
-        True,
+        [1, 16, 31, 31, 31], [3, 3, 3], [3, 3, 3], [2, 2, 3], [3, 2, 1, 0, 5, 4], "max", True
     )
 
 
 def verify_pool2d(
-    input_shape, kernel, stride, dilation, padding, pool_type, ceil_mode, count_include_pad=True, layout="NCHW"
+    input_shape,
+    kernel,
+    stride,
+    dilation,
+    padding,
+    pool_type,
+    ceil_mode,
+    count_include_pad=True,
+    layout="NCHW",
 ):
     verify_poolnd(
         2,
@@ -711,333 +630,70 @@ def verify_pool2d(
 @tvm.testing.uses_gpu
 def test_pool2d():
     """test cases of pool"""
-    verify_pool2d(
-        [1, 16, 32, 32],
-        [2, 2],
-        [2, 2],
-        [1, 1],
-        [0, 0, 0, 0],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [1, 2, 1, 2],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool2d(
-        [1, 16, 32, 32],
-        [2, 2],
-        [2, 2],
-        [1, 1],
-        [1, 2, 1, 2],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [4, 4],
-        [4, 4],
-        [1, 1],
-        [3, 3, 3, 3],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [4, 4],
-        [4, 4],
-        [1, 1],
-        [0, 0, 0, 0],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 32, 32],
-        [2, 3],
-        [2, 2],
-        [1, 1],
-        [0, 0, 0, 0],
-        "max",
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [2, 1, 2, 1],
-        "max",
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [2, 1, 2, 1],
-        "max",
-        True,
-    )
+    verify_pool2d([1, 16, 32, 32], [2, 2], [2, 2], [1, 1], [0, 0, 0, 0], "avg", False, True)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [1, 1], [1, 2, 1, 2], "avg", False, True)
+    verify_pool2d([1, 16, 32, 32], [2, 2], [2, 2], [1, 1], [1, 2, 1, 2], "avg", False, False)
+    verify_pool2d([1, 16, 31, 31], [4, 4], [4, 4], [1, 1], [3, 3, 3, 3], "avg", False, False)
+    verify_pool2d([1, 16, 31, 31], [4, 4], [4, 4], [1, 1], [0, 0, 0, 0], "avg", False, False)
+    verify_pool2d([1, 16, 32, 32], [2, 3], [2, 2], [1, 1], [0, 0, 0, 0], "max", False)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [1, 1], [2, 1, 2, 1], "max", False)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [1, 1], [2, 1, 2, 1], "max", True)
 
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [2, 1, 0, 3],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool2d(
-        [1, 16, 32, 32],
-        [2, 3],
-        [2, 2],
-        [1, 1],
-        [0, 3, 2, 1],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [1, 0, 3, 2],
-        "max",
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [3, 2, 1, 0],
-        "max",
-        True,
-    )
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [1, 1], [2, 1, 0, 3], "avg", False, True)
+    verify_pool2d([1, 16, 32, 32], [2, 3], [2, 2], [1, 1], [0, 3, 2, 1], "avg", False, False)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [1, 1], [1, 0, 3, 2], "max", False)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [1, 1], [3, 2, 1, 0], "max", True)
 
     # Test non-1 dilations
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [2, 1],
-        [2, 1, 0, 3],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool2d(
-        [1, 16, 32, 32],
-        [2, 3],
-        [2, 2],
-        [2, 3],
-        [0, 3, 2, 1],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [3, 3],
-        [1, 0, 3, 2],
-        "max",
-        False,
-    )
-    verify_pool2d(
-        [1, 16, 31, 31],
-        [3, 3],
-        [3, 3],
-        [2, 2],
-        [3, 2, 1, 0],
-        "max",
-        True,
-    )
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [2, 1], [2, 1, 0, 3], "avg", False, True)
+    verify_pool2d([1, 16, 32, 32], [2, 3], [2, 2], [2, 3], [0, 3, 2, 1], "avg", False, False)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [3, 3], [1, 0, 3, 2], "max", False)
+    verify_pool2d([1, 16, 31, 31], [3, 3], [3, 3], [2, 2], [3, 2, 1, 0], "max", True)
     # Test channel last
     verify_pool2d(
-        [1, 32, 32, 16],
-        [2, 2],
-        [2, 2],
-        [1, 1],
-        [0, 0, 0, 0],
-        "avg",
-        False,
-        True,
-        layout="NHWC",
+        [1, 32, 32, 16], [2, 2], [2, 2], [1, 1], [0, 0, 0, 0], "avg", False, True, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [1, 2, 1, 2],
-        "avg",
-        False,
-        True,
-        layout="NHWC",
+        [1, 31, 31, 16], [3, 3], [3, 3], [1, 1], [1, 2, 1, 2], "avg", False, True, layout="NHWC"
     )
     verify_pool2d(
-        [1, 32, 32, 16],
-        [2, 2],
-        [2, 2],
-        [1, 1],
-        [1, 2, 1, 2],
-        "avg",
-        False,
-        False,
-        layout="NHWC",
+        [1, 32, 32, 16], [2, 2], [2, 2], [1, 1], [1, 2, 1, 2], "avg", False, False, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [4, 4],
-        [4, 4],
-        [1, 1],
-        [3, 3, 3, 3],
-        "avg",
-        False,
-        False,
-        layout="NHWC",
+        [1, 31, 31, 16], [4, 4], [4, 4], [1, 1], [3, 3, 3, 3], "avg", False, False, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [4, 4],
-        [4, 4],
-        [1, 1],
-        [0, 0, 0, 0],
-        "avg",
-        False,
-        False,
-        layout="NHWC",
+        [1, 31, 31, 16], [4, 4], [4, 4], [1, 1], [0, 0, 0, 0], "avg", False, False, layout="NHWC"
     )
     verify_pool2d(
-        [1, 32, 32, 16],
-        [2, 3],
-        [2, 2],
-        [1, 1],
-        [0, 0, 0, 0],
-        "max",
-        False,
-        layout="NHWC",
+        [1, 32, 32, 16], [2, 3], [2, 2], [1, 1], [0, 0, 0, 0], "max", False, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [2, 1, 2, 1],
-        "max",
-        False,
-        layout="NHWC",
+        [1, 31, 31, 16], [3, 3], [3, 3], [1, 1], [2, 1, 2, 1], "max", False, layout="NHWC"
     )
-    verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [2, 1, 2, 1],
-        "max",
-        True,
-        layout="NHWC",
-    )
+    verify_pool2d([1, 31, 31, 16], [3, 3], [3, 3], [1, 1], [2, 1, 2, 1], "max", True, layout="NHWC")
 
     verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [2, 1, 0, 3],
-        "avg",
-        False,
-        True,
-        layout="NHWC",
+        [1, 31, 31, 16], [3, 3], [3, 3], [1, 1], [2, 1, 0, 3], "avg", False, True, layout="NHWC"
     )
     verify_pool2d(
-        [1, 32, 32, 16],
-        [2, 3],
-        [2, 2],
-        [1, 1],
-        [0, 3, 2, 1],
-        "avg",
-        False,
-        False,
-        layout="NHWC",
+        [1, 32, 32, 16], [2, 3], [2, 2], [1, 1], [0, 3, 2, 1], "avg", False, False, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [1, 0, 3, 2],
-        "max",
-        False,
-        layout="NHWC",
+        [1, 31, 31, 16], [3, 3], [3, 3], [1, 1], [1, 0, 3, 2], "max", False, layout="NHWC"
+    )
+    verify_pool2d([1, 31, 31, 16], [3, 3], [3, 3], [1, 1], [3, 2, 1, 0], "max", True, layout="NHWC")
+    verify_pool2d(
+        [1, 31, 31, 16], [3, 3], [3, 3], [2, 1], [2, 1, 0, 3], "avg", False, True, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [1, 1],
-        [3, 2, 1, 0],
-        "max",
-        True,
-        layout="NHWC",
+        [1, 32, 32, 16], [2, 3], [2, 2], [2, 3], [0, 3, 2, 1], "avg", False, False, layout="NHWC"
     )
     verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [2, 1],
-        [2, 1, 0, 3],
-        "avg",
-        False,
-        True,
-        layout="NHWC",
+        [1, 31, 31, 16], [3, 3], [3, 3], [3, 3], [1, 0, 3, 2], "max", False, layout="NHWC"
     )
-    verify_pool2d(
-        [1, 32, 32, 16],
-        [2, 3],
-        [2, 2],
-        [2, 3],
-        [0, 3, 2, 1],
-        "avg",
-        False,
-        False,
-        layout="NHWC",
-    )
-    verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [3, 3],
-        [1, 0, 3, 2],
-        "max",
-        False,
-        layout="NHWC",
-    )
-    verify_pool2d(
-        [1, 31, 31, 16],
-        [3, 3],
-        [3, 3],
-        [2, 2],
-        [3, 2, 1, 0],
-        "max",
-        True,
-        layout="NHWC",
-    )
+    verify_pool2d([1, 31, 31, 16], [3, 3], [3, 3], [2, 2], [3, 2, 1, 0], "max", True, layout="NHWC")
+
 
 def verify_pool1d(
     input_shape,
@@ -1067,333 +723,43 @@ def verify_pool1d(
 @tvm.testing.uses_gpu
 def test_pool1d():
     """test cases of pool1d"""
-    verify_pool1d(
-        [1, 16, 32],
-        [2],
-        [2],
-        [1],
-        [0, 0],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [1],
-        [1, 2],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool1d(
-        [1, 16, 32],
-        [2],
-        [2],
-        [1],
-        [1, 2],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [4],
-        [4],
-        [1],
-        [3, 3],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [4],
-        [4],
-        [1],
-        [0, 0],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 32],
-        [2],
-        [2],
-        [1],
-        [0, 0],
-        "max",
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [1],
-        [2, 1],
-        "max",
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [1],
-        [2, 1],
-        "max",
-        True,
-    )
+    verify_pool1d([1, 16, 32], [2], [2], [1], [0, 0], "avg", False, True)
+    verify_pool1d([1, 16, 31], [3], [3], [1], [1, 2], "avg", False, True)
+    verify_pool1d([1, 16, 32], [2], [2], [1], [1, 2], "avg", False, False)
+    verify_pool1d([1, 16, 31], [4], [4], [1], [3, 3], "avg", False, False)
+    verify_pool1d([1, 16, 31], [4], [4], [1], [0, 0], "avg", False, False)
+    verify_pool1d([1, 16, 32], [2], [2], [1], [0, 0], "max", False)
+    verify_pool1d([1, 16, 31], [3], [3], [1], [2, 1], "max", False)
+    verify_pool1d([1, 16, 31], [3], [3], [1], [2, 1], "max", True)
 
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [1],
-        [2, 5],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool1d(
-        [1, 16, 32],
-        [2],
-        [2],
-        [1],
-        [0, 3],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [1],
-        [1, 4],
-        "max",
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [1],
-        [3, 0],
-        "max",
-        True,
-    )
+    verify_pool1d([1, 16, 31], [3], [3], [1], [2, 5], "avg", False, True)
+    verify_pool1d([1, 16, 32], [2], [2], [1], [0, 3], "avg", False, False)
+    verify_pool1d([1, 16, 31], [3], [3], [1], [1, 4], "max", False)
+    verify_pool1d([1, 16, 31], [3], [3], [1], [3, 0], "max", True)
 
     # Test non-1 dilations
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [2],
-        [2, 5],
-        "avg",
-        False,
-        True,
-    )
-    verify_pool1d(
-        [1, 16, 32],
-        [2],
-        [2],
-        [3],
-        [0, 3],
-        "avg",
-        False,
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [2],
-        [1, 4],
-        "max",
-        False,
-    )
-    verify_pool1d(
-        [1, 16, 31],
-        [3],
-        [3],
-        [3],
-        [3, 0],
-        "max",
-        True,
-    )
+    verify_pool1d([1, 16, 31], [3], [3], [2], [2, 5], "avg", False, True)
+    verify_pool1d([1, 16, 32], [2], [2], [3], [0, 3], "avg", False, False)
+    verify_pool1d([1, 16, 31], [3], [3], [2], [1, 4], "max", False)
+    verify_pool1d([1, 16, 31], [3], [3], [3], [3, 0], "max", True)
     # Test Channel last
-    verify_pool1d(
-        [1, 32, 16],
-        [2],
-        [2],
-        [1],
-        [0, 0],
-        "avg",
-        False,
-        True,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [1],
-        [1, 2],
-        "avg",
-        False,
-        True,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 32, 16],
-        [2],
-        [2],
-        [1],
-        [1, 2],
-        "avg",
-        False,
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [4],
-        [4],
-        [1],
-        [3, 3],
-        "avg",
-        False,
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [4],
-        [4],
-        [1],
-        [0, 0],
-        "avg",
-        False,
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 32, 16],
-        [2],
-        [2],
-        [1],
-        [0, 0],
-        "max",
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [1],
-        [2, 1],
-        "max",
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [1],
-        [2, 1],
-        "max",
-        True,
-        layout="NWC",
-    )
+    verify_pool1d([1, 32, 16], [2], [2], [1], [0, 0], "avg", False, True, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [1], [1, 2], "avg", False, True, layout="NWC")
+    verify_pool1d([1, 32, 16], [2], [2], [1], [1, 2], "avg", False, False, layout="NWC")
+    verify_pool1d([1, 31, 16], [4], [4], [1], [3, 3], "avg", False, False, layout="NWC")
+    verify_pool1d([1, 31, 16], [4], [4], [1], [0, 0], "avg", False, False, layout="NWC")
+    verify_pool1d([1, 32, 16], [2], [2], [1], [0, 0], "max", False, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [1], [2, 1], "max", False, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [1], [2, 1], "max", True, layout="NWC")
 
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [1],
-        [2, 5],
-        "avg",
-        False,
-        True,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [2],
-        [2],
-        [1],
-        [0, 3],
-        "avg",
-        False,
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [1],
-        [1, 4],
-        "max",
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [1],
-        [3, 0],
-        "max",
-        True,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [2],
-        [2, 5],
-        "avg",
-        False,
-        True,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 32, 16],
-        [2],
-        [2],
-        [3],
-        [0, 3],
-        "avg",
-        False,
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [2],
-        [1, 4],
-        "max",
-        False,
-        layout="NWC",
-    )
-    verify_pool1d(
-        [1, 31, 16],
-        [3],
-        [3],
-        [3],
-        [3, 0],
-        "max",
-        True,
-        layout="NWC",
-    )
+    verify_pool1d([1, 31, 16], [3], [3], [1], [2, 5], "avg", False, True, layout="NWC")
+    verify_pool1d([1, 31, 16], [2], [2], [1], [0, 3], "avg", False, False, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [1], [1, 4], "max", False, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [1], [3, 0], "max", True, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [2], [2, 5], "avg", False, True, layout="NWC")
+    verify_pool1d([1, 32, 16], [2], [2], [3], [0, 3], "avg", False, False, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [2], [1, 4], "max", False, layout="NWC")
+    verify_pool1d([1, 31, 16], [3], [3], [3], [3, 0], "max", True, layout="NWC")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR should fix the issue that is preventing 1D and 3D pooling functions to be used with non-default layouts on x86 architecture. Unit tests were added as well to confirm that this is working since there were not test to cover this case.