### PR TITLE
[TOPI] [Relay] Sparse Conv2d Implementation for 3x3 kernels

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -1047,12 +1047,15 @@ struct SparseTransposeAttrs : public tvm::AttrsNode<SparseTransposeAttrs> {
 /*! \brief Attributes for sparse_dense operator */
 struct SparseConv2DAttrs : public tvm::AttrsNode<SparseConv2DAttrs> {
   std::string layout;
+  int kernel_size;
 
   TVM_DECLARE_ATTRS(SparseConv2DAttrs, "relay.attrs.SparseConv2DAttrs") {
     TVM_ATTR_FIELD(layout).set_default("NHWC").describe(
         "Dimension ordering of input data. Can be 'NCHW', 'NHWC'"
         "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"
         "dimensions respectively.");
+    TVM_ATTR_FIELD(kernel_size).set_default(1).describe(
+        "Kernel size for SparseConv2D, 1x1 or 3x3. ");
   }
 };
 

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -254,13 +254,14 @@ class RPCRunner(Runner):
 
     @ref_input.setter
     def ref_input(self, val):
-        warnings.warn(
-            "You are specifying fixed input for tuning the operator. "
-            "Be sure your input always fits the operator. Some "
-            "operators may conduct layout transformation during tuning, "
-            "thus can lead to unexpected behaviors. ",
-            RuntimeWarning,
-        )
+        if val is not None:
+            warnings.warn(
+                "You are specifying fixed input for tuning the operator. "
+                "Be sure your input always fits the operator. Some "
+                "operators may conduct layout transformation during tuning, "
+                "thus can lead to unexpected behaviors. ",
+                RuntimeWarning,
+            )
         self._ref_input = val
 
     def set_task(self, task):

--- a/python/tvm/relay/analysis/sparse_conv2d.py
+++ b/python/tvm/relay/analysis/sparse_conv2d.py
@@ -54,7 +54,7 @@ def _search_conv2d_op_weight(expr):
     return _ffi_api.search_conv2d_op_weight(expr)
 
 
-def process_params(expr, params, block_size, sparsity_threshold, layout):
+def process_params(expr, params, block_size, sparsity_threshold, layout, kernel_size, reg_task_input=True):
     """Process parameters of conv2d from dense to sparse.
 
     Parameters
@@ -86,14 +86,18 @@ def process_params(expr, params, block_size, sparsity_threshold, layout):
     for name in weight_names:
         name = str(name)
         w_np = params[name].numpy()
-        # currently only support conv2d_1*1
-        if not (
-            (w_np.shape[0] == 1 and w_np.shape[1] == 1)
-            or (w_np.shape[2] == 1 and w_np.shape[3] == 1)
-        ):
+
+        if layout == "NHWC":  # HWIO
+            weight_kernel = (w_np.shape[0], w_np.shape[1])
+        elif layout == "NCHW":  # OIHW
+            weight_kernel = (w_np.shape[2], w_np.shape[3])
+        if weight_kernel[0] != weight_kernel[1]:
             continue
-        sparsity = 1.0 - (np.count_nonzero(w_np) / w_np.size)
-        if sparsity >= sparsity_threshold:
+
+        if weight_kernel[0] == kernel_size == 1:
+            sparsity = 1.0 - (np.count_nonzero(w_np) / w_np.size)
+            if sparsity < sparsity_threshold:
+                continue
             if layout == "NHWC":
                 w_np = w_np.squeeze().T
             elif layout == "NCHW":
@@ -108,19 +112,28 @@ def process_params(expr, params, block_size, sparsity_threshold, layout):
                 )
             else:
                 sparse_weight_data = sparse_weight.data
+        elif weight_kernel[0] == kernel_size == 3 and layout == "NHWC":
+            w_np = w_np.reshape((-1, w_np.shape[-1])).T
+            sparse_weight = sp.bsr_matrix(w_np, blocksize=block_size)
+            if 1 - (sparse_weight.nnz / w_np.size) < sparsity_threshold:
+                continue
+            sparse_weight_data = sparse_weight.data
+        else:
+            continue
 
-            # remove dense weight
-            del params[name]
-            memo.weight_name.append(name)
-            memo.weight_shape.append(
-                list(sparse_weight_data.shape)
-                + list(sparse_weight.indices.shape)
-                + list(sparse_weight.indptr.shape)
-            )
-            params[name + ".data"] = tvm.nd.array(sparse_weight_data)
-            params[name + ".indices"] = tvm.nd.array(sparse_weight.indices)
-            params[name + ".indptr"] = tvm.nd.array(sparse_weight.indptr)
+        # remove dense weight
+        del params[name]
+        memo.weight_name.append(name)
+        memo.weight_shape.append(
+            list(sparse_weight_data.shape)
+            + list(sparse_weight.indices.shape)
+            + list(sparse_weight.indptr.shape)
+        )
+        params[name + ".data"] = tvm.nd.array(sparse_weight_data)
+        params[name + ".indices"] = tvm.nd.array(sparse_weight.indices)
+        params[name + ".indptr"] = tvm.nd.array(sparse_weight.indptr)
 
+        if reg_task_input:
             prefix = "sparse_conv2d_bsr_%d_%d_%d_%d_%d_%d_" % (
                 w_np.shape[0],
                 w_np.shape[1],

--- a/python/tvm/relay/data_dep_optimization/bsr_conv2d.py
+++ b/python/tvm/relay/data_dep_optimization/bsr_conv2d.py
@@ -23,7 +23,7 @@ from tvm.relay.analysis.sparse_conv2d import process_params
 from .utils import _run_opt_pass
 
 
-def convert(func, params, blocksize, sparsity_threshold, layout="NHWC"):
+def convert(func, params, blocksize, sparsity_threshold, layout="NHWC", kernel_size=1):
     """Convert a dense func and according parameters to block sparse
 
     Parameters
@@ -49,10 +49,10 @@ def convert(func, params, blocksize, sparsity_threshold, layout="NHWC"):
     params: Dict[Srting, tvm.nd.array]
         New params with BSR matrix for mutated Expr
     """
-    weight_info = process_params(func, params, blocksize, sparsity_threshold, layout)
+    weight_info = process_params(func, params, blocksize, sparsity_threshold, layout, kernel_size)
     new_func = _run_opt_pass(
         func,
-        relay.transform.Conv2dToSparse(weight_info.weight_name, weight_info.weight_shape, layout),
+        relay.transform.Conv2dToSparse(weight_info.weight_name, weight_info.weight_shape, layout, kernel_size),
     )
 
     return new_func, params

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -198,7 +198,7 @@ reg.register_pattern("nn.sparse_transpose", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 @reg.register_compute("nn.sparse_conv2d")
 def compute_sparse_conv2d(attrs, inputs, out_type):
     """Compute definition of sparse_conv2d"""
-    return [topi.nn.sparse_conv2d(inputs[0], inputs[1], inputs[2], inputs[3], attrs["layout"], attrs['kernel_size'])]
+    return [topi.nn.sparse_conv2d(inputs[0], inputs[1], inputs[2], inputs[3], attrs["layout"], attrs["kernel_size"])]
 
 
 reg.register_strategy("nn.sparse_conv2d", strategy.sparse_conv2d_strategy)

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -198,7 +198,7 @@ reg.register_pattern("nn.sparse_transpose", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 @reg.register_compute("nn.sparse_conv2d")
 def compute_sparse_conv2d(attrs, inputs, out_type):
     """Compute definition of sparse_conv2d"""
-    return [topi.nn.sparse_conv2d(inputs[0], inputs[1], inputs[2], inputs[3], attrs["layout"])]
+    return [topi.nn.sparse_conv2d(inputs[0], inputs[1], inputs[2], inputs[3], attrs["layout"], attrs['kernel_size'])]
 
 
 reg.register_strategy("nn.sparse_conv2d", strategy.sparse_conv2d_strategy)

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -575,12 +575,18 @@ def sparse_conv2d_strategy_cpu(attrs, inputs, out_type, target):
             wrap_topi_schedule(topi.generic.schedule_sparse_conv2d),
             name="sparse_conv2d.generic",
         )
-    elif attrs["kernel_size"] == 3 and attrs["layout"] == "NHWC":
-        strategy.add_implementation(
-            wrap_compute_sparse_conv2d(topi.x86.spconv2d_3x3_nhwc),
-            wrap_topi_schedule(topi.x86.schedule_spconv2d_3x3_nhwc),
-            name="conv3x3_spNHWC.x86",
-        )
+    elif attrs["kernel_size"] == 3:
+        if attrs["layout"] == "NHWC":
+            strategy.add_implementation(
+                wrap_compute_sparse_conv2d(topi.x86.spconv2d_3x3_nhwc),
+                wrap_topi_schedule(topi.x86.schedule_spconv2d_3x3_nhwc),
+                name="conv3x3_spNHWC.x86",
+            )
+        elif attrs["layout"] == "NCHW":
+            strategy.add_implementation(
+                wrap_compute_sparse_conv2d(topi.x86.spconv2d_3x3_nchw),
+                wrap_topi_schedule(topi.x86.schedule_spconv2d_3x3_nchw),
+            )
     return strategy
 
 

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -565,6 +565,25 @@ def sparse_dense_strategy_cpu(attrs, inputs, out_type, target):
     return strategy
 
 
+@sparse_conv2d_strategy.register("cpu")
+def sparse_conv2d_strategy_cpu(attrs, inputs, out_type, target):
+    """sparse conv2d x86 strategy"""
+    strategy = _op.OpStrategy()
+    if attrs["kernel_size"] == 1:
+        strategy.add_implementation(
+            wrap_compute_sparse_conv2d(topi.nn.sparse_conv2d),
+            wrap_topi_schedule(topi.generic.schedule_sparse_conv2d),
+            name="sparse_conv2d.generic",
+        )
+    elif attrs["kernel_size"] == 3 and attrs["layout"] == "NHWC":
+        strategy.add_implementation(
+            wrap_compute_sparse_conv2d(topi.x86.spconv2d_3x3_nhwc),
+            wrap_topi_schedule(topi.x86.schedule_spconv2d_3x3_nhwc),
+            name="conv3x3_spNHWC.x86",
+        )
+    return strategy
+
+
 @roi_align_strategy.register("cpu")
 def roi_align_strategy_cpu(attrs, inputs, out_type, target):
     """roi_align x86 strategy"""

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -1093,7 +1093,7 @@ def DenseToSparse(weight_name, weight_shape):
     return _ffi_api.DenseToSparse(weight_name, weight_shape)
 
 
-def Conv2dToSparse(weight_name, weight_shape, layout):
+def Conv2dToSparse(weight_name, weight_shape, layout, kernel_size):
     """
     Rewrite qualified ```nn.conv2d operation``` to ```nn.sparse_conv2d```
 
@@ -1113,7 +1113,7 @@ def Conv2dToSparse(weight_name, weight_shape, layout):
     ret : tvm.transform.Pass
         The registered DenseToSparse pass.
     """
-    return _ffi_api.Conv2dToSparse(weight_name, weight_shape, layout)
+    return _ffi_api.Conv2dToSparse(weight_name, weight_shape, layout, kernel_size)
 
 
 def SimplifyFCTranspose(target_weight_name):

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -598,14 +598,15 @@ def sparse_conv2d(dense_data, sparse_data, sparse_indices, sparse_indptr, layout
         4-D with shape [M, H, W, N] (layout=NHWC)
         4-D with shape [M, N, H ,W] (layout=NCHW)
     """
-    if layout == "NHWC":
-        return _sparse_conv2d_bsr_compute_nhwc(
-            dense_data, sparse_data, sparse_indices, sparse_indptr
-        )
-    elif layout == "NCHW":
-        return _sparse_conv2d_bsr_compute_nchw(
-            dense_data, sparse_data, sparse_indices, sparse_indptr
-        )
+    if kernel_size == 1:
+        if layout == "NHWC":
+            return _sparse_conv2d_bsr_compute_nhwc(
+                dense_data, sparse_data, sparse_indices, sparse_indptr
+            )
+        elif layout == "NCHW":
+            return _sparse_conv2d_bsr_compute_nchw(
+                dense_data, sparse_data, sparse_indices, sparse_indptr
+            )
     else:
         raise ValueError("Unsupport Layout %s" % layout)
 

--- a/python/tvm/topi/nn/sparse.py
+++ b/python/tvm/topi/nn/sparse.py
@@ -566,7 +566,7 @@ def _sparse_conv2d_bsr_compute_nchw(data, weight_data, weight_indices, weight_in
     )
 
 
-def sparse_conv2d(dense_data, sparse_data, sparse_indices, sparse_indptr, layout="NHWC"):
+def sparse_conv2d(dense_data, sparse_data, sparse_indices, sparse_indptr, layout="NHWC", kernel_size=1):
     """
     Computes sparse-conv2d(1*1) of ``data`` and
     ``(weight_data, weight_indices, weight_indptr)``

--- a/python/tvm/topi/x86/sparse.py
+++ b/python/tvm/topi/x86/sparse.py
@@ -64,39 +64,23 @@ def schedule_sparse_dense(outs):
     return s
 
 
-@autotvm.register_topi_compute('conv3x3_spNHWC.x86')
+@autotvm.register_topi_compute("conv3x3_spNHWC.x86")
 def spconv2d_3x3_nhwc(cfg, Data, Wdat, Wind, Wptr, layout="NHWC"):
-    '''# My SpConv2d_3x3_gemm
-
-        Data: N,H,W,C -> NHW,33C
-        Weight: F,3,3,C -> F,33C
-
-        yt, xt, yo =>
-            yi, k9, ci:vec =>
-                @im2col = {yt, yo, yi}/y, {k9, ci}/k
-            xo =>
-                x1:1, ko:dyn(xr), yi:unroll, xi:vec, ki:unroll =>
-                    @CC = {yt, yo, yi}/y, {xt, xo, x1}/xr, xi, ki  // ko
-                yi:unroll, xi:vec, ki:unroll =>
-                    @C = {yt, yo, yi}/y, {xt, xo, xi}/x  // ki
-    '''
     N, H, W, CI = [i.value for i in Data.shape]
     nElems, bsrR, bsrC = [i.value for i in Wdat.shape]
     CO = (Wptr.shape[0].value - 1) * bsrR
 
     Y, X, K = N*H*W, CO, 9*CI
-    # cfg = autotvm.get_config()
     cfg.define_split("tile_y", Y, num_outputs=3)
     cfg.define_split("tile_x", X // bsrR, num_outputs=2)
     cfg.add_flop(Y * (nElems * bsrC * bsrR * 2 - X))
-    #cfg.define_split("tile_k", K, num_outputs=2)
     if cfg.is_fallback:
-        cfg['tile_y'] = autotvm.task.space.SplitEntity([-1, 160, 8])
-        cfg['tile_x'] = autotvm.task.space.SplitEntity([-1, 4])
+        cfg["tile_y"] = autotvm.task.space.SplitEntity([-1, 160, 8])
+        cfg["tile_x"] = autotvm.task.space.SplitEntity([-1, 4])
     
     idxsplit = lambda x,y: reduce(lambda a,b: a[:-1]+[a[-1]%b,a[-1]//b], y, [x])
 
-    @partial(te.compute, (Y, K), name='Im2Col')
+    @partial(te.compute, (Y, K), name="Im2Col")
     def Im2Col(row, col):
         jw, jh, jn = idxsplit(row, [W, H])
         jc, kw, kh = idxsplit(col, [CI, 3])
@@ -105,27 +89,27 @@ def spconv2d_3x3_nhwc(cfg, Data, Wdat, Wind, Wptr, layout="NHWC"):
             tir.all(0 <= ih, ih < H, 0 <= iw, iw < W),
             Data[jn, ih, iw, jc], 0)
     
-    @partial(te.compute, (Y, X // bsrR, bsrR, bsrC), name='CC')
+    @partial(te.compute, (Y, X // bsrR, bsrR, bsrC), name="CC")
     def CC(drow, wrow, brow, bcol):
         row_start, row_end = Wptr[wrow], Wptr[wrow+1]
-        elem_idx = te.reduce_axis((0, row_end - row_start), name='elem_idx')
+        elem_idx = te.reduce_axis((0, row_end - row_start), name="elem_idx")
         elem = row_start + elem_idx
         return te.sum(Im2Col[drow, Wind[elem]*bsrC + bcol] * Wdat[elem, brow, bcol], axis=elem_idx)
 
-    k = te.reduce_axis((0, bsrC), name='k')
+    k = te.reduce_axis((0, bsrC), name="k")
     C = te.compute((Y, X),
         lambda y, x: te.sum(CC[y, x // bsrR, x % bsrR, k], axis=k),
-        name='C', tag='conv3x3_spNHWC')
+        name="C", tag="conv3x3_spNHWC")
     return reshape(C, (N, H, W, CO))
 
 
-@autotvm.register_topi_schedule('conv3x3_spNHWC.x86')
+@autotvm.register_topi_schedule("conv3x3_spNHWC.x86")
 def schedule_spconv2d_3x3_nhwc(cfg, outs):
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
     
     def _callback(op):
-        if op.tag == 'conv3x3_spNHWC':
+        if op.tag == "conv3x3_spNHWC":
             C = op
             CC, = op.input_tensors
             Wptr, Wind, Im2Col, Wdat = CC.op.input_tensors
@@ -134,9 +118,9 @@ def schedule_spconv2d_3x3_nhwc(cfg, outs):
             CI = Data.shape[-1].value
 
             y, x = s[C].op.axis
-            yt, yo, yi = cfg['tile_y'].apply(s, C, y)
+            yt, yo, yi = cfg["tile_y"].apply(s, C, y)
             xo, xi = s[C].split(x, factor=bsrR)
-            xt, xo = cfg['tile_x'].apply(s, C, xo)
+            xt, xo = cfg["tile_x"].apply(s, C, xo)
             (k,) = s[C].op.reduce_axis
             s[C].reorder(yt, xt, yo, xo, yi, xi, k)
             s[C].unroll(k)
@@ -161,8 +145,8 @@ def schedule_spconv2d_3x3_nhwc(cfg, outs):
     return s
 
 
-@autotvm.register_topi_compute('conv3x3_spNCHW.x86')
-def spconv2d_3x3_nchw(cfg, Data, Wdat, Wind, Wptr):
+@autotvm.register_topi_compute("conv3x3_spNCHW.x86")
+def spconv2d_3x3_nchw(cfg, Data, Wdat, Wind, Wptr, layout="NCHW"):
     N, CI, H, W = [i.value for i in Data.shape]
     NNZ, VL, bsrC = [i.value for i in Wdat.shape]
     CO = (Wptr.shape[0].value - 1) * VL
@@ -172,7 +156,7 @@ def spconv2d_3x3_nchw(cfg, Data, Wdat, Wind, Wptr):
     cfg.define_split("tile_hw", H*W, num_outputs=3)
     cfg.define_split("tile_ckk", CI*9, num_outputs=3)
     
-    @partial(te.compute, (N, CI*3*3, H*W), name='im2col')
+    @partial(te.compute, (N, CI*3*3, H*W), name="im2col")
     def Im2Col(n, ckk, hw):
         jh, jw = hw // W, hw % W
         ic, kh, kw = ckk // 9, ckk // 3 % 3, ckk % 3
@@ -181,10 +165,10 @@ def spconv2d_3x3_nchw(cfg, Data, Wdat, Wind, Wptr):
             tir.all(0 <= ih, ih < H, 0 <= iw, iw < W),
             Data[n, ic, ih, iw], 0)
     
-    @partial(te.compute, (N, CO // VL, VL, bsrC, H*W), name='CC', tag='conv3x3_spNCHW')
+    @partial(te.compute, (N, CO // VL, VL, bsrC, H*W), name="CC", tag="conv3x3_spNCHW")
     def CC(n, fo, fi, k, hw):
         row_start, row_end = Wptr[fo], Wptr[fo+1]
-        elem_idx = te.reduce_axis((0, row_end - row_start), name='elem_idx')
+        elem_idx = te.reduce_axis((0, row_end - row_start), name="elem_idx")
         elem = row_start + elem_idx
         return te.sum(Im2Col[n, Wind[elem] * bsrC + k, hw] * Wdat[elem, fi, k],
                       axis=elem_idx)
@@ -192,13 +176,13 @@ def spconv2d_3x3_nchw(cfg, Data, Wdat, Wind, Wptr):
     return reshape(CC, [N, CO, H, W])
 
 
-@autotvm.register_topi_schedule('conv3x3_spNCHW.x86')
+@autotvm.register_topi_schedule("conv3x3_spNCHW.x86")
 def schedule_spconv2d_3x3_nchw(cfg, outs):
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
     
     def _callback(op):
-        if op.tag == 'conv3x3_spNCHW':
+        if op.tag == "conv3x3_spNCHW":
             CC = op
             Wptr, Wind, im2col, Wdat = op.input_tensors
             Data, = im2col.op.input_tensors

--- a/python/tvm/topi/x86/sparse.py
+++ b/python/tvm/topi/x86/sparse.py
@@ -16,8 +16,10 @@
 # under the License.
 
 """sparse_dense schedule on x86"""
-from tvm import te
+from tvm import te, tir, autotvm
+from functools import partial, reduce
 
+from ..transform import reshape
 from ..utils import traverse_inline, get_const_int
 from .utils import get_fp32_len
 
@@ -57,6 +59,103 @@ def schedule_sparse_dense(outs):
             else:
                 m_o_noo = s[y_reshape].fuse(m_o, noo)
                 s[y_reshape].parallel(m_o_noo)
+
+    traverse_inline(s, outs[0].op, _callback)
+    return s
+
+
+@autotvm.register_topi_compute('conv3x3_spNHWC.x86')
+def spconv2d_3x3_nhwc(cfg, Data, Wdat, Wind, Wptr):
+    '''# My SpConv2d_3x3_gemm
+
+        Data: N,H,W,C -> NHW,33C
+        Weight: F,3,3,C -> F,33C
+
+        yt, xt, yo =>
+            yi, k9, ci:vec =>
+                @im2col = {yt, yo, yi}/y, {k9, ci}/k
+            xo =>
+                x1:1, ko:dyn(xr), yi:unroll, xi:vec, ki:unroll =>
+                    @CC = {yt, yo, yi}/y, {xt, xo, x1}/xr, xi, ki  // ko
+                yi:unroll, xi:vec, ki:unroll =>
+                    @C = {yt, yo, yi}/y, {xt, xo, xi}/x  // ki
+    '''
+    N, H, W, CI = [i.value for i in Data.shape]
+    nElems, bsrR, bsrC = [i.value for i in Wdat.shape]
+    CO = (Wptr.shape[0].value - 1) * bsrR
+
+    Y, X, K = N*H*W, CO, 9*CI
+    # cfg = autotvm.get_config()
+    cfg.define_split("tile_y", Y, num_outputs=3)
+    cfg.define_split("tile_x", X // bsrR, num_outputs=2)
+    cfg.add_flop(Y * (nElems * bsrC * bsrR * 2 - X))
+    #cfg.define_split("tile_k", K, num_outputs=2)
+    if cfg.is_fallback:
+        cfg['tile_y'] = autotvm.task.space.SplitEntity([-1, 160, 8])
+        cfg['tile_x'] = autotvm.task.space.SplitEntity([-1, 4])
+    
+    idxsplit = lambda x,y: reduce(lambda a,b: a[:-1]+[a[-1]%b,a[-1]//b], y, [x])
+
+    @partial(te.compute, (Y, K), name='Im2Col')
+    def Im2Col(row, col):
+        jw, jh, jn = idxsplit(row, [W, H])
+        jc, kw, kh = idxsplit(col, [CI, 3])
+        ih, iw = jh + kh - 1, jw + kw - 1
+        return tir.if_then_else(
+            tir.all(0 <= ih, ih < H, 0 <= iw, iw < W),
+            Data[jn, ih, iw, jc], 0)
+    
+    @partial(te.compute, (Y, X // bsrR, bsrR, bsrC), name='CC')
+    def CC(drow, wrow, brow, bcol):
+        row_start, row_end = Wptr[wrow], Wptr[wrow+1]
+        elem_idx = te.reduce_axis((0, row_end - row_start), name='elem_idx')
+        elem = row_start + elem_idx
+        return te.sum(Im2Col[drow, Wind[elem]*bsrC + bcol] * Wdat[elem, brow, bcol], axis=elem_idx)
+
+    k = te.reduce_axis((0, bsrC), name='k')
+    C = te.compute((Y, X),
+        lambda y, x: te.sum(CC[y, x // bsrR, x % bsrR, k], axis=k),
+        name='C', tag='conv3x3_spNHWC')
+    return reshape(C, (N, H, W, CO))
+
+
+@autotvm.register_topi_schedule('conv3x3_spNHWC.x86')
+def schedule_spconv2d_3x3_nhwc(cfg, outs):
+    outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
+    s = te.create_schedule([x.op for x in outs])
+    
+    def _callback(op):
+        if op.tag == 'conv3x3_spNHWC':
+            C = op
+            CC, = op.input_tensors
+            Wptr, Wind, Im2Col, Wdat = CC.op.input_tensors
+            Data, = Im2Col.op.input_tensors
+            bsrR = CC.shape[-2].value
+            CI = Data.shape[-1].value
+
+            y, x = s[C].op.axis
+            yt, yo, yi = cfg['tile_y'].apply(s, C, y)
+            xo, xi = s[C].split(x, factor=bsrR)
+            xt, xo = cfg['tile_x'].apply(s, C, xo)
+            (k,) = s[C].op.reduce_axis
+            s[C].reorder(yt, xt, yo, xo, yi, xi, k)
+            s[C].unroll(k)
+            s[C].vectorize(xi)
+            s[C].unroll(yi)
+
+            s[CC].compute_at(s[C], xo)
+            yi, xi, r, c = s[CC].op.axis
+            (k,) = s[CC].op.reduce_axis
+            s[CC].reorder(xi, k, yi, r, c)
+            s[CC].unroll(c)
+            s[CC].vectorize(r)
+            s[CC].unroll(yi)
+            
+            s[Im2Col].compute_at(s[C], yo)
+            yi, k = s[Im2Col].op.axis
+            ko, ki = s[Im2Col].split(k, factor=CI)
+            s[Im2Col].vectorize(ki)
+            #s[Im2Col].unroll(yi)
 
     traverse_inline(s, outs[0].op, _callback)
     return s

--- a/python/tvm/topi/x86/sparse.py
+++ b/python/tvm/topi/x86/sparse.py
@@ -65,7 +65,7 @@ def schedule_sparse_dense(outs):
 
 
 @autotvm.register_topi_compute('conv3x3_spNHWC.x86')
-def spconv2d_3x3_nhwc(cfg, Data, Wdat, Wind, Wptr):
+def spconv2d_3x3_nhwc(cfg, Data, Wdat, Wind, Wptr, layout="NHWC"):
     '''# My SpConv2d_3x3_gemm
 
         Data: N,H,W,C -> NHW,33C

--- a/src/relay/op/nn/sparse.cc
+++ b/src/relay/op/nn/sparse.cc
@@ -274,10 +274,11 @@ bool SparseConv2dRel(const Array<Type>& types, int num_inputs, const Attrs& attr
 }
 
 Expr MakeSparseConv2d(Expr data, Expr weight_data, Expr weight_indices, Expr weight_indptr,
-                      std::string layout) {
+                      std::string layout, int kernel_size) {
   static const Op& op = Op::Get("nn.sparse_conv2d");
   auto attrs = make_object<SparseConv2DAttrs>();
   attrs->layout = std::move(layout);
+  attrs->kernel_size = kernel_size;
   return Call(op, {data, weight_data, weight_indices, weight_indptr}, Attrs(attrs), {});
 }
 

--- a/src/relay/transforms/convert_sparse_conv2d.cc
+++ b/src/relay/transforms/convert_sparse_conv2d.cc
@@ -138,6 +138,163 @@ Expr Conv2dToSparse(const Expr& e, const Array<ObjectRef>& weight_name,
   return PostOrderRewrite(e, &rewriter);
 }
 
+
+template <typename elemTy, size_t... Is>
+auto unpack_to_tuple_internal(elemTy *arr, std::index_sequence<Is...>) {
+  return std::make_tuple(arr[Is]...);
+}
+
+template <int N, typename elemTy>
+auto unpack_to_tuple(elemTy *arr) {
+  return unpack_to_tuple_internal(arr, std::make_index_sequence<N>{});
+}
+
+struct Range {
+  size_t dim;
+  Range(size_t d): dim(d) {}
+
+  struct iterpoint {
+    size_t val, lim;
+    iterpoint(size_t v1, size_t v2): val(v1), lim(v2) {}
+
+    size_t operator*() const {
+      return val;
+    }
+
+    iterpoint operator/(const iterpoint &rhs) const {
+      return iterpoint(val * rhs.lim + rhs.val, lim * rhs.lim);
+    }
+  };
+
+  struct iterator {
+    size_t val, lim;
+    iterator(size_t v1, size_t v2): val(v1), lim(v2) {}
+
+    bool operator!=(const iterator &rhs) const {
+      return val != rhs.val;
+    }
+
+    void operator++() {
+      ++val;
+    }
+
+    iterpoint operator*() const {
+      return iterpoint(val, lim);
+    }
+  };
+
+  iterator begin() {
+    return iterator(0, dim);
+  }
+
+  iterator end() {
+    return iterator(dim, dim);
+  }
+};
+
+
+// Mutate ```nn.conv2d``` to ```nn.sparse_conv2d```
+class Conv2dToSparseConv2dMutator2 : public ExprRewriter {
+ public:
+  Conv2dToSparseConv2dMutator2(const String& layout, int kernel_size,
+                               int blockH, int blockW, double sparse_thresh)
+      : sparse_conv2d_op_(Op::Get("nn.sparse_conv2d")), dev_cpu0_{DLDeviceType::kDLCPU, 0},
+        layout_(layout), kernel_size_(kernel_size),
+        blockH_(blockH), blockW_(blockW), sparse_thresh_(sparse_thresh) { }
+
+  Expr Rewrite_(const CallNode* pre, const Expr& post) override {
+    // check op type & attrs
+    const auto pre_attrs = pre->attrs.as<Conv2DAttrs>();
+    if (!pre_attrs 
+        || pre_attrs->data_layout != layout_
+        || pre_attrs->strides[0].as<IntImmNode>()->value != 1
+        || pre_attrs->kernel_size[0].as<IntImmNode>()->value != kernel_size_)
+      return post;
+    // check constant weight
+    const auto pre_weight_node = pre->args[1].as<ConstantNode>();
+    if (!pre_weight_node)
+      return post;
+
+    // check weight dtype & shape
+    auto &&pre_weight = pre_weight_node->data;
+    auto dtype = pre_weight.DataType(), itype = runtime::DataType::Int(32);
+    ICHECK(dtype.code() == DataType::kFloat && dtype.bits() == 32);  // float32 only
+    auto pre_weight_shape = unpack_to_tuple<4>(pre_weight.Shape().data());
+    int O, I, H, W;
+    if (layout_ == "NCHW") {
+      std::tie(O, I, H, W) = pre_weight_shape;
+    } else {  // NHWC
+      std::tie(H, W, I, O) = pre_weight_shape;
+    }
+    int CO = O, CI = H * W * I;
+
+    // copy to vector
+    std::vector<float> pre_weight_data(CO * CI);
+    pre_weight.CopyToBytes(pre_weight_data.data(), pre_weight_data.size() * sizeof(float));
+    if (layout_ == "NHWC") {
+      std::vector<float> tmp(pre_weight_data.size());
+      for (auto i: Range(CO))
+        for (auto j: Range(CI))
+          tmp[*(i / j)] = pre_weight_data[*(j / i)];
+      std::swap(tmp, pre_weight_data);
+    }
+    // convert to BSR
+    std::vector<float> wdata, block(blockH_ * blockW_);
+    std::vector<int32_t> windices, windptr;
+    for (auto bh: Range(CO / blockH_)) {
+      windptr.push_back(windices.size());
+      for (auto bw: Range(CI / blockW_)) {
+        int cntnnz = 0;
+        for (auto i: Range(blockH_))
+        for (auto j: Range(blockW_)) {
+          auto tmp = pre_weight_data[*(bh / i / bw / j)];
+          if (tmp) cntnnz++;
+          block[*(i / j)] = tmp;
+        }
+        if (cntnnz) {
+          wdata.insert(wdata.end(), block.begin(), block.end());
+          windices.push_back(*bw);
+        }
+      }
+    }
+    windptr.push_back(windices.size());
+    double sprate = 1 - 1.0 * wdata.size() / pre_weight_data.size();
+    if (sprate < sparse_thresh_) return post;
+
+    // constrct return data
+    int nnz = windices.size();
+    auto weight_data = runtime::NDArray::Empty({nnz, blockH_, blockW_}, dtype, dev_cpu0_);
+    auto weight_indices = runtime::NDArray::Empty({nnz}, itype, dev_cpu0_);
+    auto weight_indptr = runtime::NDArray::Empty({CO / blockH_ + 1}, itype, dev_cpu0_);
+    weight_data.CopyFromBytes(wdata.data(), wdata.size() * sizeof(float));
+    weight_indices.CopyFromBytes(windices.data(), windices.size() * sizeof(int32_t));
+    weight_indptr.CopyFromBytes(windptr.data(), windptr.size() * sizeof(int32_t));
+
+    // construct return call
+    auto args = runtime::Array<relay::Expr> {
+      post.as<CallNode>()->args[0],
+      Constant(weight_data), Constant(weight_indices), Constant(weight_indptr)
+    };
+    auto attrs = make_object<SparseConv2DAttrs>();
+    attrs->layout = layout_;
+    attrs->kernel_size = kernel_size_;
+    return Call(sparse_conv2d_op_, args, Attrs(attrs));
+  }
+
+private:
+  const Op &sparse_conv2d_op_;
+  DLDevice dev_cpu0_;
+  String layout_;
+  int kernel_size_, blockH_, blockW_;
+  double sparse_thresh_;
+};  // class Conv2dToSparseConv2dMutator2
+
+Expr Conv2dToSparse2(const Expr& e, const String& layout, int kernel_size, int blockH, int blockW, double sparse_thresh) {
+  auto rewriter = Conv2dToSparseConv2dMutator2(layout, kernel_size, blockH, blockW, sparse_thresh);
+  return PostOrderRewrite(e, &rewriter);
+}
+
+
 namespace transform {
 
 Pass Conv2dToSparse(const Array<ObjectRef>& weight_name, const Array<Array<PrimExpr>>& weight_shape,
@@ -158,6 +315,18 @@ Pass Conv2dToSparse(const Array<ObjectRef>& weight_name, const Array<Array<PrimE
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.Conv2dToSparse").set_body_typed(Conv2dToSparse);
+
+
+Pass Conv2dToSparse2(const String& layout, int kernel_size, int blockH, int blockW, double sparse_thresh) {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        auto f0 = Downcast<Function>(Conv2dToSparse2(f, layout, kernel_size, blockH, blockW, sparse_thresh));
+        return f0;
+      };
+  return CreateFunctionPass(pass_func, 5, "Conv2dToSparse2", {"DeadCodeElimination"});
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.Conv2dToSparse2").set_body_typed(Conv2dToSparse2);
 
 }  // namespace transform
 


### PR DESCRIPTION
This PR currently comes with,

- NHWC & NCHW computes & schedules implemented for x86, by AutoTVM templates;
- Relay integration, reusing the infra contributed by existing 1x1 sparse conv2d kernels;
- A new relay pass to convert sparse models from models with freezed parameters;
- Tests not included for now; need discussion on coverage design;

Sample usages [here](https://github.com/Tantalus13A98B5F/convbench/blob/main/resnet50_conv3x3/tvm/integration.ipynb). Tested on Intel Xeon 6248 using ResNet18, single-threaded, we have the following results,

| Sparsity | Op Shape (NCHW) |                 |                 |               | ResNet18 Infer |
|:--------:|:---------------:|:---------------:|:---------------:|:-------------:|:--------------:|
|          |  10, 64, 56, 56 | 10, 128, 28, 28 | 10, 256, 14, 14 | 10, 512, 7, 7 |                |
|   Dense  | 0.0113          | 0.0107          | 0.0107          | 0.0127        | 0.2144         |
|    90%   | 0.0032          | 0.0031          | 0.0029          | 0.0032        | 0.0962         |
|    80%   | 0.0048          | 0.0049          | 0.0046          | 0.0053        | 0.1199         |
|    70%   | 0.0066          | 0.0065          | 0.0061          | 0.0065        | 0.1427         |
|    60%   | 0.0082          | 0.0076          | 0.0075          | 0.0078        | 0.1634         |
|    50%   | 0.0097          | 0.0085          | 0.0086          | 0.0092        | 0.1847         |
|    40%   | 0.0109          | 0.0097          | 0.0098          | 0.0107        | 0.1966         |
|    30%   | 0.0124          | 0.0110          | 0.0111          | 0.0122        | 0.2163         |
|    20%   | 0.0136          | 0.0123          | 0.0124          | 0.0138        | 0.2315         |
|    10%   | 0.0150          | 0.0137          | 0.0139          | 0.0154        | 0.2519         |

To conclude, acceleration is possible at the sparsity of 40%, compared with NCHWc convolutions.

@jcf94 