### PR TITLE
[Keras] Add l2_normalize support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ perf
 .bash_history
 *.json
 *.params
+*.ro
 *.onnx
 *.h5
 synset.txt

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -604,6 +604,26 @@ class TestKeras:
         )
         verify_keras_frontend(keras_model)
 
+    def test_forward_l2_normalize(self, keras):
+        data = keras.layers.Input(shape=(16, 12, 8))
+        K = keras.backend
+        l2_funcs = [
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, axis=-2)),
+            keras.layers.Lambda(lambda v: K.l2_normalize(x=v, axis=-1)),
+            keras.layers.Lambda(lambda v: K.l2_normalize(axis=1, x=v)),
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, 2)),
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, axis=3)),
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, axis=(2, 3))),
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, (1, 2))),
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, axis=[-2, -1])),
+            keras.layers.Lambda(lambda v: K.l2_normalize(v, [-3, -2])),
+        ]
+        for l2_func in l2_funcs:
+            x = l2_func(data)
+            keras_model = keras.models.Model(data, x)
+            verify_keras_frontend(keras_model, layout="NCHW")
+            verify_keras_frontend(keras_model, layout="NHWC")
+
 
 if __name__ == "__main__":
     for k in [keras, tf_keras]:
@@ -641,3 +661,4 @@ if __name__ == "__main__":
         sut.test_forward_zero_padding3d(keras=k)
         sut.test_forward_embedding(keras=k)
         sut.test_forward_repeat_vector(keras=k)
+        sut.test_forward_l2_normalize(keras=k)


### PR DESCRIPTION
This PR adds support for `Lambda(l2_normalize)`.
Keras does not have dedicated Layer for `l2_normalize`. [Typical solution](https://stackoverflow.com/questions/59596162/how-to-apply-l2-normalization-to-a-layer-in-keras) for that is to wrap `K.l2_normalize` with `Lambda` layer and add it to the model.
