### PR TITLE
[ci] Use sccache in builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,14 +45,14 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = "tlcpack/ci-lint:v0.68"
-ci_gpu = "tlcpack/ci-gpu:v0.81"
-ci_cpu = "tlcpack/ci-cpu:v0.81"
-ci_wasm = "tlcpack/ci-wasm:v0.71"
-ci_i386 = "tlcpack/ci-i386:v0.74"
-ci_qemu = "tlcpack/ci-qemu:v0.10"
-ci_arm = "tlcpack/ci-arm:v0.07"
-ci_hexagon = "tlcpack/ci-hexagon:v0.01"
+ci_lint = 'tlcpack/ci-lint:v0.68'
+ci_gpu = 'tlcpack/ci-gpu:v0.81'
+ci_cpu = 'tlcpack/ci-cpu:v0.81'
+ci_wasm = 'tlcpack/ci-wasm:v0.71'
+ci_i386 = 'tlcpack/ci-i386:v0.74'
+ci_qemu = 'tlcpack/ci-qemu:v0.10'
+ci_arm = 'tlcpack/ci-arm:v0.07'
+ci_hexagon = 'tlcpack/ci-hexagon:v0.01'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images
@@ -254,15 +254,22 @@ def python_unittest(image) {
 def fsim_test(image) {
   sh (
     script: "${docker_run} ${image} ./tests/scripts/task_python_vta_fsim.sh",
-    label: 'Run VTA tests in FSIM ',
+    label: 'Run VTA tests in FSIM',
   )
 }
 
 def cmake_build(image, path, make_flag) {
-  sh (
-    script: "${docker_run} ${image} ./tests/scripts/task_build.sh ${path} ${make_flag}",
-    label: 'Run cmake build',
-  )
+  // Note: This isn't really a secret, but its stored as a Jenkins credential
+  // so it can be easily configured
+  withCredentials([string(
+    credentialsId: 'tvm-sccache-bucket',
+    variable: 'SCCACHE_BUCKET',
+    )]) {
+    sh (
+      script: "${docker_run} ${image} ./tests/scripts/task_build.sh ${path} ${make_flag} $SCCACHE_BUCKET",
+      label: 'Run cmake build',
+    )
+  }
 }
 
 def cpp_unittest(image) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,6 +194,7 @@ stage('Sanity Check') {
   }
 }
 
+
 // Run make. First try to do an incremental make from a previous workspace in hope to
 // accelerate the compilation. If something is wrong, clean the workspace and then
 // build from scratch.
