### PR TITLE
[Hexagon] Treat floats as float32 when passing args to offloaded kernels

### DIFF
--- a/src/runtime/hexagon/hexagon_module.cc
+++ b/src/runtime/hexagon/hexagon_module.cc
@@ -483,9 +483,10 @@ hexagon::ArgLayout HexagonModuleNode::BuildArgLayout(const TVMArgs& As) const {
         ICHECK_EQ(static_cast<int64_t>(A), static_cast<int32_t>(A));
         Args.Push(static_cast<int>(A));
         break;
-      // 64-bit values
+      // As above, treat floating point values as float32.
       case kDLFloat:
-        Args.Push(static_cast<double>(A));
+        ICHECK_EQ(static_cast<double>(A), static_cast<float>(static_cast<double>(A)));
+        Args.Push(static_cast<float>(static_cast<double>(A)));
         break;
 
       case kTVMOpaqueHandle:


### PR DESCRIPTION
`TVMArg` can hold a floating point value, but it's stored as `double`. In Hexagon ABI doubles are passed in a register pair, but if the offloaded function was using floats (i.e. float32), it will expect values being passed in single registers. Since floats are much more common on Hexagon, assume all scalar floating point values are floats. This is only an issue with offloading, and can be treated as a limitation (we do something analogous for integers already).