### PR TITLE
[LLVM] LLVM codegen debug utilities

### DIFF
--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -105,7 +105,8 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* RuntimeTVMParallelBarrier();
   llvm::Value* CreateStaticHandle();
   llvm::Value* GetPackedFuncHandle(const std::string& str);
-  TypedPointer PackClosureData(const Array<Var>& fields, uint64_t* num_bytes);
+  TypedPointer PackClosureData(const Array<Var>& fields, uint64_t* num_bytes,
+                               std::string struct_name = "");
   TypedPointer CreateStructRefPtr(DataType t, llvm::Value* buffer, llvm::Value* index, int kind);
   void UnpackClosureData(TypedPointer cdata, const Array<Var>& fields,
                          std::unordered_map<const VarNode*, llvm::Value*>* vmap);
@@ -124,7 +125,7 @@ class CodeGenCPU : public CodeGenLLVM {
   // Create static initialization
   void CreateStaticInit(const std::string& init_fname, const Stmt& body);
   // Create parallel launch
-  void CreateParallelLaunch(const Stmt& body, int num_task);
+  void CreateParallelLaunch(const Stmt& body, int num_task, std::string name = "");
   // Create a new compute scope.
   void CreateComputeScope(const AttrStmtNode* op);
   // Check if the call to packed function is successful

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -228,6 +228,26 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   // skip first arg mode used for call extern intrinsic.
   virtual llvm::Value* CreateCallExtern(Type ret_type, String global_symbol,
                                         const Array<PrimExpr>& args, bool skip_first_arg);
+
+  /*! \brief Insert a printf() call to the generated LLVM
+   *
+   * This is intended solely for debugging purposes.  After calling
+   * printf(), immediately calls fflush() to flush the stdout buffer
+   * in case of segfault.
+   */
+  void CreatePrintf(const std::string& format, const std::vector<llvm::Value*> format_args);
+
+  /*! \brief Lookup return address, for debugging purposes
+   *
+   * This is intended solely for debugging purposes.  Calls the
+   * `llvm::Intrinsic::returnaddress`, returning the return address of
+   * the current function call.
+   *
+   * \param level Look up the return address of a frame `level` steps
+   * above the current stack frame.
+   */
+  llvm::Value* CreateLookupReturnAddress(unsigned int level = 0);
+
   // Get the corresponding thread index
   virtual llvm::Value* GetThreadIndex(const IterVar& iv);
   // Get the corresponding thread index


### PR DESCRIPTION
A few debug utilities that were needed while debugging a segfault that occurred within generated LLVM code, and may be more broadly applicable.

* Set variable names in LLVM IR to match those present in TIR.  Used for let-bindings, loop iteration variables, 
* Set LLVM block names based on those present in TIR.  (e.g. `for_body_x.outer` instead of `for_body`)
* Utility function `CreatePrintf` for inserting a `printf()` call into the generated LLVM IR.
* Utility function `CreateLookupReturnAddress`, to check the return address of the current function call.  This is useful when debugging buffer overruns that overwrite stack frames.