### PR TITLE
[Int8] Support cublas on e2e int8 models (also tried cudnn but doesn't work)

### DIFF
--- a/python/tvm/topi/cuda/dense.py
+++ b/python/tvm/topi/cuda/dense.py
@@ -42,10 +42,11 @@ def _matmul_cublas_common(
         assert len(bias.shape) == 1
     if out_dtype is None:
         out_dtype = tensor_a.dtype
-    assert out_dtype == tensor_a.dtype, "Mixed precision not supported."
+    if out_dtype != tensor_a.dtype and out_dtype != "int32":
+        assert out_dtype == tensor_a.dtype, "Mixed precision other than int8 + int32 not supported."
     batch, in_dim = get_const_tuple(tensor_a.shape)
     out_dim, _ = get_const_tuple(tensor_b.shape)
-    matmul = cublas.matmul(tensor_a, tensor_b, transpose_a, transpose_b)
+    matmul = cublas.matmul(tensor_a, tensor_b, transpose_a, transpose_b, dtype=out_dtype)
     if all(isinstance(d, int) for d in [batch, in_dim, out_dim]):
         cfg.add_flop(batch * in_dim * out_dim * 2)
     if bias is not None:

--- a/python/tvm/topi/cuda/dense.py
+++ b/python/tvm/topi/cuda/dense.py
@@ -42,7 +42,7 @@ def _matmul_cublas_common(
         assert len(bias.shape) == 1
     if out_dtype is None:
         out_dtype = tensor_a.dtype
-    if out_dtype != tensor_a.dtype and out_dtype != "int32":
+    if out_dtype not in [tensor_a.dtype, "int32"]:
         assert out_dtype == tensor_a.dtype, "Mixed precision other than int8 + int32 not supported."
     batch, in_dim = get_const_tuple(tensor_a.shape)
     out_dim, _ = get_const_tuple(tensor_b.shape)

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -140,29 +140,35 @@ WorkloadType GetWorkload(const Array<tvm::relay::Type>& arg_types, const Conv2DA
   int out_channels, kernel_h, kernel_w;
   int channel_multiplier = -1;
   bool depthwise = is_depthwise(param);
-  if (param->kernel_layout == "OIHW") {
-    out_channels = get_const_int(kernel_shape[0]);
-    kernel_h = get_const_int(kernel_shape[2]);
-    kernel_w = get_const_int(kernel_shape[3]);
-    if (depthwise) {
-      channel_multiplier = get_const_int(kernel_shape[1]);
-    }
-  } else if (param->kernel_layout == "HWIO") {
-    kernel_h = get_const_int(kernel_shape[0]);
-    kernel_w = get_const_int(kernel_shape[1]);
-    out_channels = get_const_int(kernel_shape[3]);
-    if (depthwise) {
-      channel_multiplier = get_const_int(kernel_shape[2]);
-    }
+  int index_k = 0;
+  int index_h = 2;
+  int index_w = 3;
+  int index_c = 1;
+  if (param->kernel_layout == "HWIO") {
+    index_k = 3;
+    index_h = 0;
+    index_w = 1;
+    index_c = 2;
   } else if (param->kernel_layout == "HWOI") {
-    kernel_h = get_const_int(kernel_shape[0]);
-    kernel_w = get_const_int(kernel_shape[1]);
-    out_channels = get_const_int(kernel_shape[2]);
-    if (depthwise) {
-      channel_multiplier = get_const_int(kernel_shape[3]);
-    }
-  } else {
+    index_k = 2;
+    index_h = 0;
+    index_w = 1;
+    index_c = 3;
+  } else if (param->kernel_layout == "OHWI") {
+    index_k = 0;
+    index_h = 1;
+    index_w = 2;
+    index_c = 3;
+  } else if (param->kernel_layout != "OIHW") {
     LOG(FATAL) << "qnn.conv2d does not support " << param->kernel_layout << " layout";
+  }
+
+  kernel_h = get_const_int(kernel_shape[index_h]);
+  kernel_w = get_const_int(kernel_shape[index_w]);
+  out_channels = get_const_int(kernel_shape[index_k]);
+
+  if (depthwise) {
+    channel_multiplier = get_const_int(kernel_shape[index_c]);
   }
 
   return std::make_tuple(batch_size, in_channels, out_channels, kernel_h, kernel_w,
@@ -519,6 +525,8 @@ Expr Conv2DThirdTerm(const Expr& weight, const Expr& input_zero_point, const Con
     axes_t3 = {0, 1, 2};
   } else if (param->kernel_layout == "HWOI") {
     axes_t3 = {0, 1, 3};
+  } else if (param->kernel_layout == "OHWI") {
+    axes_t3 = {0, 1, 2};
   } else {
     LOG(FATAL) << "qnn.conv2d does not support " << param->kernel_layout << " layout";
   }
@@ -701,8 +709,8 @@ Expr QnnConv2DCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   ICHECK(param->data_layout == "NCHW" || param->data_layout == "NHWC")
       << "qnn.conv2d supports only NCHW/NHWC input data layout.";
   ICHECK(param->kernel_layout == "OIHW" || param->kernel_layout == "HWIO" ||
-         param->kernel_layout == "HWOI")
-      << "qnn.conv2d supports only OIHW/HWIO/HWOI kernel data layout.";
+         param->kernel_layout == "HWOI" || param->kernel_layout == "OHWI")
+      << "qnn.conv2d supports only OIHW/HWIO/HWOI/OHWI kernel data layout.";
   ICHECK(param->kernel_size.defined()) << "qnn.conv2d requires kernel size to be specified.";
 
   int batch_size, in_channels, out_channels, kernel_h, kernel_w, channel_multiplier;

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -526,7 +526,7 @@ Expr Conv2DThirdTerm(const Expr& weight, const Expr& input_zero_point, const Con
   } else if (param->kernel_layout == "HWOI") {
     axes_t3 = {0, 1, 3};
   } else if (param->kernel_layout == "OHWI") {
-    axes_t3 = {0, 1, 2};
+    axes_t3 = {1, 2, 3};
   } else {
     LOG(FATAL) << "qnn.conv2d does not support " << param->kernel_layout << " layout";
   }


### PR DESCRIPTION
Currently, int8 GEMM (int32 output) by cublas is supported only when `contrib.cublas.matmul` is called directly. Fixed that for use in topi / relay (qnn).

Although [the doc](https://docs.nvidia.com/cuda/cublas/index.html#tensorop-restrictions) says  `Starting with cuBLAS version 11.0.0 there are no longer any restriction on matrix dimensions and memory alignments to use Tensor Cores`, the leading dimension is still needs to be 4-byte aligned for int8 (otherwise I get `CUBLAS_STATUS_NOT_SUPPORTED`).

I also added `OHWI` kernel layout support to QNN convolution, to support cudnn on e2e int8 models. But it turned out that **cudnn int8 support is unusable from TVM**.

Currently, the output dtype of cudnn conv2d is hard-coded to be the same type as input (`data_type`): https://github.com/apache/tvm/blob/70de68a38f6738255cc71fd9a38964b23f2c5f55/src/runtime/contrib/cudnn/conv_forward.cc#L88-L89
So it only does `(int8, int8) -> int8` conv2d with internal int32 accumulation + clipping at the end. But what we need is `(int8, int8) -> int32`. If I replace the output dtype to be int32, cuDNN would give `Unsupported` error. This makes it impossible to use cuDNN on real int8 models.

[The doc](https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html#rel-831) also says `The numeric behavior of INT8 operations including saturation behavior, accumulator data types, etc. have not been documented as of yet`. So I can only assume that int8 support in cudnn is premature or simply broken. I wonder how TRT supports int8 convolution.

@Laurawly @Hzfengsy @comaniac @vinx13 Let me know if my finding sounds legit or if I'm missing something (I hope so!)