### PR TITLE
Fix repository URL in ubuntu_install_rocm.sh

### DIFF
--- a/docker/install/ubuntu_install_rocm.sh
+++ b/docker/install/ubuntu_install_rocm.sh
@@ -25,6 +25,6 @@ wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
 echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.3/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 apt-get update && apt-get install -y \
     rocm-dev \
-    lld && \
+    lld-12 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/install/ubuntu_install_rocm.sh
+++ b/docker/install/ubuntu_install_rocm.sh
@@ -21,8 +21,8 @@ set -u
 set -o pipefail
 
 # Install ROCm cross compilation toolchain.
-wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list
+wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.3/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 apt-get update && apt-get install -y \
     rocm-dev \
     lld && \


### PR DESCRIPTION
Fix repository URL in ubuntu_install_rocm.sh:
* ROCm dependency installation process was following outdated procedures.
  This PR makes the installation script to point to the correct repository
* Installation documentation is at:
  https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html
* Fixes #9413

cc @tqchen @jtuyls @Mousius 