### PR TITLE
[CUTLASS] Support batch_matmul

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -86,7 +86,8 @@ class GemmAnnotator(tvm.relay.ExprVisitor):
 def select_gemm_kernel(
     cutlass_profiler, MM, KK, NN, out_dtype, batched, profile_all, use_multiprocessing
 ):
-    """TODO"""
+    """Run CUTLASS profiler to select the best kernel, or return the default one for dynamic
+    workloads."""
     if any(isinstance(s, tvm.tir.Any) for s in [MM, KK, NN]):
         out = cutlass_profiler.get_default(out_dtype, batched=batched)
         logger.info("Picked the default kernel %s", out["name"])
@@ -110,7 +111,7 @@ def select_gemm_kernel(
 def handle_batch_matmul(
     cutlass_profiler, op_type, arg0_shape, arg1_shape, out_dtype, profile_all, use_multiprocessing
 ):
-    """TODO"""
+    """Profile and select a kernel for batch_matmul op workload."""
     MM = arg0_shape[1]
     KK = arg0_shape[2]
     NN = arg1_shape[1]
@@ -137,7 +138,7 @@ def handle_batch_matmul(
 def handle_dense(
     cutlass_profiler, op_type, arg0_shape, arg1_shape, out_dtype, profile_all, use_multiprocessing
 ):
-    """TODO"""
+    """Profile and select a kernel for dense op workload."""
     MM = arg0_shape[0]
     KK = arg0_shape[1]
     NN = arg1_shape[0]

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -88,7 +88,7 @@ def select_gemm_kernel(
 ):
     """TODO"""
     if any(isinstance(s, tvm.tir.Any) for s in [MM, KK, NN]):
-        out = cutlass_profiler.get_default(out_dtype)
+        out = cutlass_profiler.get_default(out_dtype, batched=batched)
         logger.info("Picked the default kernel %s", out["name"])
     else:
         out = cutlass_profiler.profile(

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -354,11 +354,11 @@ class CutlassGemmProfiler(object):
             return False
         return True
 
-    def get_default(self, out_dtype):
+    def get_default(self, out_dtype, batched=False):
         """Return the default kernel for the requested architecture.
         For now, the default kernel was picked arbitrary.
         """
-        ops = GENERATOR_FUNC_TABLE[self.sm](out_dtype)
+        ops = GENERATOR_FUNC_TABLE[self.sm](out_dtype, batched)
         default_kernel_name = DEFAULT_KERNELS[self.sm][out_dtype]
         filtered = list(filter(lambda op: op["name"] == default_kernel_name, ops))
         assert len(filtered) == 1

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -47,7 +47,7 @@ def create_gemm_operator(
     alignment_constraints,
     epilogue_functor=EpilogueFunctor.LinearCombination,
     swizzling_functor=SwizzlingFunctor.Identity8,
-    batched=False
+    batched=False,
 ):
     """Exhaustively instantiate all kernels from a given configuration."""
     ret = []
@@ -114,7 +114,9 @@ def create_gemm_operator(
                 op_entry["op"] = op
                 op_entry["name"] = op.procedural_name()
                 op_entry["opdef"] = kernel_emitter.emit(op, batched=batched)
-                op_entry["opdef_bias"] = kernel_emitter.emit(op_bias, no_beta_scaling=True, batched=batched)
+                op_entry["opdef_bias"] = kernel_emitter.emit(
+                    op_bias, no_beta_scaling=True, batched=batched
+                )
                 op_entry["opdef_bias_relu"] = kernel_emitter.emit(
                     op_bias_relu, no_beta_scaling=True, batched=batched
                 )
@@ -132,7 +134,9 @@ def create_gemm_operator(
     return ret
 
 
-def generate_tensor_op_common(math_instructions, alignment_constraints, get_tile_descriptions, batched=False):
+def generate_tensor_op_common(
+    math_instructions, alignment_constraints, get_tile_descriptions, batched=False
+):
     """Common kernel generator to be used by archtecture specific generators."""
     ops = []
     layouts = [
@@ -147,7 +151,9 @@ def generate_tensor_op_common(math_instructions, alignment_constraints, get_tile
             math_inst.element_accumulator,
         ]
 
-        out = create_gemm_operator(layouts, tile_descriptions, data_type, alignment_constraints, batched=batched)
+        out = create_gemm_operator(
+            layouts, tile_descriptions, data_type, alignment_constraints, batched=batched
+        )
 
         ops.extend(out)
 
@@ -364,7 +370,9 @@ class CutlassGemmProfiler(object):
         assert len(filtered) == 1
         return filtered[0]
 
-    def profile(self, M, N, K, out_dtype, profile_all=True, use_multiprocessing=False, batched=False):
+    def profile(
+        self, M, N, K, out_dtype, profile_all=True, use_multiprocessing=False, batched=False
+    ):
         """Profile and select the best kernel from candidate kernels.
         If profile_all is False, return immediately after the first applicable kernel is found.
         If use_multiprocessing is True, compile all profiler executables in parallel.

--- a/python/tvm/contrib/cutlass/library.py
+++ b/python/tvm/contrib/cutlass/library.py
@@ -160,6 +160,7 @@ class SwizzlingFunctor(enum.Enum):
     Identity2 = enum_auto()
     Identity4 = enum_auto()
     Identity8 = enum_auto()
+    Batched = enum_auto()
 
 
 SwizzlingFunctorTag = {
@@ -167,6 +168,7 @@ SwizzlingFunctorTag = {
     SwizzlingFunctor.Identity2: "cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<2>",
     SwizzlingFunctor.Identity4: "cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<4>",
     SwizzlingFunctor.Identity8: "cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<8>",
+    SwizzlingFunctor.Batched: "cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle"
 }
 
 

--- a/python/tvm/contrib/cutlass/library.py
+++ b/python/tvm/contrib/cutlass/library.py
@@ -168,7 +168,7 @@ SwizzlingFunctorTag = {
     SwizzlingFunctor.Identity2: "cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<2>",
     SwizzlingFunctor.Identity4: "cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<4>",
     SwizzlingFunctor.Identity8: "cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<8>",
-    SwizzlingFunctor.Batched: "cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle"
+    SwizzlingFunctor.Batched: "cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle",
 }
 
 

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -20,13 +20,13 @@ from ...dataflow_pattern import wildcard, is_op, is_constant
 
 
 def make_gelu_pattern(bias_out, out_dtype="float16"):
-    mul = is_op("multiply")(bias_out, wildcard())
+    mul = is_op("multiply")(bias_out, is_constant() | wildcard())
     if out_dtype == "float16":
         erf = is_op("cast")(is_op("erf")(is_op("cast")(mul)))
     else:
         erf = is_op("erf")(mul)
-    mul_half = is_op("multiply")(erf, is_constant())
-    add = is_op("add")(mul_half, is_constant())
+    mul_half = is_op("multiply")(erf, is_constant() | wildcard())
+    add = is_op("add")(mul_half, is_constant() | wildcard())
     return is_op("multiply")(add, bias_out)
 
 

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -71,7 +71,7 @@ def partition_for_cutlass(mod):
         dense_bias_relu_pat,
         dense_bias_pat,
         dense_pat,
-        ("cutlass.batch_matmul", make_batch_matmul_pattern())
+        ("cutlass.batch_matmul", make_batch_matmul_pattern()),
     ]
     mod = transform.MergeComposite(cutlass_patterns)(mod)
     mod = transform.AnnotateTarget(["cutlass"])(mod)

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -204,10 +204,6 @@ std::string BatchMatmulOp(std::string id, const Str2StrMap& attrs,
   std::ostringstream gemm_decl;
   AppendPrologue(gemm_decl, attrs, func_args, "BatchedGemm", false, false, 1, 1, 2);
 
-  // "batch_stride_A": arg0_shape[1] * arg0_shape[2],
-  // "batch_stride_B": arg1_shape[1] * arg1_shape[2],
-  // "batch_stride_C": arg0_shape[1] * arg1_shape[1],
-
   auto get_batch_stride = [&attrs, &func_args](const std::string& name, int arg0_idx, int arg1_idx,
                                                int arg0_axis_idx, int arg1_axis_idx) {
     if (attrs.at(name) == kAnyDim) {

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -54,19 +54,21 @@ std::string GetDimAsStr(ObjectRef dim) {
   return kAnyDim;
 }
 
-Str2StrMap DenseArgs(const Map<String, ObjectRef>& attrs) {
+inline void CutlassPrint(std::ostringstream& os, const std::string& stmt, int indent = 2) {
+  for (int i = 0; i < indent; ++i) {
+    os << " ";
+  }
+  os << stmt;
+}
+
+Str2StrMap GemmArgsCommon(const Map<String, ObjectRef>& attrs) {
   Str2StrMap args;
   auto arg0_dtype = std::string(attrs["arg0_dtype"].as<StringObj>()->data);
   auto arg1_dtype = std::string(attrs["arg1_dtype"].as<StringObj>()->data);
   auto ret_dtype = std::string(attrs["ret_dtype"].as<StringObj>()->data);
-  auto arg0_shape = attrs["arg0_shape"].as<ArrayNode>();
-  auto arg1_shape = attrs["arg1_shape"].as<ArrayNode>();
   args["ElementInputA"] = dtype_map.at(arg0_dtype);
   args["ElementInputB"] = dtype_map.at(arg1_dtype);
   args["ElementOutput"] = dtype_map.at(ret_dtype);
-  args["M"] = GetDimAsStr(arg0_shape->at(0));
-  args["K"] = GetDimAsStr(arg0_shape->at(1));
-  args["N"] = GetDimAsStr(arg1_shape->at(0));
   args["op_def"] = std::string(attrs["cutlass_op_def"].as<StringObj>()->data);
   args["op_name"] = std::string(attrs["cutlass_op_name"].as<StringObj>()->data);
   args["op_type"] = std::string(attrs["op_type"].as<StringObj>()->data);
@@ -76,23 +78,33 @@ Str2StrMap DenseArgs(const Map<String, ObjectRef>& attrs) {
   return args;
 }
 
-inline void CutlassPrint(std::ostringstream& os, const std::string& stmt, int indent = 2) {
-  for (int i = 0; i < indent; ++i) {
-    os << " ";
-  }
-  os << stmt;
+Str2StrMap DenseArgs(const Map<String, ObjectRef>& attrs) {
+  Str2StrMap args = GemmArgsCommon(attrs);
+  auto arg0_shape = attrs["arg0_shape"].as<ArrayNode>();
+  auto arg1_shape = attrs["arg1_shape"].as<ArrayNode>();
+  args["M"] = GetDimAsStr(arg0_shape->at(0));
+  args["K"] = GetDimAsStr(arg0_shape->at(1));
+  args["N"] = GetDimAsStr(arg1_shape->at(0));
+  return args;
 }
 
-std::string DenseOp(std::string id, const Str2StrMap& attrs,
-                    const std::vector<std::string>& func_args) {
-  bool has_bias = false;
-  bool is_gelu =
-      attrs.at("op_type").find("cutlass.dense_bias_gelu") != std::string::npos;  // fp32 or fp16
-  if (attrs.at("op_type") == "cutlass.dense_bias" ||
-      attrs.at("op_type") == "cutlass.dense_bias_relu" || is_gelu) {
-    has_bias = true;
-  }
-  std::ostringstream gemm_decl;
+Str2StrMap BatchMatmulArgs(const Map<String, ObjectRef>& attrs) {
+  Str2StrMap args = GemmArgsCommon(attrs);
+  args["batch"] = std::to_string(attrs["batch"].as<IntImmNode>()->value);
+  args["batch_stride_A"] = std::to_string(attrs["batch_stride_A"].as<IntImmNode>()->value);
+  args["batch_stride_B"] = std::to_string(attrs["batch_stride_B"].as<IntImmNode>()->value);
+  args["batch_stride_C"] = std::to_string(attrs["batch_stride_C"].as<IntImmNode>()->value);
+  auto arg0_shape = attrs["arg0_shape"].as<ArrayNode>();
+  auto arg1_shape = attrs["arg1_shape"].as<ArrayNode>();
+  args["M"] = std::to_string(arg0_shape->at(1).as<IntImmNode>()->value);
+  args["K"] = std::to_string(arg0_shape->at(2).as<IntImmNode>()->value);
+  args["N"] = std::to_string(arg1_shape->at(1).as<IntImmNode>()->value);
+  return args;
+}
+
+void AppendPrologue(std::ostringstream& gemm_decl, const Str2StrMap& attrs,
+                    const std::vector<std::string>& func_args, const std::string& kernel,
+                    bool has_bias, bool is_gelu) {
   CutlassPrint(gemm_decl, "using ElementInputA = " + attrs.at("ElementInputA") + ";\n");
   CutlassPrint(gemm_decl, "using ElementInputB = " + attrs.at("ElementInputB") + ";\n");
   CutlassPrint(gemm_decl, "using ElementOutput = " + attrs.at("ElementOutput") + ";\n");
@@ -110,8 +122,10 @@ std::string DenseOp(std::string id, const Str2StrMap& attrs,
   CutlassPrint(gemm_decl, "int M = " + get_dim("M", 0, 0) + ";\n");
   CutlassPrint(gemm_decl, "int N = " + get_dim("N", 1, 0) + ";\n");
   CutlassPrint(gemm_decl, "int K = " + get_dim("K", 0, 1) + ";\n");
+  // CutlassPrint(gemm_decl, "int M = " + attrs.at("M") + ";\n");
+  // CutlassPrint(gemm_decl, "int N = " + attrs.at("N") + ";\n");
+  // CutlassPrint(gemm_decl, "int K = " + attrs.at("K") + ";\n");
   CutlassPrint(gemm_decl, "cutlass::gemm::GemmCoord problem_size(M, N, K);\n");
-  // Initialize alpha for dot product computation
   CutlassPrint(gemm_decl, "ElementComputeEpilogue alpha = ElementComputeEpilogue(1);\n");
   if (is_gelu) {
     // GeLU epilogue does not compile with NoBetaScaling, so we explicitly specify the scale.
@@ -120,11 +134,6 @@ std::string DenseOp(std::string id, const Str2StrMap& attrs,
     CutlassPrint(gemm_decl, "ElementComputeEpilogue beta = ElementComputeEpilogue(0);\n");
   }
 
-  // Split K dimension into 1 partitions
-  CutlassPrint(gemm_decl, "int split_k_slices = 1;\n");
-
-  // Create a tuple of gemm kernel arguments. This is later passed as arguments to launch
-  // instantiated CUTLASS kernel
   ICHECK(func_args.size() >= 2);
   CutlassPrint(gemm_decl, "void* ptr_a = (void*)(" + func_args[0] + "->data);\n");
   CutlassPrint(gemm_decl, "void* ptr_b = (void*)(" + func_args[1] + "->data);\n");
@@ -132,10 +141,47 @@ std::string DenseOp(std::string id, const Str2StrMap& attrs,
     ICHECK(func_args.size() >= 3);
     CutlassPrint(gemm_decl, "void* ptr_c_bias = (void*)(" + func_args[2] + "->data);\n");
   }
+
   CutlassPrint(gemm_decl, "void* ptr_out = (void*)(out0);\n");
 
-  CutlassPrint(gemm_decl, "typename Gemm::Arguments arguments{\n");
+  CutlassPrint(gemm_decl, "using " + kernel + " = Operation_" + attrs.at("op_name") + ";\n");
+  CutlassPrint(gemm_decl, "typename " + kernel + "::Arguments arguments{\n");
   CutlassPrint(gemm_decl, " problem_size,\n");
+}
+
+void AppendGemmExecute(std::ostringstream& gemm_decl, const std::string& kernel) {
+  // Using the arguments, query for extra workspace required for matrix multiplication computation
+  CutlassPrint(gemm_decl,
+               "size_t workspace_size = " + kernel + "::get_workspace_size(arguments);\n");
+  // Allocate workspace memory
+  CutlassPrint(gemm_decl,
+               "cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);\n");
+  // Instantiate CUTLASS kernel depending on template
+  CutlassPrint(gemm_decl, kernel + " gemm_op;\n");
+
+  // Check the problem size is supported or not
+  CutlassPrint(gemm_decl, "cutlass::Status status = gemm_op.can_implement(arguments);\n");
+  CutlassPrint(gemm_decl, "CHECK(status == cutlass::Status::kSuccess);\n");
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  CutlassPrint(gemm_decl, "status = gemm_op.initialize(arguments, workspace.get());\n");
+  CutlassPrint(gemm_decl, "CHECK(status == cutlass::Status::kSuccess);\n");
+  // Launch initialized CUTLASS kernel
+  CutlassPrint(gemm_decl, "status = gemm_op();\n");
+  CutlassPrint(gemm_decl, "CHECK(status == cutlass::Status::kSuccess);\n");
+}
+
+std::string DenseOp(std::string id, const Str2StrMap& attrs,
+                    const std::vector<std::string>& func_args) {
+  bool has_bias = false;
+  bool is_gelu =
+      attrs.at("op_type").find("cutlass.dense_bias_gelu") != std::string::npos;  // fp32 or fp16
+  if (attrs.at("op_type") == "cutlass.dense_bias" ||
+      attrs.at("op_type") == "cutlass.dense_bias_relu" || is_gelu) {
+    has_bias = true;
+  }
+  std::ostringstream gemm_decl;
+  AppendPrologue(gemm_decl, attrs, func_args, "Gemm", has_bias, is_gelu);
+
   CutlassPrint(gemm_decl, " {static_cast<ElementInputA*>(ptr_a), " + attrs.at("lda") + "},\n");
   CutlassPrint(gemm_decl, " {static_cast<ElementInputB*>(ptr_b), " + attrs.at("ldb") + "},\n");
   if (has_bias) {
@@ -150,24 +196,29 @@ std::string DenseOp(std::string id, const Str2StrMap& attrs,
     // For GeLU, we explicitly specify the scale.
     CutlassPrint(gemm_decl, " {alpha, beta},\n");
   }
-  CutlassPrint(gemm_decl, " split_k_slices};\n");
+  CutlassPrint(gemm_decl, " 1};\n");  // split_k_slices
 
-  // Using the arguments, query for extra workspace required for matrix multiplication computation
-  CutlassPrint(gemm_decl, "size_t workspace_size = Gemm::get_workspace_size(arguments);\n");
-  // Allocate workspace memory
-  CutlassPrint(gemm_decl,
-               "cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);\n");
-  // Instantiate CUTLASS kernel depending on template
-  CutlassPrint(gemm_decl, "Gemm gemm_op;\n");
-  // Check the problem size is supported or not
-  CutlassPrint(gemm_decl, "cutlass::Status status = gemm_op.can_implement(arguments);\n");
-  CutlassPrint(gemm_decl, "CHECK(status == cutlass::Status::kSuccess);\n");
-  // Initialize CUTLASS kernel with arguments and workspace pointer
-  CutlassPrint(gemm_decl, "status = gemm_op.initialize(arguments, workspace.get());\n");
-  CutlassPrint(gemm_decl, "CHECK(status == cutlass::Status::kSuccess);\n");
-  // Launch initialized CUTLASS kernel
-  CutlassPrint(gemm_decl, "status = gemm_op();\n");
-  CutlassPrint(gemm_decl, "CHECK(status == cutlass::Status::kSuccess);\n");
+  AppendGemmExecute(gemm_decl, "Gemm");
+  return gemm_decl.str();
+}
+
+std::string BatchMatmulOp(std::string id, const Str2StrMap& attrs,
+                          const std::vector<std::string>& func_args) {
+  std::ostringstream gemm_decl;
+  AppendPrologue(gemm_decl, attrs, func_args, "BatchedGemm", false, false);
+
+  CutlassPrint(gemm_decl, " {static_cast<ElementInputA*>(ptr_a), " + attrs.at("lda") + "},\n");
+  CutlassPrint(gemm_decl, attrs.at("batch_stride_A") + ",\n");
+  CutlassPrint(gemm_decl, " {static_cast<ElementInputB*>(ptr_b), " + attrs.at("ldb") + "},\n");
+  CutlassPrint(gemm_decl, attrs.at("batch_stride_B") + ",\n");
+  CutlassPrint(gemm_decl, " {static_cast<ElementOutput*>(ptr_out), " + attrs.at("ldc") + "},\n");
+  CutlassPrint(gemm_decl, attrs.at("batch_stride_C") + ",\n");
+  CutlassPrint(gemm_decl, " {static_cast<ElementOutput*>(ptr_out), " + attrs.at("ldc") + "},\n");
+  CutlassPrint(gemm_decl, attrs.at("batch_stride_C") + ",\n");
+  CutlassPrint(gemm_decl, " {alpha, beta},\n");
+  CutlassPrint(gemm_decl, attrs.at("batch") + "};\n");
+
+  AppendGemmExecute(gemm_decl, "BatchedGemm");
   return gemm_decl.str();
 }
 
@@ -279,6 +330,11 @@ class CodegenCutlass : public MemoizedExprTranslator<std::vector<Output>>, publi
           {"nn.dense", add_or_bias_add, "multiply", "erf", "multiply", "add", "multiply"});
       return GenerateBody(dense_call, "cutlass_dense_bias_gelu", GetArgumentNames(caller),
                           DenseArgs(std::ref(attrs_)));
+    } else if (pattern_name == "cutlass.batch_matmul") {
+      const auto* batch_matmul_call =
+          GetRootCall(callee->body.as<CallNode>(), 0, {"nn.batch_matmul"});
+      return GenerateBody(batch_matmul_call, "cutlass_batch_matmul", GetArgumentNames(caller),
+                          BatchMatmulArgs(std::ref(attrs_)));
     }
     LOG(FATAL) << "Unknown composite function: " << pattern_name;
     return {};
@@ -322,6 +378,8 @@ class CodegenCutlass : public MemoizedExprTranslator<std::vector<Output>>, publi
     if (func_name == "cutlass_dense" || func_name == "cutlass_dense_bias" ||
         func_name == "cutlass_dense_bias_relu" || func_name == "cutlass_dense_bias_gelu") {
       ret.decl = DenseOp(ext_func_id_, attribute_args, func_args);
+    } else if (func_name == "cutlass_batch_matmul") {
+      ret.decl = BatchMatmulOp(ext_func_id_, attribute_args, func_args);
     }
     return ret;
   }
@@ -374,6 +432,7 @@ class CutlassModuleCodegen : public CSourceModuleCodegenBase {
     code_stream_ << "#include <cutlass/util/host_tensor.h>\n";
     code_stream_ << "#include <cutlass/util/reference/host/tensor_fill.h>\n";
     code_stream_ << "#include <cutlass/gemm/device/gemm.h>\n";
+    code_stream_ << "#include <cutlass/gemm/device/gemm_batched.h>\n";
     code_stream_ << "#include <cutlass/epilogue/thread/linear_combination_bias_relu.h>\n";
     code_stream_ << "#include <cutlass/epilogue/thread/linear_combination_gelu.h>\n";
 

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -63,8 +63,9 @@ def get_output(rt_mod, names, inputs):
     return rt_mod.get_output(0).asnumpy()
 
 
-def get_output_vm(vm, x):
-    return vm.invoke("main", data=x).numpy()
+def get_output_vm(vm, names, inputs):
+    params = dict(zip(names, inputs))
+    return vm.invoke("main", **params).numpy()
 
 
 def get_dense_with_shape(data_shape, weight_shape, out_dtype="float16"):
@@ -158,14 +159,14 @@ def verify(func, M, N, K, ref_target="cuda", sm=80, atol=1e-5, rtol=1e-5, run_be
 
         rt_mod_ref, dev = get_ref_vm(mod, params, target=ref_target)
         x = tvm.nd.array(np_data, device=dev)
-        out = get_output_vm(rt_mod, x)
-        ref_out = get_output_vm(rt_mod_ref, x)
+        out = get_output_vm(rt_mod, ["data"], [x])
+        ref_out = get_output_vm(rt_mod_ref, ["data"], [x])
     else:
         rt_mod_ref, dev = get_ref_rt_mod(mod, params, target=ref_target)
         rt_mod, dev, num_partition = profile_and_build(mod, params, sm)
         x = tvm.nd.array(np_data, device=dev)
-        out = get_output(rt_mod, x)
-        ref_out = get_output(rt_mod_ref, x)
+        out = get_output(rt_mod, ["data"], [x])
+        ref_out = get_output(rt_mod_ref, ["data"], [x])
 
     assert num_partition > 0
     np.testing.assert_allclose(out, ref_out, atol=atol, rtol=rtol)
@@ -256,4 +257,6 @@ def test_batch_matmul():
 
 if __name__ == "__main__":
     # pytest.main([__file__])
-    test_batch_matmul()
+    # test_batch_matmul()
+    # test_dense()
+    test_dense_dynamic()

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -240,6 +240,7 @@ def test_dense_dynamic():
             ref_target="cuda -libs=cublas",
         )
 
+    return
     verify(
         get_dense_with_shape(data_shape, weight_shape, out_dtype="float32"),
         M,
@@ -258,5 +259,6 @@ def test_batch_matmul():
 if __name__ == "__main__":
     # pytest.main([__file__])
     # test_batch_matmul()
+    test_dense_bias_gelu()
     # test_dense()
-    test_dense_dynamic()
+    # test_dense_dynamic()

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -240,7 +240,6 @@ def test_dense_dynamic():
             ref_target="cuda -libs=cublas",
         )
 
-    return
     verify(
         get_dense_with_shape(data_shape, weight_shape, out_dtype="float32"),
         M,
@@ -252,13 +251,14 @@ def test_dense_dynamic():
 
 
 def test_batch_matmul():
-    batch = 32
+    batch = 8
     verify_batch_matmul(get_batch_matmul(batch, M, N, K), batch, M, N, K)
+    verify_batch_matmul(get_batch_matmul(batch, M, N, K, out_dtype="float32"), batch, M, N, K)
 
 
 if __name__ == "__main__":
     # pytest.main([__file__])
     # test_batch_matmul()
-    test_dense_bias_gelu()
+    # test_dense_bias_gelu()
     # test_dense()
-    # test_dense_dynamic()
+    test_dense_dynamic()


### PR DESCRIPTION
Adds support for offloading `batch_matmul` via `GemmBatched` cutlass kernel. Also supports dynamic shape.
I didn't add a profiler specifically for `GemmBatched` kernel - I piggy back on the `dense` profiler because cutlass `GemmBatched` uses the same kernel for normal gemm parallelized over the batch dimension (Grid Z dim). 

This allows me to test cutlass byoc on Huggingface `BERT-large` end to end. I also have a number for TensorRT measured using their [BERT demo](https://github.com/NVIDIA/TensorRT/tree/master/demo/BERT), but TensorRT one is using google's own implementation of BERT.

This is the current result comparing cutlass offload, autotvm native and TensorRT, all using tensor core on rtx3070. Input size is `(8, 128)` and numbers in milliseconds.

CUTLASS | AutoTVM | TensorRT (google's implementation)
 -- | -- | --
23.0551 |  23.6729 | 14.0

Here is the detailed nvprof output from cutlass and autotvm:
* cutlass https://gist.github.com/masahi/01c064529f859afefd0cc34ef138aa08
* autotvm https://gist.github.com/masahi/45ac7c45b637c2f3e4c35f8db11e9c88

As you can see, for now activation fusion is enabled only for GeLU. There are other activations or elemwise ops that can be fused in principle, such as
* https://gist.github.com/masahi/45ac7c45b637c2f3e4c35f8db11e9c88#file-bert_large_gelu_fusion_autotvm-txt-L30-L32
* https://gist.github.com/masahi/45ac7c45b637c2f3e4c35f8db11e9c88#file-bert_large_gelu_fusion_autotvm-txt-L26

Together, they account for about 15% of total execution time, which is a shame. To fuse them, we need to overcome all of following blockers:
* Support ND input dense to remove `reshape` between `dense` and activations (https://github.com/apache/tvm/issues/8412)
* Support multiple "source" tensors in cutlass epilogue (https://github.com/NVIDIA/cutlass/discussions/347)
* Enable fusion of `cast` op into activation (https://github.com/NVIDIA/cutlass/discussions/352)


The nvprof output also shows that softmax is a huge bottleneck, accounting for 24% of e2e time. Apparently TVM's cuda softmax is 2x slower than cudnn, here is the result if we use cudnn's softmax:

CUTLASS | AutoTVM | TensorRT (google's implementation)
 -- | -- | --
 20.2517 |  21.1869 | 14.0

cc @comaniac @Laurawly @zhiics @hwu36

