### PR TITLE
[microNPU] Enable the codegen tests for 256 mac Arm(R) Ethos(TM)-U65 NPU

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
+++ b/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
@@ -72,10 +72,11 @@ class AcceleratorArchConfig:
 
 def get_accelerator_arch_config(accel_type):
     accel_config_str_map = {
-        "ethos-u55-256": AcceleratorArchConfig(48),
-        "ethos-u55-128": AcceleratorArchConfig(24),
-        "ethos-u55-64": AcceleratorArchConfig(16),
         "ethos-u55-32": AcceleratorArchConfig(16),
+        "ethos-u55-64": AcceleratorArchConfig(16),
+        "ethos-u55-128": AcceleratorArchConfig(24),
+        "ethos-u55-256": AcceleratorArchConfig(48),
+        "ethos-u65-256": AcceleratorArchConfig(48),
     }
     return accel_config_str_map[accel_type]
 

--- a/python/tvm/relay/backend/contrib/ethosu/vela_api.py
+++ b/python/tvm/relay/backend/contrib/ethosu/vela_api.py
@@ -388,6 +388,7 @@ def get_accelerator_config() -> vapi.NpuAccelerator:
         "ethos-u55-128": vapi.NpuAccelerator.Ethos_U55_128,
         "ethos-u55-64": vapi.NpuAccelerator.Ethos_U55_64,
         "ethos-u55-32": vapi.NpuAccelerator.Ethos_U55_32,
+        "ethos-u65-256": vapi.NpuAccelerator.Ethos_U65_256,
     }
     compiler_attrs = tvm.get_global_func("relay.ext.ethos-u.get_compiler_attrs")()
     accel_config_str = compiler_attrs.accelerator_config

--- a/tests/python/contrib/test_ethosu/infra.py
+++ b/tests/python/contrib/test_ethosu/infra.py
@@ -192,8 +192,8 @@ def deserialize_command_stream(blob):
 def create_test_runner(accel="ethos-u55-256"):
     file_dir = os.path.dirname(os.path.abspath(__file__))
     test_root = os.path.join(file_dir, "reference_system")
-    ethosu_macs = accel[accel.rfind("-") + 1 :]
-    ethosu_variant = accel[accel.find("-") + 1 : -4].upper()
+    _, ethosu_variant, ethosu_macs = accel.split("-")
+    ethosu_variant = ethosu_variant.upper()
     return AOTTestRunner(
         makefile="corstone300",
         prologue="""

--- a/tests/python/contrib/test_ethosu/infra.py
+++ b/tests/python/contrib/test_ethosu/infra.py
@@ -193,6 +193,7 @@ def create_test_runner(accel="ethos-u55-256"):
     file_dir = os.path.dirname(os.path.abspath(__file__))
     test_root = os.path.join(file_dir, "reference_system")
     ethosu_macs = accel[accel.rfind("-") + 1 :]
+    ethosu_variant = accel[accel.find("-") + 1 : -4].upper()
     return AOTTestRunner(
         makefile="corstone300",
         prologue="""
@@ -205,7 +206,11 @@ def create_test_runner(accel="ethos-u55-256"):
         ethosu_release_driver(ethos_u);
         """,
         includes=["uart.h", "ethosu_55.h", "ethosu_mod.h", "hard_fault.h"],
-        parameters={"ETHOSU_TEST_ROOT": test_root, "NPU_VARIANT": ethosu_macs},
+        parameters={
+            "ETHOSU_TEST_ROOT": test_root,
+            "NPU_MACS": ethosu_macs,
+            "NPU_VARIANT": ethosu_variant,
+        },
         pass_config={
             "relay.ext.ethos-u.options": {
                 "accelerator_config": accel,

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -37,7 +37,7 @@ from tests.python.relay.aot.aot_test_utils import generate_ref_data
 from . import infra
 
 
-ACCEL_TYPES = ["ethos-u55-256", "ethos-u55-128", "ethos-u55-64", "ethos-u55-32"]
+ACCEL_TYPES = ["ethos-u55-256", "ethos-u55-128", "ethos-u55-64", "ethos-u55-32", "ethos-u65-256"]
 
 
 def infer_type_function_pass(func):

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -146,7 +146,6 @@ AOT_CORSTONE300_RUNNER = AOTTestRunner(
     uart_init();
     """,
     includes=["uart.h"],
-    parameters={"NPU_VARIANT": "256"},
     pass_config={
         "relay.ext.cmsisnn.options": {
             "mcpu": "cortex-m55",

--- a/tests/python/relay/aot/corstone300.mk
+++ b/tests/python/relay/aot/corstone300.mk
@@ -24,7 +24,15 @@ CRT_ROOT ?= ${TVM_ROOT}/build/standalone_crt
 ifeq ($(shell ls -lhd $(CRT_ROOT)),)
 $(error "CRT not found. Ensure you have built the standalone_crt target and try again")
 endif
+
 FVP_DIR ?= /opt/arm/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/
+
+NPU_MACS ?= 256
+
+MODEL = FVP_Corstone_SSE-300_Ethos-U55
+ifeq (${NPU_VARIANT}, U65)
+MODEL = FVP_Corstone_SSE-300_Ethos-U65
+endif
 
 ARM_CPU=ARMCM55
 DMLC_CORE=${TVM_ROOT}/3rdparty/dmlc-core
@@ -118,12 +126,12 @@ cleanall:
 	$(QUIET)rm -rf $(build_dir)
 
 run: $(build_dir)/aot_test_runner
-	$(FVP_DIR)/FVP_Corstone_SSE-300_Ethos-U55 -C cpu0.CFGDTCMSZ=15 \
+	$(FVP_DIR)/$(MODEL) -C cpu0.CFGDTCMSZ=15 \
 	-C cpu0.CFGITCMSZ=15 -C mps3_board.uart0.out_file=\"-\" -C mps3_board.uart0.shutdown_tag=\"EXITTHESIM\" \
 	-C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 \
 	-C mps3_board.telnetterminal1.start_telnet=0 -C mps3_board.telnetterminal2.start_telnet=0 -C mps3_board.telnetterminal5.start_telnet=0 \
 	-C ethosu.extra_args="--fast" \
-	-C ethosu.num_macs=$(NPU_VARIANT) $(build_dir)/aot_test_runner
+	-C ethosu.num_macs=$(NPU_MACS) $(build_dir)/aot_test_runner
 
 .SUFFIXES:
 

--- a/tests/python/relay/aot/corstone300.mk
+++ b/tests/python/relay/aot/corstone300.mk
@@ -28,11 +28,9 @@ endif
 FVP_DIR ?= /opt/arm/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/
 
 NPU_MACS ?= 256
+NPU_VARIANT ?= U55
 
-MODEL = FVP_Corstone_SSE-300_Ethos-U55
-ifeq (${NPU_VARIANT}, U65)
-MODEL = FVP_Corstone_SSE-300_Ethos-U65
-endif
+MODEL = FVP_Corstone_SSE-300_Ethos-$(NPU_VARIANT)
 
 ARM_CPU=ARMCM55
 DMLC_CORE=${TVM_ROOT}/3rdparty/dmlc-core


### PR DESCRIPTION
This patch has necessary changes to the Makefile and test
infra to run the FVP based codegen tests on a newer NPU variant.

