### PR TITLE
[Bugfix][Target] Correct passing of target-queried bool/int parameters

### DIFF
--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -768,9 +768,9 @@ ObjectPtr<Object> TargetInternal::FromConfig(std::unordered_map<String, ObjectRe
 
         case kTVMArgInt:
           if (type_info.type_index == Integer::ContainerType::_GetOrAllocRuntimeTypeIndex()) {
-            attrs[key] = Bool(static_cast<bool>(ret));
-          } else if (type_info.type_index == Bool::ContainerType::_GetOrAllocRuntimeTypeIndex()) {
             attrs[key] = Integer(static_cast<int64_t>(ret));
+          } else if (type_info.type_index == Bool::ContainerType::_GetOrAllocRuntimeTypeIndex()) {
+            attrs[key] = Bool(static_cast<bool>(ret));
           } else {
             LOG(FATAL) << "Expected " << type_info.type_key << " parameter for attribute '" << key
                        << "', but received integer from device api";


### PR DESCRIPTION
Bugfix for copy-paste error in #8602.  Verified that this runs vulkan unit tests locally.  @masahi, this should resolve the bug that you pointed out.