### PR TITLE
Install rust in ci-lint so cargo fmt can move to lint stage

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -51,6 +51,7 @@ COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
 RUN bash /install/ubuntu_install_rust.sh
 ENV RUSTUP_HOME /opt/rust
 ENV CARGO_HOME /opt/rust
+ENV PATH $PATH:$CARGO_HOME/bin
 
 # AutoTVM deps
 COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh
@@ -59,12 +60,11 @@ RUN bash /install/ubuntu_install_redis.sh
 # Golang environment
 COPY install/ubuntu_install_golang.sh /install/ubuntu_install_golang.sh
 RUN bash /install/ubuntu_install_golang.sh
+ENV PATH $PATH:/usr/lib/go-1.10/bin
 
 # NNPACK deps
 COPY install/ubuntu_install_nnpack.sh /install/ubuntu_install_nnpack.sh
 RUN bash /install/ubuntu_install_nnpack.sh
-
-ENV PATH $PATH:$CARGO_HOME/bin:/usr/lib/go-1.10/bin
 
 # ANTLR deps
 COPY install/ubuntu_install_java.sh /install/ubuntu_install_java.sh

--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -30,9 +30,16 @@ RUN bash /install/ubuntu1804_install_python.sh
 # Globally disable pip cache
 RUN pip config set global.cache-dir false
 
-RUN apt-get update && apt-get install -y doxygen graphviz
+RUN apt-get update && apt-get install -y doxygen graphviz curl
 
 RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1 flake8==3.9.2
+
+# Rust env (build early; takes a while)
+COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
+RUN bash /install/ubuntu_install_rust.sh
+ENV RUSTUP_HOME /opt/rust
+ENV CARGO_HOME /opt/rust
+ENV PATH $PATH:$CARGO_HOME/bin
 
 # java deps for rat
 COPY install/ubuntu_install_java.sh /install/ubuntu_install_java.sh


### PR DESCRIPTION
Currently the CI can fail due to formatting problem after 1 hour of build. This is a terrible dev experience.

Installing cargo into the ci-lint container so that `cargo fmt -- --check` can be run in `tests/scripts/task_lint.sh`

cc @mehrdadh @jroesch @tqchen 