### PR TITLE
[CMSIS-NN] Update microNPU demo to include offloading to CMSIS-NN

### DIFF
--- a/apps/microtvm/ethosu/Makefile
+++ b/apps/microtvm/ethosu/Makefile
@@ -40,6 +40,8 @@ PKG_CFLAGS = ${PKG_COMPILE_OPTS} \
 	-I${ETHOSU_PATH}/core_driver/include \
 	-I${CMSIS_PATH}/Device/ARM/${ARM_CPU}/Include/ \
 	-I${CMSIS_PATH}/CMSIS/Core/Include \
+	-I${CMSIS_PATH}/CMSIS/NN/Include \
+	-I${CMSIS_PATH}/CMSIS/DSP/Include \
 	-I$(abspath $(BUILD_DIR))/codegen/host/include \
 	-DETHOSU_TEST_RUNNER_TOL=${ETHOSU_TEST_RUNNER_TOL}
 DRIVER_CMAKE_FLAGS = -DCMAKE_TOOLCHAIN_FILE=$(abspath $(BUILD_DIR))/../arm-none-eabi-gcc.cmake \
@@ -57,6 +59,7 @@ CODEGEN_SRCS = $(wildcard $(abspath $(BUILD_DIR))/codegen/host/src/*.c)
 CODEGEN_OBJS = $(subst .c,.o,$(CODEGEN_SRCS))
 CMSIS_STARTUP_SRCS = $(wildcard ${CMSIS_PATH}/Device/ARM/${ARM_CPU}/Source/*.c)
 UART_SRCS = $(wildcard ${CORSTONE_300_PATH}/*.c)
+CMSIS_NN_LIBS = $(wildcard ${CMSIS_PATH}/CMSIS/NN/build/Source/*/*.a)
 
 demo: $(BUILD_DIR)/demo
 
@@ -88,7 +91,7 @@ ${BUILD_DIR}/ethosu_core_driver/libethosu_core_driver.a:
 	$(QUIET)cd $(abspath $(BUILD_DIR)/ethosu_core_driver) && $(MAKE)
 
 # Build demo application
-$(BUILD_DIR)/demo: src/demo.c src/tvm_ethosu_runtime.c $(UART_SRCS) $(BUILD_DIR)/stack_allocator.o $(BUILD_DIR)/crt_backend_api.o ${BUILD_DIR}/libcodegen.a ${BUILD_DIR}/libcmsis_startup.a ${BUILD_DIR}/ethosu_core_driver/libethosu_core_driver.a
+$(BUILD_DIR)/demo: src/demo.c src/tvm_ethosu_runtime.c $(UART_SRCS) $(BUILD_DIR)/stack_allocator.o $(BUILD_DIR)/crt_backend_api.o ${BUILD_DIR}/libcodegen.a ${BUILD_DIR}/libcmsis_startup.a ${BUILD_DIR}/ethosu_core_driver/libethosu_core_driver.a $(CMSIS_NN_LIBS)
 	$(QUIET)mkdir -p $(@D)
 	$(QUIET)$(CC) $(PKG_CFLAGS) -o $@ $^ $(PKG_LDFLAGS)
 

--- a/apps/microtvm/ethosu/README.md
+++ b/apps/microtvm/ethosu/README.md
@@ -16,11 +16,11 @@
 <!--- under the License. -->
 
 
-Running TVM on bare metal Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU
-========================================================================
+Running TVM on bare metal Arm(R) Cortex(R)-M55 CPU, Ethos(TM)-U55 NPU and CMSIS-NN
+==================================================================================
 
 This folder contains an example of how to use TVM to run a model
-on bare metal Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU.
+on bare metal Cortex(R)-M55 CPU, Ethos(TM)-U55 NPU and CMSIS-NN.
 
 Prerequisites
 -------------
