### PR TITLE
[Relay, Tests] Make expressions in the DynamicToStatic pass tests more dynamic

### DIFF
--- a/tests/python/relay/test_pass_dynamic_to_static.py
+++ b/tests/python/relay/test_pass_dynamic_to_static.py
@@ -26,10 +26,12 @@ import tvm.topi.testing
 import tvm.testing
 
 
-def run_opt_pass(expr, opt_pass):
+def run_opt_pass(expr, opt_pass, params=None):
     assert isinstance(opt_pass, tvm.transform.Pass)
 
     mod = tvm.IRModule.from_expr(expr)
+    if params is not None:
+        mod["main"] = bind_params_by_name(mod["main"], params)
     mod = opt_pass(mod)
     entry = mod["main"]
     return entry if isinstance(expr, relay.Function) else entry.body
@@ -148,11 +150,12 @@ def test_dynamic_to_static_topk():
     def verify_topk(k, axis, ret_type, is_ascend, dtype):
         shape = (20, 100)
         x = relay.var("x", relay.TensorType(shape, "float32"))
-        k_var = relay.const(k)
+        k_var = relay.var("k", relay.TensorType((), "int32"))
         out = relay.topk(x, k_var, axis, ret_type, is_ascend, dtype)
         if isinstance(out, relay.expr.TupleWrapper):
             out = out.astuple()
-        func = relay.Function([x], out)
+        func = relay.Function([x, k_var], out)
+        params = {"k": k}
 
         np_data = np.random.uniform(size=shape).astype("float32")
         if is_ascend:
@@ -172,7 +175,9 @@ def test_dynamic_to_static_topk():
                 np_values[i, :] = np_data[i, np_indices[i, :]]
         np_indices = np_indices.astype(dtype)
 
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
         zz = func2.body
         assert isinstance(zz, relay.Call)
         assert zz.op == relay.op.get("topk")
@@ -258,14 +263,17 @@ def test_dynamic_to_static_resize2d():
             size = (shape[2] * scale, shape[3] * scale)
 
         x = relay.var("x", relay.TensorType(shape, "float32"))
-        size_var = relay.const(np.array(size).astype("float32"))
+        size_var = relay.var("size", relay.TensorType((len(size),), "float32"))
         coord_trans = "asymmetric" if method == "nearest_neighbor" else "align_corners"
         z = relay.image.resize2d(
             x, size_var, layout, method, coordinate_transformation_mode=coord_trans
         )
+        params = {"size": np.array(size).astype("float32")}
 
-        func = run_infer_type(relay.Function([x], z))
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        func = run_infer_type(relay.Function([x, size_var], z))
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
 
         zz = func2.body
         assert isinstance(zz, relay.Call)
@@ -286,12 +294,18 @@ def test_dynamic_to_static_one_hot():
     def _verify(indices_shape, depth, on_value, off_value, axis, dtype):
         indices = relay.var("indices", relay.TensorType(indices_shape, "int32"))
         depth_var = relay.const(depth)
-        on_value_const = relay.const(on_value)
-        off_value_const = relay.const(off_value)
-        out = relay.one_hot(indices, on_value_const, off_value_const, depth_var, axis, dtype)
-        func = relay.Function([indices], out)
+        on_value_var = relay.var("on_value", relay.TensorType((), "int32"))
+        off_value_var = relay.var("off_value", relay.TensorType((), "int32"))
+        out = relay.one_hot(indices, on_value_var, off_value_var, depth_var, axis, dtype)
+        params = {
+            "on_value": on_value,
+            "off_value": off_value,
+        }
 
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        func = relay.Function([indices, on_value_var, off_value_var], out)
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
 
         zz = func2.body
         assert isinstance(zz, relay.Call)
@@ -334,12 +348,18 @@ def test_dynamic_to_static_full():
 def test_dynamic_to_static_upsampling():
     def verify_upsampling(data_shape, scale_h_val, scale_w_val, dtype):
         x = relay.var("x", relay.TensorType(data_shape, dtype))
