### PR TITLE
[PYTHON][FFI] Skip numpy.ascontiguousarray if C_CONTIGUOUS == True

### DIFF
--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -72,21 +72,6 @@ class DataType(ctypes.Structure):
         DataTypeCode.HANDLE: "handle",
         DataTypeCode.BFLOAT: "bfloat",
     }
-    NUMPY2STR = {
-        np.dtype(np.bool_): "bool",
-        np.dtype(np.int8): "int8",
-        np.dtype(np.int16): "int16",
-        np.dtype(np.int32): "int32",
-        np.dtype(np.int64): "int64",
-        np.dtype(np.uint8): "uint8",
-        np.dtype(np.uint16): "uint16",
-        np.dtype(np.uint32): "uint32",
-        np.dtype(np.uint64): "uint64",
-        np.dtype(np.float16): "float16",
-        np.dtype(np.float32): "float32",
-        np.dtype(np.float64): "float64",
-        np.dtype(np.float_): "float64",
-    }
 
     def __init__(self, type_str):
         super(DataType, self).__init__()

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -72,6 +72,21 @@ class DataType(ctypes.Structure):
         DataTypeCode.HANDLE: "handle",
         DataTypeCode.BFLOAT: "bfloat",
     }
+    NUMPY2STR = {
+        np.dtype(np.bool_) : "bool",
+        np.dtype(np.int8) : "int8",
+        np.dtype(np.int16) : "int16",
+        np.dtype(np.int32) : "int32",
+        np.dtype(np.int64) : "int64",
+        np.dtype(np.uint8) : "uint8",
+        np.dtype(np.uint16) : "uint16",
+        np.dtype(np.uint32) : "uint32",
+        np.dtype(np.uint64) : "uint64",
+        np.dtype(np.float16) : "float16",
+        np.dtype(np.float32) : "float32",
+        np.dtype(np.float64) : "float64",
+        np.dtype(np.float_) : "float64",
+    }
 
     def __init__(self, type_str):
         super(DataType, self).__init__()

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -73,19 +73,19 @@ class DataType(ctypes.Structure):
         DataTypeCode.BFLOAT: "bfloat",
     }
     NUMPY2STR = {
-        np.dtype(np.bool_) : "bool",
-        np.dtype(np.int8) : "int8",
-        np.dtype(np.int16) : "int16",
-        np.dtype(np.int32) : "int32",
-        np.dtype(np.int64) : "int64",
-        np.dtype(np.uint8) : "uint8",
-        np.dtype(np.uint16) : "uint16",
-        np.dtype(np.uint32) : "uint32",
-        np.dtype(np.uint64) : "uint64",
-        np.dtype(np.float16) : "float16",
-        np.dtype(np.float32) : "float32",
-        np.dtype(np.float64) : "float64",
-        np.dtype(np.float_) : "float64",
+        np.dtype(np.bool_): "bool",
+        np.dtype(np.int8): "int8",
+        np.dtype(np.int16): "int16",
+        np.dtype(np.int32): "int32",
+        np.dtype(np.int64): "int64",
+        np.dtype(np.uint8): "uint8",
+        np.dtype(np.uint16): "uint16",
+        np.dtype(np.uint32): "uint32",
+        np.dtype(np.uint64): "uint64",
+        np.dtype(np.float16): "float16",
+        np.dtype(np.float32): "float32",
+        np.dtype(np.float64): "float64",
+        np.dtype(np.float_): "float64",
     }
 
     def __init__(self, type_str):

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -165,9 +165,12 @@ class NDArray(NDArrayBase):
                     source_array.shape, shape
                 )
             )
-        source_array = np.ascontiguousarray(
-            source_array, dtype="uint16" if dtype == "bfloat16" else dtype
-        )
+        numpy_str_map = DataType.NUMPY2STR
+        np_dtype_str = numpy_str_map[source_array.dtype] if source_array.dtype in numpy_str_map else str(source_array.dtype)
+        if (not source_array.flags["C_CONTIGUOUS"]) or (dtype == "bfloat16" or dtype != np_dtype_str):
+            source_array = np.ascontiguousarray(
+                source_array, dtype="uint16" if dtype == "bfloat16" else dtype
+            )
         assert source_array.flags["C_CONTIGUOUS"]
         data = source_array.ctypes.data_as(ctypes.c_void_p)
         nbytes = ctypes.c_size_t(source_array.size * source_array.dtype.itemsize)

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -166,8 +166,14 @@ class NDArray(NDArrayBase):
                 )
             )
         numpy_str_map = DataType.NUMPY2STR
-        np_dtype_str = numpy_str_map[source_array.dtype] if source_array.dtype in numpy_str_map else str(source_array.dtype)
-        if (not source_array.flags["C_CONTIGUOUS"]) or (dtype == "bfloat16" or dtype != np_dtype_str):
+        np_dtype_str = (
+            numpy_str_map[source_array.dtype]
+            if source_array.dtype in numpy_str_map
+            else str(source_array.dtype)
+        )
+        if (not source_array.flags["C_CONTIGUOUS"]) or (
+                dtype == "bfloat16" or dtype != np_dtype_str
+        ):
             source_array = np.ascontiguousarray(
                 source_array, dtype="uint16" if dtype == "bfloat16" else dtype
             )

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -172,7 +172,7 @@ class NDArray(NDArrayBase):
             else str(source_array.dtype)
         )
         if (not source_array.flags["C_CONTIGUOUS"]) or (
-                dtype == "bfloat16" or dtype != np_dtype_str
+            dtype == "bfloat16" or dtype != np_dtype_str
         ):
             source_array = np.ascontiguousarray(
                 source_array, dtype="uint16" if dtype == "bfloat16" else dtype


### PR DESCRIPTION
Hi, i just run a tensorflow model with TVM. My model has 321 inputs so i find create NDArray inputs for model is time consuming. 

Code:
```
source_array = np.ascontiguousarray(
    source_array, dtype="uint16" if dtype == "bfloat16" else dtype
)
```
is used in function NDArray.copyfrom when create NDArray from Numpy. I find this code cost 0.47ms for my model, but a numpy array without operation like slice is contiguous and ascontiguousarray is not needed. In fact this code do nothing in my case, but 0.47ms is used.

So i add a type check, and i use a table DataType.NUMPY2STR to avoid str(np.dtype) as i find it time comusing, as i do in commit: https://github.com/apache/tvm/pull/9072