### PR TITLE
[Hexagon] Include Utils.cmake for tvm_file_glob used in HexagonSDK.cmake

### DIFF
--- a/apps/hexagon_launcher/cmake/HexagonLauncher.cmake
+++ b/apps/hexagon_launcher/cmake/HexagonLauncher.cmake
@@ -25,6 +25,7 @@ endif()
 set(TVM_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../")
 
 include(ExternalProject)
+include("${TVM_SOURCE_DIR}/cmake/utils/Utils.cmake")
 include("${TVM_SOURCE_DIR}/cmake/modules/HexagonSDK.cmake")
 
 find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}")

--- a/apps/hexagon_proxy_rpc/cmake/HexagonRPC.cmake
+++ b/apps/hexagon_proxy_rpc/cmake/HexagonRPC.cmake
@@ -25,6 +25,7 @@ endif()
 set(TVM_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../")
 
 include(ExternalProject)
+include("${TVM_SOURCE_DIR}/cmake/utils/Utils.cmake")
 include("${TVM_SOURCE_DIR}/cmake/modules/HexagonSDK.cmake")
 
 find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}")

--- a/cmake/libs/hexagon_rpc_skel/CMakeLists.txt
+++ b/cmake/libs/hexagon_rpc_skel/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TVM_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
 set(TVM_SRC_DIR "${TVM_SOURCE_DIR}/src")
 
 
+include("${TVM_SOURCE_DIR}/cmake/utils/Utils.cmake")
 include("${TVM_SOURCE_DIR}/cmake/modules/HexagonSDK.cmake")
 
 find_hexagon_sdk_root("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}")

--- a/src/runtime/hexagon/android/sim/driver/CMakeLists.txt
+++ b/src/runtime/hexagon/android/sim/driver/CMakeLists.txt
@@ -24,6 +24,8 @@ if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/config.cmake)
   include(${CMAKE_CURRENT_BINARY_DIR}/config.cmake)
 endif()
 
+include(../../../../../../cmake/utils/Utils.cmake)
+
 if("${HEXAGON_ARCH}" STREQUAL "")
   set(DEFAULT_HEXAGON_ARCH "v66")
   message(STATUS "HEXAGON_ARCH not defined, defaulting to ${DEFAULT_HEXAGON_ARCH}")

--- a/src/runtime/hexagon/android/target/fastrpc/CMakeLists.txt
+++ b/src/runtime/hexagon/android/target/fastrpc/CMakeLists.txt
@@ -23,7 +23,8 @@ if(NOT "${FASTRPC_LIBS}" STREQUAL "SKEL" AND
   message(SEND_ERROR "Please set FASTRPC_LIBS to either SKEL or STUB")
 endif()
 
-include(../../../../../cmake/modules/HexagonSDK.cmake)
+include(../../../../../../cmake/utils/Utils.cmake)
+include(../../../../../../cmake/modules/HexagonSDK.cmake)
 
 find_hexagon_sdk_root("${HEXAGON_SDK_ROOT}" "${HEXAGON_ARCH}")
 


### PR DESCRIPTION
Don't include it from HexagonSDK.cmake because the Hexagon SDK file can be included from different directories.