### PR TITLE
[microNPU][2d] Add more Part matchers to cascader

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/te/binary_elementwise.py
+++ b/python/tvm/relay/backend/contrib/ethosu/te/binary_elementwise.py
@@ -17,7 +17,10 @@
 # pylint: disable=invalid-name,unused-argument
 """Tensor Expressions for binary_elementwise"""
 import operator
+import numpy as np
 from tvm import te
+from tvm.contrib.ethosu.cascader import TESubgraph, EthosuPart, Propagator, register_matcher
+
 from .dma import dma_ofm_compute, dma_ifm_compute
 
 
@@ -123,6 +126,12 @@ def binary_elementwise_compute(
     te.Tensor
         The Output Feature Map tensor.
     """
+    assert ifm.shape[0] == 1
+    assert ifm2.shape[0] == 1
+    assert ifm_layout in {"NHWC", "NHCWB16"}
+    assert ifm2_layout in {"NHWC", "NHCWB16"}
+    assert ofm_layout in {"NHWC", "NHCWB16"}
+
     # Compute operation for the IFM DMA pipeline
     dmaed_ifm = dma_ifm_compute(
         ifm, ifm_layout, ifm_zero_point, ifm_scale, ifm_channels, (0, 0, 0, 0)
@@ -187,5 +196,147 @@ def binary_elementwise_compute(
             attrs=binary_elementwise_attrs,
         )
 
+    nhwc_to_nhcwb16 = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1 / 16, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 16],
+        [0, 0, 0, 0, 1],
+    ]
+    nhcwb16_to_nhwc = [
+        [1, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0],
+        [0, 0, 16, 0, 1, -16],
+        [0, 0, 0, 0, 0, 1],
+    ]
+    ifm_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 1],
+    ]
+    ifm2_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, (1 - int(broadcast[1])), 0, 0, int(broadcast[1])],
+        [0, 0, (1 - int(broadcast[2])), 0, int(broadcast[2])],
+        [0, 0, 0, (1 - int(broadcast[3])), int(broadcast[3])],
+        [0, 0, 0, 0, 1],
+    ]
+    if ofm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(ifm_matrix, nhcwb16_to_nhwc).tolist()
+        ifm2_matrix = np.matmul(ifm2_matrix, nhcwb16_to_nhwc).tolist()
+    if ifm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(nhwc_to_nhcwb16, ifm_matrix).tolist()
+    if ifm2_layout == "NHCWB16":
+        ifm2_matrix = np.matmul(nhwc_to_nhcwb16, ifm2_matrix).tolist()
+    ifm_propagator = Propagator(
+        ifm_matrix,
+        [0, 0, 0, 0] if ifm_layout == "NHWC" else [0, 0, 0, 0, 0],
+    )
+    ifm2_propagator = Propagator(
+        ifm2_matrix,
+        [0, 0, 0, 0] if ifm2_layout == "NHWC" else [0, 0, 0, 0, 0],
+    )
+    propagator_attrs = {
+        "ifm_propagator": ifm_propagator,
+        "ifm2_propagator": ifm2_propagator,
+    }
+
     # Compute operation for the OFM DMA pipeline
-    return dma_ofm_compute(binary_elementwise, ofm_layout, ofm_zero_point, ofm_scale, ifm_channels)
+    return dma_ofm_compute(
+        binary_elementwise,
+        ofm_layout,
+        ofm_zero_point,
+        ofm_scale,
+        ifm_channels,
+        attrs=propagator_attrs,
+    )
+
+
+@register_matcher
+def match_ethosu_binary_elementwise(output_tensor, device_config):
+    """Match a Tensor Expression corresponding to an NPU Binary Elementwise.
+
+    If the Tensor Expression matches, an EthosuPart will be created that models the
+    matched Tensor Expression. Otherwise, None will be returned.
+
+    Parameters
+    ----------
+    output_tensor : tvm.te.Tensor
+        The tensor to attempt to match with.
+    device_config : EthosuDeviceConfig
+        Target device configuration
+
+    Returns
+    -------
+    Union[None, EthosuPart]
+        The created EthosuPart if there was a match, otherwise None.
+
+    """
+    write = output_tensor
+    if write.op.name != "ethosu_write":
+        return None
+    convert_to_nhcwb16 = write.op.input_tensors[0]
+    if convert_to_nhcwb16.op.name != "ethosu_convert_to_nhcwb16":
+        return None
+    binary_elementwise = convert_to_nhcwb16.op.input_tensors[0]
+    if binary_elementwise.op.name != "ethosu_binary_elementwise":
+        return None
+    pad = binary_elementwise.op.input_tensors[0]
+    if pad.op.name != "ethosu_pad":
+        return None
+    convert_to_nhwc = pad.op.input_tensors[0]
+    if convert_to_nhwc.op.name != "ethosu_convert_to_nhwc":
+        return None
+    read = convert_to_nhwc.op.input_tensors[0]
+    if read.op.name != "ethosu_read":
+        return None
+    pad2 = binary_elementwise.op.input_tensors[1]
+    if pad2.op.name != "ethosu_pad":
+        return None
+    convert_to_nhwc2 = pad2.op.input_tensors[0]
+    if convert_to_nhwc2.op.name != "ethosu_convert_to_nhwc":
+        return None
+    read2 = convert_to_nhwc2.op.input_tensors[0]
+    if read2.op.name != "ethosu_read":
+        return None
+
+    input_tensors = [
+        read.op.input_tensors[0],
+        read2.op.input_tensors[0],
+    ]
+    subgraph = TESubgraph(input_tensors, output_tensor)
+    propagators = [
+        write.op.attrs["ifm_propagator"],
+        write.op.attrs["ifm2_propagator"],
+    ]
+    ifm_dtype = input_tensors[0].dtype
+    ofm_dtype = output_tensor.dtype
+
+    output_layout = convert_to_nhcwb16.op.attrs["layout"]
+    input_layout = convert_to_nhwc.op.attrs["layout"]
+    input2_layout = convert_to_nhwc2.op.attrs["layout"]
+    output_quantum = device_config.get_output_quantum(output_layout)
+
+    block_config = device_config.get_elementwise_block_config(
+        propagators[0],
+        propagators[1],
+        binary_elementwise.op.attrs,
+        output_tensor.shape,
+        output_layout,
+        input_layout,
+        input2_layout,
+        ifm_dtype,
+        ofm_dtype,
+    )
+
+    return EthosuPart(
+        subgraph,
+        propagators,
+        output_quantum,
+        1,
+        block_config,
+    )

--- a/python/tvm/relay/backend/contrib/ethosu/te/convolution.py
+++ b/python/tvm/relay/backend/contrib/ethosu/te/convolution.py
@@ -297,7 +297,9 @@ def match_ethosu_conv2d(output_tensor, device_config):
         conv2d.op.name, ifm_channels, ifm_dtype, kernel_elements
     )
     subkernels = len(
-        device_config.get_kernel_steps(kernel_height, kernel_width, ifm_dtype, is_part_kernel)
+        device_config.get_kernel_steps(
+            conv2d.op.name, kernel_height, kernel_width, ifm_dtype, is_part_kernel
+        )
     )
 
     output_layout = convert_to_nhcwb16.op.attrs["layout"]

--- a/python/tvm/relay/backend/contrib/ethosu/te/depthwise.py
+++ b/python/tvm/relay/backend/contrib/ethosu/te/depthwise.py
@@ -17,8 +17,11 @@
 # pylint: disable=invalid-name,unused-argument
 """Tensor Expressions for depthwise convolutions"""
 from typing import Tuple, Union, List
+import numpy as np
 
 from tvm import te
+from tvm.contrib.ethosu.cascader import TESubgraph, EthosuPart, Propagator, register_matcher
+
 from .dma import dma_ofm_compute, dma_ifm_compute
 
 
@@ -110,9 +113,10 @@ def depthwise_conv2d_compute(
     assert ifm_layout in {"NHWC", "NHCWB16"}
     assert ofm_layout in {"NHWC", "NHCWB16"}
 
-    stride_h, stride_w = strides
-    dilation_h, dilation_w = dilation
-    channels, kernel_h, kernel_w, _ = weight.shape
+    padding = [int(v) for v in padding]
+    stride_h, stride_w = [int(v) for v in strides]
+    dilation_h, dilation_w = [int(v) for v in dilation]
+    channels, kernel_h, kernel_w, _ = [int(v) for v in weight.shape]
 
     # Compute operation for the IFM DMA pipeline
     dmaed_ifm = dma_ifm_compute(ifm, ifm_layout, ifm_zero_point, ifm_scale, channels, padding)
@@ -165,5 +169,155 @@ def depthwise_conv2d_compute(
         attrs=depthwise_conv2d_attrs,
     )
 
+    nhwc_to_nhcwb16 = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1 / 16, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 16],
+        [0, 0, 0, 0, 1],
+    ]
+    nhcwb16_to_nhwc = [
+        [1, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0],
+        [0, 0, 16, 0, 1, -16],
+        [0, 0, 0, 0, 0, 1],
+    ]
+    ifm_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, stride_h, 0, 0, (dilated_kernel_h - stride_h)],
+        [0, 0, stride_w, 0, (dilated_kernel_w - stride_w)],
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 1],
+    ]
+    weights_matrix = [
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, kernel_h],
+        [0, 0, 0, 0, kernel_w],
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 1],
+    ]
+    bias_matrix = [
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 10],
+        [0, 0, 0, 0, 1],
+    ]
+    if ofm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(ifm_matrix, nhcwb16_to_nhwc).tolist()
+        weights_matrix = np.matmul(weights_matrix, nhcwb16_to_nhwc).tolist()
+        bias_matrix = np.matmul(bias_matrix, nhcwb16_to_nhwc).tolist()
+    if ifm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(nhwc_to_nhcwb16, ifm_matrix).tolist()
+    ifm_propagator = Propagator(
+        ifm_matrix,
+        [0, -padding[0], -padding[1], 0]
+        if ifm_layout == "NHWC"
+        else [0, -padding[0], 0, -padding[1], 0],
+    )
+    weights_propagator = Propagator(
+        weights_matrix,
+        [0, 0, 0, 0],
+    )
+    bias_propagator = Propagator(
+        bias_matrix,
+        [0, 0],
+    )
+    propagator_attrs = {
+        "ifm_propagator": ifm_propagator,
+        "weights_propagator": weights_propagator,
+        "bias_propagator": bias_propagator,
+    }
+
     # Compute operation for the OFM DMA pipeline
-    return dma_ofm_compute(depthwise, ofm_layout, ofm_zero_point, ofm_scale, channels)
+    return dma_ofm_compute(
+        depthwise, ofm_layout, ofm_zero_point, ofm_scale, channels, attrs=propagator_attrs
+    )
+
+
+@register_matcher
+def match_ethosu_depthwise_conv2d(output_tensor, device_config):
+    """Match a Tensor Expression corresponding to an NPU Depthwise Conv2D.
+
+    If the Tensor Expression matches, an EthosuPart will be created that models the
+    matched Tensor Expression. Otherwise, None will be returned.
+
+    Parameters
+    ----------
+    output_tensor : tvm.te.Tensor
+        The tensor to attempt to match with.
+    device_config : EthosuDeviceConfig
+        Target device configuration.
+
+    Returns
+    -------
+    Union[None, EthosuPart]
+        The created EthosuPart if there was a match, otherwise None.
+
+    """
+    write = output_tensor
+    if write.op.name != "ethosu_write":
+        return None
+    convert_to_nhcwb16 = write.op.input_tensors[0]
+    if convert_to_nhcwb16.op.name != "ethosu_convert_to_nhcwb16":
+        return None
+    depthwise2d = convert_to_nhcwb16.op.input_tensors[0]
+    if depthwise2d.op.name != "ethosu_depthwise_conv2d":
+        return None
+    pad = depthwise2d.op.input_tensors[0]
+    if pad.op.name != "ethosu_pad":
+        return None
+    convert_to_nhwc = pad.op.input_tensors[0]
+    if convert_to_nhwc.op.name != "ethosu_convert_to_nhwc":
+        return None
+    read = convert_to_nhwc.op.input_tensors[0]
+    if read.op.name != "ethosu_read":
+        return None
+
+    input_tensors = [
+        read.op.input_tensors[0],
+        depthwise2d.op.input_tensors[1],
+        depthwise2d.op.input_tensors[2],
+    ]
+    subgraph = TESubgraph(input_tensors, output_tensor)
+    propagators = [
+        write.op.attrs["ifm_propagator"],
+        write.op.attrs["weights_propagator"],
+        write.op.attrs["bias_propagator"],
+    ]
+    ifm_dtype = input_tensors[0].dtype
+    ofm_dtype = output_tensor.dtype
+
+    ifm_channels = int(input_tensors[0].shape[3])
+    ofm_channels, kernel_height, kernel_width = (int(axis) for axis in input_tensors[1].shape[0:3])
+
+    subkernels = len(
+        device_config.get_kernel_steps(depthwise2d.op.name, kernel_height, kernel_width, ifm_dtype)
+    )
+
+    output_layout = convert_to_nhcwb16.op.attrs["layout"]
+    input_layout = convert_to_nhwc.op.attrs["layout"]
+    output_quantum = device_config.get_output_quantum(output_layout)
+
+    valid_block_configs = device_config.get_valid_block_configs(
+        propagators[0],
+        depthwise2d.op.attrs,
+        output_tensor.shape,
+        ofm_channels,
+        ifm_channels,
+        output_layout,
+        input_layout,
+        ifm_dtype,
+        ofm_dtype,
+        kernel_height,
+        kernel_width,
+    )
+
+    return EthosuPart(
+        subgraph,
+        propagators,
+        output_quantum,
+        subkernels,
+        valid_block_configs,
+        1,
+    )

--- a/tests/python/contrib/test_ethosu/cascader/infra.py
+++ b/tests/python/contrib/test_ethosu/cascader/infra.py
@@ -29,7 +29,9 @@ def create_te_graph(func):
     return te_graph, consts
 
 
-def make_matrices(kernel, stride, dilation, padding, ifm_channels, ifm_layout, ofm_layout):
+def make_matrices(
+    op_type, kernel, stride, padding, ifm_layout, ofm_layout, dilation=(1, 1), ifm_channels=1
+):
     kernel_h, kernel_w = kernel
     stride_h, stride_w = stride
     dilation_h, dilation_w = dilation
@@ -50,20 +52,51 @@ def make_matrices(kernel, stride, dilation, padding, ifm_channels, ifm_layout, o
         [0, 0, 16, 0, 1, -16],
         [0, 0, 0, 0, 0, 1],
     ]
-    ifm_matrix = [
-        [1, 0, 0, 0, 0],
-        [0, stride_h, 0, 0, (dilated_kernel_h - stride_h)],
-        [0, 0, stride_w, 0, (dilated_kernel_w - stride_w)],
-        [0, 0, 0, 0, ifm_channels],
-        [0, 0, 0, 0, 1],
-    ]
-    weight_matrix = [
-        [0, 0, 0, 1, 0],
-        [0, 0, 0, 0, kernel_h],
-        [0, 0, 0, 0, kernel_w],
-        [0, 0, 0, 0, ifm_channels],
-        [0, 0, 0, 0, 1],
-    ]
+    if op_type == "ethosu_conv2d":
+        ifm_matrix = [
+            [1, 0, 0, 0, 0],
+            [0, stride_h, 0, 0, (dilated_kernel_h - stride_h)],
+            [0, 0, stride_w, 0, (dilated_kernel_w - stride_w)],
+            [0, 0, 0, 0, ifm_channels],
+            [0, 0, 0, 0, 1],
+        ]
+        weight_matrix = [
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, kernel_h],
+            [0, 0, 0, 0, kernel_w],
+            [0, 0, 0, 0, ifm_channels],
+            [0, 0, 0, 0, 1],
+        ]
+    elif op_type == "ethosu_depthwise_conv2d":
+        ifm_matrix = [
+            [1, 0, 0, 0, 0],
+            [0, stride_h, 0, 0, (dilated_kernel_h - stride_h)],
+            [0, 0, stride_w, 0, (dilated_kernel_w - stride_w)],
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 1],
+        ]
+        weight_matrix = [
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, kernel_h],
+            [0, 0, 0, 0, kernel_w],
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 1],
+        ]
+    elif op_type == "ethosu_pooling":
+        ifm_matrix = [
+            [1, 0, 0, 0, 0],
+            [0, stride_h, 0, 0, (dilated_kernel_h - stride_h)],
+            [0, 0, stride_w, 0, (dilated_kernel_w - stride_w)],
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 1],
+        ]
+        weight_matrix = [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ]
     scale_bias_matrix = [
         [0, 0, 0, 1, 0],
         [0, 0, 0, 0, 10],

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_binary_elementwise_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_binary_elementwise_matcher.py
@@ -14,16 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
+
+pytest.importorskip("ethosu.vela")
+
+import numpy as np
+import math
+
 from tvm import te
 import tvm.contrib.ethosu.cascader as cs
 from tvm.relay.backend.contrib.ethosu.te.binary_elementwise import (
     match_ethosu_binary_elementwise,
     binary_elementwise_compute,
 )
-
-import numpy as np
-import math
-import pytest
 
 
 def _make_matrices(broadcast, ifm_layout, ifm2_layout, ofm_layout):

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_binary_elementwise_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_binary_elementwise_matcher.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from tvm import te
+import tvm.contrib.ethosu.cascader as cs
+from tvm.relay.backend.contrib.ethosu.te.binary_elementwise import (
+    match_ethosu_binary_elementwise,
+    binary_elementwise_compute,
+)
+
+import numpy as np
+import math
+import pytest
+
+
+def _make_matrices(broadcast, ifm_layout, ifm2_layout, ofm_layout):
+    broadcast_h, broadcast_w, broadcast_c = broadcast
+    nhwc_to_nhcwb16 = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1 / 16, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 16],
+        [0, 0, 0, 0, 1],
+    ]
+    nhcwb16_to_nhwc = [
+        [1, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0],
+        [0, 0, 16, 0, 1, -16],
+        [0, 0, 0, 0, 0, 1],
+    ]
+    ifm_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 1],
+    ]
+    ifm2_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, (1 - broadcast_h), 0, 0, broadcast_h],
+        [0, 0, (1 - broadcast_w), 0, broadcast_w],
+        [0, 0, 0, (1 - broadcast_c), broadcast_c],
+        [0, 0, 0, 0, 1],
+    ]
+    if ofm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(ifm_matrix, nhcwb16_to_nhwc).tolist()
+        ifm2_matrix = np.matmul(ifm2_matrix, nhcwb16_to_nhwc).tolist()
+    if ifm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(nhwc_to_nhcwb16, ifm_matrix).tolist()
+    if ifm2_layout == "NHCWB16":
+        ifm2_matrix = np.matmul(nhwc_to_nhcwb16, ifm2_matrix).tolist()
+
+    return (ifm_matrix, ifm2_matrix)
+
+
+@pytest.mark.parametrize(
+    "ofm_shape",
+    [
+        [1, 12, 15, 128],
+        [1, 16, 16, 16],
+        [1, 1, 1, 1024],
+        [1, 73, 51, 20],
+        [1, 124, 172, 5],
+    ],
+)
+@pytest.mark.parametrize("ifm2_broadcast", [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]])
+@pytest.mark.parametrize("ifm_layout", ["NHWC", "NHCWB16"])
+@pytest.mark.parametrize("ifm2_layout", ["NHWC", "NHCWB16"])
+@pytest.mark.parametrize("ofm_layout", ["NHWC", "NHCWB16"])
+@pytest.mark.parametrize("op_type", ["MUL", "ADD", "MIN"])
+def test_ethosu_binary_elementwise_matcher(
+    ofm_shape, ifm2_broadcast, ifm_layout, ifm2_layout, ofm_layout, op_type
+):
+    ifm_shape = ofm_shape.copy()
+    ifm2_shape = [1] + [1 if (b == 1) else a for a, b in zip(ofm_shape[1:], ifm2_broadcast)]
+    ifm_channels = ifm_shape[3]
+    ifm2_channels = ifm2_shape[3]
+    nhwc_to_nhcwb16 = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1 / 16, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 16],
+        [0, 0, 0, 0, 1],
+    ]
+    broadcast = [1 if a == 1 else 0 for a in ifm2_shape[1:]]
+    if ifm_layout == "NHCWB16":
+        ifm_shape = [
+            int(math.ceil(n))
+            for n in np.matmul(
+                nhwc_to_nhcwb16,
+                ifm_shape
+                + [
+                    1,
+                ],
+            ).tolist()[:-1]
+        ]
+    if ifm2_layout == "NHCWB16":
+        ifm2_shape = [
+            int(math.ceil(n))
+            for n in np.matmul(
+                nhwc_to_nhcwb16,
+                ifm2_shape
+                + [
+                    1,
+                ],
+            ).tolist()[:-1]
+        ]
+    if ofm_layout == "NHCWB16":
+        ofm_shape = [
+            int(math.ceil(n))
+            for n in np.matmul(
+                nhwc_to_nhcwb16,
+                ofm_shape
+                + [
+                    1,
+                ],
+            ).tolist()[:-1]
+        ]
+        order = [1, 2, 4, 3, 0]
+    else:
+        order = [1, 2, 3, 4]
+
+    ifm = te.placeholder(ifm_shape, dtype="int8")
+    ifm2 = te.placeholder(ifm2_shape, dtype="int8")
+    lut = te.placeholder((), dtype="uint8")
+    out = binary_elementwise_compute(
+        ifm=ifm,
+        ifm2=ifm2,
+        lut=lut,
+        operator_type=op_type,
+        ifm_scale=1,
+        ifm_zero_point=0,
+        ifm2_scale=1,
+        ifm2_zero_point=0,
+        ofm_scale=1,
+        ofm_zero_point=0,
+        ifm_channels=ifm_channels,
+        ifm2_channels=ifm2_channels,
+        reversed_operands=False,
+        activation="NONE",
+        clip_min=0,
+        clip_max=0,
+        rounding_mode="TFL",
+        ifm_layout=ifm_layout,
+        ifm2_layout=ifm2_layout,
+        ofm_layout=ofm_layout,
+        ofm_dtype="int8",
+    )
+    ifm_propagator = out.op.attrs["ifm_propagator"]
+    ifm2_propagator = out.op.attrs["ifm2_propagator"]
+
+    offset = [0] * len(ofm_shape)
+    stripes = [0] * len(ofm_shape)
+    output_stripe_config = cs.StripeConfig(ofm_shape, ofm_shape, ofm_shape, order, stripes, offset)
+
+    (ifm_transform, ifm2_transform) = _make_matrices(
+        broadcast,
+        ifm_layout,
+        ifm2_layout,
+        ofm_layout,
+    )
+
+    device_config = cs.EthosuDeviceConfig("ethos-u55-256")
+    part = match_ethosu_binary_elementwise(out, device_config)
+
+    assert isinstance(part, cs.EthosuPart)
+    assert len(part.propagators) == 2
+    assert part.propagators[0].transform == ifm_transform
+    assert part.propagators[1].transform == ifm2_transform
+
+    propagated_ifm = ifm_propagator.propagate(output_stripe_config).shape
+    propagated_ifm2 = ifm2_propagator.propagate(output_stripe_config).shape
+
+    # Layout conversions will align the propagated IFMs to the brick, i.e. 16
+    # so the expected ifm(2)_shape needs to be rounded up to 16
+    if ifm_layout != ofm_layout:
+        assert ifm_shape[:-1] == propagated_ifm[:-1]
+        assert ((ifm_shape[-1] + 16 - 1) // 16) * 16 == propagated_ifm[-1]
+    else:
+        assert ifm_shape == propagated_ifm
+
+    if ifm2_layout != ofm_layout:
+        assert ifm2_shape[:-1] == propagated_ifm2[:-1]
+        assert ((ifm2_shape[-1] + 16 - 1) // 16) * 16 == propagated_ifm2[-1]
+    else:
+        assert ifm2_shape == propagated_ifm2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
@@ -27,7 +27,7 @@ from .infra import make_matrices
 
 
 @pytest.mark.parametrize(
-    "id, op_type, activation, kernel, stride, dilation, padding, in_shape, out_shape",
+    "test_id, op_type, activation, kernel, stride, dilation, padding, in_shape, out_shape",
     [
         # Conv2D
         (
@@ -98,6 +98,7 @@ from .infra import make_matrices
         ),
         # Depthwise Conv2D
         (
+            6,
             "ethosu_depthwise_conv2d",
             "NONE",
             (3, 5),
@@ -106,9 +107,9 @@ from .infra import make_matrices
             (0, 0, 0, 0),
             (1, 77, 23, 18),
             (1, 75, 19, 18),
-            (1, 7, 10, 16),
         ),
         (
+            7,
             "ethosu_depthwise_conv2d",
             "NONE",
             (3, 3),
@@ -117,10 +118,10 @@ from .infra import make_matrices
             (1, 1, 1, 1),
             (1, 25, 10, 276),
             (1, 13, 5, 276),
-            (1, 7, 6, 16),
         ),
         # Pooling
         (
+            8,
             "ethosu_pooling",
             "NONE",
             (13, 5),
@@ -129,9 +130,9 @@ from .infra import make_matrices
             (0, 0, 0, 0),
             (1, 13, 5, 276),
             (1, 1, 1, 276),
-            (1, 1, 2, 80),
         ),
         (
+            9,
             "ethosu_pooling",
             "NONE",
             (7, 3),
@@ -140,7 +141,6 @@ from .infra import make_matrices
             (0, 0, 0, 0),
             (1, 317, 14, 21),
             (1, 156, 12, 21),
-            (1, 10, 6, 16),
         ),
     ],
 )
@@ -159,51 +159,79 @@ from .infra import make_matrices
         (
             "ethos-u55-32",
             [
+                # Conv2D
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
                 ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
-                ((1, 10, 6, 4), (1, 16, 1, 4, 4)),
-                ((1, 10, 3, 16), (1, 10, 1, 3, 16)),
+                ((1, 10, 6, 4), (1, 5, 1, 12, 4), (1, 16, 1, 4, 4)),
+                ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
+                # Depthwise Conv2D
+                ((1, 6, 10, 16), (1, 6, 1, 10, 16)),
+                ((1, 7, 5, 16), (1, 7, 1, 5, 16)),
+                # Pooling
+                ((1, 1, 1, 16), (1, 1, 1, 1, 16)),
+                ((1, 9, 6, 16), (1, 9, 1, 6, 16)),
             ],
         ),
         (
             "ethos-u55-64",
             [
+                # Conv2D
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
                 ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 10, 6, 8), (1, 16, 1, 4, 8)),
-                ((1, 10, 3, 16), (1, 10, 1, 3, 16)),
+                ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
+                # Depthwise Conv2D
+                ((1, 6, 10, 16), (1, 6, 1, 10, 16)),
+                ((1, 7, 5, 16), (1, 7, 1, 5, 16)),
+                # Pooling
+                ((1, 1, 1, 16), (1, 1, 1, 1, 16)),
+                ((1, 9, 6, 16), (1, 9, 1, 6, 16)),
             ],
         ),
         (
             "ethos-u55-128",
             [
+                # Conv2D
                 ((1, 7, 6, 16), (1, 7, 1, 6, 16)),
                 ((1, 5, 8, 16), (1, 5, 1, 8, 16)),
                 ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
                 ((1, 16, 4, 16), (1, 16, 1, 4, 16)),
                 ((1, 8, 12, 8), (1, 8, 1, 12, 8)),
                 ((1, 10, 6, 16), (1, 10, 1, 6, 16)),
+                # Depthwise Conv2D
+                ((1, 7, 10, 16), (1, 7, 1, 10, 16)),
+                ((1, 7, 6, 16), (1, 7, 1, 6, 16)),
+                # Pooling
+                ((1, 1, 2, 80), (1, 1, 5, 2, 16)),
+                ((1, 10, 6, 16), (1, 10, 1, 6, 16)),
             ],
         ),
         (
             "ethos-u55-256",
             [
+                # Conv2D
                 ((1, 14, 8, 16), (1, 14, 1, 8, 16)),
                 ((1, 16, 8, 16), (1, 16, 1, 8, 16)),
                 ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
-                ((1, 32, 4, 16), (1, 32, 1, 4, 16)),
+                ((1, 32, 4, 16), (1, 10, 12, 16), (1, 32, 1, 4, 16), (1, 10, 1, 12, 16)),
                 ((1, 20, 12, 8), (1, 20, 1, 12, 8)),
-                ((1, 20, 6, 16), (1, 20, 1, 6, 16)),
+                ((1, 12, 10, 16), (1, 12, 1, 10, 16)),
+                # Depthwise Conv2D
+                ((1, 8, 20, 16), (1, 8, 1, 20, 16)),
+                ((1, 14, 6, 16), (1, 14, 1, 6, 16)),
+                # Pooling
+                ((1, 2, 2, 48), (1, 2, 3, 2, 16)),
+                ((1, 10, 12, 16), (1, 10, 1, 12, 16)),
             ],
         ),
     ],
 )
 def test_best_block_config(
-    id,
+    test_id,
     op_type,
     activation,
     kernel,
@@ -299,10 +327,8 @@ def test_best_block_config(
 
     block = part.get_block_config(stripe_config)
     block_shape = tuple(int(a) for a in block.output_shape)
-    if layouts[1] == "NHCWB16":
-        assert block_shape == expected_block_configs[id][1]
-    else:
-        assert block_shape == expected_block_configs[id][0]
+
+    assert block_shape in expected_block_configs[test_id]
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
@@ -29,6 +29,7 @@ from .infra import make_matrices
 @pytest.mark.parametrize(
     "id, op_type, activation, kernel, stride, dilation, padding, in_shape, out_shape",
     [
+        # Conv2D
         (
             0,
             "ethosu_conv2d",
@@ -94,6 +95,52 @@ from .infra import make_matrices
             (0, 0, 0, 0),
             (1, 62, 94, 32),
             (1, 58, 90, 16),
+        ),
+        # Depthwise Conv2D
+        (
+            "ethosu_depthwise_conv2d",
+            "NONE",
+            (3, 5),
+            (1, 1),
+            (1, 1),
+            (0, 0, 0, 0),
+            (1, 77, 23, 18),
+            (1, 75, 19, 18),
+            (1, 7, 10, 16),
+        ),
+        (
+            "ethosu_depthwise_conv2d",
+            "NONE",
+            (3, 3),
+            (2, 2),
+            (1, 1),
+            (1, 1, 1, 1),
+            (1, 25, 10, 276),
+            (1, 13, 5, 276),
+            (1, 7, 6, 16),
+        ),
+        # Pooling
+        (
+            "ethosu_pooling",
+            "NONE",
+            (13, 5),
+            (1, 1),
+            (1, 1),
+            (0, 0, 0, 0),
+            (1, 13, 5, 276),
+            (1, 1, 1, 276),
+            (1, 1, 2, 80),
+        ),
+        (
+            "ethosu_pooling",
+            "NONE",
+            (7, 3),
+            (2, 1),
+            (1, 1),
+            (0, 0, 0, 0),
+            (1, 317, 14, 21),
+            (1, 156, 12, 21),
+            (1, 10, 6, 16),
         ),
     ],
 )
@@ -185,7 +232,7 @@ def test_best_block_config(
         [0, 0, 0, 0, 0, 1],
     ]
     ifm_matrix, ifm_offset, weight_matrix, weight_offset, _, _ = make_matrices(
-        kernel, stride, dilation, padding, in_shape[3], layouts[0], layouts[1]
+        op_type, kernel, stride, padding, layouts[0], layouts[1], dilation, in_shape[3]
     )
 
     ofm_channels = out_shape[3]

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_conv2d_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_conv2d_matcher.py
@@ -24,8 +24,6 @@ from tvm.relay.backend.contrib.ethosu.te.convolution import match_ethosu_conv2d,
 
 from .infra import make_matrices
 
-import pytest
-
 
 @pytest.mark.parametrize("kernel", [(3, 3), (2, 1), (3, 5)])
 @pytest.mark.parametrize("stride", [(1, 1), (2, 1), (3, 2)])

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_depthwise2d_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_depthwise2d_matcher.py
@@ -14,6 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
+
+pytest.importorskip("ethosu.vela")
+
+import numpy as np
+
 from tvm import te
 import tvm.contrib.ethosu.cascader as cs
 from tvm.relay.backend.contrib.ethosu.te.depthwise import (
@@ -21,9 +27,6 @@ from tvm.relay.backend.contrib.ethosu.te.depthwise import (
     depthwise_conv2d_compute,
 )
 from .infra import make_matrices
-
-import numpy as np
-import pytest
 
 
 @pytest.mark.parametrize("kernel", [(3, 3), (2, 1), (3, 5)])

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_depthwise2d_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_depthwise2d_matcher.py
@@ -14,16 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
-
-pytest.importorskip("ethosu.vela")
-
 from tvm import te
 import tvm.contrib.ethosu.cascader as cs
-from tvm.relay.backend.contrib.ethosu.te.convolution import match_ethosu_conv2d, conv2d_compute
-
+from tvm.relay.backend.contrib.ethosu.te.depthwise import (
+    match_ethosu_depthwise_conv2d,
+    depthwise_conv2d_compute,
+)
 from .infra import make_matrices
 
+import numpy as np
 import pytest
 
 
@@ -31,23 +30,20 @@ import pytest
 @pytest.mark.parametrize("stride", [(1, 1), (2, 1), (3, 2)])
 @pytest.mark.parametrize("dilation", [(1, 1), (2, 1), (3, 2)])
 @pytest.mark.parametrize("padding", [(0, 0, 0, 0), (3, 2, 3, 2), (2, 1, 0, 1)])
-@pytest.mark.parametrize("ifm_channels", [8, 57])
 @pytest.mark.parametrize("ifm_layout", ["NHWC", "NHCWB16"])
 @pytest.mark.parametrize("ofm_layout", ["NHWC", "NHCWB16"])
-def test_ethosu_conv2d_matcher(
-    kernel, stride, dilation, padding, ifm_channels, ifm_layout, ofm_layout
-):
+def test_ethosu_depthwise2d_matcher(kernel, stride, dilation, padding, ifm_layout, ofm_layout):
+    ofm_channels = 57
     if ifm_layout == "NHWC":
-        ifm_shape = (1, 12, 15, ifm_channels)
+        ifm_shape = (1, 12, 15, ofm_channels)
     else:
-        ifm_shape = (1, 12, 1 + ((ifm_channels - 1) // 16), 15, 16)
-    ofm_channels = 8
+        ifm_shape = (1, 12, 1 + ((ofm_channels - 1) // 16), 15, 16)
     kernel_h, kernel_w = kernel
     ifm = te.placeholder(ifm_shape, dtype="int8")
-    weight = te.placeholder((ofm_channels, kernel_h, kernel_w, ifm_channels), dtype="int8")
+    weight = te.placeholder((ofm_channels, kernel_h, kernel_w, 1), dtype="int8")
     scale_bias = te.placeholder((ofm_channels, 10), dtype="uint8")
     lut = te.placeholder((), dtype="uint8")
-    out = conv2d_compute(
+    out = depthwise_conv2d_compute(
         ifm=ifm,
         weight=weight,
         scale_bias=scale_bias,
@@ -63,10 +59,11 @@ def test_ethosu_conv2d_matcher(
         activation="NONE",
         clip_min=0,
         clip_max=0,
-        upscale="NONE",
         rounding_mode="TFL",
+        upscale="NONE",
         ifm_layout=ifm_layout,
         ofm_layout=ofm_layout,
+        ofm_dtype=ifm.dtype,
     )
     (
         ifm_transform,
@@ -76,18 +73,17 @@ def test_ethosu_conv2d_matcher(
         scale_bias_transform,
         scale_bias_offset,
     ) = make_matrices(
-        "ethosu_conv2d",
+        "ethosu_depthwise_conv2d",
         kernel,
         stride,
         padding,
         ifm_layout,
         ofm_layout,
         dilation,
-        ifm_channels,
     )
 
     device_config = cs.EthosuDeviceConfig("ethos-u55-256")
-    part = match_ethosu_conv2d(out, device_config)
+    part = match_ethosu_depthwise_conv2d(out, device_config)
 
     assert isinstance(part, cs.EthosuPart)
     assert len(part.propagators) == 3

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_pooling_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_pooling_matcher.py
@@ -14,13 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
+
+pytest.importorskip("ethosu.vela")
+
+import numpy as np
+
 from tvm import te
 import tvm.contrib.ethosu.cascader as cs
 from tvm.relay.backend.contrib.ethosu.te.pooling import match_ethosu_pooling, pooling_compute
 from .infra import make_matrices
-
-import numpy as np
-import pytest
 
 
 @pytest.mark.parametrize("pool_shape", [(3, 3), (2, 1), (3, 5)])

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_pooling_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_pooling_matcher.py
@@ -14,89 +14,64 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
-
-pytest.importorskip("ethosu.vela")
-
 from tvm import te
 import tvm.contrib.ethosu.cascader as cs
-from tvm.relay.backend.contrib.ethosu.te.convolution import match_ethosu_conv2d, conv2d_compute
-
+from tvm.relay.backend.contrib.ethosu.te.pooling import match_ethosu_pooling, pooling_compute
 from .infra import make_matrices
 
+import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize("kernel", [(3, 3), (2, 1), (3, 5)])
+@pytest.mark.parametrize("pool_shape", [(3, 3), (2, 1), (3, 5)])
 @pytest.mark.parametrize("stride", [(1, 1), (2, 1), (3, 2)])
-@pytest.mark.parametrize("dilation", [(1, 1), (2, 1), (3, 2)])
 @pytest.mark.parametrize("padding", [(0, 0, 0, 0), (3, 2, 3, 2), (2, 1, 0, 1)])
-@pytest.mark.parametrize("ifm_channels", [8, 57])
 @pytest.mark.parametrize("ifm_layout", ["NHWC", "NHCWB16"])
 @pytest.mark.parametrize("ofm_layout", ["NHWC", "NHCWB16"])
-def test_ethosu_conv2d_matcher(
-    kernel, stride, dilation, padding, ifm_channels, ifm_layout, ofm_layout
-):
+def test_ethosu_pooling_matcher(pool_shape, stride, padding, ifm_layout, ofm_layout):
+    ofm_channels = 21
     if ifm_layout == "NHWC":
-        ifm_shape = (1, 12, 15, ifm_channels)
+        ifm_shape = (1, 12, 15, ofm_channels)
     else:
-        ifm_shape = (1, 12, 1 + ((ifm_channels - 1) // 16), 15, 16)
-    ofm_channels = 8
-    kernel_h, kernel_w = kernel
+        ifm_shape = (1, 12, 1 + ((ofm_channels - 1) // 16), 15, 16)
     ifm = te.placeholder(ifm_shape, dtype="int8")
-    weight = te.placeholder((ofm_channels, kernel_h, kernel_w, ifm_channels), dtype="int8")
-    scale_bias = te.placeholder((ofm_channels, 10), dtype="uint8")
     lut = te.placeholder((), dtype="uint8")
-    out = conv2d_compute(
+    out = pooling_compute(
         ifm=ifm,
-        weight=weight,
-        scale_bias=scale_bias,
         lut=lut,
+        pooling_type="MAX",
         ifm_scale=1,
         ifm_zero_point=0,
         ofm_scale=1,
         ofm_zero_point=0,
-        weight_zero_point=0,
+        pool_shape=pool_shape,
+        ofm_channels=ofm_channels,
         strides=stride,
         padding=padding,
-        dilation=dilation,
         activation="NONE",
         clip_min=0,
         clip_max=0,
-        upscale="NONE",
         rounding_mode="TFL",
+        upscale="NONE",
         ifm_layout=ifm_layout,
         ofm_layout=ofm_layout,
     )
-    (
-        ifm_transform,
-        ifm_offset,
-        weight_transform,
-        weight_offset,
-        scale_bias_transform,
-        scale_bias_offset,
-    ) = make_matrices(
-        "ethosu_conv2d",
-        kernel,
+    (ifm_transform, ifm_offset, _, _, _, _) = make_matrices(
+        "ethosu_pooling",
+        pool_shape,
         stride,
         padding,
         ifm_layout,
         ofm_layout,
-        dilation,
-        ifm_channels,
     )
 
     device_config = cs.EthosuDeviceConfig("ethos-u55-256")
-    part = match_ethosu_conv2d(out, device_config)
+    part = match_ethosu_pooling(out, device_config)
 
     assert isinstance(part, cs.EthosuPart)
-    assert len(part.propagators) == 3
+    assert len(part.propagators) == 1
     assert part.propagators[0].transform == ifm_transform
     assert part.propagators[0].offset == ifm_offset
-    assert part.propagators[1].transform == weight_transform
-    assert part.propagators[1].offset == weight_offset
-    assert part.propagators[2].transform == scale_bias_transform
-    assert part.propagators[2].offset == scale_bias_offset
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_unary_elementwise_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_unary_elementwise_matcher.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from tvm import te
+import tvm.contrib.ethosu.cascader as cs
+from tvm.relay.backend.contrib.ethosu.te.unary_elementwise import (
+    match_ethosu_unary_elementwise,
+    unary_elementwise_compute,
+)
+
+import numpy as np
+import math
+import pytest
+
+
+def _make_matrices(ifm_layout, ofm_layout):
+    nhwc_to_nhcwb16 = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1 / 16, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 16],
+        [0, 0, 0, 0, 1],
+    ]
+    nhcwb16_to_nhwc = [
+        [1, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0],
+        [0, 0, 16, 0, 1, -16],
+        [0, 0, 0, 0, 0, 1],
+    ]
+    ifm_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 1],
+    ]
+    if ofm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(ifm_matrix, nhcwb16_to_nhwc).tolist()
+    if ifm_layout == "NHCWB16":
+        ifm_matrix = np.matmul(nhwc_to_nhcwb16, ifm_matrix).tolist()
+
+    return ifm_matrix
+
+
+@pytest.mark.parametrize(
+    "ofm_shape",
+    [
+        [1, 12, 15, 128],
+        [1, 16, 16, 16],
+        [1, 1, 1, 1024],
+        [1, 53, 91, 7],
+        [1, 182, 12, 72],
+    ],
+)
+@pytest.mark.parametrize("ifm_layout", ["NHWC", "NHCWB16"])
+@pytest.mark.parametrize("ofm_layout", ["NHWC", "NHCWB16"])
+@pytest.mark.parametrize("op_type", ["ABS", "CLZ"])
+def test_ethosu_unary_elementwise_matcher(ofm_shape, ifm_layout, ofm_layout, op_type):
+    ifm_shape = ofm_shape.copy()
+    ofm_channels = ofm_shape[3]
+    nhwc_to_nhcwb16 = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1 / 16, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 16],
+        [0, 0, 0, 0, 1],
+    ]
+    if ifm_layout == "NHCWB16":
+        ifm_shape = [
+            int(math.ceil(n))
+            for n in np.matmul(
+                nhwc_to_nhcwb16,
+                ifm_shape
+                + [
+                    1,
+                ],
+            ).tolist()[:-1]
+        ]
+    if ofm_layout == "NHCWB16":
+        ofm_shape = [
+            int(math.ceil(n))
+            for n in np.matmul(
+                nhwc_to_nhcwb16,
+                ofm_shape
+                + [
+                    1,
+                ],
+            ).tolist()[:-1]
+        ]
+        order = [1, 2, 4, 3, 0]
+    else:
+        order = [1, 2, 3, 4]
+
+    ifm = te.placeholder(ifm_shape, dtype="int8")
+    lut = te.placeholder((), dtype="uint8")
+    out = unary_elementwise_compute(
+        ifm=ifm,
+        lut=lut,
+        operator_type=op_type,
+        ifm_scale=1,
+        ifm_zero_point=0,
+        ofm_scale=1,
+        ofm_zero_point=0,
+        ofm_channels=ofm_channels,
+        activation="NONE",
+        clip_min=0,
+        clip_max=0,
+        rounding_mode="TFL",
+        ifm_layout=ifm_layout,
+        ofm_layout=ofm_layout,
+    )
+    ifm_propagator = out.op.attrs["ifm_propagator"]
+
+    offset = [0] * len(ofm_shape)
+    stripes = [0] * len(ofm_shape)
+    output_stripe_config = cs.StripeConfig(ofm_shape, ofm_shape, ofm_shape, order, stripes, offset)
+
+    ifm_transform = _make_matrices(ifm_layout, ofm_layout)
+
+    device_config = cs.EthosuDeviceConfig("ethos-u55-256")
+    part = match_ethosu_unary_elementwise(out, device_config)
+
+    assert isinstance(part, cs.EthosuPart)
+    assert len(part.propagators) == 1
+    assert part.propagators[0].transform == ifm_transform
+
+    propagated_ifm = ifm_propagator.propagate(output_stripe_config).shape
+
+    # Layout conversions will align the propagated IFMs to the brick, i.e. 16
+    # so the expected ifm_shape needs to be rounded up to 16
+    if ifm_layout != ofm_layout:
+        assert ifm_shape[:-1] == propagated_ifm[:-1]
+        assert ((ifm_shape[-1] + 16 - 1) // 16) * 16 == propagated_ifm[-1]
+    else:
+        assert ifm_shape == propagated_ifm
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_unary_elementwise_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_unary_elementwise_matcher.py
@@ -14,16 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
+
+pytest.importorskip("ethosu.vela")
+
+import numpy as np
+import math
+
 from tvm import te
 import tvm.contrib.ethosu.cascader as cs
 from tvm.relay.backend.contrib.ethosu.te.unary_elementwise import (
     match_ethosu_unary_elementwise,
     unary_elementwise_compute,
 )
-
-import numpy as np
-import math
-import pytest
 
 
 def _make_matrices(ifm_layout, ofm_layout):

--- a/tests/python/contrib/test_ethosu/cascader/test_graph.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_graph.py
@@ -176,5 +176,29 @@ def test_create_cascader_graph(TwoConv2DWithSliceTE):
     assert conv1_part.input_tensors[2].is_constant
 
 
+def test_create_diamond_graph(MobileNetv2DiamondTE):
+    _, te_graph, const_dict = MobileNetv2DiamondTE
+    device_config = cs.EthosuDeviceConfig("ethos-u55-256")
+    graph = cs.create_cascader_graph(te_graph, const_dict, device_config)
+
+    output_tensor = graph.output_tensors[0]
+    assert output_tensor.shape == [1, 56, 56, 24]
+    assert len(output_tensor.producers) == 1
+    assert not output_tensor.is_constant
+
+    add1_part = output_tensor.producers[0]
+    assert isinstance(add1_part, cs.EthosuPart)
+    assert len(add1_part.input_tensors) == 2
+    assert graph.get_part_id(add1_part) == 0
+
+    assert add1_part.input_tensors[0].shape == [1, 56, 56, 24]
+    assert len(add1_part.input_tensors[0].producers) == 1
+    assert not add1_part.input_tensors[0].is_constant
+
+    assert add1_part.input_tensors[1].shape == [1, 56, 56, 24]
+    assert len(add1_part.input_tensors[0].producers) == 1
+    assert not add1_part.input_tensors[0].is_constant
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
RFC: apache/tvm-rfcs#37
Issue: #9429

This PR adds four additional part matchers for the cascader, ethosu_pooling, ethosu_depthwise_conv2d, ethosu_unary_elementwise and ethosu_binary_elementwise. It also contains unit tests for the matchers as well as minor additions the performance estimation to cover all of the different Parts.

Co-authored-by: Matthew Barrett <Matthew.Barrett@arm.com>