### PR TITLE
[ONNX] QLinearAveragePool and QLinearGlobalAveragePool contrib op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -705,7 +705,7 @@ class QLinearGlobalAveragePool(OnnxOpConverter):
         # sequence dequantize -> float op -> quantize, but that is how QLinearAveragePool is done.
         #
         # This op also follows the same pattern since qnn op is not available right now.
-        # TODO: Generate QNN op to perform quantized operation instead of dequant -> op -> float
+        # TODO: Generate QNN op to perform quantized operation instead of dequant -> op -> quant
         x = _qnn.op.dequantize(inputs[0], x_scale, x_zero_point)
         if rank == 3:
             out = _op.nn.global_avg_pool1d(x)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -339,14 +339,13 @@ class Pool(OnnxOpConverter):
             custom_check=dimension_constraint(),
         )
         # Onnxruntime doesn't actually do this op in integer, they dequantize to fp32
-        # and then requantize afer
+        # and then requantize afer (according to documentation below)
         # https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md#com.microsoft.QLinearAveragePool
         if cls.is_quant:
-            input = _qnn.op.dequantize(data, x_scale, x_zero_point)
-            out = attr_cvt([input], attr, params)
+            float_node = _qnn.op.dequantize(data, x_scale, x_zero_point)
+            out = attr_cvt([float_node], attr, params)
             return _qnn.op.quantize(out, y_scale, y_zero_point, out_dtype=input_dtype)
-        else:
-            return attr_cvt([data], attr, params)
+        return attr_cvt([data], attr, params)
 
 
 class Absolute(Unary):


### PR DESCRIPTION
This PR implements com.microsoft.QLinearAveragePool and com.microsoft.QLinearGlobalAveragePool.

QLinearAveragePool is implemented as (dequantize -> float op -> quantize) according to its definition in [com.microsoft.QLinearAveragePool](https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md#com.microsoft.QLinearGlobalAveragePool)

QLinearGlobalAveragePool is also implemented as (dequantize -> float op -> quantize) because the QNN op for global avg_pool is not yet available, but that is not how it's explicitly defined in the onnxruntime docs. Once QNN op is added, we could update this op frontend to directly generate a qnn op.