### PR TITLE
[skip ci] Fix for ping_reviewers wait time

### DIFF
--- a/.github/workflows/ping_reviewers.yml
+++ b/.github/workflows/ping_reviewers.yml
@@ -18,4 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eux
-          python tests/scripts/ping_reviewers.py --wait-time-minutes 1440
+          python tests/scripts/ping_reviewers.py --wait-time-minutes 10080


### PR DESCRIPTION
This was set to 1 day instead of 1 week

cc @areusch

