### PR TITLE
Don't explicitly link libgcc.a into libtvm_runtime.so on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,12 +241,6 @@ if(NOT BUILD_FOR_HEXAGON)
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${CMAKE_DL_LIBS})
 endif()
 
-if(BUILD_FOR_ANDROID)
-  # EmuTLS on Android is in libgcc. Without it linked in, libtvm_runtime.so
-  # won't load on Android due to missing __emutls_XXX symbols.
-  list(APPEND TVM_RUNTIME_LINKER_LIBS "gcc")
-endif()
-
 # add source group
 tvm_file_glob(GLOB_RECURSE GROUP_SOURCE "src/*.cc")
 tvm_file_glob(GLOB_RECURSE GROUP_INCLUDE "src/*.h" "include/*.h")


### PR DESCRIPTION
Setting Android toolchain via `CMAKE_TOOLCHAIN_FILE` also causes necessary flags to be added. Also, newer versions of the Android NDK no longer ship `libgcc.a`, so this takes care of that as well.
