### PR TITLE
[TOPI] Fix CUDA pooling schedule

### DIFF
--- a/python/tvm/topi/cuda/pooling.py
+++ b/python/tvm/topi/cuda/pooling.py
@@ -137,7 +137,7 @@ def schedule_pool(outs, layout):
     def traverse(OP):
         """Internal traverse function"""
         # inline all one-to-one-mapping operators except the last stage (output)
-        if tag.is_broadcast(OP.tag):
+        if tag.is_injective(OP.tag):
             if OP not in s.outputs:
                 s[OP].compute_inline()
             for tensor in OP.input_tensors:


### PR DESCRIPTION
Currently the schedule for pooling ops only allows fusion with broadcast ops, but injective ops should be possible to fuse with pooling ops.