### PR TITLE
[Relay][VM] Relay VM memory liveness/lifetime analysis

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -471,7 +471,13 @@ TVM_DLL Pass RelayToTIRTargetHook();
  */
 TVM_DLL Pass ManifestAlloc(VirtualDevice cpu_virtual_device);
 
-TVM_DLL Pass VMPlanMemory();
+/*!
+ * \brief A pass for manifesting variable lifetimes by inserting kill operations when variables
+ * become dead. This pass should be run after ManifestAlloc, and should not be run more than once.
+ *
+ * \return The pass.
+ */
+TVM_DLL Pass ManifestLifetimes();
 
 /*!
  * \brief Uses existing "on_device" and "device_copy" CallNodes to infer the \p VirtualDevice on

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -471,6 +471,8 @@ TVM_DLL Pass RelayToTIRTargetHook();
  */
 TVM_DLL Pass ManifestAlloc(VirtualDevice cpu_virtual_device);
 
+TVM_DLL Pass VMPlanMemory();
+
 /*!
  * \brief Uses existing "on_device" and "device_copy" CallNodes to infer the \p VirtualDevice on
  * which every Relay sub-expression should run and the result stored. Captures the result of that

--- a/include/tvm/runtime/vm/bytecode.h
+++ b/include/tvm/runtime/vm/bytecode.h
@@ -68,6 +68,7 @@ enum class Opcode {
   ShapeOf = 17U,
   ReshapeTensor = 18U,
   DeviceCopy = 19U,
+  KillRegister = 20U,
 };
 
 /*! \brief A single virtual machine instruction.
@@ -385,6 +386,8 @@ struct Instruction {
    */
   static Instruction DeviceCopy(RegName src, Index src_device_index, Index dst_device_index,
                                 RegName dst);
+
+  static Instruction KillRegister(RegName dst);
 
   Instruction();
   Instruction(const Instruction& instr);

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -1203,6 +1203,14 @@ def PlanDevices(config):
     return _ffi_api.PlanDevices(config)
 
 
