### PR TITLE
[Ansor] Improve OpenCL support

### DIFF
--- a/apps/topi_recipe/gemm/cuda_gemm_square.py
+++ b/apps/topi_recipe/gemm/cuda_gemm_square.py
@@ -27,27 +27,6 @@ TASK = "gemm"
 USE_MANUAL_CODE = False
 
 
-@tvm.register_func("tvm_callback_cuda_compile", override=True)
-def tvm_callback_cuda_compile(code):
-    ptx = nvcc.compile_cuda(code, target_format="ptx")
-    return ptx
-
-
-def write_code(code, fname):
-    with open(fname, "w") as f:
-        f.write(code)
-
-
-@tvm.register_func
-def tvm_callback_cuda_postproc(code):
-    if not os.path.exists("perf"):
-        os.mkdir("perf")
-    write_code(code, "perf/%s_generated.cu" % TASK)
-    if USE_MANUAL_CODE:
-        code = open("perf/%s_manual.cu" % TASK).read()
-    return code
-
-
 def test_gemm():
     # graph
     nn = 2048

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -104,8 +104,27 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
                             max_threads_per_block, max_vthread_extent, warp_size);
     } else {
       // add other opencl target
-      auto target_device = target->GetAttr<String>("device", "");
-      LOG(FATAL) << "No default hardware parameters for opencl target device: " << target_device;
+      auto dev = Device{static_cast<DLDeviceType>(device_type), 0};
+      auto device_name = "device_api.opencl";
+      auto func = tvm::runtime::Registry::Get(device_name);
+      ICHECK(func != nullptr) << "Cannot find OpenCL device_api in registry";
+      auto device_api = static_cast<tvm::runtime::DeviceAPI*>(((*func)()).operator void*());
+
+      tvm::runtime::TVMRetValue ret;
+      device_api->GetAttr(dev, tvm::runtime::DeviceAttrKind::kMaxSharedMemoryPerBlock, &ret);
+      int max_shared_memory_per_block = ret;
+
+      int max_local_memory_per_block = INT32_MAX;
+
+      device_api->GetAttr(dev, tvm::runtime::DeviceAttrKind::kMaxThreadsPerBlock, &ret);
+      int max_threads_per_block = ret;
+
+      device_api->GetAttr(dev, tvm::runtime::DeviceAttrKind::kWarpSize, &ret);
+      int warp_size = ret;
+
+      int max_vthread_extent = warp_size / 4;
+      return HardwareParams(-1, 16, 64, max_shared_memory_per_block, max_local_memory_per_block,
+                            max_threads_per_block, max_vthread_extent, warp_size);
     }
   } else if (device_type == kDLVulkan) {
     auto dev = Device{static_cast<DLDeviceType>(device_type), 0};

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -123,7 +123,7 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
       int warp_size = ret;
 
       if (warp_size == 1) {
-        LOG(WARNING) << "Th warp size is 1, tuning might crash or stuck.";
+        LOG(WARNING) << "Warp size 1 is not recommended for OpenCL devices. Tuning might crash or stuck";
       }
 
       int max_vthread_extent = warp_size / 4;

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -122,6 +122,10 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
       device_api->GetAttr(dev, tvm::runtime::DeviceAttrKind::kWarpSize, &ret);
       int warp_size = ret;
 
+      if (warp_size == 1) {
+        LOG(WARNING) << "Th warp size is 1, tuning might crash or stuck.";
+      }
+
       int max_vthread_extent = warp_size / 4;
       return HardwareParams(-1, 16, 64, max_shared_memory_per_block, max_local_memory_per_block,
                             max_threads_per_block, max_vthread_extent, warp_size);

--- a/src/auto_scheduler/search_task.cc
+++ b/src/auto_scheduler/search_task.cc
@@ -123,7 +123,8 @@ HardwareParams HardwareParamsNode::GetDefaultHardwareParams(const Target& target
       int warp_size = ret;
 
       if (warp_size == 1) {
-        LOG(WARNING) << "Warp size 1 is not recommended for OpenCL devices. Tuning might crash or stuck";
+        LOG(WARNING)
+            << "Warp size 1 is not recommended for OpenCL devices. Tuning might crash or stuck";
       }
 
       int max_vthread_extent = warp_size / 4;

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -20,6 +20,7 @@
 /*!
  * \file opencl_device_api.cc
  */
+#include <dmlc/parameter.h>
 #include <dmlc/thread_local.h>
 #include <tvm/runtime/registry.h>
 
@@ -122,7 +123,8 @@ void OpenCLWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
                corresponding to the number of SIMD entries the heardware configures.
                We need to figure out a way to query this information from the hardware.
       */
-      *rv = 1;
+      const int warp_size = dmlc::GetEnv("TVM_OPENCL_WARP_SIZE", 1);
+      *rv = warp_size;
       break;
     }
     case kMaxSharedMemoryPerBlock: {


### PR DESCRIPTION
Currently only Mali is enabled for opencl target, I added this change to enable Intel GPUs.

 Determining the correct warp size is tricky on OpenCL and on Intel in particular, so I added an env var `TVM_OPENCL_WARP_SIZE` so that a user can enforce a certain value. I found that on Intel GPU, using `warp_size == 1` leads to tuning being stuck.

@comaniac @FrozenGene @jcf94  