### PR TITLE
[FIX,PROFILING] Add extra precision to numbers when serializing to json

### DIFF
--- a/src/runtime/profiling.cc
+++ b/src/runtime/profiling.cc
@@ -283,11 +283,11 @@ void print_metric(std::ostream& os, ObjectRef o) {
        << "\"" << Downcast<String>(o) << "\""
        << "}";
   } else if (const CountNode* n = o.as<CountNode>()) {
-    os << "{\"count\":" << std::to_string(n->value) << "}";
+    os << "{\"count\":" << n->value << "}";
   } else if (const DurationNode* n = o.as<DurationNode>()) {
-    os << "{\"microseconds\":" << std::to_string(n->microseconds) << "}";
+    os << "{\"microseconds\":" << std::setprecision(17) << std::fixed << n->microseconds << "}";
   } else if (const PercentNode* n = o.as<PercentNode>()) {
-    os << "{\"percent\":" << std::to_string(n->percent) << "}";
+    os << "{\"percent\":" << std::setprecision(17) << std::fixed << n->percent << "}";
   } else {
     LOG(FATAL) << "Unprintable type " << o->GetTypeKey();
   }


### PR DESCRIPTION
Numbers were serialized with too little precision when serializing profiling reports to json. Deserialization can then sometimes round the number differently than if the full precision was available.

Fixes #10382.

@driazati 