### PR TITLE
[microTVM][RVM] Skip USB device attach if device is already attached

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -97,10 +97,31 @@ def parse_virtualbox_devices():
     return devices
 
 
+VIRTUALBOX_USB_DEVICE_RE = (
+    "UUID:.*([0-9a-z-]{36}).*\nVendorId:.*\(([0-9A-Z]{4})\).*\nProductId:.*\(([0-9A-Z]{4})\)\n"
+)
+
+
+def parse_virtualbox_attached_usb_devices(vm_uuid):
+    output = subprocess.check_output(["VBoxManage", "showvminfo", vm_uuid], encoding="utf-8")
+
+    r = re.compile(VIRTUALBOX_USB_DEVICE_RE)
+
+    devices = []
+    m = r.findall(output, re.MULTILINE)
+    # Transform a list of tuples (UUID, VendorId, ProductId) to a list of dicts
+    if m is not None:
+        for t in m:
+            device = {"UUID": t[0], "VendorId": t[1].lower(), "ProductId": t[2].lower()}
+            devices.append(device)
+
+    return devices
+
+
 VIRTUALBOX_VID_PID_RE = re.compile(r"0x([0-9A-Fa-f]{4}).*")
 
 
-def attach_virtualbox(uuid, vid_hex=None, pid_hex=None, serial=None):
+def attach_virtualbox(vm_uuid, vid_hex=None, pid_hex=None, serial=None):
     usb_devices = parse_virtualbox_devices()
     for dev in usb_devices:
         m = VIRTUALBOX_VID_PID_RE.match(dev["VendorId"])
@@ -122,6 +143,12 @@ def attach_virtualbox(uuid, vid_hex=None, pid_hex=None, serial=None):
             and pid_hex == dev_pid_hex
             and (serial is None or serial == dev["SerialNumber"])
         ):
+            attached_devices = parse_virtualbox_attached_usb_devices(vm_uuid)
+            for attached_dev in attached_devices:
+                if vid_hex == attached_dev["VendorId"] and pid_hex == attached_dev["ProductId"]:
+                    print(f"USB dev {vid_hex}:{pid_hex} already attached. Skipping attach.")
+                    return
+
             rule_args = [
                 "VBoxManage",
                 "usbfilter",
@@ -132,7 +159,7 @@ def attach_virtualbox(uuid, vid_hex=None, pid_hex=None, serial=None):
                 "--name",
                 "test device",
                 "--target",
-                uuid,
+                vm_uuid,
                 "--vendorid",
                 vid_hex,
                 "--productid",
@@ -141,8 +168,7 @@ def attach_virtualbox(uuid, vid_hex=None, pid_hex=None, serial=None):
             if serial is not None:
                 rule_args.extend(["--serialnumber", serial])
             subprocess.check_call(rule_args)
-            # TODO(mehrdadh): skip usb attach if it's already attached
-            subprocess.check_call(["VBoxManage", "controlvm", uuid, "usbattach", dev["UUID"]])
+            subprocess.check_call(["VBoxManage", "controlvm", vm_uuid, "usbattach", dev["UUID"]])
             return
 
     raise Exception(


### PR DESCRIPTION
Currently - when the VirtualBox provider is used - if base-box-tool.py
'test' command is used and a VM is already running with the USB device
used to perform the tests already attached to it the command fails
because it tries to blindly attach again the USB device without checking
if it is already attached.

This commit fixes that error by checking and properly skipping the USB
device if it's already attached to the VirtualBox VM.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
