### PR TITLE
[Torch] Experimental support for FX-quantized models

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -17,7 +17,7 @@
 # pylint: disable=import-self, too-many-lines, len-as-condition, no-else-return, unused-variable, too-many-nested-blocks
 # pylint: disable=consider-iterating-dictionary, invalid-name, unused-argument, unused-variable, broad-except
 # pylint: disable=import-outside-toplevel, simplifiable-if-expression, cell-var-from-loop, unnecessary-lambda
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring, redefined-builtin
 """PT: PyTorch frontend."""
 import functools
 import itertools
@@ -1781,6 +1781,7 @@ class PyTorchOpConverter:
 
         type_info = np.finfo(dtype) if "float" in dtype else np.iinfo(dtype)
 
+        # TODO(masahi): Properly handle inf in a one-way clamp case.
         if min is not None and max is not None:
             amin = get_v(min, type_info.min)
             amax = get_v(max, type_info.max)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3818,7 +3818,7 @@ def convert_params(graph, state_dict, use_parser_friendly_name=False):
             full_attr = _getattr_full_name(getattrs, attr_name_sep)
             full_attr_node_name = _get_output_name(getattrs[-1])
 
-            if full_attr.endswith("_packed_params"):  # for quantized models
+            if full_attr.endswith("_packed_params") or "_packed_weight" in full_attr:  # for quantized models
                 packed_param_map[full_attr_node_name] = full_attr
             elif full_attr in state_dict:
                 if full_attr in vars_by_name:
