### PR TITLE
fix a bug of instance norm.

### DIFF
--- a/src/relay/transforms/simplify_inference.cc
+++ b/src/relay/transforms/simplify_inference.cc
@@ -151,7 +151,7 @@ Expr InstanceNormToInferUnpack(const Attrs attrs, Expr data, Expr gamma, Expr be
     if (i != axis) reduced_axes.push_back(i);
   }
 
-  Expr epsilon = MakeConstantScalar(DataType::Float(32), static_cast<float>(param->epsilon));
+  Expr epsilon = MakeConstantScalar(ttype->dtype, static_cast<float>(param->epsilon));
   Expr mean = Mean(data, reduced_axes, true, false);
   Expr var = Variance(data, mean, reduced_axes, true, false);
   Expr denom = Sqrt(Add(var, epsilon));


### PR DESCRIPTION
The instance norm epsilon dtype is float32 originally, which will cause problem when given a half model. My model, which dtype is float16, uses instance norm and failed when extract task from the compuation graph.