### PR TITLE
[Vulkan][Topi] Parametrizing additional topi tests, marking vulkan failures

### DIFF
--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -72,6 +72,9 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   if (target->GetAttr<Bool>("supports_float16")) {
     supports_float16 = target->GetAttr<Bool>("supports_float16").value();
   }
+  if (target->GetAttr<Bool>("supports_float64")) {
+    supports_float64 = target->GetAttr<Bool>("supports_float64").value();
+  }
   if (target->GetAttr<Bool>("supports_int8")) {
     supports_int8 = target->GetAttr<Bool>("supports_int8").value();
   }

--- a/tests/python/topi/python/test_topi_conv1d_transpose_ncw.py
+++ b/tests/python/topi/python/test_topi_conv1d_transpose_ncw.py
@@ -15,15 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test code for transposed convolution."""
-import numpy as np
+
 import itertools
+import os
+
+import numpy as np
+
 import tvm
-from tvm import te
-from tvm import topi
-import tvm.topi.testing
-from tvm.contrib.pickle_memoize import memoize
-from tvm.topi.utils import get_const_tuple
 import tvm.testing
+import tvm.topi.testing
+
+from tvm import te, topi
+from tvm.topi.utils import get_const_tuple
 
 _conv1d_transpose_ncw_implement = {
     "generic": (topi.nn.conv1d_transpose_ncw, topi.generic.schedule_conv1d_transpose_ncw),
@@ -31,74 +34,88 @@ _conv1d_transpose_ncw_implement = {
 }
 
 
-def verify_conv1d_transpose_ncw(
-    batch, in_channel, in_size, num_filter, kernel, stride, padding, output_padding
+(
+    batch,
+    in_channel,
+    in_size,
+    num_filter,
+    kernel,
+    stride,
+    padding,
+    output_padding,
+) = tvm.testing.parameters(
+    (1, 3, 224, 32, 5, 1, 0, (0,)),
+    (1, 3, 224, 32, 7, 1, 2, (0,)),
+    (1, 3, 224, 32, 5, 2, 1, (0,)),
+    (1, 3, 224, 32, 5, 2, 1, (1,)),
+    (1, 3, 224, 32, 5, 2, 0, (0,)),
+    (1, 32, 32, 128, 5, 1, 0, (0,)),
+    (1, 32, 32, 128, 5, 2, 1, (0,)),
+    (1, 1, 1024, 1, 512, 1, 256, (0,)),
+    (1, 1, 1024, 1, 512, 2, 256, (0,)),
+    (1, 1, 1024, 1, 512, 5, 256, (0,)),
+    (1, 1, 1024, 1, 512, 5, 256, (3,)),
+    (1, 2, 1024, 1, 128, 128, 0, (0,)),
+    (1, 1, 1024, 2, 128, 128, 0, (0,)),
+    (1, 1, 1024, 2, 2, 2, 0, (0,)),
+    (1, 1, 10, 1, 5, 1, (0, 3), (0,)),
+    (1, 1, 10, 1, 5, 1, (1, 3), (0,)),
+    (1, 1, 10, 1, 5, 1, (2, 3), (0,)),
+    (1, 257, 128, 1, 512, 128, 256, (0,)),
+)
+
+dtype = tvm.testing.parameter("float32")
+
+
+@tvm.testing.fixture(cache_return_value=True)
+def ref_data(
+    dtype, batch, in_channel, in_size, num_filter, kernel, stride, padding, output_padding
 ):
-    in_width = in_size
-    A = te.placeholder((batch, in_channel, in_width), name="A")
-    W = te.placeholder((in_channel, num_filter, kernel), name="W")
+    dtype = "float32"
+    a_shape = (batch, in_channel, in_size)
+    w_shape = (in_channel, num_filter, kernel)
 
-    a_shape = get_const_tuple(A.shape)
-    w_shape = get_const_tuple(W.shape)
-    dtype = A.dtype
-
-    @memoize("topi.tests.test_topi_conv1d_transpose.verify_conv1d_transpose_ncw")
-    def get_ref_data():
-        a_np = np.random.uniform(size=a_shape).astype(dtype)
-        w_np = np.random.uniform(size=w_shape).astype(dtype)
-        b_np = tvm.topi.testing.conv1d_transpose_ncw_python(
-            a_np, w_np, stride, padding, output_padding
-        )
-        c_np = np.maximum(b_np, 0)
-        return a_np, w_np, b_np, c_np
-
-    a_np, w_np, b_np, c_np = get_ref_data()
-
-    def check_target(target, dev):
-        dev = tvm.device(target, 0)
-        with tvm.target.Target(target):
-            fcompute, fschedule = tvm.topi.testing.dispatch(target, _conv1d_transpose_ncw_implement)
-            B = fcompute(A, W, stride, padding, A.dtype, output_padding)
-            C = topi.nn.relu(B)
-            s1 = fschedule([B])
-            s2 = fschedule([C])
-        a = tvm.nd.array(a_np, dev)
-        w = tvm.nd.array(w_np, dev)
-        b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), dev)
-        c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), dev)
-
-        func1 = tvm.build(s1, [A, W, B], target)
-        func2 = tvm.build(s2, [A, W, C], target)
-        func1(a, w, b)
-        func2(a, w, c)
-        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5)
-        tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
-
-    for target, dev in tvm.testing.enabled_targets():
-        check_target(target, dev)
+    a_np = np.random.uniform(size=a_shape).astype(dtype)
+    w_np = np.random.uniform(size=w_shape).astype(dtype)
+    b_np = tvm.topi.testing.conv1d_transpose_ncw_python(a_np, w_np, stride, padding, output_padding)
+    c_np = np.maximum(b_np, 0)
+    return a_np, w_np, b_np, c_np
 
 
-@tvm.testing.uses_gpu
-def test_conv1d_transpose_ncw():
-    verify_conv1d_transpose_ncw(1, 3, 224, 32, 5, 1, 0, (0,))
-    verify_conv1d_transpose_ncw(1, 3, 224, 32, 7, 1, 2, (0,))
-    verify_conv1d_transpose_ncw(1, 3, 224, 32, 5, 2, 1, (0,))
-    verify_conv1d_transpose_ncw(1, 3, 224, 32, 5, 2, 1, (1,))
-    verify_conv1d_transpose_ncw(1, 3, 224, 32, 5, 2, 0, (0,))
-    verify_conv1d_transpose_ncw(1, 32, 32, 128, 5, 1, 0, (0,))
-    verify_conv1d_transpose_ncw(1, 32, 32, 128, 5, 2, 1, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 1024, 1, 512, 1, 256, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 1024, 1, 512, 2, 256, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 1024, 1, 512, 5, 256, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 1024, 1, 512, 5, 256, (3,))
-    verify_conv1d_transpose_ncw(1, 2, 1024, 1, 128, 128, 0, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 1024, 2, 128, 128, 0, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 1024, 2, 2, 2, 0, (0,))
-    verify_conv1d_transpose_ncw(1, 1, 10, 1, 5, 1, (0, 3), (0,))
-    verify_conv1d_transpose_ncw(1, 1, 10, 1, 5, 1, (1, 3), (0,))
-    verify_conv1d_transpose_ncw(1, 1, 10, 1, 5, 1, (2, 3), (0,))
-    verify_conv1d_transpose_ncw(1, 257, 128, 1, 512, 128, 256, (0,))
+@tvm.testing.known_failing_targets("vulkan")
+def test_conv1d_transpose_ncw(
+    target,
+    dev,
+    ref_data,
+    dtype,
+    stride,
+    padding,
+    output_padding,
+):
+
+    a_np, w_np, b_np, c_np = ref_data
+
+    A = te.placeholder(a_np.shape, name="A", dtype=dtype)
+    W = te.placeholder(w_np.shape, name="W", dtype=dtype)
+
+    with tvm.target.Target(target):
+        fcompute, fschedule = tvm.topi.testing.dispatch(target, _conv1d_transpose_ncw_implement)
+        B = fcompute(A, W, stride, padding, A.dtype, output_padding)
+        C = topi.nn.relu(B)
+        s1 = fschedule([B])
+        s2 = fschedule([C])
+    a = tvm.nd.array(a_np, dev)
+    w = tvm.nd.array(w_np, dev)
+    b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), dev)
+    c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), dev)
+
+    func1 = tvm.build(s1, [A, W, B], target)
+    func2 = tvm.build(s2, [A, W, C], target)
+    func1(a, w, b)
+    func2(a, w, c)
+    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5)
+    tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
 
 
 if __name__ == "__main__":
-    test_conv1d_transpose_ncw()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_loss.py
+++ b/tests/python/topi/python/test_topi_loss.py
@@ -25,9 +25,17 @@ import tvm.topi.testing
 import tvm.testing
 
 
-def verify_nll_loss(
-    dev, target, prediction_shape, reduction="mean", ignore_index=-100, dtype="float32"
-):
+prediction_shape, reduction, ignore_index, dtype = tvm.testing.parameters(
+    ((10, 5), "mean", -100, "float32"),
+    ((10, 5, 2, 2), "mean", -100, "float32"),
+    ((10, 5), "sum", -100, "float32"),
+    ((10, 5), "none", -100, "float32"),
+    ((10, 5), "mean", 3, "float32"),
+    ((10, 5), "mean", -100, "float64"),
+)
+
+
+def test_nll_loss(target, dev, prediction_shape, reduction, ignore_index, dtype):
     C = prediction_shape[1]
     target_shape = prediction_shape[:1] + prediction_shape[2:]
     predictions = te.placeholder(shape=prediction_shape, name="predictions", dtype=dtype)
@@ -56,15 +64,5 @@ def verify_nll_loss(
     tvm.testing.assert_allclose(out_topi, out_npy, rtol=1e-4, atol=1e-5)
 
 
-@tvm.testing.parametrize_targets
-def test_nll_loss(dev, target):
-    verify_nll_loss(dev, target, (10, 5))
-    verify_nll_loss(dev, target, (10, 5, 2, 2))
-    verify_nll_loss(dev, target, (10, 5), reduction="sum")
-    verify_nll_loss(dev, target, (10, 5), reduction="none")
-    verify_nll_loss(dev, target, (10, 5), ignore_index=3)
-    verify_nll_loss(dev, target, (10, 5), dtype="float64")
-
-
 if __name__ == "__main__":
-    test_nll_loss(tvm.device("cpu"), tvm.target.Target("llvm"))
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_math.py
+++ b/tests/python/topi/python/test_topi_math.py
@@ -14,14 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import sys
+
 import numpy as np
+import pytest
 import scipy
 from scipy import special
+
 import tvm
-from tvm import te
-from tvm import topi
 import tvm.testing
 import tvm.topi.testing
+
+from tvm import te, topi
 from tvm.topi import utils
 
 
@@ -31,211 +36,205 @@ def test_util():
     assert utils.get_const_tuple((x, x)) == (100, 100)
 
 
-@tvm.testing.uses_gpu
-def test_ewise():
-    def test_apply(
-        func,
-        name,
-        f_numpy,
-        low,
-        high,
-        shape=(20, 3),
-        dtype="float32",
-        check_round=False,
-        skip_name_check=False,
-    ):
-        m = te.var("m")
-        l = te.var("l")
-        A = te.placeholder((m, l), dtype=dtype, name="A")
+ewise_operations = {
+    "floor": {"topi": topi.floor, "ref": np.floor, "input_range": (-100, 100)},
+    "ceil": {"topi": topi.ceil, "ref": np.ceil, "input_range": (-100, 100)},
+    "sign": {
+        "topi": topi.sign,
+        "ref": np.sign,
+        "input_range": (-100, 100),
+        "skip_name_check": True,
+    },
+    "trunc": {"topi": topi.trunc, "ref": np.trunc, "input_range": (-100, 100)},
+    "fabs": {"topi": topi.abs, "ref": np.fabs, "input_range": (-100, 100)},
+    "round": {"topi": topi.round, "ref": np.round, "input_range": (-100, 100), "check_round": True},
+    "exp": {"topi": topi.exp, "ref": np.exp, "input_range": (-1, 1)},
+    "tanh": {
+        "topi": topi.tanh,
+        "ref": np.tanh,
+        "input_range": (-10, 10),
+        "shape": (128, 128),
+        "dtype": ["float32", "float64"],
+    },
+    "sigmoid": {
+        "topi": topi.sigmoid,
+        "ref": lambda x: 1 / (1 + np.exp(-x)),
+        "input_range": (-1, 1),
+    },
+    "log": {"topi": topi.log, "ref": np.log, "input_range": (0, 100)},
+    "sqrt": {"topi": topi.sqrt, "ref": np.sqrt, "input_range": (0, 100)},
+    "rsqrt": {
+        "topi": topi.rsqrt,
+        "ref": lambda x: np.ones_like(x) / np.sqrt(x),
+        "input_range": (0, 100),
+        "skip_name_check": True,
+    },
+    "cos": {"topi": topi.cos, "ref": np.cos, "input_range": (-2.0 * np.pi, 2.0 * np.pi)},
+    "tan": {
+        "topi": topi.tan,
+        "ref": np.tan,
+        "input_range": (-2.0 * np.pi, 2.0 * np.pi),
+        "dtypes": ["float32", "float64"],
+    },
+    "sin": {"topi": topi.sin, "ref": np.sin, "input_range": (-2.0 * np.pi, 2.0 * np.pi)},
+    "erf": {"topi": topi.erf, "ref": scipy.special.erf, "input_range": (-0.1, 0.1)},
+    "isnan": {
+        "topi": topi.isnan,
+        "ref": np.isnan,
+        "input_range": (-1, 1),
+        "replace_with_nan": True,
+    },
+    "isfinite": {
+        "topi": topi.isfinite,
+        "ref": np.isfinite,
+        "input_range": (0, 1),
+        "shape": (8, 8),
+        "skip_name_check": True,
+        "replace_with_nan": True,
+        "replace_with_inf": True,
+        "dtypes": ["float32", "float64", "int32", "int16"],
+    },
+    "isinf": {
+        "topi": topi.isinf,
+        "ref": np.isinf,
+        "input_range": (0, 1),
+        "shape": (8, 8),
+        "skip_name_check": True,
+        "replace_with_nan": True,
+        "replace_with_inf": True,
+        "dtypes": ["float32", "float64", "int32", "int16"],
+    },
+    "fast_exp": {
+        "topi": topi.fast_exp,
+        "ref": np.exp,
+        "skip_name_check": True,
+        "input_range": (-88, 88),
+        "step": 0.01,
+    },
+    "fast_erf": {
+        "topi": topi.fast_erf,
+        "ref": scipy.special.erf,
+        "skip_name_check": True,
+        "input_range": (-10, 10),
+        "step": 0.01,
+    },
+    "fast_erf": {
+        "topi": topi.fast_tanh,
+        "ref": np.tanh,
+        "skip_name_check": True,
+        "input_range": (-10, 10),
+        "step": 0.01,
+    },
+}
 
-        B = func(A)
-        assert tuple(B.shape) == tuple(A.shape)
-        if not skip_name_check:
-            assert B.op.body[0].op.name == "tir." + name
-        a_np = np.random.uniform(low=low, high=high, size=shape).astype(A.dtype) * 10
-        # avoid round check too close to boundary
-        if check_round:
-            a_np += ((np.abs(np.fmod(a_np, 1)) - 0.5) < 1e-6) * 1e-4
-        b_np = f_numpy(a_np)
-
-        def check_target(target, dev):
-            print("Running on target: %s" % target)
-            with tvm.target.Target(target):
-                s = tvm.topi.testing.get_injective_schedule(target)(B)
-            foo = tvm.build(s, [A, B], target, name=name)
-            a = tvm.nd.array(a_np, dev)
-            b = tvm.nd.array(np.zeros_like(b_np), dev)
-            foo(a, b)
-            tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5, atol=1e-5)
-
-        for target, dev in tvm.testing.enabled_targets():
-            check_target(target, dev)
-
-    def test_isnan(
-        low,
-        high,
-        shape=(20, 3),
-        dtype="float32",
-        check_round=False,
-        skip_name_check=False,
-    ):
-        m = te.var("m")
-        l = te.var("l")
-        A = te.placeholder((m, l), dtype=dtype, name="A")
-
-        B = topi.isnan(A)
-        assert tuple(B.shape) == tuple(A.shape)
-        if not skip_name_check:
-            assert B.op.body[0].op.name == "tir.isnan"
-        a_np = np.random.uniform(low=low, high=high, size=shape).astype(A.dtype) * 10
-        a_np.ravel()[np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)] = np.nan
-        # avoid round check too close to boundary
-        if check_round:
-            a_np += ((np.abs(np.fmod(a_np, 1)) - 0.5) < 1e-6) * 1e-5
-        b_np = np.isnan(a_np)
-
-        def check_target(target, dev):
-            print("Running on target: %s" % target)
-            with tvm.target.Target(target):
-                s = tvm.topi.testing.get_injective_schedule(target)(B)
-            foo = tvm.build(s, [A, B], target, name="isnan")
-            a = tvm.nd.array(a_np, dev)
-            b = tvm.nd.array(np.zeros_like(b_np), dev)
-            foo(a, b)
-            tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5, atol=1e-5)
-
-        for target, dev in tvm.testing.enabled_targets():
-            check_target(target, dev)
-
-    def test_infiniteness_ops(topi_op, ref_op, name):
-        for dtype in ["float32", "float64", "int32", "int16"]:
-            m = te.var("m")
-            l = te.var("l")
-            A = te.placeholder((m, l), dtype=dtype, name="A")
-            B = topi_op(A)
-            assert tuple(B.shape) == tuple(A.shape)
-
-            a_np = np.random.uniform(size=(8, 8)).astype(A.dtype) * 10
-            if dtype.startswith("float"):
-                a_np.ravel()[
-                    np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)
-                ] = np.infty
-                a_np.ravel()[
-                    np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)
-                ] = np.nan
-            b_np = ref_op(a_np)
-
-            def check_target(target, dev):
-                with tvm.target.Target(target):
-                    s = tvm.topi.testing.get_injective_schedule(target)(B)
-                foo = tvm.build(s, [A, B], target, name=name)
-                a = tvm.nd.array(a_np, dev)
-                b = tvm.nd.array(np.zeros_like(b_np), dev)
-                foo(a, b)
-                tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5, atol=1e-5)
-
-            for target, dev in tvm.testing.enabled_targets():
-                check_target(target, dev)
-
-    test_apply(topi.floor, "floor", np.floor, -100, 100)
-    test_apply(topi.ceil, "ceil", np.ceil, -100, 100)
-    test_apply(topi.sign, "sign", np.sign, -100, 100, skip_name_check=True)
-    test_apply(topi.trunc, "trunc", np.trunc, -100, 100)
-    test_apply(topi.abs, "fabs", np.abs, -100, 100)
-    test_apply(topi.round, "round", np.round, -100, 100, check_round=True)
-    test_apply(topi.exp, "exp", np.exp, -1, 1)
-    test_apply(topi.tanh, "tanh", np.tanh, -10, 10, shape=(128, 128))
-    test_apply(topi.tanh, "tanh", np.tanh, -10, 10, shape=(128, 128), dtype="float64")
-    test_apply(topi.sigmoid, "sigmoid", lambda x: 1 / (1 + np.exp(-x)), -1, 1)
-    test_apply(topi.log, "log", np.log, 0, 100)
-    test_apply(topi.sqrt, "sqrt", np.sqrt, 0, 100)
-    test_apply(
-        topi.rsqrt, "rsqrt", lambda x: np.ones_like(x) / np.sqrt(x), 0, 100, skip_name_check=True
-    )
-    test_apply(topi.cos, "cos", np.cos, -2.0 * np.pi, 2.0 * np.pi)
-    test_apply(topi.tan, "tan", np.tan, -2.0 * np.pi, 2.0 * np.pi, dtype="float32")
-    test_apply(topi.tan, "tan", np.tan, -2.0 * np.pi, 2.0 * np.pi, dtype="float64")
-    test_apply(topi.sin, "sin", np.sin, -2.0 * np.pi, 2.0 * np.pi)
-    test_apply(topi.erf, "erf", scipy.special.erf, -0.1, 0.1, dtype="float32")
-    test_isnan(-100, 100)
-    test_infiniteness_ops(topi.isfinite, np.isfinite, "isifinite")
-    test_infiniteness_ops(topi.isinf, np.isinf, "isinf")
+topi_name, dtype = tvm.testing.parameters(
+    *[
+        (name, dtype)
+        for name, config in ewise_operations.items()
+        for dtype in config.get("dtypes", ["float32"])
+    ]
+)
 
 
-@tvm.testing.uses_gpu
-def test_cast():
-    def verify(from_dtype, to_dtype, low=-100, high=100):
-        shape = (5, 4)
-        A = te.placeholder(shape, dtype=from_dtype, name="A")
-        B = topi.cast(A, to_dtype)
+@tvm.testing.fixture(cache_return_value=True)
+def ewise_ref_data(topi_name, dtype):
+    config = ewise_operations[topi_name]
 
-        if from_dtype == "bool":
-            a_np = np.random.choice([True, False], size=shape)
-        else:
-            a_np = np.random.uniform(low, high, size=shape).astype(from_dtype)
-        if to_dtype == "bool":
-            a_np = a_np - a_np[2, 3]
-        b_np = a_np.astype(to_dtype)
+    input_range = config["input_range"]
+    shape = config.get("shape", (20, 3))
 
-        for target, dev in tvm.testing.enabled_targets():
-            print("Running on target: %s" % target)
-            with tvm.target.Target(target):
-                s = tvm.topi.testing.get_injective_schedule(target)(B)
-            foo = tvm.build(s, [A, B], target)
-            a = tvm.nd.array(a_np, dev)
-            b = tvm.nd.empty(shape=shape, dtype=to_dtype, device=dev)
-            foo(a, b)
-            tvm.testing.assert_allclose(b.numpy(), b_np)
+    a_np = np.random.uniform(*input_range, size=shape).astype(dtype)
 
-    verify("int32", "float32")
-    verify("int32", "float64")
-    verify("int32", "bool")
-    verify("float32", "int32")
-    verify("float32", "float64")
-    verify("float32", "bool")
-    verify("bool", "float32")
-    verify("bool", "int32")
+    if dtype.startswith("float"):
+        if config.get("replace_with_nan", False):
+            a_np.ravel()[np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)] = np.nan
+        if config.get("replace_with_inf", False):
+            a_np.ravel()[
+                np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)
+            ] = np.infty
+
+    # avoid round check too close to boundary
+    if topi_name == "round":
+        a_np += ((np.abs(np.fmod(a_np, 1)) - 0.5) < 1e-6) * 1e-4
+
+    b_np = config["ref"](a_np)
+
+    return a_np, b_np
 
 
-def test_fastmath():
-    def test_apply(func, name, f_numpy, low, high, step, dtype="float32"):
-        a_np = np.arange(low, high, step).astype(dtype).reshape((1, -1))
-        b_np = f_numpy(a_np)
-        A = te.placeholder(a_np.shape, dtype=dtype, name="A")
-        B = func(A)
-        assert tuple(B.shape) == tuple(A.shape)
+def test_ewise(target, dev, topi_name, dtype, ewise_ref_data):
+    target = tvm.target.Target(target)
+    if target.kind.name == "vulkan" and topi_name in ["tan", "erf", "isnan", "isfinite", "isinf"]:
+        pytest.xfail(f"Vulkan runtime doesn't support {topi_name} yet")
 
-        def check_target(target):
-            dev = tvm.device(target, 0)
-            if not tvm.testing.device_enabled(target):
-                print("Skip because %s is not enabled" % target)
-                return
-            with tvm.target.Target(target):
-                s = topi.generic.schedule_injective(B)
-            func = tvm.build(s, [A, B], target, name=name)
-            a = tvm.nd.array(a_np, dev)
-            b = tvm.nd.array(np.zeros_like(b_np), dev)
-            func(a, b)
-            tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5, atol=1e-5)
+    topi_op = ewise_operations[topi_name]["topi"]
+    skip_name_check = ewise_operations[topi_name].get("skip_name_check", False)
 
-        check_target("llvm")
-        check_target("llvm -device=arm-cpu")
+    m = te.var("m")
+    l = te.var("l")
+    A = te.placeholder((m, l), dtype=dtype, name="A")
 
-    test_apply(topi.fast_exp, "fast_exp", np.exp, low=-88, high=88, step=0.01)
-    test_apply(topi.fast_erf, "fast_erf", scipy.special.erf, low=-10, high=10, step=0.01)
-    test_apply(topi.fast_tanh, "fast_tanh", np.tanh, low=-10, high=10, step=0.01)
-    test_apply(
-        topi.nn.fast_softmax,
-        "fast_softmax",
-        tvm.topi.testing.softmax_python,
-        low=-10,
-        high=10,
-        step=0.01,
-    )
+    B = topi_op(A)
+    assert tuple(B.shape) == tuple(A.shape)
+    if not skip_name_check:
+        assert B.op.body[0].op.name == "tir." + topi_name
+
+    a_np, b_np = ewise_ref_data
+
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(B)
+    foo = tvm.build(s, [A, B], target, name=topi_name)
+    a = tvm.nd.array(a_np, dev)
+    b = tvm.nd.array(np.zeros_like(b_np), dev)
+    foo(a, b)
+    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5, atol=1e-5)
+
+
+from_dtype, to_dtype = tvm.testing.parameters(
+    ("int32", "float32"),
+    ("int32", "float64"),
+    ("int32", "bool"),
+    ("float32", "int32"),
+    ("float32", "float64"),
+    ("float32", "bool"),
+    ("bool", "float32"),
+    ("bool", "int32"),
+)
+
+
+@tvm.testing.fixture(cache_return_value=True)
+def cast_ref_data(from_dtype, to_dtype):
+    shape = (5, 4)
+    input_range = (-100, 100)
+
+    if from_dtype == "bool":
+        a_np = np.random.choice([True, False], size=shape)
+    else:
+        a_np = np.random.uniform(*input_range, size=shape).astype(from_dtype)
+
+    if to_dtype == "bool":
+        a_np = a_np - a_np[2, 3]
+    b_np = a_np.astype(to_dtype)
+
+    return a_np, b_np
+
+
+def test_cast(target, dev, cast_ref_data, from_dtype, to_dtype):
+    m = te.var("m")
+    l = te.var("l")
+    A = te.placeholder((m, l), dtype=from_dtype, name="A")
+    B = topi.cast(A, to_dtype)
+
+    a_np, b_np = cast_ref_data
+
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(B)
+    foo = tvm.build(s, [A, B], target)
+    a = tvm.nd.array(a_np, dev)
+    b = tvm.nd.empty(b_np.shape, dtype=to_dtype, device=dev)
+    foo(a, b)
+    tvm.testing.assert_allclose(b.numpy(), b_np)
 
 
 if __name__ == "__main__":
-    test_util()
-    test_ewise()
-    test_cast()
-    test_fastmath()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_reduce.py
+++ b/tests/python/topi/python/test_topi_reduce.py
@@ -16,23 +16,76 @@
 # under the License.
 """Test code for reduce."""
 import os
+import sys
+
 import numpy as np
+import pytest
+
 import tvm
-from tvm import te
-from tvm import topi
 import tvm.testing
 import tvm.topi.testing
+
+from tvm import te, topi
+
+in_shape, axis, keepdims, reduce_type, dtype = tvm.testing.parameters(
+    ((32,), 0, False, "argmax", "float32"),
+    ((128, 24, 128, 24), (1, 2, 3), True, "sum", "float32"),
+    ((2, 3), None, True, "all", "bool"),
+    ((128, 24 * 128 * 24), (1,), False, "max", "float32"),
+    ((32, 128, 24), None, True, "sum", "float32"),
+    ((32, 128, 24), None, True, "all", "bool"),
+    ((128, 24, 128, 24), (0, 2), False, "min", "float32"),
+    ((32, 128), 1, True, "argmax", "float32"),
+    ((32, 24, 32, 24), 2, False, "argmin", "float32"),
+    ((31, 21, 15), None, True, "argmax", "float32"),
+    ((31, 21, 15), None, False, "sum", "float32"),
+    ((128, 24, 128, 24), (1, 2, 3), True, "sum", "float64"),
+    ((2, 3), None, True, "any", "bool"),
+    ((32, 128, 24), None, True, "any", "bool"),
+    ((1, 4, 7), 1, True, "any", "bool"),
+    ((128, 24, 128, 24), 2, False, "any", "bool"),
+)
+
+
+@tvm.testing.fixture(cache_return_value=True)
+def ref_data(in_shape, axis, keepdims, reduce_type, dtype):
+    # Test
+    if dtype == "bool":
+        in_npy_map = in_npy = np.random.choice([True, False], size=in_shape)
+    else:
+        in_npy = np.random.uniform(-1, 1, size=in_shape).astype(dtype)
+        in_npy_map = np.sqrt(np.exp(in_npy)).astype(dtype)
+
+    if reduce_type == "sum":
+        out_npy = in_npy_map.sum(axis=axis, keepdims=keepdims)
+    elif reduce_type == "all" and dtype == "bool":
+        out_npy = in_npy_map.all(axis=axis, keepdims=keepdims)
+    elif reduce_type == "any" and dtype == "bool":
+        out_npy = in_npy_map.any(axis=axis, keepdims=keepdims)
+    elif reduce_type == "max":
+        out_npy = in_npy_map.max(axis=axis, keepdims=keepdims)
+    elif reduce_type == "min":
+        out_npy = in_npy_map.min(axis=axis, keepdims=keepdims)
+    elif reduce_type == "argmax":
+        out_npy = _my_npy_argmax(in_npy_map, axis=axis, keepdims=keepdims)
+    elif reduce_type == "argmin":
+        out_npy = _my_npy_argmin(in_npy_map, axis=axis, keepdims=keepdims)
+    else:
+        raise NotImplementedError
+
+    return in_npy, in_npy_map, out_npy
 
 
 def _my_npy_argmax(arr, axis, keepdims):
     if not keepdims:
         return arr.argmax(axis=axis)
     else:
-        if axis is not None:
+        if axis is None:
+            out_shape = [1 for _ in arr.shape]
+        else:
             out_shape = list(arr.shape)
             out_shape[axis] = 1
-        else:
-            out_shape = [1 for _ in range(len(arr.shape))]
+
         return arr.argmax(axis=axis).reshape(out_shape)
 
 
@@ -40,120 +93,72 @@ def _my_npy_argmin(arr, axis, keepdims):
     if not keepdims:
         return arr.argmin(axis=axis)
     else:
-        out_shape = list(arr.shape)
-        out_shape[axis] = 1
+        if axis is None:
+            out_shape = [1 for _ in arr.shape]
+        else:
+            out_shape = list(arr.shape)
+            out_shape[axis] = 1
         return arr.argmin(axis=axis).reshape(out_shape)
 
 
-def verify_reduce_map_ele(in_shape, axis, keepdims, type="sum", dtype="float32"):
+def test_reduce_map(target, dev, ref_data, in_shape, axis, keepdims, reduce_type, dtype):
+    target = tvm.target.Target(target)
+    if target.kind.name == "vulkan" and reduce_type in ["sum", "any", "all"]:
+        pytest.xfail(f"Vulkan backend has known errors on {reduce_type}")
+
+    in_npy, in_npy_map, out_npy = ref_data
+
     # Build the logic and compile the function
     A = te.placeholder(shape=in_shape, name="A", dtype=dtype)
     A1 = topi.sqrt(topi.exp(A))
     out_dtype = dtype
-    if type == "sum":
+    if reduce_type == "sum":
         B = topi.sum(A1, axis=axis, keepdims=keepdims)
-    elif type == "all":
+    elif reduce_type == "all":
         B = topi.all(A, axis=axis, keepdims=keepdims)
-    elif type == "any":
+    elif reduce_type == "any":
         B = topi.any(A, axis=axis, keepdims=keepdims)
-    elif type == "max":
+    elif reduce_type == "max":
         B = topi.max(A1, axis=axis, keepdims=keepdims)
-    elif type == "min":
+    elif reduce_type == "min":
         B = topi.min(A1, axis=axis, keepdims=keepdims)
-    elif type == "argmax":
+    elif reduce_type == "argmax":
         B = topi.argmax(A1, axis=axis, keepdims=keepdims)
         out_dtype = "int32"
-    elif type == "argmin":
+    elif reduce_type == "argmin":
         B = topi.argmin(A1, axis=axis, keepdims=keepdims)
         out_dtype = "int32"
     else:
         raise NotImplementedError
 
-    def check_device(device, dev):
-        print("Running on target: %s" % device)
-        with tvm.target.Target(device):
-            s = tvm.topi.testing.get_reduce_schedule(device)(B)
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_reduce_schedule(target)(B)
 
-        foo = tvm.build(s, [A, B], device, name=type)
-        # Test
-        if dtype == "bool":
-            in_npy_map = in_npy = np.random.choice([True, False], size=in_shape)
+    foo = tvm.build(s, [A, B], target, name=reduce_type)
+
+    data_tvm = tvm.nd.array(in_npy, device=dev)
+    out_tvm = tvm.nd.empty(shape=out_npy.shape, device=dev, dtype=out_dtype)
+    foo(data_tvm, out_tvm)
+
+    if reduce_type == "argmax" or reduce_type == "argmin":
+        out_tvm_indices = out_tvm.numpy()
+        if keepdims:
+            out_tvm_indices = np.take(out_tvm_indices, indices=0, axis=axis)
+        if axis is None:
+            out_tvm_val = in_npy_map.ravel()[out_tvm_indices]
         else:
-            in_npy = np.random.uniform(-1, 1, size=in_shape).astype(dtype)
-            in_npy_map = np.sqrt(np.exp(in_npy)).astype(dtype)
-
-        if type == "sum":
-            out_npy = in_npy_map.sum(axis=axis, keepdims=keepdims)
-        elif type == "all" and dtype == "bool":
-            out_npy = in_npy_map.all(axis=axis, keepdims=keepdims)
-        elif type == "any" and dtype == "bool":
-            out_npy = in_npy_map.any(axis=axis, keepdims=keepdims)
-        elif type == "max":
-            out_npy = in_npy_map.max(axis=axis, keepdims=keepdims)
-        elif type == "min":
-            out_npy = in_npy_map.min(axis=axis, keepdims=keepdims)
-        elif type == "argmax":
-            out_npy = _my_npy_argmax(in_npy_map, axis=axis, keepdims=keepdims)
-        elif type == "argmin":
-            out_npy = _my_npy_argmin(in_npy_map, axis=axis, keepdims=keepdims)
-        else:
-            raise NotImplementedError
-        data_tvm = tvm.nd.array(in_npy, device=dev)
-        out_tvm = tvm.nd.empty(shape=out_npy.shape, device=dev, dtype=out_dtype)
-        for _ in range(1):
-            foo(data_tvm, out_tvm)
-        if type == "argmax" or type == "argmin":
-            out_tvm_indices = out_tvm.numpy()
-            if keepdims:
-                out_tvm_indices = np.take(out_tvm_indices, indices=0, axis=axis)
-            if axis is None:
-                out_tvm_val = in_npy_map.ravel()[out_tvm_indices]
-            else:
-                other_indices = tuple(np.indices(in_shape[0:axis] + in_shape[(axis + 1) :]))
-                sel_indices = other_indices[0:axis] + (out_tvm_indices,) + other_indices[axis:]
-                out_tvm_val = in_npy_map[sel_indices]
-            if type == "argmax":
-                tvm.testing.assert_allclose(out_tvm_val, in_npy_map.max(axis=axis), 1e-3, 1e-3)
-            elif type == "argmin":
-                tvm.testing.assert_allclose(out_tvm_val, in_npy_map.min(axis=axis), 1e-3, 1e-3)
-        else:
-            tvm.testing.assert_allclose(out_tvm.numpy(), out_npy, 1e-3, 1e-3)
-
-    for device, dev in tvm.testing.enabled_targets():
-        check_device(device, dev)
+            other_indices = tuple(np.indices(in_shape[0:axis] + in_shape[(axis + 1) :]))
+            sel_indices = other_indices[0:axis] + (out_tvm_indices,) + other_indices[axis:]
+            out_tvm_val = in_npy_map[sel_indices]
+        if reduce_type == "argmax":
+            tvm.testing.assert_allclose(out_tvm_val, in_npy_map.max(axis=axis), 1e-3, 1e-3)
+        elif reduce_type == "argmin":
+            tvm.testing.assert_allclose(out_tvm_val, in_npy_map.min(axis=axis), 1e-3, 1e-3)
+    else:
+        tvm.testing.assert_allclose(out_tvm.numpy(), out_npy, 1e-3, 1e-3)
 
 
-@tvm.testing.uses_gpu
-def test_reduce_map():
-
-    verify_reduce_map_ele(in_shape=(32,), axis=0, keepdims=False, type="argmax")
-    verify_reduce_map_ele(in_shape=(128, 24, 128, 24), axis=(1, 2, 3), keepdims=True, type="sum")
-    verify_reduce_map_ele(in_shape=(2, 3), axis=None, keepdims=True, type="all", dtype="bool")
-    verify_reduce_map_ele(in_shape=(128, 24 * 128 * 24), axis=(1,), keepdims=False, type="max")
-    verify_reduce_map_ele(in_shape=(32, 128, 24), axis=None, keepdims=True, type="sum")
-    verify_reduce_map_ele(
-        in_shape=(32, 128, 24), axis=None, keepdims=True, dtype="bool", type="all"
-    )
-    verify_reduce_map_ele(in_shape=(128, 24, 128, 24), axis=(0, 2), keepdims=False, type="min")
-    verify_reduce_map_ele(in_shape=(32, 128), axis=1, keepdims=True, type="argmax")
-    verify_reduce_map_ele(in_shape=(32, 24, 32, 24), axis=2, keepdims=False, type="argmin")
-    verify_reduce_map_ele(in_shape=(31, 21, 15), axis=None, keepdims=True, type="argmax")
-    verify_reduce_map_ele(in_shape=(31, 21, 15), axis=None, keepdims=False, type="sum")
-    verify_reduce_map_ele(
-        in_shape=(128, 24, 128, 24), axis=(1, 2, 3), keepdims=True, type="sum", dtype="float64"
-    )
-    verify_reduce_map_ele(in_shape=(2, 3), axis=None, keepdims=True, type="any", dtype="bool")
-    verify_reduce_map_ele(
-        in_shape=(32, 128, 24), axis=None, keepdims=True, type="any", dtype="bool"
-    )
-    verify_reduce_map_ele(in_shape=(1, 4, 7), axis=1, keepdims=True, type="any", dtype="bool")
-    verify_reduce_map_ele(
-        in_shape=(128, 24, 128, 24), axis=2, keepdims=False, type="any", dtype="bool"
-    )
-
-
-@tvm.testing.uses_gpu
-def test_complex_reduce():
+def test_complex_reduce(target, dev):
     in_shape = (2, 3)
     dtype = "float32"
     axis = 0
@@ -163,20 +168,20 @@ def test_complex_reduce():
     C = topi.add(B, B)
     D = topi.multiply(B, B)
     E = topi.add(C, D)
-    for device, dev in tvm.testing.enabled_targets():
-        print("Running on target: %s" % device)
-        with tvm.target.Target(device):
-            s = tvm.topi.testing.get_reduce_schedule(device)(E)
-        foo = tvm.build(s, [A, E], device, name="sum")
-        in_npy = np.random.uniform(-1, 1, size=in_shape).astype(dtype)
-        sum_npy = in_npy.sum(axis=axis, keepdims=keepdims)
-        out_npy = sum_npy * 2 + sum_npy * sum_npy
-        data_tvm = tvm.nd.array(in_npy, device=dev)
-        out_tvm = tvm.nd.empty(shape=out_npy.shape, device=dev, dtype=dtype)
-        foo(data_tvm, out_tvm)
-        tvm.testing.assert_allclose(out_tvm.numpy(), out_npy, 1e-3, 1e-3)
+
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_reduce_schedule(target)(E)
+    foo = tvm.build(s, [A, E], target, name="sum")
+
+    in_npy = np.random.uniform(-1, 1, size=in_shape).astype(dtype)
+    sum_npy = in_npy.sum(axis=axis, keepdims=keepdims)
+    out_npy = sum_npy * 2 + sum_npy * sum_npy
+
+    data_tvm = tvm.nd.array(in_npy, device=dev)
+    out_tvm = tvm.nd.empty(shape=out_npy.shape, device=dev, dtype=dtype)
+    foo(data_tvm, out_tvm)
+    tvm.testing.assert_allclose(out_tvm.numpy(), out_npy, 1e-3, 1e-3)
 
 
 if __name__ == "__main__":
-    test_reduce_map()
-    test_complex_reduce()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_softmax.py
+++ b/tests/python/topi/python/test_topi_softmax.py
@@ -15,14 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test code for softmax"""
+import logging
 import os
