### PR TITLE
[microTVM] Include standalone_crt dependencies in MLF

### DIFF
--- a/apps/microtvm/ethosu/Makefile
+++ b/apps/microtvm/ethosu/Makefile
@@ -25,7 +25,7 @@ ETHOSU_PATH = /opt/arm/ethosu
 ETHOSU_DRIVER_PATH ?= ${ETHOSU_PATH}/core_driver
 CMSIS_PATH ?= ${ETHOSU_PATH}/cmsis
 ETHOSU_PLATFORM_PATH ?= ${ETHOSU_PATH}/core_platform
-STANDALONE_CRT_PATH := $(abspath $(BUILD_DIR))/$(shell python3 -c "import json; data=json.load(open('./build/metadata.json')); print([e for e in data['external_dependencies'] if e['short_name'] == 'tvm_standalone_crt'][0]['url'])")
+STANDALONE_CRT_PATH := $(abspath $(BUILD_DIR))/runtime
 CORSTONE_300_PATH = ${ETHOSU_PLATFORM_PATH}/targets/corstone-300
 PKG_COMPILE_OPTS = -g -Wall -O2 -Wno-incompatible-pointer-types -Wno-format -mcpu=cortex-m55 -mthumb -mfloat-abi=hard -std=gnu99
 CMAKE ?= cmake

--- a/apps/microtvm/ethosu/Makefile
+++ b/apps/microtvm/ethosu/Makefile
@@ -19,13 +19,13 @@
 
 # Setup build environment
 BUILD_DIR := build
-STANDALONE_CRT_PATH := $(shell python3 -c "import tvm.micro; print(tvm.micro.get_standalone_crt_dir())")
 
 ARM_CPU = ARMCM55
 ETHOSU_PATH = /opt/arm/ethosu
 ETHOSU_DRIVER_PATH ?= ${ETHOSU_PATH}/core_driver
 CMSIS_PATH ?= ${ETHOSU_PATH}/cmsis
 ETHOSU_PLATFORM_PATH ?= ${ETHOSU_PATH}/core_platform
+STANDALONE_CRT_PATH := $(abspath $(BUILD_DIR))/$(shell python3 -c "import json; data=json.load(open('./build/metadata.json')); print([e for e in data['external_dependencies'] if e['short_name'] == 'tvm_standalone_crt'][0]['url'])")
 CORSTONE_300_PATH = ${ETHOSU_PLATFORM_PATH}/targets/corstone-300
 PKG_COMPILE_OPTS = -g -Wall -O2 -Wno-incompatible-pointer-types -Wno-format -mcpu=cortex-m55 -mthumb -mfloat-abi=hard -std=gnu99
 CMAKE ?= cmake

--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -138,7 +138,7 @@ python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u
     --executor-aot-interface-api=c \
     --executor-aot-unpacked-api=1 \
     --pass-config tir.disable_vectorize=1 ./mobilenet_v2_1.0_224_INT8.tflite --output-format=mlf
-tar -xvf module.tar
+tar -xf module.tar
 
 # Get ImageNet labels
 curl -sS  https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/lite/java/demo/app/src/main/assets/labels_mobilenet_quant_v1_224.txt \

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -288,7 +288,8 @@ def _make_tar(source_dir, tar_file_path, mod):
             return tarinfo
 
         tar_f.add(str(source_dir), arcname=".", filter=reset)
-        if str(mod.runtime) == "crt":
+        is_aot = isinstance(mod, executor_factory.AOTExecutorFactoryModule)
+        if is_aot and str(mod.runtime) == "crt":
             tar_f.add(get_standalone_crt_dir(), arcname="./runtime")
 
 

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -27,6 +27,7 @@ import typing
 
 import tvm
 from tvm.ir.type import TupleType
+from tvm.micro import get_standalone_crt_dir
 from .._ffi import get_global_func
 from ..contrib import utils
 from ..driver import build_module
@@ -277,7 +278,7 @@ def _should_generate_interface_header(mod):
     return "interface-api" in mod.executor and mod.executor["interface-api"] == "c"
 
 
-def _make_tar(source_dir, tar_file_path):
+def _make_tar(source_dir, tar_file_path, mod):
     """Build a tar file from source_dir."""
     with tarfile.open(tar_file_path, "w") as tar_f:
 
