### PR TITLE
[CI] bash.sh, build.sh: add option to set the container name and hostname

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -23,7 +23,8 @@
 # Usage: build.sh <CONTAINER_TYPE> [--tag <DOCKER_IMAGE_TAG>]
 #                [--dockerfile <DOCKERFILE_PATH>] [-it]
 #                [--net=host] [--cache-from <IMAGE_NAME>]
-#                [--context-path <CONTEXT_PATH>] [<COMMAND>]
+#                [--name CONTAINER_NAME] [--context-path <CONTEXT_PATH>]
+#                [<COMMAND>]
 #
 # CONTAINER_TYPE: Type of the docker container used the run the build,
 #                 e.g. "ci_cpu", "ci_gpu"
@@ -37,6 +38,9 @@
 #
 # IMAGE_NAME: An image to be as a source for cached layers when building the
 #             Docker image requested.
+#
+# CONTAINER_NAME: The name of the docker container, and the hostname that will
+#                 appear inside the container.
 #
 # CONTEXT_PATH: Path to be used for relative path resolution when building
 #               the Docker images.
@@ -93,6 +97,12 @@ if [[ "$1" == "--context-path" ]]; then
 else
     DOCKER_CONTEXT_PATH=$(dirname "${DOCKERFILE_PATH}")
     echo "Using default context path: ${DOCKER_CONTEXT_PATH}"
+fi
+
+if [[ "$1" == "--name" ]]; then
+    CI_DOCKER_EXTRA_PARAMS+=("--name ${2} --hostname ${2}")
+    echo "Using container name ${2}"
+    shift 2
 fi
 
 if [[ ! -f "${DOCKERFILE_PATH}" ]]; then


### PR DESCRIPTION

This commit adds option "--name" to bash.sh and build.sh to enable the user
specify the name of the container and set the hostname inside the
container as well.

This helps the developer idenitfy that they are inside the container
and which container they are working inside.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
