### PR TITLE
[Autoscheduler] Reduce task weight coercion overhead

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -171,7 +171,7 @@ def extract_tasks(
                 desc=",".join(func_names),
             )
         )
-        weights.append(weight)
+        weights.append(int(weight))
 
     if dump_workload_to_dag_log is not None:
         with open(dump_workload_to_dag_log, "w") as f:


### PR DESCRIPTION
In autoscheduler, a meaningful amount of time is spent collecting (discarded) backtraces in the `TaskScheduler` `objective_func` due to failing `ReflectionVTable::GetAttr` calls during coercion.

Modify `extract_tasks` to return `List[int]` instead of `List[IntImm]` to remove coercion altogether from the `objective_func`.