### PR TITLE
Fix test to reflect change of simd size for ARM

### DIFF
--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -562,9 +562,9 @@ def test_name_sanitiser_name_clash():
 @pytest.mark.parametrize(
     "workspace_byte_alignment,main_workspace_size,sum_workspace_size",
     [
-        (8, 10368, 15392),
-        (16, 10368, 15424),
-        (256, 10752, 17664),
+        (8, 10368, 15200),
+        (16, 10368, 15232),
+        (256, 10752, 17408),
     ],
 )
 def test_memory_planning(workspace_byte_alignment, main_workspace_size, sum_workspace_size):


### PR DESCRIPTION
Fixed below tests:
```
FAILED tests/python/relay/aot/test_crt_aot.py::test_memory_planning[8-10368-15392]
FAILED tests/python/relay/aot/test_crt_aot.py::test_memory_planning[16-10368-15424]
FAILED tests/python/relay/aot/test_crt_aot.py::test_memory_planning[256-10752-17664]
```

Root cause: after adding of big number x86 cpu from LLVM to topi logic and the change of the `get_simd_32bit_lanes()` logic to return default SIMD size to 128bit value, the tests appeared after creation of int8 AVX2 PR and which passed with previous default value started to fail after int8 AVX2 merge

The 128 is a correct value for ARM, need to change the test, not the default value in get_simd_32bit_lanes()