### PR TITLE
[Relay, BYOC] Make constant binding in PartitionGraph optional

### DIFF
--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -698,12 +698,19 @@ def LambdaLift():
 def PartitionGraph(mod_name="default", bind_constants=True):
     """Partition a Relay program into regions that can be executed on different
     backends.
+
     Parameters
     ----------
+    mod_name : string
+        Controls the prefix of the name of each partitioned subraph.
+        If `mod_name` is None, then `tvmgen_` prefix is used.
+        Otherwise, `tvmgen_mod_name_` prefix is used.
+
     bind_constants: bool
-        Whether or not to bind constants in partitioned subgraphs. For C-source based codegen,
-        it is recommended to set this to False to avoid embedding large constants in
-        a C source file.
+        Whether or not to bind constants in partitioned subgraphs. Note that the codegen needs
+        to maintain the bound constants; Otherwise the constants will be maintained by
+        the metadata module. So it is recommended for C-source based codegens to
+        set bind_constants=False to avoid embedding large constants in a C source file.
 
     Returns
     -------

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -695,9 +695,15 @@ def LambdaLift():
     return _ffi_api.LambdaLift()
 
 
-def PartitionGraph(mod_name="default"):
+def PartitionGraph(mod_name="default", bind_constants=True):
     """Partition a Relay program into regions that can be executed on different
     backends.
+    Parameters
+    ----------
+    bind_constants: bool
+        Whether or not to bind constants in partitioned subgraphs. For C-source based codegen,
+        it is recommended to set this to False to avoid embedding large constants in
+        a C source file.
 
     Returns
     -------
