### PR TITLE
add einsum in pytorch frontend

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2819,6 +2819,11 @@ class PyTorchOpConverter:
 
         return out
 
+    def einsum(self, inputs, input_types):
+        print(inputs)
+        equation, data = inputs
+        return _op.einsum(data, equation)
+
     # Operator mappings
     def create_convert_map(self):
         self.convert_map = {
@@ -3063,6 +3068,7 @@ class PyTorchOpConverter:
             "aten::searchsorted": self.searchsorted,
             "aten::bucketize": self.bucketize,
             "aten::roll": self.roll,
+            "aten::einsum": self.einsum,
         }
 
     def update_convert_map(self, custom_map):

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4020,5 +4020,17 @@ def test_roll():
     verify_model(test_fn(shifts=(2, 1), dims=(0, 1)), [x])
 
 
+@tvm.testing.uses_gpu
+def test_einsum():
+    def test_fn(equation):
+        return lambda *x: torch.einsum(equation, *x)
+
+    x = torch.ones([2, 3])
+    y = torch.ones([3, 4])
+    z = torch.ones([4, 5])
+    verify_model(test_fn("ij,jk"), [x, y])
+    verify_model(test_fn("ij,jk,km->im"), [x, y, z])
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Add `torch.einsum` support in pytorch frontend, thanks to https://github.com/apache/tvm/pull/8985. 

@anwang2009 @junrushao1994 @Laurawly  please help review this PR.
