### PR TITLE
Add Module-Based Model Runtime Interface for AOT (support C++ runtime)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ tvm_option(USE_LLVM "Build with LLVM, can be set to specific llvm-config path" O
 tvm_option(USE_STACKVM_RUNTIME "Include stackvm into the runtime" OFF)
 tvm_option(USE_GRAPH_EXECUTOR "Build with tiny graph executor" ON)
 tvm_option(USE_GRAPH_EXECUTOR_CUDA_GRAPH "Build with tiny graph executor with CUDA Graph for GPUs" OFF)
+tvm_option(USE_AOT_EXECUTOR "Build with AOT executor" ON)
 tvm_option(USE_PROFILER "Build profiler for the VM and graph executor" ON)
 tvm_option(USE_OPENMP "Build with OpenMP thread pool implementation" OFF)
 tvm_option(USE_RELAY_DEBUG "Building Relay in debug mode..." OFF)
@@ -391,6 +392,13 @@ if(USE_PROFILER)
   tvm_file_glob(GLOB RUNTIME_VM_PROFILER_SRCS src/runtime/vm/profiler/*.cc)
   list(APPEND RUNTIME_SRCS ${RUNTIME_VM_PROFILER_SRCS})
 endif(USE_PROFILER)
+
+if(USE_AOT_EXECUTOR)
+  message(STATUS "Build with AOT Executor support...")
+  file(GLOB RUNTIME_AOT_EXECUTOR_SRCS src/runtime/aot_executor/*.cc)
+  list(APPEND RUNTIME_SRCS ${RUNTIME_AOT_EXECUTOR_SRCS})
+
+endif(USE_AOT_EXECUTOR)
 
 # Enable ctest if gtest is available
 if(USE_GTEST)

--- a/include/tvm/relay/runtime.h
+++ b/include/tvm/relay/runtime.h
@@ -44,6 +44,12 @@ class AttrRegistry;
 
 namespace relay {
 
+/*! \brief Value used with Runtime::name to indicate the C++ runtime. */
+static constexpr const char* kTvmRuntimeCpp = "cpp";
+
+/*! \brief Value used with Runtime::name to indicate the C runtime. */
+static constexpr const char* kTvmRuntimeCrt = "c";
+
 /*!
  * \brief Runtime information.
  *

--- a/include/tvm/relay/runtime.h
+++ b/include/tvm/relay/runtime.h
@@ -48,7 +48,7 @@ namespace relay {
 static constexpr const char* kTvmRuntimeCpp = "cpp";
 
 /*! \brief Value used with Runtime::name to indicate the C runtime. */
-static constexpr const char* kTvmRuntimeCrt = "c";
+static constexpr const char* kTvmRuntimeCrt = "crt";
 
 /*!
  * \brief Runtime information.

--- a/include/tvm/runtime/metadata.h
+++ b/include/tvm/runtime/metadata.h
@@ -17,12 +17,19 @@
  * under the License.
  */
 
+// NOTE: This file is intended to be compileable in C++ and C build processes.
+// NOLINT(build/include_order)
+
 /*!
  * \file tvm/runtime/metadata.h
  * \brief Defines types which can be used in Metadata.
  */
 #ifndef TVM_RUNTIME_METADATA_H_
 #define TVM_RUNTIME_METADATA_H_
+
+#include <memory>
+#include <string>
+#include <vector>
 
 #include <inttypes.h>
 #include <tvm/runtime/c_runtime_api.h>
@@ -67,7 +74,7 @@ class TensorInfo;
 
 class MetadataNode : public MetadataBaseNode {
  public:
-  MetadataNode(const struct ::TVMMetadata* data) : data_{data} {}
+  explicit MetadataNode(const struct ::TVMMetadata* data) : data_{data} {}
   static constexpr const char* _type_key = "metadata.MetadataNode";
   std::string get_name() override;
   inline int64_t version() const { return int64_t(data_->version); }
@@ -79,10 +86,13 @@ class MetadataNode : public MetadataBaseNode {
   ArrayAccessor<const char*, ::tvm::runtime::String> devices();
   inline ::tvm::runtime::String executor() const { return ::tvm::runtime::String(data_->executor); }
   inline ::tvm::runtime::String mod_name() const { return ::tvm::runtime::String(data_->mod_name); }
-  inline ::tvm::runtime::String interface_api() const { return ::tvm::runtime::String(data_->interface_api); }
-  inline bool use_unpacked_api() const { return bool(data_->use_unpacked_api); }
+  inline ::tvm::runtime::String interface_api() const {
+    return ::tvm::runtime::String(data_->interface_api);
+  }
+  inline bool use_unpacked_api() const { return static_cast<bool>(data_->use_unpacked_api); }
   const struct ::TVMMetadata* data() const { return data_; }
   TVM_DECLARE_FINAL_OBJECT_INFO(MetadataNode, MetadataBaseNode);
+
  private:
   const struct ::TVMMetadata* data_;
   ::std::shared_ptr<::std::vector<TensorInfo>> inputs_refs_;
@@ -92,30 +102,32 @@ class MetadataNode : public MetadataBaseNode {
 
 class Metadata : public MetadataBase {
  public:
-  Metadata(const struct ::TVMMetadata* data);
+  explicit Metadata(const struct ::TVMMetadata* data);
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Metadata, MetadataBase, MetadataNode);
 };
 
 class TensorInfoNode : public MetadataBaseNode {
  public:
-  TensorInfoNode(const struct ::TVMTensorInfo* data) : data_{data} {}
+  explicit TensorInfoNode(const struct ::TVMTensorInfo* data) : data_{data} {}
   static constexpr const char* _type_key = "metadata.TensorInfoNode";
   std::string get_name() override;
   inline ::tvm::runtime::String name() const { return ::tvm::runtime::String(data_->name); }
   inline int64_t num_shape() const { return data_->num_shape; }
   inline ::tvm::support::Span<const int64_t, const int64_t> shape() const {
-    return ::tvm::support::Span<const int64_t, const int64_t>(data_->shape, data_->shape + data_->num_shape);
+    return ::tvm::support::Span<const int64_t, const int64_t>(data_->shape,
+                                                              data_->shape + data_->num_shape);
   }
   inline ::tvm::runtime::DataType dtype() const { return ::tvm::runtime::DataType(data_->dtype); }
   const struct ::TVMTensorInfo* data() const { return data_; }
   TVM_DECLARE_FINAL_OBJECT_INFO(TensorInfoNode, MetadataBaseNode);
+
  private:
   const struct ::TVMTensorInfo* data_;
 };
 
 class TensorInfo : public MetadataBase {
  public:
-  TensorInfo(const struct ::TVMTensorInfo* data);
+  explicit TensorInfo(const struct ::TVMTensorInfo* data);
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(TensorInfo, MetadataBase, TensorInfoNode);
 };
 

--- a/include/tvm/runtime/metadata.h
+++ b/include/tvm/runtime/metadata.h
@@ -94,9 +94,6 @@ class MetadataNode : public MetadataBaseNode {
 
  private:
   const struct ::TVMMetadata* data_;
-  ::std::shared_ptr<::std::vector<TensorInfo>> inputs_refs_;
-  ::std::shared_ptr<::std::vector<TensorInfo>> outputs_refs_;
-  ::std::shared_ptr<::std::vector<::tvm::runtime::String>> devices_refs_;
 };
 
 class Metadata : public MetadataBase {
@@ -112,9 +109,9 @@ class TensorInfoNode : public MetadataBaseNode {
   std::string get_name() override;
   inline ::tvm::runtime::String name() const { return ::tvm::runtime::String(data_->name); }
   inline int64_t num_shape() const { return data_->num_shape; }
-  inline ::tvm::support::Span<const int64_t, const int64_t> shape() const {
-    return ::tvm::support::Span<const int64_t, const int64_t>(data_->shape,
-                                                              data_->shape + data_->num_shape);
+  inline ::tvm::support::Span<const int64_t, int64_t> shape() const {
+    return ::tvm::support::Span<const int64_t, int64_t>(data_->shape,
+                                                        data_->shape + data_->num_shape);
   }
   inline ::tvm::runtime::DataType dtype() const { return ::tvm::runtime::DataType(data_->dtype); }
   const struct ::TVMTensorInfo* data() const { return data_; }

--- a/include/tvm/runtime/metadata.h
+++ b/include/tvm/runtime/metadata.h
@@ -25,6 +25,7 @@
 #define TVM_RUNTIME_METADATA_H_
 
 #include <inttypes.h>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,7 +33,7 @@
 // TODO(areusch): idk what's up here.
 #include <tvm/runtime/c_runtime_api.h>  // NOLINT(build/include_order)
 #include <tvm/runtime/metadata_base.h>  // NOLINT(build/include_order)
-#include <tvm/support/span.h>  // NOLINT(build/include_order)
+#include <tvm/support/span.h>           // NOLINT(build/include_order)
 
 #define TVM_METADATA_VERSION 1
 static const constexpr int64_t kMetadataVersion = TVM_METADATA_VERSION;

--- a/include/tvm/runtime/metadata.h
+++ b/include/tvm/runtime/metadata.h
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-// NOTE: This file is intended to be compileable in C++ and C build processes.
-// NOLINT(build/include_order)
-
 /*!
  * \file tvm/runtime/metadata.h
  * \brief Defines types which can be used in Metadata.
@@ -27,14 +24,15 @@
 #ifndef TVM_RUNTIME_METADATA_H_
 #define TVM_RUNTIME_METADATA_H_
 
+#include <inttypes.h>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <inttypes.h>
-#include <tvm/runtime/c_runtime_api.h>
-#include <tvm/runtime/metadata_base.h>
-#include <tvm/support/span.h>
+// TODO(areusch): idk what's up here.
+#include <tvm/runtime/c_runtime_api.h>  // NOLINT(build/include_order)
+#include <tvm/runtime/metadata_base.h>  // NOLINT(build/include_order)
+#include <tvm/support/span.h>  // NOLINT(build/include_order)
 
 #define TVM_METADATA_VERSION 1
 static const constexpr int64_t kMetadataVersion = TVM_METADATA_VERSION;

--- a/include/tvm/runtime/metadata.h
+++ b/include/tvm/runtime/metadata.h
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/runtime/metadata.h
+ * \brief Defines types which can be used in Metadata.
+ */
+#ifndef TVM_RUNTIME_METADATA_H_
+#define TVM_RUNTIME_METADATA_H_
+
+#include <inttypes.h>
+#include <tvm/runtime/c_runtime_api.h>
+#include <tvm/runtime/metadata_base.h>
+#include <tvm/support/span.h>
+
+#define TVM_METADATA_VERSION 1
+static const constexpr int64_t kMetadataVersion = TVM_METADATA_VERSION;
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct TVMMetadata {
+  int64_t version;
+  const struct TVMTensorInfo* inputs;
+  int64_t num_inputs;
+  const struct TVMTensorInfo* outputs;
+  int64_t num_outputs;
+  const char** devices;
+  int64_t num_devices;
+  const char* executor;
+  const char* mod_name;
+  const char* interface_api;
+  bool use_unpacked_api;
+};
+
+struct TVMTensorInfo {
+  const char* name;
+  const int64_t* shape;
+  int64_t num_shape;
+  DLDataType dtype;
+};
+#ifdef __cplusplus
+}  // extern "C"
+#include <tvm/runtime/object.h>
+namespace tvm {
+namespace runtime {
+namespace metadata {
+
+class Metadata;
+class TensorInfo;
+
+class MetadataNode : public MetadataBaseNode {
+ public:
+  MetadataNode(const struct ::TVMMetadata* data) : data_{data} {}
+  static constexpr const char* _type_key = "metadata.MetadataNode";
+  std::string get_name() override;
+  inline int64_t version() const { return int64_t(data_->version); }
+  inline int64_t num_inputs() const { return data_->num_inputs; }
+  ArrayAccessor<struct TVMTensorInfo, TensorInfo> inputs();
+  inline int64_t num_outputs() const { return data_->num_outputs; }
+  ArrayAccessor<struct TVMTensorInfo, TensorInfo> outputs();
+  inline int64_t num_devices() const { return data_->num_devices; }
+  ArrayAccessor<const char*, ::tvm::runtime::String> devices();
+  inline ::tvm::runtime::String executor() const { return ::tvm::runtime::String(data_->executor); }
+  inline ::tvm::runtime::String mod_name() const { return ::tvm::runtime::String(data_->mod_name); }
+  inline ::tvm::runtime::String interface_api() const { return ::tvm::runtime::String(data_->interface_api); }
+  inline bool use_unpacked_api() const { return bool(data_->use_unpacked_api); }
+  const struct ::TVMMetadata* data() const { return data_; }
+  TVM_DECLARE_FINAL_OBJECT_INFO(MetadataNode, MetadataBaseNode);
+ private:
+  const struct ::TVMMetadata* data_;
+  ::std::shared_ptr<::std::vector<TensorInfo>> inputs_refs_;
+  ::std::shared_ptr<::std::vector<TensorInfo>> outputs_refs_;
+  ::std::shared_ptr<::std::vector<::tvm::runtime::String>> devices_refs_;
+};
+
+class Metadata : public MetadataBase {
+ public:
+  Metadata(const struct ::TVMMetadata* data);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Metadata, MetadataBase, MetadataNode);
+};
+
+class TensorInfoNode : public MetadataBaseNode {
+ public:
+  TensorInfoNode(const struct ::TVMTensorInfo* data) : data_{data} {}
+  static constexpr const char* _type_key = "metadata.TensorInfoNode";
+  std::string get_name() override;
+  inline ::tvm::runtime::String name() const { return ::tvm::runtime::String(data_->name); }
+  inline int64_t num_shape() const { return data_->num_shape; }
+  inline ::tvm::support::Span<const int64_t, const int64_t> shape() const {
+    return ::tvm::support::Span<const int64_t, const int64_t>(data_->shape, data_->shape + data_->num_shape);
+  }
+  inline ::tvm::runtime::DataType dtype() const { return ::tvm::runtime::DataType(data_->dtype); }
+  const struct ::TVMTensorInfo* data() const { return data_; }
+  TVM_DECLARE_FINAL_OBJECT_INFO(TensorInfoNode, MetadataBaseNode);
+ private:
+  const struct ::TVMTensorInfo* data_;
+};
+
+class TensorInfo : public MetadataBase {
+ public:
+  TensorInfo(const struct ::TVMTensorInfo* data);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(TensorInfo, MetadataBase, TensorInfoNode);
+};
+
+}  // namespace metadata
+}  // namespace runtime
+}  // namespace tvm
+#endif  // defined(__cplusplus)
+
+#endif  // TVM_RUNTIME_METADATA_H_

--- a/include/tvm/runtime/metadata_base.h
+++ b/include/tvm/runtime/metadata_base.h
@@ -157,20 +157,21 @@ enum MetadataTypeIndex : uint8_t {
   kInt64 = 1,
   kBool = 2,
   kString = 3,
-  kHandle = 4,
+  kMetadata = 4,
 };
 
 class MetadataArrayNode : public MetadataBaseNode {
  public:
-  //  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index) : array{array},
-  //  type_index{type_index} {}
-  MetadataArrayNode(Array<ObjectRef> array, const char* c_type)
-      : array(std::move(array)), c_type{c_type} {}
+  MetadataArrayNode(Array<ObjectRef> array, MetadataTypeIndex type_index, const char* struct_name) :
+      array{array}, type_index{type_index}, struct_name{struct_name} {}
+//  MetadataArrayNode(Array<ObjectRef> array, const char* c_type)
+//      : array(std::move(array)), c_type{c_type} {}
 
   std::string get_name() override;
 
   Array<ObjectRef> array;
-  const char* c_type;
+  MetadataTypeIndex type_index;
+  const char* struct_name;
   static constexpr const char* _type_key = "metadata.MetadataArrayNode";
   TVM_DECLARE_BASE_OBJECT_INFO(MetadataArrayNode, MetadataBaseNode);
 };
@@ -178,7 +179,7 @@ class MetadataArrayNode : public MetadataBaseNode {
 class MetadataArray : public MetadataBase {
  public:
   //  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index);
-  MetadataArray(Array<ObjectRef> array, const char* c_type);
+  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index, const char* struct_name);
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MetadataArray, MetadataBase, MetadataArrayNode);
 };
 

--- a/include/tvm/runtime/metadata_base.h
+++ b/include/tvm/runtime/metadata_base.h
@@ -29,8 +29,8 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 namespace tvm {
 namespace runtime {

--- a/include/tvm/runtime/metadata_base.h
+++ b/include/tvm/runtime/metadata_base.h
@@ -24,9 +24,13 @@
 #ifndef TVM_RUNTIME_METADATA_BASE_H_
 #define TVM_RUNTIME_METADATA_BASE_H_
 
-#include <string>
 #include <tvm/ir/expr.h>
 #include <tvm/runtime/object.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <utility>
 
 namespace tvm {
 namespace runtime {
@@ -53,9 +57,7 @@ class ArrayIterator {
  public:
   ArrayIterator(size_t index, ArrayAccessor<C, Ref>* parent) : index_{index}, parent_{parent} {}
 
-  inline Ref operator*() {
-    return (*parent_)[index_];
-  }
+  inline Ref operator*() { return (*parent_)[index_]; }
 
   inline ArrayIterator<C, Ref>& operator++() {
     if (index_ < parent_->size()) {
@@ -69,9 +71,7 @@ class ArrayIterator {
     return parent_ == other.parent_ && index_ == other.index_;
   }
 
-  inline bool operator!=(const ArrayIterator<C, Ref>& other) {
-    return !operator==(other);
-  }
+  inline bool operator!=(const ArrayIterator<C, Ref>& other) { return !operator==(other); }
 
  private:
   size_t index_;
@@ -81,9 +81,9 @@ class ArrayIterator {
 template <typename C, class Ref>
 class ArrayAccessor {
  public:
-
-  template <typename T=typename std::enable_if<std::is_base_of<ObjectRef, Ref>::value>::type>
-  ArrayAccessor(const C* data, size_t num_data, ::std::shared_ptr<::std::vector<Ref>> refs) : data_{data}, num_data_{num_data}, refs_{refs} {}
+  template <typename T = typename std::enable_if<std::is_base_of<ObjectRef, Ref>::value>::type>
+  ArrayAccessor(const C* data, size_t num_data, ::std::shared_ptr<::std::vector<Ref>> refs)
+      : data_{data}, num_data_{num_data}, refs_{refs} {}
 
   inline size_t size() { return num_data_; }
 
@@ -103,13 +103,9 @@ class ArrayAccessor {
     return (*refs_)[index];
   }
 
-  inline ArrayIterator<C, Ref> begin() {
-    return ArrayIterator<C, Ref>{0, this};
-  }
+  inline ArrayIterator<C, Ref> begin() { return ArrayIterator<C, Ref>{0, this}; }
 
-  inline ArrayIterator<C, Ref> end() {
-    return ArrayIterator<C, Ref>{num_data_, this};
-  }
+  inline ArrayIterator<C, Ref> end() { return ArrayIterator<C, Ref>{num_data_, this}; }
 
  private:
   const C* data_;
@@ -120,7 +116,9 @@ class ArrayAccessor {
 template <>
 class ArrayAccessor<const char*, ::tvm::runtime::String> {
  public:
-  ArrayAccessor(const char** data, size_t num_data, ::std::shared_ptr<std::vector<::tvm::runtime::String>> refs) : data_{data}, num_data_{num_data}, refs_{refs} {}
+  ArrayAccessor(const char** data, size_t num_data,
+                ::std::shared_ptr<std::vector<::tvm::runtime::String>> refs)
+      : data_{data}, num_data_{num_data}, refs_{refs} {}
 
   inline size_t size() { return num_data_; }
 
@@ -160,13 +158,14 @@ enum MetadataTypeIndex : uint8_t {
   kBool = 2,
   kString = 3,
   kHandle = 4,
-
 };
 
 class MetadataArrayNode : public MetadataBaseNode {
  public:
-//  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index) : array{array}, type_index{type_index} {}
-  MetadataArrayNode(Array<ObjectRef> array, const char* c_type) : array(std::move(array)), c_type{c_type} {}
+  //  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index) : array{array},
+  //  type_index{type_index} {}
+  MetadataArrayNode(Array<ObjectRef> array, const char* c_type)
+      : array(std::move(array)), c_type{c_type} {}
 
   std::string get_name() override;
 
@@ -178,7 +177,7 @@ class MetadataArrayNode : public MetadataBaseNode {
 
 class MetadataArray : public MetadataBase {
  public:
-//  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index);
+  //  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index);
   MetadataArray(Array<ObjectRef> array, const char* c_type);
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MetadataArray, MetadataBase, MetadataArrayNode);
 };

--- a/include/tvm/runtime/metadata_base.h
+++ b/include/tvm/runtime/metadata_base.h
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/runtime/metadata_base.h
+ * \brief Defines types which can be used in Metadata.
+ */
+#ifndef TVM_RUNTIME_METADATA_BASE_H_
+#define TVM_RUNTIME_METADATA_BASE_H_
+
+#include <string>
+#include <tvm/ir/expr.h>
+#include <tvm/runtime/object.h>
+
+namespace tvm {
+namespace runtime {
+namespace metadata {
+
+class MetadataBaseNode : public ::tvm::runtime::Object {
+ public:
+  virtual std::string get_name() = 0;
+
+  static constexpr const char* _type_key = "metadata.MetadataBaseNode";
+  TVM_DECLARE_BASE_OBJECT_INFO(MetadataBaseNode, ::tvm::runtime::Object);
+};
+
+class MetadataBase : public ::tvm::runtime::ObjectRef {
+ public:
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MetadataBase, ::tvm::runtime::ObjectRef, MetadataBaseNode);
+};
+
+template <typename C, class Ref>
+class ArrayAccessor;
+
+template <typename C, class Ref>
+class ArrayIterator {
+ public:
+  ArrayIterator(size_t index, ArrayAccessor<C, Ref>* parent) : index_{index}, parent_{parent} {}
+
+  inline Ref operator*() {
+    return (*parent_)[index_];
+  }
+
+  inline ArrayIterator<C, Ref>& operator++() {
+    if (index_ < parent_->size()) {
+      index_++;
+    }
+
+    return *this;
+  }
+
+  inline bool operator==(const ArrayIterator<C, Ref>& other) {
+    return parent_ == other.parent_ && index_ == other.index_;
+  }
+
+  inline bool operator!=(const ArrayIterator<C, Ref>& other) {
+    return !operator==(other);
+  }
+
+ private:
+  size_t index_;
+  ArrayAccessor<C, Ref>* parent_;
+};
+
+template <typename C, class Ref>
+class ArrayAccessor {
+ public:
+
+  template <typename T=typename std::enable_if<std::is_base_of<ObjectRef, Ref>::value>::type>
+  ArrayAccessor(const C* data, size_t num_data, ::std::shared_ptr<::std::vector<Ref>> refs) : data_{data}, num_data_{num_data}, refs_{refs} {}
+
+  inline size_t size() { return num_data_; }
+
+  inline Ref operator[](size_t index) {
+    if (index >= num_data_) {
+      throw std::runtime_error("Index out of range");
+    }
+
+    if (refs_->size() <= index) {
+      refs_->resize(num_data_);
+    }
+
+    if (!(*refs_)[index].defined()) {
+      (*refs_)[index] = Ref(&data_[index]);
+    }
+
+    return (*refs_)[index];
+  }
+
+  inline ArrayIterator<C, Ref> begin() {
+    return ArrayIterator<C, Ref>{0, this};
+  }
+
+  inline ArrayIterator<C, Ref> end() {
+    return ArrayIterator<C, Ref>{num_data_, this};
+  }
+
+ private:
+  const C* data_;
+  size_t num_data_;
+  ::std::shared_ptr<::std::vector<Ref>> refs_;
+};
+
+template <>
+class ArrayAccessor<const char*, ::tvm::runtime::String> {
+ public:
+  ArrayAccessor(const char** data, size_t num_data, ::std::shared_ptr<std::vector<::tvm::runtime::String>> refs) : data_{data}, num_data_{num_data}, refs_{refs} {}
+
+  inline size_t size() { return num_data_; }
+
+  inline ::tvm::runtime::String operator[](size_t index) {
+    if (index >= num_data_) {
+      throw std::runtime_error("Index out of range");
+    }
+
+    if (refs_->size() <= index) {
+      refs_->resize(num_data_);
+    }
+
+    if (!(*refs_)[index].defined()) {
+      (*refs_)[index] = ::tvm::runtime::String(data_[index]);
+    }
+
+    return (*refs_)[index];
+  }
+
+  inline ArrayIterator<const char*, ::tvm::runtime::String> begin() {
+    return ArrayIterator<const char*, ::tvm::runtime::String>{0, this};
+  }
+
+  inline ArrayIterator<const char*, ::tvm::runtime::String> end() {
+    return ArrayIterator<const char*, ::tvm::runtime::String>{num_data_, this};
+  }
+
+ private:
+  const char** data_;
+  size_t num_data_;
+  ::std::shared_ptr<::std::vector<::tvm::runtime::String>> refs_;
+};
+
+enum MetadataTypeIndex : uint8_t {
+  kUint64 = 0,
+  kInt64 = 1,
+  kBool = 2,
+  kString = 3,
+  kHandle = 4,
+
+};
+
+class MetadataArrayNode : public MetadataBaseNode {
+ public:
+//  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index) : array{array}, type_index{type_index} {}
+  MetadataArrayNode(Array<ObjectRef> array, const char* c_type) : array(std::move(array)), c_type{c_type} {}
+
+  std::string get_name() override;
+
+  Array<ObjectRef> array;
+  const char* c_type;
+  static constexpr const char* _type_key = "metadata.MetadataArrayNode";
+  TVM_DECLARE_BASE_OBJECT_INFO(MetadataArrayNode, MetadataBaseNode);
+};
+
+class MetadataArray : public MetadataBase {
+ public:
+//  MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index);
+  MetadataArray(Array<ObjectRef> array, const char* c_type);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MetadataArray, MetadataBase, MetadataArrayNode);
+};
+
+}  // namespace metadata
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_METADATA_BASE_H_

--- a/include/tvm/support/span.h
+++ b/include/tvm/support/span.h
@@ -19,7 +19,7 @@
 
 /*!
  *
- * \file span.h
+ * \file tvm/support/span.h
  * \brief Reimplementation of part of C++-20 style span.
  */
 #ifndef TVM_SUPPORT_SPAN_H_

--- a/include/tvm/support/span.h
+++ b/include/tvm/support/span.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *
+ * \file span.h
+ * \brief Reimplementation of part of C++-20 style span.
+ */
+#ifndef TVM_SUPPORT_SPAN_H_
+#define TVM_SUPPORT_SPAN_H_
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+namespace tvm {
+namespace support {
+
+template<class T, class W> //, std::enable_if_t<std::is_constructible<W, std::add_rvalue_reference<T>::value>::value> = true>
+class Span {
+ public:
+  class iterator : public std::iterator<std::input_iterator_tag, W> {
+   public:
+    inline iterator(T* ptr, T* end) : ptr_{ptr}, end_{end} {
+      CHECK_GE(end, ptr);
+    }
+
+    inline W operator*() {
+      return W(*ptr_);
+    }
+
+    inline iterator& operator++() {
+      if (ptr_ != end_) ptr_++;
+      return *this;
+    }
+
+    inline bool operator==(iterator other) {
+      return ptr_ == other.ptr_ && end_ == other.end_;
+    }
+
+    inline bool operator!=(iterator other) {
+      return !(*this == other);
+    }
+
+   private:
+    T* ptr_;
+    T* end_;
+  };
+
+  inline Span(T* begin, int num_elements) : begin_{begin}, end_{begin + num_elements} {}
+  inline Span(T* begin, T* end) : begin_{begin}, end_{end} {}
+
+  inline iterator begin() {
+    return iterator(begin_, end_);
+  }
+
+  inline iterator end() {
+    return iterator(end_, end_);
+  }
+
+  inline W operator[](int i) {
+    T* to_return = begin_ + i;
+    ICHECK_LT(to_return, end_) << "Span access out of bounds: " << i;
+    return W(*to_return);
+  }
+
+  inline operator std::vector<W>() {
+    return std::vector<W>(begin(), end());
+  }
+
+ protected:
+  T* begin_;
+  T* end_;
+};
+
+}  // namespace support
+}  // namespace tvm
+
+#endif  // TVM_SUPPORT_SPAN_H_

--- a/include/tvm/support/span.h
+++ b/include/tvm/support/span.h
@@ -32,31 +32,23 @@
 namespace tvm {
 namespace support {
 
-template<class T, class W> //, std::enable_if_t<std::is_constructible<W, std::add_rvalue_reference<T>::value>::value> = true>
+template <class T, class W>
 class Span {
  public:
   class iterator : public std::iterator<std::input_iterator_tag, W> {
    public:
-    inline iterator(T* ptr, T* end) : ptr_{ptr}, end_{end} {
-      CHECK_GE(end, ptr);
-    }
+    inline iterator(T* ptr, T* end) : ptr_{ptr}, end_{end} { CHECK_GE(end, ptr); }
 
-    inline W operator*() {
-      return W(*ptr_);
-    }
+    inline W operator*() { return W(*ptr_); }
 
     inline iterator& operator++() {
       if (ptr_ != end_) ptr_++;
       return *this;
     }
 
-    inline bool operator==(iterator other) {
-      return ptr_ == other.ptr_ && end_ == other.end_;
-    }
+    inline bool operator==(iterator other) { return ptr_ == other.ptr_ && end_ == other.end_; }
 
-    inline bool operator!=(iterator other) {
-      return !(*this == other);
-    }
+    inline bool operator!=(iterator other) { return !(*this == other); }
 
    private:
     T* ptr_;
@@ -66,13 +58,9 @@ class Span {
   inline Span(T* begin, int num_elements) : begin_{begin}, end_{begin + num_elements} {}
   inline Span(T* begin, T* end) : begin_{begin}, end_{end} {}
 
-  inline iterator begin() {
-    return iterator(begin_, end_);
-  }
+  inline iterator begin() { return iterator(begin_, end_); }
 
-  inline iterator end() {
-    return iterator(end_, end_);
-  }
+  inline iterator end() { return iterator(end_, end_); }
 
   inline W operator[](int i) {
     T* to_return = begin_ + i;
@@ -80,9 +68,7 @@ class Span {
     return W(*to_return);
   }
 
-  inline operator std::vector<W>() {
-    return std::vector<W>(begin(), end());
-  }
+  inline operator std::vector<W>() { return std::vector<W>(begin(), end()); }
 
  protected:
   T* begin_;

--- a/include/tvm/support/span.h
+++ b/include/tvm/support/span.h
@@ -35,6 +35,12 @@ namespace support {
 template <class T, class W>
 class Span {
  public:
+  using value_type = W;
+  using reference = W&;
+  using const_reference = const W&;
+  using pointer = W*;
+  using const_pointer = const W*;
+
   class iterator : public std::iterator<std::input_iterator_tag, W> {
    public:
     inline iterator(T* ptr, T* end) : ptr_{ptr}, end_{end} { CHECK_GE(end, ptr); }
@@ -46,21 +52,23 @@ class Span {
       return *this;
     }
 
-    inline bool operator==(iterator other) { return ptr_ == other.ptr_ && end_ == other.end_; }
+    inline bool operator==(iterator other) const { return ptr_ == other.ptr_ && end_ == other.end_; }
 
-    inline bool operator!=(iterator other) { return !(*this == other); }
+    inline bool operator!=(iterator other) const { return !(*this == other); }
 
-   private:
+   protected:
     T* ptr_;
     T* end_;
   };
 
+  using const_iterator = iterator;
+
   inline Span(T* begin, int num_elements) : begin_{begin}, end_{begin + num_elements} {}
   inline Span(T* begin, T* end) : begin_{begin}, end_{end} {}
 
-  inline iterator begin() { return iterator(begin_, end_); }
+  inline iterator begin() const { return iterator(begin_, end_); }
 
-  inline iterator end() { return iterator(end_, end_); }
+  inline iterator end() const { return iterator(end_, end_); }
 
   inline W operator[](int i) {
     T* to_return = begin_ + i;

--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -162,12 +162,6 @@ class TargetKindAttrMap : public AttrRegistryMap<TargetKind, ValueType> {
   explicit TargetKindAttrMap(const AttrRegistryMapContainerMap<TargetKind>& map) : TParent(map) {}
 };
 
-/*! \brief Value used with --runtime in target specs to indicate the C++ runtime. */
-static constexpr const char* kTvmRuntimeCpp = "c++";
-
-/*! \brief Value used with --runtime in target specs to indicate the C runtime. */
-static constexpr const char* kTvmRuntimeCrt = "c";
-
 /*!
  * \brief Helper structure to register TargetKind
  * \sa TVM_REGISTER_TARGET_KIND

--- a/python/tvm/contrib/graph_executor.py
+++ b/python/tvm/contrib/graph_executor.py
@@ -188,7 +188,7 @@ class GraphModule(object):
             keys.sort(key=lambda x: -np.prod(params[x].shape))
             for k in keys:
                 # TODO(zhiics) Skip the weights for submodule in a better way.
-                # We should use MetadataModule for initialization and remove
+                # We should use ConstLoaderModule for initialization and remove
                 # params from set_input
                 val = self._get_input(k)
                 if val:

--- a/python/tvm/relay/backend/executor_factory.py
+++ b/python/tvm/relay/backend/executor_factory.py
@@ -105,6 +105,13 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         function_metadata,
         devices,
     ):
+        fcreate = get_global_func("tvm.aot_executor_factory.create")
+        args = []
+        for k, v in params.items():
+            args.append(k)
+            args.append(ndarray.array(v))
+
+        self.module = fcreate(libmod, libmod_name, *args)
         self.ir_mod = ir_mod
         self.lowered_ir_mods = lowered_ir_mods
         self.target = target
@@ -127,6 +134,9 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
 
     def get_lib(self):
         return self.lib
+
+    def export_library(self, file_name, fcompile=None, addons=None, **kwargs):
+        return self.module.export_library(file_name, fcompile, addons, **kwargs)
 
 
 class GraphExecutorFactoryModule(ExecutorFactoryModule):

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -31,3 +31,5 @@ from .ndarray import vpi, rocm, ext_dev
 from .module import load_module, enabled, system_lib
 from .container import String, ShapeTuple
 from .params import save_param_dict, load_param_dict
+
+from . import executor

--- a/python/tvm/runtime/executor/__init__.py
+++ b/python/tvm/runtime/executor/__init__.py
@@ -1,0 +1,2 @@
+
+from .aot_executor import AotModule

--- a/python/tvm/runtime/executor/__init__.py
+++ b/python/tvm/runtime/executor/__init__.py
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Top-level file for the executor module."""
 
 from .aot_executor import AotModule

--- a/python/tvm/runtime/executor/aot_executor.py
+++ b/python/tvm/runtime/executor/aot_executor.py
@@ -1,0 +1,182 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""A Python wrapper for the Module-based Model Runtime Interface for Ahead-of-Time compilation."""
+
+import numpy as np
+
+
+class AotModule(object):
+    """Wraps the AOT executor runtime.Module.
+
+    This is a thin wrapper of the underlying TVM module.
+    you can also directly call set_input, run, and get_output
+    of underlying module functions
+
+    Parameters
+    ----------
+    module : tvm.runtime.Module
+        The internal tvm module that holds the actual graph functions.
+
+    Attributes
+    ----------
+    module : tvm.runtime.Module
+        The internal tvm module that holds the actual graph functions.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        import tvm
+        from tvm import relay
+        from tvm.contrib import graph_executor
+
+        # build the library using graph executor
+        lib = relay.build(...)
+        lib.export_library("compiled_lib.so")
+        # load it back as a runtime
+        lib: tvm.runtime.Module = tvm.runtime.load_module("compiled_lib.so")
+        # Call the library factory function for default and create
+        # a new runtime.Module, wrap with graph module.
+        gmod = graph_executor.GraphModule(lib["default"](dev))
+        # use the graph module.
+        gmod.set_input("x", data)
+        gmod.run()
+    """
+
+    def __init__(self, module):
+        self.module = module
+        self._set_input = module["set_input"]
+        self._run = module["run"]
+        self._get_output = module["get_output"]
+        self._get_input = module["get_input"]
+        self._get_num_outputs = module["get_num_outputs"]
+        self._get_input_index = module["get_input_index"]
+        self._get_num_inputs = module["get_num_inputs"]
+
+    def set_input(self, key=None, value=None, **params):
+        """Set inputs to the module via kwargs
+
+        Parameters
+        ----------
+        key : int or str
+           The input key
+
+        value : the input value.
+           The input key
+
+        params : dict of str to NDArray
+           Additional arguments
+        """
+        if key is not None:
+            v = self._get_input(key)
+            if v is None:
+                raise RuntimeError("Could not find '%s' in graph's inputs" % key)
+            v.copyfrom(value)
+
+        if params:
+            # upload big arrays first to avoid memory issue in rpc mode
+            keys = list(params.keys())
+            keys.sort(key=lambda x: -np.prod(params[x].shape))
+            for k in keys:
+                # TODO(zhiics) Skip the weights for submodule in a better way.
+                # We should use MetadataModule for initialization and remove
+                # params from set_input
+                val = self._get_input(k)
+                if val:
+                    self._get_input(k).copyfrom(params[k])
+
+    def run(self, **input_dict):
+        """Run forward execution of the graph
+
+        Parameters
+        ----------
+        input_dict: dict of str to NDArray
+            List of input values to be feed to
+        """
+        if input_dict:
+            self.set_input(**input_dict)
+        self._run()
+
+    def get_num_outputs(self):
+        """Get the number of outputs from the graph
+
+        Returns
+        -------
+        count : int
+            The number of outputs.
+        """
+        return self._get_num_outputs()
+
+    def get_num_inputs(self):
+        """Get the number of inputs to the graph
+
+        Returns
+        -------
+        count : int
+            The number of inputs.
+        """
+        return self._get_num_inputs()
+
+    def get_input(self, index, out=None):
+        """Get index-th input to out
+
+        Parameters
+        ----------
+        index : int
+            The input index
+
+        out : NDArray
+            The output array container
+        """
+        if out:
+            self._get_input(index).copyto(out)
+            return out
+
+        return self._get_input(index)
+
+    def get_input_index(self, name):
+        """Get inputs index via input name.
+
+        Parameters
+        ----------
+        name : str
+           The input key name
+
+        Returns
+        -------
+        index: int
+            The input index. -1 will be returned if the given input name is not found.
+        """
+        return self._get_input_index(name)
+
+    def get_output(self, index, out=None):
+        """Get index-th output to out
+
+        Parameters
+        ----------
+        index : int
+            The output index
+
+        out : NDArray
+            The output array container
+        """
+        if out:
+            self._get_output(index, out)
+            return out
+
+        return self._get_output(index)

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -820,7 +820,11 @@ class AOTExecutorCodegen : public MixedModeVisitor {
     Integer workspace_byte_alignment =
         executor_config->GetAttr<Integer>("workspace-byte-alignment").value_or(16);
     use_unpacked_api_ = executor_config->GetAttr<Bool>("unpacked-api").value_or(Bool(false));
-    use_call_cpacked_ = Bool(interface_api == "c");
+    use_call_cpacked_ =
+      (Bool(interface_api == "c") ||
+       // for now, C runtime does not support calling functions on other devices. therefore,
+       // opt to call PackedFunc directly by name rather than TVMBackendGetFuncFromEnv.
+       runtime_config->name == kTvmRuntimeCrt);
 
     // Validate choice of use_unpacked_api_ and use_call_cpacked_
     if (runtime_config->name == kTvmRuntimeCrt) {

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -830,9 +830,9 @@ class AOTExecutorCodegen : public MixedModeVisitor {
           << ") when targeting c runtime";
     } else if (runtime_config->name == kTvmRuntimeCpp) {
       CHECK(use_unpacked_api_ == false && static_cast<bool>(use_call_cpacked_) == true)
-        << "Need unpacked-api == false (got: " << use_unpacked_api_
-        << ") and interface-api == \"c\" (got: " << interface_api
-        << ") when targeting c++ runtime";
+          << "Need unpacked-api == false (got: " << use_unpacked_api_
+          << ") and interface-api == \"c\" (got: " << interface_api
+          << ") when targeting c++ runtime";
     } else {
       ICHECK(false) << "runtime_config (" << runtime_config->name
                     << ") is not one of the expected values";

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -824,10 +824,11 @@ class AOTExecutorCodegen : public MixedModeVisitor {
 
     // Validate choice of use_unpacked_api_ and use_call_cpacked_
     if (runtime_config->name == kTvmRuntimeCrt) {
-      CHECK(interface_api == "c" || static_cast<bool>(use_unpacked_api_) == false)
-          << "Either need interface_api == \"c\" (got: " << interface_api
-          << ") or unpacked-api == false (got: " << use_unpacked_api_
-          << ") when targeting c runtime";
+      if (interface_api == "c") {
+        CHECK(static_cast<bool>(use_unpacked_api_) == true)
+          << "When interface_api == \"c\", need unpacked-api == true (got: "
+          << use_unpacked_api_ << ") when targeting c runtime";
+      }
     } else if (runtime_config->name == kTvmRuntimeCpp) {
       CHECK(static_cast<bool>(use_unpacked_api_) == false &&
             static_cast<bool>(use_call_cpacked_) == true)

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -824,12 +824,13 @@ class AOTExecutorCodegen : public MixedModeVisitor {
 
     // Validate choice of use_unpacked_api_ and use_call_cpacked_
     if (runtime_config->name == kTvmRuntimeCrt) {
-      CHECK(interface_api == "c" || use_unpacked_api_ == false)
+      CHECK(interface_api == "c" || static_cast<bool>(use_unpacked_api_) == false)
           << "Either need interface_api == \"c\" (got: " << interface_api
           << ") or unpacked-api == false (got: " << use_unpacked_api_
           << ") when targeting c runtime";
     } else if (runtime_config->name == kTvmRuntimeCpp) {
-      CHECK(use_unpacked_api_ == false && static_cast<bool>(use_call_cpacked_) == true)
+      CHECK(static_cast<bool>(use_unpacked_api_) == false &&
+            static_cast<bool>(use_call_cpacked_) == true)
           << "Need unpacked-api == false (got: " << use_unpacked_api_
           << ") and interface-api == \"c\" (got: " << interface_api
           << ") when targeting c++ runtime";

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -175,9 +175,9 @@ class AOTOnDemandAllocator : public transform::DeviceAwareExprVisitor {
  private:
   void AssignReturnSid(Expr e) {
     if (storage_device_map_.find(e) != storage_device_map_.end()) {
-      LOG(INFO) << "AssignReturnSid: is now " << e;
+//      LOG(INFO) << "AssignReturnSid: is now " << e;
       StorageInfo& sinfo = storage_device_map_[e];
-      LOG(INFO) << "AssignReturnSid: storage_device_map_ " << sinfo;
+//      LOG(INFO) << "AssignReturnSid: storage_device_map_ " << sinfo;
       return_ids_.clear();
       for (auto sid : sinfo->storage_ids) {
         return_ids_.push_back(sid);
@@ -337,7 +337,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
    * a DLTensor on stack.
    */
   PrimExpr MakeDLTensor(Expr relay_arg, TensorType ttype, PrimExpr data) {
-    LOG(INFO) << "MakeDLTensor: " << relay_arg << " (ttype " << ttype << "): " << data;
+//    LOG(INFO) << "MakeDLTensor: " << relay_arg << " (ttype " << ttype << "): " << data;
     return data;
   }
   //   for (Var v : input_vars_) {
@@ -471,7 +471,8 @@ class AOTExecutorCodegen : public MixedModeVisitor {
       }));
     } else if (use_call_cpacked_ && !use_unpacked_api_) {
       // call_cpacked calling convention needs a blank context
-      args.push_back(tir::make_zero(DataType::Handle()));
+      // TOOD only c runtime
+//      args.push_back(tir::make_zero(DataType::Handle()));
       tir::Evaluate func_call(tvm::tir::Call(DataType::Int(32), calling_pattern, args));
       create_func_call_stmts.push_back(func_call);
     } else {
@@ -971,8 +972,10 @@ class AOTExecutorCodegen : public MixedModeVisitor {
     // Legalize AOT if needed. This means that all the packed calls
     // need to be wrapped in TVMValues (unless use_unpacked_api is set)
     if (!use_unpacked_api_) {
+      LOG(INFO) << "Legalize Packed " << mod_run;
       auto pack_calls = tir::transform::LegalizePackedCalls();
       mod_run = pack_calls(mod_run);
+      LOG(INFO) << "Legalize Packed done " << mod_run;
     }
 
     ret.function_metadata = std::move(function_metadata_);

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -859,7 +859,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
           << use_unpacked_api_ << ") when targeting c runtime";
       }
     } else if (runtime_config->name == kTvmRuntimeCpp) {
-      CHECK(static_cast<bool>(use_unpacked_api_) == false &&
+      CHECK(static_cast<bool>(use_unpacked_api_) == true ||
             static_cast<bool>(use_call_cpacked_) == true)
           << "Need unpacked-api == false (got: " << use_unpacked_api_
           << ") and interface-api == \"c\" (got: " << interface_api

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -253,7 +253,7 @@ class AOTOnDemandAllocator : public transform::DeviceAwareExprVisitor {
       virtual_devices.push_back(virtual_device);
       storage_sizes_in_bytes.push_back(GetMemorySizeBytes(ttype));
     }
-    LOG(INFO) << "CreateStorage: " << expr;
+//    LOG(INFO) << "CreateStorage: " << expr;
     storage_device_map_[expr] = StorageInfo(std::move(storage_ids), std::move(virtual_devices),
                                             std::move(storage_sizes_in_bytes));
   }
@@ -337,6 +337,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
    * a DLTensor on stack.
    */
   PrimExpr MakeDLTensor(Expr relay_arg, TensorType ttype, PrimExpr data) {
+    LOG(INFO) << "MakeDLTensor: " << relay_arg << " (ttype " << ttype << "): " << data;
     return data;
   }
   //   for (Var v : input_vars_) {

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -445,7 +445,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
           func_call,
           GenerateDeviceHook(context, "Close"),
       }));
-    } else if (use_call_cpacked_) {
+    } else if (use_call_cpacked_ && !use_unpacked_api_) {
       // call_cpacked calling convention needs a blank context
       args.push_back(tir::make_zero(DataType::Handle()));
       tir::Evaluate func_call(tvm::tir::Call(DataType::Int(32), calling_pattern, args));

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -103,7 +103,7 @@ struct ExecutorCodegen {
 
   Array<String> ListDevices() { return CallFunc<Array<String>>("get_devices"); }
 
-  runtime::Metadata GetMetadata() { return CallFunc<runtime::Metadata>("get_metadata"); }
+  runtime::metadata::Metadata GetMetadata() { return CallFunc<runtime::metadata::Metadata>("get_metadata"); }
   virtual ~ExecutorCodegen() {}
 
  protected:

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -103,7 +103,9 @@ struct ExecutorCodegen {
 
   Array<String> ListDevices() { return CallFunc<Array<String>>("get_devices"); }
 
-  runtime::metadata::Metadata GetMetadata() { return CallFunc<runtime::metadata::Metadata>("get_metadata"); }
+  runtime::metadata::Metadata GetMetadata() {
+    return CallFunc<runtime::metadata::Metadata>("get_metadata");
+  }
   virtual ~ExecutorCodegen() {}
 
  protected:

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -410,6 +410,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     Function func = Downcast<Function>(relay_module->Lookup("main"));
     IRModule func_module = WithAttrs(IRModule::FromExpr(func), {{tvm::attr::kExecutor, executor_},
                                                                 {tvm::attr::kRuntime, runtime_}});
+    LOG(INFO) << "Executor " << executor_;
 
     // Generate code for the updated function.
     executor_codegen_ = MakeExecutorCodegen(executor_->name);

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -302,7 +302,6 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
   }
 
  protected:
-
   /*!
    * \brief Add node to graph
    *

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -290,6 +290,14 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
     // This is the point where we separate the functions in the module by target
     ret.lowered_funcs = tec::GetPerTargetModules(lowered_mod);
     ret.external_mods = external_modules.value();
+
+    std::vector<runtime::metadata::TensorInfo> inputs;
+    std::vector<runtime::metadata::TensorInfo> outputs;
+    std::vector<std::string> devices_vector;
+    auto n = make_object<target::metadata::InMemoryMetadataNode>(
+        kMetadataVersion, inputs, outputs, devices_vector, runtime::kTvmExecutorGraph, mod_name_,
+        "packed", Bool(false));
+    ret.metadata = runtime::metadata::Metadata(std::move(n));
     return ret;
   }
 

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -294,20 +294,6 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
   }
 
  protected:
-  /*!
-   * \brief Extract shape from expr to vector<int64_t>
-   *
-   * \param shape
-   * \return std::vector<int64_t>
-   */
-  std::vector<int64_t> _ShapeToJSON(tvm::Array<IndexExpr> shape) {
-    std::vector<int64_t> ret;
-    for (IndexExpr dim : shape) {
-      const int64_t* pval = tir::as_const_int(dim);
-      ret.push_back(*pval);
-    }
-    return ret;
-  }
 
   /*!
    * \brief Add node to graph
@@ -352,7 +338,7 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
       for (size_t i = 0; i < tuple_type->fields.size(); ++i) {
         if (const auto* typ = tuple_type->fields[i].as<TensorTypeNode>()) {
           ret.push_back(GraphNodeRef(node_id, i));
-          shape.emplace_back(_ShapeToJSON(typ->shape));
+          shape.emplace_back(ShapeToJSON(typ->shape));
           dtype.emplace_back(DType2String(typ->dtype));
         } else {
           LOG(FATAL) << "type " << checked_type->GetTypeKey() << " not supported";
@@ -369,7 +355,7 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
     if (const auto* tensor_type = checked_type.as<TensorTypeNode>()) {
       ShapeVector shape;
       std::vector<std::string> dtype;
-      shape.emplace_back(_ShapeToJSON(tensor_type->shape));
+      shape.emplace_back(ShapeToJSON(tensor_type->shape));
       dtype.emplace_back(DType2String(tensor_type->dtype));
       node->attrs_["shape"] = shape;
       node->attrs_["dtype"] = dtype;

--- a/src/relay/backend/runtime.cc
+++ b/src/relay/backend/runtime.cc
@@ -88,9 +88,9 @@ RuntimeRegEntry& RuntimeRegEntry::RegisterOrGet(const String& name) {
 
 /**********  Register Runtimes and options  **********/
 
-TVM_REGISTER_RUNTIME("crt").add_attr_option<Bool>("system-lib");
+TVM_REGISTER_RUNTIME(kTvmRuntimeCrt).add_attr_option<Bool>("system-lib");
 
-TVM_REGISTER_RUNTIME("cpp").add_attr_option<Bool>("system-lib");
+TVM_REGISTER_RUNTIME(kTvmRuntimeCpp).add_attr_option<Bool>("system-lib");
 
 /**********  Registry  **********/
 

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -278,8 +278,8 @@ void UpdateAutoSchedulerOpWeights(const IRModule& module) {
 std::vector<int64_t> ShapeToJSON(tvm::Array<IndexExpr> shape) {
   std::vector<int64_t> ret;
   for (IndexExpr dim : shape) {
-      const int64_t* pval = tir::as_const_int(dim);
-      ret.push_back(*pval);
+    const int64_t* pval = tir::as_const_int(dim);
+    ret.push_back(*pval);
   }
   return ret;
 }

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -275,6 +275,15 @@ void UpdateAutoSchedulerOpWeights(const IRModule& module) {
   (*te_compiler_update_weights)(weight_map);
 }
 
+std::vector<int64_t> ShapeToJSON(tvm::Array<IndexExpr> shape) {
+  std::vector<int64_t> ret;
+  for (IndexExpr dim : shape) {
+      const int64_t* pval = tir::as_const_int(dim);
+      ret.push_back(*pval);
+  }
+  return ret;
+}
+
 }  // namespace backend
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -527,6 +527,14 @@ Map<Target, IRModule> TargetStrModuleMapToTargetModuleMap(
  */
 void UpdateAutoSchedulerOpWeights(const IRModule& module);
 
+/*!
+ * \brief Extract shape from expr to vector<int64_t>
+ *
+ * \param shape
+ * \return std::vector<int64_t>
+ */
+std::vector<int64_t> ShapeToJSON(tvm::Array<IndexExpr> shape);
+
 }  // namespace backend
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -31,6 +31,7 @@
 #include <tvm/relay/transform.h>
 #include <tvm/relay/type.h>
 #include <tvm/target/codegen.h>
+#include <tvm/generated/target/metadata.h>
 #include <tvm/target/virtual_device.h>
 #include <tvm/te/operation.h>
 
@@ -147,7 +148,7 @@ struct LoweredOutput {
   Array<tvm::runtime::Module> external_mods;
   Map<String, FunctionInfo> function_metadata;
   std::unordered_map<std::string, std::pair<int, const tvm::runtime::NDArray>> params;
-  runtime::Metadata metadata;
+  runtime::metadata::Metadata metadata;  // points to InMemoryMetadataNode
 };
 
 /*!

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -31,7 +31,6 @@
 #include <tvm/relay/transform.h>
 #include <tvm/relay/type.h>
 #include <tvm/target/codegen.h>
-#include <tvm/generated/target/metadata.h>
 #include <tvm/target/virtual_device.h>
 #include <tvm/te/operation.h>
 

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include "../../runtime/meta_data.h"
+#include "../../target/metadata.h"
 
 namespace tvm {
 namespace relay {

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -1162,8 +1162,9 @@ void VMCompiler::Codegen() {
     lib = tvm::build(per_tvm_target_modules, config_->host_target);
   }
 
-  lib = codegen::CreateMetadataModule(params_, lib, ext_mods, config_->host_target,
-                                      Runtime::Create("cpp"), runtime::metadata::Metadata(make_object<target::metadata::InMemoryMetadataNode>()));
+  lib = codegen::CreateMetadataModule(
+      params_, lib, ext_mods, config_->host_target, Runtime::Create("cpp"),
+      runtime::metadata::Metadata(make_object<target::metadata::InMemoryMetadataNode>()));
   exec_->SetLib(lib);
 }
 

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -46,6 +46,7 @@
 #include <tuple>
 #include <vector>
 
+#include "../../../target/metadata.h"
 #include "../../../target/metadata_module.h"
 #include "../../../target/source/codegen_source_base.h"
 #include "../../op/annotation/annotation.h"
@@ -1162,7 +1163,7 @@ void VMCompiler::Codegen() {
   }
 
   lib = codegen::CreateMetadataModule(params_, lib, ext_mods, config_->host_target,
-                                      Runtime::Create("cpp"), runtime::Metadata());
+                                      Runtime::Create("cpp"), runtime::metadata::Metadata(make_object<target::metadata::InMemoryMetadataNode>()));
   exec_->SetLib(lib);
 }
 

--- a/src/runtime/aot_executor/aot_executor.cc
+++ b/src/runtime/aot_executor/aot_executor.cc
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \brief Defines an implementation of Module-based Model Runtime Interface that works with
+ *        Ahead-of-Time compilation.
+ * \file aot_executor.cc
+ */
+
+#include "aot_executor.h"
+
+#include <tvm/runtime/c_runtime_api.h>
+
+namespace tvm {
+namespace runtime {
+
+AotExecutor::AotExecutor(tvm::runtime::Module module, const std::vector<Device>& devs) :
+    module_{module}, devices_{devs} {
+
+  auto fmetadata = module->GetFunction("get_metadata");
+  CHECK(fmetadata != nullptr) << "Expected a module with PackedFunc get_metadata";
+  auto ret_value = fmetadata();
+  metadata_ = ret_value.AsObjectRef<tvm::runtime::metadata::Metadata>();
+
+  for (auto input : metadata_->inputs()) {
+    // TODO(areusch): Encode device information in Metadata.
+    args_.emplace_back(NDArray::Empty(ShapeTuple(input->shape().begin(), input->shape().end()), input->dtype(), devices_[0]));
+  }
+
+  for (auto output : metadata_->outputs()) {
+    args_.emplace_back(NDArray::Empty(ShapeTuple(output->shape().begin(), output->shape().end()), output->dtype(), devices_[0]));
+  }
+}
+
+PackedFunc AotExecutor::GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) {
+  // Return member functions during query.
+  if (name == "set_input") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      if (String::CanConvertFrom(args[0])) {
+        int in_idx = this->GetInputIndex(args[0].operator String());
+        if (in_idx >= 0) this->SetInput(in_idx, args[1]);
+      } else {
+        this->SetInput(args[0], args[1]);
+      }
+    });
+  } else if (name == "set_input_zero_copy") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      if (String::CanConvertFrom(args[0])) {
+        int in_idx = this->GetInputIndex(args[0].operator String());
+        if (in_idx >= 0) this->SetInputZeroCopy(in_idx, args[1]);
+      } else {
+        this->SetInputZeroCopy(args[0], args[1]);
+      }
+    });
+  } else if (name == "set_output_zero_copy") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      if (String::CanConvertFrom(args[0])) {
+        int out_idx = this->GetOutputIndex(args[0].operator String());
+        if (out_idx >= 0) this->SetOutputZeroCopy(out_idx, args[1]);
+      } else {
+        this->SetOutputZeroCopy(args[0], args[1]);
+      }
+    });
+  } else if (name == "get_output") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      if (args.num_args == 2) {
+        this->CopyOutputTo(args[0], args[1]);
+      } else {
+        *rv = this->GetOutput(args[0]);
+      }
+    });
+  } else if (name == "get_input") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      int in_idx = 0;
+      if (String::CanConvertFrom(args[0])) {
+        in_idx = this->GetInputIndex(args[0].operator String());
+      } else {
+        in_idx = args[0];
+      }
+      if (in_idx >= 0) {
+        *rv = this->GetInput(in_idx);
+      }
+    });
+  } else if (name == "get_num_outputs") {
+    return PackedFunc(
+        [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->NumOutputs(); });
+  } else if (name == "get_num_inputs") {
+    return PackedFunc(
+        [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->NumInputs(); });
+  } else if (name == "run") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { this->Run(); });
+  } else if (name == "get_input_index") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      CHECK(String::CanConvertFrom(args[0])) << "Input key is not a string";
+      *rv = this->GetInputIndex(args[0].operator String());
+    });
+  } else {
+    return PackedFunc();
+  }
+}
+
+void AotExecutor::Run() {
+  LOG(INFO) << "Get entrypoint " << metadata_->mod_name() << "_run_model";
+  auto pf = module_.GetFunction(metadata_->mod_name() + "_run_model", true /* query_imports */);
+  ICHECK(pf != nullptr) << "Module entrypoint is not defined";
+
+  const int num_args = args_.size();
+  ::std::unique_ptr<TVMValue> call_values{new TVMValue[num_args]};
+  ::std::unique_ptr<int> call_type_codes{new int[num_args]};
+  for (int i = 0; i < num_args; ++i) {
+    auto managed = args_[i].ToDLPack();
+    call_values.get()[i].v_handle = &managed->dl_tensor;
+    call_type_codes.get()[i] = kTVMDLTensorHandle;
+  }
+
+  TVMArgs args{call_values, call_type_codes, num_args};
+  TVMRetValue rv;
+  pf.CallPacked(args, &rv);
+}
+
+int AotExecutor::GetInputIndex(const std::string& name) {
+  auto inputs = metadata_->inputs();
+  for (unsigned int i = 0; i < inputs.size(); i++) {
+    if (inputs[i]->name() == name) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+int AotExecutor::GetOutputIndex(const std::string& name) {
+  auto outputs = metadata_->outputs();
+  for (unsigned int i = 0; i < outputs.size(); i++) {
+    if (outputs[i]->name() == name) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+void AotExecutor::SetInput(int index, DLTensor* data_ref) {
+  args_[index].CopyFrom(data_ref);
+}
+
+void AotExecutor::SetInputZeroCopy(int index, DLTensor* data_ref) {
+  ICHECK(false) << "not implemented";
+}
+
+void AotExecutor::SetOutputZeroCopy(int index, DLTensor* data_ref) {
+  ICHECK(false) << "not implemented";
+}
+
+int AotExecutor::NumOutputs() const {
+  return metadata_->num_outputs();
+}
+
+int AotExecutor::NumInputs() const {
+  return metadata_->num_inputs();
+}
+
+NDArray AotExecutor::GetInput(int index) const {
+  return args_[index];
+}
+
+NDArray AotExecutor::GetOutput(int index) const {
+  return args_[metadata_->num_inputs() + index];
+}
+
+void AotExecutor::CopyOutputTo(int index, DLTensor* data_out) {
+  GetOutput(index).CopyTo(data_out);
+}
+
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/aot_executor/aot_executor.cc
+++ b/src/runtime/aot_executor/aot_executor.cc
@@ -27,7 +27,8 @@
 
 #include <memory>
 
-#include <tvm/runtime/c_runtime_api.h>
+// TODO(areusch): idk what's up here...
+#include <tvm/runtime/c_runtime_api.h>  // NOLINT(build/include_order)
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/aot_executor/aot_executor.h
+++ b/src/runtime/aot_executor/aot_executor.h
@@ -25,19 +25,18 @@
 #ifndef TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_H_
 #define TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_H_
 
-#include <string>
-#include <vector>
 #include <tvm/runtime/metadata.h>
 #include <tvm/runtime/module.h>
-#include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/object.h>
+#include <tvm/runtime/packed_func.h>
 
+#include <string>
+#include <vector>
 
 namespace tvm {
 namespace runtime {
 
 class TVM_DLL AotExecutor : public ModuleNode {
-
  public:
   /*!
    * \brief Implements member function lookup for this Module for the frontend.

--- a/src/runtime/aot_executor/aot_executor.h
+++ b/src/runtime/aot_executor/aot_executor.h
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \brief Defines an implementation of Module-based Model Runtime Interface that works with
+ *        Ahead-of-Time compilation.
+ * \file aot_executor.h
+ */
+#ifndef TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_H_
+#define TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_H_
+
+#include <string>
+#include <vector>
+#include <tvm/runtime/metadata.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/object.h>
+
+
+namespace tvm {
+namespace runtime {
+
+class TVM_DLL AotExecutor : public ModuleNode {
+
+ public:
+  /*!
+   * \brief Implements member function lookup for this Module for the frontend.
+   * \param name The name of the function.
+   * \param sptr_to_self The pointer to the module node.
+   * \return The corresponding member function.
+   */
+  PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) override;
+
+  /*!
+   * \return The type key of the executor.
+   */
+  const char* type_key() const final { return "AotExecutor"; }
+
+  void Run();
+
+  /*!
+   * \brief Initialize the AOT executor with metadata, runtime::Module, and device.
+   * \param module The module containing the compiled functions for the host
+   *  processor.
+   * \param devs The device of the host and devices where graph nodes will be
+   *  executed on.
+   * \param lookup_linked_param_func If given, a PackedFunc invoked to lookup linked parameters
+   *  by storage_id. If not given, linked parameters are looked-up using an internal implementation,
+   *  which is not compatible with RPCModules. Default is nullptr.
+   */
+  AotExecutor(tvm::runtime::Module module, const std::vector<Device>& devs);
+
+  /*!
+   * \brief Get the input index given the name of input.
+   * \param name The name of the input.
+   * \return The index of input.
+   */
+  int GetInputIndex(const std::string& name);
+
+  /*!
+   * \brief Get the output index given the name of output.
+   * \param name The name of the output.
+   * \return The index of output.
+   */
+  int GetOutputIndex(const std::string& name);
+
+  /*!
+   * \brief set index-th input to the graph.
+   * \param index The input index.
+   * \param data_in The input data.
+   */
+  void SetInput(int index, DLTensor* data_in);
+  /*!
+   * \brief set index-th input to the graph without copying the data
+   * \param index The input index.
+   * \param data_ref The input data that is referred.
+   */
+  void SetInputZeroCopy(int index, DLTensor* data_ref);
+  /*!
+   * \brief set index-th output to the graph without copying the data.
+   * \param index The output index.
+   * \param data_ref The output data that is referred.
+   */
+  void SetOutputZeroCopy(int index, DLTensor* data_ref);
+  /*!
+   * \brief Get the number of outputs
+   *
+   * \return The number of outputs from graph.
+   */
+  int NumOutputs() const;
+  /*!
+   * \brief Get the number of inputs
+   *
+   * \return The number of inputs to the graph.
+   */
+  int NumInputs() const;
+  /*!
+   * \brief Return NDArray for given input index.
+   * \param index The input index.
+   *
+   * \return NDArray corresponding to given input node index.
+   */
+  NDArray GetInput(int index) const;
+  /*!
+   * \brief Return NDArray for given output index.
+   * \param index The output index.
+   *
+   * \return NDArray corresponding to given output node index.
+   */
+  NDArray GetOutput(int index) const;
+  /*!
+   * \brief Copy index-th output to data_out.
+   * \param index The output index.
+   * \param data_out the output data.
+   */
+  void CopyOutputTo(int index, DLTensor* data_out);
+
+ private:
+  /*! \brief Metadata provided to the runtime from the compiler. */
+  metadata::Metadata metadata_;
+
+  /*! \brief Runtime module which contains the AOT top-level function. */
+  Module module_;
+
+  /*! \brief The devices which should be used to execute the computations. */
+  std::vector<Device> devices_;
+
+  /*! \brief Holds one NDArray per function argument in the same order. */
+  std::vector<NDArray> args_;
+};
+
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_H_

--- a/src/runtime/aot_executor/aot_executor_factory.cc
+++ b/src/runtime/aot_executor/aot_executor_factory.cc
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file aot_executor_factory.cc
+ * \brief Graph executor factory implementations
+ */
+
+#include "./aot_executor_factory.h"
+
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/device_api.h>
+#include <tvm/runtime/registry.h>
+
+#include <iterator>
+#include <vector>
+
+namespace tvm {
+namespace runtime {
+
+AotExecutorFactory::AotExecutorFactory(
+    const std::unordered_map<std::string, tvm::runtime::NDArray>& params,
+    const std::string& module_name) {
+  params_ = params;
+  module_name_ = module_name;
+}
+
+PackedFunc AotExecutorFactory::GetFunction(
+    const std::string& name, const tvm::runtime::ObjectPtr<tvm::runtime::Object>& sptr_to_self) {
+  if (name == module_name_) {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      ICHECK_GT(args.num_args, 0) << "Must supply at least one device argument";
+      std::vector<Device> devices;
+      for (int i = 0; i < args.num_args; ++i) {
+        devices.emplace_back(args[i].operator Device());
+      }
+      *rv = this->ExecutorCreate(devices);
+    });
+  } else if (name == "remove_params") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      std::unordered_map<std::string, tvm::runtime::NDArray> empty_params{};
+      auto exec = make_object<AotExecutorFactory>(empty_params, this->module_name_);
+      exec->Import(this->imports_[0]);
+      *rv = Module(exec);
+    });
+  } else {
+    return PackedFunc();
+  }
+}
+
+void AotExecutorFactory::SaveToBinary(dmlc::Stream* stream) {
+  std::vector<std::string> names;
+  std::vector<DLTensor*> arrays;
+  for (const auto& v : params_) {
+    names.emplace_back(v.first);
+    arrays.emplace_back(const_cast<DLTensor*>(v.second.operator->()));
+  }
+  uint64_t sz = arrays.size();
+  ICHECK(sz == names.size());
+  stream->Write(sz);
+  stream->Write(names);
+  for (size_t i = 0; i < sz; ++i) {
+    tvm::runtime::SaveDLTensor(stream, arrays[i]);
+  }
+  stream->Write(module_name_);
+}
+
+Module AotExecutorFactory::ExecutorCreate(const std::vector<Device>& devs) {
+  auto exec = make_object<AotExecutor>(this->imports_[0], devs);
+  // set params
+  SetParams(exec.get(), this->params_);
+  return Module(exec);
+}
+
+Module AotExecutorFactoryModuleLoadBinary(void* strm) {
+  dmlc::Stream* stream = static_cast<dmlc::Stream*>(strm);
+  std::unordered_map<std::string, tvm::runtime::NDArray> params;
+  std::string module_name;
+  uint64_t sz;
+  ICHECK(stream->Read(&sz));
+  std::vector<std::string> names;
+  ICHECK(stream->Read(&names));
+  ICHECK(sz == names.size());
+  for (size_t i = 0; i < sz; ++i) {
+    tvm::runtime::NDArray temp;
+    temp.Load(stream);
+    params[names[i]] = temp;
+  }
+  ICHECK(stream->Read(&module_name));
+  auto exec = make_object<AotExecutorFactory>(params, module_name);
+  return Module(exec);
+}
+
+TVM_REGISTER_GLOBAL("tvm.aot_executor_factory.create")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      ICHECK_GE(args.num_args, 2) << "The expected number of arguments for "
+                                     "aot_executor_factory.create needs at least 2, "
+                                     "but it has "
+                                  << args.num_args;
+      // The argument order is module, module_name, param0_name, param0_tensor,
+      // [param1_name, param1_tensor], ...
+      ICHECK_EQ((args.size() - 2) % 2, 0);
+      std::unordered_map<std::string, tvm::runtime::NDArray> params;
+      for (size_t i = 2; i < static_cast<size_t>(args.size()); i += 2) {
+        std::string name = args[i].operator String();
+        params[name] = args[i + 1].operator tvm::runtime::NDArray();
+      }
+      auto exec = make_object<AotExecutorFactory>(params, args[1]);
+      exec->Import(args[0]);
+      *rv = Module(exec);
+    });
+
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_AotExecutorFactory")
+    .set_body_typed(AotExecutorFactoryModuleLoadBinary);
+
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/aot_executor/aot_executor_factory.cc
+++ b/src/runtime/aot_executor/aot_executor_factory.cc
@@ -107,24 +107,23 @@ Module AotExecutorFactoryModuleLoadBinary(void* strm) {
   return Module(exec);
 }
 
-TVM_REGISTER_GLOBAL("tvm.aot_executor_factory.create")
-    .set_body([](TVMArgs args, TVMRetValue* rv) {
-      ICHECK_GE(args.num_args, 2) << "The expected number of arguments for "
-                                     "aot_executor_factory.create needs at least 2, "
-                                     "but it has "
-                                  << args.num_args;
-      // The argument order is module, module_name, param0_name, param0_tensor,
-      // [param1_name, param1_tensor], ...
-      ICHECK_EQ((args.size() - 2) % 2, 0);
-      std::unordered_map<std::string, tvm::runtime::NDArray> params;
-      for (size_t i = 2; i < static_cast<size_t>(args.size()); i += 2) {
-        std::string name = args[i].operator String();
-        params[name] = args[i + 1].operator tvm::runtime::NDArray();
-      }
-      auto exec = make_object<AotExecutorFactory>(params, args[1]);
-      exec->Import(args[0]);
-      *rv = Module(exec);
-    });
+TVM_REGISTER_GLOBAL("tvm.aot_executor_factory.create").set_body([](TVMArgs args, TVMRetValue* rv) {
+  ICHECK_GE(args.num_args, 2) << "The expected number of arguments for "
+                                 "aot_executor_factory.create needs at least 2, "
+                                 "but it has "
+                              << args.num_args;
+  // The argument order is module, module_name, param0_name, param0_tensor,
+  // [param1_name, param1_tensor], ...
+  ICHECK_EQ((args.size() - 2) % 2, 0);
+  std::unordered_map<std::string, tvm::runtime::NDArray> params;
+  for (size_t i = 2; i < static_cast<size_t>(args.size()); i += 2) {
+    std::string name = args[i].operator String();
+    params[name] = args[i + 1].operator tvm::runtime::NDArray();
+  }
+  auto exec = make_object<AotExecutorFactory>(params, args[1]);
+  exec->Import(args[0]);
+  *rv = Module(exec);
+});
 
 TVM_REGISTER_GLOBAL("runtime.module.loadbinary_AotExecutorFactory")
     .set_body_typed(AotExecutorFactoryModuleLoadBinary);

--- a/src/runtime/aot_executor/aot_executor_factory.h
+++ b/src/runtime/aot_executor/aot_executor_factory.h
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/runtime/aot_executor/aot_executor_factory.h
+ * \brief Aot executor factory creating aot executor.
+ */
+
+#ifndef TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_FACTORY_H_
+#define TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_FACTORY_H_
+
+#include <tvm/runtime/c_runtime_api.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "./aot_executor.h"
+
+namespace tvm {
+namespace runtime {
+
+class TVM_DLL AotExecutorFactory : public runtime::ModuleNode {
+ public:
+  /*!
+   * \brief Construct the AotExecutorFactory.
+   * \param params The params of aot.
+   * \param module_name The module name of aot.
+   */
+  AotExecutorFactory(const std::unordered_map<std::string, tvm::runtime::NDArray>& params,
+                     const std::string& module_name);
+
+  /*!
+   * \brief Get member function to front-end
+   * \param name The name of the function.
+   * \param sptr_to_self The pointer to the module node.
+   * \return The corresponding member function.
+   */
+  PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
+
+  /*!
+   * \return The type key of the executor.
+   */
+  const char* type_key() const override { return "AotExecutorFactory"; }
+
+  /*!
+   * \brief Save the module to binary stream.
+   * \param stream The binary stream to save to.
+   */
+  void SaveToBinary(dmlc::Stream* stream) override;
+
+  /*!
+   * \brief Create a specific executor module
+   * \param devs The device of the host and devices where the model will be
+   *  executed.
+   * \return created executor module
+   */
+  Module ExecutorCreate(const std::vector<Device>& devs);
+
+  /*!
+   * \brief Set params.
+   * \param aot_executor The aot executor we want to set the params into.
+   * \param params The aot params value we want to set.
+   */
+  void SetParams(AotExecutor* aot_executor,
+                 const std::unordered_map<std::string, tvm::runtime::NDArray>& params) const {
+    std::unordered_map<std::string, tvm::runtime::NDArray> value = params;
+    // upload big arrays first to avoid memory issue in rpc mode
+    std::vector<std::string> keys;
+    for (const auto& p : value) {
+      keys.emplace_back(p.first);
+    }
+    std::sort(std::begin(keys), std::end(keys),
+              [&](const std::string& lhs, const std::string& rhs) -> bool {
+                auto lhs_size = GetDataSize(*value[lhs].operator->());
+                auto rhs_size = GetDataSize(*value[rhs].operator->());
+                return lhs_size > rhs_size;
+              });
+    for (const auto& key : keys) {
+      int in_idx = aot_executor->GetInputIndex(key);
+      if (in_idx >= 0) {
+        aot_executor->SetInput(in_idx, const_cast<DLTensor*>(value[key].operator->()));
+      }
+    }
+  }
+
+ protected:
+  /*! \brief The params. */
+  std::unordered_map<std::string, tvm::runtime::NDArray> params_;
+  /*! \brief module name */
+  std::string module_name_;
+};
+
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_GRAPH_EXECUTOR_GRAPH_EXECUTOR_FACTORY_H_

--- a/src/runtime/aot_executor/aot_executor_factory.h
+++ b/src/runtime/aot_executor/aot_executor_factory.h
@@ -116,4 +116,4 @@ class TVM_DLL AotExecutorFactory : public runtime::ModuleNode {
 }  // namespace runtime
 }  // namespace tvm
 
-#endif  // TVM_RUNTIME_GRAPH_EXECUTOR_GRAPH_EXECUTOR_FACTORY_H_
+#endif  // TVM_RUNTIME_AOT_EXECUTOR_AOT_EXECUTOR_FACTORY_H_

--- a/src/runtime/const_loader_module.cc
+++ b/src/runtime/const_loader_module.cc
@@ -43,17 +43,17 @@ namespace runtime {
 
 /*!
  * \brief The metadata module is designed to manage initialization of the
- * imported submodules.
+ * imported submodules for the C++ runtime.
  */
-class MetadataModuleNode : public ModuleNode {
+class ConstLoaderModuleNode : public ModuleNode {
  public:
-  MetadataModuleNode(const std::unordered_map<std::string, NDArray>& metadata,
-                     const std::unordered_map<std::string, std::vector<std::string>>& sym_vars)
-      : metadata_(metadata), sym_vars_(sym_vars) {
+  ConstLoaderModuleNode(const std::unordered_map<std::string, NDArray>& const_var_ndarray,
+                        const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol)
+      : const_var_ndarray_(const_var_ndarray), const_vars_by_symbol_(const_vars_by_symbol) {
     // Only the related submodules are cached to reduce the number of runtime
     // symbol lookup for initialization. Otherwise, symbols/primitives in the
     // DSO module will also be cached but they never need to be initialized.
-    for (const auto& it : sym_vars_) {
+    for (const auto& it : const_vars_by_symbol_) {
       initialized_[it.first] = false;
     }
   }
@@ -78,7 +78,7 @@ class MetadataModuleNode : public ModuleNode {
     return PackedFunc(nullptr);
   }
 
-  const char* type_key() const { return "metadata"; }
+  const char* type_key() const { return "const_loader"; }
 
   /*!
    * \brief Get the list of metadata that is required by the given module.
@@ -87,11 +87,11 @@ class MetadataModuleNode : public ModuleNode {
    */
   Array<NDArray> GetRequiredMetadata(const std::string& symbol) {
     Array<NDArray> ret;
-    ICHECK_GT(sym_vars_.count(symbol), 0U) << "No symbol is recorded for " << symbol;
-    std::vector<std::string> vars = sym_vars_[symbol];
+    ICHECK_GT(const_vars_by_symbol_.count(symbol), 0U) << "No symbol is recorded for " << symbol;
+    std::vector<std::string> vars = const_vars_by_symbol_[symbol];
     for (const auto& it : vars) {
-      ICHECK_GT(metadata_.count(it), 0U) << "Found not recorded constant variable: " << it;
-      ret.push_back(metadata_[it]);
+      ICHECK_GT(const_var_ndarray_.count(it), 0U) << "Found not recorded constant variable: " << it;
+      ret.push_back(const_var_ndarray_[it]);
     }
     return ret;
   }
@@ -102,7 +102,7 @@ class MetadataModuleNode : public ModuleNode {
    * for runtime lookup.
    *
    * \note  A module could be like the following:
-   *  MetadataModuleNode (contains all the metadata)
+   *  ConstLoaderModuleNode (contains all the metadata)
    *    - CSourceModule
    *    - JSON runtime module
    *
@@ -128,32 +128,32 @@ class MetadataModuleNode : public ModuleNode {
 
   void SaveToBinary(dmlc::Stream* stream) final {
     std::vector<std::string> variables;
-    std::vector<NDArray> metadata;
-    for (const auto& it : metadata_) {
+    std::vector<NDArray> const_var_ndarray;
+    for (const auto& it : const_var_ndarray_) {
       String var_name = it.first;
       variables.push_back(var_name);
-      metadata.push_back(it.second);
+      const_var_ndarray.push_back(it.second);
     }
 
     // Save all variables in the function.
     stream->Write(variables);
     // Save all constant data.
-    uint64_t sz = static_cast<uint64_t>(metadata.size());
+    uint64_t sz = static_cast<uint64_t>(const_var_ndarray.size());
     stream->Write(sz);
     for (uint64_t i = 0; i < sz; i++) {
-      metadata[i].Save(stream);
+      const_var_ndarray[i].Save(stream);
     }
 
     // Save the symbol to list of required constant variables mapping
     std::vector<std::string> symbols;
     std::vector<std::vector<std::string>> const_vars;
-    for (const auto& it : sym_vars_) {
+    for (const auto& it : const_vars_by_symbol_) {
       symbols.push_back(it.first);
       const_vars.push_back(it.second);
     }
 
     stream->Write(symbols);
-    sz = static_cast<uint64_t>(sym_vars_.size());
+    sz = static_cast<uint64_t>(const_vars_by_symbol_.size());
     stream->Write(sz);
     for (uint64_t i = 0; i < sz; i++) {
       stream->Write(const_vars[i]);
@@ -165,9 +165,9 @@ class MetadataModuleNode : public ModuleNode {
 
     // Load the variables.
     std::vector<std::string> variables;
-    ICHECK(stream->Read(&variables)) << "Loading variables failed";
+    ICHECK(stream->Read(&variables)) << "Loading variable names failed";
     uint64_t sz;
-    ICHECK(stream->Read(&sz, sizeof(sz))) << "Loading metadata size failed";
+    ICHECK(stream->Read(&sz, sizeof(sz))) << "Loading number of vars failed";
     ICHECK_EQ(static_cast<size_t>(sz), variables.size())
         << "The number of variables and ndarray counts must match";
     // Load the list of ndarray.
@@ -178,10 +178,10 @@ class MetadataModuleNode : public ModuleNode {
       arrays.push_back(temp);
     }
 
-    std::unordered_map<std::string, NDArray> metadata;
+    std::unordered_map<std::string, NDArray> const_var_ndarray;
     for (uint64_t i = 0; i < sz; i++) {
-      ICHECK_EQ(metadata.count(variables[i]), 0U);
-      metadata[variables[i]] = arrays[i];
+      ICHECK_EQ(const_var_ndarray.count(variables[i]), 0U);
+      const_var_ndarray[variables[i]] = arrays[i];
     }
 
     // Load the symbol to list of required constant variables mapping
@@ -196,12 +196,12 @@ class MetadataModuleNode : public ModuleNode {
       const_vars.push_back(vars);
     }
 
-    std::unordered_map<std::string, std::vector<std::string>> sym_vars;
+    std::unordered_map<std::string, std::vector<std::string>> const_vars_by_symbol;
     for (uint64_t i = 0; i < sz; i++) {
-      sym_vars[symbols[i]] = const_vars[i];
+      const_vars_by_symbol[symbols[i]] = const_vars[i];
     }
 
-    auto n = make_object<MetadataModuleNode>(metadata, sym_vars);
+    auto n = make_object<ConstLoaderModuleNode>(const_var_ndarray, const_vars_by_symbol);
     return Module(n);
   }
 
@@ -212,19 +212,21 @@ class MetadataModuleNode : public ModuleNode {
    */
   std::unordered_map<std::string, bool> initialized_;
   /*! \brief Variable name to NDArray mapping. */
-  std::unordered_map<std::string, NDArray> metadata_;
+  std::unordered_map<std::string, NDArray> const_var_ndarray_;
   /*! \brief Symbol name to required constant variables mapping. */
-  std::unordered_map<std::string, std::vector<std::string>> sym_vars_;
+  std::unordered_map<std::string, std::vector<std::string>> const_vars_by_symbol_;
 };
 
-Module MetadataModuleCreate(
-    const std::unordered_map<std::string, NDArray>& metadata,
-    const std::unordered_map<std::string, std::vector<std::string>>& sym_vars) {
-  auto n = make_object<MetadataModuleNode>(metadata, sym_vars);
+Module ConstLoaderModuleCreate(
+    const std::unordered_map<std::string, NDArray>& const_var_ndarray,
+    const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol) {
+  auto n = make_object<ConstLoaderModuleNode>(const_var_ndarray, const_vars_by_symbol);
   return Module(n);
 }
 
 TVM_REGISTER_GLOBAL("runtime.module.loadbinary_metadata")
-    .set_body_typed(MetadataModuleNode::LoadFromBinary);
+    .set_body_typed(ConstLoaderModuleNode::LoadFromBinary);
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_const_loader")
+    .set_body_typed(ConstLoaderModuleNode::LoadFromBinary);
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/const_loader_module.cc
+++ b/src/runtime/const_loader_module.cc
@@ -47,8 +47,9 @@ namespace runtime {
  */
 class ConstLoaderModuleNode : public ModuleNode {
  public:
-  ConstLoaderModuleNode(const std::unordered_map<std::string, NDArray>& const_var_ndarray,
-                        const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol)
+  ConstLoaderModuleNode(
+      const std::unordered_map<std::string, NDArray>& const_var_ndarray,
+      const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol)
       : const_var_ndarray_(const_var_ndarray), const_vars_by_symbol_(const_vars_by_symbol) {
     // Only the related submodules are cached to reduce the number of runtime
     // symbol lookup for initialization. Otherwise, symbols/primitives in the

--- a/src/runtime/const_loader_module.h
+++ b/src/runtime/const_loader_module.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file const_loader_module.h
+ * \brief Defines an interface to use the ConstLoaderModule.
+ */
+
+#ifndef TVM_RUNTIME_CONST_LOADER_MODULE_H_
+#define TVM_RUNTIME_CONST_LOADER_MODULE_H_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <tvm/runtime/ndarray.h>
+
+namespace tvm {
+namespace runtime {
+
+/*!
+ * \brief Create a ConstLoader module object.
+ *
+ * \param const_var_ndarray Maps consts var name to NDArray containing data for the var.
+ * \param const_vars_by_symbol Maps the name of a module init function to a list of names of
+ * const vars whose data will be passed to that init function.
+ *
+ * \return The created ConstLoaderModule.
+ */
+Module ConstLoaderModuleCreate(
+    const std::unordered_map<std::string, NDArray>& const_var_ndarray,
+    const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol);
+
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_CONST_LOADER_MODULE_H_

--- a/src/runtime/const_loader_module.h
+++ b/src/runtime/const_loader_module.h
@@ -25,10 +25,11 @@
 #ifndef TVM_RUNTIME_CONST_LOADER_MODULE_H_
 #define TVM_RUNTIME_CONST_LOADER_MODULE_H_
 
+#include <tvm/runtime/ndarray.h>
+
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <tvm/runtime/ndarray.h>
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -27,6 +27,7 @@
 #include <dmlc/io.h>
 #include <dmlc/json.h>
 #include <tvm/runtime/executor_info.h>
+#include <tvm/runtime/metadata.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/packed_func.h>
@@ -35,8 +36,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <tvm/runtime/metadata.h>
 
 #include "runtime_base.h"
 
@@ -65,7 +64,7 @@ namespace launch_param {
 /*! \brief A tag to specify whether or not dynamic shared memory is used */
 constexpr const char* kUseDynamicSharedMemoryTag = "tir.use_dyn_shared_memory";
 
-}
+}  // namespace launch_param
 
 /*! \brief function information needed by device */
 struct FunctionInfo {

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -49,53 +49,6 @@ inline String get_name_mangled(const String& module_name, const String& name) {
   return ss.str();
 }
 
-/*!
- * \brief Structure that can be optionally used by the executor codegen
- */
-class MetadataNode : public Object {
- public:
-  /*! \brief input information for the main function */
-  Array<String> inputs;
-  /*! \brief number of outputs of the main function */
-  int num_outputs = 1;
-  /*! \brief device contexts information for the main function */
-  Array<String> devices;
-  /*! \brief the executor to be used to run the model */
-  String executor = kTvmExecutorGraph;
-  /*! \brief The external API (packed or c) in use */
-  String interface_api;
-  /*! \brief The internal API (packed or unpacked) in use */
-  bool unpacked_api;
-
-  String mod_name = "";
-
-  static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
-  static constexpr const char* _type_key = "MetadataObj";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MetadataNode, Object);
-};
-
-/*!
- * \brief Managed reference to MetadataNode.
- */
-class Metadata : public ObjectRef {
- public:
-  TVM_DLL Metadata(Array<String> inputs, Array<String> devices, int num_outputs, String executor,
-                   String mod_name, String interface_api = "packed", bool unpacked_api = false) {
-    auto n = make_object<MetadataNode>();
-    n->inputs = inputs;
-    n->devices = devices;
-    n->num_outputs = num_outputs;
-    n->executor = executor;
-    n->interface_api = interface_api;
-    n->unpacked_api = unpacked_api;
-    n->mod_name = mod_name;
-    data_ = std::move(n);
-  }
-
-  TVM_DEFINE_OBJECT_REF_METHODS(Metadata, ObjectRef, MetadataNode);
-  TVM_DEFINE_OBJECT_REF_COW_METHOD(MetadataNode);
-};
-
 /*! \brief A tag to specify whether or not dynamic shared memory is used */
 constexpr const char* kUseDynamicSharedMemoryTag = "tir.use_dyn_shared_memory";
 

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -36,6 +36,8 @@
 #include <utility>
 #include <vector>
 
+#include <tvm/runtime/metadata.h>
+
 #include "runtime_base.h"
 
 namespace tvm {
@@ -48,6 +50,15 @@ inline String get_name_mangled(const String& module_name, const String& name) {
   ss << module_name << "_" << name;
   return ss.str();
 }
+
+/*!
+ * \brief Create a metadata module object.
+ *
+ * \param metadata Exported metadata structure.
+ *
+ * \return The created metadata module.
+ */
+Module MetadataModuleCreate(metadata::Metadata metadata);
 
 /*! \brief A tag to specify whether or not dynamic shared memory is used */
 constexpr const char* kUseDynamicSharedMemoryTag = "tir.use_dyn_shared_memory";

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -60,8 +60,12 @@ inline String get_name_mangled(const String& module_name, const String& name) {
  */
 Module MetadataModuleCreate(metadata::Metadata metadata);
 
+namespace launch_param {
+
 /*! \brief A tag to specify whether or not dynamic shared memory is used */
 constexpr const char* kUseDynamicSharedMemoryTag = "tir.use_dyn_shared_memory";
+
+}
 
 /*! \brief function information needed by device */
 struct FunctionInfo {

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -96,19 +96,6 @@ class Metadata : public ObjectRef {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MetadataNode);
 };
 
-/*!
- * \brief Create a metadata module object.
- *
- * \param metadata The variable name to ndarray mapping.
- * \param sym_vars The symbol to the list of required constant variables
- * mapping.
- *
- * \return The created metadata module.
- */
-Module MetadataModuleCreate(
-    const std::unordered_map<std::string, NDArray>& metadata,
-    const std::unordered_map<std::string, std::vector<std::string>>& sym_vars);
-
 /*! \brief A tag to specify whether or not dynamic shared memory is used */
 constexpr const char* kUseDynamicSharedMemoryTag = "tir.use_dyn_shared_memory";
 

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -22,17 +22,19 @@
  * \brief Defines implementations of TVM metadata which can exist in the runtime.
  */
 
-#include <string>
 #include <tvm/runtime/c_backend_api.h>
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/metadata.h>
 #include <tvm/runtime/registry.h>
 
+#include <string>
+
 namespace tvm {
 namespace runtime {
 namespace metadata {
 
-MetadataArray::MetadataArray(Array<ObjectRef> array, const char* c_type) : MetadataBase{make_object<MetadataArrayNode>(array, c_type)} {}
+MetadataArray::MetadataArray(Array<ObjectRef> array, const char* c_type)
+    : MetadataBase{make_object<MetadataArrayNode>(array, c_type)} {}
 
 std::string MetadataArrayNode::get_name() { return "MetadataArray"; }
 
@@ -40,35 +42,45 @@ TVM_REGISTER_OBJECT_TYPE(MetadataBaseNode);
 TVM_REGISTER_OBJECT_TYPE(MetadataArrayNode);
 
 ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::inputs() {
-  if (inputs_refs_.get() == nullptr) { inputs_refs_.reset(new ::std::vector<TensorInfo>()); }
-  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->inputs, data_->num_inputs, inputs_refs_);
+  if (inputs_refs_.get() == nullptr) {
+    inputs_refs_.reset(new ::std::vector<TensorInfo>());
+  }
+  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->inputs, data_->num_inputs,
+                                                         inputs_refs_);
 }
 ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::outputs() {
-  if (outputs_refs_.get() == nullptr) { outputs_refs_.reset(new ::std::vector<TensorInfo>()); }
-  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->outputs, data_->num_outputs, outputs_refs_);
+  if (outputs_refs_.get() == nullptr) {
+    outputs_refs_.reset(new ::std::vector<TensorInfo>());
+  }
+  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->outputs, data_->num_outputs,
+                                                         outputs_refs_);
 }
 ArrayAccessor<const char*, ::tvm::runtime::String> MetadataNode::devices() {
-  if (devices_refs_.get() == nullptr) { devices_refs_.reset(new ::std::vector<::tvm::runtime::String>()); }
-  return ArrayAccessor<const char*, ::tvm::runtime::String>(data_->devices, data_->num_devices, devices_refs_);
+  if (devices_refs_.get() == nullptr) {
+    devices_refs_.reset(new ::std::vector<::tvm::runtime::String>());
+  }
+  return ArrayAccessor<const char*, ::tvm::runtime::String>(data_->devices, data_->num_devices,
+                                                            devices_refs_);
 }
-Metadata::Metadata(const struct ::TVMMetadata* data) :
-    MetadataBase{make_object<MetadataNode>(data)} {}
+Metadata::Metadata(const struct ::TVMMetadata* data)
+    : MetadataBase{make_object<MetadataNode>(data)} {}
 std::string MetadataNode::get_name() { return std::string{"Metadata"}; }
 TVM_REGISTER_OBJECT_TYPE(MetadataNode);
-TensorInfo::TensorInfo(const struct ::TVMTensorInfo* data) :
-    MetadataBase{make_object<TensorInfoNode>(data)} {}
+TensorInfo::TensorInfo(const struct ::TVMTensorInfo* data)
+    : MetadataBase{make_object<TensorInfoNode>(data)} {}
 std::string TensorInfoNode::get_name() { return std::string{"TensorInfo"}; }
 
 }  // namespace metadata
 
 class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
  public:
-  MetadataModuleNode(runtime::metadata::Metadata metadata) {
+  explicit MetadataModuleNode(runtime::metadata::Metadata metadata) {
     // CHECK((metadata.defined() && code.size() > 0) || (!metadata.defined() && code.size() == 0))
-    //   << "metadata and code must both be either defined (when passed from compiler) or undefined "
+    //   << "metadata and code must both be either defined (when passed from compiler) or undefined
+    //   "
     //   << "(when passed from runtime)";
     metadata_ = metadata;
-//    code_ = code;
+    //    code_ = code;
   }
 
   const char* type_key() const { return "metadata_module"; }
@@ -92,10 +104,12 @@ class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
           ret_code = TVMFuncCall(f_handle, nullptr, nullptr, 0, &ret_value, &ret_type_code);
           CHECK_EQ(ret_code, 0) << "Invoking get_c_metadata: TVMFuncCall returned " << ret_code;
 
-          CHECK_EQ(ret_type_code, kTVMOpaqueHandle) << "Expected kOpaqueHandle returned; got " << ret_type_code;
+          CHECK_EQ(ret_type_code, kTVMOpaqueHandle)
+              << "Expected kOpaqueHandle returned; got " << ret_type_code;
           CHECK(ret_value.v_handle != nullptr) << "get_c_metadata returned nullptr";
 
-          metadata_ = runtime::metadata::Metadata(static_cast<const struct ::TVMMetadata*>(ret_value.v_handle));
+          metadata_ = runtime::metadata::Metadata(
+              static_cast<const struct ::TVMMetadata*>(ret_value.v_handle));
         }
 
         *rv = metadata_;
@@ -115,7 +129,7 @@ Module MetadataModuleCreate(metadata::Metadata metadata) {
 }
 
 TVM_REGISTER_GLOBAL("runtime.module.loadbinary_metadata_module")
-.set_body([](TVMArgs args, TVMRetValue* rv) { *rv = MetadataModuleNode::LoadFromBinary(); });
+    .set_body([](TVMArgs args, TVMRetValue* rv) { *rv = MetadataModuleNode::LoadFromBinary(); });
 
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file metadata.cc
+ * \brief Implementations of the runtime component of Metadata.
+ */
+
+#include <tvm/runtime/metadata.h>
+
+namespace tvm {
+namespace runtime {
+namespace metadata {
+
+ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::inputs() {
+  if (inputs_refs_.get() == nullptr) { inputs_refs_.reset(new ::std::vector<TensorInfo>()); }
+  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->inputs, data_->num_inputs, inputs_refs_);
+}
+ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::outputs() {
+  if (outputs_refs_.get() == nullptr) { outputs_refs_.reset(new ::std::vector<TensorInfo>()); }
+  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->outputs, data_->num_outputs, outputs_refs_);
+}
+ArrayAccessor<const char*, ::tvm::runtime::String> MetadataNode::devices() {
+  if (devices_refs_.get() == nullptr) { devices_refs_.reset(new ::std::vector<::tvm::runtime::String>()); }
+  return ArrayAccessor<const char*, ::tvm::runtime::String>(data_->devices, data_->num_devices, devices_refs_);
+}
+Metadata::Metadata(const struct ::TVMMetadata* data) :
+    MetadataBase{make_object<MetadataNode>(data)} {}
+std::string MetadataNode::get_name() { return std::string{"Metadata"}; }
+TVM_REGISTER_OBJECT_TYPE(MetadataNode);
+TensorInfo::TensorInfo(const struct ::TVMTensorInfo* data) :
+    MetadataBase{make_object<TensorInfoNode>(data)} {}
+std::string TensorInfoNode::get_name() { return std::string{"TensorInfo"}; }
+TVM_REGISTER_OBJECT_TYPE(TensorInfoNode);
+
+}  // namespace metadata
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -33,8 +33,8 @@ namespace tvm {
 namespace runtime {
 namespace metadata {
 
-MetadataArray::MetadataArray(Array<ObjectRef> array, const char* c_type)
-    : MetadataBase{make_object<MetadataArrayNode>(array, c_type)} {}
+MetadataArray::MetadataArray(Array<ObjectRef> array, MetadataTypeIndex type_index, const char* struct_name)
+    : MetadataBase{make_object<MetadataArrayNode>(array, type_index, struct_name)} {}
 
 std::string MetadataArrayNode::get_name() { return "MetadataArray"; }
 

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -18,15 +18,26 @@
  */
 
 /*!
- * \file metadata.cc
- * \brief Implementations of the runtime component of Metadata.
+ * \file tvm/runtime/metadata.h
+ * \brief Defines implementations of TVM metadata which can exist in the runtime.
  */
 
+#include <string>
+#include <tvm/runtime/c_backend_api.h>
+#include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/metadata.h>
+#include <tvm/runtime/registry.h>
 
 namespace tvm {
 namespace runtime {
 namespace metadata {
+
+MetadataArray::MetadataArray(Array<ObjectRef> array, const char* c_type) : MetadataBase{make_object<MetadataArrayNode>(array, c_type)} {}
+
+std::string MetadataArrayNode::get_name() { return "MetadataArray"; }
+
+TVM_REGISTER_OBJECT_TYPE(MetadataBaseNode);
+TVM_REGISTER_OBJECT_TYPE(MetadataArrayNode);
 
 ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::inputs() {
   if (inputs_refs_.get() == nullptr) { inputs_refs_.reset(new ::std::vector<TensorInfo>()); }
@@ -47,8 +58,64 @@ TVM_REGISTER_OBJECT_TYPE(MetadataNode);
 TensorInfo::TensorInfo(const struct ::TVMTensorInfo* data) :
     MetadataBase{make_object<TensorInfoNode>(data)} {}
 std::string TensorInfoNode::get_name() { return std::string{"TensorInfo"}; }
-TVM_REGISTER_OBJECT_TYPE(TensorInfoNode);
 
 }  // namespace metadata
+
+class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
+ public:
+  MetadataModuleNode(runtime::metadata::Metadata metadata) {
+    // CHECK((metadata.defined() && code.size() > 0) || (!metadata.defined() && code.size() == 0))
+    //   << "metadata and code must both be either defined (when passed from compiler) or undefined "
+    //   << "(when passed from runtime)";
+    metadata_ = metadata;
+//    code_ = code;
+  }
+
+  const char* type_key() const { return "metadata_module"; }
+
+  static Module LoadFromBinary() {
+    return Module(make_object<MetadataModuleNode>(runtime::metadata::Metadata()));
+  }
+
+  void SaveToBinary(dmlc::Stream* stream) final {}
+
+  PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) {
+    if (name == "get_metadata") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        if (!metadata_.defined()) {
+          TVMFunctionHandle f_handle;
+          int32_t ret_code = TVMBackendGetFuncFromEnv(this, "get_c_metadata", &f_handle);
+          CHECK_EQ(ret_code, 0) << "Unable to locate get_c_metadata PackedFunc";
+
+          TVMValue ret_value;
+          int ret_type_code;
+          ret_code = TVMFuncCall(f_handle, nullptr, nullptr, 0, &ret_value, &ret_type_code);
+          CHECK_EQ(ret_code, 0) << "Invoking get_c_metadata: TVMFuncCall returned " << ret_code;
+
+          CHECK_EQ(ret_type_code, kTVMOpaqueHandle) << "Expected kOpaqueHandle returned; got " << ret_type_code;
+          CHECK(ret_value.v_handle != nullptr) << "get_c_metadata returned nullptr";
+
+          metadata_ = runtime::metadata::Metadata(static_cast<const struct ::TVMMetadata*>(ret_value.v_handle));
+        }
+
+        *rv = metadata_;
+        return;
+      });
+    }
+
+    return PackedFunc();
+  }
+
+ private:
+  runtime::metadata::Metadata metadata_;
+};
+
+Module MetadataModuleCreate(metadata::Metadata metadata) {
+  return Module(make_object<MetadataModuleNode>(metadata));
+}
+
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_metadata_module")
+.set_body([](TVMArgs args, TVMRetValue* rv) { *rv = MetadataModuleNode::LoadFromBinary(); });
+
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -42,25 +42,13 @@ TVM_REGISTER_OBJECT_TYPE(MetadataBaseNode);
 TVM_REGISTER_OBJECT_TYPE(MetadataArrayNode);
 
 ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::inputs() {
-  if (inputs_refs_.get() == nullptr) {
-    inputs_refs_.reset(new ::std::vector<TensorInfo>());
-  }
-  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->inputs, data_->num_inputs,
-                                                         inputs_refs_);
+  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->inputs, data_->num_inputs);
 }
 ArrayAccessor<struct TVMTensorInfo, TensorInfo> MetadataNode::outputs() {
-  if (outputs_refs_.get() == nullptr) {
-    outputs_refs_.reset(new ::std::vector<TensorInfo>());
-  }
-  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->outputs, data_->num_outputs,
-                                                         outputs_refs_);
+  return ArrayAccessor<struct TVMTensorInfo, TensorInfo>(data_->outputs, data_->num_outputs);
 }
 ArrayAccessor<const char*, ::tvm::runtime::String> MetadataNode::devices() {
-  if (devices_refs_.get() == nullptr) {
-    devices_refs_.reset(new ::std::vector<::tvm::runtime::String>());
-  }
-  return ArrayAccessor<const char*, ::tvm::runtime::String>(data_->devices, data_->num_devices,
-                                                            devices_refs_);
+  return ArrayAccessor<const char*, ::tvm::runtime::String>(data_->devices, data_->num_devices);
 }
 Metadata::Metadata(const struct ::TVMMetadata* data)
     : MetadataBase{make_object<MetadataNode>(data)} {}

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -24,6 +24,7 @@
 #ifndef TVM_RUNTIME_THREAD_STORAGE_SCOPE_H_
 #define TVM_RUNTIME_THREAD_STORAGE_SCOPE_H_
 
+#include <tvm/runtime/metadata.h>
 #include <tvm/runtime/packed_func.h>
 
 #include <string>
@@ -205,7 +206,7 @@ class LaunchParamConfig {
     std::vector<bool> filled(6, false);
     for (size_t i = 0; i < launch_param_tags.size(); ++i) {
       const std::string& tag = launch_param_tags[i];
-      if (tag == kUseDynamicSharedMemoryTag) {
+      if (tag == launch_param::kUseDynamicSharedMemoryTag) {
         ICHECK_EQ(i, launch_param_tags.size() - 1)
             << "kUseDynamicSharedMemoryTag should be the last tag in launch_param_tags.";
         use_dyn_shared_memory_ = true;

--- a/src/target/build_common.h
+++ b/src/target/build_common.h
@@ -58,7 +58,7 @@ inline std::unordered_map<std::string, runtime::FunctionInfo> ExtractFuncInfo(co
     }
     if (auto opt = f->GetAttr<Integer>(tir::attr::kDeviceUseDynSharedMemory)) {
       if (opt.value()) {
-        info.launch_param_tags.push_back(runtime::kUseDynamicSharedMemoryTag);
+        info.launch_param_tags.push_back(runtime::launch_param::kUseDynamicSharedMemoryTag);
       }
     }
     auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol);

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -121,9 +121,9 @@ class CodeGenCPU : public CodeGenLLVM {
     llvm::BasicBlock* end_block;
   };
   PackedCall MakeCallPackedLowered(const Array<PrimExpr>& args, const DataType& r_type,
-                                   const int64_t begin, const int64_t end);
+                                   const int64_t begin, const int64_t end, bool use_string_lookup);
   // create call into tvm packed function.
-  llvm::Value* CreateCallPacked(const CallNode* op);
+  llvm::Value* CreateCallPacked(const CallNode* op, bool use_string_lookup);
   // Create trace call into tvm packed function.
   llvm::Value* CreateCallTracePacked(const CallNode* op);
   // Create static initialization

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -56,6 +56,11 @@ class CodeGenCPU : public CodeGenLLVM {
    */
   void DefineFunctionRegistry(Array<String> func_names);
 
+  /*!
+   * \brief Serialize the metadata object as data, and implement get_c_metadata function.
+   * \param metadata The metadata which should be serialized.
+   */
+  void DefineMetadata(runtime::metadata::Metadata metadata);
  protected:
   void AddStartupFunction() final;
   // meta data

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1261,7 +1261,11 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const LoadNode* op) {
 llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
   if (auto* ptr_op = op->op.as<OpNode>()) {
     auto call_op = GetRef<Op>(ptr_op);
-    if (op->op.same_as(builtin_call_extern_) || op->op.same_as(builtin_call_pure_extern_)) {
+    if (op->op.same_as(builtin_tvm_call_cpacked_lowered_)) {
+      auto global_symbol = Downcast<StringImm>(op->args[0]);
+      return this->CreateCallExtern(GetType(GetRef<PrimExpr>(op)), global_symbol->value, op->args,
+                                    true);
+    } else if (op->op.same_as(builtin_call_extern_) || op->op.same_as(builtin_call_pure_extern_)) {
       // call extern intrinsic
       ICHECK_GE(op->args.size(), 1U);
       auto global_symbol = Downcast<StringImm>(op->args[0]);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -190,6 +190,18 @@ void CodeGenLLVM::AddFunctionInternal(const PrimFunc& f, bool ret_void) {
   }
 }
 
+llvm::GlobalVariable* CodeGenLLVM::GetLinkedParamSymbol(const std::string& param_name, llvm::ConstantArray* array) {
+  std::string symbol_name = std::string(::tvm::runtime::symbol::tvm_param_prefix) + param_name;
+  llvm::GlobalVariable* var = module_->getGlobalVariable(symbol_name);
+  if (var == nullptr) {
+    var = new llvm::GlobalVariable(
+      *module_, t_void_p_, true, llvm::GlobalValue::CommonLinkage, nullptr, symbol_name);
+  }
+  //(array != nullptr ? static_cast<llvm::Type*>(array->getType()) : static_cast<llvm::Type*>(t_void_p_)),
+  return var;
+}
+
+
 void CodeGenLLVM::LinkParameters(const Map<String, LinkedParam> params) {
   // It would be nice to de-dupe these declarations frm src/tir/transforms/make_packed_api.cc,
   // but they are at a different layer in the compiler...
@@ -235,9 +247,7 @@ void CodeGenLLVM::LinkParameters(const Map<String, LinkedParam> params) {
   // Add data to the global section.
   for (auto kv : params) {
     auto array = NDArrayToLLVMArray(ctx_, kv.second->param);
-    std::string symbol_name = std::string(::tvm::runtime::symbol::tvm_param_prefix) + kv.first;
-    llvm::GlobalVariable* param_symbol = new llvm::GlobalVariable(
-        *module_, array->getType(), true, llvm::GlobalValue::ExternalLinkage, array, symbol_name);
+    llvm::GlobalVariable* param_symbol = GetLinkedParamSymbol(kv.first, array);
     auto dtype = tvm::runtime::DataType(kv.second->param->dtype);
     size_t align = std::max(tvm::runtime::GetVectorBytes(dtype), tvm::runtime::kAllocAlignment);
 #if TVM_LLVM_VERSION >= 100
@@ -245,8 +255,9 @@ void CodeGenLLVM::LinkParameters(const Map<String, LinkedParam> params) {
 #else
     param_symbol->setAlignment(align);
 #endif
+    param_symbol->setInitializer(array);
 
-    llvm::BasicBlock* case_block = llvm::BasicBlock::Create(*ctx_, "case_" + symbol_name, function);
+    llvm::BasicBlock* case_block = llvm::BasicBlock::Create(*ctx_, "case_" + param_symbol->getName(), function);
     switch_inst->addCase(
         llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(t_int64_, kv.second->id)), case_block);
     builder_->SetInsertPoint(case_block);
@@ -387,6 +398,10 @@ void CodeGenLLVM::Optimize() {
     fpass.run(*it);
   }
   fpass.doFinalization();
+  std::string tmp;
+  llvm::raw_string_ostream stream(tmp);
+  module_->print(stream, nullptr);
+  LOG(INFO) << "LLVM IR: " << stream.str();
   mpass.run(*module_);
 }
 
@@ -1266,8 +1281,8 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
       return this->CreateCallExtern(GetType(GetRef<PrimExpr>(op)), global_symbol->value, op->args,
                                     true);
     } else if (op->op.same_as(builtin_lookup_param_)) {
-      std::string symbol_name = std::string(::tvm::runtime::symbol::tvm_param_prefix) + Downcast<StringImm>(op->args[0])->value; //operator std::string();
-      return module_->getGlobalVariable(symbol_name);
+//      return llvm::ConstantInt::get(t_void_p_, 0);
+      return GetLinkedParamSymbol(Downcast<StringImm>(op->args[0])->value, nullptr);
     } else if (op->op.same_as(builtin_call_extern_) || op->op.same_as(builtin_call_pure_extern_)) {
       // call extern intrinsic
       ICHECK_GE(op->args.size(), 1U);
@@ -1279,7 +1294,10 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
       return this->CreateCallExtern(GetType(GetRef<PrimExpr>(op)), op_attr_global_symbol_[call_op],
                                     op->args, false);
     } else {
-      return CreateIntrinsic(op);
+      VLOG(2) << "CreateIntrinsic: " << GetRef<Call>(op);
+      auto x = CreateIntrinsic(op);
+      VLOG(2) << "CreateIntrinsic done";
+      return x;
     }
   } else {
     ICHECK(op->op.as<GlobalVarNode>());

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -392,6 +392,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   const Op& builtin_call_pure_extern_ = builtin::call_pure_extern();
   const Op& builtin_call_llvm_intrin_ = builtin::call_llvm_intrin();
   const Op& builtin_call_llvm_pure_intrin_ = builtin::call_llvm_pure_intrin();
+  const Op& builtin_tvm_call_cpacked_lowered_ = builtin::tvm_call_cpacked_lowered();
 
   /*! \brief Helper struct for debug infos. */
   struct DebugInfo {

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -187,6 +187,9 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   void VisitStmt_(const SeqStmtNode* op) override;
   void VisitStmt_(const EvaluateNode* op) override;
 
+  // Get constant string
+  llvm::Constant* GetConstString(const std::string& str);
+
  protected:
   /*!
    * \brief Address and type pair to assist in handling opaque pointers.
@@ -298,8 +301,6 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   // Get alignment given index.
   void GetAlignment(DataType t, const VarNode* buf_var, const PrimExpr& index, int* p_alignment,
                     int* p_native_bits);
-  // Get constant string
-  llvm::Constant* GetConstString(const std::string& str);
   // do a scalarize call with f
   llvm::Value* CreateScalarizedCall(const CallNode* op, llvm::Function* f,
                                     const std::vector<llvm::Value*>& args);

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -141,7 +141,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * \param e The expression to be created value for.
    * \return created value.
    */
-  llvm::Value* MakeValue(const PrimExpr& e) { auto a = VisitExpr(e); LOG(INFO) << "MakeValue (" << e << "): " << a; return a;  }
+  llvm::Value* MakeValue(const PrimExpr& e) { auto a = VisitExpr(e); /* LOG(INFO) << "MakeValue (" << e << "): " << a; */ return a;  }
   // Short hande code to get a constant int 32
   llvm::Constant* ConstInt32(int64_t value) const {
     return llvm::ConstantInt::getSigned(t_int32_, value);

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -392,6 +392,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   const Op& builtin_call_pure_extern_ = builtin::call_pure_extern();
   const Op& builtin_call_llvm_intrin_ = builtin::call_llvm_intrin();
   const Op& builtin_call_llvm_pure_intrin_ = builtin::call_llvm_pure_intrin();
+  const Op& builtin_lookup_param_ = builtin::lookup_param();
   const Op& builtin_tvm_call_cpacked_lowered_ = builtin::tvm_call_cpacked_lowered();
 
   /*! \brief Helper struct for debug infos. */

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -141,7 +141,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * \param e The expression to be created value for.
    * \return created value.
    */
-  llvm::Value* MakeValue(const PrimExpr& e) { return VisitExpr(e); }
+  llvm::Value* MakeValue(const PrimExpr& e) { auto a = VisitExpr(e); LOG(INFO) << "MakeValue (" << e << "): " << a; return a;  }
   // Short hande code to get a constant int 32
   llvm::Constant* ConstInt32(int64_t value) const {
     return llvm::ConstantInt::getSigned(t_int32_, value);
@@ -291,6 +291,13 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    */
   llvm::Function* GetIntrinsicDecl(llvm::Intrinsic::ID id, llvm::Type* ret_type,
                                    llvm::ArrayRef<llvm::Type*> arg_types);
+  /*!
+   * \brief Lookup or create a GlobalVariable whose content is the data field of a DLTensor for a
+   * given linked_param() CallNode.
+   * \param param_name Parameter name (e.g. unmangled, from lookup_param node).
+   * \return the GlobalVariable indicated in the brief.
+   */
+  llvm::GlobalVariable* GetLinkedParamSymbol(const ::std::string& param_name, llvm::ConstantArray* array);
   /*!
    * \brief Get the number of elements in the given vector value.
    * \param vec The value, must be of a vector type.

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -308,14 +308,14 @@ class LLVMModuleNode final : public runtime::ModuleNode {
 
     cg->SetFastMathFlag(fmf);
 
+    if (found_linked_params) {
+      cg->LinkParameters(linked_params);
+    }
     cg->AddFunctionsOrdered(funcs.begin(), funcs.end());
     if (entry_func.length() != 0) {
       cg->AddMainFunction(entry_func);
     }
 
-    if (found_linked_params) {
-      cg->LinkParameters(linked_params);
-    }
     module_ = cg->Finish();
     module_->addModuleFlag(llvm::Module::Warning, "tvm_target",
                            llvm::MDString::get(*ctx_, LLVMTargetToString(target)));

--- a/src/target/llvm/llvm_module.h
+++ b/src/target/llvm/llvm_module.h
@@ -33,6 +33,9 @@
 namespace tvm {
 namespace codegen {
 
+runtime::Module CreateLLVMCppMetadataModule(runtime::metadata::Metadata metadata, Target target,
+                                            tvm::relay::Runtime runtime);
+
 runtime::Module CreateLLVMCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
                                             tvm::relay::Runtime runtime);
 

--- a/src/target/metadata.cc
+++ b/src/target/metadata.cc
@@ -23,21 +23,24 @@
  */
 
 #include "metadata.h"
+
 #include <tvm/node/reflection.h>
 
 namespace tvm {
 namespace target {
 namespace metadata {
 
-TVM_REGISTER_REFLECTION_VTABLE(VisitableMetadataNode, ::tvm::detail::ReflectionTrait<VisitableMetadataNode>)
-.set_creator([](const std::string&) -> ObjectPtr<Object> {
-    return ::tvm::runtime::make_object<VisitableMetadataNode>();
-});
+TVM_REGISTER_REFLECTION_VTABLE(VisitableMetadataNode,
+                               ::tvm::detail::ReflectionTrait<VisitableMetadataNode>)
+    .set_creator([](const std::string&) -> ObjectPtr<Object> {
+      return ::tvm::runtime::make_object<VisitableMetadataNode>();
+    });
 
-TVM_REGISTER_REFLECTION_VTABLE(VisitableTensorInfoNode, ::tvm::detail::ReflectionTrait<VisitableTensorInfoNode>)
-.set_creator([](const std::string&) -> ObjectPtr<Object> {
-    return ::tvm::runtime::make_object<VisitableTensorInfoNode>();
-});
+TVM_REGISTER_REFLECTION_VTABLE(VisitableTensorInfoNode,
+                               ::tvm::detail::ReflectionTrait<VisitableTensorInfoNode>)
+    .set_creator([](const std::string&) -> ObjectPtr<Object> {
+      return ::tvm::runtime::make_object<VisitableTensorInfoNode>();
+    });
 
 }  // namespace metadata
 }  // namespace target

--- a/src/target/metadata.cc
+++ b/src/target/metadata.cc
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file metadata.cc
+ * \brief Implementations of the compiler extensions for Metadata.
+ */
+
+#include "metadata.h"
+#include <tvm/node/reflection.h>
+
+namespace tvm {
+namespace target {
+namespace metadata {
+
+TVM_REGISTER_REFLECTION_VTABLE(VisitableMetadataNode, ::tvm::detail::ReflectionTrait<VisitableMetadataNode>)
+.set_creator([](const std::string&) -> ObjectPtr<Object> {
+    return ::tvm::runtime::make_object<VisitableMetadataNode>();
+});
+
+TVM_REGISTER_REFLECTION_VTABLE(VisitableTensorInfoNode, ::tvm::detail::ReflectionTrait<VisitableTensorInfoNode>)
+.set_creator([](const std::string&) -> ObjectPtr<Object> {
+    return ::tvm::runtime::make_object<VisitableTensorInfoNode>();
+});
+
+}  // namespace metadata
+}  // namespace target
+}  // namespace tvm

--- a/src/target/metadata.h
+++ b/src/target/metadata.h
@@ -46,11 +46,13 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
     auto inputs_accessor = inputs();
     inputs_array.reserve(num_inputs());
     for (int64_t i = 0; i < num_inputs(); ++i) {
-      inputs_array.push_back(::tvm::runtime::metadata::TensorInfo{inputs_accessor[i]});
+      auto ti = ::tvm::runtime::metadata::TensorInfo{inputs_accessor[i]};
+      inputs_array.push_back(ti);
     }
-    ::tvm::runtime::metadata::MetadataArray inputs_metadata_array{inputs_array,
+    ::tvm::runtime::metadata::MetadataArray inputs_metadata_array{::std::move(inputs_array),
                                                                   runtime::metadata::MetadataTypeIndex::kMetadata,
                                                                   "TVMTensorInfo"};
+    Downcast<::tvm::runtime::metadata::TensorInfo>(inputs_metadata_array->array[0]);
     v->Visit("inputs", &inputs_metadata_array);
     auto outputs_array = Array<ObjectRef>();
     auto outputs_accessor = outputs();

--- a/src/target/metadata.h
+++ b/src/target/metadata.h
@@ -98,6 +98,7 @@ class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNo
         outputs_{new struct TVMTensorInfo[outputs.size()]()},
         outputs_objs_{outputs},
         devices_{new const char*[devices.size()]()},
+        devices_objs_{devices},
         executor_{executor},
         mod_name_{mod_name},
         interface_api_{interface_api},
@@ -125,7 +126,7 @@ class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNo
     storage_.devices = devices_.get();
     storage_.num_devices = devices.size();
     for (unsigned int i = 0; i < devices.size(); ++i) {
-      devices_.get()[i] = devices[i].c_str();
+      devices_.get()[i] = devices_objs_[i].c_str();
     }
   }
 
@@ -135,6 +136,7 @@ class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNo
   ::std::unique_ptr<struct TVMTensorInfo> outputs_;
   std::vector<::tvm::runtime::metadata::TensorInfo> outputs_objs_;
   ::std::unique_ptr<const char*> devices_;
+  std::vector<::std::string> devices_objs_;
   ::std::string executor_;
   ::std::string mod_name_;
   ::std::string interface_api_;

--- a/src/target/metadata.h
+++ b/src/target/metadata.h
@@ -21,13 +21,14 @@
  * \file tvm/target/metadata.h
  * \brief Extends Metadata for use in the compiler.
  */
-#ifndef TVM_TARGET_METADATA_H
-#define TVM_TARGET_METADATA_H
+#ifndef TVM_TARGET_METADATA_H_
+#define TVM_TARGET_METADATA_H_
+
+#include <tvm/runtime/metadata.h>
 
 #include <memory>
 #include <string>
 #include <vector>
-#include <tvm/runtime/metadata.h>
 
 namespace tvm {
 namespace target {
@@ -36,7 +37,7 @@ namespace metadata {
 class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
  public:
   explicit VisitableMetadataNode(const struct ::TVMMetadata* data) : MetadataNode{data} {}
-  explicit VisitableMetadataNode() : MetadataNode{nullptr} {}
+  VisitableMetadataNode() : MetadataNode{nullptr} {}
 
   void VisitAttrs(AttrVisitor* v) {
     int64_t version_cpp{version()};
@@ -47,7 +48,8 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
     for (int64_t i = 0; i < num_inputs(); ++i) {
       inputs_array.push_back(::tvm::runtime::metadata::TensorInfo{inputs_accessor[i]});
     }
-    ::tvm::runtime::metadata::MetadataArray inputs_metadata_array{inputs_array, "struct TVMTensorInfo"};
+    ::tvm::runtime::metadata::MetadataArray inputs_metadata_array{inputs_array,
+                                                                  "struct TVMTensorInfo"};
     v->Visit("inputs", &inputs_metadata_array);
     auto outputs_array = Array<ObjectRef>();
     auto outputs_accessor = outputs();
@@ -55,7 +57,8 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
     for (int64_t i = 0; i < num_outputs(); ++i) {
       outputs_array.push_back(::tvm::runtime::metadata::TensorInfo{outputs_accessor[i]});
     }
-    ::tvm::runtime::metadata::MetadataArray outputs_metadata_array{outputs_array, "struct TVMTensorInfo"};
+    ::tvm::runtime::metadata::MetadataArray outputs_metadata_array{outputs_array,
+                                                                   "struct TVMTensorInfo"};
     v->Visit("outputs", &outputs_metadata_array);
     auto devices_array = Array<ObjectRef>();
     auto devices_accessor = devices();
@@ -78,45 +81,37 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
 
 class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNode {
  public:
-  InMemoryMetadataNode() : InMemoryMetadataNode(
-    0 /* version */,
-    {} /* inputs */,
-    {} /* outputs */,
-    {} /* devices */,
-    "" /* executor */,
-    "" /* mod_name */,
-    "" /* interface_api */,
-    false /* use_unpacked_api */
-    ) {}
-  InMemoryMetadataNode(
-        int64_t version,
-        const ::std::vector<::tvm::runtime::metadata::TensorInfo>& inputs,
-        const ::std::vector<::tvm::runtime::metadata::TensorInfo>& outputs,
-        const ::std::vector<::std::string>& devices,
-        const ::tvm::runtime::String executor,
-        const ::tvm::runtime::String mod_name,
-        const ::tvm::runtime::String interface_api,
-        bool use_unpacked_api
-      ) :
-      VisitableMetadataNode{&storage_},
-      inputs_{new struct TVMTensorInfo[inputs.size()]()},
-      inputs_objs_{inputs},
-      outputs_{new struct TVMTensorInfo[outputs.size()]()},
-      outputs_objs_{outputs},
-      devices_{new const char*[devices.size()]()},
-      executor_{executor},
-      mod_name_{mod_name},
-      interface_api_{interface_api},
-      storage_{
-          version,
-          nullptr, 0,
-          nullptr, 0,
-          nullptr, 0,
-          executor_.c_str(),
-          mod_name_.c_str(),
-          interface_api_.c_str(),
-          use_unpacked_api
-      } {
+  InMemoryMetadataNode()
+      : InMemoryMetadataNode(0 /* version */, {} /* inputs */, {} /* outputs */, {} /* devices */,
+                             "" /* executor */, "" /* mod_name */, "" /* interface_api */,
+                             false /* use_unpacked_api */
+        ) {}
+  InMemoryMetadataNode(int64_t version,
+                       const ::std::vector<::tvm::runtime::metadata::TensorInfo>& inputs,
+                       const ::std::vector<::tvm::runtime::metadata::TensorInfo>& outputs,
+                       const ::std::vector<::std::string>& devices,
+                       const ::tvm::runtime::String executor, const ::tvm::runtime::String mod_name,
+                       const ::tvm::runtime::String interface_api, bool use_unpacked_api)
+      : VisitableMetadataNode{&storage_},
+        inputs_{new struct TVMTensorInfo[inputs.size()]()},
+        inputs_objs_{inputs},
+        outputs_{new struct TVMTensorInfo[outputs.size()]()},
+        outputs_objs_{outputs},
+        devices_{new const char*[devices.size()]()},
+        executor_{executor},
+        mod_name_{mod_name},
+        interface_api_{interface_api},
+        storage_{version,
+                 nullptr,
+                 0,
+                 nullptr,
+                 0,
+                 nullptr,
+                 0,
+                 executor_.c_str(),
+                 mod_name_.c_str(),
+                 interface_api_.c_str(),
+                 use_unpacked_api} {
     storage_.inputs = inputs_.get();
     storage_.num_inputs = inputs.size();
     for (unsigned int i = 0; i < inputs.size(); ++i) {
@@ -149,7 +144,7 @@ class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNo
 class VisitableTensorInfoNode : public ::tvm::runtime::metadata::TensorInfoNode {
  public:
   explicit VisitableTensorInfoNode(const struct ::TVMTensorInfo* data) : TensorInfoNode{data} {}
-  explicit VisitableTensorInfoNode() : TensorInfoNode{nullptr} {}
+  VisitableTensorInfoNode() : TensorInfoNode{nullptr} {}
 
   void VisitAttrs(AttrVisitor* v) {
     ::std::string name_cpp{data()->name};
@@ -158,7 +153,7 @@ class VisitableTensorInfoNode : public ::tvm::runtime::metadata::TensorInfoNode 
     auto shape_accessor = shape();
     shape_array.reserve(num_shape());
     for (int64_t i = 0; i < num_shape(); ++i) {
-      shape_array.push_back(::tvm::Integer{int(shape_accessor[i])});
+      shape_array.push_back(::tvm::Integer{static_cast<int>(shape_accessor[i])});
     }
     ::tvm::runtime::metadata::MetadataArray shape_metadata_array{shape_array, "int64_t"};
     v->Visit("shape", &shape_metadata_array);
@@ -169,24 +164,13 @@ class VisitableTensorInfoNode : public ::tvm::runtime::metadata::TensorInfoNode 
 
 class InMemoryTensorInfoNode : public ::tvm::target::metadata::VisitableTensorInfoNode {
  public:
-  InMemoryTensorInfoNode() : InMemoryTensorInfoNode(
-        "",
-        {},
-        ::tvm::runtime::DataType(0, 0, 0)
-      ) {}
-  InMemoryTensorInfoNode(
-        const ::tvm::runtime::String& name,
-        const ::std::vector<int64_t>& shape,
-        ::tvm::runtime::DataType dtype
-      ) :
-      VisitableTensorInfoNode{&storage_},
-      name_{name},
-      shape_{new int64_t[shape.size()]()},
-      storage_{
-          name_.c_str(),
-          nullptr, 0,
-          dtype
-      } {
+  InMemoryTensorInfoNode() : InMemoryTensorInfoNode("", {}, ::tvm::runtime::DataType(0, 0, 0)) {}
+  InMemoryTensorInfoNode(const ::tvm::runtime::String& name, const ::std::vector<int64_t>& shape,
+                         ::tvm::runtime::DataType dtype)
+      : VisitableTensorInfoNode{&storage_},
+        name_{name},
+        shape_{new int64_t[shape.size()]()},
+        storage_{name_.c_str(), nullptr, 0, dtype} {
     storage_.shape = shape_.get();
     storage_.num_shape = shape.size();
     for (unsigned int i = 0; i < shape.size(); ++i) {
@@ -201,7 +185,7 @@ class InMemoryTensorInfoNode : public ::tvm::target::metadata::VisitableTensorIn
 };
 
 }  // namespace metadata
-}  // namespace runtime
+}  // namespace target
 }  // namespace tvm
 
-#endif  // TVM_TARGET_METADATA_H
+#endif  // TVM_TARGET_METADATA_H_

--- a/src/target/metadata.h
+++ b/src/target/metadata.h
@@ -49,7 +49,8 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
       inputs_array.push_back(::tvm::runtime::metadata::TensorInfo{inputs_accessor[i]});
     }
     ::tvm::runtime::metadata::MetadataArray inputs_metadata_array{inputs_array,
-                                                                  "struct TVMTensorInfo"};
+                                                                  runtime::metadata::MetadataTypeIndex::kMetadata,
+                                                                  "TVMTensorInfo"};
     v->Visit("inputs", &inputs_metadata_array);
     auto outputs_array = Array<ObjectRef>();
     auto outputs_accessor = outputs();
@@ -58,7 +59,8 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
       outputs_array.push_back(::tvm::runtime::metadata::TensorInfo{outputs_accessor[i]});
     }
     ::tvm::runtime::metadata::MetadataArray outputs_metadata_array{outputs_array,
-                                                                   "struct TVMTensorInfo"};
+                                                                   runtime::metadata::MetadataTypeIndex::kMetadata,
+                                                                   "TVMTensorInfo"};
     v->Visit("outputs", &outputs_metadata_array);
     auto devices_array = Array<ObjectRef>();
     auto devices_accessor = devices();
@@ -66,7 +68,7 @@ class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
     for (int64_t i = 0; i < num_devices(); ++i) {
       devices_array.push_back(::tvm::runtime::String{devices_accessor[i]});
     }
-    ::tvm::runtime::metadata::MetadataArray devices_metadata_array{devices_array, "const char*"};
+    ::tvm::runtime::metadata::MetadataArray devices_metadata_array{devices_array, runtime::metadata::MetadataTypeIndex::kString, "const char*"};
     v->Visit("devices", &devices_metadata_array);
     ::std::string executor_cpp{data()->executor};
     v->Visit("executor", &executor_cpp);
@@ -157,7 +159,7 @@ class VisitableTensorInfoNode : public ::tvm::runtime::metadata::TensorInfoNode 
     for (int64_t i = 0; i < num_shape(); ++i) {
       shape_array.push_back(::tvm::Integer{static_cast<int>(shape_accessor[i])});
     }
-    ::tvm::runtime::metadata::MetadataArray shape_metadata_array{shape_array, "int64_t"};
+    ::tvm::runtime::metadata::MetadataArray shape_metadata_array{shape_array, runtime::metadata::MetadataTypeIndex::kInt64, "int64_t"};
     v->Visit("shape", &shape_metadata_array);
     ::tvm::runtime::DataType dtype_cpp{dtype()};
     v->Visit("dtype", &dtype_cpp);

--- a/src/target/metadata.h
+++ b/src/target/metadata.h
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/target/metadata.h
+ * \brief Extends Metadata for use in the compiler.
+ */
+#ifndef TVM_TARGET_METADATA_H
+#define TVM_TARGET_METADATA_H
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <tvm/runtime/metadata.h>
+
+namespace tvm {
+namespace target {
+namespace metadata {
+
+class VisitableMetadataNode : public ::tvm::runtime::metadata::MetadataNode {
+ public:
+  explicit VisitableMetadataNode(const struct ::TVMMetadata* data) : MetadataNode{data} {}
+  explicit VisitableMetadataNode() : MetadataNode{nullptr} {}
+
+  void VisitAttrs(AttrVisitor* v) {
+    int64_t version_cpp{version()};
+    v->Visit("version", &version_cpp);
+    auto inputs_array = Array<ObjectRef>();
+    auto inputs_accessor = inputs();
+    inputs_array.reserve(num_inputs());
+    for (int64_t i = 0; i < num_inputs(); ++i) {
+      inputs_array.push_back(TensorInfo{inputs_accessor[i]});
+    }
+    ::tvm::runtime::metadata::MetadataArray inputs_metadata_array{inputs_array, "struct TVMTensorInfo"};
+    v->Visit("inputs", &inputs_metadata_array);
+    auto outputs_array = Array<ObjectRef>();
+    auto outputs_accessor = outputs();
+    outputs_array.reserve(num_outputs());
+    for (int64_t i = 0; i < num_outputs(); ++i) {
+      outputs_array.push_back(TensorInfo{outputs_accessor[i]});
+    }
+    ::tvm::runtime::metadata::MetadataArray outputs_metadata_array{outputs_array, "struct TVMTensorInfo"};
+    v->Visit("outputs", &outputs_metadata_array);
+    auto devices_array = Array<ObjectRef>();
+    auto devices_accessor = devices();
+    devices_array.reserve(num_devices());
+    for (int64_t i = 0; i < num_devices(); ++i) {
+      devices_array.push_back(::tvm::runtime::String{devices_accessor[i]});
+    }
+    ::tvm::runtime::metadata::MetadataArray devices_metadata_array{devices_array, "const char*"};
+    v->Visit("devices", &devices_metadata_array);
+    ::std::string executor_cpp{data()->executor};
+    v->Visit("executor", &executor_cpp);
+    ::std::string mod_name_cpp{data()->mod_name};
+    v->Visit("mod_name", &mod_name_cpp);
+    ::std::string interface_api_cpp{data()->interface_api};
+    v->Visit("interface_api", &interface_api_cpp);
+    bool use_unpacked_api_cpp{use_unpacked_api()};
+    v->Visit("use_unpacked_api", &use_unpacked_api_cpp);
+  }
+};
+
+class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNode {
+ public:
+  InMemoryMetadataNode() : InMemoryMetadataNode(
+    0 /* version */,
+    {} /* inputs */,
+    {} /* outputs */,
+    {} /* devices */,
+    "" /* executor */,
+    "" /* mod_name */,
+    "" /* interface_api */,
+    false /* use_unpacked_api */
+    ) {}
+  InMemoryMetadataNode(
+        int64_t version,
+        const ::std::vector<TensorInfo>& inputs,
+        const ::std::vector<TensorInfo>& outputs,
+        const ::std::vector<::std::string>& devices,
+        const ::tvm::runtime::String executor,
+        const ::tvm::runtime::String mod_name,
+        const ::tvm::runtime::String interface_api,
+        bool use_unpacked_api
+      ) :
+      inputs_{new struct TVMTensorInfo[inputs.size()]()},
+      inputs_objs_{inputs},
+      outputs_{new struct TVMTensorInfo[outputs.size()]()},
+      outputs_objs_{outputs},
+      devices_{new const char*[devices.size()]()},
+      executor_{executor},
+      mod_name_{mod_name},
+      interface_api_{interface_api},
+      storage_{
+          version,
+          NULL, NULL,
+          NULL, NULL,
+          NULL, NULL,
+          executor_.c_str(),
+          mod_name_.c_str(),
+          interface_api_.c_str(),
+          use_unpacked_api
+      },
+      VisitableMetadataNode{&storage_} {
+    storage_.inputs = inputs_.get();
+    storage_.num_inputs = inputs.size();
+    for (int i = 0; i < inputs.size(); ++i) {
+      inputs_.get()[i] = *inputs[i]->data();
+    }
+    storage_.outputs = outputs_.get();
+    storage_.num_outputs = outputs.size();
+    for (int i = 0; i < outputs.size(); ++i) {
+      outputs_.get()[i] = *outputs[i]->data();
+    }
+    storage_.devices = devices_.get();
+    storage_.num_devices = devices.size();
+    for (int i = 0; i < devices.size(); ++i) {
+      devices_.get()[i] = devices[i].c_str();
+    }
+  }
+
+ private:
+  ::std::unique_ptr<struct TVMTensorInfo> inputs_;
+  std::vector<TensorInfo> inputs_objs_;
+  ::std::unique_ptr<struct TVMTensorInfo> outputs_;
+  std::vector<TensorInfo> outputs_objs_;
+  ::std::unique_ptr<const char*> devices_;
+  ::std::string executor_;
+  ::std::string mod_name_;
+  ::std::string interface_api_;
+  struct ::TVMMetadata storage_;
+};
+
+class VisitableTensorInfoNode : public ::tvm::runtime::metadata::TensorInfoNode {
+ public:
+  explicit VisitableTensorInfoNode(const struct ::TVMTensorInfo* data) : TensorInfoNode{data} {}
+  explicit VisitableTensorInfoNode() : TensorInfoNode{nullptr} {}
+
+  void VisitAttrs(AttrVisitor* v) {
+    ::std::string name_cpp{data()->name};
+    v->Visit("name", &name_cpp);
+    auto shape_array = Array<ObjectRef>();
+    auto shape_accessor = shape();
+    shape_array.reserve(num_shape());
+    for (int64_t i = 0; i < num_shape(); ++i) {
+      shape_array.push_back(::tvm::Integer{shape_accessor[i]});
+    }
+    ::tvm::runtime::metadata::MetadataArray shape_metadata_array{shape_array, "int64_t"};
+    v->Visit("shape", &shape_metadata_array);
+    ::tvm::runtime::DataType dtype_cpp{dtype()};
+    v->Visit("dtype", &dtype_cpp);
+  }
+};
+
+class InMemoryTensorInfoNode : public ::tvm::target::metadata::VisitableTensorInfoNode {
+ public:
+  InMemoryTensorInfoNode() : InMemoryTensorInfoNode(
+        "",
+        {},
+        ::tvm::runtime::DataType(0, 0, 0)
+      ) {}
+  InMemoryTensorInfoNode(
+        const ::tvm::runtime::String& name,
+        const ::std::vector<int64_t>& shape,
+        ::tvm::runtime::DataType dtype
+      ) :
+      name_{name},
+      shape_{new int64_t[shape.size()]()},
+      storage_{
+          name_.c_str(),
+          NULL, NULL,
+          dtype
+      },
+      VisitableTensorInfoNode{&storage_} {
+    storage_.shape = shape_.get();
+    storage_.num_shape = shape.size();
+    for (int i = 0; i < shape.size(); ++i) {
+      shape_.get()[i] = shape[i];
+    }
+  }
+
+ private:
+  ::std::string name_;
+  ::std::unique_ptr<int64_t> shape_;
+  struct ::TVMTensorInfo storage_;
+};
+
+}  // namespace metadata
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_TARGET_METADATA_H

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -97,11 +97,15 @@ static runtime::Module CreateCppMetadataModule(
       auto metadata_module = CreateCSourceCppMetadataModule(metadata);
       metadata_module->Import(target_module);
       target_module = metadata_module;
-    } else if (target->kind->name == "llvm") {
+    }
+#ifdef TVM_LLVM_VERSION
+    else if (target->kind->name == "llvm") {
       auto metadata_module = CreateLLVMCppMetadataModule(metadata, target, runtime);
       metadata_module->Import(target_module);
       target_module = metadata_module;
-    } else {
+    }
+#endif  // TVM_LLVM_VERSION
+    else {
       CHECK(false) << "Don't know how to create MetadataModule for target type " << target->str();
     }
   }

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -27,6 +27,7 @@
 
 #include <vector>
 
+#include "../runtime/const_loader_module.h"
 #include "../runtime/meta_data.h"
 #include "llvm/llvm_module.h"
 #include "source/source_module.h"
@@ -34,6 +35,88 @@
 namespace tvm {
 namespace codegen {
 
+
+static runtime::Module CreateCrtMetadataModule(runtime::Module target_module, Target target,
+                                               relay::Runtime runtime,
+                                               runtime::metadata::Metadata metadata,
+                                               Array<runtime::Module> non_crt_exportable_modules,
+                                               Array<runtime::Module> crt_exportable_modules,
+                                               const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray) {
+
+  if (!non_crt_exportable_modules.empty()) {
+    std::string non_exportable_modules;
+    for (unsigned int i = 0; i < non_crt_exportable_modules.size(); i++) {
+      if (i > 0) {
+        non_exportable_modules += ", ";
+      }
+      auto mod = non_crt_exportable_modules[i];
+      auto pf_sym = mod.GetFunction("get_symbol");
+      if (pf_sym != nullptr) {
+        non_exportable_modules += pf_sym().operator std::string();
+      } else {
+        non_exportable_modules +=
+          std::string{"(module type_key="} + mod->type_key() + std::string{")"};
+      }
+    }
+    CHECK(false) << "These " << non_crt_exportable_modules.size()
+                 << " modules are not exportable to C-runtime: " << non_exportable_modules;
+  }
+
+  if (target->kind->name == "c") {
+    crt_exportable_modules.push_back(target_module);
+    target_module = CreateCSourceCrtMetadataModule(crt_exportable_modules, target, runtime, metadata);
+  } else if (target->kind->name == "llvm") {
+#ifdef TVM_LLVM_VERSION
+    crt_exportable_modules.push_back(target_module);
+    target_module = CreateLLVMCrtMetadataModule(crt_exportable_modules, target, runtime);
+#else   // TVM_LLVM_VERSION
+    LOG(FATAL) << "TVM was not built with LLVM enabled.";
+#endif  // TVM_LLVM_VERSION
+  }
+
+  return target_module;
+}
+
+static runtime::Module CreateCppMetadataModule(
+  runtime::Module target_module, Target target, relay::Runtime runtime,
+  runtime::metadata::Metadata metadata,
+    const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol,
+    Array<runtime::Module> non_crt_exportable_modules,
+    Array<runtime::Module> crt_exportable_modules,
+    const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray) {
+  if (!non_crt_exportable_modules.empty()) {
+    runtime::Module const_loader_mod = runtime::ConstLoaderModuleCreate(const_var_ndarray, const_vars_by_symbol);
+    const_loader_mod.Import(target_module);
+    for (const auto& it : non_crt_exportable_modules) {
+      const_loader_mod.Import(it);
+    }
+    target_module = const_loader_mod;
+  }
+
+  if (metadata->executor() == runtime::kTvmExecutorAot && runtime->name == relay::kTvmRuntimeCpp) {
+    if (target->kind->name == "c") {
+      auto metadata_module = CreateCSourceCppMetadataModule(metadata);
+      metadata_module->Import(target_module);
+      target_module = metadata_module;
+    } else {
+      CHECK(false) << "Don't know how to create MetadataModule for target type " << target->str();
+    }
+  }
+
+  return target_module;
+}
+
+/*!
+ * \brief Create a metadata module wrapper. The helper is used by different
+ *        codegens, such as graph executor codegen and the vm compiler.
+ *
+ * \param params The metadata for initialization of all modules.
+ * \param target_module the internal module that is compiled by tvm.
+ * \param ext_modules The external modules that needs to be imported inside the metadata
+ * module(s).
+ * \param target The target that all the modules are compiled for
+ * \return The created metadata module that manages initialization of metadata.
+ */
 runtime::Module CreateMetadataModule(
     const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray,
     tvm::runtime::Module target_module, const Array<runtime::Module>& ext_modules, Target target,
@@ -83,49 +166,15 @@ runtime::Module CreateMetadataModule(
   }
 
   if (is_targeting_crt) {
-    if (!non_crt_exportable_modules.empty()) {
-      std::string non_exportable_modules;
-      for (unsigned int i = 0; i < non_crt_exportable_modules.size(); i++) {
-        if (i > 0) {
-          non_exportable_modules += ", ";
-        }
-        auto mod = non_crt_exportable_modules[i];
-        auto pf_sym = mod.GetFunction("get_symbol");
-        if (pf_sym != nullptr) {
-          non_exportable_modules += pf_sym().operator std::string();
-        } else {
-          non_exportable_modules +=
-              std::string{"(module type_key="} + mod->type_key() + std::string{")"};
-        }
-      }
-      CHECK(false) << "These " << non_crt_exportable_modules.size()
-                   << " modules are not exportable to C-runtime: " << non_exportable_modules;
-    }
-
-    if (target->kind->name == "c") {
-      crt_exportable_modules.push_back(target_module);
-      target_module =
-          CreateCSourceCrtMetadataModule(crt_exportable_modules, target, runtime, metadata);
-    } else if (target->kind->name == "llvm") {
-#ifdef TVM_LLVM_VERSION
-      crt_exportable_modules.push_back(target_module);
-      target_module = CreateLLVMCrtMetadataModule(crt_exportable_modules, target, runtime);
-#else   // TVM_LLVM_VERSION
-      LOG(FATAL) << "TVM was not built with LLVM enabled.";
-#endif  // TVM_LLVM_VERSION
-    }
+    return CreateCrtMetadataModule(target_module, target, runtime, metadata, non_crt_exportable_modules, crt_exportable_modules, const_var_ndarray);
   } else {
-    if (!non_crt_exportable_modules.empty()) {
-      runtime::Module binary_const_loader_mod = runtime::ConstLoaderModuleCreate(const_var_ndarray, const_vars_by_symbol);
-      binary_const_loader_mod.Import(target_module);
-      for (const auto& it : non_crt_exportable_modules) {
-        binary_const_loader_mod.Import(it);
-      }
-      return binary_const_loader_mod;
-    }
+    return CreateCppMetadataModule(target_module, target, runtime, metadata, const_vars_by_symbol,
+                                   non_crt_exportable_modules, crt_exportable_modules,
+                                   const_var_ndarray);
   }
-  return target_module;
 }
 
+
 }  // namespace codegen
+
 }  // namespace tvm

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -97,6 +97,10 @@ static runtime::Module CreateCppMetadataModule(
       auto metadata_module = CreateCSourceCppMetadataModule(metadata);
       metadata_module->Import(target_module);
       target_module = metadata_module;
+    } else if (target->kind->name == "llvm") {
+      auto metadata_module = CreateLLVMCppMetadataModule(metadata, target, runtime);
+      metadata_module->Import(target_module);
+      target_module = metadata_module;
     } else {
       CHECK(false) << "Don't know how to create MetadataModule for target type " << target->str();
     }

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -35,14 +35,11 @@
 namespace tvm {
 namespace codegen {
 
-
-static runtime::Module CreateCrtMetadataModule(runtime::Module target_module, Target target,
-                                               relay::Runtime runtime,
-                                               runtime::metadata::Metadata metadata,
-                                               Array<runtime::Module> non_crt_exportable_modules,
-                                               Array<runtime::Module> crt_exportable_modules,
-                                               const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray) {
-
+static runtime::Module CreateCrtMetadataModule(
+    runtime::Module target_module, Target target, relay::Runtime runtime,
+    runtime::metadata::Metadata metadata, Array<runtime::Module> non_crt_exportable_modules,
+    Array<runtime::Module> crt_exportable_modules,
+    const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray) {
   if (!non_crt_exportable_modules.empty()) {
     std::string non_exportable_modules;
     for (unsigned int i = 0; i < non_crt_exportable_modules.size(); i++) {
@@ -55,7 +52,7 @@ static runtime::Module CreateCrtMetadataModule(runtime::Module target_module, Ta
         non_exportable_modules += pf_sym().operator std::string();
       } else {
         non_exportable_modules +=
-          std::string{"(module type_key="} + mod->type_key() + std::string{")"};
+            std::string{"(module type_key="} + mod->type_key() + std::string{")"};
       }
     }
     CHECK(false) << "These " << non_crt_exportable_modules.size()
@@ -64,7 +61,8 @@ static runtime::Module CreateCrtMetadataModule(runtime::Module target_module, Ta
 
   if (target->kind->name == "c") {
     crt_exportable_modules.push_back(target_module);
-    target_module = CreateCSourceCrtMetadataModule(crt_exportable_modules, target, runtime, metadata);
+    target_module =
+        CreateCSourceCrtMetadataModule(crt_exportable_modules, target, runtime, metadata);
   } else if (target->kind->name == "llvm") {
 #ifdef TVM_LLVM_VERSION
     crt_exportable_modules.push_back(target_module);
@@ -78,14 +76,15 @@ static runtime::Module CreateCrtMetadataModule(runtime::Module target_module, Ta
 }
 
 static runtime::Module CreateCppMetadataModule(
-  runtime::Module target_module, Target target, relay::Runtime runtime,
-  runtime::metadata::Metadata metadata,
+    runtime::Module target_module, Target target, relay::Runtime runtime,
+    runtime::metadata::Metadata metadata,
     const std::unordered_map<std::string, std::vector<std::string>>& const_vars_by_symbol,
     Array<runtime::Module> non_crt_exportable_modules,
     Array<runtime::Module> crt_exportable_modules,
     const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray) {
   if (!non_crt_exportable_modules.empty()) {
-    runtime::Module const_loader_mod = runtime::ConstLoaderModuleCreate(const_var_ndarray, const_vars_by_symbol);
+    runtime::Module const_loader_mod =
+        runtime::ConstLoaderModuleCreate(const_var_ndarray, const_vars_by_symbol);
     const_loader_mod.Import(target_module);
     for (const auto& it : non_crt_exportable_modules) {
       const_loader_mod.Import(it);
@@ -166,14 +165,15 @@ runtime::Module CreateMetadataModule(
   }
 
   if (is_targeting_crt) {
-    return CreateCrtMetadataModule(target_module, target, runtime, metadata, non_crt_exportable_modules, crt_exportable_modules, const_var_ndarray);
+    return CreateCrtMetadataModule(target_module, target, runtime, metadata,
+                                   non_crt_exportable_modules, crt_exportable_modules,
+                                   const_var_ndarray);
   } else {
     return CreateCppMetadataModule(target_module, target, runtime, metadata, const_vars_by_symbol,
                                    non_crt_exportable_modules, crt_exportable_modules,
                                    const_var_ndarray);
   }
 }
-
 
 }  // namespace codegen
 

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -37,7 +37,7 @@ namespace codegen {
 runtime::Module CreateMetadataModule(
     const std::unordered_map<std::string, runtime::NDArray>& const_var_ndarray,
     tvm::runtime::Module target_module, const Array<runtime::Module>& ext_modules, Target target,
-    tvm::relay::Runtime runtime, runtime::Metadata metadata) {
+    tvm::relay::Runtime runtime, runtime::metadata::Metadata metadata) {
   // Here we split modules into two groups:
   //  1. Those modules which can be exported to C-runtime. These are DSO-exportable
   //     (i.e. llvm or c) modules which return nothing from get_const_vars().

--- a/src/target/metadata_module.cc
+++ b/src/target/metadata_module.cc
@@ -165,6 +165,7 @@ runtime::Module CreateMetadataModule(
   }
 
   if (is_targeting_crt) {
+    LOG(INFO) << "Create CRT metadata: " << metadata.defined();
     return CreateCrtMetadataModule(target_module, target, runtime, metadata,
                                    non_crt_exportable_modules, crt_exportable_modules,
                                    const_var_ndarray);

--- a/src/target/metadata_module.h
+++ b/src/target/metadata_module.h
@@ -26,6 +26,7 @@
 #define TVM_TARGET_METADATA_MODULE_H_
 
 #include <tvm/relay/runtime.h>
+#include <tvm/runtime/metadata.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/target/target.h>
@@ -54,7 +55,7 @@ namespace codegen {
 runtime::Module CreateMetadataModule(
     const std::unordered_map<std::string, runtime::NDArray>& params, runtime::Module target_module,
     const Array<runtime::Module>& ext_modules, Target target, tvm::relay::Runtime runtime,
-    runtime::Metadata metadata);
+    runtime::metadata::Metadata metadata);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -51,6 +51,10 @@ void CodeGenCHost::Init(bool output_ssa, bool emit_asserts, std::string target_s
   CodeGenC::Init(output_ssa);
 }
 
+void CodeGenCHost::InitGlobalContext() {
+  decl_stream << "void* " << tvm::runtime::symbol::tvm_module_ctx << " = NULL;\n";
+}
+
 void CodeGenCHost::DefineModuleName() { decl_stream << "void* " << module_name_ << " = NULL;\n"; }
 
 void CodeGenCHost::AddFunction(const PrimFunc& f) {
@@ -435,6 +439,10 @@ runtime::Module BuildCHost(IRModule mod, Target target) {
   if (could_have_linked_params && aot_executor_fn.defined()) {
     cg.DeclareParameters(linked_params, constants_byte_alignment);
     cg.AddFunction(aot_executor_fn);
+  }
+
+  if (aot_executor_fn.defined()) {
+    cg.InitGlobalContext();
   }
 
   if (target->GetAttr<Bool>("system-lib").value_or(Bool(false))) {

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -23,6 +23,7 @@
 #include "codegen_c_host.h"
 
 #include <tvm/relay/executor.h>
+#include <tvm/relay/runtime.h>
 #include <tvm/runtime/crt/error_codes.h>
 #include <tvm/runtime/module.h>
 #include <tvm/target/codegen.h>
@@ -441,7 +442,8 @@ runtime::Module BuildCHost(IRModule mod, Target target) {
     cg.AddFunction(aot_executor_fn);
   }
 
-  if (aot_executor_fn.defined()) {
+  relay::Runtime runtime = mod->GetAttr<relay::Runtime>(tvm::attr::kRuntime).value();
+  if (aot_executor_fn.defined() && runtime->name == relay::kTvmRuntimeCpp) {
     cg.InitGlobalContext();
   }
 

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -397,6 +397,7 @@ runtime::Module BuildCHost(IRModule mod, Target target) {
   bool emit_asserts = false;
   CodeGenCHost cg;
   cg.Init(output_ssa, emit_asserts, target->str());
+  LOG(INFO) << "CodegenCHost: " << mod;
 
   Map<String, LinkedParam> linked_params;
   bool found_linked_params = false;

--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -40,6 +40,7 @@ class CodeGenCHost : public CodeGenC {
   CodeGenCHost();
   void Init(bool output_ssa, bool emit_asserts, std::string target_str);
 
+  void InitGlobalContext();
   void AddFunction(const PrimFunc& f);
 
   void DefineModuleName();

--- a/src/target/source/codegen_source_base.h
+++ b/src/target/source/codegen_source_base.h
@@ -25,6 +25,7 @@
 #ifndef TVM_TARGET_SOURCE_CODEGEN_SOURCE_BASE_H_
 #define TVM_TARGET_SOURCE_CODEGEN_SOURCE_BASE_H_
 
+#include <tvm/runtime/metadata.h>
 #include <tvm/target/codegen.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/op.h>
@@ -146,6 +147,19 @@ runtime::Module CSourceModuleCreate(const String& code, const String& fmt,
                                     const Array<String>& const_vars = {});
 
 /*!
+ * \brief Wrap the submodules in a metadata module.
+ * \param params The variable to constant mapping that is collected by the host
+ *        module.
+ * \param target_module The main TIR-lowered internal runtime module
+ * \param modules All the external modules that needs to be imported inside the metadata module(s).
+ * \param target The target that all the modules are compiled for
+ * \return The wrapped module.
+ */
+runtime::Module CreateMetadataModule(
+    const std::unordered_map<std::string, runtime::NDArray>& params, runtime::Module target_module,
+    const Array<runtime::Module>& ext_modules, Target target, runtime::metadata::Metadata metadata);
+
+/*!
  * \brief Create a source module for viewing and limited saving for device.
  * \param data The code data to be viewed.
  * \param fmt The code. format.
@@ -156,6 +170,16 @@ runtime::Module CSourceModuleCreate(const String& code, const String& fmt,
 runtime::Module DeviceSourceModuleCreate(
     std::string data, std::string fmt, std::unordered_map<std::string, runtime::FunctionInfo> fmap,
     std::string type_key, std::function<std::string(const std::string&)> fget_source = nullptr);
+
+/*!
+ * \brief Wrap the submodules that are to be wrapped in a c-source metadata module for C runtime.
+ * \param modules The modules to be wrapped.
+ * \param target the target the modules are compiled for.
+ * \param metadata the metadata needed for code generation.
+ * \return The wrapped module.
+ */
+runtime::Module CreateCSourceCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
+                                               runtime::metadata::Metadata metadata);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -338,6 +338,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
       CreateFuncRegistry();
       GenerateCrtSystemLib();
     }
+    LOG(INFO) << "Metadata " << metadata_.defined() << " exec " << metadata_->executor();
     if (metadata_.defined() && metadata_->executor() == runtime::kTvmExecutorAot) {
       GenerateAOTDescriptor();
     }

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -317,6 +317,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     code_ << "#endif\n";
 
     if (metadata_->use_unpacked_api()) {
+      LOG(INFO) << "Generate AOT Descriptor: " << metadata_->interface_api();
       if (metadata_->interface_api() == "c") {
         GenerateCInterfaceEntrypoint(entrypoint_mangled, run_func_mangled, metadata_->mod_name());
       } else {

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -30,9 +30,10 @@
 #include <utility>
 #include <vector>
 
-#include <tvm/runtime/ndarray.h>
-#include <tvm/runtime/packed_func.h>
-#include <tvm/runtime/registry.h>
+// TODO(areusch): idk what's up here...
+#include <tvm/runtime/ndarray.h>  // NOLINT(build/include_order)
+#include <tvm/runtime/packed_func.h>  // NOLINT(build/include_order)
+#include <tvm/runtime/registry.h>  // NOLINT(build/include_order)
 
 #include "../../runtime/file_utils.h"
 #include "../../support/str_escape.h"

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -23,17 +23,17 @@
  */
 #include "source_module.h"
 
-#include <tuple>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 // TODO(areusch): idk what's up here...
-#include <tvm/runtime/ndarray.h>  // NOLINT(build/include_order)
+#include <tvm/runtime/ndarray.h>      // NOLINT(build/include_order)
 #include <tvm/runtime/packed_func.h>  // NOLINT(build/include_order)
-#include <tvm/runtime/registry.h>  // NOLINT(build/include_order)
+#include <tvm/runtime/registry.h>     // NOLINT(build/include_order)
 
 #include "../../runtime/file_utils.h"
 #include "../../support/str_escape.h"

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -213,13 +213,13 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     code_ << "(void* args, void* type_code, int num_args, void* out_value, void* "
              "out_type_code, void* resource_handle) {\n";
     code_ << "return " << run_func << "(";
-    for (unsigned int i = 0; i < metadata_->inputs.size(); ++i) {
+    for (unsigned int i = 0; i < metadata_->num_inputs(); ++i) {
       code_ << "((DLTensor*)(((TVMValue*)args)[" << i << "].v_handle))[0].data,";
     }
-    for (int i = 0; i < metadata_->num_outputs; ++i) {
-      int j = metadata_->inputs.size() + i;
+    for (int i = 0; i < metadata_->num_outputs(); ++i) {
+      int j = metadata_->num_inputs() + i;
       code_ << "((DLTensor*)(((TVMValue*)args)[" << j << "].v_handle))[0].data";
-      if (i + 1 != metadata_->num_outputs) {
+      if (i + 1 != metadata_->num_outputs()) {
         code_ << ",";
       }
     }

--- a/src/target/source/source_module.h
+++ b/src/target/source/source_module.h
@@ -26,24 +26,31 @@
 #define TVM_TARGET_SOURCE_SOURCE_MODULE_H_
 
 #include <tvm/relay/runtime.h>
+#include <tvm/runtime/metadata.h>
 #include <tvm/runtime/module.h>
 #include <tvm/target/target.h>
 
-#include "../../runtime/meta_data.h"
 
 namespace tvm {
 namespace codegen {
 
 /*!
+
  * \brief Wrap the submodules that are to be wrapped in a c-source metadata module for C runtime.
  * \param modules The modules to be wrapped.
  * \param target the target the modules are compiled for.
  * \param runtime the runtime to code generate against
- * \param metadata the metadata needed for code generation.
+ * \param metadata Compiler-generated metadata exported to runtime.
  * \return The wrapped module.
  */
 runtime::Module CreateCSourceCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
-                                               relay::Runtime runtime, runtime::Metadata metadata);
+                                               relay::Runtime runtime, runtime::metadata::Metadata metadata);
+
+/*!
+ * \brief Create C++-runtime targeted metadata module for "c" backend.
+ * \param metadata Compiler-generated metadata.
+ */
+runtime::Module CreateCSourceCppMetadataModule(runtime::metadata::Metadata metadata);
 
 }  // namespace codegen
 }  // namespace tvm

--- a/src/target/source/source_module.h
+++ b/src/target/source/source_module.h
@@ -44,7 +44,8 @@ namespace codegen {
  * \return The wrapped module.
  */
 runtime::Module CreateCSourceCrtMetadataModule(const Array<runtime::Module>& modules, Target target,
-                                               relay::Runtime runtime, runtime::metadata::Metadata metadata);
+                                               relay::Runtime runtime,
+                                               runtime::metadata::Metadata metadata);
 
 /*!
  * \brief Create C++-runtime targeted metadata module for "c" backend.

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -328,8 +328,8 @@ class BuiltinLower : public StmtExprMutator {
 
     // cpacked call resource_handle
     if (!use_string_lookup) {
-      tir::Var resource_handle = Downcast<Var>(op->args[arg_count]);
-      packed_args.push_back(StringImm(resource_handle->name_hint));
+//      tir::Var resource_handle = Downcast<Var>(op->args[arg_count]);
+//      packed_args.push_back(StringImm(resource_handle->name_hint));
     }
 
     auto builtin_call = use_string_lookup ? builtin::tvm_call_packed_lowered()

--- a/tests/cpp/test_metadata.cc
+++ b/tests/cpp/test_metadata.cc
@@ -19,6 +19,8 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <tvm/ir/type.h>
+#include <tvm/node/reflection.h>
 #include <tvm/runtime/metadata.h>
 
 namespace {
@@ -45,6 +47,7 @@ const struct TVMMetadata kNormal = {
   };
 }
 
+using ::tvm::runtime::Downcast;
 using ::testing::Eq;
 using ::testing::ElementsAre;
 
@@ -57,11 +60,112 @@ TEST(Metadata, ParseStruct) {
   EXPECT_THAT(input1->name(), Eq("input1"));
   EXPECT_THAT(input1->shape(), ElementsAre(1, 5, 5, 3));
   EXPECT_THAT(input1->dtype(), Eq(tvm::runtime::DataType(DLDataType{1, 2, 3})));
-  // auto md_inputs = md->inputs();
-  // EXPECT_EQ(md_inputs.size(), 1);
 
-  // auto md_input = md_inputs[0];
+  EXPECT_THAT(md->num_outputs(), Eq(1));
+  auto output1 = md->outputs()[0];
+  EXPECT_THAT(output1->name(), Eq("output1"));
+  EXPECT_THAT(::std::vector<int64_t>(output1->shape()), ElementsAre(3, 8, 8));
+  EXPECT_THAT(output1->dtype(), Eq(tvm::runtime::DataType(DLDataType{3, 4, 5})));
 
-  // EXPECT_EQ(md->get_name(), kNormal.name);
-//  EXPECT_EQ(md->get_name(), kNormal.name);
+  auto devices = md->devices();
+  EXPECT_THAT(devices, ElementsAre(::tvm::runtime::String("device1"),
+        ::tvm::runtime::String("device2")));
+
+  EXPECT_THAT(md->executor(), Eq("aot"));
+  EXPECT_THAT(md->mod_name(), Eq("default"));
+  EXPECT_THAT(md->interface_api(), Eq("c"));
+  EXPECT_THAT(md->use_unpacked_api(), Eq(true));
+}
+
+class TestVisitor : public tvm::AttrVisitor {
+ public:
+  using Element = ::std::tuple<::std::string, ::tvm::runtime::ObjectRef>;
+  void Visit(const char* key, double* value) final {
+    keys.push_back(key);
+    values.push_back(::tvm::FloatImm(::tvm::runtime::DataType(kDLFloat, 64, 1), *value));
+  }
+  void Visit(const char* key, int64_t* value) final {
+    keys.push_back(key);
+    values.push_back(::tvm::IntImm(::tvm::runtime::DataType(kDLInt, 64, 1), *value));
+  }
+  void Visit(const char* key, uint64_t* value) final {
+    keys.push_back(key);
+    int64_t v;
+    *(reinterpret_cast<uint64_t*>(&v)) = *value;
+    values.push_back(::tvm::IntImm(::tvm::runtime::DataType(kDLUInt, 64, 1), v));
+  }
+  void Visit(const char* key, int* value) final {
+    keys.push_back(key);
+    values.push_back(::tvm::IntImm(::tvm::runtime::DataType(kDLInt, 64, 1), *value));
+  }
+  void Visit(const char* key, bool* value) final {
+    keys.push_back(key);
+    values.push_back(::tvm::Bool(*value));
+  }
+  void Visit(const char* key, std::string* value) final {
+    keys.push_back(key);
+    values.push_back(::tvm::runtime::String(*value));
+  }
+  void Visit(const char* key, tvm::runtime::DataType* value) final {
+    keys.push_back(key);
+    values.push_back(::tvm::PrimType(*value));
+  }
+  void Visit(const char* key, tvm::runtime::NDArray* value) final {
+    keys.push_back(key);
+    values.push_back(*value);
+  }
+  void Visit(const char* key, void** value) final {
+    CHECK(false) << "Do not expect this type";
+  }
+
+  void Visit(const char* key, ::tvm::runtime::ObjectRef* value) final {
+    keys.push_back(key);
+    values.push_back(*value);
+  }
+
+  std::vector<std::string> keys;
+  std::vector<::tvm::runtime::ObjectRef> values;
+};
+
+TEST(Metadata, Visitor) {
+  tvm::runtime::metadata::Metadata md = tvm::runtime::metadata::Metadata(&kNormal);
+  TestVisitor v;
+  ::tvm::ReflectionVTable::Global()->VisitAttrs(md.operator->(), &v);
+
+  EXPECT_THAT(v.keys, ElementsAre(
+                Eq("version"),
+                Eq("inputs"),
+                Eq("outputs"),
+                Eq("devices"),
+                Eq("executor"),
+                Eq("mod_name"),
+                Eq("interface_api"),
+                Eq("use_unpacked_api")
+                ));
+
+  EXPECT_THAT(Downcast<tvm::IntImm>(v.values[0])->value, Eq(TVM_METADATA_VERSION));
+
+  // Just identify the tensor.
+  auto input_array = Downcast<tvm::runtime::metadata::MetadataArray>(v.values[1]);
+  EXPECT_THAT(input_array->type_index, Eq(tvm::runtime::metadata::MetadataTypeIndex::kMetadata));
+  EXPECT_THAT(input_array->struct_name, Eq(std::string("TVMTensorInfo")));
+  EXPECT_THAT(input_array->array.size(), Eq(1));
+  auto array0 = input_array->array[0];
+
+  auto input1 = Downcast<tvm::runtime::metadata::TensorInfo>(array0);
+  EXPECT_THAT(input1->name(), Eq("input1"));
+
+  auto output_array = Downcast<tvm::runtime::metadata::MetadataArray>(v.values[2]);
+  EXPECT_THAT(output_array->type_index, Eq(tvm::runtime::metadata::MetadataTypeIndex::kMetadata));
+  EXPECT_THAT(output_array->struct_name, Eq("TVMTensorInfo"));
+  auto output1 = Downcast<tvm::runtime::metadata::TensorInfo>(output_array->array[0]);
+
+  EXPECT_THAT(output1->name(), Eq("output1"));
+
+  auto devices = Downcast<tvm::runtime::metadata::MetadataArray>(v.values[3]);
+  EXPECT_THAT(devices->type_index, Eq(tvm::runtime::metadata::MetadataTypeIndex::kString));
+  EXPECT_THAT(Downcast<tvm::runtime::String>(devices->array[0]), Eq("device1"));
+  EXPECT_THAT(Downcast<tvm::runtime::String>(devices->array[1]), Eq("device1"));
+
+//  EXPECT_THAT(Downcast<IntImm>(v.values[0])->value, Eq(TVM_METADATA_VERSION));
 }

--- a/tests/cpp/test_metadata.cc
+++ b/tests/cpp/test_metadata.cc
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tvm/runtime/metadata.h>
+
+namespace {
+const int64_t kNormalInput1Shape[4] = {1, 5, 5, 3};
+const struct TVMTensorInfo kNormalInputs[1] = {{"input1", kNormalInput1Shape, 4, DLDataType{1, 2, 3}}};
+
+const int64_t kNormalOutput1Shape[3] = {3, 8, 8};
+const struct TVMTensorInfo kNormalOutputs[1] = {{"output1", kNormalOutput1Shape, 3, DLDataType{3, 4, 5}}};
+
+const char* kNormalDevices[2] = {"device1", "device2"};
+
+const struct TVMMetadata kNormal = {
+  TVM_METADATA_VERSION,
+  kNormalInputs,
+  1,
+  kNormalOutputs,
+  1,
+  kNormalDevices,
+  2,
+  "aot",
+  "default",
+  "c",
+  true,
+  };
+}
+
+using ::testing::Eq;
+using ::testing::ElementsAre;
+
+TEST(Metadata, ParseStruct) {
+  tvm::runtime::metadata::Metadata md = tvm::runtime::metadata::Metadata(&kNormal);
+  EXPECT_THAT(md->version(), Eq(TVM_METADATA_VERSION));
+  EXPECT_THAT(md->num_inputs(), Eq(1));
+
+  auto input1 = md->inputs()[0];
+  EXPECT_THAT(input1->name(), Eq("input1"));
+  EXPECT_THAT(input1->shape(), ElementsAre(1, 5, 5, 3));
+  EXPECT_THAT(input1->dtype(), Eq(tvm::runtime::DataType(DLDataType{1, 2, 3})));
+  // auto md_inputs = md->inputs();
+  // EXPECT_EQ(md_inputs.size(), 1);
+
+  // auto md_input = md_inputs[0];
+
+  // EXPECT_EQ(md->get_name(), kNormal.name);
+//  EXPECT_EQ(md->get_name(), kNormal.name);
+}

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -206,6 +206,7 @@ def parametrize_aot_options(test):
     interface_api = ["packed", "c"]
     use_unpacked_api = [True, False]
     test_runner = [AOT_DEFAULT_RUNNER, AOT_CORSTONE300_RUNNER]
+    print("TEST RUNNERS", test_runner)
 
     all_combinations = itertools.product(interface_api, use_unpacked_api, test_runner)
 

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -48,7 +48,10 @@ def print_mod_tree(m, indent=0):
 unpacked_api = tvm.testing.parameter(True, False)
 
 
-def test_conv2d(unpacked_api):
+target_kind = tvm.testing.parameter("c", "llvm")
+
+
+def test_conv2d(target_kind, unpacked_api):
     RELAY_MODEL = textwrap.dedent(
         """\
         #[version = "0.0.5"]
@@ -94,7 +97,7 @@ def test_conv2d(unpacked_api):
         mod = tvm.relay.build(
             ir_mod,
             params=params,
-            target="c",
+            target=target_kind,
             executor=backend.Executor("aot", {"unpacked-api": unpacked_api, "interface-api": "packed"}),
         )
 

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -42,7 +42,8 @@ from aot_test_utils import (
 def print_mod_tree(m, indent=0):
     print(f"{' ' * indent} - {m!r}")
     for i in m.imported_modules:
-      print_mod_tree(i, indent + 2)
+        print_mod_tree(i, indent + 2)
+
 
 def test_conv2d():
     RELAY_MODEL = textwrap.dedent(
@@ -76,8 +77,12 @@ def test_conv2d():
     output_list = generate_ref_data(ir_mod, inputs, params)
 
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
-        mod = tvm.relay.build(ir_mod, params=params, target="c",
-                              executor=backend.Executor("aot", {"interface-api": "c"}))
+        mod = tvm.relay.build(
+            ir_mod,
+            params=params,
+            target="c",
+            executor=backend.Executor("aot", {"interface-api": "c"}),
+        )
 
     print_mod_tree(mod.module)
 

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -45,7 +45,8 @@ def print_mod_tree(m, indent=0):
       print_mod_tree(i, indent + 2)
 
 def test_conv2d():
-    RELAY_MODEL = textwrap.dedent("""\
+    RELAY_MODEL = textwrap.dedent(
+        """\
         #[version = "0.0.5"]
         def @main(%data : Tensor[(1, 3, 64, 64), uint8], %weight : Tensor[(8, 3, 5, 5), int8]) {
             %1 = nn.conv2d(
@@ -59,7 +60,8 @@ def test_conv2d():
                  out_dtype="int32");
           %1
         }
-    """)
+    """
+    )
     ir_mod = tvm.parser.fromtext(RELAY_MODEL)
 
     main_func = ir_mod["main"]

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import sys
+import textwrap
+
+import numpy as np
+import pytest
+
+import tvm
+from tvm import relay, TVMError
+from tvm.ir.module import IRModule
+from tvm.relay import backend, testing, transform
+from tvm.relay.testing import byoc
+from tvm.relay.op.annotation import compiler_begin, compiler_end
+from aot_test_utils import (
+    AOTTestModel,
+    AOT_DEFAULT_RUNNER,
+    generate_ref_data,
+    convert_to_relay,
+    compile_and_run,
+    compile_models,
+    parametrize_aot_options,
+)
+
+
+def print_mod_tree(m, indent=0):
+    print(f"{' ' * indent} - {m!r}")
+    for i in m.imported_modules:
+      print_mod_tree(i, indent + 2)
+
+def test_conv2d():
+    RELAY_MODEL = textwrap.dedent("""\
+        #[version = "0.0.5"]
+        def @main(%data : Tensor[(1, 3, 64, 64), uint8], %weight : Tensor[(8, 3, 5, 5), int8]) {
+            %1 = nn.conv2d(
+                 %data,
+                 %weight,
+                 padding=[2, 2],
+                 channels=8,
+                 kernel_size=[5, 5],
+                 data_layout="NCHW",
+                 kernel_layout="OIHW",
+                 out_dtype="int32");
+          %1
+        }
+    """)
+    ir_mod = tvm.parser.fromtext(RELAY_MODEL)
+
+    main_func = ir_mod["main"]
+    shape_dict = {p.name_hint: p.checked_type.concrete_shape for p in main_func.params}
+    type_dict = {p.name_hint: p.checked_type.dtype for p in main_func.params}
+
+    weight_data = np.ones(shape_dict["weight"]).astype(type_dict["weight"])
+    input_data = np.ones(shape_dict["data"]).astype(type_dict["data"])
+
+    params = {"weight": weight_data}
+    inputs = {"data": input_data}
+    output_list = generate_ref_data(ir_mod, inputs, params)
+
+    with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
+        mod = tvm.relay.build(ir_mod, params=params, target="c",
+                              executor=backend.Executor("aot", {"interface-api": "c"}))
+
+    print_mod_tree(mod.module)
+
+    with tvm.contrib.utils.TempDirectory.set_keep_for_debug():
+        mod.export_library("test.so")
+    mod.export_library("test.tar")
+    runner = tvm.runtime.load_module("test.so")
+    print_mod_tree(runner)
+    runner = tvm.runtime.executor.AotModule(runner["default"](tvm.cpu(0)))
+    runner.set_input(**inputs)
+    runner.run()
+    assert (runner.get_output(0).asnumpy() == output_list[0]).all()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -47,7 +47,7 @@ def test_error_c_interface_with_packed_api():
     two = relay.add(relay.const(1), relay.const(1))
     func = relay.Function([], two)
 
-    with pytest.raises(tvm.TVMError, match="Packed interface required for packed operators"):
+    with pytest.raises(tvm.TVMError, match='When interface_api == "c", need unpacked-api == true'):
         compile_and_run(
             AOTTestModel(
                 module=IRModule.from_expr(func), inputs={}, outputs=generate_ref_data(func, {})

--- a/tests/python/unittest/test_metadata.py
+++ b/tests/python/unittest/test_metadata.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+
+
+def test_


### PR DESCRIPTION
This PR implements Module-based Model Runtime for AOT RFC. It adds support for targeting the C++ runtime with the Ahead-of-Time Executor for workloads which are purely CPU-based (e.g. the Device API cannot be used).

cc @manupa-arm @kparzysz-quic @csullivan @mehrdadh @adstraw for early feedback while I iterate to prepare to merge this.