### PR TITLE
Expose workspace size in tvmgen_default.h

### DIFF
--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -44,13 +44,15 @@ class UnsupportedInModelLibraryFormatError(Exception):
     """Raised when export_model_library_format does not support the given Module tree."""
 
 
-def generate_c_interface_header(module_name, inputs, outputs, devices, include_path):
+def generate_c_interface_header(
+    module_name, inputs, outputs, devices, workspace_size, include_path
+):
     """Generate C Interface header to be included in MLF"""
     mangled_name = to_c_variable_style(prefix_generated_name(module_name))
     metadata_header = os.path.join(include_path, f"{mangled_name}.h")
 
     interface_c_create = tvm._ffi.get_global_func("runtime.InterfaceCCreate")
-    interface_c_module = interface_c_create(module_name, inputs, outputs, devices)
+    interface_c_module = interface_c_create(module_name, inputs, outputs, devices, workspace_size)
 
     with open(metadata_header, "w") as header_file:
         header_file.write(interface_c_module.get_source())
@@ -319,7 +321,10 @@ def _export_graph_model_library_format(
         include_path.mkdir()
         inputs, outputs = _get_inputs_and_outputs_from_module(mod)
         devices = mod.get_devices()
-        generate_c_interface_header(mod.libmod_name, inputs, outputs, devices, include_path)
+        workspace_size = str(metadata["memory"]["functions"]["main"][0]["workspace_size_bytes"])
+        generate_c_interface_header(
+            mod.libmod_name, inputs, outputs, devices, workspace_size, include_path
+        )
 
     parameters_dir = tempdir / "parameters"
     parameters_dir.mkdir()

--- a/src/target/source/interface_c.cc
+++ b/src/target/source/interface_c.cc
@@ -41,8 +41,12 @@ using namespace tvm::relay::backend;
 class InterfaceCNode : public runtime::ModuleNode {
  public:
   InterfaceCNode(std::string module_name, Array<String> inputs, Array<String> outputs,
-                 Array<String> devices)
-      : module_name_(module_name), inputs_(inputs), outputs_(outputs), devices_(devices) {}
+                 Array<String> devices, std::string workspace_size)
+      : module_name_(module_name),
+        inputs_(inputs),
+        outputs_(outputs),
+        devices_(devices),
+        workspace_size_(workspace_size) {}
   const char* type_key() const { return "h"; }
 
   std::string GetSource(const std::string& format) final {
@@ -60,6 +64,7 @@ class InterfaceCNode : public runtime::ModuleNode {
     }
 
     EmitRunFunction(code);
+    EmitWorkspaceSize(code);
     EmitLowerHeaderGuard(code);
 
     return code.str();
@@ -140,15 +145,26 @@ class InterfaceCNode : public runtime::ModuleNode {
     code_stream << ");\n";
   }
 
+  void EmitWorkspaceSize(std::stringstream& code_stream) {
+    std::string workspace_size_name =
+        ToCConstantStyle(PrefixGeneratedName({module_name_, "WORKSPACE_SIZE"}));
+    code_stream << "/*!\n"
+                << " * \\brief Workspace size \n"
+                << " */\n"
+                << "#define " << workspace_size_name << " " << workspace_size_ << "\n";
+  }
+
   std::string module_name_;
   Array<String> inputs_;
   Array<String> outputs_;
   Array<String> devices_;
+  std::string workspace_size_;
 };
 
 runtime::Module InterfaceCCreate(std::string module_name, Array<String> inputs,
-                                 Array<String> outputs, Array<String> devices) {
-  auto n = make_object<InterfaceCNode>(module_name, inputs, outputs, devices);
+                                 Array<String> outputs, Array<String> devices,
+                                 std::string workspace_size) {
+  auto n = make_object<InterfaceCNode>(module_name, inputs, outputs, devices, workspace_size);
   return runtime::Module(n);
 }
 

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -651,7 +651,17 @@ def run_and_check(
         t.extractall(base_path)
 
         workspace_bytes += model.extra_memory_in_bytes
-        workspace_bytes += mlf_extract_workspace_size_bytes(tar_file)
+        mlf_workspace_size = mlf_extract_workspace_size_bytes(tar_file)
+        workspace_bytes += mlf_workspace_size
+
+        if interface_api == "c":
+            header_path = os.path.join(base_path, f"codegen/host/include/tvmgen_{model.name}.h")
+            with open(header_path, "r") as header_file:
+                header_contents = header_file.read()
+                assert (
+                    f"#define TVMGEN_{model.name.upper()}_WORKSPACE_SIZE {mlf_workspace_size}"
+                    in header_contents
+                )
 
         for key in model.inputs:
             sanitized_tensor_name = re.sub(r"\W", "_", key)


### PR DESCRIPTION
This PR exposes the workspace size as a macro `TVMGEN_DEFAULT_WORKSPACE_SIZE` in `tvmgen_default.h` (or `TVMGEN_<MODEL_NAME>_WORKSPACE_SIZE` in `tvmgen_<model_name>.h` in the case that the model name is not `default`).
This functionality is useful for microTVM/AOT use cases where it's useful to know the workspace size at compile time.

@manupa-arm @Mousius @areusch 
