### PR TITLE
[TIR] enhance tir signed-unsigned cast

### DIFF
--- a/tests/python/unittest/test_tir_ops.py
+++ b/tests/python/unittest/test_tir_ops.py
@@ -174,6 +174,10 @@ def test_binary_dtype_match():
     verify_general_dtype_support(lambda a, b: a <= b, is_conditional=True)
     verify_callop_float_only(lambda a, b: te.power(a, b))
 
+    # verify bool & int32 constant folding
+    assert tvm.tir.const(1) == tvm.tir.const(True)
+    assert tvm.tir.const(2) != tvm.tir.const(True)
+
 
 def test_if_then_else():
     cases = [


### PR DESCRIPTION
This is related to an issue [here](https://discuss.tvm.apache.org/t/tir-const-1-tir-const-true-throws-valueerror/10667). In a word, when `==` and `!=` binary operators are applied to `tir.const(1)` and `tir.const(True)`, the return value will be an "EQ" expression instead of a folded `IntImm` variable (e.g., `tir.const(True)` after constant folding). This issue will bring some limitations when integrating TIR to some python native operations (e.g., `==`, `!=`, python sets, etc.).

To reproduce:

```python
from tvm import tir
assert tir.const(1) == tir.const(True)
#  Or: assert tir.const(1, "int32").__eq__(tir.const(1, "uint1")).__bool__()
# `uint1` means `bool`
```

The root cause is that during `BinaryOpMatchTypes` (https://github.com/apache/tvm/blob/main/src/tir/op/op.cc#L145), singed and unsigned variable are not compatible and `IntImmNode` would be converted to `CastNode`. However, TVM's constant folding did not support `CastNode` so that `tir.const(1, "int32").__eq__(tir.const(1, "uint1"))` would return an expression instead of another folded `IntImm` variable.

This PR fixed this problem by enhancing the unsigned-signed casting:

If the bits of signed type is greater than that of unsigned type, it means that signed type has a bigger value range than that of unsigned type. In this case, we can promote the unsigned type to a signed type so that there's no need to employ `CastNode`.

A more thorough enhancement would be supporting constant folding for `CastNode`. 

@YuchenJin @junrushao1994 @tqchen 