### PR TITLE
[CI] Pin setuptools to v58.4.0 in CI to circumvent breaking change in v58.5

### DIFF
--- a/docker/install/ubuntu1804_install_python.sh
+++ b/docker/install/ubuntu1804_install_python.sh
@@ -28,5 +28,5 @@ apt-get install -y python3-dev python3-setuptools
 # Install pip
 cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
-# Pin pip version
-pip3 install pip==19.3.1
+# Pin pip and setuptools versions
+pip3 install pip==19.3.1 setuptools==58.4.0

--- a/docker/install/ubuntu1804_install_python_venv.sh
+++ b/docker/install/ubuntu1804_install_python_venv.sh
@@ -27,5 +27,5 @@ apt-get install -y python3-dev python3-setuptools python3-venv
 
 python3 -mvenv /opt/tvm-venv
 
-# Pin pip version
-/opt/tvm-venv/bin/pip3 install pip==19.3.1
+# Pin pip and setuptools versions
+/opt/tvm-venv/bin/pip3 install pip==19.3.1 setuptools==58.4.0

--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -36,5 +36,5 @@ rm -f /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python3
 # Install pip
 cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python3.6 get-pip.py
 
-# Pin pip version
-pip3 install pip==19.3.1
+# Pin pip and setuptools versions
+pip3 install pip==19.3.1 setuptools==58.4.0

--- a/docker/install/ubuntu_install_vela.sh
+++ b/docker/install/ubuntu_install_vela.sh
@@ -20,7 +20,6 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install -U setuptools
 # In a refactor between v2.1.1 and v3.0.0, find_block_configs <appropriate function name> was removed from Vela.
 # Since this is still required for the TVM port, it will be reinstated in Vela in a future release.
 # Until then, it needs to be pinned to v2.1.1.


### PR DESCRIPTION
Pin setuptools version to v58.4.0 to circumvent a breaking change in v58.5, see https://github.com/apache/tvm/issues/9445

cc @leandron 