### PR TITLE
Remove AOT Executor header from Arduino project

### DIFF
--- a/apps/microtvm/arduino/example_project/src/model.c
+++ b/apps/microtvm/arduino/example_project/src/model.c
@@ -20,7 +20,6 @@
 #include "model.h"
 
 #include "Arduino.h"
-#include "standalone_crt/include/tvm/runtime/crt/internal/aot_executor/aot_executor.h"
 #include "standalone_crt/include/tvm/runtime/crt/stack_allocator.h"
 
 // AOT memory array

--- a/apps/microtvm/arduino/host_driven/src/model_support.c
+++ b/apps/microtvm/arduino/host_driven/src/model_support.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "standalone_crt/include/tvm/runtime/crt/internal/aot_executor/aot_executor.h"
 #include "stdarg.h"
 
 // Blink code for debugging purposes


### PR DESCRIPTION
These files are no longer available for use.