### PR TITLE
Fix JUnit failure reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,17 +280,13 @@ stage('Build') {
             script: "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh",
             label: 'Create CPU cmake config',
           )
-          try {
-            make(ci_cpu, 'build', '-j2')
-            pack_lib('cpu', tvm_multilib_tsim)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_cpu)
-              // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
-              // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-              sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: "Rust build and test")
-            }
-          } finally {
-            junit 'build/pytest-results/*.xml'
+          make(ci_cpu, 'build', '-j2')
+          pack_lib('cpu', tvm_multilib_tsim)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_cpu)
+            // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
+            // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
+            sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: "Rust build and test")
           }
         }
       }
@@ -307,17 +303,13 @@ stage('Build') {
             script: "${docker_run} ${ci_wasm} ./tests/scripts/task_config_build_wasm.sh",
             label: 'Create WASM cmake config',
           )
-          try {
-            make(ci_wasm, 'build', '-j2')
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_wasm)
-              sh (
-                script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
-                label: 'Run WASM lint and tests',
-              )
-            }
-          } finally {
-            junit 'build/pytest-results/*.xml'
+          make(ci_wasm, 'build', '-j2')
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_wasm)
+            sh (
+              script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
+              label: 'Run WASM lint and tests',
+            )
           }
         }
       }
@@ -334,12 +326,8 @@ stage('Build') {
             script: "${docker_run} ${ci_i386} ./tests/scripts/task_config_build_i386.sh",
             label: 'Create i386 cmake config',
           )
