### PR TITLE
[skip ci] Fix onnx/models URLs

### DIFF
--- a/tests/python/driver/tvmc/conftest.py
+++ b/tests/python/driver/tvmc/conftest.py
@@ -145,7 +145,7 @@ def pytorch_mobilenetv2_quantized(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def onnx_resnet50():
-    base_url = "https://github.com/onnx/models/raw/master/vision/classification/resnet/model"
+    base_url = "https://github.com/onnx/models/raw/bd206494e8b6a27b25e5cf7199dbcdbfe9d05d1c/vision/classification/resnet/model"
     file_to_download = "resnet50-v2-7.onnx"
     model_file = download_testdata(
         "{}/{}".format(base_url, file_to_download), file_to_download, module=["tvmc"]
@@ -168,7 +168,7 @@ def paddle_resnet50(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def onnx_mnist():
-    base_url = "https://github.com/onnx/models/raw/master/vision/classification/mnist/model"
+    base_url = "https://github.com/onnx/models/raw/bd206494e8b6a27b25e5cf7199dbcdbfe9d05d1c/vision/classification/mnist/model"
     file_to_download = "mnist-1.onnx"
     model_file = download_testdata(
         "{}/{}".format(base_url, file_to_download), file_to_download, module=["tvmc"]


### PR DESCRIPTION
These are broken in CI: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/2500/pipeline/275

The upstream changed their default branch from `master` -> `main` which broke the links used in these tests. This pins to a specific commit (the latest one at the time of filing this PR).

