### PR TITLE
[Hexagon] Add missing #include <iterator>

### DIFF
--- a/src/runtime/hexagon/android/sim/hexagon_device_sim.cc
+++ b/src/runtime/hexagon/android/sim/hexagon_device_sim.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <deque>
 #include <iomanip>
+#include <iterator>
 #include <locale>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
This fixes compilation error with libstdc++.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
