### PR TITLE
[CI] Pre-build Reference System Dependencies

### DIFF
--- a/docker/install/ubuntu_install_ethosu_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosu_driver_stack.sh
@@ -92,3 +92,13 @@ cd "${ethosu_dir}"
 git clone "https://github.com/ARM-software/CMSIS_5.git" cmsis
 cd cmsis
 git checkout -f tags/${cmsis_ver}
+
+# Build Driver
+mkdir ${ethosu_dir}/core_driver/build && cd ${ethosu_dir}/core_driver/build
+cmake -DCMAKE_TOOLCHAIN_FILE=${ethosu_dir}/core_platform/cmake/toolchain/arm-none-eabi-gcc.cmake -DETHOSU_LOG_SEVERITY=debug -DTARGET_CPU=cortex-m55 ..
+make
+
+# Build NN Library
+mkdir ${ethosu_dir}/cmsis/CMSIS/NN/build/ && cd ${ethosu_dir}/cmsis/CMSIS/NN/build/
+cmake .. -DCMAKE_TOOLCHAIN_FILE=${ethosu_dir}/core_platform/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m55 -DBUILD_CMSIS_NN_FUNCTIONS=YES
+make


### PR DESCRIPTION
Building these dependencies from scratch in each test was taking much longer than really necessary.

Before:
```
$ time python3 -m pytest tests/python/contrib/test_ethosu/test_codegen.py::test_tflite_depthwise_conv2d[strides0-dilation0-SAME-kernel_shape0-relu-ifm_shape0-ethos-u55-256]
real    0m19.982s
user    0m13.255s
sys     0m3.403s
```

After:
```
$ time python3 -m pytest tests/python/contrib/test_ethosu/test_codegen.py::test_tflite_depthwise_conv2d[strides0-dilation0-SAME-kernel_shape0-relu-ifm_shape0-ethos-u55-256]
real    0m10.963s
user    0m5.516s
sys     0m2.232s
```
