### PR TITLE
[FFI] Specifically check handle for recursion during shutdown

### DIFF
--- a/python/tvm/runtime/object.py
+++ b/python/tvm/runtime/object.py
@@ -56,8 +56,10 @@ class Object(ObjectBase):
         return sorted([fnames(i) for i in range(size)] + class_names)
 
     def __getattr__(self, name):
-        if name in self.__slots__:
-            raise AttributeError(f"{name} is not set")
+        # specially check handle since
+        # this is required for PackedFunc calls
+        if name == "handle":
+            raise AttributeError("handle is not set")
 
         try:
             return _ffi_node_api.NodeGetAttr(self, name)


### PR DESCRIPTION
NOTE: previously slot may get overriden by child class and it
is better to directly check for handle here.

Can resolve some flaky error for long throw in CI 