### PR TITLE
[AutoTVM, Auto scheduler] Always use VM compiler for task extraction

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -25,7 +25,6 @@ Integrate auto_scheduler into relay. It implements the following items:
 import json
 import logging
 import threading
-from copy import deepcopy
 
 import tvm
 from tvm import autotvm, transform
@@ -50,7 +49,6 @@ def call_all_topi_funcs(mod, params, target, opt_level=3):
     """Call all TOPI compute to extract auto_scheduler tasks in a Relay program"""
     # pylint: disable=import-outside-toplevel
     from tvm import relay
-    from tvm.relay.backend import graph_executor_codegen
 
     # Turn off AutoTVM config not found warnings
     old_autotvm_silent = autotvm.GLOBAL_SCOPE.silent

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -22,7 +22,6 @@ Decorator and utilities for the integration with TOPI and Relay
 """
 import threading
 import logging
-from copy import deepcopy
 
 import tvm
 from tvm.autotvm.task.dispatcher import DispatchContext, FallbackContext

--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -19,7 +19,7 @@
 
 /*!
  * \file relay/backend/compile_engine.cc
- * \brief Internal compialtion engine.
+ * \brief Internal compilation engine.
  */
 #include "compile_engine.h"
 

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -44,6 +44,11 @@
 
 namespace tvm {
 namespace relay {
+
+namespace tec {
+class TECompiler;
+}
+
 namespace transform {
 Pass InlinePrimitives();
 }
@@ -491,6 +496,11 @@ TargetModuleMapToTargetStrModuleMap(Map<Target, IRModule> input_map);
  */
 Map<Target, IRModule> TargetStrModuleMapToTargetModuleMap(
     std::unordered_map<Target, IRModule, TargetStrHash, TargetStrEqual> input_map);
+
+/*
+TODO
+*/
+void UpdateAutoSchedulerOpWeights(tec::TECompiler compiler);
 
 }  // namespace backend
 }  // namespace relay

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -497,9 +497,13 @@ TargetModuleMapToTargetStrModuleMap(Map<Target, IRModule> input_map);
 Map<Target, IRModule> TargetStrModuleMapToTargetModuleMap(
     std::unordered_map<Target, IRModule, TargetStrHash, TargetStrEqual> input_map);
 
-/*
-TODO
-*/
+/*!
+ * \brief Call "weight update callback" to communicate op weights seen during Relay module
+ * lowering back to the auto scheduler.
+ * Op weights refer to the number of times each distinct op/workload appears in a given module.
+ * It is called "use_count" in TECompiler.
+ * \param TECompiler used in the Relay module lowering step.
+ */
 void UpdateAutoSchedulerOpWeights(tec::TECompiler compiler);
 
 }  // namespace backend

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -977,6 +977,8 @@ void VMCompiler::Lower(IRModule mod, const TargetsMap& targets, const tvm::Targe
   for (const auto& cfunc : context_.cached_funcs) {
     exec_->primitive_map.insert({cfunc->prim_fn_var->name_hint, primitive_index++});
   }
+
+  backend::UpdateAutoSchedulerOpWeights(context_.compiler);
 }
 
 transform::Sequential MemoryOpt(tvm::Target host_target, TargetsMap targets) {

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -102,13 +102,13 @@ def get_network(name, batch_size=1, layout="NHWC"):
 @pytest.mark.parametrize(
     "params",
     [
-        ("mlp", "NHWC", 1, 2),
-        ("resnet-18", "NHWC", 24, 25),
-        ("resnet-18", "NCHW", 24, 25),
-        ("mobilenet", "NHWC", 22, 30),
-        ("mobilenet", "NCHW", 22, 30),
-        ("resnet3d-18", "NCDHW", 23, 24),
-        ("resnet3d-18", "NDHWC", 23, 24),
+        ("mlp", "NHWC", 1, 1),
+        ("resnet-18", "NHWC", 24, 24),
+        ("resnet-18", "NCHW", 24, 24),
+        ("mobilenet", "NHWC", 22, 22),
+        ("mobilenet", "NCHW", 22, 22),
+        ("resnet3d-18", "NCDHW", 23, 23),
+        ("resnet3d-18", "NDHWC", 23, 23),
     ],
 )
 def test_task_extraction_cuda(params):

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -102,13 +102,13 @@ def get_network(name, batch_size=1, layout="NHWC"):
 @pytest.mark.parametrize(
     "params",
     [
-        ("mlp", "NHWC", 1, 1),
-        ("resnet-18", "NHWC", 24, 24),
-        ("resnet-18", "NCHW", 24, 24),
-        ("mobilenet", "NHWC", 22, 22),
-        ("mobilenet", "NCHW", 22, 22),
-        ("resnet3d-18", "NCDHW", 23, 23),
-        ("resnet3d-18", "NDHWC", 23, 23),
+        ("mlp", "NHWC", 1, 2),
+        ("resnet-18", "NHWC", 24, 25),
+        ("resnet-18", "NCHW", 24, 25),
+        ("mobilenet", "NHWC", 22, 30),
+        ("mobilenet", "NCHW", 22, 30),
+        ("resnet3d-18", "NCDHW", 23, 24),
+        ("resnet3d-18", "NDHWC", 23, 24),
     ],
 )
 def test_task_extraction_cuda(params):


### PR DESCRIPTION
https://discuss.tvm.apache.org/t/autotvm-auto-scheduler-always-use-the-vm-compiler-for-task-extraction/11092

@comaniac @icemelon 