### PR TITLE
[microTVM] Fix platform name for qemu_x86 in Zephyr AOT tests

### DIFF
--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -138,7 +138,7 @@ def _get_message(fd, expr: str, timeout_sec: int):
 def test_tflite(temp_dir, platform, west_cmd, tvm_debug):
     """Testing a TFLite model."""
 
-    if platform not in ["host", "mps2_an521", "nrf5340dk", "stm32l4r5zi_nucleo", "zynq_mp_r5"]:
+    if platform not in ["qemu_x86", "mps2_an521", "nrf5340dk", "stm32l4r5zi_nucleo", "zynq_mp_r5"]:
         pytest.skip(msg="Model does not fit.")
 
     model, zephyr_board = PLATFORMS[platform]
@@ -220,7 +220,7 @@ def test_tflite(temp_dir, platform, west_cmd, tvm_debug):
 @tvm.testing.requires_micro
 def test_qemu_make_fail(temp_dir, platform, west_cmd, tvm_debug):
     """Testing QEMU make fail."""
-    if platform not in ["host", "mps2_an521"]:
+    if platform not in ["qemu_x86", "mps2_an521"]:
         pytest.skip(msg="Only for QEMU targets.")
 
     model, zephyr_board = PLATFORMS[platform]


### PR DESCRIPTION
Currently two Zephyr AOT tests (test_tflite and test_qemu_make_fail) are
not running when qemu_x86 platform is selected because the platform name
is wrongly listed as 'host' in the match list for not skipping these
tests. This commit fixes it.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
