### PR TITLE
[RVM] Fix AttributeError when action is not specified

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -475,6 +475,8 @@ def parse_args():
         description="Automates building, testing, and releasing a base box"
     )
     subparsers = parser.add_subparsers(help="Action to perform.")
+    subparsers.required = True
+    subparsers.dest = "action"
     parser.add_argument(
         "--provider",
         choices=ALL_PROVIDERS,


### PR DESCRIPTION
Although an action (build, test, or release) is always required by
base-tool-box.py currently actions are not set as "required" in the
parser, hence it doesn't complain when an action is missing and later
when 'args.platform' attribute (present in all actions) is referenced
the tool exits abruptly due to an AttributeError (because 'platform' is
not set), without giving any clue on what went wrong. For instance:

$ python3 ./base-box-tool.py --provider virtualbox # no action is given

This commit fixes it by setting action subparsers as required so the
parser complains when no action is specified.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
