### PR TITLE
[CUTLASS] Profile only the largest-possible alignment by default

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -299,7 +299,7 @@ def tune_cutlass_kernels(
         fp32 inputs on tensorcore.
 
     profile_all_alignments : bool
-        When True, profile all kernal varaints with smaller alignments than the largest possible.
+        When True, profile all kernal variants with smaller alignments than the largest possible.
 
     profile_all : bool
         Whether or not profile all candidate kernels, or stop profiling after

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -237,6 +237,7 @@ def handle_conv2d(
     data_dtype,
     weight_dtype,
     use_3xtf32,
+        profile_all_alignments,
     profile_all,
     use_multiprocessing,
 ):
@@ -257,6 +258,7 @@ def handle_conv2d(
             data_dtype,
             weight_dtype,
             use_3xtf32,
+            profile_all_alignments,
             profile_all=profile_all,
             use_multiprocessing=use_multiprocessing,
         )

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -104,7 +104,7 @@ def select_gemm_kernel(
     arg1_dtype,
     use_3xtf32,
     batched,
-    profile_all,
+    find_first_valid,
     use_multiprocessing,
 ):
     """Run CUTLASS profiler to select the best kernel, or return the default one for dynamic
@@ -126,10 +126,10 @@ def select_gemm_kernel(
             arg1_dtype,
             use_3xtf32,
             batched=batched,
-            profile_all=profile_all,
+            find_first_valid=find_first_valid,
             use_multiprocessing=use_multiprocessing,
         )
-        if profile_all:
+        if not find_first_valid:
             logger.info("The best kernel is %s", name)
         else:
             logger.info("Picked the first kernel found %s", name)
@@ -146,7 +146,7 @@ def handle_batch_matmul(
     arg0_dtype,
     arg1_dtype,
     use_3xtf32,
-    profile_all,
+    find_first_valid,
     use_multiprocessing,
 ):
     """Profile and select a kernel for batch_matmul op workload."""
@@ -165,7 +165,7 @@ def handle_batch_matmul(
         arg1_dtype,
         use_3xtf32,
         True,
-        profile_all,
+        find_first_valid,
         use_multiprocessing,
     )
 
@@ -191,7 +191,7 @@ def handle_dense(
     arg0_dtype,
     arg1_dtype,
     use_3xtf32,
-    profile_all,
+    find_first_valid,
     use_multiprocessing,
 ):
     """Profile and select a kernel for dense op workload."""
@@ -210,7 +210,7 @@ def handle_dense(
         arg1_dtype,
         use_3xtf32,
         False,
-        profile_all,
+        find_first_valid,
         use_multiprocessing,
     )
 
@@ -238,7 +238,7 @@ def handle_conv2d(
     weight_dtype,
     use_3xtf32,
     profile_all_alignments,
-    profile_all,
+    find_first_valid,
     use_multiprocessing,
 ):
     """Profile and select a kernel for conv2d op workload."""
@@ -259,10 +259,10 @@ def handle_conv2d(
             weight_dtype,
             use_3xtf32,
             profile_all_alignments,
-            profile_all=profile_all,
+            find_first_valid=find_first_valid,
             use_multiprocessing=use_multiprocessing,
         )
-        if profile_all:
+        if not find_first_valid:
             logger.info("The best kernel is %s", name)
         else:
             logger.info("Picked the first kernel found %s", name)
@@ -278,7 +278,7 @@ def tune_cutlass_kernels(
     sm,
     use_3xtf32=True,
     profile_all_alignments=False,
-    profile_all=True,
+    find_first_valid=False,
     use_multiprocessing=False,
     tmp_dir="./tmp",
 ):
@@ -301,7 +301,7 @@ def tune_cutlass_kernels(
     profile_all_alignments : bool
         When True, profile all kernal variants with smaller alignments than the largest possible.
 
-    profile_all : bool
+    find_first_valid : bool
         Whether or not profile all candidate kernels, or stop profiling after
         the first applicable kernel is found.
 
@@ -358,7 +358,7 @@ def tune_cutlass_kernels(
                         arg1_dtype,
                         use_3xtf32,
                         profile_all_alignments,
-                        profile_all,
+                        find_first_valid,
                         use_multiprocessing,
                     )
                 )
@@ -373,7 +373,7 @@ def tune_cutlass_kernels(
                         arg0_dtype,
                         arg1_dtype,
                         use_3xtf32,
-                        profile_all,
+                        find_first_valid,
                         use_multiprocessing,
                     )
                 )
@@ -388,7 +388,7 @@ def tune_cutlass_kernels(
                         arg0_dtype,
                         arg1_dtype,
                         use_3xtf32,
-                        profile_all,
+                        find_first_valid,
                         use_multiprocessing,
                     )
                 )

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -237,7 +237,7 @@ def handle_conv2d(
     data_dtype,
     weight_dtype,
     use_3xtf32,
-        profile_all_alignments,
+    profile_all_alignments,
     profile_all,
     use_multiprocessing,
 ):
@@ -274,7 +274,13 @@ def handle_conv2d(
 
 
 def tune_cutlass_kernels(
-        mod, sm, use_3xtf32=True, profile_all_alignments=False, profile_all=True, use_multiprocessing=False, tmp_dir="./tmp"
+    mod,
+    sm,
+    use_3xtf32=True,
+    profile_all_alignments=False,
+    profile_all=True,
+    use_multiprocessing=False,
+    tmp_dir="./tmp",
 ):
     """Given a module partitioned for CUTLASS offloading, profile each workload to select which
     kernels to emit.

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -272,7 +272,7 @@ def handle_conv2d(
 
 
 def tune_cutlass_kernels(
-    mod, sm, use_3xtf32=True, profile_all=True, use_multiprocessing=False, tmp_dir="./tmp"
+        mod, sm, use_3xtf32=True, profile_all_alignments=False, profile_all=True, use_multiprocessing=False, tmp_dir="./tmp"
 ):
     """Given a module partitioned for CUTLASS offloading, profile each workload to select which
     kernels to emit.
@@ -285,6 +285,9 @@ def tune_cutlass_kernels(
     sm : int
         An integer specifying the compute capability. For example, 75 for Turing and
         80 or 86 for Ampere.
+
+    profile_all_alignments : bool
+        TODO
 
     profile_all : bool
         Whether or not profile all candidate kernels, or stop profiling after
@@ -342,6 +345,7 @@ def tune_cutlass_kernels(
                         arg0_dtype,
                         arg1_dtype,
                         use_3xtf32,
+                        profile_all_alignments,
                         profile_all,
                         use_multiprocessing,
                     )

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -294,8 +294,12 @@ def tune_cutlass_kernels(
         An integer specifying the compute capability. For example, 75 for Turing and
         80 or 86 for Ampere.
 
+    use_3xtf32 : bool
+        Wheter or not use slower but very accurate (compared to tf32) 3xtf32 mode for
+        fp32 inputs on tensorcore.
+
     profile_all_alignments : bool
-        TODO
+        When True, profile all kernal varaints with smaller alignments than the largest possible.
 
     profile_all : bool
         Whether or not profile all candidate kernels, or stop profiling after

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -179,7 +179,7 @@ class CutlassConv2DProfiler:
         weight_dtype,
         use_3xtf32,
         profile_all_alignments=False,
-        profile_all=True,
+        find_first_valid=False,
         use_multiprocessing=False,
     ):
         """
@@ -217,7 +217,7 @@ class CutlassConv2DProfiler:
             profile_all_alignments,
         )
 
-        if profile_all:
+        if find_first_valid:
             self.engine.compile_all(ops, use_multiprocessing)
 
         args = (
@@ -228,7 +228,7 @@ class CutlassConv2DProfiler:
         for op in ops:
             out = self.engine.evaluate(op, args.split(" "))
             op["runtime"] = out
-            if out < float("inf") and not profile_all:
+            if out < float("inf") and find_first_valid:
                 self.cache[workload] = op
                 return op
 
@@ -249,11 +249,11 @@ class CutlassConv2DProfiler:
         weight_dtype,
         use_3xtf32=True,
         profile_all_alignments=False,
-        profile_all=True,
+        find_first_valid=False,
         use_multiprocessing=False,
     ):
         """Profile and select the best kernel from candidate kernels.
-        If profile_all is False, return immediately after the first applicable kernel is found.
+        If find_first_valid is True, return immediately after the first applicable kernel is found.
         If use_multiprocessing is True, compile all profiler executables in parallel.
         """
         op = self.select_op(
@@ -267,7 +267,7 @@ class CutlassConv2DProfiler:
             weight_dtype,
             use_3xtf32,
             profile_all_alignments,
-            profile_all,
+            find_first_valid,
             use_multiprocessing,
         )
 

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -269,7 +269,7 @@ class CutlassConv2DProfiler:
             use_3xtf32,
             profile_all_alignments,
             profile_all,
-            use_multiprocessing
+            use_multiprocessing,
         )
 
         name, opdef = create_conv2d_operator_with_epilogue(

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=invalid-name
 """Conv2d kernel generator and profiler for CUTLASS."""
-import re
 from .conv2d_operation import Conv2dOperation, EmitConv2dInstance
 from .gen_gemm import CutlassGemmProfiler
 from .conv2d_profiler import Conv2dProfilerEmitter

--- a/python/tvm/contrib/cutlass/gen_conv2d.py
+++ b/python/tvm/contrib/cutlass/gen_conv2d.py
@@ -217,7 +217,7 @@ class CutlassConv2DProfiler:
             profile_all_alignments,
         )
 
