### PR TITLE
[microNPU] Enforce bias when pattern matching conv2d

### DIFF
--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -266,7 +266,7 @@ def qnn_conv2d_pattern() -> tvm.relay.dataflow_pattern.DFPattern:
     ).has_attr({"kernel_layout": "HWIO"})
     bias_add = is_op("nn.bias_add")(qnn_conv2d, is_constant())
     req = is_op("qnn.requantize")(
-        qnn_conv2d | bias_add, is_constant(), is_constant(), is_constant(), is_constant()
+        bias_add, is_constant(), is_constant(), is_constant(), is_constant()
     )
     clip_or_req = req.optional(is_op("clip"))
     return clip_or_req


### PR DESCRIPTION
Currently a conv2d pattern is matched when no bias is present. However, legalization expects a bias to be present, therefore causing an error when this is not the case. For now, enforce a bias when offloading conv2d to the NPU.

cc @ekalda @mbaret @manupa-arm @dchauhan-arm
