### PR TITLE
Use CTest for C++ tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,15 @@ if(USE_PROFILER)
   list(APPEND RUNTIME_SRCS ${RUNTIME_VM_PROFILER_SRCS})
 endif(USE_PROFILER)
 
+# Enable ctest if gtest is available
+find_path(GTEST_INCLUDE_DIR gtest/gtest.h)
+find_library(GTEST_LIB gtest "$ENV{GTEST_LIB}")
+if(GTEST_INCLUDE_DIR AND GTEST_LIB)
+  enable_testing()
+  include(CTest)
+  include(GoogleTest)
+endif()
+
 # Module rules
 include(cmake/modules/VTA.cmake)
 include(cmake/modules/StandaloneCrt.cmake)
@@ -558,26 +567,16 @@ if (HIDE_PRIVATE_SYMBOLS AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   target_compile_definitions(tvm_allvisible PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 endif()
 
-# Tests
-set(TEST_EXECS "")
-file(GLOB TEST_SRCS tests/cpp/*.cc)
-find_path(GTEST_INCLUDE_DIR gtest/gtest.h)
-find_library(GTEST_LIB gtest "$ENV{GTEST_LIB}")
-
 # Create the `cpptest` target if we can find GTest.  If not, we create dummy
 # targets that give the user an informative error message.
 if(GTEST_INCLUDE_DIR AND GTEST_LIB)
-  foreach(__srcpath ${TEST_SRCS})
-    get_filename_component(__srcname ${__srcpath} NAME)
-    string(REPLACE ".cc" "" __execname ${__srcname})
-    add_executable(${__execname} ${__srcpath})
-    list(APPEND TEST_EXECS ${__execname})
-    target_include_directories(${__execname} SYSTEM PUBLIC ${GTEST_INCLUDE_DIR})
-    target_link_libraries(${__execname} PRIVATE ${TVM_TEST_LIBRARY_NAME} ${GTEST_LIB} pthread dl)
-    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
-    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
-  endforeach()
-  add_custom_target(cpptest DEPENDS ${TEST_EXECS})
+  file(GLOB TEST_SRCS tests/cpp/*.cc)
+  add_executable(cpptest ${TEST_SRCS})
+  target_include_directories(cpptest SYSTEM PUBLIC ${GTEST_INCLUDE_DIR})
+  target_link_libraries(cpptest PRIVATE ${TVM_TEST_LIBRARY_NAME} ${GTEST_LIB} gtest_main pthread dl)
+  set_target_properties(cpptest PROPERTIES EXCLUDE_FROM_ALL 1)
+  set_target_properties(cpptest PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+  gtest_discover_tests(cpptest)
 elseif(NOT GTEST_INCLUDE_DIR)
   add_custom_target(cpptest
       COMMAND echo "Missing Google Test headers in include path"

--- a/cmake/modules/StandaloneCrt.cmake
+++ b/cmake/modules/StandaloneCrt.cmake
@@ -132,26 +132,16 @@ if(USE_MICRO)
           PUBLIC_HEADER "${crt_headers}")
     endforeach()
 
-    # Standalone CRT tests
-    file(GLOB TEST_SRCS ${CMAKE_SOURCE_DIR}/tests/crt/*_test.cc)
-    find_path(GTEST_INCLUDE_DIR gtest/gtest.h)
-    find_library(GTEST_LIB gtest "$ENV{GTEST_LIB}")
-
     # Create the `crttest` target if we can find GTest.  If not, we create dummy
     # targets that give the user an informative error message.
     if(GTEST_INCLUDE_DIR AND GTEST_LIB)
-      foreach(__srcpath ${TEST_SRCS})
-        get_filename_component(__srcname ${__srcpath} NAME)
-        string(REPLACE ".cc" "" __execname ${__srcname})
-        add_executable(${__execname} ${__srcpath})
-        list(APPEND TEST_EXECS ${__execname})
-        target_include_directories(${__execname} PUBLIC ${GTEST_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/standalone_crt/include ${CMAKE_SOURCE_DIR}/src/runtime/micro)
-        target_compile_options(${__execname} PRIVATE -pthread)
-        target_link_libraries(${__execname} ${cmake_crt_libraries} ${GTEST_LIB} pthread)
-        set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
-        set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
-      endforeach()
-      add_custom_target(crttest DEPENDS ${TEST_EXECS})
+      file(GLOB TEST_SRCS ${CMAKE_SOURCE_DIR}/tests/crt/*_test.cc)
+      add_executable(crttest ${TEST_SRCS})
+      target_include_directories(crttest SYSTEM PUBLIC ${GTEST_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/standalone_crt/include ${CMAKE_SOURCE_DIR}/src/runtime/micro)
+      target_link_libraries(crttest PRIVATE ${cmake_crt_libraries} ${GTEST_LIB} gtest_main pthread dl)
+      set_target_properties(crttest PROPERTIES EXCLUDE_FROM_ALL 1)
+      set_target_properties(crttest PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+      gtest_discover_tests(crttest)
     elseif(NOT GTEST_INCLUDE_DIR)
       add_custom_target(crttest
           COMMAND echo "Missing Google Test headers in include path"

--- a/tests/cpp/arith_simplify_test.cc
+++ b/tests/cpp/arith_simplify_test.cc
@@ -53,8 +53,3 @@ TEST(Simplify, Mod) {
   auto es = ana.canonical_simplify(mod - x);
   ICHECK(tvm::tir::is_zero(es));
 }
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/attrs_test.cc
+++ b/tests/cpp/attrs_test.cc
@@ -81,9 +81,3 @@ TEST(Attrs, Basic) {
   LOG(INFO) << "docstring\n" << os.str();
   ICHECK(os.str().find("expr : PrimExpr, default=1") != std::string::npos);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/auto_scheduler_test.cc
+++ b/tests/cpp/auto_scheduler_test.cc
@@ -170,9 +170,3 @@ TEST(ComputeDAG, AccessAnalyzer) {
     }
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/build_module_test.cc
+++ b/tests/cpp/build_module_test.cc
@@ -199,9 +199,3 @@ TEST(BuildModule, Heterogeneous) {
     ICHECK_LT(std::fabs(p_out[i] - (i + (i + 1.0) - (i - 1.0))), 1e-5);
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/container_test.cc
+++ b/tests/cpp/container_test.cc
@@ -695,9 +695,3 @@ TEST(Optional, PackedCall) {
   test_ffi(s, static_cast<int>(kTVMObjectHandle));
   test_ffi(String(s), static_cast<int>(kTVMObjectRValueRefArg));
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/dataflow_pattern_test.cc
+++ b/tests/cpp/dataflow_pattern_test.cc
@@ -192,9 +192,3 @@ TEST(DFPattern, HasShape) {
   ICHECK(node->pattern == a);
   ICHECK(node->shape == shape);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/expr_test.cc
+++ b/tests/cpp/expr_test.cc
@@ -42,9 +42,3 @@ TEST(ExprNodeRef, Basic) {
   const tir::MaxNode* op = z.as<tir::MaxNode>();
   ICHECK(GetRef<ObjectRef>(op).same_as(z));
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -324,9 +324,3 @@ TEST(IRF, StmtMutator) {
     ICHECK(new_block->match_buffers[0]->source->region[0]->min.same_as(x));
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/microtvm_runtime_standalone_test.cc
+++ b/tests/cpp/microtvm_runtime_standalone_test.cc
@@ -128,9 +128,3 @@ TEST(MicroStandaloneRuntime, BuildModule) {
 
 #endif
 #endif
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/object_protocol_test.cc
+++ b/tests/cpp/object_protocol_test.cc
@@ -95,9 +95,3 @@ TEST(ObjectHierachy, Basic) {
   ICHECK(refB.as<ObjAA>() == nullptr);
   ICHECK(refB.as<ObjB>() != nullptr);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/packed_func_test.cc
+++ b/tests/cpp/packed_func_test.cc
@@ -306,9 +306,3 @@ TEST(TypedPackedFunc, RValue) {
     tf(1, true);
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/parallel_for_test.cc
+++ b/tests/cpp/parallel_for_test.cc
@@ -118,9 +118,3 @@ TEST(ParallelFor, Exception) {
   }
   ICHECK(exception);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/pattern_match_test.cc
+++ b/tests/cpp/pattern_match_test.cc
@@ -138,9 +138,3 @@ TEST(Pattern, IntImm) {
   // cannot match tx + 1 to v
   ICHECK(!(v * c).Match((tx + 1) * 3));
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/profiling_test.cc
+++ b/tests/cpp/profiling_test.cc
@@ -39,9 +39,3 @@ TEST(DefaultTimer, Basic) {
 }
 }  // namespace runtime
 }  // namespace tvm
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/random_engine_test.cc
+++ b/tests/cpp/random_engine_test.cc
@@ -63,9 +63,3 @@ TEST(RandomEngine, Serialization) {
   rand_state_b = rand_state_a;
   for (int i = 0; i < 100000; i++) ICHECK_EQ(rng_a(), rng_b());
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -181,9 +181,3 @@ TEST(Relay, GetExprRefCount) {
   ICHECK(ref_count[y.get()] == 1);
   ICHECK(ref_count[z.get()] == 1);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/relay_dismantler_test.cc
+++ b/tests/cpp/relay_dismantler_test.cc
@@ -143,9 +143,3 @@ TEST(Relay, TupleiGetItemSharedTuple) {
                    .as<CallNode>()
                    ->args.size());
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/relay_pass_type_infer_test.cc
+++ b/tests/cpp/relay_pass_type_infer_test.cc
@@ -41,9 +41,3 @@ TEST(Relay, SelfReference) {
   auto expected = relay::FuncType(tvm::Array<relay::Type>{tensor_type}, tensor_type, {}, {});
   ICHECK(tvm::StructuralEqual()(type_fx->checked_type(), expected));
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/relay_text_printer_test.cc
+++ b/tests/cpp/relay_text_printer_test.cc
@@ -56,9 +56,3 @@ TEST(Relay, LargeGraphPrint) {
   };
   ASSERT_EXIT((foo(), exit(0)), ::testing::ExitedWithCode(0), ".*");
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/relay_transform_sequential_test.cc
+++ b/tests/cpp/relay_transform_sequential_test.cc
@@ -128,9 +128,3 @@ TEST(PassContextListConfigs, Basic) {
   auto config = configs["relay.backend.use_auto_scheduler"];
   ICHECK_EQ(config["type"], "IntImm");
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/support_test.cc
+++ b/tests/cpp/support_test.cc
@@ -58,9 +58,3 @@ TEST(HashTests, HashStability) {
 
 }  // namespace test
 }  // namespace tvm
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -157,9 +157,3 @@ TEST(TargetKindRegistryListTargetKinds, Basic) {
   ICHECK_EQ(names.empty(), false);
   ICHECK_EQ(std::count(std::begin(names), std::end(names), "llvm"), 1);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/tensor_test.cc
+++ b/tests/cpp/tensor_test.cc
@@ -49,9 +49,3 @@ TEST(Tensor, Reduce) {
       {m, n}, [&](Var i, Var j) { return sum(max(1 + A[i][rv] + 1, B[j][rv]), {rv}); }, "C");
   LOG(INFO) << C->op.as<te::ComputeOpNode>()->body;
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/texture_copy_test.cc
+++ b/tests/cpp/texture_copy_test.cc
@@ -134,9 +134,3 @@ TEST(TextureCopy, OverwritePoolSubview) {
     }
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/threading_backend_test.cc
+++ b/tests/cpp/threading_backend_test.cc
@@ -63,9 +63,3 @@ TEST(ThreadingBackend, TVMBackendParallelLaunchMultipleThreads) {
     }
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/tir_analysis_side_effect.cc
+++ b/tests/cpp/tir_analysis_side_effect.cc
@@ -33,9 +33,3 @@ TEST(SimplePasses, SideEffect) {
   ICHECK(tir::SideEffect(tir::Call(DataType::Handle(), tir::builtin::tvm_storage_sync(), {})) ==
          tir::CallEffectKind::kUpdateState);
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/cpp/topi_ewise_test.cc
+++ b/tests/cpp/topi_ewise_test.cc
@@ -31,9 +31,3 @@ TEST(Tensor, Basic) {
 }
 }  // namespace topi
 }  // namespace tvm
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/crt/aot_memory_test.cc
+++ b/tests/crt/aot_memory_test.cc
@@ -21,7 +21,6 @@
 #include <tvm/runtime/crt/stack_allocator.h>
 
 #include "../../src/runtime/crt/memory/stack_allocator.c"
-#include "platform.cc"
 
 // Check with LIFO checks enabled for stack allocator
 #define TVM_CRT_STACK_ALLOCATOR_ENABLE_LIFO_CHECK
@@ -199,10 +198,4 @@ TEST(AOTMemory, InitialMemoryMisAlignment) {
 
   ASSERT_EQ(tvm_runtime_workspace.next_alloc, &model_memory_ptr[alignment_offset]);
   ASSERT_EQ(tvm_runtime_workspace.workspace_size, sizeof(model_memory) - offset - alignment_offset);
-}
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
 }

--- a/tests/crt/framing_test.cc
+++ b/tests/crt/framing_test.cc
@@ -27,7 +27,6 @@
 
 #include "buffer_write_stream.h"
 #include "crt_config.h"
-#include "platform.cc"
 
 using ::tvm::runtime::micro_rpc::Escape;
 using ::tvm::runtime::micro_rpc::FrameBuffer;
@@ -61,16 +60,6 @@ class TestPacket {
   std::string payload;
   std::string wire;
 };
-
-void PrintTo(const TestPacket* p, std::ostream* os) {
-  *os << "TestPacket(\"" << p->name << "\", ...)";
-}
-
-void PrintTo(tvm_crt_error_t p, std::ostream* os) {
-  std::ios_base::fmtflags f(os->flags());
-  *os << "tvm_crt_error_t(0x" << std::hex << std::setw(8) << std::setfill('0') << p << ")";
-  os->flags(f);
-}
 
 std::vector<const TestPacket*> TestPacket::instances;
 
@@ -309,9 +298,3 @@ TEST_P(UnframerTestParameterized, TestArbitraryPacketReset) {
 INSTANTIATE_TEST_CASE_P(UnframerTests, UnframerTestParameterized,
                         ::testing::ValuesIn(TestPacket::instances));
 #pragma GCC diagnostic pop
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/crt/func_registry_test.cc
+++ b/tests/crt/func_registry_test.cc
@@ -22,8 +22,6 @@
 #include <tvm/runtime/crt/func_registry.h>
 #include <tvm/runtime/crt/internal/common/func_registry.h>
 
-#include "platform.cc"
-
 typedef struct {
   const char* a;
   const char* b;
@@ -231,10 +229,4 @@ TEST(MutableFuncRegistry, Create) {
     EXPECT_EQ(kTvmErrorFunctionRegistryFull,
               TVMMutableFuncRegistry_Set(&reg, test_function_name, TestFunctionHandle(0x03), 0));
   }
-}
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
 }

--- a/tests/crt/memory_test.cc
+++ b/tests/crt/memory_test.cc
@@ -80,9 +80,3 @@ TEST_F(MemoryManagerTest, AllocFreeFifo) {
     }
   }
 }
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
-}

--- a/tests/crt/session_test.cc
+++ b/tests/crt/session_test.cc
@@ -27,7 +27,6 @@
 
 #include "buffer_write_stream.h"
 #include "crt_config.h"
-#include "platform.cc"
 
 using ::tvm::runtime::micro_rpc::Framer;
 using ::tvm::runtime::micro_rpc::MessageType;
@@ -105,16 +104,6 @@ void TestSessionMessageReceivedThunk(void* context, MessageType message_type, Fr
   static_cast<TestSession*>(context)->messages_received.emplace_back(
       ReceivedMessage(message_type, message));
 }
-}
-
-void PrintTo(tvm_crt_error_t p, std::ostream* os) {
-  std::ios_base::fmtflags f(os->flags());
-  *os << "tvm_crt_error_t(0x" << std::hex << std::setw(8) << std::setfill('0') << p << ")";
-  os->flags(f);
-}
-
-void PrintTo(ReceivedMessage msg, std::ostream* os) {
-  *os << "ReceivedMessage(" << int(msg.type) << ", \"" << msg.message << "\")";
 }
 
 class SessionTest : public ::testing::Test {
@@ -258,10 +247,4 @@ TEST_F(SessionTest, DoubleStart) {
   bob_.ClearBuffers();
   alice_.WriteTo(&bob_);
   EXPECT_TRUE(bob_.sess.IsEstablished());
-}
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  testing::FLAGS_gtest_death_test_style = "threadsafe";
-  return RUN_ALL_TESTS();
 }

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -30,9 +30,7 @@ export VTA_HW_PATH=`pwd`/3rdparty/vta-hw
 export TVM_BIND_THREADS=0
 export OMP_NUM_THREADS=1
 
-# Remove existing testcases
-rm -f build/*_test
-
+# Build cpptest suite
 make cpptest -j2
 
 # "make crttest" requires USE_MICRO to be enabled, which is not always the case.
@@ -40,9 +38,7 @@ if grep crttest build/Makefile > /dev/null; then
     make crttest  # NOTE: don't parallelize, due to issue with build deps.
 fi
 
-for test in build/*_test; do
-    ./$test
-done
+cd build && ctest --gtest_death_test_style=threadsafe && cd ..
 
 # Test MISRA-C runtime
 cd apps/bundle_deploy


### PR DESCRIPTION
By using the `gtest_discover_tests` CMake macro the CPP and CRT tests can be configured to build binaries with a single test runner each. Once CTest has information about tests it can be used in IDE extensions such as [CMake Test Explorer](https://marketplace.visualstudio.com/items?itemName=fredericbonnet.cmake-test-adapter).

`ctest` can also run tests in parallel using the `-j` flag, which could be interesting in future.