### PR TITLE
[CI] Add Arm Compute Library to Arm CI unit test pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,6 +282,7 @@ stage('Unit Test') {
         timeout(time: max_time, unit: 'MINUTES') {
           sh "${docker_run} ${ci_arm} ./tests/scripts/task_ci_setup.sh"
           sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_unittest.sh"
+          sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh"
           junit "build/pytest-results/*.xml"
           // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
         }


### PR DESCRIPTION
In #8400 Arm Compute Library tests were removed from Arm CI due to test flakiness (#8417), #8573 attempted to re-enable these tests but forgot to add execution of the test script to the Jenkins pipeline. This PR attempts to restore and enable Arm Compute Library runtime tests on Arm CI.

cc @u99127 @leandron @masahi 