### PR TITLE
[unittests] Skip import of tvm.micro if micro-TVM was not enabled

### DIFF
--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -35,6 +35,7 @@ from tvm.target import Target
 from tvm.topi.utils import get_const_tuple
 from tvm.topi.testing import conv2d_nchw_python
 
+pytest.importorskip("tvm.micro.testing")
 from tvm.micro.testing import check_tune_log
 
 BUILD = True

--- a/tests/python/unittest/test_micro_project_api.py
+++ b/tests/python/unittest/test_micro_project_api.py
@@ -25,6 +25,8 @@ from unittest import mock
 import pytest
 
 import tvm
+
+pytest.importorskip("tvm.micro")
 from tvm.micro import project_api
 
 


### PR DESCRIPTION
The import itself will cause the test to fail if micro-TVM support was not built.