### PR TITLE
[Support] Add libinfo into the runtime build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,11 +473,11 @@ add_library(tvm_objs OBJECT ${COMPILER_SRCS})
 add_library(tvm_runtime_objs OBJECT ${RUNTIME_SRCS})
 add_library(tvm_libinfo_objs OBJECT ${LIBINFO_FILE})
 
-add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs> $<TARGET_OBJECTS:tvm_runtime_objs> $<TARGET_OBJECTS:tvm_libinfo_objs>)
+add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs> $<TARGET_OBJECTS:tvm_runtime_objs>)
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_NO_UNDEFINED_SYMBOLS}")
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
 if(BUILD_STATIC_RUNTIME)
-  add_library(tvm_runtime STATIC $<TARGET_OBJECTS:tvm_runtime_objs>)
+  add_library(tvm_runtime STATIC $<TARGET_OBJECTS:tvm_runtime_objs> $<TARGET_OBJECTS:tvm_libinfo_objs>)
   set(NOTICE_MULTILINE
     "You have build static version of the TVM runtime library. Make "
     "sure to use --whole-archive when linking it into your project.")
@@ -485,7 +485,7 @@ if(BUILD_STATIC_RUNTIME)
   add_custom_command(TARGET tvm_runtime POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --yellow --bold ${NOTICE})
 else()
-  add_library(tvm_runtime SHARED $<TARGET_OBJECTS:tvm_runtime_objs>)
+  add_library(tvm_runtime SHARED $<TARGET_OBJECTS:tvm_runtime_objs> $<TARGET_OBJECTS:tvm_libinfo_objs>)
   set_property(TARGET tvm_runtime APPEND PROPERTY LINK_OPTIONS "${TVM_NO_UNDEFINED_SYMBOLS}")
 endif()
 set_property(TARGET tvm_runtime APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,7 +473,7 @@ add_library(tvm_objs OBJECT ${COMPILER_SRCS})
 add_library(tvm_runtime_objs OBJECT ${RUNTIME_SRCS})
 add_library(tvm_libinfo_objs OBJECT ${LIBINFO_FILE})
 
-add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs> $<TARGET_OBJECTS:tvm_runtime_objs>)
+add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs> $<TARGET_OBJECTS:tvm_runtime_objs> $<TARGET_OBJECTS:tvm_libinfo_objs>)
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_NO_UNDEFINED_SYMBOLS}")
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
 if(BUILD_STATIC_RUNTIME)

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -23,7 +23,8 @@ import traceback
 
 # top-level alias
 # tvm._ffi
-from ._ffi.base import TVMError, __version__
+from ._ffi.base import TVMError, __version__, _RUNTIME_ONLY
+
 from ._ffi.runtime_ctypes import DataTypeCode, DataType
 from ._ffi import register_object, register_func, register_extension, get_global_func
 
@@ -68,7 +69,7 @@ from . import support
 # Contrib initializers
 from .contrib import rocm as _rocm, nvcc as _nvcc, sdaccel as _sdaccel
 
-if support.libinfo().get("USE_MICRO", "OFF") == "ON":
+if not _RUNTIME_ONLY and support.libinfo().get("USE_MICRO", "OFF") == "ON":
     from . import micro
 
 # NOTE: This file should be python2 compatible so we can

--- a/python/tvm/micro/__init__.py
+++ b/python/tvm/micro/__init__.py
@@ -15,12 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 """MicroTVM module for bare-metal backends"""
+from tvm._ffi.base import _RUNTIME_ONLY
 
 from .build import autotvm_build_func
 from .build import AutoTvmModuleLoader
 from .build import get_standalone_crt_dir
 from .build import get_microtvm_template_projects
-from .model_library_format import export_model_library_format, UnsupportedInModelLibraryFormatError
+
+if not _RUNTIME_ONLY:
+    from .model_library_format import (
+        export_model_library_format,
+        UnsupportedInModelLibraryFormatError,
+    )
 from .project import generate_project, GeneratedProject, TemplateProject
 from .session import (
     create_local_graph_executor,

--- a/python/tvm/micro/__init__.py
+++ b/python/tvm/micro/__init__.py
@@ -15,13 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """MicroTVM module for bare-metal backends"""
-from tvm._ffi.base import _RUNTIME_ONLY
-
 from .build import autotvm_build_func
 from .build import AutoTvmModuleLoader
 from .build import get_standalone_crt_dir
 from .build import get_microtvm_template_projects
 
+from .model_library_format import (
+    export_model_library_format,
+    UnsupportedInModelLibraryFormatError,
+)
 from .project import generate_project, GeneratedProject, TemplateProject
 from .session import (
     create_local_graph_executor,
@@ -30,9 +32,3 @@ from .session import (
     SessionTerminatedError,
 )
 from .transport import TransportLogger
-
-if not _RUNTIME_ONLY:
-    from .model_library_format import (
-        export_model_library_format,
-        UnsupportedInModelLibraryFormatError,
-    )

--- a/python/tvm/micro/__init__.py
+++ b/python/tvm/micro/__init__.py
@@ -22,11 +22,6 @@ from .build import AutoTvmModuleLoader
 from .build import get_standalone_crt_dir
 from .build import get_microtvm_template_projects
 
-if not _RUNTIME_ONLY:
-    from .model_library_format import (
-        export_model_library_format,
-        UnsupportedInModelLibraryFormatError,
-    )
 from .project import generate_project, GeneratedProject, TemplateProject
 from .session import (
     create_local_graph_executor,
@@ -35,3 +30,9 @@ from .session import (
     SessionTerminatedError,
 )
 from .transport import TransportLogger
+
+if not _RUNTIME_ONLY:
+    from .model_library_format import (
+        export_model_library_format,
+        UnsupportedInModelLibraryFormatError,
+    )


### PR DESCRIPTION
@junrushao1994 

We ran into some situations where it would be really nice to have lib information with runtime-only builds. Since we always build the runtime when we build the core tvm target, I figured this was a safe switch. What do you think?