### PR TITLE
[TIR] tir.transform.StorageFlatten refactor

### DIFF
--- a/include/tvm/tir/buffer.h
+++ b/include/tvm/tir/buffer.h
@@ -121,6 +121,14 @@ class BufferNode : public Object {
     return shape.size() != 0 ? shape[0].dtype() : DataType::Int(32);
   }
 
+  /*! \brief Determine the offset in the buffer of the given index.
+   *
+   * Returns the buffer offset, in number of elements of type dtype,
+   * without adjusting for number of lanes.  (e.g. The number of
+   * float16x4 elements in a buffer of type float16x4.)
+   */
+  PrimExpr ElemOffset(Array<PrimExpr> index) const;
+
   static constexpr const char* _type_key = "tir.Buffer";
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -321,12 +321,17 @@ class BufferStrideLegalize : public StmtExprMutator {
       return buf;
     }
 
-    Array<PrimExpr> shape = buf->shape;
-
     // Keeping this to have matched behavior to previous version.
     // There are many parts of the codebase that assume that a strided
-    // array cannot be compact.
+    // array cannot be compact.  For example, ArgBinder::BindBuffer
+    // and tir.Specialize.
     if (dim_align_.count(buf) == 0) {
+      return buf;
+    }
+
+    // Can't define the strides for a buffer without a known shape.
+    Array<PrimExpr> shape = buf->shape;
+    if (shape.size() == 0) {
       return buf;
     }
 

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -314,11 +314,12 @@ class BufferShapeLegalize : public StmtExprMutator {
     ArgBinder binder(&var_remap_);
     binder.BindBuffer(key, buffer, key->name, true);
 
+    Stmt body = this->VisitStmt(op->body);
+    body = MergeNest(binder.asserts(), body);
+    body = MergeNest(binder.init_nest(), body);
+
     Stmt stmt = AttrStmt(Array<ObjectRef>{buffer, target_remap.remap_to}, op->attr_key,
-                         Call(tuple->dtype, tuple->op, new_tuple_args, tuple->span),
-                         this->VisitStmt(op->body));
-    stmt = MergeNest(binder.asserts(), stmt);
-    stmt = MergeNest(binder.init_nest(), stmt);
+                         Call(tuple->dtype, tuple->op, new_tuple_args, tuple->span), body);
 
     for (const Var& v : binder.defs()) {
       var_remap_.erase(v.get());

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -1349,10 +1349,9 @@ class StorageFlattener : public StmtExprMutator {
 /*!
  * \brief Simplify assert statements.
  *
- * If an assert statement can be statically verified to be false, emit
- * a failure at compile time.  If an assert statement can be
- * statically verified to be true, remove the assert statement.  If
- * neither case can be verified, keep the assert statement unmodified.
+ * If an assert statement can be statically verified to be true,
+ * remove the assert statement.  Otherwise, keep the assert statement
+ * unmodified.
  */
 class AssertSimplifier : public StmtMutator {
  public:
@@ -1364,9 +1363,6 @@ class AssertSimplifier : public StmtMutator {
     op = stmt.as<AssertStmtNode>();
 
     PrimExpr condition = bound_analyzer_->Simplify(op->condition);
-    if (is_zero(condition)) {
-      LOG(FATAL) << "Assert statement failed during static checking: " << op->message;
-    }
     if (is_one(condition)) {
       return op->body;
     }

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -202,6 +202,13 @@ class BufferShapeLegalize : public StmtExprMutator {
   }
 
  private:
+  // Any buffers that give views into a resized buffer should be
+  // updated, both to refer to the resized buffer and to have the view
+  // window updated.  For example, suppose B1 is a 1-D buffer of size
+  // 100 which is only realized on the range (10,50), and buffer V1 is
+  // a view into B1[25:35].  When B1 is replaced with B2, a buffer of
+  // size 40 realized on the range (0,40), V1 must be replaced to be a
+  // view into B2[15:25].
   Stmt HandleBufferBindScope(const AttrStmtNode* op) {
     Array<ObjectRef> arr = Downcast<Array<ObjectRef>>(op->node);
     ICHECK_EQ(arr.size(), 2U);
@@ -556,6 +563,10 @@ class ThreadScopePropagate : public StmtExprMutator {
   }
 
  private:
+  // If the rewritten buffers are part of a buffer_bind_scope, either
+  // as the buffer view or as the the buffer being viewed, then the
+  // buffer_bind_scope must be rewritten to refer to the updated
+  // buffers.
   Stmt HandleBufferBindScope(const AttrStmtNode* op) {
     Array<ObjectRef> arr = Downcast<Array<ObjectRef>>(op->node);
     ICHECK_EQ(arr.size(), 2U);

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -329,6 +329,14 @@ class BufferShapeLegalize : public StmtExprMutator {
   }
 
   Array<PrimExpr> update_indices(const Array<PrimExpr>& indices, const Array<PrimExpr>& offsets) {
+    // offsets come from BufferRealizeNode::bounds, which is allowed
+    // to be empty to indicate realization of the full shape of the
+    // buffer.  In that case, the indices do not need to be modified,
+    // but may need to be extended with leading zeroes.
+    if (offsets.size() == 0) {
+      return indices;
+    }
+
     ICHECK_GE(offsets.size(), indices.size())
         << "Cannot bind buffer to a shape of lower dimension.";
 

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -71,7 +71,7 @@ class BufferShapeLegalize : public StmtExprMutator {
   Stmt VisitStmt_(const BufferRealizeNode* op) final {
     // External buffers should not be changed.
     if (extern_buffers_.count(op->buffer)) {
-      ICHECK_EQ(op->buffer->shape.size(), op->bounds.size())
+      CHECK_EQ(op->buffer->shape.size(), op->bounds.size())
           << "External buffer realize has mismatched dimension";
       Stmt stmt = StmtExprMutator::VisitStmt_(op);
       op = stmt.as<BufferRealizeNode>();


### PR DESCRIPTION
This started after noticing that StorageFlatten incorrectly handled BufferLoad/BufferStore nodes that pointed to a buffer defined in an `attr::buffer_bind_scope` annotation.  Rather than adding more logic into the existing `StorageFlattener` mutator, I split up the existing behavior into multiple independent mutators.

This PR includes a series of commits, each of which refactors one of the behaviors out of the `StorageFlattener` class and into a separate class.  While all of the transforms are called sequentially in the `tir.transform.StorageFlatten` to maintain the same overall behavior, each transform results in a valid TIR tree.

* BufferShapeLegalize, which rewrites Buffer nodes to have sizes that match the BufferRealize node in which they are defined.
* BufferStrideLegalize, which rewrites the strides of Buffer nodes that are annotated with `attr::dim_align`.
* ThreadScopePropagate, which defines the allocation scope of Buffer nodes based on the thread iter in which they are declared, if no allocation scope was already defined.
* BufferBindUnwrapper, which rewrites access into Buffer objects that are defined by `attr::buffer_bind_scope`.  Refactoring this behavior into a separate mutator was my original goal, in order to resolve the issue of BufferLoad/BufferStore nodes that point to bound buffers, but doing so required the previous three behaviors to also be refactored into separate mutators.
* StorageFlattener, which contains all remaining behavior from the original StorageFlattener, and outputs the final Allocate/Store/Load nodes.

This refactor will also help in the future, when introducing layout transformations.

