### PR TITLE
[microNPU] Update Arm(R) Ethos(TM)-U55 NPU demo README

### DIFF
--- a/apps/microtvm/ethosu/README.md
+++ b/apps/microtvm/ethosu/README.md
@@ -43,6 +43,10 @@ If the demo is not run in the ci_cpu Docker container, then you will need the fo
 
 You will also need TVM which can either be:
   - Built from source (see [Install from Source](https://tvm.apache.org/docs/install/from_source.html))
+    - When building from source, the following need to be set in config.cmake:
+      - set(USE_ETHOSU ON)
+      - set(USE_MICRO ON)
+      - set(USE_LLVM ON)
   - Installed from TLCPack(see [TLCPack](https://tlcpack.ai/))
 
 You will need to update your PATH environment variable to include the path to cmake 3.19.5 and the FVP.


### PR DESCRIPTION
An [issue was raised in the Discuss forums](https://discuss.tvm.apache.org/t/cannot-run-arm-ethosu-demo/11684/) where it isn't clear what options should be set when building TVM from source for running the Arm(R) Ethos(TM)-U55 NPU demo.

This PR updates the README.md to show which config.cmake options to set when building TVM from source.

@manupa-arm @leandron @areusch 
