### PR TITLE
Disallow copy to/from external HexagonBuffer

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -190,6 +190,8 @@ void HexagonBuffer::SetStorageScope(Optional<String> scope) {
 
 void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
   CHECK_LE(nbytes, nbytes_);
+  CHECK(managed_allocations_.size() && "CopyTo not supported on unmanaged `external` allocations");
+
   size_t copied = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
     size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
@@ -204,6 +206,9 @@ void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
 
 void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
   CHECK_LE(nbytes, nbytes_);
+  CHECK(managed_allocations_.size() &&
+        "CopyFrom not supported on unmanaged `external` allocations");
+
   size_t copied = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
     size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
@@ -219,6 +224,10 @@ void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
 void HexagonBuffer::CopyFrom(const HexagonBuffer& other, size_t nbytes) {
   CHECK_LE(nbytes, nbytes_);
   CHECK_LE(nbytes, other.nbytes_);
+  CHECK(managed_allocations_.size() &&
+        "CopyFrom not supported on unmanaged `external` allocations");
+  CHECK(other.managed_allocations_.size() &&
+        "CopyFrom not supported on unmanaged `external` allocations");
 
   if (nallocs_ == other.nallocs_) {
     size_t copied = 0;

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -38,7 +38,8 @@ namespace runtime {
 namespace hexagon {
 
 struct Allocation {
-  Allocation(size_t nbytes, size_t alignment) : nbytes_(nbytes), alignment_(alignment) {}
+  Allocation(size_t allocation_nbytes, size_t alignment)
+      : allocation_nbytes_(allocation_nbytes), alignment_(alignment) {}
   virtual ~Allocation() {}
   Allocation(const Allocation&) = delete;
   Allocation& operator=(const Allocation&) = delete;
@@ -46,7 +47,7 @@ struct Allocation {
   Allocation& operator=(Allocation&&) = delete;
 
   void* data_{nullptr};
-  size_t nbytes_;
+  size_t allocation_nbytes_;
   size_t alignment_;
 };
 
@@ -194,7 +195,7 @@ void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
 
   size_t copied = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
-    size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
+    size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->allocation_nbytes_);
     if (bytes_to_copy == 0) break;
 
     memcpy(static_cast<char*>(data) + copied,
@@ -211,7 +212,7 @@ void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
 
   size_t copied = 0;
   for (size_t i = 0; i < nallocs_; ++i) {
-    size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
+    size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->allocation_nbytes_);
     if (bytes_to_copy == 0) break;
 
     memcpy(static_cast<char*>(managed_allocations_[i]->data_),
@@ -232,10 +233,11 @@ void HexagonBuffer::CopyFrom(const HexagonBuffer& other, size_t nbytes) {
   if (nallocs_ == other.nallocs_) {
     size_t copied = 0;
     for (size_t i = 0; i < nallocs_; ++i) {
-      size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->nbytes_);
+      size_t bytes_to_copy = std::min(nbytes - copied, managed_allocations_[i]->allocation_nbytes_);
       if (bytes_to_copy == 0) break;
 
-      CHECK_LE(other.managed_allocations_[i]->nbytes_, managed_allocations_[i]->nbytes_);
+      CHECK_LE(other.managed_allocations_[i]->allocation_nbytes_,
+               managed_allocations_[i]->allocation_nbytes_);
 
       memcpy(static_cast<char*>(managed_allocations_[i]->data_),
              static_cast<const char*>(other.managed_allocations_[i]->data_), bytes_to_copy);

--- a/tests/cpp/runtime/hexagon_buffer.cc
+++ b/tests/cpp/runtime/hexagon_buffer.cc
@@ -259,3 +259,17 @@ TEST(HexagonBuffer, external) {
   Optional<String> invalid("invalid");
   EXPECT_THROW(HexagonBuffer hb_vtcm(data.data(), data.size(), invalid), InternalError);
 }
+
+TEST(HexagonBuffer, external_copy) {
+  std::vector<uint8_t> data1{0, 1, 2, 3, 4, 5, 6, 7};
+  Optional<String> global("global");
+  HexagonBuffer hb_ext(data1.data(), data1.size(), global);
+
+  std::vector<uint8_t> data2{0, 1, 2, 3, 4, 5, 6, 7};
+  EXPECT_THROW(hb_ext.CopyTo(data2.data(), data2.size()), InternalError);
+  EXPECT_THROW(hb_ext.CopyFrom(data2.data(), data2.size()), InternalError);
+
+  HexagonBuffer hb(8 /* nbytes */, 8 /* alignment */, global);
+  EXPECT_THROW(hb.CopyFrom(hb_ext, 8), InternalError);
+  EXPECT_THROW(hb_ext.CopyFrom(hb, 8), InternalError);
+}


### PR DESCRIPTION
Eventually the goal is to rework the Hexagon Device API to make `HexagonBuffer` a private entity behind the Device API.  Until then, we need support for "external" (outside the Device API) construction of a `HexagonBuffer` but we explicitly disallow copy from / to support with this PR.  Also cleaning up some names for clarity based on feedback from @kparzysz-quic.
