### PR TITLE
[USMP] Register hill climb algorithm

### DIFF
--- a/include/tvm/tir/usmp/algorithms.h
+++ b/include/tvm/tir/usmp/algorithms.h
@@ -54,6 +54,17 @@ Map<BufferInfo, PoolAllocation> GreedyBySize(const Array<BufferInfo>& buffer_inf
 Map<BufferInfo, PoolAllocation> GreedyByConflicts(const Array<BufferInfo>& buffer_info_arr,
                                                   const Integer& memory_pressure);
 
+/*!
+ * \brief The Hill-Climb algorithm to plan memory
+ *
+ * This will perform a hill climbing algorithm in deciding the offsets
+ * within provided Pools.
+ *
+ * \return A Map of BufferInfo objects and their associated PoolAllocation
+ */
+Map<BufferInfo, PoolAllocation> HillClimb(const Array<BufferInfo>& buffer_info_arr,
+                                          const Integer& memory_pressure);
+
 }  // namespace algo
 }  // namespace usmp
 }  // namespace tir

--- a/src/tir/usmp/unified_static_memory_planner.cc
+++ b/src/tir/usmp/unified_static_memory_planner.cc
@@ -46,7 +46,8 @@ static constexpr const char* kDefaultAlgo = "greedy_by_size";
 static std::unordered_map<String, std::function<Map<BufferInfo, PoolAllocation>(
                                       const Array<BufferInfo>&, const Integer&)>>
     algorithms{{"greedy_by_size", algo::GreedyBySize},
-               {"greedy_by_conflicts", algo::GreedyByConflicts}};
+               {"greedy_by_conflicts", algo::GreedyByConflicts},
+               {"hill_climb", algo::HillClimb}};
 
 IRModule PlanMemory(const IRModule& mod, String algo) {
   VLOG(1) << "workspace required = " << CalculateModuleWorkspaceSize(mod);

--- a/src/tir/usmp/unified_static_memory_planner.cc
+++ b/src/tir/usmp/unified_static_memory_planner.cc
@@ -56,7 +56,7 @@ IRModule PlanMemory(const IRModule& mod, String algo) {
   Array<BufferInfo> buffer_info_arr =
       CreateArrayBufferInfo(buffer_info_analysis->buffer_info_stmts);
   CHECK(algorithms.count(algo)) << "The selected USMP algorithm : " << algo
-                                << "is not defined. Please define it in the above algorithms map.";
+                                << " is not defined. Please define it in the above algorithms map.";
   Map<BufferInfo, PoolAllocation> buffer_info_pool_allocations =
       algorithms[algo](buffer_info_arr, buffer_info_analysis->memory_pressure);
   Map<Stmt, PoolAllocation> stmt_pool_allocations = AssignStmtPoolAllocations(


### PR DESCRIPTION
While the hill-climbing algorithm for the Unified Static Memory Planner (see #8404, #9565) was recently added to TVM in #9704, it currently can not be used by the default TVM flow due to this error:

```
TVMError: Check failed: (algorithms.count(algo)) is false: The selected USMP algorithm : hill_climbis not defined. Please define it in the above algorithms map.
```

I was able to fix this by just adding an entry in the mentioned algorithms map.

If there was a reason whythe Hill Climb allocator was not registred until now, feel free to let me know.