### PR TITLE
[AMP] Register some new ops

### DIFF
--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -28,6 +28,7 @@ MIXED_PRECISION_ALWAYS = 0
 MIXED_PRECISION_FOLLOW = 1
 MIXED_PRECISION_NEVER = 2
 
+
 # Default lists inspired from TF's classifications:
 # github.com/tensorflow/tensorflow/blob/v2.5.0/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
 # They have a bias toward Nvidia Tensor Cores so modify lists per your hardware choice.
@@ -65,6 +66,7 @@ DEFAULT_FOLLOW_LIST = [
     "scatter",
     "full",
     "dyn.full",
+    "nn.depth_to_space",
     # Comparison
     "less",
     "greater",
@@ -88,6 +90,8 @@ DEFAULT_FOLLOW_LIST = [
     "min",
     "maximum",
     "minimum",
+    "argmax",
+    "argmin",
     "nn.relu",
     "nn.leaky_relu",
     "nn.prelu",
@@ -95,6 +99,10 @@ DEFAULT_FOLLOW_LIST = [
     # Complicated activations which saturate in a narrow range
     "sigmoid",
     "tanh",
+    "fast_tanh",  # Some coefficients outside of representable range, but probably ok
+    "fast_exp",
+    "fast_erf",
+    "clip",  # Usually safe, my result in oddity if clip greater than fp16 range
     # Pooling operations
     "nn.max_pool1d",
     "nn.max_pool2d",
@@ -108,6 +116,7 @@ DEFAULT_FOLLOW_LIST = [
     "nn.adaptive_max_pool1d",
     "nn.adaptive_max_pool2d",
     "nn.adaptive_max_pool3d",
+    "image.resize2d",
 ]
 DEFAULT_NEVER_LIST = [
     # In general if |f(x)| >> |x| for expected inputs then put the op here.
@@ -133,7 +142,6 @@ DEFAULT_NEVER_LIST = [
     "variance",
     "nn.layer_norm",
 ]
-
 
 # Returns a decorator which registers for every given op, the function under FTVMMixedPrecisionConversionType
 def register_func_to_op_list(list_ops: List):

--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -28,7 +28,6 @@ MIXED_PRECISION_ALWAYS = 0
 MIXED_PRECISION_FOLLOW = 1
 MIXED_PRECISION_NEVER = 2
 
-
 # Default lists inspired from TF's classifications:
 # github.com/tensorflow/tensorflow/blob/v2.5.0/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
 # They have a bias toward Nvidia Tensor Cores so modify lists per your hardware choice.

--- a/python/tvm/relay/transform/mixed_precision.py
+++ b/python/tvm/relay/transform/mixed_precision.py
@@ -101,7 +101,7 @@ DEFAULT_FOLLOW_LIST = [
     "fast_tanh",  # Some coefficients outside of representable range, but probably ok
     "fast_exp",
     "fast_erf",
-    "clip",  # Usually safe, my result in oddity if clip greater than fp16 range
+    "clip",  # Usually safe, may result in oddity if clip greater than fp16 range
     # Pooling operations
     "nn.max_pool1d",
     "nn.max_pool2d",


### PR DESCRIPTION
Add some unregistered ops to the default AMP lists.

By default the pass places unregistered ops to the follow list so this does not change behavior. It does suppress some errors though.

`nn.depth_to_space` -- this is just a fancy reshape op so should be in follow list

`argmax`, `argmin` -- this one is pretty much the same computation as in `min` and `max` which are in the follow lists

`fast_*` -- these fast operations use approximations involving polynomials in a clipped domain of the normal functions. They seem safe, though `fast_tanh` has coefficients outside of representable range of fp16 (which I think is fine)

`clip` -- usually used to implement relu6, might have problems if clip range are outside of fp16 range but this should be rare

`image.resize2d` -- The amount of accumulation is pretty minimal

Excepting the `fast_*` functions which have no analog I know of, this matches closely with TFs mixed precision list (github.com/tensorflow/tensorflow/blob/v2.5.0/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h) so feel confident about this change.