### PR TITLE
Ensure google-mock is installed and setup

### DIFF
--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -22,9 +22,10 @@ set -o pipefail
 
 # install libraries for building c++ core on ubuntu
 apt-get update && apt-get install -y --no-install-recommends \
-        git make libgtest-dev cmake wget unzip libtinfo-dev libz-dev\
+        git make google-mock libgtest-dev cmake wget unzip libtinfo-dev libz-dev \
         libcurl4-openssl-dev libssl-dev libopenblas-dev g++ sudo \
         apt-transport-https graphviz pkg-config curl
 
 
 cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
+cd /usr/src/gmock && cmake CMakeLists.txt && make && cp *.a /usr/lib


### PR DESCRIPTION
Google Mock is the mocking/helper framework that gets bundled with Google Test, it used to be separate but now isn't.  I ran into the issue of Google Mock not being configured fully in the i386 build of #9106, which uses the `HasSubtr` matcher. This PR aims to fully configure Google Mock for use, which is interesting in itself...

The headers are installed as part of Ubuntu 18.04's `googletest` package:

```shell
$ dpkg -S /usr/include/gmock/
googletest:amd64: /usr/include/gmock
```

But not the lib sources, that requires another package named `google-mock`:

```shell
$ dpkg -S /usr/src/gmock
google-mock:amd64: /usr/src/gmock
```

But in Ubuntu 16.04 the includes and lib sources are in the `google-mock` package:
```shell
$ dpkg -S /usr/include/gmock
google-mock:i386: /usr/include/gmock
$ dpkg -S /usr/src/gmock/
google-mock:i386: /usr/src/gmock
```

And excitingly, in Ubuntu 20.04 this will again be changed to `libgmock-dev` by the looks of things, just to keep us on our toes.