### PR TITLE
[CMSIS-NN] Conv2D with equal paddings can be mapped to CMSIS-NN target

### DIFF
--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -135,8 +135,8 @@ def pattern_table():
 
         return (
             conv2d.attrs.out_dtype == "int32"
-            and int(conv2d.attrs.padding[2]) == 0
-            and int(conv2d.attrs.padding[3]) == 0
+            and int(conv2d.attrs.padding[0]) == int(conv2d.attrs.padding[2])
+            and int(conv2d.attrs.padding[1]) == int(conv2d.attrs.padding[3])
             and conv2d_input.checked_type.dtype == "int8"
             and conv2d_weight.checked_type.dtype == "int8"
             and pattern.checked_type.dtype == "int8"

--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -70,7 +70,7 @@ def make_model(
     invar = relay.var("input", shape=shape, dtype=dtype)
     p = (0, 0, 0, 0)
     if padding == "INVALID":
-        p = [1, 2, 1, 2]
+        p = [1, 2, 2, 1]
     if padding == "SAME":
         p = get_same_padding((shape[1], shape[2]), (kernel_h, kernel_w), dilation, strides)
         invar = relay.nn.pad(

--- a/tests/python/contrib/test_cmsisnn/utils.py
+++ b/tests/python/contrib/test_cmsisnn/utils.py
@@ -92,14 +92,16 @@ def get_same_padding(in_shape, kernel, dilation, stride):
     This is TFLu's "SAME" padding case.
     """
     dilated_kernel_h = dilation[0] * (kernel[0] - 1) + 1
-    dilated_kernel_w = dilation[1] * (kernel[1] - 1) + 1
     out = int(math.ceil(float(in_shape[0]) / float(stride[0])))
     pad = max(0, (out - 1) * stride[0] + dilated_kernel_h - in_shape[0])
-    pad_top, pad_bottom = (pad, 0)
+    pad_top = pad // 2
+    pad_bottom = pad - pad_top
 
+    dilated_kernel_w = dilation[1] * (kernel[1] - 1) + 1
     out = int(math.ceil(float(in_shape[1]) / float(stride[1])))
     pad = max(0, (out - 1) * stride[1] + dilated_kernel_w - in_shape[1])
-    pad_left, pad_right = (pad, 0)
+    pad_left = pad // 2
+    pad_right = pad - pad_left
     return [pad_top, pad_left, pad_bottom, pad_right]
 
 


### PR DESCRIPTION
Bugfix for padding support for Conv2D via CMSIS-NN.
TFLu and CMSIS-NN support symmetric padding in Conv2D.
This commit modifies:
    -pattern matching for Conv2D padding
    -utility function that provides padding values to unit tests
    -a negative test to test asymmetric padding does not work
