### PR TITLE
Improve tvmc error message from lazy-loading frontend imports

### DIFF
--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -73,6 +73,10 @@ class TVMCSuppressedArgumentParser(argparse.ArgumentParser):
         raise TVMCException()
 
 
+class TVMCImportError(TVMCException):
+    """TVMC TVMCImportError"""
+
+
 def convert_graph_layout(mod, desired_layout):
     """Alter the layout of the input graph.
 

--- a/python/tvm/driver/tvmc/main.py
+++ b/python/tvm/driver/tvmc/main.py
@@ -26,6 +26,7 @@ import sys
 import tvm
 
 from tvm.driver.tvmc.common import TVMCException
+from tvm.driver.tvmc.common import TVMCImportError
 
 
 REGISTERED_PARSER = []
@@ -91,6 +92,11 @@ def _main(argv):
 
     try:
         return args.func(args)
+    except TVMCImportError as err:
+        sys.stderr.write(
+            f'Package "{err}" is not installed. ' f'Hint: "pip install tlcpack[tvmc]".'
+        )
+        return 5
     except TVMCException as err:
         sys.stderr.write("Error: %s\n" % err)
         return 4

--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -16,13 +16,29 @@
 # under the License.
 
 import pytest
+import builtins
+import importlib
 
 import tvm
+from unittest import mock
 from tvm.ir.module import IRModule
 
 from tvm.driver import tvmc
 from tvm.driver.tvmc.common import TVMCException
+from tvm.driver.tvmc.common import TVMCImportError
 from tvm.driver.tvmc.model import TVMCModel
+
+
+orig_import = importlib.import_module
+
+
+def mock_error_on_name(name):
+    def mock_imports(module_name, package=None):
+        if module_name == name:
+            raise ImportError()
+        return orig_import(module_name, package)
+
+    return mock_imports
 
 
 def test_get_frontends_contains_only_strings():
@@ -367,3 +383,39 @@ def test_compile_onnx_module__same_layout__nchw_to_nchw(onnx_resnet50):
     tvm.relay.analysis.post_order_visit(after["main"], _is_layout_transform)
 
     assert not any(layout_transform_calls), "Unexpected 'layout_transform' call"
+
+
+def test_import_keras_friendly_message(keras_resnet50, monkeypatch):
+    # keras is part of tensorflow
+    monkeypatch.setattr("importlib.import_module", mock_error_on_name("tensorflow"))
+
+    with pytest.raises(TVMCImportError, match="tensorflow") as e:
+        _ = tvmc.frontends.load_model(keras_resnet50, model_format="keras")
+
+
+def test_import_onnx_friendly_message(onnx_resnet50, monkeypatch):
+    monkeypatch.setattr("importlib.import_module", mock_error_on_name("onnx"))
+
+    with pytest.raises(TVMCImportError, match="onnx") as e:
+        _ = tvmc.frontends.load_model(onnx_resnet50, model_format="onnx")
+
+
+def test_import_tensorflow_friendly_message(pb_mobilenet_v1_1_quant, monkeypatch):
+    monkeypatch.setattr("importlib.import_module", mock_error_on_name("tensorflow"))
+
+    with pytest.raises(TVMCImportError, match="tensorflow") as e:
+        _ = tvmc.frontends.load_model(pb_mobilenet_v1_1_quant, model_format="pb")
+
+
+def test_import_torch_friendly_message(pytorch_resnet18, monkeypatch):
+    monkeypatch.setattr("importlib.import_module", mock_error_on_name("torch"))
+
+    with pytest.raises(TVMCImportError, match="torch") as e:
+        _ = tvmc.frontends.load_model(pytorch_resnet18, model_format="pytorch")
+
+
+def test_import_tflite_friendly_message(tflite_mobilenet_v1_1_quant, monkeypatch):
+    monkeypatch.setattr("importlib.import_module", mock_error_on_name("tflite.Model"))
+
+    with pytest.raises(TVMCImportError, match="tflite.Model") as e:
+        _ = tvmc.frontends.load_model(tflite_mobilenet_v1_1_quant, model_format="tflite")


### PR DESCRIPTION
When installing TVM from the python package, the Frontend frameworks dependencies such as TensorFlow, PyTorch, ONNX, etc, are not installed by default.
In case a user tries to run tvmc using a model whose framework was not installed, it will be presented with a very raw Python exception in the output.
The aim of this commit is to implement a better error messages for errors related to lazy-loading frontend frameworks in tvmc.

cc @areusch @leandron @gromero @Mousius for reviews