### PR TITLE
[TARGET] Cleanup the target_host usage to new target style.

### DIFF
--- a/apps/android_camera/models/prepare_model.py
+++ b/apps/android_camera/models/prepare_model.py
@@ -98,7 +98,7 @@ def main(model_str, output_path):
         pass
     print("building...")
     with tvm.transform.PassContext(opt_level=3):
-        graph, lib, params = relay.build(net, target, target_host=target_host, params=params)
+        graph, lib, params = relay.build(net, tvm.target.Target(target, target_host), params=params)
     print("dumping lib...")
     lib.export_library(output_path_str + "/" + "deploy_lib_cpu.so", ndk.create_shared)
     print("dumping graph...")

--- a/apps/android_rpc/tests/android_rpc_test.py
+++ b/apps/android_rpc/tests/android_rpc_test.py
@@ -86,7 +86,7 @@ def test_rpc_module():
         s[B].bind(xo, te.thread_axis("blockIdx.x"))
         # Build the dynamic lib.
         # If we don't want to do metal and only use cpu, just set target to be target
-        f = tvm.build(s, [A, B], "opencl", target_host=target, name="myadd")
+        f = tvm.build(s, [A, B], tvm.target.Target("opencl", host=target), name="myadd")
         path_dso_cl = temp.relpath("dev_lib_cl.so")
         f.export_library(path_dso_cl, ndk.create_shared)
 
@@ -109,7 +109,7 @@ def test_rpc_module():
         s[B].bind(xo, te.thread_axis("blockIdx.x"))
         # Build the dynamic lib.
         # If we don't want to do metal and only use cpu, just set target to be target
-        f = tvm.build(s, [A, B], "vulkan", target_host=target, name="myadd")
+        f = tvm.build(s, [A, B], tvm.target.Target("vulkan", host=target), name="myadd")
         path_dso_vulkan = temp.relpath("dev_lib_vulkan.so")
         f.export_library(path_dso_vulkan, ndk.create_shared)
 

--- a/apps/benchmark/arm_cpu_imagenet_bench.py
+++ b/apps/benchmark/arm_cpu_imagenet_bench.py
@@ -40,7 +40,7 @@ def evaluate_network(network, target, target_host, repeat):
 
     print_progress("%-20s building..." % network)
     with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(net, target=target, target_host=target_host, params=params)
+        lib = relay.build(net, target=tvm.target.Target(target, host=target_host), params=params)
 
     tmp = tempdir()
     if "android" in str(target):

--- a/apps/benchmark/mobile_gpu_imagenet_bench.py
+++ b/apps/benchmark/mobile_gpu_imagenet_bench.py
@@ -40,7 +40,7 @@ def evaluate_network(network, target, target_host, dtype, repeat):
 
     print_progress("%-20s building..." % network)
     with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(net, target=target, target_host=target_host, params=params)
+        lib = relay.build(net, target=tvm.target.Target(target, host=target_host), params=params)
 
     tmp = tempdir()
     if "android" in str(target) or "android" in str(target_host):

--- a/apps/hexagon_launcher/README.md
+++ b/apps/hexagon_launcher/README.md
@@ -19,7 +19,7 @@
 ## Compilation
 
 The launcher consists of two parts: part running on Hexagon, and part running
-on Android. Each component must be compiled separately. 
+on Android. Each component must be compiled separately.
 
 The supported Snapdragon architectures are 855, 865, and 888.
 
@@ -37,9 +37,9 @@ Building the Hexagon launcher application as a component of the main TVM build
 used for Hexagon codegen can be achieved by setting `USE_HEXAGON_LAUNCHER=ON`.
 This option will compile core tvm, the android launcher binary and its corresponding
 tvm_runtime, as well as the Hexagon launcher shared library and its corresponding
