### PR TITLE
[BugFix][Meta Schedule] Fix meta_schedule.testing.local_rpc

### DIFF
--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -236,7 +236,7 @@ class RPCRunner(PyRunner):
         f_alloc_argument: Union[T_ALLOC_ARGUMENT, str, None] = None,
         f_run_evaluator: Union[T_RUN_EVALUATOR, str, None] = None,
         f_cleanup: Union[T_CLEANUP, str, None] = None,
-        max_connections: Optional[int] = None,
+        max_workers: int = 1,
         initializer: Optional[Callable[[], None]] = None,
     ) -> None:
         """Constructor
@@ -261,8 +261,8 @@ class RPCRunner(PyRunner):
             The function name to run the evaluator or the function itself.
         f_cleanup: Union[T_CLEANUP, str, None]
             The function name to cleanup the session or the function itself.
-        max_connections: Optional[int]
-            The maximum number of connections.
+        max_workers: int = 1
+            The maximum number of connections. Defaults to 1.
         initializer: Optional[Callable[[], None]]
             The initializer function.
         """
@@ -276,15 +276,8 @@ class RPCRunner(PyRunner):
         self.f_alloc_argument = f_alloc_argument
         self.f_run_evaluator = f_run_evaluator
         self.f_cleanup = f_cleanup
-
-        num_servers = self.rpc_config.count_num_servers(allow_missing=False)
-        if max_connections is None:
-            max_connections = num_servers
-        else:
-            max_connections = min(max_connections, num_servers)
-
         self.pool = PopenPoolExecutor(
-            max_workers=max_connections,
+            max_workers=max_workers,
             timeout=rpc_config.session_timeout_sec,
             initializer=initializer,
         )

--- a/python/tvm/meta_schedule/testing.py
+++ b/python/tvm/meta_schedule/testing.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Testing utilities in meta schedule"""
-import time
-
 from tvm.rpc.tracker import Tracker
 from tvm.rpc.server import Server
 
@@ -49,7 +47,6 @@ class LocalRPC:
             port=9190,
             port_end=12345,
         )
-        time.sleep(0.5)
         self.server = Server(
             host="0.0.0.0",
             is_proxy=False,
@@ -60,7 +57,6 @@ class LocalRPC:
             port=9190,
             port_end=12345,
         )
-        time.sleep(0.5)
         self.tracker_host = self.tracker.host
         self.tracker_port = self.tracker.port
         self.tracker_key = tracker_key


### PR DESCRIPTION
According to the suggestion from @tqchen, this PR disallows automatic worker discovery in RPCRunner, in order to accommodate the case where several tuning processes may share the same RPCTracker in the real world. In this case, automatic discovery is problematic because it could only find the workers that are idle. This addresses the flakiness in meta schedule unittests by the way because now the runner assumes `max_workers=1`