+import sys
+
 import numpy as np
+import pytest
+
 import tvm
-from tvm import te
-from tvm import topi
 import tvm.testing
 import tvm.topi.testing
-import logging
+from tvm import te, topi
 from tvm.topi.utils import get_const_tuple
 
 
@@ -34,75 +37,72 @@ _softmax_schedule = {
 }
 
 
-def check_target(A, B, a_np, b_np, target, dev, name):
-    print("Running on target: %s" % target)
+dtype = tvm.testing.parameter("float32", "float64")
+
+
+configs = {
+    "softmax": {
+        "topi": topi.nn.softmax,
+        "ref": tvm.topi.testing.softmax_python,
+        "dimensions": [2, 4],
+    },
+    "log_softmax": {
+        "topi": topi.nn.log_softmax,
+        "ref": tvm.topi.testing.log_softmax_python,
+        "dimensions": [2],
+    },
+}
+shapes = [(32, 10), (3, 4), (1, 16, 256, 256)]
+softmax_operation, shape = tvm.testing.parameters(
+    *[
+        (name, shape)
+        for name, config in configs.items()
+        for shape in shapes
+        if len(shape) in config["dimensions"]
+    ]
+)
+
+
+@tvm.testing.fixture(cache_return_value=True)
+def ref_data(shape, dtype, softmax_operation):
+    ref_func = configs[softmax_operation]["ref"]
+
+    a_np = np.random.uniform(size=shape).astype(dtype)
+
+    if len(shape) == 2:
+        b_np = ref_func(a_np)
+    elif len(shape) == 4:
+        _, c, h, w = a_np.shape
+        a_np_2d = a_np.transpose(0, 2, 3, 1).reshape(h * w, c)
+        b_np_2d = tvm.topi.testing.softmax_python(a_np_2d)
+        b_np = b_np_2d.reshape(1, h, w, c).transpose(0, 3, 1, 2)
+
+    return a_np, b_np
+
+
+def test_softmax(target, dev, shape, dtype, ref_data, softmax_operation):
+    target = tvm.target.Target(target)
+    if target.kind.name == "vulkan" and dtype == "float64":
+        # https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html
+        pytest.xfail("Vulkan GLSL.std.450 does not support 64-bit floats")
+
+    A = te.placeholder(shape, dtype=dtype, name="A")
+
+    topi_op = configs[softmax_operation]["topi"]
+    B = topi_op(A, axis=1)
+
     with tvm.target.Target(target):
