### PR TITLE
[Docker][Vulkan] Allow Vulkan GPU access in docker container.

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -83,6 +83,7 @@ RUN bash /install/ubuntu_install_caffe2.sh
 COPY install/ubuntu_install_dgl.sh /install/ubuntu_install_dgl.sh
 RUN bash /install/ubuntu_install_dgl.sh
 
+ENV NVIDIA_DRIVER_CAPABILITIES compute,graphics,utility
 COPY install/ubuntu_install_vulkan.sh /install/ubuntu_install_vulkan.sh
 RUN bash /install/ubuntu_install_vulkan.sh
 


### PR DESCRIPTION
This commit is to move in the direction of including Vulkan tests in the CI.  No vulkan tests are enabled yet, since [the CI's config.cmake](https://github.com/apache/tvm/blob/main/tests/scripts/task_config_build_gpu.sh#L26) does not enable vulkan.

- The environment variable NVIDIA_DRIVER_CAPABILITIES must include "graphics" in order to expose Vulkan drivers to the container.  This is added both to Dockerfile.ci_gpu for future image builds, and to docker/bash.sh for compatibility with current images.

- The configuration files needed by the vulkan launcher and glvnd must be exposed to the container.  These are only included in  `docker/bash.sh`, as they may vary by host and so cannot be baked into the image.