### PR TITLE
[microNPU] Added various options to the cascader

### DIFF
--- a/python/tvm/contrib/ethosu/cascader/__init__.py
+++ b/python/tvm/contrib/ethosu/cascader/__init__.py
@@ -36,5 +36,6 @@ from .parts import InlinePart, EthosuPart
 from .device_config import EthosuDeviceConfig
 from .tensor_config import TensorConfigState, MemoryRegion, TensorConfig
 from .plan import Plan
+from .logging import Logging
 from .scheduler import apply_proposal, cascade
 from .cascader_options import CascaderOptions

--- a/python/tvm/contrib/ethosu/cascader/block_config.py
+++ b/python/tvm/contrib/ethosu/cascader/block_config.py
@@ -45,5 +45,17 @@ class BlockConfig(Object):
     def output_cycles(self) -> int:
         return int(self._output_cycles)
 
+    def __ge__(self, other: "BlockConfig"):
+        if len(self.output_shape) != len(other.output_shape):
+            return False
+
+        return all(a >= b for a, b in zip(self.output_shape, other.output_shape))
+
+    def __lt__(self, other: "BlockConfig"):
+        if len(self.output_shape) != len(other.output_shape):
+            return False
+
+        return other >= self
+
     def __repr__(self) -> str:
         return f"BlockConfig(output_shape={self.output_shape})"

--- a/python/tvm/contrib/ethosu/cascader/cascader_options.py
+++ b/python/tvm/contrib/ethosu/cascader/cascader_options.py
@@ -49,7 +49,13 @@ class CascaderOptions(Object):
         max_proposals: int,
         stripe_factors: int,
         max_plan_size: int,
+        max_open_plans: int,
+        max_closed_plans: int,
         always_copy_size: int,
+        disable_pareto_plans: bool = False,
+        disable_pareto_proposals: bool = False,
+        multi_dimensional_striping: bool = False,
+        disable_block_culling: bool = True,
     ):
         self.__init_handle_by_constructor__(
             _ffi_api.CascaderOptions,
@@ -57,5 +63,11 @@ class CascaderOptions(Object):
             max_proposals,
             stripe_factors,
             max_plan_size,
+            max_open_plans,
+            max_closed_plans,
             always_copy_size,
+            disable_pareto_plans,
+            disable_pareto_proposals,
+            multi_dimensional_striping,
+            disable_block_culling,
         )

--- a/python/tvm/contrib/ethosu/cascader/device_config.py
+++ b/python/tvm/contrib/ethosu/cascader/device_config.py
@@ -21,6 +21,7 @@ from functools import reduce
 
 import math
 
+import tvm
 from . import BlockConfig
 from . import StripeConfig
 from . import Propagator
@@ -64,13 +65,14 @@ class _Shape:
 class EthosuDeviceConfig:
     """Arm(R) Ethos(TM)-U NPU config class"""
 
-    def __init__(self, device: str):
+    def __init__(self, device: str, disable_block_bulling: bool = False):
         self._device = device
         self._subkernel_limits = (8, 8)
         self._output_cycles = (1, 2, 3, 4, 6)
         self._split_depth = 16
         self._max_block_shape = _Shape([1, 32, 64, 128])
         self._bank_size_bytes = 1024
+        self._disable_block_culling = disable_block_bulling
         if self._device == "ethos-u55-256":
             self._micro_block = _Shape([1, 2, 2, 8])
             self._input_micro_block = _Shape([1, 2, 2, 8])
@@ -491,6 +493,28 @@ class EthosuDeviceConfig:
         if activation == "LUT" and not self._lut_reserved:
             banks_available -= 2
 
