### PR TITLE
[TVMC] Add codegen args to tvmc

### DIFF
--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -131,7 +131,9 @@ curl --retry 64 -sSL ${mobilenet_url} -o ./mobilenet_v2_1.0_224_INT8.tflite
 # Compile model for Arm(R) Cortex(R)-M55 CPU and Ethos(TM)-U55 NPU
 # An alternative to using "python3 -m tvm.driver.tvmc" is to call
 # "tvmc" directly once TVM has been pip installed.
-python3 -m tvm.driver.tvmc compile --target="ethos-u -accelerator_config=ethos-u55-256, cmsis-nn, c" \
+python3 -m tvm.driver.tvmc compile --target=ethos-u,cmsis-nn,c \
+    --target-ethos-u-accelerator_config=ethos-u55-256 \
+    --target-cmsis-nn-mcpu=cortex-m55 \
     --target-c-mcpu=cortex-m55 \
     --runtime=crt \
     --executor=aot \

--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -26,6 +26,9 @@ import re
 import tvm
 from tvm.driver import tvmc
 from tvm.driver.tvmc import TVMCException
+from tvm.driver.tvmc.composite_target import get_codegen_by_target, get_codegen_names
+from tvm.ir.attrs import make_node, _ffi_api as attrs_api
+from tvm.ir.transform import PassContext
 from tvm.target import Target, TargetKind
 
 # pylint: disable=invalid-name
@@ -54,6 +57,25 @@ def _generate_target_kind_args(parser, kind_name):
             )
 
 
+def _generate_codegen_args(parser, codegen_name):
+    codegen = get_codegen_by_target(codegen_name)
+    pass_configs = PassContext.list_configs()
+
+    if codegen["config_key"] is not None and codegen["config_key"] in pass_configs:
+        target_group = parser.add_argument_group(f"target {codegen_name}")
+        attrs = make_node(pass_configs[codegen["config_key"]]["type"])
+        fields = attrs_api.AttrsListFieldInfo(attrs)
+        for field in fields:
+            for tvm_type, python_type in INTERNAL_TO_NATIVE_TYPE.items():
+                if field.type_info.startswith(tvm_type):
+                    target_option = field.name
+                    target_group.add_argument(
+                        f"--target-{codegen_name}-{target_option}",
+                        type=python_type,
+                        help=f"target {codegen_name} {target_option}{python_type}",
+                    )
+
+
 def generate_target_args(parser):
     """Walks through the TargetKind registry and generates arguments for each Target's options"""
     parser.add_argument(
@@ -63,6 +85,8 @@ def generate_target_args(parser):
     )
     for target_kind in _valid_target_kinds():
         _generate_target_kind_args(parser, target_kind)
+    for codegen_name in get_codegen_names():
+        _generate_codegen_args(parser, codegen_name)
 
 
 def _reconstruct_target_kind_args(args, kind_name):
@@ -76,6 +100,27 @@ def _reconstruct_target_kind_args(args, kind_name):
     return kind_options
 
 
+def _reconstruct_codegen_args(args, codegen_name):
+    codegen = get_codegen_by_target(codegen_name)
+    pass_configs = PassContext.list_configs()
+    codegen_options = {}
+
+    if codegen["config_key"] is not None and codegen["config_key"] in pass_configs:
+        attrs = make_node(pass_configs[codegen["config_key"]]["type"])
+        fields = attrs_api.AttrsListFieldInfo(attrs)
+        for field in fields:
+            for tvm_type in INTERNAL_TO_NATIVE_TYPE:
+                if field.type_info.startswith(tvm_type):
+                    target_option = field.name
+                    var_name = (
+                        f"target_{codegen_name.replace('-', '_')}_{target_option.replace('-', '_')}"
+                    )
+                    option_value = getattr(args, var_name)
+                    if option_value is not None:
+                        codegen_options[target_option] = option_value
+    return codegen_options
+
+
 def reconstruct_target_args(args):
     """Reconstructs the target options from the arguments"""
     reconstructed = {}
@@ -83,6 +128,12 @@ def reconstruct_target_args(args):
         kind_options = _reconstruct_target_kind_args(args, target_kind)
         if kind_options:
             reconstructed[target_kind] = kind_options
