### PR TITLE
[Vulkan][Target] Added the driver name to the vulkan target string.

### DIFF
--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -156,6 +156,10 @@ VulkanDeviceProperties::VulkanDeviceProperties(const VulkanInstance& instance,
   device_name = properties.properties.deviceName;
   driver_version = properties.properties.driverVersion;
 
+  if (device.HasExtension("VK_KHR_driver_properties")) {
+    driver_name = driver.driverName;
+  }
+
   switch (properties.properties.deviceType) {
     case VK_PHYSICAL_DEVICE_TYPE_OTHER:
       device_type = "other";

--- a/src/runtime/vulkan/vulkan_device.h
+++ b/src/runtime/vulkan/vulkan_device.h
@@ -94,6 +94,7 @@ struct VulkanDeviceProperties {
   uint32_t max_shared_memory_per_block{16384};
   std::string device_type{"unknown_device_type"};
   std::string device_name{"unknown_device_name"};
+  std::string driver_name{"unknown_driver_name"};
   uint32_t driver_version{0};
   uint32_t vulkan_api_version{VK_API_VERSION_1_0};
   uint32_t max_spirv_version{0x10000};

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -242,6 +242,9 @@ void VulkanDeviceAPI::GetTargetProperty(Device dev, const std::string& property,
   if (property == "device_type") {
     *rv = prop.device_type;
   }
+  if (property == "driver_name") {
+    *rv = prop.driver_name;
+  }
   if (property == "driver_version") {
     *rv = int64_t(prop.driver_version);
   }

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -312,6 +312,7 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     // Other device properties
     .add_attr_option<String>("device_type")
     .add_attr_option<String>("device_name")
+    .add_attr_option<String>("driver_name")
     .add_attr_option<Integer>("driver_version")
     .add_attr_option<Integer>("vulkan_api_version")
     .add_attr_option<Integer>("max_spirv_version")


### PR DESCRIPTION
Driver name (e.g. "NVIDIA", "radv", "AMD open-source driver") is read from the `driverName` property in [VkPhysicalDeviceDriverProperties](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDriverProperties.html), or is left as `"unknown_driver_name"` if the driver does not support
querying the driver name.