### PR TITLE
Upgrade tensorflow to version to 2.6.x

### DIFF
--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -21,6 +21,6 @@ set -u
 set -o pipefail
 
 pip3 install \
-    "h5py<3.0" \
-    keras==2.4.3 \
-    tensorflow==2.4.2
+    "h5py==3.1.0" \
+    keras==2.6 \
+    tensorflow==2.6.2

--- a/docker/install/ubuntu_install_vitis_ai_packages_ci.sh
+++ b/docker/install/ubuntu_install_vitis_ai_packages_ci.sh
@@ -23,7 +23,7 @@ set -o pipefail
 export PYXIR_HOME=/opt/pyxir
 mkdir "$PYXIR_HOME"
 
-pip3 install progressbar h5py==2.10.0
+pip3 install progressbar
 
 git clone --recursive --branch v0.3.1 --depth 1 https://github.com/Xilinx/pyxir.git "${PYXIR_HOME}"
 cd "${PYXIR_HOME}" && python3 setup.py install


### PR DESCRIPTION
Upgrade the following versions:
keras - from 2.4.3 to 2.6
tensorflow - from 2.4.2 to 2.6.2
h5py - from version < 3.0 to version 3.1.0

cc @areusch @leandron @Mousius @gromero for reviews

Co-authored-by:  Chris Sidebottom Chris.Sidebottom@arm.com