### PR TITLE
Delete pytest-results as part of CI workspace preparation

### DIFF
--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -36,3 +36,6 @@ python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.3.0
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().
 # TODO(areusch): Make pack_lib() pack all the data dependencies of TVM.
 (cd build && cmake .. && make standalone_crt)
+
+# Ensure no stale pytest-results remain from a previous test run.
+(cd build && rm -rf pytest-results)


### PR DESCRIPTION
 * Otherwise, stale pytest-results could appear in builds.
 * See #8593 

@tqchen @masahi 