### PR TITLE
[TVMC] run: Fix call to non-existing method

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -185,9 +185,7 @@ def drive_run(args):
     if args.device == "micro":
         path = path / "model.tar"
         if not path.is_file():
-            TVMCException(
-                f"Could not find model (model.tar) in the specified project dir {path.dirname()}."
-            )
+            TVMCException(f"Could not find model '{path}'!")
 
         # Check for options unavailable for micro targets.
 


### PR DESCRIPTION
'path' has no method 'dirname' and so currently will throw an invalid
attribute exception when a 'model.tar' file can not be found in the
project directory:

```
gromero@amd:~/git/tvm$ tvmc run --device micro /tmp/x9584 --project-option arduino_board=due
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:191: Warning: Unable to detect CUDA version, default to "-mcpu=sm_20" instead
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:217: Warning: Unable to detect ROCm compute arch, default to "-mcpu=gfx900" instead
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:231: Warning: Unable to detect ROCm version, assuming >= 3.5
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:163: Warning: Unable to detect CUDA version, default to "-arch=sm_20" instead
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:191: Warning: Unable to detect CUDA version, default to "-mcpu=sm_20" instead
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:217: Warning: Unable to detect ROCm compute arch, default to "-mcpu=gfx900" instead
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:231: Warning: Unable to detect ROCm version, assuming >= 3.5
[19:29:25] /home/gromero/git/tvm/src/target/target_kind.cc:163: Warning: Unable to detect CUDA version, default to "-arch=sm_20" instead
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/gromero/git/tvm/python/tvm/driver/tvmc/__main__.py", line 24, in <module>
    tvmc.main.main()
  File "/home/gromero/git/tvm/python/tvm/driver/tvmc/main.py", line 100, in main
    sys.exit(_main(sys.argv[1:]))
  File "/home/gromero/git/tvm/python/tvm/driver/tvmc/main.py", line 93, in _main
    return args.func(args)
  File "/home/gromero/git/tvm/python/tvm/driver/tvmc/runner.py", line 189, in drive_run
    f"Could not find model (model.tar) in the specified project dir {path.dirname()}."
AttributeError: 'PosixPath' object has no attribute 'dirname'
```

This commit fixes it by using 'path' var only when raising the TVMCException.
