### PR TITLE
[VMCompiler] Support shape func lowering for nested function call

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -466,8 +466,13 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
 
   Array<te::Tensor> VisitExpr_(const VarNode* var_node) final {
     auto var = GetRef<Var>(var_node);
-    auto it = param_states_.find(var);
-    if (it == param_states_.end()) {
+    auto it = param_arg_map_.find(var);
+    if (it != param_arg_map_.end()) {
+      // This var is a parameter of a nested function. Visit the corresponding argument in the
+      // function call site.
+      return VisitExpr(it->second);
+    }
+    if (param_states_.find(var) == param_states_.end()) {
       LOG(FATAL) << "Unexpected free variable " << var->name_hint();
       return {};
     } else {
@@ -542,6 +547,12 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
   }
 
   Array<te::Tensor> VisitExpr_(const CallNode* call_node) final {
+    if (auto* func = call_node->op.as<FunctionNode>()) {
+      for (size_t i = 0; i < func->params.size(); ++i) {
+        param_arg_map_[func->params[i]] = call_node->args[i];
+      }
+      return VisitExpr(func->body);
+    }
     static auto fshape_func = Op::GetAttrMap<FShapeFunc>("FShapeFunc");
     static auto tshape_data_dependent = Op::GetAttrMap<TShapeDataDependent>("TShapeDataDependent");
     ICHECK(call_node->op.as<OpNode>()) << "Primitive function only allows call into primitive ops";
@@ -601,7 +612,7 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
   }
 
   Array<te::Tensor> VisitExpr_(const FunctionNode* op) final {
-    LOG(FATAL) << "Do not support sub function";
+    LOG(FATAL) << "Nested functions are not allowed to be visited.";
     return Array<te::Tensor>();
   }
 
@@ -644,6 +655,10 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
   std::vector<bool> data_dependents_per_input_;
   /*! \brief Scalars used in the shape function */
   Array<te::Tensor> scalars_;
+  /*! \brief Map from parameters of a nested function to corresponding arguments in a function
+   * call site.
+   */
+  std::unordered_map<Var, Expr, ObjectPtrHash, ObjectPtrEqual> param_arg_map_;
 };
 
 CachedFunc ShapeFuncFor(const Function& prim_func, const Target& target,


### PR DESCRIPTION
Currently, VM compiler does not support lowering shape function for a primitive function that calls another, nested functions, like this:

```
def @tvmgen_default_test_main_0(%test_0_i0: Tensor[(?, 16), float32], %test_0_i1: Tensor[(?, 16), float32], Inline=1, Compiler="test", global_symbol="tvmgen_default_test_main_0", Primitive=1) -> Tensor[(?, ?), float32] {
  %0 = fn (%FunctionVar_0_0: Tensor[(?, 16), float32], %FunctionVar_0_1: Tensor[(?, 16), float32], PartitionedFromPattern="nn.dense_", Composite="test.dense") -> Tensor[(?, ?), float32] {
    nn.dense(%FunctionVar_0_0, %FunctionVar_0_1, units=None) /* ty=Tensor[(?, ?), float32] */
  };
  %0(%test_0_i0, %test_0_i1) /* ty=Tensor[(?, ?), float32] */
}
``` 
The error will be raised at https://github.com/apache/tvm/blob/4c590a2c855217f4e60cfd18f8eb459e5ba467b8/src/relay/backend/te_compiler_cache.cc#L547

However, a primitive function like this comes up in BYOC settings where `MergeComposite` is used. So the shape function lowering pass should be extended to support such use cases. 

The change is simple. I simply visit the body of the callee function to propagate shape information. 

Building on this PR, I'll follow up with a PR that adds dynamic shape support to CUTLASS BYOC, where an end-to-end test will be added. 

cc @comaniac @zhiics @icemelon  @mbs-octoml  