### PR TITLE
[VM] Remove undesired arg to load_late_bound_consts

### DIFF
--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -306,7 +306,7 @@ class Executable(object):
 
     def load_late_bound_consts(self, path):
         """Re-load constants previously saved to file at path"""
-        return self._load_late_bound_consts(path, bytes)
+        return self._load_late_bound_consts(path)
 
 
 class VirtualMachine(object):

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -1159,6 +1159,20 @@ def test_large_constants():
     expected = x_data + const_data
     tvm.testing.assert_allclose(expected, actual.numpy())
 
+    # We load the mod again so it's missing the consts.
+    mod = runtime.load_module(path_dso)
+    exe = runtime.vm.Executable(mod)
+
+    # Also test loading consts via the VM's wrapper API.
+    exe.load_late_bound_consts(path_consts)
+
+    # Test main again with consts now loaded via the above API.
+    x_data = np.random.rand(1000, 1000).astype("float32")
+    the_vm = runtime.vm.VirtualMachine(exe, dev)
+    actual = the_vm.invoke("main", x_data)
+    expected = x_data + const_data
+    tvm.testing.assert_allclose(expected, actual.numpy())
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
`vm._load_late_bound_consts` was being passed the builtin `bytes`. I've removed the arg and extended a test to make sure this path is exercised.