### PR TITLE
[microNPU] Refactor base address determination to codegen

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/util.py
+++ b/python/tvm/relay/backend/contrib/ethosu/util.py
@@ -23,7 +23,7 @@ Refer to the description inside such functions
 
 from inspect import signature
 from enum import Enum
-from typing import Union, Tuple
+from typing import Union, Tuple, List
 import numpy as np  # type: ignore
 
 import tvm  # type: ignore
@@ -239,6 +239,31 @@ def calculate_size_bytes(expr):
     return element_size * elements
 
 
+@register_object("relay.ext.ethos-u.BaseAddress")
+class BaseAddress(Object):
+    """
+    This is a structure to hold base addresses for pointers
+    provided for the driver.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        primfunc_param_idx: int,
+        region: int,
+        size: int,
+        is_runtime_allocation: bool = False,
+    ):
+        self.__init_handle_by_constructor__(
+            _ffi_api.BaseAddress,  # type: ignore # pylint: disable=no-member
+            name,
+            primfunc_param_idx,
+            region,
+            size,
+            is_runtime_allocation,
+        )
+
+
 @register_object("relay.ext.ethos-u.CompilationArtifact")
 class CompilationArtifact(Object):
     """
@@ -248,19 +273,15 @@ class CompilationArtifact(Object):
 
     def __init__(
         self,
+        function_name: str,
         command_stream: str,
         encoded_constants: str,
-        scratch_size: int,
-        input_size: int,
-        output_size: int,
-        function_name: str,
+        base_addresses: List[BaseAddress],
     ):
         self.__init_handle_by_constructor__(
             _ffi_api.CompilationArtifact,  # type: ignore # pylint: disable=no-member
+            function_name,
             command_stream,
             encoded_constants,
-            scratch_size,
-            input_size,
-            output_size,
-            function_name,
+            base_addresses,
         )

