### PR TITLE
[USMP] adding support for U2 and U3 usecases

### DIFF
--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file tvm/relay/executor.h
+ * \file tvm/ir/memory_pools.h
  * \brief The object definition for relay.build argument type of memory pools
  */
 #ifndef TVM_IR_MEMORY_POOLS_H_
@@ -108,13 +108,13 @@ class PoolInfo : public ObjectRef {
   /*!
    * \brief The string parameter to indicate read and write access to a pool
    * This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
-   * python/tvm/tir/usmp/utils.py
+   * python/tvm/ir/memory_pools.py
    */
   static constexpr const char* kTargetPoolReadWriteAccess = "rw";
   /*!
    * \brief The string parameter to indicate read only access to a pool
    * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in
-   * python/tvm/tir/usmp/utils.py
+   * python/tvm/ir/memory_pools.py
    */
   static constexpr const char* kTargetPoolReadOnlyAccess = "ro";
   /*! \brief The PoolSize is unrestricted for the memory planner */

--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -126,11 +126,13 @@ class PoolInfo : public ObjectRef {
   /*! \brief The write bandwidth is not known */
   static const int kUnknownWriteBandwidth = -1;
 
-  TVM_DLL PoolInfo(String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
-                   Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
-                   Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
-                   Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes,
-                   Bool is_internal);
+  TVM_DLL PoolInfo(String pool_name, Map<Target, String> target_access,
+                   Integer size_hint_bytes = kUnrestrictedPoolSizeHint,
+                   Integer clock_frequency_hz = kUnknownClockFrequency,
+                   Integer read_bandwidth_bytes_per_cycle = kUnknownReadBandwidth,
+                   Integer write_bandwidth_bytes_per_cycle = kUnknownWriteBandwidth,
+                   Integer read_latency_cycles = 0, Integer write_latency_cycles = 0,
+                   Map<Target, Integer> target_burst_bytes = {}, Bool is_internal = Bool(false));
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PoolInfo, ObjectRef, PoolInfoNode);
 };
 

--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relay/executor.h
+ * \brief The object definition for relay.build argument type of memory pools
+ */
+#ifndef TVM_IR_MEMORY_POOLS_H_
+#define TVM_IR_MEMORY_POOLS_H_
+
+#include <tvm/runtime/registry.h>
+#include <tvm/target/target.h>
+
+namespace tvm {
+
+/*!
+ * \brief Describes a pool of memory accessible by one or more targets.
+ */
+struct PoolInfoNode : public Object {
+  /*! \brief The name of the memory pool */
+  String pool_name;
+  /*! \brief The expected size hint to be used by the allocator.
+   * The size_hint_bytes is set to kUnrestrictedPoolSizeHint
+   * to indicate the pool is not size restricted.
+   */
+  Integer size_hint_bytes;
+  /*! \brief The accessibility from each Target */
+  Map<Target, String> target_access;  // 'rw' or 'ro'
+  /*! \brief The clock frequency of the memory in Hz */
+  Integer clock_frequency_hz;
+  /*! \brief The read bandwidth in bytes/cycle */
+  Integer read_bandwidth_bytes_per_cycle;
+  /*! \brief The write bandwidth in bytes/cycle */
+  Integer write_bandwidth_bytes_per_cycle;
+  /*! \brief The read latency in cycles */
+  Integer read_latency_cycles;
+  /*! \brief The write latency in cycles */
+  Integer write_latency_cycles;
+  /*! \brief The burst length in bytes for each Target */
+  Map<Target, Integer> target_burst_bytes;
+  /*! \brief Whether pool is internally generated.
+   * The internal pools will be generated as part of
+   * the entry point code generation of the executor
+   */
+  bool is_internal = false;
+
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("pool_name", &pool_name);
+    v->Visit("size_hint_bytes", &size_hint_bytes);
+    v->Visit("target_access", &target_access);
+    v->Visit("clock_frequency_hz", &clock_frequency_hz);
+    v->Visit("read_bandwidth_bytes_per_cycle", &read_bandwidth_bytes_per_cycle);
+    v->Visit("write_bandwidth_bytes_per_cycle", &write_bandwidth_bytes_per_cycle);
+    v->Visit("read_latency_cycles", &read_latency_cycles);
+    v->Visit("write_latency_cycles", &write_latency_cycles);
+    v->Visit("target_burst_bytes", &target_burst_bytes);
+    v->Visit("is_internal", &is_internal);
+  }
+
+  bool SEqualReduce(const PoolInfoNode* other, SEqualReducer equal) const {
+    return equal(pool_name, other->pool_name) && equal(size_hint_bytes, other->size_hint_bytes) &&
+           equal(target_access, other->target_access) &&
+           equal(target_access, other->target_access) &&
+           equal(clock_frequency_hz, other->clock_frequency_hz) &&
+           equal(read_bandwidth_bytes_per_cycle, other->read_bandwidth_bytes_per_cycle) &&
+           equal(write_bandwidth_bytes_per_cycle, other->write_bandwidth_bytes_per_cycle) &&
+           equal(read_latency_cycles, other->read_latency_cycles) &&
+           equal(write_latency_cycles, other->write_latency_cycles) &&
+           equal(target_burst_bytes, other->target_burst_bytes) &&
+           equal(is_internal, other->is_internal);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce(pool_name);
+    hash_reduce(size_hint_bytes);
+    hash_reduce(target_access);
+    hash_reduce(clock_frequency_hz);
+    hash_reduce(read_bandwidth_bytes_per_cycle);
+    hash_reduce(write_bandwidth_bytes_per_cycle);
+    hash_reduce(read_latency_cycles);
+    hash_reduce(write_latency_cycles);
+    hash_reduce(target_burst_bytes);
+    hash_reduce(is_internal);
+  }
+
+  static constexpr const char* _type_key = "ir.PoolInfo";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PoolInfoNode, Object);
+};
+
+class PoolInfo : public ObjectRef {
+ public:
+  /*!
+   * \brief The string parameter to indicate read and write access to a pool
+   * This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
+   * python/tvm/tir/usmp/utils.py
+   */
+  static constexpr const char* kTargetPoolReadWriteAccess = "rw";
+  /*!
+   * \brief The string parameter to indicate read only access to a pool
+   * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in
+   * python/tvm/tir/usmp/utils.py
+   */
+  static constexpr const char* kTargetPoolReadOnlyAccess = "ro";
+  /*! \brief The PoolSize is unrestricted for the memory planner */
+  static const int kUnrestrictedPoolSizeHint = -1;
+  /*! \brief The clock frequency is not known */
+  static const int kUnknownClockFrequency = -1;
+  /*! \brief The read bandwidth is not known */
+  static const int kUnknownReadBandwidth = -1;
+  /*! \brief The write bandwidth is not known */
+  static const int kUnknownWriteBandwidth = -1;
+
+  TVM_DLL PoolInfo(String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
+                   Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
+                   Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
+                   Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes,
+                   Bool is_internal);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PoolInfo, ObjectRef, PoolInfoNode);
+};
+
+struct WorkspaceMemoryPoolsNode : public Object {
+  Array<PoolInfo> pools;
+
+  void VisitAttrs(tvm::AttrVisitor* v) { v->Visit("pools", &pools); }
+
+  bool SEqualReduce(const WorkspaceMemoryPoolsNode* other, SEqualReducer equal) const {
+    return equal(pools, other->pools);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(pools); }
+
+  static constexpr const char* _type_key = "ir.WorkspaceMemoryPools";
+  TVM_DECLARE_FINAL_OBJECT_INFO(WorkspaceMemoryPoolsNode, Object);
+};
+
+class WorkspaceMemoryPools : public ObjectRef {
+ public:
+  TVM_DLL WorkspaceMemoryPools(Array<PoolInfo> pools);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(WorkspaceMemoryPools, ObjectRef, WorkspaceMemoryPoolsNode);
+};
+
+}  // namespace tvm
+
+#endif  // TVM_IR_MEMORY_POOLS_H_

--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -495,6 +495,15 @@ constexpr const char* kExecutor = "executor";
  */
 constexpr const char* kRuntime = "runtime";
 
+/*!
+ * \brief workspace memory pools of the module
+ *
+ * Type: WorkspaceMemoryPools
+ *
+ * \sa tvm::WorkspaceMemoryPools
+ */
+constexpr const char* kWorkspaceMemoryPools = "workspace_memory_pools";
+
 }  // namespace attr
 }  // namespace tvm
 #endif  // TVM_IR_MODULE_H_

--- a/include/tvm/tir/usmp/utils.h
+++ b/include/tvm/tir/usmp/utils.h
@@ -26,6 +26,7 @@
 #define TVM_TIR_USMP_UTILS_H_
 
 #include <tvm/ir/expr.h>
