### PR TITLE
Revert "[AUTOTVM] Use opt level 3 when extracting tasks"

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("autotvm")
 
 
 # TODO(moreau89) find a more elegant way to lower for VTAs
-def _lower(mod, target, params, opt_level=3):
+def _lower(mod, target, params):
     """Helper to lower VTA properly."""
     # pylint: disable=import-outside-toplevel
     from tvm import relay
@@ -43,19 +43,16 @@ def _lower(mod, target, params, opt_level=3):
     if hasattr(target, "device_name") and target.device_name == "vta":
         import vta
 
-        with vta.build_config(opt_level=opt_level, disabled_pass={"AlterOpLayout"}):
+        with vta.build_config(opt_level=3, disabled_pass={"AlterOpLayout"}):
             mod, _ = relay.optimize(mod, target, params)
             grc = graph_executor_codegen.GraphExecutorCodegen(None, target)
             grc.codegen(mod, mod["main"])
             return
 
-    # Alter op layout code has been written expecting that tuning is applied
-    # without it, so we disable AlterOpLayout to maintain that behavior.
-    with tvm.transform.PassContext(opt_level=opt_level, disabled_pass={"AlterOpLayout"}):
-        compiler = relay.vm.VMCompiler()
-        if params:
-            compiler.set_params(params)
-        compiler.lower(mod, target=target)
+    compiler = relay.vm.VMCompiler()
+    if params:
+        compiler.set_params(params)
+    compiler.lower(mod, target=target)
 
 
 def extract_from_program(mod, params, target, target_host=None, ops=None):


### PR DESCRIPTION
Reverts apache/tvm#10065.

After doing a sweep on nvidia t4 with 2000 autotvm trials, I'm seeing regressions across the board as compared to before this commit. We should revert and investigate why this is happening before we enable this change broadly


![image](https://user-images.githubusercontent.com/13473689/152583529-b9237054-b1b5-43b6-91b1-8bee353dd595.png)