### PR TITLE
[AutoScheduler] Change the doc to reflect previous code change

### DIFF
--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -652,8 +652,8 @@ def local_build_worker(args):
 
     Parameters
     ----------
-    args: Tuple[MeasureInput, str, int, int]
-        inputs, build-func, time, verbose args passed to local_builder_build
+    args: Tuple[MeasureInput, callable, int]
+        inputs, build-func, verbose args passed to local_builder_build
 
     Returns
     -------


### PR DESCRIPTION
This PR intends to change the doc of `auto_scheduler/measure.py` to reflect code change from #8939.

@vinx13 @junrushao1994 @tqchen 
