### PR TITLE
Better reflect allocator names in CRT tests

### DIFF
--- a/tests/crt/page_allocator_test.cc
+++ b/tests/crt/page_allocator_test.cc
@@ -32,7 +32,7 @@ static constexpr const unsigned int kNumUsablePages =
 static constexpr const unsigned int kPageSizeBytesLog = 8;  // 256 byte pages.
 static constexpr const unsigned int kMemoryPoolSizeBytes = kTotalPages * (1 << kPageSizeBytesLog);
 
-class MemoryManagerTest : public ::testing::Test {
+class PageAllocatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     memset(raw_memory_pool, 0, sizeof(raw_memory_pool));
@@ -57,7 +57,7 @@ class MemoryManagerTest : public ::testing::Test {
 
 #define EXPECT_PAGE(expected, actual) EXPECT_EQ(expected, AddressToPageNumber(actual))
 
-TEST_F(MemoryManagerTest, AllocFreeFifo) {
+TEST_F(PageAllocatorTest, AllocFreeFifo) {
   EXPECT_EQ(interface->vleak_size, 0);
 
   for (int i = 0; i < 2; i++) {

--- a/tests/crt/stack_allocator_test.cc
+++ b/tests/crt/stack_allocator_test.cc
@@ -17,10 +17,10 @@
  * under the License.
  */
 
+#include "../../src/runtime/crt/memory/stack_allocator.c"
+
 #include <gtest/gtest.h>
 #include <tvm/runtime/crt/stack_allocator.h>
-
-#include "../../src/runtime/crt/memory/stack_allocator.c"
 
 // Check with LIFO checks enabled for stack allocator
 #define TVM_CRT_STACK_ALLOCATOR_ENABLE_LIFO_CHECK
@@ -58,7 +58,7 @@ static uint32_t misalign_pointer(uint8_t** memory_ptr) {
 /*
  * Tests allocations are properly aligned when allocated.
  */
-TEST(AOTMemory, Allocate) {
+TEST(StackAllocatorTest, Allocate) {
   static uint8_t model_memory[128];
   tvm_workspace_t tvm_runtime_workspace;
   uint8_t* model_memory_ptr = model_memory;
@@ -91,7 +91,7 @@ TEST(AOTMemory, Allocate) {
 /*
  * Tests resetting the stack after dealloc.
  */
-TEST(AOTMemory, Free) {
+TEST(StackAllocatorTest, Free) {
   static uint8_t model_memory[80];
   tvm_workspace_t tvm_runtime_workspace;
   uint8_t* model_memory_ptr = model_memory;
@@ -126,7 +126,7 @@ TEST(AOTMemory, Free) {
 /*
  * Tests we return NULL if we over allocate.
  */
-TEST(AOTMemory, OverAllocate) {
+TEST(StackAllocatorTest, OverAllocate) {
   static uint8_t model_memory[80];
   tvm_workspace_t tvm_runtime_workspace;
   uint8_t* model_memory_ptr = model_memory;
@@ -154,7 +154,7 @@ TEST(AOTMemory, OverAllocate) {
 /*
  * Test for out-of-order memory deallocation.
  */
-TEST(AOTMemory, FreeOutOfOrder) {
+TEST(StackAllocatorTest, FreeOutOfOrder) {
   static uint8_t model_memory[80];
   tvm_workspace_t tvm_runtime_workspace;
   uint8_t* model_memory_ptr = model_memory;
@@ -180,7 +180,7 @@ TEST(AOTMemory, FreeOutOfOrder) {
 /*
  * Test for initial memory misalignment.
  */
-TEST(AOTMemory, InitialMemoryMisAlignment) {
+TEST(StackAllocatorTest, InitialMemoryMisAlignment) {
   static uint8_t model_memory[80];
   tvm_workspace_t tvm_runtime_workspace;
   uint8_t* model_memory_ptr = model_memory;


### PR DESCRIPTION
When the AOT executor was introduced, the Stack Allocator was associated
with it by test name whereas the Page Allocator was left as just
memory_test.cc. This cleans that up a bit to clarify which tests which
allocator.
