### PR TITLE
[CI] Separate out microTVM demo script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -369,6 +369,10 @@ stage('Build') {
               script: "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh",
               label: 'Run microTVM tests',
             )
+            sh (
+              script: "${docker_run} ${ci_qemu} ./tests/scripts/task_demo_microtvm.sh",
+              label: 'Run microTVM demos',
+            )
             junit 'build/pytest-results/*.xml'
           }
         }

--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -128,9 +128,7 @@ mobilenet_url='https://storage.googleapis.com/download.tensorflow.org/models/mob
 curl --retry 64 -sSL ${mobilenet_url} | gunzip | tar -xvf - ./mobilenet_v1_1.0_224_quant.tflite
 
 # Compile model for Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU
-# An alternative to using "python3 -m tvm.driver.tvmc" is to call
-# "tvmc" directly once TVM has been pip installed.
-python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, c" \
+tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, c" \
     --target-c-mcpu=cortex-m55 \
     --runtime=crt \
     --executor=aot \

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -41,4 +41,4 @@ python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
 (cd build && rm -rf pytest-results)
 
 # Install tvm as a local package to allow tvmc to work
-python3 -m pip install --user ./python
+python3 -m pip install --user -e ./python

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -39,3 +39,6 @@ python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
 
 # Ensure no stale pytest-results remain from a previous test run.
 (cd build && rm -rf pytest-results)
+
+# Install tvm as a local package to allow tvmc to work
+python3 -m pip install --user ./python

--- a/tests/scripts/task_demo_microtvm.sh
+++ b/tests/scripts/task_demo_microtvm.sh
@@ -16,32 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
-# Python is required by apps/bundle_deploy
-source tests/scripts/setup-pytest-env.sh
-
-export LD_LIBRARY_PATH="lib:${LD_LIBRARY_PATH:-}"
-# NOTE: important to use abspath, when VTA is enabled.
-export VTA_HW_PATH=`pwd`/3rdparty/vta-hw
-
-# to avoid CI thread throttling.
-export TVM_BIND_THREADS=0
-export OMP_NUM_THREADS=1
-
-# Build cpptest suite
-make cpptest -j2
-
-# "make crttest" requires USE_MICRO to be enabled, which is not always the case.
-if grep crttest build/Makefile > /dev/null; then
-    make crttest  # NOTE: don't parallelize, due to issue with build deps.
-fi
-
-cd build && ctest --gtest_death_test_style=threadsafe && cd ..
-
-# Test MISRA-C runtime
-cd apps/bundle_deploy
-rm -rf build
-make test_dynamic test_static
-cd ../..
+pushd apps/microtvm/ethosu
+./run_demo.sh --cmake_path /opt/arm/cmake/bin/cmake
+popd


### PR DESCRIPTION
The initial solution to running the demo in CI was to include it as part of `task_cpp_unittest.sh` - this patch aims to clean up the CI scripts to run the demo so it's ran as part of a clear script and uses `tvmc` as a user would.
