### PR TITLE
Fix LayoutRewriter

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -210,10 +210,6 @@ InferCorrectLayoutOutput DenseInferCorrectLayout(const Attrs& attrs,
                                                  const Array<Layout>& new_in_layouts,
                                                  const Array<Layout>& old_in_layouts,
                                                  const Array<tvm::relay::Type>& old_in_types) {
-  // Respect input layout, if explicitly specified (for example, "NW").
-  if (new_in_layouts.size() > 0 && new_in_layouts[0].defined()) {
-    return InferCorrectLayoutOutput({new_in_layouts[0], "NC"}, {"NC"}, attrs);
-  }
   return InferCorrectLayoutOutput({"NC", "NC"}, {"NC"}, attrs);
 }
 
@@ -283,14 +279,6 @@ InferCorrectLayoutOutput DensePackInferCorrectLayout(const Attrs& attrs,
                                                      const Array<tvm::relay::Type>& old_in_types) {
   auto params = attrs.as<DensePackAttrs>();
   ICHECK(params);
-  // Respect input layout, if explicitly specified (for example, "NW").
-  // However, a packed layout such as "NC8c" is not supported by dense_pack op. For such cases,
-  // we insert a layout transform "NC8c" -> "NC".
-  // We do not expect to get a packed layout like "NW8w", which is not compatitble with "NC",
-  // since packing is always done on the "C" axis.
-  if (new_in_layouts.size() > 0 && new_in_layouts[0].defined() && new_in_layouts[0].ndim() == 2) {
-    return InferCorrectLayoutOutput({new_in_layouts[0], params->weight_layout}, {"NC"}, attrs);
-  }
   return InferCorrectLayoutOutput({"NC", params->weight_layout}, {"NC"}, attrs);
 }
 

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -346,7 +346,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   }
   ICHECK_EQ(old_in2.size(), new_in.size());
 
