### PR TITLE
Reset sphinx-gallery version to 0.4.0

### DIFF
--- a/docker/install/ubuntu_install_sphinx.sh
+++ b/docker/install/ubuntu_install_sphinx.sh
@@ -29,5 +29,5 @@ pip3 install \
     matplotlib \
     sphinx \
     sphinx_autodoc_annotation \
-    sphinx-gallery==0.4.1 \
+    sphinx-gallery==0.4.0 \
     sphinx_rtd_theme


### PR DESCRIPTION
Seeing ([Jenkins log](https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdaily-docker-image-rebuild/detail/daily-docker-image-rebuild/76/pipeline)):
```
ERROR: Could not find a version that satisfies the requirement sphinx-gallery==0.4.1 (from versions: 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 0.0.10, 0.0.11.post1, 0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 0.5.0, 0.6.0, 0.6.1, 0.6.2, 0.7.0, 0.8.0, 0.8.1, 0.8.2, 0.9.0, 0.10.0)
ERROR: No matching distribution found for sphinx-gallery==0.4.1
```

This was changed in https://github.com/apache/tvm/pull/9115
