### PR TITLE
[AMP] Disallow fp16 conversion for arange op

### DIFF
--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -128,6 +128,8 @@ DEFAULT_NEVER_LIST = [
     # Error function doesn't seem to be able to be lowered into fp16 version in llvm.
     # Move to follow list when it does.
     "erf",
+    # Do not allow arange arguments (begin/end) to be fp16
+    "arange",
 ]
 
 

--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -128,7 +128,8 @@ DEFAULT_NEVER_LIST = [
     # Error function doesn't seem to be able to be lowered into fp16 version in llvm.
     # Move to follow list when it does.
     "erf",
-    # Do not allow arange arguments (begin/end) to be fp16
+    # Do not allow arange arguments (begin/end) to be fp16. "end" can be a big fp32 number
+    # not representable in fp16.
     "arange",
 ]
 

--- a/tests/python/relay/test_to_mixed_precision.py
+++ b/tests/python/relay/test_to_mixed_precision.py
@@ -230,6 +230,17 @@ def test_do_not_convert_softmax():
     assert tvm.ir.structural_equal(mod, output_mod)
 
 
+def test_do_not_convert_arange():
+    """Arange is a red listed operation and therefore should never be fp16."""
+    dtype = "float32"
+    arange = relay.arange(relay.const(1, dtype), relay.const(128, dtype))
+    mod = tvm.IRModule.from_expr(arange)
+    mod = tvm.relay.transform.InferType()(mod)
+
+    output_mod = verify_mixed_precision_output_close(mod, {}, atol=0.0, rtol=0)
+    assert tvm.ir.structural_equal(mod, output_mod)
+
+
 def test_green_gray_propagates_simple():
     """Conv is a green listed operation, while addition is gray.
 


### PR DESCRIPTION
Right now running the fp16 conversion pass on arange op results in a type error fp16 vs fp32, since we need to update `dtype` attributes of arange https://github.com/apache/tvm/blob/1fac10b359dec1bd6ad45ce36541a882aaba586b/include/tvm/relay/attrs/transform.h#L197

We could fix the type error that way and support fp16 arguments to arange, but that would cause a problem when `end` argument is a large number which happens to be fp32. So we should disallow fp16 conversion for arange. Since the inputs to arange are scalars, cast overhead is negligible.
@AndrewZhaoLuo 