### PR TITLE
[Relay] Use target_host determined at Relay level instead of recalculating it

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -501,7 +501,7 @@ class RelayBuildModule : public runtime::ModuleNode {
         ret_.mod = tvm::codegen::CSourceModuleCreate(";", "", Array<String>{});
       }
     } else {
-      ret_.mod = tvm::build(lowered_funcs, target_host_);
+      ret_.mod = tvm::build(lowered_funcs, target_host);
     }
 
     auto ext_mods = executor_codegen_->GetExternalModules();

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -416,7 +416,7 @@ def test_compile_tflite_module_with_external_codegen_cmsisnn(
             for name in mlf_package.getnames()
             if re.match(r"\./codegen/host/src/\D+\d+\.c", name)
         ]
-        assert len(c_source_files) == 4
+        assert len(c_source_files) == 3
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
I only ran a few tests locally as this hopefully fixes the flakiness, so unsure what side effects this has. Using `targets_` without `cmsis-nn` it correctly finds the host `Target` and now correctly passes it to `tvm::build`.

It would be better if we collected [the configuration of the compiler in some uniform fashion](https://discuss.tvm.apache.org/t/pre-rfc-compilation-configuration-representation/11372), rather than recalculating host and introducing this ambiguity through-out the compiler.

Fixes #9495