### PR TITLE
[Hexagon] Fix compilation errors in Hexagon launcher

### DIFF
--- a/src/runtime/hexagon/launcher/launcher_core.cc
+++ b/src/runtime/hexagon/launcher/launcher_core.cc
@@ -162,8 +162,7 @@ tvm::runtime::Module load_module(const std::string& file_name) {
 }
 
 tvm::runtime::Module create_graph_executor(const std::string& graph_json,
-                                           tvm::runtime::Module graph_module,
-                                           tvm::runtime::Device device) {
+                                           tvm::runtime::Module graph_module, tvm::Device device) {
   std::string launcher_name = "tvm.graph_executor.create";
 
   const tvm::runtime::PackedFunc create_executor = get_runtime_func(launcher_name);

--- a/src/runtime/hexagon/launcher/launcher_core.h
+++ b/src/runtime/hexagon/launcher/launcher_core.h
@@ -87,9 +87,7 @@ struct Model {
   tvm::runtime::Module graph_module;
   std::string graph_json;
 
-  static tvm::runtime::Device device() {
-    return tvm::runtime::Device{static_cast<DLDeviceType>(kDLHexagon), 0};
-  }
+  static tvm::Device device() { return tvm::Device{static_cast<DLDeviceType>(kDLHexagon), 0}; }
 
   tvm::runtime::PackedFunc run;
 };
@@ -126,7 +124,6 @@ const tvm::runtime::PackedFunc get_module_func(tvm::runtime::Module module,
                                                const std::string& name);
 
 tvm::runtime::Module create_graph_executor(const std::string& graph_json,
-                                           tvm::runtime::Module graph_module,
-                                           tvm::runtime::Device device);
+                                           tvm::runtime::Module graph_module, tvm::Device device);
 
 #endif  // TVM_RUNTIME_HEXAGON_LAUNCHER_LAUNCHER_CORE_H_


### PR DESCRIPTION
A few instances of `runtime::Device` were missed when `Device` was moved from `tvm::runtime` to `tvm`.
