### PR TITLE
[DOCS] Fix scipy docs inv

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,7 +190,7 @@ latex_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "matplotlib": ("https://matplotlib.org/", None),
 }
 


### PR DESCRIPTION
Likely due to scipy docs site update. Fixes the CI in the mainline.