### PR TITLE
[DOCS] TVM install addenda for M1 Macs

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -74,8 +74,8 @@ linux operating systems, execute (in a terminal):
     sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
 On macOS, whether using an Intel or M1 Mac we can use homebrew. Make sure to follow the post installation steps for each of the above commaands.
-Furthermore, avoid using python 3.9.X+ which is not supported  at the time of this writing, With this, you should have the ability to compile a 
-basic TVM with llvm included. Additional missing requirements  can also be installed via brew if they arise:
+Furthermore, avoid using python 3.9.X+ which is not supported at the time of this writing. With this, you should have the ability to compile a 
+basic build of TVM with llvm included. Additional missing requirements can also be installed via brew if they arise:
 
 .. code:: bash 
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -74,8 +74,8 @@ linux operating systems, execute (in a terminal):
     sudo apt-get update
     sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
-On macOS, whether using an Intel or M1 Mac, we support using homebrew. Make sure to follow the post installation steps for each of the below commaands.
-With this, you should have the ability to compile a  basic build of TVM with llvm included. Additional missing requirements can also be installed via brew if they arise:
+Use Homebrew to install the required dependencies for macOS running either the Intel or M1 processors. You must follow the post-installation steps specified by 
+Homebrew to ensure the dependencies are correctly installed and configured:
 
 .. code:: bash 
 
@@ -303,7 +303,9 @@ like ``virtualenv``.
 
        pip3 install --user tornado psutil xgboost cloudpickle
 
-Note on M1 macs, you may have trouble installing xgboost / scipy. A workaround for this is to do the following commands:
+Note on M1 macs, you may have trouble installing xgboost / scipy. scipy and xgboost requires some additional dependencies to be installed, 
+including openblas and its dependencies. Use the following commands to install scipy and xgboost with the required dependencies and 
+configuration. A workaround for this is to do the following commands:
 
     .. code:: bash 
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -63,8 +63,8 @@ The minimal building requirements for the ``TVM`` libraries are:
    - CMake 3.5 or higher
    - We highly recommend to build with LLVM to enable all the features.
    - If you want to use CUDA, CUDA toolkit version >= 8.0 is required. If you are upgrading from an older version, make sure you purge the older version and reboot after installation.
-   - On macOS, you may want to install `Homebrew <https://brew.sh>` to easily install and manage dependencies.
-   - Python is also required. Avoid using python 3.9.X+ which is not `supported <https://github.com/apache/tvm/issues/8577>`_. 3.7.X+ and 3.8.X+ should be well supported however.
+   - On macOS, you may want to install `Homebrew <https://brew.sh>`_ to easily install and manage dependencies.
+   - Python is also required. Avoid using Python 3.9.X+ which is not `supported <https://github.com/apache/tvm/issues/8577>`_. 3.7.X+ and 3.8.X+ should be well supported however.
 
 To install the these minimal pre-requisites on Ubuntu/Debian like
 linux operating systems, execute (in a terminal):

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -311,7 +311,9 @@ Note on M1 macs, you may have trouble installing xgboost / scipy. A workaround f
 
         pip install pybind11 cython pythran   
         
-        export OPENBLAS=/opt/homebrew/opt/openblas/lib/ && pip install scipy —no-use-pep517
+        export OPENBLAS=/opt/homebrew/opt/openblas/lib/ 
+        
+        pip install scipy --no-use-pep517
         
         pip install xgboost
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -64,8 +64,7 @@ The minimal building requirements for the ``TVM`` libraries are:
    - We highly recommend to build with LLVM to enable all the features.
    - If you want to use CUDA, CUDA toolkit version >= 8.0 is required. If you are upgrading from an older version, make sure you purge the older version and reboot after installation.
    - On macOS, you may want to install `Homebrew <https://brew.sh>` to easily install and manage dependencies.