-        scale_h = relay.const(scale_h_val)
-        scale_w = relay.const(scale_w_val)
+        scale_h = relay.var("scale_h", relay.TensorType((), "float32"))
+        scale_w = relay.var("scale_w", relay.TensorType((), "float32"))
         z = relay.nn.upsampling(x, scale_h, scale_w)
+        params = {
+            "scale_h": scale_h_val,
+            "scale_w": scale_w_val,
+        }
 
-        func = run_infer_type(relay.Function([x], z))
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        func = run_infer_type(relay.Function([x, scale_h, scale_w], z))
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
 
         zz = func2.body
         assert isinstance(zz, relay.Call)
@@ -358,14 +378,21 @@ def test_dynamic_to_static_upsampling():
 def test_dynamic_to_static_upsampling3d():
     def verify_upsampling3d(data_shape, scale_d_val, scale_h_val, scale_w_val, dtype):
         x = relay.var("x", relay.TensorType(data_shape, dtype))
-        scale_d = relay.const(scale_d_val)
-        scale_h = relay.const(scale_h_val)
-        scale_w = relay.const(scale_w_val)
+        scale_d = relay.var("scale_d", relay.TensorType((), "float32"))
+        scale_h = relay.var("scale_h", relay.TensorType((), "float32"))
+        scale_w = relay.var("scale_w", relay.TensorType((), "float32"))
 
         z = relay.nn.upsampling3d(x, scale_d, scale_h, scale_w)
+        params = {
+            "scale_d": scale_d_val,
+            "scale_h": scale_h_val,
+            "scale_w": scale_w_val,
+        }
 
-        func = run_infer_type(relay.Function([x], z))
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        func = run_infer_type(relay.Function([x, scale_d, scale_h, scale_w], z))
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
 
         zz = func2.body
         assert isinstance(zz, relay.Call)
@@ -387,18 +414,24 @@ def test_dynamic_to_static_upsampling3d():
 
 
 def test_dynamic_to_static_pad():
-    def verify_pad(data_shape, pad_width, pad_val, dtype):
+    def verify_pad(data_shape, pad_width_val, pad_val, dtype):
         x = relay.var("x", relay.TensorType(data_shape, dtype))
-        z = relay.nn.pad(x, relay.const(np.array(pad_width)), pad_val)
-        func = run_infer_type(relay.Function([x], z))
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        pad_width = relay.var(
+            "pad_width", relay.TensorType((len(pad_width_val), len(pad_width_val[0])), "int32")
+        )
+        z = relay.nn.pad(x, pad_width, pad_val)
+        func = run_infer_type(relay.Function([x, pad_width], z))
+        params = {"pad_width": np.array(pad_width_val)}
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
         zz = func2.body
         assert isinstance(zz, relay.Call)
         assert zz.op == relay.op.get("nn.pad")
 
         x_data = np.random.uniform(size=data_shape).astype(dtype)
         ref_res = np.pad(
-            x_data, pad_width, "constant", constant_values=(((pad_val,) * 2),) * len(data_shape)
+            x_data, pad_width_val, "constant", constant_values=(((pad_val,) * 2),) * len(data_shape)
         )
         verify_func(func2, [x_data], ref_res)
 
@@ -407,35 +440,51 @@ def test_dynamic_to_static_pad():
 
 
 def test_dynamic_to_static_strided_slice():
-    def verify(dshape, begin, end, strides, output, slice_mode="end", test_ref=True, dtype="int32"):
+    def verify(
+        dshape,
+        begin_val,
+        end_val,
+        strides_val,
+        output,
+        slice_mode="end",
+        test_ref=True,
+        dtype="int32",
+    ):
         x = relay.var("x", relay.TensorType(dshape, "float32"))
         ndim = len(dshape)
