### PR TITLE
[BugFix] Unexpected crash by tricky parameters in TVM's Python API

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -119,10 +119,10 @@ class PrimExpr : public BaseExpr {
    */
   TVM_DLL PrimExpr(float value);  // NOLINT(*)
 
-  /*! \return the data type of this expression. */
-  DataType dtype() const { return static_cast<const PrimExprNode*>(get())->dtype; }
-
   TVM_DEFINE_OBJECT_REF_METHODS(PrimExpr, BaseExpr, PrimExprNode);
+
+  /*! \return the data type of this expression. */
+  DataType dtype() const { return operator->()->dtype; }
 
  private:
   // Internal function for conversion.

--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -363,13 +363,15 @@ class Array : public ObjectRef {
   using reverse_iterator = ReverseIterAdapter<ValueConverter, const ObjectRef*>;
 
   /*! \return begin iterator */
-  iterator begin() const { 
-    return iterator(nullptr == GetArrayNode() ? static_cast<const ObjectRef*>(nullptr) : GetArrayNode()->begin()); 
+  iterator begin() const {
+    return iterator(nullptr == GetArrayNode() ? static_cast<const ObjectRef*>(nullptr)
+                                              : GetArrayNode()->begin());
   }
 
   /*! \return end iterator */
-  iterator end() const { 
-    return iterator(nullptr == GetArrayNode() ? static_cast<const ObjectRef*>(nullptr) : GetArrayNode()->end()); 
+  iterator end() const {
+    return iterator(nullptr == GetArrayNode() ? static_cast<const ObjectRef*>(nullptr)
+                                              : GetArrayNode()->end());
   }
 
   /*! \return rbegin iterator */

--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -363,10 +363,14 @@ class Array : public ObjectRef {
   using reverse_iterator = ReverseIterAdapter<ValueConverter, const ObjectRef*>;
 
   /*! \return begin iterator */
-  iterator begin() const { return iterator(GetArrayNode()->begin()); }
+  iterator begin() const { 
+    return iterator(nullptr == GetArrayNode() ? static_cast<const ObjectRef*>(nullptr) : GetArrayNode()->begin()); 
+  }
 
   /*! \return end iterator */
-  iterator end() const { return iterator(GetArrayNode()->end()); }
+  iterator end() const { 
+    return iterator(nullptr == GetArrayNode() ? static_cast<const ObjectRef*>(nullptr) : GetArrayNode()->end()); 
+  }
 
   /*! \return rbegin iterator */
   reverse_iterator rbegin() const {

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -538,7 +538,10 @@ class ObjectRef {
   /*! \return the internal object pointer */
   const Object* get() const { return data_.get(); }
   /*! \return the internal object pointer */
-  const Object* operator->() const { ICHECK(nullptr != get()) << "Calling `->` to nullptr"; return get(); }
+  const Object* operator->() const {
+    ICHECK(nullptr != get()) << "Calling `->` to nullptr";
+    return get();
+  }
   /*! \return whether the reference is unique */
   bool unique() const { return data_.unique(); }
   /*! \return The use count of the ptr, for debug purposes */
@@ -703,16 +706,16 @@ struct ObjectPtrEqual {
  * \param ParentType The parent type of the objectref
  * \param ObjectName The type name of the object.
  */
-#define TVM_DEFINE_OBJECT_REF_METHODS(TypeName, ParentType, ObjectName)                        \
-  TypeName() = default;                                                                        \
-  explicit TypeName(::tvm::runtime::ObjectPtr<::tvm::runtime::Object> n) : ParentType(n) {}    \
-  TVM_DEFINE_DEFAULT_COPY_MOVE_AND_ASSIGN(TypeName);                                           \
-  const ObjectName* operator->() const {                                                       \
-    auto ptr = static_cast<const ObjectName*>(data_.get());                                    \
+#define TVM_DEFINE_OBJECT_REF_METHODS(TypeName, ParentType, ObjectName)                     \
+  TypeName() = default;                                                                     \
+  explicit TypeName(::tvm::runtime::ObjectPtr<::tvm::runtime::Object> n) : ParentType(n) {} \
+  TVM_DEFINE_DEFAULT_COPY_MOVE_AND_ASSIGN(TypeName);                                        \
+  const ObjectName* operator->() const {                                                    \
+    auto ptr = static_cast<const ObjectName*>(data_.get());                                 \
     ICHECK(nullptr != ptr) << "Calling `->` to <" #ObjectName ">(null)";                    \
-    return ptr;                                                                                \
-  }                                                                                            \
-  const ObjectName* get() const { return static_cast<const ObjectName*>(data_.get()); }        \
+    return ptr;                                                                             \
+  }                                                                                         \
+  const ObjectName* get() const { return static_cast<const ObjectName*>(data_.get()); }     \
   using ContainerType = ObjectName;
 
 /*
@@ -744,7 +747,7 @@ struct ObjectPtrEqual {
   explicit TypeName(::tvm::runtime::ObjectPtr<::tvm::runtime::Object> n) : ParentType(n) {} \
   ObjectName* operator->() const {                                                          \
     auto ptr = static_cast<ObjectName*>(data_.get());                                       \
-    ICHECK(nullptr != ptr) << "Calling `->` to <" #ObjectName ">(null)";                 \
+    ICHECK(nullptr != ptr) << "Calling `->` to <" #ObjectName ">(null)";                    \
     return ptr;                                                                             \
   }                                                                                         \
   using ContainerType = ObjectName;

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -538,7 +538,7 @@ class ObjectRef {
   /*! \return the internal object pointer */
   const Object* get() const { return data_.get(); }
   /*! \return the internal object pointer */
-  const Object* operator->() const { return get(); }
+  const Object* operator->() const { ICHECK(nullptr != get()) << "Calling `->` to nullptr"; return get(); }
   /*! \return whether the reference is unique */
   bool unique() const { return data_.unique(); }
   /*! \return The use count of the ptr, for debug purposes */
@@ -707,8 +707,12 @@ struct ObjectPtrEqual {
   TypeName() = default;                                                                        \
   explicit TypeName(::tvm::runtime::ObjectPtr<::tvm::runtime::Object> n) : ParentType(n) {}    \
   TVM_DEFINE_DEFAULT_COPY_MOVE_AND_ASSIGN(TypeName);                                           \
-  const ObjectName* operator->() const { return static_cast<const ObjectName*>(data_.get()); } \
-  const ObjectName* get() const { return operator->(); }                                       \
+  const ObjectName* operator->() const {                                                       \
+    auto ptr = static_cast<const ObjectName*>(data_.get());                                    \
+    ICHECK(nullptr != ptr) << "Calling `->` to <" #ObjectName ">(null)";                    \
+    return ptr;                                                                                \
+  }                                                                                            \
+  const ObjectName* get() const { return static_cast<const ObjectName*>(data_.get()); }        \
   using ContainerType = ObjectName;
 
 /*
@@ -738,7 +742,11 @@ struct ObjectPtrEqual {
   TypeName() = default;                                                                     \
   TVM_DEFINE_DEFAULT_COPY_MOVE_AND_ASSIGN(TypeName);                                        \
   explicit TypeName(::tvm::runtime::ObjectPtr<::tvm::runtime::Object> n) : ParentType(n) {} \
-  ObjectName* operator->() const { return static_cast<ObjectName*>(data_.get()); }          \
+  ObjectName* operator->() const {                                                          \
+    auto ptr = static_cast<ObjectName*>(data_.get());                                       \
+    ICHECK(nullptr != ptr) << "Calling `->` to <" #ObjectName ">(null)";                 \
+    return ptr;                                                                             \
+  }                                                                                         \
   using ContainerType = ObjectName;
 
 /*

--- a/include/tvm/tir/var.h
+++ b/include/tvm/tir/var.h
@@ -114,7 +114,8 @@ class Var : public PrimExpr {
    * \brief Get pointer to the internal value.
    * \return the corresponding Variable.
    */
-  const VarNode* operator->() const { return get(); }
+  const VarNode* operator->() const { ICHECK(nullptr != get()) << "Calling `->` to <VarNode>(null)"; return get(); }
+
   /*!
    * \brief Get pointer to the internal value.
    * \return the corresponding Variable.

--- a/include/tvm/tir/var.h
+++ b/include/tvm/tir/var.h
@@ -114,7 +114,10 @@ class Var : public PrimExpr {
    * \brief Get pointer to the internal value.
    * \return the corresponding Variable.
    */
-  const VarNode* operator->() const { ICHECK(nullptr != get()) << "Calling `->` to <VarNode>(null)"; return get(); }
+  const VarNode* operator->() const {
+    ICHECK(nullptr != get()) << "Calling `->` to <VarNode>(null)";
+    return get();
+  }
 
   /*!
    * \brief Get pointer to the internal value.

--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -106,6 +106,7 @@ class BlockReadWriteDetector : public StmtExprVisitor {
 };
 
 void BlockReadWriteDetector::operator()(const Stmt& stmt) {
+  ICHECK(nullptr != stmt.get()) << "Cannot pass null statement to BlockReadWriteDetector::operator()";
   const auto* block = stmt.as<BlockNode>();
   ICHECK(block != nullptr) << "Only visiting Blocks is allowed, but got " << stmt->GetTypeKey();
   for (const MatchBufferRegion& match_buffer : block->match_buffers) {

--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -106,7 +106,8 @@ class BlockReadWriteDetector : public StmtExprVisitor {
 };
 
 void BlockReadWriteDetector::operator()(const Stmt& stmt) {
-  ICHECK(nullptr != stmt.get()) << "Cannot pass null statement to BlockReadWriteDetector::operator()";
+  ICHECK(nullptr != stmt.get())
+      << "Cannot pass null statement to BlockReadWriteDetector::operator()";
   const auto* block = stmt.as<BlockNode>();
   ICHECK(block != nullptr) << "Only visiting Blocks is allowed, but got " << stmt->GetTypeKey();
   for (const MatchBufferRegion& match_buffer : block->match_buffers) {

--- a/src/tir/analysis/verify_gpu_code.cc
+++ b/src/tir/analysis/verify_gpu_code.cc
@@ -242,6 +242,8 @@ class GPUCodeVerifier : public StmtExprVisitor {
 };
 
 std::vector<String> VerifyGPUCode_(const PrimFunc& func, Map<String, PrimExpr> constraints) {
+  ICHECK(nullptr != constraints.get()) << "Cannot pass null map to VerifyGPUCode_";
+
   GPUCodeVerifier verifier;
 
   int64_t max_local_memory_per_block = INT64_MAX;

--- a/tests/python/unittest/test_tir_base.py
+++ b/tests/python/unittest/test_tir_base.py
@@ -117,63 +117,59 @@ def test_exception():
     with pytest.raises(tvm.TVMError):
         x = tir.Var(name=1, dtype="int")
 
+
 def test_nullptr_exception():
     test_candidates = [
-            (tvm.tir.analysis.calculate_workspace_bytes, (None, None)),
-            (tvm.tir.analysis.detect_buffer_access_lca, (None, )),
-            (tvm.tir.analysis.get_block_access_region, (None, None)),
-            (tvm.tir.analysis.get_block_read_write_region, (None, None)),
-            (tvm.tir.analysis.verify_gpu_code, (None, None)),
-            (tvm.tir.analysis.verify_memory, (None, )),
-            (tvm.tir.analysis.verify_ssa, (None, )),
-            (tvm.tir.analysis.BufferRegion, (None, None)),
-
-            # tir.expr
-            (tvm.tir.expr.BufferLoad, (None, None, None)),
-            (tvm.tir.expr.Call, (None, None, None, None)),
-            (tvm.tir.expr.ProducerLoad, (None, None, None)),
-
-            # tir.generic
-            (tvm.tir.generic.add, (None, None, None)),
-            (tvm.tir.generic.cast, (None, None, None)),
-            (tvm.tir.generic.divide, (None, None, None)),
-            (tvm.tir.generic.floordiv, (None, None, None)),
-            (tvm.tir.generic.multiply, (None, None, None)),
-            (tvm.tir.generic.subtract, (None, None, None)),
-
-            # tir.op
-            (tvm.tir.op.abs, (None, None)),
-            (tvm.tir.op.ceil, (None, None)),
-            (tvm.tir.op.clz, (None, )),
-            (tvm.tir.op.div, (None, None, None)),
-            (tvm.tir.op.floor, (None, None)),
-            (tvm.tir.op.floordiv, (None, None, None)),
-            (tvm.tir.op.floormod, (None, None, None)),
-            (tvm.tir.op.if_then_else, (None, None, None, None)),
-            (tvm.tir.op.indexdiv, (None, None, None)),
-            (tvm.tir.op.indexmod, (None, None, None)),
-            (tvm.tir.op.isfinite, (None, None)),
-            (tvm.tir.op.isinf, (None, None)),
-            (tvm.tir.op.isnan, (None, None)),
-            (tvm.tir.op.nearbyint, (None, None)),
-            (tvm.tir.op.power, (None, None, None)),
-            (tvm.tir.op.q_multiply_shift, (None, None, None, None)),
-            (tvm.tir.op.round, (None, None)),
-            (tvm.tir.op.trunc, (None, None)),
-            (tvm.tir.op.truncdiv, (None, None, None)),
-            (tvm.tir.op.truncmod, (None, None, None)),
-            (tvm.tir.op.Call, (None, None, None, None)),
-
-            # tir.stmt_functor
-            (tvm.tir.stmt_functor.ir_transform, (None, None, None, None)),
-            (tvm.tir.stmt_functor.post_order_visit, (None, None)),
-            (tvm.tir.stmt_functor.substitute, (None, None)),
-
-            # tvm.stmt
-            (tvm.tir.stmt.Allocate, (None, None, None, None, None, None)),
-            (tvm.tir.stmt.BlockRealize, (None, None, None, None)),
-            (tvm.tir.stmt.BufferRegion, (None, None)),
-            (tvm.tir.stmt.MatchBufferRegion, (None, None)),
+        (tvm.tir.analysis.calculate_workspace_bytes, (None, None)),
+        (tvm.tir.analysis.detect_buffer_access_lca, (None,)),
+        (tvm.tir.analysis.get_block_access_region, (None, None)),
+        (tvm.tir.analysis.get_block_read_write_region, (None, None)),
+        (tvm.tir.analysis.verify_gpu_code, (None, None)),
+        (tvm.tir.analysis.verify_memory, (None,)),
+        (tvm.tir.analysis.verify_ssa, (None,)),
+        (tvm.tir.analysis.BufferRegion, (None, None)),
+        # tir.expr
+        (tvm.tir.expr.BufferLoad, (None, None, None)),
+        (tvm.tir.expr.Call, (None, None, None, None)),
+        (tvm.tir.expr.ProducerLoad, (None, None, None)),
+        # tir.generic
+        (tvm.tir.generic.add, (None, None, None)),
+        (tvm.tir.generic.cast, (None, None, None)),
+        (tvm.tir.generic.divide, (None, None, None)),
+        (tvm.tir.generic.floordiv, (None, None, None)),
+        (tvm.tir.generic.multiply, (None, None, None)),
+        (tvm.tir.generic.subtract, (None, None, None)),
+        # tir.op
+        (tvm.tir.op.abs, (None, None)),
+        (tvm.tir.op.ceil, (None, None)),
+        (tvm.tir.op.clz, (None,)),
+        (tvm.tir.op.div, (None, None, None)),
+        (tvm.tir.op.floor, (None, None)),
+        (tvm.tir.op.floordiv, (None, None, None)),
+        (tvm.tir.op.floormod, (None, None, None)),
+        (tvm.tir.op.if_then_else, (None, None, None, None)),
+        (tvm.tir.op.indexdiv, (None, None, None)),
+        (tvm.tir.op.indexmod, (None, None, None)),
+        (tvm.tir.op.isfinite, (None, None)),
+        (tvm.tir.op.isinf, (None, None)),
+        (tvm.tir.op.isnan, (None, None)),
+        (tvm.tir.op.nearbyint, (None, None)),
+        (tvm.tir.op.power, (None, None, None)),
+        (tvm.tir.op.q_multiply_shift, (None, None, None, None)),
+        (tvm.tir.op.round, (None, None)),
+        (tvm.tir.op.trunc, (None, None)),
+        (tvm.tir.op.truncdiv, (None, None, None)),
+        (tvm.tir.op.truncmod, (None, None, None)),
+        (tvm.tir.op.Call, (None, None, None, None)),
+        # tir.stmt_functor
+        (tvm.tir.stmt_functor.ir_transform, (None, None, None, None)),
+        (tvm.tir.stmt_functor.post_order_visit, (None, None)),
+        (tvm.tir.stmt_functor.substitute, (None, None)),
+        # tvm.stmt
+        (tvm.tir.stmt.Allocate, (None, None, None, None, None, None)),
+        (tvm.tir.stmt.BlockRealize, (None, None, None, None)),
+        (tvm.tir.stmt.BufferRegion, (None, None)),
+        (tvm.tir.stmt.MatchBufferRegion, (None, None)),
     ]
 
     for func, args in test_candidates:
@@ -182,7 +178,6 @@ def test_nullptr_exception():
             func(*args)
         except TVMError as _:
             pass
-            
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_base.py
+++ b/tests/python/unittest/test_tir_base.py
@@ -117,9 +117,77 @@ def test_exception():
     with pytest.raises(tvm.TVMError):
         x = tir.Var(name=1, dtype="int")
 
+def test_nullptr_exception():
+    test_candidates = [
+            (tvm.tir.analysis.calculate_workspace_bytes, (None, None)),
+            (tvm.tir.analysis.detect_buffer_access_lca, (None, )),
+            (tvm.tir.analysis.get_block_access_region, (None, None)),
+            (tvm.tir.analysis.get_block_read_write_region, (None, None)),
+            (tvm.tir.analysis.verify_gpu_code, (None, None)),
+            (tvm.tir.analysis.verify_memory, (None, )),
+            (tvm.tir.analysis.verify_ssa, (None, )),
+            (tvm.tir.analysis.BufferRegion, (None, None)),
+
+            # tir.expr
+            (tvm.tir.expr.BufferLoad, (None, None, None)),
+            (tvm.tir.expr.Call, (None, None, None, None)),
+            (tvm.tir.expr.ProducerLoad, (None, None, None)),
+
+            # tir.generic
+            (tvm.tir.generic.add, (None, None, None)),
+            (tvm.tir.generic.cast, (None, None, None)),
+            (tvm.tir.generic.divide, (None, None, None)),
+            (tvm.tir.generic.floordiv, (None, None, None)),
+            (tvm.tir.generic.multiply, (None, None, None)),
+            (tvm.tir.generic.subtract, (None, None, None)),
+
+            # tir.op
+            (tvm.tir.op.abs, (None, None)),
+            (tvm.tir.op.ceil, (None, None)),
+            (tvm.tir.op.clz, (None, )),
+            (tvm.tir.op.div, (None, None, None)),
+            (tvm.tir.op.floor, (None, None)),
+            (tvm.tir.op.floordiv, (None, None, None)),
+            (tvm.tir.op.floormod, (None, None, None)),
+            (tvm.tir.op.if_then_else, (None, None, None, None)),
+            (tvm.tir.op.indexdiv, (None, None, None)),
+            (tvm.tir.op.indexmod, (None, None, None)),
+            (tvm.tir.op.isfinite, (None, None)),
+            (tvm.tir.op.isinf, (None, None)),
+            (tvm.tir.op.isnan, (None, None)),
+            (tvm.tir.op.nearbyint, (None, None)),
+            (tvm.tir.op.power, (None, None, None)),
+            (tvm.tir.op.q_multiply_shift, (None, None, None, None)),
+            (tvm.tir.op.round, (None, None)),
+            (tvm.tir.op.trunc, (None, None)),
+            (tvm.tir.op.truncdiv, (None, None, None)),
+            (tvm.tir.op.truncmod, (None, None, None)),
+            (tvm.tir.op.Call, (None, None, None, None)),
+
+            # tir.stmt_functor
+            (tvm.tir.stmt_functor.ir_transform, (None, None, None, None)),
+            (tvm.tir.stmt_functor.post_order_visit, (None, None)),
+            (tvm.tir.stmt_functor.substitute, (None, None)),
+
+            # tvm.stmt
+            (tvm.tir.stmt.Allocate, (None, None, None, None, None, None)),
+            (tvm.tir.stmt.BlockRealize, (None, None, None, None)),
+            (tvm.tir.stmt.BufferRegion, (None, None)),
+            (tvm.tir.stmt.MatchBufferRegion, (None, None)),
+    ]
+
+    for func, args in test_candidates:
+        try:
+            print(func.__name__)
+            func(*args)
+        except TVMError as _:
+            pass
+            
+
 
 if __name__ == "__main__":
     test_scalar_add()
     test_ret_const()
     test_control_flow_jump()
     test_exception()
+    test_nullptr_exception()


### PR DESCRIPTION
#### Background

This is a fixing proposal to [Discussion#10988](https://discuss.tvm.apache.org/t/operators-will-crash-when-receiving-null-object/10988) and https://github.com/apache/tvm/issues/8979 .

#### Approach

This PR fixed unexpected C++ crash by:
1. check `nullptr` before using `operator->` (in this case, it must crash);
2. allow `None` containers (Array) being capable of range-based for; (otherwise crash);
3. add specific nullptr checking to other complicated cases (e.g., `ICHECK(false) << ... << statement_causing_TVMError` will result in crash);

This PR passed test cases contributed in https://github.com/apache/tvm/issues/8979 (the crashes that can be trigger by giving `None` parameters in TVM's core python APIs)

#### Comparison with other options

According to the discussion, I also tried other proposals but don't think they are good approaches: 
(1) `NOTNULLABLE` and `tvm::runtime::Optional` suggested by @junrushao1994 and @Hzfengsy ; -> still requires lots of code changes on legacy codes;
(2) Add checkers for all those `.set_body*` statements; -> not fundamental that checkers will scale when new interface coming in;

This PR fixed a fundamental issue causing invalid memory access crashes: avoid `nullptr` objects using `->` operator because it must result in program crash; It only requires ~40 lines of edit and very few future engineering (since the fundamental issue is resolved).

#### Known issue 

Statements like `ICHECK(false) << ... << statement_causing_TVMError` will still crash so that we have to manually add new checkers before it. e.g., line 112 in `BlockReadWriteDetector::operator()`.
