### PR TITLE
[TIR] Affine utility support iter lowerbound and diagnostics

### DIFF
--- a/include/tvm/arith/iter_affine_map.h
+++ b/include/tvm/arith/iter_affine_map.h
@@ -83,7 +83,7 @@ class IterMapExpr : public PrimExpr {
 };
 
 /*!
- * \brief Mark the source as an iterator in [min, extent).
+ * \brief Mark the source as an iterator in [0, extent).
  *
  *  IterMark is used to mark source expression as a valid
  *  iterator to make future analysis easy.
@@ -96,10 +96,6 @@ class IterMarkNode : public Object {
    */
   PrimExpr source;
   /*!
-   * \brief The min of the iteration.
-   */
-  PrimExpr min;
-  /*!
    * \brief The extent of the iteration.
    */
   PrimExpr extent;
@@ -107,19 +103,17 @@ class IterMarkNode : public Object {
   // overrides
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("source", &source);
-    v->Visit("min", &min);
     v->Visit("extent", &extent);
   }
 
   bool SEqualReduce(const IterMarkNode* other, SEqualReducer equal) const {
     equal->MarkGraphNode();
-    return equal(source, other->source) && equal(extent, other->extent) && equal(min, other->min);
+    return equal(source, other->source) && equal(extent, other->extent);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce->MarkGraphNode();
     hash_reduce(source);
-    hash_reduce(min);
     hash_reduce(extent);
   }
 
