### PR TITLE
[Fix] Update the return value type of GraphExecutorCodegen.codegen

### DIFF
--- a/python/tvm/relay/backend/graph_executor_codegen.py
+++ b/python/tvm/relay/backend/graph_executor_codegen.py
@@ -78,7 +78,7 @@ class GraphExecutorCodegen(object):
         -------
         graph_json : str
             The graph json that can be consumed by runtime.
-        mod : IRModule or Dict[str, IRModule]
+        mod : IRModule or Dict[Target, IRModule]
             The lowered functions.
         params : Dict[str, tvm.nd.NDArray]
             Additional constant parameters.


### PR DESCRIPTION
The return value type of `GraphExecutorCodegen.codegen` is `Dict[Target, IRModule]` in fact, while the annotation is still `Dict[str, IRModule]`