### PR TITLE
[Profiler] Add significant VM instructions to profiling report

### DIFF
--- a/include/tvm/runtime/profiling.h
+++ b/include/tvm/runtime/profiling.h
@@ -452,11 +452,23 @@ class CountNode : public Object {
   TVM_DECLARE_FINAL_OBJECT_INFO(CountNode, Object);
 };
 
-/*! \brief String representation of an array or NDArray shapes
+/*! \brief String representation of an array of NDArray shapes
  *  \param shapes Array of NDArrays to get the shapes of.
  *  \return A textual representation of the shapes. For example: `float32[2], int64[1, 2]`.
  */
 String ShapeString(const std::vector<NDArray>& shapes);
+/*! \brief String representation of shape encoded as an NDArray
+ *  \param shape NDArray containing the shape.
+ *  \param dtype The dtype of the shape.
+ *  \return A textual representation of the shape. For example: `float32[2]`.
+ */
+String ShapeString(NDArray shape, DLDataType dtype);
+/*! \brief String representation of a shape encoded as a vector
+ *  \param shape Shape as a vector of integers.
+ *  \param dtype The dtype of the shape.
+ *  \return A textual representation of the shape. For example: `float32[2]`.
+ */
+String ShapeString(const std::vector<int64_t>& shape, DLDataType dtype);
 
 }  // namespace profiling
 }  // namespace runtime

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -198,14 +198,14 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param reg The register to read from.
    * \return The read object.
    */
-  inline ObjectRef ReadRegister(RegName reg) const;
+  ObjectRef ReadRegister(RegName reg) const;
 
   /*!
    * \brief Read a VM register and cast it to int32_t
    * \param reg The register to read from.
    * \return The read scalar.
    */
-  inline int64_t LoadScalarInt(RegName reg) const;
+  int64_t LoadScalarInt(RegName reg) const;
 
   /*!
    * \brief Invoke a VM function.
@@ -267,6 +267,22 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param offset Starting offset of the arguments in `args`.
    */
   void SetInput(std::string name, TVMArgs args, int offset);
+
+  /*!
+   * \brief Internal hook for profiling the start of an op.
+   *
+   * This hook is only called on certain ops that are likely to take a
+   * significant amount of runtime (normally because they alloc or transfer to
+   * device).
+   *
+   * \param instr Instruction that will be executed after this hook fires
+   */
+  virtual void OpStartHook(Instruction instr);
+
+  /*!
+   * \brief Internal hook for profiling the end of an op.
+   */
+  virtual void OpStopHook();
 
  protected:
   /*! \brief The virtual machine's packed function table. */

