### PR TITLE
[Bugfix] Add one extra space to improve diagnostic messages

### DIFF
--- a/src/relay/op/type_relations.cc
+++ b/src/relay/op/type_relations.cc
@@ -107,7 +107,7 @@ bool BroadcastRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
       if (t0->dtype != t1->dtype) {
         reporter->GetDiagCtx().Emit(Diagnostic::Error(t0->span)
                                     << "data types " << t0->dtype << " and " << t1->dtype
-                                    << "do not match in BroadcastRel");
+                                    << " do not match in BroadcastRel");
       }
       reporter->Assign(
           types[2], ConcreteBroadcast(GetRef<TensorType>(t0), GetRef<TensorType>(t1), t0->dtype));
@@ -127,7 +127,7 @@ bool BroadcastCompRel(const Array<Type>& types, int num_inputs, const Attrs& att
       if (t0->dtype != t1->dtype) {
         reporter->GetDiagCtx().Emit(Diagnostic::Error(t0->span)
                                     << "data types " << t0->dtype << " and " << t1->dtype
-                                    << "do not match in BroadcastCompRel");
+                                    << " do not match in BroadcastCompRel");
       }
       reporter->Assign(types[2], ConcreteBroadcast(GetRef<TensorType>(t0), GetRef<TensorType>(t1),
                                                    DataType::Bool()));


### PR DESCRIPTION
I hit the diagnostic message like 
>data types bfloat16 and float32do not match in BroadcastRel

so proposed this patch to fix this issue by adding one extra space. 
After applying the patch, the message should be readable.

>  data types bfloat16 and float32 do not match in BroadcastRel 

>Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
