### PR TITLE
Separate Windows and MacOS GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,22 @@
+runs:
+ using: "composite"
+ steps:
+  - uses: actions/cache@v1
+    env:
+      CACHE_NUMBER: 0
+    with:
+      path: ~/conda_pkgs_dir
+      key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/build-environment.yaml') }}
+  - uses: conda-incubator/setup-miniconda@v2
+    with:
+      activate-environment: tvm-build
+      channel-priority: strict
+      environment-file: conda/build-environment.yaml
+      auto-activate-base: false
+      use-only-tar-bz2: true
+  - name: Conda info
+    shell: pwsh
+    run: |
+      conda info
+      conda list
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@
 # We use it to cover windows and mac builds
 # Jenkins is still the primary CI
 
-name: WinMacBuild
+name: CI
 
 on:
   push:
@@ -30,49 +30,25 @@ on:
     branches:
       - main
 
+concurrency:
+  group: CI-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
-  Build:
-    strategy:
-      matrix:
-        os: [windows-2016, macOS-latest]
-
-    runs-on: ${{ matrix.os }}
-
+  MacOS:
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Initialize submodules
-      run: git submodule update --recursive --init
-    - uses: actions/cache@v1
-      env:
-        CACHE_NUMBER: 0
       with:
-        path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/build-environment.yaml') }}
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        activate-environment: tvm-build
-        channel-priority: strict
-        environment-file: conda/build-environment.yaml
-        auto-activate-base: false
-        use-only-tar-bz2: true
-    - name: Conda info
-      run: |
-        conda info
-        conda list
-    - name: Conda-Build@Win
-      if: startsWith(matrix.os, 'windows')
-      shell: cmd /C call {0}
-      run: >-
-        conda build --output-folder=conda/pkg conda/recipe &&
-        conda install tvm -c ./conda/pkg
-    - name: Conda-Build@MacOS
-      if: startsWith(matrix.os, 'macOS')
+        submodules: 'recursive'
+    - name: Set up environment
+      uses: ./.github/actions/setup
+    - name: Conda Build
       shell: bash -l {0}
       run: >-
         conda build --output-folder=conda/pkg  conda/recipe &&
         conda install tvm -c ./conda/pkg
-    - name: Build iOS RPC@MacOS
-      if: startsWith(matrix.os, 'macOS')
+    - name: Build iOS RPC
       run: |
         IOS_VERSION="14.0"
         CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release \
@@ -88,18 +64,11 @@ jobs:
         cd build-ios-simulator
         cmake .. ${CMAKE_FLAGS}
         cmake --build . --target ios_rpc
-    - name: Test@Win
-      if: startsWith(matrix.os, 'windows')
-      shell: cmd /C call {0}
-      run: >-
-        python -m pytest -v tests/python/all-platform-minimal-test
-    - name: Test@MacOS
-      if: startsWith(matrix.os, 'macOS')
+    - name: Test
       shell: bash -l {0}
       run: >-
         python -m pytest -v tests/python/all-platform-minimal-test
-    - name: Test iOS RPC@MacOS
-      if: startsWith(matrix.os, 'macOS')
+    - name: Test iOS RPC
       shell: bash -l {0}
       run: >-
         python -m pip install tornado psutil cloudpickle &&
@@ -107,3 +76,22 @@ jobs:
         export BUNDLE_ID=org.apache.tvmrpc &&
         export BUNDLE_PATH=build-ios-simulator/apps/ios_rpc/ios_rpc/src/ios_rpc-build/Release-iphonesimulator/tvmrpc.app &&
         python -m pytest -v tests/python/contrib/test_rpc_server_device.py
+
+  Windows:
+    runs-on: windows-2016
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Set up environment
+      uses: ./.github/actions/setup
+    - name: Conda Build
+      shell: cmd /C call {0}
+      run: >-
+        conda build --output-folder=conda/pkg conda/recipe &&
+        conda install tvm -c ./conda/pkg
+    - name: Test
+      shell: cmd /C call {0}
+      run: >-
+        python -m pytest -v tests/python/all-platform-minimal-test
+


### PR DESCRIPTION
Previously these were in one workflow with `if`s on every step after some common setup. This pulls out the common stuff into a local action and makes macos and windows builds completely separate, removing the need for any `if`s to skip steps so everything looks little cleaner. This also has some minor cleanups:
* use `submodules: recursive` on `actions/checkout` to avoid manually getting submodules
* add a `concurrency` key so that pushes that happen before the job is finished cancel previously running jobs on the same PR

@areusch @tqchen 