### PR TITLE
[AMP] Fix IsMixedPrecisionType Edge Case

### DIFF
--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -194,7 +194,9 @@ class MixedPrecisionPass : public MixedModeMutator {
        If ignore_non_float, then ignore non-floating types.
      */
     if (const TensorTypeNode* tensor_type = t.as<TensorTypeNode>()) {
-      return (!ignore_non_float || (tensor_type->dtype).is_float()) &&
+      bool is_supported_floating_point_type =
+          (tensor_type->dtype).is_float() || (tensor_type->dtype).is_bfloat16();
+      return (ignore_non_float && !is_supported_floating_point_type) ||
              tensor_type->dtype == mixed_precision_type_;
     } else if (const TupleTypeNode* tuple_type = t.as<TupleTypeNode>()) {
       for (Type t : tuple_type->fields) {

--- a/tests/python/relay/test_to_mixed_precision.py
+++ b/tests/python/relay/test_to_mixed_precision.py
@@ -468,8 +468,8 @@ def test_convert_follow_node_with_integer_arguments():
 
     data = relay.var("data", shape=[1, 10], dtype="float32")
 
-    # We add have an addition to make sure the input indices to take are not a
-    # var (which are always casted if safe)
+    # We use an addition to make sure the input indices are not a var
+    # (which are always casted if safe)
     indices = relay.var("indices", shape=[1, 1], dtype="int32") + relay.const(0, dtype="int32")
     take = relay.take(data, indices, axis=0)
     mod = tvm.IRModule.from_expr(take)

--- a/tests/python/relay/test_to_mixed_precision.py
+++ b/tests/python/relay/test_to_mixed_precision.py
@@ -467,7 +467,10 @@ def test_convert_follow_node_with_integer_arguments():
     """
 
     data = relay.var("data", shape=[1, 10], dtype="float32")
-    indices = relay.var("indices", shape=[1, 1], dtype="int32")
+
+    # We add have an addition to make sure the input indices to take are not a
+    # var (which are always casted if safe)
+    indices = relay.var("indices", shape=[1, 1], dtype="int32") + relay.const(0, dtype="int32")
     take = relay.take(data, indices, axis=0)
     mod = tvm.IRModule.from_expr(take)
 
@@ -479,7 +482,6 @@ def test_convert_follow_node_with_integer_arguments():
 
     # Create expected module
     data = relay.cast(relay.var("data", shape=[1, 10]), "float16")
-    indices = relay.var("indices", shape=[1, 1], dtype="int32")
     take = relay.take(data, indices, axis=0)
     expected_mod = tvm.IRModule.from_expr(take)
     expected_mod = InferType()(expected_mod)

--- a/tests/python/relay/test_to_mixed_precision.py
+++ b/tests/python/relay/test_to_mixed_precision.py
@@ -459,5 +459,32 @@ def test_batch_matmul_simple():
     assert tvm.ir.structural_equal(expected_mod, output_mod)
 
 
+def test_convert_follow_node_with_integer_arguments():
+    """Tests the conversion of a follow op with integer arguments + constant float args.
+
+    The follow op should convert the floating point argument into fp16 as constants/vars
+    will always be converted if safe to do so.
+    """
+
+    data = relay.var("data", shape=[1, 10], dtype="float32")
+    indices = relay.var("indices", shape=[1, 1], dtype="int32")
+    take = relay.take(data, indices, axis=0)
+    mod = tvm.IRModule.from_expr(take)
+
+    mod_params = {
+        "data": np.random.uniform(-1, 1, size=[1, 10]).astype("float32"),
+        "indices": np.array([[0]]).astype("int32"),
+    }
+    output_mod = verify_mixed_precision_output_close(mod, mod_params, atol=0.01, rtol=0.01)
+
+    # Create expected module
+    data = relay.cast(relay.var("data", shape=[1, 10]), "float16")
+    indices = relay.var("indices", shape=[1, 1], dtype="int32")
+    take = relay.take(data, indices, axis=0)
+    expected_mod = tvm.IRModule.from_expr(take)
+    expected_mod = InferType()(expected_mod)
+    assert tvm.ir.structural_equal(expected_mod, output_mod)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
IsMixedPrecisionType returns whether the given type matches the target mixed precision type if the type is a floating point type. If it is not a floating point type and the corresponding flag is set it just returns true.

This was the intended behavior. Previously this was not the case. This PR fixes things to match intended behavior.

Motivation is an op with a mix of arguments consisting of floating point and integers would never be allowed to be done in FP16 space unless the integer tensors were also constants.