### PR TITLE
BUG #8013: Remove register_alter_op_layout example from dev/use_pass_infra.py

### DIFF
--- a/tutorials/dev/use_pass_infra.py
+++ b/tutorials/dev/use_pass_infra.py
@@ -228,7 +228,6 @@ seq = tvm.transform.Sequential(
         tvm.transform.PrintIR(),
         relay.transform.EliminateCommonSubexpr(),
         relay.transform.FuseOps(),
-        relay.transform.AlterOpLayout(),
     ]
 )
 

--- a/tutorials/dev/use_pass_infra.py
+++ b/tutorials/dev/use_pass_infra.py
@@ -70,20 +70,6 @@ def example():
 
 
 ###############################################################################
-# Let us register layout alteration for a conv2d op so that we can apply the
-# layout alteration pass on the example. How alter layout pass works is out
-# the scope of this tutorial.
-
-
-@relay.op.register_alter_op_layout("nn.conv2d", level=101)
-def alter_conv2d(attrs, inputs, tinfos, out_type):
-    data, weight = inputs
-    new_attrs = dict(attrs)
-    new_attrs["data_layout"] = "NCHW16c"
-    return relay.nn.conv2d(data, weight, **new_attrs)
-
-
-###############################################################################
 # Optimize the Program
 # --------------------
 # Now we would like to optimize the program. Relay features a host of
@@ -187,21 +173,6 @@ print(mod2)
 with tvm.transform.PassContext(opt_level=3, disabled_pass=["EliminateCommonSubexpr"]):
     mod3 = seq(mod)
 print(mod3)
-
-###############################################################################
-# The passes applied so far are target independent. The pass infra also
-# provides a means to make pass target-aware. For example, the layout
-# alteration pass falls in such category.
-
-with tvm.transform.PassContext(opt_level=3):
-    mod4 = seq(mod)
-print(mod4)
-
-seq1 = tvm.transform.Sequential([relay.transform.AlterOpLayout()])
-with tvm.transform.PassContext(opt_level=3):
-    with tvm.target.Target("llvm"):
-        mod5 = seq1(mod)
-print(mod5)
 
 ##############################################################################
 # Implement a Pass Using Python Decorator


### PR DESCRIPTION
This tutorial registers a global layout transformation for conv2d for all
targets which is not well-formed. Later uses of conv2d in the tutorials
pick that layout up then assert fail in the conv2d type-relation.

Better would be to register a transform for an entirely fake target, but
that is beyond my current level of expertise.

In general our use of sphinx/sphinx_gallery for running and rendering the
tutorials is highly suspect since there is no inter-example isolation:
 - Examples using tensorflow will gobble up GPU memory and not give it back.
 - Any examples which use any of the (many!) global registration mechanisms
   need to ensure the registrant is safe across all tutorials.
I recall seeing a thread with the sphinx_gallery where they said they'd prefer
not to work on process-level isolation, but it's probably worth pinging again.

While digging into this I noticed we had a slicing cast in AlterOpLayout due
to a derived class of ObjectRef introducing virtuals. I moved the virtuals to
the corresponding Node classes. In this case we got away with it since the
ObjectRef happened to not get copied but we were on very thin ice.