### PR TITLE
[TensorIR] Print TVMScript with prefix T instead of tir

### DIFF
--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -256,7 +256,7 @@ class IRModule(Node):
     def __repr__(self):
         return self.astext()
 
-    def script(self, tir_prefix: str = "tir", show_meta: bool = False) -> str:
+    def script(self, tir_prefix: str = "T", show_meta: bool = False) -> str:
         """Print IRModule into TVMScript
 
         Parameters

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -143,7 +143,7 @@ class PrimFunc(BaseFunc):
         """
         return _ffi_api.Specialize(self, param_map)  # type: ignore
 
-    def script(self, tir_prefix: str = "tir", show_meta: bool = False) -> str:
+    def script(self, tir_prefix: str = "T", show_meta: bool = False) -> str:
         """Print IRModule into TVMScript
 
         Parameters

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -310,6 +310,13 @@ class TVMScriptPrinter : public StmtFunctor<Doc(const Stmt&)>,
     }
     return doc;
   }
+
+ public:
+  static Doc PrintHeader(const std::string& tir_prefix) {
+    Doc header;
+    header << "from tvm.script import tir as " << tir_prefix << Doc::NewLine();
+    return header;
+  }
 };
 
 Doc TVMScriptPrinter::GetUniqueName(std::string prefix) {
@@ -1437,7 +1444,10 @@ Doc TVMScriptPrinterWithDiagnostic::PrintLoop(const For& loop) {
 
 String AsTVMScript(const ObjectRef& mod, const String& tir_prefix, bool show_meta) {
   ICHECK(mod->IsInstance<PrimFuncNode>() || mod->IsInstance<IRModuleNode>());
-  return TVMScriptPrinter(tir_prefix, show_meta).Print(mod).str() + "\n";
+  Doc doc;
+  doc << TVMScriptPrinter::PrintHeader(tir_prefix)
+      << TVMScriptPrinter(tir_prefix, show_meta).Print(mod);
+  return doc.str() + "\n";
 }
 
 TVM_REGISTER_GLOBAL("script.AsTVMScript").set_body_typed(AsTVMScript);
@@ -1445,7 +1455,10 @@ TVM_REGISTER_GLOBAL("script.AsTVMScript").set_body_typed(AsTVMScript);
 String AsTVMScriptWithDiagnostic(const ObjectRef& mod, const String& tir_prefix, bool show_meta,
                                  runtime::TypedPackedFunc<std::string(Stmt)> annotate) {
   ICHECK(mod->IsInstance<PrimFuncNode>() || mod->IsInstance<IRModuleNode>());
-  return TVMScriptPrinterWithDiagnostic(tir_prefix, show_meta, annotate).Print(mod).str() + "\n";
+  Doc doc;
+  doc << TVMScriptPrinter::PrintHeader(tir_prefix)
+      << TVMScriptPrinterWithDiagnostic(tir_prefix, show_meta, annotate).Print(mod);
+  return doc.str() + "\n";
 }
 
 TVM_REGISTER_GLOBAL("script.AsTVMScriptWithDiagnostic").set_body_typed(AsTVMScriptWithDiagnostic);

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -314,7 +314,11 @@ class TVMScriptPrinter : public StmtFunctor<Doc(const Stmt&)>,
  public:
   static Doc PrintHeader(const std::string& tir_prefix) {
     Doc header;
-    header << "from tvm.script import tir as " << tir_prefix << Doc::NewLine();
+    if (tir_prefix != "tir") {
+      header << "# from tvm.script import tir as " << tir_prefix << Doc::NewLine();
+    } else {
+      header << "# from tvm.script import tir" << Doc::NewLine();
+    }
     return header;
   }
 };

--- a/src/tir/schedule/error.cc
+++ b/src/tir/schedule/error.cc
@@ -52,7 +52,7 @@ String ScheduleError::RenderReport(const String& primitive) const {
 
   os << "ScheduleError: An error occurred in the schedule primitive '" << primitive
      << "'.\n\nThe IR with diagnostic is:\n"
-     << AsTVMScriptWithDiagnostic(mod, "tir", false, annotate);
+     << AsTVMScriptWithDiagnostic(mod, "T", false, annotate);
 
   // print error message
   os << "Error message: " << msg;

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -548,9 +548,10 @@ def test_reorder_fail_block():
         sch.reorder(l, i)
     expected_sub_error_message = (
         "            # tir.Block#0\n"
-        '            with tir.block("B"):\n'
-        "            ^^^^^^^^^^^^^^^^^^^^\n"
+        '            with T.block("B"):\n'
+        "            ^^^^^^^^^^^^^^^^^^\n"
     )
+    print("expected: ", expected_sub_error_message, "actual: ", str(execinfo.value))
     assert expected_sub_error_message in str(execinfo.value)
 
 
@@ -561,11 +562,12 @@ def test_reorder_fail_nested_loop_inner():
     with pytest.raises(tvm.tir.ScheduleError) as execinfo:
         sch.reorder(k, i)
     expected_sub_error_message = (
-        "        for i in tir.serial(0, 128):\n"
+        "        for i in T.serial(0, 128):\n"
         "            # tir.For#0\n"
-        "            for j in tir.serial(0, 128):\n"
-        "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+        "            for j in T.serial(0, 128):\n"
+        "            ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
     )
+    print("expected: ", expected_sub_error_message, "actual: ", str(execinfo.value))
     assert expected_sub_error_message in str(execinfo.value)
 
 
@@ -577,10 +579,11 @@ def test_fuse_fail_nested_loop_outer():
         sch.fuse(k, i)
     expected_sub_error_message = (
         "        # tir.For#1\n"
-        "        for i in tir.serial(0, 128):\n"
-        "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
-        "            for j in tir.serial(0, 128):\n"
+        "        for i in T.serial(0, 128):\n"
+        "        ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+        "            for j in T.serial(0, 128):\n"
     )
+    print("expected: ", expected_sub_error_message, "actual: ", str(execinfo.value))
     assert expected_sub_error_message in str(execinfo.value)
 
 

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -551,7 +551,6 @@ def test_reorder_fail_block():
         '            with T.block("B"):\n'
         "            ^^^^^^^^^^^^^^^^^^\n"
     )
-    print("expected: ", expected_sub_error_message, "actual: ", str(execinfo.value))
     assert expected_sub_error_message in str(execinfo.value)
 
 
@@ -567,7 +566,6 @@ def test_reorder_fail_nested_loop_inner():
         "            for j in T.serial(0, 128):\n"
         "            ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
     )
-    print("expected: ", expected_sub_error_message, "actual: ", str(execinfo.value))
     assert expected_sub_error_message in str(execinfo.value)
 
 
@@ -583,7 +581,6 @@ def test_fuse_fail_nested_loop_outer():
         "        ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
         "            for j in T.serial(0, 128):\n"
     )
-    print("expected: ", expected_sub_error_message, "actual: ", str(execinfo.value))
     assert expected_sub_error_message in str(execinfo.value)
 
 


### PR DESCRIPTION
This PR tries to change the TVMScript printers to use `T` alias for the `tir` module as discussed in the [conversation here](https://github.com/apache/tvm/pull/9315#issuecomment-950078661)