### PR TITLE
[TIR] Add conversion from FloatImm to float in Python

### DIFF
--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -523,6 +523,9 @@ class FloatImm(ConstExpr):
             tvm.ir._ffi_api.FloatImm, dtype, value, span  # type: ignore
         )
 
+    def __float__(self):
+        return self.value
+
 
 @tvm._ffi.register_object
 class IntImm(ConstExpr):


### PR DESCRIPTION
This method matches the IntImm method for converting from IntImm to int.

@comaniac @jwfromm @masahi 
