### PR TITLE
Fix tvmc run error message when inputs aren't found

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -359,7 +359,7 @@ def make_inputs_dict(
         if input_name not in shape_dict.keys():
             raise TVMCException(
                 "the input tensor '{}' is not in the graph. Expected inputs: '{}'".format(
-                    input_name, shape_dict.keys()
+                    input_name, list(shape_dict.keys())
                 )
             )
 


### PR DESCRIPTION
This PR fixes the `tvmc run` error message when the input file doesn't contain the expected graph inputs by name. Currently:
```
$ tvmc run --inputs img/foo.npz --output predictions.npz mobilenet.tar
Error: the input tensor 'x' is not in the graph. Expected inputs: '<generator object Map.__iter__ at 0x7fef81394678>'
```

This fixes the message to read:
```
Error: the input tensor 'x' is not in the graph. Expected inputs: '['input']'
```

cc @leandron @gromero 