### PR TITLE
[Runtime] Extend generic func with get_packed_func() interface

### DIFF
--- a/include/tvm/target/generic_func.h
+++ b/include/tvm/target/generic_func.h
@@ -86,7 +86,10 @@ class GenericFunc : public ObjectRef {
    * \param ret The return value
    */
   TVM_DLL void CallPacked(runtime::TVMArgs args, runtime::TVMRetValue* ret) const;
-
+  /*!
+   * \brief Get the packed function specified for the current target context.
+   */
+  TVM_DLL PackedFunc GetPacked() const;
   /*!
    * \brief Find or register the GenericFunc instance corresponding to the give name
    * \param name The name of the registered GenericFunc

--- a/python/tvm/ir/op.py
+++ b/python/tvm/ir/op.py
@@ -59,6 +59,21 @@ class Op(RelayExpr):
         """
         return _ffi_api.OpGetAttr(self, attr_name)
 
+    def has_attr(self, attr_name):
+        """Check whether the operator has additional attribute.
+
+        Parameters
+        ----------
+        attr_name : str
+            The attribute name.
+
+        Returns
+        -------
+        value : bool
+            Whether the operator has additional attribute
+        """
+        return _ffi_api.OpHasAttr(self, attr_name)
+
     def set_attr(self, attr_name, value, plevel=10):
         """Set attribute about the operator.
 
@@ -156,6 +171,17 @@ class Op(RelayExpr):
             The type key.
         """
         _ffi_api.OpSetAttrsTypeKey(self, key)
+
+    @staticmethod
+    def list_op_names():
+        """List all the op names in the op registry.
+
+        Returns
+        -------
+        value : List[str]
+            The registered op names
+        """
+        return _ffi_api.ListOpNames()
 
 
 def register_op_attr(op_name, attr_key, value=None, level=10):

--- a/src/ir/op.cc
+++ b/src/ir/op.cc
@@ -90,6 +90,10 @@ TVM_REGISTER_GLOBAL("ir.OpGetAttr").set_body_typed([](Op op, String attr_name) -
   return rv;
 });
 
+TVM_REGISTER_GLOBAL("ir.OpHasAttr").set_body_typed([](Op op, String attr_name) -> bool {
+  return Op::HasAttrMap(attr_name);
+});
+
 TVM_REGISTER_GLOBAL("ir.OpSetAttr")
     .set_body_typed([](Op op, String attr_name, runtime::TVMArgValue value, int plevel) {
       auto& reg = OpRegistry::Global()->RegisterOrGet(op->name).set_name();

--- a/src/target/generic_func.cc
+++ b/src/target/generic_func.cc
@@ -118,6 +118,20 @@ void GenericFunc::CallPacked(TVMArgs args, TVMRetValue* ret) const {
   func.CallPacked(args, ret);
 }
 
+PackedFunc GenericFunc::GetPacked() const {
+  auto node = static_cast<const GenericFuncNode*>(get());
+  auto target = Target::Current(true);
+  if (target.defined()) {
+    for (auto& k : target->GetKeys()) {
+      auto iter = node->dispatch_dict_.find(k);
+      if (iter != node->dispatch_dict_.end()) {
+        return iter->second;
+      }
+    }
+  }
+  return node->generic_func_;
+}
+
 TVM_REGISTER_GLOBAL("target.GenericFuncCreate").set_body([](TVMArgs args, TVMRetValue* ret) {
   *ret = GenericFunc(make_object<GenericFuncNode>());
 });
@@ -156,6 +170,11 @@ TVM_REGISTER_GLOBAL("target.GenericFuncCallFunc").set_body([](TVMArgs args, TVMR
   TVMArgs func_args(&args.values[1], &args.type_codes[1], args.num_args - 1);
 
   generic_func.CallPacked(func_args, ret);
+});
+
+TVM_REGISTER_GLOBAL("target.GenericFuncGetPackedFunc").set_body([](TVMArgs args, TVMRetValue* ret) {
+  GenericFunc generic_func = args[0];
+  *ret = generic_func.GetPacked();
 });
 
 }  // namespace tvm

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -63,20 +63,75 @@ def test_all_targets_device_type_verify():
 def test_target_dispatch():
     with tvm.target.cuda():
         assert mygeneric(1) == 3
+        assert mygeneric.get_packed_func()(1) == 3
 
     with tvm.target.rocm():
         assert mygeneric(1) == 4
+        assert mygeneric.get_packed_func()(1) == 4
 
     with tvm.target.Target("cuda"):
         assert mygeneric(1) == 3
+        assert mygeneric.get_packed_func()(1) == 3
 
     with tvm.target.arm_cpu():
         assert mygeneric(1) == 11
+        assert mygeneric.get_packed_func()(1) == 11
 
     with tvm.target.Target("metal"):
         assert mygeneric(1) == 3
+        assert mygeneric.get_packed_func()(1) == 3
 
     assert tvm.target.Target.current() is None
+
+
+@tvm.target.override_native_generic_func("test_target_temp_strategy")
+def target_generic(data):
+    # default generic function
+    return data + 1
+
+
+@target_generic.register(["cuda", "gpu"])
+def target_cuda_func(data):
+    return data + 2
+
+
+def temp_target_cuda_func(data):
+    return data + 3
+
+
+def test_target_temp_strategy():
+    class TempStrategy(object):
+        def __init__(self, name, target, fstrategy):
+            generic_fstrategy = tvm.target.get_native_generic_func(name)
+            self.target = target
+            self.name = name
+            self.origin_func = {}
+            with tvm.target.Target(target) as target_obj:
+                for tgt_key in target_obj.keys:
+                    self.origin_func[tgt_key] = generic_fstrategy.get_packed_func()
+                    generic_fstrategy.register(fstrategy, tgt_key, allow_override=True)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, typ, value, traceback):
+            generic_fstrategy = tvm.target.get_native_generic_func(self.name)
+            with tvm.target.Target(self.target) as target_obj:
+                for tgt_key in target_obj.keys:
+                    generic_fstrategy.register(
+                        self.origin_func[tgt_key], tgt_key, allow_override=True
+                    )
+
+    with tvm.target.Target("cuda"):
+        assert target_generic(1) == 3
+
+    # The strategy func change to temp_target_cuda_func.
+    with TempStrategy("test_target_temp_strategy", "cuda", temp_target_cuda_func):
+        with tvm.target.Target("cuda"):
+            assert target_generic(1) == 4
+
+    with tvm.target.Target("cuda"):
+        assert target_generic(1) == 3
 
 
 def test_target_string_parse():


### PR DESCRIPTION
This PR add get_packed_func interface to GenericFunc. This interface is used to get the packed function specified for the current target. As a third-party user, we can use this interface along with python context manager to temporary override op strategy with our own device strategy. 
We can create temporary stratey registry as below:
```python
with TempOpStrategy("nn.conv2d", "cuda", general_strategy):
    lib = relay.build(...)
```
We save the current strategy function when TempOpStrategy init and register the strategy funtion back when TempOpStrtegy exit.
```python
class TempOpStrategy(object):
    def __init__(self, op_name, target, fstrategy):
        generic_fstrategy = relay.op.get(op_name).get_attr("FTVMStrategy")
        self.op_name = op_name
        self.target = target
        with tvm.target.Target(target) as target_obj:
            self.origin_func = generic_fstrategy.get_packed_func()
            for tgt_key in target_obj.keys:
                generic_fstrategy.register(fstrategy, tgt_key, allow_override=True)

    def __enter__(self):
        return self

    def __exit__(self, typ, value, traceback):
        generic_fstrategies = relay.op.get(name).get_attr("FTVMStrategy")
        with tvm.target.Target(self.target) as target_obj:
            for tgt_key in target_obj.keys:
                generic_fstrategies.register(self.origin_func, tgt_key, allow_override=True)
```


