### PR TITLE
[ONNX] Fix onnx convtranspose error

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -38,9 +38,9 @@ from .. import random as _random
 from .. import ty as _ty
 from .. import vision as _vision
 from .common import (
-    autopad,
     AttrCvt,
     Renamer,
+    autopad,
     ensure_scalar_shape,
     fold_constant,
     get_name,
@@ -557,13 +557,13 @@ class ConvTranspose(OnnxOpConverter):
     def _impl_v1(cls, inputs, attr, params):
         # get number of channels
         out_type = infer_type(inputs[1])
-        out_shapes = [get_const_tuple(out_type.checked_type.shape)]
-        channels = out_shapes[0][1]
-        attr["channels"] = channels
+        kernel_shape = [get_const_tuple(out_type.checked_type.shape)]
+        out_channels = kernel_shape[0][1] * attr.get("group", 1)
+        attr["channels"] = out_channels
         groups = attr.get("group", 1)
 
         if "kernel_shape" not in attr:
-            attr["kernel_shape"] = out_shapes[0][2:]
+            attr["kernel_shape"] = kernel_shape[0][2:]
 
         attr["groups"] = groups
         # infer pads for auto_pad
@@ -612,13 +612,13 @@ class ConvTranspose(OnnxOpConverter):
     def _impl_v11(cls, inputs, attr, params):
         # get number of channels
         out_type = infer_type(inputs[1])
-        out_shapes = [get_const_tuple(out_type.checked_type.shape)]
-        channels = out_shapes[0][1]
-        attr["channels"] = channels
+        kernel_shape = [get_const_tuple(out_type.checked_type.shape)]
+        out_channels = kernel_shape[0][1] * attr.get("group", 1)
+        attr["channels"] = out_channels
         groups = attr.get("group", 1)
 
         if "kernel_shape" not in attr:
-            attr["kernel_shape"] = out_shapes[0][2:]
+            attr["kernel_shape"] = kernel_shape[0][2:]
 
         attr["groups"] = groups
         # infer pads for auto_pad

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -189,6 +189,7 @@ def verify_with_ort_with_inputs(
             opt_level=opt_level,
             convert_config=convert_config,
         )
+
     if not isinstance(tvm_out, list):
         tvm_out = [tvm_out]
     if not isinstance(ort_out, list):
@@ -233,7 +234,8 @@ def verify_with_ort(
 
 
 def quantize_and_verify_with_ort(onnx_model, input_names, input_shapes, target, dev):
-    from onnxruntime.quantization import CalibrationDataReader, QuantType, quantize_static
+    from onnxruntime.quantization import (CalibrationDataReader, QuantType,
+                                          quantize_static)
 
     input_arrays = [np.random.random(shape).astype("float32") for shape in input_shapes]
 
@@ -2891,6 +2893,12 @@ def test_convtranspose(target, dev):
     verify_convtranspose((1, 1, 3, 3), (1, 2, 3, 3), (1, 2, 7, 3), [1, 2, 1, 2])
     # Test undefined groups.
     verify_convtranspose((1, 1, 3, 3), (1, 2, 3, 3), (1, 2, 7, 3), [1, 2, 1, 2], group=None)
+
+    # Test depthwise-convolution
+    verify_convtranspose((1, 10, 3, 3), (10, 1, 3, 3), (1, 10, 7, 3), [1, 2, 1, 2], group=10)
+
+    # Test grouped-convolution
+    verify_convtranspose((1, 10, 3, 3), (10, 1, 3, 3), (1, 5, 7, 3), [1, 2, 1, 2], group=5)
 
     def repeat(N, D):
         return tuple([N for _ in range(D)])

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -234,8 +234,7 @@ def verify_with_ort(
 
 
 def quantize_and_verify_with_ort(onnx_model, input_names, input_shapes, target, dev):
-    from onnxruntime.quantization import (CalibrationDataReader, QuantType,
-                                          quantize_static)
+    from onnxruntime.quantization import CalibrationDataReader, QuantType, quantize_static
 
     input_arrays = [np.random.random(shape).astype("float32") for shape in input_shapes]
 
@@ -2894,11 +2893,13 @@ def test_convtranspose(target, dev):
     # Test undefined groups.
     verify_convtranspose((1, 1, 3, 3), (1, 2, 3, 3), (1, 2, 7, 3), [1, 2, 1, 2], group=None)
 
-    # Test depthwise-convolution
-    verify_convtranspose((1, 10, 3, 3), (10, 1, 3, 3), (1, 10, 7, 3), [1, 2, 1, 2], group=10)
+    if "llvm" in target:
+        # GPU does not support groups != 1 for convtranspose, so only test llvm
+        # Test depthwise-convolution
+        verify_convtranspose((1, 10, 3, 3), (10, 1, 3, 3), (1, 10, 7, 3), [1, 2, 1, 2], group=10)
 
-    # Test grouped-convolution
-    verify_convtranspose((1, 10, 3, 3), (10, 1, 3, 3), (1, 5, 7, 3), [1, 2, 1, 2], group=5)
+        # Test grouped-convolution
+        verify_convtranspose((1, 10, 3, 3), (10, 1, 3, 3), (1, 5, 7, 3), [1, 2, 1, 2], group=5)
 
     def repeat(N, D):
         return tuple([N for _ in range(D)])


### PR DESCRIPTION
ONNX translation erroneously thinks "groups" attribute refers to input channels when it refers to output channels. 

This was probably the case before I switched Convtranspose layouts to fit regular convs more in PR #9336 

Should close issue #9885 