### PR TITLE
[UnitTest][Vulkan] Runnable relay unit tests on Vulkan

### DIFF
--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -81,6 +81,7 @@ def check_grad(
     scale=None,
     mean=0,
     mode="higher_order",
+    target_devices=None,
 ):
     """Perform numerical gradient checking given a relay function.
 
@@ -117,6 +118,11 @@ def check_grad(
 
     mean: float
         The mean of the inputs.
+
+    target_devices: Optional[List[Tuple[tvm.target.Target, tvm.runtime.Device]]]
+        A list of targets/devices on which the gradient should be
+        tested.  If not specified, will default to `tvm.testing.enabled_targets()`.
+
     """
 
     fwd_func = run_infer_type(func)
@@ -133,7 +139,10 @@ def check_grad(
     if test_inputs is None:
         test_inputs = inputs
 
-    for target, dev in enabled_targets():
+    if target_devices is None:
+        target_devices = enabled_targets()
+
+    for target, dev in target_devices:
         # Eval the backward and forward functions
         # TODO(mbs): Evaluate a pair of functions so can share preparation between them.
         bwd_func_compiled = relay.create_executor(device=dev, target=target).evaluate(bwd_func)

--- a/python/tvm/testing/__init__.py
+++ b/python/tvm/testing/__init__.py
@@ -17,6 +17,7 @@
 
 # pylint: disable=redefined-builtin, wildcard-import
 """Utility Python functions for TVM testing"""
+
 from .utils import *
 
 from ._ffi_api import nop, echo, device_test, run_check_signal, object_use_count

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -31,8 +31,6 @@ directory as the test scripts.
 
 """
 
-import collections
-
 import pytest
 import _pytest
 
@@ -67,6 +65,7 @@ def pytest_generate_tests(metafunc):
     """Called once per unit test, modifies/parametrizes it as needed."""
     _parametrize_correlated_parameters(metafunc)
     _auto_parametrize_target(metafunc)
+    _add_target_specific_marks(metafunc)
 
 
 def pytest_collection_modifyitems(config, items):
@@ -100,7 +99,39 @@ def _auto_parametrize_target(metafunc):
 
     """
 
+    if "target" in metafunc.fixturenames:
+        # Check if any explicit parametrizations exist, and apply one
+        # if they do not.  If the function is marked with either
+        # excluded or known failing targets, use these to determine
+        # the targets to be used.
+        parametrized_args = [
+            arg.strip()
+            for mark in metafunc.definition.iter_markers("parametrize")
+            for arg in mark.args[0].split(",")
+        ]
+        if "target" not in parametrized_args:
+            excluded_targets = getattr(metafunc.function, "tvm_excluded_targets", [])
+
+            # Add a parametrize marker instead of calling
+            # metafunc.parametrize so that the parametrize rewriting
+            # can still occur.
+            mark = pytest.mark.parametrize(
+                "target",
+                [
+                    t["target"]
+                    for t in utils._get_targets()
+                    if t["target_kind"] not in excluded_targets
+                ],
+                scope="session",
+            )
+            metafunc.definition.add_marker(mark)
+
+
+def _add_target_specific_marks(metafunc):
+    """Add any target-specific marks to parametrizations over target"""
+
     def update_parametrize_target_arg(
+        mark,
         argnames,
         argvalues,
         *args,
@@ -131,6 +162,16 @@ def _auto_parametrize_target(metafunc):
                     target = param_set[target_i]
                     additional_marks = []
 
+                if mark in metafunc.definition.own_markers:
+                    xfail_targets = getattr(metafunc.function, "tvm_known_failing_targets", [])
+                    target_kind = target.split()[0] if isinstance(target, str) else target.kind.name
+                    if target_kind in xfail_targets:
+                        additional_marks.append(
+                            pytest.mark.xfail(
+                                reason=f'Known failing test for target "{target_kind}"'
+                            )
+                        )
+
                 new_argvalues.append(
                     pytest.param(
                         *param_set, marks=_target_to_requirement(target) + additional_marks
@@ -155,25 +196,7 @@ def _auto_parametrize_target(metafunc):
         # parametrize over targets.  This adds the appropriate
         # @tvm.testing.requires_* markers for each target.
         for mark in metafunc.definition.iter_markers("parametrize"):
-            update_parametrize_target_arg(*mark.args, **mark.kwargs)
-
-        # Check if any explicit parametrizations exist, and apply one
-        # if they do not.  If the function is marked with either
-        # excluded or known failing targets, use these to determine
-        # the targets to be used.
-        parametrized_args = [
-            arg.strip()
-            for mark in metafunc.definition.iter_markers("parametrize")
-            for arg in mark.args[0].split(",")
-        ]
-        if "target" not in parametrized_args:
-            excluded_targets = getattr(metafunc.function, "tvm_excluded_targets", [])
-            xfail_targets = getattr(metafunc.function, "tvm_known_failing_targets", [])
-            metafunc.parametrize(
-                "target",
-                _pytest_target_params(None, excluded_targets, xfail_targets),
-                scope="session",
-            )
+            update_parametrize_target_arg(mark, *mark.args, **mark.kwargs)
 
 
 def _count_num_fixture_uses(items):
@@ -212,43 +235,6 @@ def _remove_global_fixture_definitions(items):
                 delattr(module, name)
 
 
-def _pytest_target_params(targets, excluded_targets=None, xfail_targets=None):
-    # Include unrunnable targets here.  They get skipped by the
-    # pytest.mark.skipif in _target_to_requirement(), showing up as
-    # skipped tests instead of being hidden entirely.
-    if targets is None:
-        if excluded_targets is None:
-            excluded_targets = set()
-
-        if xfail_targets is None:
-            xfail_targets = set()
-
-        target_marks = []
-        for t in utils._get_targets():
-            # Excluded targets aren't included in the params at all.
-            if t["target_kind"] not in excluded_targets:
-
-                # Known failing targets are included, but are marked
-                # as expected to fail.
-                extra_marks = []
-                if t["target_kind"] in xfail_targets:
-                    extra_marks.append(
-                        pytest.mark.xfail(
-                            reason='Known failing test for target "{}"'.format(t["target_kind"])
-                        )
-                    )
-
-                target_marks.append((t["target"], extra_marks))
-
-    else:
-        target_marks = [(target, []) for target in targets]
-
-    return [
-        pytest.param(target, marks=_target_to_requirement(target) + extra_marks)
-        for target, extra_marks in target_marks
-    ]
-
-
 def _target_to_requirement(target):
     if isinstance(target, str):
         target = tvm.target.Target(target)
@@ -256,6 +242,8 @@ def _target_to_requirement(target):
     # mapping from target to decorator
     if target.kind.name == "cuda" and "cudnn" in target.attrs.get("libs", []):
         return utils.requires_cudnn()
+    if target.kind.name == "cuda" and "cublas" in target.attrs.get("libs", []):
+        return utils.requires_cublas()
     if target.kind.name == "cuda":
         return utils.requires_cuda()
     if target.kind.name == "rocm":

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -989,7 +989,7 @@ def known_failing_targets(*args):
     return wraps
 
 
-def parameter(*values, ids=None):
+def parameter(*values, ids=None, by_dict=None):
     """Convenience function to define pytest parametrized fixtures.
 
     Declaring a variable using ``tvm.testing.parameter`` will define a
@@ -1009,15 +1009,22 @@ def parameter(*values, ids=None):
 
     Parameters
     ----------
-    values
+    values : Any
+
        A list of parameter values.  A unit test that accepts this
        parameter as an argument will be run once for each parameter
        given.
 
     ids : List[str], optional
+
        A list of names for the parameters.  If None, pytest will
        generate a name from the value.  These generated names may not
        be readable/useful for composite types such as tuples.
+
+    by_dict : Dict[str, Any]
+
+       A mapping from parameter name to parameter value, to set both the
+       values and ids.
 
     Returns
     -------
@@ -1036,7 +1043,21 @@ def parameter(*values, ids=None):
     >>> def test_using_size(shape):
     >>>     ... # Test code here
 
+    Or
+
+    >>> shape = tvm.testing.parameter(by_dict={'small': (5,10), 'large': (512,1024)})
+    >>> def test_using_size(shape):
+    >>>     ... # Test code here
+
     """
+
+    if by_dict is not None:
+        if values or ids:
+            raise RuntimeError(
+                "Use of the by_dict parameter cannot be used alongside positional arguments"
+            )
+
+        ids, values = zip(*by_dict.items())
 
     # Optional cls parameter in case a parameter is defined inside a
     # class scope.

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1029,7 +1029,7 @@ def parameter(*values, ids=None):
 _parametrize_group = 0
 
 
-def parameters(*value_sets):
+def parameters(*value_sets, ids=None):
     """Convenience function to define pytest parametrized fixtures.
 
     Declaring a variable using tvm.testing.parameters will define a
@@ -1052,10 +1052,17 @@ def parameters(*value_sets):
     Parameters
     ----------
     values : List[tuple]
+
        A list of parameter value sets.  Each set of values represents
        a single combination of values to be tested.  A unit test that
        accepts parameters defined will be run once for every set of
        parameters in the list.
+
+    ids : List[str], optional
+
+       A list of names for the parameter sets.  If None, pytest will
+       generate a name from each parameter set.  These generated names may
+       not be readable/useful for composite types such as tuples.
 
     Returns
     -------
@@ -1085,6 +1092,7 @@ def parameters(*value_sets):
 
         fixture_func.parametrize_group = parametrize_group
         fixture_func.parametrize_values = param_values
+        fixture_func.parametrize_ids = ids
         outputs.append(pytest.fixture(fixture_func))
 
     return outputs

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -594,6 +594,27 @@ def requires_cudnn(*args):
     return _compose(args, requirements)
 
 
+def requires_cublas(*args):
+    """Mark a test as requiring the cuBLAS library.
+
+    This also marks the test as requiring a cuda gpu.
+
+    Parameters
+    ----------
+    f : function
+        Function to mark
+    """
+
+    requirements = [
+        pytest.mark.skipif(
+            tvm.get_global_func("tvm.contrib.cublas.matmul", True),
+            reason="cuDNN library not enabled",
+        ),
+        *requires_cuda(),
+    ]
+    return _compose(args, requirements)
+
+
 def requires_nvptx(*args):
     """Mark a test as requiring the NVPTX compilation on the CUDA runtime
 

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -155,6 +155,10 @@ def parametrize_aot_options(test):
     skip_i386 = pytest.mark.skipif(
         platform.machine() == "i686", reason="Reference system unavailable in i386 container"
     )
+    requires_arm_eabi = pytest.mark.skipif(
+        shutil.which("arm-none-eabi-gcc") is None, reason="ARM embedded toolchain unavailable"
+    )
+
     interface_api = ["packed", "c"]
     use_unpacked_api = [True, False]
     test_runner = [AOT_DEFAULT_RUNNER, AOT_CORSTONE300_RUNNER]
@@ -178,7 +182,7 @@ def parametrize_aot_options(test):
 
     # Skip reference system tests if running in i386 container
     marked_combinations = map(
-        lambda parameters: pytest.param(*parameters, marks=skip_i386)
+        lambda parameters: pytest.param(*parameters, marks=[skip_i386, requires_arm_eabi])
         if parameters[2] == AOT_CORSTONE300_RUNNER
         else parameters,
         valid_combinations,

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -372,6 +372,53 @@ def test_any_shape_of():
     check_result([data], mod, np.array(3).astype("int64"))
 
 
+class TestAnyReduce:
+    config = {
+        "argmax": (relay.argmax, any_dims(3), None, False, False, (3, 4, 5), ()),
+        "argmin": (relay.argmin, any_dims(4), 1, False, True, (3, 4, 5, 6), (3, 1, 5, 6)),
+        "all": (relay.all, any_dims(3), (1, 2), True, False, (3, 4, 5), (4, 5)),
+        "max": (relay.max, any_dims(4), -1, True, True, (3, 4, 5, 6), (1, 1, 1, 6)),
+        "min": (relay.min, any_dims(3), (0, 1), False, False, (4, 5, 6), (6,)),
+        "prod": (relay.prod, any_dims(4), 2, True, True, (3, 4, 5, 6), (1, 1, 5, 1)),
+        "mean": (relay.mean, any_dims(2), 0, False, False, (1, 2), (2,)),
+        "variance": (relay.variance, any_dims(5), (2, 4), False, False, (3, 4, 5, 6, 7), (3, 4, 6)),
+    }
+
+    (
+        reduce_op,
+        data_shape,
+        axis,
+        exclude,
+        keepdims,
+        static_data_shape,
+        ref_out_shape,
+    ) = tvm.testing.parameters(*config.values(), ids=config.keys())
+
+    def test_any_reduce(
+        self,
+        target,
+        dev,
+        reduce_op,
+        data_shape,
+        axis,
+        exclude,
+        keepdims,
+        static_data_shape,
+        ref_out_shape,
+    ):
+        target = tvm.target.Target(target)
+        if target.kind.name == "vulkan" and reduce_op == relay.all:
+            pytest.xfail("Known failing test case for vulkan runtime")
+
+        mod = tvm.IRModule()
+        dtype = "bool" if reduce_op == relay.all else "float32"
+        data = relay.var("data", shape=data_shape, dtype=dtype)
+        y = reduce_op(data, axis, keepdims, exclude)
+        mod["main"] = relay.Function([data], y)
+        data_np = np.random.uniform(size=static_data_shape).astype(dtype)
+        check_result([data_np], mod, ref_out_shape, assert_shape=True, targets=[(target, dev)])
+
+
 def verify_any_reduce(
     reduce_op, data_shape, axis, exclude, keepdims, static_data_shape, ref_out_shape
 ):
@@ -579,66 +626,58 @@ def test_any_conv2d():
     )
 
 
-def verify_any_conv2d_NCHWc(
-    data_shape,
-    kernel_shape,
-    strides,
-    padding,
-    dilation,
-    data_layout,
-    kernel_layout,
-    out_layout,
-    static_data_shape,
-    ref_out_shape,
-):
-    mod = tvm.IRModule()
-    dtype = "float32"
-    data = relay.var("data", shape=data_shape, dtype=dtype)
-    kernel = relay.var("kernel", shape=kernel_shape, dtype=dtype)
-    y = relay.nn.contrib_conv2d_nchwc(
-        data,
-        kernel,
+class TestAnyConv2dNCHWc:
+    data_shape = tvm.testing.parameter((relay.Any(), 8, 224, 224, 8))
+    kernel_shape = tvm.testing.parameter((8, 8, 3, 3, 8, 8))
+    strides = tvm.testing.parameter((1, 1))
+    padding = tvm.testing.parameter((1, 1))
+    data_layout = tvm.testing.parameter("NCHW8c")
+    kernel_layout = tvm.testing.parameter("OIHW8i8o")
+    out_layout = tvm.testing.parameter("NCHW8c")
+
+    dilation, static_data_shape, ref_out_shape = tvm.testing.parameters(
+        ((1, 1), (1, 8, 224, 224, 8), (1, 8, 224, 224, 8)),
+        ((2, 2), (2, 8, 224, 224, 8), (2, 8, 222, 222, 8)),
+    )
+
+    @tvm.testing.known_failing_targets("cuda", "vulkan")
+    def test_any_conv2d_NCHWc(
+        self,
+        target,
+        dev,
+        data_shape,
+        kernel_shape,
         strides,
         padding,
         dilation,
-        kernel_size=kernel_shape[2:4],
-        channels=kernel_shape[0] * kernel_shape[-1],
-        data_layout=data_layout,
-        kernel_layout=kernel_layout,
-        out_layout=out_layout,
-    )
-    mod["main"] = relay.Function([data, kernel], y)
-    data_np = np.random.uniform(size=static_data_shape).astype(dtype)
-    kernel_np = np.random.uniform(size=kernel_shape).astype(dtype)
-    check_result([data_np, kernel_np], mod, ref_out_shape, assert_shape=True)
-
-
-# TODO(@kevinthesun): Support dynamic input height and width.
-def test_any_conv2d_NCHWc():
-    verify_any_conv2d_NCHWc(
-        (relay.Any(), 8, 224, 224, 8),
-        (8, 8, 3, 3, 8, 8),
-        (1, 1),
-        (1, 1),
-        (1, 1),
-        "NCHW8c",
-        "OIHW8i8o",
-        "NCHW8c",
-        (1, 8, 224, 224, 8),
-        (1, 8, 224, 224, 8),
-    )
-    verify_any_conv2d_NCHWc(
-        (relay.Any(), 8, 224, 224, 8),
-        (8, 8, 3, 3, 8, 8),
-        (1, 1),
-        (1, 1),
-        (2, 2),
-        "NCHW8c",
-        "OIHW8i8o",
-        "NCHW8c",
-        (2, 8, 224, 224, 8),
-        (2, 8, 222, 222, 8),
-    )
+        data_layout,
+        kernel_layout,
+        out_layout,
+        static_data_shape,
+        ref_out_shape,
+    ):
+        mod = tvm.IRModule()
+        dtype = "float32"
+        data = relay.var("data", shape=data_shape, dtype=dtype)
+        kernel = relay.var("kernel", shape=kernel_shape, dtype=dtype)
+        y = relay.nn.contrib_conv2d_nchwc(
+            data,
+            kernel,
+            strides,
+            padding,
+            dilation,
+            kernel_size=kernel_shape[2:4],
+            channels=kernel_shape[0] * kernel_shape[-1],
+            data_layout=data_layout,
+            kernel_layout=kernel_layout,
+            out_layout=out_layout,
+        )
+        mod["main"] = relay.Function([data, kernel], y)
+        data_np = np.random.uniform(size=static_data_shape).astype(dtype)
+        kernel_np = np.random.uniform(size=kernel_shape).astype(dtype)
+        check_result(
+            [data_np, kernel_np], mod, ref_out_shape, assert_shape=True, targets=[(target, dev)]
+        )
 
 
 def verify_any_conv1d_transpose_ncw(
@@ -883,135 +922,149 @@ def test_any_batch_flatten():
     check_result([data_np], mod, ref_out_shape, assert_shape=True)
 
 
-def verify_any_dense(
-    data_shape,
-    weight_shape,
-    units,
-    static_data_shape,
-    static_weight_shape,
-    ref_out_shape,
-    use_cublas=False,
-):
-    mod = tvm.IRModule()
-    dtype = "float32"
-    data = relay.var("data", shape=data_shape, dtype=dtype)
-    weight = relay.var("weight", shape=weight_shape, dtype=dtype)
-    y = relay.nn.dense(data, weight, units)
-    mod["main"] = relay.Function([data, weight], y)
-    data_np = np.random.uniform(size=static_data_shape).astype(dtype)
-    weight_np = np.random.uniform(size=static_weight_shape).astype(dtype)
-
-    targets = None
-    if use_cublas and tvm.get_global_func("tvm.contrib.cublas.matmul", True):
-        targets = [("cuda -libs=cublas", tvm.cuda(0))]
-
-    check_result([data_np, weight_np], mod, ref_out_shape, assert_shape=True, targets=targets)
-
-
 # TODO(tvm-team) Fix dense schedule
-# @tvm.testing.uses_gpu
-def test_any_dense():
-    verify_any_dense(any_dims(2), any_dims(2), None, (4, 16), (8, 16), (4, 8))
-    verify_any_dense(any_dims(2), (50, relay.Any()), 50, (4, 40), (50, 40), (4, 50))
-
-
-@tvm.testing.uses_gpu
-def test_any_dense_dynamic_batch():
-    verify_any_dense((relay.Any(), 40), (50, 40), 50, (4, 40), (50, 40), (4, 50))
-    verify_any_dense((relay.Any(), 40), (50, 40), 50, (4, 40), (50, 40), (4, 50), use_cublas=True)
-
-
-def verify_any_batch_matmul(
-    x_shape,
-    y_shape,
-    out_shape,
-    x_var_shape,
-    y_var_shape,
-    dtype="float32",
-    trans_x=False,
-    trans_y=True,
-):
-    x = relay.var("x", relay.TensorType(x_var_shape, dtype))
-    y = relay.var("y", relay.TensorType(y_var_shape, dtype))
-    z = relay.nn.batch_matmul(x, y, transpose_a=trans_x, transpose_b=trans_y)
-
-    func = relay.Function([x, y], z)
-    x_np = np.random.uniform(size=x_shape).astype(dtype)
-    y_np = np.random.uniform(size=y_shape).astype(dtype)
-    z_np = tvm.topi.testing.batch_matmul(x_np, y_np, trans_x=trans_x, trans_y=trans_y)
-
-    for target, dev in tvm.testing.enabled_targets():
-        for kind in ["vm", "debug"]:
-            mod = tvm.ir.IRModule.from_expr(func)
-            z = relay.create_executor(kind, mod=mod, device=dev, target=target).evaluate()(
-                x_np, y_np
-            )
-            tvm.testing.assert_allclose(z.numpy(), z_np, rtol=1e-5)
-
-
-# TODO(mbrookhart): enable once VM supports heterogenous execution
-# @tvm.testing.uses_gpu
-def test_any_batch_matmul():
-    verify_any_batch_matmul((1, 16, 32), (1, 16, 32), (1, 16, 16), (1, 16, 32), (relay.Any(),) * 3)
-    verify_any_batch_matmul((5, 16, 32), (5, 16, 32), (5, 16, 16), (5, 16, 32), (relay.Any(),) * 3)
-    verify_any_batch_matmul((5, 16, 32), (5, 20, 32), (5, 16, 20), (5, 16, 32), (relay.Any(),) * 3)
-    verify_any_batch_matmul(
-        (30, 16, 32), (30, 20, 32), (30, 16, 20), (30, 16, 32), (relay.Any(),) * 3
+@tvm.testing.known_failing_targets("cuda", "vulkan")
+class TestAnyDense:
+    (
+        data_shape,
+        weight_shape,
+        units,
+        static_data_shape,
+        static_weight_shape,
+        ref_out_shape,
+    ) = tvm.testing.parameters(
+        (any_dims(2), any_dims(2), None, (4, 16), (8, 16), (4, 8)),
+        (any_dims(2), (50, relay.Any()), 50, (4, 40), (50, 40), (4, 50)),
     )
 
-    verify_any_batch_matmul(
-        (1, 16, 32), (1, 16, 32), (1, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32)
-    )
-    verify_any_batch_matmul(
-        (5, 16, 32), (5, 16, 32), (5, 16, 16), (relay.Any(), 16, 32), (relay.Any(), 16, 32)
-    )
-    verify_any_batch_matmul(
-        (5, 16, 32), (5, 20, 32), (5, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32)
-    )
-    verify_any_batch_matmul(
-        (30, 16, 32), (30, 20, 32), (30, 16, 20), (relay.Any(), 16, 32), (relay.Any(), 20, 32)
+    @tvm.testing.known_failing_targets("cuda", "vulkan")
+    def test_any_dense(
+        self,
+        target,
+        dev,
+        data_shape,
+        weight_shape,
+        units,
+        static_data_shape,
+        static_weight_shape,
+        ref_out_shape,
+    ):
+        mod = tvm.IRModule()
+        dtype = "float32"
+        data = relay.var("data", shape=data_shape, dtype=dtype)
+        weight = relay.var("weight", shape=weight_shape, dtype=dtype)
+        y = relay.nn.dense(data, weight, units)
+        mod["main"] = relay.Function([data, weight], y)
+        data_np = np.random.uniform(size=static_data_shape).astype(dtype)
+        weight_np = np.random.uniform(size=static_weight_shape).astype(dtype)
+
+        check_result(
+            [data_np, weight_np], mod, ref_out_shape, assert_shape=True, targets=[(target, dev)]
+        )
+
+    @tvm.testing.parametrize_targets("cuda -libs=cublas")
+    @tvm.testing.known_failing_targets("cuda", "vulkan")
+    def test_any_dense_cublas(
+        self,
+        target,
+        dev,
+        data_shape,
+        weight_shape,
+        units,
+        static_data_shape,
+        static_weight_shape,
+        ref_out_shape,
+    ):
+
+        self.test_any_dense(
+            target,
+            dev,
+            data_shape,
+            weight_shape,
+            units,
+            static_data_shape,
+            static_weight_shape,
+            ref_out_shape,
+        )
+
+
+class TestAnyBatchMatmul:
+    dtype = tvm.testing.parameter("float32")
+    executor_kind = tvm.testing.parameter("vm", "debug")
+
+    (x_shape, y_shape) = tvm.testing.parameters(
+        ((1, 16, 32), (1, 32, 16)),
+        ((5, 16, 32), (5, 32, 16)),
+        ((5, 16, 32), (5, 32, 20)),
+        ((30, 16, 32), (30, 32, 20)),
     )
 
-    verify_any_batch_matmul(
-        (1, 32, 16), (1, 16, 32), (1, 16, 16), (1, 32, 16), (relay.Any(),) * 3, trans_x=True
+    # any_x = tvm.testing.parameter("none", "batch")
+    # any_y = tvm.testing.parameter("none", "batch", "all")
+
+    any_x, any_y = tvm.testing.parameters(
+        ("none", "batch"), ("none", "all"), ("batch", "none"), ("batch", "batch"), ("batch", "all")
     )
-    verify_any_batch_matmul(
-        (5, 16, 32), (5, 32, 16), (5, 16, 16), (5, 16, 32), (relay.Any(),) * 3, trans_y=False
-    )
-    verify_any_batch_matmul(
-        (5, 32, 16),
-        (5, 32, 20),
-        (5, 16, 20),
-        (5, 32, 16),
-        (relay.Any(),) * 3,
-        trans_x=True,
-        trans_y=False,
-    )
-    verify_any_batch_matmul(
-        (1, 32, 16),
-        (1, 16, 32),
-        (1, 16, 16),
-        (relay.Any(), 32, 16),
-        (relay.Any(), 16, 32),
-        trans_x=True,
-    )
-    verify_any_batch_matmul(
-        (5, 16, 32),
-        (5, 32, 16),
-        (5, 16, 16),
-        (relay.Any(), 16, 32),
-        (relay.Any(), 32, 16),
-        trans_y=False,
-    )
-    verify_any_batch_matmul(
-        (5, 32, 16),
-        (5, 32, 20),
-        (5, 16, 20),
-        (relay.Any(), 32, 16),
-        (relay.Any(), 32, 20),
-        trans_x=True,
-        trans_y=False,
-    )
+
+    transpose_x = tvm.testing.parameter(True, False)
+    transpose_y = tvm.testing.parameter(True, False)
+
+    @tvm.testing.fixture
+    def x_var_shape(self, x_shape, any_x):
+        if any_x == "none":
+            return x_shape
+        elif any_x == "batch":
+            return tuple(relay.Any() if i == 0 else size for i, size in enumerate(x_shape))
+        elif any_x == "all":
+            return tuple(relay.Any() for _ in x_shape)
+
+    @tvm.testing.fixture
+    def y_var_shape(self, y_shape, any_y):
+        if any_y == "none":
+            return y_shape
+        elif any_y == "batch":
+            return tuple(relay.Any() if i == 0 else size for i, size in enumerate(y_shape))
+        elif any_y == "all":
+            return tuple(relay.Any() for _ in y_shape)
+
+    @tvm.testing.known_failing_targets("cuda", "vulkan")
+    def test_any_batch_matmul(
+        self,
+        target,
+        dev,
+        x_shape,
+        y_shape,
+        any_x,
+        any_y,
+        x_var_shape,
+        y_var_shape,
+        transpose_x,
+        transpose_y,
+        executor_kind,
+        dtype,
+    ):
+        if transpose_x:
+            x_shape = (x_shape[0], x_shape[2], x_shape[1])
+            x_var_shape = (x_var_shape[0], x_var_shape[2], x_var_shape[1])
+
+        if transpose_y:
+            y_shape = (y_shape[0], y_shape[2], y_shape[1])
+            y_var_shape = (y_var_shape[0], y_var_shape[2], y_var_shape[1])
+
+        x = relay.var("x", relay.TensorType(x_var_shape, dtype))
+        y = relay.var("y", relay.TensorType(y_var_shape, dtype))
+        z = relay.nn.batch_matmul(x, y, transpose_a=transpose_x, transpose_b=transpose_y)
+
+        func = relay.Function([x, y], z)
+        x_np = np.random.uniform(size=x_shape).astype(dtype)
+        y_np = np.random.uniform(size=y_shape).astype(dtype)
+        z_np = tvm.topi.testing.batch_matmul(x_np, y_np, trans_x=transpose_x, trans_y=transpose_y)
+
+        mod = tvm.ir.IRModule.from_expr(func)
+        z = relay.create_executor(executor_kind, mod=mod, device=dev, target=target).evaluate()(
+            x_np, y_np
+        )
+        tvm.testing.assert_allclose(z.numpy(), z_np, rtol=1e-5)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_grad_level1.py
+++ b/tests/python/relay/test_op_grad_level1.py
@@ -14,15 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
+
 import numpy as np
 import pytest
 
 import tvm
-from tvm import te
-from tvm import relay
+import tvm.testing
+
+from tvm import te, relay
 from tvm.relay.testing import check_grad, run_infer_type
 from tvm.relay.transform import gradient
-import tvm.testing
 
 
 def sigmoid(x):
@@ -36,131 +38,179 @@ def relu(x):
     return x_copy
 
 
-@tvm.testing.uses_gpu
-def test_unary_op():
-    def check_single_op(opfunc, ref, dtype):
-        shape = (10, 4)
+class TestUnaryOp:
+    config = {
+        "log": (tvm.relay.log, lambda x, g: g * (1 / x)),
+        "exp": (tvm.relay.exp, lambda x, g: g * np.exp(x)),
+        "sigmoid": (tvm.relay.sigmoid, lambda x, g: g * sigmoid(x) * (1 - sigmoid(x))),
+        "tanh": (tvm.relay.tanh, lambda x, g: g * (1 - np.tanh(x) * np.tanh(x))),
+        "sqrt": (tvm.relay.sqrt, lambda x, g: g * 0.5 * np.power(x, -0.5)),
+        "abs": (tvm.relay.abs, lambda x, g: np.where(x < 0, -g, g)),
+        "relu": (relay.nn.relu, lambda x, g: np.where(x < 0, np.zeros_like(x), g)),
+        "erf": (tvm.relay.erf, lambda x, g: g * (2.0 / (np.pi ** (0.5)) * np.exp(-x * x))),
+        "cos": (tvm.relay.cos, lambda x, g: g * -1.0 * np.sin(x)),
+        "sin": (tvm.relay.sin, lambda x, g: g * np.cos(x)),
+        "tan": (tvm.relay.tan, lambda x, g: g * (1.0 / (np.cos(x) ** 2))),
+        "atan": (tvm.relay.atan, lambda x, g: g * (1 / (1 + np.power(x, 2.0)))),
+        "log2": (tvm.relay.log2, lambda x, g: g * (1 / (np.log(2) * x))),
+        "log10": (tvm.relay.log10, lambda x, g: g * (1 / (np.log(10) * x))),
+        "cosh": (tvm.relay.cosh, lambda x, g: g * (np.sinh(x))),
+        "sinh": (tvm.relay.sinh, lambda x, g: g * (np.cosh(x))),
+        "asin": (tvm.relay.asin, lambda x, g: g * (1.0 / (1.0 - x ** 2) ** (1.0 / 2.0))),
+        "acos": (tvm.relay.acos, lambda x, g: g * (-1.0 / (1.0 - x ** 2.0) ** (1.0 / 2.0))),
+        "acosh": (tvm.relay.acosh, lambda x, g: g * (1.0 / (x ** 2 - 1.0) ** (1.0 / 2.0))),
+        "asinh": (tvm.relay.asinh, lambda x, g: g * (1.0 / (x ** 2 + 1.0) ** (1.0 / 2.0))),
+        "atanh": (tvm.relay.atanh, lambda x, g: g * (-1.0 / (x ** 2 - 1.0))),
+    }
+
+    relay_op, ref_func = tvm.testing.parameters(*config.values(), ids=config.keys())
+    dtype = tvm.testing.parameter("float32", "float64")
+    shape = tvm.testing.parameter((10, 4))
+
+    def test_op(self, target, dev, relay_op, ref_func, shape, dtype):
+
+        target = tvm.target.Target(target)
+        if target.kind.name == "vulkan":
+
+            known_breaks = {
+                "float32": [
+                    tvm.relay.erf,
+                    tvm.relay.tan,
+                    tvm.relay.atan,
+                    tvm.relay.log10,
+                    tvm.relay.cosh,
+                    tvm.relay.sinh,
+                    tvm.relay.asin,
+                    tvm.relay.acos,
+                    tvm.relay.acosh,
+                    tvm.relay.asinh,
+                    tvm.relay.atanh,
+                ],
+                "float64": [
+                    tvm.relay.log,
+                    tvm.relay.exp,
+                    tvm.relay.sigmoid,
+                    tvm.relay.tanh,
+                    tvm.relay.sqrt,
+                    tvm.relay.erf,
+                    tvm.relay.cos,
+                    tvm.relay.sin,
+                    tvm.relay.tan,
+                    tvm.relay.atan,
+                    tvm.relay.log2,
+                    tvm.relay.log10,
+                    tvm.relay.cosh,
+                    tvm.relay.sinh,
+                    tvm.relay.asin,
+                    tvm.relay.acos,
+                    tvm.relay.acosh,
+                    tvm.relay.asinh,
+                    tvm.relay.atanh,
+                ],
+            }
+
+            if relay_op in known_breaks[dtype]:
+                pytest.xfail(f"{dtype} {relay_op.__name__} not yet supported on Vulkan runtime")
+
         tp = relay.TensorType(shape, dtype)
         x = relay.var("x", tp)
         g = relay.var("g", tp)
-        y = opfunc(x) * g
+        y = relay_op(x) * g
 
-        if ref is not None:
-            data = np.random.rand(*shape).astype(dtype)
-            grad_in = np.random.rand(*shape).astype(dtype)
-            ref_grad = ref(data, grad_in)
-            fwd_func = relay.Function([x, g], y)
-            fwd_func = run_infer_type(fwd_func)
-            bwd_func = run_infer_type(gradient(fwd_func))
+        fwd_func = relay.Function([x, g], y)
+        fwd_func = run_infer_type(fwd_func)
+        bwd_func = run_infer_type(gradient(fwd_func))
 
-            for target, dev in tvm.testing.enabled_targets():
-                op_res, (op_grad, _) = relay.create_executor(device=dev, target=target).evaluate(
-                    bwd_func
-                )(data, grad_in)
-                np.testing.assert_allclose(op_grad.numpy(), ref_grad, rtol=0.01)
+        data_in = np.random.rand(*shape).astype(dtype)
+        grad_in = np.random.rand(*shape).astype(dtype)
+        ref_grad_out = ref_func(data_in, grad_in)
 
-    for opfunc, ref in [
-        (tvm.relay.log, lambda x, g: g * (1 / x)),
-        (tvm.relay.exp, lambda x, g: g * np.exp(x)),
-        (tvm.relay.sigmoid, lambda x, g: g * sigmoid(x) * (1 - sigmoid(x))),
-        (tvm.relay.tanh, lambda x, g: g * (1 - np.tanh(x) * np.tanh(x))),
-        (tvm.relay.sqrt, lambda x, g: g * 0.5 * np.power(x, -0.5)),
-        (tvm.relay.abs, lambda x, g: np.where(x < 0, -g, g)),
-        (relay.nn.relu, lambda x, g: np.where(x < 0, np.zeros_like(x), g)),
-        (tvm.relay.erf, lambda x, g: g * (2.0 / (np.pi ** (0.5)) * np.exp(-x * x))),
-        (tvm.relay.cos, lambda x, g: g * -1.0 * np.sin(x)),
-        (tvm.relay.sin, lambda x, g: g * np.cos(x)),
-        (tvm.relay.tan, lambda x, g: g * (1.0 / (np.cos(x) ** 2))),
-        (tvm.relay.atan, lambda x, g: g * (1 / (1 + np.power(x, 2.0)))),
-        (tvm.relay.log2, lambda x, g: g * (1 / (np.log(2) * x))),
-        (tvm.relay.log10, lambda x, g: g * (1 / (np.log(10) * x))),
-        (tvm.relay.cosh, lambda x, g: g * (np.sinh(x))),
-        (tvm.relay.sinh, lambda x, g: g * (np.cosh(x))),
-        (tvm.relay.asin, lambda x, g: g * (1.0 / (1.0 - x ** 2) ** (1.0 / 2.0))),
-        (tvm.relay.acos, lambda x, g: g * (-1.0 / (1.0 - x ** 2.0) ** (1.0 / 2.0))),
-        (tvm.relay.acosh, lambda x, g: g * (1.0 / (x ** 2 - 1.0) ** (1.0 / 2.0))),
-        (tvm.relay.asinh, lambda x, g: g * (1.0 / (x ** 2 + 1.0) ** (1.0 / 2.0))),
-        (tvm.relay.atanh, lambda x, g: g * (-1.0 / (x ** 2 - 1.0))),
-    ]:
-        for dtype in ("float32", "float64"):
-            check_single_op(opfunc, ref, dtype)
+        op_res, (op_grad, _) = relay.create_executor(device=dev, target=target).evaluate(bwd_func)(
+            data_in, grad_in
+        )
+        np.testing.assert_allclose(op_grad.numpy(), ref_grad_out, rtol=0.01)
 
 
-@tvm.testing.uses_gpu
-def test_binary_op():
-    def inst(vars, sh):
-        return [vars.get(s, s) for s in sh]
+class TestBinaryOp:
+    config = {
+        "add": (relay.add, lambda x, y: [np.ones_like(x), np.ones_like(y)]),
+        "subtract": (relay.subtract, lambda x, y: [np.ones_like(x), -np.ones_like(y)]),
+        "multiply": (relay.multiply, lambda x, y: [y, x]),
+        "divide": (relay.divide, lambda x, y: [1 / y, -x / (y ** 2)]),
+    }
 
-    def check_binary_op(opfunc, ref, dtype):
-        s = (5, 10, 5)
-        t = relay.TensorType((5, 10, 5), dtype=dtype)
+    relay_op, ref_func = tvm.testing.parameters(*config.values(), ids=config.keys())
+    dtype = tvm.testing.parameter("float32", "float64")
+    shape = tvm.testing.parameter((5, 10, 5))
+
+    def test_binary_op(self, target, dev, relay_op, ref_func, shape, dtype):
+        t = relay.TensorType(shape, dtype=dtype)
         x = relay.var("x", t)
         y = relay.var("y", t)
-        z = opfunc(x, y)
+        z = relay_op(x, y)
 
-        x_data = np.random.rand(*s).astype(t.dtype)
-        y_data = np.random.rand(*s).astype(t.dtype)
-        ref_grad0, ref_grad1 = ref(x_data, y_data)
+        x_data = np.random.rand(*shape).astype(t.dtype)
+        y_data = np.random.rand(*shape).astype(t.dtype)
+        ref_grad0, ref_grad1 = ref_func(x_data, y_data)
         fwd_func = relay.Function([x, y], z)
         fwd_func = run_infer_type(fwd_func)
         bwd_func = run_infer_type(gradient(fwd_func))
 
-        for target, dev in tvm.testing.enabled_targets():
-            op_res, (op_grad0, op_grad1) = relay.create_executor(
-                device=dev, target=target
-            ).evaluate(bwd_func)(x_data, y_data)
-            np.testing.assert_allclose(op_grad0.numpy(), ref_grad0, rtol=0.01)
-            np.testing.assert_allclose(op_grad1.numpy(), ref_grad1, rtol=0.01)
-
-    for opfunc, ref in [
-        (relay.add, lambda x, y: [np.ones_like(x), np.ones_like(y)]),
-        (relay.subtract, lambda x, y: [np.ones_like(x), -np.ones_like(y)]),
-        (relay.multiply, lambda x, y: [y, x]),
-        (relay.divide, lambda x, y: [1 / y, -x / (y ** 2)]),
-    ]:
-        for dtype in ("float32", "float64"):
-            check_binary_op(opfunc, ref, dtype)
+        op_res, (op_grad0, op_grad1) = relay.create_executor(device=dev, target=target).evaluate(
+            bwd_func
+        )(x_data, y_data)
+        np.testing.assert_allclose(op_grad0.numpy(), ref_grad0, rtol=0.01)
+        np.testing.assert_allclose(op_grad1.numpy(), ref_grad1, rtol=0.01)
 
 
-def test_softmax_grad():
+def test_softmax_grad(target, dev):
+    target = tvm.target.Target(target)
+    if target.kind.name == "vulkan":
+        pytest.xfail("Known failure on vulkan")
+
     data = relay.var("data", relay.TensorType((1, 16), "float64"))
     fwd_func = relay.Function([data], relay.nn.softmax(data))
-    check_grad(fwd_func, scale=1)
+    check_grad(fwd_func, scale=1, target_devices=[(target, dev)])
 
 
-def test_log_softmax_grad():
+def test_log_softmax_grad(target, dev):
+    target = tvm.target.Target(target)
+    if target.kind.name == "vulkan":
+        pytest.xfail("Known failure on vulkan")
+
     data = relay.var("data", relay.TensorType((2, 16), "float64"))
     fwd_func = relay.Function([data], relay.nn.log_softmax(data))
-    check_grad(fwd_func, scale=1)
+    check_grad(fwd_func, scale=1, target_devices=[(target, dev)])
 
 
-def verify_bias_add(d_shape, b_shape, axis=1):
-    data = relay.var("data", relay.TensorType(d_shape, "float32"))
-    bias = relay.var("bias", relay.TensorType(b_shape, "float32"))
-    fwd_func = relay.Function([data, bias], relay.nn.bias_add(data, bias, axis=axis))
-    check_grad(fwd_func)
+class TestBiasAddGrad:
+    d_shape, b_shape, axis = tvm.testing.parameters(
+        ((1, 16), (16,), 1),
+        ((1, 8, 2, 2), (8,), 1),
+        ((1, 2, 2, 8), (8,), 3),
+        ((4, 8), (8,), 1),
+    )
+
+    def test_bias_add(self, target, dev, d_shape, b_shape, axis):
+        data = relay.var("data", relay.TensorType(d_shape, "float32"))
+        bias = relay.var("bias", relay.TensorType(b_shape, "float32"))
+        fwd_func = relay.Function([data, bias], relay.nn.bias_add(data, bias, axis=axis))
+        check_grad(fwd_func, target_devices=[(target, dev)])
 
 
-def test_bias_add_grad():
-    verify_bias_add((1, 16), (16,))
-    verify_bias_add((1, 8, 2, 2), (8,))
-    verify_bias_add((1, 2, 2, 8), (8,), 3)
-    verify_bias_add((4, 8), (8,))
-
-
-def test_expand_dims_grad():
+def test_expand_dims_grad(target, dev):
     data = relay.var("data", shape=(2, 3), dtype="float64")
     fwd_func = relay.Function([data], relay.expand_dims(data, axis=1, num_newaxis=2))
-    check_grad(fwd_func)
+    check_grad(fwd_func, target_devices=[(target, dev)])
 
 
-def test_concatenate_grad():
+def test_concatenate_grad(target, dev):
     x = relay.var("x", shape=(2, 2, 5))
     y = relay.var("y", shape=(2, 1, 5))
     z = relay.var("z", shape=(2, 4, 5))
     fwd_func = relay.Function([x, y, z], relay.concatenate([x, y, z], axis=1))
-    check_grad(fwd_func)
+    check_grad(fwd_func, target_devices=[(target, dev)])
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/relay/test_op_grad_level10.py
+++ b/tests/python/relay/test_op_grad_level10.py
@@ -14,35 +14,52 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
+import sys
+
 import numpy as np
+import pytest
+
+import tvm
+import tvm.testing
 
 from tvm import relay
 from tvm.relay.testing import check_grad
 
 
-def test_cross_entropy_grad():
-    for dtype in ("float32", "float64"):
-        x = relay.var("x", shape=(2, 5), dtype=dtype)
-        y = relay.var("y", shape=(2, 5), dtype=dtype)
-        check_grad(
-            relay.Function([x, y], relay.op.nn.cross_entropy(x, y)), eps=0.01, scale=0.1, mean=1
-        )
+index_dtype = tvm.testing.parameter("int32", "int64")
+val_dtype = tvm.testing.parameter("float32", "float64")
 
 
-def test_cross_entropy_with_logits_grad():
-    for dtype in ("float32", "float64"):
-        x = relay.var("x", shape=(2, 5), dtype=dtype)
-        y = relay.var("y", shape=(2, 5), dtype=dtype)
-        check_grad(
-            relay.Function([x, y], relay.op.nn.cross_entropy_with_logits(x, y)),
-            eps=0.01,
-            scale=0.1,
-            mean=1,
-        )
+def test_cross_entropy_grad(target, dev, val_dtype):
+    target = tvm.target.Target(target)
+    if target.kind.name == "vulkan" and val_dtype == "float64":
+        # GLSL.std.450's Log implementation only takes 16/32-bit floats.
+        pytest.xfail("Known failing test case for vulkan runtime")
+
+    x = relay.var("x", shape=(2, 5), dtype=val_dtype)
+    y = relay.var("y", shape=(2, 5), dtype=val_dtype)
+    check_grad(
+        relay.Function([x, y], relay.op.nn.cross_entropy(x, y)),
+        eps=0.01,
+        scale=0.1,
+        mean=1,
+        target_devices=[(target, dev)],
+    )
 
 
-def test_checkpoint():
+def test_cross_entropy_with_logits_grad(target, dev, val_dtype):
+    x = relay.var("x", shape=(2, 5), dtype=val_dtype)
+    y = relay.var("y", shape=(2, 5), dtype=val_dtype)
+    check_grad(
+        relay.Function([x, y], relay.op.nn.cross_entropy_with_logits(x, y)),
+        eps=0.01,
+        scale=0.1,
+        mean=1,
+        target_devices=[(target, dev)],
+    )
+
+
+def test_checkpoint(target, dev):
     inputs = [relay.var("x{}".format(i), shape=(1,)) for i in range(4)]
     output = relay.multiply(relay.add(inputs[0], inputs[1]), relay.add(inputs[2], inputs[3]))
     check_grad(relay.Function(inputs, relay.annotation.checkpoint(output)))
@@ -59,56 +76,59 @@ def test_checkpoint():
         )
     )
     out_single = scope.get()
-    check_grad(relay.Function(inputs, out_single))
+    check_grad(relay.Function(inputs, out_single), target_devices=[(target, dev)])
 
 
-def verify_batch_matmul_grad(a_shape, b_shape, transpose_a, transpose_b):
-    tensor_a = relay.var("tensor_a", relay.TensorType(a_shape, "float32"))
-    tensor_b = relay.var("tensor_b", relay.TensorType(b_shape, "float32"))
-    check_grad(
-        relay.Function(
-            [tensor_a, tensor_b],
-            relay.op.nn.batch_matmul(
-                tensor_a, tensor_b, transpose_a=transpose_a, transpose_b=transpose_b
+class TestBatchMatmulGrad:
+    a_shape, b_shape, transpose_a, transpose_b = tvm.testing.parameters(
+        ((2, 3, 5), (2, 5, 4), False, False),
+        ((2, 3, 5), (2, 4, 5), False, True),
+        ((2, 5, 3), (2, 5, 4), True, False),
+        ((2, 5, 3), (2, 4, 5), True, True),
+    )
+
+    def test_batch_matmul_grad(self, target, dev, a_shape, b_shape, transpose_a, transpose_b):
+        tensor_a = relay.var("tensor_a", relay.TensorType(a_shape, "float32"))
+        tensor_b = relay.var("tensor_b", relay.TensorType(b_shape, "float32"))
+        check_grad(
+            relay.Function(
+                [tensor_a, tensor_b],
+                relay.op.nn.batch_matmul(
+                    tensor_a, tensor_b, transpose_a=transpose_a, transpose_b=transpose_b
+                ),
             ),
+            target_devices=[(target, dev)],
         )
+
+
+def test_reverse_reshape_grad(target, dev):
+    x = relay.var("x", shape=(3, 4, 5), dtype="float64")
+    check_grad(
+        relay.Function([x], relay.op.reverse_reshape(x, (-1, 0))),
+        target_devices=[(target, dev)],
     )
 
 
-def test_batch_matmul_grad():
-    verify_batch_matmul_grad((2, 3, 5), (2, 5, 4), False, False)
-    verify_batch_matmul_grad((2, 3, 5), (2, 4, 5), False, True)
-    verify_batch_matmul_grad((2, 5, 3), (2, 5, 4), True, False)
-    verify_batch_matmul_grad((2, 5, 3), (2, 4, 5), True, True)
-
-
-def test_reverse_reshape_grad():
-    x = relay.var("x", shape=(3, 4, 5), dtype="float64")
-    check_grad(relay.Function([x], relay.op.reverse_reshape(x, (-1, 0))))
-
-
-def test_one_hot_grad():
+def test_one_hot_grad(target, dev, index_dtype, val_dtype):
     indices_shape = (3, 4)
     depth = 5
     axis = -1
 
-    for indices_dtype in ["int32", "int64"]:
-        for val_dtype in ["float32", "float64"]:
-            inputs = [
-                np.random.randint(depth, size=indices_shape, dtype=indices_dtype),
-                np.array(np.random.randn() * 1e-5).astype(val_dtype),
-                np.array(np.random.randn() * 1e-5).astype(val_dtype),
-            ]
-            test_inputs = inputs[1:]
+    inputs = [
+        np.random.randint(depth, size=indices_shape, dtype=index_dtype),
+        np.array(np.random.randn() * 1e-5).astype(val_dtype),
+        np.array(np.random.randn() * 1e-5).astype(val_dtype),
+    ]
+    test_inputs = inputs[1:]
 
-            indices = relay.var("indices", shape=indices_shape, dtype=indices_dtype)
-            on_val = relay.var("on_val", shape=tuple(), dtype=val_dtype)
-            off_val = relay.var("off_val", shape=tuple(), dtype=val_dtype)
-            y = relay.one_hot(indices, on_val, off_val, depth, axis, val_dtype)
-            f = relay.Function([indices, on_val, off_val], y)
+    indices = relay.var("indices", shape=indices_shape, dtype=index_dtype)
+    on_val = relay.var("on_val", shape=tuple(), dtype=val_dtype)
+    off_val = relay.var("off_val", shape=tuple(), dtype=val_dtype)
+    y = relay.one_hot(indices, on_val, off_val, depth, axis, val_dtype)
+    f = relay.Function([indices, on_val, off_val], y)
 
-            check_grad(f, inputs=inputs, test_inputs=test_inputs)
+    check_grad(f, inputs=inputs, test_inputs=test_inputs, target_devices=[(target, dev)])
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -43,54 +43,67 @@ def rsqrt(x):
     return one / np.sqrt(x)
 
 
-@tvm.testing.uses_gpu
-def test_unary_op():
-    def check_single_op(opfunc, ref, dtype):
+class TestUnaryOp:
+    op_list = {
+        "log": (tvm.relay.log, np.log),
+        "exp": (tvm.relay.exp, np.exp),
+        "erf": (tvm.relay.erf, scipy.special.erf),
+        "sqrt": (tvm.relay.sqrt, np.sqrt),
+        "rqsrt": (tvm.relay.rsqrt, rsqrt),
+        "sigmoid": (tvm.relay.sigmoid, sigmoid),
+        "tanh": (tvm.relay.tanh, np.tanh),
+        "relu": (relay.nn.relu, relu),
+        "cos": (tvm.relay.cos, np.cos),
+        "sin": (tvm.relay.sin, np.sin),
+        "tan": (tvm.relay.tan, np.tan),
+        "atan": (tvm.relay.atan, np.arctan),
+    }
+
+    dtype = tvm.testing.parameter("float16", "float32")
+
+    relay_op, ref_func = tvm.testing.parameters(*op_list.values(), ids=op_list.keys())
+
+    def test_unary_op(self, target, dev, relay_op, ref_func, dtype):
+        target = tvm.target.Target(target)
+        if (
+            dtype == "float16"
+            and target.kind.name == "cuda"
+            and not have_fp16(tvm.cuda(0).compute_version)
+        ):
+            pytest.xfail("No float16 support on local cuda device")
+        elif (
+            dtype == "float16"
+            and target.kind.name == "cuda"
+            and not target.attrs.get("supports_float16", False)
+        ):
+            pytest.xfail("No float16 support on vulkan target")
+
+        if target.kind.name == "vulkan" and relay_op in [
+            tvm.relay.erf,
+            tvm.relay.tan,
+            tvm.relay.atan,
+        ]:
+            pytest.xfail(f"Vulkan runtime doesn't yet support {relay_op}")
+
         shape = (10, 4)
         dtype = dtype
         tp = relay.TensorType(shape)
         x = relay.var("x", tp, dtype=dtype)
-        y = opfunc(x)
+        y = relay_op(x)
         # test printer
         assert ("{}(%x)".format(y.op.name)) in y.astext()
         # test type inference
         yy = run_infer_type(y)
         assert yy.checked_type == tp
 
-        if ref is not None:
+        if ref_func is not None:
             data = np.random.rand(*shape).astype(dtype)
-            ref_res = ref(data)
+            ref_res = ref_func(data)
             func = relay.Function([x], y)
-            for target, dev in tvm.testing.enabled_targets():
-                # use graph by execuor default for testing, as we need
-                # create function explicitly to avoid constant-folding.
-                if (
-                    dtype == "float16"
-                    and target == "cuda"
-                    and not have_fp16(tvm.cuda(0).compute_version)
-                ):
-                    continue
-                op_res = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
-                    data
-                )
-                np.testing.assert_allclose(op_res.numpy(), ref_res, rtol=0.01)
-
-    for opfunc, ref in [
-        (tvm.relay.log, np.log),
-        (tvm.relay.exp, np.exp),
-        (tvm.relay.erf, scipy.special.erf),
-        (tvm.relay.sqrt, np.sqrt),
-        (tvm.relay.rsqrt, rsqrt),
-        (tvm.relay.sigmoid, sigmoid),
-        (tvm.relay.tanh, np.tanh),
-        (relay.nn.relu, relu),
-        (tvm.relay.cos, np.cos),
-        (tvm.relay.sin, np.sin),
-        (tvm.relay.tan, np.tan),
-        (tvm.relay.atan, np.arctan),
-    ]:
-        for dtype in ["float16", "float32"]:
-            check_single_op(opfunc, ref, dtype)
+            # use graph by execuor default for testing, as we need
+            # create function explicitly to avoid constant-folding.
+            op_res = relay.create_executor("graph", device=dev, target=target).evaluate(func)(data)
+            np.testing.assert_allclose(op_res.numpy(), ref_res, rtol=0.01)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -16,10 +16,15 @@
 # under the License.
 """ Support level2 operator test cases.
 """
+import sys
+
 import numpy as np
+import pytest
+
 import tvm
 import tvm.testing
 import tvm.topi.testing
+
 from tvm import autotvm, relay, te
 from tvm.contrib import utils
 from tvm.relay import transform
@@ -191,8 +196,168 @@ def test_conv2d_infer_type():
     assert yy.checked_type == relay.TensorType((n, h, w, 16), "int32")
 
 
-@tvm.testing.uses_gpu
-def test_conv2d_run():
+class TestConv2D:
+    config = {
+        "group1": dict(
+            dtype="float32",
+            out_dtype="float32",
+            scale=1,
+            dshape=(1, 32, 18, 18),
+            kshape=(32, 4, 3, 3),
+            padding=(1, 1),
+            channels=32,
+            groups=8,
+            kernel_size=(3, 3),
+            dilation=(1, 1),
+        ),
+        "group2": dict(
+            dtype="float32",
+            out_dtype="float32",
+            scale=1,
+            dshape=(1, 32, 18, 18),
+            kshape=(64, 1, 3, 3),
+            padding=(1, 1),
+            channels=64,
+            groups=32,
+            kernel_size=(3, 3),
+            dilation=(1, 1),
+        ),
+        "normal": dict(
+            dtype="float32",
+            out_dtype="float32",
+            scale=1,
+            dshape=(1, 3, 224, 224),
+            kshape=(10, 3, 3, 3),
+            padding=(1, 1),
+            channels=10,
+            groups=1,
+            kernel_size=(3, 3),
+            dilation=(1, 1),
+        ),
+        "mixed_precision_int8_int32_case1": dict(
+            dtype="int8",
+            out_dtype="int32",
+            scale=1,
+            dshape=(1, 3, 224, 224),
+            kshape=(10, 3, 3, 3),
+            padding=(1, 1),
+            channels=10,
+            groups=1,
+            kernel_size=(3, 3),
+            dilation=(1, 1),
+        ),
+        "mixed_precision_int8_int32_case2": dict(
+            dtype="int8",
+            out_dtype="int32",
+            scale=1,
+            dshape=(1, 3, 224, 224),
+            kshape=(10, 3, 1, 3),
+            padding=(0, 1),
+            channels=10,
+            groups=1,
+            kernel_size=(1, 3),
+            dilation=(1, 1),
+        ),
+        "dilated": dict(
+            dtype="float32",
+            out_dtype="float32",
+            scale=1,
+            dshape=(1, 3, 18, 18),
+            kshape=(10, 3, 3, 3),
+            padding=(1, 1),
+            channels=10,
+            groups=1,
+            kernel_size=(3, 3),
+            dilation=(3, 3),
+        ),
+    }
+
+    # TODO(Lunderberg): Make a cleaner utility for this type of
+    # parametrization.  It would be much nicer to have the fixture
+    # name come from the dictionaries themselves, rather than needing
+    # to be re-packed into tuples.
+    (
+        dtype,
+        out_dtype,
+        scale,
+        dshape,
+        kshape,
+        padding,
+        channels,
+        groups,
+        kernel_size,
+        dilation,
+    ) = tvm.testing.parameters(
+        *[
+            [
+                d[p]
+                for p in [
+                    "dtype",
+                    "out_dtype",
+                    "scale",
+                    "dshape",
+                    "kshape",
+                    "padding",
+                    "channels",
+                    "groups",
+                    "kernel_size",
+                    "dilation",
+                ]
+            ]
+            for d in config.values()
+        ],
+        ids=config.keys(),
+    )
+
+    def test_run(
+        self,
+        target,
+        dev,
+        dtype,
+        out_dtype,
+        scale,
+        dshape,
+        kshape,
+        padding,
+        groups,
+        dilation,
+        channels,
+        kernel_size,
+    ):
+        target = tvm.target.Target(target)
+        if target.kind.name == "vulkan" and dtype == "int8":
+            # The schedule selection incorrectly picks an
+            # implementation that requires NCHWc packed input.
+            pytest.xfail("Known failing test for vulkan")
+
+        x = relay.var("x", shape=dshape, dtype=dtype)
+        w = relay.var("w", shape=kshape, dtype=dtype)
+        y = relay.nn.conv2d(
+            x,
+            w,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            channels=channels,
+            kernel_size=kernel_size,
+        )
+        func = relay.Function([x, w], y)
+
+        kernel = np.random.uniform(-scale, scale, size=kshape).astype(dtype)
+        dkernel = tvm.topi.testing.dilate_python(kernel, (1, 1) + dilation)
+
+        data = np.random.uniform(-scale, scale, size=dshape).astype(dtype)
+        ref_res = tvm.topi.testing.conv2d_nchw_python(
+            data.astype(out_dtype), dkernel.astype(out_dtype), 1, padding, groups=groups
+        )
+
+        op_res1 = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
+            data, kernel
+        )
+        tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-4, atol=1e-4)
+
+
+def test_conv2d_run(target, dev):
     def run_test_conv2d(
         dtype,
         out_dtype,
@@ -203,162 +368,160 @@ def test_conv2d_run():
         fref=None,
         groups=1,
         dilation=(1, 1),
-        except_targets=None,
-        **attrs,
+        channels=32,
+        kernel_size=(3, 3),
     ):
-        if except_targets is None:
-            except_targets = []
-
         x = relay.var("x", shape=dshape, dtype=dtype)
         w = relay.var("w", shape=kshape, dtype=dtype)
-        y = relay.nn.conv2d(x, w, padding=padding, dilation=dilation, groups=groups, **attrs)
+        y = relay.nn.conv2d(
+            x,
+            w,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            channels=channels,
+            kernel_size=kernel_size,
+        )
         func = relay.Function([x, w], y)
         data = np.random.uniform(-scale, scale, size=dshape).astype(dtype)
         kernel = np.random.uniform(-scale, scale, size=kshape).astype(dtype)
         dkernel = tvm.topi.testing.dilate_python(kernel, (1, 1) + dilation)
-        if fref is None:
-            ref_res = tvm.topi.testing.conv2d_nchw_python(
-                data.astype(out_dtype), dkernel.astype(out_dtype), 1, padding, groups=groups
-            )
-        else:
-            ref_res = fref(data.astype(out_dtype), dkernel.astype(out_dtype))
+        ref_res = tvm.topi.testing.conv2d_nchw_python(
+            data.astype(out_dtype), dkernel.astype(out_dtype), 1, padding, groups=groups
+        )
 
-        for target, dev in tvm.testing.enabled_targets():
-            if target in except_targets:
-                continue
-            dev = tvm.device(target, 0)
-            op_res1 = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
-                data, kernel
-            )
-            tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-4, atol=1e-4)
+        op_res1 = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
+            data, kernel
+        )
+        tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-4, atol=1e-4)
 
-    def compile_test_conv2d_arm_cpu(
-        dtype, out_dtype, scale, dshape, kshape, padding=(1, 1), groups=1, dilation=(1, 1), **attrs
-    ):
-        x = relay.var("x", shape=dshape, dtype=dtype)
-        w = relay.var("w", shape=kshape, dtype=dtype)
-        y = relay.nn.conv2d(x, w, padding=padding, dilation=dilation, groups=groups, **attrs)
-        func = relay.Function([x, w], y)
-        mod = tvm.IRModule()
-        mod["main"] = func
-
-        test_schedule = '{"i": ["llvm -device=arm_cpu", "depthwise_conv2d_nchw_spatial_pack.arm_cpu", \
-                        [["TENSOR", [1, 512, 32, 32], "float32"], \
-                        ["TENSOR", [512, 1, 3, 3], "float32"], \
-                        [1, 1], [1, 1], [1, 1], "float32"], {}, \
-                        ["depthwise_conv2d_nchw_spatial_pack.arm_cpu", [1, 512, 32, 32, "float32"], \
-                        [512, 1, 3, 3, "float32"], [1, 1], [1, 1], [1, 1], "float32"], \
-                        {"i": 743640, "t": "", "c": null, \
-                        "e": [["tile_co", "sp", [32, 16]], ["tile_oh", "sp", [8, 1]], \
-                        ["tile_ow", "sp", [1, 8]], \
-                        ["reorder_0", "re", [0, 1, 2, 3, 4, 5, 8, 6, 7]], \
-                        ["reorder_1", "re", [0, 1, 2, 3, 6, 4, 5]], \
-                        ["ann_reduce", "an", ["unroll", "none"]], \
-                        ["ann_spatial", "an", ["unroll", "unroll", "vec"]], \
-                        ["data_pad_inline", "ot", 4], ["data_vec_inline", "ot", 1], \
-                        ["conv_inline", "ot", 0]]}], "r": [[0.0002933163], \
-                        0, 3.1976189613342285, 1570811630.6058347], "v": 0.1}'
-        temp = utils.tempdir()
-        with open(temp.relpath("temp.log"), "w") as log_file:
-            log_file.write(test_schedule)
-        with autotvm.apply_history_best(temp.relpath("temp.log")):
-            with tvm.transform.PassContext(opt_level=3):
-                print("Compiling...")
-                graph_json, mod, params = tvm.relay.build(mod, target="llvm -device=arm_cpu")
-
-    # depthwise conv2d
-    dshape = (1, 32, 18, 18)
-    kshape = (32, 1, 3, 3)
-    run_test_conv2d(
-        "float32",
-        "float32",
-        1,
-        dshape,
-        kshape,
-        padding=(1, 1),
-        channels=32,
-        groups=32,
-        kernel_size=(3, 3),
-        fref=lambda x, w: tvm.topi.testing.depthwise_conv2d_python_nchw(x, w, (1, 1), "SAME"),
-    )
-
-    # depthwise conv2d for arm_cpu
-    dshape = (1, 512, 32, 32)
-    kshape = (512, 1, 3, 3)
-    compile_test_conv2d_arm_cpu(
-        "float32",
-        "float32",
-        1,
-        dshape,
-        kshape,
-        padding=(1, 1),
-        channels=512,
-        groups=512,
-        kernel_size=(3, 3),
-    )
-
-    # CUDA is disabled for 'direct' schedule:
-    # https://github.com/apache/tvm/pull/3070#issuecomment-486597553
     # group conv2d
-    dshape = (1, 32, 18, 18)
-    kshape = (32, 4, 3, 3)
     run_test_conv2d(
-        "float32",
-        "float32",
-        1,
-        dshape,
-        kshape,
+        dtype="float32",
+        out_dtype="float32",
+        scale=1,
+        dshape=(1, 32, 18, 18),
+        kshape=(32, 4, 3, 3),
         padding=(1, 1),
         channels=32,
         groups=8,
         kernel_size=(3, 3),
-        except_targets=["cuda"],
+        dilation=(1, 1),
     )
     # also group conv2d
-    dshape = (1, 32, 18, 18)
-    kshape = (64, 1, 3, 3)
     run_test_conv2d(
-        "float32",
-        "float32",
-        1,
-        dshape,
-        kshape,
+        dtype="float32",
+        out_dtype="float32",
+        scale=1,
+        dshape=(1, 32, 18, 18),
+        kshape=(64, 1, 3, 3),
         padding=(1, 1),
         channels=64,
         groups=32,
         kernel_size=(3, 3),
-        except_targets=["cuda"],
+        dilation=(1, 1),
     )
 
     # normal conv2d
-    dshape = (1, 3, 224, 224)
-    kshape = (10, 3, 3, 3)
     run_test_conv2d(
-        "float32", "float32", 1, dshape, kshape, padding=(1, 1), channels=10, kernel_size=(3, 3)
+        dtype="float32",
+        out_dtype="float32",
+        scale=1,
+        dshape=(1, 3, 224, 224),
+        kshape=(10, 3, 3, 3),
+        padding=(1, 1),
+        channels=10,
+        kernel_size=(3, 3),
+        dilation=(1, 1),
     )
     # mixed precision
     run_test_conv2d(
-        "int8", "int32", 1, dshape, kshape, padding=(1, 1), channels=10, kernel_size=(3, 3)
+        dtype="int8",
+        out_dtype="int32",
+        scale=1,
+        dshape=(1, 3, 224, 224),
+        kshape=(10, 3, 3, 3),
+        padding=(1, 1),
+        channels=10,
+        kernel_size=(3, 3),
+        dilation=(1, 1),
     )
-    kshape = (10, 3, 1, 3)
     # mixed precision.
     run_test_conv2d(
-        "int8", "int32", 1, dshape, kshape, padding=(0, 1), channels=10, kernel_size=(1, 3)
+        dtype="int8",
+        out_dtype="int32",
+        scale=1,
+        dshape=(1, 3, 224, 224),
+        kshape=(10, 3, 1, 3),
+        padding=(0, 1),
+        channels=10,
+        kernel_size=(1, 3),
+        dilation=(1, 1),
     )
     # dilated conv2d
-    dshape = (1, 3, 18, 18)
-    kshape = (10, 3, 3, 3)
     run_test_conv2d(
-        "float32",
-        "float32",
-        1,
-        dshape,
-        kshape,
+        dtype="float32",
+        out_dtype="float32",
+        scale=1,
+        dshape=(1, 3, 18, 18),
+        kshape=(10, 3, 3, 3),
         padding=(1, 1),
         channels=10,
         kernel_size=(3, 3),
         dilation=(3, 3),
     )
+
+
+def test_compile_depthwise_conv2d_arm_cpu():
+    dtype = "float32"
+    out_dtype = "float32"
+    scale = 1
+    dshape = (1, 512, 32, 32)
+    kshape = (512, 1, 3, 3)
+    padding = (1, 1)
+    channels = 512
+    groups = 512
+    kernel_size = (3, 3)
+    dilation = (1, 1)
+
+    x = relay.var("x", shape=dshape, dtype=dtype)
+    w = relay.var("w", shape=kshape, dtype=dtype)
+    y = relay.nn.conv2d(
+        x,
+        w,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+        channels=channels,
+        kernel_size=kernel_size,
+    )
+    func = relay.Function([x, w], y)
+    mod = tvm.IRModule()
+    mod["main"] = func
+
+    test_schedule = '{"i": ["llvm -device=arm_cpu", "depthwise_conv2d_nchw_spatial_pack.arm_cpu", \
+                    [["TENSOR", [1, 512, 32, 32], "float32"], \
+                    ["TENSOR", [512, 1, 3, 3], "float32"], \
+                    [1, 1], [1, 1], [1, 1], "float32"], {}, \
+                    ["depthwise_conv2d_nchw_spatial_pack.arm_cpu", [1, 512, 32, 32, "float32"], \
+                    [512, 1, 3, 3, "float32"], [1, 1], [1, 1], [1, 1], "float32"], \
+                    {"i": 743640, "t": "", "c": null, \
+                    "e": [["tile_co", "sp", [32, 16]], ["tile_oh", "sp", [8, 1]], \
+                    ["tile_ow", "sp", [1, 8]], \
+                    ["reorder_0", "re", [0, 1, 2, 3, 4, 5, 8, 6, 7]], \
+                    ["reorder_1", "re", [0, 1, 2, 3, 6, 4, 5]], \
+                    ["ann_reduce", "an", ["unroll", "none"]], \
+                    ["ann_spatial", "an", ["unroll", "unroll", "vec"]], \
+                    ["data_pad_inline", "ot", 4], ["data_vec_inline", "ot", 1], \
+                    ["conv_inline", "ot", 0]]}], "r": [[0.0002933163], \
+                    0, 3.1976189613342285, 1570811630.6058347], "v": 0.1}'
+    temp = utils.tempdir()
+    with open(temp.relpath("temp.log"), "w") as log_file:
+        log_file.write(test_schedule)
+    with autotvm.apply_history_best(temp.relpath("temp.log")):
+        with tvm.transform.PassContext(opt_level=3):
+            print("Compiling...")
+            graph_json, mod, params = tvm.relay.build(mod, target="llvm -device=arm_cpu")
 
 
 @tvm.testing.uses_gpu
@@ -1851,38 +2014,4 @@ def test_correlation():
 
 
 if __name__ == "__main__":
-    test_pool1d()
-    test_pool2d()
-    test_pool3d()
-    test_avg_pool2d_no_count_pad()
-    test_lrn()
-    test_l2_normalize()
-    test_conv1d_infer_type()
-    test_conv2d_infer_type()
-    test_conv3d_infer_type()
-    test_bitpack_infer_type()
-    test_upsampling_infer_type()
-    test_upsampling3d_infer_type()
-    test_flatten_infer_type()
-    test_pad_infer_type()
-    test_pad_run()
-    test_pad_run_dynamic_pad_value()
-    test_conv3d_transpose_infer_type()
-    test_conv3d_transpose_ncdhw_run()
-    test_conv2d_transpose_infer_type()
-    test_conv2d_transpose_nchw_run()
-    test_conv2d_transpose_nhwc_run()
-    test_conv1d_transpose_ncw_run()
-    test_conv1d_run()
-    test_conv2d_run()
-    test_conv2d_winograd()
-    test_conv3d_run()
-    test_conv3d_ndhwc_run()
-    test_conv3d_winograd()
-    test_bitserial_conv2d_infer_type()
-    test_batch_flatten()
-    test_upsampling()
-    test_upsampling3d()
-    test_conv2d_int8_intrinsics()
-    test_depthwise_conv2d_int8()
-    test_correlation()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/relay/test_op_level4.py
+++ b/tests/python/relay/test_op_level4.py
@@ -14,14 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
+
 import numpy as np
 import numpy.random
+import pytest
+
 import tvm
 import tvm.testing
 import tvm.topi.testing
+
 from tvm import relay, te
 from tvm.relay import transform
 from tvm.relay.testing import run_infer_type
+
+executor_kind = tvm.testing.parameter("graph", "debug")
 
 
 @tvm.testing.uses_gpu
@@ -223,123 +230,146 @@ def test_where():
     verify(x_np.astype(dtype), y_np.astype(dtype), cond_np)
 
 
-def verify_reduce(funcs, data, axis, keepdims, exclude, output, dtype="float32"):
-    test_func = funcs[0]
-    ref_func = funcs[1]
-    dtype = "bool" if ref_func in [np.all, np.any] else dtype
+def _with_keepdims(func):
+    def _wrapper(data, axis=None, keepdims=False):
+        if not keepdims:
+            return func(data, axis=axis)
+        else:
+            if axis is not None:
+                axis = axis if isinstance(axis, int) else axis[0]
+                out_shape = list(data.shape)
+                out_shape[axis] = 1
+            else:
+                out_shape = [1 for _ in range(len(data.shape))]
+            return func(data, axis=axis).reshape(out_shape)
 
-    x = relay.var("x", relay.TensorType(data, dtype))
-    if test_func == relay.logsumexp:
-        z = test_func(x, axis, keepdims)
-    else:
-        z = test_func(x, axis, keepdims, exclude)
-    zz = run_infer_type(z)
-    if axis:
-        assert "axis=" in z.astext()
-    if keepdims:
-        assert "keepdims=" in z.astext()
-    if exclude:
-        assert "exclude=" in z.astext()
-    out_type = "int32" if test_func in [relay.argmin, relay.argmax] else dtype
-    assert zz.checked_type == relay.ty.TensorType(output, out_type)
+    return _wrapper
 
-    if all(isinstance(v, tvm.tir.Var) == 1 for v in data):
-        return
 
-    func = relay.Function([x], z)
-    x_data = (
-        np.random.choice([True, False], size=data)
-        if ref_func in [np.all]
-        else np.random.uniform(size=data).astype(dtype)
+def _np_log_sum_exp(x, axis, keepdims=False):
+    max_x = np.max(x, axis=axis, keepdims=True)
+    x = np.log(np.sum(np.exp(x - max_x), axis=axis, keepdims=True))
+    x = x + max_x
+    if not keepdims:
+        x = np.squeeze(x, axis=axis)
+    return x
+
+
+def _unbiased_relay_wrapper(f):
+    def _unbiased_func(x, axis=None, keepdims=False, exclude=False):
+        return f(x, axis=axis, keepdims=keepdims, exclude=exclude, unbiased=True)
+
+    return _unbiased_func
+
+
+def _unbiased_np_wrapper(f):
+    def _unbiased_func(a, axis=None, dtype=None, keepdims=None):
+        return f(a, axis=axis, dtype=dtype, ddof=1, keepdims=keepdims)
+
+    return _unbiased_func
+
+
+class TestReduceFunctions:
+    funcs = {
+        "sum": (relay.sum, np.sum),
+        "max": (relay.max, np.max),
+        "min": (relay.min, np.min),
+        "mean": (relay.mean, np.mean),
+        "var": (relay.variance, np.var),
+        "unbiased_var": (_unbiased_relay_wrapper(relay.variance), _unbiased_np_wrapper(np.var)),
+        "std": (relay.std, np.std),
+        "unbiased_std": (_unbiased_relay_wrapper(relay.std), _unbiased_np_wrapper(np.std)),
+        "prod": (relay.prod, np.prod),
+        "all": (relay.all, np.all),
+        "any": (relay.any, np.any),
+        "logsumexp": (relay.logsumexp, _np_log_sum_exp),
+        "argmin": (relay.argmin, _with_keepdims(np.argmin)),
+        "argmax": (relay.argmax, _with_keepdims(np.argmax)),
+    }
+    relay_func, ref_func = tvm.testing.parameters(
+        *funcs.values(),
+        ids=list(funcs),
     )
 
-    if ref_func in [np.sum]:
-        ref_res = ref_func(x_data + 0, axis=axis, dtype=dtype, keepdims=keepdims)
-    elif ref_func in [np.max, np.min, np.mean, np.prod]:
-        ref_res = ref_func(x_data + 0, axis=axis, keepdims=keepdims)
-    else:  # argmin/argmax
-        if axis and not isinstance(axis, int) and len(axis) > 1:
-            return
-        ref_res = ref_func(x_data + 0, axis=axis, keepdims=keepdims)
-
-    for target, dev in tvm.testing.enabled_targets():
-        op_res1 = relay.create_executor("graph", device=dev, target=target).evaluate(func)(x_data)
-        tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-5)
-        op_res2 = relay.create_executor("debug", device=dev, target=target).evaluate(func)(x_data)
-        tvm.testing.assert_allclose(op_res2.numpy(), ref_res, rtol=1e-5)
-
-
-@tvm.testing.uses_gpu
-def test_reduce_functions():
-    def _with_keepdims(func):
-        def _wrapper(data, axis=None, keepdims=False):
-            if not keepdims:
-                return func(data, axis=axis)
-            else:
-                if axis is not None:
-                    axis = axis if isinstance(axis, int) else axis[0]
-                    out_shape = list(data.shape)
-                    out_shape[axis] = 1
-                else:
-                    out_shape = [1 for _ in range(len(data.shape))]
-                return func(data, axis=axis).reshape(out_shape)
-
-        return _wrapper
-
-    def _np_log_sum_exp(x, axis, keepdims=False):
-        max_x = np.max(x, axis=axis, keepdims=True)
-        x = np.log(np.sum(np.exp(x - max_x), axis=axis, keepdims=True))
-        x = x + max_x
-        if not keepdims:
-            x = np.squeeze(x, axis=axis)
-        return x
-
-    def _unbiased_relay_wrapper(f):
-        def _unbiased_func(x, axis=None, keepdims=False, exclude=False):
-            return f(x, axis=axis, keepdims=keepdims, exclude=exclude, unbiased=True)
-
-        return _unbiased_func
-
-    def _unbiased_np_wrapper(f):
-        def _unbiased_func(a, axis=None, dtype=None, keepdims=None):
-            return f(a, axis=axis, dtype=dtype, ddof=1, keepdims=keepdims)
-
-        return _unbiased_func
-
     d1, d2, d3, d4 = te.var("d1"), te.var("d2"), te.var("d3"), te.var("d4")
-    for func in [
-        [relay.sum, np.sum],
-        [relay.max, np.max],
-        [relay.min, np.min],
-        [relay.mean, np.mean],
-        [relay.variance, np.var],
-        [_unbiased_relay_wrapper(relay.variance), _unbiased_np_wrapper(np.var)],
-        [relay.std, np.std],
-        [_unbiased_relay_wrapper(relay.std), _unbiased_np_wrapper(np.std)],
-        [relay.prod, np.prod],
-        [relay.all, np.all],
-        [relay.any, np.any],
-        [relay.logsumexp, _np_log_sum_exp],
-        [relay.argmin, _with_keepdims(np.argmin)],
-        [relay.argmax, _with_keepdims(np.argmax)],
-    ]:
-        verify_reduce(func, (d1, d2, d3, d4), None, False, False, ())
-        verify_reduce(func, (d1, d2, d3, d4), 2, True, False, (d1, d2, 1, d4))
-        verify_reduce(func, (d1, d2, d3, d4), 0, True, False, (1, d2, d3, d4))
-        verify_reduce(func, (d1, d2, d3), 1, True, False, (d1, 1, d3))
-        verify_reduce(func, (d1, d2, d3), 0, True, False, (1, d2, d3))
-        verify_reduce(func, (d1, d2, d3), None, True, False, (1, 1, 1))
-        verify_reduce(func, (d1, d2, d3), (0, 1), True, False, (1, 1, d3))
-        verify_reduce(func, (2, 3, 4), 1, True, False, (2, 1, 4))
-        verify_reduce(func, (2, 3, 4), (1,), True, False, (2, 1, 4))
-        verify_reduce(func, (2, 3, 4), -1, True, False, (2, 3, 1))
-        verify_reduce(func, (2, 3, 4), (0, 1, 2), False, False, ())
-        verify_reduce(func, (4, 4, 3), None, False, False, ())
-        verify_reduce(func, (4, 4, 3), (0, 2), False, False, (4,))
-        verify_reduce(func, (128, 24, 128), (0, 1), False, False, (128,))
-        verify_reduce(func, (128, 24, 128), (0, 2), False, False, (24,))
-        verify_reduce(func, (128, 24, 128), (0, 1), True, False, (1, 1, 128))
-        verify_reduce(func, (128, 24, 128), (0, 2), True, False, (1, 24, 1))
+
+    data, axis, keepdims, exclude, output = tvm.testing.parameters(
+        ((d1, d2, d3, d4), None, False, False, ()),
+        ((d1, d2, d3, d4), 2, True, False, (d1, d2, 1, d4)),
+        ((d1, d2, d3, d4), 0, True, False, (1, d2, d3, d4)),
+        ((d1, d2, d3), 1, True, False, (d1, 1, d3)),
+        ((d1, d2, d3), 0, True, False, (1, d2, d3)),
+        ((d1, d2, d3), None, True, False, (1, 1, 1)),
+        ((d1, d2, d3), (0, 1), True, False, (1, 1, d3)),
+        ((2, 3, 4), 1, True, False, (2, 1, 4)),
+        ((2, 3, 4), (1,), True, False, (2, 1, 4)),
+        ((2, 3, 4), -1, True, False, (2, 3, 1)),
+        ((2, 3, 4), (0, 1, 2), False, False, ()),
+        ((4, 4, 3), None, False, False, ()),
+        ((4, 4, 3), (0, 2), False, False, (4,)),
+        ((128, 24, 128), (0, 1), False, False, (128,)),
+        ((128, 24, 128), (0, 2), False, False, (24,)),
+        ((128, 24, 128), (0, 1), True, False, (1, 1, 128)),
+        ((128, 24, 128), (0, 2), True, False, (1, 24, 1)),
+    )
+
+    def test_reduce(
+        self,
+        target,
+        dev,
+        relay_func,
+        ref_func,
+        executor_kind,
+        data,
+        axis,
+        keepdims,
+        exclude,
+        output,
+    ):
+        dtype = "bool" if ref_func in [np.all, np.any] else "float32"
+        out_type = "int32" if relay_func in [relay.argmin, relay.argmax] else dtype
+
+        target = tvm.target.Target(target)
+        if target.kind.name == "vulkan" and dtype == "bool":
+            pytest.xfail("Known failing test on vulkan runtime")
+
+        x = relay.var("x", relay.TensorType(data, dtype))
+        if relay_func == relay.logsumexp:
+            z = relay_func(x, axis, keepdims)
+        else:
+            z = relay_func(x, axis, keepdims, exclude)
+        zz = run_infer_type(z)
+        if axis:
+            assert "axis=" in z.astext()
+        if keepdims:
+            assert "keepdims=" in z.astext()
+        if exclude:
+            assert "exclude=" in z.astext()
+        assert zz.checked_type == relay.ty.TensorType(output, out_type)
+
+        if all(isinstance(v, tvm.tir.Var) == 1 for v in data):
+            return
+
+        func = relay.Function([x], z)
+        x_data = (
+            np.random.choice([True, False], size=data)
+            if ref_func in [np.all]
+            else np.random.uniform(size=data).astype(dtype)
+        )
+
+        if ref_func in [np.sum]:
+            ref_res = ref_func(x_data + 0, axis=axis, dtype=dtype, keepdims=keepdims)
+        elif ref_func in [np.max, np.min, np.mean, np.prod]:
+            ref_res = ref_func(x_data + 0, axis=axis, keepdims=keepdims)
+        else:  # argmin/argmax
+            if axis and not isinstance(axis, int) and len(axis) > 1:
+                return
+            ref_res = ref_func(x_data + 0, axis=axis, keepdims=keepdims)
+
+        op_res1 = relay.create_executor(executor_kind, device=dev, target=target).evaluate(func)(
+            x_data
+        )
+        tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-5)
 
 
 @tvm.testing.uses_gpu
@@ -611,13 +641,4 @@ def test_strided_set():
 
 
 if __name__ == "__main__":
-    test_strided_slice()
-    test_dyn_strided_slice()
-    # test_strided_set()
-    # test_binary_op()
-    # test_cmp_type()
-    # test_binary_int_broadcast_1()
-    # test_binary_int_broadcast_2()
-    # test_where()
-    # test_reduce_functions()
-    # test_mean_var_std()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -17,13 +17,18 @@
 """ Support level5 operator test cases.
 """
 import math
+import sys
 
 import numpy as np
+import pytest
+
 import tvm
 import tvm.testing
 import tvm.topi.testing
 from tvm import relay, te
 from tvm.relay.testing import run_infer_type
+
+executor_kind = tvm.testing.parameter("graph", "debug")
 
 
 def test_resize1d_infer_type():
@@ -41,9 +46,31 @@ def test_resize1d_infer_type():
     assert zz.checked_type == relay.TensorType((n, c, 200), "int8")
 
 
-@tvm.testing.uses_gpu
-def test_resize1d():
-    def verify_resize(dshape, scale, method, layout, coord_trans):
+class TestResize1D:
+    interpolate_method = tvm.testing.parameter("nearest_neighbor", "linear", "cubic")
+    coord_trans = tvm.testing.parameter("asymmetric", "align_corners", "half_pixel")
+
+    layout = tvm.testing.parameter("NWC", "NCW")
+    dshape, scale = tvm.testing.parameters(
+        ((1, 4, 4), 2),
+        ((2, 8, 17), 3),
+        ((2, 8, 17), 3),
+        ((3, 4, 5), 5),
+    )
+
+    def test_resize(
+        self, target, dev, executor_kind, dshape, scale, interpolate_method, layout, coord_trans
+    ):
+        target_kind = tvm.target.Target(target).kind.name
+        if (
+            target_kind == "vulkan"
+            and dshape == (3, 4, 5)
+            and scale == 5
+            and interpolate_method == "nearest_neighbor"
+            and coord_trans == "align_corners"
+        ):
+            pytest.xfail("Known failing case for these parameters")
+
         if layout == "NWC":
             size = (dshape[1] * scale,)
         else:
@@ -51,29 +78,21 @@ def test_resize1d():
 
         x_data = np.random.uniform(size=dshape).astype("float32")
 
-        ref_res = tvm.topi.testing.resize1d_python(x_data, (scale,), layout, method, coord_trans)
+        ref_res = tvm.topi.testing.resize1d_python(
+            x_data, (scale,), layout, interpolate_method, coord_trans
+        )
         x = relay.var("x", relay.TensorType(dshape, "float32"))
         z = relay.image.resize1d(
-            x, size, layout, method, coordinate_transformation_mode=coord_trans
+            x, size, layout, interpolate_method, coordinate_transformation_mode=coord_trans
         )
         assert "size=" in z.astext()
         zz = run_infer_type(z)
         assert zz.checked_type == relay.TensorType(ref_res.shape, "float32")
         func = relay.Function([x], z)
-        for target, dev in tvm.testing.enabled_targets():
-            for kind in ["graph", "debug"]:
-                op_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(
-                    x_data
-                )
-                tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-3, atol=1e-4)
-
-    for method in ["nearest_neighbor", "linear", "cubic"]:
-        for coord_trans in ["asymmetric", "align_corners", "half_pixel"]:
-            for layout in ["NWC", "NCW"]:
-                verify_resize((1, 4, 4), 2, method, layout, coord_trans)
-                verify_resize((2, 8, 17), 3, method, layout, coord_trans)
-                verify_resize((2, 8, 17), 3, method, layout, coord_trans)
-                verify_resize((3, 4, 5), 5, method, layout, coord_trans)
+        op_res = relay.create_executor(executor_kind, device=dev, target=target).evaluate(func)(
+            x_data
+        )
+        tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-3, atol=1e-4)
 
 
 def test_resize2d_infer_type():
