### PR TITLE
[RELAY] [VIRTUALDEVICE] Change syntax for device planning and store parameter virtual devices in virtual_device_ field

### DIFF
--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -190,16 +190,6 @@ constexpr const char* kTarget = "target";
  */
 constexpr const char* kGlobalSymbol = "global_symbol";
 
-/*!
- * \brief The \p VirtualDevice which will hold each of the functions parameters.
- *
- * Only supported on Relay \p Functions. Generally added by the \p PlanDevices pass, but
- * may be included as an annotation on user programs.
- *
- * Type: Array<VirtualDevice>
- */
-constexpr const char* kParamVirtualDevice = "param_virtual_devices";
-
 }  // namespace attr
 }  // namespace tvm
 #endif  // TVM_IR_FUNCTION_H_

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -513,10 +513,9 @@ TVM_DLL Pass PlanDevices(CompilationConfig config);
 TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
- * \brief Bind the free variables to a Relay expression. This is a helper
- * function usually called by other pass functions to help optimizations.
- * Differs from Bind in that it does not implicitly add any new free variables
- * to function parameters.
+ * \brief Substitute variables with new variables (including function parameters).
+ * This is a helper  function usually called by other pass functions to help optimizations.
+ * Expects all values in the bind map to be Vars.
  *
  * \param expr The input expression.
  * \param binds The variable to expression map that will be used to help the
@@ -524,7 +523,7 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
  *
  * \return The updated expression.
  */
