### PR TITLE
[CMake] Corrected warning message about USE_GRAPH_EXECUTOR_DEBUG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,7 @@ endif(USE_GRAPH_EXECUTOR)
 
 # convert old options for profiler
 if(USE_GRAPH_EXECUTOR_DEBUG)
-  message(WARNING "USE_GRAPH_EXECUTOR renamed to USE_PROFILER. Please update your config.cmake")
+  message(WARNING "USE_GRAPH_EXECUTOR_DEBUG renamed to USE_PROFILER. Please update your config.cmake")
   unset(USE_GRAPH_EXECUTOR_DEBUG CACHE)
   set(USE_PROFILER ON)
 endif()


### PR DESCRIPTION
Warning message about deprecated cmake flag `USE_GRAPH_EXECUTOR_DEBUG` referred to `USE_GRAPH_EXECUTOR` instead.