### PR TITLE
[Relay, TOPI] Make Softmax op fusible with elemwise ops

### DIFF
--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -39,17 +39,17 @@ reg.register_pattern("nn.relu", OpPattern.ELEMWISE)
 
 # softmax
 reg.register_strategy("nn.softmax", strategy.softmax_strategy)
-reg.register_pattern("nn.softmax", OpPattern.OPAQUE)
+reg.register_pattern("nn.softmax", OpPattern.OUT_ELEMWISE_FUSABLE)
 
 
 # fast softmax
 reg.register_strategy("nn.fast_softmax", strategy.fast_softmax_strategy)
-reg.register_pattern("nn.fast_softmax", OpPattern.OPAQUE)
+reg.register_pattern("nn.fast_softmax", OpPattern.OUT_ELEMWISE_FUSABLE)
 
 
 # log_softmax
 reg.register_strategy("nn.log_softmax", strategy.log_softmax_strategy)
-reg.register_pattern("nn.log_softmax", OpPattern.OPAQUE)
+reg.register_pattern("nn.log_softmax", OpPattern.OUT_ELEMWISE_FUSABLE)
 
 
 @reg.register_legalize("nn.matmul")

--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -69,7 +69,7 @@ def _schedule_softmax(softmax_op, s, outs, tgt):
             ops.append(delta.op)
         if exp is not None:
             ops.append(exp.op)
-        if softmax_op != outs[0]:
+        if softmax_op != outs[0].op:
             ops.append(outs[0].op)
 
         for op in ops:

--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -93,7 +93,10 @@ def schedule_softmax(outs):
             for op in ops:
                 s = schedule_injective_from_existing(s, op.output(0))
 
-        elif sched_warp_softmax():
+        elif sched_warp_softmax() and softmax_op == outs[0].op:
+            # TODO(masahi): Fix LowerThreadAllreduce pass to remove
+            # softmax_op == outs[0].op condition
+
             # A warp of 32 threads performs a row reduction.
             num_thread = tgt.thread_warp_size
             block_x = te.thread_axis("blockIdx.x")

--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -44,7 +44,9 @@ def schedule_softmax(outs):
 
     def _schedule(softmax_op):
         op_tag = softmax_op.tag
-        nonlocal s  # This is required due to the assignment s = schedule_injective_from_existing(...) below
+        # This is required due to the assignment
+        # s = schedule_injective_from_existing(...) below
+        nonlocal s
         if op_tag == "softmax_output":
             expsum = softmax_op.input_tensors[1]
             exp = softmax_op.input_tensors[0]
@@ -73,11 +75,12 @@ def schedule_softmax(outs):
         #
         # TODO(tvm-team) Fix nvptx codegen or deprecate nvptx backend.
         def sched_warp_softmax():
-            if tgt.kind.name == "nvptx" or tgt.kind.name == "rocm":
+            if tgt.kind.name in ["nvptx", "rocm"]:
                 dtype = softmax_op.output(0).dtype
-                return dtype == "float32" or dtype == "int32"
+                return dtype in ["float32", "int32"]
             if tgt.kind.name != "cuda":
-                # this is used as the gpu schedule for other arches which may not have warp reductions
+                # this is used as the gpu schedule for other arches which
+                # may not have warp reductions
                 return False
             return True
 

--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -24,6 +24,136 @@ from .injective import schedule_injective_from_existing
 from ..utils import traverse_inline
 
 