@@ -3941,6 +3941,7 @@ def from_pytorch(
         weight_quant_params = qnn_torch.get_weight_quant_params(
             script_module, packed_param_map.values()
         )
+        qnn_torch.inline_qparams(graph, tensors)
         input_scales_for_bias = qnn_torch.add_input_quant_params_to_op_inputs(graph)
         qnn_torch.add_quant_params_to_outputs(
             outputs,

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1875,7 +1875,6 @@ class PyTorchOpConverter:
                 assert isinstance(inputs[-1], int)
                 input_scale = _expr.const(inputs[-2])
                 input_zero_point = _expr.const(inputs[-1])
-
                 # currently piggy backs to fp32, it gets identical output as torch
                 return qnn_torch.apply_with_fp32_fallback(data, input_scale, input_zero_point, func)
 
@@ -3936,7 +3935,6 @@ def from_pytorch(
 
     graph = script_module.graph.copy()
     _run_jit_passes(graph)
-    print(graph)
 
     if custom_convert_map:
         converter.update_convert_map(custom_convert_map)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3050,7 +3050,7 @@ class PyTorchOpConverter:
             "aten::isnan": self.make_unary("isnan"),
             "aten::clamp": self.clamp,
             "aten::clamp_min": self.clamp_min,
-            "aten::clamp_min": self.clamp_max,
+            "aten::clamp_max": self.clamp_max,
             "aten::detach": self.identity,
             "aten::upsample_bilinear2d": self.make_upsample("linear"),
             "aten::upsample_bicubic2d": self.make_upsample("cubic"),

--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -39,6 +39,12 @@ def is_version_greater_than(ver):
     )
 
 
+def getattr_attr_name(node):
+    attribute_names = node.attributeNames()
+    assert len(attribute_names) == 1
+    return node.s(attribute_names[0])
+
+
 def dyn_strided_slice_pattern(inp, end):
     """A pattern to detect dynamic strided slice op."""
     zero = is_constant()

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -543,8 +543,14 @@ def quantized_relu(data, input_zero_point):
 
 def _quantize_per_tensor():
     def _impl(inputs, _):
+        dim = len(infer_shape(inputs[0]))
+        if dim > 1:
+            axis = 1
+        else:
+            axis = 0
+
         return relay.qnn.op.quantize(
-            inputs[0], _expr.const(inputs[1]), _expr.const(inputs[2]), out_dtype="uint8", axis=1
+            inputs[0], _expr.const(inputs[1]), _expr.const(inputs[2]), out_dtype="uint8", axis=axis
         )
 
     return _impl

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -440,6 +440,7 @@ def add_input_quant_params_to_op_inputs(graph):
         "quantized::mul": 2,
         "aten::dequantize": 1,
         "aten::mean": 1,
+        "aten::sigmoid": 1,
         "aten::upsample_nearest2d": 1,
         "aten::upsample_bilinear2d": 1,
         "aten::relu_": 1,
@@ -516,6 +517,12 @@ def apply_with_upcast(data, func):
 
 def quantized_mean(data, input_scale, input_zero_point, func_fp32):
     # refer to aten/src/ATen/native/quantized/cpu/qreduction.cpp
+    dequantized = relay.qnn.op.dequantize(data, input_scale, input_zero_point)
+    out = func_fp32(dequantized)
+    return relay.qnn.op.quantize(out, input_scale, input_zero_point, out_dtype="uint8", axis=1)
+
+
+def quantized_sigmoid(data, input_scale, input_zero_point, func_fp32):
     dequantized = relay.qnn.op.dequantize(data, input_scale, input_zero_point)
     out = func_fp32(dequantized)
     return relay.qnn.op.quantize(out, input_scale, input_zero_point, out_dtype="uint8", axis=1)

--- a/python/tvm/relay/frontend/qnn_torch.py
+++ b/python/tvm/relay/frontend/qnn_torch.py
@@ -507,7 +507,6 @@ def add_quant_params(params, quant_params):
 
 
 def inline_input_quant_params_for_fx(graph, params):
-    import torch
     """
     Canonicalize input scale and zero point access for FX-quantized graphs.
     We expect input qparams to aten::quantize_per_tensor to be prim::Constant, but that's
@@ -527,6 +526,7 @@ def inline_input_quant_params_for_fx(graph, params):
     %2403 : float = prim::Constant[value=1.]()
     %quantize_per_tensor_2 ...  = aten::quantize_per_tensor(..., %2403, %2402, ...)
     """
+    import torch
 
     def get_full_attr_name(current):
         current_attr = getattr_attr_name(current)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2790,6 +2790,9 @@ def test_forward_clamp():
     verify_model(Clamp3().float().eval(), input_data=input_data)
     verify_model(Clamp_MinExpr_MaxConstant().float().eval(), input_data=input_data)
 
+    verify_model(lambda inp: torch.clamp_min(inp, 0.5), input_data)
+    verify_model(lambda inp: torch.clamp_max(inp, 0.5), input_data)
+
 
 @tvm.testing.uses_gpu
 def test_forward_clamp_():

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2791,7 +2791,8 @@ def test_forward_clamp():
     verify_model(Clamp_MinExpr_MaxConstant().float().eval(), input_data=input_data)
 
     verify_model(lambda inp: torch.clamp_min(inp, 0.5), input_data)
-    verify_model(lambda inp: torch.clamp_max(inp, 0.5), input_data)
+    inp_uint8 = torch.randint(low=0, high=256, size=(100, 100), dtype=torch.uint8)
+    verify_model(lambda inp: torch.clamp_max(inp, 125), inp_uint8)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_fx_quant.py
+++ b/tests/python/frontend/pytorch/test_fx_quant.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" Tests on fx-quantized torch model conversion """
+import torch
+import torchvision
+import numpy as np
+from torch.quantization import get_default_qconfig
+from torch.quantization.quantize_fx import prepare_fx, convert_fx
+from tvm import relay
+
+
+def do_trace(model, in_size=500):
+    model_trace = torch.jit.trace(model, torch.rand(1, 3, in_size, in_size))
+    model_trace.eval()
+    return model_trace
+
+
+def quantize(model_fp):
+    qconfig = get_default_qconfig("fbgemm")
+    qconfig_dict = {"": qconfig}
+    return convert_fx(prepare_fx(model_fp, qconfig_dict))
+
+
+def test_ssd_vgg():
+    class TraceWrapper(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+        def forward(self, inp):
+            features = self.model.backbone(inp)
+            features = list(features.values())
+            out = self.model.head(features)
+            return out["bbox_regression"], out["cls_logits"]
+
+    model_func = torchvision.models.detection.ssd300_vgg16
+    model = TraceWrapper(model_func(num_classes=50, pretrained_backbone=True)).eval()
+
+    model = quantize(model)
+
+    in_size = 500
+    inp = torch.rand(1, 3, in_size, in_size)
+    input_name = "inp"
+
+    with torch.no_grad():
+        script_module = do_trace(model, in_size)
+        mod, params = relay.frontend.from_pytorch(script_module, [(input_name, inp.shape)])
+
+    print(relay.transform.InferType()(mod))
+
+
+def test_deeplab_v3():
+    class TraceWrapper(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+        def forward(self, inp):
+            out = self.model(inp)
+            return out["out"]
+
+    deeplabv3 = torchvision.models.segmentation.deeplabv3_mobilenet_v3_large(pretrained=True)
+    model = TraceWrapper(deeplabv3.eval()).eval()
+    inp = torch.rand(8, 3, 512, 512)
+
+    qmodel = quantize(model)
+
+    with torch.no_grad():
+        trace = torch.jit.trace(qmodel, inp)
+
+    mod, params = relay.frontend.from_pytorch(trace, [('input', inp.shape)])
+    print(relay.transform.InferType()(mod))
+
+
+def test_imagenet():
+    from torchvision.models.efficientnet import efficientnet_b4
+    from torchvision.models.resnet import resnet50
+
+    for model_func in [resnet50, efficientnet_b4]:
+        model = efficientnet_b4(pretrained=True).eval()
+        model = quantize(model)
+
+        x = torch.rand((1, 3, 224, 224))
+        model_traced = torch.jit.trace(model, x).eval()
+
+        mod, _ = relay.frontend.from_pytorch(model_traced, [("x", x.shape)])
+        print(relay.transform.InferType()(mod))

--- a/tests/python/frontend/pytorch/test_fx_quant.py
+++ b/tests/python/frontend/pytorch/test_fx_quant.py
@@ -38,12 +38,14 @@ def quantize_and_build(model, in_size):
 
     with torch.no_grad():
         script_module = torch.jit.trace(qmodel, inp)
-        mod, params = relay.frontend.from_pytorch(script_module, [(input_name, inp.shape)])
+        mod, _ = relay.frontend.from_pytorch(script_module, [(input_name, inp.shape)])
+        mod = relay.transform.InferType()(mod)
 
         # Make sure that the model is quantized
         assert "qnn.conv2d" in mod.astext(show_meta_data=False)
 
-    relay.build(mod, params=params, target="llvm")
+        # Skip building since it is slow on CI
+        # relay.build(mod, params=params, target="llvm")
 
 
 def test_ssd_vgg():


### PR DESCRIPTION
This is the first step toward supporting models quantized with the FX-based workflow as described in https://pytorch.org/tutorials/prototype/fx_graph_mode_ptq_static.html.

The required change was surprisingly simple: Simple graph surgery done by `inline_input_quant_params_for_fx(...)` in `qnn_torch.py` is enough. So far, I was able to quantize imagenet models, deeplab v3, ssd-vgg, and yolov5, either fully or semi automatically. See the attached test cases. 

Since my current interest is to collect real-world quantized workloads for performance benchmarking, I didn't care about calibration.    

Also added `aten::clamp_min` support for SSD-VGG.

@comaniac @lhutton1 @junrushao1994 @siju-samuel @t-vi @AndrewZhaoLuo 