@@ -91,9 +110,32 @@ def test_resize2d_infer_type():
     assert zz.checked_type == relay.TensorType((n, c, 100, 200), "int8")
 
 
-@tvm.testing.uses_gpu
-def test_resize2d():
-    def verify_resize(dshape, scale, method, layout, coord_trans):
+class TestResize2D:
+    interpolate_method = tvm.testing.parameter("nearest_neighbor", "linear", "cubic")
+    coord_trans = tvm.testing.parameter("asymmetric", "align_corners", "half_pixel")
+
+    layout = tvm.testing.parameter("NHWC", "NCHW")
+
+    dshape, scale = tvm.testing.parameters(
+        ((1, 4, 4, 4), 2),
+        ((2, 8, 17, 20), 3),
+        ((2, 8, 17, 20), 3),
+        ((3, 4, 5, 6), 5),
+    )
+
+    def test_resize(
+        self, target, dev, executor_kind, dshape, scale, interpolate_method, layout, coord_trans
+    ):
+        target_kind = tvm.target.Target(target).kind.name
+        if (
+            target_kind == "vulkan"
+            and dshape == (3, 4, 5, 6)
+            and scale == 5
+            and interpolate_method == "nearest_neighbor"
+            and coord_trans == "align_corners"
+        ):
+            pytest.xfail("Known failing case for these parameters")
+
         if layout == "NHWC":
             size = (dshape[1] * scale, dshape[2] * scale)
         else:
