### PR TITLE
[Hexagon] Detect link-params via IRModule instead of target attribute

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -638,13 +638,27 @@ def hexagon(cpu_ver="v66", **kwargs):
         args = [s.replace("=", "@") for s in llvm_options.split()]
         return "--llvm-options=" + ",".join(args)
 
+    # TVM target attributes string
+    def create_tvm_options(cpu_ver, config):  # pylint: disable=unused-argument
+        """Create TVM target features string."""
+
+        features = {
+            "link_params": "link-params",
+        }
+        opts = ""
+        for k in config:
+            if k in features:
+                opts += " --" + features[k] + "=" + str(config[k])
+        return opts
+
     # Sim args
     os.environ["HEXAGON_SIM_ARGS"] = create_sim_options(cpu_ver, config)
 
     target_str = create_llvm_target(cpu_ver, config)
     llvm_str = create_llvm_options(cpu_ver, config)
+    tvm_str = create_tvm_options(cpu_ver, config)
 
-    args_list = target_str.split() + llvm_str.split()
+    args_list = target_str.split() + llvm_str.split() + tvm_str.split()
 
     return Target(" ".join(["hexagon"] + args_list))
 

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -737,7 +737,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   std::vector<PrimFunc> funcs;
   std::string entry_func;
   Map<String, LinkedParam> linked_params;
-  bool could_have_linked_params = target->GetAttr<Bool>("link-params").value_or(Bool(false));
+  bool could_have_linked_params = mod->ShouldLinkParameters();
 
   for (auto kv : mod->functions) {
     if (could_have_linked_params &&


### PR DESCRIPTION
Additionally, restore the construction of target attributes in the Hexagon target. This was erroneously removed in PR#9352.
That PR deprecated target attributes, but also added transferring these attributes to the new mechanism. Removing the attributes from `tvm.target.hexagon` eliminated them completely. Restoring the target attributes allow time to transition TVM clients to the new mechanisms.