+#include <tvm/ir/memory_pools.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/target/target.h>
 #include <tvm/tir/stmt.h>
@@ -43,111 +44,6 @@ constexpr const char* kUSMPAlgorithmOption = "tir.usmp.algorithm";
 
 namespace tir {
 namespace usmp {
-
-/*!
- * \brief Describes a pool of memory accessible by one or more targets.
- */
-struct PoolInfoNode : public Object {
-  /*! \brief The name of the memory pool */
-  String pool_name;
-  /*! \brief The expected size hint to be used by the allocator.
-   * The size_hint_bytes is set to kUnrestrictedPoolSizeHint
-   * to indicate the pool is not size restricted.
-   */
-  Integer size_hint_bytes;
-  /*! \brief The accessibility from each Target */
-  Map<Target, String> target_access;  // 'rw' or 'ro'
-  /*! \brief The clock frequency of the memory in Hz */
-  Integer clock_frequency_hz;
-  /*! \brief The read bandwidth in bytes/cycle */
-  Integer read_bandwidth_bytes_per_cycle;
-  /*! \brief The write bandwidth in bytes/cycle */
-  Integer write_bandwidth_bytes_per_cycle;
-  /*! \brief The read latency in cycles */
-  Integer read_latency_cycles;
-  /*! \brief The write latency in cycles */
-  Integer write_latency_cycles;
-  /*! \brief The burst length in bytes for each Target */
-  Map<Target, Integer> target_burst_bytes;
-  /*! \brief Whether pool is internally generated.
-   * The internal pools will be generated as part of
-   * the entry point code generation of the executor
-   */
-  bool is_internal = false;
-
-  void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("pool_name", &pool_name);
-    v->Visit("size_hint_bytes", &size_hint_bytes);
-    v->Visit("target_access", &target_access);
-    v->Visit("clock_frequency_hz", &clock_frequency_hz);
-    v->Visit("read_bandwidth_bytes_per_cycle", &read_bandwidth_bytes_per_cycle);
-    v->Visit("write_bandwidth_bytes_per_cycle", &write_bandwidth_bytes_per_cycle);
-    v->Visit("read_latency_cycles", &read_latency_cycles);
-    v->Visit("write_latency_cycles", &write_latency_cycles);
-    v->Visit("target_burst_bytes", &target_burst_bytes);
-    v->Visit("is_internal", &is_internal);
-  }
-
-  bool SEqualReduce(const PoolInfoNode* other, SEqualReducer equal) const {
-    return equal(pool_name, other->pool_name) && equal(size_hint_bytes, other->size_hint_bytes) &&
-           equal(target_access, other->target_access) &&
-           equal(target_access, other->target_access) &&
-           equal(clock_frequency_hz, other->clock_frequency_hz) &&
-           equal(read_bandwidth_bytes_per_cycle, other->read_bandwidth_bytes_per_cycle) &&
-           equal(write_bandwidth_bytes_per_cycle, other->write_bandwidth_bytes_per_cycle) &&
-           equal(read_latency_cycles, other->read_latency_cycles) &&
-           equal(write_latency_cycles, other->write_latency_cycles) &&
-           equal(target_burst_bytes, other->target_burst_bytes) &&
-           equal(is_internal, other->is_internal);
-  }
-
-  void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce(pool_name);
-    hash_reduce(size_hint_bytes);
-    hash_reduce(target_access);
-    hash_reduce(clock_frequency_hz);
-    hash_reduce(read_bandwidth_bytes_per_cycle);
-    hash_reduce(write_bandwidth_bytes_per_cycle);
-    hash_reduce(read_latency_cycles);
-    hash_reduce(write_latency_cycles);
-    hash_reduce(target_burst_bytes);
-    hash_reduce(is_internal);
-  }
-
-  static constexpr const char* _type_key = "tir.usmp.PoolInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PoolInfoNode, Object);
-};
-
-class PoolInfo : public ObjectRef {
- public:
-  /*!
-   * \brief The string parameter to indicate read and write access to a pool
-   * This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
-   * python/tvm/tir/usmp/utils.py
-   */
-  static constexpr const char* kTargetPoolReadWriteAccess = "rw";
-  /*!
-   * \brief The string parameter to indicate read only access to a pool
-   * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in
-   * python/tvm/tir/usmp/utils.py
-   */
-  static constexpr const char* kTargetPoolReadOnlyAccess = "ro";
-  /*! \brief The PoolSize is unrestricted for the memory planner */
-  static const int kUnrestrictedPoolSizeHint = -1;
-  /*! \brief The clock frequency is not known */
-  static const int kUnknownClockFrequency = -1;
-  /*! \brief The read bandwidth is not known */
-  static const int kUnknownReadBandwidth = -1;
-  /*! \brief The write bandwidth is not known */
-  static const int kUnknownWriteBandwidth = -1;
-
-  TVM_DLL PoolInfo(String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
-                   Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
-                   Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
-                   Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes,
-                   Bool is_internal);
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PoolInfo, ObjectRef, PoolInfoNode);
-};
 
 /*!
  * \brief Describes an abstract memory buffer that will get allocated inside a pool.

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -43,6 +43,8 @@ from .ir import IRModule
 from .ir import transform
 from .ir import instrument
 from .ir import container
+from .ir import PoolInfo
+from .ir import WorkspaceMemoryPools
 from . import ir
 
 # tvm.tir

--- a/python/tvm/ir/__init__.py
+++ b/python/tvm/ir/__init__.py
@@ -30,6 +30,7 @@ from .adt import Constructor, TypeData
 from .module import IRModule
 from .attrs import Attrs, DictAttrs, make_node
 from .container import Array, Map
+from .memory_pools import PoolInfo, WorkspaceMemoryPools
 
 from . import transform
 from . import instrument

--- a/python/tvm/ir/memory_pools.py
+++ b/python/tvm/ir/memory_pools.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Objects for Memory Pools to be used within the compilation"""
+
+from typing import Optional, List
+
+from tvm._ffi import register_object
+from tvm.runtime import Object
+from . import _ffi_api
+
+
+@register_object("ir.PoolInfo")
+class PoolInfo(Object):
+    """PoolInfo object holds information related to memory pools
+    where the statically sized allocate nodes will pooled into.
+
+    Parameters
+    ----------
+    pool_name : str
+        The name of the memory pool
+
+    target_access : Dict[Target, str]
+        A dictionary where keys describe which targets could
+        access the pool where value could take the values :
+        a) "rw" : read-write access
+        b) "ro" : write-only acesss
+
+    size_hint_bytes : Optional[int]
+        The expected size hint to be used by the allocator.
+        The default value would be -1 which means the pool
+        is not size restricted.
+
+    clock_frequency_hz : Optional[int]
+        The clock frequency that the memory pool runs at in Hz.
+        If not specified/known, this will default to -1 indicating
+        it hasn't been defined.
+
+    read_bandwidth_bytes_per_cycle : Optional[int]
+        The read bandwidth of the memory pool in bytes/cycle.
+        If not specified/known, this will default to -1 indicating
+        it hasn't been defined.
+
+    write_bandwidth_bytes_per_cycle : Optional[int]
+        The write bandwidth of the memory pool in bytes/cycle.
+        If not specified/known, this will default to -1 indicating
+        it hasn't been defined.
+
+    read_latency_cycles : Optional[int]
+        The read latency of the memory pool in cycles.
+        If not specified/known, this will default to 0.
+
+    write_latency_cycles : Optional[int]
+        The write latency of the memory pool in cycles.
+        If not specified/known, this will default to 0.
+
+    target_burst_bytes : Optional[Union[Dict[Target, int], None]]
+        The burst length of the memory pool in bytes per target.
+        If not specified/known for a given target, a burst length
+        of 1 byte will be assumed.
+
+    """
+
+    # The string parameter to indicate read and write access to a pool
+    # This needs to be kept in sync with kTargetPoolReadWriteAccess in
+    # include/tvm/tir/usmp/utils.h
+    READ_WRITE_ACCESS = "rw"
+    # The string parameter to indicate read only access to a pool
+    # This needs to be kept in sync with kTargetPoolReadOnlyAccess in
+    # include/tvm/tir/usmp/utils.h
+    READ_ONLY_ACCESS = "ro"
+
+    def __init__(
+            self,
+            pool_name: str,
+            target_access,  # Dict[Target, str]
+            size_hint_bytes: Optional[int] = -1,
+            clock_frequency_hz: Optional[int] = -1,
+            read_bandwidth_bytes_per_cycle: Optional[int] = -1,
+            write_bandwidth_bytes_per_cycle: Optional[int] = -1,
+            read_latency_cycles: Optional[int] = 0,
+            write_latency_cycles: Optional[int] = 0,
+            target_burst_bytes=None,  # Optional[Union[Dict[target.Target, int], None]]
+    ):
+        if not target_burst_bytes:
+            target_burst_bytes = dict()
+
+        self.__init_handle_by_constructor__(
+            _ffi_api.PoolInfo,  # type: ignore # pylint: disable=no-member
+            pool_name,
+            target_access,
+            size_hint_bytes,
+            clock_frequency_hz,
+            read_bandwidth_bytes_per_cycle,
+            write_bandwidth_bytes_per_cycle,
+            read_latency_cycles,
+            write_latency_cycles,
+            target_burst_bytes,
+        )
+
+
+@register_object("ir.WorkspaceMemoryPools")
+class WorkspaceMemoryPools(Object):
+    """This object contains a list of PoolInfo objects to be used as
+    workspace memory in the compilation
+
+    Parameters
+    ----------
+    pools : List[PoolInfo]
+        The list of PoolInfo objects to be used with the compilation
+    """
+
+    def __init__(
+            self,
+            pools: List[PoolInfo],
+    ):
+        self.__init_handle_by_constructor__(
+            _ffi_api.WorkspaceMemoryPools,  # type: ignore # pylint: disable=no-member
+            pools
+        )

--- a/python/tvm/ir/memory_pools.py
+++ b/python/tvm/ir/memory_pools.py
@@ -84,16 +84,16 @@ class PoolInfo(Object):
     READ_ONLY_ACCESS = "ro"
 
     def __init__(
-            self,
-            pool_name: str,
-            target_access,  # Dict[Target, str]
-            size_hint_bytes: Optional[int] = -1,
-            clock_frequency_hz: Optional[int] = -1,
-            read_bandwidth_bytes_per_cycle: Optional[int] = -1,
-            write_bandwidth_bytes_per_cycle: Optional[int] = -1,
-            read_latency_cycles: Optional[int] = 0,
-            write_latency_cycles: Optional[int] = 0,
-            target_burst_bytes=None,  # Optional[Union[Dict[target.Target, int], None]]
+        self,
+        pool_name: str,
+        target_access,  # Dict[Target, str]
+        size_hint_bytes: Optional[int] = -1,
+        clock_frequency_hz: Optional[int] = -1,
+        read_bandwidth_bytes_per_cycle: Optional[int] = -1,
+        write_bandwidth_bytes_per_cycle: Optional[int] = -1,
+        read_latency_cycles: Optional[int] = 0,
+        write_latency_cycles: Optional[int] = 0,
+        target_burst_bytes=None,  # Optional[Union[Dict[target.Target, int], None]]
     ):
         if not target_burst_bytes:
             target_burst_bytes = dict()
@@ -124,10 +124,9 @@ class WorkspaceMemoryPools(Object):
     """
 
     def __init__(
-            self,
-            pools: List[PoolInfo],
+        self,
+        pools: List[PoolInfo],
     ):
         self.__init_handle_by_constructor__(
-            _ffi_api.WorkspaceMemoryPools,  # type: ignore # pylint: disable=no-member
-            pools
+            _ffi_api.WorkspaceMemoryPools, pools  # type: ignore # pylint: disable=no-member
         )

--- a/python/tvm/ir/memory_pools.py
+++ b/python/tvm/ir/memory_pools.py
@@ -76,11 +76,11 @@ class PoolInfo(Object):
 
     # The string parameter to indicate read and write access to a pool
     # This needs to be kept in sync with kTargetPoolReadWriteAccess in
-    # include/tvm/tir/usmp/utils.h
+    # include/tvm/ir/memory_pools.h
     READ_WRITE_ACCESS = "rw"
     # The string parameter to indicate read only access to a pool
     # This needs to be kept in sync with kTargetPoolReadOnlyAccess in
-    # include/tvm/tir/usmp/utils.h
+    # include/tvm/ir/memory_pools.h
     READ_ONLY_ACCESS = "ro"
 
     def __init__(

--- a/python/tvm/relay/backend/executor_factory.py
+++ b/python/tvm/relay/backend/executor_factory.py
@@ -106,6 +106,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         libmod_name,
         params,
         function_metadata,
+        executor_codegen_metadata,
         devices,
     ):
         self.ir_mod = ir_mod
@@ -118,6 +119,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         self.params = params
         self.iter_cnt = 0
         self.function_metadata = function_metadata
+        self.executor_codegen_metadata = executor_codegen_metadata
         self.devices = devices
 
     def get_devices(self):

--- a/python/tvm/tir/usmp/utils.py
+++ b/python/tvm/tir/usmp/utils.py
@@ -17,107 +17,18 @@
 """USMP Utilities and Data Structures"""
 # pylint: disable=invalid-name
 
-from typing import Dict, Optional, List, Union
+from typing import Optional, List
 
 from tvm._ffi import register_object
 from tvm.runtime import Object
-from tvm.target import Target
 from . import _ffi_api
+from ...ir.memory_pools import PoolInfo
 
 
 # The allocate node attribute to indicate candidate memory pools.
 # This needs to be kept in sync with CANDIDATE_MEMORY_POOL_ATTR in
 # include/tvm/tir/usmp/utils.h
 CANDIDATE_MEMORY_POOL_ATTR = "candidate_memory_pools"
-
-
-@register_object("tir.usmp.PoolInfo")
-class PoolInfo(Object):
-    """PoolInfo object holds information related to memory pools
-    where the statically sized allocate nodes will pooled into.
-
-    Parameters
-    ----------
-    pool_name : str
-        The name of the memory pool
-
-    target_access : Dict[Target, str]
-        A dictionary where keys describe which targets could
-        access the pool where value could take the values :
-        a) "rw" : read-write access
-        b) "ro" : write-only acesss
-
-    size_hint_bytes : Optional[int]
-        The expected size hint to be used by the allocator.
-        The default value would be -1 which means the pool
-        is not size restricted.
-
-    clock_frequency_hz : Optional[int]
-        The clock frequency that the memory pool runs at in Hz.
-        If not specified/known, this will default to -1 indicating
-        it hasn't been defined.
-
-    read_bandwidth_bytes_per_cycle : Optional[int]
-        The read bandwidth of the memory pool in bytes/cycle.
-        If not specified/known, this will default to -1 indicating
-        it hasn't been defined.
-
-    write_bandwidth_bytes_per_cycle : Optional[int]
-        The write bandwidth of the memory pool in bytes/cycle.
-        If not specified/known, this will default to -1 indicating
-        it hasn't been defined.
-
-    read_latency_cycles : Optional[int]
-        The read latency of the memory pool in cycles.
-        If not specified/known, this will default to 0.
-
-    write_latency_cycles : Optional[int]
-        The write latency of the memory pool in cycles.
-        If not specified/known, this will default to 0.
-
-    target_burst_bytes : Optional[Union[Dict[Target, int], None]]
-        The burst length of the memory pool in bytes per target.
-        If not specified/known for a given target, a burst length
-        of 1 byte will be assumed.
-
-    """
-
-    # The string parameter to indicate read and write access to a pool
-    # This needs to be kept in sync with kTargetPoolReadWriteAccess in
-    # include/tvm/tir/usmp/utils.h
-    READ_WRITE_ACCESS = "rw"
-    # The string parameter to indicate read only access to a pool
-    # This needs to be kept in sync with kTargetPoolReadOnlyAccess in
-    # include/tvm/tir/usmp/utils.h
-    READ_ONLY_ACCESS = "ro"
-
-    def __init__(
-        self,
-        pool_name: str,
-        target_access: Dict[Target, str],
-        size_hint_bytes: Optional[int] = -1,
-        clock_frequency_hz: Optional[int] = -1,
-        read_bandwidth_bytes_per_cycle: Optional[int] = -1,
-        write_bandwidth_bytes_per_cycle: Optional[int] = -1,
-        read_latency_cycles: Optional[int] = 0,
-        write_latency_cycles: Optional[int] = 0,
-        target_burst_bytes: Optional[Union[Dict[Target, int], None]] = None,
-    ):
-        if not target_burst_bytes:
-            target_burst_bytes = dict()
-
-        self.__init_handle_by_constructor__(
-            _ffi_api.PoolInfo,  # type: ignore # pylint: disable=no-member
-            pool_name,
-            target_access,
-            size_hint_bytes,
-            clock_frequency_hz,
-            read_bandwidth_bytes_per_cycle,
-            write_bandwidth_bytes_per_cycle,
-            read_latency_cycles,
-            write_latency_cycles,
-            target_burst_bytes,
-        )
 
 
 @register_object("tir.usmp.BufferInfo")

--- a/src/ir/memory_pools.cc
+++ b/src/ir/memory_pools.cc
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/backend/memory_pools.cc
+ * \brief The object definition for relay.build argument type of memory pools
+ */
+
+#include <tvm/ir/memory_pools.h>
+#include <tvm/relay/executor.h>
+
+namespace tvm {
+
+PoolInfo::PoolInfo(String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
+                   Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
+                   Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
+                   Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes,
+                   Bool is_internal) {
+  auto poolinfo_node = make_object<PoolInfoNode>();
+  poolinfo_node->pool_name = pool_name;
+  poolinfo_node->size_hint_bytes = size_hint_bytes;
+  poolinfo_node->target_access = target_access;
+  poolinfo_node->clock_frequency_hz = clock_frequency_hz;
+  poolinfo_node->read_bandwidth_bytes_per_cycle = read_bandwidth_bytes_per_cycle;
+  poolinfo_node->write_bandwidth_bytes_per_cycle = write_bandwidth_bytes_per_cycle;
+  poolinfo_node->read_latency_cycles = read_latency_cycles;
+  poolinfo_node->write_latency_cycles = write_latency_cycles;
+  poolinfo_node->target_burst_bytes = target_burst_bytes;
+  poolinfo_node->is_internal = is_internal;
+  data_ = std::move(poolinfo_node);
+}
+
+TVM_REGISTER_NODE_TYPE(PoolInfoNode);
+TVM_REGISTER_GLOBAL("ir.PoolInfo")
+    .set_body_typed([](String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
+                       Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
+                       Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
+                       Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes) {
+      return PoolInfo(pool_name, target_access, size_hint_bytes, clock_frequency_hz,
+                      read_bandwidth_bytes_per_cycle, write_bandwidth_bytes_per_cycle,
+                      read_latency_cycles, write_latency_cycles, target_burst_bytes, Bool(false));
+    });
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<PoolInfoNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      auto* node = static_cast<const PoolInfoNode*>(ref.get());
+      p->stream << "PoolInfoNode(\n"
+                << "  pool_name=" << node->pool_name << ",\n  target_access=" << node->target_access
+                << ",\n  size_hint_bytes=" << node->size_hint_bytes
+                << ",\n  clock_frequency_hz=" << node->clock_frequency_hz
+                << ",\n  read_bandwidth_bytes_per_cycle=" << node->read_bandwidth_bytes_per_cycle
+                << ",\n  write_bandwidth_bytes_per_cycle=" << node->write_bandwidth_bytes_per_cycle
+                << ",\n  read_latency_cycles=" << node->read_latency_cycles
+                << ",\n  write_latency_cycles=" << node->write_latency_cycles
+                << ",\n  target_burst_bytes=" << node->target_burst_bytes << ")";
+    });
+
+WorkspaceMemoryPools::WorkspaceMemoryPools(Array<PoolInfo> pools) {
+  auto workspace_memory_pools_node = make_object<WorkspaceMemoryPoolsNode>();
+  workspace_memory_pools_node->pools = pools;
+  data_ = std::move(workspace_memory_pools_node);
+}
+
+TVM_REGISTER_NODE_TYPE(WorkspaceMemoryPoolsNode);
+TVM_REGISTER_GLOBAL("ir.WorkspaceMemoryPools").set_body_typed([](Array<PoolInfo> pools) {
+  return WorkspaceMemoryPools(pools);
+});
+
+TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
+    .set_dispatch<WorkspaceMemoryPoolsNode>([](const ObjectRef& ref, ReprPrinter* p) {
+      auto* node = static_cast<const WorkspaceMemoryPoolsNode*>(ref.get());
+      p->stream << "WorkspaceMemoryPoolsNode(\n"
+                << "pools=" << node->pools << ")";
+    });
+
+}  // namespace tvm

