### PR TITLE
[PyTest] Sort by test location, but not parametrization

### DIFF
--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -253,7 +253,13 @@ def _sort_tests(items):
     Should be called from pytest_collection_modifyitems.
 
     """
-    items.sort(key=lambda item: item.location)
+
+    def sort_key(item):
+        filename, lineno, test_name = item.location
+        test_name = test_name.split("[")[0]
+        return filename, lineno, test_name
+
+    items.sort(key=sort_key)
 
 
 def _target_to_requirement(target):


### PR DESCRIPTION
A follow-up from https://github.com/apache/tvm/pull/9188.  The `item.location` tuple contains `(filename, line_number, test_name)`, where the `test_name` includes a string representation of all parameters.  This change preserves pytest's sorting of parametrized values within a parametrized test, rather than sorting by strings.