### PR TITLE
[Autoscheduler] Configurable workload keys

### DIFF
--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -18,7 +18,6 @@
 
 """ The auto-scheduler's computational graph and related program analyses. """
 
-import hashlib
 import json
 
 import tvm._ffi

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -235,6 +235,7 @@ class ComputeDAG(Object):
         )
 
         if hash_func is None:
+            str_dag = str_dag.encode("utf-8")
             hash_key = hashlib.md5(str_dag).hexdigest()
         else:
             hash_key = hash_func(str_dag)

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -222,7 +222,7 @@ class ComputeDAG(Object):
 
     def workload_key(self):
         """Return the workload key of this compute DAG.
-        The workload key is a JSON string from a tuple of (DAG string, tensor shapes...)
+        The workload key is a JSON string from a tuple of (hash of DAG, tensor shapes...)
 
         Returns
         -------

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -222,18 +222,23 @@ class ComputeDAG(Object):
 
     def workload_key(self):
         """Return the workload key of this compute DAG.
-        The workload key is a JSON string from a tuple of (hash-key, tensor shapes...)
+        The workload key is a JSON string from a tuple of (DAG string, tensor shapes...)
 
         Returns
         -------
         key: str
             The workload key of this compute DAG
         """
-        str_dag = _ffi_api.ComputeDAGPrintDAG(self, True)
+        hash_key = _ffi_api.ComputeDAGPrintDAG(self, True)
+        # TODO: forward a "use_hash" flag down here
+        # if use_hash:
+        #     hash_key = hash_key.encode(encoding="utf-8")
+        #     hash_key = hashlib.md5(hash_key).hexdigest()
+
         io_shapes = []
         for tensor in self.tensors:
             io_shapes.append(get_const_tuple(tensor.shape))
-        return json.dumps([str_dag] + io_shapes)
+        return json.dumps([hash_key] + io_shapes)
 
     def __str__(self):
         # pretty print

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -232,7 +232,7 @@ class ComputeDAG(Object):
         str_dag = _ffi_api.ComputeDAGPrintDAG(self, True)
         io_shapes = []
         for tensor in self.tensors:
-            io_shapes += get_const_tuple(tensor.shape)
+            io_shapes.append(get_const_tuple(tensor.shape))
         return json.dumps([str_dag] + io_shapes)
 
     def __str__(self):

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -230,8 +230,6 @@ class ComputeDAG(Object):
             The workload key of this compute DAG
         """
         str_dag = _ffi_api.ComputeDAGPrintDAG(self, True)
-        str_dag = str_dag.encode(encoding="utf-8")
-
         io_shapes = []
         for tensor in self.tensors:
             io_shapes += get_const_tuple(tensor.shape)

--- a/python/tvm/auto_scheduler/compute_dag.py
+++ b/python/tvm/auto_scheduler/compute_dag.py
@@ -231,12 +231,11 @@ class ComputeDAG(Object):
         """
         str_dag = _ffi_api.ComputeDAGPrintDAG(self, True)
         str_dag = str_dag.encode(encoding="utf-8")
-        hash_key = hashlib.md5(str_dag).hexdigest()
 
         io_shapes = []
         for tensor in self.tensors:
             io_shapes += get_const_tuple(tensor.shape)
-        return json.dumps([hash_key] + io_shapes)
+        return json.dumps([str_dag] + io_shapes)
 
     def __str__(self):
         # pretty print

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -116,7 +116,7 @@ def extract_tasks(
         Hardware parameters used for the search tasks
     include_simple_tasks: bool
         Whether to extract simple tasks that do not include complicated ops.
-    dump_workloads_extract_tasks: Optional[str]
+    dump_workload_to_dag_log: Optional[str]
         A file to dump an association between the workload keys and the actual DAG
     opt_level : Optional[int]
         The optimization level of the task extractions.

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -174,7 +174,7 @@ def extract_tasks(
         weights.append(weight)
 
     if dump_workload_to_dag_log is not None:
-        with open(dump_workload_to_dag_log, "wb") as f:
+        with open(dump_workload_to_dag_log, "w") as f:
             json.dump({task.workload_key: str(task.compute_dag) for task in tasks}, f)
 
     return tasks, weights


### PR DESCRIPTION
The old workload key uses an md5 hash of the string representation of the computational DAG. This gives the question of what to do when we have a hash collision. This change lets us dump a file in `extract_tasks` associating the workload key (e.g. hash + other things) with the printed version of the dag. 

We also provide a way to modify the hashing function being used.

Finally we have a common bug where to construct the workload key, we append the size of input tensors to the DAG. However we were appending each integer part of the shape into one big list instead of appending the tuple. This fixes this too. E.g. we have [1, 1], [3, 4, 5, 6] instead of [1, 1, 3, 4, 5, 6]

Testing:
Ran the autotuning tutorials https://tvm.apache.org/docs/tutorials/auto_scheduler/tune_network_cuda.html and made sure it works.

Unit tests