### PR TITLE
[cpptest] Reset op attributes before registering them

### DIFF
--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -100,14 +100,20 @@ TEST(Relay, BuildModule) {
   if (!reg) {
     LOG(FATAL) << "no _Register";
   }
+  auto reset = tvm::runtime::Registry::Get("ir.OpResetAttr");
+  if (!reset) {
+    LOG(FATAL) << "Reset is not defined.";
+  }
   auto fs = tvm::runtime::Registry::Get("test.strategy");
   if (!fs) {
     LOG(FATAL) << "No test_strategy registered.";
   }
-  auto fgeneric = GenericFunc::Get("test.strategy_generic").set_default(*fs);
+  auto fgeneric = GenericFunc::Get("test.strategy_generic").set_default(*fs, true);
+  (*reset)(add_op, "FTVMStrategy");
   (*reg)("add", "FTVMStrategy", fgeneric, 10);
   Array<Integer> dep;
   dep.push_back(0);
+  (*reset)(add_op, "TShapeDataDependent");
   (*reg)("add", "TShapeDataDependent", dep, 10);
   // build
   auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");

--- a/tests/cpp/relay_transform_sequential_test.cc
+++ b/tests/cpp/relay_transform_sequential_test.cc
@@ -77,11 +77,16 @@ TEST(Relay, Sequential) {
   if (!reg) {
     LOG(FATAL) << "Register is not defined.";
   }
+  auto reset = tvm::runtime::Registry::Get("ir.OpResetAttr");
+  if (!reset) {
+    LOG(FATAL) << "Reset is not defined.";
+  }
   auto fs = tvm::runtime::Registry::Get("test.seq.strategy");
   if (!fs) {
     LOG(FATAL) << "Strategy is not defined.";
   }
-  auto fgeneric = GenericFunc::Get("test.strategy_generic").set_default(*fs);
+  auto fgeneric = GenericFunc::Get("test.strategy_generic").set_default(*fs, true);
+  (*reset)(add_op, "FTVMStrategy");
   (*reg)("add", "FTVMStrategy", fgeneric, 10);
 
   // Run sequential passes.

--- a/tests/cpp/runtime_test.cc
+++ b/tests/cpp/runtime_test.cc
@@ -86,14 +86,20 @@ TEST(Runtime, ZeroCopy) {
   if (!reg) {
     LOG(FATAL) << "no _Register";
   }
+  auto reset = tvm::runtime::Registry::Get("ir.OpResetAttr");
+  if (!reset) {
+    LOG(FATAL) << "Reset is not defined.";
+  }
   auto fs = tvm::runtime::Registry::Get("runtime_test.strategy");
   if (!fs) {
     LOG(FATAL) << "No test_strategy registered.";
   }
-  auto fgeneric = GenericFunc::Get("runtime_test.strategy_generic").set_default(*fs);
+  auto fgeneric = GenericFunc::Get("runtime_test.strategy_generic").set_default(*fs, true);
+  (*reset)(add_op, "FTVMStrategy");
   (*reg)("add", "FTVMStrategy", fgeneric, 10);
   Array<Integer> dep;
   dep.push_back(0);
+  (*reset)(add_op, "TShapeDataDependent");
   (*reg)("add", "TShapeDataDependent", dep, 10);
   // build
   auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");


### PR DESCRIPTION
Prior registration of attribute XYZ can result in an error when trying to register the same attribute again:
```
Check failed: (p.second != plevel) is false: Attribute XYZ of op is already registered with same plevel=10
```

Reset the attributes before registering them.