### PR TITLE
Force CMake targets in top-level Makefile to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ FORCE:
 CMAKE_TARGETS = all runtime vta cpptest crttest
 
 define GEN_CMAKE_RULE
-%/$(CMAKE_TARGET): %/CMakeCache.txt
+%/$(CMAKE_TARGET): %/CMakeCache.txt FORCE
 	@$$(MAKE) -C $$(@D) $(CMAKE_TARGET)
 endef
 $(foreach CMAKE_TARGET,$(CMAKE_TARGETS),$(eval $(GEN_CMAKE_RULE)))


### PR DESCRIPTION
This is a bug I introduced in https://github.com/apache/tvm/pull/8809, because the built binary is now named `build/cpptest` when `make` checks that artifact it finds it exists already and skips running `make -C build cpptest`. This ensures all nested `make` calls are forced to run from the top-level `Makefile`.
