### PR TITLE
Generate correct output tensor names in C Interface API

### DIFF
--- a/apps/microtvm/ethosu/src/demo_bare_metal.c
+++ b/apps/microtvm/ethosu/src/demo_bare_metal.c
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
 
   printf("Running inference\n");
   struct tvmgen_default_outputs outputs = {
-      .output = output,
+      .MobilenetV2_Predictions_Reshape_11 = output,
   };
   struct tvmgen_default_inputs inputs = {
       .tfl_quantize = input,

--- a/apps/microtvm/ethosu/src/demo_freertos.c
+++ b/apps/microtvm/ethosu/src/demo_freertos.c
@@ -106,7 +106,7 @@ static void prvInferenceTask(void* pvParameters) {
       .tfl_quantize = pucReceivedData,
   };
   struct tvmgen_default_outputs xOutputs = {
-      .output = output,
+      .MobilenetV2_Predictions_Reshape_11 = output,
   };
   struct ethosu_driver* xDriver = ethosu_reserve_driver();
   struct tvmgen_default_devices xDevices = {

--- a/apps/microtvm/zephyr/template_project/src/aot_demo/main.c
+++ b/apps/microtvm/zephyr/template_project/src/aot_demo/main.c
@@ -178,7 +178,7 @@ void TVMInfer() {
       .input_1 = input_data,
   };
   struct tvmgen_default_outputs outputs = {
-      .output = output_data,
+      .Identity = output_data,
   };
 
   StackMemoryManager_Init(&app_workspace, g_aot_memory, WORKSPACE_SIZE);

--- a/apps/microtvm/zephyr_cmsisnn/src/main.c
+++ b/apps/microtvm/zephyr_cmsisnn/src/main.c
@@ -62,7 +62,7 @@ void main(void) {
   StackMemoryManager_Init(&app_workspace, g_crt_workspace, TVMGEN_DEFAULT_WORKSPACE_SIZE);
 
   struct tvmgen_default_inputs inputs = {.input = input_storage};
-  struct tvmgen_default_outputs outputs = {.output = output_storage};
+  struct tvmgen_default_outputs outputs = {.Identity = output_storage};
 
   if (tvmgen_default_run(&inputs, &outputs) != 0) {
     printk("Model run failed\n");

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -270,9 +270,13 @@ def _get_inputs_and_outputs_from_module(mod):
     main_func = _get_main_relay_func(mod)
     inputs = [argument.name_hint for argument in main_func.params]
 
-    outputs = ["output"]
-    if isinstance(main_func.ret_type, TupleType):
-        outputs = _convert_tuple_to_outputs(main_func.ret_type)
+    if "output_tensor_names" in main_func.attrs:
+        outputs = main_func.attrs["output_tensor_names"]
+    else:
+        if isinstance(main_func.ret_type, TupleType):
+            outputs = _convert_tuple_to_outputs(main_func.ret_type)
+        else:
+            outputs = ["output"]
 
     return inputs, outputs
 

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -18,7 +18,6 @@
 """Tensorflow lite frontend."""
 import itertools
 import math
-import re
 
 import numpy as np
 import tvm
@@ -31,6 +30,7 @@ from .. import expr as _expr
 from .. import function as _function
 from .. import op as _op
 from .. import qnn as _qnn
+from ..backend.name_transforms import sanitize_name
 from .common import ExprTable
 from .common import infer_shape as _infer_shape
 from .common import to_int_list
@@ -3774,7 +3774,7 @@ def from_tflite(model, shape_dict=None, dtype_dict=None, op_converter=OperatorCo
         "DictAttrs",
         **{
             "output_tensor_names": [
-                re.sub(r"\W", "_", get_tensor_name(subgraph, model_output))
+                sanitize_name(get_tensor_name(subgraph, model_output))
                 for model_output in model_outputs
             ]
         },

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -179,14 +179,14 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     });
 
 ExecutorCodegenMetadata::ExecutorCodegenMetadata(
-    Array<tir::Var> inputs, Array<tir::Var> pools, Array<String> devices, Integer num_outputs,
+    Array<tir::Var> inputs, Array<tir::Var> pools, Array<String> devices, Array<String> outputs,
     String executor, String mod_name, String interface_api, bool unpacked_api,
     Map<tir::Var, tir::usmp::AllocatedPoolInfo> pool_inputs) {
   auto n = make_object<ExecutorCodegenMetadataNode>();
   n->inputs = inputs;
   n->pools = pools;
   n->devices = devices;
-  n->num_outputs = num_outputs;
+  n->outputs = outputs;
   n->executor = executor;
   n->interface_api = interface_api;
   n->unpacked_api = unpacked_api;

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -61,10 +61,10 @@ class ExecutorCodegenMetadataNode : public Object {
  public:
   /*! \brief input information for the main function */
   Array<tir::Var> inputs;
+  /*! \brief output information for the main function */
+  Array<String> outputs;
   /*! \brief pool information for the main function */
   Array<tir::Var> pools;
-  /*! \brief number of outputs of the main function */
-  Integer num_outputs = 1;
   /*! \brief device contexts information for the main function */
   Array<String> devices;
   /*! \brief the executor to be used to run the model */
@@ -81,7 +81,7 @@ class ExecutorCodegenMetadataNode : public Object {
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("inputs", &inputs);
     v->Visit("pools", &pools);
-    v->Visit("num_outputs", &num_outputs);
+    v->Visit("outputs", &outputs);
     v->Visit("devices", &devices);
     v->Visit("executor", &executor);
     v->Visit("unpacked_api", &unpacked_api);
@@ -98,7 +98,7 @@ class ExecutorCodegenMetadataNode : public Object {
 class ExecutorCodegenMetadata : public ObjectRef {
  public:
   TVM_DLL ExecutorCodegenMetadata(Array<tir::Var> inputs, Array<tir::Var> pools,
-                                  Array<String> devices, Integer num_outputs, String executor,
+                                  Array<String> devices, Array<String> outputs, String executor,
                                   String mod_name, String interface_api = "packed",
                                   bool unpacked_api = false,
                                   Map<tir::Var, tir::usmp::AllocatedPoolInfo> pool_inputs =

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -273,7 +273,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
         }
         call_args_ss << " " << input_var->name_hint << ",";
       }
-      for (int i = 0; i < metadata_->num_outputs->value; ++i) {
+      for (unsigned int i = 0; i < metadata_->outputs.size(); ++i) {
         call_args_ss << "void* output" << i << ",";
       }
       for (const tir::Var& pool_var : metadata_->pools) {
@@ -300,7 +300,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
       for (unsigned int i = 0; i < metadata_->inputs.size(); ++i) {
         call_args_ss << "((DLTensor*)(((TVMValue*)args)[" << i << "].v_handle))[0].data,";
       }
-      for (int i = 0; i < metadata_->num_outputs->value; ++i) {
+      for (unsigned int i = 0; i < metadata_->outputs.size(); ++i) {
         int j = metadata_->inputs.size() + i;
         call_args_ss << "((DLTensor*)(((TVMValue*)args)[" << j << "].v_handle))[0].data,";
       }
@@ -328,7 +328,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
       entrypoint_arg_count++;
       run_func_arg_count++;
     }
-    for (int i = 0; i < metadata_->num_outputs->value; i++) {
+    for (unsigned int i = 0; i < metadata_->outputs.size(); i++) {
       run_func_to_entry_point_args[run_func_arg_count] = Integer(entrypoint_arg_count);
       entrypoint_arg_count++;
       run_func_arg_count++;
@@ -356,7 +356,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
 
     // We are creating a copy of the set of pointers
     size_t number_of_io_tensors =
-        metadata_->inputs.size() + metadata_->num_outputs->value + metadata_->pools.size();
+        metadata_->inputs.size() + metadata_->outputs.size() + metadata_->pools.size();
     code_ << "TVMValue tensors[" << number_of_io_tensors << "];\n";
 
     std::unordered_map<int, ObjectRef> run_func_to_entry_point_args =
@@ -395,7 +395,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
         }
         call_args_ss << " " << relay::backend::SanitizeName(input_var->name_hint) << ",";
       }
-      for (int i = 0; i < metadata_->num_outputs->value; ++i) {
+      for (unsigned int i = 0; i < metadata_->outputs.size(); ++i) {
         call_args_ss << "void* output" << i << ",";
       }
       for (const tir::Var& pool_var : metadata_->pools) {
@@ -449,13 +449,11 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
       for (const auto& input : metadata_->inputs) {
         call_args_ss << "inputs->" << relay::backend::SanitizeName(input->name_hint) << ",";
       }
-      if (metadata_->num_outputs->value == 1) {
-        call_args_ss << "outputs->output,";
-      } else {
-        for (int i = 0; i < metadata_->num_outputs->value; ++i) {
-          call_args_ss << "outputs->output" << i << ",";
-        }
+      for (const auto& output : metadata_->outputs) {
+        call_args_ss << "outputs->" << relay::backend::SanitizeName(output);
+        call_args_ss << ",";
       }
+
       for (const tir::Var& pool_var : metadata_->pools) {
         String pool_name = metadata_->pool_inputs.value()[pool_var]->pool_info->pool_name;
         if (IsInternalWorkspaceBuffer(pool_var)) {

--- a/tests/micro/zephyr/test_utils.py
+++ b/tests/micro/zephyr/test_utils.py
@@ -210,7 +210,7 @@ def generate_project(
                         model_files_path, arcname=os.path.relpath(model_files_path, tar_temp_dir)
                     )
                 header_path = generate_c_interface_header(
-                    lowered.libmod_name, ["input_1"], ["output"], [], [], 0, model_files_path
+                    lowered.libmod_name, ["input_1"], ["Identity"], [], [], 0, model_files_path
                 )
                 tf.add(header_path, arcname=os.path.relpath(header_path, tar_temp_dir))
 

--- a/tests/python/contrib/test_ethosu/infra.py
+++ b/tests/python/contrib/test_ethosu/infra.py
@@ -306,9 +306,10 @@ def generate_ref_data_tflite(model):
         interpreter.set_tensor(index, value)
     interpreter.invoke()
 
-    expected_output_data = [
-        interpreter.get_tensor(output_detail["index"]) for output_detail in output_details
-    ]
+    expected_output_data = {
+        output_detail["name"]: interpreter.get_tensor(output_detail["index"])
+        for output_detail in output_details
+    }
 
     return input_data, expected_output_data
 

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -754,7 +754,7 @@ def test_ethosu_right_shift_binary_elemwise(
         "ifm": lhs,
         "ifm2": rhs,
     }
-    output_data = generate_output_data(input_data)
+    output_data = {"output": generate_output_data(input_data)[0]}
     ethosu_mod = _create_ethosu_partition(cpu_mod)
 
     _compare_ethosu_with_reference(ethosu_mod, input_data, output_data, accel_type)
@@ -781,7 +781,7 @@ def test_ethosu_identity_codegen(ifm_shape, ifm_scale, ifm_zp, ofm_scale, ofm_zp
 
     cpu_mod = create_model()
     input_data = {"ifm": np.random.randint(-120, high=120, size=ifm_shape, dtype="int8")}
-    output_data = generate_output_data(input_data)
+    output_data = {"output": generate_output_data(input_data)[0]}
     ethosu_mod = _create_ethosu_partition(cpu_mod)
 
     _compare_ethosu_with_reference(
@@ -910,7 +910,7 @@ def test_ethosu_clz(accel_type):
 
     cpu_mod = create_model()
     input_data = {"ifm": np.random.randint(-500000, high=500000, size=ifm_shape, dtype="int32")}
-    output_data = generate_output_data(input_data)
+    output_data = {"output": generate_output_data(input_data)[0]}
     ethosu_mod = _create_ethosu_partition(cpu_mod)
 
     _compare_ethosu_with_reference(ethosu_mod, input_data, output_data, accel_type)

--- a/tests/python/contrib/test_ethosu/test_lookup_table.py
+++ b/tests/python/contrib/test_ethosu/test_lookup_table.py
@@ -154,7 +154,7 @@ def test_random_lut(accel_type):
     compiled_models = infra.build_source(
         mod,
         {"ifm": in_data},
-        out_data,
+        {"output": out_data},
         accel_type,
     )
 

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -59,7 +59,7 @@ class AOTTestModel(NamedTuple):
     inputs: Dict[str, np.array]
         Dict of input names to value arrays
     outputs: List[np.array]
-        Ordered list of output value arrays
+        Dict of output names to value arrays
     output_tolerance: Optional[Union[int, float]]
         Allowed tolerance of the output
     name: str
@@ -72,7 +72,7 @@ class AOTTestModel(NamedTuple):
 
     module: tvm.IRModule
     inputs: Dict[str, np.array]
-    outputs: List[np.array]
+    outputs: Dict[str, np.array]
     output_tolerance: Optional[Union[int, float]] = None
     name: str = "default"
     params: Optional[Dict[str, np.array]] = None
@@ -304,16 +304,19 @@ int main(){\n
     main_file.write(custom_prologue)
 
 
-def emit_main_data(main_file, input_map, output_list, mod_name):
+def emit_main_data(main_file, input_map, output_map, mod_name):
     for key in input_map:
         sanitized_tensor_name = re.sub(r"\W", "_", key)
         main_file.write(
             f'#include "{mangle_name(mod_name,"input_data")}_{sanitized_tensor_name}.h"\n'
         )
 
-    for i in range(0, len(output_list)):
-        main_file.write(f'#include "{mangle_name(mod_name,"expected_output_data")}{i}.h"\n')
-        main_file.write(f'#include "{mangle_name(mod_name,"output_data")}{i}.h"\n')
+    for key in output_map:
+        sanitized_tensor_name = re.sub(r"\W", "_", key)
+        main_file.write(
+            f'#include "{mangle_name(mod_name,"expected_output_data")}_{sanitized_tensor_name}.h"\n'
+            f'#include "{mangle_name(mod_name,"output_data")}_{sanitized_tensor_name}.h"\n'
+        )
 
 
 def emit_main_device_structs(main_file, devices, mod_name):
@@ -336,7 +339,7 @@ def emit_main_workspace_pool_structs(main_file, workspace_pool_names, mod_name):
         main_file.write("};\n")
 
 
-def emit_main_data_structs(main_file, input_map, output_list, mod_name):
+def emit_main_data_structs(main_file, input_map, output_map, mod_name):
     main_file.write(
         f"struct {mangle_name(mod_name, 'inputs')} {mangle_name(mod_name, 'inputs')} = {{"
     )
@@ -350,17 +353,16 @@ def emit_main_data_structs(main_file, input_map, output_list, mod_name):
     main_file.write(
         f"struct {mangle_name(mod_name, 'outputs')} {mangle_name(mod_name, 'outputs')} = {{"
     )
-    num_outputs = len(output_list)
-    if num_outputs == 1:
-        main_file.write(f"\t.output = {mangle_name(mod_name, 'output_data')}0,\n")
-    else:
-        for i in range(0, num_outputs):
-            main_file.write(f"\t.output{i} = {mangle_name(mod_name, 'output_data')}{i},\n")
+    for key in output_map:
+        sanitized_tensor_name = re.sub(r"\W", "_", key)
+        main_file.write(
+            f"\t.{sanitized_tensor_name} = {mangle_name(mod_name, 'output_data')}_{sanitized_tensor_name},\n"
+        )
     main_file.write("};\n")
 
 
-def emit_main_data_setup(main_file, input_map, output_list, mod_name):
-    num_outputs = len(output_list)
+def emit_main_data_setup(main_file, input_map, output_map, mod_name):
+    num_outputs = len(output_map)
     num_inputs = len(input_map)
 
     main_file.write(f'void* {mangle_name(mod_name,"inputs")}[{num_inputs}] = {{ ')
@@ -370,8 +372,9 @@ def emit_main_data_setup(main_file, input_map, output_list, mod_name):
     main_file.write("};\n")
 
     main_file.write(f'void* {mangle_name(mod_name,"outputs")}[{num_outputs}]  = {{ ')
-    for i in range(0, num_outputs):
-        main_file.write(f'{mangle_name(mod_name,"output_data")}{i}, ')
+    for key in output_map:
+        sanitized_tensor_name = re.sub(r"\W", "_", key)
+        main_file.write(f'{mangle_name(mod_name, "output_data")}_{sanitized_tensor_name}, ')
     main_file.write("};\n")
 
 
@@ -446,13 +449,12 @@ def emit_main_packed_call(main_file, input_map, output_list, mod_name):
     main_file.write("\n")
 
 
-def emit_main_compare(main_file, output_list, output_tolerance, mod_name):
-    num_outputs = len(output_list)
-    actual_data_name = mangle_name(mod_name, "output_data")
-    expected_data_name = mangle_name(mod_name, "expected_output_data")
-
-    for i in range(0, num_outputs):
-        is_float_dtype = output_list[i].dtype == "float32"
+def emit_main_compare(main_file, outputs, output_tolerance, mod_name):
+    for key in outputs:
+        sanitized_tensor_name = re.sub(r"\W", "_", key)
+        actual_data_name = mangle_name(mod_name, f"output_data_{sanitized_tensor_name}")
+        expected_data_name = mangle_name(mod_name, f"expected_output_data_{sanitized_tensor_name}")
+        is_float_dtype = outputs[key].dtype == "float32"
 
         comparison_function = "abs"
         tolerance = output_tolerance or 0
@@ -462,8 +464,8 @@ def emit_main_compare(main_file, output_list, output_tolerance, mod_name):
 
         main_file.write(
             f"""
-            for (int i = 0; i<{actual_data_name}{i}_len; i++) {{
-                if ({comparison_function}({actual_data_name}{i}[i]-{expected_data_name}{i}[i]) > {tolerance}) {{
+            for (int i = 0; i<{actual_data_name}_len; i++) {{
+                if ({comparison_function}({actual_data_name}[i]-{expected_data_name}[i]) > {tolerance}) {{
                     printf("{AOT_FAILURE_TOKEN}\\n");
                     return -1;
                 }}
@@ -721,16 +723,17 @@ def run_and_check(
                 data_linkage,
             )
 
-        for i in range(len(model.outputs)):
+        for key in model.outputs:
+            sanitized_tensor_name = re.sub(r"\W", "_", key)
             create_header_file(
-                (f'{mangle_name(model.name,"output_data")}{i}'),
-                np.zeros(model.outputs[i].shape, model.outputs[i].dtype),
+                f'{mangle_name(model.name, "output_data")}_{sanitized_tensor_name}',
+                np.zeros(model.outputs[key].shape, model.outputs[key].dtype),
                 include_path,
                 data_linkage,
             )
             create_header_file(
-                (f'{mangle_name(model.name, "expected_output_data")}{i}'),
-                model.outputs[i],
+                f'{mangle_name(model.name, "expected_output_data")}_{sanitized_tensor_name}',
+                model.outputs[key],
                 include_path,
                 data_linkage,
             )
@@ -852,4 +855,16 @@ def generate_ref_data(mod, input_data, params=None, target="llvm"):
     grt_mod.run()
     output_count = grt_mod.get_num_outputs()
     out = [grt_mod.get_output(i).numpy() for i in range(output_count)]
-    return out
+    if isinstance(mod, tvm.relay.Function):
+        main = mod
+    else:
+        main = mod["main"]
+    if main.attrs == None or main.attrs["output_tensor_names"] == None:
+        if output_count == 1:
+            output_tensor_names = ["output"]
+        else:
+            output_tensor_names = [f"output{i}" for i in range(output_count)]
+    else:
+        output_tensor_names = main.attrs["output_tensor_names"]
+
+    return dict(zip(output_tensor_names, out))

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -111,7 +111,10 @@ def test_add_with_params(interface_api, use_unpacked_api, test_runner):
 
     compile_and_run(
         AOTTestModel(
-            module=IRModule.from_expr(func), inputs=inputs, outputs=output_list, params=params
+            module=IRModule.from_expr(func),
+            inputs=inputs,
+            outputs=output_list,
+            params=params,
         ),
         test_runner,
         interface_api,
@@ -447,7 +450,13 @@ def test_add_name_mangling_with_params(interface_api, use_unpacked_api, test_run
     output_list = generate_ref_data(func, inputs, params)
 
     compile_and_run(
-        AOTTestModel(name="my_mod", module=func, inputs=inputs, outputs=output_list, params=params),
+        AOTTestModel(
+            name="my_mod",
+            module=func,
+            inputs=inputs,
+            outputs=output_list,
+            params=params,
+        ),
         test_runner,
         interface_api,
         use_unpacked_api,
@@ -495,10 +504,18 @@ def @main(%data : Tensor[(1, 3, 64, 64), uint8], %weight : Tensor[(8, 3, 5, 5), 
     compile_and_run(
         [
             AOTTestModel(
-                name="mod1", module=mod1, inputs=inputs1, outputs=output_list1, params=params1
+                name="mod1",
+                module=mod1,
+                inputs=inputs1,
+                outputs=output_list1,
+                params=params1,
             ),
             AOTTestModel(
-                name="mod2", module=mod2, inputs=inputs2, outputs=output_list2, params=params2
+                name="mod2",
+                module=mod2,
+                inputs=inputs2,
+                outputs=output_list2,
+                params=params2,
             ),
         ],
         test_runner,
@@ -647,7 +664,10 @@ def test_deprecated_target_arguments(capsys):
 
     compile_and_run(
         AOTTestModel(
-            module=IRModule.from_expr(func), inputs=inputs, outputs=output_list, params=params
+            module=IRModule.from_expr(func),
+            inputs=inputs,
+            outputs=output_list,
+            params=params,
         ),
         test_runner,
         interface_api,
@@ -718,6 +738,109 @@ def test_constants_alignment(constants_byte_alignment):
     )
     source = compiled_test_mods[0].executor_factory.lib.imported_modules[0].get_source()
     assert f'__attribute__((section(".rodata.tvm"), aligned({constants_byte_alignment})))' in source
+
+
+def test_output_tensor_names():
+    """Test that the output names generated match those in the model"""
+    pytest.importorskip("tflite")
+
+    import os
+    import tensorflow as tf
+    import tflite.Model
+
+    ifm_shape = (1, 299, 299, 3)
+    padding = "VALID"
+    strides = (1, 1)
+    dilation = (1, 1)
+    kernel_shape = (3, 2)
+
+    def create_tflite_graph_two_outs():
+        """Create a model with 2 output tensors"""
+
+        class Model(tf.Module):
+            @tf.function
+            def tf_function(self, x):
+                # Use tf.nn API to create the model
+                tf_strides = [1, strides[0], strides[1], 1]
+                op = tf.nn.conv2d(
+                    x,
+                    filters=tf.constant(
+                        np.random.uniform(size=[kernel_shape[0], kernel_shape[1], 3, 3]),
+                        dtype=tf.float32,
+                    ),
+                    strides=tf_strides,
+                    padding=padding,
+                    dilations=dilation,
+                )
+                op = tf.nn.relu(op)
+                # Second convolution
+                op2 = tf.nn.conv2d(
+                    x,
+                    filters=tf.constant(
+                        np.random.uniform(size=(kernel_shape[0], kernel_shape[1], 3, 3)),
+                        dtype=tf.float32,
+                    ),
+                    strides=strides,
+                    padding=padding,
+                    data_format="NHWC",
+                    dilations=dilation,
+                )
+                op2 = tf.nn.relu(op2)
+                return op, op2
+
+        model = Model()
+        concrete_func = model.tf_function.get_concrete_function(
+            tf.TensorSpec(ifm_shape, dtype=tf.float32)
+        )
+
+        # Convert the model
+        def representative_dataset():
+            for _ in range(100):
+                data = np.random.rand(*tuple(ifm_shape))
+                yield [data.astype(np.float32)]
+
+        converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.representative_dataset = representative_dataset
+        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+        converter.inference_input_type = tf.int8
+        converter.inference_output_type = tf.int8
+        tflite_model = converter.convert()
+        return tflite_model
+
+    tflite_graph = create_tflite_graph_two_outs()
+    tflite_model = tflite.Model.Model.GetRootAsModel(tflite_graph, 0)
+    mod, params = relay.frontend.from_tflite(
+        tflite_model,
+        shape_dict={"input": ifm_shape},
+        dtype_dict={"input": "int8"},
+    )
+
+    use_unpacked_api = True
+    interface_api = "c"
+    test_runner = AOT_DEFAULT_RUNNER
+
+    in_min, in_max = (-128, 127)
+    data = np.random.randint(in_min, high=in_max, size=ifm_shape, dtype="int8")
+    inputs = {"x_int8": data}
+    output_list = generate_ref_data(mod, inputs, params)
+    compile_and_run(
+        AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),
+        test_runner,
+        interface_api,
+        use_unpacked_api,
+    )
+
+    compiled_test_mods = compile_models(
+        AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),
+        interface_api,
+        use_unpacked_api,
+    )
+
+    # Check that the names of the output tensors occur in the source code
+    source = compiled_test_mods[0].executor_factory.lib.get_source()
+    for output_name in output_list.keys():
+        assert output_name in source
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/utils/external_codegen.py
+++ b/tests/python/relay/utils/external_codegen.py
@@ -110,7 +110,7 @@ def check_aot_executor_result(
     use_unpacked_api = False
     test_runner = AOT_DEFAULT_RUNNER
     compile_and_run(
-        AOTTestModel(module=mod, inputs=map_inputs, outputs=[result]),
+        AOTTestModel(module=mod, inputs=map_inputs, outputs={"output": result}),
         test_runner,
         interface_api,
         use_unpacked_api,


### PR DESCRIPTION
Currently for the C Interface API, output tensor names default to "output", "output0", "output1" etc.
This is in contrast to the input tensor names that are derived from the model.

This PR updates the code to generate output tensor names derived from the model and updates unit tests accordingly.