### PR TITLE
Removed a manual file handler pitfall

### DIFF
--- a/version.py
+++ b/version.py
@@ -126,19 +126,20 @@ def update(file_name, pattern, repl, dry_run=False):
     update = []
     hit_counter = 0
     need_update = False
-    for l in open(file_name):
-        result = re.findall(pattern, l)
-        if result:
-            assert len(result) == 1
-            hit_counter += 1
-            if result[0] != repl:
-                l = re.sub(pattern, repl, l)
-                need_update = True
-                print("%s: %s -> %s" % (file_name, result[0], repl))
-            else:
-                print("%s: version is already %s" % (file_name, repl))
+    with open(file_name) as file:
+        for l in file:
+            result = re.findall(pattern, l)
+            if result:
+                assert len(result) == 1
+                hit_counter += 1
+                if result[0] != repl:
+                    l = re.sub(pattern, repl, l)
+                    need_update = True
+                    print("%s: %s -> %s" % (file_name, result[0], repl))
+                else:
+                    print("%s: version is already %s" % (file_name, repl))
 
-        update.append(l)
+            update.append(l)
     if hit_counter != 1:
         raise RuntimeError("Cannot find version in %s" % file_name)
 


### PR DESCRIPTION
**The problem**
There was a case where the code was using a manual file handler pitfall, where a file stream was being opened and closed manually. But since Python supports automatic stream closing using the block 'with', its better to use it instead of the manual close in order to remove a bug vector.

**Solution**
Refactored the code to remove the manual file handler