+def _schedule_softmax(softmax_op, s, outs, tgt):
+    op_tag = softmax_op.tag
+    if op_tag == "softmax_output":
+        expsum = softmax_op.input_tensors[1]
+        exp = softmax_op.input_tensors[0]
+        max_elem = s[exp].op.input_tensors[1]
+        delta = None
+    elif op_tag == "fast_softmax_output":
+        expsum = softmax_op.input_tensors[1]
+        exp = softmax_op.input_tensors[0]
+        delta = s[exp].op.input_tensors[0]
+        max_elem = s[delta].op.input_tensors[1]
+    elif op_tag == "log_softmax_output":
+        exp = None
+        delta = None
+        max_elem = softmax_op.input_tensors[1]
+        expsum = softmax_op.input_tensors[2]
+    else:
+        raise ValueError(
+            "Tag is expected to be softmax_output or log_softmax_output. \
+                         Got {0}".format(
+                op_tag
+            )
+        )
+
+    # The nvptx and rocm backends only supports 32-bits warp shuffle
+    # instructions.
+    #
+    # TODO(tvm-team) Fix nvptx codegen or deprecate nvptx backend.
+    def sched_warp_softmax():
+        if tgt.kind.name in ["nvptx", "rocm"]:
+            dtype = softmax_op.output(0).dtype
+            return dtype in ["float32", "int32"]
+        if tgt.kind.name != "cuda":
+            # this is used as the gpu schedule for other arches which
+            # may not have warp reductions
+            return False
+        return True
+
+    if len(outs[0].shape) > 2:
+        ops = [max_elem.op, expsum.op, softmax_op]
+        if delta is not None:
+            ops.append(delta.op)
+        if exp is not None:
+            ops.append(exp.op)
+        if softmax_op != outs[0]:
+            ops.append(outs[0].op)
+
+        for op in ops:
+            s = schedule_injective_from_existing(s, op.output(0))
+
+    elif sched_warp_softmax() and softmax_op == outs[0].op:
+        # TODO(masahi): Fix LowerThreadAllreduce pass to remove
+        # softmax_op == outs[0].op condition
+
+        # A warp of 32 threads performs a row reduction.
+        num_thread = tgt.thread_warp_size
+        block_x = te.thread_axis("blockIdx.x")
+        thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
+
+        # (4) softmax
+        output = outs[0]
+        xo, xi = s[output].split(output.op.axis[1], nparts=num_thread)
+        xio, xii = s[output].split(xi, factor=4)
+        s[output].vectorize(xii)
+        s[output].bind(xo, thread_x)
+        s[output].bind(output.op.axis[0], block_x)
+
+        if softmax_op != outs[0].op:
+            s[softmax_op].compute_at(s[output], xio)
+            s[softmax_op].vectorize(softmax_op.axis[1])  # vec_len == 4
+
+        # (3) expsum
+        k = expsum.op.reduce_axis[0]
+        ko, _ = s[expsum].split(k, nparts=num_thread)
+        s[expsum].bind(ko, thread_x)
+        s[expsum].compute_at(s[output], xo)
+
+        # (2) exp
+        if delta is not None:
+            s[exp].compute_inline()
+            s[delta].compute_inline()
+        elif exp is not None:
+            xo, xi = s[exp].split(exp.op.axis[1], nparts=num_thread)
+            _, xii = s[exp].split(xi, factor=4)
+            s[exp].vectorize(xii)
+            s[exp].bind(xo, thread_x)
+            s[exp].compute_at(s[expsum], expsum.op.axis[0])
+            s[exp].compute_at(s[output], output.op.axis[0])
+            s[exp].set_scope("warp")
+
+        # (1) max_elem
+        k = max_elem.op.reduce_axis[0]
+        ko, _ = s[max_elem].split(k, nparts=num_thread)
+        s[max_elem].bind(ko, thread_x)
+        if exp is not None and delta is None:
+            s[max_elem].compute_at(s[exp], xo)
+        else:
+            s[max_elem].bind(ko, thread_x)
+            s[max_elem].bind(max_elem.op.axis[0], block_x)
+
+    else:
+        num_thread = 64
+        block_x = te.thread_axis("blockIdx.x")
+        thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
+
+        if delta is not None:
+            s[exp].compute_inline()
+            s[delta].compute_inline()
+        elif exp is not None:
+            s[exp].bind(exp.op.axis[0], block_x)
+
+        s[max_elem].bind(max_elem.op.axis[0], block_x)
+        k = expsum.op.reduce_axis[0]
+        ko, ki = s[expsum].split(k, factor=num_thread)
+        EF = s.rfactor(expsum, ki)
+        s[expsum].bind(s[expsum].op.axis[0], block_x)
+        s[expsum].bind(s[expsum].op.reduce_axis[0], thread_x)
+        s[EF].compute_at(s[expsum], s[expsum].op.reduce_axis[0])
+        s[expsum].set_store_predicate(thread_x.var.equal(0))
+
+        output = outs[0]
+        tx, xi = s[output].split(output.op.axis[1], nparts=num_thread)
+        s[output].bind(output.op.axis[0], block_x)
+        s[output].bind(tx, thread_x)
+
+        if softmax_op != outs[0].op:
+            s[softmax_op].compute_at(s[output], tx)
+
+
 def schedule_softmax(outs):
     """Schedule for softmax op.
 
@@ -42,141 +172,9 @@ def schedule_softmax(outs):
     s = te.create_schedule([x.op for x in outs])
     tgt = Target.current(allow_none=False)
 
-    def _schedule(softmax_op):
-        op_tag = softmax_op.tag
-        # This is required due to the assignment
-        # s = schedule_injective_from_existing(...) below
-        nonlocal s
-        if op_tag == "softmax_output":
-            expsum = softmax_op.input_tensors[1]
-            exp = softmax_op.input_tensors[0]
-            max_elem = s[exp].op.input_tensors[1]
-            delta = None
-        elif op_tag == "fast_softmax_output":
-            expsum = softmax_op.input_tensors[1]
-            exp = softmax_op.input_tensors[0]
-            delta = s[exp].op.input_tensors[0]
-            max_elem = s[delta].op.input_tensors[1]
-        elif op_tag == "log_softmax_output":
-            exp = None
-            delta = None
-            max_elem = softmax_op.input_tensors[1]
-            expsum = softmax_op.input_tensors[2]
-        else:
-            raise ValueError(
-                "Tag is expected to be softmax_output or log_softmax_output. \
-                             Got {0}".format(
-                    op_tag
-                )
-            )
-
-        # The nvptx and rocm backends only supports 32-bits warp shuffle
-        # instructions.
-        #
-        # TODO(tvm-team) Fix nvptx codegen or deprecate nvptx backend.
-        def sched_warp_softmax():
-            if tgt.kind.name in ["nvptx", "rocm"]:
-                dtype = softmax_op.output(0).dtype
-                return dtype in ["float32", "int32"]
-            if tgt.kind.name != "cuda":
-                # this is used as the gpu schedule for other arches which
-                # may not have warp reductions
-                return False
-            return True
-
-        if len(outs[0].shape) > 2:
-            ops = [max_elem.op, expsum.op, softmax_op]
-            if delta is not None:
-                ops.append(delta.op)
-            if exp is not None:
-                ops.append(exp.op)
-            if softmax_op != outs[0]:
-                ops.append(outs[0].op)
-
-            for op in ops:
-                s = schedule_injective_from_existing(s, op.output(0))
-
-        elif sched_warp_softmax() and softmax_op == outs[0].op:
-            # TODO(masahi): Fix LowerThreadAllreduce pass to remove
-            # softmax_op == outs[0].op condition
-
-            # A warp of 32 threads performs a row reduction.
-            num_thread = tgt.thread_warp_size
-            block_x = te.thread_axis("blockIdx.x")
-            thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
-
-            # (4) softmax
-            output = outs[0]
-            xo, xi = s[output].split(output.op.axis[1], nparts=num_thread)
-            xio, xii = s[output].split(xi, factor=4)
-            s[output].vectorize(xii)
-            s[output].bind(xo, thread_x)
-            s[output].bind(output.op.axis[0], block_x)
-
-            if softmax_op != outs[0].op:
-                s[softmax_op].compute_at(s[output], xio)
-                s[softmax_op].vectorize(softmax_op.axis[1])  # vec_len == 4
-
-            # (3) expsum
-            k = expsum.op.reduce_axis[0]
-            ko, _ = s[expsum].split(k, nparts=num_thread)
-            s[expsum].bind(ko, thread_x)
-            s[expsum].compute_at(s[output], xo)
-
-            # (2) exp
-            if delta is not None:
-                s[exp].compute_inline()
-                s[delta].compute_inline()
-            elif exp is not None:
-                xo, xi = s[exp].split(exp.op.axis[1], nparts=num_thread)
-                _, xii = s[exp].split(xi, factor=4)
-                s[exp].vectorize(xii)
-                s[exp].bind(xo, thread_x)
-                s[exp].compute_at(s[expsum], expsum.op.axis[0])
-                s[exp].compute_at(s[output], output.op.axis[0])
-                s[exp].set_scope("warp")
-
-            # (1) max_elem
-            k = max_elem.op.reduce_axis[0]
-            ko, _ = s[max_elem].split(k, nparts=num_thread)
-            s[max_elem].bind(ko, thread_x)
-            if exp is not None and delta is None:
-                s[max_elem].compute_at(s[exp], xo)
-            else:
-                s[max_elem].bind(ko, thread_x)
-                s[max_elem].bind(max_elem.op.axis[0], block_x)
-
-        else:
-            num_thread = 64
-            block_x = te.thread_axis("blockIdx.x")
-            thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
-
-            if delta is not None:
-                s[exp].compute_inline()
-                s[delta].compute_inline()
-            elif exp is not None:
-                s[exp].bind(exp.op.axis[0], block_x)
-
-            s[max_elem].bind(max_elem.op.axis[0], block_x)
-            k = expsum.op.reduce_axis[0]
-            ko, ki = s[expsum].split(k, factor=num_thread)
-            EF = s.rfactor(expsum, ki)
-            s[expsum].bind(s[expsum].op.axis[0], block_x)
-            s[expsum].bind(s[expsum].op.reduce_axis[0], thread_x)
-            s[EF].compute_at(s[expsum], s[expsum].op.reduce_axis[0])
-            s[expsum].set_store_predicate(thread_x.var.equal(0))
-
-            output = outs[0]
-            tx, xi = s[output].split(output.op.axis[1], nparts=num_thread)
-            s[output].bind(output.op.axis[0], block_x)
-            s[output].bind(tx, thread_x)
-
-            if softmax_op != outs[0].op:
-                s[softmax_op].compute_at(s[output], tx)
-
     def _callback(op):
         if "softmax" in op.tag:
-            _schedule(op)
+            _schedule_softmax(op, s, outs, tgt)
 
     traverse_inline(s, outs[0].op, _callback)
     return s

--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -21,6 +21,7 @@ from tvm import te
 from tvm.contrib import cudnn
 from .. import generic
 from .injective import schedule_injective_from_existing
+from ..utils import traverse_inline
 
 
 def schedule_softmax(outs):
@@ -39,120 +40,133 @@ def schedule_softmax(outs):
     """
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
-    softmax = outs[0]
     tgt = Target.current(allow_none=False)
 
