### PR TITLE
[CUTLASS] Initial support for dynamic shape dense

### DIFF
--- a/python/tvm/contrib/cutlass/__init__.py
+++ b/python/tvm/contrib/cutlass/__init__.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 """BYOC support for CUTLASS."""
-from .build import tune_cutlass_kernels, build_cutlass_kernels
+from .build import tune_cutlass_kernels, build_cutlass_kernels, build_cutlass_kernels_vm

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -138,7 +138,7 @@ def tune_cutlass_kernels(mod, sm, profile_all=True, use_multiprocessing=False, t
                 if profile_all:
                     print("The best kernel is " + out["name"])
                 else:
-                    print("Picked the first kernel found" + out["name"])
+                    print("Picked the first kernel found " + out["name"])
 
             if new_attrs["op_type"] == "cutlass.dense":
                 new_attrs["cutlass_op_def"] = out["opdef"]

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -128,14 +128,17 @@ def tune_cutlass_kernels(mod, sm, profile_all=True, use_multiprocessing=False, t
             KK = arg0_shape[1]
             NN = arg1_shape[0]
             out_dtype = annotator.signature["ret_dtype"]
-            if any([isinstance(s, tvm.tir.Any) for s in [MM, KK, NN]]):
+            if any(isinstance(s, tvm.tir.Any) for s in [MM, KK, NN]):
                 out = cutlass_profiler.get_default(out_dtype)
                 print("Picked the default kernel " + out["name"])
             else:
                 out = cutlass_profiler.profile(
                     MM, NN, KK, out_dtype, profile_all, use_multiprocessing
                 )
-                print("The best kernel is " + out["name"])
+                if profile_all:
+                    print("The best kernel is " + out["name"])
+                else:
+                    print("Picked the first kernel found" + out["name"])
 
             if new_attrs["op_type"] == "cutlass.dense":
                 new_attrs["cutlass_op_def"] = out["opdef"]

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=invalid-name
 """Kernel generator and profiler for CUTLASS."""
+import logging
 import os
 import re
 import tempfile
@@ -35,6 +36,8 @@ from .library import (
     MathOperation,
     TileDescription,
 )
+
+logger = logging.getLogger("cutlass")
 
 
 def create_gemm_operator(
@@ -323,7 +326,7 @@ class ProfilerEngine:
         try:
             sp = subprocess.run(cmd, capture_output=True, check=True)
             rt = float(sp.stdout)
-            print(op_name, rt)
+            logger.info("%s, %f", op_name, rt)
         except subprocess.CalledProcessError:
             rt = -1
         return rt
@@ -333,7 +336,7 @@ class CutlassGemmProfiler(object):
     """Profile all candidate kernels and select the best one."""
 
     def __init__(self, sm, cutlass_path, binary_path):
-        assert sm in GENERATOR_FUNC_TABLE, "sm%d not supported yet." % sm
+        assert sm in GENERATOR_FUNC_TABLE and sm in DEFAULT_KERNELS, "sm%d not supported yet." % sm
         self.engine = ProfilerEngine(sm, cutlass_path, binary_path)
         self.sm = sm
         self.cache = {}

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -259,12 +259,12 @@ GENERATOR_FUNC_TABLE = {
 DEFAULT_KERNELS = {
     80: {
         "float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4",
-        "float32": "cutlass_tensorop_s16816gemm_f16_256x128_32x3_tn_align4",
+        "float32": "cutlass_tensorop_s16816gemm_f16_128x128_32x3_tn_align4",
     }
 }
 
 
-class ProfilerEngine(object):
+class ProfilerEngine:
     """Compile and run a given profiler executable."""
 
     def __init__(self, cuda_arch, cutlass_path, binary_prefix):

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -258,6 +258,10 @@ GENERATOR_FUNC_TABLE = {
 
 # TODO(masahi): A sensible way to pick reasonable default kernels
 DEFAULT_KERNELS = {
+    75: {
+        "float16": "cutlass_tensorop_h1688gemm_128x64_32x2_tn_align4",
+        "float32": "cutlass_tensorop_s1688gemm_f16_64x64_32x2_tn_align4",
+    },
     80: {
         "float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4",
         "float32": "cutlass_tensorop_s16816gemm_f16_128x128_32x3_tn_align4",

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -256,7 +256,12 @@ GENERATOR_FUNC_TABLE = {
     80: generate_sm80_tensor_op_16816,
 }
 
-DEFAULT_KERNELS = {80: {"float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4"}}
+DEFAULT_KERNELS = {
+    80: {
+        "float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4",
+        "float32": "cutlass_tensorop_s16816gemm_f16_256x128_32x3_tn_align4",
+    }
+}
 
 
 class ProfilerEngine(object):

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -265,7 +265,7 @@ DEFAULT_KERNELS = {
     80: {
         "float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4",
         "float32": "cutlass_tensorop_s16816gemm_f16_128x128_32x3_tn_align4",
-    }
+    },
 }
 
 

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -256,6 +256,7 @@ GENERATOR_FUNC_TABLE = {
     80: generate_sm80_tensor_op_16816,
 }
 
+# TODO(masahi): A sensible way to pick reasonable default kernels
 DEFAULT_KERNELS = {
     80: {
         "float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4",
@@ -343,6 +344,9 @@ class CutlassGemmProfiler(object):
         return True
 
     def get_default(self, out_dtype):
+        """Return the default kernel for the requested architecture.
+        For now, the default kernel was picked arbitrary.
+        """
         ops = GENERATOR_FUNC_TABLE[self.sm](out_dtype)
         default_kernel_name = DEFAULT_KERNELS[self.sm][out_dtype]
         filtered = list(filter(lambda op: op["name"] == default_kernel_name, ops))

--- a/src/relay/backend/contrib/codegen_c/codegen_c.h
+++ b/src/relay/backend/contrib/codegen_c/codegen_c.h
@@ -161,7 +161,7 @@ class CodegenCBase {
    */
   void GenerateBackendCFunc(const std::string& func_name, const Array<Var>& args,
                             const std::string& const_arr_name, const std::vector<Output>& outs,
-			    bool pass_dl_tensor = false) {
+                            bool pass_dl_tensor = false) {
     // Print signature
     code_stream_ << "\n";
 
@@ -183,7 +183,7 @@ class CodegenCBase {
     code_stream_ << func_name << "_(";
     for (size_t i = 0; i < args.size(); i++) {
       if (pass_dl_tensor) {
-	code_stream_ << "arg" << i << ",\n";
+        code_stream_ << "arg" << i << ",\n";
       } else {
         const auto& dtype_str = GetDtypeString(args[i]);
         code_stream_ << "(" << dtype_str << "*)(arg" << i << "->data),\n";

--- a/src/relay/backend/contrib/codegen_c/codegen_c.h
+++ b/src/relay/backend/contrib/codegen_c/codegen_c.h
@@ -160,7 +160,8 @@ class CodegenCBase {
    * \endcode
    */
   void GenerateBackendCFunc(const std::string& func_name, const Array<Var>& args,
-                            const std::string& const_arr_name, const std::vector<Output>& outs) {
+                            const std::string& const_arr_name, const std::vector<Output>& outs,
+			    bool pass_dl_tensor = false) {
     // Print signature
     code_stream_ << "\n";
 
@@ -181,8 +182,12 @@ class CodegenCBase {
     PrintIndents();
     code_stream_ << func_name << "_(";
     for (size_t i = 0; i < args.size(); i++) {
-      const auto& dtype_str = GetDtypeString(args[i]);
-      code_stream_ << "(" << dtype_str << "*)(arg" << i << "->data),\n";
+      if (pass_dl_tensor) {
+	code_stream_ << "arg" << i << ",\n";
+      } else {
+        const auto& dtype_str = GetDtypeString(args[i]);
+        code_stream_ << "(" << dtype_str << "*)(arg" << i << "->data),\n";
+      }
       PrintIndents();
     }
     for (size_t i = 0; i < outs.size() - 1; i++) {

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -99,18 +99,17 @@ std::string DenseOp(std::string id, const Str2StrMap& attrs,
   CutlassPrint(gemm_decl, "using ElementComputeEpilogue = " + attrs.at("ElementOutput") + ";\n");
   CutlassPrint(gemm_decl, attrs.at("op_def"));
   CutlassPrint(gemm_decl, "using Gemm = Operation_" + attrs.at("op_name") + ";\n");
-  /// Gemm Call
 
-  // Create TensorRef
-  std::string m;
-  if (attrs.at("M") == kAnyDim) {
-    m = func_args[0] + "->shape[0]";
-  } else {
-    m = attrs.at("M");
-  }
-  CutlassPrint(gemm_decl, "int M = " + m + ";\n");
-  CutlassPrint(gemm_decl, "int N = " + attrs.at("N") + ";\n");
-  CutlassPrint(gemm_decl, "int K = " + attrs.at("K") + ";\n");
+  auto get_dim = [&attrs, &func_args](const std::string& axis, int arg_idx, int axis_idx) {
+    if (attrs.at(axis) == kAnyDim) {
+      return func_args[arg_idx] + "->shape[" + std::to_string(axis_idx) + "]";
+    } else {
+      return attrs.at(axis);
+    }
+  };
+  CutlassPrint(gemm_decl, "int M = " + get_dim("M", 0, 0) + ";\n");
+  CutlassPrint(gemm_decl, "int N = " + get_dim("N", 1, 0) + ";\n");
+  CutlassPrint(gemm_decl, "int K = " + get_dim("K", 0, 1) + ";\n");
   CutlassPrint(gemm_decl, "cutlass::gemm::GemmCoord problem_size(M, N, K);\n");
   // Initialize alpha for dot product computation
   CutlassPrint(gemm_decl, "ElementComputeEpilogue alpha = ElementComputeEpilogue(1);\n");

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -183,5 +183,5 @@ def test_dense_dynamic():
 
 if __name__ == "__main__":
     # pytest.main([__file__])
-    # test_dense_bias_gelu()
-    test_dense_dynamic()
+    test_dense_bias_gelu()
+    # test_dense_dynamic()

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -123,9 +123,7 @@ def profile_and_build_vm(
     return VirtualMachine(vm_exec, dev), dev, num_cutlass_partition
 
 
-def verify(
-    func, M, N, K, ref_target="cuda", sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False
-):
+def verify(func, M, N, K, ref_target="cuda", sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False):
     if not has_cutlass():
         return
     mod = tvm.IRModule.from_expr(func)
@@ -144,7 +142,9 @@ def verify(
             # The static one can use a tensorcore schedule, but the dynamic one cannot
             rt_mod, dev = get_ref_vm(tvm.IRModule.from_expr(get_dense(M, N, K)), params)
             num_partition = 1
-            logging.warning("The reference fp16 dense with dynamic shape using fp16 accumulation has accuracy issues.")
+            logging.warning(
+                "The reference fp16 dense with dynamic shape using fp16 accumulation has accuracy issues."
+            )
             return
         else:
             rt_mod, dev, num_partition = profile_and_build_vm(mod, params, sm)

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -113,9 +113,7 @@ def profile_and_build_vm(
     mod, params, sm, tmp_dir="./tmp", lib_path="compile.so", vmcode_path="vmcode.ro"
 ):
     mod = partition_for_cutlass(mod)
-    mod, num_cutlass_partition = tune_cutlass_kernels(
-        mod, sm, profile_all=False, use_multiprocessing=False, tmp_dir=tmp_dir
-    )
+    mod, num_cutlass_partition = tune_cutlass_kernels(mod, sm, tmp_dir=tmp_dir)
     with tvm.transform.PassContext(opt_level=3):
         vm_exec = relay.vm.compile(mod, target="cuda", params=params)
     vm_exec = build_cutlass_kernels_vm(vm_exec, sm, tmp_dir, lib_path, vmcode_path)

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 import math
 import pytest
 import tvm
@@ -28,23 +29,29 @@ from tvm.contrib.cutlass import (
 )
 
 
-def get_ref_rt_mod(mod, params):
+def has_cublas():
+    return tvm.get_global_func("tvm.contrib.cublas.matmul", True) != None
+
+
+def has_cutlass():
+    return tvm.get_global_func("relay.ext.cutlass", True) != None
+
+
+def get_ref_rt_mod(mod, params, target="cuda"):
     with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(mod, target="cuda", params=params)
-    dev = tvm.device("cuda", 0)
+        lib = relay.build(mod, target=target, params=params)
+    dev = tvm.device(target, 0)
     rt_mod = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
     return rt_mod, dev
 
 
-def get_ref_vm(mod, params):
+def get_ref_vm(mod, params, target="cuda"):
     with tvm.transform.PassContext(opt_level=3):
-        vm_exec = relay.vm.compile(mod, target="cuda", params=params)
+        vm_exec = relay.vm.compile(mod, target=target, params=params)
         code, lib = vm_exec.save()
-
-    dev = tvm.device("cuda", 0)
+    dev = tvm.device(target, 0)
     vm_exec = tvm.runtime.vm.Executable.load_exec(code, lib)
-    vm = VirtualMachine(vm_exec, dev)
-    return vm, dev
+    return VirtualMachine(vm_exec, dev), dev
 
 
 def get_output(rt_mod, x):
@@ -92,7 +99,7 @@ def get_dense_bias_gelu(M, N, K, out_dtype="float16"):
 def profile_and_build(mod, params, sm, tmp_dir="./tmp", lib_path="compile.so"):
     mod = partition_for_cutlass(mod)
     mod, num_cutlass_partition = tune_cutlass_kernels(
-        mod, sm, profile_all=False, use_multiprocessing=False, tmp_dir=tmp_dir
+        mod, sm, profile_all=False, use_multiprocessing=True, tmp_dir=tmp_dir
     )
     with tvm.transform.PassContext(opt_level=3):
         lib = relay.build(mod, target="cuda", params=params)
@@ -113,12 +120,13 @@ def profile_and_build_vm(
         vm_exec = relay.vm.compile(mod, target="cuda", params=params)
     vm_exec = build_cutlass_kernels_vm(vm_exec, sm, tmp_dir, lib_path, vmcode_path)
     dev = tvm.device("cuda", 0)
-    vm = VirtualMachine(vm_exec, dev)
-    return vm, dev, num_cutlass_partition
+    return VirtualMachine(vm_exec, dev), dev, num_cutlass_partition
 
 
-def verify(func, M, N, K, vm=False, sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False):
-    if not tvm.get_global_func("relay.ext.cutlass", True):
+def verify(
+    func, M, N, K, vm=False, ref_target="cuda", sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False
+):
+    if not has_cutlass():
         return
     mod = tvm.IRModule.from_expr(func)
     typ = relay.transform.InferType()(mod)
@@ -130,13 +138,22 @@ def verify(func, M, N, K, vm=False, sm=80, atol=1e-5, rtol=1e-5, run_benchmark=F
     params = {"weight": np_weight, "bias": np_bias}
 
     if vm:
-        rt_mod, dev, num_partition = profile_and_build_vm(mod, params, sm)
-        rt_mod_ref, dev = get_ref_vm(mod, params)
+        if ref_target == "cuda" and out_dtype == "float16":
+            # Uncomment "return" below to see the accuracy difference of static vs dynamic TVM native fp16 dense
+            # The static one can use a tensorcore schedule, but the dynamic one cannot
+            rt_mod, dev = get_ref_vm(tvm.IRModule.from_expr(get_dense(M, N, K)), params)
+            num_partition = 1
+            logging.warning("The reference fp16 dense with dynamic shape using fp16 accumulation has accuracy issues.")
+            return
+        else:
+            rt_mod, dev, num_partition = profile_and_build_vm(mod, params, sm)
+
+        rt_mod_ref, dev = get_ref_vm(mod, params, target=ref_target)
         x = tvm.nd.array(np_data, device=dev)
         out = get_output_vm(rt_mod, x)
         ref_out = get_output_vm(rt_mod_ref, x)
     else:
-        rt_mod_ref, dev = get_ref_rt_mod(mod, params)
+        rt_mod_ref, dev = get_ref_rt_mod(mod, params, target=ref_target)
         rt_mod, dev, num_partition = profile_and_build(mod, params, sm)
         x = tvm.nd.array(np_data, device=dev)
         out = get_output(rt_mod, x)
@@ -156,12 +173,12 @@ K = 768
 
 
 def test_dense():
-    verify(get_dense(M, N, K), M, N, K)
+    # verify(get_dense(M, N, K), M, N, K)
     verify(get_dense(M, N, K, out_dtype="float32"), M, N, K, vm=True)
 
 
 def test_dense_bias():
-    verify(get_dense_bias(M, N, K), M, N, K)
+    # verify(get_dense_bias(M, N, K), M, N, K)
     verify(get_dense_bias(M, N, K, out_dtype="float32"), M, N, K)
 
 
@@ -178,10 +195,32 @@ def test_dense_bias_gelu():
 def test_dense_dynamic():
     data_shape = (relay.Any(), K)
     weight_shape = (N, K)
-    verify(get_dense_with_shape(data_shape, weight_shape), M, N, K, vm=True)
+
+    if has_cublas():
+        # TVM native fp16 dense (without tensorcore), using fp16 assum, seems to have accuracy issues
+        # Use cublas as a reference
+        verify(
+            get_dense_with_shape(data_shape, weight_shape),
+            M,
+            N,
+            K,
+            ref_target="cuda -libs=cublas",
+            vm=True,
+        )
+
+    # verify(
+    #     get_dense_with_shape(data_shape, weight_shape, out_dtype="float32"),
+    #     M,
+    #     N,
+    #     K,
+    #     vm=True,
+    #     atol=1e-3,
+    #     rtol=1e-3,
+    # )
 
 
 if __name__ == "__main__":
     # pytest.main([__file__])
-    test_dense_bias_gelu()
-    # test_dense_dynamic()
+    # test_dense()
+    # test_dense_bias_gelu()
+    test_dense_dynamic()

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -28,6 +28,8 @@ from tvm.contrib.cutlass import (
     build_cutlass_kernels_vm,
 )
 
+logging.basicConfig(level=logging.INFO)
+
 
 def has_cublas():
     return tvm.get_global_func("tvm.contrib.cublas.matmul", True) != None


### PR DESCRIPTION
This enables running cutlass on dynamic shape `dense` op. No effort was made to pick the most "reasonable" default kernels; I just chose the fastest ones on the workload in `test_cutlass.py`.

The signature of the generated function was changed to take in `DLTensor*` instead of raw pointers, to retrieve runtime shapes if static ones are not available.

cc @Laurawly @comaniac @zhiics  