### PR TITLE
[ONNX] Add support for QLinearConcat contrib op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -197,7 +197,8 @@ def dimension_constraint():
 
 def get_scalar(x, params, dtype="float32"):
     """Helper to get a scalar value for Quantized operators."""
-    if isinstance(x, _expr.Var) and x.name_hint in params:
+    if isinstance(x, _expr.Var):
+        assert x.name_hint in params, "Var should be found in params lookup"
         return _op.const(params[x.name_hint].numpy(), dtype)
     rank = len(infer_shape(x))
     assert rank <= 1, "scale and zero_point input must be scalars"

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3301,10 +3301,12 @@ class QLinearConcat(OnnxOpConverter):
         y_scale = fold_constant(get_scalar(inputs[0], params))
         y_zero_point = get_scalar(inputs[1], params, "int32")
 
+        out_dtype = infer_type(inputs[1]).checked_type.dtype
+
         # input tensors, scales, zero_points
         assert (
             len(inputs) % 3 == 2
-        ), "Additional number of inputs beyond y_scale, y_zero_point for QLinearConcat must be a multiple of 3, indicating complete input tensor/scale/zero_point tubles"
+        ), "Additional number of inputs beyond y_scale, y_zero_point for QLinearConcat must be a multiple of 3, indicating complete input tensor/scale/zero_point tuples"
         tensors = []
         scales = []
         zero_points = []

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -197,8 +197,7 @@ def dimension_constraint():
 
 def get_scalar(x, params, dtype="float32"):
     """Helper to get a scalar value for Quantized operators."""
-    if isinstance(x, _expr.Var):
-        assert x.name_hint in params, "Var should be found in params lookup"
+    if isinstance(x, _expr.Var) and x.name_hint in params:
         return _op.const(params[x.name_hint].numpy(), dtype)
     rank = len(infer_shape(x))
     assert rank <= 1, "scale and zero_point input must be scalars"

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3301,12 +3301,10 @@ class QLinearConcat(OnnxOpConverter):
         y_scale = fold_constant(get_scalar(inputs[0], params))
         y_zero_point = get_scalar(inputs[1], params, "int32")
 
-        out_dtype = infer_type(inputs[1]).checked_type.dtype
-
         # input tensors, scales, zero_points
         assert (
             len(inputs) % 3 == 2
-        ), "Additional number of inputs beyond y_scale, y_zero_point for QLinearConcat must be a multiple of 3, indicating complete input tensor/scale/zero_point tuples"
+        ), "Additional input count must be a multiple of 3 -- tensor/scale/zero_point tuples"
         tensors = []
         scales = []
         zero_points = []

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5281,7 +5281,7 @@ def test_qlinearconcat(target, dev):
             input_values.append(np.random.random(shape).astype("float32"))
             input_nodes.append(node)
 
-        node = helper.make_node("Concat", input_names, ["OUT"])
+        node = helper.make_node("Concat", input_names, ["C"])
         if axis is not None:
             axis_attr = helper.make_attribute("axis", axis)
             node.attribute.append(axis_attr)
@@ -5289,14 +5289,15 @@ def test_qlinearconcat(target, dev):
             [node],
             "qlinearconcat_test",
             inputs=input_nodes,
-            outputs=[helper.make_tensor_value_info("OUT", TensorProto.FLOAT, list(out_shape))],
+            outputs=[helper.make_tensor_value_info("C", TensorProto.FLOAT, list(out_shape))],
         )
+        breakpoint()
         model = helper.make_model(graph, producer_name="qlinearconcat_test")
         quantize_and_verify_with_ort(model, input_names, shapes, target, dev)
 
     verify_qlinearconcat([[2, 1], [2, 1]], [4, 1], 0)
     verify_qlinearconcat([[2, 1], [2, 1]], [2, 2], 1)
-    verify_qlinearconcat([[1, 2, 2], [1, 2, 3]], [1, 2, 5], 2)
+    verify_qlinearconcat([[1, 2], [2, 2], [3,2]], [6, 2], 0)
 
 
 @tvm.testing.parametrize_targets

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5291,7 +5291,6 @@ def test_qlinearconcat(target, dev):
             inputs=input_nodes,
             outputs=[helper.make_tensor_value_info("C", TensorProto.FLOAT, list(out_shape))],
         )
-        breakpoint()
         model = helper.make_model(graph, producer_name="qlinearconcat_test")
         quantize_and_verify_with_ort(model, input_names, shapes, target, dev)
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5296,7 +5296,7 @@ def test_qlinearconcat(target, dev):
 
     verify_qlinearconcat([[2, 1], [2, 1]], [4, 1], 0)
     verify_qlinearconcat([[2, 1], [2, 1]], [2, 2], 1)
-    verify_qlinearconcat([[1, 2], [2, 2], [3,2]], [6, 2], 0)
+    verify_qlinearconcat([[1, 2], [2, 2], [3, 2]], [6, 2], 0)
 
 
 @tvm.testing.parametrize_targets

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5273,7 +5273,7 @@ def test_qlinearconcat(target, dev):
         input_values = []
         input_nodes = []
         for i in range(len(shapes)):
-            tensor_name = str(chr(ord("a") + i))
+            tensor_name = chr(ord("a") + i)
             shape = shapes[i]
             node = helper.make_tensor_value_info(tensor_name, TensorProto.FLOAT, list(shape))
 


### PR DESCRIPTION
- Moves `get_scalar` to common point where other Q op impls can reach it. 
- Adds QLinearConcat
- Note the Lowering function within `_qnn.op.concatenate` will requantize as necessary, so there is nothing special necessary that needs to be done here for this Q op.