### PR TITLE
[microNPU] Add support for transpose convolution

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/te/convolution.py
+++ b/python/tvm/relay/backend/contrib/ethosu/te/convolution.py
@@ -115,10 +115,17 @@ def conv2d_compute(
     stride_h, stride_w = [int(v) for v in strides]
     dilation_h, dilation_w = [int(v) for v in dilation]
     ofm_channels, kernel_h, kernel_w, ifm_channels = [int(v) for v in weight.shape]
+    upscale_factor = 2 if upscale != "NONE" else 1
 
     # Compute operation for the IFM DMA pipeline
     dmaed_ifm = dma_ifm_compute(
-        ifm, ifm_layout, ifm_zero_point, ifm_scale, weight.shape[3], padding
+        ifm,
+        ifm_layout,
+        ifm_zero_point,
+        ifm_scale,
+        weight.shape[3],
+        padding,
+        upscale_factor,
     )
 
     # 2D Convolution compute operation

--- a/python/tvm/relay/backend/contrib/ethosu/tir/convolution.py
+++ b/python/tvm/relay/backend/contrib/ethosu/tir/convolution.py
@@ -102,7 +102,7 @@ def get_conv2d_params(stmt, producers, consumers):
             padding=serial_padding,
             activation=serial_activation,
             rounding_mode=attrs["rounding_mode"],
-            upscale="NONE",
+            upscale=attrs["upscale"],
         ),
         output_pointer,
         replace_pointer,

--- a/python/tvm/relay/backend/contrib/ethosu/util.py
+++ b/python/tvm/relay/backend/contrib/ethosu/util.py
@@ -47,6 +47,20 @@ class QConv2DArgs(Enum):
     WEIGHTS_SCALE = 5
 
 