-    op_tag = softmax.op.tag
-    if op_tag == "softmax_output":
-        expsum = softmax.op.input_tensors[1]
-        exp = softmax.op.input_tensors[0]
-        max_elem = s[exp].op.input_tensors[1]
-        delta = None
-    elif op_tag == "fast_softmax_output":
-        expsum = softmax.op.input_tensors[1]
-        exp = softmax.op.input_tensors[0]
-        delta = s[exp].op.input_tensors[0]
-        max_elem = s[delta].op.input_tensors[1]
-    elif op_tag == "log_softmax_output":
-        exp = None
-        delta = None
-        max_elem = softmax.op.input_tensors[1]
-        expsum = softmax.op.input_tensors[2]
-    else:
-        raise ValueError(
-            "Tag is expected to be softmax_output or log_softmax_output. \
-                         Got {0}".format(
-                op_tag
-            )
-        )
-
-    # The nvptx and rocm backends only supports 32-bits warp shuffle
-    # instructions.
-    #
-    # TODO(tvm-team) Fix nvptx codegen or deprecate nvptx backend.
-    def sched_warp_softmax():
-        if tgt.kind.name == "nvptx" or tgt.kind.name == "rocm":
-            return softmax.dtype == "float32" or softmax.dtype == "int32"
-        if tgt.kind.name != "cuda":
-            # this is used as the gpu schedule for other arches which may not have warp reductions
-            return False
-        return True
-
-    if len(softmax.shape) > 2:
-        ops = [max_elem.op, expsum.op, softmax.op]
-        if delta is not None:
-            ops.append(delta.op)
-        if exp is not None:
-            ops.append(exp.op)
-
-        for op in ops:
-            s = schedule_injective_from_existing(s, op.output(0))
-
-    elif sched_warp_softmax():
-        # A warp of 32 threads performs a row reduction.
-        num_thread = tgt.thread_warp_size
-        block_x = te.thread_axis("blockIdx.x")
-        thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
-
-        # (4) softmax
-        xo, xi = s[softmax].split(softmax.op.axis[1], nparts=num_thread)
-        _, xii = s[softmax].split(xi, factor=4)
-        s[softmax].vectorize(xii)
-        s[softmax].bind(xo, thread_x)
-        s[softmax].bind(softmax.op.axis[0], block_x)
-
-        # (3) expsum
-        k = expsum.op.reduce_axis[0]
-        ko, _ = s[expsum].split(k, nparts=num_thread)
-        s[expsum].bind(ko, thread_x)
-        s[expsum].compute_at(s[softmax], xo)
-
-        # (2) exp
-        if delta is not None:
-            s[exp].compute_inline()
-            s[delta].compute_inline()
-        elif exp is not None:
-            xo, xi = s[exp].split(exp.op.axis[1], nparts=num_thread)
-            _, xii = s[exp].split(xi, factor=4)
-            s[exp].vectorize(xii)
-            s[exp].bind(xo, thread_x)
-            s[exp].compute_at(s[expsum], expsum.op.axis[0])
-            s[exp].compute_at(s[softmax], softmax.op.axis[0])
-            s[exp].set_scope("warp")
-
-        # (1) max_elem
-        k = max_elem.op.reduce_axis[0]
-        ko, _ = s[max_elem].split(k, nparts=num_thread)
-        s[max_elem].bind(ko, thread_x)
-        if exp is not None and delta is None:
-            s[max_elem].compute_at(s[exp], xo)
+    def _schedule(softmax_op):
+        op_tag = softmax_op.tag
+        nonlocal s  # This is required due to the assignment s = schedule_injective_from_existing(...) below
+        if op_tag == "softmax_output":
+            expsum = softmax_op.input_tensors[1]
+            exp = softmax_op.input_tensors[0]
+            max_elem = s[exp].op.input_tensors[1]
+            delta = None
+        elif op_tag == "fast_softmax_output":
+            expsum = softmax_op.input_tensors[1]
+            exp = softmax_op.input_tensors[0]
+            delta = s[exp].op.input_tensors[0]
+            max_elem = s[delta].op.input_tensors[1]
+        elif op_tag == "log_softmax_output":
+            exp = None
+            delta = None
+            max_elem = softmax_op.input_tensors[1]
+            expsum = softmax_op.input_tensors[2]
         else:
