### PR TITLE
[CI] Update TVM ci-cpu docker image to v0.79

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = "tlcpack/ci-lint:v0.67"
 ci_gpu = "tlcpack/ci-gpu:v0.78"
-ci_cpu = "tlcpack/ci-cpu:v0.78"
+ci_cpu = "tlcpack/ci-cpu:v0.79"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.74"
 ci_qemu = "tlcpack/ci-qemu:v0.08"


### PR DESCRIPTION
Update TVM ci-cpu docker image to v0.79:
 * Requested in #9296
 * Validated at https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/169/pipeline/

Fixes #9296

cc @Mousius @ashutosh-arm @areusch @junrushao1994 @tqchen for reviews