@@ -45,6 +45,7 @@ You will also need TVM which can either be:
   - Built from source (see [Install from Source](https://tvm.apache.org/docs/install/from_source.html))
     - When building from source, the following need to be set in config.cmake:
       - set(USE_ETHOSU ON)
+      - set(USE_CMSISNN ON)
       - set(USE_MICRO ON)
       - set(USE_LLVM ON)
   - Installed from TLCPack(see [TLCPack](https://tlcpack.ai/))
@@ -72,15 +73,15 @@ the locations for these can be specified as arguments to run_demo.sh, for exampl
 ```
 
 This will:
-- Download a quantized mobilenet v1 model
-- Use tvmc to compile the model for Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU
-- Download an image of a kitten to run the model on
+- Download a quantized (int8) mobilenet v2 model
+- Use tvmc to compile the model for Cortex(R)-M55 CPU, Ethos(TM)-U55 NPU and CMSIS-NN
+- Download an image of a penguig to run the model on
 - Create a C header file inputs.c containing the image data as a C array
 - Create a C header file outputs.c containing a C array where the output of inference will be stored
 - Build the Ethos(TM)-U55 core driver
 - Build the demo application
 - Run the demo application on a Fixed Virtual Platform (FVP) based on Arm(R) Corstone(TM)-300 software
-- The application will display what the image has been classified as e.g. "The image has been classified as 'tabby'"
+- The application will display what the image has been classified as e.g. "The image has been classified as 'king penguin'"
 
 Using your own image
 --------------------
@@ -90,6 +91,6 @@ image to be converted into an array of bytes for consumption by the model.
 The demo can be modified to use an image of your choice by changing the following lines in run_demo.sh
 
 ```bash
-curl -sS https://s3.amazonaws.com/model-server/inputs/kitten.jpg -o ./kitten.jpg
-python3 ./convert_image.py ./kitten.jpg
+curl -sS https://upload.wikimedia.org/wikipedia/commons/1/18/Falkland_Islands_Penguins_29.jpg -o penguin.jpg
+python3 ./convert_image.py ./build/penguin.jpg
 ```

--- a/apps/microtvm/ethosu/convert_image.py
+++ b/apps/microtvm/ethosu/convert_image.py
@@ -34,8 +34,9 @@ def create_header_file(name, section, tensor_name, tensor_data, output_path):
         header_file.write(
             "#include <tvmgen_default.h>\n"
             + f"const size_t {tensor_name}_len = {tensor_data.size};\n"
-            + f'uint8_t {tensor_name}[] __attribute__((section("{section}"), aligned(16))) = "'
+            + f'int8_t {tensor_name}[] __attribute__((section("{section}"), aligned(16))) = "'
         )
+
         data_hexstr = tensor_data.tobytes().hex()
         for i in range(0, len(data_hexstr), 2):
             header_file.write(f"\\x{data_hexstr[i:i+2]}")
@@ -52,14 +53,14 @@ def create_headers(image_name):
     resized_image = Image.open(img_path).resize((224, 224))
     img_data = np.asarray(resized_image).astype("float32")
 
-    # Convert input to NCHW
-    img_data = np.transpose(img_data, (2, 0, 1))
+    # # Add the batch dimension, as we are expecting 4-dimensional input: NCHW.
+    img_data = np.expand_dims(img_data, axis=0)
 
     # Create input header file
-    input_data = img_data.astype(np.uint8)
+    input_data = img_data.astype(np.int8)
     create_header_file("inputs", "ethosu_scratch", "input", input_data, "./include")
     # Create output header file
-    output_data = np.zeros([1001], np.uint8)
+    output_data = np.zeros([1001], np.int8)
     create_header_file(
         "outputs",
         "output_data_sec",

--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -123,20 +123,20 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 mkdir -p build
 cd build
 
-# Get mobilenet_v1 tflite model
-mobilenet_url='https://storage.googleapis.com/download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz'
-curl --retry 64 -sSL ${mobilenet_url} | gunzip | tar -xvf - ./mobilenet_v1_1.0_224_quant.tflite
+# Get mobilenet_v2 tflite model
+mobilenet_url='https://github.com/ARM-software/ML-zoo/raw/master/models/image_classification/mobilenet_v2_1.0_224/tflite_int8/mobilenet_v2_1.0_224_INT8.tflite'
+curl --retry 64 -sSL ${mobilenet_url} -o ./mobilenet_v2_1.0_224_INT8.tflite
 
 # Compile model for Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU
 # An alternative to using "python3 -m tvm.driver.tvmc" is to call
 # "tvmc" directly once TVM has been pip installed.
-python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, c" \
+python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, cmsis-nn, c" \
     --target-c-mcpu=cortex-m55 \
     --runtime=crt \
     --executor=aot \
     --executor-aot-interface-api=c \
     --executor-aot-unpacked-api=1 \
-    --pass-config tir.disable_vectorize=1 ./mobilenet_v1_1.0_224_quant.tflite --output-format=mlf
+    --pass-config tir.disable_vectorize=1 ./mobilenet_v2_1.0_224_INT8.tflite --output-format=mlf
 tar -xvf module.tar
 
 # Get ImageNet labels
@@ -144,11 +144,11 @@ curl -sS  https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorf
     -o ./labels_mobilenet_quant_v1_224.txt
 
 # Get input image
-curl -sS https://s3.amazonaws.com/model-server/inputs/kitten.jpg -o ./kitten.jpg
+curl -sS https://upload.wikimedia.org/wikipedia/commons/1/18/Falkland_Islands_Penguins_29.jpg -o penguin.jpg
 
 # Create C header files
 cd ..
-python3 ./convert_image.py ./build/kitten.jpg
+python3 ./convert_image.py ./build/penguin.jpg
 python3 ./convert_labels.py ./build/labels_mobilenet_quant_v1_224.txt
 
 # Build demo executable

--- a/apps/microtvm/ethosu/src/demo.c
+++ b/apps/microtvm/ethosu/src/demo.c
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
       .output = output,
   };
   struct tvmgen_default_inputs inputs = {
-      .input = input,
+      .tfl_quantize = input,
   };
   struct ethosu_driver* driver = ethosu_reserve_driver();
   struct tvmgen_default_devices devices = {
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
   ethosu_release_driver(driver);
 
   // Calculate index of max value
-  uint8_t max_value = 0;
+  int8_t max_value = -128;
   int32_t max_index = -1;
   for (unsigned int i = 0; i < output_len; ++i) {
     if (output[i] > max_value) {

--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -102,14 +102,6 @@ def validate_targets(parse_targets, additional_target_options=None):
             f"The last target needs to be a TVM target. Choices: {tvm_target_names}"
         )
 
-    tvm_targets = [t for t in targets if t in tvm_target_kinds]
-    if len(tvm_targets) > 2:
-        verbose_tvm_targets = ", ".join(tvm_targets)
-        raise TVMCException(
-            "Only two of the following targets can be used at a time. "
-            f"Found: {verbose_tvm_targets}."
-        )
-
     if additional_target_options is not None:
         for target_name in additional_target_options:
             if not any([target for target in parse_targets if target["name"] == target_name]):


### PR DESCRIPTION
This PR updates the microNPU demo to include offloading to CMSIS-NN.
In particular, the demo is updated to use Mobilenet v2 and the softmax function is offloaded to CMSIS-NN, while the Conv2D's and DepthwiseConv2D's are offloaded to the microNPU.

@Mousius @manupa-arm @areusch @ashutosh-arm 
