### PR TITLE
[RVM] Improve base-box-tool 'build' command

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -22,6 +22,7 @@ from ast import arg
 import copy
 import json
 import logging
+import pathlib
 import os
 import re
 import shlex
@@ -251,19 +252,34 @@ def generate_packer_config(platform, file_path, providers):
 
 
 def build_command(args):
+    this_dir = pathlib.Path(THIS_DIR)
+    base_box_dir = this_dir / args.platform / "base-box"
+
     generate_packer_config(
         args.platform,
-        os.path.join(THIS_DIR, args.platform, "base-box", PACKER_FILE_NAME),
+        os.path.join(base_box_dir, PACKER_FILE_NAME),
         args.provider or ALL_PROVIDERS,
     )
     env = copy.copy(os.environ)
-    packer_args = ["packer", "build"]
+    packer_args = ["packer", "build", "-force"]
     env["PACKER_LOG"] = "1"
     env["PACKER_LOG_PATH"] = "packer.log"
     if args.debug_packer:
         packer_args += ["-debug"]
 
     packer_args += [PACKER_FILE_NAME]
+
+    box_package_exists = False
+    if not args.force:
+        box_package_dirs = [(base_box_dir / f"output-packer-{p}") for p in args.provider]
+        for box_package_dir in box_package_dirs:
+            if box_package_dir.exists():
+                print(f"A box package {box_package_dir} already exists. Refusing to overwrite it!")
+                box_package_exists = True
+
+    if box_package_exists:
+        sys.exit("One or more box packages exist (see list above). To rebuild use '--force'")
+
     subprocess.check_call(
         packer_args, cwd=os.path.join(THIS_DIR, args.platform, "base-box"), env=env
     )
@@ -503,6 +519,11 @@ def parse_args():
         "--debug-packer",
         action="store_true",
         help=("Run packer in debug mode, and write log to the base-box directory."),
+    )
+    parser_build.add_argument(
+        "--force",
+        action="store_true",
+        help=("Force rebuilding a base box from scratch if one already exists."),
     )
 
     # Options for test subcommand


### PR DESCRIPTION
Currently base-box-tool.py 'build' command will fail with a 'packer'
error message on the second run if it's run twice and the box for a
provider built on the first run is not removed manually before the
second run.

This commit avoids that failure by checking for the existence of a box
for each specified provider and if a box already exists it will refuse
to overwrite the box (since building a box takes a quite amount of time
to be done), exiting and warning the user. A new option '--force' is
added to the 'build' command that allows the user to explicitly rebuild
the box in case one already exists.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
