### PR TITLE
Remove unnecessary memset in TVMMutableFuncRegistry initialization

### DIFF
--- a/src/runtime/crt/common/func_registry.c
+++ b/src/runtime/crt/common/func_registry.c
@@ -99,7 +99,6 @@ tvm_crt_error_t TVMMutableFuncRegistry_Create(TVMMutableFuncRegistry* reg, uint8
     return kTvmErrorBufferTooSmall;
   }
 
-  memset(reg, 0, sizeof(*reg));
   reg->registry.names = (const char*)buffer;
   buffer[0] = 0;  // number of functions present in buffer.
   buffer[1] = 0;  // end of names list marker.


### PR DESCRIPTION
Remove unnecessary memset() call in TVMMutableFuncRegistry_Create()
when initializing a TVMMutableFuncRegistry struct. All struct members
(registry.names, registry.funcs, and max_functions) are already
initialized properly before returning, hence some CPU cycles might be
saved (usually 12 bytes in a 32-bit platform and 24 bytes in a 64-bit
platform must be written with 0 by memset()).

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>