### PR TITLE
[Relay] Change Default "opt_level" of Sequential from 2 to 0

### DIFF
--- a/python/tvm/ir/transform.py
+++ b/python/tvm/ir/transform.py
@@ -199,7 +199,7 @@ class Sequential(Pass):
         The list of passes that the sequential pass is dependent on.
     """
 
-    def __init__(self, passes=None, opt_level=2, name="sequential", required=None):
+    def __init__(self, passes=None, opt_level=0, name="sequential", required=None):
         passes = passes if passes else []
         if not isinstance(passes, (list, tuple)):
             raise TypeError("passes must be a list of Pass objects.")

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -435,7 +435,7 @@ Sequential::Sequential(tvm::Array<Pass> passes, PassInfo pass_info) {
 Sequential::Sequential(tvm::Array<Pass> passes, String name) {
   auto n = make_object<SequentialNode>();
   n->passes = std::move(passes);
-  PassInfo pass_info = PassInfo(2, std::move(name), {});
+  PassInfo pass_info = PassInfo(0, std::move(name), {});
   n->pass_info = std::move(pass_info);
   data_ = std::move(n);
 }


### PR DESCRIPTION
Current default "opt_level" of Sequential is 2, this value will lead to bug when sequential nested.
The below test case can't pass, through the opt_level of pass SimplifyExpr is 0, but the opt_level of wrapper sequential is 2, so the pass SimplifyExpr will not be run.

```python
def test_nested_sequential_with_scoping():
    def before():
        x = relay.var("x", shape=(1, 16, 16, 16), dtype="float32")
        w = relay.var("w", shape=(32, 16, 3, 3), dtype="float32")
        y = relay.nn.conv2d(x, w, padding=(1, 1))
        y = relay.reshape(y, newshape=(1, 16, -1))
        y = relay.reshape(y, newshape=(4, 8, -1, 16))
        y = relay.reverse_reshape(y, newshape=(32, 0, -1))
        return tvm.IRModule.from_expr(y)

    def expected():
        x = relay.var("x", shape=(1, 16, 16, 16), dtype="float32")
        w = relay.var("w", shape=(32, 16, 3, 3), dtype="float32")
        y = relay.nn.conv2d(x, w, padding=(1, 1))
        y = relay.reshape(y, newshape=(32, 16, 16))
        return tvm.IRModule.from_expr(y)

    z = before()
    passes = [
        tvm.transform.Sequential([relay.transform.SimplifyExpr()]),
    ]
    with tvm.transform.PassContext(opt_level=1):
        zz = tvm.transform.Sequential(passes)(z)

    expected = relay.transform.InferType()(expected())
    assert tvm.ir.structural_equal(zz, expected)
```
Actually from the comments of class Sequential, it seems we think the default value of this opt_level should be 0, but the code is not changed.
https://github.com/apache/tvm/blob/804ba2783cba8ad690ebd61e8934fd41d8a5840d/python/tvm/ir/transform.py#L189-L193

@tqchen @zhiics