### PR TITLE
[Torch] Better support in-place variant of ops (aten::relu_ etc)

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2860,18 +2860,14 @@ class PyTorchOpConverter:
             "aten::device": self.none,
             "prim::device": self.none,
             "aten::sub": self.make_elemwise("subtract"),
-            "aten::sub_": self.make_elemwise("subtract"),
             "aten::max": self.max,
             "aten::min": self.min,
             "aten::mul": self.make_elemwise("multiply"),
-            "aten::mul_": self.make_elemwise("multiply"),
             "aten::pow": self.make_elemwise("power"),
             "aten::arange": self.arange,
             "aten::meshgrid": self.meshgrid,
             "aten::div": self.make_elemwise("divide"),
-            "aten::div_": self.make_elemwise("divide"),
             "aten::floor_divide": self.make_elemwise("floor_divide"),
-            "aten::floor_divide_": self.make_elemwise("floor_divide"),
             "aten::true_divide": self.make_elemwise("divide"),
             "aten::addcdiv": self.addcdiv,
             "aten::addcmul": self.addcmul,
@@ -2888,7 +2884,6 @@ class PyTorchOpConverter:
             "aten::to": self.to,
             "aten::squeeze": self.squeeze,
             "aten::unsqueeze": self.unsqueeze,
-            "aten::unsqueeze_": self.unsqueeze,
             "aten::cat": self.concatenate,
             "aten::slice": self.slice,
             "aten::narrow": self.narrow,
@@ -2899,17 +2894,13 @@ class PyTorchOpConverter:
             "aten::where": self.where,
             "aten::topk": self.topk,
             "aten::relu": self.relu,
-            "aten::relu_": self.relu,
             "aten::prelu": self.prelu,
             "aten::leaky_relu": self.leaky_relu,
-            "aten::leaky_relu_": self.leaky_relu,
             "aten::elu": self.elu,
-            "aten::elu_": self.elu,
             "aten::celu": self.celu,
             "aten::gelu": self.gelu,
             "aten::selu": self.selu,
             "aten::silu": self.silu,