-  Array<Layout> new_in_tmp = new_in; // for backward compatibility of InferCorrectLayouts
+  Array<Layout> new_in_tmp = new_in;  // for backward compatibility of InferCorrectLayouts
   // if new_in_tmp == 'undef':  new_in_tmp = old_in2
   for (size_t i = 0; i < new_in_tmp.size(); ++i) {
     if (!new_in_tmp[i].defined()) {
@@ -375,11 +375,11 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   ICHECK_EQ(new_in.size(), new_in2.size())
       << "The number of input nodes should keep the same during alter_op_layout";
 
-  auto transform_layout = [&memorizer](Expr arg_item, const Layout &old_in, const Layout &old_in2, 
+  auto transform_layout = [&memorizer](Expr arg_item, const Layout &old_in, const Layout &old_in2,
                               const Layout &new_in, const Layout &new_in2) {
-    if (old_in2.Equals(old_in)) // the two transforms can be fused to one
+    if (old_in2.Equals(old_in)) {  // the two transforms can be fused to one
       arg_item = memorizer.Transform(arg_item, new_in, new_in2);
-    else {
+    } else {
       if (old_in.defined()) arg_item = memorizer.Transform(arg_item, new_in, old_in);
       arg_item = memorizer.Transform(arg_item, old_in2, new_in2);
     }
@@ -395,12 +395,14 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
       Array<Expr> transformed_tuple_arg;
       transformed_tuple_arg.reserve(tuple_arg->fields.size());
       for (auto arg_item : tuple_arg->fields) {
-        transformed_tuple_arg.push_back(transform_layout(arg_item, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
+        transformed_tuple_arg.push_back(
+          transform_layout(arg_item, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
         pt++;
       }
       transformed_args.push_back(WithFields(tuple_arg, transformed_tuple_arg));
     } else {
-      transformed_args.push_back(transform_layout(arg, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
+      transformed_args.push_back(
+        transform_layout(arg, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
       pt++;
     }
   }

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -376,7 +376,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
       << "The number of input nodes should keep the same during alter_op_layout";
 
   auto transform_layout = [&memorizer](Expr arg_item, const Layout &old_in, const Layout &old_in2,
-                              const Layout &new_in, const Layout &new_in2) {
+                                       const Layout &new_in, const Layout &new_in2) {
     if (old_in2.Equals(old_in)) {  // the two transforms can be fused to one
       arg_item = memorizer.Transform(arg_item, new_in, new_in2);
     } else {
@@ -396,13 +396,13 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
       transformed_tuple_arg.reserve(tuple_arg->fields.size());
       for (auto arg_item : tuple_arg->fields) {
         transformed_tuple_arg.push_back(
-          transform_layout(arg_item, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
+            transform_layout(arg_item, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
         pt++;
       }
       transformed_args.push_back(WithFields(tuple_arg, transformed_tuple_arg));
     } else {
       transformed_args.push_back(
-        transform_layout(arg, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
+          transform_layout(arg, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
       pt++;
     }
   }

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -320,7 +320,10 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   }
 
   // old_in, new_in = state[inputs]
-  Array<Layout> old_in, old_out, new_in, new_out, new_in2;
+  // naming rule:
+  // old_in, new_in: the input layouts given by downstream node.
+  // old_in2, new_in2: the input layouts inferred by the current node.
+  Array<Layout> old_in, old_in2, old_out, new_in, new_out, new_in2;
   for (auto inp : inputs) {
     old_in.push_back(inp->old_layout);
     new_in.push_back(inp->new_layout);
@@ -336,17 +339,18 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   InferCorrectLayoutOutput infer_out;
   std::tie(infer_out, success) =
       InferCorrectLayouts(ref_call, Array<Layout>(nullptr), old_in, types);
-  old_in = infer_out->input_layouts;
+  old_in2 = infer_out->input_layouts;
   old_out = infer_out->output_layouts;
   if (!success) {
     return Expr(nullptr);
   }
-  ICHECK_EQ(old_in.size(), new_in.size());
+  ICHECK_EQ(old_in2.size(), new_in.size());
 
-  // if new_in == 'undef':  new_in = old_in
-  for (size_t i = 0; i < new_in.size(); ++i) {
-    if (!new_in[i].defined()) {
-      new_in.Set(i, old_in[i]);
+  Array<Layout> new_in_tmp = new_in; // for backward compatibility of InferCorrectLayouts
+  // if new_in_tmp == 'undef':  new_in_tmp = old_in2
+  for (size_t i = 0; i < new_in_tmp.size(); ++i) {
+    if (!new_in_tmp[i].defined()) {
+      new_in_tmp.Set(i, old_in2[i]);
     }
   }
 
@@ -356,7 +360,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   // new_in2, new_out = op.infer(new_in)
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
-    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in, old_in, types);
+    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in_tmp, old_in2, types);
     new_in2 = infer_out->input_layouts;
     new_out = infer_out->output_layouts;
     if (!success) {
@@ -371,6 +375,17 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   ICHECK_EQ(new_in.size(), new_in2.size())
       << "The number of input nodes should keep the same during alter_op_layout";
 
+  auto transform_layout = [&memorizer](Expr arg_item, const Layout &old_in, const Layout &old_in2, 
+                              const Layout &new_in, const Layout &new_in2) {
+    if (old_in2.Equals(old_in)) // the two transforms can be fused to one
+      arg_item = memorizer.Transform(arg_item, new_in, new_in2);
+    else {
+      if (old_in.defined()) arg_item = memorizer.Transform(arg_item, new_in, old_in);
+      arg_item = memorizer.Transform(arg_item, old_in2, new_in2);
+    }
+    return arg_item;
+  };
+
   // if (new_in != new_in2): insert transform (new_in -> new_in2)
   Array<Expr> transformed_args;
   size_t pt = 0;
@@ -380,12 +395,12 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
       Array<Expr> transformed_tuple_arg;
       transformed_tuple_arg.reserve(tuple_arg->fields.size());
       for (auto arg_item : tuple_arg->fields) {
-        transformed_tuple_arg.push_back(memorizer.Transform(arg_item, new_in[pt], new_in2[pt]));
+        transformed_tuple_arg.push_back(transform_layout(arg_item, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
         pt++;
       }
       transformed_args.push_back(WithFields(tuple_arg, transformed_tuple_arg));
     } else {
-      transformed_args.push_back(memorizer.Transform(arg, new_in[pt], new_in2[pt]));
+      transformed_args.push_back(transform_layout(arg, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
       pt++;
     }
   }

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -375,8 +375,8 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   ICHECK_EQ(new_in.size(), new_in2.size())
       << "The number of input nodes should keep the same during alter_op_layout";
 
-  auto transform_layout = [&memorizer](Expr arg_item, const Layout &old_in, const Layout &old_in2,
-                                       const Layout &new_in, const Layout &new_in2) {
+  auto transform_layout = [&memorizer](Expr arg_item, const Layout& old_in, const Layout& old_in2,
+                                       const Layout& new_in, const Layout& new_in2) {
     if (old_in2.Equals(old_in)) {  // the two transforms can be fused to one
       arg_item = memorizer.Transform(arg_item, new_in, new_in2);
     } else {

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1471,5 +1471,18 @@ def test_conv2d_reduce_channels():
         relay.build(mod, params=params, target="llvm")
 
 
+def test_axis_semantic_change():
+    x = relay.var("x", shape=(1, 1, 24, 48))
+    w1 = relay.const(np.random.uniform(size=(1, 1, 1, 1)))
+    w2 = relay.const(np.random.uniform(size=(1, 1, 1, 1)))
+    y = relay.nn.conv2d(x, w1, kernel_size=(1, 1), padding=(0, 0), channels=1)
+    y = relay.transpose(y, (0, 1, 3, 2))
+    z = relay.nn.conv2d(y, w2, kernel_size=(1, 1), padding=(0, 0), channels=1)
+    func = relay.Function([x], z)
+    mod = tvm.IRModule.from_expr(func)
+    with tvm.transform.PassContext(opt_level=3):
+        relay.build(mod, target="llvm")
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

Fix #10109 
Originally during alter layout pass each node (`LayoutAlternatedExprNode`) is tied with only one specific layout stored in `old_layout` (or `new_layout` after altering layout https://github.com/apache/tvm/blob/6a274af9cb4e7baf6d9dd06f0fb38bea5ac3154a/src/relay/transforms/transform_layout.h#L175-L176). This layout can be determined by either one of its consumer(s) or producer. Previously they are implicitly assumed to agree with each other, but this imposes restrictions on the graphs, and some reasonable graph will also violate this assumption (see #10109 for a concrete example). Actually this assumption is more than necessary for this pass. All we need is to the "delta" information of how each tensor's layout is transformed, and we don't really need to know what layouts they are before or after change. 

This PR removes this assumption. Now the specific layouts stored in `old_layout` and `new_layout` do not matter, instead, they only serve to convey that the tensor changed by the transformation `old_layout`->`new_layout`. With the new change, the alter layout pass can be understood as follows (at least IMO):

1. Visit each node in Post DFS order.
2. For each node, call the specific alter layout function. Its `InferCorrectLayout` function will tell us the "expected" input layouts from a consumer's perspective (e.g., conv_nchw will say 1st input is NCHW and 2nd is OIHW), on both the graphs before and after rewrite, denoted by `old_in2` and `new_in2`. When they differ, it means that we need to apply the transformation `old_in2`->`new_in2` on the **original** inputs to work properly (https://github.com/lazycal/tvm/blob/42364531dea0fe72e1ffc80aba89ca04e50b2a67/src/relay/transforms/transform_layout.h#L384).
3. Note that the previous transformation is assuming original input, thus prior to that we need to transform the inputs back to its layout (https://github.com/lazycal/tvm/blob/42364531dea0fe72e1ffc80aba89ca04e50b2a67/src/relay/transforms/transform_layout.h#L383).
4. Apparently the two transformations can be fused by aligning the layout letters, e.g., `layout_transform(CN->NC) + layout_transform(NW->NW8w)` is equivalent to `layout_transform(CN->NC8c)`. The previous assumption assumes that they are already aligned, thus only one transformation was inserted (https://github.com/lazycal/tvm/blob/42364531dea0fe72e1ffc80aba89ca04e50b2a67/src/relay/transforms/transform_layout.h#L381). I kept this case as well.

The only thing that I didn't fully check is `InferCorrectLayout`s. I am not fully aware of its formal semantic, but I assumed that they should return `old_in2` and `new_in2` that are transformable. Some ops may not conform to this in order to workaround the previous restriction. E.g., I found that the dense_op has this specifal hack (https://github.com/apache/tvm/compare/main...lazycal:fix-layout-pass?expand=1#diff-b1f7105acbdb593d30dc3f1506f8f226d8663164bf0e46702f8b050b056604f6L213-L216). So I just removed it.


## Misc
Another potential bug I found is that the AlterOpLayout pass seems to be overloaded. People often use it to drop a subgraph to replace a certain node (e.g., https://github.com/apache/tvm/blob/d1dafbd6d050ddcd673f567c5ff720a6b6419cfe/python/tvm/topi/x86/conv2d_alter_op.py#L171-L181), while the current code logic in `transform_layout.h` assumes only replacing a node. For example, https://github.com/apache/tvm/blob/6a274af9cb4e7baf6d9dd06f0fb38bea5ac3154a/src/relay/transforms/transform_layout.h#L388,
this transformation is performed on the args to the call object, but I believe in the subgraph case it's should be changed to the args to the subgraph.