### PR TITLE
[TEST] Fix flaky NMS test by making sure scores are unique

### DIFF
--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1963,8 +1963,9 @@ def test_forward_nms():
         boxes = torch.rand(num_boxes, box_len, dtype=torch.float) * 0.5
         boxes[:, 2] += boxes[:, 0]
         boxes[:, 3] += boxes[:, 1]
-        scores = torch.from_numpy(np.random.uniform(-1, 1, size=(num_boxes,)).astype(np.float32))
-        return boxes, scores
+        scores = np.linspace(0, 1, num=num_boxes).astype("float32")
+        np.random.shuffle(scores)
+        return boxes, torch.from_numpy(scores)
 
     targets = ["llvm", "cuda"]
 


### PR DESCRIPTION
Closes https://github.com/apache/tvm/issues/6689

The cause of flaky ness was the tie in scores. The solution is simply to make sure scores are unique, following the same approach in https://github.com/apache/tvm/pull/8335 that fixed the flaky TF NMS test. 

I ran the test 800 times and no error occurred.

@comaniac @junrushao1994 

