### PR TITLE
[TVMC] Re-enable PyTorch test

### DIFF
--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -204,7 +204,6 @@ def test_load_model___wrong_language__to_onnx(tflite_mobilenet_v1_1_quant):
         tvmc.load(tflite_mobilenet_v1_1_quant, model_format="onnx")
 
 
-@pytest.mark.skip(reason="https://github.com/apache/tvm/issues/7455")
 def test_load_model__pth(pytorch_resnet18):
     # some CI environments wont offer torch, so skip in case it is not present
     pytest.importorskip("torch")


### PR DESCRIPTION
This test was originally disabled due to the issue documented in #7455 affecting CI. I believe this has since been resolved by #9362.

Note: This patch should not be merged until the changes in https://github.com/tlc-pack/tlcpack/pull/81 are reflected in CI.

cc @leandron @masahi 
