### PR TITLE
[CI] Fix Google Mock differences between Ubuntu 18.04 and 16.04

### DIFF
--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -26,6 +26,13 @@ apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev libssl-dev libopenblas-dev g++ sudo \
         apt-transport-https graphviz pkg-config curl
 
-
-cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
-cd /usr/src/gmock && cmake CMakeLists.txt && make && cp *.a /usr/lib
+if [[ -d /usr/src/googletest ]]; then
+  # Single package source (Ubuntu 18.04)
+  # googletest is installed via libgtest-dev
+  cd /usr/src/googletest && cmake CMakeLists.txt && make && cp -v {googlemock,googlemock/gtest}/*.a /usr/lib
+else
+  # Split source package (Ubuntu 16.04)
+  # libgtest-dev and google-mock
+  cd /usr/src/gtest && cmake CMakeLists.txt && make && cp -v *.a /usr/lib
+  cd /usr/src/gmock && cmake CMakeLists.txt && make && cp -v *.a /usr/lib
+fi


### PR DESCRIPTION
I thought I got all of these, but turns out I didn't, there's another weirdism in how Google Mock and Google Test are packaged on Ubuntu where the `cmake` command fails due to directories outside of the build root.

Double checked logs on Ubuntu 18.04 and Ubuntu 16.04 for this after enabling verbose copying:
```shell
$ ./docker/build.sh ci_cpu --net=host
...
'googlemock/libgmock.a' -> '/usr/lib/libgmock.a'
'googlemock/libgmock_main.a' -> '/usr/lib/libgmock_main.a'
'googlemock/gtest/libgtest.a' -> '/usr/lib/libgtest.a'
'googlemock/gtest/libgtest_main.a' -> '/usr/lib/libgtest_main.a'

$ ./docker/build.sh ci_i386 --net=host
...
'libgtest.a' -> '/usr/lib/libgtest.a'
'libgtest_main.a' -> '/usr/lib/libgtest_main.a'
...
'libgmock.a' -> '/usr/lib/libgmock.a'
'libgmock_main.a' -> '/usr/lib/libgmock_main.a'
```