### PR TITLE
[Target] Several minor corrections to the device property query

### DIFF
--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -122,7 +122,7 @@ void VulkanDeviceAPI::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       break;
     }
     case kDeviceName:
-      *rv = String(prop.device_name);
+      *rv = std::string(prop.device_name);
       break;
 
     case kMaxClockRate:
@@ -237,7 +237,10 @@ void VulkanDeviceAPI::GetTargetProperty(Device dev, const std::string& property,
     *rv = int64_t(prop.max_shared_memory_per_block);
   }
   if (property == "device_name") {
-    *rv = String(prop.device_name);
+    *rv = prop.device_name;
+  }
+  if (property == "device_type") {
+    *rv = prop.device_type;
   }
   if (property == "driver_version") {
     *rv = int64_t(prop.driver_version);

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -169,7 +169,7 @@ static Optional<String> JoinString(const std::vector<String>& array, char separa
     } else {
       os << quote;
       for (char c : str) {
-        if (c == separator || c == quote) {
+        if (c == quote) {
           os << escape;
         }
         os << c;
@@ -781,7 +781,7 @@ ObjectPtr<Object> TargetInternal::FromConfig(std::unordered_map<String, ObjectRe
           ICHECK_EQ(type_info.type_index, String::ContainerType::_GetOrAllocRuntimeTypeIndex())
               << "Expected " << type_info.type_key << " parameter for attribute '" << key
               << "', but received string from device api";
-          attrs[key] = ret;
+          attrs[key] = String(ret.operator std::string());
           break;
 
         default:

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -83,6 +83,11 @@ def test_target_string_with_spaces():
     assert target.attrs["device_name"] == "Name of GPU with spaces"
     assert target.attrs["device_type"] == "discrete"
 
+    target = tvm.target.Target(str(target))
+
+    assert target.attrs["device_name"] == "Name of GPU with spaces"
+    assert target.attrs["device_type"] == "discrete"
+
 
 def test_target_create():
     targets = [cuda(), rocm(), mali(), intel_graphics(), arm_cpu("rk3399"), vta(), bifrost()]


### PR DESCRIPTION
- Pass parameters through TVMRetValue as std::string instead of runtime::String

- Remove escaping of spaces inside quotes for target attributes. Updated unit test to verify round-trip behavior.

- Added missing "device_type" query for Vulkan.
