### PR TITLE
[CMSIS-NN] Convert CMSIS-NN to use Target Hooks

### DIFF
--- a/python/tvm/driver/tvmc/common.py
+++ b/python/tvm/driver/tvmc/common.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 
 import tvm
 
+from tvm.driver import tvmc
 from tvm import relay
 from tvm import transform
 from tvm._ffi import registry
@@ -206,6 +207,7 @@ def parse_target(target):
         a key-value for all options passed via CLI; 'raw',
         containing the plain string for this codegen
     """
+    codegen_names = tvmc.composite_target.get_codegen_names()
     codegens = []
 
     tvm_target_kinds = tvm.target.Target.list_kinds()
@@ -232,7 +234,7 @@ def parse_target(target):
     for codegen_def in split_codegens:
         # the first is expected to be the name
         name = codegen_def[0]
-        is_tvm_target = name in tvm_target_kinds
+        is_tvm_target = name in tvm_target_kinds and name not in codegen_names
         raw_target = " ".join(codegen_def)
         all_opts = codegen_def[1:] if len(codegen_def) > 1 else []
         opts = {}

--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name, unused-argument
 """Arm(R) CMSIS-NN supported operators for Cortex-M."""
 import tvm.ir
+from tvm.target import Target
 from tvm.relay import transform
 from tvm.relay.build_module import bind_params_by_name
 
@@ -25,7 +26,7 @@ from .register import register_pattern_table
 
 
 def enabled():
-    return bool(tvm.get_global_func("relay.ext.cmsisnn", True))
+    return "cmsis-nn" in Target.list_kinds()
 
 
 def partition_for_cmsisnn(mod, params=None, **opts):
@@ -51,7 +52,7 @@ def partition_for_cmsisnn(mod, params=None, **opts):
         [
             transform.InferType(),
             transform.MergeComposite(pattern_table()),
-            transform.AnnotateTarget("cmsisnn"),
+            transform.AnnotateTarget("cmsis-nn"),
             transform.MergeCompilerRegions(),
             transform.PartitionGraph(),
         ]
@@ -60,9 +61,9 @@ def partition_for_cmsisnn(mod, params=None, **opts):
     return seq(mod)
 
 
-@register_pattern_table("cmsisnn")
+@register_pattern_table("cmsis-nn")
 def pattern_table():
-    """Get the cmsisnn compiler pattern table."""
+    """Get the CMSIS-NN compiler pattern table."""
 
     def softmax_pattern():
         pattern = is_op("qnn.dequantize")(wildcard(), is_constant(), is_constant())
@@ -104,14 +105,14 @@ def pattern_table():
         )
 
     return [
-        ("cmsisnn.quantized_softmax", softmax_pattern(), check_quantized_softmax),
+        ("cmsis-nn.quantized_softmax", softmax_pattern(), check_quantized_softmax),
         (
-            "cmsisnn.quantized_mul",
+            "cmsis-nn.quantized_mul",
             binary_op_pattern("mul"),
             check_quantized_binary_op,
         ),
         (
-            "cmsisnn.quantized_add",
+            "cmsis-nn.quantized_add",
             binary_op_pattern("add"),
             check_quantized_binary_op,
         ),

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -607,7 +607,10 @@ transform::Sequential MixedModulePassManager(IRModule mixed_mod, Target target) 
   mixed_pass_list.push_back(tir::transform::InferFragment());
   mixed_pass_list.push_back(tir::transform::LowerThreadAllreduce());
 
-  if (target->GetAttr<Bool>("unpacked-api").value_or(Bool(false))) {
+  // The host Target contains these parameters at the moment rather than
+  // the specific Target
+  // TODO(Mousius) - Move these to the Executor object rather than Target
+  if (target->GetHost().value()->GetAttr<Bool>("unpacked-api").value_or(Bool(false))) {
     mixed_pass_list.push_back(tir::transform::MakeUnpackedAPI());
   } else {
     mixed_pass_list.push_back(tir::transform::MakePackedAPI(-1));

--- a/src/relay/backend/contrib/cmsisnn/target.cc
+++ b/src/relay/backend/contrib/cmsisnn/target.cc
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,34 +17,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <tvm/relay/transform.h>
-#include <tvm/runtime/module.h>
-#include <tvm/runtime/registry.h>
+#include <tvm/target/target.h>
 
 namespace tvm {
+
 namespace relay {
 namespace contrib {
 namespace cmsisnn {
 
-transform::Pass RelayToTIR();
+tvm::transform::Pass RelayToTIR();
+runtime::Module TIRToRuntime(IRModule mod, Target target);
 
-runtime::Module CompileCMSISNN(const ObjectRef& ref) {
-  IRModule relay_mod;
-  Function relay_func = Downcast<Function>(ref);
-  auto func_name = relay_func->GetAttr<String>(tvm::attr::kGlobalSymbol);
-  GlobalVar var = GlobalVar(func_name.value());
-  relay_mod->Add(var, relay_func);
-  relay_mod = transform::InferType()(relay_mod);
-
-  Array<transform::Pass> pass_seqs{transform::InferType(), RelayToTIR()};
-  transform::Sequential seq(pass_seqs);
-  IRModule tir_mod = seq(relay_mod);
-
-  const auto* pf = runtime::Registry::Get("runtime.CMSISNNModuleNodeCreate");
-  return (*pf)(tir_mod);
-}
-
-TVM_REGISTER_GLOBAL("relay.ext.cmsisnn").set_body_typed(CompileCMSISNN);
+TVM_REGISTER_TARGET_KIND("cmsis-nn", kDLCPU)
+    .set_attr<FTVMRelayToTIR>("RelayToTIR", RelayToTIR())
+    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime);
 
 }  // namespace cmsisnn
 }  // namespace contrib

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -580,6 +580,7 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
 
   Expr DeviceAwareVisitExpr_(const CallNode* call_node) override {
     Call call = GetRef<Call>(call_node);
+
     // Look for (indirect) calls to primitives.
     BaseFunc prim_func = ResolveToPrimitive(call_node->op);
     if (!prim_func.defined()) {
@@ -590,10 +591,16 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
       return ExprMutator::VisitExpr_(call_node);
     }
 
+    // Similarly transform arguments.
+    Array<Expr> args;
+    for (const auto& arg : call_node->args) {
+      args.push_back(VisitExpr(arg));
+    }
+
     // Already lowered by other means so we don't need to mutate
-    // the call
+    // the call but we do need to mutate the arguments
     if (prim_func->IsInstance<tir::PrimFuncNode>()) {
-      return std::move(call);
+      return Call(call_node->op, args, call_node->attrs);
     }
 
     // Find the desired target device.
@@ -611,12 +618,6 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     // Lower the primitive function for that target.
     Function func = Downcast<Function>(prim_func);
     std::pair<GlobalVar, Attrs> pair = LowerFunction(func, target);
-
-    // Similarly transform arguments.
-    Array<Expr> args;
-    for (const auto& arg : call_node->args) {
-      args.push_back(VisitExpr(arg));
-    }
 
     // Replace with direct call to lowered primitive, and attach annotations to record calling
     // convention.

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include "../analysis/annotated_region_set.h"
+#include "../backend/name_transforms.h"
 #include "../backend/utils.h"
 #include "pass_utils.h"
 
@@ -501,7 +502,7 @@ class NameMangleExtFuncs : public MixedModeMutator {
       if (auto* fn = pair.second.as<FunctionNode>()) {
         auto func = GetRef<Function>(fn);
         if (func->GetAttr<String>(attr::kCompiler).defined()) {
-          auto fn_name_mangled = mangle_fn_(pair.first->name_hint);
+          auto fn_name_mangled = relay::backend::SanitizeName(mangle_fn_(pair.first->name_hint));
           GlobalVar gvar = GlobalVar(fn_name_mangled);
           mangled_gvars_[pair.first->name_hint] = gvar;
         }
@@ -519,7 +520,8 @@ class NameMangleExtFuncs : public MixedModeMutator {
 
         if (func->GetAttr<String>(attr::kCompiler).defined()) {
           auto new_dict = func->attrs->dict;
-          new_dict.Set(tvm::attr::kGlobalSymbol, String(mangle_fn_(pair.first->name_hint)));
+          new_dict.Set(tvm::attr::kGlobalSymbol,
+                       String(relay::backend::SanitizeName(mangle_fn_(pair.first->name_hint))));
           func = Function(func->params, VisitExpr(func->body), func->ret_type, func->type_params,
                           DictAttrs(new_dict));
           new_module->Add(mangled_gvars_[pair.first->name_hint], func);

--- a/tests/python/contrib/test_cmsisnn/test_binary_ops.py
+++ b/tests/python/contrib/test_cmsisnn/test_binary_ops.py
@@ -103,7 +103,7 @@ def test_op_int8(op, input_0_scale, input_0_zero_point, input_1_scale, input_1_z
     assert any(attrs), "At least one function with external attributes was expected."
 
     compilers = [
-        key == "Compiler" and value == "cmsisnn" for attr in attrs for key, value in attr.items()
+        key == "Compiler" and value == "cmsis-nn" for attr in attrs for key, value in attr.items()
     ]
     assert any(compilers), "Module does not contain function for cmsisnn target."
 

--- a/tests/python/contrib/test_cmsisnn/test_softmax.py
+++ b/tests/python/contrib/test_cmsisnn/test_softmax.py
@@ -85,7 +85,7 @@ def test_softmax_int8(zero_point, scale):
     assert any(attrs), "At least one function with external attributes was expected."
 
     compilers = [
-        key == "Compiler" and value == "cmsisnn" for attr in attrs for key, value in attr.items()
+        key == "Compiler" and value == "cmsis-nn" for attr in attrs for key, value in attr.items()
     ]
     assert any(compilers), "Module does not contain function for cmsisnn target."
 

--- a/tests/python/contrib/test_ethosn/infrastructure.py
+++ b/tests/python/contrib/test_ethosn/infrastructure.py
@@ -170,11 +170,19 @@ def build(mod, params, npu=True, expected_host_ops=0, npu_partitions=1):
                 assert (
                     host_op_count == expected_host_ops
                 ), "Got {} host operators, expected {}".format(host_op_count, expected_host_ops)
-                partition_count = 0
-                for global_var in mod.get_global_vars():
-                    if "ethos-n" in global_var.name_hint:
-                        partition_count += 1
 
+                attrs = [
+                    mod[var.name_hint].attrs
+                    for var in mod.get_global_vars()
+                    if mod[var.name_hint].attrs
+                ]
+                partition_count = sum(
+                    [
+                        key == "Compiler" and value == "ethos-n"
+                        for attr in attrs
+                        for key, value in attr.items()
+                    ]
+                )
                 assert (
                     npu_partitions == partition_count
                 ), "Got {} ethos-n partitions, expected {}".format(partition_count, npu_partitions)

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -123,9 +123,9 @@ def test_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"1fd4ef29a1ea9f3a015cab87c0b8014a"}
+    _compile_hash = {"0433d3c3947a067b36f0228bdb5f1838"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
-        _compile_hash = {"b879dfbff1f907eaf6129dfd41b44ece"}
+        _compile_hash = {"e4ed29dceb1187505948ab17fc3cc6d6"}
     if tei.get_ethosn_api_version() == 2011:
         _compile_hash = {"9c9f63b30824f5b223cdb27d2f22c857"}
         if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
@@ -150,9 +150,9 @@ def test_inception_v3():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"b90ed315639c6a0e97584c2dbc42a55c"}
+    _compile_hash = {"43dc2097127eb224c0191b1a15f8acca"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
-        _compile_hash = {"5693569055695e581a8739194d0301aa"}
+        _compile_hash = {"7db23387bdc5af6eaa1ae3f7d456caf0"}
     if tei.get_ethosn_api_version() == 2011:
         _compile_hash = {"46ccafc840633633aca441645e41b444"}
         if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
@@ -176,9 +176,9 @@ def test_inception_v4():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"b36877d2386d9f9c37a11772e3c4072c"}
+    _compile_hash = {"fab6c2297502f95d33079c6ce1a737f9"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
-        _compile_hash = {"b5046a6f56d78af0b4f51960bf2deeda"}
+        _compile_hash = {"8da68849b75613ac3dffd3fff2dd87da"}
     if tei.get_ethosn_api_version() == 2011:
         _compile_hash = {"4a1a56393078367dd27915a188d6a6af"}
         if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
@@ -202,9 +202,9 @@ def test_ssd_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"956caf9e7fe5cfd5c042bd17857f7407", "4313033d14328e2aa022b1bd71b27b1c"}
+    _compile_hash = {"2345cf5d6c0013bad7c76dcccee9d862", "7795b6c67178da9d1f9b98063bad75b1"}
     if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
-        _compile_hash = {"dc60cc687d892cd2877873094e9dfc0b", "6b3deeec16c24c0dcef23df0db5fb162"}
+        _compile_hash = {"928dc6ae5ce49a4ad63ca87f7575970f", "b092f9820f7e9341fc53daa781b98772"}
     if tei.get_ethosn_api_version() == 2011:
         _compile_hash = {"10826406ae724e52f360a06c35ced09d", "9a484d5ecec7acb18c9d6bc6058be031"}
         if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":

--- a/tests/python/driver/tvmc/test_target.py
+++ b/tests/python/driver/tvmc/test_target.py
@@ -118,6 +118,19 @@ def test_parse_multiple_target():
     assert "llvm" == targets[1]["name"]
 
 
+def test_parse_hybrid_target():
+    """Hybrid Target and external codegen"""
+    targets = tvmc.common.parse_target(
+        "cmsis-nn -accelerator_config=ethos-u55-256, llvm -device=arm_cpu --system-lib"
+    )
+
+    assert len(targets) == 2
+    assert "cmsis-nn" == targets[0]["name"]
+    assert not targets[0]["is_tvm_target"]
+    assert "llvm" == targets[1]["name"]
+    assert targets[1]["is_tvm_target"]
+
+
 def test_parse_quotes_and_separators_on_options():
     targets_no_quote = tvmc.common.parse_target("foo -option1=+v1.0x,+value,+bar")
     targets_single_quote = tvmc.common.parse_target("foo -option1='+v1.0x,+value'")

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -42,6 +42,16 @@ def test_mapping_target_args():
     assert reconstruct_target_args(parsed) == {"llvm": {"mcpu": "cortex-m3"}}
 
 
+def test_skip_target_from_codegen():
+    parser = argparse.ArgumentParser()
+    generate_target_args(parser)
+    parsed, left = parser.parse_known_args(
+        ["--target=cmsis-nn, c", "--target-cmsis-nn-from_device=1", "--target-c-mcpu=cortex-m55"]
+    )
+    assert left == ["--target-cmsis-nn-from_device=1"]
+    assert reconstruct_target_args(parsed) == {"c": {"mcpu": "cortex-m55"}}
+
+
 def test_target_recombobulation_single():
     tvm_target, _ = tvmc.common.target_from_cli("llvm", {"llvm": {"mcpu": "cortex-m3"}})
 


### PR DESCRIPTION
This migrates CMSIS-NN to use Target Hooks instead of fully BYOC, which
means it will now go through any central passes the Driver API.

Found a few things whilst doing this:
* Forgot to mutate PrimFunc arguments in LowerTE which meant functions weren't getting lowered passed the first function in test_networks
* Target `cmsis-nn` needs to match external code generator `cmsis-nn` to connect the Target with the external code generator
* Partition Graph needed to sanitise compiler names to generate them properly in C
