### PR TITLE
[microTVM][RVM] Set the number of cores based on the VM sizing

### DIFF
--- a/apps/microtvm/reference-vm/zephyr/Vagrantfile
+++ b/apps/microtvm/reference-vm/zephyr/Vagrantfile
@@ -46,7 +46,12 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.provision "shell", path: "provision_setup.sh", env: {"TVM_HOME": dirs_to_mount[0]}, privileged: false
+  config.vm.provision "shell",
+    path: "provision_setup.sh",
+    env: {"TVM_HOME": dirs_to_mount[0],
+          "TVM_CI_NUM_CORES": num_cores
+    },
+    privileged: false
 
   # Enable USB Controller on VirtualBox
   vm_name = "microtvm-#{Time.now.tv_sec}"


### PR DESCRIPTION
Set the number of cores for scripts and builds that run inside the RVM
based on the specified number of cores for the VM.

Currently Vagrant doesn't set env. variable TVM_CI_NUM_CORES with the
number of cores available in the VM created by Vagrant, as a consequence
the scripts and builds (like the ones used to build TVM and QEMU) that
run inside the VM after it is created will use the default number of
only 2 CPUs, so not using the full CPU resources available in the VM,
in case there are more than 2 cores available.

This commit sets TVM_CI_NUM_CORES equal to the number of cores available
in the VM created by Vagrant so the builds (which use that environment
variable to find out the number of CPUs that must be used for the
builds) can use all the CPUs available, speeding up the builds.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
