### PR TITLE
[AMP] Disallow converting layer norm to fp16

### DIFF
--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -130,6 +130,8 @@ DEFAULT_NEVER_LIST = [
     "nn.adaptive_avg_pool3d",
     "sum",
     "mean",
+    "variance",
+    "nn.layer_norm"
 ]
 
 

--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -131,7 +131,7 @@ DEFAULT_NEVER_LIST = [
     "sum",
     "mean",
     "variance",
-    "nn.layer_norm"
+    "nn.layer_norm",
 ]
 
 


### PR DESCRIPTION
`nn.layer_norm` is decomposed into `mean` and `variance` during `SimplifyInference`, so if `ToMixedPrecision` is applied before `SimplifyInference`, we end up with fp16 input `mean` and `variance` even though they are on the `NEVER` list!

This happens in the facebook [DETR](https://github.com/facebookresearch/detr) object detection model, but not in BERT.

@AndrewZhaoLuo @comaniac 