+def ManifestLifetimes():
+    """
+    Manifest the lifetimes of variables after allocations have been manifested, by inserting kill
+    operations once variables become dead.
+    """
+    return _ffi_api.ManifestLifetimes()
+
+
 def FoldExplicitPadding():
     """
     FoldExplicitPadding finds explict padding before an op that can support

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -996,7 +996,8 @@ transform::Sequential VMCompiler::MemoryOpt(const VirtualDevice& host_virtual_de
   // Compute away possibly introduced constant computation.
   pass_seqs.push_back(transform::FoldConstant());
 
-  pass_seqs.push_back(transform::VMPlanMemory());
+  // Insert kills to free memory.
+  pass_seqs.push_back(transform::ManifestLifetimes());
 
   // Lift constants to the top-level of the block to simplify VM code generation.
   // TODO(@icemelon9, @jroesch): Remove this pass for now because some

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -328,6 +328,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
       case Opcode::Ret:
       case Opcode::Goto:
       case Opcode::Fatal:
+      case Opcode::KillRegister:
         break;
     }
     instructions_.push_back(instr);
@@ -647,8 +648,10 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
                    Emit(Instruction::ReshapeTensor(tensor_reg, shape_reg, NewRegister()));
                  })
           .Match("memory.kill",
-                 [](const Array<Expr>& args, const Attrs& attrs, const Array<Type>& type_arg) {
-                   LOG(FATAL) << "memory.kill is not yet supported";
+                 [this](const Array<Expr>& args, const Attrs& attrs, const Array<Type>& type_arg) {
+                   ICHECK_EQ(args.size(), 1u);
+                   this->VisitExpr(args[0]);
+                   Emit(Instruction::KillRegister(this->last_register_));
                  });
       matcher(GetRef<Call>(call_node));
       return;
@@ -992,6 +995,8 @@ transform::Sequential VMCompiler::MemoryOpt(const VirtualDevice& host_virtual_de
 
   // Compute away possibly introduced constant computation.
   pass_seqs.push_back(transform::FoldConstant());
+
+  pass_seqs.push_back(transform::VMPlanMemory());
 
   // Lift constants to the top-level of the block to simplify VM code generation.
   // TODO(@icemelon9, @jroesch): Remove this pass for now because some

--- a/src/relay/backend/vm/manifest_lifetimes.cc
+++ b/src/relay/backend/vm/manifest_lifetimes.cc
@@ -419,9 +419,9 @@ class KillInserter : public ExprMutator {
 
   // Limitations
   // -----------
-  // 1. For simplicity, we only insert kills when visiting Let bindings, and always emit the kill as a
-  // single subsequent binding. This is slightly inaccurate; for example, if the condition of an If
-  // is dead after the test, we can immediately kill the condition in each branch:
+  // 1. For simplicity, we only insert kills when visiting Let bindings, and always emit the kill as
+  // a single subsequent binding. This is slightly inaccurate; for example, if the condition of an
+  // If is dead after the test, we can immediately kill the condition in each branch:
   //   let %x = if (%dead_cond) {
   //     let %_0 = memory.kill(%dead_cond);
   //     ...
@@ -435,7 +435,7 @@ class KillInserter : public ExprMutator {
   //
   // 2. Killed variables are calculated as live in - live out, which misses variables that are
   // actually dead but not in live in. Examples include: when the last use of a var is the result
-  // expr of an If branch; when bound vars (i.e. function inputs, pattern matched vars, dead 
+  // expr of an If branch; when bound vars (i.e. function inputs, pattern matched vars, dead
   // bindings) are never used.
   //
   // 3. When the result expr of an If branch is a variable, and this expr is the last use of the

--- a/src/relay/backend/vm/manifest_lifetimes.cc
+++ b/src/relay/backend/vm/manifest_lifetimes.cc
@@ -417,7 +417,9 @@ class KillInserter : public ExprMutator {
  public:
   KillInserter(const ControlFlowGraph* cfg, const LivenessAnalysis* lva) : cfg_(cfg), lva_(lva) {}
 
-  // For simplicity, we only insert kills when visiting Let bindings, and always emit the kill as a
+  // Limitations
+  // -----------
+  // 1. For simplicity, we only insert kills when visiting Let bindings, and always emit the kill as a
   // single subsequent binding. This is slightly inaccurate; for example, if the condition of an If
   // is dead after the test, we can immediately kill the condition in each branch:
   //   let %x = if (%dead_cond) {
@@ -430,7 +432,19 @@ class KillInserter : public ExprMutator {
   // as opposed to:
   //   let %x = if (%dead_cond) ...
   //   let %_0 = memory.kill(%dead_cond);
-  // This is unlikely to be a problem in practice though.
+  //
+  // 2. Killed variables are calculated as live in - live out, which misses variables that are
+  // actually dead but not in live in. Examples include: when the last use of a var is the result
+  // expr of an If branch; when bound vars (i.e. function inputs, pattern matched vars, dead 
+  // bindings) are never used.
+  //
+  // 3. When the result expr of an If branch is a variable, and this expr is the last use of the
+  // var, we cannot "kill" the var since it is being returned. The VM compiler also emits a Move
+  // instruction to merge the branch results, which creates another ObjectRef to the Object held
+  // by the var. The var is also not in the subsequent live-in (since it is indeed dead by this
+  // point), so it won't be killed.
+  //
+  // However, these limitations are unlikely to cause large leaks in practice.
 
   Expr VisitExpr_(const LetNode* let_node) override {
     Expr expr = GetRef<Expr>(let_node);

--- a/src/relay/backend/vm/plan_memory.cc
+++ b/src/relay/backend/vm/plan_memory.cc
@@ -27,21 +27,6 @@
 #include "../../transforms/device_aware_visitors.h"
 #include "../../transforms/let_list.h"
 
-// pipeline: ManifestAlloc -> CoalesceStorage -> PlanMemory
-
-// PlanMemory: analyze liveness info and insert kill operations
-
-// A LIVE storage:
-//   - has live tensors or
-//   - has pending tensor allocations
-// So a DEAD storage has no live tensors and provably no pending tensor allocations
-
-// A LIVE tensor:
-//   - has pending dependent tensor computations
-//   - a tuple is like a weird kind of aliasing
-//   - var aliasing
-//   - what if it escapes? e.g. func ret value -> always alive
-
 namespace tvm {
 namespace relay {
 namespace transform {

--- a/src/relay/backend/vm/plan_memory.cc
+++ b/src/relay/backend/vm/plan_memory.cc
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/backend/vm/plan_memory.cc
+ * \brief Tensor and storage liveness analysis and memory planning.
+ */
+
+#include <tvm/relay/transform.h>
+#include "../../transforms/let_list.h"
+
+#include "../../transforms/device_aware_visitors.h"
+
+// pipeline: ManifestAlloc -> CoalesceStorage -> PlanMemory
+
+// PlanMemory: analyze liveness info and insert kill operations
+
+// A LIVE storage:
+//   - has live tensors or
+//   - has pending tensor allocations
+// So a DEAD storage has no live tensors and provably no pending tensor allocations
+
+// A LIVE tensor:
+//   - has pending dependent tensor computations
+//   - a tuple is like a weird kind of aliasing
+//   - var aliasing
+//   - what if it escapes? e.g. func ret value -> always alive
+
+namespace tvm {
+namespace relay {
+namespace transform {
+
+// x = 1
+// y = x
+// z = y
+// return z
+
+/*
+
+let x = op(in);
+let y = x;
+let z = op(y);
+let w = if (z) {
+  let xx = op(x);
+  op(xx)
+} else {
+  let zz = op(z);
+  op(zz);
+};
+op(w)
+
+---
+
+block0:
+  x <- op(in);
+  y <- x;
+  z <- = op(y);
+  jz z block2
+
+block1:
+  xx <- op(x);
+  w <- op(xx)
+  jmp block3
+
+block2:
+  zz <- op(z)
+  w <- op(zz)
+
+block3:
+  ret op(w)
+*/
+
+
+class LivenessAnalyzer : public ExprVisitor {
+ private:
+  using TVarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
+  using TSuper = ExprVisitor;
+
+ public:
+  LivenessAnalyzer() {}
+
+  void PreVisitLetBinding_(const Var& var, const Expr& value) {
+    // if value is a variable, alias[var] = alias[value]
+    // else, alias[var] = var
+    ICHECK(!alias_.count(var));
+    if (value.as<VarNode>()) {
+      Var rhs = Downcast<Var>(value);
+      ICHECK(alias_.count(rhs)) << "aliasing info of rhs should be tracked";
+      alias_[var] = alias_[rhs];
+    } else {
+      alias_[var] = var;
+    }
+
+    VisitExpr(var);
+    VisitExpr(value);
+  }
+
+  void PostVisitLetBlock_(const LetNode* let_node) {
+    Expr expr = GetRef<Expr>(let_node);
+    while (const LetNode* inner_let_node = expr.as<LetNode>()) {
+      if (!inner_let_node->value.as<VarNode>()) {
+        ICHECK(use_.count(inner_let_node->value));
+        def_[expr] = inner_let_node->var;
+        use_[expr] = use_[inner_let_node->value];
+      }
+      expr = inner_let_node->body;
+    }
+  }
+
+  void VisitExpr_(const LetNode* let_node) {
+    std::vector<const LetNode*> bindings;
+    Expr expr = GetRef<Expr>(let_node);
+    while (const auto* inner_let_node = expr.as<LetNode>()) {
+      PreVisitLetBinding_(inner_let_node->var, inner_let_node->value);
+      bindings.emplace_back(inner_let_node);
+      expr = inner_let_node->body;
+    }
+
+    VisitExpr(expr);
+
+    PostVisitLetBlock_(let_node);
+}
+
+  void VisitExpr_(const TupleNode* tuple_node) override {
+    TSuper::VisitExpr_(tuple_node);
+    TVarSet use;
+    for (const Expr& field : tuple_node->fields) {
+      ICHECK(use_.count(field));
+      TVarSet field_use = use_[field];
+      use.insert(field_use.begin(), field_use.end());
+    }
+    use_[GetRef<Expr>(tuple_node)] = use;
+  }
+
+  void VisitExpr_(const GlobalVarNode* global_var_node) override {
+    use_[GetRef<Expr>(global_var_node)] = empty_set_;
+  }
+
+  void VisitExpr_(const VarNode* var_node) override {
+    Var var = GetRef<Var>(var_node);
+    ICHECK(alias_.count(var));
+    use_[var] = {alias_[var]};
+  }
+
+  void VisitExpr_(const ConstantNode* const_node) override {
+    use_[GetRef<Expr>(const_node)] = empty_set_;
+  }
+
+  void VisitExpr_(const CallNode* call_node) override {
+    TVarSet use;
+    for (const Expr& arg : call_node->args) {
+      VisitExpr(arg);
+      ICHECK(use_.count(arg)) << arg;
+      TVarSet arg_use = use_[arg];
+      use.insert(arg_use.begin(), arg_use.end());
+    }
+    use_[GetRef<Expr>(call_node)] = use;
+  }
+
+  void VisitExpr_(const FunctionNode* function_node) override {
+    if (function_node->HasNonzeroAttr(attr::kPrimitive)) {
+      TSuper::VisitExpr_(function_node);
+      return;
+    }
+
+    // TODO: figure out the closure nesting thing
+    ICHECK(!function_node->HasNonzeroAttr(attr::kClosure)) << "closures not supported yet";
+    ICHECK(func_depth_ == 0) << "nested functions not supported";
+
+    use_.clear();
+    def_.clear();
+    alias_.clear();
+
+    for (const Var& param : function_node->params) {
+      alias_[param] = param;
+    }
+
+    ++func_depth_;
+
+    VisitExpr(function_node->body);
+
+    --func_depth_;
+  }
+
+  void VisitExpr_(const IfNode* if_node) override {
+    LOG(FATAL) << "if not supported yet";
+  }
+
+  void DebugDump() {
+    // for (auto pr : alias_) {
+    //   std::cout << pr.first << " -> " << pr.second << std::endl;
+    // }
+    // for (auto pr : use_) {
+    //   std::cout << pr.first.get() << " uses";
+    //   for (auto var : pr.second) {
+    //     std::cout << " " << var;
+    //   }
+    //   std::cout << std::endl;
+    // }
+    // for (auto pr : def_) {
+    //   std::cout << pr.first.get() << " defs " << pr.second << std::endl;
+    // }
+    for (auto pr : live_in_) {
+      if (auto* l = pr.first.as<LetNode>()) {
+        auto lo = live_out_[GetRef<Expr>(l)];
+        std::cout << l->var->name_hint() << " kill";
+        for (auto v : pr.second) {
+          if (!lo.count(v)) {
+            std::cout << " " << v->name_hint();
+          }
+        }
+        std::cout << std::endl;
+        // std::cout << l->var->name_hint() << " = " << (l->value) << " live in: ";
+        // for (auto var : pr.second) {
+        //   std::cout << " " << var->name_hint();
+        // }
+        // std::cout << std::endl;
+      }
+    }
+
+    // for (auto pr : live_out_) {
+    //   if (auto* l = pr.first.as<LetNode>()) {
+    //     std::cout << l->var->name_hint() << " = " << (l->value) << " live out: ";
+    //     for (auto var : pr.second) {
+    //       std::cout << " " << var->name_hint();
+    //     }
+    //     std::cout << std::endl;
+    //   }
+    // }
+  }
+
+  void ComputeLiveness(const Expr& expr) {
+    VisitExpr(expr);
+
+    bool did_work = true;
+
+    auto visitor = [&](const Expr& n) {
+      TVarSet old_in_n = this->live_in_[n];
+      TVarSet old_out_n = this->live_out_[n];
+
+      this->live_in_[n] = TVarSet(this->use_[n].begin(), this->use_[n].end());
+      for (auto v : this->live_out_[n]) {
+        if (!v.same_as(this->def_[n])) {
+          this->live_in_[n].insert(v);
+        }
+      }
+      if (auto* l = n.as<LetNode>()) {
+        this->live_out_[n] = this->live_in_[l->body];
+      }
+
+      if (old_in_n.size() != this->live_in_[n].size() || old_out_n.size() != this->live_out_[n].size()) {
+        did_work = true;
+      } else {
+        for (auto o : old_in_n) {
+          did_work |= !this->live_in_[n].count(o);
+        }
+        for (auto o : old_out_n) {
+          did_work |= !this->live_out_[n].count(o);
+        }
+      }
+    };
+
+    while (did_work) {
+      did_work = false;
+      PostOrderVisit(expr, visitor);
+    }
+  }
+
+ private:
+  friend class MemoryPlanner;
+
+  // v in use_[n] means v is read in n
+  std::unordered_map<Expr, TVarSet, ObjectPtrHash, ObjectPtrEqual> use_;
+  // def_[n] = v means n is an expr "let v = ...; ..."
+  std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> def_;
+  // e.g. alias_[x] = y means y is an alias of x, created by "let y = x; ..."
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectPtrEqual> alias_;
+
+  std::unordered_map<Expr, TVarSet, ObjectPtrHash, ObjectPtrEqual> live_in_;
+  std::unordered_map<Expr, TVarSet, ObjectPtrHash, ObjectPtrEqual> live_out_;
+
+  size_t func_depth_ = 0;
+
+  const TVarSet empty_set_;
+};
+
+class MemoryPlanner : public ExprMutator {
+ public:
+  MemoryPlanner() {}
+
+  Expr PlanMemory(const Expr& e) {
+    lva_.ComputeLiveness(e);
+    return VisitExpr(e);
+  }
+
+  Expr VisitExpr_(const LetNode* let_node) override {
+    Expr value = VisitExpr(let_node->value);
+    Let let = GetRef<Let>(let_node);
+    auto li = lva_.live_in_[let];
+    auto lo = lva_.live_out_[let];
+    LivenessAnalyzer::TVarSet kills;
+    for (auto v : li) {
+      if (!lo.count(v)) {
+        kills.insert(v);
+      }
+    }
+    if (!kills.empty()) {
+      LetList ll;
+      ll.Push(let->var, value);
+      for (auto v : kills) {
+        ll.Push(Call(Op::Get("memory.kill"), {v}));
+      }
+      return ll.Get(VisitExpr(let_node->body));
+    }
+    return Let(let->var, value, VisitExpr(let_node->body));
+  }
+
+ private:
+  LivenessAnalyzer lva_;
+};
+
+Pass VMPlanMemory() {
+  auto pass_func = [](Function f, IRModule m, PassContext pc) -> Function {
+    // LivenessAnalyzer lva;
+    // lva.ComputeLiveness(f);
+    // lva.DebugDump();
+    MemoryPlanner mp;
+    Expr nf = mp.PlanMemory(f);
+    std::cout << PrettyPrint(nf);
+    return Downcast<Function>(nf);
+  };
+  return CreateFunctionPass(pass_func, 0, "VMPlanMemory", {});
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.VMPlanMemory").set_body_typed(VMPlanMemory);
+
+}  // namespace transform
+}  // namespace relay
+}  // namespace tvm
+
+// class LivenessAnalyzer : public DeviceA

--- a/src/relay/backend/vm/plan_memory.cc
+++ b/src/relay/backend/vm/plan_memory.cc
@@ -24,6 +24,7 @@
 
 #include <tvm/relay/transform.h>
 
+#include "../../../support/arena.h"
 #include "../../transforms/device_aware_visitors.h"
 #include "../../transforms/let_list.h"
 
@@ -31,174 +32,160 @@ namespace tvm {
 namespace relay {
 namespace transform {
 
-class LivenessAnalyzer : public ExprVisitor {
+using support::LinkedList;
+using support::LinkNode;
+
+using VarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
+
+class ControlFlowGraph {
+ public:
+  struct Node {
+    LinkedList<Node*> pred;
+    LinkedList<Node*> succ;
+    Expr expr;
+  };
+
+  std::unordered_map<Expr, Node*, ObjectPtrHash, ObjectPtrEqual> let_map;
+  std::vector<Node*> reverse_post_order;
+  // Node* entry;
+
+  static ControlFlowGraph Create(support::Arena* arena, const Expr& body);
+
  private:
-  using TVarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
-  using TSuper = ExprVisitor;
+  class Creator;
+};
+
+using NodeList = std::vector<ControlFlowGraph::Node*>;
+
+class ControlFlowGraph::Creator : private ExprFunctor<ControlFlowGraph::Node*(
+                                      const Expr&, const NodeList&)> {
+ public:
+  Creator(support::Arena* arena) : arena_(arena) {}
+
+  ControlFlowGraph Create(const Expr& body) {
+    VisitExpr(body, {});
+    return std::move(cfg_);
+  }
+
+ private:
+  support::Arena* arena_;
+  ControlFlowGraph cfg_;
+  std::unordered_set<Expr, ObjectPtrHash, ObjectPtrEqual> visited_;
+  bool in_func_ = false;
+
+  void Succ(Node* from, Node* to) {
+    auto succ_link = arena_->make<LinkNode<Node*>>();
+    succ_link->value = to;
+    from->succ.Push(succ_link);
+
+    auto pred_link = arena_->make<LinkNode<Node*>>();
+    pred_link->value = from;
+    to->pred.Push(pred_link);
+  }
+
+#define DEFAULT_CFG(OP)                                         \
+  Node* VisitExpr_(const OP* op, const NodeList& preds) final { \
+    Node* n = arena_->make<Node>();                             \
+    n->expr = GetRef<Expr>(op);                                 \
+    for (Node * pred : preds) {                                 \
+      Succ(pred, n);                                            \
+    }                                                           \
+    cfg_.reverse_post_order.push_back(n);                       \
+    return n;                                                   \
+  }
+
+  Node* VisitExpr_(const FunctionNode* f, const NodeList& preds) final {
+    ICHECK(!in_func_) << "nested functions not supported by CFG analysis";
+    in_func_ = true;
+
+    if (f->HasNonzeroAttr(attr::kClosure)) {
+      ICHECK(f->body.as<FunctionNode>());
+      return VisitExpr(Downcast<Function>(f->body)->body, {});
+    }
+
+    // cfg_.entry = arena_->make<Node>();
+    // Succ(cfg_.entry, VisitExpr(f->body));
+
+    return VisitExpr(f->body, {});
+  }
+
+  Node* VisitExpr_(const LetNode* let_node, const NodeList& let_preds) final {
+    Expr expr = GetRef<Expr>(let_node);
+    NodeList preds = let_preds;
+
+    while (const LetNode* inner_let_node = expr.as<LetNode>()) {
+      Node* curr_node = arena_->make<Node>();
+      curr_node->expr = expr;
+      ICHECK(!cfg_.let_map.count(expr));
+      cfg_.let_map[expr] = curr_node;
+
+      // 2 predecessors if last let bound value was an If, else 1
+      for (Node* pred : preds) {
+        Succ(pred, curr_node);
+      }
+
+      cfg_.reverse_post_order.push_back(curr_node);
+      if (const IfNode* ite = AsIgnoringOnDevice<IfNode>(inner_let_node->value)) {
+        Node* t_node = VisitExpr(ite->true_branch, {curr_node});
+        Node* f_node = VisitExpr(ite->false_branch, {curr_node});
+        preds = {t_node, f_node};
+      } else {
+        preds = {curr_node};
+      }
+      expr = inner_let_node->body;
+    }
+
+    Node* body_node = VisitExpr(expr, preds);
+
+    return body_node;
+  }
+
+  DEFAULT_CFG(VarNode);
+  DEFAULT_CFG(GlobalVarNode);
+  DEFAULT_CFG(ConstantNode);
+  DEFAULT_CFG(IfNode);
+  DEFAULT_CFG(CallNode);
+  DEFAULT_CFG(OpNode);
+  DEFAULT_CFG(TupleNode);
+  DEFAULT_CFG(TupleGetItemNode);
+};
+
+ControlFlowGraph ControlFlowGraph::Create(support::Arena* arena, const Expr& body) {
+  return Creator(arena).Create(body);
+}
+
+// 
+class LivenessAnalyzer : private ExprFunctor<ControlFlowGraph::Node*(const Expr& e, ControlFlowGraph::Node*)> {
+ private:
+  using CFG = ControlFlowGraph;
 
  public:
   LivenessAnalyzer() {}
 
-  void PreVisitLetBinding_(const Var& var, const Expr& value) {
-    // if value is a variable, alias[var] = alias[value]
-    // else, alias[var] = var
-    ICHECK(!alias_.count(var));
-    if (value.as<VarNode>()) {
-      Var rhs = Downcast<Var>(value);
-      ICHECK(alias_.count(rhs)) << "aliasing info of rhs should be tracked";
-      alias_[var] = alias_[rhs];
-      alias_[rhs]->insert(var);
-    } else {
-      alias_[var] = std::make_shared<TVarSet>();
-      alias_[var]->insert(var);
-    }
-
-    VisitExpr(var);
-    VisitExpr(value);
-  }
-
-  void PostVisitLetBlock_(const LetNode* let_node) {
-    Expr expr = GetRef<Expr>(let_node);
-    while (const LetNode* inner_let_node = expr.as<LetNode>()) {
-      ICHECK(use_.count(inner_let_node->value));
-      def_[expr] = inner_let_node->var;
-      use_[expr] = TVarSet(use_[inner_let_node->value].begin(), use_[inner_let_node->value].end());
-      expr = inner_let_node->body;
-    }
-  }
-
-  void VisitExpr_(const LetNode* let_node) {
-    Expr expr = GetRef<Expr>(let_node);
-    while (const auto* inner_let_node = expr.as<LetNode>()) {
-      PreVisitLetBinding_(inner_let_node->var, inner_let_node->value);
-
-      Expr let_body = inner_let_node->body;
-      if (const auto* ite = AsIgnoringOnDevice<IfNode>(inner_let_node->value)) {
-        succ_[expr] = {ite->true_branch, ite->false_branch};
-        succ_[ite->true_branch] = {let_body};
-        succ_[ite->false_branch] = {let_body};
-      } else {
-        succ_[expr] = {let_body};
-      }
-
-      expr = let_body;
-    }
-
-    VisitExpr(expr);
-
-    PostVisitLetBlock_(let_node);
-  }
-
-  void VisitExpr_(const TupleNode* tuple_node) override {
-    TSuper::VisitExpr_(tuple_node);
-    TVarSet use;
-    for (const Expr& field : tuple_node->fields) {
-      ICHECK(use_.count(field));
-      TVarSet field_use = use_[field];
-      use.insert(field_use.begin(), field_use.end());
-    }
-    use_[GetRef<Expr>(tuple_node)] = use;
-  }
-
-  void VisitExpr_(const TupleGetItemNode* get_node) override {
-    TSuper::VisitExpr_(get_node);
-    use_[GetRef<Expr>(get_node)] = use_[get_node->tuple];
-  }
-
-  void VisitExpr_(const GlobalVarNode* global_var_node) override {
-    use_[GetRef<Expr>(global_var_node)] = empty_set_;
-  }
-
-  void VisitExpr_(const VarNode* var_node) override {
-    Var var = GetRef<Var>(var_node);
-    ICHECK(alias_.count(var));
-    use_[var] = {var};
-  }
-
-  void VisitExpr_(const ConstantNode* const_node) override {
-    use_[GetRef<Expr>(const_node)] = empty_set_;
-  }
-
-  void VisitExpr_(const CallNode* call_node) override {
-    TVarSet use;
-    for (const Expr& arg : call_node->args) {
-      VisitExpr(arg);
-      ICHECK(use_.count(arg)) << arg;
-      TVarSet arg_use = use_[arg];
-      use.insert(arg_use.begin(), arg_use.end());
-    }
-    use_[GetRef<Expr>(call_node)] = use;
-  }
-
-  void VisitExpr_(const FunctionNode* function_node) override {
-    if (function_node->HasNonzeroAttr(attr::kPrimitive)) {
-      TSuper::VisitExpr_(function_node);
-      return;
-    }
-
-    // TODO(@altanh): figure out the closure nesting thing
-    ICHECK(!function_node->HasNonzeroAttr(attr::kClosure)) << "closures not supported yet";
-    ICHECK(func_depth_ == 0) << "nested functions should have been transformed away";
-
-    use_.clear();
-    def_.clear();
-    alias_.clear();
-
-    for (const Var& param : function_node->params) {
-      alias_[param] = std::make_shared<TVarSet>();
-      alias_[param]->insert(param);
-    }
-
-    ++func_depth_;
-
-    VisitExpr(function_node->body);
-
-    --func_depth_;
-  }
-
-  void VisitExpr_(const IfNode* if_node) override {
-    TSuper::VisitExpr_(if_node);
-    use_[GetRef<Expr>(if_node)] = use_[if_node->cond];
-  }
-
-  bool SetEqual(const TVarSet& a, const TVarSet& b) {
-    if (a.size() != b.size()) {
-      return false;
-    }
-    for (auto& xa : a) {
-      if (!b.count(xa)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
+  // see https://lambda.uta.edu/cse5317/notes/node40.html for an overview of the algorithm
   void ComputeLiveness(const Expr& expr) {
-    VisitExpr(expr);
+    cfg_ = CFG::Create(&arena_, expr);
+    VisitExpr(expr, nullptr);
 
     bool did_work = true;
 
-    // see https://lambda.uta.edu/cse5317/notes/node40.html for an overview of the algorithm
-    auto visitor = [&](const Expr& n) {
-      TVarSet old_in_n = this->live_in_[n];
-      TVarSet old_out_n = this->live_out_[n];
+    auto visitor = [&](CFG::Node* n) {
+      VarSet old_in_n = this->live_in_[n];
+      VarSet old_out_n = this->live_out_[n];
 
-      // we only compute live in/out for bindings
-      if (!n.as<LetNode>()) {
-        return;
-      }
-
-      this->live_in_[n] = TVarSet(this->use_[n].begin(), this->use_[n].end());
+      this->live_in_[n] = this->use_[n];
       for (const Var& v : this->live_out_[n]) {
         if (!v.same_as(this->def_[n])) {
           this->live_in_[n].insert(v);
         }
       }
 
-      ICHECK(succ_.count(n));
-      this->live_out_[n] = TVarSet();
-      for (const Expr& s : succ_[n]) {
-        this->live_out_[n].insert(this->live_in_[s].begin(), this->live_in_[s].end());
+      this->live_out_[n] = VarSet();
+      auto s = n->succ.head;
+      while (s) {
+        CFG::Node* s_node = s->value;
+        this->live_out_[n].insert(this->live_in_[s_node].begin(), this->live_in_[s_node].end());
+        s = s->next;
       }
 
       if (!SetEqual(old_in_n, this->live_in_[n])) {
@@ -210,44 +197,263 @@ class LivenessAnalyzer : public ExprVisitor {
 
     while (did_work) {
       did_work = false;
-      PostOrderVisit(expr, visitor);
+      for (auto it = cfg_.reverse_post_order.rbegin(); it != cfg_.reverse_post_order.rend(); ++it) {
+        visitor(*it);
+      }
     }
+  }
+
+ private:
+  CFG::Node* VisitExpr_(const LetNode* let_node, CFG::Node* cfg_node) override {
+    Expr expr = GetRef<Expr>(let_node);
+    ICHECK(!cfg_node || cfg_node == cfg_.let_map[expr]) << cfg_node->expr << std::endl <<
+    std::endl << cfg_.let_map[expr]->expr;
+
+    while (const auto* inner_let_node = expr.as<LetNode>()) {
+      const Var& var = inner_let_node->var;
+      const Expr& value = inner_let_node->value;
+
+      ICHECK(!cfg_node || cfg_node == cfg_.let_map[expr]) << cfg_node->expr << std::endl <<
+      std::endl << cfg_.let_map[expr]->expr; cfg_node = cfg_.let_map[expr];
+
+      // ICHECK(!alias_.count(var));
+      // if (value.as<VarNode>()) {
+      //   Var rhs = Downcast<Var>(value);
+      //   ICHECK(alias_.count(rhs));
+      //   alias_[var] = alias_[rhs];
+      //   alias_[rhs]->insert(var);
+      // } else {
+      //   alias_[var] = std::make_shared<VarSet>();
+      //   alias_[var]->insert(var);
+      // }
+
+      cfg_node = cfg_.let_map[expr];
+      def_[cfg_node] = var;
+
+      if (const IfNode* ite = AsIgnoringOnDevice<IfNode>(value)) {
+        VisitExpr_(ite, cfg_node);
+
+        // there should be exactly two successors: the true branch then the false branch
+        ICHECK(cfg_node->succ.head);
+        ICHECK(cfg_node->succ.head->next);
+        ICHECK(!cfg_node->succ.head->next->next);
+        CFG::Node* t_entry = cfg_node->succ.head->value;
+        CFG::Node* f_entry = cfg_node->succ.head->next->value;
+
+        CFG::Node* t_exit = VisitExpr(ite->true_branch, t_entry);
+        CFG::Node* f_exit = VisitExpr(ite->false_branch, f_entry);
+
+        // each branch should have exactly one succcessor, and it should be the same
+        ICHECK(t_exit->succ.head && !t_exit->succ.head->next);
+        ICHECK(f_exit->succ.head && !f_exit->succ.head->next);
+        ICHECK(t_exit->succ.head->value == f_exit->succ.head->value);
+        cfg_node = t_exit->succ.head->value;
+        if (inner_let_node->body.as<LetNode>()) {
+          ICHECK(cfg_node->expr.same_as(inner_let_node->body));
+          ICHECK(cfg_.let_map[inner_let_node->body] == cfg_node);
+        }
+      } else {
+        VisitExpr(value, cfg_node);
+
+        // normal bindings should have just one successor
+        ICHECK(cfg_node->succ.head && !cfg_node->succ.head->next);
+        cfg_node = cfg_node->succ.head->value;
+        if (inner_let_node->body.as<LetNode>()) {
+          ICHECK(cfg_node->expr.same_as(inner_let_node->body));
+          ICHECK(cfg_.let_map[inner_let_node->body] == cfg_node);
+        }
+      }
+
+      expr = inner_let_node->body;
+    }
+
+    return VisitExpr(expr, cfg_node);
+  }
+
+  CFG::Node* VisitExpr_(const IfNode* if_node, CFG::Node* cfg_node) override {
+    VisitExpr(if_node->cond, cfg_node);
+    return cfg_node;
+  }
+
+  CFG::Node* VisitExpr_(const TupleNode* tuple_node, CFG::Node* cfg_node) override {
+    for (const Expr& field : tuple_node->fields) {
+      VisitExpr(field, cfg_node);
+    }
+    return cfg_node;
+  }
+
+  CFG::Node* VisitExpr_(const TupleGetItemNode* get_node, CFG::Node* cfg_node) override {
+    VisitExpr(get_node->tuple, cfg_node);
+    return cfg_node;
+  }
+
+  CFG::Node* VisitExpr_(const GlobalVarNode* global_var_node, CFG::Node* cfg_node) override {return cfg_node;}
+
+  CFG::Node* VisitExpr_(const VarNode* var_node, CFG::Node* cfg_node) override {
+    Var var = GetRef<Var>(var_node);
+    // ICHECK(alias_.count(var));
+    use_[cfg_node].insert(var);
+    return cfg_node;
+  }
+
+  CFG::Node* VisitExpr_(const ConstantNode* const_node, CFG::Node* cfg_node) override {return cfg_node;}
+
+  CFG::Node* VisitExpr_(const OpNode* op_node, CFG::Node* cfg_node) override {return cfg_node;}
+
+  CFG::Node* VisitExpr_(const CallNode* call_node, CFG::Node* cfg_node) override {
+    VisitExpr(call_node->op, cfg_node);
+    for (const Expr& arg : call_node->args) {
+      VisitExpr(arg, cfg_node);
+    }
+    return cfg_node;
+  }
+
+  CFG::Node* VisitExpr_(const FunctionNode* func_node, CFG::Node* cfg_node) override { 
+    ICHECK(!used_);
+    used_ = true;
+
+    if (func_node->HasNonzeroAttr(attr::kPrimitive)) {
+      return nullptr;
+    }
+
+    // TODO(@altanh): figure out the closure nesting thing
+    // ICHECK(!function_node->HasNonzeroAttr(attr::kClosure)) << "closures not supported yet";
+    ICHECK(func_depth_ == 0) << "nested functions should have been transformed away";
+
+    Expr body = func_node->body;
+    if (func_node->HasNonzeroAttr(attr::kClosure)) {
+      ICHECK(body.as<FunctionNode>());
+      body = Downcast<Function>(func_node->body)->body;
+    }
+
+    ++func_depth_;
+    VisitExpr(body, nullptr);
+    --func_depth_;
+
+    return nullptr;
+  }
+
+  bool SetEqual(const VarSet& a, const VarSet& b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    for (auto& xa : a) {
+      if (!b.count(xa)) {
+        return false;
+      }
+    }
+    return true;
   }
 
  private:
   friend class MemoryPlanner;
 
+  bool used_ = false;
+
+  support::Arena arena_;
+  CFG cfg_;
+
+  CFG::Node* cfg_node_;
+
   // v in use_[n] means v is read in n.
   // NOTE: the use set of an If expression does not include the branches, just the condition.
   //       This lets us pretend the IR is composed of basic blocks (seq of bindings) + unstructured
   //       control flow, which is what most data-flow algorithms assume as input.
-  std::unordered_map<Expr, TVarSet, ObjectPtrHash, ObjectPtrEqual> use_;
+  // std::unordered_map<Expr, VarSet, ObjectPtrHash, ObjectPtrEqual> use_;
+  std::unordered_map<CFG::Node*, VarSet> use_;
 
-  // def_[n] = v means n is an expr "let v = ...; ..."
+  // def_[n] = v means n is a node "let v = ...;"
   // TODO(@altanh): pretty sure this can be removed since we don't allow binding the same var twice
   //                (unless I'm misremembering).
-  std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> def_;
+  // std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual> def_;
+  std::unordered_map<CFG::Node*, Var> def_;
 
   // y in alias_[x] means y is an alias of x, created by let binding y to an alias of x.
   // NOTE: x in alias_[x] for all x.
-  std::unordered_map<Var, std::shared_ptr<TVarSet>, ObjectPtrHash, ObjectPtrEqual> alias_;
+  // std::unordered_map<Var, std::shared_ptr<VarSet>, ObjectPtrHash, ObjectPtrEqual> alias_;
 
-  // Maps expr -> {successor expr/basic block}.
+  // Maps node -> {successor expr/basic block}.
   // NOTE: a pair of bindings without control flow, e.g. e = "b0; b1; body", results in a linear
   //       successor e -> b1. If expressions on the other hand, e.g.
   //       e = "let x = if (cond) { true_b } else { false_b }; body" have branching
   //       e -> {true_b, false_b} -> body.
-  std::unordered_map<Expr, std::vector<Expr>, ObjectPtrHash, ObjectPtrEqual> succ_;
+  // std::unordered_map<Expr, std::vector<Expr>, ObjectPtrHash, ObjectPtrEqual> succ_;
 
-  // Maps expr -> {v: Var | v is live before expr}
-  std::unordered_map<Expr, TVarSet, ObjectPtrHash, ObjectPtrEqual> live_in_;
-
-  // Maps expr -> {v: Var | v is live after expr}
-  std::unordered_map<Expr, TVarSet, ObjectPtrHash, ObjectPtrEqual> live_out_;
+  // Maps node -> {v: Var | v is live before node}
+  std::unordered_map<CFG::Node*, VarSet> live_in_;
+  // Maps node -> {v: Var | v is live after node}
+  std::unordered_map<CFG::Node*, VarSet> live_out_;
 
   size_t func_depth_ = 0;
 
-  const TVarSet empty_set_;
+  const VarSet empty_set_;
+};
+
+// TODO(@altanh): figure out if letrec is a problem
+// FIXME(@altanh): device_copy can be aliasing when src == dst
+
+class AliasEliminator : public MixedModeMutator {
+ public:
+  Expr VisitExpr_(const LetNode* let_node) override {
+    Expr expr = GetRef<Expr>(let_node);
+    LetList ll;
+    std::vector<Var> bound_vars;
+
+    while (const LetNode* inner_let_node = expr.as<LetNode>()) {
+      const Var& var = inner_let_node->var;
+      const Expr& val = inner_let_node->value;
+      ICHECK(!alias_.count(var));
+      if (val.as<VarNode>()) {
+        ICHECK(alias_.count(Downcast<Var>(val)));
+        alias_[var] = alias_[Downcast<Var>(val)];
+      } else {
+        alias_[var] = var;
+        ll.Push(var, VisitExpr(val));
+      }
+
+      bound_vars.push_back(var);
+
+      expr = inner_let_node->body;
+    }
+
+    Expr body = ll.Get(VisitExpr(expr));
+
+    // remove the bound vars so that alias_ only tracks things in scope
+    for (const Var& v : bound_vars) {
+      alias_.erase(v);
+    }
+
+    return body;
+  }
+
+  Expr VisitExpr_(const VarNode* var_node) override {
+    Var var = GetRef<Var>(var_node);
+    ICHECK(alias_.count(var));
+    return alias_[var];
+  }
+
+  Expr VisitExpr_(const FunctionNode* func_node) override {
+    for (const Var& param : func_node->params) {
+      alias_[param] = param;
+    }
+
+    Expr new_body = VisitExpr(func_node->body);
+    Expr result = GetRef<Expr>(func_node);
+    if (!new_body.same_as(func_node->body)) {
+      result = Function(func_node->params, new_body, func_node->ret_type, func_node->type_params,
+                        func_node->attrs, func_node->span);
+    }
+
+    for (const Var& param : func_node->params) {
+      size_t erased = alias_.erase(param);
+      ICHECK(erased);
+    }
+
+    return result;
+  }
+
+ private:
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectPtrEqual> alias_;
 };
 
 class MemoryPlanner : public ExprMutator {
@@ -266,24 +472,36 @@ class MemoryPlanner : public ExprMutator {
     while (const LetNode* inner_let_node = expr.as<LetNode>()) {
       ll.Push(inner_let_node->var, VisitExpr(inner_let_node->value));
 
-      auto& li = lva_.live_in_[expr];
-      auto& lo = lva_.live_out_[expr];
+      ICHECK(!inner_let_node->value.as<VarNode>());
+
+      ICHECK(lva_.cfg_.let_map.count(expr));
+
+      ControlFlowGraph::Node* n = lva_.cfg_.let_map[expr];
+
+      auto& li = lva_.live_in_[n];
+      auto& lo = lva_.live_out_[n];
+
+      // std::cout << "let " << inner_let_node->var->name_hint() << " = ...;" << std::endl;
+      // std::cout << "  live in:";
+      // for (auto& v : li) {
+      //   std::cout << " " << v->name_hint();
+      // }
+      // std::cout << std::endl << "  live out:";
+      // for (auto& v : lo) {
+      //   std::cout << " " << v->name_hint();
+      // }
+      // std::cout << std::endl << std::endl;
 
       // killed vars = live in - live out
-      LivenessAnalyzer::TVarSet kills;
+      VarSet kills;
       for (auto& v : li) {
         if (!lo.count(v)) {
           kills.insert(v);
         }
       }
 
-      // remove dead aliases from their alias sets
       for (auto& v : kills) {
-        lva_.alias_[v]->erase(v);
-        if (lva_.alias_[v]->empty()) {
-          // all aliases are dead, so we can actually kill the register
-          ll.Push(Call(Op::Get("memory.kill"), {v}));
-        }
+        ll.Push(Call(Op::Get("memory.kill"), {v}));
       }
 
       expr = inner_let_node->body;
@@ -294,12 +512,14 @@ class MemoryPlanner : public ExprMutator {
 
  private:
   LivenessAnalyzer lva_;
+  ControlFlowGraph::Node* curr_node_;
 };
 
 Pass VMPlanMemory() {
   auto pass_func = [](Function f, IRModule m, PassContext pc) -> Function {
+    AliasEliminator el;
     MemoryPlanner mp;
-    Expr nf = mp.PlanMemory(f);
+    Expr nf = mp.PlanMemory(el.Mutate(f));
     return Downcast<Function>(nf);
   };
   return CreateFunctionPass(pass_func, 0, "VMPlanMemory", {});

--- a/src/relay/backend/vm/plan_memory.cc
+++ b/src/relay/backend/vm/plan_memory.cc
@@ -148,6 +148,11 @@ class LivenessAnalyzer : public ExprVisitor {
     use_[GetRef<Expr>(tuple_node)] = use;
   }
 
+  void VisitExpr_(const TupleGetItemNode* get_node) override {
+    TSuper::VisitExpr_(get_node);
+    use_[GetRef<Expr>(get_node)] = use_[get_node->tuple];
+  }
+
   void VisitExpr_(const GlobalVarNode* global_var_node) override {
     use_[GetRef<Expr>(global_var_node)] = empty_set_;
   }
@@ -342,7 +347,7 @@ Pass VMPlanMemory() {
     // lva.DebugDump();
     MemoryPlanner mp;
     Expr nf = mp.PlanMemory(f);
-    std::cout << PrettyPrint(nf);
+    // std::cout << PrettyPrint(nf);
     return Downcast<Function>(nf);
   };
   return CreateFunctionPass(pass_func, 0, "VMPlanMemory", {});

--- a/src/relay/backend/vm/plan_memory.cc
+++ b/src/relay/backend/vm/plan_memory.cc
@@ -420,7 +420,7 @@ class AliasEliminator : public MixedModeMutator {
             }
           }
         }
-      } 
+      }
 
       if (!aliased) {
         ll.Push(var, VisitExpr(val));

--- a/src/relay/backend/vm/plan_memory.cc
+++ b/src/relay/backend/vm/plan_memory.cc
@@ -151,9 +151,9 @@ class LivenessAnalyzer : public ExprVisitor {
       return;
     }
 
-    // TODO: figure out the closure nesting thing
+    // TODO(@altanh): figure out the closure nesting thing
     ICHECK(!function_node->HasNonzeroAttr(attr::kClosure)) << "closures not supported yet";
-    ICHECK(func_depth_ == 0) << "nested functions not supported";
+    ICHECK(func_depth_ == 0) << "nested functions should have been transformed away";
 
     use_.clear();
     def_.clear();

--- a/src/relay/op/memory/memory.cc
+++ b/src/relay/op/memory/memory.cc
@@ -90,7 +90,7 @@ RELAY_REGISTER_OP("memory.alloc_storage")
     .set_attrs_type_key("relay.attrs.AllocStorageAttrs")
     .set_support_level(10)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
-    .set_attr<TOpIsStateful>("TOpIsStateful", true)
+    .set_attr<TOpIsStateful>("TOpIsStateful", false)
     .set_attr<TNonComputational>("TNonComputational", true)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout);
 
@@ -200,7 +200,7 @@ RELAY_REGISTER_OP("memory.alloc_tensor")
     .set_attrs_type_key("relay.attrs.AllocTensorAttrs")
     .set_support_level(10)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
-    .set_attr<TOpIsStateful>("TOpIsStateful", true)
+    .set_attr<TOpIsStateful>("TOpIsStateful", false)
     .set_attr<TNonComputational>("TNonComputational", true)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout);
 
@@ -213,13 +213,13 @@ bool KillRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 }
 
 RELAY_REGISTER_OP("memory.kill")
-    .describe(R"code(Mark a tensor for release to the allocator.)code" TVM_ADD_FILELINE)
+    .describe(R"code(Mark a variable for release to the allocator.)code" TVM_ADD_FILELINE)
     .set_num_inputs(1)
-    .add_argument("to_free", "Tensor", "The tensor to free.")
+    .add_argument("to_free", "Variable", "The variable to free.")
     .add_type_rel("Kill", KillRel)
     .set_support_level(10)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
-    .set_attr<TOpIsStateful>("TOpIsStateful", false)
+    .set_attr<TOpIsStateful>("TOpIsStateful", true)
     .set_attr<TNonComputational>("TNonComputational", true)
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout);
 

--- a/src/runtime/vm/bytecode.cc
+++ b/src/runtime/vm/bytecode.cc
@@ -125,6 +125,8 @@ Instruction::Instruction(const Instruction& instr) {
     case Opcode::DeviceCopy:
       this->device_copy = instr.device_copy;
       return;
+    case Opcode::KillRegister:
+      return;
     default:
       std::ostringstream out;
       out << "Invalid instruction " << static_cast<int>(instr.op);
@@ -228,6 +230,8 @@ Instruction& Instruction::operator=(const Instruction& instr) {
     case Opcode::DeviceCopy:
       this->device_copy = instr.device_copy;
       return *this;
+    case Opcode::KillRegister:
+      return *this;
     default:
       std::ostringstream out;
       out << "Invalid instruction " << static_cast<int>(instr.op);
@@ -251,6 +255,7 @@ Instruction::~Instruction() {
     case Opcode::ReshapeTensor:
     case Opcode::DeviceCopy:
     case Opcode::Fatal:
+    case Opcode::KillRegister:
       return;
     case Opcode::AllocTensor:
       delete[] this->alloc_tensor.shape;
@@ -369,6 +374,13 @@ Instruction Instruction::DeviceCopy(RegName src, Index src_device_index, Index d
   instr.device_copy.src = src;
   instr.device_copy.src_device_index = src_device_index;
   instr.device_copy.dst_device_index = dst_device_index;
+  return instr;
+}
+
+Instruction Instruction::KillRegister(RegName dst) {
+  Instruction instr;
+  instr.op = Opcode::KillRegister;
+  instr.dst = dst;
   return instr;
 }
 
@@ -619,6 +631,10 @@ void InstructionPrint(std::ostream& os, const Instruction& instr) {
     case Opcode::DeviceCopy: {
       os << "device_copy $" << instr.dst << " $" << instr.device_copy.src << " "
          << instr.device_copy.dst_device_index << " " << instr.device_copy.src_device_index;
+      break;
+    }
+    case Opcode::KillRegister: {
+      os << "kill_register $" << instr.dst;
       break;
     }
     default:

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -665,6 +665,10 @@ VMInstructionSerializer SerializeInstruction(const Instruction& instr) {
                      instr.device_copy.dst_device_index, instr.dst});
       break;
     }
+    case Opcode::KillRegister: {
+      fields.assign({instr.dst});
+      break;
+    }
     default:
       LOG(FATAL) << "Invalid opcode" << static_cast<int>(instr.op);
       break;
@@ -981,6 +985,10 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       DCHECK_EQ(instr.fields.size(), 4U);
       return Instruction::DeviceCopy(instr.fields[0], instr.fields[1], instr.fields[2],
                                      instr.fields[3]);
+    }
+    case Opcode::KillRegister: {
+      DCHECK_EQ(instr.fields.size(), 1U);
+      return Instruction::KillRegister(instr.fields[0]);
     }
     default:
       LOG(FATAL) << "Invalid opcode" << instr.opcode;

--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -137,7 +137,7 @@ void VirtualMachineDebug::OpStartHook(Instruction instr) {
       prof_.operator*().StartCall("VM::AllocStorage", dev,
                                   {{"VM::Argument Shapes", String(shape.str())}});
     } else {
-      prof_.operator*().StartCall("VM::UnknownOp", devices_[0], {});
+      prof_.operator*().StartCall("VM::UnknownOp", GetDevice(exec_->host_device_index), {});
     }
   }
 }

--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -137,7 +137,7 @@ void VirtualMachineDebug::OpStartHook(Instruction instr) {
       prof_.operator*().StartCall("VM::AllocStorage", dev,
                                   {{"VM::Argument Shapes", String(shape.str())}});
     } else {
-      prof_.operator*().StartCall("VM::UnknownOp", devices_[1], {});
+      prof_.operator*().StartCall("VM::UnknownOp", devices_[0], {});
     }
   }
 }

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -764,6 +764,7 @@ void VirtualMachine::RunLoop() {
       case Opcode::KillRegister: {
         OpStartHook(instr);
         WriteRegister(instr.dst, ObjectRef());
+        OpStopHook();
         pc_++;
         goto main_loop;
       }

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -761,6 +761,12 @@ void VirtualMachine::RunLoop() {
         pc_++;
         goto main_loop;
       }
+      case Opcode::KillRegister: {
+        OpStartHook(instr);
+        WriteRegister(instr.dst, ObjectRef());
+        pc_++;
+        goto main_loop;
+      }
       default:
         LOG(FATAL) << "Unknown instruction opcode: " << int(instr.op);
     }

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -52,7 +52,7 @@ def test_large_graph():
     y = relay.var("y")
     one = relay.const(10e10, dtype="float32")
     z = relay.add(x, one)
-    for i in range(int(1e6)):
+    for i in range(int(9e5)):
         z = relay.add(z, one)
     f = relay.Function([x, y], z)
     show(astext(f))

--- a/tests/python/relay/test_pass_dead_code_elimination.py
+++ b/tests/python/relay/test_pass_dead_code_elimination.py
@@ -235,6 +235,7 @@ def test_impure_op():
            let %size: int64 = cast(1024, dtype="int64");
            let %alignment: int64 = cast(64, dtype="int64");
            let %x = memory.alloc_storage(%size, %alignment, virtual_device=meta[VirtualDevice][0]);
+           let %_ = memory.kill(%x);
            0
         }
         """,
