### PR TITLE
[microTVM][Zephyr] Add skip for AOT test

### DIFF
--- a/apps/microtvm/zephyr/host_driven/src/main.c
+++ b/apps/microtvm/zephyr/host_driven/src/main.c
@@ -100,7 +100,7 @@ size_t TVMPlatformFormatMessage(char* out_buf, size_t out_buf_size_bytes, const 
 
 // Called by TVM when an internal invariant is violated, and execution cannot continue.
 void TVMPlatformAbort(tvm_crt_error_t error) {
-  TVMLogf("TVMError: %x", error);
+  TVMLogf("TVMError: 0x%x", error);
   sys_reboot(SYS_REBOOT_COLD);
 #ifdef CONFIG_LED
   gpio_pin_set(led0_pin, LED0_PIN, 1);

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -155,6 +155,9 @@ def _get_message(fd, expr: str):
 
 @tvm.testing.requires_micro
 def test_tflite(platform, west_cmd, skip_build, tvm_debug):
+    if platform not in ["host", "mps2_an521", "nrf5340dk", "stm32l4r5zi_nucleo", "zynq_mp_r5"]:
+        pytest.skip(msg="Model does not fit.")
+
     """Testing a TFLite model."""
     model, zephyr_board = PLATFORMS[platform]
     input_shape = (1, 32, 32, 3)


### PR DESCRIPTION
This PR adds `pytest.skip` for platforms that cannot fit the model. 
