### PR TITLE
[ETHOSN] Avoid duplicate specification of tvmc targets

### DIFF
--- a/docs/how_to/deploy/arm_compute_lib.rst
+++ b/docs/how_to/deploy/arm_compute_lib.rst
@@ -120,7 +120,7 @@ Annotate and partition the graph for ACL.
 .. code:: python
 
     from tvm.relay.op.contrib.arm_compute_lib import partition_for_arm_compute_lib
-    module = partition_for_arm_compute_lib(module)
+    module, _ = partition_for_arm_compute_lib(module)
 
 
 Build the Relay graph.

--- a/docs/how_to/deploy/bnns.rst
+++ b/docs/how_to/deploy/bnns.rst
@@ -69,7 +69,7 @@ For your convenience "partition_for_bnns" can do this for you if params dictiona
 .. code:: python
 
     from tvm.relay.op.contrib.bnns import partition_for_bnns
-    model = partition_for_bnns(model, params=params)
+    model, config = partition_for_bnns(model, params=params)
 
 
 Input data layout for operations to be offloaded to BNNS execution
@@ -128,7 +128,7 @@ After that you need to compile new module with target corresponding to required 
     # target for macOS Big Sur 11.1:
     target = "llvm -mtriple=x86_64-apple-darwin20.2.0"
 
-    model = partition_for_bnns(model, params=params)  # to markup operations to be offloaded to BNNS
+    model, _ = partition_for_bnns(model, params=params)  # to markup operations to be offloaded to BNNS
     with tvm.transform.PassContext(opt_level=3):
         lib = relay.build(model, target=target, params=params)
 

--- a/docs/how_to/deploy/vitis_ai.rst
+++ b/docs/how_to/deploy/vitis_ai.rst
@@ -299,7 +299,7 @@ After importing the model, we utilize the Relay API to annotate the Relay expres
 
 .. code:: python
 
-    mod = partition_for_vitis_ai(mod, params, dpu=dpu_target)
+    mod, config = partition_for_vitis_ai(mod, params, dpu=dpu_target)
 
 
 **Build the Model**   

--- a/python/tvm/relay/op/contrib/arm_compute_lib.py
+++ b/python/tvm/relay/op/contrib/arm_compute_lib.py
@@ -55,7 +55,10 @@ def partition_for_arm_compute_lib(mod, params=None, **opts):
 
     Returns
     -------
-    ret : annotated and partitioned module.
+    mod : Module
+        Annotated and partitioned module
+    config : dict
+        Configuration which should be given to PassContext when building
     """
     if params:
         mod["main"] = bind_params_by_name(mod["main"], params)
@@ -69,7 +72,7 @@ def partition_for_arm_compute_lib(mod, params=None, **opts):
         ]
     )
 
-    return seq(mod)
+    return seq(mod), None
 
 
 @register_func("relay.ext.arm_compute_lib.optimize")

--- a/python/tvm/relay/op/contrib/bnns.py
+++ b/python/tvm/relay/op/contrib/bnns.py
@@ -45,7 +45,10 @@ def partition_for_bnns(mod, params=None):
 
     Returns
     -------
-    ret : annotated and partitioned module.
+    mod : Module
+        Annotated and partitioned module
+    config : dict
+        Configuration which should be given to PassContext when building
     """
     if params:
         mod["main"] = bind_params_by_name(mod["main"], params)
@@ -70,7 +73,7 @@ def partition_for_bnns(mod, params=None):
         ]
     )
 
-    return seq(mod)
+    return seq(mod), None
 
 
 def _register_external_op_helper(op_name, supported=True):

--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -44,8 +44,10 @@ def partition_for_cmsisnn(mod, params=None, **opts):
 
     Returns
     -------
