### PR TITLE
Extend op attrs with commutattive annotation

### DIFF
--- a/include/tvm/ir/op.h
+++ b/include/tvm/ir/op.h
@@ -111,7 +111,7 @@ class OpNode : public RelayExprNode {
   }
 
   /*!
-   * \brief Check that if current op is a "primtive operator".
+   * \brief Check that if current op is a "primitive operator".
    * That is the arguments are all type variables, and there is a single
    * type relation applied to the input and output types.
    */

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -90,6 +90,11 @@ using TNonComputational = bool;
 using TReshapeOp = bool;
 
 /*!
+ * \brief Mark the operator as commutative to allow expr simplifications.
+ */
+using CommutativeOp = bool;
+
+/*!
  * \brief Mark the operator whether output shape is data dependent.
  */
 using TShapeDataDependent = Array<Integer>;

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -76,6 +76,23 @@ def register_stateful(op_name, stateful, level=10):
     tvm.ir.register_op_attr(op_name, "TOpIsStateful", stateful, level)
 
 
+def register_commutativity(op_name, commutativity, level=10):
+    """Register operator commutativity of lhs an rhs.
+
+    Parameters
+    ----------
+    op_name : str
+        The name of the op.
+
+    commutativity : bool
+        The commutativity flag.
+
+    level : int
+        The priority level
+    """
+    tvm.ir.register_op_attr(op_name, "CommutativeOp", commutativity, level)
+
+
 class OpPattern(object):
     """Operator generic patterns
 

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -213,6 +213,14 @@ bool DFPatternMatcher::VisitDFPattern_(const CallPatternNode* op, const Expr& ex
     }
     return false;
   };
+  auto is_commutative_op = [&get_op_node](const CallPatternNode* op_node) {
+    if (const auto* op_node_ = get_op_node(op_node)) {
+      if ((op_node_->name == "add") || (op_node_->name == "multiply")) {
+        return true;
+      }
+    }
+    return false;
+  };
 
   // logic
   auto watermark = matched_nodes_.size();
@@ -247,7 +255,7 @@ bool DFPatternMatcher::VisitDFPattern_(const CallPatternNode* op, const Expr& ex
       }
       // Commutative Matching
       if (const OpNode* op_node = get_op_node(op)) {
-        if ((op_node->name == "add") || (op_node->name == "multiply")) {
+        if (is_commutative_op(op)) {
           if (match_args(reverse(op->args), call_node->args)) {
             return true;
           }

--- a/src/relay/op/op_common.h
+++ b/src/relay/op/op_common.h
@@ -60,6 +60,7 @@ namespace relay {
       .add_type_rel("Identity", IdentityRel)                                   \
       .set_attr<TOpPattern>("TOpPattern", kElemWise)                           \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                         \
+      .set_attr<CommutativeOp>("CommutativeOp", false)                         \
       .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
 
 /*! Quick helper macro
@@ -84,6 +85,7 @@ namespace relay {
       .add_type_rel("Broadcast", BroadcastRel)                                          \
       .set_attr<TOpPattern>("TOpPattern", kBroadcast)                                   \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                                  \
+      .set_attr<CommutativeOp>("CommutativeOp", isCommutativeOp(OpName))                \
       .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout)
 
 // Comparisons
@@ -99,6 +101,7 @@ namespace relay {
       .add_type_rel("BroadcastComp", BroadcastCompRel)                                  \
       .set_attr<TOpPattern>("TOpPattern", kBroadcast)                                   \
       .set_attr<TOpIsStateful>("TOpIsStateful", false)                                  \
+      .set_attr<CommutativeOp>("CommutativeOp", false)                                  \
       .set_attr<FInferCorrectLayout>("FInferCorrectLayout", BinaryBroadcastLayout)
 
 /*! \brief A helper class for matching and rewriting operators. */
@@ -190,6 +193,10 @@ inline void GetPaddingDepthHeightWidth(const Array<IndexExpr>& padding, IndexExp
   } else {
     ICHECK_EQ(padding.size(), 6) << " Padding size should be 1, 3 or 6, but got " << padding.size();
   }
+}
+
+inline bool isCommutativeOp(const std::string& op_node_name) {
+  return (op_node_name == "add") || (op_node_name == "multiply");
 }
 
 }  // namespace relay

--- a/tests/python/relay/test_ir_op.py
+++ b/tests/python/relay/test_ir_op.py
@@ -120,6 +120,12 @@ def test_op_register():
     assert _op.get(op_name).get_attr("TOpIsStateful") == False
 
 
+def test_op_commutative_attr():
+    assert relay.op.get("add").get_attr("CommutativeOp") == 1
+    assert relay.op.get("multiply").get_attr("CommutativeOp") == 1
+    assert relay.op.get("divide").get_attr("CommutativeOp") == 0
+
+
 if __name__ == "__main__":
     test_op_attr()
     test_op_reset_attr()


### PR DESCRIPTION
This PR extends the op `attrs` with commutativity. 
This is required for the ongoing work to use the pattern language to express more general patterns.


@mbs-octoml  @mbrookhart @jroesch @electriclilies 