### PR TITLE
Ensure AOT passes all intermediary storages to function calls

### DIFF
--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -291,7 +291,9 @@ class AOTExecutorCodegen : public MixedModeVisitor {
         args.push_back(param_handle);
       } else {
         auto var_arg = FindExpr(arg);
-        args.push_back(var_arg[0]);
+        for (const auto& var : var_arg) {
+          args.push_back(var);
+        }
       }
     }
 


### PR DESCRIPTION
This iterates over the return storage IDs rather than just using the
first one to ensure all of them get passed to subsequent calls.

Fixes #9036
