### PR TITLE
[Arith] Support integer BufferLoad in IntervalSetEvaluator

### DIFF
--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -453,6 +453,24 @@ class IntervalSetEvaluator : public ExprFunctor<IntervalSet(const PrimExpr&)> {
     return IntervalSet(min_value, max_value);
   }
 
+  IntervalSet VisitExpr_(const BufferLoadNode* op) final {
+    if (!(op->dtype.is_int() || op->dtype.is_uint())) {
+      DLOG(WARNING) << "cannot evaluate set BufferLoad which loads from a " << op->dtype
+                    << " buffer";
+      return IntervalSet::Everything();
+    }
+    // If the indices do not contain any variables to be relaxed, return the BufferLoad itself.
+    // Otherwise return `IntervalSet::everything()` since we have no knowledge on the buffer data.
+    for (const PrimExpr& index : op->indices) {
+      if (UsesVar(index, [dom_map = &this->dom_map_](const VarNode* var) {
+            return dom_map->find(GetRef<Var>(var)) != dom_map->end();
+          })) {
+        return IntervalSet::Everything();
+      }
+    }
+    return IntervalSet::SinglePoint(GetRef<PrimExpr>(op));
+  }
+
   IntervalSet VisitExprDefault_(const Object* op) final {
     DLOG(WARNING) << "cannot evaluate set type " << op->GetTypeKey();
     return IntervalSet::Everything();

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -515,8 +515,7 @@ def sparse_read_cache(
     for i in T.serial(128):
         with T.block("rowsum_outer"):
             T.reads(
-                A_indptr[i],
-                A_indptr[i + 1],
+                A_indptr[i : i + 1],
                 A_data[A_indptr[i] + 0 : A_indptr[i] + (A_indptr[i + 1] - A_indptr[i])],
             )
             T.writes(B[i])
@@ -549,8 +548,7 @@ def compacted_sparse_read_cache(
     for i in T.serial(128):
         with T.block("rowsum_outer"):
             T.reads(
-                A_indptr[i],
-                A_indptr[i + 1],
+                A_indptr[i : i + 1],
                 A_data[A_indptr[i] + 0 : A_indptr[i] + 0 + (A_indptr[i + 1] - A_indptr[i])],
             )
             T.writes(B[i])

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -505,6 +505,74 @@ def compacted_opaque_access_annotated_func(a: T.handle) -> None:
                 T.store(C.data, i, T.load("float32", B.data, i))
 
 
+@T.prim_func
+def sparse_read_cache(
+    A_data: T.Buffer[(819,), "float32"],
+    B: T.Buffer[(128,), "float32"],
+    A_indptr: T.Buffer[(129,), "int32"],
+    A_indices: T.Buffer[(819,), "int32"],
+) -> None:
+    for i in T.serial(128):
+        with T.block("rowsum_outer"):
+            T.reads(
+                A_indptr[i],
+                A_indptr[i + 1],
+                A_data[A_indptr[i] + 0 : A_indptr[i] + (A_indptr[i + 1] - A_indptr[i])],
+            )
+            T.writes(B[i])
+            with T.block("rowsum_init"):
+                T.reads()
+                T.writes(B[i])
+                B[i] = T.float32(0)
+            for k in T.serial(A_indptr[i + 1] - A_indptr[i]):
+                with T.block():
+                    T.reads(A_indptr[i], A_data[A_indptr[i] + k], B[i])
+                    T.writes(B[i])
+                    A_data_local = T.alloc_buffer([819], dtype="float32", scope="local")
+                    with T.block("A_data_cache_read"):
+                        T.reads(A_indptr[i], A_data[A_indptr[i] + k])
+                        T.writes(A_data_local[A_indptr[i] + k])
+                        A_data_local[A_indptr[i] + k] = A_data[A_indptr[i] + k]
+                    with T.block("rowsum_inner"):
+                        T.reads(B[i], A_indptr[i], A_data[A_indptr[i] + k])
+                        T.writes(B[i])
+                        B[i] = B[i] + A_data_local[A_indptr[i] + k]
+
+
+@T.prim_func
+def compacted_sparse_read_cache(
+    A_data: T.Buffer[(819,), "float32"],
+    B: T.Buffer[(128,), "float32"],
+    A_indptr: T.Buffer[(129,), "int32"],
+    A_indices: T.Buffer[(819,), "int32"],
+) -> None:
+    for i in T.serial(128):
+        with T.block("rowsum_outer"):
+            T.reads(
+                A_indptr[i],
+                A_indptr[i + 1],
+                A_data[A_indptr[i] + 0 : A_indptr[i] + 0 + (A_indptr[i + 1] - A_indptr[i])],
+            )
+            T.writes(B[i])
+            with T.block("rowsum_init"):
+                T.reads()
+                T.writes(B[i])
+                B[i] = T.float32(0)
+            for k in T.serial(A_indptr[i + 1] - A_indptr[i]):
+                with T.block():
+                    T.reads(A_indptr[i], A_data[A_indptr[i] + k], B[i])
+                    T.writes(B[i])
+                    A_data_local = T.alloc_buffer([1], dtype="float32", scope="local")
+                    with T.block("A_data_cache_read"):
+                        T.reads(A_indptr[i], A_data[A_indptr[i] + k])
+                        T.writes(A_data_local[A_indptr[i] + k - (A_indptr[i] + k)])
+                        A_data_local[A_indptr[i] + k - (A_indptr[i] + k)] = A_data[A_indptr[i] + k]
+                    with T.block("rowsum_inner"):
+                        T.reads(B[i], A_indptr[i], A_data[A_indptr[i] + k])
+                        T.writes(B[i])
+                        B[i] = B[i] + A_data_local[A_indptr[i] + k - (A_indptr[i] + k)]
+
+
 def test_elementwise():
     _check(elementwise_func, compacted_elementwise_func)
 
@@ -562,6 +630,10 @@ def test_opaque_access_annotated_func():
     _check(opaque_access_annotated_func, compacted_opaque_access_annotated_func)
 
 
+def test_sparse_read_cache():
+    _check(sparse_read_cache, compacted_sparse_read_cache)
+
+
 if __name__ == "__main__":
     test_elementwise()
     test_unschedulable_block()
@@ -576,3 +648,4 @@ if __name__ == "__main__":
     test_padding_pattern()
     test_mem_access_in_branch_func()
     test_opaque_access_annotated_func()
+    test_sparse_read_cache()

--- a/tests/python/unittest/test_tvmscript_complete.py
+++ b/tests/python/unittest/test_tvmscript_complete.py
@@ -210,7 +210,7 @@ def expected_bufferslice_indices(data: T.handle, index: T.handle) -> None:
         for i0, i1 in T.grid(16, 16):
             with T.block():
                 vi, vj = T.axis.remap("SS", [i0, i1])
-                T.reads([data_buf[vi, 0:16], index_buf[0]])
+                T.reads([data_buf[vi, index_buf[0]], index_buf[0]])
                 T.writes([out_buf[vi, vj]])
                 out_buf[vi, vj] = data_buf[vi, index_buf[0]]
 
@@ -238,7 +238,12 @@ def expected_recursive_bufferslice_indices(data: T.handle, index: T.handle) -> N
         for i0, i1 in T.grid(16, 16):
             with T.block():
                 vi, vj = T.axis.remap("SS", [i0, i1])
-                T.reads([data_buf[0:16, 0:16], index_buf[0]])
+                T.reads(
+                    [
+                        data_buf[index_buf[index_buf[0]], index_buf[0]],
+                        index_buf[T.min(index_buf[0], 0) : T.max(index_buf[0], 0) + 1],
+                    ]
+                )
                 T.writes([out_buf[vi, vj]])
                 out_buf[vi, vj] = data_buf[index_buf[index_buf[0]], index_buf[0]]
 


### PR DESCRIPTION
This PR introduces the support of integer BufferLoadNodes in `arith::IntervalSetEvaluator` as well as a unittest.

Prior to this PR, the evaluator always return `IntervalSet::Everything()` (that is `[-∞, +∞]`) once it encounters a BufferLoad. However, as long as 1) the buffer data _is of type integer_ and 2) the indices of the BufferLoad _contain no variable_ that needs to be relaxed during evaluation, we can keep the BufferLoad as it is.

Besides, we're considering introducing `assume_in_range` for buffers for the use of range/region analysis. With `assume_in_range`, even when the indices of BufferLoad contain some variables to be relaxed, we can just return the asserted range, which is more compact, instead of the universe.

cc @yzh119 @Hzfengsy @spectrometerHBH @junrushao1994 @tqchen 