@@ -102,30 +144,20 @@ def test_resize2d():
         x_data = np.random.uniform(size=dshape).astype("float32")
 
         ref_res = tvm.topi.testing.resize2d_python(
-            x_data, (scale, scale), layout, method, coord_trans
+            x_data, (scale, scale), layout, interpolate_method, coord_trans
         )
         x = relay.var("x", relay.TensorType(dshape, "float32"))
         z = relay.image.resize2d(
-            x, size, layout, method, coordinate_transformation_mode=coord_trans
+            x, size, layout, interpolate_method, coordinate_transformation_mode=coord_trans
         )
         assert "size=" in z.astext()
         zz = run_infer_type(z)
         assert zz.checked_type == relay.TensorType(ref_res.shape, "float32")
         func = relay.Function([x], z)
-        for target, dev in tvm.testing.enabled_targets():
-            for kind in ["graph", "debug"]:
-                op_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(
-                    x_data
-                )
-                tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-3, atol=1e-4)
-
-    for method in ["nearest_neighbor", "linear", "cubic"]:
-        for coord_trans in ["asymmetric", "align_corners", "half_pixel"]:
-            for layout in ["NHWC", "NCHW"]:
-                verify_resize((1, 4, 4, 4), 2, method, layout, coord_trans)
-                verify_resize((2, 8, 17, 20), 3, method, layout, coord_trans)
-                verify_resize((2, 8, 17, 20), 3, method, layout, coord_trans)
-                verify_resize((3, 4, 5, 6), 5, method, layout, coord_trans)
+        op_res = relay.create_executor(executor_kind, device=dev, target=target).evaluate(func)(
+            x_data
+        )
+        tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-3, atol=1e-4)
 
 
 def test_resize3d_infer_type():
