### PR TITLE
[Fix][TOPI] remove wrong fix in x86's dense_nopack operator

### DIFF
--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -154,7 +154,6 @@ def _default_dense_nopack_config(cfg, M, N, K):
     cfg["tile_k"] = SplitEntity([K // tilek_bn, tilek_bn])
     cfg["tile_x"] = SplitEntity([N, 1])
     cfg["tile_y"] = SplitEntity([1, M])
-    return M, N, K
 
 
 @autotvm.register_topi_compute("dense_nopack.x86")
@@ -175,7 +174,7 @@ def dense_nopack(cfg, data, weight, bias=None, out_dtype=None):
         "tile_k", 32 if isinstance(K, (tvm.tir.Var, tvm.tir.Any)) else K, num_outputs=2
     )
     if cfg.is_fallback:
-        M, N, K = _default_dense_nopack_config(cfg, M, N, K)
+        _default_dense_nopack_config(cfg, M, N, K)
 
     vec = cfg["tile_k"].size[-1]
     k = te.reduce_axis((0, K // vec), "k")


### PR DESCRIPTION
Before #8266, `tvm.tir.Any` is a subclass of `PrimExpr` which does not have the `__floordiv__` operator `//`. When the input has a dynamic shape with `Any` in it, this line `k = te.reduce_axis((0, K // vec), "k")` in `dense_nopack` will throw an error like

```
...
    k = te.reduce_axis((0, K // vec), "k")
TypeError: unsupported operand type(s) for //: 'Any' and 'int'
```

In #8166, I made a wrong fix of the `dense_nopack` operator in x86 platform (sorry for that :( ) where I used `M`, `N` and `K` in `_default_dense_nopack_config` directly as the input of `te.compute` in `dense_nopack` (actually they are used in `_default_dense_nopack_config` to compute tile sizes, I think). I think the correct fix should be

```
if isinstance(K, tvm.tir.Any):
    k = te.reduce_axis((0, tvm.tir.floordiv(K, vec)), "k")
else:
    k = te.reduce_axis((0, K // vec), "k")
```

Now `tvm.tir.Any` is a subclass of `PrimExprWithOp` and performing floordiv with `//` is valid. I think we can remove this wrong fix now.
