### PR TITLE
Change Call with TIRCallAttrs to call_lowered op

### DIFF
--- a/include/tvm/relay/attrs/annotation.h
+++ b/include/tvm/relay/attrs/annotation.h
@@ -116,17 +116,6 @@ struct CompilerAttrs : public tvm::AttrsNode<CompilerAttrs> {
   }
 };
 
-/*!
- * \brief Metadata for calls to TIR functions, useful for program analysis crossing Relay and TIR.
- */
-struct TIRCallAttrs : public tvm::AttrsNode<TIRCallAttrs> {
-  /*! \brief The metadata attached to the call node. */
-  Map<String, ObjectRef> metadata;
-
-  TVM_DECLARE_ATTRS(TIRCallAttrs, "relay.attrs.TIRCallAttrs") {
-    TVM_ATTR_FIELD(metadata).describe("Metadata attached to the TIR function call.");
-  }
-};
 
 }  // namespace relay
 }  // namespace tvm

--- a/include/tvm/relay/attrs/call.h
+++ b/include/tvm/relay/attrs/call.h
@@ -18,23 +18,31 @@
  */
 
 /*!
- * \file src/relay/op/vm/vm.h
- * \brief Dialect operators for Relay VM.
+ * \file tvm/relay/attrs/call.h
+ * \brief Attribute for call_lowered operator.
  */
-#ifndef TVM_RELAY_OP_VM_VM_H_
-#define TVM_RELAY_OP_VM_VM_H_
+#ifndef TVM_RELAY_ATTRS_CALL_H_
+#define TVM_RELAY_ATTRS_CALL_H_
 
-#include <tvm/relay/expr.h>
+#include <tvm/ir/attrs.h>
+
+#include <string>
 
 namespace tvm {
 namespace relay {
 
-Expr InvokeTVMOp(Expr func, Expr inputs, Expr outputs);
-Expr ShapeFunc(Expr func, Expr inputs, Expr outputs, Array<tvm::Integer> is_input);
-Expr ShapeOf(Expr expr);
-Expr ReshapeTensor(Expr data, Expr shape, Array<PrimExpr> newshape);
+/*!
+ * \brief Metadata for calls to TIR functions, useful for program analysis crossing Relay and TIR.
+ */
+struct CallLoweredAttrs : public tvm::AttrsNode<CallLoweredAttrs> {
+  /*! \brief The metadata attached to the call node. */
+  Map<String, ObjectRef> metadata;
+
+  TVM_DECLARE_ATTRS(CallLoweredAttrs, "relay.attrs.CallLoweredAttrs") {
+    TVM_ATTR_FIELD(metadata).describe("Metadata attached to the lowered function call.");
+  }
+};
 
 }  // namespace relay
 }  // namespace tvm
