### PR TITLE
[TIR] Fixed LowerThreadallreduce not remapping Store buffer var

### DIFF
--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -75,10 +75,7 @@ def _schedule_softmax(softmax_op, s, outs, tgt):
         for op in ops:
             s = schedule_injective_from_existing(s, op.output(0))
 
-    elif sched_warp_softmax() and softmax_op == outs[0].op:
-        # TODO(masahi): Fix LowerThreadAllreduce pass to remove
-        # softmax_op == outs[0].op condition
-
+    elif sched_warp_softmax():
         # A warp of 32 threads performs a row reduction.
         num_thread = tgt.thread_warp_size
         block_x = te.thread_axis("blockIdx.x")


### PR DESCRIPTION
I hit a bug in `LowerThreadallreduce` that was caused by two issues:
* The `StorageRewrite` pass makes the storage of reduction output `reduce_temp0` reused by the next compute.  See `reduce_temp0[0] = ...` in the following example, which was originally `T_softmax_norm[0] = ...` before  `StorageRewrite`.

Example:
```
... 
tir.tvm_thread_allreduce((uint32)1, normal_reduce_temp0[0], 1, reduce_temp0, threadIdx.x)
if ((threadIdx.x < 16)) {
   reduce_temp0[0] = (T_softmax_exp[threadIdx.x] / reduce_temp0[0])
}
...
```

*  `LowerThreadallreduce` doesn't remap the buffer variable of `Store` destination, unlike `Load`. Therefore, the output of `LowerThreadallreduce` looks something like this. Since the allocation for `reduce_temp0` is removed  by `LowerThreadallreduce`, this results in the use of undefined variable error.
```
...
red_buf0[0] = tir.tvm_warp_shuffle(mask[0], red_buf0[0], 0, 32, 32)
if ((threadIdx.x < 16)) {
   reduce_temp0[0] = (T_softmax_exp[threadIdx.x] / red_buf0[0])        <<< reduce_temp0 is not declared
}
...
```

After this PR, the storage destination is correctly remapped:
```
...
red_buf0[0] = tir.tvm_warp_shuffle(mask[0], red_buf0[0], 0, 32, 32)
if ((threadIdx.x < 16)) {
  red_buf0[0] = (T_softmax_exp[threadIdx.x]/red_buf0[0])
}
...
```