@@ -138,10 +132,9 @@ class IterMark : public ObjectRef {
   /*!
    * \brief constructor.
    * \param source The source expression.
-   * \param min The min of the iterator.
    * \param extent The extent of the iterator.
    */
-  TVM_DLL IterMark(PrimExpr source, PrimExpr min, PrimExpr extent);
+  TVM_DLL IterMark(PrimExpr source, PrimExpr extent);
 
   TVM_DEFINE_OBJECT_REF_METHODS(IterMark, ObjectRef, IterMarkNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IterMarkNode);

--- a/include/tvm/arith/iter_affine_map.h
+++ b/include/tvm/arith/iter_affine_map.h
@@ -283,6 +283,7 @@ class IterSumExpr : public IterMapExpr {
  * \param predicate The predicate constraints on the input iterators
  * \param require_bijective A boolean flag that indicates whether the mapping should be bijective.
  * \param analyzer Analyzer used to get context information.
+ * \param diag_ctx Diagnostic context.
  *
  * \return The detected pattern if a match exists,
  *         otherwise return an empty array.
@@ -297,7 +298,6 @@ Array<IterSumExpr> DetectIterMap(const Array<PrimExpr>& indices, const Map<Var, 
  * \param input_iters Map from variable to iterator's range.
  * \param input_pred The predicate constraints on the input iterators
  * \param require_bijective A boolean flag that indicates whether the mapping should be bijective.
- * \param diag_ctx Diagnostic context.
  *
  * \return The indices after rewrite
  */

--- a/python/tvm/arith/iter_affine_map.py
+++ b/python/tvm/arith/iter_affine_map.py
@@ -34,15 +34,12 @@ class IterMark(Object):
     source : PrimExpr.
         The source expression.
 
-    min_value : PrimExpr
-        The min of the iterator.
-
     extent : PrimExpr
         The extent of the iterator.
     """
 
-    def __init__(self, source, min_value, extent):
-        self.__init_handle_by_constructor__(_ffi_api.IterMark, source, min_value, extent)
+    def __init__(self, source, extent):
+        self.__init_handle_by_constructor__(_ffi_api.IterMark, source, extent)
 
 
 @tvm._ffi.register_object("arith.IterSplitExpr")

--- a/python/tvm/arith/iter_affine_map.py
+++ b/python/tvm/arith/iter_affine_map.py
@@ -34,12 +34,15 @@ class IterMark(Object):
     source : PrimExpr.
         The source expression.
 
+    min_value : PrimExpr
+        The min of the iterator.
+
     extent : PrimExpr
         The extent of the iterator.
     """
 
-    def __init__(self, source, extent):
-        self.__init_handle_by_constructor__(_ffi_api.IterMark, source, extent)
+    def __init__(self, source, min_value, extent):
+        self.__init_handle_by_constructor__(_ffi_api.IterMark, source, min_value, extent)
 
 
 @tvm._ffi.register_object("arith.IterSplitExpr")

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -835,12 +835,13 @@ Optional<Array<IntSet>> EstimateRegionLowerBound(const Array<Range>& region,
     for (const Range& range : region) {
       affine_indices.push_back(range->min);
     }
+    DiagnosticContext diag_ctx(DiagnosticContext::Default(IRModule()));
     iter_sum_exprs = DetectIterMap(
         /*indices=*/affine_indices, /*input_iters=*/var_dom,
-        /*predicate=*/predicate, /*require_bijective=*/false, analyzer);
-  }
-  if (iter_sum_exprs.empty()) {
-    return NullOpt;
+        /*predicate=*/predicate, /*require_bijective=*/false, analyzer, diag_ctx);
+    if (iter_sum_exprs.empty()) {
+      return NullOpt;
+    }
   }
   ICHECK_EQ(iter_sum_exprs.size(), ndim);
   Array<IntSet> result;
@@ -857,6 +858,7 @@ Optional<Array<IntSet>> EstimateRegionLowerBound(const Array<Range>& region,
     if (!analyzer->CanProve(range->extent >= split->scale)) {
       return NullOpt;
     }
+
     const PrimExpr& base = sum_expr->base;
     // IterSplitExpr: (source // lower_factor) % extent * scale
     // where `(source // lower_factor) % extent` is within [0, extent - 1]

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -839,9 +839,9 @@ Optional<Array<IntSet>> EstimateRegionLowerBound(const Array<Range>& region,
     iter_sum_exprs = DetectIterMap(
         /*indices=*/affine_indices, /*input_iters=*/var_dom,
         /*predicate=*/predicate, /*require_bijective=*/false, analyzer, diag_ctx);
-    if (iter_sum_exprs.empty()) {
-      return NullOpt;
-    }
+  }
+  if (iter_sum_exprs.empty()) {
+    return NullOpt;
   }
   ICHECK_EQ(iter_sum_exprs.size(), ndim);
   Array<IntSet> result;

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -781,21 +781,21 @@ std::vector<IterConstraint> MatchBoundConstraints(PrimExpr pred,
     bool is_finish = false;
     bool is_greater = false;
     bool is_equal = false;
-    if ((rest && (lhs < rhs)).Match(pred)) {
+    if ((rest && (lhs < rhs)).Match(pred) || ((lhs < rhs) && rest).Match(pred)) {
       // pass
     } else if ((lhs < rhs).Match(pred)) {
       is_finish = true;
-    } else if ((rest && (lhs <= rhs)).Match(pred)) {
+    } else if ((rest && (lhs <= rhs)).Match(pred) || ((lhs <= rhs) && rest).Match(pred)) {
       is_equal = true;
     } else if ((lhs <= rhs).Match(pred)) {
       is_equal = true;
       is_finish = true;
-    } else if ((rest && (lhs > rhs)).Match(pred)) {
+    } else if ((rest && (lhs > rhs)).Match(pred) || ((lhs > rhs) && rest).Match(pred)) {
       is_greater = true;
     } else if ((lhs > rhs).Match(pred)) {
       is_greater = true;
       is_finish = true;
-    } else if ((rest && (lhs >= rhs)).Match(pred)) {
+    } else if ((rest && (lhs >= rhs)).Match(pred) || ((lhs >= rhs) && rest).Match(pred)) {
       is_greater = true;
       is_equal = true;
     } else if ((lhs >= rhs).Match(pred)) {

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -36,23 +36,26 @@ namespace arith {
 
 using namespace tir;
 
-IterMark::IterMark(PrimExpr source, PrimExpr extent) {
+IterMark::IterMark(PrimExpr source, PrimExpr min, PrimExpr extent) {
   auto n = make_object<IterMarkNode>();
   n->source = std::move(source);
+  n->min = std::move(min);
   n->extent = std::move(extent);
   data_ = std::move(n);
 }
 
-TVM_REGISTER_GLOBAL("arith.IterMark").set_body_typed([](PrimExpr source, PrimExpr extent) {
-  return IterMark(source, extent);
-});
+TVM_REGISTER_GLOBAL("arith.IterMark")
+    .set_body_typed([](PrimExpr source, PrimExpr min, PrimExpr extent) {
+      return IterMark(source, min, extent);
+    });
 
 TVM_REGISTER_NODE_TYPE(IterMarkNode);
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<IterMarkNode>([](const ObjectRef& node, ReprPrinter* p) {
       auto* op = static_cast<const IterMarkNode*>(node.get());
-      p->stream << "IterMark(" << op->source << ", extent=" << op->extent << ")";
+      p->stream << "IterMark(" << op->source << ", min=" << op->min << ", extent=" << op->extent
+                << ")";
     });
 
 IterSplitExpr::IterSplitExpr(IterMark source) {
@@ -72,6 +75,9 @@ IterSplitExpr::IterSplitExpr(IterMark source, PrimExpr scale) {
   n->dtype = source->source->dtype;
   n->source = std::move(source);
   n->extent = n->source->extent;
+  if (is_zero(n->source->min)) {
+    n->extent = n->extent + n->source->min;
+  }
   n->lower_factor = one;
   n->scale = std::move(scale);
   data_ = std::move(n);
@@ -165,19 +171,20 @@ class IterMapRewriter : public ExprMutator {
  public:
   using Parent = ExprMutator;
 
-  explicit IterMapRewriter(Analyzer* analyzer, const Map<Var, Range>& input_iters)
-      : analyzer_(analyzer) {
+  explicit IterMapRewriter(Analyzer* analyzer, const Map<Var, Range>& input_iters,
+                           DiagnosticContext diag_ctx)
+      : analyzer_(analyzer), diag_ctx_(diag_ctx) {
     for (auto kv : input_iters) {
       const Var& var = kv.first;
       const Range& vrng = kv.second;
       if (is_one(vrng->extent)) {
         var_map_[var] = IterSumExpr({}, vrng->min);
       } else if (is_zero(vrng->min)) {
-        IterMark mark(var, vrng->extent);
+        IterMark mark(var, 0, vrng->extent);
         var_map_[var] = IterSplitExpr(mark);
         input_marks_.push_back(mark);
       } else {
-        IterMark mark(var - vrng->min, vrng->extent);
+        IterMark mark(var - vrng->min, 0, vrng->extent);
         IterSumExpr sum_expr = ToIterSumExpr(IterSplitExpr(mark));
         sum_expr.CopyOnWrite()->base = vrng->min;
         var_map_[var] = sum_expr;
@@ -192,9 +199,10 @@ class IterMapRewriter : public ExprMutator {
     return NormalizeToIterWithOffset(ToIterSumExpr(DirectMutate(expr)));
   }
 
-  IterSumExpr RewriteIterConstraint(const PrimExpr& expr,
-                                    const PrimExpr& predicate_induced_extent) {
-    return NormalizeToIterOnBoundExpr(ToIterSumExpr(DirectMutate(expr)), predicate_induced_extent);
+  IterSumExpr RewriteIterConstraint(const PrimExpr& expr, const PrimExpr& predicate_induced_min,
+                                    const PrimExpr& predicate_induced_max) {
+    return NormalizeToIterOnBoundExpr(ToIterSumExpr(DirectMutate(expr)), predicate_induced_min,
+                                      predicate_induced_max);
   }
 
   /*!
@@ -224,8 +232,9 @@ class IterMapRewriter : public ExprMutator {
     // The splits do not overlap with each other.
     collector.Collect(bindings);
     for (const IterMark& mark : collector.visited_) {
-      if (TryNormalizeSplits(mark, collector.mark2splits_[mark], require_bijective).empty())
+      if (TryNormalizeSplits(mark, collector.mark2splits_[mark], require_bijective).empty()) {
         return false;
+      }
     }
     if (require_bijective) {
       // all input marks must be visited
@@ -278,7 +287,7 @@ class IterMapRewriter : public ExprMutator {
   PrimExpr VisitExpr(const PrimExpr& input_expr) final {
     auto expr = ExprMutator::VisitExpr(input_expr);
     if (expr->IsInstance<IterMapExprNode>()) {
-      ++unresolved_count_;
+      Fail(Diagnostic::Error(input_expr->span));
     }
     return expr;
   }
@@ -328,6 +337,13 @@ class IterMapRewriter : public ExprMutator {
     }
   };
 
+  void Fail(const Diagnostic& diagnostic) {
+    unresolved_count_++;
+    if (diag_ctx_.defined()) {
+      diag_ctx_.Emit(diagnostic);
+    }
+  }
+
   // Internal analyzer
   Analyzer* analyzer_;
   // Counter to keep track of unresolved cases.
@@ -352,6 +368,8 @@ class IterMapRewriter : public ExprMutator {
   std::unordered_map<IterSumExpr, IterSumExpr, IterSumHash, IterSumEqual> flattened_map_;
   // The flattened forms of constrained iters
   std::vector<IterSumExpr> constrained_iters_flattened_;
+  // Diagnostic context
+  DiagnosticContext diag_ctx_;
 
   /*!
    * \brief Look for a split in splits that is not used such that its lower_factor is smallest.
@@ -433,14 +451,21 @@ class IterMapRewriter : public ExprMutator {
   }
 
   /*!
-   * \brief Normalize the left hand side of iter constraint(expr < predicate_induced_extent)
-   * \param expr The left hand side of iter constraint.
-   * \param predicate_induced_extent Extent from iter constraint.
+   * \brief Normalize the iter expression with constraint (min <= expr < max)
+   * \param expr The iter expression.
+   * \param predicate_induced_min Closed lower bound from iter constraint, maybe undefined.
+   * \param predicate_induced_max Open upper bound from iter constraint, maybe undefined.
    * \return The Normalized expression.
    */
-  IterSumExpr NormalizeToIterOnBoundExpr(IterSumExpr expr,
-                                         const PrimExpr& predicate_induced_extent) {
-    // We are normalizing the left hand side of iter constraint(iter < predicate_induced_extent)
+  IterSumExpr NormalizeToIterOnBoundExpr(IterSumExpr expr, PrimExpr predicate_induced_min,
+                                         PrimExpr predicate_induced_max) {
+    // remove base temporarily since `TryFuseIters` require zero base iter sum
+    PrimExpr base = expr->base;
+    if (!is_zero(base)) {
+      expr.CopyOnWrite()->base = 0;
+      if (predicate_induced_min.defined()) predicate_induced_min = predicate_induced_min - base;
+      if (predicate_induced_max.defined()) predicate_induced_max = predicate_induced_max - base;
+    }
     Optional<IterSplitExpr> opt = TryFuseIters(expr);
     // scale should be 1
     if (opt.defined() && is_one(opt.value()->scale)) {
@@ -453,16 +478,30 @@ class IterMapRewriter : public ExprMutator {
       auto it_mark = sum_fuse_map_.find(flattened_form);
       ICHECK(it_mark != sum_fuse_map_.end());
       IterMark mark = it_mark->second;
-      mark.CopyOnWrite()->extent = min(predicate_induced_extent, mark->extent);
+      // update iter mark iter range to [0, mark->extent) ^ [pred_min, pred_max)
+      PrimExpr mark_min = mark->min;
+      PrimExpr mark_max = mark->min + mark->extent;
+      if (predicate_induced_min.defined()) {
+        mark_min = max(predicate_induced_min, mark_min);
+      }
+      if (predicate_induced_max.defined()) {
+        mark_max = min(predicate_induced_max, mark_max);
+      }
+      mark.CopyOnWrite()->min = mark_min;
+      mark.CopyOnWrite()->extent = mark_max - mark_min;
+
       // update the bound of the lhs based on predicate_induced_extent
       sum_fuse_map_[flattened_form] = mark;
       // we need to note down the flattened form of constrained iterators
       // to check the validity of constraints, see also CheckConstraints()
       constrained_iters_flattened_.push_back(flattened_form);
       expr.CopyOnWrite()->args = Array<IterSplitExpr>({opt.value()});
+      expr.CopyOnWrite()->base = base;
       return expr;
     }
-    ++unresolved_count_;
+    Fail(Diagnostic::Error(expr->span)
+         << "Fail to normalize " << expr << " with predicate bound [" << predicate_induced_min
+         << ", " << predicate_induced_max << ")");
     return expr;
   }
 
@@ -482,7 +521,7 @@ class IterMapRewriter : public ExprMutator {
       expr.CopyOnWrite()->args = Array<IterSplitExpr>({opt.value()});
       return expr;
     } else {
-      ++unresolved_count_;
+      Fail(Diagnostic::Error(expr->span) << "Fail to normalize iter sum with offset: " << expr);
       return expr;
     }
   }
@@ -534,6 +573,8 @@ class IterMapRewriter : public ExprMutator {
     // check if it can be remapped into a fused pattern.
     PrimExpr expected_scale = base_scale.value();
     for (size_t i = 0; i < expr->args.size();) {
+      // check arg iter mark starts from zero
+      if (!is_zero(expr->args[i]->source->min)) return NullOpt;
       // find j such that expr->args[j] has expected scale
       size_t j = i == 0 ? base_index : 0;
       for (; j < expr->args.size(); ++j) {
@@ -602,7 +643,7 @@ class IterMapRewriter : public ExprMutator {
       return IterSplitExpr(it->second, base_scale.value());
     } else {
       // new iter, form a new mark
-      IterMark mark = IterMark(structured_form, div(expected_scale, base_scale.value()));
+      IterMark mark = IterMark(structured_form, 0, div(expected_scale, base_scale.value()));
       sum_fuse_map_[flattened_form] = mark;
       flattened_map_[structured_form] = flattened_form;
       return IterSplitExpr(mark, base_scale.value());
@@ -667,34 +708,126 @@ class IterMapRewriter : public ExprMutator {
 struct IterConstraint {
   // The expr of the iter
   PrimExpr iter;
+  // The expr of the lower_bound
+  PrimExpr lower_bound;
   // The expr of the upper_bound
   PrimExpr upper_bound;
   // The size of the iter, which is the number of nodes
   size_t expr_size = 0;
 
-  IterConstraint(PrimExpr iter, PrimExpr upper_bound, size_t size)
-      : iter(std::move(iter)), upper_bound(std::move(upper_bound)), expr_size(size) {}
+  IterConstraint(PrimExpr iter, PrimExpr lower_bound, PrimExpr upper_bound, size_t size)
+      : iter(std::move(iter)),
+        lower_bound(std::move(lower_bound)),
+        upper_bound(std::move(upper_bound)),
+        expr_size(size) {}
 };
 
 /*!
  * \brief Split the predicate into `(a < b) && (c < d) && ...`
  * \param pred The predicate to be split.
- * \return A list of pairs, each element of which are lhs and rhs of the '<' sign,
- *         empty if the split failed.
+ * \return A list of IterConstraint, empty if the split failed.
  */
-std::vector<IterConstraint> MatchUpperBoundConstraints(PrimExpr pred) {
+std::vector<IterConstraint> MatchBoundConstraints(PrimExpr pred,
+                                                  const Map<Var, Range>& input_iters) {
   std::vector<IterConstraint> result;
   arith::PVar<PrimExpr> lhs, rhs, rest;
   for (;;) {
+    // try extract comparisions
+    bool is_finish = false;
+    bool is_greater = false;
+    bool is_equal = false;
     if ((rest && (lhs < rhs)).Match(pred)) {
-      result.emplace_back(lhs.Eval(), rhs.Eval(), 0);
-      pred = rest.Eval();
+      // pass
     } else if ((lhs < rhs).Match(pred)) {
-      result.emplace_back(lhs.Eval(), rhs.Eval(), 0);
-      break;
+      is_finish = true;
+    } else if ((rest && (lhs <= rhs)).Match(pred)) {
+      is_equal = true;
+    } else if ((lhs <= rhs).Match(pred)) {
+      is_equal = true;
+      is_finish = true;
+    } else if ((rest && (lhs > rhs)).Match(pred)) {
+      is_greater = true;
+    } else if ((lhs > rhs).Match(pred)) {
+      is_greater = true;
+      is_finish = true;
+    } else if ((rest && (lhs >= rhs)).Match(pred)) {
+      is_greater = true;
+      is_equal = true;
+    } else if ((lhs >= rhs).Match(pred)) {
+      is_greater = true;
+      is_equal = true;
+      is_finish = true;
     } else {
       return std::vector<IterConstraint>();
     }
+    PrimExpr lhs_expr = lhs.Eval();
+    PrimExpr rhs_expr = rhs.Eval();
+    // we only accept predicate of integers
+    if (!((lhs_expr->dtype.is_int() || lhs_expr->dtype.is_uint()) &&
+          (rhs_expr->dtype.is_int() || rhs_expr->dtype.is_uint()))) {
+      return std::vector<IterConstraint>();
+    }
+    // determine iter and bound, if we can not distinguish them simply,
+    // try divide (lhs - rhs) into itervar aware and itervar free parts
+    auto f_use_itervar = [&input_iters](const VarNode* v) {
+      return input_iters.count(GetRef<Var>(v));
+    };
+    bool bound_at_left;
+    if (is_const_int(lhs_expr) || !UsesVar(lhs_expr, f_use_itervar)) {
+      bound_at_left = true;
+    } else if (is_const_int(rhs_expr) || !UsesVar(rhs_expr, f_use_itervar)) {
+      bound_at_left = false;
+    } else {
+      bound_at_left = false;  // accumulate bound to rhs
+      PrimExpr sum_parts = lhs_expr - rhs_expr;
+      lhs_expr = 0;
+      rhs_expr = 0;
+      std::function<void(const PrimExpr&, bool)> f_extract =
+          [&lhs_expr, &rhs_expr, f_use_itervar, &f_extract](const PrimExpr& part, bool sign) {
+            if (const AddNode* add = part.as<AddNode>()) {
+              f_extract(add->a, sign);
+              f_extract(add->b, sign);
+            } else if (const SubNode* sub = part.as<SubNode>()) {
+              f_extract(sub->a, sign);
+              f_extract(sub->b, !sign);
+            } else if (UsesVar(part, f_use_itervar)) {
+              lhs_expr = sign ? lhs_expr + part : lhs_expr - part;
+            } else {
+              rhs_expr = sign ? rhs_expr - part : rhs_expr + part;
+            }
+          };
+      f_extract(sum_parts, true);
+      arith::Analyzer analyzer;
+      lhs_expr = analyzer.Simplify(lhs_expr);
+      rhs_expr = analyzer.Simplify(rhs_expr);
+    }
+    PrimExpr lower_bound, upper_bound, iter;
+    if (is_greater) {
+      if (bound_at_left) {
+        // bound > iter
+        upper_bound = is_equal ? lhs_expr + 1 : lhs_expr;
+        iter = rhs_expr;
+      } else {
+        // iter > bound
+        lower_bound = is_equal ? rhs_expr : rhs_expr + 1;
+        iter = lhs_expr;
+      }
+    } else {
+      if (bound_at_left) {
+        // bound < iter
+        lower_bound = is_equal ? lhs_expr : lhs_expr + 1;
+        iter = rhs_expr;
+      } else {
+        // iter < bound
+        upper_bound = is_equal ? rhs_expr + 1 : rhs_expr;
+        iter = lhs_expr;
+      }
+    }
+    result.emplace_back(iter, lower_bound, upper_bound, 0);
+    if (is_finish) {
+      break;
+    }
+    pred = rest.Eval();
   }
   return result;
 }
@@ -711,14 +844,17 @@ bool IterRangeSanityCheck(const Map<Var, Range>& iter_ranges) {
 
 Array<IterSumExpr> DetectIterMap(const Array<PrimExpr>& indices, const Map<Var, Range>& input_iters,
                                  const PrimExpr& predicate, bool require_bijective,
-                                 arith::Analyzer* analyzer) {
+                                 arith::Analyzer* analyzer, DiagnosticContext diag_ctx) {
   // Overall detection algorithm is divided into two steps:
   // - Step0: IterMapRewriter rewrites the expression to use IterMapExpr patterns.
   // - Step1: IterIndependenceChecker checks if the iterator are independent.
-
   if (!IterRangeSanityCheck(input_iters)) return Array<IterSumExpr>();
-  std::vector<IterConstraint> constraints = MatchUpperBoundConstraints(predicate);
-  if (!is_one(predicate) && constraints.empty()) return Array<IterSumExpr>();
+  std::vector<IterConstraint> constraints = MatchBoundConstraints(predicate, input_iters);
+  if (!is_one(predicate) && constraints.empty()) {
+    diag_ctx.Emit(Diagnostic::Error(predicate->span)
+                  << "Fail to collect constraints from iteration predicate: " << predicate);
+    return Array<IterSumExpr>();
+  }
 
   // We have to make sure when we visit an iterator, all the constraints related with its successors
   // in the iter var graph has been visited, where the expression of this iterator will contain the
@@ -731,13 +867,17 @@ Array<IterSumExpr> DetectIterMap(const Array<PrimExpr>& indices, const Map<Var, 
       constraints.begin(), constraints.end(),
       [](const IterConstraint& a, const IterConstraint& b) { return a.expr_size < b.expr_size; });
 
-  IterMapRewriter rewriter(analyzer, input_iters);
+  IterMapRewriter rewriter(analyzer, input_iters, diag_ctx);
   // Step0.0: rewrite constraints in the order from size-small ones to size-big ones
   for (const IterConstraint& constraint : constraints) {
-    PrimExpr res = rewriter.RewriteIterConstraint(constraint.iter, constraint.upper_bound);
+    rewriter.RewriteIterConstraint(constraint.iter, constraint.lower_bound, constraint.upper_bound);
     if (rewriter.unresolved_count() != 0) return Array<IterSumExpr>();
   }
-  if (!rewriter.CheckConstraints()) return Array<IterSumExpr>();
+  if (!rewriter.CheckConstraints()) {
+    diag_ctx.Emit(Diagnostic::Error(predicate->span)
+                  << "Illegal iteration constraints: " << predicate);
+    return Array<IterSumExpr>();
+  }
   // Step0.1: rewrite indices
   Array<IterSumExpr> results;
   for (PrimExpr value : indices) {
@@ -745,7 +885,10 @@ Array<IterSumExpr> DetectIterMap(const Array<PrimExpr>& indices, const Map<Var, 
     if (rewriter.unresolved_count() != 0) return Array<IterSumExpr>();
   }
   // Step1: IterIndependenceChecker checks if the iterator are independent.
-  if (!rewriter.CheckMapping(results, require_bijective)) return Array<IterSumExpr>();
+  if (!rewriter.CheckMapping(results, require_bijective)) {
+    diag_ctx.Emit(Diagnostic::Error(predicate->span) << "Iterators are not independent");
+    return Array<IterSumExpr>();
+  }
 
   return results;
 }
@@ -754,7 +897,8 @@ TVM_REGISTER_GLOBAL("arith.DetectIterMap")
     .set_body_typed([](const Array<PrimExpr>& indices, const Map<Var, Range>& input_iters,
                        const PrimExpr& input_pred, bool is_bijective) {
       arith::Analyzer ana;
-      return DetectIterMap(indices, input_iters, input_pred, is_bijective, &ana);
+      DiagnosticContext diag_ctx(DiagnosticContext::Default(IRModule()));
+      return DetectIterMap(indices, input_iters, input_pred, is_bijective, &ana, diag_ctx);
     });
 
 PrimExpr IterMapRewriter::VisitExpr_(const VarNode* op) {
@@ -769,8 +913,16 @@ PrimExpr IterMapRewriter::VisitExpr_(const AddNode* op) {
     return Parent::VisitExpr_(op);
   }
 
-  PrimExpr a = this->DirectMutate(op->a);
-  PrimExpr b = this->DirectMutate(op->b);
+  // skip analysis of irrelated sum parts
+  auto f_use_itervar = [this](const VarNode* v) { return var_map_.count(GetRef<Var>(v)); };
+  PrimExpr a = op->a;
+  PrimExpr b = op->b;
+  if (!is_const_int(a) && UsesVar(a, f_use_itervar)) {
+    a = this->DirectMutate(op->a);
+  }
+  if (!is_const_int(b) && UsesVar(b, f_use_itervar)) {
+    b = this->DirectMutate(op->b);
+  }
 
   // const folding
   PrimExpr const_res = TryConstFold<Add>(a, b);
@@ -858,7 +1010,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const MulNode* op) {
 
   if (a->IsInstance<IterMapExprNode>() && b->IsInstance<IterMapExprNode>()) {
     // cannot multiply two iterators, mark as unresolved.
-    ++unresolved_count_;
+    Fail(Diagnostic::Error(op->span) << "Cannot multiply two iterators: " << GetRef<PrimExpr>(op));
     return GetRef<PrimExpr>(op);
   }
 
@@ -894,7 +1046,9 @@ PrimExpr IterMapRewriter::SplitFloorDivConst(IterSplitExpr lhs, PrimExpr rhs,
         lhs.CopyOnWrite()->scale = make_const(rhs->dtype, 1);
       } else {
         // mark as unresolved.
-        ++unresolved_count_;
+        Fail(Diagnostic::Error(orig->span)
+             << "Can not prove floordiv rhs " << rhs << " divisible by lhs scale " << lhs->scale
+             << ", lhs=" << lhs);
         return orig;
       }
     }
@@ -916,7 +1070,8 @@ PrimExpr IterMapRewriter::SplitFloorDivConst(IterSplitExpr lhs, PrimExpr rhs,
     return std::move(lhs);
   } else {
     // mark as unresolved.
-    ++unresolved_count_;
+    Fail(Diagnostic::Error(orig->span)
+         << "Can not prove floordiv lhs extent " << lhs->extent << " divisible by rhs " << rhs);
     return orig;
   }
 }
@@ -944,7 +1099,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorDivNode* op) {
 
   if (b->IsInstance<IterMapExprNode>()) {
     // cannot divide an iterator, mark as unresolved.
-    ++unresolved_count_;
+    Fail(Diagnostic::Error(op->span) << "Cannot divide an iterator: " << GetRef<PrimExpr>(op));
     return GetRef<PrimExpr>(op);
   }
 
@@ -953,7 +1108,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorDivNode* op) {
     if (Optional<IterSplitExpr> opt = TryFuseIters(ret)) {
       return SplitFloorDivConst(opt.value(), b, GetRef<PrimExpr>(op));
     } else {
-      ++unresolved_count_;
+      Fail(Diagnostic::Error(op->span) << "Fuse IterSumExpr " << ret << " failed");
       return GetRef<PrimExpr>(op);
     }
   } else {
@@ -977,7 +1132,8 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr rhs,
         rhs = floordiv(rhs, lhs->scale);
       } else {
         // mark as unresolved.
-        ++unresolved_count_;
+        Fail(Diagnostic::Error(orig->span) << "Can not prove floormod rhs " << rhs
+                                           << " divisible by " << lhs->scale << ", lhs=" << lhs);
         return orig;
       }
     }
@@ -991,7 +1147,8 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr rhs,
     return std::move(lhs);
   } else {
     // mark as unresolved.
-    ++unresolved_count_;
+    Fail(Diagnostic::Error(orig->span)
+         << "Can not prove floormod lhs extent " << lhs->extent << " divisible by rhs " << rhs);
     return orig;
   }
 }
@@ -1019,7 +1176,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorModNode* op) {
 
   if (b->IsInstance<IterMapExprNode>()) {
     // cannot mod an iterator, mark as unresolved.
-    ++unresolved_count_;
+    Fail(Diagnostic::Error(op->span) << "Cannot mod an iterator: " << GetRef<PrimExpr>(op));
     return GetRef<PrimExpr>(op);
   }
 
@@ -1028,7 +1185,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorModNode* op) {
     if (Optional<IterSplitExpr> opt = TryFuseIters(ret)) {
       return SplitFloorModConst(opt.value(), b, GetRef<PrimExpr>(op));
     } else {
-      ++unresolved_count_;
+      Fail(Diagnostic::Error(op->span) << "Fail to fuse iters of " << ret);
       return GetRef<PrimExpr>(op);
     }
   } else {
@@ -1039,19 +1196,21 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorModNode* op) {
 }
 
 /*! * \brief Given an IterVarMapExpr, transform it to normal PrimExpr. */
-class IterMapToExprNormalizer {
+class IterMapToExprNormalizer : public ExprMutator {
  public:
   explicit IterMapToExprNormalizer(Analyzer* analyzer) : analyzer_(analyzer) {}
 
-  PrimExpr Convert(const IterMapExpr& expr) {
+  PrimExpr Convert(const IterMapExpr& expr) { return VisitExpr(expr); }
+
+ private:
+  /*! \brief Override VisitExpr for iter expr type processing */
+  PrimExpr VisitExpr(const PrimExpr& expr) override {
     if (const auto* op = expr.as<IterSplitExprNode>()) {
       return ConvertIterSplitExpr(GetRef<IterSplitExpr>(op));
     } else if (const auto* op = expr.as<IterSumExprNode>()) {
       return ConvertIterSumExpr(GetRef<IterSumExpr>(op));
     } else {
-      ICHECK(expr.defined());
-      LOG(FATAL) << "Unknown IterMapExpr type " << expr->GetTypeKey();
-      return 0;
+      return ExprMutator::VisitExpr(expr);
     }
   }
 
@@ -1071,7 +1230,7 @@ class IterMapToExprNormalizer {
     } else if (const auto* op = expr->source->source.as<IterSumExprNode>()) {
       source = ConvertIterSumExpr(GetRef<IterSumExpr>(op));
     } else {
-      LOG(FATAL) << "Unexpected source of IterSplitExpr";
+      source = VisitExpr(expr->source->source);
     }
     if (analyzer_->CanProve(expr->extent == expr->source->extent) && is_one(expr->lower_factor)) {
       return source * expr->scale;
@@ -1100,8 +1259,9 @@ Array<PrimExpr> IterMapSimplify(const Array<PrimExpr>& indices, const Map<Var, R
                                 const PrimExpr& input_pred, bool require_bijective) {
   if (!IterRangeSanityCheck(input_iters)) return indices;
   Analyzer analyzer;
+  DiagnosticContext diag_ctx(DiagnosticContext::Default(IRModule()));
   Array<IterSumExpr> rewrite =
-      DetectIterMap(indices, input_iters, input_pred, require_bijective, &analyzer);
+      DetectIterMap(indices, input_iters, input_pred, require_bijective, &analyzer, diag_ctx);
   if (rewrite.empty()) {
     return indices;
   }
@@ -1128,8 +1288,9 @@ Array<PrimExpr> IterMapSimplify(const Array<PrimExpr>& indices, const Map<Var, R
 class SubspaceDivider {
  public:
   explicit SubspaceDivider(Analyzer* analyzer, const IterMarkSplitCollector& collector,
-                           const std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>& sub_iters)
-      : analyzer_(analyzer), collector_(collector), sub_iters_(sub_iters) {}
+                           const std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>& sub_iters,
+                           DiagnosticContext diag_ctx)
+      : analyzer_(analyzer), collector_(collector), sub_iters_(sub_iters), diag_ctx_(diag_ctx) {}
 
   size_t unresolved_count() const { return unresolved_count_; }
 
@@ -1175,7 +1336,7 @@ class SubspaceDivider {
       if (const auto* op = expr.as<IterSplitExprNode>()) {
         return GetRef<IterSplitExpr>(op);
       } else if (const auto* op = expr.as<IterSumExprNode>()) {
-        return IterSplitExpr(IterMark(GetRef<IterSumExpr>(op), extent));
+        return IterSplitExpr(IterMark(GetRef<IterSumExpr>(op), 0, extent));
       } else {
         LOG(FATAL) << "Unknown IterMapExpr type";
         return NullValue<IterSplitExpr>();
@@ -1190,7 +1351,10 @@ class SubspaceDivider {
       return DivisionResult(IterSumExpr({}, 0), 1, IterSumExpr({}, expr->base), 1);
     } else if (expr->args.size() == 1) {
       // arg + base, if arg=Y*E(X)+X, then arg+base = Y*E(X)+(X+base)
-      if (!is_one(expr->args[0]->scale)) return Fail();
+      if (!is_one(expr->args[0]->scale)) {
+        return Fail(Diagnostic::Error(expr->span)
+                    << "Expect split scale be 1, got " << expr->args[0]->scale);
+      }
       DivisionResult res = DivideIterSplitExpr(expr->args[0]);
       if (!is_zero(expr->base)) res = AddBase(res, expr->base);
       return res;
@@ -1208,7 +1372,9 @@ class SubspaceDivider {
       DivisionResult arg_division = DivideIterSplitExpr(arg);
       IterSplitExpr new_arg;
       if (arg_division.IsInner()) {
-        if (!inner) return Fail();
+        if (!inner)
+          return Fail(Diagnostic::Error(expr->span)
+                      << "Current division is inner but outer division exists for previous args");
         new_arg = arg_division.GetInnerAsSplit();
         inner_args.push_back(new_arg);
         inner = true;
@@ -1217,11 +1383,13 @@ class SubspaceDivider {
         outer_args.push_back(new_arg);
         inner = false;
       } else {
-        return Fail();
+        return Fail(Diagnostic::Error(expr->span)
+                    << "Division of " << arg << " is neither inner nor outer");
       }
       extent *= new_arg->extent;
     }
-    if (!scale_is_one) return Fail();
+    if (!scale_is_one)
+      return Fail(Diagnostic::Error(expr->span) << "Expect all iter sum arg's scale be 1");
     bool need_predicate = !analyzer_->CanProveEqual(extent, mark_extent);
     const IterMark& outer_mark = MarkFromArgsAndBase(outer_args, 0);
     const IterMark& inner_mark = MarkFromArgsAndBase(inner_args, expr->base);
@@ -1240,7 +1408,8 @@ class SubspaceDivider {
         inner_preds_ = inner_preds_ && (converter.Convert(inner_source) < mark_extent);
         return DivisionResult::Inner(inner_source, mark_extent);
       } else {
-        return Fail();
+        return Fail(Diagnostic::Error(expr->span)
+                    << "Either inner or outer args should exists if need predicate: " << expr);
       }
     }
     return DivisionResult(outer_source, outer_mark->extent, inner_source, inner_mark->extent);
@@ -1250,8 +1419,11 @@ class SubspaceDivider {
   PrimExpr GetInnerPreds() const { return inner_preds_; }
 
  private:
-  DivisionResult Fail() {
+  DivisionResult Fail(const Diagnostic& diagnostic) {
     unresolved_count_++;
+    if (diag_ctx_.defined()) {
+      diag_ctx_.Emit(diagnostic);
+    }
     return DivisionResult(IterSumExpr({}, 0), 0, IterSumExpr({}, 0), 0);
   }
 
@@ -1276,7 +1448,7 @@ class SubspaceDivider {
       extent *= arg->extent;
       res.push_back(arg);
     }
-    return IterMark(IterSumExpr(Array<IterSplitExpr>(res.rbegin(), res.rend()), base), extent);
+    return IterMark(IterSumExpr(Array<IterSplitExpr>(res.rbegin(), res.rend()), base), 0, extent);
   }
 
   DivisionResult DivideIterSplitExpr(const IterSplitExpr& expr) {
@@ -1317,8 +1489,10 @@ class SubspaceDivider {
       if (splits.size() == 1) {
         return mark_division;
       }
-      IterMark outer_mark(Downcast<IterSumExpr>(mark_division.outer), mark_division.outer_extent);
-      IterMark inner_mark(Downcast<IterSumExpr>(mark_division.inner), mark_division.inner_extent);
+      IterMark outer_mark(Downcast<IterSumExpr>(mark_division.outer), 0,
+                          mark_division.outer_extent);
+      IterMark inner_mark(Downcast<IterSumExpr>(mark_division.inner), 0,
+                          mark_division.inner_extent);
       bool encountered_boundary = mark_division.IsOuter();
       std::vector<bool> used(splits.size(), false);
       std::vector<IterSplitExpr> inner_iters, outer_iters;
@@ -1330,7 +1504,10 @@ class SubspaceDivider {
           if (!used[j] && analyzer_->CanProveEqual(splits[j]->lower_factor, expected_lower_factor))
             break;
         }
-        if (j == splits.size()) return Fail();
+        if (j == splits.size())
+          return Fail(Diagnostic::Error(expr->span)
+                      << "Can not find expected lower factor " << expected_lower_factor
+                      << " in splits of " << expr->source);
         used[j] = true;
         if (!encountered_boundary) {
           inner_iters.push_back(splits[j]);
@@ -1341,7 +1518,9 @@ class SubspaceDivider {
         if (analyzer_->CanProveEqual(expected_lower_factor, mark_division.inner_extent))
           encountered_boundary = true;
       }
-      if (!encountered_boundary) return Fail();
+      if (!encountered_boundary)
+        return Fail(Diagnostic::Error(expr->span)
+                    << "Can not find inner/outer boundary of " << expr);
       for (const IterSplitExpr& inner_iter : inner_iters) {
         IterSplitExpr new_iter = inner_iter;
         new_iter.CopyOnWrite()->source = inner_mark;
@@ -1355,7 +1534,8 @@ class SubspaceDivider {
         split_map_.emplace(outer_iter, DivisionResult::Outer(new_iter, outer_iter->extent));
       }
     } else {
-      return Fail();
+      return Fail(Diagnostic::Error(expr->span)
+                  << "Source expr to divide is neither var nor IterSumExpr");
     }
     return split_map_.at(expr);
   }
@@ -1371,15 +1551,18 @@ class SubspaceDivider {
   std::unordered_map<IterSplitExpr, DivisionResult, ObjectPtrHash, ObjectPtrEqual> split_map_;
   // predicate of outer space and inner space;
   PrimExpr outer_preds_{Bool(true)}, inner_preds_{Bool(true)};
+  // diagnostic context
+  DiagnosticContext diag_ctx_;
 };
 
 Array<Array<IterMark>> SubspaceDivide(const Array<PrimExpr>& bindings,
                                       const Map<Var, Range>& input_iters,
                                       const Array<Var>& sub_iters, const PrimExpr& predicate,
-                                      bool require_bijective, arith::Analyzer* analyzer) {
+                                      bool require_bijective, arith::Analyzer* analyzer,
+                                      DiagnosticContext diag_ctx) {
   if (!IterRangeSanityCheck(input_iters)) return Array<Array<IterMark>>();
   const Array<IterSumExpr>& maps =
-      DetectIterMap(bindings, input_iters, predicate, require_bijective, analyzer);
+      DetectIterMap(bindings, input_iters, predicate, require_bijective, analyzer, diag_ctx);
   if (maps.empty()) return {};
 
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> inner_iter_set;
@@ -1389,18 +1572,18 @@ Array<Array<IterMark>> SubspaceDivide(const Array<PrimExpr>& bindings,
 
   IterMarkSplitCollector collector;
   collector.Collect(maps);
-  SubspaceDivider subspace_divider(analyzer, collector, inner_iter_set);
+  SubspaceDivider subspace_divider(analyzer, collector, inner_iter_set, diag_ctx);
 
   std::vector<Array<IterMark>> results;
   for (const IterSumExpr& expr : maps) {
     SubspaceDivider::DivisionResult res = subspace_divider.DivideIterSumExpr(expr, 0);
     if (subspace_divider.unresolved_count()) return {};
     results.push_back(
-        {IterMark(res.outer, res.outer_extent), IterMark(res.inner, res.inner_extent)});
+        {IterMark(res.outer, 0, res.outer_extent), IterMark(res.inner, 0, res.inner_extent)});
   }
 
-  results.push_back({IterMark(IterSumExpr({}, 0), subspace_divider.GetOuterPreds()),
-                     IterMark(IterSumExpr({}, 0), subspace_divider.GetInnerPreds())});
+  results.push_back({IterMark(IterSumExpr({}, 0), 0, subspace_divider.GetOuterPreds()),
+                     IterMark(IterSumExpr({}, 0), 0, subspace_divider.GetInnerPreds())});
   return results;
 }
 
@@ -1409,7 +1592,9 @@ TVM_REGISTER_GLOBAL("arith.SubspaceDivide")
                        const Array<Var>& sub_iters, const PrimExpr& predicate,
                        bool require_bijective) {
       arith::Analyzer ana;
-      return SubspaceDivide(bindings, root_iters, sub_iters, predicate, require_bijective, &ana);
+      DiagnosticContext diag_ctx(DiagnosticContext::Default(IRModule()));
+      return SubspaceDivide(bindings, root_iters, sub_iters, predicate, require_bijective, &ana,
+                            diag_ctx);
     });
 
 class InverseAffineIterMapTransformer {

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -362,7 +362,8 @@ class IterMapRewriter : public ExprMutator {
   // input iter marks
   std::vector<IterMark> input_marks_;
   // The map for sum that maps flattened form to IterMark with normal form and extent (and possibly
-  // an extra offset) Example(1): expr = i*9 + j*2 + k, i in [0, 4) j in [0, 5) k in [0, 2)
+  // an extra offset)
+  // Example(1): expr = i*9 + j*2 + k, i in [0, 4) j in [0, 5) k in [0, 2)
   //          predicate: j*2 + k < 9
   // Then,    flattened form = IterSum(IterSplit(i, scale=9),
   //                                   IterSplit(j, scale=2),

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -415,12 +415,14 @@ bool IsAffineBinding(const BlockRealize& realize, const Map<Var, Range>& loop_va
   if (loop_var_ranges.empty()) {
     return true;
   }
+  DiagnosticContext diag_ctx(DiagnosticContext::Default(IRModule()));
   Array<arith::IterSumExpr> results = arith::DetectIterMap(
       /*indices=*/realize->iter_values,
       /*input_iters=*/loop_var_ranges,
       /*predicate=*/realize->predicate,
       /*require_bijective=*/false,
-      /*analyzer=*/analyzer);
+      /*analyzer=*/analyzer,
+      /*diag_ctx*/ diag_ctx);
   if (results.empty()) {
     return false;
   }

--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -16,6 +16,7 @@
 # under the License.
 import tvm
 from tvm import te
+from tvm import tir
 from tvm.ir.base import structural_equal
 
 
@@ -238,14 +239,9 @@ def test_region_lower_bound_for_non_perfect_tile():
     h1 = tvm.tir.Var("h1", "int32")
     h2 = tvm.tir.Var("h2", "int32")
     h3 = tvm.tir.Var("h3", "int32")
-    # h1, h2 are bounded, h3 is free
-    var_dom = {
-        h2: tvm.ir.Range(begin=0, end=2),
-        h1: tvm.ir.Range(begin=0, end=5),
-    }
     analyzer = tvm.arith.Analyzer()
 
-    def do_test_point_access(point, predicates, expect):
+    def do_test_point_access(point, predicates, var_dom, expect):
         regions = tvm.arith.estimate_region_lower_bound(
             region=[
                 tvm.ir.Range.from_min_extent(min_value=point, extent=1),
@@ -257,29 +253,68 @@ def test_region_lower_bound_for_non_perfect_tile():
             assert regions is None
         else:
             assert len(regions) == 1
-            assert structural_equal(
-                analyzer.simplify(expect[0], 3), analyzer.simplify(regions[0].min_value, 3)
-            )
-            assert structural_equal(
-                analyzer.simplify(expect[1], 3), analyzer.simplify(regions[0].max_value, 3)
-            )
+            for binding, expect_min, expect_max in expect:
+                min_diff = expect_min - regions[0].min_value
+                assert analyzer.simplify(tir.stmt_functor.substitute(min_diff, binding), 3) == 0
+                max_diff = expect_max - regions[0].max_value
+                assert analyzer.simplify(tir.stmt_functor.substitute(max_diff, binding), 3) == 0
 
-    # normal case of a non-uniform tiling
+    # non-uniform tiling, single inner variable
     # h3 == 0: region is [1, 9]
     # 0 < h3 <= 26: region is [h3 * 8, h3 * 8 + 9]
     # h3 > 26: region is [h3 * 8, 223]
     do_test_point_access(
+        point=h3 * 8 + h2,
+        predicates=[1 <= h3 * 8 + h2, h3 * 8 + h2 < 224],
+        var_dom={
+            h2: tvm.ir.Range(begin=0, end=10),
+        },
+        expect=[
+            (
+                {},
+                tvm.tir.max(h3 * 8, 1),
+                tvm.tir.max(h3 * 8, 1)
+                - tvm.tir.max(h3 * 8, 214)
+                - tvm.tir.max(1 - h3 * 8, 0)
+                + 223,
+            ),
+            ({h3: 0}, 1, 9),
+            ({h3: 10}, h3 * 8, h3 * 8 + 9),
+            ({h3: 27}, h3 * 8, 223),
+        ],
+    )
+
+    # non-uniform tiling, two inner variables
+    do_test_point_access(
         point=h3 * 8 + h2 * 5 + h1,
         predicates=[1 <= h3 * 8 + h2 * 5 + h1, h3 * 8 + h2 * 5 + h1 < 224],
-        expect=(
-            tvm.tir.max(h3 * 8, 1),
-            tvm.tir.max(h3 * 8, 1) - tvm.tir.max(h3 * 8, 214) - tvm.tir.max(1 - h3 * 8, 0) + 223,
-        ),
+        var_dom={
+            h2: tvm.ir.Range(begin=0, end=2),
+            h1: tvm.ir.Range(begin=0, end=5),
+        },
+        expect=[
+            (
+                {},
+                tvm.tir.max(h3 * 8, 1),
+                tvm.tir.max(h3 * 8, 1)
+                - tvm.tir.max(h3 * 8, 214)
+                - tvm.tir.max(1 - h3 * 8, 0)
+                + 223,
+            ),
+            ({h3: 0}, 1, 9),
+            ({h3: 10}, h3 * 8, h3 * 8 + 9),
+            ({h3: 27}, h3 * 8, 223),
+        ],
     )
+
     # should fail on incompatible predicates
     do_test_point_access(
         point=h3 * 8 + h2 * 5 + h1,
         predicates=[1 <= h3 * 8 + h2 * 5 + h1, h3 * 8 + h1 * 2 + h2 < 224],
+        var_dom={
+            h2: tvm.ir.Range(begin=0, end=2),
+            h1: tvm.ir.Range(begin=0, end=5),
+        },
         expect=None,
     )
 

--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -271,7 +271,7 @@ def test_region_lower_bound_for_non_perfect_tile():
             tvm.tir.max(h3 * 8, 1) - tvm.tir.max(h3 * 8, 214) - tvm.tir.max(1 + h3 * -8, 0) + 223,
         ),
     )
-    # shoud fail on incompatible predicates
+    # should fail on incompatible predicates
     do_test_point_access(
         point=h3 * 8 + h2 * 5 + h1,
         predicates=[1 <= h3 * 8 + h2 * 5 + h1, h3 * 8 + h1 * 2 + h2 < 224],

--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -16,6 +16,7 @@
 # under the License.
 import tvm
 from tvm import te
+from tvm.ir.base import structural_equal
 
 
 class IntSetChecker:
@@ -233,6 +234,51 @@ def test_region_lower_bound_negative_scale():
     assert int_set_1.max_value.value == 35
 
 
+def test_region_lower_bound_for_non_perfect_tile():
+    h1 = tvm.tir.Var("h1", "int32")
+    h2 = tvm.tir.Var("h2", "int32")
+    h3 = tvm.tir.Var("h3", "int32")
+    # h1, h2 are bounded, h3 is free
+    var_dom = {
+        h2: tvm.ir.Range(begin=0, end=2),
+        h1: tvm.ir.Range(begin=0, end=5),
+    }
+
+    def do_test_point_access(point, predicates, expect):
+        regions = tvm.arith.estimate_region_lower_bound(
+            region=[
+                tvm.ir.Range.from_min_extent(min_value=point, extent=1),
+            ],
+            var_dom=var_dom,
+            predicate=tvm.tir.all(*predicates),
+        )
+        if expect is None:  # expect a failure
+            assert regions is None
+        else:
+            assert len(regions) == 1
+            assert structural_equal(expect[0], regions[0].min_value)
+            assert structural_equal(expect[1], regions[0].max_value)
+
+    # normal case of a non-uniform tiling
+    # h3 == 0: region is [1, 9]
+    # 0 < h3 <= 8: region is [h3 * 8, h3 * 8 + 9]
+    # h3 > 8: region is [h3 * 8, 223]
+    do_test_point_access(
+        point=h3 * 8 + h2 * 5 + h1,
+        predicates=[1 <= h3 * 8 + h2 * 5 + h1, h3 * 8 + h2 * 5 + h1 < 224],
+        expect=(
+            tvm.tir.max(h3 * 8, 1),
+            tvm.tir.max(h3 * 8, 1) - tvm.tir.max(h3 * 8, 214) - tvm.tir.max(1 + h3 * -8, 0) + 223,
+        ),
+    )
+    # shoud fail on incompatible predicates
+    do_test_point_access(
+        point=h3 * 8 + h2 * 5 + h1,
+        predicates=[1 <= h3 * 8 + h2 * 5 + h1, h3 * 8 + h1 * 2 + h2 < 224],
+        expect=None,
+    )
+
+
 def test_union_lower_bound():
     neg_inf = tvm.arith.int_set.neg_inf()
     pos_inf = tvm.arith.int_set.pos_inf()
@@ -257,4 +303,5 @@ if __name__ == "__main__":
     test_region_lower_bound_split_predicate()
     test_region_lower_bound_multiple_variables()
     test_region_lower_bound_negative_scale()
+    test_region_lower_bound_for_non_perfect_tile()
     test_union_lower_bound()

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -247,24 +247,21 @@ def test_predicate():
     res = tvm.arith.detect_iter_map([i], var_dom([(i, 48)]), tvm.tir.all(i < 10))
     assert_iter_sum_pattern(res[0], 10, 0)
 
-    # iterations are subparts of constraint, case 1
+    # iterations are subparts of constraint, invalid, case 1
     res = tvm.arith.detect_iter_map(
         [i, j, k],
         var_dom([(i, 128), (j, 128), (k, 128)]),
         tvm.tir.all(i * 16384 + j * 128 + k < 100),
     )
-    assert_iter_sum_pattern(res[0], 128, 0)
-    assert_iter_sum_pattern(res[1], 128, 0)
-    assert_iter_sum_pattern(res[2], 128, 0)
+    assert len(res) == 0
 
-    # iterations are subparts of constraint, case 2
+    # iterations are subparts of constraint, invalid, case 2
     res = tvm.arith.detect_iter_map(
         [i * 128 + j, k],
         var_dom([(i, 128), (j, 128), (k, 128)]),
         tvm.tir.all(i * 16384 + j * 128 + k < 100),
     )
-    assert_iter_sum_pattern(res[0], 16384, 0)
-    assert_iter_sum_pattern(res[1], 128, 0)
+    assert len(res) == 0
 
     # constraint on nested fused iters
     res = tvm.arith.detect_iter_map(

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -44,7 +44,7 @@ def var_dom(iters):
     return {var: tvm.ir.Range(0, ext) for var, ext in iters}
 
 
-def assert_iter_sum_pattern(sum_expr, extent, base, scale=1, mark_min=0, mark_extent=None):
+def assert_iter_sum_pattern(sum_expr, extent, base, scale=1, mark_extent=None):
     """Check the sum expr have the right pattern."""
     assert isinstance(sum_expr, tvm.arith.IterSumExpr)
     if extent == 1:
@@ -53,9 +53,6 @@ def assert_iter_sum_pattern(sum_expr, extent, base, scale=1, mark_min=0, mark_ex
         assert len(sum_expr.args) == 1
         tvm.testing.assert_prim_expr_equal(sum_expr.args[0].extent, extent)
         tvm.testing.assert_prim_expr_equal(sum_expr.args[0].scale, scale)
-        tvm.testing.assert_prim_expr_equal(sum_expr.args[0].source.min, mark_min)
-        if mark_extent:
-            tvm.testing.assert_prim_expr_equal(sum_expr.args[0].source.extent, mark_extent)
     tvm.testing.assert_prim_expr_equal(sum_expr.base, base)
 
 
@@ -181,8 +178,8 @@ def test_compound():
     assert_iter_sum_pattern(res[0], 18, 0)
     assert_iter_sum_pattern(res[1], 5, 0)
     # reconstruct the pattern manually
-    mx = tvm.arith.IterMark(x[0], 0, 10)
-    my = tvm.arith.IterMark(y[0], 0, 9)
+    mx = tvm.arith.IterMark(x[0], 10)
+    my = tvm.arith.IterMark(y[0], 9)
 
     xoscale = 3
     xiscale = 1
@@ -193,7 +190,7 @@ def test_compound():
     myo = tvm.arith.IterSplitExpr(my, 3, 3, yoscale)
     myi = tvm.arith.IterSplitExpr(my, 1, 3, yiscale)
 
-    mz = tvm.arith.IterMark(tvm.arith.IterSumExpr([myo, mxo, myi], 0), 0, 18)
+    mz = tvm.arith.IterMark(tvm.arith.IterSumExpr([myo, mxo, myi], 0), 18)
     sz = tvm.arith.IterSumExpr([tvm.arith.IterSplitExpr(mz, 1, 18, 1)], 0)
     tvm.ir.assert_structural_equal(sz, res[0])
 
@@ -214,10 +211,10 @@ def test_predicate():
     # lower bound only
     res = tvm.arith.detect_iter_map([x[0] * 10 + y[0]], var_dom([x, y]), x[0] * 10 + y[0] > 5)
     assert len(res) == 1
-    assert_iter_sum_pattern(res[0], 130, 0, mark_min=6, mark_extent=124)
+    assert_iter_sum_pattern(res[0], 124, 6)
     res = tvm.arith.detect_iter_map([x[0] * 10 + y[0]], var_dom([x, y]), x[0] * 10 + y[0] >= 6)
     assert len(res) == 1
-    assert_iter_sum_pattern(res[0], 130, 0, mark_min=6, mark_extent=124)
+    assert_iter_sum_pattern(res[0], 124, 6)
 
     # lower bound + upper bound
     res = tvm.arith.detect_iter_map(
@@ -226,14 +223,14 @@ def test_predicate():
         tvm.tir.And(x[0] * 10 + y[0] > 5, x[0] * 10 + y[0] < 128),
     )
     assert len(res) == 1
-    assert_iter_sum_pattern(res[0], 128, 0, mark_min=6, mark_extent=122)
+    assert_iter_sum_pattern(res[0], 122, 6)
     res = tvm.arith.detect_iter_map(
         [x[0] * 10 + y[0]],
         var_dom([x, y]),
         tvm.tir.And(x[0] * 10 + y[0] >= 6, x[0] * 10 + y[0] <= 127),
     )
     assert len(res) == 1
-    assert_iter_sum_pattern(res[0], 128, 0, mark_min=6, mark_extent=122)
+    assert_iter_sum_pattern(res[0], 122, 6)
 
     # non-standard form of predicate
     res = tvm.arith.detect_iter_map([x[0] * 10 + y[0]], var_dom([x, y]), x[0] * 10 < 128 - y[0])
@@ -577,12 +574,12 @@ def test_complex():
     )
     assert len(res) == 2
 
-    n0_mark = tvm.arith.IterMark(n0[0], 0, n0[1])
-    n1_mark = tvm.arith.IterMark(n1[0], 0, n1[1])
-    l0_mark = tvm.arith.IterMark(l0[0], 0, l0[1])
-    l1_mark = tvm.arith.IterMark(l1[0], 0, l1[1])
-    m1_mark = tvm.arith.IterMark(m1[0], 0, m1[1])
-    l3_mark = tvm.arith.IterMark(l3[0], 0, l3[1])
+    n0_mark = tvm.arith.IterMark(n0[0], n0[1])
+    n1_mark = tvm.arith.IterMark(n1[0], n1[1])
+    l0_mark = tvm.arith.IterMark(l0[0], l0[1])
+    l1_mark = tvm.arith.IterMark(l1[0], l1[1])
+    m1_mark = tvm.arith.IterMark(m1[0], m1[1])
+    l3_mark = tvm.arith.IterMark(l3[0], l3[1])
 
     m0_expr = tvm.arith.IterSumExpr(
         [
@@ -591,12 +588,12 @@ def test_complex():
         ],
         0,
     )
-    m0_mark = tvm.arith.IterMark(m0_expr, 0, 6)
+    m0_mark = tvm.arith.IterMark(m0_expr, 6)
     l2_expr = tvm.arith.IterSumExpr(
         [tvm.arith.IterSplitExpr(m0_mark, 1, 6, 3), tvm.arith.IterSplitExpr(m1_mark, 1, m1[1], 1)],
         0,
     )
-    l2_mark = tvm.arith.IterMark(l2_expr, 0, 16)
+    l2_mark = tvm.arith.IterMark(l2_expr, 16)
     k0_expr = tvm.arith.IterSplitExpr(l0_mark, 2, 2, 4)
     k1_expr = tvm.arith.IterSplitExpr(l1_mark, 2, 4, 1)
     k2_expr = tvm.arith.IterSplitExpr(l2_mark, 4, 4, 8)
@@ -607,19 +604,19 @@ def test_complex():
     k7_expr = tvm.arith.IterSplitExpr(l3_mark, 1, 4, 1)
 
     j0_expr = tvm.arith.IterSumExpr([k0_expr, k1_expr], 0)
-    j0_mark = tvm.arith.IterMark(j0_expr, 0, 7)
+    j0_mark = tvm.arith.IterMark(j0_expr, 7)
     i0_expr = tvm.arith.IterSumExpr(
         [tvm.arith.IterSplitExpr(j0_mark, 1, 7, 32), k2_expr, k3_expr], 0
     )
 
     j3_expr = tvm.arith.IterSumExpr([k6_expr, k7_expr], 0)
-    j3_mark = tvm.arith.IterMark(j3_expr, 0, 15)
+    j3_mark = tvm.arith.IterMark(j3_expr, 15)
     i1_expr = tvm.arith.IterSumExpr(
         [k4_expr, k5_expr, tvm.arith.IterSplitExpr(j3_mark, 1, 15, 1)], 0
     )
 
-    i0_mark = tvm.arith.IterMark(i0_expr, 0, i0[1])
-    i1_mark = tvm.arith.IterMark(i1_expr, 0, i1[1])
+    i0_mark = tvm.arith.IterMark(i0_expr, i0[1])
+    i1_mark = tvm.arith.IterMark(i1_expr, i1[1])
 
     i0_final = tvm.arith.IterSumExpr([tvm.arith.IterSplitExpr(i0_mark, 1, i0[1], 1)], 0)
     i1_final = tvm.arith.IterSumExpr([tvm.arith.IterSplitExpr(i1_mark, 1, i1[1], 1)], 0)
@@ -688,7 +685,7 @@ def test_normalize_iter_map_to_expr():
     tvm.ir.assert_structural_equal(tvm.arith.normalize_iter_map_to_expr(res[1]), flm(x[0], 5))
 
     # iter mark wrap a complex expr
-    split = tvm.arith.IterSplitExpr(tvm.arith.IterMark(x[0] * y[0] + 1, 0, 1024), 1, 1024, 1)
+    split = tvm.arith.IterSplitExpr(tvm.arith.IterMark(x[0] * y[0] + 1, 1024), 1, 1024, 1)
     tvm.ir.assert_structural_equal(tvm.arith.normalize_iter_map_to_expr(split), x[0] * y[0] + 1)
 
 

--- a/tests/python/unittest/test_tir_schedule_reorder.py
+++ b/tests/python/unittest/test_tir_schedule_reorder.py
@@ -217,9 +217,8 @@ def test_reorder_with_predicate():
     sch = tir.Schedule(elementwise_predicate, debug_mask="all")
     block_b = sch.get_block("B")
     i, j, k, l = sch.get_loops(block_b)
-    sch.reorder(l, i)
-    tvm.ir.assert_structural_equal(elementwise_reordered_with_predicate, sch.mod["main"])
-    verify_trace_roundtrip(sch=sch, mod=elementwise_predicate)
+    with pytest.raises(tvm.tir.ScheduleError):
+        sch.reorder(l, i)
 
 
 def test_reorder_fail_with_multi_appearance_loops():

--- a/tests/python/unittest/test_tir_schedule_rfactor.py
+++ b/tests/python/unittest/test_tir_schedule_rfactor.py
@@ -690,11 +690,9 @@ def test_reduction_rfactor_predicate():  # pylint: disable=invalid-name
     s = tir.Schedule(rowsum_predicate, debug_mask="all")
     B = s.get_block("B")
     _, ko, _ = s.get_loops(B)
-    rf_block = s.rfactor(ko, 1)
-    tvm.ir.assert_structural_equal(s.mod["main"], rowsum_predicate_rfactor)
-    assert s.get(rf_block).same_as(s.get(s.get_block("B_rf")))
-    assert s.get(B).same_as(s.get(s.get_block("B")))
-    verify_trace_roundtrip(s, mod=rowsum_predicate)
+    # TODO: should be a tvm.tir.ScheduleError
+    with pytest.raises(tvm.TVMError):
+        rf_block = s.rfactor(ko, 1)
 
 
 def test_reduction_rfactor_with_annotation():

--- a/tests/python/unittest/test_tir_schedule_state_cached_flags.py
+++ b/tests/python/unittest/test_tir_schedule_state_cached_flags.py
@@ -320,11 +320,11 @@ def non_perfect_tiling_cache(a: T.handle, b: T.handle) -> None:
     Y = T.match_buffer(b, [224, 224], dtype="float32")
     cache = T.alloc_buffer([224, 224], dtype="float32")
     for hh_0, ww_0 in T.grid(28, 28):
-        for ax0 in T.serial(0, T.min(hh_0 * 8 + 8, 223) + 1 - T.max(hh_0 * 8 - 1, 0)):
-            for ax1 in T.serial(0, T.min(ww_0 * 8 + 8, 223) + 1 - T.max(ww_0 * 8 - 1, 0)):
+        for ax0 in T.serial(0, 10):
+            for ax1 in T.serial(0, 10):
                 with T.block("cache"):
-                    h = T.axis.spatial(224, T.max(hh_0 * 8 - 1, 0) + ax0)
-                    w = T.axis.spatial(224, T.max(ww_0 * 8 - 1, 0) + ax1)
+                    h = T.axis.spatial(224, hh_0 * 8 - 1 + ax0)
+                    w = T.axis.spatial(224, ww_0 * 8 - 1 + ax1)
                     T.where(
                         1 <= hh_0 * 8 + ax0
                         and hh_0 * 8 + ax0 < 225

--- a/tests/python/unittest/test_tir_schedule_state_cached_flags.py
+++ b/tests/python/unittest/test_tir_schedule_state_cached_flags.py
@@ -314,6 +314,39 @@ def warp_memory_negative(a: T.handle, c: T.handle) -> None:
                         C[warp_id * 32 + lane_id, vj] = B[vj, warp_id, lane_id] + 1.0
 
 
+@T.prim_func
+def non_uniform_tiling_cache(a: T.handle, b: T.handle) -> None:
+    X = T.match_buffer(a, [224, 224], dtype="float32")
+    Y = T.match_buffer(b, [224, 224], dtype="float32")
+    cache = T.alloc_buffer([224, 224], dtype="float32")
+    for hh_0, ww_0 in T.grid(28, 28):
+        for ax0 in T.serial(0, T.min(hh_0 * 8 + 8, 223) + 1 - T.max(hh_0 * 8 - 1, 0)):
+            for ax1 in T.serial(0, T.min(ww_0 * 8 + 8, 223) + 1 - T.max(ww_0 * 8 - 1, 0)):
+                with T.block("cache"):
+                    h = T.axis.spatial(224, T.max(hh_0 * 8 - 1, 0) + ax0)
+                    w = T.axis.spatial(224, T.max(ww_0 * 8 - 1, 0) + ax1)
+                    cache[h, w] = X[h, w]
+        for hh_1, ww_1, khh, kww in T.grid(8, 8, 3, 3):
+            with T.block("compute"):
+                h = T.axis.spatial(224, hh_0 * 8 + hh_1)
+                w = T.axis.spatial(224, ww_0 * 8 + ww_1)
+                kh, kw = T.axis.remap("RR", [khh, kww])
+                with T.init():
+                    Y[h, w] = 0.0
+                Y[h, w] = T.max(
+                    Y[h, w],
+                    T.if_then_else(
+                        T.likely(1 <= h + kh, dtype="bool")
+                        and T.likely(h + kh < 225, dtype="bool")
+                        and T.likely(1 <= w + kw, dtype="bool")
+                        and T.likely(w + kw < 225, dtype="bool"),
+                        cache[h + kh - 1, w + kw - 1],
+                        0.0,
+                        dtype="float32",
+                    ),
+                )
+
+
 # pylint: enable=no-member,invalid-name,unused-variable,unexpected-keyword-arg
 
 
@@ -697,6 +730,22 @@ def test_warp_memory_negative():
     assert s._get_cached_flags(_get_block(s, "C")) == CachedFlags(
         affine_binding=True,
         region_cover=False,
+        stage_pipeline=True,
+    )
+    # pylint: enable=protected-access
+
+
+def test_non_uniform_tiling():
+    s = tir.ScheduleState(non_uniform_tiling_cache, debug_mask="all")
+    # pylint: disable=protected-access
+    assert s._get_cached_flags(_get_block(s, "cache")) == CachedFlags(
+        affine_binding=False,
+        region_cover=True,
+        stage_pipeline=True,
+    )
+    assert s._get_cached_flags(_get_block(s, "compute")) == CachedFlags(
+        affine_binding=True,
+        region_cover=True,
         stage_pipeline=True,
     )
     # pylint: enable=protected-access

--- a/tests/python/unittest/test_tir_schedule_state_cached_flags.py
+++ b/tests/python/unittest/test_tir_schedule_state_cached_flags.py
@@ -751,7 +751,7 @@ def test_non_perfect_tiling_cache():
     )
     assert s._get_cached_flags(_get_block(s, "compute")) == CachedFlags(
         affine_binding=True,
-        region_cover=True,
+        region_cover=False,
         stage_pipeline=True,
     )
     # pylint: enable=protected-access


### PR DESCRIPTION
Hi, there. The PR originate from the issue detected in https://github.com/apache/tvm/pull/9527, where a tiled block with both lowerbound and upperbound predicates fail to infer the `region_cover` property. Some tracing show that the `DetectIterMap` fail on such cases.
```python
for hh_0, ww_0 in T.grid(28, 28):
    for ax0, ax1 in T.grid(10, 10):
        with T.block("cache"):
            h = T.axis.spatial(224, hh_0 * 8 - 1 + ax0)
            w = T.axis.spatial(224, ww_0 * 8 - 1 + ax1)
            T.where(1 <= hh_0 * 8 + ax0 and hh_0 * 8 + ax0 < 225 and 1 <= ww_0 * 8 + ax1 and ww_0 * 8 + ax1 < 225)
            cache[h, w] = X[h, w]
```

The PR modify affine utility in aspects below :
- Free vars
  For `DetectIterMap`, if the expression do not contain vars in domain map, it should be safe to not analyze affine form into it. eg,  `x*x + 8y + z` could pass affine analysis if `x` is not an var of iter domains. We can just put `x*x` into base part of IterSumExpr. It benefit the above case since `hh_0 * 8 + ax0` is not an affine form, but outer var might be free in certain analysis procedures.

- Add `min` field to `IterMark` class
  It is zero almost all time. But when lowerbound predicate exists, it seems much hard to represent the lowerbound with only source and extent.

- More flexible predicate support
  Support resolve all kinds of >, >=, <, <= integer comparisions, for the expr of form like `i * 8 < 10 - j`, try refactor the expr into domain var related part and domain var free parts. 

- Introduce `DiagnosticContext` for debug purpose
  Replace each fail point (`++unresolved_cnt_`) with an error message recorded into diagnostic context. Or else it would be too hard to detect what happend for beginners. However, I do not find a proper point to call `Render()` of diagnostics for now.