### PR TITLE
Gitignore work items in jvm and android_rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ DerivedData/
 *.class
 jvm/*/target/
 jvm/*/*/target/
+jvm/native/*/generated
+jvm/native/src/main/native/org_apache_tvm_native_c_api.h
 *.worksheet
 *.idea
 *.iml

--- a/apps/android_rpc/.gitignore
+++ b/apps/android_rpc/.gitignore
@@ -7,3 +7,9 @@
 /build
 /captures
 .externalNativeBuild
+
+/app/src/main/jni/jni_helper_func.h
+/app/src/main/jni/org_apache_tvm_native_c_api.cc
+/app/src/main/jni/org_apache_tvm_native_c_api.h
+/app/src/main/obj/
+dev_tools/tvmrpc.keystore


### PR DESCRIPTION
When I want to use TVM with RPC Server/Tracker I need to create tvm4j and have working android_rpc app. Generated items should be in gitignore.