### PR TITLE
[ONNX] Add per channel quantization to QLinearConv and fix related bugs

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -216,6 +216,15 @@ def get_scalar(x, params, dtype="float32"):
     return _op.cast(x, dtype)
 
 
+def get_scalar_or_1d_tensor(x, params, dtype="float32"):
+    """Helper to get a scalar value or 1D tensor for Quantized operators."""
+    if isinstance(x, _expr.Var) and x.name_hint in params:
+        return _op.const(params[x.name_hint].numpy(), dtype)
+    rank = len(infer_shape(x))
+    assert rank <= 1, "scale and zero_point input must be scalars or 1D tensors"
+    return _op.cast(x, dtype)
+
+
 def matmul_out_dtype(inputs, out_dtype):
     """Common function to handle MatMul and MatMulInteger16"""
     a_shape = shape_of(inputs[0])
@@ -3646,10 +3655,20 @@ class QLinearConv(OnnxOpConverter):
         x_scale = get_scalar(inputs[1], params)
         x_zero_point = get_scalar(inputs[2], params, "int32")
         weight = inputs[3]
-        w_scale = get_scalar(inputs[4], params)
-        w_zero_point = get_scalar(inputs[5], params, "int32")
+        w_scale = get_scalar_or_1d_tensor(inputs[4], params)
+        w_zero_point = get_scalar_or_1d_tensor(inputs[5], params, "int32")
         y_scale = fold_constant(get_scalar(inputs[6], params))
         y_zero_point = get_scalar(inputs[7], params, "int32")
+
+        # Check shapes for per channel quantization
+        w_scale_shape = infer_shape(w_scale)
+        w_zero_point_shape = infer_shape(w_zero_point)
+        if len(w_scale_shape) == 1 or len(w_zero_point_shape) == 1:
+            m = infer_shape(weight)[0]
+            if m != w_scale_shape[0] or m != w_zero_point_shape[0]:
+                raise tvm.error.OpAttributeInvalid(
+                    "The number of elements should be equal to the number of output channels"
+                )
 
         input_shape = infer_shape(data)
 
@@ -3723,11 +3742,11 @@ class QLinearConv(OnnxOpConverter):
                 y_scale,
                 y_zero_point,
                 out_dtype=out_dtype,
-                axis=0,
+                axis=1,
             )
         else:
-            out = _qnn.op.dequantize(out, requantize_scale, _op.const(0, dtype="int32"), axis=0)
-            out = _qnn.op.quantize(out, y_scale, y_zero_point, axis=0, out_dtype=out_dtype)
+            out = _qnn.op.dequantize(out, requantize_scale, _op.const(0, dtype="int32"), axis=1)
+            out = _qnn.op.quantize(out, y_scale, y_zero_point, axis=1, out_dtype=out_dtype)
         return out
 
 

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -195,7 +195,7 @@ def helper_no_fast_int8_hw_legalization(attrs, inputs, types, relay_op):
 
         shift_kernel = relay.nn.bias_add(
             relay.cast(kernel, dtype="int16"),
-            relay.cast(kernel_zero_point, dtype="int16"),
+            -relay.cast(kernel_zero_point, dtype="int16"),
             output_axis,
         )
     new_attrs = {k: attrs[k] for k in attrs.keys()}

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5408,6 +5408,7 @@ def test_qlinearconv(target, dev):
         dilations,
         auto_pad="NOTSET",
         bias=False,
+        per_channel_quantization=False,
     ):
 
         x_array = np.random.randint(low=0, high=255, size=x_shape).astype("uint8")
@@ -5416,8 +5417,6 @@ def test_qlinearconv(target, dev):
         initializer = [
             helper.make_tensor("x_scale", TensorProto.FLOAT, (), [np.random.rand()]),
             helper.make_tensor("x_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
-            helper.make_tensor("w_scale", TensorProto.FLOAT, (), [np.random.rand()]),
-            helper.make_tensor("w_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
             helper.make_tensor("y_scale", TensorProto.FLOAT, (), [np.random.rand()]),
             helper.make_tensor("y_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
         ]
@@ -5437,6 +5436,28 @@ def test_qlinearconv(target, dev):
             "y_zero_point",
         ]
         input_values = [x_array, w_array]
+
+        if per_channel_quantization:
+            w_scale_array = np.random.random(w_shape[0]).astype("float32")
+            w_zero_point_array = np.random.randint(0, 255, size=w_shape[0]).astype("uint8")
+
+            initializer.append(
+                helper.make_tensor("w_scale", TensorProto.FLOAT, [w_shape[0]], w_scale_array)
+            )
+            initializer.append(
+                helper.make_tensor(
+                    "w_zero_point", TensorProto.UINT8, [w_shape[0]], w_zero_point_array
+                )
+            )
+        else:
+            initializer.append(
+                helper.make_tensor("w_scale", TensorProto.FLOAT, (), [np.random.rand()])
+            )
+            initializer.append(
+                helper.make_tensor(
+                    "w_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]
+                )
+            )
 
         if bias is True:
             b_shape = w_shape[0:1]
@@ -5576,6 +5597,17 @@ def test_qlinearconv(target, dev):
         repeat(3, D),
         repeat(1, D),
         repeat(2, D),
+    )
+    # Convolution with per channel quantization
+    verify_qlinearconv(
+        (1, 1) + repeat(5, D),
+        (1, 1) + repeat(3, D),
+        (1, 1) + repeat(3, D),
+        None,
+        repeat(3, D),
+        repeat(1, D),
+        repeat(1, D),
+        per_channel_quantization=True,
     )
 
 

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -70,12 +70,12 @@ def test_fake_quantize_conv_per_channel():
         x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
         w = relay.var("w", shape=[16, 3, 5, 5], dtype="int8")
         one = relay.const([1.0] * 16)
-        zero = relay.const([0] * 16)
+        zero_point = relay.const([np.random.randint(0, 255)] * 16)
 
         op = relay.op.nn.conv2d(
             relay.qnn.op.dequantize(x, relay.const(2.0), relay.const(0)),
             relay.qnn.op.dequantize(
-                w, relay.const(np.random.random([16]).astype("float32")), zero, axis=0
+                w, relay.const(np.random.random([16]).astype("float32")), zero_point, axis=0
             ),
             kernel_size=[5, 5],
             channels=16,


### PR DESCRIPTION
The ONNX importer is missing per-channel quantization support for QLinearConv. Also, there are some bugs related to that. This PR adds the missing support to the importer, fixes a related non-zero-point bug in legalization, and updates unit tests.
