### PR TITLE
Introduction tutorial formatting fixes

### DIFF
--- a/gallery/tutorial/auto_scheduler_matmul_x86.py
+++ b/gallery/tutorial/auto_scheduler_matmul_x86.py
@@ -81,7 +81,7 @@ def matmul_add(N, L, M, dtype):
 # multiplication, in this case a multiplication of to square matricies of size
 # 1024x1024. We then create a search task with N=L=M=1024 and dtype="float32"
 #
-# .. note:: Improve performance with custom targets
+# .. admonition:: Improve performance with custom targets
 #   In order for TVM to take full advantage of specific hardware platforms,
 #   you will want to manuall specify your CPU capabilities. For example:
 #   - replace "llvm" below with "llvm -mcpu=core-avx2" to enable AVX2

--- a/gallery/tutorial/auto_scheduler_matmul_x86.py
+++ b/gallery/tutorial/auto_scheduler_matmul_x86.py
@@ -106,10 +106,10 @@ print(task.compute_dag)
 #   during the search.  We only make 10 trials in this tutorial for a fast
 #   demonstration. In practice, 1000 is a good value for the search to converge.
 #   You can do more trials according to your time budget.
-# * In addition, we use :any:`RecordToFile` to log measurement records into a
+# * In addition, we use :any:`RecordToFile <auto_scheduler.RecordToFile>` to log measurement records into a
 #   file ``matmul.json``.  The measurement records can be used to query the history
 #   best, resume the search, and do more analyses later.
