### PR TITLE
Add `extern "C"` to C Interface API header

### DIFF
--- a/python/tvm/micro/interface_api.py
+++ b/python/tvm/micro/interface_api.py
@@ -57,9 +57,12 @@ def generate_c_interface_header(module_name, inputs, outputs, output_path):
     metadata_header = os.path.join(output_path, f"{mangled_name}.h")
     with open(metadata_header, "w") as header_file:
         header_file.write(
-            "#include <stdint.h>\n"
             f"#ifndef {mangled_name.upper()}_H_\n"
-            f"#define {mangled_name.upper()}_H_\n"
+            f"#define {mangled_name.upper()}_H_\n\n"
+            "#include <stdint.h>\n\n"
+            "#ifdef __cplusplus\n"
+            'extern "C" {\n'
+            "#endif\n\n"
         )
 
         _emit_brief(header_file, module_name, "Input tensor pointers")
@@ -91,6 +94,8 @@ def generate_c_interface_header(module_name, inputs, outputs, output_path):
             ");\n"
         )
 
-        header_file.write(f"#endif // {mangled_name.upper()}_H_\n")
+        header_file.write(
+            "\n#ifdef __cplusplus\n}\n#endif\n\n" f"#endif // {mangled_name.upper()}_H_\n"
+        )
 
     return metadata_header


### PR DESCRIPTION
This is to provide the hint to C++ compilers that these functions are C linkage.

New header looks similar to:

```c++
#ifndef TVMGEN_DEFAULT_H_
#define TVMGEN_DEFAULT_H_

#include <stdint.h>

#ifdef __cplusplus
extern "C" {
#endif

/*!
 * \brief Input tensor pointers for TVM module "default" 
 */
struct tvmgen_default_inputs {
  void* y;
};

/*!
 * \brief Output tensor pointers for TVM module "default" 
 */
struct tvmgen_default_outputs {
  void* output;
};

/*!
 * \brief entrypoint function for TVM module "default"
 * \param inputs Input tensors for the module 
 * \param outputs Output tensors for the module 
 */
int32_t tvmgen_default_run(
  struct tvmgen_default_inputs* inputs,
  struct tvmgen_default_outputs* outputs
);

#ifdef __cplusplus
}
#endif

#endif // TVMGEN_DEFAULT_H_

```
