### PR TITLE
[CI] Use Python 3.6 variant of pypa.io

### DIFF
--- a/docker/install/ubuntu1804_install_python.sh
+++ b/docker/install/ubuntu1804_install_python.sh
@@ -26,7 +26,7 @@ apt-get install -y software-properties-common
 apt-get install -y python3-dev python3-setuptools
 
 # Install pip
-cd /tmp && wget -q https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+cd /tmp && wget -q https://bootstrap.pypa.io/pip/3.6/get-pip.py && python3 get-pip.py
 
 # Pin pip and setuptools versions
 pip3 install pip==19.3.1 setuptools==58.4.0


### PR DESCRIPTION
Using pypa.io directly now results in:
```
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
The command '/bin/sh -c bash /install/ubuntu1804_install_python.sh' returned a non-zero code: 1
```

Also see: https://github.com/apache/tvm/issues/9703
