### PR TITLE
Add CMake summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(tvm C CXX)
 
 # Utility functions
 include(cmake/utils/Utils.cmake)
+include(cmake/utils/Summary.cmake)
 include(cmake/utils/FindCUDA.cmake)
 include(cmake/utils/FindOpenCL.cmake)
 include(cmake/utils/FindVulkan.cmake)
@@ -94,6 +95,7 @@ tvm_option(USE_TENSORRT_CODEGEN "Build with TensorRT Codegen support" OFF)
 tvm_option(USE_TENSORRT_RUNTIME "Build with TensorRT runtime" OFF)
 tvm_option(USE_RUST_EXT "Build with Rust based compiler extensions, STATIC, DYNAMIC, or OFF" OFF)
 tvm_option(USE_VITIS_AI "Build with VITIS-AI Codegen support" OFF)
+tvm_option(SUMMARIZE "Print CMake option summary after configuring" OFF)
 
 # include directories
 include_directories(${CMAKE_INCLUDE_PATH})
@@ -713,3 +715,7 @@ if(USE_CCACHE) # True for AUTO, ON, /path/to/ccache
   # Set the flag for ccache
   set(CXX_COMPILER_LAUNCHER PATH_TO_CCACHE)
 endif(USE_CCACHE)
+
+if(${SUMMARIZE})
+  print_summary()
+endif()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -361,3 +361,6 @@ set(USE_GTEST AUTO)
 # Enable using CUTLASS as a BYOC backend
 # Need to have USE_CUDA=ON
 set(USE_CUTLASS OFF)
+
+# Enable to show a summary of TVM options
+set(SUMMARIZE OFF)

--- a/cmake/utils/Summary.cmake
+++ b/cmake/utils/Summary.cmake
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+function(pad_string output str padchar length)
+    string(LENGTH "${str}" _strlen)
+    math(EXPR _strlen "${length} - ${_strlen}")
+
+    if(_strlen GREATER 0)
+    if(${CMAKE_VERSION} VERSION_LESS "3.14")
+        unset(_pad)
+        foreach(_i RANGE 1 ${_strlen}) # inclusive
+        string(APPEND _pad ${padchar})
+        endforeach()
+    else()
+        string(REPEAT ${padchar} ${_strlen} _pad)
+    endif()
+    string(APPEND str ${_pad})
+    endif()
+
+    set(${output} "${str}" PARENT_SCOPE)
+endfunction()
+
+macro(print_summary)
+    message(STATUS "  ---------------- Summary ----------------")
+
+    # Show some basic system information
+    message(STATUS "  CMake version         : ${CMAKE_VERSION}")
+    message(STATUS "  CMake executable      : ${CMAKE_COMMAND}")
+    message(STATUS "  Generator             : ${CMAKE_GENERATOR}")
+    message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
+    message(STATUS "  C++ compiler          : ${CMAKE_CXX_COMPILER}")
+    message(STATUS "  C++ compiler ID       : ${CMAKE_CXX_COMPILER_ID}")
+    message(STATUS "  C++ compiler version  : ${CMAKE_CXX_COMPILER_VERSION}")
+    message(STATUS "  CXX flags             : ${CMAKE_CXX_FLAGS}")
+    message(STATUS "  Build type            : ${CMAKE_BUILD_TYPE}")
+    get_directory_property(READABLE_COMPILE_DEFS DIRECTORY ${PROJECT_SOURCE_DIR} COMPILE_DEFINITIONS)
+    message(STATUS "  Compile definitions   : ${READABLE_COMPILE_DEFS}")
+
+    list(SORT TVM_ALL_OPTIONS)
+    message(STATUS "  Options:")
+
+    # Compute padding necessary for options
+    set(MAX_LENGTH 0)
+    foreach(OPTION ${TVM_ALL_OPTIONS})
+        string(LENGTH ${OPTION} OPTIONLENGTH)
+        if(${OPTIONLENGTH} GREATER ${MAX_LENGTH})
+            set(MAX_LENGTH ${OPTIONLENGTH})
+        endif()
+    endforeach()
+    math(EXPR PADDING_LENGTH "${MAX_LENGTH} + 3")
+
+    # Print each of the options (padded out so they're all aligned)
+    foreach(OPTION ${TVM_ALL_OPTIONS})
+        set(OPTION_VALUE "${${OPTION}}")
+        pad_string(OUT "   ${OPTION}" " " ${PADDING_LENGTH})
+        message(STATUS ${OUT} " : " ${OPTION_VALUE})
+    endforeach()
+endmacro()

--- a/cmake/utils/Utils.cmake
+++ b/cmake/utils/Utils.cmake
@@ -21,6 +21,8 @@ macro(__tvm_option variable description value)
   endif()
 endmacro()
 
+set(TVM_ALL_OPTIONS)
+
 #######################################################
 # An option that the user can select. Can accept condition to control when option is available for user.
 # Usage:
@@ -29,6 +31,7 @@ macro(tvm_option variable description value)
   set(__value ${value})
   set(__condition "")
   set(__varname "__value")
+  list(APPEND TVM_ALL_OPTIONS ${variable})
   foreach(arg ${ARGN})
     if(arg STREQUAL "IF" OR arg STREQUAL "if")
       set(__varname "__condition")

--- a/tests/scripts/task_config_build_arm.sh
+++ b/tests/scripts/task_config_build_arm.sh
@@ -35,3 +35,4 @@ echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB_GRAPH_EXECUTOR "/opt/acl"\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -49,3 +49,4 @@ echo set\(USE_VERILATOR ON\) >> config.cmake
 echo set\(USE_LIBBACKTRACE ON\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
 echo set\(USE_ETHOSU ON\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu.sh
+++ b/tests/scripts/task_config_build_gpu.sh
@@ -46,3 +46,4 @@ echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_TENSORRT_CODEGEN ON\) >> config.cmake
 echo set\(USE_LIBBACKTRACE AUTO\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu_other.sh
+++ b/tests/scripts/task_config_build_gpu_other.sh
@@ -33,3 +33,4 @@ echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_LIBBACKTRACE OFF\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake

--- a/tests/scripts/task_config_build_i386.sh
+++ b/tests/scripts/task_config_build_i386.sh
@@ -35,4 +35,5 @@ echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake
 echo set\(USE_VERILATOR ON\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake
 

--- a/tests/scripts/task_config_build_qemu.sh
+++ b/tests/scripts/task_config_build_qemu.sh
@@ -30,3 +30,4 @@ echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake

--- a/tests/scripts/task_config_build_wasm.sh
+++ b/tests/scripts/task_config_build_wasm.sh
@@ -34,3 +34,4 @@ echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake
+echo set\(SUMMARIZE ON\) >> config.cmake


### PR DESCRIPTION
This adds a printout at the end of CMake's configuration that prints out all the user options (anything declared via `tvm_option`) plus some extra metadata about CMake itself (version, system, etc). This makes it easier to see what CMake is doing without guessing from config files (i.e. is the build release or debug mode, is CUDA on, ...). To avoid spewing in people's build output it's behind a flag but can be enabled with `cmake -DSUMMARIZE=1 ...` or turning the config option on.

