### PR TITLE
[CUDNN] Refactor descriptor initialization, remove `cudnn.conv.output_shape_from_cudnn`

### DIFF
--- a/python/tvm/contrib/cudnn.py
+++ b/python/tvm/contrib/cudnn.py
@@ -285,68 +285,6 @@ def conv_output_shape(
     return output
 
 
-def _conv_output_shape_from_cudnn(
-    tensor_format, pad, stride, dilation, x_shape, w_shape, data_dtype, conv_dtype, groups=1
-):
-    """Get output shape of 2D or 3D convolution.  The output of this
-    function should be identical to that of conv_output_shape, but
-    requires a GPU with CuDNN to be present.  This is maintained for
-    testing purposes to validate the output of conv_output_shape.
-
-    Paramters
-    ---------
-    tensor_format: int
-        0: CUDNN_TENSOR_NCHW
-        1: CUDNN_TENSOR_NHWC
-        2: CUDNN_TENSOR_NCHW_VECT_C
-    pad: int or list
-        padding
-    stride: int or list
-        stride
-    dilation: int or list
-        dilation
-    x_shape: list
-        input shape
-    w_shape: list
-        weight shape
-    data_dtype: str
-        data type
-    conv_dtype: str
-        convolution type
-    groups: int
-        number of groups
-
-    Returns
-    -------
-    oshape: list
-        output shape
-
-    """
-    dims = len(x_shape)
-    assert dims in (4, 5)
-
-    pad, stride, dilation, xshape, wshape = _prepare_global_func_params(
-        dims - 2, pad, stride, dilation, x_shape, w_shape
-    )
-    oshape = np.zeros((dims), dtype=np.int32)
-
-    func = tvm._ffi.get_global_func("tvm.contrib.cudnn.conv.output_shape_from_cudnn")
-    func(
-        tensor_format,
-        dims - 2,
-        _get_np_int32_array_handle(pad),
-        _get_np_int32_array_handle(stride),
-        _get_np_int32_array_handle(dilation),
-        _get_np_int32_array_handle(xshape),
-        _get_np_int32_array_handle(wshape),
-        _get_np_int32_array_handle(oshape),
-        data_dtype,
-        conv_dtype,
-        groups,
-    )
-    return list(oshape)
-
-
 def conv_find_algo(
     tensor_format,
     pad,

--- a/src/runtime/contrib/cudnn/conv_forward.cc
+++ b/src/runtime/contrib/cudnn/conv_forward.cc
@@ -35,94 +35,11 @@ void ConvolutionForward(int mode, int format, int algo, int dims, int groups, co
                         const int stride[], const int dilation[], DLTensor* x, DLTensor* w,
                         DLTensor* y, const std::string& conv_dtype) {
   CuDNNThreadEntry* entry_ptr = CuDNNThreadEntry::ThreadLocal();
-  // Set Mode
-  entry_ptr->conv_entry.mode = static_cast<cudnnConvolutionMode_t>(mode);
-  // Set Format
-  entry_ptr->conv_entry.tensor_format = static_cast<cudnnTensorFormat_t>(format);
-  // Set Algo
-  entry_ptr->conv_entry.fwd_algo = static_cast<cudnnConvolutionFwdAlgo_t>(algo);
-  // Set Device
-  entry_ptr->conv_entry.device = x->device;
-  // Set Data Type
-  entry_ptr->conv_entry.data_type = CuDNNDataType::DLTypeToCuDNNType(String2DLDataType(conv_dtype));
-  cudnnDataType_t data_type = CuDNNDataType::DLTypeToCuDNNType(x->dtype);
-  // Dims includes N and C
-  int full_dims = dims + 2;
+  SetConvDescriptors(entry_ptr, mode, format, algo, dims, groups, pad, stride, dilation, x, w, y,
+                     conv_dtype);
 
-  std::vector<int> dim(full_dims);
-  std::vector<int> tensor_stride(full_dims);
-
-  // Note: For 2D tenor, using ND setters causes CUDNN_STATUS_NOT_SUPPORTED error
-  // in following cudnnGetConvolutionForwardWorkspaceSize() when data type is fp16, int
-
-  CUDNN_CALL(cudnnSetConvolutionGroupCount(entry_ptr->conv_entry.conv_desc, groups));
-  if (dims == 2) {
-    // Set Desc
-    CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-        entry_ptr->conv_entry.conv_desc, pad[0], pad[1], stride[0], stride[1], dilation[0],
-        dilation[1], entry_ptr->conv_entry.mode, entry_ptr->conv_entry.data_type));
-    int ni, ci, hi, wi;
-    if (entry_ptr->conv_entry.tensor_format == CUDNN_TENSOR_NHWC) {
-      ni = 0;
-      ci = 3;
-      hi = 1;
-      wi = 2;
-    } else {
-      ni = 0;
-      ci = 1;
-      hi = 2;
-      wi = 3;
-    }
-
-    // Set Filter
-    CUDNN_CALL(cudnnSetFilter4dDescriptor(
-        entry_ptr->conv_entry.filter_desc, data_type, entry_ptr->conv_entry.tensor_format,
-        static_cast<int>(w->shape[ni]), static_cast<int>(w->shape[ci]),
-        static_cast<int>(w->shape[hi]), static_cast<int>(w->shape[wi])));
-    // Set Input
-    CUDNN_CALL(cudnnSetTensor4dDescriptor(
-        entry_ptr->conv_entry.input_desc, entry_ptr->conv_entry.tensor_format, data_type,
-        static_cast<int>(x->shape[ni]), static_cast<int>(x->shape[ci]),
-        static_cast<int>(x->shape[hi]), static_cast<int>(x->shape[wi])));
-    // Set Output
-    CUDNN_CALL(cudnnSetTensor4dDescriptor(
-        entry_ptr->conv_entry.output_desc, entry_ptr->conv_entry.tensor_format, data_type,
-        static_cast<int>(y->shape[ni]), static_cast<int>(y->shape[ci]),
-        static_cast<int>(y->shape[hi]), static_cast<int>(y->shape[wi])));
-  } else {
-    CUDNN_CALL(cudnnSetConvolutionNdDescriptor(entry_ptr->conv_entry.conv_desc, dims, pad, stride,
-                                               dilation, entry_ptr->conv_entry.mode,
-                                               entry_ptr->conv_entry.data_type));
-
-    // Set Filter
-    for (int i = 0; i < full_dims; i++) {
-      dim[i] = static_cast<int>(w->shape[i]);
-    }
-    CUDNN_CALL(cudnnSetFilterNdDescriptor(entry_ptr->conv_entry.filter_desc, data_type,
-                                          entry_ptr->conv_entry.tensor_format, full_dims,
-                                          dim.data()));
-    // Set Input
-    for (int i = 0; i < full_dims; i++) {
-      dim[i] = static_cast<int>(x->shape[i]);
-    }
-    GetCudnnStride(full_dims, dim.data(), tensor_stride.data());
-    CUDNN_CALL(cudnnSetTensorNdDescriptor(entry_ptr->conv_entry.input_desc, data_type, full_dims,
-                                          dim.data(), tensor_stride.data()));
-    // Set Output
-    for (int i = 0; i < full_dims; i++) {
-      dim[i] = static_cast<int>(y->shape[i]);
-    }
-    GetCudnnStride(full_dims, dim.data(), tensor_stride.data());
-    CUDNN_CALL(cudnnSetTensorNdDescriptor(entry_ptr->conv_entry.output_desc, data_type, full_dims,
-                                          dim.data(), tensor_stride.data()));
-  }
-
-  if (cudnnGetVersion() > 7000) {
-    CUDNN_CALL(cudnnSetConvolutionMathType(entry_ptr->conv_entry.conv_desc, CUDNN_TENSOR_OP_MATH))
-  }
-
-  // Set workspace
-  size_t workspace_size = 0;
+      // Set workspace
+      size_t workspace_size = 0;
   CUDNN_CALL(cudnnGetConvolutionForwardWorkspaceSize(
       entry_ptr->handle, entry_ptr->conv_entry.input_desc, entry_ptr->conv_entry.filter_desc,
       entry_ptr->conv_entry.conv_desc, entry_ptr->conv_entry.output_desc,

--- a/src/runtime/contrib/cudnn/cudnn_utils.cc
+++ b/src/runtime/contrib/cudnn/cudnn_utils.cc
@@ -20,11 +20,15 @@
 /*!
  * \file Use external cudnn utils function
  */
+
 #include "cudnn_utils.h"
 
 #include <dmlc/thread_local.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/registry.h>
+
+#include <string>
+#include <vector>
 
 namespace tvm {
 namespace contrib {

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -64,7 +64,7 @@ inline void GetCudnnStride(int nbdim, const int* dims, int* strides) {
 
 struct ConvEntry {
   cudnnConvolutionDescriptor_t conv_desc;
-  cudnnConvolutionMode_t mode;
+  cudnnConvolutionMode_t mode{CUDNN_CROSS_CORRELATION};
   cudnnFilterDescriptor_t filter_desc;
   cudnnDataType_t data_type;
   cudnnTensorFormat_t tensor_format;
@@ -103,9 +103,10 @@ struct CuDNNThreadEntry {
   static CuDNNThreadEntry* ThreadLocal(bool check_exists = true);
 };  // CuDNNThreadEntry
 
-void SetConvDescriptors(CuDNNThreadEntry* entry_ptr, int mode, int format, int algo, int dims,
-                        int groups, const int pad[], const int stride[], const int dilation[],
-                        DLTensor* x, DLTensor* w, DLTensor* y, const std::string& conv_dtype);
+void SetConvDescriptors(CuDNNThreadEntry* entry_ptr, int format, int dims, int groups,
+                        const int pad[], const int stride[], const int dilation[], int64_t x_dim[],
+                        int64_t w_dim[], int64_t y_dim[], DLDataType data_dtype,
+                        const std::string& conv_dtype);
 
 }  // namespace contrib
 }  // namespace tvm

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -103,6 +103,10 @@ struct CuDNNThreadEntry {
   static CuDNNThreadEntry* ThreadLocal(bool check_exists = true);
 };  // CuDNNThreadEntry
 
+void SetConvDescriptors(CuDNNThreadEntry* entry_ptr, int mode, int format, int algo, int dims,
+                        int groups, const int pad[], const int stride[], const int dilation[],
+                        DLTensor* x, DLTensor* w, DLTensor* y, const std::string& conv_dtype);
+
 }  // namespace contrib
 }  // namespace tvm
 

--- a/src/runtime/contrib/cudnn/cudnn_utils.h
+++ b/src/runtime/contrib/cudnn/cudnn_utils.h
@@ -28,6 +28,8 @@
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/logging.h>
 
+#include <string>
+
 #include "../../cuda/cuda_common.h"
 
 namespace tvm {

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -316,4 +316,6 @@ def test_conv_output_shape(conv_output_shape_kwargs):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    # sys.exit(pytest.main(sys.argv))
+    test_conv2d()
+    test_conv3d()

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -29,7 +29,7 @@ import tvm.testing
 
 
 requires_cudnn = pytest.mark.skipif(
-    tvm.get_global_func("tvm.contrib.cudnn.conv.output_shape_from_cudnn", True) is None,
+    tvm.get_global_func("tvm.contrib.cudnn.conv2d.forward", True) is None,
     reason="CuDNN is not enabled",
 )
 
@@ -307,15 +307,5 @@ def conv_output_shape_kwargs(request):
     return request.param
 
 
-@tvm.testing.requires_gpu
-@requires_cudnn
-def test_conv_output_shape(conv_output_shape_kwargs):
-    shape_from_cudnn = cudnn._conv_output_shape_from_cudnn(**conv_output_shape_kwargs)
-    shape_from_python = cudnn.conv_output_shape(**conv_output_shape_kwargs)
-    assert shape_from_cudnn == shape_from_python
-
-
 if __name__ == "__main__":
-    # sys.exit(pytest.main(sys.argv))
-    test_conv2d()
-    test_conv3d()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -541,7 +541,7 @@ def verify_any_conv2d(
     kernel_np = np.random.uniform(size=kernel_shape).astype(dtype)
 
     targets = None
-    if use_cudnn and tvm.get_global_func("tvm.contrib.cudnn.conv.output_shape_from_cudnn", True):
+    if use_cudnn and tvm.get_global_func("tvm.contrib.cudnn.conv2d.forward", True):
         targets = [("cuda -libs=cudnn", tvm.cuda(0))]
 
     check_result([data_np, kernel_np], mod, ref_out_shape, assert_shape=True, targets=targets)


### PR DESCRIPTION
In preparation for adding cudnn gradient kernels, I wanted to refactor the duplicated logic of various descriptor initialization.

Also removes `tvm.contrib.cudnn.conv.output_shape_from_cudnn` since it is no longer used.

@Hzfengsy @comaniac @Laurawly 