### PR TITLE
[microTVM] Zephyr: Set 'choices' for ProjectOption 'verbose'

### DIFF
--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -234,7 +234,7 @@ PROJECT_OPTIONS = [
         help="Type of project to generate.",
         choices=tuple(PROJECT_TYPES),
     ),
-    server.ProjectOption("verbose", help="Run build with verbose output."),
+    server.ProjectOption("verbose", help="Run build with verbose output.", choices=(True, False)),
     server.ProjectOption(
         "west_cmd",
         help=(


### PR DESCRIPTION
Set 'choices' tuple returned for ProjectOption 'verbose' as a double
of True and False so TVMC and other interfaces can easily determine
it's a boolean option.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>
