### PR TITLE
[TIR] Implement BufferPointer node

### DIFF
--- a/include/tvm/tir/expr_functor.h
+++ b/include/tvm/tir/expr_functor.h
@@ -118,6 +118,7 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
   virtual R VisitExpr_(const SizeVarNode* op, Args... args) {
     return VisitExpr_(static_cast<const VarNode*>(op), std::forward<Args>(args)...);
   }
+  virtual R VisitExpr_(const BufferPointerNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const BufferLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const ProducerLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const LoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
@@ -164,6 +165,7 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
     IR_EXPR_FUNCTOR_DISPATCH(VarNode);
     IR_EXPR_FUNCTOR_DISPATCH(SizeVarNode);
     IR_EXPR_FUNCTOR_DISPATCH(LoadNode);
+    IR_EXPR_FUNCTOR_DISPATCH(BufferPointerNode);
     IR_EXPR_FUNCTOR_DISPATCH(BufferLoadNode);
     IR_EXPR_FUNCTOR_DISPATCH(ProducerLoadNode);
     IR_EXPR_FUNCTOR_DISPATCH(LetNode);
@@ -216,6 +218,7 @@ class TVM_DLL ExprVisitor : public ExprFunctor<void(const PrimExpr&)> {
   void VisitExpr_(const VarNode* op) override;
   void VisitExpr_(const SizeVarNode* op) override;
   void VisitExpr_(const LoadNode* op) override;
+  void VisitExpr_(const BufferPointerNode* op) override;
   void VisitExpr_(const BufferLoadNode* op) override;
   void VisitExpr_(const ProducerLoadNode* op) override;
   void VisitExpr_(const LetNode* op) override;
@@ -263,6 +266,7 @@ class TVM_DLL ExprMutator : protected ExprFunctor<PrimExpr(const PrimExpr&)> {
   PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const SizeVarNode* op) override;
   PrimExpr VisitExpr_(const LoadNode* op) override;
+  PrimExpr VisitExpr_(const BufferPointerNode* op) override;
   PrimExpr VisitExpr_(const BufferLoadNode* op) override;
   PrimExpr VisitExpr_(const ProducerLoadNode* op) override;
   PrimExpr VisitExpr_(const LetNode* op) override;

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -285,29 +285,24 @@ class Store : public Stmt {
  */
 class BufferStoreNode : public StmtNode {
  public:
-  /*! \brief The buffer variable. */
-  Buffer buffer;
+  /*! \brief The buffer and location being accessed. */
+  BufferPointer pointer;
   /*! \brief The value to be stored. */
   PrimExpr value;
-  /*! \brief The indices location to be stored. */
-  Array<PrimExpr> indices;
 
   void VisitAttrs(AttrVisitor* v) {
-    v->Visit("buffer", &buffer);
+    v->Visit("pointer", &pointer);
     v->Visit("value", &value);
-    v->Visit("indices", &indices);
     v->Visit("span", &span);
   }
 
   bool SEqualReduce(const BufferStoreNode* other, SEqualReducer equal) const {
-    return equal(buffer, other->buffer) && equal(value, other->value) &&
-           equal(indices, other->indices);
+    return equal(pointer, other->pointer) && equal(value, other->value);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce(buffer);
+    hash_reduce(pointer);
     hash_reduce(value);
-    hash_reduce(indices);
   }
 
   static constexpr const char* _type_key = "tir.BufferStore";
@@ -320,6 +315,8 @@ class BufferStoreNode : public StmtNode {
  */
 class BufferStore : public Stmt {
  public:
+  TVM_DLL explicit BufferStore(BufferPointer pointer, PrimExpr value, Span span = Span());
+
   TVM_DLL explicit BufferStore(Buffer buffer, PrimExpr value, Array<PrimExpr> indices,
                                Span span = Span());
 

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -24,7 +24,7 @@ from .data_layout import Layout, BijectiveLayout, bijective_layout, layout
 from .expr import Var, SizeVar, Reduce, FloatImm, IntImm, StringImm, Cast
 from .expr import Add, Sub, Mul, Div, Mod, FloorDiv, FloorMod
 from .expr import Min, Max, EQ, NE, LT, LE, GT, GE, And, Or, Not
-from .expr import Select, BufferLoad, ProducerLoad, Load, Ramp, Broadcast, Shuffle
+from .expr import Select, BufferPointer, BufferLoad, ProducerLoad, Load, Ramp, Broadcast, Shuffle
 from .expr import Call, CallEffectKind, Let, IterVar, CommReducer, Any
 
 from .stmt import Stmt, LetStmt, AssertStmt, ForKind, For, While

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -1036,6 +1036,39 @@ class Load(PrimExprWithOp):
         )
 
 
+@tvm._ffi.register_object("tir.BufferPointer")
+class BufferPointer(PrimExpr):
+    """Buffer load node.
+
+    Parameters
+    ----------
+    buffer : Buffer
+        The buffer to be loaded.
+
+    indices : List[PrimExpr]
+        The buffer indices.
+
+    span : Optional[Span]
+        The location of this itervar in the source code.
+    """
+
+    def __init__(self, buffer, indices, span=None):
+        self.__init_handle_by_constructor__(
+            _ffi_api.BufferPointer, buffer, indices, span  # type: ignore
+        )
+
+    def value_dtype(self):
+        """The datatype of the location pointed to.
+
+        Will have the same scalar type as `self.buffer.dtype`, but may
+        have a different number of lanes.  This is because access of a
+        buffer using an index with more than one lane, such as a
+        RampNode, indicates more than one location in the buffer.
+
+        """
+        return _ffi_api.BufferPointer_value_dtype(self)
+
+
 @tvm._ffi.register_object("tir.BufferLoad")
 class BufferLoad(PrimExprWithOp):
     """Buffer load node.

--- a/src/arith/domain_touched.cc
+++ b/src/arith/domain_touched.cc
@@ -78,15 +78,15 @@ class BufferTouchedDomain final : public StmtExprVisitor {
   }
 
   void VisitExpr_(const BufferLoadNode* op) final {
-    if (consider_loads_ && buffer_.same_as(op->buffer)) {
-      Touch(op->indices);
+    if (consider_loads_ && buffer_.same_as(op->pointer->buffer)) {
+      Touch(op->pointer->indices);
     }
     StmtExprVisitor::VisitExpr_(op);
   }
 
   void VisitStmt_(const BufferStoreNode* op) final {
-    if (consider_stores_ && buffer_.same_as(op->buffer)) {
-      Touch(op->indices);
+    if (consider_stores_ && buffer_.same_as(op->pointer->buffer)) {
+      Touch(op->pointer->indices);
     }
     StmtExprVisitor::VisitStmt_(op);
   }

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -307,6 +307,7 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc VisitExpr_(const OrNode* op) override;
   Doc VisitExpr_(const NotNode* op) override;
   Doc VisitExpr_(const SelectNode* op) override;
+  Doc VisitExpr_(const BufferPointerNode* op) override;
   Doc VisitExpr_(const BufferLoadNode* op) override;
   Doc VisitExpr_(const ProducerLoadNode* op) override;
   Doc VisitExpr_(const LoadNode* op) override;

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -346,9 +346,15 @@ Doc TIRTextPrinter::VisitExpr_(const SelectNode* op) {
   return doc;
 }
 
+Doc TIRTextPrinter::VisitExpr_(const BufferPointerNode* op) {
+  Doc doc;
+  doc << "&" << Print(op->buffer) << Print(op->indices);
+  return doc;
+}
+
 Doc TIRTextPrinter::VisitExpr_(const BufferLoadNode* op) {
   Doc doc;
-  doc << Print(op->buffer) << Print(op->indices);
+  doc << Print(op->pointer->buffer) << Print(op->pointer->indices);
   return doc;
 }
 
@@ -455,7 +461,7 @@ Doc TIRTextPrinter::VisitStmt_(const StoreNode* op) {
 
 Doc TIRTextPrinter::VisitStmt_(const BufferStoreNode* op) {
   Doc doc;
-  doc << Print(op->buffer) << Print(op->indices) << " = " << Print(op->value);
+  doc << Print(op->pointer->buffer) << Print(op->pointer->indices) << " = " << Print(op->value);
   return doc;
 }
 

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -642,10 +642,10 @@ Doc TVMScriptPrinter::VisitExpr_(const ProducerLoadNode* op, ExprPrecedence* out
 Doc TVMScriptPrinter::VisitExpr_(const BufferLoadNode* op, ExprPrecedence* out_precedence) {
   *out_precedence = ExprPrecedence::kIdentity;
   Doc doc;
-  if (op->indices.size() == 0) {
-    doc << Print(op->buffer) << "[()]";
+  if (op->pointer->indices.size() == 0) {
+    doc << Print(op->pointer->buffer) << "[()]";
   } else {
-    doc << Print(op->buffer) << Print(op->indices);
+    doc << Print(op->pointer->buffer) << Print(op->pointer->indices);
   }
   return doc;
 }
@@ -960,10 +960,10 @@ Doc TVMScriptPrinter::VisitType_(const TupleTypeNode* node) {
 
 Doc TVMScriptPrinter::VisitStmt_(const BufferStoreNode* op) {
   Doc doc;
-  if (op->indices.size() == 0) {
-    doc << Print(op->buffer) << "[()] = " << Print(op->value);
+  if (op->pointer->indices.size() == 0) {
+    doc << Print(op->pointer->buffer) << "[()] = " << Print(op->value);
   } else {
-    doc << Print(op->buffer) << Print(op->indices) << " = " << Print(op->value);
+    doc << Print(op->pointer->buffer) << Print(op->pointer->indices) << " = " << Print(op->value);
   }
   return doc;
 }

--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -140,10 +140,10 @@ void BlockReadWriteDetector::VisitExpr_(const LoadNode* op) {
 
 void BlockReadWriteDetector::VisitExpr_(const BufferLoadNode* op) {
   std::vector<arith::IntSet> relaxed_region;
-  for (const PrimExpr& index : op->indices) {
+  for (const PrimExpr& index : op->pointer->indices) {
     relaxed_region.push_back(arith::EvalSet(index, dom_map_));
   }
-  Update(&read_buffers_, &read_regions_, op->buffer, relaxed_region);
+  Update(&read_buffers_, &read_regions_, op->pointer->buffer, relaxed_region);
   ExprVisitor::VisitExpr_(op);
 }
 
@@ -161,10 +161,10 @@ void BlockReadWriteDetector::VisitStmt_(const StoreNode* op) {
 
 void BlockReadWriteDetector::VisitStmt_(const BufferStoreNode* op) {
   std::vector<arith::IntSet> relaxed_region;
-  for (const PrimExpr& index : op->indices) {
+  for (const PrimExpr& index : op->pointer->indices) {
     relaxed_region.push_back(arith::EvalSet(index, dom_map_));
   }
-  Update(&writes_buffers_, &write_regions_, op->buffer, relaxed_region);
+  Update(&writes_buffers_, &write_regions_, op->pointer->buffer, relaxed_region);
   StmtVisitor::VisitStmt_(op);
 }
 

--- a/src/tir/analysis/buffer_access_lca_detector.cc
+++ b/src/tir/analysis/buffer_access_lca_detector.cc
@@ -101,12 +101,12 @@ class LCADetector : public StmtExprVisitor {
   }
 
   void VisitExpr_(const BufferLoadNode* op) final {
-    UpdateBufferLCA(op->buffer.get());
+    UpdateBufferLCA(op->pointer->buffer.get());
     StmtExprVisitor::VisitExpr_(op);
   }
 
   void VisitStmt_(const BufferStoreNode* op) final {
-    UpdateBufferLCA(op->buffer.get());
+    UpdateBufferLCA(op->pointer->buffer.get());
     StmtExprVisitor::VisitStmt_(op);
   }
 

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -1127,10 +1127,10 @@ TVM_REGISTER_NODE_TYPE(BufferLoadNode);
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<BufferLoadNode>([](const ObjectRef& node, ReprPrinter* p) {
       auto* op = static_cast<const BufferLoadNode*>(node.get());
-      p->stream << op->buffer->name << "[";
-      for (size_t i = 0; i < op->indices.size(); ++i) {
-        p->Print(op->indices[i]);
-        if (i < op->indices.size() - 1) {
+      p->stream << op->pointer->buffer->name << "[";
+      for (size_t i = 0; i < op->pointer->indices.size(); ++i) {
+        p->Print(op->pointer->indices[i]);
+        if (i < op->pointer->indices.size() - 1) {
           p->stream << ", ";
         }
       }

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -615,10 +615,10 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<BufferStoreNode>([](const ObjectRef& node, ReprPrinter* p) {
       auto* op = static_cast<const BufferStoreNode*>(node.get());
       p->PrintIndent();
-      p->stream << op->buffer->name << "[";
-      for (size_t i = 0; i < op->indices.size(); ++i) {
-        p->Print(op->indices[i]);
-        if (i < op->indices.size() - 1) p->stream << ", ";
+      p->stream << op->pointer->buffer->name << "[";
+      for (size_t i = 0; i < op->pointer->indices.size(); ++i) {
+        p->Print(op->pointer->indices[i]);
+        if (i < op->pointer->indices.size() - 1) p->stream << ", ";
       }
       p->stream << "]";
       p->stream << " = ";

--- a/src/tir/transforms/bf16_legalize.cc
+++ b/src/tir/transforms/bf16_legalize.cc
@@ -230,9 +230,9 @@ class BF16LowerRewriter : public StmtExprMutator {
     Stmt ret = StmtExprMutator::VisitStmt_(op);
     op = ret.as<BufferStoreNode>();
 
-    auto it = buffer_remap_.find(op->buffer);
+    auto it = buffer_remap_.find(op->pointer->buffer);
     if (it != buffer_remap_.end()) {
-      return BufferStore(it->second, op->value, op->indices);
+      return BufferStore(it->second, op->value, op->pointer->indices);
     } else {
       return ret;
     }
@@ -285,9 +285,9 @@ class BF16LowerRewriter : public StmtExprMutator {
     PrimExpr ret = StmtExprMutator::VisitExpr_(op);
     op = ret.as<BufferLoadNode>();
 
-    auto it = buffer_remap_.find(op->buffer);
+    auto it = buffer_remap_.find(op->pointer->buffer);
     if (it != buffer_remap_.end()) {
-      return BufferLoad(it->second, op->indices);
+      return BufferLoad(it->second, op->pointer->indices);
     } else {
       return ret;
     }

--- a/src/tir/transforms/flatten_buffer.cc
+++ b/src/tir/transforms/flatten_buffer.cc
@@ -109,7 +109,7 @@ class BufferFlattener : public StmtExprMutator {
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {
     BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
-    return store->buffer.vstore(store->indices, store->value);
+    return store->pointer->buffer.vstore(store->pointer->indices, store->value);
   }
 
   PrimExpr VisitExpr_(const VarNode* op) final {
@@ -128,7 +128,7 @@ class BufferFlattener : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {
     BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
-    return load->buffer.vload(load->indices, load->dtype);
+    return load->pointer->buffer.vload(load->pointer->indices, load->dtype);
   }
 
   static Stmt MakeAllocStmt(const Buffer& buffer, Stmt body) {

--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -309,7 +309,7 @@ def recursive_match(a: T.handle, b: T.handle) -> None:
                         )
                     )
                     for jjj, kkk in T.grid(4, 4):
-                        sub_sub_B[jjj, kkk] = 1
+                        sub_sub_B[jjj, kkk] = 1.0
 
 
 @T.prim_func
@@ -354,7 +354,7 @@ def transformed_recursive_match(a: T.handle, b: T.handle) -> None:
                         )
                     )
                     for jjj, kkk in T.grid(4, 4):
-                        B[i, j * 16 + jj * 4 + jjj, k * 16 + kk * 4 + kkk] = 1
+                        B[i, j * 16 + jj * 4 + jjj, k * 16 + kk * 4 + kkk] = 1.0
 
 
 @T.prim_func
@@ -372,7 +372,7 @@ def symbolic_match(a: T.handle, b: T.handle, n: T.int32, m: T.int32) -> None:
                 B[i * n : i * n + 2, 0 : m * 4], (2, m * 4), strides=[Bs_0, Bs_1], offset_factor=1
             )
             for ii, jj in T.grid(m, m):
-                sub_A[ii, jj] = 1
+                sub_A[ii, jj] = 1.0
             for j in range(0, 4):
                 T.evaluate(
                     T.intrin_test(
@@ -396,7 +396,7 @@ def transformed_symbolic_match(a: T.handle, b: T.handle, n: T.int32, m: T.int32)
             T.reads([])
             T.writes([A[i * m : i * m + n, 0:m], B[i * n : i * n + 2, 0 : m * 4]])
             for ii, jj in T.grid(m, m):
-                A[i * m + ii, jj] = 1
+                A[i * m + ii, jj] = 1.0
             for j in range(0, 4):
                 T.evaluate(
                     T.intrin_test(
@@ -421,7 +421,7 @@ def rank0_buffer(a: T.handle, b: T.handle) -> None:
             T.writes([A[i, j], B[i, j]])
             sub_A = T.match_buffer(A[i, j], (), offset_factor=1)
             sub_B = T.match_buffer(B[i, j], (), offset_factor=1)
-            sub_A[()] = 1
+            sub_A[()] = 1.0
             T.evaluate(
                 T.intrin_test(
                     sub_B.data,
@@ -443,7 +443,7 @@ def transformed_rank0_buffer(a: T.handle, b: T.handle) -> None:
         with T.block():
             T.reads([])
             T.writes([A[i, j], B[i, j]])
-            A[i, j] = 1
+            A[i, j] = 1.0
             T.evaluate(
                 T.intrin_test(
                     B.data,
@@ -489,7 +489,7 @@ def fail_buffer_bind(a: T.handle) -> None:
                 A[i, j * 4 : j * 4 + 4], (1, 4), strides=[stride, stride], offset_factor=1
             )
             for jj in range(0, 4):
-                sub_A[i, j * 4 + jj] = 1
+                sub_A[i, j * 4 + jj] = 1.0
 
 
 @T.prim_func
@@ -499,7 +499,7 @@ def fail_match_func_param(a: T.handle, m: T.handle, n: T.handle) -> None:
         with T.block():
             sub_A = T.match_buffer(A[i, j * 4 : j * 4 + 4], (1, 4), strides=[m, n], offset_factor=1)
             for jj in range(0, 4):
-                sub_A[i, j * 4 + jj] = 1
+                sub_A[i, j * 4 + jj] = 1.0
 
 
 def test_buffer_load_store():

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -355,15 +355,31 @@ def test_scoped_storage_vars():
     assert isinstance(ptype.element_type, tvm.ir.PrimType)
 
 
-def test_buffer_load_store():
+def test_buffer_pointer():
     b = tvm.tir.decl_buffer((10,), "float32")
-    x = tvm.tir.BufferLoad(b, [0])
-    assert isinstance(x, tvm.tir.BufferLoad)
-    assert x.dtype == "float32"
-    assert x.buffer == b
-    s = tvm.tir.BufferStore(b, 0.1, [0])
-    assert isinstance(s, tvm.tir.BufferStore)
+    node = tvm.tir.BufferPointer(b, [0])
+    assert isinstance(node, tvm.tir.BufferPointer)
+    assert node.dtype == "handle"
+    assert node.value_dtype() == "float32"
 
+
+def test_buffer_load():
+    b = tvm.tir.decl_buffer((10,), "float32")
+    node = tvm.tir.BufferLoad(b, [0])
+    assert isinstance(node, tvm.tir.BufferLoad)
+    assert node.dtype == "float32"
+    assert node.pointer.buffer == b
+
+
+def test_buffer_store():
+    b = tvm.tir.decl_buffer((10,), "float32")
+    node = tvm.tir.BufferStore(b, 0.1, [0])
+    assert isinstance(node, tvm.tir.BufferStore)
+    assert node.pointer.buffer == b
+
+
+def test_buffer_realize():
+    b = tvm.tir.decl_buffer((10,), "float32")
     s = tvm.tir.BufferRealize(b, [tvm.ir.Range(0, 1)], True, tvm.tir.Evaluate(0))
     assert isinstance(s, tvm.tir.BufferRealize)
 

--- a/tests/python/unittest/test_tir_schedule_state_cached_flags.py
+++ b/tests/python/unittest/test_tir_schedule_state_cached_flags.py
@@ -121,11 +121,11 @@ def concatenate_multi_producer(a: T.handle, b: T.handle) -> None:
     for i in range(0, 64):
         with T.block("A_0"):
             vi = T.axis.S(64, i)
-            A[vi] = vi + 1
+            A[vi] = T.cast(vi, "float32") + 1.0
     for i in range(0, 64):
         with T.block("A_1"):
             vi = T.axis.S(64, i + 64)
-            A[vi] = vi + 2
+            A[vi] = T.cast(vi, "float32") + 2.0
     for i in range(0, 128):
         with T.block("B"):
             vi = T.axis.S(128, i)
@@ -139,11 +139,11 @@ def concatenate_multi_producer_uncovered(a: T.handle, b: T.handle) -> None:
     for i in range(0, 63):
         with T.block("A_0"):
             vi = T.axis.S(63, i)
-            A[vi] = vi + 1
+            A[vi] = T.cast(vi, "float32") + 1.0
     for i in range(0, 64):
         with T.block("A_1"):
             vi = T.axis.S(64, i + 64)
-            A[vi] = vi + 2
+            A[vi] = T.cast(vi, "float32") + 2.0
     for i in range(0, 128):
         with T.block("B"):
             vi = T.axis.S(128, i)
@@ -171,11 +171,11 @@ def multi_producer_consumer(a: T.handle, b: T.handle) -> None:
     for i in range(0, 64):
         with T.block("A_0"):
             vi = T.axis.S(64, i)
-            A[vi] = vi + 1
+            A[vi] = T.cast(vi, "float32") + 1.0
     for i in range(0, 64):
         with T.block("A_1"):
             vi = T.axis.S(64, i + 64)
-            A[vi] = vi + 2
+            A[vi] = T.cast(vi, "float32") + 2.0
     for i in range(0, 64):
         with T.block("B_0"):
             vi = T.axis.S(64, i)

--- a/tests/python/unittest/test_tir_transform_plan_update_buffer_allocation_location.py
+++ b/tests/python/unittest/test_tir_transform_plan_update_buffer_allocation_location.py
@@ -139,7 +139,7 @@ def match_buffer_func() -> None:
                 with T.block():
                     jj = T.axis.S(128, j)
                     C1 = T.match_buffer(C0[jj], ())
-                    C1[()] = 0
+                    C1[()] = 0.0
 
 
 @T.prim_func
@@ -153,7 +153,7 @@ def transformed_match_buffer_func() -> None:
                 with T.block():
                     jj = T.axis.S(128, j)
                     C1 = T.match_buffer(C0[jj], ())
-                    C1[()] = 0
+                    C1[()] = 0.0
 
 
 @T.prim_func

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2922,7 +2922,7 @@ def test_opaque_block():
 def rank0(a: T.handle) -> None:
     A = T.match_buffer(a, (), "float32")
     B = T.alloc_buffer((), "float32")
-    A[()] = 2
+    A[()] = 2.0
     B[()] = A[()]
 
 
@@ -2954,7 +2954,7 @@ def test_rank0_blocks():
 @T.prim_func
 def select(a: T.handle) -> None:
     A = T.match_buffer(a, (), "float32")
-    A[()] = T.Select(True, 1, 2)
+    A[()] = T.Select(True, 1.0, 2.0)
 
 
 def test_select():
@@ -2966,8 +2966,8 @@ def test_select():
 @T.prim_func
 def minmax(a: T.handle) -> None:
     A = T.match_buffer(a, (), "float32")
-    A[()] = T.min(1, 2)
-    A[()] = T.max(1, 2)
+    A[()] = T.min(1.0, 2.0)
+    A[()] = T.max(1.0, 2.0)
 
 
 def test_minmax():
@@ -3027,11 +3027,11 @@ def var_with_same_name(a: T.handle) -> None:
     for i, j in T.grid(16, 16):
         with T.block():
             vi, vj = T.axis.remap("SS", [i, j])
-            A[vi, vj] = 0
+            A[vi, vj] = 0.0
     for i, j in T.grid(16, 16):
         with T.block():
             vi, vj = T.axis.remap("SS", [i, j])
-            A[vi, vj] = 0
+            A[vi, vj] = 0.0
 
 
 def test_same_name_var():
@@ -3057,7 +3057,7 @@ def while_loop(a: T.handle, b: T.handle) -> None:
     for ii in range(16):
         with T.block():
             vi = T.axis.S(16, ii)
-            B[vi] = 0
+            B[vi] = 0.0
         while i[()] < 10:
             for j in range(16):
                 B[j] += A[j]

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2865,7 +2865,7 @@ def block_elements(a: T.handle, b: T.handle) -> None:
         D = T.match_buffer(A[0:4, 0], (4, 1))
         with T.init():
             B[0, 0] = T.float32(0)
-        B[0, 0] = A[0, 0] + B[0, 0] + C[1, 1] + D[2]
+        B[0, 0] = A[0, 0] + B[0, 0] + C[1, 1] + D[2, 0]
 
 
 def test_block_elements():

--- a/vta/python/vta/transform.py
+++ b/vta/python/vta/transform.py
@@ -729,8 +729,8 @@ def InjectConv2DTransposeSkip():
                     body = op.body.body
                     while isinstance(body, tvm.tir.IfThenElse):
                         body = body.then_case
-                    args = body.indices
-                    res_buffer = body.buffer
+                    args = body.pointer.indices
+                    res_buffer = body.pointer.buffer
                     tpl = (args[0], 1, args[1], 1, args[2], 1, args[3], 1, 0, 1, 0, env.BLOCK_OUT)
                     inner = tvm.tir.AttrStmt(
                         [dout, res_buffer],
@@ -741,9 +741,9 @@ def InjectConv2DTransposeSkip():
                     return inner
                 else:
                     conv_call, data_call, kernel_call = calls[-3:]
-                    pad_data_tensor = data_call.buffer
-                    kernel_tensor = kernel_call.buffer
-                    res_tensor = conv_call.buffer
+                    pad_data_tensor = data_call.pointer.buffer
+                    kernel_tensor = kernel_call.pointer.buffer
+                    res_tensor = conv_call.pointer.buffer
 
                     if selects:
                         condition = selects[0].condition
@@ -774,7 +774,7 @@ def InjectConv2DTransposeSkip():
                         )
                     inner = irb.get()
 
-                    args = conv_call.indices
+                    args = conv_call.pointer.indices
                     tpl = (args[0], 1, args[1], 1, args[2], 1, args[3], 1, 0, 1, 0, env.BLOCK_OUT)
                     inner = tvm.tir.AttrStmt(
                         [dout, res_tensor],
@@ -782,7 +782,7 @@ def InjectConv2DTransposeSkip():
                         tvm.tir.call_intrin("handle", "tir.tvm_tuple", *tpl),
                         inner,
                     )
-                    args = kernel_call.indices
+                    args = kernel_call.pointer.indices
                     tpl = (
                         args[0],
                         1,
@@ -803,7 +803,7 @@ def InjectConv2DTransposeSkip():
                         tvm.tir.call_intrin("handle", "tir.tvm_tuple", *tpl),
                         inner,
                     )
-                    args = data_call.indices
+                    args = data_call.pointer.indices
                     tpl = (args[0], 1, args[1], 1, args[2], 1, args[3], 1, 0, 1, 0, env.BLOCK_IN)
                     inner = tvm.tir.AttrStmt(
                         [dinp, pad_data_tensor],


### PR DESCRIPTION
This is intended to simplify transformations that impact BufferStore and BufferLoad nodes.  As this impacts the TIR definitions, an RFC will be posted shortly.

This PR is divided into separate commits to help in review.  The first commit is the main change adding an implementation of `BufferPointer`, and modifying `BufferStore` and `BufferLoad`.  The majority of the commits that follow are responses to this change, fixing breakages caused by the main change.  The final commit "Updated transforms..." contains the simplifications to existing transformations that are enabled by the new `BufferPointer`.

Edit: RFC posted [here](https://github.com/apache/tvm-rfcs/pull/42).