### PR TITLE
[ONNX][#8838] QLinearSigmoid contrib op and Bug Fix for DequantizeLinear

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3357,10 +3357,10 @@ class QLinearSigmoid(OnnxOpConverter):
     @classmethod
     def _impl_v10(cls, inputs, attr, params):
         x = inputs[0]
-        x_scale = get_scalar(inputs[1])
-        x_zero_point = get_scalar(inputs[2], "int32")
-        y_scale = fold_constant(get_scalar(inputs[3]))
-        y_zero_point = get_scalar(inputs[4], "int32")
+        x_scale = get_scalar(inputs[1], params)
+        x_zero_point = get_scalar(inputs[2], params, "int32")
+        y_scale = fold_constant(get_scalar(inputs[3], params))
+        y_zero_point = get_scalar(inputs[4], params, "int32")
 
         dtype = infer_type(x).checked_type.dtype
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3176,7 +3176,7 @@ class DequantizeLinear(OnnxOpConverter):
     @classmethod
     def _impl_v13(cls, inputs, attr, params):
         data, scale, zp = inputs
-        axis = attr.get("axis", 1)
+        axis = attr.get("axis", 0)
         return _qnn.op.dequantize(data, scale, _op.cast(zp, "int32"), axis)
 
 
@@ -3348,6 +3348,36 @@ class QLinearMul(OnnxOpConverter):
         a = _qnn.op.dequantize(inputs[0], a_scale, a_zero_point)
         b = _qnn.op.dequantize(inputs[3], b_scale, b_zero_point)
         out = _op.multiply(a, b)
+        return _qnn.op.quantize(out, y_scale, y_zero_point, out_dtype=dtype)
+
+
+class QLinearSigmoid(OnnxOpConverter):
+    """Operator converter for QLinearSigmoid from Microsoft onnxruntime contrib opset."""
+
+    @classmethod
+    def _impl_v10(cls, inputs, attr, params):
+        def get_scalar(x, dtype="float32"):
+            if isinstance(x, _expr.Var) and x.name_hint in params:
+                return _op.const(params[x.name_hint].numpy(), dtype)
+            rank = len(infer_shape(x))
+            assert rank <= 1, "QLinearSigmoid scale and zero_point input must be scalars"
+            if rank == 1:
+                x = _op.squeeze(x, [0])
+            return _op.cast(x, dtype)
+
+        x = inputs[0]
+        x_scale = get_scalar(inputs[1])
+        x_zero_point = get_scalar(inputs[2], "int32")
+        y_scale = fold_constant(get_scalar(inputs[3]))
+        y_zero_point = get_scalar(inputs[4], "int32")
+
+        dtype = infer_type(x).checked_type.dtype
+
+        ## Apparently, onnxruntime doesn't do this op in integer, they dequantize to fp32
+        ## and then requantize after:
+        ## https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp#L245
+        x = _qnn.op.dequantize(inputs[0], x_scale, x_zero_point)
+        out = _op.sigmoid(x)
         return _qnn.op.quantize(out, y_scale, y_zero_point, out_dtype=dtype)
 
 
@@ -3941,6 +3971,7 @@ def _get_convert_map(opset):
         "QLinearConcat": QLinearConcat.get_converter(opset),
         "QLinearAdd": QLinearAdd.get_converter(opset),
         "QLinearMul": QLinearMul.get_converter(opset),
+        "QLinearSigmoid": QLinearSigmoid.get_converter(opset),
         "ConvInteger": ConvInteger.get_converter(opset),
         # Random number generation.
         "RandomUniform": RandomUniform.get_converter(opset),

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3253,7 +3253,9 @@ class DequantizeLinear(OnnxOpConverter):
     @classmethod
     def _impl_v13(cls, inputs, attr, params):
         data, scale, zp = inputs
-        axis = attr.get("axis", 0)
+        axis = attr.get("axis", 1)
+        if len(infer_shape(data)) <= 1:
+            axis = 0
         return _qnn.op.dequantize(data, scale, _op.cast(zp, "int32"), axis)
 
 
@@ -3445,7 +3447,7 @@ class QLinearSigmoid(OnnxOpConverter):
         ## and then requantize after:
         ## https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/
         ## providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp#L245
-        x = _qnn.op.dequantize(inputs[0], x_scale, x_zero_point)
+        x = _qnn.op.dequantize(x, x_scale, x_zero_point)
         out = _op.sigmoid(x)
         return _qnn.op.quantize(out, y_scale, y_zero_point, out_dtype=dtype)
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5432,9 +5432,35 @@ def test_qlinearmul(target, dev):
         model = helper.make_model(graph, producer_name="qlinearmul_test")
         quantize_and_verify_with_ort(model, input_names, [a_shape, b_shape], target, dev)
 
+    verify_qlinearmul([7], [7], [7])
     verify_qlinearmul([4, 2], [4, 2], [4, 2])
     verify_qlinearmul([4, 2], [2], [4, 2])
     verify_qlinearmul([5, 1, 7], [2, 7], [5, 2, 7])
+
+
+@tvm.testing.parametrize_targets
+def test_qlinearsigmoid(target, dev):
+    def verify_qlinearsigmoid(a_shape):
+
+        a_array = np.random.random(a_shape).astype("float32")
+
+        input_nodes = [helper.make_tensor_value_info("a", TensorProto.FLOAT, list(a_shape))]
+
+        input_values = [a_array]
+
+        node = helper.make_node("Sigmoid", ["a"], ["B"])
+        graph = helper.make_graph(
+            [node],
+            "qlinearsigmoid_test",
+            inputs=input_nodes,
+            outputs=[helper.make_tensor_value_info("B", TensorProto.FLOAT, list(a_shape))],
+        )
+        model = helper.make_model(graph, producer_name="qlinearsigmoid_test")
+        quantize_and_verify_with_ort(model, ["a"], [a_shape], target, dev)
+
+    verify_qlinearsigmoid([4, 2])
+    verify_qlinearsigmoid([5])
+    verify_qlinearsigmoid([3, 4, 5])
 
 
 @tvm.testing.parametrize_targets

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5571,6 +5571,7 @@ def test_qlinearsigmoid(target, dev):
     verify_qlinearsigmoid([4, 2])
     verify_qlinearsigmoid([5])
     verify_qlinearsigmoid([3, 4, 5])
+    verify_qlinearsigmoid([])
 
 
 @tvm.testing.parametrize_targets


### PR DESCRIPTION
This PR implements com.microsoft.QLinearSigmoid (tracked here). This is implemented as dequantize->sigmoid->quantize for now.

This also fixes an issue with DequantizeLinear for tensors with rank=1. The current default axis of 1 for _impl_v13 leads to failures with rank=1 tensors. A new test is added for an existing op (QLinearMul) for this case.
