### PR TITLE
[Frontend][PaddlePaddle] Add operators of interploate/flatten and modify try_infer_value

### DIFF
--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -578,14 +578,15 @@ def infer_value_simulated(input_val, params):
     return output_value
 
 
-def try_infer_value(val, on_success=None, on_failure=None, parameters={}):
+def try_infer_value(val, on_success=None, on_failure=None, parameters=None):
     """Try running infer_value on the input val, and if successful, return the inferred value or
     pass it to on_success callback if provided. Otherwise, run on_failure callback if it is
     provided, or return the input val as output. In each case, the second return value
     indicates whether infer_value has succeeded or not.
     """
     try:
-        ret = infer_value(val, parameters).numpy()
+        params = parameters if parameters is not None else {}
+        ret = infer_value(val, params).numpy()
         if on_success:
             return on_success(ret), True
         return ret, True

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -578,14 +578,14 @@ def infer_value_simulated(input_val, params):
     return output_value
 
 
-def try_infer_value(val, on_success=None, on_failure=None):
+def try_infer_value(val, on_success=None, on_failure=None, parameters={}):
     """Try running infer_value on the input val, and if successful, return the inferred value or
     pass it to on_success callback if provided. Otherwise, run on_failure callback if it is
     provided, or return the input val as output. In each case, the second return value
     indicates whether infer_value has succeeded or not.
     """
     try:
