### PR TITLE
[TIR] Allow compute_at create block predicate for non-trivial bounds and support floordiv pattern

### DIFF
--- a/include/tvm/arith/int_set.h
+++ b/include/tvm/arith/int_set.h
@@ -93,6 +93,11 @@ class IntSet : public ObjectRef {
   bool CanProveNonPositive() const;
   /*! \return Whether the set is proved to be larger than or equal to 0 */
   bool CanProveNonNegative() const;
+  /*! \return Whether the set has upper bound. */
+  bool HasUpperBound() const;
+  /*! \return Whether the set has lower bound. */
+  bool HasLowerBound() const;
+
   /*!
    * \brief The single point value, call only if IsSinglePoint is true
    * \return The point value.

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -574,6 +574,20 @@ bool IntSet::CanProveNonNegative() const {
   return false;
 }
 
+bool IntSet::HasLowerBound() const {
+  if (const IntervalSetNode* s_int = (*this).as<IntervalSetNode>()) {
+    return s_int->HasLowerBound();
+  }
+  return false;
+}
+
+bool IntSet::HasUpperBound() const {
+  if (const IntervalSetNode* s_int = (*this).as<IntervalSetNode>()) {
+    return s_int->HasUpperBound();
+  }
+  return false;
+}
+
 SignType IntSet::GetSignType() const {
   if (CanProvePositive()) {
     return kPositive;

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -503,6 +503,7 @@ class IterMapRewriter : public ExprMutator {
       if (predicate_induced_min.defined()) predicate_induced_min = predicate_induced_min - base;
       if (predicate_induced_max.defined()) predicate_induced_max = predicate_induced_max - base;
     }
+    if (expr->args.size() < 1) return expr;
     Optional<IterSumExpr> opt = TryFuseIters(expr);
     ICHECK(!opt.defined() || opt.value()->args.size() == 1);
     // scale should be 1

--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -145,22 +145,10 @@ void BlockReadWriteDetector::VisitExpr_(const LoadNode* op) {
   ExprVisitor::VisitExpr_(op);
 }
 
-arith::IntSet BlockReadWriteDetector::RelaxAccessIndex(const PrimExpr& index) {
-  arith::IntSet relaxed = arith::EvalSet(index, dom_map_);
-  if (!hint_map_.empty()) {
-    // take non-relaxed var bound hints into considerations
-    // eg, if i * 4 + j with i >= 10 and j in [0, 4), only j in domain scope
-    // then the index region can be relaxed to [i*4, i*4+4) ^ [40, inf)
-    arith::IntSet hint_bound = arith::EvalSet(relaxed, hint_map_);
-    relaxed = arith::Intersect({relaxed, hint_bound});
-  }
-  return relaxed;
-}
-
 void BlockReadWriteDetector::VisitExpr_(const BufferLoadNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (const PrimExpr& index : op->indices) {
-    relaxed_region.push_back(RelaxAccessIndex(index));
+    relaxed_region.push_back(arith::EvalSet(index, dom_map_));
   }
   Update(&read_buffers_, &read_regions_, op->buffer, relaxed_region);
   ExprVisitor::VisitExpr_(op);
@@ -213,7 +201,7 @@ void BlockReadWriteDetector::VisitStmt_(const StoreNode* op) {
 void BlockReadWriteDetector::VisitStmt_(const BufferStoreNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (const PrimExpr& index : op->indices) {
-    relaxed_region.push_back(RelaxAccessIndex(index));
+    relaxed_region.push_back(arith::EvalSet(index, dom_map_));
   }
   Update(&writes_buffers_, &write_regions_, op->buffer, relaxed_region);
   StmtVisitor::VisitStmt_(op);

--- a/src/tir/schedule/primitive/compute_at.cc
+++ b/src/tir/schedule/primitive/compute_at.cc
@@ -164,6 +164,49 @@ int FindInsertionPoint(
 }
 
 /*!
+ * \brief Represent the iteration domain to fully cover the required region of Intersect(dom, bound)
+ * The bound region may not get directly intersected with dom region, instead we try to generate
+ * extra predicates for non-trivial bound. The domain info class can also union with each other.
+ */
+struct BlockVarDomainInfo {
+  arith::IntSet dom{arith::IntSet::Nothing()};  // dom is ensured to be bounded
+  arith::IntSet bound{arith::IntSet::Nothing()};
+
+  /*! \brief Relaxed union operation */
+  void Union(const BlockVarDomainInfo& other) {
+    // just relax (d0 ^ b0) v (d1 ^ b1) to (d0 v d1) ^ (b0 v b1)
+    dom = arith::Union({dom, other.dom});
+    bound = arith::Union({bound, other.bound});
+  }
+
+  /*! \brief Simplify domain info */
+  void Simplify(arith::Analyzer* analyzer) {
+    auto to_simplified = [analyzer](const arith::IntSet& set) {
+      PrimExpr min = set.HasLowerBound() ? analyzer->Simplify(set.min()) : set.min();
+      PrimExpr max = set.HasUpperBound() ? analyzer->Simplify(set.max()) : set.max();
+      return arith::IntSet::Interval(min, max);
+    };
+    // if no dom specified, try use bound as dom
+    if (dom.IsNothing()) {
+      if (bound.HasLowerBound() && bound.HasUpperBound()) {
+        bound = to_simplified(bound);
+        std::swap(dom, bound);
+      }
+      return;
+    }
+    // simplify intsets
+    dom = to_simplified(dom);
+    bound = to_simplified(bound);
+    // if can proof the dom is within bound, remove bound
+    auto intersect = to_simplified(arith::Intersect({dom, bound}));
+    if (analyzer->CanProveEqual(dom.min(), intersect.min()) &&
+        analyzer->CanProveEqual(dom.max(), intersect.max())) {
+      bound = arith::IntSet::Nothing();
+    }
+  }
+};
+
+/*!
  * \brief A helper to reconstruct the block scope where the given block is moved under the given
  * loop, and the given block's induced loop nest is regenerated to satisfy the required region.
  */
@@ -179,9 +222,11 @@ class ScopeReconstructor : private StmtMutator {
    * \param insert_position The position among the subtrees where the block and its induced loop
    * nest is inserted
    * \param iter_doms The domain of each block var
+   * \param analyzer The arithmetic analyzer
    * \param preserve_unit_loops Whether to generate unit loops where the loop extent is 1
    */
-  void MakeNewLoop(int insert_position, std::vector<Range> iter_doms, bool preserve_unit_loops) {
+  void MakeNewLoop(int insert_position, std::vector<BlockVarDomainInfo> iter_doms,
+                   arith::Analyzer* analyzer, bool preserve_unit_loops) {
     int n_iters = iter_doms.size();
     Array<Var> loop_vars;
     Array<PrimExpr> loop_extents;
@@ -189,19 +234,30 @@ class ScopeReconstructor : private StmtMutator {
     loop_vars.reserve(n_iters);
     loop_extents.reserve(n_iters);
     iter_values.reserve(n_iters);
+    PrimExpr predicate = const_true();
     for (int i = 0; i < n_iters; ++i) {
-      const Range& iter_dom = iter_doms[i];
-      if (preserve_unit_loops || !is_one(iter_dom->extent)) {
+      Range iter_dom = iter_doms[i].dom.CoverRange(block_->iter_vars[i]->dom);
+      const arith::IntSet& pred_bound = iter_doms[i].bound;
+      if (preserve_unit_loops || !is_one(iter_dom->extent) || !pred_bound.IsNothing()) {
         Var var("ax" + std::to_string(loop_vars.size()), DataType::Int(32));
         loop_vars.push_back(var);
         loop_extents.push_back(iter_dom->extent);
         iter_values.push_back(iter_dom->min + var);
+        analyzer->Bind(var, Range::FromMinExtent(0, iter_dom->extent));
+        if (pred_bound.HasLowerBound()) {
+          PrimExpr lower_bound = iter_dom->min + var >= pred_bound.min();
+          predicate = predicate && lower_bound;
+        }
+        if (pred_bound.HasUpperBound()) {
+          PrimExpr upper_bound = iter_dom->min + var < pred_bound.max() + 1;
+          predicate = predicate && upper_bound;
+        }
       } else {
         iter_values.push_back(iter_dom->min);
       }
     }
     this->new_block_realize_ =
-        BlockRealize(std::move(iter_values), const_true(), std::move(block_));
+        BlockRealize(std::move(iter_values), analyzer->Simplify(predicate), std::move(block_));
     Stmt new_subtree = this->new_block_realize_;
     for (int i = static_cast<int>(loop_vars.size()) - 1; i >= 0; --i) {
       const Var& loop_var = loop_vars[i];
@@ -310,17 +366,16 @@ void RelaxBufferRegions(const Map<Var, PrimExpr>& binding,
  * domain
  * \param provided The provided integer set to cover the required domain
  * \param required The required domain to be covered
- * \param iter_doms The result iteration domains to be updated
  * \param analyzer The arithmetic analyzer
  */
-void UpdateBlockVarDomain(const arith::IntSet& provided, const arith::IntSet& required,
-                          std::unordered_map<const VarNode*, std::vector<arith::IntSet>>* iter_doms,
-                          arith::Analyzer* analyzer) {
+std::pair<Var, arith::IntSet> SolveBlockVarDomain(const arith::IntSet& provided,
+                                                  const arith::IntSet& required,
+                                                  arith::Analyzer* analyzer) {
   PrimExpr provided_min = analyzer->Simplify(provided.min());
-  PrimExpr provided_extent = analyzer->Simplify(provided.max() - provided_min + 1);
+  PrimExpr provided_max = analyzer->Simplify(provided.max());
   PrimExpr required_min = analyzer->Simplify(required.min());
-  PrimExpr required_extent = analyzer->Simplify(required.max() - required_min + 1);
-  PrimExpr dom_min{nullptr}, dom_extent{nullptr};
+  PrimExpr required_max = analyzer->Simplify(required.max());
+  PrimExpr dom_min{nullptr}, dom_max{nullptr};
   Var dom_var{ObjectPtr<VarNode>{nullptr}};
   arith::PVar<Var> p_v;
   arith::PVar<PrimExpr> p_e;
@@ -328,21 +383,57 @@ void UpdateBlockVarDomain(const arith::IntSet& provided, const arith::IntSet& re
     PrimExpr e = p_e.Eval();
     dom_var = p_v.Eval();
     dom_min = floordiv(required_min, e);
-    dom_extent = analyzer->Simplify((required_extent + e - 1) / e);
-  } else if (analyzer->CanProveEqual(provided_extent, 1) && p_v.Match(provided_min)) {
-    dom_var = p_v.Eval();
-    dom_min = required_min;
-    dom_extent = required_extent;
-  } else {
-    ICHECK(false) << "ValueError: BufferRegion pattern match failed";
+    dom_max = floordiv(required_max, e);
+  } else if (analyzer->CanProveEqual(provided_min, provided_max)) {
+    if (p_v.Match(provided_min)) {
+      dom_var = p_v.Eval();
+      dom_min = required_min;
+      dom_max = required_max;
+    } else {
+      arith::PVar<PrimExpr> p_f;
+      if ((floordiv(p_v, p_f)).Match(provided_min)) {
+        // a <= (x // factor) <= b, fac > 0 ==> (a * fac) <= x <= (b * fac + fac - 1)
+        PrimExpr fac = p_f.Eval();
+        if (analyzer->CanProveGreaterEqual(fac, 1)) {
+          dom_var = p_v.Eval();
+          dom_min = required_min * fac;
+          dom_max = analyzer->Simplify(required_max * fac + fac - 1);
+        }
+      } else if ((floormod(p_v, p_f).Match(provided_min))) {
+        // generally domain of (x % fac) enforce no constraints to domain of x
+        dom_var = p_v.Eval();
+        return std::make_pair(dom_var, arith::IntSet::Nothing());
+      }
+    }
   }
-  auto it = iter_doms->find(dom_var.get());
+  ICHECK(dom_var.defined()) << "ValueError: BufferRegion pattern match failed: " << provided_min;
+  return std::make_pair(dom_var, arith::IntSet::Interval(dom_min, dom_max));
+}
+
+/*!
+ * \brief Calculate and update the iteration domain info to fully cover the required domain
+ * \param provided The provided integer set to cover the required domain
+ * \param required The required domain to be covered
+ * \param required_bound The additional region bound of the required domain to be covered
+ * \param iter_doms The result iteration domains to be updated
+ * \param analyzer The arithmetic analyzer
+ */
+void UpdateBlockVarDomain(const arith::IntSet& provided, const arith::IntSet& required,
+                          const arith::IntSet& required_bound,
+                          std::unordered_map<const VarNode*, BlockVarDomainInfo>* iter_doms,
+                          arith::Analyzer* analyzer) {
+  auto var_with_dom = SolveBlockVarDomain(provided, required, analyzer);
+  auto var_with_bound = SolveBlockVarDomain(provided, required_bound, analyzer);
+  const Var& var = var_with_dom.first;
+  const auto& var_dom = var_with_dom.second;
+  const auto& var_bound = var_with_bound.second;
+  ICHECK(var.same_as(var_with_bound.first));
+  auto it = iter_doms->find(var.get());
   if (it != iter_doms->end()) {
-    std::vector<arith::IntSet>& doms = it->second;
-    doms.push_back(arith::IntSet::FromMinExtent(dom_min, dom_extent));
+    it->second.Union({var_dom, var_bound});
   } else {
-    ICHECK(analyzer->CanProveEqual(provided_min, required_min));
-    ICHECK(analyzer->CanProveEqual(provided_extent, required_extent));
+    ICHECK(analyzer->CanProveEqual(provided.min(), required.min()));
+    ICHECK(analyzer->CanProveEqual(provided.max(), required.max()));
   }
 }
 
@@ -352,19 +443,19 @@ void UpdateBlockVarDomain(const arith::IntSet& provided, const arith::IntSet& re
  * \param provided_regions The region provided by one iteration instance of the block vars
  * \param required_regions The region required to be covered
  * \param analyzer The arithmetic analyzer
- * \return A list of iteration domain corresponding to the given list of block vars
+ * \return A list of iteration domain info corresponding to the given list of block vars
  */
-std::vector<Range> CalculateBlockVarDomain(
+std::vector<BlockVarDomainInfo> CalculateBlockVarDomain(
     const Array<IterVar>& iter_vars,
     std::unordered_map<const BufferNode*, std::vector<NDIntSet>> provided_regions,
     std::unordered_map<const BufferNode*, std::vector<NDIntSet>> required_regions,
     arith::Analyzer* analyzer) {
   int n_iters = iter_vars.size();
   // Step 1. Construct the mapping from block var to their iteration domain (initialized to empty)
-  std::unordered_map<const VarNode*, std::vector<arith::IntSet>> iter_doms;
+  std::unordered_map<const VarNode*, BlockVarDomainInfo> iter_doms;
   iter_doms.reserve(n_iters);
   for (const IterVar& iter_var : iter_vars) {
-    iter_doms[iter_var->var.get()] = {};
+    iter_doms[iter_var->var.get()] = BlockVarDomainInfo();
   }
   // Step 2. For each buffer, update the domain according to the provided and required regions
   for (const auto& kv : provided_regions) {
@@ -384,23 +475,23 @@ std::vector<Range> CalculateBlockVarDomain(
     for (int i = 0; i < ndim; ++i) {
       arith::IntSet provided = provided_region[i];
       arith::IntSet required = required_region[i];
-      required = arith::Intersect(
-          {std::move(required), arith::IntSet::FromMinExtent(Integer(0), buffer->shape[i])});
-      UpdateBlockVarDomain(provided, required, &iter_doms, analyzer);
+      arith::IntSet required_bound = arith::IntSet::FromMinExtent(Integer(0), buffer->shape[i]);
+      UpdateBlockVarDomain(provided, required, required_bound, &iter_doms, analyzer);
     }
   }
   // Union the iter var domains, put them in the same order of block vars, and return
-  std::vector<Range> result;
+  std::vector<BlockVarDomainInfo> result;
   result.reserve(n_iters);
   for (const IterVar& iter_var : iter_vars) {
-    const std::vector<arith::IntSet>& doms = iter_doms.at(iter_var->var.get());
-    arith::IntSet dom = arith::IntSet::FromRange(iter_var->dom);
-    if (!doms.empty()) {
-      dom = arith::Intersect({std::move(dom), arith::Union(doms)});
+    BlockVarDomainInfo& info = iter_doms.at(iter_var->var.get());
+    if (info.bound.IsNothing()) {
+      info.bound = arith::IntSet::FromRange(iter_var->dom);
+    } else {
+      info.bound = arith::Intersect({info.bound, arith::IntSet::FromRange(iter_var->dom)});
     }
-    PrimExpr min = analyzer->Simplify(dom.min());
-    PrimExpr extent = analyzer->Simplify(dom.max() - min + 1);
-    result.push_back(Range::FromMinExtent(min, extent));
+    info.Simplify(analyzer);
+    ICHECK(!info.dom.IsNothing());
+    result.push_back(info);
   }
   return result;
 }
@@ -498,14 +589,14 @@ void ComputeAtOrReverseComputeAtImpl(ScheduleState self, const StmtSRef& block_s
       /*consumer_srefs=*/std::move(consumer_srefs),
       /*provided_regions=*/&provided_regions, /*required_regions=*/&required_regions);
   // Step 5. Calculate the iteration domain for each block var
-  std::vector<Range> iter_doms =
+  std::vector<BlockVarDomainInfo> iter_doms =
       CalculateBlockVarDomain(/*iter_vars=*/block->iter_vars,
                               /*provided_regions=*/std::move(provided_regions),
                               /*required_regions=*/std::move(required_regions),
                               /*analyzer=*/analyzer);
   // Step 6. Create the new scope according to the iteration domain
   reconstructor.MakeNewLoop(/*insert_position=*/insert_position, /*iter_doms=*/std::move(iter_doms),
-                            /*preserve_unit_loops=*/preserve_unit_loops);
+                            /*analyzer=*/analyzer, /*preserve_unit_loops=*/preserve_unit_loops);
   Block new_scope_root = Downcast<Block>(reconstructor(scope_root));
 
   // Step 7. Do the actual replacement

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -263,6 +263,14 @@ def test_predicate():
     )
     assert len(res) == 0
 
+    # irrelavant predicate
+    res = tvm.arith.detect_iter_map(
+        [i + j],
+        var_dom([(i, 1)]),
+        j <= 24,
+    )
+    assert_iter_sum_pattern(res[0], 1, j)
+
     # constraint on nested fused iters
     res = tvm.arith.detect_iter_map(
         [i * 8 + j * 2 + k],

--- a/tests/python/unittest/test_tir_analysis_get_block_access_region.py
+++ b/tests/python/unittest/test_tir_analysis_get_block_access_region.py
@@ -138,29 +138,15 @@ def access_of_padding_pattern() -> None:
     for i, j in T.grid(32, 32):
         with T.block("padding"):
             vi, vj = T.axis.remap("SS", [i, j])
-            T.reads(
-                [
-                    X[
-                        T.max(vi - 2, 0) : T.min(vi - 2, 27) + 1,
-                        T.max(vj - 2, 0) : T.min(vj - 2, 27) + 1,
-                    ]
-                ]
-            )
+            T.reads([X[vi - 2, vj - 2]])
             T.writes([X_pad[vi, vj]])
             X_pad[vi, vj] = T.if_then_else(
                 2 <= vi and vi < 30 and 2 <= vj and vj < 30, X[vi - 2, vj - 2], 0.0, dtype="float32"
             )
         with T.block("padding_reverse"):
             vi, vj = T.axis.remap("SS", [i, j])
-            T.reads([X_pad[T.max(vi, 2) : T.min(vi, 29) + 1, T.max(vj, 2) : T.min(vj, 29) + 1]])
-            T.writes(
-                [
-                    Y[
-                        T.max(vi - 2, 0) : T.min(vi - 2, 27) + 1,
-                        T.max(vj - 2, 0) : T.min(vj - 2, 27) + 1,
-                    ]
-                ]
-            )
+            T.reads([X_pad[vi, vj]])
+            T.writes([Y[vi - 2, vj - 2]])
             if 2 <= vi and vi < 30 and 2 <= vj and vj < 30:
                 Y[vi - 2, vj - 2] = X_pad[vi, vj]
 

--- a/tests/python/unittest/test_tir_schedule_compute_at.py
+++ b/tests/python/unittest/test_tir_schedule_compute_at.py
@@ -805,16 +805,12 @@ def tiled_pooling_read_cache(a: T.handle, b: T.handle) -> None:
     for hh, ww in T.grid(224, 224):
         with T.block("cache"):
             h, w = T.axis.remap("SS", [hh, ww])
-            T.reads([X[h, w]])
-            T.writes([cache[h, w]])
             cache[h, w] = X[h, w]
     for hh_0, ww_0, hh_1, ww_1, khh, kww in T.grid(28, 28, 8, 8, 3, 3):
         with T.block("compute"):
             h = T.axis.spatial(224, hh_0 * 8 + hh_1)
             w = T.axis.spatial(224, ww_0 * 8 + ww_1)
             kh, kw = T.axis.remap("RR", [khh, kww])
-            T.reads([Y[h, w], cache[h + kh - 1, w + kw - 1]])
-            T.writes([Y[h, w]])
             with T.init():
                 Y[h, w] = 0.0
             Y[h, w] = T.max(Y[h, w], T.if_then_else(
@@ -835,16 +831,12 @@ def tiled_pooling_read_cache_after_compute_at(a: T.handle, b: T.handle) -> None:
                 h = T.axis.spatial(224, hh_0 * 8 - 1 + ax0)
                 w = T.axis.spatial(224, ww_0 * 8 - 1 + ax1)
                 T.where(1 <= hh_0 * 8 + ax0 and hh_0 * 8 + ax0 < 225 and 1 <= ww_0 * 8 + ax1 and ww_0 * 8 + ax1 < 225)
-                T.reads([X[h, w]])
-                T.writes([cache[h, w]])
                 cache[h, w] = X[h, w]
         for hh_1, ww_1, khh, kww in T.grid(8, 8, 3, 3):
             with T.block("compute"):
                 h = T.axis.spatial(224, hh_0 * 8 + hh_1)
                 w = T.axis.spatial(224, ww_0 * 8 + ww_1)
                 kh, kw = T.axis.remap("RR", [khh, kww])
-                T.reads([Y[h, w], cache[h + kh - 1, w + kw - 1]])
-                T.writes([Y[h, w]])
                 with T.init():
                     Y[h, w] = 0.0
                 Y[h, w] = T.max(Y[h, w], T.if_then_else(
@@ -853,6 +845,93 @@ def tiled_pooling_read_cache_after_compute_at(a: T.handle, b: T.handle) -> None:
                     T.likely(1 <= w + kw, dtype="bool") and \
                     T.likely(w + kw < 225, dtype="bool"),
                     cache[h + kh - 1, w + kw - 1], 0.0, dtype="float32"))
+
+@T.prim_func
+def non_uniform_tiled_conv(x: T.Buffer[(1, 3, 100, 100), "float32"],
+                           w: T.Buffer[(16, 3, 3, 3), "float32"],
+                           y: T.Buffer[(1, 16, 98, 98), "float32"]) -> None:
+    x_global = T.alloc_buffer([1, 3, 100, 100], dtype="float32")
+    for ax0, ax1, ax2, ax3 in T.grid(1, 3, 100, 100):
+        with T.block("cache"):
+            v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            x_global[v0, v1, v2, v3] = x[v0, v1, v2, v3]
+    for h_o, w_o, n, c_o, h_i, w_i, c_i, kh, kw in T.grid(7, 7, 1, 16, 15, 15, 3, 3, 3):
+        with T.block("compute"):
+            nn = T.axis.spatial(1, 0)
+            cc = T.axis.spatial(16, c_o)
+            hh = T.axis.spatial(98, h_o * 15 + h_i)
+            ww = T.axis.spatial(98, w_o * 15 + w_i)
+            rc, rh, rw = T.axis.remap("RRR", [c_i, kh, kw])
+            T.where(h_o * 15 + h_i < 98 and w_o * 15 + w_i < 98)
+            with T.init():
+                y[nn, cc, hh, ww] = T.float32(0)
+            y[nn, cc, hh, ww] = y[nn, cc, hh, ww] + \
+                x_global[nn, cc // 16 * 3 + rc, hh + rh, ww + rw] * w[cc, rc, rh, rw]
+
+@T.prim_func
+def non_uniform_tiled_conv_after_compute_at(x: T.Buffer[(1, 3, 100, 100), "float32"],
+                                            w: T.Buffer[(16, 3, 3, 3), "float32"],
+                                            y: T.Buffer[(1, 16, 98, 98), "float32"]) -> None:
+    x_global = T.alloc_buffer([1, 3, 100, 100], dtype="float32")
+    for h_o, w_o in T.grid(7, 7):
+        for ax0, ax1, ax2 in T.grid(3, 17, 17):
+            with T.block("cache"):
+                v0 = T.axis.spatial(1, 0)
+                v1 = T.axis.spatial(3, ax0)
+                v2 = T.axis.spatial(100, h_o * 15 + ax1)
+                v3 = T.axis.spatial(100, w_o * 15 + ax2)
+                T.where(h_o * 15 + ax1 < 100 and w_o * 15 + ax2 < 100)
+                x_global[v0, v1, v2, v3] = x[v0, v1, v2, v3]
+        for n, c_o, h_i, w_i, c_i, kh, kw in T.grid(1, 16, 15, 15, 3, 3, 3):
+            with T.block("compute"):
+                nn = T.axis.spatial(1, 0)
+                cc = T.axis.spatial(16, c_o)
+                hh = T.axis.spatial(98, h_o * 15 + h_i)
+                ww = T.axis.spatial(98, w_o * 15 + w_i)
+                rc, rh, rw = T.axis.remap("RRR", [c_i, kh, kw])
+                T.where(h_o * 15 + h_i < 98 and w_o * 15 + w_i < 98)
+                with T.init():
+                    y[nn, cc, hh, ww] = T.float32(0)
+                y[nn, cc, hh, ww] = y[nn, cc, hh, ww] + \
+                    x_global[nn, cc // 16 * 3 + rc, hh + rh, ww + rw] * w[cc, rc, rh, rw]
+
+@T.prim_func
+def concat_two_elemwise(x: T.Buffer[(16,), "float32"],
+                        y: T.Buffer[(8,), "float32"],
+                        T_concat: T.Buffer[(24,), "float32"]) -> None:
+    T_add_1 = T.alloc_buffer([16], dtype="float32")
+    T_add_2 = T.alloc_buffer([8], dtype="float32")
+    for i in T.serial(16):
+        with T.block("T_add_1"):
+            ax = T.axis.spatial(16, i)
+            T_add_1[ax] = x[ax] + T.float32(1)
+    for i in T.serial(8):
+        with T.block("T_add_2"):
+            ax = T.axis.spatial(8, i)
+            T_add_2[ax] = y[ax] + T.float32(2)
+    for i in T.serial(24):
+        with T.block("T_concat"):
+            ax = T.axis.spatial(24, i)
+            T_concat[ax] = T.if_then_else(16 <= ax, T_add_1[ax - 16], T_add_2[ax], dtype="float32")
+
+@T.prim_func
+def concat_two_elemwise_after_compute_at(x: T.Buffer[(16,), "float32"],
+                                         y: T.Buffer[(8,), "float32"],
+                                         T_concat: T.Buffer[(24,), "float32"]) -> None:
+    T_add_1 = T.alloc_buffer([16], dtype="float32")
+    T_add_2 = T.alloc_buffer([8], dtype="float32")
+    for i in T.serial(24):
+        with T.block("T_add_1"):
+            ax = T.axis.spatial(16, i - 16)
+            T.where(16 <= i)
+            T_add_1[ax] = x[ax] + T.float32(1)
+        with T.block("T_add_2"):
+            ax = T.axis.spatial(8, i)
+            T.where(i < 8)
+            T_add_2[ax] = y[ax] + T.float32(2)
+        with T.block("T_concat"):
+            ax = T.axis.spatial(24, i)
+            T_concat[ax] = T.if_then_else(16 <= ax, T_add_1[ax - 16], T_add_2[ax], dtype="float32")
 
 @T.prim_func
 def floordiv_and_floormod_indices(a: T.handle, b: T.handle) -> None:
@@ -976,6 +1055,26 @@ def test_compute_at_tiled_pooling_read_cache():
     sch.compute_at(cache, w_o)
     tvm.ir.assert_structural_equal(tiled_pooling_read_cache_after_compute_at, sch.mod["main"])
     verify_trace_roundtrip(sch=sch, mod=tiled_pooling_read_cache)
+
+
+def test_compute_at_non_uniform_tiled_conv():
+    sch = tir.Schedule(non_uniform_tiled_conv, debug_mask="all")
+    compute = sch.get_block("compute")
+    sch.compute_at(sch.get_block("cache"), sch.get_loops(compute)[1])
+    tvm.ir.assert_structural_equal(non_uniform_tiled_conv_after_compute_at, sch.mod["main"])
+    verify_trace_roundtrip(sch=sch, mod=non_uniform_tiled_conv)
+
+
+def test_compute_at_concat():
+    sch = tir.Schedule(concat_two_elemwise, debug_mask="all")
+    concat = sch.get_block("T_concat")
+    add1 = sch.get_block("T_add_1")
+    add2 = sch.get_block("T_add_2")
+    axis = sch.get_loops(concat)[0]
+    sch.compute_at(add1, axis)
+    sch.compute_at(add2, axis)
+    tvm.ir.assert_structural_equal(concat_two_elemwise_after_compute_at, sch.mod["main"])
+    verify_trace_roundtrip(sch=sch, mod=concat_two_elemwise)
 
 
 def test_reverse_compute_at_tiled():


### PR DESCRIPTION
Hi there~ This PR is an enforcement for `compute_at` and `reverse_compute_at` primitives. Binding block into loops may create some non-trivial iter bounds. Complex iter bound is neither human-kind friendly nor compatible with backend passes targeting at bounds and conditions (eg, loop partition). So the PR try to distinguish some of complex bounds and use block predicates to make the ir structure simpler.

A working example is as below, we want to create spatial tiles and read each tiled data from cache, thus the schedule operation is `compute_at` cache_read block into tiled loops.
```python
@T.prim_func
def tiled_pooling_read_cache(a: T.handle, b: T.handle) -> None:
    X = T.match_buffer(a, [224, 224], dtype="float32")
    Y = T.match_buffer(b, [224, 224], dtype="float32")
    cache = T.alloc_buffer([224, 224], dtype="float32")
    for hh, ww in T.grid(224, 224):
        with T.block("cache"):
            h, w = T.axis.remap("SS", [hh, ww])
            T.reads([X[h, w]])
            T.writes([cache[h, w]])
            cache[h, w] = X[h, w]
    for hh_0, ww_0, hh_1, ww_1, khh, kww in T.grid(28, 28, 8, 8, 3, 3):
        with T.block("compute"):
            h = T.axis.spatial(224, hh_0 * 8 + hh_1)
            w = T.axis.spatial(224, ww_0 * 8 + ww_1)
            kh, kw = T.axis.remap("RR", [khh, kww])
            T.reads([Y[h, w], cache[h + kh - 1, w + kw - 1]])
            T.writes([Y[h, w]])
            with T.init():
                Y[h, w] = 0.0
            Y[h, w] = T.max(Y[h, w], T.if_then_else(
                T.likely(1 <= h + kh, dtype="bool") and \
                T.likely(h + kh < 225, dtype="bool") and \
                T.likely(1 <= w + kw, dtype="bool") and \
                T.likely(w + kw < 225, dtype="bool"),
                cache[h + kh - 1, w + kw - 1], 0.0, dtype="float32"))
```
Main stream code will produce
```python
@T.prim_func
def func(a: T.handle, b: T.handle) -> None:
    X = T.match_buffer(a, [224, 224], dtype="float32")
    Y = T.match_buffer(b, [224, 224], dtype="float32")
    # body
    # with T.block("root")
    cache = T.alloc_buffer([224, 224], dtype="float32")
    for hh_0, ww_0 in T.grid(28, 28):
        for ax0 in T.serial(0, T.min(hh_0 * 8 + 8, 223) + 1 - T.max(hh_0 * 8 - 1, 0)):
            for ax1 in T.serial(0, T.min(ww_0 * 8 + 8, 223) + 1 - T.max(ww_0 * 8 - 1, 0)):
                with T.block("cache"):
                    h = T.axis.spatial(224, T.max(hh_0 * 8 - 1, 0) + ax0)
                    w = T.axis.spatial(224, T.max(ww_0 * 8 - 1, 0) + ax1)
                    T.reads([X[h, w]])
                    T.writes([cache[h, w]])
                    cache[h, w] = X[h, w]
        for hh_1, ww_1, khh, kww in T.grid(8, 8, 3, 3):
            with T.block("compute"):
                ...
```
The PR will produce
```python
def tiled_pooling_read_cache_after_compute_at(a: T.handle, b: T.handle) -> None:
    X = T.match_buffer(a, [224, 224], dtype="float32")
    Y = T.match_buffer(b, [224, 224], dtype="float32")
    cache = T.alloc_buffer([224, 224], dtype="float32")
    for hh_0, ww_0 in T.grid(28, 28):
        for ax0, ax1 in T.grid(10, 10):
            with T.block("cache"):
                h = T.axis.spatial(224, hh_0 * 8 - 1 + ax0)
                w = T.axis.spatial(224, ww_0 * 8 - 1 + ax1)
                T.where(1 <= hh_0 * 8 + ax0 and hh_0 * 8 + ax0 < 225 and 1 <= ww_0 * 8 + ax1 and ww_0 * 8 + ax1 < 225)
                T.reads([X[h, w]])
                T.writes([cache[h, w]])
                cache[h, w] = X[h, w]
        for hh_1, ww_1, khh, kww in T.grid(8, 8, 3, 3):
            with T.block("compute"):
                ...
```

The modification is to delay the intersection of intset deduced from required uses and intset enforced by buffer shape / original iter bound. Instead of direct intset intersection (can create much complex expr of min/max), A `BlockVarDomainInfo` class is added to maintain above two intsets named as `dom` and `bound`. Finally the implementation can choose with some heuristic:
1. use (`dom` ^ `bound`) as iter domain if it is simple enough
2. use `dom` as iter domain and add block predicate for `bound`

The PR also add minimal support to analyze floordiv/floormod in provide-required region mapping.