### PR TITLE
[DRIVER] Specify name when build with primfunc

### DIFF
--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -228,7 +228,11 @@ def build(
         for x in inputs:
             merged_mod.update(lower(x))
         input_mod = merged_mod
-    elif isinstance(inputs, (tvm.IRModule, PrimFunc)):
+    elif isinstance(inputs, PrimFunc):
+        input_mod = lower(inputs, name=name)
+    elif isinstance(inputs, tvm.IRModule):
+        if name is not None:
+            warnings.warn("Specifying name with IRModule input is useless")
         input_mod = lower(inputs)
     elif not isinstance(inputs, (dict, container.Map)):
         raise ValueError(


### PR DESCRIPTION
If pass a primfunc into tvm.build(), explicitly pass a function name now take no effect, which seems to be a non-prefered behavior.
