### PR TITLE
[CUTLASS] More robust support for pattern matching and alignment

### DIFF
--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -128,16 +128,16 @@ class CutlassConv2DProfiler:
         If profile_all is False, return immediately after the first applicable kernel is found.
         If use_multiprocessing is True, compile all profiler executables in parallel.
         """
-        B, H, W, C = d_shape
-        K, R, S, _ = w_shape
+        B, H, W, IC = d_shape
+        OC, R, S, _ = w_shape
         _, P, Q, _ = out_shape
 
-        M = B * H * W
-        K = R * S * C
-        N = B * P * Q
+        M = B * P * Q
+        N = OC
+        K = R * S * IC
 
         gemm_profile_result = self.gemm_profiler.profile(
-            M, K, N, out_dtype, profile_all=profile_all, use_multiprocessing=use_multiprocessing
+            M, N, K, out_dtype, profile_all=profile_all, use_multiprocessing=use_multiprocessing
         )
 
         tile_description = gemm_profile_result["tile_description"]

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -128,7 +128,7 @@ class CutlassConv2DProfiler:
         If profile_all is False, return immediately after the first applicable kernel is found.
         If use_multiprocessing is True, compile all profiler executables in parallel.
         """
-        B, H, W, IC = d_shape
+        B, _, _, IC = d_shape
         OC, R, S, _ = w_shape
         _, P, Q, _ = out_shape
 

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -141,12 +141,13 @@ GENERATOR_FUNC_TABLE = {
 # TODO(masahi): A sensible way to pick reasonable default kernels
 DEFAULT_KERNELS = {
     75: {
-        "float16": "cutlass_tensorop_h1688gemm_128x64_32x2_tn_align4",
-        "float32": "cutlass_tensorop_s1688gemm_f16_64x64_32x2_tn_align4",
+        "float16": "cutlass_tensorop_h1688gemm_128x64_32x2_tn_align1",
+        "float32": "cutlass_tensorop_s1688gemm_f16_64x64_32x2_tn_align1",
     },
+    # align1 variants do not seem to be available for sm80
     80: {
-        "float16": "cutlass_tensorop_h16816gemm_128x256_32x3_tn_align4",
-        "float32": "cutlass_tensorop_s16816gemm_f16_128x128_32x3_tn_align4",
+        "float16": "cutlass_tensorop_h1688gemm_128x64_32x2_tn_align1",
+        "float32": "cutlass_tensorop_s1688gemm_f16_64x64_32x2_tn_align1",
     },
 }
 
@@ -160,14 +161,16 @@ class CutlassGemmProfiler:
         self.sm = sm
         self.cache = {}
 
-    def check_align(self, op_name, M):
+    def check_align(self, op_name, M, K):
         """Filter out kernels that cannot be supported."""
         aligns = re.findall(r"align[1|2|4|8]", op_name)
         assert len(aligns) == 1
+        # The same alignment is used for all axes
         align = int(aligns[0][-1])
-        if M % align != 0:
-            return False
-        return True
+        # TODO(masahi): CUTLASS alignment check on gemm kernels is too restrictive.
+        # See https://github.com/NVIDIA/cutlass/issues/362.
+        # When the above issue is resolved, we can remove the alignment check on M below.
+        return M % align == 0 and K % align == 0
 
     def get_default(self, out_dtype, batched=False):
         """Return the default kernel for the requested architecture.
@@ -194,7 +197,7 @@ class CutlassGemmProfiler:
         ops = GENERATOR_FUNC_TABLE[self.sm](
             out_dtype, op_creator=partial(create_gemm_operator, batched=batched)
         )
-        ops = list(filter(lambda op: self.check_align(op["name"], M), ops))
+        ops = list(filter(lambda op: self.check_align(op["name"], M, K), ops))
 
         for op in ops:
             op["runtime"] = -1

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -136,6 +136,7 @@ def generate_sm80_tensor_op_16816(out_dtype, op_creator):
             TileDescription([128, 256, 32], 3, [2, 4, 1], math_inst, min_cc, max_cc),
             TileDescription([256, 64, 32], 4, [4, 1, 1], math_inst, min_cc, max_cc),
             TileDescription([64, 256, 32], 4, [1, 4, 1], math_inst, min_cc, max_cc),
+            TileDescription([128, 128, 32], 2, [2, 2, 1], math_inst, min_cc, max_cc),
             TileDescription([128, 128, 32], 3, [2, 2, 1], math_inst, min_cc, max_cc),
             TileDescription([128, 128, 32], 4, [2, 2, 1], math_inst, min_cc, max_cc),
             TileDescription([128, 128, 32], 5, [2, 2, 1], math_inst, min_cc, max_cc),
@@ -152,9 +153,11 @@ def generate_sm80_tensor_op_16816(out_dtype, op_creator):
             TileDescription([64, 64, 64], 5, [2, 2, 1], math_inst, min_cc, max_cc),
         ]
 
-    return generate_tensor_op_common(
+    sm75_kernels = generate_sm75_tensor_op_1688(out_dtype, op_creator)
+    sm80_kernels = generate_tensor_op_common(
         math_instructions, alignment_constraints, get_tile_descriptions, op_creator
     )
+    return sm75_kernels + sm80_kernels
 
 
 class ProfilerEngine:

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -136,7 +136,6 @@ def generate_sm80_tensor_op_16816(out_dtype, op_creator):
             TileDescription([128, 256, 32], 3, [2, 4, 1], math_inst, min_cc, max_cc),
             TileDescription([256, 64, 32], 4, [4, 1, 1], math_inst, min_cc, max_cc),
             TileDescription([64, 256, 32], 4, [1, 4, 1], math_inst, min_cc, max_cc),
-            TileDescription([128, 128, 32], 2, [2, 2, 1], math_inst, min_cc, max_cc),
             TileDescription([128, 128, 32], 3, [2, 2, 1], math_inst, min_cc, max_cc),
             TileDescription([128, 128, 32], 4, [2, 2, 1], math_inst, min_cc, max_cc),
             TileDescription([128, 128, 32], 5, [2, 2, 1], math_inst, min_cc, max_cc),

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -56,19 +56,51 @@ def make_batch_matmul_pattern():
 
 
 def make_conv2d_pattern():
-    # TODO(masahi): Check layout and alignment
     return is_op("nn.conv2d")(wildcard(), wildcard())
+
+
+def check_dtype(lhs, rhs):
+    """Check if dtypes in the given workload are supported by CUTLASS."""
+    return lhs.dtype == rhs.dtype and lhs.dtype == "float16" and rhs.dtype == "float16"
+
+
+def check_gemm(call):
+    """Check if the given dense workload can be offloaded to CUTLASS."""
+    lhs = call.args[0].checked_type
+    rhs = call.args[1].checked_type
+    return check_dtype(lhs, rhs)
+
+
+def check_batch_matmul(call):
+    """Check if the given batch_matmul workload can be offloaded to CUTLASS."""
+    transpose_a = call.attrs.transpose_a
+    transpose_b = call.attrs.transpose_b
+    return check_gemm(call) and transpose_a == False and transpose_b == True
+
+
+def check_conv2d(call):
+    """Check if the given conv2d workload can be offloaded to CUTLASS."""
+    data_layout = call.attrs.data_layout
+    kernel_layout = call.attrs.kernel_layout
+    data = call.args[0].checked_type
+    weight = call.args[1].checked_type
+    return data_layout == "NHWC" and kernel_layout == "OHWI" and check_dtype(data, weight)
 
 
 def partition_for_cutlass(mod):
     """Partition the input module into CUTLASS-supported subgraphs."""
-    dense_pat = ("cutlass.dense", make_gemm_pattern(False, None))
-    dense_bias_pat = ("cutlass.dense_bias", make_gemm_pattern(True, None))
-    dense_bias_relu_pat = ("cutlass.dense_bias_relu", make_gemm_pattern(True, "relu"))
-    dense_bias_gelu_fp16_pat = ("cutlass.dense_bias_gelu_fp16", make_gemm_pattern(True, "gelu"))
+    dense_pat = ("cutlass.dense", make_gemm_pattern(False, None), check_gemm)
+    dense_bias_pat = ("cutlass.dense_bias", make_gemm_pattern(True, None), check_gemm)
+    dense_bias_relu_pat = ("cutlass.dense_bias_relu", make_gemm_pattern(True, "relu"), check_gemm)
+    dense_bias_gelu_fp16_pat = (
+        "cutlass.dense_bias_gelu_fp16",
+        make_gemm_pattern(True, "gelu"),
+        check_gemm,
+    )
     dense_bias_gelu_fp32_pat = (
         "cutlass.dense_bias_gelu_fp32",
         make_gemm_pattern(True, "gelu", out_dtype="float32"),
+        check_gemm,
     )
     cutlass_patterns = [
         dense_bias_gelu_fp16_pat,
@@ -76,9 +108,9 @@ def partition_for_cutlass(mod):
         dense_bias_relu_pat,
         dense_bias_pat,
         dense_pat,
-        ("cutlass.batch_matmul", make_batch_matmul_pattern()),
+        ("cutlass.batch_matmul", make_batch_matmul_pattern(), check_batch_matmul),
         # TODO(masahi): Add more conv2d patterns
-        ("cutlass.conv2d", make_conv2d_pattern()),
+        ("cutlass.conv2d", make_conv2d_pattern(), check_conv2d),
     ]
     mod = transform.MergeComposite(cutlass_patterns)(mod)
     mod = transform.AnnotateTarget(["cutlass"])(mod)

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -87,7 +87,7 @@ def check_batch_matmul(call):
     rhs = batch_matmul.args[1].checked_type
     transpose_a = batch_matmul.attrs.transpose_a
     transpose_b = batch_matmul.attrs.transpose_b
-    return check_dtype(lhs, rhs) and transpose_a == False and transpose_b == True
+    return check_dtype(lhs, rhs) and not transpose_a and transpose_b
 
 
 def check_conv2d(call):

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name
 """Patterns supported CUTLASS."""
 from tvm.ir.transform import Sequential
 from tvm.relay import transform

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -106,7 +106,7 @@ def check_conv2d(call):
         return False
     IC = data.shape[3]
     OC = weight.shape[0]
-    return not is_depthwise_conv2d(IC, OC, call.attrs.groups)
+    return not is_depthwise_conv2d(IC, OC, conv2d.attrs.groups)
 
 
 def partition_for_cutlass(mod):

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -90,6 +90,10 @@ def check_batch_matmul(call):
     return check_dtype(lhs, rhs) and not transpose_a and transpose_b
 
 
+def is_depthwise_conv2d(ic, oc, groups):
+    return ic == oc == groups
+
+
 def check_conv2d(call):
     """Check if the given conv2d workload can be offloaded to CUTLASS."""
     conv2d = get_root_call(call, "nn.conv2d")
@@ -97,7 +101,11 @@ def check_conv2d(call):
     kernel_layout = conv2d.attrs.kernel_layout
     data = conv2d.args[0].checked_type
     weight = conv2d.args[1].checked_type
-    return data_layout == "NHWC" and kernel_layout == "OHWI" and check_dtype(data, weight)
+    if data_layout != "NHWC" or kernel_layout != "OHWI" or not check_dtype(data, weight):
+        return False
+    IC = data.shape[3]
+    OC = weight.shape[0]
+    return not is_depthwise_conv2d(IC, OC, call.attrs.groups)
 
 
 def partition_for_cutlass(mod):

--- a/python/tvm/topi/cuda/conv2d_alter_op.py
+++ b/python/tvm/topi/cuda/conv2d_alter_op.py
@@ -450,6 +450,10 @@ def _conv2d_legalize(attrs, inputs, arg_types):
 
     elif data_dtype in ["float16"]:
         if data_layout == "NHWC" and kernel_layout == "HWIO":
+            if isinstance(data_tensor.shape[0], tvm.tir.expr.Any):
+                # Skip legalize when the batch size is dynamic
+                return None
+
             batch = data_tensor.shape[0].value
             in_channel = data_tensor.shape[3].value
             out_channel = kernel_tensor.shape[3].value

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -386,7 +386,7 @@ def test_conv2d():
             sm=80,
             atol=1e-5,
             rtol=1e-5,
-            use_cudnn_ref=IC == 3,
+            use_cudnn_ref=(IC == 3),  # The autotvm kernel has an accuracy issue with IC == 3 case
             run_benchmark=False,
         )
 

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -242,6 +242,8 @@ K = 768
 def test_dense():
     verify_dense(get_dense(M, N, K), M, N, K)
     verify_dense(get_dense(M, N, K, out_dtype="float32"), M, N, K)
+    # Test align1 case
+    verify_dense(get_dense_bias(M, N + 1, K), M, N + 1, K)
 
 
 def test_dense_bias():


### PR DESCRIPTION
* Introduce "check" functions for merge composite to reject invalid input layout and dtype.
* Fix GEMM kernel selection for cases where `N, K` dimensions are not divisible by 8, 4 etc, i.e. `align = 1` is mandatory. This came up in MaskRCNN where there is a workload `(M, N, K) = (?, 91, 1024)`. Since the output shape is `(?, 91)`, we cannot do vectorized memory access on the output tensor. Hence, only `align = 1` variants are valid candidates. The same fix also enabled offloading conv2d with `IC = 3` case.
* On dynamic workload, since the input size can be anything, only `align = 1` variants are valid candidates. 
* Fixed im2col encoding of `conv2d` (see the change in `gen_conv2d.py `). But this code will be removed soon anyway when I introduce the dedicated conv2d profiler and kernel selection.

Since we need to use `align = 1` kernels for cases above and CUTLASS sm80 gemm kernels do not seem to support `align=1`, I had to add sm75 kernels to sm80 kernel selection (see the change in `gen_tensor_op.py`). It turned out sm75 kernels are faster than sm80 on RTX 3070 on some workloads, so mixing sm75 and 80 seems to be a good idea.

cc @comaniac @Laurawly     