### PR TITLE
[TEST] Fix duplicate definition error for gpu export mod testcase

### DIFF
--- a/tests/python/unittest/test_runtime_module_export.py
+++ b/tests/python/unittest/test_runtime_module_export.py
@@ -74,10 +74,10 @@ def test_mod_export():
         synthetic_llvm_mod, synthetic_llvm_params = relay.testing.synthetic.get_workload()
         with tvm.transform.PassContext(opt_level=3):
             _, synthetic_gpu_lib, _ = relay.build_module.build(
-                synthetic_mod, "cuda", params=synthetic_params
+                synthetic_mod, "cuda", params=synthetic_params, mod_name="cudalib"
             )
             _, synthetic_llvm_cpu_lib, _ = relay.build_module.build(
-                synthetic_llvm_mod, "llvm", params=synthetic_llvm_params
+                synthetic_llvm_mod, "llvm", params=synthetic_llvm_params, mod_name="llvmlib"
             )
 
         from tvm.contrib import utils


### PR DESCRIPTION
 `python tests/python/unittest/test_runtime_module_export.py` get error on cuda enabled build:

RuntimeError: Compilation error:
/tmp/tmpnsas97vt/lib1.o: In function `tvmgen_default_fused_nn_softmax_add':
TVMMod:(.text+0x2500): multiple definition of `tvmgen_default_fused_nn_softmax_add'
/tmp/tmpnsas97vt/lib0.o:TVMMod:(.text+0xb40): first defined here
/tmp/tmpnsas97vt/lib1.o: In function `tvmgen_default_fused_nn_softmax_add_add_multiply_add':
TVMMod:(.text+0x2ce0): multiple definition of `tvmgen_default_fused_nn_softmax_add_add_multiply_add'