### PR TITLE
[UnitTest] Updated tolerances to avoid flaky unit test.

### DIFF
--- a/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
@@ -179,7 +179,7 @@ def tune_and_check(mod, data, weight):
         actual_output = get_output(data, lib)
         expected_output = get_output(data, lib2)
 
-        tvm.testing.assert_allclose(actual_output, expected_output, rtol=1e-4, atol=1e-4)
+        tvm.testing.assert_allclose(actual_output, expected_output, rtol=1e-4, atol=2e-4)
 
 
 def test_conv2d():

--- a/tests/python/topi/python/test_topi_conv2d_nchw.py
+++ b/tests/python/topi/python/test_topi_conv2d_nchw.py
@@ -142,7 +142,7 @@ class BaseConv2DTests:
         if "int" in dtype:
             tol = {"atol": 0, "rtol": 0}
         elif dtype == "float32":
-            tol = {"rtol": 1e-4, "atol": 1e-4}
+            tol = {"rtol": 1e-4, "atol": 2e-4}
         elif dtype == "float16":
             # A summation in float16 with a single accumulator very
             # quickly runs into large rounding errors.  At some point,


### PR DESCRIPTION
The result was correct, but the atol was just small enough to trigger a CI error for a value that was close to zero in an unrelated PR at #8670.

https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-8670/16/pipeline/#step-236-log-1703