### PR TITLE
Run cpplint in quiet mode

### DIFF
--- a/tests/lint/cpplint.sh
+++ b/tests/lint/cpplint.sh
@@ -18,8 +18,9 @@
 
 set -e
 
-python3 3rdparty/dmlc-core/scripts/lint.py vta cpp vta/include vta/src
-python3 3rdparty/dmlc-core/scripts/lint.py tvm cpp \
+echo "Running 2 cpplints (VTA and TVM)..."
+python3 3rdparty/dmlc-core/scripts/lint.py --quiet vta cpp vta/include vta/src
+python3 3rdparty/dmlc-core/scripts/lint.py --quiet tvm cpp \
 	include src \
 	examples/extension/src examples/graph_executor/src \
 	tests/cpp tests/crt \


### PR DESCRIPTION
Removes lots of
```
Done processing ...
```

spam from cpplint logs.

cc @driazati 