-        begin = begin if begin else [0] * ndim
-        end = end if end else list(dshape)
-        if strides:
-            if len(strides) == 1:
-                strides = strides * ndim
+        begin_val = begin_val if begin_val else [0] * ndim
+        end_val = end_val if end_val else list(dshape)
+        if strides_val:
+            if len(strides_val) == 1:
+                strides_val = strides_val * ndim
         else:
-            strides = [1] * ndim
+            strides_val = [1] * ndim
 
         # target numpy result
         x_data = np.random.uniform(size=dshape).astype("float32")
-        ref_res = tvm.topi.testing.strided_slice_python(x_data, begin, end, strides, slice_mode)
-        data = [x_data, np.array(begin), np.array(end)]
+        ref_res = tvm.topi.testing.strided_slice_python(
+            x_data, begin_val, end_val, strides_val, slice_mode
+        )
+        data = [x_data, np.array(begin_val), np.array(end_val)]
 
-        begin = relay.const(begin, dtype=dtype)
-        end = relay.const(end, dtype=dtype)
+        begin = relay.var("begin", relay.TensorType((len(begin_val),), dtype))
+        end = relay.var("end", relay.TensorType((len(end_val),), dtype))
 
-        if strides:
-            data.append(np.array(strides))
-            strides = relay.const(strides, dtype=dtype)
+        func_params = [x, begin, end]
+        if strides_val:
+            data.append(np.array(strides_val))
+            strides = relay.var("strides", relay.TensorType((len(strides_val),), dtype))
             z = relay.strided_slice(x, begin=begin, end=end, strides=strides, slice_mode=slice_mode)
+            func_params.append(strides)
         else:
             z = relay.strided_slice(x, begin=begin, end=end, slice_mode=slice_mode)
-        func = relay.Function([x], z)
+        func = relay.Function(func_params, z)
+        params = {"begin": begin_val, "end": end_val, "strides": strides_val}
 
         func = run_infer_type(func)
-        func2 = run_opt_pass(run_opt_pass(func, transform.DynamicToStatic()), transform.InferType())
+        func2 = run_opt_pass(
+            run_opt_pass(func, transform.DynamicToStatic(), params), transform.InferType()
+        )
         assert isinstance(func2.body, relay.Call)
         assert func2.body.op == relay.op.get("strided_slice")
         verify_func(func2, [x_data], ref_res)


### PR DESCRIPTION
While experimenting with `dyn.strided_slice` I noticed that some of the DynamicToStatic pass tests are not testing dynamic expressions. For example, the created strided_slice function here https://github.com/apache/tvm/blob/02f885aacde5739c060507afa0b534019d5439cc/tests/python/relay/test_pass_dynamic_to_static.py#L435
looks like this: 
```
fn (%x: Tensor[(1, 3, 10, 10), float32]) {
  strided_slice(%x, begin=[0, 0, 0, 0], end=[1, 3, 10, 10], strides=[1, 1, 1, 1], axes=None)
}
```
which I think doesn't test the DynamicToStatic pass being executed on this expression. With the small changes in this PR, the above function looks like this:
```
fn (%x: Tensor[(1, 3, 10, 10), float32], %begin: Tensor[(4), int64], %end: Tensor[(4), int64], %strides: Tensor[(4), int64]) {
  %0 = cast_like(0, %begin);
  %1 = shape_of(%x, dtype="int32");
  %2 = cast_like(%1, %begin);
  %3 = slice_like(%2, %begin, axes=None);
  %4 = less(%begin, %0);
  %5 = add(%begin, %3);
  %6 = where(%4, %5, %begin);
  %7 = greater_equal(%6, %3);
  %8 = where(%7, %3, %6);
  dyn.strided_slice(%x, %8, %end, %strides, begin=None, end=None, strides=None, axes=None)
}
```
which I think is a better test for the DynamicToStatic pass.

Similarly, tests for topk, resize2d, upsampling, upsampling3d and pad have been adjusted.

@mbrookhart Could you help with reviewing this PR?