### PR TITLE
[skip ci] Revert "[community] @AndrewZhaoLuo -> Committer (#9896)"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,8 +48,8 @@ We do encourage everyone to work anything they are interested in.
 - [Wuwei Lin](https://github.com/vinx13): @vinx13 - relay, topi
 - [Yizhi Liu](https://github.com/yzhliu) (PMC): @yzhliu - jvm, topi, relay
 - [Hao Lu](https://github.com/hlu1): @hlu1 - nnpack, frontends
-- [Eric Lunderberg](https://github.com/Lunderberg): @Lunderberg - CI, Vulkan backend
-- [Andrew Z. Luo](https://github.com/AndrewZhaoLuo): @AndrewZhaoLuo - amp, relay, frontends
+- [Eric Lunderberg](https://github.com/Lunderberg): @Lunderberg - CI, Vulkan
+  backend
 - [Steven Lyubomirsky](https://github.com/slyubomirsky): @slyubomirsky - relay
 - [Masahiro Masuda](https://github.com/masahi) (PMC): @masahi - topi, relay
 - [Thierry Moreau](https://github.com/tmoreau89) (PMC): @tmoreau89 - vta


### PR DESCRIPTION
This reverts commit 9d867c207db1b991387682ffcc023de356b5d35b.

Note: This PR is a test of the skip CI functionality from #9554. It was made with:

```bash
git checkout -b revert_test
git revert HEAD
gh pr create --draft
```

ps: sorry andrew
