### PR TITLE
[TIR] For-kind inheritance in decompose-reduction

### DIFF
--- a/src/tir/schedule/primitive/reduction.cc
+++ b/src/tir/schedule/primitive/reduction.cc
@@ -281,7 +281,7 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
     body = For(/*loop_var=*/new_loop_var,
                /*min=*/old_loop->min,
                /*extent=*/old_loop->extent,
-               /*kind=*/ForKind::kSerial,
+               /*kind=*/old_loop->kind,
                /*body=*/body);
   }
   body = Substitute(body, loop_var_map);


### PR DESCRIPTION
This PR changes a behavior in schedule primitive decompose-reduction. Prior to this PR, loops outside the newly created init block always have the for-kind "serial". And this PR changes this behavior, letting the new loops inherit the for-kinds from the old loops.

Several reasons for this change:
* If the new loops don't inherit the for-kinds, their for-kinds is impossible to be changed once after the decompose-reduction. This is because after decompose-reduction, the init block and the update block write to a same buffer. Thus the compact-dataflow property is no longer satisfied (more specifically, the "dominant" property is no longer satisfied). And in this case, we cannot apply vectorization or parallelization to those loops.
* From the perspective of performance, it makes sense to let the new loops have the same for-kinds as the original loops.
* TE has this behavior.

---

cc @spectrometerHBH @junrushao1994 @Hzfengsy 