### PR TITLE
[OpenCL] Remove redundant visit statement in CodeGen.

### DIFF
--- a/src/target/source/codegen_opencl.cc
+++ b/src/target/source/codegen_opencl.cc
@@ -59,8 +59,6 @@ class InferTextureAccess : public StmtExprVisitor {
       var_access_map_[op->args[0].as<VarNode>()] |= kReadAccess;
     } else if (op->op.same_as(builtin::texture2d_store())) {
       var_access_map_[op->args[0].as<VarNode>()] |= kWriteAccess;
-    } else {
-      StmtExprVisitor::VisitExpr_(op);
     }
     StmtExprVisitor::VisitExpr_(op);
   }


### PR DESCRIPTION
Fixes regression with some models on which compilation
doesn't terminate.


This was introduced by https://github.com/apache/tvm/commit/c6f62aafc91e2600ed7772597fd4238c924c2a1b

I have run tests/python/unittest/test_target_texture_codegen_opencl.py test on the fix, but open to other suggestions about testing.
