### PR TITLE
Fix typo in Git Usage Tips

### DIFF
--- a/docs/contribute/git_howto.rst
+++ b/docs/contribute/git_howto.rst
@@ -23,7 +23,8 @@ Git Usage Tips
 
 Here are some tips for git workflow.
 
-## How to resolve conflict with main
+How to resolve a conflict with `main`
+-------------------------------------
 
 - First rebase to most recent main
 


### PR DESCRIPTION
Fixed a typo where Markdown syntax with mixed with RST syntax