-          try {
-            make(ci_i386, 'build', '-j2')
-            pack_lib('i386', tvm_multilib_tsim)
-          } finally {
-            junit 'build/pytest-results/*.xml'
-          }
+          make(ci_i386, 'build', '-j2')
+          pack_lib('i386', tvm_multilib_tsim)
         }
       }
     } else {
@@ -355,12 +343,8 @@ stage('Build') {
             script: "${docker_run} ${ci_arm} ./tests/scripts/task_config_build_arm.sh",
             label: 'Create ARM cmake config',
           )
-          try {
-            make(ci_arm, 'build', '-j4')
-            pack_lib('arm', tvm_multilib)
-          } finally {
-            junit 'build/pytest-results/*.xml'
-          }
+          make(ci_arm, 'build', '-j4')
+          pack_lib('arm', tvm_multilib)
         }
       }
      } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,20 +256,20 @@ def cpp_unittest(image) {
 }
 
 stage('Build') {
-    parallel 'BUILD: GPU': {
-      if (!skip_ci) {
-        node('GPUBUILD') {
-          ws(per_exec_ws('tvm/build-gpu')) {
-            init_git()
-            sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
-            make(ci_gpu, 'build', '-j2')
-            pack_lib('gpu', tvm_multilib)
-            // compiler test
-            sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
-            make(ci_gpu, 'build2', '-j2')
-          }
+  parallel 'BUILD: GPU': {
+    if (!skip_ci) {
+      node('GPUBUILD') {
+        ws(per_exec_ws('tvm/build-gpu')) {
+          init_git()
+          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
+          make(ci_gpu, 'build', '-j2')
+          pack_lib('gpu', tvm_multilib)
+          // compiler test
+          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
+          make(ci_gpu, 'build2', '-j2')
         }
       }
+    }
   },
   'BUILD: CPU': {
     if (!skip_ci && is_docs_only_build != 1) {
@@ -382,139 +382,139 @@ stage('Build') {
 }
 
 stage('Test') {
-    parallel 'unittest: GPU': {
-      if (!skip_ci && is_docs_only_build != 1) {
-        node('TensorCore') {
-          ws(per_exec_ws('tvm/ut-python-gpu')) {
-            init_git()
-            unpack_lib('gpu', tvm_multilib)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_gpu)
-              sh (
-                script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
-                label: 'Run Java unit tests',
-              )
-              sh (
-                script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh",
-                label: 'Run Python GPU unit tests',
-              )
-              sh (
-                script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh",
-                label: 'Run Python GPU integration tests',
-              )
-              junit 'build/pytest-results/*.xml'
-            }
+  parallel 'unittest: GPU': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('TensorCore') {
+        ws(per_exec_ws('tvm/ut-python-gpu')) {
+          init_git()
+          unpack_lib('gpu', tvm_multilib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_gpu)
+            sh (
+              script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
+              label: 'Run Java unit tests',
+            )
+            sh (
+              script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh",
+              label: 'Run Python GPU unit tests',
+            )
+            sh (
+              script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_integration_gpuonly.sh",
+              label: 'Run Python GPU integration tests',
+            )
+            junit 'build/pytest-results/*.xml'
           }
         }
-      } else {
-        Utils.markStageSkippedForConditional('unittest: GPU')
       }
-    },
-    'integration: CPU': {
-      if (!skip_ci && is_docs_only_build != 1) {
-        node('CPU') {
-          ws(per_exec_ws('tvm/ut-python-cpu')) {
-            init_git()
-            unpack_lib('cpu', tvm_multilib_tsim)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_cpu)
-              sh (
-                script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
-                label: 'Run CPU integration tests',
-              )
-              junit 'build/pytest-results/*.xml'
-            }
-          }
-        }
-      } else {
-        Utils.markStageSkippedForConditional('integration: CPU')
-      }
-    },
-    'unittest: CPU': {
-      if (!skip_ci && is_docs_only_build != 1) {
-        node('CPU') {
-          ws(per_exec_ws("tvm/ut-python-cpu")) {
-            init_git()
-            unpack_lib('cpu', tvm_multilib_tsim)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_cpu)
-              python_unittest(ci_cpu)
-              fsim_test(ci_cpu)
-              sh (
-                script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh",
-                label: "Run VTA tests in TSIM",
-              )
-              junit "build/pytest-results/*.xml"
-            }
-          }
-        }
-      } else {
-        Utils.markStageSkippedForConditional('unittest: CPU')
-      }
-    },
-    'python3: i386': {
-      if (!skip_ci && is_docs_only_build != 1) {
-        node('CPU') {
-          ws(per_exec_ws('tvm/ut-python-i386')) {
-            init_git()
-            unpack_lib('i386', tvm_multilib)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_i386)
-              python_unittest(ci_i386)
-              sh (
-                script: "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh",
-                label: 'Run i386 integration tests',
-              )
-              fsim_test(ci_i386)
-              junit 'build/pytest-results/*.xml'
-            }
-          }
-        }
-     } else {
-        Utils.markStageSkippedForConditional('python3: i386')
-      }
-    },
-    'python3: arm': {
-      if (!skip_ci && is_docs_only_build != 1) {
-        node('ARM') {
-          ws(per_exec_ws('tvm/ut-python-arm')) {
-            init_git()
-            unpack_lib('arm', tvm_multilib)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_arm)
-              python_unittest(ci_arm)
-              sh (
-                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh",
-                label: 'Run test_arm_compute_lib test',
-              )
-              junit 'build/pytest-results/*.xml'
-            // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
-            }
-          }
-        }
-      } else {
-         Utils.markStageSkippedForConditional('python3: arm')
-      }
-    },
-  'topi: GPU': {
-  if (!skip_ci && is_docs_only_build != 1) {
-    node('GPU') {
-      ws(per_exec_ws('tvm/topi-python-gpu')) {
-        init_git()
-        unpack_lib('gpu', tvm_multilib)
-        timeout(time: max_time, unit: 'MINUTES') {
-          ci_setup(ci_gpu)
-          sh (
-            script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh",
-            label: 'Run TOPI tests',
-          )
-          junit 'build/pytest-results/*.xml'
-        }
-      }
-    }
     } else {
-      Utils.markStageSkippedForConditional('topi: GPU')
-  }
+      Utils.markStageSkippedForConditional('unittest: GPU')
+    }
+  },
+  'integration: CPU': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('CPU') {
+        ws(per_exec_ws('tvm/ut-python-cpu')) {
+          init_git()
+          unpack_lib('cpu', tvm_multilib_tsim)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_cpu)
+            sh (
+              script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
+              label: 'Run CPU integration tests',
+            )
+            junit 'build/pytest-results/*.xml'
+          }
+        }
+      }
+    } else {
+      Utils.markStageSkippedForConditional('integration: CPU')
+    }
+  },
+  'unittest: CPU': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('CPU') {
+        ws(per_exec_ws("tvm/ut-python-cpu")) {
+          init_git()
+          unpack_lib('cpu', tvm_multilib_tsim)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_cpu)
+            python_unittest(ci_cpu)
+            fsim_test(ci_cpu)
+            sh (
+              script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh",
+              label: "Run VTA tests in TSIM",
+            )
+            junit "build/pytest-results/*.xml"
+          }
+        }
+      }
+    } else {
+      Utils.markStageSkippedForConditional('unittest: CPU')
+    }
+  },
+  'python3: i386': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('CPU') {
+        ws(per_exec_ws('tvm/ut-python-i386')) {
+          init_git()
+          unpack_lib('i386', tvm_multilib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_i386)
+            python_unittest(ci_i386)
+            sh (
+              script: "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh",
+              label: 'Run i386 integration tests',
+            )
+            fsim_test(ci_i386)
+            junit 'build/pytest-results/*.xml'
+          }
+        }
+      }
+    } else {
+      Utils.markStageSkippedForConditional('python3: i386')
+    }
+  },
+  'python3: arm': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('ARM') {
+        ws(per_exec_ws('tvm/ut-python-arm')) {
+          init_git()
+          unpack_lib('arm', tvm_multilib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_arm)
+            python_unittest(ci_arm)
+            sh (
+              script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh",
+              label: 'Run test_arm_compute_lib test',
+            )
+            junit 'build/pytest-results/*.xml'
+          // sh "${docker_run} ${ci_arm} ./tests/scripts/task_python_integration.sh"
+          }
+        }
+      }
+    } else {
+        Utils.markStageSkippedForConditional('python3: arm')
+    }
+  },
+  'topi: GPU': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('GPU') {
+        ws(per_exec_ws('tvm/topi-python-gpu')) {
+          init_git()
+          unpack_lib('gpu', tvm_multilib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            ci_setup(ci_gpu)
+            sh (
+              script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh",
+              label: 'Run TOPI tests',
+            )
+            junit 'build/pytest-results/*.xml'
+          }
+        }
+      }
+      } else {
+        Utils.markStageSkippedForConditional('topi: GPU')
+    }
   },
   'frontend: GPU': {
     if (!skip_ci && is_docs_only_build != 1) {
@@ -595,13 +595,13 @@ stage('Build packages') {
 */
 
 stage('Deploy') {
-    node('doc') {
-      ws(per_exec_ws('tvm/deploy-docs')) {
-        if (env.BRANCH_NAME == 'main') {
+  node('doc') {
+    ws(per_exec_ws('tvm/deploy-docs')) {
+      if (env.BRANCH_NAME == 'main') {
         unpack_lib('docs', 'docs.tgz')
         sh 'cp docs.tgz /var/docs/docs.tgz'
         sh 'tar xf docs.tgz -C /var/docs'
-        }
       }
     }
+  }
 }

--- a/tests/scripts/task_python_frontend.sh
+++ b/tests/scripts/task_python_frontend.sh
@@ -42,9 +42,11 @@ run_pytest cython python-frontend-coreml tests/python/frontend/coreml
 echo "Running relay Tensorflow frontend test..."
 # Note: Tensorflow tests often have memory issues, so invoke each one separately
 TENSORFLOW_TESTS=$(./tests/scripts/pytest_ids.py --folder tests/python/frontend/tensorflow)
+i=0
 for node_id in $TENSORFLOW_TESTS; do
     echo "$node_id"
-    run_pytest cython python-frontend-tensorflow "$node_id"
+    run_pytest cython "python-frontend-tensorflow-$i" "$node_id"
+    i=$((i+1))
 done
 
 echo "Running relay caffe2 frontend test..."

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 export PYTHONPATH=${PYTHONPATH}:${TVM_PATH}/apps/extension/python
@@ -44,22 +43,22 @@ rm -rf lib
 make
 cd ../..
 
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions apps/extension/tests
-run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions apps/extension/tests
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions-0 apps/extension/tests
+run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-extensions-1 apps/extension/tests
 
 # Test dso plugin
 cd apps/dso_plugin_module
 rm -rf lib
 make
 cd ../..
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_plugin_module
-run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module apps/dso_plugin_module
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module-0 apps/dso_plugin_module
+run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module-1 apps/dso_plugin_module
 
 # Do not enable TensorFlow op
 # TVM_FFI=cython sh prepare_and_test_tfop_module.sh
 # TVM_FFI=ctypes sh prepare_and_test_tfop_module.sh
 
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME} tests/python/integration
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-integration tests/python/integration
 
 # Ignoring Arm(R) Ethos(TM)-U NPU tests in the collective to run to run them in parallel in the next step.
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu

--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 
@@ -31,9 +30,9 @@ if [ -z "${TVM_UNITTEST_TESTSUITE_NAME:-}" ]; then
 fi
 
 # First run minimal test on both ctypes and cython.
-run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME}-platform-minimal-test tests/python/all-platform-minimal-test
-run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME}-platform-minimal-test tests/python/all-platform-minimal-test
+run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME}-platform-minimal-test-0 tests/python/all-platform-minimal-test
+run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME}-platform-minimal-test-1 tests/python/all-platform-minimal-test
 
 # Then run all unittests on both ctypes and cython.
