### PR TITLE
[MetaSchedule] bug fix in ApplyHistoryBest

### DIFF
--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -130,7 +130,11 @@ Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRMod
     Array<TuningRecord> records = database->GetTopK(database->CommitWorkload(prim_mod), 1);
     if (records.size() == 1) {
       LOG(INFO) << "Applied history best for " << task_name << ".";
-      return records[0]->workload->mod;
+      tir::Schedule sch =
+          tir::Schedule::Traced(records[0]->workload->mod, /*seed=*/-1, /*debug_mask=*/0,
+                                /*error_render_level=*/tir::ScheduleErrorRenderLevel::kNone);
+      records[0]->trace->ApplyToSchedule(sch, false);
+      return sch->mod();
     }
   }
   return NullOpt;


### PR DESCRIPTION
I found out that `ApplyHistoryBest` did not apply the traces from the tuning history. 
This PR fixes this issue and enables the application of tuning history during relay build.
e.g., 
```
with ApplyHistoryBest(db):
   with tvm.transform.PassContext(opt_level=3):
        ex, lib = relay.build(mod, target)
``` 

cc: @junrushao1994 @zxybazh 