### PR TITLE
[Dynamic] Use SizeVar instead of Var in the GetShape function

### DIFF
--- a/python/tvm/relay/backend/te_compiler.py
+++ b/python/tvm/relay/backend/te_compiler.py
@@ -268,7 +268,7 @@ def get_shape(shape):
                 assert val <= np.iinfo(np.int32).max
                 ret.append(tvm.tir.IntImm("int32", val))
         elif isinstance(dim, tvm.tir.Any):
-            ret.append(te.var("any_dim", "int32"))
+            ret.append(te.size_var("any_dim", "int32"))
         else:
             ret.append(dim)
     return ret


### PR DESCRIPTION
Recently I've got performance issue with a simple case, test script as shown:

```python
import numpy as np
import tvm
from tvm import testing
from tvm import relay
from tvm.runtime import profiler_vm

def zeros_graph():
    a = relay.var("shape", shape=[5], dtype="int32")
    b = relay.zeros(a, dtype="float32")

    func = relay.Function([a], b)
    mod = tvm.IRModule()
    mod["main"] = func
    return mod

target = tvm.target.Target("cuda")
dev = tvm.cuda(0)
a_data = np.array([1, 320, 168, 10, 24], dtype="int32")
b_data = np.zeros(a_data, dtype="float32")
a_tvm = tvm.nd.array(a_data, dev)
b_tvm = tvm.nd.empty(b_data.shape, b_data.dtype, dev)

def test_speed_and_check_vm(mod, target, buffers):
    with tvm.transform.PassContext(opt_level=3):
        lib = relay.vm.compile(mod, target=target)
    run_mod = profiler_vm.VirtualMachineProfiler(lib, dev)
    run_mod.run(*buffers)
    b_tvm = run_mod.get_output(0)
    evaluator = run_mod.module.time_evaluator("invoke", dev, min_repeat_ms=500)
    costs = np.median(evaluator("main").results)
    print("Execution time of this operator: %.3f ms" % (costs * 1e3))
    testing.assert_allclose(b_data, b_tvm.numpy())
    print(run_mod.profile())

mod = zeros_graph()
test_speed_and_check_vm(mod, target, [a_tvm])
```

In my A100 gpu, this simple zeros costs 5 ms:

```bash
Execution time of this operator: 5.308 ms
Name                  Duration (us)  Percent  Device              Hash                         Argument Shapes  Count
fused_dyn_zeros             5315.64    49.64   cuda0  3e3cf66c3e738993  int32[5], float32[1, 320, 168, 10, 24]      1
shape_func_dyn_zeros           3.13     0.03    cpu0  3e3cf66c3e738993                      int32[5], int64[5]      1
fused_prod                     0.68     0.01    cpu0  64ff7b71305dadd2                       int64[5], int64[]      1
fused_multiply                 0.52     0.00    cpu0  e2e2680f0ff08f46                        int64[], int64[]      1
----------
Sum                         5319.97    49.68                                                                        4
Total                       5455.01            cuda0                                                                1
Total                      10709.44             cpu0                                                                1
```

Finaly I find out that there should be an addition patch to https://github.com/apache/tvm/pull/8555 .The shape of `te.var` seems to stop some expression simplification rules.

After the modification of `te.var` to `te.size_var`, we can get:
```bash
Execution time of this operator: 0.335 ms
Name                  Duration (us)  Percent  Device              Hash                         Argument Shapes  Count
fused_dyn_zeros              328.92    43.66   cuda0  3e3cf66c3e738993  int32[5], float32[1, 320, 168, 10, 24]      1
shape_func_dyn_zeros           4.61     0.61    cpu0  3e3cf66c3e738993                      int32[5], int64[5]      1
fused_prod                     1.30     0.17    cpu0  64ff7b71305dadd2                       int64[5], int64[]      1
fused_multiply                 1.11     0.15    cpu0  e2e2680f0ff08f46                        int64[], int64[]      1
----------
Sum                          335.95    44.59                                                                        4
Total                        520.00            cuda0                                                                1
Total                        753.41             cpu0                                                                1
```

