### PR TITLE
[microNPU] Change weights and command stream section

### DIFF
--- a/apps/microtvm/ethosu/corstone300.ld
+++ b/apps/microtvm/ethosu/corstone300.ld
@@ -133,6 +133,16 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+  /* .ddr is placed before .text so that .rodata.tvm is encountered before .rodata* */
+  .ddr :
+  {
+    . = ALIGN(16);
+    *(ethosu_scratch)
+    . = ALIGN (16);
+    *(.rodata.tvm)
+    . = ALIGN (16);
+  } > DDR
+
   .text :
   {
     KEEP(*(.vectors))
@@ -256,14 +266,6 @@ SECTIONS
     . = ALIGN(4);
     __bss_end__ = .;
   } > DTCM AT > DTCM
-
-  .ddr :
-  {
-    . = ALIGN(4);
-    . = ALIGN(16);
-    *(ethosu_scratch)
-    . = ALIGN (16);
-  } > DDR
 
   .data_sram :
   {

--- a/src/relay/backend/contrib/ethosu/source_module.cc
+++ b/src/relay/backend/contrib/ethosu/source_module.cc
@@ -224,17 +224,17 @@ class EthosUModuleNode : public ModuleNode {
     size_t weights_size = (weights_bias_hex.size() / 2);
     ss << "static const size_t weights_size = " << std::to_string(weights_size) << ";\n";
     ss << "static const size_t scratch_size = " << std::to_string(scratch_size) << ";\n";
-    ss << "// Update linker script to place ethosu_scratch in memory that can be accessed by the "
+    ss << "// Update linker script to place .rodata.tvm in memory that can be accessed by the "
           "NPU\n";
     if (weights_size > 0) {
-      ss << "__attribute__((section(\"ethosu_scratch\"), aligned(16))) static int8_t weights["
+      ss << "__attribute__((section(\".rodata.tvm\"), aligned(16))) static int8_t weights["
          << weights_size << "] = \"";
       ss << GetHexString(weights_bias_hex);
       ss << "\";\n";
     } else {
       ss << "static int8_t* weights = NULL;\n";
     }
-    ss << "__attribute__((section(\"ethosu_scratch\"), aligned(16))) static int8_t cms_data_data["
+    ss << "__attribute__((section(\".rodata.tvm\"), aligned(16))) static int8_t cms_data_data["
        << cmms_hex.size() / 2 << "] = \"";
     ss << GetHexString(cmms_hex);
     ss << "\";\n";

--- a/tests/python/relay/aot/corstone300.ld
+++ b/tests/python/relay/aot/corstone300.ld
@@ -133,6 +133,16 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+  /* .ddr is placed before .text so that .rodata.tvm is encountered before .rodata* */
+  .ddr :
+  {
+    . = ALIGN(16);
+    *(ethosu_scratch)
+    . = ALIGN (16);
+    *(.rodata.tvm)
+    . = ALIGN (16);
+  } > DDR
+
   .text :
   {
     KEEP(*(.vectors))
@@ -256,14 +266,6 @@ SECTIONS
     . = ALIGN(4);
     __bss_end__ = .;
   } > DTCM AT > DTCM
-
-  .ddr :
-  {
-    . = ALIGN(4);
-    . = ALIGN(16);
-    *(ethosu_scratch)
-    . = ALIGN (16);
-  } > DDR
 
   .data_sram :
   {


### PR DESCRIPTION
This PR moves the microNPU weights and command stream to a section named `.rodata.tvm`

@manupa-arm @Mousius @areusch 
