### PR TITLE
[Hexagon] Add trivial conv2d operator to Hexagon relay strategy

### DIFF
--- a/python/tvm/relay/op/strategy/hexagon.py
+++ b/python/tvm/relay/op/strategy/hexagon.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Definition of Hexagon operator strategy."""
+
+# pylint: disable=invalid-name,unused-argument,wildcard-import,unused-wildcard-import
+
+from tvm import topi
+from .generic import *
+from .. import op as _op
+
+
+@conv2d_strategy.register("hexagon")
+def conv2d_strategy_hexagon(attrs, inputs, out_type, target):
+    """Conv2d strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    data_layout = attrs.data_layout
+    kernel_layout = attrs.kernel_layout
+
+    if data_layout == "NHWC" and kernel_layout == "HWIO":
+        strategy.add_implementation(
+            wrap_compute_conv2d(topi.nn.conv2d_nhwc),
+            wrap_topi_schedule(topi.hexagon.schedule_conv2d_nhwc),
+            name="conv2d.hexagon",
+        )
+        return strategy
+
+    raise RuntimeError(
+        "Unsupported layouts: data_layout:{}, kernel_layout:{}".format(data_layout, kernel_layout)
+    )

--- a/python/tvm/topi/__init__.py
+++ b/python/tvm/topi/__init__.py
@@ -61,6 +61,7 @@ from . import image
 from . import sparse
 from . import hls
 from . import random
+from . import hexagon
 
 # error reporting
 from .utils import InvalidShapeError

--- a/python/tvm/topi/hexagon/__init__.py
+++ b/python/tvm/topi/hexagon/__init__.py
@@ -15,17 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# pylint: disable=wildcard-import
-"""Relay op strategies."""
-from __future__ import absolute_import as _abs
+""" Schedules for Hexagon. """
 
-from .generic import *
-from . import x86
-from . import arm_cpu
-from . import cuda
-from . import hls
-from . import mali
-from . import bifrost
-from . import rocm
-from . import intel_graphics
-from . import hexagon
+# pylint: disable=wildcard-import
+
+from .conv2d import *

--- a/python/tvm/topi/hexagon/conv2d.py
+++ b/python/tvm/topi/hexagon/conv2d.py
@@ -15,17 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# pylint: disable=wildcard-import
-"""Relay op strategies."""
-from __future__ import absolute_import as _abs
+""" Schedules for conv2d. """
 
-from .generic import *
-from . import x86
-from . import arm_cpu
-from . import cuda
-from . import hls
-from . import mali
-from . import bifrost
-from . import rocm
-from . import intel_graphics
-from . import hexagon
+import tvm
+
+
+def schedule_conv2d_nhwc(outs):
+    """Schedule for Conv2d NHWC operator."""
+    s = tvm.te.create_schedule([x.op for x in outs])
+    return s


### PR DESCRIPTION
This is just to enable relay codegen for conv2d on Hexagon, not for performance.
