### PR TITLE
BUG: alloc_tensor offset and reshape shape should be on the CPU

### DIFF
--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -132,6 +132,13 @@ class Executable : public ModuleNode {
   std::string GetBytecode() const;
 
   /*!
+   * \brief Returns a description of all the contants in the executable in human-readable
+   * format. Not intended to be machine readable, but rather to help with debugging and
+   * diffing generated code.
+   */
+  std::string GetConstants() const;
+
+  /*!
    * \brief Print the detailed statistics of the given code, i.e. number of
    * globls and constants, etc.
    */

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -71,6 +71,7 @@ class Executable(object):
         self._save = self.mod["save"]
         self._get_lib = self.mod["get_lib"]
         self._get_bytecode = self.mod["get_bytecode"]
+        self._get_constants = self.mod["get_constants"]
         self._get_stats = self.mod["get_stats"]
         self._get_function_arity = self.mod["get_function_arity"]
         self._get_function_param_name = self.mod["get_function_param_name"]
@@ -243,6 +244,12 @@ class Executable(object):
         doesn't need to deal with it as well.
         """
         return self._get_bytecode()
+
+    @property
+    def constants(self):
+        """Returns a human-readable description of all the constants in the executable.
+        Useful for debugging and diffing generated executables in unit tests."""
+        return self._get_constants()
 
     @property
     def globals(self):

--- a/src/relay/transforms/memory_alloc.cc
+++ b/src/relay/transforms/memory_alloc.cc
@@ -62,8 +62,9 @@ inline Constant MakeConstant(const std::vector<int64_t>& value) {
 }
 
 inline Expr AllocTensor(const Expr& storage, tvm::relay::Expr shape, DataType dtype,
-                        Array<IndexExpr> assert_shape) {
-  auto offset = MakeConstantScalar(DataType::Int(64), 0);
+                        Array<IndexExpr> assert_shape, DLDeviceType offset_device_type) {
+  auto offset =
+      OnDevice(MakeConstantScalar(DataType::Int(64), 0), offset_device_type, /*is_fixed=*/true);
   return AllocTensor(storage, offset, shape, dtype, assert_shape);
 }
 
@@ -267,8 +268,9 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
     auto sto = scope->Push(var, value);
 
     // TODO(@jroesch): There is a bug with typing based on the constant shape.
-    auto tensor = OnDevice(AllocTensor(sto, shape, type->dtype, /*assert_shape=*/type->shape),
-                           dev.device_type, /*is_fixed=*/true);
+    auto tensor = OnDevice(
+        AllocTensor(sto, shape, type->dtype, /*assert_shape=*/type->shape, cpu_device_.device_type),
+        dev.device_type, /*is_fixed=*/true);
     Var tensor_var("tensor_" + name_hint, Type(nullptr));
     return scope->Push(tensor_var, tensor);
   }
@@ -367,7 +369,8 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
       auto out_shape = out_shapes[i];
       auto out_type = out_types[i];
       auto storage = storages[i];
-      auto alloc = OnDevice(AllocTensor(storage, out_shape, out_type->dtype, out_type->shape),
+      auto alloc = OnDevice(AllocTensor(storage, out_shape, out_type->dtype, out_type->shape,
+                                        cpu_device_.device_type),
                             dev.device_type, /*is_fixed=*/true);
       Var out_var("out_" + std::to_string(i), Type(nullptr));
       outs.push_back(scope->Push(out_var, alloc));
@@ -394,7 +397,7 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
         CHECK(imm) << "expect static int shape";
         shape.push_back(imm->value);
       }
-      shape_expr = MakeConstant(shape);
+      shape_expr = OnDevice(MakeConstant(shape), cpu_device_.device_type, /*is_fixed=*/true);
     }
     return ReshapeTensor(new_args[0], shape_expr, ret_ty->shape);
   }

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -61,6 +61,8 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
   } else if (name == "get_bytecode") {
     return PackedFunc(
         [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->GetBytecode(); });
+  } else if (name == "get_constants") {
+    return PackedFunc([this](TVMArgs args, TVMRetValue* rv) { *rv = this->GetConstants(); });
   } else if (name == "get_stats") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->Stats(); });
   } else if (name == "save") {
@@ -143,6 +145,34 @@ std::string Executable::GetBytecode() const {
     oss << std::endl;
   }
 
+  return oss.str();
+}
+
+namespace {
+String ShapeString(const ShapeTuple& shape_tuple, DLDataType dtype) {
+  std::stringstream sizes;
+  sizes << dtype << "[";
+  for (size_t i = 0; i < shape_tuple.size(); i++) {
+    if (i != 0) {
+      sizes << ", ";
+    }
+    sizes << shape_tuple.data()[i];
+  }
+  sizes << "]";
+  return String(sizes.str());
+}
+}  // namespace
+
+std::string Executable::GetConstants() const {
+  std::ostringstream oss;
+
+  for (size_t i = 0; i < constants.size(); ++i) {
+    const auto& constant = constants[i];
+    auto ndarray = Downcast<NDArray>(constant);
+    DLDeviceType device_type = static_cast<DLDeviceType>(const_device_type[i]);
+    oss << "VM Constant[" << i << "]: has shape " << ShapeString(ndarray.Shape(), ndarray->dtype)
+        << " on device of type " << device_type << std::endl;
+  }
   return oss.str();
 }
 

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -151,7 +151,7 @@ std::string Executable::GetBytecode() const {
 namespace {
 String ShapeString(const ShapeTuple& shape_tuple, DLDataType dtype) {
   std::stringstream sizes;
-  sizes << dtype << "[";
+  sizes << DLDataType2String(dtype) << "[";
   for (size_t i = 0; i < shape_tuple.size(); i++) {
     if (i != 0) {
       sizes << ", ";

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -999,6 +999,71 @@ def test_shape_func_nested_function():
     compiler.lower(mod, "llvm")
 
 
+def test_storage_size_and_offset_on_cpu():
+    """Tests allocations place sizes and offsets on the CPU host even if the rest
+    of the computation is on a different device type."""
+
+    # CPU = device type 1
+    # GPU = device type 2
+    def input():
+        return tvm.parser.fromtext(
+            """
+            #[version = "0.0.5"]
+            def @main(%a: Tensor[(5, 7), float32],
+                      param_device_types=[2], result_device_type=2) {
+              add(%a, %a)
+            }
+        """
+        )
+
+    exe = relay.vm.compile(
+        input(),
+        tvm.target.Target("cuda"),
+    )
+
+    print(exe.constants)
+    print(exe.bytecode)
+
+    # This program needs two constants:
+    # - The size of the tensor's storage (first arg) to alloc_storage
+    # - The offset of the tensor within the storage (second arg) to alloc_tensor
+    # Both should be on the CPU
+    assert not "on device of type 2" in exe.constants
+    assert "on device of type 1" in exe.constants
+
+
+def test_reshape_shape_on_cpu():
+    """Tests the argument to a reshape places the shape on the CPU host even if the rest
+    of the copmutation is on a different device type."""
+
+    # CPU = device type 1
+    # GPU = device type 2
+    def input():
+        newshape = [2, 4, 2]
+        metatable = {"relay.Constant": [relay.const(newshape, dtype="int64")]}
+        return tvm.parser.fromtext(
+            """
+            #[version = "0.0.5"]
+            def @main(%x: Tensor[(2, 8), float32],
+                      param_device_types=[2], result_device_type=2) {
+              reshape(%x, newshape=[2, 4, 2])
+            }
+        """
+        )
+
+    exe = relay.vm.compile(
+        input(),
+        tvm.target.Target("cuda"),
+    )
+
+    print(exe.constants)
+    print(exe.bytecode)
+
+    # The newshape annotation should have been turned into a constant on the CPU.
+    assert not "on device of type 2" in exe.constants
+    assert "on device of type 1" in exe.constants
+
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -999,9 +999,11 @@ def test_shape_func_nested_function():
     compiler.lower(mod, "llvm")
 
 
+@tvm.testing.requires_cuda
 def test_storage_size_and_offset_on_cpu():
     """Tests allocations place sizes and offsets on the CPU host even if the rest
     of the computation is on a different device type."""
+    # TODO(mbs): Better would be to test ManifestAlloc independently.
 
     # CPU = device type 1
     # GPU = device type 2
@@ -1021,9 +1023,6 @@ def test_storage_size_and_offset_on_cpu():
         tvm.target.Target("cuda"),
     )
 
-    print(exe.constants)
-    print(exe.bytecode)
-
     # This program needs two constants:
     # - The size of the tensor's storage (first arg) to alloc_storage
     # - The offset of the tensor within the storage (second arg) to alloc_tensor
@@ -1032,15 +1031,15 @@ def test_storage_size_and_offset_on_cpu():
     assert "on device of type 1" in exe.constants
 
 
+@tvm.testing.requires_cuda
 def test_reshape_shape_on_cpu():
     """Tests the argument to a reshape places the shape on the CPU host even if the rest
-    of the copmutation is on a different device type."""
+    of the computation is on a different device type."""
+    # TODO(mbs): Better would be to test ManifestAlloc independently.
 
     # CPU = device type 1
     # GPU = device type 2
     def input():
-        newshape = [2, 4, 2]
-        metatable = {"relay.Constant": [relay.const(newshape, dtype="int64")]}
         return tvm.parser.fromtext(
             """
             #[version = "0.0.5"]
@@ -1055,9 +1054,6 @@ def test_reshape_shape_on_cpu():
         input(),
         tvm.target.Target("cuda"),
     )
-
-    print(exe.constants)
-    print(exe.bytecode)
 
     # The newshape annotation should have been turned into a constant on the CPU.
     assert not "on device of type 2" in exe.constants


### PR DESCRIPTION
The VM ManifestAlloc pass was allocating constants in a few places I
forgot to tag with on_device for the host/cpu. As a result the runtime
would (silently) do the x-device copy, which destroys perf.

To make this easier to spot in the future added a 'constants' property
to the VM Executable to dump the shape & device for all VM constants.

This is CORE-102 in OctoML JIRA.

(Special thanks to @mbrookhart  & @tkonolige for finding this.)