### PR TITLE
Enable python debug runtime for exported network libraries

### DIFF
--- a/docs/dev/debugger.rst
+++ b/docs/dev/debugger.rst
@@ -153,6 +153,7 @@ How to use Debugger?
      of debug runtime will be slightly different
 
 ::
+
     lib = tvm.runtime.load_module("network.so")
     m = graph_executor.create(lib["get_graph_json"](), lib, dev, dump_root="/tmp/tvmdbg")
     # set inputs

--- a/docs/dev/debugger.rst
+++ b/docs/dev/debugger.rst
@@ -123,12 +123,12 @@ Example of loading the parameters
 How to use Debugger?
 ***************************************
 
-1. In ``config.cmake`` set the ``USE_GRAPH_RUNTIME_DEBUG`` flag to ``ON``
+1. In ``config.cmake`` set the ``USE_PROFILER`` flag to ``ON``
 
    ::
 
        # Whether enable additional graph debug functions
-       set(USE_GRAPH_RUNTIME_DEBUG ON)
+       set(USE_PROFILER ON)
 
 2. Do 'make' tvm, so that it will make the ``libtvm_runtime.so``
 
@@ -154,8 +154,7 @@ How to use Debugger?
 
 ::
     lib = tvm.runtime.load_module("network.so")
-    m = graph_executor.GraphModuleDebug(lib["debug_create"]("default", dev),
-                                         [dev], lib["get_json"](), dump_root="/tmp/tvmdbg")
+    m = graph_executor.create(lib["get_graph_json"](), lib, dev, dump_root="/tmp/tvmdbg")
     # set inputs
     m.set_input('data', tvm.nd.array(data.astype(dtype)))
     m.set_input(**params)

--- a/docs/dev/debugger.rst
+++ b/docs/dev/debugger.rst
@@ -123,12 +123,12 @@ Example of loading the parameters
 How to use Debugger?
 ***************************************
 
-1. In ``config.cmake`` set the ``USE_GRAPH_EXECUTOR_DEBUG`` flag to ``ON``
+1. In ``config.cmake`` set the ``USE_GRAPH_RUNTIME_DEBUG`` flag to ``ON``
 
    ::
 
        # Whether enable additional graph debug functions
-       set(USE_GRAPH_EXECUTOR_DEBUG ON)
+       set(USE_GRAPH_RUNTIME_DEBUG ON)
 
 2. Do 'make' tvm, so that it will make the ``libtvm_runtime.so``
 
@@ -147,6 +147,22 @@ How to use Debugger?
     # execute
     m.run()
     tvm_out = m.get_output(0, tvm.nd.empty(out_shape, dtype)).numpy()
+
+4. If network previously was exported to external libray using ``lib.export_library("network.so")``
+     like shared object file/dynamic linked library, the initialization
+     of debug runtime will be slightly different
+
+::
+    lib = tvm.runtime.load_module("network.so")
+    m = graph_executor.GraphModuleDebug(lib["debug_create"]("default", dev),
+                                         [dev], lib["get_json"](), dump_root="/tmp/tvmdbg")
+    # set inputs
+    m.set_input('data', tvm.nd.array(data.astype(dtype)))
+    m.set_input(**params)
+    # execute
+    m.run()
+    tvm_out = m.get_output(0, tvm.nd.empty(out_shape, dtype)).numpy()
+
 
 The outputs are dumped to a temporary folder in ``/tmp`` folder or the
 folder specified while creating the runtime.

--- a/src/runtime/graph_executor/graph_executor_factory.cc
+++ b/src/runtime/graph_executor/graph_executor_factory.cc
@@ -53,6 +53,10 @@ PackedFunc GraphExecutorFactory::GetFunction(
       }
       *rv = this->ExecutorCreate(devices);
     });
+  } else if (name == "get_json") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      *rv = this->graph_json_;
+    });
   } else if (name == "debug_create") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       ICHECK_GE(args.size(), 2);

--- a/src/runtime/graph_executor/graph_executor_factory.cc
+++ b/src/runtime/graph_executor/graph_executor_factory.cc
@@ -54,9 +54,8 @@ PackedFunc GraphExecutorFactory::GetFunction(
       *rv = this->ExecutorCreate(devices);
     });
   } else if (name == "get_json") {
-    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-      *rv = this->graph_json_;
-    });
+    return PackedFunc(
+        [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->graph_json_; });
   } else if (name == "debug_create") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       ICHECK_GE(args.size(), 2);

