### PR TITLE
[Frontend] clean duplicates of infer_type and infer_shape in frontends

### DIFF
--- a/python/tvm/relay/frontend/caffe.py
+++ b/python/tvm/relay/frontend/caffe.py
@@ -27,7 +27,7 @@ from .. import function as _function
 from .. import op as _op
 from ... import nd as _nd
 from .common import ExprTable
-from .common import infer_shape as _infer_shape
+from .common import infer_shape
 
 __all__ = ["from_caffe"]
 
@@ -84,8 +84,8 @@ class OperatorConverter(object):
         lhs_expr = self.exp_tab.get_expr(inputs[0])
         rhs_expr = self.exp_tab.get_expr(inputs[1])
 
-        lhs_shape = _infer_shape(lhs_expr)
-        rhs_shape = _infer_shape(rhs_expr)
+        lhs_shape = infer_shape(lhs_expr)
+        rhs_shape = infer_shape(rhs_expr)
 
         assert lhs_shape == rhs_shape, "input tensors shape should be equal"
 
@@ -163,7 +163,7 @@ class OperatorConverter(object):
         """Convert BatchNorm layer"""
         inputs = op.bottom
         in_expr = self.exp_tab.get_expr(inputs[0])
-        n, c, h, w = _infer_shape(in_expr)
+        n, c, h, w = infer_shape(in_expr)
 
         if op.name in self.new_bn:
             mean, var, eps, gamma, beta = self.new_bn[op.name]
@@ -234,7 +234,7 @@ class OperatorConverter(object):
                 np.zeros(gamma.shape, dtype=np.float32), dtype="float32"
             )
 
-        _, c, _, _ = _infer_shape(in_expr)
+        _, c, _, _ = infer_shape(in_expr)
         gamma_expr = _op.reshape(gamma_expr, newshape=(1, c, 1, 1))
         beta_expr = _op.reshape(beta_expr, newshape=(1, c, 1, 1))
         out = _op.multiply(in_expr, gamma_expr)
@@ -262,7 +262,7 @@ class OperatorConverter(object):
         dims = list(reshape_param.shape.dim)
 
         in_expr = self.exp_tab.get_expr(input_name)
-        input_shape = list(_infer_shape(in_expr))
+        input_shape = list(infer_shape(in_expr))
 
         start_axis = int(reshape_param.axis)
         if start_axis < 0:
@@ -571,7 +571,7 @@ class OperatorConverter(object):
         offset = list(getattr(crop_params, "offset", 0))
 
         # expand offset to (offset1, offset2, ...)
-        in_a_shape = _infer_shape(in_expr_a)
+        in_a_shape = infer_shape(in_expr_a)
         num_to_crop = len(in_a_shape) - axis
         if not offset:
             offset = [0] * num_to_crop

--- a/python/tvm/relay/frontend/coreml.py
+++ b/python/tvm/relay/frontend/coreml.py
@@ -29,7 +29,7 @@ from .. import op as _op
 from ... import nd as _nd
 from ..._ffi import base as _base
 from .common import ExprTable
-from .common import infer_shape as _infer_shape
+from .common import infer_shape
 
 __all__ = ["from_coreml"]
 
@@ -67,7 +67,7 @@ def _ConvolutionLayerParams(op, inexpr, etab):
     dilation = list(op.dilationFactor)
     if not dilation:
         dilation = [1, 1]
