### PR TITLE
[UnitTest] Removed vulkan from CI run of task_python_topi.sh

### DIFF
--- a/tests/scripts/task_python_topi.sh
+++ b/tests/scripts/task_python_topi.sh
@@ -21,6 +21,8 @@ set -u
 
 source tests/scripts/setup-pytest-env.sh
 
+export TVM_TEST_TARGETS="llvm; llvm -device=arm_cpu; cuda; cuda -model=unknown -libs=cudnn"
+
 # to avoid CI thread throttling.
 export TVM_BIND_THREADS=0
 export OMP_NUM_THREADS=1


### PR DESCRIPTION
Vulkan unit tests were enabled with https://github.com/apache/tvm/pull/9093, but were only intended to run tests/python/unittest/test_target_codegen_vulkan.py.  Since task_python_topi.sh did not explicitly specify `TVM_TEST_TARGETS`, it defaulted to `tvm.testing.utils.DEFAULT_TEST_TARGETS`, which includes the vulkan runtime.