### PR TITLE
[TEST] Refactor RPC test to isolate runs into a sub-function

### DIFF
--- a/tests/python/contrib/test_edgetpu_runtime.py
+++ b/tests/python/contrib/test_edgetpu_runtime.py
@@ -51,7 +51,7 @@ def skipped_test_tflite_runtime():
             interpreter = tflite.Interpreter(model_path=model_path)
         return interpreter
 
-    def check_remote(target_edgetpu=False):
+    def check_remote(server, target_edgetpu=False):
         tflite_model_path = get_tflite_model_path(target_edgetpu)
 
         # inference via tflite interpreter python apis
@@ -67,7 +67,6 @@ def skipped_test_tflite_runtime():
         tflite_output = interpreter.get_tensor(output_details[0]["index"])
 
         # inference via remote tvm tflite runtime
-        server = rpc.Server("127.0.0.1")
         remote = rpc.connect(server.host, server.port)
         dev = remote.cpu(0)
         if target_edgetpu:
@@ -83,9 +82,9 @@ def skipped_test_tflite_runtime():
             np.testing.assert_equal(out.numpy(), tflite_output)
 
     # Target CPU on coral board
-    check_remote()
+    check_remote(rpc.Server("127.0.0.1"))
     # Target EdgeTPU on coral board
-    check_remote(target_edgetpu=True)
+    check_remote(rpc.Server("127.0.0.1"), target_edgetpu=True)
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -120,17 +120,20 @@ def test_random_fill():
             return
 
         np_ones = np.ones((512, 512), dtype=dtype)
-        server = rpc.Server("127.0.0.1")
-        remote = rpc.connect(server.host, server.port)
-        value = tvm.nd.empty((512, 512), dtype, remote.cpu())
-        random_fill = remote.get_function("tvm.contrib.random.random_fill")
-        random_fill(value)
 
-        assert np.count_nonzero(value.numpy()) == 512 * 512
+        def check_remote(server):
+            remote = rpc.connect(server.host, server.port)
+            value = tvm.nd.empty((512, 512), dtype, remote.cpu())
+            random_fill = remote.get_function("tvm.contrib.random.random_fill")
+            random_fill(value)
 
