### PR TITLE
Add link to docs and tutorials in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ TVM works with deep learning frameworks to provide end to end compilation to dif
 
 License
 -------
-© Contributors Licensed under an [Apache-2.0](LICENSE) license.
+TVM is licensed under the [Apache-2.0](LICENSE) license.
+
+Getting Started
+---------------
+Check out the [TVM Documentation](https://tvm.apache.org/docs/) site for installation instructions, tutorials, examples, and more.
+The [Getting Started with TVM](https://tvm.apache.org/docs/tutorials/get_started/introduction.html) tutorial is a great
+place to start.
 
 Contribute to TVM
 -----------------


### PR DESCRIPTION
Most project pages on GitHub have a README.md file with a clear link to installation or tutorial material for new users.
While there is a link to Documentation, it's not that obvious, and adding a more explicit "getting started" link may be
helpful for new TVM users trying to navigate the project.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
