### PR TITLE
[microNPU] Refactor type inference data type checks

### DIFF
--- a/src/relay/op/contrib/ethosu/binary_elementwise.cc
+++ b/src/relay/op/contrib/ethosu/binary_elementwise.cc
@@ -152,12 +152,12 @@ bool EthosuBinaryElementwiseRel(const Array<Type>& types, int num_inputs, const 
   CheckDataTypeMatch(reporter, ifm_dtype, ifm2_dtype, operator_name, "ifm", "ifm2", operator_type);
 
   if (operator_type == "ADD" || operator_type == "SUB" || operator_type == "MUL") {
-    std::unordered_set<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8),
-                                                  DataType::Int(16), DataType::Int(32)};
+    std::initializer_list<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8),
+                                                     DataType::Int(16), DataType::Int(32)};
     CheckDataType(reporter, ifm_dtype, allowed_types, operator_name, "ifm", operator_type);
     CheckDataType(reporter, ofm_dtype, allowed_types, operator_name, "ofm", operator_type);
   } else if (operator_type == "MIN" || operator_type == "MAX") {
-    std::unordered_set<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8)};
+    std::initializer_list<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8)};
     CheckDataType(reporter, ifm_dtype, allowed_types, operator_name, "ifm", operator_type);
     CheckDataTypeMatch(reporter, ifm_dtype, ofm_dtype, operator_name, "ifm", "ofm", operator_type);
   } else if (operator_type == "SHR") {

--- a/src/relay/op/contrib/ethosu/binary_elementwise.cc
+++ b/src/relay/op/contrib/ethosu/binary_elementwise.cc
@@ -152,12 +152,12 @@ bool EthosuBinaryElementwiseRel(const Array<Type>& types, int num_inputs, const 
   CheckDataTypeMatch(reporter, ifm_dtype, ifm2_dtype, operator_name, "ifm", "ifm2", operator_type);
 
   if (operator_type == "ADD" || operator_type == "SUB" || operator_type == "MUL") {
-    std::initializer_list<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8),
-                                                     DataType::Int(16), DataType::Int(32)};
+    auto allowed_types = {DataType::Int(8), DataType::UInt(8), DataType::Int(16),
+                          DataType::Int(32)};
     CheckDataType(reporter, ifm_dtype, allowed_types, operator_name, "ifm", operator_type);
     CheckDataType(reporter, ofm_dtype, allowed_types, operator_name, "ofm", operator_type);
   } else if (operator_type == "MIN" || operator_type == "MAX") {
-    std::initializer_list<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8)};
+    auto allowed_types = {DataType::Int(8), DataType::UInt(8)};
     CheckDataType(reporter, ifm_dtype, allowed_types, operator_name, "ifm", operator_type);
     CheckDataTypeMatch(reporter, ifm_dtype, ofm_dtype, operator_name, "ifm", "ofm", operator_type);
   } else if (operator_type == "SHR") {

--- a/src/relay/op/contrib/ethosu/binary_elementwise.cc
+++ b/src/relay/op/contrib/ethosu/binary_elementwise.cc
@@ -143,98 +143,34 @@ bool EthosuBinaryElementwiseRel(const Array<Type>& types, int num_inputs, const 
   const auto* param = attrs.as<EthosuBinaryElementwiseAttrs>();
   ICHECK(param != nullptr) << "EthosuBinaryElementwiseAttrs cannot be nullptr.";
 
-  String operator_type = param->operator_type;
-  auto ifm_dtype = ifm->dtype;
-  auto ifm2_dtype = ifm2->dtype;
-  DataType ofm_dtype;
+  const String operator_name = "ethosu_binary_elementwise";
+  const String operator_type = param->operator_type;
+  const DataType ifm_dtype = ifm->dtype;
+  const DataType ifm2_dtype = ifm2->dtype;
+  const DataType ofm_dtype = DataTypeFromString(param->ofm_dtype);
 
-  if (param->ofm_dtype == "int8") {
-    ofm_dtype = DataType::Int(8);
-  } else if (param->ofm_dtype == "uint8") {
-    ofm_dtype = DataType::UInt(8);
-  } else if (param->ofm_dtype == "int16") {
-    ofm_dtype = DataType::Int(16);
-  } else if (param->ofm_dtype == "int32") {
-    ofm_dtype = DataType::Int(32);
-  }
-
-  if (ifm_dtype != ifm2_dtype) {
-    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: expected ethosu_binary_elementwise "
-                                     << "type for ifm2 be the same of ifm but was " << ifm2_dtype
-                                     << " instead of " << ifm_dtype);
-    return false;
-  }
+  CheckDataTypeMatch(reporter, ifm_dtype, ifm2_dtype, operator_name, "ifm", "ifm2", operator_type);
 
   if (operator_type == "ADD" || operator_type == "SUB" || operator_type == "MUL") {
-    if (ifm_dtype != DataType::UInt(8) && ifm_dtype != DataType::Int(8) &&
-        ifm_dtype != DataType::Int(16) && ifm_dtype != DataType::Int(32)) {
-      reporter->GetDiagCtx().EmitFatal(
-          Diagnostic::Error(reporter->GetSpan())
-          << "Invalid operator: expected ethosu_binary_elementwise " << operator_type
-          << " type(uint8), type(int8), type(int16) or type(int32) for ifm but was " << ifm_dtype);
-      return false;
-    }
-    if (ofm_dtype != DataType::UInt(8) && ofm_dtype != DataType::Int(8) &&
-        ofm_dtype != DataType::Int(16) && ofm_dtype != DataType::Int(32)) {
-      reporter->GetDiagCtx().EmitFatal(
-          Diagnostic::Error(reporter->GetSpan())
-          << "Invalid operator: expected ethosu_binary_elementwise " << operator_type
-          << " type(uint8), type(int8), type(int16) or type(int32) for ofm but was " << ofm_dtype);
-      return false;
-    }
+    std::unordered_set<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8),
+                                                  DataType::Int(16), DataType::Int(32)};
+    CheckDataType(reporter, ifm_dtype, allowed_types, operator_name, "ifm", operator_type);
+    CheckDataType(reporter, ofm_dtype, allowed_types, operator_name, "ofm", operator_type);
   } else if (operator_type == "MIN" || operator_type == "MAX") {
-    if (ifm_dtype != DataType::UInt(8) && ifm_dtype != DataType::Int(8)) {
-      reporter->GetDiagCtx().EmitFatal(
-          Diagnostic::Error(reporter->GetSpan())
-          << "Invalid operator: expected ethosu_binary_elementwise " << operator_type
-          << " type(uint8) or type(int8) for ifm but was " << ifm_dtype);
-      return false;
-    }
-    if (ifm_dtype != ofm_dtype) {
-      reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                       << "Invalid operator: expected ethosu_binary_elementwise "
-                                       << operator_type
-                                       << " type for ofm be the same of ifm but was " << ofm_dtype
-                                       << " instead of " << ifm_dtype);
-      return false;
-    }
+    std::unordered_set<DataType> allowed_types = {DataType::Int(8), DataType::UInt(8)};
+    CheckDataType(reporter, ifm_dtype, allowed_types, operator_name, "ifm", operator_type);
+    CheckDataTypeMatch(reporter, ifm_dtype, ofm_dtype, operator_name, "ifm", "ofm", operator_type);
   } else if (operator_type == "SHR") {
-    if (ifm_dtype != DataType::Int(32)) {
-      reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                       << "Invalid operator: expected ethosu_binary_elementwise "
-                                       << operator_type << " type(int32) for ifm but was "
-                                       << ifm_dtype);
-      return false;
-    }
-    if (ofm_dtype != DataType::UInt(8) && ofm_dtype != DataType::Int(8) &&
-        ofm_dtype != DataType::Int(32)) {
-      reporter->GetDiagCtx().EmitFatal(
-          Diagnostic::Error(reporter->GetSpan())
-          << "Invalid operator: expected ethosu_binary_elementwise " << operator_type
-          << " type(uint8) or type(int8) or type(int32) for ofm but was " << ofm_dtype);
-      return false;
-    }
+    CheckDataType(reporter, ifm_dtype, {DataType::Int(32)}, operator_name, "ifm", operator_type);
+    CheckDataType(reporter, ofm_dtype, {DataType::UInt(8), DataType::Int(8), DataType::Int(32)},
+                  operator_name, "ofm", operator_type);
   } else if (operator_type == "SHL") {
-    if (ifm_dtype != DataType::Int(32)) {
-      reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                       << "Invalid operator: expected ethosu_binary_elementwise "
-                                       << operator_type << " type(int32) for ifm but was "
-                                       << ifm_dtype);
-
-      return false;
-    }
-    if (ofm_dtype != DataType::Int(32)) {
-      reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                       << "Invalid operator: expected ethosu_binary_elementwise "
-                                       << operator_type << " type(int32) for ofm but was "
-                                       << ofm_dtype);
-      return false;
-    }
+    CheckDataType(reporter, ifm_dtype, {DataType::Int(32)}, operator_name, "ifm", operator_type);
+    CheckDataType(reporter, ofm_dtype, {DataType::Int(32)}, operator_name, "ofm", operator_type);
   } else {
     reporter->GetDiagCtx().EmitFatal(
         Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_binary_elementwise 'ADD' or 'SUB' or 'MUL' or "
+        << "Invalid operator: expected " << operator_name << " 'ADD' or 'SUB' or 'MUL' or "
         << "'MIN' or 'MAX' or 'SHR' or 'SHL' for operator_type but was " << param->operator_type);
     return false;
   }

