### PR TITLE
[ONNX][Converter] Add dynamic nodes support

### DIFF
--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -275,14 +275,18 @@ class VMExecutor(Executor):
         self.mod = mod
         self.device = device
         self.target = target
-        self.executable = compile(mod, target)
-        self.vm = vm_rt.VirtualMachine(self.executable, device)
+        self.executable = None
+        self.vm = None
 
     def _make_executor(self, expr=None):
-        main = self.mod["main"]
+        if expr:
+            self.mod["main"] = expr
+
+        self.executable = compile(self.mod, self.target)
+        self.vm = vm_rt.VirtualMachine(self.executable, self.device)
 
         def _vm_wrapper(*args, **kwargs):
-            args = self._convert_args(main, args, kwargs)
+            args = self._convert_args(self.mod["main"], args, kwargs)
             return self.vm.run(*args)
 
         return _vm_wrapper

--- a/tests/python/contrib/test_onnx.py
+++ b/tests/python/contrib/test_onnx.py
@@ -51,9 +51,7 @@ def run_relay(func, data_tuple, is_dyn=False):
     target = "llvm"
     dev = tvm.device("llvm", 0)
     kind = "graph" if not is_dyn else "vm"
-    relay_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(
-        *data_tuple
-    )
+    relay_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(*data_tuple)
 
     result = []
     relay_res = relay_res if isinstance(relay_res, list) else [relay_res]
@@ -713,7 +711,9 @@ def test_dyn():
         func = relay.Function([x, y], z)
         lhs_data = np.random.uniform(size=lhs_shape).astype(dtype)
         rhs_data = np.random.uniform(size=rhs_shape).astype(dtype)
-        verify_results(func, [lhs_data, rhs_data], "test_dyn_bcast", rtol=1e-5, atol=1e-5, is_dyn=True)
+        verify_results(
+            func, [lhs_data, rhs_data], "test_dyn_bcast", rtol=1e-5, atol=1e-5, is_dyn=True
+        )
 
     verify_dyn_bcast((1, 3, 32, 1), (1, 3, 1, 3), "float32")
     verify_dyn_bcast((1, 13), (4, 3, 5, 1), "float32")


### PR DESCRIPTION
* Added dynamic nodes support for ONNX converter if a Relay model contains such.
* Fix the inconsistent behavior of `relay.create_executor(kind, device, target).evaluate(func)(args)`, kind is either **graph** or **vm**.