### PR TITLE
[LLVM][Hexagon] Fix LLVM version

### DIFF
--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -298,6 +298,9 @@ if(USE_HEXAGON_RPC)
     ${HEXAGON_RPC_OUTPUT} COPYONLY)
 
   set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${HEXAGON_RPC_OUTPUT}")
+
+  # Used in `src/target/llvm/llvm_common.h`
+  add_definitions(-DTVM_USE_HEXAGON_LLVM)
 endif()
 
 if(USE_HEXAGON_DEVICE STREQUAL "${PICK_SIM}")

--- a/src/target/llvm/llvm_common.h
+++ b/src/target/llvm/llvm_common.h
@@ -71,7 +71,11 @@
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/MemoryBuffer.h>
+#if TVM_LLVM_VERSION >= 140 && !defined(TVM_USE_HEXAGON_LLVM)
+#include <llvm/MC/TargetRegistry.h>
+#else
 #include <llvm/Support/TargetRegistry.h>
+#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>


### PR DESCRIPTION
PR https://github.com/apache/tvm/pull/9631 breaks LLVM version due to conflict between qualcomm hexagon LLVM 14 include structure with LLVM. This PR introduces an LLVM flag for Hexagon.

Thanks to @driazati for catching this.

cc @csullivan 