--- a/src/relay/op/contrib/ethosu/common.cc
+++ b/src/relay/op/contrib/ethosu/common.cc
@@ -24,6 +24,9 @@
 
 #include "common.h"
 
+#include <sstream>
+#include <unordered_set>
+
 #include "../../op_common.h"
 
 namespace tvm {
@@ -90,6 +93,56 @@ Array<IndexExpr> EthosuInferUpscaledInput(Array<IndexExpr> ifm_shape, String ifm
   }
 
   return new_ifm_shape;
+}
+
+DataType DataTypeFromString(const String& dtype) {
+  DLDataType dl_dtype = tvm::runtime::String2DLDataType(dtype);
+  return DataType(dl_dtype);
+}
+
+void CheckDataType(const TypeReporter& reporter, const DataType& data_type,
+                   const std::unordered_set<DataType>& allowed_data_types,
+                   const String& operator_name, const String& tensor_name,
+                   const String& operator_type) {
+  if (allowed_data_types.find(data_type) != allowed_data_types.end()) {
+    return;
+  }
+
+  std::ostringstream message;
+  message << "Invalid operator: expected " << operator_name << " ";
+  if (operator_type != "") {
+    message << operator_type << " ";
+  }
+  message << "to have type in {";
+  for (auto it = allowed_data_types.begin(); it != allowed_data_types.end(); ++it) {
+    message << *it;
+    if (std::next(it) != allowed_data_types.end()) {
+      message << ", ";
+    }
+  }
+  message << "}";
+  message << " for " << tensor_name << " but was " << data_type << ".";
+
+  reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan()) << message.str());
+}
+
+void CheckDataTypeMatch(const TypeReporter& reporter, const DataType& data_type,
+                        const DataType& data_type2, const String& operator_name,
+                        const String& tensor_name, const String& tensor_name2,
+                        const String& operator_type) {
+  if (data_type == data_type2) {
+    return;
+  }
+
+  std::ostringstream message;
+  message << "Invalid operator: expected " << operator_name << " ";
+  if (operator_type != " ") {
+    message << operator_type << " ";
+  }
+  message << "data types for " << tensor_name << " and " << tensor_name2 << " to match, but was "
+          << data_type << " and " << data_type2;
+
+  reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan()) << message.str());
 }
 
 }  // namespace ethosu

