### PR TITLE
[BUG] Shape Func of Split Op Error

### DIFF
--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -756,9 +756,9 @@ def tile_shape_func(attrs, inputs, _):
 
 
 @script
-def _split_shape_func(data_shape, index, indices_or_sections, axis):
+def _split_shape_func(data_shape, index, indices_or_sections, param_is_indices, axis):
     out = output_tensor((data_shape.shape[0],), "int64")
-    if len(indices_or_sections) == 1:
+    if param_is_indices:
         for i in const_range(data_shape.shape[0]):
             if i == axis:
                 assert (
@@ -806,10 +806,18 @@ def split_shape_func(attrs, inputs, _):
         if isinstance(indices_or_sections, int)
         else len(indices_or_sections) + 1
     )
-    if isinstance(indices_or_sections, int):
+
+    param_is_indices = isinstance(indices_or_sections, int)
+    if param_is_indices:
         indices_or_sections = [indices_or_sections]
     return [
-        _split_shape_func(inputs[0], convert(i), convert(indices_or_sections), convert(axis))
+        _split_shape_func(
+		    inputs[0],
+			convert(i),
+			convert(indices_or_sections),
+			convert(param_is_indices),
+			convert(axis),
+		)
         for i in range(num_out)
     ]
 

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -812,12 +812,12 @@ def split_shape_func(attrs, inputs, _):
         indices_or_sections = [indices_or_sections]
     return [
         _split_shape_func(
-		    inputs[0],
-			convert(i),
-			convert(indices_or_sections),
-			convert(param_is_indices),
-			convert(axis),
-		)
+            inputs[0],
+            convert(i),
+            convert(indices_or_sections),
+            convert(param_is_indices),
+            convert(axis),
+        )
         for i in range(num_out)
     ]
 

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -724,6 +724,8 @@ def test_any_split():
     verify_any_split((relay.Any(), relay.Any()), 2, 1, (9, 4), [(9, 2), (9, 2)])
     verify_any_split((relay.Any(), 12), (1, 4, 8), 1, (7, 12), [(7, 1), (7, 3), (7, 4)])
     verify_any_split((relay.Any(), relay.Any()), (1, 4, 8), 1, (7, 12), [(7, 1), (7, 3), (7, 4)])
+    verify_any_split((relay.Any(), 12), (8,), 1, (7, 12), [(7, 8), (7, 4)])
+    verify_any_split((relay.Any(), relay.Any()), (8,), 1, (7, 12), [(7, 8), (7, 4)])
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
Function split_shape_func converts indices_or_sections to a list if indices_or_sections is actually indices (a int num):
```
if isinstance(indices_or_sections, int):
    indices_or_sections = [indices_or_sections]
```
and remains indices_or_sections a list if indices_or_sections is actually sections. 

Then funtion _split_shape_func treats indices_or_sections as indices if len(indices_or_sections) == 1, treats indices_or_sections as sections otherwise:
```
if len(indices_or_sections) == 1:
    ...
else:
    ...
```

However, if indices_or_sections is actually sections but only contains one element, it will be treated as indices in error.
