### PR TITLE
[TIR] Encode conditional accesses info into block read/write regions

### DIFF
--- a/src/tir/transforms/compact_buffer_region.cc
+++ b/src/tir/transforms/compact_buffer_region.cc
@@ -123,12 +123,12 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
     StmtExprVisitor::VisitExpr(op->condition);
     {
       // Visit then branch
-      With<ConditionalBoundsContext> ctx(op->condition, &dom_map_, true);
+      With<ConditionalBoundsContext> ctx(op->condition, &dom_map_, &hint_map_, true);
       StmtExprVisitor::VisitStmt(op->then_case);
     }
     if (op->else_case.defined()) {
       // Visit else branch
-      With<ConditionalBoundsContext> ctx(op->condition, &dom_map_, false);
+      With<ConditionalBoundsContext> ctx(op->condition, &dom_map_, &hint_map_, false);
       StmtExprVisitor::VisitStmt(op->else_case);
     }
   }
@@ -139,12 +139,12 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
       StmtExprVisitor::VisitExpr(op->args[0]);
       {
         // Visit then branch
-        With<ConditionalBoundsContext> ctx(op->args[0], &dom_map_, true);
+        With<ConditionalBoundsContext> ctx(op->args[0], &dom_map_, &hint_map_, true);
         StmtExprVisitor::VisitExpr(op->args[1]);
       }
       {
         // Visit else branch
-        With<ConditionalBoundsContext> ctx(op->args[0], &dom_map_, false);
+        With<ConditionalBoundsContext> ctx(op->args[0], &dom_map_, &hint_map_, false);
         StmtExprVisitor::VisitExpr(op->args[2]);
       }
       return;
@@ -282,6 +282,8 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
 
   /*! \brief The map from loop vars to their iter range. */
   std::unordered_map<const VarNode*, arith::IntSet> dom_map_;
+  /*! \brief Extra map from free vars to their iter range hints. */
+  std::unordered_map<const VarNode*, arith::IntSet> hint_map_;
   /*! \brief The analyzer aware of loop domains. */
   arith::Analyzer dom_analyzer_;
   /*! \brief The map from Buffer to it's relaxed access set. */

--- a/src/tir/transforms/ir_utils.h
+++ b/src/tir/transforms/ir_utils.h
@@ -231,9 +231,9 @@ Bool IsFromLegacyTESchedule(PrimFunc f);
  *\brief Context helper to update domain map within conditional scope.
  *
  * Assume the condition is `0 <= i && i < 9` and global domain of i is [0, 20], thus `bounds[i]` is
- *[0, 8]. Then `With<ConditionalBoundsContext> ctx(&dom_map, bounds, true)` step into scope where
- *dom_map[i] is [0, 8] and `With<ConditionalBoundsContext> ctx(&dom_map, bounds, false)` step into
- *scope where dom_map[i] is [9, 20]
+ * [0, 8]. Then `With<ConditionalBoundsContext> ctx(condition, &relax_map, &hint_map, true)` step
+ *into scope where dom_map[i] is [0, 8] and `With<ConditionalBoundsContext> ctx(condition,
+ *&relax_map, &hint_map, false)` step into scope where dom_map[i] is [9, 20]
  */
 class ConditionalBoundsContext {
  private:
@@ -241,11 +241,13 @@ class ConditionalBoundsContext {
   /*!
    * \brief Construct a condition bounds context.
    * \param condition The condition holds on true branch.
-   * \param dom_map The global domain map to be updated.
+   * \param relax_map The domain map for relaxed vars to update.
+   * \param hint_map The domain map for free vars to update.
    * \param is_true_branch Whether step into the branch where condition bounds holds.
    */
   ConditionalBoundsContext(const PrimExpr& condition,
-                           std::unordered_map<const VarNode*, arith::IntSet>* dom_map,
+                           std::unordered_map<const VarNode*, arith::IntSet>* relax_map,
+                           std::unordered_map<const VarNode*, arith::IntSet>* hint_map,
                            bool is_true_branch);
   void EnterWithScope();
   void ExitWithScope();
@@ -255,8 +257,10 @@ class ConditionalBoundsContext {
 
   /*! \brief the condition holds on true branch. */
   const PrimExpr& condition_;
-  /*! \brief global domain map to updated */
-  std::unordered_map<const VarNode*, arith::IntSet>* dom_map_;
+  /*! \brief domain map for relaxed vars to update */
+  std::unordered_map<const VarNode*, arith::IntSet>* relax_map_;
+  /*! \brief domain map for free vars to update */
+  std::unordered_map<const VarNode*, arith::IntSet>* hint_map_;
   /*! \brief whether is on true branch */
   bool is_true_branch_;
   /*! \brief used to record and restore original var bounds */

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -413,6 +413,13 @@ def compacted_padding_pattern_func(a: T.handle, c: T.handle) -> None:
                 B[i, j] = A[i, j]
         for i, j in T.grid(20, 20):
             with T.block():
+                T.reads(
+                    B[
+                        T.max(i - 2, 0) : T.min(i + -2, 15) + 1,
+                        T.max(j - 2, 0) : T.min(j + -2, 15) + 1,
+                    ]
+                )
+                T.writes(C[i, j])
                 C[i, j] = T.if_then_else(
                     2 <= i and i < 18 and 2 <= j and j < 18, B[i - 2, j - 2], 0.0, dtype="float32"
                 )

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -24,6 +24,7 @@ def _check(original, transformed):
     mod = tvm.IRModule.from_expr(func)
     mod = tvm.tir.transform.CompactBufferAllocation()(mod)
     mod = tvm.tir.transform.Simplify()(mod)
+    transformed = tvm.tir.transform.Simplify()(tvm.IRModule.from_expr(transformed))["main"]
     tvm.ir.assert_structural_equal(mod["main"], transformed)
 
 
@@ -413,13 +414,6 @@ def compacted_padding_pattern_func(a: T.handle, c: T.handle) -> None:
                 B[i, j] = A[i, j]
         for i, j in T.grid(20, 20):
             with T.block():
-                T.reads(
-                    B[
-                        T.max(i - 2, 0) : T.min(i + -2, 15) + 1,
-                        T.max(j - 2, 0) : T.min(j + -2, 15) + 1,
-                    ]
-                )
-                T.writes(C[i, j])
                 C[i, j] = T.if_then_else(
                     2 <= i and i < 18 and 2 <= j and j < 18, B[i - 2, j - 2], 0.0, dtype="float32"
                 )


### PR DESCRIPTION
When we analysis block read/write regions, there are constraints on iter vars not defined within block body. These vars should not be relaxed, but do affect the actual accessed regions. 

```python
for i in range(16):
  with T.block():
      if i < 8: 
        # access X[i]
```

Current analysis will ignore the constraint `i < 8` (`i` is free when analyzing on the block's scope), and get the read region `T.reads([X[i:i+1])`. This would be an overly relaxed region. If the block nodes are designed to isolate the inner behaviors, the conditional access info will get lost in the read/write annotations.

The pr make a trial to keep awareness also on the free iter vars out of relaxed domain in `BlockReadWriteDetector`. The result region is intersected with itself relaxed on the domain of free vars. For the case above, it would be `[i, i+1) ^ [0, 8)`, thus if i >= 8, the read region of X becomes empty.