### PR TITLE
[Hexagon] Allow undefined symbols in libtvm_runtime.so on Hexagon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,8 @@ if(BUILD_FOR_HEXAGON)
   # static one.
   if(NOT BUILD_STATIC_RUNTIME)
     list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon_posix.cc)
+    # Allow undefined symbols (there will be some from libc).
+    set(TVM_NO_UNDEFINED_SYMBOLS "")
   endif()
 
   add_definitions(-D_MACH_I32=int)


### PR DESCRIPTION
The shared library `libtvm_runtime.so` (or any other shared library built for Hexagon) will not contain definitions of symbols from libc. To avoid undefined symbol errors, turn that check off when building shared libs for Hexagon.