### PR TITLE
[CMSIS-NN] Initial operator support for Add

### DIFF
--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -79,9 +79,9 @@ def pattern_table():
             and dequantize_call.args[0].checked_type.dtype == "int8"
         )
 
-    def mul_pattern():
-        """Matcher for QNN multiplication"""
-        return is_op("qnn.mul")(
+    def binary_op_pattern(op):
+        """Matches QNN binary operation"""
+        return is_op(f"qnn.{op}")(
             wildcard(),
             wildcard(),
             is_constant(),
@@ -92,7 +92,7 @@ def pattern_table():
             is_constant(),
         )
 
-    def check_quantized_mul(extract):
+    def check_quantized_binary_op(extract):
         """Check if multiply is supported by CMSIS-NN."""
         return (
             extract.args[0].checked_type.dtype == "int8"
@@ -101,5 +101,14 @@ def pattern_table():
 
     return [
         ("cmsisnn.quantized_softmax", softmax_pattern(), check_quantized_softmax),
-        ("cmsisnn.quantized_mul", mul_pattern(), check_quantized_mul),
+        (
+            "cmsisnn.quantized_mul",
+            binary_op_pattern("mul"),
+            check_quantized_binary_op,
+        ),
+        (
+            "cmsisnn.quantized_add",
+            binary_op_pattern("add"),
+            check_quantized_binary_op,
+        ),
     ]


### PR DESCRIPTION
This patch aims to add initial support for the `Add` operator to CMSIS NN, which was actually similar enough to the `Mul` operator that it shares quite a bit of code - exciting times.
