### PR TITLE
Merge Java unittests into GPU unittests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,6 +381,10 @@ stage('Unit Test') {
                 label: "Check Sphinx warnings in docs",
               )
               sh (
+                script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
+                label: "Run Java unit tests",
+              )
+              sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh",
                 label: "Run Python GPU unit tests",
               )
@@ -460,25 +464,6 @@ stage('Unit Test') {
          Utils.markStageSkippedForConditional('python3: arm')
       }
     },
-    'java: GPU': {
-      if (is_docs_only_build != 1 ) {
-        node('GPU') {
-          ws(per_exec_ws('tvm/ut-java')) {
-            init_git()
-              unpack_lib('gpu', tvm_multilib)
-              timeout(time: max_time, unit: 'MINUTES') {
-                ci_setup(ci_gpu)
-                sh (
-                  script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
-                  label: "Run Java unit tests",
-                )
-              }
-          }
-        }
-      } else {
-         Utils.markStageSkippedForConditional('java: GPU')
-      }
-    }
 }
 
 stage('Integration Test') {


### PR DESCRIPTION
These run on the same node but the Java unit tests take < 1 min (whereas the node setup alone takes 3-4 min), so it seems like it would be good to just run the Java tests as part of the general GPU unit testing rather than allocate and set up a separate node for it. See the [test run](https://jenkins.tvm.octoml.ai/blue/organizations/jenkins/octoml-tvm/detail/driazati%2Fmerge_java/2/pipeline/53) in the staging Jenkins