+            raise ValueError(
+                "Tag is expected to be softmax_output or log_softmax_output. \
+                             Got {0}".format(
+                    op_tag
+                )
+            )
+
+        # The nvptx and rocm backends only supports 32-bits warp shuffle
+        # instructions.
+        #
+        # TODO(tvm-team) Fix nvptx codegen or deprecate nvptx backend.
+        def sched_warp_softmax():
+            if tgt.kind.name == "nvptx" or tgt.kind.name == "rocm":
+                return softmax_op.dtype == "float32" or softmax_op.dtype == "int32"
+            if tgt.kind.name != "cuda":
+                # this is used as the gpu schedule for other arches which may not have warp reductions
+                return False
+            return True
+
+        if len(outs[0].shape) > 2:
+            ops = [max_elem.op, expsum.op, softmax_op]
+            if delta is not None:
+                ops.append(delta.op)
+            if exp is not None:
+                ops.append(exp.op)
+            if softmax_op != outs[0]:
+                ops.append(outs[0].op)
+
+            for op in ops:
+                s = schedule_injective_from_existing(s, op.output(0))
+
+        elif sched_warp_softmax():
+            # A warp of 32 threads performs a row reduction.
+            num_thread = tgt.thread_warp_size
+            block_x = te.thread_axis("blockIdx.x")
+            thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
+
+            # (4) softmax
+            xo, xi = s[softmax_op].split(softmax_op.axis[1], nparts=num_thread)
+            _, xii = s[softmax_op].split(xi, factor=4)
+            s[softmax_op].vectorize(xii)
+            s[softmax_op].bind(xo, thread_x)
+            s[softmax_op].bind(softmax_op.axis[0], block_x)
+
+            # (3) expsum
+            k = expsum.op.reduce_axis[0]
+            ko, _ = s[expsum].split(k, nparts=num_thread)
+            s[expsum].bind(ko, thread_x)
+            s[expsum].compute_at(s[softmax_op], xo)
+
+            # (2) exp
+            if delta is not None:
+                s[exp].compute_inline()
+                s[delta].compute_inline()
+            elif exp is not None:
+                xo, xi = s[exp].split(exp.op.axis[1], nparts=num_thread)
+                _, xii = s[exp].split(xi, factor=4)
+                s[exp].vectorize(xii)
+                s[exp].bind(xo, thread_x)
+                s[exp].compute_at(s[expsum], expsum.op.axis[0])
+                s[exp].compute_at(s[softmax_op], softmax_op.axis[0])
+                s[exp].set_scope("warp")
+
+            # (1) max_elem
+            k = max_elem.op.reduce_axis[0]
+            ko, _ = s[max_elem].split(k, nparts=num_thread)
             s[max_elem].bind(ko, thread_x)
