### PR TITLE
[Onnx] Pow support for other types

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1013,10 +1013,6 @@ class ParametricSoftPlus(OnnxOpConverter):
 class Pow(OnnxOpConverter):
     """Operator converter for Pow."""
 
-
-class Pow(OnnxOpConverter):
-    """Operator converter for Pow."""
-
     @classmethod
     def _impl_v13(cls, inputs, attr, params):
         x = inputs[0]

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1013,16 +1013,31 @@ class ParametricSoftPlus(OnnxOpConverter):
 class Pow(OnnxOpConverter):
     """Operator converter for Pow."""
 
+
+class Pow(OnnxOpConverter):
+    """Operator converter for Pow."""
+
     @classmethod
     def _impl_v13(cls, inputs, attr, params):
         x = inputs[0]
         y = inputs[1]
+
         x_type = infer_type(x).checked_type.dtype
+        output_type = x_type
         y_type = infer_type(y).checked_type.dtype
+
+        if not x_type.startswith("float"):
+            x_type = "float32"
+            x = _op.cast(x, x_type)
 
         if x_type != y_type:
             y = _op.cast(y, x_type)
-        return _op.power(x, y)
+
+        # TODO: come up with good default integer pow() func for common backends
+        result = _op.power(x, y)
+        if x_type != output_type:
+            return _op.cast(result, output_type)
+        return result
 
 
 class Prelu(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1010,6 +1010,21 @@ class ParametricSoftPlus(OnnxOpConverter):
         return _op.log(_op.exp(beta * inputs[0]) + _expr.const(1.0)) * alpha
 
 
+class Pow(OnnxOpConverter):
+    """Operator converter for Pow."""
+
+    @classmethod
+    def _impl_v13(cls, inputs, attr, params):
+        x = inputs[0]
+        y = inputs[1]
+        x_type = infer_type(x).checked_type.dtype
+        y_type = infer_type(y).checked_type.dtype
+
+        if x_type != y_type:
+            y = _op.cast(y, x_type)
+        return _op.power(x, y)
+
+
 class Prelu(OnnxOpConverter):
     """Operator converter for Prelu."""
 
@@ -3644,7 +3659,7 @@ def _get_convert_map(opset):
         "Sinh": Renamer("sinh"),
         "Tan": Renamer("tan"),
         "Tanh": Renamer("tanh"),
-        "Pow": Renamer("power"),
+        "Pow": Pow.get_converter(opset),
         "PRelu": Prelu.get_converter(opset),
         "Sigmoid": Renamer("sigmoid"),
         "HardSigmoid": HardSigmoid.get_converter(opset),

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4766,16 +4766,6 @@ unsupported_onnx_tests = [
     # This nllloss test is flaky and sometimes gives NaNs
     # Investigate it here: https://github.com/apache/tvm/issues/8918
     "test_nllloss_NCd1d2d3_none_no_weight_negative_ii",
-    "test_pow_types_float",
-    "test_pow_types_float32_int32",
-    "test_pow_types_float32_int64",
-    "test_pow_types_float32_uint32",
-    "test_pow_types_float32_uint64",
-    "test_pow_types_int",
-    "test_pow_types_int32_float32",
-    "test_pow_types_int32_int32",
-    "test_pow_types_int64_float32",
-    "test_pow_types_int64_int64",
     "test_qlinearmatmul_2D",
     "test_qlinearmatmul_3D",
     "test_range_float_type_positive_delta_expanded",


### PR DESCRIPTION
This updates the onnx spec for pow up to the latest opset. This includes mixing types and having integer pow().

We handle all of this by casting to float since codegen does not support an intrinsic pow operator. It might be worth it to come up with a good default implementation in relay for integer pow but I do not know if this is going to be faster than simply casting.