### PR TITLE
Modify FQ2I pass not to depend on ending quantize op

### DIFF
--- a/src/relay/qnn/op/make_qnn_op.h
+++ b/src/relay/qnn/op/make_qnn_op.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *
+ * \file tvm/relay/op/make_op.h
+ * \brief Header of internal operator functions
+ * to assist in creating ops in C++
+ */
+#ifndef TVM_RELAY_QNN_OP_MAKE_QNN_OP_H_
+#define TVM_RELAY_QNN_OP_MAKE_QNN_OP_H_
+
+#include <tvm/relay/expr.h>
+#include <tvm/relay/op.h>
+
+namespace tvm {
+namespace relay {
+namespace qnn {
+
+Expr MakeDequantize(Expr data, Expr input_scale, Expr input_zero_point, int axis);
+
+}  // namespace qnn
+}  // namespace relay
+}  // namespace tvm
+#endif  // TVM_RELAY_QNN_OP_MAKE_QNN_OP_H_

--- a/src/relay/transforms/fake_quantization_to_integer.cc
+++ b/src/relay/transforms/fake_quantization_to_integer.cc
@@ -129,8 +129,7 @@ class AnchorQuantExtractor : public ExprVisitor {
   void VisitExpr(const Expr& expr) override {
     if (expr.as<CallNode>() == nullptr && expr.as<OpNode>() == nullptr &&
         expr.as<TupleNode>() == nullptr && expr.as<TupleGetItemNode>() == nullptr &&
-        expr.as<ConstantNode>() == nullptr &&
-        !stack_.empty() &&
+        expr.as<ConstantNode>() == nullptr && !stack_.empty() &&
         Downcast<Op>(stack_[stack_.size() - 1].as<CallNode>()->op) != quantize_op_) {
       nonquantizable_.insert(stack_[stack_.size() - 1]);
     }

--- a/src/relay/transforms/fake_quantization_to_integer.cc
+++ b/src/relay/transforms/fake_quantization_to_integer.cc
@@ -129,6 +129,7 @@ class AnchorQuantExtractor : public ExprVisitor {
   void VisitExpr(const Expr& expr) override {
     if (expr.as<CallNode>() == nullptr && expr.as<OpNode>() == nullptr &&
         expr.as<TupleNode>() == nullptr && expr.as<TupleGetItemNode>() == nullptr &&
+        expr.as<ConstantNode>() == nullptr &&
         !stack_.empty() &&
         Downcast<Op>(stack_[stack_.size() - 1].as<CallNode>()->op) != quantize_op_) {
       nonquantizable_.insert(stack_[stack_.size() - 1]);

--- a/src/relay/transforms/fake_quantization_to_integer.cc
+++ b/src/relay/transforms/fake_quantization_to_integer.cc
@@ -179,7 +179,6 @@ class AnchorQuantExtractor : public ExprVisitor {
 class SubgraphExtractor : public ExprVisitor {
  public:
   const ExprSet GetSubgraph(const Expr& expr) {
-    VisitExpr(expr);
     ExprSet subgraph;
     if (const CallNode* call_node = expr.as<CallNode>()) {
       if (call_node->op != dequantize_op_) {
@@ -260,7 +259,7 @@ class SubgraphMutator : public ExprMutator {
     }
     Expr mutated = Mutate(expr);
     // no requantize op at the end of modified subgraph is a reason to add dequantize op
-    if (Downcast<Op>(mutated.as<CallNode>()->op) != requantize_op_) {
+    if (Downcast<Op>(expr.as<CallNode>()->op) != quantize_op_) {
       const TensorAffineTypeNode* outta = affine_types_[mutated].as<TensorAffineTypeNode>();
       ICHECK(outta);
       mutated = qnn::MakeDequantize(mutated, outta->scale, outta->zero_point, -1);
@@ -323,7 +322,7 @@ class SubgraphMutator : public ExprMutator {
   ExprSet subgraph_;
   AffineTypeMap affine_types_;
   AffineType out_type_;
-  const Op requantize_op_ = Op::Get("qnn.requantize");
+  const Op quantize_op_ = Op::Get("qnn.quantize");
   const Op dequantize_op_ = Op::Get("qnn.dequantize");
 };
 

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -352,3 +352,24 @@ def test_fake_quantize_pad():
     x_np = np.random.randint(-25, 25, size=[1, 383, 128], dtype="int8")
 
     compare_fq_to_int(op, [x_np])
+
+
+def test_fake_quantize_dense_noq():
+    x = relay.var("x", shape=[128, 64], dtype="int8")
+    w = relay.var("w", shape=[64, 256], dtype="int8")
+
+    one = relay.const(1.0)
+    zero = relay.const(0)
+
+    wt = relay.qnn.op.dequantize(w, relay.const(0.5), zero)
+    t = relay.op.transpose(wt, [1, 0])
+
+    op = relay.op.nn.dense(
+        relay.qnn.op.dequantize(x, relay.const(2.0), zero),
+        t,
+    )
+
+    x_np = np.random.randint(-128, 127, size=[128, 64], dtype="int8")
+    w_np = np.random.randint(-128, 127, size=[64, 256], dtype="int8")
+
+    compare_fq_to_int(op, [x_np, w_np])


### PR DESCRIPTION
The idea of this change - not to depend on quantize op at the end of the pattern for subgraph to be converted to quantized form. I have added one more analysis pass which identifies end node in such subgraph all found nodes as anchors for further modify pass instead sticking only to quantize op

@mbrookhart could you please review?