+            if exp is not None and delta is None:
+                s[max_elem].compute_at(s[exp], xo)
+            else:
+                s[max_elem].bind(ko, thread_x)
+                s[max_elem].bind(max_elem.op.axis[0], block_x)
+
+        else:
+            num_thread = 64
+            block_x = te.thread_axis("blockIdx.x")
+            thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
+
+            if delta is not None:
+                s[exp].compute_inline()
+                s[delta].compute_inline()
+            elif exp is not None:
+                s[exp].bind(exp.op.axis[0], block_x)
+
             s[max_elem].bind(max_elem.op.axis[0], block_x)
+            k = expsum.op.reduce_axis[0]
+            ko, ki = s[expsum].split(k, factor=num_thread)
+            EF = s.rfactor(expsum, ki)
+            s[expsum].bind(s[expsum].op.axis[0], block_x)
+            s[expsum].bind(s[expsum].op.reduce_axis[0], thread_x)
+            s[EF].compute_at(s[expsum], s[expsum].op.reduce_axis[0])
+            s[expsum].set_store_predicate(thread_x.var.equal(0))
 
-    else:
-        num_thread = 64
-        block_x = te.thread_axis("blockIdx.x")
-        thread_x = te.thread_axis((0, num_thread), "threadIdx.x")
+            output = outs[0]
+            tx, xi = s[output].split(output.op.axis[1], nparts=num_thread)
+            s[output].bind(output.op.axis[0], block_x)
+            s[output].bind(tx, thread_x)
 
-        if delta is not None:
-            s[exp].compute_inline()
-            s[delta].compute_inline()
-        elif exp is not None:
-            s[exp].bind(exp.op.axis[0], block_x)
+            if softmax_op != outs[0]:
+                s[softmax_op].compute_at(s[output], tx)
 
-        s[max_elem].bind(max_elem.op.axis[0], block_x)
-        k = expsum.op.reduce_axis[0]
-        ko, ki = s[expsum].split(k, factor=num_thread)
-        EF = s.rfactor(expsum, ki)
-        s[expsum].bind(s[expsum].op.axis[0], block_x)
-        s[expsum].bind(s[expsum].op.reduce_axis[0], thread_x)
-        s[EF].compute_at(s[expsum], s[expsum].op.reduce_axis[0])
-        s[expsum].set_store_predicate(thread_x.var.equal(0))
-        tx, xi = s[softmax].split(softmax.op.axis[1], nparts=num_thread)
-        s[softmax].bind(softmax.op.axis[0], block_x)
-        s[softmax].bind(tx, thread_x)
+    def _callback(op):
+        if "softmax" in op.tag:
+            _schedule(op)
 
+    traverse_inline(s, outs[0].op, _callback)
     return s
 
 

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -17,7 +17,6 @@
 # pylint: disable=invalid-name,too-many-locals,unused-variable
 """x86 nn operators"""
 from tvm import te
