### PR TITLE
[microNPU] Added checks for out of range shifts

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/vela_api.py
+++ b/python/tvm/relay/backend/contrib/ethosu/vela_api.py
@@ -316,7 +316,10 @@ def _quantize_scale(scale: float) -> Tuple[int, int]:
     mantissa_scaled = mantissa * (1 << 31)
     mantissa_scaled = int(util.round_away_zero(mantissa_scaled))
     required_shift = 31 - exponent
-    assert 0 <= required_shift < (1 << 6)
+    if not (0 <= required_shift < (1 << 6)):
+        # Shift outside of valid range, set scale to 0
+        return 0, 16
+
     return mantissa_scaled, required_shift
 
 
@@ -332,6 +335,11 @@ def _reduced_quantize_scale(scale: float) -> Tuple[int, int]:
     else:
         reduced_mantissa_scaled = (mantissa_scaled + (1 << 15)) >> 16
     reduced_shift = required_shift - 16
+
+    if not (0 <= reduced_shift < (1 << 6)):
+        # Shift outside of valid range, set scale to 0
+        return 0, 16
+
     return reduced_mantissa_scaled, reduced_shift
 
 

--- a/python/tvm/relay/backend/contrib/ethosu/vela_api.py
+++ b/python/tvm/relay/backend/contrib/ethosu/vela_api.py
@@ -316,7 +316,7 @@ def _quantize_scale(scale: float) -> Tuple[int, int]:
     mantissa_scaled = mantissa * (1 << 31)
     mantissa_scaled = int(util.round_away_zero(mantissa_scaled))
     required_shift = 31 - exponent
-    if not (0 <= required_shift < (1 << 6)):
+    if required_shift < 0 or required_shift >= (1 << 6):
         # Shift outside of valid range, set scale to 0
         return 0, 16
 
@@ -336,7 +336,7 @@ def _reduced_quantize_scale(scale: float) -> Tuple[int, int]:
         reduced_mantissa_scaled = (mantissa_scaled + (1 << 15)) >> 16
     reduced_shift = required_shift - 16
 
