### PR TITLE
Fix GLOBAL_SCOPE Shallow copy bug

### DIFF
--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -19,6 +19,7 @@
 
 class AutotvmGlobalScope(object):
     """The global autotvm scope. And the deepcopy function: deep copy AutotvmGlobalScope state."""
+
     current = None
 
     def __init__(self):

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -18,7 +18,7 @@
 
 
 class AutotvmGlobalScope(object):
-    """The global autotvm scope. And the deepcopy function: deep copy AutotvmGlobalScope state."""
+    """The global autotvm scope."""
 
     current = None
 
@@ -30,6 +30,7 @@ class AutotvmGlobalScope(object):
         self.silent = False
 
     def deepcopy(self, global_scope):
+        """Deep copy from another instance of AutotvmGlobalScope."""
         self._old = AutotvmGlobalScope.current
 
         self.in_tuning = global_scope.in_tuning

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -41,4 +41,4 @@ def reset_global_scope(global_scope):
     """Reset global autotvm state. This is needed to initialize PopenPool workers."""
     global GLOBAL_SCOPE
     GLOBAL_SCOPE.deepcopy(global_scope)
-    AutotvmGlobalScope.current = GLOBAL_SCOPE
+    AutotvmGlobalScope.current = global_scope

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -29,7 +29,6 @@ class AutotvmGlobalScope(object):
 
     def deepcopy(self, global_scope):
         self._old = AutotvmGlobalScope.current
-        AutotvmGlobalScope.current = global_scope
 
         self.in_tuning = global_scope.in_tuning
         self.silent = global_scope.silent
@@ -42,3 +41,4 @@ def reset_global_scope(global_scope):
     """Reset global autotvm state. This is needed to initialize PopenPool workers."""
     global GLOBAL_SCOPE
     GLOBAL_SCOPE.deepcopy(global_scope)
+    AutotvmGlobalScope.current = GLOBAL_SCOPE

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -18,6 +18,7 @@
 
 
 class AutotvmGlobalScope(object):
+    """The global autotvm scope. And the deepcopy function: deep copy AutotvmGlobalScope state."""
     current = None
 
     def __init__(self):

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -41,4 +41,4 @@ GLOBAL_SCOPE = AutotvmGlobalScope()
 def reset_global_scope(global_scope):
     """Reset global autotvm state. This is needed to initialize PopenPool workers."""
     global GLOBAL_SCOPE
-    GLOBAL_SCOPE = global_scope
+    GLOBAL_SCOPE.deepcopy(global_scope)

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -29,7 +29,7 @@ class AutotvmGlobalScope(object):
         self.in_tuning = False
         self.silent = False
 
-    def deepcopy(self, global_scope):
+    def deep_copy(self, global_scope):
         """Deep copy from another instance of AutotvmGlobalScope."""
         self._old = AutotvmGlobalScope.current
 
@@ -43,5 +43,5 @@ GLOBAL_SCOPE = AutotvmGlobalScope()
 def reset_global_scope(global_scope):
     """Reset global autotvm state. This is needed to initialize PopenPool workers."""
     global GLOBAL_SCOPE
-    GLOBAL_SCOPE.deepcopy(global_scope)
+    GLOBAL_SCOPE.deep_copy(global_scope)
     AutotvmGlobalScope.current = global_scope

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -27,6 +27,13 @@ class AutotvmGlobalScope(object):
         self.in_tuning = False
         self.silent = False
 
+    def deepcopy(self, global_scope):
+        self._old = AutotvmGlobalScope.current
+        AutotvmGlobalScope.current = global_scope
+
+        self.in_tuning = global_scope.in_tuning
+        self.silent = global_scope.silent
+
 
 GLOBAL_SCOPE = AutotvmGlobalScope()
 
@@ -35,4 +42,3 @@ def reset_global_scope(global_scope):
     """Reset global autotvm state. This is needed to initialize PopenPool workers."""
     global GLOBAL_SCOPE
     GLOBAL_SCOPE = global_scope
-    AutotvmGlobalScope.current = global_scope


