### PR TITLE
[EZ][Autoscheduler] Log exceptions in topi lowering

### DIFF
--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -42,6 +42,7 @@ from .dispatcher import DispatchContext
 from .search_task import SearchTask
 from .utils import get_const_tuple
 from .workload_registry import register_workload_tensors
+import traceback
 
 logger = logging.getLogger("auto_scheduler")
 
@@ -66,9 +67,12 @@ def call_all_topi_funcs(mod, params, target, opt_level=3):
         if params:
             compiler.set_params(params)
         mod = tvm.IRModule.from_expr(mod) if isinstance(mod, relay.Function) else mod
-        compiler.lower(mod, target)
-
-    autotvm.GLOBAL_SCOPE.silent = old_autotvm_silent
+        try:
+            compiler.lower(mod, target)
+        except Exception:
+            logger.warning(f"Got exception in task extraction:\n{traceback.format_exc()}")
+        finally:
+            autotvm.GLOBAL_SCOPE.silent = old_autotvm_silent
 
 
 def extract_tasks(

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -69,9 +69,7 @@ def call_all_topi_funcs(mod, params, target, opt_level=3):
         mod = tvm.IRModule.from_expr(mod) if isinstance(mod, relay.Function) else mod
         try:
             compiler.lower(mod, target)
-
-        # pylint: disable=broad-except
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             logger.warning("Got exception in task extraction:\n %s", traceback.format_exc())
         finally:
             autotvm.GLOBAL_SCOPE.silent = old_autotvm_silent

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -25,6 +25,7 @@ Integrate auto_scheduler into relay. It implements the following items:
 import json
 import logging
 import threading
+import traceback
 import warnings
 
 import tvm
@@ -42,7 +43,6 @@ from .dispatcher import DispatchContext
 from .search_task import SearchTask
 from .utils import get_const_tuple
 from .workload_registry import register_workload_tensors
-import traceback
 
 logger = logging.getLogger("auto_scheduler")
 
@@ -69,8 +69,10 @@ def call_all_topi_funcs(mod, params, target, opt_level=3):
         mod = tvm.IRModule.from_expr(mod) if isinstance(mod, relay.Function) else mod
         try:
             compiler.lower(mod, target)
+
+        # pylint: disable=broad-except
         except Exception:
-            logger.warning(f"Got exception in task extraction:\n{traceback.format_exc()}")
+            logger.warning(f"Got exception in task extraction:\n %s", traceback.format_exc())
         finally:
             autotvm.GLOBAL_SCOPE.silent = old_autotvm_silent
 

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -72,7 +72,7 @@ def call_all_topi_funcs(mod, params, target, opt_level=3):
 
         # pylint: disable=broad-except
         except Exception:
-            logger.warning(f"Got exception in task extraction:\n %s", traceback.format_exc())
+            logger.warning("Got exception in task extraction:\n %s", traceback.format_exc())
         finally:
             autotvm.GLOBAL_SCOPE.silent = old_autotvm_silent
 

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -30,6 +30,7 @@ import warnings
 
 import tvm
 from tvm import autotvm, transform
+from tvm._ffi.base import TVMError
 from tvm.ir.transform import PassContext
 from tvm.runtime import convert_to_object
 from tvm.target import Target
@@ -69,7 +70,7 @@ def call_all_topi_funcs(mod, params, target, opt_level=3):
         mod = tvm.IRModule.from_expr(mod) if isinstance(mod, relay.Function) else mod
         try:
             compiler.lower(mod, target)
-        except Exception: # pylint: disable=broad-except
+        except TVMError:
             logger.warning("Got exception in task extraction:\n %s", traceback.format_exc())
         finally:
             autotvm.GLOBAL_SCOPE.silent = old_autotvm_silent


### PR DESCRIPTION
During task extraction we might not support an operator. Right now we have an uncaught exception which gets sent to std error. Now we send it to the autoscheduler logger instead.

Finally, we restore the autotvm GLOBAL_SCOPE state though I don't believe this is technically needed since the thread will end execution shortly after.