### PR TITLE
Add synr==0.3.0 dependency for Docker images and Python dependency.

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -36,5 +36,6 @@ pip3 install \
     pytest-xdist \
     requests \
     scipy \
+    synr==0.3.0 \
     six \
     tornado

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -231,7 +231,7 @@ CONSTRAINTS = [
     ("sphinx_autodoc_annotation", None),
     ("sphinx_gallery", None),
     ("sphinx_rtd_theme", None),
-    ("synr", ">=0.2.1"),  # Requires bugfix commit ee0b12a61c08f01604475f36ff37d4cb110bdc27
+    ("synr", "==0.3.0"),
     ("tensorflow", None),
     ("tensorflow-estimator", None),
     ("tflite", None),


### PR DESCRIPTION
Add synr==0.3.0 dependency for Docker images and Python dependency:

- PR #8776 removed `synr` as a dependency to be installed in the Docker
  images, making the images to need manual intervention so that we could
  run tests.

- This PR add back `synr` (with current constraint as observed in
  tests/scripts/task_ci_setup.sh) to be part of the Docker image.


cc @areusch @jroesch @Mousius for reviews