### PR TITLE
Make cc bot skip errors

### DIFF
--- a/.github/workflows/cc_bot.yml
+++ b/.github/workflows/cc_bot.yml
@@ -43,4 +43,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eux
-          python tests/scripts/github_cc_reviewers.py
+          python tests/scripts/github_cc_reviewers.py || echo step failed

--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -39,7 +39,7 @@ class GitHubRepo:
         return self._post("https://api.github.com/graphql", {"query": query})
 
     def _post(self, full_url: str, body: Dict[str, Any]) -> Dict[str, Any]:
-        print("Requesting", full_url)
+        print("Requesting POST to", full_url, "with", body)
         req = request.Request(full_url, headers=self.headers(), method="POST")
         req.add_header("Content-Type", "application/json; charset=utf-8")
         data = json.dumps(body)
@@ -55,7 +55,7 @@ class GitHubRepo:
 
     def get(self, url: str) -> Dict[str, Any]:
         url = self.base + url
-        print("Requesting", url)
+        print("Requesting GET to", url)
         req = request.Request(url, headers=self.headers())
         with request.urlopen(req) as response:
             response = json.loads(response.read())
@@ -63,7 +63,7 @@ class GitHubRepo:
 
     def delete(self, url: str) -> Dict[str, Any]:
         url = self.base + url
-        print("Requesting", url)
+        print("Requesting DELETE to", url)
         req = request.Request(url, headers=self.headers(), method="DELETE")
         with request.urlopen(req) as response:
             response = json.loads(response.read())

--- a/tests/scripts/github_cc_reviewers.py
+++ b/tests/scripts/github_cc_reviewers.py
@@ -20,6 +20,7 @@ import os
 import json
 import argparse
 import re
+from urllib import error
 from typing import Dict, Any, List
 
 
@@ -70,4 +71,11 @@ if __name__ == "__main__":
 
     if not args.dry_run:
         github = GitHubRepo(token=os.environ["GITHUB_TOKEN"], user=user, repo=repo)
-        github.post(f"pulls/{number}/requested_reviewers", {"reviewers": to_add})
+
+        # Add reviewers 1 by 1 since GitHub will error out if any of the
+        # requested reviewers aren't members / contributors
+        for reviewer in to_add:
+            try:
+                github.post(f"pulls/{number}/requested_reviewers", {"reviewers": [reviewer]})
+            except error.HTTPError as e:
+                print(f"Failed to add reviewer {reviewer}: {e}")


### PR DESCRIPTION
This adds some better logging and ignores errors (this job shouldn't ever show up as a PR failure) so we can diagnose things like https://github.com/apache/tvm/runs/4873810315?check_suite_focus=true

