### PR TITLE
[QNN] Fix order of operations in qnn.quantize slightly to prevent undefined behavior

### DIFF
--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -130,8 +130,8 @@ Expr QuantizeLower(const Expr& input_tensor, const Expr& output_scale,
   auto scale_data = Divide(input_tensor, expanded_output_scale);
   auto add_zero_point = Add(scale_data, Cast(expanded_output_zero_point, DataType::Float(32)));
   auto clamped_output = Clip(add_zero_point, min_val, max_val);
-  auto clamp_out_dtype = Cast(clamped_output, out_dtype);
-  return clamp_out_dtype;
+  auto rounded_clamped_output = Round(clamped_output);
+  return Cast(rounded_clamped_output, out_dtype);
 }
 
 Expr QuantizeQnnCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,

--- a/src/relay/qnn/op/quantize.cc
+++ b/src/relay/qnn/op/quantize.cc
@@ -128,9 +128,7 @@ Expr QuantizeLower(const Expr& input_tensor, const Expr& output_scale,
   const int32_t min_val = GetQmin(out_dtype);
   const int32_t max_val = GetQmax(out_dtype);
   auto scale_data = Divide(input_tensor, expanded_output_scale);
-  auto add_zero_point =
-      Cast(Round(Add(scale_data, Cast(expanded_output_zero_point, DataType::Float(32)))),
-           DataType::Int(32));
+  auto add_zero_point = Add(scale_data, Cast(expanded_output_zero_point, DataType::Float(32)));
   auto clamped_output = Clip(add_zero_point, min_val, max_val);
   auto clamp_out_dtype = Cast(clamped_output, out_dtype);
   return clamp_out_dtype;


### PR DESCRIPTION
We switch the order of some operations. This is to stop an edge case where casting a float with NaNs, or infinity leads to undefined behavior.

In my experience, casting a +inf to int32 led to the minimum int32 value on x86 (a 5900X - zen3) while on an m1 mac led to the maximum int32 value. This fixes this by moving the clipping operation to operate on the floating point values before casting to integer.