### PR TITLE
Add back missing __init__.py to unbreak CI.

### DIFF
--- a/python/tvm/relay/backend/contrib/__init__.py
+++ b/python/tvm/relay/backend/contrib/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""External backend codegen modules for Relay."""


### PR DESCRIPTION
- #8951 deleted `python/tvm/relay/backend/contrib/__init__.py` since, at the time it was authored, `cmsisnn` was the sole package in `tvm.relay.backend.contrib`.
- however after it passed CI but before it merged, #8806 added `python/tvm/relay/backend/contrib/ethosu`
- the merge conflict broke the mypy build.

cc @ashutosh-arm @manupa-arm @tqchen @mikepapadim 