-        # make sure arithmentic doesn't overflow too
-        np_values = value.numpy()
-        assert np.isfinite(np_values * np_values + np_values).any()
+            assert np.count_nonzero(value.numpy()) == 512 * 512
+
+            # make sure arithmentic doesn't overflow too
+            np_values = value.numpy()
+            assert np.isfinite(np_values * np_values + np_values).any()
+
+        check_remote(rpc.Server("127.0.0.1"))
 
     for dtype in [
         "bool",

--- a/tests/python/contrib/test_tflite_runtime.py
+++ b/tests/python/contrib/test_tflite_runtime.py
@@ -128,18 +128,18 @@ def test_remote():
     tflite_output = interpreter.get_tensor(output_details[0]["index"])
 
     # inference via remote tvm tflite runtime
-    server = rpc.Server("127.0.0.1")
-    remote = rpc.connect(server.host, server.port)
-    a = remote.upload(tflite_model_path)
+    def check_remote(server):
+        remote = rpc.connect(server.host, server.port)
+        a = remote.upload(tflite_model_path)
 
-    with open(tflite_model_path, "rb") as model_fin:
-        runtime = tflite_runtime.create(model_fin.read(), remote.cpu(0))
-        runtime.set_input(0, tvm.nd.array(tflite_input, remote.cpu(0)))
-        runtime.invoke()
-        out = runtime.get_output(0)
-        np.testing.assert_equal(out.numpy(), tflite_output)
+        with open(tflite_model_path, "rb") as model_fin:
+            runtime = tflite_runtime.create(model_fin.read(), remote.cpu(0))
+            runtime.set_input(0, tvm.nd.array(tflite_input, remote.cpu(0)))
+            runtime.invoke()
+            out = runtime.get_output(0)
+            np.testing.assert_equal(out.numpy(), tflite_output)
 
-    server.terminate()
+    check_remote(rpc.Server("127.0.0.1"))
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_runtime_graph.py
+++ b/tests/python/unittest/test_runtime_graph.py
@@ -65,9 +65,8 @@ def test_graph_simple():
         out = mod.get_output(0, tvm.nd.empty((n,)))
         np.testing.assert_equal(out.numpy(), a + 1)
 
-    def check_remote():
+    def check_remote(server):
         mlib = tvm.build(s, [A, B], "llvm", name="myadd")
-        server = rpc.Server("127.0.0.1")
         remote = rpc.connect(server.host, server.port)
         temp = utils.tempdir()
         dev = remote.cpu(0)
@@ -115,7 +114,7 @@ def test_graph_simple():
             del mod
 
     check_verify()
-    check_remote()
+    check_remote(rpc.Server("127.0.0.1"))
     check_sharing()
 
 

--- a/tests/python/unittest/test_runtime_graph_debug.py
+++ b/tests/python/unittest/test_runtime_graph_debug.py
@@ -32,6 +32,7 @@ from tvm.contrib.debugger import debug_executor
 
 
 @tvm.testing.requires_llvm
+@tvm.testing.requires_rpc
 def test_graph_simple():
     n = 4
     A = te.placeholder((n,), name="A")
@@ -160,9 +161,8 @@ def test_graph_simple():
         # verify dump root delete after cleanup
         assert not os.path.exists(directory)
 
-    def check_remote():
+    def check_remote(server):
         mlib = tvm.build(s, [A, B], "llvm", name="myadd")
-        server = rpc.Server("127.0.0.1")
         remote = rpc.connect(server.host, server.port)
         temp = utils.tempdir()
         dev = remote.cpu(0)
@@ -182,7 +182,7 @@ def test_graph_simple():
         np.testing.assert_equal(out.numpy(), a + 1)
 
     check_verify()
-    check_remote()
+    check_remote(rpc.Server("127.0.0.1"))
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -275,29 +275,31 @@ def test_mod_export():
 
         from tvm import rpc
 
-        server = rpc.Server("127.0.0.1", port=9094)
-        remote = rpc.connect(server.host, server.port)
-        remote.upload(path_lib)
-        loaded_lib = remote.load_module(path_lib)
-        data = np.random.uniform(-1, 1, size=input_shape(mod)).astype("float32")
-        dev = remote.cuda()
+        def check_remote(server):
+            remote = rpc.connect(server.host, server.port)
+            remote.upload(path_lib)
+            loaded_lib = remote.load_module(path_lib)
+            data = np.random.uniform(-1, 1, size=input_shape(mod)).astype("float32")
+            dev = remote.cuda()
 
-        # raw api
-        gmod = loaded_lib["default"](dev)
-        set_input = gmod["set_input"]
-        run = gmod["run"]
-        get_output = gmod["get_output"]
-        set_input("data", tvm.nd.array(data, device=dev))
-        run()
-        out = get_output(0).numpy()
-        tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
+            # raw api
+            gmod = loaded_lib["default"](dev)
+            set_input = gmod["set_input"]
+            run = gmod["run"]
+            get_output = gmod["get_output"]
+            set_input("data", tvm.nd.array(data, device=dev))
+            run()
+            out = get_output(0).numpy()
+            tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
 
-        # graph executor wrapper
-        gmod = graph_executor.GraphModule(loaded_lib["default"](dev))
-        gmod.set_input("data", data)
-        gmod.run()
-        out = gmod.get_output(0).numpy()
-        tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
+            # graph executor wrapper
+            gmod = graph_executor.GraphModule(loaded_lib["default"](dev))
+            gmod.set_input("data", data)
+            gmod.run()
+            out = gmod.get_output(0).numpy()
+            tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
+
+        check_remote(rpc.Server("127.0.0.1"))
 
     for obj_format in [".so", ".tar"]:
         verify_cpu_export(obj_format)

--- a/tests/python/unittest/test_runtime_rpc.py
+++ b/tests/python/unittest/test_runtime_rpc.py
@@ -53,6 +53,9 @@ pytestmark = pytest.mark.skipif(
     ),
 )
 
+# NOTE: When writing tests, wrap remote related checking in a sub-function
+# to ensure all the remote resources destructs before the server terminates
+
 
 @tvm.testing.requires_rpc
 def test_bigendian_rpc():
@@ -90,38 +93,49 @@ def test_bigendian_rpc():
 def test_rpc_simple():
     server = rpc.Server(key="x1")
     client = rpc.connect("127.0.0.1", server.port, key="x1")
-    f1 = client.get_function("rpc.test.addone")
-    assert f1(10) == 11
-    f3 = client.get_function("rpc.test.except")
 
-    with pytest.raises(tvm._ffi.base.TVMError):
-        f3("abc")
+    def check_remote():
+        f1 = client.get_function("rpc.test.addone")
+        assert f1(10) == 11
+        f3 = client.get_function("rpc.test.except")
 
-    f2 = client.get_function("rpc.test.strcat")
-    assert f2("abc", 11) == "abc:11"
+        with pytest.raises(tvm._ffi.base.TVMError):
+            f3("abc")
+
+        f2 = client.get_function("rpc.test.strcat")
+        assert f2("abc", 11) == "abc:11"
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc
 def test_rpc_runtime_string():
     server = rpc.Server(key="x1")
     client = rpc.connect("127.0.0.1", server.port, key="x1")
