### PR TITLE
[microTVM][RVM] Fix platform name in base-box-tool

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -43,7 +43,8 @@ ALL_PROVIDERS = (
 
 # List of microTVM platforms for testing.
 ALL_MICROTVM_PLATFORMS = (
-    "stm32f746xx",
+    "stm32f746xx_nucleo",
+    "stm32f746xx_disco",
     "nrf5340dk",
     "mps2_an521",
 )

--- a/apps/microtvm/reference-vm/zephyr/base-box/test-config.json
+++ b/apps/microtvm/reference-vm/zephyr/base-box/test-config.json
@@ -1,5 +1,9 @@
 {
-    "stm32f746xx": {
+    "stm32f746xx_nucleo": {
+        "vid_hex": "0483",
+        "pid_hex": "374b"
+        },
+    "stm32f746xx_disco": {
         "vid_hex": "0483",
         "pid_hex": "374b"
         },


### PR DESCRIPTION
Platform boards passed to base-box-tool.py needs to be a subset of
platform boards support by 'tests/micro/zephyr --microtvm-platforms='.

Currently base-box-tool.py only accepts the 'stm32f746xx' ST board,
which is not supported by 'tests/micro/zephyr --microtvm-platforms='. As
a consequence if one passes '--microtvm-platform=stm32f746xx' to
base-box-tool.py the 'tests/micro/zephyr' test will fail.

That commmit fixes it by adding two new platforms to base-box-tool
('stm32f746xx_nucleo' and 'stm32f746xx_disco') which are supported by
tests/micro/zephyr and by removing the nonexistent 'stm32f746xx'
platform. The new platform boards are quite similar and share the same
USB vID and pID.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
