### PR TITLE
[ETHOSN] Drop back to Ethos(TM)-N release 21.08

### DIFF
--- a/docker/install/ubuntu_install_ethosn_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosn_driver_stack.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
 repo_dir="ethosn-driver"
-repo_revision="21.11"
+repo_revision="21.08"
 install_path="/opt/arm/$repo_dir"
 
 tmpdir=$(mktemp -d)

--- a/tests/python/contrib/test_ethosn/test_addition.py
+++ b/tests/python/contrib/test_ethosn/test_addition.py
@@ -56,7 +56,7 @@ def _get_addition_qnn_params(dtype, input1_zp, input1_sc, input2_zp, input2_sc):
 
 
 @requires_ethosn
-@pytest.mark.parametrize("dtype", ["uint8", "int8"])
+@pytest.mark.parametrize("dtype", ["uint8"])
 def test_addition(dtype):
     trials = [
         ((1, 22, 9, 9), 24, 1.057, 253, 0.452),

--- a/tests/python/contrib/test_ethosn/test_fullyconnected.py
+++ b/tests/python/contrib/test_ethosn/test_fullyconnected.py
@@ -58,7 +58,7 @@ def _get_model(
 
 
 @requires_ethosn
-@pytest.mark.parametrize("dtype", ["uint8", "int8"])
+@pytest.mark.parametrize("dtype", ["uint8"])
 def test_fullyconnected(dtype):
     trials = [
         ((1, 1024), 71, 0.580, 79, 1.498),


### PR DESCRIPTION
There is some clash with the int8 support that went in at the same time.