### PR TITLE
[TVMC] Treat invalid FILE arguments

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -20,6 +20,7 @@ Provides support to run compiled networks both locally and remotely.
 import json
 import logging
 from typing import Dict, List, Optional, Union
+from tarfile import ReadError
 
 import numpy as np
 import tvm
@@ -115,7 +116,14 @@ def drive_run(args):
     except IOError as ex:
         raise TVMCException("Error loading inputs file: %s" % ex)
 
-    tvmc_package = TVMCPackage(package_path=args.FILE)
+    try:
+        tvmc_package = TVMCPackage(package_path=args.FILE)
+    except IsADirectoryError:
+        raise TVMCException(f"File {args.FILE} must be an archive, not a directory.")
+    except FileNotFoundError:
+        raise TVMCException(f"File {args.FILE} does not exist.")
+    except ReadError:
+        raise TVMCException(f"Could not read model from archive {args.FILE}!")
 
     result = run_module(
         tvmc_package,


### PR DESCRIPTION
Currently if an invalid FILE argument is passed to 'tvmc run' the user
will catch a traceback because exceptions are not treated, for instance:
$ tvmc run /tmp/nonexistingfile will throw a FileNotFoundError trace.

This commit catches the possible exceptions that can happen when an
invalid FILE argument is used and convert them to better messages for
the user so the invalid FILE can be easily spotted.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