-from .. import tag
 from ..utils import traverse_inline
 
 

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -20,6 +20,58 @@ from tvm import te
 from ..utils import traverse_inline
 
 
+def _schedule_softmax(softmax_op, s, outs):
+    op_tag = softmax_op.tag
+    if op_tag == "softmax_output":
+        exp = softmax_op.input_tensors[0]
+        expsum = softmax_op.input_tensors[1]
+        max_elem = s[exp].op.input_tensors[1]
+        delta = None
+        axis = int(softmax_op.attrs["axis"])
+    elif op_tag == "fast_softmax_output":
+        exp = softmax_op.input_tensors[0]
+        expsum = softmax_op.input_tensors[1]
+        delta = s[exp].op.input_tensors[0]
+        max_elem = s[delta].op.input_tensors[1]
+        axis = int(softmax_op.attrs["axis"])
+    elif op_tag == "log_softmax_output":
+        exp = None
+        delta = None
+        max_elem = softmax_op.input_tensors[1]
+        expsum = softmax_op.input_tensors[2]
+        axis = 1
+    else:
+        raise ValueError(
+            "Tag is expected to be softmax_output or log_softmax_output. \
+                         Got {0}".format(
+                op_tag
+            )
+        )
+
+    # only parallelize outer dimensions up to axis
+    outer_axes = [s[softmax_op].op.axis[i] for i in range(0, axis)]
+    fused_outer_axes = s[softmax_op].fuse(*outer_axes)
+    s[softmax_op].parallel(fused_outer_axes)
+
+    # move computations with the same outer dimensions under the same root
+    s[max_elem].compute_at(s[softmax_op], fused_outer_axes)
+    s[expsum].compute_at(s[softmax_op], fused_outer_axes)
+
+    if delta is not None:
+        s[exp].compute_inline()
+        s[delta].compute_inline()
+    if exp is not None:
+        s[exp].compute_at(s[softmax_op], fused_outer_axes)
+
+    if softmax_op != outs[0].op:
+        # fuse softmax output with following elemwise ops.
+        output = outs[0]
+        outer_axes = [s[output].op.axis[i] for i in range(0, axis)]
+        fused_outer_axes = s[output].fuse(*outer_axes)
+        s[output].parallel(fused_outer_axes)
+        s[softmax_op].compute_at(s[output], fused_outer_axes)
+
+
 def schedule_softmax(outs):
     """Schedule for softmax
 
@@ -37,60 +89,9 @@ def schedule_softmax(outs):
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
 
-    def _schedule(softmax_op):
-        op_tag = softmax_op.tag
-        if op_tag == "softmax_output":
-            exp = softmax_op.input_tensors[0]
-            expsum = softmax_op.input_tensors[1]
-            max_elem = s[exp].op.input_tensors[1]
-            delta = None
-            axis = int(softmax_op.attrs["axis"])
-        elif op_tag == "fast_softmax_output":
-            exp = softmax_op.input_tensors[0]
-            expsum = softmax_op.input_tensors[1]
-            delta = s[exp].op.input_tensors[0]
-            max_elem = s[delta].op.input_tensors[1]
-            axis = int(softmax_op.attrs["axis"])
-        elif op_tag == "log_softmax_output":
-            exp = None
-            delta = None
-            max_elem = softmax_op.input_tensors[1]
-            expsum = softmax_op.input_tensors[2]
-            axis = 1
-        else:
-            raise ValueError(
-                "Tag is expected to be softmax_output or log_softmax_output. \
-                             Got {0}".format(
-                    op_tag
-                )
-            )
-
-        # only parallelize outer dimensions up to axis
-        outer_axes = [s[softmax_op].op.axis[i] for i in range(0, axis)]
-        fused_outer_axes = s[softmax_op].fuse(*outer_axes)
-        s[softmax_op].parallel(fused_outer_axes)
-
-        # move computations with the same outer dimensions under the same root
-        s[max_elem].compute_at(s[softmax_op], fused_outer_axes)
-        s[expsum].compute_at(s[softmax_op], fused_outer_axes)
-
-        if delta is not None:
-            s[exp].compute_inline()
-            s[delta].compute_inline()
-        if exp is not None:
-            s[exp].compute_at(s[softmax_op], fused_outer_axes)
-
-        if softmax_op != outs[0].op:
-            # fuse softmax output with following elemwise ops.
-            output = outs[0]
-            outer_axes = [s[output].op.axis[i] for i in range(0, axis)]
-            fused_outer_axes = s[output].fuse(*outer_axes)
-            s[output].parallel(fused_outer_axes)
-            s[softmax_op].compute_at(s[output], fused_outer_axes)
-
     def _callback(op):
         if "softmax" in op.tag:
-            _schedule(op)
+            _schedule_softmax(op, s, outs)
 
     traverse_inline(s, outs[0].op, _callback)
     return s

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name,too-many-locals,unused-variable
 """x86 nn operators"""
 from tvm import te
+from .. import tag
 
 
 def schedule_softmax(outs):
@@ -34,49 +35,63 @@ def schedule_softmax(outs):
         The computation schedule for the op.
     """
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
-    softmax = outs[0]
     s = te.create_schedule([x.op for x in outs])
