### PR TITLE
[Relay] Remove unnecessary Optional<IRModule> argument to ToANormalForm and friends

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -165,12 +165,11 @@ TVM_DLL Pass ToANormalForm();
 /*!
  * \brief ToANormalForm but on incomplete graph.
  *
- * \param maybe_mod optional module holding definitions for global vars in \p expr
  * \param expr the graph.
  *
  * \return The transformed program.
  */
-TVM_DLL Expr ToANormalForm(const Optional<IRModule>& maybe_mod, const Expr& expr);
+TVM_DLL Expr ToANormalForm(const Expr& expr);
 
 /*!
  * \brief Turn an expression into continuation passing style(CPS).

--- a/src/relay/transforms/higher_order_gradient.cc
+++ b/src/relay/transforms/higher_order_gradient.cc
@@ -293,7 +293,7 @@ struct ReverseAD : ExprMutator {
           return Call(bpv, {});
         });
         Expr nbp = Function({}, nbp_body, TupleType::Empty(), {});
-        ll->Push(RefWrite(bp, transform::ToANormalForm(mod, nbp)));
+        ll->Push(RefWrite(bp, transform::ToANormalForm(nbp)));
         // TODO(@M.K.): ToANF should be called on rev. Enhance ToANF for that.
         return ret;
       });

--- a/src/relay/transforms/pass_utils.h
+++ b/src/relay/transforms/pass_utils.h
@@ -227,7 +227,7 @@ std::pair<NodeScopeMap, ExprSet> CalcScope(const DependencyGraph& dg);
 Scope LCA(Scope lhs, Scope rhs);
 
 // For basic block normal form.
-Expr ToBasicBlockNormalFormAux(const Optional<IRModule>& maybe_mod, const Expr& e);
+Expr ToBasicBlockNormalFormAux(const Expr& e);
 
 // ToANormalForm for expressions and as a Pass are declared in transform.h
 

--- a/src/relay/transforms/to_basic_block_normal_form.cc
+++ b/src/relay/transforms/to_basic_block_normal_form.cc
@@ -46,7 +46,7 @@ IRModule ToBasicBlockNormalForm(const IRModule& mod) {
     if (const auto* n = it.second.as<FunctionNode>()) {
       if (n->GetAttr<String>(attr::kCompiler).defined()) continue;
       Function func = GetRef<Function>(n);
-      Function ret = Downcast<Function>(ToBasicBlockNormalFormAux(mod, func));
+      Function ret = Downcast<Function>(ToBasicBlockNormalFormAux(func));
       VLOG(1) << "rewritten:" << std::endl
               << PrettyPrint(func) << std::endl
               << "to BasicBlockANF:" << std::endl


### PR DESCRIPTION
 This is a follow up to address Christopher's comment in #8788. The nature of ToANF means we don't need to worry about passing in an IRModule context to recover the result device for a global function.