### PR TITLE
refactored GraphProto.from_onnx into smaller functions

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4835,7 +4835,7 @@ class GraphProto:
         self._check_user_inputs_in_outermost_graph_scope()
         self._check_for_unsupported_ops(graph)
         self._construct_nodes(graph)
-        
+
         # now return the outputs
         outputs = [self._nodes[self._parse_value_proto(i)] for i in graph.output]
         outputs = outputs[0] if len(outputs) == 1 else _expr.Tuple(outputs)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4878,7 +4878,6 @@ class GraphProto:
             if i_name in self._params:
                 # i is a param instead of input
                 self._num_param += 1
-                self._params[i_name] = self._params.pop(i_name)
                 self._nodes[i_name] = new_var(
                     i_name, shape=self._params[i_name].shape, dtype=self._params[i_name].dtype
                 )

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=invalid-name, import-self, len-as-condition, unused-argument, too-many-lines
-# pylint: disable=import-outside-toplevel
+# pylint: disable=import-outside-toplevel 
 """ONNX: Open Neural Network Exchange frontend for Relay."""
 import copy
 import warnings


### PR DESCRIPTION
I split GraphProto.from_onnx into smaller functions.
I find it useful to see faster what is going on.
Are such refactorings wanted in the TVM codebase?
I am aware that they require careful review without adding any functionality so a comment on that in general would be helpful.
