### PR TITLE
[Rust] Update Rust bindings

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -1232,7 +1232,7 @@ struct UpSampling3DAttrs : public tvm::AttrsNode<UpSampling3DAttrs> {
 /*! \brief Attributes used for the padding operator */
 struct PadAttrs : public tvm::AttrsNode<PadAttrs> {
   Array<Array<Integer>> pad_width;
-  std::string pad_mode;
+  tvm::String pad_mode;
 
   TVM_DECLARE_ATTRS(PadAttrs, "relay.attrs.PadAttrs") {
     TVM_ATTR_FIELD(pad_width).describe(

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -173,7 +173,7 @@ struct GatherNDAttrs : public tvm::AttrsNode<GatherNDAttrs> {
 struct TakeAttrs : public tvm::AttrsNode<TakeAttrs> {
   Integer batch_dims;
   Integer axis;
-  std::string mode;
+  tvm::String mode;
 
   TVM_DECLARE_ATTRS(TakeAttrs, "relay.attrs.TakeAttrs") {
     TVM_ATTR_FIELD(batch_dims)
@@ -321,7 +321,7 @@ struct StridedSliceAttrs : public tvm::AttrsNode<StridedSliceAttrs> {
   Optional<Array<Integer>> begin;
   Optional<Array<Integer>> end;
   Optional<Array<Integer>> strides;
-  std::string slice_mode;
+  tvm::String slice_mode;
   Optional<Array<Integer>> axes;
 
   TVM_DECLARE_ATTRS(StridedSliceAttrs, "relay.attrs.StridedSliceAttrs") {

--- a/rust/tvm/src/ir/relay/attrs/nn.rs
+++ b/rust/tvm/src/ir/relay/attrs/nn.rs
@@ -28,6 +28,35 @@ type IndexExpr = PrimExpr;
 
 #[repr(C)]
 #[derive(Object, Debug)]
+#[ref_name = "PadAttrs"]
+#[type_key = "relay.attrs.PadAttrs"]
+pub struct PadAttrsNode {
+    pub base: BaseAttrsNode,
+    pub pad_width: Array<Array<IndexExpr>>,
+    pub pad_mode: TString,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "Conv1DAttrs"]
+#[type_key = "relay.attrs.Conv1DAttrs"]
+pub struct Conv1DAttrsNode {
+    pub base: BaseAttrsNode,
+    pub strides: Array<IndexExpr>,
+    pub padding: Array<IndexExpr>,
+    pub dilation: Array<IndexExpr>,
+    // TODO(@gussmith23) groups is "int", what should it be here?
+    pub groups: i32,
+    pub channels: IndexExpr,
+    pub kernel_size: Array<IndexExpr>,
+    pub data_layout: TString,
+    pub kernel_layout: TString,
+    pub out_layout: TString,
+    pub out_dtype: DataType,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
 #[ref_name = "Conv2DAttrs"]
 #[type_key = "relay.attrs.Conv2DAttrs"]
 pub struct Conv2DAttrsNode {
@@ -42,6 +71,7 @@ pub struct Conv2DAttrsNode {
     pub data_layout: TString,
     pub kernel_layout: TString,
     pub out_layout: TString,
+    pub auto_scheduler_rewritten_layout: TString,
     pub out_dtype: DataType,
 }
 
@@ -138,6 +168,7 @@ pub struct AvgPool2DAttrsNode {
     pub pool_size: Array<IndexExpr>,
     pub strides: Array<IndexExpr>,
     pub padding: Array<IndexExpr>,
+    pub dilation: Array<IndexExpr>,
     pub layout: TString,
     pub ceil_mode: bool,
     pub count_include_pad: bool,
@@ -154,4 +185,35 @@ pub struct UpSamplingAttrsNode {
     pub layout: TString,
     pub method: TString,
     pub align_corners: bool,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "DropoutAttrs"]
+#[type_key = "relay.attrs.DropoutAttrs"]
+pub struct DropoutAttrsNode {
+    pub base: BaseAttrsNode,
+    pub rate: f64,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "BatchMatmulAttrs"]
+#[type_key = "relay.attrs.BatchMatmulAttrs"]
+pub struct BatchMatmulAttrsNode {
+    pub base: BaseAttrsNode,
+    pub auto_scheduler_rewritten_layout: TString,
+    pub out_dtype: DataType,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "LayerNormAttrs"]
+#[type_key = "relay.attrs.LayerNormAttrs"]
+pub struct LayerNormAttrsNode {
+    pub base: BaseAttrsNode,
+    pub axis: i32,
+    pub epsilon: f64,
+    pub center: bool,
+    pub scale: bool,
 }

--- a/rust/tvm/src/ir/relay/attrs/reduce.rs
+++ b/rust/tvm/src/ir/relay/attrs/reduce.rs
@@ -17,6 +17,32 @@
  * under the License.
  */
 
-pub mod nn;
-pub mod reduce;
-pub mod transform;
+use crate::ir::attrs::BaseAttrsNode;
+use crate::ir::PrimExpr;
+use crate::runtime::array::Array;
+use tvm_macros::Object;
+
+type IndexExpr = PrimExpr;
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "ReduceAttrs"]
+#[type_key = "relay.attrs.ReduceAttrs"]
+pub struct ReduceAttrsNode {
+    pub base: BaseAttrsNode,
+    pub axis: Array<IndexExpr>,
+    pub keepdims: bool,
+    pub exclude: bool,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "VarianceAttrs"]
+#[type_key = "relay.attrs.ReduceAttrs"]
+pub struct VarianceAttrsNode {
+    pub base: BaseAttrsNode,
+    pub axis: Array<IndexExpr>,
+    pub keepdims: bool,
+    pub exclude: bool,
+    pub unbiased: bool,
+}

--- a/rust/tvm/src/ir/relay/attrs/transform.rs
+++ b/rust/tvm/src/ir/relay/attrs/transform.rs
@@ -18,12 +18,34 @@
  */
 
 use crate::ir::attrs::BaseAttrsNode;
+use crate::ir::relay::TString;
+use crate::ir::tir::IntImm;
 use crate::ir::PrimExpr;
 use crate::runtime::array::Array;
 use crate::runtime::ObjectRef;
 use tvm_macros::Object;
+use tvm_rt::DataType;
 
 type IndexExpr = PrimExpr;
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "ClipAttrs"]
+#[type_key = "relay.attrs.ClipAttrs"]
+pub struct ClipAttrsNode {
+    pub base: BaseAttrsNode,
+    pub a_min: f64,
+    pub a_max: f64,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "CastAttrs"]
+#[type_key = "relay.attrs.CastAttrs"]
+pub struct CastAttrsNode {
+    pub base: BaseAttrsNode,
+    pub dtype: DataType,
+}
 
 #[repr(C)]
 #[derive(Object, Debug)]
@@ -79,5 +101,40 @@ pub struct TransposeAttrsNode {
 #[type_key = "relay.attrs.SqueezeAttrs"]
 pub struct SqueezeAttrsNode {
     pub base: BaseAttrsNode,
-    pub axis: Array<IndexExpr>,
+    pub axis: Array<IntImm>,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "TakeAttrs"]
+#[type_key = "relay.attrs.TakeAttrs"]
+pub struct TakeAttrsNode {
+    pub base: BaseAttrsNode,
+    pub batch_dims: IntImm,
+    pub axis: IntImm,
+    pub mode: TString,
+}
+
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "StackAttrs"]
+#[type_key = "relay.attrs.StackAttrs"]
+pub struct StackAttrsNode {
+    pub base: BaseAttrsNode,
+    pub axis: IntImm,
+}
+
+// TODO(@gussmith23) How to support Optional type? This "just works" when values
+// are provided for begin/end/strides, but I'm not sure what happens if None is
+// passed from the C++ side.
+#[repr(C)]
+#[derive(Object, Debug)]
+#[ref_name = "StridedSliceAttrs"]
+#[type_key = "relay.attrs.StridedSliceAttrs"]
+pub struct StridedSliceAttrsNode {
+    pub base: BaseAttrsNode,
+    pub begin: Array<IntImm>,
+    pub end: Array<IntImm>,
+    pub strides: Array<IntImm>,
+    pub slice_mode: TString,
 }

--- a/rust/tvm/src/ir/relay/mod.rs
+++ b/rust/tvm/src/ir/relay/mod.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 use crate::runtime::array::Array;
-use crate::runtime::{object::*, IsObjectRef, String as TString, self};
+use crate::runtime::{self, object::*, IsObjectRef, String as TString};
 
 use super::attrs::Attrs;
 use super::expr::BaseExprNode;

--- a/rust/tvm/src/ir/relay/mod.rs
+++ b/rust/tvm/src/ir/relay/mod.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 use crate::runtime::array::Array;
-use crate::runtime::{object::*, IsObjectRef, String as TString};
+use crate::runtime::{object::*, IsObjectRef, String as TString, self};
 
 use super::attrs::Attrs;
 use super::expr::BaseExprNode;
@@ -150,6 +150,7 @@ impl Var {
 #[type_key = "relay.Call"]
 pub struct CallNode {
     pub base: ExprNode,
+    deleter: ObjectRef,
     pub op: Expr,
     pub args: Array<Expr>,
     pub attrs: Attrs,
@@ -166,6 +167,7 @@ impl Call {
     ) -> Call {
         let node = CallNode {
             base: ExprNode::base::<CallNode>(span),
+            deleter: todo!("Don't know how to construct this"),
             op: op,
             args: args,
             attrs: attrs,


### PR DESCRIPTION
- Adds Rust bindings.
- Fixes Rust bindings that have been broken by changes on the C++ side.
- Introduces various other changes to make Rust bindings work (namely, changing things to use tvm::String).

I'm still unsure on how to construct the `deleter` on the Rust side, see the `todo!`.

@jroesch 