### PR TITLE
[Bugfix] Add check to avoid calling back() on an empty container

### DIFF
--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -113,8 +113,9 @@ class IRConvertSSA final : public StmtExprMutator {
   PrimExpr VisitExpr_(const LoadNode* op) final {
     PrimExpr expr = StmtExprMutator::VisitExpr_(op);
     op = expr.as<LoadNode>();
-    if (scope_.count(op->buffer_var.get())) {
-      return Load(op->dtype, scope_[op->buffer_var.get()].back(), op->index, op->predicate);
+    const VarNode* v = op->buffer_var.get();
+    if (scope_.count(v) && !scope_[v].empty()) {
+      return Load(op->dtype, scope_[v].back(), op->index, op->predicate);
     } else {
       return expr;
     }
@@ -122,8 +123,9 @@ class IRConvertSSA final : public StmtExprMutator {
   Stmt VisitStmt_(const StoreNode* op) final {
     Stmt stmt = StmtExprMutator::VisitStmt_(op);
     op = stmt.as<StoreNode>();
-    if (scope_.count(op->buffer_var.get())) {
-      return Store(scope_[op->buffer_var.get()].back(), op->value, op->index, op->predicate);
+    const VarNode* v = op->buffer_var.get();
+    if (scope_.count(v) && !scope_[v].empty()) {
+      return Store(scope_[v].back(), op->value, op->index, op->predicate);
     } else {
       return stmt;
     }

--- a/tests/python/unittest/test_tir_transform_ir_utils.py
+++ b/tests/python/unittest/test_tir_transform_ir_utils.py
@@ -28,7 +28,9 @@ def test_convert_ssa():
     seq = tir.SeqStmt([for_stmt, for_stmt, load])
     func = tir.PrimFunc([], seq)
     mod = tvm.IRModule({"main": func})
-    mod = tir.transform.InjectVirtualThread()(mod)
+    mod = tir.transform.InjectVirtualThread()(
+        mod
+    ) # Use pass InjectVirtualThread to invoke ConvertSSA
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_transform_ir_utils.py
+++ b/tests/python/unittest/test_tir_transform_ir_utils.py
@@ -14,26 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 import tvm
 from tvm import tir
 
-import pytest
 
 def test_convert_ssa():
     zero = tir.const(0)
     nop = tir.Evaluate(zero)
-
-    v = tir.Var('i1', 'int32')
+    v = tir.Var("i1", "int32")
     for_stmt = tir.For(v, zero, zero, tir.ForKind.SERIAL, nop)
-    load = tir.Evaluate(tir.Load('int32', v, zero))
+    load = tir.Evaluate(tir.Load("int32", v, zero))
     seq = tir.SeqStmt([for_stmt, for_stmt, load])
     func = tir.PrimFunc([], seq)
     mod = tvm.IRModule({"main": func})
-
-    """use tir pass InjectVirtualThread to trigger ConvertSSA"""
-    with tvm.transform.PassContext(opt_level=4):
-        tir.transform.InjectVirtualThread()(mod)
+    mod = tir.transform.InjectVirtualThread()(mod)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_transform_ir_utils.py
+++ b/tests/python/unittest/test_tir_transform_ir_utils.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+from tvm import tir
+
+import pytest
+
+def test_convert_ssa():
+    zero = tir.const(0)
+    nop = tir.Evaluate(zero)
+
+    v = tir.Var('i1', 'int32')
+    for_stmt = tir.For(v, zero, zero, tir.ForKind.SERIAL, nop)
+    load = tir.Evaluate(tir.Load('int32', v, zero))
+    seq = tir.SeqStmt([for_stmt, for_stmt, load])
+    func = tir.PrimFunc([], seq)
+    mod = tvm.IRModule({"main": func})
+
+    """use tir pass InjectVirtualThread to trigger ConvertSSA"""
+    with tvm.transform.PassContext(opt_level=4):
+        tir.transform.InjectVirtualThread()(mod)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/unittest/test_tir_transform_ir_utils.py
+++ b/tests/python/unittest/test_tir_transform_ir_utils.py
@@ -30,7 +30,7 @@ def test_convert_ssa():
     mod = tvm.IRModule({"main": func})
     mod = tir.transform.InjectVirtualThread()(
         mod
-    ) # Use pass InjectVirtualThread to invoke ConvertSSA
+    )  # Use pass InjectVirtualThread to invoke ConvertSSA
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is related to an issue [here](https://discuss.tvm.apache.org/t/crash-triggered-by-8-lines-of-tir-code/10808/5). 

In a word, function `PrimExpr VisitExpr_(const LoadNode* op)` forgets to check the size of the vector `scope_[op->buffer_var.get()]`, while calling std::vector::back on an empty container will cause undefined behavior. 

This PR fixed this problem by adding the vector size check before calling `back()`.

To reproduce the bug:
```python
from tvm import tir
import tvm

zero = tir.const(0)
nop = tir.Evaluate(zero)
v = tir.Var('i1', 'int32')
for_stmt = tir.For(v, zero, zero, tir.ForKind.SERIAL, nop)
load = tir.Evaluate(tir.Load('int32', v, zero))
seq = tir.SeqStmt([for_stmt, for_stmt, load])
func = tir.PrimFunc([], seq)

tvm.build(func)
```
