### PR TITLE
[Target] enable -arch=sm_xx for assigning cuda target arch and deprecate autotvm.measure.set_cuda_target_arch api

### DIFF
--- a/apps/topi_recipe/broadcast/test_broadcast_map.py
+++ b/apps/topi_recipe/broadcast/test_broadcast_map.py
@@ -27,7 +27,7 @@ TASK = "reduce_map"
 USE_MANUAL_CODE = False
 
 
-@tvm.register_func
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
 def tvm_callback_cuda_compile(code):
     ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx

--- a/apps/topi_recipe/broadcast/test_broadcast_map.py
+++ b/apps/topi_recipe/broadcast/test_broadcast_map.py
@@ -29,7 +29,7 @@ USE_MANUAL_CODE = False
 
 @tvm.register_func
 def tvm_callback_cuda_compile(code):
-    ptx = nvcc.compile_cuda(code, target="ptx")
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx
 
 

--- a/apps/topi_recipe/conv/depthwise_conv2d_test.py
+++ b/apps/topi_recipe/conv/depthwise_conv2d_test.py
@@ -34,7 +34,7 @@ USE_MANUAL_CODE = False
 
 @tvm.register_func
 def tvm_callback_cuda_compile(code):
-    ptx = nvcc.compile_cuda(code, target="ptx")
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx
 
 

--- a/apps/topi_recipe/conv/depthwise_conv2d_test.py
+++ b/apps/topi_recipe/conv/depthwise_conv2d_test.py
@@ -32,7 +32,7 @@ TASK = "depthwise_conv2d"
 USE_MANUAL_CODE = False
 
 
-@tvm.register_func
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
 def tvm_callback_cuda_compile(code):
     ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx

--- a/apps/topi_recipe/conv/test_conv2d_hwcn_map.py
+++ b/apps/topi_recipe/conv/test_conv2d_hwcn_map.py
@@ -30,7 +30,7 @@ USE_MANUAL_CODE = False
 
 @tvm.register_func
 def tvm_callback_cuda_compile(code):
-    ptx = nvcc.compile_cuda(code, target="ptx")
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx
 
 

--- a/apps/topi_recipe/conv/test_conv2d_hwcn_map.py
+++ b/apps/topi_recipe/conv/test_conv2d_hwcn_map.py
@@ -28,7 +28,7 @@ TASK = "conv2d_hwcn_map"
 USE_MANUAL_CODE = False
 
 
-@tvm.register_func
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
 def tvm_callback_cuda_compile(code):
     ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx

--- a/apps/topi_recipe/gemm/cuda_gemm_square.py
+++ b/apps/topi_recipe/gemm/cuda_gemm_square.py
@@ -27,7 +27,7 @@ TASK = "gemm"
 USE_MANUAL_CODE = False
 
 
-@tvm.register_func
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
 def tvm_callback_cuda_compile(code):
     ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx

--- a/apps/topi_recipe/gemm/cuda_gemm_square.py
+++ b/apps/topi_recipe/gemm/cuda_gemm_square.py
@@ -29,7 +29,7 @@ USE_MANUAL_CODE = False
 
 @tvm.register_func
 def tvm_callback_cuda_compile(code):
-    ptx = nvcc.compile_cuda(code, target="ptx")
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx
 
 

--- a/apps/topi_recipe/rnn/lstm.py
+++ b/apps/topi_recipe/rnn/lstm.py
@@ -33,7 +33,7 @@ UNROLL_WLOAD = True
 @tvm.register_func
 def tvm_callback_cuda_compile(code):
     """Use nvcc compiler for better perf."""
-    ptx = nvcc.compile_cuda(code, target="ptx")
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx
 
 

--- a/apps/topi_recipe/rnn/lstm.py
+++ b/apps/topi_recipe/rnn/lstm.py
@@ -30,7 +30,7 @@ SKIP_CHECK = False
 UNROLL_WLOAD = True
 
 
