### PR TITLE
[TVMC][Relay] Introduce executor and runtime parameters

### DIFF
--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -130,8 +130,12 @@ curl --retry 64 -sSL ${mobilenet_url} | gunzip | tar -xvf - ./mobilenet_v1_1.0_2
 # Compile model for Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU
 # An alternative to using "python3 -m tvm.driver.tvmc" is to call
 # "tvmc" directly once TVM has been pip installed.
-python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, \
-    c -runtime=c --link-params -mcpu=cortex-m55 -executor=aot -interface-api=c -unpacked-api=1" \
+python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, c" \
+    --target-c-mcpu=cortex-m55 \
+    --runtime=crt \
+    --executor=aot \
+    --executor-aot-interface-api=c \
+    --executor-aot-unpacked-api=1 \
     --pass-config tir.disable_vectorize=1 ./mobilenet_v1_1.0_224_quant.tflite --output-format=mlf
 tar -xvf module.tar
 

--- a/docs/arch/microtvm_design.rst
+++ b/docs/arch/microtvm_design.rst
@@ -127,7 +127,7 @@ logs use it to rank measured performance (but see Future Work).
 Targets are currently represented as strings structured similarly to command-line arguments. An
 example target is shown below:
 
-    ``c -keys=arm_cpu -mcpu=cortex-m7 -link-params -model=stm32f746xx -runtime=c -system-lib=1``
+    ``c -keys=arm_cpu -mcpu=cortex-m7 -model=stm32f746xx``
 
 The relevant parts to microTVM are:
 
@@ -135,10 +135,16 @@ The relevant parts to microTVM are:
  * ``-mcpu=cortex-m7``: used by TOPI to enable Cortex-M schedules, and, when the C source code
    generator is selected, included in the output as a comment to help identify the code and
    configure the downstream C compiler.
