### PR TITLE
[CI] Rev ci-cpu to v0.76

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = "tlcpack/ci-lint:v0.66"
 ci_gpu = "tlcpack/ci-gpu:v0.76"
-ci_cpu = "tlcpack/ci-cpu:v0.75"
+ci_cpu = "tlcpack/ci-cpu:v0.76"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.73"
 ci_qemu = "tlcpack/ci-qemu:v0.08"


### PR DESCRIPTION
* This includes changes up to commit 1a95f9bd0.
* Tracking issue is https://github.com/apache/tvm/issues/8782

**Important: there is some ongoing pre-work being done by @jroesch before this can be safely merged, so, in doubt, don't merge it.**


cc @jroesch @areusch @grant-arm