### PR TITLE
Allow Ctrl+C during docker/lint.sh

### DIFF
--- a/docker/dev_common.sh
+++ b/docker/dev_common.sh
@@ -56,6 +56,11 @@ function lookup_image_spec() {
 }
 
 function run_docker() {
+    docker_bash_args=( )
+    while [ "x${1:0:1}" == "x-" ]; do
+        docker_bash_args=( "${docker_bash_args[@]}" "$1" )
+        shift
+    done
     image_name="$1"  # Name of the Jenkinsfile var to find
     shift
 
@@ -65,5 +70,6 @@ function run_docker() {
         exit 2
     fi
 
-    "${GIT_TOPLEVEL}/docker/bash.sh" "${image_spec}" "$@"
+    docker_bash_args=( "${docker_bash_args[@]}" "${image_spec}" "$@" )
+    "${GIT_TOPLEVEL}/docker/bash.sh" "${docker_bash_args[@]}"
 }

--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -84,7 +84,7 @@ function run_lint_step() {
     shift
 
     if [ $validate_only -eq 0 ]; then
-        run_docker "ci_lint" "${cmd[@]}"
+        run_docker -it "ci_lint" "${cmd[@]}"
     fi
 }
 


### PR DESCRIPTION
This allows you to bail out of linting halfway through, which makes the script more friendly to developers. This PR assumes docker/lint.sh used interactively.

cc @driazati