### PR TITLE
[CUDA] Support float16 erf,tan,atan

### DIFF
--- a/src/target/source/intrin_rule_cuda.cc
+++ b/src/target/source/intrin_rule_cuda.cc
@@ -74,7 +74,7 @@ struct CUDAFastMathTan : public CUDAMath {
         case 32:
           return name + 'f';
         case 16:
-          LOG(FATAL) << "cuda tan unsupported for float16";
+          return 'h' + name;
         default:
           return "";
       }

--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -294,20 +294,34 @@ __pack_half2(const half x, const half y) {
   return (v1 << 16) | v0;
 }
 
-// fix undefined fp16 match function
+// Some fp16 match functions are not supported in cuda_fp16.h,
+// so we define them here to make sure the generated CUDA code
+// is valid.
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)
-static inline __device__ __host__ half hpow(half x, half y) {
-  float tmp_x = __half2float(x);
-  float tmp_y = __half2float(y);
-  float result = powf(tmp_x, tmp_y);
-  return __float2half(result);
+#define CUDA_UNSUPPORTED_HALF_MATH_BINARY(HALF_MATH_NAME, FP32_MATH_NAME) \
+static inline __device__ __host__ half NAME(half x, half y) {             \
+  float tmp_x = __half2float(x);                                          \
+  float tmp_y = __half2float(y);                                          \
+  float result = FP32_MATH_NAME(tmp_x, tmp_y);                            \
+  return __float2half(result);                                            \
 }
 
-static inline __device__ __host__ half htanh(half x) {
-  float tmp_x = __half2float(x);
-  float result = tanhf(tmp_x);
-  return __float2half(result);
+#define CUDA_UNSUPPORTED_HALF_MATH_UNARY(HALF_MATH_NAME, FP32_MATH_NAME) \
+static inline __device__ __host__ half HALF_MATH_NAME(half x) {          \
+  float tmp_x = __half2float(x);                                         \
+  float result = FP32_MATH_NAME(tmp_x);                                  \
+  return __float2half(result);                                           \
 }
+
+CUDA_UNSUPPORTED_HALF_MATH_BINARY(hpow, powf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(htanh, tanhf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(htan, tanf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(hatan, atanf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(herf, erf)
+
+#undef CUDA_UNSUPPORTED_HALF_MATH_BINARY
+#undef CUDA_UNSUPPORTED_HALF_MATH_UNARY
+
 #endif
 )";
 
@@ -320,19 +334,32 @@ __pack_nv_bfloat162(const nv_bfloat16 x, const nv_bfloat16 y) {
   return (v1 << 16) | v0;
 }
 
-// fix undefined fp16 match function
-static inline __device__ __host__ nv_bfloat16 hpow(nv_bfloat16 x, nv_bfloat16 y) {
-  float tmp_x = __bfloat162float(x);
-  float tmp_y = __bfloat162float(y);
-  float result = powf(tmp_x, tmp_y);
-  return __float2bfloat16(result);
+// Some bfp16 match functions are not supported in cuda_bfp16.h,
+// so we define them here to make sure the generated CUDA code
+// is valid.
+#define CUDA_UNSUPPORTED_HALF_MATH_BINARY(HALF_MATH_NAME, FP32_MATH_NAME) \
+static inline __device__ __host__ half NAME(half x, half y) {             \
+  float tmp_x = __bfloat162float(x);                                      \
+  float tmp_y = __bfloat162float(y);                                      \
+  float result = FP32_MATH_NAME(tmp_x, tmp_y);                            \
+  return __float2bfloat16(result);                                        \
 }
 
-static inline __device__ __host__ nv_bfloat16 htanh(nv_bfloat16 x) {
-  float tmp_x = __bfloat162float(x);
-  float result = tanhf(tmp_x);
-  return __float2bfloat16(result);
+#define CUDA_UNSUPPORTED_HALF_MATH_UNARY(HALF_MATH_NAME, FP32_MATH_NAME) \
+static inline __device__ __host__ half HALF_MATH_NAME(half x) {          \
+  float tmp_x = __bfloat162float(x);                                     \
+  float result = FP32_MATH_NAME(tmp_x);                                  \
+  return __float2bfloat16(result);                                       \
 }
+
+CUDA_UNSUPPORTED_HALF_MATH_BINARY(hpow, powf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(htanh, tanhf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(htan, tanf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(hatan, atanf)
+CUDA_UNSUPPORTED_HALF_MATH_UNARY(herf, erf)
+
+#undef CUDA_UNSUPPORTED_HALF_MATH_BINARY
+#undef CUDA_UNSUPPORTED_HALF_MATH_UNARY
 )";
 
 static constexpr const char* _cuda_warp_intrinsic_util = R"(

--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -338,7 +338,7 @@ __pack_nv_bfloat162(const nv_bfloat16 x, const nv_bfloat16 y) {
 // so we define them here to make sure the generated CUDA code
 // is valid.
 #define CUDA_UNSUPPORTED_HALF_MATH_BINARY(HALF_MATH_NAME, FP32_MATH_NAME) \
-static inline __device__ __host__ half NAME(half x, half y) {             \
+static inline __device__ __host__ half HALF_MATH_NAME(half x, half y) {   \
   float tmp_x = __bfloat162float(x);                                      \
   float tmp_y = __bfloat162float(y);                                      \
   float result = FP32_MATH_NAME(tmp_x, tmp_y);                            \

--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -299,7 +299,7 @@ __pack_half2(const half x, const half y) {
 // is valid.
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)
 #define CUDA_UNSUPPORTED_HALF_MATH_BINARY(HALF_MATH_NAME, FP32_MATH_NAME) \
-static inline __device__ __host__ half NAME(half x, half y) {             \
+static inline __device__ __host__ half HALF_MATH_NAME(half x, half y) {   \
   float tmp_x = __half2float(x);                                          \
   float tmp_y = __half2float(y);                                          \
   float result = FP32_MATH_NAME(tmp_x, tmp_y);                            \

--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -294,7 +294,7 @@ __pack_half2(const half x, const half y) {
   return (v1 << 16) | v0;
 }
 
-// Some fp16 match functions are not supported in cuda_fp16.h,
+// Some fp16 math functions are not supported in cuda_fp16.h,
 // so we define them here to make sure the generated CUDA code
 // is valid.
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)

--- a/src/target/source/literal/cuda_half_t.h
+++ b/src/target/source/literal/cuda_half_t.h
@@ -334,7 +334,7 @@ __pack_nv_bfloat162(const nv_bfloat16 x, const nv_bfloat16 y) {
   return (v1 << 16) | v0;
 }
 
-// Some bfp16 match functions are not supported in cuda_bfp16.h,
+// Some bfp16 math functions are not supported in cuda_bfp16.h,
 // so we define them here to make sure the generated CUDA code
 // is valid.
 #define CUDA_UNSUPPORTED_HALF_MATH_BINARY(HALF_MATH_NAME, FP32_MATH_NAME) \


### PR DESCRIPTION
#6225 reported that some math functions (e.g., `pow` and `tanh`) are not supported in `cuda_fp16.h` and result in nvcc error due to undefined reference. The solution in #6225 is hard coded these two functions as a patch. However, other functions such as `erf`, `tan`, `atan` also have this issue, as reported by #6349. This PR adds the support of these functions with some refactors.

Meanwhile, the unit test failed to cache this issue because of the incorrect logic. This PR also fixes them.
1. The unary unit test skips all unary ops with float16 on CUDA GPU instead of just Vulkan.
2. The unary unit test never creates float16 Relay graph. Note that `relay.var("x", TensorType(shape), dtype="float16")` will create a *float32* var, because when a complete TensorType is given as a type annotation, the dtype parameter will be ignored (we should error out in this case...)

cc @vinx13 @Lunderberg @junrushao1994 