### PR TITLE
[Target] Add __launch_bounds__ directive as part of the CUDA code generation

### DIFF
--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -83,6 +83,7 @@ void CodeGenC::AddFunction(const PrimFunc& f) {
   bool no_alias = f->HasNonzeroAttr(tir::attr::kNoAlias);
 
   this->PrintFuncPrefix();
+  this->PrintExtraAttrs(f);
   this->stream << " " << static_cast<std::string>(global_symbol.value()) << "(";
 
   for (size_t i = 0; i < f->params.size(); ++i) {
@@ -124,6 +125,8 @@ void CodeGenC::AddFunction(const PrimFunc& f) {
 }
 
 void CodeGenC::PrintFuncPrefix() { stream << "void"; }
+
+void CodeGenC::PrintExtraAttrs(const PrimFunc& f) {}
 
 void CodeGenC::PrintFinalReturn() {}
 

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -104,6 +104,12 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
    */
   virtual void PrintFuncPrefix();  // NOLINT(*)
   /*!
+   * \brief Print extra function attributes
+   *
+   *  Example: __launch_bounds__(256) for CUDA functions
+   */
+  virtual void PrintExtraAttrs(const PrimFunc& f);
+  /*!
    * \brief Print the final return at the end the function.
    */
   virtual void PrintFinalReturn();  // NOLINT(*)

--- a/src/target/source/codegen_cuda.h
+++ b/src/target/source/codegen_cuda.h
@@ -46,6 +46,7 @@ class CodeGenCUDA final : public CodeGenC {
   }
   // override behavior
   void PrintFuncPrefix() final;
+  void PrintExtraAttrs(const PrimFunc& f) final;
   void VisitStmt_(const ForNode* op) final;
   void PrintStorageSync(const CallNode* op) final;
   void PrintStorageScope(const std::string& scope, std::ostream& os) final;  // NOLINT(*)


### PR DESCRIPTION
# Short Summary

Sometimes, when executing CUDA kernels, we might encounter the error `CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES` (e.g., [here](https://discuss.tvm.apache.org/t/cuda-got-error-cuda-error-launch-out-of-resources/4173)). This happens because **the nvcc compiler allocates too many registers per thread**. In the case when we launch the CUDA kernel using too many threads, the GPU will notice that the CUDA kernel requests more registers than what are available on the chip and therefore refuse to launch the kernel.

This hence implies that we need a way of telling nvcc what to expect in terms of the number of threads per block. Luckily, the `__launch_bounds__` directive can help us achieve what we want. In this patch, we add `__launch_bounds__` as part of the CUDA code generation procedure. `__launch_bounds__` will be automatically printed if it is detected that the number of threads per block is a constant integer value. Passing this information to nvcc allows it to spill registers if needed, which might hurt performance, but is still better than having a CUDA kernel that is not functional.

# Q & A

**Q: Would this affect the AutoTVM and the auto-scheduler submodule?**

A: No. Although in those cases the number of threads keeps changing at each trial, the number will be set to a constant when it comes to the code generation phase. Furthermore, in the case when the number of threads per block is not a constant, `__launch_bounds__` will simply not be printed.

Any feedback on this patch is appreciated. @comaniac @icemelon @yzhliu @yidawang 