--- a/src/ir/memory_pools.cc
+++ b/src/ir/memory_pools.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file src/relay/backend/memory_pools.cc
+ * \file src/ir/memory_pools.cc
  * \brief The object definition for relay.build argument type of memory pools
  */
 

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -1021,7 +1021,7 @@ class AOTExecutorCodegenModule : public runtime::ModuleNode {
       return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
         *rv = this->codegen_->ListDevices();
       });
-    } else if (name == "get_metadata") {
+    } else if (name == "get_executor_codegen_metadata") {
       return PackedFunc(
           [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = output_.metadata; });
     } else {

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -695,7 +695,7 @@ class GraphExecutorCodegenModule : public runtime::ModuleNode {
       });
     } else if (name == "get_devices") {
       return PackedFunc([sptr_to_self](TVMArgs args, TVMRetValue* rv) { *rv = Array<String>(); });
-    } else if (name == "get_metadata") {
+    } else if (name == "get_executor_codegen_metadata") {
       return PackedFunc(
           [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->output_.metadata; });
     } else if (name == "get_function_metadata") {

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -178,6 +178,25 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
                 << ",\n  relay_primfuncs=" << node->relay_primfuncs << ")";
     });
 
+ExecutorCodegenMetadata::ExecutorCodegenMetadata(
+    Array<tir::Var> inputs, Array<tir::Var> pools, Array<String> devices, Integer num_outputs,
+    String executor, String mod_name, String interface_api, bool unpacked_api,
+    Map<tir::Var, tir::usmp::AllocatedPoolInfo> pool_inputs) {
+  auto n = make_object<ExecutorCodegenMetadataNode>();
+  n->inputs = inputs;
+  n->pools = pools;
+  n->devices = devices;
+  n->num_outputs = num_outputs;
+  n->executor = executor;
+  n->interface_api = interface_api;
+  n->unpacked_api = unpacked_api;
+  n->mod_name = mod_name;
+  n->pool_inputs = pool_inputs;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(ExecutorCodegenMetadataNode);
+
 Array<Pass> GetPassPrefix(bool is_homegeneous, bool is_vm) {
   Array<Pass> pass_seqs;
   // TODO(mbs): Would be nice to get spans on all diagnostics, but since they arg forgotton

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -64,7 +64,7 @@ class ExecutorCodegenMetadataNode : public Object {
   /*! \brief pool information for the main function */
   Array<tir::Var> pools;
   /*! \brief number of outputs of the main function */
-  unsigned int num_outputs = 1;
+  Integer num_outputs = 1;
   /*! \brief device contexts information for the main function */
   Array<String> devices;
   /*! \brief the executor to be used to run the model */
@@ -78,7 +78,16 @@ class ExecutorCodegenMetadataNode : public Object {
 
   String mod_name = "";
 
-  static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("inputs", &inputs);
+    v->Visit("pools", &pools);
+    v->Visit("num_outputs", &num_outputs);
+    v->Visit("devices", &devices);
+    v->Visit("executor", &executor);
+    v->Visit("unpacked_api", &unpacked_api);
+    v->Visit("pool_inputs", &pool_inputs);
+  }
+
   static constexpr const char* _type_key = "MetadataObj";
   TVM_DECLARE_FINAL_OBJECT_INFO(ExecutorCodegenMetadataNode, Object);
 };
@@ -89,26 +98,14 @@ class ExecutorCodegenMetadataNode : public Object {
 class ExecutorCodegenMetadata : public ObjectRef {
  public:
   TVM_DLL ExecutorCodegenMetadata(Array<tir::Var> inputs, Array<tir::Var> pools,
-                                  Array<String> devices, int num_outputs, String executor,
+                                  Array<String> devices, Integer num_outputs, String executor,
                                   String mod_name, String interface_api = "packed",
                                   bool unpacked_api = false,
                                   Map<tir::Var, tir::usmp::AllocatedPoolInfo> pool_inputs =
-                                      Map<tir::Var, tir::usmp::AllocatedPoolInfo>()) {
-    auto n = make_object<ExecutorCodegenMetadataNode>();
-    n->inputs = inputs;
-    n->pools = pools;
-    n->devices = devices;
-    n->num_outputs = num_outputs;
-    n->executor = executor;
-    n->interface_api = interface_api;
-    n->unpacked_api = unpacked_api;
-    n->mod_name = mod_name;
-    n->pool_inputs = pool_inputs;
-    data_ = std::move(n);
-  }
+                                      Map<tir::Var, tir::usmp::AllocatedPoolInfo>());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ExecutorCodegenMetadata, ObjectRef, ExecutorCodegenMetadataNode);
-  TVM_DEFINE_OBJECT_REF_COW_METHOD(ExecutorCodegenMetadataNode);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(ExecutorCodegenMetadata, ObjectRef,
+                                        ExecutorCodegenMetadataNode);
 };
 
 /*!

--- a/src/target/source/interface_c.cc
+++ b/src/target/source/interface_c.cc
@@ -66,7 +66,7 @@ class InterfaceCNode : public runtime::ModuleNode {
       EmitStruct(code, "devices", devices_);
     }
     if (!pools_.empty()) {
-      EmitBrief(code, "Device context pointers");
+      EmitBrief(code, "Workspace pool pointers");
       Array<String> pool_names;
       for (const tir::usmp::AllocatedPoolInfo pool : pools_) {
         pool_names.push_back(pool->pool_info->pool_name);
@@ -81,8 +81,8 @@ class InterfaceCNode : public runtime::ModuleNode {
     for (const tir::usmp::AllocatedPoolInfo pool : pools_) {
       String pool_name = pool->pool_info->pool_name;
       Integer pool_size = pool->allocated_size;
-      EmitIntegerValueMacro(code, pool_name + " size", pool_name + "_WORKSPACE_POOL_SIZE",
-                            pool_size->value);
+      EmitIntegerValueMacro(code, SanitizeName(pool_name) + " size",
+                            SanitizeName(pool_name) + "_WORKSPACE_POOL_SIZE", pool_size->value);
     }
     EmitLowerHeaderGuard(code);
 
@@ -178,7 +178,7 @@ class InterfaceCNode : public runtime::ModuleNode {
     std::string call_args_str = call_args_ss.str();
     call_args_str.pop_back();
     call_args_str.pop_back();
-    code_stream << call_args_str << ");\n";
+    code_stream << call_args_str << "\n);\n";
   }
 
   Array<tir::usmp::AllocatedPoolInfo> FilterExternalPools(

--- a/src/target/source/interface_c.cc
+++ b/src/target/source/interface_c.cc
@@ -27,6 +27,7 @@
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/tir/usmp/utils.h>
 
 #include <string>
 
@@ -41,11 +42,13 @@ using namespace tvm::relay::backend;
 class InterfaceCNode : public runtime::ModuleNode {
  public:
   InterfaceCNode(std::string module_name, Array<String> inputs, Array<String> outputs,
-                 Array<String> devices, int workspace_size)
+                 Array<tir::usmp::AllocatedPoolInfo> pools, Array<String> devices,
+                 int workspace_size)
       : module_name_(module_name),
         inputs_(inputs),
         outputs_(outputs),
         devices_(devices),
+        pools_(FilterExternalPools(pools)),
         workspace_size_(workspace_size) {}
   const char* type_key() const { return "h"; }
 
@@ -62,9 +65,25 @@ class InterfaceCNode : public runtime::ModuleNode {
       EmitBrief(code, "Device context pointers");
       EmitStruct(code, "devices", devices_);
     }
+    if (!pools_.empty()) {
+      EmitBrief(code, "Device context pointers");
+      Array<String> pool_names;
+      for (const tir::usmp::AllocatedPoolInfo pool : pools_) {
+        pool_names.push_back(pool->pool_info->pool_name);
+      }
+      EmitStruct(code, "workspace_pools", pool_names);
+    }
 
     EmitRunFunction(code);
-    EmitWorkspaceSize(code);
+    // Emit workspace
+    EmitIntegerValueMacro(code, "Workspace size", "WORKSPACE_SIZE", workspace_size_);
+    // Emit memory pool sizes
+    for (const tir::usmp::AllocatedPoolInfo pool : pools_) {
+      String pool_name = pool->pool_info->pool_name;
+      Integer pool_size = pool->allocated_size;
+      EmitIntegerValueMacro(code, pool_name + " size", pool_name + "_WORKSPACE_POOL_SIZE",
+                            pool_size->value);
+    }
     EmitLowerHeaderGuard(code);
 
     return code.str();
@@ -116,11 +135,21 @@ class InterfaceCNode : public runtime::ModuleNode {
     code_stream << "};\n\n";
   }
 
+  void EmitIntegerValueMacro(std::stringstream& code_stream, const std::string& brief_description,
+                             const std::string& macro_name, int macro_value) {
+    EmitBrief(code_stream, brief_description);
+    std::string macro_name_prefixed =
+        ToCConstantStyle(PrefixGeneratedName({module_name_, macro_name}));
+    code_stream << "#define " << macro_name_prefixed << " " << macro_value << "\n";
+  }
+
   void EmitRunFunction(std::stringstream& code_stream) {
     std::string run_function = ToCVariableStyle(PrefixGeneratedName({module_name_, "run"}));
     std::string inputs_struct = ToCVariableStyle(PrefixGeneratedName({module_name_, "inputs"}));
     std::string outputs_struct = ToCVariableStyle(PrefixGeneratedName({module_name_, "outputs"}));
     std::string devices_struct = ToCVariableStyle(PrefixGeneratedName({module_name_, "devices"}));
+    std::string pools_struct =
+        ToCVariableStyle(PrefixGeneratedName({module_name_, "workspace_pools"}));
 
     code_stream << "/*!\n"
                 << " * \\brief entrypoint function for TVM module \"" << module_name_ << "\"\n"
@@ -130,40 +159,52 @@ class InterfaceCNode : public runtime::ModuleNode {
     if (!devices_.empty()) {
       code_stream << " * \\param devices Device context pointers for the module \n";
     }
-
-    code_stream << " */\n"
-                << "int32_t " << run_function << "(\n"
-                << "  struct " << inputs_struct << "* inputs,\n";
-
-    if (!devices_.empty()) {
-      code_stream << "  struct " << outputs_struct << "* outputs,\n";
-      code_stream << "  struct " << devices_struct << "* devices\n";
-    } else {
-      code_stream << "  struct " << outputs_struct << "* outputs\n";
+    if (!pools_.empty()) {
+      code_stream << " * \\param workspace_pools Workspace memory pool pointers for the module \n";
     }
 
-    code_stream << ");\n";
+    code_stream << " */\n"
+                << "int32_t " << run_function << "(\n";
+
+    std::stringstream call_args_ss;
+    call_args_ss << "  struct " << inputs_struct << "* inputs,\n";
+    call_args_ss << "  struct " << outputs_struct << "* outputs,\n";
+    if (!devices_.empty()) {
+      call_args_ss << "  struct " << devices_struct << "* devices,\n";
+    }
+    if (!pools_.empty()) {
+      call_args_ss << "  struct " << pools_struct << "* workspace_pools,\n";
+    }
+    std::string call_args_str = call_args_ss.str();
+    call_args_str.pop_back();
+    call_args_str.pop_back();
+    code_stream << call_args_str << ");\n";
   }
 
-  void EmitWorkspaceSize(std::stringstream& code_stream) {
-    std::string workspace_size_name =
-        ToCConstantStyle(PrefixGeneratedName({module_name_, "WORKSPACE_SIZE"}));
-    code_stream << "/*!\n"
-                << " * \\brief Workspace size for TVM module \"" << module_name_ << "\"\n"
-                << " */\n"
-                << "#define " << workspace_size_name << " " << workspace_size_ << "\n";
+  Array<tir::usmp::AllocatedPoolInfo> FilterExternalPools(
+      const Array<tir::usmp::AllocatedPoolInfo>& pools) {
+    Array<tir::usmp::AllocatedPoolInfo> external_pools;
+    for (tir::usmp::AllocatedPoolInfo pool : pools) {
+      if (!pool->pool_info->is_internal) {
+        external_pools.push_back(pool);
+      }
+    }
+    return external_pools;
   }
 
   std::string module_name_;
   Array<String> inputs_;
   Array<String> outputs_;
   Array<String> devices_;
+  Array<tir::usmp::AllocatedPoolInfo> pools_;
   int workspace_size_;
 };
 
 runtime::Module InterfaceCCreate(std::string module_name, Array<String> inputs,
-                                 Array<String> outputs, Array<String> devices, int workspace_size) {
-  auto n = make_object<InterfaceCNode>(module_name, inputs, outputs, devices, workspace_size);
+                                 Array<String> outputs, Array<tir::usmp::AllocatedPoolInfo> pools,
+                                 Array<String> devices, int workspace_size) {
+  auto n =
+      make_object<InterfaceCNode>(module_name, inputs, outputs, pools, devices, workspace_size);
   return runtime::Module(n);
 }
 

--- a/src/tir/usmp/utils.cc
+++ b/src/tir/usmp/utils.cc
@@ -22,6 +22,7 @@
  * \brief Utilities for Unified Static Memory Planner
  */
 
+#include <tvm/ir/memory_pools.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/analysis.h>
@@ -92,49 +93,6 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
                 << ",\n  memory_pressure=" << node->memory_pressure << ")";
     });
 
