### PR TITLE
[BugFix][Micro] fix tvm.micro ImportError in tvmc when USE_MICRO is OFF

### DIFF
--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -69,7 +69,7 @@ from . import support
 # Contrib initializers
 from .contrib import rocm as _rocm, nvcc as _nvcc, sdaccel as _sdaccel
 
-if not _RUNTIME_ONLY and support.libinfo().get("USE_MICRO", "OFF") == "ON":
+if not _RUNTIME_ONLY and support.check_micro_support():
     from . import micro
 
 # NOTE: This file should be python2 compatible so we can

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -36,6 +36,7 @@ import warnings
 
 import tvm._ffi
 import tvm.ir.transform
+import tvm.support
 from tvm import nd
 from tvm import rpc as _rpc
 from tvm.autotvm.env import AutotvmGlobalScope, reset_global_scope
@@ -537,11 +538,10 @@ class _WrappedBuildFunc:
             # TODO(tvm-team) consider linline _build_func_common
             func, arg_info = _build_func_common(measure_input, self.runtime, **kwargs)
             if self.build_func.output_format == ".model-library-format":
+                tvm.support.check_micro_support(raise_error=True)
                 # Late import to preserve autoTVM with USE_MICRO OFF
-                try:
-                    from tvm import micro  # pylint: disable=import-outside-toplevel
-                except ImportError:
-                    raise ImportError("Requires USE_MICRO")
+                from tvm import micro  # pylint: disable=import-outside-toplevel
+
                 micro.export_model_library_format(func, filename)
             else:
                 func.export_library(filename, self.build_func)

--- a/python/tvm/driver/tvmc/__init__.py
+++ b/python/tvm/driver/tvmc/__init__.py
@@ -19,7 +19,11 @@
 TVMC - TVM driver command-line interface
 """
 
-from . import micro
+from tvm.support import check_micro_support
+
+# pylint: disable=wrong-import-position
+if check_micro_support():
+    from . import micro
 from . import runner
 from . import autotuner
 from . import compiler

--- a/python/tvm/driver/tvmc/model.py
+++ b/python/tvm/driver/tvmc/model.py
@@ -56,11 +56,7 @@ from tvm.contrib import utils
 from tvm.relay.backend.executor_factory import GraphExecutorFactoryModule
 from tvm.runtime.module import BenchmarkResult
 
-try:
-    from tvm.micro import export_model_library_format
-except ImportError:
-    export_model_library_format = None
-
+from . import check_micro_support
 from .common import TVMCException
 
 
@@ -286,10 +282,11 @@ class TVMCModel(object):
                 executor_factory, package_path, cross, cross_options, output_format
             )
         elif output_format == "mlf":
-            if export_model_library_format:
-                package_path = export_model_library_format(executor_factory, package_path)
-            else:
-                raise Exception("micro tvm is not enabled. Set USE_MICRO to ON in config.cmake")
+            check_micro_support(raise_error=True)
+            # pylint: disable=import-outside-toplevel
+            from tvm.micro import export_model_library_format
+
+            package_path = export_model_library_format(executor_factory, package_path)
 
         return package_path
 

--- a/python/tvm/support.py
+++ b/python/tvm/support.py
@@ -39,6 +39,17 @@ def libinfo():
     return dict(lib_info.items())
 
 
+USE_MICRO = libinfo().get("USE_MICRO", "OFF") == "ON"
+
+
+def check_micro_support(raise_error=False):
+    if USE_MICRO:
+        return True
+    if raise_error:
+        raise Exception("micro tvm is not enabled. Set USE_MICRO to ON in config.cmake")
+    return False
+
+
 class FrontendTestModule(Module):
     """A tvm.runtime.Module whose member functions are PackedFunc."""
 


### PR DESCRIPTION
As discussed in issue https://github.com/apache/tvm/issues/9617.

Recently `tvm.micro` is imported by tvmc even though `USE_MICRO` macro is `OFF`.
This bug was mistakenly introduced by https://github.com/apache/tvm/pull/9229.

As we can see in
https://github.com/apache/tvm/blob/32e80128d195db9987e47a89755f4ef4d7cf8e8d/python/tvm/driver/tvmc/__init__.py#L22
and
https://github.com/apache/tvm/blob/32e80128d195db9987e47a89755f4ef4d7cf8e8d/python/tvm/driver/tvmc/runner.py#L37-L39

I tried to fix it by,
- adding a `check_micro_support` api to `tvm.support`,
- lazy import `tvm.micro` after `check_micro_support` to preserve tvm with USE_MICRO OFF.