### PR TITLE
[BUG]fix batch matmul not set attrs_type_key, when using tvm.parse.parse_expr will raise error.

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -1009,6 +1009,7 @@ Both `tensor_a` and `tensor_b` can be transposed. For legacy reason, we use NT f
 - **out**: `(b, m, n)`.
 
 )code" TVM_ADD_FILELINE)
+    .set_attrs_type<BatchMatmulAttrs>()
     .set_num_inputs(2)
     .add_argument("tensor_a", "3D Tensor", "The first input.")
     .add_argument("tensor_b", "3D Tensor", "The second input.")


### PR DESCRIPTION
```
df_parsed = tvm.parser.parse_expr(
    '''
    fn (%p0527: Tensor[(16, 256, 256), float16], %p1361: Tensor[(16, 64, 256), float16]) -> Tensor[(16, 256, 64), float16] {
        nn.batch_matmul(%p0527, %p1361, transpose_b=True) /* ty=Tensor[(16, 256, 64), float32] */
    }
    '''
)
```
the code above may fail, cause not set nn.batch_matmul attrs_type_key.

test_code:
```
def test_nn_batch_matmul():
    df_parsed = tvm.parser.parse_expr(
        '''
        fn (%p0527: Tensor[(16, 256, 256), float16], %p1361: Tensor[(16, 64, 256), float16]) -> Tensor[(16, 256, 64), float16] {
        nn.batch_matmul(%p0527, %p1361, transpose_b=True) /* ty=Tensor[(16, 256, 64), float32] */
      }
        ''')


```

![image](https://user-images.githubusercontent.com/53092165/153335508-061897e5-993e-4c55-9eb3-353baf2259d9.png)

now the attr has been properly set.