-    if not (0 <= reduced_shift < (1 << 6)):
+    if required_shift < 0 or required_shift >= (1 << 6):
         # Shift outside of valid range, set scale to 0
         return 0, 16
 

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -242,6 +242,93 @@ def test_ethosu_conv2d_double(
     infra.verify_source(compiled_models, accel_type)
 
 
+@pytest.mark.parametrize("weight_min, weight_max", [(0.0, 1e-11), (-1e10, 1e10)])
+def test_out_of_range_scaling(weight_min, weight_max):
+    ifm_shape = (1, 6, 6, 2)
+    dtype = "int8"
+    strides = (1, 1)
+    kernel_shape = (1, 1)
+    dilation = (1, 1)
+    padding = "SAME"
+    activation = "RELU"
+    accel_type = "ethos-u55-128"
+
+    def create_tflite_graph():
+        class Model(tf.Module):
+            @tf.function
+            def tf_function(self, x):
+                # Use tf.nn API to create the model
+                tf_strides = [1, strides[0], strides[1], 1]
+                weights = np.random.uniform(size=[kernel_shape[-1], kernel_shape[1], 2, 2])
+                # Overwrite to force quantization that produces out of range shift values
+                weights[0][0][0][0] = weight_min
+                weights[0][0][1][0] = weight_max
+                op = tf.nn.conv2d(
+                    x,
+                    filters=tf.constant(
+                        weights,
+                        dtype=tf.float32,
+                    ),
+                    strides=tf_strides,
+                    padding=padding,
+                    dilations=dilation,
+                )
+                if activation:
+                    op = tf.nn.relu(op)
+                return op
+
+        model = Model()
+        concrete_func = model.tf_function.get_concrete_function(
+            tf.TensorSpec(ifm_shape, dtype=tf.float32)
+        )
+
+        # Convert the model
+        def representative_dataset():
+            for _ in range(100):
+                data = np.random.rand(*tuple(ifm_shape))
+                yield [data.astype(np.float32)]
+
+        converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.representative_dataset = representative_dataset
+        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+        converter.inference_input_type = tf.int8
+        converter.inference_output_type = tf.int8
+        tflite_model = converter.convert()
+        return tflite_model
+
+    tflite_graph = create_tflite_graph()
+    tflite_model = tflite.Model.Model.GetRootAsModel(tflite_graph, 0)
+
+    relay_module, params = relay.frontend.from_tflite(
+        tflite_model,
+        shape_dict={"input": ifm_shape},
+        dtype_dict={"input": dtype},
+    )
+    mod = partition_for_ethosu(relay_module, params)
+    print(mod)
+
+    # Generate reference data
+    input_data, output_data = infra.generate_ref_data_tflite(tflite_graph)
+
+    compiled_models = infra.build_source(
+        mod,
+        input_data,
+        output_data,
+        accel_type,
+    )
+
+    # Assumes only two runtime.Modules are created -- i.e. single offload module
+    ethosu_module = compiled_models[0].executor_factory.lib.imported_modules[0].imported_modules[0]
+
+    # Verify generated C source
+    get_artifacts = tvm._ffi.get_global_func("runtime.module.ethos-u.get_artifacts")
+    compilation_artifacts = get_artifacts(ethosu_module)
+    cmms = bytes.fromhex(compilation_artifacts[0].command_stream)
+    infra.print_payload(cmms)
+    infra.verify_source(compiled_models, accel_type)
+
+
 def _compare_ethosu_with_reference(
     mod, input_data, output_data, accel_type, output_tolerance=0, print_cmm=False
 ):

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -245,7 +245,6 @@ def test_ethosu_conv2d_double(
 @pytest.mark.parametrize("weight_min, weight_max", [(0.0, 1e-11), (-1e10, 1e10)])
 def test_out_of_range_scaling(weight_min, weight_max):
     ifm_shape = (1, 6, 6, 2)
-    dtype = "int8"
     strides = (1, 1)
     kernel_shape = (1, 1)
     dilation = (1, 1)
@@ -253,80 +252,29 @@ def test_out_of_range_scaling(weight_min, weight_max):
     activation = "RELU"
     accel_type = "ethos-u55-128"
 
-    def create_tflite_graph():
-        class Model(tf.Module):
-            @tf.function
-            def tf_function(self, x):
-                # Use tf.nn API to create the model
-                tf_strides = [1, strides[0], strides[1], 1]
-                weights = np.random.uniform(size=[kernel_shape[-1], kernel_shape[1], 2, 2])
-                # Overwrite to force quantization that produces out of range shift values
-                weights[0][0][0][0] = weight_min
-                weights[0][0][1][0] = weight_max
-                op = tf.nn.conv2d(
-                    x,
-                    filters=tf.constant(
-                        weights,
-                        dtype=tf.float32,
-                    ),
-                    strides=tf_strides,
-                    padding=padding,
-                    dilations=dilation,
-                )
-                if activation:
-                    op = tf.nn.relu(op)
-                return op
-
-        model = Model()
-        concrete_func = model.tf_function.get_concrete_function(
-            tf.TensorSpec(ifm_shape, dtype=tf.float32)
+    @tf.function
+    def conv_invalid_scale(x):
+        # Use tf.nn API to create the model
+        tf_strides = [1, strides[0], strides[1], 1]
+        weights = np.random.uniform(size=[kernel_shape[0], kernel_shape[1], 2, 2])
+        # Overwrite to force quantization that produces out of range shift values
+        weights[0][0][0][0] = weight_min
+        weights[0][0][1][0] = weight_max
+        op = tf.nn.conv2d(
+            x,
+            filters=tf.constant(
+                weights,
+                dtype=tf.float32,
+            ),
+            strides=tf_strides,
+            padding=padding,
+            dilations=dilation,
         )
+        if activation:
+            op = tf.nn.relu(op)
+        return op
 
-        # Convert the model
-        def representative_dataset():
-            for _ in range(100):
-                data = np.random.rand(*tuple(ifm_shape))
-                yield [data.astype(np.float32)]
-
-        converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
-        converter.optimizations = [tf.lite.Optimize.DEFAULT]
-        converter.representative_dataset = representative_dataset
-        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
-        converter.inference_input_type = tf.int8
-        converter.inference_output_type = tf.int8
-        tflite_model = converter.convert()
-        return tflite_model
-
-    tflite_graph = create_tflite_graph()
-    tflite_model = tflite.Model.Model.GetRootAsModel(tflite_graph, 0)
-
-    relay_module, params = relay.frontend.from_tflite(
-        tflite_model,
-        shape_dict={"input": ifm_shape},
-        dtype_dict={"input": dtype},
-    )
-    mod = partition_for_ethosu(relay_module, params)
-    print(mod)
-
-    # Generate reference data
-    input_data, output_data = infra.generate_ref_data_tflite(tflite_graph)
-
-    compiled_models = infra.build_source(
-        mod,
-        input_data,
-        output_data,
-        accel_type,
-    )
-
-    # Assumes only two runtime.Modules are created -- i.e. single offload module
-    ethosu_module = compiled_models[0].executor_factory.lib.imported_modules[0].imported_modules[0]
-
-    # Verify generated C source
-    get_artifacts = tvm._ffi.get_global_func("runtime.module.ethos-u.get_artifacts")
-    compilation_artifacts = get_artifacts(ethosu_module)
-    cmms = bytes.fromhex(compilation_artifacts[0].command_stream)
-    infra.print_payload(cmms)
-    infra.verify_source(compiled_models, accel_type)
+    _compare_tvm_with_tflite(conv_invalid_scale, [ifm_shape], accel_type)
 
 
 def _compare_ethosu_with_reference(


### PR DESCRIPTION
Bugfix, removed an invalid assert.
Added explicit handling of quantization `scale` and `shift` values that are outside the valid range of the NPU.