@@ -149,9 +181,19 @@ def test_resize3d_infer_type():
     assert zz.checked_type == relay.TensorType((n, c, 10, 10, 20), "int8")
 
 
-@tvm.testing.parametrize_targets
-def test_resize3d(target, dev):
-    def verify_resize(dshape, scale, method, layout):
+class TestResize3D:
+    interpolate_method = tvm.testing.parameter("nearest_neighbor", "linear", "cubic")
+    coord_trans = tvm.testing.parameter("asymmetric", "align_corners", "half_pixel")
+
+    layout = tvm.testing.parameter("NDHWC", "NCDHW")
+
+    dshape, scale = tvm.testing.parameters(
+        ((1, 4, 4, 4, 4), 2),
+    )
+
+    def test_resize(
+        self, target, dev, executor_kind, dshape, scale, interpolate_method, layout, coord_trans
+    ):
         if layout == "NDHWC":
             size = (dshape[1] * scale, dshape[2] * scale, dshape[3] * scale)
         else:
@@ -159,35 +201,59 @@ def test_resize3d(target, dev):
 
         x_data = np.random.uniform(size=dshape).astype("float32")
         ref_res = tvm.topi.testing.resize3d_python(
-            x_data, (scale, scale, scale), layout, method, "align_corners"
+            x_data, (scale, scale, scale), layout, interpolate_method, coord_trans
         )
         x = relay.var("x", relay.TensorType(dshape, "float32"))
