### PR TITLE
[Build] Rename build module helper func

### DIFF
--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -255,7 +255,7 @@ def build(
         target_input_mod, target_host
     )
 
-    rt_mod_host = _driver_ffi.finalize_module(target_input_mod, target_host)
+    rt_mod_host = _driver_ffi.preprocess_module(target_input_mod, target_host)
 
     target_input_mod, target_host = Target.check_and_update_host_consist(
         target_input_mod, target_host

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -425,7 +425,8 @@ std::pair<IRModule, IRModule> SplitMixedModule(IRModule mod_mixed, const Target&
   return {host_mod, device_mod};
 }
 
-runtime::Module FinalizeModule(const Map<Target, IRModule>& inputs_arg, const Target& host_target) {
+runtime::Module PreProcessModuleForBuild(const Map<Target, IRModule>& inputs_arg,
+                                         const Target& host_target) {
   std::vector<runtime::Module> device_modules;
   Map<Target, IRModule> inputs = inputs_arg;
   Target target_host = host_target;
@@ -479,9 +480,9 @@ runtime::Module FinalizeModule(const Map<Target, IRModule>& inputs_arg, const Ta
   return complete_mod;
 }
 
-TVM_REGISTER_GLOBAL("driver.finalize_module")
+TVM_REGISTER_GLOBAL("driver.preprocess_module")
     .set_body_typed([](const Map<Target, IRModule>& inputs_arg, Target host_target) {
-      return FinalizeModule(inputs_arg, host_target);
+      return PreProcessModuleForBuild(inputs_arg, host_target);
     });
 
 runtime::Module build(const Map<Target, IRModule>& inputs_arg, const Target& target_host_arg) {


### PR DESCRIPTION
Followup of #9103 
Renaming `finalize_module` to avoid inconsistencies. 

@jroesch @mbs-octoml @electriclilies 