### PR TITLE
[BUG][TVMScript] fix block range error

### DIFF
--- a/python/tvm/script/tir/special_stmt.py
+++ b/python/tvm/script/tir/special_stmt.py
@@ -468,10 +468,12 @@ class BlockAxis(SpecialStmt):
         block_var = tvm.tir.Var(var_name, dtype="int32")
         dom = tvm.runtime.convert(dom)
         if isinstance(dom, PrimExpr):
-            dom = tvm.ir.Range.from_min_extent(0, dom)
+            dom = tvm.ir.Range(dom)
+        elif isinstance(dom, tvm.ir.container.Array) and len(dom) == 2:
+            dom = tvm.ir.Range(dom[0], dom[1])
         elif not isinstance(dom, tvm.ir.Range):
             self.context.report_error(
-                f"Block axis domain expected PrimExpr or Range, but got {type(value)}",
+                f"Block axis domain expected PrimExpr or Range, but got {type(dom)}",
                 self.node.span,
             )
         value = tvm.runtime.convert(value)

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3190,5 +3190,20 @@ def test_loop_extent_dependent():
     tvm.ir.assert_structural_equal(func, rt_func, True)
 
 
+@T.prim_func
+def nontrivial_range_axis(a: T.handle) -> None:
+    A = T.match_buffer(a, (10), "float32")
+    for i in range(10):
+        with T.block("block"):
+            vi = T.axis.spatial((1, 11), i + 1)
+            A[vi - 1] = A[vi - 1] + 1.0
+
+
+def test_nontrivial_range_axis():
+    func = nontrivial_range_axis
+    rt_func = tvm.script.from_source(func.script(show_meta=True))
+    tvm.ir.assert_structural_equal(func, rt_func, True)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
TVM runtime will convert (1, 11) to Array rather than Range. So `vi = T.axis.spatial((1, 11), i)` fails due to (1, 11).
This PR fixes this bug. Reported by @wrongtest 

cc @junrushao1994 