### PR TITLE
[TVMC] run: Don't use static path to find model.tar

### DIFF
--- a/python/tvm/driver/tvmc/model.py
+++ b/python/tvm/driver/tvmc/model.py
@@ -47,6 +47,7 @@ import os
 import tarfile
 import json
 from typing import Optional, Union, Dict, Callable, TextIO
+from pathlib import Path
 import numpy as np
 
 import tvm
@@ -258,7 +259,7 @@ class TVMCModel(object):
         Parameters
         ----------
         executor_factory : GraphExecutorFactoryModule
-            The factory containing compiled the compiled artifacts needed to run this model.
+            The factory containing the compiled artifacts needed to run this model.
         package_path : str, None
             Where the model should be saved. Note that it will be packaged as a .tar file.
             If not provided, the package will be saved to a generically named file in tmp.
@@ -311,12 +312,19 @@ class TVMCPackage(object):
     ----------
     package_path : str
         The path to the saved TVMCPackage that will be loaded.
+
+    project_dir : Path, str
+        If given and loading a MLF file, the path to the project directory that contains the file.
     """
 
-    def __init__(self, package_path: str):
+    def __init__(self, package_path: str, project_dir: Optional[Union[Path, str]] = None):
         self._tmp_dir = utils.tempdir()
         self.package_path = package_path
         self.import_package(self.package_path)
+
+        if project_dir and self.type != "mlf":
+            raise TVMCException("Setting 'project_dir' is only allowed when importing a MLF.!")
+        self.project_dir = project_dir
 
     def import_package(self, package_path: str):
         """Load a TVMCPackage from a previously exported TVMCModel.

--- a/tests/python/driver/tvmc/conftest.py
+++ b/tests/python/driver/tvmc/conftest.py
@@ -187,6 +187,7 @@ def tflite_compile_model(tmpdir_factory):
         args = {"target": "llvm", **overrides}
         return tvmc.compiler.compile_model(tvmc_model, package_path=package_path, **args)
 
+    # Returns a TVMCPackage
     return model_compiler
 
 

--- a/tests/python/driver/tvmc/test_mlf.py
+++ b/tests/python/driver/tvmc/test_mlf.py
@@ -88,6 +88,33 @@ def test_tvmc_export_package_mlf(tflite_mobilenet_v1_1_quant, tmpdir_factory):
     assert str(exp.value) == expected_reason, on_error
 
 
+def test_tvmc_import_package_project_dir(tflite_mobilenet_v1_1_quant, tflite_compile_model):
+    pytest.importorskip("tflite")
+
+    # Generate a MLF archive.
+    compiled_model_mlf_tvmc_package = tflite_compile_model(
+        tflite_mobilenet_v1_1_quant, output_format="mlf"
+    )
+
+    # Import the MLF archive setting 'project_dir'. It must succeed.
+    mlf_archive_path = compiled_model_mlf_tvmc_package.package_path
+    tvmc_package = TVMCPackage(mlf_archive_path, project_dir="/tmp/foobar")
+    assert tvmc_package.type == "mlf", "Can't load the MLF archive passing the project directory!"
+
+    # Generate a Classic archive.
+    compiled_model_classic_tvmc_package = tflite_compile_model(tflite_mobilenet_v1_1_quant)
+
+    # Import the Classic archive setting 'project_dir'.
+    # It must fail since setting 'project_dir' is only support when importing a MLF archive.
+    classic_archive_path = compiled_model_classic_tvmc_package.package_path
+    with pytest.raises(TVMCException) as exp:
+        tvmc_package = TVMCPackage(classic_archive_path, project_dir="/tmp/foobar")
+
+    expected_reason = "Setting 'project_dir' is only allowed when importing a MLF.!"
+    on_error = "A TVMCException was caught but its reason is not the expected one."
+    assert str(exp.value) == expected_reason, on_error
+
+
 def test_tvmc_import_package_mlf_graph(tflite_mobilenet_v1_1_quant, tflite_compile_model):
     pytest.importorskip("tflite")
 


### PR DESCRIPTION
Currently `tvmc run` can't run Arduino models because `model.tar` is never found:

```
$ tvmc run --device micro /tmp/arduino_sine --project-option arduino_board=due --print-top 6 --fill-mode zeros
Error: File /tmp/arduino_sine/model.tar does not exist.
```

This happens because Arduino doesn't store `model.tar` in `<project_dir>/model.tar` like Zephyr.

If this change is applied the MLF path used is taken as returned by the Project API, so `tvmc run` now works for both Zephyr and Arduino and any future platforms:

```
$ tvmc run --device micro /tmp/arduino_sine --project-option arduino_board=due --print-top 6 --fill-mode zeros
[[0.        ]
 [0.03384194]]
```