### PR TITLE
[CI] Update ci_qemu to v0.10 and Zephyr project generator for Zephyr 2.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ ci_gpu = "tlcpack/ci-gpu:v0.81"
 ci_cpu = "tlcpack/ci-cpu:v0.80"
 ci_wasm = "tlcpack/ci-wasm:v0.71"
 ci_i386 = "tlcpack/ci-i386:v0.74"
-ci_qemu = "tlcpack/ci-qemu:v0.09"
+ci_qemu = "tlcpack/ci-qemu:v0.10"
 ci_arm = "tlcpack/ci-arm:v0.06"
 // <--- End of regex-scanned config.
 

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -63,8 +63,7 @@ BOARDS = API_SERVER_DIR / "boards.json"
 
 # Used to check Zephyr version installed on the host.
 # We only check two levels of the version.
-ZEPHYR_VERSION = 2.5
-
+ZEPHYR_VERSION = 2.7
 
 WEST_CMD = default = sys.executable + " -m west" if sys.executable else None
 
@@ -373,7 +372,12 @@ class Handler(server.ProjectAPIHandler):
             f.write("# For TVMPlatformAbort().\n" "CONFIG_REBOOT=y\n" "\n")
 
             if options["project_type"] == "host_driven":
-                f.write("# For RPC server C++ bindings.\n" "CONFIG_CPLUSPLUS=y\n" "\n")
+                f.write(
+                    "# For RPC server C++ bindings.\n"
+                    "CONFIG_CPLUSPLUS=y\n"
+                    "CONFIG_LIB_CPLUSPLUS=y\n"
+                    "\n"
+                )
 
             f.write("# For math routines\n" "CONFIG_NEWLIB_LIBC=y\n" "\n")
 


### PR DESCRIPTION
This commit updates the ci_qemu image, in order to do this the Zephyr
generator had to be updated to account for the newer version in the
image.
