### PR TITLE
Generate compile_commands.json by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,10 @@ include_directories(SYSTEM ${PICOJSON_PATH})
 # initial variables
 set(TVM_LINKER_LIBS "")
 set(TVM_RUNTIME_LINKER_LIBS "")
+if("${CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "")
+  # If not set manually, change the default to ON
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
 
 # Generic compilation options
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ set(TVM_RUNTIME_LINKER_LIBS "")
 # If we update to CMake 2.21+, we can use PROJECT_IS_TOP_LEVEL instead
 get_directory_property(IS_SUBPROJECT PARENT_DIRECTORY)
 
-if(NOT IS_SUBPROJECT AND "${CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "")
+if(NOT IS_SUBPROJECT AND NOT DEFINED "${CMAKE_EXPORT_COMPILE_COMMANDS}")
   # If not set manually, change the default to ON
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,13 @@ include_directories(SYSTEM ${PICOJSON_PATH})
 # initial variables
 set(TVM_LINKER_LIBS "")
 set(TVM_RUNTIME_LINKER_LIBS "")
-if("${CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "")
+
+
+# Check if this is being run on its own or as a subdirectory for another project
+# If we update to CMake 2.21+, we can use PROJECT_IS_TOP_LEVEL instead
+get_directory_property(IS_SUBPROJECT PARENT_DIRECTORY)
+
+if(NOT IS_SUBPROJECT AND "${CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "")
   # If not set manually, change the default to ON
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()


### PR DESCRIPTION
This is low overhead (it only affects the make-generation step, not the actual build) and makes developer tooling like clangd work much better, so we should have it on by default instead of off (which is CMake's default). If necessary, it can be disabled with

```bash
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=0 ...
```

or adding this to `config.cmake`

```
set(CMAKE_EXPORT_COMPILE_COMMANDS OFF)
```

If CMake is run from a subproject, this does nothing and leaves it to the parent to configure. For example, this does not generate `compile_commands.json` by default:

```cmake
cmake_minimum_required(VERSION 2.0 FATAL_ERROR)
project(test)
add_subdirectory(tvm)
add_executable(test test.cpp)
```

cc @areusch 