-   - Python is also required. Avoid using python 3.9.X+ which is not supported at the time of this `writing <https://github.com/apache/tvm/issues/8577>`. 3.7.X+ and 3.8.X+ 
-        should be well supported however.
+   - Python is also required. Avoid using python 3.9.X+ which is not `supported <https://github.com/apache/tvm/issues/8577>`_. 3.7.X+ and 3.8.X+ should be well supported however.
 
 To install the these minimal pre-requisites on Ubuntu/Debian like
 linux operating systems, execute (in a terminal):

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -64,6 +64,8 @@ The minimal building requirements for the ``TVM`` libraries are:
    - We highly recommend to build with LLVM to enable all the features.
    - If you want to use CUDA, CUDA toolkit version >= 8.0 is required. If you are upgrading from an older version, make sure you purge the older version and reboot after installation.
    - On macOS, you may want to install `Homebrew <https://brew.sh>` to easily install and manage dependencies.
+   - Python is also required. Avoid using python 3.9.X+ which is not supported at the time of this `writing <https://github.com/apache/tvm/issues/8577>`. 3.7.X+ and 3.8.X+ 
+        should be well supported however.
 
 To install the these minimal pre-requisites on Ubuntu/Debian like
 linux operating systems, execute (in a terminal):
@@ -73,9 +75,8 @@ linux operating systems, execute (in a terminal):
     sudo apt-get update
     sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
-On macOS, whether using an Intel or M1 Mac we can use homebrew. Make sure to follow the post installation steps for each of the below commaands.
-Furthermore, avoid using python 3.9.X+ which is not supported at the time of this writing. With this, you should have the ability to compile a 
-basic build of TVM with llvm included. Additional missing requirements can also be installed via brew if they arise:
+On macOS, whether using an Intel or M1 Mac, we support using homebrew. Make sure to follow the post installation steps for each of the below commaands.
+With this, you should have the ability to compile a  basic build of TVM with llvm included. Additional missing requirements can also be installed via brew if they arise:
 
 .. code:: bash 
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -73,7 +73,7 @@ linux operating systems, execute (in a terminal):
     sudo apt-get update
     sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
-On macOS, whether using an Intel or M1 Mac we can use homebrew. Make sure to follow the post installation steps for each of the above commaands.
+On macOS, whether using an Intel or M1 Mac we can use homebrew. Make sure to follow the post installation steps for each of the below commaands.
 Furthermore, avoid using python 3.9.X+ which is not supported at the time of this writing. With this, you should have the ability to compile a 
 basic build of TVM with llvm included. Additional missing requirements can also be installed via brew if they arise:
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -73,6 +73,16 @@ linux operating systems, execute (in a terminal):
     sudo apt-get update
     sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
+On macOS, whether using an Intel or M1 Mac we can use homebrew. Make sure to follow the post installation steps for each of the above commaands.
+Furthermore, avoid using python 3.9.X+ which is not supported  at the time of this writing, With this, you should have the ability to compile a 
+basic TVM with llvm included. Additional missing requirements  can also be installed via brew if they arise:
+
+.. code:: bash 
+
+    brew install gcc git cmake 
+    brew install llvm 
+    brew install python@3.8 
+
 
 We use cmake to build the library.
 The configuration of TVM can be modified by editing `config.cmake` and/or by passing cmake flags to the command line:
@@ -293,6 +303,17 @@ like ``virtualenv``.
 
        pip3 install --user tornado psutil xgboost cloudpickle
 
+Note on M1 macs, you may have trouble installing xgboost / scipy. A workaround for this is to do the following commands:
+
+    .. code:: bash 
+
+        brew install openblas gfortran
+
+        pip install pybind11 cython pythran   
+        
+        export OPENBLAS=/opt/homebrew/opt/openblas/lib/ && pip install scipy —no-use-pep517
+        
+        pip install xgboost
 
 Install Contrib Libraries
 -------------------------


### PR DESCRIPTION
Testing: 
Ran `restview` on the doc and made sure it looked ok-ish.

Tested this on a sort-of-fresh M1 mac and can confirm these instructions work.