### PR TITLE
[Relay] Non-recursive dependency graph

### DIFF
--- a/src/relay/ir/indexed_graph.cc
+++ b/src/relay/ir/indexed_graph.cc
@@ -61,7 +61,11 @@ IndexedGraph<Expr> CreateIndexedGraph(const Expr& expr) {
       auto post_visit = [&](const LetNode* op) {
         this->VisitExpr(op->body);
         if (let != op) {
+          Expr expr = GetRef<Expr>(op);
           visit_counter_[op]++;
+          auto node = std::make_shared<IndexedGraph<Expr>::Node>(expr, index_++);
+          graph_.node_map_[expr] = node;
+          graph_.topological_order_.push_back(node);
         }
       };
       ExpandANormalForm(let, pre_visit, post_visit);

--- a/src/relay/ir/indexed_graph.cc
+++ b/src/relay/ir/indexed_graph.cc
@@ -51,6 +51,22 @@ IndexedGraph<Expr> CreateIndexedGraph(const Expr& expr) {
       graph_.node_map_[expr] = node;
       graph_.topological_order_.push_back(node);
     }
+
+    void VisitExpr_(const LetNode* let) override {
+      auto pre_visit = [&](const LetNode* op) {
+        this->VisitSpan(op->span);
+        this->VisitExpr(op->value);
+        this->VisitExpr(op->var);
+      };
+      auto post_visit = [&](const LetNode* op) {
+        this->VisitExpr(op->body);
+        if (let != op) {
+          visit_counter_[op]++;
+        }
+      };
+      ExpandANormalForm(let, pre_visit, post_visit);
+    }
+
     IndexedGraph<Expr> graph_;
     size_t index_ = 0;
   };


### PR DESCRIPTION
Relay IR printer suffers from stack overflow when the graph is too large. This PR cherry-picks #8434 to make it non-recursive.
