### PR TITLE
[AutoScheduler] Fix FLOPS estimation

### DIFF
--- a/tests/python/unittest/test_auto_scheduler_compute_dag.py
+++ b/tests/python/unittest/test_auto_scheduler_compute_dag.py
@@ -62,6 +62,11 @@ def test_estimate_flop():
     dag = auto_scheduler.ComputeDAG([A, B, F])
     assert abs(dag.flop_ct - (2 * N ** 3 + 1234)) < 0.5
 
+    A = te.placeholder((N, N), dtype="float32", name="A")
+    F = te.compute((N, N), lambda i, j: te.if_then_else(A[i, j] > 0, A[i, j], 0))
+    dag = auto_scheduler.ComputeDAG([A, F])
+    assert abs(dag.flop_ct - N ** 2) < 0.5
+
 
 def test_stage_order():
     """Test if the stage order is preserved when recovering a DAG."""


### PR DESCRIPTION
The AutoScheduler FLOP estimator now mis-estimates the following case to be 0 FLOPS:
```
tir.if_then_else(A[i] > 0, A[i], 0)
```

This is because the expression `A[i] > 0` has output dtype `uint` while the input dtypes are `float32`. In this case the current FLOP estimater ignores the comparison flops. The original concern behinds this logic is to avoid counting index calculation, but we need to make it more general to cover the above case.

cc @merrymercy 