### PR TITLE
[TVMScript] Improve printer for TIR syntax sugar

### DIFF
--- a/python/tvm/script/tir/special_stmt.py
+++ b/python/tvm/script/tir/special_stmt.py
@@ -338,8 +338,8 @@ class BlockReads(SpecialStmt):
                 for read_region in read_regions:
                     if not isinstance(read_region, BufferSlice):
                         self.context.report_error(
-                            "Incorrect input type. "
-                            + f"Expected *BufferSlice or List[BufferSlice], but got {type(read_regions)}",
+                            "Incorrect input type. Expected *BufferSlice or List[BufferSlice],"
+                            + f" but got {type(read_regions)}",
                             span,
                         )
             elif len(read_regions) == 1:
@@ -390,8 +390,8 @@ class BlockWrites(SpecialStmt):
                 for write_region in write_regions:
                     if not isinstance(write_region, BufferSlice):
                         self.context.report_error(
-                            "Incorrect input type. "
-                            + f"Expected *BufferSlice or List[BufferSlice], but got {type(write_regions)}",
+                            "Incorrect input type. Expected *BufferSlice or List[BufferSlice],"
+                            + f" but got {type(write_regions)}",
                             span,
                         )
             elif len(write_regions) == 1:

--- a/python/tvm/script/tir/special_stmt.py
+++ b/python/tvm/script/tir/special_stmt.py
@@ -317,8 +317,7 @@ class BlockReads(SpecialStmt):
 
     def __init__(self):
         def reads(
-            read_regions: Union[BufferSlice, List[BufferSlice]],
-            *other_regions: BufferSlice,
+            *read_regions: Union[BufferSlice, List[BufferSlice]],
             span: Span = None,
         ):
             assert self.context, "call 'exit_scope' before 'enter_scope'"
@@ -335,16 +334,18 @@ class BlockReads(SpecialStmt):
                     + str(", ".join(str(x) for x in block_scope.reads)),
                     span,
                 )
-            if isinstance(read_regions, BufferSlice):
-                read_regions = [read_regions]
-                for region in other_regions:
-                    read_regions.append(region)
-            if not isinstance(read_regions, list):
-                self.context.report_error(
-                    "Incorrect input type. "
-                    + f"Expected BufferSlice or List[BufferSlice], but got {type(read_regions)}",
-                    span,
-                )
+            if len(read_regions) > 1:
+                for read_region in read_regions:
+                    if not isinstance(read_region, BufferSlice):
+                        self.context.report_error(
+                            "Incorrect input type. "
+                            + f"Expected *BufferSlice or List[BufferSlice], but got {type(read_regions)}",
+                            span,
+                        )
+            elif len(read_regions) == 1:
+                if isinstance(read_regions[0], list):
+                    read_regions = read_regions[0]
+
             block_scope.reads = read_regions
 
         super().__init__(reads, def_symbol=False)
@@ -368,8 +369,7 @@ class BlockWrites(SpecialStmt):
 
     def __init__(self):
         def writes(
-            write_region: Union[BufferSlice, List[BufferSlice]],
-            *other_region: BufferSlice,
+            *write_regions: Union[BufferSlice, List[BufferSlice]],
             span: Span = None,
         ):
             assert self.context, "call 'exit_scope' before 'enter_scope'"
@@ -386,19 +386,18 @@ class BlockWrites(SpecialStmt):
                     + str(", ".join(str(x) for x in block_scope.writes)),
                     span,
                 )
