### PR TITLE
BUG #9216: Don't disable FuseOps pass since required by GraphExecutor

### DIFF
--- a/tutorials/micro/micro_tflite.py
+++ b/tutorials/micro/micro_tflite.py
@@ -206,7 +206,7 @@ BOARD = "qemu_x86"
 # Now, compile the model for the target:
 
 with tvm.transform.PassContext(
-    opt_level=3, config={"tir.disable_vectorize": True}, disabled_pass=["FuseOps", "AlterOpLayout"]
+    opt_level=3, config={"tir.disable_vectorize": True}, disabled_pass=["AlterOpLayout"]
 ):
     module = relay.build(mod, target=TARGET, params=params)
 


### PR DESCRIPTION
This tutorial disabled the FuseOps pass, but before #8788 that was
ignored since FuseOps was applied directly.
