### PR TITLE
[CI][Rust] Change rust installation profile from default to minimal

### DIFF
--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -24,9 +24,10 @@ set -o pipefail
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 # this rustc is one supported by the installed version of rust-sgx-sdk
-curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain stable
+curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
 export PATH=$CARGO_HOME/bin:$PATH
 rustup component add rustfmt
+rustup component add clippy
 
 # install wasmtime
 apt-get install -y --no-install-recommends libc6-dev-i386


### PR DESCRIPTION
Purpose of this change is to remove rust docs which we don't need for CI.
`/opt/rust` will be reduced from 1.0GB->551MB.

[Profiles - The rustup book](https://rust-lang.github.io/rustup/concepts/profiles.html)