### PR TITLE
[BUGFIX] Define kTargetPoolReadWriteAccess globally

### DIFF
--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -104,10 +104,10 @@ struct PoolInfoNode : public Object {
 };
 
 /*!
-* \brief The string parameter to indicate read and write access to a pool
-* This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
-* python/tvm/ir/memory_pools.py
-*/
+ * \brief The string parameter to indicate read and write access to a pool
+ * This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
+ * python/tvm/ir/memory_pools.py
+ */
 
 static constexpr const char* kTargetPoolReadWriteAccess = "rw";
 

--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -108,26 +108,29 @@ struct PoolInfoNode : public Object {
  * This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
  * python/tvm/ir/memory_pools.py
  */
-
 static constexpr const char* kTargetPoolReadWriteAccess = "rw";
+
+/*!
+ * \brief The string parameter to indicate read only access to a pool
+ * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in
+ * python/tvm/ir/memory_pools.py
+ */
+static constexpr const char* kTargetPoolReadOnlyAccess = "ro";
+
+/*! \brief The PoolSize is unrestricted for the memory planner */
+static const int kUnrestrictedPoolSizeHint = -1;
+
+/*! \brief The clock frequency is not known */
+static const int kUnknownClockFrequency = -1;
+
+/*! \brief The read bandwidth is not known */
+static const int kUnknownReadBandwidth = -1;
+
+/*! \brief The write bandwidth is not known */
+static const int kUnknownWriteBandwidth = -1;
 
 class PoolInfo : public ObjectRef {
  public:
-  /*!
-   * \brief The string parameter to indicate read only access to a pool
-   * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in
-   * python/tvm/ir/memory_pools.py
-   */
-  static constexpr const char* kTargetPoolReadOnlyAccess = "ro";
-  /*! \brief The PoolSize is unrestricted for the memory planner */
-  static const int kUnrestrictedPoolSizeHint = -1;
-  /*! \brief The clock frequency is not known */
-  static const int kUnknownClockFrequency = -1;
-  /*! \brief The read bandwidth is not known */
-  static const int kUnknownReadBandwidth = -1;
-  /*! \brief The write bandwidth is not known */
-  static const int kUnknownWriteBandwidth = -1;
-
   TVM_DLL PoolInfo(String pool_name, Map<Target, String> target_access,
                    Integer size_hint_bytes = kUnrestrictedPoolSizeHint,
                    Integer clock_frequency_hz = kUnknownClockFrequency,

--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -103,14 +103,17 @@ struct PoolInfoNode : public Object {
   TVM_DECLARE_FINAL_OBJECT_INFO(PoolInfoNode, Object);
 };
 
+/*!
+* \brief The string parameter to indicate read and write access to a pool
+* This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
+* python/tvm/ir/memory_pools.py
+*/
+
+static constexpr const char* kTargetPoolReadWriteAccess = "rw";
+
 class PoolInfo : public ObjectRef {
  public:
-  /*!
-   * \brief The string parameter to indicate read and write access to a pool
-   * This needs to be kept in sync with PoolInfo.READ_WRITE_ACCESS in
-   * python/tvm/ir/memory_pools.py
-   */
-  static constexpr const char* kTargetPoolReadWriteAccess = "rw";
+
   /*!
    * \brief The string parameter to indicate read only access to a pool
    * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in

--- a/include/tvm/ir/memory_pools.h
+++ b/include/tvm/ir/memory_pools.h
@@ -113,7 +113,6 @@ static constexpr const char* kTargetPoolReadWriteAccess = "rw";
 
 class PoolInfo : public ObjectRef {
  public:
-
   /*!
    * \brief The string parameter to indicate read only access to a pool
    * This needs to be kept in sync with PoolInfo.READ_ONLY_ACCESS in

--- a/src/tir/usmp/algo/greedy.cc
+++ b/src/tir/usmp/algo/greedy.cc
@@ -61,7 +61,7 @@ size_t GreedyBase::round_up_to_byte_alignment(const size_t& non_aligned_byte_off
  */
 bool GreedyBase::IsValidPlacement(const PoolInfo& candidate_pool, const size_t& next_offset,
                                   const size_t& size_bytes) {
-  if (candidate_pool->size_hint_bytes == PoolInfo::kUnrestrictedPoolSizeHint) {
+  if (candidate_pool->size_hint_bytes == kUnrestrictedPoolSizeHint) {
     // this means pool is not bounded
     return true;
   }

--- a/src/tir/usmp/transform/assign_pool_info.cc
+++ b/src/tir/usmp/transform/assign_pool_info.cc
@@ -48,11 +48,11 @@ class PoolInfoAssigner : public StmtExprMutator {
     ICHECK(target_host) << "main function does not have a target attr";
     WorkspaceMemoryPools workspace_pools =
         module->GetAttr<WorkspaceMemoryPools>(tvm::attr::kWorkspaceMemoryPools)
-            .value_or(WorkspaceMemoryPools({PoolInfo(
-                "global_workspace", {{target_host.value(), kTargetPoolReadWriteAccess}},
-                PoolInfo::kUnrestrictedPoolSizeHint, PoolInfo::kUnknownClockFrequency,
-                PoolInfo::kUnknownReadBandwidth, PoolInfo::kUnknownWriteBandwidth, 0, 0,
-                {{target_host.value(), 1}}, Bool(true))}));
+            .value_or(WorkspaceMemoryPools(
+                {PoolInfo("global_workspace", {{target_host.value(), kTargetPoolReadWriteAccess}},
+                          PoolInfo::kUnrestrictedPoolSizeHint, PoolInfo::kUnknownClockFrequency,
+                          PoolInfo::kUnknownReadBandwidth, PoolInfo::kUnknownWriteBandwidth, 0, 0,
+                          {{target_host.value(), 1}}, Bool(true))}));
     Array<PoolInfo> pool_infos = workspace_pools->pools;
     for (const PoolInfo& pool_info : pool_infos) {
       for (const auto& kv : pool_info->target_access) {

--- a/src/tir/usmp/transform/assign_pool_info.cc
+++ b/src/tir/usmp/transform/assign_pool_info.cc
@@ -50,9 +50,8 @@ class PoolInfoAssigner : public StmtExprMutator {
         module->GetAttr<WorkspaceMemoryPools>(tvm::attr::kWorkspaceMemoryPools)
             .value_or(WorkspaceMemoryPools(
                 {PoolInfo("global_workspace", {{target_host.value(), kTargetPoolReadWriteAccess}},
-                          PoolInfo::kUnrestrictedPoolSizeHint, PoolInfo::kUnknownClockFrequency,
-                          PoolInfo::kUnknownReadBandwidth, PoolInfo::kUnknownWriteBandwidth, 0, 0,
-                          {{target_host.value(), 1}}, Bool(true))}));
+                          kUnrestrictedPoolSizeHint, kUnknownClockFrequency, kUnknownReadBandwidth,
+                          kUnknownWriteBandwidth, 0, 0, {{target_host.value(), 1}}, Bool(true))}));
     Array<PoolInfo> pool_infos = workspace_pools->pools;
     for (const PoolInfo& pool_info : pool_infos) {
       for (const auto& kv : pool_info->target_access) {

--- a/src/tir/usmp/transform/assign_pool_info.cc
+++ b/src/tir/usmp/transform/assign_pool_info.cc
@@ -49,7 +49,7 @@ class PoolInfoAssigner : public StmtExprMutator {
     WorkspaceMemoryPools workspace_pools =
         module->GetAttr<WorkspaceMemoryPools>(tvm::attr::kWorkspaceMemoryPools)
             .value_or(WorkspaceMemoryPools({PoolInfo(
-                "global_workspace", {{target_host.value(), PoolInfo::kTargetPoolReadWriteAccess}},
+                "global_workspace", {{target_host.value(), kTargetPoolReadWriteAccess}},
                 PoolInfo::kUnrestrictedPoolSizeHint, PoolInfo::kUnknownClockFrequency,
                 PoolInfo::kUnknownReadBandwidth, PoolInfo::kUnknownWriteBandwidth, 0, 0,
                 {{target_host.value(), 1}}, Bool(true))}));


### PR DESCRIPTION
kTargetPoolReadWriteAccess was defined inside the PoolInfo class, leading to a compile time error for me. Making it global fixes the issue, and is also is consistent with how other attribute strings are defined in TVM. 