### PR TITLE
[CUDA] Fix dense tensorcore legalize type error when units is specified

### DIFF
--- a/python/tvm/topi/cuda/tensorcore_alter_op.py
+++ b/python/tvm/topi/cuda/tensorcore_alter_op.py
@@ -176,6 +176,12 @@ def _dense_legalize(attrs, inputs, arg_types):
 
     x_ = relay.nn.pad(x, pad_width=((0, dm), (0, dk))) if dm or dk else x
     y_ = relay.nn.pad(y, pad_width=((0, dn), (0, dk))) if dn or dk else y
+
+    # If units is explicitly specified, it is used to compute the output shape.
+    # We need to update units after padding to prevent a type error.
+    if attrs["units"] is not None:
+        new_attrs["units"] = N + dn
+
     out_ = relay.nn.dense(x_, y_, **new_attrs)
     out = (
         relay.strided_slice(out_, begin=[0, 0], end=[x.value for x in output_tensor.shape])

--- a/tests/python/relay/test_pass_legalize_tensorcore.py
+++ b/tests/python/relay/test_pass_legalize_tensorcore.py
@@ -307,7 +307,10 @@ def test_legalize_batch_matmul():
                 weight_pad = relay.nn.pad(weight, pad_width=((0, 0), (0, dn), (0, dk)))
             else:
                 weight_pad = weight
-            y_pad = relay.nn.batch_matmul(x_pad, weight_pad,)
+            y_pad = relay.nn.batch_matmul(
+                x_pad,
+                weight_pad,
+            )
             if dm or dn:
                 y = relay.strided_slice(y_pad, begin=[0, 0, 0], end=out_shape)
             else:


### PR DESCRIPTION
When `units` parameter is specified for `dense` op and padding for tensorcore kicks in (see https://github.com/apache/tvm/pull/7147), we get an obscure error like below in the middle of `relay.build(...)`. This happens because `units` parameter is used to compute the output shape when it is specified, while currently this value is not updated after padding.

```
The Relay type checker is unable to show the following types match.
In particular dimension 0 conflicts: 30 does not match 32.
The Relay type checker is unable to show the following types match.
In particular `Tensor[(32, 16), float16]` does not match `Tensor[(30, 16), float16]`
```

@comaniac @jwfromm @Meteorix 