### PR TITLE
Fix Jenkins skip for CPU/GPU

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -324,7 +324,7 @@ stage('Unit Test') {
           }
         }
       } else {
-        Utils.markStageSkippedForConditional('python3: i386')
+        Utils.markStageSkippedForConditional('python3: GPU')
       }
     },
     'python3: CPU': {
@@ -341,7 +341,7 @@ stage('Unit Test') {
           }
         }
       } else {
-        Utils.markStageSkippedForConditional('python3: i386')
+        Utils.markStageSkippedForConditional('python3: CPU')
       }
     },
     'python3: i386': {


### PR DESCRIPTION
Each step should be checking the docs-only build and marking itself as skipped if necessary, these two were skipping the i386 step instead.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

@areusch 