### PR TITLE
Fix building with llvm 13

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -861,7 +861,7 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
                                                                 : llvm::Type::getVoidTy(*ctx_);
     llvm::Function* f = GetIntrinsicDecl(id, return_type, arg_type);
     ICHECK(f) << "Cannot find intrinsic declaration, possible type mismatch: "
-#if TVM_LLVM_VERSION <= 130
+#if TVM_LLVM_VERSION < 130
               << llvm::Intrinsic::getName(id, {});
 #else
               << llvm::Intrinsic::getName(id, return_type, {});


### PR DESCRIPTION
`std::string getName(ID Id, ArrayRef<Type *> Tys);` was removed in https://github.com/llvm/llvm-project/commit/bb8ce25e88218be60d2a4ea9c9b0b721809eff27 and is contained in `llvmorg-13.0.0-rc1` and onward.
