### PR TITLE
[vulkan] Add integer dot product (4xint8, 4xuint8) tensorization for the vulkan SPIR-V target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,16 @@ endif()
 tvm_option(USE_CUDA "Build with CUDA" OFF)
 tvm_option(USE_OPENCL "Build with OpenCL" OFF)
 tvm_option(USE_VULKAN "Build with Vulkan" OFF)
+
+
+# Whether to use spirv-tools.and SPIRV-Headers from Khronos github or gitlab.
+#
+# Possible values:
+# - OFF: not to use
+# - /path/to/install: path to your khronis spirv-tools and SPIRV-Headers installation directory
+#
+tvm_option(USE_KHRONOS_SPIRV "Whether to use spirv-tools.and SPIRV-Headers from Khronos github or gitlab" OFF)
+tvm_option(USE_SPIRV_KHR_INTEGER_DOT_PRODUCT "whether enable SPIRV_KHR_DOT_PRODUCT" OFF)
 tvm_option(USE_METAL "Build with Metal" OFF)
 tvm_option(USE_ROCM "Build with ROCM" OFF)
 tvm_option(ROCM_PATH "The path to rocm" /opt/rocm)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -81,6 +81,17 @@ set(USE_METAL OFF)
 # - /path/to/vulkan-sdk: use specific path to vulkan-sdk
 set(USE_VULKAN OFF)
 
+# Whether to use spirv-tools.and SPIRV-Headers from Khronos github or gitlab.
+#
+# Possible values:
+# - OFF: not to use
+# - /path/to/install: path to your khronis spirv-tools and SPIRV-Headers installation directory
+#
+set(USE_KHRONOS_SPIRV OFF)
+
+# whether enable SPIRV_KHR_DOT_PRODUCT
+set(USE_SPIRV_KHR_INTEGER_DOT_PRODUCT OFF)
+
 # Whether enable OpenGL runtime
 set(USE_OPENGL OFF)
 

--- a/cmake/modules/Vulkan.cmake
+++ b/cmake/modules/Vulkan.cmake
@@ -16,11 +16,15 @@
 # under the License.
 
 # Be compatible with older version of CMake
-find_vulkan(${USE_VULKAN})
+find_vulkan(${USE_VULKAN} ${USE_KHRONOS_SPIRV})
 
 if(USE_VULKAN)
   if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Cannot find Vulkan, USE_VULKAN=" ${USE_VULKAN})
+  endif()
+  if (USE_SPIRV_KHR_INTEGER_DOT_PRODUCT)
+    add_definitions(-DTVM_SPIRV_KHR_INTEGER_DOT_PRODUCT=1)
+    message(STATUS "Enable SPIRV_KHR_INTEGER_DOT_PRODUCT")
   endif()
   include_directories(SYSTEM ${Vulkan_INCLUDE_DIRS})
   message(STATUS "Build with Vulkan support")

--- a/cmake/utils/FindVulkan.cmake
+++ b/cmake/utils/FindVulkan.cmake
@@ -32,7 +32,7 @@
 # - Vulkan_SPIRV_TOOLS_LIBRARY
 #
 
-macro(find_vulkan use_vulkan)
+macro(find_vulkan use_vulkan use_khronos_spirv)
   set(__use_vulkan ${use_vulkan})
   if(IS_DIRECTORY ${__use_vulkan})
     set(__vulkan_sdk ${__use_vulkan})
@@ -42,6 +42,15 @@ macro(find_vulkan use_vulkan)
    else()
      set(__vulkan_sdk "")
    endif()
+
+   
+   if(IS_DIRECTORY ${use_khronos_spirv})
+     set(__use_khronos_spirv ${use_khronos_spirv})
+     message(STATUS "Custom khronos spirv PATH=" ${__use_khronos_spirv})
+   else()
+     set(__use_khronos_spirv "")
+   endif()
+
 
    if(__vulkan_sdk)
      set(Vulkan_INCLUDE_DIRS ${__vulkan_sdk}/include)
@@ -61,11 +70,18 @@ macro(find_vulkan use_vulkan)
 
   if(Vulkan_FOUND)
     get_filename_component(VULKAN_LIBRARY_PATH ${Vulkan_LIBRARY} DIRECTORY)
-    find_library(Vulkan_SPIRV_TOOLS_LIBRARY SPIRV-Tools
-        HINTS ${VULKAN_LIBRARY_PATH} ${VULKAN_LIBRARY_PATH}/spirv-tools ${VULKAN_SDK}/lib)
+    if (WIN32)
+      find_library(Vulkan_SPIRV_TOOLS_LIBRARY SPIRV-Tools
+        HINTS ${__use_khronos_spirv}/spirv-tools/lib ${VULKAN_LIBRARY_PATH} ${VULKAN_LIBRARY_PATH}/spirv-tools ${VULKAN_SDK}/lib)
+      find_path(_libspirv libspirv.h HINTS ${__use_khronos_spirv}/spirv-tools/include ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan spirv-tools)
+      find_path(_spirv spirv.hpp HINTS ${__use_khronos_spirv}/SPIRV-Headers/include ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan SPIRV spirv/unified1 spirv-headers)
+    else()
+      find_library(Vulkan_SPIRV_TOOLS_LIBRARY SPIRV-Tools
+          HINTS ${__use_khronos_spirv}/lib ${VULKAN_LIBRARY_PATH} ${VULKAN_LIBRARY_PATH}/spirv-tools ${VULKAN_SDK}/lib)
+      find_path(_libspirv libspirv.h HINTS ${__use_khronos_spirv}/include ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan spirv-tools)
+      find_path(_spirv spirv.hpp HINTS ${__use_khronos_spirv}/include ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan SPIRV spirv/unified1 spirv-headers)
+    endif()
 
