### PR TITLE
Rev ci-qemu to v0.08

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ ci_gpu = "tlcpack/ci-gpu:v0.76"
 ci_cpu = "tlcpack/ci-cpu:v0.75"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.73"
-ci_qemu = "tlcpack/ci-qemu:v0.07"
+ci_qemu = "tlcpack/ci-qemu:v0.08"
 ci_arm = "tlcpack/ci-arm:v0.06"
 // <--- End of regex-scanned config.
 

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -37,5 +37,4 @@ pip3 install \
     requests \
     scipy \
     six \
-    synr \
     tornado


### PR DESCRIPTION
Changes:
 
 * Properly install arduino dependencies in CI-read-writable location
 * Remove synr from container-installed dependencies (it is installed last-minute in `tests/scripts/task_ci_setup.sh`
 
cc @guberti @leandron @tkonolige 