### PR TITLE
[TIR] add loop partition hint pragma

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1339,6 +1339,12 @@ constexpr const char* hand_threaded = "hand_threaded";
  *       if (mask & 2) the write region should be detected.
  */
 constexpr const char* script_parsing_detect_access = "tir.script_parsing_detect_access";
+
+/*!
+ * \brief Mark that the loop should be partitioned.
+ */
+constexpr const char* pragma_loop_partition_hint = "pragma_loop_partition_hint";
+
 /*!
  * \brief Check if attr_key is a pragma key extension
  * \param attr_key The attr key to be compared

--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -138,7 +138,7 @@ class CandidateSelector final : public StmtExprVisitor {
         return;
       }
     } else if (op->attr_key == attr::pragma_loop_partition_hint) {
-      const VarNode* var;
+      const VarNode* var = nullptr;
       if (op->node->IsInstance<VarNode>()) {
         var = op->node.as<VarNode>();
       } else if (op->node->IsInstance<IterVarNode>()) {

--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -98,7 +98,13 @@ class CandidateSelector final : public StmtExprVisitor {
   void VisitStmt_(const ForNode* op) final {
     // partition const loop when sets partition_const_loop_
     if (!is_const_int(op->min) || !is_const_int(op->extent) || partition_const_loop_) {
+      // always treat var with hint to be partitioned
       const VarNode* var = op->loop_var.get();
+      if (partition_hint_vars.count(var)) {
+        candidates.insert(GetRef<Stmt>(op));
+        StmtExprVisitor::VisitStmt_(op);
+        return;
+      }
       record_.insert({var, false});
       StmtExprVisitor::VisitStmt_(op);
       if (record_.at(var) && !no_split_) {
@@ -117,6 +123,12 @@ class CandidateSelector final : public StmtExprVisitor {
       Var var = iv->var;
       runtime::ThreadScope scope = runtime::ThreadScope::Create(iv->thread_tag);
       if ((scope.rank == 0) && (!is_const_int(op->value) || partition_const_loop_)) {
+        // always treat var with hint to be partitioned
+        if (partition_hint_vars.count(var.get())) {
+          candidates.insert(GetRef<Stmt>(op));
+          StmtExprVisitor::VisitStmt_(op);
+          return;
+        }
         record_.insert({var.get(), false});
         StmtExprVisitor::VisitStmt_(op);
         if (record_.at(var.get()) && !no_split_) {
@@ -125,6 +137,15 @@ class CandidateSelector final : public StmtExprVisitor {
         record_.erase(var.get());
         return;
       }
+    } else if (op->attr_key == attr::pragma_loop_partition_hint) {
+      const VarNode* var;
+      if (op->node->IsInstance<VarNode>()) {
+        var = op->node.as<VarNode>();
+      } else if (op->node->IsInstance<IterVarNode>()) {
+        var = op->node.as<IterVarNode>()->var.get();
+      }
+      ICHECK(var);
+      partition_hint_vars.insert(var);
     }
     StmtExprVisitor::VisitStmt_(op);
   }
@@ -162,6 +183,7 @@ class CandidateSelector final : public StmtExprVisitor {
   }
 
   std::unordered_set<Stmt, ObjectPtrHash, ObjectPtrEqual> candidates;
+  std::unordered_set<const VarNode*> partition_hint_vars;
 
  private:
   bool in_likely_{false};
@@ -170,15 +192,28 @@ class CandidateSelector final : public StmtExprVisitor {
   std::unordered_map<const VarNode*, VarIsUsed> record_;
 };
 
+// Finder try best to find partitions for hinted vars
+#define DEFINE_PARTITION_FINDER_VISIT_CMP_OP(OpNodeT) \
+  void VisitExpr_(const OpNodeT* op) final {          \
+    if (has_partition_hint_) {                        \
+      DeduceCondition(GetRef<PrimExpr>(op));          \
+      return;                                         \
+    }                                                 \
+    StmtExprVisitor::VisitExpr_(op);                  \
+  }
+
 // Populate partitions data structure, i.e., for a specific variable,
-// find an interval in which each condition
-// (currently, "likely" conditions) has fixed true or false value
+// find an interval in which each condition has fixed true or false value
 class PartitionFinder : public StmtExprVisitor {
  public:
   explicit PartitionFinder(Var current_var,
                            const std::unordered_map<const VarNode*, IntSet>& hint_map,
-                           const std::unordered_map<const VarNode*, IntSet>& relax_map)
-      : current_var_(current_var), hint_map_(hint_map), relax_map_(relax_map) {
+                           const std::unordered_map<const VarNode*, IntSet>& relax_map,
+                           bool has_partition_hint)
+      : current_var_(current_var),
+        has_partition_hint_(has_partition_hint),
+        hint_map_(hint_map),
+        relax_map_(relax_map) {
     for (const auto& kv : hint_map) {
       out_vars_.insert(kv.first);
     }
@@ -218,33 +253,43 @@ class PartitionFinder : public StmtExprVisitor {
 
   void VisitExpr_(const CallNode* op) final {
     if (op->op.same_as(builtin::likely())) {
-      PrimExpr cond = op->args[0];
-      if (UsesVar(cond, [this](const VarNode* var) { return var == current_var_.get(); })) {
-        // For cond, find out the interval, if exists, in which we can prove that cond is
-        // true. Also find the interval, if exists, in which we can prove that cond is
-        // false.
-        IntSet interval = DeduceBound(current_var_, cond, hint_map_, relax_map_);
-        if (!interval.IsNothing()) {
-          // cond is true within interval
-          partitions[{cond, true}] = interval;
-        }
-        PrimExpr inverse_cond = InverseCond(cond);
-        if (inverse_cond.defined()) {
-          IntSet interval = DeduceBound(current_var_, inverse_cond, hint_map_, relax_map_);
-          if (!interval.IsNothing()) {
-            // cond is false within interval
-            partitions[{cond, false}] = interval;
-          }
-        }
-      }
+      DeduceCondition(op->args[0]);
     } else {
       StmtExprVisitor::VisitExpr_(op);
     }
   }
 
+  DEFINE_PARTITION_FINDER_VISIT_CMP_OP(GENode);
+  DEFINE_PARTITION_FINDER_VISIT_CMP_OP(GTNode);
+  DEFINE_PARTITION_FINDER_VISIT_CMP_OP(LENode);
+  DEFINE_PARTITION_FINDER_VISIT_CMP_OP(LTNode);
+  DEFINE_PARTITION_FINDER_VISIT_CMP_OP(EQNode);
+  DEFINE_PARTITION_FINDER_VISIT_CMP_OP(NENode);
+
   Partition partitions;
 
  private:
+  void DeduceCondition(const PrimExpr& cond) {
+    // For cond, find out the interval, if exists, in which we can prove that cond is
+    // true. Also find the interval, if exists, in which we can prove that cond is
+    // false.
+    if (UsesVar(cond, [this](const VarNode* var) { return var == current_var_.get(); })) {
+      IntSet interval = DeduceBound(current_var_, cond, hint_map_, relax_map_);
+      if (!interval.IsNothing()) {
+        // cond is true within interval
+        partitions[{cond, true}] = interval;
+      }
+      PrimExpr inverse_cond = InverseCond(cond);
+      if (inverse_cond.defined()) {
+        IntSet interval = DeduceBound(current_var_, inverse_cond, hint_map_, relax_map_);
+        if (!interval.IsNothing()) {
+          // cond is false within interval
+          partitions[{cond, false}] = interval;
+        }
+      }
+    }
+  }
+
   PrimExpr InverseCond(const PrimExpr& cond) {
     PrimExpr inverse_cond;
     if (const LTNode* op = cond.as<LTNode>()) {
@@ -270,6 +315,7 @@ class PartitionFinder : public StmtExprVisitor {
   }
 
   Var current_var_;
+  bool has_partition_hint_;
   std::unordered_set<const VarNode*> out_vars_;
   std::unordered_map<const VarNode*, IntSet> hint_map_;
   std::unordered_map<const VarNode*, IntSet> relax_map_;
@@ -352,6 +398,9 @@ class LoopPartitioner : public StmtMutator {
   }
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
+    if (op->attr_key == attr::pragma_loop_partition_hint) {
+      return VisitStmt(op->body);
+    }
     if (op->attr_key != attr::thread_extent) {
       return StmtMutator::VisitStmt_(op);
     }
@@ -472,7 +521,8 @@ Stmt LoopPartitioner::TryPartition(const Stmt& stmt, Var var, PrimExpr min, Prim
   // include hint of var.
   hint_map_.insert({var.get(), IntSet::Interval(min, max)});
 
-  PartitionFinder finder(var, hint_map_, relax_map_);
+  bool has_partition_hint_ = selector.partition_hint_vars.count(var.get());
+  PartitionFinder finder(var, hint_map_, relax_map_, has_partition_hint_);
   finder(body);
 
   hint_map_.erase(var.get());


### PR DESCRIPTION
Currently `LoopPartition` pass will try to partition loops assiociated with condition in likely tag, it would be great if developers can take control of which loop to partition, no-matter whether the condition to eliminate is "likely" tagged or not.

The PR add a pragma attr key `loop_partition_hint`, which can be tagged explicitly in schedule phase. The loop partition pass will consider all arith conditions for hinted loop var.

Below are two examples of how explicit controlled loop partition benefits, the target is on Ubuntu20.08 i7-7700, with llvm version 11.0 :

- For max pooling with padding inlined, which create conditional buffer accesses
    ```python
    data = te.placeholder([1, 128, 56, 56], name="x")
    out = topi.nn.pool2d(data, kernel=[5, 5], stride=[1, 1], padding=[2, 2, 2, 2], pool_type="max", dilation=[1, 1], layout="NCHW")
    pad = out.op.input_tensors[0]
    x = tvm.nd.array(np.random.randint(0, 64, [1, 128, 56, 56]).astype("float32"))

    def test(do_partition):
        s = te.create_schedule([out.op])
        s[pad].compute_inline()
        n, c, h, w = s[out].op.axis
        if do_partition:
            s[out].pragma(h, "loop_partition_hint")
            s[out].pragma(w, "loop_partition_hint")

        with tvm.ir.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True}}):
            f = tvm.build(s, [data, out], "llvm")
        y = tvm.nd.array(np.zeros([1, 128, 56, 56]).astype("float32"))
        f(x, y)
        result = y.asnumpy()
        print(f.get_source("asm"))
        evaluator = f.time_evaluator(f.entry_name, tvm.cpu(), number=1000)
        print("partition=%s: %.3f millisecs" % (do_partition, evaluator(x, y).mean * 1000))
        return result

    r1 = test(do_partition=False)
    r2 = test(do_partition=True)
    testing.assert_allclose(r1, r2, rtol=1e-5)
    ```
    The performance I get:
    - no loop partition: 3.708 millisecs
    - with loop partition: 0.975 millisecs
    

- For tiled matmul following TVM tensor expression tutorial, but with shape not divided by tiling factor. The tir split do not create a likely condition for it now.
    ```python
   M, N, K = 1025, 1025, 1025
   dtype = "float32"
   dev = tvm.cpu()
   a = tvm.nd.array(np.random.rand(M, K).astype(dtype), dev)
   b = tvm.nd.array(np.random.rand(K, N).astype(dtype), dev)
   k = te.reduce_axis((0, K), "k")
   A = te.placeholder((M, K), name="A")
   B = te.placeholder((K, N), name="B")
   C = te.compute((M, N), lambda x, y: te.sum(A[x, k] * B[k, y], axis=k), name="C")
   f = te.create_prim_func([A, B, C])
   s = tvm.tir.Schedule(f)

   def evaluate_operation(s, target, optimization):
       with tvm.ir.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True}}):
           print(tvm.lower(s.mod["main"], [], simple_mode=True))
           func = tvm.build(s.mod["main"], [], target=target, name="mmult")
           assert func

       c = tvm.nd.array(np.zeros((M, N), dtype=dtype), dev)
       func(a, b, c)
       evaluator = func.time_evaluator(func.entry_name, dev, number=10)
       mean_time = evaluator(a, b, c).mean
       print("%s: %f" % (optimization, mean_time))

   # no opt
   evaluate_operation(s, target="llvm", optimization="none")

   # tiling and vectorize
   x, y, k = s.get_loops(s.get_block("C"))
   xo, xi = s.split(x, factors=[None, 32])
   yo, yi = s.split(y, factors=[None, 32])
   ko, ki = s.split(k, factors=[None, 4])
   s.reorder(xo, yo, ko, ki, xi, yi)
   s.vectorize(yi)
   evaluate_operation(s, target="llvm", optimization="blocking")

   # loop partition
   def pragma(s, rv, key):
       sref = s.get_sref(rv)
       loop = sref.stmt
       new_loop = tvm.tir.For(loop.loop_var, loop.min, loop.extent, loop.kind, loop.body, annotations={key: 1})
       s.state.replace(sref, new_loop)
   pragma(s, xo, "pragma_loop_partition_hint")
   pragma(s, yo, "pragma_loop_partition_hint")
   evaluate_operation(s, target="llvm",  optimization="loop_partition")
   ```
   The performance I get:
    - no opt: 1.374402
    - with tiling + vectorize:  0.843930
    - with tiling + vectorize + loop partition: 0.272183


