### PR TITLE
[Hexagon] Reuse Hexagon SDK analysis across cmake files

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -273,6 +273,13 @@ set(USE_FALLBACK_STL_MAP OFF)
 set(USE_HEXAGON_DEVICE OFF)
 set(USE_HEXAGON_SDK /path/to/sdk)
 
+# Hexagon architecture to target when compiling TVM itself (not the target for
+# compiling _by_ TVM). This applies to components like the TVM runtime, but is
+# also used to select correct include/library paths from the Hexagon SDK when
+# building offloading runtime for Android.
+# Valid values are v60, v62, v65, v66, v68.
+set(USE_HEXAGON_ARCH "v66")
+
 # Whether to use ONNX codegen
 set(USE_TARGET_ONNX OFF)
 

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -48,7 +48,7 @@ function(find_hexagon_toolchain)
 endfunction()
 
 if(BUILD_FOR_HEXAGON)
-  find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "v66")
+  find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}")
   # Add SDK and QuRT includes when building for Hexagon.
   include_directories(SYSTEM ${HEXAGON_SDK_INCLUDES} ${HEXAGON_QURT_INCLUDES})
 endif()
@@ -82,10 +82,11 @@ if(USE_HEXAGON_DEVICE STREQUAL "${PICK_SIM}")
     CMAKE_ARGS
       "-DCMAKE_C_COMPILER=${HEXAGON_TOOLCHAIN}/bin/hexagon-clang"
       "-DCMAKE_CXX_COMPILER=${HEXAGON_TOOLCHAIN}/bin/hexagon-clang++"
+      "-DHEXAGON_ARCH=${USE_HEXAGON_ARCH}"
     INSTALL_COMMAND "true"
   )
 elseif(USE_HEXAGON_DEVICE STREQUAL "${PICK_HW}")
-  find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "v66")
+  find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}")
   find_hexagon_toolchain()
   file(GLOB RUNTIME_HEXAGON_DEVICE_SRCS src/runtime/hexagon/target/*.cc)
 

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -16,12 +16,12 @@
 # under the License.
 
 include(ExternalProject)
+include(cmake/modules/HexagonSDK.cmake)
 
 set(PICK_SIM  "sim")
 set(PICK_HW   "target")
 set(PICK_NONE "OFF")
 
-set(FOUND_HEXAGON_SDK_ROOT  FALSE)
 set(FOUND_HEXAGON_TOOLCHAIN FALSE)
 
 function(find_hexagon_toolchain)
@@ -47,41 +47,10 @@ function(find_hexagon_toolchain)
   endif()
 endfunction()
 
-function(find_hexagon_sdk_root)
-  if(FOUND_HEXAGON_SDK_ROOT)
-    return()
-  endif()
-  message(STATUS "Checking Hexagon SDK root: ${USE_HEXAGON_SDK}")
-  file(GLOB_RECURSE HEXAGON_AEESTDDEF "${USE_HEXAGON_SDK}/*/AEEStdDef.h")
-  if(HEXAGON_AEESTDDEF)
-    # The path is ${HEXAGON_SDK_ROOT}/incs/stddef/AEEStdDef.h.
-    get_filename_component(HEXAGON_TMP0 "${HEXAGON_AEESTDDEF}" DIRECTORY)
-    get_filename_component(HEXAGON_TMP1 "${HEXAGON_TMP0}" DIRECTORY)
-    get_filename_component(HEXAGON_TMP2 "${HEXAGON_TMP1}" DIRECTORY)
-    set(HEXAGON_SDK_ROOT "${HEXAGON_TMP2}" CACHE PATH
-        "Root directory of Hexagon SDK")
-    set(FOUND_HEXAGON_SDK_ROOT TRUE)
-  else(HEXAGON_AEESTDDEF)
-    message(SEND_ERROR "Cannot validate Hexagon SDK in ${USE_HEXAGON_SDK}")
-  endif()
-endfunction()
-
 if(BUILD_FOR_HEXAGON)
-  find_hexagon_sdk_root()
-  if(HEXAGON_SDK_ROOT MATCHES "3.5.1")
-    message(SEND_ERROR "Hexagon SDK 3.5.1 is not supported")
-  elseif(HEXAGON_SDK_ROOT MATCHES "3\.[0-9]+\.[0-9]+")
-    include_directories(
-      SYSTEM "${USE_HEXAGON_SDK}/libs/common/qurt/ADSPv62MP/include/posix"
-      SYSTEM "${USE_HEXAGON_SDK}/libs/common/qurt/ADSPv62MP/include/qurt")
-  else()
-    include_directories(
-      SYSTEM "${HEXAGON_SDK_ROOT}/rtos/qurt/computev65/include/posix"
-      SYSTEM "${HEXAGON_SDK_ROOT}/rtos/qurt/computev65/include/qurt")
-  endif()
-  include_directories(
-    SYSTEM "${HEXAGON_SDK_ROOT}/incs"
-    SYSTEM "${HEXAGON_SDK_ROOT}/incs/stddef")
+  find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "v66")
+  # Add SDK and QuRT includes when building for Hexagon.
+  include_directories(SYSTEM ${HEXAGON_SDK_INCLUDES} ${HEXAGON_QURT_INCLUDES})
 endif()
 
 if(USE_HEXAGON_DEVICE STREQUAL "OFF")
