### PR TITLE
[AutoTVM] Sort arguments of built autotvm func in topological order.

### DIFF
--- a/python/tvm/autotvm/task/task.py
+++ b/python/tvm/autotvm/task/task.py
@@ -244,7 +244,7 @@ class TaskTemplate(object):
     def _default_func(self, *args, **kwargs):
         assert callable(self.fcompute) and callable(self.fschedule)
         out = self.fcompute(*args, **kwargs)
-        arg_bufs = [out] + self._get_inputs(out)
+        arg_bufs = self._get_inputs(out) + [out]
         s = self.fschedule([out])
         return s, arg_bufs
 
@@ -259,8 +259,10 @@ class TaskTemplate(object):
                 inputs.append(t)
             else:
                 input_tensors = [t for t in t.op.input_tensors if t not in hash_set]
+                input_tensors.reverse()
                 queue.extend(input_tensors)
                 hash_set.update(input_tensors)
+        inputs.reverse()
         return inputs
 
 


### PR DESCRIPTION
Currently, the order of the AutoTVM function arguments might cause confusion in some cases. For example, for a 3x3 conv, the order of `arg_bufs` after calling `s, arg_bufs = task.instantiate(best_config)` is output, filter, input, while for a 1x1 conv, the order is output, input, filter, since it doesn't need padding and thus both input and filter are directly the input_tensors of conv, in which input comes first. This will significantly affect the use of the generated CUDA/asm code externally.

This fix sorts the arguments in topological order.
