### PR TITLE
[CMSIS-NN] Only run ScalarToTensorConstants pass on CMSISNN external functions

### DIFF
--- a/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
+++ b/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
@@ -174,20 +174,20 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
 
 IRModule ScalarToTensorConstant(const IRModule& mod) {
   for (auto gv : mod->GetGlobalVars()) {
-    Function main_func = Downcast<Function>(mod->Lookup(gv));
+    Function func = Downcast<Function>(mod->Lookup(gv));
 
     // only mutate CMSIS-NN external functions
-    auto compiler_name = main_func->GetAttr<String>(attr::kCompiler);
+    auto compiler_name = func->GetAttr<String>(attr::kCompiler);
     if (!compiler_name.defined() || compiler_name != "cmsis-nn") {
       continue;
     }
 
     auto mutator = ScalarToTensorConstantMutator(mod);
-    auto new_main_body = mutator.VisitExpr(main_func->body);
-    if (!new_main_body.same_as(main_func->body)) {
-      Function new_main_func = Function(main_func->params, new_main_body, main_func->ret_type,
-                                        main_func->type_params, main_func->attrs);
-      mod->Update(gv, new_main_func);
+    auto new_func_body = mutator.VisitExpr(func->body);
+    if (!new_func_body.same_as(func->body)) {
+      Function new_func =
+          Function(func->params, new_func_body, func->ret_type, func->type_params, func->attrs);
+      mod->Update(gv, new_func);
     }
   }
   return mod;

--- a/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
+++ b/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
@@ -76,10 +76,6 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
     if (auto* glob_var_node = call->op.as<GlobalVarNode>()) {
       GlobalVar global_var = GetRef<GlobalVar>(glob_var_node);
       Function func = Downcast<Function>(mod_->Lookup(global_var));
-      auto compiler_name = func->GetAttr<String>(::tvm::relay::attr::kCompiler);
-      if (!compiler_name.defined() || compiler_name != "cmsis-nn") {
-        return final_call;
-      }
       auto new_body = VisitExpr(func->body);
       if (new_body.same_as(func->body)) {
         return final_call;
@@ -177,14 +173,22 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
 };
 
 IRModule ScalarToTensorConstant(const IRModule& mod) {
-  auto mutator = ScalarToTensorConstantMutator(mod);
-  Function main_func = Downcast<Function>(mod->Lookup("main"));
-  auto new_main_body = mutator.VisitExpr(main_func->body);
-  if (!new_main_body.same_as(main_func->body)) {
-    auto main_var = mod->GetGlobalVar("main");
-    auto new_main_func = Function(main_func->params, new_main_body, main_func->ret_type,
-                                  main_func->type_params, main_func->attrs);
-    mod->Update(main_var, new_main_func);
+  for (auto gv : mod->GetGlobalVars()) {
+    Function main_func = Downcast<Function>(mod->Lookup(gv));
+
+    // only mutate CMSIS-NN external functions
+    auto compiler_name = main_func->GetAttr<String>(attr::kCompiler);
+    if (!compiler_name.defined() || compiler_name != "cmsis-nn") {
+      continue;
+    }
+
+    auto mutator = ScalarToTensorConstantMutator(mod);
+    auto new_main_body = mutator.VisitExpr(main_func->body);
+    if (!new_main_body.same_as(main_func->body)) {
+      Function new_main_func = Function(main_func->params, new_main_body, main_func->ret_type,
+                                        main_func->type_params, main_func->attrs);
+      mod->Update(gv, new_main_func);
+    }
   }
   return mod;
 }


### PR DESCRIPTION
Ensures the `ScalarToTensorConstants` pass only runs on functions with the "cmsis-nn" compiler attribute. Previously, it was possible for parts of the pass to run on all of the input. For example, `ReplaceScalarWithTensorVariable` was running on all OpNodes without regard to the containing function. As a result, this change means that the pass now visits each CMSIS-NN function separately, rather than visiting the body of the main function.