@@ -705,7 +711,7 @@ def PartitionGraph(mod_name="default"):
         The registered pass that partitions the Relay program.
     """
     mod_name = mangle_module_name(mod_name)
-    return _ffi_api.PartitionGraph(mod_name)
+    return _ffi_api.PartitionGraph(mod_name, bind_constants)
 
 
 def AnnotateTarget(targets, include_non_call_ops=True):

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -115,7 +115,8 @@ struct RegionFuncMetadata {
 
 class Partitioner : public MixedModeMutator {
  public:
-  explicit Partitioner(const IRModule& module) : module_(module) {
+  Partitioner(const IRModule& module, bool bind_constants)
+      : module_(module), bind_constants_(bind_constants) {
     std::set<std::string> func_names;
     for (auto f : module->functions) {
       GlobalVar f_var = f.first;
@@ -293,7 +294,7 @@ class Partitioner : public MixedModeMutator {
     Map<Var, Expr> params_bind;
     for (auto pair : region_func_meta_[region].args) {
       params.push_back(pair.first);
-      if (IsConstant(pair.second)) {
+      if (bind_constants_ && IsConstant(pair.second)) {
         params_bind.Set(pair.first, pair.second);
       } else {
         param_expr.push_back(pair.second);
@@ -401,6 +402,9 @@ class Partitioner : public MixedModeMutator {
 
   /*!\brief The IRModule used for partitioning. */
   IRModule module_;
+
+  /*!\brief Whether or not to bind constants in partitioned subgraphs. */
+  bool bind_constants_{false};
 };
 
 IRModule RemoveDefaultAnnotations(IRModule module) {
@@ -562,7 +566,7 @@ class NameMangleExtFuncs : public MixedModeMutator {
 
 namespace transform {
 
-Pass PartitionGraph(String mod_name) {
+Pass PartitionGraph(String mod_name, bool bind_constants) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> flatten_tuples = [=](IRModule m,
                                                                                  PassContext pc) {
     // There could be compiler_end annotations on tuples
@@ -581,8 +585,10 @@ Pass PartitionGraph(String mod_name) {
     return partitioning::RemoveDefaultAnnotations(m);
   };
 
-  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> part_func =
-      [=](IRModule m, PassContext pc) { return partitioning::Partitioner(m).Partition(); };
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> part_func = [=](IRModule m,
+                                                                            PassContext pc) {
+    return partitioning::Partitioner(m, bind_constants).Partition();
+  };
 
   auto name_mangling_fn = [mod_name](String name) {
     return runtime::get_name_mangled(mod_name, name);
@@ -601,9 +607,10 @@ Pass PartitionGraph(String mod_name) {
       {flatten_tuples_pass, remove_default_pass, partition_pass, name_mangling_pass, InferType()});
 }
 
-TVM_REGISTER_GLOBAL("relay._transform.PartitionGraph").set_body_typed([](String mod_name) {
-  return transform::PartitionGraph(mod_name);
-});
+TVM_REGISTER_GLOBAL("relay._transform.PartitionGraph")
+    .set_body_typed([](String mod_name, bool bind_constants = false) {
+      return transform::PartitionGraph(mod_name, bind_constants);
+    });
 
 }  // namespace transform
 

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -608,7 +608,7 @@ Pass PartitionGraph(String mod_name, bool bind_constants) {
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.PartitionGraph")
-    .set_body_typed([](String mod_name, bool bind_constants = false) {
+    .set_body_typed([](String mod_name, bool bind_constants) {
       return transform::PartitionGraph(mod_name, bind_constants);
     });
 


### PR DESCRIPTION
As discussed in https://discuss.tvm.apache.org/t/byoc-cutlass-dealing-with-constants-in-c-source-gen-based-byoc/11362, constant binding in C-source based BYOC is a common problem. So far, I've been avoiding this problem by **not** running `bind_params` and `FoldConstant` before partitioning. However, to convert `conv2d -> batch_norm -> relu` into `conv2d -> bias_add -> relu`, constant folding is necessary.

This PR is my proposal to allow batch norm fusion while avoiding constants binding. The change is simple and works perfectly for my use case.

Before `PartitionGraph`:
```
  %26 = annotation.compiler_begin(%input0, compiler="cutlass") /* ty=Tensor[(8, 3, 224, 224), float32] */;
  %27 = annotation.compiler_begin(meta[relay.Constant][0] /* ty=Tensor[(64, 3, 7, 7), float32] */, compiler="cutlass") /* ty=Tensor[(64, 3, 7, 7), float32] */;
  %28 = annotation.compiler_begin(meta[relay.Constant][1] /* ty=Tensor[(64, 1, 1), float32] */, compiler="cutlass") /* ty=Tensor[(64, 1, 1), float32] */;
  %29 = fn (%FunctionVar_8_01: Tensor[(8, 3, 224, 224), float32], %FunctionVar_8_11: Tensor[(64, 3, 7, 7), float32], %FunctionVar_8_21: Tensor[(64, 1, 1), float32], PartitionedFromPattern="nn.conv2d_add_nn.relu_", Composite="cutlass.conv2d_bias_relu") -> Tensor[(8, 64, 112, 112), float32] {
    ...
  };
  %30 = %29(%26, %27, %28) /* ty=Tensor[(8, 64, 112, 112), float32] */;
```

After  `PartitionGraph` with `bind_constants = False`:
```
def @main(%input0: Tensor[(8, 3, 224, 224), float32]) -> Tensor[(8, 1000), float32] {
  %0 = @tvmgen_default_cutlass_main_0(%input0, meta[relay.Constant][0] /* ty=Tensor[(64, 3, 7, 7), float32] */, meta[relay.Constant][1] /* ty=Tensor[(64, 1, 1), float32] */) /* ty=Tensor[(8, 64, 112, 112), float32] */;
   ...
}

def @tvmgen_default_cutlass_main_0(%cutlass_0_i0: Tensor[(8, 3, 224, 224), float32], %cutlass_0_i1: Tensor[(64, 3, 7, 7), float32], %cutlass_0_i2: Tensor[(64, 1, 1), float32], Inline=1, Compiler="cutlass", global_symbol="tvmgen_default_cutlass_main_0", Primitive=1) -> Tensor[(8, 64, 112, 112), float32] {
  %43 = fn (%FunctionVar_8_0: Tensor[(8, 3, 224, 224), float32], %FunctionVar_8_1: Tensor[(64, 3, 7, 7), float32], %FunctionVar_8_2: Tensor[(64, 1, 1), float32], PartitionedFromPattern="nn.conv2d_add_nn.relu_", Composite="cutlass.conv2d_bias_relu") -> Tensor[(8, 64, 112, 112), float32] {
     ...
  };
  %43(%cutlass_0_i0, %cutlass_0_i1, %cutlass_0_i2) /* ty=Tensor[(8, 64, 112, 112), float32] */
}

```

cc @zhiics @comaniac @manupa-arm @ashutosh-arm 