### PR TITLE
Propagate ssh-agent authentication socket

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -199,7 +199,9 @@ if [[ -n ${COMMAND} ]]; then
     echo ${DOCKER_BINARY}
     ${DOCKER_BINARY} run --rm --pid=host \
         -v ${WORKSPACE}:/workspace \
+        ${SSH_AUTH_SOCK:+-v $SSH_AUTH_SOCK:/ssh-agent} \
         -w /workspace \
+        ${SSH_AUTH_SOCK:+-e "SSH_AUTH_SOCK=/ssh-agent"} \
         -e "CI_BUILD_HOME=/workspace" \
         -e "CI_BUILD_USER=$(id -u -n)" \
         -e "CI_BUILD_UID=$(id -u)" \


### PR DESCRIPTION
In case that SSH_AUTH_SOCK is defined, two items will be added to the docker run command:
1) A propagated ssh authentication socket value , to support
   an underlying ssh calls inside the running container.
2) A mounted volume for ssh channel.

cc @Leo-arm @leandron @Mousius  for reviews