### PR TITLE
Bumping up CMSIS-NN version to be in sync with TFLu

### DIFF
--- a/docker/install/ubuntu_install_ethosu_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosu_driver_stack.sh
@@ -24,7 +24,7 @@ fvp_dir="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
 cmake_dir="/opt/arm/cmake"
 ethosu_dir="/opt/arm/ethosu"
 ethosu_driver_ver="21.05"
-cmsis_ver="5.7.0"
+cmsis_ver="5.8.0"
 
 mkdir -p /opt/arm
 


### PR DESCRIPTION
Need to bump up CMSIS version in the docker image to match TFLu.


CC: @Mousius @grant-arm @areusch @leandron 