### PR TITLE
[Relay] Add a non-recursive LetNode VisitExpr_ for LabelOps Pass to avoid stack overflow

### DIFF
--- a/src/relay/transforms/label_ops.cc
+++ b/src/relay/transforms/label_ops.cc
@@ -95,7 +95,7 @@ class LabelOpsMutator : public MixedModeMutator {
     };
     ExpandANormalForm(op, pre_visit, post_visit);
     return memo_[GetRef<Expr>(op)];
-  }
+  } 
 
   Expr Rewrite_(const CallNode* op, const Expr& post) final {
     auto updated = MixedModeMutator::Rewrite_(op, post);

--- a/src/relay/transforms/label_ops.cc
+++ b/src/relay/transforms/label_ops.cc
@@ -77,6 +77,25 @@ class LabelOpsMutator : public MixedModeMutator {
     }
     return std::move(f);
   }
+  Expr VisitExpr_(const LetNode* op) final {
+    auto pre_visit = [this](const LetNode* op) {
+      this->Mutate(op->var);
+      this->Mutate(op->value);
+    };
+    auto post_visit = [this](const LetNode* op) {
+      Var var = Downcast<Var>(this->Mutate(op->var));
+      auto value = this->Mutate(op->value);
+      auto body = this->Mutate(op->body);
+      auto expr = GetRef<Expr>(op);
+      if (var.same_as(op->var) && value.same_as(op->value) && body.same_as(op->body)) {
+        this->memo_[expr] = expr;
+      } else {
+        this->memo_[expr] = Let(var, value, body);
+      }
+    };
+    ExpandANormalForm(op, pre_visit, post_visit);
+    return memo_[GetRef<Expr>(op)];
+  }
 
   Expr Rewrite_(const CallNode* op, const Expr& post) final {
     auto updated = MixedModeMutator::Rewrite_(op, post);

--- a/src/relay/transforms/label_ops.cc
+++ b/src/relay/transforms/label_ops.cc
@@ -95,7 +95,7 @@ class LabelOpsMutator : public MixedModeMutator {
     };
     ExpandANormalForm(op, pre_visit, post_visit);
     return memo_[GetRef<Expr>(op)];
-  } 
+  }
 
   Expr Rewrite_(const CallNode* op, const Expr& post) final {
     auto updated = MixedModeMutator::Rewrite_(op, post);


### PR DESCRIPTION
When I use the relay VM to compile a graph that contains a huge for loop, the LabelOps pass encountered stack overflow. This problem is caused by the LabelOps applies the default `ExprMutator::VisitExpr_(const LetNode* op)` function to visit the LetNode, which is a recursive function.

Here is a small testing case:
``` python3
data = relay.var("data", tvm.ir.TensorType(shape = (relay.Any(),5,2), dtype = "float32"))
shape = relay.op.shape_of(data)

for i in range(1000):
    tmp = relay.op.ones(shape, "float32")
    shape = relay.op.shape_of(tmp)
res = shape

mod = tvm.IRModule()
mod["main"] = relay.Function([data], res)
```
In this case, I set the for loop with 1000 times, note that the specific number of times that will cause the LabelOps stack overflow may vary in different machine environment.

To fix this bug, I added a non-recursive LetNode VisitExpr_ in the Class LabelOpsMutator.