### PR TITLE
Fix use of fallback AutoTVM knobs in default scheduling

### DIFF
--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -824,7 +824,10 @@ class ConfigSpace(object):
 
     def _add_new_transform(self, space_class, name, axes, policy, **kwargs):
         """Add a new transform space in template"""
-        if self._collect:
+        # if we do not have tuned info (_collect == True) but defined KNOB value
+        # for "default" scheduling before call of _add_new_transform, in this case
+        # no need to create new space and override previously pointed KNOB values
+        if self._collect and not (self.is_fallback and name in self._entity_map):
             # convert schedule axis to space definition axis
             axes = [x if isinstance(x, (VirtualAxis, Axis)) else self.axis(x) for x in axes]
 

--- a/tests/python/unittest/test_autotvm_space.py
+++ b/tests/python/unittest/test_autotvm_space.py
@@ -84,6 +84,8 @@ def test_split():
     cfg = FallbackConfigEntity()
     cfg.define_split("tile_n", cfg.axis(128), num_outputs=3)
     cfg.fallback_split("tile_n", [-1, 8, 4])
+    # verify if define_split override previously manualy defined split params
+    cfg.define_split("tile_n", cfg.axis(128), num_outputs=3)
     assert cfg["tile_n"].size == [4, 8, 4]
 
     cfg = FallbackConfigEntity()


### PR DESCRIPTION
Previously knob values depended on order of explicit cfg update and cfg.define_split calls in fallback mode

I.e. schedule depend where and when default KNOB values are defined. I.e. for [dense x8](https://github.com/apache/tvm/blob/main/python/tvm/topi/x86/dense.py#L168)6 we define a split space and then if we are in fallback mode, we manually point some heuristic factors. And everything works well. But for batch_matmul x86 we define certain values in case of fallback in [compute func first](https://github.com/apache/tvm/blob/main/python/tvm/topi/x86/batch_matmul.py#L74) and only then [in schedule](https://github.com/apache/tvm/blob/main/python/tvm/topi/x86/batch_matmul.py#L120) these values will be overwritten by first pair from search space that is (-1,1).

This fix makes any order of execution reuse predefined values in fallback mode