### PR TITLE
Enable NPU and CMSIS in ci_qemu

### DIFF
--- a/tests/scripts/task_config_build_qemu.sh
+++ b/tests/scripts/task_config_build_qemu.sh
@@ -25,6 +25,8 @@ cp ../cmake/config.cmake .
 
 echo set\(USE_SORT ON\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
+echo set\(USE_CMSISNN ON\) >> config.cmake
+echo set\(USE_ETHOSU ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-10\) >> config.cmake
 echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake


### PR DESCRIPTION
These are required for running the demos under ci_qemu in combination with Zephyr
