### PR TITLE
[microTVM][Arduino] Fix Arduino Versions in RVM Build

### DIFF
--- a/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
+++ b/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
@@ -45,7 +45,7 @@ ADAFRUIT_BOARDS_URL="https://adafruit.github.io/arduino-board-index/package_adaf
 ESP32_BOARDS_URL="https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
 SPARKFUN_BOARDS_URL="https://raw.githubusercontent.com/sparkfun/Arduino_Boards/master/IDE_Board_Manager/package_sparkfun_index.json"
 SEEED_BOARDS_URL="https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json"
-SPRESENSE_BOARDS_URL="https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/generic/package_spresense_index.json"
+SPRESENSE_BOARDS_URL="https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/v2.2.1/package_spresense_index.json"
 arduino-cli core update-index --additional-urls $ADAFRUIT_BOARDS_URL,$ESP32_BOARDS_URL,$SPARKFUN_BOARDS_URL,$SEEED_BOARDS_URL,$SPRESENSE_BOARDS_URL
 
 # Install supported cores from those URLS

--- a/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
+++ b/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
@@ -30,9 +30,9 @@ cd ~
 
 sudo apt-get install -y ca-certificates
 
-# Install Arduino-CLI (latest version)
+# Install Arduino-CLI (specific version)
 export PATH="/home/vagrant/bin:$PATH"
-wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s
+wget -O - https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 0.18.3
 
 # Arduino (the CLI and GUI) require the dialout permission for uploading
 sudo usermod -a -G dialout $USER
@@ -49,6 +49,7 @@ SPRESENSE_BOARDS_URL="https://github.com/sonydevworld/spresense-arduino-compatib
 arduino-cli core update-index --additional-urls $ADAFRUIT_BOARDS_URL,$ESP32_BOARDS_URL,$SPARKFUN_BOARDS_URL,$SEEED_BOARDS_URL,$SPRESENSE_BOARDS_URL
 
 # Install supported cores from those URLS
+arduino-cli version
 arduino-cli core install arduino:mbed_nano
 arduino-cli core install arduino:sam
 arduino-cli core install adafruit:samd --additional-urls $ADAFRUIT_BOARDS_URL

--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -391,7 +391,7 @@ def test_command(args):
     providers = args.provider
     provider_passed = {p: False for p in providers}
 
-    release_test_dir = os.path.join(THIS_DIR, f"release-test-{args.platform}")
+    release_test_dir = os.path.join(THIS_DIR, "release-test")
 
     if args.skip_build:
         assert len(providers) == 1, "--skip-build was given, but >1 provider specified"

--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -391,7 +391,7 @@ def test_command(args):
     providers = args.provider
     provider_passed = {p: False for p in providers}
 
-    release_test_dir = os.path.join(THIS_DIR, "release-test")
+    release_test_dir = os.path.join(THIS_DIR, f"release-test-{args.platform}")
 
     if args.skip_build:
         assert len(providers) == 1, "--skip-build was given, but >1 provider specified"


### PR DESCRIPTION
Currently it downloads the latest cli version which causes breaks in RVM build. This PR fixes the version at 0.18.3 which is the version that we have tested the hardware.

Also the SPRESENSE release version was generic which we should fix to 2.2.1 based on the current hack.

cc @areusch @guberti 