### PR TITLE
[Bugfix] Prevent casting handle to other types

### DIFF
--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -273,6 +273,7 @@ PrimExpr cast(const DataType& t, PrimExpr value, Span span) {
     } else if (const FloatImmNode* op = value.as<FloatImmNode>()) {
       return make_const(t, op->value, op->span);
     }
+    ICHECK(!value.dtype().is_handle()) << "Can't cast a handle to other types.";
     return tir::Cast(t, value, span);
   } else {
     if (value.dtype().lanes() == 1) {

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 import tvm
 from tvm import te
 import numpy as np
@@ -103,6 +104,11 @@ def test_cast():
     assert isinstance(y, tvm.tir.Cast)
     assert isinstance(z, tvm.tir.Broadcast)
     assert z.lanes == 4
+
+    s = tvm.tir.StringImm("s")
+    with pytest.raises(tvm.error.TVMError) as cm:
+        s.astype("int")
+        assert "Can't cast a handle to other types" in str(cm.execption)
 
 
 def test_attr():
@@ -468,28 +474,4 @@ def test_block_blockrealize():
 
 
 if __name__ == "__main__":
-    test_intimm_cond()
-    test_buffer_load_store()
-    test_vars()
-    test_prim_func()
-    test_cast()
-    test_attr()
-    test_const()
-    test_scalar_dtype_inference()
-    test_make()
-    test_ir()
-    test_basic()
-    test_stmt()
-    test_let()
-    test_dir()
-    test_dtype()
-    test_any()
-    test_all()
-    test_bitwise()
-    test_float_bitwise()
-    test_shift_bounds()
-    test_divide_by_zero()
-    test_isnan()
-    test_equality()
-    test_equality_string_imm()
-    test_block_blockrealize()
+    pytest.main([__file__])


### PR DESCRIPTION
As we discussed in [this post](https://discuss.tvm.apache.org/t/undefined-behavior-happens-when-casting-string-to-bool/11090/10), a casting from handle to int or other types is actually undefined.

For example, when we try to cast a handle to bool, it will invoke `llvm::Constant* zero = llvm::ConstantInt::get(DTypeToLLVMType(from), 0);`, which means that we regard the from type is `int`, but actually it is `handle`. 

[src/target/llvm/codegen_llvm.cc - CodeGenLLVM::CreateCast](https://github.com/apache/tvm/blob/main/src/target/llvm/codegen_llvm.cc#L687):

```c++
llvm::Value* CodeGenLLVM::CreateCast(DataType from, DataType to, llvm::Value* value) {
  llvm::Type* target = DTypeToLLVMType(to);
  if (value->getType() == target) return value;
  if (to.is_handle()) {
    return builder_->CreateBitCast(value, target);
  } else if (to.is_uint() && to.bits() == 1) {
    if (from.is_float()) {
      llvm::Constant* zero = llvm::ConstantFP::get(DTypeToLLVMType(from), 0.);
      return builder_->CreateFCmpONE(value, zero);
    } else {
      llvm::Constant* zero = llvm::ConstantInt::get(DTypeToLLVMType(from), 0);
      return builder_->CreateICmpNE(value, zero);
    }
  } else if (!from.is_float() && !to.is_float()) {
    return builder_->CreateIntCast(value, target, from.is_int());
  } else if (from.is_float() && to.is_int()) {
    return builder_->CreateFPToSI(value, target);
  } else if (from.is_float() && to.is_uint()) {
    if (to.bits() < 8) {
      value = builder_->CreateFPToUI(value, DTypeToLLVMType(to.with_bits(8)));
      return builder_->CreateIntCast(value, target, false);
    } else {
      return builder_->CreateFPToUI(value, target);
    }
  } else if (from.is_int() && to.is_float()) {
    return builder_->CreateSIToFP(value, target);
  } else if (from.is_uint() && to.is_float()) {
    return builder_->CreateUIToFP(value, target);
  } else {
    ICHECK(from.is_float() && to.is_float());
    return builder_->CreateFPCast(value, target);
  }
}
```

And this undefined behavior may cause some other problems, like program crashes:

![image](https://user-images.githubusercontent.com/25731241/134774421-7b37a89c-1460-467a-911c-448dcdd8a602.png)


