### PR TITLE
[Relay] PlanDevices supports 'free' on_device annotations

### DIFF
--- a/include/tvm/relay/attrs/call.h
+++ b/include/tvm/relay/attrs/call.h
@@ -39,7 +39,9 @@ struct CallLoweredAttrs : public tvm::AttrsNode<CallLoweredAttrs> {
   Map<String, ObjectRef> metadata;
 
   TVM_DECLARE_ATTRS(CallLoweredAttrs, "relay.attrs.CallLoweredAttrs") {
-    TVM_ATTR_FIELD(metadata).describe("Metadata attached to the lowered function call.");
+    TVM_ATTR_FIELD(metadata)
+        .describe("Metadata attached to the lowered function call.")
+        .set_default(Map<String, ObjectRef>());
   }
 };
 

--- a/include/tvm/relay/attrs/on_device.h
+++ b/include/tvm/relay/attrs/on_device.h
@@ -19,7 +19,7 @@
 
 /*!
  * \file tvm/relay/attrs/on_device.h
- * \brief Attribute for the on device annotation.
+ * \brief Attribute for the "on_device" annotation (ie operator).
  */
 #ifndef TVM_RELAY_ATTRS_ON_DEVICE_H_
 #define TVM_RELAY_ATTRS_ON_DEVICE_H_
