### PR TITLE
[PartitionPattern] Modify  Pattern Partitioner to only check expr in current group

### DIFF
--- a/python/tvm/relay/op/contrib/bnns.py
+++ b/python/tvm/relay/op/contrib/bnns.py
@@ -29,7 +29,7 @@ from tvm.relay.expr import const
 from tvm.relay.build_module import bind_params_by_name
 
 from .register import register_pattern_table, get_pattern_table
-from ...dataflow_pattern import wildcard, is_op, is_expr
+from ...dataflow_pattern import wildcard, is_op, is_expr, ConstantPattern
 
 
 def partition_for_bnns(mod, params=None):
@@ -211,8 +211,8 @@ def dense(expr):
 def make_conv_pattern(with_bias=True, activation="none"):
     """Make pattern for bnns.conv2d primitive"""
     data = wildcard()
-    weight = wildcard()
-    bias = wildcard()
+    weight = ConstantPattern()
+    bias = ConstantPattern()
     pat = is_op("nn.conv2d")(data, weight)
     if with_bias:
         pat = is_op("add")(pat, bias) | is_op("nn.bias_add")(pat, bias)


### PR DESCRIPTION
I think current check_ function in PatternPartitioner should only check exprs in current matched group, exclude of exprs outside of the matched group(these exprs are  deemed as args of current group). For example, if a target has a very special requirement for nn.pad, such as requires pad_value equal to 0. we has defined thousands of patterns for the target and nn.pad exists in many of them. Current check_ function is impossible to distinguish nn.pad in current group from nn.pad in args of current group, but I only care about whether nn.pad in current group  is valid for the target.
