### PR TITLE
[PyTorch] Fix rsub type

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1972,10 +1972,7 @@ class PyTorchOpConverter:
             return self.tensor_array_stack(inputs, input_types)
 
     def rsub(self, inputs, input_types):
-        data0, data1 = self.pytorch_promote_types(inputs[:2], input_types[:2])
-
-        # TODO (t-vi): should this also be part of the type promotion?
-        alpha = _expr.const(float(inputs[2]))
+        data0, data1, alpha = self.pytorch_promote_types(inputs, input_types)
 
         # note: rsub means data0 and data1 swap places
         return get_relay_op("subtract")(data1, alpha * data0)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2693,10 +2693,10 @@ def test_forward_rsub():
 
     d1 = torch.rand([1, 3]).half()
     d2 = torch.rand([1, 3]).half()
-    verify_model(Rsub1().float().eval(), input_data=[d1, d2])
-    verify_model(Rsub1().float().eval(), input_data=[d1, d3])
-    verify_model(Rsub2().float().eval(), input_data=[d1, d2])
-    verify_model(Rsub2().float().eval(), input_data=[d1, d3])
+    verify_model(Rsub1().half().eval(), input_data=[d1, d2])
+    verify_model(Rsub1().half().eval(), input_data=[d1, d3])
+    verify_model(Rsub2().half().eval(), input_data=[d1, d2])
+    verify_model(Rsub2().half().eval(), input_data=[d1, d3])
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2691,6 +2691,13 @@ def test_forward_rsub():
     verify_model(Rsub2().float().eval(), input_data=[d1, d2])
     verify_model(Rsub2().float().eval(), input_data=[d1, d3])
 
+    d1 = torch.rand([1, 3]).half()
+    d2 = torch.rand([1, 3]).half()
+    verify_model(Rsub1().float().eval(), input_data=[d1, d2])
+    verify_model(Rsub1().float().eval(), input_data=[d1, d3])
+    verify_model(Rsub2().float().eval(), input_data=[d1, d2])
+    verify_model(Rsub2().float().eval(), input_data=[d1, d3])
+
 
 @tvm.testing.uses_gpu
 def test_forward_embedding():


### PR DESCRIPTION
A quick patch to fix `rsub` conversion in PyTorch. The original implementation use `float(inputs[2])` for alpha, which implies both data0 data1 must be float32. As a result, I got type error when converting a FP16 model.

cc @t-vi @masahi 