### PR TITLE
[Relay][Frontend] Prune redundant logging

### DIFF
--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -39,9 +39,8 @@ class DuplicateFilter:
         self.msgs = set()
 
     def filter(self, record):
-        rv = record.msg not in self.msgs
         self.msgs.add(record.msg)
-        return rv
+        return record.msg not in self.msgs
 
 
 # pylint: disable=invalid-name

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -31,8 +31,22 @@ from .. import op as _op
 from .. import ty as _ty
 from .. import analysis
 
+
+class DuplicateFilter:
+    """A log filter that only prints the same message once."""
+
+    def __init__(self):
+        self.msgs = set()
+
+    def filter(self, record):
+        rv = record.msg not in self.msgs
+        self.msgs.add(record.msg)
+        return rv
+
+
 # pylint: disable=invalid-name
-logger = logging.getLogger("Common")
+logger = logging.getLogger("Frontend")
+logger.addFilter(DuplicateFilter())
 # Uncomment below line to print all debug msgs
 # logger.setLevel(logging.DEBUG)
 

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=invalid-name, import-outside-toplevel
 """ Functions to convert quantized torch models to QNN """
-import logging
 
 import numpy as np
 import tvm
@@ -25,6 +24,7 @@ from tvm.relay import expr as _expr
 from tvm.relay import op as _op
 from tvm.relay.frontend.common import infer_shape
 
+from .common import logger
 from .pytorch_utils import is_version_greater_than
 
 
@@ -776,7 +776,7 @@ def _binop(relay_op, with_relu=False, fp32_piggy_back=False):
         input_zero_point_rhs = _expr.const(inputs[7])
 
         if fp32_piggy_back:
-            logging.info("Piggy backing to FP32 op (PyTorch way)")
+            logger.info("Piggy backing to FP32 op (PyTorch way)")
             return torch_impl(
                 lhs,
                 rhs,


### PR DESCRIPTION
This is a small patch to remove duplicated logging messages in Relay frontends. For example, without this PR, we will see the following messages from the PyTorch frontend:

```
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
WARNING:root:Untyped Tensor found, assume it is float32
Incompatible broadcast type TensorType([32, 784, 768], float32) and TensorType([1, 512, 768], float32)
The type inference pass was unable to infer a type for this expression.
This usually occurs when an operator call is under constrained in some way, check other reported errors for hints of what may of happened.
note: run with `TVM_BACKTRACE=1` environment variable to display a backtrace.
```

With this PR:

```
Untyped Tensor found, assume it is float32
Incompatible broadcast type TensorType([32, 784, 768], float32) and TensorType([1, 512, 768], float32)
The type inference pass was unable to infer a type for this expression.
This usually occurs when an operator call is under constrained in some way, check other reported errors for hints of what may of happened.
note: run with `TVM_BACKTRACE=1` environment variable to display a backtrace.
```

Note that I only implemented and applied this logging mechanism in Relay frontends because I don't want the DuplicateFileter to cache all messages during the TVM execution.

cc @masahi 