### PR TITLE
[microTVM][Tutorials] Add tutorials to run on ci_qemu

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -27,11 +27,15 @@ Autotuning with microTVM
 This tutorial explains how to autotune a model using the C runtime.
 """
 
+import os
+import json
 import numpy as np
 import pathlib
 
 import tvm
 from tvm.relay.backend import Runtime
+
+use_physical_hw = bool(os.getenv("TVM_MICRO_USE_HW"))
 
 ####################
 # Defining the model
@@ -77,6 +81,7 @@ params = {"weight": weight_sample}
 # PLATFORM list in this tutorial. You can chose the platform by passing --platform argument when running
 # this tutorial.
 #
+
 RUNTIME = Runtime("crt", {"system-lib": True})
 TARGET = tvm.target.target.micro("host")
 
@@ -85,8 +90,15 @@ TARGET = tvm.target.target.micro("host")
 #  When running on physical hardware, choose a TARGET and a BOARD that describe the hardware. The
 #  STM32L4R5ZI Nucleo target and board is chosen in the example below.
 #
-#    TARGET = tvm.target.target.micro("stm32l4r5zi")
-#    BOARD = "nucleo_l4r5zi"
+
+if use_physical_hw:
+    boards_file = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")) / "boards.json"
+    with open(boards_file) as f:
+        boards = json.load(f)
+
+    BOARD = os.getenv("TVM_MICRO_BOARD", default="nucleo_l4r5zi")
+    TARGET = tvm.target.target.micro(boards[BOARD]["model"])
+
 
 #########################
 # Extracting tuning tasks
@@ -97,6 +109,7 @@ TARGET = tvm.target.target.micro("host")
 #
 # Because task extraction involves running the compiler, we first configure the compiler's
 # transformation passes; we'll apply the same configuration later on during autotuning.
+#
 
 pass_context = tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True})
 with pass_context:
@@ -115,7 +128,6 @@ assert len(tasks) > 0
 # choose other options by choosing from `PLATFORM` list.
 #
 
-
 module_loader = tvm.micro.AutoTvmModuleLoader(
     template_project_dir=pathlib.Path(tvm.micro.get_microtvm_template_projects("crt")),
     project_options={"verbose": False},
@@ -133,38 +145,46 @@ measure_option = tvm.autotvm.measure_option(builder=builder, runner=runner)
 
 # Compiling for physical hardware
 # --------------------------------------------------------------------------
-#    module_loader = tvm.micro.AutoTvmModuleLoader(
-#        template_project_dir=pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")),
-#        project_options={
-#            "zephyr_board": BOARD,
-#            "west_cmd": "west",
-#            "verbose": False,
-#            "project_type": "host_driven",
-#        },
-#    )
-#    builder = tvm.autotvm.LocalBuilder(
-#        n_parallel=1,
-#        build_kwargs={"build_option": {"tir.disable_vectorize": True}},
-#        do_fork=False,
-#        build_func=tvm.micro.autotvm_build_func,
-#    )
-#    runner = tvm.autotvm.LocalRunner(number=1, repeat=1, timeout=100, module_loader=module_loader)
 #
-#    measure_option = tvm.autotvm.measure_option(builder=builder, runner=runner)
+
+if use_physical_hw:
+    module_loader = tvm.micro.AutoTvmModuleLoader(
+        template_project_dir=pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")),
+        project_options={
+            "zephyr_board": BOARD,
+            "west_cmd": "west",
+            "verbose": False,
+            "project_type": "host_driven",
+        },
+    )
+    builder = tvm.autotvm.LocalBuilder(
+        n_parallel=1,
+        build_kwargs={"build_option": {"tir.disable_vectorize": True}},
+        do_fork=False,
+        build_func=tvm.micro.autotvm_build_func,
+        runtime=RUNTIME,
+    )
+    runner = tvm.autotvm.LocalRunner(number=1, repeat=1, timeout=100, module_loader=module_loader)
+
+    measure_option = tvm.autotvm.measure_option(builder=builder, runner=runner)
 
 ################
 # Run Autotuning
 ################
 # Now we can run autotuning separately on each extracted task.
+#
 
-num_trials = 10
+autotune_log_file = pathlib.Path("microtvm_autotune.log.txt")
+autotune_log_file.unlink()
+
+num_trials = 2
 for task in tasks:
     tuner = tvm.autotvm.tuner.GATuner(task)
     tuner.tune(
         n_trial=num_trials,
         measure_option=measure_option,
         callbacks=[
-            tvm.autotvm.callback.log_to_file("microtvm_autotune.log.txt"),
+            tvm.autotvm.callback.log_to_file(str(autotune_log_file)),
             tvm.autotvm.callback.progress_bar(num_trials, si_prefix="M"),
         ],
         si_prefix="M",
@@ -176,12 +196,12 @@ for task in tasks:
 # For comparison, let's compile and run the graph without imposing any autotuning schedules. TVM
 # will select a randomly-tuned implementation for each operator, which should not perform as well as
 # the tuned operator.
+#
 
 with pass_context:
     lowered = tvm.relay.build(relay_mod, target=TARGET, runtime=RUNTIME, params=params)
 
 temp_dir = tvm.contrib.utils.tempdir()
-
 project = tvm.micro.generate_project(
     str(tvm.micro.get_microtvm_template_projects("crt")),
     lowered,
@@ -191,17 +211,21 @@ project = tvm.micro.generate_project(
 
 # Compiling for physical hardware
 # --------------------------------------------------------------------------
-#    project = tvm.micro.generate_project(
-#        str(tvm.micro.get_microtvm_template_projects("zephyr")),
-#        lowered,
-#        temp_dir / "project",
-#        {
-#            "zephyr_board": BOARD,
-#            "west_cmd": "west",
-#            "verbose": False,
-#            "project_type": "host_driven",
-#        },
-#    )
+#
+
+if use_physical_hw:
+    temp_dir = tvm.contrib.utils.tempdir()
+    project = tvm.micro.generate_project(
+        str(tvm.micro.get_microtvm_template_projects("zephyr")),
+        lowered,
+        temp_dir / "project",
+        {
+            "zephyr_board": BOARD,
+            "west_cmd": "west",
+            "verbose": False,
+            "project_type": "host_driven",
+        },
+    )
 
 project.build()
 project.flash()
@@ -219,12 +243,11 @@ with tvm.micro.Session(project.transport()) as session:
 ##########################
 # Once autotuning completes, you can time execution of the entire program using the Debug Runtime:
 
-with tvm.autotvm.apply_history_best("microtvm_autotune.log.txt"):
+with tvm.autotvm.apply_history_best(str(autotune_log_file)):
     with pass_context:
         lowered_tuned = tvm.relay.build(relay_mod, target=TARGET, runtime=RUNTIME, params=params)
 
 temp_dir = tvm.contrib.utils.tempdir()
-
 project = tvm.micro.generate_project(
     str(tvm.micro.get_microtvm_template_projects("crt")),
     lowered_tuned,
@@ -234,17 +257,21 @@ project = tvm.micro.generate_project(
 
 # Compiling for physical hardware
 # --------------------------------------------------------------------------
-#    project = tvm.micro.generate_project(
-#        str(tvm.micro.get_microtvm_template_projects("zephyr")),
-#        lowered_tuned,
-#        temp_dir / "project",
-#        {
-#            "zephyr_board": BOARD,
-#            "west_cmd": "west",
-#            "verbose": False,
-#            "project_type": "host_driven",
-#        },
-#    )
+#
+
+if use_physical_hw:
+    temp_dir = tvm.contrib.utils.tempdir()
+    project = tvm.micro.generate_project(
+        str(tvm.micro.get_microtvm_template_projects("zephyr")),
+        lowered_tuned,
+        temp_dir / "project",
+        {
+            "zephyr_board": BOARD,
+            "west_cmd": "west",
+            "verbose": False,
+            "project_type": "host_driven",
+        },
+    )
 
 project.build()
 project.flash()

--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -89,8 +89,6 @@ TARGET = tvm.target.target.micro("host")
 # --------------------------------------------------------------------------
 #  When running on physical hardware, choose a TARGET and a BOARD that describe the hardware. The
 #  STM32L4R5ZI Nucleo target and board is chosen in the example below.
-#
-
 if use_physical_hw:
     boards_file = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")) / "boards.json"
     with open(boards_file) as f:
@@ -144,9 +142,6 @@ runner = tvm.autotvm.LocalRunner(number=1, repeat=1, timeout=100, module_loader=
 measure_option = tvm.autotvm.measure_option(builder=builder, runner=runner)
 
 # Compiling for physical hardware
-# --------------------------------------------------------------------------
-#
-
 if use_physical_hw:
     module_loader = tvm.micro.AutoTvmModuleLoader(
         template_project_dir=pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")),
@@ -168,16 +163,17 @@ if use_physical_hw:
 
     measure_option = tvm.autotvm.measure_option(builder=builder, runner=runner)
 
-################
+##########################
 # Run Autotuning
-################
-# Now we can run autotuning separately on each extracted task.
+##########################
+# Now we can run autotuning separately on each extracted task on microTVM device.
 #
 
 autotune_log_file = pathlib.Path("microtvm_autotune.log.txt")
-autotune_log_file.unlink()
+if os.path.exists(autotune_log_file):
+    os.remove(autotune_log_file)
 
-num_trials = 2
+num_trials = 10
 for task in tasks:
     tuner = tvm.autotvm.tuner.GATuner(task)
     tuner.tune(
@@ -210,9 +206,6 @@ project = tvm.micro.generate_project(
 )
 
 # Compiling for physical hardware
-# --------------------------------------------------------------------------
-#
-
 if use_physical_hw:
     temp_dir = tvm.contrib.utils.tempdir()
     project = tvm.micro.generate_project(
@@ -256,9 +249,6 @@ project = tvm.micro.generate_project(
 )
 
 # Compiling for physical hardware
-# --------------------------------------------------------------------------
-#
-
 if use_physical_hw:
     temp_dir = tvm.contrib.utils.tempdir()
     project = tvm.micro.generate_project(

--- a/tests/python/contrib/test_cmsisnn/test_networks.py
+++ b/tests/python/contrib/test_cmsisnn/test_networks.py
@@ -79,16 +79,19 @@ def convert_to_relay(
 @tvm.testing.requires_cmsisnn
 def test_cnn_small():
     # download the model
-    base_url = "https://github.com/ARM-software/ML-zoo/raw/ee35139af86bdace5e502b09fe8b9da9cb1f06bb/models/keyword_spotting/cnn_small/tflite_int8"
+    base_url = "https://github.com/ARM-software/ML-zoo/raw/48a22ee22325d15d2371a6df24eb7d67e21dcc97/models/keyword_spotting/cnn_small/tflite_int8"
     file_to_download = "cnn_s_quantized.tflite"
-    model_file = download_testdata("{}/{}".format(base_url, file_to_download), file_to_download)
+    file_saved = "cnn_s_quantized_15Dec2021.tflite"
+    model_file = download_testdata("{}/{}".format(base_url, file_to_download), file_saved)
 
     with open(model_file, "rb") as f:
         tflite_model_buf = f.read()
 
     input_shape = (1, 490)
+    dtype = "int8"
+    in_min, in_max = get_range_for_dtype_str(dtype)
     rng = np.random.default_rng(12345)
-    input_data = rng.random(input_shape, dtype=np.float32)
+    input_data = rng.integers(in_min, high=in_max, size=input_shape, dtype=dtype)
 
     orig_mod, params = convert_to_relay(tflite_model_buf, input_data, "input")
     cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod, params)

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -250,7 +250,7 @@ def test_autotune():
     inputs = {"data": input_data}
 
     target = tvm.target.target.micro("host")
-    template_project_dir = pathlib.Path(tvm.micro.get_standalone_crt_dir()) / "template" / "host"
+    template_project_dir = pathlib.Path(tvm.micro.get_microtvm_template_projects("crt"))
 
     pass_context = tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True})
     with pass_context:

--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -44,3 +44,13 @@ run_pytest ctypes python-microtvm-stm32 tests/micro/stm32
 # Common Tests
 run_pytest ctypes python-microtvm-common-qemu_x86 tests/micro/common --board=qemu_x86
 run_pytest ctypes python-microtvm-common-due tests/micro/common  --test-build-only --board=due
+
+# # Tutorials running with host CRT
+python3 gallery/how_to/work_with_microtvm/micro_tflite.py
+python3 gallery/how_to/work_with_microtvm/micro_autotune.py
+
+# Tutorials running with Zephyr
+export TVM_MICRO_USE_HW=1
+export TVM_MICRO_BOARD=qemu_x86
+python3 gallery/how_to/work_with_microtvm/micro_tflite.py
+python3 gallery/how_to/work_with_microtvm/micro_autotune.py


### PR DESCRIPTION
This PR enables running `micro_autotune.py` and `micro_tflite` on ci_qemu in both CRT host mode and Zephyr qemu_x86.