--- a/src/relay/backend/contrib/ethosu/source_module.cc
+++ b/src/relay/backend/contrib/ethosu/source_module.cc
@@ -124,7 +124,9 @@ class EthosUModuleNode : public ModuleNode {
  private:
   std::string c_source;
   Array<CompilationArtifact> compilation_artifacts_;
+  Map<Integer, String> pool_var_names_;
   int indent_{0};
+  constexpr static int kMaxBaseAddresses_ = 6;
 
   /*!
    * \brief Convert the raw string of hex values into a hex string
@@ -150,7 +152,7 @@ class EthosUModuleNode : public ModuleNode {
    * \return string of code that updates the base_addrs array with the base address of the given
    * array
    */
-  std::string SetBaseAddress(int index, std::string name, std::string size) {
+  std::string SetBaseAddress(int index, std::string name, int size) {
     std::stringstream ss;
     ss << "  base_addrs[" << index << "] = (uintptr_t)(" << name << ");\n";
     ss << "  base_addrs_size[" << index << "] = " << size << ";\n";
@@ -178,11 +180,24 @@ class EthosUModuleNode : public ModuleNode {
   }
 
   /*!
-   * \brief Creates a runtime function header
+   * \brief Creates a runtime function signature
    */
-  void PrintRuntimeFunctionHeader(std::stringstream& ss, std::string func_name) {
-    ss << "TVM_DLL int32_t ";
-    ss << func_name << "(void* input, void* output, void* resource_handle) {\n";
+  void PrintRuntimeFunctionSignature(std::stringstream& ss,
+                                     const relay::contrib::ethosu::CompilationArtifact& artifact,
+                                     std::string func_name) {
+    ss << "TVM_DLL int32_t " << func_name;
+    ss << "(";
+    std::unordered_map<int, relay::contrib::ethosu::BaseAddress> param_idx_to_base_address;
+    for (const relay::contrib::ethosu::BaseAddress& base_address : artifact->base_addresses) {
+      if (base_address->primfunc_param_idx.defined()) {
+        param_idx_to_base_address[base_address->primfunc_param_idx] = base_address;
+      }
+    }
+    for (unsigned int i = 0; i < param_idx_to_base_address.size(); i++) {
+      relay::contrib::ethosu::BaseAddress base_address = param_idx_to_base_address[i];
+      ss << "void* " << base_address->name << ",";
+    }
+    ss << "void* resource_handle) {\n";
   }
 
   /*!
@@ -216,7 +231,6 @@ class EthosUModuleNode : public ModuleNode {
     std::stringstream ss;
 
     size_t weights_size = (compilation_artifact->encoded_constants.size() / 2);
-    size_t scratch_size = compilation_artifact->scratch_size;
     ss << "// Update linker script to place .rodata.tvm in memory that can be accessed by the "
           "NPU\n";
     if (weights_size > 0) {
@@ -234,61 +248,44 @@ class EthosUModuleNode : public ModuleNode {
     ss << "\n";
 
     PrintExternCPrefix(ss);
-    ss << "static int32_t " << func_no_dashes + "_(int8_t* in0, "
-       << "size_t in0_size, int8_t* out0, size_t out0_size, void* resource_handle) {\n";
-    ss << "  int num_tensors = 5;\n";
+    PrintRuntimeFunctionSignature(ss, compilation_artifact, func_no_dashes);
     ss << "  void* cms_data = (void*)(" << func_no_dashes << "_cms_data_data);\n";
     ss << "  int64_t device_type = kDLCPU;\n";
     ss << "  int64_t device_id = 0;\n";
-    ss << "  const size_t weights_size = " << std::to_string(weights_size) << ";\n";
-    ss << "  const size_t scratch_size = " << std::to_string(scratch_size) << ";\n";
     ss << "  const size_t cms_data_size = sizeof(" << func_no_dashes << "_cms_data_data);\n";
-    if (scratch_size > 0) {
-      ss << "  int8_t* scratch = (int8_t*) TVMBackendAllocWorkspace(device_type, device_id, "
-            "(uint64_t)scratch_size, 0, 16);\n";
-    } else {
-      ss << "  int8_t* scratch = NULL;\n";
+    ss << "  size_t base_addrs_size[" << kMaxBaseAddresses_ << "] = {0};\n";
+    ss << "  uint64_t base_addrs[" << kMaxBaseAddresses_ << "] = {0};\n";
+    ss << "\n";
+
+    ss << SetBaseAddress(0, func_no_dashes + "_weights", weights_size);
+    for (const relay::contrib::ethosu::BaseAddress& base_address :
+         compilation_artifact->base_addresses) {
+      if (base_address->is_runtime_allocation) {
+        ss << "  int8_t* " << base_address->name
+           << " = (int8_t*) TVMBackendAllocWorkspace(device_type, device_id, "
+              "(uint64_t)"
+           << base_address->size << ", 0, 16);\n";
+      }
+      ss << SetBaseAddress(base_address->region->value, base_address->name.c_str(),
+                           base_address->size->value);
     }
-    ss << "  size_t base_addrs_size[num_tensors];\n";
-    ss << "  uint64_t base_addrs[num_tensors];\n";
     ss << "\n";
-    ss << SetBaseAddress(0, func_no_dashes + "_weights", "weights_size");
-    ss << SetBaseAddress(1, "scratch", "scratch_size");
-    ss << SetBaseAddress(2, "scratch", "scratch_size");
-    ss << SetBaseAddress(3, "in0", "in0_size");
-    ss << SetBaseAddress(4, "out0", "out0_size");
-    ss << "\n";
+
     ss << "  int32_t result = TVMEthosULaunch(resource_handle, cms_data, cms_data_size, "
-          "base_addrs, base_addrs_size, num_tensors);\n";
-    if (scratch_size > 0) {
-      ss << "  TVMBackendFreeWorkspace(device_type, device_id, scratch);\n";
+          "base_addrs, base_addrs_size, "
+       << kMaxBaseAddresses_ << ");\n";
+
+    for (const relay::contrib::ethosu::BaseAddress& base_address :
+         compilation_artifact->base_addresses) {
+      if (base_address->is_runtime_allocation) {
+        ss << "  TVMBackendFreeWorkspace(device_type, device_id, " << base_address->name << ");\n";
+      }
     }
     ss << "  return result;\n";
     ss << "}\n";
     ss << "\n";
     PrintExternCPostfix(ss);
     ss << "\n";
-    PrintExternCPrefix(ss);
-    ss << "// Wrapper function is provided to allow for easier debugging\n";
-    ss << "inline static int32_t " + func_no_dashes +
-              "_wrapper_(void* input, void* output, void* resource_handle) {\n";
-    ss << "  size_t input_data_size = " << compilation_artifact->input_size << ";\n";
-    ss << "  size_t output_data_size = " << compilation_artifact->output_size << ";\n";
-    ss << "  return " + func_no_dashes +
-              "_((int8_t*)input, input_data_size, (int8_t*)output, output_data_size, " +
-              "resource_handle);\n";
-    ss << "}\n";
-    PrintExternCPostfix(ss);
-    ss << "\n";
-    PrintExternCPrefix(ss);
-    PrintRuntimeFunctionHeader(ss, func_no_dashes);
-    EnterScope();
-    PrintIndents(ss);
-    ss << "return " << func_no_dashes << "_wrapper_(input, output, resource_handle);\n";
-    ExitScope();
-    ss << "}\n";
-    PrintExternCPostfix(ss);
-
     return ss.str();
   }
 };

--- a/src/relay/backend/contrib/ethosu/utils.h
+++ b/src/relay/backend/contrib/ethosu/utils.h
@@ -36,7 +36,8 @@ namespace ethosu {
 
 /*!
  * \brief Base addresses are input pointers to
- * the driver that get accessed by produced
+ * the driver that get accessed by the command stream
+ * using offsets to read/write data.
  */
 struct BaseAddressNode : public Object {
   /*! \brief The identifier, usually it the param name of the PrimFunc that gets lowered */

--- a/src/relay/backend/contrib/ethosu/utils.h
+++ b/src/relay/backend/contrib/ethosu/utils.h
@@ -35,46 +35,89 @@ namespace contrib {
 namespace ethosu {
 
 /*!
+ * \brief Base addresses are input pointers to
+ * the driver that get accessed by produced
+ */
+struct BaseAddressNode : public Object {
+  /*! \brief The identifier, usually it the param name of the PrimFunc that gets lowered */
+  String name;
+  /*! \brief The index in the params array of the PrimFunc. This is needed to keep aligned
+   * between the PrimFunc arguments ordering and argument ordering of generated code */
+  Integer primfunc_param_idx;
+  /*! \brief The region used by the command stream. This needs to match with base address
+   * index passed into the driver */
+  Integer region;
+  /*! \brief The size of the buffer accessible by this base address */
+  Integer size;
+  /*! \brief This is a runtime allocation that needs to be done in the function */
+  Bool is_runtime_allocation{Bool(false)};
+
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("name", &name);
+    v->Visit("primfunc_param_idx", &primfunc_param_idx);
+    v->Visit("region", &region);
+    v->Visit("size", &size);
+    v->Visit("is_runtime_allocation", &is_runtime_allocation);
+  }
+
+  bool SEqualReduce(const BaseAddressNode* other, SEqualReducer equal) const {
+    return equal(name, other->name) && equal(primfunc_param_idx, other->primfunc_param_idx) &&
+           equal(region, other->region) && equal(size, other->size) &&
+           equal(is_runtime_allocation, other->is_runtime_allocation);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce(name);
+    hash_reduce(primfunc_param_idx);
+    hash_reduce(region);
+    hash_reduce(size);
+    hash_reduce(is_runtime_allocation);
+  }
+
+  static constexpr const char* _type_key = "relay.ext.ethos-u.BaseAddress";
+  TVM_DECLARE_FINAL_OBJECT_INFO(BaseAddressNode, Object);
+};
+
+class BaseAddress : public ObjectRef {
+ public:
+  TVM_DLL BaseAddress(String name, Integer primfunc_param_idx, Integer region, Integer size,
+                      Bool is_runtime_allocation = Bool(false));
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(BaseAddress, ObjectRef, BaseAddressNode);
+};
+
+/*!
  * \brief Captures all the binary artifactes required to create
  * the C-source runtime module
  */
 struct CompilationArtifactNode : public Object {
+  /*! \brief The function name for this artifact belongs to */
+  String function_name;
   /*! \brief The binary command stream (CS) in hex format */
   String command_stream;
   /*! \brief The encoded biases and weights in hex format */
   String encoded_constants;
-  /*! \brief The intermediary scratch area required for the execution of the CS */
-  Integer scratch_size;
-  /*! \brief The size of the input tensor in bytes */
-  Integer input_size;
-  /*! \brief The size of the output tensor in bytes */
-  Integer output_size;
-  /*! \brief The name of the function */
-  String function_name;
+  /*! \brief The information regarding the base addresses */
+  Array<BaseAddress> base_addresses;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("function_name", &function_name);
     v->Visit("command_stream", &command_stream);
     v->Visit("encoded_constants", &encoded_constants);
-    v->Visit("scratch_size", &scratch_size);
-    v->Visit("input_size", &input_size);
-    v->Visit("output_size", &output_size);
-    v->Visit("function_name", &function_name);
+    v->Visit("base_addresses", &base_addresses);
   }
 
   bool SEqualReduce(const CompilationArtifactNode* other, SEqualReducer equal) const {
-    return equal(command_stream, other->command_stream) &&
+    return equal(function_name, other->function_name) &&
+           equal(command_stream, other->command_stream) &&
            equal(encoded_constants, other->encoded_constants) &&
-           equal(scratch_size, other->scratch_size) && equal(input_size, other->input_size) &&
-           equal(output_size, other->output_size) && equal(function_name, other->function_name);
+           equal(base_addresses, other->base_addresses);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce(function_name);
     hash_reduce(command_stream);
     hash_reduce(encoded_constants);
-    hash_reduce(scratch_size);
-    hash_reduce(input_size);
-    hash_reduce(output_size);
-    hash_reduce(function_name);
+    hash_reduce(base_addresses);
   }
 
   static constexpr const char* _type_key = "relay.ext.ethos-u.CompilationArtifact";
@@ -83,8 +126,8 @@ struct CompilationArtifactNode : public Object {
 
 class CompilationArtifact : public ObjectRef {
  public:
-  TVM_DLL CompilationArtifact(String command_stream, String encoded_constants, Integer scratch_size,
-                              Integer input_size, Integer output_size, String function_name);
+  TVM_DLL CompilationArtifact(String function_name, String command_stream, String encoded_constants,
+                              Array<BaseAddress> base_addresses);
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(CompilationArtifact, ObjectRef, CompilationArtifactNode);
 };
 

--- a/src/tir/transforms/make_unpacked_api.cc
+++ b/src/tir/transforms/make_unpacked_api.cc
@@ -60,12 +60,16 @@ PrimFunc MakeUnpackedAPI(PrimFunc&& func) {
 
   // Collect variables and buffers to map between
   Array<Var> args;
+  Map<Var, Buffer> new_buffer_map;
   for (const Var& param : func->params) {
     // Ideally all func params should have Buffers defined in the buffer_map
     // We should look to insert buffer_maps for all PrimFuncs that are returned
     // to the core compiler.
     if (func->buffer_map.find(param) != func->buffer_map.end()) {
       args.push_back(func->buffer_map[param]->data);
+      // Rewiring the buffer_var to map to Buffers for low-level passes
+      // retain information about the buffer.
+      new_buffer_map.Set(func->buffer_map[param]->data, func->buffer_map[param]);
     } else {
       args.push_back(param);
     }
@@ -79,6 +83,7 @@ PrimFunc MakeUnpackedAPI(PrimFunc&& func) {
   func_ptr->body = MergeNest(device_init, func_ptr->body);
   func_ptr->params = args;
   func_ptr->ret_type = PrimType(DataType::Int(32));
+  func_ptr->buffer_map = new_buffer_map;
 
   // return the function.
   return std::move(func);

--- a/tests/python/contrib/test_ethosu/test_tir_to_cs_translator.py
+++ b/tests/python/contrib/test_ethosu/test_tir_to_cs_translator.py
@@ -230,12 +230,12 @@ def test_buffer_info_extraction():
                 "ethosu_conv2d_2": (
                     [1024],
                     "uint8",
-                    tir_to_cs_translator.BufferType.runtime_allocate,
+                    tir_to_cs_translator.BufferType.scratch,
                 ),
                 "ethosu_conv2d_3": (
                     [2048],
                     "uint8",
-                    tir_to_cs_translator.BufferType.runtime_allocate,
+                    tir_to_cs_translator.BufferType.scratch,
                 ),
             },
         },
@@ -776,15 +776,15 @@ def test_assign_addresses():
         original tir buffers.
         - If its constant, this will check
           the slice in the constant tensor has the values.
-        - If its runtime_allocation, this will check
-          the slice is within runtime_allocation and does not have conflicts
-          with other runtime_allocation tensors.
+        - If its scratch, this will check
+          the slice is within scratch and does not have conflicts
+          with other scratch tensors.
         - If its input/output, this will check the
           address is zero
         """
         inverse_region_map = {
             0: tir_to_cs_translator.BufferType.constant,
-            1: tir_to_cs_translator.BufferType.runtime_allocate,
+            1: tir_to_cs_translator.BufferType.scratch,
             3: tir_to_cs_translator.BufferType.input,
             4: tir_to_cs_translator.BufferType.output,
         }
@@ -804,21 +804,19 @@ def test_assign_addresses():
             constant_tensor_read_mask[address : address + length] = np.ones(
                 length, dtype=buffer_dtype
             )
-        elif buffer_type == tir_to_cs_translator.BufferType.runtime_allocate:
+        elif buffer_type == tir_to_cs_translator.BufferType.scratch:
             shape = list(buffer_info[buffer_var].shape)
             assert length == np.prod(shape)
-            assert address < runtime_allocation_size
+            assert address < scratch_size
 
             size_in_bytes = int(np.prod(shape)) * dtype_bytes
             # Every buffer is adjusted to align to 16 bytes
             size_in_bytes = util.round_up(size_in_bytes, 16)
-            assert address + size_in_bytes <= runtime_allocation_size
-            # The runtime_allocation area should not be used by anyother buffer
-            assert not runtime_allocation_mask[address : address + size_in_bytes].any()
-            # The runtime_allocation area is marked as used
-            runtime_allocation_mask[address : address + size_in_bytes] = np.ones(
-                size_in_bytes, dtype="uint8"
-            )
+            assert address + size_in_bytes <= scratch_size
+            # The scratch area should not be used by any other buffer
+            assert not scratch_mask[address : address + size_in_bytes].any()
+            # The scratch area is marked as used
+            scratch_mask[address : address + size_in_bytes] = np.ones(size_in_bytes, dtype="uint8")
         elif buffer_type == tir_to_cs_translator.BufferType.input:
             assert address == 0
         else:
@@ -898,13 +896,13 @@ def test_assign_addresses():
         (
             _npu_ops,
             constant_hex_string,
-            runtime_allocation_size,
+            scratch_size,
         ) = tir_to_cs_translator.assign_addresses(buffer_info, _npu_ops)
-        runtime_allocation_mask = np.zeros(runtime_allocation_size, dtype="uint8")
+        scratch_mask = np.zeros(scratch_size, dtype="uint8")
         constant_tensor_read_mask = np.zeros(len(constant_hex_string) // 2, dtype="uint8")
         verify(_npu_ops)
-        # This will be only 1 if all allocated runtime_allocation is used.
-        assert np.prod(runtime_allocation_mask) == 1
+        # This will be only 1 if all allocated scratch is used.
+        assert np.prod(scratch_mask) == 1
         # This will be only 1 if all constant tensors is read at least once.
         assert np.prod(constant_tensor_read_mask) == 1
 


### PR DESCRIPTION
This commit introduces BaseAddress ObjectRef to determine
base addresses in the codegen for microNPU. This is
required when multiple memory pools become available. Thus,
base addresses could not be statically determined in the
source module.
