### PR TITLE
[BugFix][TVMScript] Fix printer for dependent loops

### DIFF
--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3176,5 +3176,19 @@ def test_div_mod():
     assert isinstance(func.body[3].value, tvm.tir.Mod)
 
 
+@T.prim_func
+def loop_extent_dependent(a: T.handle) -> None:
+    A = T.match_buffer(a, [], dtype="int32")
+    for i in T.serial(0, 128):
+        for j in T.serial(0, i):
+            A[()] = A[()] + j
+
+
+def test_loop_extent_dependent():
+    func = loop_extent_dependent
+    rt_func = tvm.script.from_source(func.script(show_meta=True))
+    tvm.ir.assert_structural_equal(func, rt_func, True)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
This PR fixes a bug in TVMScript printer. Suppose we have the following script:
```python
@T.prim_func
def func(a: T.handle) -> None:
    A = T.match_buffer(a, [], dtype="int32")
    for i in T.serial(0, 128):
        for j in T.serial(0, i):
            A[()] = A[()] + j
```

Before this PR, the printer prints it as
```python
@T.prim_func
def func(a: T.handle) -> None:
    A = T.match_buffer(a, [], dtype="int32")
    # body
    for i, j in T.grid(128, i):  # <=== Invalid Python syntax!
        A[()] = A[()] + j
```

Note that the last but one line is erroneous. When TVMScript parser deals with the printed script, it says
```
error: Unknown identifier i.
 --> tensorir.py:23:29
    |  
 23 |      for i, j in T.grid(128, i):
    |                              ^  
note: run with `TVM_BACKTRACE=1` environment variable to display a backtrace.
```

After this PR, the printer separately prints loops with dependency. So the issue above won't show again :-)

cc @Hzfengsy @junrushao1994 