### PR TITLE
Move to new style issue template system

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-Thanks for participating in the TVM community! We use https://discuss.tvm.ai for any general usage questions and discussions. The issue tracker is used for actionable items such as feature proposals discussion, roadmaps, and bug tracking.  You are always welcomed to post on the forum first :)
-
-Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
-
-For bug reports, to help the developer act on the issues, please include a description of your environment, preferably a minimum script to reproduce the problem.
-
-For feature proposals, list clear, small actionable items so we can track the progress of the change.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,26 @@
+---
+name: "\U0001F41B Bug report"
+about: To help the developer act on the issues, please include a description of your environment, preferably a minimum script to reproduce the problem.
+title: "[Bug] "
+
+---
+
+Thanks for participating in the TVM community! We use https://discuss.tvm.ai for any general usage questions and discussions. The issue tracker is used for actionable items such as feature proposals discussion, roadmaps, and bug tracking.  You are always welcomed to post on the forum first :smile_cat:
+
+Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
+
+### Expected behavior
+
+What you were expecting
+
+### Actual behavior
+
+What actually happened
+
+### Environment
+
+Any environment details, such as: Operating System, TVM version, etc
+
+### Steps to reproduce
+
+Preferably a minimal script to cause the issue to occur.

--- a/.github/ISSUE_TEMPLATE/ci-update.md
+++ b/.github/ISSUE_TEMPLATE/ci-update.md
@@ -9,21 +9,21 @@ Thanks for participating in the TVM community! We use https://discuss.tvm.ai for
 
 Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
 
-[] S0. Reason: For example, a blocked PR or a feature issue
+- [ ] S0. Reason: For example, a blocked PR or a feature issue
 
-[] S1. Tag of nightly build: TAG. Docker hub: https://hub.docker.com/layers/tlcpackstaging/ci_cpu/...
+- [ ] S1. Tag of nightly build: TAG. Docker hub: https://hub.docker.com/layers/tlcpackstaging/ci_cpu/...
 
-[] S2. The nightly is built on TVM commit: TVM_COMMIT. Detailed info can be found here: https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdaily-docker-image-rebuild/detail/daily-docker-image-rebuild/....
+- [ ] S2. The nightly is built on TVM commit: TVM_COMMIT. Detailed info can be found here: https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdaily-docker-image-rebuild/detail/daily-docker-image-rebuild/....
 
-[] S3. Testing the nightly image on ci-docker-staging: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/...
+- [ ] S3. Testing the nightly image on ci-docker-staging: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/...
 
-[] S4. Retag TAG to VERSION:
+- [ ] S4. Retag TAG to VERSION:
 ```
 docker pull tlcpackstaging/IMAGE_NAME:TAG
 docker tag tlcpackstaging/IMAGE_NAME:TAG tlcpack/IMAGE_NAME:VERSION
 docker push tlcpack/IMAGE_NAME:VERSION
 ```
 
-[] S5. Check if the new tag is really there: https://hub.docker.com/u/tlcpack
+- [ ] S5. Check if the new tag is really there: https://hub.docker.com/u/tlcpack
 
-[] S6. Submit a PR updating the IMAGE_NAME version on Jenkins
+- [ ] S6. Submit a PR updating the IMAGE_NAME version on Jenkins

--- a/.github/ISSUE_TEMPLATE/ci-update.md
+++ b/.github/ISSUE_TEMPLATE/ci-update.md
@@ -1,0 +1,29 @@
+---
+name: "\U0001F40B Update CI Docker Image"
+about: Provide information on CI Docker Images requiring updates
+title: "[CI] "
+
+---
+
+Thanks for participating in the TVM community! We use https://discuss.tvm.ai for any general usage questions and discussions. The issue tracker is used for actionable items such as feature proposals discussion, roadmaps, and bug tracking.  You are always welcomed to post on the forum first :smile_cat:
+
+Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
+
+[] S0. Reason: For example, a blocked PR or a feature issue
+
+[] S1. Tag of nightly build: TAG. Docker hub: https://hub.docker.com/layers/tlcpackstaging/ci_cpu/...
+
+[] S2. The nightly is built on TVM commit: TVM_COMMIT. Detailed info can be found here: https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdaily-docker-image-rebuild/detail/daily-docker-image-rebuild/....
+
+[] S3. Testing the nightly image on ci-docker-staging: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/...
+
+[] S4. Retag TAG to VERSION:
+```
+docker pull tlcpackstaging/IMAGE_NAME:TAG
+docker tag tlcpackstaging/IMAGE_NAME:TAG tlcpack/IMAGE_NAME:VERSION
+docker push tlcpack/IMAGE_NAME:VERSION
+```
+
+[] S5. Check if the new tag is really there: https://hub.docker.com/u/tlcpack
+
+[] S6. Submit a PR updating the IMAGE_NAME version on Jenkins

--- a/.github/ISSUE_TEMPLATE/feature-tracking.md
+++ b/.github/ISSUE_TEMPLATE/feature-tracking.md
@@ -11,4 +11,4 @@ Thanks for participating in the TVM community! We use https://discuss.tvm.ai for
 Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
 
 ### This issue to track progress for FEATURE NAME
-[] P1. Title of this piece of the feature (PR link if available)
+- [ ] P1. Title of this piece of the feature (PR link if available)

--- a/.github/ISSUE_TEMPLATE/feature-tracking.md
+++ b/.github/ISSUE_TEMPLATE/feature-tracking.md
@@ -1,0 +1,14 @@
+---
+name: "\U0001F527 Feature Tracking"
+about: List clear, small actionable items so we can track the progress of the change.
+labels: type:rfc-tracking
+title: "[Tracking Issue] "
+
+---
+
+Thanks for participating in the TVM community! We use https://discuss.tvm.ai for any general usage questions and discussions. The issue tracker is used for actionable items such as feature proposals discussion, roadmaps, and bug tracking.  You are always welcomed to post on the forum first :smile_cat:
+
+Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
+
+### This issue to track progress for FEATURE NAME
+[] P1. Title of this piece of the feature (PR link if available)


### PR DESCRIPTION
This lets us have a template for each type of issue, notably this includes a template for requesting a CI image update.

I can't find a decent way of testing this but GitHub does seem to have acknowledged they are issue templates here: https://github.com/Mousius/tvm/blob/issue-templates/.github/ISSUE_TEMPLATE/bug-report.md

