### PR TITLE
[Contrib][ONNX] Handle removal of onnx.utils.polish_model

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -22,6 +22,10 @@ set -o pipefail
 
 # We need to fix the onnx version because changing versions tends to break tests
 # TODO(mbrookhart): periodically update
+
+# onnx 1.9 removed onnx optimizer from the main repo (see
+# https://github.com/onnx/onnx/pull/2834).  When updating the CI image
+# to onnx>=1.9, onnxoptimizer should also be installed.
 pip3 install \
     onnx==1.8.1 \
     onnxruntime==1.7.0

--- a/tutorials/frontend/from_onnx.py
+++ b/tutorials/frontend/from_onnx.py
@@ -27,7 +27,7 @@ A quick solution is to install protobuf compiler, and
 
 .. code-block:: bash
 
-    pip install onnx --user
+    pip install --user onnx onnxoptimizer
 
 or please refer to official site.
 https://github.com/onnx/onnx

--- a/tutorials/get_started/tvmc_command_line_driver.py
+++ b/tutorials/get_started/tvmc_command_line_driver.py
@@ -104,10 +104,11 @@ capabilities, and set the stage for understanding how TVM works.
 ################################################################################
 # .. note:: Adding ONNX Support to TVM
 #
-#    TVM relies on the ONNX python library being available on your system. You
-#    can install ONNX using the command ``pip3 install --user onnx``. You may
-#    remove the ``--user`` option if you have root access and want to install
-#    ONNX globally.
+#    TVM relies on the ONNX python library being available on your system. You can
+#    install ONNX using the command ``pip3 install --user onnx onnxoptimizer``. You
+#    may remove the ``--user`` option if you have root access and want to install
+#    ONNX globally.  The ``onnxoptimizer`` dependency is optional, and is only used
+#    for ``onnx>=1.9``.
 #
 
 ################################################################################


### PR DESCRIPTION
Onnx 1.9 removed optimizers from the core repository (see discussion
in https://github.com/onnx/onnx/pull/2834), including
onnx.utils.polish_model, breaking RelayToONNXConverter.  This PR add
onnxoptimizer.optimize as a fallback method if onnx.utils.polish_model
is unavailable.

Also updates tutorials/documentation to recommend installing
onnxoptimizer when installing onnx, because the current PyPI version
of onnx is above version 1.9.
