### PR TITLE
Attempt to prevent concurrent update in Map

### DIFF
--- a/include/tvm/runtime/container/map.h
+++ b/include/tvm/runtime/container/map.h
@@ -29,7 +29,6 @@
 #endif
 
 #include <algorithm>
-#include <atomic>
 #include <unordered_map>
 #include <utility>
 
@@ -306,7 +305,7 @@ class MapNode : public Object {
 
  protected:
 #if TVM_LOG_DEBUG
-  std::atomic<uint64_t> state_marker;
+  uint64_t state_marker;
 #endif  // TVM_LOG_DEBUG
   /*!
    * \brief Create the map using contents from the given iterators.

--- a/tests/cpp/container_test.cc
+++ b/tests/cpp/container_test.cc
@@ -380,6 +380,19 @@ TEST(Map, Erase) {
   }
 }
 
+TEST(Map, Race) {
+  using namespace tvm::runtime;
+  Map<Integer, Integer> m;
+
+  m.Set(1, 1);
+  Map<tvm::Integer, tvm::Integer>::iterator it = m.begin();
+  EXPECT_NO_THROW({ auto& kv = *it; });
+
+  m.Set(2, 2);
+  // changed. iterator should be re-obtained
+  EXPECT_ANY_THROW({ auto& kv = *it; });
+}
+
 TEST(String, MoveFromStd) {
   using namespace std;
   string source = "this is a string";

--- a/tests/cpp/container_test.cc
+++ b/tests/cpp/container_test.cc
@@ -380,6 +380,7 @@ TEST(Map, Erase) {
   }
 }
 
+#if TVM_LOG_DEBUG
 TEST(Map, Race) {
   using namespace tvm::runtime;
   Map<Integer, Integer> m;
@@ -392,6 +393,7 @@ TEST(Map, Race) {
   // changed. iterator should be re-obtained
   EXPECT_ANY_THROW({ auto& kv = *it; });
 }
+#endif  // TVM_LOG_DEBUG
 
 TEST(String, MoveFromStd) {
   using namespace std;


### PR DESCRIPTION
Calling Map::Set invalidates existing iterators to protect from
using already deleted data due to re-hashing

Related to the issue fixed [here](https://github.com/apache/tvm/commit/6aa959028b94ab67621d81c6a7f7e5281e7376d3)