### PR TITLE
Fix end to end benchmark with rpc devices

### DIFF
--- a/python/tvm/contrib/graph_executor.py
+++ b/python/tvm/contrib/graph_executor.py
@@ -401,7 +401,7 @@ class GraphModule(object):
                 repeat=repeat,
                 number=number,
                 min_repeat_ms=min_repeat_ms,
-            )(device.device_type, device.device_id, *args)
+            )(device.device_type % rpc_base.RPC_SESS_MASK, device.device_id, *args)
         if kwargs:
             self.set_input(**kwargs)
         return self.module.time_evaluator(

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -598,7 +598,7 @@ class VirtualMachine(object):
                 repeat=repeat,
                 number=number,
                 min_repeat_ms=min_repeat_ms,
-            )(func_name, device.device_type, device.device_id, *packed_args)
+            )(func_name, device.device_type % RPC_SESS_MASK, device.device_id, *packed_args)
         if args or kwargs:
             self.set_input(func_name, *args, **kwargs)
         return self.module.time_evaluator(

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -234,7 +234,8 @@ void NDArray::CopyFromTo(const DLTensor* from, DLTensor* to, TVMStreamHandle str
   ICHECK(from->device.device_type == to->device.device_type || from->device.device_type == kDLCPU ||
          to->device.device_type == kDLCPU || from->device.device_type == kDLCUDAHost ||
          to->device.device_type == kDLCUDAHost)
-      << "Can not copy across different device types directly";
+      << "Can not copy across different device types directly. From device type: "
+      << from->device.device_type << " to device type: " << to->device.device_type;
 
   // Use the device that is *not* a cpu device to get the correct device
   // api manager.

--- a/tests/python/relay/test_backend_graph_executor.py
+++ b/tests/python/relay/test_backend_graph_executor.py
@@ -361,13 +361,13 @@ def test_benchmark_end_to_end(dev, target):
     assert len(result.results) == 2
 
 
-@tvm.testing.requires_llvm
+@tvm.testing.requires_cuda
 def test_benchmark_end_to_end_rpc():
     server = rpc.Server("127.0.0.1")
     remote = rpc.connect(server.host, server.port)
 
     mod, params = mlp.get_workload(1)
-    lib = relay.build(mod, target="llvm", params=params)
+    lib = relay.build(mod, target="cuda", params=params)
 
     temp = utils.tempdir()
     path = temp.relpath("library.so")
@@ -375,7 +375,7 @@ def test_benchmark_end_to_end_rpc():
     remote.upload(path)
     rlib = remote.load_module("library.so")
 
-    dev = remote.cpu()
+    dev = remote.device("cuda")
     exe = graph_executor.create(lib.get_graph_json(), rlib, dev)
 
     data = tvm.nd.array(np.random.rand(1, 1, 28, 28).astype("float32"), device=dev)

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -777,11 +777,11 @@ def test_roi_align():
             op_res1 = relay.create_executor("graph", device=dev, target=target).evaluate(func)(
                 np_data, np_rois
             )
-            tvm.testing.assert_allclose(op_res1.numpy(), ref_res, rtol=1e-4)
+            tvm.testing.assert_allclose(op_res1.numpy(), ref_res, atol=1e-6, rtol=1e-3)
             op_res2 = relay.create_executor("debug", device=dev, target=target).evaluate(func)(
                 np_data, np_rois
             )
-            tvm.testing.assert_allclose(op_res2.numpy(), ref_res, rtol=1e-4)
+            tvm.testing.assert_allclose(op_res2.numpy(), ref_res, atol=1e-6, rtol=1e-3)
 
     def verify_roi_align_nchw(
         data_shape, rois_shape, pooled_size, spatial_scale, sample_ratio, mode

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -936,13 +936,13 @@ def test_benchmark_end_to_end(target, dev):
     assert result.mean > 0
 
 
-@tvm.testing.requires_llvm
+@tvm.testing.requires_cuda
 def test_benchmark_end_to_end_rpc():
     server = rpc.Server("127.0.0.1")
     remote = rpc.connect(server.host, server.port)
 
     mod, params = mlp.get_workload(1)
-    lib = vm.compile(mod, target="llvm", params=params)
+    lib = vm.compile(mod, target="cuda", params=params)
 
     temp = utils.tempdir()
     path = temp.relpath("vm_library.so")
@@ -950,10 +950,12 @@ def test_benchmark_end_to_end_rpc():
     remote.upload(path)
     rlib = remote.load_module("vm_library.so")
 
-    exe = runtime.vm.VirtualMachine(rlib, remote.cpu())
-    data = tvm.nd.array(np.random.rand(1, 1, 28, 28).astype("float32"), device=remote.cpu())
+    exe = runtime.vm.VirtualMachine(rlib, remote.device("cuda"))
+    data = tvm.nd.array(
+        np.random.rand(1, 1, 28, 28).astype("float32"), device=remote.device("cuda")
+    )
     result = exe.benchmark(
-        remote.cpu(), data=data, func_name="main", repeat=2, number=1, end_to_end=True
+        remote.device("cuda"), data=data, func_name="main", repeat=2, number=1, end_to_end=True
     )
     assert result.mean > 0
 


### PR DESCRIPTION
I forgot to convert remote devices to local devices in the `benchmark` rpc call. This PR fixes the issue and also adds a test to catch it. I've also improved the error message for the failure.