### PR TITLE
[microNPU] Upgrade Vela to v3.2.0

### DIFF
--- a/docker/install/ubuntu_install_vela.sh
+++ b/docker/install/ubuntu_install_vela.sh
@@ -20,7 +20,4 @@ set -e
 set -u
 set -o pipefail
 
-# In a refactor between v2.1.1 and v3.0.0, find_block_configs <appropriate function name> was removed from Vela.
-# Since this is still required for the TVM port, it will be reinstated in Vela in a future release.
-# Until then, it needs to be pinned to v2.1.1.
-pip3 install ethos-u-vela==2.1.1
+pip3 install ethos-u-vela==3.2.0

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -233,7 +233,7 @@ CONSTRAINTS = [
         "docutils",
         "<0.17",
     ),  # Work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-    ("ethos-u-vela", "==2.1.1"),
+    ("ethos-u-vela", "==3.2.0"),
     ("future", None),
     ("h5py", "==2.10.0"),
     ("image", None),

--- a/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
+++ b/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
@@ -444,8 +444,6 @@ def _create_npu_op_conv2d(
     npu_conv2d_op.rounding_mode = _create_npu_rounding_mode(serial_2d_convolution.rounding_mode)
     npu_conv2d_op.upscale = _create_npu_resampling_mode(serial_2d_convolution.upscale)
     accel_config = vela_api.get_accelerator_config()
-    block_config = vela_api.get_optimal_block_config(npu_conv2d_op, accel_config)
-    npu_conv2d_op.block_config = block_config
     weights_shape_ohwi = [
         npu_conv2d_op.ofm.shape.depth,
         npu_conv2d_op.kernel.height,
@@ -457,6 +455,8 @@ def _create_npu_op_conv2d(
         weights_shape_ohwi=weights_shape_ohwi,
         ifm_bitdepth=npu_conv2d_op.ifm.data_type.size_in_bits(),
     )
+    block_config = vela_api.get_optimal_block_config(npu_conv2d_op, accel_config)
+    npu_conv2d_op.block_config = block_config
     return npu_conv2d_op, weights_zero_point
 
 

--- a/python/tvm/relay/backend/contrib/ethosu/vela_api.py
+++ b/python/tvm/relay/backend/contrib/ethosu/vela_api.py
@@ -207,7 +207,7 @@ def compress_weights(
     layout_transform_indices = {"HWIO": (3, 0, 1, 2), "HWOI": (2, 0, 1, 3), "OHWI": (0, 1, 2, 3)}
     assert weights_layout in layout_transform_indices.keys()
     assert isinstance(weights_zp, np.int64)
-    weights = weights.astype(np.int64) - weights_zp
+    weights = weights.astype(np.int16) - weights_zp
     # Vela needs the weights in OHWI layout
     weights_ohwi = np.transpose(weights, layout_transform_indices[weights_layout])
     shape_ohwi = [


### PR DESCRIPTION
In addition to upgrading the version of Vela, this contains a bug fix and a fix due to an api change.

The bug fix was found as a result of upgrading the version and ensures that block traversal mode is calculated before a set of block configs is found. As a result, valid block configs are calculated consistently throughout compilation.

The fix for the api change is a cast to the datatype now expected by Vela due to using strict casting rules.

cc @manupa-arm @ekalda @leandron 
