### PR TITLE
[Hexagon] Disable `thread_local` on Hexagon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ if(BUILD_FOR_HEXAGON)
   endif()
 
   add_definitions(-D_MACH_I32=int)
+  add_definitions(-DDMLC_CXX11_THREAD_LOCAL=0)
 endif()
 
 # Package runtime rules


### PR DESCRIPTION
This is specific to running code on hardware: libc++abi can create TLS keys with destructors in the libc++abi library. Despite that,
the library gets unloaded before the keys are destroyed, leading to a crash. Turning off the use of `thread_local` is a workaround for this.