### PR TITLE
gitignore build-* folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .Python
 env/
 build/
+build-*/
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
I have couple of build folders in my tvm repository, I don't want to manage my own branch and updating it with main branch, so I decided to create very very simple PR with gitignore update.
