### PR TITLE
[ci] Invoke tensorflow tests individually

### DIFF
--- a/tests/scripts/task_python_frontend.sh
+++ b/tests/scripts/task_python_frontend.sh
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 # to avoid openblas threading error
@@ -41,7 +40,12 @@ echo "Running relay CoreML frontend test..."
 run_pytest cython python-frontend-coreml tests/python/frontend/coreml
 
 echo "Running relay Tensorflow frontend test..."
-run_pytest cython python-frontend-tensorflow tests/python/frontend/tensorflow
+# Note: Tensorflow tests often have memory issues, so invoke each one separately
+TENSORFLOW_TESTS=$(grep '^def test_' tests/python/frontend/tensorflow/* | sed 's/\(.*\.py\):def \(.*\)():/\1::\2/g')
+for node_id in $TENSORFLOW_TESTS; do
+    echo "$node_id"
+    run_pytest cython python-frontend-tensorflow "$node_id"
+done
 
 echo "Running relay caffe2 frontend test..."
 run_pytest cython python-frontend-caffe2 tests/python/frontend/caffe2


### PR DESCRIPTION
This is another (simpler) attempt at #10151 to avoid CUDA issues with tensorflow tests. This should work by cleaning up any reserved GPU memory by tearing down the whole process that has imported tensorflow each time a test is run.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
