### PR TITLE
[Relay] Add `conv2d_backward_weight` op (without topi)

### DIFF
--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -425,16 +425,16 @@ def conv2d_grad(orig, grad):
     )
 
     backward_weight = _nn.conv2d_backward_weight(
-        data,
         grad,
+        data,
         strides=attrs.strides,
         padding=attrs.padding,
         dilation=attrs.dilation,
         groups=attrs.groups,
         channels=attrs.channels,
         kernel_size=(filter_h, filter_w),
-        data_layout=attrs.data_layout,
         grad_layout=attrs.out_layout if attrs.out_layout else attrs.data_layout,
+        data_layout=attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
         out_dtype=attrs.out_dtype,
     )

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -425,6 +425,7 @@ def conv2d_grad(orig, grad):
         output_padding=output_padding,
     )
 
+    # TODO: modify attributes related to filter
     backward_weight = _nn.conv2d_backward_weight(
         data,
         grad,

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -425,7 +425,6 @@ def conv2d_grad(orig, grad):
         output_padding=output_padding,
     )
 
-    # TODO: modify attributes related to filter
     backward_weight = _nn.conv2d_backward_weight(
         data,
         grad,

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -435,8 +435,8 @@ def conv2d_grad(orig, grad):
         channels=attrs.channels,
         kernel_size=(filter_h, filter_w),
         data_layout=attrs.data_layout,
+        grad_layout=attrs.out_layout if attrs.out_layout else attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
-        out_layout=attrs.out_layout,
         out_dtype=attrs.out_dtype,
     )
 

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -434,7 +434,7 @@ def conv2d_grad(orig, grad):
         dilation=attrs.dilation,
         groups=attrs.groups,
         channels=attrs.channels,
-        kernel_size=attrs.kernel_size,
+        kernel_size=(filter_h, filter_w),
         data_layout=attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
         out_layout=attrs.out_layout,

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -399,15 +399,14 @@ def conv2d_grad(orig, grad):
     data_shape = get_const_tuple(data.checked_type.shape)
     weight_shape = get_const_tuple(weight.checked_type.shape)
     _, _, grad_h, grad_w = get_const_tuple(orig.checked_type.shape)
-    batch, in_channel, in_h, in_w = data_shape
-    out_channel, _, filter_h, filter_w = weight_shape
+    _, _, in_h, in_w = data_shape
+    _, _, filter_h, filter_w = weight_shape
 
     # infer output_padding
     fpad_top, fpad_left, fpad_bottom, fpad_right = get_pad_tuple(
         get_const_tuple(attrs.padding), (filter_h, filter_w)
     )
     stride_h, stride_w = get_const_tuple(attrs.strides)
-    dilation_h, dilation_w = get_const_tuple(attrs.dilation)
     out_h = (grad_h - 1) * stride_h - fpad_top - fpad_bottom + filter_h
     out_w = (grad_w - 1) * stride_w - fpad_left - fpad_right + filter_w
     output_padding = (in_h - out_h, in_w - out_w)
@@ -425,46 +424,21 @@ def conv2d_grad(orig, grad):
         groups=attrs.groups,
         output_padding=output_padding,
     )
