### PR TITLE
[Target][BugFix] Convert dict and str to TVM object

### DIFF
--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -264,6 +264,17 @@ def test_target_host_merge_2():
     assert tgt.host.kind.name == "llvm"
 
 
+def test_target_tvm_object():
+    """Test creating Target by using TVM Objects"""
+    String = tvm.runtime.container.String
+    tgt = tvm.target.Target(target=String("cuda --host llvm"))
+    assert tgt.kind.name == "cuda"
+    assert tgt.host.kind.name == "llvm"
+    tgt = tvm.target.Target(target=String("cuda"), host=String("llvm"))
+    assert tgt.kind.name == "cuda"
+    assert tgt.host.kind.name == "llvm"
+
+
 @pytest.mark.skip(reason="Causing infinite loop because of pytest and handle issue")
 def test_target_host_merge_3():
     with pytest.raises(ValueError, match=r"target host has to be a string or dictionary."):
@@ -315,6 +326,27 @@ def test_check_and_update_host_consist_3():
     assert target.host.kind.name == "llvm"
     assert host.kind.name == "llvm"
     assert target.host == host
+
+
+def test_check_and_update_host_consist_4():
+    """Test `check_and_update_host_consist` by using TVM Objects"""
+    cuda_device_type = tvm.device("cuda").device_type
+    target = {cuda_device_type: Target(target="cuda", host="llvm")}
+    host = None
+    target_1, host_1 = Target.check_and_update_host_consist(target, host)
+    assert isinstance(target_1, dict)
+    assert target_1[cuda_device_type].kind.name == "cuda"
+    assert target_1[cuda_device_type].host.kind.name == "llvm"
+    assert host_1 is None
+
+    target = {cuda_device_type: Target(tvm.runtime.container.String("cuda"))}
+    host = Target(tvm.runtime.container.String("llvm"))
+    target = tvm.runtime.convert(target)
+    assert isinstance(target, tvm.ir.container.Map)
+    target_2, host_2 = Target.check_and_update_host_consist(target, host)
+    assert isinstance(target_2, dict)
+    assert target_2[cuda_device_type].kind.name == "cuda"
+    assert host_2.kind.name == "llvm"
 
 
 def test_target_attr_bool_value():


### PR DESCRIPTION
Hi All,

This PR tries to fix the Target constructing issue. I just found an error when invoking `relay.backend._backend.build` from the python side. After `build_target_by_device_type_map`, we got a dict target and it will be converted to Map when calling `relay.backend._backend.build`, because it is a global function. Then, the error occurred due to we cannot construct Target by type Map or String.
https://github.com/apache/tvm/blob/main/python/tvm/relay/build_module.py#L273-L280

Reproduce case
```python
import tvm
from tvm import relay
from tvm.relay.backend import graph_executor_codegen


def test_add():

    def build_graph(mod, target):
        target = tvm.relay.build_module.build_target_by_device_type_map(target)
        target, target_host = tvm.target.Target.check_and_update_host_consist(target)
        mod, _ = relay.optimize(mod, target, None)
        grc = graph_executor_codegen.GraphExecutorCodegen(None, target)
        graph_json, lowered_funcs, params = grc.codegen(mod, mod["main"])
        built_mod = relay.backend._backend.build(lowered_funcs, target, target_host)

    def add(shape, dtype):
        A = relay.var("A", shape=shape, dtype=dtype)
        B = relay.var("B", shape=shape, dtype=dtype)
        C = relay.add(A, B)
        expr = relay.Function((A, B), C)
        mod = tvm.IRModule.from_expr(expr)
        return mod

    mod = build_graph(add((1, 8), "float32"), tvm.target.Target("llvm"))


test_add()
```

Trace log
```bash
Traceback (most recent call last):
  File "test_build_graph.py", line 27, in <module>
    test_add()
  File "test_build_graph.py", line 24, in test_add
    mod = build_graph(add((1, 8), "float32"), tvm.target.Target("llvm"))
  File "test_build_graph.py", line 14, in build_graph
    built_mod = relay.backend._backend.build(lowered_funcs, target, target_host)
  File "/home/tuisku/project/apache/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
ValueError: Traceback (most recent call last):
  4: TVMFuncCall
        at ../src/runtime/c_runtime_api.cc:475
  3: tvm::runtime::PackedFunc::CallPacked(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const
        at ../include/tvm/runtime/packed_func.h:1151
  2: std::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const
        at /usr/include/c++/7/bits/std_function.h:706
  1: _M_invoke
        at /usr/include/c++/7/bits/std_function.h:316
  0: operator()
        at ../src/runtime/c_runtime_api.cc:526
  File "~/apache/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 81, in cfun
    rv = local_pyfunc(*pyargs)
  File "/home/tuisku/project/apache/tvm/python/tvm/relay/backend/_backend.py", line 44, in build
    target, target_host = Target.check_and_update_host_consist(target, target_host)
  File "/home/tuisku/project/apache/tvm/python/tvm/target/target.py", line 239, in check_and_update_host_consist
    target = Target(target, host)
  File "/home/tuisku/project/apache/tvm/python/tvm/target/target.py", line 111, in __init__
    raise ValueError("target has to be a string or dictionary.")
ValueError: target has to be a string or dictionary.
```

I also found there are two container definitions `tvm.runtime.container` and `tvm.ir.container`. Can we merge them?