### PR TITLE
Don't use std::move in WithFields

### DIFF
--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -203,8 +203,7 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* func_node) {
   auto ret_type = this->VisitType(func_node->ret_type);
   auto body = this->Mutate(func_node->body);
 
-  return WithFields(GetRef<Function>(func_node), params, body,
-                    ret_type, ty_params);
+  return WithFields(GetRef<Function>(func_node), params, body, ret_type, ty_params);
 }
 
 Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
@@ -225,8 +224,7 @@ Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
     call_args.push_back(new_arg);
   }
 
-  return WithFields(GetRef<Call>(call_node), new_op, call_args, {},
-                    ty_args);
+  return WithFields(GetRef<Call>(call_node), new_op, call_args, {}, ty_args);
 }
 
 Expr ExprMutator::VisitExpr_(const LetNode* let_node) {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -166,7 +166,7 @@ Expr ExprMutator::VisitExpr_(const VarNode* var_node) {
   if (var_node->type_annotation.defined()) {
     type_annotation = this->VisitType(var_node->type_annotation);
   }
-  return WithFields(GetRef<Var>(var_node), std::move(var_node->vid), std::move(type_annotation));
+  return WithFields(GetRef<Var>(var_node), var_node->vid, type_annotation);
 }
 
 Expr ExprMutator::VisitExpr_(const ConstantNode* op) { return GetRef<Expr>(op); }
@@ -183,7 +183,7 @@ Expr ExprMutator::VisitExpr_(const TupleNode* tuple_node) {
     auto new_field = this->Mutate(field);
     fields.push_back(new_field);
   }
-  return WithFields(GetRef<Tuple>(tuple_node), std::move(fields));
+  return WithFields(GetRef<Tuple>(tuple_node), fields);
 }
 
 Expr ExprMutator::VisitExpr_(const FunctionNode* func_node) {
@@ -203,8 +203,8 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* func_node) {
   auto ret_type = this->VisitType(func_node->ret_type);
   auto body = this->Mutate(func_node->body);
 
-  return WithFields(GetRef<Function>(func_node), std::move(params), std::move(body),
-                    std::move(ret_type), std::move(ty_params));
+  return WithFields(GetRef<Function>(func_node), params, body,
+                    ret_type, ty_params);
 }
 
 Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
@@ -225,8 +225,8 @@ Expr ExprMutator::VisitExpr_(const CallNode* call_node) {
     call_args.push_back(new_arg);
   }
 
