### PR TITLE
[CUDNN] Properly support NHWC layout for cuDNN

### DIFF
--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -102,8 +102,8 @@ def verify_conv2d(data_dtype, conv_dtype, tensor_format=0, groups=1):
 def test_conv2d():
     verify_conv2d("float32", "float32", tensor_format=0)
     verify_conv2d("float16", "float32", tensor_format=1)
-    # This test is flaky, disable for now
-    # verify_conv2d("float16", "float16", tensor_format=0)
+    verify_conv2d("float16", "float16", tensor_format=0)
+    verify_conv2d("float16", "float16", tensor_format=1)
     verify_conv2d("int8", "int32", tensor_format=1)
 
     verify_conv2d("float32", "float32", tensor_format=0, groups=2)


### PR DESCRIPTION
Currently, using the NHWC layout with `-libs=cudnn` doesn't work for two reasons:

1. Relay op strategy doesn't handle `kernel_layout == OHWI` case, which cudnn + NHWC requires.
2. Kernel profiling is completely busted. A sample output is shown below. Even if on a workload that tensorcore can be applied, a generic direct algorithm (not `CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM`) is always chosen at runtime.
```
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:278:    CUDNN Found 8 fwd algorithms, choosing CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            0) CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            1) CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            2) CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            3) CUDNN_CONVOLUTION_FWD_ALGO_GEMM - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            4) CUDNN_CONVOLUTION_FWD_ALGO_DIRECT - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            5) CUDNN_CONVOLUTION_FWD_ALGO_FFT - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            6) CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING - time: -1 ms, Memory: 0
[19:36:21] ../src/runtime/contrib/cudnn/conv_forward.cc:281:            7) CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD - time: -1 ms, Memory: 0
```

This PR fixes both of issues above. Kernel profiling now works and I can see that cuDNN is choosing a tensorcore kernel (based on `nvprof` output).
```
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:277:    CUDNN Found 8 fwd algorithms, choosing CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            0) CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM - time: 0.030624 ms, Memory: 0
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            1) CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM - time: 0.045632 ms, Memory: 1168
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            2) CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM - time: 0.474752 ms, Memory: 51472
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            3) CUDNN_CONVOLUTION_FWD_ALGO_GEMM - time: -1 ms, Memory: 0
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            4) CUDNN_CONVOLUTION_FWD_ALGO_DIRECT - time: -1 ms, Memory: 0
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            5) CUDNN_CONVOLUTION_FWD_ALGO_FFT - time: -1 ms, Memory: 0
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            6) CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING - time: -1 ms, Memory: 0
[19:35:41] ../src/runtime/contrib/cudnn/conv_forward.cc:280:            7) CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD - time: -1 ms, Memory: 0
```

The reason kernel profiling was failing is apparently due to `cudnnSetTensorNdDescriptor` API. Looking at the [doc](https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnSetTensorNdDescriptor), I don't think it supports NHWC layout. There is another API `cudnnSetTensorNdDescriptorEx` which does take the tensor format into account. I tried it but it didn't fix the problem either.

This issue is probably the same one as reported by @Laurawly long time ago
https://discuss.tvm.apache.org/t/cudnn-tensorcore-support-has-wrong-results-and-strange-timing-for-fp16-and-int8/5896
 
@comaniac @Hzfengsy @vinx13 @Laurawly 