### PR TITLE
[BugFix][TensorIR] `specialize()` updates the `attrs` of PrimFuncs

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -226,7 +226,7 @@ class DictAttrsNode : public BaseAttrsNode {
 class DictAttrs : public Attrs {
  public:
   /*!
-   * \brief Consruct a Attrs backed by DictAttrsNode.
+   * \brief Construct a Attrs backed by DictAttrsNode.
    * \param dict The attributes.
    * \return The dict attributes.
    */


### PR DESCRIPTION
The first version of `specialize()` introduced in PR #8354 didn't update the `attrs` of `PrimFunc`s. This might lead to something unexpected when a function attribute is a `PrimExpr` which contains the variables being specialized.

So this PR fixes this issue, and meanwhile provides a regression test. The regression test is a naive illustration of the described issue.

(Besides, this PR also fixes some typos.)

cc @Hzfengsy @tqchen @comaniac @jcf94 