### PR TITLE
[TVMScript][FIX] Fix number of arguments for T.Buffer[...]

### DIFF
--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -137,8 +137,11 @@ class GenericBufferType(SpecialStmt):  # pylint: disable=too-few-public-methods,
         if len(args) < 2:
             raise ValueError("T.Buffer[...] needs at least two arguments: shape and dtype.")
         shape = args[0]
-        if not isinstance(shape, tuple):
-            raise ValueError("The first argument of T.Buffer[...] needs to be a tuple.")
+        if not isinstance(shape, (tuple, list)):
+            raise ValueError(
+                "The first argument of T.Buffer[...] needs to be a tuple, "
+                "followed by the second argument dtype as a string"
+            )
 
 
 uint8 = ConcreteType("uint8")

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -134,7 +134,11 @@ class GenericBufferType(SpecialStmt):  # pylint: disable=too-few-public-methods,
         This function is for Buffer[...] syntax sugar
         Note that args is the list of all arguments
         """
-        pass  # pylint: disable=unnecessary-pass
+        if len(args) < 2:
+            raise ValueError("T.Buffer[...] needs at least two arguments: shape and dtype.")
+        shape = args[0]
+        if not isinstance(shape, tuple):
+            raise ValueError("The first argument of T.Buffer[...] needs to be a tuple.")
 
 
 uint8 = ConcreteType("uint8")

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -137,7 +137,7 @@ class GenericBufferType(SpecialStmt):  # pylint: disable=too-few-public-methods,
         if len(args) < 2:
             raise ValueError("T.Buffer[...] needs at least two arguments: shape and dtype.")
         shape = args[0]
-        if not isinstance(shape, (tuple, list)):
+        if not isinstance(shape, tuple):
             raise ValueError(
                 "The first argument of T.Buffer[...] needs to be a tuple, "
                 "followed by the second argument dtype as a string"

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -139,6 +139,12 @@ def elementwise_buffer_no_kwargs(
             b[vi, vj, vk, vl] = a[vi, vj, vk, vl] * 2.0
 
 
+# match buffer failed case
+def test_elementwise_buffer_no_kwargs_failed() -> None:
+    with pytest.raises(ValueError) as e:
+        a = T.Buffer[(128, 128, 128, 128)]
+
+
 def test_match_buffer_syntax_sugar():
     # with kwargs
     assert_structural_equal(elementwise_handle, elementwise_buffer_kwargs)

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -139,17 +139,22 @@ def elementwise_buffer_no_kwargs(
             b[vi, vj, vk, vl] = a[vi, vj, vk, vl] * 2.0
 
 
-# match buffer failed case
-def test_elementwise_buffer_no_kwargs_failed() -> None:
-    with pytest.raises(ValueError) as e:
-        a = T.Buffer[(128, 128, 128, 128)]
-
-
 def test_match_buffer_syntax_sugar():
     # with kwargs
     assert_structural_equal(elementwise_handle, elementwise_buffer_kwargs)
     # without kwargs
     assert_structural_equal(elementwise_handle, elementwise_buffer_no_kwargs)
+
+
+# match buffer failed case
+def test_match_buffer_no_kwargs_failed():
+    with pytest.raises(ValueError) as e:
+
+        def elementwise_buffer_no_kwargs_failed(
+            a: T.Buffer[(128, 128, 128, 128)],
+            b: T.Buffer[(128, 128, 128, 128)],
+        ) -> None:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR intends to fix the number of arguments for `T.Buffer[]` and raise an error if the first argument of it is not a `tuple`.

cc: @vinx13 @junrushao1994 