-run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest
-run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest
+run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME}-0 tests/python/unittest
+run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME}-1 tests/python/unittest

--- a/tests/scripts/task_python_unittest_gpuonly.sh
+++ b/tests/scripts/task_python_unittest_gpuonly.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -euo pipefail
+set -euxo pipefail
 
 export PYTEST_ADDOPTS="-m gpu ${PYTEST_ADDOPTS:-}"
 
@@ -33,5 +33,5 @@ export TVM_UNITTEST_TESTSUITE_NAME=python-unittest-vulkan
 
 source tests/scripts/setup-pytest-env.sh
 
-run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest/test_target_codegen_vulkan.py
-run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME} tests/python/unittest/test_target_codegen_vulkan.py
+run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME}-0 tests/python/unittest/test_target_codegen_vulkan.py
+run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME}-1 tests/python/unittest/test_target_codegen_vulkan.py


### PR DESCRIPTION
Currently we only collect reports when the `junit` function runs in the Jenkinsfile, which only happens if the earlier test scripts didn't fail. We should always try to collect whatever reports are there, so this wraps everything in `try..finally` which is [apparently](https://stackoverflow.com/questions/36651432/how-to-implement-post-build-stage-using-jenkins-pipeline-plug-in) the only way to do this in a scripted pipeline (another point where moving to a declarative pipeline would simplify things). A bunch of the JUnits are also colliding and getting overwritten before Jenkins ingests them, so this fixes that as well.

Note for reviewing: first commit is all whitespace, see [this commit](https://github.com/apache/tvm/pull/10121/files/fa07581220e628080ba30db92d7ffe715c228fda..5418e9adbbe5ac195086d9d60354401b10f8ccef) for significant changes

cc @areusch @Mousius
