### PR TITLE
[microNPU][4] Add the cascader Proposal generator

### DIFF
--- a/python/tvm/contrib/ethosu/cascader/pareto.py
+++ b/python/tvm/contrib/ethosu/cascader/pareto.py
@@ -21,8 +21,6 @@ from tvm import Object
 
 from . import _ffi_api
 from .plan import Plan
-from .proposal import Proposal
-from .tensor_config import MemoryRegion
 
 
 def _get_pareto_frontier(costs: List[List[float]]) -> List[bool]:
@@ -39,9 +37,3 @@ def _thin_vector(vec: List[Object], max_size: int) -> List[Object]:
 
 def _pareto_cull_plans(plans: List[Plan], max_plans: int) -> List[Plan]:
     return list(_ffi_api.ParetoCullPlans(plans, max_plans))
-
-
-def pareto_cull_proposals(
-    proposals: List[Proposal], cascade_region: MemoryRegion, max_proposals: int
-) -> List[Proposal]:
-    return list(_ffi_api.ParetoCullProposals(proposals, cascade_region, max_proposals))

--- a/python/tvm/contrib/ethosu/cascader/proposal.py
+++ b/python/tvm/contrib/ethosu/cascader/proposal.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Proposal class to hold graph scheduling information."""
+from typing import Dict, FrozenSet, List
+import tvm._ffi
+from tvm.contrib.ethosu.cascader.plan import Plan
+
+from tvm.runtime import Object
+
+from . import _ffi_api
+from .graph import Tensor, Part
+from .tensor_config import TensorConfig, MemoryRegion
+
+
+@tvm._ffi.register_object("contrib.ethosu.cascader.Proposal")
+class Proposal(Object):
+    """Proposal class"""
+
+    def __init__(
+        self,
+        part_group: FrozenSet[Part],
+        plans: List[Plan],
+        input_tensor_configs: Dict[Tensor, TensorConfig],
+        memory_usage: Dict[MemoryRegion, int],
+        cycles: int,
+    ):
+        self.__init_handle_by_constructor__(
+            _ffi_api.Proposal,
+            list(part_group),
+            plans,
+            input_tensor_configs,
+            memory_usage,
+            cycles,
+        )
+
+    @property
+    def graph(self):
+        return self._graph
+
+    @property
+    def part_group(self):
+        return frozenset(self._part_group)
+
+    @property
+    def plans(self):
+        return list(self._plans)
+
+    @property
+    def input_tensor_configs(self):
+        return dict(self._input_tensor_configs)
+
+    @property
+    def memory_usage(self):
+        return int(self._memory_usage)
+
+    @property
+    def cycles(self):
+        return int(self._cycles)

--- a/python/tvm/contrib/ethosu/cascader/proposal.py
+++ b/python/tvm/contrib/ethosu/cascader/proposal.py
@@ -22,51 +22,85 @@ from tvm.contrib.ethosu.cascader.plan import Plan
 from tvm.runtime import Object
 
 from . import _ffi_api
-from .graph import Tensor, Part
+from .graph import Tensor, Part, CascaderGraph
 from .tensor_config import TensorConfig, MemoryRegion
 
 
 @tvm._ffi.register_object("contrib.ethosu.cascader.Proposal")
 class Proposal(Object):
-    """Proposal class"""
+    """A class which describes how to schedule a CascaderGraph as a series of disjoint Plans.
+
+    Attributes
+    ----------
+    graph : CascaderGraph
+        The CascaderGraph to which the Proposal applies.
+    part_group : FrozenSet[Part]
+        The Parts which are covered by the Proposal.
+    plans : List[Plan]
+        The Plans used in the Proposal.
+    input_tensor_configs : Dict[Tensor, TensorConfig]
+        The TensorConfigs indexed by Tensor in the Proposal which aren't produced by a Plan.
+    cascade_region : MemoryRegion
+        The MemoryRegion where cascading buffers should be homed.
+    memory_usage : int
+        The memory required to execute the Proposal in the cascading MemoryRegion.
+    cycles : int
+        The estimated cycles taken to execute the Proposal.
+
+    """
 
     def __init__(
         self,
+        graph: CascaderGraph,
         part_group: FrozenSet[Part],
         plans: List[Plan],
         input_tensor_configs: Dict[Tensor, TensorConfig],
+        cascade_region: MemoryRegion,
         memory_usage: Dict[MemoryRegion, int],
         cycles: int,
     ):
         self.__init_handle_by_constructor__(
             _ffi_api.Proposal,
+            graph,
             list(part_group),
             plans,
             input_tensor_configs,
+            cascade_region,
             memory_usage,
             cycles,
         )
 
     @property
-    def graph(self):
+    def graph(self) -> CascaderGraph:
+        """The CascaderGraph to which the Proposal applies."""
         return self._graph
 
     @property
-    def part_group(self):
+    def part_group(self) -> FrozenSet[Part]:
+        """The Parts which are covered by the Proposal."""
         return frozenset(self._part_group)
 
     @property
-    def plans(self):
+    def plans(self) -> List[Plan]:
+        """The Plans used in the Proposal."""
         return list(self._plans)
 
     @property
-    def input_tensor_configs(self):
+    def input_tensor_configs(self) -> Dict[Tensor, TensorConfig]:
+        """The TensorConfigs indexed by Tensor in the Proposal which aren't produced by a Plan."""
         return dict(self._input_tensor_configs)
 
     @property
