### PR TITLE
[Relay] Add printer for op strategy objects

### DIFF
--- a/src/relay/ir/op_strategy.cc
+++ b/src/relay/ir/op_strategy.cc
@@ -104,5 +104,19 @@ TVM_REGISTER_GLOBAL("relay.op._OpStrategyAddImplementation")
       strategy.AddImplementation(compute, schedule, name, plevel);
     });
 
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<OpStrategyNode>([](const ObjectRef& node, ReprPrinter* p) {
+      auto* op = static_cast<const OpStrategyNode*>(node.get());
+      p->stream << "op_strategy(" << op->specializations << ")";
+    })
+    .set_dispatch<OpSpecializationNode>([](const ObjectRef& node, ReprPrinter* p) {
+      auto* op = static_cast<const OpSpecializationNode*>(node.get());
+      p->stream << "op_spec(" << op->condition << ", " << op->implementations << ")";
+    })
+    .set_dispatch<OpImplementationNode>([](const ObjectRef& node, ReprPrinter* p) {
+      auto* op = static_cast<const OpImplementationNode*>(node.get());
+      p->stream << "op_impl(name=" << op->name << ", level=" << op->plevel << ")";
+    });
+
 }  // namespace relay
 }  // namespace tvm


### PR DESCRIPTION
Add the printer to print `OpStrategyNode`, `OpSpecializationNode` and `OpImplementationNode` for debug purpose. :) An example as below.
```python
op_strategy([op_spec((nullptr), [op_impl(name=conv2d_nchw.x86, level=10)])])
```