### PR TITLE
[microNPU] Fix stride bug in strided slice legalization

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/legalize.py
+++ b/python/tvm/relay/backend/contrib/ethosu/legalize.py
@@ -986,12 +986,19 @@ class StridedSliceRewriter(DFPatternCallback):
     ) -> tvm.relay.Expr:
 
         slice_input = post.args[0]
+
+        # TODO(lhutton1) For an unknown reason compilation will fail for strides of 4
+        # dimensions, so we cannot use params.strides as this will sometimes give
+        # strides as [1, 1, 1, 1]. Since we only support strides of 1, hardcoding this
+        # value for now.
+        strides = [1]
+
         params = ethosu_patterns.StridedSliceParams(post.op.body)
         strided_slice = relay.op.strided_slice(
             slice_input,
             params.begin,
             params.end,
-            strides=params.strides,
+            strides=strides,
             axes=params.axes,
             slice_mode=params.slice_mode,
         )

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -835,6 +835,19 @@ def test_tflite_slice(accel_type, ifm_shape, begin, size):
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
+@pytest.mark.parametrize(
+    "ifm_shape, begin, end",
+    [([1, 1, 5, 8], [0, 0, 0, 0], [1, 1, 2, 3]), ([1, 3, 3], [0, 1, 2], [1, 2, 3])],
+)
+def test_tflite_strided_slice(accel_type, ifm_shape, begin, end):
+    @tf.function
+    def strided_slice_func(x):
+        return tf.strided_slice(x, begin, end)
+
+    _compare_tvm_with_tflite(strided_slice_func, [ifm_shape], accel_type)
+
+
+@pytest.mark.parametrize("accel_type", ACCEL_TYPES)
 @pytest.mark.parametrize("operator_type", ["ABS"])
 @pytest.mark.parametrize(
     "ifm_shape",


### PR DESCRIPTION
TFLite slice is legalized to a strided slice operation with `strides=[1]`, but a similar TFLite strided slice operation is legalized with `strides=[1, 1, 1, 1]` which fails during compilation. Since we only support strided slice with no stride, hard-coding this value to `[1]` during legalization.

cc @ekalda @manupa-arm @dchauhan-arm @jacobbohlin
