### PR TITLE
[Torch] Support returning quantized weights and bias for BYOC use cases

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3770,7 +3770,6 @@ def from_pytorch(
     if custom_convert_map:
         converter.update_convert_map(custom_convert_map)
 
-
     op_names = get_all_op_names(graph)
     converter.report_missing_conversion(op_names)
 
@@ -3794,9 +3793,17 @@ def from_pytorch(
     # For quantized models
     quantized_ops = set(["aten::quantize_per_tensor", "quantized::linear_dynamic"])
     if len(quantized_ops.intersection(set(op_names))) > 0:
-        weight_quant_params = qnn_torch.get_weight_quant_params(script_module)
+        weight_quant_params = qnn_torch.get_weight_quant_params(
+            script_module, packed_param_map.values()
+        )
         input_scales_for_bias = qnn_torch.add_input_quant_params_to_op_inputs(graph)
-        qnn_torch.add_quant_params_to_outputs(outputs, packed_param_map, weight_quant_params, input_scales_for_bias)
+        qnn_torch.add_quant_params_to_outputs(
+            outputs,
+            packed_param_map,
+            weight_quant_params,
+            input_scales_for_bias,
+            return_int8_weight,
+        )
         qnn_torch.add_quant_params(tvm_params, weight_quant_params)
         converter.update_convert_map(qnn_torch.convert_map)
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3747,7 +3747,13 @@ def from_pytorch(
         Use this option when you want to run the AnnotateSpans pass on the imported module.
 
     return_int8_weight : bool
-        TODO
+        Return quantized weights and bias, rather than float ones. PyTorch stores quantized weights
+        in a custom format, so we cannot directly access 8 bit weights as Numpy arrays. We use
+        a PyTorch function to unpack quantized weights into float32 arrays and quantization parameters.
+        By default, we return float32 weights and rely on the QNN lowering and the Relay constant folding pass
+        to quantize weights at compile time. In BYOC use cases, however, we cannot apply the constant folding pass
+        on a QNN graph. If return_int8_weight is True, we quantize weights in the frontend using a function that
+        is equivalent to qnn.op.quantize(...) operating on Numpy arrays.
 
     Returns
     -------

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3749,11 +3749,12 @@ def from_pytorch(
     return_int8_weight : bool
         Return quantized weights and bias, rather than float ones. PyTorch stores quantized weights
         in a custom format, so we cannot directly access 8 bit weights as Numpy arrays. We use
-        a PyTorch function to unpack quantized weights into float32 arrays and quantization parameters.
-        By default, we return float32 weights and rely on the QNN lowering and the Relay constant folding pass
-        to quantize weights at compile time. In BYOC use cases, however, we cannot apply the constant folding pass
-        on a QNN graph. If return_int8_weight is True, we quantize weights in the frontend using a function that
-        is equivalent to qnn.op.quantize(...) operating on Numpy arrays.
+        a PyTorch function to unpack quantized weights into float32 arrays and quantization
+        parameters. By default, we return float32 weights and rely on the QNN lowering and the
+        Relay constant folding pass to quantize weights at compile time. In BYOC use cases, however,
+        we cannot apply the constant folding pass on a QNN graph. If return_int8_weight is True,
+        we quantize weights in the frontend using a function that is equivalent to
+        qnn.op.quantize(...) operating on Numpy arrays.
 
     Returns
     -------

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3713,7 +3713,7 @@ def from_pytorch(
     custom_convert_map=None,
     default_dtype="float32",
     use_parser_friendly_name=False,
-    return_int8_weight=False,
+    keep_quantized_weight=False,
 ):
     """Load PyTorch model in the form of a scripted PyTorch model and convert into relay.
     The companion parameters will be handled automatically.
@@ -3746,13 +3746,13 @@ def from_pytorch(
         so a variable name like "dense.weight" cannot be parsed correctly.
         Use this option when you want to run the AnnotateSpans pass on the imported module.
 
-    return_int8_weight : bool
+    keep_quantized_weight : bool
         Return quantized weights and bias, rather than float ones. PyTorch stores quantized weights
         in a custom format, so we cannot directly access 8 bit weights as Numpy arrays. We use
         a PyTorch function to unpack quantized weights into float32 arrays and quantization
         parameters. By default, we return float32 weights and rely on the QNN lowering and the
         Relay constant folding pass to quantize weights at compile time. In BYOC use cases, however,
-        we cannot apply the constant folding pass on a QNN graph. If return_int8_weight is True,
+        we cannot apply the constant folding pass on a QNN graph. If keep_quantized_weight is True,
         we quantize weights in the frontend using a function that is equivalent to
         qnn.op.quantize(...) operating on Numpy arrays.
 
@@ -3809,7 +3809,7 @@ def from_pytorch(
             packed_param_map,
             weight_quant_params,
             input_scales_for_bias,
-            return_int8_weight,
+            keep_quantized_weight,
         )
         qnn_torch.add_quant_params(tvm_params, weight_quant_params)
         converter.update_convert_map(qnn_torch.convert_map)

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -140,8 +140,8 @@ def quantize_numpy(weight, scale, zero_point, out_dtype_np):
     iinfo = np.iinfo(out_dtype_np)
     clip_min = iinfo.min
     clip_max = iinfo.max
-    if len(scale.shape) > 0 and len(weight.shape) == 4:
-        scale = np.reshape(scale, (weight.shape[0], 1, 1, 1))
+    if len(scale.shape) > 0:
+        scale = np.reshape(scale, [weight.shape[0]] + [1] * (len(weight.shape) - 1))
     transformed = zero_point + weight / scale
     return np.clip(np.round(transformed), clip_min, clip_max).astype(out_dtype_np)
 

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -147,7 +147,7 @@ def quantize_numpy(weight, scale, zero_point, out_dtype_np):
 
 
 def add_quant_params_to_outputs(
-    outputs, packed_param_map, quant_params, input_scales_for_bias, return_int8_weight=False
+    outputs, packed_param_map, quant_params, input_scales_for_bias, keep_quantized_weight=False
 ):
     """
     Add quant params to outputs so that they can be referenced by other
@@ -160,7 +160,7 @@ def add_quant_params_to_outputs(
         param_prefix = packed_param_name[: -len("._packed_params")]
         qbias = None
 
-        if return_int8_weight:
+        if keep_quantized_weight:
             qparam.weight_var = _expr.var(
                 param_prefix + "_weight", shape=qparam.weight.shape, dtype="int8"
             )

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -648,6 +648,3 @@ def test_return_int8_weight():
         tvm_result_int8_weight = runtime_int8_weight.get_output(0).numpy()
 
         tvm.testing.assert_allclose(tvm_result, tvm_result_int8_weight)
-
-
-test_return_int8_weight()

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -648,6 +648,3 @@ def test_keep_quantized_weight():
         tvm_result_int8_weight = runtime_int8_weight.get_output(0).numpy()
 
         tvm.testing.assert_allclose(tvm_result, tvm_result_int8_weight)
-
-
-test_quantize_dynamic()

--- a/tests/python/frontend/pytorch/qnn_test.py
+++ b/tests/python/frontend/pytorch/qnn_test.py
@@ -40,13 +40,13 @@ def torch_version_check():
     return version.parse(torch.__version__) > version.parse("1.4.0")
 
 
-def get_tvm_runtime(script_module, input_name, ishape, return_int8_weight=False):
+def get_tvm_runtime(script_module, input_name, ishape, keep_quantized_weight=False):
     input_shapes = [(input_name, ishape)]
     mod, params = relay.frontend.from_pytorch(
-        script_module, input_shapes, return_int8_weight=return_int8_weight
+        script_module, input_shapes, keep_quantized_weight=keep_quantized_weight
     )
 
-    if return_int8_weight:
+    if keep_quantized_weight:
         for p in params.values():
             assert p.dtype in ["int8", "int32"]
 
@@ -617,7 +617,7 @@ def test_qnn_mergecomposite():
     run_qnn_mergecomposite(script_module, input_name, inp.shape)
 
 
-def test_return_int8_weight():
+def test_keep_quantized_weight():
     qmodules = []
 
     for per_channel in [False, True]:
@@ -635,16 +635,19 @@ def test_return_int8_weight():
 
         input_name = "input"
 
-        runtime = get_tvm_runtime(script_module, input_name, ishape, return_int8_weight=False)
+        runtime = get_tvm_runtime(script_module, input_name, ishape, keep_quantized_weight=False)
         runtime.set_input(input_name, inp.numpy().copy())
         runtime.run()
         tvm_result = runtime.get_output(0).numpy()
 
         runtime_int8_weight = get_tvm_runtime(
-            script_module, input_name, ishape, return_int8_weight=True
+            script_module, input_name, ishape, keep_quantized_weight=True
         )
         runtime_int8_weight.set_input(input_name, inp.numpy().copy())
         runtime_int8_weight.run()
         tvm_result_int8_weight = runtime_int8_weight.get_output(0).numpy()
 
         tvm.testing.assert_allclose(tvm_result, tvm_result_int8_weight)
+
+
+test_quantize_dynamic()


### PR DESCRIPTION
This addresses the issue discussed in https://discuss.tvm.apache.org/t/qnn-pytorch-byoc-full-integer-qnn-support/11127

PyTorch stores quantized weights in a custom format, so we cannot directly access 8 bit weights as Numpy arrays. We use  a PyTorch function to unpack quantized weights into float32 arrays and quantization parameters. 

By default, we use `qnn.op.quantize(...)` to recover int8 weights in a QNN graph, return float32 weights to users, and rely on the QNN lowering and the Relay constant folding pass to quantize weights at compile time. In BYOC use cases, however,  we cannot apply the constant folding pass on a QNN graph. 

I added a new option to quantize weights in the frontend using a function that is equivalent to `qnn.op.quantize(...)` operating on Numpy arrays. In hindsight, we should've chosen this way from the beginning. The old behavior is kept as the default for backward compatibility. 

cc @comaniac 