### PR TITLE
[TVMC] End to end benchmarking by default

### DIFF
--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -557,8 +557,12 @@ def run_module(
             module.run()
             times = []
         else:
-            # call the benchmarking function of the executor
-            times = module.benchmark(dev, number=number, repeat=repeat)
+            # Call the benchmarking function of the executor.
+            # We measure e2e data transfers in the runtime, and
+            # always measure from the CPU device to account for
+            # CPU to device memory transfer overheads (e.g. PCIE
+            # overheads if the device is a discrete GPU).
+            times = module.benchmark(tvm.cpu(), number=number, repeat=repeat, end_to_end=True)
 
         logger.debug("Collecting the output tensors.")
         num_outputs = module.get_num_outputs()

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -562,7 +562,7 @@ def run_module(
             # always measure from the CPU device to account for
             # CPU to device memory transfer overheads (e.g. PCIE
             # overheads if the device is a discrete GPU).
-            times = module.benchmark(tvm.cpu(), number=number, repeat=repeat, end_to_end=True)
+            times = module.benchmark(session.cpu(), number=number, repeat=repeat, end_to_end=True)
 
         logger.debug("Collecting the output tensors.")
         num_outputs = module.get_num_outputs()


### PR DESCRIPTION
[End to end benchmarking](https://github.com/apache/tvm/pull/8858) was added to the VM and graph executor in order to faithfully represent execution time by accounting for data transfer overheads. This can be particularly significant on discrete GPUs, where PCI-E transfers are important to account for in a typical model serving deployment.

This PR proposes to modify the default measurement done by TVMC to always benchmark end to end execution time from CPU local device context.
Another option is to expose in TVMC a flag that lets the user perform end to end benchmarking. I recommend however not benchmarking without data transfer overheads as it presents an overly optimistic outlook on TVM performance.
