### PR TITLE
Include \0 terminating character in strncpy

### DIFF
--- a/src/runtime/object.cc
+++ b/src/runtime/object.cc
@@ -267,6 +267,6 @@ int TVMObjectTypeIndex2Key(unsigned tindex, char** out_type_key) {
   API_BEGIN();
   auto key = tvm::runtime::Object::TypeIndex2Key(tindex);
   *out_type_key = static_cast<char*>(malloc(key.size() + 1));
-  strncpy(*out_type_key, key.c_str(), key.size());
+  strncpy(*out_type_key, key.c_str(), key.size() + 1);
   API_END();
 }


### PR DESCRIPTION
I'm fairly certain that this bugfix is correct, but please check my code. I'm not sure how this hasn't caused more problems for people! Perhaps the malloced memory is usually filled with 0s? Either way, on my system, the malloced memory was NOT all 0s, and so when we would copy the `key.size()` valid characters of `key` into `*out_type_key`, it was likely that the next character was not 0, and thus, because no terminator was copied over, the string wouldn't be terminated correctly. This fix ensures the terminator gets copied over, by copying `key.size() + 1` characters.