### PR TITLE
realize the function op during forward rewrite

### DIFF
--- a/src/relay/transforms/forward_rewrite.cc
+++ b/src/relay/transforms/forward_rewrite.cc
@@ -136,6 +136,9 @@ class ForwardRewriter : private MixedModeMutator {
     }
     const auto* post_node = post.as<CallNode>();
     auto new_op = post_node->op;
+    if (new_op->IsInstance<FunctionNode>()) {
+      new_op = realizer_.Realize(new_op);
+    }
     bool unchanged = call_node->op.same_as(new_op);
 
     Array<Expr> call_args;

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1701,5 +1701,18 @@ def test_axis_semantic_change():
         relay.build(mod, target="llvm")
 
 
+def test_alter_with_subfunc():
+    v1 = relay.var("v", shape=[1, 256, 10, 10], dtype="float32")
+    v2 = relay.image.resize2d(v1, size=[16, 16], roi=[0.0, 0.0, 0.0, 0.0], rounding_method="")
+    sub_func = relay.Function([v1], v2)
+    x1 = relay.var("x", shape=[1, 256, 10, 10], dtype="float32")
+    x2 = sub_func(x1)
+    x3 = relay.image.resize2d(x2, size=[8, 8], roi=[0.0, 0.0, 0.0, 0.0], rounding_method="")
+    func = relay.Function([x1], x3)
+    mod = tvm.IRModule.from_expr(func)
+    mod = relay.transform.InferType()(mod)
+    assert tvm.ir.structural_equal(relay.transform.AlterOpLayout()(mod), mod)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Hi, the pr try to fix exception `Check failed: (can_dispatch(n)) is false: NodeFunctor calls un-registered function on type relay.alter_op_layout.LayoutAlternatedExprNode`. 

For the pass using `TempExpr` and `ForwardRewrite`, there is code path which will leak unrealized `TempExpr` if sub-function body is also transformed to `TempExpr`. Since the user-defined realizer will not necessary do the full recursion, https://github.com/apache/tvm/blob/main/src/relay/transforms/forward_rewrite.cc#L46. we can explicitly realize the func op body during rewriting.

The script to reproduce is as below:
```python
import tvm
from tvm.ir.module import IRModule
from tvm import relay

x = relay.var("x", shape=[1, 256, 130, 130], dtype="float32")
w = relay.var("w", shape=[64, 256, 1, 1], dtype="float32")
b = relay.var("w", shape=[64], dtype="float32")
conv = relay.nn.conv2d(x, w, padding=[0,0,0,0], channels=64, kernel_size=[1,1])
exp = relay.expand_dims(b, axis=1, num_newaxis=2)
add = conv + exp
f = relay.Function([x, w, b], add)

xx = relay.var("xx", shape=[1, 256, 130, 130], dtype="float32")
ww = relay.var("ww", shape=[64, 256, 1, 1], dtype="float32")
bb = relay.var("bb", shape=[64], dtype="float32")
yy = f(xx, ww, bb)
yy2 = relay.image.resize2d(yy, size=[520, 520], roi=[0.,0.,0.,0.], rounding_method="")
ff = relay.Function([xx, ww, bb], yy2)
mod = IRModule.from_expr(ff)
mod = relay.transform.InferType()(mod)
with tvm.ir.transform.PassContext(opt_level=3):
    relay.build(mod, target="llvm")
```