-        ret = infer_value(val, {}).numpy()
+        ret = infer_value(val, parameters).numpy()
         if on_success:
             return on_success(ret), True
         return ret, True

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -1368,6 +1368,7 @@ _convert_map = {
     "matmul_v2": convert_matmul,
     "mul": convert_mul,
     "nearest_interp_v2": convert_interpolate,
+    "not_equal": convert_elementwise_op,
     "pad1d": convert_padding,
     "pad2d": convert_padding,
     "pad3d": convert_padding,

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -591,7 +591,7 @@ def convert_interpolate(g, op, block):
     """Operator converter for interpolate."""
 
     def get_interpolate_mode(op):
-        """Get parameters for interpolate methos."""
+        """Get parameters for interpolation methods."""
 
         interp_method = op.attr("interp_method")
         align_corners = op.attr("align_corners")

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -1333,6 +1333,7 @@ _convert_map = {
     "elementwise_floordiv": convert_elementwise_op,
     "elementwise_max": convert_elementwise_op,
     "elementwise_min": convert_elementwise_op,
+    "elementwise_mod": convert_elementwise_op,
     "elementwise_mul": convert_elementwise_op,
     "elementwise_pow": convert_elementwise_op,
     "elementwise_prod": convert_elementwise_op,

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -38,8 +38,8 @@ from .common import (
     infer_shape,
     infer_type,
     infer_value,
-    try_infer_value,
     shape_of,
+    try_infer_value,
     new_var,
 )
 

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -386,7 +386,7 @@ def convert_expand(g, op, block):
         sizes = op.attr("shape")
 
     if isinstance(sizes, _expr.Expr):
-        sizes, infered = try_infer_value(sizes, parameters=g.get_params())
+        sizes = try_infer_value(sizes, parameters=g.get_params())[0]
 
     if isinstance(sizes, np.ndarray):
         sizes = sizes.tolist()
@@ -453,7 +453,7 @@ def convert_fill_constant(g, op, block):
         shape = g.get_node(op.input("ShapeTensor")[0])
 
     if isinstance(shape, _expr.Expr):
-        shape, infered = try_infer_value(shape, parameters=g.get_params())
+        shape = try_infer_value(shape, parameters=g.get_params())[0]
 
     if isinstance(shape, np.ndarray):
         shape = shape.tolist()

--- a/tests/python/frontend/paddlepaddle/test_forward.py
+++ b/tests/python/frontend/paddlepaddle/test_forward.py
@@ -586,6 +586,24 @@ def test_forward_expand_as():
 
 
 @tvm.testing.uses_gpu
+def test_forward_flatten():
+    class Flatten(nn.Layer):
+        def __init__(self, start_axis=0, stop_axis=-1):
+            super(Flatten, self).__init__()
+            self.start_axis = start_axis
+            self.stop_axis = stop_axis
+
+        @paddle.jit.to_static
+        def forward(self, x):
+            return paddle.flatten(x, start_axis=self.start_axis, stop_axis=self.stop_axis)
+
+    input_data = paddle.rand([2, 3, 4, 5, 2], dtype="float32")
+    verify_model(Flatten(), input_data=input_data)
+    verify_model(Flatten(2), input_data=input_data)
+    verify_model(Flatten(2, -2), input_data=input_data)
+
+
+@tvm.testing.uses_gpu
 def test_forward_gather():
     class Gather(nn.Layer):
         def __init__(self, axis=None):
@@ -762,6 +780,77 @@ def test_forward_hard_swish():
     input_shape = [1, 3, 10, 10]
     input_data = paddle.rand(input_shape, dtype="float32")
     verify_model(hard_swish, input_data=input_data)
+
+
+@tvm.testing.uses_gpu
+def test_forward_interpolate():
+    class Interpolate0(nn.Layer):
+        def __init__(
+            self,
+            mode="nearest",
+            align_corners=False,
+            align_mode=0,
+            data_format="NCHW",
+            use_scale=False,
+            use_list=False,
+            use_const=False,
+        ):
+            super(Interpolate0, self).__init__()
+            self.mode = mode
+            self.align_corners = align_corners
+            self.align_mode = align_mode
+            self.data_format = data_format
+            self.use_scale = use_scale
+            self.use_list = use_list
+            self.use_const = use_const
+
+        @paddle.jit.to_static
+        def forward(self, x):
+            size = np.array([15, 19]).astype("int32")
+            scale = np.array([2.0, 1.0]).astype("float32")
+            if not self.use_list and not self.use_const:
+                size = paddle.to_tensor(size)
+                scale = paddle.to_tensor(scale)
+            elif not self.use_const:
+                size0 = paddle.to_tensor(size[0:1])
+                size = [size0, int(size[1])]
+            else:
+                size = size.tolist()
+                scale = scale.tolist()
+            if not self.use_scale:
+                return paddle.nn.functional.interpolate(
+                    x,
+                    size=size,
+                    mode=self.mode,
+                    align_corners=self.align_corners,
+                    align_mode=self.align_mode,
+                    data_format=self.data_format,
+                )
+            else:
+                return paddle.nn.functional.interpolate(
+                    x,
+                    scale_factor=scale,
+                    mode=self.mode,
+                    align_corners=self.align_corners,
+                    align_mode=self.align_mode,
+                    data_format=self.data_format,
+                )
+
+    input_data = paddle.rand([1, 2, 8, 12]).astype("float32")
+    verify_model(Interpolate0(), input_data)
+    verify_model(Interpolate0(use_list=True), input_data)
+    verify_model(Interpolate0(use_scale=True), input_data)
+    verify_model(Interpolate0("bilinear", use_scale=True), input_data)
+    verify_model(Interpolate0("bilinear", use_scale=True, align_corners=True), input_data)
+    verify_model(
+        Interpolate0(
+            "bilinear", use_scale=True, align_corners=True, align_mode=1, data_format="NHWC"
+        ),
+        input_data,
+    )
+    verify_model(
+        Interpolate0("bicubic", use_scale=True, align_corners=True, align_mode=1), input_data
+    )
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/paddlepaddle/test_forward.py
+++ b/tests/python/frontend/paddlepaddle/test_forward.py
@@ -784,7 +784,7 @@ def test_forward_hard_swish():
 
 @tvm.testing.uses_gpu
 def test_forward_interpolate():
-    class Interpolate0(nn.Layer):
+    class Interpolate(nn.Layer):
         def __init__(
             self,
             mode="nearest",
@@ -795,7 +795,7 @@ def test_forward_interpolate():
             use_list=False,
             use_const=False,
         ):
-            super(Interpolate0, self).__init__()
+            super(Interpolate, self).__init__()
             self.mode = mode
             self.align_corners = align_corners
             self.align_mode = align_mode
@@ -837,19 +837,19 @@ def test_forward_interpolate():
                 )
 
     input_data = paddle.rand([1, 2, 8, 12]).astype("float32")
-    verify_model(Interpolate0(), input_data)
-    verify_model(Interpolate0(use_list=True), input_data)
-    verify_model(Interpolate0(use_scale=True), input_data)
-    verify_model(Interpolate0("bilinear", use_scale=True), input_data)
-    verify_model(Interpolate0("bilinear", use_scale=True, align_corners=True), input_data)
+    verify_model(Interpolate(), input_data)
+    verify_model(Interpolate(use_list=True), input_data)
+    verify_model(Interpolate(use_scale=True), input_data)
+    verify_model(Interpolate("bilinear", use_scale=True), input_data)
+    verify_model(Interpolate("bilinear", use_scale=True, align_corners=True), input_data)
     verify_model(
-        Interpolate0(
+        Interpolate(
             "bilinear", use_scale=True, align_corners=True, align_mode=1, data_format="NHWC"
         ),
         input_data,
     )
     verify_model(
-        Interpolate0("bicubic", use_scale=True, align_corners=True, align_mode=1), input_data
+        Interpolate("bicubic", use_scale=True, align_corners=True, align_mode=1), input_data
     )
 
 


### PR DESCRIPTION
Add 4 operators,  the first 3 operators support 4D tensor's interpolation, and `flatten_contiguous_range` is a operator just like `torch.flatten`. 
- `nearest_interp_v2` 
- `bicubic_interp_v2`
- `bilinear_interp_v2`
- `flatten_contiguous_range`

This pull request modified `frontend/common.py::try_infer_value`, while before this function will not take model's parameters to infer value. With this pull request, it will help to solve some dynamic shape problem， e.g `x = op.reshape(x, shape=shape)`,  if the `shape` is a parameter of the original model, the old `try_infer_value` will fail to infer its value.  
While reviewing the code, I found `try_infer_value` was not called correctly in paddle frontend, although it didn't cause error because the execution is under `try` block, this also fixed in this pull request.

@mbrookhart  @AndrewZhaoLuo @masahi 

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
