### PR TITLE
[CI] Enable custom images to be set in TVM Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,21 @@ ci_qemu = "tlcpack/ci-qemu:v0.07"
 ci_arm = "tlcpack/ci-arm:v0.06"
 // <--- End of regex-scanned config.
 
+// Parameters to allow overriding (in Jenkins UI), the images
+// to be used by a given build. When provided, they take precedence
+// over default values above.
+properties([
+  parameters([
+    string(name: 'ci_lint_param', defaultValue: ""),
+    string(name: 'ci_cpu_param',  defaultValue: ""),
+    string(name: 'ci_gpu_param',  defaultValue: ""),
+    string(name: 'ci_wasm_param', defaultValue: ""),
+    string(name: 'ci_i386_param', defaultValue: ""),
+    string(name: 'ci_qemu_param', defaultValue: ""),
+    string(name: 'ci_arm_param',  defaultValue: "")
+  ])
+])
+
 // tvm libraries
 tvm_runtime = "build/libtvm_runtime.so, build/config.cmake"
 tvm_lib = "build/libtvm.so, " + tvm_runtime
@@ -106,6 +121,30 @@ def cancel_previous_build() {
 }
 
 cancel_previous_build()
+
+stage('Prepare') {
+  node('CPU') {
+    // When something is provided in ci_*_param, use it, otherwise default with ci_*
+    ci_lint = ci_lint_param ?: ci_lint
+    ci_cpu = ci_cpu_param ?: ci_cpu
+    ci_gpu = ci_gpu_param ?: ci_gpu
+    ci_wasm = ci_wasm_param ?: ci_wasm
+    ci_i386 = ci_i386_param ?: ci_i386
+    ci_qemu = ci_qemu_param ?: ci_qemu
+    ci_arm = ci_arm_param ?: ci_arm
+
+    sh """
+      echo "Docker images being used in this build:"
+      echo " ci_lint = ${ci_lint}"
+      echo " ci_cpu  = ${ci_cpu}"
+      echo " ci_gpu  = ${ci_gpu}"
+      echo " ci_wasm = ${ci_wasm}"
+      echo " ci_i386 = ${ci_i386}"
+      echo " ci_qemu = ${ci_qemu}"
+      echo " ci_arm  = ${ci_arm}"
+    """
+  }
+}
 
 stage("Sanity Check") {
   timeout(time: max_time, unit: 'MINUTES') {


### PR DESCRIPTION
Enable custom images to be set in TVM Jenkinsfile:
* This work is needed to enable automatic testing of our newly built Docker images as part of CI
* The default value is set by variables in the same Jenkinsfile and are used when no custom values are provided
* Changes are only expected to be visible in the Jenkins UI

This is also a follow-up on work done in https://github.com/tlc-pack/tlcpack/pull/62, that will allow use to test the images using always the latest from TVM Jenkinsfile.

cc @areusch @jroesch @tqchen @mbrookhart @Mousius for reviews