### PR TITLE
Remove unused allocated memory in crt initialization

### DIFF
--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -398,20 +398,13 @@ int RPCGetCRTMaxPacketSize(TVMValue* args, int* type_codes, int num_args, TVMVal
 tvm_crt_error_t TVMInitializeRuntime() {
   int idx = 0;
   tvm_crt_error_t error = kTvmErrorNoError;
-  void* func_registry_memory = NULL;
 
   DLDevice dev = {kDLCPU, 0};
-  error = TVMPlatformMemoryAllocate(TVM_CRT_GLOBAL_FUNC_REGISTRY_SIZE_BYTES, dev,
-                                    &func_registry_memory);
-  if (error != kTvmErrorNoError) {
-    return error;
-  }
 
   void* registry_backing_memory;
   error = TVMPlatformMemoryAllocate(TVM_CRT_GLOBAL_FUNC_REGISTRY_SIZE_BYTES, dev,
                                     &registry_backing_memory);
   if (error != kTvmErrorNoError) {
-    TVMPlatformMemoryFree(func_registry_memory, dev);
     return error;
   }
 
@@ -441,7 +434,6 @@ tvm_crt_error_t TVMInitializeRuntime() {
 
   if (error != kTvmErrorNoError) {
     TVMPlatformMemoryFree(registry_backing_memory, dev);
-    TVMPlatformMemoryFree(func_registry_memory, dev);
   }
 
   return error;


### PR DESCRIPTION
Currently TVMInitializeRuntime() allocates 250 bytes dynamically to back
buffer 'func_registry_memory' which is never used. That is not much in
general but besides being twice the current necessary amount for the
runtime (allocated to back 'registry_backing_memory' buffer) that amount
can be important to be saved on memory-constrained devices (microTVM).

This commit removes the 'func_registry_memory' buffer which is allocated
dynamically in TVMInitializeRuntime() since it occupies 250 bytes and is
never used.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>