### PR TITLE
[Hexagon] Account for objects being smaller than the allocated space

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -190,29 +190,29 @@ void HexagonBuffer::SetStorageScope(Optional<String> scope) {
 
 void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
   CHECK_LE(nbytes, nbytes_);
-  size_t offset = 0;
+  size_t copied = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
-    size_t bytes_to_copy = std::min(nbytes - offset, managed_allocations_[i]->nbytes_);
+    size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
     if (bytes_to_copy == 0) break;
 
-    memcpy(static_cast<char*>(data) + offset,
+    memcpy(static_cast<char*>(data) + copied,
            static_cast<const char*>(managed_allocations_[i]->data_), bytes_to_copy);
 
-    offset += bytes_to_copy;
+    copied += bytes_to_copy;
   }
 }
 
 void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
   CHECK_LE(nbytes, nbytes_);
-  size_t offset = 0;
+  size_t copied = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
-    size_t bytes_to_copy = std::min(nbytes - offset, managed_allocations_[i]->nbytes_);
+    size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
     if (bytes_to_copy == 0) break;
 
     memcpy(static_cast<char*>(managed_allocations_[i]->data_),
-           static_cast<const char*>(data) + offset, bytes_to_copy);
+           static_cast<const char*>(data) + copied, bytes_to_copy);
 
-    offset += bytes_to_copy;
+    copied += bytes_to_copy;
   }
 }
 

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -187,66 +187,55 @@ void HexagonBuffer::SetStorageScope(Optional<String> scope) {
   }
 }
 
-void HexagonBuffer::CopyTo(void* data, size_t nbytes) {
-  CHECK(nbytes_ == nbytes);
+void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
+  CHECK_LE(nbytes, nbytes_);
   size_t offset = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
-    CHECK(nbytes / nallocs_ == managed_allocations_[i]->nbytes_);
+    size_t bytes_to_copy = std::min(nbytes - offset, managed_allocations_[i]->nbytes_);
+    if (bytes_to_copy == 0) break;
 
     memcpy(static_cast<char*>(data) + offset,
-           static_cast<const char*>(managed_allocations_[i]->data_),
-           managed_allocations_[i]->nbytes_);
+           static_cast<const char*>(managed_allocations_[i]->data_), bytes_to_copy);
 
-    offset += managed_allocations_[i]->nbytes_;
+    offset += bytes_to_copy;
   }
 }
 
 void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
-  CHECK(nbytes_ == nbytes);
+  CHECK_LE(nbytes, nbytes_);
   size_t offset = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
-    CHECK(nbytes / nallocs_ == managed_allocations_[i]->nbytes_);
+    size_t bytes_to_copy = std::min(nbytes - offset, managed_allocations_[i]->nbytes_);
+    if (bytes_to_copy == 0) break;
 
     memcpy(static_cast<char*>(managed_allocations_[i]->data_),
-           static_cast<const char*>(data) + offset, managed_allocations_[i]->nbytes_);
+           static_cast<const char*>(data) + offset, bytes_to_copy);
 
-    offset += managed_allocations_[i]->nbytes_;
+    offset += bytes_to_copy;
   }
 }
 
