### PR TITLE
[CUDA] Swap block x and z dimension for conv2d NHWC schedule

### DIFF
--- a/python/tvm/topi/cuda/conv2d_nhwc.py
+++ b/python/tvm/topi/cuda/conv2d_nhwc.py
@@ -86,14 +86,14 @@ def schedule_conv2d_nhwc_direct(cfg, s, Conv):
 
     # Schedule for output
     ni, hi, wi, fi = s[output].op.axis
-    bz = s[output].fuse(hi, wi)
+    bx = s[output].fuse(hi, wi)
     tx, fi = s[output].split(fi, factor=tile_c)
     txz, tx = s[output].split(tx, factor=num_thread_c)
-    bx, txz = s[output].split(txz, factor=vthread_c)
+    bz, txz = s[output].split(txz, factor=vthread_c)
     ty, ni = s[output].split(ni, factor=tile_n)
     tyz, ty = s[output].split(ty, factor=num_thread_n)
     by, tyz = s[output].split(tyz, factor=vthread_n)
-    s[output].reorder(bz, by, bx, tyz, txz, ty, tx, ni, fi)
+    s[output].reorder(bx, by, bz, tyz, txz, ty, tx, ni, fi)
     s[output].bind(bz, block_z)
     s[output].bind(by, block_y)
     s[output].bind(bx, block_x)


### PR DESCRIPTION
In the cuda conv2d NHWC schedule, the number of blocks launched in the Z dimension is (roughly, modulo constant divisor) `H * W / 4`. According to `deviceQuery`, the max grid z dimension is 65536:
```
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
```
When H and W are large, it is very likely to generate an invalid schedule, because we try to launch too many blocks in the Z dimension. For example, here is an error that I hit when the input size is (800, 750). I cannot avoid this error even after auto tuning, since the block z size stays fixed during tuning. Without the change in this PR, I cannot ever run this model unless I use the auto scheduler.
```

  Check failed: ret == 0 (-1 vs. 0) : TVMError: CUDALaunch Error: CUDA_ERROR_INVALID_VALUE
 grid=(8,1,150000),  block=(4,4,1)
```

My solution is simply to swap the use of block x and z dimension, since we can launch far more blocks in the x dim as  `deviceQuery` shows above.

cc @vinx13 @junrushao1994 @Hzfengsy 