-    find_path(_libspirv libspirv.h HINTS ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan spirv-tools)
-    find_path(_spirv spirv.hpp HINTS ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan SPIRV spirv/unified1 spirv-headers)
     find_path(_glsl_std GLSL.std.450.h HINTS ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan SPIRV spirv/unified1 spirv-headers)
     list(APPEND Vulkan_INCLUDE_DIRS ${_libspirv} ${_spirv} ${_glsl_std})
     message(STATUS "Vulkan_INCLUDE_DIRS=" ${Vulkan_INCLUDE_DIRS})

--- a/gallery/how_to/deploy_models/deploy_prequantized.py
+++ b/gallery/how_to/deploy_models/deploy_prequantized.py
@@ -175,7 +175,8 @@ mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
 #
 # Under the hood, quantization specific operators are lowered to a sequence of
 # standard Relay operators before compilation.
-tvm_result, rt_mod = run_tvm_model(mod, params, input_name, inp, target="llvm")
+target = "llvm"
+tvm_result, rt_mod = run_tvm_model(mod, params, input_name, inp, target=target)
 
 ##########################################################################
 # Compare the output labels

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -145,7 +145,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
         if layout == "NCHW":
             assert kernel_layout == "OIHW"
             if (
-                target.kind.name == "cuda"
+                (target.kind.name in ["cuda", "vulkan"])
                 and data.dtype in ("int8", "uint8")
                 and kernel.dtype in ("int8", "uint8")
             ):
@@ -296,7 +296,11 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                     "Unsupported shape for conv2d HWNC.\
                                     Need to satisfy tensor core schedule."
                 )
