### PR TITLE
[CI] Use correct tag in Docker --cache-from

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -85,7 +85,7 @@ if [[ "$1" == "--cache-from" ]]; then
     shift 1
     cached_image="$1"
     DOCKER_NO_CACHE_ARG=
-    CI_DOCKER_BUILD_EXTRA_PARAMS+=("--cache-from tvm.$CONTAINER_TYPE")
+    CI_DOCKER_BUILD_EXTRA_PARAMS+=("--cache-from tvm.$CONTAINER_TYPE:$DOCKER_IMAGE_TAG")
     CI_DOCKER_BUILD_EXTRA_PARAMS+=("--cache-from $cached_image")
     shift 1
 fi


### PR DESCRIPTION
When I didn't have `:latest` available I saw that my image wasn't being re-used between runs.

