### PR TITLE
[Frontend] Add Span filling for frontends to Relay

### DIFF
--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -316,10 +316,13 @@ class TupleGetItem(ExprWithOp):
 
     index: int
         The index.
+
+    span: Optional[tvm.relay.Span]
+        Span that points to original source code
     """
 
-    def __init__(self, tuple_value, index):
-        self.__init_handle_by_constructor__(_ffi_api.TupleGetItem, tuple_value, index)
+    def __init__(self, tuple_value, index, span=None):
+        self.__init_handle_by_constructor__(_ffi_api.TupleGetItem, tuple_value, index, span)
 
 
 @tvm._ffi.register_object("relay.RefCreate")

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -956,40 +956,46 @@ def try_resolve_var_to_const(x, graph_params):
 
     return x
 
+
 def set_span(sym, node_name):
     """Set up the sapn for while converting OP"""
 
     class SpanFiller(ExprMutator):
         """SpanFiller"""
 
-        def __init__(self, node_name, surfix_str="_DERIVED_"):
+        def __init__(self, node_name, surfix_str="_PART_"):
             ExprMutator.__init__(self)
             self.node_name = node_name
             self.surfix_str = surfix_str
-            self.is_root = True
             self.counter = 0
+            self.distance_from_leaf = -1
 
         def _create_span(self):
-            if self.is_root:
-                self.is_root = False
+            if self.distance_from_leaf == 0:
                 return tvm.relay.Span(tvm.relay.SourceName(self.node_name), 0, 0, 0, 0)
+            self.distance_from_leaf -= 1
             span_str = "{}{}{}".format(self.node_name, self.surfix_str, str(self.counter))
             self.counter += 1
             return tvm.relay.Span(tvm.relay.SourceName(span_str), 0, 0, 0, 0)
 
         def visit_call(self, call):
-            if call.span == None:
+            if call.span is None:
+                self.distance_from_leaf += 1
                 new_args = [self.visit(arg) for arg in call.args]
-                return _expr.Call(call.op, new_args, call.attrs, call.type_args, self._create_span())
+                return _expr.Call(
+                    call.op, new_args, call.attrs, call.type_args, self._create_span()
+                )
             return call
 
         def visit_tuple(self, tup):
-            if tup.span == None:
+            if tup.span is None:
+                self.distance_from_leaf += 1
                 return _expr.Tuple([self.visit(field) for field in tup.fields], self._create_span())
             return tup
 
         def visit_tuple_getitem(self, op):
-            if op.span == None:
+            if op.span is None:
+                self.distance_from_leaf += 1
                 return _expr.TupleGetItem(self.visit(op.tuple_value), op.index, self._create_span())
             return op
 

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -958,15 +958,15 @@ def try_resolve_var_to_const(x, graph_params):
 
 
 def set_span(sym, node_name):
-    """Set up the sapn for while converting OP"""
+    """Set up the sapn of relay expression(s) while converting OP"""
 
     class SpanFiller(ExprMutator):
         """SpanFiller"""
 
-        def __init__(self, node_name, surfix_str="_PART_"):
+        def __init__(self, node_name, suffix_str="_PART_"):
             ExprMutator.__init__(self)
             self.node_name = node_name
-            self.surfix_str = surfix_str
+            self.suffix_str = suffix_str
             self.counter = 0
             self.distance_from_leaf = -1
 
@@ -974,7 +974,7 @@ def set_span(sym, node_name):
             if self.distance_from_leaf == 0:
                 return tvm.relay.Span(tvm.relay.SourceName(self.node_name), 0, 0, 0, 0)
             self.distance_from_leaf -= 1
-            span_str = "{}{}{}".format(self.node_name, self.surfix_str, str(self.counter))
+            span_str = "{}{}{}".format(self.node_name, self.suffix_str, str(self.counter))
             self.counter += 1
             return tvm.relay.Span(tvm.relay.SourceName(span_str), 0, 0, 0, 0)
 

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -999,9 +999,11 @@ def set_span(sym, node_name):
                 return _expr.TupleGetItem(self.visit(op.tuple_value), op.index, self._create_span())
             return op
 
-        def fill(self, expr):
-            if isinstance(expr, _expr.TupleWrapper):
-                return _expr.TupleWrapper(self.visit(expr.tuple_value), expr.size)
-            return self.visit(expr)
+        def fill(self, sym):
+            if isinstance(sym, _expr.TupleWrapper):
+                return _expr.TupleWrapper(self.visit(sym.tuple_value), sym.size)
+            elif isinstance(sym, _expr.RelayExpr):
+                return self.visit(sym)
+            return sym
 
     return SpanFiller(node_name).fill(sym)

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -1002,7 +1002,7 @@ def set_span(sym, node_name):
         def fill(self, sym):
             if isinstance(sym, _expr.TupleWrapper):
                 return _expr.TupleWrapper(self.visit(sym.tuple_value), sym.size)
-            elif isinstance(sym, _expr.RelayExpr):
+            if isinstance(sym, _expr.RelayExpr):
                 return self.visit(sym)
             return sym
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3322,17 +3322,17 @@ class PyTorchOpConverter:
     def _get_torch_span(self, node_repr):
         # torch span looks like
         # %input.5 : Float(...) = aten::relu_(%input.3), scope: __module.relu # ${torch}/nn file
-        scope_part = ''
-        aten_part = ''
-        scope_str = ', scope:'
-        aten_str =  'aten::'
+        scope_part = "EMPTY"
+        aten_part = ""
+        scope_str = ", scope:"
+        aten_str = "aten::"
         if scope_str in node_repr:
             scope_part = node_repr.split(scope_str)[1]
-            scope_part = scope_part.split('#')[0].strip()
+            scope_part = scope_part.split("#")[0].strip()
         if aten_str in node_repr:
             aten_part = node_repr.split(aten_str)[1]
-            aten_part = aten_str + aten_part.split('(')[0]
-        return 'C.graph: {}, , jit._trace.TopLevelTracedModule: {}'.format(aten_part, scope_part)
+            aten_part = aten_str + aten_part.split("(")[0]
+        return "C.graph: {}, , jit._trace.TopLevelTracedModule: {}".format(aten_part, scope_part)
 
 
 def _pytorch_result_type(dtypes, non_tensor_inputs):

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -37,6 +37,7 @@ from .common import get_relay_op
 from .common import infer_type as _infer_type
 from .common import infer_shape as _infer_shape
 from .common import infer_value as _infer_value
+from .common import set_span
 
 from .tensorflow_ops import _convert_map
 from .tensorflow_ops import _need_prelude_for_shape_inference
@@ -1028,22 +1029,8 @@ class GraphProto(object):
         else:
             raise NotImplementedError("Operator {} not implemented.".format(op_name))
 
-        sym = self._set_span(sym, node_name)
+        sym = set_span(sym, node_name)
 
-        return sym
-
-    @staticmethod
-    def _set_span(sym, node_name):
-        span = tvm.relay.Span(tvm.relay.SourceName(node_name), 0, 0, 0, 0)
-        if isinstance(sym, _expr.Call) and sym.span is None:
-            sym = _expr.Call(sym.op, sym.args, sym.attrs, sym.type_args, span)
-        elif isinstance(sym, _expr.TupleWrapper):
-            tuple_value = sym.tuple_value
-            if isinstance(tuple_value, _expr.Call) and tuple_value.span is None:
-                tuple_value = _expr.Call(
-                    tuple_value.op, tuple_value.args, tuple_value.attrs, tuple_value.type_args, span
-                )
-                sym = _expr.TupleWrapper(tuple_value, sym.size)
         return sym
 
     def _licm_construct(self, loop_name, node_name):

--- a/python/tvm/relay/frontend/tensorflow2.py
+++ b/python/tvm/relay/frontend/tensorflow2.py
@@ -36,6 +36,7 @@ from .. import analysis
 from .. import function as _function
 from ..loops import while_loop as _while_loop
 from .common import infer_type as _infer_type
+from .common import set_span
 
 from .tensorflow_ops import _convert_map as _convert_map_common
 from .tensorflow_ops import _get_more_static_shape_rank
@@ -56,22 +57,6 @@ _tensor_list_write_ops = {
 def _infer_type_with_prelude(val, prelude):
     body = _infer_type(val, prelude.mod)
     return body.checked_type
-
-
-def set_span(sym, node_name):
-    """set span of symbol"""
-
-    span = tvm.relay.Span(tvm.relay.SourceName(node_name), 0, 0, 0, 0)
-    if isinstance(sym, _expr.Call):
-        sym = _expr.Call(sym.op, sym.args, sym.attrs, sym.type_args, span)
-    elif isinstance(sym, _expr.TupleWrapper):
-        tuple_value = sym.tuple_value
-        if isinstance(tuple_value, _expr.Call):
-            tuple_value = _expr.Call(
-                tuple_value.op, tuple_value.args, tuple_value.attrs, tuple_value.type_args, span
-            )
-            sym = _expr.TupleWrapper(tuple_value, sym.size)
-    return sym
 
 
 def is_tensor_list_constuctor(tf_node):

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -32,6 +32,7 @@ from .. import op as _op
 from .. import qnn as _qnn
 from .common import ExprTable
 from .common import infer_shape as _infer_shape
+from .common import set_span
 from .common import to_int_list
 from .tflite_flexbuffer import FlexBufferDecoder
 
@@ -239,12 +240,17 @@ class OperatorConverter(object):
 
             if len(output_tensors) == 1:
                 tensor_idx = output_tensors[0].tensor_idx
-                self.exp_tab.set_expr(get_tensor_name(self.subgraph, tensor_idx), ret)
+                curr_output= get_tensor_name(self.subgraph, tensor_idx)
+                ret = set_span(ret, "location: {}, output_name: {}".format(op_idx, curr_output))
+                self.exp_tab.set_expr(curr_output, ret)
             else:
-                for idx, output_tensor in enumerate(output_tensors):
-                    self.exp_tab.set_expr(
-                        get_tensor_name(self.subgraph, output_tensor.tensor_idx), ret[idx]
-                    )
+                out_names = []
+                for output_tensor in output_tensors:
+                    out_names.append(get_tensor_name(self.subgraph, output_tensor.tensor_idx))
+                curr_output = ', '.join(out_names)
+                ret = set_span(ret, "location: {}, output_name: {}".format(op_idx, curr_output))
+                for idx, out_name in enumerate(out_names):
+                    self.exp_tab.set_expr(out_name, ret[idx])
 
     def get_op_code_str(self, op):
         """Get TFLite ops string representation"""

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -240,14 +240,14 @@ class OperatorConverter(object):
 
             if len(output_tensors) == 1:
                 tensor_idx = output_tensors[0].tensor_idx
-                curr_output= get_tensor_name(self.subgraph, tensor_idx)
+                curr_output = get_tensor_name(self.subgraph, tensor_idx)
                 ret = set_span(ret, "location: {}, output_name: {}".format(op_idx, curr_output))
                 self.exp_tab.set_expr(curr_output, ret)
             else:
                 out_names = []
                 for output_tensor in output_tensors:
                     out_names.append(get_tensor_name(self.subgraph, output_tensor.tensor_idx))
-                curr_output = ', '.join(out_names)
+                curr_output = ", ".join(out_names)
                 ret = set_span(ret, "location: {}, output_name: {}".format(op_idx, curr_output))
                 for idx, out_name in enumerate(out_names):
                     self.exp_tab.set_expr(out_name, ret[idx])

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -977,11 +977,13 @@ Doc RelayTextPrinter::PrintMapAsAttributeValue(const Map<ObjectRef, ObjectRef>& 
   return doc;
 }
 
-Doc RelayTextPrinter::PrintSpan(const Span& span) {
+Doc RelayTextPrinter::PrintSpan(const Span& span, bool include_spans) {
   Doc doc;
-  const auto* span_node = span.as<SpanNode>();
-  ICHECK(span_node);
-  doc << span_node->source_name->name;
+  if (include_spans) {
+    const auto* span_node = span.as<SpanNode>();
+    ICHECK(span_node);
+    doc << span_node->source_name->name;
+  }
   return doc;
 }
 

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -389,12 +389,21 @@ Doc RelayTextPrinter::VisitExpr_(const TupleNode* op) {
   if (op->fields.size() == 1) {
     doc << ",";
   }
-  return doc << ")";
+  doc << ")";
+  if (op->span.defined()) {
+    doc << " /* " << PrintSpan(op->span) << " */";
+  }
+  return doc;
 }
 
 Doc RelayTextPrinter::VisitExpr_(const TupleGetItemNode* op) {
   Doc doc;
-  return doc << Print(op->tuple) << "." << op->index;
+  doc << Print(op->tuple) << "." << op->index;
+
+  if (op->span.defined()) {
+    doc << " /* " << PrintSpan(op->span) << " */";
+  }
+  return doc;
 }
 
 Doc RelayTextPrinter::VisitExpr_(const IfNode* op) {

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -113,7 +113,7 @@ class RelayTextPrinter : public ExprFunctor<Doc(const Expr&)>,
    */
   Doc PrintMapAsAttributeValue(const Map<ObjectRef, ObjectRef>& map);
 
-  Doc PrintSpan(const Span& span);
+  Doc PrintSpan(const Span& span, bool include_spans = true);
 
   Doc Print(const ObjectRef& node, bool meta = false, bool try_inline = false);
 

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -355,8 +355,8 @@ TupleGetItem WithFields(TupleGetItem tuple_get_item, Optional<Expr> opt_tuple,
 
 TVM_REGISTER_NODE_TYPE(TupleGetItemNode);
 
-TVM_REGISTER_GLOBAL("relay.ir.TupleGetItem").set_body_typed([](Expr tuple, int index) {
-  return TupleGetItem(tuple, index);
+TVM_REGISTER_GLOBAL("relay.ir.TupleGetItem").set_body_typed([](Expr tuple, int index, Span span) {
+  return TupleGetItem(tuple, index, span);
 });
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -244,6 +244,53 @@ def verify_model(
     torch.cuda.empty_cache()
 
 
+def verify_span(model_name, input_data=[], custom_convert_map={}):
+    if isinstance(model_name, str):
+        baseline_model, baseline_input = load_model(model_name)
+    elif isinstance(input_data, list):
+        baseline_model = model_name
+        baseline_input = input_data
+    elif isinstance(input_data, torch.Tensor) or len(input_data.shape) == 0:
+        baseline_model = model_name
+        baseline_input = [input_data]
+    else:
+        assert False, "Unexpected input format"
+
+    trace = torch.jit.trace(baseline_model, [input.clone() for input in baseline_input])
+    if isinstance(baseline_model, torch.nn.Module):
+        trace = trace.float().eval()
+
+        if torch.cuda.is_available():
+            trace = trace.cuda()
+        else:
+            trace = trace.cpu()
+
+    input_names = ["input{}".format(idx) for idx, inp in enumerate(baseline_input)]
+    input_shapes = list(zip(input_names, [inp.shape for inp in baseline_input]))
+    mod, params = relay.frontend.from_pytorch(trace, input_shapes, custom_convert_map)
+
+    # collect fail cases for the convenience of further improvement
+    fail_cases = []
+    mod_main_start = False
+    for line in str(mod.__str__).split('\n'):
+        if "@main" in line:
+            mod_main_start = True
+            continue
+
+        if mod_main_start == True:
+            if '}' == line:
+                break
+            elif not ('/*' in line and '*/' in line):
+                fail_cases.append(line)
+
+    print(fail_cases)
+    assert len(fail_cases) == 0
+
+
+def test_span():
+    verify_span("resnet18")
+
+
 # Single operator tests
 @tvm.testing.uses_gpu
 def test_forward_pixel_shuffle():

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -272,15 +272,15 @@ def verify_span(model_name, input_data=[], custom_convert_map={}):
     # collect fail cases for the convenience of further improvement
     fail_cases = []
     mod_main_start = False
-    for line in str(mod.__str__).split('\n'):
+    for line in str(mod.__str__).split("\n"):
         if "@main" in line:
             mod_main_start = True
             continue
 
         if mod_main_start == True:
-            if '}' == line:
+            if "}" == line:
                 break
-            elif not ('/*' in line and '*/' in line):
+            elif not ("/*" in line and "*/" in line):
                 fail_cases.append(line)
 
     print(fail_cases)

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -302,15 +302,15 @@ def verify_span(mod):
     # collect fail cases for the convenience of further improvement
     fail_cases = []
     mod_main_start = False
-    for line in str(mod.__str__).split('\n'):
+    for line in str(mod.__str__).split("\n"):
         if "@main" in line:
             mod_main_start = True
             continue
 
         if mod_main_start == True:
-            if '}' == line:
+            if "}" == line:
                 break
-            elif not ('/*' in line and '*/' in line):
+            elif not ("/*" in line and "*/" in line):
                 fail_cases.append(line)
 
     print(fail_cases)
@@ -318,10 +318,7 @@ def verify_span(mod):
 
 
 def simple_model():
-    input_node = tf.placeholder(shape=[None, None ,3, 1],
-                                dtype=np.float32,
-                                name='input'
-    )
+    input_node = tf.placeholder(shape=[None, None, 3, 1], dtype=np.float32, name="input")
 
     shape = tf.shape(input_node)
     stack = tf.stack([shape[0], 3, 3], axis=0)
@@ -339,21 +336,20 @@ def test_span_complement_simple_model():
 
         graph_def = tf_testing.ProcessGraphDefParam(graph_def)
 
-        mod, params = relay.frontend.from_tensorflow(graph_def, shape={'input:0',(1, 3, 3, 1)})
+        mod, params = relay.frontend.from_tensorflow(graph_def, shape={"input:0", (1, 3, 3, 1)})
         verify_span(mod)
 
 
 def test_span_complement_big_model():
     with tf.Graph().as_default() as graph:
-        graph_def = tf_testing.get_workload(
-            "ResnetV2/resnet-20180601_resnet_v2_imagenet-shapes.pb"
-        )
+        graph_def = tf_testing.get_workload("ResnetV2/resnet-20180601_resnet_v2_imagenet-shapes.pb")
         # Call the utility to import the graph definition into default graph.
         graph_def = tf_testing.ProcessGraphDefParam(graph_def)
 
-        mod, params = relay.frontend.from_tensorflow(graph_def, shape={'input_tensor:0',(128, 224, 224, 3)})
+        mod, params = relay.frontend.from_tensorflow(
+            graph_def, shape={"input_tensor:0", (128, 224, 224, 3)}
+        )
         verify_span(mod)
-
 
 
 #######################################################################

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -298,6 +298,64 @@ def is_gpu_available():
         return False
 
 
+def verify_span(mod):
+    # collect fail cases for the convenience of further improvement
+    fail_cases = []
+    mod_main_start = False
+    for line in str(mod.__str__).split('\n'):
+        if "@main" in line:
+            mod_main_start = True
+            continue
+
+        if mod_main_start == True:
+            if '}' == line:
+                break
+            elif not ('/*' in line and '*/' in line):
+                fail_cases.append(line)
+
+    print(fail_cases)
+    assert len(fail_cases) == 0
+
+
+def simple_model():
+    input_node = tf.placeholder(shape=[None, None ,3, 1],
+                                dtype=np.float32,
+                                name='input'
+    )
+
+    shape = tf.shape(input_node)
+    stack = tf.stack([shape[0], 3, 3], axis=0)
+    output_node = tf.reshape(input_node, stack, name="output")
+    return output_node
+
+
+#######################################################################
+# Span fill up
+# -------
+def test_span_complement_simple_model():
+    with tf.Graph().as_default() as graph:
+        model_graph = simple_model()
+        graph_def = graph.as_graph_def()
+
+        graph_def = tf_testing.ProcessGraphDefParam(graph_def)
+
+        mod, params = relay.frontend.from_tensorflow(graph_def, shape={'input:0',(1, 3, 3, 1)})
+        verify_span(mod)
+
+
+def test_span_complement_big_model():
+    with tf.Graph().as_default() as graph:
+        graph_def = tf_testing.get_workload(
+            "ResnetV2/resnet-20180601_resnet_v2_imagenet-shapes.pb"
+        )
+        # Call the utility to import the graph definition into default graph.
+        graph_def = tf_testing.ProcessGraphDefParam(graph_def)
+
+        mod, params = relay.frontend.from_tensorflow(graph_def, shape={'input_tensor:0',(128, 224, 224, 3)})
+        verify_span(mod)
+
+
+
 #######################################################################
 # Pooling
 # -------

--- a/tests/python/frontend/tensorflow2/test_sequential_models.py
+++ b/tests/python/frontend/tensorflow2/test_sequential_models.py
@@ -26,6 +26,25 @@ from tensorflow.python.framework.convert_to_constants import convert_variables_t
 
 from common import compare_tf_tvm
 from common import run_tf_code
+from tvm.relay.frontend.tensorflow2 import from_tensorflow
+
+
+def verify_span(mod):
+    fail_cases = []
+    mod_main_start = False
+    for line in str(mod.__str__).split('\n'):
+        if "@main" in line:
+            mod_main_start = True
+            continue
+
+        if mod_main_start == True:
+            if '}' == line:
+                break
+            elif not ('/*' in line and '*/' in line):
+                fail_cases.append(line)
+
+    print(fail_cases)
+    assert len(fail_cases) == 0
 
 
 def run_sequential_model(model_fn, input_shape):
@@ -48,7 +67,10 @@ def run_sequential_model(model_fn, input_shape):
         gdef = f.graph.as_graph_def(add_shapes=True)
         return gdef, _input, _output
 
-    compare_tf_tvm(*model_graph(model_fn, input_shape), runtime="vm")
+    gdef, _input, _output = model_graph(model_fn, input_shape)
+    mod, _ = from_tensorflow(gdef)
+    compare_tf_tvm(gdef, _input, _output, runtime="vm")
+    verify_span(mod)
 
 
 def test_dense_model():

--- a/tests/python/frontend/tensorflow2/test_sequential_models.py
+++ b/tests/python/frontend/tensorflow2/test_sequential_models.py
@@ -32,15 +32,15 @@ from tvm.relay.frontend.tensorflow2 import from_tensorflow
 def verify_span(mod):
     fail_cases = []
     mod_main_start = False
-    for line in str(mod.__str__).split('\n'):
+    for line in str(mod.__str__).split("\n"):
         if "@main" in line:
             mod_main_start = True
             continue
 
         if mod_main_start == True:
-            if '}' == line:
+            if "}" == line:
                 break
-            elif not ('/*' in line and '*/' in line):
+            elif not ("/*" in line and "*/" in line):
                 fail_cases.append(line)
 
     print(fail_cases)

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -289,24 +289,22 @@ def run_span_verification(
         shape_dict[e] = input_data[i].shape
         dtype_dict[e] = input_data[i].dtype.name
 
-    mod, _ = relay.frontend.from_tflite(
-        tflite_model, shape_dict=shape_dict, dtype_dict=dtype_dict
-    )
+    mod, _ = relay.frontend.from_tflite(tflite_model, shape_dict=shape_dict, dtype_dict=dtype_dict)
     verify_span(mod)
 
 
 def verify_span(mod):
     fail_cases = []
     mod_main_start = False
-    for line in str(mod.__str__).split('\n'):
+    for line in str(mod.__str__).split("\n"):
         if "@main" in line:
             mod_main_start = True
             continue
 
         if mod_main_start == True:
-            if '}' == line:
+            if "}" == line:
                 break
-            elif not ('/*' in line and '*/' in line):
+            elif not ("/*" in line and "*/" in line):
                 fail_cases.append(line)
 
     print(fail_cases)

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -258,6 +258,61 @@ def run_tflite_graph(tflite_model_buf, input_data):
     return tflite_output
 
 
+def run_span_verification(
+    tflite_model_buf,
+    input_data,
+    input_node,
+    num_output=1,
+    target="llvm",
+    out_names=None,
+    mode="graph_executor",
+):
+    """Generic function to compile on relay and execute on tvm"""
+    # TFLite.Model.Model has changed to TFLite.Model from 1.14 to 2.1
+    try:
+        import tflite.Model
+
+        tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
+    except AttributeError:
+        import tflite
+
+        tflite_model = tflite.Model.GetRootAsModel(tflite_model_buf, 0)
+    except ImportError:
+        raise ImportError("The tflite package must be installed")
+
+    input_data = convert_to_list(input_data)
+    input_node = convert_to_list(input_node)
+
+    shape_dict = {}
+    dtype_dict = {}
+    for i, e in enumerate(input_node):
+        shape_dict[e] = input_data[i].shape
+        dtype_dict[e] = input_data[i].dtype.name
+
+    mod, _ = relay.frontend.from_tflite(
+        tflite_model, shape_dict=shape_dict, dtype_dict=dtype_dict
+    )
+    verify_span(mod)
+
+
+def verify_span(mod):
+    fail_cases = []
+    mod_main_start = False
+    for line in str(mod.__str__).split('\n'):
+        if "@main" in line:
+            mod_main_start = True
+            continue
+
+        if mod_main_start == True:
+            if '}' == line:
+                break
+            elif not ('/*' in line and '*/' in line):
+                fail_cases.append(line)
+
+    print(fail_cases)
+    assert len(fail_cases) == 0
+
+
 def compare_tflite_with_tvm(
     in_data,
     in_name,
@@ -4500,6 +4555,7 @@ def test_forward_tflite2_qnn_resnet50():
         tflite_output = run_tflite_graph(tflite_model_buf, data)
         tflite_predictions = np.squeeze(tflite_output)
         tflite_sorted_labels = tflite_predictions.argsort()[-3:][::-1]
+        run_span_verification(tflite_model_buf, np.array(data), "input_1")
         tvm_output = run_tvm_graph(tflite_model_buf, np.array(data), "input_1")
         tvm_predictions = np.squeeze(tvm_output)
         tvm_sorted_labels = tvm_predictions.argsort()[-3:][::-1]


### PR DESCRIPTION
* Add a common span filling feature for tf1/2, tflite and pytorch.
* Add test cases for Span filling in each frontend.
* Expose Tuple and TupleGetItem span to python end

Hi community,

Here is a pull request about span filling for frontends -> relay
(frontedns: TF 1 and 2, tfltie and pytorch)
This feature could help users to track the conversion more precisely
I would like to descript more about how it works and current status below. :D

1. One to many conversion
First, though there is a set_span function for tensorflow and tensorflow2, some spans are still missing from time to time.
One of the reasons is that an op conversion might be an one to many conversion.
In this situation the intermediate ops result in empty string.
Take the [pack](https://github.com/apache/tvm/blob/2b35cfd6ddb73afecd3f550f33881e1fdc7c3267/python/tvm/relay/frontend/tensorflow_ops.py#L1535) conversion for example, there are several expand_dims ops might be added before concatenate.
Via adding a ExprMutator to traverse expression each time after an op is converted, we should get a full span tagged RelayIR.

Here gives a simple example:
Before modification, the test case in this patch (tensorflow/test_forward.py:320) is converted to the following Relay expressions

> def @main(%input: Tensor[(?, ?, 3, 1), float32]) {
>   %113 = shape_of(%input, dtype="int32") /* Shape */;
>   %114 = strided_slice(%113, begin=[0], end=[1], strides=[1], axes=None);
>   %115 = squeeze(%114) /* strided_slice */;
>   %116 = expand_dims(%115, axis=0);
>   %117 = expand_dims(3, axis=0);
>   %118 = expand_dims(3, axis=0);
>   %119 = (%116, %117, %118);
>   %120 = concatenate(%119) /* stack */;
>   dyn.reshape(%input, %120, newshape=[]) /* output */
> }

With this patch we can obtain the following format.

> def @main (%input: Tensor[(?, ?, 3, 1), float32]) {
>   %0 = shape_of(%input, dtype="int32") /* Shape */;
>   %1 = strided_slice(%0, begin=[0], end=[1], strides=[1], axes=None) /* strided_slice_PART_0 */;
>   %2 = squeeze(%1) /* strided_slice */;
>   %3 = expand_dims(%2, axis=0) /* stack_PART_0 */;
>   %4 = expand_dims(3, axis=0) /* stack_PART_1 */;
>   %5 = expand_dims(3, axis=0) /* stack_PART_2 */;
>   %6 = (%3, %4, %5) /* stack_PART_3 */;
>   %7 = concatenate(%6) /* stack */;
>   dyn.reshape(%input, %7, newshape=[]) /* output */
> }

(Thanks to @lixiaoquan's advice, keeping the span without suffix in the same position  seems better :D)

2. span naming for each frontend
  2.1. TensorFlow (1 and 2) naming: is kept the same.
  2.2. tflite naming: is a combination of its op position index and output tensor name(s).
      op position is good enough to map back the tflite.
      And the output tensor name should be helpful when user search the op in Netron
  2.3. Pytorch naming: Because PyTorch provides two kinds of graph, jit._trace.TopLevelTracedModule, and _C.Graph, two key attributes, kind() and scopeName() are recorded in a span.
      scopeName(), is used to map a Realy expression back to its original pytorch module part in jit._trace.TopLevelTracedModule, and _C.Graph.
      Combined with kind(), the position of node can be precisely located in _C.Graph.

3. Limitation
  3.1. Few model in test_functional_models.py is still in investigation.
  3.2. [In the end of tflie conversion](https://github.com/apache/tvm/blob/af869bc79cecdc18371862524ea241803dc78c7a/python/tvm/relay/frontend/tflite.py#L3763), a Tuple expression is added if output  more than 1. This tuple will not have any span.
  3.2 Note that some conversion, like aten::to in Pytorch might result in a python-built-in float instance. its node information will be drop simply.

4. Trivial
   Several test cases are attached. Should be a quick verifier for reviewing.

Thank you for reading. Any comment is appreciated. :)

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
