### PR TITLE
Fix printing of schedule operations

### DIFF
--- a/src/te/schedule/schedule_lang.cc
+++ b/src/te/schedule/schedule_lang.cc
@@ -778,11 +778,18 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
       p->Print(op->outer);
       p->stream << ", inner=";
       p->Print(op->inner);
+      if (op->factor.defined()) {
+        p->stream << ", factor=";
+        p->Print(op->factor);
+      } else {
+        p->stream << ", nparts=";
+        p->Print(op->nparts);
+      }
       p->stream << ')';
     })
     .set_dispatch<FuseNode>([](const ObjectRef& node, ReprPrinter* p) {
       auto* op = static_cast<const FuseNode*>(node.get());
-      p->stream << "split(";
+      p->stream << "fuse(";
       p->stream << "outer=";
       p->Print(op->outer);
       p->stream << ", inner=";


### PR DESCRIPTION
- Add printing of factor/nparts in "split".
- Print correct operation name in "fuse".