@@ -287,6 +288,8 @@ def _make_tar(source_dir, tar_file_path):
             return tarinfo
 
         tar_f.add(str(source_dir), arcname=".", filter=reset)
+        if str(mod.runtime) == "crt":
+            tar_f.add(get_standalone_crt_dir(), arcname="./runtime")
 
 
 _GENERATED_VERSION = 5
@@ -316,6 +319,16 @@ def _export_graph_model_library_format(
         "executors": executor,
         "style": "full-model",
     }
+
+    if is_aot and (str(mod.runtime) == "crt"):
+        standalone_crt = {
+            "short_name": "tvm_standalone_crt",
+            "url": "./runtime",
+            "url_type": "mlf_path",
+            "version_spec": f"{tvm.__version__}",
+        }
+        external_dependencies = [standalone_crt]
+        metadata["external_dependencies"] = external_dependencies
 
     with open(tempdir / "metadata.json", "w") as json_f:
         json.dump(metadata, json_f, indent=2, sort_keys=True)
@@ -488,6 +501,6 @@ def export_model_library_format(mod: ExportableModule, file_name: typing.Union[s
     else:
         raise NotImplementedError(f"Don't know how to export module of type {mod.__class__!r}")
 
-    _make_tar(tempdir.path, file_name)
+    _make_tar(tempdir.path, file_name, mod)
 
     return file_name

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -39,6 +39,7 @@ from ..tir import expr
 
 # This should be kept identical to runtime::symbol::tvm_module_main
 MAIN_FUNC_NAME_STR = "__tvm_main__"
+STANDALONE_CRT_URL = "./runtime"
 
 
 class UnsupportedInModelLibraryFormatError(Exception):
@@ -290,7 +291,7 @@ def _make_tar(source_dir, tar_file_path, mod):
         tar_f.add(str(source_dir), arcname=".", filter=reset)
         is_aot = isinstance(mod, executor_factory.AOTExecutorFactoryModule)
         if is_aot and str(mod.runtime) == "crt":
-            tar_f.add(get_standalone_crt_dir(), arcname="./runtime")
+            tar_f.add(get_standalone_crt_dir(), arcname=STANDALONE_CRT_URL)
 
 
 _GENERATED_VERSION = 5
@@ -324,7 +325,7 @@ def _export_graph_model_library_format(
     if is_aot and (str(mod.runtime) == "crt"):
         standalone_crt = {
             "short_name": "tvm_standalone_crt",
-            "url": "./runtime",
+            "url": f"{STANDALONE_CRT_URL}",
             "url_type": "mlf_path",
             "version_spec": f"{tvm.__version__}",
         }

--- a/python/tvm/relay/backend/executor_factory.py
+++ b/python/tvm/relay/backend/executor_factory.py
@@ -81,6 +81,8 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         The Target used to build this module.
     executor : tvm.relay.backend.Executor
         Internal representation of the Executor
+    runtime : tvm.relay.backend.Runtime
+        Internal representation of the Runtime
     libmod : tvm.Module
         The module of the corresponding function
     libmod_name: str
@@ -99,6 +101,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         lowered_ir_mods,
         target,
         executor,
+        runtime,
         libmod,
         libmod_name,
         params,
@@ -109,6 +112,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         self.lowered_ir_mods = lowered_ir_mods
         self.target = target
         self.executor = executor
+        self.runtime = runtime
         self.lib = libmod
         self.libmod_name = libmod_name
         self.params = params

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -464,6 +464,7 @@ def build(
                 lowered_ir_mods,
                 target,
                 executor,
+                runtime,
                 runtime_mod,
                 mod_name,
                 params,


### PR DESCRIPTION
This PR includes the standalone_crt files in the MLF tarball if the runtime is `crt` .
It also updates the `metadata.json` file as described in the ["Capturing dependent libraries..." discussion](https://discuss.tvm.apache.org/t/tvm-capturing-dependent-libraries-of-code-generated-tir-initially-for-use-in-model-library-format/11080/9) in the Discuss forums.

 * Adds runtime to AOTExecutorFactoryModule
 * Standalone CRT files are added to MLF tarball if runtime is crt
 * external_dependencies info added to metadata.json for crt runtime
 * microNPU demo Makefile references standalone crt files from MLF tarball

@manupa-arm @Mousius @areusch 
