### PR TITLE
[DOCS] Add github issue template for documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,22 @@
+---
+name: "\U0001F4C4 Documentation"
+about: Use this template to suggest additions and changes to the documentation.
+title: "[Docs] "
+labels: "type: doc"
+
+---
+
+Thanks for participating in the TVM community! We use https://discuss.tvm.ai for any general usage questions and discussions. The issue tracker is used for actionable items such as feature proposals discussion, roadmaps, and bug tracking.  You are always welcomed to post on the forum first :smile_cat:
+
+Issues that are inactive for a period of time may get closed. We adopt this policy so that we won't lose track of actionable issues that may fall at the bottom of the pile. Feel free to reopen a new one if you feel there is an additional problem that needs attention when an old one gets closed.
+
+### Documentation Title & Type
+
+Include the title of the document (e.g. "Getting Started with TVM"), and the type of documentation (e.g. user docs, developer docs, tutorials)
+
+### Additions/Changes Requested
+
+If an RFC/discuss post exists, link it here.
+
+Otherwise, specify what actions should be taken to provide additional clarity/readability/reproducibility to the document. Include code snippets from the previous documentation if applicable.
+


### PR DESCRIPTION
I really like the new issue templates that @Mousius created, and I think we could encourage the community to contribute more on docs if we had an issue category for docs like we do for bugs and CI. With that being said, this PR adds a new issue template for docs.