### PR TITLE
[Fix][Pass] add naming resume mechanism for AnnotateSpans

### DIFF
--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -154,6 +154,9 @@ Doc RelayTextPrinter::GetUniqueName(const std::string& prefix) {
     }
   }
   name_alloc_map_[unique_prefix] = 0;
+  if (unique_prefix != prefix) {  // name changed.
+    name_alloc_reverse_map_[unique_prefix] = prefix;
+  }
   return Doc::Text(unique_prefix);
 }
 
@@ -889,6 +892,11 @@ Doc RelayTextPrinter::PrintSpan(const Span& span) {
   ICHECK(span_node);
   doc << span_node->source_name->name;
   return doc;
+}
+
+const std::unordered_map<std::string, std::string>& RelayTextPrinter::AllocNameReverseMapping()
+    const {
+  return name_alloc_reverse_map_;
 }
 
 TVM_REGISTER_GLOBAL("ir.TextPrinter").set_body_typed([](ObjectRef node) {

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -111,6 +111,8 @@ class RelayTextPrinter : public ExprFunctor<Doc(const Expr&)>,
   Doc PrintFunc(const Doc& prefix, const BaseFunc& base_func);
   Doc PrintMod(const IRModule& mod);
 
+  const std::unordered_map<std::string, std::string>& AllocNameReverseMapping() const;
+
   //------------------------------------
   // Overload of Expr printing functions
   //------------------------------------
@@ -189,6 +191,8 @@ class RelayTextPrinter : public ExprFunctor<Doc(const Expr&)>,
   std::unordered_map<Pattern, Doc, ObjectPtrHash, ObjectPtrEqual> memo_pattern_;
   /*! \brief name allocation map */
   std::unordered_map<std::string, int> name_alloc_map_;
+  /*! \brief Map from allocated name to original name */
+  std::unordered_map<std::string, std::string> name_alloc_reverse_map_;
   /*! \brief meta data context */
   TextMetaDataContext* meta_;
   /*! \brief counter of temporary variable */

--- a/tests/python/relay/test_pass_annotate_spans.py
+++ b/tests/python/relay/test_pass_annotate_spans.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for annotating spans."""
+
+
+import tvm
+import tvm.relay as relay
+from tvm.relay import testing
+import tvm.testing
+
+
+def test_annotate_spans_compatibility():
+    data = relay.var("data", relay.TensorType((1, 3, 64, 64), "float32"))
+    weight = relay.var("weight")
+
+    bn_gamma = relay.var("bn_gamma")
+    bn_beta = relay.var("bn_beta")
+    bn_mmean = relay.var("bn_mean")
+    bn_mvar = relay.var("bn_var")
+
+    simple_net = relay.nn.conv2d(
+        data=data, weight=weight, kernel_size=(3, 3), channels=3, padding=(1, 1)
+    )
+    simple_net = relay.nn.batch_norm(simple_net, bn_gamma, bn_beta, bn_mmean, bn_mvar)[0]
+    simple_net = relay.Function(relay.analysis.free_vars(simple_net), simple_net)
+
+    module, params = testing.create_workload(simple_net)
+
+    # Apply some simple passes to legalize the IR.
+    with tvm.transform.PassContext(opt_level=0):
+        module, params = relay.optimize(module, tvm.testing.enabled_targets()[0][0], params)
+
+    seq = tvm.transform.Sequential([relay.transform.AnnotateSpans(), relay.transform.DefuseOps()])
+    with tvm.transform.PassContext(opt_level=3):
+        module = seq(module)
+
+
+if __name__ == "__main__":
+    test_annotate_spans_compatibility()


### PR DESCRIPTION
`AnnotateSpans` creates span information by print (`AsText`) and re-parse the IR. However, `GetUniqueName` in `AsText` renames identical variable names (say we have 2 `%p0`, `AsText` will rename one of them as `%p01`). Such behaviour makes themselves incompatible with some other passes (e.g., `DefuseOps`) which depend on information brought by original variable names.

For details, see https://discuss.tvm.apache.org/t/pass-incompatibility-annotatespans-and-defuseops/10448/8

@YuchenJin @junrushao1994 @merrymercy 