### PR TITLE
[FIX,AUTOTVM] Add backtraces to tuning errors

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -694,7 +694,10 @@ def run_through_rpc(
             msg = msg[: msg.index("Stack trace returned")]
         if "CUDA Source" in msg:
             msg = msg[: msg.index("CUDA Source")]
-        costs = (traceback.format_exc(), RuntimeError(msg[:1024]),)
+        costs = (
+            traceback.format_exc(),
+            RuntimeError(msg[:1024]),
+        )
         errno = MeasureErrorNo.RUNTIME_DEVICE
     tstamp = time.time()
     time.sleep(cooldown_interval)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -159,7 +159,10 @@ class LocalBuilder(Builder):
                                 except Exception:  # pylint: disable=broad-except
                                     pass
                                 res = MeasureResult(
-                                    (tb, InstantiationError(msg),),
+                                    (
+                                        tb,
+                                        InstantiationError(msg),
+                                    ),
                                     MeasureErrorNo.INSTANTIATION_ERROR,
                                     res.time_cost,
                                     time.time(),
@@ -167,7 +170,10 @@ class LocalBuilder(Builder):
 
                             else:  # tvm error
                                 res = MeasureResult(
-                                    (tb, res.error,),
+                                    (
+                                        tb,
+                                        res.error,
+                                    ),
                                     MeasureErrorNo.COMPILE_HOST,
                                     res.time_cost,
                                     time.time(),
@@ -175,12 +181,21 @@ class LocalBuilder(Builder):
                 except TimeoutError as ex:
                     tb = traceback.format_exc()
                     res = MeasureResult(
-                        (tb, ex,), MeasureErrorNo.BUILD_TIMEOUT, self.timeout, time.time()
+                        (
+                            tb,
+                            ex,
+                        ),
+                        MeasureErrorNo.BUILD_TIMEOUT,
+                        self.timeout,
+                        time.time(),
                     )
                 except ChildProcessError as ex:
                     tb = traceback.format_exc()
                     res = MeasureResult(
-                        (tb, ex,),
+                        (
+                            tb,
+                            ex,
+                        ),
                         MeasureErrorNo.RUNTIME_DEVICE,
                         self.timeout,
                         time.time(),
@@ -371,7 +386,10 @@ class RPCRunner(Runner):
                     tb = traceback.format_exc()
                     results.append(
                         MeasureResult(
-                            (tb + "\n" + str(ex),), MeasureErrorNo.RUN_TIMEOUT, self.timeout, time.time()
+                            (tb + "\n" + str(ex),),
+                            MeasureErrorNo.RUN_TIMEOUT,
+                            self.timeout,
+                            time.time(),
                         )
                     )
 

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -694,7 +694,7 @@ def run_through_rpc(
             msg = msg[: msg.index("Stack trace returned")]
         if "CUDA Source" in msg:
             msg = msg[: msg.index("CUDA Source")]
-        costs = (RuntimeError(msg[:1024]),)
+        costs = (traceback.format_exc(), RuntimeError(msg[:1024]),)
         errno = MeasureErrorNo.RUNTIME_DEVICE
     tstamp = time.time()
     time.sleep(cooldown_interval)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -141,11 +141,18 @@ class LocalBuilder(Builder):
                 try:
                     res = future.result()
                     if res.error is not None:
+                        assert len(res.error) == 2, (
+                            f"BuildResult errors should be a 2-tuple, but it is a {len(res.error)}"
+                            "-tuple. This should not happen!"
+                        )
                         tb, exception = res.error
                         # instantiation error
                         if isinstance(exception, InstantiationError):
                             res = MeasureResult(
-                                (tb, exception,),
+                                (
+                                    tb,
+                                    exception,
+                                ),
                                 MeasureErrorNo.INSTANTIATION_ERROR,
                                 res.time_cost,
                                 time.time(),

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -393,7 +393,10 @@ class RPCRunner(Runner):
                     tb = traceback.format_exc()
                     results.append(
                         MeasureResult(
-                            (tb + "\n" + str(ex),),
+                            (
+                                tb,
+                                ex,
+                            ),
                             MeasureErrorNo.RUN_TIMEOUT,
                             self.timeout,
                             time.time(),

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -141,17 +141,17 @@ class LocalBuilder(Builder):
                 try:
                     res = future.result()
                     if res.error is not None:
+                        tb, exception = res.error
                         # instantiation error
-                        if isinstance(res.error, InstantiationError):
+                        if isinstance(exception, InstantiationError):
                             res = MeasureResult(
-                                (res.error,),
+                                (tb, exception,),
                                 MeasureErrorNo.INSTANTIATION_ERROR,
                                 res.time_cost,
                                 time.time(),
                             )
 
                         else:
-                            tb, exception = res.error
                             if "InstantiationError" in str(exception):
                                 msg = str(exception)
                                 try:

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -141,7 +141,7 @@ class Tuner(object):
                 else:
                     flops = 0
                     error_ct += 1
-                    tb, error = res.costs[0]
+                    tb, error = res.costs
                     if isinstance(error, str):
                         errors.append(tb + "\n" + error)
                     else:

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -141,11 +141,11 @@ class Tuner(object):
                 else:
                     flops = 0
                     error_ct += 1
-                    error = res.costs[0]
+                    tb, error = res.costs[0]
                     if isinstance(error, str):
-                        errors.append(error)
+                        errors.append(tb + "\n" + error)
                     else:
-                        errors.append(str(error))
+                        errors.append(tb + "\n" + str(error))
 
                 if flops > self.best_flops:
                     self.best_flops = flops

--- a/python/tvm/runtime/object.py
+++ b/python/tvm/runtime/object.py
@@ -64,7 +64,7 @@ class Object(ObjectBase):
         try:
             return _ffi_node_api.NodeGetAttr(self, name)
         except AttributeError:
-            raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
+            raise AttributeError("%s has no attribute %s" % (str(type(self)), name)) from None
 
     def __hash__(self):
         return _ffi_api.ObjectPtrHash(self)


### PR DESCRIPTION
Collects tracebacks in LocalBuilder and LocalRunner and adds them to the error messages.

@masahi
