### PR TITLE
[microTVM][Zephyr] Fix board names

### DIFF
--- a/apps/microtvm/reference-vm/README.md
+++ b/apps/microtvm/reference-vm/README.md
@@ -85,7 +85,7 @@ $ ./base-box-tool.py --provider virtualbox build zephyr
 
    For example:
    ```base
-   $ ./base-box-tool.py --provider virtualbox test --microtvm-board=stm32f746xx_disco zephyr
+   $ ./base-box-tool.py --provider virtualbox test --microtvm-board=stm32f746g_disco zephyr
    ```
 
    This command does the following for the specified provider:

--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -73,7 +73,7 @@ ALL_MICROTVM_BOARDS = {
     ),
     "zephyr": (
         "nucleo_f746zg",
-        "stm32f746xx_disco",
+        "stm32f746g_disco",
         "nrf5340dk_nrf5340_cpuapp",
         "mps2_an521",
     ),

--- a/apps/microtvm/reference-vm/zephyr/base-box/base_box_test.sh
+++ b/apps/microtvm/reference-vm/zephyr/base-box/base_box_test.sh
@@ -32,7 +32,7 @@ board=$1
 
 pytest tests/micro/zephyr/test_zephyr.py --zephyr-board=${board}
 
-if [ $board == "stm32f746xx" ]; then
+if [ $board == "stm32f746g_disco" ] || [ $board == "nucleo_f746zg" ]; then
     echo "NOTE: skipped test_zephyr_aot.py on $board -- known failure"
 else
     pytest tests/micro/zephyr/test_zephyr_aot.py --zephyr-board=${board}

--- a/apps/microtvm/reference-vm/zephyr/base-box/test-config.json
+++ b/apps/microtvm/reference-vm/zephyr/base-box/test-config.json
@@ -1,13 +1,13 @@
 {
-    "stm32f746xx_nucleo": {
+    "nucleo_f746zg": {
         "vid_hex": "0483",
         "pid_hex": "374b"
         },
-    "stm32f746xx_disco": {
+    "stm32f746g_disco": {
         "vid_hex": "0483",
         "pid_hex": "374b"
         },
-    "nrf5340dk": {
+    "nrf5340dk_nrf5340_cpuapp": {
         "vid_hex": "1366",
         "pid_hex": "1055"
         },

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -80,8 +80,8 @@ BOARD_PROPERTIES = {
         "board": "nrf5340dk_nrf5340_cpuapp",
         "model": "nrf5340dk",
     },
-    "stm32f746xx_disco": {
-        "board": "stm32f746xx_disco",
+    "stm32f746g_disco": {
+        "board": "stm32f746g_disco",
         "model": "stm32f746xx",
     },
     "nucleo_f746zg": {

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -140,8 +140,8 @@ def test_tflite(temp_dir, board, west_cmd, tvm_debug):
         "qemu_x86",
         "mps2_an521",
         "nrf5340dk_nrf5340_cpuapp",
-        "stm32l4r5zi_nucleo",
-        "zynq_mp_r5",
+        "nucleo_l4r5zi",
+        "qemu_cortex_r5",
     ]:
         pytest.skip(msg="Model does not fit.")
 

--- a/tutorials/micro/micro_reference_vm.py
+++ b/tutorials/micro/micro_reference_vm.py
@@ -143,7 +143,7 @@ Once the VM has been provisioned, tests can executed using ``poetry``:
 .. code-block:: bash
 
     $ cd apps/microtvm/reference-vm/zephyr
-    $ poetry run python3 ../../../../tests/micro/qemu/test_zephyr.py --zephyr-board=stm32f746xx
+    $ poetry run python3 ../../../../tests/micro/qemu/test_zephyr.py --zephyr-board=stm32f746g_disco
 
 If you do not have physical hardware attached, but wish to run the tests using the
 local QEMU emulator running within the VM, run the following commands instead:


### PR DESCRIPTION
This PR fixes some of the board names left out from recent refactor: https://github.com/apache/tvm/pull/8940
