### PR TITLE
[MetaSchedule] Fix comments in instruction traits

### DIFF
--- a/src/tir/schedule/instruction_traits.h
+++ b/src/tir/schedule/instruction_traits.h
@@ -56,12 +56,12 @@ namespace tir {
  *      const Array<String>& outputs);
  *
  *   // Convertible to `InstructionKindNode::FInstructionAttrsAsJSON`
- *   static Array<ObjectRef> AttrsAsJSON(
+ *   static ObjectRef AttrsAsJSON(
  *      const Array<ObjectRef>& attrs);
  *
  *   // Convertible to `InstructionKindNode::FInstructionAttrsFromJSON`
  *   static Array<ObjectRef> AttrsFromJSON(
- *      const Array<ObjectRef>& attrs_record);
+ *      const ObjectRef& attrs_record);
  * };
  *
  * TVM_REGISTER_INST_KIND_TRAITS(SomeInstructionKindTraits);


### PR DESCRIPTION
The example in the comment is inconsistent with https://github.com/apache/tvm/blob/main/include/tvm/tir/schedule/instruction.h#L61-L75

@junrushao1994 