### PR TITLE
[Conda] Fix CUDA 11 compatibility in conda scripts

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -61,11 +61,11 @@ outputs:
         - zlib
         - llvmdev ==10.0.0
         - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
-        - {{ pin_compatible('cudnn', lower_bound='7.6.0', max_pin='x') }}  # [cuda]
+        - cudnn >=7.6.0  # [cuda]
       run:
         - llvmdev ==10.0.0
         - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
-        - {{ pin_compatible('cudnn', lower_bound='7.6.0', max_pin='x') }}  # [cuda]
+        - cudnn >=7.6.0  # [cuda]
 
   - name: {{ pkg_name }}
     script: install_tvm_python.sh  # [not win]


### PR DESCRIPTION
In `conda/recipe/meta.yaml`, the version requirement for `cudnn` is from`>=7.6.0` (`lower_bound`) to `<8` (bounded by `max_pin`), while cuDNN 7 requires `cudatoolkit` version `<11`.

So I just remove the `max_pin` requirements for `cudnn` library to be compatible with `cudatoolkit>=11`.

For more details, please refer to #10134.


