### PR TITLE
fix compute inline not to over write annotated opaque accesses

### DIFF
--- a/src/tir/schedule/primitive/compute_inline.cc
+++ b/src/tir/schedule/primitive/compute_inline.cc
@@ -313,7 +313,11 @@ class BaseInliner : public StmtExprMutator {
     // Step 2. Update `BlockNode::reads` and `BlockNode::writes`
     Array<BufferRegion> reads = std::move(block->reads);
     Array<BufferRegion> writes = std::move(block->writes);
-    if (!is_scope_root) {
+    auto f_access_inline_buffer = [this](const BufferRegion& access) {
+      return access->buffer.same_as(this->inlined_buffer_);
+    };
+    if (!is_scope_root && (std::any_of(reads.begin(), reads.end(), f_access_inline_buffer) ||
+                           std::any_of(writes.begin(), writes.end(), f_access_inline_buffer))) {
       Array<Array<BufferRegion>> inspected = GetBlockReadWriteRegion(block, buffer_var_map_);
       reads = std::move(inspected[0]);
       writes = std::move(inspected[1]);


### PR DESCRIPTION
Hi~ This is a fix for `compute_inline` primitive. The error case is that it would overwrite some irrelavent block's opaque read/write annotations to full region, which would not be preferred. 
