### PR TITLE
[tvmc] Adds ethos-u-vela dependency in the `tvmc` set of python dependencies.

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -143,6 +143,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
         (
             "Requirements for the tvmc command-line tool",
             [
+                "ethos-u-vela",
                 "future",  # Hidden dependency of torch.
                 "onnx",
                 "onnxruntime",


### PR DESCRIPTION
The ethos-u-vela dependency is required for tvmc, given we support "ethos-u" as one  part of our tvmc targets, therefore, we need to add this package to the optional set of dependencies that users explicit ask when using tvmc.

There is no impact for other sets of dependencies.

cc @manupa-arm @grant-arm @areusch @gromero for reviews