### PR TITLE
Add -i option to fix ASF headers to lint scripts.

### DIFF
--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -37,6 +37,9 @@ function run_lint_step() {
             ;;
         asf)
             cmd=( tests/lint/check_asf_header.sh --local )
+            if [ $inplace_fix -eq 1 ]; then
+                cmd=( "${cmd[@]}" --fix )
+            fi
             ;;
         clang_format)
             if [ $inplace_fix -eq 0 ]; then

--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -80,6 +80,9 @@ function run_lint_step() {
             echo "error: don't know how to run lint step: $1" >&2
             echo "usage: ${SCRIPT_NAME} [-i] <lint_step>" >&2
             echo >&2
+            echo "options:" >&2
+            echo " -i    Fix lint errors in-place where possible (modifies non-compliant files)" >&2
+            echo >&2
             echo "available lint_step: ${DEFAULT_STEPS[@]}" >&2
             exit 2
             ;;

--- a/tests/lint/check_asf_header.sh
+++ b/tests/lint/check_asf_header.sh
@@ -76,6 +76,7 @@ else
         echo "- Create file_list.txt in your text editor"
         echo "- Copy paste the above content in file-list into file_list.txt"
         echo "- python3 tests/lint/add_asf_header.py file_list.txt"
+        echo "When running via docker/lint.sh, add -i to automatically fix these problems."
     fi
     exit 1
 fi

--- a/tests/lint/check_asf_header.sh
+++ b/tests/lint/check_asf_header.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
+set -euo pipefail
 
 rat_tempdir="$(mktemp -d)"
 
@@ -27,10 +27,23 @@ trap cleanup EXIT
 
 rat_output="${rat_tempdir}/$$.apache-rat.txt"
 
+fix=0
 filter_untracked=0
-if [ "$1" == "--local" ]; then
-    filter_untracked=1
-fi
+while [ "x${1-}" != "x" ]; do
+    case "$1" in
+        --local)
+            filter_untracked=1
+            ;;
+        --fix)
+            fix=1
+            ;;
+        *)
+            echo "Unrecognized option: $1"
+            exit 2
+            ;;
+    esac
+    shift
+done
 
 java -jar /bin/apache-rat.jar -E tests/lint/rat-excludes  -d . | (grep -E "^== File" >"${rat_output}" || true)
 
@@ -44,14 +57,25 @@ if [ ${filter_untracked} -eq 1 ]; then
     rat_output="${processed_rat_output}"
 fi
 
-if grep --quiet -E "File" "${rat_output}"; then
-    echo "Need to add ASF header to the following files."
+grep --quiet -E "File" "${rat_output}" && success=1 || success=0
+
+if [ $success -eq 0 ]; then
+    echo "No files violate ASF header check"
+else
+    if [ $fix -eq 1 ]; then
+        python3 tests/lint/add_asf_header.py "${rat_output}"
+        echo "Ran add_asf_header.py to fix the following files:"
+    else
+        echo "Need to add ASF header to the following files."
+    fi
     echo "----------------File List----------------"
     cat "${rat_output}"
     echo "-----------------------------------------"
-    echo "Use the following steps to add the headers:"
-    echo "- Create file_list.txt in your text editor"
-    echo "- Copy paste the above content in file-list into file_list.txt"
-    echo "- python3 tests/lint/add_asf_header.py file_list.txt"
+    if [ $fix -eq 0 ]; then
+        echo "To fix, run check_asf_header.sh --fix, or use the following manual steps:"
+        echo "- Create file_list.txt in your text editor"
+        echo "- Copy paste the above content in file-list into file_list.txt"
+        echo "- python3 tests/lint/add_asf_header.py file_list.txt"
+    fi
     exit 1
 fi


### PR DESCRIPTION
This PR makes it possible to fix ASF headers automatically by running `docker/lint.sh -i asf`.

cc @driazati 