### PR TITLE
[GraphExecutor] Add API `get_input_info` to graph_executor

### DIFF
--- a/python/tvm/contrib/graph_executor.py
+++ b/python/tvm/contrib/graph_executor.py
@@ -158,6 +158,7 @@ class GraphModule(object):
         self._get_input = module["get_input"]
         self._get_num_outputs = module["get_num_outputs"]
         self._get_input_index = module["get_input_index"]
+        self._get_input_info = module["get_input_info"]
         self._get_num_inputs = module["get_num_inputs"]
         self._load_params = module["load_params"]
         self._share_params = module["share_params"]
@@ -257,6 +258,32 @@ class GraphModule(object):
             The input index. -1 will be returned if the given input name is not found.
         """
         return self._get_input_index(name)
+
+    def get_input_info(self):
+        """Return the 'shape' and 'dtype' dictionaries of the graph.
+
+        .. note::
+            We can't simply get the input tensors from a TVM graph
+            because weight tensors are treated equivalently. Therefore, to
+            find the input tensors we look at the 'arg_nodes' in the graph
+            (which are either weights or inputs) and check which ones don't
+            appear in the params (where the weights are stored). These nodes
+            are therefore inferred to be input tensors.
+
+        Returns
+        -------
+        shape_dict : Map
+            Shape dictionary - {input_name: tuple}.
+        dtype_dict : Map
+            dtype dictionary - {input_name: dtype}.
+        """
+        input_info = self._get_input_info()
+        assert "shape" in input_info
+        shape_dict = input_info["shape"]
+        assert "dtype" in input_info
+        dtype_dict = input_info["dtype"]
+
+        return shape_dict, dtype_dict
 
     def get_output(self, index, out=None):
         """Get index-th output to out

--- a/python/tvm/runtime/container.py
+++ b/python/tvm/runtime/container.py
@@ -161,3 +161,14 @@ class ShapeTuple(Object):
 
     def __getitem__(self, idx):
         return getitem_helper(self, _ffi_api.GetShapeTupleElem, len(self), idx)
+
+    def __eq__(self, other):
+        if self.same_as(other):
+            return True
+        if len(self) != len(other):
+            return False
+        for a, b in zip(self, other):
+            if a != b:
+                return False
+
+        return True

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -33,7 +33,9 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -71,6 +73,8 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   };
 
  public:
+  using ShapeInfo = Map<String, ObjectRef>;
+  using DtypeInfo = Map<String, ObjectRef>;
   /*!
    * \brief Get member function to front-end
    * \param name The name of the function.
@@ -106,6 +110,12 @@ class TVM_DLL GraphExecutor : public ModuleNode {
    * \return The index of input.
    */
   int GetInputIndex(const std::string& name);
+
+  /*!
+   * \brief Get the input info of Graph by parsing the input nodes.
+   * \return The shape and dtype tuple.
+   */
+  std::tuple<ShapeInfo, DtypeInfo> GetInputInfo() const;
 
   /*!
    * \brief Get the output index given the name of output.
@@ -417,6 +427,8 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   std::vector<Node> nodes_;
   /*! \brief The argument nodes. */
   std::vector<uint32_t> input_nodes_;
+  /*! \brief The parameter names. */
+  std::unordered_set<std::string> param_names_;
   /*! \brief Map of input names to input indices. */
   std::unordered_map<std::string, uint32_t> input_map_;
   /*! \brief Map of output names to output indices. */

--- a/tests/python/relay/test_backend_graph_executor.py
+++ b/tests/python/relay/test_backend_graph_executor.py
@@ -325,6 +325,21 @@ def test_graph_executor_api():
     assert mod.get_input_index(dname_0) == 0
     assert mod.get_input_index("Invalid") == -1
 
+    shape_dict, dtype_dict = mod.get_input_info()
+    assert isinstance(shape_dict, tvm.container.Map)
+    assert isinstance(dtype_dict, tvm.container.Map)
+    for data in [data_0, data_1]:
+        name = data.name_hint
+        ty = data.type_annotation
+        # verify shape
+        assert name in shape_dict
+        assert isinstance(shape_dict[name], tvm.runtime.container.ShapeTuple)
+        assert shape_dict[name] == tvm.runtime.container.ShapeTuple([i.value for i in ty.shape])
+        # verify dtype
+        assert name in dtype_dict
+        assert isinstance(dtype_dict[name], tvm.runtime.container.String)
+        assert dtype_dict[name] == ty.dtype
+
 
 @tvm.testing.requires_llvm
 def test_benchmark():

--- a/tests/python/unittest/test_runtime_container.py
+++ b/tests/python/unittest/test_runtime_container.py
@@ -83,6 +83,12 @@ def test_shape_tuple():
     len(stuple) == len(shape)
     for a, b in zip(stuple, shape):
         assert a == b
+    # ShapleTuple vs. list
+    assert stuple == list(shape)
+    # ShapleTuple vs. tuple
+    assert stuple == tuple(shape)
+    # ShapleTuple vs. ShapeTuple
+    assert stuple == _container.ShapeTuple(shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi All,

In the GraphExecutor use case, we always should get the input info of a compiled graph module, including shape and dtype. For `TVMC`, it provides [get_input_info](https://github.com/apache/tvm/blob/8c40dfd8493aff01f055ef13f2d44caedf5cf74b/python/tvm/driver/tvmc/runner.py#L583-L584) to get and then to generate the input data. But it is inconvenient if we only deploy the CPP runtime because there is no graph info to be exposed outside of GraphExecutor, and it is very cumbersome to load and parse the Graph JSON again. So here I move the `get_input_info` function into GraphExecutor, then we can easily write a [make_inputs_dict](https://github.com/apache/tvm/blob/8c40dfd8493aff01f055ef13f2d44caedf5cf74b/python/tvm/driver/tvmc/runner.py#L372) function on the CPP side.