-        s_func = tvm.topi.testing.dispatch(target, _softmax_schedule)
-        s = s_func(B)
+        fschedule = tvm.topi.testing.dispatch(target, _softmax_schedule)
+        s = fschedule(B)
+
+    a_np, b_np = ref_data
 
     a = tvm.nd.array(a_np, dev)
     b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), dev)
-    f = tvm.build(s, [A, B], target, name=name)
+    f = tvm.build(s, [A, B], target)
     f(a, b)
     tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5)
 
 
-def verify_softmax(m, n, dtype="float32"):
-    A = te.placeholder((m, n), dtype=dtype, name="A")
-    B = topi.nn.softmax(A)
-    # confirm lower works
-    s = te.create_schedule([B.op])
-    tvm.lower(s, [A, B], simple_mode=True)
-
-    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
-    b_np = tvm.topi.testing.softmax_python(a_np)
-
-    for target, dev in tvm.testing.enabled_targets():
-        check_target(A, B, a_np, b_np, target, dev, "softmax")
-
-
-def verify_softmax_4d(shape, dtype="float32"):
-    A = te.placeholder(shape, dtype=dtype, name="A")
-    B = topi.nn.softmax(A, axis=1)
-
-    _, c, h, w = shape
-    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
-    b_np = tvm.topi.testing.softmax_python(a_np.transpose(0, 2, 3, 1).reshape(h * w, c))
-    b_np = b_np.reshape(1, h, w, c).transpose(0, 3, 1, 2)
-
-    for target, dev in tvm.testing.enabled_targets():
-        check_target(A, B, a_np, b_np, target, dev, "softmax")
-
-
-@tvm.testing.uses_gpu
-def test_softmax():
-    verify_softmax(32, 10)
-    verify_softmax(3, 4)
-    verify_softmax(32, 10, "float64")
-    verify_softmax_4d((1, 16, 256, 256))
-
-
-def verify_log_softmax(m, n, dtype="float32"):
-    A = te.placeholder((m, n), dtype=dtype, name="A")
-    B = topi.nn.log_softmax(A)
-    # confirm lower works
-    s = te.create_schedule([B.op])
-    tvm.lower(s, [A, B], simple_mode=True)
-    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
-    b_np = tvm.topi.testing.log_softmax_python(a_np)
-
-    for target, dev in tvm.testing.enabled_targets():
-        check_target(A, B, a_np, b_np, target, dev, "log_softmax")
-
-
-@tvm.testing.uses_gpu
-def test_log_softmax():
-    verify_log_softmax(32, 10)
-    verify_log_softmax(3, 4)
-    verify_log_softmax(32, 10, "float64")
-
-
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    test_softmax()
-    test_log_softmax()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_sort.py
+++ b/tests/python/topi/python/test_topi_sort.py
@@ -15,13 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test code for vision package"""
-from __future__ import print_function
+import sys
+
 import numpy as np
+import pytest
+
 import tvm
-from tvm import te
-from tvm import topi
-import tvm.topi.testing
 import tvm.testing
+import tvm.topi.testing
+
+from tvm import te, topi
 
 _sort_implement = {
     "generic": (topi.sort, topi.generic.schedule_sort),
@@ -38,8 +41,17 @@ _topk_implement = {
     "gpu": (topi.cuda.topk, topi.cuda.schedule_topk),
 }
 
+axis = tvm.testing.parameter(0, -1, 1)
+is_ascend = tvm.testing.parameter(True, False, ids=["is_ascend", "not_ascend"])
+dtype = tvm.testing.parameter("int64", "float32")
 
-def verify_sort(axis, is_ascend):
+topk = tvm.testing.parameter(0, 1, 5)
+topk_ret_type = tvm.testing.parameter("values", "indices", "both")
+
+
+def test_sort(target, dev, axis, is_ascend):
+    np.random.seed(0)
+
     dshape = (20, 100)
     data_dtype = "float32"
     data = te.placeholder(dshape, name="data", dtype=data_dtype)
@@ -58,28 +70,19 @@ def verify_sort(axis, is_ascend):
     else:
         np_sort = np_sort[:, : dshape[axis]]
 
-    def check_target(target):
-        if not tvm.testing.device_enabled(target):
-            print("Skip because %s is not enabled" % target)
-            return
-        dev = tvm.device(target, 0)
-        print("Running on target: %s" % target)
-        with tvm.target.Target(target):
-            fcompute, fschedule = tvm.topi.testing.dispatch(target, _sort_implement)
-            out = fcompute(data, axis=axis, is_ascend=is_ascend)
-            s = fschedule(out)
+    with tvm.target.Target(target):
+        fcompute, fschedule = tvm.topi.testing.dispatch(target, _sort_implement)
+        out = fcompute(data, axis=axis, is_ascend=is_ascend)
+        s = fschedule(out)
 
-        tvm_data = tvm.nd.array(np_data, dev)
-        tvm_out = tvm.nd.array(np.zeros(dshape, dtype=data_dtype), dev)
-        f = tvm.build(s, [data, out], target)
-        f(tvm_data, tvm_out)
-        tvm.testing.assert_allclose(tvm_out.numpy(), np_sort, rtol=1e0)
-
-    for target in ["llvm", "cuda", "opencl", "vulkan", "nvptx"]:
-        check_target(target)
+    tvm_data = tvm.nd.array(np_data, dev)
+    tvm_out = tvm.nd.array(np.zeros(dshape, dtype=data_dtype), dev)
+    f = tvm.build(s, [data, out], target)
+    f(tvm_data, tvm_out)
+    tvm.testing.assert_allclose(tvm_out.numpy(), np_sort, rtol=1e0)
 
 
-def verify_argsort(axis, is_ascend):
+def test_argsort(target, dev, axis, is_ascend):
     dshape = (20, 100)
     data_dtype = "float32"
     data = te.placeholder(dshape, name="data", dtype=data_dtype)
@@ -98,28 +101,21 @@ def verify_argsort(axis, is_ascend):
     else:
         np_indices = np_indices[:, : dshape[axis]]
 
-    def check_target(target):
-        if not tvm.testing.device_enabled(target):
-            print("Skip because %s is not enabled" % target)
-            return
-        dev = tvm.device(target, 0)
-        print("Running on target: %s" % target)
-        with tvm.target.Target(target):
-            fcompute, fschedule = tvm.topi.testing.dispatch(target, _argsort_implement)
-            out = fcompute(data, axis=axis, is_ascend=is_ascend)
-            s = fschedule(out)
+    with tvm.target.Target(target):
+        fcompute, fschedule = tvm.topi.testing.dispatch(target, _argsort_implement)
+        out = fcompute(data, axis=axis, is_ascend=is_ascend)
+        s = fschedule(out)
 
-        tvm_data = tvm.nd.array(np_data, dev)
-        tvm_out = tvm.nd.array(np.zeros(dshape, dtype=data_dtype), dev)
-        f = tvm.build(s, [data, out], target)
-        f(tvm_data, tvm_out)
-        tvm.testing.assert_allclose(tvm_out.numpy(), np_indices.astype(data_dtype), rtol=1e0)
-
-    for target in ["llvm", "cuda", "opencl", "vulkan", "nvptx"]:
-        check_target(target)
+    tvm_data = tvm.nd.array(np_data, dev)
+    tvm_out = tvm.nd.array(np.zeros(dshape, dtype=data_dtype), dev)
+    f = tvm.build(s, [data, out], target)
+    f(tvm_data, tvm_out)
+    tvm.testing.assert_allclose(tvm_out.numpy(), np_indices.astype(data_dtype), rtol=1e0)
 
 
-def verify_topk(k, axis, ret_type, is_ascend, dtype):
+def test_topk(target, dev, topk, axis, topk_ret_type, is_ascend, dtype):
+    np.random.seed(0)
+
     shape = (20, 100)
     data_dtype = "float32"
     data = te.placeholder(shape, name="data", dtype=data_dtype)
@@ -129,7 +125,7 @@ def verify_topk(k, axis, ret_type, is_ascend, dtype):
         np_indices = np.argsort(np_data, axis=axis)
     else:
         np_indices = np.argsort(-np_data, axis=axis)
-    kk = k if k >= 1 else shape[axis]
+    kk = topk if topk >= 1 else shape[axis]
     if axis == 0:
         np_indices = np_indices[:kk, :]
         np_values = np.zeros(np_indices.shape).astype(data_dtype)
@@ -142,61 +138,25 @@ def verify_topk(k, axis, ret_type, is_ascend, dtype):
             np_values[i, :] = np_data[i, np_indices[i, :]]
     np_indices = np_indices.astype(dtype)
 
-    def check_target(target):
-        dev = tvm.device(target, 0)
-        if not tvm.testing.device_enabled(target):
-            print("Skip because %s is not enabled" % target)
-            return
-        print("Running on target: %s" % target)
-        with tvm.target.Target(target):
-            fcompute, fschedule = tvm.topi.testing.dispatch(target, _topk_implement)
-            outs = fcompute(data, k, axis, ret_type, is_ascend, dtype)
-            outs = outs if isinstance(outs, list) else [outs]
-            s = fschedule(outs)
-        tvm_data = tvm.nd.array(np_data, dev)
-        tvm_res = []
-        for t in outs:
-            tvm_res.append(tvm.nd.empty(t.shape, dtype=t.dtype, device=dev))
-        f = tvm.build(s, [data] + outs, target)
-        f(tvm_data, *tvm_res)
-        if ret_type == "both":
-            tvm.testing.assert_allclose(tvm_res[0].numpy(), np_values)
-            tvm.testing.assert_allclose(tvm_res[1].numpy(), np_indices)
-        elif ret_type == "values":
-            tvm.testing.assert_allclose(tvm_res[0].numpy(), np_values)
-        else:
-            tvm.testing.assert_allclose(tvm_res[0].numpy(), np_indices)
-
-    for target in ["llvm", "cuda", "opencl", "vulkan", "nvptx"]:
-        check_target(target)
-
-
-@tvm.testing.uses_gpu
-def test_sort():
-    np.random.seed(0)
-    for axis in [0, -1, 1]:
-        verify_sort(axis, True)
-        verify_sort(axis, False)
-
-
-@tvm.testing.uses_gpu
-def test_argsort():
-    np.random.seed(0)
-    for axis in [0, -1, 1]:
-        verify_argsort(axis, True)
-        verify_argsort(axis, False)
-
-
-@tvm.testing.uses_gpu
-def test_topk():
-    np.random.seed(0)
-    for k in [0, 1, 5]:
-        for axis in [0, -1, 1]:
-            for ret_type in ["both", "values", "indices"]:
-                verify_topk(k, axis, ret_type, True, "int64")
-                verify_topk(k, axis, ret_type, False, "float32")
+    with tvm.target.Target(target):
+        fcompute, fschedule = tvm.topi.testing.dispatch(target, _topk_implement)
+        outs = fcompute(data, topk, axis, topk_ret_type, is_ascend, dtype)
+        outs = outs if isinstance(outs, list) else [outs]
+        s = fschedule(outs)
+    tvm_data = tvm.nd.array(np_data, dev)
+    tvm_res = []
+    for t in outs:
+        tvm_res.append(tvm.nd.empty(t.shape, dtype=t.dtype, device=dev))
+    f = tvm.build(s, [data] + outs, target)
+    f(tvm_data, *tvm_res)
+    if topk_ret_type == "both":
+        tvm.testing.assert_allclose(tvm_res[0].numpy(), np_values)
+        tvm.testing.assert_allclose(tvm_res[1].numpy(), np_indices)
+    elif topk_ret_type == "values":
+        tvm.testing.assert_allclose(tvm_res[0].numpy(), np_values)
+    else:
+        tvm.testing.assert_allclose(tvm_res[0].numpy(), np_indices)
 
 
 if __name__ == "__main__":
-    test_argsort()
-    test_topk()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_unique.py
+++ b/tests/python/topi/python/test_topi_unique.py
@@ -20,9 +20,14 @@ import tvm.testing
 from tvm import topi
 import tvm.topi.testing
 
+in_dtype = tvm.testing.parameter("int32", "int64")
+is_sorted = tvm.testing.parameter(True, False, ids=["sorted", "unsorted"])
+with_counts = tvm.testing.parameter(True, False, ids=["with_counts", "no_counts"])
+arr_size, maxval = tvm.testing.parameters((1, 100), (10, 10), (10000, 100))
+
 
 @tvm.testing.parametrize_targets
-def test_unique(dev, target):
+def test_unique(dev, target, in_dtype, is_sorted, with_counts, arr_size, maxval):
     def calc_numpy_unique(data, is_sorted=False):
         uniq, index, inverse, counts = np.unique(
             data, return_index=True, return_inverse=True, return_counts=True
@@ -43,82 +48,67 @@ def test_unique(dev, target):
             num_uniq,
         ]
 
-    def check_unique(data, is_sorted=False, with_counts=False):
-        # numpy reference
-        np_unique, np_indices, np_inverse_indices, np_counts, np_num_unique = calc_numpy_unique(
-            data, is_sorted
-        )
-        num_unique = np_num_unique[0]
+    data = np.random.randint(0, maxval, size=(arr_size)).astype(in_dtype)
 
-        implementations = {
-            "generic": (
-                lambda x, return_counts: topi.unique(x, is_sorted, return_counts),
-                topi.generic.schedule_unique,
-            ),
-            "cuda": (
-                lambda x, return_counts: topi.cuda.unique(x, is_sorted, return_counts),
-                topi.cuda.schedule_scan,
-            ),
-            "nvptx": (
-                lambda x, return_counts: topi.cuda.unique(x, is_sorted, return_counts),
-                topi.cuda.schedule_scan,
-            ),
-        }
-        fcompute, fschedule = tvm.topi.testing.dispatch(target, implementations)
-        tvm_data = tvm.nd.array(data, device=dev)
-        tvm_unique = tvm.nd.array(np.zeros(data.shape).astype(data.dtype), device=dev)
-        tvm_indices = tvm.nd.array(np.zeros(data.shape).astype("int32"), device=dev)
-        tvm_inverse_indices = tvm.nd.array(np.zeros(data.shape).astype("int32"), device=dev)
-        tvm_num_unique = tvm.nd.array(np.zeros([1]).astype("int32"), device=dev)
+    # numpy reference
+    np_unique, np_indices, np_inverse_indices, np_counts, np_num_unique = calc_numpy_unique(
+        data, is_sorted
+    )
+    num_unique = np_num_unique[0]
 
-        with tvm.target.Target(target):
-            te_input = tvm.te.placeholder(shape=data.shape, dtype=str(data.dtype))
-            outs = fcompute(te_input, with_counts)
-            s = fschedule(outs)
-            func = tvm.build(s, [te_input, *outs])
+    implementations = {
+        "generic": (
+            lambda x, return_counts: topi.unique(x, is_sorted, return_counts),
+            topi.generic.schedule_unique,
+        ),
+        "gpu": (
+            lambda x, return_counts: topi.cuda.unique(x, is_sorted, return_counts),
+            topi.cuda.schedule_scan,
+        ),
+        "nvptx": (
+            lambda x, return_counts: topi.cuda.unique(x, is_sorted, return_counts),
+            topi.cuda.schedule_scan,
+        ),
+    }
+    fcompute, fschedule = tvm.topi.testing.dispatch(target, implementations)
+    tvm_data = tvm.nd.array(data, device=dev)
+    tvm_unique = tvm.nd.array(np.zeros(data.shape).astype(data.dtype), device=dev)
+    tvm_indices = tvm.nd.array(np.zeros(data.shape).astype("int32"), device=dev)
+    tvm_inverse_indices = tvm.nd.array(np.zeros(data.shape).astype("int32"), device=dev)
+    tvm_num_unique = tvm.nd.array(np.zeros([1]).astype("int32"), device=dev)
 
-            if with_counts:
-                tvm_counts = tvm.nd.array(np.zeros(data.shape).astype("int32"), device=dev)
-                func(
-                    tvm_data,
-                    tvm_unique,
-                    tvm_indices,
-                    tvm_inverse_indices,
-                    tvm_num_unique,
-                    tvm_counts,
-                )
-            else:
-                func(tvm_data, tvm_unique, tvm_indices, tvm_inverse_indices, tvm_num_unique)
-
-        num_unique = np_num_unique[0]
-        assert tvm_num_unique.numpy()[0] == np_num_unique
-
-        np.testing.assert_allclose(tvm_unique.numpy()[:num_unique], np_unique, atol=1e-5, rtol=1e-5)
-        np.testing.assert_allclose(
-            tvm_indices.numpy()[:num_unique], np_indices, atol=1e-5, rtol=1e-5
-        )
-
-        np.testing.assert_allclose(
-            tvm_inverse_indices.numpy(), np_inverse_indices, atol=1e-5, rtol=1e-5
-        )
+    with tvm.target.Target(target):
+        te_input = tvm.te.placeholder(shape=data.shape, dtype=str(data.dtype))
+        outs = fcompute(te_input, with_counts)
+        s = fschedule(outs)
+        func = tvm.build(s, [te_input, *outs])
 
         if with_counts:
-            np.testing.assert_allclose(
-                tvm_counts.numpy()[:num_unique], np_counts, atol=1e-5, rtol=1e-5
+            tvm_counts = tvm.nd.array(np.zeros(data.shape).astype("int32"), device=dev)
+            func(
+                tvm_data,
+                tvm_unique,
+                tvm_indices,
+                tvm_inverse_indices,
+                tvm_num_unique,
+                tvm_counts,
             )
+        else:
+            func(tvm_data, tvm_unique, tvm_indices, tvm_inverse_indices, tvm_num_unique)
 
-    for in_dtype in ["int32", "int64"]:
-        for is_sorted in [True, False]:
-            for with_counts in [True, False]:
-                data = np.random.randint(0, 100, size=(1)).astype(in_dtype)
-                check_unique(data, is_sorted, with_counts)
-                data = np.random.randint(0, 10, size=(10)).astype(in_dtype)
-                check_unique(data, is_sorted, with_counts)
-                data = np.random.randint(0, 100, size=(10000)).astype(in_dtype)
-                check_unique(data, is_sorted, with_counts)
+    num_unique = np_num_unique[0]
+    assert tvm_num_unique.numpy()[0] == np_num_unique
+
+    np.testing.assert_allclose(tvm_unique.numpy()[:num_unique], np_unique, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(tvm_indices.numpy()[:num_unique], np_indices, atol=1e-5, rtol=1e-5)
+
+    np.testing.assert_allclose(
+        tvm_inverse_indices.numpy(), np_inverse_indices, atol=1e-5, rtol=1e-5
+    )
+
+    if with_counts:
+        np.testing.assert_allclose(tvm_counts.numpy()[:num_unique], np_counts, atol=1e-5, rtol=1e-5)
 
 
 if __name__ == "__main__":
-    test_unique(tvm.device("cpu"), tvm.target.Target("llvm"))
-    test_unique(tvm.device("cuda"), tvm.target.Target("cuda"))
-    test_unique(tvm.device("nvptx"), tvm.target.Target("nvptx"))
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/unittest/test_tvm_testing_features.py
+++ b/tests/python/unittest/test_tvm_testing_features.py
@@ -57,7 +57,10 @@ class TestTargetAutoParametrization:
         self.targets_with_explicit_list.append(target)
 
     def test_no_repeats_in_explicit_list(self):
-        assert self.targets_with_explicit_list == ["llvm"]
+        if tvm.testing.device_enabled("llvm"):
+            assert self.targets_with_explicit_list == ["llvm"]
+        else:
+            assert self.targets_with_explicit_list == []
 
     targets_with_exclusion = []
 


### PR DESCRIPTION
This PR aims to make the unit test suite run with `TVM_TEST_TARGETS="vulkan -from_device=0"`.  This PR applies a few minor fixes, parametrizes several topi unit tests that were previously failing, and marks the specific failing cases with xfail.  The failing cases will be tracked in https://github.com/apache/tvm/issues/8903.

[UnitTest][Topi] Parametrized several unit tests, identify vulkan failures

- Parametrized topi modules
  - test_topi_conv1d_transpose_ncw.py
  - test_topi_conv2d_nhwc.py
  - test_topi_correlation.py
  - test_topi_loss.py
  - test_topi_math.py
  - test_topi_reduce.py
  - test_topi_softmax.py
  - test_topi_sort.py
  - test_topi_unique.py
  - test_topi_vision.py

- Unit Tests fixed

  - `test_topi_loss::test_nll_loss`, failure due to `supports_float64` not being passed from the target to the codegen.

- Known Vulkan failures (tracked in https://github.com/apache/tvm/issues/8903)

  - test_topi_math.py::test_ewise, ["tan", "erf", "isnan", "isfinite", "isinf"]

    Unimplemented CallNode operations

  - test_topi_reduce.py::test_reduce_map, ["sum", "any", "all"]

    Fails during codegen, unexpected size of data type.

  - test_topi_vision.py::test_proposal

    Marked test_proposal as xfail on vulkan, currently has a type error between bool/int8.

  - test_topi_conv1d_transpose_ncw.py::test_conv1d_transpose_ncw

    Incorrect numeric output, a few elements outside of allowed tolerance, only occurs on vulkan backend.

  - test_softmax.py::test_softmax

    Marked float64 operations as xfail in vulkan, because GLSL.std.450 only supports 16/32-bit floats.


[UnitTests][Vulkan] Improved robustness of test_tir_intrin::test_clz

Previously, would fail during build since support for Int64 primitives wasn't declared in the `"vulkan"` target.  Now, uses `"vulkan -from_device=0"` target and marks the test as xfail if the current target doesn't support Int64.


[Pytest] Fixed TestTargetAutoParametrization in cases where LLVM is disabled.
