### PR TITLE
adding ArgReduceAttr to to inherit from Attrs

### DIFF
--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -509,6 +509,11 @@ class ReduceAttrs(Attrs):
     """Attributes used in reduction operators (e.g. sum)"""
 
 
+@tvm._ffi.register_object("relay.attrs.ArgReduceAttrs")
+class ArgReduceAttrs(Attrs):
+    """Attributes used in reduction operators (e.g. sum)"""
+
+
 @tvm._ffi.register_object("relay.attrs.VarianceAttrs")
 class VarianceAttrs(Attrs):
     """Attributes used in reduction operators (e.g. sum)"""

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -511,7 +511,7 @@ class ReduceAttrs(Attrs):
 
 @tvm._ffi.register_object("relay.attrs.ArgReduceAttrs")
 class ArgReduceAttrs(Attrs):
-    """Attributes used in reduction operators (e.g. sum)"""
+    """Attributes used in reduction operators (e.g. argmin/argmax)"""
 
 
 @tvm._ffi.register_object("relay.attrs.VarianceAttrs")


### PR DESCRIPTION
This PR is related to [Issue-11583](https://discuss.tvm.apache.org/t/tvm-relay-attrs-argreduceattrs-not-inheriting-from-attrs-in-python/11583)

Not able to use `.keys()` on `tvm.relay.attrs.ArgReduceAttrs`

This PR is intended to fix this.