### PR TITLE
[BugFix] Fix Infinite Loop Caused When Calling Methods Not Overrided In PyClass.

### DIFF
--- a/include/tvm/meta_schedule/builder.h
+++ b/include/tvm/meta_schedule/builder.h
@@ -137,6 +137,7 @@ class PyBuilderNode : public BuilderNode {
   }
 
   Array<BuilderResult> Build(const Array<BuilderInput>& build_inputs) final {
+    ICHECK(f_build != nullptr) << "PyBuilder's Build method not implemented!";
     return f_build(build_inputs);
   }
 

--- a/include/tvm/meta_schedule/database.h
+++ b/include/tvm/meta_schedule/database.h
@@ -230,18 +230,29 @@ class PyDatabaseNode : public DatabaseNode {
     // `f_size` is not visited
   }
 
-  static constexpr const char* _type_key = "meta_schedule.PyDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyDatabaseNode, DatabaseNode);
+  Workload CommitWorkload(const IRModule& mod) final {
+    ICHECK(f_commit_workload != nullptr) << "PyDatabase's CommitWorkload method not implemented!";
+    return f_commit_workload(mod);
+  }
 
-  Workload CommitWorkload(const IRModule& mod) final { return f_commit_workload(mod); }
-
-  void CommitTuningRecord(const TuningRecord& record) final { f_commit_tuning_record(record); }
+  void CommitTuningRecord(const TuningRecord& record) final {
+    ICHECK(f_commit_tuning_record != nullptr)
+        << "PyDatabase's CommitTuningRecord method not implemented!";
+    f_commit_tuning_record(record);
+  }
 
   Array<TuningRecord> GetTopK(const Workload& workload, int top_k) final {
+    ICHECK(f_get_top_k != nullptr) << "PyDatabase's GetTopK method not implemented!";
     return f_get_top_k(workload, top_k);
   }
 
