### PR TITLE
[Relay] Fix CUDA batchmatmul strategy to allow mixed precision

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -839,7 +839,7 @@ def batch_matmul_strategy_cuda(attrs, inputs, out_type, target):
         )
     else:
         strategy.add_implementation(
-            wrap_compute_batch_matmul(topi.cuda.batch_matmul),
+            wrap_compute_batch_matmul(topi.cuda.batch_matmul, need_out_dtype=True),
             wrap_topi_schedule(topi.cuda.schedule_batch_matmul),
             name="batch_matmul.cuda",
             plevel=10,


### PR DESCRIPTION
In the past, mixed precision workloads for cuda-batchmatmul were removed for some reason. This allows this to occur. Honestly don't know why its this way but we need this for https://github.com/apache/tvm/pull/9186