### PR TITLE
Add tvm-bot to triage role

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,3 +46,4 @@ github:
   # cycle. PMC may review and recycle slots when necessary.
   collaborators:
     - denise-k
+    - tvm-bot  # For automated feedback in PR review.


### PR DESCRIPTION
 * Based on discussion in
 https://discuss.tvm.apache.org/t/rfc-ci-add-a-skip-ci-tag-to-shortcut-builds-and-tests/11589/10
 * We will probably continue to leverage this bot for other, similar
 PR review feedback.

@tqchen @driazati 