### PR TITLE
Cleanup GraphExecutor parameter-passing style between Python and C++.

### DIFF
--- a/python/tvm/contrib/debugger/debug_executor.py
+++ b/python/tvm/contrib/debugger/debug_executor.py
@@ -58,7 +58,7 @@ def create(graph_json_str, libmod, device, dump_root=None):
     assert isinstance(graph_json_str, string_types)
 
     try:
-        dev, num_rpc_dev, device_type_id = graph_executor.get_device(libmod, device)
+        dev, num_rpc_dev, non_rpc_devices = graph_executor.get_device(libmod, device)
         if num_rpc_dev == len(dev):
             fcreate = dev[0]._rpc_sess.get_function("tvm.graph_executor_debug.create")
         else:
@@ -67,7 +67,7 @@ def create(graph_json_str, libmod, device, dump_root=None):
         raise ValueError(
             "Please set '(USE_PROFILER ON)' in " "config.cmake and rebuild TVM to enable debug mode"
         )
-    func_obj = fcreate(graph_json_str, libmod, *device_type_id)
+    func_obj = fcreate(graph_json_str, libmod, *non_rpc_devices)
     return GraphModuleDebug(func_obj, dev, graph_json_str, dump_root)
 
 

--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -208,10 +208,9 @@ def create_local_graph_executor(graph_json_str, mod, device):
     tvm.contrib.GraphExecutor :
          A local graph executor instance that executes on the remote device.
     """
-    device_type_id = [device.device_type, device.device_id]
     fcreate = get_global_func("tvm.graph_executor.create")
     return graph_executor.GraphModule(
-        fcreate(graph_json_str, mod, lookup_remote_linked_param, *device_type_id)
+        fcreate(graph_json_str, mod, lookup_remote_linked_param, device)
     )
 
 
@@ -237,10 +236,9 @@ def create_local_debug_executor(graph_json_str, mod, device, dump_root=None):
     tvm.contrib.GraphExecutor :
          A local graph executor instance that executes on the remote device.
     """
-    device_type_id = [device.device_type, device.device_id]
     fcreate = get_global_func("tvm.graph_executor_debug.create")
     return debug_executor.GraphModuleDebug(
-        fcreate(graph_json_str, mod, lookup_remote_linked_param, *device_type_id),
+        fcreate(graph_json_str, mod, lookup_remote_linked_param, device),
         [device],
         graph_json_str,
         dump_root=dump_root,

--- a/python/tvm/relay/backend/executor_factory.py
+++ b/python/tvm/relay/backend/executor_factory.py
@@ -137,7 +137,7 @@ class GraphExecutorFactoryModule(ExecutorFactoryModule):
 
         self.ir_mod = ir_mod
         self.target = target
-        self.module = fcreate(graph_json_str, libmod, libmod_name, *args)
+        self.module = fcreate(graph_json_str, libmod, libmod_name, str(target), *args)
         self.graph_json = graph_json_str
         self.lib = libmod
         self.libmod_name = libmod_name

--- a/src/runtime/graph_executor/cuda_graph/graph_runtime_cuda_graph.cc
+++ b/src/runtime/graph_executor/cuda_graph/graph_runtime_cuda_graph.cc
@@ -128,9 +128,12 @@ TVM_REGISTER_GLOBAL("tvm.graph_executor_cuda_graph.create")
         lookup_linked_param_func = args[2];
         dev_start_arg++;
       }
+      std::vector<DLDevice> devices;
+      for (int i = dev_start_arg; i < args.size(); ++i) {
+        devices.push_back(args[i].operator DLDevice());
+      }
 
-      *rv = GraphExecutorCudaGraphCreate(args[0], args[1], GetAllDevice(args, dev_start_arg),
-                                         lookup_linked_param_func);
+      *rv = GraphExecutorCudaGraphCreate(args[0], args[1], devices, lookup_linked_param_func);
     });
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/graph_executor/debug/graph_executor_debug.cc
+++ b/src/runtime/graph_executor/debug/graph_executor_debug.cc
@@ -412,8 +412,11 @@ TVM_REGISTER_GLOBAL("tvm.graph_executor_debug.create").set_body([](TVMArgs args,
     dev_start_arg++;
   }
 
-  *rv = GraphExecutorDebugCreate(args[0], args[1], GetAllDevice(args, dev_start_arg),
-                                 lookup_linked_param_func);
+  std::vector<DLDevice> devices;
+  for (int i = dev_start_arg; i < args.size(); ++i) {
+    devices.push_back(args[i].operator DLDevice());
+  }
+  *rv = GraphExecutorDebugCreate(args[0], args[1], devices, lookup_linked_param_func);
 });
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/graph_executor/graph_executor_factory.h
+++ b/src/runtime/graph_executor/graph_executor_factory.h
@@ -52,7 +52,7 @@ class TVM_DLL GraphExecutorFactory : public runtime::ModuleNode {
    */
   GraphExecutorFactory(const std::string& graph_json,
                        const std::unordered_map<std::string, tvm::runtime::NDArray>& params,
-                       const std::string& module_name = "default");
+                       const std::string& target_str, const std::string& module_name = "default");
 
   /*!
    * \brief Get member function to front-end
@@ -125,10 +125,16 @@ class TVM_DLL GraphExecutorFactory : public runtime::ModuleNode {
   }
 
  protected:
+  inline bool is_link_params() const {
+    return target_str_.find("-link-params=1") != std::string::npos;
+  }
+
   /*! \brief The execution graph. */
   std::string graph_json_;
   /*! \brief The params. */
   std::unordered_map<std::string, tvm::runtime::NDArray> params_;
+  /*! \brief Target string used to build this artifact */
+  std::string target_str_;
   /*! \brief module name */
   std::string module_name_;
 };


### PR DESCRIPTION
 * Fix GraphExecutor factory instantiation.

This PR leverages DLDevice support in PackedFunc to improve the GraphExecutor parameter-passing style between Python and c++.