### PR TITLE
[TIR]Show meaningful message when input shape size mismatch with expected size.

### DIFF
--- a/src/tir/ir/data_layout.cc
+++ b/src/tir/ir/data_layout.cc
@@ -281,7 +281,9 @@ inline Array<PrimExpr> TransformShape(const Array<PrimExpr>& src_shape,
                                       const Array<IterVar>& target_axis,
                                       const Array<PrimExpr>& transform_rule) {
   arith::Analyzer ana;
-  ICHECK_EQ(src_shape.size(), src_axis.size());
+  ICHECK_EQ(src_shape.size(), src_axis.size())
+      << "Input shape size " << src_shape.size() << " mismatch with the exepected shape size "
+      << src_axis.size();
   // bind variables for original axes
   // for major-axis, bind the corresponding size
   // for minor-axis, simply bind it as 0, so that we can reuse forward/backward_rule,


### PR DESCRIPTION
[Issue]
When the transform function get a input data with incorrect shape size, the error message for example "src_shape.size() == src_axis.size() (6 vs. 4)" will be printed out, but the said message not provide enough information to help trouble shooting.

[Solution]
Add more meaningful error message.