### PR TITLE
Re-enable Compute library tests.

### DIFF
--- a/tests/scripts/task_python_arm_compute_library.sh
+++ b/tests/scripts/task_python_arm_compute_library.sh
@@ -27,5 +27,4 @@ source tests/scripts/setup-pytest-env.sh
 find . -type f -path "*.pyc" | xargs rm -f
 make cython3
 
-echo "Temporarily suspended while we understand flakiness with #8117"
-#run_pytest ctypes python-arm_compute_lib tests/python/contrib/test_arm_compute_lib
+run_pytest ctypes python-arm_compute_lib tests/python/contrib/test_arm_compute_lib


### PR DESCRIPTION
ci image v0.06 does not appear to have the flakiness shown in ci image v0.05.
However what changed between the 2 remains a mystery and needs further
debugging. However for now re-enable this to see how this fares in CI

Fixes #8417


@leandron , @areusch , Please could you help review and merge this .
