### PR TITLE
[MetaSchedule] Add target field to MetaScheduleContext

### DIFF
--- a/include/tvm/meta_schedule/integration.h
+++ b/include/tvm/meta_schedule/integration.h
@@ -21,6 +21,7 @@
 
 #include <tvm/meta_schedule/database.h>
 #include <tvm/support/with.h>
+#include <tvm/target/target.h>
 
 #include <unordered_set>
 
@@ -38,12 +39,15 @@ class ExtractedTaskNode : public runtime::Object {
   String task_name;
   /*! \brief The high-level IR */
   IRModule mod;
+  /*! \brief Target */
+  Target target;
   /*! \brief A list of low-level IRs that the high-level IR could potentially dispatch to */
   Array<IRModule> dispatched;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("task_name", &task_name);
     v->Visit("mod", &mod);
+    v->Visit("target", &target);
     v->Visit("dispatched", &dispatched);
   }
 
@@ -62,7 +66,7 @@ class ExtractedTask : public runtime::ObjectRef {
    * \brief The high-level IR
    * \brief A list of low-level IRs that the high-level IR could potentially dispatch to
    */
-  explicit ExtractedTask(String task_name, IRModule mod, Array<IRModule> dispatched);
+  explicit ExtractedTask(String task_name, IRModule mod, Target target, Array<IRModule> dispatched);
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ExtractedTask, runtime::ObjectRef, ExtractedTaskNode);
 };
 
@@ -79,6 +83,7 @@ class MetaScheduleContextNode : public runtime::Object {
    * \brief The entry point of the integration
    * \param task_name The name of the task
    * \param mod The high-level IR
+   * \param target Target info
    * \param dispatched A list of low-level IRs that the high-level IR could potentially dispatch to.
    *                   NullOpt means the dispatch needs to be done in the context.
    * \return There are different types of the output
@@ -87,7 +92,7 @@ class MetaScheduleContextNode : public runtime::Object {
    *         3) relay::Function if `mod` should be dispatched to BYOC workflow
    *         4) IRModule for unified dispatch
    */
-  virtual Optional<ObjectRef> Query(runtime::String task_name, IRModule mod,
+  virtual Optional<ObjectRef> Query(runtime::String task_name, IRModule mod, Target target,
                                     Optional<Array<IRModule>> dispatched) = 0;
 
   static constexpr const char* _type_key = "meta_schedule.MetaScheduleContext";
@@ -116,6 +121,7 @@ class MetaScheduleContext : public runtime::ObjectRef {
    * IR should call this method for task extraction and for feedback hints
    * \param task_name The name of the task
    * \param mod The high-level IR
+   * \param target Target info
    * \param dispatched A list of low-level IRs that the high-level IR could potentially dispatch to
    * \return There are different types of the output
    *         1) NullOpt if there is no feedback hint
@@ -123,7 +129,7 @@ class MetaScheduleContext : public runtime::ObjectRef {
    *         3) relay::Function if `mod` should be dispatched to BYOC workflow
    *         4) IRModule for unified dispatch
    */
