### PR TITLE
[microTVM] Zephyr: refactor _find_openocd_serial_port

### DIFF
--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -4,8 +4,8 @@
         "model": "imxrt10xx",
         "is_qemu": false,
         "fpu": true,
-        "vid_hex": "",
-        "pid_hex": ""
+        "vid_hex": "1366",
+        "pid_hex": "0105"
     },
     "mps2_an521": {
         "board": "mps2_an521",


### PR DESCRIPTION
Refactor _find_openocd_serial_port() as a generic USB serial port
finder since other runners beyond openocd use it (e.g. jlink runner).

Also instead of using redundant hardcoded values in BOARD_USB_FIND_KW
dict, use idVendor and idProduct from boards.json. And don't use 'usb'
module to first find the serial number of the port and then pass it to
'serial' module to obtain the port path, instead search for the port
path directly via 'serial' module using the serial number (if provided)
or use idVendor and idProduct values taken from boards.json.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

