### PR TITLE
Fixed some warnings about lambda's closures that are bigger than necessary

### DIFF
--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -166,7 +166,7 @@ transform::Pass BindTarget(Target target) {
 }
 
 static transform::Pass AnnotateEntryFunc(bool b) {
-  auto fpass = [b](tir::PrimFunc f, IRModule m, transform::PassContext ctx) {
+  auto fpass = [](tir::PrimFunc f, IRModule m, transform::PassContext ctx) {
     return WithAttr(std::move(f), tir::attr::kIsEntryFunc, Bool(true));
   };
   return tir::transform::CreatePrimFuncPass(fpass, 0, "AnnotateEntryFunc", {});

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -618,8 +618,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
                    }
                  })
           .Match("memory.alloc_storage",
-                 [this](const Array<Expr>& args, const Attrs& attrs,
-                                   const Array<Type>& type_arg) {
+                 [this](const Array<Expr>& args, const Attrs& attrs, const Array<Type>& type_arg) {
                    ICHECK_EQ(args.size(), 2);
                    // Compute the size of the allocation.
                    this->VisitExpr(args[0]);

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -618,7 +618,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
                    }
                  })
           .Match("memory.alloc_storage",
-                 [this, call_node](const Array<Expr>& args, const Attrs& attrs,
+                 [this](const Array<Expr>& args, const Attrs& attrs,
                                    const Array<Type>& type_arg) {
                    ICHECK_EQ(args.size(), 2);
                    // Compute the size of the allocation.


### PR DESCRIPTION
Hi,

Just a couple of small changes to fix some warnings about some lambda's closures that are bigger than necessary as they capture variables that are not used.

Thanks!
