### PR TITLE
[BugFix][TVMScript] Use operator `is` when recognizing TIR Module

### DIFF
--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -1226,7 +1226,7 @@ def from_source(
     elif inspect.isfunction(input_func):
         _, start_line = inspect.getsourcelines(input_func)
         env: Dict[str, Any] = input_func.__globals__
-        namespace = [key for key in env.keys() if env[key] == tir]
+        namespace = [key for key in env.keys() if env[key] is tir]
         parser = TVMScriptParser(start_line, namespace)
         result = to_ast(input_func, TVMDiagnosticCtx(), parser)
         return result

--- a/tests/python/unittest/test_tvmscript_regression.py
+++ b/tests/python/unittest/test_tvmscript_regression.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import numpy
+
+import tvm
+from tvm.script import tir as T
+
+
+# This numpy array is used to test the comparison between the global objects and the
+# `tvm.script.tir` submodule.
+np_array = numpy.array([0, 1, 2, 3])
+
+
+@T.prim_func
+def matmul(a: T.handle, b: T.handle, c: T.handle) -> None:
+    A = T.match_buffer(a, [128, 128])
+    B = T.match_buffer(b, [128, 128])
+    C = T.match_buffer(c, [128, 128])
+
+    for i, j, k in T.grid(128, 128, 128):
+        with T.block("update"):
+            vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+            with T.init():
+                C[vi, vj] = T.float32(0)
+            C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
+
+
+def test_multi_element_array_in_outmost_namespace():
+    func = matmul
+    rt_func = tvm.script.from_source(func.script(show_meta=True))
+    tvm.ir.assert_structural_equal(func, rt_func)
+
+
+if __name__ == "__main__":
+    test_multi_element_array_in_outmost_namespace()


### PR DESCRIPTION
This PR fixes a bug in TVMScript parser. The bug will be triggered by the following code.

```python
import numpy as np
from tvm.script import tir as T


indptr = np.array([0, 1, 2, 3])


@T.prim_func
def func(A_data: T.Buffer[(13056,), "float32"], B_data: T.Buffer[(131072,), "float32"], C_data: T.Buffer[(131072,), "float32"], J_indptr: T.Buffer[(33,), "int32"], J_indices: T.Buffer[(51,), "int32"]) -> None:
    for v_vi, v_vbi, v_vf in T.grid(32, 16, 256):
        with T.block("bsrmm0"):
            vi, vbi, vf = T.axis.remap("SSS", [v_vi, v_vbi, v_vf])
            ...
```

The code above leads to error
```
Traceback (most recent call last):
  File "tensorir.py", line 111, in <module>
    def func(A_data: T.Buffer[(13056,), "float32"], B_data: T.Buffer[(131072,), "float32"], C_data: T.Buffer[(131072,), "float32"], J_indptr: T.Buffer[(33,), "int32"], J_indices: T.Buffer[(51,), "int32"]) -> None:
  File "/home/rhlai/tvm/python/tvm/script/tir/prim_func.py", line 40, in prim_func
    result = from_source(input_func)
  File "/home/rhlai/tvm/python/tvm/script/parser.py", line 1209, in from_source
    namespace = [key for key in env.keys() if env[key] == tir]
  File "/home/rhlai/tvm/python/tvm/script/parser.py", line 1209, in <listcomp>
    namespace = [key for key in env.keys() if env[key] == tir]
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
, which is because previously we used operator `==` to recognize the `tvm.script.tir` submodule. When `key` is `indptr`, `env[key]` will be `numpy.ndarray([0, 1, 2, 3])`. Comparing a `numpy.ndarray` with `tir` submodule using operator `==` leads to the error.

To avoid the error, we are supposed to use operator `is` for the comparison.

---

However, I'm not sure how to add a suitable regression test 😐, and would like to ask for some idea to add a test.

cc @junrushao1994 @vinx13 @Hzfengsy @tqchen 