@@ -33,9 +33,9 @@ namespace tvm {
 namespace relay {
 
 /*!
- * \brief Attributes for the "on_device" special operator.
+ * \brief Attributes for the "on_device" annotation (ie operator).
  *
- * The Relay call (aka 'annotation'):
+ * The Relay call:
  * \code
  *   on_device(sub_expr, se_scope=S)
  * \endcode
@@ -54,44 +54,48 @@ namespace relay {
  *   multiply(device_copy(add(%x, %y), src_se_scope=GPU, dst_se_scope=CPU), %z)
  * \endcode
  *
- * The Relay call
- * \code
- *   on_device(sub_expr, se_scope=S, is_fixed=True)
- * \endcode
- * is similar to the above, however the annotation itself must appear in an expression on the
- * same \p SEScope \p S. The compiler will check the \p SEScopes are consistent, and will not
- * insert any "device_copy" call. This form of annotation shouldn't be necessary in user programs.
- * However it is needed by the \p PlanDevices pass to fully specify the results of device planning
- * so that the pass is idempotent.
- *
- * E.g.: The following program is equivalent to the above:
- * \code
- *   let %a = on_device(add(%x, %y), se_scope=GPU, is_fixed=True)
- *   multiply(device_copy(%a, src_se_scope=GPU, dst_se_scope=CPU), %z)
- * \endcode
- * The "on_device" annotation with \p is_fixed=True indicates unambiguously that \p %a is stored
- * on the GPU.
+ * The \p constraint_body (default true) and \p constraint_result (default false) fields can be
+ * used by passes for finer-grained control over how the \p SEScope constraint should be applied.
  */
 struct OnDeviceAttrs : public tvm::AttrsNode<OnDeviceAttrs> {
   /*!
-   * \brief (Virtual) \p SEScope on which the result of the argument expression should be stored.
+   * \brief The \p SEScope to constraint to apply to the body, result, or both body and result
+   * of the "on_device" call.
    */
   SEScope se_scope = SEScope::FullyUnconstrained();
+
   /*!
-   * \brief If true, the result \p SEScope must also be \p se_scope, and device planning should
-   * not insert any "device_copy" calls to respect this annotation.
-   *
-   * This is used by the device planning pass itself when annotating the planned program.
+   * \brief If fales (the default), the result of the "on_device" call is not constrained to be
+   * \p se_scope.
    */
-  bool is_fixed = false;
+  bool constrain_result = false;
+
+  /*!
+   * \brief If true (the default), the body of the "on_device" call is constrained to be \p
+   * se_scope.
+   */
+  bool constrain_body = true;
+
+  /*!
+   * \brief Returns true if both the body and result are constrained.
+   */
+  bool is_fixed() const { return constrain_result && constrain_body; }
+
+  /*!
+   * \brief Returns true only the body is constrained (the 'normal' case).
+   */
+  bool is_normal() const { return !constrain_result && constrain_body; }
 
   TVM_DECLARE_ATTRS(OnDeviceAttrs, "relay.attrs.OnDeviceAttrs") {
     TVM_ATTR_FIELD(se_scope)
-        .describe("The (virtual) device and scope holding the expression result.")
+        .describe("The (virtual) device to constrain to.")
         .set_default(SEScope::FullyUnconstrained());
-    TVM_ATTR_FIELD(is_fixed)
-        .describe("If true, do not insert a \"device_copy\" call to respect this annotation.")
+    TVM_ATTR_FIELD(constrain_result)
+        .describe("Whether the constraint applies to the overall expression")
         .set_default(false);
+    TVM_ATTR_FIELD(constrain_body)
+        .describe("Whether the constraint applies to the body sub-expression.")
+        .set_default(true);
   }
 };
 

--- a/include/tvm/target/se_scope.h
+++ b/include/tvm/target/se_scope.h
@@ -170,7 +170,7 @@ class SEScopeNode : public AttrsNode<SEScopeNode> {
    *
    * kInvalidDeviceType denotes unconstrained.
    */
-  int device_type_int;
+  int /* actually DLDeviceType */ device_type_int;
 
   DLDeviceType device_type() const { return static_cast<DLDeviceType>(device_type_int); }
 
@@ -301,6 +301,11 @@ class SEScope : public ObjectRef {
   static SEScope ForTarget(Target target) {
     DLDeviceType device_type = static_cast<DLDeviceType>(target->kind->device_type);
     return SEScope(device_type, /*virtual_device_id=*/0, std::move(target));
+  }
+
+  /*! \brief Returns the \p SEScope for \p memory_scope alone. */
+  static SEScope ForMemoryScope(MemoryScope memory_scope) {
+    return SEScope(kInvalidDeviceType, -1, {}, std::move(memory_scope));
   }
 
   /*! \brief Returns the \p SEScope for \p device, \p target and \p memory_scope. */

--- a/python/tvm/relay/op/annotation/annotation.py
+++ b/python/tvm/relay/op/annotation/annotation.py
@@ -31,29 +31,35 @@ def _make_se_scope(device):
     raise ValueError("expecting a Device or device name, but received a %s" % (type(device)))
 
 
-def on_device(data, device, is_fixed=False):
-    """Annotates an expression with the device type on which its result should be stored.
+def on_device(body, device, constrain_result=False, constrain_body=True):
+    """Annotates a body expression with device constraints. The constraint influences
+    how the body is compiled, where the body is evaluated, and where the result of
+    evaluation is stored.
+
+    Note that the defaults for the constrain_body and constrain_result parameters should
+    almost never need to be overridden by the user. These parameters are exposed here
+    to help unit tests exercise the PlanDevices pass machinery.
 
     Parameters
     ----------
-    data : tvm.relay.Expr
+    body : tvm.relay.Expr
         The expression to be annotated.
 
     device : Union[:py:class:`Device`, str]
         The device to annotate with.
 
-    is_fixed : bool
-        If false (the default), a device_copy
-        If true, the annotation does not imply a device_copy may be inserted to
-        reconcile the device of the data argument with the device for the context of the
-        annotated expression.
+    constrain_result  : bool
+        If false (the default), the result of the on_device is not constrained to be on device.
+
+    constrain_body : bool
+        If true (the default), the body of the on_device is constrained to be on device.
 
     Returns
     -------
     result : tvm.relay.Expr
         The annotated expression.
     """
-    return _make.OnDevice(data, _make_se_scope(device), is_fixed)
+    return _make.OnDevice(body, _make_se_scope(device), constrain_result, constrain_body)
 
 
 def function_on_device(function, param_devices, result_device):

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -502,12 +502,6 @@ Doc RelayTextPrinter::VisitExpr_(const FunctionNode* op) {
 Doc RelayTextPrinter::VisitExpr_(const GlobalVarNode* op) {
   Doc doc;
   doc << "@" << op->name_hint;
-#if TVM_LOG_DEBUG
-  if (op->checked_type_.defined()) {
-    doc << " /* type=" << PrintType(op->checked_type_, /*meta=*/false) << " */";
-  }
-  doc << " /* id=" << reinterpret_cast<uint64_t>(op) << " */";
-#endif
   return doc;
 }
 
@@ -521,6 +515,11 @@ Doc RelayTextPrinter::VisitExpr_(const CallNode* op) {
   for (const Expr& arg : op->args) {
     args.push_back(Print(arg));
   }
+#if TVM_LOG_DEBUG
+  for (const Type& type_arg : op->type_args) {
+    args.push_back(Print(type_arg));
+  }
+#endif
   for (const Doc& d : PrintCallAttrs(op->attrs, op->op)) {
     args.push_back(d);
   }

--- a/src/printer/text_printer.cc
+++ b/src/printer/text_printer.cc
@@ -27,6 +27,7 @@
 
 #include <tvm/tir/function.h>
 
+#include <algorithm>
 #include <string>
 
 namespace tvm {
@@ -36,49 +37,71 @@ static const char* kSemVer = "0.0.5";
 Doc TextPrinter::PrintMod(const IRModule& mod) {
   Doc doc;
   int counter = 0;
+
+  // We'll print in alphabetical order to make a/b diffs easier to work with.
+
   // type definitions
+  std::vector<GlobalTypeVar> tyvars;
   for (const auto& kv : mod->type_definitions) {
+    tyvars.emplace_back(kv.first);
+  }
+  std::sort(tyvars.begin(), tyvars.end(),
+            [](const GlobalTypeVar& left, const GlobalTypeVar& right) {
+              return left->name_hint < right->name_hint;
+            });
+  for (const auto& tyvar : tyvars) {
     if (counter++ != 0) {
       doc << Doc::NewLine();
     }
-    doc << relay_text_printer_.Print(kv.second);
+    doc << relay_text_printer_.Print(mod->type_definitions[tyvar]);
     doc << Doc::NewLine();
   }
+
   // functions
+  std::vector<GlobalVar> vars;
   for (const auto& kv : mod->functions) {
-    if (kv.second.as<relay::FunctionNode>()) {
+    vars.emplace_back(kv.first);
+  }
+  std::sort(vars.begin(), vars.end(), [](const GlobalVar& left, const GlobalVar& right) {
+    return left->name_hint < right->name_hint;
+  });
+  for (const auto& var : vars) {
+    const BaseFunc& base_func = mod->functions[var];
+    if (base_func.as<relay::FunctionNode>()) {
       relay_text_printer_.dg_ =
-          relay::DependencyGraph::Create(&relay_text_printer_.arena_, kv.second);
+          relay::DependencyGraph::Create(&relay_text_printer_.arena_, base_func);
     }
     if (counter++ != 0) {
       doc << Doc::NewLine();
     }
-    if (kv.second.as<relay::FunctionNode>()) {
+    if (base_func.as<relay::FunctionNode>()) {
       std::ostringstream os;
-      os << "def @" << kv.first->name_hint;
-#if TVM_LOG_DEBUG
-      os << " /* id=" << reinterpret_cast<uint64_t>(kv.first.get()) << " */";
-#endif
-      doc << relay_text_printer_.PrintFunc(Doc::Text(os.str()), kv.second);
-    } else if (kv.second.as<tir::PrimFuncNode>()) {
-      doc << "@" << kv.first->name_hint;
-#if TVM_LOG_DEBUG
-      doc << " /* id=" << reinterpret_cast<uint64_t>(kv.first.get()) << " */";
-#endif
-      doc << " = " << tir_text_printer_.PrintPrimFunc(Downcast<tir::PrimFunc>(kv.second));
+      os << "def @" << var->name_hint;
+      doc << relay_text_printer_.PrintFunc(Doc::Text(os.str()), base_func);
+    } else if (base_func.as<tir::PrimFuncNode>()) {
+      doc << "@" << var->name_hint;
+      doc << " = " << tir_text_printer_.PrintPrimFunc(Downcast<tir::PrimFunc>(base_func));
     }
     doc << Doc::NewLine();
   }
+
 #if TVM_LOG_DEBUG
   // attributes
+  // TODO(mbs): Make this official, including support from parser.
   if (mod->attrs.defined() && !mod->attrs->dict.empty()) {
-    doc << "attributes {" << Doc::NewLine();
+    std::vector<String> keys;
     for (const auto& kv : mod->attrs->dict) {
-      doc << "  '" << kv.first << "' = " << PrettyPrint(kv.second) << Doc::NewLine();
+      keys.emplace_back(kv.first);
+    }
+    std::sort(keys.begin(), keys.end());
+    doc << "attributes {" << Doc::NewLine();
+    for (const auto& key : keys) {
+      doc << "  '" << key << "' = " << PrettyPrint(mod->attrs->dict[key]) << Doc::NewLine();
     }
     doc << "}" << Doc::NewLine();
   }
 #endif
+
   return doc;
 }
 

--- a/src/relay/backend/contrib/example_target_hooks/relay_to_tir.cc
+++ b/src/relay/backend/contrib/example_target_hooks/relay_to_tir.cc
@@ -116,10 +116,10 @@ class ConvertAddToSubtract : public MixedModeMutator {
 
         // Since we are replacing the Relay function with a call to a TIR function, we must use the
         // call_lowered op.
-        auto call_lowered_attrs = make_object<CallLoweredAttrs>();
-        call_lowered_attrs->metadata.Set("relay_attrs", call->attrs);
-        return CallLowered(std::move(new_global_var), call->args,
-                           std::move(Attrs(call_lowered_attrs)), call->type_args, call->span);
+        CallLoweredAttrs attrs;
+        attrs.metadata.Set("relay_attrs", call->attrs);
+        ICHECK(call->type_args.empty()) << "lowered functions cannot be polymorphic";
+        return CallLowered(std::move(new_global_var), call->args, std::move(attrs), call->span);
       }
     }
 
@@ -144,5 +144,4 @@ transform::Pass RelayToTIR() {
 }  // namespace example_target_hooks
 }  // namespace contrib
 }  // namespace relay
-
 }  // namespace tvm

--- a/src/relay/op/call/call.cc
+++ b/src/relay/op/call/call.cc
@@ -63,23 +63,23 @@ bool CallLoweredRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
 
 const Op& CallLoweredOp() { return Op::Get("call_lowered"); }
 
-Expr CallLowered(Expr func, Array<Expr> inputs, Attrs attrs, Array<Type> type_args, Span span) {
-  // Right now, call_lowered only supports func being a global var pointing to the lowered
-  // function.
-  ICHECK(func.as<GlobalVarNode>())
-      << "Function to call should be GlobalVarNode, but got:" << std::endl
-      << PrettyPrint(func);
-  ICHECK(attrs.as<CallLoweredAttrs>())
-      << "Expected attributes to be CallLoweredAttrs, but got " << attrs->GetTypeKey();
-  return Call(CallLoweredOp(), {std::move(func), Tuple(std::move(inputs))}, std::move(attrs),
-              std::move(type_args), std::move(span));
+Call CallLowered(GlobalVar lowered_func, Array<Expr> args, CallLoweredAttrs call_lowered_attrs,
+                 Span span) {
+  auto attrs = make_object<CallLoweredAttrs>(std::move(call_lowered_attrs));
+  return Call(CallLoweredOp(), {std::move(lowered_func), Tuple(std::move(args))},
+              Attrs(std::move(attrs)), /*type_args=*/{}, std::move(span));
 }
 
 TVM_REGISTER_GLOBAL("relay.op.call_lowered")
-    .set_body_typed([](Expr func, Array<Expr> inputs, Attrs attrs, Array<Type> type_args,
-                       Span span) {
-      const TupleNode* tuple_node = inputs.as<TupleNode>();
-      return CallLowered(func, tuple_node->fields, attrs, type_args, span);
+    .set_body_typed([](Expr lowered_func, Array<Expr> args, Attrs attrs, Span span) {
+      const auto* lowered_func_node = lowered_func.as<GlobalVarNode>();
+      ICHECK(lowered_func_node) << "Function to call should be GlobalVarNode, but got:" << std::endl
+                                << PrettyPrint(lowered_func);
+      const auto* call_lowered_attrs = attrs.as<CallLoweredAttrs>();
+      ICHECK(call_lowered_attrs) << "Expected attributes to be CallLoweredAttrs, but got "
+                                 << attrs->GetTypeKey();
+      return CallLowered(GetRef<GlobalVar>(lowered_func_node), std::move(args), *call_lowered_attrs,
+                         std::move(span));
     });
 
 RELAY_REGISTER_OP("call_lowered")
@@ -105,10 +105,12 @@ CallLoweredProps GetCallLoweredProps(const CallNode* call_node) {
     ICHECK(tuple_args) << "Expected second arg to call_lowered to be a Tuple of input arguments.";
 
     ICHECK(call_node->attrs.defined()) << "Expecting call_lowered to have attributes.";
-    const auto* attrs = call_node->attrs.as<CallLoweredAttrs>();
-    ICHECK(attrs) << "Expected call_lowered op to have CallLoweredAttrs, but found "
-                  << call_node->attrs->GetTypeKey();
-    return CallLoweredProps{GetRef<GlobalVar>(function_node), tuple_args->fields, *attrs};
+    const auto* call_lowered_attrs = call_node->attrs.as<CallLoweredAttrs>();
+    ICHECK(call_lowered_attrs) << "Expected call_lowered op to have CallLoweredAttrs, but found "
+                               << call_node->attrs->GetTypeKey();
+    // If the call_node has type_args then they are for the polymorphic 'call_lowered' operator
+    // itself which expects the function type and argument type as parameters.
+    return {GetRef<GlobalVar>(function_node), tuple_args->fields, *call_lowered_attrs};
   }
   return {};
 }
@@ -116,8 +118,9 @@ CallLoweredProps GetCallLoweredProps(const CallNode* call_node) {
 Call GetAnyCall(const CallNode* call_node) {
   CallLoweredProps props = GetCallLoweredProps(call_node);
   if (props.lowered_func.defined()) {
-    auto attrs = make_object<CallLoweredAttrs>(props.attrs);
-    return Call(std::move(props.lowered_func), props.arguments, Attrs(std::move(attrs)),
+    auto call_lowered_attrs = make_object<CallLoweredAttrs>(props.attrs);
+    return Call(std::move(props.lowered_func), std::move(props.arguments),
+                Attrs(std::move(call_lowered_attrs)),
                 /*type_args=*/{}, call_node->span);
   } else {
     return GetRef<Call>(call_node);

--- a/src/relay/op/call/call.h
+++ b/src/relay/op/call/call.h
@@ -33,21 +33,31 @@ namespace tvm {
 namespace relay {
 
 /*!
- * \brief Helper to construct a Relay call with the call_lowered op.
- * \param func Lowered function to call with call_lowered.
- * \param inputs Arguments to be passed to the function.
- * \param attrs Function attributes, should be TIRCallAttrs.
- * \param type_args Type arguments for the call.
- * \param span TVM span for propogating debugging info.
- * \return
- */
-Expr CallLowered(Expr func, Array<Expr> inputs, Attrs attrs, Array<Type> type_args, Span span);
-
-/*!
  * \brief Returns the Relay call_lowered op. Use this helper to avoid extraneous calls to
  * Registry::Get.
  */
 const Op& CallLoweredOp();
+
+/*!
+ * \brief Helper to construct a Relay call with the "call_lowered" op.
+ *
+ * The callee must:
+ *  - Be a global bound to a PrimFunc or an externally defined functions.
+ *  - Accept only tensor arguments and return tensor results.
+ *  - Arguments and results correspond to the flattened form (see FlattenTupleType) of the
+ *    Relay Function type.
+ *  - Return results by output pointer, ie use DPS.
+ * The arguments remain in Relay form (ie not flattened).
+ * The result remains in Relay form (ie returned from the call and not flattened).
+ *
+ * \param lowered_func Lowered function to call with call_lowered.
+ * \param args Arguments to be passed to the function.
+ * \param call_lowered_attrs Function attributes.
+ * \param span TVM span for propagating debugging info.
+ * \return
+ */
+Call CallLowered(GlobalVar lowered_func, Array<Expr> args, CallLoweredAttrs call_lowered_attrs,
+                 Span span);
 
 /*!
  * \brief Lowered function and the arguments to call it with.
@@ -57,7 +67,7 @@ struct CallLoweredProps {
   GlobalVar lowered_func;
   /*! \brief Array of the arguments to call lowered_func with. */
   Array<Expr> arguments;
-  /*! \brief Arguments from the call_lowered op. */
+  /*! \brief Attributes from the call_lowered op. */
   CallLoweredAttrs attrs;
 };
 

--- a/src/relay/transforms/device_domains.cc
+++ b/src/relay/transforms/device_domains.cc
@@ -199,16 +199,23 @@ DeviceDomainPtr DeviceDomains::DomainForCallee(const Call& call) {
   DeviceCopyProps device_copy_props = GetDeviceCopyProps(call.get());
   CallLoweredProps call_lowered_props = GetCallLoweredProps(call.get());
 
+  // TODO(mbs): Support call_lowered to PrimFuncs.
+  ICHECK(!call_lowered_props.lowered_func.defined());
   if (on_device_props.body.defined()) {
-    // on_device(expr, se_scope=<t>, is_fixed=false)
-    // on_device : fn(<t>):?x?
-    //
-    // on_device(expr, se_scope=<t>, is_fixed=true)
-    // on_device: fn(<t>):<t>
-    args_and_result.emplace_back(
-        ForSEScope(on_device_props.body->checked_type(), on_device_props.se_scope));
-    if (on_device_props.is_fixed) {
-      args_and_result.emplace_back(args_and_result.front());
+    // By default:
+    //   on_device(expr, se_scope=<t>)
+    //   on_device : fn(<t>):?x?
+    // However we'll interpret the constrain_body and constrain_result fields to decide
+    // on free vs constrained domains for the argument and result respectively.
+    if (on_device_props.constrain_body) {
+      args_and_result.emplace_back(
+          ForSEScope(on_device_props.body->checked_type(), on_device_props.se_scope));
+    } else {
+      args_and_result.emplace_back(Free(on_device_props.body->checked_type()));
+    }
+    if (on_device_props.constrain_result) {
+      args_and_result.emplace_back(
+          ForSEScope(on_device_props.body->checked_type(), on_device_props.se_scope));
     } else {
       args_and_result.emplace_back(Free(on_device_props.body->checked_type()));
     }
@@ -286,11 +293,9 @@ DeviceDomainPtr DeviceDomains::DomainForCallee(const Call& call) {
       args_and_result.emplace_back(param_domain);
     }
     args_and_result.emplace_back(result_domain);
-  } else if (call_lowered_props.lowered_func.defined()) {
-    return DomainFor(call_lowered_props.lowered_func);
   } else {
     // We still need to handle the case where the function / op is not lowered
-    // because the device planner runs before and after lowering.
+    // because the device planner runs both before and after lowering.
     return DomainFor(call->op);
   }
   auto domain = MakeHigherOrderDomain(std::move(args_and_result));
@@ -310,6 +315,33 @@ void DeviceDomains::UnifyExprExact(const Expr& lhs, const Expr& rhs) {
                << PrettyPrint(rhs) << std::endl
                << "with scope:" << std::endl
                << ToString(rhs_domain);
+  }
+}
+
+void DeviceDomains::OptionalUnifyExprExact(const Expr& lhs, const Expr& rhs) {
+  auto lhs_domain = DomainFor(lhs);
+  auto rhs_domain = DomainFor(rhs);
+  // Snapshot
+  std::unordered_map<DeviceDomainPtr, DeviceDomainPtr> domain_to_equiv_snapshot = domain_to_equiv_;
+  if (UnifyOrNull(lhs_domain, rhs_domain) == nullptr) {
+    // Rollback
+    domain_to_equiv_ = domain_to_equiv_snapshot;
+    VLOG(2) << "Unable to unify SEScopes for expression:" << std::endl
+            << PrettyPrint(lhs) << std::endl
+            << "with scope:" << std::endl
+            << ToString(lhs_domain) << std::endl
+            << "and expression:" << std::endl
+            << PrettyPrint(rhs) << std::endl
+            << "with scope:" << std::endl
+            << ToString(rhs_domain) << std::endl
+            << ". Leaving scopes non-unified.";
+  } else {
+    VLOG(2) << "Unified SEScopes for expression:" << std::endl
+            << PrettyPrint(lhs) << std::endl
+            << "and expression:" << std::endl
+            << PrettyPrint(rhs) << std::endl
+            << "to scope:" << std::endl
+            << ToString(lhs_domain);
   }
 }
 

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -20,6 +20,10 @@
 /*!
  * \file src/relay/transforms/device_planner.cc
  * \brief Determines a unique \p SEScope to hold the result of every Relay sub-expression.
+ * This pass can be run multiple times, and can be run both before and after lowering.
+ *
+ * TODO(mbs): Rename SEScope |-> VirtualDevice, and use 'virtual device' (or just 'device')
+ * throughout.
  *
  * We say a Relay expression E is 'on device D' if the result of executing E is stored on D.
  * We represent D by an \p SEScope, which means we can track anywhere from an arbitrary device
@@ -29,17 +33,21 @@
  * Note that 'stored on device D' is almost but not quite the same as 'executes on device D',
  * see below.
  *
- * This pass assumes the module already contains some "on_device" and/or "device_copy" CallNodes:
- *  - "device_copy" CallNodes (with a \p DeviceCopyAttrs attribute) specify a 'src_se_scope' and
- *    'dst_se_scope' \p SEScopes, which constrain the argument and context of the call
- *     respectively. It is ok if source and destination devices are the same, such no-op copies
- *     will be removed after accounting for the device preference.
- *  - "on_device" CallNodes (with a \p OnDeviceAttrs attribute) specify an 'se_scope', which
- *    constrains the argument of the call, but (usually, see below) leaves the context
+ * This pass works by collecting and solving device constraints, using defaulting heuristics to
+ * resolve any remaining undetermined devices, and encoding the results on the output in a form
+ * that's reasonably friendly to downstream passes.
+ *
+ * Specific \p SEScopes flow into the constraints from five places:
+ *  - Existing "device_copy" CallNodes (with a \p DeviceCopyAttrs attribute) specify a
+ *    'src_se_scope' and 'dst_se_scope' \p SEScope. Those constrain the argument and context of
+ *     the call respectively. It is ok if source and destination devices are the same, such no-op
+ *     copies will be removed after accounting for the device preference.
+ *  - Existing "on_device" CallNodes (with a \p OnDeviceAttrs attribute) specify an 'se_scope',
+ *    which constrains the argument of the call, but (usually, see below) leaves the context
  *    unconstrained. These are called 'annotations' in the rest of the code, have no operational
- *    significance by themselves, but may trigger the insertion of a new "device_copy".
- *  - In two situations the result of an "on_device" CallNode may also be constrained to the
- *    given device:
+ *    significance by themselves, but may trigger the insertion of a new "device_copy" call by
+ *    this pass. In two situations the result of an "on_device" CallNode may also be constrained
+ *    to the given 'se_scope':
  *     - The "on_device" call occurs at the top-level of a function body, or occurs as an
  *       immediately let-bound expression. In this situation the extra degree of freedom in
  *       the function result and let-binding leads to surprising device copies, so we simply
@@ -47,6 +55,11 @@
  *     - The \p OnDeviceAttrs has an \p is_fixed field of \p true, which indicates we inserted
  *       it ourselves during an earlier invocation of this pass. This helps make this pass
  *       idempotent.
+ *  - Some special operators require their arguments or results to be on the 'host' (typcially
+ *    a CPU) \p SEScope, see below.
+ *  - Annotations left over from a previous run of this pass, such as 'param_se_scopes' and
+ *    'result_se_scope' function attributes we introduce below. This is so the pass is idempotent
+ *    and can be re-run to flow additional memory scope constraints.
  *
  * We proceed in four phases:
  *
@@ -61,14 +74,13 @@
  *
  * Phase 1
  * -------
- * We flow constraints from the "on_device" and "device_copy" calls (and some special ops, see
- * below) to all other Relay sub-expressions. (For idempotence we also respect any existing
- * "param_se_scopes" and "result_se_scope" function attributes we introduce below.)
+ * We flow constraints from the "on_device" and "device_copy" calls,
+ * and some special ops, to all other Relay sub-expressions.
  *
  * For a primitive such as \code add(e1, e2) \endcode all arguments and results must be on the
  * same device. However each call site can use a different device. In other words primitives are
  * 'device polymorphic' since we compile and execute them for each required device. ADT constructors
- * are similarly polymorphic.
+ * are similarly polymorphic, but require all constructor args to be on the same device.
  *
  * For most Relay expressions the device for the overall expression is the same as the device
  * for its sub-expressions. E.g. each field of a tuple must be on the same device as the tuple
@@ -99,6 +111,8 @@
  *  - Unconstrained let-bound expression devices default to the device for the overall let.
  * TODO(mbs): These are very simple minded heuristics, and ultimately we'd like to treat the
  * assignment of the remaining unconstrained sub-expressions as an optimiziation problem in itself.
+ * This requires a formal notion of 'choicepoint' inside the compiler which can integrate with
+ * automation.
  *
  * Phase 3
  * -------
@@ -108,10 +122,15 @@
  *    the function's parameters and the result.
  *  - Additional "device_copy" CallNodes where a copy is required in order to respect the
  *    intent of the original "on_device" CallNodes.
- *  - Additional "on_device" CallNodes where the device type of an expression does not match
- *    that of the lexically enclosing "on_device" CallNode or function attribute. In practice
+ *  - Additional "on_device" CallNodes where the device type of an expression is not trivially
+ *    implied by the lexically enclosing "on_device" CallNode or function attribute. In practice
  *    this means "on_device" CallNodes may appear in two places:
- *     - On a let-bound expression if its device differs from the overall let expression.
+ *     - On let-bound expressions. It is tempting to elide the "on_device" if the let-bound value
+ *       has the same device as the overall let expression. However this would mean passes which
+ *       inline let-bound values, such as FoldConstant and DeadCodeElimination, would need to us
+ *       a DeviceAware visitor which in turn requires the expression to be in ANF to avoid
+ *       deep recursion. To minimize disruption we always include the "on_device" so that it
+ *       can follow the inline.
  *     - On a call argument if its device differs from the call result. In particular, the
  *       argument to a "device_copy" call will always be wrapped in an "on_device". (That may
  *       seem pedantic but simplifies downstream handling.)
@@ -125,15 +144,14 @@
  * passes must preserve the lexical scoping of the "on_device" CallNodes. E.g. conversion
  * to ANF must respect the lexical scoping convention:
  * \code
- * f(on_device(g(h(a, b), c), se_scope=CPU))
- * ==>
- * let %x0 = on_device(h(a, b), se_scope=CPU)
- * let %x1 = on_device(g(%x0), se_scope=CPU)
- * f(on_device(%x1, se_scope=CPU))
+ *   f(on_device(g(h(a, b), c), se_scope=CPU))
+ *   ==>
+ *   let %x0 = on_device(h(a, b), se_scope=CPU)
+ *   let %x1 = on_device(g(%x0), se_scope=CPU)
+ *   f(on_device(%x1, se_scope=CPU))
  * \endcode
  *
- * This pass can be run before FuseOps it can use device-specific fusion rules.
- * TODO(mbs): We also need to support running after FuseOps.
+ * This pass can be run before FuseOps so that it can use device-specific fusion rules.
  *
  * 'Stored on' vs 'Executes on'
  * ----------------------------
@@ -227,17 +245,10 @@
  *    |
  *    `-- Mark's stamp of completeness :-)
  *
- * TODO(mbs):
- *  * Proper diagnostics for unification failure using spans.
- *  * Support running the pass post FuseOps (so need to understand primitive functions, both
- *    outlines and lined) and post the VM transforms (probably need to support more intrinsic
- *    forms?).
- *  * Don't hardcode the 'CPU' device for shape funcs etc, and distinguish between the default
- *    device for primitives vs the default device for the rest of Relay.
- *  * We may want some 'device polymorphism' for Relay functions. Eg it's ok for the function
- *    to be called with params/result on different (virtual) device ids provided the target and
- *    memory scopes are consistent.
- *  * Switch to expr.CopyWith(...) form once implemented to avoid unnecessary copies.
+ * TODO(mbs): Proper diagnostics for unification failure using spans.
+ * TODO(mbs): We may want some 'device polymorphism' for Relay functions. Eg it's ok for the
+ * function to be called with params/result on different (virtual) device ids provided the target
+ * and memory scopes are consistent.
  */
 
 #include <tvm/ir/transform.h>
@@ -252,6 +263,8 @@
 #include <tvm/relay/type.h>
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/object.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/stmt_functor.h>
 
 #include <unordered_map>
 
@@ -266,27 +279,32 @@ namespace transform {
 
 namespace {
 
-/******
-******* Phase 0
-*******/
+/* =============== Phase 0 =============== */
 
 /*!
  * \brief Rewrites "on_device" calls to handle some special cases.
  *
- * \code
- * let %x = on_device(e, se_scope=d)
- * ==> let %x = on_device(e, se_scope=d, is_fixed=True)
+ *  - Don't let the device for %x remain unconstrained:
+ *    \code
+ *      let %x = on_device(e, se_scope=d)
+ *      ==> let %x = on_device(e, se_scope=d, constraint=kBoth)
+ *    \endcode
  *
- * fn(%x) { on_device(e, se_scope=d) }
- * ==> fn(%x) { on_device(e, se_scope=d, is_fixed=True)
+ *  - Don't let the function result remain unconstrained:
+ *    \code
+ *      fn(%x) { on_device(e, se_scope=d) }
+ *      ==> fn(%x) { on_device(e, se_scope=d, constraint=kBoth)
+ *    \endcode
  *
- * on_device(e).0
- * ==> on_device(e.0)
- * \endcode
+ *  - Project-then-copy rather than copy-then-project:
+ *    \code
+ *      on_device(e).0
+ *      ==> on_device(e.0)
+ *    \endcode
  */
 class RewriteOnDevices : public ExprMutator {
  public:
-  RewriteOnDevices() = default;
+  explicit RewriteOnDevices(IRModule mod) : mod_(std::move(mod)) {}
 
  private:
   Expr VisitExpr_(const TupleGetItemNode* tuple_get_item_node) final {
@@ -294,11 +312,11 @@ class RewriteOnDevices : public ExprMutator {
     OnDeviceProps props = GetOnDeviceProps(tuple);
 
     Expr tuple_get_item = WithFields(GetRef<TupleGetItem>(tuple_get_item_node), std::move(tuple));
-    if (props.body.defined() && !props.is_fixed) {
+    if (props.body.defined() && props.is_normal()) {
       VLOG(2) << "wrapping tuple get item:" << std::endl
               << PrettyPrint(GetRef<TupleGetItem>(tuple_get_item_node)) << std::endl
               << "with \"on_device\" for SEScope " << props.se_scope;
-      return OnDevice(tuple_get_item, props.se_scope, /*is_fixed=*/false);
+      return OnDeviceWithProps(tuple_get_item, props);
     } else {
       return tuple_get_item;
     }
@@ -311,19 +329,19 @@ class RewriteOnDevices : public ExprMutator {
       Let inner_let = GetRef<Let>(inner_let_node);
       Expr value = VisitExpr(inner_let_node->value);
       OnDeviceProps props = GetOnDeviceProps(value);
-      if (props.body.defined() && !props.is_fixed) {
+      if (props.body.defined() && props.is_normal()) {
         VLOG(2) << "revising let-bound expression of let:" << std::endl
                 << PrettyPrint(expr) << std::endl
                 << "to be fixed to SEScope " << props.se_scope;
-        value = OnDevice(props.body, props.se_scope, /*is_fixed=*/true);
+        value = MaybeOnDeviceFixed(props.body, props.se_scope);
       }
       bindings.emplace_back(inner_let, value);
       expr = inner_let_node->body;
     }
     expr = VisitExpr(expr);
     for (auto itr = bindings.rbegin(); itr != bindings.rend(); ++itr) {
-      expr = WithFields(/*let=*/std::move(std::get<0>(*itr)), /*var = unchanged*/ {},
-                        /*value=*/std::move(std::get<1>(*itr)), /*body=*/std::move(expr));
+      expr = WithFields(/*let=*/std::move(std::get<0>(*itr)), /*opt_var=*/{},
+                        /*opt_value=*/std::move(std::get<1>(*itr)), /*opt_body=*/std::move(expr));
     }
     return expr;
   }
@@ -331,20 +349,20 @@ class RewriteOnDevices : public ExprMutator {
   Expr VisitExpr_(const FunctionNode* function_node) final {
     Expr body = VisitExpr(function_node->body);
     OnDeviceProps props = GetOnDeviceProps(body);
-    if (props.body.defined() && !props.is_fixed) {
+    if (props.body.defined() && props.is_normal()) {
       VLOG(2) << "revising body of function:" << std::endl
               << PrettyPrint(GetRef<Function>(function_node)) << std::endl
               << "to be fixed to SEScope " << props.se_scope;
-      body = OnDevice(props.body, props.se_scope, /*is_fixed=*/true);
+      body = MaybeOnDeviceFixed(props.body, props.se_scope);
     }
-    return WithFields(GetRef<Function>(function_node), std::move(function_node->params),
-                      std::move(body));
+    return WithFields(GetRef<Function>(function_node), function_node->params, std::move(body));
   }
+
+  /*! \brief Module we are rewriting, so we can lookup global definitions. */
+  IRModule mod_;
 };
 
-/******
-******* Phase 1
-*******/
+/* =============== Phase 1 =============== */
 
 /*
  * \brief Collects the system of device constraints for all sub-expressions in a module.
@@ -374,10 +392,18 @@ class DeviceAnalyzer : public ExprVisitor {
    */
   std::unique_ptr<DeviceDomains> Analyze() {
     VLOG_CONTEXT << "DeviceAnalyzer";
-    for (const auto& pair : mod_->functions) {
-      VLOG(2) << "collecting constraints for '" << PrettyPrint(pair.first) << "'";
-      domains_->UnifyExprExact(pair.first, pair.second);
-      VisitExpr(pair.second);
+    for (const auto& kv : mod_->functions) {
+      // The global variable and what it is bound to must obviously agree on domain.
+      if (const auto* function_node = AsOptimizableFunctionNode(kv.second)) {
+        VLOG(2) << "collecting constraints from Relay Function '" << kv.first->name_hint << "'";
+        domains_->UnifyExprExact(kv.first, kv.second);
+        VisitExpr(GetRef<Function>(function_node));
+      } else if (const auto* prim_func_node = kv.second.as<tir::PrimFuncNode>()) {
+        VLOG(2) << "skipping TIR PrimFunc '" << kv.first->name_hint << "'";
+        // TODO(mbs): Handle PrimFuncs
+      } else {
+        VLOG(2) << "skipping '" << kv.first->name_hint << "'";
+      }
     }
     return std::move(domains_);
   }
@@ -386,16 +412,19 @@ class DeviceAnalyzer : public ExprVisitor {
   void VisitExpr_(const CallNode* call_node) final {
     auto call = GetRef<Call>(call_node);
 
+    // We don't care if the call is in pre- or post-lowered form.
+    auto vanilla_call = GetAnyCall(call_node);
+
     // Find the higher-order domain for the callee. See DomainForCallee for the special rules
     // for primitives.
-    VisitExpr(call_node->op);
+    VisitExpr(vanilla_call->op);
     auto func_domain = domains_->DomainForCallee(call);  // higher-order
 
     // Build the domain for the function implied by its arguments and call context.
-    ICHECK_EQ(func_domain->function_arity(), call_node->args.size());
+    ICHECK_EQ(func_domain->function_arity(), vanilla_call->args.size()) << PrettyPrint(call);
     std::vector<DeviceDomainPtr> args_and_result_domains;
-    args_and_result_domains.reserve(call_node->args.size() + 1);
-    for (const auto& arg : call_node->args) {
+    args_and_result_domains.reserve(vanilla_call->args.size() + 1);
+    for (const auto& arg : vanilla_call->args) {
       args_and_result_domains.emplace_back(domains_->DomainFor(arg));
       VisitExpr(arg);
     }
@@ -416,9 +445,9 @@ class DeviceAnalyzer : public ExprVisitor {
       LOG(FATAL) << "Function parameters and result SEScopes do not match those of call. Call:"
                  << std::endl
                  << PrettyPrint(call) << std::endl
-                 << "with function scopes:" << std::endl
+                 << "with function virtual devices:" << std::endl
                  << domains_->ToString(func_domain) << std::endl
-                 << "and implied call scopes:" << std::endl
+                 << "and implied call virtual devices:" << std::endl
                  << domains_->ToString(implied_domain);
     }
 
@@ -494,9 +523,9 @@ class DeviceAnalyzer : public ExprVisitor {
             << "Function SEScopes are incompatible with its \"on_device\" annotation. Function:"
             << std::endl
             << PrettyPrint(function) << std::endl
-            << "with function scopes:" << std::endl
+            << "with function virtual devices:" << std::endl
             << domains_->ToString(func_domain) << std::endl
-            << "and annotation scopes:" << std::endl
+            << "and annotation virtual devices:" << std::endl
             << domains_->ToString(annotation_domain);
       }
     }
@@ -621,9 +650,52 @@ class DeviceAnalyzer : public ExprVisitor {
   std::unique_ptr<DeviceDomains> domains_;
 };
 
-/******
-******* Phase 2
-*******/
+/* =============== Phase 2 =============== */
+
+/*!
+ * \brief Calls to 'free' "on_device" annotations (ie where both constrain_body=false and
+ * constrain_result=false) indicate a device_copy is allowed if required, but no particular
+ * device is imposed on the body or the context. At this stage we can attempt to unify the
+ * body and device contexts. In this way we can avoid the defaulting rules in \p DeviceDefaulter
+ * from choosing default devices which are only going to induce a device copy.
+ *
+ * TODO(mbs): The order in which we encounter the "on_device" calls can influence the final global
+ * device assignment. However we visit global functions in hash map order.
+ */
+class FreeOnDeviceDefaulter : public ExprVisitor {
+ public:
+  FreeOnDeviceDefaulter(IRModule mod, std::unique_ptr<DeviceDomains> domains)
+      : mod_(std::move(mod)), domains_(std::move(domains)) {}
+
+  std::unique_ptr<DeviceDomains> Default() {
+    VLOG_CONTEXT << "FreeOnDeviceDefaulter";
+    VLOG(0) << "unifying free on_device annotations";
+    for (const auto& kv : mod_->functions) {
+      if (const auto* function_node = AsOptimizableFunctionNode(kv.second)) {
+        VLOG(2) << "unifying for '" << kv.first->name_hint << "'";
+        VisitExpr(GetRef<Function>(function_node));
+      } else {
+        VLOG(2) << "skipping '" << kv.first->name_hint << "'";
+      }
+    }
+    return std::move(domains_);
+  }
+
+ private:
+  void VisitExpr_(const CallNode* call_node) final {
+    auto call = GetRef<Call>(call_node);
+    OnDeviceProps props = GetOnDeviceProps(call_node);
+    ExprVisitor::VisitExpr_(call_node);
+    if (props.body.defined() && !props.constrain_body && !props.constrain_result) {
+      domains_->OptionalUnifyExprExact(call, props.body);
+    }
+  }
+
+  /*! \brief The module we are processing. */
+  IRModule mod_;
+  /*! \brief The domains for all expressions.  */
+  std::unique_ptr<DeviceDomains> domains_;
+};
 
 /*!
  * \brief Ensures every sub-expression in a module has a device type, using both the global
@@ -634,10 +706,11 @@ class DeviceAnalyzer : public ExprVisitor {
  *   def @main(%x, %y, %z) {
  *     let %a = add(%x, %y);
  *     multiply(%a, on_device(%z, se_scope=d))
+ *   }
  * \endcode
  * we know the parameter \p %z must be on device \p d, but the devices for \p %x and \p %y,
  * and the device for the function result, are still 'free'. The global 'default' device type
- * is first used to 'fix' \p @main's result type, which in turn 'fixes' \p %x and \p %y, which
+ * is first used to 'fix' \p main's result type, which in turn 'fixes' \p %x and \p %y, which
  * in turn 'fixes' the device on which the \p add and \p multiply are executed.
  *
  * TODO(mbs): I think this is deterministic? We do however visit the top-level defs in hashmap
@@ -651,9 +724,13 @@ class DeviceDefaulter : public ExprVisitor {
   std::unique_ptr<DeviceDomains> Default() {
     VLOG_CONTEXT << "DeviceDefaulter";
     VLOG(0) << "defaulting to SEScope " << domains_->config()->default_primitive_se_scope;
-    for (const auto& pair : mod_->functions) {
-      VLOG(2) << "defaulting devices for '" << PrettyPrint(pair.first) << "'";
-      VisitExpr(pair.second);
+    for (const auto& kv : mod_->functions) {
+      if (const auto* function_node = AsOptimizableFunctionNode(kv.second)) {
+        VLOG(2) << "defaulting devices for '" << kv.first->name_hint << "'";
+        VisitExpr(GetRef<Function>(function_node));
+      } else {
+        VLOG(2) << "skipping '" << kv.first->name_hint << "'";
+      }
     }
     return std::move(domains_);
   }
@@ -678,8 +755,12 @@ class DeviceDefaulter : public ExprVisitor {
 
   void VisitExpr_(const CallNode* call_node) final {
     auto call = GetRef<Call>(call_node);
+
+    // We don't care if the call is pre- or post-lowered.
+    auto vanilla_call = GetAnyCall(call_node);
+
     auto func_domain = domains_->DomainForCallee(call);  // higher-order
-    ICHECK_EQ(func_domain->function_arity(), call_node->args.size());
+    ICHECK_EQ(func_domain->function_arity(), vanilla_call->args.size());
     if (!domains_->IsFullyConstrained(func_domain)) {
       // For calls to Relay functions this step is identical to that for VisitExpr_(FunctionNode*)
       // above. But for calls to primitives we may still need to force free domains to be
@@ -720,9 +801,7 @@ class DeviceDefaulter : public ExprVisitor {
   std::unique_ptr<DeviceDomains> domains_;
 };
 
-/******
-******* Phase 3
-*******/
+/* =============== Phase 3 =============== */
 
 /*!
  * \brief Inserts missing "device_copy" CallNodes, and ensures the device type of every
@@ -749,6 +828,8 @@ class DeviceDefaulter : public ExprVisitor {
  *   keeps downstream processing simple. The "on_device" calls should be removed before code gen,
  *   which is easily done on-the-fly.
  *
+ * - Update memory scopes in PrimFunc buffer maps.
+ *
  * For example, we'll end up with programs that look like:
  * \code
  *   def @main(%x, %y, param_se_scopes=[...], result_se_scope=...) {
@@ -767,9 +848,17 @@ class DeviceCapturer : public ExprMutator {
     VLOG_CONTEXT << "CaptureDevices";
     IRModule result(/*functions=*/{}, mod_->type_definitions, mod_->Imports(), mod_->source_map,
                     mod_->attrs);
-    for (const auto& pair : mod_->functions) {
-      VLOG(2) << "capturing devices for '" << PrettyPrint(pair.first) << "'";
-      result->Add(pair.first, Downcast<BaseFunc>(Mutate(pair.second)));
+    for (const auto& kv : mod_->functions) {
+      if (const auto* function_node = AsOptimizableFunctionNode(kv.second)) {
+        VLOG(2) << "capturing devices for Relay Function '" << kv.first->name_hint << "'";
+        result->Add(kv.first, Downcast<Function>(Mutate(GetRef<Function>(function_node))));
+      } else if (const auto* prim_func_node = kv.second.as<tir::PrimFuncNode>()) {
+        VLOG(2) << "skipping TIR PrimFunc '" << kv.first->name_hint << "'";
+        // TODO(mbs): Handle PrimFuncs.
+      } else {
+        VLOG(2) << "skipping '" << kv.first->name_hint << "'";
+        result->Add(kv.first, kv.second);
+      }
     }
     return result;
   }
@@ -825,6 +914,11 @@ class DeviceCapturer : public ExprMutator {
 
   Expr VisitExpr_(const CallNode* call_node) final {
     auto call = GetRef<Call>(call_node);
+
+    // We don't care if the call is pre- or post-lowered
+    // (However we'll preserve the form in the result below.)
+    auto vanilla_call = GetAnyCall(call_node);
+
     SEScope call_se_scope = GetSEScope(call);
 
     auto on_device_props = GetOnDeviceProps(call_node);
@@ -844,7 +938,8 @@ class DeviceCapturer : public ExprMutator {
         // match.
         return VisitExpr(device_copy_props.body);
       } else {
-        return VisitChild(/*lexical_se_scope=*/dst_se_scope,
+        return VisitChild(/*lexical_se_scope=*/
+                          dst_se_scope,
                           /*expected_se_scope=*/dst_se_scope,
                           /*child_se_scope=*/src_se_scope, device_copy_props.body);
       }
@@ -854,7 +949,7 @@ class DeviceCapturer : public ExprMutator {
     auto func_domain = domains_->DomainForCallee(call);  // higher-order
     VLOG(2) << "considering call:" << std::endl
             << PrettyPrint(call) << std::endl
-            << "in scope " << call_se_scope << " with function domain:" << std::endl
+            << "in scope " << call_se_scope << " with function virtual devices:" << std::endl
             << domains_->ToString(func_domain);
     SEScope result_se_scope = domains_->ResultSEScope(func_domain);
     ICHECK(!result_se_scope->IsFullyUnconstrained());
@@ -863,25 +958,32 @@ class DeviceCapturer : public ExprMutator {
     Expr op = VisitChild(
         /*lexical_se_scope=*/call_se_scope,
         /*expected_se_scope=*/call_se_scope,
-        /*child_se_scope=*/result_se_scope, call_node->op);
+        /*child_se_scope=*/result_se_scope, vanilla_call->op);
 
     // Each argument can be on the device for the corresponding function parameter. However if
     // any of those differ from the overall call device then wrap them in an "on_device" to
     // help downstream transforms track devices lexically.
     Array<Expr> args;
-    args.reserve(call_node->args.size());
-    ICHECK_EQ(func_domain->function_arity(), call->args.size());
-    for (size_t i = 0; i < call_node->args.size(); ++i) {
+    args.reserve(vanilla_call->args.size());
+    ICHECK_EQ(func_domain->function_arity(), vanilla_call->args.size());
+    for (size_t i = 0; i < vanilla_call->args.size(); ++i) {
       SEScope param_se_scope = domains_->ResultSEScope(func_domain->function_param(i));
       ICHECK(!param_se_scope->IsFullyUnconstrained())
           << "for parameter " << i << " for call:" << std::endl
           << PrettyPrint(call);
       args.push_back(VisitChild(/*lexical_se_scope=*/call_se_scope,
                                 /*expected_se_scope=*/param_se_scope,
-                                /*child_se_scope=*/GetSEScope(call_node->args[i]),
-                                call_node->args[i]));
+                                /*child_se_scope=*/GetSEScope(vanilla_call->args[i]),
+                                vanilla_call->args[i]));
     }
-    return WithFields(GetRef<Call>(call_node), std::move(op), std::move(args));
+
+    if (call_node->op == CallLoweredOp()) {
+      Call new_call =
+          CallLowered(Downcast<GlobalVar>(op), args, /*call_lowered_attrs=*/{}, /*span=*/{});
+      return WithFields(call, std::move(new_call->op), std::move(new_call->args));
+    } else {
+      return WithFields(call, std::move(op), std::move(args));
+    }
   }
 
   Expr VisitExpr_(const LetNode* let_node) final {
@@ -895,11 +997,11 @@ class DeviceCapturer : public ExprMutator {
         // We have a device transition which needs to be handled.
         break;
       }
-      // The let-bound value can be on a different device than the overall let. However if those
-      // devices don't agree wrap the let-bound value in an "on_device" to help downstream
-      // transforms track devices lexically.
+      // The let-bound value can be on a different device than the overall let.
+      // By using the fully-unconstrained SEScope for the 'lexical' scope we'll force the let-bound
+      // value to *always* be wrapped by an "on_device" (see introductory comment for motivation.)
       Expr value =
-          VisitChild(/*lexical_se_scope=*/let_se_scope,
+          VisitChild(/*lexical_se_scope=*/SEScope::FullyUnconstrained(),
                      /*expected_se_scope=*/GetSEScope(inner_let_node->var),
                      /*child_se_scope=*/GetSEScope(inner_let_node->value), inner_let_node->value);
       bindings.emplace_back(inner_let_node->var, value, inner_let_node->span);
@@ -967,7 +1069,7 @@ class DeviceCapturer : public ExprMutator {
     OnDeviceProps props = GetOnDeviceProps(expr);
     Expr true_expr = props.body.defined() ? props.body : expr;
     ICHECK(domains_->contains(true_expr));
-    // If expr is higher order we'll return only the result domain's SEScope.
+    // If expr is higher order we'll return only the result domain's device.
     SEScope se_scope = domains_->ResultSEScope(domains_->DomainFor(true_expr));
     ICHECK(!se_scope->IsFullyUnconstrained())
         << "no SEScope was determined for expression:" << std::endl
@@ -1003,7 +1105,6 @@ class DeviceCapturer : public ExprMutator {
    */
   Expr VisitChild(const SEScope& lexical_se_scope, const SEScope& expected_se_scope,
                   const SEScope& child_se_scope, const Expr& child) {
-    ICHECK(!lexical_se_scope->IsFullyUnconstrained());
     ICHECK(!expected_se_scope->IsFullyUnconstrained());
     if (child->IsInstance<OpNode>() || child->IsInstance<ConstructorNode>()) {
       // Primitive operators and contructors don't need to be rewritten and can have a
@@ -1012,19 +1113,19 @@ class DeviceCapturer : public ExprMutator {
     }
     Expr result = VisitExpr(child);
     if (child_se_scope != expected_se_scope) {
-      VLOG(2) << "creating " << DeviceCopyOp()->name << " from scope " << child_se_scope
-              << " to scope " << expected_se_scope << " for:" << std::endl
+      VLOG(2) << "creating " << DeviceCopyOp()->name << " from virtual device " << child_se_scope
+              << " to virtual device " << expected_se_scope << " for:" << std::endl
               << PrettyPrint(result);
       // Also wrap the child in an "on_device" so downstream transforms can track devices
       // lexically.
-      result = MaybeOnDevice(result, child_se_scope, /*is_fixed=*/true);
+      result = MaybeOnDeviceFixed(result, child_se_scope);
       result = DeviceCopy(result, child_se_scope, expected_se_scope);
     }
     if (expected_se_scope != lexical_se_scope) {
-      VLOG(2) << "creating " << OnDeviceOp()->name << " for scope " << expected_se_scope
+      VLOG(2) << "creating " << OnDeviceOp()->name << " for virtual device " << expected_se_scope
               << " for:" << std::endl
               << PrettyPrint(result);
-      result = MaybeOnDevice(result, expected_se_scope, /*is_fixed=*/true);
+      result = MaybeOnDeviceFixed(result, expected_se_scope);
     }
     return result;
   }
@@ -1048,7 +1149,7 @@ class DeviceCapturer : public ExprMutator {
 /*! \brief Rewrite the "on_device" calls (and implicitly re-type-check). */
 tvm::transform::Pass Rewrite() {
   auto pass_func = [](Function f, IRModule m, transform::PassContext ctxt) {
-    return Downcast<Function>(RewriteOnDevices().Mutate(f));
+    return Downcast<Function>(RewriteOnDevices(std::move(m)).Mutate(f));
   };
   return tvm::relay::transform::CreateFunctionPass(pass_func, 0, "PlanDevicesRewrite", {});
 }
@@ -1065,6 +1166,7 @@ tvm::transform::Pass PlanDevicesCore(CompilationConfig config) {
 
         // Choose sensible default devices for every sub-expression if otherwise unconstrained
         // by existing "on_device" or "device_copy" calls.
+        domains = FreeOnDeviceDefaulter(mod, std::move(domains)).Default();
         domains = DeviceDefaulter(mod, std::move(domains)).Default();
         VLOG(3) << "Domains after defaulting: " << std::endl << domains->ToString();
 
@@ -1078,9 +1180,7 @@ tvm::transform::Pass PlanDevicesCore(CompilationConfig config) {
 
 }  // namespace
 
-/******
-******* Overall composite Pass
-*******/
+/* =============== Driver =============== */
 
 // This function is declared in the public <tvm/relay/transform.h>.
 tvm::transform::Pass PlanDevices(CompilationConfig config) {

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -398,9 +398,6 @@ class DeviceAnalyzer : public ExprVisitor {
         VLOG(2) << "collecting constraints from Relay Function '" << kv.first->name_hint << "'";
         domains_->UnifyExprExact(kv.first, kv.second);
         VisitExpr(GetRef<Function>(function_node));
-      } else if (const auto* prim_func_node = kv.second.as<tir::PrimFuncNode>()) {
-        VLOG(2) << "skipping TIR PrimFunc '" << kv.first->name_hint << "'";
-        // TODO(mbs): Handle PrimFuncs
       } else {
         VLOG(2) << "skipping '" << kv.first->name_hint << "'";
       }
@@ -852,9 +849,6 @@ class DeviceCapturer : public ExprMutator {
       if (const auto* function_node = AsOptimizableFunctionNode(kv.second)) {
         VLOG(2) << "capturing devices for Relay Function '" << kv.first->name_hint << "'";
         result->Add(kv.first, Downcast<Function>(Mutate(GetRef<Function>(function_node))));
-      } else if (const auto* prim_func_node = kv.second.as<tir::PrimFuncNode>()) {
-        VLOG(2) << "skipping TIR PrimFunc '" << kv.first->name_hint << "'";
-        // TODO(mbs): Handle PrimFuncs.
       } else {
         VLOG(2) << "skipping '" << kv.first->name_hint << "'";
         result->Add(kv.first, kv.second);

--- a/src/relay/transforms/fold_constant.cc
+++ b/src/relay/transforms/fold_constant.cc
@@ -145,7 +145,7 @@ class ConstantFolder : public MixedModeMutator {
   Expr Rewrite_(const CallNode* pre_call_node, const Expr& post) final {
     Call pre_call = GetRef<Call>(pre_call_node);
     if (inside_primitive_) {
-      return pre_call;
+      return std::move(pre_call);
     }
 
     Call post_call = Downcast<Call>(post);
@@ -215,12 +215,12 @@ class ConstantFolder : public MixedModeMutator {
       OnDeviceProps props = GetOnDeviceProps(post_tuple_get_item_node->tuple);
       if (props.body.defined()) {
         // (on_device((x, y, z), se_scope=D).1 ==> on_device(y, se_scope=D)
-        return MaybeOnDevice(result, props.se_scope, props.is_fixed);
+        return MaybeOnDeviceWithProps(result, props);
       } else {
         return result;
       }
     }
-    return std::move(post_tuple_get_item);
+    return post_tuple_get_item;
   }
 
   // Convert value to expression.

--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -211,14 +211,14 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
   }
 
   Expr Atomic(const Expr& e, const Var& v) {
-    Expr annotated_expr = MaybeOnDevice(e, GetSEScope(e), /*is_fixed=*/true);
+    Expr annotated_expr = MaybeOnDeviceFixed(e, GetSEScope(e));
     return v.defined() ? GetScope(e)->let_list->Push(v, annotated_expr) : annotated_expr;
   }
 
   // Bind expression `now` to var `v` if the original expression is in the include set, or if
   // v is already defined (e.g. coming from a Let expression). Otherwise return `now` directly
   Expr Compound(const Expr& orig, const Expr& now, const Var& v) {
-    Expr annotated_expr = MaybeOnDevice(now, GetSEScope(orig), /*is_fixed=*/true);
+    Expr annotated_expr = MaybeOnDeviceFixed(now, GetSEScope(orig));
     Var var = v.defined() ? v : Var(String("x"), Type());
     bool not_included = include_set_ && include_set_->find(orig) == include_set_->end();
     if (!v.defined() && not_included) {
@@ -230,14 +230,14 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
 
   Expr VisitExpr_(const CallNode* c, const Var& v) final {
     OnDeviceProps props = GetOnDeviceProps(c);
-    if (props.body.defined() && props.is_fixed) {
+    if (props.body.defined() && props.is_fixed()) {
       // Keep track of expression device type for lexically enclosing sub-expressions.
       PushSEScope(props.se_scope);
       Expr body = VisitExpr(props.body, v);
       // We are done with this sub-expression.
       PopSEScope();
       // Preserve the "on_device" annotations.
-      return OnDevice(body, props.se_scope, props.is_fixed);
+      return OnDeviceWithProps(body, props);
     }
 
     Expr e = GetRef<Expr>(c);

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -178,7 +178,7 @@ std::string Executable::GetConstants() const {
   for (size_t i = 0; i < constants.size(); ++i) {
     const auto& constant = constants[i];
     auto ndarray = Downcast<NDArray>(constant);
-    oss << "VM Constant[" << i << "]: has shape " << ShapeString(ndarray.Shape(), ndarray->dtype)
+    oss << "VM Const[" << i << "]: has shape " << ShapeString(ndarray.Shape(), ndarray->dtype)
         << " on device index " << const_device_indexes[i] << std::endl;
   }
   return oss.str();

--- a/src/target/se_scope.cc
+++ b/src/target/se_scope.cc
@@ -62,10 +62,6 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
           p->stream << "memory_scope='" << node->memory_scope << "'";
         }
       }
-#if TVM_LOG_DEBUG
-      // We rely on object identity of SEScopes, so include the object address to help debugging.
-      p->stream << ", id=" << reinterpret_cast<uint64_t>(ref.get());
-#endif
       p->stream << ")";
     });
 
@@ -173,11 +169,9 @@ SEScope SEScopeCache::Make(DLDeviceType device_type, int virtual_device_id, Targ
   SEScope prototype(device_type, virtual_device_id, std::move(target), std::move(memory_scope));
   auto itr = cache_.find(prototype);
   if (itr == cache_.end()) {
-    VLOG(1) << "added new scope " << prototype;
     cache_.emplace(prototype);
     return prototype;
   } else {
-    VLOG(1) << "reusing existing scope " << *itr;
     ICHECK_EQ(prototype->target.defined(), (*itr)->target.defined());
     if (prototype->target.defined()) {
       ICHECK_EQ(prototype->target->host.defined(), (*itr)->target->host.defined());

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -566,10 +566,6 @@ String TargetNode::ToDebugString() const {
   if (host.defined()) {
     os << ", host=" << GetHost().value()->ToDebugString();
   }
-#if TVM_LOG_DEBUG
-  // We depend on pointer equality so include that in the debug representation.
-  os << ", id=" << reinterpret_cast<uint64_t>(this);
-#endif
   os << ")";
   return os.str();
 }

--- a/tests/cpp/relay/op/memory/on_device_test.cc
+++ b/tests/cpp/relay/op/memory/on_device_test.cc
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "../../../../../src/relay/op/memory/on_device.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace tvm {
+namespace relay {
+
+TEST(OnDeviceOp, Name) { EXPECT_EQ(OnDeviceOp()->name, "on_device"); }
+
+TEST(OnDevice, Default) {
+  Var body("x", {});
+  SEScope se_scope = SEScope::ForDeviceType(kDLCPU, 3);
+  Call call = OnDevice(body, se_scope);
+  EXPECT_EQ(call->op, OnDeviceOp());
+  EXPECT_EQ(call->args.size(), 1);
+  EXPECT_EQ(call->args[0], body);
+  const auto* attrs = call->attrs.as<OnDeviceAttrs>();
+  ASSERT_TRUE(attrs != nullptr);
+  EXPECT_EQ(attrs->se_scope, se_scope);
+  EXPECT_FALSE(attrs->constrain_result);
+  EXPECT_TRUE(attrs->constrain_body);
+}
+
+TEST(OnDevice, Fixed) {
+  Var body("x", {});
+  SEScope se_scope = SEScope::ForDeviceType(kDLCPU, 3);
+  Call call = OnDevice(body, se_scope, /*constrain_result=*/true);
+  const auto* attrs = call->attrs.as<OnDeviceAttrs>();
+  ASSERT_TRUE(attrs != nullptr);
+  EXPECT_TRUE(attrs->constrain_result);
+  EXPECT_TRUE(attrs->constrain_body);
+}
+
+TEST(OnDevice, Free) {
+  Var body("x", {});
+  SEScope se_scope = SEScope::ForDeviceType(kDLCPU, 3);
+  Call call = OnDevice(body, se_scope, /*constrain_result=*/false, /*constrain_body=*/false);
+  const auto* attrs = call->attrs.as<OnDeviceAttrs>();
+  ASSERT_TRUE(attrs != nullptr);
+  EXPECT_FALSE(attrs->constrain_result);
+  EXPECT_FALSE(attrs->constrain_body);
+}
+
+TEST(GetOnDeviceProps, Correct) {
+  Var body("x", {});
+  SEScope se_scope = SEScope::ForDeviceType(kDLCPU, 3);
+  Call call = OnDevice(body, se_scope, /*constrain_result=*/true, /*constrain_body=*/false);
+  OnDeviceProps props = GetOnDeviceProps(call);
+  ASSERT_TRUE(props.body.defined());
+  ASSERT_EQ(props.se_scope, se_scope);
+  ASSERT_TRUE(props.constrain_result);
+  ASSERT_FALSE(props.constrain_body);
+}
+
+TEST(MaybeOnDevice, Wrapped) {
+  SEScope se_scope = SEScope::ForDeviceType(kDLCPU, 3);
+  Var body("x", {});
+  Call inner = OnDevice(body, se_scope);
+  Call outer = OnDevice(inner, se_scope);
+  OnDeviceProps props = GetOnDeviceProps(outer);
+  ASSERT_TRUE(props.body.defined());
+  ASSERT_EQ(props.se_scope, se_scope);
+  ASSERT_FALSE(props.constrain_result);
+  ASSERT_TRUE(props.constrain_body);
+}
+
+}  // namespace relay
+}  // namespace tvm

--- a/tests/python/relay/op/annotation/test_annotation.py
+++ b/tests/python/relay/op/annotation/test_annotation.py
@@ -30,7 +30,8 @@ def test_on_device_via_string():
     assert call.attrs.se_scope.virtual_device_id == 0
     assert call.attrs.se_scope.target is None
     assert call.attrs.se_scope.memory_scope == ""
-    assert not call.attrs.is_fixed
+    assert call.attrs.constrain_body
+    assert not call.attrs.constrain_result
 
 
 def test_on_device_via_device():
@@ -44,11 +45,20 @@ def test_on_device_invalid_device():
     pytest.raises(ValueError, lambda: relay.annotation.on_device(x, "bogus"))
 
 
-def test_on_device_is_fixed():
+def test_on_device_fixed():
     x = relay.Var("x")
-    call = relay.annotation.on_device(x, "cuda", True)
+    call = relay.annotation.on_device(x, "cuda", constrain_result=True)
     assert call.attrs.se_scope.device_type_int == 2  # ie kDLCUDA
-    assert call.attrs.is_fixed
+    assert call.attrs.constrain_body
+    assert call.attrs.constrain_result
+
+
+def test_on_device_free():
+    x = relay.Var("x")
+    call = relay.annotation.on_device(x, "cuda", constrain_result=False, constrain_body=False)
+    assert call.attrs.se_scope.device_type_int == -1  # ie kInvalidDeviceType
+    assert not call.attrs.constrain_body
+    assert not call.attrs.constrain_result
 
 
 def test_function_on_device():

--- a/tests/python/relay/test_pass_fold_constant.py
+++ b/tests/python/relay/test_pass_fold_constant.py
@@ -29,7 +29,7 @@ def annot_func(f):
 
 def annot_expr(e):
     """Returns e wrapped with an on_device annotation."""
-    return relay.op.annotation.on_device(e, tvm.cpu(), is_fixed=True)
+    return relay.op.annotation.on_device(e, tvm.cpu(), constrain_result=True)
 
 
 def run_opt_pass(expr, opt_pass):

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -1040,8 +1040,8 @@ def test_storage_size_and_offset_on_cpu():
     # - The offset of the tensor within the storage (second arg) to alloc_tensor
     # Both should be on the CPU
     assert "VirtualDevice[0]: device type 1" in exe.virtual_devices
-    assert "Constant[0]: has shape int64[] on device index 0" in exe.constants
-    assert "Constant[1]: has shape int64[] on device index 0" in exe.constants
+    assert "Const[0]: has shape int64[] on device index 0" in exe.constants
+    assert "Const[1]: has shape int64[] on device index 0" in exe.constants
 
 
 @tvm.testing.requires_cuda
@@ -1073,7 +1073,7 @@ def test_reshape_shape_on_cpu():
 
     # The newshape annotation should have been turned into a constant on the CPU.
     assert "VirtualDevice[0]: device type 1" in exe.virtual_devices
-    assert "Constant[0]: has shape int64[3] on device index 0" in exe.constants
+    assert "Const[0]: has shape int64[3] on device index 0" in exe.constants
 
 
 @tvm.testing.requires_cuda


### PR DESCRIPTION
This is in support of #9613, which allows PlanDevices to be run
after lowering so as to flow memory constraints in and
out of PrimFuncs. That requires a way to insert device_copies
when the memory scopes chosen during separate lowering of fused
primitive functions clashes, but otherwise avoid device_copies when
scopes can be chosen so as to avoid them.

We support that by generalizing the "on_device" annotation to
allow the device constraint to be independently controlled for
its 'body' and 'result'.

- Standard user annotation: body is constrained to S
```
on_device(body, S)
```

- Used by PlanDevices to 'fix' expression to S
 (was is_fixed=True)
```
on_device(body, S, constrain_result=True)
```

-  Used by PlanDevices to indicate a device_copy can be
   inserted if necessary.
```
on_device(body, S, constrain_body=False)
```

- Supported, but currently has no use.
```
on_device(body, S, constrain_result=True, constrain_body=False)
```

A few extra odd's 'n ends collected along the way:
 - Some CallLowered cleanup which I found useful.
 - The usual extra debugging output needed as I debugged.
   In return I removed some particularly verbose logging I'd
   added while tracking down unexpected object copies.
 - Cleanup warnings from clang-12 as I touch files.