### PR TITLE
[microTVM] Zephyr: implement 'west_cmd' server option

### DIFF
--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -399,6 +399,9 @@ class Handler(server.ProjectAPIHandler):
         if options.get("zephyr_base"):
             cmake_args.append(f"-DZEPHYR_BASE:STRING={options['zephyr_base']}")
 
+        if options.get("west_cmd"):
+            cmake_args.append(f"-DWEST={options['west_cmd']}")
+
         cmake_args.append(f"-DBOARD:STRING={options['zephyr_board']}")
 
         check_call(cmake_args, cwd=BUILD_DIR)


### PR DESCRIPTION
Currently Zephyr Project API server lists option 'west_cmd' as an
option available in Zephyr platform by advertising it in PROJECT_OPTIONS
but that option is not used by any API method.

That commit adds that option to the server as a non-required option to
the flash() interface method, allowing the user to specify an
alternative path to the west tool. If that option is not specified the
Zephyr build system takes care of searching for west as a module (so
relying on West being available on Python, i.e. relying on
'python3 -m west').

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>
