### PR TITLE
[TE] Support negative indices 

### DIFF
--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -103,7 +103,7 @@ class Tensor : public DataProducer {
  private:
   /*!
    * \brief Helper for indexing operations into tensors
-   * \param args The indices
+   * \param indices The indices
    * \param support_negative_indices Whether to normalize indices in the case of negative indices.
    * \return the result expression representing tensor read.
    */

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -100,6 +100,9 @@ class TensorNode : public DataProducerNode {
  *  or intermediate computation result.
  */
 class Tensor : public DataProducer {
+ private:
+  inline PrimExpr index_tensor(Array<PrimExpr> indices, bool support_negative_indices) const;
+
  public:
   TVM_DLL Tensor(Array<PrimExpr> shape, DataType dtype, Operation op, int value_index);
   /*!
@@ -129,15 +132,39 @@ class Tensor : public DataProducer {
   /*!
    * \brief Take elements from the tensor
    * \param indices the indices.
+   * \param support_negative_indices
    * \return the result expression representing tensor read.
    */
-  TVM_DLL PrimExpr operator()(Array<PrimExpr> indices, bool support_negative_indices) const;
+  TVM_DLL PrimExpr operator()(Array<PrimExpr> indices) const;
   /*!
    * \brief Take elements from the tensor
    * \param indices the indices.
    * \return the result expression representing tensor read.
    */
-  TVM_DLL PrimExpr operator()(Array<Var> indices, bool support_negative_indices) const;
+  TVM_DLL PrimExpr operator()(Array<Var> indices) const;
+  /*!
+   * \brief Take elements from the tensor with support for negative indices.
+   * \param args The indices
+   * \return the result expression representing tensor read.
+   */
+  template <typename... Args>
+  TVM_DLL PrimExpr IndexWithNegativeIndices(Args&&... args) const {
+    Array<PrimExpr> indices{std::forward<Args>(args)...};
+    return IndexWithNegativeIndices(indices);
+  }
+  /*!
+   * \brief Take elements from the tensor with support for negative indices.
+   * \param indices the indices.
+   * \return the result expression representing tensor read.
+   */
+  TVM_DLL PrimExpr IndexWithNegativeIndices(Array<PrimExpr> indices) const;
+  /*!
+   * \brief Take elements from the tensor with support for negative indices.
+   * \param indices the indices.
+   * \return the result expression representing tensor read.
+   */
+  TVM_DLL PrimExpr IndexWithNegativeIndices(Array<Var> indices) const;
+
   /*!
    * \brief data structure to represent a slice that fixes first k coordinates.
    *  This is used to enable syntax sugar of Tensor[x][y][z] to get the element.

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -131,13 +131,13 @@ class Tensor : public DataProducer {
    * \param indices the indices.
    * \return the result expression representing tensor read.
    */
-  TVM_DLL PrimExpr operator()(Array<PrimExpr> indices) const;
+  TVM_DLL PrimExpr operator()(Array<PrimExpr> indices, bool support_negative_indices) const;
   /*!
    * \brief Take elements from the tensor
    * \param indices the indices.
    * \return the result expression representing tensor read.
    */
-  TVM_DLL PrimExpr operator()(Array<Var> indices) const;
+  TVM_DLL PrimExpr operator()(Array<Var> indices, bool support_negative_indices) const;
   /*!
    * \brief data structure to represent a slice that fixes first k coordinates.
    *  This is used to enable syntax sugar of Tensor[x][y][z] to get the element.

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -138,7 +138,6 @@ class Tensor : public DataProducer {
   /*!
    * \brief Take elements from the tensor
    * \param indices the indices.
-   * \param support_negative_indices
    * \return the result expression representing tensor read.
    */
   TVM_DLL PrimExpr operator()(Array<PrimExpr> indices) const;

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -107,7 +107,7 @@ class Tensor : public DataProducer {
    * \param support_negative_indices Whether to normalize indices in the case of negative indices.
    * \return the result expression representing tensor read.
    */
-  inline PrimExpr index_tensor(Array<PrimExpr> indices, bool support_negative_indices) const;
+  inline PrimExpr IndexTensor(Array<PrimExpr> indices, bool support_negative_indices) const;
 
  public:
   TVM_DLL Tensor(Array<PrimExpr> shape, DataType dtype, Operation op, int value_index);

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -101,6 +101,12 @@ class TensorNode : public DataProducerNode {
  */
 class Tensor : public DataProducer {
  private:
+  /*!
+   * \brief Helper for indexing operations into tensors
+   * \param args The indices
+   * \param support_negative_indices Whether to normalize indices in the case of negative indices.
+   * \return the result expression representing tensor read.
+   */
   inline PrimExpr index_tensor(Array<PrimExpr> indices, bool support_negative_indices) const;
 
  public:

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -39,12 +39,7 @@ IterVar reduce_axis(Range dom, std::string name) { return IterVar(dom, Var(name)
 Var var(std::string name_hint, DataType t) { return Var(name_hint, t); }
 
 // Tensor
-PrimExpr Tensor::operator()(Array<Var> indices, bool support_negative_indices = false) const {
-  Array<PrimExpr> arr(indices.begin(), indices.end());
-  return operator()(arr, support_negative_indices);
-}
-
-PrimExpr Tensor::operator()(Array<PrimExpr> indices, bool support_negative_indices = false) const {
+inline PrimExpr Tensor::index_tensor(Array<PrimExpr> indices, bool support_negative_indices) const {
   Array<PrimExpr> shape = (*this)->shape;
 
   if (shape.size() != 0) {
@@ -60,8 +55,23 @@ PrimExpr Tensor::operator()(Array<PrimExpr> indices, bool support_negative_indic
       indices.Set(i, new_index);
     }
   }
-
   return ProducerLoad((*this), indices);
+}
+
+PrimExpr Tensor::operator()(Array<Var> indices) const {
+  Array<PrimExpr> arr(indices.begin(), indices.end());
+  return operator()(arr);
+}
+
+PrimExpr Tensor::operator()(Array<PrimExpr> indices) const { return index_tensor(indices, false); }
+
+PrimExpr Tensor::IndexWithNegativeIndices(Array<Var> indices) const {
+  Array<PrimExpr> arr(indices.begin(), indices.end());
+  return IndexWithNegativeIndices(arr);
+}
+
+PrimExpr Tensor::IndexWithNegativeIndices(Array<PrimExpr> indices) const {
+  return index_tensor(indices, true);
 }
 
 String TensorNode::GetNameHint() const {

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -39,15 +39,26 @@ IterVar reduce_axis(Range dom, std::string name) { return IterVar(dom, Var(name)
 Var var(std::string name_hint, DataType t) { return Var(name_hint, t); }
 
 // Tensor
-PrimExpr Tensor::operator()(Array<Var> indices) const {
+PrimExpr Tensor::operator()(Array<Var> indices, bool support_negative_indices = false) const {
   Array<PrimExpr> arr(indices.begin(), indices.end());
-  return operator()(arr);
+  return operator()(arr, support_negative_indices);
 }
 
-PrimExpr Tensor::operator()(Array<PrimExpr> indices) const {
-  if (ndim() != 0) {
-    ICHECK_EQ(ndim(), indices.size()) << "Tensor dimension mismatch in read "
-                                      << "ndim = " << ndim() << ", indices.size=" << indices.size();
+PrimExpr Tensor::operator()(Array<PrimExpr> indices, bool support_negative_indices = false) const {
+  Array<PrimExpr> shape = (*this)->shape;
+
+  if (shape.size() != 0) {
+    ICHECK_EQ(shape.size(), indices.size())
+        << "Tensor dimension mismatch in read "
+        << "ndim = " << ndim() << ", indices.size=" << indices.size();
+  }
+
+  if (support_negative_indices) {
+    for (size_t i = 0; i < shape.size(); i++) {
+      PrimExpr new_index = if_then_else(indices[i] < make_const(indices[i]->dtype, 0),
+                                        indices[i] + shape[i], indices[i]);
+      indices.Set(i, new_index);
+    }
   }
 
   return ProducerLoad((*this), indices);

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -39,7 +39,7 @@ IterVar reduce_axis(Range dom, std::string name) { return IterVar(dom, Var(name)
 Var var(std::string name_hint, DataType t) { return Var(name_hint, t); }
 
 // Tensor
-inline PrimExpr Tensor::index_tensor(Array<PrimExpr> indices, bool support_negative_indices) const {
+inline PrimExpr Tensor::IndexTensor(Array<PrimExpr> indices, bool support_negative_indices) const {
   Array<PrimExpr> shape = (*this)->shape;
 
   if (shape.size() != 0) {
@@ -63,7 +63,7 @@ PrimExpr Tensor::operator()(Array<Var> indices) const {
   return operator()(arr);
 }
 
-PrimExpr Tensor::operator()(Array<PrimExpr> indices) const { return index_tensor(indices, false); }
+PrimExpr Tensor::operator()(Array<PrimExpr> indices) const { return IndexTensor(indices, false); }
 
 PrimExpr Tensor::IndexWithNegativeIndices(Array<Var> indices) const {
   Array<PrimExpr> arr(indices.begin(), indices.end());
@@ -71,7 +71,7 @@ PrimExpr Tensor::IndexWithNegativeIndices(Array<Var> indices) const {
 }
 
 PrimExpr Tensor::IndexWithNegativeIndices(Array<PrimExpr> indices) const {
-  return index_tensor(indices, true);
+  return IndexTensor(indices, true);
 }
 
 String TensorNode::GetNameHint() const {

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -50,8 +50,8 @@ inline PrimExpr Tensor::index_tensor(Array<PrimExpr> indices, bool support_negat
 
   if (support_negative_indices) {
     for (size_t i = 0; i < shape.size(); i++) {
-      PrimExpr new_index = if_then_else(indices[i] < make_const(indices[i]->dtype, 0),
-                                        indices[i] + shape[i], indices[i]);
+      PrimExpr new_index =
+          Select(indices[i] < make_const(indices[i]->dtype, 0), indices[i] + shape[i], indices[i]);
       indices.Set(i, new_index);
     }
   }

--- a/tests/cpp/tensor_test.cc
+++ b/tests/cpp/tensor_test.cc
@@ -49,3 +49,14 @@ TEST(Tensor, Reduce) {
       {m, n}, [&](Var i, Var j) { return sum(max(1 + A[i][rv] + 1, B[j][rv]), {rv}); }, "C");
   LOG(INFO) << C->op.as<te::ComputeOpNode>()->body;
 }
+
+TEST(Tensor, Indexing) {
+  using namespace tvm;
+  using namespace tvm::te;
+
+  Var x("x"), y("y");
+  te::Tensor A = te::placeholder({x, y}, DataType::Float(32), "A");
+  LOG(INFO) << A(0, 0);
+  LOG(INFO) << A.IndexWithNegativeIndices(-1, -1);
+  LOG(INFO) << A.IndexWithNegativeIndices(0, -1);
+}


### PR DESCRIPTION
Negative indices are a pretty common feature in most modern programming languages and libraries. This proposed PR would add optional support for negative indices out of the box for tensors in TE.

A lot of operators from other frontends support negative indices. See ONNX, numpy, and PyTorch where their tensors support negative indices out of the box. Unfortunately TE and the rest of TVM does not.

One benefit of this change is now it is trivial to change operators to support negative indices. This makes adapting frontends to our operators simpler. For example an operator using this simply has to turn the `support_negative_indices` flag to true for every relevant indexing operation. An example of doing this can be found in https://github.com/AndrewZhaoLuo/tvm/blob/02f1870d7f2e274cfd7e04678691da019ff201f0/include/tvm/topi/transform.h#L1265. Right now how we handle negative indices is by manually converting them to positive indices which can be cumbersome and results in lots of code duplication.

The downside is that it technically adds a little more computation per indexing operation. While these operations are probably memory and not compute bound I am not 100% confident that setting `support_negative_indices=true` would not result in performance regressions. Furthermore, it will make some of printouts very ugly since it will but the comparison operation in each index statement.

@jroesch also has great points that this might make loop level analysis hard and result in some optimizations harder.

Pros:
- Clear way to support negative indices 

Cons:
- Printouts will be ugly
- Might be slower (but can turn off easily)

Unknowns:
- Dynamic shapes?
- Effect on compile time optimizations