### PR TITLE
[TOPI,CUDA] Don't enable cudnn conv2d kernel if is not supported

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -313,6 +313,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
             and layout in ["NCHW", "NHWC"]
             and padding[0] == padding[2]
             and padding[1] == padding[3]
+            and not ((data.dtype == "int8" or kernel.dtype == "int8") and layout == "NCHW")
         ):
             # add cudnn implementation
             if layout == "NHWC":
@@ -347,7 +348,12 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
         # add cudnn implementation, if any
         cudnn_impl = False
         if target.kind.name == "cuda" and "cudnn" in target.libs:
-            if layout in ["NCHW", "NHWC"] and padding[0] == padding[2] and padding[1] == padding[3]:
+            if (
+                layout in ["NCHW", "NHWC"]
+                and padding[0] == padding[2]
+                and padding[1] == padding[3]
+                and not ((data.dtype == "int8" or kernel.dtype == "int8") and layout == "NCHW")
+            ):
                 strategy.add_implementation(
                     wrap_compute_conv2d(
                         topi.cuda.conv2d_cudnn, need_data_layout=True, has_groups=True

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -313,7 +313,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
             and layout in ["NCHW", "NHWC"]
             and padding[0] == padding[2]
             and padding[1] == padding[3]
-            and not ((data.dtype == "int8" or kernel.dtype == "int8") and layout == "NCHW")
+            and not (data.dtype in ["uint8", "int8"] or kernel.dtype in ["uint8", "int8"])
         ):
             # add cudnn implementation
             if layout == "NHWC":
@@ -352,7 +352,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                 layout in ["NCHW", "NHWC"]
                 and padding[0] == padding[2]
                 and padding[1] == padding[3]
-                and not ((data.dtype == "int8" or kernel.dtype == "int8") and layout == "NCHW")
+                and not (data.dtype in ["uint8", "int8"] or kernel.dtype in ["uint8", "int8"])
             ):
                 strategy.add_implementation(
                     wrap_compute_conv2d(


### PR DESCRIPTION
Specifically, check that layout is not NCHW if datatype is int8.

@mbrookhart