### PR TITLE
[Bugfix]  fix the bug when  the test_enter_pass_ctx_exception() is tested separately

### DIFF
--- a/tests/python/relay/test_pass_instrument.py
+++ b/tests/python/relay/test_pass_instrument.py
@@ -236,7 +236,7 @@ def test_enter_pass_ctx_exception():
     # Make sure we get correct PassContext
     cur_pass_ctx = tvm.transform.PassContext.current()
     assert pass_ctx != cur_pass_ctx
-    assert cur_pass_ctx.instruments == None
+    assert not cur_pass_ctx.instruments
 
 
 def test_enter_pass_ctx_exception_global():


### PR DESCRIPTION
In the batch test ,cause a previous function will specify the value of PassContext.current() as None,so tests the test_enter_pass_exception() will pass. but when testing it individually ,the result of PassContext.current() is a [] instead of None,it will not pass, this may happen when using the option of "pytest -n 4".

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
