### PR TITLE
[Executor] Debug Graph Executor - Dumping output tensors include topographical ordering

### DIFF
--- a/python/tvm/contrib/debugger/debug_result.py
+++ b/python/tvm/contrib/debugger/debug_result.py
@@ -18,6 +18,7 @@
 import collections
 import json
 import os
+
 import numpy as np
 import tvm
 
@@ -111,15 +112,17 @@ class DebugResult(object):
         return self._dtype_list
 
     def get_output_tensors(self):
-        """Dump the outputs to a temporary folder, the tensors are in numpy format"""
+        """Get the output tensors of each operation in numpy format"""
         eid = 0
         order = 0
         output_tensors = {}
-        for node, time in zip(self._nodes_list, self._time_list):
+        for i, (node, time) in enumerate(zip(self._nodes_list, self._time_list)):
             num_outputs = self.get_graph_node_output_num(node)
             for j in range(num_outputs):
                 order += time[0]
-                key = node["name"] + "_" + str(j)
+
+                # the node name is not unique, so we need a consistent indexing based on the list in the nodes
+                key = f"{node['name']}____topo-index:{i}____output-num:{j}"
                 output_tensors[key] = self._output_tensor_list[eid]
                 eid += 1
         return output_tensors
@@ -141,14 +144,7 @@ class DebugResult(object):
         """Dump the outputs to a temporary folder, the tensors are in numpy format"""
         # cleanup existing tensors before dumping
         self._cleanup_tensors()
-        eid = 0
-        output_tensors = {}
-        for node in self._nodes_list:
-            num_outputs = self.get_graph_node_output_num(node)
-            for j in range(num_outputs):
-                key = node["name"] + "____" + str(j)
-                output_tensors[key] = self._output_tensor_list[eid]
-                eid += 1
+        output_tensors = self.get_output_tensors()
 
         with open(os.path.join(self._dump_path, "output_tensors.params"), "wb") as param_f:
             param_f.write(save_tensors(output_tensors))

--- a/python/tvm/contrib/debugger/debug_result.py
+++ b/python/tvm/contrib/debugger/debug_result.py
@@ -121,7 +121,8 @@ class DebugResult(object):
             for j in range(num_outputs):
                 order += time[0]
 
-                # the node name is not unique, so we need a consistent indexing based on the list in the nodes
+                # the node name is not unique, so we need a consistent
+                # indexing based on the list ordering in the nodes
                 key = f"{node['name']}____topo-index:{i}____output-num:{j}"
                 output_tensors[key] = self._output_tensor_list[eid]
                 eid += 1


### PR DESCRIPTION
The previous dumping of output tensors from the debug graph executor only used the name of the operation as the key in a dictionary.

This does not work because op-names are in fact not unique! We get around this by including a topological index into the key which should be consistent with a fixed graph.json