-  int64_t Size() final { return f_size(); }
+  int64_t Size() final {
+    ICHECK(f_size != nullptr) << "PyDatabase's Size method not implemented!";
+    return f_size();
+  }
+
+  static constexpr const char* _type_key = "meta_schedule.PyDatabase";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PyDatabaseNode, DatabaseNode);
 };
 
 /*!

--- a/include/tvm/meta_schedule/runner.h
+++ b/include/tvm/meta_schedule/runner.h
@@ -207,7 +207,10 @@ class PyRunnerNode : public RunnerNode {
     // `f_run` is not visited
   }
 
-  Array<RunnerFuture> Run(Array<RunnerInput> runner_inputs) final { return f_run(runner_inputs); }
+  Array<RunnerFuture> Run(Array<RunnerInput> runner_inputs) final {
+    ICHECK(f_run != nullptr) << "PyRunner's Run method not implemented!";
+    return f_run(runner_inputs);
+  }
 
   static constexpr const char* _type_key = "meta_schedule.PyRunner";
   TVM_DECLARE_FINAL_OBJECT_INFO(PyRunnerNode, RunnerNode);

--- a/include/tvm/meta_schedule/search_strategy.h
+++ b/include/tvm/meta_schedule/search_strategy.h
@@ -187,20 +187,30 @@ class PySearchStrategyNode : public SearchStrategyNode {
   }
 
   void InitializeWithTuneContext(const TuneContext& context) final {
+    ICHECK(f_initialize_with_tune_context != nullptr)
+        << "PySearchStrategy's InitializeWithTuneContext method not implemented!";
     this->f_initialize_with_tune_context(context);
   }
 
   void PreTuning(const Array<tir::Schedule>& design_spaces) final {
+    ICHECK(f_pre_tuning != nullptr) << "PySearchStrategy's PreTuning method not implemented!";
     this->f_pre_tuning(design_spaces);
   }
 
-  void PostTuning() final { this->f_post_tuning(); }
+  void PostTuning() final {
+    ICHECK(f_post_tuning != nullptr) << "PySearchStrategy's PostTuning method not implemented!";
+    this->f_post_tuning();
+  }
 
   Optional<Array<MeasureCandidate>> GenerateMeasureCandidates() final {
+    ICHECK(f_generate_measure_candidates != nullptr)
+        << "PySearchStrategy's GenerateMeasureCandidates method not implemented!";
     return this->f_generate_measure_candidates();
   }
 
   void NotifyRunnerResults(const Array<RunnerResult>& results) final {
+    ICHECK(f_notify_runner_results != nullptr)
+        << "PySearchStrategy's NotifyRunnerResults method not implemented!";
     this->f_notify_runner_results(results);
   }
 

--- a/include/tvm/meta_schedule/space_generator.h
+++ b/include/tvm/meta_schedule/space_generator.h
@@ -113,10 +113,14 @@ class PySpaceGeneratorNode : public SpaceGeneratorNode {
   }
 
   void InitializeWithTuneContext(const TuneContext& tune_context) final {
+    ICHECK(f_initialize_with_tune_context != nullptr)
+        << "PySpaceGenerator's InitializeWithTuneContext !";
     f_initialize_with_tune_context(tune_context);
   }
 
   Array<tir::Schedule> GenerateDesignSpace(const IRModule& mod) final {
+    ICHECK(f_generate_design_space != nullptr)
+        << "PySpaceGenerator's GenerateDesignSpace method not implemented!";
     return f_generate_design_space(mod);
   }
 

--- a/python/tvm/meta_schedule/builder/builder.py
+++ b/python/tvm/meta_schedule/builder/builder.py
@@ -23,6 +23,7 @@ from tvm.runtime import Object
 from tvm.target import Target
 
 from .. import _ffi_api
+from ..utils import check_override
 
 
 @register_object("meta_schedule.BuilderInput")
@@ -119,6 +120,7 @@ class PyBuilder(Builder):
     def __init__(self):
         """Constructor."""
 
+        @check_override(self.__class__, Builder)
         def f_build(build_inputs: List[BuilderInput]) -> List[BuilderResult]:
             return self.build(build_inputs)
 
@@ -126,6 +128,3 @@ class PyBuilder(Builder):
             _ffi_api.BuilderPyBuilder,  # type: ignore # pylint: disable=no-member
             f_build,
         )
-
-    def build(self, build_inputs: List[BuilderInput]) -> List[BuilderResult]:
-        raise NotImplementedError

--- a/python/tvm/meta_schedule/database/database.py
+++ b/python/tvm/meta_schedule/database/database.py
@@ -25,7 +25,7 @@ from tvm.tir.schedule import Trace
 
 from .. import _ffi_api
 from ..arg_info import ArgInfo
-from ..utils import _json_de_tvm
+from ..utils import _json_de_tvm, check_override
 
 
 @register_object("meta_schedule.Workload")
@@ -207,15 +207,19 @@ class PyDatabase(Database):
     def __init__(self):
         """Constructor."""
 
+        @check_override(self.__class__, Database)
         def f_commit_workload(mod: IRModule) -> Workload:
             return self.commit_workload(mod)
 
+        @check_override(self.__class__, Database)
         def f_commit_tuning_record(record: TuningRecord) -> None:
             self.commit_tuning_record(record)
 
+        @check_override(self.__class__, Database)
         def f_get_top_k(workload: Workload, top_k: int) -> List[TuningRecord]:
             return self.get_top_k(workload, top_k)
 
+        @check_override(self.__class__, Database, func_name="__len__")
         def f_size() -> int:
             return len(self)
 
@@ -226,15 +230,3 @@ class PyDatabase(Database):
             f_get_top_k,
             f_size,
         )
-
-    def commit_workload(self, mod: IRModule) -> Workload:
-        raise NotImplementedError
-
-    def commit_tuning_record(self, record: TuningRecord) -> None:
-        raise NotImplementedError
-
-    def get_top_k(self, workload: Workload, top_k: int) -> List[TuningRecord]:
-        raise NotImplementedError
-
-    def __len__(self) -> int:
-        raise NotImplementedError

--- a/python/tvm/meta_schedule/runner/runner.py
+++ b/python/tvm/meta_schedule/runner/runner.py
@@ -22,6 +22,7 @@ from tvm.runtime import Object
 
 from .. import _ffi_api
 from ..arg_info import ArgInfo
+from ..utils import check_override
 
 
 @register_object("meta_schedule.RunnerInput")
@@ -158,6 +159,7 @@ class PyRunner(Runner):
     def __init__(self) -> None:
         """Constructor"""
 
+        @check_override(self.__class__, Runner)
         def f_run(runner_inputs: List[RunnerInput]) -> List[RunnerFuture]:
             return self.run(runner_inputs)
 
@@ -165,6 +167,3 @@ class PyRunner(Runner):
             _ffi_api.RunnerPyRunner,  # type: ignore # pylint: disable=no-member
             f_run,
         )
-
-    def run(self, runner_inputs: List[RunnerInput]) -> List[RunnerFuture]:
-        raise NotImplementedError

--- a/python/tvm/meta_schedule/search_strategy/search_strategy.py
+++ b/python/tvm/meta_schedule/search_strategy/search_strategy.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Search Strategy"""
-
+"""
+Meta Schedule search strategy that generates the measure
+candidates for measurement.
+"""
 from typing import List, Optional, TYPE_CHECKING
 
 from tvm._ffi import register_object
@@ -25,6 +27,7 @@ from tvm.tir.schedule import Schedule
 from .. import _ffi_api
 from ..arg_info import ArgInfo
 from ..runner import RunnerResult
+from ..utils import check_override
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
@@ -126,18 +129,23 @@ class PySearchStrategy(SearchStrategy):
     def __init__(self):
         """Constructor."""
 
+        @check_override(self.__class__, SearchStrategy)
         def f_initialize_with_tune_context(context: "TuneContext") -> None:
             self.initialize_with_tune_context(context)
 
+        @check_override(self.__class__, SearchStrategy)
         def f_pre_tuning(design_spaces: List[Schedule]) -> None:
             self.pre_tuning(design_spaces)
 
+        @check_override(self.__class__, SearchStrategy)
         def f_post_tuning() -> None:
             self.post_tuning()
 
+        @check_override(self.__class__, SearchStrategy)
         def f_generate_measure_candidates() -> List[MeasureCandidate]:
             return self.generate_measure_candidates()
 
+        @check_override(self.__class__, SearchStrategy)
         def f_notify_runner_results(results: List["RunnerResult"]) -> None:
             self.notify_runner_results(results)
 
@@ -149,18 +157,3 @@ class PySearchStrategy(SearchStrategy):
             f_generate_measure_candidates,
             f_notify_runner_results,
         )
-
-    def initialize_with_tune_context(self, tune_context: "TuneContext") -> None:
-        raise NotImplementedError
-
-    def pre_tuning(self, design_spaces: List[Schedule]) -> None:
-        raise NotImplementedError
-
-    def post_tuning(self) -> None:
-        raise NotImplementedError
-
-    def generate_measure_candidates(self) -> List[MeasureCandidate]:
-        raise NotImplementedError
-
-    def notify_runner_results(self, results: List["RunnerResult"]) -> None:
-        raise NotImplementedError

--- a/python/tvm/meta_schedule/space_generator/space_generator.py
+++ b/python/tvm/meta_schedule/space_generator/space_generator.py
@@ -18,7 +18,6 @@
 Meta Schedule design space generators that generates design
 space for generation of measure candidates.
 """
-
 from typing import TYPE_CHECKING, List
 
 from tvm._ffi import register_object
@@ -27,6 +26,7 @@ from tvm.runtime import Object
 from tvm.tir.schedule import Schedule
 
 from .. import _ffi_api
+from ..utils import check_override
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
@@ -74,9 +74,11 @@ class PySpaceGenerator(SpaceGenerator):
     def __init__(self):
         """Constructor."""
 
+        @check_override(self.__class__, SpaceGenerator)
         def f_initialize_with_tune_context(tune_context: "TuneContext") -> None:
             self.initialize_with_tune_context(tune_context)
 
+        @check_override(self.__class__, SpaceGenerator)
         def f_generate_design_space(mod: IRModule) -> List[Schedule]:
             return self.generate_design_space(mod)
 
@@ -85,9 +87,3 @@ class PySpaceGenerator(SpaceGenerator):
             f_initialize_with_tune_context,
             f_generate_design_space,
         )
-
-    def initialize_with_tune_context(self, tune_context: "TuneContext") -> None:
-        raise NotImplementedError
-
-    def generate_design_space(self, mod: IRModule) -> List[Schedule]:
-        raise NotImplementedError

--- a/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
+++ b/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
@@ -15,19 +15,64 @@
 # specific language governing permissions and limitations
 # under the License.
 """Auto-tuning Task Scheduler"""
+
+from typing import List
+
 from tvm._ffi import register_object
 from tvm.runtime import Object
 
+from ..runner import Runner
+from ..builder import Builder
+from ..database import Database
+from ..tune_context import TuneContext
 from .. import _ffi_api
+from ..utils import check_override
 
 
 @register_object("meta_schedule.TaskScheduler")
 class TaskScheduler(Object):
-    """The abstract task scheduler interface."""
+    """The abstract task scheduler interface.
+
+    Parameters
+    ----------
+    tasks: List[TuneContext]
+        The list of tune context to process.
+    builder: Builder
+        The builder of the scheduler.
+    runner: Runner
+        The runner of the scheduler.
+    database: Database
+        The database of the scheduler.
+    """
+
+    tasks: List[TuneContext]
+    builder: Builder
+    runner: Runner
+    database: Database
 
     def tune(self) -> None:
         """Auto-tuning."""
         _ffi_api.TaskSchedulerTune(self)  # type: ignore # pylint: disable=no-member
+
+    def next_task_id(self) -> int:
+        """Fetch the next task id.
+
+        Returns
+        -------
+        int
+            The next task id.
+        """
+        return _ffi_api.TaskSchedulerNextTaskId(self)  # type: ignore # pylint: disable=no-member
+
+    def _initialize_task(self, task_id: int) -> None:
+        """Initialize modules of the given task.
+
+        Parameters
+        ----------
+        task_id : int
+            The task id to be initialized.
+        """
+        _ffi_api.TaskSchedulerInitializeTask(self, task_id)  # type: ignore # pylint: disable=no-member
 
     def _set_task_stopped(self, task_id: int) -> None:
         """Set specific task to be stopped.
@@ -64,59 +109,74 @@ class TaskScheduler(Object):
         """
         _ffi_api.TaskSchedulerJoinRunningTask(self, task_id)  # type: ignore # pylint: disable=no-member
 
-    def _next_task_id(self) -> int:
-        """Fetch the next task id.
-
-        Returns
-        -------
-        int
-            The next task id.
-        """
-        return _ffi_api.TaskSchedulerNextTaskId(self)  # type: ignore # pylint: disable=no-member
-
 
 @register_object("meta_schedule.PyTaskScheduler")
 class PyTaskScheduler(TaskScheduler):
     """An abstract task scheduler with customized methods on the python-side."""
 
-    def __init__(self):
-        """Constructor."""
+    def __init__(
+        self,
+        tasks: List[TuneContext],
+        builder: Builder,
+        runner: Runner,
+        database: Database,
+    ):
+        """Constructor.
 
+        Parameters
+        ----------
+        tasks: List[TuneContext]
+            The list of tune context to process.
+        builder: Builder
+            The builder of the scheduler.
+        runner: Runner
+            The runner of the scheduler.
+        database: Database
+            The database of the scheduler.
+        """
+
+        @check_override(self.__class__, TaskScheduler, required=False)
         def f_tune() -> None:
             self.tune()
 
+        @check_override(self.__class__, TaskScheduler)
+        def f_next_task_id() -> int:
+            return self.next_task_id()
+
+        @check_override(
+            PyTaskScheduler, TaskScheduler, required=False, func_name="_initialize_task"
+        )
+        def f_initialize_task(task_id: int) -> None:
+            self._initialize_task(task_id)
+
+        @check_override(
+            PyTaskScheduler, TaskScheduler, required=False, func_name="_set_task_stopped"
+        )
         def f_set_task_stopped(task_id: int) -> None:
             self._set_task_stopped(task_id)
 
+        @check_override(
+            PyTaskScheduler, TaskScheduler, required=False, func_name="_is_task_running"
+        )
         def f_is_task_running(task_id: int) -> bool:
             return self._is_task_running(task_id)
 
+        @check_override(
+            PyTaskScheduler, TaskScheduler, required=False, func_name="_join_running_task"
+        )
         def f_join_running_task(task_id: int) -> None:
             self._join_running_task(task_id)
 
-        def f_next_task_id() -> int:
-            return self._next_task_id()
-
         self.__init_handle_by_constructor__(
             _ffi_api.TaskSchedulerPyTaskScheduler,  # type: ignore # pylint: disable=no-member
+            tasks,
+            builder,
+            runner,
+            database,
             f_tune,
+            f_initialize_task,
             f_set_task_stopped,
             f_is_task_running,
             f_join_running_task,
             f_next_task_id,
         )
-
-    def tune(self) -> None:
-        raise NotImplementedError()
-
-    def _set_task_stopped(self, task_id: int) -> None:
-        _ffi_api.TaskSchedulerSetTaskStopped(self, task_id)  # type: ignore # pylint: disable=no-member
-
-    def _is_task_running(self, task_id: int) -> bool:
-        return _ffi_api.TaskSchedulerIsTaskRunning(self, task_id)  # type: ignore # pylint: disable=no-member
-
-    def _join_running_task(self, task_id: int) -> None:
-        _ffi_api.TaskSchedulerJoinRunningTask(self, task_id)  # type: ignore # pylint: disable=no-member
-
-    def _next_task_id(self) -> int:
-        return _ffi_api.TaskSchedulerNextTaskId(self)  # type: ignore # pylint: disable=no-member

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -205,3 +205,44 @@ def structural_hash(mod: IRModule) -> str:
         # but ffi can't handle unsigned integers properly so it's parsed into a negative number
         shash += 1 << 64
     return str(shash)
+
+
+def check_override(
+    derived_class: Any, base_class: Any, required: bool = True, func_name: str = None
+) -> Callable:
+    """Check if the derived class has overrided the base class's method.
+
+    Parameters
+    ----------
+    derived_class : Any
+        The derived class.
+    base_class : Any
+        The base class of derived class.
+    required : bool
+        If the method override is required.
+    func_name : str
+        Name of the method. Default value None, which would be set to substring of the given
+        function, e.g. `f_generate`->`generate`.
+
+    Returns
+    -------
+    func : Callable
+        Raise NotImplementedError if the function is required and not overrided. If the
+        function is not overrided return None, other return the overrided function.
+    """
+
+    def inner(func: Callable):
+
+        if func_name is None:
+            method = func.__name__[2:]
+        else:
+            method = func_name
+
+        if getattr(derived_class, method) is getattr(base_class, method):
+            if required:
+                raise NotImplementedError(f"{derived_class}'s {method} method is not implemented!")
+            else:
+                return None
+        return func
+
+    return inner

--- a/src/meta_schedule/task_scheduler/round_robin.cc
+++ b/src/meta_schedule/task_scheduler/round_robin.cc
@@ -52,7 +52,9 @@ class RoundRobinNode final : public TaskSchedulerNode {
   }
 };
 
-TaskScheduler TaskScheduler::RoundRobin(Array<TuneContext> tasks, Builder builder, Runner runner,
+TaskScheduler TaskScheduler::RoundRobin(Array<TuneContext> tasks,  //
+                                        Builder builder,           //
+                                        Runner runner,             //
                                         Database database) {
   ObjectPtr<RoundRobinNode> n = make_object<RoundRobinNode>();
   n->tasks = tasks;

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -92,19 +92,30 @@ Array<RunnerFuture> SendToRunner(const Runner& runner,  //
   return results;
 }
 
+void TaskSchedulerNode::InitializeTask(int task_id) {
+  TuneContext task = this->tasks[task_id];
+  // Derive the values.
+  IRModule mod = task->mod.value();
+  SpaceGenerator space = task->space_generator.value();
+  SearchStrategy strategy = task->search_strategy.value();
+  // Initialize Modules.
+  space->InitializeWithTuneContext(task);
+  strategy->InitializeWithTuneContext(task);
+}
+
 void TaskSchedulerNode::Tune() {
-  for (const TuneContext& task : this->tasks) {
-    CHECK(task->mod.defined()) << "ValueError: Require `context.mod`, but it is not defined";
-    CHECK(task->space_generator.defined())
+  for (int i = 0; i < static_cast<int>(this->tasks.size()); i++) {
+    // Check Optional value validity.
+    CHECK(tasks[i]->mod.defined()) << "ValueError: Require `context.mod`, but it is not defined";
+    CHECK(tasks[i]->space_generator.defined())
         << "ValueError: Require `context.space_generator`, but it is not defined";
-    CHECK(task->search_strategy.defined())
+    CHECK(tasks[i]->search_strategy.defined())
         << "ValueError: Require `context.search_strategy`, but it is not defined";
-    IRModule mod = task->mod.value();
-    SpaceGenerator space = task->space_generator.value();
-    SearchStrategy strategy = task->search_strategy.value();
-    space->InitializeWithTuneContext(task);
-    strategy->InitializeWithTuneContext(task);
-    strategy->PreTuning(space->GenerateDesignSpace(mod));
+
+    InitializeTask(i);
+
+    tasks[i]->search_strategy.value()->PreTuning(
+        tasks[i]->space_generator.value()->GenerateDesignSpace(tasks[i]->mod.value()));
   }
 
   int running_tasks = tasks.size();
@@ -114,7 +125,7 @@ void TaskSchedulerNode::Tune() {
       ICHECK(!task->is_stopped);
       ICHECK(!task->runner_futures.defined());
       SearchStrategy strategy = task->search_strategy.value();
-      if (task->measure_candidates = strategy->GenerateMeasureCandidates()) {
+      if ((task->measure_candidates = strategy->GenerateMeasureCandidates()).defined()) {
         Array<BuilderResult> builder_results =
             SendToBuilder(this->builder, task, task->measure_candidates.value());
         task->runner_futures =
@@ -186,13 +197,23 @@ void TaskSchedulerNode::JoinRunningTask(int task_id) {
 }
 
 TaskScheduler TaskScheduler::PyTaskScheduler(
+    Array<TuneContext> tasks,                                   //
+    Builder builder,                                            //
+    Runner runner,                                              //
+    Database database,                                          //
     PyTaskSchedulerNode::FTune f_tune,                          //
+    PyTaskSchedulerNode::FInitializeTask f_initialize_task,     //
     PyTaskSchedulerNode::FSetTaskStopped f_set_task_stopped,    //
     PyTaskSchedulerNode::FIsTaskRunning f_is_task_running,      //
     PyTaskSchedulerNode::FJoinRunningTask f_join_running_task,  //
     PyTaskSchedulerNode::FNextTaskId f_next_task_id) {
   ObjectPtr<PyTaskSchedulerNode> n = make_object<PyTaskSchedulerNode>();
+  n->tasks = tasks;
+  n->builder = builder;
+  n->runner = runner;
+  n->database = database;
   n->f_tune = f_tune;
+  n->f_initialize_task = f_initialize_task;
   n->f_set_task_stopped = f_set_task_stopped;
   n->f_is_task_running = f_is_task_running;
   n->f_join_running_task = f_join_running_task;
@@ -202,14 +223,16 @@ TaskScheduler TaskScheduler::PyTaskScheduler(
 
 TVM_REGISTER_OBJECT_TYPE(TaskSchedulerNode);
 TVM_REGISTER_NODE_TYPE(PyTaskSchedulerNode);
-TVM_REGISTER_GLOBAL("tvm.task.TaskSchedulerPyTaskScheduler")
+TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerPyTaskScheduler")
     .set_body_typed(TaskScheduler::PyTaskScheduler);
+TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerTune")
+    .set_body_method<TaskScheduler>(&TaskSchedulerNode::Tune);
+TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerInitializeTask")
+    .set_body_method<TaskScheduler>(&TaskSchedulerNode::InitializeTask);
 TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerSetTaskStopped")
     .set_body_method<TaskScheduler>(&TaskSchedulerNode::SetTaskStopped);
 TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerIsTaskRunning")
     .set_body_method<TaskScheduler>(&TaskSchedulerNode::IsTaskRunning);
-TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerTune")
-    .set_body_method<TaskScheduler>(&TaskSchedulerNode::Tune);
 TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerJoinRunningTask")
     .set_body_method<TaskScheduler>(&TaskSchedulerNode::JoinRunningTask);
 TVM_REGISTER_GLOBAL("meta_schedule.TaskSchedulerNextTaskId")

--- a/tests/python/unittest/test_meta_schedule_space_generator.py
+++ b/tests/python/unittest/test_meta_schedule_space_generator.py
@@ -24,9 +24,8 @@ import pytest
 
 import tvm
 from tvm.script import tir as T
-
 from tvm.tir.schedule import Schedule
-from tvm.meta_schedule.space_generator import ScheduleFn, SpaceGeneratorUnion
+from tvm.meta_schedule.space_generator import ScheduleFn, PySpaceGenerator, SpaceGeneratorUnion
 
 
 # pylint: disable=invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument
@@ -84,6 +83,11 @@ def test_meta_schedule_design_space_generator_union():
     assert len(design_spaces) == 2
     for design_space in design_spaces:
         _check_correct(design_space)
+
+
+def test_meta_schedule_design_space_generator_NIE():
+    with pytest.raises(NotImplementedError):
+        PySpaceGenerator()
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_meta_schedule_task_scheduler.py
+++ b/tests/python/unittest/test_meta_schedule_task_scheduler.py
@@ -33,8 +33,7 @@ from tvm.meta_schedule.search_strategy import ReplayTrace
 from tvm.meta_schedule.builder import PyBuilder, BuilderInput, BuilderResult
 from tvm.meta_schedule.runner import PyRunner, RunnerInput, RunnerFuture, RunnerResult
 from tvm.meta_schedule.database import PyDatabase, TuningRecord, Workload
-from tvm.meta_schedule.task_scheduler import RoundRobin
-from tvm.meta_schedule.utils import structural_hash
+from tvm.meta_schedule.task_scheduler import RoundRobin, PyTaskScheduler
 
 
 # pylint: disable=invalid-name,no-member,line-too-long,too-many-nested-blocks,missing-docstring
@@ -220,6 +219,78 @@ def test_meta_schedule_task_scheduler_multiple():
     round_robin.tune()
     assert len(database) == num_trials_total * len(tasks)
     print(database.workload_reg)
+    for task in tasks:
+        assert len(database.get_top_k(database.commit_workload(task.mod), 1e9)) == num_trials_total
+
+
+def test_meta_schedule_task_scheduler_NIE():
+    class MyTaskScheduler(PyTaskScheduler):
+        pass
+
+    with pytest.raises(NotImplementedError):
+        MyTaskScheduler([], DummyBuilder(), DummyRunner(), DummyDatabase())
+
+
+def test_meta_schedule_task_scheduler_override_next_task_id_only():
+    class MyTaskScheduler(PyTaskScheduler):
+        done = set()
+
+        def next_task_id(self) -> int:
+            while len(self.done) != len(tasks):
+                x = random.randint(0, len(tasks) - 1)
+                task = tasks[x]
+                if not task.is_stopped:
+                    """Calling base func via following route:
+                    Python side:
+                        PyTaskScheduler does not have `_is_task_running`
+                        Call TaskScheduler's `is_task_running`, which calls ffi
+                    C++ side:
+                        The ffi calls TaskScheduler's `is_task_running`
+                        But it is overrided in PyTaskScheduler
+                        PyTaskScheduler checks if the function is overrided in python
+                        If not, it returns the TaskScheduler's vtable, calling
+                            TaskScheduler::IsTaskRunning
+                    """
+                    if self._is_task_running(x):
+                        # Same Here
+                        self._join_running_task(x)
+                    return x
+                else:
+                    self.done.add(x)
+            return -1
+
+    num_trials_per_iter = 6
+    num_trials_total = 101
+    tasks = [
+        TuneContext(
+            MatmulModule,
+            target=tvm.target.Target("llvm"),
+            space_generator=ScheduleFn(sch_fn=_schedule_matmul),
+            search_strategy=ReplayTrace(num_trials_per_iter, num_trials_total),
+            task_name="Matmul",
+            rand_state=42,
+        ),
+        TuneContext(
+            MatmulReluModule,
+            target=tvm.target.Target("llvm"),
+            space_generator=ScheduleFn(sch_fn=_schedule_matmul),
+            search_strategy=ReplayTrace(num_trials_per_iter, num_trials_total),
+            task_name="MatmulRelu",
+            rand_state=0xDEADBEEF,
+        ),
+        TuneContext(
+            BatchMatmulModule,
+            target=tvm.target.Target("llvm"),
+            space_generator=ScheduleFn(sch_fn=_schedule_batch_matmul),
+            search_strategy=ReplayTrace(num_trials_per_iter, num_trials_total),
+            task_name="BatchMatmul",
+            rand_state=0x114514,
+        ),
+    ]
+    database = DummyDatabase()
+    scheduler = MyTaskScheduler(tasks, DummyBuilder(), DummyRunner(), database)
+    scheduler.tune()
+    assert len(database) == num_trials_total * len(tasks)
     for task in tasks:
         assert len(database.get_top_k(database.commit_workload(task.mod), 1e9)) == num_trials_total
 


### PR DESCRIPTION
This patch fixes the infinite loop when you call a PyClass's undefined method. Now that we defined a new helper function decorator `check_override` and it would make sure a not implemented error would be thrown if the method has no default implementation. And it could still leverage default implementation for methods on the c++ side as shown in `test_meta_schedule_task_scheduler.py::test_meta_schedule_task_scheduler_override_next_task_id_only` test case.

To summarize:
1. It fixed a infinite loop bug.
2. It enables PyClasses to define only methods required to implement.
3. It throws `NotImplementError` early when a class with any required function is missing.
4. It fixes the constructor of task scheduler and enhances its unittests.