### PR TITLE
[BUGFIX] fix text printer when TVM_LOG_DEBUG is on

### DIFF
--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -515,11 +515,7 @@ Doc RelayTextPrinter::VisitExpr_(const CallNode* op) {
   for (const Expr& arg : op->args) {
     args.push_back(Print(arg));
   }
-#if TVM_LOG_DEBUG
-  for (const Type& type_arg : op->type_args) {
-    args.push_back(Print(type_arg));
-  }
-#endif
+
   for (const Doc& d : PrintCallAttrs(op->attrs, op->op)) {
     args.push_back(d);
   }


### PR DESCRIPTION
Remove extra printing of type args when TVM_LOG_DEBUG is on so that the text printer works when TVM_LOG_DEBUG is on