### PR TITLE
[Relay] Add icheck to avoid crash in opt_level=0 vm build

### DIFF
--- a/src/relay/transforms/memory_alloc.cc
+++ b/src/relay/transforms/memory_alloc.cc
@@ -140,6 +140,9 @@ class DialectRewriter : public transform::DeviceAwareExprMutator {
 
     VirtualDevice virtual_device = GetVirtualDevice(call);
     ICHECK(!virtual_device->IsFullyUnconstrained());
+    ICHECK(!scopes_.empty())
+        << "Calls out of a let block are not supported, do you forget to transform "
+        << "with ToANormalForm or set opt_level >= 1 in the pass context?";
     LetList& scope = scopes_.back();
 
     std::vector<Expr> new_args;


### PR DESCRIPTION
issue reported by
https://github.com/apache/tvm/issues/10324 and
https://discuss.tvm.apache.org/t/crash-when-opt-level-0/12131