### PR TITLE
Followup from #9312 (Introduce call_lowered op)

### DIFF
--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -600,15 +600,15 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     }
 
     // Similarly transform arguments.
-    Array<Expr> args;
+    Array<Expr> visited_args;
     for (const auto& arg : call_node->args) {
-      args.push_back(VisitExpr(arg));
+      visited_args.push_back(VisitExpr(arg));
     }
 
     // Already lowered by other means so we don't need to mutate
     // the call but we do need to mutate the arguments
     if (prim_func->IsInstance<tir::PrimFuncNode>()) {
-      return Call(call_node->op, args, call_node->attrs);
+      return Call(call_node->op, visited_args, call_node->attrs);
     }
 
     // Find the desired target device.
@@ -623,10 +623,7 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
       target = se_scope->target;
       ICHECK(target.defined());
     }
-    Array<Expr> visited_args;
-    for (const auto& arg : call_node->args) {
-      visited_args.push_back(VisitExpr(arg));
-    }
+
     // Lower the primitive function for that target.
     Function func = Downcast<Function>(prim_func);
     return MakeLoweredCall(func, visited_args, call_node->type_args, call_node->span, target);

--- a/src/relay/op/call/call.cc
+++ b/src/relay/op/call/call.cc
@@ -108,8 +108,7 @@ CallLoweredProps GetCallLoweredProps(const CallNode* call_node) {
   const auto* attrs = call_node->attrs.as<CallLoweredAttrs>();
   ICHECK(attrs) << "Expected call_lowered op to have CallLoweredAttrs, but found "
                 << call_node->attrs->GetTypeKey();
-  return CallLoweredProps{std::move(GetRef<GlobalVar>(function)), std::move(tuple_args->fields),
-                          std::move(*attrs)};
+  return CallLoweredProps{GetRef<GlobalVar>(function), tuple_args->fields, *attrs};
 }
 
 }  // namespace relay


### PR DESCRIPTION
Two cleanups from #9312 -- 
1. Remove processing of CallLoweredOp in GetDeviceCopyProps since we also process CallLowered in GetPrimitiveDeviceCopyProps and it is redundant
2. Only visit arguments once in DeviceAwareVisitExpr_(const CallNode* call_node) in the TE compiler.
@mbs-octoml 