### PR TITLE
[TEST] Remove `llvm -device=arm_cpu` and `cuda -libs=cudnn` from default enabled list

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -433,9 +433,7 @@ def _get_targets(target_str=None):
 
 DEFAULT_TEST_TARGETS = [
     "llvm",
-    "llvm -device=arm_cpu",
     "cuda",
-    "cuda -model=unknown -libs=cudnn",
     "nvptx",
     "vulkan -from_device=0",
     "opencl",


### PR DESCRIPTION
Right now `tvm.testing.enabled_targets()` return `llvm -device=arm_cpu` and `cuda -libs=cudnn` (if cudnn is enabled, applies to CI env) in addition to `llvm` and `cuda`. So all tests that loop over enabled targets using `tvm.testing.enabled_targets()` are essentially running x86 and cuda tests twice. 

I don't see a reason to run `llvm -device=arm_cpu` tests in addition to `llvm`. For cudnn, we have separate unit tests dedicated for it, we don't need to run full integration tests with it.

I did this change for PyTorch in https://github.com/apache/tvm/pull/9781 and it sped up local testing time significantly. It should make the CI situation a lot better.

@areusch @leandron @Lunderberg @driazati 