### PR TITLE
[BugFix] Fix divide by zero error in TIR pass lower_warp_memory

### DIFF
--- a/src/tir/transforms/lower_warp_memory.cc
+++ b/src/tir/transforms/lower_warp_memory.cc
@@ -224,6 +224,7 @@ class WarpAccessRewriter : protected StmtExprMutator {
     // Align the local memory size. The number of elements may not
     // be a multiple of width_ * warp_coeff_; round it up.
     int factor = width_ * warp_coeff_;
+    ICHECK_NE(factor, 0) << "Divide by zero";
     warp_group_ = (alloc_size + (factor - 1)) / factor;
     alloc_size = warp_group_ * factor;
 

--- a/tests/python/unittest/test_tir_transform_lower_warp_memory.py
+++ b/tests/python/unittest/test_tir_transform_lower_warp_memory.py
@@ -330,9 +330,8 @@ def test_lower_warp_memory_divide_by_factor():
     cuda_target = tvm.target.Target("cuda")
     mod = tvm.lower(func, name="f")
     mod = tvm.tir.transform.Apply(lambda f: f.with_attr("target", cuda_target))(mod)
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(tvm.error.TVMError, match="Divide by zero") as cm:
         tvm.tir.transform.LowerWarpMemory()(mod)["f_kernel0"]
-        assert "Divide by zero" in str(cm.execption)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_transform_lower_warp_memory.py
+++ b/tests/python/unittest/test_tir_transform_lower_warp_memory.py
@@ -20,6 +20,7 @@ from tvm.contrib.nvcc import have_fp16
 
 import numpy as np
 import tvm.testing
+import pytest
 
 
 @tvm.testing.requires_cuda
@@ -310,11 +311,29 @@ def test_lower_warp_memory_same_thread():
     assert "tvm_warp_shuffle" not in fdevice.astext()
 
 
+@tvm.testing.requires_cuda
+def test_lower_warp_memory_divide_by_factor():
+    ib = tvm.tir.ir_builder.IRBuilder()
+    bx = te.thread_axis("blockIdx.x")
+    tx = te.thread_axis("threadIdx.x")
+
+    with ib.new_scope():
+        ib.scope_attr(bx, "thread_extent", 32)
+        ib.scope_attr(tx, "thread_extent", 32)
+        t = ib.allocate("float32", 16, name="t", scope="warp")
+        n = ib.allocate("float32", 16, name="n", scope="local")
+        n[0] = t[0]
+
+    stmt = ib.get()
+    func = tvm.tir.PrimFunc([], stmt)
+    func = func.with_attr('from_legacy_te_schedule', True)
+    cuda_target = tvm.target.Target("cuda")
+    mod = tvm.lower(func, name="f")
+    mod = tvm.tir.transform.Apply(lambda f: f.with_attr("target", cuda_target))(mod)
+    with pytest.raises(tvm.error.TVMError) as cm:
+        tvm.tir.transform.LowerWarpMemory()(mod)["f_kernel0"]
+        assert "Divide by zero" in str(cm.execption)
+
+
 if __name__ == "__main__":
-    test_lower_warp_memory_local_scope()
-    test_lower_warp_memory_correct_indices()
-    test_lower_warp_memory_cuda_end_to_end()
-    test_lower_warp_memory_cuda_half_a_warp()
-    test_lower_warp_memory_cuda_2_buffers()
-    test_lower_warp_memory_roundup()
-    test_lower_warp_memory_same_thread()
+    pytest.main([__file__])

--- a/tests/python/unittest/test_tir_transform_lower_warp_memory.py
+++ b/tests/python/unittest/test_tir_transform_lower_warp_memory.py
@@ -326,7 +326,7 @@ def test_lower_warp_memory_divide_by_factor():
 
     stmt = ib.get()
     func = tvm.tir.PrimFunc([], stmt)
-    func = func.with_attr('from_legacy_te_schedule', True)
+    func = func.with_attr("from_legacy_te_schedule", True)
     cuda_target = tvm.target.Target("cuda")
     mod = tvm.lower(func, name="f")
     mod = tvm.tir.transform.Apply(lambda f: f.with_attr("target", cuda_target))(mod)


### PR DESCRIPTION
Here is a PR to fix the `divide by zero` bug mentioned in this [post](https://discuss.tvm.apache.org/t/divide-by-zero-error-in-tir-pass-lower-warp-memory/11433). In short, when applying TIR pass `lower_warp_memory`,  it will re-calculate the size and then allocate. And if the variable `factor` is zero, it can cause such an error.

https://github.com/apache/tvm/blob/86781e99371663f7c3315f8d98aba273dddb4422/src/tir/transforms/lower_warp_memory.cc#L222-L227

Here is the code example to reproduce the bug:

```python
import tvm
from tvm import te, tir

ib = tir.ir_builder.IRBuilder()
bx = te.thread_axis("blockIdx.x")
tx = te.thread_axis("threadIdx.x")

with ib.new_scope():
    ib.scope_attr(bx, "thread_extent", 32)
    ib.scope_attr(tx, "thread_extent", 32)
    t = ib.allocate("float32", 16, name="t", scope="warp")
    n = ib.allocate("float32", 16, name="n", scope="local")
    n[0] = t[0]

stmt = ib.get()
f = tvm.tir.PrimFunc([], stmt)
f = f.with_attr('from_legacy_te_schedule', True)
m = tvm.lower(f)
tvm.build(m, target=tvm.target.Target('cuda'))
```