-    N, C, H, W = _infer_shape(inexpr)
+    N, C, H, W = infer_shape(inexpr)
     params = {
         "channels": op.outputChannels,
         "kernel_size": list(op.kernelSize),

--- a/python/tvm/relay/frontend/nnvm_common.py
+++ b/python/tvm/relay/frontend/nnvm_common.py
@@ -22,8 +22,7 @@ from ...tir.op import min_value
 from .. import expr as _expr
 from .. import op as _op
 from .common import get_relay_op
-from .common import infer_type as _infer_type
-from .common import infer_shape as _infer_shape
+from .common import infer_type, infer_shape
 
 
 def _warn_not_used(attr, op="nnvm"):
@@ -74,9 +73,9 @@ def _softmax_op(new_op):
 
             data = inputs[0]
             length = inputs[1]
-            data_shape = _infer_shape(data)
-            data_dtype = _infer_type(data).checked_type.dtype
-            length_shape = _infer_shape(length)
+            data_shape = infer_shape(data)
+            data_dtype = infer_type(data).dtype
+            length_shape = infer_shape(length)
 
             if axis < 0:
                 axis = len(data_shape) + axis
@@ -188,7 +187,7 @@ def _binop_scalar(new_op):
         assert len(inputs) == 1
         scalar = attrs.get_float("scalar")
         if odtype is None:
-            odtype = _infer_type(inputs[0]).checked_type.dtype
+            odtype = infer_type(inputs[0]).dtype
         scalar = _expr.const(scalar, dtype=odtype)
         return new_op(inputs[0], scalar)
 
@@ -200,7 +199,7 @@ def _rbinop_scalar(new_op):
         assert len(inputs) == 1
         scalar = attrs.get_float("scalar")
         if odtype is None:
-            odtype = _infer_type(inputs[0]).checked_type.dtype
+            odtype = infer_type(inputs[0]).dtype
         scalar = _expr.const(scalar, dtype=odtype)
         return new_op(scalar, inputs[0])
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3321,7 +3321,7 @@ class QLinearMul(OnnxOpConverter):
         y_scale = fold_constant(get_scalar(inputs[6]))
         y_zero_point = get_scalar(inputs[7], "int32")
 
-        dtype = infer_type(a).checked_type.dtype
+        dtype = infer_type(a).dtype
 
         ## Onnxruntime doesn't actually do this op in integer, they dequantize to fp32
         ## and then requantize afer
@@ -3986,7 +3986,7 @@ class Celu(OnnxOpConverter):
     @classmethod
     def _impl_v12(cls, inputs, attr, params):
         x = inputs[0]
-        dtype = infer_type(x).checked_type.dtype
+        dtype = infer_type(x).dtype
         alpha = _op.const(attr.get("alpha", 1.0), dtype)
         zero = _op.const(0, dtype)
         one = _op.const(1, dtype)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -26,12 +26,10 @@ import sys
 
 import numpy as np
 import tvm
-from tvm.ir import IRModule
 from tvm.topi.utils import get_const_tuple
 
 from .. import analysis as _analysis
 from .. import expr as _expr
-from .. import function as _function
 from .. import op as _op
 from .. import qnn, transform
 from ..expr_functor import ExprMutator

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -34,8 +34,7 @@ from .. import function as _function
 from ..ty import Any
 from ..expr_functor import ExprMutator, ExprVisitor
 from .common import get_relay_op
-from .common import infer_type as _infer_type
-from .common import infer_shape as _infer_shape
+from .common import infer_type, infer_shape
 from .common import infer_value as _infer_value
 
 from .tensorflow_ops import _convert_map
@@ -344,7 +343,7 @@ class Loop:
             # beginning with loop name.
             if lv not in self._lvar2expr[self._loop_name]:
                 var_name = "{}_loop_var_{}".format(self._loop_name, i)
-                var_type = _infer_type(lv, self._mod).checked_type
+                var_type = infer_type(lv, self._mod)
                 loop_var = tvm.relay.var(var_name, type_annotation=var_type)
                 self._lvar2expr[self._loop_name][loop_var] = lv
                 bind_map[lv] = loop_var
@@ -951,7 +950,7 @@ class GraphProto(object):
             subgraph_shape_dict, input_expr_dict = {}, {}
             for f_arg, input in zip(func.signature.input_arg, inputs):
                 input_expr_dict[f_arg.name] = input
-                subgraph_shape_dict[f_arg.name] = _infer_shape(input, main_graph_proto._mod)
+                subgraph_shape_dict[f_arg.name] = infer_shape(input, main_graph_proto._mod)
 
             func_name = "func_{}".format(func.signature.name)
             try:
@@ -1078,7 +1077,7 @@ class GraphProto(object):
 
             if node_name not in self._lname_map[loop_name]:
                 var_name = "{}_loop_var".format(node_name)
-                var_type = _infer_type(actual_expr, self._mod).checked_type
+                var_type = infer_type(actual_expr, self._mod)
                 loop_var = tvm.relay.var(var_name, type_annotation=var_type)
                 try:
                     extra_param = _infer_value(actual_expr, self._params, self._mod)
@@ -1158,7 +1157,7 @@ class GraphProto(object):
                         if output_index > 0:
                             name += ":" + str(output_index)
                         converted = self._backtrack_construct(name)
-                        shape = _infer_shape(converted, self._mod)
+                        shape = infer_shape(converted, self._mod)
                         if wnode_op.startswith("TensorArraySplit"):
                             shape = (Any(),) + shape[1:]
                         elif wnode_op.startswith("TensorArrayScatter"):

--- a/python/tvm/relay/frontend/tensorflow2_ops.py
+++ b/python/tvm/relay/frontend/tensorflow2_ops.py
@@ -22,13 +22,8 @@ from tvm.relay.prelude import StaticTensorArrayOps, get_tensor_array_shape
 from .. import op as _op
 from ..ty import Any
 from .common import infer_value as _infer_value
-from .common import infer_type as _infer_type
+from .common import infer_type
 from .tensorflow_ops import _get_more_static_shape_rank
-
-
-def _infer_type_with_prelude(val, prelude):
-    body = _infer_type(val, prelude.mod)
-    return body.checked_type
 
 
 def _need_prelude_for_shape_inference(op):
@@ -60,7 +55,7 @@ def _tensorlist_set_item():
         dtype_str = attr.get("element_dtype").name
         input_ta = inputs[0]
         input_ta_shape = get_tensor_array_shape(input_ta, dtype_str, prelude)
-        input_t_shape = _infer_type_with_prelude(inputs[2], prelude).shape
+        input_t_shape = infer_type(inputs[2], prelude.mod).shape
         input_rank = len(input_t_shape)
 
         if input_ta_shape is None:
@@ -161,7 +156,7 @@ def _tensorlist_stack():
 def _tensorlist_from_tensor():
     def _impl(inputs, attr, params, prelude):
         dtype_str = attr["element_dtype"].name
-        input_ta_shape = _infer_type_with_prelude(inputs[0], prelude).shape
+        input_ta_shape = infer_type(inputs[0], prelude.mod).shape
 
         if input_ta_shape is None:
             unstack_func = prelude.get_global_var("tensor_array_unstack", dtype_str)

--- a/tests/python/relay/test_const.py
+++ b/tests/python/relay/test_const.py
@@ -28,7 +28,7 @@ def test_const_dtype():
     strides = _op.const(np_array, dtype="int64")
 
     # strides needs to be autoconverted to int64 on Windows
-    assert infer_type(strides).checked_type.dtype == np.dtype(np.int64)
+    assert infer_type(strides).dtype == np.dtype(np.int64)
 
     a = tvm.nd.array(np.random.randint(0, high=255, size=(2, 3), dtype="uint8"))
     a = _op.const(a, dtype="uint8")


### PR DESCRIPTION
Duplicates of infer_type and infer_shape were cleaned in frontends. These methods were developed in common.py
1. In general duplicates were observed in pytorch frontend. Wrapper over infer_type is used to write nodes after graph pass to map and reuse them further. Any other frontends do not use such mechanism.
2. Practicaly the result of infer_type is needed in "checked_type" method, it was inserted to infer_type. Other option is "type_annotation", it can be directly return from infer_type, condition check was goten from pytorch frontend code for this.

@jwfromm please review