-        if find_first_valid:
+        if not find_first_valid:
             self.engine.compile_all(ops, use_multiprocessing)
 
         args = (

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -156,9 +156,9 @@ class CutlassGemmProfiler:
             arg0_dtype,
             arg1_dtype,
             enumerate_gemm_operators,
-            lambda _: True,
+            lambda align: align == 1,  # Only request align1 kernels
             use_3xtf32,
-            profile_all_alignments=True,  # To include align1 kernels
+            profile_all_alignments=False,
         )
 
         default_kernel_name = DEFAULT_KERNELS[self.sm][(arg0_dtype, out_dtype)]

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -222,7 +222,7 @@ class CutlassGemmProfiler:
             profile_all_alignments=profile_all_alignments,
         )
 
-        if find_first_valid:
+        if not find_first_valid:
             self.engine.compile_all(ops, use_multiprocessing)
 
         for op in ops:

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -168,7 +168,7 @@ class CutlassGemmProfiler:
         For now, the default kernel was picked arbitrary.
         """
         ops = GENERATOR_FUNC_TABLE[self.sm](
-            out_dtype, arg0_dtype, arg1_dtype, enumerate_gemm_operators, use_3xtf32
+            out_dtype, arg0_dtype, arg1_dtype, enumerate_gemm_operators, lambda _: True, use_3xtf32
         )
         default_kernel_name = DEFAULT_KERNELS[self.sm][(arg0_dtype, out_dtype)]
 

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -156,9 +156,9 @@ class CutlassGemmProfiler:
             arg0_dtype,
             arg1_dtype,
             enumerate_gemm_operators,
-            lambda align: align == 1,  # Only request align1 kernels
+            lambda align: align == 1  # Only request align1 kernels
             use_3xtf32,
-            profile_all_alignments=False,
+            profile_all_alignments=True,  # To include all align1 kernels
         )
 
         default_kernel_name = DEFAULT_KERNELS[self.sm][(arg0_dtype, out_dtype)]

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -218,7 +218,7 @@ class CutlassGemmProfiler:
             arg1_dtype,
             enumerate_gemm_operators,
             lambda align: all([dim % align == 0 for dim in [M, N, K]]),
-            use_3xtf32=use_3xtf32,
+            use_3xtf32,
             profile_all_alignments=profile_all_alignments,
         )
 

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -29,7 +29,12 @@ from .library import (
 
 
 def create_gemm_operator_with_epilogue(
-    op_type, tile_description, data_type, alignment, swizzling_functor, batched=False,
+    op_type,
+    tile_description,
+    data_type,
+    alignment,
+    swizzling_functor,
+    batched=False,
 ):
     """
     Instantiate a cutlass kernel from the given configuration,
