### PR TITLE
[TOPI] fix icelake target for avx512 and vnni

### DIFF
--- a/python/tvm/topi/x86/utils.py
+++ b/python/tvm/topi/x86/utils.py
@@ -81,8 +81,8 @@ def target_has_avx512(target):
         # explicit enumeration of VNNI capable due to collision with alderlake
         "cascadelake",
         "icelake-client",
+        "icelake-server",
         "rocketlake",
-        "icelake",
         "tigerlake",
         "cooperlake",
         "sapphirerapids",
@@ -93,8 +93,8 @@ def target_has_vnni(target):
     return target in {
         "cascadelake",
         "icelake-client",
+        "icelake-server",
         "rocketlake",
-        "icelake",
         "tigerlake",
         "cooperlake",
         "sapphirerapids",


### PR DESCRIPTION
@elvin-n @masahi 

The mcpu target list for icelake was wrong, there is icelake-client and icelake-server, but not plain icelake.

Thanks!