@@ -259,17 +260,10 @@ def fsim_test(image) {
 }
 
 def cmake_build(image, path, make_flag) {
-  // Note: This isn't really a secret, but its stored as a Jenkins credential
-  // so it can be easily configured
-  withCredentials([string(
-    credentialsId: 'tvm-sccache-bucket',
-    variable: 'SCCACHE_BUCKET',
-    )]) {
-    sh (
-      script: "${docker_run} ${image} ./tests/scripts/task_build.sh ${path} ${make_flag} $SCCACHE_BUCKET",
-      label: 'Run cmake build',
-    )
-  }
+  sh (
+    script: "${docker_run} ${image} ./tests/scripts/task_build.sh ${path} ${make_flag} tvm-sccache-prod",
+    label: 'Run cmake build',
+  )
 }
 
 def cpp_unittest(image) {

--- a/docker/dev_common.sh
+++ b/docker/dev_common.sh
@@ -45,7 +45,7 @@ function filter_jenkinsfile() {
 function lookup_image_spec() {
     img_line=$(cat "${GIT_TOPLEVEL}/Jenkinsfile" | filter_jenkinsfile | grep -E "^${1} = ")
     if [ -n "${img_line}" ]; then
-        img_spec=$(echo "${img_line}" | sed -E "s/${1} = \"([^\"]*)\"/\1/")
+        img_spec=$(echo "${img_line}" | sed -E "s/${1} = '([^\"]*)'/\1/")
         has_similar_docker_image=1
         docker inspect "${1}" &>/dev/null || has_similar_docker_image=0
         if [ ${has_similar_docker_image} -ne 0 ]; then

--- a/tests/scripts/task_build.sh
+++ b/tests/scripts/task_build.sh
@@ -39,7 +39,7 @@ fi
 
 # Send this out through a side channel, the bucket name is not actually secret
 # so it's OK to leak it in this way
-echo "$SCCACHE_BUCKET" | base64
+echo "sccache bucket: $SCCACHE_BUCKET"
 
 if [ "$HAS_SCCACHE" -eq "1" ]; then
     sccache --start-server || echo failed

--- a/tests/scripts/task_build.sh
+++ b/tests/scripts/task_build.sh
@@ -15,5 +15,43 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-export VTA_HW_PATH=`pwd`/3rdparty/vta-hw
-cd $1 && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make $2 && cd ..
+set -eux
+
+VTA_HW_PATH=$(pwd)/3rdparty/vta-hw
+export VTA_HW_PATH
+
+pushd "$1"
+
+# Set up sccache to use S3
+if [ -n "${3+x}" ] && which sccache; then
+    export SCCACHE_BUCKET=$3
+    HAS_SCCACHE=1
+else
+    export SCCACHE_BUCKET="no-bucket-configured"
+    HAS_SCCACHE=0
+fi
+
+if [ "$HAS_SCCACHE" -eq "1" ]; then
+    echo "Running with sccache enabled"
+    export CC=/opt/sccache/cc
+    export CXX=/opt/sccache/c++
+fi
+
+# Send this out through a side channel, the bucket name is not actually secret
+# so it's OK to leak it in this way
+echo "$SCCACHE_BUCKET" | base64
+
+if [ "$HAS_SCCACHE" -eq "1" ]; then
+    sccache --start-server || echo failed
+    echo "===== sccache stats ====="
+    sccache --show-stats
+fi
+
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake --build . -- VERBOSE=1 "$2"
+
+if [ "$HAS_SCCACHE" -eq "1" ]; then
+    echo "===== sccache stats ====="
+    sccache --show-stats
+fi
+popd

--- a/tests/scripts/task_config_build_arm.sh
+++ b/tests/scripts/task_config_build_arm.sh
@@ -29,7 +29,6 @@ echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-8\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -33,7 +33,6 @@ echo set\(USE_LLVM llvm-config-11\) >> config.cmake
 echo set\(USE_NNPACK ON\) >> config.cmake
 echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake

--- a/tests/scripts/task_config_build_gpu.sh
+++ b/tests/scripts/task_config_build_gpu.sh
@@ -41,7 +41,6 @@ echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_BLAS openblas\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_TENSORRT_CODEGEN ON\) >> config.cmake
 echo set\(USE_LIBBACKTRACE AUTO\) >> config.cmake

--- a/tests/scripts/task_config_build_i386.sh
+++ b/tests/scripts/task_config_build_i386.sh
@@ -29,7 +29,6 @@ echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-4.0\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake

--- a/tests/scripts/task_config_build_qemu.sh
+++ b/tests/scripts/task_config_build_qemu.sh
@@ -28,7 +28,6 @@ echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_CMSISNN ON\) >> config.cmake
 echo set\(USE_ETHOSU ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-10\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake

--- a/tests/scripts/task_config_build_wasm.sh
+++ b/tests/scripts/task_config_build_wasm.sh
@@ -29,7 +29,6 @@ echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_LLVM llvm-config-11\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake

--- a/tests/scripts/task_show_node_info.sh
+++ b/tests/scripts/task_show_node_info.sh
@@ -19,11 +19,11 @@
 set -x
 
 echo "===== JENKINS INFO ====="
-echo "$NODE_NAME"
-echo "$EXECUTOR_NUMBER"
-echo "$WORKSPACE"
-echo "$BUILD_NUMBER"
-echo "$WORKSPACE"
+echo "NODE_NAME=$NODE_NAME"
+echo "EXECUTOR_NUMBER=$EXECUTOR_NUMBER"
+echo "WORKSPACE=$WORKSPACE"
+echo "BUILD_NUMBER=$BUILD_NUMBER"
+echo "WORKSPACE=$WORKSPACE"
 
 echo "===== EC2 INFO ====="
 function ec2_metadata() {


### PR DESCRIPTION
This sets the builds for each platform to use [sccache](https://github.com/mozilla/sccache) as a build cache. For a fully cached rebuild, this reduces the time (in testing) from 30+ minutes to 1-2 minutes (e.g. if the build isn't touching any C++ files). We can run this for a while and if it is successful then remove the extra code around rebuilding using the existing on-instance build directory.

The sccache server is backed by an S3 bucket configured in https://github.com/tlc-pack/ci-terraform/pull/3.

Example run: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10353/5/pipeline/57
