### PR TITLE
[WIP][microNPU] Show debug logging when running tests

### DIFF
--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -62,7 +62,7 @@ run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-integration tests/python/int
 
 # Ignoring Arm(R) Ethos(TM)-U NPU tests in the collective to run to run them in parallel in the next step.
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto --log-cli-level=DEBUG
 
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \


### PR DESCRIPTION
In an effort to show more information about the failures mentioned in
issue #10300, enabled printing debug information to the CLI when running
the integration tests.
