### PR TITLE
Migrate flake8 from workflow to lint script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Initialize submodules
       run: git submodule update --recursive --init
-    - name: Lint Python
-      if: startsWith(matrix.os, 'macOS')
-      run: |
-        python3 -m pip install flake8
-        python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics
     - uses: actions/cache@v1
       env:
         CACHE_NUMBER: 0

--- a/tests/lint/flake8.sh
+++ b/tests/lint/flake8.sh
@@ -16,5 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Disabled until docker images are rebuilt
-# python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics
+
+python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics


### PR DESCRIPTION
Saw https://github.com/apache/tvm/pull/9055 adds `flake8.sh` to the `docker/lint.sh` and remembered I started doing this in https://github.com/apache/tvm/pull/8652, but never updated it after the Docker images were actually updated.
