### PR TITLE
Fix reduce NCHWc infer layout (do not keep reduced inner c when keepdims=false)

### DIFF
--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -176,7 +176,7 @@ InferCorrectLayoutOutput ReduceInferCorrectLayout(const Attrs& attrs,
           if (params->exclude) {
             // The primal axis is not reduced, so keep the input packed dim.
             inferred_out_string += packed_dim;
-          } else {
+	  } else if (params->keepdims) {
             // If the primal axis is part of reduce axes in the original layout, the inner dim
             // becomes 1 after reduction.
             inferred_out_string += "1" + layout_dim;

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -176,7 +176,7 @@ InferCorrectLayoutOutput ReduceInferCorrectLayout(const Attrs& attrs,
           if (params->exclude) {
             // The primal axis is not reduced, so keep the input packed dim.
             inferred_out_string += packed_dim;
-	  } else if (params->keepdims) {
+          } else if (params->keepdims) {
             // If the primal axis is part of reduce axes in the original layout, the inner dim
             // becomes 1 after reduction.
             inferred_out_string += "1" + layout_dim;

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -24,6 +24,7 @@ from tvm.relay.testing.temp_op_attr import TempOpAttr
 from tvm.relay.testing import run_infer_type
 import numpy as np
 import tvm.testing
+from tvm.relay import testing
 
 
 def run_opt_pass(expr, passes):
@@ -1450,6 +1451,22 @@ def test_conv2d_strided_slice_packed_to_unpacked():
         a = run_opt_pass(before(), transform.AlterOpLayout())
         b = run_opt_pass(expected(), transform.InferType())
         assert tvm.ir.structural_equal(a, b)
+
+
+def test_conv2d_reduce_channels():
+    x = relay.var("data", shape=(1, 8, 48, 48))
+    y = relay.nn.conv2d(data=x,
+                        weight=relay.var("weight"),
+                        kernel_size=(1, 1),
+                        channels=8,
+                        dilation=1,
+                        strides=(47, 47))
+    z = relay.argmin(y, axis=1)
+
+    mod, params = testing.create_workload(z)
+
+    with tvm.transform.PassContext(opt_level=3):
+        relay.build(mod, params=params, target="llvm")
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1455,12 +1455,14 @@ def test_conv2d_strided_slice_packed_to_unpacked():
 
 def test_conv2d_reduce_channels():
     x = relay.var("data", shape=(1, 8, 48, 48))
-    y = relay.nn.conv2d(data=x,
-                        weight=relay.var("weight"),
-                        kernel_size=(1, 1),
-                        channels=8,
-                        dilation=1,
-                        strides=(47, 47))
+    y = relay.nn.conv2d(
+        data=x,
+        weight=relay.var("weight"),
+        kernel_size=(1, 1),
+        channels=8,
+        dilation=1,
+        strides=(47, 47),
+    )
     z = relay.argmin(y, axis=1)
 
     mod, params = testing.create_workload(z)


### PR DESCRIPTION
Closes https://github.com/apache/tvm/issues/9813

The error happened at https://github.com/apache/tvm/blob/813136401a11a49d6c15e6013c34dd822a5c4ff6/src/tir/ir/data_layout.cc#L140-L141 where it checks for the presence of the "primal" axis `C` when it finds a "non-primal" axis `c`. In the test case in https://github.com/apache/tvm/issues/9813, the reduction is over the channel dimension, so the `C` axis would be gone unless `keepdims = True`. But `ReduceInferCorrectLayout` had a bug where it always preserved the inner `1c` when the reduction is over the channel dimension. This resulted in an invalid layout `NHW1c`. 

@ganler @comaniac 