### PR TITLE
[CORE][MVP]  POC of fuse ops pass based on the DFPatterns

### DIFF
--- a/include/tvm/relay/dataflow_matcher.h
+++ b/include/tvm/relay/dataflow_matcher.h
@@ -97,14 +97,28 @@ Expr RewritePatterns(Array<DFPatternCallback> callbacks, Expr expr, IRModule mod
  * \brief Partition all matches of a DFPattern inside an Expr into separate Function calls
  *
  * \param pattern The pattern to match
- * \param expr The expression to patition
+ * \param expr The expression to partition
  * \param attrs A set of parameter names and values to apply to the partitioned function
  * \param check A callback function for checking more complicated properties of the matched
  * expressions, returns true if the match is accepted and false otherwise
  *
- * \return Return the paritioned Expr.
+ * \return Return the partitioned Expr.
  */
 Expr PartitionPattern(DFPattern pattern, Expr expr, Map<String, ObjectRef> attrs, PackedFunc check);
+
+/*!
+ * \brief Partition all matches of a DFPattern inside an Expr into separate Function calls
+ *
+ * \param patterns An array of patterns to match in hierarchical order.
+ * \param expr The expression to partition
+ * \param attrs A set of parameter names and values to apply to the partitioned function
+ * \param check A callback function for checking more complicated properties of the matched
+ * expressions, returns true if the match is accepted and false otherwise
+ *
+ * \return Return the partitioned Expr.
+ */
+Expr PartitionPattern(Array<DFPattern> patterns, Expr expr, Map<String, ObjectRef> attrs,
+                      PackedFunc check);
 
 }  // namespace relay
 }  // namespace tvm

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -134,6 +134,14 @@ TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
 TVM_DLL Pass DefuseOps();
 
 /*!
+ * \brief Fuse operation based on pattern-based rules and splits the initial graph into separate
+ * functions.
+ *
+ * \return The pass.
+ */
+TVM_DLL Pass FuseWithPattern();
+
+/*!
  * \brief Rewrite the annotated program.
  *
  * \param fallback_device The fallback device which is the default device for
@@ -250,13 +258,23 @@ TVM_DLL Pass DynamicToStatic();
 /*!
  * \brief Infer the type of an expression.
  *
- * The result of type checking is a new expression with unambigous
+ * The result of type checking is a new expression with unambiguous
  * type information filled in, as well as it's checked type field
  * populated with the result type.
  *
  * \return The pass.
  */
 TVM_DLL Pass InferType();
