### PR TITLE
[Docker] Pin sphinx version to workaround sphinx-gallery bug

### DIFF
--- a/docker/install/ubuntu_install_redis.sh
+++ b/docker/install/ubuntu_install_redis.sh
@@ -23,4 +23,4 @@ set -o pipefail
 apt-get update && apt-get install -y redis-server
 pip3 install \
     psutil \
-    "xgboost>=1.1.0"
+    xgboost==1.4.2

--- a/docker/install/ubuntu_install_sphinx.sh
+++ b/docker/install/ubuntu_install_sphinx.sh
@@ -27,7 +27,7 @@ pip3 install \
     "docutils>=0.11,<0.17" \
     Image \
     matplotlib \
-    sphinx \
+    sphinx==4.2.0 \
     sphinx_autodoc_annotation \
     sphinx-gallery==0.4.0 \
     sphinx_rtd_theme


### PR DESCRIPTION
I'm working on an CI update and getting this strange error during `./tests/scripts/task_sphinx_precheck.sh`
```
embedding documentation hyperlinks...
WARNING: The following HTTP Error has occurred fetching https://numpy.org/doc/stable/: 403 Forbidden
embedding documentation hyperlinks for tutorial... [  8%] tensor_ir_blitz_course.html

Extension error (sphinx_gallery.docs_resolv):
Handler <function embed_code_links at 0x7fa541df5f28> for event 'build-finished' threw an exception (exception: list indices must be integers or slices, not str)
Makefile:110: recipe for target 'html' failed
make: *** [html] Error 2
script returned exit code 2
```
https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/187/pipeline/267/

Apparently, this is a known issue https://github.com/sphinx-gallery/sphinx-gallery/issues/879. We should pin the sphinx version to `4.2.0` to avoid the problem with `4.3.0` + `sphinx-gallery==0.4.0`. Upgrading `sphinx-gallery` would also work but I was told that that would require upgrading Python to 3.7 or newer.

Also pins xgb to suppress a warning from `coremltools` during `task_sphinx_precheck.sh`.
```
WARNING:root:XGBoost version 1.5.1 has not been tested with coremltools. You may run into unexpected errors. XGBoost 1.4.2 is the most recent version that has been tested.
```

@driazati @areusch @leandron 