### PR TITLE
[TVMScript] Report error if add attr to implicit root block

### DIFF
--- a/python/tvm/script/context_maintainer.py
+++ b/python/tvm/script/context_maintainer.py
@@ -138,6 +138,10 @@ class ContextMaintainer:
     _report_error: Callable[[str, Union[Span, synr.ast.Span]], None]
     """Callable[[str, Union[Span, synr.ast.Span]], None]: The report error function handle"""
 
+    # root alloc_buffer
+    root_alloc_buffers: List[Buffer] = []
+    """List[Buffer]: The buffers allocated under root block"""
+
     def __init__(self, _report_error: Callable[[str, Union[Span, synr.ast.Span]], None]):
         # scope context
         self.node_stack = []
@@ -152,6 +156,8 @@ class ContextMaintainer:
         # parser and analyzer
         self._report_error = _report_error
         self.analyzer = tvm.arith.Analyzer()
+        # root alloc_buffer
+        self.root_alloc_buffers = []
 
     def enter_scope(self, nodes: Optional[List[synr.ast.Node]] = None):
         """Creates a new scope
@@ -230,4 +236,6 @@ class ContextMaintainer:
         self._report_error(message, span)
 
     def current_block_scope(self) -> BlockInfo:
-        return self.block_info_stack[-1]
+        if self.block_info_stack:
+            return self.block_info_stack[-1]
+        return None

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -36,7 +36,7 @@ from tvm.tir.function import PrimFunc
 from . import _ffi_api
 from . import tir
 
-from .context_maintainer import BlockInfo, ContextMaintainer
+from .context_maintainer import ContextMaintainer
 from .meta_unparser import MetaUnparser
 from .registry import Registry
 from .diagnostics import TVMDiagnosticCtx

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -487,6 +487,39 @@ def test_block_has_option_vars():
     check_error(block_has_option_vars, 2)
 
 
+def implicit_root_has_read():
+    T.reads([])  # error: implicit root does not support reads
+    T.evaluate(0.0)
+
+
+def implicit_root_has_write():
+    T.writes([])  # error: implicit root does not support writes
+    T.evaluate(0.0)
+
+
+def implicit_root_has_attrs():
+    T.block_attr({})  # error: implicit root does not support block_attr
+    T.evaluate(0.0)
+
+
+def implicit_root_has_predicate():
+    T.where(True)  # error: implicit root does not support predicate
+    T.evaluate(0.0)
+
+
+def implicit_root_has_axes():
+    v = T.axis.S(0, 0)  # error: implicit root does not support axis define
+    T.evaluate(0.0)
+
+
+def test_implicit_root_has_attrs():
+    check_error(implicit_root_has_read, 2)
+    check_error(implicit_root_has_write, 2)
+    check_error(implicit_root_has_attrs, 2)
+    check_error(implicit_root_has_predicate, 2)
+    check_error(implicit_root_has_axes, 2)
+
+
 def check_error(func, rel_lineno):
     # Override the default renderer to accumulate errors
     errors = []
@@ -508,9 +541,6 @@ def check_error(func, rel_lineno):
         assert (
             d.span.line - 1 == rel_lineno
         ), f"Expected error to be on line {rel_lineno}, but it was on {d.span.line - 1}"
-
-
-# TODO(Siyuan): block iter errors.
 
 
 @T.prim_func


### PR DESCRIPTION
We disallow to add some block attrs (e.g. `T.block_attr`, `T.reads`) to implicit root block, but still allow `alloc_buffer`.

```python
# Disallow
def func():
    T.block_attr({})
    ...

# Allow
def func():
    T.alloc_buffer((128,))
    ...
# Same as
def func():
    with T.block("root"):
        T.alloc_buffer((128,))
        ...
```

cc @spectrometerHBH @junrushao1994 