### PR TITLE
[onnx] fix onnx where broadcast

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2206,28 +2206,7 @@ class Where(OnnxOpConverter):
 
     @classmethod
     def _impl_v9(cls, inputs, attr, params):
-        condition_rank = len(infer_shape(inputs[0]))
-        x_rank = len(infer_shape(inputs[1]))
-        y_rank = len(infer_shape(inputs[2]))
-        ranks = [condition_rank, x_rank, y_rank]
-
-        # If one rank is longer than others, then we can broadcast
-        # to that shape.
-        max_rank = max(ranks)
-        max_rank_idxs = [i for i, x in enumerate(ranks) if x == max_rank]
-        broadcast_shape = shape_of(inputs[max_rank_idxs[0]])
-        # If two or more inputs have the same rank, compute the broadcast
-        # shape by taking the maximum value of each dimensions.
-        if len(max_rank_idxs) > 1:
-            for idx in max_rank_idxs:
-                broadcast_shape = _op.maximum(broadcast_shape, shape_of(inputs[idx]))
-
-        broadcast_shape = fold_constant(broadcast_shape)
-
-        condition = _op.broadcast_to(inputs[0], broadcast_shape)
-        x = _op.broadcast_to(inputs[1], broadcast_shape)
-        y = _op.broadcast_to(inputs[2], broadcast_shape)
-        return _op.where(condition, x, y)
+        return _op.where(*inputs)
 
 
 class Or(Elemwise):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2510,6 +2510,12 @@ def test_where(target, dev):
     verify_where(condition, x, y, TensorProto.FLOAT, outdata)
     verify_where(condition, x, y, TensorProto.FLOAT, outdata, dynamic=True)
 
+    condition = np.random.uniform(size=(3, 1)) < 0.5
+    x = np.random.uniform(size=2).astype(np.float32)
+    y = np.random.uniform(size=2).astype(np.float32)
+    outdata = np.where(condition, x, y)
+    verify_where(condition, x, y, TensorProto.FLOAT, outdata)
+
 
 @tvm.testing.parametrize_targets
 def test_or(target, dev):


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


Previous logic for importing `where` only considers the shape of the tensors with the largest rank. This is incorrect, for instance when cond, x, and y are of the following shapes: [3,1], [2], [2]. The resulting shape should be [3,2], but original logic gives [3,1]. Below is the code snippet to reproduce.

```python
from tvm import relay
import numpy as np
import onnx
from onnx import TensorProto, helper, mapping, numpy_helper


def get_onnx_model(condition, x, y):
    outdata = np.where(condition, x, y)
    dtype = TensorProto.FLOAT
    where_inputs = ["cond", "x", "y"]
    node = helper.make_node("Where", inputs=where_inputs, outputs=["out"])
    node_list = [node]
    graph = helper.make_graph(
        node_list,
        "where_test",
        inputs=[
            helper.make_tensor_value_info(
                "cond", TensorProto.BOOL, list(condition.shape)),
            helper.make_tensor_value_info("x", dtype, list(x.shape)),
            helper.make_tensor_value_info("y", dtype, list(y.shape)),
        ],
        outputs=[helper.make_tensor_value_info(
            "out", dtype, list(outdata.shape))],
    )
    model = helper.make_model(graph, producer_name="where_test")
    return model


def main():
    condition = np.random.uniform(size=(3, 1)) < 0.5
    x = np.random.uniform(size=(2,)).astype(np.float32)
    y = np.random.uniform(size=(2,)).astype(np.float32)
    model = get_onnx_model(condition, x, y)
    mod, params = relay.frontend.from_onnx(model, freeze_params=True)

    res = relay.build_module.create_executor('graph', mod).evaluate()(
        **{'cond': condition, 'x': x, 'y': y})
    assert np.allclose(res.asnumpy(), np.where(
        condition, x, y), rtol=0, atol=0)


main()
```

This PR simply delegates the broadcast logic to `relay.where`, instead of handling during import.