### PR TITLE
[Object] Throw AttributeError if the object doesn't have a reflection table.

### DIFF
--- a/include/tvm/node/reflection.h
+++ b/include/tvm/node/reflection.h
@@ -387,8 +387,7 @@ inline ReflectionVTable::Registry ReflectionVTable::Register() {
 inline void ReflectionVTable::VisitAttrs(Object* self, AttrVisitor* visitor) const {
   uint32_t tindex = self->type_index();
   if (tindex >= fvisit_attrs_.size() || fvisit_attrs_[tindex] == nullptr) {
-    LOG(FATAL) << "TypeError: " << self->GetTypeKey()
-               << " is not registered via TVM_REGISTER_NODE_TYPE";
+    return;
   }
   fvisit_attrs_[tindex](self, visitor);
 }

--- a/tests/python/unittest/test_tir_schedule_error.py
+++ b/tests/python/unittest/test_tir_schedule_error.py
@@ -67,5 +67,11 @@ def test_tir_schedule_error_none():
     assert "(not rendered)" in msg
 
 
+def test_tir_schedule_attribute_error():
+    sch = tir.Schedule(matmul)
+    with pytest.raises(AttributeError):
+        sch.non_existent_field()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
There are a few objects only registered via `TVM_REGISTER_OBJECT_TYPE` instead of `TVM_REGISTER_NODE_TYPE`. They don't have reflections tables available. From python ffi, any registered objects will always go into `NodeGetAttr`, even if some of them don't reflection table. After this PR, it will raises `AttributeError` instead here https://github.com/apache/tvm/blob/main/src/node/reflection.cc#L108-L111

@junrushao1994 @tqchen @Hzfengsy 