-        z = relay.image.resize3d(x, size, layout, method, "align_corners")
+        z = relay.image.resize3d(x, size, layout, interpolate_method, coord_trans)
         assert "size=" in z.astext()
         zz = run_infer_type(z)
         assert zz.checked_type == relay.TensorType(ref_res.shape, "float32")
         func = relay.Function([x], z)
 
-        for kind in ["graph", "debug"]:
-            op_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(x_data)
-            tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-4, atol=1e-6)
-
-    for method in ["nearest_neighbor", "linear", "cubic"]:
-        for coord_trans in ["asymmetric", "align_corners", "half_pixel"]:
-            for layout in ["NDHWC", "NCDHW"]:
-                verify_resize((1, 4, 4, 4, 4), 2, method, layout)
+        op_res = relay.create_executor(executor_kind, device=dev, target=target).evaluate(func)(
+            x_data
+        )
+        tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-4, atol=1e-6)
 
 
-@tvm.testing.uses_gpu
-def test_crop_and_resize():
-    def verify_crop_and_resize(
-        img_shape, boxes, box_indices, crop_size, layout, method, extrapolation_value=0.0
-    ):
+class TestCropAndResize:
+    interpolate_method = tvm.testing.parameter("bilinear", "nearest_neighbor")
+    layout = tvm.testing.parameter("NHWC", "NCHW")
+
+    def test_crop_and_resize(self, target, dev, executor_kind, layout, interpolate_method):
+        target_kind = tvm.target.Target(target).kind.name
+        if (
+            target_kind == "vulkan"
+            and layout == "NHWC"
+            and interpolate_method == "nearest_neighbor"
+        ):
+            pytest.xfail("Known failing case for these parameters")
+
+        extrapolation_value = 0.0
+
+        if layout == "NHWC":
+            img_shape = (10, 224, 224, 3)
+            boxes = np.array([[0.1, 0.2, 0.8, 0.7], [0.2, 0, 1, 0.6]]).astype("float32")
+            box_indices = np.array([1, 0]).astype("int32")
+            crop_size = np.array([20, 30]).astype("int32")
+        elif layout == "NCHW":
+            img_shape = (5, 3, 255, 255)
+            boxes = np.array([[0, 0, 1, 1], [0.2, 0.1, 1, 0.9]]).astype("float32")
+            box_indices = np.array([0, 1]).astype("int32")
+            crop_size = np.array([30, 30]).astype("int32")
+        else:
+            raise ValueError(f"Unknown layout: {layout}")
 
         image_data = np.random.uniform(size=img_shape).astype("float32")
 
         ref_res = tvm.topi.testing.crop_and_resize_python(
-            image_data, boxes, box_indices, crop_size, layout, method, extrapolation_value
+            image_data,
+            boxes,
+            box_indices,
+            crop_size,
+            layout,
+            interpolate_method,
+            extrapolation_value,
         )
 
         img = relay.var("img", relay.TensorType(img_shape, "float32"))
