### PR TITLE
[CUTLASS] Refactor cutlass kernel generation and selection

### DIFF
--- a/python/tvm/contrib/cutlass/conv2d_operation.py
+++ b/python/tvm/contrib/cutlass/conv2d_operation.py
@@ -186,7 +186,7 @@ class EmitConv2dInstance:
   >::Kernel;
 """
 
-    def emit(self, operation, no_beta_scaling=True):
+    def emit(self, operation, no_beta_scaling=False):
         """Instantiate a Conv2d kernel from given `operation`."""
         warp_shape = [
             int(

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -35,7 +35,10 @@ from .library import (
 def create_conv2d_operator_with_epilogue(
     op_type, tile_description, data_type, alignment, swizzling_functor
 ):
-    """TODO"""
+    """
+    Instantiate a cutlass kernel from the given configuration,
+    along with the epilouge functor
+    """
     epilogue, no_beta_scaling = EPILOGUE_MAP[op_type]
 
     element_a, element_b, element_c, element_epilogue = data_type
@@ -151,7 +154,10 @@ class CutlassConv2DProfiler:
         profile_all=True,
         use_multiprocessing=False,
     ):
-        """TODO"""
+        """
+        Profile and select the best kernel from candidate kernels.
+        See the documentation for the profile method below.
+        """
         N, H, W, IC = d_shape
         OC, R, S, _ = w_shape
         workload = (

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -20,10 +20,7 @@ import re
 from .conv2d_operation import Conv2dOperation, EmitConv2dInstance
 from .gen_gemm import CutlassGemmProfiler
 from .conv2d_profiler import Conv2dProfilerEmitter
-from .gen_tensor_op import (
-    ProfilerEngine,
-    GENERATOR_FUNC_TABLE,
-)
+from .gen_tensor_op import ProfilerEngine, GENERATOR_FUNC_TABLE, EPILOGUE_MAP
 from .library import (
     EpilogueFunctor,
     SwizzlingFunctor,
@@ -35,7 +32,39 @@ from .library import (
 )
 
 
-def create_conv2d_operator(
+def create_conv2d_operator_with_epilogue(
+    op_type, tile_description, data_type, alignment, swizzling_functor
+):
+    """TODO"""
+    epilogue, no_beta_scaling = EPILOGUE_MAP[op_type]
+
+    element_a, element_b, element_c, element_epilogue = data_type
+
+    A = TensorDescription(element_a, LayoutType.TensorNHWC, alignment)
+    B = TensorDescription(element_b, LayoutType.TensorNHWC, alignment)
+    C = TensorDescription(element_c, LayoutType.TensorNHWC, alignment)
+
+    op = Conv2dOperation(
+        ConvKind.Fprop,
+        IteratorAlgorithm.Optimized,
+        tile_description.minimum_compute_capability,
+        tile_description,
+        A,
+        B,
+        C,
+        element_epilogue,
+        StrideSupport.Strided,
+        epilogue,
+        swizzling_functor,
+    )
+
+    name = op.procedural_name()
+    opdef = EmitConv2dInstance().emit(op, no_beta_scaling=no_beta_scaling)
+
+    return name, opdef
+
+
+def enumerate_conv2d_operators(
     tile_descriptions,
     data_type,
     alignment_constraints,
@@ -48,77 +77,38 @@ def create_conv2d_operator(
     profiler_emitter = Conv2dProfilerEmitter()
 
     element_a, element_b, element_c, element_epilogue = data_type
-    iterator_algorithms = [IteratorAlgorithm.Optimized]
 
-    layout = (LayoutType.TensorNHWC, LayoutType.TensorNHWC, LayoutType.TensorNHWC)
     for tile in tile_descriptions:
         for alignment in alignment_constraints:
 
-            alignment_c = min(8, alignment)
+            A = TensorDescription(element_a, LayoutType.TensorNHWC, alignment)
+            B = TensorDescription(element_b, LayoutType.TensorNHWC, alignment)
+            C = TensorDescription(element_c, LayoutType.TensorNHWC, alignment)
 
-            A = TensorDescription(element_a, layout[0], alignment)
-            B = TensorDescription(element_b, layout[1], alignment)
-            C = TensorDescription(element_c, layout[2], alignment_c)
+            op = Conv2dOperation(
+                ConvKind.Fprop,
+                IteratorAlgorithm.Optimized,
+                tile.minimum_compute_capability,
+                tile,
+                A,
+                B,
+                C,
+                element_epilogue,
+                StrideSupport.Strided,
+                EpilogueFunctor.LinearCombination,
+                swizzling_functor,
+            )
 
-            swizzling_functor_ = swizzling_functor
-
-            for iterator_algorithm in iterator_algorithms:
-                op_entry = {}
-
-                op = Conv2dOperation(
-                    ConvKind.Fprop,
-                    iterator_algorithm,
-                    tile.minimum_compute_capability,
-                    tile,
-                    A,
-                    B,
-                    C,
-                    element_epilogue,
-                    StrideSupport.Strided,
-                    EpilogueFunctor.LinearCombination,
-                    swizzling_functor_,
-                )
-
-                op_entry["opdef"] = kernel_emitter.emit(op)
-                op_entry["op"] = op
-                op_entry["src"] = profiler_emitter.emit(op_entry["opdef"], op.procedural_name())
-                op_entry["name"] = op.procedural_name()
-
-                # fused ops
-                for epilogue, opdef, no_bias_scaling in zip(
-                    [
-                        EpilogueFunctor.LinearCombinationBias,
-                        EpilogueFunctor.LinearCombinationRelu,
-                        EpilogueFunctor.LinearCombinationSigmoid,
-                        EpilogueFunctor.LinearCombinationSilu,
-                        EpilogueFunctor.LinearCombinationHardSwish,
-                    ],
-                    [
-                        "opdef_bias",
-                        "opdef_bias_relu",
-                        "opdef_bias_sigmoid",
-                        "opdef_bias_silu",
-                        "opdef_bias_hardswish",
-                    ],
-                    [True, True, False, False, False],
-                ):
-                    op = Conv2dOperation(
-                        ConvKind.Fprop,
-                        iterator_algorithm,
-                        tile.minimum_compute_capability,
-                        tile,
-                        A,
-                        B,
-                        C,
-                        element_epilogue,
-                        StrideSupport.Strided,
-                        epilogue,
-                        swizzling_functor_,
-                    )
-
-                    op_entry[opdef] = kernel_emitter.emit(op, no_bias_scaling)
-
-                ret.append(op_entry)
+            ret.append(
+                {
+                    "src": profiler_emitter.emit(kernel_emitter.emit(op), op.procedural_name()),
+                    "name": op.procedural_name(),
+                    "tile_description": tile,
+                    "alignment": alignment,
+                    "data_type": data_type,
+                    "swizzle_functor": swizzling_functor,
+                }
+            )
 
     return ret
 
@@ -133,12 +123,15 @@ class CutlassConv2DProfiler:
         self.engine = ProfilerEngine(sm, cutlass_path, binary_path)
         self.cache = {}
 
-    def get_default(self, out_dtype):
-        gemm_profile_result = self.gemm_profiler.get_default(out_dtype)
+    def get_default(self, op_type, out_dtype):
+        gemm_profile_result = self.gemm_profiler.get_default(op_type, out_dtype)
         tile_description = gemm_profile_result["tile_description"]
         alignment = gemm_profile_result["alignment"]
         data_type = gemm_profile_result["data_type"]
-        return create_conv2d_operator([tile_description], data_type, [alignment])[0]
+        name, opdef = create_conv2d_operator_with_epilogue(
+            op_type, tile_description, data_type, alignment, SwizzlingFunctor.Identity4
+        )
+        return {"name": name, "opdef": opdef}
 
     def check_align(self, op_name, C, K):
         """Filter out kernels that cannot be supported."""
@@ -147,7 +140,7 @@ class CutlassConv2DProfiler:
         align = int(aligns[0][-1])
         return all([dim % align == 0 for dim in [C, K]])
 
-    def profile(
+    def select_op(
         self,
         d_shape,
         w_shape,
@@ -158,10 +151,7 @@ class CutlassConv2DProfiler:
         profile_all=True,
         use_multiprocessing=False,
     ):
-        """Profile and select the best kernel from candidate kernels.
-        If profile_all is False, return immediately after the first applicable kernel is found.
-        If use_multiprocessing is True, compile all profiler executables in parallel.
-        """
+        """TODO"""
         N, H, W, IC = d_shape
         OC, R, S, _ = w_shape
         workload = (
@@ -183,7 +173,10 @@ class CutlassConv2DProfiler:
         if workload in self.cache:
             return self.cache[workload]
 
-        ops = GENERATOR_FUNC_TABLE[self.sm](out_dtype, op_creator=create_conv2d_operator)
+        ops = GENERATOR_FUNC_TABLE[self.sm](
+            out_dtype,
+            op_creator=enumerate_conv2d_operators,
+        )
         ops = list(filter(lambda op: self.check_align(op["name"], IC, OC), ops))
 
         if profile_all:
@@ -201,6 +194,39 @@ class CutlassConv2DProfiler:
                 self.cache[workload] = op
                 return op
 
-        output = min(ops, key=lambda i: i["runtime"])
-        self.cache[workload] = output
-        return output
+        op = min(ops, key=lambda i: i["runtime"])
+        self.cache[workload] = op
+        return op
+
+    def profile(
+        self,
+        op_type,
+        d_shape,
+        w_shape,
+        padding,
+        stride,
+        dilation,
+        out_dtype,
+        profile_all=True,
+        use_multiprocessing=False,
+    ):
+        """Profile and select the best kernel from candidate kernels.
+        If profile_all is False, return immediately after the first applicable kernel is found.
+        If use_multiprocessing is True, compile all profiler executables in parallel.
+        """
+        op = self.select_op(
+            d_shape,
+            w_shape,
+            padding,
+            stride,
+            dilation,
+            out_dtype,
+            profile_all=profile_all,
+            use_multiprocessing=use_multiprocessing,
+        )
+
+        name, opdef = create_conv2d_operator_with_epilogue(
+            op_type, op["tile_description"], op["data_type"], op["alignment"], op["swizzle_functor"]
+        )
+
+        return name, opdef, op["runtime"]

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -16,14 +16,10 @@
 # under the License.
 # pylint: disable=invalid-name
 """GEMM kernel generator and profiler for CUTLASS."""
-from functools import partial
 import re
 from .gemm_operation import GemmOperation, EmitGemmInstance
 from .gemm_profiler import GemmProfilerEmitter
-from .gen_tensor_op import (
-    ProfilerEngine,
-    GENERATOR_FUNC_TABLE,
-)
+from .gen_tensor_op import ProfilerEngine, GENERATOR_FUNC_TABLE, EPILOGUE_MAP
 from .library import (
     EpilogueFunctor,
     SwizzlingFunctor,
@@ -33,12 +29,47 @@ from .library import (
 )
 
 
-def create_gemm_operator(
+def create_gemm_operator_with_epilogue(
+    op_type,
+    tile_description,
+    data_type,
+    alignment,
+    swizzling_functor,
+    batched=False,
+):
+    """TODO"""
+    element_a, element_b, element_c, element_epilogue = data_type
+
+    A = TensorDescription(element_a, LayoutType.RowMajor, alignment)
+    B = TensorDescription(element_b, LayoutType.ColumnMajor, alignment)
+    C = TensorDescription(element_c, LayoutType.RowMajor, alignment)
+
+    if batched:
+        swizzling_functor = SwizzlingFunctor.Batched
+
+    epilogue, no_beta_scaling = EPILOGUE_MAP[op_type]
+
+    op = GemmOperation(
+        tile_description.minimum_compute_capability,
+        tile_description,
+        A,
+        B,
+        C,
+        element_epilogue,
+        epilogue,
+        swizzling_functor,
+    )
+
+    return op.procedural_name(), EmitGemmInstance().emit(
+        op, no_beta_scaling=no_beta_scaling, batched=batched
+    )
+
+
+def enumerate_gemm_operators(
     tile_descriptions,
     data_type,
     alignment_constraints,
     swizzling_functor=SwizzlingFunctor.Identity8,
-    batched=False,
 ):
     """Exhaustively instantiate all kernels from a given configuration."""
     ret = []
@@ -47,86 +78,44 @@ def create_gemm_operator(
 
     element_a, element_b, element_c, element_epilogue = data_type
 
-    if batched:
-        swizzling_functor = SwizzlingFunctor.Batched
+    for tile_description in tile_descriptions:
+        for alignment in alignment_constraints:
+            A = TensorDescription(element_a, LayoutType.RowMajor, alignment)
+            B = TensorDescription(element_b, LayoutType.ColumnMajor, alignment)
+            C = TensorDescription(element_c, LayoutType.RowMajor, alignment)
 
-    layouts = [
-        (LayoutType.RowMajor, LayoutType.ColumnMajor, LayoutType.RowMajor),
-    ]
+            op = GemmOperation(
+                tile_description.minimum_compute_capability,
+                tile_description,
+                A,
+                B,
+                C,
+                element_epilogue,
+                EpilogueFunctor.LinearCombination,
+                swizzling_functor,
+            )
 
-    for layout in layouts:
-        for tile_description in tile_descriptions:
-            for alignment in alignment_constraints:
-                alignment_c = min(8, alignment)
+            src = profiler_emitter.emit(
+                op.procedural_name(),
+                kernel_emitter.emit(op, batched=False),
+                DataTypeTag[element_a],
+                DataTypeTag[element_b],
+                DataTypeTag[element_c],
+                op.leading_dim(),
+            )
 
-                A = TensorDescription(element_a, layout[0], alignment)
-                B = TensorDescription(element_b, layout[1], alignment)
-                C = TensorDescription(element_c, layout[2], alignment_c)
+            ret.append(
+                {
+                    "src": src,
+                    "op": op,
+                    "name": op.procedural_name(),
+                    "tile_description": tile_description,
+                    "alignment": alignment,
+                    "data_type": data_type,
+                    "swizzle_functor": swizzling_functor,
+                }
+            )
 
-                op_entry = {}
-                op = GemmOperation(
-                    tile_description.minimum_compute_capability,
-                    tile_description,
-                    A,
-                    B,
-                    C,
-                    element_epilogue,
-                    EpilogueFunctor.LinearCombination,
-                    swizzling_functor,
-                )
-                op_bias = GemmOperation(
-                    tile_description.minimum_compute_capability,
-                    tile_description,
-                    A,
-                    B,
-                    C,
-                    element_epilogue,
-                    EpilogueFunctor.LinearCombinationBias,
-                    swizzling_functor,
-                )
-                op_bias_relu = GemmOperation(
-                    tile_description.minimum_compute_capability,
-                    tile_description,
-                    A,
-                    B,
-                    C,
-                    element_epilogue,
-                    EpilogueFunctor.LinearCombinationRelu,
-                    swizzling_functor,
-                )
-                op_bias_gelu = GemmOperation(
-                    tile_description.minimum_compute_capability,
-                    tile_description,
-                    A,
-                    B,
-                    C,
-                    element_epilogue,
-                    EpilogueFunctor.LinearCombinationGelu,
-                    swizzling_functor,
-                )
-
-                op_entry["op"] = op
-                op_entry["name"] = op.procedural_name()
-                op_entry["opdef"] = kernel_emitter.emit(op, batched=batched)
-                op_entry["opdef_bias"] = kernel_emitter.emit(
-                    op_bias, no_beta_scaling=True, batched=batched
-                )
-                op_entry["opdef_bias_relu"] = kernel_emitter.emit(
-                    op_bias_relu, no_beta_scaling=True, batched=batched
-                )
-                op_entry["opdef_bias_gelu"] = kernel_emitter.emit(op_bias_gelu, batched=batched)
-                op_entry["src"] = profiler_emitter.emit(
-                    op.procedural_name(),
-                    kernel_emitter.emit(op, batched=False),
-                    DataTypeTag[element_a],
-                    DataTypeTag[element_b],
-                    DataTypeTag[element_c],
-                    op.leading_dim(),
-                )
-                op_entry["tile_description"] = tile_description
-                op_entry["alignment"] = alignment
-                op_entry["data_type"] = data_type
-                ret.append(op_entry)
     return ret
 
 
@@ -164,30 +153,35 @@ class CutlassGemmProfiler:
         # When the above issue is resolved, we can remove the alignment check on M below.
         return all([dim % align == 0 for dim in [M, N, K]])
 
-    def get_default(self, out_dtype, batched=False):
+    def get_default(self, op_type, out_dtype, batched=False):
         """Return the default kernel for the requested architecture.
         For now, the default kernel was picked arbitrary.
         """
-        ops = GENERATOR_FUNC_TABLE[self.sm](
-            out_dtype, op_creator=partial(create_gemm_operator, batched=batched)
-        )
+        ops = GENERATOR_FUNC_TABLE[self.sm](out_dtype, op_creator=enumerate_gemm_operators)
         default_kernel_name = DEFAULT_KERNELS[self.sm][out_dtype]
         filtered = list(filter(lambda op: op["name"] == default_kernel_name, ops))
         assert len(filtered) == 1
-        return filtered[0]
+        op = filtered[0]
+        name, opdef = create_gemm_operator_with_epilogue(
+            op_type,
+            op["tile_description"],
+            op["data_type"],
+            op["alignment"],
+            op["swizzle_functor"],
+            batched=batched,
+        )
+        op.update({"name": name, "opdef": opdef})
+        return op
 
-    def profile(
-        self, M, N, K, out_dtype, profile_all=True, use_multiprocessing=False, batched=False
-    ):
-        """Profile and select the best kernel from candidate kernels.
-        If profile_all is False, return immediately after the first applicable kernel is found.
-        If use_multiprocessing is True, compile all profiler executables in parallel.
-        """
+    def select_op(self, M, N, K, out_dtype, profile_all=True, use_multiprocessing=False):
+        """TODO"""
         if (M, N, K) in self.cache:
-            return self.cache[(M, N, K)]
+            op = self.cache[(M, N, K)]
+            return op
 
         ops = GENERATOR_FUNC_TABLE[self.sm](
-            out_dtype, op_creator=partial(create_gemm_operator, batched=batched)
+            out_dtype,
+            op_creator=enumerate_gemm_operators,
         )
         ops = list(filter(lambda op: self.check_align(op["name"], M, N, K), ops))
 
@@ -201,6 +195,36 @@ class CutlassGemmProfiler:
                 self.cache[(M, N, K)] = op
                 return op
 
-        output = min(ops, key=lambda i: i["runtime"])
-        self.cache[(M, N, K)] = output
-        return output
+        op = min(ops, key=lambda i: i["runtime"])
+        self.cache[(M, N, K)] = op
+        return op
+
+    def profile(
+        self,
+        op_type,
+        M,
+        N,
+        K,
+        out_dtype,
+        profile_all=True,
+        use_multiprocessing=False,
+        batched=False,
+    ):
+        """Profile and select the best kernel from candidate kernels.
+        If profile_all is False, return immediately after the first applicable kernel is found.
+        If use_multiprocessing is True, compile all profiler executables in parallel.
+        """
+        op = self.select_op(
+            M, N, K, out_dtype, profile_all=profile_all, use_multiprocessing=use_multiprocessing
+        )
+
+        name, opdef = create_gemm_operator_with_epilogue(
+            op_type,
+            op["tile_description"],
+            op["data_type"],
+            op["alignment"],
+            op["swizzle_functor"],
+            batched=batched,
+        )
+
+        return name, opdef, op["runtime"]

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -37,7 +37,10 @@ def create_gemm_operator_with_epilogue(
     swizzling_functor,
     batched=False,
 ):
-    """TODO"""
+    """
+    Instantiate a cutlass kernel from the given configuration,
+    along with the epilouge functor
+    """
     element_a, element_b, element_c, element_epilogue = data_type
 
     A = TensorDescription(element_a, LayoutType.RowMajor, alignment)
@@ -174,7 +177,10 @@ class CutlassGemmProfiler:
         return op
 
     def select_op(self, M, N, K, out_dtype, profile_all=True, use_multiprocessing=False):
-        """TODO"""
+        """
+        Profile and select the best kernel from candidate kernels.
+        See the documentation for the profile method below.
+        """
         if (M, N, K) in self.cache:
             op = self.cache[(M, N, K)]
             return op

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -27,6 +27,7 @@ from .library import (
     OpcodeClass,
     MathOperation,
     TileDescription,
+    EpilogueFunctor,
 )
 
 logger = logging.getLogger("cutlass")
@@ -162,6 +163,23 @@ def generate_sm80_tensor_op_16816(out_dtype, op_creator):
 GENERATOR_FUNC_TABLE = {
     75: generate_sm75_tensor_op_1688,
     80: generate_sm80_tensor_op_16816,
+}
+
+
+# (Epilogue functor name, no_beta_scaling)
+EPILOGUE_MAP = {
+    "cutlass.dense": (EpilogueFunctor.LinearCombination, True),
+    "cutlass.dense_bias": (EpilogueFunctor.LinearCombinationBias, True),
+    "cutlass.dense_bias_relu": (EpilogueFunctor.LinearCombinationRelu, True),
+    "cutlass.dense_bias_gelu_fp16": (EpilogueFunctor.LinearCombinationGelu, False),
+    "cutlass.dense_bias_gelu_fp32": (EpilogueFunctor.LinearCombinationGelu, False),
+    "cutlass.batch_matmul": (EpilogueFunctor.LinearCombination, True),
+    "cutlass.conv2d_bias_hardswish": (EpilogueFunctor.LinearCombinationHardSwish, False),
+    "cutlass.conv2d_bias_silu": (EpilogueFunctor.LinearCombinationSilu, False),
+    "cutlass.conv2d_bias_sigmoid": (EpilogueFunctor.LinearCombinationSigmoid, False),
+    "cutlass.conv2d_bias_relu": (EpilogueFunctor.LinearCombinationRelu, True),
+    "cutlass.conv2d_bias": (EpilogueFunctor.LinearCombinationBias, True),
+    "cutlass.conv2d": (EpilogueFunctor.LinearCombination, True),
 }
 
 

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -168,18 +168,18 @@ GENERATOR_FUNC_TABLE = {
 
 # (Epilogue functor name, no_beta_scaling)
 EPILOGUE_MAP = {
-    "cutlass.dense": (EpilogueFunctor.LinearCombination, True),
+    "cutlass.dense": (EpilogueFunctor.LinearCombination, False),
     "cutlass.dense_bias": (EpilogueFunctor.LinearCombinationBias, True),
     "cutlass.dense_bias_relu": (EpilogueFunctor.LinearCombinationRelu, True),
     "cutlass.dense_bias_gelu_fp16": (EpilogueFunctor.LinearCombinationGelu, False),
     "cutlass.dense_bias_gelu_fp32": (EpilogueFunctor.LinearCombinationGelu, False),
-    "cutlass.batch_matmul": (EpilogueFunctor.LinearCombination, True),
+    "cutlass.batch_matmul": (EpilogueFunctor.LinearCombination, False),
     "cutlass.conv2d_bias_hardswish": (EpilogueFunctor.LinearCombinationHardSwish, False),
     "cutlass.conv2d_bias_silu": (EpilogueFunctor.LinearCombinationSilu, False),
     "cutlass.conv2d_bias_sigmoid": (EpilogueFunctor.LinearCombinationSigmoid, False),
     "cutlass.conv2d_bias_relu": (EpilogueFunctor.LinearCombinationRelu, True),
     "cutlass.conv2d_bias": (EpilogueFunctor.LinearCombinationBias, True),
-    "cutlass.conv2d": (EpilogueFunctor.LinearCombination, True),
+    "cutlass.conv2d": (EpilogueFunctor.LinearCombination, False),
 }
 
 

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -176,16 +176,6 @@ def partition_for_cutlass(mod, params=None):
             check_conv2d,
         ),
         (
-            "cutlass.conv2d_bias_hardswish",
-            make_conv2d_pattern(with_bias=True, with_act="hardswish"),
-            check_conv2d,
-        ),
-        (
-            "cutlass.conv2d_bias_silu",
-            make_conv2d_pattern(with_bias=True, with_act="silu"),
-            check_conv2d,
-        ),
-        (
             "cutlass.conv2d_bias_relu",
             make_conv2d_pattern(with_bias=True, with_act="relu"),
             check_conv2d,

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -217,7 +217,6 @@ def partition_for_cutlass(mod, params=None):
     seq = Sequential(
         [
             transform.InferType(),
-            transform.SimplifyExpr(),
             transform.MergeComposite(cutlass_patterns),
             transform.AnnotateTarget(["cutlass"], include_non_call_ops=False),
             transform.PartitionGraph(bind_constants=False),

--- a/python/tvm/relay/op/contrib/cutlass.py
+++ b/python/tvm/relay/op/contrib/cutlass.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=invalid-name
 """Patterns supported CUTLASS."""
-from functools import partial
 from tvm import relay
 from tvm.ir.transform import Sequential, PassContext
 from tvm.relay import transform


### PR DESCRIPTION
Currently, when we enumerate cutlass kernels for profiling, for each parameter config we generate all variants of the kernel with different epilogues. See for example

https://github.com/apache/tvm/blob/1afcf36d311acf04873bd1985c0c832fc2fa1771/python/tvm/contrib/cutlass/gen_gemm.py#L67-L106

After profiling, we select which variant of epilogue to use based on the pattern name:

https://github.com/apache/tvm/blob/1afcf36d311acf04873bd1985c0c832fc2fa1771/python/tvm/contrib/cutlass/build.py#L219-L230 

This approach simply doesn't work when we introduce support for residual connection fusion, because there are so many different kinds of epilogues. 

The idea of this change is to split kernel generation into two steps:
(1) First, we generate all kernels without any epilogue. This is used for profiling 
(2) After profiling decides the best parameter configuration, use that information to generate a single kernel with the required epilogue. 

Overall I believe this refactoring of kernel generation and selection have made things much cleaner, and makes us well-prepared for residual block fusion.

cc @comaniac @Laurawly  