-TVM_DLL Expr ExprBind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
+TVM_DLL Expr SubstituteVars(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
  * \brief Apply rewrite rules to rewrite the expr in post DFS order. This

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -514,7 +514,7 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
  * \brief Substitute variables with new variables (including function parameters).
- * This is a helper  function usually called by other pass functions to help optimizations.
+ * This is a helper function usually called by other pass functions to help optimizations.
  * Expects all values in the bind map to be Vars.
  *
  * \param expr The input expression.

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -523,7 +523,7 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
  *
  * \return The updated expression.
  */
-TVM_DLL Expr SubstituteVars(const Expr& expr, const tvm::Map<Var, Expr>& binds);
+TVM_DLL Function SubstituteBoundVars(const Function& func, const tvm::Map<Var, Expr>& binds);
 
 /*!
  * \brief Apply rewrite rules to rewrite the expr in post DFS order. This

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -499,6 +499,10 @@ TVM_DLL Pass PlanDevices(CompilationConfig config);
 /*!
  * \brief Bind the free variables to a Relay expression. This is a helper
  * function usually called by other pass functions to help optimizations.
+ * If any free variables are introduced into a function, those are added
+ * to the functoin parameters.
+ * Additionally this may change the order of parameters if you map a variable
+ * to a variable.
  *
  * \param expr The input expression.
  * \param binds The variable to expression map that will be used to help the
@@ -507,6 +511,20 @@ TVM_DLL Pass PlanDevices(CompilationConfig config);
  * \return The updated expression.
  */
 TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
+
+/*!
+ * \brief Bind the free variables to a Relay expression. This is a helper
+ * function usually called by other pass functions to help optimizations.
+ * Differs from Bind in that it does not implicitly add any new free variables
+ * to function parameters.
+ *
+ * \param expr The input expression.
+ * \param binds The variable to expression map that will be used to help the
+ *        binding.
+ *
+ * \return The updated expression.
+ */
+TVM_DLL Expr ExprBinder(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
  * \brief Apply rewrite rules to rewrite the expr in post DFS order. This

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -524,7 +524,7 @@ TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
  *
  * \return The updated expression.
  */
-TVM_DLL Expr ExprBinder(const Expr& expr, const tvm::Map<Var, Expr>& binds);
+TVM_DLL Expr ExprBind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
  * \brief Apply rewrite rules to rewrite the expr in post DFS order. This

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -513,11 +513,11 @@ TVM_DLL Pass PlanDevices(CompilationConfig config);
 TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
 
 /*!
- * \brief Substitute variables with new variables (including function parameters).
+ * \brief Substitute variables with new variables (including function parameters) in a function.
  * This is a helper function usually called by other pass functions to help optimizations.
  * Expects all values in the bind map to be Vars.
  *
- * \param expr The input expression.
+ * \param func The input function.
  * \param binds The variable to expression map that will be used to help the
  *        binding.
  *

--- a/include/tvm/target/virtual_device.h
+++ b/include/tvm/target/virtual_device.h
@@ -367,7 +367,7 @@ class VirtualDeviceCache {
  *
  * Type: VirtualDevice
  */
-constexpr const char* kVirtualDevice = "result_virtual_device";
+constexpr const char* kVirtualDevice = "virtual_device";
 
 }  // namespace tvm
 

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -452,7 +452,8 @@ class Parser {
    * to unique variable nodes.
    * If a virtual device is specified, sets the virtual device of the variable.
    */
-  Var BindVar(const std::string& name, const relay::Type& type_annotation, Optional<VirtualDevice> virtual_device = Optional<VirtualDevice>()) {
+  Var BindVar(const std::string& name, const relay::Type& type_annotation,
+              Optional<VirtualDevice> virtual_device = Optional<VirtualDevice>()) {
     auto var = Var(name, type_annotation);
     var->virtual_device_ = virtual_device.value_or(VirtualDevice::FullyUnconstrained());
     VLOG(1) << "Binding var named " << name << " to variable node " << PrettyPrint(var);
@@ -1118,7 +1119,9 @@ class Parser {
               VLOG(1) << "Fake attributes for function parameter: " << fake_attrs;
               Match(TokenType::kRCurly);
               if (fake_attrs.size() == 1 && fake_attrs.count(kVirtualDevice)) {
-                ICHECK(fake_attrs[kVirtualDevice].as<VirtualDeviceNode>()) << "Expected the " << kVirtualDevice << " to have type VirtualDeviceNode, but got " << virtual_device->GetTypeKey();
+                ICHECK(fake_attrs[kVirtualDevice].as<VirtualDeviceNode>())
+                    << "Expected the " << kVirtualDevice
+                    << " to have type VirtualDeviceNode, but got " << virtual_device->GetTypeKey();
                 virtual_device = Downcast<VirtualDevice>(fake_attrs[kVirtualDevice]);
               }
             }
@@ -1162,7 +1165,8 @@ class Parser {
               << vid->GetTypeKey();
 
           DictAttrs attrs;
-          // Don't fill the raw_attrs in if there's nothing other than kVirtualDevice in the attributes
+          // Don't fill the raw_attrs in if there's nothing other than kVirtualDevice in the
+          // attributes
           if (raw_attrs.size() > 1) {
             raw_attrs.erase(kVirtualDevice);
             attrs = DictAttrs(raw_attrs);

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -1162,7 +1162,7 @@ class Parser {
               << vid->GetTypeKey();
 
           DictAttrs attrs;
-          // 
+          // Don't fill the raw_attrs in if there's nothing other than kVirtualDevice in the attributes
           if (raw_attrs.size() > 1) {
             raw_attrs.erase(kVirtualDevice);
             attrs = DictAttrs(raw_attrs);

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -1116,7 +1116,7 @@ class Parser {
             VirtualDevice virtual_device;
             if (WhenMatch(TokenType::kLCurly)) {
               Map<String, ObjectRef> fake_attrs = ParseAttrs();
-              VLOG(1) << "Fake attributes for function parameter: " << fake_attrs;
+              VLOG(9) << "Fake attributes for function parameter: " << fake_attrs;
               Match(TokenType::kRCurly);
               if (fake_attrs.size() == 1 && fake_attrs.count(kVirtualDevice)) {
                 ICHECK(fake_attrs[kVirtualDevice].as<VirtualDeviceNode>())

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -1160,8 +1160,14 @@ class Parser {
           ICHECK(vid.as<VirtualDeviceNode>())
               << "Expected the " << kVirtualDevice << " to have type VirtualDeviceNode, but got "
               << vid->GetTypeKey();
-          raw_attrs.erase(kVirtualDevice);
-          Function func = relay::Function(params, body, ret_type, generics, DictAttrs(raw_attrs));
+
+          DictAttrs attrs;
+          // 
+          if (raw_attrs.size() > 1) {
+            raw_attrs.erase(kVirtualDevice);
+            attrs = DictAttrs(raw_attrs);
+          }
+          Function func = relay::Function(params, body, ret_type, generics, attrs);
           func->virtual_device_ = vid;
           return func;
         } else {

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -450,9 +450,12 @@ class Parser {
    *
    * "x" -> Var("x"), these are needed to map from the raw string names
    * to unique variable nodes.
+   * If a virtual device is specified, sets the virtual device of the variable.
    */
-  Var BindVar(const std::string& name, const relay::Type& type_annotation) {
+  Var BindVar(const std::string& name, const relay::Type& type_annotation, Optional<VirtualDevice> virtual_device = Optional<VirtualDevice>()) {
     auto var = Var(name, type_annotation);
+    var->virtual_device_ = virtual_device.value_or(VirtualDevice::FullyUnconstrained());
+    VLOG(1) << "Binding var named " << name << " to variable node " << PrettyPrint(var);
     this->expr_scopes.Add(name, var);
     return var;
   }
@@ -1107,11 +1110,24 @@ class Parser {
           [&]() {
             auto token = Match(TokenType::kLocal);
             auto string = token.ToString();
+
+            // The fake attributes where the virtual device is specified.
+            VirtualDevice virtual_device;
+            if (WhenMatch(TokenType::kLCurly)) {
+              Map<String, ObjectRef> fake_attrs = ParseAttrs();
+              VLOG(1) << "Fake attributes for function parameter: " << fake_attrs;
+              Match(TokenType::kRCurly);
+              if (fake_attrs.size() == 1 && fake_attrs.count(kVirtualDevice)) {
+                ICHECK(fake_attrs[kVirtualDevice].as<VirtualDeviceNode>()) << "Expected the " << kVirtualDevice << " to have type VirtualDeviceNode, but got " << virtual_device->GetTypeKey();
+                virtual_device = Downcast<VirtualDevice>(fake_attrs[kVirtualDevice]);
+              }
+            }
+
             Type type;
             if (WhenMatch(TokenType::kColon)) {
               type = ParseType();
             }
-            return BindVar(string, type);
+            return BindVar(string, type, virtual_device);
           },
           [&] {
             auto is_ident = Lookahead(1)->token_type == TokenType::kIdentifier;

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -223,6 +223,10 @@ Doc RelayTextPrinter::AllocVar(const Var& var) {
   if (var->type_annotation.defined()) {
     val << ": " << Print(var->type_annotation);
   }
+  if (var->virtual_device() != VirtualDevice::FullyUnconstrained()) {
+    VLOG(9) << "Virtual device for " << var << " is defined, and is: " << var->virtual_device();
+    val << kVirtualDevice << "=" << PrintAttributeValue(var->virtual_device());
+  }
   val << PrintOptionalInfo(var);
   return val;
 }

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -454,7 +454,6 @@ Doc RelayTextPrinter::PrintFunc(const Doc& prefix, const relay::Function& fn) {
   if (fn->ret_type.defined()) {
     doc << "-> " << Print(fn->ret_type) << " ";
   }
-
   doc << PrintBody(fn->body);
   return doc;
 }

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -220,13 +220,13 @@ Doc RelayTextPrinter::AllocVar(const Var& var) {
   }
   Doc val = GetUniqueName("%" + name);
   memo_[var] = val;
+  if (!var->virtual_device()->IsFullyUnconstrained()) {
+    val << " {" << kVirtualDevice << "=" << PrintAttributeValue(var->virtual_device()) << "}";
+  }
   if (var->type_annotation.defined()) {
     val << ": " << Print(var->type_annotation);
   }
-  if (!var->virtual_device()->IsFullyUnconstrained()) {
-    // VLOG(9) << "Virtual device for " << var << " is defined, and is: " << var->virtual_device();
-    val << " {" << kVirtualDevice << "=" << PrintAttributeValue(var->virtual_device()) << "}";
-  }
+
   val << PrintOptionalInfo(var);
   return val;
 }
@@ -335,11 +335,6 @@ Doc RelayTextPrinter::PrintExpr(const Expr& expr, bool meta, bool try_inline, bo
 // first time.
 Doc RelayTextPrinter::VisitExpr_(const VarNode* op) {
   Doc var_doc = AllocVar(GetRef<Var>(op));
-  /*if (op->virtual_device()->IsFullyUnconstrained()) {
-    return var_doc;
-  } else {
-    return var_doc << " {" << kVirtualDevice << "=" << PrettyPrint(op->virtual_device()) << "}";
-  }*/
   return var_doc;
 }
 

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -223,9 +223,9 @@ Doc RelayTextPrinter::AllocVar(const Var& var) {
   if (var->type_annotation.defined()) {
     val << ": " << Print(var->type_annotation);
   }
-  if (var->virtual_device() != VirtualDevice::FullyUnconstrained()) {
-    VLOG(9) << "Virtual device for " << var << " is defined, and is: " << var->virtual_device();
-    val << kVirtualDevice << "=" << PrintAttributeValue(var->virtual_device());
+  if (!var->virtual_device()->IsFullyUnconstrained()) {
+    //VLOG(9) << "Virtual device for " << var << " is defined, and is: " << var->virtual_device();
+    val << " {" << kVirtualDevice << "=" << PrintAttributeValue(var->virtual_device()) << "}";
   }
   val << PrintOptionalInfo(var);
   return val;
@@ -333,7 +333,15 @@ Doc RelayTextPrinter::PrintExpr(const Expr& expr, bool meta, bool try_inline, bo
 
 // Should only be triggered when op is a free variable being visited for the
 // first time.
-Doc RelayTextPrinter::VisitExpr_(const VarNode* op) { return AllocVar(GetRef<Var>(op)); }
+Doc RelayTextPrinter::VisitExpr_(const VarNode* op) { 
+  Doc var_doc = AllocVar(GetRef<Var>(op));
+  /*if (op->virtual_device()->IsFullyUnconstrained()) {
+    return var_doc;
+  } else {
+    return var_doc << " {" << kVirtualDevice << "=" << PrettyPrint(op->virtual_device()) << "}";
+  }*/
+  return var_doc;
+  }
 
 /*!
  * \brief special method to print out const scalar
@@ -449,7 +457,7 @@ Doc RelayTextPrinter::PrintFunc(const Doc& prefix, const relay::Function& fn) {
   for (const Doc& d : PrintDictAttrs(fn->attrs)) {
     params.push_back(d);
   }
-  if (fn->virtual_device() != VirtualDevice::FullyUnconstrained()) {
+  if (!fn->virtual_device()->IsFullyUnconstrained()) {
     Doc vid_doc;
     vid_doc << kVirtualDevice << "=" << PrintAttributeValue(fn->virtual_device());
     params.push_back(vid_doc);

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -333,10 +333,7 @@ Doc RelayTextPrinter::PrintExpr(const Expr& expr, bool meta, bool try_inline, bo
 
 // Should only be triggered when op is a free variable being visited for the
 // first time.
-Doc RelayTextPrinter::VisitExpr_(const VarNode* op) {
-  Doc var_doc = AllocVar(GetRef<Var>(op));
-  return var_doc;
-}
+Doc RelayTextPrinter::VisitExpr_(const VarNode* op) { return AllocVar(GetRef<Var>(op)); }
 
 /*!
  * \brief special method to print out const scalar

--- a/src/printer/relay_text_printer.cc
+++ b/src/printer/relay_text_printer.cc
@@ -224,7 +224,7 @@ Doc RelayTextPrinter::AllocVar(const Var& var) {
     val << ": " << Print(var->type_annotation);
   }
   if (!var->virtual_device()->IsFullyUnconstrained()) {
-    //VLOG(9) << "Virtual device for " << var << " is defined, and is: " << var->virtual_device();
+    // VLOG(9) << "Virtual device for " << var << " is defined, and is: " << var->virtual_device();
     val << " {" << kVirtualDevice << "=" << PrintAttributeValue(var->virtual_device()) << "}";
   }
   val << PrintOptionalInfo(var);
@@ -333,7 +333,7 @@ Doc RelayTextPrinter::PrintExpr(const Expr& expr, bool meta, bool try_inline, bo
 
 // Should only be triggered when op is a free variable being visited for the
 // first time.
-Doc RelayTextPrinter::VisitExpr_(const VarNode* op) { 
+Doc RelayTextPrinter::VisitExpr_(const VarNode* op) {
   Doc var_doc = AllocVar(GetRef<Var>(op));
   /*if (op->virtual_device()->IsFullyUnconstrained()) {
     return var_doc;
@@ -341,7 +341,7 @@ Doc RelayTextPrinter::VisitExpr_(const VarNode* op) {
     return var_doc << " {" << kVirtualDevice << "=" << PrettyPrint(op->virtual_device()) << "}";
   }*/
   return var_doc;
-  }
+}
 
 /*!
  * \brief special method to print out const scalar

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -252,21 +252,16 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
       // Do that flattening on-the-fly here.
       Function inner_func = Downcast<Function>(func->body);
       std::vector<Var> params;
-      std::vector<VirtualDevice> param_virtual_devices;
       params.reserve(func->params.size() + inner_func->params.size());
-      param_virtual_devices.reserve(func->params.size() + inner_func->params.size());
       param_device_indexes.reserve(func->params.size() + inner_func->params.size());
       for (size_t i = 0; i < func->params.size(); ++i) {
         params.emplace_back(func->params[i]);
-        VirtualDevice param_virtual_device = GetFunctionParamVirtualDevice(func.get(), i);
-        param_virtual_devices.push_back(param_virtual_device);
-        param_device_indexes.push_back(GetDeviceIndex(param_virtual_device));
+        param_device_indexes.push_back(GetDeviceIndex(func->params[i]->virtual_device()));
       }
       for (size_t i = 0; i < inner_func->params.size(); ++i) {
         params.emplace_back(inner_func->params[i]);
-        VirtualDevice param_virtual_device = GetFunctionParamVirtualDevice(inner_func.get(), i);
-        param_virtual_devices.push_back(param_virtual_device);
-        param_device_indexes.push_back(GetDeviceIndex(param_virtual_device));
+
+        param_device_indexes.push_back(GetDeviceIndex(inner_func->params[i]->virtual_device()));
       }
       std::vector<TypeVar> type_params;
       type_params.reserve(func->type_params.size() + inner_func->type_params.size());
@@ -278,13 +273,13 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
       }
       Function flattened_func = Function(params, inner_func->body, inner_func->ret_type,
                                          type_params, func->attrs, func->span);
-      VisitExpr(MaybeFunctionOnDevice(flattened_func, param_virtual_devices,
-                                      GetFunctionResultVirtualDevice(inner_func.get())));
+      flattened_func->virtual_device_ = inner_func->virtual_device();
+      VisitExpr(flattened_func);
     } else {
       param_device_indexes.reserve(func->params.size());
       for (size_t i = 0; i < func->params.size(); ++i) {
         param_device_indexes.push_back(
-            GetDeviceIndex(GetFunctionParamVirtualDevice(func.get(), i)));
+            GetDeviceIndex(func->params[i]->virtual_device()));
       }
       VisitExpr(func);
     }

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -278,8 +278,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
     } else {
       param_device_indexes.reserve(func->params.size());
       for (size_t i = 0; i < func->params.size(); ++i) {
-        param_device_indexes.push_back(
-            GetDeviceIndex(func->params[i]->virtual_device()));
+        param_device_indexes.push_back(GetDeviceIndex(func->params[i]->virtual_device()));
       }
       VisitExpr(func);
     }

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -111,7 +111,6 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
     auto free_type_vars = FreeTypeVars(func, module_);
 
     Array<Var> captured_vars;
-    std::vector<VirtualDevice> captured_var_virtual_devices;
     bool recursive = false;
     for (const auto& var : free_vars) {
       if (!letrec_.empty() && var == letrec_.back()) {
@@ -119,7 +118,6 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
         continue;
       }
       captured_vars.push_back(var);
-      captured_var_virtual_devices.push_back(GetVirtualDevice(var));
     }
 
     // Freshen all the captured vars.
@@ -198,8 +196,7 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
       lifted_func =
           Function(typed_captured_vars, rebound_body, /*ret_type=*/func->func_type_annotation(),
                    free_type_vars, /*attrs=*/{}, func->span);
-      lifted_func =
-          MaybeFunctionOnDevice(lifted_func, captured_var_virtual_devices, result_virtual_device);
+      lifted_func->virtual_device_ = result_virtual_device;
       lifted_func = MarkClosure(lifted_func);
     }
 

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -127,6 +127,7 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
     Map<Var, Expr> rebinding_map;
     for (auto free_var : captured_vars) {
       auto var = Var(free_var->name_hint(), free_var->checked_type());
+      var->virtual_device_ = free_var->virtual_device();
       typed_captured_vars.push_back(var);
       rebinding_map.Set(free_var, var);
     }
@@ -173,6 +174,8 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
     if (captured_vars.empty() && free_type_vars.empty()) {
       lifted_func = Function(body->params, body->body, body->ret_type, body->type_params,
                              body->attrs, body->span);
+      // We also need to copy the virtual device
+      lifted_func->virtual_device_ = body->virtual_device();
     } else {
       // When a closure is locally bound in a program, we have its full type information
       // avalible to us.
@@ -187,6 +190,8 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
       // construct the "closure" function with fully annotated arguments, no longer relying
       // on type inference.
       size_t before_arity = body->params.size();
+      VLOG(1) << "Binding " << rebinding_map << " into\n" << PrettyPrint(body->body);
+      // I think the problem is in here!
       auto rebound_body = WithFields(func, func->params, Bind(body->body, rebinding_map));
       size_t after_arity = rebound_body->params.size();
       CHECK_EQ(before_arity, after_arity);

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -125,7 +125,7 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
     Map<Var, Expr> rebinding_map;
     for (auto free_var : captured_vars) {
       auto var = Var(free_var->name_hint(), free_var->checked_type());
-      var->virtual_device_ = free_var->virtual_device();
+      var->virtual_device_ = GetVirtualDevice(free_var);
       typed_captured_vars.push_back(var);
       rebinding_map.Set(free_var, var);
     }
@@ -188,8 +188,7 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
       // construct the "closure" function with fully annotated arguments, no longer relying
       // on type inference.
       size_t before_arity = body->params.size();
-      VLOG(1) << "Binding " << rebinding_map << " into\n" << PrettyPrint(body->body);
-      // I think the problem is in here!
+      VLOG(9) << "Binding " << rebinding_map << " into\n" << PrettyPrint(body->body);
       auto rebound_body = WithFields(func, func->params, Bind(body->body, rebinding_map));
       size_t after_arity = rebound_body->params.size();
       CHECK_EQ(before_arity, after_arity);

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -496,17 +496,17 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
       set.insert(v);
     }
     for (const auto& v : FreeVars(ret)) {
-          if (set.count(v) == 0) {
-            new_params.push_back(v);
-            if (!v->virtual_device()->IsFullyUnconstrained()) {
-              // TODO(mbs): The function has been annotated with a device, which means we are supposed
-              // to be preserving device annotations on every transformation. However there's no
-              // such context for the free vars in args_map.
-              LOG(WARNING) << "introduced free var '" << PrettyPrint(v)
-                          << "' into function body but no device is known for it";
-            }
-          }
+      if (set.count(v) == 0) {
+        new_params.push_back(v);
+        if (!v->virtual_device()->IsFullyUnconstrained()) {
+          // TODO(mbs): The function has been annotated with a device, which means we are supposed
+          // to be preserving device annotations on every transformation. However there's no
+          // such context for the free vars in args_map.
+          LOG(WARNING) << "introduced free var '" << PrettyPrint(v)
+                       << "' into function body but no device is known for it";
         }
+      }
+    }
 
     VLOG(4) << "Expr:\n" << expr;
     VLOG(4) << "Ret:\n" << ret;
@@ -539,11 +539,13 @@ Expr SubstituteVars(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
         if (const VarNode* var = args_map[func->params[i]].as<VarNode>()) {
           new_params.push_back(GetRef<Var>(var));
         } else {
-          ICHECK(false) << "Expected all values in args_map to be vars, but found " << args_map[func->params[i]]->GetTypeKey();
+          ICHECK(false) << "Expected all values in args_map to be vars, but found "
+                        << args_map[func->params[i]]->GetTypeKey();
         }
       }
     }
-    auto ret = Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
+    auto ret =
+        Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
     ret->virtual_device_ = func->virtual_device();
     return ret;
   } else {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -528,6 +528,10 @@ TVM_REGISTER_GLOBAL("relay.ir.Bind").set_body([](TVMArgs args, TVMRetValue* ret)
   }
 });
 
+Expr ExprBind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
+  return ExprBinder(args_map).VisitExpr(expr);
+}
+
 void ExpandANormalForm(const LetNode* op, std::function<void(const LetNode*)> pre_visit,
                        std::function<void(const LetNode*)> post_visit) {
   std::stack<const LetNode*> stack;

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -511,6 +511,12 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
         Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
     ret =
         MaybeFunctionOnDevice(ret, new_param_virtual_devices, GetFunctionResultVirtualDevice(func));
+    VLOG(4) << "Expr:\n" << expr;
+    VLOG(4) << "Ret:\n" << ret;
+    // For the conditional test that's failing, the parameter y that is inside
+    // the nested let is getting bound and then is no longer free? which is confusing.
+    //
+
     ICHECK_EQ(FreeVars(expr).size(), FreeVars(ret).size());
     return std::move(ret);
   } else {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -477,12 +477,13 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
     Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
     Array<Var> new_params;
     for (size_t i = 0; i < func->params.size(); ++i) {
-      if (!args_map.count(func->params[i])) { // I think in higher order cases we do want to replace the parameter as well?
+      if (!args_map.count(func->params[i])) {  // I think in higher order cases we do want to
+                                               // replace the parameter as well?
         new_params.push_back(func->params[i]);
-      } else if(const auto var = args_map[func->params[i]].as<VarNode>()) {
+      } else if (const auto var = args_map[func->params[i]].as<VarNode>()) {
         // If we're mapping a variable to a variable and not a normal expr, then we want to
         // put the substitution in the new parameters.
-          new_params.push_back(GetRef<Var>(var));
+        new_params.push_back(GetRef<Var>(var));
       }
     }
     if (new_body.same_as(func->body) && new_params.size() == func->params.size()) {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -490,10 +490,10 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
     }
     auto ret =
         Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
-    ret->virtual_device_ = GetFunctionResultVirtualDevice(func);
+    ret->virtual_device_ = func->virtual_device();
     ret =
         Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
-    ret->virtual_device_ = GetFunctionResultVirtualDevice(func);
+    ret->virtual_device_ = func->virtual_device();
 
     VLOG(4) << "Expr:\n" << expr;
     VLOG(4) << "Ret:\n" << ret;

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -501,6 +501,10 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
       }
     }
 
+    ret =
+        Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
+    ret->virtual_device_ = func->virtual_device();
+
     VLOG(4) << "Expr:\n" << expr;
     VLOG(4) << "Ret:\n" << ret;
 
@@ -521,29 +525,25 @@ TVM_REGISTER_GLOBAL("relay.ir.Bind").set_body([](TVMArgs args, TVMRetValue* ret)
   }
 });
 
-Expr SubstituteVars(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
-  if (const FunctionNode* func = expr.as<FunctionNode>()) {
-    Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
-    Array<Var> new_params;
-    for (size_t i = 0; i < func->params.size(); i++) {
-      if (!args_map.count(func->params[i])) {
-        new_params.push_back(func->params[i]);
+Function SubstituteBoundVars(const Function& func, const tvm::Map<Var, Expr>& args_map) {
+  Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
+  Array<Var> new_params;
+  for (size_t i = 0; i < func->params.size(); i++) {
+    if (!args_map.count(func->params[i])) {
+      new_params.push_back(func->params[i]);
+    } else {
+      if (const VarNode* var = args_map[func->params[i]].as<VarNode>()) {
+        new_params.push_back(GetRef<Var>(var));
       } else {
-        if (const VarNode* var = args_map[func->params[i]].as<VarNode>()) {
-          new_params.push_back(GetRef<Var>(var));
-        } else {
-          ICHECK(false) << "Expected all values in args_map to be vars, but found "
-                        << args_map[func->params[i]]->GetTypeKey();
-        }
+        ICHECK(false) << "Expected all values in args_map to be vars, but found "
+                      << args_map[func->params[i]]->GetTypeKey();
       }
     }
-    auto ret =
-        Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
-    ret->virtual_device_ = func->virtual_device();
-    return ret;
-  } else {
-    return ExprBinder(args_map).VisitExpr(expr);
   }
+  auto ret =
+      Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
+  ret->virtual_device_ = func->virtual_device();
+  return ret;
 }
 
 void ExpandANormalForm(const LetNode* op, std::function<void(const LetNode*)> pre_visit,

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -472,7 +472,6 @@ class ExprBinder : public MixedModeMutator, PatternMutator {
   const tvm::Map<Var, Expr>& args_map_;
 };
 
-// I need to make Bind not call function on device.
 Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
   if (const FunctionNode* func = expr.as<FunctionNode>()) {
     Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
@@ -498,9 +497,6 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
 
     VLOG(4) << "Expr:\n" << expr;
     VLOG(4) << "Ret:\n" << ret;
-    // For the conditional test that's failing, the parameter y that is inside
-    // the nested let is getting bound and then is no longer free? which is confusing.
-    //
 
     ICHECK_EQ(FreeVars(expr).size(), FreeVars(ret).size());
     return std::move(ret);

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -472,31 +472,41 @@ class ExprBinder : public MixedModeMutator, PatternMutator {
   const tvm::Map<Var, Expr>& args_map_;
 };
 
+// This function should be called SubstAndBind, since it assumes any variables introduced
+// in the substitution right hand side should be implicitly bound in the function.
 Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
   if (const FunctionNode* func = expr.as<FunctionNode>()) {
     Expr new_body = ExprBinder(args_map).VisitExpr(func->body);
     Array<Var> new_params;
-    bool params_unchanged = true;
     for (size_t i = 0; i < func->params.size(); ++i) {
       if (!args_map.count(func->params[i])) {
         new_params.push_back(func->params[i]);
-      } else if (const auto var = args_map[func->params[i]].as<VarNode>()) {
-        // If we're mapping a variable to a variable and not a normal expr, then we want to
-        // put the substitution in the new parameters.
-        params_unchanged = false;
-        new_params.push_back(GetRef<Var>(var));
       }
     }
-    if (new_body.same_as(func->body) && new_params.size() == func->params.size() &&
-        params_unchanged) {
+    if (new_body.same_as(func->body) && new_params.size() == func->params.size()) {
       return expr;
     }
+
     auto ret =
         Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
     ret->virtual_device_ = func->virtual_device();
-    ret =
-        Function(new_params, new_body, func->ret_type, func->type_params, func->attrs, func->span);
-    ret->virtual_device_ = func->virtual_device();
+
+    std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> set;
+    for (const auto& v : FreeVars(expr)) {
+      set.insert(v);
+    }
+    for (const auto& v : FreeVars(ret)) {
+          if (set.count(v) == 0) {
+            new_params.push_back(v);
+            if (!v->virtual_device()->IsFullyUnconstrained()) {
+              // TODO(mbs): The function has been annotated with a device, which means we are supposed
+              // to be preserving device annotations on every transformation. However there's no
+              // such context for the free vars in args_map.
+              LOG(WARNING) << "introduced free var '" << PrettyPrint(v)
+                          << "' into function body but no device is known for it";
+            }
+          }
+        }
 
     VLOG(4) << "Expr:\n" << expr;
     VLOG(4) << "Ret:\n" << ret;

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -487,7 +487,8 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
         new_params.push_back(GetRef<Var>(var));
       }
     }
-    if (new_body.same_as(func->body) && new_params.size() == func->params.size() && params_unchanged) {
+    if (new_body.same_as(func->body) && new_params.size() == func->params.size() &&
+        params_unchanged) {
       return expr;
     }
     auto ret =

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -498,13 +498,6 @@ Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& args_map) {
     for (const auto& v : FreeVars(ret)) {
       if (set.count(v) == 0) {
         new_params.push_back(v);
-        if (!v->virtual_device()->IsFullyUnconstrained()) {
-          // TODO(mbs): The function has been annotated with a device, which means we are supposed
-          // to be preserving device annotations on every transformation. However there's no
-          // such context for the free vars in args_map.
-          LOG(WARNING) << "introduced free var '" << PrettyPrint(v)
-                       << "' into function body but no device is known for it";
-        }
       }
     }
 

--- a/src/relay/op/memory/on_device.cc
+++ b/src/relay/op/memory/on_device.cc
@@ -143,12 +143,5 @@ OnDeviceProps GetOnDeviceProps(const Expr& expr) {
   return {};
 }
 
-VirtualDevice GetFunctionParamVirtualDevice(const FunctionNode* function_node, size_t i) {
-  ICHECK_LT(i, function_node->params.size())
-      << "param index " << i << " out of range for function of arity "
-      << function_node->params.size();
-  return function_node->params[i]->virtual_device();
-}
-
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/op/memory/on_device.cc
+++ b/src/relay/op/memory/on_device.cc
@@ -154,11 +154,14 @@ Function FunctionOnDevice(Function function, Array<VirtualDevice> param_virtual_
     Var annotated_param = WithFields(function->params[i], {}, {}, param_virtual_devices[i]);
     annotated_params.push_back(annotated_param);
     // We are creating new parameters so we need to substitute uses of the old parameters with the new ones
-    free_var_bind_map.Set(function->params[i], annotated_param);
+    if (!annotated_param.same_as(function->params[i])) {
+      free_var_bind_map.Set(function->params[i], annotated_param);
+      VLOG(1) << "Bind map has: " << function->params[i] << " with VID " << function->params[i]->virtual_device() << " with value " << annotated_param << " with VID " << annotated_param->virtual_device();
+    }
   }
-  VLOG(1) << "Original Body:\n" << function->body;
-  Expr bound_body = Bind(function->body, free_var_bind_map);
-  VLOG(1) << "Bound body:\n" << bound_body;
+  //VLOG(1) << "Original Body:\n" << function->body;
+  //Expr bound_body = Bind(function->body, free_var_bind_map);
+  //VLOG(1) << "Bound body:\n" << bound_body;
 
   // TODO(@electriclilies): deal with CF & higher order fns
   auto func = WithFields(function, annotated_params, Bind(function->body, free_var_bind_map), {}, {}, {}, std::move(result_virtual_device));

--- a/src/relay/op/memory/on_device.cc
+++ b/src/relay/op/memory/on_device.cc
@@ -27,9 +27,9 @@
 
 #include <tvm/relay/attrs/annotation.h>
 #include <tvm/relay/expr.h>
-#include <tvm/relay/transform.h>
 #include <tvm/relay/op.h>
 #include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
 
 #include "../../transforms/infer_layout_utils.h"
 #include "../type_relations.h"

--- a/src/relay/op/memory/on_device.cc
+++ b/src/relay/op/memory/on_device.cc
@@ -156,8 +156,11 @@ Function FunctionOnDevice(Function function, Array<VirtualDevice> param_virtual_
     // We are creating new parameters so we need to substitute uses of the old parameters with the new ones
     free_var_bind_map.Set(function->params[i], annotated_param);
   }
-  
-  // bind here? in helper?
+  VLOG(1) << "Original Body:\n" << function->body;
+  Expr bound_body = Bind(function->body, free_var_bind_map);
+  VLOG(1) << "Bound body:\n" << bound_body;
+
+  // TODO(@electriclilies): deal with CF & higher order fns
   auto func = WithFields(function, annotated_params, Bind(function->body, free_var_bind_map), {}, {}, {}, std::move(result_virtual_device));
   VLOG(1) << "Annotated func: " << PrettyPrint(func);
   return func;

--- a/src/relay/op/memory/on_device.cc
+++ b/src/relay/op/memory/on_device.cc
@@ -143,10 +143,6 @@ OnDeviceProps GetOnDeviceProps(const Expr& expr) {
   return {};
 }
 
-VirtualDevice GetFunctionResultVirtualDevice(const FunctionNode* function_node) {
-  return function_node->virtual_device();
-}
-
 VirtualDevice GetFunctionParamVirtualDevice(const FunctionNode* function_node, size_t i) {
   ICHECK_LT(i, function_node->params.size())
       << "param index " << i << " out of range for function of arity "

--- a/src/relay/op/memory/on_device.h
+++ b/src/relay/op/memory/on_device.h
@@ -155,12 +155,6 @@ const NodeType* AsIgnoringOnDevice(const Expr& expr) {
 }
 
 /*!
- * \brief Returns the \p VirtualDevice for the resut of \p function_node, or the unconstrained
- * \p VirtualDevice if function does not have the "result_virtual_device" annotation.
- */
-VirtualDevice GetFunctionResultVirtualDevice(const FunctionNode* function_node);
-
-/*!
  * \brief Returns the \p VirtualDevice for the \p i'th parameter of \p function_node, or
  * the unconstrained \p VirtualDevice if function does not have the "param_virtual_devices"
  * annotation.

--- a/src/relay/op/memory/on_device.h
+++ b/src/relay/op/memory/on_device.h
@@ -155,20 +155,6 @@ const NodeType* AsIgnoringOnDevice(const Expr& expr) {
 }
 
 /*!
- * \brief Returns \p function annotated with "param_virtual_devices" and "result_virtual_device"
- * attributes capturing parameter and result \p VirtualDevices respectively.
- */
-Function FunctionOnDevice(Function function, Array<VirtualDevice> param_virtual_devices,
-                          VirtualDevice body_virtual_device);
-
-/*!
- * \brief As for \p FunctionOnDevice, but returns \p function unchanged if all parameters and
- * result \p VirtualDevices are unconstrained.
- */
-Function MaybeFunctionOnDevice(Function function, Array<VirtualDevice> param_virtual_devices,
-                               VirtualDevice result_virtual_device);
-
-/*!
  * \brief Returns the \p VirtualDevice for the resut of \p function_node, or the unconstrained
  * \p VirtualDevice if function does not have the "result_virtual_device" annotation.
  */

--- a/src/relay/op/memory/on_device.h
+++ b/src/relay/op/memory/on_device.h
@@ -154,13 +154,6 @@ const NodeType* AsIgnoringOnDevice(const Expr& expr) {
   return props.body.as<NodeType>();
 }
 
-/*!
- * \brief Returns the \p VirtualDevice for the \p i'th parameter of \p function_node, or
- * the unconstrained \p VirtualDevice if function does not have the "param_virtual_devices"
- * annotation.
- */
-VirtualDevice GetFunctionParamVirtualDevice(const FunctionNode* function_node, size_t i);
-
 }  // namespace relay
 }  // namespace tvm
 

--- a/src/relay/transforms/device_aware_visitors.cc
+++ b/src/relay/transforms/device_aware_visitors.cc
@@ -38,7 +38,7 @@ LexicalOnDeviceMixin::LexicalOnDeviceMixin(const Optional<IRModule>& maybe_mod) 
   if (maybe_mod) {
     for (const auto& kv : maybe_mod.value()->functions) {
       if (const auto* function_node = kv.second.as<FunctionNode>()) {
-        VirtualDevice virtual_device = GetFunctionResultVirtualDevice(function_node);
+        VirtualDevice virtual_device = function_node->virtual_device();
         if (!virtual_device->IsFullyUnconstrained()) {
           VLOG(2) << "global '" << kv.first->name_hint << "' has virtual device " << virtual_device;
           global_var_virtual_devices_.emplace(kv.first, virtual_device);
@@ -74,7 +74,7 @@ VirtualDevice LexicalOnDeviceMixin::GetVirtualDevice(const Expr& expr) const {
       }
       // else: fallthrough to unconstrained
     } else {
-      return GetFunctionResultVirtualDevice(function_node);
+      return function_node->virtual_device();
     }
   } else {
     if (!expr_virtual_devices_.empty()) {
@@ -136,7 +136,7 @@ void DeviceAwareExprVisitor::VisitExpr_(const FunctionNode* function_node) {
       PushBoundVar(function_node->params[i], GetFunctionParamVirtualDevice(function_node, i));
     }
     // Entering scope of function body.
-    PushVirtualDevice(GetFunctionResultVirtualDevice(function_node));
+    PushVirtualDevice(function_node->virtual_device());
     EnterFunctionBody();
 
     DeviceAwareVisitExpr_(function_node);
@@ -222,7 +222,7 @@ Expr DeviceAwareExprMutator::VisitExpr_(const FunctionNode* function_node) {
       PushBoundVar(function_node->params[i], GetFunctionParamVirtualDevice(function_node, i));
     }
     // Entering scope of function body.
-    PushVirtualDevice(GetFunctionResultVirtualDevice(function_node));
+    PushVirtualDevice(function_node->virtual_device());
     EnterFunctionBody();
 
     Expr result = DeviceAwareVisitExpr_(function_node);

--- a/src/relay/transforms/device_aware_visitors.cc
+++ b/src/relay/transforms/device_aware_visitors.cc
@@ -132,8 +132,8 @@ void DeviceAwareExprVisitor::VisitExpr_(const FunctionNode* function_node) {
     DeviceAwareVisitExpr_(function_node);
   } else {
     // Function parameters come into scope.
-    for (size_t i = 0; i < function_node->params.size(); ++i) {
-      PushBoundVar(function_node->params[i], GetFunctionParamVirtualDevice(function_node, i));
+    for (auto param: function_node->params) {
+      PushBoundVar(param, param->virtual_device());
     }
     // Entering scope of function body.
     PushVirtualDevice(function_node->virtual_device());
@@ -218,8 +218,8 @@ Expr DeviceAwareExprMutator::VisitExpr_(const FunctionNode* function_node) {
     return DeviceAwareVisitExpr_(function_node);
   } else {
     // Function parameters come into scope.
-    for (size_t i = 0; i < function_node->params.size(); ++i) {
-      PushBoundVar(function_node->params[i], GetFunctionParamVirtualDevice(function_node, i));
+    for (auto param: function_node->params) {
+      PushBoundVar(param, param->virtual_device());
     }
     // Entering scope of function body.
     PushVirtualDevice(function_node->virtual_device());

--- a/src/relay/transforms/device_aware_visitors.cc
+++ b/src/relay/transforms/device_aware_visitors.cc
@@ -132,7 +132,7 @@ void DeviceAwareExprVisitor::VisitExpr_(const FunctionNode* function_node) {
     DeviceAwareVisitExpr_(function_node);
   } else {
     // Function parameters come into scope.
-    for (auto param: function_node->params) {
+    for (auto param : function_node->params) {
       PushBoundVar(param, param->virtual_device());
     }
     // Entering scope of function body.
@@ -218,7 +218,7 @@ Expr DeviceAwareExprMutator::VisitExpr_(const FunctionNode* function_node) {
     return DeviceAwareVisitExpr_(function_node);
   } else {
     // Function parameters come into scope.
-    for (auto param: function_node->params) {
+    for (auto param : function_node->params) {
       PushBoundVar(param, param->virtual_device());
     }
     // Entering scope of function body.

--- a/src/relay/transforms/device_aware_visitors.h
+++ b/src/relay/transforms/device_aware_visitors.h
@@ -145,8 +145,8 @@ class DeviceAwareExprFunctor<void(const Expr& n)> : public ExprFunctor<void(cons
       return DeviceAwareVisitExpr_(function_node);
     } else {
       // Function parameters come into scope.
-      for (size_t i = 0; i < function_node->params.size(); ++i) {
-        PushBoundVar(function_node->params[i], GetFunctionParamVirtualDevice(function_node, i));
+      for (auto param: function_node->params) {
+        PushBoundVar(param, param->virtual_device());
       }
       // Entering scope of function body.
       VirtualDevice virtual_device = function_node->virtual_device();

--- a/src/relay/transforms/device_aware_visitors.h
+++ b/src/relay/transforms/device_aware_visitors.h
@@ -145,7 +145,7 @@ class DeviceAwareExprFunctor<void(const Expr& n)> : public ExprFunctor<void(cons
       return DeviceAwareVisitExpr_(function_node);
     } else {
       // Function parameters come into scope.
-      for (auto param: function_node->params) {
+      for (auto param : function_node->params) {
         PushBoundVar(param, param->virtual_device());
       }
       // Entering scope of function body.

--- a/src/relay/transforms/device_aware_visitors.h
+++ b/src/relay/transforms/device_aware_visitors.h
@@ -149,7 +149,7 @@ class DeviceAwareExprFunctor<void(const Expr& n)> : public ExprFunctor<void(cons
         PushBoundVar(function_node->params[i], GetFunctionParamVirtualDevice(function_node, i));
       }
       // Entering scope of function body.
-      VirtualDevice virtual_device = GetFunctionResultVirtualDevice(function_node);
+      VirtualDevice virtual_device = function_node->virtual_device();
       VLOG(2) << "entering " << virtual_device << " for function:" << std::endl
               << PrettyPrint(GetRef<Function>(function_node));
       PushVirtualDevice(virtual_device);

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1016,7 +1016,7 @@ class DeviceCapturer : public ExprMutator {
       ICHECK(!param_virtual_device->IsFullyUnconstrained());
       annotated_bind_map.Set(function_node->params[i], annotated_var);
     }
-    for (auto kv : annotated_bind_map){
+    for (auto kv : annotated_bind_map) {
       VLOG(4) << "Var: " << kv.first;
       VLOG(4) << "Value: " << kv.second;
       VLOG(4) << "Value VID: " << kv.second->virtual_device();

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1028,11 +1028,10 @@ class DeviceCapturer : public ExprMutator {
         /*lexical_virtual_device=*/result_virtual_device,
         /*expected_virtual_device=*/result_virtual_device,
         /*child_virtual_device=*/GetVirtualDevice(function_node->body), function_node->body);
-    VLOG(4) << "Body: " << body;
-    // ICHECK(!body.as<FunctionNode>()) << "Body is a function oops";
-    Expr bound_body = SubstituteVars(body, annotated_bind_map);
-    VLOG(4) << "Bound body: " << bound_body;
-    Function func = WithFields(GetRef<Function>(function_node), annotated_params, bound_body);
+    VLOG(4) << "Visited body: " << body;
+    Function func = WithFields(GetRef<Function>(function_node), function_node->params, body);
+    VLOG(4) << "New function: " << func;
+    func = Downcast<Function>(SubstituteVars(func, annotated_bind_map));
     VLOG(4) << "Func with bound params: " << func;
     func->virtual_device_ = result_virtual_device;
     VLOG(4) << "Func with bound params & result vid set: " << func;

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1009,9 +1009,17 @@ class DeviceCapturer : public ExprMutator {
     for (size_t i = 0; i < function_node->params.size(); ++i) {
       VirtualDevice param_virtual_device =
           domains_->ResultVirtualDevice(func_domain->function_param(i));
+      VLOG(4) << "Param: " << function_node->params[i];
       Var annotated_var = WithFields(function_node->params[i], {}, {}, param_virtual_device);
+      VLOG(4) << "Annotated param: " << annotated_var;
+      VLOG(4) << "VirtualDevice: " << annotated_var->virtual_device();
       ICHECK(!param_virtual_device->IsFullyUnconstrained());
       annotated_bind_map.Set(function_node->params[i], annotated_var);
+    }
+    for (auto kv : annotated_bind_map){
+      VLOG(4) << "Var: " << kv.first;
+      VLOG(4) << "Value: " << kv.second;
+      VLOG(4) << "Value VID: " << kv.second->virtual_device();
     }
 
     // Eventually we probably want to bind before visiting, but for now this is causing an issue
@@ -1025,10 +1033,13 @@ class DeviceCapturer : public ExprMutator {
         /*expected_virtual_device=*/result_virtual_device,
         /*child_virtual_device=*/GetVirtualDevice(function_node->body), function_node->body);
 
+    VLOG(4) << "Body: " << body;
     Function func = WithFields(GetRef<Function>(function_node), function_node->params, body);
+    VLOG(4) << "Func: " << func;
     func = Downcast<Function>(Bind(func, annotated_bind_map));
-
+    VLOG(4) << "Func with bound params: " << func;
     func->virtual_device_ = result_virtual_device;
+    VLOG(4) << "Func with bound params & result vid set: " << func;
     return func;
   }
 

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -876,7 +876,6 @@ class DeviceDefaulter : public ExprVisitor {
 };
 
 /* =============== Phase 3 =============== */
-// TODO(@electriclilies): rewrite this comment
 /*!
  * \brief Inserts missing "device_copy" CallNodes, and ensures the device type of every
  * sub-expression in a module can be easily recovered by a later transformation using simple
@@ -885,8 +884,9 @@ class DeviceDefaulter : public ExprVisitor {
  * - Discard any existing "on_device" CallNodes since their job is done. Similarly, discard
  *   any existing "device_copy" CallNodes which are no-ops.
  *
- * - Functions are given "param_virtual_devices" and "result_virtual_device" attributes to capture
- *   the device type for its parameters and result.
+ * - The result virtual device for a function is stored in the function's virtual_device_ field
+ *   and the virtual devices of the function's parameters are stored in the parameter's
+ *   virtual_device_ field.
  *
  * - Additional "device_copy" CallNodes are inserted wherever there's a transition between
  *   storage device types. Since the DeviceAnalyzer phase succeeded this can only happen
@@ -1031,7 +1031,7 @@ class DeviceCapturer : public ExprMutator {
     VLOG(4) << "Visited body: " << body;
     Function func = WithFields(GetRef<Function>(function_node), function_node->params, body);
     VLOG(4) << "New function: " << func;
-    func = Downcast<Function>(SubstituteVars(func, annotated_bind_map));
+    func = SubstituteBoundVars(func, annotated_bind_map);
     VLOG(4) << "Func with bound params: " << func;
     func->virtual_device_ = result_virtual_device;
     VLOG(4) << "Func with bound params & result vid set: " << func;

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -583,7 +583,7 @@ class DeviceAnalyzer : public MixedModeVisitor {
 
     // If the function already has VirtualDevice attributes then we can further constrain the
     // function's domain to match them.
-    if (!GetFunctionResultVirtualDevice(function_node)->IsFullyUnconstrained()) {
+    if (!function_node->virtual_device()->IsFullyUnconstrained()) {
       std::vector<DeviceDomainPtr> args_and_result;
       for (size_t i = 0; i < function_node->params.size(); ++i) {
         args_and_result.emplace_back(
@@ -591,7 +591,7 @@ class DeviceAnalyzer : public MixedModeVisitor {
                                        GetFunctionParamVirtualDevice(function_node, i)));
       }
       args_and_result.emplace_back(domains_->ForVirtualDevice(
-          function_node->body->checked_type(), GetFunctionResultVirtualDevice(function_node)));
+          function_node->body->checked_type(), function_node->virtual_device()));
       auto annotation_domain = domains_->MakeHigherOrderDomain(std::move(args_and_result));
       if (domains_->UnifyOrNull(func_domain, annotation_domain) == nullptr) {  // higher-order
         // TODO(mbs): Proper diagnostics.

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1016,15 +1016,8 @@ class DeviceCapturer : public ExprMutator {
       ICHECK(!param_virtual_device->IsFullyUnconstrained());
       annotated_bind_map.Set(function_node->params[i], annotated_var);
     }
-    for (auto kv : annotated_bind_map) {
-      VLOG(4) << "Var: " << kv.first;
-      VLOG(4) << "Value: " << kv.second;
-      VLOG(4) << "Value VID: " << kv.second->virtual_device();
-    }
-
     // Eventually we probably want to bind before visiting, but for now this is causing an issue
-    // with the GetVirtualDevice utility, so leaving as is for now. Function func =
-    // Downcast<Function>(Bind(GetRef<Function>(function_node), annotated_bind_map));
+    // with the GetVirtualDevice utility, so leaving as is for now.
 
     // Rewrite the body. Note that the body may have begun with an "on_device" so
     // be prepared to insert a "device_copy".

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -585,12 +585,12 @@ class DeviceAnalyzer : public MixedModeVisitor {
     // function's domain to match them.
     if (!function_node->virtual_device()->IsFullyUnconstrained()) {
       std::vector<DeviceDomainPtr> args_and_result;
-      for (auto param: function_node->params) {
+      for (auto param : function_node->params) {
         args_and_result.emplace_back(
             domains_->ForVirtualDevice(param->checked_type(), param->virtual_device()));
       }
-      args_and_result.emplace_back(domains_->ForVirtualDevice(
-          function_node->body->checked_type(), function_node->virtual_device()));
+      args_and_result.emplace_back(domains_->ForVirtualDevice(function_node->body->checked_type(),
+                                                              function_node->virtual_device()));
       auto annotation_domain = domains_->MakeHigherOrderDomain(std::move(args_and_result));
       if (domains_->UnifyOrNull(func_domain, annotation_domain) == nullptr) {  // higher-order
         // TODO(mbs): Proper diagnostics.
@@ -1014,9 +1014,9 @@ class DeviceCapturer : public ExprMutator {
       annotated_bind_map.Set(function_node->params[i], annotated_var);
     }
 
-    // Eventually we probably want to bind before visiting, but for now this is causing an issue with the GetVirtualDevice
-    // utility, so leaving as is for now.
-    // Function func = Downcast<Function>(Bind(GetRef<Function>(function_node), annotated_bind_map));
+    // Eventually we probably want to bind before visiting, but for now this is causing an issue
+    // with the GetVirtualDevice utility, so leaving as is for now. Function func =
+    // Downcast<Function>(Bind(GetRef<Function>(function_node), annotated_bind_map));
 
     // Rewrite the body. Note that the body may have begun with an "on_device" so
     // be prepared to insert a "device_copy".

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1029,7 +1029,7 @@ class DeviceCapturer : public ExprMutator {
     VLOG(4) << "Body: " << body;
     Function func = WithFields(GetRef<Function>(function_node), function_node->params, body);
     VLOG(4) << "Func: " << func;
-    func = Downcast<Function>(ExprBinder(func, annotated_bind_map));
+    func = Downcast<Function>(ExprBind(func, annotated_bind_map));
     VLOG(4) << "Func with bound params: " << func;
     func->virtual_device_ = result_virtual_device;
     VLOG(4) << "Func with bound params & result vid set: " << func;

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -877,7 +877,7 @@ class DeviceDefaulter : public ExprVisitor {
 };
 
 /* =============== Phase 3 =============== */
-
+// TODO(@electriclilies): rewrite this comment
 /*!
  * \brief Inserts missing "device_copy" CallNodes, and ensures the device type of every
  * sub-expression in a module can be easily recovered by a later transformation using simple

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1029,7 +1029,7 @@ class DeviceCapturer : public ExprMutator {
     VLOG(4) << "Body: " << body;
     Function func = WithFields(GetRef<Function>(function_node), function_node->params, body);
     VLOG(4) << "Func: " << func;
-    func = Downcast<Function>(Bind(func, annotated_bind_map));
+    func = Downcast<Function>(ExprBinder(func, annotated_bind_map));
     VLOG(4) << "Func with bound params: " << func;
     func->virtual_device_ = result_virtual_device;
     VLOG(4) << "Func with bound params & result vid set: " << func;

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -585,10 +585,9 @@ class DeviceAnalyzer : public MixedModeVisitor {
     // function's domain to match them.
     if (!function_node->virtual_device()->IsFullyUnconstrained()) {
       std::vector<DeviceDomainPtr> args_and_result;
-      for (size_t i = 0; i < function_node->params.size(); ++i) {
+      for (auto param: function_node->params) {
         args_and_result.emplace_back(
-            domains_->ForVirtualDevice(function_node->params[i]->checked_type(),
-                                       GetFunctionParamVirtualDevice(function_node, i)));
+            domains_->ForVirtualDevice(param->checked_type(), param->virtual_device()));
       }
       args_and_result.emplace_back(domains_->ForVirtualDevice(
           function_node->body->checked_type(), function_node->virtual_device()));

--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -304,7 +304,7 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
     } else {
       // Keep track of expression and bound variable device types for lexically enclosing
       // sub-expressions.
-      PushVirtualDevice(GetFunctionResultVirtualDevice(f));
+      PushVirtualDevice(f->virtual_device());
       for (size_t i = 0; i < f->params.size(); ++i) {
         PushBoundVar(f->params[i], GetFunctionParamVirtualDevice(f, i));
       }

--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -305,7 +305,7 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
       // Keep track of expression and bound variable device types for lexically enclosing
       // sub-expressions.
       PushVirtualDevice(f->virtual_device());
-      for (auto param: f->params) {
+      for (auto param : f->params) {
         PushBoundVar(param, param->virtual_device());
       }
       EnterFunctionBody();

--- a/src/relay/transforms/to_a_normal_form.cc
+++ b/src/relay/transforms/to_a_normal_form.cc
@@ -305,8 +305,8 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)>, private transform::Lexi
       // Keep track of expression and bound variable device types for lexically enclosing
       // sub-expressions.
       PushVirtualDevice(f->virtual_device());
-      for (size_t i = 0; i < f->params.size(); ++i) {
-        PushBoundVar(f->params[i], GetFunctionParamVirtualDevice(f, i));
+      for (auto param: f->params) {
+        PushBoundVar(param, param->virtual_device());
       }
       EnterFunctionBody();
       ret = WithFields(GetRef<Function>(f), f->params,

--- a/tests/python/relay/op/annotation/test_annotation.py
+++ b/tests/python/relay/op/annotation/test_annotation.py
@@ -61,18 +61,6 @@ def test_on_device_free():
     assert not call.attrs.constrain_result
 
 
-def test_function_on_device():
-    x = relay.Var("x")
-    y = relay.Var("y")
-    f = relay.Function([x, y], relay.add(x, y))
-    func = relay.annotation.function_on_device(f, ["cpu", "cuda"], "cuda")
-    assert isinstance(func, relay.Function)
-    assert len(func.attrs["param_virtual_devices"]) == 2
-    assert func.attrs["param_virtual_devices"][0].device_type_int == 1  # ie kDLCPU
-    assert func.attrs["param_virtual_devices"][1].device_type_int == 2  # ie kDLCUDA
-    assert func.virtual_device_.device_type_int == 2  # ie KDLCUDA
-
-
 if __name__ == "__main__":
     import sys
 

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -101,10 +101,10 @@ def rands(shape, n):
 def exercise(in_mod: tvm.IRModule, expected_mod: tvm.IRModule, reference_func, args):
     """Test in_mod against expected_mod and reference_func using args."""
     # Correctness
+    
     print("in mod main: ", in_mod["main"])
-    print("in mod main attrs: ", in_mod["main"].attrs)
     print("expected main: ", expected_mod["main"])
-    print("expected main attrs: ", expected_mod["main"].attrs)
+    
     rewrite_and_assert(in_mod, expected_mod)
     print("correctness succeeded")
     # Idempotence
@@ -1324,7 +1324,7 @@ def test_conditional():
             #[version = "0.0.5"]
             def @main(%x {virtual_device=meta[VirtualDevice][0]}: bool, %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %z {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][0]) {
-              let %f = fn (%a {virtual_device=meta[VirtualDevice][0]} virtual_device=meta[VirtualDevice][0]) {
+              let %f = fn (%a {virtual_device=meta[VirtualDevice][0]}, virtual_device=meta[VirtualDevice][0]) {
                 add(%a, %y)
               };
               let %g = fn (%a1 {virtual_device=meta[VirtualDevice][0]}, virtual_device=meta[VirtualDevice][0]) {

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -177,9 +177,8 @@ def test_left_add_on_cpu():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device= meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %d {virtual_device= meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -224,9 +223,8 @@ def test_left_add_on_cpu_via_copy():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -271,9 +269,8 @@ def test_both_adds_on_cpu():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -319,8 +316,8 @@ def test_sharing():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -366,9 +363,8 @@ def test_let_on_cpu():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               let %l = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -416,12 +412,11 @@ def test_func_param_on_cpu():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][0]) {
-              let %f = fn (%x, %y,
-                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+              let %f = fn (%x {virtual_device=meta[VirtualDevice][0]}, %y {virtual_device=meta[VirtualDevice][0]},
+                           virtual_device=meta[VirtualDevice][0]) {
                 add(%x, %y)
               };
               %0 = %f(%a, %b);
@@ -468,12 +463,11 @@ def test_func_result_on_cpu():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
-              let %f = fn (%x, %y,
-                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+              let %f = fn (%x {virtual_device=meta[VirtualDevice][0]}, %y {virtual_device=meta[VirtualDevice][0]},
+                           virtual_device=meta[VirtualDevice][0]) {
                 add(%x, %y)
               };
               %1 = %f(%a, %b);
@@ -527,16 +521,16 @@ def test_higher_order():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
-              let %f = fn (%g, param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
-                fn (%a, param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
+              let %f = fn (%g {virtual_device=meta[VirtualDevice][1]}, virtual_device=meta[VirtualDevice][1]) {
+                fn (%a {virtual_device=meta[VirtualDevice][0]}, virtual_device=meta[VirtualDevice][1]) {
                   %0 = device_copy(%a, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
                   %1 = %g(%0);
                   add(%1, %x)
                 }
               };
-              let %h = fn (%b, param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
+              let %h = fn (%b  {virtual_device=meta[VirtualDevice][1]}, virtual_device=meta[VirtualDevice][1]) {
                 negative(%b)
               };
               %2 = %f(%h);
@@ -589,10 +583,10 @@ def test_function_in_tuple():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
-              let %f = fn (%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][0]) {
+              let %f = fn (%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                           virtual_device=meta[VirtualDevice][0]) {
                 add(%a, %b)
               };
               let %t = on_device((%f, %x), virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -634,8 +628,8 @@ def test_device_copy():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = device_copy(%x, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
               add(%0, meta[relay.Constant][0])
             }
@@ -675,8 +669,8 @@ def test_shape_of():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(?, ?), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][0]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(?, ?), float32],
+                      virtual_device=meta[VirtualDevice][0]) {
               vm.shape_of(%x, dtype="int64")
             }
         """,
@@ -711,8 +705,8 @@ def test_alloc_storage():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%size: int64, %alignment: int64,
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%size {virtual_device=meta[VirtualDevice][0]}: int64, %alignment {virtual_device=meta[VirtualDevice][0]}: int64,
+                      virtual_device=meta[VirtualDevice][1]) {
               memory.alloc_storage(%size, %alignment, virtual_device=meta[VirtualDevice][1])
             }
         """,
@@ -750,7 +744,7 @@ def test_alloc_tensor():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%sto: Storage[], param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%sto {virtual_device=meta[VirtualDevice][1]}: Storage[], virtual_device=meta[VirtualDevice][1]) {
               %0 = on_device(0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %1 = on_device(meta[relay.Constant][0], virtual_device=meta[VirtualDevice][0], constrain_result=True);
               memory.alloc_tensor(%sto, %0, %1, const_shape=meta[relay.Constant][0], assert_shape=[])
@@ -789,8 +783,8 @@ def test_reshape_tensor():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(2, 8), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(2, 8), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = on_device(meta[relay.Constant][0], virtual_device=meta[VirtualDevice][0], constrain_result=True);
               vm.reshape_tensor(%x, %0, newshape=[2, 4, 2])
             }
@@ -827,8 +821,8 @@ def test_dynamic_input():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x0: Tensor[(?, ?), float32], %x1: Tensor[(?, ?), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+            def @main(%x0 {virtual_device=meta[VirtualDevice][0]}: Tensor[(?, ?), float32], %x1 {virtual_device=meta[VirtualDevice][0]}: Tensor[(?, ?), float32],
+                      virtual_device=meta[VirtualDevice][0]) {
               add(%x0, %x1)
             }
         """,
@@ -867,8 +861,7 @@ def test_redundant_annotation():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1]],
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %z {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%x, %y);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -914,8 +907,7 @@ def test_annotate_expr():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1], meta[VirtualDevice][0]],
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %z {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][0]) {
               %0 = add(%x, %y);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
@@ -957,8 +949,7 @@ def test_annotate_all():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %z {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][0]) {
               %0 = add(%x, %y);
               subtract(%0, %z)
@@ -1015,9 +1006,8 @@ def test_conv_network():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%data1: Tensor[(1, 64, 56, 56), float32], %data2: Tensor[(1, 64, 56, 56), float32],
-                      %weight: Tensor[(64, 64, 3, 3), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
+            def @main(%data1 {virtual_device=meta[VirtualDevice][0]}: Tensor[(1, 64, 56, 56), float32], %data2 {virtual_device=meta[VirtualDevice][0]}: Tensor[(1, 64, 56, 56), float32],
+                      %weight {virtual_device=meta[VirtualDevice][0]}: Tensor[(64, 64, 3, 3), float32],
                       virtual_device=meta[VirtualDevice][0]) {
               %0 = nn.conv2d(%data1, %weight, padding=[1, 1, 1, 1], channels=64, kernel_size=[3, 3]);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -1068,8 +1058,8 @@ def test_tuple_get_item():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(3, 3, 4), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(3, 3, 4), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = split(%x, indices_or_sections=3);
               let %t = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %1 = %t.0;
@@ -1136,8 +1126,8 @@ def test_propogation():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = negative(%x);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
@@ -1206,8 +1196,8 @@ def test_fusible_network():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][0]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = add(%x, %y);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][0]);
@@ -1272,9 +1262,8 @@ def test_unpropagatable_graph():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][0]) {
               %0 = multiply(%c, %d);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
@@ -1327,13 +1316,12 @@ def test_conditional():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: bool, %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: bool, %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %z {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][0]) {
-              let %f = fn (%a, param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+              let %f = fn (%a {virtual_device=meta[VirtualDevice][0]} virtual_device=meta[VirtualDevice][0]) {
                 add(%a, %y)
               };
-              let %g = fn (%a1, param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+              let %g = fn (%a1 {virtual_device=meta[VirtualDevice][0]}, virtual_device=meta[VirtualDevice][0]) {
                 subtract(%a1, %y)
               };
               let %h = on_device(if (%x) {
@@ -1387,15 +1375,13 @@ def test_global():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @f(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                   param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]],
+            def @f(%a {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
                    virtual_device=meta[VirtualDevice][1]) -> Tensor[(5, 7), float32] {
               %0 = device_copy(%b, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
               add(%a, %0)
             }
 
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][1]],
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) -> Tensor[(5, 7), float32] {
               @f(%y, %x)
             }
@@ -1438,8 +1424,8 @@ def test_ref():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
               let %r = on_device(ref(%x), virtual_device=meta[VirtualDevice][1], constrain_result=True);
               %0 = device_copy(%y, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
               on_device(ref_write(%r, %0), virtual_device=meta[VirtualDevice][1], constrain_result=True);
@@ -1495,8 +1481,8 @@ def test_adt():
               Cons(A, List[A]),
               Nil,
             }
-            def @main(%x : Tensor[(5, 7), float32], %y : Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %y {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = Nil;
               %1 = Cons(%y, %0);
               let %l = on_device(Cons(%x, %1), virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -1534,13 +1520,11 @@ def test_free_on_device():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @on_scope_b(%x: Tensor[(5, 7), float32],
-                            param_virtual_devices=[meta[VirtualDevice][2]],
+            def @on_scope_b(%x {virtual_device=meta[VirtualDevice][2]}: Tensor[(5, 7), float32],
                             virtual_device=meta[VirtualDevice][2]) -> Tensor[(5, 7), float32] {
               %x
             }
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32], %c: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][2]],
+            def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %c {virtual_device=meta[VirtualDevice][2]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               // %a's memory scope is unconstrained, so will take on "scopeB" and on_device has no effect
               %0 = @on_scope_b(on_device(%a, virtual_device=meta[VirtualDevice][0], constrain_body=False));
@@ -1562,13 +1546,11 @@ def test_free_on_device():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @on_scope_b(%x: Tensor[(5, 7), float32],
-                            param_virtual_devices=[meta[VirtualDevice][2]],
+            def @on_scope_b(%x {virtual_device=meta[VirtualDevice][2]}: Tensor[(5, 7), float32],
                             virtual_device=meta[VirtualDevice][2]) -> Tensor[(5, 7), float32] {
               %x
             }
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32], %c: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][2], meta[VirtualDevice][1], meta[VirtualDevice][2]],
+            def @main(%a {virtual_device=meta[VirtualDevice][2]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %c {virtual_device=meta[VirtualDevice][2]}: Tensor[(5, 7), float32],
                       virtual_device=meta[VirtualDevice][1]) {
               %0 = @on_scope_b(%a);
               %1 = device_copy(%b, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][2]);
@@ -1648,10 +1630,9 @@ def test_lowered():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x : Tensor[(128, 128), float32],
-                      %y : Tensor[(128, 128), float32],
-                      %z : Tensor[(128, 128), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][2], meta[VirtualDevice][1]],
+            def @main(%x {virtual_device=meta[VirtualDevice][0]}: Tensor[(128, 128), float32],
+                      %y {virtual_device=meta[VirtualDevice][2]}: Tensor[(128, 128), float32],
+                      %z {virtual_device=meta[VirtualDevice][1]}: Tensor[(128, 128), float32],
                       virtual_device=meta[VirtualDevice][2]) {
               call_lowered(@gem, (%x, %y, %z))
             }
@@ -1671,10 +1652,9 @@ def test_lowered():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%x : Tensor[(128, 128), float32],
-                      %y : Tensor[(128, 128), float32],
-                      %z : Tensor[(128, 128), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][2], meta[VirtualDevice][1]],
+            def @main(%x {virtual_device=meta[VirtualDevice][1]}: Tensor[(128, 128), float32],
+                      %y {virtual_device=meta[VirtualDevice][2]}: Tensor[(128, 128), float32],
+                      %z {virtual_device=meta[VirtualDevice][1]}: Tensor[(128, 128), float32],
                       virtual_device=meta[VirtualDevice][2]) {
               %0 = device_copy(%z, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][2]);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][2], constrain_result=True);

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -133,10 +133,9 @@ def test_plain():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1], meta[VirtualDevice][1], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+            def @main(%a {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %b {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
+                      %c {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], %d {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32],
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = add(%c, %d);
               subtract(%0, %1)
@@ -181,7 +180,7 @@ def test_left_add_on_cpu():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
@@ -228,7 +227,7 @@ def test_left_add_on_cpu_via_copy():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
@@ -275,7 +274,7 @@ def test_both_adds_on_cpu():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = add(%c, %d);
@@ -321,7 +320,7 @@ def test_sharing():
             """
             #[version = "0.0.5"]
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -370,7 +369,7 @@ def test_let_on_cpu():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%a, %b);
               let %l = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               let %r = on_device(add(%c, %d), virtual_device=meta[VirtualDevice][1], constrain_result=True);
@@ -420,9 +419,9 @@ def test_func_param_on_cpu():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
-                      result_virtual_device=meta[VirtualDevice][0]) {
+                      virtual_device=meta[VirtualDevice][0]) {
               let %f = fn (%x, %y,
-                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
                 add(%x, %y)
               };
               %0 = %f(%a, %b);
@@ -472,9 +471,9 @@ def test_func_result_on_cpu():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               let %f = fn (%x, %y,
-                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
                 add(%x, %y)
               };
               %1 = %f(%a, %b);
@@ -529,15 +528,15 @@ def test_higher_order():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
-              let %f = fn (%g, param_virtual_devices=[meta[VirtualDevice][1]], result_virtual_device=meta[VirtualDevice][1]) {
-                fn (%a, param_virtual_devices=[meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
+              let %f = fn (%g, param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
+                fn (%a, param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
                   %0 = device_copy(%a, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
                   %1 = %g(%0);
                   add(%1, %x)
                 }
               };
-              let %h = fn (%b, param_virtual_devices=[meta[VirtualDevice][1]], result_virtual_device=meta[VirtualDevice][1]) {
+              let %h = fn (%b, param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
                 negative(%b)
               };
               %2 = %f(%h);
@@ -591,9 +590,9 @@ def test_function_in_tuple():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
               let %f = fn (%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
-                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                           param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
                 add(%a, %b)
               };
               let %t = on_device((%f, %x), virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -636,7 +635,7 @@ def test_device_copy():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
               %0 = device_copy(%x, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
               add(%0, meta[relay.Constant][0])
             }
@@ -677,7 +676,7 @@ def test_shape_of():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(?, ?), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1]], result_virtual_device=meta[VirtualDevice][0]) {
+                      param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][0]) {
               vm.shape_of(%x, dtype="int64")
             }
         """,
@@ -713,7 +712,7 @@ def test_alloc_storage():
             """
             #[version = "0.0.5"]
             def @main(%size: int64, %alignment: int64,
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
               memory.alloc_storage(%size, %alignment, virtual_device=meta[VirtualDevice][1])
             }
         """,
@@ -751,7 +750,7 @@ def test_alloc_tensor():
         return tvm.parser.parse(
             """
             #[version = "0.0.5"]
-            def @main(%sto: Storage[], param_virtual_devices=[meta[VirtualDevice][1]], result_virtual_device=meta[VirtualDevice][1]) {
+            def @main(%sto: Storage[], param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
               %0 = on_device(0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %1 = on_device(meta[relay.Constant][0], virtual_device=meta[VirtualDevice][0], constrain_result=True);
               memory.alloc_tensor(%sto, %0, %1, const_shape=meta[relay.Constant][0], assert_shape=[])
@@ -791,7 +790,7 @@ def test_reshape_tensor():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(2, 8), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][1]) {
               %0 = on_device(meta[relay.Constant][0], virtual_device=meta[VirtualDevice][0], constrain_result=True);
               vm.reshape_tensor(%x, %0, newshape=[2, 4, 2])
             }
@@ -829,7 +828,7 @@ def test_dynamic_input():
             """
             #[version = "0.0.5"]
             def @main(%x0: Tensor[(?, ?), float32], %x1: Tensor[(?, ?), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
               add(%x0, %x1)
             }
         """,
@@ -870,7 +869,7 @@ def test_redundant_annotation():
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = add(%x, %y);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
@@ -917,7 +916,7 @@ def test_annotate_expr():
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1], meta[VirtualDevice][0]],
-                      result_virtual_device=meta[VirtualDevice][0]) {
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = add(%x, %y);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][0]);
@@ -960,7 +959,7 @@ def test_annotate_all():
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
-                      result_virtual_device=meta[VirtualDevice][0]) {
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = add(%x, %y);
               subtract(%0, %z)
             }
@@ -1019,7 +1018,7 @@ def test_conv_network():
             def @main(%data1: Tensor[(1, 64, 56, 56), float32], %data2: Tensor[(1, 64, 56, 56), float32],
                       %weight: Tensor[(64, 64, 3, 3), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
-                      result_virtual_device=meta[VirtualDevice][0]) {
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = nn.conv2d(%data1, %weight, padding=[1, 1, 1, 1], channels=64, kernel_size=[3, 3]);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = nn.conv2d(%data2, %weight, padding=[1, 1, 1, 1], channels=64, kernel_size=[3, 3]);
@@ -1070,7 +1069,7 @@ def test_tuple_get_item():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(3, 3, 4), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
               %0 = split(%x, indices_or_sections=3);
               let %t = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %1 = %t.0;
@@ -1138,7 +1137,7 @@ def test_propogation():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                      param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
               %0 = negative(%x);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][0], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
@@ -1208,7 +1207,7 @@ def test_fusible_network():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1]], result_virtual_device=meta[VirtualDevice][0]) {
+                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1]], virtual_device=meta[VirtualDevice][0]) {
               %0 = add(%x, %y);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
               %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][0]);
@@ -1276,7 +1275,7 @@ def test_unpropagatable_graph():
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                       %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][0]) {
+                      virtual_device=meta[VirtualDevice][0]) {
               %0 = multiply(%c, %d);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
               %2 = add(%a, %b);
@@ -1330,11 +1329,11 @@ def test_conditional():
             #[version = "0.0.5"]
             def @main(%x: bool, %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0], meta[VirtualDevice][0]],
-                      result_virtual_device=meta[VirtualDevice][0]) {
-              let %f = fn (%a, param_virtual_devices=[meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                      virtual_device=meta[VirtualDevice][0]) {
+              let %f = fn (%a, param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
                 add(%a, %y)
               };
-              let %g = fn (%a1, param_virtual_devices=[meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+              let %g = fn (%a1, param_virtual_devices=[meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
                 subtract(%a1, %y)
               };
               let %h = on_device(if (%x) {
@@ -1390,14 +1389,14 @@ def test_global():
             #[version = "0.0.5"]
             def @f(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
                    param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]],
-                   result_virtual_device=meta[VirtualDevice][1]) -> Tensor[(5, 7), float32] {
+                   virtual_device=meta[VirtualDevice][1]) -> Tensor[(5, 7), float32] {
               %0 = device_copy(%b, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
               add(%a, %0)
             }
 
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][1]) -> Tensor[(5, 7), float32] {
+                      virtual_device=meta[VirtualDevice][1]) -> Tensor[(5, 7), float32] {
               @f(%y, %x)
             }
         """,
@@ -1440,7 +1439,7 @@ def test_ref():
             """
             #[version = "0.0.5"]
             def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][1]) {
+                      param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][1]) {
               let %r = on_device(ref(%x), virtual_device=meta[VirtualDevice][1], constrain_result=True);
               %0 = device_copy(%y, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
               on_device(ref_write(%r, %0), virtual_device=meta[VirtualDevice][1], constrain_result=True);
@@ -1497,7 +1496,7 @@ def test_adt():
               Nil,
             }
             def @main(%x : Tensor[(5, 7), float32], %y : Tensor[(5, 7), float32],
-                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], result_virtual_device=meta[VirtualDevice][0]) {
+                      param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][0]], virtual_device=meta[VirtualDevice][0]) {
               %0 = Nil;
               %1 = Cons(%y, %0);
               let %l = on_device(Cons(%x, %1), virtual_device=meta[VirtualDevice][0], constrain_result=True);
@@ -1537,12 +1536,12 @@ def test_free_on_device():
             #[version = "0.0.5"]
             def @on_scope_b(%x: Tensor[(5, 7), float32],
                             param_virtual_devices=[meta[VirtualDevice][2]],
-                            result_virtual_device=meta[VirtualDevice][2]) -> Tensor[(5, 7), float32] {
+                            virtual_device=meta[VirtualDevice][2]) -> Tensor[(5, 7), float32] {
               %x
             }
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32], %c: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][1], meta[VirtualDevice][2]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               // %a's memory scope is unconstrained, so will take on "scopeB" and on_device has no effect
               %0 = @on_scope_b(on_device(%a, virtual_device=meta[VirtualDevice][0], constrain_body=False));
               // %b's memory scope is "scopeA", so will require a "scopeA"->"scopeB" copy.
@@ -1565,12 +1564,12 @@ def test_free_on_device():
             #[version = "0.0.5"]
             def @on_scope_b(%x: Tensor[(5, 7), float32],
                             param_virtual_devices=[meta[VirtualDevice][2]],
-                            result_virtual_device=meta[VirtualDevice][2]) -> Tensor[(5, 7), float32] {
+                            virtual_device=meta[VirtualDevice][2]) -> Tensor[(5, 7), float32] {
               %x
             }
             def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32], %c: Tensor[(5, 7), float32],
                       param_virtual_devices=[meta[VirtualDevice][2], meta[VirtualDevice][1], meta[VirtualDevice][2]],
-                      result_virtual_device=meta[VirtualDevice][1]) {
+                      virtual_device=meta[VirtualDevice][1]) {
               %0 = @on_scope_b(%a);
               %1 = device_copy(%b, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][2]);
               %2 = @on_scope_b(%1);
@@ -1653,7 +1652,7 @@ def test_lowered():
                       %y : Tensor[(128, 128), float32],
                       %z : Tensor[(128, 128), float32],
                       param_virtual_devices=[meta[VirtualDevice][0], meta[VirtualDevice][2], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][2]) {
+                      virtual_device=meta[VirtualDevice][2]) {
               call_lowered(@gem, (%x, %y, %z))
             }
             """,
@@ -1676,7 +1675,7 @@ def test_lowered():
                       %y : Tensor[(128, 128), float32],
                       %z : Tensor[(128, 128), float32],
                       param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][2], meta[VirtualDevice][1]],
-                      result_virtual_device=meta[VirtualDevice][2]) {
+                      virtual_device=meta[VirtualDevice][2]) {
               %0 = device_copy(%z, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][2]);
               %1 = on_device(%0, virtual_device=meta[VirtualDevice][2], constrain_result=True);
               %2 = call_lowered(@gem, (%x, %y, %1));

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -101,15 +101,9 @@ def rands(shape, n):
 def exercise(in_mod: tvm.IRModule, expected_mod: tvm.IRModule, reference_func, args):
     """Test in_mod against expected_mod and reference_func using args."""
     # Correctness
-    
-    print("in mod main: ", in_mod["main"])
-    print("expected main: ", expected_mod["main"])
-    
     rewrite_and_assert(in_mod, expected_mod)
-    print("correctness succeeded")
     # Idempotence
     rewrite_and_assert(expected_mod, expected_mod)
-    print("idempotence succeeded")
     # The VM can compile and possibly even run the module
     if not (reference_func is None) and not (args is None):
         eval_and_assert(in_mod, reference_func, args)

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -101,9 +101,15 @@ def rands(shape, n):
 def exercise(in_mod: tvm.IRModule, expected_mod: tvm.IRModule, reference_func, args):
     """Test in_mod against expected_mod and reference_func using args."""
     # Correctness
+    print("in mod main: ", in_mod["main"])
+    print("in mod main attrs: ", in_mod["main"].attrs)
+    print("expected main: ", expected_mod["main"])
+    print("expected main attrs: ", expected_mod["main"].attrs)
     rewrite_and_assert(in_mod, expected_mod)
+    print("correctness succeeded")
     # Idempotence
     rewrite_and_assert(expected_mod, expected_mod)
+    print("idempotence succeeded")
     # The VM can compile and possibly even run the module
     if not (reference_func is None) and not (args is None):
         eval_and_assert(in_mod, reference_func, args)


### PR DESCRIPTION
# Scope of this PR

Below, I outline a design for representing virtual devices in tree. This PR only implements a small part of the design below-- it changes the representation of the virtual devices for function parameters and is relatively straightforward. However, I do change the syntax through which the function parameter virtual device is specified, and I designed the change to be consistent with what I want to do for let-bound variables in the future. I have provided this document because it provides important context for this PR.

_____________________________________________________________________________________________________

# Background

Currently, users can write virtual devices into the program by specifying the `function_result_virtual_device`, and the `function_param_virtual_devices` in the function attributes. Users can also introduce annotations using the `on_device` op, mostly on function arguments, but sometimes on let-bound variables. 

Device planning solves the constraints created by the user-specified virtual devices— for each sub-expression, it determines a unique and consistent virtual device. We’ll call this the **complete representation.**

# Motivation

Currently, function parameter virtual devices and the function result virtual device is represented through attributes on the function. Since there is already a text format for attributes on functions, we can represent the function parameter virtual devices and the function result virtual device in the text format by just putting them in the attributes— we get the text representation automatically. 

However, once we move the function virtual devices out of the attributes, we no longer get the text representation for free. The most immediate challenge is that the unit tests for the device planner are written in RelayScript— so without rethinking the text format for virtual devices, we can’t run the unit tests. 

A second motivation is that the current text representation is clunky— for the user to specify the virtual device of a subexpr, they need to wrap that expression in an `on_device` op. In the current implementation, let-bound variables and also arguments to functions must be wrapped in `on_device` . While I am rethinking the text format, I’d like to rethink this as well. 

# Goal

The goal for the text representation is a RelayScript program that preserves all virtual device information from device planning in a **minimal representation**. The minimal representation is the least amount of information (subexprs assigned virtual devices) we need to reconstruct the device planned program using simple lexical scoping rules. 

Additionally, I want to be able to reconstruct the **complete representation** from the **minimal representation** without using device planning itself. This will let us express the expected result of running PlanDevices in RelayScript without running PlanDevices itself. 

# Proposed design

In general, I propose removing the `on_device` op from the RelayScript representation, and simplifying the way function virtual devices are represented in text. I will

1) formalize the minimal representation

2) introduce syntax for the critical virtual devices

3)  introduce a pass that uses simple, lexical scoping rules to expand the minimal representation into the complete representation

## The minimal representation of device planning information

The current text format for representing the device planned program in RelayScript preserves the virtual devices for

1) function parameters and the function result

2) arguments to functions if the argument device is different from the function result device

3) let-bound variables

4) inputs to `device_copy`

For our minimal representation, we don’t need 4, since the virtual devices of the inputs of `device_copy` must agree with the virtual devices specified in the `device_copy` op itself.

In this example from the current text representation, the virtual device specified in `%1`  is the same as the source virtual device in `%2`. We can remove the `on_device` op and not lose any information.

```python
def @main(%x: Tensor[(5, 7), float32], %y: Tensor[(5, 7), float32], %z: Tensor[(5, 7), float32],
          param_virtual_devices=[meta[VirtualDevice][1], meta[VirtualDevice][1], meta[VirtualDevice][0]],
          result_virtual_device=meta[VirtualDevice][0]) {
     %0 = add(%x, %y);
     %1 = on_device(%0, virtual_device=meta[VirtualDevice][1], constrain_result=True);
     %2 = device_copy(%1, src_virtual_device=meta[VirtualDevice][1], dst_virtual_device=meta[VirtualDevice][0]);
     subtract(%2, %z)
}
```

So, we’ll define our minimal representation to consist of:

1. The virtual devices of variable bindings (namely, function parameters and let-bound variables)
2. The virtual device of function results

We’ll call these the **critical virtual devices.**

## Syntax for the critical virtual devices

Piggy-backing off the current text representation, we’d like to represent the virtual devices for let-bound variables and function parameters directly after the variable definition in a structure that looks like attributes. 

Here is an example:

```python
def @main(%x: Tensor[(3, 3, 4)], float32] {virtual_device=meta[VirtualDevice][0]},
          virtual_device=meta[VirtualDevice][1] /* result virtual device*/) {
    %0 = split(%x, indices_or_sections=3);
    let %t {virtual_device=meta[VirtualDevice][0]} = %0;
    %2 = %t.1;
    %3 = device_copy(%1, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
    %4 = device_copy(%2, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
	  subtract(%3, %4)
}
```

The function result virtual device is represented directly in the function’s attributes, just like in the current implementation. We are still using the `meta` syntax to represent the value of the virtual device function. In the parser, we’ll “promote” the function’s `virtual_device` attribute to first-class by setting the `virtual_device_` field of the function. We won’t put the virtual device in the attributes of the function.

For variable definitions, the virtual device will be represented directly after the type annotation of the variable in text that looks like attributes. We won’t actually add attributes to variable definitions. However, by using the same syntax as attributes, we can reuse the utilities in the parser for parsing attributes to parse the virtual device. (If there are fields other than `virtual_device` in the fake attributes, the parser will fail). An advantage to this approach is that if we do want to add attributes to bound variables in the future, we don’t need to change our syntax at all. 

## Expansion of minimal representation / propagation of ‘critical’ virtual devices

We’ll introduce a new pass, called DPL (”device plan lite”), which propagates the ‘critical’ virtual devices and `device_copy` virtual devices so that every subexpr’s `virtual_device_` field is populated. This pass will follow simple lexical propagation rules; if it finds a ‘critical’ virtual device that is not set, it will fail. 

Note that in the current implementation, the minimal representation is not expanded into the complete representation at all— rather, during traversal in the DeviceAwareVisitExpr, the visitor keeps track of what the current virtual device is using simple lexical scoping rules. Every time you traverse the program, you must recompute the virtual devices of all the subexpressions. With DPL, we only have to do the propagation once, and we can get rid of DeviceAwareVisitExpr completely.

## Implied virtual device rules

The DPL pass will rely on some implied rules to properly flow device planning information, most importantly

1) The virtual device of an argument to a function is the same as the virtual device of a function parameter

2) Call ops are either literals, globals and possibly let-bound variables

Note that for number 1, the user will need to insert a device copy op around function arguments whose virtual device is different than the corresponding function parameter’s virtual device. Also note that for number 2, if we have a call to something other than a literal, global or let-bound variable, we will need to re-run device planning completely since DPL won’t be able to reconstruct the complete representation.

## Tests in device planning

The test cases will use the new Relay Script syntax and the DPL pass to test device planning.

Let `input` be the input program (in text format), containing `on_device` ops and `device_copy` ops, and `expected` be our expected output program (in text format), which has the virtual device information for every ‘critical’ virtual device.

Then, let  `complete_output = DP(parse(input))` , where `complete_output` is a fully device planned program with all the `virtual_device_` fields propagated (the complete representation).

Now, let `minimal_expected = parse(expected)` be the minimal representation of the fully device planned program. `minimal_expected` doesn’t have all the `virtual_device_` fields propagated, but it does contain enough information to completely reconstruct the device planned program through simple lexical rules. We then use DPL (”device plan lite”) to recreate the original program.

Finally, we can check that `complete_output == DPL(minimal_expected)`. It is also true that `parse(print(complete_output)) == minimal_expected`.

Note that the DPL pass will also be useful for reconstructing any virtual device information that is removed or not propagated correctly by some other Relay pass. We expect that this may occasionally happen. As long as the ‘critical’ virtual devices are preserved, we can run DPL to get the complete representation.