### PR DESCRIPTION
In the process of using autotvm to tune dense_pack [(python/tvm/topi/x86/dense.py:242)](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/topi/x86/dense.py#L242) did not enter in_tuning, that is, autotvm.GLOBALSCOPE.in_tuning = False, but in the tuner.tune function ([python/ tvm/autotvm/tuner/tuner.py:123](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/autotvm/tuner/tuner.py#L123)) has been set to True.

The test code is as follows

 ```jsx
import tempfile

import numpy as np
from tvm.autotvm.tuner import XGBTuner, RandomTuner
import tvm
from tvm import relay, auto_scheduler,autotvm, topi
from tvm.relay import transform
from tvm.contrib import graph_executor
import tvm.testing
from tvm.relay.testing.temp_op_attr import TempOpAttr
import sys
import logging
import os

logging.getLogger("te_compiler").setLevel(logging.INFO)
logging.getLogger("te_compiler").addHandler(logging.StreamHandler(sys.stdout))

def get_np_array(var, dtype):
    return np.random.randn(*[int(x) for x in var.type_annotation.shape]).astype(dtype)

def get_relay_dense(m=5, n=256, k=438):
    dtype = "float32"
    d = relay.var("data", shape=(m, k), dtype=dtype)
    w = relay.var("weight", shape=(n, k), dtype=dtype)
    y = relay.nn.dense(d, w)
    mod = tvm.IRModule()
    mod["main"] = relay.Function([d, w], y)
    data, weight = get_np_array(d, dtype), get_np_array(w, dtype)
    return mod, data, weight

def autotvmtune_and_check(mod, data, weight):
    print("Extract tasks from a relay program")
    target = tvm.target.Target("llvm")
    
    tasks = autotvm.task.extract_from_program(mod["main"], target=target, params={"weight": weight})
    for i, task in enumerate(tasks):
        prefix = "[Task %2d/%2d] " % (i + 1, len(tasks))
        print(task)
        #tuner_obj = XGBTuner(task)
        tuner_obj = RandomTuner(task)
        tuner_obj.tune(
            n_trial=2000,
            early_stopping=800,
            measure_option=autotvm.measure_option(builder=autotvm.LocalBuilder(), runner=autotvm.LocalRunner(number=5, timeout=20, enable_cpu_cache_flush=True)),
            callbacks=[
                autotvm.callback.progress_bar(
                    2000, prefix=prefix),
                autotvm.callback.log_to_file("dense_test.json"),
            ],
        )
    print("compling")
    with autotvm.apply_history_best("dense_test.json"):
        with tvm.target.Target("llvm"):
            with TempOpAttr("nn.dense", "FTVMAlterOpLayout", topi.x86.dense_alter_op._alter_dense_layout):
                seq = tvm.transform.Sequential([transform.AlterOpLayout()])
                with tvm.transform.PassContext(opt_level=3, config={}):
                    mod = seq(mod)
                    lib = relay.build(mod, target=target, params={"weight": weight})
    dev = tvm.device(str(target), 0)
    module = graph_executor.GraphModule(lib["default"](dev))
    print(module.module.time_evaluator(
                "run", dev, repeat=10, number=1000, min_repeat_ms=500
            )()) 
    print("Compile without auto-scheduler for correctness check")
    with tvm.transform.PassContext(opt_level=0):
        lib2 = relay.build(mod, target=target, params={"weight": weight})

    def get_output(data, lib):
        dev = tvm.cpu()
        module = graph_executor.GraphModule(lib["default"](dev))
        module.set_input("data", data)
        module.run()

        return module.get_output(0).numpy()

    # Check correctness
    actual_output = get_output(data, lib)
    expected_output = get_output(data, lib2)

    tvm.testing.assert_allclose(actual_output, expected_output, rtol=1e-4, atol=2e-4)


def test_dense():
    mod, data, weight = get_relay_dense()
    print("tune_and_check")
    autotvmtune_and_check(mod, data, weight)


if __name__ == "__main__":
    os.environ["TVM_NUM_THREADS"] = str(1)
    test_dense()
```

For checking convenience, set max_workers = 1([python/tvm/contrib/popen_pool.py:304](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/contrib/popen_pool.py#L304))，Write the log in the source code to get:

1. The main process ([python/tvm/autotvm/tuner/tuner.py:129](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/autotvm/tuner/tuner.py#L129))

Function tune GLOBAL_SCOPE = <tvm.autotvm.env.AutotvmGlobalScope object at 0x7f3dc62da0b8>

Function tune GLOBAL_SCOPE.in_tuning = True

2. Child process reset([python/tvm/autotvm/env.py](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/autotvm/env.py#L36))

Function reset_global_scope old GLOBAL_SCOPE = <tvm.autotvm.env.AutotvmGlobalScope object at 0x7f8e361c2128>

Function reset_global_scope old GLOBAL_SCOPE.in_tuning = False

Function reset_global_scope new GLOBAL_SCOPE = <tvm.autotvm.env.AutotvmGlobalScope object at 0x7f8d488ff9b0>

Function reset_global_scope new GLOBAL_SCOPE.in_tuning = True

3.  Child process  dense_pack([python/tvm/topi/x86/dense.py](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/topi/x86/dense.py#L242))

Function dense_pack autotvm.GLOBAL_SCOPE = <tvm.autotvm.env.AutotvmGlobalScope object at 0x7f8e361c2128>

Function dense_pack autotvm.GLOBAL_SCOPE.in_tuning = False

Function dense_pack autotvm.GLOBAL_SCOPE.current = <tvm.autotvm.env.AutotvmGlobalScope object at 0x7f8d488ff9b0>

Function dense_pack autotvm.GLOBAL_SCOPE.current.in_tuning = True


The main process passes the current value of GLOBAL_SCOPE to the child process, and the child process resets its own GLOBAL_SCOPE and changes current at the same time.
However, the address of autotvm.GLOBALSCOPE in dense_pack has not changed, and it is still the old GLOBALSCOPE. At this time, current is changed.

I think the reason for this bug is that the reset_global_scope function is a shallow copy of GLOBAL_SCOPE, and the problem is solved after replacing it with a deep copy.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
