### PR TITLE
Run extract constants pass only for CMSIS-NN target

### DIFF
--- a/src/relay/backend/contrib/cmsisnn/extract_constants.cc
+++ b/src/relay/backend/contrib/cmsisnn/extract_constants.cc
@@ -50,6 +50,18 @@ class ExtractConstantsMutator : public MixedModeMutator {
 
   Expr VisitExpr_(const FunctionNode* function) final {
     Function func = GetRef<Function>(function);
+    auto composite_name = func->GetAttr<String>(attr::kComposite);
+    if (composite_name.defined()) {
+      std::string name = composite_name.value().operator std::string();
+      if (name.find("cmsis-nn") == std::string::npos) {
+        return func;
+      }
+    }
+    auto compiler_name = func->GetAttr<String>(::tvm::relay::attr::kCompiler);
+    if (compiler_name.defined() && compiler_name != "cmsis-nn") {
+      return func;
+    }
+
     function_to_constants_.Set(func, Array<Constant>{});
     functions_.push_back(func);
     auto new_body = VisitExpr(func->body);


### PR DESCRIPTION
Run extract constant pass only for CMSIS-NN

-Added checks for CMSIS-NN target in the pass extract_constant
-Added a negative test with nested functions mapped to a combination of cmsis-nn and other compiler