-void HexagonBuffer::CopyFrom(const HexagonBuffer& other) {
-  CHECK(nbytes_ == other.nbytes_);
+void HexagonBuffer::CopyFrom(const HexagonBuffer& other, size_t nbytes) {
+  CHECK_LE(nbytes, nbytes_);
+  CHECK_LE(nbytes, other.nbytes_);
 
   if (nallocs_ == other.nallocs_) {
+    size_t copied = 0;
     for (size_t i = 0; i < nallocs_; ++i) {
+      size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
+      if (bytes_to_copy == 0) break;
+
       CHECK(managed_allocations_[i]->nbytes_ == other.managed_allocations_[i]->nbytes_);
 
       memcpy(static_cast<char*>(managed_allocations_[i]->data_),
-             static_cast<const char*>(other.managed_allocations_[i]->data_),
-             managed_allocations_[i]->nbytes_);
+             static_cast<const char*>(other.managed_allocations_[i]->data_), bytes_to_copy);
+
+      copied += bytes_to_copy;
     }
   } else if (nallocs_ == 1) {
-    size_t offset = 0;
-    for (size_t i = 0; i < other.nallocs_; ++i) {
-      CHECK(nbytes_ / other.nallocs_ == other.managed_allocations_[i]->nbytes_);
-
-      memcpy(static_cast<char*>(managed_allocations_[0]->data_) + offset,
-             static_cast<const char*>(other.managed_allocations_[i]->data_),
-             other.managed_allocations_[i]->nbytes_);
-
-      offset += other.managed_allocations_[i]->nbytes_;
-    }
+    return other.CopyTo(managed_allocations_[0]->data_, nbytes);
   } else if (other.nallocs_ == 1) {
-    size_t offset = 0;
-    for (size_t i = 0; i < nallocs_; ++i) {
-      CHECK(other.nbytes_ / nallocs_ == managed_allocations_[i]->nbytes_);
-
-      memcpy(static_cast<char*>(managed_allocations_[i]->data_),
-             static_cast<const char*>(other.managed_allocations_[0]->data_) + offset,
-             managed_allocations_[i]->nbytes_);
-
-      offset += managed_allocations_[i]->nbytes_;
-    }
+    return CopyFrom(other.managed_allocations_[0]->data_, nbytes);
   } else {
     CHECK(false) << "To copy between Hexagon Buffers they must either have the same number of "
                     "dimensions or one of the Hexagon Buffers must have a single dimension.";

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -226,7 +226,7 @@ void HexagonBuffer::CopyFrom(const HexagonBuffer& other, size_t nbytes) {
       size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
       if (bytes_to_copy == 0) break;
 
-      CHECK(managed_allocations_[i]->nbytes_ == other.managed_allocations_[i]->nbytes_);
+      CHECK_LE(other.managed_allocations_[i]->nbytes_, managed_allocations_[i]->nbytes_);
 
       memcpy(static_cast<char*>(managed_allocations_[i]->data_),
              static_cast<const char*>(other.managed_allocations_[i]->data_), bytes_to_copy);

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -29,6 +29,7 @@
 #include "HAP_compute_res.h"
 #endif
 
+#include <algorithm>
 #include <string>
 #include <utility>
 

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.h
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.h
@@ -116,7 +116,7 @@ class HexagonBuffer {
    *
    * \param nbytes The number of bytes to copy.
    */
-  void CopyTo(void* data, size_t nbytes);
+  void CopyTo(void* data, size_t nbytes) const;
 
   /* \brief Copy data from an external buffer to a Hexagon Buffer.
    *
@@ -129,8 +129,10 @@ class HexagonBuffer {
   /* \brief Copy data from one Hexagon Buffer to another.
    *
    * \param other The other Hexagon Buffer.
+   *
+   * \param nbytes The number of bytes to copy.
    */
-  void CopyFrom(const HexagonBuffer& other);
+  void CopyFrom(const HexagonBuffer& other, size_t nbytes);
 
  private:
   //! \brief Assign a storage scope to the buffer.

--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
@@ -126,7 +126,7 @@ void HexagonDeviceAPIv2::CopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamH
       TVMDeviceExtType(to->device.device_type) == kDLHexagon) {
     CHECK(hex_from_buf != nullptr);
     CHECK(hex_to_buf != nullptr);
-    hex_to_buf->CopyFrom(*hex_from_buf);
+    hex_to_buf->CopyFrom(*hex_from_buf, GetDataSize(*from));
   } else if (from->device.device_type == kDLCPU &&
              TVMDeviceExtType(to->device.device_type) == kDLHexagon) {
     CHECK(hex_to_buf != nullptr);


### PR DESCRIPTION
In particular, graph executor will reuse allocated buffers for various tensors. These tensors may be of various sizes as long as the buffer is large enough to hold them.
