### PR TITLE
Add is_global_func tag to differentiate global and device function

### DIFF
--- a/include/tvm/tir/function.h
+++ b/include/tvm/tir/function.h
@@ -289,6 +289,13 @@ constexpr const char* kIsEntryFunc = "tir.is_entry_func";
  */
 constexpr const char* kLinkedParams = "tir.linked_params";
 
+/*!
+ * \brief Mark the function as the global function called from the host.
+ *
+ * Type: Integer
+ */
+constexpr const char* kIsGlobalFunc = "tir.is_global_func";
+
 }  // namespace attr
 }  // namespace tir
 }  // namespace tvm

--- a/src/tir/transforms/split_host_device.cc
+++ b/src/tir/transforms/split_host_device.cc
@@ -278,6 +278,7 @@ class HostDeviceSplitter : public StmtMutator {
         WithAttr(std::move(device_func), tvm::attr::kGlobalSymbol, runtime::String(kernel_symbol));
     device_func = WithAttr(std::move(device_func), tir::attr::kNoAlias, Integer(1));
     device_func = WithAttr(std::move(device_func), tvm::attr::kTarget, device_target_);
+    device_func = WithAttr(std::move(device_func), tir::attr::kIsGlobalFunc, Integer(1));
     if (m.use_dyn_shmem_) {
       device_func =
           WithAttr(std::move(device_func), tir::attr::kDeviceUseDynSharedMemory, Integer(1));

--- a/tests/python/unittest/test_tir_transform_split_host_device.py
+++ b/tests/python/unittest/test_tir_transform_split_host_device.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+from tvm import te
+import tvm.testing
+
+
+@tvm.testing.requires_cuda
+def test_split_host_device_func_attr():
+    m = te.size_var("m")
+    l = te.size_var("l")
+    A = te.placeholder((m, l), name="A")
+
+    A1 = te.compute((m, l), lambda i, j: A[i, j], name="A1")
+    A2 = te.compute((m, l), lambda i, j: A1[i, j] + 3, name="A2")
+
+    s = te.create_schedule(A2.op)
+    xo, xi = s[A2].split(A2.op.axis[0], factor=8)
+    s[A2].bind(xo, te.thread_axis("blockIdx.x"))
+    s[A1].compute_at(s[A2], xo)
+    s[A1].set_scope("shared")
+
+    mod = tvm.lower(s, [A, A2], name="f")
+
+    cuda_target = tvm.target.Target("cuda")
+    mod = tvm.tir.transform.Apply(
+        lambda f: f.with_attr({"global_symbol": "test", "target": cuda_target})
+    )(mod)
+    fdevice = tvm.tir.transform.SplitHostDevice()(mod)["test_kernel0"]
+
+    assert fdevice.attrs["global_symbol"] == "test_kernel0"
+    assert fdevice.attrs["calling_conv"].value == 2
+    assert fdevice.attrs["target"] == cuda_target
+    assert fdevice.attrs["tir.is_global_func"].value
+
+
+if __name__ == "__main__":
+    test_split_host_device_func_attr()


### PR DESCRIPTION

Add KIsEntryFunc tag for the  device function after being split.  Normally,  the device function after being split should be a entry function. With this attribute, the global fucniton or device funtion can be generated by checking the KIsEntryFunc tag. That will be useful when generaing cross function calls. 