### PR TITLE
[CUTLASS] Residual connection fusion

### DIFF
--- a/python/tvm/contrib/cutlass/library.py
+++ b/python/tvm/contrib/cutlass/library.py
@@ -151,6 +151,7 @@ class EpilogueFunctor(enum.Enum):
     LinearCombinationSigmoid = enum_auto()
     LinearCombinationSilu = enum_auto()
     LinearCombinationHardSwish = enum_auto()
+    LinearCombinationResidualBlock = enum_auto()
 
 
 EpilogueFunctorTag = {
@@ -161,6 +162,7 @@ EpilogueFunctorTag = {
     EpilogueFunctor.LinearCombinationSigmoid: "cutlass::epilogue::thread::LinearCombinationSigmoid",
     EpilogueFunctor.LinearCombinationSilu: "cutlass::epilogue::thread::LinearCombinationSilu",
     EpilogueFunctor.LinearCombinationHardSwish: "cutlass::epilogue::thread::LinearCombinationHardSwish",
+    EpilogueFunctor.LinearCombinationResidualBlock: "cutlass::epilogue::thread::LinearCombinationResidualBlock",
 }
 
 

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -338,15 +338,9 @@ std::string Conv2dOp(std::string id, const Str2StrMap& attrs,
                "TensorNHWC layout_B(TensorNHWC::packed(cutlass::make_Coord(K, R, S, C)));\n");
 
   if (has_residual_block) {
-    if (attrs.at("P") == attrs.at("residual_H") && attrs.at("Q") == attrs.at("residual_W")) {
-      CutlassPrint(conv2d_decl,
-                   "TensorNHWC layout_C(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");
-    } else {
-      ICHECK(attrs.at("residual_H") == "1" && attrs.at("residual_W") == "1");
-      // Handle broadcast ops (MobilenetV3 and EfficientNetV2) in a residual block-like pattern
-      CutlassPrint(conv2d_decl, "// Broadcast in a residual block \n");
-      CutlassPrint(conv2d_decl, "TensorNHWC layout_C(TensorNHWC(0, 0, K));\n\n");
-    }
+    ICHECK(attrs.at("P") == attrs.at("residual_H") && attrs.at("Q") == attrs.at("residual_W"));
+    CutlassPrint(conv2d_decl,
+                 "TensorNHWC layout_C(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");
   } else {
     CutlassPrint(conv2d_decl,
                  "TensorNHWC layout_C(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -254,13 +254,6 @@ Str2StrMap Conv2dArgs(const Map<String, ObjectRef>& attrs) {
   args["stride_w"] = GetDimAsStr(attrs["strides"].as<ArrayNode>()->at(1));
   args["dilation_h"] = GetDimAsStr(attrs["dilation"].as<ArrayNode>()->at(0));
   args["dilation_w"] = GetDimAsStr(attrs["dilation"].as<ArrayNode>()->at(1));
-
-  if (attrs.find("arg3_shape") != attrs.end()) {
-    auto arg3_shape = attrs["arg3_shape"].as<ArrayNode>();
-    args["residual_N"] = GetDimAsStr(arg3_shape->at(0));
-    args["residual_H"] = GetDimAsStr(arg3_shape->at(1));
-    args["residual_W"] = GetDimAsStr(arg3_shape->at(2));
-  }
   return args;
 }
 
@@ -336,16 +329,8 @@ std::string Conv2dOp(std::string id, const Str2StrMap& attrs,
                "TensorNHWC layout_A(TensorNHWC::packed(cutlass::make_Coord(N, H, W, C)));\n");
   CutlassPrint(conv2d_decl,
                "TensorNHWC layout_B(TensorNHWC::packed(cutlass::make_Coord(K, R, S, C)));\n");
-
-  if (has_residual_block) {
-    ICHECK(attrs.at("P") == attrs.at("residual_H") && attrs.at("Q") == attrs.at("residual_W"));
-    CutlassPrint(conv2d_decl,
-                 "TensorNHWC layout_C(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");
-  } else {
-    CutlassPrint(conv2d_decl,
-                 "TensorNHWC layout_C(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");
-  }
-
+  CutlassPrint(conv2d_decl,
+               "TensorNHWC layout_C(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");
   CutlassPrint(conv2d_decl,
                "TensorNHWC layout_D(TensorNHWC::packed(cutlass::make_Coord(N, P, Q, K)));\n\n");
 

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -406,9 +406,10 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
 
 /*!
  * \brief Retrieve the "root" op nested inside a fused call, such as conv2d in relu(add(conv2d))
+ * Unlike the previous definition, it does not verify operator names of intermediate nodes. Instead,
+ * it recursively visit child nodes until it finds a call node with the given op_name.
  * \param call A Relay call node.
- * \param op_name The name of an op to look for.
- * "nn.relu"}
+ * \param op_name The name of an op to look for, such as ""nn.conv2d".
  * \return A CallNode corresponding to the root op with the given op_name
  */
 inline const CallNode* GetRootCall(const CallNode* current_call, const std::string& op_name) {

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -389,7 +389,6 @@ inline bool IsOp(const CallNode* call, const std::string& op_name) {
  * "nn.relu"}
  * \return A CallNode corresponding to the root op, whose name is expected_op_names[0]
  */
-
 inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
                                    const std::vector<std::string>& expected_op_names) {
   ICHECK(current_call && depth >= 0 && static_cast<size_t>(depth) < expected_op_names.size() &&
@@ -403,6 +402,23 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
 
   const auto* next_call = current_call->args[0].as<CallNode>();
   return GetRootCall(next_call, depth - 1, expected_op_names);
+}
+
+/*!
+ * \brief Retrieve the "root" op nested inside a fused call, such as conv2d in relu(add(conv2d))
+ * \param call A Relay call node.
+ * \param op_name The name of an op to look for.
+ * "nn.relu"}
+ * \return A CallNode corresponding to the root op with the given op_name
+ */
+inline const CallNode* GetRootCall(const CallNode* current_call, const std::string& op_name) {
+  if (current_call == nullptr) return nullptr;
+  if (IsOp(current_call, op_name)) return current_call;
+
+  ICHECK_GT(current_call->args.size(), 0);
+
+  const auto* next_call = current_call->args[0].as<CallNode>();
+  return GetRootCall(next_call, op_name);
 }
 
 /*!


### PR DESCRIPTION
This adds support for fusing a residual block of the form `UnaryOp(BinaryOp(ActivationOp(TensorOp(X) + bias), residual))` into one cutlass kernel, which I thought was not possible until recently. As discussed in https://github.com/NVIDIA/cutlass/discussions/347#discussioncomment-1830989, it turns out that [one of cutlass conv2d kernels](https://github.com/NVIDIA/cutlass/blob/master/include/cutlass/conv/kernel/implicit_gemm_convolution_with_fused_epilogue.h#L61) already supports computing `elementwise(alpha x conv + beta x C + per_channel_bias)`. With [a little tweak](https://github.com/NVIDIA/cutlass/pull/391) (or one might say it is an abuse of the intended API usage), it is possible to support fully general residual blocks found in deep learning models.

As expected, this brings good speedup on resnet based models (resnet50 and DETR-R50 below). On other models, speedup is modest or it even becomes worse (`deeplabv3`, strange result, haven't looked into what's going on).

@comaniac @Laurawly  @hwu36 

Model name | Input size | CUTLASS with activation fusion only | CUTLASS with activation + residual block fusion | cuDNN 
-- | -- | -- | -- | --
resnet50   | (8, 3, 224, 224) | 3.16 |2.76 |4.08|  4.14 
efficientnet_v2 | (8, 3, 224, 224) | 8.05 | 7.87| 14.0 
DETR-R50            | (8, 3, 800, 750) | 57.19 | 51.6 | 68.4 
deeplabv3_mobilenet_v3_large | (8, 3, 512, 512) | 9.16 | 9.68 (?) | 17.5 
YOLOv5l         |  (8, 3, 512, 512)| 25.4 | 24.2 | 34.8
