### PR TITLE
[TE] Fix Const Int bound analysis to handle uints for division

### DIFF
--- a/src/arith/const_int_bound.cc
+++ b/src/arith/const_int_bound.cc
@@ -430,7 +430,7 @@ class ConstIntBoundAnalyzer::Impl
     // the domain ranges.
 
     // If the range of b contains 0, then some infinity will be involved
-    if (b.min_value <= 0 && 0 <= b.max_value) {
+    if (b.min_value <= 0 && 0 <= b.max_value && dt.is_int()) {
       Entry b_neg = b.min_value < 0 ? MakeBound(b.min_value, -1) : Everything(dt);
       Entry b_pos = b.max_value > 0 ? MakeBound(1, b.max_value) : Everything(dt);
 
@@ -439,6 +439,10 @@ class ConstIntBoundAnalyzer::Impl
 
       return MakeBound(std::min(e_neg.min_value, e_pos.min_value),
                        std::max(e_neg.max_value, e_pos.max_value));
+    } else if (b.min_value == 0 && dt.is_uint()) {
+      // uints only have one sided bounds
+      Entry assumed_b = MakeBound(1, b.max_value);
+      return BinaryOpBoundary(a, assumed_b, op);
     }
     // If the range of b does not have 0, use BinaryOpBoundary.
     return BinaryOpBoundary(a, b, op);

--- a/tests/python/unittest/test_arith_const_int_bound.py
+++ b/tests/python/unittest/test_arith_const_int_bound.py
@@ -195,6 +195,14 @@ def test_floordiv_bound():
     assert bd.min_value == -9
     assert bd.max_value == 9
 
+    # Test handling unsigned integers well
+    x, y = te.var("x", dtype="uint32"), te.var("y", dtype="uint32")
+    analyzer.update(x, tvm.arith.ConstIntBound(1, 4), override=True)
+    analyzer.update(y, tvm.arith.ConstIntBound(0, 12), override=True)
+    bd = analyzer.const_int_bound(fld(x, y))
+    assert bd.min_value == 0
+    assert bd.max_value == 4
+
 
 def test_floormod_bound():
     analyzer = tvm.arith.Analyzer()


### PR DESCRIPTION
The analyzer tries to see the range an integer variable can represent. Specifically, if the range of a divisor contained zero it would just sort of be ignored (assuming probably that run time checks or otherwise would catch this). This didn't really work for uints though and the analyzer would be sure you were dividing by 0 and be very mad at you

Now
https://discuss.tvm.apache.org/t/failure-occurs-when-using-relay-floor-mod-and-the-divisor-is-of-type-uint64/11994/2
