### PR TITLE
[AMP][Pass][Typing] Add faster type inference

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -262,15 +262,16 @@ TVM_DLL Pass InferType();
  * \brief Infer the type of an expression, reusing existing type information.
  *
  * The result of type checking is a new expression with unambiguous
- * type information filled in for that expression only. The fast
+ * type information filled in for that expression only. The local
  * version depends on existing type information populated throughout
- * the expression and assumes this information is correct. The fast
+ * the expression and assumes this information is correct. The local
  * version also avoids examining large amounts of the graph assuming
- * type information is filled in.
+ * type information is filled in properly which makes it much faster if we
+ * iteratively call type inference.
  *
  * \return The pass.
  */
-TVM_DLL Type InferTypeFast(const Expr& expr);
+TVM_DLL Type InferTypeLocal(const Expr& expr);
 
 /*!
  * \brief Search and eliminate common subexpression. For example, if there are

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -262,8 +262,8 @@ TVM_DLL Pass InferType();
  * \brief Infer the type of an expression, reusing existing type information.
  *
  * The result of type checking is a new expression with unambiguous
- * type information filled in for that expression only. The local
- * version depends on existing type information populated throughout
+ * type information filled in for the given node only. The local
+ * version can use existing type information populated throughout
  * the expression and assumes this information is correct. The local
  * version also avoids examining large amounts of the graph assuming
  * type information is filled in properly which makes it much faster if we

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -258,6 +258,11 @@ TVM_DLL Pass DynamicToStatic();
  */
 TVM_DLL Pass InferType();
 
+/*
+TODO
+*/
+TVM_DLL Type InferTypeFast(const Expr& expr);
+
 /*!
  * \brief Search and eliminate common subexpression. For example, if there are
  * two expressions evaluated to an identical value, a single variable is created

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -269,7 +269,7 @@ TVM_DLL Pass InferType();
  * type information is filled in properly which makes it much faster if we
  * iteratively call type inference.
  *
- * \return The pass.
+ * \return The type of the expression.
  */
 TVM_DLL Type InferTypeLocal(const Expr& expr);
 

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -259,12 +259,14 @@ TVM_DLL Pass DynamicToStatic();
 TVM_DLL Pass InferType();
 
 /*!
- * \brief Infer the type of an expression.
+ * \brief Infer the type of an expression, reusing existing type information.
  *
  * The result of type checking is a new expression with unambiguous
  * type information filled in for that expression only. The fast
  * version depends on existing type information populated throughout
- * the expression and assumes this information is correct.
+ * the expression and assumes this information is correct. The fast 
+ * version also avoids examining large amounts of the graph assuming
+ * type information is filled in.
  *
  * \return The pass.
  */

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -250,7 +250,7 @@ TVM_DLL Pass DynamicToStatic();
 /*!
  * \brief Infer the type of an expression.
  *
- * The result of type checking is a new expression with unambigous
+ * The result of type checking is a new expression with unambiguous
  * type information filled in, as well as it's checked type field
  * populated with the result type.
  *
@@ -258,9 +258,16 @@ TVM_DLL Pass DynamicToStatic();
  */
 TVM_DLL Pass InferType();
 