-    ret : Module
-        annotated and partitioned module.
+    mod : Module
+        Annotated and partitioned module
+    config : dict
+        Configuration which should be given to PassContext when building
     """
     if params:
         mod["main"] = bind_params_by_name(mod["main"], params)
@@ -62,7 +64,8 @@ def partition_for_cmsisnn(mod, params=None, **opts):
             transform.InferType(),
         ]
     )
-    return seq(mod)
+
+    return seq(mod), None
 
 
 @register_pattern_table("cmsis-nn")

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -299,4 +299,4 @@ def partition_for_cutlass(mod, params=None):
         ]
     )
 
-    return seq(mod)
+    return seq(mod, None)

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -214,4 +214,4 @@ def partition_for_dnnl(mod, params=None):
     )
     with tvm.transform.PassContext(opt_level=3):
         mod = seq(mod)
-    return mod
+    return mod, None

--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -59,7 +59,10 @@ def partition_for_ethosn77(mod, params=None, **opts):
 
     Returns
     -------
-    ret : annotated and partitioned module.
+    mod : Module
+        Annotated and partitioned module
+    config : dict
+        Configuration which should be given to PassContext when building
     """
     if opts:
         tops = opts.get("tops", None)
@@ -83,7 +86,7 @@ def partition_for_ethosn77(mod, params=None, **opts):
         ]
     )
 
-    return seq(mod)
+    return seq(mod), None
 
 
 def partition_for_ethosn78(mod, params=None, **opts):
@@ -99,10 +102,13 @@ def partition_for_ethosn78(mod, params=None, **opts):
 
     Returns
     -------
-    ret : annotated and partitioned module.
+    mod : Module
+        Annotated and partitioned module
+    config : dict
+        Configuration which should be given to PassContext when building
     """
-    if not opts or opts.get("variant", "").lower() != "ethos-n78":
-        raise ValueError("When targeting Ethos(TM)-N78, -variant=Ethos-N78 should be set.")
+    config = opts or {}
+    config["variant"] = "Ethos-N78"
 
     if params:
         mod["main"] = bind_params_by_name(mod["main"], params)
@@ -117,7 +123,7 @@ def partition_for_ethosn78(mod, params=None, **opts):
         ]
     )
 
-    return seq(mod)
+    return seq(mod), config
 
 
 @register_pattern_table("ethos-n")

--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -1675,6 +1675,8 @@ def partition_for_ethosu(
     -------
     mod : IRModule
         The partitioned IRModule with external global functions
+    config : dict
+        Configuration which should be given to PassContext when building
     """
     from tvm.relay.backend.contrib.ethosu import preprocess
 