-@tvm.register_func
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
 def tvm_callback_cuda_compile(code):
     """Use nvcc compiler for better perf."""
     ptx = nvcc.compile_cuda(code, target_format="ptx")

--- a/apps/topi_recipe/rnn/matexp.py
+++ b/apps/topi_recipe/rnn/matexp.py
@@ -42,7 +42,7 @@ SKIP_CHECK = False
 @tvm.register_func
 def tvm_callback_cuda_compile(code):
     """Use nvcc compiler for better perf."""
-    ptx = nvcc.compile_cuda(code, target="ptx")
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
     return ptx
 
 

--- a/apps/topi_recipe/rnn/matexp.py
+++ b/apps/topi_recipe/rnn/matexp.py
@@ -39,7 +39,7 @@ DETECT_GLOBAL_BARRIER = PERSIST_KERNEL
 SKIP_CHECK = False
 
 
-@tvm.register_func
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
 def tvm_callback_cuda_compile(code):
     """Use nvcc compiler for better perf."""
     ptx = nvcc.compile_cuda(code, target_format="ptx")

--- a/jvm/core/src/test/scripts/test_add_gpu.py
+++ b/jvm/core/src/test/scripts/test_add_gpu.py
@@ -18,7 +18,13 @@ import os
 
 import tvm
 from tvm import te
-from tvm.contrib import cc, utils
+from tvm.contrib import cc, utils, nvcc
+
+
+@tvm.register_func("tvm_callback_cuda_compile", override=True)
+def tvm_callback_cuda_compile(code):
+    ptx = nvcc.compile_cuda(code, target_format="ptx")
+    return ptx
 
 
 def test_add(target_dir):

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -42,7 +42,6 @@ import tvm._ffi
 from tvm.runtime import Object, module, ndarray
 from tvm.driver import build_module
 from tvm.ir import transform
-from tvm.autotvm.measure.measure_methods import set_cuda_target_arch
 from tvm.autotvm.env import AutotvmGlobalScope, reset_global_scope
 from tvm.contrib import tar, ndk
 from tvm.contrib.popen_pool import PopenWorker, PopenPoolExecutor, StatusKind
@@ -550,10 +549,6 @@ class LocalRPCMeasureContext:
         from tvm.rpc.tracker import Tracker
         from tvm.rpc.server import Server
 
