### PR TITLE
[Hexagon] Sort functions before adding to LLVM codegen

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -730,6 +730,12 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
     funcs.emplace_back(f);
   }
 
+  std::sort(funcs.begin(), funcs.end(), [](PrimFunc func_a, PrimFunc func_b) {
+    std::string name_a = func_a->GetAttr<String>(tvm::attr::kGlobalSymbol).value();
+    std::string name_b = func_b->GetAttr<String>(tvm::attr::kGlobalSymbol).value();
+    return name_a < name_b;
+  });
+
   cg->Init("TVMHexagonModule", tm.get(), ctx.get(), false, false, false);
   for (const PrimFunc& f : funcs) {
     cg->AddFunction(f);


### PR DESCRIPTION
PrimFuncs are stored in a map where the order of iteration is not deterministic. This can cause a different `llvm::Module` to be created each time, which can defeat debugging tools like `-opt-bisect-limit`.

Sort the PrimFuncs in a deterministic way before adding them to the LLVM code generator.
