### PR TITLE
[skip ci] Fix missing pack_lib in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -571,6 +571,7 @@ stage('Test') {
               label: 'Build docs',
             )
           }
+          pack_lib('docs', 'docs.tgz')
         }
       }
     }
@@ -599,7 +600,7 @@ stage('Deploy') {
     node('doc') {
       ws(per_exec_ws('tvm/deploy-docs')) {
         if (env.BRANCH_NAME == 'main') {
-        unpack_lib('mydocs', 'docs.tgz')
+        unpack_lib('docs', 'docs.tgz')
         sh 'cp docs.tgz /var/docs/docs.tgz'
         sh 'tar xf docs.tgz -C /var/docs'
         }


### PR DESCRIPTION
[This](https://github.com/apache/tvm/blob/d216730c81273d739f7bdf67f16229a34c31ee70/Jenkinsfile#L542-L558) was inadvertently removed by #9554, causing failures on `main` like https://ci.tlcpack.ai/job/tvm/job/main/2381/console

