### PR TITLE
Fix CallNode Rust binding

### DIFF
--- a/rust/tvm/src/ir/relay/mod.rs
+++ b/rust/tvm/src/ir/relay/mod.rs
@@ -163,7 +163,7 @@ impl Call {
         span: Span,
     ) -> Call {
         let node = CallNode {
-            base: ExprNode::base::<VarNode>(span),
+            base: ExprNode::base::<CallNode>(span),
             op: op,
             args: args,
             attrs: attrs,


### PR DESCRIPTION
Was being constructed as VarNode.

@masahi @jroesch 