### PR TITLE
[CORE] Make external mods first class field in the IR module

### DIFF
--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -294,7 +294,7 @@ if(USE_HEXAGON_RPC)
   )
 
   # copy android_bash template file
-  configure_file("${CMAKE_SOURCE_DIR}/src/runtime/hexagon/rpc/android_bash.sh.template" 
+  configure_file("${CMAKE_SOURCE_DIR}/src/runtime/hexagon/rpc/android_bash.sh.template"
     ${HEXAGON_RPC_OUTPUT} COPYONLY)
 
   set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${HEXAGON_RPC_OUTPUT}")
@@ -366,7 +366,7 @@ if(USE_HEXAGON_SDK AND BUILD_FOR_ANDROID)
   set(RPC_IDL "hexagon_rpc.idl")
   set(RPC_H "hexagon_rpc.h")
   set(RPC_STUB_C "hexagon_rpc_stub.c")
-  
+
   add_custom_command(
     OUTPUT "${HEXAGON_RPC_DIR}/${RPC_STUB_C}" "${HEXAGON_RPC_DIR}/${RPC_H}"
     COMMAND ${QAIC_EXE} ${QAIC_FLAGS} "${HEXAGON_RPC_DIR}/${RPC_IDL}" -o ${HEXAGON_RPC_DIR}
@@ -377,5 +377,5 @@ if(USE_HEXAGON_SDK AND BUILD_FOR_ANDROID)
 endif()
 
 list(APPEND RUNTIME_SRCS ${RUNTIME_HEXAGON_SRCS} ${RUNTIME_HEXAGON_SIM_SRCS}
-                         ${RUNTIME_HEXAGON_DEVICE_SRCS} ${HEXAGON_RPC_CPP} ${HEXAGON_RPC_STUB_C} 
+                         ${RUNTIME_HEXAGON_DEVICE_SRCS} ${HEXAGON_RPC_CPP} ${HEXAGON_RPC_STUB_C}
                          ${RUNTIME_HEXAGON_COMMON_SRCS})

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -163,7 +163,7 @@ class TVM_DLL ModuleNode : public Object {
    * \param query_imports Whether also query dependency modules.
    * \return The result function.
    *  This function will return PackedFunc(nullptr) if function do not exist.
-   * \note Implemented in packed_func.cc
+   * \note Implemented in packed_func.cc (this file doesn't exist?)
    */
   PackedFunc GetFunction(const std::string& name, bool query_imports = false);
   /*!
@@ -182,6 +182,9 @@ class TVM_DLL ModuleNode : public Object {
    * \return The corresponding function.
    */
   const PackedFunc* GetFuncFromEnv(const std::string& name);
+
+  const bool FuncInExternalModule(const std::string& name);
+
   /*! \return The module it imports from */
   const std::vector<Module>& imports() const { return imports_; }
 
@@ -195,11 +198,11 @@ class TVM_DLL ModuleNode : public Object {
  protected:
   friend class Module;
   friend class ModuleInternal;
-  /*! \brief The modules this module depend on */
+  /*! \brief The modules this module depends on */
   std::vector<Module> imports_;
 
  private:
-  /*! \brief Cache used by GetImport */
+  /*! \brief Cache used by GetFunction */
   std::unordered_map<std::string, std::shared_ptr<PackedFunc> > import_cache_;
 };
 

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -283,9 +283,9 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
     }
     ret.function_metadata = std::move(function_metadata_);
 
-    Optional<Array<tvm::runtime::Module>> external_modules =
-        lowered_mod->GetAttr<Array<tvm::runtime::Module>>("external_mods");
-    ICHECK(external_modules) << "Attribute \"external_mods\" should be set at this point.";
+    Optional<Array<tvm::runtime::Module>> external_modules = lowered_mod->external_mods;
+    ICHECK(external_modules.defined())
+        << "Attribute \"external_mods\" should be defined at this point.";
 
     // This is the point where we separate the functions in the module by target
     ret.lowered_funcs = tec::GetPerTargetModules(lowered_mod);

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -1085,9 +1085,12 @@ IRModule LowerTE(const IRModule& module, const String& module_name, ProcessFn pr
 
   // Invoke external codegen for all Functions in the cache tagged with "Compiler", and
   // annotate the module with the resulting runtime modules.
-  // TODO(mbs): runtime modules should be first class rather than attributes.
-  Array<runtime::Module> external_mods =
-      module->GetAttr<Array<runtime::Module>>("external_mods", Array<runtime::Module>()).value();
+
+  Array<runtime::Module> external_mods = Array<runtime::Module>();
+  if (module->external_mods.defined()) {
+    external_mods = module->external_mods;
+  }
+
   Array<runtime::Module> new_external_mods = compiler->LowerExternalFunctions();
   VLOG(1) << "capturing " << external_mods.size() << " existing and " << new_external_mods.size()
           << " new external modules";
@@ -1109,8 +1112,9 @@ IRModule LowerTE(const IRModule& module, const String& module_name, ProcessFn pr
     device_contexts.Set(kv.first, kv.second);  // copy-on-write.
   }
 
-  updated_module = WithAttrs(updated_module, {{"external_mods", std::move(external_mods)},
-                                              {"device_contexts", std::move(device_contexts)}});
+  // TODO(@electriclilies): Implement WithFields for IRModules and use here
+  updated_module = WithAttrs(updated_module, {{"device_contexts", std::move(device_contexts)}});
+  updated_module->external_mods = std::move(external_mods);
 
   if (backend::IsAutoSchedulerEnabled()) {
     // Capture all the 'operator weights', ie usage counts for each PrimFunc.

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -105,6 +105,22 @@ std::string ModuleNode::GetSource(const std::string& format) {
   return "";
 }
 
+// This function does NOT check whether name is registered globally.
+// This is different from GetFuncFromEnv
+const bool ModuleNode::FuncInExternalModule(const std::string& name) {
+  auto it = import_cache_.find(name);
+  if (it != import_cache_.end()) return true;
+  PackedFunc pf;
+  for (Module& m : this->imports_) {
+    pf = m.GetFunction(name, true);
+    if (pf != nullptr) {
+      import_cache_.insert(std::make_pair(name, std::make_shared<PackedFunc>(pf)));
+      return true;
+    }
+  }
+  return false;
+}
+
 const PackedFunc* ModuleNode::GetFuncFromEnv(const std::string& name) {
   auto it = import_cache_.find(name);
   if (it != import_cache_.end()) return it->second.get();

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -587,7 +587,7 @@ def test_function_in_tuple():
     def expected():
         return tvm.parser.parse(
             """
-            #[version = "0.0.5"] 
+            #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
                       param_se_scopes=[meta[SEScope][0], meta[SEScope][0]], result_se_scope=meta[SEScope][0]) {
               let %f = fn (%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
@@ -618,7 +618,7 @@ def test_device_copy():
     def input():
         return tvm.parser.parse(
             """
-            #[version = "0.0.5"] 
+            #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32]) {
               %0 = device_copy(%x, src_se_scope=meta[SEScope][0], dst_se_scope=meta[SEScope][1]);
               add(%0, meta[relay.Constant][0])
@@ -632,7 +632,7 @@ def test_device_copy():
     def expected():
         return tvm.parser.parse(
             """
-            #[version = "0.0.5"] 
+            #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32],
                       param_se_scopes=[meta[SEScope][0]], result_se_scope=meta[SEScope][1]) {
               %0 = device_copy(%x, src_se_scope=meta[SEScope][0], dst_se_scope=meta[SEScope][1]);
@@ -659,7 +659,7 @@ def test_shape_of():
     def input():
         return tvm.parser.parse(
             """
-            #[version = "0.0.5"] 
+            #[version = "0.0.5"]
             def @main(%x: Tensor[(?, ?), float32]) {
               %0 = on_device(%x, se_scope=meta[SEScope][1], constrain_result=True);
               vm.shape_of(%0, dtype="int64")
@@ -1366,7 +1366,7 @@ def test_global():
               %0 = on_device(%b, se_scope=meta[SEScope][0]);
               add(%a, %0)
             }
-            
+
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32]) -> Tensor[(5, 7), float32] {
               @f(%y, %x)
             }
@@ -1386,7 +1386,7 @@ def test_global():
               %0 = device_copy(%b, src_se_scope=meta[SEScope][0], dst_se_scope=meta[SEScope][1]);
               add(%a, %0)
             }
-            
+
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
                       param_se_scopes=[meta[SEScope][0], meta[SEScope][1]],
                       result_se_scope=meta[SEScope][1]) -> Tensor[(5, 7), float32] {
@@ -1530,8 +1530,8 @@ def test_free_on_device():
             def @on_scope_b(%x: Tensor[(5, 7), float32],
                             param_se_scopes=[meta[SEScope][2]],
                             result_se_scope=meta[SEScope][2]) -> Tensor[(5, 7), float32] {
-              %x                
-            }                 
+              %x
+            }
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32], %c: Tensor[(5, 7), float32],
                       param_se_scopes=[meta[SEScope][0], meta[SEScope][1], meta[SEScope][2]],
                       result_se_scope=meta[SEScope][1]) {
@@ -1558,8 +1558,8 @@ def test_free_on_device():
             def @on_scope_b(%x: Tensor[(5, 7), float32],
                             param_se_scopes=[meta[SEScope][2]],
                             result_se_scope=meta[SEScope][2]) -> Tensor[(5, 7), float32] {
-              %x                
-            }                 
+              %x
+            }
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32], %c: Tensor[(5, 7), float32],
                       param_se_scopes=[meta[SEScope][2], meta[SEScope][1], meta[SEScope][2]],
                       result_se_scope=meta[SEScope][1]) {
@@ -1568,7 +1568,7 @@ def test_free_on_device():
               %2 = @on_scope_b(%1);
               %3 = @on_scope_b(%c);
               %4 = add(add(%0, %2), %3);
-              %5 = on_device(%4, se_scope=meta[SEScope][2], constrain_result=True); 
+              %5 = on_device(%4, se_scope=meta[SEScope][2], constrain_result=True);
               device_copy(%5, src_se_scope=meta[SEScope][2], dst_se_scope=meta[SEScope][1])
             }
         """,


### PR DESCRIPTION
Co-authored-by: Lily Orth-Smith <lilyorthsmith@gmail.com>

This PR extracts the external modules used by the TECOmpiler and various places in the AOT flow and makes them first class fields in the IRModule.

@mbs-octoml @electriclilies 