### PR TITLE
[Vulkan] Prioritize discrete GPUs as device_id=0.

### DIFF
--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -156,6 +156,27 @@ VulkanDeviceProperties::VulkanDeviceProperties(const VulkanInstance& instance,
   device_name = properties.properties.deviceName;
   driver_version = properties.properties.driverVersion;
 
+  switch (properties.properties.deviceType) {
+    case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+      device_type = "other";
+      break;
+    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+      device_type = "integrated";
+      break;
+    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+      device_type = "discrete";
+      break;
+    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+      device_type = "virtual";
+      break;
+    case VK_PHYSICAL_DEVICE_TYPE_CPU:
+      device_type = "cpu";
+      break;
+    default:
+      LOG(FATAL) << "Unknown vulkan device type: " << properties.properties.deviceType;
+      break;
+  }
+
   // By default, use the maximum API version that the driver allows,
   // so that any supported features can be used by TVM shaders.
   // However, if we can query the conformance version, then limit to

--- a/src/runtime/vulkan/vulkan_device.h
+++ b/src/runtime/vulkan/vulkan_device.h
@@ -92,7 +92,8 @@ struct VulkanDeviceProperties {
   uint32_t max_storage_buffer_range{1 << 27};
   uint32_t max_per_stage_descriptor_storage_buffer{4};
   uint32_t max_shared_memory_per_block{16384};
-  std::string device_name{"unknown device name"};
+  std::string device_type{"unknown_device_type"};
+  std::string device_name{"unknown_device_name"};
   uint32_t driver_version{0};
   uint32_t vulkan_api_version{VK_API_VERSION_1_0};
   uint32_t max_spirv_version{0x10000};

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -249,7 +249,7 @@ Map<String, ObjectRef> UpdateVulkanAttrs(Map<String, ObjectRef> attrs) {
                                          "driver_version",
                                          "vulkan_api_version",
                                          "max_spirv_version"};
-    std::vector<const char*> str_opts = {"device_name"};
+    std::vector<const char*> str_opts = {"device_name", "device_type"};
 
     for (auto& key : bool_opts) {
       if (!attrs.count(key)) {
@@ -387,6 +387,7 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Integer>("max_per_stage_descriptor_storage_buffer")
     .add_attr_option<Integer>("max_shared_memory_per_block")
     // Other device properties
+    .add_attr_option<String>("device_type")
     .add_attr_option<String>("device_name")
     .add_attr_option<Integer>("driver_version")
     .add_attr_option<Integer>("vulkan_api_version")


### PR DESCRIPTION
This previously caused some issues in performance comparison between cuda/vulkan, as `device_id=0` referred to different physical hardware.

- Added device_type to the device-queried information.

- Sort the vulkan devices by the device_type.  Priority is discrete >  integrated > virtual > cpu > other