### PR TITLE
Add dilation to MaxPool2DAttrs Rust bindings

### DIFF
--- a/rust/tvm/src/ir/relay/attrs/nn.rs
+++ b/rust/tvm/src/ir/relay/attrs/nn.rs
@@ -94,6 +94,7 @@ pub struct MaxPool2DAttrsNode {
     pub pool_size: Array<IndexExpr>,
     pub strides: Array<IndexExpr>,
     pub padding: Array<IndexExpr>,
+    pub dilation: Array<IndexExpr>,
     pub layout: TString,
     pub ceil_mode: bool,
 }


### PR DESCRIPTION
Gets Rust bindings back in sync. Dilation must have been added to MaxPool2DAttrs on the C++ side, without it being added on the Rust side. There should probably be tests to catch this!

@jroesch 
