### PR TITLE
[CI] Fix Flaky Test `test_task_scheduler_gradient`

### DIFF
--- a/tests/python/unittest/test_auto_scheduler_task_scheduler.py
+++ b/tests/python/unittest/test_auto_scheduler_task_scheduler.py
@@ -101,7 +101,7 @@ def test_task_scheduler_gradient():
         )
 
     def objective_func(costs):
-        return costs[0]
+        return 1e5 * costs[0]
 
     with tempfile.NamedTemporaryFile() as fp:
         log_file = fp.name


### PR DESCRIPTION
A change to fix the issue of flaky test mentioned in #10356 by increase the `chain_rule` factor and avoid small gradient.

CC: @masahi @junrushao1994 