--- a/src/relay/op/contrib/ethosu/common.cc
+++ b/src/relay/op/contrib/ethosu/common.cc
@@ -25,7 +25,6 @@
 #include "common.h"
 
 #include <sstream>
-#include <unordered_set>
 
 #include "../../op_common.h"
 

--- a/src/relay/op/contrib/ethosu/common.cc
+++ b/src/relay/op/contrib/ethosu/common.cc
@@ -101,11 +101,13 @@ DataType DataTypeFromString(const String& dtype) {
 }
 
 void CheckDataType(const TypeReporter& reporter, const DataType& data_type,
-                   const std::unordered_set<DataType>& allowed_data_types,
+                   const std::initializer_list<DataType>& allowed_data_types,
                    const String& operator_name, const String& tensor_name,
                    const String& operator_type) {
-  if (allowed_data_types.find(data_type) != allowed_data_types.end()) {
-    return;
+  for (const auto& i : allowed_data_types) {
+    if (data_type == i) {
+      return;
+    }
   }
 
   std::ostringstream message;
@@ -126,6 +128,33 @@ void CheckDataType(const TypeReporter& reporter, const DataType& data_type,
   reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan()) << message.str());
 }
 
+void CheckUpscaleMethod(const TypeReporter& reporter, const String& upscale_method,
+                        const std::initializer_list<String>& allowed_upscale_methods,
+                        const String& operator_name, const String& operator_type) {
+  for (const auto& i : allowed_upscale_methods) {
+    if (upscale_method == i) {
+      return;
+    }
+  }
+
+  std::ostringstream message;
+  message << "Invalid operator: expected " << operator_name << " ";
+  if (operator_type != "") {
+    message << operator_type << " ";
+  }
+  message << "to have upscale method in {";
+  for (auto it = allowed_upscale_methods.begin(); it != allowed_upscale_methods.end(); ++it) {
+    message << *it;
+    if (std::next(it) != allowed_upscale_methods.end()) {
+      message << ", ";
+    }
+  }
+  message << "}";
+  message << " but was " << upscale_method << ".";
+
+  reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan()) << message.str());
+}
+
 void CheckDataTypeMatch(const TypeReporter& reporter, const DataType& data_type,
                         const DataType& data_type2, const String& operator_name,
                         const String& tensor_name, const String& tensor_name2,
@@ -136,7 +165,7 @@ void CheckDataTypeMatch(const TypeReporter& reporter, const DataType& data_type,
 
   std::ostringstream message;
   message << "Invalid operator: expected " << operator_name << " ";
-  if (operator_type != " ") {
+  if (operator_type != "") {
     message << operator_type << " ";
   }
   message << "data types for " << tensor_name << " and " << tensor_name2 << " to match, but was "

--- a/src/relay/op/contrib/ethosu/common.h
+++ b/src/relay/op/contrib/ethosu/common.h
@@ -27,6 +27,8 @@
 
 #include <tvm/relay/expr.h>
 
+#include <unordered_set>
+
 namespace tvm {
 namespace relay {
 namespace op {
@@ -64,6 +66,40 @@ Array<IndexExpr> EthosuInferKernelOutput(Array<IndexExpr> ifm_shape, String ifm_
  * \param ifm_layout The layout of the Input Feature Map.
  */
 Array<IndexExpr> EthosuInferUpscaledInput(Array<IndexExpr> ifm_shape, String ifm_layout);
+
+/*! \brief Get data type from string representation.
+ * \param dtype Data type in lower case format followed by number of bits e.g. "int8".
+ */
+DataType DataTypeFromString(const String& dtype);
+
+/*! \brief Check the data type for a given input matches one given in allowed_data_types. Raise a
+ * type inference error if not.
+ * \param reporter The infer type reporter.
+ * \param data_type The data ntype to check.
+ * \param allowed_data_types An unordered set of allowed data types.
+ * \param operator_name The name of the operator to report.
+ * \param tensor_name The name of the tensor to report e.g. "ifm", "ofm".
+ * \param operator_type The type of the operator to report e.g. "ADD" for binary_elementwise.
+ */
+void CheckDataType(const TypeReporter& reporter, const DataType& data_type,
+                   const std::unordered_set<DataType>& allowed_data_types,
+                   const String& operator_name, const String& tensor_name,
+                   const String& operator_type = "");
+
+/*! \brief Check the data type matches that of the second data type provided. Raise a type inference
+ * error if not.
+ * \param reporter The infer type reporter.
+ * \param data_type The data type to check.
+ * \param data_type2 The second data type to check.
+ * \param operator_name The name of the operator to report.
+ * \param tensor_name The name of the tensor to report e.g. "ifm", "ofm".
+ * \param tensor_name2 The name of the second tensor to report e.g. "ifm2".
+ * \param operator_type The type of the operator to report e.g. "ADD" for binary_elementwise.
+ */
+void CheckDataTypeMatch(const TypeReporter& reporter, const DataType& data_type,
+                        const DataType& data_type2, const String& operator_name,
+                        const String& tensor_name, const String& tensor_name2,
+                        const String& operator_type = "");
 
 }  // namespace ethosu
 }  // namespace contrib

--- a/src/relay/op/contrib/ethosu/common.h
+++ b/src/relay/op/contrib/ethosu/common.h
@@ -75,16 +75,28 @@ DataType DataTypeFromString(const String& dtype);
 /*! \brief Check the data type for a given input matches one given in allowed_data_types. Raise a
  * type inference error if not.
  * \param reporter The infer type reporter.
- * \param data_type The data ntype to check.
- * \param allowed_data_types An unordered set of allowed data types.
+ * \param data_type The data type to check.
+ * \param allowed_data_types An initializer list of allowed data types.
  * \param operator_name The name of the operator to report.
  * \param tensor_name The name of the tensor to report e.g. "ifm", "ofm".
  * \param operator_type The type of the operator to report e.g. "ADD" for binary_elementwise.
  */
 void CheckDataType(const TypeReporter& reporter, const DataType& data_type,
-                   const std::unordered_set<DataType>& allowed_data_types,
+                   const std::initializer_list<DataType>& allowed_data_types,
                    const String& operator_name, const String& tensor_name,
                    const String& operator_type = "");
+
+/*! \brief Check the upscale method matches one given in allowed_upscale_methods. Raise a type
+ * inference error if not.
+ * \param reporter The infer type reporter.
+ * \param upscale_method The upscale method string to check.
+ * \param allowed_upscale_methods An initializer list of allowed upscale methods.
+ * \param operator_name The name of the operator to report.
+ * \param operator_type The type of the operator to report e.g. "ADD" for binary_elementwise.
+ */
+void CheckUpscaleMethod(const TypeReporter& reporter, const String& upscale_method,
+                        const std::initializer_list<String>& allowed_upscale_methods,
+                        const String& operator_name, const String& operator_type = "");
 
 /*! \brief Check the data type matches that of the second data type provided. Raise a type inference
  * error if not.

--- a/src/relay/op/contrib/ethosu/common.h
+++ b/src/relay/op/contrib/ethosu/common.h
@@ -27,8 +27,6 @@
 
 #include <tvm/relay/expr.h>
 
-#include <unordered_set>
-
 namespace tvm {
 namespace relay {
 namespace op {

--- a/src/relay/op/contrib/ethosu/convolution.cc
+++ b/src/relay/op/contrib/ethosu/convolution.cc
@@ -131,28 +131,12 @@ bool EthosuConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attr
   if (ifm == nullptr || weight == nullptr) return false;
   const auto* param = attrs.as<EthosuConv2DAttrs>();
   CHECK(param != nullptr) << "EthosuConv2DAttrs cannot be nullptr.";
+  const String operator_name = "ethosu_conv2d";
 
-  if (ifm->dtype != DataType::UInt(8) && ifm->dtype != DataType::Int(8)) {
-    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: expected ethosu_conv2d input data type "
-                                     << "of type(uint8) or type(int8) but was " << ifm->dtype);
-    return false;
-  }
-
-  if (weight->dtype != DataType::UInt(8) && weight->dtype != DataType::Int(8)) {
-    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: expected ethosu_conv2d weight data type "
-                                     << "of type(uint8) or type(int8) but was " << weight->dtype);
-    return false;
-  }
-
-  if (scale_bias->dtype != DataType::UInt(8)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_conv2d scale bias data type "
-        << "of type(uint8) but was " << scale_bias->dtype);
-    return false;
-  }
+  CheckDataType(reporter, ifm->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm");
+  CheckDataType(reporter, weight->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name,
+                "weight");
+  CheckDataType(reporter, scale_bias->dtype, {DataType::UInt(8)}, operator_name, "scale bias");
 
   const std::unordered_set<std::string> upscale_methods = {"NONE", "ZEROS", "NEAREST"};
   if (upscale_methods.find(param->upscale) == upscale_methods.end()) {

--- a/src/relay/op/contrib/ethosu/convolution.cc
+++ b/src/relay/op/contrib/ethosu/convolution.cc
@@ -138,14 +138,7 @@ bool EthosuConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attr
                 "weight");
   CheckDataType(reporter, scale_bias->dtype, {DataType::UInt(8)}, operator_name, "scale bias");
 
-  const std::unordered_set<std::string> upscale_methods = {"NONE", "ZEROS", "NEAREST"};
-  if (upscale_methods.find(param->upscale) == upscale_methods.end()) {
-    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: Expected upsample method to be 'NONE', "
-                                        "'ZEROS' or 'NEAREST' but got "
-                                     << param->upscale);
-    return false;
-  }
+  CheckUpscaleMethod(reporter, param->upscale, {"NONE", "ZEROS", "NEAREST"}, operator_name);
 
   // The scale_bias should be provided as a tensor of size {ofm_channels, 10}
   reporter->Assign(types[2], TensorType({weight->shape[0], 10}, DataType::UInt(8)));

--- a/src/relay/op/contrib/ethosu/depthwise.cc
+++ b/src/relay/op/contrib/ethosu/depthwise.cc
@@ -144,8 +144,7 @@ bool EthosuDepthwiseConv2DRel(const Array<Type>& types, int num_inputs, const At
   CheckDataType(reporter, scale_bias->dtype, {DataType::UInt(8)}, operator_name, "scale bias");
 
   DataType ofm_dtype = DataTypeFromString(param->ofm_dtype);
-  std::initializer_list<DataType> ofm_dtypes = {DataType::UInt(8), DataType::Int(8),
-                                                DataType::Int(16), DataType::Int(32)};
+  auto ofm_dtypes = {DataType::UInt(8), DataType::Int(8), DataType::Int(16), DataType::Int(32)};
   CheckDataType(reporter, ofm_dtype, ofm_dtypes, operator_name, "ofm");
 
   // Collect the ifm, weight and ofm tensors for using in the inference function

--- a/src/relay/op/contrib/ethosu/depthwise.cc
+++ b/src/relay/op/contrib/ethosu/depthwise.cc
@@ -136,50 +136,17 @@ bool EthosuDepthwiseConv2DRel(const Array<Type>& types, int num_inputs, const At
   const auto* param = attrs.as<EthosuDepthwiseConv2DAttrs>();
   ICHECK(param != nullptr) << "EthosuDepthwiseConv2DAttrs cannot be nullptr.";
 
-  DataType ofm_dtype;
+  const String operator_name = "ethosu_depthwise_conv2d";
 
-  if (param->ofm_dtype == "int8") {
-    ofm_dtype = DataType::Int(8);
-  } else if (param->ofm_dtype == "uint8") {
-    ofm_dtype = DataType::UInt(8);
-  } else if (param->ofm_dtype == "int16") {
-    ofm_dtype = DataType::Int(16);
-  } else if (param->ofm_dtype == "int32") {
-    ofm_dtype = DataType::Int(32);
-  }
+  CheckDataType(reporter, ifm->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm");
+  CheckDataType(reporter, weight->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name,
+                "weight");
+  CheckDataType(reporter, scale_bias->dtype, {DataType::UInt(8)}, operator_name, "scale bias");
 
-  if (ifm->dtype != DataType::UInt(8) && ifm->dtype != DataType::Int(8)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_depthwise_conv2d input data type "
-        << "of type(uint8) or type(int8) but was " << ifm->dtype);
-    return false;
-  }
-
-  if (weight->dtype != DataType::UInt(8) && weight->dtype != DataType::Int(8)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_depthwise_conv2d weight data type "
-        << "of type(uint8) or type(int8) but was " << weight->dtype);
-    return false;
-  }
-
-  if (scale_bias->dtype != DataType::UInt(8)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_depthwise_conv2d scale bias data type "
-        << "of type(uint8) but was " << scale_bias->dtype);
-    return false;
-  }
-
-  if (ofm_dtype != DataType::UInt(8) && ofm_dtype != DataType::Int(8) &&
-      ofm_dtype != DataType::Int(16) && ofm_dtype != DataType::Int(32)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_depthwise_conv2d output data type "
-        << " type(uint8), type(int8), type(int16) or type(int32) for ofm but was " << ofm_dtype);
-    return false;
-  }
+  DataType ofm_dtype = DataTypeFromString(param->ofm_dtype);
+  std::unordered_set<DataType> ofm_dtypes = {DataType::UInt(8), DataType::Int(8), DataType::Int(16),
+                                             DataType::Int(32)};
+  CheckDataType(reporter, ofm_dtype, ofm_dtypes, operator_name, "ofm");
 
   // Collect the ifm, weight and ofm tensors for using in the inference function
   Array<Type> tensor_types = {types[0], types[1], types[4]};

--- a/src/relay/op/contrib/ethosu/depthwise.cc
+++ b/src/relay/op/contrib/ethosu/depthwise.cc
@@ -144,8 +144,8 @@ bool EthosuDepthwiseConv2DRel(const Array<Type>& types, int num_inputs, const At
   CheckDataType(reporter, scale_bias->dtype, {DataType::UInt(8)}, operator_name, "scale bias");
 
   DataType ofm_dtype = DataTypeFromString(param->ofm_dtype);
-  std::unordered_set<DataType> ofm_dtypes = {DataType::UInt(8), DataType::Int(8), DataType::Int(16),
-                                             DataType::Int(32)};
+  std::initializer_list<DataType> ofm_dtypes = {DataType::UInt(8), DataType::Int(8),
+                                                DataType::Int(16), DataType::Int(32)};
   CheckDataType(reporter, ofm_dtype, ofm_dtypes, operator_name, "ofm");
 
   // Collect the ifm, weight and ofm tensors for using in the inference function

--- a/src/relay/op/contrib/ethosu/identity.cc
+++ b/src/relay/op/contrib/ethosu/identity.cc
@@ -69,15 +69,11 @@ bool EthosuIdentityRel(const Array<Type>& types, int num_inputs, const Attrs& at
   if (ifm == nullptr) return false;
 
   const auto* param = attrs.as<EthosuIdentityAttrs>();
-
   ICHECK(param != nullptr) << "EthosuIdentityAttrs cannot be nullptr.";
 
-  if (ifm->dtype != DataType::UInt(8) && ifm->dtype != DataType::Int(8)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: Expected type(uint8) or type(int8) for ifm but was " << ifm->dtype);
-    return false;
-  }
+  const String operator_name = "ethosu_identity";
+
+  CheckDataType(reporter, ifm->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm");
 
   if (ifm->shape.size() > 4) {
     reporter->GetDiagCtx().EmitFatal(

--- a/src/relay/op/contrib/ethosu/pooling.cc
+++ b/src/relay/op/contrib/ethosu/pooling.cc
@@ -135,14 +135,7 @@ bool EthosuPoolingRel(const Array<Type>& types, int num_inputs, const Attrs& att
   CheckDataType(reporter, ifm->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm",
                 param->pooling_type);
 
-  const std::unordered_set<std::string> upscale_methods = {"NONE", "ZEROS", "NEAREST"};
-  if (upscale_methods.find(param->upscale) == upscale_methods.end()) {
-    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: Expected upsample method to be 'NONE', "
-                                        "'ZEROS' or 'NEAREST' but got "
-                                     << param->upscale);
-    return false;
-  }
+  CheckUpscaleMethod(reporter, param->upscale, {"NONE", "ZEROS", "NEAREST"}, operator_name);
 
   Array<IndexExpr> ifm_shape = ifm->shape;
   if (param->upscale != "NONE") {

--- a/src/relay/op/contrib/ethosu/pooling.cc
+++ b/src/relay/op/contrib/ethosu/pooling.cc
@@ -123,21 +123,17 @@ bool EthosuPoolingRel(const Array<Type>& types, int num_inputs, const Attrs& att
   const auto* param = attrs.as<EthosuPoolingAttrs>();
   ICHECK(param != nullptr) << "EthosuPoolingAttrs cannot be nullptr.";
 
+  const String operator_name = "ethosu_pooling";
+
   if (param->pooling_type != "AVG" && param->pooling_type != "MAX") {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected pooling_type 'AVG' or 'MAX' but was "
-        << param->pooling_type);
+    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
+                                     << "Invalid operator: expected " << operator_name
+                                     << " type 'AVG' or 'MAX' but was " << param->pooling_type);
     return false;
   }
 
-  if (ifm->dtype != DataType::UInt(8) && ifm->dtype != DataType::Int(8)) {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: Expected pool type(uint8) or type(int8) for ifm but was "
-        << ifm->dtype);
-    return false;
-  }
+  CheckDataType(reporter, ifm->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm",
+                param->pooling_type);
 
   const std::unordered_set<std::string> upscale_methods = {"NONE", "ZEROS", "NEAREST"};
   if (upscale_methods.find(param->upscale) == upscale_methods.end()) {

--- a/src/relay/op/contrib/ethosu/unary_elementwise.cc
+++ b/src/relay/op/contrib/ethosu/unary_elementwise.cc
@@ -104,30 +104,22 @@ bool EthosuUnaryElementwiseRel(const Array<Type>& types, int num_inputs, const A
   const auto* param = attrs.as<EthosuUnaryElementwiseAttrs>();
   CHECK(param != nullptr) << "EthosuUnaryElementwiseAttrs cannot be nullptr.";
 
-  String operator_type = param->operator_type;
+  const String operator_name = "ethosu_unary_elementwise";
+  const String operator_type = param->operator_type;
   if (operator_type != "ABS" && operator_type != "CLZ") {
     reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: expected ethosu_unary_elementwise 'ABS' "
-                                        "or 'CLZ' for operator_type but was"
+                                     << "Invalid operator: expected << " << operator_name
+                                     << "  'ABS' or 'CLZ' for operator_type but was"
                                      << operator_type);
     return false;
   }
 
-  auto ifm_dtype = ifm->dtype;
-  if (ifm_dtype != DataType::UInt(8) && ifm_dtype != DataType::Int(8) && operator_type == "ABS") {
-    reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
-                                     << "Invalid operator: expected ethosu_unary_elementwise "
-                                     << operator_type << "input data type "
-                                     << "of type(uint8) or type(int8) but was " << ifm_dtype);
-    return false;
-  }
-
-  if (ifm_dtype != DataType::Int(32) && operator_type == "CLZ") {
-    reporter->GetDiagCtx().EmitFatal(
-        Diagnostic::Error(reporter->GetSpan())
-        << "Invalid operator: expected ethosu_unary_elementwise CLZ input data type "
-        << "of type(int32) but was " << ifm_dtype);
-    return false;
+  const DataType ifm_dtype = ifm->dtype;
+  if (operator_type == "CLZ") {
+    CheckDataType(reporter, ifm_dtype, {DataType::Int(32)}, operator_name, "ifm", operator_type);
+  } else {
+    CheckDataType(reporter, ifm_dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm",
+                  operator_type);
   }
 
   // Assign ofm type


### PR DESCRIPTION
Aims to improve readability, extensibility and error message unification for data type checks across NPU operators.

A follow up for the comments in #9576.

cc @ekalda @manupa-arm @NicolaLancellotti @mbaret @dchauhan-arm @jacobbohlin 
