### PR TITLE
[Tutorial] Fix VTA vision detection tutorial 'sphinx' style error.

### DIFF
--- a/vta/tutorials/frontend/deploy_detection.py
+++ b/vta/tutorials/frontend/deploy_detection.py
@@ -34,15 +34,15 @@ tensorization in the core) to massage the compute graph for the hardware target.
 #
 # .. code-block:: bash
 #
-# pip3 install "Pillow<7"
+#   pip3 install "Pillow<7"
 #
 # YOLO-V3-tiny Model with Darknet parsing have dependancy with CFFI and CV2 library,
 # we need to install CFFI and CV2 before executing this script.
 #
-# pip3 install "Pillow<7"
+# .. code-block:: bash
 #
-# pip3 install cffi
-# pip3 install opencv-python
+#   pip3 install cffi
+#   pip3 install opencv-python
 #
 # Now return to the python code. Import packages.
 


### PR DESCRIPTION
Issue:
   Some bash code in this tutorial does not get syntax highlighting because of the format errors.

Solution:
   Fix the 'sphinx' 'rst' style error.
