### PR TITLE
Support sub warp reduction for CUDA target.

### DIFF
--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -267,8 +267,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       Var mask_var("mask", PointerType(PrimType(mask_dtype)));
       {
         PrimExpr pred = const_true(1);
-        PrimExpr mask = Call(mask_dtype, builtin::tvm_warp_activemask(), {}) &
-                        (((unsigned)1 << reduce_extent) - 1);
+        PrimExpr mask = Call(mask_dtype, builtin::tvm_warp_activemask(), {});
         seq.emplace_back(Store(mask_var, mask, index, pred));
         // Push allocation with an empty body. Later this will be fixed
         // when the entire body is ready.

--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -604,7 +604,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         return false;  // no need to warp reduce
       } else {
         if (warp_size_ % reduce_extent == 0) {
-          return true;  // warp size is multiple of blockDim.x
+          return true;  // warp size is multiple of reduce extent
         } else {
           return group_extent == 1 && reduce_extent <= warp_size_;
         }

--- a/tests/python/unittest/test_subwarp_reduction_cuda.py
+++ b/tests/python/unittest/test_subwarp_reduction_cuda.py
@@ -29,7 +29,7 @@ def reduce(a: T.handle, b: T.handle, d1: T.int32, d2: T.int32, d3: T.int32) -> N
         with T.block("reduce"):
             vi, vj, vk, vl = T.axis.remap("SSSR", [i, j, k, l])
             with T.init():
-                B[vi, vj, vk] = 0.
+                B[vi, vj, vk] = 0.0
             B[vi, vj, vk] = B[vi, vj, vk] + A[vi, vj, vk, vl]
 
 
@@ -38,9 +38,7 @@ def test_cuda_subwarp_reduction():
         for d2 in range(1, 5):
             for d3 in range(2, 33):
                 _, _, _d1, _d2, _d3 = reduce.params
-                mod = reduce.specialize(
-                    {_d1: d1, _d2: d2, _d3: d3}
-                )
+                mod = reduce.specialize({_d1: d1, _d2: d2, _d3: d3})
                 sch = tvm.tir.Schedule(mod)
                 blk = sch.get_block("reduce")
                 i, j, k, l = sch.get_loops(blk)

--- a/tests/python/unittest/test_subwarp_reduction_cuda.py
+++ b/tests/python/unittest/test_subwarp_reduction_cuda.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import tvm.testing
+import numpy as np
+from tvm.script import tir as T
+
+
+@T.prim_func
+def reduce(a: T.handle, b: T.handle, d1: T.int32, d2: T.int32, d3: T.int32) -> None:
+    A = T.match_buffer(a, [1, d1, d2, d3])
+    B = T.match_buffer(b, [1, d1, d2])
+
+    for i, j, k, l in T.grid(1, d1, d2, d3):
+        with T.block("reduce"):
+            vi, vj, vk, vl = T.axis.remap("SSSR", [i, j, k, l])
+            with T.init():
+                B[vi, vj, vk] = 0.
+            B[vi, vj, vk] = B[vi, vj, vk] + A[vi, vj, vk, vl]
+
+
+def test_cuda_subwarp_reduction():
+    for d1 in range(1, 5):
+        for d2 in range(1, 5):
+            for d3 in range(2, 33):
+                _, _, _d1, _d2, _d3 = reduce.params
+                mod = reduce.specialize(
+                    {_d1: d1, _d2: d2, _d3: d3}
+                )
+                sch = tvm.tir.Schedule(mod)
+                blk = sch.get_block("reduce")
+                i, j, k, l = sch.get_loops(blk)
+                sch.bind(i, "blockIdx.x")
+                sch.bind(j, "threadIdx.z")
+                sch.bind(k, "threadIdx.y")
+                sch.bind(l, "threadIdx.x")
+                f = tvm.build(sch.mod["main"], target="cuda")
+
+                # prepare input and output array
+                a_np = np.random.rand(1, d1, d2, d3).astype("float32")
+                b_np = a_np.sum(axis=-1).astype("float32")
+                a = tvm.nd.array(a_np, tvm.cuda(0))
+                b = tvm.nd.array(np.zeros_like(b_np), tvm.cuda(0))
+
+                # launch kernel
+                f(a, b)
+                tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+
+
+if __name__ == "__main__":
+    test_cuda_subwarp_reduction()

--- a/tests/python/unittest/test_subwarp_reduction_cuda.py
+++ b/tests/python/unittest/test_subwarp_reduction_cuda.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from tabnanny import check
 import tvm
 import tvm.testing
 import numpy as np
@@ -48,7 +47,6 @@ def test_cuda_subwarp_reduction():
         sch.bind(k, "threadIdx.y")
         sch.bind(l, "threadIdx.x")
         f = tvm.build(sch.mod["main"], target="cuda")
-        print(f.imported_modules[0].get_source())
 
         # prepare input and output array
         a_np = np.random.rand(1, d1, d2, d3).astype("float32")

--- a/tests/python/unittest/test_subwarp_reduction_cuda.py
+++ b/tests/python/unittest/test_subwarp_reduction_cuda.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from tabnanny import check
 import tvm
 import tvm.testing
 import numpy as np
@@ -33,30 +34,36 @@ def reduce(a: T.handle, b: T.handle, d1: T.int32, d2: T.int32, d3: T.int32) -> N
             B[vi, vj, vk] = B[vi, vj, vk] + A[vi, vj, vk, vl]
 
 
+@tvm.testing.requires_gpu
+@tvm.testing.requires_cuda
 def test_cuda_subwarp_reduction():
+    def check(d1: int, d2: int, d3: int):
+        _, _, _d1, _d2, _d3 = reduce.params
+        mod = reduce.specialize({_d1: d1, _d2: d2, _d3: d3})
+        sch = tvm.tir.Schedule(mod)
+        blk = sch.get_block("reduce")
+        i, j, k, l = sch.get_loops(blk)
+        sch.bind(i, "blockIdx.x")
+        sch.bind(j, "threadIdx.z")
+        sch.bind(k, "threadIdx.y")
+        sch.bind(l, "threadIdx.x")
+        f = tvm.build(sch.mod["main"], target="cuda")
+        print(f.imported_modules[0].get_source())
+
+        # prepare input and output array
+        a_np = np.random.rand(1, d1, d2, d3).astype("float32")
+        b_np = a_np.sum(axis=-1).astype("float32")
+        a = tvm.nd.array(a_np, tvm.cuda(0))
+        b = tvm.nd.array(np.zeros_like(b_np), tvm.cuda(0))
+
+        # launch kernel
+        f(a, b)
+        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+
     for d1 in range(1, 5):
         for d2 in range(1, 5):
             for d3 in range(2, 33):
-                _, _, _d1, _d2, _d3 = reduce.params
-                mod = reduce.specialize({_d1: d1, _d2: d2, _d3: d3})
-                sch = tvm.tir.Schedule(mod)
-                blk = sch.get_block("reduce")
-                i, j, k, l = sch.get_loops(blk)
-                sch.bind(i, "blockIdx.x")
-                sch.bind(j, "threadIdx.z")
-                sch.bind(k, "threadIdx.y")
-                sch.bind(l, "threadIdx.x")
-                f = tvm.build(sch.mod["main"], target="cuda")
-
-                # prepare input and output array
-                a_np = np.random.rand(1, d1, d2, d3).astype("float32")
-                b_np = a_np.sum(axis=-1).astype("float32")
-                a = tvm.nd.array(a_np, tvm.cuda(0))
-                b = tvm.nd.array(np.zeros_like(b_np), tvm.cuda(0))
-
-                # launch kernel
-                f(a, b)
-                tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+                check(d1, d2, d3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously the `LowerThreadAllReduce` pass will only emit code that uses `shfl_down` when reduce extent equals warp size, when reduce extent is less than warp size, the codegen fall back to emit code that uses shared memory, which is not efficient. Considering CUDA supports sub-warp reduction by specifying the mask, we can still use the shuffle-down approach for reduction by changing the mask.

Example code:
```python
import tvm
import numpy as np
from tvm.script import tir as T


@T.prim_func
def reduce(a: T.handle, b: T.handle) -> None:
    A = T.match_buffer(a, [1024, 11])
    B = T.match_buffer(b, [1024])

    for i, j in T.grid(1024, 11):
        with T.block("reduce"):
            vi, vj = T.axis.remap("SR", [i, j])
            with T.init():
                B[vi] = 0.
            B[vi] = B[vi] + A[vi, vj]

sch = tvm.tir.Schedule(reduce)
blk = sch.get_block("reduce")
i, j = sch.get_loops(blk)
sch.bind(i, "blockIdx.x")
sch.bind(j, "threadIdx.x")
f = tvm.build(sch.mod["main"], target="cuda")
print(f.imported_modules[0].get_source())
```


Emitted code before this PR:
```cuda
extern "C" __global__ void __launch_bounds__(11) default_function_kernel0(float* __restrict__ A, float* __restrict__ B) {
  __shared__ float red_buf0[11];
  __syncthreads();
  ((volatile float*)red_buf0)[(((int)threadIdx.x))] = A[(((((int)blockIdx.x) * 11) + ((int)threadIdx.x)))];
  __syncthreads();
  if (((int)threadIdx.x) < 3) {
    ((volatile float*)red_buf0)[(((int)threadIdx.x))] = (((volatile float*)red_buf0)[(((int)threadIdx.x))] + ((volatile float*)red_buf0)[((((int)threadIdx.x) + 8))]);
  }
  __syncthreads();
  if (((int)threadIdx.x) < 4) {
    float w_4_0 = (((volatile float*)red_buf0)[(((int)threadIdx.x))] + ((volatile float*)red_buf0)[((((int)threadIdx.x) + 4))]);
    ((volatile float*)red_buf0)[(((int)threadIdx.x))] = w_4_0;
    float w_2_0 = (((volatile float*)red_buf0)[(((int)threadIdx.x))] + ((volatile float*)red_buf0)[((((int)threadIdx.x) + 2))]);
    ((volatile float*)red_buf0)[(((int)threadIdx.x))] = w_2_0;
    float w_1_0 = (((volatile float*)red_buf0)[(((int)threadIdx.x))] + ((volatile float*)red_buf0)[((((int)threadIdx.x) + 1))]);
    ((volatile float*)red_buf0)[(((int)threadIdx.x))] = w_1_0;
  }
  __syncthreads();
  B[(((int)blockIdx.x))] = ((volatile float*)red_buf0)[(0)];
}
```

Emitted code after this PR:
```cuda
extern "C" __global__ void __launch_bounds__(11) default_function_kernel0(float* __restrict__ A, float* __restrict__ B) {
  float red_buf0[1];
  uint mask[1];
  float t0[1];
  red_buf0[(0)] = A[(((((int)blockIdx.x) * 11) + ((int)threadIdx.x)))];
  mask[(0)] = __activemask();
  t0[(0)] = __shfl_down_sync(mask[(0)], red_buf0[(0)], 8, 32);
  red_buf0[(0)] = (red_buf0[(0)] + t0[(0)]);
  t0[(0)] = __shfl_down_sync(mask[(0)], red_buf0[(0)], 4, 32);
  red_buf0[(0)] = (red_buf0[(0)] + t0[(0)]);
  t0[(0)] = __shfl_down_sync(mask[(0)], red_buf0[(0)], 2, 32);
  red_buf0[(0)] = (red_buf0[(0)] + t0[(0)]);
  t0[(0)] = __shfl_down_sync(mask[(0)], red_buf0[(0)], 1, 32);
  red_buf0[(0)] = (red_buf0[(0)] + t0[(0)]);
  red_buf0[(0)] = __shfl_sync(mask[(0)], red_buf0[(0)], 0, 32);
  B[(((int)blockIdx.x))] = red_buf0[(0)];
}
```

# Future work
CUDA 11 supports [cooperative group reduction](https://developer.nvidia.com/blog/cuda-11-features-revealed/) which we can directly use.

cc @vinx13 @junrushao1994 
