### PR TITLE
[UnitTests][Contrib] Enable contrib tensorrt/coreml unit tests

### DIFF
--- a/python/tvm/testing/__init__.py
+++ b/python/tvm/testing/__init__.py
@@ -24,6 +24,7 @@ from .utils import fixture, parameter, parameters, parametrize_targets, uses_gpu
 from .utils import known_failing_targets, requires_cuda, requires_cudagraph
 from .utils import requires_gpu, requires_llvm, requires_rocm, requires_rpc
 from .utils import requires_tensorcore, requires_metal, requires_micro, requires_opencl
+from .utils import requires_package
 from .utils import identity_after, terminate_self
 
 from ._ffi_api import nop, echo, device_test, run_check_signal, object_use_count

--- a/tests/python/contrib/test_coreml_codegen.py
+++ b/tests/python/contrib/test_coreml_codegen.py
@@ -19,11 +19,12 @@ import pytest
 from unittest import mock
 
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay import transform
 from tvm.contrib.target import coreml as _coreml
 
-pytest.importorskip("coremltools")
+requires_coremltools = tvm.testing.requires_package("coremltools")
 
 
 def _has_xcode():
@@ -88,6 +89,11 @@ def _create_graph_annotated():
     return mod
 
 
+@pytest.mark.xfail(
+    reason="Currently failing test.  See tracking issue https://github.com/apache/tvm/issues/8901"
+)
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_annotate():
     mod = _create_graph()
     mod = transform.AnnotateTarget("coremlcompiler")(mod)
@@ -98,6 +104,8 @@ def test_annotate():
 
 
 @pytest.mark.skipif(not _has_xcode(), reason="Xcode is not available")
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_compile_and_run():
     dev = tvm.cpu()
     target = "llvm"
@@ -136,6 +144,8 @@ def _construct_model(func, m1, m2):
             fcompile(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_add():
     shape = (10, 10)
     x = relay.var("x", shape=shape)
@@ -144,6 +154,8 @@ def test_add():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_multiply():
     shape = (10, 10)
     x = relay.var("x", shape=shape)
@@ -152,6 +164,8 @@ def test_multiply():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_clip():
     shape = (10, 10)
     x = relay.var("x", shape=shape)
@@ -160,6 +174,8 @@ def test_clip():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_batch_flatten():
     shape = (10, 10, 10)
     x = relay.var("x", shape=shape)
@@ -168,6 +184,8 @@ def test_batch_flatten():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_expand_dims():
     shape = (10, 10)
     x = relay.var("x", shape=shape)
@@ -180,6 +198,8 @@ def test_expand_dims():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_relu():
     shape = (10, 10)
     x = relay.var("x", shape=shape)
@@ -188,6 +208,8 @@ def test_relu():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_softmax():
     shape = (10, 10)
     x = relay.var("x", shape=shape)
@@ -196,6 +218,8 @@ def test_softmax():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_conv2d():
     x = relay.var("x", shape=(1, 3, 224, 224))
     w = relay.const(np.zeros((16, 3, 3, 3), dtype="float32"))
@@ -204,6 +228,8 @@ def test_conv2d():
     _construct_model(func)
 
 
+@tvm.testing.uses_gpu
+@requires_coremltools
 def test_global_avg_pool2d():
     shape = (10, 10, 10, 10)
     x = relay.var("x", shape=shape)


### PR DESCRIPTION
Some unit tests in the contrib directory have not been running in CI (see https://github.com/apache/tvm/issues/8901 for tracking issue).  This PR re-enables these tests, and marks any regressions with `xfail`.

[Pytest][TensorRT] Mark the TensorRT tests with tvm.testing.requires_cuda
    
- Previously, the tests had an early bailout if tensorrt was disabled, or if there was no cuda device present.  However, the tests were not marked with `pytest.mark.gpu` and so they didn't run during `task_python_integration_gpuonly.sh`.  This commit adds the `requires_cuda` mark, and maintains the same behavior of testing the tensorrt compilation steps if compilation is enabled, and running the results if tensorrt is enabled.
    
- In addition, some of the tests result in failures when run.  These have been marked with `pytest.mark.xfail`, and are being tracked in issue #8901.


[UnitTests][CoreML] Marked test_annotate as a known failure.
    
The unit tests in `test_coreml_codegen.py` haven't run in the CI lately, so this test wasn't caught before.  (See tracking issue #8901).
    
- Added `pytest.mark.xfail` mark to `test_annotate`.

- Added `tvm.testing.requires_package` decorator, which can mark tests as requiring a specific python package to be available.  Switched from `pytest.importorskip('coremltools')` to `requires_package('coremltools')` in `test_coreml_codegen.py` so that all tests would explicitly show up as skipped in the report.

- Added `uses_gpu` tag to all tests in `test_coreml_codegen.py`, since only ci_gpu has coremltools installed.  In the future, if the ci_cpu image has coremltools installed, this mark can be removed.