### PR TITLE
[HOTFIX][TARGET] Change LOG in compilation config to DLOG

### DIFF
--- a/src/target/compilation_config.cc
+++ b/src/target/compilation_config.cc
@@ -61,31 +61,31 @@ void CompilationConfigNode::EstablishDefaultSEScopes(const transform::PassContex
   if (host_target.defined()) {
     CHECK(!host_target->host.defined()) << "Host targets are not expected to have hosts";
     host_device_type = static_cast<DLDeviceType>(host_target->kind->device_type);
-    LOG(INFO) << "Using the given host target " << host_target->ToDebugString()
-              << " of device type " << host_device_type << " for the host target";
+    DLOG(INFO) << "Using the given host target " << host_target->ToDebugString()
+               << " of device type " << host_device_type << " for the host target";
     for (const auto& primitive_target : primitive_targets) {
       if (primitive_target->host.defined() &&
           !StructuralEqual()(primitive_target->host, host_target)) {
-        LOG(WARNING) << "The primitive target " << primitive_target->ToDebugString()
-                     << " already has a host which disagrees with the desired host target. It "
-                        "will be ignored.";
+        DLOG(WARNING) << "The primitive target " << primitive_target->ToDebugString()
+                      << " already has a host which disagrees with the desired host target. It "
+                      << "will be ignored.";
       }
     }
   } else if (primitive_targets.size() == 1 && primitive_targets.front()->host.defined()) {
     host_target = primitive_targets.front()->GetHost().value();
     CHECK(!host_target->host.defined()) << "Host targets are not expected to have hosts";
     host_device_type = static_cast<DLDeviceType>(host_target->kind->device_type);
-    LOG(INFO) << "Using the host of the unique primitive target, namely "
-              << host_target->ToDebugString() << " of device type " << host_device_type
-              << " for the host target";
+    DLOG(INFO) << "Using the host of the unique primitive target, namely "
+               << host_target->ToDebugString() << " of device type " << host_device_type
+               << " for the host target";
   } else if (primitive_targets.size() == 1 &&
              primitive_targets.front()->kind->device_type == kDLCPU) {
     // In the homogenous case without an explicit host target just use the given target so long as
     // it's a CPU.
     host_device_type = kDLCPU;
     host_target = primitive_targets.front();
-    LOG(INFO) << "Using the unique primitive target " << host_target->ToDebugString()
-              << " of device type " << host_device_type << " for the host target";
+    DLOG(INFO) << "Using the unique primitive target " << host_target->ToDebugString()
+               << " of device type " << host_device_type << " for the host target";
   } else {
     // Fallback.
     host_device_type = kDLCPU;
@@ -93,8 +93,8 @@ void CompilationConfigNode::EstablishDefaultSEScopes(const transform::PassContex
     // in the hetrogeneous case since its options may not be appropriate for host code
     // (eg shape functions). Instead, create a fresh default Target.
     host_target = MakeDefaultTarget(host_device_type);
-    LOG(WARNING) << "Using the default target " << host_target->ToDebugString()
-                 << " of device type " << host_device_type << " for the host target";
+    DLOG(WARNING) << "Using the default target " << host_target->ToDebugString()
+                  << " of device type " << host_device_type << " for the host target";
   }
   ICHECK(host_target.defined());
   ICHECK(!host_target->host.defined());
@@ -131,22 +131,22 @@ void CompilationConfigNode::EstablishDefaultSEScopes(const transform::PassContex
     CHECK_GT(v, 0)
         << "The 'relay.fallback_device_type' pass attribute is set to an invalid device type " << v;
     default_primitive_device_type = static_cast<DLDeviceType>(v);
-    LOG(INFO) << "Using the 'relay.fallback_device_type' pass attribute "
-              << default_primitive_device_type
-              << " as the default device type for all primitive operations";
+    DLOG(INFO) << "Using the 'relay.fallback_device_type' pass attribute "
+               << default_primitive_device_type
+               << " as the default device type for all primitive operations";
   } else if (primitive_targets.size() == 1) {
     // In the homogeneous case there's no free choice.
     default_primitive_device_type =
         static_cast<DLDeviceType>(primitive_targets.front()->kind->device_type);
-    LOG(INFO) << "Using the device type " << default_primitive_device_type
-              << " of the unique primitive target as the default device type for all primitive "
-                 "operations";
+    DLOG(INFO) << "Using the device type " << default_primitive_device_type
+               << " of the unique primitive target as the default device type for all primitive "
+               << "operations";
   } else {
     // Fallback. Note that we'll require a primitive Target of kDLCPU device_type to be given
     // and won't manufacture one out of thin air.
     default_primitive_device_type = kDLCPU;
-    LOG(WARNING) << "Using " << default_primitive_device_type
-                 << " as the default device type for all primitive operations";
+    DLOG(WARNING) << "Using " << default_primitive_device_type
+                  << " as the default device type for all primitive operations";
   }
 
   //
@@ -222,11 +222,11 @@ CompilationConfig::CompilationConfig(const transform::PassContext& pass_ctx,
       node->primitive_targets.size() == 1 ? *node->primitive_targets.begin() : Target();
 
   for (const auto& target : node->primitive_targets) {
-    LOG(INFO) << "Target " << target->ToDebugString() << " of device type "
-              << target->kind->device_type << " is available for primitives";
+    DLOG(INFO) << "Target " << target->ToDebugString() << " of device type "
+               << target->kind->device_type << " is available for primitives";
   }
-  LOG(INFO) << "Using default primitive scope " << node->default_primitive_se_scope;
-  LOG(INFO) << "Using host scope " << node->host_se_scope;
+  DLOG(INFO) << "Using default primitive scope " << node->default_primitive_se_scope;
+  DLOG(INFO) << "Using host scope " << node->host_se_scope;
 
   data_ = std::move(node);
 }


### PR DESCRIPTION
CompilationConfig was merged in on the basis that it is an internal experimental
structure that helps to group the target. Constructing the config should not
emit messages for most cases. Change LOG(INFO) to DLOG(INFO)
so users won't be overwhelmed by messages.

There are a few warning cases that also changes to DLOG. Given CompilationConfig
is still experimental, it would be better to respect the current default convention
and not trigger warnings that indicate an non-experimental suggestion.
Warnings can be updated according to the convention as it evolves.
