### PR TITLE
[AutoScheduler] Fix task scheduler after 8478

### DIFF
--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -480,6 +480,7 @@ class TaskScheduler:
 
     def _compute_score(self, costs):
         """compute the objective function"""
+        # Make sure to return float.
         score = self.objective_func(costs)
         return score.value if hasattr(score, "value") else score
 

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -480,7 +480,8 @@ class TaskScheduler:
 
     def _compute_score(self, costs):
         """compute the objective function"""
-        return self.objective_func(costs)
+        score = self.objective_func(costs)
+        return score.value if hasattr(score, "value") else score
 
     def _adjust_similarity_group(self, task_idx):
         """adjust the similarity group for the selected task"""
@@ -598,7 +599,7 @@ class PrintTableInfo(TaskSchedulerCallback):
 
         # overall info
         if all(cost < 1e9 for cost in task_scheduler.best_costs):
-            total_latency_str = "%.3f" % (task_scheduler.cur_score.value * 1e3)
+            total_latency_str = "%.3f" % (task_scheduler.cur_score * 1e3)
         else:
             total_latency_str = "-"
         print(
@@ -629,7 +630,7 @@ class LogEstimatedLatency(TaskSchedulerCallback):
 
     def post_tune(self, task_scheduler, task_id):
         if all(cost < 1e9 for cost in task_scheduler.best_costs):
-            total_latency_str = "%.3f" % (task_scheduler.cur_score.value * 1e3)
+            total_latency_str = "%.3f" % (task_scheduler.cur_score * 1e3)
         else:
             total_latency_str = "N/A"
 


### PR DESCRIPTION
#8478 added `.value` to the use of `cur_score`. However, its type may not be a TVM primitive but a numpy value. In this case, we will encounter the following error:

```
total_latency_str = "%.3f" % (task_scheduler.cur_score.value * 1e3)
AttributeError: 'numpy.float64' object has no attribute 'value
```

Although I cannot find the reason why `cur_score` would be a TVM primitive, I make sure its producer `_compute_score` returns a native/numpy value in this PR.

cc @echuraev @jcf94 