@@ -156,7 +161,7 @@ class CutlassGemmProfiler:
             arg0_dtype,
             arg1_dtype,
             enumerate_gemm_operators,
-            lambda align: align == 1  # Only request align1 kernels
+            lambda align: align == 1,  # Only request align1 kernels
             use_3xtf32,
             profile_all_alignments=True,  # To include all align1 kernels
         )

--- a/python/tvm/contrib/cutlass/gen_gemm.py
+++ b/python/tvm/contrib/cutlass/gen_gemm.py
@@ -197,7 +197,7 @@ class CutlassGemmProfiler:
         arg1_dtype,
         use_3xtf32,
         profile_all_alignments=False,
-        profile_all=True,
+        find_first_valid=False,
         use_multiprocessing=False,
     ):
         """
@@ -222,13 +222,13 @@ class CutlassGemmProfiler:
             profile_all_alignments=profile_all_alignments,
         )
 
-        if profile_all:
+        if find_first_valid:
             self.engine.compile_all(ops, use_multiprocessing)
 
         for op in ops:
             out = self.engine.evaluate(op, [M, N, K])
             op["runtime"] = out
-            if out < float("inf") and not profile_all:
+            if out < float("inf") and find_first_valid:
                 self.cache[(M, N, K)] = op
                 return op
 
@@ -247,12 +247,12 @@ class CutlassGemmProfiler:
         arg1_dtype,
         use_3xtf32=True,
         profile_all_alignments=False,
-        profile_all=True,
+        find_first_valid=False,
         use_multiprocessing=False,
         batched=False,
     ):
         """Profile and select the best kernel from candidate kernels.
