### PR TITLE
[Relay] fix a corner case when relay return empty tuple

### DIFF
--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -895,7 +895,7 @@ backend::FunctionInfo UpdateMainWorkspaceSize(const IRModule& mod, tec::TargetMa
         device_consts[device_type] += size_bytes;
       }
     } else if (expr->IsInstance<VarNode>() || expr.same_as(func->body)) {
-      CHECK_GE(virtual_devices.size(), 1) << "must be at least one device";
+      CHECK(size_bytes == 0 || virtual_devices.size() >= 1) << "must be at least one device";
       for (const auto& virtual_device : virtual_devices) {
         DLDeviceType device_type = virtual_device->device_type();
         device_io[device_type] += size_bytes;

--- a/tests/python/relay/test_backend_graph_executor.py
+++ b/tests/python/relay/test_backend_graph_executor.py
@@ -292,6 +292,14 @@ def test_compile_nested_tuples():
         ref = ref + 1
 
 
+def test_compile_return_empty_tuple():
+    x = relay.var("x", shape=[16], dtype="float32")
+    mod = tvm.IRModule.from_expr(relay.Function([x], relay.Tuple([])))
+    graph, lib, _ = relay.build(mod, "llvm")
+    mod = graph_executor.create(graph, lib, device=tvm.cpu(0))
+    mod.run()
+
+
 def test_graph_executor_nested_tuples():
     x, y, z, w = [relay.var(c, shape=(2, 3), dtype="float32") for c in "xyzw"]
     out = relay.Tuple([x, relay.Tuple([y, relay.Tuple([z, w])])])


### PR DESCRIPTION
Avoid compile error for corner case of return ().

```
#[version = "0.0.5"]
def @main(%x: Tensor[(16), float32]) {
  ()
}
```
