### PR TITLE
[ci] Check more events before pinging reviewers

### DIFF
--- a/tests/python/unittest/test_ci.py
+++ b/tests/python/unittest/test_ci.py
@@ -206,11 +206,20 @@ def test_ping_reviewers(tmpdir_factory):
 
         assert check in proc.stdout
 
+    def all_time_keys(time):
+        return {
+            "updatedAt": time,
+            "lastEditedAt": time,
+            "createdAt": time,
+            "publishedAt": time,
+        }
+
     run(
         {
             "isDraft": True,
+            "number": 2,
         },
-        "Checking 0 PRs",
+        "Checking 0 of 1 fetched",
     )
 
     run(
@@ -218,7 +227,7 @@ def test_ping_reviewers(tmpdir_factory):
             "isDraft": False,
             "number": 2,
         },
-        "Checking 0 PRs",
+        "Checking 0 of 1 fetched",
     )
 
     run(
@@ -229,7 +238,7 @@ def test_ping_reviewers(tmpdir_factory):
             "isDraft": False,
             "author": {"login": "user"},
             "reviews": {"nodes": []},
-            "publishedAt": "2022-01-18T17:54:19Z",
+            **all_time_keys("2022-01-18T17:54:19Z"),
             "comments": {"nodes": []},
         },
         "Pinging reviewers ['someone'] on https://github.com/apache/tvm/pull/123",
@@ -244,14 +253,14 @@ def test_ping_reviewers(tmpdir_factory):
             "isDraft": False,
             "author": {"login": "user2"},
             "reviews": {"nodes": []},
-            "publishedAt": "2022-01-18T17:54:19Z",
+            **all_time_keys("2022-01-18T17:54:19Z"),
             "comments": {
                 "nodes": [
-                    {"updatedAt": "2022-01-19T17:54:19Z", "bodyText": "abc"},
+                    {**all_time_keys("2022-01-19T17:54:19Z"), "bodyText": "abc"},
                 ]
             },
         },
-        "Checking 0 PRs",
+        "Checking 0 of 1 fetched",
     )
 
     # Old comment, ping
@@ -263,10 +272,13 @@ def test_ping_reviewers(tmpdir_factory):
             "isDraft": False,
             "author": {"login": "user"},
             "reviews": {"nodes": []},
-            "publishedAt": "2022-01-18T17:54:19Z",
+            **all_time_keys("2022-01-18T17:54:19Z"),
             "comments": {
                 "nodes": [
-                    {"updatedAt": "2022-01-19T17:54:19Z", "bodyText": "abc"},
+                    {
+                        **all_time_keys("2022-01-18T17:54:19Z"),
+                        "bodyText": "abc",
+                    },
                 ]
             },
         },
@@ -282,10 +294,10 @@ def test_ping_reviewers(tmpdir_factory):
             "isDraft": False,
             "author": {"login": "user"},
             "reviews": {"nodes": []},
-            "publishedAt": "2022-01-18T17:54:19Z",
+            **all_time_keys("2022-01-18T17:54:19Z"),
             "comments": {
                 "nodes": [
-                    {"updatedAt": "2022-01-27T17:54:19Z", "bodyText": "abc"},
+                    {**all_time_keys("2022-01-27T17:54:19Z"), "bodyText": "abc"},
                 ]
             },
         },


### PR DESCRIPTION
This was missing some events before (reviews without comments, PR updated from a draft -> ready for review) so these were being ignored when finding the latest event. This PR adds them and restructures the code a bit to make it more clear what is happening for each PR. This addresses some of the issues from #9983

cc @areusch @hpanda-naut