### PR TITLE
[microTVM] Rev ci-qemu to 0.07 (add arduino-cli to ci-qemu)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ ci_gpu = "tlcpack/ci-gpu:v0.76"
 ci_cpu = "tlcpack/ci-cpu:v0.75"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.73"
-ci_qemu = "tlcpack/ci-qemu:v0.06"
+ci_qemu = "tlcpack/ci-qemu:v0.07"
 ci_arm = "tlcpack/ci-arm:v0.06"
 // <--- End of regex-scanned config.
 


### PR DESCRIPTION
This PR adds the arduino CLI to the ci-qemu image to unblock Arduino project generator for µTVM.

cc @guberti @mehrdadh 