-        dev = tvm.device("cuda", 0)
-        if dev.exist:
-            cuda_arch = "sm_" + "".join(dev.compute_version.split("."))
-            set_cuda_target_arch(cuda_arch)
         self.tracker = Tracker(port=9000, port_end=10000, silent=True)
         device_key = "$local$device$%d" % self.tracker.port
         self.server = Server(

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -24,7 +24,6 @@ class AutotvmGlobalScope(object):
         self._old = AutotvmGlobalScope.current
         AutotvmGlobalScope.current = self
 
-        self.cuda_target_arch = None
         self.in_tuning = False
         self.silent = False
 

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -39,7 +39,7 @@ import tvm.ir.transform
 from tvm import nd
 from tvm import rpc as _rpc
 from tvm.autotvm.env import AutotvmGlobalScope, reset_global_scope
-from tvm.contrib import ndk, nvcc, stackvm, tar
+from tvm.contrib import ndk, stackvm, tar
 from tvm.contrib.popen_pool import PopenPoolExecutor
 from tvm.driver import build
 from tvm.error import TVMError
@@ -460,9 +460,7 @@ class LocalRunner(RPCRunner):
         return server, tracker
 
 
-def _build_func_common(
-    measure_input, runtime=None, check_gpu=None, build_option=None
-):
+def _build_func_common(measure_input, runtime=None, check_gpu=None, build_option=None):
     """Common part for building a configuration"""
     target, task, config = measure_input
     target, task.target_host = Target.check_and_update_host_consist(target, task.target_host)

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -38,19 +38,13 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
         The cuda code.
 
     target_format : str
-        The target format of nvcc compiler
+        The target format of nvcc compiler.
 
     arch : str
         The cuda architecture.
-        If None, then it will use `tvm.target.Target.current().arch`.
-        Target arch could be a str as "sm_xx",
-        or a list, such as [
-          "-gencode", "arch=compute_52,code=sm_52",
-          "-gencode", "arch=compute_70,code=sm_70"
-        ]
 
     options : str or list of str
-        The additional options
+        The additional options.
 
     path_target : str, optional
         Output file.
@@ -61,6 +55,12 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
         The bytearray of the cubin
     """
     if arch is None:
+        # If None, then it will use `tvm.target.Target.current().arch`.
+        # Target arch could be a str like "sm_xx", or a list, such as
+        # [
+        #   "-gencode", "arch=compute_52,code=sm_52",
+        #   "-gencode", "arch=compute_70,code=sm_70"
+        # ]
         compute_version = "".join(
             get_target_compute_version(Target.current(allow_none=True)).split(".")
         )

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -23,7 +23,6 @@ import os
 import warnings
 
 import tvm._ffi
-from tvm.runtime import ndarray as nd
 from tvm.target import Target
 
 from . import utils

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -24,12 +24,13 @@ import warnings
 
 import tvm._ffi
 from tvm.runtime import ndarray as nd
+from tvm.target import Target
 
 from . import utils
 from .._ffi.base import py_str
 
 
-def compile_cuda(code, target="ptx", arch=None, options=None, path_target=None):
+def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target=None):
     """Compile cuda code with NVCC from env.
 
     Parameters
@@ -37,11 +38,17 @@ def compile_cuda(code, target="ptx", arch=None, options=None, path_target=None):
     code : str
         The cuda code.
 
-    target : str
-        The target format
+    target_format : str
+        The target format of nvcc compiler
 
     arch : str
-        The architecture
+        The cuda architecture.
+        If None, then it will use `tvm.target.Target.current().arch`.
+        Target arch could be a str as "sm_xx",
+        or a list, such as [
+          "-gencode", "arch=compute_52,code=sm_52",
+          "-gencode", "arch=compute_70,code=sm_70"
+        ]
 
     options : str or list of str
         The additional options
@@ -54,28 +61,27 @@ def compile_cuda(code, target="ptx", arch=None, options=None, path_target=None):
     cubin : bytearray
         The bytearray of the cubin
     """
+    if arch is None:
+        compute_version = "".join(
+            get_target_compute_version(Target.current(allow_none=True)).split(".")
+        )
+        arch = ["-gencode", f"arch=compute_{compute_version},code=sm_{compute_version}"]
+
     temp = utils.tempdir()
-    if target not in ["cubin", "ptx", "fatbin"]:
-        raise ValueError("target must be in cubin, ptx, fatbin")
+    if target_format not in ["cubin", "ptx", "fatbin"]:
+        raise ValueError("target_format must be in cubin, ptx, fatbin")
     temp_code = temp.relpath("my_kernel.cu")
-    temp_target = temp.relpath("my_kernel.%s" % target)
+    temp_target = temp.relpath("my_kernel.%s" % target_format)
 
     with open(temp_code, "w") as out_file:
         out_file.write(code)
 
-    if arch is None:
-        if nd.cuda(0).exist:
-            # auto detect the compute arch argument
-            arch = "sm_" + "".join(nd.cuda(0).compute_version.split("."))
-        else:
-            raise ValueError("arch(sm_xy) is not passed, and we cannot detect it from env")
-
     file_target = path_target if path_target else temp_target
     cmd = ["nvcc"]
-    cmd += ["--%s" % target, "-O3"]
+    cmd += ["--%s" % target_format, "-O3"]
     if isinstance(arch, list):
         cmd += arch
-    else:
+    elif isinstance(arch, str):
         cmd += ["-arch", arch]
 
     if options:
@@ -172,6 +178,13 @@ def get_cuda_version(cuda_path):
     raise RuntimeError("Cannot read cuda version file")
 
 
+@tvm._ffi.register_func
+def tvm_callback_cuda_compile(code):
+    """use nvcc to generate fatbin code for better optimization"""
+    ptx = compile_cuda(code, target_format="fatbin")
+    return ptx
+
+
 @tvm._ffi.register_func("tvm_callback_libdevice_path")
 def find_libdevice_path(arch):
     """Utility function to find libdevice
@@ -221,8 +234,8 @@ def callback_libdevice_path(arch):
 def get_target_compute_version(target=None):
     """Utility function to get compute capability of compilation target.
 
-    Looks for the arch in three different places, first in the target attributes, then the global
-    scope, and finally the GPU device (if it exists).
+    Looks for the target arch in three different places, first in the target input, then the
+    Target.current() scope, and finally the GPU device (if it exists).
 
     Parameters
     ----------
@@ -232,31 +245,23 @@ def get_target_compute_version(target=None):
     Returns
     -------
     compute_version : str
-        compute capability of a GPU (e.g. "8.0")
+        compute capability of a GPU (e.g. "8.6")
     """
-    # 1. Target
-    if target:
-        if "arch" in target.attrs:
-            compute_version = target.attrs["arch"]
-            major, minor = compute_version.split("_")[1]
-            return major + "." + minor
-
-    # 2. Global scope
-    from tvm.autotvm.env import AutotvmGlobalScope  # pylint: disable=import-outside-toplevel
-
-    if AutotvmGlobalScope.current.cuda_target_arch:
-        major, minor = AutotvmGlobalScope.current.cuda_target_arch.split("_")[1]
+    # 1. input target object
+    # 2. Target.current()
+    target = target or Target.current()
+    if target and target.arch:
+        major, minor = target.arch.split("_")[1]
         return major + "." + minor
 
-    # 3. GPU
+    # 3. GPU compute version
     if tvm.cuda(0).exist:
         return tvm.cuda(0).compute_version
 
-    warnings.warn(
+    raise ValueError(
         "No CUDA architecture was specified or GPU detected."
         "Try specifying it by adding '-arch=sm_xx' to your target."
     )
-    return None
 
 
 def parse_compute_version(compute_version):

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -206,13 +206,9 @@ def default_build(mod: IRModule, target: Target) -> Module:
         The built Module.
     """
     # pylint: disable=import-outside-toplevel
-    from tvm.autotvm.measure.measure_methods import set_cuda_target_arch
     from tvm.driver import build as tvm_build
 
     # pylint: enable=import-outside-toplevel
-
-    if target.kind.name == "cuda":
-        set_cuda_target_arch(target.attrs["arch"])
 
     return tvm_build(mod, target=target)
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -140,11 +140,18 @@ class Target(Object):
         return _ffi_api.TargetCurrent(allow_none)
 
     @property
+    def arch(self):
+        """Returns the cuda arch from the target if it exists."""
+        return str(self.attrs.get("arch", ""))
+
+    @property
     def max_num_threads(self):
+        """Returns the max_num_threads from the target if it exists."""
         return int(self.attrs["max_num_threads"])
 
     @property
     def thread_warp_size(self):
+        """Returns the thread_warp_size from the target if it exists."""
         return int(self.attrs["thread_warp_size"])
 
     @property

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -242,6 +242,8 @@ def cuda(model="unknown", arch=None, options=None):
     ----------
     model: str
         The model of cuda device (e.g. 1080ti)
+    arch: str
+        The cuda architecture (e.g. sm_61)
     options : str or list of str
         Additional options
     """

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -235,7 +235,7 @@ def _merge_opts(opts, new_opts):
     return opts
 
 
-def cuda(model="unknown", options=None):
+def cuda(model="unknown", arch=None, options=None):
     """Returns a cuda target.
 
     Parameters
@@ -246,6 +246,10 @@ def cuda(model="unknown", options=None):
         Additional options
     """
     opts = _merge_opts(["-model=%s" % model], options)
+    if arch:
+        opts = _merge_opts(["-arch=%s" % arch], opts)
+    if not any(["-arch" in opts]):
+        warnings.warn("Try specifying cuda arch by adding '-arch=sm_xx' to your target.")
     return Target(" ".join(["cuda"] + opts))
 
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -250,8 +250,8 @@ def cuda(model="unknown", arch=None, options=None):
     opts = _merge_opts(["-model=%s" % model], options)
     if arch:
         opts = _merge_opts(["-arch=%s" % arch], opts)
-    if not any(["-arch" in opts]):
-        warnings.warn("Try specifying cuda arch by adding '-arch=sm_xx' to your target.")
+    if not any(["-arch" in opt for opt in opts]):
+        warnings.warn("Try specifying cuda arch by adding 'arch=sm_xx' to your target.")
     return Target(" ".join(["cuda"] + opts))
 
 

--- a/src/target/opt/build_cuda_on.cc
+++ b/src/target/opt/build_cuda_on.cc
@@ -147,6 +147,8 @@ runtime::Module BuildCUDA(IRModule mod, Target target) {
   }
   std::string fmt = "ptx";
   std::string ptx;
+  const auto* f_enter = Registry::Get("target.TargetEnterScope");
+  (*f_enter)(target);
   if (const auto* f = Registry::Get("tvm_callback_cuda_compile")) {
     ptx = (*f)(code).operator std::string();
     // Dirty matching to check PTX vs cubin.
@@ -155,6 +157,8 @@ runtime::Module BuildCUDA(IRModule mod, Target target) {
   } else {
     ptx = NVRTCCompile(code, cg.need_include_path());
   }
+  const auto* f_exit = Registry::Get("target.TargetExitScope");
+  (*f_exit)(target);
   return CUDAModuleCreate(ptx, fmt, ExtractFuncInfo(mod), code);
 }
 

--- a/tests/python/integration/test_ewise.py
+++ b/tests/python/integration/test_ewise.py
@@ -281,7 +281,7 @@ def try_warp_memory():
     xo, xi = s[AA].split(s[AA].op.axis[0], warp_size)
     s[AA].bind(xi, tx)
 
-    @tvm.register_func
+    @tvm.register_func("tvm_callback_cuda_compile", override=True)
     def tvm_callback_cuda_compile(code):
         ptx = nvcc.compile_cuda(code, target_format="ptx")
         return ptx

--- a/tests/python/integration/test_ewise.py
+++ b/tests/python/integration/test_ewise.py
@@ -283,7 +283,7 @@ def try_warp_memory():
 
     @tvm.register_func
     def tvm_callback_cuda_compile(code):
-        ptx = nvcc.compile_cuda(code, target="ptx")
+        ptx = nvcc.compile_cuda(code, target_format="ptx")
         return ptx
 
     # one line to build the function.


### PR DESCRIPTION
This PR aims to find a better way to set cuda arch.

The old style of setting cuda arch is too weird. You can only set cuda arch through 
```python
from tvm.autotvm.measure.measure_methods import set_cuda_target_arch
set_cuda_target_arch('sm_75')
```
This is quite confusing because setting cuda arch has nothing to do with autotvm. (Please refer to the troubleshooting topic [Nvcc fatal : Value ‘sm_86’ is not defined for option ‘gpu-architecture’](https://discuss.tvm.apache.org/t/nvcc-fatal-value-sm-86-is-not-defined-for-option-gpu-architecture/11422/7) in TVM Disscuss for more.)

Therefore, we will deprecate`set_cuda_target_arch` api and bind `arch` attribute to `tvm.target.Target` object. The new style of setting cuda arch will be like,
```python
>>> target = tvm.target.Target("cuda -arch=sm_75")  # or
>>> target = tvm.target.cuda(model="2080ti", arch="sm_75")
>>> target.arch
sm_75
```
If `-arch` attribute is not set, `target.arch` will set to the compute version of the first CUDA GPU by default. However, If your cuda version is too old, you may encounter errors during compilation. 

Thus, it is strongly recommended to attach the cuda arch directly onto the Target object.