### PR TITLE
[CODEGEN][OpenCL]: fix tir.erf codegen to opencl directly

### DIFF
--- a/src/target/source/intrin_rule_opencl.cc
+++ b/src/target/source/intrin_rule_opencl.cc
@@ -49,6 +49,9 @@ TVM_REGISTER_OP("tir.round")
 TVM_REGISTER_OP("tir.exp").set_attr<FLowerIntrinsic>("opencl.FLowerIntrinsic",
                                                      DispatchPureExtern<Direct>);
 
+TVM_REGISTER_OP("tir.erf").set_attr<FLowerIntrinsic>("opencl.FLowerIntrinsic",
+                                                     DispatchPureExtern<Direct>);
+
 TVM_REGISTER_OP("tir.exp2")
     .set_attr<FLowerIntrinsic>("opencl.FLowerIntrinsic", DispatchPureExtern<Direct>);
 

--- a/tests/python/unittest/test_target_codegen_opencl.py
+++ b/tests/python/unittest/test_target_codegen_opencl.py
@@ -17,6 +17,7 @@
 import tvm
 from tvm import te
 import tvm.testing
+import re
 
 target = "opencl"
 
@@ -119,8 +120,7 @@ def test_opencl_max():
     check_max(dev, 1, "float32")
     check_max(dev, 1, "float64")
 
-@tvm.testing.requires_gpu
-@tvm.testing.requires_opencl
+
 def test_opencl_erf():
     def check_erf(dev, n, dtype):
         A = te.placeholder((n,), name="A", dtype=dtype)
@@ -128,10 +128,10 @@ def test_opencl_erf():
         s = te.create_schedule(C.op)
         s[C].bind(s[C].op.axis[0], te.thread_axis("threadIdx.x"))
         fun = tvm.build(s, [A, C], target)
-        a = tvm.nd.empty((n,), A.dtype, dev)
-        c = tvm.nd.empty((n,), A.dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
+        source_str = fun.imported_modules[0].get_source()
+        matches = re.findall("erf", source_str)
+        error_matches = re.findall("erff", source_str)
+        assert len(matches) == 1 and len(error_matches) == 0
 
     dev = tvm.device(target, 0)
 


### PR DESCRIPTION
Hi! When I was testing erf function on opencl target, there is an error show as the follow image
![image](https://user-images.githubusercontent.com/69908243/129524959-c892824b-d08d-4401-90ee-3194f6ec647e.png)

and the opencl codegen by tvm is:
`__kernel void tvmgen_default_fused_erf_kernel0(__global float* restrict T_erf, __global float* restrict placeholder) {
  for (int ax0_ax1_fused_outer = 0; ax0_ax1_fused_outer < 3; ++ax0_ax1_fused_outer) {
    if ((((ax0_ax1_fused_outer * 65536) + (((int)get_group_id(0)) * 256)) + ((int)get_local_id(0))) < 132444) {
      T_erf[((((ax0_ax1_fused_outer * 65536) + (((int)get_group_id(0)) * 256)) + ((int)get_local_id(0))))] = erff(placeholder[((((ax0_ax1_fused_outer * 65536) + (((int)get_group_id(0)) * 256)) + ((int)get_local_id(0))))]);
    }
  }
}`

So I add two lines in intrin_rule_opencl.cc to let tir.erf codegen to opencl directly instead of add suffix "f" as default which make erf become erff.