### PR TITLE
[CI] Split Integration tests out of first phase of pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,8 +305,8 @@ stage('Unit Test') {
         init_git()
         unpack_lib('cpu', tvm_multilib_tsim)
         timeout(time: max_time, unit: 'MINUTES') {
-          sh "${docker_run} ${ci_i386} ./tests/scripts/task_ci_setup.sh"
-          sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
           junit "build/pytest-results/*.xml"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,6 @@ stage('Build') {
         timeout(time: max_time, unit: 'MINUTES') {
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_fsim.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh"
           // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
@@ -295,6 +294,19 @@ stage('Unit Test') {
           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_sphinx_precheck.sh"
           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh"
           sh "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh"
+          junit "build/pytest-results/*.xml"
+        }
+      }
+    }
+  },
+  'python3: CPU': {
+    node('CPU') {
+      ws(per_exec_ws("tvm/ut-python-cpu")) {
+        init_git()
+        unpack_lib('cpu', tvm_multilib_tsim)
+        timeout(time: max_time, unit: 'MINUTES') {
+          sh "${docker_run} ${ci_i386} ./tests/scripts/task_ci_setup.sh"
+          sh "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration.sh"
           junit "build/pytest-results/*.xml"
         }
       }


### PR DESCRIPTION
I took a look at the time taken by each stage in the Jenkins pipeline and what comprises the 6 hour CI build time. CPU Integration tests took `60` minutes of the `100` minutes of `Build: CPU`. By adding `python3: CPU` with just those Integration tests, it lines up with `python3: GPU` and `python3: i386` which both take a similar amount of time and takes roughly 60 minutes off the overall run time.

Numbers copied from sample successful run (final time approx: 358 minutes):
|Phase|ID                           |Job   |Minutes                                      |Start|
|-----|-----------------------------|------|---------------------------------------------|-----|
|0    |0                            |Sanity|3                                            |0    |
|1    |0                            |BUILD: arm|2                                            |3    |
|1    |1                            |BUILD: i386|33                                           |3    |
|1    |2                            |BUILD: CPU|100                                          |3    |
|1    |3                            |BUILD: GPU|25                                           |3    |
|1    |4                            |BUILD: QEMU|6                                            |3    |
|1    |5                            |BUILD: WASM|2                                            |3    |
|2    |0                            |java: GPU|1                                            |103  |
|2    |1                            |python3: GPU|66                                           |103  |
|2    |2                            |python3: arm|22                                           |103  |
|2    |3                            |python3: i386|70                                           |103  |
|3    |0                            |docs: GPU|3                                            |173  |
|3    |1                            |frontend: CPU|40                                           |173  |
|3    |2                            |frontend: GPU|185                                          |173  |
|3    |3                            |topi: GPU|110                                          |173  |
|     |                             |      |                                             |     |

Numbers predicted after change (final time approx: 293 minutes):
|Phase|ID                           |Job   |Minutes                                      |Start|
|-----|-----------------------------|------|---------------------------------------------|-----|
|0    |0                            |Sanity|3                                            |0    |
|1    |0                            |BUILD: arm|2                                            |3    |
|1    |1                            |BUILD: i386|33                                           |3    |
|1    |2                            |BUILD: CPU|35                                           |3    |
|1    |3                            |BUILD: GPU|25                                           |3    |
|1    |4                            |BUILD: QEMU|6                                            |3    |
|1    |5                            |BUILD: WASM|2                                            |3    |
|2    |0                            |java: GPU|1                                            |38   |
|2    |1                            |python3: GPU|66                                           |38   |
|2    |2                            |python3: arm|22                                           |38   |
|2    |3                            |python3: i386|70                                           |38   |
|2    |4                            |python3: CPU|60                                           |38   |
|3    |0                            |docs: GPU|3                                            |108  |
|3    |1                            |frontend: CPU|40                                           |108  |
|3    |2                            |frontend: GPU|185                                          |108  |
|3    |3                            |topi: GPU|110                                          |108  |