-
-#endif  // TVM_RELAY_OP_VM_VM_H_
+#endif  // TVM_RELAY_ATTRS_CALL_H_

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -403,19 +403,15 @@ class AOTExecutorCodegen : public MixedModeVisitor {
     CallLoweredProps call_lowered_props;
     if (const auto* gvn = call_node->op.as<GlobalVarNode>()) {  // Lowered extern function
       ICHECK(!(call_node->attrs.defined())) << "Extern functions should have null attributes.";
-
       for (const auto& arg : call_node->args) {
         VisitExpr(arg);
       }
-      call_lowered_props =
-          CallLoweredProps{std::move(GetRef<GlobalVar>(gvn)), std::move(call_node->args), {}};
+      call_lowered_props = CallLoweredProps{GetRef<GlobalVar>(gvn), call_node->args, {}};
     } else {
       ICHECK(call_node->op == CallLoweredOp()) << "Operators should be transformed away; Try "
                                                   "applying the fuse_ops transformation to the "
                                                   "expression.";
-
-      CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
-
+      call_lowered_props = GetCallLoweredProps(call_node);
       for (const auto& arg : call_lowered_props.arguments) {
         VisitExpr(arg);
       }

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -404,7 +404,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
     if (const auto* gvn = call_node->op.as<GlobalVarNode>()) {  // Lowered extern function
       ICHECK(!(call_node->attrs.defined())) << "Extern functions should have null attributes.";
 
-      for (auto arg : call_node->args) {
+      for (const auto& arg : call_node->args) {
         VisitExpr(arg);
       }
       call_lowered_props =
@@ -416,7 +416,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
 
       CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
 
-      for (auto arg : call_lowered_props.arguments) {
+      for (const auto& arg : call_lowered_props.arguments) {
         VisitExpr(arg);
       }
     }

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -727,10 +727,11 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
             Downcast<Integer>(call_lowered_props.attrs.metadata.at("prim_shape_fn_num_outputs"))
                 ->value);
       }
-
-      return InvokePrimitiveOp(call_lowered_props.lowered_func, all_prim_fn_vars, target_,
-                               prim_shape_fn_var, all_prim_shape_fn_vars, prim_shape_fn_states,
-                               num_shape_inputs, num_shape_outputs, cpu_target_, args);
+      ICHECK(config_->optional_homogeneous_target.defined());
+      return InvokePrimitiveOp(call_lowered_props.lowered_func, all_prim_fn_vars,
+                               config_->optional_homogeneous_target, prim_shape_fn_var,
+                               all_prim_shape_fn_vars, prim_shape_fn_states, num_shape_inputs,
+                               num_shape_outputs, config_->host_se_scope->target, args);
     } else {  // All other calls
       // Evaluate all arguments
       std::vector<ObjectRef> args;

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -24,6 +24,7 @@
 #include <tvm/ir/function.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/attrs/annotation.h>
+#include <tvm/relay/attrs/call.h>
 #include <tvm/relay/attrs/device_copy.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
@@ -43,6 +44,7 @@
 #include <vector>
 
 #include "../op/annotation/annotation.h"
+#include "../op/call/call.h"
 #include "../transforms/device_aware_visitors.h"
 #include "./te_compiler_cache.h"
 #include "./utils.h"
@@ -460,7 +462,8 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
    * to the TIR implementation, and attributes to attach to the call to identify it as
    * a TIR call.
    */
-  std::pair<GlobalVar, Attrs> LowerFunction(Function func, Target target) {
+  Expr MakeLoweredCall(Function func, Array<Expr> visited_args, Array<Type> type_args, Span span,
+                       Target target) {
     if (func->GetAttr<String>(attr::kCompiler).defined()) {
       // BYOC flow.
       CCacheKey key = CCacheKey(func, target);
@@ -468,6 +471,7 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
       ICHECK(ext_func.defined()) << "Lowering returned undefined function for "
                                  << ext_func->prim_fn_var->name_hint;
 
+      // TODO(@areusch, @jroesch): this metadata is for AOT, this should be our interface for AOT
       Map<GlobalVar, tir::PrimFunc> prim_fns;
       relay::Function func_with_metadata = func;
       func_with_metadata = WithAttr(func_with_metadata, "prim_fn_var", ext_func->prim_fn_var);
@@ -478,87 +482,91 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
       // act when we process a function.
       this->process_fn_(func_with_metadata);
 
-      // TODO(mbs): Need TIRCallAttrs or equiv so targets know this is an extern.
       // TODO(mbs): Dynamic shapes?
-      return {ext_func->prim_fn_var, Attrs()};
-    }
+      // TODO(@mbs, electriclilies): Make extern functions explicit
+      return Call(ext_func->prim_fn_var, visited_args, Attrs(), type_args, span);
 
-    // Non-External Relay Function
-    VLOG(1) << "lowering to target '" << target->str() << "' for primitive:\n" << PrettyPrint(func);
-    CCacheKey key = CCacheKey(func, target);
-    CachedFunc lowered_func = compiler_->Lower(key, module_name_);
-    VLOG(1) << "lowered primitive bound to '" << PrettyPrint(lowered_func->prim_fn_var) << "'";
+    } else {
+      // Non-External Relay Function
+      VLOG(1) << "lowering to target '" << target->str() << "' for primitive:\n"
+              << PrettyPrint(func);
+      CCacheKey key = CCacheKey(func, target);
+      CachedFunc lowered_func = compiler_->Lower(key, module_name_);
+      VLOG(1) << "lowered primitive bound to '" << PrettyPrint(lowered_func->prim_fn_var) << "'";
 
-    // Collect all the lowered functions produced for this primitive function.
-    Map<GlobalVar, tir::PrimFunc> prim_fns;
-    Array<GlobalVar> all_prim_fn_vars;
-    for (auto prim_fn : lowered_func->funcs->functions) {
-      CHECK(prim_fn.second.as<tir::PrimFuncNode>()) << "must be a prim fn";
-      prim_fns.Set(prim_fn.first, Downcast<tir::PrimFunc>(prim_fn.second));
-      all_prim_fn_vars.push_back(prim_fn.first);
-      VLOG(1) << "lowered primitive includes bindings for '" << PrettyPrint(prim_fn.first) << "'";
-    }
-
-    // TODO(@areusch, @jroesch): this metadata is for AOT, this should be our interface for AOT
-    relay::Function func_with_metadata = func;
-    func_with_metadata = WithAttr(func_with_metadata, "prim_fn_var", lowered_func->prim_fn_var);
-    func_with_metadata = WithAttr(func_with_metadata, "prim_funcs", prim_fns);
-    func_with_metadata = WithAttr(func_with_metadata, tvm::attr::kTarget, lowered_func->target);
-
-    // Provide a callback hook which allows one-level up code generators to
-    // act when we process a function.
-    this->process_fn_(func_with_metadata);
-
-    auto tir_call_attrs = make_object<TIRCallAttrs>();
-    if (func->HasNonzeroAttr(attr::kReshapeOnly)) {
-      tir_call_attrs->metadata.Set(attr::kReshapeOnly, tvm::Integer(1));
-    }
-
-    auto device_copy = IsDeviceCopy(func);
-    if (std::get<0>(device_copy)) {
-      // Record that device copy source and destination devices so the device planner can
-      // still follow along.
-      auto source_device = std::get<1>(device_copy);
-      auto dst_device = std::get<2>(device_copy);
-      tir_call_attrs->metadata.Set("source_device", tvm::Integer(source_device));
-      tir_call_attrs->metadata.Set("dst_device", tvm::Integer(dst_device));
-    }
-
-    tir_call_attrs->metadata.Set("relay_attrs", func->attrs);
-    tir_call_attrs->metadata.Set("all_prim_fn_vars", all_prim_fn_vars);
-
-    if (IsDynamic(func->ret_type)) {
-      // Also lower the dynamic shape function.
-      // Shape function keys use the underlying primitive function as their 'function',
-      // but the generic 'cpu' target as the target since all shape functions run
-      // on the host cpu irrespective of where the primitive runs.
-      // TODO(mbs): Cleanup target handling.
-      Target shape_target("llvm");
-      VLOG(1) << "lowering to target '" << shape_target->str()
-              << "' for dynamic shape function for primitive";
-      CCacheKey shape_key(func, shape_target);
-      CachedFunc lowered_shape_func = compiler_->LowerShapeFunc(shape_key);
-      // Capture the shape function's global var and parameters 'states' in call
-      // annotations so calling convention can be recovered.
-      // TODO(mbs): Capture all this as part of a 'call into TIR' construct once available.
-      // The way the shape function calling convention is derived and passed to call sites
-      // via the 'parameter states' could be improved.
-      tir_call_attrs->metadata.Set("prim_shape_fn_var", lowered_shape_func->prim_fn_var);
-      tir_call_attrs->metadata.Set("prim_shape_fn_states",
-                                   lowered_shape_func->shape_func_param_states);
-      tir_call_attrs->metadata.Set("prim_shape_fn_num_inputs",
-                                   Integer(static_cast<int>(lowered_shape_func->inputs.size())));
-      tir_call_attrs->metadata.Set("prim_shape_fn_num_outputs",
-                                   Integer(static_cast<int>(lowered_shape_func->outputs.size())));
-      Array<GlobalVar> all_prim_shape_fn_vars;
-      for (auto prim_shape_fn : lowered_shape_func->funcs->functions) {
-        CHECK(prim_shape_fn.second.as<tir::PrimFuncNode>()) << "must be a prim fn";
-        all_prim_shape_fn_vars.push_back(prim_shape_fn.first);
+      // Collect all the lowered functions produced for this primitive function.
+      Map<GlobalVar, tir::PrimFunc> prim_fns;
+      Array<GlobalVar> all_prim_fn_vars;
+      for (auto prim_fn : lowered_func->funcs->functions) {
+        CHECK(prim_fn.second.as<tir::PrimFuncNode>()) << "must be a prim fn";
+        prim_fns.Set(prim_fn.first, Downcast<tir::PrimFunc>(prim_fn.second));
+        all_prim_fn_vars.push_back(prim_fn.first);
+        VLOG(1) << "lowered primitive includes bindings for '" << PrettyPrint(prim_fn.first) << "'";
       }
-      tir_call_attrs->metadata.Set("all_prim_shape_fn_vars", all_prim_shape_fn_vars);
-    }
 
-    return {lowered_func->prim_fn_var, Attrs(tir_call_attrs)};
+      // TODO(@areusch, @jroesch): this metadata is for AOT, this should be our interface for AOT
+      relay::Function func_with_metadata = func;
+      func_with_metadata = WithAttr(func_with_metadata, "prim_fn_var", lowered_func->prim_fn_var);
+      func_with_metadata = WithAttr(func_with_metadata, "prim_funcs", prim_fns);
+      func_with_metadata = WithAttr(func_with_metadata, tvm::attr::kTarget, lowered_func->target);
+
+      // Provide a callback hook which allows one-level up code generators to
+      // act when we process a function.
+      this->process_fn_(func_with_metadata);
+
+      auto call_lowered_attrs = make_object<CallLoweredAttrs>();
+      if (func->HasNonzeroAttr(attr::kReshapeOnly)) {
+        call_lowered_attrs->metadata.Set(attr::kReshapeOnly, tvm::Integer(1));
+      }
+
+      auto device_copy = IsDeviceCopy(func);
+      if (std::get<0>(device_copy)) {
+        // Record that device copy source and destination devices so the device planner can
+        // still follow along.
+        auto source_device = std::get<1>(device_copy);
+        auto dst_device = std::get<2>(device_copy);
+        call_lowered_attrs->metadata.Set("source_device", tvm::Integer(source_device));
+        call_lowered_attrs->metadata.Set("dst_device", tvm::Integer(dst_device));
+      }
+
+      call_lowered_attrs->metadata.Set("relay_attrs", func->attrs);
+      call_lowered_attrs->metadata.Set("all_prim_fn_vars", all_prim_fn_vars);
+
+      if (IsDynamic(func->ret_type)) {
+        // Also lower the dynamic shape function.
+        // Shape function keys use the underlying primitive function as their 'function',
+        // but the generic 'cpu' target as the target since all shape functions run
+        // on the host cpu irrespective of where the primitive runs.
+        // TODO(mbs): Cleanup target handling.
+        Target shape_target("llvm");
+        VLOG(1) << "lowering to target '" << shape_target->str()
+                << "' for dynamic shape function for primitive";
+        CCacheKey shape_key(func, shape_target);
+        CachedFunc lowered_shape_func = compiler_->LowerShapeFunc(shape_key);
+        // Capture the shape function's global var and parameters 'states' in call
+        // annotations so calling convention can be recovered.
+        // TODO(mbs): Capture all this as part of a 'call into TIR' construct once available.
+        // The way the shape function calling convention is derived and passed to call sites
+        // via the 'parameter states' could be improved.
+        call_lowered_attrs->metadata.Set("prim_shape_fn_var", lowered_shape_func->prim_fn_var);
+        call_lowered_attrs->metadata.Set("prim_shape_fn_states",
+                                         lowered_shape_func->shape_func_param_states);
+        call_lowered_attrs->metadata.Set(
+            "prim_shape_fn_num_inputs",
+            Integer(static_cast<int>(lowered_shape_func->inputs.size())));
+        call_lowered_attrs->metadata.Set(
+            "prim_shape_fn_num_outputs",
+            Integer(static_cast<int>(lowered_shape_func->outputs.size())));
+        Array<GlobalVar> all_prim_shape_fn_vars;
+        for (auto prim_shape_fn : lowered_shape_func->funcs->functions) {
+          CHECK(prim_shape_fn.second.as<tir::PrimFuncNode>()) << "must be a prim fn";
+          all_prim_shape_fn_vars.push_back(prim_shape_fn.first);
+        }
+        call_lowered_attrs->metadata.Set("all_prim_shape_fn_vars", all_prim_shape_fn_vars);
+      }
+      return CallLowered(lowered_func->prim_fn_var, visited_args, Attrs(call_lowered_attrs),
+                         type_args, span);
+    }
   }
 
   std::pair<Var, Expr> PreVisitLetBinding_(const Var& var, const Expr& value) final {
@@ -593,6 +601,9 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
   }
 
   Expr DeviceAwareVisitExpr_(const CallNode* call_node) override {
+    // Passes before lowering might insert a call_lowered to call a function that has already
+    // been lowered. Therefore we might see call_lowered ops here, but we don't need to do anything
+    // because ResolveToPrimitive returns null for all calls where the call_node->op is an OpNode
     Call call = GetRef<Call>(call_node);
 
     // Look for (indirect) calls to primitives.
@@ -628,15 +639,13 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
       // TODO(mbs): Replace device_type with target so this lookup is unnecessary.
       target = GetTargetFromInteger(device_type, targets_);
     }
-
+    Array<Expr> visited_args;
+    for (const auto& arg : call_node->args) {
+      visited_args.push_back(VisitExpr(arg));
+    }
     // Lower the primitive function for that target.
     Function func = Downcast<Function>(prim_func);
-    std::pair<GlobalVar, Attrs> pair = LowerFunction(func, target);
-
-    // Replace with direct call to lowered primitive, and attach annotations to record calling
-    // convention.
-    // =====> in new call_lowered form
-    return Call(pair.first, args, pair.second);
+    return MakeLoweredCall(func, visited_args, call_node->type_args, call_node->span, target);
   }
 
   IRModule module_;

--- a/src/relay/op/call/call.cc
+++ b/src/relay/op/call/call.cc
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/op/call/call.cc
+ * \brief Operators for calling lowered functions.
+ */
+
+#include "./call.h"
+
+#include <tvm/relay/attrs/call.h>
+#include <tvm/relay/expr.h>
+#include <tvm/relay/op.h>
+#include <tvm/relay/op_attr_types.h>
+
+#include "../../transforms/infer_layout_utils.h"
+
+namespace tvm {
+namespace relay {
+
+TVM_REGISTER_NODE_TYPE(CallLoweredAttrs);
+
+// call_lowered
+bool CallLoweredRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+                    const TypeReporter& reporter) {
+  // Types = [func, call_args, ret_type]
+  if (types.size() != 3u) {
+    return false;
+  }
+  const auto* func_type = types[0].as<FuncTypeNode>();
+  if (!func_type) {
+    return false;
+  }
+
+  const auto* tuple_type_node = types[1].as<TupleTypeNode>();
+  if (!tuple_type_node) {
+    return false;
+  }
+
+  // Constraint to ensure function arguments are the same type as the inputs to the function (modulo
+  // the Tuple wrapper)
+  reporter->Assign(GetRef<TupleType>(tuple_type_node), TupleType(func_type->arg_types, {}));
+  // Constraint to ensure the output of call_lowered is the same as the function's return type
+  reporter->Assign(types[2], func_type->ret_type);
+  return true;
+}
+
+const Op& CallLoweredOp() { return Op::Get("call_lowered"); }
+
+Expr CallLowered(Expr func, Array<Expr> inputs, Attrs attrs, Array<Type> type_args, Span span) {
+  // Right now, call_lowered only supports func being a global var pointing to the lowered
+  // function.
+  ICHECK(func.as<GlobalVarNode>())
+      << "Function to call should be GlobalVarNode, but got " << func->GetTypeKey();
+  ICHECK(attrs.as<CallLoweredAttrs>())
+      << "Expected attributes to be CallLoweredAttrs, but got " << attrs->GetTypeKey();
+  return Call(CallLoweredOp(), {std::move(func), Tuple(std::move(inputs))}, std::move(attrs),
+              std::move(type_args), std::move(span));
+}
+
+TVM_REGISTER_GLOBAL("relay.op.call_lowered")
+    .set_body_typed([](Expr func, Array<Expr> inputs, Attrs attrs, Array<Type> type_args,
+                       Span span) {
+      const TupleNode* tuple_node = inputs.as<TupleNode>();
+      return CallLowered(func, tuple_node->fields, attrs, type_args, span);
+    });
+
+RELAY_REGISTER_OP("call_lowered")
+    .describe(R"code(Invoke an operation compiled by TVM.)code" TVM_ADD_FILELINE)
+    .set_num_inputs(2)
+    .set_attrs_type<CallLoweredAttrs>()
+    .add_argument("func", "Function", "The lowered function to call.")
+    .add_argument("call_args", "Tuple", "The input tensors.")
+    .add_type_rel("CallLoweredRel", CallLoweredRel)
+    .set_support_level(10)
+    .set_attr<TOpPattern>("TOpPattern", kOpaque)
+    .set_attr<TOpIsStateful>("TOpIsStateful", false)
+    .set_attr<TNonComputational>("TNonComputational", true)
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout);
+
+CallLoweredProps GetCallLoweredProps(const CallNode* call_node) {
+  ICHECK(call_node->op == CallLoweredOp())
+      << "GetCallLoweredProps expects the op to be call_lowered. ";
+  ICHECK(call_node->args.size() == 2) << "Expected call_lowered to have 2 arguments. ";
+  const auto* function = call_node->args[0].as<GlobalVarNode>();
+  ICHECK(function) << "Expected first arg to call_lowered to be a GlobalVar. ";
+
+  const auto* tuple_args = call_node->args[1].as<TupleNode>();
+  ICHECK(tuple_args) << "Expected second arg to call_lowered to be a Tuple. ";
+
+  ICHECK(call_node->attrs.defined()) << "Attributes for call_lowered should be defined!";
+  const auto* attrs = call_node->attrs.as<CallLoweredAttrs>();
+  ICHECK(attrs) << "Expected call_lowered op to have CallLoweredAttrs, but found "
+                << call_node->attrs->GetTypeKey();
+  return CallLoweredProps{std::move(GetRef<GlobalVar>(function)), std::move(tuple_args->fields),
+                          std::move(*attrs)};
+}
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/op/call/call.h
+++ b/src/relay/op/call/call.h
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/op/call/call.h
+ * \brief Operators for calling lowered functions.
+ */
+#ifndef TVM_RELAY_OP_CALL_CALL_H_
+#define TVM_RELAY_OP_CALL_CALL_H_
+
+#include <tvm/relay/attrs/call.h>
+#include <tvm/relay/expr.h>
+
+#include <utility>
+
+namespace tvm {
+namespace relay {
+
+/*!
+ * \brief Helper to construct a Relay call with the call_lowered op.
+ * \param func Lowered function to call with call_lowered.
+ * \param inputs Arguments to be passed to the function.
+ * \param attrs Function attributes, should be TIRCallAttrs.
+ * \param type_args Type arguments for the call.
+ * \param span TVM span for propogating debugging info.
+ * \return
+ */
+Expr CallLowered(Expr func, Array<Expr> inputs, Attrs attrs, Array<Type> type_args, Span span);
+
+/*!
+ * \brief Returns the Relay call_lowered op. Use this helper to avoid extraneous calls to
+ * Registry::Get.
+ */
+const Op& CallLoweredOp();
+
+/*!
+ * \brief Lowered function and the arguments to call it with.
+ */
+struct CallLoweredProps {
+  /*! \brief Global variable pointing to the lowered function. */
+  GlobalVar lowered_func;
+  /*! \brief Array of the arguments to call lowered_func with. */
+  Array<Expr> arguments;
+  /*! \brief Arguments from the call_lowered op. */
+  CallLoweredAttrs attrs;
+};
+
+/*!
+ * \brief Helper to extract the lowered function and its arguments from Call("call_lowered", ...).
+ * Will fail if called on a Call whose op is not "call_lowered" \param call_node CallNode that we
+ * want to get the function and its arguments from.
+ */
+CallLoweredProps GetCallLoweredProps(const CallNode* call_node);
+
+}  // namespace relay
+}  // namespace tvm
+
+#endif  // TVM_RELAY_OP_CALL_CALL_H_


### PR DESCRIPTION
In this PR, I change `Call` with `TIRCallAttrs` to a relay op called call_lowered. (I also rename `CallTIRAttrs` to `CallLoweredAttrs`). This means that after lowering, calls are of the form `Call("call_lowered", [fn: GlobalVar, args: Tuple] Attrs(CallLoweredAttrs))`. 

One benefit to this approach is it is easy to identify calls to lowered functions-- instead of checking the type of the call's attributes, we can just check what the op is. This is especially helpful for passes that run both before an after lowering, like device planning and memory allocation. 

I left the calling convention for extern functions as-is. A codegened extern call looks like this: `Call(fn: GlobalVar, [arg1: Expr, ... argn: Expr], Attrs()) `with null attributes. In the future we will probably need to change the extern calling convention to have attributes that store information like the target, but that is outside the scope of this work. 