-PoolInfo::PoolInfo(String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
-                   Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
-                   Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
-                   Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes,
-                   Bool is_internal) {
-  auto poolinfo_node = make_object<PoolInfoNode>();
-  poolinfo_node->pool_name = pool_name;
-  poolinfo_node->size_hint_bytes = size_hint_bytes;
-  poolinfo_node->target_access = target_access;
-  poolinfo_node->clock_frequency_hz = clock_frequency_hz;
-  poolinfo_node->read_bandwidth_bytes_per_cycle = read_bandwidth_bytes_per_cycle;
-  poolinfo_node->write_bandwidth_bytes_per_cycle = write_bandwidth_bytes_per_cycle;
-  poolinfo_node->read_latency_cycles = read_latency_cycles;
-  poolinfo_node->write_latency_cycles = write_latency_cycles;
-  poolinfo_node->target_burst_bytes = target_burst_bytes;
-  poolinfo_node->is_internal = is_internal;
-  data_ = std::move(poolinfo_node);
-}
-
-TVM_REGISTER_NODE_TYPE(PoolInfoNode);
-TVM_REGISTER_GLOBAL("tir.usmp.PoolInfo")
-    .set_body_typed([](String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
-                       Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
-                       Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,
-                       Integer write_latency_cycles, Map<Target, Integer> target_burst_bytes) {
-      return PoolInfo(pool_name, target_access, size_hint_bytes, clock_frequency_hz,
-                      read_bandwidth_bytes_per_cycle, write_bandwidth_bytes_per_cycle,
-                      read_latency_cycles, write_latency_cycles, target_burst_bytes, Bool(false));
-    });
-
-TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
-    .set_dispatch<PoolInfoNode>([](const ObjectRef& ref, ReprPrinter* p) {
-      auto* node = static_cast<const PoolInfoNode*>(ref.get());
-      p->stream << "PoolInfoNode(\n"
-                << "  pool_name=" << node->pool_name << ",\n  target_access=" << node->target_access
-                << ",\n  size_hint_bytes=" << node->size_hint_bytes
-                << ",\n  clock_frequency_hz=" << node->clock_frequency_hz
-                << ",\n  read_bandwidth_bytes_per_cycle=" << node->read_bandwidth_bytes_per_cycle
-                << ",\n  write_bandwidth_bytes_per_cycle=" << node->write_bandwidth_bytes_per_cycle
-                << ",\n  read_latency_cycles=" << node->read_latency_cycles
-                << ",\n  write_latency_cycles=" << node->write_latency_cycles
-                << ",\n  target_burst_bytes=" << node->target_burst_bytes << ")";
-    });
 
 PoolAllocation::PoolAllocation(PoolInfo pool_info, Integer byte_offset) {
   auto pool_allocation_node = make_object<PoolAllocationNode>();

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <tvm/driver/driver_api.h>
+#include <tvm/ir/memory_pools.h>
 #include <tvm/ir/module.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/executor.h>
@@ -128,7 +129,8 @@ TEST(Relay, BuildModule) {
   targets.Set(0, llvm_tgt);
   auto relay_mod = tvm::IRModule::FromExpr(func);
   ICHECK(relay_mod.defined()) << "Module must be defined";
-  build_f(relay_mod, targets, llvm_tgt, Executor::Create("graph"), Runtime::Create("cpp"), "");
+  build_f(relay_mod, targets, llvm_tgt, Executor::Create("graph"), Runtime::Create("cpp"),
+          WorkspaceMemoryPools(), "");
   std::string json = json_f();
   tvm::runtime::Module mod = mod_f();
   // run

--- a/tests/cpp/runtime_test.cc
+++ b/tests/cpp/runtime_test.cc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <tvm/driver/driver_api.h>
+#include <tvm/ir/memory_pools.h>
 #include <tvm/ir/module.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/executor.h>
@@ -114,7 +115,8 @@ TEST(Runtime, ZeroCopy) {
   targets.Set(0, llvm_tgt);
   auto relay_mod = tvm::IRModule::FromExpr(func);
   ICHECK(relay_mod.defined()) << "Module must be defined";
-  build_f(relay_mod, targets, llvm_tgt, Executor::Create("graph"), Runtime::Create("cpp"), "");
+  build_f(relay_mod, targets, llvm_tgt, Executor::Create("graph"), Runtime::Create("cpp"),
+          WorkspaceMemoryPools(), "");
   // create graph executor
   std::string json = json_f();
   tvm::runtime::Module mod = mod_f();

--- a/tests/micro/zephyr/test_utils.py
+++ b/tests/micro/zephyr/test_utils.py
@@ -210,7 +210,7 @@ def generate_project(
                         model_files_path, arcname=os.path.relpath(model_files_path, tar_temp_dir)
                     )
                 header_path = generate_c_interface_header(
-                    lowered.libmod_name, ["input_1"], ["output"], [], 0, model_files_path
+                    lowered.libmod_name, ["input_1"], ["output"], [], [], 0, model_files_path
                 )
                 tf.add(header_path, arcname=os.path.relpath(header_path, tar_temp_dir))
 

--- a/tests/python/contrib/test_ethosu/test_networks.py
+++ b/tests/python/contrib/test_ethosu/test_networks.py
@@ -54,7 +54,7 @@ def test_forward_mobilenet_v1(accel_type):
     in_min, in_max = util.get_range_for_dtype_str(input_dtype)
     input_data = np.random.randint(in_min, high=in_max, size=input_shape, dtype=input_dtype)
 
-    relay_mod, params = convert_to_relay(tflite_model_buf, input_data, "input")
+    relay_mod, params = convert_to_relay(tflite_model_buf)
     input_data = {input_tensor: input_data}
     output_data = generate_ref_data(relay_mod, input_data)
 

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -822,7 +822,7 @@ def compile_and_run(
         enable_op_fusion=enable_op_fusion,
         pass_config=runner.pass_config,
         use_runtime_executor=use_runtime_executor,
-        target=tvm.target.Target(target, host=target),
+        target=tvm.target.Target(target),
     )
 
     run_and_check(

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -161,16 +161,8 @@ def mangle_name(mod_name, name):
 
 def convert_to_relay(
     tflite_model_buf,
-    input_data,
-    input_node,
 ):
     """Convert a tflite model buffer in a Relay module"""
-
-    def convert_to_list(x):
-        if not isinstance(x, list):
-            x = [x]
-        return x
-
     # TFLite.Model.Model has changed to TFLite.Model from 1.14 to 2.1
     try:
         import tflite.Model
@@ -183,18 +175,7 @@ def convert_to_relay(
     except ImportError:
         raise ImportError("The tflite package must be installed")
 
-    input_data = convert_to_list(input_data)
-    input_node = convert_to_list(input_node)
-
-    shape_dict = {}
-    dtype_dict = {}
-    for i, e in enumerate(input_node):
-        shape_dict[e] = input_data[i].shape
-        dtype_dict[e] = input_data[i].dtype.name
-
-    mod, params = relay.frontend.from_tflite(
-        tflite_model, shape_dict=shape_dict, dtype_dict=dtype_dict
-    )
+    mod, params = relay.frontend.from_tflite(tflite_model)
     mod["main"] = relay.build_module.bind_params_by_name(mod["main"], params)
     return mod, params
 
@@ -345,6 +326,16 @@ def emit_main_device_structs(main_file, devices, mod_name):
         main_file.write("};\n")
 
 
+def emit_main_workspace_pool_structs(main_file, workspace_pool_names, mod_name):
+    if workspace_pool_names and len(workspace_pool_names) > 0:
+        main_file.write(
+            f"struct {mangle_name(mod_name, 'workspace_pools')} {mangle_name(mod_name, 'workspace_pools')} = {{"
+        )
+        for workspace_pool_name in workspace_pool_names:
+            main_file.write(f"\t.{workspace_pool_name} = {workspace_pool_name},\n")
+        main_file.write("};\n")
+
+
 def emit_main_data_structs(main_file, input_map, output_list, mod_name):
     main_file.write(
         f"struct {mangle_name(mod_name, 'inputs')} {mangle_name(mod_name, 'inputs')} = {{"
@@ -384,20 +375,25 @@ def emit_main_data_setup(main_file, input_map, output_list, mod_name):
     main_file.write("};\n")
 
 
-def emit_main_c_interface_call(main_file, devices, mod_name):
+def emit_main_c_interface_call(main_file, devices, workspace_pool_names, mod_name):
+    sub_strings = list()
+    sub_strings.append(f'{mangle_name(mod_name,"run")}(')
+    sub_strings.append(f'&{mangle_name(mod_name,"inputs")}, ')
+    sub_strings.append(f'&{mangle_name(mod_name,"outputs")}, ')
+    if workspace_pool_names:
+        sub_strings.append(f'&{mangle_name(mod_name,"workspace_pools")}, ')
     if devices:
-        main_file.write(
-            f'{mangle_name(mod_name,"run")}('
-            f'&{mangle_name(mod_name,"inputs")}, '
-            f'&{mangle_name(mod_name,"outputs")}, '
-            f'&{mangle_name(mod_name,"devices")});\n'
-        )
-    else:
-        main_file.write(
-            f'{mangle_name(mod_name,"run")}('
-            f'&{mangle_name(mod_name,"inputs")}, '
-            f'&{mangle_name(mod_name,"outputs")});\n'
-        )
+        sub_strings.append(f'&{mangle_name(mod_name,"devices")}, ')
+    # Removing the last two characters that is a comma and a space
+    sub_strings[-1] = sub_strings[-1][:-2]
+    # Adding brackets and newline instead
+    sub_strings[-1] = sub_strings[-1] + ");\n"
+
+    main_file_string = ""
+    for sub_string in sub_strings:
+        main_file_string += sub_string
+
+    main_file.write(main_file_string)
 
 
 def emit_main_fake_packed_values(main_file):
@@ -541,10 +537,21 @@ def create_main(
         if interface_api == "c":
             for compiled_model in compiled_models:
                 model = compiled_model.model
+                executor_codegen_metadata = (
+                    compiled_model.executor_factory.executor_codegen_metadata
+                )
                 devices = compiled_model.executor_factory.get_devices()
+                workspace_pool_names = None
+                if executor_codegen_metadata.pool_inputs:
+                    workspace_pool_names = [
+                        allocated_pool.pool_info.pool_name
+                        for allocated_pool in dict(executor_codegen_metadata.pool_inputs).values()
+                        if not allocated_pool.pool_info.is_internal
+                    ]
                 emit_main_device_structs(main_file, devices, model.name)
+                emit_main_workspace_pool_structs(main_file, workspace_pool_names, model.name)
                 emit_main_data_structs(main_file, model.inputs, model.outputs, model.name)
-                emit_main_c_interface_call(main_file, devices, model.name)
+                emit_main_c_interface_call(main_file, devices, workspace_pool_names, model.name)
         else:
             emit_main_fake_packed_values(main_file)
             for compiled_model in compiled_models:
@@ -599,8 +606,8 @@ def compile_models(
     enable_op_fusion: bool = True,
     pass_config: Dict[str, Any] = None,
     use_runtime_executor: bool = True,
-    target: str = "c",
-    target_opts: Dict = None,
+    target: tvm.target.Target = tvm.target.Target("c"),
+    workspace_memory_pools=None,
 ) -> List[AOTCompiledTestModel]:
     """
     This method generates runtime.Modules for the tests
@@ -617,9 +624,6 @@ def compile_models(
             "unpacked-api": use_unpacked_api,
         },
     )
-    if target_opts:
-        for key, val in target_opts.items():
-            target += f" {key}={val}"
 
     config = {"tir.disable_vectorize": True}
     if pass_config:
@@ -634,9 +638,10 @@ def compile_models(
             if use_runtime_executor:
                 executor_factory = tvm.relay.build(
                     model.module,
-                    tvm.target.Target(target, host=target),
+                    target,
                     executor=executor,
                     runtime=runtime,
+                    workspace_memory_pools=workspace_memory_pools,
                     params=model.params,
                     mod_name=model.name,
                 )
@@ -776,7 +781,6 @@ def run_and_check(
         print("Run command:\n", run_command)
     ret = subprocess_log_output(run_command, build_path, run_log_path)
     assert ret == 0
-
     with open(run_log_path) as run_log:
         assert AOT_SUCCESS_TOKEN in run_log.read()
 
@@ -805,6 +809,11 @@ def compile_and_run(
     verbose: bool
         Prints commands to build and run AOT test runner
     """
+
+    if target_opts:
+        for key, val in target_opts.items():
+            target += f" {key}={val}"
+
     compiled_test_mods = compile_models(
         models=models,
         interface_api=interface_api,
@@ -813,8 +822,7 @@ def compile_and_run(
         enable_op_fusion=enable_op_fusion,
         pass_config=runner.pass_config,
         use_runtime_executor=use_runtime_executor,
-        target=target,
-        target_opts=target_opts,
+        target=tvm.target.Target(target, host=target),
     )
 
     run_and_check(

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -529,7 +529,7 @@ def test_quant_mobilenet_tfl():
     data_shape = (1, 224, 224, 3)
     in_min, in_max = (0, 255)
     data = np.random.randint(in_min, high=in_max, size=data_shape, dtype="uint8")
-    mod, params = convert_to_relay(tflite_model_buf, data, "input")
+    mod, params = convert_to_relay(tflite_model_buf)
     inputs = {"input": data}
     output_list = generate_ref_data(mod, inputs, params)
     compile_and_run(

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -709,12 +709,12 @@ def test_constants_alignment(constants_byte_alignment):
     data = np.random.uniform(size=data_shape).astype("float32")
     inputs = {"data": data}
     output_list = generate_ref_data(mod, inputs, params)
-    target_opts = {"-constants-byte-alignment": constants_byte_alignment}
+    target = f"c -constants-byte-alignment={constants_byte_alignment}"
     compiled_test_mods = compile_models(
         AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),
         interface_api,
         use_unpacked_api,
-        target_opts=target_opts,
+        target=tvm.target.Target(target, host=target),
     )
     source = compiled_test_mods[0].executor_factory.lib.imported_modules[0].get_source()
     assert f'__attribute__((section(".rodata.tvm"), aligned({constants_byte_alignment})))' in source

--- a/tests/python/relay/aot/test_crt_aot_usmp.py
+++ b/tests/python/relay/aot/test_crt_aot_usmp.py
@@ -29,6 +29,7 @@ from tvm.relay import testing, transform
 from tvm.relay.testing import byoc
 from tvm.relay.op.annotation import compiler_begin, compiler_end
 from tvm.relay.backend import Executor, Runtime
+from tvm import WorkspaceMemoryPools, PoolInfo
 from aot_test_utils import (
     AOTTestModel,
     AOTTestRunner,
@@ -201,9 +202,30 @@ def test_byoc_microtvm(merge_compiler_regions):
     )
 
 
+def _get_relay_module_and_inputs_from_tflite_file(tflite_model_file):
+    with open(tflite_model_file, "rb") as f:
+        tflite_model_buf = f.read()
+    mod, params = convert_to_relay(tflite_model_buf)
+
+    inputs = dict()
+    for param in mod["main"].params:
+        name = str(param.name_hint)
+        data_shape = [int(i) for i in param.type_annotation.shape]
+        dtype = str(param.type_annotation.dtype)
+        in_min, in_max = (np.iinfo(dtype).min, np.iinfo(dtype).max)
+        data = np.random.randint(in_min, high=in_max, size=data_shape, dtype=dtype)
+        inputs[name] = data
+
+    return mod, inputs, params
+
+
 MOBILENET_V1_URL = (
     "https://storage.googleapis.com/download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz",
     "mobilenet_v1_1.0_224_quant.tflite",
+)
+MOBILENET_V2_URL = (
+    "https://storage.googleapis.com/download.tensorflow.org/models/tflite_11_05_08/mobilenet_v2_1.0_224_quant.tgz",
+    "mobilenet_v2_1.0_224_quant.tflite",
 )
 
 
@@ -215,7 +237,7 @@ MOBILENET_V1_URL = (
         (MOBILENET_V1_URL, "hill_climb", 3240064),
     ],
 )
-def test_tflite_model(model_url, usmp_algo, workspace_size):
+def test_tflite_model_u1_usecase(model_url, usmp_algo, workspace_size):
     """This checks for ML models and the memory used by them when using USMP with different algorithms"""
     pytest.importorskip("tflite")
 
@@ -231,13 +253,7 @@ def test_tflite_model(model_url, usmp_algo, workspace_size):
         model_url[0],
         model_url[1],
     )
-    with open(tflite_model_file, "rb") as f:
-        tflite_model_buf = f.read()
-    data_shape = (1, 224, 224, 3)
-    in_min, in_max = (0, 255)
-    data = np.random.randint(in_min, high=in_max, size=data_shape, dtype="uint8")
-    mod, params = convert_to_relay(tflite_model_buf, data, "input")
-    inputs = {"input": data}
+    mod, inputs, params = _get_relay_module_and_inputs_from_tflite_file(tflite_model_file)
     output_list = generate_ref_data(mod, inputs, params)
 
     compiled_test_mods = compile_models(
@@ -259,6 +275,197 @@ def test_tflite_model(model_url, usmp_algo, workspace_size):
         )
         == workspace_size
     )
+
+    run_and_check(
+        models=compiled_test_mods,
+        runner=test_runner,
+        interface_api=interface_api,
+    )
+
+
+def _get_workspace_size_define_macro(pool_name: str, model_name="default") -> str:
+    """This function converts pool names to compiler generated
+    workspace pool size macros"""
+
+    prefix = "TVMGEN_" + model_name.upper() + "_"
+    postfix = "_WORKSPACE_POOL_SIZE"
+    return prefix + pool_name.upper() + postfix
+
+
+@pytest.mark.parametrize(
+    "model_url, usmp_algo",
+    [
+        (MOBILENET_V1_URL, "greedy_by_size"),
+    ],
+)
+def test_tflite_model_u3_usecase_single_external_pool(model_url, usmp_algo):
+    """This checks for ML models and the memory used by them when using USMP with different algorithms"""
+    pytest.importorskip("tflite")
+
+    import tvm.relay.testing.tf as tf_testing
+
+    use_unpacked_api = True
+    interface_api = "c"
+
+    pool_name = "my_memory_pool"
+    target = tvm.target.Target("c")
+    workspace_memory_pools = WorkspaceMemoryPools(
+        [PoolInfo(pool_name, {target: PoolInfo.READ_WRITE_ACCESS})]
+    )
+    test_runner = AOTTestRunner(
+        pass_config={"tir.usmp.enable": True, "tir.usmp.algorithm": usmp_algo},
+        prologue=f"""
+        __attribute__((section(".data.tvm"), aligned(16)))
+        static uint8_t {pool_name}[{_get_workspace_size_define_macro(pool_name)}];
+        """,
+    )
+
+    tflite_model_file = tf_testing.get_workload_official(
+        model_url[0],
+        model_url[1],
+    )
+    mod, inputs, params = _get_relay_module_and_inputs_from_tflite_file(tflite_model_file)
+    output_list = generate_ref_data(mod, inputs, params)
+
+    compiled_test_mods = compile_models(
+        AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),
+        interface_api=interface_api,
+        use_unpacked_api=use_unpacked_api,
+        pass_config=test_runner.pass_config,
+        workspace_memory_pools=workspace_memory_pools,
+        target=target,
+    )
+
+    for compiled_model in compiled_test_mods:
+        check_for_no_tvm_backendallocworkspace_calls(compiled_model.executor_factory.lib)
+
+    run_and_check(
+        models=compiled_test_mods,
+        runner=test_runner,
+        interface_api=interface_api,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_url, usmp_algo",
+    [
+        (MOBILENET_V1_URL, "greedy_by_size"),
+    ],
+)
+def test_tflite_model_u3_usecase_two_external_pools(model_url, usmp_algo):
+    """This checks for ML models and the memory used by them when using USMP with different algorithms"""
+    pytest.importorskip("tflite")
+
+    import tvm.relay.testing.tf as tf_testing
+
+    use_unpacked_api = True
+    interface_api = "c"
+
+    target = tvm.target.Target("c")
+    workspace_memory_pools = WorkspaceMemoryPools(
+        [
+            PoolInfo(
+                "my_memory_pool_1", {target: PoolInfo.READ_WRITE_ACCESS}, size_hint_bytes=2500000
+            ),
+            PoolInfo("my_memory_pool_2", {target: PoolInfo.READ_WRITE_ACCESS}),
+        ]
+    )
+    test_runner = AOTTestRunner(
+        pass_config={"tir.usmp.enable": True, "tir.usmp.algorithm": usmp_algo},
+        prologue=f"""
+        __attribute__((section(".data.tvm"), aligned(16)))
+        static uint8_t my_memory_pool_1[{_get_workspace_size_define_macro("my_memory_pool_1")}];
+        __attribute__((section(".data.tvm"), aligned(16)))
+        static uint8_t my_memory_pool_2[{_get_workspace_size_define_macro("my_memory_pool_2")}];
+        """,
+    )
+
+    tflite_model_file = tf_testing.get_workload_official(
+        model_url[0],
+        model_url[1],
+    )
+    mod, inputs, params = _get_relay_module_and_inputs_from_tflite_file(tflite_model_file)
+    output_list = generate_ref_data(mod, inputs, params)
+
+    compiled_test_mods = compile_models(
+        AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),
+        interface_api=interface_api,
+        use_unpacked_api=use_unpacked_api,
+        pass_config=test_runner.pass_config,
+        workspace_memory_pools=workspace_memory_pools,
+        target=target,
+    )
+
+    for compiled_model in compiled_test_mods:
+        check_for_no_tvm_backendallocworkspace_calls(compiled_model.executor_factory.lib)
+
+    run_and_check(
+        models=compiled_test_mods,
+        runner=test_runner,
+        interface_api=interface_api,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_urls, usmp_algo",
+    [
+        ((MOBILENET_V1_URL, MOBILENET_V2_URL), "greedy_by_size"),
+    ],
+)
+def test_tflite_model_u2_usecase_two_models_with_a_single_external_pool(model_urls, usmp_algo):
+    """This checks for ML models and the memory used by them when using USMP with different algorithms"""
+    pytest.importorskip("tflite")
+
+    import tvm.relay.testing.tf as tf_testing
+
+    use_unpacked_api = True
+    interface_api = "c"
+
+    target = tvm.target.Target("c")
+    workspace_memory_pools = WorkspaceMemoryPools(
+        [PoolInfo("my_memory_pool", {target: PoolInfo.READ_WRITE_ACCESS})]
+    )
+    test_runner = AOTTestRunner(
+        pass_config={"tir.usmp.enable": True, "tir.usmp.algorithm": usmp_algo},
+        prologue=f"""
+        #define MAX(A, B) ((A > B) ? A : B)
+        __attribute__((section(".data.tvm"), aligned(16)))
+        static uint8_t my_memory_pool[MAX({_get_workspace_size_define_macro("my_memory_pool", "mod1")},{_get_workspace_size_define_macro("my_memory_pool", "mod2")})];
+        """,
+    )
+
+    tflite_model_file1 = tf_testing.get_workload_official(
+        model_urls[0][0],
+        model_urls[0][1],
+    )
+    mod1, inputs1, params1 = _get_relay_module_and_inputs_from_tflite_file(tflite_model_file1)
+    output_list1 = generate_ref_data(mod1, inputs1, params1)
+
+    tflite_model_file2 = tf_testing.get_workload_official(
+        model_urls[1][0],
+        model_urls[1][1],
+    )
+    mod2, inputs2, params2 = _get_relay_module_and_inputs_from_tflite_file(tflite_model_file2)
+    output_list2 = generate_ref_data(mod2, inputs2, params2)
+
+    compiled_test_mods = compile_models(
+        [
+            AOTTestModel(
+                name="mod1", module=mod1, inputs=inputs1, outputs=output_list1, params=params1
+            ),
+            AOTTestModel(
+                name="mod2", module=mod2, inputs=inputs2, outputs=output_list2, params=params2
+            ),
+        ],
+        interface_api=interface_api,
+        use_unpacked_api=use_unpacked_api,
+        pass_config=test_runner.pass_config,
+        workspace_memory_pools=workspace_memory_pools,
+        target=target,
+    )
+
+    for compiled_model in compiled_test_mods:
+        check_for_no_tvm_backendallocworkspace_calls(compiled_model.executor_factory.lib)
 
     run_and_check(
         models=compiled_test_mods,

--- a/tests/python/relay/aot/test_crt_aot_usmp.py
+++ b/tests/python/relay/aot/test_crt_aot_usmp.py
@@ -299,7 +299,7 @@ def _get_workspace_size_define_macro(pool_name: str, model_name="default") -> st
     ],
 )
 def test_tflite_model_u3_usecase_single_external_pool(model_url, usmp_algo):
-    """This checks for ML models and the memory used by them when using USMP with different algorithms"""
+    """This checks for inference with USMP using external pool placed in the application"""
     pytest.importorskip("tflite")
 
     import tvm.relay.testing.tf as tf_testing
@@ -353,7 +353,7 @@ def test_tflite_model_u3_usecase_single_external_pool(model_url, usmp_algo):
     ],
 )
 def test_tflite_model_u3_usecase_two_external_pools(model_url, usmp_algo):
-    """This checks for ML models and the memory used by them when using USMP with different algorithms"""
+    """This checks for inference using two external pools placed in the application"""
     pytest.importorskip("tflite")
 
     import tvm.relay.testing.tf as tf_testing
@@ -413,7 +413,7 @@ def test_tflite_model_u3_usecase_two_external_pools(model_url, usmp_algo):
     ],
 )
 def test_tflite_model_u2_usecase_two_models_with_a_single_external_pool(model_urls, usmp_algo):
-    """This checks for ML models and the memory used by them when using USMP with different algorithms"""
+    """This checks for inference using a single large enough common pool"""
     pytest.importorskip("tflite")
 
     import tvm.relay.testing.tf as tf_testing


### PR DESCRIPTION
This commit adds a MemoryPools argument for
the compilation flow according to RFC0029.

Moreover, it is used to provide support for
external pools from the application layer
that could be pinned for different memories
and/or be reused between multiple inferences.