@@ -1690,4 +1692,4 @@ def partition_for_ethosu(
     mod = relay.transform.PartitionGraph()(mod)
     mod = relay.transform.InferType()(mod)
     mod = preprocess.preprocess_ext_io()(mod)
-    return mod
+    return mod, None

--- a/python/tvm/relay/op/contrib/vitis_ai.py
+++ b/python/tvm/relay/op/contrib/vitis_ai.py
@@ -153,7 +153,10 @@ def partition_for_vitis_ai(mod, params=None, dpu=None, **opts):
 
     Returns
     -------
-    ret : Module
+    mod : Module
+        Annotated and partitioned module
+    config : dict
+        Configuration which should be given to PassContext when building
     """
 
     if dpu is None:
@@ -188,4 +191,4 @@ def partition_for_vitis_ai(mod, params=None, dpu=None, **opts):
     )
 
     with tvm.transform.PassContext(opt_level=3):
-        return seq(mod)
+        return seq(mod), None

--- a/tests/python/contrib/test_arm_compute_lib/infrastructure.py
+++ b/tests/python/contrib/test_arm_compute_lib/infrastructure.py
@@ -169,7 +169,7 @@ def build_module(mod, target, params=None, enable_acl=True, tvm_ops=0, acl_parti
         mod = tvm.IRModule.from_expr(mod)
     with tvm.transform.PassContext(opt_level=3, disabled_pass=["AlterOpLayout"]):
         if enable_acl:
-            mod = arm_compute_lib.partition_for_arm_compute_lib(mod, params)
+            mod, _ = arm_compute_lib.partition_for_arm_compute_lib(mod, params)
             tvm_op_count = get_cpu_op_count(mod)
             assert tvm_op_count == tvm_ops, "Got {} TVM operators, expected {}".format(
                 tvm_op_count, tvm_ops

--- a/tests/python/contrib/test_bnns/infrastructure.py
+++ b/tests/python/contrib/test_bnns/infrastructure.py
@@ -141,7 +141,7 @@ def build_module(mod, target, params=None, enable_bnns=True, tvm_ops=0):
         mod = tvm.IRModule.from_expr(mod)
     with tvm.transform.PassContext(opt_level=3):
         if enable_bnns:
-            mod = partition_for_bnns(mod)
+            mod, _ = partition_for_bnns(mod)
         relay.backend.te_compiler.get().clear()
         return relay.build(mod, target=target, params=params)
 

--- a/tests/python/contrib/test_bnns/test_conv2d_patterns.py
+++ b/tests/python/contrib/test_bnns/test_conv2d_patterns.py
@@ -29,7 +29,7 @@ def partition(exp):
     """Apply BNNS specific partitioning transformation"""
     mod = tvm.IRModule.from_expr(exp)
     with tvm.transform.PassContext(opt_level=3):
-        mod = partition_for_bnns(mod)
+        mod, _ = partition_for_bnns(mod)
     return mod
 
 

--- a/tests/python/contrib/test_bnns/test_onnx_topologies.py
+++ b/tests/python/contrib/test_bnns/test_onnx_topologies.py
@@ -108,7 +108,7 @@ def process(model_name):
             if simplify:
                 mod = simplify_model(mod)
             if with_bnns:
-                mod = partition_for_bnns(mod)
+                mod, _ = partition_for_bnns(mod)
             graph_module = relay.build(mod, target=target, params=params)
 
         lib_name = "deploy.tar"

--- a/tests/python/contrib/test_cmsisnn/test_binary_ops.py
+++ b/tests/python/contrib/test_cmsisnn/test_binary_ops.py
@@ -116,7 +116,7 @@ def test_op_int8(op, input_0_scale, input_0_zero_point, input_1_scale, input_1_z
     )
     orig_mod = make_module(model)
 
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -264,7 +264,7 @@ def test_invalid_parameters(
     )
 
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod)
     assert_no_external_function(cmsisnn_mod)
 
 

--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -190,7 +190,7 @@ def test_conv2d_symmetric_padding_int8(
         relu_type,
     )
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -280,7 +280,7 @@ def test_conv2d_asymmetric_padding_int8(
         relu_type,
     )
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -385,7 +385,7 @@ def test_depthwise_int8(
         relu_type,
     )
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -473,7 +473,7 @@ def test_invalid_parameters(
         relu_type="NONE",
     )
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
     assert_no_external_function(cmsisnn_mod)
 
 

--- a/tests/python/contrib/test_cmsisnn/test_fully_connected.py
+++ b/tests/python/contrib/test_cmsisnn/test_fully_connected.py
@@ -151,7 +151,7 @@ def test_op_int8(
         enable_bias,
     )
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -232,7 +232,7 @@ def test_invalid_parameters(
         enable_bias=True,
     )
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
 
     # validate pattern matching
     assert_no_external_function(cmsisnn_mod)

--- a/tests/python/contrib/test_cmsisnn/test_generate_constants.py
+++ b/tests/python/contrib/test_cmsisnn/test_generate_constants.py
@@ -212,7 +212,7 @@ def test_op_int8(
     )
     mod = make_module(model)
 
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(mod, params)
     multiplier_array = []
     shift_array = []
     for i in range(out_channels):

--- a/tests/python/contrib/test_cmsisnn/test_networks.py
+++ b/tests/python/contrib/test_cmsisnn/test_networks.py
@@ -94,7 +94,7 @@ def test_cnn_small():
     input_data = rng.integers(in_min, high=in_max, size=input_shape, dtype=dtype)
 
     orig_mod, params = convert_to_relay(tflite_model_buf, input_data, "input")
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod, params)
 
     # validate CMSIS-NN output against CPU output
     interface_api = "c"

--- a/tests/python/contrib/test_cmsisnn/test_pooling.py
+++ b/tests/python/contrib/test_cmsisnn/test_pooling.py
@@ -104,7 +104,7 @@ def test_op_int8(
     )
     orig_mod = make_module(model)
 
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -145,7 +145,7 @@ def test_invalid_parameters():
     )
 
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod)
     assert_no_external_function(cmsisnn_mod)
 
 

--- a/tests/python/contrib/test_cmsisnn/test_softmax.py
+++ b/tests/python/contrib/test_cmsisnn/test_softmax.py
@@ -75,7 +75,7 @@ def test_op_int8(zero_point, scale):
     model = make_model(shape, dtype, dtype, zero_point, scale)
     orig_mod = make_module(model)
 
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod)
 
     # validate pattern matching
     assert_partitioned_function(orig_mod, cmsisnn_mod)
@@ -128,7 +128,7 @@ def test_invalid_parameters(in_dtype, out_dtype, zero_point, scale, out_zero_poi
     )
 
     orig_mod = make_module(model)
-    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+    cmsisnn_mod, _ = cmsisnn.partition_for_cmsisnn(orig_mod)
     assert_no_external_function(cmsisnn_mod)
 
 

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -262,7 +262,7 @@ def profile_and_build(
     use_fast_math=False,
     use_3xtf32=True,
 ):
-    mod = partition_for_cutlass(mod)
+    mod, _ = partition_for_cutlass(mod)
     mod, num_cutlass_partition = tune_cutlass_kernels(
         mod,
         sm,
@@ -292,7 +292,7 @@ def profile_and_build_vm(
     use_fast_math=False,
     use_3xtf32=True,
 ):
-    mod = partition_for_cutlass(mod)
+    mod, _ = partition_for_cutlass(mod)
     mod, num_cutlass_partition = tune_cutlass_kernels(
         mod,
         sm,

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -64,7 +64,7 @@ def run_and_verify(mod, input, params, target, run_module):
         for use_dnnl in [False, True]:
             result_key = mode + ("_dnnl" if use_dnnl else "")
             if use_dnnl:
-                mod = dnnl.partition_for_dnnl(mod, params)
+                mod, _ = dnnl.partition_for_dnnl(mod, params)
             with tvm.transform.PassContext(opt_level=3):
                 func = relay.create_executor(mode, mod=mod, device=dev, target=target).evaluate()
             if run_module:
@@ -228,7 +228,7 @@ def test_dnnl_not_compatible(run_module, target="llvm", dtype="float32"):
     f = relay.Function([x], out)
     mod = tvm.IRModule()
     mod["main"] = f
-    mod = dnnl.partition_for_dnnl(mod)
+    mod, _ = dnnl.partition_for_dnnl(mod)
     for mode in ["graph", "vm"]:
         with tvm.transform.PassContext(opt_level=3):
             func = relay.create_executor(mode, mod=mod, device=tvm.cpu(0), target=target).evaluate()

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -119,7 +119,7 @@ def test_ethosu_conv2d_single(
         shape_dict={"input": ifm_shape},
         dtype_dict={"input": dtype},
     )
-    mod = partition_for_ethosu(relay_module, params)
+    mod, _ = partition_for_ethosu(relay_module, params)
 
     # Generate reference data
     input_data, output_data = infra.generate_ref_data_tflite(tflite_graph)
@@ -219,7 +219,7 @@ def test_ethosu_conv2d_double(
         shape_dict={"input": ifm_shape},
         dtype_dict={"input": dtype},
     )
-    mod = partition_for_ethosu(relay_module, params)
+    mod, _ = partition_for_ethosu(relay_module, params)
 
     # Generate reference data
     input_data, output_data = infra.generate_ref_data_tflite(tflite_graph)
@@ -348,7 +348,7 @@ def _get_tflite_graph(tf_func, shapes, ranges=None):
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_graph, 0)
 
     relay_module, params = relay.frontend.from_tflite(tflite_model)
-    mod = partition_for_ethosu(relay_module, params)
+    mod, _ = partition_for_ethosu(relay_module, params)
     return mod, tflite_graph
 
 
@@ -607,7 +607,7 @@ def test_mean(accel_type, ifm_shape, axis, keep_dims, use_same_quantization):
     mod, input_data, output_data = (
         create_mod_from_relay() if use_same_quantization else create_mod_from_tflite()
     )
-    mod = partition_for_ethosu(mod)
+    mod, _ = partition_for_ethosu(mod)
 
     # TODO(lhutton1) For now output is not bit exact with TFLite.
     # This is because TFLite reference kernels are not being used.
@@ -649,7 +649,7 @@ def test_elementwise_add_from_constant_scalar(accel_type, dtype, constant):
         return tvm.IRModule.from_expr(relay.Function(relay.analysis.free_vars(add), add))
 
     cpu_mod = create_relay_graph()
-    ethosu_mod = partition_for_ethosu(cpu_mod)
+    ethosu_mod, _ = partition_for_ethosu(cpu_mod)
 
     # Generate reference data
     input_data = {
@@ -695,7 +695,7 @@ def test_ethosu_left_shift_binary_elemwise(
         "ifm2": np.random.randint(0, high=32, size=ifm2_shape, dtype=dtype),
     }
     output_data = generate_ref_data(cpu_mod, input_data)
-    ethosu_mod = partition_for_ethosu(cpu_mod)
+    ethosu_mod, _ = partition_for_ethosu(cpu_mod)
 
     _compare_ethosu_with_reference(
         ethosu_mod, input_data, output_data, accel_type, output_tolerance=0
@@ -1010,7 +1010,7 @@ def test_ethosu_requantize(accel_type, ifm_shape, ifm_scale, ifm_zp, ofm_scale, 
     cpu_mod = create_model()
     input_data = {"ifm": np.random.randint(-128, high=127, size=ifm_shape, dtype=dtype)}
     output_data = generate_ref_data(cpu_mod, input_data)
-    ethosu_mod = partition_for_ethosu(cpu_mod)
+    ethosu_mod, _ = partition_for_ethosu(cpu_mod)
 
     _compare_ethosu_with_reference(ethosu_mod, input_data, output_data, accel_type)
 

--- a/tests/python/contrib/test_ethosu/test_layout_optimizer.py
+++ b/tests/python/contrib/test_ethosu/test_layout_optimizer.py
@@ -70,7 +70,7 @@ def _compile_and_compare_model(tflite_graph, ifm_shape, dtype):
             "ifm": dtype,
         },
     )
-    mod = partition_for_ethosu(mod, params)
+    mod, _ = partition_for_ethosu(mod, params)
 
     # Generate reference data
     input_data, output_data = infra.generate_ref_data_tflite(tflite_graph)
@@ -720,7 +720,7 @@ def test_layout_optimizer_runs_in_compilation_pipeline():
         return tvm.IRModule.from_expr(func)
 
     mod = get_graph()
-    mod = partition_for_ethosu(mod)
+    mod, _ = partition_for_ethosu(mod)
 
     external_gv_name = mod["main"].body.op.name_hint
     external_func = mod[external_gv_name]

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -1073,7 +1073,7 @@ def test_tflite_tanh_legalize():
         dtype_dict={"input": dtype},
     )
 
-    mod = ethosu.partition_for_ethosu(mod, params)
+    mod, _ = ethosu.partition_for_ethosu(mod, params)
     mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
         legalize.TanhRewriter(), mod["tvmgen_default_ethos_u_main_0"]
     )
@@ -1364,7 +1364,7 @@ def test_tflite_sigmoid_legalize():
         dtype_dict={"input": dtype},
     )
 
-    mod = ethosu.partition_for_ethosu(mod, params)
+    mod, _ = ethosu.partition_for_ethosu(mod, params)
     mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
         legalize.SigmoidRewriter(), mod["tvmgen_default_ethos_u_main_0"]
     )
@@ -1440,7 +1440,7 @@ def test_tflite_split_legalize(ifm_shape, num_or_size_splits, axis):
         shape_dict={"input": ifm_shape},
         dtype_dict={"input": dtype},
     )
-    mod = ethosu.partition_for_ethosu(mod)
+    mod, _ = ethosu.partition_for_ethosu(mod)
 
     mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
         legalize.PartitionedSplitRewriter(), mod["tvmgen_default_ethos_u_main_0"]
@@ -1522,7 +1522,7 @@ def test_tflite_split_v_legalize(ifm_shape, num_or_size_splits, axis):
         shape_dict={"input": ifm_shape},
         dtype_dict={"input": dtype},
     )
-    mod = ethosu.partition_for_ethosu(mod)
+    mod, _ = ethosu.partition_for_ethosu(mod)
 
     mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
         legalize.PartitionedSplitRewriter(), mod["tvmgen_default_ethos_u_main_0"]
@@ -1629,7 +1629,7 @@ def test_multiple_requantize_offload():
         assert isinstance(op, relay.Var)
 
     mod = create_model()
-    mod = ethosu.partition_for_ethosu(mod)
+    mod, _ = ethosu.partition_for_ethosu(mod)
     mod = legalize.LegalizeEthosU()(mod)
     verify(mod["tvmgen_default_ethos_u_main_0"])
 

--- a/tests/python/contrib/test_ethosu/test_legalize_no_ops.py
+++ b/tests/python/contrib/test_ethosu/test_legalize_no_ops.py
@@ -101,7 +101,7 @@ def test_tflite_reshape_and_strided_slice():
         dtype_dict={"input": dtype},
     )
     mod["main"] = bind_params_by_name(mod["main"], params)
-    mod = ethosu.partition_for_ethosu(mod)
+    mod, _ = ethosu.partition_for_ethosu(mod)
     mod = legalize.LegalizeEthosU()(mod)
 
     verify(mod["tvmgen_default_ethos_u_main_0"])

--- a/tests/python/contrib/test_ethosu/test_lookup_table.py
+++ b/tests/python/contrib/test_ethosu/test_lookup_table.py
@@ -91,7 +91,7 @@ def test_tflite_lut_activations(accel_type):
         shape_dict={"input": ifm_shape},
         dtype_dict={"input": dtype},
     )
-    mod = partition_for_ethosu(relay_module, params)
+    mod, _ = partition_for_ethosu(relay_module, params)
 
     # Generate reference data
     input_data, output_data = infra.generate_ref_data_tflite(tflite_graph)

--- a/tests/python/contrib/test_ethosu/test_lut_optimizer.py
+++ b/tests/python/contrib/test_ethosu/test_lut_optimizer.py
@@ -118,7 +118,7 @@ def test_lut_optimizer_runs_in_compilation_pipeline():
         return tf.nn.tanh(op)
 
     mod, _ = _get_tflite_graph(get_graph, [ifm_shape])
-    mod = partition_for_ethosu(mod)
+    mod, _ = partition_for_ethosu(mod)
 
     external_gv_name = mod["main"].body.op.name_hint
     external_func = mod[external_gv_name]

--- a/tests/python/contrib/test_ethosu/test_networks.py
+++ b/tests/python/contrib/test_ethosu/test_networks.py
@@ -58,7 +58,7 @@ def test_forward_mobilenet_v1(accel_type):
     input_data = {input_tensor: input_data}
     output_data = generate_ref_data(relay_mod, input_data)
 
-    mod = partition_for_ethosu(relay_mod, params)
+    mod, _ = partition_for_ethosu(relay_mod, params)
     compiled_models = infra.build_source(
         mod, input_data, output_data, accel_type, output_tolerance=10
     )

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -1315,7 +1315,7 @@ def test_dynamic_offload():
     mod = tvm.IRModule()
     mod["main"] = f
     mod = relay.transform.InferType()(mod)
-    mod_trt, config = tensorrt.partition_for_tensorrt(mod, params={})
+    mod_trt, _ = tensorrt.partition_for_tensorrt(mod, params={})
 
     # Get the expected relay graph and compare
     mod_exp = get_expected()
@@ -1403,7 +1403,7 @@ def test_maskrcnn_resnet50(run_module) -> None:
         input_name = "input0"
         shape_list = [(input_name, input_shape)]
         mod, params = relay.frontend.from_pytorch(traced_module, shape_list)
-        mod, config = tensorrt.partition_for_tensorrt(mod, params, remove_no_mac_subgraphs=True)
+        mod, _ = tensorrt.partition_for_tensorrt(mod, params, remove_no_mac_subgraphs=True)
         with tvm.transform.PassContext(opt_level=3, disabled_pass=["FoldScaleAxis"]):
             vm_trt_exec = relay.vm.compile(mod, target=target, params=params)
 

--- a/tests/python/contrib/test_vitis_ai/infrastructure.py
+++ b/tests/python/contrib/test_vitis_ai/infrastructure.py
@@ -84,7 +84,7 @@ def build_module(
         opt_level=3, config={"relay.ext.vitis_ai.options.target": dpu_target}
     ):
         if enable_vitis_ai:
-            mod = partition_for_vitis_ai(mod, params, dpu_target)
+            mod, _ = partition_for_vitis_ai(mod, params, dpu_target)
             tvm_op_count = get_cpu_op_count(mod)
             assert tvm_op_count == tvm_ops, "Got {} TVM operators, expected {}".format(
                 tvm_op_count, tvm_ops

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -430,14 +430,13 @@ def test_compile_tflite_module_with_external_codegen_cmsisnn(
 def test_compile_tflite_module_with_external_codegen_ethos_n78(tflite_mobilenet_v1_1_quant):
     pytest.importorskip("tflite")
     tvmc_model = tvmc.load(tflite_mobilenet_v1_1_quant)
-    tvmc_package = tvmc.compile(
-        tvmc_model, target="ethos-n78 -variant=ethos-n78, llvm", dump_code="relay"
-    )
+    tvmc_package = tvmc.compile(tvmc_model, target="ethos-n78, llvm", dump_code="relay")
     dumps_path = tvmc_package.package_path + ".relay"
 
     # check for output types
     assert type(tvmc_package) is TVMCPackage
     assert type(tvmc_package.graph) is str
+    assert tvmc_package.graph.find("_ethos_n_")
     assert type(tvmc_package.lib_path) is str
     assert type(tvmc_package.params) is bytearray
     assert os.path.exists(dumps_path)
@@ -515,7 +514,7 @@ def test_compile_tflite_module_with_external_codegen_ethosu(
 def test_compile_check_configs_composite_target(mock_pkg, mock_pc, mock_fe, mock_ct, mock_relay):
     mock_codegen = {}
     mock_codegen["config_key"] = "relay.ext.mock.options"
-    mock_codegen["pass_pipeline"] = lambda *args, **kwargs: None
+    mock_codegen["pass_pipeline"] = lambda *args, **kwargs: (None, None)
 
     mock_fe.return_value = mock.MagicMock()
     mock_ct.return_value = mock_codegen

--- a/tests/python/driver/tvmc/test_target.py
+++ b/tests/python/driver/tvmc/test_target.py
@@ -36,9 +36,9 @@ def test_target_from_cli__error_target_not_found():
         _ = target_from_cli("invalidtarget")
 
 
-def test_target_from_cli__error_no_tvm_target():
+def test_target_from_cli__error_no_tvm_target_ethos_n78():
     with pytest.raises(TVMCException):
-        _ = target_from_cli("ethos-n77")
+        _ = target_from_cli("ethos-n78")
 
 
 def test_target_two_tvm_targets():
@@ -156,16 +156,6 @@ def test_parse_quotes_and_separators_on_options():
 
     assert len(targets_double_quote) == 1
     assert "+v1.0x,+value" == targets_double_quote[0]["opts"]["option1"]
-
-
-def test_parse_multiple_target_with_opts_ethos_n77():
-    targets = parse_target("ethos-n77 -myopt=value, llvm -device=arm_cpu --system-lib")
-
-    assert len(targets) == 2
-    assert "ethos-n77" == targets[0]["name"]
-    assert "myopt" in targets[0]["opts"]
-    assert "value" == targets[0]["opts"]["myopt"]
-    assert "llvm" == targets[1]["name"]
 
 
 def test_parse_multiple_target_with_opts_ethos_n78():

--- a/tests/python/relay/aot/test_c_device_api.py
+++ b/tests/python/relay/aot/test_c_device_api.py
@@ -74,7 +74,7 @@ def device_api_main_func():
         shape_dict={"x": [1, 3, 4, 3]},
         dtype_dict={"x": "int8"},
     )
-    mod = partition_for_ethosu(relay_module, params)
+    mod, _ = partition_for_ethosu(relay_module, params)
 
     # Generate reference data
     input_data, output_data = generate_ref_data_tflite(tflite_graph)


### PR DESCRIPTION
Remove the need to specify targets as "Ethos-N -variant=Ethos-N"

Co-authored-by: Tristan O'Connor <tristan.oconnor@arm.com>
