### PR TITLE
[Relay] WithFields method for Call, Function, Var, TupleGetItem, If, Let, RefCreate, RefRead, RefWrite, Match, and Clause

### DIFF
--- a/include/tvm/relay/adt.h
+++ b/include/tvm/relay/adt.h
@@ -260,7 +260,24 @@ class Clause : public ObjectRef {
   TVM_DLL explicit Clause(Pattern lhs, Expr rhs);
 
   TVM_DEFINE_OBJECT_REF_METHODS(Clause, ObjectRef, ClauseNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(ClauseNode);
 };
+
+/*!
+ * \brief Returns the clause with given properties. A null property denotes 'no change'.
+ * Returns clause if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param clause The clause to copy.
+ * \param opt_lhs The (optional) lhs for the copied clause. If none, ret_clause->lhs = clause->lhs.
+ * \param opt_rhs The (optional) rhs for the copied clause. If none,
+ * ret_clause->rhs = clause->rhs.
+ * \return If all
+ * properties are null or the same as the property in the input clause (i.e., opt_lhs is null or
+ * opt_lhs.value() == clause->lhs, etc.), then we return clause. Otherwise, we return a copy of
+ * clause with the different fields overwritten. (i.e., if opt_lhs.value() != clause->lhs, then
+ * ret_clause->lhs = opt_lhs.value()).
+ */
+Clause WithFields(Clause clause, Optional<Pattern> opt_lhs = Optional<Pattern>(),
+                  Optional<Expr> opt_rhs = Optional<Expr>());
 
 /*! \brief ADT pattern matching exression. */
 class Match;
@@ -315,7 +332,29 @@ class Match : public Expr {
   TVM_DLL Match(Expr data, tvm::Array<Clause> clauses, bool complete = true, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Match, RelayExpr, MatchNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(MatchNode);
 };
+
+/*!
+ * \brief Returns the match with given properties. A null property denotes 'no change'.
+ * Returns match if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param match The match to copy.
+ * \param opt_data The (optional) data for the copied match. If none, ret_match->data = match->data.
+ * \param opt_clauses The (optional) clauses for the copied match. If none, ret_match->clauses =
+ * match->clauses.
+ * \param opt_complete The (optional) complete for the copied match. If none, ret_match->complete =
+ * match->complete.
+ * \param opt_span The (optional) span for the copied match. If none, ret_match->span = match->span.
+ * \return If all properties are null or the same as the
+ * property in the input match (i.e., opt_clauses is null or opt_clauses.value() == match->clauses,
+ * etc.), then we return match. Otherwise, we return a copy of match with the different fields
+ * overwritten. (i.e., if opt_clauses.value() != match->clauses, then ret_match->clauses =
+ * opt_clauses.value()).
+ */
+Match WithFields(Match match, Optional<Expr> opt_data = Optional<Expr>(),
+                 Optional<Array<Clause>> opt_clauses = Optional<Array<Clause>>(),
+                 Optional<Bool> opt_complete = Optional<Bool>(),
+                 Optional<Span> opt_span = Optional<Span>());
 
 }  // namespace relay
 }  // namespace tvm

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -230,7 +230,25 @@ class Var : public Expr {
   TVM_DLL Var(Id vid, Type type_annotation, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Var, RelayExpr, VarNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(VarNode);
 };
+
+/*!
+ * \brief Returns the var with given properties. A null property denotes 'no change'.
+ * Returns var if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param var The var to copy.
+ * \param opt_vid The (optional) vid for the copied var. If none, ret_var->vid = var->vid.
+ * \param opt_type_annotation The (optional) type_annotation for the copied var. If none,
+ * ret_var->type_annotation = var->type_annotation.
+ * \param opt_span The (optional) span for the copied var. If none, ret_var->span = var->span.
+ * \return If all properties are null or the same as the property in the input var
+ * (i.e., opt_vid is null or opt_vid.value() == var->vid, etc.), then we return var. Otherwise,
+ * we return a copy of call with the different fields overwritten. (i.e., if
+ * opt_vid.value() != var->vid, then ret_var->vid = opt_.value()).
+ */
+Var WithFields(Var var, Optional<Id> opt_vid = Optional<Id>(),
+               Optional<Type> opt_type_annotation = Optional<Type>(),
+               Optional<Span> opt_span = Optional<Span>());
 
 /*!
  * \brief Call corresponds to operator invocation.
@@ -331,7 +349,30 @@ class Call : public Expr {
                Array<Type> type_args = Array<Type>(), Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Call, RelayExpr, CallNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(CallNode);
 };
+
+/*!
+ * \brief Returns the call with given properties. A null property denotes 'no change'.
+ * Returns call if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param call The call to copy.
+ * \param opt_op The (optional) op for the copied call. If none, ret_call->op = call->op.
+ * \param opt_args The (optional) args for the copied call. If none, ret_call->args = call->args.
+ * \param opt_attrs The (optional) attrs for the copied call. If none, ret_call->attrs =
+ * call->attrs.
+ * \param opt_type_args The (optional) type args for the copied call. If none,
+ * ret_call->type_args = call->type_args.
+ * \param opt_span The (optional) span for the copied call. If none, ret_call->span = call->span.
+ * \return If all properties are null or the same as the property in the input call
+ * (i.e., opt_op is null or opt_op.value() == call->op, etc.), then we return call. Otherwise, we
+ * return a copy of call with the different fields overwritten. (i.e., if opt_op.value() !=
+ * call->op, then ret_call->op = opt_op.value()).
+ */
+Call WithFields(Call call, Optional<Expr> opt_op = Optional<Expr>(),
+                Optional<Array<Expr>> opt_args = Optional<Array<Expr>>(),
+                Optional<Attrs> opt_attrs = Optional<Attrs>(),
+                Optional<Array<Type>> opt_type_args = Optional<Array<Type>>(),
+                Optional<Span> opt_span = Optional<Span>());
 
 /*!
  * \brief Let binding that binds a local var and optionally a type annotation.
@@ -405,7 +446,26 @@ class Let : public Expr {
   TVM_DLL Let(Var var, Expr value, Expr body, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Let, RelayExpr, LetNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(LetNode);
 };
+
+/*!
+ * \brief Returns the let with given properties. A null property denotes 'no change'.
+ * Returns let if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param let The let to copy.
+ * \param opt_var The (optional) var for the copied let. If none, ret_let->op = let->op.
+ * \param opt_value The (optional) value for the copied let. If none, ret_let->args = let->args.
+ * \param opt_body The (optional) body for the copied let. If none, ret_let->attrs = let->attrs.
+ * \param opt_span The (optional) span for the copied let. If none, ret_let->span = let->span.
+ * \return If all properties are null or the same as the property in the input let (i.e., opt_var is
+ * null or opt_var.value() == let->var, etc.), then we return let. Otherwise, we return a copy of
+ * let with the different fields overwritten. (i.e., if opt_var.value() != let->var, then
+ * ret_let->var = opt_var.value()).
+ */
+Let WithFields(Let let, Optional<Var> opt_var = Optional<Var>(),
+               Optional<Expr> opt_value = Optional<Expr>(),
+               Optional<Expr> opt_body = Optional<Expr>(),
+               Optional<Span> opt_span = Optional<Span>());
 
 /*!
  * \brief Condition expression
@@ -466,7 +526,31 @@ class If : public Expr {
   TVM_DLL If(Expr cond, Expr true_branch, Expr false_branch, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(If, RelayExpr, IfNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(IfNode);
 };
+
+/*!
+ * \brief Returns the if_expr with given properties. A null property denotes 'no change'.
+ * Returns if_expr if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param if_expr The if expression to copy.
+ * \param opt_cond The (optional) cond for the copied if_expr. If none, ret_if->cond =
+ * if_expr->cond.
+ * \param opt_true_branch The (optional) true_branch for the copied if_expr. If none,
+ * ret_if->true_branch = ret_if->false_branch.
+ * \param opt_false_branch The (optional) false_branch
+ * for the copied if_expr. If none, ret_if->false_branch = if_expr->false_branch.
+ * \param opt_span
+ * The (optional) span for the copied if_expr. If none, ret_if->span = if_expr->span.
+ * \return If all
+ * properties are null or the same as the property in the input if_expr (i.e., opt_cond is null or
+ * opt_cond.value() == if_expr->cond, etc.), then we return if_expr. Otherwise, we return a copy of
+ * if_expr with the different fields overwritten. (i.e., if opt_cond.value() != if_expr->cond, then
+ * ret_if->cond = opt_cond.value()).
+ */
+If WithFields(If if_expr, Optional<Expr> opt_cond = Optional<Expr>(),
+              Optional<Expr> opt_true_branch = Optional<Expr>(),
+              Optional<Expr> opt_false_branch = Optional<Expr>(),
+              Optional<Span> opt_span = Optional<Span>());
 
 /*! \brief Get index-th field out of a tuple. */
 class TupleGetItem;
@@ -508,7 +592,29 @@ class TupleGetItem : public Expr {
   TVM_DLL TupleGetItem(Expr tuple, int index, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(TupleGetItem, RelayExpr, TupleGetItemNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleGetItemNode);
 };
+
+/*!
+ * \brief Returns the tuple_get_item with given properties. A null property denotes 'no change'.
+ * Returns if_expr if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param tuple_get_item The tuple_get_item to copy.
+ * \param opt_tuple The (optional) tuple for the copied tuple_get_item. If none,
+ * ret_tuple_get_item->tuple = tuple_get_item->tuple.
+ * \param opt_index The (optional) index for the copied tuple_get_item. If none,
+ * ret_tuple_get_item->index = tuple_get_item->index.
+ * \param
+ * opt_span The (optional) span for the copied tuple_get_item. If none,
+ * ret_tuple_get_item->span = tuple_get_item->span.
+ * \return If all properties are null or the same as the property in the input tuple_get_item
+ * (i.e., opt_tuple is null or opt_tuple.value() == tuple_get_item->tuple, etc.), then we return
+ * tuple_get_item. Otherwise, we return a copy of tuple_get_item with the different fields
+ * overwritten. (i.e., if opt_tuple.value() != tuple_get_item->tuple, then
+ * ret_tuple_get_item->tuple = opt_tuple.value()).
+ */
+TupleGetItem WithFields(TupleGetItem tuple_get_item, Optional<Expr> opt_tuple = Optional<Expr>(),
+                        Optional<Integer> opt_index = Optional<Integer>(),
+                        Optional<Span> opt_span = Optional<Span>());
 
 /*! \brief Create a new Reference out of initial value. */
 class RefCreate;
@@ -547,7 +653,26 @@ class RefCreate : public Expr {
   TVM_DLL explicit RefCreate(Expr value, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(RefCreate, RelayExpr, RefCreateNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(RefCreateNode);
 };
+
+/*!
+ * \brief Returns the ref create with given properties. A null property denotes 'no change'.
+ * Returns ref_create if all properties are unchanged. Otherwise, returns a copy with the new
+ * fields.
+ * \param ref_create The ref_create to copy.
+ * \param opt_value The (optional) value for the copied ref_create. If none,
+ * ret_ref_create->value = ref_create->value.
+ * \param opt_span The (optional) span for the copied ref_create. If none,
+ * ret_ref_create->span = ref_create->span.
+ * \return If all properties are null or the same as the property in the input ref_create
+ * (i.e., opt_value is null or opt_value.value() == ref_create->value, etc.), then we return
+ * ref_create. Otherwise, we return a copy of ref_create with the different fields overwritten.
+ * (i.e., if opt_value.value() != ref_create->value, then
+ * ret_ref_create->value = opt_value.value()).
+ */
+RefCreate WithFields(RefCreate ref_create, Optional<Expr> opt_value = Optional<Expr>(),
+                     Optional<Span> opt_span = Optional<Span>());
 
 /*! \brief Get value out of Reference. */
 class RefRead;
@@ -586,7 +711,26 @@ class RefRead : public Expr {
   TVM_DLL explicit RefRead(Expr ref, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(RefRead, RelayExpr, RefReadNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(RefReadNode);
 };
+
+/*!
+ * \brief Returns the ref read with given properties. A null property denotes 'no change'.
+ * Returns ref_read if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param ref_read The ref_read to copy.
+ * \param opt_ref The (optional) ref for the copied ref_read. If none, ret_ref_read->ref =
+ * ref_read->ref.
+ * \param opt_span
+ * The (optional) span for the copied ref_read. If none, ret_ref_read->span = ref_read->span.
+ * \return If all properties are null or the same as the property in the input ref_read
+ * (i.e., opt_ref is null or opt_ref.value() == ref_read->ref, etc.), then we return ref_read.
+ * Otherwise, we return a copy of ref_read with the different fields overwritten.
+ * (i.e., if opt_ref.value() != ref_read->ref, then
+ * ret_ref_read->ref = opt_ref.value()).
+ */
+RefRead WithFields(RefRead ref_read, Optional<Expr> opt_ref = Optional<Expr>(),
+                   Optional<Span> opt_span = Optional<Span>());
+
 /*! \brief Set value of Reference. The whole expression evaluates to an Empty Tuple. */
 class RefWrite;
 class RefWriteNode : public ExprNode {
@@ -629,7 +773,28 @@ class RefWrite : public Expr {
   TVM_DLL RefWrite(Expr ref, Expr value, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(RefWrite, RelayExpr, RefWriteNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(RefWriteNode);
 };
+
+/*!
+ * \brief Returns the ref write with given properties. A null property denotes 'no change'.
+ * Returns ref_write if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param ref_write The ref_write to copy.
+ * \param opt_ref The (optional) ref for the copied ref_write. If none,
+ * ret_ref_write->ref = ref_write->ref.
+ * \param opt_value The (optional) value for the copied ref_write. If none,
+ * ret_ref_write->value = ref_write->value.
+ * \param opt_span
+ * The (optional) span for the copied ref_write. If none, ret_ref_write->span = ref_write->span.
+ * \return If all properties are null or the same as the property in the input ref_write
+ * (i.e., opt_ref is null or opt_ref.value() == ref_write->ref, etc.), then we return ref_write.
+ * Otherwise, we return a copy of ref_write with the different fields overwritten.
+ * (i.e., if ref_write.value() != ref_write->ref, then
+ * ret_ref_write->ref = opt_ref.value()).
+ */
+RefWrite WithFields(RefWrite ref_write, Optional<Expr> opt_ref = Optional<Expr>(),
+                    Optional<Expr> opt_value = Optional<Expr>(),
+                    Optional<Span> opt_span = Optional<Span>());
 
 /*!
  * \brief Base class of the temporary expression.

--- a/include/tvm/relay/function.h
+++ b/include/tvm/relay/function.h
@@ -120,6 +120,35 @@ class Function : public BaseFunc {
 };
 
 /*!
+ * \brief Returns the function with given properties. A null property denotes 'no change'.
+ * Returns function if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param function The function to copy.
+ * \param opt_params The (optional) params for the copied function. If none,
+ * ret_function->params = function->params.
+ * \param opt_body The (optional) body for the copied function. If none,
+ * ret_function->body = function->body.
+ * \param opt_ret_type The (optional) return type for the copied function. If none,
+ * ret_function->ret_type = function->ret_type.
+ * \param opt_ty_params The (optional) type params for the copied function. If none,
+ * ret_function->type_params = function->type_params.
+ * \param opt_attrs
+ * The (optional) attributes for the copied function. If none,
+ * ret_function->attrs = function->attrs.
+ * \param opt_span The (optional) span for the copied function. If none,
+ * ret_function->span = function->span.
+ * \return If all properties are null or the same as the property in the input function
+ * (i.e., opt_params is null or opt_params.value() == function->params, etc.), then we return
+ * function. Otherwise, we return a copy of function with the different fields overwritten. (i.e.,
+ * if opt_params.value() != function->params, then ret_function->params = opt_params.value()).
+ */
+Function WithFields(Function function, Optional<Array<Var>> opt_params = Optional<Array<Var>>(),
+                    Optional<Expr> opt_body = Optional<Expr>(),
+                    Optional<Type> opt_ret_type = Optional<Type>(),
+                    Optional<Array<TypeVar>> opt_ty_params = Optional<Array<TypeVar>>(),
+                    Optional<DictAttrs> opt_attrs = Optional<DictAttrs>(),
+                    Optional<Span> opt_span = Optional<Span>());
+
+/*!
  * \brief namespace of the attributes that can be attached to a relay::Function.
  */
 namespace attr {

--- a/src/relay/ir/adt.cc
+++ b/src/relay/ir/adt.cc
@@ -104,6 +104,20 @@ Clause::Clause(Pattern lhs, Expr rhs) {
   data_ = std::move(n);
 }
 
+Clause WithFields(Clause clause, Optional<Pattern> opt_lhs, Optional<Expr> opt_rhs) {
+  Pattern lhs = opt_lhs.value_or(clause->lhs);
+  Expr rhs = opt_rhs.value_or(clause->rhs);
+
+  bool unchanged = lhs.same_as(clause->lhs) && rhs.same_as(clause->rhs);
+
+  if (!unchanged) {
+    ClauseNode* cow_clause_node = clause.CopyOnWrite();
+    cow_clause_node->lhs = lhs;
+    cow_clause_node->rhs = rhs;
+  }
+  return std::move(clause);
+}
+
 TVM_REGISTER_NODE_TYPE(ClauseNode);
 
 TVM_REGISTER_GLOBAL("relay.ir.Clause").set_body_typed([](Pattern lhs, Expr rhs) {
@@ -123,6 +137,38 @@ Match::Match(Expr data, tvm::Array<Clause> clauses, bool complete, Span span) {
   n->complete = complete;
   n->span = std::move(span);
   data_ = std::move(n);
+}
+
+Match WithFields(Match match, Optional<Expr> opt_data, Optional<Array<Clause>> opt_clauses,
+                 Optional<Bool> opt_complete, Optional<Span> opt_span) {
+  Expr data = opt_data.value_or(match->data);
+  Array<Clause> clauses = opt_clauses.value_or(match->clauses);
+  Bool complete = opt_complete.value_or(Bool(match->complete));
+  Span span = opt_span.value_or(match->span);
+
+  bool unchanged =
+      data.same_as(match->data) && (complete == match->complete) && span.same_as(match->span);
+
+  // Check that all clauses are unchanged
+  if (unchanged) {
+    bool all_clauses_unchanged = true;
+    if (clauses.size() == match->clauses.size()) {
+      for (size_t i = 0; i < clauses.size(); i++) {
+        all_clauses_unchanged &= clauses[i].same_as(match->clauses[i]);
+      }
+    } else {
+      all_clauses_unchanged = false;
+    }
+    unchanged &= all_clauses_unchanged;
+  }
+  if (!unchanged) {
+    MatchNode* cow_match_node = match.CopyOnWrite();
+    cow_match_node->data = data;
+    cow_match_node->clauses = clauses;
+    cow_match_node->complete = complete;
+    cow_match_node->span = span;
+  }
+  return std::move(match);
 }
 
 TVM_REGISTER_NODE_TYPE(MatchNode);

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -25,6 +25,7 @@
  * the cost of using functional updates.
  */
 #include <tvm/ir/type_functor.h>
+#include <tvm/relay/adt.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/pattern_functor.h>
@@ -160,15 +161,12 @@ Expr ExprMutator::VisitExpr(const Expr& expr) {
   }
 }
 
-Expr ExprMutator::VisitExpr_(const VarNode* op) {
-  if (op->type_annotation.defined()) {
-    auto type = this->VisitType(op->type_annotation);
-    if (!op->type_annotation.same_as(type)) {
-      return Var(op->vid, type, op->span);
-    }
+Expr ExprMutator::VisitExpr_(const VarNode* var_node) {
+  Type type_annotation = var_node->type_annotation;
+  if (var_node->type_annotation.defined()) {
+    type_annotation = this->VisitType(var_node->type_annotation);
   }
-  // default case return self.
-  return GetRef<Expr>(op);
+  return WithFields(GetRef<Var>(var_node), std::move(var_node->vid), std::move(type_annotation));
 }
 
 Expr ExprMutator::VisitExpr_(const ConstantNode* op) { return GetRef<Expr>(op); }
@@ -188,147 +186,101 @@ Expr ExprMutator::VisitExpr_(const TupleNode* tuple_node) {
   return WithFields(GetRef<Tuple>(tuple_node), std::move(fields));
 }
 
-Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
+Expr ExprMutator::VisitExpr_(const FunctionNode* func_node) {
   tvm::Array<TypeVar> ty_params;
-  bool all_ty_params_unchanged = true;
 
-  for (auto ty_param : op->type_params) {
+  for (auto ty_param : func_node->type_params) {
     TypeVar new_ty_param = Downcast<TypeVar>(VisitType(ty_param));
     ty_params.push_back(new_ty_param);
-    all_ty_params_unchanged &= new_ty_param.same_as(ty_param);
   }
 
   tvm::Array<Var> params;
-  bool all_params_unchanged = true;
-  for (auto param : op->params) {
+  for (auto param : func_node->params) {
     Var new_param = Downcast<Var>(this->Mutate(param));
     params.push_back(new_param);
-    all_params_unchanged &= param.same_as(new_param);
   }
 
-  auto ret_type = this->VisitType(op->ret_type);
-  auto body = this->Mutate(op->body);
+  auto ret_type = this->VisitType(func_node->ret_type);
+  auto body = this->Mutate(func_node->body);
 
-  if (all_ty_params_unchanged && all_params_unchanged && ret_type.same_as(op->ret_type) &&
-      body.same_as(op->body)) {
-    return GetRef<Expr>(op);
-  } else {
-    return Function(params, body, ret_type, ty_params, op->attrs, op->span);
-  }
+  return WithFields(GetRef<Function>(func_node), std::move(params), std::move(body), std::move(ret_type), std::move(ty_params));
 }
 
 Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
   auto new_op = this->Mutate(call_node->op);
-  bool unchanged = call_node->op.same_as(new_op);
 
   tvm::Array<Type> ty_args;
+  ty_args.reserve(call_node->type_args.size());
+
   for (auto ty_arg : call_node->type_args) {
     auto new_ty_arg = this->VisitType(ty_arg);
     ty_args.push_back(new_ty_arg);
-    unchanged &= new_ty_arg.same_as(ty_arg);
   }
 
   tvm::Array<Expr> call_args;
+  call_args.reserve(call_node->args.size());
   for (auto arg : call_node->args) {
     auto new_arg = this->Mutate(arg);
     call_args.push_back(new_arg);
-    unchanged &= new_arg.same_as(arg);
   }
 
-  if (unchanged) {
-    return GetRef<Expr>(call_node);
-  } else {
-    return Call(new_op, call_args, call_node->attrs, ty_args, call_node->span);
-  }
+  return WithFields(GetRef<Call>(call_node), std::move(new_op), std::move(call_args), {},
+                    std::move(ty_args));
 }
 
-Expr ExprMutator::VisitExpr_(const LetNode* op) {
-  Var var = Downcast<Var>(this->Mutate(op->var));
-  auto value = this->Mutate(op->value);
-  auto body = this->Mutate(op->body);
+Expr ExprMutator::VisitExpr_(const LetNode* let_node) {
+  Var var = Downcast<Var>(this->Mutate(let_node->var));
+  auto value = this->Mutate(let_node->value);
+  auto body = this->Mutate(let_node->body);
 
-  if (var.same_as(op->var) && value.same_as(op->value) && body.same_as(op->body)) {
-    return GetRef<Expr>(op);
-  } else {
-    return Let(var, value, body, op->span);
-  }
+  return WithFields(GetRef<Let>(let_node), std::move(var), std::move(value), std::move(body));
 }
 
-Expr ExprMutator::VisitExpr_(const IfNode* op) {
-  auto guard = this->Mutate(op->cond);
-  auto true_b = this->Mutate(op->true_branch);
-  auto false_b = this->Mutate(op->false_branch);
-  if (op->cond.same_as(guard) && op->true_branch.same_as(true_b) &&
-      op->false_branch.same_as(false_b)) {
-    return GetRef<Expr>(op);
-  } else {
-    return If(guard, true_b, false_b, op->span);
-  }
+Expr ExprMutator::VisitExpr_(const IfNode* if_node) {
+  auto cond = this->Mutate(if_node->cond);
+  auto true_b = this->Mutate(if_node->true_branch);
+  auto false_b = this->Mutate(if_node->false_branch);
+
+  return WithFields(GetRef<If>(if_node), std::move(cond), std::move(true_b), std::move(false_b));
 }
 
 Expr ExprMutator::VisitExpr_(const TupleGetItemNode* get_item) {
-  auto t = this->Mutate(get_item->tuple);
-  if (get_item->tuple == t) {
-    return GetRef<Expr>(get_item);
-  } else {
-    return TupleGetItem(t, get_item->index, get_item->span);
-  }
+  Expr tuple = this->Mutate(get_item->tuple);
+  return WithFields(GetRef<TupleGetItem>(get_item), std::move(tuple));
 }
 
-Expr ExprMutator::VisitExpr_(const RefCreateNode* op) {
-  Expr value = this->Mutate(op->value);
-  if (value.same_as(op->value)) {
-    return GetRef<Expr>(op);
-  } else {
-    return RefCreate(value, op->span);
-  }
+Expr ExprMutator::VisitExpr_(const RefCreateNode* ref_create) {
+  Expr value = this->Mutate(ref_create->value);
+  return WithFields(GetRef<RefCreate>(ref_create), std::move(value));
 }
 
-Expr ExprMutator::VisitExpr_(const RefReadNode* op) {
-  Expr ref = this->Mutate(op->ref);
-  if (ref.same_as(op->ref)) {
-    return GetRef<Expr>(op);
-  } else {
-    return RefRead(ref, op->span);
-  }
+Expr ExprMutator::VisitExpr_(const RefReadNode* ref_read) {
+  Expr ref = this->Mutate(ref_read->ref);
+  return WithFields(GetRef<RefRead>(ref_read), std::move(ref));
 }
 
-Expr ExprMutator::VisitExpr_(const RefWriteNode* op) {
-  Expr ref = this->Mutate(op->ref);
-  Expr value = this->Mutate(op->value);
-  if (ref.same_as(op->ref) && value.same_as(op->value)) {
-    return GetRef<Expr>(op);
-  } else {
-    return RefWrite(ref, value, op->span);
-  }
+Expr ExprMutator::VisitExpr_(const RefWriteNode* ref_write) {
+  Expr ref = this->Mutate(ref_write->ref);
+  Expr value = this->Mutate(ref_write->value);
+  return WithFields(GetRef<RefWrite>(ref_write), std::move(ref), std::move(value));
 }
 
 Expr ExprMutator::VisitExpr_(const ConstructorNode* c) { return GetRef<Expr>(c); }
 
-Expr ExprMutator::VisitExpr_(const MatchNode* m) {
-  bool unchanged = true;
-  std::vector<Clause> clauses;
-  for (const Clause& p : m->clauses) {
-    Clause c = VisitClause(p);
-    clauses.push_back(c);
-    unchanged &= c.same_as(p);
+Expr ExprMutator::VisitExpr_(const MatchNode* match_node) {
+  Array<Clause> clauses;
+  for (const Clause& p : match_node->clauses) {
+    clauses.push_back(VisitClause(p));
   }
-  Expr data = Mutate(m->data);
-  unchanged &= data.same_as(m->data);
+  Expr data = Mutate(match_node->data);
 
-  if (unchanged) {
-    return GetRef<Expr>(m);
-  }
-  return Match(data, clauses, m->complete, m->span);
+  return WithFields(GetRef<Match>(match_node), std::move(data), std::move(clauses));
 }
 
-Clause ExprMutator::VisitClause(const Clause& c) {
-  Pattern p = VisitPattern(c->lhs);
-  Expr rhs = Mutate(c->rhs);
-  if (p.same_as(c->lhs) && rhs.same_as(c->rhs)) {
-    return c;
-  }
-  return Clause(p, rhs);
+Clause ExprMutator::VisitClause(const Clause& clause) {
+  Pattern lhs = VisitPattern(clause->lhs);
+  Expr rhs = Mutate(clause->rhs);
+  return WithFields(std::move(clause), std::move(lhs), std::move(rhs));
 }
 
 Pattern ExprMutator::VisitPattern(const Pattern& p) { return p; }
@@ -507,9 +459,9 @@ class ExprBinder : public MixedModeMutator, PatternMutator {
 
   Pattern VisitPattern(const Pattern& p) final { return PatternMutator::VisitPattern(p); }
 
-  Clause VisitClause(const Clause& c) final {
-    Pattern pat = VisitPattern(c->lhs);
-    return Clause(pat, VisitExpr(c->rhs));
+  Clause VisitClause(const Clause& clause) final {
+    Pattern lhs = VisitPattern(clause->lhs);
+    return WithFields(std::move(clause), std::move(lhs), VisitExpr(clause->rhs));
   }
 
   Var VisitVar(const Var& v) final {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -203,7 +203,8 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* func_node) {
   auto ret_type = this->VisitType(func_node->ret_type);
   auto body = this->Mutate(func_node->body);
 
-  return WithFields(GetRef<Function>(func_node), std::move(params), std::move(body), std::move(ret_type), std::move(ty_params));
+  return WithFields(GetRef<Function>(func_node), std::move(params), std::move(body),
+                    std::move(ret_type), std::move(ty_params));
 }
 
 Expr ExprMutator::VisitExpr_(const CallNode* call_node) {

--- a/src/relay/transforms/partial_eval.cc
+++ b/src/relay/transforms/partial_eval.cc
@@ -615,8 +615,8 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
       value.push_back(ps);
       expr.push_back(ps->dynamic);
     }
-    // Note(@electriclilies): The partial evaluator seems to do some weird stuff with sharing.
-    // Changing Tuple(expr) to WithFields(op, expr) causes some strange failures.
+    // Note: The partial evaluator seems to do some weird stuff with sharing. Changing Tuple(expr)
+    // to WithFields(op, expr) causes failures in the partial evaluator tests.
     return HasStatic(MkSTuple(value), ll->Push(Tuple(expr)));
   }
 


### PR DESCRIPTION
In this PR, I implement the WithFields method for Call, Function, Var, TupleGetItem, If, Let, RefCreate, RefRead, RefWrite, Match and Clause. It is a continuation of work in #9533, where I implement WithFields for Tuples.  
Additionally, I remove the explicit COW logic from the visitors in expr_functor.cc for these classes. In future work, I'll use these methods to replace most explicit reconstructions of these classes in visitors.
@mbs-octoml @mikepapadim PTAL! I would especially appreciate typo checks in the documentation, I did a lot of copy-pasting and probably missed some things there.
cc @tqchen in case you are interested -- I've kept the API consistent with what we discussed for WithFields for tuples