### PR TITLE
[Vulkan] Remote target.h #include

### DIFF
--- a/src/runtime/vulkan/vulkan_common.h
+++ b/src/runtime/vulkan/vulkan_common.h
@@ -24,7 +24,7 @@
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/packed_func.h>
-#include <tvm/target/target.h>
+#include <tvm/runtime/registry.h>
 #include <vulkan/vulkan.h>
 
 #include <memory>


### PR DESCRIPTION
Was added in #8127, should have been removed in #8171 along with the rest of the references outside of libtvm_runtime.so.  This didn't impact the Vulkan+g++ builds, because no symbols were accessed outside of the runtime library.  However, it broke the Vulkan+Windows builds, which expected symbols due to the `__declspec(dllexport)` defintion of `TVM_DLL` on MSVC (see #8805).  This wasn't caught by the CI build on Windows, because it doesn't perform the Vulkan build.