### PR TITLE
[UnitTests][Ethos-N] Mark unit tests as requiring Ethos-N

### DIFF
--- a/python/tvm/testing/__init__.py
+++ b/python/tvm/testing/__init__.py
@@ -17,15 +17,7 @@
 
 # pylint: disable=redefined-builtin, wildcard-import
 """Utility Python functions for TVM testing"""
-from .utils import assert_allclose, assert_prim_expr_equal, check_bool_expr_is_true
-from .utils import check_int_constraints_trans_consistency, check_numerical_grads
-from .utils import device_enabled, enabled_targets, exclude_targets
-from .utils import fixture, parameter, parameters, parametrize_targets, uses_gpu
-from .utils import known_failing_targets, requires_cuda, requires_cudagraph
-from .utils import requires_gpu, requires_llvm, requires_rocm, requires_rpc
-from .utils import requires_tensorcore, requires_metal, requires_micro, requires_opencl
-from .utils import requires_package
-from .utils import identity_after, terminate_self
+from .utils import *
 
 from ._ffi_api import nop, echo, device_test, run_check_signal, object_use_count
 from ._ffi_api import test_wrap_callback, test_raise_error_callback, test_check_eq_callback

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -49,6 +49,7 @@ MARKERS = {
     "vulkan": "mark a test as requiring vulkan",
     "metal": "mark a test as requiring metal",
     "llvm": "mark a test as requiring llvm",
+    "ethosn": "mark a test as requiring ethosn",
 }
 
 

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -81,6 +81,7 @@ import tvm._ffi
 
 from tvm.contrib import nvcc, cudnn
 from tvm.error import TVMError
+from tvm.relay.op.contrib.ethosn import ethosn_available
 
 
 def assert_allclose(actual, desired, rtol=1e-7, atol=1e-7):
@@ -772,6 +773,28 @@ def requires_rpc(*args):
         )
     ]
     return _compose(args, _requires_rpc)
+
+
+def requires_ethosn(*args):
+    """Mark a test as requiring ethosn to run.
+
+    Parameters
+    ----------
+    f : function
+        Function to mark
+    """
+    marks = [
+        pytest.mark.ethosn,
+        pytest.mark.skipif(
+            not ethosn_available(),
+            reason=(
+                "Ethos-N support not enabled.  "
+                "Set USE_ETHOSN=ON in config.cmake to enable, "
+                "and ensure that hardware support is present."
+            ),
+        ),
+    ]
+    return _compose(args, marks)
 
 
 def requires_package(*packages):

--- a/tests/python/contrib/test_ethosn/test_addition.py
+++ b/tests/python/contrib/test_ethosn/test_addition.py
@@ -19,7 +19,7 @@
 
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 import numpy as np
 
@@ -54,10 +54,8 @@ def _get_addition_qnn_params(input1_zp, input1_sc, input2_zp, input2_sc):
     return output_zp, output_sc
 
 
+@requires_ethosn
 def test_addition():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 22, 9, 9), 24, 1.057, 253, 0.452),
         ((1, 27, 21, 16), 79, 0.850, 24, 0.380),
@@ -81,10 +79,8 @@ def test_addition():
         tei.verify(outputs, 2)
 
 
