### PR TITLE
Bump the CMake version in ubuntu_install_cmake_source.sh to 3.14.7.

### DIFF
--- a/docker/install/ubuntu_install_cmake_source.sh
+++ b/docker/install/ubuntu_install_cmake_source.sh
@@ -20,8 +20,8 @@ set -e
 set -u
 set -o pipefail
 
-v=3.13
-version=3.13.5
+v=3.14
+version=3.14.7
 wget https://cmake.org/files/v${v}/cmake-${version}.tar.gz
 tar xvf cmake-${version}.tar.gz
 cd cmake-${version}


### PR DESCRIPTION
Bump the CMake version in ubuntu_install_cmake_source.sh to 3.14.7

 * This is required in platforms we need to build xgboost from source
 * Fixes #9414


cc @tkonolige @tqchen @areusch @Mousius 