### PR TITLE
Document missing qnn operators

### DIFF
--- a/docs/reference/langref/relay_op.rst
+++ b/docs/reference/langref/relay_op.rst
@@ -231,5 +231,18 @@ This level supports dialect operators.
 .. autosummary::
    :nosignatures:
 
-   tvm.relay.qnn.op.requantize
+   tvm.relay.qnn.op.add
+   tvm.relay.qnn.op.batch_matmul
+   tvm.relay.qnn.op.concatenate
    tvm.relay.qnn.op.conv2d
+   tvm.relay.qnn.op.conv2d_transpose
+   tvm.relay.qnn.op.dense
+   tvm.relay.qnn.op.dequantize
+   tvm.relay.qnn.op.mul
+   tvm.relay.qnn.op.quantize
+   tvm.relay.qnn.op.requantize
+   tvm.relay.qnn.op.rsqrt
+   tvm.relay.qnn.op.simulated_dequantize
+   tvm.relay.qnn.op.simulated_quantize
+   tvm.relay.qnn.op.subtract
+   tvm.relay.qnn.op.transpose_conv2d


### PR DESCRIPTION
The following qnn operators were missing from the relay documentation. For the future , if new relay operators are added can they be documented here. 

regards
Ramana