### PR TITLE
fix RPC waiting for device

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -806,17 +806,22 @@ def check_remote(target, device_key, host=None, port=None, priority=100, timeout
     """
 
     def _check():
+        logger.debug("waiting for device...")
         remote = request_remote(device_key, host, port, priority)
         dev = remote.device(str(target))
         while not dev.exist:  # wait until we get an available device
             pass
+        logger.debug("device available")
 
     t = threading.Thread(
         target=_check,
     )
     t.start()
     t.join(timeout)
-    return not t.is_alive()
+
+    remote = request_remote(device_key, host, port, priority)
+    dev = remote.device(str(target))
+    return dev.exist
 
 
 def set_cuda_target_arch(arch):


### PR DESCRIPTION
Hello,
This PR solves issue 10240. Previous implementation for checking device was little misleading/problematic. It was checking device in almost infinite loop (`while not dev.exist`), but the thread which was doing this was set with timeout. Check status was equivalent to thread state, imho it's incorrect and misleading.

So I have changed to more proper way, but with little duplicated code:
1. Still we have almost infinite loop (`while not dev.exist`)
2. After loop finish we do not check thread status, but again check device
3. I have added extra debug logging - leave or remove it - decision for owners of the project :)