-            "aten::silu_": self.silu,
             "aten::log_sigmoid": self.log_sigmoid,
             "aten::adaptive_avg_pool1d": functools.partial(
                 self.adaptive_avg_pool, _op.nn.adaptive_avg_pool1d
@@ -2934,18 +2925,15 @@ class PyTorchOpConverter:
             "aten::max_pool1d": self.maxpool_1d,
             "aten::max_pool3d": self.maxpool_3d,
             "aten::hardtanh": self.hardtanh,
-            "aten::hardtanh_": self.hardtanh,
             "aten::_convolution": self.convolution,
             "aten::softmax": self.softmax,
             "aten::threshold": self.threshold,
-            "aten::threshold_": self.threshold,
             "aten::contiguous": self.contiguous,
             "aten::batch_norm": self.batch_norm,
             "aten::instance_norm": self.instance_norm,
             "aten::layer_norm": self.layer_norm,
             "aten::group_norm": self.group_norm,
             "aten::transpose": self.transpose,
-            "aten::transpose_": self.transpose,
             "aten::t": self.transpose,
             "aten::flatten": self.flatten,
             "aten::addmm": self.addmm,
@@ -2955,14 +2943,12 @@ class PyTorchOpConverter:
             "aten::clone": self.clone,
             "aten::log_softmax": self.log_softmax,
             "aten::sigmoid": self.sigmoid,
-            "aten::sigmoid_": self.sigmoid,
             "aten::softplus": self.softplus,
             "aten::avg_pool1d": self.make_avg_pool(1),
             "aten::avg_pool2d": self.make_avg_pool(2),
             "aten::avg_pool3d": self.make_avg_pool(3),
             "aten::linear": self.linear,
             "aten::dropout": self.dropout,
-            "aten::dropout_": self.dropout,
             "aten::feature_dropout": self.dropout,
             "aten::alpha_dropout": self.dropout,
             "aten::mean": self.mean,
@@ -2998,7 +2984,6 @@ class PyTorchOpConverter:
             "aten::sinh": self.make_unary("sinh"),
             "aten::tan": self.make_unary("tan"),
             "aten::tanh": self.make_unary("tanh"),
-            "aten::tanh_": self.make_unary("tanh"),
             "aten::acos": self.make_unary("acos"),
             "aten::asin": self.make_unary("asin"),
             "aten::atan": self.make_unary("atan"),
@@ -3014,13 +2999,11 @@ class PyTorchOpConverter:
             "aten::rsqrt": self.make_unary("rsqrt"),
             "aten::ceil": self.make_unary("ceil"),
             "aten::floor": self.make_unary("floor"),
-            "aten::floor_": self.make_unary("floor"),
             "aten::round": self.make_unary("round"),
             "aten::isfinite": self.make_unary("isfinite"),
             "aten::isinf": self.make_unary("isinf"),
             "aten::isnan": self.make_unary("isnan"),
             "aten::clamp": self.clamp,
-            "aten::clamp_": self.clamp,
             "aten::detach": self.identity,
             "aten::upsample_bilinear2d": self.make_upsample("linear"),
             "aten::upsample_bicubic2d": self.make_upsample("cubic"),
@@ -3045,7 +3028,6 @@ class PyTorchOpConverter:
             "aten::one_hot": self.one_hot,
             "aten::mm": self.matmul,
             "aten::add": self.add,
-            "aten::add_": self.add,
             "aten::stack": self.stack,
             "aten::__getitem__": self.list_getitem,
             "aten::len": self.list_len,
@@ -3065,7 +3047,6 @@ class PyTorchOpConverter:
             "aten::nonzero_numpy": self.nonzero_numpy,
             "aten::scatter": self.scatter,
             "aten::index_put": self.index_put,
-            "aten::index_put_": self.index_put,
             "aten::scalar_tensor": self.scalar_tensor,
             "aten::__interpolate": self.interpolate,
             "aten::IntImplicit": self.identity,
@@ -3075,13 +3056,10 @@ class PyTorchOpConverter:
             "aten::bincount": self.bincount,
             "aten::scatter_add": self.scatter_add,
             "aten::__not__": self.logical_not,
-            "aten::hardswish_": self.hard_swish,
             "aten::hardswish": self.hard_swish,
-            "aten::hardsigmoid_": self.hard_sigmoid,
             "aten::hardsigmoid": self.hard_sigmoid,
             "aten::cumsum": self.cumsum,
             "aten::masked_fill": self.masked_fill,
-            "aten::masked_fill_": self.masked_fill,
             "aten::masked_select": self.masked_select,
             "aten::argsort": self.argsort,
             "aten::sort": self.sort,
@@ -3119,7 +3097,14 @@ class PyTorchOpConverter:
         known_ops += list(self.convert_map.keys())
         known_ops += list(qnn_torch.convert_map.keys())
 
-        missing = [op_name for op_name in op_names if op_name not in known_ops]
+        missing = []
+
+        for op_name in op_names:
+            # Also take care of in-place variant ops like aten::relu_
+            if op_name not in known_ops and not (
+                op_name.endswith("_") and op_name[:-1] in known_ops
+            ):
+                missing.append(op_name)
 
         if missing:
             msg = "The following operators are not implemented: {}".format(missing)
@@ -3308,7 +3293,14 @@ class PyTorchOpConverter:
                 assert len(loop_out) == len(unpacked_names)
                 outputs.update(zip(unpacked_names, loop_out))
             else:
-                relay_op = self.convert_map[operator]
+                if operator not in self.convert_map:
+                    # At this point, the only possible ops that are not in convert_map are
+                    # in-place variant of ops like aten::relu_
+                    assert operator.endswith("_")
+                    relay_op = self.convert_map[operator[:-1]]
+                else:
+                    relay_op = self.convert_map[operator]
+
                 relay_out = relay_op(
                     inputs, _get_input_types(op_node, outputs, default_dtype=self.default_dtype)
                 )

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3299,7 +3299,8 @@ class PyTorchOpConverter:
                     assert operator.endswith("_")
                     logger.warning(
                         "An in-place op %s found, the result will not be correct "
-                        "if the model depends on side-effects by this op." % operator
+                        "if the model depends on side-effects by this op.",
+                        operator,
                     )
                     relay_op = self.convert_map[operator[:-1]]
                 else:

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3297,6 +3297,10 @@ class PyTorchOpConverter:
                     # At this point, the only possible ops that are not in convert_map are
                     # in-place variant of ops like aten::relu_
                     assert operator.endswith("_")
+                    logger.warning(
+                        "An in-place op %s found, the result will not be correct "
+                        "if the model depends on side-effects by this op." % operator
+                    )
                     relay_op = self.convert_map[operator[:-1]]
                 else:
                     relay_op = self.convert_map[operator]


### PR DESCRIPTION
So far we've been kept adding "underscore ops" like `aten::relu_` as they come up, but this is annoying. This change lets us support all `_` ops automatically.

@comaniac 