-  return WithFields(GetRef<Call>(call_node), std::move(new_op), std::move(call_args), {},
-                    std::move(ty_args));
+  return WithFields(GetRef<Call>(call_node), new_op, call_args, {},
+                    ty_args);
 }
 
 Expr ExprMutator::VisitExpr_(const LetNode* let_node) {
@@ -234,7 +234,7 @@ Expr ExprMutator::VisitExpr_(const LetNode* let_node) {
   auto value = this->Mutate(let_node->value);
   auto body = this->Mutate(let_node->body);
 
-  return WithFields(GetRef<Let>(let_node), std::move(var), std::move(value), std::move(body));
+  return WithFields(GetRef<Let>(let_node), var, value, body);
 }
 
 Expr ExprMutator::VisitExpr_(const IfNode* if_node) {
@@ -242,28 +242,28 @@ Expr ExprMutator::VisitExpr_(const IfNode* if_node) {
   auto true_b = this->Mutate(if_node->true_branch);
   auto false_b = this->Mutate(if_node->false_branch);
 
-  return WithFields(GetRef<If>(if_node), std::move(cond), std::move(true_b), std::move(false_b));
+  return WithFields(GetRef<If>(if_node), cond, true_b, false_b);
 }
 
 Expr ExprMutator::VisitExpr_(const TupleGetItemNode* get_item) {
   Expr tuple = this->Mutate(get_item->tuple);
-  return WithFields(GetRef<TupleGetItem>(get_item), std::move(tuple));
+  return WithFields(GetRef<TupleGetItem>(get_item), tuple);
 }
 
 Expr ExprMutator::VisitExpr_(const RefCreateNode* ref_create) {
   Expr value = this->Mutate(ref_create->value);
-  return WithFields(GetRef<RefCreate>(ref_create), std::move(value));
+  return WithFields(GetRef<RefCreate>(ref_create), value);
 }
 
 Expr ExprMutator::VisitExpr_(const RefReadNode* ref_read) {
   Expr ref = this->Mutate(ref_read->ref);
-  return WithFields(GetRef<RefRead>(ref_read), std::move(ref));
+  return WithFields(GetRef<RefRead>(ref_read), ref);
 }
 
 Expr ExprMutator::VisitExpr_(const RefWriteNode* ref_write) {
   Expr ref = this->Mutate(ref_write->ref);
   Expr value = this->Mutate(ref_write->value);
-  return WithFields(GetRef<RefWrite>(ref_write), std::move(ref), std::move(value));
+  return WithFields(GetRef<RefWrite>(ref_write), ref, value);
 }
 
 Expr ExprMutator::VisitExpr_(const ConstructorNode* c) { return GetRef<Expr>(c); }
@@ -275,13 +275,13 @@ Expr ExprMutator::VisitExpr_(const MatchNode* match_node) {
   }
   Expr data = Mutate(match_node->data);
 
-  return WithFields(GetRef<Match>(match_node), std::move(data), std::move(clauses));
+  return WithFields(GetRef<Match>(match_node), data, clauses);
 }
 
 Clause ExprMutator::VisitClause(const Clause& clause) {
   Pattern lhs = VisitPattern(clause->lhs);
   Expr rhs = Mutate(clause->rhs);
-  return WithFields(std::move(clause), std::move(lhs), std::move(rhs));
+  return WithFields(clause, lhs, rhs);
 }
 
 Pattern ExprMutator::VisitPattern(const Pattern& p) { return p; }
@@ -462,7 +462,7 @@ class ExprBinder : public MixedModeMutator, PatternMutator {
 
   Clause VisitClause(const Clause& clause) final {
     Pattern lhs = VisitPattern(clause->lhs);
-    return WithFields(std::move(clause), std::move(lhs), VisitExpr(clause->rhs));
+    return WithFields(clause, lhs, VisitExpr(clause->rhs));
   }
 
   Var VisitVar(const Var& v) final {

--- a/src/relay/transforms/annotate_target.cc
+++ b/src/relay/transforms/annotate_target.cc
@@ -270,7 +270,7 @@ class AnnotateTargetRewriter : public ExprRewriter {
     auto tuple = Downcast<Tuple>(post);
 
     auto target_n_args = AnnotateArgs(tuple->fields);
-    auto new_expr = WithFields(std::move(tuple), std::move(std::get<1>(target_n_args)));
+    auto new_expr = WithFields(tuple, std::get<1>(target_n_args));
     op_expr_to_target_[new_expr] = std::get<0>(target_n_args);
     return std::move(new_expr);
   }
@@ -378,7 +378,7 @@ class CallOpsTargetRewriter : public AnnotateTargetRewriter {
     for (auto f : tuple->fields) {
       new_fields.push_back(InsertCompilerEndAndPropogateTarget(f));
     }
-    return WithFields(std::move(tuple), std::move(new_fields));
+    return WithFields(tuple, new_fields);
   }
 
   Expr Rewrite_(const TupleGetItemNode* op, const Expr& post) override {

--- a/src/relay/transforms/first_order_gradient.cc
+++ b/src/relay/transforms/first_order_gradient.cc
@@ -211,7 +211,7 @@ struct FirstOrderReverseAD : ExprFunctor<ADValue(const Expr&)> {
       field_bindings.push_back(f_ad->get<ADTensor>().forward);
     }
     // reconstruct tuple using let-bound variables to avoid duplication
-    auto orig = WithFields(GetRef<Tuple>(tuple_node), std::move(field_bindings));
+    auto orig = WithFields(GetRef<Tuple>(tuple_node), field_bindings);
     orig->checked_type_ = tt;
     auto ret = std::make_shared<ADTensor>(ll, orig, diag_ctx);
     // for orig = tuple(x1, ..., xn), tuple_grad(x1, ..., xn, G) = [pi(G, 1), ..., pi(G, n)]

--- a/src/relay/transforms/forward_rewrite.cc
+++ b/src/relay/transforms/forward_rewrite.cc
@@ -122,7 +122,7 @@ class ForwardRewriter : private MixedModeMutator {
       fields.push_back(this->GetTempExpr(tuple_node->fields[i], post_tuple_node->fields[i]));
     }
 
-    return WithFields(GetRef<Tuple>(tuple_node), std::move(fields));
+    return WithFields(GetRef<Tuple>(tuple_node), fields);
   }
 
   Expr Rewrite_(const CallNode* call_node, const Expr& post) final {

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -905,7 +905,7 @@ class FuseMutator : private MixedModeMutator {
     }
     // This tuple is an intermediate node in the group
     Array<Expr> new_fields = GetNewArguments(tuple_node->fields, ret_group);
-    return WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields));
+    return WithFields(GetRef<Tuple>(tuple_node), new_fields);
   }
 
   Expr Rewrite_(const TupleGetItemNode* tuple_get, const Expr& post) {

--- a/src/relay/transforms/memory_alloc.cc
+++ b/src/relay/transforms/memory_alloc.cc
@@ -92,7 +92,7 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
       }
       new_fields.push_back(new_field);
     }
