### PR TITLE
[Docs] Fix an irrelevant sentence in relay.reverse

### DIFF
--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -704,7 +704,6 @@ def tile(data, reps):
 
 def reverse(data, axis):
     """Reverses the order of elements along given axis while preserving array shape.
-    By default, repeat flattens the input array into 1-D and then repeats the elements.
 
     Parameters
     ----------


### PR DESCRIPTION
It seems the sentence is from relay.repeat() and not related to relay.reverse().

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
