### PR TITLE
Use pytest-forked for tensorflow tests

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -52,6 +52,12 @@ def pytest_addoption(parser):
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--enable-corstone300-tests"):
         for item in items:
+            # See https://github.com/apache/tvm/issues/10150
+            if len(item.location) == 3 and item.location[0].startswith(
+                "tests/python/frontend/tensorflow"
+            ):
+                item.add_marker(pytest.mark.forked)
+
             if "corstone300" in item.keywords:
                 item.add_marker(
                     pytest.mark.skip(

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -56,7 +56,7 @@ def pytest_collection_modifyitems(config, items):
             if len(item.location) == 3 and item.location[0].startswith(
                 "tests/python/frontend/tensorflow"
             ):
-                item.add_marker(pytest.mark.forked)
+                item.add_marker(pytest.mark.subprocessed)
 
             if "corstone300" in item.keywords:
                 item.add_marker(

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -30,7 +30,7 @@ set -o pipefail
 #
 echo "Additional setup in ${CI_IMAGE_NAME}"
 
-python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
+python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0 pytest-forked==1.4.0
 
 # Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -30,7 +30,7 @@ set -o pipefail
 #
 echo "Additional setup in ${CI_IMAGE_NAME}"
 
-python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0 pytest-forked==1.4.0
+python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0 pytest-subprocessed
 
 # Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().


### PR DESCRIPTION
This auto-marks all tensorflow frontend tests with `pytest.mark.forked`, which tells pytest to run each test in a subprocess rather than in the main test process. Hopefully this will help alleviate #10150 as the memory used should be released when the test subprocess ends.

Tested locally by running a tensorflow test then `ps -aef --forest` and confirming that with the decorator a subprocess is spawned.

cc @areusch @altanh @tkonolige

