### PR TITLE
[CI] Add TVM_INTEGRATION_I386_ONLY for Integration Test on i386

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -335,7 +335,7 @@ stage('Unit Test') {
             unpack_lib('cpu', tvm_multilib_tsim)
             timeout(time: max_time, unit: 'MINUTES') {
               sh "${docker_run} ${ci_cpu} ./tests/scripts/task_ci_setup.sh"
-              sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
+              sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration_i386only.sh"
               junit "build/pytest-results/*.xml"
             }
           }

--- a/tests/scripts/task_python_integration_i386only.sh
+++ b/tests/scripts/task_python_integration_i386only.sh
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+set -e
+set -u
 
 export TVM_INTEGRATION_I386_ONLY=1
 

--- a/tests/scripts/task_python_integration_i386only.sh
+++ b/tests/scripts/task_python_integration_i386only.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+export TVM_INTEGRATION_I386_ONLY=1
+
+./tests/scripts/task_python_integration.sh


### PR DESCRIPTION
This is a fix to run integration tests only on i386 docker image. It will be used by PR #9233