-  static Optional<ObjectRef> QueryInsideWithScope(runtime::String task_name, IRModule mod,
+  static Optional<ObjectRef> QueryInsideWithScope(runtime::String task_name, IRModule mod, Target target,
                                                   Optional<Array<IRModule>> dispatched);
 
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(MetaScheduleContext, runtime::ObjectRef,
@@ -151,7 +157,7 @@ class TaskExtractionNode : public MetaScheduleContextNode {
   void VisitAttrs(AttrVisitor* v) { v->Visit("tasks", &tasks); }
 
   // Inherited from base class
-  Optional<ObjectRef> Query(runtime::String task_name, IRModule mod,
+  Optional<ObjectRef> Query(runtime::String task_name, IRModule mod, Target target,
                             Optional<Array<IRModule>> dispatched) final;
 
   static constexpr const char* _type_key = "meta_schedule.TaskExtraction";
@@ -186,7 +192,7 @@ class ApplyHistoryBestNode : public MetaScheduleContextNode {
   }
 
   // Inherited from base class
-  Optional<ObjectRef> Query(runtime::String task_name, IRModule mod,
+  Optional<ObjectRef> Query(runtime::String task_name, IRModule mod, Target target,
                             Optional<Array<IRModule>> dispatched) final;
 
   static constexpr const char* _type_key = "meta_schedule.ApplyHistoryBest";

--- a/include/tvm/meta_schedule/integration.h
+++ b/include/tvm/meta_schedule/integration.h
@@ -129,7 +129,8 @@ class MetaScheduleContext : public runtime::ObjectRef {
    *         3) relay::Function if `mod` should be dispatched to BYOC workflow
    *         4) IRModule for unified dispatch
    */
-  static Optional<ObjectRef> QueryInsideWithScope(runtime::String task_name, IRModule mod, Target target,
+  static Optional<ObjectRef> QueryInsideWithScope(runtime::String task_name, IRModule mod,
+                                                  Target target,
                                                   Optional<Array<IRModule>> dispatched);
 
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(MetaScheduleContext, runtime::ObjectRef,

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -39,6 +39,8 @@ class ExtractedTask(Object):
         The name of the task extracted
     mod : IRModule
         The high-level IR
+    target: Target
+        Target information
     dispatched : List[IRModule]
         A list of low-level IRs that the high-level IR could potentially dispatch to
     """
@@ -51,12 +53,14 @@ class ExtractedTask(Object):
         self,
         task_name: str,
         mod: IRModule,
+        target: Target,
         dispatched: List[IRModule],
     ) -> None:
         self.__init_handle_by_constructor__(
             _ffi_api.ExtractedTask,  # type: ignore # pylint: disable=no-member
             task_name,
             mod,
+            target,
             dispatched,
         )
 
@@ -69,6 +73,7 @@ class MetaScheduleContext(Object):
         self,
         task_name: str,
         mod: IRModule,
+        target: Target,
         dispatched: Optional[List[IRModule]],
     ) -> Union[IRModule, RelayFunc, PrimFunc, None]:
         """The entry point of the integration
@@ -79,6 +84,8 @@ class MetaScheduleContext(Object):
             The name of the task extracted
         mod : IRModule
             The high-level IR
+        target: Target
+            Target Info
         dispatched : Optional[List[IRModule]]
             A list of low-level IRs that the high-level IR could potentially dispatch to
 
@@ -95,6 +102,7 @@ class MetaScheduleContext(Object):
             self,
             task_name,
             mod,
+            target,
             dispatched,
         )
 
@@ -114,6 +122,7 @@ class MetaScheduleContext(Object):
     def query_inside_with_scope(
         task_name: str,
         mod: IRModule,
+        target: Target,
         dispatched: Optional[List[IRModule]],
     ) -> Union[IRModule, RelayFunc, PrimFunc, None]:
         """The entry point of the integration workflow. The compilation process of the high-level
@@ -126,7 +135,7 @@ class MetaScheduleContext(Object):
             def query_inside_with_scope(task_name, mod, dispatched):
                 ctx = MetaScheduleContext.current()
                 assert ctx is not None
-                ctx.query(task_name, mod, dispatched)
+                ctx.query(task_name, mod, target, dispatched)
 
         Parameters
         ----------
@@ -134,6 +143,8 @@ class MetaScheduleContext(Object):
             The name of the task
         mod : IRModule
             The high-level IR
+        target: Target
+            Target
         dispatched : Optional[List[IRModule]]
             A list of low-level IRs that the high-level IR could potentially dispatch to
 
@@ -149,6 +160,7 @@ class MetaScheduleContext(Object):
         return _ffi_api.MetaScheduleContextQueryInsideWithScope(  # type: ignore # pylint: disable=no-member
             task_name,
             mod,
+            target,
             dispatched,
         )
 

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -43,10 +43,11 @@ bool HasOnlyOneFunction(const IRModule& mod) {
 
 /**************** ExtractedTask ****************/
 
-ExtractedTask::ExtractedTask(String task_name, IRModule mod, Array<IRModule> dispatched) {
+ExtractedTask::ExtractedTask(String task_name, IRModule mod, Target target, Array<IRModule> dispatched) {
   ObjectPtr<ExtractedTaskNode> n = make_object<ExtractedTaskNode>();
   n->task_name = task_name;
   n->mod = mod;
+  n->target = target;
   n->dispatched = dispatched;
   data_ = n;
 }
@@ -78,9 +79,9 @@ void MetaScheduleContext::ExitWithScope() {
 }
 
 Optional<ObjectRef> MetaScheduleContext::QueryInsideWithScope(
-    runtime::String task_name, IRModule mod, Optional<Array<IRModule>> dispatched) {
+    runtime::String task_name, IRModule mod, Target target, Optional<Array<IRModule>> dispatched) {
   if (Optional<MetaScheduleContext> ctx = MetaScheduleContext::Current()) {
-    return ctx.value()->Query(task_name, mod, dispatched);
+    return ctx.value()->Query(task_name, mod, target, dispatched);
   }
   return NullOpt;
 }
@@ -93,14 +94,14 @@ TaskExtraction::TaskExtraction() {
   data_ = n;
 }
 
-Optional<ObjectRef> TaskExtractionNode::Query(runtime::String task_name, IRModule mod,
+Optional<ObjectRef> TaskExtractionNode::Query(runtime::String task_name, IRModule mod, Target target,
                                               Optional<Array<IRModule>> dispatched) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);
   IRModule prim_mod = dispatched.value()[0];
   ICHECK(HasOnlyOneFunction<tir::PrimFunc>(prim_mod)) << prim_mod;
   ICHECK(HasOnlyOneFunction<relay::Function>(mod)) << mod;
-  tasks.push_back(ExtractedTask(task_name, mod, {prim_mod}));
+  tasks.push_back(ExtractedTask(task_name, mod, target, {prim_mod}));
   return NullOpt;
 }
 
@@ -112,7 +113,7 @@ ApplyHistoryBest::ApplyHistoryBest(Database database) {
   data_ = n;
 }
 
-Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod,
+Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Target target,
                                                 Optional<Array<IRModule>> dispatched) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);
@@ -147,9 +148,9 @@ TVM_REGISTER_NODE_TYPE(TaskExtractionNode);
 TVM_REGISTER_NODE_TYPE(ApplyHistoryBestNode);
 
 TVM_REGISTER_GLOBAL("meta_schedule.ExtractedTask")
-    .set_body_typed([](String task_name, IRModule mod,
+    .set_body_typed([](String task_name, IRModule mod, Target target,
                        Array<IRModule> dispatched) -> ExtractedTask {
-      return ExtractedTask(task_name, mod, dispatched);
+      return ExtractedTask(task_name, mod, target, dispatched);
     });
 TVM_REGISTER_GLOBAL("meta_schedule.MetaScheduleContextEnterScope")
     .set_body_typed(MetaScheduleContextInternal::EnterScope);

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -43,7 +43,8 @@ bool HasOnlyOneFunction(const IRModule& mod) {
 
 /**************** ExtractedTask ****************/
 
-ExtractedTask::ExtractedTask(String task_name, IRModule mod, Target target, Array<IRModule> dispatched) {
+ExtractedTask::ExtractedTask(String task_name, IRModule mod, Target target,
+                             Array<IRModule> dispatched) {
   ObjectPtr<ExtractedTaskNode> n = make_object<ExtractedTaskNode>();
   n->task_name = task_name;
   n->mod = mod;
@@ -94,8 +95,8 @@ TaskExtraction::TaskExtraction() {
   data_ = n;
 }
 
-Optional<ObjectRef> TaskExtractionNode::Query(runtime::String task_name, IRModule mod, Target target,
-                                              Optional<Array<IRModule>> dispatched) {
+Optional<ObjectRef> TaskExtractionNode::Query(runtime::String task_name, IRModule mod,
+                                              Target target, Optional<Array<IRModule>> dispatched) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);
   IRModule prim_mod = dispatched.value()[0];
@@ -113,7 +114,8 @@ ApplyHistoryBest::ApplyHistoryBest(Database database) {
   data_ = n;
 }
 
-Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Target target,
+Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod,
+                                                Target target,
                                                 Optional<Array<IRModule>> dispatched) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -183,8 +183,8 @@ class ScheduleBuilder : public backend::MemoizedExprTranslator<Array<te::Tensor>
             << "meta_schedule.MetaScheduleContextQueryInsideWithScope is not registered";
         prim_func = (*f_create_func)(tensor_outs);
         Optional<ObjectRef> opt_mod_or_base_func =
-            (*f_meta_schedule)(prim_fn_var->name_hint, IRModule({{prim_fn_var, relay_func}}), target_,
-                               Array<IRModule>{IRModule({{prim_fn_var, prim_func}})});
+            (*f_meta_schedule)(prim_fn_var->name_hint, IRModule({{prim_fn_var, relay_func}}),
+                               target_, Array<IRModule>{IRModule({{prim_fn_var, prim_func}})});
         if (const auto* result = opt_mod_or_base_func.as<tir::PrimFuncNode>()) {
           prim_func = GetRef<tir::PrimFunc>(result);
         } else {

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -183,7 +183,7 @@ class ScheduleBuilder : public backend::MemoizedExprTranslator<Array<te::Tensor>
             << "meta_schedule.MetaScheduleContextQueryInsideWithScope is not registered";
         prim_func = (*f_create_func)(tensor_outs);
         Optional<ObjectRef> opt_mod_or_base_func =
-            (*f_meta_schedule)(prim_fn_var->name_hint, IRModule({{prim_fn_var, relay_func}}),
+            (*f_meta_schedule)(prim_fn_var->name_hint, IRModule({{prim_fn_var, relay_func}}), target_,
                                Array<IRModule>{IRModule({{prim_fn_var, prim_func}})});
         if (const auto* result = opt_mod_or_base_func.as<tir::PrimFuncNode>()) {
           prim_func = GetRef<tir::PrimFunc>(result);

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -70,7 +70,7 @@ def test_meta_schedule_integration_task_extraction_query():
         dtype="float32",
     )
     env = TaskExtraction()
-    env.query(task_name="mock-task", mod=mod, dispatched=[MockModule])
+    env.query(task_name="mock-task", mod=mod, target=Target("llvm"), dispatched=[MockModule])
     _check_mock_task(env.tasks, mod)
 
 
@@ -104,6 +104,7 @@ def test_meta_schedule_integration_query_inside_with_scope():
         MetaScheduleContext.query_inside_with_scope(
             task_name="mock-task",
             mod=mod,
+            target=Target("llvm"),
             dispatched=[MockModule],
         )
     _check_mock_task(env.tasks, mod)
@@ -166,11 +167,12 @@ def test_meta_schedule_integration_apply_history_best():
     )
     database = DummyDatabase()
     env = ApplyHistoryBest(database)
+    target = Target("llvm")
     workload = database.commit_workload(MockModule)
     database.commit_tuning_record(
-        TuningRecord(Schedule(MockModule).trace, [1.0], workload, Target("llvm"), [])
+        TuningRecord(Schedule(MockModule).trace, [1.0], workload, target, [])
     )
-    mod = env.query(task_name="mock-task", mod=mod, dispatched=[MockModule])
+    mod = env.query(task_name="mock-task", mod=mod, target=target, dispatched=[MockModule])
     assert tvm.ir.structural_equal(mod, workload.mod)
 
 


### PR DESCRIPTION
Since a tuning task can be target-dependent, this PR adds target field to `MetaScheduleContext` and `ExtractedTask` to maintain target information. 

cc: @junrushao1994 @zxybazh 

I've also noticed that current database interface commits and query workload in target-agnostic fashion. 
https://github.com/apache/tvm/blob/main/tests/python/unittest/test_meta_schedule_integration.py#L169-L173
I think `workload` = `mod` + `target` in the same context with the change in this PR, but I would be happy to receive other inputs before I make the change. 