### PR TITLE
[skip ci] Fix scipy intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,7 @@ latex_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
     "matplotlib": ("https://matplotlib.org/", None),
 }
 


### PR DESCRIPTION
Scipy [changed their docs](https://github.com/scipy/scipy/issues/15545) recently to be pinned to each release, so we need to update the URL we pass to intersphinx accordingly. Skipping CI on this to unblock other developers but local testing with

```bash
python tests/scripts/ci.py docs
```

both showed the same error as CI before this change and no error after.

cc @junrushao1994 