--- a/src/runtime/graph_executor/graph_executor_factory.cc
+++ b/src/runtime/graph_executor/graph_executor_factory.cc
@@ -53,9 +53,10 @@ PackedFunc GraphExecutorFactory::GetFunction(
       }
       *rv = this->ExecutorCreate(devices);
     });
-  } else if (name == "get_json") {
+  } else if (name == "get_graph_json") {
     return PackedFunc(
         [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->graph_json_; });
+
   } else if (name == "debug_create") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       ICHECK_GE(args.size(), 2);

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -106,7 +106,7 @@ def test_cpu_get_graph_json():
     loaded_lib = tvm.runtime.load_module(path_lib)
     json = loaded_lib["get_graph_json"]()
     assert isinstance(json, str) == True
-    assert json.find("tvmgen_default_fused_nn_softmax1") == 6312
+    assert json.find("tvmgen_default_fused_nn_softmax1") > -1
 
 
 @tvm.testing.requires_cuda

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -46,10 +46,8 @@ def verify(data):
     return out
 
 
+@tvm.testing.requires_llvm
 def test_legacy_compatibility():
-    if not tvm.testing.device_enabled("llvm"):
-        print("Skip because llvm is not enabled")
-        return
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):
         graph, lib, graph_params = relay.build_module.build(mod, "llvm", params=params)
@@ -63,10 +61,8 @@ def test_legacy_compatibility():
     tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
 
 
+@tvm.testing.requires_llvm
 def test_cpu():
-    if not tvm.testing.device_enabled("llvm"):
-        print("Skip because llvm is not enabled")
-        return
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):
         complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)
@@ -90,10 +86,8 @@ def test_cpu():
     tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
 
 
+@tvm.testing.requires_llvm
 def test_cpu_get_graph_json():
-    if not tvm.testing.device_enabled("llvm"):
-        print("Skip because llvm is not enabled")
-        return
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):
         complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)
@@ -139,9 +133,6 @@ def test_gpu():
 @tvm.testing.uses_gpu
 def test_mod_export():
     def verify_cpu_export(obj_format):
-        if not tvm.testing.device_enabled("llvm"):
-            print("Skip because llvm is not enabled")
-            return
         mod, params = relay.testing.synthetic.get_workload()
         with relay.build_config(opt_level=3):
             complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)
@@ -229,10 +220,8 @@ def test_mod_export():
         out = gmod.get_output(0).numpy()
         tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
 
+    @tvm.testing.requires_llvm
     def verify_rpc_cpu_export(obj_format):
-        if not tvm.testing.device_enabled("llvm"):
-            print("Skip because llvm is not enabled")
-            return
         mod, params = relay.testing.synthetic.get_workload()
         with relay.build_config(opt_level=3):
             complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)
@@ -327,12 +316,10 @@ def test_mod_export():
         verify_rpc_gpu_export(obj_format)
 
 
+@tvm.testing.requires_llvm
 @tvm.testing.uses_gpu
 def test_remove_package_params():
     def verify_cpu_remove_package_params(obj_format):
-        if not tvm.testing.device_enabled("llvm"):
-            print("Skip because llvm is not enabled")
-            return
         mod, params = relay.testing.synthetic.get_workload()
         with relay.build_config(opt_level=3):
             complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)
@@ -423,10 +410,8 @@ def test_remove_package_params():
         out = gmod.get_output(0).numpy()
         tvm.testing.assert_allclose(out, verify(data), atol=1e-5)
 
+    @tvm.testing.requires_llvm
     def verify_rpc_cpu_remove_package_params(obj_format):
-        if not tvm.testing.device_enabled("llvm"):
-            print("Skip because llvm is not enabled")
-            return
         mod, params = relay.testing.synthetic.get_workload()
         with relay.build_config(opt_level=3):
             complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)
@@ -536,10 +521,8 @@ def test_remove_package_params():
         verify_rpc_gpu_remove_package_params(obj_format)
 
 
+@tvm.testing.requires_llvm
 def test_debug_graph_executor():
-    if not tvm.testing.device_enabled("llvm"):
-        print("Skip because llvm is not enabled")
-        return
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):
         complied_graph_lib = relay.build_module.build(mod, "llvm", params=params)


### PR DESCRIPTION
Python debug runtime object require json for its initialization, but in case of previously exported library, json is not accessible outside of the compiled module. Added PAcked func "get_json" to module and updated documentation how to init python debug_executor for this case