### PR TITLE
Trivial uTVM -> microTVM "spelling" fix to align with branding.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -108,7 +108,7 @@ set(USE_GRAPH_EXECUTOR_CUDA_GRAPH OFF)
 # Whether to enable the profiler for the graph executor and vm
 set(USE_PROFILER ON)
 
-# Whether enable uTVM standalone runtime
+# Whether enable microTVM standalone runtime
 set(USE_MICRO_STANDALONE_RUNTIME OFF)
 
 # Whether build with LLVM support


### PR DESCRIPTION
Embarrassingly trivial fix remove use of uTVM and replace with the proper microTVM naming convention.

