### PR TITLE
[Frontend][TFlite] Cast MirrorPad paddings to int32

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -2628,7 +2628,7 @@ class OperatorConverter(object):
         # paddings
         pad_list = self.get_tensor_value(input_tensors[1])
         # convert list of lists to tuple of tuples
-        paddings = tuple(tuple(l) for l in pad_list)
+        paddings = tuple(tuple(l.astype(np.int32)) for l in pad_list)
 
         assert op.BuiltinOptionsType() == BuiltinOptions.MirrorPadOptions
         op_options = op.BuiltinOptions()

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -2780,6 +2780,20 @@ def test_forward_pad():
         ],
         mode="SYMMETRIC",
     )
+        _test_pad(
+        [
+            np.arange(1.0, 7.0, dtype=np.float32).reshape((2, 3)),
+            np.array([[1, 1], [2, 2]], dtype=np.int64),
+        ],
+        mode="REFLECT",
+    )
+    _test_pad(
+        [
+            np.arange(1.0, 7.0, dtype=np.float32).reshape((2, 3)),
+            np.array([[1, 1], [2, 2]], dtype=np.int64),
+        ],
+        mode="SYMMETRIC",
+    )
     _test_pad(
         [
             np.arange(0, 256, dtype=np.uint8).reshape((1, 256)),

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -2780,7 +2780,7 @@ def test_forward_pad():
         ],
         mode="SYMMETRIC",
     )
-        _test_pad(
+    _test_pad(
         [
             np.arange(1.0, 7.0, dtype=np.float32).reshape((2, 3)),
             np.array([[1, 1], [2, 2]], dtype=np.int64),


### PR DESCRIPTION
As an int64 paddings of MirrorPad would generate wrong TIR as result, try to cast paddings to int32 for best compatibility.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
