### PR TITLE
[Bugfix] Fix visit_attrs error if its function pointer is equal to nullptr

### DIFF
--- a/python/tvm/ir/container.py
+++ b/python/tvm/ir/container.py
@@ -38,6 +38,17 @@ class Array(Object):
     def __len__(self):
         return _ffi_api.ArraySize(self)
 
+    def __dir__(self):
+        return sorted(dir(self.__class__) + ["type_key"])
+
+    def __getattr__(self, name):
+        if name == "handle":
+            raise AttributeError("handle is not set")
+        elif name == "type_key":
+            return super().__getattr__(name)
+        else:
+            raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
+
 
 @tvm._ffi.register_object
 class Map(Object):
@@ -58,6 +69,17 @@ class Map(Object):
         akvs = _ffi_api.MapItems(self)
         for i in range(len(self)):
             yield akvs[i * 2]
+
+    def __dir__(self):
+        return sorted(dir(self.__class__) + ["type_key"])
+
+    def __getattr__(self, name):
+        if name == "handle":
+            raise AttributeError("handle is not set")
+        elif name == "type_key":
+            return super().__getattr__(name)
+        else:
+            raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
 
     def keys(self):
         return iter(self)

--- a/python/tvm/ir/container.py
+++ b/python/tvm/ir/container.py
@@ -44,10 +44,9 @@ class Array(Object):
     def __getattr__(self, name):
         if name == "handle":
             raise AttributeError("handle is not set")
-        elif name == "type_key":
+        if name == "type_key":
             return super().__getattr__(name)
-        else:
-            raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
+        raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
 
 
 @tvm._ffi.register_object
@@ -76,10 +75,9 @@ class Map(Object):
     def __getattr__(self, name):
         if name == "handle":
             raise AttributeError("handle is not set")
-        elif name == "type_key":
+        if name == "type_key":
             return super().__getattr__(name)
-        else:
-            raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
+        raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
 
     def keys(self):
         return iter(self)

--- a/tests/python/unittest/test_ir_container.py
+++ b/tests/python/unittest/test_ir_container.py
@@ -34,6 +34,21 @@ def test_array_save_load_json():
     assert a_loaded[1].value == 2
 
 
+def test_dir_array():
+    a = tvm.runtime.convert([1, 2, 3])
+    dir(a)
+
+
+def test_getattr_array():
+    a = tvm.runtime.convert([1, 2, 3])
+    type_key = getattr(a, "type_key")
+    assert type_key == "Array"
+    try:
+        getattr(a, "test_key")
+    except AttributeError:
+        pass
+
+
 def test_map():
     a = te.var("a")
     b = te.var("b")
@@ -70,6 +85,25 @@ def test_map_save_load_json():
     assert dd == {"a": 2, "b": 3}
 
 
+def test_dir_map():
+    a = te.var("a")
+    b = te.var("b")
+    amap = tvm.runtime.convert({a: 2, b: 3})
+    dir(amap)
+
+
+def test_getattr_map():
+    a = te.var("a")
+    b = te.var("b")
+    amap = tvm.runtime.convert({a: 2, b: 3})
+    type_key = getattr(amap, "type_key")
+    assert type_key == "Map"
+    try:
+        getattr(amap, "test_key")
+    except AttributeError:
+        pass
+
+
 def test_in_container():
     arr = tvm.runtime.convert(["a", "b", "c"])
     assert "a" in arr
@@ -91,5 +125,10 @@ if __name__ == "__main__":
     test_map()
     test_array_save_load_json()
     test_map_save_load_json()
+    test_dir_array()
+    test_dir_map()
+    test_getattr_array()
+    test_getattr_map()
     test_in_container()
     test_ndarray_container()
+    

--- a/tests/python/unittest/test_ir_container.py
+++ b/tests/python/unittest/test_ir_container.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 import tvm
 from tvm import te
 import numpy as np
@@ -36,17 +37,13 @@ def test_array_save_load_json():
 
 def test_dir_array():
     a = tvm.runtime.convert([1, 2, 3])
-    dir(a)
+    assert dir(a)
 
 
 def test_getattr_array():
     a = tvm.runtime.convert([1, 2, 3])
-    type_key = getattr(a, "type_key")
-    assert type_key == "Array"
-    try:
-        getattr(a, "test_key")
-    except AttributeError:
-        pass
+    assert getattr(a, "type_key") == "Array"
+    assert not hasattr(a, "test_key")
 
 
 def test_map():
@@ -89,19 +86,15 @@ def test_dir_map():
     a = te.var("a")
     b = te.var("b")
     amap = tvm.runtime.convert({a: 2, b: 3})
-    dir(amap)
+    assert dir(amap)
 
 
 def test_getattr_map():
     a = te.var("a")
     b = te.var("b")
     amap = tvm.runtime.convert({a: 2, b: 3})
-    type_key = getattr(amap, "type_key")
-    assert type_key == "Map"
-    try:
-        getattr(amap, "test_key")
-    except AttributeError:
-        pass
+    assert getattr(amap, "type_key") == "Map"
+    assert not hasattr(amap, "test_key")
 
 
 def test_in_container():
@@ -120,15 +113,5 @@ def test_ndarray_container():
 
 
 if __name__ == "__main__":
-    test_str_map()
-    test_array()
-    test_map()
-    test_array_save_load_json()
-    test_map_save_load_json()
-    test_dir_array()
-    test_dir_map()
-    test_getattr_array()
-    test_getattr_map()
-    test_in_container()
-    test_ndarray_container()
-    
+    pytest.main([__file__])
+

--- a/tests/python/unittest/test_ir_container.py
+++ b/tests/python/unittest/test_ir_container.py
@@ -114,4 +114,3 @@ def test_ndarray_container():
 
 if __name__ == "__main__":
     pytest.main([__file__])
-


### PR DESCRIPTION
Fix the bug mentioned in https://discuss.tvm.apache.org/t/cannot-list-attrs-of-tvm-ir-array-via-dir/10924

Every time when we try to register a node, the size of `fvisit_attrs_` will increase, and there are no other operations to unregister these nodes, so if `tindex < fvisit_attrs_.size()` is true, it means that the node has been registered.

```c++
template <typename T, typename TraitName>
inline ReflectionVTable::Registry ReflectionVTable::Register() {
  uint32_t tindex = T::RuntimeTypeIndex();
  if (tindex >= fvisit_attrs_.size()) {
    fvisit_attrs_.resize(tindex + 1, nullptr);
    fcreate_.resize(tindex + 1, nullptr);
    frepr_bytes_.resize(tindex + 1, nullptr);
    fsequal_reduce_.resize(tindex + 1, nullptr);
    fshash_reduce_.resize(tindex + 1, nullptr);
  }
  // functor that implements the redirection.
  fvisit_attrs_[tindex] = ::tvm::detail::SelectVisitAttrs<T, TraitName>::VisitAttrs;

  fsequal_reduce_[tindex] = ::tvm::detail::SelectSEqualReduce<T, TraitName>::SEqualReduce;

  fshash_reduce_[tindex] = ::tvm::detail::SelectSHashReduce<T, TraitName>::SHashReduce;

  return Registry(this, tindex);
}
```

Therefore, I just use the `tindex >= fvisit_attrs_.size()` to determine whether it has been registered. And if `fvisit_attrs_[tindex] != nullptr` exists, I will execute `fvisit_attrs_[tindex](self, visitor);` to get its attribute.

@junrushao1994 @comaniac 