### PR TITLE
[AlterLayout] Respect input layout for `dense` op if explicitly specified

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -210,6 +210,10 @@ InferCorrectLayoutOutput DenseInferCorrectLayout(const Attrs& attrs,
                                                  const Array<Layout>& new_in_layouts,
                                                  const Array<Layout>& old_in_layouts,
                                                  const Array<tvm::relay::Type>& old_in_types) {
+  // Respect input layout, if explicitly specified (for example, "NW").
+  if (new_in_layouts.size() > 0 && new_in_layouts[0].defined()) {
+    return InferCorrectLayoutOutput({new_in_layouts[0], "NC"}, {"NC"}, attrs);
+  }
   return InferCorrectLayoutOutput({"NC", "NC"}, {"NC"}, attrs);
 }
 
@@ -279,6 +283,14 @@ InferCorrectLayoutOutput DensePackInferCorrectLayout(const Attrs& attrs,
                                                      const Array<tvm::relay::Type>& old_in_types) {
   auto params = attrs.as<DensePackAttrs>();
   ICHECK(params);
+  // Respect input layout, if explicitly specified (for example, "NW").
+  // However, a packed layout such as "NC8c" is not supported by dense_pack op. For such cases,
+  // we insert a layout transform "NC8c" -> "NC".
+  // We do not expect to get a packed layout like "NW8w", which is not compatitble with "NC",
+  // since packing is always done on the "C" axis.
+  if (new_in_layouts.size() > 0 && new_in_layouts[0].defined() && new_in_layouts[0].ndim() == 2) {
+    return InferCorrectLayoutOutput({new_in_layouts[0], params->weight_layout}, {"NC"}, attrs);
+  }
   return InferCorrectLayoutOutput({"NC", params->weight_layout}, {"NC"}, attrs);
 }
 


### PR DESCRIPTION
I found a case where the input to `dense` op has a layout `NW`. This happens with the combination of `adaptive_pool1d` having `NCW` layout, followed by `squeeze(..., axis=1`) which removes the second axis. Currently we get an error like:

```
E             Check failed: (tir::BijectiveLayout(new_src_layout, dst_layout).defined()) is false: Cannot insert layout transform because there are inconvertible layouts: NW v.s. NC
```

I updated `InferCorrect` functions to prevent such errors. But by now I've seen `NW vs NC` and `NK vs NC` crashes, maybe we should make those layouts compatible... 

cc @comaniac @yzhliu 