### PR TITLE
[microTVM] Zephyr: add B-U585I-IOT02A board support

### DIFF
--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -1,4 +1,12 @@
 {
+    "b_u585i_iot02a": {
+        "board": "b_u585i_iot02a",
+        "model": "stm32u5xx",
+        "is_qemu": false,
+        "fpu": true,
+        "vid_hex": "0483",
+        "pid_hex": "374e"
+    },
     "mimxrt1050_evk": {
         "board": "mimxrt1050_evk",
         "model": "imxrt10xx",

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -662,6 +662,10 @@ class ZephyrSerialTransport:
         return generic_find_serial_port()
 
     @classmethod
+    def _find_stm32cubeprogrammer_serial_port(cls, options):
+        return generic_find_serial_port()
+
+    @classmethod
     def _find_serial_port(cls, options):
         flash_runner = _get_flash_runner()
 
@@ -673,6 +677,9 @@ class ZephyrSerialTransport:
 
         if flash_runner == "jlink":
             return cls._find_jlink_serial_port(options)
+
+        if flash_runner == "stm32cubeprogrammer":
+            return cls._find_stm32cubeprogrammer_serial_port(options)
 
         raise RuntimeError(f"Don't know how to deduce serial port for flash runner {flash_runner}")
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -339,6 +339,7 @@ MICRO_SUPPORTED_MODELS = {
     "sam3x8e": ["-mcpu=cortex-m3"],
     "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
     "stm32l4r5zi": ["-mcpu=cortex-m4"],
+    "stm32u5xx": ["-mcpu=cortex-m33"],
     "zynq_mp_r5": ["-mcpu=cortex-r5"],
 }
 


### PR DESCRIPTION
Add B-U585I-IOT02A board support to microTVM.

For more details about this board, please see:
https://www.st.com/en/evaluation-tools/b-u585i-iot02a.html

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

