### PR TITLE
Simple workaround for PyTorch symbol crash problem in meta schedule test

### DIFF
--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -21,6 +21,8 @@ import pytest
 import numpy as np
 from typing import Tuple, List
 
+import torch
+
 import tvm
 from tvm import relay
 from tvm.ir import IRModule

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -21,7 +21,10 @@ import pytest
 import numpy as np
 from typing import Tuple, List
 
-import torch
+try:
+    import torch
+except ModuleNotFoundError:
+    pass
 
 import tvm
 from tvm import relay


### PR DESCRIPTION
Without this, people might see an error like 
```
free(): invalid pointer
Aborted (core dumped)
```

This is a simple workaround for PyTorch vs LLVM symbol crash problem, that doesn't involve rebuild.

@junrushao1994 @zxybazh 