+
+/*!
+ * \brief Annoate primitive functions
+ *
+ * The result is an update module with annotated the primitive functions originated from the fuse
+ * ops pass.
+ *
+ * \return The pass.
+ */
+TVM_DLL Pass AnnotatePostFuseFuncs();
 
 /*!
  * \brief Search and eliminate common subexpression. For example, if there are

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -299,6 +299,21 @@ def DefuseOps():
     return _ffi_api.DefuseOps()
 
 
+def FuseWithPattern():
+    """Fuse operators in an expr to a larger operator according to some rules.
+    Parameters
+    ----------
+    fuse_opt_level : int
+        The level of fuse optimization. -1 indicates that the level will be
+        inferred from pass context.
+    Returns
+    -------
+    ret : tvm.transform.Pass
+        The registered pass for operator fusion.
+    """
+    return _ffi_api.FuseWithPattern()
+
+
 def CombineParallelConv2D(min_num_branches=3):
     """Combine multiple conv2d operators into one.
 
@@ -524,7 +539,10 @@ def MergeComposite(pattern_table):
     for tup in pattern_table:
         if len(tup) == 2:
             pattern_name, pattern = tup
-            check = lambda extract: True
+
+            def check(extract):
+                return True
+
         elif len(tup) == 3:
             pattern_name, pattern, check = tup
 

--- a/src/relay/transforms/annotate_post_fuse_funcs.cc
+++ b/src/relay/transforms/annotate_post_fuse_funcs.cc
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/transforms/fold_explicit_padding.cc
+ * \brief A pass for folding explicit pads into other ops.
+ */
+
+#include <tvm/relay/dataflow_matcher.h>
+#include <tvm/relay/expr.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/transform.h>
+#include <tvm/runtime/logging.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "../op/tensor/transform.h"
+#include "./pattern_fuse.h"
+
+namespace tvm {
+namespace relay {
+
+namespace transform {
+
+Pass AnnotatePostFuseFuncs() {
+  auto pass_info = PassInfo(0, "AnnotatePostFuseFuncs", {});
+  return tvm::transform::CreateModulePass(
+      [=](IRModule mod, const PassContext& pass_ctx) {
+        // Execute the pass function and return a new module.
+        IRModule updated_mod = mod->ShallowCopy();
+
+        pass_ctx->diag_ctx = DiagnosticContext::Default(updated_mod);
+
+        std::vector<std::pair<GlobalVar, Function> > updates;
+        for (const auto& it : updated_mod->functions) {
+          if (auto* func_node = it.second.as<FunctionNode>()) {
+            auto func = GetRef<Function>(func_node);
+
+            // add check from where it originate
+            func = WithAttr(std::move(func), attr::kPrimitive, tvm::Integer(1));
+
+            updates.push_back({it.first, Downcast<Function>(func)});
+          }
+        }
+
+        for (const auto& pair : updates) {
+          updated_mod->Add(pair.first, pair.second, true);
+        }
+
+        return updated_mod;
+      },
+      0, "AnnotatePostFuseFuncs", {});
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.AnnotatePostFuseFuncs").set_body_typed([]() {
+  return AnnotatePostFuseFuncs();
+});
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/transforms/pattern_fuse.cc
+++ b/src/relay/transforms/pattern_fuse.cc
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/transforms/pattern_fuse.cc
+ * \brief A pass to apply fuse_ops based on hierarchical DFPattern-based approach.
+ *
+ * Currently fuse_ops (i.e., src/relay/transforms/fuse_ops.cc) are legacy pass originate from the
+ * early days of TVM. At this point no helpers exist to simplify mutations in the relay IR. Also,
+ * hardware constrains in terms of hardware units were constraint. Also, original fuse_ops rely on
+ * OpPatternKind of each operator, as well as a hardcoded upper bound of the maximum number of ops
+ * to be fused together in a single kernel.
+ *
+ * This pass is stepping stone to leverage a more modern TVM approach to mutate graphs in the relay
+ * level. It uses the pattern language to express fusable patterns.
+ *
+ *
+ * Now the patterns are applied in hierarchical order as in \p Composer, and eventually will be
+ * split in 2 different phases respecting the legacy iterative process to fuse ops. These phases are
+ * the following:
+ *
+ * Phase 0
+ * -------
+ * Apply dominant/high-performing patterns, such as kOutEWiseFusable -> BroadCast* -> Elemwise
+ * (i.e., conv2->add->mul->relu) or kInjective* (i.e., exp*).
+ * Note: * operator on the given state denotes an IsUpTo operator, where the upper bound limit is
+ * the max number of ops to be fused to together.
+ *
+ * Phase 1:
+ * -------
+ * The second phase as TVM lowers a fused function, it expects all arguments to be a Tensor or a
+ * tuple containing only Tensors. But this tuple may contain a reference or another tuple. To avoid
+ * modifying codegen logic, we do not allow fusing through this node if the tuple contains such non
+ * Tensor fields.
+ * So, injective ops need to be fused into intermediate tuples.
+ */
+
+#include "./pattern_fuse.h"
+
+#include <tvm/relay/dataflow_matcher.h>
+#include <tvm/relay/expr.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/transform.h>
+#include <tvm/runtime/logging.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "../op/tensor/transform.h"
+#include "pass_utils.h"
+
+namespace tvm {
+namespace relay {
+static const Op& stop_fusion_op = Op::Get("annotation.stop_fusion");
+
+static const int DEPTH_OF_FUSED_OPS = 256;
+
+TVM_REGISTER_PASS_CONFIG_OPTION("relay.PatternFuse.max_depth", Integer);
+
+/*!
+ *  General fusor is to handle possible diamond shape branches, in the following graph, conv2d can
+ * be fused to elemwise add.
+ *
+ *           conv2d
+ *          /  |  \
+ *         /   |   \
+ *       op    op   op
+ *        \    |    /
+ *         \   |   /
+ *        elemwise add
+ *             |
+ */
+class GeneralFusorPattern {
+ public:
+  GeneralFusorPattern() {
+    attrs_elemwise.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_broad.Set("TOpPattern", Integer(static_cast<int>(kBroadcast)));
+    attrs_kfusable.Set("TOpPattern", Integer(static_cast<int>(kOutEWiseFusable)));
+
+    x = IsWildcard();
+    y = IsWildcard();
+
+    k_elemwise_fusable = IsWildcard().HasAttr(attrs_kfusable)({x, y});
+
+    broadcast_op = IsWildcard().HasAttr(attrs_broad)({k_elemwise_fusable, IsWildcard()});
+
+    for (int idx = 0; idx < DEPTH_OF_FUSED_OPS; idx++) {
+      broadcast_op =
+          broadcast_op || IsWildcard().HasAttr(attrs_broad_next)({IsWildcard(), broadcast_op});
+    }
+
+    elemwise_op = IsWildcard().HasAttr(attrs_elemwise);
+
+    pattern_ = elemwise_op({broadcast_op});
+  }
+
+  String GetPatternID() { return "GeneralFusorPattern"; }
+
+  DFPattern GetPattern() { return pattern_; }
+
+ private:
+  Map<String, ObjectRef> attrs_elemwise, attrs_broad, attrs_kfusable, attrs_broad_next;
+
+  DFPattern pattern_;
+  DFPattern k_elemwise_fusable;
+  DFPattern broadcast_op;
+  DFPattern elemwise_op;
+  DFPattern x;
+  DFPattern y;
+};
+
+class DomPattern {
+ public:
+  DomPattern() {
+    attrs_elemwise.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_broad.Set("TOpPattern", Integer(static_cast<int>(kBroadcast)));
+    attrs_kfusable.Set("TOpPattern", Integer(static_cast<int>(kOutEWiseFusable)));
+
+    x = IsWildcard();
+    y = IsWildcard();
+
+    k_elemwise_fusable = IsWildcard().HasAttr(attrs_kfusable)({x, y});
+
+    broadcast_op = IsWildcard().HasAttr(attrs_broad)({IsWildcard(), IsWildcard()});
+
+    for (int idx = 0; idx < DEPTH_OF_FUSED_OPS; idx++) {
+      broadcast_op =
+          broadcast_op || IsWildcard().HasAttr(attrs_broad_next)({IsWildcard(), broadcast_op});
+    }
+
+    elemwise_op = IsWildcard().HasAttr(attrs_elemwise)({broadcast_op});
+    // elemwise_op = IsOp("nn.relu")({IsWildcard});
+
+    pattern_ = elemwise_op;
+  }
+
+  String GetPatternID() { return "GeneralFusorPattern"; }
+
+  DFPattern GetPattern() { return pattern_; }
+
+ private:
+  Map<String, ObjectRef> attrs_elemwise, attrs_broad, attrs_kfusable, attrs_broad_next;
+
+  DFPattern pattern_;
+  DFPattern k_elemwise_fusable;
+  DFPattern broadcast_op;
+  DFPattern elemwise_op;
+  DFPattern x;
+  DFPattern y;
+};
+
+class DomPatternKElemwise {
+ public:
+  /*! Trying to get into the following
+  // kOutEWiseFusable --> KBroadCast* --> Elemwise* */
+  DomPatternKElemwise() {
+    attrs_elemwise.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_broad.Set("TOpPattern", Integer(static_cast<int>(kBroadcast)));
+    attrs_kfusable.Set("TOpPattern", Integer(static_cast<int>(kOutEWiseFusable)));
+
+    elemwise_op = IsWildcard().HasAttr(attrs_elemwise)({IsWildcard()});
+
+    broadcast_op = IsWildcard().HasAttr(attrs_broad)({IsWildcard(), IsWildcard()});
+
+    pattern_ = DominatorPattern(k_elemwise_fusable, elemwise_op, broadcast_op);
+  }
+
+  String GetPatternID() { return "GeneralFusorPattern"; }
+
+  DFPattern GetPattern() { return pattern_; }
+
+ private:
+  Map<String, ObjectRef> attrs_elemwise, attrs_broad, attrs_kfusable, attrs_broad_next;
+
+  DFPattern pattern_;
+  DFPattern k_elemwise_fusable;
+  DFPattern broadcast_op;
+  DFPattern elemwise_op;
+  DFPattern x;
+  DFPattern y;
+};
+
+class KElemewiseBr {
+ public:
+  KElemewiseBr() {
+    attrs_elemwise.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_broad.Set("TOpPattern", Integer(static_cast<int>(kBroadcast)));
+    attrs_kfusable.Set("TOpPattern", Integer(static_cast<int>(kOutEWiseFusable)));
+
+    // x = IsVar(IsWildcard());
+    // y = IsVar(IsWildcard());
+
+    DFPattern var = IsVar("x");
+
+    k_elemwise_fusable = IsWildcard().HasAttr(attrs_kfusable);
+
+    broadcast_op = IsWildcard().HasAttr(attrs_broad)({k_elemwise_fusable, IsWildcard()});
+
+    for (int idx = 0; idx < DEPTH_OF_FUSED_OPS; idx++) {
+      broadcast_op =
+          broadcast_op || IsWildcard().HasAttr(attrs_broad_next)({IsWildcard(), broadcast_op});
+    }
+
+    // elemwise_op = IsWildcard().HasAttr(attrs_elemwise);
+
+    pattern_ = broadcast_op;
+  }
+
+  String GetPatternID() { return "GeneralFusorPattern"; }
+
+  DFPattern GetPattern() { return pattern_; }
+
+ private:
+  Map<String, ObjectRef> attrs_elemwise, attrs_broad, attrs_kfusable, attrs_broad_next;
+
+  DFPattern pattern_;
+  DFPattern k_elemwise_fusable;
+  DFPattern broadcast_op;
+  DFPattern elemwise_op;
+  DFPattern x;
+  DFPattern y;
+};
+
+class InjectiveOpsPattern {
+ public:
+  /*! Trying to get into the following
+  // kOutEWiseFusable --> KBroadCast* --> Elemwise* */
+  InjectiveOpsPattern() {
+    attrs_elemwise.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_elemwise_.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_broad.Set("TOpPattern", Integer(static_cast<int>(kBroadcast)));
+
+    kinjective_f = IsWildcard().HasAttr(attrs_elemwise)({IsWildcard()});
+    kinjective_s = IsWildcard().HasAttr(attrs_elemwise_)({IsWildcard()});
+
+    for (size_t i = 0; i < DEPTH_OF_FUSED_OPS; i++) {
+      kinjective_f = kinjective_f || IsWildcard().HasAttr(attrs_kinjective)({kinjective_f});
+      kinjective_s = kinjective_s || IsWildcard().HasAttr(attrs_kinjective_)({kinjective_s});
+    }
+
+    elemwise_op =
+        IsWildcard().HasAttr(attrs_broad)({IsWildcard().HasAttr(attrs_elemwise)({IsWildcard()}),
+                                           IsWildcard().HasAttr(attrs_elemwise_)({IsWildcard()})});
+
+    pattern_ = elemwise_op;
+  }
+
+  String GetPatternID() { return "InjectivePattern"; }
+
+  DFPattern GetPattern() { return pattern_; }
+
+ private:
+  Map<String, ObjectRef> attrs_elemwise, attrs_broad, attrs_kfusable, attrs_broad_next,
+      attrs_kinjective, attrs_kinjective_, attrs_elemwise_;
+
+  DFPattern pattern_;
+  DFPattern k_elemwise_fusable;
+  DFPattern broadcast_op;
+  DFPattern elemwise_op;
+  DFPattern kinjective_f;
+  DFPattern kinjective_s;
+};
+
+class MaxDepthOfKElemwiseOps {
+ public:
+  MaxDepthOfKElemwiseOps() {
+    attrs_elemwise.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+    attrs_elemwise_n.Set("TOpPattern", Integer(static_cast<int>(kElemWise)));
+
+    in_var = IsWildcard();
+    elemwise_op = IsWildcard().HasAttr(attrs_elemwise)({in_var});
+
+    for (int idx = 0; idx < DEPTH_OF_FUSED_OPS; idx++) {
+      elemwise_op = IsWildcard().HasAttr(attrs_elemwise_n)({elemwise_op}) || elemwise_op;
+    }
+
+    pattern_ = elemwise_op;
+  }
+
+  String GetPatternID() { return "MaxDepthOfKElemwiseOps"; }
+
+  DFPattern GetPattern() { return pattern_; }
+
+ private:
+  Map<String, ObjectRef> attrs_elemwise, attrs_elemwise_n;
+  DFPattern in_var;
+  DFPattern pattern_;
+  DFPattern elemwise_op;
+};
+
+Function InferType(const Function& expr, const IRModule& m) {
+  IRModule mod(m);
+  mod->Update(mod->GetGlobalVar("main"), expr);
+  mod = transform::InferType()(mod);
+  return Downcast<Function>(mod->Lookup("main"));
+}
+
+Expr FusePattern(const Function& func, const IRModule& mod) {
+  Function merged_func = func;
+  Map<String, ObjectRef> attrs;
+  DFPatternPartitionComposer df_composer;
+  // Phase 1
+  df_composer.AddPattern(GeneralFusorPattern().GetPattern());
+  df_composer.AddPattern(MaxDepthOfKElemwiseOps().GetPattern());
+  // df_composer.AddPattern(InjectiveOpsPattern().GetPattern());
+  // df_composer.AddPattern(KElemewiseBr().GetPattern());
+  // Phase 2
+  // Phase 3 : here we should merge into tuples
+
+  return PartitionPattern(df_composer.GetPatterns(), merged_func, attrs, PackedFunc());
+}
+
+namespace transform {
+
+Pass FuseWithPattern() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> fuse_pattern =
+      [=](Function f, IRModule m, PassContext pc) { return Downcast<Function>(FusePattern(f, m)); };
+
+  auto fuse_with_pattern = CreateFunctionPass(fuse_pattern, 0, "FuseWithPattern", {"InferType"});
+
+  return Sequential({fuse_with_pattern, AnnotatePostFuseFuncs()});
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.FuseWithPattern").set_body_typed(FuseWithPattern);
+
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/transforms/pattern_fuse.h
+++ b/src/relay/transforms/pattern_fuse.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relay/transforms/pattern_fuse.h
+ * \brief A pattern matcher for matching dataflow properties.
+ */
+#ifndef TVM_RELAY_TRANSFORMS_PATTERN_FUSE_H_
+#define TVM_RELAY_TRANSFORMS_PATTERN_FUSE_H_
+
+#include <tvm/relay/dataflow_pattern.h>
+#include <tvm/relay/dataflow_pattern_functor.h>
+
+namespace tvm {
+namespace relay {
+/*!
+ * \brief Base type of all dataflow patterns expressing fuse oops.
+ * \sa DFPatternPartitionComposer
+ */
+class DFPatternPartitionComposer {
+ public:
+  inline void AddPattern(DFPattern pattern) { patterns_.push_back(pattern); }
+
+  inline Array<DFPattern> GetPatterns() { return patterns_; }
+
+ private:
+  /*! \brief the rewrites to be composed. */
+  Array<DFPattern> patterns_;
+};
+}  // namespace relay
+}  // namespace tvm
+
+#endif  // TVM_RELAY_TRANSFORMS_PATTERN_FUSE_H_

--- a/tests/python/relay/test_dataflow_pattern.py
+++ b/tests/python/relay/test_dataflow_pattern.py
@@ -24,14 +24,17 @@ from tvm.relay.build_module import bind_params_by_name
 from tvm.relay.dataflow_pattern import *
 from tvm.relay.testing import run_opt_pass
 
-# NB: 1 corresponds to the C++ enum that specicfies this
+# NB: 1 corresponds to the C++ enum that specifies this
 # we loose the type safety due to the Python/C++ calling
 # convention.
 K_ELEMWISE = 0
 K_BROADCAST = 1
+K_INJECTIVE = 2
+K_COMM_REDUCE = 3
+K_OUT_EWISE_FUSABLE = 4
 
 
-## NODE TESTS
+# NODE TESTS
 def test_expr_pattern():
     ep = is_expr(relay.var("x", shape=(4, 1)))
     assert isinstance(ep, ExprPattern)
@@ -151,7 +154,7 @@ def test_LetPattern():
     assert isinstance(pat.body, VarPattern)
 
 
-## MATCHER TESTS
+# MATCHER TESTS
 
 
 def test_match_op():

--- a/tests/python/relay/test_fuse_with_patterns.py
+++ b/tests/python/relay/test_fuse_with_patterns.py
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-wildcard-import
+import numpy as np
+import pytest
+
+import tvm
+import pytest
+from tests.python.relay.test_dataflow_pattern import (
+    K_BROADCAST,
+    K_ELEMWISE,
+    K_INJECTIVE,
+    K_OUT_EWISE_FUSABLE,
+)
+from tvm import relay
+from tvm.ir.module import IRModule
+from tvm.relay import transform
+from tvm.relay.dataflow_pattern import wildcard
+from tvm.relay.testing import run_opt_pass
+from tvm.relay.transform.transform import FuseWithPattern
+
+DEPTH_OP = 256
+
+
+def test_fuse_max():
+    """Test the constraint of number of nodes in op fusion."""
+
+    def before(n):
+        x = relay.var("x", shape=(10, 20))
+        y = x
+        for i in range(n):
+            y = relay.exp(y)
+        return relay.Function([x], y)
+
+    n = 300
+    z = before(n)
+    fuse_pattern = relay.transform.FuseWithPattern()
+    zz = run_opt_pass(z, fuse_pattern)
+    zzz = run_opt_pass(z, fuse_pattern)
+
+    print(zz)
+    print("-------------------")
+    print(zzz)
+    # assert tvm.ir.structural_equal(zz, zzz)
+
+
+def test_fuse_max_configs():
+    """Test the constraint of number of nodes in op fusion."""
+
+    def before(n):
+        x = relay.var("x", shape=(10, 20))
+        y = x
+        for i in range(n):
+            y = relay.exp(y)
+        return relay.Function([x], y)
+
+    n = 300
+    z = before(n)
+    fuse_pattern = relay.transform.FuseWithPattern()
+    zz = run_opt_pass(z, fuse_pattern)
+    zzz = run_opt_pass(z, fuse_pattern)
+
+    print(zz)
+    print("-------------------")
+    print(zzz)
+    # assert tvm.ir.structural_equal(zz, zzz)
+
+
+def three_paths():
+    x = relay.var("x", shape=(1, 16, 64, 64))
+    w1 = relay.var("w1", shape=(16, 16, 3, 3))
+    b1 = relay.var("b", shape=(3,))
+    w2 = relay.var("w2", shape=(16, 16, 3, 3))
+    w3 = relay.var("w3", shape=(16, 16, 3, 3))
+    w4 = relay.var("w4", shape=(16, 16, 3, 3))
+    b2 = relay.var("b", shape=(3,))
+
+    y0 = relay.nn.conv2d(x, w1, kernel_size=(3, 3), padding=(1, 1, 1, 1), channels=16)
+    y1 = relay.multiply(y0, relay.const(1, "float32"))
+    y2 = relay.add(relay.const(2, "float32"), y1)
+    y = relay.nn.relu(y2)
+    # second path
+    z1 = relay.nn.conv2d(y, w2, kernel_size=(3, 3), padding=(1, 1, 1, 1), channels=16)
+    z2 = relay.multiply(z1, relay.const(1, "float32"))
+    z3 = relay.add(relay.const(2, "float32"), z2)
+    z4 = relay.nn.relu(z3)
+    # third path
+    c1 = relay.nn.conv2d(z4, w3, kernel_size=(3, 3), padding=(1, 1, 1, 1), channels=16)
+    c2 = relay.multiply(c1, relay.const(1, "float32"))
+    c3 = relay.add(relay.const(2, "float32"), c2)
+    c4 = relay.nn.relu(c3)
+    return relay.Function(relay.analysis.free_vars(c4), c4)
+
+
+def make_pattern_vertical_fuse():
+    x = wildcard()
+    y = wildcard()
+    z = wildcard()
+    w = wildcard()
+    conv_node = wildcard().has_attr({"TOpPattern": K_OUT_EWISE_FUSABLE})(x, y)
+    bc = wildcard().has_attr({"TOpPattern": K_BROADCAST})(conv_node, z)
+    for i in range(1, DEPTH_OP):
+        bc = bc | wildcard().has_attr({"TOpPattern": K_BROADCAST})(w, bc)
+    r = wildcard().has_attr({"TOpPattern": K_ELEMWISE})(bc)
+    return r
+
+
+def test_fuse_pattern():
+
+    vertical_fuse_patten = [("make_pattern_vertical_fuse", make_pattern_vertical_fuse())]
+
+    input_func = three_paths()
+
+    mod = IRModule.from_expr(input_func)
+
+    seq = tvm.transform.Sequential(
+        [
+            relay.transform.InferType(),
+            relay.transform.MergeComposite(vertical_fuse_patten),
+            relay.transform.PartitionGraph(),
+        ]
+    )
+    mod = seq(mod)
+
+    mod_r = IRModule.from_expr(input_func)
+
+    seq = tvm.transform.Sequential([relay.transform.InferType(), relay.transform.FuseOps()])
+    mod_r = seq(mod_r)
+
+    fuse_patter = run_opt_pass(input_func, relay.transform.FuseWithPattern(), import_prelude=False)
+
+    print("-----------Pattern Partitioner--------")
+    print(mod)
+
+    print("-----------Legacy Fuse Ops--------")
+    print(mod_r)
+
+    print("----- FuseWithPattern ------------")
+    print(fuse_patter)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This is a WIP of reproducing the functionality of the fuse_ops pass by using the pattern language instead. 

The main goal is to replace the legacy fuse_ops with a cleaner and easier to maintain pass.
Also, we want to be able to extend it with pattern selection based on specific targets.

This MVP currently showcases the following patterns:
* Max number of elemwise ops that can be fused together.
* kOutEWiseFusable -> Broadcast* -> Elemwise


This is a draft as I am still migrating patterns from other branches and assertions for IR structural equality are missing.
@mbs-octoml @electriclilies @jroesch 