### PR TITLE
Run full build when no files were changed over main

### DIFF
--- a/tests/scripts/git_change_docs.sh
+++ b/tests/scripts/git_change_docs.sh
@@ -19,6 +19,7 @@
 
 set -eux
 
+FOUND_ONE_FILE=0
 DOCS_DIR=0
 OTHER_DIR=0
 DOC_DIR="docs/"
@@ -26,6 +27,7 @@ DOC_DIR="docs/"
 changed_files=`git diff --no-commit-id --name-only -r origin/main`
 
 for file in $changed_files; do
+    FOUND_ONE_FILE=1
     if grep -q "$DOC_DIR" <<< "$file"; then
         DOCS_DIR=1
     else
@@ -34,9 +36,8 @@ for file in $changed_files; do
     fi
 done
 
-if [ ${OTHER_DIR} -eq 1 ]; then
+if [ ${FOUND_ONE_FILE} -eq 0 -o ${OTHER_DIR} -eq 1 ]; then
     exit 0
 else
     exit 1
 fi
-


### PR DESCRIPTION
Currently our periodic post-merge builds are running tutorials only due to #8673 . Modify script to consider the case when no files were changed as a full rebuild.

cc @mikepapadim @tqchen @junrushao1994 