### PR TITLE
[TVMC] Keep quantized weights when importing PyTorch model

### DIFF
--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -262,7 +262,9 @@ class PyTorchFrontend(Frontend):
         input_shapes = list(shape_dict.items())
 
         logger.debug("parse Torch model and convert into Relay computation graph")
-        return relay.frontend.from_pytorch(traced_model, input_shapes, **kwargs)
+        return relay.frontend.from_pytorch(
+            traced_model, input_shapes, keep_quantized_weight=True, **kwargs
+        )
 
 
 class PaddleFrontend(Frontend):


### PR DESCRIPTION
BYOC requires `keep_quantized_weight` be set to true when converting PyTorch models using `from_torch`. Setting this to be True when importing a model using TVMC.

cc @leandron @masahi @ekalda 

