### PR TITLE
[Test] Fix flaky LocalRunner test due to restrictive timeout

### DIFF
--- a/python/tvm/meta_schedule/runner/local_runner.py
+++ b/python/tvm/meta_schedule/runner/local_runner.py
@@ -175,7 +175,7 @@ class LocalRunner(PyRunner):
 
     def __init__(
         self,
-        timeout_sec: float,
+        timeout_sec: float = 30,
         evaluator_config: Optional[EvaluatorConfig] = None,
         cooldown_sec: float = 0.0,
         alloc_repeat: int = 1,

--- a/tests/python/unittest/test_meta_schedule_runner.py
+++ b/tests/python/unittest/test_meta_schedule_runner.py
@@ -507,7 +507,7 @@ def test_meta_schedule_rpc_runner_exception():
 
 
 def test_meta_schedule_local_runner_exception():
-    """Test meta schedule Local Runner time out"""
+    """Test meta schedule Local Runner exception"""
     mod = MatmulModule
     builder = LocalBuilder()
     (builder_result,) = builder.build([BuilderInput(mod, Target("llvm"))])
@@ -541,7 +541,6 @@ def test_meta_schedule_local_runner_exception():
     )
 
     runner = LocalRunner(
-        timeout_sec=1,
         evaluator_config=evaluator_config,
         initializer=initializer,
         f_alloc_argument="meta_schedule.runner.test_exception",


### PR DESCRIPTION
This flakiness introduced by #9153 hasn't been exposed on our CI, but can be reproduced very frequently in my local machine. The root of the issue is that our timeout setting in LocalRunner in this particular unittest is too small (1s). Given it's a LocalRunner which always exist, I increased the timeout to 30s by default.

CC: @shingjan @vinx13 @zxybazh 