### PR TITLE
WithFields for Tuples

### DIFF
--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -141,19 +141,18 @@ class Tuple : public Expr {
    */
   TVM_DLL explicit Tuple(tvm::Array<relay::Expr> fields, Span span = Span());
 
-  /*!
-   * \brief Returns this with given properties. A null property denotes 'no change'.
-   * Returns this if all properties are unchanged. Returns a modified this if this is the only
-   * reference to the underlying node.
-   *
-   * TODO(mbs): Extend to all node types.
-   */
-  Tuple WithFields(Optional<Array<Expr>> opt_fields = Optional<Array<Expr>>(),
-                   Optional<Span> opt_span = Optional<Span>(nullptr));
-
   TVM_DEFINE_OBJECT_REF_METHODS(Tuple, RelayExpr, TupleNode);
-  TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleNode);
 };
+
+/*!
+ * \brief Returns the tuple with given properties. A null property denotes 'no change'.
+ * Returns this if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param tuple The tuple to copy
+ * \param fields The fields for the copied tuple
+ * \param span The span for the copied tuple
+ */
+Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields = Optional<Array<Expr>>(),
+                 Optional<Span> opt_span = Optional<Span>(nullptr));
 
 /*!
  * \brief Local variables used in the let expression.

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -141,7 +141,18 @@ class Tuple : public Expr {
    */
   TVM_DLL explicit Tuple(tvm::Array<relay::Expr> fields, Span span = Span());
 
+  /*!
+   * \brief Returns this with given properties. A null property denotes 'no change'.
+   * Returns this if all properties are unchanged. Returns a modified this if this is the only
+   * reference to the underlying node.
+   *
+   * TODO(mbs): Extend to all node types.
+   */
+  Tuple WithFields(Optional<Array<Expr>> opt_fields = Optional<Array<Expr>>(),
+                   Optional<Span> opt_span = Optional<Span>(nullptr));
+
   TVM_DEFINE_OBJECT_REF_METHODS(Tuple, RelayExpr, TupleNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleNode);
 };
 
 /*!

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -142,6 +142,7 @@ class Tuple : public Expr {
   TVM_DLL explicit Tuple(tvm::Array<relay::Expr> fields, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Tuple, RelayExpr, TupleNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleNode);
 };
 
 /*!

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -148,8 +148,9 @@ class Tuple : public Expr {
  * \brief Returns the tuple with given properties. A null property denotes 'no change'.
  * Returns this if all properties are unchanged. Otherwise, returns a copy with the new fields.
  * \param tuple The tuple to copy
- * \param fields The fields for the copied tuple
- * \param span The span for the copied tuple
+ * \param opt_fields The (optional) fields for the copied tuple. If none, ret_tuple->fields =
+ * tuple->fields.
+ * \param opt_span The (optional) span for the copied tuple. If none, ret_tuple->span = tuple->span.
  */
 Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields = Optional<Array<Expr>>(),
                  Optional<Span> opt_span = Optional<Span>(nullptr));

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -90,14 +90,12 @@ Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields, Optional<Span> o
   }
 
   all_fields_unchanged = all_fields_unchanged && span.same_as(tuple->span);