+@requires_ethosn
 def test_addition_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         (
             (2, 4, 4, 4),

--- a/tests/python/contrib/test_ethosn/test_concatenate.py
+++ b/tests/python/contrib/test_ethosn/test_concatenate.py
@@ -20,7 +20,7 @@
 import numpy as np
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 
 
@@ -53,10 +53,8 @@ def _get_model(shapes, dtype, axis):
     return con
 
 
+@requires_ethosn
 def test_concatenate():
-    if not ethosn_available():
-        return
-
     trials = [
         ([(1, 4), (1, 6)], 1),
         ([(1, 16, 4), (1, 16, 4)], 1),
@@ -75,10 +73,8 @@ def test_concatenate():
         tei.verify(outputs, 0)
 
 
+@requires_ethosn
 def test_concatenate_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         ([(1, 4, 4, 4, 4), (1, 4, 4, 4, 4)], "uint8", 1, "dimensions=5, dimensions must be <= 4;"),
         (

--- a/tests/python/contrib/test_ethosn/test_constant_duplication.py
+++ b/tests/python/contrib/test_ethosn/test_constant_duplication.py
@@ -20,7 +20,7 @@
 import numpy as np
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 
 
@@ -70,10 +70,8 @@ def _get_model():
     return req, params
 
 
+@requires_ethosn
 def test_constant_duplication():
-    if not ethosn_available():
-        return
-
     model, params = _get_model()
     mod = tei.make_module(model, params)
     res = tei.build(mod, params, npu=True, expected_host_ops=1)

--- a/tests/python/contrib/test_ethosn/test_conv2d.py
+++ b/tests/python/contrib/test_ethosn/test_conv2d.py
@@ -21,7 +21,7 @@ import numpy as np
 import math
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 
 
@@ -113,10 +113,8 @@ def _get_model(
     return req, params
 
 
+@requires_ethosn
 def test_conv2d():
-    if not ethosn_available():
-        return
-
     trials = [
         [(1, 17, 20, 26), 4, 3, 1, "attr", (2, 2), (1, 1)],
         [(1, 30, 27, 30), 5, 5, 3, "none", (1, 1), (1, 1)],
@@ -181,10 +179,8 @@ def test_conv2d():
             tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_conv2d_failure():
-    if not ethosn_available():
-        return
-
     _scale_error_msg = (
         "Overall scale (of the input * weights / output) should be in the range [0, 1)"
     )

--- a/tests/python/contrib/test_ethosn/test_depth_to_space.py
+++ b/tests/python/contrib/test_ethosn/test_depth_to_space.py
@@ -19,7 +19,7 @@
 
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 import numpy as np
 
@@ -30,10 +30,8 @@ def _get_model(shape, block, dtype, layout):
     return depth
 
 
+@requires_ethosn
 def test_depth_to_space():
-    if not ethosn_available():
-        return
-
     trials = [
         (1, 16, 16, 16),
         (1, 64, 32, 16),
@@ -52,10 +50,8 @@ def test_depth_to_space():
         tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_depth_to_space_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         ((2, 16, 16, 16), 2, "uint8", "NHWC", "batch size=2, batch size must = 1"),
         ((1, 16, 16, 16), 2, "int8", "NHWC", "dtype='int8', dtype must be either uint8 or int32"),

--- a/tests/python/contrib/test_ethosn/test_fullyconnected.py
+++ b/tests/python/contrib/test_ethosn/test_fullyconnected.py
@@ -20,7 +20,7 @@
 import numpy as np
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 
 
@@ -56,10 +56,8 @@ def _get_model(
     return req, params
 
 
+@requires_ethosn
 def test_fullyconnected():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 1024), 71, 0.580, 79, 1.498),
         ((1, 4096), 166, 1.724, 117, 0.180),
@@ -91,10 +89,8 @@ def test_fullyconnected():
         tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_fullyconnected_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         (
             (1, 64),

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -23,8 +23,10 @@ pytest.importorskip("tflite")
 pytest.importorskip("tensorflow")
 
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from tvm.contrib import download
+from tvm.testing import requires_ethosn
+
 import tvm.relay.testing.tf as tf_testing
 import tflite.Model
 from . import infrastructure as tei
@@ -88,8 +90,6 @@ def _test_image_network(
         to check the correctness/accuracy.
 
     """
-    if not ethosn_available():
-        return
 
     def get_model():
         if model_url[-3:] in ("tgz", "zip"):
@@ -116,6 +116,7 @@ def _test_image_network(
         tei.run(m, inputs, output_count, npu=True)
 
 
+@requires_ethosn
 def test_mobilenet_v1():
     # If this test is failing due to a hash mismatch, please notify @mbaret and
     # @Leo-arm. The hash is there to catch any changes in the behaviour of the
@@ -142,6 +143,7 @@ def test_mobilenet_v1():
     )
 
 
+@requires_ethosn
 def test_inception_v3():
     # If this test is failing due to a hash mismatch, please notify @mbaret and
     # @Leo-arm. The hash is there to catch any changes in the behaviour of the
@@ -167,6 +169,7 @@ def test_inception_v3():
     )
 
 
+@requires_ethosn
 def test_inception_v4():
     # If this test is failing due to a hash mismatch, please notify @mbaret and
     # @Leo-arm. The hash is there to catch any changes in the behaviour of the
@@ -192,6 +195,7 @@ def test_inception_v4():
     )
 
 
+@requires_ethosn
 def test_ssd_mobilenet_v1():
     # If this test is failing due to a hash mismatch, please notify @mbaret and
     # @Leo-arm. The hash is there to catch any changes in the behaviour of the

--- a/tests/python/contrib/test_ethosn/test_pooling.py
+++ b/tests/python/contrib/test_ethosn/test_pooling.py
@@ -20,7 +20,7 @@
 import numpy as np
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 
 
@@ -35,10 +35,8 @@ def _get_model(shape, typef, sizes, strides, pads, layout, dtype):
     return req
 
 
+@requires_ethosn
 def test_pooling():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 8, 8, 8), relay.nn.max_pool2d, (2, 2), (2, 2), (0, 0, 0, 0), "NHWC"),
         ((1, 9, 9, 9), relay.nn.max_pool2d, (2, 2), (2, 2), (0, 0, 1, 1), "NHWC"),
@@ -60,10 +58,8 @@ def test_pooling():
         tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_pooling_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         (
             (2, 8, 8, 8),

--- a/tests/python/contrib/test_ethosn/test_relu.py
+++ b/tests/python/contrib/test_ethosn/test_relu.py
@@ -19,7 +19,7 @@
 
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 import numpy as np
 
@@ -30,10 +30,8 @@ def _get_model(shape, dtype, a_min, a_max):
     return relu
 
 
+@requires_ethosn
 def test_relu():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 4, 4, 4), 65, 178),
         ((1, 8, 4, 2), 1, 254),
@@ -53,10 +51,8 @@ def test_relu():
         tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_relu_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 4, 4, 4, 4), "uint8", 65, 78, "dimensions=5, dimensions must be <= 4"),
         ((1, 8, 4, 2), "int8", 1, 254, "dtype='int8', dtype must be either uint8 or int32"),

--- a/tests/python/contrib/test_ethosn/test_reshape.py
+++ b/tests/python/contrib/test_ethosn/test_reshape.py
@@ -19,7 +19,8 @@
 
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib import ethosn_available, get_pattern_table
+from tvm.testing import requires_ethosn
+from tvm.relay.op.contrib import get_pattern_table
 from . import infrastructure as tei
 import numpy as np
 
@@ -32,10 +33,8 @@ def _get_model(input_shape, output_shape, dtype):
     return req, params
 
 
+@requires_ethosn
 def test_reshape():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 15, 4, 1), (1, 60)),
         ((1, 15, 4, 1), (1, 30, 2)),
@@ -58,10 +57,8 @@ def test_reshape():
         tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_reshape_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         (
             (1, 15, 4, 1),

--- a/tests/python/contrib/test_ethosn/test_sigmoid.py
+++ b/tests/python/contrib/test_ethosn/test_sigmoid.py
@@ -19,7 +19,7 @@
 
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 import numpy as np
 
@@ -41,10 +41,8 @@ def _get_model(shape, input_zp, input_sc, output_zp, output_sc, dtype):
     return model
 
 
+@requires_ethosn
 def test_sigmoid():
-    if not ethosn_available():
-        return
-
     trials = [
         (1, 16, 16, 16),
         (1, 8, 8),
@@ -64,10 +62,8 @@ def test_sigmoid():
         tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_sigmoid_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         ((2, 4, 4, 4), 64, 0.2, 0, 1 / 256, "uint8", "batch size=2, batch size must = 1"),
         (

--- a/tests/python/contrib/test_ethosn/test_split.py
+++ b/tests/python/contrib/test_ethosn/test_split.py
@@ -20,7 +20,7 @@
 import numpy as np
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available
+from tvm.testing import requires_ethosn
 from . import infrastructure as tei
 
 
@@ -30,10 +30,8 @@ def _get_model(shape, dtype, splits, axis):
     return split.astuple()
 
 
+@requires_ethosn
 def test_split():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 16, 16, 32), (2, 7, 10), 2),
         ((1, 12, 8, 16), 3, 1),
@@ -53,10 +51,8 @@ def test_split():
         tei.verify(outputs, 0)
 
 
+@requires_ethosn
 def test_split_failure():
-    if not ethosn_available():
-        return
-
     trials = [
         ((1, 4, 4, 4, 4), "uint8", 4, 2, "dimensions=5, dimensions must be <= 4;"),
         ((1, 4, 4, 4), "int8", 4, 2, "dtype='int8', dtype must be either uint8 or int32;"),

--- a/tests/python/contrib/test_ethosn/test_topologies.py
+++ b/tests/python/contrib/test_ethosn/test_topologies.py
@@ -19,14 +19,13 @@
 import numpy as np
 import tvm
 from tvm import relay
-from tvm.relay.op.contrib.ethosn import ethosn_available, Available
+from tvm.testing import requires_ethosn
+from tvm.relay.op.contrib.ethosn import Available
 from . import infrastructure as tei
 
 
+@requires_ethosn
 def test_split_add_concat():
-    if not ethosn_available():
-        return
-
     def get_model(input_shape, var_names):
         """Return a model"""
 
@@ -71,6 +70,7 @@ def test_split_add_concat():
     tei.verify(outputs, 2)
 
 
+@requires_ethosn
 def test_multiple_command_streams():
     """Check that multiple Ethos-N partitions are correctly handled.
 
@@ -80,8 +80,6 @@ def test_multiple_command_streams():
     simple graph which creates two Ethos-N partitions and checks the result
     against an 'all-CPU' run through TVM.
     """
-    if not ethosn_available():
-        return
 
     def get_model():
         """
@@ -107,10 +105,8 @@ def test_multiple_command_streams():
     )
 
 
+@requires_ethosn
 def test_output_order():
-    if not ethosn_available():
-        return
-
     def get_model(input_shape, var_names):
         """Return a model"""
 
@@ -140,10 +136,8 @@ def test_output_order():
     tei.verify(outputs, 1)
 
 
+@requires_ethosn
 def test_split_with_asym_concats():
-    if not ethosn_available():
-        return
-
     def get_model(shape, splits, axis):
         a = relay.var("a", shape=shape, dtype="uint8")
         split = relay.op.split(a, indices_or_sections=splits, axis=axis)
@@ -183,11 +177,10 @@ def test_split_with_asym_concats():
         tei.verify(outputs, 0)
 
 
+@requires_ethosn
 def test_output_tuple_propagation():
     """This tests the case where the output tuple must be inferred
     as having dummy tensor information."""
-    if not ethosn_available():
-        return
 
     def get_model():
         a = relay.var("a", shape=(1, 4, 4, 16), dtype="uint8")
@@ -205,10 +198,8 @@ def test_output_tuple_propagation():
     tei.verify(outputs, 0)
 
 
+@requires_ethosn
 def test_input_tuples():
-    if not ethosn_available():
-        return
-
     def get_model(shapes, axis):
         tup = []
         for i, shape in enumerate(shapes):

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -22,8 +22,8 @@ from unittest import mock
 import pytest
 
 import tvm
+import tvm.testing
 
-from tvm.relay.op.contrib.ethosn import ethosn_available
 from tvm.contrib.target.vitis_ai import vitis_ai_available
 
 from tvm.driver import tvmc
@@ -290,10 +290,7 @@ def test_compile_opencl(tflite_mobilenet_v1_0_25_128):
     assert os.path.exists(dumps_path)
 
 
-@pytest.mark.skipif(
-    not ethosn_available(),
-    reason="--target=ethos-n77 is not available. TVM built with 'USE_ETHOSN OFF'",
-)
+@tvm.testing.requires_ethosn
 def test_compile_tflite_module_with_external_codegen(tflite_mobilenet_v1_1_quant):
     pytest.importorskip("tflite")
     tvmc_model = tvmc.load(tflite_mobilenet_v1_1_quant)


### PR DESCRIPTION
- Adds the decorator `tvm.testing.requires_ethosn`

- Marks all tests in `tests/python/contrib/test_ethosn` as requiring ethosn instead of directly checking `ethosn_available()`.  This way, they show up as skipped rather than passing.