### PR TITLE
[VirtualMachine] fix raw pointer using by VirtualMachine

### DIFF
--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -442,7 +442,7 @@ class ObjectPtr {
    * \brief nullptr check
    * \return result of comparison of internal pointer with nullptr.
    */
-  explicit operator bool() { return get() != nullptr; }
+  explicit operator bool() const { return get() != nullptr; }
   /*! \brief reset the content of ptr to be nullptr */
   void reset() {
     if (data_ != nullptr) {

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -442,9 +442,7 @@ class ObjectPtr {
    * \brief nullptr check
    * \return result of comparison of internal pointer with nullptr.
    */
-  explicit operator bool() {
-    return get() != nullptr;
-  }
+  explicit operator bool() { return get() != nullptr; }
   /*! \brief reset the content of ptr to be nullptr */
   void reset() {
     if (data_ != nullptr) {

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -438,6 +438,13 @@ class ObjectPtr {
     ObjectPtr(std::move(other)).swap(*this);  // NOLINT(*)
     return *this;
   }
+  /*!
+   * \brief nullptr check
+   * \return result of comparison of internal pointer with nullptr.
+   */
+  explicit operator bool() {
+    return get() != nullptr;
+  }
   /*! \brief reset the content of ptr to be nullptr */
   void reset() {
     if (data_ != nullptr) {

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -174,7 +174,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \brief load the executable for the virtual machine.
    * \param exec The executable.
    */
-  virtual void LoadExecutable(Executable* exec);
+  virtual void LoadExecutable(const ObjectPtr<Executable>& exec);
 
  protected:
   /*! \brief Push a call frame on to the call stack. */
@@ -300,7 +300,7 @@ class VirtualMachine : public runtime::ModuleNode {
   /*! \brief The special return register. */
   ObjectRef return_register_;
   /*! \brief The executable the VM will operate on. */
-  Executable* exec_;
+  ObjectPtr<Executable> exec_;
   /*! \brief The function name to inputs mapping. */
   std::unordered_map<std::string, std::vector<ObjectRef>> inputs_;
   /*!

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -86,7 +86,8 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
   } else if (name == "vm_load_executable") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       auto vm = make_object<VirtualMachine>();
-      vm->LoadExecutable(this);
+      ICHECK(sptr_to_self.get() == this);
+      vm->LoadExecutable(GetObjectPtr<Executable>(this));
       *rv = Module(vm);
     });
   } else if (name == "move_late_bound_consts") {

--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -90,9 +90,8 @@ PackedFunc VirtualMachineDebug::GetFunction(const std::string& name,
   }
 }
 
-void VirtualMachineDebug::LoadExecutable(Executable* exec) {
+void VirtualMachineDebug::LoadExecutable(const ObjectPtr<Executable>& exec) {
   VirtualMachine::LoadExecutable(exec);
-  ICHECK(exec_);
   for (auto kv : exec_->primitive_map) {
     packed_index_map_[kv.second] = kv.first;
   }
@@ -204,15 +203,13 @@ void VirtualMachineDebug::InvokePacked(Index packed_index, const PackedFunc& fun
 
 runtime::Module CreateVirtualMachineDebug(Executable* exec) {
   auto vm = make_object<VirtualMachineDebug>();
-  vm->LoadExecutable(exec);
+  vm->LoadExecutable(GetObjectPtr<Executable>(exec));
   return runtime::Module(vm);
 }
 
 TVM_REGISTER_GLOBAL("runtime._VirtualMachineDebug").set_body([](TVMArgs args, TVMRetValue* rv) {
   runtime::Module mod = args[0];
   auto* exec = dynamic_cast<Executable*>(mod.operator->());
-  ICHECK(exec) << "Virtual machine has not been defined yet."
-               << "\n";
   *rv = CreateVirtualMachineDebug(exec);
 });
 

--- a/src/runtime/vm/profiler/vm.h
+++ b/src/runtime/vm/profiler/vm.h
@@ -44,7 +44,7 @@ class VirtualMachineDebug : public VirtualMachine {
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
-  void LoadExecutable(Executable* exec) final;
+  void LoadExecutable(const ObjectPtr<Executable>& exec) final;
 
   ~VirtualMachineDebug() {}
 

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -374,7 +374,7 @@ void VirtualMachine::InvokePacked(Index packed_index, const PackedFunc& func, In
   }
 }
 
-void VirtualMachine::LoadExecutable(Executable* exec) {
+void VirtualMachine::LoadExecutable(const ObjectPtr<Executable>& exec) {
   ICHECK(exec) << "The executable is not created yet.";
   ICHECK(exec->late_bound_constant_names.empty())
       << "Need to load late-bound-constants before creating VM";
@@ -382,7 +382,7 @@ void VirtualMachine::LoadExecutable(Executable* exec) {
 
   runtime::Module lib = exec_->GetLib();
 
-  ICHECK(exec->primitive_map.empty() || lib.operator->())
+  ICHECK(exec_->primitive_map.empty() || lib.operator->())
       << "If the executable has declared primitive functions, the "
       << "generated kernel library must non-be null.";
 
@@ -769,14 +769,13 @@ void VirtualMachine::RunLoop() {
 
 runtime::Module CreateVirtualMachine(Executable* exec) {
   auto vm = make_object<VirtualMachine>();
-  vm->LoadExecutable(exec);
+  vm->LoadExecutable(GetObjectPtr<Executable>(exec));
   return runtime::Module(vm);
 }
 
 TVM_REGISTER_GLOBAL("runtime._VirtualMachine").set_body([](TVMArgs args, TVMRetValue* rv) {
   runtime::Module mod = args[0];
   auto* exec = dynamic_cast<Executable*>(mod.operator->());
-  ICHECK(exec) << "The virtual machine executable has not been defined yet.";
   *rv = CreateVirtualMachine(exec);
 });
 


### PR DESCRIPTION
The issue was observed during generation of VirtulaMachine Module on python side and using it on c++ one.
Work case: when we work in one python session the lib (exec) object is generated and used for VirtualMachine compilation. Inside VM the raw pointer to the lib (exec) is copied. Due to the lib object is alive along the session the VM object can use the pointer and execute different methods like "set_input", "invoke" and so on.
Unworkable case: if we use python session for generation VM and try to use it on c++ side it does not work. The reason is the lib object died after the session is closed. Thus VM uses the pointer to the spoiled object and it leads to failure.

To fix this problem new field in VM (ObjectPtr<Executable>) is used instead of Executable* exec_. ObjectPtr<Executable> object is constructed by GetObjectPtr<Executable>() and used as before.
There is shorter workaround: use `this->IncRef()` in executable.cc. But it looks no so good and I followed @tqchen advice

@jwfromm @tmoreau89 please see
