### PR TITLE
Remove CMake string REPEAT

### DIFF
--- a/cmake/utils/Summary.cmake
+++ b/cmake/utils/Summary.cmake
@@ -20,15 +20,11 @@ function(pad_string output str padchar length)
     math(EXPR _strlen "${length} - ${_strlen}")
 
     if(_strlen GREATER 0)
-    if(${CMAKE_VERSION} VERSION_LESS "3.14")
         unset(_pad)
         foreach(_i RANGE 1 ${_strlen}) # inclusive
-        string(APPEND _pad ${padchar})
+            string(APPEND _pad ${padchar})
         endforeach()
-    else()
-        string(REPEAT ${padchar} ${_strlen} _pad)
-    endif()
-    string(APPEND str ${_pad})
+        string(APPEND str ${_pad})
     endif()
 
     set(${output} "${str}" PARENT_SCOPE)


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/command/string.html#repeat this was added in 3.15, we can revert this if we ever use a minimum cmake newer than that. Until then we should just remove the alternate path to reduce complexity.

cc @leandron 