-  if (all_fields_unchanged) {
-    return std::move(tuple);
-  } else {
+  if (!all_fields_unchanged) {
     TupleNode* cow_tuple_node = tuple.CopyOnWrite();
     cow_tuple_node->fields = fields;
     cow_tuple_node->span = span;
-    return tuple;
   }
+  return std::move(tuple);
 }
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -77,7 +77,7 @@ Tuple Tuple::WithFields(Optional<Array<Expr>> opt_fields, Optional<Span> opt_spa
 
   // TODO(@electriclilies): Turn into a helper, will need this for functions as well.
   bool all_fields_unchanged = true;
-  if (fields.same_as(get()->fields) && (fields.size() == get()->fields.size())) {
+  if (fields.size() == get()->fields.size()) {
     for (uint i = 0; i < fields.size(); i++) {
       all_fields_unchanged &= fields[i].same_as(get()->fields[i]);
     }

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -83,17 +83,20 @@ Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields, Optional<Span> o
   bool all_fields_unchanged = true;
   if (fields.size() == tuple->fields.size()) {
     for (uint i = 0; i < fields.size(); i++) {
-      all_fields_unchanged &= fields[i] == (tuple->fields[i]);
+      all_fields_unchanged &= fields[i].same_as(tuple->fields[i]);
     }
   } else {
     all_fields_unchanged = false;
   }
 
-  all_fields_unchanged = all_fields_unchanged && span == tuple->span;
+  all_fields_unchanged = all_fields_unchanged && span.same_as(tuple->span);
   if (all_fields_unchanged) {
     return std::move(tuple);
   } else {
-    return Tuple(std::move(fields), std::move(span));
+    TupleNode* cow_tuple_node = tuple.CopyOnWrite();
+    cow_tuple_node->fields = fields;
+    cow_tuple_node->span = span;
+    return GetRef<Tuple>(cow_tuple_node);
   }
 }
 

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -71,34 +71,31 @@ Tuple::Tuple(tvm::Array<relay::Expr> fields, Span span) {
   data_ = std::move(n);
 }
 
-Tuple Tuple::WithFields(Optional<Array<Expr>> opt_fields, Optional<Span> opt_span) {
-  Array<Expr> fields = opt_fields.value_or(get()->fields);
-  Span span = opt_span.value_or(get()->span);
-
-  // TODO(@electriclilies): Turn into a helper, will need this for functions as well.
-  bool all_fields_unchanged = true;
-  if (fields.size() == get()->fields.size()) {
-    for (uint i = 0; i < fields.size(); i++) {
-      all_fields_unchanged &= fields[i].same_as(get()->fields[i]);
-    }
-  } else {
-    all_fields_unchanged = false;
-  }
-
-  if (all_fields_unchanged && span.same_as(get()->span)) {
-    return *this;
-  }
-  TupleNode* cow_tuple_node = CopyOnWrite();
-  cow_tuple_node->fields = fields;
-  cow_tuple_node->span = span;
-  return GetRef<Tuple>(cow_tuple_node);
-}
-
 TVM_REGISTER_NODE_TYPE(TupleNode);
 
 TVM_REGISTER_GLOBAL("relay.ir.Tuple").set_body_typed([](tvm::Array<relay::Expr> fields, Span span) {
   return Tuple(fields, span);
 });
+Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields, Optional<Span> opt_span) {
+  Array<Expr> fields = opt_fields.value_or(tuple->fields);
+  Span span = opt_span.value_or(tuple->span);
+
+  bool all_fields_unchanged = true;
+  if (fields.size() == tuple->fields.size()) {
+    for (uint i = 0; i < fields.size(); i++) {
+      all_fields_unchanged &= fields[i] == (tuple->fields[i]);
+    }
+  } else {
+    all_fields_unchanged = false;
+  }
+
+  all_fields_unchanged = all_fields_unchanged && span == tuple->span;
+  if (all_fields_unchanged) {
+    return std::move(tuple);
+  } else {
+    return Tuple(std::move(fields), std::move(span));
+  }
+}
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<TupleNode>([](const ObjectRef& ref, ReprPrinter* p) {

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -82,7 +82,7 @@ Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields, Optional<Span> o
 
   bool all_fields_unchanged = true;
   if (fields.size() == tuple->fields.size()) {
-    for (uint i = 0; i < fields.size(); i++) {
+    for (size_t i = 0; i < fields.size(); i++) {
       all_fields_unchanged &= fields[i].same_as(tuple->fields[i]);
     }
   } else {

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -96,7 +96,7 @@ Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields, Optional<Span> o
     TupleNode* cow_tuple_node = tuple.CopyOnWrite();
     cow_tuple_node->fields = fields;
     cow_tuple_node->span = span;
-    return GetRef<Tuple>(cow_tuple_node);
+    return tuple;
   }
 }
 

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -77,7 +77,7 @@ Tuple Tuple::WithFields(Optional<Array<Expr>> opt_fields, Optional<Span> opt_spa
 
   // TODO(@electriclilies): Turn into a helper, will need this for functions as well.
   bool all_fields_unchanged = true;
-  if (fields.size() == get()->fields.size()) {
+  if (fields.same_as(get()->fields) && (fields.size() == get()->fields.size())) {
     for (uint i = 0; i < fields.size(); i++) {
       all_fields_unchanged &= fields[i].same_as(get()->fields[i]);
     }
@@ -85,8 +85,7 @@ Tuple Tuple::WithFields(Optional<Array<Expr>> opt_fields, Optional<Span> opt_spa
     all_fields_unchanged = false;
   }
 
-  if (fields.same_as(get()->fields) /* do I need this check? */ && all_fields_unchanged &&
-      span.same_as(get()->span)) {
+  if (all_fields_unchanged && span.same_as(get()->span)) {
     return *this;
   }
   TupleNode* cow_tuple_node = CopyOnWrite();

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -183,7 +183,7 @@ Expr ExprMutator::VisitExpr_(const TupleNode* tuple_node) {
     auto new_field = this->Mutate(field);
     fields.push_back(new_field);
   }
-  return WithFields(GetRef<Tuple>(std::move(tuple_node)), std::move(fields));
+  return WithFields(GetRef<Tuple>(tuple_node), std::move(fields));
 }
 
 Expr ExprMutator::VisitExpr_(const FunctionNode* op) {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -179,6 +179,8 @@ Expr ExprMutator::VisitExpr_(const OpNode* op) { return GetRef<Expr>(op); }
 
 Expr ExprMutator::VisitExpr_(const TupleNode* tuple_node) {
   tvm::Array<Expr> fields;
+  fields.reserve(tuple_node->fields.size());
+
   for (auto field : tuple_node->fields) {
     auto new_field = this->Mutate(field);
     fields.push_back(new_field);

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -177,20 +177,13 @@ Expr ExprMutator::VisitExpr_(const GlobalVarNode* op) { return GetRef<Expr>(op);
 
 Expr ExprMutator::VisitExpr_(const OpNode* op) { return GetRef<Expr>(op); }
 
-Expr ExprMutator::VisitExpr_(const TupleNode* op) {
+Expr ExprMutator::VisitExpr_(const TupleNode* tuple_node) {
   tvm::Array<Expr> fields;
-  bool all_fields_unchanged = true;
-  for (auto field : op->fields) {
+  for (auto field : tuple_node->fields) {
     auto new_field = this->Mutate(field);
     fields.push_back(new_field);
-    all_fields_unchanged &= new_field.same_as(field);
   }
-
-  if (all_fields_unchanged) {
-    return GetRef<Expr>(op);
-  } else {
-    return Tuple(fields, op->span);
-  }
+  return GetRef<Tuple>(tuple_node).WithFields(fields);
 }
 
 Expr ExprMutator::VisitExpr_(const FunctionNode* op) {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -183,7 +183,7 @@ Expr ExprMutator::VisitExpr_(const TupleNode* tuple_node) {
     auto new_field = this->Mutate(field);
     fields.push_back(new_field);
   }
-  return GetRef<Tuple>(tuple_node).WithFields(fields);
+  return WithFields(GetRef<Tuple>(std::move(tuple_node)), std::move(fields));
 }
 
 Expr ExprMutator::VisitExpr_(const FunctionNode* op) {

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -266,11 +266,11 @@ class AnnotateTargetRewriter : public ExprRewriter {
 
   virtual std::unique_ptr<Call> RewriteVarCall(const Call& post_call) { return nullptr; }
 
-  Expr Rewrite_(const TupleNode* op, const Expr& post) override {
-    auto expr = Downcast<Tuple>(post);
+  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post_tuple_node) override {
+    auto tuple = Downcast<Tuple>(post_tuple_node);
 
-    auto target_n_args = AnnotateArgs(expr->fields);
-    auto new_expr = Tuple(std::get<1>(target_n_args));
+    auto target_n_args = AnnotateArgs(tuple->fields);
+    auto new_expr = WithFields(std::move(tuple), std::move(std::get<1>(target_n_args)));
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
     return std::move(new_expr);
   }
@@ -370,13 +370,13 @@ class CallOpsTargetRewriter : public AnnotateTargetRewriter {
     return new_call;
   }
 
-  Expr Rewrite_(const TupleNode* op, const Expr& post) override {
-    auto expr = Downcast<Tuple>(post);
+  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post_tuple_node) override {
+    auto tuple = Downcast<Tuple>(post_tuple_node);
     Array<Expr> new_fields;
-    for (auto f : expr->fields) {
+    for (auto f : tuple->fields) {
       new_fields.push_back(InsertCompilerEndAndPropogateTarget(f));
     }
-    return std::move(Tuple(new_fields));
+    return WithFields(std::move(tuple), std::move(new_fields));
   }
 
   Expr Rewrite_(const TupleGetItemNode* op, const Expr& post) override {

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -373,6 +373,8 @@ class CallOpsTargetRewriter : public AnnotateTargetRewriter {
   Expr Rewrite_(const TupleNode* tuple_node, const Expr& post) override {
     auto tuple = Downcast<Tuple>(post);
     Array<Expr> new_fields;
+    new_fields.reserve(tuple->fields.size());
+
     for (auto f : tuple->fields) {
       new_fields.push_back(InsertCompilerEndAndPropogateTarget(f));
     }

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -266,8 +266,8 @@ class AnnotateTargetRewriter : public ExprRewriter {
 
   virtual std::unique_ptr<Call> RewriteVarCall(const Call& post_call) { return nullptr; }
 
-  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post_tuple_node) override {
-    auto tuple = Downcast<Tuple>(post_tuple_node);
+  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post) override {
+    auto tuple = Downcast<Tuple>(post);
 
     auto target_n_args = AnnotateArgs(tuple->fields);
     auto new_expr = WithFields(std::move(tuple), std::move(std::get<1>(target_n_args)));
@@ -370,8 +370,8 @@ class CallOpsTargetRewriter : public AnnotateTargetRewriter {
     return new_call;
   }
 
-  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post_tuple_node) override {
-    auto tuple = Downcast<Tuple>(post_tuple_node);
+  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post) override {
+    auto tuple = Downcast<Tuple>(post);
     Array<Expr> new_fields;
     for (auto f : tuple->fields) {
       new_fields.push_back(InsertCompilerEndAndPropogateTarget(f));

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -786,8 +786,7 @@ class DeviceCapturer : public ExprMutator {
     for (const auto& field : tuple_node->fields) {
       fields.push_back(VisitChild(tuple, field));
     }
-    // TODO(mbs): Avoid copy
-    return Tuple(std::move(fields), tuple_node->span);
+    return WithFields(std::move(tuple), std::move(fields));
   }
 
   Expr VisitExpr_(const FunctionNode* function_node) final {

--- a/src/relay/transforms/first_order_gradient.cc
+++ b/src/relay/transforms/first_order_gradient.cc
@@ -199,6 +199,8 @@ struct FirstOrderReverseAD : ExprFunctor<ADValue(const Expr&)> {
     auto tt = Downcast<TupleType>(tuple_node->checked_type());
     std::vector<ADValue> ad_fields;
     Array<Expr> field_bindings;
+    field_bindings.reserve(tuple_node->fields.size());
+
     for (const auto& f : tuple_node->fields) {
       ADValue f_ad = VisitExpr(f);
       if (!dynamic_cast<ADTensor*>(f_ad.get())) {

--- a/src/relay/transforms/first_order_gradient.cc
+++ b/src/relay/transforms/first_order_gradient.cc
@@ -195,11 +195,11 @@ struct FirstOrderReverseAD : ExprFunctor<ADValue(const Expr&)> {
     return ret;
   }
 
-  ADValue VisitExpr_(const TupleNode* op) final {
-    auto tt = Downcast<TupleType>(op->checked_type());
+  ADValue VisitExpr_(const TupleNode* tuple_node) final {
+    auto tt = Downcast<TupleType>(tuple_node->checked_type());
     std::vector<ADValue> ad_fields;
-    std::vector<Expr> field_bindings;
-    for (const auto& f : op->fields) {
+    Array<Expr> field_bindings;
+    for (const auto& f : tuple_node->fields) {
       ADValue f_ad = VisitExpr(f);
       if (!dynamic_cast<ADTensor*>(f_ad.get())) {
         diag_ctx.EmitFatal(Diagnostic::Error(f->span)
@@ -209,7 +209,7 @@ struct FirstOrderReverseAD : ExprFunctor<ADValue(const Expr&)> {
       field_bindings.push_back(f_ad->get<ADTensor>().forward);
     }
     // reconstruct tuple using let-bound variables to avoid duplication
-    auto orig = Tuple(field_bindings);
+    auto orig = WithFields(GetRef<Tuple>(tuple_node), std::move(field_bindings));
     orig->checked_type_ = tt;
     auto ret = std::make_shared<ADTensor>(ll, orig, diag_ctx);
     // for orig = tuple(x1, ..., xn), tuple_grad(x1, ..., xn, G) = [pi(G, 1), ..., pi(G, n)]

--- a/src/relay/transforms/forward_rewrite.cc
+++ b/src/relay/transforms/forward_rewrite.cc
@@ -115,6 +115,7 @@ class ForwardRewriter : private MixedModeMutator {
 
   Expr Rewrite_(const TupleNode* tuple_node, const Expr& post) final {
     tvm::Array<Expr> fields;
+    fields.reserve(tuple_node->fields.size());
 
     const auto* post_tuple_node = post.as<TupleNode>();
     for (size_t i = 0; i < tuple_node->fields.size(); ++i) {

--- a/src/relay/transforms/forward_rewrite.cc
+++ b/src/relay/transforms/forward_rewrite.cc
@@ -113,21 +113,15 @@ class ForwardRewriter : private MixedModeMutator {
     }
   }
 
-  Expr Rewrite_(const TupleNode* op, const Expr& post) final {
+  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post) final {
     tvm::Array<Expr> fields;
-    bool all_fields_unchanged = true;
-    const auto* post_node = post.as<TupleNode>();
-    for (size_t i = 0; i < op->fields.size(); ++i) {
-      auto new_field = this->GetTempExpr(op->fields[i], post_node->fields[i]);
-      fields.push_back(new_field);
-      all_fields_unchanged &= new_field.same_as(op->fields[i]);
+
+    const auto* post_tuple_node = post.as<TupleNode>();
+    for (size_t i = 0; i < tuple_node->fields.size(); ++i) {
+      fields.push_back(this->GetTempExpr(tuple_node->fields[i], post_tuple_node->fields[i]));
     }
 
-    if (all_fields_unchanged) {
-      return GetRef<Expr>(op);
-    } else {
-      return Tuple(fields);
-    }
+    return WithFields(GetRef<Tuple>(tuple_node), std::move(fields));
   }
 
   Expr Rewrite_(const CallNode* call_node, const Expr& post) final {

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -898,14 +898,14 @@ class FuseMutator : private MixedModeMutator {
     }
   }
 
-  Expr Rewrite_(const TupleNode* tuple, const Expr& post) {
-    auto* ret_group = gmap_.at(tuple)->FindRoot();
-    if (ret_group->root_ref == tuple) {
-      return ExprMutator::VisitExpr_(tuple);
+  Expr Rewrite_(const TupleNode* tuple_node, const Expr& post) {
+    auto* ret_group = gmap_.at(tuple_node)->FindRoot();
+    if (ret_group->root_ref == tuple_node) {
+      return ExprMutator::VisitExpr_(tuple_node);
     }
     // This tuple is an intermediate node in the group
-    Array<Expr> new_fields = GetNewArguments(tuple->fields, ret_group);
-    return Tuple(new_fields);
+    Array<Expr> new_fields = GetNewArguments(tuple_node->fields, ret_group);
+    return WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields));
   }
 
   Expr Rewrite_(const TupleGetItemNode* tuple_get, const Expr& post) {

--- a/src/relay/transforms/memory_alloc.cc
+++ b/src/relay/transforms/memory_alloc.cc
@@ -87,6 +87,8 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
   Expr VisitExpr_(const TupleNode* tuple_node) final {
     LetList& scope = scopes_.back();
     Array<Expr> new_fields;
+    new_fields.reserve(tuple_node->fields.size());
+
     for (auto field : tuple_node->fields) {
       auto new_field = Mutate(field);
       if (new_field->IsInstance<ConstantNode>()) {

--- a/src/relay/transforms/memory_alloc.cc
+++ b/src/relay/transforms/memory_alloc.cc
@@ -84,10 +84,10 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
   Function Rewrite(const Function& expr) { return Downcast<Function>(Mutate(expr)); }
 
  private:
-  Expr VisitExpr_(const TupleNode* tn) final {
+  Expr VisitExpr_(const TupleNode* tuple_node) final {
     LetList& scope = scopes_.back();
     Array<Expr> new_fields;
-    for (auto field : tn->fields) {
+    for (auto field : tuple_node->fields) {
       auto new_field = Mutate(field);
       if (new_field->IsInstance<ConstantNode>()) {
         Var const_var("const", Type(nullptr));
@@ -95,7 +95,7 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
       }
       new_fields.push_back(new_field);
     }
-    return Tuple(new_fields);
+    return WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields));
   }
 
   void PreVisitLetBlock_(const LetNode* let_node) final { scopes_.emplace_back(); }

--- a/src/relay/transforms/partial_eval.cc
+++ b/src/relay/transforms/partial_eval.cc
@@ -615,6 +615,8 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
       value.push_back(ps);
       expr.push_back(ps->dynamic);
     }
+    // Note(@electriclilies): The partial evaluator seems to do some weird stuff with sharing.
+    // Changing Tuple(expr) to WithFields(op, expr) causes some strange failures.
     return HasStatic(MkSTuple(value), ll->Push(Tuple(expr)));
   }
 

--- a/src/relay/transforms/partial_eval.cc
+++ b/src/relay/transforms/partial_eval.cc
@@ -607,17 +607,15 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
     return HasStatic(MkSTensor(op->data.CopyTo(device_)), ll->Push(GetRef<Expr>(op)));
   }
 
-  PStatic VisitExpr_(const TupleNode* tuple_node, LetList* ll) final {
+  PStatic VisitExpr_(const TupleNode* op, LetList* ll) final {
     std::vector<PStatic> value;
-    tvm::Array<Expr> new_fields;
-    new_fields.reserve(tuple_node->fields.size());
-    for (const Expr& e : tuple_node->fields) {
+    tvm::Array<Expr> expr;
+    for (const Expr& e : op->fields) {
       PStatic ps = VisitExpr(e, ll);
       value.push_back(ps);
-      new_fields.push_back(ps->dynamic);
+      expr.push_back(ps->dynamic);
     }
-    return HasStatic(MkSTuple(value),
-                     ll->Push(WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields))));
+    return HasStatic(MkSTuple(value), ll->Push(Tuple(expr)));
   }
 
   PStatic VisitExpr_(const TupleGetItemNode* op, LetList* ll) final {

--- a/src/relay/transforms/partial_eval.cc
+++ b/src/relay/transforms/partial_eval.cc
@@ -610,6 +610,7 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
   PStatic VisitExpr_(const TupleNode* tuple_node, LetList* ll) final {
     std::vector<PStatic> value;
     tvm::Array<Expr> new_fields;
+    new_fields.reserve(tuple_node->fields.size());
     for (const Expr& e : tuple_node->fields) {
       PStatic ps = VisitExpr(e, ll);
       value.push_back(ps);

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -465,8 +465,8 @@ IRModule FlattenTupleOutputs(IRModule module) {
 
           // Return a tuple of compiler_ends in the place of the tuple that was
           // annotated with a compiler_end.
-          auto out = Tuple(new_fields);
-          return std::move(out);
+          Tuple tuple = GetRef<Tuple>(tn);
+          return WithFields(tuple, new_fields);
         }
       }
       return post;

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -465,8 +465,7 @@ IRModule FlattenTupleOutputs(IRModule module) {
 
           // Return a tuple of compiler_ends in the place of the tuple that was
           // annotated with a compiler_end.
-          Tuple tuple = GetRef<Tuple>(tn);
-          return WithFields(tuple, new_fields);
+          return WithFields(GetRef<Tuple>(tn), new_fields);
         }
       }
       return post;

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -457,6 +457,7 @@ IRModule FlattenTupleOutputs(IRModule module) {
         auto annotated_op = Downcast<Call>(post)->args[0];
         if (const auto* tuple_node = annotated_op.as<TupleNode>()) {
           Array<Expr> new_fields;
+          new_fields.reserve(tuple_node->fields.size());
 
           // Here each input of the tuple will be annotated with compiler_ends
           for (auto& tn_arg : tuple_node->fields) {

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -465,7 +465,7 @@ IRModule FlattenTupleOutputs(IRModule module) {
 
           // Return a tuple of compiler_ends in the place of the tuple that was
           // annotated with a compiler_end.
-          return WithFields(GetRef<Tuple>(tn), new_fields);
+          return WithFields(GetRef<Tuple>(tn), std::move(new_fields));
         }
       }
       return post;

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -455,17 +455,17 @@ IRModule FlattenTupleOutputs(IRModule module) {
         // Arguments of annotation ops should be 1
         ICHECK_EQ(call->args.size(), 1U);
         auto annotated_op = Downcast<Call>(post)->args[0];
-        if (const auto* tn = annotated_op.as<TupleNode>()) {
+        if (const auto* tuple_node = annotated_op.as<TupleNode>()) {
           Array<Expr> new_fields;
 
           // Here each input of the tuple will be annotated with compiler_ends
-          for (auto& tn_arg : tn->fields) {
+          for (auto& tn_arg : tuple_node->fields) {
             new_fields.push_back((*make_end_op)(tn_arg, target));
           }
 
           // Return a tuple of compiler_ends in the place of the tuple that was
           // annotated with a compiler_end.
-          return WithFields(GetRef<Tuple>(tn), std::move(new_fields));
+          return WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields));
         }
       }
       return post;

--- a/src/relay/transforms/split_args.cc
+++ b/src/relay/transforms/split_args.cc
@@ -54,6 +54,8 @@ class ArgumentSplitter : public ExprRewriter {
         int startIdx = i * limit;
         int argsCount = std::min(limit, argsNum - startIdx);
         tvm::Array<Expr> args;
+        args.reserve(argsCount);
+
         for (int j = 0; j < argsCount; ++j) {
           args.push_back(tuple_node->fields[j + startIdx]);
         }

--- a/src/relay/transforms/split_args.cc
+++ b/src/relay/transforms/split_args.cc
@@ -37,14 +37,14 @@ class ArgumentSplitter : public ExprRewriter {
   Expr Rewrite_(const CallNode* call, const Expr& post) final {
     if (max_function_args_ < 0) return post;
     if (call->op == concat_op_) {
-      auto op = call->args[0].as<TupleNode>();
+      auto tuple_node = call->args[0].as<TupleNode>();
       const auto param = call->attrs.as<ConcatenateAttrs>();
       int outputsNum = 1;
       if (const auto* tuple_type = call->checked_type().as<TupleTypeNode>()) {
         outputsNum = tuple_type->fields.size();
       }
       const int limit = max_function_args_ - outputsNum;
-      int argsNum = op->fields.size();
+      int argsNum = tuple_node->fields.size();
       if (argsNum < limit) return post;
       int splitNum = argsNum / limit;
       splitNum = (argsNum % limit) ? splitNum + 1 : splitNum;
@@ -55,15 +55,15 @@ class ArgumentSplitter : public ExprRewriter {
         int argsCount = std::min(limit, argsNum - startIdx);
         tvm::Array<Expr> args;
         for (int j = 0; j < argsCount; ++j) {
-          args.push_back(op->fields[j + startIdx]);
+          args.push_back(tuple_node->fields[j + startIdx]);
         }
-        Tuple tuple(args);
-        Expr body = MakeConcatenate(tuple, param->axis);
+        Tuple new_tuple = WithFields(GetRef<Tuple>(tuple_node), std::move(args));
+        Expr body = MakeConcatenate(new_tuple, param->axis);
         splitted[i] = StopFusion(body);
       }
-      tvm::Array<Expr> tupleArgs(splitted);
-      Tuple tuple(tupleArgs);
-      return MakeConcatenate(tuple, param->axis);
+      tvm::Array<Expr> tuple_args(splitted);
+      Tuple new_tuple = WithFields(GetRef<Tuple>(tuple_node), std::move(tuple_args));
+      return MakeConcatenate(new_tuple, param->axis);
     }
     return post;
   }

--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -248,13 +248,14 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
     return Compound(e, Call(VisitExpr(c->op), args, c->attrs, c->type_args), v);
   }
 
-  Expr VisitExpr_(const TupleNode* t, const Var& v) final {
-    Expr e = GetRef<Expr>(t);
-    std::vector<Expr> fields;
-    for (const auto& a : t->fields) {
+  Expr VisitExpr_(const TupleNode* tuple_node, const Var& v) final {
+    Expr e = GetRef<Expr>(tuple_node);
+    Array<Expr> fields;
+    fields.reserve(tuple_node->fields.size());
+    for (const auto& a : tuple_node->fields) {
       fields.push_back(VisitExpr(a));
     }
-    return Compound(e, Tuple(fields), v);
+    return Compound(e, WithFields(GetRef<Tuple>(tuple_node), std::move(fields)), v);
   }
 
   Expr VisitExpr_(const TupleGetItemNode* t, const Var& v) final {

--- a/src/relay/transforms/to_cps.cc
+++ b/src/relay/transforms/to_cps.cc
@@ -210,13 +210,14 @@ Function ToCPS(const Function& f, const IRModule& m, CPSMap* cm, VarMap* vm,
       });
     }
 
-    Expr VisitExpr_(const TupleNode* op, const MCont& k) final {
+    Expr VisitExpr_(const TupleNode* tuple_node, const MCont& k) final {
       tvm::Array<Expr> fields;
+      fields.reserve(tuple_node->fields.size());
       std::function<Expr()> next;
       next = [&]() {
-        return (fields.size() == op->fields.size())
-                   ? k(Tuple(fields))
-                   : VisitExpr(op->fields[fields.size()], [&](const Expr& v) {
+        return (fields.size() == tuple_node->fields.size())
+                   ? k(WithFields(GetRef<Tuple>(tuple_node), std::move(fields)))
+                   : VisitExpr(tuple_node->fields[fields.size()], [&](const Expr& v) {
                        fields.push_back(v);
                        return next();
                      });

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -32,7 +32,6 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "infer_layout_utils.h"

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "infer_layout_utils.h"


### PR DESCRIPTION
This is a draft PR implementing WithFields on tuples.

WithFields is parallel to WithAttrs in behavior. It returns this* if all the fields passed in are the same as the ones already in this. Otherwise, it creates a copy of the tuple with the new fields. 

The motivation for WithFields is to ensure that spans, checked types, and other fields on nodes are propagated correctly during passes so we can rely on that information. If we decide to go ahead with this change, I will also implement WithFields for all other relay exprs.
