### PR TITLE
[TFLite] Bugfix in convert_unpack()

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -2696,7 +2696,7 @@ class OperatorConverter(object):
         # Relay doesn't support 'unpack' operator so we use 'split' & 'squeeze' instead.
         # We have to do 'squeeze' along the split axis but Relay expects
         # squeeze_axis to be either None or List.
-        squeeze_axis = None if unpack_axis == 0 else [unpack_axis]
+        squeeze_axis = [unpack_axis]
 
         # Relay doesn't like TupleWrapper of 1 element so we isolate the case of unpacking
         # a tensor by an axis with len(axis) == 1. For reference see convert_split().

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -3165,6 +3165,7 @@ def test_forward_unpack():
     """UNPACK"""
     _test_unpack(np.array(np.random.uniform(0, 5, (3, 1)), dtype=np.int32), axis=1, num_unpacks=1)
     _test_unpack(np.array(np.random.uniform(0, 5, (3, 4)), dtype=np.float32), axis=0, num_unpacks=3)
+    _test_unpack(np.array(np.random.uniform(0, 5, (1, 3, 4, 1)), dtype=np.float32), axis=0, num_unpacks=1)
     # tflite 1.13 doesn't accept negative axis
     if package_version.parse(tf.VERSION) >= package_version.parse("1.14.0"):
         _test_unpack(


### PR DESCRIPTION
This PR fixes a bug in convert_unpack().
This func currently convert `unpack(input, axis=0, num_packs=1)` into `squeeze(input, axis=None)`.
However, this results in wrong results when `input` has multiple dimensions of size 1.

For example, when `input`'s shape is `(1, 3, 4, 1)` as I added in the test code, a converted relay outputs a tensor which shape is `(3, 4)`.
But, the correct output is `(3, 4, 1)`.

To fix this problem, I made a change to always use `[unpack_axis]`.
