### PR TITLE
[ci] Move pip dependencies to docker images, add ninja / shellcheck

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -30,7 +30,7 @@ RUN bash /install/ubuntu1804_install_python.sh
 # Globally disable pip cache
 RUN pip config set global.no-cache-dir false
 
-RUN apt-get update && apt-get install -y doxygen graphviz curl
+RUN apt-get update && apt-get install -y doxygen graphviz curl shellcheck
 
 RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1 flake8==3.9.2
 

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -24,7 +24,7 @@ set -o pipefail
 apt-get update && apt-get install -y --no-install-recommends \
         git make google-mock libgtest-dev cmake wget unzip libtinfo-dev libz-dev \
         libcurl4-openssl-dev libssl-dev libopenblas-dev g++ sudo \
-        apt-transport-https graphviz pkg-config curl
+        apt-transport-https graphviz pkg-config curl ninja-build parallel
 
 if [[ -d /usr/src/googletest ]]; then
   # Single package source (Ubuntu 18.04)

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -32,10 +32,12 @@ pip3 install \
     packaging \
     Pillow \
     pytest \
+    tlcpack-sphinx-addon==0.2.1 \
     pytest-profiling \
     pytest-xdist \
     requests \
     scipy \
     synr==0.6.0 \
+    junitparser==2.4.2 \
     six \
     tornado


### PR DESCRIPTION
Following on from #10246, this moves the `pip install`-at-runtime deps to the docker image install so they are baked in. This adds some extra dependencies to support #10425 and make it so we can easily run things in parallel in CI scripts via GNU parallel and lint our bash scripts.