### PR TITLE
[Makefile] Fixed error in "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ FORCE:
 # Since the pattern stem is already being used for the directory name,
 # cannot also have it refer to the command passed to cmake.
 # Therefore, explicitly listing out the delegated.
-CMAKE_TARGETS = all runtime vta cpptest crttest
+CMAKE_TARGETS = all runtime vta cpptest crttest clean
 
 define GEN_CMAKE_RULE
 %/$(CMAKE_TARGET): %/CMakeCache.txt FORCE
@@ -174,7 +174,7 @@ jvminstall:
 			-Dcurrent_libdir="$(TVM_BUILD_PATH)" $(JVM_TEST_ARGS))
 
 # Final cleanup rules, delegate to more specific rules.
-clean: cmake_clean cyclean webclean
+clean: $(addsuffix /clean,$(TVM_BUILD_PATH)) cyclean webclean
 
 docs:
 	python3 tests/scripts/ci.py docs


### PR DESCRIPTION
The top-level makefile should delegate `make clean` to the cmake folder of each enabled build, similar to the existing delegation of
`make all` and `make runtime`.