-tvm_runtime. As described in the [Manual compilation](#Manual compilation) section 
-each component requires Hexagon and android dependencies. When building the launcher 
-along with TVM these configurations must be providing when invoking cmake. A minimal 
+tvm_runtime. As described in the [Manual compilation](#Manual compilation) section
+each component requires Hexagon and android dependencies. When building the launcher
+along with TVM these configurations must be providing when invoking cmake. A minimal
 example invocation for compiling TVM along with the Hexagon launcher is included below:
 
 ```
@@ -59,9 +59,9 @@ cmake -DCMAKE_C_COMPILER=/path/to/clang \
 ```
 
 where `v65|v66|v68` means "one of" these architecture versions.
-The Hexagon launcher application is an android binary and thus requires the use 
-of an android toolchain for compilation. Similarly, the Hexagon tvm runtime 
-requires the use of the Hexagon toolchain and depends on the Hexagon SDK. The 
+The Hexagon launcher application is an android binary and thus requires the use
+of an android toolchain for compilation. Similarly, the Hexagon tvm runtime
+requires the use of the Hexagon toolchain and depends on the Hexagon SDK. The
 resulting hexagon launcher binaries can be found in the `apps_hexagon_launcher`
 subdirectory of the cmake build directory. Please note that the above command
 will not build support for Hexagon codegen in the TVM library, for that please
@@ -70,7 +70,7 @@ additionally define the `USE_HEXAGON_DEVICE` variable. Also, the LLVM used in
 
 ### Manual compilation
 
-Since some source files are shared between the Hexagon and android builds, 
+Since some source files are shared between the Hexagon and android builds,
 make sure to delete all object files between compilations. Compile the Hexagon
 code first.
 
@@ -157,7 +157,7 @@ mod, params = relay.frontend.from_tflite(
 
 target = tvm.target.hexagon('v68', link_params=True)
 with tvm.transform.PassContext(opt_level=3):
-    lib = relay.build(mod, target, target_host=target, params=params, mod_name="default")
+    lib = relay.build(mod, tvm.target.Target(target, host=target), params=params, mod_name="default")
 
 # Save model.so and model.json:
 with open('model.json', 'w') as f:

--- a/apps/ios_rpc/tests/ios_rpc_mobilenet.py
+++ b/apps/ios_rpc/tests/ios_rpc_mobilenet.py
@@ -93,7 +93,9 @@ def test_mobilenet(host, port, key, mode):
 
     def run(mod, target):
         with relay.build_config(opt_level=3):
-            lib = relay.build(mod, target=target, target_host=target_host, params=params)
+            lib = relay.build(
+                mod, target=tvm.target.Target(target, host=target_host), params=params
+            )
         path_dso = temp.relpath("deploy.dylib")
         lib.export_library(path_dso, xcode.create_dylib, arch=arch, sdk=sdk)
 

--- a/apps/ios_rpc/tests/ios_rpc_test.py
+++ b/apps/ios_rpc/tests/ios_rpc_test.py
@@ -55,7 +55,7 @@ def test_rpc_module(host, port, key, mode):
     s[B].bind(xo, te.thread_axis("blockIdx.x"))
     # Build the dynamic lib.
     # If we don't want to do metal and only use cpu, just set target to be target
-    f = tvm.build(s, [A, B], "metal", target_host=target, name="myadd")
+    f = tvm.build(s, [A, B], tvm.target.Target("metal", host=target), name="myadd")
     path_dso1 = temp.relpath("dev_lib.dylib")
     f.export_library(path_dso1, xcode.create_dylib, arch=arch, sdk=sdk)
 

--- a/apps/topi_recipe/gemm/android_gemm_square.py
+++ b/apps/topi_recipe/gemm/android_gemm_square.py
@@ -120,7 +120,7 @@ def test_gemm_gpu(N, times, bn, num_block, num_thread):
 
     print(tvm.lower(s, [A, B, C], simple_mode=True))
 
-    f = tvm.build(s, [A, B, C], "opencl", target_host=target, name="gemm_gpu")
+    f = tvm.build(s, [A, B, C], tvm.target.Target("opencl", host=target), name="gemm_gpu")
     temp = utils.tempdir()
     path_dso = temp.relpath("gemm_gpu.so")
     f.export_library(path_dso, ndk.create_shared)

--- a/docs/how_to/deploy/bnns.rst
+++ b/docs/how_to/deploy/bnns.rst
@@ -130,7 +130,7 @@ After that you need to compile new module with target corresponding to required 
 
     model = partition_for_bnns(model, params=params)  # to markup operations to be offloaded to BNNS
     with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(model, target=target, target_host=target, params=params)
+        lib = relay.build(model, target=target, params=params)
 
 Export the module.
 

--- a/docs/how_to/deploy/hls.rst
+++ b/docs/how_to/deploy/hls.rst
@@ -34,8 +34,7 @@ We use two python scripts for this tutorial.
       import tvm
       from tvm import te
 
-      tgt_host="llvm"
-      tgt="sdaccel"
+      tgt= tvm.target.Target("sdaccel", host="llvm")
 
       n = te.var("n")
       A = te.placeholder((n,), name='A')
@@ -47,7 +46,7 @@ We use two python scripts for this tutorial.
 
       s[C].bind(px, tvm.te.thread_axis("pipeline"))
 
-      fadd = tvm.build(s, [A, B, C], tgt, target_host=tgt_host, name="myadd")
+      fadd = tvm.build(s, [A, B, C], tgt, name="myadd")
 
       fadd.save("myadd.o")
       fadd.imported_modules[0].save("myadd.xclbin")

--- a/golang/sample/deploy.py
+++ b/golang/sample/deploy.py
@@ -26,7 +26,6 @@ import numpy as np
 
 # Global declarations of environment.
 
-tgt_host = "llvm"
 tgt = "llvm"
 
 ######################################################################
@@ -45,7 +44,7 @@ s = te.create_schedule(C.op)
 ######################################################################
 # Compilation
 # -----------
-fadd = tvm.build(s, [A, B, C], tgt, target_host=tgt_host, name="myadd")
+fadd = tvm.build(s, [A, B, C], tgt, name="myadd")
 
 ######################################################################
 # Save Compiled Module

--- a/jvm/README.md
+++ b/jvm/README.md
@@ -105,7 +105,7 @@ def test_add(target_dir):
     B = te.placeholder((n,), name='B')
     C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")
     s = te.create_schedule(C.op)
-    fadd = tvm.build(s, [A, B, C], "llvm", target_host="llvm", name="myadd")
+    fadd = tvm.build(s, [A, B, C], "llvm", name="myadd")
 
     fadd.save(os.path.join(target_dir, "add_cpu.o"))
     cc.create_shared(os.path.join(target_dir, "add_cpu.so"),

--- a/jvm/core/src/test/scripts/test_add_cpu.py
+++ b/jvm/core/src/test/scripts/test_add_cpu.py
@@ -27,7 +27,7 @@ def test_add(target_dir):
     B = te.placeholder((n,), name="B")
     C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")
     s = te.create_schedule(C.op)
-    fadd = tvm.build(s, [A, B, C], "llvm", target_host="llvm", name="myadd")
+    fadd = tvm.build(s, [A, B, C], "llvm", name="myadd")
 
     fadd.save(os.path.join(target_dir, "add_cpu.o"))
     cc.create_shared(

--- a/jvm/core/src/test/scripts/test_add_gpu.py
+++ b/jvm/core/src/test/scripts/test_add_gpu.py
@@ -35,7 +35,7 @@ def test_add(target_dir):
     bx, tx = s[C].split(C.op.axis[0], factor=64)
     s[C].bind(bx, te.thread_axis("blockIdx.x"))
     s[C].bind(tx, te.thread_axis("threadIdx.x"))
-    fadd_cuda = tvm.build(s, [A, B, C], "cuda", target_host="llvm", name="myadd")
+    fadd_cuda = tvm.build(s, [A, B, C], tvm.target.Target("cuda", host="llvm"), name="myadd")
 
     fadd_cuda.save(os.path.join(target_dir, "add_cuda.o"))
     fadd_cuda.imported_modules[0].save(os.path.join(target_dir, "add_cuda.ptx"))

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -25,6 +25,7 @@ Integrate auto_scheduler into relay. It implements the following items:
 import json
 import logging
 import threading
+import warnings
 
 import tvm
 from tvm import autotvm, transform
@@ -109,6 +110,11 @@ def extract_tasks(
         The weight (i.e. the number of appearance) of extracted tasks
     """
     # pylint: disable=import-outside-toplevel
+    if target_host is not None:
+        warnings.warn(
+            "target_host parameter is going to be deprecated. "
+            "Please pass in tvm.target.Target(target, host=target_host) instead."
+        )
 
     target, target_host = Target.check_and_update_host_consist(target, target_host)
 

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -22,6 +22,7 @@ Decorator and utilities for the integration with TOPI and Relay
 """
 import threading
 import logging
+import warnings
 
 import tvm
 from tvm.autotvm.task.dispatcher import DispatchContext, FallbackContext
@@ -77,6 +78,11 @@ def extract_from_program(mod, params, target, target_host=None, ops=None):
     task: Array of autotvm.task.Task
         collected tasks
     """
+    if target_host is not None:
+        warnings.warn(
+            "target_host parameter is going to be deprecated. "
+            "Please pass in tvm.target.Target(target, host=target_host) instead."
+        )
     target, target_host = Target.check_and_update_host_consist(target, target_host)
     return extract_from_multiple_program([mod], [params], target, ops=ops)
 

--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -17,6 +17,7 @@
 
 # pylint: disable=invalid-name
 """The build utils in python."""
+import warnings
 
 from typing import Union, Optional, List, Mapping
 
@@ -206,7 +207,7 @@ def build(
           s2 = topi.cuda.schedule_injective(cuda_tgt, [C])
           m1 = tvm.lower(s1, [A, B, C], name="test_add1")
           m2 = tvm.lower(s2, [A, B, C], name="test_add2")
-          rt_mod = tvm.build({"llvm": m1, "cuda": m2}, target_host="llvm")
+          rt_mod = tvm.build({"llvm": m1, "cuda": m2})
 
     Note
     ----
@@ -227,6 +228,12 @@ def build(
         raise ValueError(
             f"Inputs must be Schedule, IRModule or dict of target to IRModule, "
             f"but got {type(inputs)}."
+        )
+
+    if target_host is not None:
+        warnings.warn(
+            "target_host parameter is going to be deprecated. "
+            "Please pass in tvm.target.Target(target, host=target_host) instead."
         )
 
     if not isinstance(inputs, (dict, container.Map)):

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -20,6 +20,8 @@ The Relay Virtual Machine.
 
 Implements a Python interface to compiling and executing on the Relay VM.
 """
+import warnings
+
 import numpy as np
 
 import tvm
@@ -63,6 +65,11 @@ def compile(mod, target=None, target_host=None, params=None):
     exec : tvm.runtime.vm.Executable
         The VM executable that contains both library code and bytecode.
     """
+    if target_host is not None:
+        warnings.warn(
+            "target_host parameter is going to be deprecated. "
+            "Please pass in tvm.target.Target(target, host=target_host) instead."
+        )
     target, target_host = Target.check_and_update_host_consist(
         target, target_host, target_is_dict_key=False
     )
@@ -132,6 +139,11 @@ class VMCompiler(object):
             By default, llvm is used if it is enabled,
             otherwise a stackvm intepreter is used.
         """
+        if target_host is not None:
+            warnings.warn(
+                "target_host parameter is going to be deprecated. "
+                "Please pass in tvm.target.Target(target, host=target_host) instead."
+            )
         target = self._update_target(target)
         target_host = self._update_target_host(target, target_host)
         target, target_host = Target.check_and_update_host_consist(
@@ -173,6 +185,11 @@ class VMCompiler(object):
         params : dict
             The parameters of the final module.
         """
+        if target_host is not None:
+            warnings.warn(
+                "target_host parameter is going to be deprecated. "
+                "Please pass in tvm.target.Target(target, host=target_host) instead."
+            )
         target = self._update_target(target)
         target_host = self._update_target_host(target, target_host)
         target, target_host = Target.check_and_update_host_consist(

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -148,6 +148,11 @@ class BuildModule(object):
         params : dict
             The parameters of the final graph.
         """
+        if target_host is not None:
+            warnings.warn(
+                "target_host parameter is going to be deprecated. "
+                "Please pass in tvm.target.Target(target, host=target_host) instead."
+            )
         target = build_target_by_device_type_map(target)
         target, target_host = Target.check_and_update_host_consist(
             target, target_host, target_is_dict_key=False
@@ -332,15 +337,22 @@ def build(ir_mod, target=None, target_host=None, params=None, mod_name="default"
             "instead of deprecated parameter mod (tvm.relay.function.Function)",
             DeprecationWarning,
         )
+
+    if target_host is not None:
+        warnings.warn(
+            "target_host parameter is going to be deprecated. "
+            "Please pass in tvm.target.Target(target, host=target_host) instead."
+        )
+
+    target, target_host = Target.check_and_update_host_consist(
+        target, target_host, target_is_dict_key=False
+    )
+
     target = build_target_by_device_type_map(target)
     if isinstance(target_host, (str, Target)):
         target_host = Target(target_host)
     elif target_host:
         raise ValueError("target host must be the type of str, " + "tvm.target.Target, or None")
-
-    target, target_host = Target.check_and_update_host_consist(
-        target, target_host, target_is_dict_key=False
-    )
 
     # Retrieve the executor from the target
     executor = get_executor_from_target(target, target_host)

--- a/rust/tvm/tests/basics/src/tvm_add.py
+++ b/rust/tvm/tests/basics/src/tvm_add.py
@@ -36,7 +36,7 @@ def main(target, out_dir):
         s[C].bind(bx, te.thread_axis("blockIdx.x"))
         s[C].bind(tx, te.thread_axis("threadIdx.x"))
 
-    fadd = tvm.build(s, [A, B, C], target, target_host="llvm", name="myadd")
+    fadd = tvm.build(s, [A, B, C], tvm.target.Target(target, host="llvm"), name="myadd")
     fadd.save(osp.join(out_dir, "test_add.o"))
     if target == "cuda":
         fadd.imported_modules[0].save(osp.join(out_dir, "test_add.ptx"))

--- a/tests/python/contrib/test_bnns/infrastructure.py
+++ b/tests/python/contrib/test_bnns/infrastructure.py
@@ -143,7 +143,7 @@ def build_module(mod, target, params=None, enable_bnns=True, tvm_ops=0):
         if enable_bnns:
             mod = partition_for_bnns(mod)
         relay.backend.te_compiler.get().clear()
-        return relay.build(mod, target=target, target_host=target, params=params)
+        return relay.build(mod, target=target, params=params)
 
 
 def build_and_run(

--- a/tests/python/contrib/test_bnns/test_onnx_topologies.py
+++ b/tests/python/contrib/test_bnns/test_onnx_topologies.py
@@ -109,7 +109,7 @@ def process(model_name):
                 mod = simplify_model(mod)
             if with_bnns:
                 mod = partition_for_bnns(mod)
-            graph_module = relay.build(mod, target=target, target_host=target, params=params)
+            graph_module = relay.build(mod, target=target, params=params)
 
         lib_name = "deploy.tar"
         path_dso = temp.relpath(lib_name)

--- a/tests/python/contrib/test_hexagon/infrastructure.py
+++ b/tests/python/contrib/test_hexagon/infrastructure.py
@@ -64,7 +64,9 @@ def get_packed_filter_layout(out_channel, in_channel, kernel_h, kernel_w):
 def build_and_run(inputs, func, target, target_host, *args, **kwargs):
     schedule, placeholders, binds = func(*args, **kwargs)
 
-    func = tvm.build(schedule, placeholders, target=target, target_host=target_host, binds=binds)
+    func = tvm.build(
+        schedule, placeholders, target=tvm.target.Target(target, host=target_host), binds=binds
+    )
     dev = tvm.device(target)
     tensors = []
     for tensor in inputs:

--- a/tests/python/frontend/caffe/test_forward.py
+++ b/tests/python/frontend/caffe/test_forward.py
@@ -199,11 +199,10 @@ def _run_tvm(data, proto_file, blob_file):
     mod, params = relay.frontend.from_caffe(init_net, predict_net, shape_dict, dtype_dict)
 
     target = "llvm"
-    target_host = "llvm"
 
     dev = tvm.cpu(0)
     with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(mod, target=target, target_host=target_host, params=params)
+        lib = relay.build(mod, target=target, params=params)
     dtype = "float32"
     m = graph_executor.GraphModule(lib["default"](dev))
     if isinstance(data, (tuple, list)):

--- a/tests/python/frontend/tensorflow2/common.py
+++ b/tests/python/frontend/tensorflow2/common.py
@@ -51,13 +51,15 @@ def run_tf_code(func, input_):
 
 def compile_graph_executor(mod, params, target="llvm", target_host="llvm", opt_level=3):
     with tvm.transform.PassContext(opt_level):
-        lib = relay.build(mod, target=target, target_host=target_host, params=params)
+        lib = relay.build(mod, target=tvm.target.Target(target, host=target_host), params=params)
     return lib
 
 
 def compile_vm(mod, params, target="llvm", target_host="llvm", opt_level=3, disabled_pass=None):
     with tvm.transform.PassContext(opt_level, disabled_pass=disabled_pass):
-        vm_exec = relay.vm.compile(mod, target, target_host, params=params)
+        vm_exec = relay.vm.compile(
+            mod, target=tvm.target.Target(target, host=target_host), params=params
+        )
     return vm_exec
 
 

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -567,8 +567,7 @@ def compile_models(
         with tvm.transform.PassContext(opt_level=3, config=config):
             executor_factory = tvm.relay.build(
                 model.module,
-                target,
-                target_host=target,
+                tvm.target.Target(target, host=target),
                 params=model.params,
                 mod_name=model.name,
             )

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -130,7 +130,6 @@ def test_export_model_library_format_c(executor, target, should_generate_interfa
             factory = tvm.relay.build(
                 relay_mod,
                 target,
-                target_host=target,
                 mod_name="add",
                 params={"c": numpy.array([[2.0, 4.0]], dtype="float32")},
             )
@@ -213,7 +212,6 @@ def test_export_model_library_format_llvm():
             factory = tvm.relay.build(
                 relay_mod,
                 target,
-                target_host=target,
                 mod_name="add",
                 params={"c": numpy.array([[2.0, 4.0]], dtype="float32")},
             )
@@ -291,7 +289,7 @@ def test_export_model_library_format_workspace(target):
             }
             """
         )
-        factory = tvm.relay.build(relay_mod, target, target_host=target, mod_name="qnn_conv2d")
+        factory = tvm.relay.build(relay_mod, target, mod_name="qnn_conv2d")
 
     temp_dir = utils.tempdir()
     mlf_tar_path = temp_dir.relpath("lib.tar")

--- a/tests/python/unittest/test_target_codegen_hexagon.py
+++ b/tests/python/unittest/test_target_codegen_hexagon.py
@@ -133,7 +133,7 @@ def test_linked_params_codegen():
     target = tvm.target.hexagon("v68", link_params=True)
 
     with tvm.transform.PassContext(opt_level=3):
-        lib = tvm.relay.build(mod, target=target, target_host=target, params=params)
+        lib = tvm.relay.build(mod, target=target, params=params)
         llvm_ir = lib.get_lib().get_source("ll")
 
     # The definition of the parameter:

--- a/vta/scripts/tune_conv2d_transpose.py
+++ b/vta/scripts/tune_conv2d_transpose.py
@@ -136,8 +136,7 @@ if __name__ == "__main__":
         task = autotvm.task.create(
             conv2d_transpose,
             args=(N, CI, H, W, CO, KH, KW, strides, padding, opadding),
-            target=tvm.target.vta(),
-            target_host=env.target_host,
+            target=tvm.target.Target(tvm.target.vta(), host=env.target_host),
             template_key="direct",
         )
         print(task.config_space)

--- a/vta/scripts/tune_resnet.py
+++ b/vta/scripts/tune_resnet.py
@@ -274,8 +274,7 @@ if __name__ == "__main__":
         func=relay_prog,
         params=params,
         ops=(relay.op.get("nn.conv2d"),),
-        target=target,
-        target_host=env.target_host,
+        target=tvm.target.Target(target, host=env.target_host),
     )
 
     # Perform Autotuning
@@ -309,12 +308,16 @@ if __name__ == "__main__":
         if target.device_name != "vta":
             with tvm.transform.PassContext(opt_level=3, disabled_pass={"AlterOpLayout"}):
                 graph, lib, params = relay.build(
-                    relay_prog, target=target, params=params, target_host=env.target_host
+                    relay_prog,
+                    target=tvm.target.Target(target, host=env.target_host),
+                    params=params,
                 )
         else:
             with vta.build_config(opt_level=3, disabled_pass={"AlterOpLayout"}):
                 graph, lib, params = relay.build(
-                    relay_prog, target=target, params=params, target_host=env.target_host
+                    relay_prog,
+                    target=tvm.target.Target(target, host=env.target_host),
+                    params=params,
                 )
 
         # Export library

--- a/vta/tests/python/integration/test_benchmark_gemm.py
+++ b/vta/tests/python/integration/test_benchmark_gemm.py
@@ -60,7 +60,12 @@ def test_gemm():
         res = te.compute(res_shape, lambda *i: res_min(*i).astype(env.inp_dtype), name="res")
 
         def verify(s):
-            mod = vta.build(s, [data, weight, res], "ext_dev", env.target_host, name="gemm")
+            mod = vta.build(
+                s,
+                [data, weight, res],
+                tvm.target.Target("ext_dev", host=env.target_host),
+                name="gemm",
+            )
             temp = utils.tempdir()
             mod.save(temp.relpath("gemm.o"))
             remote.upload(temp.relpath("gemm.o"))

--- a/vta/tests/python/integration/test_benchmark_topi_conv2d.py
+++ b/vta/tests/python/integration/test_benchmark_topi_conv2d.py
@@ -218,11 +218,17 @@ def run_conv2d(env, remote, wl, target, check_correctness=True, print_ir=False, 
     # Build
     if "vta" in target.keys:
         mod = vta.build(
-            s, [data, kernel, bias, res], target=target, target_host=env.target_host, name="conv2d"
+            s,
+            [data, kernel, bias, res],
+            target=tvm.target.Target(target, host=env.target_host),
+            name="conv2d",
         )
     else:
         mod = tvm.build(
-            s, [data, kernel, bias, res], target=target, target_host=env.target_host, name="conv2d"
+            s,
+            [data, kernel, bias, res],
+            target=tvm.target.Target(target, host=env.target_host),
+            name="conv2d",
         )
     temp = utils.tempdir()
     mod.save(temp.relpath("conv2d.o"))

--- a/vta/tests/python/integration/test_benchmark_topi_dense.py
+++ b/vta/tests/python/integration/test_benchmark_topi_dense.py
@@ -125,11 +125,17 @@ def run_gemm(
     # Build
     if "vta" in target.keys:
         mod = vta.build(
-            s, [data, kernel, res], target=target, target_host=env.target_host, name="dense"
+            s,
+            [data, kernel, res],
+            target=tvm.target.Target(target, host=env.target_host),
+            name="dense",
         )
     else:
         mod = tvm.build(
-            s, [data, kernel, res], target=target, target_host=env.target_host, name="dense"
+            s,
+            [data, kernel, res],
+            target=tvm.target.Target(target, host=env.target_host),
+            name="dense",
         )
     temp = utils.tempdir()
     mod.save(temp.relpath("dense.o"))

--- a/vta/tests/python/integration/test_benchmark_topi_group_conv2d.py
+++ b/vta/tests/python/integration/test_benchmark_topi_group_conv2d.py
@@ -212,11 +212,17 @@ def run_group_conv2d(env, remote, wl, target, check_correctness=True, print_ir=F
     # Build
     if "vta" in target.keys:
         mod = vta.build(
-            s, [data, kernel, bias, res], target=target, target_host=env.target_host, name="conv2d"
+            s,
+            [data, kernel, bias, res],
+            target=tvm.target.Target(target, host=env.target_host),
+            name="conv2d",
         )
     else:
         mod = tvm.build(
-            s, [data, kernel, bias, res], target=target, target_host=env.target_host, name="conv2d"
+            s,
+            [data, kernel, bias, res],
+            target=tvm.target.Target(target, host=env.target_host),
+            name="conv2d",
         )
     temp = utils.tempdir()
     mod.save(temp.relpath("conv2d.o"))

--- a/vta/tests/python/unittest/test_vta_insn.py
+++ b/vta/tests/python/unittest/test_vta_insn.py
@@ -50,7 +50,7 @@ def test_save_load_out():
 
         # verification
         with vta.build_config():
-            m = vta.build(s, [x, y], "ext_dev", env.target_host)
+            m = vta.build(s, [x, y], tvm.target.Target("ext_dev", host=env.target_host))
 
         if not remote:
             return
@@ -121,7 +121,7 @@ def test_padded_load():
             s[y].pragma(y.op.axis[0], env.dma_copy)
             # build
             with vta.build_config():
-                mod = vta.build(s, [x, y], "ext_dev", env.target_host)
+                mod = vta.build(s, [x, y], tvm.target.Target("ext_dev", host=env.target_host))
 
             if not remote:
                 return
@@ -208,7 +208,7 @@ def test_gemm():
             return
 
         def verify(s, name=None):
-            mod = vta.build(s, [x, w, y], "ext_dev", env.target_host)
+            mod = vta.build(s, [x, w, y], tvm.target.Target("ext_dev", host=env.target_host))
             temp = utils.tempdir()
             mod.save(temp.relpath("gemm.o"))
             remote.upload(temp.relpath("gemm.o"))
@@ -368,9 +368,11 @@ def test_alu():
             # build
             with vta.build_config():
                 if use_imm:
-                    mod = vta.build(s, [a, res], "ext_dev", env.target_host)
+                    mod = vta.build(s, [a, res], tvm.target.Target("ext_dev", host=env.target_host))
                 else:
-                    mod = vta.build(s, [a, b, res], "ext_dev", env.target_host)
+                    mod = vta.build(
+                        s, [a, b, res], tvm.target.Target("ext_dev", host=env.target_host)
+                    )
             temp = utils.tempdir()
             mod.save(temp.relpath("load_act.o"))
             remote.upload(temp.relpath("load_act.o"))
@@ -451,7 +453,7 @@ def test_relu():
         s[res].pragma(res.op.axis[0], env.dma_copy)  # SRAM->DRAM
         # build
         with vta.build_config():
-            mod = vta.build(s, [a, res], "ext_dev", env.target_host)
+            mod = vta.build(s, [a, res], tvm.target.Target("ext_dev", host=env.target_host))
         if not remote:
             return
         temp = utils.tempdir()
@@ -513,7 +515,7 @@ def test_shift_and_scale():
         s[res_scale].pragma(res_scale.op.axis[0], env.alu)  # compute
         s[res].pragma(res.op.axis[0], env.dma_copy)  # SRAM->DRAM
         # build
-        mod = vta.build(s, [a, res], "ext_dev", env.target_host)
+        mod = vta.build(s, [a, res], tvm.target.Target("ext_dev", host=env.target_host))
         if not remote:
             return
         temp = utils.tempdir()

--- a/vta/tutorials/autotvm/tune_alu_vta.py
+++ b/vta/tutorials/autotvm/tune_alu_vta.py
@@ -285,8 +285,7 @@ def tune_and_evaluate(tuning_opt):
             relay.op.get("add"),
             relay.op.get("multiply"),
         ),
-        target=target,
-        target_host=env.target_host,
+        target=tvm.target.Target(target, host=env.target_host),
     )
 
     # filter out non-packed alu task

--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -200,7 +200,7 @@ with autotvm.tophub.context(target):
     if target.device_name != "vta":
         with tvm.transform.PassContext(opt_level=3, disabled_pass={"AlterOpLayout"}):
             graph, lib, params = relay.build(
-                relay_prog, target=target, params=params, target_host=env.target_host
+                relay_prog, target=tvm.target.Target(target, host=env.target_host), params=params
             )
     else:
         if env.TARGET == "intelfocl":
@@ -208,7 +208,7 @@ with autotvm.tophub.context(target):
             target = {"cpu": env.target_vta_cpu, "ext_dev": target}
         with vta.build_config(opt_level=3, disabled_pass={"AlterOpLayout"}):
             graph, lib, params = relay.build(
-                relay_prog, target=target, params=params, target_host=env.target_host
+                relay_prog, target=tvm.target.Target(target, host=env.target_host), params=params
             )
 
     # Measure Relay build time

--- a/vta/tutorials/frontend/deploy_detection.py
+++ b/vta/tutorials/frontend/deploy_detection.py
@@ -233,7 +233,9 @@ with autotvm.tophub.context(target):
 
     # Compile Relay program with AlterOpLayout disabled
     with vta.build_config(disabled_pass={"AlterOpLayout"}):
-        lib = relay.build(mod, target=target, params=params, target_host=env.target_host)
+        lib = relay.build(
+            mod, target=tvm.target.Target(target, host=env.target_host), params=params
+        )
 
     # Measure Relay build time
     build_time = time.time() - build_start

--- a/vta/tutorials/matrix_multiply.py
+++ b/vta/tutorials/matrix_multiply.py
@@ -386,7 +386,9 @@ print(vta.lower(s, [A, B, C], simple_mode=True))
 # into a TVM function.
 
 # Build GEMM VTA kernel
-my_gemm = vta.build(s, [A, B, C], "ext_dev", env.target_host, name="my_gemm")
+my_gemm = vta.build(
+    s, [A, B, C], tvm.target.Target("ext_dev", host=env.target_host), name="my_gemm"
+)
 
 # Write the compiled module into an object file.
 temp = utils.tempdir()

--- a/vta/tutorials/optimize/convolution_opt.py
+++ b/vta/tutorials/optimize/convolution_opt.py
@@ -369,7 +369,9 @@ print(vta.lower(s, [data, kernel, res], simple_mode=True))
 from tvm.topi.testing import conv2d_nchw_python
 
 # Compile the TVM module
-my_conv = vta.build(s, [data, kernel, res], "ext_dev", env.target_host, name="my_conv")
+my_conv = vta.build(
+    s, [data, kernel, res], tvm.target.Target("ext_dev", host=env.target_host), name="my_conv"
+)
 temp = utils.tempdir()
 my_conv.save(temp.relpath("conv2d.o"))
 remote.upload(temp.relpath("conv2d.o"))

--- a/vta/tutorials/optimize/matrix_multiply_opt.py
+++ b/vta/tutorials/optimize/matrix_multiply_opt.py
@@ -310,7 +310,9 @@ print(vta.lower(s, [data, weight, res], simple_mode=True))
 # ensure correctness.
 
 # Compile the TVM module
-my_gemm = vta.build(s, [data, weight, res], "ext_dev", env.target_host, name="my_gemm")
+my_gemm = vta.build(
+    s, [data, weight, res], tvm.target.Target("ext_dev", host=env.target_host), name="my_gemm"
+)
 temp = utils.tempdir()
 my_gemm.save(temp.relpath("gemm.o"))
 remote.upload(temp.relpath("gemm.o"))

--- a/vta/tutorials/vta_get_started.py
+++ b/vta/tutorials/vta_get_started.py
@@ -311,7 +311,9 @@ print(vta.lower(s, [A, B, C], simple_mode=True))
 # function(including the inputs and outputs) as well as target language
 # we want to compile to.
 #
-my_vadd = vta.build(s, [A, B, C], "ext_dev", env.target_host, name="my_vadd")
+my_vadd = vta.build(
+    s, [A, B, C], tvm.target.Target("ext_dev", host=env.target_host), name="my_vadd"
+)
 
 ######################################################################
 # Saving the Module

--- a/web/tests/python/webgpu_rpc_test.py
+++ b/web/tests/python/webgpu_rpc_test.py
@@ -34,8 +34,9 @@ def test_rpc():
     if not tvm.runtime.enabled("rpc"):
         return
     # generate the wasm library
-    target_device = "webgpu"
-    target_host = "llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
+    target = tvm.target.Target(
+        "webgpu", host="llvm -mtriple=wasm32-unknown-unknown-wasm -system-lib"
+    )
     if not tvm.runtime.enabled(target_host):
         raise RuntimeError("Target %s is not enbaled" % target_host)
 
@@ -49,7 +50,7 @@ def test_rpc():
     s[B].bind(xi, te.thread_axis("threadIdx.x"))
     s[B].bind(xo, te.thread_axis("blockIdx.x"))
 
-    fadd = tvm.build(s, [A, B], target_device, target_host=target_host, name="addone")
+    fadd = tvm.build(s, [A, B], target, name="addone")
     temp = utils.tempdir()
 
     wasm_path = temp.relpath("addone_gpu.wasm")


### PR DESCRIPTION
As we move towards the new Target system, most of the target specifications in the compiler already moved to the new style. This PR aims to cleanup the rest in the codebase.

- Add deprecation warnings to functions with target_host parameters.
- Update the build usage to new target style.
