### PR TITLE
[CMSIS-NN] Assert correct amount of CMSIS-NN artifacts in MLF

### DIFF
--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -416,7 +416,7 @@ def test_compile_tflite_module_with_external_codegen_cmsisnn(
             for name in mlf_package.getnames()
             if re.match(r"\./codegen/host/src/\D+\d+\.c", name)
         ]
-        assert len(c_source_files) == 3
+        assert len(c_source_files) == 4
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Unsure why this wasn't picked up by another PR, assuming some race conditions - there's now 4 artifacts in the archive:
* Interface in lib0
* CMSIS-NN in lib1
* Linked params in lib2
* Host code and executor in lib3
