### PR TITLE
[TIR] Fix opaque access in buffer locator pass and match_buffer in region detector

### DIFF
--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -110,8 +110,11 @@ void BlockReadWriteDetector::operator()(const Stmt& stmt) {
   ICHECK(block != nullptr) << "Only visiting Blocks is allowed, but got " << stmt->GetTypeKey();
   for (const MatchBufferRegion& match_buffer : block->match_buffers) {
     const Var& target_var = match_buffer->buffer->data;
-    match_buffers_[target_var.get()] = match_buffer;
-    buffer_var_map_.Set(target_var, match_buffer->buffer);
+    const Var& source_var = match_buffer->source->buffer->data;
+    if (buffer_var_map_.find(source_var) != buffer_var_map_.end()) {
+      match_buffers_[target_var.get()] = match_buffer;
+      buffer_var_map_.Set(target_var, match_buffer->buffer);
+    }
   }
   StmtExprVisitor::operator()(stmt);
 }

--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -98,7 +98,7 @@ class BufferAllocationLocator : public StmtExprMutator {
       const Var& target_var = match_buffer->buffer->data;
       buffer_data_to_buffer_.erase(target_var);
     }
-    // Ignore buffer allocated inside the block when updating access region.
+    // No longer consider buffers allocated inside the block when updating access region.
     if (it != alloc_buffers_.end()) {
       for (const Buffer& buf : it->second) {
         buffer_data_to_buffer_.erase(buf->data);

--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -93,7 +93,8 @@ class BufferAllocationLocator : public StmtExprMutator {
     op = stmt.as<BlockNode>();
     ICHECK(op != nullptr);
 
-    // No longer consider buffers created by match_buffer inside the block when updating access region.
+    // No longer consider buffers created by match_buffer inside the block when updating access
+    // region.
     for (const MatchBufferRegion match_buffer : op->match_buffers) {
       const Var& target_var = match_buffer->buffer->data;
       buffer_data_to_buffer_.erase(target_var);
@@ -108,8 +109,8 @@ class BufferAllocationLocator : public StmtExprMutator {
     ObjectPtr<BlockNode> n = CopyOnWrite(op);
     n->alloc_buffers = std::move(alloc_buffers);
     // Erase buffer allocated inside the block from access region.
-    n->reads = UpdateRegion(n->reads);
-    n->writes = UpdateRegion(n->writes);
+    n->reads = RemoveRedundantBufferRegion(n->reads);
+    n->writes = RemoveRedundantBufferRegion(n->writes);
     return Stmt(n);
   }
 
@@ -133,7 +134,7 @@ class BufferAllocationLocator : public StmtExprMutator {
     return std::move(realize);
   }
 
-  Array<BufferRegion> UpdateRegion(const Array<BufferRegion>& region) const {
+  Array<BufferRegion> RemoveRedundantBufferRegion(const Array<BufferRegion>& region) const {
     Array<BufferRegion> result;
     for (const BufferRegion& buffer_region : region) {
       if (buffer_data_to_buffer_.count(buffer_region->buffer->data)) {

--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -93,7 +93,7 @@ class BufferAllocationLocator : public StmtExprMutator {
     op = stmt.as<BlockNode>();
     ICHECK(op != nullptr);
 
-    // Ignore buffer created by match_buffer inside the block when updating access region.
+    // No longer consider buffers created by match_buffer inside the block when updating access region.
     for (const MatchBufferRegion match_buffer : op->match_buffers) {
       const Var& target_var = match_buffer->buffer->data;
       buffer_data_to_buffer_.erase(target_var);

--- a/tests/python/unittest/test_tir_transform_plan_update_buffer_allocation_location.py
+++ b/tests/python/unittest/test_tir_transform_plan_update_buffer_allocation_location.py
@@ -23,9 +23,6 @@ def _check(original, transformed):
     func = original
     mod = tvm.IRModule.from_expr(func)
     mod = tvm.tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
-    print(tvm.script.asscript(original))
-    print(tvm.script.asscript(mod["main"]))
-    print(tvm.script.asscript(transformed))
     tvm.ir.assert_structural_equal(mod["main"], transformed)
 
 
@@ -153,7 +150,14 @@ def opaque_access(a: ty.handle, b: ty.handle) -> None:
                 tir.writes([A_cache[(v * 128) : ((v * 128) + 128)]])
                 tir.evaluate(
                     tir.call_extern(
-                        "test", A_cache.data, (v * 128), 128, A.data, (v * 128), 128, dtype="float32"
+                        "test",
+                        A_cache.data,
+                        (v * 128),
+                        128,
+                        A.data,
+                        (v * 128),
+                        128,
+                        dtype="float32",
                     )
                 )
             for j in tir.serial(0, 128):

--- a/tests/python/unittest/test_tir_transform_plan_update_buffer_allocation_location.py
+++ b/tests/python/unittest/test_tir_transform_plan_update_buffer_allocation_location.py
@@ -23,6 +23,9 @@ def _check(original, transformed):
     func = original
     mod = tvm.IRModule.from_expr(func)
     mod = tvm.tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
+    print(tvm.script.asscript(original))
+    print(tvm.script.asscript(mod["main"]))
+    print(tvm.script.asscript(transformed))
     tvm.ir.assert_structural_equal(mod["main"], transformed)
 
 
@@ -137,6 +140,56 @@ def transformed_match_buffer_func() -> None:
                 C1[()] = 0
 
 
+@tvm.script.tir
+def opaque_access(a: ty.handle, b: ty.handle) -> None:
+    A = tir.match_buffer(a, [1024])
+    B = tir.match_buffer(b, [1024])
+    A_cache = tir.alloc_buffer([1024])
+    for i in tir.serial(0, 8):
+        with tir.block([8]) as [vi]:
+            with tir.block([8]) as [v]:
+                tir.bind(v, vi)
+                tir.reads([A[(v * 128) : ((v * 128) + 128)]])
+                tir.writes([A_cache[(v * 128) : ((v * 128) + 128)]])
+                tir.evaluate(
+                    tir.call_extern(
+                        "test", A_cache.data, (v * 128), 128, A.data, (v * 128), 128, dtype="float32"
+                    )
+                )
+            for j in tir.serial(0, 128):
+                with tir.block([1024]) as [v]:
+                    tir.bind(v, ((vi * 128) + j))
+                    tir.reads([A_cache[v]])
+                    tir.writes([B[v]])
+                    B[v] = A_cache[v]
+
+
+@tvm.script.tir
+def transformed_opaque_access(a: ty.handle, b: ty.handle) -> None:
+    A = tir.match_buffer(a, [1024])
+    B = tir.match_buffer(b, [1024])
+    for i in tir.serial(0, 8):
+        with tir.block([8]) as [vi]:
+            tir.reads(A[vi * 128 : vi * 128 + 128])
+            tir.writes(B[vi * 128 : vi * 128 + 128])
+            A_cache = tir.alloc_buffer([1024])
+            with tir.block([8]) as [v]:
+                tir.bind(v, vi)
+                tir.reads([A[v * 128 : v * 128 + 128]])
+                tir.writes([A_cache[v * 128 : v * 128 + 128]])
+                tir.evaluate(
+                    tir.call_extern(
+                        "test", A_cache.data, v * 128, 128, A.data, v * 128, 128, dtype="float32"
+                    )
+                )
+            for j in tir.serial(0, 128):
+                with tir.block([1024]) as [v]:
+                    tir.bind(v, ((vi * 128) + j))
+                    tir.reads([A_cache[v]])
+                    tir.writes([B[v]])
+                    B[v] = A_cache[v]
+
+
 def test_elementwise():
     _check(element_func, transformed_element_func)
 
@@ -147,6 +200,10 @@ def test_locate_buffer_allocation():
 
 def test_match_buffer_allocation():
     _check(match_buffer_func, transformed_match_buffer_func)
+
+
+def test_opaque_access():
+    _check(opaque_access, transformed_opaque_access)
 
 
 def test_lower_te():
@@ -164,4 +221,5 @@ if __name__ == "__main__":
     test_elementwise()
     test_locate_buffer_allocation()
     test_match_buffer_allocation()
+    test_opaque_access()
     test_lower_te()


### PR DESCRIPTION
In this PR, I have fixed two bugs:
1. Incorrectly detect access region for opaque access in `PlanAndUpdateBufferAllocationLocation`
    Currently, the pass `PlanAndUpdateBufferAllocationLocation` will re-calculate the access region. It will enlarge the access region even though with manually specified access regions. Actually, the only thing we should do is erase the buffers allocated inside the block. 
2. Incorrectly analyze the buffer access region created by `match_buffer`.
   `block_access_region_detector` will only detector buffers in the given map. As for the buffer created by `match_buffer`, we SHOULD only consider the buffers whose source buffer is in the given map. But we detect all buffers created by `match_buffer` by mistake. Also, the previous testcase is incorrect, so we can pass it even the logic is wrong.

Thanks @MasterJH5574 for reporting this error.