### PR TITLE
[UnitTests] Enable minimum testing on Vulkan target in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,7 +209,7 @@ stage('Build') {
         make(ci_gpu, 'build', '-j2')
         pack_lib('gpu', tvm_multilib)
         // compiler test
-        sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_vulkan.sh"
+        sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_rocm.sh"
         make(ci_gpu, 'build2', '-j2')
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,7 +209,7 @@ stage('Build') {
         make(ci_gpu, 'build', '-j2')
         pack_lib('gpu', tvm_multilib)
         // compiler test
-        sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_rocm.sh"
+        sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
         make(ci_gpu, 'build2', '-j2')
       }
     }

--- a/tests/scripts/task_config_build_gpu.sh
+++ b/tests/scripts/task_config_build_gpu.sh
@@ -26,6 +26,7 @@ cp ../cmake/config.cmake .
 echo set\(USE_CUBLAS ON\) >> config.cmake
 echo set\(USE_CUDNN ON\) >> config.cmake
 echo set\(USE_CUDA ON\) >> config.cmake
+echo set\(USE_VULKAN ON\) >> config.cmake
 echo set\(USE_OPENGL ON\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu_other.sh
+++ b/tests/scripts/task_config_build_gpu_other.sh
@@ -16,22 +16,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -euo pipefail
+# This file is a compiler test to ensure that runtimes can compile
+# correctly, even if they aren't actively tested in the CI.
 
-export PYTEST_ADDOPTS="-m gpu ${PYTEST_ADDOPTS:-}"
+set -e
+set -u
 
-# Test most of the enabled runtimes here.
-export TVM_TEST_TARGETS="cuda;opencl;metal;rocm;nvptx;opencl -device=mali,aocl_sw_emu"
-export TVM_UNITTEST_TESTSUITE_NAME=python-unittest-gpu
+mkdir -p build2
+cd build2
+cp ../cmake/config.cmake .
 
-./tests/scripts/task_python_unittest.sh
-
-# Kept separate to avoid increasing time needed to run CI, testing
-# only minimal functionality of Vulkan runtime.
-export TVM_TEST_TARGETS="vulkan -from_device=0"
-export TVM_UNITTEST_TESTSUITE_NAME=python-unittest-vulkan
-
-source tests/scripts/setup-pytest-env.sh
-
-run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest/test_target_codegen_vulkan.py
-run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest/test_target_codegen_vulkan.py
+echo set\(USE_OPENCL ON\) >> config.cmake
+echo set\(USE_ROCM ON\) >> config.cmake
+echo set\(USE_MICRO ON\) >> config.cmake
+echo set\(USE_PROFILER ON\) >> config.cmake
+echo set\(USE_LIBBACKTRACE OFF\) >> config.cmake
+echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
+echo set\(USE_CCACHE OFF\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu_rocm.sh
+++ b/tests/scripts/task_config_build_gpu_rocm.sh
@@ -25,7 +25,6 @@ cp ../cmake/config.cmake .
 
 echo set\(USE_OPENCL ON\) >> config.cmake
 echo set\(USE_ROCM ON\) >> config.cmake
-echo set\(USE_VULKAN ON\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_LIBBACKTRACE OFF\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu_vulkan.sh
+++ b/tests/scripts/task_config_build_gpu_vulkan.sh
@@ -16,17 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+# TODO(Lunderberg): Remove this file once the Jenkinsfile in the
+# ci-docker-staging branch no longer references it.
 
-mkdir -p build2
-cd build2
-cp ../cmake/config.cmake .
+# This file is a backwards compatibility file, as the TVM CI uses the
+# Jenkinsfile from the ci-docker-staging branch, but the task scripts
+# from the PR branch.
 
-echo set\(USE_OPENCL ON\) >> config.cmake
-echo set\(USE_ROCM ON\) >> config.cmake
-echo set\(USE_MICRO ON\) >> config.cmake
-echo set\(USE_PROFILER ON\) >> config.cmake
-echo set\(USE_LIBBACKTRACE OFF\) >> config.cmake
-echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
-echo set\(USE_CCACHE OFF\) >> config.cmake
+set -euo pipefail
+
+./tests/scripts/task_config_build_gpu_other.sh

--- a/tests/scripts/task_python_integration_gpuonly.sh
+++ b/tests/scripts/task_python_integration_gpuonly.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-export TVM_TEST_TARGETS="cuda;opencl;metal;rocm;vulkan;nvptx;opencl -device=mali,aocl_sw_emu"
+export TVM_TEST_TARGETS="cuda;opencl;metal;rocm;nvptx;opencl -device=mali,aocl_sw_emu"
 export PYTEST_ADDOPTS="-m gpu $PYTEST_ADDOPTS"
 export TVM_RELAY_TEST_TARGETS="cuda"
 export TVM_INTEGRATION_TESTSUITE_NAME=python-integration-gpu

--- a/tests/scripts/task_python_unittest_gpuonly.sh
+++ b/tests/scripts/task_python_unittest_gpuonly.sh
@@ -16,8 +16,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-export TVM_TEST_TARGETS="cuda;opencl;metal;rocm;vulkan;nvptx;opencl -device=mali,aocl_sw_emu"
+set -euo pipefail
+
+export TVM_TEST_TARGETS="cuda;opencl;metal;rocm;nvptx;opencl -device=mali,aocl_sw_emu"
 export PYTEST_ADDOPTS="-m gpu $PYTEST_ADDOPTS"
 export TVM_UNITTEST_TESTSUITE_NAME=python-unittest-gpu
 
 ./tests/scripts/task_python_unittest.sh
+
+# Kept separate to avoid increasing time needed to run CI, testing
+# only minimal functionality of Vulkan runtime.
+export TVM_TEST_TARGETS="vulkan -from_device=0"
+export PYTEST_ADDOPTS="-m gpu $PYTEST_ADDOPTS"
+export TVM_UNITTEST_TESTSUITE_NAME=python-unittest-vulkan
+
+source tests/scripts/setup-pytest-env.sh
+
+run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest/test_target_codegen_vulkan.py
+run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest/test_target_codegen_vulkan.py


### PR DESCRIPTION
The goal of this PR is to enable a minimum testing of the vulkan runtime, without significantly increasing the runtime of the pre-commit CI.  The additional tests enabled run in about 3.5 seconds on my local machine, so the CI runtime impact should be minimal.

- Include the Vulkan runtime in the GPU build.
- Run test_target_codegen_vulkan.py as part of the `python3: GPU` CI step.
