### PR TITLE
Upgrade to latest version of FVP based on Arm(R) Corstone(TM)-300 software

### DIFF
--- a/apps/microtvm/ethosu/README.md
+++ b/apps/microtvm/ethosu/README.md
@@ -48,7 +48,7 @@ You will also need TVM which can either be:
 You will need to update your PATH environment variable to include the path to cmake 3.19.5 and the FVP.
 For example if you've installed these in ```/opt/arm``` , then you would do the following:
 ```bash
-export PATH=/opt/arm/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4:/opt/arm/cmake/bin:$PATH
+export PATH=/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4:/opt/arm/cmake/bin:$PATH
 ```
 
 Running the demo application

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -121,7 +121,7 @@ COPY install/ubuntu_install_vela.sh /install/ubuntu_install_vela.sh
 RUN bash /install/ubuntu_install_vela.sh
 
 # Update PATH
-ENV PATH /opt/arm/gcc-arm-none-eabi/bin:$PATH
+ENV PATH /opt/arm/gcc-arm-none-eabi/bin:/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4:$PATH
 
 # PaddlePaddle deps
 COPY install/ubuntu_install_paddle.sh /install/ubuntu_install_paddle.sh

--- a/docker/install/ubuntu_install_ethosu_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosu_driver_stack.sh
@@ -20,7 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-fvp_dir="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
+fvp_dir="/opt/arm/FVP_Corstone_SSE-300"
 cmake_dir="/opt/arm/cmake"
 ethosu_dir="/opt/arm/ethosu"
 ethosu_driver_ver="21.05"
@@ -56,9 +56,9 @@ apt-get install -y \
 # Download the FVP
 mkdir -p "$fvp_dir"
 cd "$tmpdir"
-curl -sL https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/MPS3/FVP_Corstone_SSE-300_Ethos-U55_11.14_24.tgz | tar -xz
-./FVP_Corstone_SSE-300_Ethos-U55.sh --i-agree-to-the-contained-eula --no-interactive -d "$fvp_dir"
-rm -rf FVP_Corstone_SSE-300_Ethos-U55.sh license_terms
+curl -sL https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/FVP_Corstone_SSE-300_11.15_24.tgz | tar -xz
+./FVP_Corstone_SSE-300.sh --i-agree-to-the-contained-eula --no-interactive -d "$fvp_dir"
+rm -rf FVP_Corstone_SSE-300.sh license_terms
 
 # Setup cmake 3.19.5
 mkdir -p "${cmake_dir}"

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -734,6 +734,10 @@ def run_and_check(
     file_dir = os.path.dirname(os.path.abspath(__file__))
     codegen_path = os.path.join(base_path, "codegen")
     makefile = os.path.join(file_dir, f"{runner.makefile}.mk")
+    fvp_dir = "/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4/"
+    # TODO(@grant-arm): Remove once ci_cpu docker image has been updated to FVP_Corstone_SSE
+    if not os.path.isdir(fvp_dir):
+        fvp_dir = "/opt/arm/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/"
     custom_params = " ".join([f" {param}='{value}'" for param, value in runner.parameters.items()])
     make_command = (
         f"make -f {makefile} build_dir={build_path}"
@@ -742,6 +746,7 @@ def run_and_check(
         + f" AOT_TEST_ROOT={file_dir}"
         + f" CODEGEN_ROOT={codegen_path}"
         + f" STANDALONE_CRT_DIR={tvm.micro.get_standalone_crt_dir()}"
+        + f" FVP_DIR={fvp_dir}"
         + custom_params
     )
 

--- a/tests/python/relay/aot/corstone300.mk
+++ b/tests/python/relay/aot/corstone300.mk
@@ -24,6 +24,7 @@ CRT_ROOT ?= ${TVM_ROOT}/build/standalone_crt
 ifeq ($(shell ls -lhd $(CRT_ROOT)),)
 $(error "CRT not found. Ensure you have built the standalone_crt target and try again")
 endif
+FVP_DIR ?= /opt/arm/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/
 
 ARM_CPU=ARMCM55
 DMLC_CORE=${TVM_ROOT}/3rdparty/dmlc-core
@@ -117,7 +118,7 @@ cleanall:
 	$(QUIET)rm -rf $(build_dir)
 
 run: $(build_dir)/aot_test_runner
-	/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55 -C cpu0.CFGDTCMSZ=15 \
+	$(FVP_DIR)/FVP_Corstone_SSE-300_Ethos-U55 -C cpu0.CFGDTCMSZ=15 \
 	-C cpu0.CFGITCMSZ=15 -C mps3_board.uart0.out_file=\"-\" -C mps3_board.uart0.shutdown_tag=\"EXITTHESIM\" \
 	-C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 \
 	-C mps3_board.telnetterminal1.start_telnet=0 -C mps3_board.telnetterminal2.start_telnet=0 -C mps3_board.telnetterminal5.start_telnet=0 \

--- a/tests/python/relay/aot/corstone300.mk
+++ b/tests/python/relay/aot/corstone300.mk
@@ -117,7 +117,7 @@ cleanall:
 	$(QUIET)rm -rf $(build_dir)
 
 run: $(build_dir)/aot_test_runner
-	/opt/arm/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55 -C cpu0.CFGDTCMSZ=15 \
+	/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55 -C cpu0.CFGDTCMSZ=15 \
 	-C cpu0.CFGITCMSZ=15 -C mps3_board.uart0.out_file=\"-\" -C mps3_board.uart0.shutdown_tag=\"EXITTHESIM\" \
 	-C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 \
 	-C mps3_board.telnetterminal1.start_telnet=0 -C mps3_board.telnetterminal2.start_telnet=0 -C mps3_board.telnetterminal5.start_telnet=0 \

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -48,6 +48,12 @@ cd ../..
 
 # Test Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU demo app
 FVP_PATH="/opt/arm/FVP_Corstone_SSE-300"
+
+# TODO(@grant-arm): Remove once ci_cpu docker image has been updated to FVP_Corstone_SSE
+if test ! -d $FVP_PATH; then
+    FVP_PATH="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
+fi
+
 if test -d $FVP_PATH && pip3 list | grep vela; then
     cd apps/microtvm/ethosu
     ./run_demo.sh --fvp_path $FVP_PATH --cmake_path /opt/arm/cmake/bin/cmake

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -47,7 +47,7 @@ make test_dynamic test_static
 cd ../..
 
 # Test Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU demo app
-FVP_PATH="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
+FVP_PATH="/opt/arm/FVP_Corstone_SSE-300"
 if test -d $FVP_PATH && pip3 list | grep vela; then
     cd apps/microtvm/ethosu
     ./run_demo.sh --fvp_path $FVP_PATH --cmake_path /opt/arm/cmake/bin/cmake


### PR DESCRIPTION
This PR updates the `ci_cpu` docker image to use the latest version of the FVP (Fixed Virtual Platform) based on Arm(R) Corstone(TM)-300 software.

@manupa-arm @ekalda @leandron @Mousius @areusch 