-        elif target.kind.name == "cuda" and layout == "NCHW4c" and data.dtype in ["int8", "uint8"]:
+        elif (
+            (target.kind.name in ["cuda", "vulkan"])
+            and layout == "NCHW4c"
+            and data.dtype in ["int8", "uint8"]
+        ):
             assert kernel_layout == "OIHW4o4i"
             strategy.add_implementation(
                 wrap_compute_conv2d(topi.cuda.conv2d_NCHWc_int8, True),
@@ -372,7 +376,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
             ic_chunk = in_channels // 4
 
             if (
-                target.kind.name == "cuda"
+                (target.kind.name in ["cuda", "vulkan"])
                 and data.dtype in ["int8", "uint8"]
                 and kernel.dtype in ["int8", "uint8"]
                 and channels % groups == 0

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -189,6 +189,12 @@ class Target(Object):
         return list(self.attrs.get("mattr", []))
 
     @property
+    def supports_integer_dot_product(self):
+        if self.attrs.get("supports_integer_dot_product", []):
+            return bool(self.attrs["supports_integer_dot_product"])
+        return False
+
+    @property
     def libs(self):
         return list(self.attrs.get("libs", []))
 

--- a/python/tvm/topi/cuda/conv2d_int8.py
+++ b/python/tvm/topi/cuda/conv2d_int8.py
@@ -153,13 +153,15 @@ def conv2d_NCHWc_int8(cfg, data, kernel, stride, padding, dilation, layout, out_
     kh = te.reduce_axis((0, kernel_h), name="kh")
     kw = te.reduce_axis((0, kernel_w), name="kw")
 
+    packed_kernel_dtype = packed_kernel.dtype
+    packed_dtype = "int32" if packed_kernel_dtype == "int8" else "uint32"
     conv = te.compute(
         oshape,
         lambda n, oc_chunk, oh, ow, oc_block: te.sum(
             pad_data[
                 n, icc, oh * stride_h + kh * dilation_h, ow * stride_w + kw * dilation_w, icb
-            ].astype("int32")
-            * packed_kernel[oc_chunk, icc, kh, kw, oc_block, icb].astype("int32"),
+            ].astype(packed_dtype)
+            * packed_kernel[oc_chunk, icc, kh, kw, oc_block, icb].astype(packed_dtype),
             axis=[icc, kh, kw, icb],
         ),
     )
@@ -186,9 +188,6 @@ def conv2d_NCHWc_int8(cfg, data, kernel, stride, padding, dilation, layout, out_
     cfg.add_flop(num_flop)
 
     return output
-
-
-_dp4a = dp4a("shared", "shared", "local")
 
 
 @autotvm.register_topi_schedule("conv2d_NCHWc_int8.cuda")
@@ -311,7 +310,13 @@ def _schedule_conv2d_NCHWc_int8(cfg, s, output):
     cfg["reorder_inner"].apply(s, conv, [rci, ryi, rxi])
 
     _, rc_block = s[conv].split(rc_block, factor=4)
-    s[conv].tensorize(rc_block, _dp4a)
+    target = tvm.target.Target.current(allow_none=False)
+    do_tensorize = True
+    if "vulkan" in target.keys:
+        do_tensorize = "+dotprod" in target.mattr or target.supports_integer_dot_product
+    if do_tensorize:
+        dtypes = (pad_data.dtype, packed_kernel.dtype)
+        s[conv].tensorize(rc_block, dp4a("shared", "shared", "local", dtypes))
 
     cache_loc = [rco, ryo, rxo][cfg["reorder_inner"].perm[-1]]
     s[AA].compute_at(s[conv], cache_loc)

--- a/python/tvm/topi/cuda/dense.py
+++ b/python/tvm/topi/cuda/dense.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name, unused-argument
 """Schedule for dense operator"""
 import logging
+import tvm
 from tvm import te
 import tvm.autotvm as autotvm
 from tvm.contrib import cublas
@@ -133,9 +134,6 @@ def schedule_dense_int8(cfg, outs):
     return s
 
 
-_dp4a = dp4a("shared", "shared", "local")
-
-
 def _schedule_dense_int8(cfg, s, output):
     data, weight = s[output].op.input_tensors
     if len(weight.op.input_tensors) == 1 and weight.op.input_tensors[0] == data:
@@ -173,7 +171,13 @@ def _schedule_dense_int8(cfg, s, output):
     ko = CC.op.reduce_axis[0]
     ko, ki = s[CC].split(ko, factor=4)
     ko, kt = cfg["tile_k"].apply(s, CC, ko)
-    s[CC].tensorize(ki, _dp4a)
+    target = tvm.target.Target.current(allow_none=False)
+    do_tensorize = True
+    if "vulkan" in target.keys:
+        do_tensorize = "+dotprod" in target.mattr or target.supports_integer_dot_product
+    if do_tensorize:
+        dtypes = (data.dtype, weight.dtype)
+        s[CC].tensorize(ki, dp4a("shared", "shared", "local", dtypes))
     by, vy, ty, yi = cfg["tile_y"].apply(s, output, n)
     bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
 

--- a/python/tvm/topi/cuda/group_conv2d_nchw.py
+++ b/python/tvm/topi/cuda/group_conv2d_nchw.py
@@ -396,9 +396,6 @@ def schedule_group_conv2d_NCHWc_int8(cfg, outs):
     return s
 
 
-_dp4a = dp4a("shared", "shared", "local")
-
-
 def _schedule_group_conv2d_NCHWc_int8(cfg, s, output):
     """Schedule group conv2d int8 NCHWc template"""
     workload = output.op.attrs["workload"]
@@ -509,7 +506,13 @@ def _schedule_group_conv2d_NCHWc_int8(cfg, s, output):
 
     s[conv].reorder(rco, ryo, rxo, rci, ryi, rxi, n, f, y, x, c, rc_block)
     _, rc_block = s[conv].split(rc_block, factor=4)
-    s[conv].tensorize(rc_block, _dp4a)
+    target = tvm.target.Target.current(allow_none=False)
+    do_tensorize = True
+    if "vulkan" in target.keys:
+        do_tensorize = "+dotprod" in target.mattr or target.supports_integer_dot_product
+    if do_tensorize:
+        dtypes = (pad_data.dtype, packed_kernel.dtype)
+        s[conv].tensorize(rc_block, dp4a("shared", "shared", "local", dtypes))
 
     s[AA].compute_at(s[conv], rxo)
     s[WW].compute_at(s[conv], rxo)

--- a/python/tvm/topi/cuda/tensor_intrin.py
+++ b/python/tvm/topi/cuda/tensor_intrin.py
@@ -20,7 +20,7 @@ import tvm
 from tvm import te
 
 
-def dp4a(x_scope="local", y_scope="local", z_scope="local"):
+def dp4a(x_scope="local", y_scope="local", z_scope="local", dtypes=("int8", "int8")):
     """
     Int8 dot product reduced by every 4 elements using __dp4a
 
@@ -32,6 +32,8 @@ def dp4a(x_scope="local", y_scope="local", z_scope="local"):
         The storage scope of buffer for rhs
     z_scope : str, optional
         The storage scope of buffer for result
+    dtypes:  tuple of strs, optional
+        The dtype of x and y
 
     Returns
     -------
@@ -40,28 +42,36 @@ def dp4a(x_scope="local", y_scope="local", z_scope="local"):
     """
 
     n = 4  # dp4a requires operands packed by 4
-    x = te.placeholder((n,), name="x", dtype="int8")
-    y = te.placeholder((n,), name="y", dtype="int8")
+    result_dtype = "int32" if dtypes[1] == "int8" else "uint32"
+
+    x = te.placeholder((n,), name="x", dtype=dtypes[0])
+    y = te.placeholder((n,), name="y", dtype=dtypes[1])
 
     k = te.reduce_axis((0, n), name="rc")
 
-    z = te.compute((1,), lambda i: te.sum(x[k].astype("int32") * y[k].astype("int32"), axis=[k]))
+    z = te.compute(
+        (1,), lambda i: te.sum(x[k].astype(result_dtype) * y[k].astype(result_dtype), axis=[k])
+    )
 
     def _intrin_func(ins, outs):
         def _instr(index):
             xx, yy = ins
             zz = outs[0]
+            zz_dtype = zz.dtype
 
             if index == 1:
-                return zz.vstore(0, 0)
+                return zz.vstore(0, tvm.tir.const(0, zz_dtype))
 
             ib = tvm.tir.ir_builder.create()
 
-            vec_x = xx.vload(0, dtype="int8x4")
-            vec_y = yy.vload(0, dtype="int8x4")
+            vec_x_dtype = "int8x4" if xx.dtype == "int8" else "uint8x4"
+            vec_y_dtype = "int8x4" if yy.dtype == "int8" else "uint8x4"
+
+            vec_x = xx.vload(0, dtype=vec_x_dtype)
+            vec_y = yy.vload(0, dtype=vec_y_dtype)
             prev_z = 0 if index == 0 else zz.vload(0)
 
-            new_z = tvm.tir.call_pure_extern("int32", "__dp4a", vec_x, vec_y, prev_z)
+            new_z = tvm.tir.call_pure_extern(zz_dtype, "__dp4a", vec_x, vec_y, prev_z)
             ib.emit(zz.vstore(0, new_z))
 
             return ib.get()

--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -132,6 +132,8 @@ VulkanDeviceProperties::VulkanDeviceProperties(const VulkanInstance& instance,
       device.HasExtension("VK_KHR_dedicated_allocation") &&
       !support::BoolEnvironmentVar("TVM_VULKAN_DISABLE_DEDICATED_ALLOCATION");
 
+  supports_integer_dot_product = device.HasExtension("VK_KHR_shader_integer_dot_product");
+
   // The check of VK_SHADER_STAGE_COMPUTE_BIT isn't technically
   // needed, since it will be set so long at least one queue has
   // VK_QUEUE_COMPUTE_BIT.  Including it to avoid potential future
@@ -410,18 +412,17 @@ uint32_t VulkanDevice::SelectComputeQueueFamily() const {
 
 std::vector<const char*> VulkanDevice::SelectEnabledExtensions() const {
   std::vector<const char*> required_extensions{};
-  std::vector<const char*> optional_extensions{
-      "VK_KHR_driver_properties",
-      "VK_KHR_storage_buffer_storage_class",
-      "VK_KHR_8bit_storage",
-      "VK_KHR_16bit_storage",
-      "VK_KHR_shader_float16_int8",
-      "VK_KHR_push_descriptor",
-      "VK_KHR_descriptor_update_template",
-      "VK_KHR_get_memory_requirements2",
-      "VK_KHR_dedicated_allocation",
-      "VK_KHR_spirv_1_4",
-  };
+  std::vector<const char*> optional_extensions{"VK_KHR_driver_properties",
+                                               "VK_KHR_storage_buffer_storage_class",
+                                               "VK_KHR_8bit_storage",
+                                               "VK_KHR_16bit_storage",
+                                               "VK_KHR_shader_float16_int8",
+                                               "VK_KHR_push_descriptor",
+                                               "VK_KHR_descriptor_update_template",
+                                               "VK_KHR_get_memory_requirements2",
+                                               "VK_KHR_dedicated_allocation",
+                                               "VK_KHR_spirv_1_4",
+                                               "VK_KHR_shader_integer_dot_product"};
 
   uint32_t device_extension_prop_count;
   VULKAN_CALL(vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,

--- a/src/runtime/vulkan/vulkan_device.h
+++ b/src/runtime/vulkan/vulkan_device.h
@@ -81,6 +81,7 @@ struct VulkanDeviceProperties {
   bool supports_storage_buffer_storage_class{false};
   bool supports_push_descriptor{false};
   bool supports_dedicated_allocation{false};
+  bool supports_integer_dot_product{false};
   uint32_t supported_subgroup_operations{0};
   uint32_t max_num_threads{1};
   uint32_t thread_warp_size{1};

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -236,6 +236,11 @@ void VulkanDeviceAPI::GetTargetProperty(Device dev, const std::string& property,
   if (property == "max_shared_memory_per_block") {
     *rv = int64_t(prop.max_shared_memory_per_block);
   }
+
+  if (property == "supports_integer_dot_product") {
+    *rv = prop.supports_integer_dot_product;
+  }
+
   if (property == "device_name") {
     *rv = prop.device_name;
   }

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -452,7 +452,8 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const BufferLoadNode* op) {
   if (desired_read_type == info.element_type) {
     // Requested a single value from an array.  This may be a scalar load
     // or a vectorized load, based on the array element type.
-    spirv::Value index = MakeValue(prim_index);
+    PrimExpr vec_index = analyzer_->Simplify(prim_index);
+    spirv::Value index = MakeValue(vec_index);
     spirv::Value ptr = builder_->StructArrayAccess(ptr_type, buffer, index);
     spirv::Value loaded = builder_->MakeValue(spv::OpLoad, content_type, ptr, mask);
     // OpTypeBool have no physical address/storage.  Here, cast from

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -420,6 +420,17 @@ class IRBuilder {
    * \return The result value.
    */
   Value CallGLSL450(const SType& ret_type, uint32_t inst_id, const std::vector<Value>& args);
+
+  /*!
+   * \brief Create a SPIRV_KHR_integer_dot_product call
+   *
+   * \param ret_type The result type.
+   * \param args The arguments
+   * \return The result value.
+   */
+  Value CallKHRIntegerDotProduct(const SType& ret_type, const std::vector<Value>& args,
+                                 const DataType& dtype);
+
   /*!
    * \brief Build vector by concatenating components
    *

--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -84,6 +84,19 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   if (target->GetAttr<Bool>("supports_int64")) {
     supports_int64 = target->GetAttr<Bool>("supports_int64").value();
   }
+  // Check whether integer dot product is enabled in the target string.
+  if (target->GetAttr<Bool>("supports_integer_dot_product")) {
+    supports_integer_dot_product = target->GetAttr<Bool>("supports_integer_dot_product").value();
+  }
+  // Check whether integer dot product is enabled in mattr.
+  if (const Optional<Array<String>>& v = target->GetAttr<Array<String>>("mattr")) {
+    for (const String& s : v.value()) {
+      if (s.compare("+dotprod") == 0) {
+        supports_integer_dot_product = true;
+        break;
+      }
+    }
+  }
 }
 
 }  // namespace codegen

--- a/src/target/spirv/spirv_support.h
+++ b/src/target/spirv/spirv_support.h
@@ -262,6 +262,20 @@ struct SPIRVSupport {
    * attempting to create a 64-bit int.
    */
   bool supports_int64{false};
+
+  /*!
+   * \brief Whether the driver supports operations involving integer dot product.
+   *
+   * Vulkan extension: VK_KHR_shader_integer_dot_product
+   * SPV Extension name: SPV_KHR_integer_dot_product
+   * SPV Capability: spv::CapabilityDotProductKHR,
+   *                 spv::CapabilityDotProductInput4x8BitPackedKHR);
+   *
+   * If support is present, can perform integer dot product operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to perform integer dot product.
+   */
+  bool supports_integer_dot_product{false};
 };
 
 }  // namespace codegen

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -330,6 +330,7 @@ TVM_REGISTER_TARGET_KIND("metal", kDLMetal)
     .set_default_keys({"metal", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
+    .add_attr_option<Array<String>>("mattr")
     .add_attr_option<Bool>("system-lib")
     // Feature support
     .add_attr_option<Bool>("supports_float16")
@@ -344,6 +345,7 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Bool>("supports_storage_buffer_storage_class")
     .add_attr_option<Bool>("supports_push_descriptor")
     .add_attr_option<Bool>("supports_dedicated_allocation")
+    .add_attr_option<Bool>("supports_integer_dot_product")
     .add_attr_option<Integer>("supported_subgroup_operations")
     // Physical device limits
     .add_attr_option<Integer>("max_num_threads", Integer(256))

--- a/tests/python/topi/python/test_topi_batch_matmul.py
+++ b/tests/python/topi/python/test_topi_batch_matmul.py
@@ -128,7 +128,7 @@ def verify_batch_matmul_int8(x_batch, y_batch, M, N, K):
         f(a, b, c)
         tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
 
-    for device in ["cuda"]:
+    for device in ["cuda", "vulkan -from_device=0"]:
         check_device(device)
 
 

--- a/tests/python/topi/python/test_topi_batch_matmul.py
+++ b/tests/python/topi/python/test_topi_batch_matmul.py
@@ -128,7 +128,7 @@ def verify_batch_matmul_int8(x_batch, y_batch, M, N, K):
         f(a, b, c)
         tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-5)
 
-    for device in ["cuda", "vulkan -from_device=0"]:
+    for device in ["cuda"]:
         check_device(device)
 
 

--- a/tests/python/topi/python/test_topi_conv2d_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_int8.py
@@ -370,7 +370,14 @@ def verify_conv2d_NCHWc_int8(
             lambda a, w, s, p, d, l, ol, o: topi.cuda.conv2d_NCHWc_int8(a, w, s, p, d, l, o),
             topi.cuda.schedule_conv2d_NCHWc_int8,
             4,
-        )
+        ),
+        # Disable on CI since it does not support spirv int8 dot product
+        # (
+        #     "vulkan -from_device=0",
+        #     lambda a, w, s, p, d, l, ol, o: topi.cuda.conv2d_NCHWc_int8(a, w, s, p, d, l, o),
+        #     topi.cuda.schedule_conv2d_NCHWc_int8,
+        #     4,
+        # ),
     ]
 
     if in_dtype == "int8":

--- a/tests/python/topi/python/test_topi_conv2d_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_int8.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 """Example code to do convolution."""
 
 import numpy as np
@@ -32,6 +33,7 @@ from tvm.topi.generic.conv2d import fallback_schedule_cpu_common_int8
 
 from common import Int8Fallback
 import tvm.testing
+import pytest
 
 
 def compile_conv2d_NHWC_gemm_int8_arm(
@@ -226,6 +228,7 @@ def verify_conv2d_NHWC_gemm_int8(
 
 
 def verify_conv2d_NCHWc_int8(
+    in_dtype,
     batch,
     in_channel,
     in_size,
@@ -246,12 +249,15 @@ def verify_conv2d_NCHWc_int8(
 
     in_height = in_width = in_size
 
-    A = te.placeholder((batch, in_channel, in_height, in_width), name="A", dtype="int8")
-    W = te.placeholder((num_filter, in_channel, kernel, kernel), name="W", dtype="int8")
+    A = te.placeholder((batch, in_channel, in_height, in_width), name="A", dtype=in_dtype)
+    W = te.placeholder((num_filter, in_channel, kernel, kernel), name="W", dtype=in_dtype)
 
     a_shape = get_const_tuple(A.shape)
     w_shape = get_const_tuple(W.shape)
     dtype = A.dtype
+    out_dtype = "int32" if in_dtype == "int8" else "uint32"
+    lo = -128 if in_dtype == "int8" else 0
+    hi = 127 if in_dtype == "int8" else 255
 
     def check_target(target, compute, schedule, oc_block_factor):
         dev = tvm.device(target, 0)
@@ -263,17 +269,19 @@ def verify_conv2d_NCHWc_int8(
             return
 
         bias = te.placeholder(
-            (num_filter // oc_block_factor, 1, 1, oc_block_factor), name="bias", dtype="int32"
+            (num_filter // oc_block_factor, 1, 1, oc_block_factor), name="bias", dtype=out_dtype
         )
         bias_shape = get_const_tuple(bias.shape)
 
         @memoize("topi.tests.test_topi_conv2d_int8.verify_conv2d_nchw")
         def get_ref_data():
-            a_np = np.random.randint(low=-128, high=127, size=a_shape).astype("int32")
-            w_np = np.random.randint(low=-128, high=128, size=w_shape).astype("int32")
-            b_np = np.random.uniform(size=bias_shape).astype("int32")
+            a_np = np.random.randint(low=lo, high=hi, size=a_shape).astype(out_dtype)
+            w_np = np.random.randint(low=lo, high=hi, size=w_shape).astype(out_dtype)
+            b_np = np.random.uniform(size=bias_shape).astype(out_dtype)
             dw_np = tvm.topi.testing.dilate_python(w_np, (1, 1, dilation, dilation))
-            c_np = tvm.topi.testing.conv2d_nchw_python(a_np, dw_np, stride, padding).astype("int32")
+            c_np = tvm.topi.testing.conv2d_nchw_python(a_np, dw_np, stride, padding).astype(
+                out_dtype
+            )
 
             # convert to NCHWc
             _, _, out_height, out_width = c_np.shape
@@ -282,7 +290,7 @@ def verify_conv2d_NCHWc_int8(
             ).transpose(0, 1, 3, 4, 2)
 
             if add_bias:
-                b_np = np.random.uniform(size=bias_shape).astype("int32")
+                b_np = np.random.uniform(size=bias_shape).astype(out_dtype)
                 c_np += b_np
             if add_relu:
                 c_np = np.maximum(c_np, 0)
@@ -301,7 +309,7 @@ def verify_conv2d_NCHWc_int8(
                 (dilation, dilation),
                 "NCHW",
                 "NCHW",
-                "int32",
+                out_dtype,
             )
             print(C.shape)
             print(bias.shape)
@@ -313,7 +321,7 @@ def verify_conv2d_NCHWc_int8(
 
         a = tvm.nd.array(a_np.astype(dtype), dev)
         w = tvm.nd.array(w_np.astype(dtype), dev)
-        b = tvm.nd.array(b_np.astype("int32"), dev)
+        b = tvm.nd.array(b_np.astype(out_dtype), dev)
         c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), dev)
         if add_bias:
             tvm.build(
@@ -375,6 +383,7 @@ def verify_conv2d_NCHWc_int8(
 
 
 def verify_conv2d_nchw_int8(
+    in_dtype,
     batch,
     in_channel,
     in_size,
@@ -395,9 +404,9 @@ def verify_conv2d_nchw_int8(
 
     in_height = in_width = in_size
 
-    A = te.placeholder((batch, in_channel, in_height, in_width), name="A", dtype="int8")
-    W = te.placeholder((num_filter, in_channel, kernel, kernel), name="W", dtype="int8")
-    bias = te.placeholder((num_filter, 1, 1), name="bias", dtype="int8")
+    A = te.placeholder((batch, in_channel, in_height, in_width), name="A", dtype=in_dtype)
+    W = te.placeholder((num_filter, in_channel, kernel, kernel), name="W", dtype=in_dtype)
+    bias = te.placeholder((num_filter, 1, 1), name="bias", dtype=in_dtype)
 
     a_shape = get_const_tuple(A.shape)
     w_shape = get_const_tuple(W.shape)
@@ -495,114 +504,118 @@ def verify_conv2d_nchw_int8(
         check_target(target)
 
 
-@tvm.testing.requires_cuda
-def test_conv2d_nchw():
+@pytest.mark.parametrize("in_dtype", ["int8", "uint8"])
+def test_conv2d_nchw(in_dtype):
     with Int8Fallback():
         # ResNet18 workloads where channels in / out are multiple of oc_block_factor
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 128, 3, 2, 1)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 128, 1, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 128, 28, 128, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 128, 28, 256, 3, 2, 1)
-        verify_conv2d_NCHWc_int8(1, 128, 28, 256, 1, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 256, 14, 256, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 256, 14, 512, 3, 2, 1)
-        verify_conv2d_NCHWc_int8(1, 256, 14, 512, 1, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 512, 7, 512, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 64, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 128, 3, 2, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 128, 1, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 28, 128, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 28, 256, 3, 2, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 28, 256, 1, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 256, 14, 256, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 256, 14, 512, 3, 2, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 256, 14, 512, 1, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 512, 7, 512, 3, 1, 1)
 
         # bias, relu
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 3, 1, 1, add_relu=True)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 3, 1, 1, add_bias=True)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 3, 1, 1, add_bias=True, add_relu=True)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1, add_relu=True)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1, add_bias=True)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1, add_bias=True, add_relu=True)
 
         # dilation = 2
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 3, 1, 1, dilation=2)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1, dilation=2)
 
         # batch size
-        verify_conv2d_NCHWc_int8(4, 64, 56, 64, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(9, 64, 56, 64, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 4, 64, 56, 64, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 9, 64, 56, 64, 3, 1, 1)
 
         # weird workloads
-        verify_conv2d_NCHWc_int8(4, 4, 4, 8, 4, 4, 4)
+        verify_conv2d_NCHWc_int8(in_dtype, 4, 4, 4, 8, 4, 4, 4)
 
         # inception v3 workloads where channels in / out are multiple of oc_block_factor
-        verify_conv2d_NCHWc_int8(1, 32, 149, 32, 3, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 32, 147, 64, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 64, 73, 80, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 80, 73, 192, 3, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 192, 35, 64, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 192, 35, 48, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 48, 35, 64, 5, 1, 2)
-        verify_conv2d_NCHWc_int8(1, 64, 35, 96, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 96, 35, 96, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 192, 35, 32, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 256, 35, 64, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 256, 35, 48, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 288, 35, 64, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 288, 35, 48, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 288, 35, 384, 3, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 96, 35, 96, 3, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 768, 17, 192, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 768, 17, 128, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 128, 17, 128, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 128, 17, 192, 7, 1, 3)
-        verify_conv2d_NCHWc_int8(1, 128, 17, 128, 7, 1, 3)
-        verify_conv2d_NCHWc_int8(1, 128, 17, 192, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 768, 17, 160, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 160, 17, 160, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 160, 17, 192, 7, 1, 3)
-        verify_conv2d_NCHWc_int8(1, 160, 17, 160, 7, 1, 3)
-        verify_conv2d_NCHWc_int8(1, 160, 17, 192, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 192, 17, 192, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 192, 17, 192, 7, 1, 3)
-        verify_conv2d_NCHWc_int8(1, 192, 17, 320, 3, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 192, 17, 192, 3, 2, 0)
-        verify_conv2d_NCHWc_int8(1, 1280, 8, 320, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 1280, 8, 384, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 384, 8, 384, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 384, 8, 384, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 1280, 8, 448, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 448, 8, 384, 3, 1, 1)
-        verify_conv2d_NCHWc_int8(1, 1280, 8, 192, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 2048, 8, 320, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 2048, 8, 384, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 2048, 8, 448, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 2048, 8, 192, 1, 1, 0)
-        verify_conv2d_NCHWc_int8(1, 1024, 19, 88, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 32, 149, 32, 3, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 32, 147, 64, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 73, 80, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 80, 73, 192, 3, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 35, 64, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 35, 48, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 48, 35, 64, 5, 1, 2)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 35, 96, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 96, 35, 96, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 35, 32, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 256, 35, 64, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 256, 35, 48, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 288, 35, 64, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 288, 35, 48, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 288, 35, 384, 3, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 96, 35, 96, 3, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 768, 17, 192, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 768, 17, 128, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 17, 128, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 17, 192, 7, 1, 3)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 17, 128, 7, 1, 3)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 17, 192, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 768, 17, 160, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 160, 17, 160, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 160, 17, 192, 7, 1, 3)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 160, 17, 160, 7, 1, 3)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 160, 17, 192, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 17, 192, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 17, 192, 7, 1, 3)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 17, 320, 3, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 192, 17, 192, 3, 2, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 1280, 8, 320, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 1280, 8, 384, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 384, 8, 384, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 384, 8, 384, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 1280, 8, 448, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 448, 8, 384, 3, 1, 1)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 1280, 8, 192, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 2048, 8, 320, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 2048, 8, 384, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 2048, 8, 448, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 2048, 8, 192, 1, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 1024, 19, 88, 3, 1, 1)
 
         # batch > 1
-        verify_conv2d_NCHWc_int8(7, 32, 149, 32, 3, 1, 0)
-        verify_conv2d_NCHWc_int8(8, 32, 149, 32, 3, 1, 0)
-        verify_conv2d_NCHWc_int8(32, 32, 149, 32, 3, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 7, 32, 149, 32, 3, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 8, 32, 149, 32, 3, 1, 0)
+        verify_conv2d_NCHWc_int8(in_dtype, 32, 32, 149, 32, 3, 1, 0)
 
         # Asymmetric padding
-        verify_conv2d_NCHWc_int8(1, 32, 35, 64, 7, 2, (0, 0, 1, 1))
-        verify_conv2d_NCHWc_int8(1, 64, 8, 128, 3, 1, (3, 3, 2, 2))
-        verify_conv2d_NCHWc_int8(1, 64, 8, 64, 1, 1, (1, 2, 2, 1))
-        verify_conv2d_NCHWc_int8(1, 64, 17, 192, 1, 1, (1, 2))
-        verify_conv2d_NCHWc_int8(1, 64, 8, 64, 3, 1, (3, 1))
-        verify_conv2d_NCHWc_int8(1, 128, 8, 384, 3, 1, (0, 2))
-        verify_conv2d_NCHWc_int8(1, 64, 8, 64, 1, 1, "VALID")
-        verify_conv2d_NCHWc_int8(1, 392, 8, 64, 3, 1, "VALID")
-        verify_conv2d_NCHWc_int8(1, 512, 19, 64, 1, 1, "SAME")
-        verify_conv2d_NCHWc_int8(1, 64, 16, 32, 2, 1, "SAME")
-        verify_conv2d_NCHWc_int8(1, 64, 8, 64, 3, 1, (1, 2, 2, 1), add_relu=True)
-        verify_conv2d_NCHWc_int8(1, 64, 8, 64, 5, 2, (1, 3), add_bias=True)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 3, 1, "VALID", add_bias=True, add_relu=True)
-        verify_conv2d_NCHWc_int8(1, 64, 56, 64, 24, 1, "SAME", add_bias=True, add_relu=True)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 32, 35, 64, 7, 2, (0, 0, 1, 1))
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 8, 128, 3, 1, (3, 3, 2, 2))
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 8, 64, 1, 1, (1, 2, 2, 1))
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 17, 192, 1, 1, (1, 2))
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 8, 64, 3, 1, (3, 1))
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 128, 8, 384, 3, 1, (0, 2))
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 8, 64, 1, 1, "VALID")
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 392, 8, 64, 3, 1, "VALID")
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 512, 19, 64, 1, 1, "SAME")
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 16, 32, 2, 1, "SAME")
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 8, 64, 3, 1, (1, 2, 2, 1), add_relu=True)
+        verify_conv2d_NCHWc_int8(in_dtype, 1, 64, 8, 64, 5, 2, (1, 3), add_bias=True)
+        verify_conv2d_NCHWc_int8(
+            in_dtype, 1, 64, 56, 64, 3, 1, "VALID", add_bias=True, add_relu=True
+        )
+        verify_conv2d_NCHWc_int8(
+            in_dtype, 1, 64, 56, 64, 24, 1, "SAME", add_bias=True, add_relu=True
+        )
 
         # Conv2d NCHW int8 schedule testing. Internally, it uses NCHWc schedule. So, just
         # performing basic testing - one test for all different scenarios - batch, dilation etc..
