### PR TITLE
[Keras] Support return_sequences in LSTM

### DIFF
--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -417,6 +417,17 @@ class TestKeras:
         keras_model = keras.models.Model(data, z)
         verify_keras_frontend(keras_model)
 
+    def test_forward_lstm(self, keras):
+        data = keras.layers.Input(shape=(10, 32))
+        rnn_funcs = [
+            keras.layers.LSTM(16),
+            keras.layers.LSTM(16, return_sequences=True),
+        ]
+        for rnn_func in rnn_funcs:
+            x = rnn_func(data)
+            keras_model = keras.models.Model(data, x)
+            verify_keras_frontend(keras_model, need_transpose=False)
+
     def test_forward_rnn(self, keras):
         data = keras.layers.Input(shape=(1, 32))
         rnn_funcs = [
@@ -613,6 +624,7 @@ if __name__ == "__main__":
         sut.test_forward_multi_inputs(keras=k)
         sut.test_forward_multi_outputs(keras=k)
         sut.test_forward_reuse_layers(keras=k)
+        sut.test_forward_lstm(keras=k)
         sut.test_forward_rnn(keras=k)
         sut.test_forward_vgg16(keras=k)
         sut.test_forward_vgg16(keras=k, layout="NHWC")


### PR DESCRIPTION
This PR adds support for `return_sequences` bool param for [Keras LSTM layer](https://keras.io/api/layers/recurrent_layers/lstm/).
By default the param is False - LSTM returns only the last h output
If `return_sequences is True` then ALL h outputs should be returned. The outputs should be concatenated along axis 1.

I also added dedicated test for LSTM. Input shape increased to test `return_sequences is True` case.

`return_sequences = True` is needed if your model has two or more LSTM layers. By Default LSTM layer takes 3D tensor and returns 2D tensor. To connect two LSTM layers together the first layers should return 3D tensor. It can be achieved if `return_sequences param` set to `True`.

[Understanding LSTM Networks](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)

Related discussion https://discuss.tvm.apache.org/t/keras-lstm-return-sequences-parameter-not-supported/11239
