### PR TITLE
Section names for TVM generated constants

### DIFF
--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -45,7 +45,7 @@ class CodeGenCHost : public CodeGenC {
   void DefineModuleName();
 
   /*! \brief Add linked parameters, if they are present. */
-  void DeclareParameters(Map<String, LinkedParam> params);
+  void DeclareParameters(Map<String, LinkedParam> params, const Integer& constants_byte_alignment);
   void LinkParameters(Map<String, LinkedParam> params);
 
   void PrintType(DataType t, std::ostream& os) final;  // NOLINT(*)

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -276,6 +276,7 @@ TVM_REGISTER_TARGET_KIND("c", kDLCPU)
     .add_attr_option<String>("march")
     .add_attr_option<String>("executor")
     .add_attr_option<Integer>("workspace-byte-alignment")
+    .add_attr_option<Integer>("constants-byte-alignment")
     .add_attr_option<Bool>("unpacked-api")
     .add_attr_option<String>("interface-api")
     .set_default_keys({"cpu"});

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -590,7 +590,6 @@ def compile_models(
     interface_api: str,
     use_unpacked_api: bool,
     workspace_byte_alignment: int = 8,
-    constants_byte_alignment: int = 16,
     enable_op_fusion: bool = True,
     pass_config: Dict[str, Any] = None,
     use_runtime_executor: bool = True,
@@ -608,7 +607,6 @@ def compile_models(
         "aot",
         {
             "workspace-byte-alignment": workspace_byte_alignment,
-            "constants-byte-alignment": constants_byte_alignment,
             "interface-api": interface_api,
             "unpacked-api": use_unpacked_api,
         },

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -590,6 +590,7 @@ def compile_models(
     interface_api: str,
     use_unpacked_api: bool,
     workspace_byte_alignment: int = 8,
+    constants_byte_alignment: int = 16,
     enable_op_fusion: bool = True,
     pass_config: Dict[str, Any] = None,
     use_runtime_executor: bool = True,
@@ -607,6 +608,7 @@ def compile_models(
         "aot",
         {
             "workspace-byte-alignment": workspace_byte_alignment,
+            "constants-byte-alignment": constants_byte_alignment,
             "interface-api": interface_api,
             "unpacked-api": use_unpacked_api,
         },

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -745,16 +745,12 @@ def test_constants_alignment(constants_byte_alignment):
     data = np.random.uniform(size=data_shape).astype("float32")
     inputs = {"data": data}
     output_list = generate_ref_data(mod, inputs, params)
+    target_opts = {"-constants-byte-alignment": constants_byte_alignment}
     compiled_test_mods = compile_models(
-        AOTTestModel(
-            module=mod,
-            inputs=inputs,
-            outputs=output_list,
-            params=params,
-        ),
+        AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),
         interface_api,
         use_unpacked_api,
-        constants_byte_alignment=constants_byte_alignment,
+        target_opts=target_opts,
     )
     source = compiled_test_mods[0].executor_factory.lib.imported_modules[0].get_source()
     assert f'__attribute__((section(".rodata.tvm"), aligned({constants_byte_alignment})))' in source

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -733,5 +733,32 @@ def test_aot_codegen_backend_alloc_workspace_calls():
     assert source.count("TVMBackendAllocWorkspace") == 3
 
 
+@pytest.mark.parametrize("constants_byte_alignment", [8, 16, 32])
+def test_constants_alignment(constants_byte_alignment):
+    """Test that constants_byte_alignment correctly sets constants byte alignment"""
+
+    use_unpacked_api = True
+    interface_api = "c"
+
+    mod, params = testing.mobilenet.get_workload(batch_size=1)
+    data_shape = [int(x) for x in mod["main"].checked_type.arg_types[0].shape]
+    data = np.random.uniform(size=data_shape).astype("float32")
+    inputs = {"data": data}
+    output_list = generate_ref_data(mod, inputs, params)
+    compiled_test_mods = compile_models(
+        AOTTestModel(
+            module=mod,
+            inputs=inputs,
+            outputs=output_list,
+            params=params,
+        ),
+        interface_api,
+        use_unpacked_api,
+        constants_byte_alignment=constants_byte_alignment,
+    )
+    source = compiled_test_mods[0].executor_factory.lib.imported_modules[0].get_source()
+    assert f'__attribute__((section(".rodata.tvm"), aligned({constants_byte_alignment})))' in source
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -283,7 +283,7 @@ def test_c_link_params():
             c_dtype = _get_c_datatype(dtype)
             src_lines = src.split("\n")
             param = lib.params["p0"].numpy().reshape(np.prod(KERNEL_SHAPE))
-            param_def = f"static const {c_dtype} __tvm_param__p0[{np.prod(param.shape)}] = {{"
+            param_def = f'static const {c_dtype} __attribute__((section(".rodata.tvm"), aligned(16))) __tvm_param__p0[{np.prod(param.shape)}] = {{'
             for i, line in enumerate(src_lines):
                 if line == param_def:
                     i += 1


### PR DESCRIPTION
This PR places the TVM generated static const arrays in a memory section named `.rodata.tvm`.
The arrays default to 16-byte aligned but a `constants-byte-alignment` parameter can be added to the target to set alignment to a specific value.
This allows the linker script to optionally place TVM generated constants in particular memory regions.

@manupa-arm @Mousius @areusch 
