### PR TITLE
Improve the tensorflow frontend _test_spop_resource_variables to supp…

### DIFF
--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -5445,7 +5445,12 @@ def _test_spop_resource_variables():
 def test_forward_spop():
     _test_spop_stateful()
     _test_spop_device_assignment()
-    _test_spop_resource_variables()
+    # tensorflow version upgrade support
+    # This test is expected to fail in TF version >= 2.6
+    # as the generated graph will be considered frozen, hence
+    # not passing the criteria for the test below.
+    if tf.__version__ < LooseVersion("2.6.1"):
+        _test_spop_resource_variables()
 
     # Placeholder test cases
     _test_spop_placeholder_without_shape_info()


### PR DESCRIPTION
…ort tensoflow 2.6

On tensorflow 2.4 the test is expected to fail as the generated graph is not frozen.
On tensorflow 2.6 the generated graph is identified as frozen, therefore the test is not needed.

cc @areusch @leandron @Mousius @gromero for reviews
