### PR TITLE
[Strategy] Disable cuda int8 schedule for non-cuda gpu target

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -144,7 +144,11 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
     if groups == 1:
         if layout == "NCHW":
             assert kernel_layout == "OIHW"
-            if data.dtype in ("int8", "uint8") and kernel.dtype in ("int8", "uint8"):
+            if (
+                target.kind.name == "cuda"
+                and data.dtype in ("int8", "uint8")
+                and kernel.dtype in ("int8", "uint8")
+            ):
                 assert data.dtype == kernel.dtype
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.cuda.conv2d_nchw_int8),
@@ -293,7 +297,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                     "Unsupported shape for conv2d HWNC.\
                                     Need to satisfy tensor core schedule."
                 )
-        elif layout == "NCHW4c" and data.dtype in ["int8", "uint8"]:
+        elif target.kind.name == "cuda" and layout == "NCHW4c" and data.dtype in ["int8", "uint8"]:
             assert kernel_layout == "OIHW4o4i"
             strategy.add_implementation(
                 wrap_compute_conv2d(topi.cuda.conv2d_NCHWc_int8, True),
@@ -353,7 +357,8 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
             ic_chunk = in_channels // 4
 
             if (
-                data.dtype in ["int8", "uint8"]
+                target.kind.name == "cuda"
+                and data.dtype in ["int8", "uint8"]
                 and kernel.dtype in ["int8", "uint8"]
                 and channels % groups == 0
                 and out_channels % groups == 0

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -325,10 +325,6 @@ class TestConv2D:
         kernel_size,
     ):
         target = tvm.target.Target(target)
-        if target.kind.name == "vulkan" and dtype == "int8":
-            # The schedule selection incorrectly picks an
-            # implementation that requires NCHWc packed input.
-            pytest.xfail("Known failing test for vulkan")
 
         x = relay.var("x", shape=dshape, dtype=dtype)
         w = relay.var("w", shape=kshape, dtype=dtype)


### PR DESCRIPTION
Int8 convolution is currently broken for non-cuda GPU targets, because the int8 specific conv2d schedule uses an intrinsic only available on CUDA.

https://github.com/apache/tvm/blob/a9933211a926e432bf3cf96d92b40b22fac99594/python/tvm/topi/cuda/conv2d_int8.py#L314

This fixes one of tests that are currently broken for vulkan https://github.com/apache/tvm/issues/8903.

@vinx13 @Lunderberg @tmoreau89 