### PR TITLE
Fix typos in runtime comments

### DIFF
--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -56,9 +56,9 @@ namespace runtime {
  * \brief Check if signals have been sent to the process and if so
  *  invoke the registered signal handler in the frontend environment.
  *
- *  When runnning TVM in another langugage(python), the signal handler
+ *  When running TVM in another language (Python), the signal handler
  *  may not be immediately executed, but instead the signal is marked
- *  in the interpreter state(to ensure non-blocking of the signal handler).
+ *  in the interpreter state (to ensure non-blocking of the signal handler).
  *
  *  This function can be explicitly invoked to check the cached signal
  *  and run the related processing if a signal is marked.

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -120,9 +120,9 @@ class EnvCAPIRegistry {
    * \brief Callback to check if signals have been sent to the process and
    *        if so invoke the registered signal handler in the frontend environment.
    *
-   *  When runnning TVM in another langugage(python), the signal handler
+   *  When running TVM in another language (Python), the signal handler
    *  may not be immediately executed, but instead the signal is marked
-   *  in the interpreter state(to ensure non-blocking of the signal handler).
+   *  in the interpreter state (to ensure non-blocking of the signal handler).
    *
    * \return 0 if no error happens, -1 if error happens.
    */
@@ -176,7 +176,7 @@ void EnvCheckSignals() { EnvCAPIRegistry::Global()->CheckSignals(); }
 }  // namespace runtime
 }  // namespace tvm
 
-/*! \brief entry to to easily hold returning information */
+/*! \brief entry to easily hold returning information */
 struct TVMFuncThreadLocalEntry {
   /*! \brief result holder for returning strings */
   std::vector<std::string> ret_vec_str;


### PR DESCRIPTION
Fix typos in comments about signal handling and entries in the runtime
code.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
