### PR TITLE
Options to create test directory and print commands in AOT Test Runner

### DIFF
--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -768,6 +768,7 @@ def run_and_check(
     with open(run_log_path) as run_log:
         assert AOT_SUCCESS_TOKEN in run_log.read()
 
+
 def compile_and_run(
     models: Union[List[AOTTestModel], AOTTestModel],
     runner: AOTTestRunner,

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -784,14 +784,15 @@ def compile_and_run(
     test_dir: str = None,
     verbose: bool = False,
 ):
-    """
-    Compiles the AOTTestModel and runs using AOT test runner
+    """This is a wrapper API to compile and run models as test for AoT
+
     Parameters
     ----------
-    test_dir : This path will contain build, codegen, include directories
-    verbose: Prints commands to build and run AOT test runner
+    test_dir : str
+        This path will contain build, codegen, include directories
+    verbose: bool
+        Prints commands to build and run AOT test runner
     """
-    """This is a wrapper API to compile and run models as test for AoT"""
     compiled_test_mods = compile_models(
         models=models,
         interface_api=interface_api,

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -657,21 +657,26 @@ def run_and_check(
     debug_calculated_workspaces=False,
     workspace_byte_alignment=8,
     data_linkage: AOTDataLinkage = None,
+    test_dir: str = None,
+    verbose: bool = False,
 ):
     """
     This method uses the original test data and compiled runtime.Modules
     to run in the test runner to verify the results.
     """
 
-    tmp_path = utils.tempdir()
-    tmp_dir = tmp_path.temp_dir
+    base_path = test_dir
+    if test_dir is None:
+        tmp_path = utils.tempdir()
+        tmp_dir = tmp_path.temp_dir
+        base_path = os.path.join(tmp_dir, "test")
 
     cflags = f"-DTVM_RUNTIME_ALLOC_ALIGNMENT_BYTES={workspace_byte_alignment} "
     # The calculated workspaces will not account for stack allocator tags used for debugging
     if debug_calculated_workspaces:
         cflags += "-DTVM_CRT_STACK_ALLOCATOR_ENABLE_LIFO_CHECK "
 
-    base_path = os.path.join(tmp_dir, "test")
+    base_path = os.path.abspath(base_path)
     build_path = os.path.join(base_path, "build")
     os.makedirs(build_path, exist_ok=True)
 
@@ -747,18 +752,21 @@ def run_and_check(
 
     compile_log_path = os.path.join(build_path, "test_compile.log")
     compile_command = f"{make_command} aot_test_runner"
+    if verbose:
+        print("Compile command:\n", compile_command)
     ret = subprocess_log_output(compile_command, ".", compile_log_path)
     assert ret == 0
 
     # Verify that runs fine
     run_log_path = os.path.join(build_path, "test_run.log")
     run_command = f"{make_command} run"
+    if verbose:
+        print("Run command:\n", run_command)
     ret = subprocess_log_output(run_command, build_path, run_log_path)
     assert ret == 0
 
     with open(run_log_path) as run_log:
         assert AOT_SUCCESS_TOKEN in run_log.read()
-
 
 def compile_and_run(
     models: Union[List[AOTTestModel], AOTTestModel],
@@ -772,7 +780,16 @@ def compile_and_run(
     use_runtime_executor: bool = True,
     target: str = "c",
     target_opts: Dict = None,
+    test_dir: str = None,
+    verbose: bool = False,
 ):
+    """
+    Compiles the AOTTestModel and runs using AOT test runner
+    Parameters
+    ----------
+    test_dir : This path will contain build, codegen, include directories
+    verbose: Prints commands to build and run AOT test runner
+    """
     """This is a wrapper API to compile and run models as test for AoT"""
     compiled_test_mods = compile_models(
         models=models,
@@ -792,6 +809,8 @@ def compile_and_run(
         debug_calculated_workspaces=debug_calculated_workspaces,
         workspace_byte_alignment=workspace_byte_alignment,
         data_linkage=data_linkage,
+        test_dir=test_dir,
+        verbose=verbose,
     )
 
 


### PR DESCRIPTION
Support for user given path to untar the MLF and produce files needed by the AOT test runner. Added verbose mode to peek into the steps test runner follows. With this PR,  it will print make commands.