### PR TITLE
Add flaky test issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/flaky-test.md
@@ -1,0 +1,18 @@
+---
+name: "\U00002744 Flaky Test"
+about: Report a flaky test, make sure to include links to CI runs, a sample failure log, and the name of the test(s)
+title: "[Flaky Test] "
+labels: "test: flaky"
+---
+
+Thanks for participating in the TVM community! We use https://discuss.tvm.ai for any general usage questions and discussions. The issue tracker is used for actionable items such as feature proposals discussion, roadmaps, and bug tracking. You are always welcomed to post on the forum first :smile_cat:
+
+These tests were found to be flaky (intermittently failing on `main` or failed in a PR with unrelated changes). As per [the docs](https://github.com/apache/tvm/blob/main/docs/contribute/ci.rst#handling-flaky-failures, these failures will be disabled in a PR that references this issue until the test owners can fix the source of the flakiness.
+
+### Test(s)
+
+- `tests/python/some_file.py::the_test_name`
+
+### Jenkins Links
+
+- Please provide link(s) to failed CI runs. If runs are for a PR, explain why your PR did not break the test (e.g. did not touch that part of the codebase)


### PR DESCRIPTION
This adds a template so we can report (and label) flaky test issues separately from CI infra problems. This also helps others report flaky tests by pointing them to the relevant documentation.

cc @areusch @denise-k @hpanda-naut @masahi

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