-        verify_conv2d_nchw_int8(1, 64, 56, 64, 3, 1, 1)
-        verify_conv2d_nchw_int8(1, 64, 56, 64, 3, 1, 1, add_relu=True)
-        verify_conv2d_nchw_int8(1, 64, 56, 64, 3, 1, 1, dilation=2)
-        verify_conv2d_nchw_int8(9, 64, 56, 64, 3, 1, 1)
-        verify_conv2d_nchw_int8(4, 4, 4, 4, 4, 4, 4)
-        verify_conv2d_nchw_int8(1, 32, 149, 32, 3, 1, 0)
-        verify_conv2d_nchw_int8(7, 32, 149, 32, 3, 1, 0)
-        verify_conv2d_nchw_int8(1, 32, 35, 64, 7, 2, (0, 0, 1, 1))
-        verify_conv2d_nchw_int8(1, 32, 35, 64, 7, 2, (0, 0, 2, 2))
+        verify_conv2d_nchw_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1)
+        verify_conv2d_nchw_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1, add_relu=True)
+        verify_conv2d_nchw_int8(in_dtype, 1, 64, 56, 64, 3, 1, 1, dilation=2)
+        verify_conv2d_nchw_int8(in_dtype, 9, 64, 56, 64, 3, 1, 1)
+        verify_conv2d_nchw_int8(in_dtype, 4, 4, 4, 4, 4, 4, 4)
+        verify_conv2d_nchw_int8(in_dtype, 1, 32, 149, 32, 3, 1, 0)
+        verify_conv2d_nchw_int8(in_dtype, 7, 32, 149, 32, 3, 1, 0)
+        verify_conv2d_nchw_int8(in_dtype, 1, 32, 35, 64, 7, 2, (0, 0, 1, 1))
+        verify_conv2d_nchw_int8(in_dtype, 1, 32, 35, 64, 7, 2, (0, 0, 2, 2))
 
 
 def test_conv2d_nhwc():
