### PR TITLE
Add @slow decorator to run tests on `main`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,21 @@ def init_git() {
   }
 }
 
+def should_skip_slow_tests(pr_number) {
+  withCredentials([string(
+    credentialsId: 'tvm-bot-jenkins-reader',
+    variable: 'GITHUB_TOKEN',
+  )]) {
+    // Exit code of 1 means run slow tests, exit code of 0 means skip slow tests
+    result = sh (
+      returnStatus: true,
+      script: "./tests/scripts/should_run_slow_tests.py --pr '${pr_number}'",
+      label: 'Check if CI should run slow tests',
+    )
+  }
+  return result == 0
+}
+
 def cancel_previous_build() {
   // cancel previous build if it is not on main.
   if (env.BRANCH_NAME != 'main') {
@@ -168,6 +183,7 @@ stage('Sanity Check') {
           label: 'Check for docs only changes',
         )
         skip_ci = should_skip_ci(env.CHANGE_ID)
+        skip_slow_tests = should_skip_slow_tests(env.CHANGE_ID)
         sh (
           script: "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh",
           label: 'Run lint',
@@ -256,6 +272,9 @@ def cpp_unittest(image) {
 }
 
 stage('Build') {
+  environment {
+    SKIP_SLOW_TESTS = "${skip_slow_tests}"
+  }
   parallel 'BUILD: GPU': {
     if (!skip_ci) {
       node('GPUBUILD') {
@@ -286,7 +305,7 @@ stage('Build') {
             ci_setup(ci_cpu)
             // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
             // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-            sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: "Rust build and test")
+            sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
           }
         }
       }
@@ -385,6 +404,9 @@ stage('Build') {
 }
 
 stage('Test') {
+  environment {
+    SKIP_SLOW_TESTS = "${skip_slow_tests}"
+  }
   parallel 'unittest: GPU': {
     if (!skip_ci && is_docs_only_build != 1) {
       node('TensorCore') {
@@ -442,7 +464,7 @@ stage('Test') {
   'unittest: CPU': {
     if (!skip_ci && is_docs_only_build != 1) {
       node('CPU') {
-        ws(per_exec_ws("tvm/ut-python-cpu")) {
+        ws(per_exec_ws('tvm/ut-python-cpu')) {
           try {
             init_git()
             unpack_lib('cpu', tvm_multilib_tsim)
@@ -452,7 +474,7 @@ stage('Test') {
               fsim_test(ci_cpu)
               sh (
                 script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh",
-                label: "Run VTA tests in TSIM",
+                label: 'Run VTA tests in TSIM',
               )
             }
           } finally {

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -84,6 +84,8 @@ from tvm.error import TVMError
 from tvm.relay.op.contrib.ethosn import ethosn_available
 from tvm.relay.op.contrib import cmsisnn
 
+SKIP_SLOW_TESTS = os.getenv("SKIP_SLOW_TESTS", "").lower() in {"true", "1", "yes"}
+
 
 def assert_allclose(actual, desired, rtol=1e-7, atol=1e-7):
     """Version of np.testing.assert_allclose with `atol` and `rtol` fields set
@@ -514,6 +516,17 @@ def _compose(args, decs):
             f = d(f)
         return f
     return decs
+
+
+def slow(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if SKIP_SLOW_TESTS:
+            pytest.skip("Skipping slow test since RUN_SLOW_TESTS environment variables is 'true'")
+        else:
+            fn(*args, **kwargs)
+
+    return wrapper
 
 
 def uses_gpu(*args):

--- a/tests/scripts/should_run_slow_tests.py
+++ b/tests/scripts/should_run_slow_tests.py
@@ -25,6 +25,10 @@ import textwrap
 from urllib import request
 from typing import Dict, Tuple, Any, List, Optional
 
+
+from git_utils import GitHubRepo, parse_remote, git
+
+
 SLOW_TEST_TRIGGERS = [
     "@ci run slow tests",
     "@ci run slow test",
@@ -35,56 +39,12 @@ SLOW_TEST_TRIGGERS = [
 ]
 
 
-class GitHubRepo:
-    def __init__(self, user, repo, token):
-        self.token = token
-        self.user = user
-        self.repo = repo
-        self.base = f"https://api.github.com/repos/{user}/{repo}/"
-
-    def headers(self):
-        return {
-            "Authorization": f"Bearer {self.token}",
-        }
-
-    def get(self, url: str) -> Dict[str, Any]:
-        url = self.base + url
-        print("Requesting", url)
-        req = request.Request(url, headers=self.headers())
-        with request.urlopen(req) as response:
-            response = json.loads(response.read())
-        return response
-
-
-def parse_remote(remote: str) -> Tuple[str, str]:
-    """
-    Get a GitHub (user, repo) pair out of a git remote
-    """
-    if remote.startswith("https://"):
-        # Parse HTTP remote
-        parts = remote.split("/")
-        if len(parts) < 2:
-            raise RuntimeError(f"Unable to parse remote '{remote}'")
-        return parts[-2], parts[-1].replace(".git", "")
-    else:
-        # Parse SSH remote
-        m = re.search(r":(.*)/(.*)\.git", remote)
-        if m is None or len(m.groups()) != 2:
-            raise RuntimeError(f"Unable to parse remote '{remote}'")
-        return m.groups()
-
-
 def check_match(s: str, searches: List[str]) -> Tuple[bool, Optional[str]]:
     for search in searches:
         if search in s:
             return True, search
 
     return False, None
-
-
-def git(command):
-    proc = subprocess.run(["git"] + command, stdout=subprocess.PIPE, check=True)
-    return proc.stdout.decode().strip()
 
 
 def display(long_str: str) -> str:

--- a/tests/scripts/should_run_slow_tests.py
+++ b/tests/scripts/should_run_slow_tests.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import json
+import argparse
+import subprocess
+import re
+import textwrap
+from urllib import request
+from typing import Dict, Tuple, Any, List, Optional
+
+SLOW_TEST_TRIGGERS = [
+    "@ci run slow tests",
+    "@ci run slow test",
+    "@ci run slow",
+    "@ci slow tests",
+    "@ci slow test",
+    "@ci slow",
+]
+
+
+class GitHubRepo:
+    def __init__(self, user, repo, token):
+        self.token = token
+        self.user = user
+        self.repo = repo
+        self.base = f"https://api.github.com/repos/{user}/{repo}/"
+
+    def headers(self):
+        return {
+            "Authorization": f"Bearer {self.token}",
+        }
+
+    def get(self, url: str) -> Dict[str, Any]:
+        url = self.base + url
+        print("Requesting", url)
+        req = request.Request(url, headers=self.headers())
+        with request.urlopen(req) as response:
+            response = json.loads(response.read())
+        return response
+
+
+def parse_remote(remote: str) -> Tuple[str, str]:
+    """
+    Get a GitHub (user, repo) pair out of a git remote
+    """
+    if remote.startswith("https://"):
+        # Parse HTTP remote
+        parts = remote.split("/")
+        if len(parts) < 2:
+            raise RuntimeError(f"Unable to parse remote '{remote}'")
+        return parts[-2], parts[-1].replace(".git", "")
+    else:
+        # Parse SSH remote
+        m = re.search(r":(.*)/(.*)\.git", remote)
+        if m is None or len(m.groups()) != 2:
+            raise RuntimeError(f"Unable to parse remote '{remote}'")
+        return m.groups()
+
+
+def check_match(s: str, searches: List[str]) -> Tuple[bool, Optional[str]]:
+    for search in searches:
+        if search in s:
+            return True, search
+
+    return False, None
+
+
+def git(command):
+    proc = subprocess.run(["git"] + command, stdout=subprocess.PIPE, check=True)
+    return proc.stdout.decode().strip()
+
+
+def display(long_str: str) -> str:
+    return textwrap.indent(long_str, "    ")
+
+
+if __name__ == "__main__":
+    help = "Exits with 1 if CI should run slow tests, 0 otherwise"
+    parser = argparse.ArgumentParser(description=help)
+    parser.add_argument("--pr", required=True)
+    parser.add_argument("--remote", default="origin", help="ssh remote to parse")
+    parser.add_argument(
+        "--pr-body", help="(testing) PR body to use instead of fetching from GitHub"
+    )
+    args = parser.parse_args()
+
+    branch = git(["rev-parse", "--abbrev-ref", "HEAD"])
+
+    # Don't skip slow tests on main or ci-docker-staging
+    skip_branches = {"main", "ci-docker-staging"}
+    if branch in skip_branches:
+        print(f"Branch {branch} is in {skip_branches}, running slow tests")
+        exit(1)
+    print(f"Branch {branch} is not in {skip_branches}, checking last commit...")
+
+    log = git(["log", "--format=%B", "-1"])
+
+    # Check if anything in the last commit's body message matches
+    log_match, reason = check_match(log, SLOW_TEST_TRIGGERS)
+    if log_match:
+        print(f"Matched {reason} in commit message:\n{display(log)}, running slow tests")
+        exit(1)
+
+    print(
+        f"Last commit:\n{display(log)}\ndid not have any of {SLOW_TEST_TRIGGERS}, checking PR body..."
+    )
+
+    if args.pr_body:
+        body = args.pr_body
+    else:
+        remote = git(["config", "--get", f"remote.{args.remote}.url"])
+        user, repo = parse_remote(remote)
+
+        github = GitHubRepo(token=os.environ["GITHUB_TOKEN"], user=user, repo=repo)
+        pr = github.get(f"pulls/{args.pr}")
+        body = pr["body"]
+
+    body_match, reason = check_match(body, SLOW_TEST_TRIGGERS)
+
+    if body_match:
+        print(f"Matched {reason} in PR body:\n{display(body)}, running slow tests")
+        exit(1)
+
+    print(
+        f"PR Body:\n{display(body)}\ndid not have any of {SLOW_TEST_TRIGGERS}, skipping slow tests"
+    )
+    exit(0)


### PR DESCRIPTION
This adds the infrastructure discussed in https://discuss.tvm.apache.org/t/rfc-ci-skip-slow-tests-on-prs/11910, but without affecting any tests. As we investigate reasons behind [slow tests](https://gist.github.com/driazati/e009f09ff44c6bc91c4d95a8e17fd6f1) in CI, this decorator will allow us to move these to run only on `main` and not PRs after checking with all concerned parties.

To run slow tests on a PR, the PR body needs to have `@ci run slow tests` (or similar, see `should_run_slow_tests.py`) in it somewhere. Skipping slow tests is a positive-only check, so they have to be explicitly skipped rather than run (meaning that for local runs no workflow change is necessary, slow tests will run as before)
