### PR TITLE
[microNPU] Re-enable LayoutOptimizer pass

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/codegen.py
+++ b/python/tvm/relay/backend/contrib/ethosu/codegen.py
@@ -294,6 +294,7 @@ def relay_to_tir_func(ext_func: relay.Function) -> tvm.tir.PrimFunc:
     mod = tvm.IRModule()
     mod["main"] = ext_func
     mod = LegalizeEthosU()(mod)
+    mod = LayoutOptimizer()(mod)
     mod = LUTsOptimizer()(mod)
     mod = relay.transform.InferType()(mod)
     # We are currently using copy_constants scheduler In the long run,

--- a/python/tvm/relay/backend/contrib/ethosu/codegen.py
+++ b/python/tvm/relay/backend/contrib/ethosu/codegen.py
@@ -294,8 +294,8 @@ def relay_to_tir_func(ext_func: relay.Function) -> tvm.tir.PrimFunc:
     mod = tvm.IRModule()
     mod["main"] = ext_func
     mod = LegalizeEthosU()(mod)
-    mod = LayoutOptimizer()(mod)
     mod = LUTsOptimizer()(mod)
+    mod = LayoutOptimizer()(mod)
     mod = relay.transform.InferType()(mod)
     # We are currently using copy_constants scheduler In the long run,
     # this should be a single intelligent and a composite scheduler


### PR DESCRIPTION
It looks like the LayoutOptimizer pass was accidentally removed. Probably due to a race condition when merging PR's. Re-enabling this feature.

cc @ekalda @manupa-arm @mbaret
