### PR TITLE
[BYOC] Fix build with TensorRT 8

### DIFF
--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -61,9 +61,6 @@ TensorRTBuilder::TensorRTBuilder(TensorRTLogger* logger,
   this->calibrator_ = calibrator;
   if (calibrator != nullptr) {
     use_int8_ = true;
-    builder_->setFp16Mode(true);
-    builder_->setInt8Mode(true);
-    builder_->setInt8Calibrator(calibrator);
   }
   network_ = builder_->createNetworkV2(flags);
 #else

--- a/src/runtime/contrib/tensorrt/tensorrt_calibrator.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_calibrator.h
@@ -62,13 +62,13 @@ class TensorRTCalibrator : public nvinfer1::IInt8EntropyCalibrator2 {
     data_sizes_.push_back(binding_sizes);
   }
 
-  int getBatchSize() const override { return batch_size_; }
+  int getBatchSize() const noexcept override { return batch_size_; }
 
   /*!
    * \brief TensorRT will call this method to get next batch of data to
    * calibrate with.
    */
-  bool getBatch(void* bindings[], const char* names[], int nbBindings) override {
+  bool getBatch(void* bindings[], const char* names[], int nbBindings) noexcept override {
     AllocateBuffersIfNotAllocated();
     CHECK_EQ(input_names_.size(), nbBindings);
     for (size_t i = 0; i < input_names_.size(); ++i) {
@@ -83,13 +83,13 @@ class TensorRTCalibrator : public nvinfer1::IInt8EntropyCalibrator2 {
     return (num_batches_calibrated_ < data_.size());
   }
 
-  const void* readCalibrationCache(size_t& length) override {
+  const void* readCalibrationCache(size_t& length) noexcept override {
     if (calibration_cache_.empty()) return nullptr;
     length = calibration_cache_.size();
     return calibration_cache_.data();
   }
 
-  void writeCalibrationCache(const void* cache, size_t length) override {
+  void writeCalibrationCache(const void* cache, size_t length) noexcept override {
     calibration_cache_.assign(static_cast<const char*>(cache), length);
   }
 


### PR DESCRIPTION
I tried to use TRT BYOC with the latest TensorRT version, but got a build error. The code is using [functions that were deprecated in TRT 7](https://github.com/NVIDIA/TensorRT/blob/release/7.0/include/NvInfer.h#L6617-L6619) and removed in 8. 

These function calls should be redundant, since we are also using `config_->setFlag(...)` API anyway.  
https://github.com/apache/tvm/blob/6f5b674064d2b1dd804546babc426be21b9b07ad/src/runtime/contrib/tensorrt/tensorrt_builder.cc#L171-L172

@trevor-m @comaniac @tiandiao123 