### PR TITLE
[Debug] iters_num and repeat were added to debug executor init args

### DIFF
--- a/docs/dev/debugger.rst
+++ b/docs/dev/debugger.rst
@@ -140,7 +140,7 @@ How to use Debugger?
 ::
 
     from tvm.contrib.debugger import debug_executor as graph_executor
-    m = graph_executor.create(graph, lib, dev, dump_root="/tmp/tvmdbg", iters_num=10, repeat=1)
+    m = graph_executor.create(graph, lib, dev, dump_root="/tmp/tvmdbg", number=10, repeat=1, min_repeat_ms=1)
     # set inputs
     m.set_input('data', tvm.nd.array(data.astype(dtype)))
     m.set_input(**params)
@@ -155,7 +155,7 @@ How to use Debugger?
 ::
 
     lib = tvm.runtime.load_module("network.so")
-    m = graph_executor.create(lib["get_graph_json"](), lib, dev, dump_root="/tmp/tvmdbg", iters_num=10, repeat=1)
+    m = graph_executor.create(lib["get_graph_json"](), lib, dev, dump_root="/tmp/tvmdbg", number=10, repeat=1, min_repeat_ms=1)
     # set inputs
     m.set_input('data', tvm.nd.array(data.astype(dtype)))
     m.set_input(**params)
@@ -166,8 +166,13 @@ How to use Debugger?
 
 The outputs are dumped to a temporary folder in ``/tmp`` folder or the
 folder specified while creating the runtime.
-iters_num is number of runs for measurement of average performance time for each op.
-repeat is number of iterations group. As a result, the number of outputs (see below) will be equal to repeat
+number argument is the number of times to run the inner loop of the timing code. This inner loop is run in
+between the timer starting and stopping. In order to amortize any timing overhead, `number` should be increased
+when the runtime of the function is small (less than a 1/10 of a millisecond).
+repeat argument is the number of times to run the outer loop of the timing code. The output will
+contain `repeat` number of datapoints.
+min_repeat_ms argument is optional. If set, the inner loop will be run until it takes longer than `min_repeat_ms`
+milliseconds. This can be used to ensure that the function is run enough to get an accurate measurement.
 
 ***************************************
 Sample Output

--- a/docs/dev/debugger.rst
+++ b/docs/dev/debugger.rst
@@ -140,7 +140,7 @@ How to use Debugger?
 ::
 
     from tvm.contrib.debugger import debug_executor as graph_executor
-    m = graph_executor.create(graph, lib, dev, dump_root="/tmp/tvmdbg")
+    m = graph_executor.create(graph, lib, dev, dump_root="/tmp/tvmdbg", iters_num=10, repeat=1)
     # set inputs
     m.set_input('data', tvm.nd.array(data.astype(dtype)))
     m.set_input(**params)
@@ -155,7 +155,7 @@ How to use Debugger?
 ::
 
     lib = tvm.runtime.load_module("network.so")
-    m = graph_executor.create(lib["get_graph_json"](), lib, dev, dump_root="/tmp/tvmdbg")
+    m = graph_executor.create(lib["get_graph_json"](), lib, dev, dump_root="/tmp/tvmdbg", iters_num=10, repeat=1)
     # set inputs
     m.set_input('data', tvm.nd.array(data.astype(dtype)))
     m.set_input(**params)
@@ -166,6 +166,8 @@ How to use Debugger?
 
 The outputs are dumped to a temporary folder in ``/tmp`` folder or the
 folder specified while creating the runtime.
+iters_num is number of runs for measurement of average performance time for each op.
+repeat is number of iterations group. As a result, the number of outputs (see below) will be equal to repeat
 
 ***************************************
 Sample Output

--- a/python/tvm/contrib/debugger/debug_executor.py
+++ b/python/tvm/contrib/debugger/debug_executor.py
@@ -56,7 +56,7 @@ def create(graph_json_str, libmod, device, dump_root=None, number=10, repeat=1, 
         `number` should be increased when the runtime of the function is small (less than a 1/10
         of a millisecond).
     repeat : int
-        Number of times to run the outer loop of the timing code (see above). The output will
+        Number of times to run the outer loop of the timing code. The output will
         contain `repeat` number of datapoints.
     min_repeat_ms : Optional[float]
         If set, the inner loop will be run until it takes longer than `min_repeat_ms`
@@ -111,7 +111,7 @@ class GraphModuleDebug(graph_executor.GraphModule):
         `number` should be increased when the runtime of the function is small (less than a 1/10
         of a millisecond).
     repeat : int
-        Number of times to run the outer loop of the timing code (see above). The output will
+        Number of times to run the outer loop of the timing code. The output will
         contain `repeat` number of datapoints.
     min_repeat_ms : Optional[float]
         If set, the inner loop will be run until it takes longer than `min_repeat_ms`

--- a/python/tvm/contrib/debugger/debug_executor.py
+++ b/python/tvm/contrib/debugger/debug_executor.py
@@ -53,7 +53,8 @@ def create(graph_json_str, libmod, device, dump_root=None, iters_num=10, repeat=
     iters_num : int
         Number of iterations for average performance time measurement
     repeat: int
-        Repeat argument for individual node run
+        number of iterations group. As a result, the number of output tables with time measured
+        will be equal to repea
     Returns
     -------
     graph_module : GraphModuleDebug
@@ -100,7 +101,8 @@ class GraphModuleDebug(graph_executor.GraphModule):
     iters_num : int
         Number of iterations for average performance time measurement
     repeat: int
-        Repeat argument for individual node run
+        number of iterations group. As a result, the number of output tables with time measured
+        will be equal to repeat
     """
 
     def __init__(self, module, device, graph_json_str, dump_root, iters_num=10, repeat=1):


### PR DESCRIPTION
iters_num and repeat were added to debug executor to control them on high level of API. Before it they were hard coded 
