### PR TITLE
[Runtime][PackedFunc] Bring `PackedFunc` into TVM Object System

### DIFF
--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -46,6 +46,7 @@
 #include <tvm/runtime/packed_func.h>
 
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -108,7 +109,11 @@ class Registry {
    * \brief set the body of the function to be f
    * \param f The body of the function.
    */
-  Registry& set_body(PackedFunc::FType f) {  // NOLINT(*)
+  template <typename TCallable,
+            typename = typename std::enable_if_t<
+                std::is_convertible<TCallable, std::function<void(TVMArgs, TVMRetValue*)>>::value &&
+                !std::is_base_of<PackedFunc, TCallable>::value>>
+  Registry& set_body(TCallable f) {  // NOLINT(*)
     return set_body(PackedFunc(f));
   }
   /*!

--- a/src/ir/op.cc
+++ b/src/ir/op.cc
@@ -121,13 +121,13 @@ TVM_REGISTER_GLOBAL("ir.OpAddTypeRel")
       auto& reg = OpRegistry::Global()->RegisterOrGet(op->name).set_name();
       if (value.type_code() == kTVMPackedFuncHandle) {
         // do an eager copy of the PackedFunc to avoid deleting function from frontend.
-        PackedFunc* fcopy = new PackedFunc(value.operator tvm::runtime::PackedFunc());
+        PackedFunc fcopy = value;
         auto f = [=](const Array<Type>& args, int num_inputs, const Attrs& attrs,
                      const TypeReporter& reporter) -> bool {
           Array<Type> input_types(args.begin(), args.end() - 1);
           // call customized relation functions
           // *fcopy's signature: function (args: List[Type], attrs: Attrs) -> Type
-          Type ret_type = (*fcopy)(input_types, attrs);
+          Type ret_type = fcopy(input_types, attrs);
           // when defined ret_type, inference of output type is ok, do type assign
           // otherwise, inference failure happens
           if (ret_type.defined()) {
@@ -185,9 +185,7 @@ TVM_REGISTER_GLOBAL("ir.RegisterOpAttr")
         if (value.type_code() == kTVMPackedFuncHandle) {
           // do an eager copy of the PackedFunc
           PackedFunc f = value;
-          // If we get a function from frontend, avoid deleting it.
-          auto* fcopy = new PackedFunc(f);
-          reg.set_attr(attr_key, *fcopy, plevel);
+          reg.set_attr(attr_key, f, plevel);
         } else {
           reg.set_attr(attr_key, value, plevel);
         }

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -407,7 +407,12 @@ int TVMModGetFunction(TVMModuleHandle mod, const char* func_name, int query_impo
   API_BEGIN();
   PackedFunc pf = ObjectInternal::GetModuleNode(mod)->GetFunction(func_name, query_imports != 0);
   if (pf != nullptr) {
-    *func = new PackedFunc(pf);
+    tvm::runtime::TVMRetValue ret;
+    ret = pf;
+    TVMValue val;
+    int type_code;
+    ret.MoveToCHost(&val, &type_code);
+    *func = val.v_handle;
   } else {
     *func = nullptr;
   }
@@ -418,7 +423,7 @@ int TVMModFree(TVMModuleHandle mod) { return TVMObjectFree(mod); }
 
 int TVMBackendGetFuncFromEnv(void* mod_node, const char* func_name, TVMFunctionHandle* func) {
   API_BEGIN();
-  *func = (TVMFunctionHandle)(static_cast<ModuleNode*>(mod_node)->GetFuncFromEnv(func_name));
+  *func = (TVMFunctionHandle)(static_cast<ModuleNode*>(mod_node)->GetFuncFromEnv(func_name))->get();
   API_END();
 }
 
@@ -452,11 +457,7 @@ int TVMBackendRunOnce(void** handle, int (*f)(void*), void* cdata, int nbytes) {
   return 0;
 }
 
-int TVMFuncFree(TVMFunctionHandle func) {
-  API_BEGIN();
-  delete static_cast<PackedFunc*>(func);
-  API_END();
-}
+int TVMFuncFree(TVMFunctionHandle func) { return TVMObjectFree(func); }
 
 int TVMByteArrayFree(TVMByteArray* arr) {
   if (arr == &TVMAPIRuntimeStore::Get()->ret_bytes) {
@@ -472,7 +473,8 @@ int TVMFuncCall(TVMFunctionHandle func, TVMValue* args, int* arg_type_codes, int
   API_BEGIN();
 
   TVMRetValue rv;
-  (*static_cast<const PackedFunc*>(func)).CallPacked(TVMArgs(args, arg_type_codes, num_args), &rv);
+  (static_cast<const PackedFuncObj*>(func))
+      ->CallPacked(TVMArgs(args, arg_type_codes, num_args), &rv);  
   // handle return string.
   if (rv.type_code() == kTVMStr || rv.type_code() == kTVMDataType || rv.type_code() == kTVMBytes) {
     TVMRuntimeEntry* e = TVMAPIRuntimeStore::Get();
@@ -508,24 +510,34 @@ int TVMFuncCreateFromCFunc(TVMPackedCFunc func, void* resource_handle, TVMPacked
                            TVMFunctionHandle* out) {
   API_BEGIN();
   if (fin == nullptr) {
-    *out = new PackedFunc([func, resource_handle](TVMArgs args, TVMRetValue* rv) {
+    tvm::runtime::TVMRetValue ret;
+    ret = PackedFunc([func, resource_handle](TVMArgs args, TVMRetValue* rv) {
       int ret = func(const_cast<TVMValue*>(args.values), const_cast<int*>(args.type_codes),
                      args.num_args, rv, resource_handle);
       if (ret != 0) {
         throw tvm::Error(TVMGetLastError() + tvm::runtime::Backtrace());
       }
     });
+    TVMValue val;
+    int type_code;
+    ret.MoveToCHost(&val, &type_code);
+    *out = val.v_handle;
   } else {
     // wrap it in a shared_ptr, with fin as deleter.
     // so fin will be called when the lambda went out of scope.
     std::shared_ptr<void> rpack(resource_handle, fin);
-    *out = new PackedFunc([func, rpack](TVMArgs args, TVMRetValue* rv) {
+    tvm::runtime::TVMRetValue ret;
+    ret = PackedFunc([func, rpack](TVMArgs args, TVMRetValue* rv) {
       int ret = func(const_cast<TVMValue*>(args.values), const_cast<int*>(args.type_codes),
                      args.num_args, rv, rpack.get());
       if (ret != 0) {
         throw tvm::Error(TVMGetLastError() + tvm::runtime::Backtrace());
       }
     });
+    TVMValue val;
+    int type_code;
+    ret.MoveToCHost(&val, &type_code);
+    *out = val.v_handle;
   }
   API_END();
 }

--- a/web/emcc/tvmjs_support.cc
+++ b/web/emcc/tvmjs_support.cc
@@ -108,9 +108,19 @@ class AsyncLocalSession : public LocalSession {
       return get_time_eval_placeholder_.get();
     } else if (auto* fp = tvm::runtime::Registry::Get(name)) {
       // return raw handle because the remote need to explicitly manage it.
-      return new PackedFunc(*fp);
+      tvm::runtime::TVMRetValue ret;
+      ret = *fp;
+      TVMValue val;
+      int type_code;
+      ret.MoveToCHost(&val, &type_code);
+      return val.v_handle;
     } else if (auto* fp = tvm::runtime::Registry::Get("__async." + name)) {
-      auto* rptr = new PackedFunc(*fp);
+      tvm::runtime::TVMRetValue ret;
+      ret = *fp;
+      TVMValue val;
+      int type_code;
+      ret.MoveToCHost(&val, &type_code);
+      auto* rptr = val.v_handle;
       async_func_set_.insert(rptr);
       return rptr;
     } else {


### PR DESCRIPTION
This PR allows developers to use `PackedFunc` as TVM objects, which completes the last missing step of TVM runtime object system.
