### PR TITLE
[BUGFIX][ARITH] Fix FloorMod Simplifier

### DIFF
--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -982,9 +982,13 @@ SplitExpr CanonicalSimplifier::Impl::SplitModConst(SplitExpr lhs, int64_t cval, 
     return lhs;
   }
   if (cval % lhs->scale == 0) {
-    // (x * c1) % (c2 * c1) => (x % c2) * c1
+    // The rationale:
+    //   (index % upper) / lower * scale % cval, given cval = scaled_cval * scale
+    //   by the rule (x * c1) % (c2 * c1) => (x % c2) * c1,
+    // = (index % upper) / lower % scaled_cval * scale
+    //   by the rule (x / c1) % c2  =>  (x % (c1 * c2)) / c1,
+    // = (index % upper) % (new_upper_factor) / lower * scale
     int64_t scaled_cval = cval / lhs->scale;
-    //  (x / c1) % c2  =>  (x % (c1 * c2)) / c2
     int64_t new_upper_factor = lhs->lower_factor * scaled_cval;
     // try to see if we can reduce the existing upper modular.
     if (lhs->upper_factor == SplitExprNode::kPosInf || lhs->upper_factor % new_upper_factor == 0) {

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -995,11 +995,13 @@ SplitExpr CanonicalSimplifier::Impl::SplitModConst(SplitExpr lhs, int64_t cval, 
       if (new_upper_factor < lhs->upper_factor && lhs->upper_factor != SplitExprNode::kPosInf) {
         auto updated = ToSplitExpr(this->VisitExpr(
             ModImpl(lhs->index, make_const(lhs.dtype(), new_upper_factor), div_mode)));
-        updated.CopyOnWrite()->scale = lhs->scale;
         // re-apply the lower_factor
         if (lhs->lower_factor != 1) {
-          return SplitDivConst(updated, lhs->lower_factor, div_mode);
+          auto ret = SplitDivConst(updated, lhs->lower_factor, div_mode);
+          ret.CopyOnWrite()->MulToSelf(lhs->scale);
+          return ret;
         } else {
+          updated.CopyOnWrite()->MulToSelf(lhs->scale);
           return updated;
         }
       } else {

--- a/tests/python/unittest/test_arith_canonical_simplify.py
+++ b/tests/python/unittest/test_arith_canonical_simplify.py
@@ -142,6 +142,7 @@ def test_canonical_mixed():
     ck.verify(tvm.te.max(x, 1) - tvm.te.max(x, 1), 0)
     ck.verify(tvm.te.min(x, 1) - tvm.te.min(x, 1), 0)
     ck.verify(x * x - x * x, 0)
+    ck.verify(tmod(tdiv(tmod(x, 20), 2) * 2, 4), tdiv(tmod(x, 4), 2) * 2)
 
     fld = tvm.te.floordiv
     ck.verify(fld(x, (z * z)) - fld(x, (z * z)), 0)


### PR DESCRIPTION
`relay.layout_transform(x, 'NCHW4c', 'NCHW2c')` this op is not simplified correctly in TIR by canonical simplifier. Specifically, there is a term `i%20/2*2%4` being simplified to `i%4` incorrectly. This is caused by an incomplete fix in #5505, which incorrectly swapped the order of `/2` and `*2`. A reproducible example:

```python
import tvm
from tvm import relay
import numpy as np
from tvm import relay


def main():
    import random
    random.seed(0)
    np.random.seed(0)
    O1 = 20
    xsh = (2, O1 // 4, 2, 2, 4)
    x = relay.var("x", shape=xsh)
    y = relay.layout_transform(x, 'NCHW4c', 'NCHW2c')
    func = relay.Function([x], y)
    mod = tvm.IRModule.from_expr(func)

    inp = np.zeros(xsh).astype(np.float32)
    with tvm.transform.PassContext(opt_level=0):
        res = relay.build_module.create_executor(
            'graph', mod, target='llvm', device=tvm.cpu()).evaluate()(inp)
    with tvm.transform.PassContext(opt_level=0, disabled_pass=['tir.Simplify']): #this pass invokes canonical simplifier
        res1 = relay.build_module.create_executor(
            'debug', mod, target='llvm', device=tvm.cpu()).evaluate()(inp)
    print('opt=\n', res.numpy())
    print('debug=\n', res1.numpy())
    np.testing.assert_allclose(res.numpy(), res1.numpy())


for i in range(10):
    main()
    print(f'{i}-th run passed')
```