-            if isinstance(write_region, list):
-                pass
-            elif isinstance(write_region, BufferSlice):
-                write_region = [write_region]
-                for region in other_region:
-                    write_region.append(region)
-            else:
-                self.context.report_error(
-                    "Incorrect input type. "
-                    + f"Expected BufferSlice or List[BufferSlice], but got {type(write_region)}",
-                    span,
-                )
-            block_scope.writes = write_region
+            if len(write_regions) > 1:
+                for write_region in write_regions:
+                    if not isinstance(write_region, BufferSlice):
+                        self.context.report_error(
+                            "Incorrect input type. "
+                            + f"Expected *BufferSlice or List[BufferSlice], but got {type(write_regions)}",
+                            span,
+                        )
+            elif len(write_regions) == 1:
+                if isinstance(write_regions[0], list):
+                    write_regions = write_regions[0]
+            block_scope.writes = write_regions
 
         super().__init__(writes, def_symbol=False)
 

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -413,7 +413,7 @@ Doc TVMScriptPrinter::AllocBufferDeclaration(const Buffer& buf) {
   if (buf->offset_factor != 1 || print_factor_explicitly) {
     doc << ", offset_factor=" << buf->offset_factor;
   }
-  if (buf->buffer_type != 1) {
+  if (buf->buffer_type != BufferType::kDefault) {
     doc << ", type=" << Doc::StrLiteral("auto");
   }
   return doc;
@@ -509,7 +509,7 @@ bool TVMScriptPrinter::IsSimpleBuffer(const Buffer& buf) {
   if (buf->offset_factor != 1) {
     return false;
   }
-  if (buf->buffer_type != 1) {
+  if (buf->buffer_type != BufferType::kDefault) {
     return false;
   }
   return true;
@@ -1307,7 +1307,8 @@ Doc TVMScriptPrinter::PrintPrimFunc(const PrimFunc& primFunc) {
       const auto buf = (*it).second;
       if (IsSimpleBuffer(buf)) {
         buf_not_in_headers_.insert(buf.get());
-        Doc buf_param_doc = Print(param) << ": " << MatchBufferDeclaration(buf);
+        Doc buf_param_doc;
+        buf_param_doc << buf->name << ": " << MatchBufferDeclaration(buf);
         params.push_back(buf_param_doc);
         continue;
       }

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1408,8 +1408,12 @@ Doc TVMScriptPrinter::PrintAnnotations(const Map<String, ObjectRef>& annotations
 Doc TVMScriptPrinter::PrintLoop(const For& loop) {
   Doc res;
   res << "for " << Print(loop->loop_var) << " in " << tir_prefix_
-      << "." + std::string(ForKind2String(loop->kind)) + "(" << Print(loop->min) << ", "
-      << Print(loop->min + loop->extent);
+      << "." + std::string(ForKind2String(loop->kind)) + "(";
+  if (is_zero(loop->min)) {
+    res << Print(loop->extent);
+  } else {
+    res << Print(loop->min) << ", " << Print(loop->min + loop->extent);
+  }
   if (loop->thread_binding.defined()) {
     res << ", thread=";
     res << Print(loop->thread_binding.value()->thread_tag);

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -544,10 +544,10 @@ def test_reorder_fail_nested_loop_inner():
     with pytest.raises(tvm.tir.ScheduleError) as execinfo:
         sch.reorder(k, i)
     expected_sub_error_message = (
-        "        for i in T.serial(0, 128):\n"
+        "        for i in T.serial(128):\n"
         "            # tir.For#0\n"
-        "            for j in T.serial(0, 128):\n"
-        "            ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+        "            for j in T.serial(128):\n"
+        "            ^^^^^^^^^^^^^^^^^^^^^^^\n"
     )
     assert expected_sub_error_message in str(execinfo.value)
 
@@ -560,9 +560,9 @@ def test_fuse_fail_nested_loop_outer():
         sch.fuse(k, i)
     expected_sub_error_message = (
         "        # tir.For#1\n"
-        "        for i in T.serial(0, 128):\n"
-        "        ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
-        "            for j in T.serial(0, 128):\n"
+        "        for i in T.serial(128):\n"
+        "        ^^^^^^^^^^^^^^^^^^^^^^^\n"
+        "            for j in T.serial(128):\n"
     )
     assert expected_sub_error_message in str(execinfo.value)
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -79,6 +79,7 @@ class Module1:
 
 def test_opt_gemm_normalize():
     mod = Module1
+    print(mod.script(show_meta=True))
     rt_mod = tvm.script.from_source(mod.script(show_meta=True))
     tvm.ir.assert_structural_equal(mod, rt_mod, True)
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -79,7 +79,6 @@ class Module1:
 
 def test_opt_gemm_normalize():
     mod = Module1
-    print(mod.script(show_meta=True))
     rt_mod = tvm.script.from_source(mod.script(show_meta=True))
     tvm.ir.assert_structural_equal(mod, rt_mod, True)
 

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -118,8 +118,8 @@ def elementwise_handle(
 # match buffer - use buffer with kwargs
 @T.prim_func
 def elementwise_buffer_kwargs(
-    a: T.Buffer(shape=(128, 128, 128, 128), dtype="float32", elem_offset=None),
-    b: T.Buffer(shape=(128, 128, 128, 128), dtype="float32", elem_offset=None),
+    a: T.Buffer(shape=(128, 128, 128, 128), dtype="float32"),
+    b: T.Buffer(shape=(128, 128, 128, 128), dtype="float32"),
 ) -> None:
     for i, j, k, l in T.grid(128, 128, 128, 128):
         with T.block("B"):

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -141,7 +141,6 @@ def elementwise_buffer_no_kwargs(
 
 def test_match_buffer_syntax_sugar():
     # with kwargs
-    print(elementwise_buffer_kwargs.script())
     assert_structural_equal(elementwise_handle, elementwise_buffer_kwargs)
     # without kwargs
     assert_structural_equal(elementwise_handle, elementwise_buffer_no_kwargs)

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -141,6 +141,7 @@ def elementwise_buffer_no_kwargs(
 
 def test_match_buffer_syntax_sugar():
     # with kwargs
+    print(elementwise_buffer_kwargs.script())
     assert_structural_equal(elementwise_handle, elementwise_buffer_kwargs)
     # without kwargs
     assert_structural_equal(elementwise_handle, elementwise_buffer_no_kwargs)


### PR DESCRIPTION
This PR intends to improve the printing of three kinds of syntax sugar introduced in TVMScript from #9492, #9620 and #9634. Examples below are supposedly the output of `print(some_tir_prim_func.script())`.

1. For reads & writes:

Before this PR
```
@T.prim_func
def func(a: T.handle, b: T.handle, c: T.handle) -> None:
            ...
            T.reads([C[vi, vj], A[vi, vk], B[vj, vk]])
            T.writes([C[vi, vj], A[vi, vk]])
            ...
```
After this PR, note that brackets are removed
```
@T.prim_func
def func(a: T.handle, b: T.handle, c: T.handle) -> None:
            ...
            T.reads(C[vi, vj], A[vi, vk], B[vj, vk])
            T.writes(C[vi, vj], A[vi, vk])
            ...
```

2. For loops:

Before this PR
```
@T.prim_func
def func(a: T.handle) -> None:
    ...
    for i in T.serial(0, 128):
        for j in T.parallel(0, 128):
            for k in T.vectorized(0, 128):
                for x in T.unroll(0, 128):
                    for y in T.thread_binding(0, 128, thread="threadIdx.x"):
                        ...
```
After this PR, note that all loops with 0 as min will be printed out as syntax sugar
```
    ...
    for i in T.serial(128):
        for j in T.parallel(128):
            for k in T.vectorized(128):
                for x in T.unroll(128):
                    for y in T.thread_binding(128, thread="threadIdx.x"):
                        ...
```

3. For T.match_buffer():

Before this PR
```
@T.prim_func
def elementwise(
    a: T.handle,
    b: T.handle,
) -> None:
    A = T.match_buffer(a, (128, 128, 128, 128))
    B = T.match_buffer(b, (128, 128, 128, 128))
    # some computation
```
After this PR, note that we assume T.match_buffer with two or less arguments specified are syntax-sugarred.
```
@T.prim_func
def elementwise(
    a: T.Buffer[[128, 128, 128, 128], "float32"],
    b:T.Buffer[[128, 128, 128, 128], "float32"],
) -> None:
    # some computation
```

cc: @vinx13 @junrushao1994 @Hzfengsy 
