### PR TITLE
[ci] Invoke tensorflow tests individually

### DIFF
--- a/tests/scripts/pytest_ids.py
+++ b/tests/scripts/pytest_ids.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+import io
+import argparse
+
+from contextlib import redirect_stdout
+
+
+class NodeidsCollector:
+    def pytest_collection_modifyitems(self, items):
+        self.nodeids = [item.nodeid for item in items]
+
+
+def main(folder):
+    collector = NodeidsCollector()
+    f = io.StringIO()
+    with redirect_stdout(f):
+        pytest.main(["-qq", "--collect-only", folder], plugins=[collector])
+    for nodeid in collector.nodeids:
+        print(nodeid)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="List pytest nodeids for a folder")
+    parser.add_argument("--folder", required=True, help="test folder to inspect")
+    args = parser.parse_args()
+    main(args.folder)

--- a/tests/scripts/task_python_frontend.sh
+++ b/tests/scripts/task_python_frontend.sh
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 # to avoid openblas threading error
@@ -41,7 +40,12 @@ echo "Running relay CoreML frontend test..."
 run_pytest cython python-frontend-coreml tests/python/frontend/coreml
 
 echo "Running relay Tensorflow frontend test..."
-run_pytest cython python-frontend-tensorflow tests/python/frontend/tensorflow
+# Note: Tensorflow tests often have memory issues, so invoke each one separately
+TENSORFLOW_TESTS=$(grep '^def test_' tests/python/frontend/tensorflow/* | sed 's/\(.*\.py\):def \(.*\)():/\1::\2/g')
+for node_id in $TENSORFLOW_TESTS; do
+    echo "$node_id"
+    run_pytest cython python-frontend-tensorflow "$node_id"
+done
 
 echo "Running relay caffe2 frontend test..."
 run_pytest cython python-frontend-caffe2 tests/python/frontend/caffe2

--- a/tests/scripts/task_python_frontend.sh
+++ b/tests/scripts/task_python_frontend.sh
@@ -41,7 +41,7 @@ run_pytest cython python-frontend-coreml tests/python/frontend/coreml
 
 echo "Running relay Tensorflow frontend test..."
 # Note: Tensorflow tests often have memory issues, so invoke each one separately
-TENSORFLOW_TESTS=$(grep '^def test_' tests/python/frontend/tensorflow/* | sed 's/\(.*\.py\):def \(.*\)():/\1::\2/g')
+TENSORFLOW_TESTS=$(./tests/scripts/pytest_ids.py --folder tests/python/frontend/tensorflow)
 for node_id in $TENSORFLOW_TESTS; do
     echo "$node_id"
     run_pytest cython python-frontend-tensorflow "$node_id"


### PR DESCRIPTION
This loops through and invokes all the tensorflow tests individually rather than in a single Python process. This should have the OS clean up tensorflow's CPU/GPU memory usage between each test and reduce flakiness, at the cost of some runtime overhead (which we could maybe remove in the future with some caching inside pytest, but it's small compared to the test time)

cc @areusch @mbrookhart @masahi 