### PR TITLE
[ETHOSN] Allow Ethos(TM)-N testing without hardware

### DIFF
--- a/src/runtime/contrib/ethosn/ethosn_runtime.cc
+++ b/src/runtime/contrib/ethosn/ethosn_runtime.cc
@@ -116,7 +116,11 @@ Module EthosnModule::LoadFromBinary(void* strm) {
 #if _ETHOSN_API_VERSION_ <= 2102
     compiled.compiled_cmm = sl::DeserializeCompiledNetwork(cmm_strm);
 #else
+#if defined ETHOSN_HW
+    // If hardware unavaiable use the mock inference functionality. If hardware is
+    // avaiable, deserialize the compiled graph.
     compiled.runtime_cmm = std::make_unique<dl::Network>(cmm.c_str(), cmm.size());
+#endif
 #endif
     // Read the number of inputs
     stream->Read<uint64_t>(&input_size);


### PR DESCRIPTION
If no hardware is available, simulated tests allows execution
of the Ethos(TM)-N - TVM integration. This patch allows this
for the 21.08 release of the Ethos(TM)-N driver stack.
