### PR TITLE
[CUDA] Do not emit vector load on unaligned base offset

### DIFF
--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -719,7 +719,7 @@ void CodeGenC::VisitExpr_(const LoadNode* op, std::ostream& os) {  // NOLINT(*)
       ICHECK(ramp);
       arith::ModularSet me = arith::Analyzer().modular_set(ramp->base);
       // The condition: {k * coeff + base} divisible by the alignment for any k
-      if (me->coeff != 1 && me->base % op->dtype.lanes() == 0) {
+      if (me->coeff % op->dtype.lanes() == 0 && me->base % op->dtype.lanes() == 0) {
         can_vector_load = true;
       }
     }

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -718,7 +718,8 @@ void CodeGenC::VisitExpr_(const LoadNode* op, std::ostream& os) {  // NOLINT(*)
       const RampNode* ramp = op->index.as<RampNode>();
       ICHECK(ramp);
       arith::ModularSet me = arith::Analyzer().modular_set(ramp->base);
-      if (me->base % op->dtype.lanes() == 0) {
+      // The condition: {k * coeff + base} divisible by the alignment for any k
+      if (me->coeff != 1 && me->base % op->dtype.lanes() == 0) {
         can_vector_load = true;
       }
     }

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -22,6 +22,8 @@
  */
 #include "codegen_c.h"
 
+#include <tvm/arith/analyzer.h>
+
 #include <cctype>
 #include <iomanip>
 
@@ -715,9 +717,8 @@ void CodeGenC::VisitExpr_(const LoadNode* op, std::ostream& os) {  // NOLINT(*)
     if (arith::ramp(base, 1, op->dtype.lanes()).Match(op->index)) {
       const RampNode* ramp = op->index.as<RampNode>();
       ICHECK(ramp);
-      auto* base_int = ramp->base.as<IntImmNode>();
-      auto access_bytes = op->dtype.lanes() * op->dtype.bytes();
-      if (base_int && (base_int->value % access_bytes == 0)) {
+      arith::ModularSet me = arith::Analyzer().modular_set(ramp->base);
+      if (me->base % op->dtype.lanes() == 0) {
         can_vector_load = true;
       }
     }

--- a/tests/python/unittest/test_target_codegen_cuda.py
+++ b/tests/python/unittest/test_target_codegen_cuda.py
@@ -1001,13 +1001,13 @@ def test_unrolled_vectorization():
 def test_try_unaligned_vector_load():
     N = 3
     C_N = N - 1
-    A = te.placeholder((N,), name="A", dtype='float16')
-    C = te.compute((C_N,), lambda i: A[i+1], name="C")
+    A = te.placeholder((N,), name="A", dtype="float16")
+    C = te.compute((C_N,), lambda i: A[i + 1], name="C")
 
     s = te.create_schedule(C.op)
     oi, ii = s[C].split(C.op.axis[0], factor=2)
     s[C].bind(oi, te.thread_axis("threadIdx.x"))
-    s[C].vectorize(ii) # BUG: misalignment
+    s[C].vectorize(ii)  # BUG: misalignment
 
     tgt = tvm.target.Target(target="cuda", host="llvm")
     foo = tvm.build(s, [A, C], tgt, name="foo")
@@ -1017,7 +1017,7 @@ def test_try_unaligned_vector_load():
     a = tvm.nd.array(a_data, dev)
     c = tvm.nd.array(np.zeros(C_N, dtype=C.dtype), dev)
     foo(a, c)
-    expected = a_data[1:C_N+1]
+    expected = a_data[1 : C_N + 1]
     assert np.allclose(c.numpy(), expected), f"expected={expected}\nactual={c}"
 
 


### PR DESCRIPTION
Closes https://github.com/apache/tvm/issues/8540

Only emit vector loads when the load index has an offset that is a multiple of the vector length.

Before this PR, we were generating invalid code like this for the test case in https://github.com/apache/tvm/issues/8540:
```
extern "C" __global__ void foo_kernel0(half* __restrict__ C, half* __restrict__ A) {                                                                                         
  ((uint1*)(C + (0)))[0] = ((uint1*)(A + (1)))[0];                                    
}                                                                                     
```

After this PR, we do not emit vector load for the above test case and emit code like below.
```
extern "C" __global__ void foo_kernel0(half* __restrict__ C, half* __restrict__ A) {
  int2 _1 = make_int2((1)+(1*0), (1)+(1*1));
  ((uint1*)(C + (0)))[0] = make_uint1(__pack_half2(A[_1.x],A[_1.y]));
}
```

For an aligned access, the following valid code can be generated:
```
extern "C" __global__ void foo_kernel0(half* __restrict__ C, half* __restrict__ A) {
  ((uint1*)(C + (0)))[0] = ((uint1*)(A + (2)))[0];
}
```
cc @vinx13 @comaniac @Laurawly 