### PR TITLE
[Relay] Prepare for switching VM to LowerTEPass.

### DIFF
--- a/include/tvm/parser/parser.h
+++ b/include/tvm/parser/parser.h
@@ -20,10 +20,11 @@
 #ifndef TVM_PARSER_PARSER_H_
 #define TVM_PARSER_PARSER_H_
 /*!
- * \file parser.h
+ * \file include/tvm/parser/parser.h
  * \brief A parser for TVM IR.
  */
 #include <tvm/ir/module.h>
+#include <tvm/ir/transform.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
 
@@ -38,6 +39,13 @@ using MetaTable = Map<String, Array<ObjectRef>>;
 IRModule ParseModule(const std::string& file_name, const std::string& file_content,
                      const Optional<IRModule>& init_module = Optional<IRModule>(),
                      const MetaTable& init_meta_table = MetaTable());
+
+/*!
+ * \brief This pass pretty-prints mod then parses it back so as to establish spans and sources
+ * for all Relay sub-expressions. This improves error and debugging diagnostics downstream for
+ * modules constructed programaticaly rather than textually.
+ */
+transform::Pass AnnotateSpans();
 
 }  // namespace parser
 }  // namespace tvm

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -145,6 +145,13 @@ class Executable : public ModuleNode {
   std::string GetVirtualDevices() const;
 
   /*!
+   * \brief Returns a description of all the 'primitive' (ie PackedFuncs) in the executable.
+   * These correspond to eithed PrimFuncs we've compiled locally, or functions compiled by
+   * a BYOC external codegen.
+   */
+  std::string GetPrimitives() const;
+
+  /*!
    * \brief Print the detailed statistics of the given code, i.e. number of
    * globls and constants, etc.
    */
@@ -201,9 +208,9 @@ class Executable : public ModuleNode {
   int host_device_index = -1;
   /*! \brief The global constant pool. */
   std::vector<ObjectRef> constants;
-  /*! \brief A map from globals (as strings) to their index in the function map. */
+  /*! \brief A map from globals (as strings) to their index in the Relay function map. */
   std::unordered_map<std::string, Index> global_map;
-  /*! \brief A mapping from the packed function (as string) to the index that
+  /*! \brief A mapping from the packed function's global name (as string) to the index that
    * corresponds to the position of the `packed_funcs` list in a `VirtualMachine` object.
    */
   std::unordered_map<std::string, Index> primitive_map;

--- a/include/tvm/target/compilation_config.h
+++ b/include/tvm/target/compilation_config.h
@@ -32,7 +32,7 @@ namespace tvm {
 
 /*!
  * \brief Gathers the \p Targets and distinguished \p SEScopes in canonical form needed to
- * compile a Relay module. All centralizes any setup and validation logic needed to transition
+ * compile a Relay module. Centralizes any setup and validation logic needed to transition
  * from configuration options conveyed implicitly (eg in \p PassContexts) or explicitly
  * (eg a a list of \p Targets) to the configuration.
  *
@@ -49,9 +49,12 @@ namespace tvm {
 class CompilationConfigNode : public Object {
  public:
   /*!
-   * \brief The legacy targets map, mapping device type to \p Targets. Does not include any
-   * entry for the host target. Intended to give a unique \p Target for every \p DLDeviceType,
-   * though we want to get rid of that limitation.
+   * \brief The legacy targets map, mapping device type to the corresponding \p Target to use
+   * when compiling primitive functions. Does not include an entry for the host target, however
+   * each \p Target in this map will have it's \p host field set to the \p host_target.
+   *
+   * Currently we require at most one \p Target per \p DLDeviceType, though we want to get rid of
+   * that limitation.
    *
    * CAUTION: Since keys are \p Integers they are compared by object equality not integer
    * value.
@@ -63,13 +66,18 @@ class CompilationConfigNode : public Object {
   /*!
    * \brief The host target. Used for 'scalar' data and code (such as shapes and shape
    * functions) and residual Relay expressions and data (such as conditionals and ADTs).
+   *
+   * Note that it is possible for a \p Target used for primitive operations to be structurally
+   * equal to the host \p Target (up to the \p host field.) However the \p Target objects will
+   * be distinct, and can be used as keys within a \p Map without collision.
    */
   Target host_target;
 
   /*!
-   * \brief Vector of all available targets for primitive operators. May contain a \p Target
-   * for the same device type as for the \p host_target, however the \p host_target should
-   * be preferred for all host computations and data.
+   * \brief Vector of all available \p Targets for compiling primitive operators. May contain
+   * a \p Target for the same device type as for the \p host_target, however the \p host_target
+   * should be used for all host computations and data. Each \p Target will have \p host_target
+   * as its host.
    */
   Array<Target> primitive_targets;
 

--- a/include/tvm/target/se_scope.h
+++ b/include/tvm/target/se_scope.h
@@ -297,6 +297,12 @@ class SEScope : public ObjectRef {
     return SEScope(device.device_type, device.device_id, std::move(target));
   }
 
+  /*! \brief Returns the \p SEScope for \p target. */
+  static SEScope ForTarget(Target target) {
+    return SEScope(static_cast<DLDeviceType>(target->kind->device_type), /*virtual_device_id=*/0,
+                   std::move(target));
+  }
+
   /*! \brief Returns the \p SEScope for \p device, \p target and \p memory_scope. */
   TVM_DLL static SEScope ForDeviceTargetAndMemoryScope(const Device& device, Target target,
                                                        MemoryScope memory_scope) {

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -73,6 +73,7 @@ class Executable(object):
         self._get_bytecode = self.mod["get_bytecode"]
         self._get_constants = self.mod["get_constants"]
         self._get_virtual_devices = self.mod["get_virtual_devices"]
+        self._get_primitives = self.mod["get_primitives"]
         self._get_stats = self.mod["get_stats"]
         self._get_function_arity = self.mod["get_function_arity"]
         self._get_function_param_name = self.mod["get_function_param_name"]
@@ -256,6 +257,12 @@ class Executable(object):
     def virtual_devices(self):
         """Returns a human-readable description of all the (virtual) devices in the executable."""
         return self._get_virtual_devices()
+
+    @property
+    def primitive(self):
+        """Returns a human-readable dencription of all the primitives (ie PackedFuncs) in the
+        executable"""
+        return self._get_primitives()
 
     @property
     def globals(self):

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -213,7 +213,7 @@ void IRModuleNode::AddUnchecked(const GlobalVar& var, const BaseFunc& func) {
     ICHECK_EQ((*it).second, var);
   } else {
     ICHECK(global_var_map_.count(var->name_hint) == 0)
-        << "Duplicate global function name " << var->name_hint;
+        << "Duplicate global function name " << PrettyPrint(var);
   }
 
   global_var_map_.Set(var->name_hint, var);
@@ -243,7 +243,7 @@ void IRModuleNode::AddTypeDefUnchecked(const GlobalTypeVar& var, const TypeData&
   if (!update) {
     // set global type var map
     ICHECK(global_type_var_map_.count(var->name_hint) == 0)
-        << "Duplicate global type definition name " << var->name_hint;
+        << "Duplicate global type definition name " << PrettyPrint(var);
   }
   global_type_var_map_.Set(var->name_hint, var);
   RegisterConstructors(var, type);
@@ -266,7 +266,7 @@ void IRModuleNode::Remove(const GlobalVar& var) {
 
 BaseFunc IRModuleNode::Lookup(const GlobalVar& var) const {
   auto it = functions.find(var);
-  ICHECK(it != functions.end()) << "There is no definition of " << var->name_hint;
+  ICHECK(it != functions.end()) << "There is no definition of " << PrettyPrint(var);
   return (*it).second;
 }
 
@@ -277,7 +277,7 @@ BaseFunc IRModuleNode::Lookup(const String& name) const {
 
 TypeData IRModuleNode::LookupTypeDef(const GlobalTypeVar& var) const {
   auto it = type_definitions.find(var);
-  ICHECK(it != type_definitions.end()) << "There is no definition of " << var->name_hint;
+  ICHECK(it != type_definitions.end()) << "There is no definition of " << PrettyPrint(var);
   return (*it).second;
 }
 
@@ -306,6 +306,10 @@ String IRModuleNode::GetUniqueName(const String& name) {
   }
 }
 
+/*!
+ * \brief Renames global type/term variables to prefer the GlobalTypeVar/GlobalVar in the lhs
+ * ('one') side above the rhs ('two').
+ */
 struct Renamer : relay::ExprMutator, TypeMutator {
   Map<String, GlobalVar> defs;
   Map<String, GlobalTypeVar> types;
@@ -411,7 +415,6 @@ IRModule IRModule::FromExpr(const RelayExpr& expr, const Map<GlobalVar, BaseFunc
 void IRModuleNode::Import(const String& path) {
   if (this->import_set_.count(path) == 0) {
     this->import_set_.insert(path);
-    DLOG(INFO) << "Importing: " << path;
     std::fstream src_file(path, std::fstream::in);
     std::string file_contents{std::istreambuf_iterator<char>(src_file),
                               std::istreambuf_iterator<char>()};

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -499,7 +499,17 @@ Doc RelayTextPrinter::VisitExpr_(const FunctionNode* op) {
   return PrintFunc(Doc::Text("fn "), GetRef<Function>(op));
 }
 
-Doc RelayTextPrinter::VisitExpr_(const GlobalVarNode* op) { return Doc::Text("@" + op->name_hint); }
+Doc RelayTextPrinter::VisitExpr_(const GlobalVarNode* op) {
+  Doc doc;
+  doc << "@" << op->name_hint;
+#if TVM_LOG_DEBUG
+  if (op->checked_type_.defined()) {
+    doc << " /* type=" << PrintType(op->checked_type_, /*meta=*/false) << " */";
+  }
+  doc << " /* id=" << reinterpret_cast<uint64_t>(op) << " */";
+#endif
+  return doc;
+}
 
 Doc RelayTextPrinter::VisitExpr_(const OpNode* op) { return Doc::Text(op->name); }
 

--- a/src/printer/text_printer.cc
+++ b/src/printer/text_printer.cc
@@ -56,13 +56,29 @@ Doc TextPrinter::PrintMod(const IRModule& mod) {
     if (kv.second.as<relay::FunctionNode>()) {
       std::ostringstream os;
       os << "def @" << kv.first->name_hint;
+#if TVM_LOG_DEBUG
+      os << " /* id=" << reinterpret_cast<uint64_t>(kv.first.get()) << " */";
+#endif
       doc << relay_text_printer_.PrintFunc(Doc::Text(os.str()), kv.second);
     } else if (kv.second.as<tir::PrimFuncNode>()) {
-      doc << "@" << kv.first->name_hint << " = ";
-      doc << tir_text_printer_.PrintPrimFunc(Downcast<tir::PrimFunc>(kv.second));
+      doc << "@" << kv.first->name_hint;
+#if TVM_LOG_DEBUG
+      doc << " /* id=" << reinterpret_cast<uint64_t>(kv.first.get()) << " */";
+#endif
+      doc << " = " << tir_text_printer_.PrintPrimFunc(Downcast<tir::PrimFunc>(kv.second));
     }
     doc << Doc::NewLine();
   }
+#if TVM_LOG_DEBUG
+  // attributes
+  if (mod->attrs.defined() && !mod->attrs->dict.empty()) {
+    doc << "attributes {" << Doc::NewLine();
+    for (const auto& kv : mod->attrs->dict) {
+      doc << "  '" << kv.first << "' = " << PrettyPrint(kv.second) << Doc::NewLine();
+    }
+    doc << "}" << Doc::NewLine();
+  }
+#endif
   return doc;
 }
 

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -83,8 +83,8 @@ class AOTOnDemandAllocator : public transform::DeviceAwareExprVisitor {
     Expr func;
     Array<Expr> args;
 
-    if (call_node->op == CallLoweredOp()) {
-      CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
+    CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
+    if (call_lowered_props.lowered_func.defined()) {
       func = call_lowered_props.lowered_func;
       args = call_lowered_props.arguments;
     } else {  // Relay functions that have not been lowered and lowered extern functions
@@ -516,10 +516,11 @@ class AOTExecutorCodegen : public MixedModeVisitor {
       }
       call_lowered_props = CallLoweredProps{GetRef<GlobalVar>(gvn), call_node->args, {}};
     } else {
-      ICHECK(call_node->op == CallLoweredOp()) << "Operators should be transformed away; Try "
-                                                  "applying the fuse_ops transformation to the "
-                                                  "expression.";
       call_lowered_props = GetCallLoweredProps(call_node);
+      ICHECK(call_lowered_props.lowered_func.defined())
+          << "Operators should be transformed away; Try "
+             "applying the fuse_ops transformation to the "
+             "expression.";
       for (const auto& arg : call_lowered_props.arguments) {
         VisitExpr(arg);
       }
@@ -717,6 +718,14 @@ class AOTExecutorCodegen : public MixedModeVisitor {
       : mod_(mod), targets_(targets), target_host_(target_host), use_unpacked_api_(Bool(false)) {}
 
   LoweredOutput Codegen(IRModule mod, relay::Function func, String mod_name) {
+    VLOG_CONTEXT << "AOT";
+    for (const auto& kv : targets_) {
+      VLOG(1) << "target: " << kv.second->ToDebugString();
+    }
+    if (target_host_.defined()) {
+      VLOG(1) << "target host: " << target_host_->ToDebugString();
+    }
+
     Executor executor_config = mod->GetAttr<Executor>(tvm::attr::kExecutor).value();
     String interface_api = executor_config->GetAttr<String>("interface-api").value_or("packed");
     Integer workspace_byte_alignment =
@@ -793,10 +802,11 @@ class AOTExecutorCodegen : public MixedModeVisitor {
           std::make_pair(static_cast<int>(param_storage_ids_[param.first]), param.second)));
     }
 
-    // Build the TIR IRModule for the AOT function
+    // Build the TIR IRModule for the main AOT function
     Map<GlobalVar, BaseFunc> symbol_map;
     symbol_map.Set(GlobalVar(::tvm::runtime::symbol::tvm_run_func_suffix), prim_func);
     IRModule mod_run(symbol_map, {}, {}, {}, mod->attrs);
+    VLOG(1) << "main module:" << std::endl << PrettyPrint(mod_run);
 
     // Apply storage rewrite pass to the runner function to do memory planning
     auto storage_rewrite = tir::transform::StorageRewrite();
@@ -827,12 +837,23 @@ class AOTExecutorCodegen : public MixedModeVisitor {
     ICHECK(external_modules) << "Attribute \"external_mods\" should be set at this point.";
 
     // This is the point where we separate the functions in the module by target
+    VLOG(1) << "lowered module:" << std::endl << PrettyPrint(lowered_mod);
     ret.lowered_funcs = tec::GetPerTargetModules(lowered_mod);
+    VLOG(1) << "per-target modules:";
+    for (const auto& kv : ret.lowered_funcs) {
+      VLOG(1) << "target:" << std::endl
+              << kv.first->ToDebugString() << std::endl
+              << "maps to:" << std::endl
+              << PrettyPrint(kv.second);
+    }
+
     ret.external_mods = external_modules.value();
 
     if (ret.lowered_funcs.find(target_host_) != ret.lowered_funcs.end()) {
+      VLOG(1) << "merging main into existing module for host target";
       ret.lowered_funcs[target_host_]->Update(mod_run);
     } else {
+      VLOG(1) << "adding main into new module for host target";
       ret.lowered_funcs.Set(target_host_, mod_run);
     }
 

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -407,9 +407,9 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
     std::vector<GraphNodeRef> inputs;
     std::string func_name;
 
-    if (call->op == CallLoweredOp()) {
+    CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
+    if (call_lowered_props.lowered_func.defined()) {
       // Extract function and arguments from the call_lowered op
-      CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
 
       func_name = call_lowered_props.lowered_func->name_hint;
 

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -684,8 +684,9 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
   }
 
   ObjectRef VisitExpr_(const CallNode* call_node) final {
-    if (call_node->op == CallLoweredOp()) {  // Special case: Call a lowered TIR function.
-      CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
+    CallLoweredProps call_lowered_props = GetCallLoweredProps(call_node);
+    if (call_lowered_props.lowered_func.defined()) {
+      // Special case: Call a lowered TIR function.
 
       // Evaluate only function args
       std::vector<ObjectRef> args;

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -215,7 +215,7 @@ class ScheduleBuilder : public backend::MemoizedExprTranslator<Array<te::Tensor>
   }
 
   Array<te::Tensor> VisitExpr_(const VarNode* op) final {
-    LOG(FATAL) << "Unexpected free variable " << op->name_hint();
+    LOG(FATAL) << "Unexpected free variable " << PrettyPrint(GetRef<Var>(op));
     return {};
   }
 
@@ -384,7 +384,6 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
 
   CachedFunc Create(const Function& prim_func, const Target& target,
                     std::function<std::string(std::string)> renamer) {
-    Array<te::Tensor> inputs;
     TShapeDataDependent shape_func_param_states;
 
     for (auto param : prim_func->params) {
@@ -429,6 +428,7 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
     }
 
     // Set all the inputs correctly.
+    Array<te::Tensor> inputs;
     for (auto param : prim_func->params) {
       int state = param_states_[param];
       shape_func_param_states.push_back(IntImm(DataType::Int(32), state));
@@ -496,7 +496,7 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
       return VisitExpr(it->second);
     }
     if (param_states_.find(var) == param_states_.end()) {
-      LOG(FATAL) << "Unexpected free variable " << var->name_hint();
+      LOG(FATAL) << "Unexpected free variable " << PrettyPrint(var);
       return {};
     } else {
       ICHECK(data_dependents_per_input_.size());

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -24,6 +24,7 @@
 
 #include "utils.h"
 
+#include <tvm/parser/parser.h>
 #include <tvm/relay/qnn/transform.h>
 
 #include "te_compiler.h"
@@ -177,6 +178,10 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 Array<Pass> GetPassPrefix(bool is_homegeneous, bool is_vm) {
   Array<Pass> pass_seqs;
+  // TODO(mbs): Would be nice to get spans on all diagnostics, but since they arg forgotton
+  // by most passes there's little utility in including this now. Plus we'd need to only do
+  // this if there's no existing spans to work from.
+  // pass_seqs.push_back(parser::AnnotateSpans());
   Array<runtime::String> entry_functions{"main"};
   pass_seqs.push_back(transform::RemoveUnusedFunctions(entry_functions));
   pass_seqs.push_back(transform::ToBasicBlockNormalForm());

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -996,7 +996,10 @@ void VMCompiler::Lower(IRModule mod, TargetMap targets, tvm::Target target_host)
 
   VLOG(1) << std::endl
           << "-------------------------------------------------" << std::endl
-          << exec_->GetVirtualDevices() << exec_->GetConstants() << exec_->GetBytecode()
+          << exec_->GetVirtualDevices()  //
+          << exec_->GetConstants()       //
+          << exec_->GetPrimitives()      //
+          << exec_->GetBytecode()        //
           << "-------------------------------------------------";
 
   backend::UpdateAutoSchedulerOpWeights(context_.compiler);

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -107,7 +107,14 @@ class VMCompiler : public runtime::ModuleNode {
   void SetParam(const std::string& name, runtime::NDArray data_in);
 
   /*!
-   * \brief Lower the functions in a Module
+   * \brief Lower the functions in a Module.
+   *
+   * ----------------------------------------------------------------------------------
+   * | This is the main entry point for the VM compilation flow.                      |
+   * |  - Preceded by \p SetParam for the global params.                             |
+   * |  - Followed by \p Codegen() to finalize the executable.                        |
+   * |  - Then the result runtime::Module can be constructed from the internal exec_. |
+   * ----------------------------------------------------------------------------------
    *
    * \param mod Relay Module
    * \param targets For heterogeneous compilation, it is a dictionary indicating device type

--- a/src/relay/op/call/call.h
+++ b/src/relay/op/call/call.h
@@ -62,11 +62,15 @@ struct CallLoweredProps {
 };
 
 /*!
- * \brief Helper to extract the lowered function and its arguments from Call("call_lowered", ...).
- * Will fail if called on a Call whose op is not "call_lowered" \param call_node CallNode that we
- * want to get the function and its arguments from.
+ * \brief Helper to extract the lowered function and its arguments from a Call("call_lowered", ...).
+ * Returns the null/empty \p CallLoweredProps if \p call_node is not in that form.
  */
 CallLoweredProps GetCallLoweredProps(const CallNode* call_node);
+
+/*!
+ * \brief Returns true if lowered call described by \p props is to a reshape primitive.
+ */
+bool IsReshapeOnly(const CallLoweredProps& props);
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/op/memory/device_copy.cc
+++ b/src/relay/op/memory/device_copy.cc
@@ -24,6 +24,7 @@
 
 #include "./device_copy.h"
 
+#include <tvm/relay/attrs/annotation.h>
 #include <tvm/relay/attrs/call.h>
 #include <tvm/relay/attrs/device_copy.h>
 #include <tvm/relay/expr.h>
@@ -112,6 +113,16 @@ DeviceCopyProps GetDeviceCopyProps(const CallNode* call_node) {
 DeviceCopyProps GetDeviceCopyProps(const Expr& expr) {
   if (const auto* call_node = expr.as<CallNode>()) {
     return GetDeviceCopyProps(call_node);
+  }
+  return {};
+}
+
+DeviceCopyProps GetLoweredDeviceCopyProps(const CallLoweredProps& props) {
+  if (props.attrs.metadata.count("src_se_scope") == 1 &&
+      props.attrs.metadata.count("dst_se_scope") == 1) {
+    ICHECK_EQ(props.arguments.size(), 1) << "device_copy is of arity 1";
+    return {props.arguments[0], Downcast<SEScope>(props.attrs.metadata["src_se_scope"]),
+            Downcast<SEScope>(props.attrs.metadata["dst_se_scope"])};
   }
   return {};
 }

--- a/src/relay/op/memory/device_copy.h
+++ b/src/relay/op/memory/device_copy.h
@@ -30,6 +30,8 @@
 
 #include <utility>
 
+#include "../call/call.h"
+
 namespace tvm {
 namespace relay {
 
@@ -76,6 +78,14 @@ DeviceCopyProps GetDeviceCopyProps(const CallNode* call_node);
  * scopes.
  */
 DeviceCopyProps GetDeviceCopyProps(const Expr& expr);
+
+/*!
+ * \brief As for GetDeviceCopyProps, but for a lowered call rather than the original
+ * "device_copy" operator.
+ *
+ * See te_compiler.cc for where this rewriting occurs.
+ */
+DeviceCopyProps GetLoweredDeviceCopyProps(const CallLoweredProps& props);
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -558,7 +558,7 @@ String TargetNode::ToDebugString() const {
       if (!first) {
         os << ", ";
       }
-      os << '"' << pair.first << "': " << pair.second;
+      os << "'" << pair.first << "': " << pair.second;
       first = false;
     }
     os << "}";


### PR DESCRIPTION
This is a grab bag of fallout changes from switching the VM to use LoweTEPass
which can be ealy split out of the main #9483 PR.

- AnnotateSpans can be used from C++ (though, unfortunately, it didn't help
  me with debugging since spans are universally dropped in most passes).
- Can get a human readable dump of the VM's PackedFunc names and indexes for
  debugging.
- If TVM_LOG_DEBUG defined then include types and ids of GlobalVars. I had
  a lot of difficulty tracking down where duplicate GlobalVars for the same
  name_hint were getting created and propagated.
- GetCallLoweredProps follows same API as GetDeviceCopy and GetOnDevice
  where will return 'null' properties if call/expr is not of call_lowered
  form. Mildly more convenient, though switching all the above to ICHECK
  and push 'if (op == the relevant op)' into all use sites would also be just
  fine and I can be talked into that too.
- Misc VLOG improvements made while tracking down issues in main PR.
- Don't attach host targets to the CompilationConfig's 'primitive_targets' array. Since
  Targets and SEScopes are compared by pointer equality, and the same Target with
  and without a host are distinct objects, this was causing unnecessary copies in code which
  is already dealing with the explicit host_target or host_se_scope anyway. I've left the hosts
  in the legacy_target_map. (The sooner we sort out multi-target compilation and hosts the
  better!) 