@@ -116,26 +85,15 @@ if(USE_HEXAGON_DEVICE STREQUAL "${PICK_SIM}")
     INSTALL_COMMAND "true"
   )
 elseif(USE_HEXAGON_DEVICE STREQUAL "${PICK_HW}")
-  find_hexagon_sdk_root()
+  find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "v66")
   find_hexagon_toolchain()
-  message(STATUS "Hexagon SDK: ${HEXAGON_SDK_ROOT}")
-  if(HEXAGON_SDK_ROOT MATCHES "3.5.1")
-    message(SEND_ERROR "Hexagon SDK 3.5.1 is not supported")
-  elseif(HEXAGON_SDK_ROOT MATCHES "3\.[0-9]+\.[0-9]+")
-      set(RPCMEM_DIR "libs/common/rpcmem")
-      set(REMOTE_DIR "libs/common/remote/ship/android_Release_aarch64")
-  else()
-      set(RPCMEM_DIR "ipc/fastrpc/rpcmem")
-      set(REMOTE_DIR "ipc/fastrpc/remote/ship/android_aarch64")
-  endif()
   file(GLOB RUNTIME_HEXAGON_DEVICE_SRCS src/runtime/hexagon/target/*.cc)
-  include_directories(SYSTEM "${HEXAGON_SDK_ROOT}/incs/stddef")
-  include_directories(SYSTEM "${HEXAGON_SDK_ROOT}/${RPCMEM_DIR}/inc")
-  include_directories(
-      SYSTEM "${HEXAGON_SDK_ROOT}/incs")
-  include_directories(
-      SYSTEM "${HEXAGON_SDK_ROOT}/${REMOTE_DIR}")
-  include_directories(SYSTEM "${HEXAGON_TOOLCHAIN}/include/iss")
+
+  include_directories(SYSTEM
+    ${HEXAGON_SDK_INCLUDES}
+    ${HEXAGON_RPCMEM_ROOT}/inc
+    ${HEXAGON_REMOTE_ROOT}
+  )
   list(APPEND TVM_RUNTIME_LINKER_LIBS "dl")
   if(BUILD_FOR_ANDROID)
     # Hexagon runtime uses __android_log_print, which is in liblog.

--- a/cmake/modules/HexagonSDK.cmake
+++ b/cmake/modules/HexagonSDK.cmake
@@ -65,7 +65,7 @@ function(find_hexagon_sdk_root HEXAGON_SDK_PATH HEXAGON_ARCH)
   set(HEXARCH_DIR_v66 "computev66")
   set(HEXARCH_DIR_v68 "computev68")
   set(HEXARCH_DIR_STR "HEXARCH_DIR_${HEXAGON_ARCH}")
-  set(HEXARCH_DIR ${${HEXARCH_DIR_STR}})
+  set(HEXARCH_DIR "${${HEXARCH_DIR_STR}}")
 
   if(NOT HEXARCH_DIR)
     message(SEND_ERROR

--- a/cmake/modules/HexagonSDK.cmake
+++ b/cmake/modules/HexagonSDK.cmake
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(FOUND_HEXAGON_SDK_ROOT FALSE)
+
+macro(set_parent var)
+  set(${var} ${ARGN} PARENT_SCOPE)
+endmacro()
+
+function(find_hexagon_sdk_root HEXAGON_SDK_PATH HEXAGON_ARCH)
+  if(FOUND_HEXAGON_SDK_ROOT)
+    return()
+  endif()
+  if(${ARGC} LESS "2")
+    message(SEND_ERROR "Must provide Hexagon SDK path and Hexagon arch")
+  endif()
+
+  # Initial verification of the Hexagon SDK.
+  message(STATUS "Checking Hexagon SDK root: ${HEXAGON_SDK_PATH}")
+  file(GLOB_RECURSE VERSION_HEADERS "${HEXAGON_SDK_PATH}/*/version.h")
+  if(VERSION_HEADERS)
+    foreach(HEADER IN LISTS VERSION_HEADERS)
+      if(HEADER MATCHES "incs/version.h$")
+        set(SDK_VERSION_HEADER "${HEADER}")
+        break()
+      endif()
+    endforeach()
+    # The path is ${HEXAGON_SDK_ROOT}/incs/version.h.
+    get_filename_component(TMP0 "${SDK_VERSION_HEADER}" DIRECTORY)
+    get_filename_component(TMP1 "${TMP0}" DIRECTORY)
+    set(HEXAGON_SDK_ROOT "${TMP1}" CACHE PATH "Root directory of Hexagon SDK")
+  else()
+    message(SEND_ERROR "Cannot validate Hexagon SDK in ${HEXAGON_SDK_PATH}")
+  endif()
+
+  execute_process(
+    COMMAND grep "#define[ \t]*VERSION_STRING" "${SDK_VERSION_HEADER}"
+    OUTPUT_VARIABLE SDK_VERSION_DEFINE)
+  string(
+    REGEX REPLACE ".*VERSION_STRING.* ([0-9\\.]+) .*" "\\1"
+    SDK_VERSION_STRING "${SDK_VERSION_DEFINE}")
+
+  if (SDK_VERSION_STRING MATCHES "3.5.1")
+    message(SEND_ERROR "Hexagon SDK 3.5.1 is not supported")
+  endif()
+
+  # Set the Hexagon arch directory component.
+  set(HEXARCH_DIR_v60 "ADSPv60MP")
+  set(HEXARCH_DIR_v62 "ADSPv62MP")
+  set(HEXARCH_DIR_v65 "computev65")
+  set(HEXARCH_DIR_v66 "computev66")
+  set(HEXARCH_DIR_v68 "computev68")
+  set(HEXARCH_DIR_STR "HEXARCH_DIR_${HEXAGON_ARCH}")
+  set(HEXARCH_DIR ${${HEXARCH_DIR_STR}})
+
+  if(NOT HEXARCH_DIR)
+    message(SEND_ERROR
+      "Please set HEXAGON_ARCH to one of v60, v62, v65, v66, v68")
+  endif()
+
+  # Set parent variables:
+  # - HEXAGON_SDK_VERSION
+  # - HEXAGON_SDK_INCLUDES
+  # - HEXAGON_QURT_INCLUDES
+  # - HEXAGON_RPCMEM_ROOT
+  # - HEXAGON_REMOTE_ROOT
+  # - HEXAGON_QAIC_EXE
+  set_parent(HEXAGON_SDK_VERSION "${SDK_VERSION_STRING}")
+
+  if(SDK_VERSION_STRING MATCHES "^3\.[0-9]+\.[0-9]+")
+    # SDK 3.x.y
+    if(HEXAGON_ARCH MATCHES "v6[7-9]|v[7-9][0-9]")
+      message(SEND_ERROR
+        "Hexagon SDK ${SDK_VERSION_STRING} does not support ${HEXAGON_ARCH}")
+    endif()
+    set_parent(HEXAGON_SDK_INCLUDES
+      "${HEXAGON_SDK_ROOT}/incs"
+      "${HEXAGON_SDK_ROOT}/incs/a1std"
+      "${HEXAGON_SDK_ROOT}/incs/qlist"
+      "${HEXAGON_SDK_ROOT}/incs/stddef")
+    set_parent(HEXAGON_QURT_INCLUDES
+      "${HEXAGON_SDK_ROOT}/libs/common/qurt/${HEXARCH_DIR}/include/posix"
+      "${HEXAGON_SDK_ROOT}/libs/common/qurt/${HEXARCH_DIR}/include/qurt")
+    set_parent(HEXAGON_RPCMEM_ROOT "${HEXAGON_SDK_ROOT}/libs/common/rpcmem")
+    set_parent(HEXAGON_REMOTE_ROOT
+      "${HEXAGON_SDK_ROOT}/libs/common/remote/ship/android_Release_aarch64")
+    set_parent(HEXAGON_QAIC_EXE "${HEXAGON_SDK_ROOT}/tools/qaic/bin/qaic")
+  else()
+    # SDK 4.x.y.z
+    if(HEXAGON_ARCH MATCHES "v6[02]")
+      message(SEND_ERROR
+        "Hexagon SDK ${SDK_VERSION_STRING} does not support ${HEXAGON_ARCH}")
+    endif()
+    set_parent(HEXAGON_SDK_INCLUDES
+      "${HEXAGON_SDK_ROOT}/incs"
+      "${HEXAGON_SDK_ROOT}/incs/stddef")
+    set_parent(HEXAGON_QURT_INCLUDES
+      "${HEXAGON_SDK_ROOT}/rtos/qurt/${HEXARCH_DIR}/include/posix"
+      "${HEXAGON_SDK_ROOT}/rtos/qurt/${HEXARCH_DIR}/include/qurt")
+    set_parent(HEXAGON_RPCMEM_ROOT "${HEXAGON_SDK_ROOT}/ipc/fastrpc/rpcmem")
+    set_parent(HEXAGON_REMOTE_ROOT  # libadsprpc.so
+      "${HEXAGON_SDK_ROOT}/ipc/fastrpc/remote/ship/android_aarch64")
+    set_parent(HEXAGON_QAIC_EXE
+      "${HEXAGON_SDK_ROOT}/ipc/fastrpc/qaic/Ubuntu16/qaic")
+  endif()
+
+  set(FOUND_HEXAGON_SDK_ROOT TRUE)
+endfunction()
+

--- a/src/runtime/hexagon/sim/driver/CMakeLists.txt
+++ b/src/runtime/hexagon/sim/driver/CMakeLists.txt
@@ -24,11 +24,17 @@ if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/config.cmake)
   include(${CMAKE_CURRENT_BINARY_DIR}/config.cmake)
 endif()
 
