### PR TITLE
[CI] Fix global pip cache disable change

### DIFF
--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -23,9 +23,6 @@ FROM ubuntu:18.04
 RUN apt-get update --fix-missing
 RUN apt-get install -y ca-certificates gnupg2
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
@@ -34,6 +31,9 @@ RUN bash /install/ubuntu_install_llvm.sh
 
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source.sh
 RUN bash /install/ubuntu_install_cmake_source.sh

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -21,14 +21,14 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 COPY install/ubuntu_install_python_package.sh /install/ubuntu_install_python_package.sh
 RUN bash /install/ubuntu_install_python_package.sh

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -22,14 +22,14 @@ FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 # Base scripts
 RUN apt-get update --fix-missing
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 COPY install/ubuntu1804_install_llvm.sh /install/ubuntu1804_install_llvm.sh
 RUN bash /install/ubuntu1804_install_llvm.sh

--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -22,9 +22,6 @@ FROM ioft/i386-ubuntu:16.04
 
 RUN apt-get update --fix-missing && apt-get install -y ca-certificates
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
@@ -33,6 +30,9 @@ RUN bash /install/ubuntu_install_llvm.sh
 
 COPY install/ubuntu_install_python.sh /install/ubuntu_install_python.sh
 RUN bash /install/ubuntu_install_python.sh
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source.sh
 RUN bash /install/ubuntu_install_cmake_source.sh

--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -22,13 +22,13 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 RUN apt-get update && apt-get install -y wget git sudo make
 
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 RUN apt-get update && apt-get install -y doxygen graphviz
 

--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -21,15 +21,15 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
 COPY install/ubuntu1804_install_python_venv.sh /install/ubuntu1804_install_python_venv.sh
 RUN bash /install/ubuntu1804_install_python_venv.sh
 ENV PATH=/opt/tvm-venv/bin:/opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 COPY install/ubuntu_install_python_package.sh /install/ubuntu_install_python_package.sh
 RUN bash /install/ubuntu_install_python_package.sh

--- a/docker/Dockerfile.ci_wasm
+++ b/docker/Dockerfile.ci_wasm
@@ -18,14 +18,14 @@ FROM ubuntu:18.04
 
 RUN apt-get update --fix-missing
 
-# Globally disable pip cache
-RUN pip config set global.cache-dir false
-
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
+
+# Globally disable pip cache
+RUN pip config set global.cache-dir false
 
 COPY install/ubuntu_install_python_package.sh /install/ubuntu_install_python_package.sh
 RUN bash /install/ubuntu_install_python_package.sh


### PR DESCRIPTION
Fixing my mistake in #8575.
* The fix to disable cache needs to run after pip is installed
* This is quick follow up fix after #8575

**Note:** I think it is important to run this command at the Dockerfile level, otherwise people that run the scripts locally on their machine might accidentally disable the cache, which for developers' workstations is useful.

cc @areusch @tqchen @Mousius for reviews