### PR TITLE
TVMC: Don't divide trials by zero tasks

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -468,7 +468,7 @@ def tune_model(
 
         # In autotvm, trials is specified per task. We can convert the per-model input
         # provided to per-task trials by dividing by the number of tasks.
-        trials = int(trials / len(tasks))
+        trials = int(trials / max(len(tasks), 1))
         logger.info("Autotuning with %d trials per task.", trials)
 
         tuning_options = {


### PR DESCRIPTION
Fixes https://github.com/apache/tvm/issues/9657.

If there are no tasks to tune, the number of trails are meaningless.