### PR TITLE
[Bugfix] Fix div zero error in rewrite_simplify

### DIFF
--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -474,6 +474,8 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const DivNode* op) {
     if ((div(ramp(b1, c1, lanes), broadcast(c2, lanes))).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
+      // If divisor is equal to zero
+      ICHECK(c2val != 0) << "division by zero";
       if (c1val % c2val == 0) {
         return ramp(div(b1, c2), div(c1, c2), lanes).Eval();
       }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -474,7 +474,6 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const DivNode* op) {
     if ((div(ramp(b1, c1, lanes), broadcast(c2, lanes))).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
-      // If divisor is equal to zero
       ICHECK(c2val != 0) << "division by zero";
       if (c1val % c2val == 0) {
         return ramp(div(b1, c2), div(c1, c2), lanes).Eval();

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import py
 import pytest
 import tvm
 from tvm import te

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import py
+import pytest
 import tvm
 from tvm import te
 
@@ -931,20 +933,13 @@ def test_shift_left_simplify():
     ck.verify(z, tvm.tir.const(1 << 10, "int32"))
 
 
+def test_div_zero_simplify():
+    ck = RewriteChecker()
+
+    with pytest.raises(tvm.error.TVMError) as cm:
+        ck.analyzer.rewrite_simplify(tvm.tir.Div(tvm.tir.Ramp(1,1,2), tvm.tir.Broadcast(0, 2)))
+        assert "division by zero" in str(cm.execption)
+
+
 if __name__ == "__main__":
-    test_floordiv_index_simplify()
-    test_floormod_index_simplify()
-    test_cmp_simplify()
-    test_vector_simplify()
-    test_add_index_simplify()
-    test_sub_index_simplify()
-    test_mul_index_simplify()
-    test_div_index_simplify()
-    test_max_index_simplify()
-    test_min_index_simplify()
-    test_mod_index_simplify()
-    test_select_simplify()
-    test_logical_simplify()
-    test_let_simplify()
-    test_cast_simplify()
-    test_shift_left_simplify()
+    pytest.main([__file__])

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -937,7 +937,7 @@ def test_div_zero_simplify():
     ck = RewriteChecker()
 
     with pytest.raises(tvm.error.TVMError) as cm:
-        ck.analyzer.rewrite_simplify(tvm.tir.Div(tvm.tir.Ramp(1,1,2), tvm.tir.Broadcast(0, 2)))
+        ck.analyzer.rewrite_simplify(tvm.tir.Div(tvm.tir.Ramp(1, 1, 2), tvm.tir.Broadcast(0, 2)))
         assert "division by zero" in str(cm.execption)
 
 


### PR DESCRIPTION
## Bug Description

I found there will be a segfault when we try to  use `rewrite_simplify` to simplify div expr whose dividend and divisor are `Ramp` and `Broadcast` respectively.

Here is the code to trigger the segmentation fault error.

```python
import tvm

analyzer = tvm.arith.Analyzer()
analyzer.rewrite_simplify(tvm.tir.Div(tvm.tir.Ramp(1,1,2), tvm.tir.Broadcast(0, 2)))
```

```shell
(tvm-build) ➜  ~ python test_div_zero.py
[1]    44116 floating point exception (core dumped)  python test_div_zero.py
```

## Bug Analysis

The root cause of this bug is that two numbers are divided directly in [src/arith/rewrite_simplify.cc, Line 477](https://github.com/apache/tvm/blob/main/src/arith/rewrite_simplify.cc#L477).

![image](https://user-images.githubusercontent.com/25731241/132496381-cab7d565-0361-4b88-8397-bc34f3d3fca1.png)

Thus, I add a zero check in `src/arith/rewrite_simplify.cc` to prevent division by 0 in this commit. I also add a test case in `tests/python/unittest/test_arith_rewrite_simplify.py` to cover this problem.