### PR TITLE
[Coreml] Fix Coreml Input Shape Handling

### DIFF
--- a/python/tvm/relay/frontend/coreml.py
+++ b/python/tvm/relay/frontend/coreml.py
@@ -562,7 +562,7 @@ def from_coreml(model, shape=None):
 
     etab = ExprTable()
     for i in spec.description.input:
-        input_shape = shape[i.name] if shape is not None and i.name in shape else None
+        input_shape = list(shape[i.name]) if shape is not None and i.name in shape else None
         etab.set_expr(i.name, _expr.var(i.name, shape=input_shape))
 
     for pp in cc.preprocessing:

--- a/tests/python/frontend/coreml/test_forward.py
+++ b/tests/python/frontend/coreml/test_forward.py
@@ -30,6 +30,11 @@ from tvm.topi.testing import conv2d_nchw_python
 import coremltools as cm
 import model_zoo
 import tvm.testing
+import tempfile
+from os import path
+import tvm
+import tvm.relay as relay
+import tensorflow.keras as keras
 
 
 def get_tvm_output(
@@ -783,6 +788,44 @@ def test_forward_convolution():
     verify_convolution((1, 3, 224, 224), filter=(32, 3, 3, 3), padding="SAME")
 
 
+def test_can_build_keras_to_coreml_to_relay():
+    """Test multiple conversion paths and importing from
+    a saved file."""
+    model = keras.models.Sequential()
+    model.add(
+        keras.layers.Conv2D(
+            filters=6,
+            kernel_size=(1, 1),
+            activation="relu",
+            padding="same",
+            input_shape=(3, 3, 1),
+            data_format="channels_first",
+        )
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        kmodel_fn = path.join(tmpdir, "c1mdl.h5")
+        model.save(kmodel_fn)
+
+        mdl = cm.convert(kmodel_fn)
+        model_file = path.join(tmpdir, "c1.mlmodel")
+        mdl.save(model_file)
+
+        mdl = cm.models.MLModel(model_file)
+        desc = mdl.get_spec().description
+        iname = desc.input[0].name
+        ishape = desc.input[0].type.multiArrayType.shape
+        shape_dict = {}
+        for i in mdl.get_spec().description.input:
+            iname = i.name
+            ishape = i.type.multiArrayType.shape
+            shape_dict[iname] = ishape
+        mod, params = relay.frontend.from_coreml(mdl, shape_dict)
+
+        with tvm.transform.PassContext(opt_level=3):
+            relay.build(mod, "llvm", params=params)
+
+
 if __name__ == "__main__":
     test_forward_AddLayerParams()
     test_forward_ConcatLayerParams()
@@ -801,3 +844,4 @@ if __name__ == "__main__":
     test_resnet50_checkonly()
     test_forward_image_scaler()
     test_forward_convolution()
+    test_can_build_keras_to_coreml_to_relay()


### PR DESCRIPTION
The input shape may not be a python list (which is what the ffi knows how to handle) but rather a rather complicated protobuf object. The solution is to just convert it to a python list.

Before:
TypeError: Don't know how to handle type <class 'google.protobuf.pyext._message.RepeatedScalarContainer'>

After:
Works! Now we just have an issue with unsupported ops.

Before:
Running this script: https://github.com/AndrewZhaoLuo/TVM-Sandbox/blob/bf3df0ee1dcc382a68cb551bc73826dff94b73b9/coreml_debug/coreml-test.py#L1

Fails with 
`TypeError: Don't know how to handle type <class 'google.protobuf.pyext._message.RepeatedScalarContainer'>`

Now: 
It fails with an unsupported operator which the user can now add.