### PR TITLE
 Overload get() function for `Optional` type.

### DIFF
--- a/include/tvm/runtime/container/optional.h
+++ b/include/tvm/runtime/container/optional.h
@@ -97,7 +97,7 @@ class Optional : public ObjectRef {
    * \return The internal object pointer with type T* for Optional<T>.
    * \note This function do not perform not-null checking.
    */
-  const ContainerType* get() const { return data_; }
+  const ContainerType* get() const { return static_cast<ContainerType*>(data_.get()); }
   /*!
    * \return The contained value if the Optional is not null
    *         otherwise return the default_value.

--- a/include/tvm/runtime/container/optional.h
+++ b/include/tvm/runtime/container/optional.h
@@ -94,6 +94,13 @@ class Optional : public ObjectRef {
     return T(data_);
   }
   /*!
+   * \return The internal object pointer with type T* for Optional<T>.
+   * \note This function do not perform not-null checking.
+   */
+  const T* get() const {
+    return data_;
+  }
+  /*!
    * \return The contained value if the Optional is not null
    *         otherwise return the default_value.
    */

--- a/include/tvm/runtime/container/optional.h
+++ b/include/tvm/runtime/container/optional.h
@@ -94,7 +94,7 @@ class Optional : public ObjectRef {
     return T(data_);
   }
   /*!
-   * \return The internal object pointer with type T* for Optional<T>.
+   * \return The internal object pointer with container type of T.
    * \note This function do not perform not-null checking.
    */
   const ContainerType* get() const { return static_cast<ContainerType*>(data_.get()); }

--- a/include/tvm/runtime/container/optional.h
+++ b/include/tvm/runtime/container/optional.h
@@ -97,9 +97,7 @@ class Optional : public ObjectRef {
    * \return The internal object pointer with type T* for Optional<T>.
    * \note This function do not perform not-null checking.
    */
-  const T* get() const {
-    return data_;
-  }
+  const T* get() const { return data_; }
   /*!
    * \return The contained value if the Optional is not null
    *         otherwise return the default_value.

--- a/include/tvm/runtime/container/optional.h
+++ b/include/tvm/runtime/container/optional.h
@@ -97,7 +97,7 @@ class Optional : public ObjectRef {
    * \return The internal object pointer with type T* for Optional<T>.
    * \note This function do not perform not-null checking.
    */
-  const T* get() const { return data_; }
+  const ContainerType* get() const { return data_; }
   /*!
    * \return The contained value if the Optional is not null
    *         otherwise return the default_value.

--- a/src/tir/transforms/inject_rolling_buffer.cc
+++ b/src/tir/transforms/inject_rolling_buffer.cc
@@ -172,7 +172,7 @@ class RollingBufferInjector : public StmtExprMutator {
 
           auto it{std::find_if(
               bound_iter_vars.begin(), bound_iter_vars.end(),
-              [&](Optional<Var> var) { return var && (var.value().get() == loop_var.get()); })};
+              [&](Optional<Var> var) { return var && (var.get() == loop_var.get()); })};
 
           if (it != bound_iter_vars.end()) {
             auto i{std::distance(bound_iter_vars.begin(), it)};

--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -44,7 +44,7 @@ class BufferAllocationLocator : public StmtExprMutator {
     // create buffers to be allocated at each stmts
     for (const auto& kv : buffer_lca) {
       const Buffer& buffer = kv.first;
-      const StmtNode* stmt = kv.second.defined() ? kv.second.value().get() : nullptr;
+      const StmtNode* stmt = kv.second.defined() ? kv.second.get() : nullptr;
       if (arg_buffers.count(buffer.get())) {
         continue;
       }

--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -44,7 +44,7 @@ class BufferAllocationLocator : public StmtExprMutator {
     // create buffers to be allocated at each stmts
     for (const auto& kv : buffer_lca) {
       const Buffer& buffer = kv.first;
-      const StmtNode* stmt = kv.second.defined() ? kv.second.get() : nullptr;
+      const StmtNode* stmt = kv.second.get();
       if (arg_buffers.count(buffer.get())) {
         continue;
       }


### PR DESCRIPTION
Currently `Optional` don't have its own `get()` implementation, so if we want to get the internal container pointer of an optional object `o` with type `Optional<T>`, we can either use `o.value().get()` (in the case it's defined) or `static_cast<const T*>(o.get())` (because the inherited `get()` function has no type information). Neither of them are satisfactory if we want to get a pointer with type `const T*`.

This PR overloads the `get()` function of `Optional`, which returns `nullptr` when the object is not defined, and it's corresponding data pointer otherwise.

cc @junrushao1994 @tqchen 