For more details, I also paste the generated te code here:
```bash
With te.var:
lower primfn(T_full_1: handle) -> ()
  attr = {"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True}
  buffers = {T_full: Buffer(T_full_2: Pointer(float32), float32, [any_dim: int32, any_dim_1: int32, any_dim_2: int32, any_dim_3: int32, any_dim_4: int32], [stride: int32, stride_1: int32, stride_2: int32, stride_3: int32, stride_4: int32], type="auto")}
  buffer_map = {T_full_1: T_full} {
  attr [IterVar(blockIdx.x: int32, (nullptr), "ThreadIndex", "blockIdx.x")] "thread_extent" = floordiv((((((any_dim*any_dim_1)*any_dim_2)*any_dim_3)*any_dim_4) + 511), 512);
  attr [IterVar(threadIdx.x: int32, (nullptr), "ThreadIndex", "threadIdx.x")] "thread_extent" = 512;
  if (blockIdx.x < floordiv(((((any_dim*any_dim_1)*any_dim_2)*any_dim_3)*any_dim_4), 512)) {
    if (floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1) < any_dim) {
      if (floormod(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1) < any_dim_1) {
        if (floormod(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2) < any_dim_2) {
          if (floormod(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3) < any_dim_3) {
            if (floormod(((blockIdx.x*512) + threadIdx.x), any_dim_4) < any_dim_4) {
              if (floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2) < (any_dim*any_dim_1)) {
                if (floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3) < ((any_dim*any_dim_1)*any_dim_2)) {
                  if (floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4) < (((any_dim*any_dim_1)*any_dim_2)*any_dim_3)) {
                    T_full_2[(((((floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride) + (floormod(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride_1)) + (floormod(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2)*stride_2)) + (floormod(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3)*stride_3)) + (floormod(((blockIdx.x*512) + threadIdx.x), any_dim_4)*stride_4))] = 0f32
                  }
                }
              }
            }
          }
        }
      }
    }
  } else {
    if (floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1) < any_dim) {
      if (floormod(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1) < any_dim_1) {
        if (floormod(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2) < any_dim_2) {
          if (floormod(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3) < any_dim_3) {
            if (floormod(((blockIdx.x*512) + threadIdx.x), any_dim_4) < any_dim_4) {
              if (floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2) < (any_dim*any_dim_1)) {
                if (floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3) < ((any_dim*any_dim_1)*any_dim_2)) {
                  if (floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4) < (((any_dim*any_dim_1)*any_dim_2)*any_dim_3)) {
                    if (((blockIdx.x*512) + threadIdx.x) < ((((any_dim*any_dim_1)*any_dim_2)*any_dim_3)*any_dim_4)) {
                      T_full_2[(((((floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride) + (floormod(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride_1)) + (floormod(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2)*stride_2)) + (floormod(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3)*stride_3)) + (floormod(((blockIdx.x*512) + threadIdx.x), any_dim_4)*stride_4))] = 0f32
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}

With te.size_var:
lower primfn(T_full_1: handle) -> ()
  attr = {"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True}
  buffers = {T_full: Buffer(T_full_2: Pointer(float32), float32, [any_dim: int32, any_dim_1: int32, any_dim_2: int32, any_dim_3: int32, any_dim_4: int32], [stride: int32, stride_1: int32, stride_2: int32, stride_3: int32, stride_4: int32], type="auto")}
  buffer_map = {T_full_1: T_full} {
  attr [IterVar(blockIdx.x: int32, (nullptr), "ThreadIndex", "blockIdx.x")] "thread_extent" = floordiv((((((any_dim*any_dim_1)*any_dim_2)*any_dim_3)*any_dim_4) + 511), 512);
  attr [IterVar(threadIdx.x: int32, (nullptr), "ThreadIndex", "threadIdx.x")] "thread_extent" = 512;
  if (blockIdx.x < floordiv(((((any_dim*any_dim_1)*any_dim_2)*any_dim_3)*any_dim_4), 512)) {
    if (floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1) < any_dim) {
      if (floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2) < (any_dim*any_dim_1)) {
        if (floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3) < ((any_dim*any_dim_1)*any_dim_2)) {
          if (floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4) < (((any_dim*any_dim_1)*any_dim_2)*any_dim_3)) {
            T_full_2[(((((floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride) + (floormod(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride_1)) + (floormod(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2)*stride_2)) + (floormod(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3)*stride_3)) + (floormod(((blockIdx.x*512) + threadIdx.x), any_dim_4)*stride_4))] = 0f32
          }
        }
      }
    }
  } else {
    if (floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1) < any_dim) {
      if (floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2) < (any_dim*any_dim_1)) {
        if (floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3) < ((any_dim*any_dim_1)*any_dim_2)) {
          if (floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4) < (((any_dim*any_dim_1)*any_dim_2)*any_dim_3)) {
            if (((blockIdx.x*512) + threadIdx.x) < ((((any_dim*any_dim_1)*any_dim_2)*any_dim_3)*any_dim_4)) {
              T_full_2[(((((floordiv(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride) + (floormod(floordiv(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2), any_dim_1)*stride_1)) + (floormod(floordiv(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3), any_dim_2)*stride_2)) + (floormod(floordiv(((blockIdx.x*512) + threadIdx.x), any_dim_4), any_dim_3)*stride_3)) + (floormod(((blockIdx.x*512) + threadIdx.x), any_dim_4)*stride_4))] = 0f32
            }
          }
        }
      }
    }
  }
}
```