### PR TITLE
Make from_tensorflow.py more GPU memory friendly.

### DIFF
--- a/tutorials/frontend/deploy_sparse.py
+++ b/tutorials/frontend/deploy_sparse.py
@@ -90,6 +90,20 @@ from tensorflow.python.framework.convert_to_constants import (
 import scipy.sparse as sp
 
 
+# Ask tensorflow to limit its GPU memory to what's actually needed
+# instead of gobbling everything that's available.
+# https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
+# This way this tutorial is a little more friendly to sphinx-gallery.
+gpus = tf.config.list_physical_devices("GPU")
+if gpus:
+    try:
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        print("tensorflow will use experimental.set_memory_growth(True)")
+    except RuntimeError as e:
+        print("experimental.set_memory_growth option is not available: {}".format(e))
+
+
 ###############################################################################
 # Configure Settings
 # ------------------

--- a/tutorials/frontend/from_tensorflow.py
+++ b/tutorials/frontend/from_tensorflow.py
@@ -36,6 +36,21 @@ import os.path
 # Tensorflow imports
 import tensorflow as tf
 
+
+# Ask tensorflow to limit it's GPU memory to what's actually needed
+# instead of gobbling everything that's available.
+# https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
+# This way this tutorial is a little more friendly to sphinx-gallery.
+gpus = tf.config.list_physical_devices("GPU")
+if gpus:
+    try:
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        print("tensorflow will use experimental.set_memory_growth(True)")
+    except RuntimeError as e:
+        print("experimental.set_memory_growth option is not available: {}".format(e))
+
+
 try:
     tf_compat_v1 = tf.compat.v1
 except ImportError:

--- a/tutorials/frontend/from_tensorflow.py
+++ b/tutorials/frontend/from_tensorflow.py
@@ -37,7 +37,7 @@ import os.path
 import tensorflow as tf
 
 
-# Ask tensorflow to limit it's GPU memory to what's actually needed
+# Ask tensorflow to limit its GPU memory to what's actually needed
 # instead of gobbling everything that's available.
 # https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
 # This way this tutorial is a little more friendly to sphinx-gallery.


### PR DESCRIPTION
Sphinx-gallery runs everything in a single process. There
doesn't appear to be any easy way to force Tensorflow to
return memory other than terminating the process. This at
least gives us a little more wiggle room.