### PR TITLE
[Rust] Fix an infinite recompilation loop in the tvm-sys crate

### DIFF
--- a/rust/tvm-sys/build.rs
+++ b/rust/tvm-sys/build.rs
@@ -224,10 +224,9 @@ fn main() -> Result<()> {
     }?;
 
     // If the TVM_HOME environment variable changed, the LLVM_CONFIG_PATH environment variable
-    // changed, the build directory or headers have changed we need to rebuild the Rust bindings.
+    // changed or the source headers have changed we need to rebuild the Rust bindings.
     println!("cargo:rerun-if-env-changed=TVM_HOME");
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG_PATH");
-    println!("cargo:rerun-if-changed={}", build_path.display());
     println!("cargo:rerun-if-changed={}/include", source_path.display());
 
     let library_name = if cfg!(feature = "runtime-only") {


### PR DESCRIPTION
Including the CMake `build` directory in `rerun-if-changed` was leading to `tvm-sys` recompiling on every invocation of `cargo build` (along with every crate which depended on it). This has had some knock-on effects for our development and CI workflows which have led to TVM being disabled in a few places.

I can't think of a legitimate reason why `tvm-sys` should rebuild when the build _output_ directory changes, but I'm open to alternate ways to mitigate this issue if there was a reason for this behavior.

@jroesch @schell recommended I pass this directly to you.
