### PR TITLE
Move flake8 to ci_lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Initialize submodules
       run: git submodule update --recursive --init
-    - name: Lint Python
-      if: startsWith(matrix.os, 'macOS')
-      run: |
-        python3 -m pip install flake8
-        python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics
     - uses: actions/cache@v1
       env:
         CACHE_NUMBER: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Initialize submodules
       run: git submodule update --recursive --init
+    - name: Lint Python
+      if: startsWith(matrix.os, 'macOS')
+      run: |
+        python3 -m pip install flake8
+        python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics
     - uses: actions/cache@v1
       env:
         CACHE_NUMBER: 0

--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -32,7 +32,7 @@ RUN pip config set global.cache-dir false
 
 RUN apt-get update && apt-get install -y doxygen graphviz
 
-RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1
+RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1 flake8==3.9.2
 
 # java deps for rat
 COPY install/ubuntu_install_java.sh /install/ubuntu_install_java.sh

--- a/tests/lint/flake8.sh
+++ b/tests/lint/flake8.sh
@@ -16,5 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics
+# Disabled until docker images are rebuilt
+# python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics

--- a/tests/lint/flake8.sh
+++ b/tests/lint/flake8.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,41 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
-set -o pipefail
 
-cleanup()
-{
-  rm -rf /tmp/$$.*
-}
-trap cleanup 0
-
-
-echo "Checking file types..."
-python3 tests/lint/check_file_type.py
-
-echo "Checking ASF license headers..."
-tests/lint/check_asf_header.sh --local
-
-echo "Linting the C++ code..."
-tests/lint/cpplint.sh
-
-echo "clang-format check..."
-tests/lint/clang_format.sh
-
-echo "black check..."
-tests/lint/python_format.sh
-
-echo "Linting the Python code..."
-tests/lint/pylint.sh
-tests/lint/flake8.sh
-
-echo "Lintinf the JNI code..."
-tests/lint/jnilint.sh
-
-echo "Checking C++ documentation..."
-tests/lint/cppdocs.sh
-
-echo "Type checking with MyPy ..."
-tests/scripts/task_mypy.sh
+python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics


### PR DESCRIPTION
This fixes the scenario where you lint with ci_lint but it can still
fail in PR due to flake8 being injected only into the Mac build.