-    return WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields));
+    return WithFields(GetRef<Tuple>(tuple_node), new_fields);
   }
 
   void PreVisitLetBlock_(const LetNode* let_node) final { scopes_.emplace_back(); }

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -470,7 +470,7 @@ IRModule FlattenTupleOutputs(IRModule module) {
 
           // Return a tuple of compiler_ends in the place of the tuple that was
           // annotated with a compiler_end.
-          return WithFields(GetRef<Tuple>(tuple_node), std::move(new_fields));
+          return WithFields(GetRef<Tuple>(tuple_node), new_fields);
         }
       }
       return post;

--- a/src/relay/transforms/split_args.cc
+++ b/src/relay/transforms/split_args.cc
@@ -59,12 +59,12 @@ class ArgumentSplitter : public ExprRewriter {
         for (int j = 0; j < argsCount; ++j) {
           args.push_back(tuple_node->fields[j + startIdx]);
         }
-        Tuple new_tuple = WithFields(GetRef<Tuple>(tuple_node), std::move(args));
+        Tuple new_tuple = WithFields(GetRef<Tuple>(tuple_node), args);
         Expr body = MakeConcatenate(new_tuple, param->axis);
         splitted[i] = StopFusion(body);
       }
       tvm::Array<Expr> tuple_args(splitted);
-      Tuple new_tuple = WithFields(GetRef<Tuple>(tuple_node), std::move(tuple_args));
+      Tuple new_tuple = WithFields(GetRef<Tuple>(tuple_node), tuple_args);
       return MakeConcatenate(new_tuple, param->axis);
     }
     return post;

--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -255,7 +255,7 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
     for (const auto& a : tuple_node->fields) {
       fields.push_back(VisitExpr(a));
     }
-    return Compound(e, WithFields(GetRef<Tuple>(tuple_node), std::move(fields)), v);
+    return Compound(e, WithFields(GetRef<Tuple>(tuple_node), fields), v);
   }
 
   Expr VisitExpr_(const TupleGetItemNode* t, const Var& v) final {

--- a/src/relay/transforms/to_cps.cc
+++ b/src/relay/transforms/to_cps.cc
@@ -216,7 +216,7 @@ Function ToCPS(const Function& f, const IRModule& m, CPSMap* cm, VarMap* vm,
       std::function<Expr()> next;
       next = [&]() {
         return (fields.size() == tuple_node->fields.size())
-                   ? k(WithFields(GetRef<Tuple>(tuple_node), std::move(fields)))
+                   ? k(WithFields(GetRef<Tuple>(tuple_node), fields))
                    : VisitExpr(tuple_node->fields[fields.size()], [&](const Expr& v) {
                        fields.push_back(v);
                        return next();

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -300,7 +300,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
         Expr tmp = push_back_one_arg(x);
         fields.push_back(tmp);
       }
-      normal_new_args.push_back(WithFields(tuple_new_arg, std::move(fields)));
+      normal_new_args.push_back(WithFields(tuple_new_arg, fields));
     } else {
       Expr tmp = push_back_one_arg(new_arg);
       normal_new_args.push_back(tmp);
@@ -383,7 +383,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
         transformed_tuple_arg.push_back(memorizer.Transform(arg_item, new_in[pt], new_in2[pt]));
         pt++;
       }
-      transformed_args.push_back(WithFields(tuple_arg, std::move(transformed_tuple_arg)));
+      transformed_args.push_back(WithFields(tuple_arg, transformed_tuple_arg));
     } else {
       transformed_args.push_back(memorizer.Transform(arg, new_in[pt], new_in2[pt]));
       pt++;


### PR DESCRIPTION
std::move usually does nothing to improve perf, and I noticed a few places where std::move was causing a potential use-after-free. I suspect that some of these might have been contributing to some of the flaky seg faults we've been seeing recently. We'll see what happens when it goes thru CI.