### PR TITLE
[BugFix] Fix a wrong use of `std::move()` in cross-thread reduction lowering

### DIFF
--- a/src/tir/transforms/lower_cross_thread_reduction.cc
+++ b/src/tir/transforms/lower_cross_thread_reduction.cc
@@ -117,7 +117,7 @@ bool IsReductionBlock(const BlockRealize& realize, const Map<Var, Range>& loop_r
  * \return The created buffer
  */
 Buffer MakeScratchpad(String name, const DataType& dtype) {
-  return Buffer(/*ptr=*/Var(std::move(name), PointerType(PrimType(dtype), "local")),
+  return Buffer(/*ptr=*/Var(name, PointerType(PrimType(dtype), "local")),
                 /*dtype=*/dtype,
                 /*shape=*/{Integer(1)},
                 /*strides=*/{Integer(1)},

--- a/src/tir/transforms/lower_cross_thread_reduction.cc
+++ b/src/tir/transforms/lower_cross_thread_reduction.cc
@@ -117,12 +117,12 @@ bool IsReductionBlock(const BlockRealize& realize, const Map<Var, Range>& loop_r
  * \return The created buffer
  */
 Buffer MakeScratchpad(String name, const DataType& dtype) {
-  return Buffer(/*ptr=*/Var(name, PointerType(PrimType(dtype), "local")),
+  return Buffer(/*ptr=*/Var(std::move(name), PointerType(PrimType(dtype), "local")),
                 /*dtype=*/dtype,
                 /*shape=*/{Integer(1)},
                 /*strides=*/{Integer(1)},
                 /*elem_offset=*/PrimExpr{nullptr},
-                /*name=*/std::move(name),
+                /*name=*/name,
                 /*data_alignment=*/0,
                 /*offset_factor=*/0,
                 /*buffer_type=*/kDefault);


### PR DESCRIPTION
Find a wrong use of `std::move()`. Please see the changes for detail. The wrong use leads to undefined Var of a buffer's `data` field.

Given C++ evaluates parameter expressions from the end to the beginning, we should use `std::move` at the first occurrence, instead of the last.

cc @junrushao1994 @Hzfengsy 