### PR TITLE
[Bugfix] Added definition for constexpr char* PoolInfo variables.

### DIFF
--- a/src/ir/memory_pools.cc
+++ b/src/ir/memory_pools.cc
@@ -27,6 +27,16 @@
 
 namespace tvm {
 
+// In C++14, even though these are declared as static constexpr and
+// have a value defined in the class definition, they must still have
+// a declaration in a compilation unit.  This defect is fixed in
+// C++17, but since TVM currently targets C++14, these declarations
+// are required.
+//
+// See https://stackoverflow.com/a/28846608 for more details.
+constexpr const char* PoolInfo::kTargetPoolReadOnlyAccess;
+constexpr const char* PoolInfo::kTargetPoolReadWriteAccess;
+
 PoolInfo::PoolInfo(String pool_name, Map<Target, String> target_access, Integer size_hint_bytes,
                    Integer clock_frequency_hz, Integer read_bandwidth_bytes_per_cycle,
                    Integer write_bandwidth_bytes_per_cycle, Integer read_latency_cycles,


### PR DESCRIPTION
These are required for compatibility with C++14, and resolve a link-time error that was observed in debug builds on `g++-10`.  For release builds, the external linkage was optimized out, so the link-time error was avoided.