-/*
-TODO
-*/
+/*!
+ * \brief Infer the type of an expression.
+ *
+ * The result of type checking is a new expression with unambiguous
+ * type information filled in for that expression only. The fast
+ * version depends on existing type information populated throughout
+ * the expression and assumes this information is correct.
+ *
+ * \return The pass.
+ */
 TVM_DLL Type InferTypeFast(const Expr& expr);
 
 /*!

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -264,7 +264,7 @@ TVM_DLL Pass InferType();
  * The result of type checking is a new expression with unambiguous
  * type information filled in for that expression only. The fast
  * version depends on existing type information populated throughout
- * the expression and assumes this information is correct. The fast 
+ * the expression and assumes this information is correct. The fast
  * version also avoids examining large amounts of the graph assuming
  * type information is filled in.
  *

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -99,6 +99,25 @@ def InferType():
     return _ffi_api.InferType()
 
 
+def InferTypeLocal(expr):
+    """Infer the type of a single expr, reusing type information to do so.
+
+    This populates the checked_type field in expr. We assume existing type information
+    in the graph is correct!
+
+    Parameters
+    ----------
+    expr: relay.Expr
+        The expression we want to know the type of
+
+    Returns
+    -------
+    type: relay.Type
+        The type of the expression
+    """
+    return _ffi_api.InferTypeLocal(expr)
+
+
 def FoldScaleAxis():
     """Fold the scaling of axis into weights of conv2d/dense. This pass will
     invoke both forward and backward scale folding.

--- a/src/relay/op/nn/nn.h
+++ b/src/relay/op/nn/nn.h
@@ -162,6 +162,7 @@ bool BatchMatmulRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   if (out_dtype.bits() == 0) {
     out_dtype = x->dtype;
   }
+
   // assign output type
   const auto& out_b =
       xb->IsInstance<tir::AnyNode>() || yb->IsInstance<tir::AnyNode>() ? tir::Any() : max(xb, yb);

--- a/src/relay/op/nn/nn.h
+++ b/src/relay/op/nn/nn.h
@@ -162,7 +162,6 @@ bool BatchMatmulRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
   if (out_dtype.bits() == 0) {
     out_dtype = x->dtype;
   }
-
   // assign output type
   const auto& out_b =
       xb->IsInstance<tir::AnyNode>() || yb->IsInstance<tir::AnyNode>() ? tir::Any() : max(xb, yb);

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -180,9 +180,9 @@ class MixedPrecisionPass : public MixedModeMutator {
     if (checked_type.defined()) {
       return checked_type;
     }
-    checked_type = transform::InferTypeFast(expr);
-    expr->checked_type_ = checked_type;
-    return checked_type;
+
+    // This also populates the checked_type_ field for expr
+    return transform::InferTypeFast(expr);
   }
 
   bool IsMixedPrecisionType(const Type& t, bool ignore_non_float = false) const {

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -182,7 +182,7 @@ class MixedPrecisionPass : public MixedModeMutator {
     }
 
     // This also populates the checked_type_ field for expr
-    return transform::InferTypeFast(expr);
+    return transform::InferTypeLocal(expr);
   }
 
   bool IsMixedPrecisionType(const Type& t, bool ignore_non_float = false) const {

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -176,6 +176,10 @@ class MixedPrecisionPass : public MixedModeMutator {
   }
 
   Type GetType(const Expr& expr) const {
+    // The expression has not been changed AND it's existing type
+    // is known to still be valid. (See special handling for tuples etc
+    // below for where we null out checked_type_ when we can not
+    // sure it is still valid.
     Type checked_type = expr->checked_type_;
     if (checked_type.defined()) {
       return checked_type;

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -36,6 +36,73 @@
 namespace tvm {
 namespace relay {
 
+class SameTypedSubgraphExtractor : public ExprMutator {
+  /*
+  Creates a small subgraph with the same type as the input expression.
+
+  ExprMutator is sufficient over MixedModemutator since we will not recurse much.
+  */
+
+  Expr VisitExpr_(const VarNode* op) { return Var(op->vid, op->type_annotation, op->span); }
+  Expr VisitExpr_(const ConstantNode* op) { return Constant(op->data, op->span); }
+  Expr VisitExpr_(const GlobalVarNode* op) { return GlobalVar(op->name_hint); }
+  Expr VisitExpr_(const OpNode* op) { return Op(GetRef<Op>(op)); }
+  Expr VisitExpr_(const TupleNode* op) {
+    return Tuple(get_analogous_expression(op->fields), op->span);
+  }
+  Expr VisitExpr_(const FunctionNode* op) {
+    // Here will be the only VisitExpr
+    return Function(op->params, get_analogous_expression(op->body), op->ret_type, op->type_params,
+                    op->attrs, op->span);
+  }
+  Expr VisitExpr_(const CallNode* op) {
+    return Call(op->op, get_analogous_expression(op->args), op->attrs, op->type_args, op->span);
+  }
+  Expr VisitExpr_(const LetNode* op) {
+    return Let(op->var, get_analogous_expression(op->value), get_analogous_expression(op->body),
+               op->span);
+  }
+  Expr VisitExpr_(const IfNode* op) {
+    return If(get_analogous_expression(op->cond), get_analogous_expression(op->true_branch),
+              get_analogous_expression(op->false_branch), op->span);
+  }
+  Expr VisitExpr_(const TupleGetItemNode* op) {
+    return TupleGetItem(get_analogous_expression(op->tuple), op->index, op->span);
+  }
+  Expr VisitExpr_(const RefCreateNode* op) {
+    return RefCreate(get_analogous_expression(op->value), op->span);
+  }
+  Expr VisitExpr_(const RefReadNode* op) {
+    return RefRead(get_analogous_expression(op->ref), op->span);
+  }
+  Expr VisitExpr_(const RefWriteNode* op) {
+    return RefWrite(get_analogous_expression(op->ref), get_analogous_expression(op->value),
+                    op->span);
+  }
+  Expr VisitExpr_(const ConstructorNode* op) {
+    return Constructor(op->name_hint, op->inputs, op->belong_to);
+  }
+  Expr VisitExpr_(const MatchNode* op) {
+    return Match(get_analogous_expression(op->data), op->clauses, op->complete, op->span);
+  }
+
+ private:
+  Expr get_analogous_expression(const Expr& expr) {
+    if (!expr->checked_type_.defined()) {
+      return VisitExpr(expr);
+    }
+
+    return Var("dummy_var", expr->checked_type(), expr->span);
+  }
+  Array<Expr> get_analogous_expression(const Array<Expr>& fields) {
+    Array<Expr> new_fields;
+    for (Expr expr : fields) {
+      new_fields.push_back(get_analogous_expression(expr));
+    }
+    return new_fields;
+  }
+};
+
 // A callable which hashes std::pair
 struct pair_hash {
   template <class T1, class T2>
@@ -194,23 +261,13 @@ class MixedPrecisionPass : public MixedModeMutator {
   }
 
   Type GetType(const Expr& expr) const {
-    const Type old_checked_type = expr->checked_type_;
-    if (old_checked_type.defined()) {
-      return old_checked_type;
+    Type checked_type = expr->checked_type_;
+    if (checked_type.defined()) {
+      return checked_type;
     }
-
-    auto mod = IRModule::FromExpr(MakeAnalogousSubgraph(expr));
-    // LOG(WARNING) << mod;
-    // LOG(WARNING) << IRModule::FromExpr(expr);
-    mod = transform::InferType()(mod);
-    Type t;
-    if (expr.as<FunctionNode>()) {
-      t = mod->Lookup("main")->checked_type();
-    } else {
-      t = mod->Lookup("main").as<FunctionNode>()->body->checked_type();
-    }
-    expr->checked_type_ = t;
-    return t;
+    checked_type = transform::InferTypeFast(expr);
+    expr->checked_type_ = checked_type;
+    return checked_type;
   }
 
   bool IsMixedPrecisionType(const Type& t, bool ignore_non_float = false) const {

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -36,73 +36,6 @@
 namespace tvm {
 namespace relay {
 
-class SameTypedSubgraphExtractor : public ExprMutator {
-  /*
-  Creates a small subgraph with the same type as the input expression.
-
-  ExprMutator is sufficient over MixedModemutator since we will not recurse much.
-  */
-
-  Expr VisitExpr_(const VarNode* op) { return Var(op->vid, op->type_annotation, op->span); }
-  Expr VisitExpr_(const ConstantNode* op) { return Constant(op->data, op->span); }
-  Expr VisitExpr_(const GlobalVarNode* op) { return GlobalVar(op->name_hint); }
-  Expr VisitExpr_(const OpNode* op) { return Op(GetRef<Op>(op)); }
-  Expr VisitExpr_(const TupleNode* op) {
-    return Tuple(get_analogous_expression(op->fields), op->span);
-  }
-  Expr VisitExpr_(const FunctionNode* op) {
-    // Here will be the only VisitExpr
-    return Function(op->params, get_analogous_expression(op->body), op->ret_type, op->type_params,
-                    op->attrs, op->span);
-  }
-  Expr VisitExpr_(const CallNode* op) {
-    return Call(op->op, get_analogous_expression(op->args), op->attrs, op->type_args, op->span);
-  }
-  Expr VisitExpr_(const LetNode* op) {
-    return Let(op->var, get_analogous_expression(op->value), get_analogous_expression(op->body),
-               op->span);
-  }
-  Expr VisitExpr_(const IfNode* op) {
-    return If(get_analogous_expression(op->cond), get_analogous_expression(op->true_branch),
-              get_analogous_expression(op->false_branch), op->span);
-  }
-  Expr VisitExpr_(const TupleGetItemNode* op) {
-    return TupleGetItem(get_analogous_expression(op->tuple), op->index, op->span);
-  }
-  Expr VisitExpr_(const RefCreateNode* op) {
-    return RefCreate(get_analogous_expression(op->value), op->span);
-  }
-  Expr VisitExpr_(const RefReadNode* op) {
-    return RefRead(get_analogous_expression(op->ref), op->span);
-  }
-  Expr VisitExpr_(const RefWriteNode* op) {
-    return RefWrite(get_analogous_expression(op->ref), get_analogous_expression(op->value),
-                    op->span);
-  }
-  Expr VisitExpr_(const ConstructorNode* op) {
-    return Constructor(op->name_hint, op->inputs, op->belong_to);
-  }
-  Expr VisitExpr_(const MatchNode* op) {
-    return Match(get_analogous_expression(op->data), op->clauses, op->complete, op->span);
-  }
-
- private:
-  Expr get_analogous_expression(const Expr& expr) {
-    if (!expr->checked_type_.defined()) {
-      return VisitExpr(expr);
-    }
-
-    return Var("dummy_var", expr->checked_type(), expr->span);
-  }
-  Array<Expr> get_analogous_expression(const Array<Expr>& fields) {
-    Array<Expr> new_fields;
-    for (Expr expr : fields) {
-      new_fields.push_back(get_analogous_expression(expr));
-    }
-    return new_fields;
-  }
-};
-
 // A callable which hashes std::pair
 struct pair_hash {
   template <class T1, class T2>
@@ -167,9 +100,6 @@ class MixedPrecisionPass : public MixedModeMutator {
 
   /*! \brief The target datatype we want to convert to e.g. FP16 */
   const DataType mixed_precision_type_;
-
-  /* TODO*/
-  std::unordered_map<Expr, Expr, ObjectPtrHash, ObjectPtrEqual> analgous_graphs;
 
   /*! \brief Map of Ops with no associated FTVMMixedPrecisionConversionType to the times they were
    * encountered. Used for emitting warnings on missing ops in the pass.

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -175,21 +175,6 @@ class MixedPrecisionPass : public MixedModeMutator {
     return Attrs(new_attrs);
   }
 
-  Expr MakeAnalogousSubgraph(const Expr& expr) const {
-    if (auto node = expr.as<CallNode>()) {
-      Array<Expr> args;
-      for (Expr expr : node->args) {
-        args.push_back(Var("dummy_temp", GetType(expr)));
-      }
-      return Call(node->op, args, node->attrs, node->type_args, node->span);
-    } else if (auto node = expr.as<TupleGetItemNode>()) {
-      return TupleGetItem(MakeAnalogousSubgraph(node->tuple), node->index, node->span);
-    } else {
-      LOG(FATAL) << "Unknown node " << expr;
-      return Expr(nullptr);
-    }
-  }
-
   Type GetType(const Expr& expr) const {
     Type checked_type = expr->checked_type_;
     if (checked_type.defined()) {

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -898,7 +898,7 @@ class SameTypedSubgraphExtractor : public ExprMutator {
 
 namespace transform {
 
-Type InferTypeFast(const Expr& expr) {
+Type InferTypeLocal(const Expr& expr) {
   SameTypedSubgraphExtractor subgraph_extractor;
   auto mod = IRModule::FromExpr(subgraph_extractor(expr));
 
@@ -909,8 +909,8 @@ Type InferTypeFast(const Expr& expr) {
   return result_type;
 }
 
-TVM_REGISTER_GLOBAL("relay._transform.InferTypeFast").set_body_typed([](const Expr& expr) {
-  return InferTypeFast(expr);
+TVM_REGISTER_GLOBAL("relay._transform.InferTypeLocal").set_body_typed([](const Expr& expr) {
+  return InferTypeLocal(expr);
 });
 
 Pass InferType() {

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -830,7 +830,8 @@ class SameTypedSubgraphExtractor : public ExprMutator {
   by depending on existing type information being populated in expressions the target
   node depends on. If a node with populated type information is found we simply
   replace it with a variable of that type. In this way, we can avoid copying and
-  recursing through most of the expression graph.
+  recursing through most of the expression graph. Note, this assumes that current
+  populated type information is correct!
 
   ExprMutator is sufficient over MixedModemutator since we will not recurse much.
   */
@@ -899,6 +900,17 @@ class SameTypedSubgraphExtractor : public ExprMutator {
 namespace transform {
 
 Type InferTypeLocal(const Expr& expr) {
+  /*
+  This type inference differs from InferType in that it uses existing type information
+  to avoid recursing over much of the graph, and it only examines the type of the input
+  node. This makes it faster if you need to run type inference iteratively throughout
+  a pass for example.
+
+  However, it assumes any existing populated type inference is correct! If some populated
+  type inference is incorrect, an incorrect type may be returned or a type error will be
+  raised. If you know not all populated type fields are correct with the current graph,
+  you should use InferType() instead.
+  */
   SameTypedSubgraphExtractor subgraph_extractor;
   auto mod = IRModule::FromExpr(subgraph_extractor(expr));
 

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -841,50 +841,49 @@ class SameTypedSubgraphExtractor : public ExprMutator {
   Expr VisitExpr_(const GlobalVarNode* op) { return GlobalVar(op->name_hint); }
   Expr VisitExpr_(const OpNode* op) { return Op(GetRef<Op>(op)); }
   Expr VisitExpr_(const TupleNode* op) {
-    return Tuple(get_analogous_expression(op->fields), op->span);
+    return Tuple(GetAnalogousExpression(op->fields), op->span);
   }
   Expr VisitExpr_(const FunctionNode* op) {
     // We use these to regenerate the list of free variables in the function and place them in
     // the list of input parameters for the model.
-    Expr new_body = get_analogous_expression(op->body);
+    Expr new_body = GetAnalogousExpression(op->body);
     IRModule new_body_mod = IRModule::FromExpr(new_body);
     return Function(relay::FreeVars(new_body), new_body, op->ret_type,
                     relay::FreeTypeVars(new_body, IRModule::FromExpr(new_body)), op->attrs,
                     op->span);
   }
   Expr VisitExpr_(const CallNode* op) {
-    return Call(op->op, get_analogous_expression(op->args), op->attrs, op->type_args, op->span);
+    return Call(op->op, GetAnalogousExpression(op->args), op->attrs, op->type_args, op->span);
   }
   Expr VisitExpr_(const LetNode* op) {
-    return Let(op->var, get_analogous_expression(op->value), get_analogous_expression(op->body),
+    return Let(op->var, GetAnalogousExpression(op->value), GetAnalogousExpression(op->body),
                op->span);
   }
   Expr VisitExpr_(const IfNode* op) {
-    return If(get_analogous_expression(op->cond), get_analogous_expression(op->true_branch),
-              get_analogous_expression(op->false_branch), op->span);
+    return If(GetAnalogousExpression(op->cond), GetAnalogousExpression(op->true_branch),
+              GetAnalogousExpression(op->false_branch), op->span);
   }
   Expr VisitExpr_(const TupleGetItemNode* op) {
-    return TupleGetItem(get_analogous_expression(op->tuple), op->index, op->span);
+    return TupleGetItem(GetAnalogousExpression(op->tuple), op->index, op->span);
   }
   Expr VisitExpr_(const RefCreateNode* op) {
-    return RefCreate(get_analogous_expression(op->value), op->span);
+    return RefCreate(GetAnalogousExpression(op->value), op->span);
   }
   Expr VisitExpr_(const RefReadNode* op) {
-    return RefRead(get_analogous_expression(op->ref), op->span);
+    return RefRead(GetAnalogousExpression(op->ref), op->span);
   }
   Expr VisitExpr_(const RefWriteNode* op) {
-    return RefWrite(get_analogous_expression(op->ref), get_analogous_expression(op->value),
-                    op->span);
+    return RefWrite(GetAnalogousExpression(op->ref), GetAnalogousExpression(op->value), op->span);
   }
   Expr VisitExpr_(const ConstructorNode* op) {
     return Constructor(op->name_hint, op->inputs, op->belong_to);
   }
   Expr VisitExpr_(const MatchNode* op) {
-    return Match(get_analogous_expression(op->data), op->clauses, op->complete, op->span);
+    return Match(GetAnalogousExpression(op->data), op->clauses, op->complete, op->span);
   }
 
  private:
-  Expr get_analogous_expression(const Expr& expr) {
+  Expr GetAnalogousExpression(const Expr& expr) {
     // Replace the expression with a potentially simpler expression of the same type
     if (!expr->checked_type_.defined()) {
       return VisitExpr(expr);
@@ -892,10 +891,10 @@ class SameTypedSubgraphExtractor : public ExprMutator {
 
     return Var("dummy_var", expr->checked_type(), expr->span);
   }
-  Array<Expr> get_analogous_expression(const Array<Expr>& fields) {
+  Array<Expr> GetAnalogousExpression(const Array<Expr>& fields) {
     Array<Expr> new_fields;
     for (Expr expr : fields) {
-      new_fields.push_back(get_analogous_expression(expr));
+      new_fields.push_back(GetAnalogousExpression(expr));
     }
     return new_fields;
   }

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -826,7 +826,11 @@ void AddGlobalTypes(IRModule mod) {
 
 class SameTypedSubgraphExtractor : public ExprMutator {
   /*
-  Creates a small subgraph with the same type as the input expression.
+  Creates a small subgraph with the same type as the input expression. We attempt to do
+  by depending on existing type information being populated in expressions the target
+  node depends on. If a node with populated type information is found we simply
+  replace it with a variable of that type. In this way, we can avoid copying and
+  recursing through most of the expression graph.
 
   ExprMutator is sufficient over MixedModemutator since we will not recurse much.
   */
@@ -876,6 +880,7 @@ class SameTypedSubgraphExtractor : public ExprMutator {
 
  private:
   Expr get_analogous_expression(const Expr& expr) {
+    // Replace the expression with a potentially simpler expression of the same type
     if (!expr->checked_type_.defined()) {
       return VisitExpr(expr);
     }

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -885,11 +885,13 @@ class SameTypedSubgraphExtractor : public ExprMutator {
  private:
   Expr GetAnalogousExpression(const Expr& expr) {
     // Replace the expression with a potentially simpler expression of the same type
-    if (!expr->checked_type_.defined()) {
-      return VisitExpr(expr);
+    if (expr->checked_type_.defined()) {
+      // Since the expression already has a checked_type which we assume is correct we don't need
+      // full type inference to enter it. So stub it out with a dummy var of the same type.
+      return Var("dummy_var", expr->checked_type(), expr->span);
     }
 
-    return Var("dummy_var", expr->checked_type(), expr->span);
+    return VisitExpr(expr);
   }
   Array<Expr> GetAnalogousExpression(const Array<Expr>& fields) {
     Array<Expr> new_fields;

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -901,12 +901,12 @@ namespace transform {
 Type InferTypeFast(const Expr& expr) {
   SameTypedSubgraphExtractor subgraph_extractor;
   auto mod = IRModule::FromExpr(subgraph_extractor(expr));
+
   mod = transform::InferType()(mod);
-  if (expr.as<FunctionNode>()) {
-    return mod->Lookup("main")->checked_type();
-  } else {
-    return mod->Lookup("main").as<FunctionNode>()->body->checked_type();
-  }
+  Type result_type = mod->Lookup("main").as<FunctionNode>()->body->checked_type();
+
+  expr->checked_type_ = result_type;
+  return result_type;
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.InferTypeFast").set_body_typed([](const Expr& expr) {

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -824,18 +824,18 @@ void AddGlobalTypes(IRModule mod) {
   }
 }
 
+/*!
+ * \brief Returns a possibly much smaller subgraph whose inner nodes have the same type.
+ *
+ * Returns the largest sub-graph who's inner nodes need types and leaves are vars standing in
+ * for already typed sub-expressions. This creates a graph whose inner nodes have the same
+ * type as the original graph and when running type inference, we can avoid copying and
+ * recursing through most of the expression graph when running type inference. Note, this assumes
+ * that current populated type information is correct!
+ *
+ * ExprMutator is sufficient over MixedModemutator since we will not recurse much.
+ */
 class SameTypedSubgraphExtractor : public ExprMutator {
-  /*
-  Creates a small subgraph with the same type as the input expression. We attempt to do
-  by depending on existing type information being populated in expressions the target
-  node depends on. If a node with populated type information is found we simply
-  replace it with a variable of that type. In this way, we can avoid copying and
-  recursing through most of the expression graph. Note, this assumes that current
-  populated type information is correct!
-
-  ExprMutator is sufficient over MixedModemutator since we will not recurse much.
-  */
-
   Expr VisitExpr_(const VarNode* op) { return Var(op->vid, op->type_annotation, op->span); }
   Expr VisitExpr_(const ConstantNode* op) { return Constant(op->data, op->span); }
   Expr VisitExpr_(const GlobalVarNode* op) { return GlobalVar(op->name_hint); }

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -19,9 +19,8 @@
 """
 import pytest
 import tvm
-
-from tvm import IRModule, te, relay, parser
-from tvm.relay import op, transform, analysis
+from tvm import IRModule, parser, relay, te
+from tvm.relay import analysis, op, transform
 from tvm.relay.op import op as _op
 
 
@@ -33,12 +32,9 @@ def infer_mod(mod, annotate_spans=True):
     return mod
 
 
-def infer_expr(expr, annotate_spans=True):
-    mod = IRModule.from_expr(expr)
-    mod = infer_mod(mod, annotate_spans)
-    mod = transform.InferType()(mod)
-    entry = mod["main"]
-    return entry if isinstance(expr, relay.Function) else entry.body
+def infer_expr(expr):
+    transform.InferTypeLocal(expr)
+    return expr
 
 
 def assert_has_type(expr, typ, mod=None):
@@ -68,7 +64,7 @@ def test_monomorphic_let():
     # TODO(@jroesch): this seems whack.
     sb = relay.ScopeBuilder()
     x = relay.var("x", dtype="float64", shape=())
-    x = sb.let("x", relay.const(1.0, "float64"))
+    x = sb.let(x, relay.const(1.0, "float64"))
     sb.ret(x)
     xchecked = infer_expr(sb.get())
     assert xchecked.checked_type == relay.scalar_type("float64")
@@ -165,11 +161,11 @@ def test_recursion():
 def test_incomplete_call():
     tt = relay.scalar_type("int32")
     x = relay.var("x", tt)
+    f_type = relay.FuncType([tt], tt)
     f = relay.var("f")
     func = relay.Function([x, f], relay.Call(f, [x]), tt)
 
     ft = infer_expr(func)
-    f_type = relay.FuncType([tt], tt)
     assert ft.checked_type == relay.FuncType([tt, f_type], tt)
 
 
@@ -245,7 +241,7 @@ def test_ref():
 def test_free_expr():
     x = relay.var("x", "float32")
     y = relay.add(x, x)
-    yy = infer_expr(y, annotate_spans=False)
+    yy = infer_expr(y)
     assert tvm.ir.structural_equal(yy.args[0], x, map_free_vars=True)
     assert yy.checked_type == relay.scalar_type("float32")
     assert x.vid.same_as(yy.args[0].vid)
@@ -255,8 +251,11 @@ def test_type_args():
     x = relay.var("x", shape=(10, 10))
     y = relay.var("y", shape=(1, 10))
     z = relay.add(x, y)
-    ty_z = infer_expr(z)
-    ty_args = ty_z.type_args
+
+    # InferTypeLocal does not support populating the type_args field
+    mod = infer_mod(IRModule.from_expr(z))
+    mod = infer_mod(mod, annotate_spans=False)
+    ty_args = mod["main"].body.type_args
     assert len(ty_args) == 2
     assert ty_args[0].dtype == "float32"
     assert ty_args[1].dtype == "float32"


### PR DESCRIPTION
This PR adds a faster type inference pass which specifically is designed for the Automatic Mixed Precision Pass (AMP). The issue with AMP pass is it uses the existing type inference infrastructure extensively but existing type inference is not designed for the AMP workload.

AMP works by topologically going through the expression graph, replacing nodes with casted versions and using type inference extensively to do this. However, in order to use the type inference we must, for every subgraph build an IRModule and run type inference. The current type inference ignores previously populated type information and essentially repopulates the type fields of the subgraph we are examining. In a situation with N nodes arranged in a linear fashion, for AMP pass we will have N subgraphs we examine. For the `i`-th subgraph we have `i` nodes which IRModule and type inference will touch. This essentially means we have O(N^2) runtime at least which is bad.

The key issues are therefore:
1. Type inference needs an IRModule which touches all nodes in a graph
2. Type inference looks at all nodes in a graph and does not reuse information

The solution I came up with is a bit of a hack that let's me avoid rewriting the Type Inference pass (which is super essential and would take a long time to change). Essentially given an expression graph with partially populated type information, we can, given a subgraph, very easily construct an analogous graph which has the same type; we just need to replace nodes with known type information with a constant or variable expression. Doing this means if we are only interested in the type of a single node, we can extract a smaller subgraph with all the needed information to infer type. We then build an IRModule and run standard type inference on this much smaller subgraph.

This has 100x reduction in the AMP pass runtime. arcfaceresnet100 on a 2020 m1 macbook pro went from 20s --> 0.2s for example.