### PR TITLE
[PyTorch][Frontend] Semantic difference of 'bias_add' between relay and pytorch

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1469,7 +1469,7 @@ class PyTorchOpConverter:
         if isinstance(bias, _expr.Expr):
             bias_ndims = len(self.infer_shape_with_prelude(bias))
             if bias_ndims == 1:
-                return _op.nn.bias_add(mm_out, bias)
+                return _op.nn.bias_add(mm_out, bias, axis=-1)
             mm_dtype = self.infer_type_with_prelude(mm_out).dtype
             return self.add([mm_out, bias], [mm_dtype, input_types[2]])
         return mm_out


### PR DESCRIPTION
Greetings. I encountered a problem when trying translating Pytorch models into relay. `relay.nn.bias_add` has a default `axis=1`, which is inconsistent with [linear](https://pytorch.org/docs/stable/generated/torch.nn.functional.linear.html#torch.nn.functional.linear) in PyTorch, which always adds bias to the last dimension. So it is necessary to explicitly assign `axis=-1` here.

Thanks @spectrometerHBH for helping debug. cc @junrushao1994 