### PR TITLE
[TOPI] VNNI support for batch matmul

### DIFF
--- a/python/tvm/topi/nn/dense.py
+++ b/python/tvm/topi/nn/dense.py
@@ -274,3 +274,22 @@ def dense_alter_layout(attrs, inputs, tinfos, out_type):
     """
     # not to change by default
     return None
+
+
+@tvm.target.generic_func
+def batch_matmul_legalize(attrs, inputs, types):
+    """Legalizes batch_matmul op.
+    Parameters
+    ----------
+    attrs : tvm.ir.Attrs
+        Attributes of current batch_matmul
+    inputs : list of tvm.relay.Expr
+        The args of the Relay expr to be legalized
+    types : list of types
+        List of input and output types
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The legalized expr
+    """
+    return None

--- a/python/tvm/topi/x86/batch_matmul.py
+++ b/python/tvm/topi/x86/batch_matmul.py
@@ -120,7 +120,9 @@ def batch_matmul(
     mcpu = tvm.target.Target.current().mcpu
 
     if (
-        target_has_vnni(mcpu)
+        not transpose_a
+        and transpose_b
+        and target_has_vnni(mcpu)
         and tensor_a.dtype == "uint8"
         and tensor_b.dtype == "int8"
         and tensor_b.shape[-2] % 16 == 0

--- a/python/tvm/topi/x86/batch_matmul.py
+++ b/python/tvm/topi/x86/batch_matmul.py
@@ -24,7 +24,6 @@ from tvm.contrib import cblas, mkl
 from .. import generic, nn
 from ..transform import layout_transform
 from ..utils import traverse_inline, get_const_tuple, get_max_power2_factor
-from .injective import schedule_injective_from_existing
 from .utils import target_has_vnni
 from .dense import dense_vnni_schedule
 
@@ -55,7 +54,7 @@ def batch_matmul_vnni_compute(cfg, x, y):
     return z
 
 
-def batch_matmul_vnni_schedule(cfg, s, C, O):
+def batch_matmul_vnni_schedule(cfg, s, C, O, layout_trans):
     """Schedule batch_matmul compute using VNNI vpdpbusd instruction"""
     # C: The output of batched GEMM
     # O: The output of the fused op
@@ -65,6 +64,12 @@ def batch_matmul_vnni_schedule(cfg, s, C, O):
     # Parallelize over batch
     fused = s[O].fuse(O.op.axis[0], fused_inner)
     s[O].parallel(fused)
+
+    s[layout_trans].compute_at(s[O], fused)
+    _, _, _, ni, ki = s[layout_trans].op.axis
+    s[layout_trans].vectorize(ki)
+    s[layout_trans].unroll(ni)
+
     return s
 
 
@@ -158,12 +163,8 @@ def schedule_batch_matmul(cfg, outs):
 
     def _callback(op):
         if "batch_matmul_vnni" in op.tag:
-            # Schedule layout transform
             layout_trans = op.input_tensors[1]
-            s[layout_trans].compute_root()
-            schedule_injective_from_existing(s, layout_trans)
-            # Schedule batch matmul
-            batch_matmul_vnni_schedule(cfg, s, op.output(0), outs[0])
+            batch_matmul_vnni_schedule(cfg, s, op.output(0), outs[0], layout_trans)
         elif "batch_matmul" in op.tag:
             C = op.output(0)
             A, B = op.input_tensors

--- a/python/tvm/topi/x86/dense_alter_op.py
+++ b/python/tvm/topi/x86/dense_alter_op.py
@@ -25,6 +25,18 @@ from .dense import _default_dense_pack_config
 from ..utils import get_const_tuple
 from ..nn import dense_alter_layout
 from .utils import target_has_vnni
+from .. import nn
+
+
+def check_vnni_applicable(x, y):
+    mcpu = tvm.target.Target.current().mcpu
+    return (
+        target_has_vnni(mcpu)
+        and "int8" in x.dtype
+        and "int8" in y.dtype
+        and y.shape[-2] % 16 == 0
+        and y.shape[-1] % 4 == 0
+    )
 
 
 @dense_alter_layout.register(["cpu", "arm_cpu"])
@@ -35,16 +47,8 @@ def _alter_dense_layout(attrs, inputs, tinfos, out_type):
     out_dtype = out_type.dtype
     M, K = get_const_tuple(data_tensor.shape)
     N, _ = get_const_tuple(weight_tensor.shape)
-    mcpu = tvm.target.Target.current().mcpu
 
-    if (
-        target_has_vnni(mcpu)
-        and data_tensor.dtype == "uint8"
-        and weight_tensor.dtype == "int8"
-        and weight_tensor.shape[0] % 16 == 0
-        and weight_tensor.shape[1] % 4 == 0
-    ):
-        # TODO(masahi): Support int8 x int8 case
+    if check_vnni_applicable(data_tensor, weight_tensor) and data_tensor.dtype == "uint8":
         weight_layout = "NC16n4c"
         return relay.nn.contrib_dense_pack(inputs[0], inputs[1], weight_layout, None, out_dtype)
 
@@ -79,3 +83,37 @@ def _alter_dense_layout(attrs, inputs, tinfos, out_type):
             return relay.nn.contrib_dense_pack(inputs[0], inputs[1], weight_layout, None, out_dtype)
 
     return None
+
+
+def vnni_legalize(inputs, arg_types, op, attrs, need_expand=False):
+    """Legalizes s8, s8 -> s32 GEMM op for VNNI."""
+    if check_vnni_applicable(arg_types[0], arg_types[1]) and arg_types[0].dtype == "int8":
+        x, y = inputs
+        x = relay.cast(x, "int32")
+        x = relay.add(x, relay.const(128, "int32"))
+        x = relay.cast(x, "uint8")
+
+        adjust_shift = relay.const(128, "int32") * relay.sum(relay.cast(y, "int32"), axis=[-1])
+
+        if need_expand:
+            adjust_shift = relay.expand_dims(adjust_shift, axis=1)
+
+        out = op(x, y, **attrs)
+
+        return relay.subtract(out, adjust_shift)
+
+    return None
+
+
+@nn.dense_legalize.register("cpu")
+def _dense_legalize(attrs, inputs, arg_types):
+    """Legalizes s8, s8 -> s32 dense for VNNI."""
+    return vnni_legalize(inputs, arg_types, relay.nn.dense, attrs)
+
+
+@nn.batch_matmul_legalize.register("cpu")
+def _batch_matmul_legalize(attrs, inputs, arg_types):
+    """Legalizes s8, s8 -> s32 batch_matmul for VNNI."""
+    if attrs["transpose_a"] == True or attrs["transpose_b"] == False:
+        return None
+    return vnni_legalize(inputs, arg_types, relay.nn.batch_matmul, attrs, need_expand=True)

--- a/python/tvm/topi/x86/dense_alter_op.py
+++ b/python/tvm/topi/x86/dense_alter_op.py
@@ -114,6 +114,6 @@ def _dense_legalize(attrs, inputs, arg_types):
 @nn.batch_matmul_legalize.register("cpu")
 def _batch_matmul_legalize(attrs, inputs, arg_types):
     """Legalizes s8, s8 -> s32 batch_matmul for VNNI."""
-    if attrs["transpose_a"] == True or attrs["transpose_b"] == False:
+    if attrs["transpose_a"] or not attrs["transpose_b"]:
         return None
     return vnni_legalize(inputs, arg_types, relay.nn.batch_matmul, attrs, need_expand=True)

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -639,33 +639,37 @@ def test_dense_vnni():
     data_shape = (32, 96)
     weight_shape = (128, 96)
 
-    data = relay.var("data", shape=data_shape, dtype="uint8")
-    weight = relay.var("weight", shape=weight_shape, dtype="int8")
-    bias = relay.var("bias", shape=(weight_shape[0],), dtype="int32")
-    dense = relay.nn.dense(data, weight, out_dtype="int32")
-    out = relay.nn.bias_add(dense, bias)
-    mod = tvm.IRModule.from_expr(out)
+    for data_dtype in ["uint8", "int8"]:
+        data = relay.var("data", shape=data_shape, dtype=data_dtype)
+        weight = relay.var("weight", shape=weight_shape, dtype="int8")
+        bias = relay.var("bias", shape=(weight_shape[0],), dtype="int32")
+        dense = relay.nn.dense(data, weight, out_dtype="int32")
+        out = relay.nn.bias_add(dense, bias)
+        mod = tvm.IRModule.from_expr(out)
 
-    target = "llvm -mcpu=cascadelake"
-    with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(mod, target=target)
+        target = "llvm -mcpu=cascadelake"
+        with tvm.transform.PassContext(opt_level=3):
+            lib = relay.build(mod, target=target)
 
-    dev = tvm.device(target, 0)
-    runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
+        asm = lib.lib.get_source("asm")
+        assert "vpdpbusd" in asm
 
-    a = np.random.uniform(1, 10, size=data_shape).astype("uint8")
-    b = np.random.uniform(1, 10, size=weight_shape).astype("int8")
-    c = np.random.uniform(1, 10, size=(weight_shape[0],)).astype("int32")
+        dev = tvm.device(target, 0)
+        runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
 
-    runtime.set_input("data", a)
-    runtime.set_input("weight", b)
-    runtime.set_input("bias", c)
-    runtime.run()
+        a = np.random.uniform(1, 10, size=data_shape).astype(data_dtype)
+        b = np.random.uniform(1, 10, size=weight_shape).astype("int8")
+        c = np.random.uniform(1, 10, size=(weight_shape[0],)).astype("int32")
 
-    out = runtime.get_output(0).numpy()
-    ref = np.dot(a, b.transpose()) + c
+        runtime.set_input("data", a)
+        runtime.set_input("weight", b)
+        runtime.set_input("bias", c)
+        runtime.run()
 
-    np.testing.assert_equal(out, ref)
+        out = runtime.get_output(0).numpy()
+        ref = np.dot(a.astype("int32"), b.transpose().astype("int32")) + c
+
+        np.testing.assert_equal(out, ref)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -408,6 +408,9 @@ def test_batch_matmul_vnni():
     with tvm.transform.PassContext(opt_level=3):
         lib = relay.build(mod, target=target)
 
+    asm = lib.lib.get_source("asm")
+    assert "vpdpbusd" in asm
+
     dev = tvm.device(target, 0)
     runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
 

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -397,36 +397,37 @@ def test_batch_matmul_vnni():
     y_shape = (16, 128, 96)
     z_shape = (16, 32, 128)
 
-    x = relay.var("x", shape=x_shape, dtype="uint8")
-    y = relay.var("y", shape=y_shape, dtype="int8")
-    z = relay.var("z", shape=z_shape, dtype="int32")
-    bmm = relay.nn.batch_matmul(x, y, out_dtype="int32")
-    out = bmm + z
-    mod = tvm.IRModule.from_expr(out)
+    for lhs_dtype in ["uint8", "int8"]:
+        x = relay.var("x", shape=x_shape, dtype=lhs_dtype)
+        y = relay.var("y", shape=y_shape, dtype="int8")
+        z = relay.var("z", shape=z_shape, dtype="int32")
+        bmm = relay.nn.batch_matmul(x, y, out_dtype="int32")
+        out = bmm + z
+        mod = tvm.IRModule.from_expr(out)
 
-    target = "llvm -mcpu=cascadelake"
-    with tvm.transform.PassContext(opt_level=3):
-        lib = relay.build(mod, target=target)
+        target = "llvm -mcpu=cascadelake"
+        with tvm.transform.PassContext(opt_level=3):
+            lib = relay.build(mod, target=target)
 
-    asm = lib.lib.get_source("asm")
-    assert "vpdpbusd" in asm
+        asm = lib.lib.get_source("asm")
+        assert "vpdpbusd" in asm
 
-    dev = tvm.device(target, 0)
-    runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
+        dev = tvm.device(target, 0)
+        runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
 
-    x_np = np.random.uniform(1, 10, size=x_shape).astype("uint8")
-    y_np = np.random.uniform(1, 10, size=y_shape).astype("int8")
-    z_np = np.random.uniform(1, 10, size=z_shape).astype("int32")
+        x_np = np.random.uniform(1, 10, size=x_shape).astype(lhs_dtype)
+        y_np = np.random.uniform(1, 10, size=y_shape).astype("int8")
+        z_np = np.random.uniform(1, 10, size=z_shape).astype("int32")
 
-    runtime.set_input("x", x_np)
-    runtime.set_input("y", y_np)
-    runtime.set_input("z", z_np)
-    runtime.run()
+        runtime.set_input("x", x_np)
+        runtime.set_input("y", y_np)
+        runtime.set_input("z", z_np)
+        runtime.run()
 
-    out = runtime.get_output(0).numpy()
-    ref = tvm.topi.testing.batch_matmul(x_np, y_np, out_dtype="int32") + z_np
+        out = runtime.get_output(0).numpy()
+        ref = tvm.topi.testing.batch_matmul(x_np, y_np, out_dtype="int32") + z_np
 
-    np.testing.assert_equal(out, ref)
+        np.testing.assert_equal(out, ref)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -395,11 +395,14 @@ def test_batch_matmul():
 def test_batch_matmul_vnni():
     x_shape = (16, 32, 96)
     y_shape = (16, 128, 96)
+    z_shape = (16, 32, 128)
 
     x = relay.var("x", shape=x_shape, dtype="uint8")
     y = relay.var("y", shape=y_shape, dtype="int8")
+    z = relay.var("z", shape=z_shape, dtype="int32")
     bmm = relay.nn.batch_matmul(x, y, out_dtype="int32")
-    mod = tvm.IRModule.from_expr(bmm)
+    out = bmm + z
+    mod = tvm.IRModule.from_expr(out)
 
     target = "llvm -mcpu=cascadelake"
     with tvm.transform.PassContext(opt_level=3):
@@ -410,13 +413,15 @@ def test_batch_matmul_vnni():
 
     x_np = np.random.uniform(1, 10, size=x_shape).astype("uint8")
     y_np = np.random.uniform(1, 10, size=y_shape).astype("int8")
+    z_np = np.random.uniform(1, 10, size=z_shape).astype("int32")
 
     runtime.set_input("x", x_np)
     runtime.set_input("y", y_np)
+    runtime.set_input("z", z_np)
     runtime.run()
 
     out = runtime.get_output(0).numpy()
-    ref = tvm.topi.testing.batch_matmul(x_np, y_np, out_dtype="int32")
+    ref = tvm.topi.testing.batch_matmul(x_np, y_np, out_dtype="int32") + z_np
 
     np.testing.assert_equal(out, ref)
     print("ok")

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -424,7 +424,6 @@ def test_batch_matmul_vnni():
     ref = tvm.topi.testing.batch_matmul(x_np, y_np, out_dtype="int32") + z_np
 
     np.testing.assert_equal(out, ref)
-    print("ok")
 
 
 @tvm.testing.uses_gpu
@@ -662,5 +661,4 @@ def test_nll_loss(dev, target):
 
 
 if __name__ == "__main__":
-    # sys.exit(pytest.main([__file__] + sys.argv[1:]))
-    test_batch_matmul_vnni()
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -16,6 +16,9 @@
 # under the License.
 """ Support level10 operator test cases.
 """
+import sys
+import pytest
+
 import numpy as np
 import tvm
 import tvm.testing
@@ -388,6 +391,37 @@ def test_batch_matmul():
     verify_batch_matmul_with_inputs(x, x, x_np, x_np, (10, 27, 27))
 
 
+@pytest.mark.skip("Requires cascadelake")
+def test_batch_matmul_vnni():
+    x_shape = (16, 32, 96)
+    y_shape = (16, 128, 96)
+
+    x = relay.var("x", shape=x_shape, dtype="uint8")
+    y = relay.var("y", shape=y_shape, dtype="int8")
+    bmm = relay.nn.batch_matmul(x, y, out_dtype="int32")
+    mod = tvm.IRModule.from_expr(bmm)
+
+    target = "llvm -mcpu=cascadelake"
+    with tvm.transform.PassContext(opt_level=3):
+        lib = relay.build(mod, target=target)
+
+    dev = tvm.device(target, 0)
+    runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
+
+    x_np = np.random.uniform(1, 10, size=x_shape).astype("uint8")
+    y_np = np.random.uniform(1, 10, size=y_shape).astype("int8")
+
+    runtime.set_input("x", x_np)
+    runtime.set_input("y", y_np)
+    runtime.run()
+
+    out = runtime.get_output(0).numpy()
+    ref = tvm.topi.testing.batch_matmul(x_np, y_np, out_dtype="int32")
+
+    np.testing.assert_equal(out, ref)
+    print("ok")
+
+
 @tvm.testing.uses_gpu
 def test_shape_of():
     shape = (10, 5, 12)
@@ -623,7 +657,5 @@ def test_nll_loss(dev, target):
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    # sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    test_batch_matmul_vnni()


### PR DESCRIPTION
Following https://github.com/apache/tvm/pull/10230, I added VNNI support for `batch_matmul` as well. The cool part is that I reuse the same `dense` schedule in https://github.com/apache/tvm/pull/10230 to schedule the GEMM part, and parallelize over the batch dimension.  See the perf result in https://github.com/apache/tvm/pull/10332#issuecomment-1047304225

~After this PR, I'll add `int8, int8` support to VNNI `dense` and `batch_matmul`~ (UPDATE: Done) - that will allow us to benchmark e2e performance on QAT BERT made possible by @Icemist in https://github.com/apache/tvm/pull/10239.

Unlike `dense` case, the second input to `batch_matmul` is typically not a constant tensor. So I don't use `alter_layout` and compile time layout transform. Instead, layout transform is done at runtime. So the lowered IR for `batch_matmul` + post ops looks like:
```
  parallel (ax0.ax1.outer.ax2.outer.fused.fused, 0, 128) {
    // attr [T_layout_trans] storage_alignment = 128
    let T_layout_trans = tir.TVMBackendAllocWorkspace(1, dev_id, (uint64)1536, 0, 8)
    allocate compute[int32x16 * 1], storage_scope = global
    for (ax2, 0, 24) {
      let cse_var_2 = (ax2*64)
      let cse_var_1 = ((ax0.ax1.outer.ax2.outer.fused.fused*1536) + (ax2*4))
      T_layout_trans[ramp(cse_var_2, 1, 4)] = placeholder[ramp(cse_var_1, 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 4), 1, 4)] = placeholder[ramp((cse_var_1 + 96), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 8), 1, 4)] = placeholder[ramp((cse_var_1 + 192), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 12), 1, 4)] = placeholder[ramp((cse_var_1 + 288), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 16), 1, 4)] = placeholder[ramp((cse_var_1 + 384), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 20), 1, 4)] = placeholder[ramp((cse_var_1 + 480), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 24), 1, 4)] = placeholder[ramp((cse_var_1 + 576), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 28), 1, 4)] = placeholder[ramp((cse_var_1 + 672), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 32), 1, 4)] = placeholder[ramp((cse_var_1 + 768), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 36), 1, 4)] = placeholder[ramp((cse_var_1 + 864), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 40), 1, 4)] = placeholder[ramp((cse_var_1 + 960), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 44), 1, 4)] = placeholder[ramp((cse_var_1 + 1056), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 48), 1, 4)] = placeholder[ramp((cse_var_1 + 1152), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 52), 1, 4)] = placeholder[ramp((cse_var_1 + 1248), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 56), 1, 4)] = placeholder[ramp((cse_var_1 + 1344), 1, 4)]
      T_layout_trans[ramp((cse_var_2 + 60), 1, 4)] = placeholder[ramp((cse_var_1 + 1440), 1, 4)]
    }
    for (ax1.inner, 0, 32) {
      let cse_var_3 = (((tir.shift_right(ax0.ax1.outer.ax2.outer.fused.fused, 3)*4096) + (ax1.inner*128)) + (tir.bitwise_and(ax0.ax1.outer.ax2.outer.fused.fused, 7)*16))
      compute[ramp(0, 1, 16)] = x16(0)
      for (k.outer, 0, 24) {
        compute[ramp(0, 1, 16)] = (tir.call_llvm_pure_intrin((uint32)9785, (uint32)0, x16(0), x16(tir.reinterpret(placeholder[ramp((((tir.shift_right(ax0.ax1.outer.ax2.outer.fused.fused, 3)*3072) + (ax1.inner*96)) + (k.outer*4)), 1, 4)])), tir.reinterpret(T_layout_trans[ramp((k.outer*64), 1, 64)])) + compute[ramp(0, 1, 16)])
      }
      T_add[ramp(cse_var_3, 1, 16)] = (compute[ramp(0, 1, 16)] + placeholder[ramp(cse_var_3, 1, 16)])
    }

```
Future work can explore possibilities for eliminating runtime layout transform, or pipelining layout transform and compute to hide the overhead.

@elvin-n @mbrookhart @tkonolige @junrushao1994 @vinx13 