@@ -247,9 +248,10 @@ def test_impure_op():
         """
         #[version = "0.0.5"]
         def @main() {
-           let %x = memory.alloc_storage(cast(1024, dtype="int64"),
-                                         cast(64, dtype="int64"),
-                                         virtual_device=meta[VirtualDevice][0]);
+           %0 = memory.alloc_storage(cast(1024, dtype="int64"),
+                                     cast(64, dtype="int64"),
+                                     virtual_device=meta[VirtualDevice][0]);
+           let %_ = memory.kill(%0);
            0
         }
         """,
@@ -272,6 +274,7 @@ def test_impure_func():
            let %size: int64 = cast(1024, dtype="int64");
            let %alignment: int64 = cast(64, dtype="int64");
            let %x = memory.alloc_storage(%size, %alignment, virtual_device=meta[VirtualDevice][0]);
+           let %_ = memory.kill(%x);
            0
         }
         def @main() -> int {
@@ -288,9 +291,10 @@ def test_impure_func():
         """
         #[version = "0.0.5"]
         def @f() -> int {
-           let %x = memory.alloc_storage(cast(1024, dtype="int64"),
-                                         cast(64, dtype="int64"),
-                                         virtual_device=meta[VirtualDevice][0]);
+           %0 = memory.alloc_storage(cast(1024, dtype="int64"),
+                                     cast(64, dtype="int64"),
+                                     virtual_device=meta[VirtualDevice][0]);
+           let %_ = memory.kill(%0);
            0
         }
         def @main() -> int {

--- a/tests/python/relay/test_pass_manifest_lifetimes.py
+++ b/tests/python/relay/test_pass_manifest_lifetimes.py
@@ -18,6 +18,7 @@ import tvm
 from tvm.relay import Function, transform
 from tvm.relay.testing import inception_v3
 import pytest
+import sys
 
 
 def optimize_and_check(before_program, after_program, passes):
@@ -140,3 +141,7 @@ def test_simple_match():
     }
     """
     optimize_and_check(before_program, after_program, transform.ManifestLifetimes())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relay/test_pass_manifest_lifetimes.py
+++ b/tests/python/relay/test_pass_manifest_lifetimes.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+from tvm.relay import Function, transform
+from tvm.relay.testing import inception_v3
+import pytest
+
+
+def optimize_and_check(before_program, after_program, passes):
+    if isinstance(before_program, str):
+        before_program = tvm.parser.parse(before_program)
+    if isinstance(after_program, str):
+        after_program = tvm.parser.parse(after_program)
+    if not isinstance(passes, list):
+        passes = [passes]
+    optimize = tvm.transform.Sequential(passes)
+    optimized_program = optimize(before_program)
+    print("Actual:")
+    print(optimized_program)
+    print("Expected:")
+    print(after_program)
+    assert tvm.ir.structural_equal(optimized_program, after_program, map_free_vars=True)
+
+
+def test_simple_linear():
+    before_program = """
+    #[version = "0.0.5"]
+    def @main(%x: int) {
+        let %y = %x + %x;
+        let %z = %y + %y;
+        let %w = %z + %z;
+        %w
+    }
+    """
+    after_program = """
+    #[version = "0.0.5"]
+    def @main(%x: int) {
+        let %y = %x + %x;
+        let %_0 = memory.kill(%x);
+        let %z = %y + %y;
+        let %_1 = memory.kill(%y);
+        let %w = %z + %z;
+        let %_2 = memory.kill(%z);
+        %w
+    }
+    """
+    optimize_and_check(before_program, after_program, transform.ManifestLifetimes())
+
+
+def test_simple_if():
+    before_program = """
+    #[version = "0.0.5"]
+    def @main(%x: int) {
+        let %y = cast(%x, dtype="bool");
+        let %z = if (%y) {
+            let %v0 = %x + %x;
+            let %v1 = %v0 * 2;
+            %v1
+        } else {
+            %x
+        };
+        %z
+    }
+    """
+    after_program = """
+    #[version = "0.0.5"]
+    def @main(%x: int) {
+        let %y = cast(%x, dtype="bool");
+        let %z = if (%y) {
+            let %v0 = %x + %x;
+            let %_0 = memory.kill(%x);
+            let %v1 = %v0 * 2;
+            let %_1 = memory.kill(%v0);
+            %v1
+        } else {
+            %x
+        };
+        let %_1 = memory.kill(%y);
+        %z
+    }
+    """
+    optimize_and_check(before_program, after_program, transform.ManifestLifetimes())
+
+
+def test_simple_match():
+    before_program = """
+    #[version = "0.0.5"]
+    type List[A] {
+        Cons(A, List[A]),
+        Nil,
+    }
+    def @main(%x: int) {
+        let %l : List[int] = Nil;
+        let %m = (match (%l) {
+            Cons(%head, %rest) => {
+                let %y = %x + 1;
+                let %z = %y + %y;
+                %z
+            },
+            Nil => -1,
+        });
+        %m
+    }
+    """
+    after_program = """
+    #[version = "0.0.5"]
+    type List[A] {
+        Cons(A, List[A]),
+        Nil,
+    }
+    def @main(%x: int) {
+        let %l : List[int] = Nil;
+        let %m = (match (%l) {
+            Cons(%head, %rest) => {
+                let %y = %x + 1;
+                let %_0 = memory.kill(%x);
+                let %z = %y + %y;
+                let %_1 = memory.kill(%y);
+                /* TODO: %head and %rest should be immediately killed */
+                %z
+            },
+            Nil => -1
+        });
+        let %_2 = memory.kill(%l);
+        %m
+    }
+    """
+    optimize_and_check(before_program, after_program, transform.ManifestLifetimes())


### PR DESCRIPTION
This PR adds basic memory management to the Relay VM by inserting kill annotations on variables at the end of their lifetimes. Kill annotations are translated to a new VM instruction `KillRegister`, which nulls out the specified register. By nulling out a register, we destroy the ObjectRef inside, which eventually leads to tensors being freed via refcounting. This approach automatically handles aliasing of tensors (e.g. via tuples, ADTs) as the aliases are reflected in the run-time refcount.

Lifetime analysis is done using standard data-flow analysis on the CFG of the post-memory-lowering IR. The main tricky bit involves respecting the VM compiler's register aliasing scheme (e.g. var-to-var bindings); an alternative approach would be to move the register aliasing logic into the VM compiler itself, so that kill annotations are only translated to a `KillRegister` when all aliases of a register have been killed.

This PR does not do "static" memory planning in the sense of optimizing an allocation plan. Follow-up work should revive the storage coalescing pass and do static planning within each storage (although this would need static analysis of aliasing).

With this PR, BERT-SQuAD sees around 10x memory reduction (~20GB -> ~2GB on our tested input size).

**Other changes in this PR:**
- `memory.alloc_storage` and `memory.alloc_tensor` are now marked as non-stateful, since they can be safely eliminated by DCE
- fix small bug in VM profiling when timing "unknown" instructions

TODOs:

- [x] ~conservatively support relay refs (or skip memory planning gracefully at least)~ refs are not supported in the VM currently (see #6798)
- [x] support closures
- [x] support If
- [x] support Match
- [x] add tests
- [x] add more docs
