### PR TITLE
[Relay] Fix compiler warning in ExtractOperators

### DIFF
--- a/src/relay/analysis/extract_operators.cc
+++ b/src/relay/analysis/extract_operators.cc
@@ -40,6 +40,8 @@ class OperatorExtractorWrapper : private MixedModeVisitor {
   }
 
  private:
+  using MixedModeVisitor::VisitExpr_;
+
   const IRModule mod_;
   /*! \brief Map of operator to frequency. */
   Map<String, tvm::Integer> operator_freqs_;


### PR DESCRIPTION
Fix clang warning:
```
  'OperatorExtractorWrapper::VisitExpr_' hides overloaded virtual functions
```