### PR TITLE
[TIRScript] fix parse StringImm value in for loop annotations

### DIFF
--- a/python/tvm/script/tir/scope_handler.py
+++ b/python/tvm/script/tir/scope_handler.py
@@ -490,7 +490,7 @@ class ForScopeHandler(ScopeHandler):
                 for key, val in annotations.items()
             }
 
-        self.loop_info.append(LoopInfo(begin, extent, kind, thread_binding, annotations))
+        self.loop_info.append(LoopInfo(begin, extent, kind, thread_binding, self.annotations))
 
 
 @register

--- a/python/tvm/script/tir/scope_handler.py
+++ b/python/tvm/script/tir/scope_handler.py
@@ -483,13 +483,7 @@ class ForScopeHandler(ScopeHandler):
         """
         assert self.context and self.node, "call 'exit_scope' before 'enter_scope'"
         extent = end if begin == 0 else self.context.analyzer.simplify(end - begin)
-        self.annotations: Mapping[str, Object] = {}
-        if annotations is not None:
-            self.annotations = {
-                key: String(val) if isinstance(val, str) else val
-                for key, val in annotations.items()
-            }
-
+        self.annotations = annotations
         self.loop_info.append(LoopInfo(begin, extent, kind, thread_binding, self.annotations))
 
 

--- a/python/tvm/script/tir/scope_handler.py
+++ b/python/tvm/script/tir/scope_handler.py
@@ -20,7 +20,7 @@ from typing import Tuple, Any, Callable, Optional, List, Union, Mapping
 
 import synr
 import tvm.tir
-from tvm.runtime import Object, String
+from tvm.runtime import Object
 from tvm.ir import Span, Range
 from tvm.tir import Stmt, PrimExpr, IterVar, Var, Buffer, BufferRegion, ForKind
 

--- a/src/tir/transforms/flatten_buffer.cc
+++ b/src/tir/transforms/flatten_buffer.cc
@@ -97,9 +97,13 @@ class BufferFlattener : public StmtExprMutator {
       body = For(op->loop_var, std::move(min), std::move(extent), op->kind, std::move(body));
     }
     // Step 4. Handle annotations
+    std::set<std::string> ordered_ann_keys;
     for (const auto& annotation : op->annotations) {
-      const String& ann_key = annotation.first;
-      const ObjectRef& ann_value = annotation.second;
+      ordered_ann_keys.insert(annotation.first);
+    }
+    for (auto it = ordered_ann_keys.rbegin(); it != ordered_ann_keys.rend(); ++it) {
+      const std::string& ann_key = *it;
+      const ObjectRef& ann_value = op->annotations.at(ann_key);
       if (attr::IsPragmaKey(ann_key)) {
         body =
             AttrStmt(op->loop_var, ann_key, ConvertAttrValue(ann_key, ann_value), std::move(body));

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2806,7 +2806,6 @@ def test_for_thread_binding():
     assert isinstance(rt_func.body.body, tir.stmt.For)
     assert rt_func.body.body.kind == 4
     assert rt_func.body.body.thread_binding.thread_tag == "threadIdx.y"
-    assert isinstance(rt_func.body.body.annotations["attr_key"], tir.StringImm)
     assert rt_func.body.body.annotations["attr_key"] == "attr_value"
 
 
@@ -2881,7 +2880,6 @@ def test_block_elements():
     assert isinstance(block.body, tir.stmt.BufferStore)
     assert isinstance(block.init, tir.stmt.BufferStore)
     assert len(block.annotations) == 1
-    assert isinstance(block.annotations["attr_key"], tir.StringImm)
     assert block.annotations["attr_key"] == "attr_value"
 
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2806,6 +2806,7 @@ def test_for_thread_binding():
     assert isinstance(rt_func.body.body, tir.stmt.For)
     assert rt_func.body.body.kind == 4
     assert rt_func.body.body.thread_binding.thread_tag == "threadIdx.y"
+    assert isinstance(rt_func.body.body.annotations["attr_key"], tir.StringImm)
     assert rt_func.body.body.annotations["attr_key"] == "attr_value"
 
 
@@ -2880,6 +2881,7 @@ def test_block_elements():
     assert isinstance(block.body, tir.stmt.BufferStore)
     assert isinstance(block.init, tir.stmt.BufferStore)
     assert len(block.annotations) == 1
+    assert isinstance(block.annotations["attr_key"], tir.StringImm)
     assert block.annotations["attr_key"] == "attr_value"
 
 


### PR DESCRIPTION
Fix a minor issue that `for i in T.serial(0, 4, annotations={"pragma_key":"value"})` result to a `runtime.String` typed dict value.  The flatten pass do not allow attribute value of `runtime.String` .