@@ -195,33 +261,16 @@ def test_crop_and_resize():
         bx_idx = relay.var("bx_idx", relay.TensorType(box_indices.shape, "int32"))
 
         z = relay.image.crop_and_resize(
-            img, bx, bx_idx, list(crop_size), layout, method, extrapolation_value
+            img, bx, bx_idx, list(crop_size), layout, interpolate_method, extrapolation_value
         )
         zz = run_infer_type(z)
         assert zz.checked_type == relay.TensorType(ref_res.shape, "float32")
         func = relay.Function([img, bx, bx_idx], z)
 
-        for target, dev in tvm.testing.enabled_targets():
-            for kind in ["graph", "debug"]:
-                op_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(
-                    image_data, boxes, box_indices
-                )
-                tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-3, atol=1e-04)
-
-    boxes_nhwc = np.array([[0.1, 0.2, 0.8, 0.7], [0.2, 0, 1, 0.6]]).astype("float32")
-    indices_nhwc = np.array([1, 0]).astype("int32")
-    size_nhwc = np.array([20, 30]).astype("int32")
-    boxes_nchw = np.array([[0, 0, 1, 1], [0.2, 0.1, 1, 0.9]]).astype("float32")
-    indices_nchw = np.array([0, 1]).astype("int32")
-    size_nchw = np.array([30, 30]).astype("int32")
-
-    for method in ["bilinear", "nearest_neighbor"]:
-        verify_crop_and_resize(
-            (10, 224, 224, 3), boxes_nhwc, indices_nhwc, size_nhwc, "NHWC", method
+        op_res = relay.create_executor(executor_kind, device=dev, target=target).evaluate(func)(
+            image_data, boxes, box_indices
         )
-        verify_crop_and_resize(
-            (5, 3, 255, 255), boxes_nchw, indices_nchw, size_nchw, "NCHW", method, 0.1
-        )
+        tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-3, atol=1e-04)
 
 
 @tvm.testing.uses_gpu
@@ -957,37 +1006,74 @@ def test_yolo_reorg():
     verify_yolo_reorg((1, 4, 6, 6), 2)
 
 
-@tvm.testing.uses_gpu
-def test_deformable_conv2d():
-    def test_infer_type(batch, in_channel, size, out_channel, deformable_groups, groups, layout):
-        kernel_size = (3, 3)
+class TestDeformableConv2D:
+    batch, in_channel, size, out_channel, deformable_groups = tvm.testing.parameters(
+        (1, 4, 16, 4, 4),
+        (2, 4, 16, 4, 1),
+    )
+    kernel_size = tvm.testing.parameter((3, 3))
+    groups = tvm.testing.parameter(1, 2)
+    layout = tvm.testing.parameter("NCHW", "NHWC")
+    dtype = tvm.testing.parameter("float32")
+
+    @tvm.testing.fixture
+    def data_shape(self, layout, batch, in_channel, size):
         if layout == "NCHW":
