### PR TITLE
[Onnx] [EZ] Fix reshape bug with passing both scale and size

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2639,8 +2639,12 @@ class Resize(OnnxOpConverter):
     def _impl_v13(cls, inputs, attr, params):
         scale = inputs[2]
         size = inputs[3]
+        scale_type = infer_type(scale)
+
         if size is not None:
-            assert scale is None, "One of scale or size should be passed, not both."
+            scale_shape = scale_type.checked_type.shape
+            is_empty = scale is None or len(scale_shape) == 0 or scale_shape[0] == 0
+            assert is_empty, "One of scale or size should be passed, not both."
         else:
             scale_type = infer_type(scale)
             scale_shape = scale_type.checked_type.shape

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2643,7 +2643,7 @@ class Resize(OnnxOpConverter):
 
         if size is not None:
             scale_shape = scale_type.checked_type.shape
-            is_empty = scale is None or len(scale_shape) == 0 or scale_shape[0] == 0
+            is_empty = scale is None or not scale_shape or scale_shape[0] == 0
             assert is_empty, "One of scale or size should be passed, not both."
         else:
             scale_type = infer_type(scale)


### PR DESCRIPTION
Resize can either take a scale or size parameter describing how the resize operation can be performed. Both cannot be given and we throw an error if they are. However, we assume if size is present then scale is none. This is not exhaustive as sometimes it seems that an empty sequence is also sufficient for this.

See the previous opset implementations for Resize to see this case.