### PR TITLE
Submit cc'ed reviewers one at a time

### DIFF
--- a/tests/scripts/github_cc_reviewers.py
+++ b/tests/scripts/github_cc_reviewers.py
@@ -20,6 +20,7 @@ import os
 import json
 import argparse
 import re
+from urllib import error
 from typing import Dict, Any, List
 
 
@@ -70,4 +71,11 @@ if __name__ == "__main__":
 
     if not args.dry_run:
         github = GitHubRepo(token=os.environ["GITHUB_TOKEN"], user=user, repo=repo)
-        github.post(f"pulls/{number}/requested_reviewers", {"reviewers": to_add})
+
+        # Add reviewers 1 by 1 since GitHub will error out if any of the
+        # requested reviewers aren't members / contributors
+        for reviewer in to_add:
+            try:
+                github.post(f"pulls/{number}/requested_reviewers", {"reviewers": [reviewer]})
+            except error.HTTPError as e:
+                print(f"Failed to add reviewer {reviewer}: {e}")


### PR DESCRIPTION
This is a followup to #9934 that should make able to handle reviewers that can't actually be added as reviewers on GitHub.

Tested in #9992 this fixes the issues from #9986