### PR TITLE
BUG: FoldConstant can see through on_device annotations.

### DIFF
--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -84,11 +84,11 @@ struct VMFunction {
   /*! \brief The size of the frame for this function */
   Index register_file_size;
   /*! \brief The device type of each parameter for this function. */
-  std::vector<DLDeviceType> params_device_type;
+  std::vector<Index> params_device_type;
 
   VMFunction(const std::string& name, std::vector<std::string> params,
              const std::vector<Instruction>& instructions, Index register_file_size,
-             const std::vector<DLDeviceType> params_device_type = {})
+             const std::vector<Index> params_device_type = {})
       : name(name),
         params(params),
         instructions(instructions),

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -187,9 +187,12 @@ void WarnIfMalformed(const IRModule& mod, relay::Function func) {
   auto fv = relay::FreeVars(func);
   auto ftv = relay::FreeTypeVars(func, mod);
   // TODO(@jroesch): refactor to use diagnostic context
-  ICHECK_EQ(fv.size(), 0) << "There are free variables: " << fv << std::endl;
-  ICHECK_EQ(ftv.size(), 0) << "There are free type variables: " << fv
-                           << " in function: " << AsText(func, false);
+  ICHECK_EQ(fv.size(), 0) << "Function:" << std::endl
+                          << PrettyPrint(func) << std::endl
+                          << "contains free variables: " << fv;
+  ICHECK_EQ(ftv.size(), 0) << "Function:" << std::endl
+                           << PrettyPrint(func) << std::endl
+                           << "contains free type variables: " << fv;
 }
 
 void IRModuleNode::Add(const GlobalVar& var, const BaseFunc& f, bool update) {

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -562,7 +562,7 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     BaseFunc prim_func = ResolveToPrimitive(new_value);
 
     if (prim_func.defined() && !prim_func->IsInstance<tir::PrimFuncNode>()) {
-      // Remember let var is bound to (possibly indirectly) to a non-tir primitive.
+      // Remember let var is bound to (possibly indirectly) a non-tir primitive.
       Function func = Downcast<Function>(prim_func);
       primitive_functions_.emplace(var, func);
     }
@@ -896,8 +896,6 @@ void UpdateFunctionMetadata(Function relay_func,
 
 IRModule LowerTE(const IRModule& module, TargetMap targets, const String& module_name,
                  std::function<void(Function)> process_fn) {
-  DLOG(INFO) << "lowering module:\n" << PrettyPrint(module);
-
   TECompiler compiler;
 
   auto updated_module = LowerTensorExpr(targets, module_name, compiler, process_fn)(module);

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -304,7 +304,13 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
       }
       VisitExpr(func);
     }
-    return VMFunction(var->name_hint, params_, instructions_, registers_num_, params_device_type);
+    std::vector<Index> params_device_type_index;
+    params_device_type_index.reserve(params_device_type.size());
+    for (auto device_type : params_device_type) {
+      params_device_type_index.push_back(static_cast<Index>(device_type));
+    }
+    return VMFunction(var->name_hint, params_, instructions_, registers_num_,
+                      params_device_type_index);
   }
 
   /*! \brief Attrs objects for each op. */
