### PR TITLE
[Frontend][ONNX] Add onnx support for `LessOrEqual`, `GreaterOrEqual`

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1620,6 +1620,22 @@ class Less(OnnxOpConverter):
         return _op.less(inputs[0], inputs[1])
 
 
+class LessOrEqual(OnnxOpConverter):
+    """Operator logical less or equal than."""
+
+    @classmethod
+    def _impl_v12(cls, inputs, attr, params):
+        return _op.less_equal(inputs[0], inputs[1])
+
+
+class GreaterOrEqual(OnnxOpConverter):
+    """Operator logical greater or equal than."""
+
+    @classmethod
+    def _impl_v12(cls, inputs, attr, params):
+        return _op.greater_equal(inputs[0], inputs[1])
+
+
 class LRN(OnnxOpConverter):
     """Operator converter for Local Response Normalization."""
 
@@ -3477,6 +3493,8 @@ def _get_convert_map(opset):
         "Exp": Renamer("exp"),
         "Greater": Greater.get_converter(opset),
         "Less": Less.get_converter(opset),
+        "LessOrEqual": LessOrEqual.get_converter(opset),
+        "GreaterOrEqual": GreaterOrEqual.get_converter(opset),
         "Log": Renamer("log"),
         "Acos": Renamer("acos"),
         "Acosh": Renamer("acosh"),

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1927,8 +1927,12 @@ def test_binary_ops(target, dev):
     verify_binary_ops("Sum", x, z)
     verify_binary_ops("Greater", x, y, "bool")
     verify_binary_ops("Greater", x, z, "bool")
+    verify_binary_ops("GreaterOrEqual", x, y, "bool")
+    verify_binary_ops("GreaterOrEqual", x, z, "bool")
     verify_binary_ops("Less", x, y, "bool")
     verify_binary_ops("Less", x, z, "bool")
+    verify_binary_ops("LessOrEqual", x, y, "bool")
+    verify_binary_ops("LessOrEqual", x, z, "bool")
     verify_binary_ops("Equal", x, y, "bool")
     verify_binary_ops("Equal", x, z, "bool")
 


### PR DESCRIPTION
This adds support for `LessOrEqual` (`<=`) and `GreaterOrEqual` (`>=`) ops for ONNX frontend, as introduced in opset 12.