### PR TITLE
[ETHOSN] Stricter data type conversion checks

### DIFF
--- a/src/relay/backend/contrib/ethosn/codegen.cc
+++ b/src/relay/backend/contrib/ethosn/codegen.cc
@@ -718,6 +718,7 @@ TVM_REGISTER_GLOBAL("relay.ethos-n.support.reshape")
     .set_body([](tvm::TVMArgs args, tvm::TVMRetValue* rv) {
       Call call = args[0];
       ReshapeParams params;
+      EthosnAPI::DefaultInputTensor(call);
       auto err = EthosnAPI::Reshape(call, &params);
       err += EthosnCompiler::SupportedSetup();
       char reason[kReasonMaxLength];
@@ -784,6 +785,7 @@ TVM_REGISTER_GLOBAL("relay.ethos-n.support.split")
     .set_body([](tvm::TVMArgs args, tvm::TVMRetValue* rv) {
       Call call = args[0];
       SplitParams params;
+      EthosnAPI::DefaultInputTensor(call);
       auto err = EthosnAPI::Split(call, &params);
       err += EthosnCompiler::SupportedSetup();
       char reason[kReasonMaxLength];

--- a/src/relay/backend/contrib/ethosn/ethosn_api.h
+++ b/src/relay/backend/contrib/ethosn/ethosn_api.h
@@ -179,6 +179,9 @@ class EthosnError {
  */
 class EthosnAPI {
  public:
+  /*! \brief Create a default input tensor */
+  static sl::TensorInfo DefaultInputTensor(const Expr& expr);
+
   /*! \brief Extract the Support Library convolution params from an ethos-n.qnn_conv2d func */
   static EthosnError QnnConv2d(const Expr& expr, ConvolutionParams* params);
   /*! \brief Extract the Support Library dense params from an ethos-n.qnn_fc func */
@@ -235,8 +238,8 @@ class EthosnAPI {
   // Convert an array of IntImmNodes into ValueT
   // IndexT type of Array indexing variable
   // ValueT type of resulting value
-  template <typename IndexT, typename ValueT>
-  static EthosnError AsArray(const Array<IndexT>& arr, std::array<ValueT, 4>* v);
+  template <typename IndexT, typename ValueT, size_t N>
+  static EthosnError AsArray(const Array<IndexT>& arr, std::array<ValueT, N>* v);
 
   // Get a T from a constant represented by a NDArray.
   template <typename T>

--- a/tests/python/contrib/test_ethosn/test_depth_to_space.py
+++ b/tests/python/contrib/test_ethosn/test_depth_to_space.py
@@ -69,7 +69,7 @@ def test_depth_to_space_failure():
             "dtype='int16', dtype must be either uint8, int8 or int32;",
         ),
         ((1, 16, 16, 16), 4, "uint8", "NHWC", "Only block size of 2 is supported"),
-        ((1, 16, 16, 16), 2, "uint8", "NCHW", "layout=NCHW, layout must = NHWC"),
+        ((1, 16, 16, 16), 2, "uint8", "NCHW", "Input layer must be NHWC or NHWCB"),
     ]
 
     for shape, block, dtype, layout, err_msg in trials:

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -228,7 +228,8 @@ def test_ssd_mobilenet_v1():
     # on hardware that isn't available in CI.
     _compile_hash = {"5ee8ed6af9a7f31fc14957b51a8e7423", "e6a91ccc47ba4c6b4614fcd676bd726f"}
     if tei.get_ethosn_api_version() == 2111:
-        _compile_hash = {"afb68ca8f452d1f4a674b457b5e30f59", "a37f900601b9493bd142e8aed16205e5"}
+        # TODO(Leo-arm): review split operator
+        _compile_hash = {"a37f900601b9493bd142e8aed16205e5", "afb68ca8f452d1f4a674b457b5e30f59"}
     if tei.get_ethosn_api_version() == 2102:
         _compile_hash = {"7795b6c67178da9d1f9b98063bad75b1", "10826406ae724e52f360a06c35ced09d"}
         if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":

--- a/tests/python/contrib/test_ethosn/test_split.py
+++ b/tests/python/contrib/test_ethosn/test_split.py
@@ -37,8 +37,9 @@ def test_split(dtype):
     trials = [
         ((1, 16, 16, 32), (2, 7, 10), 2),
         ((1, 12, 8, 16), 3, 1),
-        ((1, 66), 11, 1),
     ]
+    if tei.get_ethosn_api_version() < 2111:
+        trials.append(((1, 66), 11, 1))
 
     np.random.seed(0)
     for shape, splits, axis in trials:


### PR DESCRIPTION
The 21.11 update for the Ethos(TM)-N driver is slightly more strict in
accepting various operator attributes.
