### PR TITLE
[codegen][LLVM][bugfix] Specify argument to FastMathFlags setAllowContract

### DIFF
--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -292,7 +292,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
     Bool fast_math_afn = target->GetAttr<Bool>("fast-math-afn").value_or(Bool(false));
     Bool fast_math_reassoc = target->GetAttr<Bool>("fast-math-reassoc").value_or(Bool(false));
     if (fast_math_contract) {
-      fmf.setAllowContract();
+      fmf.setAllowContract(true);
     }
     if (fast_math_afn) {
       fmf.setApproxFunc();


### PR DESCRIPTION
PR #9223 added a fast math flags setting to the LLVM codegen. The setting checks if the LLVM version is >= 6.0 and calls the below lines
```
    if (fast_math_contract) {
      fmf.setAllowContract();
    }
```

Recent LLVM versions have a default argument of `true` to `llvm::FastMathFlags::setAllowContract()`. However, LLVM 6.0 does not have a default argument for that method, so this fails to compile because it expects an explicit argument. This PR makes the argument explicit to be compatible with LLVM 6.0 (the version my system happened to have).