-    grad = tile(grad, [1, in_channel // attrs.groups, 1, 1])
-    grad = reshape(grad, [-1, 1, 0, 0])  # batch * oc * ic // groups, 1, oh, ow
-    data = reshape(data, [1, -1, 0, 0])  # 1, batch * ic, ih, iw
 
-    backward_weight = _nn.conv2d(
+    backward_weight = _nn.conv2d_backward_weight(
         data,
         grad,
-        strides=attrs.dilation,
+        strides=attrs.strides,
         padding=attrs.padding,
-        dilation=attrs.strides,
-        groups=in_channel * batch,
+        dilation=attrs.dilation,
+        groups=attrs.groups,
+        channels=attrs.channels,
+        kernel_size=attrs.kernel_size,
+        data_layout=attrs.data_layout,
+        kernel_layout=attrs.kernel_layout,
+        out_layout=attrs.out_layout,
+        out_dtype=attrs.out_dtype,
     )
-    # infer shape of backward_weight
-    padded_weight_grad_h = (
-        in_h - (grad_h - 1) * stride_h - 1 + fpad_top + fpad_bottom
-    ) // dilation_h + 1
-    padded_weight_grad_w = (
-        in_w - (grad_w - 1) * stride_w - 1 + fpad_left + fpad_right
-    ) // dilation_w + 1
-    backward_weight = reshape(
-        backward_weight,
-        [
-            batch,
-            in_channel // attrs.groups,
-            out_channel,
-            padded_weight_grad_h,
-            padded_weight_grad_w,
-        ],
-    )
-    backward_weight = _sum(backward_weight, axis=0)
-    backward_weight = transpose(backward_weight, [1, 0, 2, 3])
-
-    assert padded_weight_grad_h >= filter_h
-    assert padded_weight_grad_w >= filter_w
-    if padded_weight_grad_h > filter_h or padded_weight_grad_w > filter_w:
-        backward_weight = strided_slice(
-            backward_weight,
-            begin=[0, 0, 0, 0],
-            end=[out_channel, in_channel // attrs.groups, filter_h, filter_w],
-        )
 
     return [backward_data, backward_weight]
 

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -434,7 +434,7 @@ def conv2d_grad(orig, grad):
         dilation=attrs.dilation,
         groups=attrs.groups,
         channels=attrs.channels,
-        kernel_size=(grad_h, grad_w),
+        kernel_size=(filter_h, filter_w),
         data_layout=attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
         out_layout=attrs.out_layout,

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -434,7 +434,7 @@ def conv2d_grad(orig, grad):
         dilation=attrs.dilation,
         groups=attrs.groups,
         channels=attrs.channels,
-        kernel_size=(filter_h, filter_w),
+        kernel_size=(grad_h, grad_w),
         data_layout=attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
         out_layout=attrs.out_layout,

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -52,7 +52,6 @@ from .transform import (
     reshape_like,
     strided_slice,
     take,
-    tile,
     transpose,
     where,
     repeat,

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -938,12 +938,12 @@ def convert_deformable_conv2d(attrs, inputs, tinfos, desired_layouts):
 
 @reg.register_convert_op_layout("nn.conv2d_backward_weight")
 def convert_conv2d_backward_weight(attrs, inputs, tinfos, desired_layouts):
-    """Convert Layout pass registration for conv2d op.
+    """Convert Layout pass registration for conv2d_backward_weight op.
 
     Parameters
     ----------
     attrs : tvm.ir.Attrs
-        Attributes of current convolution
+        Attributes of current op
     inputs : list of tvm.relay.Expr
         The args of the Relay expr to be legalized
     tinfos : list of types
@@ -1098,6 +1098,22 @@ reg.register_injective_schedule("nn.batch_to_space_nd")
 
 @reg.register_legalize("nn.conv2d_backward_weight")
 def legalize_conv2d_backward_weight(attrs, inputs, types):
+    """Legalize conv2d_backward_weight op.
+
+    Parameters
+    ----------
+    attrs : tvm.ir.Attrs
+        Attributes of current op
+    inputs : list of tvm.relay.Expr
+        The args of the Relay expr to be legalized
+    types : list of types
+        List of input and output types
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The legalized expr
+    """
     data, grad = inputs
     data_shape = get_const_tuple(data.checked_type.shape)
     weight_shape = get_const_tuple(types[2].shape)

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -959,14 +959,11 @@ def convert_conv2d_backward_weight(attrs, inputs, tinfos, desired_layouts):
     """
     data, grad = inputs
     new_attrs = dict(attrs)
-    assert len(desired_layouts) == 2, "A desired layout is expected for both of nn.conv2d's inputs"
-    desired_data_layout, desired_kernel_layout = map(str, desired_layouts)
+    assert len(desired_layouts) == 2, "A desired layout is expected for both of data and gradient."
+    desired_data_layout, desired_grad_layout = map(str, desired_layouts)
     assert desired_data_layout != "default", "Data layout cannot be default"
     new_attrs["data_layout"] = desired_data_layout
-
-    assert desired_kernel_layout == "OHWI", "Only OHWI kernel layout is supported"
-
-    new_attrs["kernel_layout"] = desired_kernel_layout
+    new_attrs["grad_layout"] = desired_grad_layout
     return relay.nn.conv2d_backward_weight(data, grad, **new_attrs)
 
 

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -1061,7 +1061,6 @@ reg.register_pattern("nn.correlation", OpPattern.OUT_ELEMWISE_FUSABLE)
 reg.register_injective_schedule("nn.space_to_batch_nd")
 reg.register_injective_schedule("nn.batch_to_space_nd")
 
-reg.register_pattern("nn.conv2d_backward_weight", OpPattern.OUT_ELEMWISE_FUSABLE)
 
 @reg.register_legalize("nn.conv2d_backward_weight")
 def legalize_conv2d_backward_weight(attrs, inputs, types):
@@ -1089,6 +1088,7 @@ def legalize_conv2d_backward_weight(attrs, inputs, types):
         dilation=attrs.strides,
         groups=in_channel * batch,
     )
+
     # infer shape of backward_weight
     padded_weight_grad_h = (
         in_h - (grad_h - 1) * stride_h - 1 + fpad_top + fpad_bottom
@@ -1096,6 +1096,7 @@ def legalize_conv2d_backward_weight(attrs, inputs, types):
     padded_weight_grad_w = (
         in_w - (grad_w - 1) * stride_w - 1 + fpad_left + fpad_right
     ) // dilation_w + 1
+
     backward_weight = relay.reshape(
         backward_weight,
         [

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -936,43 +936,6 @@ def convert_deformable_conv2d(attrs, inputs, tinfos, desired_layouts):
     return relay.nn.deformable_conv2d(data, offset, weight, **new_attrs)
 
 
-@reg.register_convert_op_layout("nn.conv2d_backward_weight")
-def convert_conv2d_backward_weight(attrs, inputs, _, desired_layouts):
-    """Convert Layout pass registration for conv2d_backward_weight op.
-    Note that `desired_layouts` must be a pair [`data_layout`, `kernel_layouts`],
-    where `kernel_layouts` affects the output of this op (since the output of this op
-    is the weight gradient). The layout of the output gradient (the second input to this op)
-    is assumed to be the same as `data_layout`.
-
-    Parameters
-    ----------
-    attrs : tvm.ir.Attrs
-        Attributes of current op
-    inputs : list of tvm.relay.Expr
-        The args of the Relay expr to be legalized
-    tinfos : list of types
-        List of input and output types
-    desired_layouts : list of layout strings
-        List of layouts defining our desired
-        layout for the data and kernel inputs respectively.
-
-    Returns
-    -------
-    result : tvm.relay.Expr
-        The transformed expr
-    """
-    data, grad = inputs
-    new_attrs = dict(attrs)
-    assert len(desired_layouts) == 2, "A desired layout is expected for both of data and gradient."
-    desired_data_layout, desired_kernel_layout = map(str, desired_layouts)
-    assert desired_data_layout != "default", "Data layout cannot be default"
-    new_attrs["data_layout"] = desired_data_layout
-    new_attrs["grad_layout"] = desired_data_layout
-    new_attrs["kernel_layout"] = desired_kernel_layout
-    new_attrs.pop("out_layout")
-    return relay.nn.conv2d_backward_weight(data, grad, **new_attrs)
-
-
 # bitpack
 @reg.register_compute("nn.bitpack")
 def compute_bitpack(attrs, inputs, out_dtype):

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -23,6 +23,7 @@ from tvm import relay, topi
 from tvm.runtime import convert
 from tvm.te.hybrid import script
 from tvm.topi.utils import get_const_tuple
+from tvm.topi.nn.utils import get_pad_tuple
 
 from ....ir import container
 from ....tir import expr
@@ -1060,10 +1061,22 @@ reg.register_pattern("nn.correlation", OpPattern.OUT_ELEMWISE_FUSABLE)
 reg.register_injective_schedule("nn.space_to_batch_nd")
 reg.register_injective_schedule("nn.batch_to_space_nd")
 
+reg.register_pattern("nn.conv2d_backward_weight", OpPattern.OUT_ELEMWISE_FUSABLE)
 
-@_reg.register_legalize("nn.conv2d_backward_weight")
+@reg.register_legalize("nn.conv2d_backward_weight")
 def legalize_conv2d_backward_weight(attrs, inputs, types):
     data, grad = inputs
+    data_shape = get_const_tuple(data.checked_type.shape)
+    weight_shape = get_const_tuple(types[2].shape)
+    _, out_channel, grad_h, grad_w = get_const_tuple(grad.checked_type.shape)
+    batch, in_channel, in_h, in_w = data_shape
+    _, _, filter_h, filter_w = weight_shape
+    fpad_top, fpad_left, fpad_bottom, fpad_right = get_pad_tuple(
+        get_const_tuple(attrs.padding), (filter_h, filter_w)
+    )
+    stride_h, stride_w = get_const_tuple(attrs.strides)
+    dilation_h, dilation_w = get_const_tuple(attrs.dilation)
+
     grad = relay.tile(grad, [1, in_channel // attrs.groups, 1, 1])
     grad = relay.reshape(grad, [-1, 1, 0, 0])  # batch * oc * ic // groups, 1, oh, ow
     data = relay.reshape(data, [1, -1, 0, 0])  # 1, batch * ic, ih, iw
@@ -1100,7 +1113,7 @@ def legalize_conv2d_backward_weight(attrs, inputs, types):
     assert padded_weight_grad_w >= filter_w
 
     if padded_weight_grad_h > filter_h or padded_weight_grad_w > filter_w:
-        backward_weight = strided_slice(
+        backward_weight = relay.strided_slice(
             backward_weight,
             begin=[0, 0, 0, 0],
             end=[out_channel, in_channel // attrs.groups, filter_h, filter_w],

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -957,59 +957,17 @@ def convert_conv2d_backward_weight(attrs, inputs, tinfos, desired_layouts):
     result : tvm.relay.Expr
         The transformed expr
     """
-    data, weight = inputs
-
-    # First check if there is a LayoutConfig scope, and if so, whether
-    # it indicates we should ignore this layer or not.
-    layout_config = LayoutConfig.current
-    if layout_config is not None:
-        skip_layer = layout_config.check_skip()
-        if skip_layer:
-            return relay.nn.conv2d(data, weight, **attrs)
-
-    # Prepare new layout.
+    data, grad = inputs
     new_attrs = dict(attrs)
     assert len(desired_layouts) == 2, "A desired layout is expected for both of nn.conv2d's inputs"
     desired_data_layout, desired_kernel_layout = map(str, desired_layouts)
     assert desired_data_layout != "default", "Data layout cannot be default"
     new_attrs["data_layout"] = desired_data_layout
-    need_tile = re.match(r"NCHW(\d*)c", desired_data_layout)
 
-    if desired_kernel_layout != "default" and not need_tile:
-        new_attrs["kernel_layout"] = desired_kernel_layout
-        return relay.nn.conv2d(data, weight, **new_attrs)
+    assert desired_kernel_layout == "OHWI", "Only OHWI kernel layout is supported"
 
-    # Handle default kernel layouts
-    if desired_data_layout == "NCHW":
-        new_attrs["kernel_layout"] = "OIHW"
-        return relay.nn.conv2d(data, weight, **new_attrs)
-    elif desired_data_layout == "NHWC":
-        # Check for depthwise convolution.
-        data_info, weight_info = tinfos
-        if is_depthwise_conv2d(
-            data_info.shape,
-            attrs["data_layout"],
-            weight_info.shape,
-            attrs["kernel_layout"],
-            attrs["groups"],
-        ):
-            new_attrs["kernel_layout"] = "HWOI"
-        else:
-            new_attrs["kernel_layout"] = "HWIO"
-        return relay.nn.conv2d(data, weight, **new_attrs)
-    elif desired_data_layout == "HWNC":
-        new_attrs["kernel_layout"] = "HWOI"
-        return relay.nn.conv2d(data, weight, **new_attrs)
-    elif need_tile:
-        assert desired_kernel_layout != "default", "Kernel layout cannot be default."
-        tile = int(need_tile.group(1))
-        if isinstance(data, relay.expr.Var) and data.checked_type.shape[1] % tile != 0:
-            return relay.nn.conv2d(data, weight, **attrs)
-        else:
-            new_attrs["kernel_layout"] = desired_kernel_layout
-            return relay.nn.contrib_conv2d_nchwc(data, weight, **new_attrs)
-
-    raise ValueError("Layout %s is not yet supported." % desired_data_layout)
+    new_attrs["kernel_layout"] = desired_kernel_layout
+    return relay.nn.conv2d_backward_weight(data, grad, **new_attrs)
 
 
 # bitpack

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -964,6 +964,8 @@ def convert_conv2d_backward_weight(attrs, inputs, tinfos, desired_layouts):
     assert desired_data_layout != "default", "Data layout cannot be default"
     new_attrs["data_layout"] = desired_data_layout
     new_attrs["grad_layout"] = desired_grad_layout
+    new_attrs["kernel_layout"] = new_attrs["out_layout"]
+    new_attrs.pop("out_layout")
     return relay.nn.conv2d_backward_weight(data, grad, **new_attrs)
 
 

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -1080,7 +1080,7 @@ def legalize_conv2d_backward_weight(attrs, inputs, types):
     result : tvm.relay.Expr
         The legalized expr
     """
-    data, grad = inputs
+    grad, data = inputs
     data_shape = get_const_tuple(data.checked_type.shape)
     weight_shape = get_const_tuple(types[2].shape)
     _, out_channel, grad_h, grad_w = get_const_tuple(grad.checked_type.shape)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3809,7 +3809,6 @@ def conv2d_backward_weight(
         dilation = (dilation, dilation)
     padding = get_pad_tuple2d(padding)
 
-    print(data_layout, grad_layout, kernel_layout)
     return _make.conv2d_backward_weight(
         data,
         grad,

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3770,3 +3770,33 @@ def batch_to_space_nd(data, block_shape, crops):
     """
 
     return _make.batch_to_space_nd(data, block_shape, crops)
+
+
+def conv2d_backward_weight(
+    data,
+    grad,
+    strides=(1, 1),
+    padding=(0, 0),
+    dilation=(1, 1),
+    groups=1,
+    channels=None,
+    kernel_size=None,
+    data_layout="NCHW",
+    kernel_layout="OIHW",
+    out_layout="",
+    out_dtype="",
+):
+    return _make.conv2d_backward_weight(
+        data,
+        grad,
+        strides,
+        padding,
+        dilation,
+        groups,
+        channels,
+        kernel_size,
+        data_layout,
+        kernel_layout,
+        out_layout,
+        out_dtype,
+    )

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3782,10 +3782,32 @@ def conv2d_backward_weight(
     channels=None,
     kernel_size=None,
     data_layout="NCHW",
-    kernel_layout="OIHW",
-    out_layout="",
+    grad_layout="NCHW",
+    output_kernel_layout="OIHW",
     out_dtype="",
 ):
+    r"""The gradient of conv2d with respect to weight.
+
+    This operator takes the output gradient `grad` as the convolution kernel
+    and convolves it with `data` to produce the gradeint with respect to weight.
+    Depending on an implementation, the roles of `data` and `grad` can be swapped
+    (For example, in CUTLASS `data` acts as the filter).
+
+    Note that the parameter `kernel_size` is the spatial size of the corresponding
+    forward convolution kernel, not the spatial size of `grad`.
+
+    Other parameters are the same as the conv2d op. See its documentation for more
+    details.
+
+    """
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if isinstance(strides, int):
+        strides = (strides, strides)
+    if isinstance(dilation, int):
+        dilation = (dilation, dilation)
+    padding = get_pad_tuple2d(padding)
+
     return _make.conv2d_backward_weight(
         data,
         grad,
@@ -3796,7 +3818,7 @@ def conv2d_backward_weight(
         channels,
         kernel_size,
         data_layout,
-        kernel_layout,
-        out_layout,
+        grad_layout,
+        output_kernel_layout,
         out_dtype,
     )

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3789,7 +3789,7 @@ def conv2d_backward_weight(
     r"""The gradient of conv2d with respect to weight.
 
     This operator takes the output gradient `grad` as the convolution kernel
-    and convolves it with `data` to produce the gradeint with respect to weight.
+    and convolves it with `data` to produce the gradient with respect to weight.
     Depending on an implementation, the roles of `data` and `grad` can be swapped
     (For example, in CUTLASS `data` acts as the filter).
 

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3783,7 +3783,7 @@ def conv2d_backward_weight(
     kernel_size=None,
     data_layout="NCHW",
     grad_layout="NCHW",
-    output_kernel_layout="OIHW",
+    kernel_layout="OIHW",
     out_dtype="",
 ):
     r"""The gradient of conv2d with respect to weight.
@@ -3794,7 +3794,8 @@ def conv2d_backward_weight(
     (For example, in CUTLASS `data` acts as the filter).
 
     Note that the parameter `kernel_size` is the spatial size of the corresponding
-    forward convolution kernel, not the spatial size of `grad`.
+    forward convolution kernel, not the spatial size of `grad`. `grad_layout` and
+    `kernel_layout` are the layouts of `grad` and the weight gradient respectively.
 
     Other parameters are the same as the conv2d op. See its documentation for more
     details.
@@ -3808,6 +3809,7 @@ def conv2d_backward_weight(
         dilation = (dilation, dilation)
     padding = get_pad_tuple2d(padding)
 
+    print(data_layout, grad_layout, kernel_layout)
     return _make.conv2d_backward_weight(
         data,
         grad,
@@ -3819,6 +3821,6 @@ def conv2d_backward_weight(
         kernel_size,
         data_layout,
         grad_layout,
-        output_kernel_layout,
+        kernel_layout,
         out_dtype,
     )

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3773,28 +3773,26 @@ def batch_to_space_nd(data, block_shape, crops):
 
 
 def conv2d_backward_weight(
-    data,
     grad,
+    data,
     strides=(1, 1),
     padding=(0, 0),
     dilation=(1, 1),
     groups=1,
     channels=None,
     kernel_size=None,
-    data_layout="NCHW",
     grad_layout="NCHW",
+    data_layout="NCHW",
     kernel_layout="OIHW",
     out_dtype="",
 ):
     r"""The gradient of conv2d with respect to weight.
 
-    This operator takes the output gradient `grad` as the convolution kernel
-    and convolves it with `data` to produce the gradient with respect to weight.
-    Depending on an implementation, the roles of `data` and `grad` can be swapped
-    (For example, in CUTLASS `data` acts as the filter).
+    This operator takes the output gradient `grad` and convolves it with `data` as
+    the convolution kernel, to produce the gradient with respect to weight.
 
     Note that the parameter `kernel_size` is the spatial size of the corresponding
-    forward convolution kernel, not that of `grad`. `grad_layout` and
+    forward convolution kernel, not that of `data`. `grad_layout` and
     `kernel_layout` are the layouts of `grad` and the weight gradient respectively.
 
     Other parameters are the same as the conv2d op. See its documentation for more
@@ -3810,16 +3808,16 @@ def conv2d_backward_weight(
     padding = get_pad_tuple2d(padding)
 
     return _make.conv2d_backward_weight(
-        data,
         grad,
+        data,
         strides,
         padding,
         dilation,
         groups,
         channels,
         kernel_size,
-        data_layout,
         grad_layout,
+        data_layout,
         kernel_layout,
         out_dtype,
     )

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -3794,7 +3794,7 @@ def conv2d_backward_weight(
     (For example, in CUTLASS `data` acts as the filter).
 
     Note that the parameter `kernel_size` is the spatial size of the corresponding
-    forward convolution kernel, not the spatial size of `grad`. `grad_layout` and
+    forward convolution kernel, not that of `grad`. `grad_layout` and
     `kernel_layout` are the layouts of `grad` and the weight gradient respectively.
 
     Other parameters are the same as the conv2d op. See its documentation for more

--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -127,6 +127,7 @@ def check_grad(
 
     fwd_func = run_infer_type(func)
     bwd_func = run_infer_type(gradient(fwd_func, mode=mode))
+    bwd_func = run_opt_pass(bwd_func, relay.transform.Legalize())
 
     if scale is None:
         scale = 10 * eps

--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -133,17 +133,19 @@ def check_grad(
             seq = tvm.transform.Sequential([relay.transform.ConvertLayout(desired_layouts)])
             return seq(mod)
 
-    mod = tvm.IRModule.from_expr(bwd_func)
-    # print(
-    #     convert_conv2d_layout(
-    #         mod,
-    #         {
-    #             "nn.conv2d": ["NHWC", "OHWI"],
-    #             "nn.conv2d_transpose": ["NHWC", "OHWI"],
-    #             "nn.conv2d_backward_weight": ["NHWC", "OHWI"],
-    #         },
-    #     )
-    # )
+    bwd_weight_func = relay.Function(bwd_func.params, relay.TupleGetItem(relay.TupleGetItem(bwd_func.body, 1), 1))
+    mod = tvm.IRModule.from_expr(bwd_weight_func)
+    print(mod)
+    print(
+        convert_conv2d_layout(
+            mod,
+            {
+                "nn.conv2d": ["NHWC", "OHWI"],
+                "nn.conv2d_transpose": ["NHWC", "OHWI"],
+                "nn.conv2d_backward_weight": ["NHWC", "OHWI"],
+            },
+        )
+    )
 
     bwd_func = run_opt_pass(bwd_func, relay.transform.Legalize())
 

--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -133,7 +133,9 @@ def check_grad(
             seq = tvm.transform.Sequential([relay.transform.ConvertLayout(desired_layouts)])
             return seq(mod)
 
-    bwd_weight_func = relay.Function(bwd_func.params, relay.TupleGetItem(relay.TupleGetItem(bwd_func.body, 1), 1))
+    bwd_weight_func = relay.Function(
+        bwd_func.params, relay.TupleGetItem(relay.TupleGetItem(bwd_func.body, 1), 1)
+    )
     mod = tvm.IRModule.from_expr(bwd_weight_func)
     print(mod)
     print(

--- a/python/tvm/relay/testing/__init__.py
+++ b/python/tvm/relay/testing/__init__.py
@@ -128,29 +128,6 @@ def check_grad(
     fwd_func = run_infer_type(func)
     bwd_func = run_infer_type(gradient(fwd_func, mode=mode))
 
-    def convert_conv2d_layout(mod, desired_layouts):
-        with tvm.transform.PassContext(opt_level=3):
-            seq = tvm.transform.Sequential([relay.transform.ConvertLayout(desired_layouts)])
-            return seq(mod)
-
-    bwd_weight_func = relay.Function(
-        bwd_func.params, relay.TupleGetItem(relay.TupleGetItem(bwd_func.body, 1), 1)
-    )
-    mod = tvm.IRModule.from_expr(bwd_weight_func)
-    print(mod)
-    print(
-        convert_conv2d_layout(
-            mod,
-            {
-                "nn.conv2d": ["NHWC", "OHWI"],
-                "nn.conv2d_transpose": ["NHWC", "OHWI"],
-                "nn.conv2d_backward_weight": ["NHWC", "OHWI"],
-            },
-        )
-    )
-
-    bwd_func = run_opt_pass(bwd_func, relay.transform.Legalize())
-
     if scale is None:
         scale = 10 * eps
 

--- a/python/tvm/topi/testing/__init__.py
+++ b/python/tvm/topi/testing/__init__.py
@@ -75,3 +75,4 @@ from .batch_to_space_nd import batch_to_space_nd_python
 from .nll_loss import nll_loss
 from .dense import dense
 from .searchsorted import searchsorted_ref
+from .conv2d_backcward_weight_python import conv2d_backward_weight_nchw_python

--- a/python/tvm/topi/testing/conv2d_backcward_weight_python.py
+++ b/python/tvm/topi/testing/conv2d_backcward_weight_python.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-nested-blocks
 """Gradient of conv2d with respect to weight in python"""
 import numpy as np
 

--- a/python/tvm/topi/testing/conv2d_backcward_weight_python.py
+++ b/python/tvm/topi/testing/conv2d_backcward_weight_python.py
@@ -15,12 +15,37 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=invalid-name
-"""Convolution in python"""
+"""Gradient of conv2d with respect to weight in python"""
 import numpy as np
 
 
 # Reference: cutlass/tools/util/include/cutlass/util/reference/host/convolution.h
-def conv2d_backward_weight_nchw_python(dy_np, x_np, stride, kernel_size, padding):
+def conv2d_backward_weight_nchw_python(dy_np, x_np, kernel_size, stride, padding):
+    """Gradient of the conv2d op with respect to weight, in NCHW layout.
+
+    Parameters
+    ----------
+    dy_np : numpy.ndarray
+        4-D with shape [batch, in_channel, out_height, out_width]
+
+    x_np : numpy.ndarray
+        4-D with shape [batch, in_channel, in_height, in_width]
+
+    kernel_size : tuple of two ints
+        Height and width of the weight
+
+    stride : tuple of two ints
+        Stride size, or [stride_height, stride_width]
+
+    padding : tuple of two ints
+        Spatial padding, or [pad_h, pad_w]
+
+    Returns
+    -------
+    b_np : np.ndarray
+        4-D with shape [num_filter, in_channel, filter_height, filter_width]
+
+    """
     N, C, H, W = x_np.shape
     _, K, P, Q = dy_np.shape
     R, S = kernel_size

--- a/python/tvm/topi/testing/conv2d_backcward_weight_python.py
+++ b/python/tvm/topi/testing/conv2d_backcward_weight_python.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Convolution in python"""
+import numpy as np
+
+
+def conv2d_backward_weight_nchw_python(dy_np, x_np, stride, kernel_size, padding):
+    N, C, H, W = x_np.shape[1]
+    _, K, P, Q = dy_np.shape[1]
+    pad_h, pad_w = padding
+    dw = np.zeros((K, C, kernel_size[0], kernel_size[1])).astype(dy_np.dtype)
+
+    for k in range(K):
+        for r in range(R):
+            for s in range(S):
+                for c in range(C):
+                    acc = 0
+                    for n in range(N):
+                        for p in range(P):
+                            for q in range(Q):
+                                coord = (n, c, p - pad_h + r, q - pad_w + s)
+
+                                if (
+                                    coord[2] < H
+                                    and coord[2] >= 0
+                                    and coord[3] < W
+                                    and coord[3] >= 0
+                                ):
+                                    acc += x[coord]
+
+                    dw[k, c, r, s] = acc
+
+    return dw

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -622,6 +622,8 @@ bool Conv2DBackwardWeightRel(const Array<Type>& types, int num_inputs, const Att
 
   const auto* param = attrs.as<Conv2DAttrs>();
   ICHECK(param != nullptr);
+  ICHECK(param->kernel_size.defined());
+
   const Layout in_layout(param->data_layout);
   const Layout kernel_layout(param->kernel_layout);
 
@@ -633,12 +635,11 @@ bool Conv2DBackwardWeightRel(const Array<Type>& types, int num_inputs, const Att
 
   auto in_channels = dshape_nchw[1];
   auto out_channels = grad_shape_nchw[1];
-  ICHECK(param->kernel_size.defined());
+
   Array<IndexExpr> wshape_oihw(
       {out_channels, in_channels, param->kernel_size[0], param->kernel_size[1]});
 
   auto wshape = trans_kernel_layout.BackwardShape(wshape_oihw);
-  LOG(INFO) << "wshape: " << wshape;
   reporter->Assign(types[2], TensorType(wshape, data->dtype));
   return true;
 }
@@ -659,6 +660,7 @@ TODO
     .add_argument("grad", "Tensor", "The gradient tensor.")
     .set_support_level(2)
     .add_type_rel("Conv2DBackwardWeight", Conv2DBackwardWeightRel)
+    .set_attr<TNonComputational>("TNonComputational", true)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>);
 
 }  // namespace relay

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -651,7 +651,7 @@ RELAY_REGISTER_OP("nn.conv2d_backward_weight")
     .describe(R"code(The gradient of the 2D convolution layer with respect to the weight.
 
 This layer computes the gradient of the conv2d op with respect to weight,
-given the origial input data and the output gradient.
+given the original input data and the output gradient.
 
 - **data**: This depends on the `layout` parameter. Input is 4D array of shape
             (batch_size, in_channels, height, width) if `layout` is `NCHW`.

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -579,5 +579,54 @@ TVM_REGISTER_GLOBAL("relay.op.nn._make.deformable_conv2d")
           kernel_size, data_layout, kernel_layout, out_layout, out_dtype, "nn.deformable_conv2d");
     });
 
+inline Expr MakeConv2dBackwardWeight(Expr data, Expr grad, Array<IndexExpr> strides,
+                                     Array<IndexExpr> padding, Array<IndexExpr> dilation,
+                                     int groups, IndexExpr channels, Array<IndexExpr> kernel_size,
+                                     std::string data_layout, std::string kernel_layout,
+                                     std::string out_layout, DataType out_dtype) {
+  auto attrs = make_object<Conv2DAttrs>();
+  attrs->strides = std::move(strides);
+  attrs->padding = std::move(padding);
+  attrs->dilation = std::move(dilation);
+  attrs->groups = groups;
+  attrs->channels = std::move(channels);
+  attrs->kernel_size = std::move(kernel_size);
+  attrs->data_layout = std::move(data_layout);
+  attrs->kernel_layout = std::move(kernel_layout);
+  attrs->out_layout = std::move(out_layout);
+  attrs->out_dtype = std::move(out_dtype);
+  const Op& op = Op::Get("nn.conv2d_backward_weight");
+  return Call(op, {data, grad}, Attrs(attrs), {});
+}
+
+// TODO: Clean up arguments
+TVM_REGISTER_GLOBAL("relay.op.nn._make.conv2d_backward_weight")
+    .set_body_typed([](Expr data, Expr grad, Array<IndexExpr> strides, Array<IndexExpr> padding,
+                       Array<IndexExpr> dilation, int groups, IndexExpr channels,
+                       Array<IndexExpr> kernel_size, String data_layout, String kernel_layout,
+                       String out_layout, DataType out_dtype) {
+      return MakeConv2dBackwardWeight(data, grad, strides, padding, dilation, groups, channels,
+                                      kernel_size, data_layout, kernel_layout, out_layout,
+                                      out_dtype);
+    });
+
+RELAY_REGISTER_OP("nn.conv2d_backward_weight")
+    .describe(R"code(The gradient of the 2D convolution layer with respect to the weight.
+
+TODO
+- **data**: This depends on the `layout` parameter. Input is 4D array of shape
+            (batch_size, in_channels, height, width) if `layout` is `NCHW`.
+- **grad**: (batch, channels, out_height, out_width) if `layout` is `NCHW`.
+- **out**:  This depends on the `layout` parameter. Output is 4D array of shape
+            (channels, in_channels, kernel_size[0], kernel_size[1]) if `layout` is `NCHW`.
+)code" TVM_ADD_FILELINE)
+    .set_attrs_type<Conv2DAttrs>()
+    .set_num_inputs(2)
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_argument("grad", "Tensor", "The gradient tensor.")
+    .set_support_level(2)
+    .add_type_rel("Conv2DBackwardWeight", Conv2DRel<Conv2DAttrs>)
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ConvInferCorrectLayout<Conv2DAttrs>);
+
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -595,12 +595,10 @@ inline Expr MakeConv2dBackwardWeight(Expr data, Expr grad, Array<IndexExpr> stri
   attrs->out_dtype = std::move(out_dtype);
   attrs->kernel_layout = std::move(grad_layout);
   attrs->out_layout = std::move(kernel_layout);
-
   const Op& op = Op::Get("nn.conv2d_backward_weight");
   return Call(op, {data, grad}, Attrs(attrs), {});
 }
 
-// TODO: Clean up arguments
 TVM_REGISTER_GLOBAL("relay.op.nn._make.conv2d_backward_weight")
     .set_body_typed([](Expr data, Expr grad, Array<IndexExpr> strides, Array<IndexExpr> padding,
                        Array<IndexExpr> dilation, int groups, IndexExpr channels,

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -234,7 +234,7 @@ def verify_conv2d_backward_weight(dy_shape, x_shape, kernel_size, stride, paddin
     dy = relay.var("dy", shape=dy_shape, dtype=dtype)
     x = relay.var("x", shape=x_shape, dtype=dtype)
     dw = relay.nn.conv2d_backward_weight(
-        x, dy, strides=stride, padding=padding, kernel_size=kernel_size
+        dy, x, strides=stride, padding=padding, kernel_size=kernel_size
     )
     dw_func = relay.Function([dy, x], dw)
     dw_func_legalized = run_opt_pass(dw_func, relay.transform.Legalize())

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -229,11 +229,8 @@ def test_batch_flatten_grad():
     verify_batch_flatten_grad((1, 8))
 
 
-def verify_conv2d_backward_weight(dy_shape, x_shape):
+def verify_conv2d_backward_weight(dy_shape, x_shape, kernel_size, stride, padding):
     dtype = "float32"
-    stride = (1, 1)
-    padding = (1, 1)
-    kernel_size = (3, 3)
     dy = relay.var("dy", shape=dy_shape, dtype=dtype)
     x = relay.var("x", shape=x_shape, dtype=dtype)
     dw = relay.nn.conv2d_backward_weight(
@@ -249,7 +246,7 @@ def verify_conv2d_backward_weight(dy_shape, x_shape):
 
     dw_np = relay.create_executor(device=dev, target=target).evaluate(dw_legalized)(dy_np, x_np)
     ref_dw_np = tvm.topi.testing.conv2d_backward_weight_nchw_python(
-        dy_np, x_np, stride, kernel_size, padding
+        dy_np, x_np, kernel_size, stride, padding
     )
 
     print(dw_np.shape)
@@ -259,7 +256,7 @@ def verify_conv2d_backward_weight(dy_shape, x_shape):
 
 @tvm.testing.uses_gpu
 def test_conv2d_backward_weight():
-    verify_conv2d_backward_weight((2, 8, 32, 32), (2, 4, 32, 32))
+    verify_conv2d_backward_weight((2, 8, 32, 32), (2, 4, 32, 32), (3, 3), (1, 1), (1, 1))
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -237,7 +237,6 @@ def verify_conv2d_backward_weight(dy_shape, x_shape, kernel_size, stride, paddin
         x, dy, strides=stride, padding=padding, kernel_size=kernel_size
     )
     dw_func = relay.Function([dy, x], dw)
-
     dw_func_legalized = run_opt_pass(dw_func, relay.transform.Legalize())
 
     target = "llvm"
@@ -257,10 +256,9 @@ def verify_conv2d_backward_weight(dy_shape, x_shape, kernel_size, stride, paddin
     np.testing.assert_allclose(dw_np, ref_dw_np, rtol=1e-4, atol=1e-4)
 
 
-@tvm.testing.uses_gpu
 def test_conv2d_backward_weight():
     verify_conv2d_backward_weight((2, 8, 32, 32), (2, 4, 32, 32), (3, 3), (1, 1), (1, 1))
-    verify_conv2d_backward_weight((2, 8, 15, 15), (2, 4, 32, 32), (3, 3), (2, 2), (0, 0))
+    verify_conv2d_backward_weight((2, 16, 15, 15), (2, 3, 32, 32), (3, 3), (2, 2), (0, 0))
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 import numpy as np
-
+import pytest
 from tvm import topi
 import tvm.topi.testing
 import tvm
 from tvm import te
 from tvm import relay
-from tvm.relay.testing import check_grad, run_infer_type
+from tvm.relay.testing import check_grad, run_infer_type, run_opt_pass
 from tvm.relay.transform import gradient
 import tvm.testing
 
@@ -229,11 +229,39 @@ def test_batch_flatten_grad():
     verify_batch_flatten_grad((1, 8))
 
 
+def verify_conv2d_backward_weight(dy_shape, x_shape):
+    dtype = "float32"
+    stride = (1, 1)
+    padding = (1, 1)
+    kernel_size = (3, 3)
+    dy = relay.var("dy", shape=dy_shape, dtype=dtype)
+    x = relay.var("x", shape=x_shape, dtype=dtype)
+    dw = relay.nn.conv2d_backward_weight(
+        dy, x, strides=stride, padding=padding, kernel_size=kernel_size
+    )
+
+    dw_legalized = run_opt_pass(dw, relay.transform.Legalize())
+
+    target = "llvm"
+    dev = tvm.device(target, 0)
+    dy_np = np.random.randn(*dy_shape).astype(dtype)
+    x_np = np.random.randn(*x_shape).astype(dtype)
+
+    dw_np = relay.create_executor(device=dev, target=target).evaluate(dw_legalized)(dy_np, x_np)
+    ref_dw_np = tvm.topi.testing.conv2d_backward_weight_nchw_python(
+        dy_np, x_np, stride, kernel_size, padding
+    )
+
+    print(dw_np.shape)
+    # np.testing.assert_allclose(dw_np, ref_dw_np, rtol=1e-5, atol=1e-5)
+    print(np.max(np.abs(dw_np - ref_dw_np)))
+
+
+@tvm.testing.uses_gpu
+def test_conv2d_backward_weight():
+    verify_conv2d_backward_weight((2, 8, 32, 32), (2, 4, 32, 32))
+
+
 if __name__ == "__main__":
-    test_max_pool2d_grad()
-    test_avg_pool2d_grad()
-    test_global_avg_pool2d_grad()
-    test_conv2d_grad()
-    test_dense_grad()
-    test_matmul_grad()
-    test_batch_flatten_grad()
+    # pytest.main([__file__])
+    test_conv2d_backward_weight()


### PR DESCRIPTION
This PR adds a Relay op for the gradient of conv2d op with respect to weight (wgrad for short). It is implemented simply using the existing equivalent expressions in https://github.com/apache/tvm/blob/850abb0c01afffda071bdeda952f053407005050/python/tvm/relay/op/_tensor_grad.py#L428-L467 and make it the target for `conv2d_backward_weight` op  legalization. So no topi op has been added for now.

The motivation for introducing this op is threefold:
* Both cutlass and cuDNN have a dedicated op for wgrad. Having an op that maps one-to-one makes it easy to offload this op to these backends.
* The existing implementation, as a composition of `nn.con2d` and other ops, works but it is likely to be inefficient since it involves `tile(grad, [1, in_channel // attrs.groups, 1, 1])` , a larger group conv2d workload and other post-processing (sum, transpose, slice etc). A direct implementation would likely be much faster.
* The third reason is more subtle but this was what necessitated this PR. If I want to use cuDNN or cutlass wgrad with NHWC layout, I'd run `convert_layout` pass on a backward graph, resulting in. 
```
  %1 = tile(%dy, reps=[1, 4, 1, 1]) /* ty=Tensor[(2, 32, 32, 32), float32] */;
  %2 = reshape(%1, newshape=[-1, 1, 0, 0]) /* ty=Tensor[(64, 1, 32, 32), float32] */;
  %3 = layout_transform(%0, src_layout="NCHW", dst_layout="NHWC") /* ty=Tensor[(1, 32, 32, 8), float32] */;
  %4 = layout_transform(%2, src_layout="OIHW", dst_layout="OHWI") /* ty=Tensor[(64, 32, 32, 1), float32] */;
  %5 = nn.conv2d(%3, %4, padding=[1, 1, 1, 1], groups=8, data_layout="NHWC", kernel_layout="OHWI") /* ty=Tensor[(1, 3, 3, 64), float32] */;
  %6 = layout_transform(%5, src_layout="NHWC", dst_layout="NCHW") /* ty=Tensor[(1, 64, 3, 3), float32] */;
  %7 = reshape(%6, newshape=[2, 4, 8, 3, 3]) /* ty=Tensor[(2, 4, 8, 3, 3), float32] */;
  %8 = sum(%7, axis=[0]) /* ty=Tensor[(4, 8, 3, 3), float32] */;
  transpose(%8, axes=[1, 0, 2, 3]) /* ty=Tensor[(8, 4, 3, 3), float32] */
```
I cannot pattern match this graph and extract NHWC conv2d wgrad, since `layout_transform` ops are "too close" to `nn.conv2d`. I need them to happen before `tile` and after `transpose`. So this anti-behavior is the strong reason to want a dedicated wgrad op representation in Relay. 

cc @vinx13 @tkonolige @comaniac @YuchenJin 