### PR TITLE
[Doc] Current passes

### DIFF
--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name, unused-argument, missing-docstring, unused-import
+# pylint: disable=invalid-name, unused-argument, missing-docstring, unused-import, line-too-long
 """
 Relay pass transformation infrastructure.
 """
@@ -264,6 +264,27 @@ def FoldConstant():
     -------
     ret : tvm.transform.Pass
         The registered pass for constant folding.
+
+    Example
+    -------
+    Before/After from the test_fold_const() in `test_pass_fold_constant.py
+    <https://github.com/apache/tvm/blob/main/tests/python/relay/test_pass_fold_constant.py>`_.
+
+        .. code-block:: cpp
+
+            // Before :
+            fn (%x: Tensor[(1, 2, 3), float32]) -> Tensor[(1, 2, 3), float32] {
+                %0 = add(meta[relay.Constant][0] /* ty=Tensor[(3), float32] */, meta[relay.Constant][0] /* ty=Tensor[(3), float32] */) /* ty=Tensor[(3), float32] */;
+                %1 = multiply(%0, 2f /* ty=float32 */) /* ty=Tensor[(3), float32] */;
+                %2 = add(%x, %1) /* ty=Tensor[(1, 2, 3), float32] */;
+                add(%2, meta[relay.Constant][0] /* ty=Tensor[(3), float32] */) /* ty=Tensor[(1, 2, 3), float32] */
+              }
+
+            // After :
+              fn (%x: Tensor[(1, 2, 3), float32]) -> Tensor[(1, 2, 3), float32] {
+                %0 = add(%x, meta[relay.Constant][0] /* ty=Tensor[(3), float32] */) /* ty=Tensor[(1, 2, 3), float32] */;
+                add(%0, meta[relay.Constant][1] /* ty=Tensor[(3), float32] */) /* ty=Tensor[(1, 2, 3), float32] */
+              }
     """
     return _ffi_api.FoldConstant()
 


### PR DESCRIPTION
Add a before/after example of realy pass

Hi communities, I am wondering perhaps it might be good to have an example to see immediately for each (or most) relay pass in the transform document.
Therefore I create this example here. 
![image](https://user-images.githubusercontent.com/82346784/131597774-fe6b8ee9-9386-4db5-ae10-5963b1b39a3f.png)

Since the document is generated from the comments of python. I simply add more contents in its comments.
I would like to have your comments, and if it is fine I will add more before/after examples and submit request again.
@hogepodge  @tqchen  May I have your advices please? :D

Thank you! 

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