+
+    for codegen_name in get_codegen_names():
+        codegen_options = _reconstruct_codegen_args(args, codegen_name)
+        if codegen_options:
+            reconstructed[codegen_name] = codegen_options
+
     return reconstructed
 
 
@@ -349,6 +400,10 @@ def target_from_cli(target, additional_target_options=None):
             target = _recombobulate_target(tvm_targets[0])
             target_host = _recombobulate_target(tvm_targets[1])
 
-        extra_targets = [t for t in parsed_targets if not t["is_tvm_target"]]
+        extra_targets = [
+            _combine_target_options(t, additional_target_options)
+            for t in parsed_targets
+            if not t["is_tvm_target"]
+        ]
 
     return tvm.target.Target(target, host=target_host), extra_targets

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -34,11 +34,40 @@ def test_target_to_argparse():
     assert parsed.target_llvm_mattr == "+fp,+mve"
 
 
+def test_target_to_argparse_known_codegen():
+    parser = argparse.ArgumentParser()
+    generate_target_args(parser)
+    parsed, _ = parser.parse_known_args(
+        [
+            "--target=cmsis-nn,llvm",
+            "--target-cmsis-nn-mcpu=cortex-m3",
+            "--target-llvm-mattr=+fp,+mve",
+            "--target-llvm-mcpu=cortex-m3",
+        ]
+    )
+    assert parsed.target == "cmsis-nn,llvm"
+    assert parsed.target_llvm_mcpu == "cortex-m3"
+    assert parsed.target_llvm_mattr == "+fp,+mve"
+    assert parsed.target_cmsis_nn_mcpu == "cortex-m3"
+
+
 def test_mapping_target_args():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)
     parsed, _ = parser.parse_known_args(["--target=llvm", "--target-llvm-mcpu=cortex-m3"])
     assert reconstruct_target_args(parsed) == {"llvm": {"mcpu": "cortex-m3"}}
+
+
+def test_include_known_codegen():
+    parser = argparse.ArgumentParser()
+    generate_target_args(parser)
+    parsed, _ = parser.parse_known_args(
+        ["--target=cmsis-nn,c", "--target-cmsis-nn-mcpu=cortex-m55", "--target-c-mcpu=cortex-m55"]
+    )
+    assert reconstruct_target_args(parsed) == {
+        "c": {"mcpu": "cortex-m55"},
+        "cmsis-nn": {"mcpu": "cortex-m55"},
+    }
 
 
 def test_skip_target_from_codegen():
@@ -67,6 +96,18 @@ def test_target_recombobulation_many():
     assert "-device=mali" in str(tvm_target)
     assert "-mtriple=aarch64-linux-gnu" in str(tvm_target.host)
     assert "-mcpu=cortex-m3" in str(tvm_target.host)
+
+
+def test_target_recombobulation_codegen():
+    tvm_target, extras = target_from_cli(
+        "cmsis-nn, c -mcpu=cortex-m55",
+        {"cmsis-nn": {"mcpu": "cortex-m55"}},
+    )
+
+    assert "-mcpu=cortex-m55" in str(tvm_target)
+    assert len(extras) == 1
+    assert extras[0]["name"] == "cmsis-nn"
+    assert extras[0]["opts"] == {"mcpu": "cortex-m55"}
 
 
 def test_error_if_target_missing():

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -19,6 +19,7 @@ import argparse
 
 import pytest
 
+import tvm
 from tvm.driver.tvmc import TVMCException
 from tvm.driver.tvmc.target import generate_target_args, reconstruct_target_args, target_from_cli
 
@@ -34,6 +35,7 @@ def test_target_to_argparse():
     assert parsed.target_llvm_mattr == "+fp,+mve"
 
 
+@tvm.testing.requires_cmsisnn
 def test_target_to_argparse_known_codegen():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)
@@ -58,6 +60,7 @@ def test_mapping_target_args():
     assert reconstruct_target_args(parsed) == {"llvm": {"mcpu": "cortex-m3"}}
 
 
+@tvm.testing.requires_cmsisnn
 def test_include_known_codegen():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)


### PR DESCRIPTION
This enables external codegen arguments similar to those for `Target`s:

```
tvmc compile --target=cmsis-nn,c --target-cmsis-nn-mcpu=cortex-m55
```