### PR TITLE
Support match pvar with dtype constraint

### DIFF
--- a/src/arith/pattern_match.h
+++ b/src/arith/pattern_match.h
@@ -253,9 +253,9 @@ class PVarWithCheck : public arith::Pattern<PVarWithCheck<Derived, T>> {
  */
 template <typename T, typename DType,
           typename = std::enable_if<std::is_base_of<T, PrimExpr>::value>>
-class PVarWithType : public PVarWithCheck<PVarWithType<T, DType>, T> {
+class PVarWithDataType : public PVarWithCheck<PVarWithDataType<T, DType>, T> {
  public:
-  explicit PVarWithType(const DType& dtype) : dtype_(dtype) {}
+  explicit PVarWithDataType(const DType& dtype) : dtype_(dtype) {}
 
   bool Match_(const T& value) const { return dtype_.Match_(value->dtype); }
 
@@ -266,10 +266,10 @@ class PVarWithType : public PVarWithCheck<PVarWithType<T, DType>, T> {
 /*!
  * \brief Pattern variable container for data type with lanes.
  */
-class PVecType : public PVarWithCheck<PVecType, DataType> {
+class PVecDataType : public PVarWithCheck<PVecDataType, DataType> {
  public:
   /*! \brief construct vector dtype placeholder with element type check */
-  explicit PVecType(const DataType& elem_dtype) : elem_dtype_(elem_dtype) {}
+  explicit PVecDataType(const DataType& elem_dtype) : elem_dtype_(elem_dtype) {}
 
   bool Match_(const DataType& dtype) const { return dtype.code() == elem_dtype_.code(); }
 

--- a/tests/cpp/pattern_match_test.cc
+++ b/tests/cpp/pattern_match_test.cc
@@ -142,7 +142,7 @@ TEST(Pattern, IntImm) {
 TEST(Pattern, MatchWithType) {
   using namespace tvm;
   // match expr with specified dtype
-  arith::PVarWithType<PrimExpr, arith::PConst<DataType>> pat(DataType::Float(32));
+  arith::PVarWithDataType<PrimExpr, arith::PConst<DataType>> pat(DataType::Float(32));
   tir::Var x("x", DataType::Float(32));
   tir::Var y("y", DataType::Float(32));
   tir::Var x_int("x", DataType::Int(32));
@@ -151,8 +151,8 @@ TEST(Pattern, MatchWithType) {
   ICHECK(!pat.Match(x_int + y_int * 2));
 
   // match vectorized expr with specified element dtype
-  arith::PVecType vec_ty(DataType::Float(32));
-  arith::PVarWithType<PrimExpr, arith::PVecType> vpat(vec_ty);
+  arith::PVecDataType vec_ty(DataType::Float(32));
+  arith::PVarWithDataType<PrimExpr, arith::PVecDataType> vpat(vec_ty);
   tir::Var vx = tir::Var("x", DataType::Float(32, 8));
   tir::Var vy("y", DataType::Float(32, 8));
   tir::Var vx_int("x", DataType::Int(32, 8));

--- a/tests/cpp/pattern_match_test.cc
+++ b/tests/cpp/pattern_match_test.cc
@@ -138,3 +138,25 @@ TEST(Pattern, IntImm) {
   // cannot match tx + 1 to v
   ICHECK(!(v * c).Match((tx + 1) * 3));
 }
+
+TEST(Pattern, MatchWithType) {
+  using namespace tvm;
+  // match expr with specified dtype
+  arith::PVarWithType<PrimExpr, arith::PConst<DataType>> pat(DataType::Float(32));
+  tir::Var x("x", DataType::Float(32));
+  tir::Var y("y", DataType::Float(32));
+  tir::Var x_int("x", DataType::Int(32));
+  tir::Var y_int("y", DataType::Int(32));
+  ICHECK(pat.Match(x + y * 2.0f));
+  ICHECK(!pat.Match(x_int + y_int * 2));
+
+  // match vectorized expr with specified element dtype
+  arith::PVecType vec_ty(DataType::Float(32));
+  arith::PVarWithType<PrimExpr, arith::PVecType> vpat(vec_ty);
+  tir::Var vx = tir::Var("x", DataType::Float(32, 8));
+  tir::Var vy("y", DataType::Float(32, 8));
+  tir::Var vx_int("x", DataType::Int(32, 8));
+  tir::Var vy_int("y", DataType::Int(32, 8));
+  ICHECK(vpat.Match(vx + vy * tir::Broadcast(2.0f, 8)));
+  ICHECK(!vpat.Match(vx_int + vy_int * tir::Broadcast(2, 8)));
+}


### PR DESCRIPTION
This PR add two helper class for tir expression pattern match.

- `PVarWithType` works same as `PVar` with dtype match
- `PVecType` represent a wildcard vec type placeholder same as `PVar<DataType>`, but with element dtype match

```c++
PVecType vec_ph(DataType::Float(32));
PVarWithType<PrimExpr, arith::PVecType> pat(vec_ph);
if (pat.Match(expr)) { ... }

// equaivalent to
PVar<PrimExpr> pat;
if (pat.Match(expr)) {
   PrimExpr x = pat.Eval();
   if (x->dtype == DataType::Float(32)) { ... }
}
```
