### PR TITLE
[CI][microNPU]Running tests parallel using pytest-xdist

### DIFF
--- a/tests/python/contrib/test_ethosu/test_placeholder.py
+++ b/tests/python/contrib/test_ethosu/test_placeholder.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This files contain a placeholder test that always run"""
+"""This file contains a placeholder test that always run"""
 
 
 def test_placeholder():

--- a/tests/python/contrib/test_ethosu/test_placeholder.py
+++ b/tests/python/contrib/test_ethosu/test_placeholder.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This files contain a placeholder test that always run"""
+
+
+def test_placeholder():
+    """
+    This test always run on every docker image.
+    Otherwise, pytest will return exit code 5
+    and breaks CI in the docker images where
+    microNPU tests are not run.
+    """
+    pass

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -60,7 +60,10 @@ run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_p
 # TVM_FFI=ctypes sh prepare_and_test_tfop_module.sh
 
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME} tests/python/integration
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib
+
+# Ignoring Arm(R) Ethos(TM)-U NPU tests in the collective to run to run them in parallel in the next step.
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto
 
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \


### PR DESCRIPTION
The microNPU tests runs safely, parallel using pytest-xdist.
This commit introduces changes to run them in parallel on
CI.
