### PR TITLE
[ONNX][Converter] Fix when onnxoptimizer is unavailable

### DIFF
--- a/python/tvm/contrib/target/onnx.py
+++ b/python/tvm/contrib/target/onnx.py
@@ -59,7 +59,7 @@ def run_onnx_optimizer(onnx_model):
     else:
         return onnxoptimizer.optimize(onnx_model)
 
-    return model
+    return onnx_model
 
 
 def tvm_array_to_list(arr):


### PR DESCRIPTION
Fix the error below
```python
  File "~/tvm/python/tvm/contrib/target/onnx.py", line 1078, in to_onnx
    onnx_model = converter.convert_to_onnx(func)
  File "~/tvm/python/tvm/contrib/target/onnx.py", line 912, in convert_to_onnx
    return run_onnx_optimizer(model)
  File "~/tvm/python/tvm/contrib/target/onnx.py", line 62, in run_onnx_optimizer
    return model
NameError: name 'model' is not defined
```