### PR TITLE
[PROFILER,VM] Fix timer device type for reshape_tensor

### DIFF
--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -107,7 +107,7 @@ void VirtualMachineDebug::OpStartHook(Instruction instr) {
       Device dst_dev = GetDevice(instr.device_copy.dst_device_index);
       prof_.operator*().StartCall("VM::DeviceCopy", dst_dev, {});
     } else if (instr.op == Opcode::ReshapeTensor) {
-      prof_.operator*().StartCall("VM::ReshapeTensor", devices_[1], {});
+      prof_.operator*().StartCall("VM::ReshapeTensor", devices_[exec_->host_device_index], {});
     } else if (instr.op == Opcode::AllocTensor) {
       auto shape = std::vector<int64_t>(instr.alloc_tensor.ndim);
 

--- a/tests/python/unittest/test_runtime_vm_profiler.py
+++ b/tests/python/unittest/test_runtime_vm_profiler.py
@@ -37,6 +37,7 @@ def test_basic(dev, target):
     res = vm.profile(tvm.nd.array(data), func_name="main")
     assert "softmax" in str(res)
 
+
 def test_vm_reshape_and_copy():
     target = "llvm"
     dev = tvm.gpu()

--- a/tests/python/unittest/test_runtime_vm_profiler.py
+++ b/tests/python/unittest/test_runtime_vm_profiler.py
@@ -37,6 +37,20 @@ def test_basic(dev, target):
     res = vm.profile(tvm.nd.array(data), func_name="main")
     assert "softmax" in str(res)
 
+def test_vm_reshape_and_copy():
+    target = "llvm"
+    dev = tvm.gpu()
+    x_np = np.random.uniform(size=(8, 16)).astype("float32")
+    x = relay.var("x", shape=(8, 16), dtype="float32")
+    y = relay.reshape(x, [-1, 4, 8])
+    mod = tvm.IRModule()
+    mod["main"] = relay.Function([x], y)
+    with tvm.transform.PassContext(opt_level=3):
+        exec = relay.vm.compile(mod, "llvm")
+    assert "reshape_tensor" in exec.bytecode
+    vm = profiler_vm.VirtualMachineProfiler(exec, dev)
+    vm.profile(tvm.nd.array(x_np))
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
The index of the host device was changed in the VM's `devices_` array, but we forgot to update this index in the profiler.

@mbrookhart @mbs-octoml 