### PR TITLE
[VirtualMachine] new method allowing to set one input tensor by its index or name

### DIFF
--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -219,6 +219,13 @@ class Executable : public ModuleNode {
   void SetLib(const runtime::Module& lib);
 
   /*!
+   * \brief Get VMFunction.
+   * \param func_name The function's name.
+   * \return VMFunction.
+   */
+  const VMFunction& GetVMFunctionWithName(const std::string& func_name) const;
+
+  /*!
    * \brief Get the arity of the VMFunction.
    * \param func Function name.
    * \return The number of parameters.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -271,6 +271,15 @@ class VirtualMachine : public runtime::ModuleNode {
   void SetInput(std::string name, TVMArgs args, int offset);
 
   /*!
+   * \brief Set input tensor with index to a function.
+   * \param name The function name
+   * \param args args[1:] are two arguments (index, tensor) to the
+   * function. If the tensor is not of the correct device for the function,
+   * they will be copied to the device.
+   */
+  void SetInputWithIndex(std::string name, TVMArgs args);
+
+  /*!
    * \brief Internal hook for profiling the start of an op.
    *
    * This hook is only called on certain ops that are likely to take a

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -307,7 +307,7 @@ class VirtualMachine : public runtime::ModuleNode {
    */
   int64_t getInputIndexFromName(const std::string& input_name, const std::string& func_name) const;
   /*!
-   * \brief Check executable exists and function name is in global map, get VM function.
+   * \brief Check executable exists and get VM function from it.
    * \param func_name The function's name.
    * \return VM function.
    */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -313,6 +313,13 @@ class VirtualMachine : public runtime::ModuleNode {
    */
   const VMFunction& checkAndGetVMFunction(const std::string& func_name) const;
   /*!
+   * \brief Creats inputs_ field, if it exists check its size.
+   * \param func_name The function's name.
+   * \param size inputs_ field size.
+   * \return VM function.
+   */
+  void createInputsOrCheckSize(const std::string& func_name, size_t size);
+  /*!
    * \brief Set one input tensor with given index to set of input tensors if need copy to given
    * device. \param tensors the input tensors set (destination) \param tensor some tensor (not
    * neccessary DLTensor). \param index The input tensor index. \param dev device to copy if need.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -94,8 +94,7 @@ struct VMFunction {
         instructions(std::move(instructions)),
         register_file_size(register_file_size),
         param_device_indexes(std::move(param_device_indexes)) {
-    ICHECK_EQ(params.size(), param_device_indexes.size())
-        << "The number of provided parameters doesn't match the number of assigned devices";
+    ICHECK_EQ(params.size(), param_device_indexes.size());
   }
 
   VMFunction() = default;
@@ -275,12 +274,12 @@ class VirtualMachine : public runtime::ModuleNode {
 
   /*!
    * \brief Set one input tensor with index or name to a function.
-   * \param name The function name
-   * \param args args[1:] are two arguments (index or name, tensor) to the
-   * function. If the tensor is not of the correct device for the function,
+   * \param name The function name.
+   * \param tag index or name of the input tensor .
+   * \param tensor the input tensor. If the tensor is not of the correct device for the function,
    * they will be copied to the device.
    */
-  void SetOneInputTensor(std::string name, TVMArgs args);
+  void SetOneInput(std::string name, const TVMArgValue& tag, const TVMArgValue& tensor);
 
   /*!
    * \brief Internal hook for profiling the start of an op.
@@ -305,7 +304,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param input_name The input tensor name.
    * \return The input tensor index.
    */
-  int64_t getInputIndexFromVMFunction(const std::string& func_name,
+  int64_t GetInputIndexFromVMFunction(const std::string& func_name,
                                       const std::string& input_name) const;
 
   /*!
@@ -314,7 +313,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param input_name The input tensor name.
    * \return The input tensor index.
    */
-  int64_t getInputIndexFromName(const std::vector<std::string>& params,
+  int64_t GetInputIndexFromName(const std::vector<std::string>& params,
                                 const std::string& input_name) const;
 
   /*!
@@ -322,7 +321,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param func_name The function's name.
    * \return VM function.
    */
-  const VMFunction& checkAndGetVMFunction(const std::string& func_name) const;
+  const VMFunction& CheckAndGetVMFunction(const std::string& func_name) const;
 
   /*!
    * \brief Creats inputs_ field, if it exists check its size.
@@ -330,7 +329,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param size inputs_ field size.
    * \return VM function.
    */
-  void createInputsOrCheckSize(const std::string& func_name, size_t size);
+  void CreateInputsOrCheckSize(const std::string& func_name, size_t size);
 
   /*!
    * \brief Set one input tensor with given index to set of input tensors if need copy to given

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -302,25 +302,20 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param func_name The function's name.
    * \return The input tensor index.
    */
-  int64_t getInputIndexFromName(const std::string& input_name,
-                                const std::string& func_name) const;
+  int64_t getInputIndexFromName(const std::string& input_name, const std::string& func_name) const;
   /*!
    * \brief Check executable exists and function name is in global map, get VM function.
    * \param func_name The function's name.
    * \return VM function.
    */
   const VMFunction& checkAndGetVMFunction(const std::string& func_name) const;
-    /*!
-   * \brief Set one input tensor with given index to set of input tensors if need copy to given device.
-   * \param tensors the input tensors set (destination)
-   * \param tensor some tensor (not neccessary DLTensor)
-   * \param index The input tensor index.
-   * \param dev device to copy if need.
+  /*!
+   * \brief Set one input tensor with given index to set of input tensors if need copy to given
+   * device. \param tensors the input tensors set (destination) \param tensor some tensor (not
+   * neccessary DLTensor). \param index The input tensor index. \param dev device to copy if need.
    */
-  void SetInputTensorWithIndex(std::vector<ObjectRef>& tensors, // NOLINT(*)
-                               const TVMArgValue& tensor,
-                               int index,
-                               Device dev);
+  void SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,  // NOLINT(*)
+                               const TVMArgValue& tensor, int index, Device dev);
 
  protected:
   /*! \brief The virtual machine's packed function table. */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -296,8 +296,28 @@ class VirtualMachine : public runtime::ModuleNode {
   virtual void OpStopHook();
 
  private:
+  /*!
+   * \brief Get index of input tensor from its name.
+   * \param input_name The input tensor name
+   * \param func_name The function's name.
+   * \return The input tensor index.
+   */
+  int64_t getInputIndexFromName(const std::string& input_name,
+                                const std::string& func_name) const;
+  /*!
+   * \brief Check executable exists and function name is in global map, get VM function.
+   * \param func_name The function's name.
+   * \return VM function.
+   */
   const VMFunction& checkAndGetVMFunction(const std::string& func_name) const;
-  void SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,
+    /*!
+   * \brief Set one input tensor with given index to set of input tensors if need copy to given device.
+   * \param tensors the input tensors set (destination)
+   * \param tensor some tensor (not neccessary DLTensor)
+   * \param index The input tensor index.
+   * \param dev device to copy if need.
+   */
+  void SetInputTensorWithIndex(std::vector<ObjectRef>& tensors, // NOLINT(*)
                                const TVMArgValue& tensor,
                                int index,
                                Device dev);

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -93,7 +93,10 @@ struct VMFunction {
         params(std::move(params)),
         instructions(std::move(instructions)),
         register_file_size(register_file_size),
-        param_device_indexes(std::move(param_device_indexes)) {}
+        param_device_indexes(std::move(param_device_indexes)) {
+          ICHECK_EQ(params.size(), param_device_indexes.size())
+            << "The number of provided parameters doesn't match the number of assigned devices";
+        }
 
   VMFunction() = default;
 

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -295,6 +295,13 @@ class VirtualMachine : public runtime::ModuleNode {
    */
   virtual void OpStopHook();
 
+ private:
+  const VMFunction& checkAndGetVMFunction(const std::string& func_name) const;
+  void SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,
+                               const TVMArgValue& tensor,
+                               int index,
+                               Device dev);
+
  protected:
   /*! \brief The virtual machine's packed function table. */
   std::vector<PackedFunc> packed_funcs_;

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -94,9 +94,9 @@ struct VMFunction {
         instructions(std::move(instructions)),
         register_file_size(register_file_size),
         param_device_indexes(std::move(param_device_indexes)) {
-          ICHECK_EQ(params.size(), param_device_indexes.size())
-            << "The number of provided parameters doesn't match the number of assigned devices";
-        }
+    ICHECK_EQ(params.size(), param_device_indexes.size())
+        << "The number of provided parameters doesn't match the number of assigned devices";
+  }
 
   VMFunction() = default;
 
@@ -280,7 +280,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * function. If the tensor is not of the correct device for the function,
    * they will be copied to the device.
    */
-  void SetOneInputTensor(std::string func_name, TVMArgs args);
+  void SetOneInputTensor(std::string name, TVMArgs args);
 
   /*!
    * \brief Internal hook for profiling the start of an op.
@@ -305,7 +305,8 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param input_name The input tensor name.
    * \return The input tensor index.
    */
-  int64_t getInputIndexFromVMFunction(const std::string& func_name, const std::string& input_name) const;
+  int64_t getInputIndexFromVMFunction(const std::string& func_name,
+                                      const std::string& input_name) const;
 
   /*!
    * \brief Get index of input tensor from its name.
@@ -313,7 +314,8 @@ class VirtualMachine : public runtime::ModuleNode {
    * \param input_name The input tensor name.
    * \return The input tensor index.
    */
-  int64_t getInputIndexFromName(const std::vector<std::string>& params, const std::string& input_name) const;
+  int64_t getInputIndexFromName(const std::vector<std::string>& params,
+                                const std::string& input_name) const;
 
   /*!
    * \brief Check executable exists and get VM function from it.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -274,22 +274,13 @@ class VirtualMachine : public runtime::ModuleNode {
   void SetInput(std::string name, TVMArgs args, int offset);
 
   /*!
-   * \brief Set input tensor with index to a function.
+   * \brief Set one input tensor with index or name to a function.
    * \param name The function name
-   * \param args args[1:] are two arguments (index, tensor) to the
+   * \param args args[1:] are two arguments (index or name, tensor) to the
    * function. If the tensor is not of the correct device for the function,
    * they will be copied to the device.
    */
-  void SetInputWithIndex(std::string name, TVMArgs args);
-
-  /*!
-   * \brief Set input tensor with name to a function.
-   * \param name The function name
-   * \param args args[1:] are two arguments (name, tensor) to the
-   * function. If the tensor is not of the correct device for the function,
-   * they will be copied to the device.
-   */
-  void SetInputWithName(std::string name, TVMArgs args);
+  void SetOneInputTensor(std::string func_name, TVMArgs args);
 
   /*!
    * \brief Internal hook for profiling the start of an op.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -283,6 +283,15 @@ class VirtualMachine : public runtime::ModuleNode {
   void SetInputWithIndex(std::string name, TVMArgs args);
 
   /*!
+   * \brief Set input tensor with name to a function.
+   * \param name The function name
+   * \param args args[1:] are two arguments (name, tensor) to the
+   * function. If the tensor is not of the correct device for the function,
+   * they will be copied to the device.
+   */
+  void SetInputWithName(std::string name, TVMArgs args);
+
+  /*!
    * \brief Internal hook for profiling the start of an op.
    *
    * This hook is only called on certain ops that are likely to take a
@@ -301,17 +310,27 @@ class VirtualMachine : public runtime::ModuleNode {
  private:
   /*!
    * \brief Get index of input tensor from its name.
-   * \param input_name The input tensor name
    * \param func_name The function's name.
+   * \param input_name The input tensor name.
    * \return The input tensor index.
    */
-  int64_t getInputIndexFromName(const std::string& input_name, const std::string& func_name) const;
+  int64_t getInputIndexFromVMFunction(const std::string& func_name, const std::string& input_name) const;
+
+  /*!
+   * \brief Get index of input tensor from its name.
+   * \param params parameter names.
+   * \param input_name The input tensor name.
+   * \return The input tensor index.
+   */
+  int64_t getInputIndexFromName(const std::vector<std::string>& params, const std::string& input_name) const;
+
   /*!
    * \brief Check executable exists and get VM function from it.
    * \param func_name The function's name.
    * \return VM function.
    */
   const VMFunction& checkAndGetVMFunction(const std::string& func_name) const;
+
   /*!
    * \brief Creats inputs_ field, if it exists check its size.
    * \param func_name The function's name.
@@ -319,6 +338,7 @@ class VirtualMachine : public runtime::ModuleNode {
    * \return VM function.
    */
   void createInputsOrCheckSize(const std::string& func_name, size_t size);
+
   /*!
    * \brief Set one input tensor with given index to set of input tensors if need copy to given
    * device. \param tensors the input tensors set (destination) \param tensor some tensor (not

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -451,23 +451,29 @@ class VirtualMachine(object):
         cargs = convert(args)
         self._set_input(func_name, *cargs)
 
-    def set_one_input(self, func_name, **kwargs):
+    def set_one_input(self, func_name, *args, **kwargs):
         """Set the one input tensor with tag to a function.
 
         Parameters
         ----------
         func_name : str
             The name of the function.
-
-        kwargs: dict of str or int to tvm.runtime.NDArray or np.ndarray
-            Named arguments to the function.
+        args : [str or int, tvm.runtime.NDArray]
+            name or index of tensor and input tensor, optional
+        kwargs: dict of str or int to tvm.runtime.NDArray, optional
+            taged arguments to the function.
+        Only args or kwargs should exist
         """
-        assert len(kwargs) == 1
-        tag = kwargs.keys()[0]
-        if isinstance(tag, str):
-            func_params = self._exec.get_function_params(func_name)
-            assert tag in func_params
-        self._set_one_input(func_name, tag, kwargs[tag])
+        if kwargs:
+            assert len(kwargs) == 1
+            tag = next(iter(kwargs))
+            if isinstance(tag, str):
+                func_params = self._exec.get_function_params(func_name)
+                assert tag in func_params
+            self._set_one_input(func_name, tag, kwargs[tag])
+        else:
+            assert len(args) == 2
+            self._set_one_input(func_name, args[0], args[1])
 
     def invoke(self, func_name, *args, **kwargs):
         """Invoke a function.

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -380,6 +380,7 @@ class VirtualMachine(object):
         self._get_num_outputs = self.module["get_num_outputs"]
         self._get_input_index = self.module["get_input_index"]
         self._set_input = self.module["set_input"]
+        self._set_one_input = self.module["set_one_input"]
         self._setup_device(device, memory_cfg)
 
     def _setup_device(self, dev, memory_cfg):
@@ -449,6 +450,24 @@ class VirtualMachine(object):
             args = new_args
         cargs = convert(args)
         self._set_input(func_name, *cargs)
+
+    def set_one_input(self, func_name, **kwargs):
+        """Set the one input tensor with tag to a function.
+
+        Parameters
+        ----------
+        func_name : str
+            The name of the function.
+
+        kwargs: dict of str or int to tvm.runtime.NDArray or np.ndarray
+            Named arguments to the function.
+        """
+        assert len(kwargs) == 1
+        tag = kwargs.keys()[0]
+        if isinstance(tag, str):
+            func_params = self._exec.get_function_params(func_name)
+            assert tag in func_params
+        self._set_one_input(func_name, tag, kwargs[tag])
 
     def invoke(self, func_name, *args, **kwargs):
         """Invoke a function.

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -109,27 +109,20 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
   }
 }
 
-int Executable::GetFunctionArity(std::string func_name) const {
+const VMFunction& Executable::GetVMFunctionWithName(const std::string& func_name) const {
   auto it = global_map.find(func_name);
-  if (it == global_map.end()) {
-    LOG(ERROR) << "Cannot find function " << func_name << " in executable";
-    return -1;
-  }
-  const auto& func = functions[it->second];
+  ICHECK(it != global_map.end()) << "Cannot find function " << func_name << " in executable";
+  return functions[it->second];
+}
+
+int Executable::GetFunctionArity(std::string func_name) const {
+  const auto& func = GetVMFunctionWithName(func_name);
   return func.params.size();
 }
 
 std::string Executable::GetFunctionParameterName(std::string func_name, uint32_t index) const {
-  auto it = global_map.find(func_name);
-  if (it == global_map.end()) {
-    LOG(ERROR) << "Cannot find function " << func_name << " in executable";
-    return "";
-  }
-  const auto& func = functions[it->second];
-  if (index > func.params.size()) {
-    LOG(ERROR) << "Invalid parameter index";
-    return "";
-  }
+  const auto& func = GetVMFunctionWithName(func_name);
+  ICHECK_LT(index, func.params.size()) << "Invalid parameter index";
   return func.params[index];
 }
 

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -242,7 +242,8 @@ void VirtualMachine::SetInput(std::string func_name, TVMArgs args, int offset) {
 }
 
 void VirtualMachine::SetOneInputTensor(std::string func_name, TVMArgs args) {
-  ICHECK_EQ(args.size(), 3) << "The expected number of arguments is 3 (func_name, index or name, tensor)";
+  ICHECK_EQ(args.size(), 3) << "The expected number of arguments is 3 "
+                            << "(func_name, index or name, tensor)";
   const auto& vm_func = checkAndGetVMFunction(func_name);
   size_t params_num = vm_func.params.size();
 
@@ -250,9 +251,10 @@ void VirtualMachine::SetOneInputTensor(std::string func_name, TVMArgs args) {
   if (args[1].type_code() == kTVMArgInt) {
     inp_index = args[1];
   } else if (args[1].type_code() == kTVMStr) {
-    inp_index = int(getInputIndexFromName(vm_func.params, args[1]));
+    inp_index = static_cast<int>(getInputIndexFromName(vm_func.params, args[1]));
   } else {
-    LOG(FATAL) << "The second argument type (" << args[1].type_code() << ") doesn't match integer or string";
+    LOG(FATAL) << "The second argument type (" << args[1].type_code()
+               << ") doesn't match integer or string";
   }
   ICHECK_LT(inp_index, params_num);
 

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -231,9 +231,6 @@ void VirtualMachine::SetInput(std::string func_name, TVMArgs args, int offset) {
   const auto& param_names = vm_func.params;
   ICHECK_EQ(args.size() - offset, param_names.size())
       << "The number of provided parameters doesn't match the number of arguments";
-  // TODO(vvchernov): Looks like it should be checked earlier and in other place
-  ICHECK_EQ(param_names.size(), vm_func.param_device_indexes.size())
-      << "The number of provided parameters doesn't match the number of assigned devices";
   std::vector<ObjectRef> func_args(param_names.size());
   for (int i = offset; i < args.size(); ++i) {
     int index = i - offset;
@@ -248,9 +245,6 @@ void VirtualMachine::SetInputWithIndex(std::string func_name, TVMArgs args) {
   const auto& vm_func = checkAndGetVMFunction(func_name);
   const auto& param_names = vm_func.params;
   ICHECK_EQ(args.size(), 3) << "The expected number of arguments is 3 (func_name, index, tensor)";
-  // TODO(vvchernov): Looks like it should be checked earlier and in other place
-  ICHECK_EQ(param_names.size(), vm_func.param_device_indexes.size())
-      << "The number of provided parameters doesn't match the number of assigned devices";
   if (inputs_.count(func_name)) {
     ICHECK_EQ(inputs_[func_name].size(), param_names.size())
         << "The size of function" << func_name

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -275,10 +275,7 @@ int64_t VirtualMachine::getInputIndexFromName(const std::string& input_name,
 
 const VMFunction& VirtualMachine::checkAndGetVMFunction(const std::string& func_name) const {
   ICHECK(exec_) << "The executable is not created yet.";
-  auto gvit = exec_->global_map.find(func_name);
-  ICHECK(gvit != exec_->global_map.end()) << "Cannot find function " << func_name;
-  auto func_index = gvit->second;
-  return exec_->functions[func_index];
+  return exec_->GetVMFunctionWithName(func_name);
 }
 
 void VirtualMachine::SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -288,9 +288,7 @@ const VMFunction& VirtualMachine::checkAndGetVMFunction(const std::string& func_
 }
 
 void VirtualMachine::SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,
-                                             const TVMArgValue& inp_tensor,
-                                             int index,
-                                             Device dev) {
+                                             const TVMArgValue& inp_tensor, int index, Device dev) {
   if (inp_tensor.type_code() == kTVMDLTensorHandle) {
     // Automatically convert input DLTensors to NDArray
     DLTensor* tensor = inp_tensor;

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -244,7 +244,8 @@ void VirtualMachine::SetInput(std::string func_name, TVMArgs args, int offset) {
   inputs_.emplace(func_name, func_args);
 }
 
-void VirtualMachine::SetOneInput(std::string func_name, const TVMArgValue& tag, const TVMArgValue& tensor) {
+void VirtualMachine::SetOneInput(std::string func_name, const TVMArgValue& tag,
+                                 const TVMArgValue& tensor) {
   const auto& vm_func = CheckAndGetVMFunction(func_name);
   size_t params_num = vm_func.params.size();
 

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -35,6 +35,8 @@ from tvm.relay.testing import mlp
 from tvm.relay.dataflow_pattern import wildcard, is_op
 from tvm.relay.backend.vm import VMCompiler
 
+from onnx import helper, checker, mapping
+
 
 def check_result(target, dev, args, expected_result, mod):
     """
@@ -922,6 +924,216 @@ def test_get_input_index(target, dev):
     assert vm_factory.get_input_index(data_0) == 0
     assert vm_factory.get_input_index("invalid") == -1
 
+def get_one_input_onnx_model(weight_data, tensor_type, shape, data_name):
+    constant = helper.make_node(
+        "Constant",
+        inputs=[],
+        outputs=["constant"],
+        value=helper.make_tensor(
+            name="const_tensor",
+            data_type=tensor_type,
+            dims=shape,
+            vals=weight_data.flatten(),
+        ),
+    )
+    add_layer = helper.make_node("Add", [data_name, "constant"], ["out"])
+
+    graph = helper.make_graph(
+        [constant, add_layer],
+        "one_input_test",
+        inputs=[
+            helper.make_tensor_value_info(data_name, tensor_type, shape),
+        ],
+        outputs=[
+            helper.make_tensor_value_info(
+                "out", tensor_type, shape
+            )
+        ],
+    )
+    onnx_model = helper.make_model(graph, producer_name="one_input_test")
+    checker.check_model(onnx_model, full_check=True)
+    return onnx_model
+
+@tvm.testing.parametrize_targets("llvm")
+def test_one_set_input(target, dev):
+    dtype = "float32"
+    tensor_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
+    in_shape = [1, 2, 3, 3]
+    in_data_name_0 = "d0"
+
+    weight_data = np.random.uniform(size=in_shape).astype(dtype)
+    onnx_model = get_one_input_onnx_model(weight_data, tensor_type, in_shape, in_data_name_0)
+
+    # Compile to VMExecutable.
+    shape_dict = {in_data_name_0: in_shape}
+    mod, _ = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
+    vm_exec = vm.compile(mod, target=target)
+    exe = runtime.vm.VirtualMachine(vm_exec, dev)
+
+    data0_core = np.random.uniform(size=in_shape).astype(dtype)
+    data0 = tvm.nd.array(data0_core)
+    ref_res_core = data0_core + weight_data
+    ref_res = tvm.nd.array(ref_res_core)
+
+    exe.set_input("main", data0)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+    data_dict = {in_data_name_0: data0}
+    exe.set_input("main", **data_dict)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+def get_multiple_input_onnx_model(weight_data, tensor_type, shape, data_name0, data_name1):
+    constant = helper.make_node(
+        "Constant",
+        inputs=[],
+        outputs=["constant"],
+        value=helper.make_tensor(
+            name="const_tensor",
+            data_type=tensor_type,
+            dims=shape,
+            vals=weight_data.flatten(),
+        ),
+    )
+    add_layer_0 = helper.make_node("Add", [data_name0, "constant"], ["out0"])
+    add_layer_1 = helper.make_node("Add", [data_name1, "constant"], ["out1"])
+    add_layer_2 = helper.make_node("Add", ["out0", "out1"], ["out"])
+
+    graph = helper.make_graph(
+        [constant, add_layer_0, add_layer_1, add_layer_2],
+        "multiple_input_test",
+        inputs=[
+            helper.make_tensor_value_info(data_name0, tensor_type, shape),
+            helper.make_tensor_value_info(data_name1, tensor_type, shape),
+        ],
+        outputs=[
+            helper.make_tensor_value_info(
+                "out", tensor_type, shape
+            )
+        ],
+    )
+    onnx_model = helper.make_model(graph, producer_name="multiple_input_test")
+    checker.check_model(onnx_model, full_check=True)
+    return onnx_model
+
+@tvm.testing.parametrize_targets("llvm")
+def test_multiple_set_input(target, dev):
+    dtype = "float32"
+    tensor_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
+    in_shape = [1, 2, 3, 3]
+    in_data_name_0 = "d0"
+    in_data_name_1 = "d1"
+
+    weight_data = np.random.uniform(size=in_shape).astype(dtype)
+    onnx_model = get_multiple_input_onnx_model(weight_data, tensor_type, in_shape, in_data_name_0, in_data_name_1)
+
+    # Compile to VMExecutable.
+    shape_dict = {in_data_name_0: in_shape, in_data_name_1: in_shape}
+    mod, _ = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
+    vm_exec = vm.compile(mod, target=target)
+    exe = runtime.vm.VirtualMachine(vm_exec, dev)
+
+    data0_core = np.random.uniform(size=in_shape).astype(dtype)
+    data0 = tvm.nd.array(data0_core)
+    data1_core = np.random.uniform(size=in_shape).astype(dtype)
+    data1 = tvm.nd.array(data1_core)
+    ref_res_core = (data0_core + weight_data) + (data1_core + weight_data)
+    ref_res = tvm.nd.array(ref_res_core)
+
+    exe.set_input("main", data0, data1)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+    data_dict = {in_data_name_1: data1, in_data_name_0: data0}
+    exe.set_input("main", **data_dict)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+@tvm.testing.parametrize_targets("llvm")
+def test_one_set_one_input(target, dev):
+    dtype = "float32"
+    tensor_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
+    in_shape = [1, 2, 3, 3]
+    in_data_name_0 = "d0"
+
+    weight_data = np.random.uniform(size=in_shape).astype(dtype)
+    onnx_model = get_one_input_onnx_model(weight_data, tensor_type, in_shape, in_data_name_0)
+
+    # Compile to VMExecutable.
+    shape_dict = {in_data_name_0: in_shape}
+    mod, _ = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
+    vm_exec = vm.compile(mod, target=target)
+    exe = runtime.vm.VirtualMachine(vm_exec, dev)
+
+    data0_core = np.random.uniform(size=in_shape).astype(dtype)
+    data0 = tvm.nd.array(data0_core)
+    ref_res_core = data0_core + weight_data
+    ref_res = tvm.nd.array(ref_res_core)
+
+    exe.set_one_input("main", 0, data0)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+    exe.set_one_input("main", in_data_name_0, data0)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+    data_dict = {in_data_name_0: data0}
+    exe.set_one_input("main", **data_dict)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+@tvm.testing.parametrize_targets("llvm")
+def test_multiple_set_one_input(target, dev):
+    dtype = "float32"
+    tensor_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
+    in_shape = [1, 2, 3, 3]
+    in_data_name_0 = "d0"
+    in_data_name_1 = "d1"
+
+    weight_data = np.random.uniform(size=in_shape).astype(dtype)
+    onnx_model = get_multiple_input_onnx_model(weight_data, tensor_type, in_shape, in_data_name_0, in_data_name_1)
+
+    # Compile to VMExecutable.
+    shape_dict = {in_data_name_0: in_shape, in_data_name_1: in_shape}
+    mod, _ = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
+    vm_exec = vm.compile(mod, target=target)
+    exe = runtime.vm.VirtualMachine(vm_exec, dev)
+
+    data0_core = np.random.uniform(size=in_shape).astype(dtype)
+    data0 = tvm.nd.array(data0_core)
+    data1_core = np.random.uniform(size=in_shape).astype(dtype)
+    data1 = tvm.nd.array(data1_core)
+    ref_res_core = (data0_core + weight_data) + (data1_core + weight_data)
+    ref_res = tvm.nd.array(ref_res_core)
+
+    exe.set_one_input("main", 1, data1)
+    exe.set_one_input("main", 0, data0)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+    exe.set_one_input("main", in_data_name_1, data1)
+    exe.set_one_input("main", in_data_name_0, data0)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
+
+    data_dict = {in_data_name_1: data1}
+    exe.set_one_input("main", **data_dict)
+    data_dict = {in_data_name_0: data0}
+    exe.set_one_input("main", **data_dict)
+    output = exe.invoke("main")
+    assert output.dtype == ref_res.dtype
+    tvm.testing.assert_allclose(ref_res_core, output.numpy())
 
 @tvm.testing.parametrize_targets("llvm")
 def test_benchmark(target, dev):


### PR DESCRIPTION
Implementation of `set_one_input` method in VirtualMachine (VM) class. It provides more convenient way to work with multiple input models on native side. Now you can use index or name to set one input tensor to VM.
Examples:
`set_one_input("main", "data", tensor0)`
`set_one_input("main", 1, tensor1)`
It was required due to GraphExecutor (GE) and VM have different signature for `set_input` method. `set_input` from VM is not so convenient for work with multiple tensor input. Implemented `set_one_input` method in VM is repeated signature from `set_input` in GE.
I think it will be good if we have the same API for both GraphExecutor and VirtualMachine. But I do not see simple way for it.
My current solution seems solid but not final.

Possible improvements: I can insert functionality of `set_one_input` method to base method `set_input`. But I do not think that it is good idea to mix them. Other possible extension is to additionally reload `set_input` with args: func_name, index1(name1), tensor1, index2(name2), tensor2, …, indexN(nameN), tensorN, where N is number of all input tensors. But it is still not perfect solution for me.