### PR TITLE
[Relay] fix incorrect binding of Lets in ANF conversion

### DIFF
--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -223,6 +223,17 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
     bool not_included = include_set_ && include_set_->find(orig) == include_set_->end();
     if (!v.defined() && not_included) {
       return annotated_expr;
+    } else if (const LetNode* let = AsIgnoringOnDevice<LetNode>(now)) {
+      // Instead of making a nested binding "let var = (let x = ...; bindings...; body)", we push
+      // the inner bindings into the outer scope and bind body to var, giving
+      // "let x = ...; bindings...; let var = body;" as the resulting bindings.
+      Expr e = GetRef<Expr>(let);
+      while (const LetNode* inner_let = AsIgnoringOnDevice<LetNode>(e)) {
+        GetScope(orig)->let_list->Push(inner_let->var, inner_let->value);
+        e = inner_let->body;
+      }
+      Expr annotated_body = MaybeOnDeviceFixed(e, GetVirtualDevice(orig));
+      return GetScope(orig)->let_list->Push(var, annotated_body);
     } else {
       return GetScope(orig)->let_list->Push(var, annotated_expr);
     }

--- a/tests/python/relay/test_pass_to_a_normal_form.py
+++ b/tests/python/relay/test_pass_to_a_normal_form.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from telnetlib import IP
 import numpy as np
 import tvm
 from tvm import te
@@ -92,6 +93,25 @@ def test_if():
     expected_output = relay.Let(c, cond, expected_output)
     expected_output = run_opt_pass(expected_output, transform.InferType())
     assert tvm.ir.structural_equal(anf, expected_output)
+
+
+def test_let_as_subexpr():
+    x = relay.Var("x", relay.IncompleteType())
+    c = relay.const(1)
+    l = relay.Let(x, c + c, x)
+    body = l * l
+
+    anf = run_opt_pass(body, [transform.ToANormalForm(), transform.InferType()])
+
+    v0 = relay.Var("v0", relay.IncompleteType())
+    v1 = relay.Var("v1", relay.IncompleteType())
+    v2 = relay.Var("v2", relay.IncompleteType())
+    expected_output = relay.Let(
+        v0, c, relay.Let(x, v0 + v0, relay.Let(v1, x, relay.Let(v2, v1 * v1, v2)))
+    )
+    expected_output = run_opt_pass(expected_output, transform.InferType())
+
+    tvm.ir.assert_structural_equal(anf, expected_output)
 
 
 # make sure we dont infinite loop.

--- a/tests/python/relay/test_pass_to_a_normal_form.py
+++ b/tests/python/relay/test_pass_to_a_normal_form.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from telnetlib import IP
+import pytest
 import numpy as np
 import tvm
 from tvm import te
@@ -218,12 +218,4 @@ def test_gradient_if():
 
 
 if __name__ == "__main__":
-    test_explicit_bound()
-    test_order()
-    test_if()
-    test_recursion()
-    test_ref()
-    test_let()
-    test_nat_add()
-    test_function()
-    test_gradient_if()
+    pytest.main([__file__])


### PR DESCRIPTION
Previously, ANF conversion would bind Let expressions directly as the value of a fresh Let binding, breaking atomicity. This PR pushes the bindings of the inner Let into the outer scope (where the fresh Let binding would be pushed), and binds the body of the inner Let to the fresh variable instead.

Example ANF IR before this change:
```
let %x = (
  let %y = 1;
  let %z = %y * %y;
  %z
);
%x
```

ANF IR after this change:
```
let %y = 1;
let %z = %y * %y;
let %x = %z;
%x
```

cc @mbs-octoml 
