### PR TITLE
Fix compiler warning with clang-13.0

### DIFF
--- a/include/tvm/relay/executor.h
+++ b/include/tvm/relay/executor.h
@@ -159,9 +159,6 @@ class Executor : public ObjectRef {
  */
 class ExecutorRegEntry {
  public:
-  /*! \brief Set name of the Executor to be the same as registry if it is empty */
-  inline ExecutorRegEntry& set_name();
-
   /*!
    * \brief Register a valid configuration option and its ValueType for validation
    * \param key The configuration key
@@ -218,13 +215,6 @@ class ExecutorRegEntry {
   friend class Executor;
 };
 
-inline ExecutorRegEntry& ExecutorRegEntry::set_name() {
-  if (name.empty()) {
-    name = name;
-  }
-  return *this;
-}
-
 template <typename ValueType>
 inline ExecutorRegEntry& ExecutorRegEntry::add_attr_option(const String& key) {
   ICHECK(!key2vtype_.count(key)) << "AttributeError: add_attr_option failed because '" << key
@@ -269,7 +259,7 @@ inline ExecutorRegEntry& ExecutorRegEntry::add_attr_option(const String& key,
  */
 #define TVM_REGISTER_EXECUTOR(ExecutorName)                    \
   TVM_STR_CONCAT(TVM_EXECUTOR_REGISTER_VAR_DEF, __COUNTER__) = \
-      ::tvm::relay::ExecutorRegEntry::RegisterOrGet(ExecutorName).set_name()
+      ::tvm::relay::ExecutorRegEntry::RegisterOrGet(ExecutorName)
 }  // namespace relay
 }  // namespace tvm
 

--- a/include/tvm/relay/runtime.h
+++ b/include/tvm/relay/runtime.h
@@ -159,9 +159,6 @@ class Runtime : public ObjectRef {
  */
 class RuntimeRegEntry {
  public:
-  /*! \brief Set name of the Runtime to be the same as registry if it is empty */
-  inline RuntimeRegEntry& set_name();
-
   /*!
    * \brief Register a valid configuration option and its ValueType for validation
    * \param key The configuration key
@@ -218,13 +215,6 @@ class RuntimeRegEntry {
   friend class Runtime;
 };
 
-inline RuntimeRegEntry& RuntimeRegEntry::set_name() {
-  if (name.empty()) {
-    name = name;
-  }
-  return *this;
-}
-
 template <typename ValueType>
 inline RuntimeRegEntry& RuntimeRegEntry::add_attr_option(const String& key) {
   ICHECK(!key2vtype_.count(key)) << "AttributeError: add_attr_option failed because '" << key
@@ -269,7 +259,7 @@ inline RuntimeRegEntry& RuntimeRegEntry::add_attr_option(const String& key,
  */
 #define TVM_REGISTER_RUNTIME(RuntimeName)                     \
   TVM_STR_CONCAT(TVM_RUNTIME_REGISTER_VAR_DEF, __COUNTER__) = \
-      ::tvm::relay::RuntimeRegEntry::RegisterOrGet(RuntimeName).set_name()
+      ::tvm::relay::RuntimeRegEntry::RegisterOrGet(RuntimeName)
 }  // namespace relay
 }  // namespace tvm
 

--- a/src/relay/backend/contrib/example_target_hooks/tir_to_runtime.cc
+++ b/src/relay/backend/contrib/example_target_hooks/tir_to_runtime.cc
@@ -30,6 +30,8 @@ using namespace tir;
 
 class CodeGenExampleTargetHook : public codegen::CodeGenCHost {
  public:
+  using codegen::CodeGenCHost::VisitExpr_;
+
   /*!
    * \brief Emit code that changes adds to multiplies for testing
    */


### PR DESCRIPTION
Fix clang warning  `CodeGenExampleTargetHook::VisitExpr_' hides overloaded virtual functions`
and weird self assignment warning in `set_name` of some registry classes.