+    scheduled_ops = []
 
-    op_tag = softmax.op.tag
-    if op_tag == "softmax_output":
-        exp = softmax.op.input_tensors[0]
-        expsum = softmax.op.input_tensors[1]
-        max_elem = s[exp].op.input_tensors[1]
-        delta = None
-        axis = int(softmax.op.attrs["axis"])
-    elif op_tag == "fast_softmax_output":
-        exp = softmax.op.input_tensors[0]
-        expsum = softmax.op.input_tensors[1]
-        delta = s[exp].op.input_tensors[0]
-        max_elem = s[delta].op.input_tensors[1]
-        axis = int(softmax.op.attrs["axis"])
-    elif op_tag == "log_softmax_output":
-        exp = None
-        delta = None
-        max_elem = softmax.op.input_tensors[1]
-        expsum = softmax.op.input_tensors[2]
-        axis = 1
-    else:
-        raise ValueError(
-            "Tag is expected to be softmax_output or log_softmax_output. \
-                         Got {0}".format(
-                op_tag
+    def _schedule(softmax_op):
+        op_tag = softmax_op.tag
+        if op_tag == "softmax_output":
+            exp = softmax_op.input_tensors[0]
+            expsum = softmax_op.input_tensors[1]
+            max_elem = s[exp].op.input_tensors[1]
+            delta = None
+            axis = int(softmax_op.attrs["axis"])
+        elif op_tag == "fast_softmax_output":
+            exp = softmax_op.input_tensors[0]
+            expsum = softmax_op.input_tensors[1]
+            delta = s[exp].op.input_tensors[0]
+            max_elem = s[delta].op.input_tensors[1]
+            axis = int(softmax_op.attrs["axis"])
+        elif op_tag == "log_softmax_output":
+            exp = None
+            delta = None
+            max_elem = softmax_op.input_tensors[1]
+            expsum = softmax_op.input_tensors[2]
+            axis = 1
+        else:
+            raise ValueError(
+                "Tag is expected to be softmax_output or log_softmax_output. \
+                             Got {0}".format(
+                    op_tag
+                )
             )
-        )
 
-    # only parallelize outer dimensions up to axis
-    outer_axes = [s[softmax].op.axis[i] for i in range(0, axis)]
-    fused_outer_axes = s[softmax].fuse(*outer_axes)
-    s[softmax].parallel(fused_outer_axes)
+        # only parallelize outer dimensions up to axis
+        outer_axes = [s[softmax_op].op.axis[i] for i in range(0, axis)]
+        fused_outer_axes = s[softmax_op].fuse(*outer_axes)
+        s[softmax_op].parallel(fused_outer_axes)
 
-    # move computations with the same outer dimensions under the same root
-    s[max_elem].compute_at(s[softmax], fused_outer_axes)
-    s[expsum].compute_at(s[softmax], fused_outer_axes)
+        # move computations with the same outer dimensions under the same root
+        s[max_elem].compute_at(s[softmax_op], fused_outer_axes)
+        s[expsum].compute_at(s[softmax_op], fused_outer_axes)
 
-    if delta is not None:
-        s[exp].compute_inline()
-        s[delta].compute_inline()
-    if exp is not None:
-        s[exp].compute_at(s[softmax], fused_outer_axes)
+        if delta is not None:
+            s[exp].compute_inline()
+            s[delta].compute_inline()
+        if exp is not None:
+            s[exp].compute_at(s[softmax_op], fused_outer_axes)
 
+    def traverse(OP):
+        if tag.is_broadcast(OP.tag):
+            if OP not in s.outputs:
+                s[OP].compute_inline()
+            for tensor in OP.input_tensors:
+                if isinstance(tensor.op, te.tensor.ComputeOp) and tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+        elif "softmax" in OP.tag:
+            _schedule(OP)
+
+        scheduled_ops.append(OP)
+
+    traverse(outs[0].op)
     return s

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -81,7 +81,7 @@ def schedule_softmax(outs):
         if exp is not None:
             s[exp].compute_at(s[softmax_op], fused_outer_axes)
 
-        if softmax_op != outs[0]:
+        if softmax_op != outs[0].op:
             # fuse softmax output with following elemwise ops.
             output = outs[0]
             outer_axes = [s[output].op.axis[i] for i in range(0, axis)]

--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -119,17 +119,6 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     }
   }
 