--- a/src/runtime/vm/profiler/vm.h
+++ b/src/runtime/vm/profiler/vm.h
@@ -51,6 +51,8 @@ class VirtualMachineDebug : public VirtualMachine {
  private:
   void InvokePacked(Index packed_index, const PackedFunc& func, Index arg_count, Index output_size,
                     const std::vector<ObjectRef>& args) final;
+  void OpStartHook(Instruction instr) final;
+  void OpStopHook() final;
 
   std::unordered_map<Index, std::string> packed_index_map_;
   dmlc::optional<profiling::Profiler> prof_;

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -113,6 +113,9 @@ std::vector<int64_t> ToShape(NDArray shape_tensor) {
   return shape;
 }
 
+void VirtualMachine::OpStartHook(Instruction instr) {}
+void VirtualMachine::OpStopHook() {}
+
 PackedFunc VirtualMachine::GetFunction(const std::string& name,
                                        const ObjectPtr<Object>& sptr_to_self) {
   if (name == "invoke") {
@@ -400,11 +403,9 @@ inline void VirtualMachine::WriteRegister(Index r, const ObjectRef& val) {
   frames_.back().register_file[r] = val;
 }
 
-inline ObjectRef VirtualMachine::ReadRegister(Index r) const {
-  return frames_.back().register_file[r];
-}
+ObjectRef VirtualMachine::ReadRegister(Index r) const { return frames_.back().register_file[r]; }
 
-inline int64_t VirtualMachine::LoadScalarInt(Index r) const {
+int64_t VirtualMachine::LoadScalarInt(Index r) const {
   int64_t result = 0;
   const auto& obj = ReadRegister(r);
   NDArray array = Downcast<NDArray>(CopyTo(obj, {kDLCPU, 0}));
@@ -458,6 +459,11 @@ void VirtualMachine::RunLoop() {
         throw std::runtime_error("VM encountered fatal error");
       }
       case Opcode::LoadConst: {
+        bool is_not_cached = const_pool_.size() <= static_cast<size_t>(instr.const_index) ||
+                             !const_pool_[instr.const_index].defined();
+        if (is_not_cached) {
+          OpStartHook(instr);
+        }
         auto constant_obj = exec_->constants[instr.const_index];
         // We cache the allocated object in the constant pool. To measure, the
         // first iteration will set the pool up. The other iterations will
@@ -471,6 +477,9 @@ void VirtualMachine::RunLoop() {
           const_pool_[instr.const_index] = CopyTo(constant_obj, dev);
         }
         WriteRegister(instr.dst, const_pool_[instr.const_index]);
+        if (is_not_cached) {
+          OpStopHook();
+        }
         pc_++;
         goto main_loop;
       }
@@ -560,6 +569,7 @@ void VirtualMachine::RunLoop() {
         goto main_loop;
       }
       case Opcode::AllocTensor: {
+        OpStartHook(instr);
         auto shape = std::vector<int64_t>(instr.alloc_tensor.ndim);
 
         for (uint32_t i = 0; i < instr.alloc_tensor.ndim; ++i) {
@@ -572,10 +582,12 @@ void VirtualMachine::RunLoop() {
         auto obj = storage->AllocNDArray(offset, shape, instr.alloc_tensor.dtype);
 
         WriteRegister(instr.dst, obj);
+        OpStopHook();
         pc_++;
         goto main_loop;
       }
       case Opcode::AllocTensorReg: {
+        OpStartHook(instr);
         Device cpu_dev = GetDevice(static_cast<Index>(kDLCPU));
         auto shape_obj = ReadRegister(instr.alloc_tensor_reg.shape_register);
         NDArray shape_tensor = Downcast<NDArray>(CopyTo(shape_obj, cpu_dev));
@@ -586,6 +598,7 @@ void VirtualMachine::RunLoop() {
         auto obj = storage->AllocNDArray(offset, shape, instr.alloc_tensor_reg.dtype);
 
         WriteRegister(instr.dst, obj);
+        OpStopHook();
         pc_++;
         goto main_loop;
       }
@@ -609,6 +622,7 @@ void VirtualMachine::RunLoop() {
         goto main_loop;
       }
       case Opcode::AllocStorage: {
+        OpStartHook(instr);
         auto size = LoadScalarInt(instr.alloc_storage.allocation_size);
         auto alignment = instr.alloc_storage.alignment;
 
@@ -625,6 +639,7 @@ void VirtualMachine::RunLoop() {
         storage_obj->buffer = alloc->Alloc(size, alignment, instr.alloc_storage.dtype_hint);
         Storage storage(storage_obj);
         WriteRegister(instr.dst, storage);
+        OpStopHook();
         pc_++;
         goto main_loop;
       }
@@ -656,6 +671,7 @@ void VirtualMachine::RunLoop() {
         }
       }
       case Opcode::ReshapeTensor: {
+        OpStartHook(instr);
         Device cpu_dev = GetDevice(static_cast<Index>(kDLCPU));
         auto tensor_obj = ReadRegister(instr.reshape_tensor.tensor);
         NDArray tensor_arr = Downcast<NDArray>(tensor_obj);
@@ -671,10 +687,12 @@ void VirtualMachine::RunLoop() {
         // Reshape the input tensor
         auto out_tensor = tensor_arr.CreateView(shape, tensor_arr->dtype);
         WriteRegister(instr.dst, out_tensor);
+        OpStopHook();
         pc_++;
         goto main_loop;
       }
       case Opcode::DeviceCopy: {
+        OpStartHook(instr);
         auto tensor_src = ReadRegister(instr.src);
         NDArray src_data = Downcast<NDArray>(tensor_src);
         Device src_dev = src_data->device;
@@ -686,6 +704,7 @@ void VirtualMachine::RunLoop() {
 
         NDArray dst_data = src_data.CopyTo(dst_dev);
         WriteRegister(instr.dst, dst_data);
+        OpStopHook();
         pc_++;
         goto main_loop;
       }


### PR DESCRIPTION
Added a hooks to the VM execution loop to record runtime of certain instructions with significant runtimes. Now the profiling report will include data allocation and transfer times.

@masahi @leandron @jwfromm 