-    func = client.get_function("rpc.test.runtime_str_concat")
-    x = tvm.runtime.container.String("abc")
-    y = tvm.runtime.container.String("def")
-    assert str(func(x, y)) == "abcdef"
+
+    def check_remote():
+        func = client.get_function("rpc.test.runtime_str_concat")
+        x = tvm.runtime.container.String("abc")
+        y = tvm.runtime.container.String("def")
+        assert str(func(x, y)) == "abcdef"
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc
 def test_rpc_array():
-    x = np.ones((3, 4))
-
     server = rpc.Server()
     remote = rpc.connect("127.0.0.1", server.port)
-    r_cpu = tvm.nd.array(x, remote.cpu(0))
-    assert str(r_cpu.device).startswith("remote")
-    np.testing.assert_equal(r_cpu.numpy(), x)
-    fremote = remote.get_function("rpc.test.remote_array_func")
-    fremote(r_cpu)
+
+    def check_remote():
+        x = np.ones((3, 4))
+        r_cpu = tvm.nd.array(x, remote.cpu(0))
+        assert str(r_cpu.device).startswith("remote")
+        np.testing.assert_equal(r_cpu.numpy(), x)
+        fremote = remote.get_function("rpc.test.remote_array_func")
+        fremote(r_cpu)
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc
@@ -129,13 +143,17 @@ def test_rpc_large_array():
     # testcase of large array creation
     server = rpc.Server()
     remote = rpc.connect("127.0.0.1", server.port)
-    dev = remote.cpu(0)
-    a_np = np.ones((5041, 720)).astype("float32")
-    b_np = np.ones((720, 192)).astype("float32")
-    a = tvm.nd.array(a_np, dev)
-    b = tvm.nd.array(b_np, dev)
-    np.testing.assert_equal(a.numpy(), a_np)
-    np.testing.assert_equal(b.numpy(), b_np)
+
+    def check_remote():
+        dev = remote.cpu(0)
+        a_np = np.ones((5041, 720)).astype("float32")
+        b_np = np.ones((720, 192)).astype("float32")
+        a = tvm.nd.array(a_np, dev)
+        b = tvm.nd.array(b_np, dev)
+        np.testing.assert_equal(a.numpy(), a_np)
+        np.testing.assert_equal(b.numpy(), b_np)
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc
@@ -186,10 +204,14 @@ def test_rpc_echo():
 def test_rpc_file_exchange():
     server = rpc.Server()
     remote = rpc.connect("127.0.0.1", server.port)
-    blob = bytearray(np.random.randint(0, 10, size=(10)))
-    remote.upload(blob, "dat.bin")
-    rev = remote.download("dat.bin")
-    assert rev == blob
+
+    def check_remote():
+        blob = bytearray(np.random.randint(0, 10, size=(10)))
+        remote.upload(blob, "dat.bin")
+        rev = remote.download("dat.bin")
+        assert rev == blob
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc
@@ -321,9 +343,13 @@ def test_rpc_remote_module():
 def test_rpc_return_func():
     server = rpc.Server(key="x1")
     client = rpc.connect("127.0.0.1", server.port, key="x1")
-    f1 = client.get_function("rpc.test.add_to_lhs")
-    fadd = f1(10)
-    assert fadd(12) == 22
+
+    def check_remote():
+        f1 = client.get_function("rpc.test.add_to_lhs")
+        fadd = f1(10)
+        assert fadd(12) == 22
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc
@@ -386,14 +412,18 @@ def test_rpc_return_ndarray():
 @tvm.testing.requires_rpc
 def test_local_func():
     client = rpc.LocalSession()
-    f1 = client.get_function("rpc.test.add_to_lhs")
-    fadd = f1(10)
-    assert fadd(12) == 22
 
-    blob = bytearray(np.random.randint(0, 10, size=(10)))
-    client.upload(blob, "dat.bin")
-    rev = client.download("dat.bin")
-    assert rev == blob
+    def check_remote():
+        f1 = client.get_function("rpc.test.add_to_lhs")
+        fadd = f1(10)
+        assert fadd(12) == 22
+
+        blob = bytearray(np.random.randint(0, 10, size=(10)))
+        client.upload(blob, "dat.bin")
+        rev = client.download("dat.bin")
+        assert rev == blob
+
+    check_remote()
 
 
 @tvm.testing.requires_rpc


### PR DESCRIPTION
We kill the rpc server in the del function. When a server
co-exist with remote resources in the same function scope,
the destruction order is not determined.

This can cause server to be destructed before the actual remote array.
As a side effect, it can cause sometime test to timeout due to
waiting on the socket.