-  Stmt VisitStmt_(const StoreNode* op) final {
-    auto it = store_remap_.find(op->buffer_var.get());
-    if (it != store_remap_.end()) {
-      ICHECK(is_zero(op->index));
-      auto value = StmtExprMutator::VisitExpr(op->value);
-      return Store(it->second, value, 0, op->predicate);
-    } else {
-      return StmtExprMutator::VisitStmt_(op);
-    }
-  }
-
   std::unordered_map<const VarNode*, String> new_storage_scopes_;
 
  private:
@@ -339,7 +328,6 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         PrimExpr pred = const_true(types[i].lanes());
         Var var = shared_bufs[i];
         load_remap_[buffers[i]] = Load(types[i], var, index, pred);
-        store_remap_[buffers[i]] = var;
         Array<PrimExpr> extents{PrimExpr(1)};
         auto node = Allocate(var, types[i], extents, pred, Evaluate(0));
         alloc_remap_[buffers[i]] = node;
@@ -382,7 +370,6 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         alloc_remap_[buffers[idx]] =
             Allocate(shared_bufs[idx], types[idx],
                      {PrimExpr(group_extent), PrimExpr(reduce_extent)}, pred, Evaluate(0));
-        store_remap_[buffers[idx]] = shared_bufs[idx];
       }
     }
 
@@ -600,8 +587,6 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
   std::vector<const CommReducerNode*> reduce_combiner_;
   // The load remap
   std::unordered_map<const VarNode*, PrimExpr> load_remap_;
-  // The store remap
-  std::unordered_map<const VarNode*, Var> store_remap_;
   // Allocate remap
   std::unordered_map<const VarNode*, Stmt> alloc_remap_;
   // Allocate from warp reductions

--- a/tests/micro/arduino/test_arduino_workflow.py
+++ b/tests/micro/arduino/test_arduino_workflow.py
@@ -17,6 +17,7 @@
 
 import datetime
 import pathlib
+import re
 import shutil
 import sys
 
@@ -80,7 +81,16 @@ def test_model_header_templating(project_dir, project):
     # Ensure model.h was templated with correct WORKSPACE_SIZE
     with (project_dir / "src" / "model.h").open() as f:
         model_h = f.read()
-        assert "#define WORKSPACE_SIZE 21312" in model_h
+        workspace_size_defs = re.findall(r"\#define WORKSPACE_SIZE ([0-9]*)", model_h)
+        assert workspace_size_defs
+        assert len(workspace_size_defs) == 1
+
+        # Make sure the WORKSPACE_SIZE we define is a reasonable size. We don't want
+        # to set an exact value, as this test shouldn't break if an improvement to
+        # TVM causes the amount of memory needed to decrease.
+        workspace_size = int(workspace_size_defs[0])
+        assert workspace_size < 30000
+        assert workspace_size > 10000
 
 
 def test_import_rerouting(project_dir, project):

--- a/tests/python/relay/test_analysis_extract_fused_functions.py
+++ b/tests/python/relay/test_analysis_extract_fused_functions.py
@@ -96,7 +96,7 @@ def test_extract_conv_net():
 def test_extract_resnet():
     mod, _params = get_workload()
     items = relay.analysis.extract_fused_functions(mod)
-    assert len(items) == 6
+    assert len(items) == 7
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -817,8 +817,8 @@ def test_fuse_softmax():
     inp = np.random.randn(16, channel_size).astype("float32")
     ref = tvm.topi.testing.softmax_python(inp).astype("float16")
 
-    for target in ["llvm", "cuda"]:
-        ex = relay.create_executor("graph", mod=m, device=tvm.device(target, 0), target=target)
+    for tgt, dev in tvm.testing.enabled_targets():
+        ex = relay.create_executor("graph", mod=m, device=dev, target=tgt)
         result = ex.evaluate()(inp).numpy()
         tvm.testing.assert_allclose(result, ref, rtol=1e-4, atol=1e-4)
 

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -100,7 +100,7 @@ def test_cpu_get_graph_json():
     loaded_lib = tvm.runtime.load_module(path_lib)
     json = loaded_lib["get_graph_json"]()
     assert isinstance(json, str) == True
-    assert json.find("tvmgen_default_fused_nn_softmax1") > -1
+    assert json.find("tvmgen_default_fused_nn_softmax_add") > -1
 
 
 @tvm.testing.requires_cuda


### PR DESCRIPTION
Currently, op fusion is not enabled for `softmax` op. This has been fine for imagenet models where `softmax` is only used at the end. But transformer models use a lot of softmax in the middle. 

When the FP16 conversion is applied, `softmax` is always left fp32, so there are always a lot of `cast(softmax_output, dtype="float16")` after the conversion. Since `softmax` and `cast` cannot be fused, we end up a lot of inefficient "cast only" kernels: https://gist.github.com/masahi/0d7d96ae88722b616a906cec2054559e#file-transformer-txt-L37-L43 

This PR changes `softmax` op's fuse pattern, so that it can be fused with following elemwise / injective ops, just like conv2d etc. Topi schedules have also been updated to take fused ops into account. 

cc @yzhliu @comaniac @AndrewZhaoLuo @mbrookhart 