### PR TITLE
[LLVM,TIR] Print LLVM intrinsic names instead of ids

### DIFF
--- a/python/tvm/target/codegen.py
+++ b/python/tvm/target/codegen.py
@@ -55,6 +55,22 @@ def llvm_lookup_intrinsic_id(name):
     return _ffi_api.llvm_lookup_intrinsic_id(name)
 
 
+def llvm_get_intrinsic_name(intrin_id: int) -> str:
+    """Get the name of an intrinsic for a given id.
+
+    Parameters
+    ----------
+    intrin_id : int
+        The id of the intrinsic.
+
+    Returns
+    -------
+    name : str
+        The name of the intrinsic.
+    """
+    return _ffi_api.llvm_get_intrinsic_name(intrin_id)
+
+
 def llvm_version_major(allow_none=False):
     """Get the major LLVM version.
 

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -485,10 +485,20 @@ TVM_REGISTER_GLOBAL("target.llvm_lookup_intrinsic_id")
       return static_cast<int64_t>(llvm::Function::lookupIntrinsicID(name));
     });
 
-TVM_REGISTER_GLOBAL("target.llvm_get_intrinsic_name")
-    .set_body_typed([](int64_t id) -> String {
-      return std::string(llvm::Intrinsic::getName(static_cast<llvm::Intrinsic::ID>(id)));
-    });
+TVM_REGISTER_GLOBAL("target.llvm_get_intrinsic_name").set_body_typed([](int64_t id) -> String {
+#if TVM_LLVM_VERSION >= 130
+  return std::string(llvm::Intrinsic::getBaseName(static_cast<llvm::Intrinsic::ID>(id)));
+#elif TVM_LLVM_VERSION >= 40
+  // This is the version of Intrinsic::getName that works for overloaded
+  // intrinsics. Helpfully, if we provide no types to this function, it
+  // will give us the overloaded name without the types appended. This
+  // should be enough information for most uses.
+  return std::string(llvm::Intrinsic::getName(static_cast<llvm::Intrinsic::ID>(id), {}));
+#else
+  // Nothing to do, just return the intrinsic id number
+  return std::to_string(id);
+#endif
+});
 
 TVM_REGISTER_GLOBAL("target.llvm_version_major").set_body_typed([]() -> int {
   return TVM_LLVM_VERSION / 10;

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -485,6 +485,11 @@ TVM_REGISTER_GLOBAL("target.llvm_lookup_intrinsic_id")
       return static_cast<int64_t>(llvm::Function::lookupIntrinsicID(name));
     });
 
+TVM_REGISTER_GLOBAL("target.llvm_get_intrinsic_name")
+    .set_body_typed([](int64_t id) -> String {
+      return std::string(llvm::Intrinsic::getName(static_cast<llvm::Intrinsic::ID>(id)));
+    });
+
 TVM_REGISTER_GLOBAL("target.llvm_version_major").set_body_typed([]() -> int {
   return TVM_LLVM_VERSION / 10;
 });

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -24,6 +24,7 @@ import tvm.testing
 from tvm import te
 from tvm.relay.backend import Runtime
 from tvm.contrib import utils, clang
+from tvm.target.codegen import llvm_lookup_intrinsic_id, llvm_get_intrinsic_name
 import tvm.script.tir as T
 import numpy as np
 
@@ -55,6 +56,14 @@ def test_llvm_void_intrin():
     body = ib.get()
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([A], body).with_attr("global_symbol", "main"))
     fcode = tvm.build(mod, None, "llvm")
+
+
+@tvm.testing.requires_llvm
+def test_llvm_intrinsic_id():
+    orig_name = "llvm.x86.sse2.pmadd.wd"
+    intrin_id = llvm_lookup_intrinsic_id(orig_name)
+    name = llvm_get_intrinsic_name(intrin_id)
+    assert orig_name == name
 
 
 @tvm.testing.requires_llvm


### PR DESCRIPTION
This makes it much easy to understand what is happening with llvm intrinsics.

@masahi 
