### PR TITLE
[CI.Lint.Black] Use "en_US.UTF-8" for Red Hat 6&7 Compatibility

### DIFF
--- a/tests/lint/git-black.sh
+++ b/tests/lint/git-black.sh
@@ -38,8 +38,8 @@ if [[ "$#" -lt 1 ]]; then
 fi
 
 # required to make black's dep click to work
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
 
 if [ ! -x "$(command -v black)" ]; then
     echo "Cannot find black"


### PR DESCRIPTION
Lots of company use Red Hat Enterprise Linux servers, for RHEL 6 & 7 there isn't "C.UTF-8" locale, and from the bug tracking https://bugzilla.redhat.com/show_bug.cgi?id=1361965, it seems it's hard to fix this bug in RHEL 6 & 7 soon.