### PR TITLE
[Hexagon] Return pathlib.Path from get_hexagon_rpc_path()

### DIFF
--- a/python/tvm/contrib/hexagon/build.py
+++ b/python/tvm/contrib/hexagon/build.py
@@ -51,11 +51,11 @@ def get_hexagon_rpc_dir() -> pathlib.Path:
         for path in libinfo.find_lib_path():
             rpc_dir = os.path.join(os.path.dirname(path), "hexagon_rpc")
             if os.path.isdir(rpc_dir):
-                HEXAGON_RPC_DIR = pathlib.Path(rpc_dir)
+                HEXAGON_RPC_DIR = rpc_dir
                 break
         else:
             raise "hexagon_rpc was not found."
-    return HEXAGON_RPC_DIR
+    return pathlib.Path(HEXAGON_RPC_DIR)
 
 
 class HexagonLauncher:


### PR DESCRIPTION
Type annotations don't do anything, the type conversion needs to be explicit.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
