### PR TITLE
WIP: [Relay][TOPI] Ubind op

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -288,6 +288,7 @@ struct SqueezeAttrs : public tvm::AttrsNode<SqueezeAttrs> {
   }
 };  // struct SqueezeAttrs
 
+/*! \brief Attributes used in split operators */
 struct SplitAttrs : public tvm::AttrsNode<SplitAttrs> {
   ObjectRef indices_or_sections;
   int axis;
@@ -303,6 +304,15 @@ struct SplitAttrs : public tvm::AttrsNode<SplitAttrs> {
     TVM_ATTR_FIELD(axis).set_default(0).describe("the axis to be splitted.");
   }
 };
+
+/*! \brief Attributes used in unbind operators */
+struct UnbindAttrs : public tvm::AttrsNode<UnbindAttrs> {
+  int axis;
+
+  TVM_DECLARE_ATTRS(UnbindAttrs, "relay.attrs.UnbindAttrs") {
+    TVM_ATTR_FIELD(axis).set_default(0).describe("the axis to be unbinded.");
+  }
+};  // struct UnbindAttrs
 
 /*! \brief Attributes for StridedSlice operator */
 struct StridedSliceAttrs : public tvm::AttrsNode<StridedSliceAttrs> {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -568,7 +568,7 @@ inline Array<Tensor> unbind(const Tensor& x, int axis = 0,
     axis += static_cast<int>(x->shape.size());
   }
   ICHECK_LT(axis, x->shape.size()) << "axis out of bounds";
-  ICHECK_GT(axis, 0) << "axis out of bounds";
+  ICHECK_GE(axis, 0) << "axis out of bounds";
 
   int src_axis_size = static_cast<int>(x->shape[axis].as<IntImmNode>()->value);
   Array<PrimExpr> shape;

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -562,8 +562,8 @@ inline Array<Tensor> split(const Tensor& x, Array<PrimExpr> split_indices, int a
  *
  * \return A Tensor array after unbinding input tensor
  */
-inline Array<Tensor> unbind(const Tensor& x, int axis = 0,
-                            std::string name = "T_unbind", std::string tag = kInjective) {
+inline Array<Tensor> unbind(const Tensor& x, int axis = 0, std::string name = "T_unbind",
+                            std::string tag = kInjective) {
   if (axis < 0) {
     axis += static_cast<int>(x->shape.size());
   }

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -626,37 +626,6 @@ def to_int_list(np_array):
     return [int(x) for x in np_array]
 
 
-def unbind(data, axis=0):
-    """
-    Unbind was taken from Pytorch frontend. The operation removes a tensor dimension
-    and returns a tuple of all slices along a given dimension, with specified axis removed.
-    TODO (vvchernov): It needs such operation on relay side to reduce time consumption
-    on squeeze operation.
-
-    Parameters
-    ----------
-    data : relay.Expr
-        Input tensor
-    axis : int
-        Axis along which tensor is split.
-    Returns
-    -------
-    result : List[relay.Expr]
-        The sequence of computed tensors
-    """
-    shape = infer_shape(data)
-    if axis >= len(shape):
-        msg = "Please check input dim, it shouldn't be greater than or equal to rank."
-        raise AttributeError(msg)
-
-    selections = shape[axis]
-    res_split = _op.split(data, selections, axis)
-    ret = []
-    for i in range(selections):
-        ret.append(_op.squeeze(res_split[i], axis=[axis]))
-    return _expr.TupleWrapper(_expr.Tuple(ret), selections)
-
-
 def lstm_cell(
     input_seqs,
     hidden_state,

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2256,7 +2256,7 @@ class LSTM(RNN):
             acts = [_op.sigmoid, _op.tanh, _op.tanh] * num_directions
 
         # TODO (vvchernov): It can be replaced by _op.split if issue #8412 is resolved
-        X_steps = unbind(X, axis=0)
+        X_steps = _op.unbind(X, axis=0)
 
         H_ts = _op.split(Hp_0, num_directions)
         C_ts = _op.split(Cp_0, num_directions)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -46,7 +46,6 @@ from .common import (
     infer_type,
     infer_value,
     new_var,
-    unbind,
     lstm_cell,
 )
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2256,7 +2256,7 @@ class LSTM(RNN):
             acts = [_op.sigmoid, _op.tanh, _op.tanh] * num_directions
 
         # TODO (vvchernov): It can be replaced by _op.split if issue #8412 is resolved
-        X_steps = _op.unbind(X, axis=0)
+        X_steps = _op.unbind(X, X_shape[0], axis=0)
 
         H_ts = _op.split(Hp_0, num_directions)
         C_ts = _op.split(Cp_0, num_directions)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2106,7 +2106,8 @@ class PyTorchOpConverter:
     def unbind(self, inputs, input_types):
         data = inputs[0]
         axis = int(inputs[1])
-        return _op.unbind(data, axis)
+
+        return _op.unbind(data, _infer_shape(data)[axis], axis)
 
     def shape_as_tensor(self, inputs, input_types):
         is_symbolic_shape = False
@@ -2133,7 +2134,7 @@ class PyTorchOpConverter:
         data = inputs[0]
         ret = _op.transform.argwhere(data)
         if is_numpy_style or (len(inputs) > 1 and inputs[1]):
-            return _op.unbind(ret, 1)
+            return _op.unbind(ret, _infer_shape(ret)[1], 1)
         return ret
 
     def nonzero_numpy(self, inputs, input_types):
@@ -2362,7 +2363,8 @@ class PyTorchOpConverter:
         """
         layers_num = len(layer_weights_dicts)
         # unbind input sequence to samples set
-        input_seqs = _op.unbind(input_data, 0)  # [seq_num, (batch, feature_size)]
+        # input_seqs shape = [seq_num, (batch, feature_size)]
+        input_seqs = _op.unbind(input_data, _infer_shape(input_data)[0], 0)
         output_hiddens = []
         for i in range(layers_num):
             weights_dicts = layer_weights_dicts[i]
@@ -2495,13 +2497,13 @@ class PyTorchOpConverter:
             for i in range(hidden_layers_num):
                 layers_h.append(h_0)
         else:
-            layers_h = _op.unbind(h_0, 0)
+            layers_h = _op.unbind(h_0, hidden_layers_num, 0)
         if c_0 is None:
             c_0 = _op.zeros((batch_size, hidden_size), X_dtype)
             for i in range(hidden_layers_num):
                 layers_c.append(c_0)
         else:
-            layers_c = _op.unbind(c_0, 0)
+            layers_c = _op.unbind(c_0, hidden_layers_num, 0)
 
         layer_weights_dicts = []
         k = 0  # layer counter

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2106,7 +2106,7 @@ class PyTorchOpConverter:
     def unbind(self, inputs, input_types):
         data = inputs[0]
         axis = int(inputs[1])
-        return unbind(data, axis)
+        return _op.unbind(data, axis)
 
     def shape_as_tensor(self, inputs, input_types):
         is_symbolic_shape = False
@@ -2133,7 +2133,7 @@ class PyTorchOpConverter:
         data = inputs[0]
         ret = _op.transform.argwhere(data)
         if is_numpy_style or (len(inputs) > 1 and inputs[1]):
-            return unbind(ret, 1)
+            return _op.unbind(ret, 1)
         return ret
 
     def nonzero_numpy(self, inputs, input_types):
@@ -2361,8 +2361,8 @@ class PyTorchOpConverter:
         Methods iterates layers for Stacked LSTM
         """
         layers_num = len(layer_weights_dicts)
-        # split input sequence to samples set
-        input_seqs = unbind(input_data, 0)  # [seq_num, (batch, feature_size)]
+        # unbind input sequence to samples set
+        input_seqs = _op.unbind(input_data, 0)  # [seq_num, (batch, feature_size)]
         output_hiddens = []
         for i in range(layers_num):
             weights_dicts = layer_weights_dicts[i]
@@ -2495,13 +2495,13 @@ class PyTorchOpConverter:
             for i in range(hidden_layers_num):
                 layers_h.append(h_0)
         else:
-            layers_h = unbind(h_0, 0)
+            layers_h = _op.unbind(h_0, 0)
         if c_0 is None:
             c_0 = _op.zeros((batch_size, hidden_size), X_dtype)
             for i in range(hidden_layers_num):
                 layers_c.append(c_0)
         else:
-            layers_c = unbind(c_0, 0)
+            layers_c = _op.unbind(c_0, 0)
 
         layer_weights_dicts = []
         k = 0  # layer counter

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -39,7 +39,7 @@ from ..loops import while_loop
 from ..prelude import Prelude, StaticTensorArrayOps
 from ..ty import Any, TensorType, TupleType
 from . import qnn_torch
-from .common import AttrCvt, get_relay_op, unbind, lstm_cell
+from .common import AttrCvt, get_relay_op, lstm_cell
 from .common import infer_value as _infer_value
 from .common import infer_shape as _infer_shape
 from .common import infer_value_simulated as _infer_value_simulated

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -278,6 +278,10 @@ class SqueezeAttrs(Attrs):
 class SplitAttrs(Attrs):
     """Attributes for transform.split"""
 
+@tvm._ffi.register_object("relay.attrs.UnbindAttrs")
+class UnbindAttrs(Attrs):
+    """Attributes for transform.unbind"""
+
 
 @tvm._ffi.register_object("relay.attrs.StridedSliceAttrs")
 class StridedSliceAttrs(Attrs):

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -278,6 +278,7 @@ class SqueezeAttrs(Attrs):
 class SplitAttrs(Attrs):
     """Attributes for transform.split"""
 
+
 @tvm._ffi.register_object("relay.attrs.UnbindAttrs")
 class UnbindAttrs(Attrs):
     """Attributes for transform.unbind"""

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -869,6 +869,30 @@ def split(data, indices_or_sections, axis=0):
         ret_size = len(indices_or_sections) + 1
     return TupleWrapper(_make.split(data, indices_or_sections, axis), ret_size)
 
+def unbind(data, axis=0):
+    """
+    Unbind was taken from Pytorch frontend.
+    The operation returns a tuple of all slices along a given dimension,
+    with specified axis removed.
+
+    This operation is reverse for stack
+
+    Parameters
+    ----------
+    data : relay.Expr
+        The source tensor
+
+    axis : int, optional
+        The axis over which to unbind.
+
+    Returns
+    -------
+    ret : relay.Tuple([relay.Expr, relay.Expr])
+        A tuple of all slices along a given axis, already without it.
+    """
+
+    ret_size = take(shape_of(data), const(axis))
+    return TupleWrapper(_make.unbind(data, axis), ret_size)
 
 def strided_slice(data, begin, end, strides=None, axes=None, slice_mode="end"):
     """Strided slice of an array.

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -869,7 +869,8 @@ def split(data, indices_or_sections, axis=0):
         ret_size = len(indices_or_sections) + 1
     return TupleWrapper(_make.split(data, indices_or_sections, axis), ret_size)
 
-def unbind(data, axis=0):
+
+def unbind(data, seq_size, axis=0):
     """
     Unbind was taken from Pytorch frontend.
     The operation returns a tuple of all slices along a given dimension,
@@ -891,8 +892,9 @@ def unbind(data, axis=0):
         A tuple of all slices along a given axis, already without it.
     """
 
-    ret_size = take(shape_of(data), const(axis))
-    return TupleWrapper(_make.unbind(data, axis), ret_size)
+    # seq_size = take(shape_of(data), const(axis))
+    return TupleWrapper(_make.unbind(data, axis), seq_size)
+
 
 def strided_slice(data, begin, end, strides=None, axes=None, slice_mode="end"):
     """Strided slice of an array.

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -404,6 +404,24 @@ def split(ary, indices_or_sections, axis=0):
     return cpp.split(ary, indices_or_sections, axis)
 
 
+def unbind(data, axis=0):
+    """
+    Unbind operation: split a tensor into multiple sub-tensors and
+    remove specified dimension from shape of unbinded sub-tensors
+
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+
+    axis : int
+
+    Returns
+    -------
+    ret : tuple of tvm.te.Tensor
+    """
+    return cpp.unbind(data, axis)
+
+
 def take(a, indices, axis=None, batch_dims=0, mode="clip"):
     """Take elements from an array along an axis.
 

--- a/src/relay/op/make_op.h
+++ b/src/relay/op/make_op.h
@@ -74,6 +74,8 @@ Expr MakeReshapeLike(Expr lhs, Expr rhs, int lhs_begin, Integer lhs_end, int rhs
 
 Expr MakeSplit(Expr data, ObjectRef indices_or_sections, int axis);
 
+Expr MakeUnbind(Expr data, int axis);
+
 Expr MakeSqueeze(Expr data, Array<Integer> axis);
 
 Expr MakeStack(Expr data, int axis);

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2914,11 +2914,11 @@ the entries indicate where along axis the array is split.
     .set_attr<FTVMCompute>("FTVMCompute", SplitCompute)
     .set_attr<TOpPattern>("TOpPattern", kInjective);
 
-//relay.unbind
+// relay.unbind
 TVM_REGISTER_NODE_TYPE(UnbindAttrs);
 
 bool UnbindRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
-              const TypeReporter& reporter) {
+               const TypeReporter& reporter) {
   // `types` contains: [data, result]
   ICHECK_EQ(types.size(), 2) << "Expects two types, one for the input and another for the output";
   const auto* data = types[0].as<TensorTypeNode>();
@@ -2949,7 +2949,7 @@ bool UnbindRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 }
 
 Array<te::Tensor> UnbindCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
-                               const Type& out_type) {
+                                const Type& out_type) {
   const auto param = attrs.as<UnbindAttrs>();
   ICHECK(param != nullptr);
   return Array<te::Tensor>{topi::unbind(inputs[0], param->axis)};
@@ -2977,7 +2977,7 @@ RELAY_REGISTER_OP("unbind")
     .set_support_level(3)
     .add_type_rel("Unbind", UnbindRel)
     .set_attr<FTVMCompute>("FTVMCompute", UnbindCompute)
-    // TODO (vvchernov): may be kTuple or kOpaque more correct pattern
+    // TODO(vvchernov): may be kTuple or kOpaque more correct pattern
     .set_attr<TOpPattern>("TOpPattern", kInjective);
 
 // relay.slice_like

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3484,10 +3484,10 @@ def test_forward_unbind():
         def forward(self, x):
             return torch.unbind(x, self.axis)
 
-    inp = torch.randn(8, 8, 8)
-    verify_model(Unbind(0), input_data=inp)
+    inp = torch.randn(3, 5, 7, 2)
+    verify_model(Unbind(), input_data=inp)
     verify_model(Unbind(1), input_data=inp)
-    verify_model(Unbind(2), input_data=inp)
+    verify_model(Unbind(-1), input_data=inp)
 
 
 def test_forward_nonzero():

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -525,7 +525,7 @@ def test_split_infer_type():
 def test_unbind_infer_type():
     def verify_unbind(dshape, ret_type, axis=0):
         x = relay.var("x", relay.ty.TensorType(dshape, "float32"))
-        y = relay.unbind(x, axis=axis)
+        y = relay.unbind(x, dshape[axis], axis=axis)
         yy = run_infer_type(y.astuple())
         assert yy.checked_type == ret_type
 

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -522,6 +522,71 @@ def test_split_infer_type():
     )
 
 
+def test_unbind_infer_type():
+    def verify_unbind(dshape, ret_type, axis=0):
+        x = relay.var("x", relay.ty.TensorType(dshape, "float32"))
+        y = relay.unbind(x, axis=axis)
+        yy = run_infer_type(y.astuple())
+        assert yy.checked_type == ret_type
+
+    verify_unbind(
+        (3, 5, 7, 2),
+        relay.ty.TupleType(
+            tvm.runtime.convert(
+                [
+                    relay.ty.TensorType((5, 7, 2), "float32"),
+                    relay.ty.TensorType((5, 7, 2), "float32"),
+                    relay.ty.TensorType((5, 7, 2), "float32"),
+                ]
+            )
+        ),
+        axis=0,
+    )
+    verify_unbind(
+        (3, 5, 7, 2),
+        relay.ty.TupleType(
+            tvm.runtime.convert(
+                [
+                    relay.ty.TensorType((3, 7, 2), "float32"),
+                    relay.ty.TensorType((3, 7, 2), "float32"),
+                    relay.ty.TensorType((3, 7, 2), "float32"),
+                    relay.ty.TensorType((3, 7, 2), "float32"),
+                    relay.ty.TensorType((3, 7, 2), "float32"),
+                ]
+            )
+        ),
+        axis=1,
+    )
+    verify_unbind(
+        (3, 5, 7, 2),
+        relay.ty.TupleType(
+            tvm.runtime.convert(
+                [
+                    relay.ty.TensorType((3, 5, 7), "float32"),
+                    relay.ty.TensorType((3, 5, 7), "float32"),
+                ]
+            )
+        ),
+        axis=-1,
+    )
+
+    # d1, d2, d3, d4 = te.var("d1"), te.var("d2"), te.var("d3"), te.var("d4")
+    # verify_unbind(
+    #     (d1, d2, d3, d4),
+    #     relay.ty.TupleType(
+    #         tvm.runtime.convert(
+    #             [
+    #                 relay.ty.TensorType((d1, d2, d4), "float32"),
+    #                 relay.ty.TensorType((d1, d2, d4), "float32"),
+    #                 relay.ty.TensorType((d1, d2, d4), "float32"),
+    #                 relay.ty.TensorType((d1, d2, d4), "float32"),
+    #             ]
+    #         )
+    #     ),
+    #     axis=2,
+    # )
+
+
 def test_full_infer_type():
     # default settings: match input dtype
     x = relay.var("x", relay.TensorType((), "int8"))


### PR DESCRIPTION
WORK IN PROGRESS: frontend tests issue
Implementation of unbind op in relay and topi sides.
Unbind splits given tensor along specified axis to sequence of subtensors. The number of the subtensors is equal to size of the tensor along the axis. The specified axis is squeezed for each subtensor.

Example:
tensor X
shape(X) = [3, 5, 7]
seqs = unbind(X, axis = 1)
len(seqs) = 5
shape(seqs[0]) = [3, 7]

Split op is reverse concatenate op
Unbind op is reverse stack op
