### PR TITLE
[Support] Add `parallel_for_dynamic` with dynamic schedules

### DIFF
--- a/include/tvm/support/parallel_for.h
+++ b/include/tvm/support/parallel_for.h
@@ -57,7 +57,7 @@ TVM_DLL std::vector<std::vector<int>> rr_partitioner(int begin, int end, int ste
  *   });
  * \param begin The start index of this parallel loop(inclusive).
  * \param end The end index of this parallel loop(exclusive).
- * \param f The task function to be excuted. Assert to take an int index as input with no output.
+ * \param f The task function to be executed. Assert to take an int index as input with no output.
  * \param step The traversal step to the index.
  * \param partitioner A partition function to split tasks to different threads. Use Round-robin
  * partitioner by default.
@@ -67,6 +67,26 @@ TVM_DLL std::vector<std::vector<int>> rr_partitioner(int begin, int end, int ste
 TVM_DLL void parallel_for(int begin, int end, const std::function<void(int)>& f, int step = 1,
                           const PartitionerFuncType partitioner = rr_partitioner);
 
+/*!
+ * \brief An API to launch fix amount of threads to run the specific functor in parallel.
+ * Different from `parallel_for`, the partition is determined dynamically on the fly,
+ * i.e. any time when a thread is idle, it fetches the next task to run.
+ * The behavior is similar to dynamic scheduling in OpenMP:
+ *
+ *   \#pragma omp parallel for schedule(dynamic) num_threads(num_threads)
+ *   for (int i = 0; i < 10; i++) {
+ *     a[i] = i;
+ *   }
+ *
+ * \param begin The start index of this parallel loop (inclusive).
+ * \param end The end index of this parallel loop (exclusive).
+ * \param num_threads The number of threads to be used.
+ * \param f The task function to be executed. Takes the thread index and the task index as
+ * input with no output.
+ * \note `step` support is left for future work.
+ */
+TVM_DLL void parallel_for_dynamic(int begin, int end, int num_threads,
+                                  const std::function<void(int thread_id, int task_id)>& f);
 }  // namespace support
 }  // namespace tvm
 

--- a/src/support/parallel_for.cc
+++ b/src/support/parallel_for.cc
@@ -67,8 +67,8 @@ void parallel_for(int begin, int end, const std::function<void(int)>& f, int ste
   res_vec.reserve(run_partitions.size());
   for (const auto& run_partition : run_partitions) {
     std::packaged_task<void(const std::vector<int>&, const std::function<void(int)>&)> task(
-        [](const std::vector<int>& run_pattition, const std::function<void(int)>& f) {
-          for (const auto& i : run_pattition) {
+        [](const std::vector<int>& run_partition, const std::function<void(int)>& f) {
+          for (const auto& i : run_partition) {
             f(i);
           }
         });
@@ -87,6 +87,53 @@ void parallel_for(int begin, int end, const std::function<void(int)>& f, int ste
   try {
     for (auto&& i : res_vec) {
       i.get();
+    }
+  } catch (const std::exception& e) {
+    LOG(FATAL) << "Parallel_for error with " << e.what();
+  }
+}
+
+void parallel_for_dynamic(int begin, int end, int num_threads,
+                          const std::function<void(int thread_id, int task_id)>& f) {
+  // Step 1. Sanity checks
+  if (begin == end) {
+    return;
+  }
+  CHECK_LT(begin, end) << "ValueError: The interval [begin, end) requires `begin <= end`";
+  CHECK_GT(num_threads, 0) << "ValueError: `num_threads` should be positive";
+  // Step 2. Launch threads
+  // Step 2.1. Launch worker 1 to worker `num_threads - 1`
+  std::atomic<int> counter{begin};
+  std::vector<std::future<void>> futures;
+  std::vector<std::thread> threads;
+  futures.reserve(num_threads - 1);
+  threads.reserve(num_threads - 1);
+  auto worker = [end, &counter, &f](int thread_id) -> void {
+    for (int task_id; (task_id = counter++) < end;) {
+      f(thread_id, task_id);
+    }
+  };
+  for (int thread_id = 1; thread_id < num_threads; ++thread_id) {
+    std::packaged_task<void(int)> task(worker);
+    futures.emplace_back(task.get_future());
+    threads.emplace_back(std::move(task), thread_id);
+  }
+  // Step 2.2. Launch worker 0 inplace
+  try {
+    worker(0);
+  } catch (const std::exception& e) {
+    for (auto&& thread : threads) {
+      thread.join();
+    }
+    LOG(FATAL) << "Parallel_for error with " << e.what();
+  }
+  // Step 3. Join threads and check exceptions
+  for (auto&& thread : threads) {
+    thread.join();
+  }
+  try {
+    for (auto&& future : futures) {
+      future.get();
     }
   } catch (const std::exception& e) {
     LOG(FATAL) << "Parallel_for error with " << e.what();

--- a/src/support/parallel_for.cc
+++ b/src/support/parallel_for.cc
@@ -99,7 +99,7 @@ void parallel_for_dynamic(int begin, int end, int num_threads,
   if (begin == end) {
     return;
   }
-  CHECK_LT(begin, end) << "ValueError: The interval [begin, end) requires `begin <= end`";
+  CHECK_LE(begin, end) << "ValueError: The interval [begin, end) requires `begin <= end`";
   CHECK_GT(num_threads, 0) << "ValueError: `num_threads` should be positive";
   // Step 2. Launch threads
   // Step 2.1. Launch worker 1 to worker `num_threads - 1`

--- a/src/support/parallel_for.cc
+++ b/src/support/parallel_for.cc
@@ -125,7 +125,7 @@ void parallel_for_dynamic(int begin, int end, int num_threads,
     for (auto&& thread : threads) {
       thread.join();
     }
-    LOG(FATAL) << "Parallel_for error with " << e.what();
+    LOG(FATAL) << "RuntimeError: parallel_for_dynamic error with " << e.what();
   }
   // Step 3. Join threads and check exceptions
   for (auto&& thread : threads) {
@@ -136,7 +136,7 @@ void parallel_for_dynamic(int begin, int end, int num_threads,
       future.get();
     }
   } catch (const std::exception& e) {
-    LOG(FATAL) << "Parallel_for error with " << e.what();
+    LOG(FATAL) << "RuntimeError: parallel_for_dynamic error with " << e.what();
   }
 }
 


### PR DESCRIPTION
This PR introduces an API `parallel_for_dynamic` which is analogous to OpenMP's dynamic scheduling below:

```C++
#pragma omp parallel for schedule(dynamic) num_threads(num_threads)
for (int i = 0; i < 10; i++) {
    a[i] = i;
}
```

CC: @jcf94 @zxybazh @comaniac 