### PR TITLE
[Arith] Simplify floordiv(x*8+7, 16) to floordiv(x, 2)

### DIFF
--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -31,7 +31,7 @@ class IntSetChecker:
             return "\ndata={}\ndmap={}\nres={}\nexpected={}".format(data, dmap, res, expected)
 
         def equal(x, y):
-            res = self.analyzer.canonical_simplify(x - y)
+            res = self.analyzer.simplify(x - y)
             return tvm.tir.analysis.expr_deep_equal(res, 0)
 
         assert equal(res.min_value, expected[0]), err_msg()
@@ -99,10 +99,14 @@ def test_mod():
     ck.verify(flm(x, 10), {x: tvm.arith.IntervalSet(3, 11)}, (0, 9))
     ck.verify(flm(x, 10), {x: tvm.arith.IntervalSet(1, 21)}, (0, 9))
 
-    floordiv = tvm.te.floordiv
+    fld = tvm.te.floordiv
     z = te.var("z")
     ck.analyzer.bind(x, tvm.ir.Range.from_min_extent(0, 3))
-    ck.verify(flm(y, 8), {y: tvm.arith.IntervalSet(z * 8 + x * 4, z * 8 + x * 4 + 3)}, (0, 7))
+    ck.verify(
+        flm(y, 8),
+        {y: tvm.arith.IntervalSet(z * 8 + x * 4, z * 8 + x * 4 + 3)},
+        (x * 4 - 8 * fld(x * 4, 8), x * 4 - 8 * fld(x * 4, 8) + 3),
+    )
     ck1 = IntSetChecker()
     ck1.analyzer.bind(x, tvm.ir.Range.from_min_extent(0, 2))
     ck1.verify(

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -462,6 +462,10 @@ def test_floordiv_index_simplify():
 
     ck.verify(fld(x * 2, 4), fld(x, 2))
     ck.verify(fld(x * 4, 2), x * 2)
+    ck.verify(fld(x * 8 + 7, 16), fld(x, 2))
+    ck.verify(fld(x * 8 + 39, 16), fld(x, 2) + 2)
+    ck.verify(fld(x * 8 - 1, 16), fld(x * 8 + -1, 16))
+    ck.verify(fld(x * 8 - 9, 16), fld(x, 2) + -1)
 
     ck.verify(fld(x * 4 + y, 2), x * 2 + fld(y, 2))
     ck.verify(fld(tvm.te.min(x * 6, y), 2), tvm.te.min(x * 3, fld(y, 2)))


### PR DESCRIPTION
Hi, the PR add a simplify rule to allow patterns like floordiv(x*8+7, 16) => floordiv(x, 2). 

We find the issue when using compute_at to `repeat` op:
```python
T_add = T.alloc_buffer([4], dtype="float32")
    for i0 in T.serial(4):
        with T.block("T_add"):
            ax0 = T.axis.spatial(4, i0)
            T_add[ax0] = x[ax0] + 1.0
    for i0_0, i0_1 in T.grid(8, 8):
        with T.block("T_repeat"):
            ax0 = T.axis.spatial(64, i0_0 * 8 + i0_1)
            T_repeat[ax0] = T_add[ax0 // 16]
```
 compute_at(`T_add` , `i0_0`) currently will result to a "dynamic" extent `floordiv(x*8 + 7, 16) - floordiv(x, 2) + 1`.




Also fix a typo of previous compute at testcase.
