### PR TITLE
[TIR][Schedule] Opaque block does not satisfy stage-pipeline

### DIFF
--- a/include/tvm/tir/schedule/block_scope.h
+++ b/include/tvm/tir/schedule/block_scope.h
@@ -223,7 +223,8 @@ class BlockScopeNode : public Object {
    * 1) The region cover property holds for every of its child blocks
    * 2) No write-after-read dependency or opaque dependency, only read-after-write and
    * write-after-write are allowed
-   * 3) All the statements in the scope are schedulable statements, i.e. Block and For
+   * 3) All the statements in the scope are schedulable statements,
+   *    i.e. schedulable Blocks (block with block vars) and For
    */
   bool stage_pipeline{false};
 

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -225,6 +225,11 @@ class BlockInfoCollector : private StmtVisitor {
                                         const Array<StmtSRef>& child_block_srefs) {
     const StmtSRefNode* limit = scope_root->parent;
     bool stage_pipeline = true;
+    // Step 0. All blocks are not opaque
+    for (const StmtSRef& block_sref : child_block_srefs) {
+      const BlockNode* block = TVM_SREF_TO_BLOCK(block, block_sref);
+      if (block->iter_vars.empty()) stage_pipeline = false;
+    }
     // Step 1. Unbind the read/write regions of each child block
     std::unordered_map<const StmtSRefNode*, Array<BufferRegion>> block_reads_unbound;
     std::unordered_map<const StmtSRefNode*, Array<BufferRegion>> block_writes_unbound;

--- a/tests/python/unittest/test_tir_schedule_compute_inline.py
+++ b/tests/python/unittest/test_tir_schedule_compute_inline.py
@@ -280,6 +280,7 @@ def access_opaque_ptr_then_elemwise(a: T.handle, b: T.handle) -> None:
     BB = T.alloc_buffer([1024])
     with T.block("opaque"):
         # annotated opaque partial access
+        vi = T.axis.S(0, 0)
         T.reads(A[0:512])
         T.writes(A_cache[0:512])
         T.evaluate(

--- a/tests/python/unittest/test_tir_schedule_state_cached_flags.py
+++ b/tests/python/unittest/test_tir_schedule_state_cached_flags.py
@@ -430,7 +430,7 @@ def test_block_in_opaque_block():
     assert s._get_cached_flags(_get_block(s, "B")) == CachedFlags(
         affine_binding=True,
         region_cover=True,
-        stage_pipeline=True,
+        stage_pipeline=False,
     )
     assert s._get_cached_flags(_get_block(s, "C")) == CachedFlags(
         affine_binding=True,


### PR DESCRIPTION
Stage pipeline property requires all stmts in scope are schedulable stmts, which means opaque block (block without block vars) does not satisfy the property. 

This PR fixes the bug.

cc @junrushao1994 @spectrometerHBH 