### PR TITLE
[Hotfix][Testing] Wait for RPCServer to be established

### DIFF
--- a/python/tvm/meta_schedule/testing.py
+++ b/python/tvm/meta_schedule/testing.py
@@ -60,6 +60,7 @@ class LocalRPC:
             port=9190,
             port_end=12345,
         )
+        time.sleep(0.5)
         self.tracker_host = self.tracker.host
         self.tracker_port = self.tracker.port
         self.tracker_key = tracker_key


### PR DESCRIPTION
In unittests, we establish a "faked" RPC tracker/runner locally, but we forgot to wait until the server process is set up, which causes flakiness on mainline.

https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/1815/pipeline

Thanks @vinx13 for reporting! CC @zxybazh 
