### PR TITLE
Add sliding_window operator

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -33,6 +33,29 @@
 namespace tvm {
 namespace relay {
 
+/*! \brief Attributes used for the windows operator */
+struct WindowsAttrs : public tvm::AttrsNode<WindowsAttrs> {
+  int axis;
+  Array<Integer> window_shape;
+  Array<Integer> strides;
+  TVM_DECLARE_ATTRS(WindowsAttrs, "relay.attrs.WindowsAttrs") {
+    TVM_ATTR_FIELD(axis).describe(
+        "What axis the windows begin forming over."
+        "Windows will be formed over this axis and all following axes."
+        "The axis value determines the window shape (and thus, the"
+        "number of strides):"
+        "window shape and strides must both be of length"
+        "`data.ndim-axis`.");
+    TVM_ATTR_FIELD(window_shape)
+        .describe(
+            "The window shape to form over the input."
+            "Window shape must be of length `data.ndim-axis`.");
+    TVM_ATTR_FIELD(strides).describe(
+        "How to stride the window along each dimension."
+        "Strides must be of length `data.ndim-axis`.");
+  }
+};  // struct WindowsAttrs
+
 /*! \brief data type cast */
 struct CastAttrs : public tvm::AttrsNode<CastAttrs> {
   DataType dtype;

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -33,15 +33,15 @@
 namespace tvm {
 namespace relay {
 
-/*! \brief Attributes used for the windows operator */
-struct WindowsAttrs : public tvm::AttrsNode<WindowsAttrs> {
+/*! \brief Attributes used for the sliding_window operator */
+struct SlidingWindowAttrs : public tvm::AttrsNode<SlidingWindowAttrs> {
   int axis;
   Array<Integer> window_shape;
   Array<Integer> strides;
-  TVM_DECLARE_ATTRS(WindowsAttrs, "relay.attrs.WindowsAttrs") {
+  TVM_DECLARE_ATTRS(SlidingWindowAttrs, "relay.attrs.SlidingWindowAttrs") {
     TVM_ATTR_FIELD(axis).describe(
-        "What axis the windows begin forming over."
-        "Windows will be formed over this axis and all following axes."
+        "What axis the sliding window begin forming over."
+        "Window will be slid over this axis and all following axes."
         "The axis value determines the window shape (and thus, the"
         "number of strides):"
         "window shape and strides must both be of length"
@@ -54,7 +54,7 @@ struct WindowsAttrs : public tvm::AttrsNode<WindowsAttrs> {
         "How to stride the window along each dimension."
         "Strides must be of length `data.ndim-axis`.");
   }
-};  // struct WindowsAttrs
+};  // struct SlidingWindowAttrs
 
 /*! \brief data type cast */
 struct CastAttrs : public tvm::AttrsNode<CastAttrs> {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -66,7 +66,6 @@ using namespace topi::detail;
  */
 inline Tensor windows(const Tensor& x, int axis, Array<Integer> window_shape,
                       Array<Integer> strides, std::string name = "T_windows",
-                      // TODO(@gussmith23) what to tag it?
                       std::string tag = "") {
   ICHECK(axis <= 0);
   auto _axis = size_t(axis);

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -67,12 +67,12 @@ using namespace topi::detail;
 inline Tensor windows(const Tensor& x, int axis, Array<Integer> window_shape,
                       Array<Integer> strides, std::string name = "T_windows",
                       std::string tag = "") {
-  ICHECK(axis <= 0);
+  CHECK(axis <= 0);
   auto _axis = size_t(axis);
-  ICHECK(_axis < x->shape.size()) << "axis must be a valid dimension index of x.";
-  ICHECK(x->shape.size() - _axis == window_shape.size())
+  CHECK(_axis < x->shape.size()) << "axis must be a valid dimension index of x.";
+  CHECK(x->shape.size() - _axis == window_shape.size())
       << "There must be a window shape for every dimension of x over which we are forming windows.";
-  ICHECK(strides.size() == window_shape.size()) << "Windows and strides should be the same length.";
+  CHECK(strides.size() == window_shape.size()) << "Windows and strides should be the same length.";
 
   // Compute the new shape.
   Array<PrimExpr> new_shape;
@@ -104,8 +104,6 @@ inline Tensor windows(const Tensor& x, int axis, Array<Integer> window_shape,
   return compute(
       new_shape,
       [&](const Array<Var>& indices) {
-        ICHECK(indices.size() == _axis + 2 * window_shape.size());
-
         // The index at which to index the old tensor x.
         Array<PrimExpr> idx;
 

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -67,12 +67,12 @@ using namespace topi::detail;
 inline Tensor windows(const Tensor& x, int axis, Array<Integer> window_shape,
                       Array<Integer> strides, std::string name = "T_windows",
                       std::string tag = "") {
-  CHECK(axis <= 0);
+  CHECK_GE(axis, 0);
   auto _axis = size_t(axis);
-  CHECK(_axis < x->shape.size()) << "axis must be a valid dimension index of x.";
-  CHECK(x->shape.size() - _axis == window_shape.size())
+  CHECK_LT(_axis, x->shape.size()) << "axis must be a valid dimension index of x.";
+  CHECK_EQ(x->shape.size() - _axis, window_shape.size())
       << "There must be a window shape for every dimension of x over which we are forming windows.";
-  CHECK(strides.size() == window_shape.size()) << "Windows and strides should be the same length.";
+  CHECK_EQ(strides.size(), window_shape.size()) << "Windows and strides should be the same length.";
 
   // Compute the new shape.
   Array<PrimExpr> new_shape;

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -65,8 +65,8 @@ using namespace topi::detail;
  * \return A Tensor whose op member is the sliding_window operation
  */
 inline Tensor sliding_window(const Tensor& x, int axis, Array<Integer> window_shape,
-                      Array<Integer> strides, std::string name = "T_sliding_window",
-                      std::string tag = "") {
+                             Array<Integer> strides, std::string name = "T_sliding_window",
+                             std::string tag = "") {
   CHECK_GE(axis, 0);
   auto _axis = size_t(axis);
   CHECK_LT(_axis, x->shape.size()) << "axis must be a valid dimension index of x.";

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -48,10 +48,10 @@ using namespace tvm::te;
 using namespace topi::detail;
 
 /*!
- * \brief Creates an operation to form windows over the input x.
+ * \brief Creates an operation to slide a window over the input x.
  *
  * \param x The input tensor.
- * \param axis What axis the windows begin forming over. Windows will be formed
+ * \param axis What axis the window begins sliding over. Window will be slid
  * over this axis and all following axes. The axis value determines the window
  * shape (and thus, the number of strides): window shape and strides must both
  * be of length `data.ndim-axis`.
@@ -62,16 +62,16 @@ using namespace topi::detail;
  * \param name The name of the operation
  * \param tag The tag to mark the operation
  *
- * \return A Tensor whose op member is the windows operation
+ * \return A Tensor whose op member is the sliding_window operation
  */
-inline Tensor windows(const Tensor& x, int axis, Array<Integer> window_shape,
-                      Array<Integer> strides, std::string name = "T_windows",
+inline Tensor sliding_window(const Tensor& x, int axis, Array<Integer> window_shape,
+                      Array<Integer> strides, std::string name = "T_sliding_window",
                       std::string tag = "") {
   CHECK_GE(axis, 0);
   auto _axis = size_t(axis);
   CHECK_LT(_axis, x->shape.size()) << "axis must be a valid dimension index of x.";
   CHECK_EQ(x->shape.size() - _axis, window_shape.size())
-      << "There must be a window shape for every dimension of x over which we are forming windows.";
+      << "There must be a window shape for every dimension of x over which we are sliding the window.";
   CHECK_EQ(strides.size(), window_shape.size()) << "Windows and strides should be the same length.";
 
   // Compute the new shape.

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -71,7 +71,8 @@ inline Tensor sliding_window(const Tensor& x, int axis, Array<Integer> window_sh
   auto _axis = size_t(axis);
   CHECK_LT(_axis, x->shape.size()) << "axis must be a valid dimension index of x.";
   CHECK_EQ(x->shape.size() - _axis, window_shape.size())
-      << "There must be a window shape for every dimension of x over which we are sliding the window.";
+      << "There must be a window shape for every dimension of x "
+      << "over which we are sliding the window.";
   CHECK_EQ(strides.size(), window_shape.size()) << "Windows and strides should be the same length.";
 
   // Compute the new shape.

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -70,6 +70,15 @@ _reg.register_injective_schedule("adv_index")
 # concatenate
 _reg.register_schedule("concatenate", strategy.schedule_concatenate)
 
+# windows
+@_reg.register_compute("windows")
+def compute_windows(attrs, inputs, output_type):
+    """Compute definition of windows"""
+    return [topi.windows(inputs[0], attrs.axis, attrs.window_shape, attrs.strides)]
+
+
+_reg.register_strategy("windows", strategy.windows_strategy)
+
 # strided_set
 @_reg.register_compute("strided_set")
 def compute_strided_set(attrs, inputs, output_type):

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -70,14 +70,14 @@ _reg.register_injective_schedule("adv_index")
 # concatenate
 _reg.register_schedule("concatenate", strategy.schedule_concatenate)
 
-# windows
-@_reg.register_compute("windows")
-def compute_windows(attrs, inputs, output_type):
-    """Compute definition of windows"""
-    return [topi.windows(inputs[0], attrs.axis, attrs.window_shape, attrs.strides)]
+# sliding_window
+@_reg.register_compute("sliding_window")
+def compute_sliding_window(attrs, inputs, output_type):
+    """Compute definition of sliding_window"""
+    return [topi.sliding_window(inputs[0], attrs.axis, attrs.window_shape, attrs.strides)]
 
 
-_reg.register_strategy("windows", strategy.windows_strategy)
+_reg.register_strategy("sliding_window", strategy.sliding_window_strategy)
 
 # strided_set
 @_reg.register_compute("strided_set")

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1662,6 +1662,28 @@ def uniform_strategy(attrs, inputs, out_type, target):
     return strategy
 
 
+# windows
+def wrap_compute_windows():
+    """Wrap windows topi compute"""
+
+    def _compute_windows(attrs, inputs, _):
+        return [topi.windows(inputs[0], attrs.axis, attrs.window_shape, attrs.strides)]
+
+    return _compute_windows
+
+
+@override_native_generic_func("windows_strategy")
+def windows_strategy(attrs, inputs, out_type, target):
+    """windows generic strategy"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_windows(),
+        wrap_topi_schedule(topi.generic.schedule_extern),
+        name="windows.generic",
+    )
+    return strategy
+
+
 @override_native_generic_func("normal_strategy")
 def normal_strategy(attrs, inputs, out_type, target):
     """normal generic strategy"""

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1662,24 +1662,24 @@ def uniform_strategy(attrs, inputs, out_type, target):
     return strategy
 
 
-# windows
-def wrap_compute_windows():
-    """Wrap windows topi compute"""
+# sliding_window
+def wrap_compute_sliding_window():
+    """Wrap sliding_window topi compute"""
 
-    def _compute_windows(attrs, inputs, _):
-        return [topi.windows(inputs[0], attrs.axis, attrs.window_shape, attrs.strides)]
+    def _compute_sliding_window(attrs, inputs, _):
+        return [topi.sliding_window(inputs[0], attrs.axis, attrs.window_shape, attrs.strides)]
 
-    return _compute_windows
+    return _compute_sliding_window
 
 
-@override_native_generic_func("windows_strategy")
-def windows_strategy(attrs, inputs, out_type, target):
-    """windows generic strategy"""
+@override_native_generic_func("sliding_window_strategy")
+def sliding_window_strategy(attrs, inputs, out_type, target):
+    """sliding_window generic strategy"""
     strategy = _op.OpStrategy()
     strategy.add_implementation(
-        wrap_compute_windows(),
+        wrap_compute_sliding_window(),
         wrap_topi_schedule(topi.generic.schedule_extern),
-        name="windows.generic",
+        name="sliding_window.generic",
     )
     return strategy
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -25,6 +25,63 @@ from .dyn import _make as _dyn_make
 from .tensor import shape_of
 
 
+def windows(data, axis, window_shape, strides):
+    """Form windows over the data tensor.
+
+    Parameters
+    ----------
+    data : relay.Expr
+        The input data to the operator.
+
+    axis : int
+        What axis the windows begin forming over. Windows will be formed over
+        this axis and all following axes. The axis value determines the window
+        shape (and thus, the number of strides): window shape and strides must
+        both be of length `data.ndim-axis`.
+
+    window_shape : List[int]
+        The window shape to form over the input. Window shape must be of length
+        `data.ndim-axis`.
+
+    strides : List[int]
+        How to stride the window along each dimension. Strides must be of length
+        `data.ndim-axis`.
+
+    Returns
+    -------
+    result : relay.Expr
+        The resulting tensor.
+
+    Examples
+    --------
+    .. code-block:: python
+        # Slide a window of shape (3, 4, 5) over the x tensor, beginning with
+        # dimension 1, which slides the window over the two subtensors of
+        # shape (3, 32, 32).
+        x = relay.var("x", relay.TensorType((2, 3, 32, 32), "float32"))
+        y = relay.windows(x, 1, [3, 4, 5], [1, 2, 3])
+
+        data = np.random.rand(2, 3, 32, 32).astype("float32")
+        result = create_executor().evaluate(y, {x: relay.const(data)}).numpy()
+
+        # The resulting shape still has batch size 2. Each dimension in
+        # (1, 15, 10) represents the locations where we were able to
+        # form a window; that is, we were able to place the window
+        # in one place along the dimension of length 3, 15 places along
+        # the dimension of length 32 (when striding by 2), and 10 places
+        # along the second dimension of length 32 (when striding by 3).
+        # The remaining dimension (3, 4, 5) represent the formed windows.
+        assert result.shape == (2, 1, 15, 10, 3, 4, 5)
+
+        assert np.array_equal(result[0, 0, 0, 0, :, :, :], data[0, :, 0:4, 0:5])
+        assert np.array_equal(result[1, 0, 7, 3, :, :, :], data[1, :, 14:18, 9:14])
+        assert np.array_equal(result[1, 0, 14, 9, :, :, :], data[1, :, 28:32, 27:32])
+    """
+    from .. import _ffi_api as _relay_make
+
+    return _relay_make.windows(data, axis, window_shape, strides)
+
+
 def cast(data, dtype):
     """Cast input tensor to data type.
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -55,6 +55,7 @@ def windows(data, axis, window_shape, strides):
     Examples
     --------
     .. code-block:: python
+
         # Slide a window of shape (3, 4, 5) over the x tensor, beginning with
         # dimension 1, which slides the window over the two subtensors of
         # shape (3, 32, 32).

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -25,8 +25,8 @@ from .dyn import _make as _dyn_make
 from .tensor import shape_of
 
 
-def windows(data, axis, window_shape, strides):
-    """Form windows over the data tensor.
+def sliding_window(data, axis, window_shape, strides):
+    """Slide a window over the data tensor.
 
     Parameters
     ----------
@@ -34,7 +34,7 @@ def windows(data, axis, window_shape, strides):
         The input data to the operator.
 
     axis : int
-        What axis the windows begin forming over. Windows will be formed over
+        What axis the window begins sliding over. Window will be slid over
         this axis and all following axes. The axis value determines the window
         shape (and thus, the number of strides): window shape and strides must
         both be of length `data.ndim-axis`.
@@ -60,7 +60,7 @@ def windows(data, axis, window_shape, strides):
         # dimension 1, which slides the window over the two subtensors of
         # shape (3, 32, 32).
         x = relay.var("x", relay.TensorType((2, 3, 32, 32), "float32"))
-        y = relay.windows(x, 1, [3, 4, 5], [1, 2, 3])
+        y = relay.sliding_window(x, 1, [3, 4, 5], [1, 2, 3])
 
         data = np.random.rand(2, 3, 32, 32).astype("float32")
         result = create_executor().evaluate(y, {x: relay.const(data)}).numpy()
@@ -80,7 +80,7 @@ def windows(data, axis, window_shape, strides):
     """
     from .. import _ffi_api as _relay_make
 
-    return _relay_make.windows(data, axis, window_shape, strides)
+    return _relay_make.sliding_window(data, axis, window_shape, strides)
 
 
 def cast(data, dtype):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -51,31 +51,6 @@ def windows(data, axis, window_shape, strides):
     -------
     result : relay.Expr
         The resulting tensor.
-
-    Examples
-    --------
-    .. code-block:: python
-        # Slide a window of shape (3, 4, 5) over the x tensor, beginning with
-        # dimension 1, which slides the window over the two subtensors of
-        # shape (3, 32, 32).
-        x = relay.var("x", relay.TensorType((2, 3, 32, 32), "float32"))
-        y = relay.windows(x, 1, [3, 4, 5], [1, 2, 3])
-
-        data = np.random.rand(2, 3, 32, 32).astype("float32")
-        result = create_executor().evaluate(y, {x: relay.const(data)}).numpy()
-
-        # The resulting shape still has batch size 2. Each dimension in
-        # (1, 15, 10) represents the locations where we were able to
-        # form a window; that is, we were able to place the window
-        # in one place along the dimension of length 3, 15 places along
-        # the dimension of length 32 (when striding by 2), and 10 places
-        # along the second dimension of length 32 (when striding by 3).
-        # The remaining dimension (3, 4, 5) represent the formed windows.
-        assert result.shape == (2, 1, 15, 10, 3, 4, 5)
-
-        assert np.array_equal(result[0, 0, 0, 0, :, :, :], data[0, :, 0:4, 0:5])
-        assert np.array_equal(result[1, 0, 7, 3, :, :, :], data[1, :, 14:18, 9:14])
-        assert np.array_equal(result[1, 0, 14, 9, :, :, :], data[1, :, 28:32, 27:32])
     """
     from .. import _ffi_api as _relay_make
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -51,6 +51,31 @@ def windows(data, axis, window_shape, strides):
     -------
     result : relay.Expr
         The resulting tensor.
+
+    Examples
+    --------
+    .. code-block:: python
+        # Slide a window of shape (3, 4, 5) over the x tensor, beginning with
+        # dimension 1, which slides the window over the two subtensors of
+        # shape (3, 32, 32).
+        x = relay.var("x", relay.TensorType((2, 3, 32, 32), "float32"))
+        y = relay.windows(x, 1, [3, 4, 5], [1, 2, 3])
+
+        data = np.random.rand(2, 3, 32, 32).astype("float32")
+        result = create_executor().evaluate(y, {x: relay.const(data)}).numpy()
+
+        # The resulting shape still has batch size 2. Each dimension in
+        # (1, 15, 10) represents the locations where we were able to
+        # form a window; that is, we were able to place the window
+        # in one place along the dimension of length 3, 15 places along
+        # the dimension of length 32 (when striding by 2), and 10 places
+        # along the second dimension of length 32 (when striding by 3).
+        # The remaining dimension (3, 4, 5) represent the formed windows.
+        assert result.shape == (2, 1, 15, 10, 3, 4, 5)
+
+        assert np.array_equal(result[0, 0, 0, 0, :, :, :], data[0, :, 0:4, 0:5])
+        assert np.array_equal(result[1, 0, 7, 3, :, :, :], data[1, :, 14:18, 9:14])
+        assert np.array_equal(result[1, 0, 14, 9, :, :, :], data[1, :, 28:32, 27:32])
     """
     from .. import _ffi_api as _relay_make
 

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -971,3 +971,33 @@ def invert_permutation(data):
         r_ind = data[ind]
         result[r_ind] = ind
     return result
+
+
+def windows(data, axis, window_shape, strides):
+    """Form windows over the data tensor.
+
+    Parameters
+    ----------
+    data : relay.Expr
+        The input data to the operator.
+
+    axis : int
+        What axis the windows begin forming over. Windows will be formed over
+        this axis and all following axes. The axis value determines the window
+        shape (and thus, the number of strides): window shape and strides must
+        both be of length `data.ndim-axis`.
+
+    window_shape : List[int]
+        The window shape to form over the input. Window shape must be of length
+        `data.ndim-axis`.
+
+    strides : List[int]
+        How to stride the window along each dimension. Strides must be of length
+        `data.ndim-axis`.
+
+    Returns
+    -------
+    result : relay.Expr
+        The resulting tensor.
+    """
+    return cpp.windows(data, axis, window_shape, strides)

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -973,8 +973,8 @@ def invert_permutation(data):
     return result
 
 
-def windows(data, axis, window_shape, strides):
-    """Form windows over the data tensor.
+def sliding_window(data, axis, window_shape, strides):
+    """Slide a window over the data tensor.
 
     Parameters
     ----------
@@ -982,7 +982,7 @@ def windows(data, axis, window_shape, strides):
         The input data to the operator.
 
     axis : int
-        What axis the windows begin forming over. Windows will be formed over
+        What axis the window begins sliding over. Window will be slid over
         this axis and all following axes. The axis value determines the window
         shape (and thus, the number of strides): window shape and strides must
         both be of length `data.ndim-axis`.
@@ -1000,4 +1000,4 @@ def windows(data, axis, window_shape, strides):
     result : relay.Expr
         The resulting tensor.
     """
-    return cpp.windows(data, axis, window_shape, strides)
+    return cpp.sliding_window(data, axis, window_shape, strides)

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -59,8 +59,9 @@ bool WindowsRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   ICHECK_EQ(types.size(), 2);
   const auto* data = types[0].as<TensorTypeNode>();
   if (data == nullptr) {
-    ICHECK(types[0].as<IncompleteTypeNode>())
-        << "windows: expect input type to be TensorType but get " << types[0];
+    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
+                                     << "Windows operator expects input to be of TensorType "
+                                     << "but got " << PrettyPrint(types[0]));
     return false;
   }
   const auto* param = attrs.as<WindowsAttrs>();

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -54,7 +54,7 @@ using tir::IntImmNode;
 TVM_REGISTER_NODE_TYPE(SlidingWindowAttrs);
 
 bool SlidingWindowRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
-                const TypeReporter& reporter) {
+                      const TypeReporter& reporter) {
   // `types` contains: [data, result]
   ICHECK_EQ(types.size(), 2);
   const auto* data = types[0].as<TensorTypeNode>();
@@ -97,7 +97,7 @@ bool SlidingWindowRel(const Array<Type>& types, int num_inputs, const Attrs& att
 }
 
 Array<te::Tensor> SlidingWindowCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
-                                 const Type& out_type) {
+                                       const Type& out_type) {
   const SlidingWindowAttrs* param = attrs.as<SlidingWindowAttrs>();
   ICHECK(param != nullptr);
   return {topi::sliding_window(inputs[0], param->axis, param->window_shape, param->strides)};

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -51,6 +51,76 @@ namespace tvm {
 namespace relay {
 using tir::IntImmNode;
 
+TVM_REGISTER_NODE_TYPE(WindowsAttrs);
+
+bool WindowsRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+                const TypeReporter& reporter) {
+  // `types` contains: [data, result]
+  ICHECK_EQ(types.size(), 2);
+  const auto* data = types[0].as<TensorTypeNode>();
+  if (data == nullptr) {
+    ICHECK(types[0].as<IncompleteTypeNode>())
+        << "windows: expect input type to be TensorType but get " << types[0];
+    return false;
+  }
+  const auto* param = attrs.as<WindowsAttrs>();
+  const int axis = param->axis;
+
+  std::vector<IndexExpr> oshape;
+
+  // Dimensions up until `axis` remain the same.
+  for (int i = 0; i < axis; ++i) {
+    oshape.emplace_back(data->shape[i]);
+  }
+
+  // New dimensions which result from sliding the window in each dimension. One new dimension per
+  // window dimension.
+  for (size_t i = 0; i < param->window_shape.size(); ++i) {
+    // Length of the shape along this dimension.
+    auto dim_len = data->shape[axis + i];
+    // Length of the window along this dimension.
+    auto window_len = param->window_shape[i];
+    // Strides along this dimension.
+    auto stride = param->strides[i];
+
+    oshape.push_back(floordiv(dim_len - (window_len - 1) + stride - 1, stride));
+  }
+
+  // Dimensions comprising the window.
+  for (size_t i = 0; i < param->window_shape.size(); ++i) {
+    oshape.push_back(param->window_shape[i]);
+  }
+
+  reporter->Assign(types[1], TensorType(oshape, data->dtype));
+  return true;
+}
+
+Array<te::Tensor> WindowsCompute(const Attrs& attrs, const Array<te::Tensor>& inputs,
+                                 const Type& out_type) {
+  const WindowsAttrs* param = attrs.as<WindowsAttrs>();
+  ICHECK(param != nullptr);
+  return {topi::windows(inputs[0], param->axis, param->window_shape, param->strides)};
+}
+
+Expr MakeWindows(Expr data, int axis, Array<Integer> window_shape, Array<Integer> strides) {
+  auto attrs = make_object<WindowsAttrs>();
+  attrs->axis = axis;
+  attrs->window_shape = window_shape;
+  attrs->strides = strides;
+  static const Op& op = Op::Get("windows");
+  return Call(op, {data}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relay.ir.windows").set_body_typed(MakeWindows);
+
+RELAY_REGISTER_OP("windows")
+    .describe(R"code(Form windows over a tensor.)code" TVM_ADD_FILELINE)
+    .set_num_inputs(1)
+    .set_attrs_type<WindowsAttrs>()
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_type_rel("Windows", WindowsRel)
+    .set_attr<TOpPattern>("TOpPattern", kOpaque);
+
 // relay.cast
 TVM_REGISTER_NODE_TYPE(CastAttrs);
 

--- a/src/topi/transform.cc
+++ b/src/topi/transform.cc
@@ -54,6 +54,10 @@ TVM_REGISTER_GLOBAL("topi.reshape").set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = reshape(args[0], args[1]);
 });
 
+TVM_REGISTER_GLOBAL("topi.windows").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = windows(args[0], args[1], args[2], args[3]);
+});
+
 TVM_REGISTER_GLOBAL("topi.squeeze").set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = squeeze(args[0], ArrayOrInt(args[1]));
 });

--- a/src/topi/transform.cc
+++ b/src/topi/transform.cc
@@ -54,8 +54,8 @@ TVM_REGISTER_GLOBAL("topi.reshape").set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = reshape(args[0], args[1]);
 });
 
-TVM_REGISTER_GLOBAL("topi.windows").set_body([](TVMArgs args, TVMRetValue* rv) {
-  *rv = windows(args[0], args[1], args[2], args[3]);
+TVM_REGISTER_GLOBAL("topi.sliding_window").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = sliding_window(args[0], args[1], args[2], args[3]);
 });
 
 TVM_REGISTER_GLOBAL("topi.squeeze").set_body([](TVMArgs args, TVMRetValue* rv) {

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -92,8 +92,18 @@ def test_cast():
 
 
 def test_windows():
+    # Slide a window of shape (3, 4, 5) over the x tensor, beginning with
+    # dimension 1, which slides the window over the two subtensors of shape (3,
+    # 32, 32).
     x = relay.var("x", relay.TensorType((2, 3, 32, 32), "float32"))
     y = relay.windows(x, 1, [3, 4, 5], [1, 2, 3])
+
+    # The resulting shape still has batch size 2. Each dimension in (1, 15, 10)
+    # represents the locations where we were able to form a window; that is, we
+    # were able to place the window in one place along the dimension of length
+    # 3, 15 places along the dimension of length 32 (when striding by 2), and 10
+    # places along the second dimension of length 32 (when striding by 3). The
+    # remaining dimensions (3, 4, 5) represent the formed windows.
     yy = run_infer_type(y)
     assert yy.checked_type == relay.TensorType((2, 1, 15, 10, 3, 4, 5), "float32")
 

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -91,12 +91,12 @@ def test_cast():
     assert yy.checked_type == relay.TensorType((8, 9, 4), "int32")
 
 
-def test_windows():
+def test_sliding_window():
     # Slide a window of shape (3, 4, 5) over the x tensor, beginning with
     # dimension 1, which slides the window over the two subtensors of shape (3,
     # 32, 32).
     x = relay.var("x", relay.TensorType((2, 3, 32, 32), "float32"))
-    y = relay.windows(x, 1, [3, 4, 5], [1, 2, 3])
+    y = relay.sliding_window(x, 1, [3, 4, 5], [1, 2, 3])
 
     # The resulting shape still has batch size 2. Each dimension in (1, 15, 10)
     # represents the locations where we were able to form a window; that is, we


### PR DESCRIPTION
Adds the windows operator, which slides a window over a tensor to produce a new tensor of all possible windows. This is an essential operation for implementing the `im2col` transformation, which transforms a conv2d into a matrix multiplication by constructing the windows over the activation tensor and storing them explicitly in memory.

This is the first time I've added an operator to TVM, so please let me know if I've missed anything. I am also happy to spend more time adding more tests and documentation.