-            kernel_layout = "OIHW"
-            data_shape = (batch, in_channel, size, size)
-            weight_shape = (out_channel, in_channel // groups, kernel_size[0], kernel_size[1])
-            out_shape = (batch, out_channel, size, size)
-            offset_shape = (
+            return (batch, in_channel, size, size)
+        elif layout == "NHWC":
+            return (batch, size, size, in_channel)
+
+    @tvm.testing.fixture
+    def kernel_shape(self, layout, in_channel, out_channel, groups, kernel_size):
+        if layout == "NCHW":
+            return (out_channel, in_channel // groups, kernel_size[0], kernel_size[1])
+        elif layout == "NHWC":
+            return (kernel_size[0], kernel_size[1], in_channel // groups, out_channel)
+
+    @tvm.testing.fixture
+    def out_shape(self, layout, batch, out_channel, size):
+        if layout == "NCHW":
+            return (batch, out_channel, size, size)
+        elif layout == "NHWC":
+            return (batch, size, size, out_channel)
+
+    @tvm.testing.fixture
+    def offset_shape(self, layout, batch, kernel_size, deformable_groups, out_shape):
+        if layout == "NCHW":
+            return (
                 batch,
                 2 * kernel_size[0] * kernel_size[1] * deformable_groups,
                 out_shape[2],
                 out_shape[3],
             )
-        else:
-            kernel_layout = "HWIO"
-            data_shape = (batch, size, size, in_channel)
-            weight_shape = (kernel_size[0], kernel_size[1], in_channel // groups, out_channel)
-            out_shape = (batch, size, size, out_channel)
-            offset_shape = (
+        elif layout == "NHWC":
+            return (
                 batch,
                 out_shape[1],
                 out_shape[2],
                 2 * kernel_size[0] * kernel_size[1] * deformable_groups,
             )
 
-        data = relay.var("data", shape=data_shape)
-        offset = relay.var("offset")
-        kernel = relay.var("kernel")
-        y = relay.nn.deformable_conv2d(
+    @tvm.testing.fixture
+    def kernel_layout(self, layout):
+        return {"NCHW": "OIHW", "NHWC": "HWIO"}[layout]
+
+    @tvm.testing.fixture
+    def relay_setup(
+        self,
+        dtype,
+        data_shape,
+        layout,
+        kernel_layout,
+        kernel_size,
+        deformable_groups,
+        groups,
+        out_channel,
+    ):
+        data = relay.var("data", shape=data_shape, dtype=dtype)
+        offset = relay.var("offset", dtype=dtype)
+        kernel = relay.var("kernel", dtype=dtype)
+        expr = relay.nn.deformable_conv2d(
             data,
             offset,
             kernel,
@@ -1001,60 +1087,37 @@ def test_deformable_conv2d():
             groups=groups,
             channels=out_channel,
         )
-        yy = run_infer_type(y)
+        func = relay.Function([data, offset, kernel], expr)
+        return expr, func
+
+    def test_infer_type(self, relay_setup, out_shape, offset_shape, kernel_shape):
+        expr, func = relay_setup
+        yy = run_infer_type(expr)
         assert yy.checked_type == relay.TensorType(out_shape), yy.checked_type
         assert yy.args[1].checked_type == relay.TensorType(offset_shape), yy.args[1].checked_type
-        assert yy.args[2].checked_type == relay.TensorType(weight_shape), yy.args[2].checked_type
+        assert yy.args[2].checked_type == relay.TensorType(kernel_shape), yy.args[2].checked_type
 
-    test_infer_type(1, 4, 16, 4, 4, 1, "NCHW")
-    test_infer_type(2, 4, 16, 4, 1, 2, "NCHW")
-    test_infer_type(1, 4, 16, 4, 4, 1, "NHWC")
-    test_infer_type(2, 4, 16, 4, 1, 2, "NHWC")
+    # The reference python implementation only supports groups==1.
+    @pytest.mark.parametrize("groups", [1])
+    def test_run(
+        self,
+        target,
+        dev,
+        dtype,
+        executor_kind,
+        data_shape,
+        offset_shape,
+        kernel_shape,
+        relay_setup,
+        deformable_groups,
+        groups,
+        layout,
+    ):
+        target = tvm.target.Target(target)
+        if layout == "NHWC" and target.kind.name != "llvm":
+            pytest.xfail("Can only run NHWC layout on llvm")
 
-    def test_run(batch, in_channel, size, out_channel, deformable_groups, groups, layout):
-        kernel_size = (3, 3)
-        if layout == "NCHW":
-            kernel_layout = "OIHW"
-            data_shape = (batch, in_channel, size, size)
-            kernel_shape = (out_channel, in_channel // groups, kernel_size[0], kernel_size[1])
-            out_shape = (batch, out_channel, size, size)
-            offset_shape = (
-                batch,
-                2 * kernel_size[0] * kernel_size[1] * deformable_groups,
-                out_shape[2],
-                out_shape[3],
-            )
-        else:
-            kernel_layout = "HWIO"
-            data_shape = (batch, size, size, in_channel)
-            kernel_shape = (kernel_size[0], kernel_size[1], in_channel // groups, out_channel)
-            out_shape = (batch, size, size, out_channel)
-            offset_shape = (
-                batch,
-                out_shape[1],
-                out_shape[2],
-                2 * kernel_size[0] * kernel_size[1] * deformable_groups,
-            )
-
-        dtype = "float32"
-        data = relay.var("data", shape=data_shape, dtype=dtype)
-        offset = relay.var("offset")
-        kernel = relay.var("kernel")
-        y = relay.nn.deformable_conv2d(
-            data,
-            offset,
-            kernel,
-            strides=(1, 1),
-            padding=(1, 1),
-            dilation=(1, 1),
-            data_layout=layout,
-            kernel_layout=kernel_layout,
-            kernel_size=kernel_size,
-            deformable_groups=deformable_groups,
-            groups=groups,
-            channels=out_channel,
-        )
-        func = relay.Function([data, offset, kernel], y)
+        expr, func = relay_setup
         data = np.random.uniform(size=data_shape).astype(dtype)
         offset = np.random.uniform(size=offset_shape).astype(dtype)
         kernel = np.random.uniform(size=kernel_shape).astype(dtype)
@@ -1080,19 +1143,11 @@ def test_deformable_conv2d():
                 deformable_groups=deformable_groups,
                 groups=groups,
             )
-        for target, dev in tvm.testing.enabled_targets():
-            if target == "cuda" and layout == "NHWC":
-                continue  # Cannot run NHWC layout on cuda target, only on llvm
-            for kind in ["graph", "debug"]:
-                op_res1 = relay.create_executor(kind, device=dev, target=target).evaluate(func)(
-                    data, offset, kernel
-                )
-                tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-5, atol=1e-5)
 
-    test_run(1, 4, 16, 4, 1, 1, "NCHW")
-    test_run(1, 4, 16, 4, 1, 1, "NHWC")
-    test_run(2, 4, 16, 4, 4, 1, "NCHW")
-    test_run(2, 4, 16, 4, 4, 1, "NHWC")
+        op_res1 = relay.create_executor(executor_kind, device=dev, target=target).evaluate(func)(
+            data, offset, kernel
+        )
+        tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-5, atol=1e-5)
 
 
 @tvm.testing.uses_gpu
@@ -1202,119 +1257,111 @@ def test_dilation2d_infer_type():
     assert yy.checked_type == relay.TensorType((n, 10, 217, 217), "float32")
 
 
-@tvm.testing.uses_gpu
-def test_dilation2d_run():
-    def run_test_dilation2d(
-        indata,
-        kernel,
-        out,
-        dtype="float32",
-        strides=[1, 1],
-        padding=[0, 0],
-        dilations=[1, 1],
-        except_targets=["cuda"],
-        **attrs,
-    ):
+class TestDilation2DRun:
+    data_layout, kernel_layout = tvm.testing.parameters(("NCHW", "IHW"), ("NHWC", "HWI"))
+    dtype = tvm.testing.parameter("float32")
 
-        dshape = indata.shape
-        kshape = kernel.shape
+    config = tvm.testing.parameter(
+        dict(
+            image=[[[[0.1], [0.2]], [[0.3], [0.4]]]],
+            kernel=[[[0.4], [0.3]], [[0.1], [0.0]]],
+            out=[[[[0.5]]]],
+        ),
+        dict(
+            image=[[[[0.1], [0.2]], [[0.3], [0.4]]]],
+            kernel=[[[0.4], [0.3]], [[0.1], [0.0]]],
+            out=[[[[0.5], [0.6]], [[0.7], [0.8]]]],
+            padding=[0, 0, 1, 1],
+        ),
+        dict(
+            image=[[[[0.1, 0.2, 0.0], [0.2, 0.3, 0.1]], [[0.3, 0.4, 0.2], [0.4, 0.5, 0.3]]]],
+            kernel=[[[0.4, 0.5, 0.3], [0.3, 0.4, 0.2]], [[0.1, 0.2, 0.0], [0.0, 0.1, -0.1]]],
+            out=[[[[0.5, 0.7, 0.3], [0.6, 0.8, 0.4]], [[0.7, 0.9, 0.5], [0.8, 1.0, 0.6]]]],
+            padding=[0, 0, 1, 1],
+        ),
+        dict(
+            image=[[[[0.1], [0.2]], [[0.3], [0.4]]], [[[0.2], [0.3]], [[0.4], [0.5]]]],
+            kernel=[[[0.4], [0.3]], [[0.1], [0.0]]],
+            out=[[[[0.5], [0.6]], [[0.7], [0.8]]], [[[0.6], [0.7]], [[0.8], [0.9]]]],
+            padding=[0, 0, 1, 1],
+        ),
+        dict(
+            image=[[[[0.1], [0.2]], [[0.3], [0.4]]]],
+            kernel=[[[0.4], [0.3]]],
+            out=[[[[0.5]], [[0.7]]]],
+        ),
+        dict(
+            image=[[[[0.1], [0.2], [0.3]], [[0.4], [0.5], [0.6]], [[0.7], [0.8], [0.9]]]],
+            kernel=[[[0.4], [0.3]], [[0.1], [0.2]]],
+            out=[[[[0.7], [0.8], [0.6]], [[1.0], [1.1], [0.9]], [[0.8], [0.9], [0.9]]]],
+            padding=[1, 1],
+            dilations=[2, 2],
+        ),
+        dict(
+            image=[
+                [
+                    [[0.1], [0.2], [0.3], [0.4]],
+                    [[0.5], [0.6], [0.7], [0.8]],
+                    [[0.9], [1.0], [1.1], [1.2]],
+                ]
+            ],
+            kernel=[[[0.4], [0.3]], [[0.1], [0.2]]],
+            out=[[[[0.8], [1.0]], [[1.2], [1.4]]]],
+            strides=[1, 2],
+        ),
+    )
 
-        if except_targets is None:
-            except_targets = []
+    @tvm.testing.fixture
+    def test_case(self, config, data_layout, dtype):
+        indata = np.array(config["image"], dtype=dtype)
+        kernel = np.array(config["kernel"], dtype=dtype)
+        out = np.array(config["out"], dtype=dtype)
 
-        x = relay.var("x", shape=dshape, dtype=dtype)
-        w = relay.var("w", shape=kshape, dtype=dtype)
-        y = relay.image.dilation2d(
-            x, w, strides=strides, dilations=dilations, padding=padding, **attrs
-        )
-        func = relay.Function([x, w], y)
-
-        for target, dev in tvm.testing.enabled_targets():
-            if target in except_targets:
-                continue
-            op_res = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
-                indata, kernel
-            )
-            tvm.testing.assert_allclose(op_res.numpy(), out, rtol=1e-5, atol=1e-5)
-
-    def _convert_data(indata, kernel, out, layout=None):
-        indata = np.asarray(indata)
-        kernel = np.asarray(kernel)
-        out = np.asarray(out)
-        if layout == "NCHW":
+        if data_layout == "NHWC":
+            pass
+        elif data_layout == "NCHW":
             indata = indata.transpose([0, 3, 1, 2])
             kernel = kernel.transpose([2, 0, 1])
             out = out.transpose([0, 3, 1, 2])
+        else:
+            raise ValueError(f"Unsupported layout '{data_layout}'")
+
         return indata, kernel, out
 
-    image = [[[[0.1], [0.2]], [[0.3], [0.4]]]]
-    kernel = [[[0.4], [0.3]], [[0.1], [0.0]]]
-    out = [[[[0.5]]]]
-    run_test_dilation2d(*_convert_data(image, kernel, out, layout="NCHW"))
-    run_test_dilation2d(*_convert_data(image, kernel, out), data_layout="NHWC", kernel_layout="HWI")
+    @tvm.testing.parametrize_targets("llvm")
+    def test_dilation2d(
+        self,
+        target,
+        dev,
+        test_case,
+        dtype,
+        config,
+        data_layout,
+        kernel_layout,
+    ):
+        strides = config.get("strides", [1, 1])
+        padding = config.get("padding", [0, 0])
+        dilations = config.get("dilations", [1, 1])
 
-    image = [[[[0.1], [0.2]], [[0.3], [0.4]]]]
-    kernel = [[[0.4], [0.3]], [[0.1], [0.0]]]
-    out = [[[[0.5], [0.6]], [[0.7], [0.8]]]]
-    run_test_dilation2d(*_convert_data(image, kernel, out, layout="NCHW"), padding=[0, 0, 1, 1])
-    run_test_dilation2d(
-        *_convert_data(image, kernel, out),
-        padding=[0, 0, 1, 1],
-        data_layout="NHWC",
-        kernel_layout="HWI",
-    )
+        indata, kernel, out = test_case
 
-    image = [[[[0.1, 0.2, 0.0], [0.2, 0.3, 0.1]], [[0.3, 0.4, 0.2], [0.4, 0.5, 0.3]]]]
-    kernel = [[[0.4, 0.5, 0.3], [0.3, 0.4, 0.2]], [[0.1, 0.2, 0.0], [0.0, 0.1, -0.1]]]
-    out = [[[[0.5, 0.7, 0.3], [0.6, 0.8, 0.4]], [[0.7, 0.9, 0.5], [0.8, 1.0, 0.6]]]]
-    run_test_dilation2d(*_convert_data(image, kernel, out, layout="NCHW"), padding=[0, 0, 1, 1])
-    run_test_dilation2d(
-        *_convert_data(image, kernel, out),
-        padding=[0, 0, 1, 1],
-        data_layout="NHWC",
-        kernel_layout="HWI",
-    )
+        x = relay.var("x", shape=indata.shape, dtype=dtype)
+        w = relay.var("w", shape=kernel.shape, dtype=dtype)
+        y = relay.image.dilation2d(
+            x,
+            w,
+            strides=strides,
+            dilations=dilations,
+            padding=padding,
+            data_layout=data_layout,
+            kernel_layout=kernel_layout,
+        )
+        func = relay.Function([x, w], y)
 
-    image = [[[[0.1], [0.2]], [[0.3], [0.4]]], [[[0.2], [0.3]], [[0.4], [0.5]]]]
-    kernel = [[[0.4], [0.3]], [[0.1], [0.0]]]
-    out = [[[[0.5], [0.6]], [[0.7], [0.8]]], [[[0.6], [0.7]], [[0.8], [0.9]]]]
-    run_test_dilation2d(*_convert_data(image, kernel, out, layout="NCHW"), padding=[0, 0, 1, 1])
-    run_test_dilation2d(
-        *_convert_data(image, kernel, out),
-        padding=[0, 0, 1, 1],
-        data_layout="NHWC",
-        kernel_layout="HWI",
-    )
-
-    image = [[[[0.1], [0.2]], [[0.3], [0.4]]]]
-    kernel = [[[0.4], [0.3]]]
-    out = [[[[0.5]], [[0.7]]]]
-    run_test_dilation2d(*_convert_data(image, kernel, out, layout="NCHW"))
-    run_test_dilation2d(*_convert_data(image, kernel, out), data_layout="NHWC", kernel_layout="HWI")
-
-    image = [[[[0.1], [0.2], [0.3]], [[0.4], [0.5], [0.6]], [[0.7], [0.8], [0.9]]]]
-    kernel = [[[0.4], [0.3]], [[0.1], [0.2]]]
-    out = [[[[0.7], [0.8], [0.6]], [[1.0], [1.1], [0.9]], [[0.8], [0.9], [0.9]]]]
-    run_test_dilation2d(
-        *_convert_data(image, kernel, out, layout="NCHW"), padding=[1, 1], dilations=[2, 2]
-    )
-    run_test_dilation2d(
-        *_convert_data(image, kernel, out),
-        padding=[1, 1],
-        dilations=[2, 2],
-        data_layout="NHWC",
-        kernel_layout="HWI",
-    )
-
-    image = [
-        [[[0.1], [0.2], [0.3], [0.4]], [[0.5], [0.6], [0.7], [0.8]], [[0.9], [1.0], [1.1], [1.2]]]
-    ]
-    kernel = [[[0.4], [0.3]], [[0.1], [0.2]]]
-    out = [[[[0.8], [1.0]], [[1.2], [1.4]]]]
-    run_test_dilation2d(*_convert_data(image, kernel, out, layout="NCHW"), strides=[1, 2])
-    run_test_dilation2d(
-        *_convert_data(image, kernel, out), strides=[1, 2], data_layout="NHWC", kernel_layout="HWI"
-    )
+        op_res = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
+            indata, kernel
+        )
+        tvm.testing.assert_allclose(op_res.numpy(), out, rtol=1e-5, atol=1e-5)
 
 
 @tvm.testing.uses_gpu
@@ -1523,25 +1570,4 @@ def test_all_class_non_max_suppression():
 
 
 if __name__ == "__main__":
-    test_resize_infer_type()
-    test_resize()
-    test_resize3d_infer_type()
-    test_crop_and_resize()
-    test_multibox_prior()
-    test_multibox_transform_loc()
-    test_get_valid_counts()
-    test_roi_align()
-    test_roi_pool()
-    test_proposal()
-    test_yolo_reorg_infer_shape()
-    test_yolo_reorg()
-    test_non_max_suppression()
-    test_deformable_conv2d()
-    test_depth_to_space()
-    test_space_to_depth()
-    test_dilation2d_infer_type()
-    test_dilation2d_run()
-    test_affine_grid()
-    test_grid_sample()
-    test_space_to_batch_nd()
-    test_all_class_non_max_suppression()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -34,7 +34,7 @@ from tvm.relay.transform import InferType
 from tvm.relay.testing import mlp
 
 
-def check_result(args, expected_result, mod=None):
+def check_result(target, dev, args, expected_result, mod=None):
     """
     Check that evaluating `expr` applied to the arguments produces
     `result` on Relay VM.
@@ -47,11 +47,8 @@ def check_result(args, expected_result, mod=None):
     expected_result:
         The expected result of running the expression.
     """
-    for target, dev in tvm.testing.enabled_targets():
-        rts_result = relay.create_executor("vm", device=dev, target=target, mod=mod).evaluate()(
-            *args
-        )
-        tvm.testing.assert_allclose(expected_result, rts_result.numpy())
+    rts_result = relay.create_executor("vm", device=dev, target=target, mod=mod).evaluate()(*args)
+    tvm.testing.assert_allclose(expected_result, rts_result.numpy())
 
 
 def veval(f, *args, device=tvm.cpu(), target="llvm"):
@@ -78,8 +75,7 @@ def vmobj_to_list(o):
         raise RuntimeError("Unknown object type: %s" % type(o))
 
 
-@tvm.testing.uses_gpu
-def test_split():
+def test_split(target, dev):
     x = relay.var("x", shape=(12,))
     y = relay.split(x, 3, axis=0).astuple()
     f = relay.Function([x], y)
@@ -88,14 +84,12 @@ def test_split():
         12,
     ).astype("float32")
     ref_res = np.split(x_data, 3, axis=0)
-    for tgt, dev in tvm.testing.enabled_targets():
-        res = veval(f, x_data, device=dev, target=tgt)
-        for i in range(3):
-            tvm.testing.assert_allclose(res[i].numpy(), ref_res[i])
+    res = veval(f, x_data, device=dev, target=target)
+    for i in range(3):
+        tvm.testing.assert_allclose(res[i].numpy(), ref_res[i])
 
 
-@tvm.testing.uses_gpu
-def test_split_no_fuse():
+def test_split_no_fuse(target, dev):
     x = relay.var("x", shape=(12,))
     y = relay.split(x, 3, axis=0).astuple()
     z = relay.concatenate([relay.TupleGetItem(y, 0)], axis=0)
@@ -104,29 +98,27 @@ def test_split_no_fuse():
     x_data = np.random.rand(
         12,
     ).astype("float32")
-    for tgt, dev in tvm.testing.enabled_targets():
-        res = veval(f, x_data, device=dev, target=tgt)
-        tvm.testing.assert_allclose(res.numpy(), np.split(x_data, 3, axis=0)[0])
+
+    res = veval(f, x_data, device=dev, target=target)
+    tvm.testing.assert_allclose(res.numpy(), np.split(x_data, 3, axis=0)[0])
 
 
-@tvm.testing.uses_gpu
-def test_id():
+def test_id(target, dev):
     x = relay.var("x", shape=(10, 10), dtype="float64")
     f = relay.Function([x], x)
     x_data = np.random.rand(10, 10).astype("float64")
     mod = tvm.IRModule()
     mod["main"] = f
-    check_result([x_data], x_data, mod=mod)
+    check_result(target, dev, [x_data], x_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_op():
+def test_op(target, dev):
     x = relay.var("x", shape=(10, 10))
     f = relay.Function([x], x + x)
     x_data = np.random.rand(10, 10).astype("float32")
     mod = tvm.IRModule()
     mod["main"] = f
-    check_result([x_data], 2 * x_data, mod=mod)
+    check_result(target, dev, [x_data], 2 * x_data, mod=mod)
 
 
 def any(x):
@@ -134,8 +126,8 @@ def any(x):
     return relay.op.min(x, axis=[0, 1])
 
 
-@tvm.testing.uses_gpu
-def test_cond():
+@tvm.testing.known_failing_targets("vulkan")
+def test_cond(target, dev):
     x = relay.var("x", shape=(10, 10))
     y = relay.var("y", shape=(10, 10))
     # f = relay.Function([x, y], relay.op.equal(x, y))
@@ -146,14 +138,14 @@ def test_cond():
     mod = tvm.IRModule()
     mod["main"] = f
     # same
-    check_result([x_data, x_data], True, mod=mod)
+    check_result(target, dev, [x_data, x_data], True, mod=mod)
 
     # diff
-    check_result([x_data, y_data], False, mod=mod)
+    check_result(target, dev, [x_data, y_data], False, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_simple_if():
+@tvm.testing.known_failing_targets("vulkan")
+def test_simple_if(target, dev):
     x = relay.var("x", shape=(10, 10))
     y = relay.var("y", shape=(10, 10))
     f = relay.Function([x, y], relay.If(any(relay.op.equal(x, y)), x, y))
@@ -163,14 +155,14 @@ def test_simple_if():
     mod = tvm.IRModule()
     mod["main"] = f
     # same
-    check_result([x_data, x_data], x_data, mod=mod)
+    check_result(target, dev, [x_data, x_data], x_data, mod=mod)
 
     # diff
-    check_result([x_data, y_data], y_data, mod=mod)
+    check_result(target, dev, [x_data, y_data], y_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_multiple_ifs():
+@tvm.testing.parametrize_targets("llvm")
+def test_multiple_ifs(target, dev):
     mod = tvm.IRModule({})
     b = relay.var("b")
     v0 = relay.var("v0")
@@ -184,14 +176,12 @@ def test_multiple_ifs():
     out = relay.Let(v0, relay.Tuple([relay.const(0)]), out)
     fn = relay.Function([b], out)
     mod["main"] = fn
-    dev = tvm.runtime.device("llvm", 0)
     func = relay.create_executor(device=dev, mod=mod, kind="vm").evaluate()
     res = vmobj_to_list(func(False))
     assert res == [1, 0]
 
 
-@tvm.testing.uses_gpu
-def test_unused_function():
+def test_unused_function(target, dev):
     cond = relay.const(True)
     mod = tvm.IRModule()
     then_name = relay.GlobalVar("times_2")
@@ -212,11 +202,10 @@ def test_unused_function():
     x_data = np.random.rand(2, 2).astype("float32")
     y_data = x_data * 2
 
-    check_result([x_data], y_data, mod=mod)
+    check_result(target, dev, [x_data], y_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_simple_call():
+def test_simple_call(target, dev):
     mod = tvm.IRModule({})
     sum_up = relay.GlobalVar("sum_up")
     i = relay.var("i", shape=[], dtype="int32")
@@ -227,11 +216,10 @@ def test_simple_call():
     i_data = np.array(0, dtype="int32")
     iarg = relay.var("iarg", shape=[], dtype="int32")
     mod["main"] = relay.Function([iarg], sum_up(iarg))
-    check_result([i_data], i_data, mod=mod)
+    check_result(target, dev, [i_data], i_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_count_loop():
+def test_count_loop(target, dev):
     mod = tvm.IRModule({})
     sum_up = relay.GlobalVar("sum_up")
     i = relay.var("i", shape=[], dtype="int32")
@@ -247,14 +235,12 @@ def test_count_loop():
     i_data = np.array(0, dtype="int32")
     iarg = relay.var("i", shape=[], dtype="int32")
     mod["main"] = relay.Function([iarg], sum_up(iarg))
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, i_data, device=dev, target=tgt)
-        tvm.testing.assert_allclose(result.numpy(), i_data)
-    check_result([i_data], i_data, mod=mod)
+    result = veval(mod, i_data, device=dev, target=target)
+    tvm.testing.assert_allclose(result.numpy(), i_data)
+    check_result(target, dev, [i_data], i_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_sum_loop():
+def test_sum_loop(target, dev):
     mod = tvm.IRModule({})
     sum_up = relay.GlobalVar("sum_up")
     i = relay.var("i", shape=[], dtype="int32")
@@ -275,11 +261,10 @@ def test_sum_loop():
     iarg = relay.var("i", shape=[], dtype="int32")
     aarg = relay.var("accum", shape=[], dtype="int32")
     mod["main"] = relay.Function([iarg, aarg], sum_up(iarg, aarg))
-    check_result([i_data, accum_data], sum(range(1, loop_bound + 1)), mod=mod)
+    check_result(target, dev, [i_data, accum_data], sum(range(1, loop_bound + 1)), mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_tuple_fst():
+def test_tuple_fst(target, dev):
     ttype = relay.TupleType([relay.TensorType((1,)), relay.TensorType((10,))])
     tup = relay.var("tup", type_annotation=ttype)
     f = relay.Function([tup], relay.TupleGetItem(tup, 0))
@@ -287,11 +272,10 @@ def test_tuple_fst():
     j_data = np.random.rand(10).astype("float32")
     mod = tvm.IRModule()
     mod["main"] = f
-    check_result([(i_data, j_data)], i_data, mod=mod)
+    check_result(target, dev, [(i_data, j_data)], i_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_tuple_second():
+def test_tuple_second(target, dev):
     ttype = relay.TupleType([relay.TensorType((1,)), relay.TensorType((10,))])
     tup = relay.var("tup", type_annotation=ttype)
     f = relay.Function([tup], relay.TupleGetItem(tup, 1))
@@ -299,11 +283,10 @@ def test_tuple_second():
     j_data = np.random.rand(10).astype("float32")
     mod = tvm.IRModule()
     mod["main"] = f
-    check_result([(i_data, j_data)], j_data, mod=mod)
+    check_result(target, dev, [(i_data, j_data)], j_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_list_constructor():
+def test_list_constructor(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -316,17 +299,15 @@ def test_list_constructor():
 
     mod["main"] = f
 
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        assert len(result) == 2
-        assert len(result[1]) == 2
+    result = veval(mod, device=dev, target=target)
+    assert len(result) == 2
+    assert len(result[1]) == 2
 
-        obj = vmobj_to_list(result)
-        tvm.testing.assert_allclose(obj, np.array([3, 2, 1]))
+    obj = vmobj_to_list(result)
+    tvm.testing.assert_allclose(obj, np.array([3, 2, 1]))
 
 
-@tvm.testing.uses_gpu
-def test_let_tensor():
+def test_let_tensor(target, dev):
     sb = relay.ScopeBuilder()
     shape = (1,)
     x = relay.var("x", shape=shape, dtype="float32")
@@ -342,11 +323,10 @@ def test_let_tensor():
     x_data = np.random.rand(*shape).astype("float32")
     mod = tvm.IRModule()
     mod["main"] = f
-    check_result([x_data], x_data + 42.0, mod=mod)
+    check_result(target, dev, [x_data], x_data + 42.0, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_let_scalar():
+def test_let_scalar(target, dev):
     sb = relay.ScopeBuilder()
 
     x = relay.var("x", "float32")
@@ -360,11 +340,10 @@ def test_let_scalar():
     x_data = np.array(np.random.rand()).astype("float32")
     mod = tvm.IRModule()
     mod["main"] = f
-    check_result([x_data], x_data + 42.0, mod=mod)
+    check_result(target, dev, [x_data], x_data + 42.0, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_compose():
+def test_compose(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -394,13 +373,11 @@ def test_compose():
     mod["main"] = f
 
     x_data = np.array(np.random.rand()).astype("float32")
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, [x_data], device=dev, target=tgt)
-        tvm.testing.assert_allclose(result.numpy(), x_data + 2.0)
+    result = veval(mod, [x_data], device=dev, target=target)
+    tvm.testing.assert_allclose(result.numpy(), x_data + 2.0)
 
 
-@tvm.testing.uses_gpu
-def test_list_hd():
+def test_list_hd(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -415,13 +392,11 @@ def test_list_hd():
 
     mod["main"] = f
 
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(result.numpy(), 3)
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(result.numpy(), 3)
 
 
-@pytest.mark.xfail
-def test_list_tl_empty_list():
+def test_list_tl_empty_list(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -432,12 +407,11 @@ def test_list_tl_empty_list():
 
     mod["main"] = f
 
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
+    with pytest.raises(tvm.error.TVMError):
+        result = veval(mod, device=dev, target=target)
 
 
-@tvm.testing.uses_gpu
-def test_list_tl():
+def test_list_tl(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -452,13 +426,11 @@ def test_list_tl():
 
     mod["main"] = f
 
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(vmobj_to_list(result), np.array([2, 1]))
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(vmobj_to_list(result), np.array([2, 1]))
 
 
-@tvm.testing.uses_gpu
-def test_list_nth():
+def test_list_nth(target, dev):
     expected = list(range(10))
 
     for i in range(len(expected)):
@@ -474,13 +446,11 @@ def test_list_nth():
 
         f = relay.Function([], nth(l, relay.const(i)))
         mod["main"] = f
-        for tgt, dev in tvm.testing.enabled_targets():
-            result = veval(mod, device=dev, target=tgt)
-            tvm.testing.assert_allclose(result.numpy(), expected[i])
+        result = veval(mod, device=dev, target=target)
+        tvm.testing.assert_allclose(result.numpy(), expected[i])
 
 
-@tvm.testing.uses_gpu
-def test_list_update():
+def test_list_update(target, dev):
     expected = list(range(10))
 
     mod = tvm.IRModule()
@@ -500,13 +470,11 @@ def test_list_update():
 
     f = relay.Function([], l)
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(vmobj_to_list(result), np.array(expected))
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(vmobj_to_list(result), np.array(expected))
 
 
-@tvm.testing.uses_gpu
-def test_list_length():
+def test_list_length(target, dev):
     expected = list(range(10))
 
     mod = tvm.IRModule()
@@ -524,13 +492,11 @@ def test_list_length():
 
     f = relay.Function([], l)
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(result.numpy(), 10)
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(result.numpy(), 10)
 
 
-@tvm.testing.uses_gpu
-def test_list_map():
+def test_list_map(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -544,13 +510,11 @@ def test_list_map():
 
     f = relay.Function([], map(add_one_func, l))
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(vmobj_to_list(result), np.array([3, 2]))
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(vmobj_to_list(result), np.array([3, 2]))
 
 
-@tvm.testing.uses_gpu
-def test_list_foldl():
+def test_list_foldl(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -564,13 +528,11 @@ def test_list_foldl():
     l = cons(relay.const(1), cons(relay.const(2), cons(relay.const(3), nil())))
     f = relay.Function([], foldl(rev_dup_func, nil(), l))
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(vmobj_to_list(result), np.array([3, 3, 2, 2, 1, 1]))
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(vmobj_to_list(result), np.array([3, 3, 2, 2, 1, 1]))
 
 
-@tvm.testing.uses_gpu
-def test_list_foldr():
+def test_list_foldr(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -584,13 +546,11 @@ def test_list_foldr():
     l = cons(relay.const(1), cons(relay.const(2), cons(relay.const(3), nil())))
     f = relay.Function([], foldr(identity_func, nil(), l))
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(vmobj_to_list(result), np.array([1, 2, 3]))
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(vmobj_to_list(result), np.array([1, 2, 3]))
 
 
-@tvm.testing.uses_gpu
-def test_list_sum():
+def test_list_sum(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -600,13 +560,11 @@ def test_list_sum():
     l = cons(relay.const(1), cons(relay.const(2), cons(relay.const(3), nil())))
     f = relay.Function([], sum(l))
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(result.numpy(), 6)
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(result.numpy(), 6)
 
 
-@tvm.testing.uses_gpu
-def test_list_filter():
+def test_list_filter(target, dev):
     mod = tvm.IRModule()
     p = Prelude(mod)
 
@@ -623,26 +581,22 @@ def test_list_filter():
     )
     f = relay.Function([], filter(greater_than_one, l))
     mod["main"] = f
-    for tgt, dev in tvm.testing.enabled_targets():
-        result = veval(mod, device=dev, target=tgt)
-        tvm.testing.assert_allclose(vmobj_to_list(result), np.array([3, 5]))
+    result = veval(mod, device=dev, target=target)
+    tvm.testing.assert_allclose(vmobj_to_list(result), np.array([3, 5]))
 
 
-@tvm.testing.uses_gpu
-def test_closure():
+def test_closure(target, dev):
     x = relay.var("x", shape=())
     y = relay.var("y", shape=())
     f = relay.Function([x], x + y)
     ff = relay.Function([y], f)
     clo = ff(relay.const(1.0))
     main = clo(relay.const(2.0))
-    for tgt, dev in tvm.testing.enabled_targets():
-        res = veval(main, device=dev, target=tgt)
-        tvm.testing.assert_allclose(res.numpy(), 3.0)
+    res = veval(main, device=dev, target=target)
+    tvm.testing.assert_allclose(res.numpy(), 3.0)
 
 
-@tvm.testing.uses_gpu
-def test_add_op_scalar():
+def test_add_op_scalar(target, dev):
     """
     test_add_op_scalar:
         fn (x, y) {
@@ -660,11 +614,10 @@ def test_add_op_scalar():
     ]
     for (x_data, y_data) in x_y_data:
         mod["main"] = func
-        check_result([x_data, y_data], x_data + y_data, mod=mod)
+        check_result(target, dev, [x_data, y_data], x_data + y_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_add_op_scalar_int():
+def test_add_op_scalar_int(target, dev):
     """
     test_add_op_scalar_int:
         fn (x, y) {
@@ -682,11 +635,10 @@ def test_add_op_scalar_int():
     ]
     for (x_data, y_data) in x_y_data:
         mod["main"] = func
-        check_result([x_data, y_data], x_data + y_data, mod=mod)
+        check_result(target, dev, [x_data, y_data], x_data + y_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_add_op_tensor():
+def test_add_op_tensor(target, dev):
     """
     test_add_op_tensor:
         fn (x, y) {
@@ -700,11 +652,10 @@ def test_add_op_tensor():
     x_data = np.random.rand(10, 5).astype("float32")
     y_data = np.random.rand(10, 5).astype("float32")
     mod["main"] = func
-    check_result([x_data, y_data], x_data + y_data, mod=mod)
+    check_result(target, dev, [x_data, y_data], x_data + y_data, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_add_op_broadcast():
+def test_add_op_broadcast(target, dev):
     """
     test_add_op_broadcast:
         fn (x, y) {
@@ -718,7 +669,7 @@ def test_add_op_broadcast():
     x_data = np.random.rand(10, 5).astype("float32")
     y_data = np.random.rand(1, 5).astype("float32")
     mod["main"] = func
-    check_result([x_data, y_data], x_data + y_data, mod=mod)
+    check_result(target, dev, [x_data, y_data], x_data + y_data, mod=mod)
 
 
 def test_vm_optimize_dynamic():
@@ -742,8 +693,7 @@ def test_vm_optimize():
     assert len(free_vars) == 1
 
 
-@tvm.testing.uses_gpu
-def test_loop_free_var():
+def test_loop_free_var(target, dev):
     x = relay.var("x", shape=(), dtype="int32")
     i = relay.var("i", shape=(), dtype="int32")
     s = relay.var("s", shape=(), dtype="int32")
@@ -765,11 +715,10 @@ def test_loop_free_var():
         ret = relay.TupleGetItem(tup, 1)
         mod = tvm.IRModule()
         mod["main"] = relay.Function(relay.analysis.free_vars(ret), ret)
-        check_result(args, expected, mod=mod)
+        check_result(target, dev, args, expected, mod=mod)
 
 
-@tvm.testing.uses_gpu
-def test_vm_reshape_tensor():
+def test_vm_reshape_tensor(target, dev):
     x_np = np.random.uniform(size=(8, 16)).astype("float32")
     x = relay.var("x", shape=(8, 16), dtype="float32")
     y = relay.reshape(x, [-1, 4, 8])
@@ -778,7 +727,7 @@ def test_vm_reshape_tensor():
     with tvm.transform.PassContext(opt_level=3):
         exec = relay.vm.compile(mod, "llvm")
     assert "reshape_tensor" in exec.bytecode
-    check_result([x_np], x_np.reshape([4, 4, 8]), mod)
+    check_result(target, dev, [x_np], x_np.reshape([4, 4, 8]), mod)
 
     x = relay.var("x", shape=(8, 16), dtype="float32")
     y = relay.reshape(x, [16, -1])
@@ -788,7 +737,7 @@ def test_vm_reshape_tensor():
     with tvm.transform.PassContext(opt_level=3):
         exec = relay.vm.compile(mod, "llvm")
     assert exec.bytecode.count("reshape_tensor") == 1
-    check_result([x_np], x_np.reshape([4, 4, 8]), mod)
+    check_result(target, dev, [x_np], x_np.reshape([4, 4, 8]), mod)
 
     # reshape with symbolic/any shape
     for n in [tvm.tir.Any(), tvm.te.size_var("n")]:
@@ -800,7 +749,7 @@ def test_vm_reshape_tensor():
         with tvm.transform.PassContext(opt_level=3):
             exec = relay.vm.compile(mod, "llvm")
         assert exec.bytecode.count("reshape_tensor") == 1
-        check_result([x_np], x_np.reshape([32, 2, 2]), mod)
+        check_result(target, dev, [x_np], x_np.reshape([32, 2, 2]), mod)
 
     # dyn.reshape
     x = relay.var("x", shape=(8, 16), dtype="float32")
@@ -814,10 +763,10 @@ def test_vm_reshape_tensor():
     assert exec.bytecode.count("reshape_tensor") == 2
     assert "reshape_tensor" in exec.bytecode
     y_np = np.array([8, 2, 8]).astype("int32")
-    check_result([x_np, y_np], x_np.reshape([8, 2, 8]), mod)
+    check_result(target, dev, [x_np, y_np], x_np.reshape([8, 2, 8]), mod)
 
 
-def test_vm_reshape_tuple(x_shape=(1, 4, 2), y_shape=(1, 2, 10)):
+def test_vm_reshape_tuple(target, dev, x_shape=(1, 4, 2), y_shape=(1, 2, 10)):
     tup = relay.var(
         "tup",
         type_annotation=relay.TupleType([relay.TensorType(x_shape), relay.TensorType(y_shape)]),
@@ -828,9 +777,8 @@ def test_vm_reshape_tuple(x_shape=(1, 4, 2), y_shape=(1, 2, 10)):
     x_data = np.random.uniform(size=x_shape).astype("float32")
     y_data = np.random.uniform(size=y_shape).astype("float32")
 
-    for tgt, dev in tvm.testing.enabled_targets():
-        res = veval(f, (x_data, y_data), device=dev, target=tgt)
-        tvm.testing.assert_allclose(res.numpy(), np.reshape(x_data, (1, -1)))
+    res = veval(f, (x_data, y_data), device=dev, target=target)
+    tvm.testing.assert_allclose(res.numpy(), np.reshape(x_data, (1, -1)))
 
 
 def test_constant_shape_with_external_codegen():
@@ -921,9 +869,8 @@ def test_get_output_single():
     np.testing.assert_allclose(outputs[0].numpy(), inp + inp)
 
 
-def test_get_output_multiple():
-    target = tvm.target.Target("llvm")
-
+@tvm.testing.parametrize_targets("llvm")
+def test_get_output_multiple(target, dev):
     # Build a IRModule.
     x = relay.var("x", shape=(10,))
     f = relay.Function([x], relay.Tuple([x + x, x]))
@@ -931,7 +878,7 @@ def test_get_output_multiple():
 
     # Compile to VMExecutable.
     vm_exec = vm.compile(mod, target=target)
-    vm_factory = runtime.vm.VirtualMachine(vm_exec, tvm.cpu())
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, dev)
     inp = np.ones(10, dtype="float32")
     vm_factory.invoke_stateful("main", inp)
     outputs = vm_factory.get_outputs()
@@ -940,9 +887,8 @@ def test_get_output_multiple():
     np.testing.assert_allclose(outputs[1].numpy(), inp)
 
 
-def test_get_input_index():
-    target = tvm.target.Target("llvm")
-
+@tvm.testing.parametrize_targets("llvm")
+def test_get_input_index(target, dev):
     # Build a IRModule.
     data_0, data_1 = ["d1", "d2"]
     x, y = [relay.var(c, shape=(10,)) for c in [data_0, data_1]]
@@ -951,16 +897,16 @@ def test_get_input_index():
 
     # Compile to VMExecutable.
     vm_exec = vm.compile(mod, target=target)
-    vm_factory = runtime.vm.VirtualMachine(vm_exec, tvm.cpu())
+    vm_factory = runtime.vm.VirtualMachine(vm_exec, dev)
     assert vm_factory.get_input_index(data_1) == 1
     assert vm_factory.get_input_index(data_0) == 0
     assert vm_factory.get_input_index("invalid") == -1
 
 
-@tvm.testing.requires_llvm
-def test_benchmark():
+@tvm.testing.parametrize_targets("llvm")
+def test_benchmark(target, dev):
     mod, params = mlp.get_workload(1)
-    lib = vm.compile(mod, target="llvm", params=params)
+    lib = vm.compile(mod, target=target, params=params)
     exe = runtime.vm.VirtualMachine(lib, tvm.cpu())
     data = tvm.nd.array(np.random.rand(1, 1, 28, 28).astype("float32"))
     result = exe.benchmark(tvm.cpu(), data, func_name="main", repeat=2, number=1)
@@ -973,7 +919,7 @@ def test_benchmark():
         "time_evaluator",
         return_value=lambda x: tvm.runtime.module.BenchmarkResult([1, 2, 2, 5]),
     ) as method:
-        result = exe.benchmark(tvm.cpu(), data, func_name="main", repeat=2, number=1)
+        result = exe.benchmark(dev, data, func_name="main", repeat=2, number=1)
         assert result.mean == 2.5
         assert result.median == 2.0
         assert result.max == 5
@@ -981,8 +927,7 @@ def test_benchmark():
         assert result.std == 1.5
 
 
-@tvm.testing.parametrize_targets("cuda", "llvm")
-def test_benchmark_end_to_end(dev, target):
+def test_benchmark_end_to_end(target, dev):
     mod, params = mlp.get_workload(1)
     lib = vm.compile(mod, target=target, params=params)
     exe = runtime.vm.VirtualMachine(lib, dev)
@@ -1014,4 +959,4 @@ def test_benchmark_end_to_end_rpc():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/unittest/test_tvm_testing_features.py
+++ b/tests/python/unittest/test_tvm_testing_features.py
@@ -98,7 +98,8 @@ class TestJointParameter:
 
     joint_usages = 0
     joint_param_vals = list(zip(param1_vals, param2_vals))
-    joint_param1, joint_param2 = tvm.testing.parameters(*joint_param_vals)
+    joint_param_ids = ["apple", "pear", "banana"]
+    joint_param1, joint_param2 = tvm.testing.parameters(*joint_param_vals, ids=joint_param_ids)
 
     def test_using_independent(self, param1, param2):
         type(self).independent_usages += 1
@@ -112,6 +113,14 @@ class TestJointParameter:
 
     def test_joint(self):
         assert self.joint_usages == len(self.joint_param_vals)
+
+    def test_joint_test_id(self, joint_param1, joint_param2, request):
+        param_string = (
+            request.node.name.replace(request.node.originalname, "")
+            .replace("[", "")
+            .replace("]", "")
+        )
+        assert param_string in self.joint_param_ids
 
 
 class TestFixtureCaching:

--- a/tests/python/unittest/test_tvm_testing_features.py
+++ b/tests/python/unittest/test_tvm_testing_features.py
@@ -87,6 +87,11 @@ class TestTargetAutoParametrization:
     def test_all_targets_ran(self):
         assert self.run_targets_with_known_failure == self.enabled_targets
 
+    @tvm.testing.known_failing_targets("llvm")
+    @tvm.testing.parametrize_targets("llvm")
+    def test_known_failing_explicit_list(self, target):
+        assert target != "llvm"
+
 
 class TestJointParameter:
     param1_vals = [1, 2, 3]
@@ -211,8 +216,8 @@ class TestBrokenFixture:
 class TestAutomaticMarks:
     @staticmethod
     def check_marks(request, target):
-        parameter = tvm.testing.plugin._pytest_target_params([target])[0]
-        required_marks = [decorator.mark for decorator in parameter.marks]
+        decorators = tvm.testing.plugin._target_to_requirement(target)
+        required_marks = [decorator.mark for decorator in decorators]
         applied_marks = list(request.node.iter_markers())
 
         for required_mark in required_marks:


### PR DESCRIPTION
This commit allows the relay test suite to be run targeting Vulkan with `TVM_TEST_TARGETS="vulkan -from_device=0" pytest tests/python/relay`.  All tests that require a specific environment are skipped if that environment isn't present.  All tests that are known to fail when running on Vulkan are marked as expected failure, and will be tracked in https://github.com/apache/tvm/issues/8903.