### PR TITLE
[CI] Disable pip cache when creating Docker images

### DIFF
--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -23,6 +23,9 @@ FROM ubuntu:18.04
 RUN apt-get update --fix-missing
 RUN apt-get install -y ca-certificates gnupg2
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -21,6 +21,9 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -22,6 +22,9 @@ FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 # Base scripts
 RUN apt-get update --fix-missing
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -22,6 +22,9 @@ FROM ioft/i386-ubuntu:16.04
 
 RUN apt-get update --fix-missing && apt-get install -y ca-certificates
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -22,6 +22,9 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 RUN apt-get update && apt-get install -y wget git sudo make
 
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh

--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -21,6 +21,9 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_wasm
+++ b/docker/Dockerfile.ci_wasm
@@ -18,6 +18,9 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/install/ubuntu_install_darknet.sh
+++ b/docker/install/ubuntu_install_darknet.sh
@@ -23,4 +23,7 @@ set -o pipefail
 #install the necessary dependancies, cffi, opencv
 wget -q 'https://github.com/siju-samuel/darknet/blob/master/lib/libdarknet.so?raw=true' -O libdarknet.so
 debian_version=`cat /etc/debian_version`
-pip3 install opencv-python cffi
+
+pip3 install \
+    cffi \
+    opencv-python

--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -22,11 +22,14 @@ set -o pipefail
 
 # We need to fix the onnx version because changing versions tends to break tests
 # TODO(mbrookhart): periodically update
-pip3 install onnx==1.8.1
-pip3 install onnxruntime==1.7.0
+pip3 install \
+    onnx==1.8.1 \
+    onnxruntime==1.7.0
 
 # torch depends on a number of other packages, but unhelpfully, does
 # not expose that in the wheel!!!
 pip3 install future
 
-pip3 install torch==1.7.0 torchvision==0.8.1
+pip3 install \
+    torch==1.7.0 \
+    torchvision==0.8.1

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -21,4 +21,21 @@ set -u
 set -o pipefail
 
 # install libraries for python package on ubuntu
-pip3 install six numpy pytest cython decorator scipy tornado pytest pytest-xdist pytest-profiling mypy orderedset attrs requests Pillow packaging cloudpickle synr
+pip3 install \
+    attrs \
+    cloudpickle \
+    cython \
+    decorator \
+    mypy \
+    numpy \
+    orderedset \
+    packaging \
+    Pillow \
+    pytest \
+    pytest-profiling \
+    pytest-xdist \
+    requests \
+    scipy \
+    six \
+    synr \
+    tornado

--- a/docker/install/ubuntu_install_redis.sh
+++ b/docker/install/ubuntu_install_redis.sh
@@ -21,4 +21,6 @@ set -u
 set -o pipefail
 
 apt-get update && apt-get install -y redis-server
-pip3 install "xgboost>=1.1.0" psutil
+pip3 install \
+    psutil \
+    "xgboost>=1.1.0"

--- a/docker/install/ubuntu_install_sphinx.sh
+++ b/docker/install/ubuntu_install_sphinx.sh
@@ -21,4 +21,13 @@ set -u
 set -o pipefail
 
 # NOTE: install docutils < 0.17 to work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-pip3 install sphinx sphinx-gallery==0.4.0 autodocsumm sphinx_rtd_theme sphinx_autodoc_annotation matplotlib Image "commonmark>=0.7.3" "docutils>=0.11,<0.17"
+pip3 install \
+    autodocsumm \
+    "commonmark>=0.7.3" \
+    "docutils>=0.11,<0.17" \
+    Image \
+    matplotlib \
+    sphinx \
+    sphinx_autodoc_annotation \
+    sphinx-gallery==0.4.0 \
+    sphinx_rtd_theme

--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -20,4 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install tensorflow==2.4.2 keras==2.4.3 "h5py<3.0"
+pip3 install \
+    "h5py<3.0" \
+    keras==2.4.3 \
+    tensorflow==2.4.2


### PR DESCRIPTION
Disable pip cache when creating Docker images:
* For each Python package we install in any `docker/install/*.sh` script, we re keeping a copy of it in `/root/.cache/pip/*`
* Disabling the pip cache is a good practice to save storage space in the Docker images being created
* Also sort pip package lists alphabetically

In summary, this saves around **700Mb** on the ci_cpu image, and **1.6Gb** on the ci_gpu image.

cc @tqchen @areusch @mbrookhart @Mousius for reviews
