### PR TITLE
[TVMC] micro, run: Disable micro support when USE_MICRO=OFF

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -34,9 +34,6 @@ from tvm.autotvm.measure import request_remote
 from tvm.contrib import graph_executor as runtime
 from tvm.contrib.debugger import debug_executor
 from tvm.relay.param_dict import load_param_dict
-import tvm.micro.project as project
-from tvm.micro.project import TemplateProjectError
-from tvm.micro.project_api.client import ProjectAPIServerNotFoundError
 from . import common
 from .common import (
     TVMCException,
@@ -47,6 +44,15 @@ from .common import (
 from .main import register_parser
 from .model import TVMCPackage, TVMCResult
 from .result_utils import get_top_results
+
+try:
+    import tvm.micro.project as project
+    from tvm.micro.project import TemplateProjectError
+    from tvm.micro.project_api.client import ProjectAPIServerNotFoundError
+
+    SUPPORT_MICRO = True
+except ImportError:
+    SUPPORT_MICRO = False
 
 # pylint: disable=invalid-name
 logger = logging.getLogger("TVMC")
@@ -134,6 +140,12 @@ def add_run_parser(subparsers, main_parser):
     if vars(known_args).get("device") != "micro":
         # No need to augment the parser for micro targets.
         return
+
+    if SUPPORT_MICRO is False:
+        sys.exit(
+            "'--device micro' is not supported. "
+            "Please build TVM with micro support (USE_MICRO ON)!"
+        )
 
     project_dir = known_args.PATH
 


### PR DESCRIPTION
Do not generate 'tvmc micro' subcommand and disable micro device option
in 'tvmc run' when TVM is built without support for microTVM, i.e. with
set(USE_MICRO OFF).

Otherwise tvmc will crash on importing any `tvm.micro` module / class. For instance:
```
gromero@amd:~/git/tvm/build$ tvmc -h 
Traceback (most recent call last):
  File "/home/gromero/git/tvm/python/tvm/micro/session.py", line 35, in <module>
    from .base import _rpc_connect
ImportError: cannot import name '_rpc_connect' from 'tvm.micro.base' (/home/gromero/git/tvm/python/tvm/micro/base.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.9/runpy.py", line 147, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/home/gromero/git/tvm/python/tvm/driver/tvmc/__init__.py", line 22, in <module>
    from . import micro
  File "/home/gromero/git/tvm/python/tvm/driver/tvmc/micro.py", line 26, in <module>
    import tvm.micro.project as project
  File "/home/gromero/git/tvm/python/tvm/micro/__init__.py", line 28, in <module>
    from .session import (
  File "/home/gromero/git/tvm/python/tvm/micro/session.py", line 37, in <module>
    raise ImportError("micro tvm is not enabled. Set USE_MICRO to ON in config.cmake")
ImportError: micro tvm is not enabled. Set USE_MICRO to ON in config.cmake
gromero@amd:~/git/tvm/build$ 
```

For any user, which is bad specially for the ones not interested in using `tvmc` for micro targets.
