### PR TITLE
[ci] Add more details when showing node info

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,10 +93,8 @@ def per_exec_ws(folder) {
 def init_git() {
   // Add more info about job node
   sh (
-    script: """
-     echo "INFO: NODE_NAME=${NODE_NAME} EXECUTOR_NUMBER=${EXECUTOR_NUMBER}"
-     """,
-     label: 'Show executor node info',
+    script: './task/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
   )
   checkout scm
   retry(5) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,12 +91,12 @@ def per_exec_ws(folder) {
 
 // initialize source codes
 def init_git() {
+  checkout scm
   // Add more info about job node
   sh (
     script: './tests/scripts/task_show_node_info.sh',
     label: 'Show executor node info',
   )
-  checkout scm
   retry(5) {
     timeout(time: 2, unit: 'MINUTES') {
       sh (script: 'git submodule update --init -f', label: 'Update git submodules')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ def per_exec_ws(folder) {
 def init_git() {
   // Add more info about job node
   sh (
-    script: './task/scripts/task_show_node_info.sh',
+    script: './tests/scripts/task_show_node_info.sh',
     label: 'Show executor node info',
   )
   checkout scm

--- a/tests/scripts/task_show_node_info.sh
+++ b/tests/scripts/task_show_node_info.sh
@@ -26,14 +26,18 @@ echo "$BUILD_NUMBER"
 echo "$WORKSPACE"
 
 echo "===== EC2 INFO ====="
-# See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/ami-id || echo failed
-curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/instance-id || echo failed
-curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/instance-type || echo failed
-curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/hostname || echo failed
-curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/public-hostname || echo failed
+function ec2_metadata() {
+    # See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+    curl -w '\n' -fsSL "http://169.254.169.254/latest/meta-data/$1" || echo failed
+}
+
+ec2_metadata ami-id
+ec2_metadata instance-id
+ec2_metadata instance-type
+ec2_metadata hostname
+ec2_metadata public-hostname
 
 echo "===== RUNNER INFO ====="
 df --human-readable
 lscpu
-
+free

--- a/tests/scripts/task_show_node_info.sh
+++ b/tests/scripts/task_show_node_info.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -x
+
+echo "===== JENKINS INFO ====="
+echo "$NODE_NAME"
+echo "$EXECUTOR_NUMBER"
+echo "$WORKSPACE"
+echo "$BUILD_NUMBER"
+echo "$WORKSPACE"
+
+echo "===== EC2 INFO ====="
+# See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/ami-id || echo failed
+curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/instance-id || echo failed
+curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/instance-type || echo failed
+curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/hostname || echo failed
+curl -w '\n' -fsSL http://169.254.169.254/latest/meta-data/public-hostname || echo failed
+
+echo "===== RUNNER INFO ====="
+df --human-readable
+lscpu
+


### PR DESCRIPTION
This adds some more information to help debug when there are infra problems with Jenkins, notably:
* More Jenkins environment variables: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
* EC2 metadata
* System level information (disk space, CPUs)

