### PR TITLE
[Frontend][ONNX] ignore 'training_mode' tag from onnx in batch_norm op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -395,8 +395,10 @@ class BatchNorm(OnnxOpConverter):
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
         # TODO(zhreshold): 'spatial' is not properly handled here.
+        # TODO(vvchernov): 'training_mode' (onnx tag) is not correctly handled, ignore for now
         out = AttrCvt(
-            op_name="batch_norm", ignores=["spatial", "is_test", "consumed_inputs", "momentum"]
+            op_name="batch_norm",
+            ignores=["spatial", "is_test", "consumed_inputs", "momentum", "training_mode"],
         )(inputs, attr, params)
         return out[0]
 


### PR DESCRIPTION
Onnxruntime framework is developed and moves to supporting of model training due to this new versions of onnx generate new tags like 'training_mode' in batch_norm op. TVM batch_norm op does not support this tag and should ignore it for correct work.
@denise-k @jwfromm Please see