-# * see :any:`auto_scheduler.TuningOptions` for more parameters
+# * see :any:`TuningOptions <auto_scheduler.TuningOptions>` for more parameters
 
 log_file = "matmul.json"
 tune_option = auto_scheduler.TuningOptions(

--- a/gallery/tutorial/auto_scheduler_matmul_x86.py
+++ b/gallery/tutorial/auto_scheduler_matmul_x86.py
@@ -49,7 +49,7 @@ from tvm import te, auto_scheduler
 # ----------------------------------
 # To start, we define a matrix multiplication with a bias addition.  Note that
 # this uses standard operations available in TVMs Tensor Expression language.
-# The major difference is the use of the `auto_sceduler` decorator at the top
+# The major difference is the use of the :any:`register_workload` decorator at the top
 # of the function definition.  The function should return a list of
 # input/output tensors.  From these tensors, the auto-scheduler can get the
 # whole computational graph.
@@ -82,10 +82,12 @@ def matmul_add(N, L, M, dtype):
 # 1024x1024. We then create a search task with N=L=M=1024 and dtype="float32"
 #
 # .. admonition:: Improve performance with custom targets
+#
 #   In order for TVM to take full advantage of specific hardware platforms,
 #   you will want to manuall specify your CPU capabilities. For example:
-#   - replace "llvm" below with "llvm -mcpu=core-avx2" to enable AVX2
-#   - replace "llvm" below with "llvm -mcpu=skylake-avx512" to enable AVX-512
+#
+#     - replace ``llvm`` below with ``llvm -mcpu=core-avx2`` to enable AVX2
+#     - replace ``llvm`` below with ``llvm -mcpu=skylake-avx512`` to enable AVX-512
 
 target = tvm.target.Target("llvm")
 N = L = M = 1024
@@ -104,8 +106,8 @@ print(task.compute_dag)
 #   during the search.  We only make 10 trials in this tutorial for a fast
 #   demonstration. In practice, 1000 is a good value for the search to converge.
 #   You can do more trials according to your time budget.
-# * In addition, we use :code:`RecordToFile` to log measurement records into a
-#   file `matmul.json`.  The measurement records can be used to query the history
+# * In addition, we use :any:`RecordToFile` to log measurement records into a
+#   file ``matmul.json``.  The measurement records can be used to query the history
 #   best, resume the search, and do more analyses later.
 # * see :any:`auto_scheduler.TuningOptions` for more parameters
 
@@ -172,7 +174,7 @@ print(
 # Using the record file
 # ---------------------
 # During the search, all measurement records are logged into the record file
-# "matmul.json". The measurement records can be used to re-apply search
+# ``matmul.json```. The measurement records can be used to re-apply search
 # results, resume the search, and perform other analyses.
 #
 # Here is an example where we load the best schedule from a file, and print the

--- a/gallery/tutorial/autotvm_matmul_x86.py
+++ b/gallery/tutorial/autotvm_matmul_x86.py
@@ -242,7 +242,7 @@ def matmul(N, L, M, dtype):
 
 
 ################################################################################
-# .. note:: More Explanation on :code:`cfg.define_split`
+# .. admonition:: More Explanation on :code:`cfg.define_split`
 #
 #  In this template, :code:`cfg.define_split("tile_y", y, num_outputs=2)` will
 #  enumerate all possible combinations that can split axis y into two axes with

--- a/gallery/tutorial/autotvm_relay_x86.py
+++ b/gallery/tutorial/autotvm_relay_x86.py
@@ -79,7 +79,7 @@ from tvm.contrib import graph_executor
 # the model and save it to disk. For the instance of an ONNX model, you can
 # then load it into memory using the ONNX runtime.
 #
-# .. note:: Working with Other Model Formats
+# .. admonition:: Working with Other Model Formats
 #
 #   TVM supports many popular model formats. A list can be found in the
 #   :ref:`Compile Deep Learning Models <tutorial-frontend>` section of the TVM
@@ -145,7 +145,7 @@ img_data = np.expand_dims(norm_img_data, axis=0)
 target = "llvm"
 
 ######################################################################
-# .. note:: Defining the Correct Target
+# .. admonition:: Defining the Correct Target
 #
 #   Specifying the correct target can have a huge impact on the performance of
 #   the compiled module, as it can take advantage of hardware features
@@ -331,7 +331,7 @@ tuning_option = {
 }
 
 ################################################################################
-# .. note:: Defining the Tuning Search Algorithm
+# .. admonition:: Defining the Tuning Search Algorithm
 #
 #   By default this search is guided using an `XGBoost Grid` algorithm.
 #   Depending on your model complexity and amount of time available, you might
@@ -339,7 +339,7 @@ tuning_option = {
 
 
 ################################################################################
-# .. note:: Setting Tuning Parameters
+# .. admonition:: Setting Tuning Parameters
 #
 #   In this example, in the interest of time, we set the number of trials and
 #   early stopping to 10. You will likely see more performance improvements if

--- a/gallery/tutorial/autotvm_relay_x86.py
+++ b/gallery/tutorial/autotvm_relay_x86.py
@@ -21,7 +21,7 @@ Compiling and Optimizing a Model with the Python Interface (AutoTVM)
 `Chris Hoge <https://github.com/hogepodge>`_
 
 In the `TVMC Tutorial <tvmc_command_line_driver>`_, we covered how to compile, run, and tune a
-pre-trained vision model, ResNet-50-v2 using the command line interface for
+pre-trained vision model, ResNet-50 v2 using the command line interface for
 TVM, TVMC. TVM is more that just a command-line tool though, it is an
 optimizing framework with APIs available for a number of different languages
 that gives you tremendous flexibility in working with machine learning models.
@@ -30,7 +30,7 @@ In this tutorial we will cover the same ground we did with TVMC, but show how
 it is done with the Python API. Upon completion of this section, we will have
 used the Python API for TVM to accomplish the following tasks:
 
-* Compile a pre-trained ResNet 50 v2 model for the TVM runtime.
+* Compile a pre-trained ResNet-50 v2 model for the TVM runtime.
 * Run a real image through the compiled model, and interpret the output and model
   performance.
 * Tune the model that model on a CPU using TVM.
@@ -67,7 +67,7 @@ from tvm.contrib import graph_executor
 # --------------------------------------
 #
 # For this tutorial, we will be working with ResNet-50 v2. ResNet-50 is a
-# convolutional neural network that is 50-layers deep and designed to classify
+# convolutional neural network that is 50 layers deep and designed to classify
 # images. The model we will be using has been pre-trained on more than a
 # million images with 1000 different classifications. The network has an input
 # image size of 224x224. If you are interested exploring more of how the
@@ -159,7 +159,7 @@ target = "llvm"
 #
 
 # The input name may vary across model types. You can use a tool
-# like netron to check input names
+# like Netron to check input names
 input_name = "data"
 shape_dict = {input_name: img_data.shape}
 
@@ -220,7 +220,7 @@ print(unoptimized)
 # providing output tensors.
 #
 # In our case, we need to run some post-processing to render the outputs from
-# ResNet-50-V2 into a more human-readable form, using the lookup-table provided
+# ResNet-50 v2 into a more human-readable form, using the lookup-table provided
 # for the model.
 
 from scipy.special import softmax
@@ -472,6 +472,6 @@ print("unoptimized: %s" % (unoptimized))
 # demonstrated how to compare the performance of the unoptimized and optimize
 # models.
 #
-# Here we presented a simple example using ResNet 50 V2 locally. However, TVM
+# Here we presented a simple example using ResNet-50 v2 locally. However, TVM
 # supports many more features including cross-compilation, remote execution and
 # profiling/benchmarking.

--- a/gallery/tutorial/install.py
+++ b/gallery/tutorial/install.py
@@ -29,7 +29,7 @@ methods for installing TVM. These include:
 """
 
 ################################################################################
-# Installing from Source
+# Installing From Source
 # ----------------------
 # Installing from source is the recommended method for installing TVM. It will
 # allow you to enable specific features such as GPU support, microcontroller
@@ -41,10 +41,10 @@ methods for installing TVM. These include:
 ################################################################################
 # Installing From Binary Packages
 # --------------------------------
-# You may install convenient third-party binary package distributions to
-# quickly try things out. TLCPack is a thirdparty volunteer community that
-# builds binary packages from TVM source. It offers support matrix with
+# You may install convenient third party binary package distributions to
+# quickly try things out. TLCPack is a third party volunteer community that
+# builds binary packages from TVM source. It offers a support matrix with
 # instructions to install on different platforms, with different features.
-# Checkout  `TLCPack <https://tlcpack.ai>`_ to learn more. Note that the
-# thirdparty binary packages could contain additional licensing terms for
+# Check out  `TLCPack <https://tlcpack.ai>`_ to learn more. Note that the
+# third party binary packages could contain additional licensing terms for
 # the hardware drivers that are bundled with it.

--- a/gallery/tutorial/introduction.py
+++ b/gallery/tutorial/introduction.py
@@ -56,7 +56,7 @@ Contents
 #   :width: 100%
 #   :alt: A High Level View of TVM
 #
-# 1. Import the model from a framework like *Tensorflow*, *Pytorch*, or *Onnx*.
+# 1. Import the model from a framework like *Tensorflow*, *PyTorch*, or *Onnx*.
 #    The importer layer is where TVM can ingest models from other frameworks, like
 #    Tensorflow, PyTorch, or ONNX. The level of support that TVM offers for each
 #    frontend varies as we are constantly improving the open source project. If

--- a/gallery/tutorial/tensor_expr_get_started.py
+++ b/gallery/tutorial/tensor_expr_get_started.py
@@ -52,11 +52,12 @@ import tvm.testing
 from tvm import te
 import numpy as np
 
+################################################################################
 # You will get better performance if you can identify the CPU you are targeting
-# and specify it. If you're using llvm, you can get this information from the
+# and specify it. If you're using LLVM, you can get this information from the
 # command ``llc --version`` to get the CPU type, and you can check
 # ``/proc/cpuinfo`` for additional extensions that your processor might
-# support. For example, you can use "llvm -mcpu=skylake-avx512" for CPUs with
+# support. For example, you can use ``llvm -mcpu=skylake-avx512`` for CPUs with
 # AVX-512 instructions.
 
 tgt = tvm.target.Target(target="llvm", host="llvm")
@@ -88,7 +89,7 @@ C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")
 #   The second argument to the ``te.compute`` method is the function that
 #   performs the computation. In this example, we're using an anonymous function,
 #   also known as a ``lambda`` function, to define the computation, in this case
-#   addition on the ``i``th element of ``A`` and ``B``.
+#   addition on the ``i``\th element of ``A`` and ``B``.
 
 ################################################################################
 # Create a Default Schedule for the Computation
@@ -100,7 +101,7 @@ C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")
 # split across different threads. TVM requires that the user to provide a
 # schedule, which is a description of how the computation should be performed.
 # Scheduling operations within TE can change loop orders, split computations
-# across different threads, group blocks of data together, amongst other
+# across different threads, and group blocks of data together, amongst other
 # operations. An important concept behind schedules is that they only describe
 # how the computation is performed, so different schedules for the same TE will
 # produce the same result.
@@ -125,7 +126,7 @@ s = te.create_schedule(C.op)
 # the target and host, and the name of the function we are producing. The result
 # of the output is a type-erased function that can be called directly from Python.
 #
-# In the following line, we use tvm.build to create a function. The build
+# In the following line, we use ``tvm.build`` to create a function. The build
 # function takes the schedule, the desired signature of the function (including
 # the inputs and outputs) as well as target language we want to compile to.
 

--- a/gallery/tutorial/tensor_expr_get_started.py
+++ b/gallery/tutorial/tensor_expr_get_started.py
@@ -84,7 +84,7 @@ B = te.placeholder((n,), name="B")
 C = te.compute(A.shape, lambda i: A[i] + B[i], name="C")
 
 ################################################################################
-# .. note:: Lambda Functions
+# .. admonition:: Lambda Functions
 #
 #   The second argument to the ``te.compute`` method is the function that
 #   performs the computation. In this example, we're using an anonymous function,
@@ -273,7 +273,7 @@ for result in log:
 
 
 ################################################################################
-# .. note:: Code Specialization
+# .. admonition:: Code Specialization
 #
 #   As you may have noticed, the declarations of ``A``, ``B`` and ``C`` all
 #   take the same shape argument, ``n``. TVM will take advantage of this to
@@ -417,7 +417,7 @@ cc.create_shared(temp.relpath("myadd.so"), [temp.relpath("myadd.o")])
 print(temp.listdir())
 
 ################################################################################
-# .. note:: Module Storage Format
+# .. admonition:: Module Storage Format
 #
 #   The CPU (host) module is directly saved as a shared library (.so). There
 #   can be multiple customized formats of the device code. In our example, the
@@ -461,7 +461,7 @@ fadd2(a, b, c)
 tvm.testing.assert_allclose(c.numpy(), a.numpy() + b.numpy())
 
 ################################################################################
-# .. note:: Runtime API and Thread-Safety
+# .. admonition:: Runtime API and Thread-Safety
 #
 #   The compiled modules of TVM do not depend on the TVM compiler. Instead,
 #   they only depend on a minimum runtime library. The TVM runtime library
@@ -493,7 +493,7 @@ if tgt.kind.name.startswith("opencl"):
     tvm.testing.assert_allclose(c.numpy(), a.numpy() + b.numpy())
 
 ################################################################################
-# .. note:: TE Scheduling Primitives
+# .. admonition:: TE Scheduling Primitives
 #
 #   TVM includes a number of different scheduling primitives:
 #

--- a/gallery/tutorial/tvmc_command_line_driver.py
+++ b/gallery/tutorial/tvmc_command_line_driver.py
@@ -29,7 +29,7 @@ execution of models through a command line interface.
 Upon completion of this section, we will have used TVMC to accomplish the
 following tasks:
 
-* Compile a pre-trained ResNet 50 v2 model for the TVM runtime.
+* Compile a pre-trained ResNet-50 v2 model for the TVM runtime.
 * Run a real image through the compiled model, and interpret the output and
   model performance.
 * Tune the model on a CPU using TVM.
@@ -77,12 +77,12 @@ capabilities, and set the stage for understanding how TVM works.
 # -------------------
 #
 # For this tutorial, we will be working with ResNet-50 v2. ResNet-50 is a
-# convolutional neural network that is 50-layers deep and designed to classify
+# convolutional neural network that is 50 layers deep and designed to classify
 # images. The model we will be using has been pre-trained on more than a
 # million images with 1000 different classifications. The network has an input
 # image size of 224x224. If you are interested exploring more of how the
 # ResNet-50 model is structured, we recommend downloading `Netron
-# <https://netron.app>`, a freely available ML model viewer.
+# <https://netron.app>`_, a freely available ML model viewer.
 #
 # For this tutorial we will be using the model in ONNX format.
 #
@@ -91,18 +91,17 @@ capabilities, and set the stage for understanding how TVM works.
 #   wget https://github.com/onnx/models/raw/master/vision/classification/resnet/model/resnet50-v2-7.onnx
 #
 
-
 ################################################################################
-# .. note:: Supported model formats
+# .. admonition:: Supported model formats
 #
 #   TVMC supports models created with Keras, ONNX, TensorFlow, TFLite
-#   and Torch. Use the option``--model-format`` if you need to
+#   and Torch. Use the option ``--model-format`` if you need to
 #   explicitly provide the model format you are using. See ``tvmc
 #   compile --help`` for more information.
 #
 
 ################################################################################
-# .. note:: Adding ONNX Support to TVM
+# .. admonition:: Adding ONNX Support to TVM
 #
 #    TVM relies on the ONNX python library being available on your system. You can
 #    install ONNX using the command ``pip3 install --user onnx onnxoptimizer``. You
@@ -123,6 +122,7 @@ capabilities, and set the stage for understanding how TVM works.
 #
 # .. code-block:: bash
 #
+#   # This may take several minutes depending on your machine
 #   tvmc compile \
 #   --target "llvm" \
 #   --output resnet50-v2-7-tvm.tar \
@@ -189,8 +189,8 @@ capabilities, and set the stage for understanding how TVM works.
 # Input pre-processing
 # ~~~~~~~~~~~~~~~~~~~~
 #
-# For our ResNet 50 V2 model, the input is expected to be in ImageNet format.
-# Here is an example of a script to pre-process an image for ResNet 50 V2.
+# For our ResNet-50 v2 model, the input is expected to be in ImageNet format.
+# Here is an example of a script to pre-process an image for ResNet-50 v2.
 #
 # You will need to have a supported version of the Python Image Library
 # installed. You can use ``pip3 install --user pillow`` to satisfy this
@@ -220,7 +220,7 @@ capabilities, and set the stage for understanding how TVM works.
 #     imagenet_stddev = np.array([0.229, 0.224, 0.225])
 #     norm_img_data = np.zeros(img_data.shape).astype("float32")
 #     for i in range(img_data.shape[0]):
-#    	    norm_img_data[i, :, :] = (img_data[i, :, :] / 255 - imagenet_mean[i]) / imagenet_stddev[i]
+#    	  norm_img_data[i, :, :] = (img_data[i, :, :] / 255 - imagenet_mean[i]) / imagenet_stddev[i]
 #
 #     # Add batch dimension
 #     img_data = np.expand_dims(norm_img_data, axis=0)
@@ -243,7 +243,7 @@ capabilities, and set the stage for understanding how TVM works.
 #     --output predictions.npz \
 #     resnet50-v2-7-tvm.tar
 #
-# Recall that the `.tar` model file includes a C++ library, a description of
+# Recall that the ``.tar`` model file includes a C++ library, a description of
 # the Relay model, and the parameters for the model. TVMC includes the TVM
 # runtime, which can load the model and make predictions against input. When
 # running the above command, TVMC outputs a new file, ``predictions.npz``, that
@@ -261,7 +261,7 @@ capabilities, and set the stage for understanding how TVM works.
 # providing output tensors.
 #
 # In our case, we need to run some post-processing to render the outputs from
-# ResNet 50 V2 into a more human-readable form, using the lookup-table provided
+# ResNet-50 v2 into a more human-readable form, using the lookup-table provided
 # for the model.
 #
 # The script below shows an example of the post-processing to extract labels
@@ -303,7 +303,6 @@ capabilities, and set the stage for understanding how TVM works.
 # .. code-block:: bash
 #
 #     python postprocess.py
-#
 #     # class='n02123045 tabby, tabby cat' with probability=0.610553
 #     # class='n02123159 tiger cat' with probability=0.367179
 #     # class='n02124075 Egyptian cat' with probability=0.019365
@@ -343,14 +342,18 @@ capabilities, and set the stage for understanding how TVM works.
 #
 # .. code-block:: bash
 #
+#     # The default search algorithm requires xgboost, see below for further
+#     # details on tuning search algorithms
+#     pip install xgboost
+#
 #     tvmc tune \
 #     --target "llvm" \
 #     --output resnet50-v2-7-autotuner_records.json \
 #     resnet50-v2-7.onnx
 #
 # In this example, you will see better results if you indicate a more specific
-# target for the `--target` flag.  For example, on an Intel i7 processor you
-# could use `--target llvm -mcpu=skylake`. For this tuning example, we are
+# target for the ``--target`` flag.  For example, on an Intel i7 processor you
+# could use ``--target llvm -mcpu=skylake``. For this tuning example, we are
 # tuning locally on the CPU using LLVM as the compiler for the specified
 # achitecture.
 #
@@ -359,12 +362,12 @@ capabilities, and set the stage for understanding how TVM works.
 # fastest on your platform. Although this is a guided search based on the CPU
 # and model operations, it can still take several hours to complete the search.
 # The output of this search will be saved to the
-# `resnet50-v2-7-autotuner_records.json` file, which will later be used to
+# ``resnet50-v2-7-autotuner_records.json`` file, which will later be used to
 # compile an optimized model.
 #
 # .. note:: Defining the Tuning Search Algorithm
 #
-#   By default this search is guided using an `XGBoost Grid` algorithm.
+#   By default this search is guided using an ``XGBoost Grid`` algorithm.
 #   Depending on your model complexity and amount of time avilable, you might
 #   want to choose a different algorithm. A full list is available by
 #   consulting ``tvmc tune --help``.
@@ -373,7 +376,10 @@ capabilities, and set the stage for understanding how TVM works.
 #
 # .. code-block:: bash
 #
-#   tvmc tune   --target "llvm -mcpu=broadwell"   --output resnet50-v2-7-autotuner_records.json   resnet50-v2-7.onnx
+#   tvmc tune \
+#   --target "llvm -mcpu=broadwell" \
+#   --output resnet50-v2-7-autotuner_records.json \
+#   resnet50-v2-7.onnx
 #   # [Task  1/24]  Current/Best:    9.65/  23.16 GFLOPS | Progress: (60/1000) | 130.74 s Done.
 #   # [Task  1/24]  Current/Best:    3.56/  23.16 GFLOPS | Progress: (192/1000) | 381.32 s Done.
 #   # [Task  2/24]  Current/Best:   13.13/  58.61 GFLOPS | Progress: (960/1000) | 1190.59 s Done.
@@ -498,7 +504,7 @@ capabilities, and set the stage for understanding how TVM works.
 # process, we demonstrated how to compare the performance of the unoptimized
 # and optimize models.
 #
-# Here we presented a simple example using ResNet 50 V2 locally. However, TVMC
+# Here we presented a simple example using ResNet-50 v2 locally. However, TVMC
 # supports many more features including cross-compilation, remote execution and
 # profiling/benchmarking.
 #

--- a/gallery/tutorial/tvmc_command_line_driver.py
+++ b/gallery/tutorial/tvmc_command_line_driver.py
@@ -149,7 +149,7 @@ capabilities, and set the stage for understanding how TVM works.
 
 
 ################################################################################
-# .. note:: Defining the Correct Target
+# .. admonition:: Defining the Correct Target
 #
 #   Specifying the correct target (option ``--target``) can have a huge
 #   impact on the performance of the compiled module, as it can take
@@ -365,7 +365,7 @@ capabilities, and set the stage for understanding how TVM works.
 # ``resnet50-v2-7-autotuner_records.json`` file, which will later be used to
 # compile an optimized model.
 #
-# .. note:: Defining the Tuning Search Algorithm
+# .. admonition:: Defining the Tuning Search Algorithm
 #
 #   By default this search is guided using an ``XGBoost Grid`` algorithm.
 #   Depending on your model complexity and amount of time avilable, you might

--- a/python/tvm/target/codegen.py
+++ b/python/tvm/target/codegen.py
@@ -73,4 +73,4 @@ def llvm_version_major(allow_none=False):
     except AttributeError:
         if allow_none:
             return None
-        raise RuntimeError("LLVM version is not available, please check if you build with LLVM")
+        raise RuntimeError("LLVM version is not available, please check if you built TVM with LLVM")


### PR DESCRIPTION
This fixes some rST issues I noticed while going through the getting started tutorial. Some of these shouldn't be too controversial like using \` instead of `` and consistency fixes. I noticed lots of the `.. note:`s have titles even though they don't really render as anything special in Sphinx, but the base `.. admonition:` does render the title in the top line. This looks nicer IMO and wastes less space but it could go either way, I didn't change it in all places yet either until others agree.

Before:

![image](https://user-images.githubusercontent.com/9407960/142671849-b09cb0c0-5b1e-488e-a54a-023070493388.png)

After:

![image](https://user-images.githubusercontent.com/9407960/142671862-41f5925f-40bd-4cfe-af94-6513a075eed6.png)


Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

@areusch 