### PR TITLE
[TVMC] Switch profile flag to use new profiler

### DIFF
--- a/python/tvm/driver/tvmc/model.py
+++ b/python/tvm/driver/tvmc/model.py
@@ -371,7 +371,7 @@ class TVMCPackage(object):
 class TVMCResult(object):
     """A class that stores the results of tvmc.run and provides helper utilities."""
 
-    def __init__(self, outputs: Dict[str, np.ndarray], times: List[str]):
+    def __init__(self, outputs: Dict[str, np.ndarray], times: List[float]):
         """Create a convenience wrapper around the output of tvmc.run
 
         Parameters

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -417,7 +417,9 @@ def run_module(
     # Run must be called explicitly if profiling
     if profile:
         logger.info("Running the module with profiling enabled.")
-        module.run()
+        report = module.profile()
+        # This print is intentional
+        print(report)
 
     # create the module time evaluator (returns a function)
     timer = module.module.time_evaluator("run", dev, number=number, repeat=repeat)


### PR DESCRIPTION
TVMC was using the old style profiler. This PR switches it to use the new interface. For now the profiling information is just printed to stdout, but we could introduce a separate command in the future to output the profiling information in various ways.

@jwfromm @leandron 