-        If profile_all is False, return immediately after the first applicable kernel is found.
+        If find_first_valid is True, return immediately after the first applicable kernel is found.
         If use_multiprocessing is True, compile all profiler executables in parallel.
         """
         op = self.select_op(
@@ -264,7 +264,7 @@ class CutlassGemmProfiler:
             arg1_dtype,
             use_3xtf32,
             profile_all_alignments=profile_all_alignments,
-            profile_all=profile_all,
+            find_first_valid=find_first_valid,
             use_multiprocessing=use_multiprocessing,
         )
 

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -411,7 +411,8 @@ class Module(object):
                         "c",
                         "cc",
                         "cpp",
-                    ], "The module.format needs to be either c, cc or cpp"
+                        "cu",
+                    ], "The module.format needs to be either c, cc, cpp or cu."
                     object_format = module.format
                     has_c_module = True
                 else:
@@ -426,7 +427,8 @@ class Module(object):
                             "c",
                             "cc",
                             "cpp",
-                        ], "The module.format needs to be either c, cc or cpp"
+                            "cu",
+                        ], "The module.format needs to be either c, cc, cpp, or cu."
                         object_format = module.format
                     else:
                         object_format = "c"

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -531,9 +531,9 @@ def test_conv2d():
     mod_nchw = get_conv2d_nchw(d_shape, w_shape, padding)
     mod_dyn = get_conv2d_nchw(dyn_batch_shape, w_shape, padding)
 
-    verify_conv2d(
-        mod_dyn, mod_nchw, d_shape, w_shape, sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False
-    )
+    # verify_conv2d(
+    #     mod_dyn, mod_nchw, d_shape, w_shape, sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False
+    # )
 
     for data_dtype, weight_dtype, out_dtype in [
         ("float32", "float32", "float32"),  # 3xtf32
@@ -632,4 +632,5 @@ def test_conv2d_residual_block():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_conv2d()

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -189,7 +189,7 @@ def profile_and_build(
         sm,
         use_3xtf32=use_3xtf32,
         profile_all_alignments=False,
-        profile_all=False,
+        find_first_valid=True,
         use_multiprocessing=False,
         tmp_dir=tmp_dir,
     )

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -350,7 +350,12 @@ def test_dense():
     )
     # 3xtf32
     verify_dense(
-        dense_fp32, M, N, K, data_dtype="float32", weight_dtype="float32",
+        dense_fp32,
+        M,
+        N,
+        K,
+        data_dtype="float32",
+        weight_dtype="float32",
     )
 
 
@@ -377,7 +382,11 @@ def test_dense_dynamic():
         # TVM native fp16 dense (without tensorcore), using fp16 accum, seems to have accuracy issues
         # Use cublas as a reference
         verify_dense(
-            get_dense_with_shape(data_shape, weight_shape), M, N, K, ref_target="cuda -libs=cublas",
+            get_dense_with_shape(data_shape, weight_shape),
+            M,
+            N,
+            K,
+            ref_target="cuda -libs=cublas",
         )
 
     verify_dense(
@@ -623,5 +632,4 @@ def test_conv2d_residual_block():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_conv2d()
+    pytest.main([__file__])

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -350,12 +350,7 @@ def test_dense():
     )
     # 3xtf32
     verify_dense(
-        dense_fp32,
-        M,
-        N,
-        K,
-        data_dtype="float32",
-        weight_dtype="float32",
+        dense_fp32, M, N, K, data_dtype="float32", weight_dtype="float32",
     )
 
 
@@ -382,11 +377,7 @@ def test_dense_dynamic():
         # TVM native fp16 dense (without tensorcore), using fp16 accum, seems to have accuracy issues
         # Use cublas as a reference
         verify_dense(
-            get_dense_with_shape(data_shape, weight_shape),
-            M,
-            N,
-            K,
-            ref_target="cuda -libs=cublas",
+            get_dense_with_shape(data_shape, weight_shape), M, N, K, ref_target="cuda -libs=cublas",
         )
 
     verify_dense(

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -240,6 +240,9 @@ def verify_dense(
 ):
     if not has_cutlass():
         return
+    if sm < 80 and data_dtype == "float32":
+        return
+
     mod = tvm.IRModule.from_expr(func)
     typ = relay.transform.InferType()(mod)["main"].body.checked_type
     out_dtype = typ.dtype
@@ -450,6 +453,8 @@ def verify_conv2d(
     ref_target="cuda",
 ):
     if not has_cutlass():
+        return
+    if sm < 80 and data_dtype == "float32":
         return
 
     mod_nchw = tvm.IRModule.from_expr(expr_nchw)

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -188,6 +188,7 @@ def profile_and_build(
         mod,
         sm,
         use_3xtf32=use_3xtf32,
+        profile_all_alignments=True,
         profile_all=False,
         use_multiprocessing=False,
         tmp_dir=tmp_dir,

--- a/tests/python/contrib/test_cutlass.py
+++ b/tests/python/contrib/test_cutlass.py
@@ -188,7 +188,7 @@ def profile_and_build(
         mod,
         sm,
         use_3xtf32=use_3xtf32,
-        profile_all_alignments=True,
+        profile_all_alignments=False,
         profile_all=False,
         use_multiprocessing=False,
         tmp_dir=tmp_dir,
@@ -531,9 +531,9 @@ def test_conv2d():
     mod_nchw = get_conv2d_nchw(d_shape, w_shape, padding)
     mod_dyn = get_conv2d_nchw(dyn_batch_shape, w_shape, padding)
 
-    # verify_conv2d(
-    #     mod_dyn, mod_nchw, d_shape, w_shape, sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False
-    # )
+    verify_conv2d(
+        mod_dyn, mod_nchw, d_shape, w_shape, sm=80, atol=1e-5, rtol=1e-5, run_benchmark=False
+    )
 
     for data_dtype, weight_dtype, out_dtype in [
         ("float32", "float32", "float32"),  # 3xtf32


### PR DESCRIPTION
When we can use 8-elements alignment for fp16, for example, there is no need to profile smaller alignment variants since `align8` ones are always faster than `align4`, `align2` etc. This should result in 3-4x speedup in tuning time.

Other changes
* Refactored alignment checking to occur before kernels are generated, rather than the current approach of `generate -> reject later`.
* Fix compile error after https://github.com/apache/tvm/pull/9243
* Fix bugs with `sm = 75` 

@comaniac @Laurawly 