@@ -317,7 +323,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
   size_t NewRegister() { return registers_num_++; }
 
   inline void Emit(const Instruction& instr) {
-    VLOG(1) << "VMCompiler::Emit: instr=" << instr;
+    VLOG(2) << "VMCompiler::Emit: instr=" << instr;
     ICHECK((int)instr.op < 100) << "Invalid opcode " << (int)instr.op;
     switch (instr.op) {
       case Opcode::AllocADT:
@@ -703,7 +709,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
       auto global = GetRef<GlobalVar>(global_node);
       auto it = context_->global_map.find(global);
       ICHECK(it != context_->global_map.end());
-      VLOG(1) << "VisitExpr_: generating invoke for " << global->name_hint
+      VLOG(2) << "VisitExpr_: generating invoke for " << global->name_hint
               << " with func_index=" << it->second;
 
       // TODO(tvm-team):
@@ -941,12 +947,6 @@ void VMCompiler::Lower(IRModule mod, const TargetsMap& targets, const tvm::Targe
     }
   }
 
-#if USE_RELAY_DEBUG
-  for (auto vm_func : exec_->functions) {
-    VLOG(1) << vm_func << "-------------";
-  }
-#endif  // USE_RELAY_DEBUG
-
   // populate constants
   for (auto data : context_.constants) {
     exec_->constants.push_back(data);
@@ -966,6 +966,12 @@ void VMCompiler::Lower(IRModule mod, const TargetsMap& targets, const tvm::Targe
   for (const auto& cfunc : context_.cached_funcs) {
     exec_->primitive_map.insert({cfunc->prim_fn_var->name_hint, primitive_index++});
   }
+
+#if USE_RELAY_DEBUG
+  for (const auto& vm_func : exec_->functions) {
+    VLOG(1) << vm_func << "-------------";
+  }
+#endif  // USE_RELAY_DEBUG
 
   backend::UpdateAutoSchedulerOpWeights(context_.compiler);
 }
@@ -1018,6 +1024,7 @@ transform::Sequential MemoryOpt(tvm::Target host_target, TargetsMap targets) {
 
 IRModule VMCompiler::OptimizeModule(IRModule mod, const TargetsMap& targets_arg,
                                     const Target& target_host_arg) {
+  VLOG_CONTEXT << "VMCompiler::OptimizeModule";
   TargetsMap targets = targets_arg;
   Target target_host = target_host_arg;
   CheckAndUpdateHostConsistency(&targets, &target_host);

--- a/src/relay/backend/vm/inline_primitives.cc
+++ b/src/relay/backend/vm/inline_primitives.cc
@@ -87,7 +87,7 @@ struct PrimitiveInliner : ExprMutator {
     // in w(...)
     while ((var_node = op.as<VarNode>())) {
       auto var = GetRef<Var>(var_node);
-      DLOG(INFO) << "Var: " << var << std::endl;
+      VLOG(1) << "Var: " << var << std::endl;
       auto it = var_map.find(GetRef<Var>(var_node));
       if (it != var_map.end()) {
         op = it->second;

--- a/src/relay/op/annotation/annotation.cc
+++ b/src/relay/op/annotation/annotation.cc
@@ -76,6 +76,16 @@ Expr MaybeOnDevice(Expr expr, DLDeviceType device_type, bool is_fixed) {
     // by the function's attributes.
     return expr;
   }
+  OnDeviceProps props = GetOnDeviceProps(expr);
+  if (props.body.defined()) {
+    // Don't nest on_devices.
+    // If the inner and outer device types differ then we need to be careful:
+    //  - If the inner on_device is_fixed then it disagrees with the outer.
+    //  - If the outer on_device is_fixed then it implies a hidden device_copy
+    // Otherwise just use the inner device type and ignore the outer.
+    ICHECK(props.device_type == device_type || (!is_fixed && !props.is_fixed));
+    return OnDevice(props.body, device_type, is_fixed || props.is_fixed);
+  }
   return OnDevice(expr, device_type, is_fixed);
 }
 

--- a/src/relay/transforms/device_aware_visitors.cc
+++ b/src/relay/transforms/device_aware_visitors.cc
@@ -262,7 +262,7 @@ Expr DeviceAwareExprMutator::VisitExpr_(const CallNode* call_node) {
     Expr expr = VisitExpr(props.body);
     // Leaving lexical scope of "on_device" call.
     PopDeviceType();
-    return OnDevice(expr, props.device_type, props.is_fixed);
+    return MaybeOnDevice(expr, props.device_type, props.is_fixed);
   } else {
     return DeviceAwareVisitExpr_(call_node);
   }

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file src/relay/analysis/device_planner.cc
+ * \file src/relay/transforms/device_planner.cc
  * \brief Determines a unique device to hold the result of every Relay sub-expression.
  *
  * We say a Relay expression E is 'on device D' if the result of executing E is stored on D.

--- a/src/relay/transforms/memory_alloc.cc
+++ b/src/relay/transforms/memory_alloc.cc
@@ -415,7 +415,6 @@ Pass ManifestAlloc(Target target_host, Map<tvm::Integer, tvm::Target> targets) {
   CheckAndUpdateHostConsistency(&targets, &target_host);
   return tvm::transform::CreateModulePass(
       [=](IRModule mod, const PassContext& pass_ctx) {
-        DLOG(INFO) << "tvm::relay::transform::ManifestAlloc";
         // We need to mutate module, therefore making a copy of it.
         mod.CopyOnWrite();
         mod->ImportFromStd("core.rly");

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -112,14 +112,14 @@ class CUDADeviceAPI final : public DeviceAPI {
     ICHECK_EQ(256 % alignment, 0U) << "CUDA space is aligned at 256 bytes";
     void* ret;
     if (dev.device_type == kDLCUDAHost) {
-      DLOG(INFO) << "allocating " << nbytes << "bytes on host";
+      VLOG(1) << "allocating " << nbytes << "bytes on host";
       CUDA_CALL(cudaMallocHost(&ret, nbytes));
     } else {
       CUDA_CALL(cudaSetDevice(dev.device_id));
       size_t free_mem, total_mem;
       CUDA_CALL(cudaMemGetInfo(&free_mem, &total_mem));
-      DLOG(INFO) << "allocating " << nbytes << " bytes on device, with " << free_mem
-                 << " bytes currently free out of " << total_mem << " bytes available";
+      VLOG(1) << "allocating " << nbytes << " bytes on device, with " << free_mem
+              << " bytes currently free out of " << total_mem << " bytes available";
       CUDA_CALL(cudaMalloc(&ret, nbytes));
     }
     return ret;
@@ -127,11 +127,11 @@ class CUDADeviceAPI final : public DeviceAPI {
 
   void FreeDataSpace(Device dev, void* ptr) final {
     if (dev.device_type == kDLCUDAHost) {
-      DLOG(INFO) << "freeing host memory";
+      VLOG(1) << "freeing host memory";
       CUDA_CALL(cudaFreeHost(ptr));
     } else {
       CUDA_CALL(cudaSetDevice(dev.device_id));
-      DLOG(INFO) << "freeing device memory";
+      VLOG(1) << "freeing device memory";
       CUDA_CALL(cudaFree(ptr));
     }
   }

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -308,7 +308,7 @@ void Executable::SavePrimitiveOpNames(dmlc::Stream* strm) {
 VMInstructionSerializer SerializeInstruction(const Instruction& instr) {
   std::vector<Index> fields;
   // Save the opcode.
-  DLOG(INFO) << "Serializing: " << instr << std::endl;
+  VLOG(1) << "Serializing: " << instr << std::endl;
   switch (instr.op) {
     case Opcode::Move: {
       // Number of fields = 2

--- a/src/runtime/vm/memory_manager.cc
+++ b/src/runtime/vm/memory_manager.cc
@@ -119,14 +119,14 @@ Allocator* MemoryManager::GetOrCreateAllocator(Device dev, AllocatorType type) {
     std::unique_ptr<Allocator> alloc;
     switch (type) {
       case kNaive: {
-        DLOG(INFO) << "New naive allocator for " << DeviceName(dev.device_type) << "("
-                   << dev.device_id << ")";
+        VLOG(1) << "New naive allocator for " << DeviceName(dev.device_type) << "(" << dev.device_id
+                << ")";
         alloc.reset(new NaiveAllocator(dev));
         break;
       }
       case kPooled: {
-        DLOG(INFO) << "New pooled allocator for " << DeviceName(dev.device_type) << "("
-                   << dev.device_id << ")";
+        VLOG(1) << "New pooled allocator for " << DeviceName(dev.device_type) << "("
+                << dev.device_id << ")";
         alloc.reset(new PooledAllocator(dev));
         break;
       }

--- a/src/runtime/vm/pooled_allocator.h
+++ b/src/runtime/vm/pooled_allocator.h
@@ -67,7 +67,7 @@ class PooledAllocator final : public Allocator {
     }
 
     used_memory_.fetch_add(size, std::memory_order_relaxed);
-    DLOG(INFO) << "allocate " << size << " B, used memory " << used_memory_ << " B";
+    VLOG(1) << "allocate " << size << " B, used memory " << used_memory_ << " B";
     return buf;
   }
 
@@ -77,7 +77,7 @@ class PooledAllocator final : public Allocator {
       memory_pool_.emplace(buffer.size, std::vector<Buffer>{});
     }
     memory_pool_.at(buffer.size).push_back(buffer);
-    DLOG(INFO) << "reclaim buffer " << buffer.size;
+    VLOG(1) << "reclaim buffer " << buffer.size;
   }
 
   size_t UsedMemory() const override { return used_memory_.load(std::memory_order_relaxed); }
@@ -93,7 +93,7 @@ class PooledAllocator final : public Allocator {
     }
     memory_pool_.clear();
     used_memory_ = 0;
-    DLOG(INFO) << "release all buffers";
+    VLOG(1) << "release all buffers";
   }
 
  private:

--- a/src/runtime/vm/serialize_utils.h
+++ b/src/runtime/vm/serialize_utils.h
@@ -59,13 +59,13 @@ struct VMFunctionSerializer {
   /*! \brief The parameters of the VMFunction. */
   std::vector<std::string> params;
   /*! \brief The device type of each parameter of the VMFunction. */
-  std::vector<DLDeviceType> params_device_type;
+  std::vector<Index> params_device_type;
 
   VMFunctionSerializer() = default;
 
   VMFunctionSerializer(const std::string& name, Index register_file_size, size_t num_instructions,
                        const std::vector<std::string>& params,
-                       const std::vector<DLDeviceType>& params_device_type)
+                       const std::vector<Index>& params_device_type)
       : name(name),
         register_file_size(register_file_size),
         num_instructions(num_instructions),

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -1526,4 +1526,7 @@ def test_empty_subgraph(run_module):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    # sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    test_maskrcnn_resnet50(run_module)

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -523,3 +523,9 @@ def test_compile_check_configs_composite_target(mock_pkg, mock_pc, mock_fe, mock
         config={"relay.ext.mock.options": {"testopt": "value"}},
         disabled_pass=None,
     )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relay/test_pass_fold_constant.py
+++ b/tests/python/relay/test_pass_fold_constant.py
@@ -22,6 +22,16 @@ from tvm.relay.build_module import bind_params_by_name
 from tvm.relay.testing import run_infer_type, create_workload
 
 
+def annot_func(f):
+    """Returns f with arg/result device attributes for the argument and result."""
+    return relay.op.annotation.function_on_device(f, [tvm.cpu()], tvm.cpu())
+
+
+def annot_expr(e):
+    """Returns e wrapped with an on_device annotation."""
+    return relay.op.annotation.on_device(e, tvm.cpu(), is_fixed=True)
+
+
 def run_opt_pass(expr, opt_pass):
     assert isinstance(opt_pass, tvm.transform.Pass)
 
@@ -75,7 +85,35 @@ def test_fold_const():
     with tvm.target.Target("cuda"):
         zz = run_opt_pass(before(), transform.FoldConstant())
     zexpected = run_opt_pass(expected(), transform.InferType())
-    assert tvm.ir.structural_equal(zz, zexpected)
+    tvm.ir.assert_structural_equal(zz, zexpected)
+
+
+def test_fold_const_with_on_device():
+    """Make sure on_device annotations don't get in the way of constant folding"""
+    c_data = np.array([1, 2, 3]).astype("float32")
+    t = relay.TensorType([1, 2, 3], "float32")
+
+    def before():
+        c = relay.const(c_data)
+        x = relay.var("x", t)
+        y = relay.add(c, c)
+        y = relay.multiply(y, relay.const(2, "float32"))
+        y = relay.add(x, y)
+        z = relay.add(y, c)
+        f = relay.Function([x], z)
+        return annot_func(f)
+
+    def expected():
+        x = relay.var("x", t)
+        c_folded = (c_data + c_data) * 2
+        y = relay.add(x, relay.const(c_folded))
+        z = relay.add(y, relay.const(c_data))
+        f = relay.Function([x], z)
+        return annot_func(f)
+
+    zz = run_opt_pass(before(), transform.FoldConstant())
+    zexpected = run_opt_pass(expected(), transform.InferType())
+    tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_let():
@@ -101,7 +139,37 @@ def test_fold_let():
 
     zz = run_opt_pass(before(), transform.FoldConstant())
     zexpected = run_opt_pass(expected(), transform.InferType())
-    assert tvm.ir.structural_equal(zz, zexpected)
+    tvm.ir.assert_structural_equal(zz, zexpected)
+
+
+def test_fold_let_with_on_device():
+    """Make sure on_device annotations don't get in the way of constant folding,
+    and inlined constants bring their annotations with them."""
+    c_data = np.array(1).astype("float32")
+    t = relay.TensorType([1], "float32")
+
+    def before():
+        sb = relay.ScopeBuilder()
+        x = relay.var("x", t)
+        t1 = sb.let("t1", annot_expr(relay.const(c_data)))
+        t2 = sb.let("t2", annot_expr(relay.add(t1, t1)))
+        t3 = sb.let("t3", annot_expr(relay.add(t2, x)))
+        sb.ret(t3)
+        f = relay.Function([x], sb.get())
+        return annot_func(f)
+
+    def expected():
+        sb = relay.ScopeBuilder()
+        x = relay.var("x", t)
+        c_folded = c_data + c_data
+        t3 = sb.let("t3", annot_expr(relay.add(annot_expr(relay.const(c_folded)), x)))
+        sb.ret(t3)
+        f = relay.Function([x], sb.get())
+        return annot_func(f)
+
+    zz = run_opt_pass(before(), transform.FoldConstant())
+    zexpected = run_opt_pass(expected(), transform.InferType())
+    tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_tuple():
@@ -124,7 +192,7 @@ def test_fold_tuple():
 
     zz = run_opt_pass(before(), transform.FoldConstant())
     zexpected = run_opt_pass(expected(), transform.InferType())
-    assert tvm.ir.structural_equal(zz, zexpected)
+    tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_concat():
@@ -143,7 +211,7 @@ def test_fold_concat():
 
     zz = run_opt_pass(before(), transform.FoldConstant())
     zexpected = run_opt_pass(expected(), transform.InferType())
-    assert tvm.ir.structural_equal(zz, zexpected)
+    tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_if():
@@ -164,7 +232,7 @@ def test_fold_if():
 
     zz = run_opt_pass(before(), transform.FoldConstant())
     zexpected = run_opt_pass(expected(), transform.InferType())
-    assert tvm.ir.structural_equal(zz, zexpected)
+    tvm.ir.assert_structural_equal(zz, zexpected)
 
     cond_data = np.array(0).astype("bool")
 
@@ -182,7 +250,7 @@ def test_fold_if():
 
     zz = run_opt_pass(before(), transform.FoldConstant())
     zexpected = run_opt_pass(expected(), transform.InferType())
-    assert tvm.ir.structural_equal(zz, zexpected)
+    tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_shape_of():
@@ -204,7 +272,7 @@ def test_fold_shape_of():
     for dtype in ["int32", "float32"]:
         zz = run_opt_pass(before(dtype), transform.FoldConstant())
         zexpected = run_opt_pass(expected(dtype), transform.InferType())
-        assert tvm.ir.structural_equal(zz, zexpected)
+        tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_ndarray_size():
@@ -227,7 +295,7 @@ def test_fold_ndarray_size():
     for dtype in ["int32", "float32"]:
         zz = run_opt_pass(before(dtype), transform.FoldConstant())
         zexpected = run_opt_pass(expected(dtype), transform.InferType())
-        assert tvm.ir.structural_equal(zz, zexpected)
+        tvm.ir.assert_structural_equal(zz, zexpected)
 
 
 def test_fold_batch_norm():
@@ -272,7 +340,7 @@ def test_fold_batch_norm():
         mod = remove_bn_pass(mod)
 
     expect = run_infer_type(expected())
-    assert tvm.ir.structural_equal(mod["main"], expect)
+    tvm.ir.assert_structural_equal(mod["main"], expect)
 
 
 def test_fold_dropout():
@@ -295,15 +363,11 @@ def test_fold_dropout():
     with tvm.transform.PassContext(opt_level=3):
         after_mod = passes(before_mod)
 
-    assert tvm.ir.structural_equal(run_infer_type(before_mod["main"]), after_mod["main"])
+    tvm.ir.assert_structural_equal(run_infer_type(before_mod["main"]), after_mod["main"])
 
 
 if __name__ == "__main__":
-    test_fold_const()
-    test_fold_let()
-    test_fold_tuple()
-    test_fold_concat()
-    test_fold_shape_of()
-    test_fold_batch_norm()
-    test_fold_ndarray_size()
-    test_fold_dropout()
+    import sys
+    import pytest
+
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relay/test_prng.py
+++ b/tests/python/relay/test_prng.py
@@ -166,7 +166,6 @@ def test_threefry_generate_out_size():
 
 
 if __name__ == "__main__":
-    test_threefry_repeatability(tvm.target.Target("llvm"), tvm.device("cpu"))
-    test_threefry_split(tvm.target.Target("llvm"), tvm.device("cpu"))
-    test_threefry_sequential_generate(tvm.target.Target("llvm"), tvm.device("cpu"))
-    test_threefry_sequential_generate_remaining(tvm.target.Target("llvm"), tvm.device("cpu"))
+    import sys
+
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -17,7 +17,6 @@
 
 import random
 import re
-import sys
 import threading
 
 import numpy as np
@@ -557,4 +556,6 @@ def test_shared_mem_alloc(target, dev):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    import sys
+
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
BUG: Make sure FoldConstant can inline constants underneath on_device annotations

After device planning and conversion to ANF we can end up with:
```
  let %x = on_device(constant, device_type=D)
  ...
  @f(..., %x, ...)
```
where the device D is not the same as the device for the let-expression itself. (eg D may be the CPU, %x a shape, and @f an allocation primitive that requires shapes to reside on the CPU). That's all consistent with the convention the DeviceAware* visitors expect for recovering device information. However, it means folding constant into @f's call site must both 'see' the constant underneath the on_device annotation and bring the on_device annotation along for the ride:
```
   @f(..., on_device(constant, device_type=D), ...)
```
  - Make FoldConstant be on_device aware
  - Clean things up a bit while I'm there.
  - Setup unit tests specifically for const folding with on_device annotations.
  - Replacing `if __name__ == "main"` drivers for units tests with official incantation as I encounter them.
  - Don't create `on_device(on_device(...))`
  - Logging changes so A/B diffs can focus on just the pass of interest.
  - Revert Index->DLDeviceType changes in the vm in case they are the cause of downstream problems.

(CORE-102 in OctoML JIRA).