### PR TITLE
Enable for qnn operations for const folding transformation

### DIFF
--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -30,6 +30,7 @@
 #include <tvm/relay/feature.h>
 #include <tvm/relay/interpreter.h>
 #include <tvm/relay/pattern_functor.h>
+#include <tvm/relay/qnn/transform.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/container/map.h>
 #include <tvm/runtime/device_api.h>
@@ -903,7 +904,7 @@ IRModule Prepare(IRModule mod, Device device, Target target) {
   tec::DeviceMap device_map;
 
   // Run minimal transforms on module to establish invariants needed by interpreter.
-  transform::Sequential seq({transform::SimplifyInference(),
+  transform::Sequential seq({transform::SimplifyInference(), qnn::transform::Legalize(),
                              // FuseOps will mark wrapped calls to prim-ops with the 'Primitive'
                              // attribute.
                              transform::FuseOps(/*fuse_opt_level=*/0), transform::ToANormalForm(),


### PR DESCRIPTION
Current the sequence `cons -> qnn.quantize` is not treated like a constant subgraph. Suggestion is to allow FoldConstant pass to replace this pattern with single int8 constant tensor.

**Reason**: Some BYOC runtimes may has a limitation to have a weight like a constant tensor. Pointed FoldConstant pass limitation may breaks BYOC runtimes applicability.