### PR TITLE
Mark test_op_int8 as flaky

### DIFF
--- a/docs/contribute/ci.rst
+++ b/docs/contribute/ci.rst
@@ -117,7 +117,7 @@ disabling PR.
 
 .. code:: python
 
-    @pytest.mark.xfail(strict=False, reason="Flaky test: https://github.com/apache/tvm/issues/1234
+    @pytest.mark.xfail(strict=False, reason="Flaky test: https://github.com/apache/tvm/issues/1234")
     def test_something_flaky():
         pass
 

--- a/tests/python/contrib/test_cmsisnn/test_fully_connected.py
+++ b/tests/python/contrib/test_cmsisnn/test_fully_connected.py
@@ -99,6 +99,7 @@ def make_model(
 
 
 @tvm.testing.requires_cmsisnn
+@pytest.mark.xfail(strict=False, reason="Flaky test: https://github.com/apache/tvm/issues/10213")
 @pytest.mark.parametrize("in_shape", [(2, 28), (1, 64)])
 @pytest.mark.parametrize("out_channels", [12, 128])
 @pytest.mark.parametrize("enable_bias", [False, True])


### PR DESCRIPTION
As per the docs [here](https://github.com/apache/tvm/blob/main/docs/contribute/ci.rst#handling-flaky-failures) this PR marks `test_op_int8` as a flaky test so it will run but failures won't be reflected in the Jenkins jobs. Once #10213 is addressed this PR can be reverted.

cc @hpanda-naut
