### PR TITLE
[Hexagon] Don't use cmake glob for auto-generated source files

### DIFF
--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -209,6 +209,10 @@ if(USE_HEXAGON_RPC)
     file_glob_append(RUNTIME_HEXAGON_SRCS
       "${TVMRT_SOURCE_DIR}/hexagon/host/*.cc"
       "${TVMRT_SOURCE_DIR}/hexagon/rpc/android/*.cc"
+    )
+    # Add this file separately, because it's auto-generated, and glob won't
+    # find it during cmake-time.
+    list(APPEND RUNTIME_HEXAGON_SRCS
       "${TVMRT_SOURCE_DIR}/hexagon/rpc/hexagon_rpc_stub.c"
     )
     list(APPEND TVM_RUNTIME_LINKER_LIBS cdsprpc)


### PR DESCRIPTION
Glob treats inputs as patterns: if the file with a given name does not exist (is to be generated later), it won't be added to the output.
