### PR TITLE
[Bugfix] Add nullptr checking for `AttrStmt` with `coproc_uop_scope` attr key

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -941,7 +941,9 @@ void CodeGenCPU::VisitStmt_(const AssertStmtNode* op) {
 
 void CodeGenCPU::VisitStmt_(const AttrStmtNode* op) {
   if (op->attr_key == tir::attr::coproc_uop_scope) {
-    this->CreateStaticInit(op->value.as<StringImmNode>()->value, op->body);
+    const StringImmNode* value = op->value.as<StringImmNode>();
+    ICHECK(value != nullptr);
+    this->CreateStaticInit(value->value, op->body);
   } else if (op->attr_key == tir::attr::compute_scope) {
     this->CreateComputeScope(op);
   } else if (tir::attr::IsPragmaKey(op->attr_key)) {

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -440,9 +440,11 @@ void CodeGenCPU::CreateComputeScope(const AttrStmtNode* op) {
   // $xxx_compute_ functions are not global. They should be marked as static (via InternalLinkage)
   // to call them correctly on MIPS platform (CALL16 issue)
   // Linkage ld Error: CALL16 reloc at 0x290 not against global symbol
+  const StringImmNode* value = op->value.as<StringImmNode>();
+  ICHECK(value != nullptr);
   llvm::Function* fcompute = llvm::Function::Create(
       ftype, llvm::Function::InternalLinkage,
-      op->value.as<StringImmNode>()->value.operator llvm::StringRef(), module_.get());
+      value->value.operator llvm::StringRef(), module_.get());
   BasicBlock* compute_call_end = CheckCallSuccess(builder_->CreateCall(fcompute, arg_values));
   // setup compute function.
   std::unordered_map<const VarNode*, llvm::Value*> new_vmap;

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -442,9 +442,9 @@ void CodeGenCPU::CreateComputeScope(const AttrStmtNode* op) {
   // Linkage ld Error: CALL16 reloc at 0x290 not against global symbol
   const StringImmNode* value = op->value.as<StringImmNode>();
   ICHECK(value != nullptr);
-  llvm::Function* fcompute = llvm::Function::Create(
-      ftype, llvm::Function::InternalLinkage,
-      value->value.operator llvm::StringRef(), module_.get());
+  llvm::Function* fcompute =
+      llvm::Function::Create(ftype, llvm::Function::InternalLinkage,
+                             value->value.operator llvm::StringRef(), module_.get());
   BasicBlock* compute_call_end = CheckCallSuccess(builder_->CreateCall(fcompute, arg_values));
   // setup compute function.
   std::unordered_map<const VarNode*, llvm::Value*> new_vmap;


### PR DESCRIPTION
## Bug Description

I found there will be a segfault if we try to pass other types of parameters(except String) to `tir.AttrStmt` when `attr_key` is equal to `coproc_uop_scope`.

Here is the code to trigger the segmentation fault error:

```python
# (tvm-build) ➜ cat test_coproc_uop_scope.py
import tvm
from tvm import ir, tir

a = tir.Var("a", "int32")
b = tir.Var("b", "handle")
iter_var = tir.IterVar(ir.Range(0,1 ), a, 1)
buffer = tir.buffer.decl_buffer((1,))
buffer_map = {b: buffer}
store = tir.Store(buffer.data, tir.const(1), tir.const(1))
attr_stmt = tir.AttrStmt(iter_var, "coproc_uop_scope", tir.const(1), store)
f = tir.PrimFunc({a, b}, body=attr_stmt, buffer_map=buffer_map)
mod = tvm.lower(f)
tvm.build(mod)
```

```shell
(tvm-build) ➜ python3 test_coproc_uop_scope.py
[1]    28685 segmentation fault (core dumped)  python3 test_coproc_uop_scope.py
```

## Bug Analysis

The bug located in [src/target/llvm/codegen_cpu.cc](https://github.com/apache/tvm/blob/main/src/target/llvm/codegen_cpu.cc#L944). It assumes the value is a valid pointer after casting, but actually, it can be invalid. And we can find this function will check whether the value is a valid pointer for other `attr_key`, such as `tir::attr::pragma_import_llvm`. So to prevent this crash happen, I add a check after casting the `value` to `StringImmNode` to verify its validity.

```c++
void CodeGenCPU::VisitStmt_(const AttrStmtNode* op) {
  if (op->attr_key == tir::attr::coproc_uop_scope) {
    this->CreateStaticInit(op->value.as<StringImmNode>()->value, op->body);
  } 
  // ...
    } else if (op->attr_key == tir::attr::pragma_import_llvm) {
      const StringImmNode* value = op->value.as<StringImmNode>();
      ICHECK(value != nullptr);
      this->HandleImport(value->value);
      this->VisitStmt(op->body);
    }
    // ...
}
```
