### PR TITLE
[Hexagon] Change declaration order of unique_ptr objects to fix crash

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -704,8 +704,8 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   (void)CallOnce;
 
   std::unique_ptr<llvm::TargetMachine> tm = GetLLVMTargetMachine(target);
-  std::unique_ptr<CodeGenHexagon> cg(new CodeGenHexagon());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
+  std::unique_ptr<CodeGenHexagon> cg(new CodeGenHexagon());
   cg->Init("TVMHexagonModule", tm.get(), ctx.get(), false, false, false);
   for (auto kv : mod->functions) {
     ICHECK(kv.second->IsInstance<PrimFuncNode>()) << "Can only lower IR Module with PrimFuncs";


### PR DESCRIPTION
A crash occurs when automatically deleting an instance of `CodeGenHexagon` because the `LLVMContext` object has already been freed. Objects of both types are created using `unique_ptr`, but the object managed by the `LLVMContext` `unique_ptr` is passed to `CodeGenHexagon` object (not as a `unique_ptr`).

This crash is fixed by moving the declaration of the `LLVMContext` object before the `CodeGenHexagon` object.