### PR TITLE
[Refactor] Avoid Override Generic Op Strategy in "hls.py"

### DIFF
--- a/python/tvm/relay/op/strategy/hls.py
+++ b/python/tvm/relay/op/strategy/hls.py
@@ -80,7 +80,7 @@ def log_softmax_strategy_hls(attrs, inputs, out_type, target):
     return strategy
 
 
-@override_native_generic_func("conv2d_strategy")
+@conv2d_strategy.register("hls")
 def conv2d_strategy_hls(attrs, inputs, out_type, target):
     """conv2d hls strategy"""
     strategy = _op.OpStrategy()
@@ -132,7 +132,7 @@ def conv2d_strategy_hls(attrs, inputs, out_type, target):
     return strategy
 
 
-@override_native_generic_func("conv2d_NCHWc_strategy")
+@conv2d_NCHWc_strategy.register("hls")
 def conv2d_NCHWc_strategy_hls(attrs, inputs, out_type, target):
     """conv2d_NCHWc hls strategy"""
     strategy = _op.OpStrategy()

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -615,7 +615,6 @@ def verify_any_conv2d_NCHWc(
 
 
 # TODO(@kevinthesun): Support dynamic input height and width.
-@tvm.testing.uses_gpu
 def test_any_conv2d_NCHWc():
     verify_any_conv2d_NCHWc(
         (relay.Any(), 8, 224, 224, 8),

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -712,7 +712,6 @@ def test_alter_layout_nchw_dyn_upsamping_op():
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
 
 
-@tvm.testing.uses_gpu
 def test_alter_layout_strided_slice():
     """Test rewriting strided_slice during alter_iop_layout"""
 


### PR DESCRIPTION
This is a very obvious issue, now "hls.py" directly call decorator "override_native_generic_func" to operator "conv2d", "conv2d_NCHWc", it should call decorator "conv2d_strategy" like `conv2d_strategy.register("hls")`.

If new target is added, and there isn't define the new target specific "conv2d" op strategy, then the strategy will use that of "hls.py", this is not expected, it should use that of "generic.py".