+        # Handle user-forced block config
+        options = tvm.transform.PassContext.current().config.get("relay.ext.ethos-u.options", None)
+        if options and options.dev_force_block_config:
+            block_config = [int(v) for v in options.dev_force_block_config.split("x")]
+            assert len(block_config) == 3
+            if output_layout == "NHWC":
+                block_shape = [output_shape[0], block_config[0], block_config[1], block_config[2]]
+            else:
+                block_shape = [
+                    output_shape[0],
+                    block_config[0],
+                    1 + ((block_config[2] - 1) // 16),
+                    block_config[1],
+                    16,
+                ]
+            output_cycles = self._get_output_cycles(
+                op_type, op_str, ifm_dtype, ofm_dtype, activation
+            )
+            output_cycles *= reduce(lambda a, b: a * b, block_shape, 1)
+            output_cycles = int(math.ceil(output_cycles))
+            return [BlockConfig(block_shape, 0, output_cycles)]
+
         # Split the block in half until it fits into SHRAM
         if output_layout == "NHCWB16":
             split_order = (a for a in [1, 3, 2])
@@ -649,6 +673,21 @@ class EthosuDeviceConfig:
         max_depth = min(ofm_channels, self._max_block_shape.depth)
         min_depth = max(self._micro_block.depth, upscaling_factor)
 
+        heights = range(min_height, max_height + min_height, min_height)
+        widths = range(min_width, max_width + min_width, min_width)
+        depths = range(min_depth, max_depth + min_depth, min_depth)
+
+        # Handle user-forced block config
+        options = tvm.transform.PassContext.current().config.get("relay.ext.ethos-u.options", None)
+        forced = False
+        if options and options.dev_force_block_config:
+            block_config = [int(v) for v in options.dev_force_block_config.split("x")]
+            assert len(block_config) == 3
+            heights = [block_config[0]]
+            widths = [block_config[1]]
+            depths = [block_config[2]]
+            forced = True
+
         input_bytewidth = 1 if ifm_dtype == "int8" else 2
         acc_bytewidth = self._get_accumulator_width(op_type, ifm_dtype)
         banks_available = self._total_banks - self._reserved_banks
@@ -664,22 +703,20 @@ class EthosuDeviceConfig:
             else:
                 input_block_depth = min(ifm_channels, 32)
 
-        for depth in range(min_depth, max_depth + min_depth, min_depth):
-            if (depth < output_shape.depth) and (depth % self._split_depth != 0):
+        for depth in reversed(depths):
+            if (depth < output_shape.depth) and (depth % self._split_depth != 0) and not forced:
                 # Block depth has to be less than full depth or a multiple of the split depth
                 continue
 
-            for width in range(min_width, max_width + min_width, min_width):
-                for height in range(min_height, max_height + min_height, min_height):
+            for width in reversed(widths):
+                for height in reversed(heights):
                     if output_layout == "NHCWB16":
                         output_block = (
                             1,
                             height,
                             1 + ((depth - 1) // 16),
                             width,
-                            _round_up(
-                                min(16, max(ofm_channels, min_depth)), self._micro_block.depth
-                            ),
+                            min(16, _round_up(ofm_channels, self._micro_block.depth)),
                         )
                         order = [1, 2, 4, 3, 0]
                     else:
@@ -738,13 +775,28 @@ class EthosuDeviceConfig:
                             ifm_channels,
                             is_partkernel,
                         )
-                        valid_block_configs.append(
-                            BlockConfig(output_block, compute_cycles, output_cycles)
-                        )
-                    else:
-                        # Block config does not fit into SHRAM
-                        # Any Block config that is strictly larger than this one will also fail
-                        break
+
+                        block_config = BlockConfig(output_block, compute_cycles, output_cycles)
+                        if self._disable_block_culling:
+                            # Block culling disabled - add all block configs that fit
+                            valid_block_configs.append(block_config)
+                        else:
+                            # Add block config only if it's not dominated by an existing block.
+                            # A block config is dominated by another if its output_shape is greater
+                            # or equal in every dimension and strictly greater in at least one
+                            # dimension.
+                            dominated = False
+                            for valid_block in valid_block_configs:
+                                if block_config < valid_block:
+                                    dominated = True
+                                    break
+
+                            if not dominated:
+                                valid_block_configs.append(block_config)
+
+                            # Every consecutive block in the innermost loop will be dominated by
+                            # this one so break
+                            break
 
         return valid_block_configs
 

--- a/python/tvm/contrib/ethosu/cascader/logging.py
+++ b/python/tvm/contrib/ethosu/cascader/logging.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""A class to hold logging information about the cascader"""
+from typing import Tuple
+import datetime
+import json
+import os
+import math
+
+
+class Logging:
+    """Cascader logging class"""
+
+    def __init__(self):
+        self.min_memory_usage = 0
+        self.max_memory_usage = 0
+        self.min_cycles = 0
+        self.max_cycles = 0
+
+        self.selected_proposal_idx = -1
+        self.proposals = {}
+        self.cascader_runtime = 0
+
+    def add_proposal(self, idx: int, memory_usage: int, cycles: int):
+        self.proposals[idx] = {"memory_usage": memory_usage, "cycles": cycles}
+
+    def get_extreme_points(self) -> Tuple[int, int, int, int]:
+        min_cycles, min_mem_usage = math.inf, math.inf
+        max_cycles, max_mem_usage = 0, 0
+        for proposal in self.proposals.values():
+            min_mem_usage = min(proposal["memory_usage"], min_mem_usage)
+            max_mem_usage = max(proposal["memory_usage"], max_mem_usage)
+            min_cycles = min(proposal["cycles"], min_cycles)
+            max_cycles = max(proposal["cycles"], max_cycles)
+
+        return min_mem_usage, max_mem_usage, min_cycles, max_cycles
+
+    def dump_json(self):
+        min_mem_usage, max_mem_usage, min_cycles, max_cycles = self.get_extreme_points()
+        with open(os.getcwd() + "/cascader_log.json", "w") as json_file:
+            print(
+                json.dumps(
+                    {
+                        "date": f"{datetime.datetime.now()}",
+                        "cascader_runtime": self.cascader_runtime,
+                        "min_cycles": min_cycles,
+                        "max_cycles": max_cycles,
+                        "min_memory_usage": min_mem_usage,
+                        "max_memory_usage": max_mem_usage,
+                        "selected_proposal": self.selected_proposal_idx,
+                        "proposals": self.proposals,
+                    },
+                    indent=2,
+                ),
+                file=json_file,
+            )

--- a/python/tvm/contrib/ethosu/cascader/pareto.py
+++ b/python/tvm/contrib/ethosu/cascader/pareto.py
@@ -35,5 +35,7 @@ def _thin_vector(vec: List[Object], max_size: int) -> List[Object]:
     return list(_ffi_api.ThinVector(vec, max_size))
 
 
-def _pareto_cull_plans(plans: List[Plan], max_plans: int) -> List[Plan]:
-    return list(_ffi_api.ParetoCullPlans(plans, max_plans))
+def _pareto_cull_plans(
+    plans: List[Plan], max_plans: int, disable_pareto_metric: bool
+) -> List[Plan]:
+    return list(_ffi_api.ParetoCullPlans(plans, max_plans, disable_pareto_metric))

--- a/python/tvm/contrib/ethosu/cascader/plan_generator.py
+++ b/python/tvm/contrib/ethosu/cascader/plan_generator.py
@@ -26,8 +26,10 @@ from .stripe_config import StripeConfig
 from .graph import CascaderGraph, Part, Tensor
 
 
-def _generate_output_stripe_configs(part: Part, stripe_factors: int) -> List[StripeConfig]:
-    return list(_ffi_api.GenerateOutputStripeConfigs(part, stripe_factors))
+def _generate_output_stripe_configs(
+    part: Part, stripe_factors: int, multi_dimensional: bool
+) -> List[StripeConfig]:
+    return list(_ffi_api.GenerateOutputStripeConfigs(part, stripe_factors, multi_dimensional))
 
 
 def _generate_single_plans(

--- a/python/tvm/contrib/ethosu/cascader/scheduler.py
+++ b/python/tvm/contrib/ethosu/cascader/scheduler.py
@@ -17,8 +17,10 @@
 """Scheduler for cascader which converts Proposals into Schedules."""
 from typing import Tuple, List, Dict, DefaultDict
 from collections import defaultdict
+import time
 import numpy as np
 
+import tvm
 from tvm import te
 from tvm import tir
 from .cascader_options import CascaderOptions
@@ -28,6 +30,7 @@ from .proposal import Proposal
 from .proposal_generator import generate_proposals
 from .graph import create_cascader_graph
 from .device_config import EthosuDeviceConfig
+from .logging import Logging
 
 
 def tile_nd(
@@ -165,13 +168,19 @@ def create_home_map(
     return home_map
 
 
-def choose_proposal(proposals: List[Proposal], cascade_region: MemoryRegion):
+def choose_proposal(
+    proposals: List[Proposal], cascade_region: MemoryRegion, select_proposal_idx: int
+):
     """Choose the best performing Proposal that doesn't overflow the cascade region."""
-    proposal_choice = proposals[0]
-    for proposal in reversed(proposals):
-        if proposal.memory_usage < cascade_region.size:
-            proposal_choice = proposal
-            break
+    if select_proposal_idx != -1:
+        # Manually select proposal based on index
+        proposal_choice = proposals[select_proposal_idx % len(proposals)]
+    else:
+        proposal_choice = proposals[0]
+        for proposal in reversed(proposals):
+            if proposal.memory_usage < cascade_region.size:
+                proposal_choice = proposal
+                break
 
     return proposal_choice
 
@@ -219,6 +228,17 @@ def cascade(
         Target device configuration.
 
     """
+    tvmc_options = tvm.transform.PassContext.current().config.get("relay.ext.ethos-u.options", None)
+    log = Logging() if tvmc_options and tvmc_options.dev_cascader_logging else None
+    select_proposal_idx = (
+        int(tvmc_options.dev_select_proposal_idx)
+        if tvmc_options and tvmc_options.dev_select_proposal_idx
+        else -1
+    )
+
+    if log:
+        start = time.time()
+
     assert options.cascade_region in working_regions
     # First convert the Tensor Expression graph into a CascaderGraph
     casc_graph = create_cascader_graph(te_graph, const_dict, device_config)
@@ -227,6 +247,16 @@ def cascade(
     # Generate Proposals for Pareto-optimal ways to cascade the CascaderGraph
     proposals = generate_proposals(casc_graph, home_map, options)
     # Select the best Proposal subject to the memory constraints
-    proposal_choice = choose_proposal(proposals, options.cascade_region)
+    proposal_choice = choose_proposal(proposals, options.cascade_region, select_proposal_idx)
+
+    if log:
+        for idx, proposal in enumerate(proposals):
+            log.add_proposal(idx, proposal.memory_usage, proposal.cycles)
+            if proposal == proposal_choice:
+                log.selected_proposal_idx = idx
+
+        log.cascader_runtime = time.time() - start
+        log.dump_json()
+
     # Apply the selected Proposal to the Tensor Expression Schedule
     apply_proposal(proposal_choice, sch)

--- a/python/tvm/contrib/ethosu/cascader/scheduler.py
+++ b/python/tvm/contrib/ethosu/cascader/scheduler.py
@@ -1,0 +1,232 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Scheduler for cascader which converts Proposals into Schedules."""
+from typing import Tuple, List, Dict, DefaultDict
+from collections import defaultdict
+import numpy as np
+
+from tvm import te
+from tvm import tir
+from .cascader_options import CascaderOptions
+from .graph import CascaderGraph, Part, Tensor, TESubgraph
+from .tensor_config import MemoryRegion
+from .proposal import Proposal
+from .proposal_generator import generate_proposals
+from .graph import create_cascader_graph
+from .device_config import EthosuDeviceConfig
+
+
+def tile_nd(
+    sch: te.Schedule, tensor: te.Tensor, tile: Tuple[int, ...]
+) -> Tuple[List[tir.IterVar], List[tir.IterVar]]:
+    """Scheduling utility to perform N-dimensional tiling.
+
+    Parameters
+    ----------
+    sch : te.Schedule
+        The schedule to apply the tiling to.
+    tensor : te.Tensor
+        The tensor to apply the tiling to.
+    tile : Tuple[int, ...]
+        The N-dimensional tile size.
+
+    Returns
+    -------
+    outer_indices : List[tir.IterVar]
+        The outer iteration variables.
+    inner_indices : List[tir.IterVar]
+        The inner iteration variables.
+
+    """
+    outer_indices = []
+    inner_indices = []
+    for i, size in enumerate(tile):
+        outer, inner = sch[tensor].split(tensor.op.axis[i], size)
+        outer_indices.append(outer)
+        inner_indices.append(inner)
+
+    sch[tensor].reorder(*outer_indices, *inner_indices)
+    return outer_indices, inner_indices
+
+
+def stripe_part(
+    part: Part, stripe_shape: Tuple[int, ...], sch: te.Schedule
+) -> Tuple[te.Stage, tir.IterVar]:
+    """Apply a striping schedule to the TE subgraph represented by a Part."""
+    te_subgraph = part.subgraph
+    te_output_tensor = te_subgraph.output_tensor
+    outer_indices, _ = tile_nd(sch, te_output_tensor, stripe_shape)
+    g = sch.create_group(
+        outputs=te_output_tensor.op.input_tensors,
+        inputs=te_subgraph.input_tensors,
+        include_inputs=False,
+    )
+    g.compute_at(sch[te_output_tensor], outer_indices[-1])
+    for ax in outer_indices:
+        sch[te_output_tensor].unroll(ax)
+
+    return sch[te_output_tensor], outer_indices[-1]
+
+
+def cascade_part(
+    part: Part, stripe_stage: te.Stage, stripe_axis: tir.IterVar, sch: te.Schedule
+) -> None:
+    """Schedule a Part into a cascade indicated by a stripe Stage."""
+    te_subgraph = part.subgraph
+    g = sch.create_group(
+        outputs=te_subgraph.output_tensor, inputs=te_subgraph.input_tensors, include_inputs=False
+    )
+    g.compute_at(stripe_stage, stripe_axis)
+
+
+def update_readers(part: Part, readers: DefaultDict[te.Tensor, List[te.Tensor]]) -> None:
+    """Update a dictionary which stores the te.Tensors that need to be read in order to produce a given te.Tensor."""
+    visited = set()
+
+    def _visit(tensor):
+        if tensor is not visited and tensor not in part.subgraph.input_tensors:
+            visited.add(tensor)
+            for input_tensor in tensor.op.input_tensors:
+                readers[input_tensor].append(tensor)
+                _visit(input_tensor)
+
+    _visit(part.subgraph.output_tensor)
+
+
+def apply_proposal(proposal: Proposal, sch: te.Schedule) -> None:
+    """Apply a Proposal to a Schedule, converting all the Plans into TE scheduling instructions.
+
+    Note that the Schedule is mutated in-place.
+
+    Parameters
+    ----------
+    proposal : Proposal
+        The Proposal to apply to the Schedule.
+    sch : te.Schedule
+        The Schedule to apply to Proposal to.
+
+    """
+    for plan in proposal.plans:
+        output_tensor_config = plan.output_config
+        output_tensor = output_tensor_config.tensor
+        output_part = output_tensor.producers[0]
+        if output_part.in_line:
+            continue
+        stripe_config = output_tensor_config.stripe_configs[0]
+        stripe_shape = [int(x) for x in stripe_config.shape]
+        stripe_stage, stripe_axis = stripe_part(output_part, stripe_shape, sch)
+        copy_te_tensors = []
+        readers = defaultdict(list)
+        for part in plan.part_group:
+            if part != output_part:
+                cascade_part(part, stripe_stage, stripe_axis, sch)
+
+            update_readers(part, readers)
+            for i, input_tensor in enumerate(part.input_tensors):
+                tensor_config = plan.tensor_configs[input_tensor]
+                if tensor_config.home_region != tensor_config.copy_region:
+                    copy_te_tensors.append(part.subgraph.input_tensors[i])
+
+        for te_tensor in copy_te_tensors:
+            copy_stage = sch.cache_read(te_tensor, "global", readers[te_tensor])
+            sch[copy_stage].compute_at(stripe_stage, stripe_axis)
+
+
+def create_home_map(
+    graph: CascaderGraph,
+    io_region: MemoryRegion,
+    constant_region: MemoryRegion,
+    working_regions: List[MemoryRegion],
+) -> Dict[Tensor, List[MemoryRegion]]:
+    """Create a map between Tensors and the MemoryRegions they can be homed in."""
+    home_map = {}
+    for tensor in graph.tensor_order:
+        if tensor.is_constant:
+            home_map[tensor] = [constant_region]
+        elif tensor in graph.input_tensors or tensor in graph.output_tensors:
+            home_map[tensor] = [io_region]
+        else:
+            home_map[tensor] = working_regions
+
+    return home_map
+
+
+def choose_proposal(proposals: List[Proposal], cascade_region: MemoryRegion):
+    """Choose the best performing Proposal that doesn't overflow the cascade region."""
+    proposal_choice = proposals[0]
+    for proposal in reversed(proposals):
+        if proposal.memory_usage < cascade_region.size:
+            proposal_choice = proposal
+            break
+
+    return proposal_choice
+
+
+def cascade(
+    sch: te.Schedule,
+    te_graph: TESubgraph,
+    const_dict: Dict[int, np.ndarray],
+    options: CascaderOptions,
+    io_region: MemoryRegion,
+    constant_region: MemoryRegion,
+    working_regions: List[MemoryRegion],
+    device_config: EthosuDeviceConfig,
+) -> None:
+    """Schedule a Tensor Expression graph using the technique of 'cascading'.
+
+    'Cascading' is a technique whereby operations are split into smaller
+    dependent tiles ('stripes') which can then execute in an interleaved
+    fashion. This allows for operations to execute together rather than
+    sequentially which can reduce intermediate memory requirements and in
+    certain cases improve performance.
+
+    For more detail on 'cascading' as well as how it is implemented, refer to
+    the RFC here: https://github.com/apache/tvm-rfcs/pull/37.
+
+    Parameters
+    ----------
+    sch : te.Schedule
+        The Schedule to apply the cascading to.
+    te_graph : TESubgraph
+        The Tensor Expression graph from which the Schedule was created.
+    const_dict : Dict[int, np.ndarray]
+        A dictionary mapping input index to constant data if that input is
+        to be a constant.
+    options : CascaderOptions
+        Configuration options for the cascading scheduler.
+    io_region : MemoryRegion
+        The MemoryRegion in which input/output tensors should reside.
+    constant_region : MemoryRegion
+        The MemoryRegion in which constants should reside.
+    working_regions : List[MemoryRegion]
+        The MemoryRegions in which intermediate working tensors can reside. The
+        cascading scheduler will select which MemoryRegion to per tensor.
+    device_config : EthosuDeviceConfig
+        Target device configuration.
+
+    """
+    assert options.cascade_region in working_regions
+    # First convert the Tensor Expression graph into a CascaderGraph
+    casc_graph = create_cascader_graph(te_graph, const_dict, device_config)
+    # Then create a mapping between Tensors and their possible memory homes
+    home_map = create_home_map(casc_graph, io_region, constant_region, working_regions)
+    # Generate Proposals for Pareto-optimal ways to cascade the CascaderGraph
+    proposals = generate_proposals(casc_graph, home_map, options)
+    # Select the best Proposal subject to the memory constraints
+    proposal_choice = choose_proposal(proposals, options.cascade_region)
+    # Apply the selected Proposal to the Tensor Expression Schedule
+    apply_proposal(proposal_choice, sch)

--- a/python/tvm/relay/backend/contrib/ethosu/vela_api.py
+++ b/python/tvm/relay/backend/contrib/ethosu/vela_api.py
@@ -67,6 +67,10 @@ def get_optimal_block_config(
     ethosu.vela.api.NpuShape3D :
         The optimal block config for the operator
     """
+    options = tvm.transform.PassContext.current().config.get("relay.ext.ethos-u.options", None)
+    if options and options.dev_force_block_config:
+        block_config = [int(v) for v in options.dev_force_block_config.split("x")]
+        return vapi.NpuShape3D(height=block_config[0], width=block_config[1], depth=block_config[2])
     all_valid_block_configs = vapi.npu_find_block_configs(npu_op, accel_config)
     return _get_optimal_block_config(all_valid_block_configs)
 

--- a/src/contrib/ethosu/cascader/block_config.cc
+++ b/src/contrib/ethosu/cascader/block_config.cc
@@ -35,6 +35,8 @@ namespace cascader {
 void BlockConfigNode::VisitAttrs(AttrVisitor* v) {
   Array<Integer> tmp_arr = make_array(output_shape_);
   v->Visit("_output_shape", &tmp_arr);
+  v->Visit("_compute_cycles", &compute_cycles_);
+  v->Visit("_output_cycles", &output_cycles_);
 }
 
 BlockConfig::BlockConfig(const std::vector<int>& output_shape, int compute_cycles,

--- a/src/contrib/ethosu/cascader/cascader_options.cc
+++ b/src/contrib/ethosu/cascader/cascader_options.cc
@@ -30,25 +30,45 @@ void CascaderOptionsNode::VisitAttrs(AttrVisitor* v) {
   v->Visit("max_proposals", &max_proposals);
   v->Visit("stripe_factors", &stripe_factors);
   v->Visit("max_plan_size", &max_plan_size);
+  v->Visit("max_open_plans", &max_open_plans);
+  v->Visit("max_closed_plans", &max_closed_plans);
   v->Visit("always_copy_size", &always_copy_size);
+  v->Visit("disable_pareto_plans", &disable_pareto_plans);
+  v->Visit("disable_pareto_proposals", &disable_pareto_proposals);
+  v->Visit("multi_dimensional_striping", &multi_dimensional_striping);
+  v->Visit("disable_block_culling", &disable_block_culling);
 }
 
 CascaderOptions::CascaderOptions(const MemoryRegion& cascade_region, int max_proposals,
-                                 int stripe_factors, int max_plan_size, int always_copy_size) {
+                                 int stripe_factors, int max_plan_size, int max_open_plans,
+                                 int max_closed_plans, int always_copy_size,
+                                 bool disable_pareto_plans, bool disable_pareto_proposals,
+                                 bool multi_dimensional_striping, bool disable_block_culling) {
   auto n = make_object<CascaderOptionsNode>();
   n->cascade_region = std::move(cascade_region);
   n->max_proposals = max_proposals;
   n->stripe_factors = stripe_factors;
   n->max_plan_size = max_plan_size;
+  n->max_open_plans = max_open_plans;
+  n->max_closed_plans = max_closed_plans;
   n->always_copy_size = always_copy_size;
+  n->disable_pareto_plans = disable_pareto_plans;
+  n->disable_pareto_proposals = disable_pareto_proposals;
+  n->multi_dimensional_striping = multi_dimensional_striping;
+  n->disable_block_culling = disable_block_culling;
   data_ = std::move(n);
 }
 
 TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.CascaderOptions")
     .set_body_typed([](MemoryRegion cascade_region, int max_proposals, int stripe_factors,
-                       int max_plan_size, int always_copy_size) {
+                       int max_plan_size, int max_open_plans, int max_closed_plans,
+                       int always_copy_size, bool disable_pareto_plans,
+                       bool disable_pareto_proposals, bool multi_dimensional_striping,
+                       bool disable_block_culling) {
       return CascaderOptions(cascade_region, max_proposals, stripe_factors, max_plan_size,
-                             always_copy_size);
+                             max_open_plans, max_closed_plans, always_copy_size,
+                             disable_pareto_plans, disable_pareto_proposals,
+                             multi_dimensional_striping, disable_block_culling);
     });
 
 TVM_REGISTER_NODE_TYPE(CascaderOptionsNode);

--- a/src/contrib/ethosu/cascader/cascader_options.h
+++ b/src/contrib/ethosu/cascader/cascader_options.h
@@ -47,8 +47,20 @@ class CascaderOptionsNode : public Object {
   int stripe_factors;
   /*! \brief The maximum number of Parts in a Plan. */
   int max_plan_size;
+  /*! \brief The maximum number of open Plans saved for a Part Group */
+  int max_open_plans;
+  /*! \brief The maximum number of closed Plans saved for a Part Group */
+  int max_closed_plans;
   /*! \brief The maximum size of Tensor that will always be copied into the cascade region. */
   int always_copy_size;
+  /*! \brief Flag to disable pareto culling for plans to allow non pareto-optimal plans */
+  bool disable_pareto_plans;
+  /*! \brief Flag to disable pareto culling for proposals to allow non pareto-optimal proposals */
+  bool disable_pareto_proposals;
+  /*! \brief Whether to consider multi-dimensional striping */
+  bool multi_dimensional_striping;
+  /*! \brief Flag to disable culling for block configs to allow non-dominant blocks */
+  bool disable_block_culling;
 
   static constexpr const char* _type_key = "contrib.ethosu.cascader.CascaderOptions";
   TVM_DECLARE_FINAL_OBJECT_INFO(CascaderOptionsNode, Object)
@@ -58,7 +70,9 @@ class CascaderOptionsNode : public Object {
 class CascaderOptions : public ObjectRef {
  public:
   CascaderOptions(const MemoryRegion& cascade_region, int max_proposals, int stripe_factors,
-                  int max_plan_size, int always_copy_size);
+                  int max_plan_size, int max_open_plans, int max_closed_plans, int always_copy_size,
+                  bool disable_pareto_plans, bool disable_pareto_proposals,
+                  bool multi_dimensional_striping, bool disable_block_culling);
 
   TVM_DEFINE_OBJECT_REF_METHODS(CascaderOptions, ObjectRef, CascaderOptionsNode);
 };

--- a/src/contrib/ethosu/cascader/pareto.h
+++ b/src/contrib/ethosu/cascader/pareto.h
@@ -65,9 +65,11 @@ std::vector<T> ThinVector(const std::vector<T>& vec, size_t max_size);
  * \note Plan Pareto-optimality is determined based upon a Plan's memory_usage
  * and cycles.
  */
-std::vector<Plan> ParetoCullPlans(std::vector<Plan> plans, size_t max_plans);
+std::vector<Plan> ParetoCullPlans(std::vector<Plan> plans, size_t max_plans,
+                                  bool disable_pareto_metric);
 
-std::vector<Proposal> ParetoCullProposals(std::vector<Proposal> proposals, size_t max_proposals);
+std::vector<Proposal> ParetoCullProposals(std::vector<Proposal> proposals, size_t max_proposals,
+                                          bool disable_pareto_metric);
 
 }  // namespace cascader
 }  // namespace ethosu

--- a/src/contrib/ethosu/cascader/plan_generator.cc
+++ b/src/contrib/ethosu/cascader/plan_generator.cc
@@ -89,7 +89,8 @@ std::vector<bool> GetCascadableAxes(const Part& part) {
   return cascadable_axes;
 }
 
-std::vector<StripeConfig> GenerateOutputStripeConfigs(const Part& part, int stripe_factors) {
+std::vector<StripeConfig> GenerateOutputStripeConfigs(const Part& part, int stripe_factors,
+                                                      bool multi_dimensional) {
   // If stripe_factors is <= 0, then we won't produce any StripeConfigs
   if (stripe_factors <= 0) {
     return std::vector<StripeConfig>();
@@ -130,11 +131,29 @@ std::vector<StripeConfig> GenerateOutputStripeConfigs(const Part& part, int stri
     }
     splits.push_back(std::vector<int>(axis_splits.begin(), axis_splits.end()));
   }
-  // Now calculate all the possible combinations of splits for each dimension
-  // to give us all the possible stripe shapes. For example, if we had two axes
-  // both with possible splits in {128, 64, 32, 1}, the stripe shapes would be:
-  // (128, 128), (128, 64), (128, 32) ... (1, 64), (1, 32), (1, 1)
-  auto stripe_shapes = EnumerateCombinations<int>(splits);
+
+  std::vector<std::vector<int>> stripe_shapes;
+  if (multi_dimensional) {
+    // Now calculate all the possible combinations of splits for each dimension
+    // to give us all the possible stripe shapes. For example, if we had two axes
+    // both with possible splits in {128, 64, 32, 1}, the stripe shapes would be:
+    // (128, 128), (128, 64), (128, 32) ... (1, 64), (1, 32), (1, 1)
+    stripe_shapes = EnumerateCombinations<int>(splits);
+  } else {
+    // Only consider splitting a single axis
+    int axis = 0;
+    for (const auto& split : splits) {
+      for (const auto& axis_split : split) {
+        std::vector<int> stripe_shape = output_shape;
+        if (stripe_shape[axis] != axis_split) {
+          stripe_shape[axis] = axis_split;
+          stripe_shapes.push_back(stripe_shape);
+        }
+      }
+      axis++;
+    }
+    stripe_shapes.push_back(output_shape);
+  }
   auto offset = std::vector<int>(output_dims);
   std::vector<StripeConfig> stripe_configs;
   // Calculate the possible axis orderings such that each axis has the opportunity
@@ -398,8 +417,8 @@ std::unordered_map<std::vector<Part>, std::vector<Plan>> GenerateGraphPlans(
     // First generate all the possible StripeConfigs for the Part assuming that it will become the
     // output of a Plan. The number generated is a function of stripe_factors and the number of
     // cascadable dimensions in the Part.
-    std::vector<StripeConfig> stripe_configs =
-        GenerateOutputStripeConfigs(part, options->stripe_factors);
+    std::vector<StripeConfig> stripe_configs = GenerateOutputStripeConfigs(
+        part, options->stripe_factors, options->multi_dimensional_striping);
     // Check to see if the output Tensor is part of any existing open Plans
     if (stripe_configs_by_tensor.find(part->GetOutputTensor()) != stripe_configs_by_tensor.end()) {
       // If there are other open Plans which have this Part's output Tensor as an input, then
@@ -453,10 +472,12 @@ std::unordered_map<std::vector<Part>, std::vector<Plan>> GenerateGraphPlans(
     // and plans_by_config maps.
     for (const auto& part_group : new_part_groups) {
       if (closed_plans.find(part_group) != closed_plans.end()) {
-        closed_plans[part_group] = ParetoCullPlans(closed_plans.at(part_group), 32);
+        closed_plans[part_group] = ParetoCullPlans(
+            closed_plans.at(part_group), options->max_closed_plans, options->disable_pareto_plans);
       }
       for (const auto& it : open_plans[part_group]) {
-        auto pareto_plans = ParetoCullPlans(it.second, 8);
+        auto pareto_plans =
+            ParetoCullPlans(it.second, options->max_open_plans, options->disable_pareto_plans);
         for (const auto& plan : pareto_plans) {
           for (const auto& open_config : plan->GetOpenConfigs()) {
             if (open_config != plan->GetOutputConfig()) {
@@ -477,11 +498,12 @@ std::unordered_map<std::vector<Part>, std::vector<Plan>> GenerateGraphPlans(
 }
 
 TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.GenerateOutputStripeConfigs")
-    .set_body_typed([](Part part, int stripe_factors) {
+    .set_body_typed([](Part part, int stripe_factors, bool multi_dimensional) {
       if (stripe_factors < 0) {
         return Array<StripeConfig>();
       }
-      return Array<StripeConfig>(GenerateOutputStripeConfigs(part, stripe_factors));
+      return Array<StripeConfig>(
+          GenerateOutputStripeConfigs(part, stripe_factors, multi_dimensional));
     });
 
 TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.GenerateSinglePlans")

--- a/src/contrib/ethosu/cascader/plan_generator.h
+++ b/src/contrib/ethosu/cascader/plan_generator.h
@@ -51,9 +51,11 @@ using HomeMap =
  * \brief Generate possible output StripeConfigs that could be applied to a Part's output.
  * \param part The Part to generate StripeConfigs for.
  * \param stripe_factors How many striping factors to try per axis.
+ * \param multi_dimensional Whether to stripe in more than one dimension.
  * \return The generated StripeConfigs for the Part's output.
  */
-std::vector<StripeConfig> GenerateOutputStripeConfigs(const Part& part, int stripe_factors);
+std::vector<StripeConfig> GenerateOutputStripeConfigs(const Part& part, int stripe_factors,
+                                                      bool multi_dimensional);
 
 /*!
  * \brief Generate single-Part Plans for a Part for a given list of output StripeConfigs.

--- a/src/contrib/ethosu/cascader/proposal_generator.cc
+++ b/src/contrib/ethosu/cascader/proposal_generator.cc
@@ -177,7 +177,8 @@ std::vector<Proposal> GeneratePartialProposals(
       }
     }
     (*proposals_by_group)[partial_proposal_group] =
-        ParetoCullProposals(proposals_by_group->at(partial_proposal_group), options->max_proposals);
+        ParetoCullProposals(proposals_by_group->at(partial_proposal_group), options->max_proposals,
+                            options->disable_pareto_proposals);
   }
   return proposals_by_group->at(partial_proposal_group);
 }

--- a/src/relay/backend/contrib/ethosu/compiler_attrs.cc
+++ b/src/relay/backend/contrib/ethosu/compiler_attrs.cc
@@ -39,6 +39,14 @@ namespace ethosu {
 /*! \brief Attributes to store the compiler options for Arm(R) Ethos(TM)-U NPU. */
 struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode> {
   String accelerator_config;
+  String dev_force_block_config;
+  String dev_max_open_plans;
+  String dev_max_closed_plans;
+  String dev_select_proposal_idx;
+  bool dev_disable_pareto_plans;
+  bool dev_disable_pareto_proposals;
+  bool dev_disable_block_culling;
+  bool dev_cascader_logging;
 
   TVM_DECLARE_ATTRS(EthosUCompilerConfigNode, "ext.attrs.EthosUCompilerConfigNode") {
     TVM_ATTR_FIELD(accelerator_config)
@@ -46,6 +54,38 @@ struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode
             "The class of Arm(R) Ethos(TM)-U NPU; possible values = {ethos-u55-32, ethos-u55-64, "
             "ethos-u55-128, ethos-u55-256}")
         .set_default("ethos-u55-256");
+    String dev_warning = "Option is intended for development and debugging purposes only. ";
+    TVM_ATTR_FIELD(dev_force_block_config)
+        .describe(
+            "Force the block config to a given value; format = "
+            "\"[BLK_HEIGHT]x[BLK_WIDTH]x[BLK_DEPTH]\"")
+        .set_default("");
+    TVM_ATTR_FIELD(dev_max_open_plans)
+        .describe(
+            (dev_warning + String("Specify the number of open plans kept for each part group"))
+                .data())
+        .set_default("8");
+    TVM_ATTR_FIELD(dev_max_closed_plans)
+        .describe(
+            (dev_warning + String("Specify the number of closed plans kept for each part group"))
+                .data())
+        .set_default("32");
+    TVM_ATTR_FIELD(dev_select_proposal_idx)
+        .describe((dev_warning + String("Select proposal by index")).data())
+        .set_default("-1");
+    TVM_ATTR_FIELD(dev_disable_pareto_plans)
+        .describe((dev_warning + String("Disable pareto culling for plans")).data())
+        .set_default(false);
+    TVM_ATTR_FIELD(dev_disable_pareto_proposals)
+        .describe((dev_warning + String("Disable pareto culling for proposals")).data())
+        .set_default(false);
+    TVM_ATTR_FIELD(dev_disable_block_culling)
+        .describe((dev_warning + String("Disable culling for block configs")).data())
+        .set_default(false);
+    TVM_ATTR_FIELD(dev_cascader_logging)
+        .describe(
+            (dev_warning + String("Enable cascader logging, log is dumped to .json file")).data())
+        .set_default(false);
   }
 };
 

--- a/tests/python/contrib/test_ethosu/cascader/infra.py
+++ b/tests/python/contrib/test_ethosu/cascader/infra.py
@@ -31,14 +31,22 @@ def make_options(
     max_proposals: int = 1,
     stripe_factors: int = 1,
     max_plan_size: int = 1,
+    max_open_plans: int = 8,
+    max_closed_plans: int = 32,
     always_copy_size: int = 1024,
+    disable_pareto_plans: bool = False,
+    disable_pareto_proposals: bool = False,
 ):
     return cs.CascaderOptions(
         cascade_region=cascade_region,
         max_proposals=max_proposals,
         stripe_factors=stripe_factors,
         max_plan_size=max_plan_size,
+        max_open_plans=max_open_plans,
+        max_closed_plans=max_closed_plans,
         always_copy_size=always_copy_size,
+        disable_pareto_plans=disable_pareto_plans,
+        disable_pareto_proposals=disable_pareto_proposals,
     )
 
 

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
@@ -21,6 +21,7 @@ pytest.importorskip("ethosu.vela")
 import numpy as np
 import math
 
+import tvm
 import tvm.contrib.ethosu.cascader as cs
 
 from .infra import make_matrices
@@ -162,15 +163,15 @@ from .infra import make_matrices
                 # Conv2D
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
-                ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
+                ((1, 4, 4, 96), (1, 4, 6, 4, 16)),
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 10, 6, 4), (1, 5, 1, 12, 4), (1, 16, 1, 4, 4)),
                 ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
                 # Depthwise Conv2D
                 ((1, 6, 10, 16), (1, 6, 1, 10, 16)),
-                ((1, 7, 5, 16), (1, 7, 1, 5, 16)),
+                ((1, 8, 5, 16), (1, 8, 1, 5, 16)),
                 # Pooling
-                ((1, 1, 1, 16), (1, 1, 1, 1, 16)),
+                ((1, 1, 1, 128), (1, 1, 8, 1, 16)),
                 ((1, 9, 6, 16), (1, 9, 1, 6, 16)),
             ],
         ),
@@ -180,15 +181,15 @@ from .infra import make_matrices
                 # Conv2D
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
-                ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
+                ((1, 4, 4, 96), (1, 4, 6, 4, 16)),
                 ((1, 8, 4, 16), (1, 8, 1, 4, 16)),
                 ((1, 10, 6, 8), (1, 16, 1, 4, 8)),
                 ((1, 6, 5, 16), (1, 6, 1, 5, 16)),
                 # Depthwise Conv2D
                 ((1, 6, 10, 16), (1, 6, 1, 10, 16)),
-                ((1, 7, 5, 16), (1, 7, 1, 5, 16)),
+                ((1, 8, 5, 16), (1, 8, 1, 5, 16)),
                 # Pooling
-                ((1, 1, 1, 16), (1, 1, 1, 1, 16)),
+                ((1, 1, 1, 128), (1, 1, 8, 1, 16)),
                 ((1, 9, 6, 16), (1, 9, 1, 6, 16)),
             ],
         ),
@@ -198,15 +199,15 @@ from .infra import make_matrices
                 # Conv2D
                 ((1, 7, 6, 16), (1, 7, 1, 6, 16)),
                 ((1, 5, 8, 16), (1, 5, 1, 8, 16)),
-                ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
+                ((1, 4, 4, 128), (1, 4, 8, 4, 16)),
                 ((1, 16, 4, 16), (1, 16, 1, 4, 16)),
                 ((1, 8, 12, 8), (1, 8, 1, 12, 8)),
                 ((1, 10, 6, 16), (1, 10, 1, 6, 16)),
                 # Depthwise Conv2D
                 ((1, 7, 10, 16), (1, 7, 1, 10, 16)),
-                ((1, 7, 6, 16), (1, 7, 1, 6, 16)),
+                ((1, 10, 6, 16), (1, 10, 1, 6, 16)),
                 # Pooling
-                ((1, 1, 2, 80), (1, 1, 5, 2, 16)),
+                ((1, 1, 2, 128), (1, 1, 8, 2, 16)),
                 ((1, 10, 6, 16), (1, 10, 1, 6, 16)),
             ],
         ),
@@ -216,7 +217,7 @@ from .infra import make_matrices
                 # Conv2D
                 ((1, 14, 8, 16), (1, 14, 1, 8, 16)),
                 ((1, 16, 8, 16), (1, 16, 1, 8, 16)),
-                ((1, 4, 4, 16), (1, 4, 1, 4, 16)),
+                ((1, 4, 4, 128), (1, 4, 8, 4, 16)),
                 ((1, 32, 4, 16), (1, 10, 12, 16), (1, 32, 1, 4, 16), (1, 10, 1, 12, 16)),
                 ((1, 20, 12, 8), (1, 20, 1, 12, 8)),
                 ((1, 12, 10, 16), (1, 12, 1, 10, 16)),
@@ -224,7 +225,7 @@ from .infra import make_matrices
                 ((1, 8, 20, 16), (1, 8, 1, 20, 16)),
                 ((1, 14, 6, 16), (1, 14, 1, 6, 16)),
                 # Pooling
-                ((1, 2, 2, 48), (1, 2, 3, 2, 16)),
+                ((1, 2, 2, 128), (1, 2, 8, 2, 16)),
                 ((1, 10, 12, 16), (1, 10, 1, 12, 16)),
             ],
         ),
@@ -329,6 +330,118 @@ def test_best_block_config(
     block_shape = tuple(int(a) for a in block.output_shape)
 
     assert block_shape in expected_block_configs[test_id]
+
+
+@pytest.mark.parametrize(
+    "ofm_layout, block_config_str, expected_block_shape",
+    [
+        ("NHWC", "4x4x8", [1, 4, 4, 8]),
+        ("NHCWB16", "4x4x8", [1, 4, 1, 4, 16]),
+        ("NHCWB16", "4x4x24", [1, 4, 2, 4, 16]),
+    ],
+)
+def test_force_block_config_kernelwise(ofm_layout, block_config_str, expected_block_shape):
+    op_type = "ethosu_pooling"
+    activation = "NONE"
+    kernel = (2, 2)
+    stride = (2, 2)
+    padding = (0, 0)
+    dilation = (1, 1)
+    ifm_channels = 32
+    out_shape = (1, 8, 10, 16)
+
+    ifm_matrix, ifm_offset, _, _, _, _ = make_matrices(
+        op_type, kernel, stride, padding, "NHWC", ofm_layout, dilation, ifm_channels
+    )
+
+    ofm_channels = out_shape[3]
+
+    propagator = cs.Propagator(ifm_matrix, ifm_offset)
+
+    op_attrs = {
+        "op": op_type,
+        "activation": activation,
+        "stride_h": stride[0],
+        "stride_w": stride[1],
+        "dilation_h": dilation[0],
+        "dilation_w": dilation[1],
+    }
+
+    config = {
+        "dev_force_block_config": block_config_str,
+    }
+    with tvm.transform.PassContext(config={"relay.ext.ethos-u.options": config}):
+        device_config = cs.EthosuDeviceConfig("ethos-u55-128")
+        block_configs = device_config.get_valid_block_configs(
+            propagator,
+            op_attrs,
+            out_shape,
+            ofm_channels,
+            ifm_channels,
+            ofm_layout,
+            "NHWC",
+            "int8",
+            "int8",
+            kernel[0],
+            kernel[1],
+        )
+
+    assert len(block_configs) == 1
+    assert block_configs[0].output_shape == expected_block_shape
+
+
+@pytest.mark.parametrize(
+    "ofm_layout, block_config_str, expected_block_shape",
+    [
+        ("NHWC", "4x4x8", [1, 4, 4, 8]),
+        ("NHCWB16", "4x4x8", [1, 4, 1, 4, 16]),
+        ("NHCWB16", "4x4x24", [1, 4, 2, 4, 16]),
+    ],
+)
+def test_force_block_config_elementwise(ofm_layout, block_config_str, expected_block_shape):
+    op_type = "ethosu_elementwise_unary"
+    op_str = "ABS"
+    activation = "NONE"
+    ofm_shape = (1, 8, 10, 16)
+    ifm_matrix = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 1],
+    ]
+    ifm_offset = [0, 0, 0, 0]
+
+    propagator = cs.Propagator(ifm_matrix, ifm_offset)
+
+    op_attrs = {
+        "op": op_type,
+        "operator_type": op_str,
+        "activation": activation,
+        "clip_min": 0,
+        "clip_max": 0,
+        "rounding_mode": "TFL",
+    }
+
+    config = {
+        "dev_force_block_config": block_config_str,
+    }
+    with tvm.transform.PassContext(config={"relay.ext.ethos-u.options": config}):
+        device_config = cs.EthosuDeviceConfig("ethos-u55-128")
+        block_configs = device_config.get_elementwise_block_config(
+            propagator,
+            None,
+            op_attrs,
+            ofm_shape,
+            ofm_layout,
+            "NWHC",
+            None,
+            "int8",
+            "int8",
+        )
+
+    assert len(block_configs) == 1
+    assert block_configs[0].output_shape == expected_block_shape
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_ethosu/cascader/test_pareto.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_pareto.py
@@ -141,7 +141,7 @@ def test_pareto_cull_plans(num_plans, max_plans, SRAM):
 
     plans = _make_plans(num_plans)
     reference = list(_ref_pareto_cull_plans(plans, max_plans))
-    result = _pareto_cull_plans(plans, max_plans)
+    result = _pareto_cull_plans(plans, max_plans, False)
     assert result == reference
 
 

--- a/tests/python/contrib/test_ethosu/cascader/test_plan_generator.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_plan_generator.py
@@ -26,9 +26,8 @@ from tvm.contrib.ethosu.cascader.plan_generator import (
 )
 
 
-def test_generate_output_stripe_configs():
+def test_generate_output_stripe_configs_multi_dimensional():
     stripe_factors = 3
-    expected_configs = 13
     subgraph = cs.TESubgraph([], None)
     part_1 = cs.InlinePart(
         subgraph,
@@ -47,7 +46,98 @@ def test_generate_output_stripe_configs():
     tensor_1.add_consumer(part_1)
     tensor_2.add_producer(part_1)
 
-    assert len(_generate_output_stripe_configs(part_1, stripe_factors)) == expected_configs
+    expected_stripe_configs = {
+        cs.StripeConfig([1, 1], [400, 400], [1, 1], [1, 2], [400, 400], [0, 0]),
+        cs.StripeConfig([1, 1], [400, 400], [1, 1], [2, 1], [400, 400], [0, 0]),
+        cs.StripeConfig([200, 1], [400, 400], [200, 1], [1, 2], [2, 400], [0, 0]),
+        cs.StripeConfig([200, 1], [400, 400], [200, 1], [2, 1], [2, 400], [0, 0]),
+        cs.StripeConfig([400, 1], [400, 400], [400, 1], [2, 1], [1, 400], [0, 0]),
+        cs.StripeConfig([1, 200], [400, 400], [1, 200], [1, 2], [400, 2], [0, 0]),
+        cs.StripeConfig([1, 200], [400, 400], [1, 200], [2, 1], [400, 2], [0, 0]),
+        cs.StripeConfig([200, 200], [400, 400], [200, 200], [2, 1], [2, 2], [0, 0]),
+        cs.StripeConfig([200, 200], [400, 400], [200, 200], [1, 2], [2, 2], [0, 0]),
+        cs.StripeConfig([400, 200], [400, 400], [400, 200], [2, 1], [1, 2], [0, 0]),
+        cs.StripeConfig([1, 400], [400, 400], [1, 400], [1, 2], [400, 1], [0, 0]),
+        cs.StripeConfig([200, 400], [400, 400], [200, 400], [1, 2], [2, 1], [0, 0]),
+        cs.StripeConfig([400, 400], [400, 400], [400, 400], [1, 2], [1, 1], [0, 0]),
+    }
+
+    output_stripe_configs = _generate_output_stripe_configs(
+        part=part_1, stripe_factors=stripe_factors, multi_dimensional=True
+    )
+
+    assert len(output_stripe_configs) == len(expected_stripe_configs)
+    assert set(output_stripe_configs) == expected_stripe_configs
+
+
+def test_generate_output_stripe_configs_uncascadable_axis():
+    stripe_factors = 3
+    subgraph = cs.TESubgraph([], None)
+    part_1 = cs.InlinePart(
+        subgraph,
+        [
+            cs.Propagator(
+                [[2, 0, 0], [0, 0, 200], [0, 0, 1]],
+                [0, 0],
+            ),
+        ],
+    )
+    tensor_1 = cs.Tensor([800, 200], "uint8")
+    tensor_2 = cs.Tensor([400, 400], "uint8")
+
+    part_1.set_input(0, tensor_1)
+    part_1.set_output(tensor_2)
+    tensor_1.add_consumer(part_1)
+    tensor_2.add_producer(part_1)
+
+    expected_stripe_configs = {
+        cs.StripeConfig([1, 400], [400, 400], [1, 400], [1, 2], [400, 1], [0, 0]),
+        cs.StripeConfig([200, 400], [400, 400], [200, 400], [1, 2], [2, 1], [0, 0]),
+        cs.StripeConfig([400, 400], [400, 400], [400, 400], [1, 2], [1, 1], [0, 0]),
+    }
+
+    output_stripe_configs = _generate_output_stripe_configs(
+        part=part_1, stripe_factors=stripe_factors, multi_dimensional=True
+    )
+
+    assert len(output_stripe_configs) == len(expected_stripe_configs)
+    assert set(output_stripe_configs) == expected_stripe_configs
+
+
+def test_generate_output_stripe_configs_single_dimension():
+    stripe_factors = 3
+    subgraph = cs.TESubgraph([], None)
+    part_1 = cs.InlinePart(
+        subgraph,
+        [
+            cs.Propagator(
+                [[2, 0, 0], [0, 2, 0], [0, 0, 1]],
+                [0, 0],
+            ),
+        ],
+    )
+    tensor_1 = cs.Tensor([800, 800], "uint8")
+    tensor_2 = cs.Tensor([400, 400], "uint8")
+
+    part_1.set_input(0, tensor_1)
+    part_1.set_output(tensor_2)
+    tensor_1.add_consumer(part_1)
+    tensor_2.add_producer(part_1)
+
+    expected_stripe_configs = {
+        cs.StripeConfig([400, 1], [400, 400], [400, 1], [2, 1], [1, 400], [0, 0]),
+        cs.StripeConfig([400, 200], [400, 400], [400, 200], [2, 1], [1, 2], [0, 0]),
+        cs.StripeConfig([1, 400], [400, 400], [1, 400], [1, 2], [400, 1], [0, 0]),
+        cs.StripeConfig([200, 400], [400, 400], [200, 400], [1, 2], [2, 1], [0, 0]),
+        cs.StripeConfig([400, 400], [400, 400], [400, 400], [1, 2], [1, 1], [0, 0]),
+    }
+
+    output_stripe_configs = _generate_output_stripe_configs(
+        part=part_1, stripe_factors=stripe_factors, multi_dimensional=False
+    )
+
+    assert len(output_stripe_configs) == len(expected_stripe_configs)
+    assert set(output_stripe_configs) == expected_stripe_configs
 
 
 def test_generate_single_plans(SRAM, DRAM):
@@ -74,7 +164,7 @@ def test_generate_single_plans(SRAM, DRAM):
         tensor_2: [SRAM],
     }
     options = make_options(cascade_region=SRAM, stripe_factors=1)
-    output_stripe_configs = _generate_output_stripe_configs(part_1, options.stripe_factors)
+    output_stripe_configs = _generate_output_stripe_configs(part_1, options.stripe_factors, True)
     plans = _generate_single_plans(part_1, output_stripe_configs, home_map, options)
     for plan in plans:
         assert plan.interior_region == SRAM

--- a/tests/python/contrib/test_ethosu/cascader/test_scheduler.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_scheduler.py
@@ -33,7 +33,11 @@ def test_cascade(SRAM, FLASH, TwoConv2DWithSliceTE, TwoConv2DTE, MobileNetv1Star
             max_proposals=64,
             stripe_factors=4,
             max_plan_size=10,
+            max_open_plans=8,
+            max_closed_plans=32,
             always_copy_size=1024,
+            disable_pareto_plans=False,
+            disable_pareto_proposals=False,
         )
         cs.cascade(sch, te_graph, const_dict, options, SRAM, FLASH, [SRAM], device_config)
 

--- a/tests/python/contrib/test_ethosu/test_vela_api.py
+++ b/tests/python/contrib/test_ethosu/test_vela_api.py
@@ -254,6 +254,19 @@ def test_get_optimal_block_config():
         assert vela_api._get_optimal_block_config(test_case["test"]) == test_case["ref"]
 
 
+@pytest.mark.parametrize(
+    "block_config_str, expected_block_config",
+    [("4x4x8", vapi.NpuShape3D(4, 4, 8)), ("3x7x16", vapi.NpuShape3D(3, 7, 16))],
+)
+def test_force_block_config(block_config_str, expected_block_config):
+    config = {
+        "dev_force_block_config": block_config_str,
+    }
+    with tvm.transform.PassContext(config={"relay.ext.ethos-u.options": config}):
+        block_config = vela_api.get_optimal_block_config(None, vapi.NpuAccelerator.Ethos_U55_128)
+        assert block_config == expected_block_config
+
+
 def test_compress_weights():
     test_vecs = [
         {


### PR DESCRIPTION
This PR adds multiple options to the cascader. One option is to toggle multi-dimensional striping and it is disabled by default. The reasoning is that exploring striping in more than 1 dimension has a very high computational cost.
The remainder of the options are aimed towards developers/debugging and are prefixed with `dev_`. The options are exposed to tvmc. It also introduces the ability to dump information about the cascader proposals to a `.json` file.