### PR TITLE
[Hexagon] Export `ir_lower_vtcm_pass` function in the init file

### DIFF
--- a/python/tvm/contrib/hexagon/__init__.py
+++ b/python/tvm/contrib/hexagon/__init__.py
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 """Hexagon APIs."""
+from .hexagon import ir_lower_vtcm_pass


### PR DESCRIPTION
Without this, I have to add `from tvm.contrib.hexagon.hexagon import ir_lower_vtcm_pass` which is a bit awkward. Moreover, to make `hexagon_link` and `link_shared` in https://github.com/apache/tvm/blob/cd2fa69677516048e165e84a88c774dfb0ee65d1/python/tvm/contrib/hexagon/hexagon.py#L53-L61 visible, I have to add `import tvm.contrib.hexagon.hexagon`.

With this patch, either
```
from tvm.contrib.hexagon import ir_lower_vtcm_pass
```

or 
```
import tvm.contrib.hexagon
```

is enough to load  `hexagon_link` and `link_shared`.

cc @kparzysz-quic 
