### PR TITLE
[Rust][Doc] Re-enable the building and copying of Rust documentation. 

### DIFF
--- a/docs/reference/api/links.rst
+++ b/docs/reference/api/links.rst
@@ -24,3 +24,4 @@ build system.
 * `C++ doyxgen API <doxygen/index.html>`_
 * `Typescript typedoc API <typedoc/index.html>`_
 * `Java Javadoc API <javadoc/index.html>`_
+* `Rust Rustdoc API <rust/index.html>`_

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -76,7 +76,7 @@ cd ..
 # Rust doc
 cd rust
 # Temp disable rust doc build
-# cargo doc --workspace --no-deps
+cargo doc --workspace --no-deps
 cd ..
 
 # Prepare the doc dir
@@ -86,7 +86,7 @@ rm -f _docs/.buildinfo
 mkdir -p _docs/reference/api
 mv docs/doxygen/html _docs/reference/api/doxygen
 mv jvm/core/target/site/apidocs _docs/reference/api/javadoc
-# mv rust/target/doc _docs/api/rust
+mv rust/target/doc _docs/api/rust
 mv web/dist/docs _docs/reference/api/typedoc
 
 echo "Start creating the docs tarball.."


### PR DESCRIPTION
Closes #9217, #7743, #7744. This turns back on the documentation for the Rust bindings. 