### PR TITLE
[microTVM] Add timeouts for CI tests

### DIFF
--- a/tests/scripts/task_demo_microtvm.sh
+++ b/tests/scripts/task_demo_microtvm.sh
@@ -19,7 +19,7 @@
 set -euxo pipefail
 
 pushd apps/microtvm/zephyr_cmsisnn
-./run_demo.sh
+timeout 5m ./run_demo.sh
 popd
 
 pushd apps/microtvm/ethosu
@@ -27,6 +27,6 @@ FVP_PATH="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
 CMAKE_PATH="/opt/arm/cmake/bin/cmake"
 FREERTOS_PATH="/opt/freertos/FreeRTOSv202112.00"
 
-./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH
-./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH --freertos_path $FREERTOS_PATH
+timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH
+timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH --freertos_path $FREERTOS_PATH
 popd


### PR DESCRIPTION
These shouldn't take longer than 5 minutes but since they have to poll they can end up running for a long while (e.g. this failure: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/2534/pipeline).

cc @mehrdadh

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