@@ -646,5 +659,4 @@ def test_conv2d_nhwc():
 
 
 if __name__ == "__main__":
-    test_conv2d_nchw()
-    test_conv2d_nhwc()
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/topi/python/test_topi_conv2d_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_int8.py
@@ -370,14 +370,19 @@ def verify_conv2d_NCHWc_int8(
             lambda a, w, s, p, d, l, ol, o: topi.cuda.conv2d_NCHWc_int8(a, w, s, p, d, l, o),
             topi.cuda.schedule_conv2d_NCHWc_int8,
             4,
-        ),
-        (
-            "llvm -device arm_cpu -mtriple aarch64-linux-gnu -mattr=+neon",
-            topi.arm_cpu.conv2d_NCHWc_int8,
-            topi.arm_cpu.schedule_conv2d_NCHWc_int8,
-            8,
-        ),
+        )
     ]
+
+    if in_dtype == "int8":
+        targets.append(
+            (
+                "llvm -device arm_cpu -mtriple aarch64-linux-gnu -mattr=+neon",
+                topi.arm_cpu.conv2d_NCHWc_int8,
+                topi.arm_cpu.schedule_conv2d_NCHWc_int8,
+                8,
+            )
+        )
+
     for target, compute, schedule, oc_block_factor in targets:
         check_target(target, compute, schedule, oc_block_factor)
 


### PR DESCRIPTION
@masahi

[vulkan] Add integer dot product (4xint8, 4xuint8) tensorization for the vulkan SPIR-V target. Currently only autotvm path is supported.
    
Prerequisites for compilation: (1) Use VulkanSDK 1.2.198 release with SPIR-V integer dot product suppport  (2) set(USE_SPIRV_KHR_INTEGER_DOT_PRODUCT ON) in config.cmake and build (3) Use a driver that supports VK_KHR_shader_integer_dot_product extension.
    
The compiled binary can only be run on a hardware that supports relevant ISA. This work is tested on AMD RDNA2 famillies (e.g., Rembrandt and RX6800).
    
To compile on a device that supports this extension, use target: vulkan -from_device=0
    
To compile on a device that supports int8 but does not support this extension, add "-supports_integer_dot_product=1" or "-mattr=+dotprod" to the target string.
    
To support pre-released vulkan and SPIR-V extensions, we need SPIR-V tool and header file from Khronos github, use the option: USE_KHRONOS_SPIRV in config.cmake.
    
Example to use this feature can be found in: gallery/how_to/deploy_models/deploy_prequantized.py and gallery/how_to/deploy_models/deploy_prequantized_tflite.py

