### PR TITLE
[microNPU] Fix typo in depthwise to allow int8 weights

### DIFF
--- a/src/relay/op/contrib/ethosu/depthwise.cc
+++ b/src/relay/op/contrib/ethosu/depthwise.cc
@@ -126,7 +126,7 @@ bool EthosuDepthwiseConv2DRel(const Array<Type>& types, int num_inputs, const At
   ICHECK(ifm->dtype == DataType::UInt(8) || ifm->dtype == DataType::Int(8))
       << "Expected ethosu_depthwise_conv2d type(uint8) or type(int8) for ifm but was "
       << ifm->dtype;
-  ICHECK(weight->dtype == DataType::UInt(8) || ifm->dtype == DataType::Int(8))
+  ICHECK(weight->dtype == DataType::UInt(8) || weight->dtype == DataType::Int(8))
       << "Expected ethosu_depthwise_conv2d type(uint8) or type(int8) for weight but was "
       << weight->dtype;
   ICHECK(scale_bias->dtype == DataType::UInt(8))

--- a/tests/python/contrib/test_ethosu/test_replace_depthwise_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_depthwise_conv2d.py
@@ -20,9 +20,10 @@ import pytest
 pytest.importorskip("ethosu.vela")
 
 import tvm
-from tvm import relay
+from tvm import relay, TVMError
 from tvm.relay.testing import run_opt_pass
 from tvm.relay.backend.contrib.ethosu.tir.compiler import lower_to_tir
+
 from .infra import make_ethosu_depthwise_conv2d, get_convolutional_args
 
 
@@ -243,3 +244,29 @@ def test_depthwise_conv2d_single(trial):
         "NONE",
     ]
     assert data[0] == answer, data[0]
+
+
+def test_incompatible_weight_data_type():
+    ifm = relay.var("ifm", shape=(1, 8, 8, 3), dtype="int8")
+
+    depthwise = make_ethosu_depthwise_conv2d(
+        ifm=ifm,
+        channels=3,
+        kernel_shape=(3, 2),
+        padding=(0, 0),
+        strides=(1, 1),
+        dilation=(1, 1),
+        activation="NONE",
+        ifm_layout="NHWC",
+        ofm_layout="NHWC",
+        weight_dtype="int16",
+    )
+
+    func = relay.Function(relay.analysis.free_vars(depthwise), depthwise)
+    mod = tvm.IRModule.from_expr(func)
+
+    with pytest.raises(TVMError) as err:
+        mod = relay.transform.InferType()(mod)
+
+    message = "Expected ethosu_depthwise_conv2d type(uint8) or type(int8) for weight but was int16"
+    assert message in str(err.value)


### PR DESCRIPTION
Small typo means that ifm datatype is checked when it should be weight.

cc @ekalda 