-    def memory_usage(self):
+    def cascade_region(self) -> MemoryRegion:
+        """The MemoryRegion where cascading buffers should be homed."""
+        return self._cascade_region
+
+    @property
+    def memory_usage(self) -> int:
+        """The memory required to execute the Proposal in the cascading MemoryRegion."""
         return int(self._memory_usage)
 
     @property
-    def cycles(self):
+    def cycles(self) -> int:
+        """The estimated cycles taken to execute the Proposal."""
         return int(self._cycles)

--- a/python/tvm/contrib/ethosu/cascader/proposal_generator.py
+++ b/python/tvm/contrib/ethosu/cascader/proposal_generator.py
@@ -14,34 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Pareto optimisation functions for the NPU cascader."""
-from typing import List
-
-from tvm import Object
+"""Algorithms to generate Proposals for a Graph."""
+from typing import List, Dict, FrozenSet
 
 from . import _ffi_api
+from .cascader_options import CascaderOptions
 from .plan import Plan
 from .proposal import Proposal
-from .tensor_config import MemoryRegion
+from .graph import CascaderGraph, Part
 
 
-def _get_pareto_frontier(costs: List[List[float]]) -> List[bool]:
-    for i, cost in enumerate(costs):
-        for j, value in enumerate(cost):
-            costs[i][j] = float(value)
-
-    return [bool(v) for v in _ffi_api.GetParetoFrontier(costs)]
-
-
-def _thin_vector(vec: List[Object], max_size: int) -> List[Object]:
-    return list(_ffi_api.ThinVector(vec, max_size))
-
-
-def _pareto_cull_plans(plans: List[Plan], max_plans: int) -> List[Plan]:
-    return list(_ffi_api.ParetoCullPlans(plans, max_plans))
-
-
-def pareto_cull_proposals(
-    proposals: List[Proposal], cascade_region: MemoryRegion, max_proposals: int
+def generate_proposals(
+    graph: CascaderGraph,
+    home_map: Dict[FrozenSet[Part], List[Plan]],
+    options: CascaderOptions,
 ) -> List[Proposal]:
-    return list(_ffi_api.ParetoCullProposals(proposals, cascade_region, max_proposals))
+    return list(
+        _ffi_api.GenerateProposals(
+            graph,
+            home_map,
+            options,
+        )
+    )

--- a/python/tvm/contrib/ethosu/cascader/proposal_generator.py
+++ b/python/tvm/contrib/ethosu/cascader/proposal_generator.py
@@ -29,6 +29,26 @@ def generate_proposals(
     home_map: Dict[FrozenSet[Part], List[Plan]],
     options: CascaderOptions,
 ) -> List[Proposal]:
+    """Generate Pareto optimal Proposals for a CascaderGraph.
+
+    This algorithm takes a top-down dynamic programming approach to determining how
+    to optimally combine Plans into Proposals.
+
+    Parameters
+    ----------
+    graph : CascaderGraph
+        The CascaderGraph to generate Proposals for.
+    home_map : Dict[FrozenSet[Part], List[Plan]]
+        The Tensor homing map defining valid memory homes for Tensors.
+    options : CascaderOptions
+        The configuration options with which to run the generator.
+
+    Returns
+    ------
+    List[Proposal]
+        A list of Pareto optimal Proposals.
+
+    """
     return list(
         _ffi_api.GenerateProposals(
             graph,

--- a/src/contrib/ethosu/cascader/pareto.cc
+++ b/src/contrib/ethosu/cascader/pareto.cc
@@ -161,12 +161,6 @@ TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.ParetoCullPlans")
       return Array<Plan>(ParetoCullPlans(vplans, max_size));
     });
 
-TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.ParetoCullProposals")
-    .set_body_typed([](Array<Proposal> proposals, int max_size) {
-      std::vector<Proposal> vproposals(proposals.begin(), proposals.end());
-      return Array<Proposal>(ParetoCullProposals(vproposals, max_size));
-    });
-
 }  // namespace cascader
 }  // namespace ethosu
 }  // namespace contrib

--- a/src/contrib/ethosu/cascader/pareto.h
+++ b/src/contrib/ethosu/cascader/pareto.h
@@ -37,6 +37,8 @@ namespace ethosu {
 namespace cascader {
 
 class Plan;
+class MemoryRegion;
+class Proposal;
 
 /*!
  * \brief Determine the Pareto optimal points.
@@ -64,6 +66,8 @@ std::vector<T> ThinVector(const std::vector<T>& vec, size_t max_size);
  * and cycles.
  */
 std::vector<Plan> ParetoCullPlans(std::vector<Plan> plans, size_t max_plans);
+
+std::vector<Proposal> ParetoCullProposals(std::vector<Proposal> proposals, size_t max_proposals);
 
 }  // namespace cascader
 }  // namespace ethosu

--- a/src/contrib/ethosu/cascader/proposal.cc
+++ b/src/contrib/ethosu/cascader/proposal.cc
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "proposal.h"
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/map.h>
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/registry.h>
+
+#include <utility>
+#include <vector>
+
+#include "plan.h"
+
+namespace tvm {
+namespace contrib {
+namespace ethosu {
+namespace cascader {
+
+void ProposalNode::VisitAttrs(AttrVisitor* v) {
+  v->Visit("_graph", &graph_);
+  Array<Part> tmp_parts(part_group_.begin(), part_group_.end());
+  v->Visit("_part_group", &tmp_parts);
+  Array<Plan> tmp_plans(plans_.begin(), plans_.end());
+  v->Visit("_plans", &tmp_plans);
+  Map<Tensor, TensorConfig> tmp_tmap(input_tensor_configs_.begin(), input_tensor_configs_.end());
+  v->Visit("_input_tensor_configs", &tmp_tmap);
+  v->Visit("_cascade_region", &cascade_region_);
+  v->Visit("_memory_usage", &memory_usage_);
+  v->Visit("_cycles", &cycles_);
+}
+
+Proposal::Proposal(const CascaderGraph& graph, const std::vector<Part>& part_group,
+                   const std::vector<Plan>& plans, const TensorConfigMap& input_tensor_configs,
+                   const MemoryRegion& cascade_region, int memory_usage, int cycles) {
+  auto n = make_object<ProposalNode>();
+  n->graph_ = std::move(graph);
+  n->part_group_ = std::move(part_group);
+  std::sort(n->part_group_.begin(), n->part_group_.end());
+  n->plans_ = std::move(plans);
+  n->input_tensor_configs_ = std::move(input_tensor_configs);
+  n->cascade_region_ = std::move(cascade_region);
+  n->memory_usage_ = std::move(memory_usage);
+  n->cycles_ = cycles;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.Proposal")
+    .set_body_typed([](CascaderGraph graph, Array<Part> part_group, Array<Plan> plans,
+                       Map<Tensor, TensorConfig> input_tensor_configs, MemoryRegion cascade_region,
+                       int memory_usage, int cycles) {
+      std::vector<Part> spart_group(part_group.begin(), part_group.end());
+      std::vector<Plan> vplans(plans.begin(), plans.end());
+      TensorConfigMap minput_tensor_configs(input_tensor_configs.begin(),
+                                            input_tensor_configs.end());
+      return Proposal(graph, spart_group, vplans, minput_tensor_configs, cascade_region,
+                      memory_usage, cycles);
+    });
+
+TVM_REGISTER_NODE_TYPE(ProposalNode);
+
+}  // namespace cascader
+}  // namespace ethosu
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/ethosu/cascader/proposal.cc
+++ b/src/contrib/ethosu/cascader/proposal.cc
@@ -23,6 +23,7 @@
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
 
+#include <algorithm>
 #include <utility>
 #include <vector>
 

--- a/src/contrib/ethosu/cascader/proposal.h
+++ b/src/contrib/ethosu/cascader/proposal.h
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/ethosu/cascader/proposal.h
+ * \brief Proposal object for the NPU cascader
+ */
+#ifndef TVM_CONTRIB_ETHOSU_CASCADER_PROPOSAL_H_
+#define TVM_CONTRIB_ETHOSU_CASCADER_PROPOSAL_H_
+
+#include <tvm/node/reflection.h>
+#include <tvm/runtime/object.h>
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "graph.h"
+#include "plan.h"
+#include "tensor_config.h"
+
+namespace tvm {
+namespace contrib {
+namespace ethosu {
+namespace cascader {
+
+using MemoryUsageMap = std::unordered_map<MemoryRegion, int, ObjectPtrHash, ObjectPtrEqual>;
+using TensorConfigMap = std::unordered_map<Tensor, TensorConfig, ObjectPtrHash, ObjectPtrEqual>;
+
+/*! \brief Node to represent a Proposal */
+class ProposalNode : public Object {
+ public:
+  void VisitAttrs(AttrVisitor* v);
+
+  /*! \return The CascaderGraph to which the Proposal applies */
+  const CascaderGraph GetGraph() const { return graph_; }
+  /*! \return The Parts which are covered by the Proposal */
+  const std::vector<Part> GetPartGroup() const { return part_group_; }
+  /*! \return The Plans used in the Proposal */
+  const std::vector<Plan> GetPlans() const { return plans_; }
+  /*! \return The TensorConfigs indexed by Tensor in the Proposal which aren't produced by a Plan */
+  const TensorConfigMap GetInputTensorConfigs() const { return input_tensor_configs_; }
+  /*! \return The MemoryRegion where cascading buffers should be homed */
+  const MemoryRegion GetCascadeRegion() const { return cascade_region_; }
+  /*! \return The memory required to execute the Proposal in the cascading MemoryRegion */
+  const int GetMemoryUsage() const { return memory_usage_; }
+  /*! \return The estimated cycles taken to execute the Proposal */
+  int GetCycles() const { return cycles_; }
+
+  static constexpr const char* _type_key = "contrib.ethosu.cascader.Proposal";
+  TVM_DECLARE_FINAL_OBJECT_INFO(ProposalNode, Object);
+
+ protected:
+  friend class Proposal;
+
+  /*! \brief The CascaderGraph to which the Proposal applies */
+  CascaderGraph graph_;
+  /*! \brief The Parts which are covered by the Proposal */
+  std::vector<Part> part_group_;
+  /*! \brief The Plans used in the Proposal */
+  std::vector<Plan> plans_;
+  /*! \brief The TensorConfigs indexed by Tensor in the Proposal which aren't produced by a Plan */
+  TensorConfigMap input_tensor_configs_;
+  /*! \brief The MemoryRegion where cascading buffers should be homed */
+  MemoryRegion cascade_region_;
+  /*! \brief The memory required to execute the Proposal in the cascading MemoryRegion */
+  int memory_usage_;
+  /*! \brief The estimated cycles taken to execute the Proposal */
+  int cycles_;
+};
+
+/*!
+ * \brief A class which describes how to schedule a CascaderGraph as a series of disjoint Plans.
+ */
+class Proposal : public ObjectRef {
+ public:
+  Proposal(const CascaderGraph& graph, const std::vector<Part>& part_group,
+           const std::vector<Plan>& plans, const TensorConfigMap& input_tensor_configs,
+           const MemoryRegion& cascade_region, int memory_usage, int cycles);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(Proposal, ObjectRef, ProposalNode);
+};
+
+}  // namespace cascader
+}  // namespace ethosu
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_ETHOSU_CASCADER_PROPOSAL_H_

--- a/src/contrib/ethosu/cascader/proposal_generator.cc
+++ b/src/contrib/ethosu/cascader/proposal_generator.cc
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/map.h>
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/support/parallel_for.h>
+
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "cascader_options.h"
+#include "graph.h"
+#include "pareto.h"
+#include "plan.h"
+#include "plan_generator.h"
+#include "proposal.h"
+#include "stripe_config.h"
+#include "tensor_config.h"
+
+namespace tvm {
+namespace contrib {
+namespace ethosu {
+namespace cascader {
+
+std::unordered_set<TensorConfig> GetPlanBoundaryConfigs(const Plan& plan) {
+  std::unordered_set<TensorConfig> boundary_configs;
+  for (const auto& config : plan->GetTensorConfigs()) {
+    if (config->GetState() == TensorConfigState::BOUNDARY) {
+      boundary_configs.insert(config);
+    }
+  }
+  return boundary_configs;
+}
+
+bool IsPlanCompatible(const Proposal& proposal,
+                      const std::vector<Part>& plan_part_group,
+                      const std::unordered_set<TensorConfig>& plan_boundary_configs) {
+  // Check the Plan Part group is disjoint with the Proposal Part group
+  for(const auto& plan_part : plan_part_group) {
+    for(const auto& proposal_part : proposal->GetPartGroup()) {
+      if(plan_part == proposal_part) {
+        return false;
+      }
+    }
+  }
+  // If the Plan and Proposal disagree on the memory home of a Tensor, they
+  // are incompatible and can't be used to create a new Proposal
+  auto tensor_configs = proposal->GetInputTensorConfigs();
+  for (const auto& plan_config : plan_boundary_configs) {
+    if (tensor_configs.find(plan_config->GetTensor()) != tensor_configs.end()) {
+      auto proposal_config = tensor_configs.at(plan_config->GetTensor());
+      if (proposal_config->GetHomeRegion() != plan_config->GetHomeRegion()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+std::unordered_map<Part, std::vector<Plan>, ObjectPtrHash, ObjectPtrEqual> CreatePlansByPart(
+    const std::unordered_map<std::vector<Part>, std::vector<Plan>>& plans_by_group,
+    const CascaderGraph& graph) {
+  std::unordered_map<Part, std::vector<Plan>, ObjectPtrHash, ObjectPtrEqual> plans_by_part;
+  for (const auto& it : plans_by_group) {
+    auto part_group = it.first;
+    auto plans = it.second;
+    int highest_index = 0;
+    Part& index_part = part_group.front();
+    // Determine the Part in the Part group with the highest ID - this will be used to index
+    // the Plans
+    for (const auto& part : part_group) {
+      int pid = graph->GetPartID(part);
+      if (pid >= highest_index) {
+        index_part = part;
+        highest_index = pid;
+      }
+    }
+    plans_by_part[index_part].insert(plans_by_part[index_part].begin(), plans.begin(), plans.end());
+  }
+  return plans_by_part;
+}
+
+Proposal AddPlanToProposal(const Proposal& proposal, const Plan& plan,
+                           const std::unordered_set<TensorConfig>& plan_boundary_configs) {
+  std::vector<Plan> new_plans = proposal->GetPlans();
+  new_plans.push_back(plan);
+  TensorConfigMap new_configs = proposal->GetInputTensorConfigs();
+  // Add input configs from the Plan if they're homed in the cascade region
+  for (const auto& config : plan_boundary_configs) {
+    if (config->GetHomeRegion() == proposal->GetCascadeRegion()) {
+      new_configs[config->GetTensor()] = config;
+    }
+  }
+  // Remove the Plan's output config from the new_configs if it's present because
+  // it won't be an input to the Proposal any more
+  if (new_configs.find(plan->GetOutputConfig()->GetTensor()) != new_configs.end()) {
+    new_configs.erase(plan->GetOutputConfig()->GetTensor());
+  }
+  // The updated memory usage is the memory required to run the Plan plus the
+  // non-local memory that's required in the Proposal at that point in time
+  int new_memory_usage = plan->GetMemoryUsage();
+  for (const auto& it : new_configs) {
+    if (plan_boundary_configs.find(it.second) == plan_boundary_configs.end()) {
+      new_memory_usage += it.first->GetSize();
+    }
+  }
+  new_memory_usage = std::max(new_memory_usage, proposal->GetMemoryUsage());
+  int new_cycles = proposal->GetCycles() + plan->GetCycles();
+  std::vector<Part> new_part_group = proposal->GetPartGroup();
+  new_part_group.insert(new_part_group.end(), plan->GetPartGroup().begin(), plan->GetPartGroup().end());
+  std::sort(new_part_group.begin(), new_part_group.end());
+  return Proposal(proposal->GetGraph(), new_part_group, new_plans, new_configs,
+                  proposal->GetCascadeRegion(), new_memory_usage, new_cycles);
+}
+
+std::vector<Proposal> GeneratePartialProposals(const CascaderGraph& graph, const HomeMap& home_map,
+                                        const CascaderOptions options,
+                                        const std::unordered_map<Part, std::vector<Plan>, ObjectPtrHash, ObjectPtrEqual>& plans_by_part,
+                                        const std::vector<Part>& partial_proposal_group,
+                                        std::unordered_map<std::vector<Part>, std::vector<Proposal>>* proposals_by_group) {
+  if (proposals_by_group->find(partial_proposal_group) != proposals_by_group->end()) {
+    return proposals_by_group->at(partial_proposal_group);
+  }
+  if (partial_proposal_group.size() == 0) {
+    (*proposals_by_group)[partial_proposal_group] =
+      std::vector<Proposal>{Proposal(graph, std::vector<Part>(), std::vector<Plan>(),
+                                     TensorConfigMap(), options->cascade_region, 0, 0)};
+  } else {
+    Part part = partial_proposal_group.back();
+    const auto& plans = plans_by_part.at(part);
+    for (const auto& plan : plans) {
+      if (plan->GetInteriorRegion() == options->cascade_region) {
+        // Doing this isn't very efficient, but it improves the performance of the Plan
+        // generator
+        std::unordered_set<TensorConfig> plan_boundary_configs = GetPlanBoundaryConfigs(plan);
+        // The residual_proposal_group is a Part group indicating the Parts which aren't
+        // covered by the current Plan. It's the group for which we must find 'residual
+        // Proposals', meaning Proposals which cover the rest of the CascaderGraph assuming we
+        // pick the current Plan.
+        std::vector<Part> residual_proposal_group;
+        std::copy_if(partial_proposal_group.begin(), partial_proposal_group.end(),
+                      std::back_inserter(residual_proposal_group), [&plan](Part value) {
+                        return std::find(plan->GetPartGroup().begin(),
+                                        plan->GetPartGroup().end(),
+                                        value) == plan->GetPartGroup().end();
+                      });
+        // std::sort(residual_proposal_group.begin(), residual_proposal_group.end());
+        const auto& residual_proposals = GeneratePartialProposals(graph, home_map, options, plans_by_part, residual_proposal_group, proposals_by_group);
+        auto plan_output_tensor = plan->GetOutputConfig()->GetTensor();
+        ICHECK_LE(plan_output_tensor->GetProducers().size(), 1)
+            << "All tensors must have at most one producer.";
+        for (const auto& residual_proposal : residual_proposals) {
+          if (IsPlanCompatible(residual_proposal, plan->GetPartGroup(), plan_boundary_configs)) {
+            (*proposals_by_group)[partial_proposal_group].push_back(AddPlanToProposal(
+                residual_proposal, plan, plan_boundary_configs));
+          }
+        }
+      }
+    }
+    (*proposals_by_group)[partial_proposal_group] = ParetoCullProposals(
+          proposals_by_group->at(partial_proposal_group), options->max_proposals);
+  }
+  return proposals_by_group->at(partial_proposal_group);
+}
+
+std::vector<Proposal> GenerateProposals(const CascaderGraph& graph, const HomeMap& home_map,
+                                        const CascaderOptions options) {
+  // First generate all the Pareto optimal Plans for the CascaderGraph
+  auto plans_by_group = GenerateGraphPlans(graph, home_map, options);
+  // First create a map between every Part in the CascaderGraph and all the Plans for which that
+  // Part is the lowest ID Part within the Plan's Part group
+  std::unordered_map<Part, std::vector<Plan>, ObjectPtrHash, ObjectPtrEqual> plans_by_part =
+      CreatePlansByPart(plans_by_group, graph);
+  // The Part group that partial Proposals are current being generated for
+  std::vector<Part> partial_proposal_group = graph->GetPartOrder();
+  // A map of Proposals indexed by the Part group they cover
+  std::unordered_map<std::vector<Part>, std::vector<Proposal>> proposals_by_group;
+  return GeneratePartialProposals(graph, home_map, options, plans_by_part, partial_proposal_group, &proposals_by_group);
+}
+
+TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.GenerateProposals")
+    .set_body_typed([](CascaderGraph graph, Map<Tensor, Array<MemoryRegion>> home_map,
+                       CascaderOptions options) {
+      std::unordered_map<Tensor, std::vector<MemoryRegion>, ObjectPtrHash, ObjectPtrEqual>
+          mhome_map;
+      for (const auto& it : home_map) {
+        std::vector<MemoryRegion> home_regions;
+        for (const auto& i : it.second) {
+          home_regions.push_back(i);
+        }
+        mhome_map[it.first] = home_regions;
+      }
+      return Array<Proposal>(GenerateProposals(graph, mhome_map, options));
+    });
+
+}  // namespace cascader
+}  // namespace ethosu
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/ethosu/cascader/proposal_generator.h
+++ b/src/contrib/ethosu/cascader/proposal_generator.h
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/ethosu/cascader/proposal_generator.h
+ * \brief Algorithm to generate possible Proposals in the NPU cascader
+ */
+#ifndef TVM_CONTRIB_ETHOSU_CASCADER_PROPOSAL_GENERATOR_H_
+#define TVM_CONTRIB_ETHOSU_CASCADER_PROPOSAL_GENERATOR_H_
+
+#include <tvm/node/reflection.h>
+#include <tvm/runtime/object.h>
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace tvm {
+namespace contrib {
+namespace ethosu {
+namespace cascader {
+
+class CascaderGraph;
+class MemoryRegion;
+class Tensor;
+class Proposal;
+class CascaderOptions;
+
+using HomeMap =
+    std::unordered_map<Tensor, std::vector<MemoryRegion>, ObjectPtrHash, ObjectPtrEqual>;
+
+/*!
+ * \brief Generate Pareto optimal Proposals for a CascaderGraph.
+ * \param graph The CascaderGraph to generate Proposals for.
+ * \param home_map The Tensor homing map defining valid memory homes for Tensors.
+ * \param options The configuration options with which to run the generator.
+ * \return A vector of Pareto optimal Proposals.
+ * \note This algorithm takes a top-down dynamic programming approach to determining how
+ * to optimally combine Plans into Proposals. It does the following:
+ *
+ * First, run GenerateGraphPlans to generate the Pareto optimal Plans that cover all the
+ * Part groups in the CascaderGraph.
+ *
+ * Solve the problem recursively, generating optimal Proposals for increasingly small
+ * portions of the overall graph.
+ *
+ * Take the first Part in the graph:
+ *   1. Find all the Plans for which the Part is both in the Plan's Part group and has the
+ *      highest Part ID of any Part in the Part group (i.e. it's the 'first' Part in the
+ *      group).
+ *   For each Plan:
+ *     2. Get the Part group covered by the Plan and subtract it from the 'total Part group'
+ *        covering all the Parts. This forms a 'residual Part group'.
+ *     3. Recursively, determine the optimal Proposals for the 'residual Part group' (the graph
+ *        minus the Parts included in the Plan). Memoize the results.
+ *     For each residual Proposal:
+ *       4. Create a new Proposal by adding the current Plan to the residual Proposal.
+ *   5. Pareto cull all the newly created Proposals (which all share the same Part group).
+ * 6. Return the Proposals which cover all the Parts in the CascaderGraph.
+ *
+ */
+std::vector<Proposal> GenerateProposals(const CascaderGraph& graph, const HomeMap& home_map,
+                                        const CascaderOptions& options);
+
+}  // namespace cascader
+}  // namespace ethosu
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_ETHOSU_CASCADER_PROPOSAL_GENERATOR_H_

--- a/tests/python/contrib/test_ethosu/cascader/test_proposal_generator.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_proposal_generator.py
@@ -17,124 +17,122 @@
 import pytest
 from tvm.contrib.ethosu.cascader.proposal_generator import generate_proposals
 
-from .infra import make_simple_home_map, make_options
+from .infra import make_simple_home_map, make_options, ethosu_enabled
 
 
-def test_generate_proposals(FLASH, SRAM, TwoConv2DGraph):
-    graph = TwoConv2DGraph
-    min_sram = 3700
-    max_sram = 11700
-    input_configs = 1
-    parts = 2
-    home_map = make_simple_home_map(graph, SRAM, FLASH)
-    options = make_options(
-        cascade_region=SRAM,
-        max_proposals=32,
-        stripe_factors=4,
-        max_plan_size=10,
-    )
+if ethosu_enabled:
 
-    proposals = generate_proposals(graph, home_map, options)
+    def test_generate_proposals(FLASH, SRAM, TwoConv2DGraph):
+        graph = TwoConv2DGraph
+        min_sram = 3700
+        max_sram = 11700
+        input_configs = 1
+        parts = 2
+        home_map = make_simple_home_map(graph, SRAM, FLASH)
+        options = make_options(
+            cascade_region=SRAM,
+            max_proposals=32,
+            stripe_factors=4,
+            max_plan_size=10,
+        )
 
-    for proposal in proposals:
-        assert 0 < len(proposal.plans) <= parts
-        assert len(proposal.input_tensor_configs) == input_configs
-        assert len(proposal.part_group) == parts
-        assert min_sram < proposal.memory_usage < max_sram
-        assert proposal.cycles > 0
+        proposals = generate_proposals(graph, home_map, options)
 
+        for proposal in proposals:
+            assert 0 < len(proposal.plans) <= parts
+            assert len(proposal.input_tensor_configs) == input_configs
+            assert len(proposal.part_group) == parts
+            assert min_sram < proposal.memory_usage < max_sram
+            assert proposal.cycles > 0
 
-def test_generate_proposals_binary(FLASH, SRAM, BinaryGraph):
-    graph = BinaryGraph
-    input_configs = 2
-    parts = 3
-    home_map = make_simple_home_map(graph, SRAM, FLASH)
-    options = make_options(
-        cascade_region=SRAM,
-        max_proposals=32,
-        stripe_factors=4,
-        max_plan_size=10,
-    )
+    def test_generate_proposals_binary(FLASH, SRAM, BinaryGraph):
+        graph = BinaryGraph
+        input_configs = 2
+        parts = 3
+        home_map = make_simple_home_map(graph, SRAM, FLASH)
+        options = make_options(
+            cascade_region=SRAM,
+            max_proposals=32,
+            stripe_factors=4,
+            max_plan_size=10,
+        )
 
-    proposals = generate_proposals(graph, home_map, options)
+        proposals = generate_proposals(graph, home_map, options)
 
-    for proposal in proposals:
-        assert 0 < len(proposal.plans) <= parts
-        # assert len(proposal.input_tensor_configs) == input_configs
-        assert len(proposal.part_group) == parts
-        assert proposal.cycles > 0
+        for proposal in proposals:
+            assert 0 < len(proposal.plans) <= parts
+            assert len(proposal.input_tensor_configs) == input_configs
+            assert len(proposal.part_group) == parts
+            assert proposal.cycles > 0
 
+    def test_generate_proposals_mobilenetv1_start(FLASH, SRAM, MobileNetv1StartGraph):
+        graph = MobileNetv1StartGraph
+        min_sram = 200000
+        max_sram = 1300000
+        input_configs = 1
+        parts = 8
+        home_map = make_simple_home_map(graph, SRAM, FLASH)
+        options = make_options(
+            cascade_region=SRAM,
+            max_proposals=32,
+            stripe_factors=5,
+            max_plan_size=10,
+        )
 
-def test_generate_proposals_mobilenetv1_start(FLASH, SRAM, MobileNetv1StartGraph):
-    graph = MobileNetv1StartGraph
-    min_sram = 200000
-    max_sram = 1300000
-    input_configs = 1
-    parts = 8
-    home_map = make_simple_home_map(graph, SRAM, FLASH)
-    options = make_options(
-        cascade_region=SRAM,
-        max_proposals=32,
-        stripe_factors=5,
-        max_plan_size=10,
-    )
+        proposals = generate_proposals(graph, home_map, options)
 
-    proposals = generate_proposals(graph, home_map, options)
+        for proposal in proposals:
+            assert 0 < len(proposal.plans) <= parts
+            assert len(proposal.input_tensor_configs) == input_configs
+            assert len(proposal.part_group) == parts
+            assert min_sram < proposal.memory_usage < max_sram
+            assert proposal.cycles > 0
 
-    for proposal in proposals:
-        assert 0 < len(proposal.plans) <= parts
-        assert len(proposal.input_tensor_configs) == input_configs
-        assert len(proposal.part_group) == parts
-        assert min_sram < proposal.memory_usage < max_sram
-        assert proposal.cycles > 0
+    def test_generate_proposals_mobilenetv1(FLASH, SRAM, MobileNetv1Graph):
+        graph = MobileNetv1Graph
+        min_sram = 200000
+        max_sram = 1300000
+        input_configs = 1
+        parts = 27
+        home_map = make_simple_home_map(graph, SRAM, FLASH)
+        options = make_options(
+            cascade_region=SRAM,
+            max_proposals=32,
+            stripe_factors=5,
+            max_plan_size=10,
+        )
 
+        proposals = generate_proposals(graph, home_map, options)
 
-def test_generate_proposals_mobilenetv1(FLASH, SRAM, MobileNetv1Graph):
-    graph = MobileNetv1Graph
-    min_sram = 200000
-    max_sram = 1300000
-    input_configs = 1
-    parts = 27
-    home_map = make_simple_home_map(graph, SRAM, FLASH)
-    options = make_options(
-        cascade_region=SRAM,
-        max_proposals=32,
-        stripe_factors=5,
-        max_plan_size=10,
-    )
+        for proposal in proposals:
+            assert 0 < len(proposal.plans) <= parts
+            assert len(proposal.input_tensor_configs) == input_configs
+            assert len(proposal.part_group) == parts
+            assert min_sram < proposal.memory_usage < max_sram
+            assert proposal.cycles > 0
 
-    proposals = generate_proposals(graph, home_map, options)
+    def test_generate_proposals_mobilenetv2diamond(FLASH, SRAM, MobileNetv2DiamondGraph):
+        graph = MobileNetv2DiamondGraph
+        min_sram = 370000
+        max_sram = 990000
+        input_configs = 1
+        parts = 5
+        home_map = make_simple_home_map(graph, SRAM, FLASH)
+        options = make_options(
+            cascade_region=SRAM,
+            max_proposals=64,
+            stripe_factors=5,
+            max_plan_size=10,
+        )
 
-    for proposal in proposals:
-        assert 0 < len(proposal.plans) <= parts
-        assert len(proposal.input_tensor_configs) == input_configs
-        assert len(proposal.part_group) == parts
-        assert min_sram < proposal.memory_usage < max_sram
-        assert proposal.cycles > 0
+        proposals = generate_proposals(graph, home_map, options)
 
-
-def test_generate_proposals_mobilenetv2diamond(FLASH, SRAM, MobileNetv2DiamondGraph):
-    graph = MobileNetv2DiamondGraph
-    min_sram = 370000
-    max_sram = 990000
-    input_configs = 1
-    parts = 5
-    home_map = make_simple_home_map(graph, SRAM, FLASH)
-    options = make_options(
-        cascade_region=SRAM,
-        max_proposals=64,
-        stripe_factors=5,
-        max_plan_size=10,
-    )
-
-    proposals = generate_proposals(graph, home_map, options)
-
-    for proposal in proposals:
-        assert 0 < len(proposal.plans) <= parts
-        assert len(proposal.input_tensor_configs) == input_configs
-        assert len(proposal.part_group) == parts
-        assert min_sram < proposal.memory_usage < max_sram
-        assert proposal.cycles > 0
+        for proposal in proposals:
+            assert 0 < len(proposal.plans) <= parts
+            assert len(proposal.input_tensor_configs) == input_configs
+            assert len(proposal.part_group) == parts
+            assert min_sram < proposal.memory_usage < max_sram
+            assert proposal.cycles > 0
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_ethosu/cascader/test_proposal_generator.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_proposal_generator.py
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+from tvm.contrib.ethosu.cascader.proposal_generator import generate_proposals
+
+from .infra import make_simple_home_map, make_options
+
+
+def test_generate_proposals(FLASH, SRAM, TwoConv2DGraph):
+    graph = TwoConv2DGraph
+    min_sram = 3700
+    max_sram = 11700
+    input_configs = 1
+    parts = 2
+    home_map = make_simple_home_map(graph, SRAM, FLASH)
+    options = make_options(
+        cascade_region=SRAM,
+        max_proposals=32,
+        stripe_factors=4,
+        max_plan_size=10,
+    )
+
+    proposals = generate_proposals(graph, home_map, options)
+
+    for proposal in proposals:
+        assert 0 < len(proposal.plans) <= parts
+        assert len(proposal.input_tensor_configs) == input_configs
+        assert len(proposal.part_group) == parts
+        assert min_sram < proposal.memory_usage < max_sram
+        assert proposal.cycles > 0
+
+
+def test_generate_proposals_binary(FLASH, SRAM, BinaryGraph):
+    graph = BinaryGraph
+    input_configs = 2
+    parts = 3
+    home_map = make_simple_home_map(graph, SRAM, FLASH)
+    options = make_options(
+        cascade_region=SRAM,
+        max_proposals=32,
+        stripe_factors=4,
+        max_plan_size=10,
+    )
+
+    proposals = generate_proposals(graph, home_map, options)
+
+    for proposal in proposals:
+        assert 0 < len(proposal.plans) <= parts
+        # assert len(proposal.input_tensor_configs) == input_configs
+        assert len(proposal.part_group) == parts
+        assert proposal.cycles > 0
+
+
+def test_generate_proposals_mobilenetv1_start(FLASH, SRAM, MobileNetv1StartGraph):
+    graph = MobileNetv1StartGraph
+    min_sram = 200000
+    max_sram = 1300000
+    input_configs = 1
+    parts = 8
+    home_map = make_simple_home_map(graph, SRAM, FLASH)
+    options = make_options(
+        cascade_region=SRAM,
+        max_proposals=32,
+        stripe_factors=5,
+        max_plan_size=10,
+    )
+
+    proposals = generate_proposals(graph, home_map, options)
+
+    for proposal in proposals:
+        assert 0 < len(proposal.plans) <= parts
+        assert len(proposal.input_tensor_configs) == input_configs
+        assert len(proposal.part_group) == parts
+        assert min_sram < proposal.memory_usage < max_sram
+        assert proposal.cycles > 0
+
+
+def test_generate_proposals_mobilenetv1(FLASH, SRAM, MobileNetv1Graph):
+    graph = MobileNetv1Graph
+    min_sram = 200000
+    max_sram = 1300000
+    input_configs = 1
+    parts = 27
+    home_map = make_simple_home_map(graph, SRAM, FLASH)
+    options = make_options(
+        cascade_region=SRAM,
+        max_proposals=32,
+        stripe_factors=5,
+        max_plan_size=10,
+    )
+
+    proposals = generate_proposals(graph, home_map, options)
+
+    for proposal in proposals:
+        assert 0 < len(proposal.plans) <= parts
+        assert len(proposal.input_tensor_configs) == input_configs
+        assert len(proposal.part_group) == parts
+        assert min_sram < proposal.memory_usage < max_sram
+        assert proposal.cycles > 0
+
+
+def test_generate_proposals_mobilenetv2diamond(FLASH, SRAM, MobileNetv2DiamondGraph):
+    graph = MobileNetv2DiamondGraph
+    min_sram = 370000
+    max_sram = 990000
+    input_configs = 1
+    parts = 5
+    home_map = make_simple_home_map(graph, SRAM, FLASH)
+    options = make_options(
+        cascade_region=SRAM,
+        max_proposals=64,
+        stripe_factors=5,
+        max_plan_size=10,
+    )
+
+    proposals = generate_proposals(graph, home_map, options)
+
+    for proposal in proposals:
+        assert 0 < len(proposal.plans) <= parts
+        assert len(proposal.input_tensor_configs) == input_configs
+        assert len(proposal.part_group) == parts
+        assert min_sram < proposal.memory_usage < max_sram
+        assert proposal.cycles > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
RFC: apache/tvm-rfcs#37
Issue: #9429

The Proposal generator takes optimal Plans and combines them to find optimal 'Proposals' - sets of disjoint Plans that cover every Part in a CascaderGraph. It ultimately produces a Pareto-frontier of 'optimal' Proposals in terms of estimated cycles and memory usage.