### PR TITLE
[CI] Make `version.py` to rely on repository metadata to generate version string

### DIFF
--- a/version.py
+++ b/version.py
@@ -31,17 +31,21 @@ import argparse
 import logging
 import subprocess
 
-# Modify the following two settings during release
+# Modify the following value during release
 # ---------------------------------------------------
-# Current version
+# Current version:
 # We use the version of the incoming release for code
-# that is under development
+# that is under development.
+#
+# It is also fallback version to be used when --git-describe
+# is not invoked, or when the repository does not present the
+# git tags in a format that this script can use.
+#
+# Two tag formats are supported:
+# - vMAJ.MIN.PATCH (e.g. v0.8.0) or
+# - vMAJ.MIN.devN (e.g. v0.8.dev0)
 __version__ = "0.8.dev0"
 
-# Most recent tag, used for git describe validation
-# set this value to be the most recent release tag
-# before this development cycle.
-__most_recent_tag__ = "v0.7.0"
 # ---------------------------------------------------
 
 PROJ_ROOT = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
@@ -80,7 +84,15 @@ def git_describe_version():
       after the most recent tag(v0.7.0),
       the git short hash tag of the current commit is 0d07a329e.
     """
-    cmd = ["git", "describe", "--tags", "--match", "v[0-9]*.[0-9]*.[0-9]*"]
+    cmd = [
+        "git",
+        "describe",
+        "--tags",
+        "--match",
+        "v[0-9]*.[0-9]*.[0-9]*",
+        "--match",
+        "v[0-9]*.[0-9]*.dev[0-9]*",
+    ]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=PROJ_ROOT)
     (out, _) = proc.communicate()
 
@@ -92,15 +104,6 @@ def git_describe_version():
         return __version__, __version__
     describe = py_str(out).strip()
     arr_info = describe.split("-")
-
-    if not arr_info[0].endswith(__most_recent_tag__):
-        logging.warning(
-            "%s does not match most recent tag %s, fallback to %s",
-            describe,
-            __most_recent_tag__,
-            __version__,
-        )
-        return __version__, __version__
 
     # Remove the v prefix, mainly to be robust
     # to the case where v is not presented as well.
@@ -115,8 +118,22 @@ def git_describe_version():
         logging.warning("Invalid output from git describe %s", describe)
         return __version__, __version__
 
-    dev_pos = __version__.find(".dev")
-    pub_ver = "%s.dev%s" % (__version__[:dev_pos], arr_info[1])
+    dev_pos = arr_info[0].find(".dev")
+
+    # Development versions:
+    # The code will reach this point in case it can't match a full release version, such as v0.7.0.
+    #
+    # 1. in case the last known label looks like vMAJ.MIN.devN e.g. v0.8.dev0, we use
+    # the current behaviour of just using vMAJ.MIN.devNNNN+gGIT_REV
+    if dev_pos != -1:
+        dev_version = arr_info[0][: arr_info[0].find(".dev")]
+    # 2. in case the last known label looks like vMAJ.MIN.PATCH e.g. v0.8.0
+    # then we just carry on with a similar version to what git describe provides, which is
+    # vMAJ.MIN.PATCH.devNNNN+gGIT_REV
+    else:
+        dev_version = arr_info[0]
+
+    pub_ver = "%s.dev%s" % (dev_version, arr_info[1])
     local_ver = "%s+%s" % (pub_ver, arr_info[2])
     return pub_ver, local_ver
 


### PR DESCRIPTION
Make `version.py` to rely on repository metadata to generate version string:

* This change removes the need for a hardcoded version string (in `version.py`) when generating a TVM release from a `git` repository. The long term goal here is to be able to have reproducible release versions without manual intervention on files such as `version.py`.

* It also removes assumptions of what the last valid tag should be, in order for the version string to be generated. This information should be encoded in the repository, as we are already using git tags to retrieve that information.

**Important**: before merging this change we need to tag the beginning of `0.8` development cycle with the appropriate tag, so that the metadata is encoded in the repository. Here is the revision we need to tag:
```
git tag v0.8.dev0 a644e29735c043d6c8614d2d7fbe1eac7307d08e
```

Also, when `0.9` starts (or something else _e.g._ `1.0`), we need to tag it, so development versions are correctly generated.

cc @mshawcroft @tqchen @areusch @Mousius @mbaret @gromero @junrushao1994  for reviews