+if("${HEXAGON_ARCH}" STREQUAL "")
+  set(DEFAULT_HEXAGON_ARCH "v66")
+  message(STATUS "HEXAGON_ARCH not defined, defaulting to ${DEFAULT_HEXAGON_ARCH}")
+  set(HEXAGON_ARCH "${DEFAULT_HEXAGON_ARCH}")
+endif()
+
 set(EXTRA_CXX_FLAGS
   "-O2"
   "-Wno-format"
   "-mhvx -mhvx-length=128b"
-  "-mv65"
+  "-m${HEXAGON_ARCH}"
   "-stdlib=libc++"
 )
 

--- a/src/runtime/hexagon/target/fastrpc/CMakeLists.txt
+++ b/src/runtime/hexagon/target/fastrpc/CMakeLists.txt
@@ -103,11 +103,6 @@ if("${FASTRPC_LIBS}" STREQUAL "SKEL")
   )
   string(REGEX REPLACE ";" " " EXTRA_LINK_FLAGS_STR "${EXTRA_LINK_FLAGS}")
 
-  # Extra linker flags for linking shared libraries.
-  set(CMAKE_SHARED_LINKER_FLAGS
-    "${EXTRA_LINK_FLAGS_STR} ${CMAKE_SHARED_LINKER_FLAGS}"
-  )
-
   set(SKEL_ND_SRCS
     "src/tvm_hvx.cc"
     "src/tvm_remote_nd_imp.cc"
@@ -137,6 +132,10 @@ if("${FASTRPC_LIBS}" STREQUAL "SKEL")
   set(WRAP_PTHREAD_SRCS "src/tvm_wrap_pthread.cc")
   add_library(tvm_wrap_pthread SHARED ${WRAP_PTHREAD_SRCS})
 
+  # Extra linker flags for linking shared libraries.
+  set_target_properties(tvm_remote_nd_skel PROPERTIES LINK_FLAGS ${EXTRA_LINK_FLAGS_STR})
+  set_target_properties(tvm_remote_skel PROPERTIES LINK_FLAGS ${EXTRA_LINK_FLAGS_STR})
+  set_target_properties(tvm_wrap_pthread PROPERTIES LINK_FLAGS ${EXTRA_LINK_FLAGS_STR})
 else()
   # Stub libraries.
   #

--- a/src/runtime/hexagon/target/fastrpc/CMakeLists.txt
+++ b/src/runtime/hexagon/target/fastrpc/CMakeLists.txt
@@ -23,22 +23,19 @@ if(NOT "${FASTRPC_LIBS}" STREQUAL "SKEL" AND
   message(SEND_ERROR "Please set FASTRPC_LIBS to either SKEL or STUB")
 endif()
 
+include(../../../../../cmake/modules/HexagonSDK.cmake)
 
-set(FASTRPC_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
+find_hexagon_sdk_root("${HEXAGON_SDK_ROOT}" "${HEXAGON_ARCH}")
 
 include_directories(include)
-include_directories(SYSTEM ${HEXAGON_SDK_ROOT}/incs)
-include_directories(SYSTEM ${HEXAGON_SDK_ROOT}/incs/stddef)
-include_directories(
-    SYSTEM ${HEXAGON_SDK_ROOT}/libs/common/remote/ship/android_Release_aarch64)
+include_directories(SYSTEM ${HEXAGON_SDK_INCLUDES} ${HEXAGON_REMOTE_ROOT})
 
-set(QAIC_EXE "${HEXAGON_SDK_ROOT}/tools/qaic/Ubuntu16/qaic")
-set(QAIC_FLAGS
-    "-I${HEXAGON_SDK_ROOT}/incs/stddef"
-    "-I${HEXAGON_SDK_ROOT}/libs/common/remote/ship/android_Release_aarch64"
-    "-I${HEXAGON_SDK_ROOT}/libs/common/rpcmem/inc"
-)
+set(QAIC_EXE "${HEXAGON_QAIC_EXE}")
+foreach(INCDIR IN LISTS HEXAGON_SDK_INCLUDES HEXAGON_REMOTE_ROOT)
+  list(APPEND QAIC_FLAGS "-I${INCDIR}")
+endforeach()
 
+set(FASTRPC_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_SKIP_RPATH TRUE)
 
 # Qaic for the non-domain header.
@@ -51,13 +48,13 @@ set(TVM_REMOTE_ND_SKEL_C "tvm_remote_nd_skel.c")
 set(TVM_REMOTE_ND_STUB_C "tvm_remote_nd_stub.c")
 
 add_custom_command(
-    OUTPUT ${TVM_REMOTE_ND_SKEL_C} ${TVM_REMOTE_ND_STUB_C}
-           "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
-    COMMAND ${QAIC_EXE} ${QAIC_FLAGS}
-            "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_IDL}"
-    COMMAND ${CMAKE_COMMAND} -E rename "${TVM_REMOTE_ND_H}"
-                "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
-    MAIN_DEPENDENCY "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_IDL}"
+  OUTPUT ${TVM_REMOTE_ND_SKEL_C} ${TVM_REMOTE_ND_STUB_C}
+         "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
+  COMMAND ${QAIC_EXE} ${QAIC_FLAGS}
+          "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_IDL}"
+  COMMAND ${CMAKE_COMMAND} -E rename "${TVM_REMOTE_ND_H}"
+          "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
+  MAIN_DEPENDENCY "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_IDL}"
 )
 
 # Qaic for the domain header.
@@ -70,35 +67,20 @@ set(TVM_REMOTE_D_SKEL_C "tvm_remote_skel.c")
 set(TVM_REMOTE_D_STUB_C "tvm_remote_stub.c")
 
 add_custom_command(
-    OUTPUT ${TVM_REMOTE_D_SKEL_C} ${TVM_REMOTE_D_STUB_C}
-           "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
-    COMMAND ${QAIC_EXE} ${QAIC_FLAGS}
-            "${FASTRPC_SRC}/include/${TVM_REMOTE_D_IDL}"
-    COMMAND ${CMAKE_COMMAND} -E rename "${TVM_REMOTE_D_H}"
-                "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
-    MAIN_DEPENDENCY "${FASTRPC_SRC}/include/${TVM_REMOTE_D_IDL}"
+  OUTPUT ${TVM_REMOTE_D_SKEL_C} ${TVM_REMOTE_D_STUB_C}
+         "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
+  COMMAND ${QAIC_EXE} ${QAIC_FLAGS}
+          "${FASTRPC_SRC}/include/${TVM_REMOTE_D_IDL}"
+  COMMAND ${CMAKE_COMMAND} -E rename "${TVM_REMOTE_D_H}"
+          "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
+  MAIN_DEPENDENCY "${FASTRPC_SRC}/include/${TVM_REMOTE_D_IDL}"
 )
 
 
 if("${FASTRPC_LIBS}" STREQUAL "SKEL")
   # Skel libraries.
   #
-  set(HEXARCH_DIR_v60 "ADSPv60MP")
-  set(HEXARCH_DIR_v62 "ADSPv62MP")
-  set(HEXARCH_DIR_v65 "computev65")
-  set(HEXARCH_DIR_v66 "computev66")
-  set(HEXARCH_DIR_STR "HEXARCH_DIR_${HEXAGON_ARCH}")
-  set(HEXARCH_DIR ${${HEXARCH_DIR_STR}})
-
-  if(NOT HEXARCH_DIR)
-    message(SEND_ERROR
-            "Please set HEXAGON_ARCH to one of v60, v62, v65, v66")
-  endif()
-
-  include_directories(
-      SYSTEM ${HEXAGON_SDK_ROOT}/libs/common/qurt/${HEXARCH_DIR}/include/qurt)
-  include_directories(
-      SYSTEM ${HEXAGON_SDK_ROOT}/libs/common/qurt/${HEXARCH_DIR}/include/posix)
+  include_directories(SYSTEM ${HEXAGON_QURT_INCLUDES})
 
   # Extra compile flags (both C and C++).
   set(EXTRA_COMP_FLAGS
@@ -106,45 +88,45 @@ if("${FASTRPC_LIBS}" STREQUAL "SKEL")
     "-m${HEXAGON_ARCH}"
   )
   string(REGEX REPLACE ";" " " EXTRA_COMP_FLAGS_STR "${EXTRA_COMP_FLAGS}")
-  message(STATUS "EXTRA_COMP_FLAGS_STR: ${EXTRA_COMP_FLAGS_STR}")
   set(CMAKE_C_FLAGS "${EXTRA_COMP_FLAGS_STR} ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "${EXTRA_COMP_FLAGS_STR} ${CMAKE_CXX_FLAGS}")
 
   set(EXTRA_LINK_FLAGS
-      "-Wl,--no-threads"
-      "-Wl,--wrap=malloc"
-      "-Wl,--wrap=calloc"
-      "-Wl,--wrap=free"
-      "-Wl,--wrap=realloc"
-      "-Wl,--wrap=memalign"
-      "-Wl,--wrap=posix_memalign"
-      "-Wl,--wrap=__stack_chk_fail"
+    "-Wl,--no-threads"
+    "-Wl,--wrap=malloc"
+    "-Wl,--wrap=calloc"
+    "-Wl,--wrap=free"
+    "-Wl,--wrap=realloc"
+    "-Wl,--wrap=memalign"
+    "-Wl,--wrap=posix_memalign"
+    "-Wl,--wrap=__stack_chk_fail"
   )
   string(REGEX REPLACE ";" " " EXTRA_LINK_FLAGS_STR "${EXTRA_LINK_FLAGS}")
 
   # Extra linker flags for linking shared libraries.
   set(CMAKE_SHARED_LINKER_FLAGS
-        "${EXTRA_LINK_FLAGS_STR} ${CMAKE_SHARED_LINKER_FLAGS}")
+    "${EXTRA_LINK_FLAGS_STR} ${CMAKE_SHARED_LINKER_FLAGS}"
+  )
 
   set(SKEL_ND_SRCS
-      "src/tvm_hvx.cc"
-      "src/tvm_remote_nd_imp.cc"
+    "src/tvm_hvx.cc"
+    "src/tvm_remote_nd_imp.cc"
   )
   add_library(tvm_remote_nd_skel SHARED
-      "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
-      ${TVM_REMOTE_ND_SKEL_C}
-      ${SKEL_ND_SRCS}
+    "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
+    ${TVM_REMOTE_ND_SKEL_C}
+    ${SKEL_ND_SRCS}
   )
 
   set(SKEL_D_SRCS
-      # Also includes src/tvm_remote_nd_imp.cc
-      ${SKEL_ND_SRCS}
-      "src/tvm_remote_imp.cc"
+    # Also includes src/tvm_remote_nd_imp.cc
+    ${SKEL_ND_SRCS}
+    "src/tvm_remote_imp.cc"
   )
   add_library(tvm_remote_skel SHARED
-      "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
-      ${TVM_REMOTE_D_SKEL_C}
-      ${SKEL_D_SRCS}
+    "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
+    ${TVM_REMOTE_D_SKEL_C}
+    ${SKEL_D_SRCS}
   )
 
   # Separate shared library with __wrap_pthread_create.
@@ -158,21 +140,21 @@ if("${FASTRPC_LIBS}" STREQUAL "SKEL")
 else()
   # Stub libraries.
   #
-  include_directories(SYSTEM ${HEXAGON_SDK_ROOT}/incs/a1std)
-  include_directories(SYSTEM ${HEXAGON_SDK_ROOT}/incs/qlist)
-  include_directories(SYSTEM ${HEXAGON_SDK_ROOT}/libs/common/rpcmem/inc)
-  link_directories(
-      SYSTEM ${HEXAGON_SDK_ROOT}/libs/common/remote/ship/android_Release_aarch64)
+  include_directories(SYSTEM
+    ${HEXAGON_SDK_INCLUDES}
+    "${HEXAGON_RPCMEM_ROOT}/inc"
+  )
+  link_directories(${HEXAGON_REMOTE_ROOT})
 
   add_library(tvm_remote_nd_stub SHARED
-      "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
-      "${HEXAGON_SDK_ROOT}/libs/common/rpcmem/src/rpcmem_android.c"
-      "${TVM_REMOTE_ND_STUB_C}"
+    "${FASTRPC_SRC}/include/${TVM_REMOTE_ND_H}"
+    "${HEXAGON_RPCMEM_ROOT}/src/rpcmem_android.c"
+    "${TVM_REMOTE_ND_STUB_C}"
   )
   add_library(tvm_remote_stub SHARED
-      "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
-      "${HEXAGON_SDK_ROOT}/libs/common/rpcmem/src/rpcmem_android.c"
-      "${TVM_REMOTE_D_STUB_C}"
+    "${FASTRPC_SRC}/include/${TVM_REMOTE_D_H}"
+    "${HEXAGON_RPCMEM_ROOT}/src/rpcmem_android.c"
+    "${TVM_REMOTE_D_STUB_C}"
   )
   target_link_libraries(tvm_remote_nd_stub adsprpc)
   target_link_libraries(tvm_remote_stub adsprpc)


### PR DESCRIPTION
Different versions of the Hexagon SDK may have different directory structures. Extract the directory identification code into a separate cmake module. Use that module in `Hexagon.cmake` and in the cmake file for the FastRPC libraries.