+class QConv2DTransposeArgs(Enum):
+    """
+    This is a helper enum to obtain the correct index
+    of qnn.conv2d_transpose arguments.
+    """
+
+    IFM = 0
+    WEIGHTS = 1
+    IFM_ZERO_POINT = 2
+    WEIGHTS_ZERO_POINT = 3
+    IFM_SCALE = 4
+    WEIGHTS_SCALE = 5
+
+
 class RequantArgs(Enum):
     """
     This is a helper enum to obtain the correct index

--- a/tests/python/contrib/test_ethosu/infra.py
+++ b/tests/python/contrib/test_ethosu/infra.py
@@ -423,6 +423,7 @@ def make_ethosu_conv2d(
     weight_dtype="int8",
     scale_bias_dtype="uint8",
     rounding_mode="TFL",
+    upscale="NONE",
 ):
     # conv params
     weight_shape = (ofm_channels, kernel_shape[0], kernel_shape[1], ifm_channels)
@@ -451,7 +452,7 @@ def make_ethosu_conv2d(
         clip_min=10 if activation == "CLIP" else 0,
         clip_max=100 if activation == "CLIP" else 0,
         rounding_mode=rounding_mode,
-        upscale="NONE",
+        upscale=upscale,
         ifm_layout=ifm_layout,
         ofm_layout=ofm_layout,
     )

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -1061,5 +1061,44 @@ def test_tflite_resize2d_bilinear(accel_type, ifm_shape, size, align_corners):
     _compare_tvm_with_tflite(resize_model, [ifm_shape], accel_type, output_tolerance=1)
 
 
+@pytest.mark.parametrize("accel_type", ACCEL_TYPES)
+@pytest.mark.parametrize(
+    "ifm_shape,ofm_shape,kernel_shape,padding",
+    [
+        [(1, 2, 2, 1), (1, 4, 4, 1), (3, 3), "SAME"],
+        [(1, 2, 2, 1), (1, 9, 9, 1), (7, 7), "VALID"],
+        [(1, 2, 4, 3), (1, 4, 8, 3), (5, 3), "SAME"],
+        [(1, 10, 5, 3), (1, 21, 13, 3), (3, 5), "VALID"],
+    ],
+)
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_tflite_transpose_convolution(
+    accel_type, ifm_shape, ofm_shape, kernel_shape, padding, has_bias
+):
+    dilations = (1, 1)
+    strides = (2, 2)
+
+    @tf.function
+    def conv2d_transpose(x):
+        weight_shape = [kernel_shape[0], kernel_shape[1], ifm_shape[3], ofm_shape[3]]
+        weight = tf.constant(np.random.uniform(size=weight_shape), dtype=tf.float32)
+        bias_shape = ofm_shape[3]
+        bias = tf.constant(np.random.uniform(size=bias_shape), dtype=tf.float32)
+        tf_strides = [1, strides[0], strides[1], 1]
+        op = tf.nn.conv2d_transpose(
+            x,
+            weight,
+            output_shape=ofm_shape,
+            strides=tf_strides,
+            padding=padding,
+            dilations=dilations,
+        )
+        if has_bias:
+            op = tf.nn.bias_add(op, bias)
+        return op
+
+    _compare_tvm_with_tflite(conv2d_transpose, [ifm_shape], accel_type=accel_type)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -33,6 +33,7 @@ from tvm.relay import dataflow_pattern
 from tvm.relay.op.contrib import ethosu
 from tvm.relay.backend.contrib.ethosu import util
 from tvm.relay.build_module import bind_params_by_name
+from tvm.relay.frontend.tflite import get_pad_value
 
 from . import infra
 
@@ -1768,6 +1769,134 @@ def test_tflite_resize2d_bilinear(ifm_shape, size, align_corners):
 
     mod = create_tflite_graph()
     mod = partition_ethosu_by_table(mod, pattern_table)
+    mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
+        rewriter, mod["tvmgen_default_ethos_u_main_0"]
+    )
+    verify(mod["tvmgen_default_ethos_u_main_0"])
+
+
+@pytest.mark.parametrize(
+    "ifm_shape,ofm_shape,kernel_shape,padding",
+    [
+        [(1, 2, 2, 1), (1, 4, 4, 1), (3, 3), "SAME"],
+        [(1, 2, 2, 1), (1, 9, 9, 1), (7, 7), "VALID"],
+        [(1, 2, 4, 3), (1, 4, 8, 3), (3, 3), "SAME"],
+        [(1, 10, 5, 3), (1, 21, 13, 3), (3, 5), "VALID"],
+    ],
+)
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_tflite_transpose_convolution(ifm_shape, ofm_shape, kernel_shape, padding, has_bias):
+    dtype = "int8"
+    dilations = (1, 1)
+    strides = (2, 2)
+
+    def create_tflite_graph():
+        @tf.function
+        def conv2d_transpose(x):
+            bias_shape = ofm_shape[3]
+            bias = tf.constant(np.random.uniform(size=bias_shape), dtype=tf.float32)
+            weight_shape = [kernel_shape[0], kernel_shape[1], ifm_shape[3], ofm_shape[3]]
+            weight = tf.constant(np.random.uniform(size=weight_shape), dtype=tf.float32)
+            tf_strides = [1, strides[0], strides[1], 1]
+            op = tf.nn.conv2d_transpose(
+                x,
+                weight,
+                output_shape=ofm_shape,
+                strides=tf_strides,
+                padding=padding,
+                dilations=dilations,
+            )
+            if has_bias:
+                op = tf.nn.bias_add(op, bias)
+            return op
+
+        concrete_func = conv2d_transpose.get_concrete_function(
+            tf.TensorSpec(ifm_shape, dtype=tf.float32)
+        )
+
+        def representative_dataset():
+            for _ in range(100):
+                data = np.random.rand(*tuple(ifm_shape))
+                yield [data.astype(np.float32)]
+
+        converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.representative_dataset = representative_dataset
+        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+        converter.inference_input_type = tf.int8
+        converter.inference_output_type = tf.int8
+        tflite_model = converter.convert()
+        tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model, 0)
+
+        mod, params = relay.frontend.from_tflite(
+            tflite_model,
+            shape_dict={"input": ifm_shape},
+            dtype_dict={"input": dtype},
+        )
+        return mod, params
+
+    def verify(ext_func):
+        strided_slice = ext_func.body
+        conv = strided_slice.args[0]
+        ofm_channels = conv.attrs.ofm_channels
+
+        # Check IFM
+        ifm = conv.args[0].checked_type
+        assert list(ifm.shape) == list(ifm_shape)
+        assert str(ifm.dtype) == dtype
+        assert ifm.shape[3] == ofm_channels
+
+        # Check OFM
+        ofm = strided_slice.checked_type
+        assert list(ofm.shape) == list(ofm_shape)
+        assert str(ofm.dtype) == dtype
+        assert ofm.shape[3] == ofm_channels
+
+        # Check weights
+        weights_ohwi = conv.args[1].data.asnumpy()
+        assert str(weights_ohwi.dtype) == dtype
+        assert list(weights_ohwi.shape) == [
+            ofm_channels,
+            kernel_shape[0],
+            kernel_shape[1],
+            ifm_shape[3],
+        ]
+
+        # Check that scale_bias matches weight tensor
+        assert list(conv.args[2].checked_type.shape)[0] == ofm_channels
+
+        # Calculate expected padding for conv2d op
+        if padding == "VALID":
+            expected_padding = [0, 0, 0, 0]
+        elif padding == "SAME":
+            pad_top, pad_bottom = get_pad_value(ofm_shape[1], kernel_shape[0], strides[0])
+            pad_left, pad_right = get_pad_value(ofm_shape[2], kernel_shape[1], strides[1])
+            expected_padding = [pad_top, pad_left, pad_bottom, pad_right]
+        pad_top = kernel_shape[0] - 1 - expected_padding[0]
+        pad_left = kernel_shape[1] - 1 - expected_padding[1]
+        pad_bottom = kernel_shape[0] - 1 - expected_padding[2]
+        pad_right = kernel_shape[1] - 1 - expected_padding[3]
+        if strides == [2, 2]:
+            pad_bottom -= 1
+            pad_right -= 1
+        expected_padding = [pad_top, pad_left, pad_bottom, pad_right]
+        assert list(conv.attrs.padding) == list(expected_padding)
+
+        assert list(conv.attrs.strides) == [1, 1]
+
+    rewriter = legalize.Conv2DTransposeRewriter()
+    pattern_table = [
+        (
+            ethosu.QnnConv2DTransposeParams.composite_name,
+            ethosu.qnn_conv2d_transpose_pattern(),
+            lambda pat: ethosu.QnnConv2DTransposeParams(pat).is_valid(),
+        ),
+    ]
+
+    mod, params = create_tflite_graph()
+    mod["main"] = bind_params_by_name(mod["main"], params)
+    mod = partition_ethosu_by_table(mod, pattern_table)
+
     mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
         rewriter, mod["tvmgen_default_ethos_u_main_0"]
     )

--- a/tests/python/contrib/test_ethosu/test_replace_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_conv2d.py
@@ -26,156 +26,45 @@ from tvm.relay.backend.contrib.ethosu.tir.scheduler import total_cascader
 from .infra import make_ethosu_conv2d, get_convolutional_args
 
 
-@pytest.mark.parametrize(
-    "trial",
-    [
-        [(1, 8, 8, 3), 3, 16, (1, 1), (2, 1), (1, 1), (1, 1), "CLIP", "NHWC", "NHWC", "TFL"],
-        [(1, 8, 8, 3), 3, 16, (1, 1), (0, 0), (1, 1), (1, 1), "NONE", "NHWC", "NHWC", "NATURAL"],
-        [(1, 1, 1, 1), 1, 16, (1, 1), (0, 0), (1, 1), (1, 1), "CLIP", "NHWC", "NHWC", "TRUNCATE"],
-        [(1, 7, 9, 4), 4, 13, (3, 2), (1, 2), (2, 1), (1, 2), "NONE", "NHWC", "NHWC", "TFL"],
-        [
-            (1, 8, 2, 8, 16),
-            18,
-            12,
-            (1, 1),
-            (2, 1),
-            (1, 1),
-            (1, 1),
-            "CLIP",
-            "NHCWB16",
-            "NHWC",
-            "NATURAL",
-        ],
-        [
-            (1, 7, 9, 4),
-            4,
-            71,
-            (3, 2),
-            (1, 2),
-            (2, 1),
-            (1, 2),
-            "CLIP",
-            "NHWC",
-            "NHCWB16",
-            "TRUNCATE",
-        ],
-        [
-            (1, 4, 12, 9, 16),
-            182,
-            67,
-            (2, 3),
-            (6, 3),
-            (2, 2),
-            (1, 1),
-            "CLIP",
-            "NHCWB16",
-            "NHCWB16",
-            "TFL",
-        ],
-        [(1, 7, 9, 4), 4, 13, (3, 2), (1, 2), (2, 1), (2, 2), "CLIP", "NHWC", "NHWC", "NATURAL"],
-        [
-            (1, 7, 9, 4),
-            4,
-            71,
-            (3, 2),
-            (1, 2),
-            (2, 1),
-            (2, 2),
-            "CLIP",
-            "NHWC",
-            "NHCWB16",
-            "TRUNCATE",
-        ],
-        [
-            (1, 13, 12, 19, 16),
-            182,
-            67,
-            (1, 3),
-            (5, 3),
-            (2, 1),
-            (2, 1),
-            "CLIP",
-            "NHCWB16",
-            "NHCWB16",
-            "TFL",
-        ],
-    ],
-)
-def test_conv2d_single(trial):
-    def _get_func(
-        ifm_shape,
-        ifm_channels,
-        ofm_channels,
-        kernel_shape,
-        padding,
-        strides,
-        dilation,
-        activation,
-        ifm_layout,
-        ofm_layout,
-        rounding_mode,
-    ):
-        ifm = relay.var("ifm", shape=ifm_shape, dtype="int8")
-        conv = make_ethosu_conv2d(
-            ifm,
-            ifm_channels,
-            ofm_channels,
-            kernel_shape,
-            padding,
-            strides,
-            dilation,
-            activation=activation,
-            ifm_layout=ifm_layout,
-            ofm_layout=ofm_layout,
-            rounding_mode=rounding_mode,
-        )
-        func = relay.Function(relay.analysis.free_vars(conv), conv)
-        func = run_opt_pass(func, relay.transform.InferType())
-        return func
-
-    # TODO(@mbaret) Fix the tests for these known failures
-    # These are anticipated to actually be correct, just a testing issue to do with
-    # equivalent convolutions.
-    known_failures = [
-        [(1, 3, 12, 9, 16), 182, 67, (2, 3), (1, 3), (2, 2), (1, 1), "CLIP", "NHCWB16", "NHCWB16"],
-        [(1, 2, 12, 9, 16), 182, 67, (1, 3), (6, 3), (2, 2), (1, 1), "CLIP", "NHCWB16", "NHCWB16"],
-    ]
-    func = _get_func(*trial)
-    mod, _ = lower_to_tir(func)
-    data = []
-
-    def _visit(stmt):
-        if isinstance(stmt, tvm.tir.Call):
-            data.append(get_convolutional_args(stmt, remove_constants=True))
-
-    tvm.tir.stmt_functor.post_order_visit(mod["main"].body, _visit)
-    (
-        ifm_shape,
-        ifm_channels,
-        ofm_channels,
-        kernel_shape,
-        padding,
-        strides,
-        dilation,
-        activation,
-        ifm_layout,
-        ofm_layout,
-        rounding_mode,
-    ) = trial
+def _create_serial_conv2d_params(
+    ifm_shape,
+    ifm_channels,
+    ofm_channels,
+    kernel_shape,
+    padding,
+    strides,
+    dilation,
+    activation="NONE",
+    ifm_layout="NHWC",
+    ofm_layout="NHWC",
+    rounding_mode="TFL",
+    upscale="NONE",
+):
+    dtype = "int8"
     dilated_kernel_h = (kernel_shape[0] - 1) * dilation[0] + 1
     dilated_kernel_w = (kernel_shape[1] - 1) * dilation[1] + 1
+    upscale_factor = 2 if upscale != "NONE" else 1
+
     if ifm_layout == "NHWC":
         ifm_stride_c = 1
         ifm_stride_w = ifm_shape[3]
         ifm_stride_h = ifm_shape[2] * ifm_shape[3]
-        ofm_height = (ifm_shape[1] - dilated_kernel_h + padding[0] + padding[0]) // strides[0] + 1
-        ofm_width = (ifm_shape[2] - dilated_kernel_w + padding[1] + padding[1]) // strides[1] + 1
+        ofm_height = (
+            ifm_shape[1] * upscale_factor - dilated_kernel_h + padding[0] + padding[2]
+        ) // strides[0] + 1
+        ofm_width = (
+            ifm_shape[2] * upscale_factor - dilated_kernel_w + padding[1] + padding[3]
+        ) // strides[1] + 1
     else:
         ifm_stride_w = 16
         ifm_stride_c = 16 * ifm_shape[3]
         ifm_stride_h = 16 * ifm_shape[2] * ifm_shape[3]
-        ofm_height = (ifm_shape[1] - dilated_kernel_h + padding[0] + padding[0]) // strides[0] + 1
-        ofm_width = (ifm_shape[3] - dilated_kernel_w + padding[1] + padding[1]) // strides[1] + 1
+        ofm_height = (
+            ifm_shape[1] * upscale_factor - dilated_kernel_h + padding[0] + padding[2]
+        ) // strides[0] + 1
+        ofm_width = (
+            ifm_shape[3] * upscale_factor - dilated_kernel_w + padding[1] + padding[3]
+        ) // strides[1] + 1
 
     if ofm_layout == "NHWC":
         ofm_stride_c = 1
@@ -186,8 +75,8 @@ def test_conv2d_single(trial):
         ofm_stride_c = 16 * ofm_width
         ofm_stride_h = 16 * ofm_width * ((ofm_channels - 1) // 16 + 1)
 
-    answer = [
-        "int8",
+    return [
+        dtype,
         ifm_shape[1],
         ifm_shape[2] if ifm_layout == "NHWC" else ifm_shape[3],
         ifm_channels,
@@ -204,7 +93,7 @@ def test_conv2d_single(trial):
         ifm_stride_h,
         ifm_stride_w,
         ifm_stride_c,
-        "int8",
+        dtype,
         ofm_height,
         ofm_width,
         ofm_channels,
@@ -230,14 +119,213 @@ def test_conv2d_single(trial):
         12,
         padding[0],
         padding[1],
-        padding[0],
-        padding[1],
+        padding[2],
+        padding[3],
         activation,
         10 if activation == "CLIP" else 0,
         100 if activation == "CLIP" else 0,
         rounding_mode,
-        "NONE",
+        upscale,
     ]
+
+
+@pytest.mark.parametrize(
+    "trial",
+    [
+        [
+            (1, 8, 8, 3),
+            3,
+            16,
+            (1, 1),
+            (2, 1, 2, 1),
+            (1, 1),
+            (1, 1),
+            "CLIP",
+            "NHWC",
+            "NHWC",
+            "TFL",
+            "NONE",
+        ],
+        [
+            (1, 8, 8, 3),
+            3,
+            16,
+            (1, 1),
+            (0, 0, 0, 0),
+            (1, 1),
+            (1, 1),
+            "NONE",
+            "NHWC",
+            "NHWC",
+            "NATURAL",
+            "NONE",
+        ],
+        [
+            (1, 1, 1, 1),
+            1,
+            16,
+            (1, 1),
+            (0, 0, 0, 0),
+            (1, 1),
+            (1, 1),
+            "CLIP",
+            "NHWC",
+            "NHWC",
+            "TRUNCATE",
+            "NONE",
+        ],
+        [
+            (1, 7, 9, 4),
+            4,
+            13,
+            (3, 2),
+            (1, 2, 1, 2),
+            (2, 1),
+            (1, 2),
+            "NONE",
+            "NHWC",
+            "NHWC",
+            "TFL",
+            "NONE",
+        ],
+        [
+            (1, 8, 2, 8, 16),
+            18,
+            12,
+            (1, 1),
+            (2, 1, 2, 1),
+            (1, 1),
+            (1, 1),
+            "CLIP",
+            "NHCWB16",
+            "NHWC",
+            "NATURAL",
+            "ZEROS",
+        ],
+        [
+            (1, 7, 9, 4),
+            4,
+            71,
+            (3, 2),
+            (1, 2, 0, 2),
+            (2, 1),
+            (1, 2),
+            "CLIP",
+            "NHWC",
+            "NHCWB16",
+            "TRUNCATE",
+            "ZEROS",
+        ],
+        [
+            (1, 4, 12, 9, 16),
+            182,
+            67,
+            (2, 3),
+            (6, 3, 6, 2),
+            (2, 2),
+            (1, 1),
+            "CLIP",
+            "NHCWB16",
+            "NHCWB16",
+            "TFL",
+            "ZEROS",
+        ],
+        [
+            (1, 7, 9, 4),
+            4,
+            13,
+            (3, 2),
+            (1, 2, 0, 3),
+            (2, 1),
+            (2, 2),
+            "CLIP",
+            "NHWC",
+            "NHWC",
+            "NATURAL",
+            "NEAREST",
+        ],
+        [
+            (1, 7, 9, 4),
+            4,
+            71,
+            (3, 2),
+            (1, 2, 0, 2),
+            (2, 1),
+            (2, 2),
+            "CLIP",
+            "NHWC",
+            "NHCWB16",
+            "TRUNCATE",
+            "NEAREST",
+        ],
+        [
+            (1, 13, 12, 19, 16),
+            182,
+            67,
+            (1, 3),
+            (5, 3, 2, 3),
+            (2, 1),
+            (2, 1),
+            "CLIP",
+            "NHCWB16",
+            "NHCWB16",
+            "TFL",
+            "NEAREST",
+        ],
+    ],
+)
+def test_conv2d_single(trial):
+    def _get_func(
+        ifm_shape,
+        ifm_channels,
+        ofm_channels,
+        kernel_shape,
+        padding,
+        strides,
+        dilation,
+        activation,
+        ifm_layout,
+        ofm_layout,
+        rounding_mode,
+        upscale,
+    ):
+        ifm = relay.var("ifm", shape=ifm_shape, dtype="int8")
+        conv = make_ethosu_conv2d(
+            ifm,
+            ifm_channels,
+            ofm_channels,
+            kernel_shape,
+            padding,
+            strides,
+            dilation,
+            activation=activation,
+            ifm_layout=ifm_layout,
+            ofm_layout=ofm_layout,
+            rounding_mode=rounding_mode,
+            upscale=upscale,
+        )
+        func = relay.Function(relay.analysis.free_vars(conv), conv)
+        func = run_opt_pass(func, relay.transform.InferType())
+        return func
+
+    # TODO(@mbaret) Fix the tests for these known failures
+    # These are anticipated to actually be correct, just a testing issue to do with
+    # equivalent convolutions.
+    known_failures = [
+        [(1, 3, 12, 9, 16), 182, 67, (2, 3), (1, 3), (2, 2), (1, 1), "CLIP", "NHCWB16", "NHCWB16"],
+        [(1, 2, 12, 9, 16), 182, 67, (1, 3), (6, 3), (2, 2), (1, 1), "CLIP", "NHCWB16", "NHCWB16"],
+    ]
+    func = _get_func(*trial)
+    mod, _ = lower_to_tir(func)
+    data = []
+
+    def _visit(stmt):
+        if isinstance(stmt, tvm.tir.Call):
+            data.append(get_convolutional_args(stmt, remove_constants=True))
+
+    tvm.tir.stmt_functor.post_order_visit(mod["main"].body, _visit)
+
+    answer = _create_serial_conv2d_params(*trial)
     assert data[0] == answer, data[0]
 
 
@@ -318,6 +406,42 @@ class Conv2dDoubleCascade4:
         T.evaluate(T.call_extern("ethosu_conv2d", "int8", 6, 8, 3, 6, 0, 8, T.load("int8", placeholder_5.data, 256), 0, 0, 0, T.float32(0.5), 10, "NHCWB16", 128, 16, 1, "int8", 5, 8, 35, 5, 0, 8, T.load("int8", ethosu_write_2, 0), 0, 0, 0, T.float32(0.25), 14, "NHCWB16", 384, 16, 128, 3, 3, 1, 1, 1, 1, T.load("uint8", buffer, 0), 1456, 12, T.load("uint8", buffer_1, 0), 352, 0, 1, 1, 1, "NONE", 0, 0, "TFL", "NONE", dtype="handle"))
         T.evaluate(T.call_extern("ethosu_conv2d", "int8", 5, 8, 35, 5, 0, 8, T.load("int8", ethosu_write_2, 0), 0, 0, 0, T.float32(0.5), 10, "NHCWB16", 384, 16, 128, "int8", 4, 8, 26, 4, 0, 8, T.load("int8", ethosu_write_1.data, 1024), 0, 0, 0, T.float32(0.25), 14, "NHCWB16", 256, 16, 128, 3, 3, 1, 1, 1, 1, T.load("uint8", buffer_3, 0), 11040, 12, T.load("uint8", buffer_2, 0), 272, 0, 1, 1, 1, "NONE", 0, 0, "TFL", "NONE", dtype="handle"))
     __tvm_meta__ = None
+
+
+@tvm.script.ir_module
+class Conv2dDoubleCascade5:
+    @T.prim_func
+    def main(placeholder: T.Buffer[(1, 8, 8, 3), "int8"], ethosu_write: T.Buffer[(1, 32, 32, 8), "int8"]) -> None:
+        # function attr dict
+        T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
+        buffer = T.buffer_var("uint8", "")
+        buffer_1 = T.buffer_var("uint8", "")
+        buffer_2 = T.buffer_var("uint8", "")
+        buffer_3 = T.buffer_var("uint8", "")
+        # body
+        ethosu_write_1 = T.allocate([4096], "int8", "global", annotations={"disable_lower_builtin":True})
+        T.evaluate(T.call_extern("ethosu_conv2d", "int8", 4, 8, 3, 4, 0, 8, T.load("int8", placeholder.data, 0), 0, 0, 0, T.float32(0.5), 10, "NHWC", 24, 3, 1, "int8", 8, 16, 32, 8, 0, 16, T.load("int8", ethosu_write_1, 0), 0, 0, 0, T.float32(0.25), 14, "NHWC", 512, 32, 1, 1, 1, 1, 1, 1, 1, T.load("uint8", buffer, 0), 160, 12, T.load("uint8", buffer_1, 0), 320, 0, 0, 0, 0, "NONE", 0, 0, "TFL", "ZEROS", dtype="handle"))
+        T.evaluate(T.call_extern("ethosu_conv2d", "int8", 8, 16, 32, 8, 0, 16, T.load("int8", ethosu_write_1, 0), 0, 0, 0, T.float32(0.5), 10, "NHWC", 512, 32, 1, "int8", 16, 32, 8, 16, 0, 32, T.load("int8", ethosu_write.data, 0), 0, 0, 0, T.float32(0.25), 14, "NHWC", 256, 8, 1, 1, 1, 1, 1, 1, 1, T.load("uint8", buffer_2, 0), 304, 12, T.load("uint8", buffer_3, 0), 80, 0, 0, 0, 0, "NONE", 0, 0, "TFL", "ZEROS", dtype="handle"))
+        T.evaluate(T.call_extern("ethosu_conv2d", "int8", 4, 8, 3, 4, 0, 8, T.load("int8", placeholder.data, 96), 0, 0, 0, T.float32(0.5), 10, "NHWC", 24, 3, 1, "int8", 8, 16, 32, 8, 0, 16, T.load("int8", ethosu_write_1, 0), 0, 0, 0, T.float32(0.25), 14, "NHWC", 512, 32, 1, 1, 1, 1, 1, 1, 1, T.load("uint8", buffer, 0), 160, 12, T.load("uint8", buffer_1, 0), 320, 0, 0, 0, 0, "NONE", 0, 0, "TFL", "ZEROS", dtype="handle"))
+        T.evaluate(T.call_extern("ethosu_conv2d", "int8", 8, 16, 32, 8, 0, 16, T.load("int8", ethosu_write_1, 0), 0, 0, 0, T.float32(0.5), 10, "NHWC", 512, 32, 1, "int8", 16, 32, 8, 16, 0, 32, T.load("int8", ethosu_write.data, 4096), 0, 0, 0, T.float32(0.25), 14, "NHWC", 256, 8, 1, 1, 1, 1, 1, 1, 1, T.load("uint8", buffer_2, 0), 304, 12, T.load("uint8", buffer_3, 0), 80, 0, 0, 0, 0, "NONE", 0, 0, "TFL", "ZEROS", dtype="handle"))
+    __tvm_meta__ = None
+
+
+@tvm.script.ir_module
+class Conv2dDoubleCascade6:
+    @T.prim_func
+    def main(placeholder: T.Buffer[(1, 8, 1, 8, 16), "int8"], ethosu_write: T.Buffer[(1, 32, 2, 32, 16), "int8"]) -> None:
+        # function attr dict
+        T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
+        buffer = T.buffer_var("uint8", "")
+        buffer_1 = T.buffer_var("uint8", "")
+        buffer_2 = T.buffer_var("uint8", "")
+        buffer_3 = T.buffer_var("uint8", "")
+        # body
+        ethosu_write_1 = T.allocate([12288], "int8", "global", annotations={"disable_lower_builtin":True})
+        T.evaluate(T.call_extern("ethosu_conv2d", "int8", 8, 8, 3, 8, 0, 8, T.load("int8", placeholder.data, 0), 0, 0, 0, T.float32(0.5), 10, "NHCWB16", 128, 16, 1, "int8", 16, 16, 35, 16, 0, 16, T.load("int8", ethosu_write_1, 0), 0, 0, 0, T.float32(0.25), 14, "NHCWB16", 768, 16, 256, 3, 3, 1, 1, 1, 1, T.load("uint8", buffer, 0), 1456, 12, T.load("uint8", buffer_1, 0), 352, 1, 1, 1, 1, "NONE", 0, 0, "TFL", "NEAREST", dtype="handle"))
+        T.evaluate(T.call_extern("ethosu_conv2d", "int8", 16, 16, 35, 16, 0, 16, T.load("int8", ethosu_write_1, 0), 0, 0, 0, T.float32(0.5), 10, "NHCWB16", 768, 16, 256, "int8", 32, 32, 26, 32, 0, 32, T.load("int8", ethosu_write.data, 0), 0, 0, 0, T.float32(0.25), 14, "NHCWB16", 1024, 16, 512, 3, 3, 1, 1, 1, 1, T.load("uint8", buffer_2, 0), 11040, 12, T.load("uint8", buffer_3, 0), 272, 1, 1, 1, 1, "NONE", 0, 0, "TFL", "NEAREST", dtype="handle"))
+    __tvm_meta__ = None
 # fmt: on
 
 
@@ -331,10 +455,11 @@ class Conv2dDoubleCascade4:
             32,
             8,
             (1, 1),
-            (0, 0),
+            (0, 0, 0, 0),
             (1, 1),
             (1, 1),
             "NHWC",
+            "NONE",
             (1, 8, 4, 8),
         ],
         [
@@ -344,10 +469,11 @@ class Conv2dDoubleCascade4:
             32,
             8,
             (3, 3),
-            (1, 1),
+            (1, 1, 1, 1),
             (1, 1),
             (1, 1),
             "NHWC",
+            "NONE",
             (1, 4, 8, 8),
         ],
         [
@@ -357,10 +483,11 @@ class Conv2dDoubleCascade4:
             32,
             8,
             (3, 2),
-            (2, 1),
+            (2, 1, 2, 1),
             (1, 2),
             (1, 2),
             "NHWC",
+            "NONE",
             (1, 8, 4, 8),
         ],
         [
@@ -370,11 +497,40 @@ class Conv2dDoubleCascade4:
             35,
             26,
             (3, 3),
-            (1, 1),
+            (1, 1, 1, 1),
             (1, 1),
             (1, 1),
             "NHCWB16",
+            "NONE",
             (1, 4, 2, 8, 16),
+        ],
+        [
+            Conv2dDoubleCascade5,
+            (1, 8, 8, 3),
+            3,
+            32,
+            8,
+            (1, 1),
+            (0, 0, 0, 0),
+            (1, 1),
+            (1, 1),
+            "NHWC",
+            "ZEROS",
+            (1, 16, 32, 8),
+        ],
+        [
+            Conv2dDoubleCascade6,
+            (1, 8, 1, 8, 16),
+            3,
+            35,
+            26,
+            (3, 3),
+            (1, 1, 1, 1),
+            (1, 1),
+            (1, 1),
+            "NHCWB16",
+            "NEAREST",
+            (1, 32, 2, 32, 16),
         ],
     ],
 )
@@ -389,6 +545,7 @@ def test_conv2d_double_cascade(trial):
         strides,
         dilation,
         layout,
+        upscale,
     ):
         ifm = relay.var("ifm", shape=ifm_shape, dtype="int8")
         conv1 = make_ethosu_conv2d(
@@ -402,6 +559,7 @@ def test_conv2d_double_cascade(trial):
             activation="NONE",
             ifm_layout=layout,
             ofm_layout=layout,
+            upscale=upscale,
         )
         conv2 = make_ethosu_conv2d(
             conv1,
@@ -414,6 +572,7 @@ def test_conv2d_double_cascade(trial):
             activation="NONE",
             ifm_layout=layout,
             ofm_layout=layout,
+            upscale=upscale,
         )
         func = relay.Function(relay.analysis.free_vars(conv2), conv2)
         func = run_opt_pass(func, relay.transform.InferType())

--- a/tests/python/contrib/test_ethosu/test_type_inference.py
+++ b/tests/python/contrib/test_ethosu/test_type_inference.py
@@ -91,6 +91,32 @@ def test_ethosu_conv2d_invalid_dtypes(ifm_dtype, weight_dtype, scale_bias_dtype)
         run_opt_pass(func, relay.transform.InferType())
 
 
+def test_ethosu_conv2d_invalid_upscale_method():
+    invalid_upscale_method = "FOO"
+    ifm_channels = 55
+    ofm_channels = 122
+    kernel_shape = (3, 2)
+    padding = (0, 1, 2, 3)
+    strides = (1, 2)
+    dilation = (2, 1)
+    ifm = relay.var("ifm", shape=(1, 56, 72, 55), dtype="int8")
+    conv2d = make_ethosu_conv2d(
+        ifm,
+        ifm_channels,
+        ofm_channels,
+        kernel_shape,
+        padding,
+        strides,
+        dilation,
+        weight_dtype="int8",
+        scale_bias_dtype="uint8",
+        upscale=invalid_upscale_method,
+    )
+    func = relay.Function([ifm], conv2d)
+    with pytest.raises(TVMError):
+        run_opt_pass(func, relay.transform.InferType())
+
+
 @pytest.mark.parametrize(
     "ifm_shape, ifm_layout", [((1, 46, 71, 55), "NHWC"), ((1, 46, 4, 71, 16), "NHCWB16")]
 )


### PR DESCRIPTION
Adds support for legalizing transpose convolution (deconvolution) to an NPU conv2d operation for the case when strides==(2, 2), dilation==(1, 1) and no padding of the output is required.

Note: This PR depends on #9841 so also contains the contents of that PR.

cc @manupa-arm @ekalda @dchauhan-arm @mbaret @NicolaLancellotti @jacobbohlin