- * ``-link-params``: include parameters as global constants to load from flash.
- * ``-runtime=c``: build glue code to allow operators to work with the C runtime
- * ``-system-lib=1``: emit a system library (i.e. which can be loaded by calling the PackedFunc
-   ``runtime.SystemLib``.
+
+Runtime and Executor configuration for microTVM
+-----------------------------------------------
+
+When using microTVM, it's important to use the C Runtime (``Runtime('crt')``), which is the runtime that works best on micro devices rather than the more dynamic C++ Runtime. Alongside this, there are two executors which you could use in combination with the C runtime:
+
+* ``Executor("aot")`` - The Ahead of Time (AOT) executor precompiles the network into a runnable function which you can add directly into your micro application
+* ``Executor("graph", {"link-params": True})`` - The Graph executor provides a JSON representation of your network and requires the C Runtime's system library to be generated to find functions in the function registry (``Runtime("crt", {"system-lib": True})``). ``{"link-params":True}`` enables parameters to be linked into the generated files rather than provided externally.
+
+These are specified when building a runtime module: ``relay.build(..., runtime=..., executor=...)``.
 
 Writing Schedules for microTVM
 ------------------------------

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -124,12 +124,9 @@ model with Relay.
 
 import os
 import numpy as np
-import logging
 
 import tvm
-import tvm.micro as micro
 from tvm.contrib.download import download_testdata
-from tvm.contrib import graph_executor, utils
 from tvm import relay
 
 model_url = "https://people.linaro.org/~tom.gall/sine_model.tflite"
@@ -179,9 +176,10 @@ mod, params = relay.frontend.from_tflite(
 # Now we create a build config for relay, turning off two options and then calling relay.build which
 # will result in a C source file for the selected TARGET. When running on a simulated target of the
 # same architecture as the host (where this Python script is executed) choose "host" below for the
-# TARGET and a proper board/VM to run it (Zephyr will create the right QEMU VM based on BOARD. In
-# the example below the x86 arch is selected and a x86 VM is picked up accordingly:
+# TARGET, the C Runtime as the RUNTIME and a proper board/VM to run it (Zephyr will create the right
+# QEMU VM based on BOARD. In the example below the x86 arch is selected and a x86 VM is picked up accordingly:
 #
+RUNTIME = tvm.relay.backend.Runtime("crt", {"system-lib": True})
 TARGET = tvm.target.target.micro("host")
 BOARD = "qemu_x86"
 #
@@ -210,7 +208,7 @@ BOARD = "qemu_x86"
 with tvm.transform.PassContext(
     opt_level=3, config={"tir.disable_vectorize": True}, disabled_pass=["AlterOpLayout"]
 ):
-    module = relay.build(mod, target=TARGET, params=params)
+    module = relay.build(mod, target=TARGET, runtime=RUNTIME, params=params)
 
 
 # Inspecting the compilation output

--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -302,6 +302,12 @@ class IRModuleNode : public Object {
   TVM_DLL void ImportFromStd(const String& path);
 
   /*!
+   * \brief Should Link Parameters into the module
+   * \return Whether the Executor is configured to execute with linked parameters (Default: false)
+   */
+  TVM_DLL Bool ShouldLinkParameters() const;
+
+  /*!
    * \brief The set of imported files.
    */
   TVM_DLL std::unordered_set<String> Imports() const;
@@ -468,5 +474,27 @@ TVM_DLL String PrettyPrint(const ObjectRef& node);
  */
 TVM_DLL String AsText(const ObjectRef& node, bool show_meta_data = true,
                       runtime::TypedPackedFunc<String(ObjectRef)> annotate = nullptr);
+
+namespace attr {
+
+/*!
+ * \brief Executor targetted by the module
+ *
+ * Type: Executor
+ *
+ * \sa tvm::relay::Executor
+ */
+constexpr const char* kExecutor = "executor";
+
+/*!
+ * \brief Runtime target of the module
+ *
+ * Type: Runtime
+ *
+ * \sa tvm::relay::Runtime
+ */
+constexpr const char* kRuntime = "runtime";
+
+}  // namespace attr
 }  // namespace tvm
 #endif  // TVM_IR_MODULE_H_

--- a/include/tvm/relay/executor.h
+++ b/include/tvm/relay/executor.h
@@ -60,6 +60,14 @@ class ExecutorNode : public Object {
   DictAttrs attrs;
 
   /*!
+   * \brief Should Link Parameters into the module
+   * \return Whether the Executor is configured to execute modules with linked parameters
+   */
+  Bool ShouldLinkParameters() const {
+    return name == "aot" || GetAttr<Bool>("link-params").value_or(Bool(false));
+  }
+
+  /*!
    * \brief Get an attribute.
    *
    * \param attr_key The attribute key.
@@ -114,6 +122,8 @@ class ExecutorNode : public Object {
  */
 class Executor : public ObjectRef {
  public:
+  Executor() = default;
+
   /*!
    * \brief Create a new Executor object using the registry
    * \throws Error if name is not registered
@@ -121,7 +131,7 @@ class Executor : public ObjectRef {
    * \param attrs Attributes for the executor.
    * \return the new Executor object.
    */
-  TVM_DLL static Executor Create(String name, Map<String, ObjectRef> attrs);
+  TVM_DLL static Executor Create(String name, Map<String, ObjectRef> attrs = {});
 
   /*!
    * \brief List all registered Executors

--- a/include/tvm/relay/runtime.h
+++ b/include/tvm/relay/runtime.h
@@ -114,6 +114,8 @@ class RuntimeNode : public Object {
  */
 class Runtime : public ObjectRef {
  public:
+  Runtime() = default;
+
   /*!
    * \brief Create a new Runtime object using the registry
    * \throws Error if name is not registered
@@ -121,7 +123,7 @@ class Runtime : public ObjectRef {
    * \param attrs Attributes for the Runtime.
    * \return the new Runtime object.
    */
-  TVM_DLL static Runtime Create(String name, Map<String, ObjectRef> attrs);
+  TVM_DLL static Runtime Create(String name, Map<String, ObjectRef> attrs = {});
 
   /*!
    * \brief List all registered Runtimes

--- a/python/tvm/autotvm/graph_tuner/utils/traverse_graph.py
+++ b/python/tvm/autotvm/graph_tuner/utils/traverse_graph.py
@@ -144,9 +144,7 @@ def _expr2graph_impl(expr, target_ops, node_dict, node_list, tvm_target):
                 mod = tvm.IRModule.from_expr(relay.Function(params, call))
                 relay.backend.te_compiler.get().clear()
                 tracing_target = _replace_device_with_tracing(tvm_target)
-                build_thread = threading.Thread(
-                    target=relay.build, args=(mod, tracing_target, None, None)
-                )
+                build_thread = threading.Thread(target=relay.build, args=(mod, tracing_target))
                 build_thread.start()
                 build_thread.join()
         elif isinstance(node, Var):

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -46,7 +46,7 @@ def _lower(mod, target, params):
         with vta.build_config(opt_level=3, disabled_pass={"AlterOpLayout"}):
             mod, _ = relay.optimize(mod, target, params)
             grc = graph_executor_codegen.GraphExecutorCodegen(None, target)
-            grc.codegen(mod["main"])
+            grc.codegen(mod, mod["main"])
             return
 
     compiler = relay.vm.VMCompiler()

--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -139,6 +139,9 @@ def build(
     args: Optional[List[Union[Buffer, tensor.Tensor, Var]]] = None,
     target: Optional[Union[str, Target]] = None,
     target_host: Optional[Union[str, Target]] = None,
+    runtime: Optional[
+        "tvm.relay.backend.Runtime"
+    ] = None,  # Type is annotated this way to avoid cyclic dependency
     name: Optional[str] = "default_function",
     binds: Optional[Mapping[tensor.Tensor, Buffer]] = None,
 ):
@@ -165,6 +168,9 @@ def build(
         target_host is used to specify the host side codegen target.
         By default, llvm is used if it is enabled,
         otherwise a stackvm interpreter is used.
+
+    runtime : Optional[Runtime]
+        Runtime to generate artifacts for
 
     name : Optional[str]
         The name of result function.
@@ -243,18 +249,20 @@ def build(
     else:
         target_input_mod = inputs
 
+    # Because modules can be created from a variety of sources, we annotate them
+    # with the relevant attributes here to ensure they propagate
+    annotated_mods = {}
     for tar, mod in target_input_mod.items():
         if not isinstance(tar, (str, Target)):
             raise ValueError("The key of inputs must be str or " "Target when inputs is dict.")
         if not isinstance(mod, tvm.IRModule):
             raise ValueError("inputs must be Schedule, IRModule," "or dict of str to IRModule.")
+        annotated_mods[tar] = mod.with_attr("runtime", runtime)
 
-    target_input_mod, target_host = Target.check_and_update_host_consist(
-        target_input_mod, target_host
-    )
+    annotated_mods, target_host = Target.check_and_update_host_consist(annotated_mods, target_host)
 
     if not target_host:
-        for tar, mod in target_input_mod.items():
+        for tar, mod in annotated_mods.items():
             tar = Target(tar)
             device_type = ndarray.device(tar.kind.name, 0).device_type
             if device_type == ndarray.cpu(0).device_type:
@@ -263,37 +271,30 @@ def build(
     if not target_host:
         target_host = "llvm" if tvm.runtime.enabled("llvm") else "stackvm"
 
-    target_input_mod, target_host = Target.check_and_update_host_consist(
-        target_input_mod, target_host
-    )
+    annotated_mods, target_host = Target.check_and_update_host_consist(annotated_mods, target_host)
 
-    rt_mod_host = _driver_ffi.preprocess_module(target_input_mod, target_host)
+    rt_mod_host = _driver_ffi.preprocess_module(annotated_mods, target_host)
 
-    target_input_mod, target_host = Target.check_and_update_host_consist(
-        target_input_mod, target_host
-    )
+    annotated_mods, target_host = Target.check_and_update_host_consist(annotated_mods, target_host)
 
     if not isinstance(target_host, Target):
         target_host = Target(target_host)
-    if (
-        target_host.attrs.get("runtime", tvm.runtime.String("c++")) == "c"
-        and target_host.attrs.get("system-lib", 0) == 1
-    ):
+
+    if str(runtime) == "crt" and runtime["system-lib"]:
         if target_host.kind.name == "c":
             create_csource_crt_metadata_module = tvm._ffi.get_global_func(
                 "runtime.CreateCSourceCrtMetadataModule"
             )
-            to_return = create_csource_crt_metadata_module([rt_mod_host], target_host)
-
+            to_return = create_csource_crt_metadata_module([rt_mod_host], target_host, runtime)
         elif target_host.kind.name == "llvm":
             create_llvm_crt_metadata_module = tvm._ffi.get_global_func(
                 "runtime.CreateLLVMCrtMetadataModule"
             )
-            to_return = create_llvm_crt_metadata_module([rt_mod_host], target_host)
+            to_return = create_llvm_crt_metadata_module([rt_mod_host], target_host, runtime)
     else:
         to_return = rt_mod_host
 
-    return OperatorModule.from_module(to_return, ir_module_by_target=target_input_mod, name=name)
+    return OperatorModule.from_module(to_return, ir_module_by_target=annotated_mods, name=name)
 
 
 class OperatorModule(Module):

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -25,7 +25,9 @@ from pathlib import Path
 import tvm
 from tvm import autotvm, auto_scheduler
 from tvm import relay
+from tvm.driver.tvmc.registry import generate_registry_args, reconstruct_registry_entity
 from tvm.target import Target
+from tvm.relay.backend import Executor, Runtime
 
 from . import common, composite_target, frontends
 from .model import TVMCModel, TVMCPackage
@@ -92,6 +94,7 @@ def add_compile_parser(subparsers):
         "times, each one to set one configuration value, "
         "e.g. '--pass-config relay.backend.use_auto_scheduler=0'.",
     )
+
     generate_target_args(parser)
     parser.add_argument(
         "--tuning-records",
@@ -100,6 +103,9 @@ def add_compile_parser(subparsers):
         help="path to an auto-tuning log file by AutoTVM. If not presented, "
         "the fallback/tophub configs will be used.",
     )
+    generate_registry_args(parser, Executor, "graph")
+    generate_registry_args(parser, Runtime, "cpp")
+
     parser.add_argument("-v", "--verbose", action="count", default=0, help="increase verbosity.")
     # TODO (@leandron) This is a path to a physical file, but
     #     can be improved in future to add integration with a modelzoo
@@ -141,6 +147,8 @@ def drive_compile(args):
     compile_model(
         tvmc_model,
         args.target,
+        executor=reconstruct_registry_entity(args, Executor),
+        runtime=reconstruct_registry_entity(args, Runtime),
         tuning_records=args.tuning_records,
         package_path=args.output,
         cross=args.cross_compiler,
@@ -160,6 +168,8 @@ def drive_compile(args):
 def compile_model(
     tvmc_model: TVMCModel,
     target: str,
+    executor: Optional[Executor] = Executor("graph"),
+    runtime: Optional[Runtime] = Runtime("cpp"),
     tuning_records: Optional[str] = None,
     package_path: Optional[str] = None,
     cross: Optional[Union[str, Callable]] = None,
@@ -257,18 +267,24 @@ def compile_model(
                     opt_level=3, config=config, disabled_pass=disabled_pass
                 ):
                     logger.debug("building relay graph with autoscheduler")
-                    graph_module = relay.build(mod, target=tvm_target, params=params)
+                    graph_module = relay.build(
+                        mod, target=tvm_target, executor=executor, runtime=runtime, params=params
+                    )
         else:
             with autotvm.apply_history_best(tuning_records):
                 with tvm.transform.PassContext(
                     opt_level=3, config=config, disabled_pass=disabled_pass
                 ):
                     logger.debug("building relay graph with tuning records")
-                    graph_module = relay.build(mod, target=tvm_target, params=params)
+                    graph_module = relay.build(
+                        mod, target=tvm_target, executor=executor, runtime=runtime, params=params
+                    )
     else:
         with tvm.transform.PassContext(opt_level=3, config=config, disabled_pass=disabled_pass):
             logger.debug("building relay graph (no tuning records provided)")
-            graph_module = relay.build(mod, target=tvm_target, params=params)
+            graph_module = relay.build(
+                mod, target=tvm_target, executor=executor, runtime=runtime, params=params
+            )
 
     # Generate output dump files with sources
     if dump_code is None:

--- a/python/tvm/driver/tvmc/registry.py
+++ b/python/tvm/driver/tvmc/registry.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This file contains functions for processing registry based inputs for the TVMC CLI
+"""
+
+from tvm.driver.tvmc.common import TVMCException
+
+# We can't tell the type inside an Array but all current options are strings so
+# it can default to that. Bool is used alongside Integer but aren't distinguished
+# between as both are represented by IntImm
+INTERNAL_TO_NATIVE_TYPE = {"runtime.String": str, "IntImm": int, "Array": str}
+INTERNAL_TO_HELP = {"runtime.String": " string", "IntImm": "", "Array": " options"}
+
+
+def _generate_registry_option_args(parser, registry, name):
+    target_group = parser.add_argument_group(f"{registry.name} {name}")
+    for option_name, option_type in registry.list_registered_options(name).items():
+        if option_type in INTERNAL_TO_NATIVE_TYPE:
+            target_group.add_argument(
+                f"--{registry.name}-{name}-{option_name}",
+                type=INTERNAL_TO_NATIVE_TYPE[option_type],
+                help=f"{registry.name.title()} {name} {option_name}{INTERNAL_TO_HELP[option_type]}",
+            )
+
+
+def generate_registry_args(parser, registry, default=None):
+    """Walks through the given registry and generates arguments for each of the available options"""
+    parser.add_argument(
+        f"--{registry.name}",
+        help=f"{registry.name.title()} to compile the model with",
+        required=False,
+        default=default,
+    )
+    names = registry.list_registered()
+    for name in names:
+        _generate_registry_option_args(parser, registry, name)
+
+
+def _reconstruct_registry_options(args, registry, name):
+    options = {}
+    for option, option_type in registry.list_registered_options(name).items():
+        if option_type in INTERNAL_TO_NATIVE_TYPE:
+            var_name = f"{registry.name}_{name}_{option.replace('-', '_')}"
+            option_value = getattr(args, var_name)
+            if option_value is not None:
+                options[option] = option_value
+    return options
+
+
+def reconstruct_registry_entity(args, registry):
+    """Reconstructs an entity from arguments generated from a registry"""
+    possible_names = registry.list_registered()
+    name = getattr(args, registry.name)
+    if name is None:
+        return None
+
+    if name not in possible_names:
+        raise TVMCException(f'{registry.name.title()} "{name}" is not defined')
+
+    reconstructed = {
+        possible_name: _reconstruct_registry_options(args, registry, possible_name)
+        for possible_name in possible_names
+    }
+
+    for possible_name in possible_names:
+        if possible_name != name and reconstructed[possible_name]:
+            first_option = list(reconstructed[possible_name])[0]
+            raise TVMCException(
+                f"Passed --{registry.name}-{possible_name}-{first_option} "
+                f"but did not specify {possible_name} executor"
+            )
+
+    return registry(name, reconstructed[name])

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -275,3 +275,38 @@ class IRModule(Node):
         return tvm._ffi.get_global_func("script.AsTVMScript")(
             self, tir_prefix, show_meta
         )  # type: ignore
+
+    def get_attr(self, attr_key):
+        """Get the IRModule attribute.
+
+        Parameters
+        ----------
+        attr_key : str
+            The attribute key.
+
+        Returns
+        -------
+        attr_value : Any
+            Attribute value
+        """
+
+        return _ffi_api.Module_GetAttr(self, attr_key)
+
+    def with_attr(self, attr_key, attr_value):
+        """Copy the IRModule and add an attribute to it.
+
+        Parameters
+        ----------
+        attr_key : str
+            The attribute key.
+
+        attr_value : Object
+            The new attribute value.
+
+        Returns
+        -------
+        mod : IRModule
+            A new copy of the IRModule with the attribute
+        """
+
+        return _ffi_api.Module_WithAttr(self, attr_key, attr_value)

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -270,7 +270,7 @@ def _get_inputs_and_outputs_from_module(mod):
 
 
 def _should_generate_interface_header(mod):
-    return any(target.attrs.get("interface-api") == "c" for target in mod.target.values())
+    return "interface-api" in mod.executor and mod.executor["interface-api"] == "c"
 
 
 def _make_tar(source_dir, tar_file_path):

--- a/python/tvm/relay/backend/executor.py
+++ b/python/tvm/relay/backend/executor.py
@@ -27,6 +27,8 @@ from . import _backend
 class Executor(Object):
     """Executor configuration"""
 
+    name = "executor"
+
     def __init__(self, name, options=None) -> None:
         if options is None:
             options = {}
@@ -39,12 +41,15 @@ class Executor(Object):
     def __getitem__(self, name):
         return self._attrs[name]
 
+    def __eq__(self, other):
+        return str(other) == str(self) and dict(other._attrs) == dict(self._attrs)
+
     @staticmethod
-    def list_executors():
+    def list_registered():
         """Returns a list of possible executors"""
         return list(_backend.ListExecutors())
 
     @staticmethod
-    def list_executor_options(executor):
+    def list_registered_options(executor):
         """Returns the dict of available option names and types"""
         return dict(_backend.ListExecutorOptions(str(executor)))

--- a/python/tvm/relay/backend/executor_factory.py
+++ b/python/tvm/relay/backend/executor_factory.py
@@ -79,6 +79,8 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         The IR modules lowered per Target.
     target : tvm.Target
         The Target used to build this module.
+    executor : tvm.relay.backend.Executor
+        Internal representation of the Executor
     libmod : tvm.Module
         The module of the corresponding function
     libmod_name: str
@@ -96,6 +98,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         ir_mod,
         lowered_ir_mods,
         target,
+        executor,
         libmod,
         libmod_name,
         params,
@@ -105,6 +108,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         self.ir_mod = ir_mod
         self.lowered_ir_mods = lowered_ir_mods
         self.target = target
+        self.executor = executor
         self.lib = libmod
         self.libmod_name = libmod_name
         self.params = params
@@ -135,6 +139,8 @@ class GraphExecutorFactoryModule(ExecutorFactoryModule):
         The IR module to build.
     target : tvm.Target
         The Target used to build this module.
+    executor : tvm.relay.backend.Executor
+        Internal representation of the Executor
     graph_json_str : the json graph to be deployed in json format output by graph compiler.
         The graph can contain operator(tvm_op) that points to the name of
         PackedFunc in the libmod.
@@ -152,6 +158,7 @@ class GraphExecutorFactoryModule(ExecutorFactoryModule):
         self,
         ir_mod,
         target,
+        executor,
         graph_json_str,
         libmod,
         libmod_name,
@@ -167,6 +174,7 @@ class GraphExecutorFactoryModule(ExecutorFactoryModule):
 
         self.ir_mod = ir_mod
         self.target = target
+        self.executor = executor
         self.module = fcreate(graph_json_str, libmod, libmod_name, *args)
         self.graph_json = graph_json_str
         self.lib = libmod

--- a/python/tvm/relay/backend/graph_executor_codegen.py
+++ b/python/tvm/relay/backend/graph_executor_codegen.py
@@ -64,11 +64,13 @@ class GraphExecutorCodegen(object):
             tgts[_expr.IntImm("int32", 0)] = Target(target)
         self._init(mod, tgts)
 
-    def codegen(self, func):
+    def codegen(self, ir_module, func):
         """Compile a single function into a graph.
 
         Parameters
         ----------
+        ir_module: tvm.ir.Module
+            The module to compile
         func: tvm.relay.Expr
             The function to compile.
 
@@ -82,7 +84,7 @@ class GraphExecutorCodegen(object):
             Additional constant parameters.
         """
         default_mod_name = mangle_module_name("default")
-        self._codegen(func, default_mod_name)
+        self._codegen(ir_module, func, default_mod_name)
         graph_json = self._get_graph_json()
         lowered_func = self._get_irmodule()
         param_names = self._list_params_name()

--- a/python/tvm/relay/backend/runtime.py
+++ b/python/tvm/relay/backend/runtime.py
@@ -27,6 +27,8 @@ from . import _backend
 class Runtime(Object):
     """Runtime configuration"""
 
+    name = "runtime"
+
     def __init__(self, name, options=None) -> None:
         if options is None:
             options = {}
@@ -37,14 +39,18 @@ class Runtime(Object):
         return name in self._attrs
 
     def __getitem__(self, name):
+        self._attrs = _backend.GetRuntimeAttrs(self)
         return self._attrs[name]
 
+    def __eq__(self, other):
+        return str(other) == str(self) and dict(other._attrs) == dict(self._attrs)
+
     @staticmethod
-    def list_runtimes():
+    def list_registered():
         """Returns a list of possible runtimes"""
         return list(_backend.ListRuntimes())
 
     @staticmethod
-    def list_runtime_options(runtime):
+    def list_registered_options(runtime):
         """Returns the dict of available option names and types"""
         return dict(_backend.ListRuntimeOptions(str(runtime)))

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -316,12 +316,9 @@ def micro(model="unknown", options=None):
     if model not in MICRO_SUPPORTED_MODELS:
         raise ValueError(f"Model {model} not supported by tvm.target.micro.")
     opts = _merge_opts(
-        MICRO_SUPPORTED_MODELS[model] + ["-runtime=c", f"-model={model}"],
+        MICRO_SUPPORTED_MODELS[model] + [f"-model={model}"],
         options,
     )
-
-    if (not options) or (options and not any("-executor=aot" in o for o in options)):
-        opts = _merge_opts(opts, "--system-lib")
 
     # NOTE: in the future, the default micro target will be LLVM except when
     # external dependencies are present.
@@ -623,27 +620,13 @@ def hexagon(cpu_ver="v66", **kwargs):
         args = [s.replace("=", "@") for s in llvm_options.split()]
         return "--llvm-options=" + ",".join(args)
 
-    # TVM target attributes string
-    def create_tvm_options(cpu_ver, config):  # pylint: disable=unused-argument
-        """Create TVM target features string."""
-
-        features = {
-            "link_params": "link-params",
-        }
-        opts = ""
-        for k in config:
-            if k in features:
-                opts += " --" + features[k] + "=" + str(config[k])
-        return opts
-
     # Sim args
     os.environ["HEXAGON_SIM_ARGS"] = create_sim_options(cpu_ver, config)
 
     target_str = create_llvm_target(cpu_ver, config)
     llvm_str = create_llvm_options(cpu_ver, config)
-    tvm_str = create_tvm_options(cpu_ver, config)
 
-    args_list = target_str.split() + llvm_str.split() + tvm_str.split()
+    args_list = target_str.split() + llvm_str.split()
 
     return Target(" ".join(["hexagon"] + args_list))
 

--- a/rust/tvm-graph-rt/tests/test_tvm_basic/src/build_test_lib.py
+++ b/rust/tvm-graph-rt/tests/test_tvm_basic/src/build_test_lib.py
@@ -22,6 +22,7 @@ from os import path as osp
 import sys
 
 import tvm
+from tvm.relay.backend import Runtime
 from tvm import te
 
 
@@ -32,8 +33,9 @@ def main():
     C = te.compute(A.shape, lambda *i: A(*i) + B(*i), name="C")
     s = tvm.te.create_schedule(C.op)
     s[C].parallel(s[C].op.axis[0])
+    runtime = Runtime("cpp", {"system-lib": True})
     print(tvm.lower(s, [A, B, C], simple_mode=True))
-    tvm.build(s, [A, B, C], "llvm --system-lib").save(osp.join(sys.argv[1], "test.o"))
+    tvm.build(s, [A, B, C], "llvm", runtime=runtime).save(osp.join(sys.argv[1], "test.o"))
 
 
 if __name__ == "__main__":

--- a/rust/tvm-graph-rt/tests/test_wasm32/src/build_test_lib.py
+++ b/rust/tvm-graph-rt/tests/test_wasm32/src/build_test_lib.py
@@ -23,6 +23,7 @@ import sys
 
 import tvm
 from tvm import te
+from tvm.relay.backend import Runtime
 
 
 def main():
@@ -33,7 +34,8 @@ def main():
     s = tvm.te.create_schedule(C.op)
     s[C].parallel(s[C].op.axis[0])
     print(tvm.lower(s, [A, B, C], simple_mode=True))
-    tvm.build(s, [A, B, C], "llvm -mtriple=wasm32-unknown-unknown --system-lib").save(
+    runtime = Runtime("cpp", {"system-lib": True})
+    tvm.build(s, [A, B, C], "llvm -mtriple=wasm32-unknown-unknown", runtime=runtime).save(
         osp.join(sys.argv[1], "test.o")
     )
 

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -32,6 +32,7 @@
 #include <tvm/ir/type_functor.h>
 #include <tvm/parser/parser.h>
 #include <tvm/relay/analysis.h>
+#include <tvm/relay/executor.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/transform.h>
 
@@ -426,6 +427,14 @@ void IRModuleNode::ImportFromStd(const String& path) {
   this->Import(std_path + "/" + path);
 }
 
+Bool IRModuleNode::ShouldLinkParameters() const {
+  Optional<relay::Executor> executor = GetAttr<tvm::relay::Executor>(tvm::attr::kExecutor);
+  if (!executor.defined()) {
+    return Bool(false);
+  }
+  return executor.value()->ShouldLinkParameters();
+}
+
 std::unordered_set<String> IRModuleNode::Imports() const { return this->import_set_; }
 
 IRModule IRModule::FromText(const String& text, const String& source_path) {
@@ -519,6 +528,15 @@ TVM_REGISTER_GLOBAL("ir.Module_Import").set_body_typed([](IRModule mod, String p
 
 TVM_REGISTER_GLOBAL("ir.Module_ImportFromStd").set_body_typed([](IRModule mod, String path) {
   mod->ImportFromStd(path);
+});
+
+TVM_REGISTER_GLOBAL("ir.Module_WithAttr")
+    .set_body_typed([](IRModule mod, String key, ObjectRef value) -> IRModule {
+      return WithAttr(mod, key, value);
+    });
+
+TVM_REGISTER_GLOBAL("ir.Module_GetAttr").set_body_typed([](IRModule mod, String key) -> ObjectRef {
+  return mod->GetAttr<ObjectRef>(key);
 });
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)

--- a/src/relay/backend/executor.cc
+++ b/src/relay/backend/executor.cc
@@ -89,11 +89,10 @@ ExecutorRegEntry& ExecutorRegEntry::RegisterOrGet(const String& name) {
 
 TVM_REGISTER_EXECUTOR("aot")
     .add_attr_option<Bool>("unpacked-api")
-    .add_attr_option<String>("interface-api");
+    .add_attr_option<String>("interface-api")
+    .add_attr_option<Integer>("workspace-byte-alignment");
 
 TVM_REGISTER_EXECUTOR("graph").add_attr_option<Bool>("link-params", Bool(false));
-
-TVM_REGISTER_EXECUTOR("vm");
 
 /**********  Registry  **********/
 

--- a/src/relay/backend/runtime.cc
+++ b/src/relay/backend/runtime.cc
@@ -88,9 +88,9 @@ RuntimeRegEntry& RuntimeRegEntry::RegisterOrGet(const String& name) {
 
 /**********  Register Runtimes and options  **********/
 
-TVM_REGISTER_RUNTIME("c").add_attr_option<Bool>("system-lib");
+TVM_REGISTER_RUNTIME("crt").add_attr_option<Bool>("system-lib");
 
-TVM_REGISTER_RUNTIME("cpp");
+TVM_REGISTER_RUNTIME("cpp").add_attr_option<Bool>("system-lib");
 
 /**********  Registry  **********/
 

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -848,7 +848,8 @@ backend::FunctionInfo UpdateMainWorkspaceSize(const IRModule& mod, tec::TargetMa
  * \param function_metadata The map that stores all the function metadatas
  */
 void UpdateFunctionMetadata(BaseFunc func,
-                            Map<String, backend::FunctionInfo>& function_metadata) {  // NOLINT(*)
+                            Map<String, backend::FunctionInfo>& function_metadata,  // NOLINT(*)
+                            Integer workspace_byte_alignment) {
   VLOG_CONTEXT << "UpdateFunctionMetadata";
   VLOG(1) << "updating function metadata for:" << std::endl << PrettyPrint(func);
   // Originally UpdateFunctionMetadata took in CCachedFunc and looped through all the funcs stored
@@ -877,9 +878,6 @@ void UpdateFunctionMetadata(BaseFunc func,
   for (const auto& kv : prim_fns.value()) {
     auto prim_fn = Downcast<tir::PrimFunc>(kv.second);
     CHECK(prim_fn.defined()) << "the primitive function must be defined";
-
-    auto workspace_byte_alignment =
-        relay_target.value()->GetAttr<Integer>("workspace-byte-alignment").value_or(16);
 
     Integer workspace_size = CalculateWorkspaceBytes(prim_fn, workspace_byte_alignment);
 

--- a/src/relay/backend/te_compiler.h
+++ b/src/relay/backend/te_compiler.h
@@ -142,9 +142,11 @@ class TECompiler : public ObjectRef {
  * input/output sizes)
  * \param func The function to calculate function metadata for
  * \param function_metadata The map that stores all the function metadatas
+ * \param workspace_byte_alignment Byte alignment for allocations
  */
-void UpdateFunctionMetadata(BaseFunc func,
-                            Map<String, backend::FunctionInfo>& function_metadata);  // NOLINT(*)
+void UpdateFunctionMetadata(BaseFunc relay_func,
+                            Map<String, backend::FunctionInfo>& function_metadata,  // NOLINT(*)
+                            Integer workspace_byte_alignment = 16);
 
 /*!
  * \brief Obtain the Target from the device type.

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -32,6 +32,7 @@
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/interpreter.h>
 #include <tvm/relay/qnn/transform.h>
+#include <tvm/relay/runtime.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/vm/vm.h>
@@ -44,6 +45,7 @@
 #include <tuple>
 #include <vector>
 
+#include "../../../target/metadata_module.h"
 #include "../../../target/source/codegen_source_base.h"
 #include "../../op/annotation/annotation.h"
 #include "../../op/op_common.h"
@@ -1170,7 +1172,7 @@ void VMCompiler::Codegen() {
     lib = codegen::CSourceModuleCreate(";", "", Array<String>{});
   }
   lib = codegen::CreateMetadataModule(params_, lib, ext_mods, config_->host_target,
-                                      runtime::Metadata());
+                                      Runtime::Create("cpp"), runtime::Metadata());
   exec_->SetLib(lib);
 }
 

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -62,6 +62,10 @@ class MetadataNode : public Object {
   Array<String> devices;
   /*! \brief the executor to be used to run the model */
   String executor = kTvmExecutorGraph;
+  /*! \brief The external API (packed or c) in use */
+  String interface_api;
+  /*! \brief The internal API (packed or unpacked) in use */
+  bool unpacked_api;
 
   String mod_name = "";
 
@@ -76,12 +80,14 @@ class MetadataNode : public Object {
 class Metadata : public ObjectRef {
  public:
   TVM_DLL Metadata(Array<String> inputs, Array<String> devices, int num_outputs, String executor,
-                   String mod_name) {
+                   String mod_name, String interface_api = "packed", bool unpacked_api = false) {
     auto n = make_object<MetadataNode>();
     n->inputs = inputs;
     n->devices = devices;
     n->num_outputs = num_outputs;
     n->executor = executor;
+    n->interface_api = interface_api;
+    n->unpacked_api = unpacked_api;
     n->mod_name = mod_name;
     data_ = std::move(n);
   }

--- a/src/target/llvm/llvm_module.h
+++ b/src/target/llvm/llvm_module.h
@@ -33,7 +33,8 @@
 namespace tvm {
 namespace codegen {
 
-runtime::Module CreateLLVMCrtMetadataModule(const Array<runtime::Module>& modules, Target target);
+runtime::Module CreateLLVMCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
+                                            tvm::relay::Runtime runtime);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/src/target/metadata_module.h
+++ b/src/target/metadata_module.h
@@ -25,6 +25,7 @@
 #ifndef TVM_TARGET_METADATA_MODULE_H_
 #define TVM_TARGET_METADATA_MODULE_H_
 
+#include <tvm/relay/runtime.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/target/target.h>
@@ -37,9 +38,22 @@
 namespace tvm {
 namespace codegen {
 
+/*!
+ * \brief Create a metadata module wrapper. The helper is used by different
+ *        codegens, such as graph executor codegen and the vm compiler.
+ *
+ * \param params The metadata for initialization of all modules.
+ * \param target_module the internal module that is compiled by tvm.
+ * \param ext_modules The external modules that needs to be imported inside the metadata
+ * module(s).
+ * \param target The target that all the modules are compiled for
+ * \param runtime The runtime to codegen for
+ * \param metadata Module metadata
+ * \return The created metadata module that manages initialization of metadata.
+ */
 runtime::Module CreateMetadataModule(
-    const std::unordered_map<std::string, runtime::NDArray>& params,
-    tvm::runtime::Module target_module, const Array<runtime::Module>& ext_modules, Target target,
+    const std::unordered_map<std::string, runtime::NDArray>& params, runtime::Module target_module,
+    const Array<runtime::Module>& ext_modules, Target target, tvm::relay::Runtime runtime,
     runtime::Metadata metadata);
 
 }  // namespace codegen

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -22,6 +22,7 @@
  */
 #include "codegen_c_host.h"
 
+#include <tvm/relay/executor.h>
 #include <tvm/runtime/crt/error_codes.h>
 #include <tvm/runtime/module.h>
 #include <tvm/target/codegen.h>
@@ -384,7 +385,7 @@ runtime::Module BuildCHost(IRModule mod, Target target) {
 
   Map<String, LinkedParam> linked_params;
   bool found_linked_params = false;
-  bool could_have_linked_params = target->GetAttr<Bool>("link-params").value_or(Bool(false));
+  bool could_have_linked_params = mod->ShouldLinkParameters();
   PrimFunc aot_executor_fn;
 
   for (auto kv : mod->functions) {

--- a/src/target/source/codegen_source_base.h
+++ b/src/target/source/codegen_source_base.h
@@ -146,19 +146,6 @@ runtime::Module CSourceModuleCreate(const String& code, const String& fmt,
                                     const Array<String>& const_vars = {});
 
 /*!
- * \brief Wrap the submodules in a metadata module.
- * \param params The variable to constant mapping that is collected by the host
- *        module.
- * \param target_module The main TIR-lowered internal runtime module
- * \param modules All the external modules that needs to be imported inside the metadata module(s).
- * \param target The target that all the modules are compiled for
- * \return The wrapped module.
- */
-runtime::Module CreateMetadataModule(
-    const std::unordered_map<std::string, runtime::NDArray>& params, runtime::Module target_module,
-    const Array<runtime::Module>& ext_modules, Target target, runtime::Metadata metadata);
-
-/*!
  * \brief Create a source module for viewing and limited saving for device.
  * \param data The code data to be viewed.
  * \param fmt The code. format.
@@ -169,16 +156,6 @@ runtime::Module CreateMetadataModule(
 runtime::Module DeviceSourceModuleCreate(
     std::string data, std::string fmt, std::unordered_map<std::string, runtime::FunctionInfo> fmap,
     std::string type_key, std::function<std::string(const std::string&)> fget_source = nullptr);
-
-/*!
- * \brief Wrap the submodules that are to be wrapped in a c-source metadata module for C runtime.
- * \param modules The modules to be wrapped.
- * \param target the target the modules are compiled for.
- * \param metadata the metadata needed for code generation.
- * \return The wrapped module.
- */
-runtime::Module CreateCSourceCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
-                                               runtime::Metadata metadata);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/src/target/source/source_module.h
+++ b/src/target/source/source_module.h
@@ -25,6 +25,7 @@
 #ifndef TVM_TARGET_SOURCE_SOURCE_MODULE_H_
 #define TVM_TARGET_SOURCE_SOURCE_MODULE_H_
 
+#include <tvm/relay/runtime.h>
 #include <tvm/runtime/module.h>
 #include <tvm/target/target.h>
 
@@ -34,12 +35,15 @@ namespace tvm {
 namespace codegen {
 
 /*!
- * \brief Create C-runtime targeted metadata module for "c" backend.
- * \param modules Array of modules included in the compilation output.
- * \param target TVM target.
+ * \brief Wrap the submodules that are to be wrapped in a c-source metadata module for C runtime.
+ * \param modules The modules to be wrapped.
+ * \param target the target the modules are compiled for.
+ * \param runtime the runtime to code generate against
+ * \param metadata the metadata needed for code generation.
+ * \return The wrapped module.
  */
-runtime::Module CreateCSourceCrtMetadataModule(const Array<runtime::Module>& modules,
-                                               tvm::Target target, runtime::Metadata metadata);
+runtime::Module CreateCSourceCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
+                                               relay::Runtime runtime, runtime::Metadata metadata);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -21,9 +21,11 @@
 #include <tvm/driver/driver_api.h>
 #include <tvm/ir/module.h>
 #include <tvm/relay/analysis.h>
+#include <tvm/relay/executor.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/op_attr_types.h>
 #include <tvm/relay/op_strategy.h>
+#include <tvm/relay/runtime.h>
 #include <tvm/relay/transform.h>
 #include <tvm/relay/type.h>
 #include <tvm/runtime/executor_info.h>
@@ -126,7 +128,7 @@ TEST(Relay, BuildModule) {
   targets.Set(0, llvm_tgt);
   auto relay_mod = tvm::IRModule::FromExpr(func);
   ICHECK(relay_mod.defined()) << "Module must be defined";
-  build_f(relay_mod, targets, llvm_tgt, runtime::kTvmExecutorGraph, "");
+  build_f(relay_mod, targets, llvm_tgt, Executor::Create("graph"), Runtime::Create("cpp"), "");
   std::string json = json_f();
   tvm::runtime::Module mod = mod_f();
   // run

--- a/tests/cpp/runtime_test.cc
+++ b/tests/cpp/runtime_test.cc
@@ -21,9 +21,11 @@
 #include <tvm/driver/driver_api.h>
 #include <tvm/ir/module.h>
 #include <tvm/relay/analysis.h>
+#include <tvm/relay/executor.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/op_attr_types.h>
 #include <tvm/relay/op_strategy.h>
+#include <tvm/relay/runtime.h>
 #include <tvm/relay/transform.h>
 #include <tvm/relay/type.h>
 #include <tvm/runtime/executor_info.h>
@@ -112,7 +114,7 @@ TEST(Runtime, ZeroCopy) {
   targets.Set(0, llvm_tgt);
   auto relay_mod = tvm::IRModule::FromExpr(func);
   ICHECK(relay_mod.defined()) << "Module must be defined";
-  build_f(relay_mod, targets, llvm_tgt, runtime::kTvmExecutorGraph, "");
+  build_f(relay_mod, targets, llvm_tgt, Executor::Create("graph"), Runtime::Create("cpp"), "");
   // create graph executor
   std::string json = json_f();
   tvm::runtime::Module mod = mod_f();

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -24,7 +24,9 @@ from unittest import mock
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.testing.utils import ethosn_available
+from tvm.relay.backend import Runtime, Executor
 
 from tvm.contrib.target.vitis_ai import vitis_ai_available
 
@@ -398,9 +400,11 @@ def test_compile_tflite_module_with_external_codegen_cmsisnn(
 
     output_file_name = f"{output_dir}/file.tar"
 
-    tvmc_package = tvmc.compiler.compile_model(
+    tvmc.compiler.compile_model(
         tvmc_model,
-        target=f"cmsis-nn, c -runtime=c --system-lib --link-params -mcpu=cortex-m55 -executor=aot",
+        target=f"cmsis-nn, c -mcpu=cortex-m55",
+        runtime=Runtime("crt", {"system-lib": True}),
+        executor=Executor("aot"),
         output_format="mlf",
         package_path=output_file_name,
         pass_context_configs=["tir.disable_vectorize=true"],
@@ -476,9 +480,11 @@ def test_compile_tflite_module_with_external_codegen_ethosu(
     for accel_type in ACCEL_TYPES:
         output_file_name = f"{output_dir}/file_{accel_type}.tar"
 
-        tvmc_package = tvmc.compiler.compile_model(
+        tvmc.compiler.compile_model(
             tvmc_model,
-            target=f"ethos-u -accelerator_config={accel_type}, c -runtime=c --system-lib --link-params -mcpu=cortex-m55 -executor=aot",
+            target=f"ethos-u -accelerator_config={accel_type}, c -mcpu=cortex-m55",
+            runtime=Runtime("crt", {"system-lib": True}),
+            executor=Executor("aot"),
             output_format="mlf",
             package_path=output_file_name,
             pass_context_configs=["tir.disable_vectorize=true"],

--- a/tests/python/driver/tvmc/test_mlf.py
+++ b/tests/python/driver/tvmc/test_mlf.py
@@ -21,15 +21,17 @@ import shlex
 import sys
 
 import tvm
+from tvm.autotvm.measure.executor import Executor
 from tvm.driver import tvmc
 from tvm.driver.tvmc.main import _main
 from tvm.driver.tvmc.model import TVMCPackage, TVMCException
+from tvm.relay import backend
 
 
-@pytest.mark.parametrize(
-    "target,pass_configs", [["llvm", []], ["c -executor=aot", ["tir.disable_vectorize=1"]]]
-)
-def test_tvmc_cl_compile_run_mlf(tflite_mobilenet_v1_1_quant, tmpdir_factory, target, pass_configs):
+def test_tvmc_cl_compile_run_mlf(tflite_mobilenet_v1_1_quant, tmpdir_factory):
+    target = "c"
+    executor = "aot"
+    pass_configs = ["tir.disable_vectorize=1"]
     pytest.importorskip("tflite")
 
     output_dir = tmpdir_factory.mktemp("mlf")
@@ -38,7 +40,7 @@ def test_tvmc_cl_compile_run_mlf(tflite_mobilenet_v1_1_quant, tmpdir_factory, ta
 
     # Compile the input model and generate a Model Library Format (MLF) archive.
     pass_config_args = " ".join([f"--pass-config {pass_config}" for pass_config in pass_configs])
-    tvmc_cmd = f"tvmc compile {input_model} --target='{target}' {pass_config_args} --output {output_file} --output-format mlf"
+    tvmc_cmd = f"tvmc compile {input_model} --target={target} --executor={executor} {pass_config_args} --output {output_file} --output-format mlf"
     tvmc_args = shlex.split(tvmc_cmd)[1:]
     _main(tvmc_args)
     assert os.path.exists(output_file), "Could not find the exported MLF archive."
@@ -114,7 +116,8 @@ def test_tvmc_import_package_mlf_aot(tflite_mobilenet_v1_1_quant, tflite_compile
 
     tflite_compiled_model_mlf = tflite_compile_model(
         tflite_mobilenet_v1_1_quant,
-        target="c -executor=aot",
+        target="c",
+        executor=backend.Executor("aot"),
         output_format="mlf",
         pass_context_configs=["tir.disable_vectorize=1"],
     )

--- a/tests/python/driver/tvmc/test_registry_options.py
+++ b/tests/python/driver/tvmc/test_registry_options.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+
+import pytest
+
+from tvm.driver.tvmc.common import TVMCException
+from tvm.driver.tvmc.registry import generate_registry_args, reconstruct_registry_entity
+from tvm.relay.backend import Executor
+
+
+def test_registry_to_argparse():
+    parser = argparse.ArgumentParser()
+    generate_registry_args(parser, Executor)
+    parsed, _ = parser.parse_known_args(["--executor=aot", "--executor-aot-interface-api=c"])
+
+    assert parsed.executor == "aot"
+    assert parsed.executor_aot_interface_api == "c"
+
+
+def test_registry_to_argparse_default():
+    parser = argparse.ArgumentParser()
+    generate_registry_args(parser, Executor, "aot")
+    parsed, _ = parser.parse_known_args([])
+
+    assert parsed.executor == "aot"
+
+
+def test_mapping_registered_args():
+    parser = argparse.ArgumentParser()
+    generate_registry_args(parser, Executor)
+    parsed, _ = parser.parse_known_args(["--executor=aot", "--executor-aot-interface-api=c"])
+    entity = reconstruct_registry_entity(parsed, Executor)
+
+    assert isinstance(entity, Executor)
+    assert "interface-api" in entity
+    assert entity["interface-api"] == "c"
+
+
+def test_mapping_registered_args_no_match_for_name():
+    parser = argparse.ArgumentParser()
+    generate_registry_args(parser, Executor)
+    parsed, _ = parser.parse_known_args(["--executor=woof"])
+
+    with pytest.raises(TVMCException, match='Executor "woof" is not defined'):
+        reconstruct_registry_entity(parsed, Executor)
+
+
+def test_mapping_registered_args_no_arg():
+    parser = argparse.ArgumentParser()
+    generate_registry_args(parser, Executor)
+    parsed, _ = parser.parse_known_args([])
+
+    assert reconstruct_registry_entity(parsed, Executor) == None
+
+
+def test_mapping_registered_args_mismatch_for_arg():
+    parser = argparse.ArgumentParser()
+    generate_registry_args(parser, Executor)
+    parsed, _ = parser.parse_known_args(["--executor=aot", "--executor-graph-link-params=1"])
+
+    with pytest.raises(
+        TVMCException,
+        match="Passed --executor-graph-link-params but did not specify graph executor",
+    ):
+        reconstruct_registry_entity(parsed, Executor)

--- a/tests/python/driver/tvmc/test_target.py
+++ b/tests/python/driver/tvmc/test_target.py
@@ -103,15 +103,15 @@ def test_tokenize_target_with_dashes():
 
 
 def test_parse_single_target_with_opts():
-    targets = tvmc.common.parse_target("llvm -device=arm_cpu --system-lib")
+    targets = tvmc.common.parse_target("llvm -device=arm_cpu -mattr=+fp")
 
     assert len(targets) == 1
     assert "device" in targets[0]["opts"]
-    assert "system-lib" in targets[0]["opts"]
+    assert "mattr" in targets[0]["opts"]
 
 
 def test_parse_multiple_target():
-    targets = tvmc.common.parse_target("compute-library, llvm -device=arm_cpu --system-lib")
+    targets = tvmc.common.parse_target("compute-library, llvm -device=arm_cpu")
 
     assert len(targets) == 2
     assert "compute-library" == targets[0]["name"]

--- a/tests/python/relay/test_build_module.py
+++ b/tests/python/relay/test_build_module.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from tvm.target.target import Target
+from tvm.relay.backend import Runtime, Executor
+from tvm.relay.build_module import _reconstruct_from_deprecated_options
+
+
+@pytest.mark.parametrize(
+    "target,executor,runtime",
+    [
+        [Target("c"), None, None],
+        [Target("c -runtime=c"), None, Runtime("crt")],
+        [Target("c -system-lib"), None, Runtime("cpp", {"system-lib": True})],
+        [Target("c -runtime=c -system-lib"), None, Runtime("crt", {"system-lib": True})],
+        [Target("c -executor=aot"), Executor("aot"), None],
+        [
+            Target("c -executor=aot -interface-api=c"),
+            Executor("aot", {"interface-api": "c"}),
+            None,
+        ],
+        [
+            Target("c -executor=aot -unpacked-api=1"),
+            Executor("aot", {"unpacked-api": True}),
+            None,
+        ],
+        [Target("c -executor=aot -link-params=1"), Executor("aot"), None],
+        [Target("c -link-params=1"), Executor("graph", {"link-params": True}), None],
+        [
+            Target(
+                "c -executor=aot -link-params=1 -interface-api=c"
+                "  -unpacked-api=1 -runtime=c -system-lib"
+            ),
+            Executor("aot", {"unpacked-api": True, "interface-api": "c"}),
+            Runtime("crt", {"system-lib": True}),
+        ],
+    ],
+)
+def test_deprecated_target_parameters(target, executor, runtime):
+    actual_executor, actual_runtime = _reconstruct_from_deprecated_options(target)
+    assert executor == actual_executor
+    assert runtime == actual_runtime
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/python/relay/test_executor.py
+++ b/tests/python/relay/test_executor.py
@@ -63,16 +63,16 @@ def test_create_executor_attr_type_incorrect():
 
 
 def test_list_executors():
-    assert "aot" in Executor.list_executors()
+    assert "aot" in Executor.list_registered()
 
 
 @pytest.mark.parametrize("executor", [Executor("aot"), "aot"])
 def test_list_executor_options(executor):
-    aot_options = Executor.list_executor_options(executor)
+    aot_options = Executor.list_registered_options(executor)
     assert "interface-api" in aot_options
     assert aot_options["interface-api"] == "runtime.String"
 
 
 def test_list_executor_options_not_found():
     with pytest.raises(TVMError, match='Executor "woof" is not defined'):
-        Executor.list_executor_options("woof")
+        Executor.list_registered_options("woof")

--- a/tests/python/relay/test_runtime.py
+++ b/tests/python/relay/test_runtime.py
@@ -27,13 +27,13 @@ def test_create():
 
 
 def test_create_runtime_with_options():
-    runtime = Runtime("c", {"system-lib": True})
-    assert str(runtime) == "c"
+    runtime = Runtime("crt", {"system-lib": True})
+    assert str(runtime) == "crt"
     assert runtime["system-lib"]
 
 
 def test_attr_check():
-    runtime = Runtime("c", {"system-lib": True})
+    runtime = Runtime("crt", {"system-lib": True})
     assert "woof" not in runtime
     assert "system-lib" in runtime
 
@@ -45,7 +45,7 @@ def test_create_runtime_not_found():
 
 def test_create_runtime_attr_not_found():
     with pytest.raises(TVMError, match='Attribute "woof" is not available on this Runtime'):
-        Runtime("c", {"woof": "bark"})
+        Runtime("crt", {"woof": "bark"})
 
 
 def test_create_runtime_attr_type_incorrect():
@@ -54,20 +54,20 @@ def test_create_runtime_attr_type_incorrect():
         match='Attribute "system-lib" should have type "IntImm"'
         ' but instead found "runtime.String"',
     ):
-        Runtime("c", {"system-lib": "woof"})
+        Runtime("crt", {"system-lib": "woof"})
 
 
 def test_list_runtimes():
-    assert "c" in Runtime.list_runtimes()
+    assert "crt" in Runtime.list_registered()
 
 
-@pytest.mark.parametrize("runtime", [Runtime("c"), "c"])
+@pytest.mark.parametrize("runtime", [Runtime("crt"), "crt"])
 def test_list_runtime_options(runtime):
-    aot_options = Runtime.list_runtime_options(runtime)
+    aot_options = Runtime.list_registered_options(runtime)
     assert "system-lib" in aot_options
     assert aot_options["system-lib"] == "IntImm"
 
 
 def test_list_runtime_options_not_found():
     with pytest.raises(TVMError, match='Runtime "woof" is not defined'):
-        Runtime.list_runtime_options("woof")
+        Runtime.list_registered_options("woof")

--- a/tests/python/unittest/test_auto_scheduler_search_task.py
+++ b/tests/python/unittest/test_auto_scheduler_search_task.py
@@ -114,7 +114,7 @@ def test_search_task_record():
     assert new_task.task_input_names[1] == "test_input_1"
 
     # Log with version 0.5
-    v5_log = """["[\\\"matmul_auto_scheduler_test\\\", 64, 64, 64]", "llvm -keys=cpu -link-params=0", [6, 64, 64, 0, 0, 0, 0, 0], "", 1]"""
+    v5_log = """["[\\\"matmul_auto_scheduler_test\\\", 64, 64, 64]", "llvm -keys=cpu", [6, 64, 64, 0, 0, 0, 0, 0], "", 1]"""
     new_task = auto_scheduler._ffi_api.DeserializeSearchTask(v5_log)
     assert task.workload_key == new_task.workload_key
     assert str(task.target) == str(new_task.target)
@@ -191,7 +191,7 @@ def test_recover_measure_input_with_task_input():
     assert new_task.task_input_names[1] == "test_input_1"
 
     # Log with version 0.5
-    v5_log = """{"i": [["[\\\"matmul_auto_scheduler_test\\\", 512, 512, 512]", "llvm -keys=cpu -link-params=0", [6, 64, 64, 0, 0, 0, 0, 0], "", 1], [[], []]], "r": [[0.1], 0, 0.2, 1], "v": "v0.6"}"""
+    v5_log = """{"i": [["[\\\"matmul_auto_scheduler_test\\\", 512, 512, 512]", "llvm -keys=cpu", [6, 64, 64, 0, 0, 0, 0, 0], "", 1], [[], []]], "r": [[0.1], 0, 0.2, 1], "v": "v0.6"}"""
     measure_log = auto_scheduler.measure_record.load_record_from_string(v5_log)
     new_task = measure_log[0].task
     assert task.workload_key == new_task.workload_key

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -25,7 +25,7 @@ import pytest
 
 import tvm
 import tvm.relay
-from tvm.relay.backend import executor_factory
+from tvm.relay.backend import Executor, Runtime
 from tvm.relay.testing import byoc
 import tvm.runtime.module
 import tvm.testing
@@ -42,7 +42,13 @@ def test_export_operator_model_library_format():
         B = tvm.te.placeholder((1,), dtype="int8")
         C = tvm.te.compute(A.shape, lambda i: A[i] + B[0], name="C")
         sched = tvm.te.create_schedule(C.op)
-        mod = tvm.build(sched, [A, B, C], tvm.target.Target(target, target), name="add")
+        mod = tvm.build(
+            sched,
+            [A, B, C],
+            tvm.target.Target(target, target),
+            runtime=Runtime("crt", {"system-lib": True}),
+            name="add",
+        )
 
     temp_dir = utils.tempdir()
     mlf_tar_path = temp_dir.relpath("lib.tar")
@@ -81,7 +87,7 @@ def test_export_operator_model_library_format():
 
     assert (
         len(mod.ir_module_by_target) == 1
-    ), f"expect 1 ir_model_by_target: {ir_module_by_target!r}"
+    ), f"expect 1 ir_model_by_target: {mod.ir_module_by_target!r}"
     for target, ir_mod in mod.ir_module_by_target.items():
         assert int(tvm.runtime.ndarray.device(str(target)).device_type) == 1
         with open(os.path.join(extract_dir, "src", "tir-1.txt")) as tir_f:
@@ -102,20 +108,15 @@ def validate_graph_json(extract_dir, factory):
 
 @tvm.testing.requires_micro
 @pytest.mark.parametrize(
-    "executor,target,should_generate_interface",
+    "executor,runtime,should_generate_interface",
     [
-        ("graph", tvm.target.target.micro("host"), False),
-        ("aot", tvm.target.target.micro("host", options="-executor=aot"), False),
-        (
-            "aot",
-            tvm.target.target.micro(
-                "host", options="-executor=aot --unpacked-api=1 --interface-api=c"
-            ),
-            True,
-        ),
+        (Executor("graph"), Runtime("crt", {"system-lib": True}), False),
+        (Executor("aot"), Runtime("crt"), False),
+        (Executor("aot", {"unpacked-api": True, "interface-api": "c"}), Runtime("crt"), True),
     ],
 )
-def test_export_model_library_format_c(executor, target, should_generate_interface):
+def test_export_model_library_format_c(executor, runtime, should_generate_interface):
+    target = tvm.target.target.micro("host")
     with utils.TempDirectory.set_keep_for_debug(True):
         with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
             relay_mod = tvm.parser.fromtext(
@@ -129,6 +130,8 @@ def test_export_model_library_format_c(executor, target, should_generate_interfa
             factory = tvm.relay.build(
                 relay_mod,
                 target,
+                executor=executor,
+                runtime=runtime,
                 mod_name="add",
                 params={"c": numpy.array([[2.0, 4.0]], dtype="float32")},
             )
@@ -153,7 +156,7 @@ def test_export_model_library_format_c(executor, target, should_generate_interfa
             )
             assert (datetime.datetime.now() - export_datetime) < datetime.timedelta(seconds=60 * 5)
             assert metadata["target"] == {"1": str(target)}
-            if executor == "graph":
+            if str(executor) == "graph":
                 assert metadata["memory"]["sids"] == [
                     {"storage_id": 0, "size_bytes": 2, "input_binding": "a"},
                     {"storage_id": 1, "size_bytes": 8, "input_binding": "b"},
@@ -182,7 +185,7 @@ def test_export_model_library_format_c(executor, target, should_generate_interfa
             os.path.join(extract_dir, "codegen", "host", "include", "tvmgen_add.h")
         )
 
-        if executor == "graph":
+        if str(executor) == "graph":
             validate_graph_json(extract_dir, factory)
 
         with open(os.path.join(extract_dir, "src", "relay.txt")) as relay_f:
@@ -211,6 +214,7 @@ def test_export_model_library_format_llvm():
             factory = tvm.relay.build(
                 relay_mod,
                 target,
+                runtime=Runtime("crt", {"system-lib": True}),
                 mod_name="add",
                 params={"c": numpy.array([[2.0, 4.0]], dtype="float32")},
             )
@@ -271,10 +275,11 @@ def test_export_model_library_format_llvm():
 
 @tvm.testing.requires_micro
 @pytest.mark.parametrize(
-    "target",
-    [tvm.target.target.micro("host"), tvm.target.target.micro("host", options="-executor=aot")],
+    "executor,runtime",
+    [(Executor("graph"), Runtime("crt", {"system-lib": True})), (Executor("aot"), Runtime("crt"))],
 )
-def test_export_model_library_format_workspace(target):
+def test_export_model_library_format_workspace(executor, runtime):
+    target = tvm.target.target.micro("host")
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         relay_mod = tvm.parser.fromtext(
             """
@@ -288,7 +293,13 @@ def test_export_model_library_format_workspace(target):
             }
             """
         )
-        factory = tvm.relay.build(relay_mod, target, mod_name="qnn_conv2d")
+        factory = tvm.relay.build(
+            relay_mod,
+            target,
+            executor=executor,
+            runtime=runtime,
+            mod_name="qnn_conv2d",
+        )
 
     temp_dir = utils.tempdir()
     mlf_tar_path = temp_dir.relpath("lib.tar")
@@ -381,7 +392,7 @@ def test_export_byoc_c_module():
     mod = tvm.relay.transform.InferType()(mod)
 
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
-        factory = tvm.relay.build(mod, tvm.target.target.micro("host"))
+        factory = tvm.relay.build(mod, tvm.target.target.micro("host"), runtime=Runtime("crt"))
 
     temp_dir = utils.tempdir()
     mlf_tar_path = temp_dir.relpath("lib.tar")

--- a/tests/python/unittest/test_runtime_module_load.py
+++ b/tests/python/unittest/test_runtime_module_load.py
@@ -18,11 +18,11 @@ import tvm
 from tvm import te
 from tvm.contrib import cc, utils
 import ctypes
-import os
 import sys
 import numpy as np
 import subprocess
 import tvm.testing
+from tvm.relay.backend import Runtime
 
 runtime_py = """
 import os
@@ -117,7 +117,8 @@ def test_device_module_dump():
         temp = utils.tempdir()
         name = "myadd_%s" % device
         if sys.platform == "darwin" or sys.platform.startswith("linux"):
-            f = tvm.build(s, [A, B], device, "llvm -system-lib", name=name)
+            runtime = Runtime("cpp", {"system-lib": True})
+            f = tvm.build(s, [A, B], device, "llvm", runtime=runtime, name=name)
         elif sys.platform == "win32":
             f = tvm.build(s, [A, B], device, "llvm", name=name)
         else:
@@ -198,8 +199,9 @@ def test_combine_module_llvm():
             print("Skip because llvm is not enabled")
             return
         temp = utils.tempdir()
-        fadd1 = tvm.build(s, [A, B], "llvm -system-lib", name="myadd1")
-        fadd2 = tvm.build(s, [A, B], "llvm -system-lib", name="myadd2")
+        runtime = Runtime("cpp", {"system-lib": True})
+        fadd1 = tvm.build(s, [A, B], "llvm", runtime=runtime, name="myadd1")
+        fadd2 = tvm.build(s, [A, B], "llvm", runtime=runtime, name="myadd2")
         path1 = temp.relpath("myadd1.o")
         path2 = temp.relpath("myadd2.o")
         path_dso = temp.relpath("mylib.so")
@@ -207,7 +209,7 @@ def test_combine_module_llvm():
         fadd2.save(path2)
         cc.create_shared(path_dso, [path1, path2])
         # Load dll, will trigger system library registration
-        dll = ctypes.CDLL(path_dso)
+        ctypes.CDLL(path_dso)
         # Load the system wide library
         mm = tvm.runtime.system_lib()
         a = tvm.nd.array(np.random.uniform(size=nn).astype(A.dtype), dev)

--- a/tests/python/unittest/test_runtime_rpc.py
+++ b/tests/python/unittest/test_runtime_rpc.py
@@ -17,7 +17,6 @@
 import tvm
 from tvm import te
 import tvm.testing
-import logging
 import multiprocessing
 import os
 import stat
@@ -27,6 +26,7 @@ import time
 import pytest
 import numpy as np
 from tvm import rpc
+from tvm.relay.backend import Runtime
 from tvm.contrib import utils, cc
 from tvm.rpc.tracker import Tracker
 from tvm.rpc.proxy import Proxy
@@ -267,7 +267,8 @@ def test_rpc_remote_module():
             return
         # export to minrpc
         temp = utils.tempdir()
-        f = tvm.build(s, [A, B], "llvm --system-lib", name="myadd")
+        runtime = Runtime("cpp", {"system-lib": True})
+        f = tvm.build(s, [A, B], "llvm", name="myadd", runtime=runtime)
         path_minrpc = temp.relpath("dev_lib.minrpc")
         f.export_library(path_minrpc, rpc.with_minrpc(cc.create_executable))
 

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -22,10 +22,10 @@ import sys
 import tvm
 import tvm.testing
 from tvm import te
-from tvm import topi
+from tvm.relay.backend import Runtime
 from tvm.contrib import utils, clang
 import numpy as np
-import ctypes
+
 import math
 import re
 import pytest
@@ -747,7 +747,12 @@ def test_llvm_crt_static_lib():
     B = te.placeholder((32,), dtype="bfloat16")
     d = te.compute((32,), lambda x: A[x] + B[x])
     sch = te.create_schedule(d.op)
-    module = tvm.build(sch, [A, B, d], target=tvm.target.Target("llvm --system-lib --runtime=c"))
+    module = tvm.build(
+        sch,
+        [A, B, d],
+        target=tvm.target.Target("llvm"),
+        runtime=Runtime("crt", {"system-lib": True}),
+    )
     print(module.get_source())
     module.save("test.o")
 

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -104,7 +104,6 @@ def test_target_config():
         "keys": ["arm_cpu", "cpu"],
         "device": "arm_cpu",
         "libs": ["cblas"],
-        "system-lib": True,
         "mfloat-abi": "hard",
         "mattr": ["+neon", "-avx512f"],
     }
@@ -117,7 +116,6 @@ def test_target_config():
         assert all([key in target.keys for key in ["arm_cpu", "cpu"]])
         assert target.device_name == "arm_cpu"
         assert target.libs == ["cblas"]
-        assert "system-lib" in str(target)
         assert target.attrs["mfloat-abi"] == "hard"
         assert all([attr in target.attrs["mattr"] for attr in ["+neon", "-avx512f"]])
 
@@ -303,14 +301,14 @@ def test_check_and_update_host_consist_3():
 
 
 def test_target_attr_bool_value():
-    target0 = Target("llvm --link-params=True")
-    assert target0.attrs["link-params"] == 1
-    target1 = Target("llvm --link-params=true")
-    assert target1.attrs["link-params"] == 1
-    target2 = Target("llvm --link-params=False")
-    assert target2.attrs["link-params"] == 0
-    target3 = Target("llvm --link-params=false")
-    assert target3.attrs["link-params"] == 0
+    target0 = Target("vulkan --supports_float16=True")
+    assert target0.attrs["supports_float16"] == 1
+    target1 = Target("vulkan --supports_float16=true")
+    assert target1.attrs["supports_float16"] == 1
+    target2 = Target("vulkan --supports_float16=False")
+    assert target2.attrs["supports_float16"] == 0
+    target3 = Target("vulkan --supports_float16=false")
+    assert target3.attrs["supports_float16"] == 0
 
 
 if __name__ == "__main__":

--- a/web/tests/python/prepare_test_libs.py
+++ b/web/tests/python/prepare_test_libs.py
@@ -19,18 +19,20 @@
 import tvm
 from tvm import te
 from tvm.contrib import emcc
+from tvm.relay.backend import Runtime
 import os
 
 
 def prepare_test_libs(base_path):
-    target = "llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
+    runtime = Runtime("cpp", {"system-lib": True})
+    target = "llvm -mtriple=wasm32-unknown-unknown-wasm"
     if not tvm.runtime.enabled(target):
         raise RuntimeError("Target %s is not enbaled" % target)
     n = te.var("n")
     A = te.placeholder((n,), name="A")
     B = te.compute(A.shape, lambda *i: A(*i) + 1.0, name="B")
     s = te.create_schedule(B.op)
-    fadd = tvm.build(s, [A, B], target, name="add_one")
+    fadd = tvm.build(s, [A, B], target, runtime=runtime, name="add_one")
 
     wasm_path = os.path.join(base_path, "test_addone.wasm")
     fadd.export_library(wasm_path, emcc.create_tvmjs_wasm)

--- a/web/tests/python/webgpu_rpc_test.py
+++ b/web/tests/python/webgpu_rpc_test.py
@@ -24,6 +24,7 @@ import tvm
 from tvm import te
 from tvm import rpc
 from tvm.contrib import utils, emcc
+from tvm.relay.backend import Runtime
 import numpy as np
 
 proxy_host = "127.0.0.1"
@@ -34,9 +35,8 @@ def test_rpc():
     if not tvm.runtime.enabled("rpc"):
         return
     # generate the wasm library
-    target = tvm.target.Target(
-        "webgpu", host="llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
-    )
+    target = tvm.target.Target("webgpu", host="llvm -mtriple=wasm32-unknown-unknown-wasm")
+    runtime = Runtime("cpp", {"system-lib": True})
     if not tvm.runtime.enabled(target_host):
         raise RuntimeError("Target %s is not enbaled" % target_host)
 
@@ -50,7 +50,7 @@ def test_rpc():
     s[B].bind(xi, te.thread_axis("threadIdx.x"))
     s[B].bind(xo, te.thread_axis("blockIdx.x"))
 
-    fadd = tvm.build(s, [A, B], target, name="addone")
+    fadd = tvm.build(s, [A, B], target, runtime=runtime, name="addone")
     temp = utils.tempdir()
 
     wasm_path = temp.relpath("addone_gpu.wasm")


### PR DESCRIPTION
This introduces `executor` and `runtime` into the various entrypoints but also into `tvmc` as `--executor` and `--runtime`. This touchs a lot of files and I've tried to update anywhere as necessary.

Notable, executor code generators now accept the initial `IRModule` rather than creating
it themselves so it can be annotated once.

Validated the demo application continues to classify the tabby cat with
new CLI options.

Builds on https://github.com/apache/tvm/pull/9246