### PR TITLE
[fix] Change the rule of determining compact dataflow.

### DIFF
--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -318,8 +318,8 @@ int CheckReductionBlockErrorCode(const ScheduleState& self, const StmtSRef& bloc
       bool has_reduction = false;
       bool all_complete_reduction = true;
       for (const StmtSRef& child_block_sref : child_block_srefs) {
-        int complete_code = CheckCompleteBlockErrorCode(self, child_block_sref, scope_root_sref);
-        int reduction_code = CheckReductionBlockErrorCode(self, child_block_sref, scope_root_sref);
+        int complete_code = CheckCompleteBlockErrorCode(self, child_block_sref, block_sref);
+        int reduction_code = CheckReductionBlockErrorCode(self, child_block_sref, block_sref);
         if (complete_code != 0 && reduction_code != 0) {
           all_complete_reduction = false;
           break;
@@ -1498,7 +1498,14 @@ bool ReductionIterNotIndexOutputBuffer(const Block& block) {
     if (!store) {
       return true;
     }
-    ICHECK(buffer_written.count(store->buffer.get()))
+    // whether the buffer is allocated inside block.
+    bool is_block_allocated_buf = false;
+    for (const Buffer& alloc_buf : block->alloc_buffers) {
+      if (store->buffer == alloc_buf) {
+        return true;
+      }
+    }
+    ICHECK(buffer_written.count(store->buffer.get()) || is_block_allocated_buf)
         << "ValueError: The buffer \"" << store->buffer
         << "\" is written in the block but is not in the block's signature";
     for (const PrimExpr& index : store->indices) {

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -328,9 +328,7 @@ int CheckReductionBlockErrorCode(const ScheduleState& self, const StmtSRef& bloc
           has_reduction = true;
         }
       }
-      if (has_reduction && all_complete_reduction) {
-        return 0;
-      } else {
+      if (!has_reduction || !all_complete_reduction) {
         return 1;
       }
     }

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -22,7 +22,6 @@ import tvm
 import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
-from tvm.tir.schedule.schedule import Schedule
 from tvm.tir.schedule.testing import verify_trace_roundtrip
 
 # pylint: disable=no-member,invalid-name,unused-variable

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -377,9 +377,9 @@ def nested_block_bind_after_cache_read(
     for i in T.serial(16):
         with T.block("outer"):
             vi = T.axis.spatial(16, i)
+            T.reads(B[vi], A[vi, 0:16])
+            T.writes(B[vi])
             A_shared = T.alloc_buffer([1, 16], dtype="float32", scope="shared")
-            T.reads(B[vi], A[vi, 0:16], A_shared[0, 0:16])
-            T.writes(B[vi], A_shared[0, 0:16])
             for ax0, ax1 in T.grid(1, 16):
                 with T.block("A_shared"):
                     v0 = T.axis.spatial(16, vi + ax0)
@@ -404,9 +404,9 @@ def thread_bound_nested_block_after_cache_read(
     for i in T.thread_binding(16, thread="blockIdx.x"):
         with T.block("outer"):
             vi = T.axis.spatial(16, i)
+            T.reads(B[vi], A[vi, 0:16])
+            T.writes(B[vi])
             A_shared = T.alloc_buffer([1, 16], dtype="float32", scope="shared")
-            T.reads(B[vi], A[vi, 0:16], A_shared[0, 0:16])
-            T.writes(B[vi], A_shared[0, 0:16])
             for ax0, ax1 in T.grid(1, 16):
                 with T.block("A_shared"):
                     v0 = T.axis.spatial(16, vi + ax0)
@@ -582,6 +582,7 @@ def test_nexted_block_bind_after_cache_read():
     (j,) = s.get_loops(block_inner)
     s.bind(i, "blockIdx.x")
     s.bind(j, "threadIdx.x")
+    print(s.mod["main"].script())
     tvm.ir.assert_structural_equal(s.mod["main"], thread_bound_nested_block_after_cache_read)
     verify_trace_roundtrip(s, mod=nested_block_bind_after_cache_read)
 

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-function-docstring,missing-module-docstring
+from os import get_blocking
 import sys
 
 import pytest
@@ -22,6 +23,7 @@ import tvm
 import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
+from tvm.tir.schedule.schedule import Schedule
 from tvm.tir.schedule.testing import verify_trace_roundtrip
 
 # pylint: disable=no-member,invalid-name,unused-variable
@@ -330,6 +332,100 @@ def decomposed_gemm_after_vectorize(
                     C[vi, vj] = local[vi, vj]
 
 
+@T.prim_func
+def nested_block_bind(
+    A: T.Buffer[(16, 16, 16, 16), "float32"], B: T.Buffer[(16, 16, 16), "float32"]
+):
+    for i, j in T.grid(16, 16):
+        with T.block("outer"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            T.reads(B[vi, vj, 0:16], A[vi, vj, 0:16, 0:16])
+            T.writes(B[vi, vj, 0:16])
+            for k, l in T.grid(16, 16):
+                with T.block("inner"):
+                    vk, vl = T.axis.remap("SR", [k, l])
+                    T.reads(B[vi, vj, vk], A[vi, vj, vk, vl])
+                    T.writes(B[vi, vj, vk])
+                    with T.init():
+                        B[vi, vj, vk] = 0.0
+                    B[vi, vj, vk] = B[vi, vj, vk] + A[vi, vj, vk, vl]
+
+
+@T.prim_func
+def thread_bound_nested_block(
+    A: T.Buffer[(16, 16, 16, 16), "float32"], B: T.Buffer[(16, 16, 16), "float32"]
+) -> None:
+    for i in T.serial(16):
+        for j in T.thread_binding(16, thread="blockIdx.x"):
+            with T.block("outer"):
+                vi, vj = T.axis.remap("SS", [i, j])
+                T.reads(B[vi, vj, 0:16], A[vi, vj, 0:16, 0:16])
+                T.writes(B[vi, vj, 0:16])
+                for k in T.serial(16):
+                    for l in T.thread_binding(16, thread="threadIdx.x"):
+                        with T.block("inner"):
+                            vk, vl = T.axis.remap("SR", [k, l])
+                            T.reads(B[vi, vj, vk], A[vi, vj, vk, vl])
+                            T.writes(B[vi, vj, vk])
+                            with T.init():
+                                B[vi, vj, vk] = T.float32(0)
+                            B[vi, vj, vk] = B[vi, vj, vk] + A[vi, vj, vk, vl]
+
+
+@T.prim_func
+def nested_block_bind_after_cache_read(
+    A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16,), "float32"]
+) -> None:
+    for i in T.serial(16):
+        with T.block("outer"):
+            vi = T.axis.spatial(16, i)
+            A_shared = T.alloc_buffer([1, 16], dtype="float32", scope="shared")
+            T.reads(B[vi], A[vi, 0:16], A_shared[0, 0:16])
+            T.writes(B[vi], A_shared[0, 0:16])
+            for ax0, ax1 in T.grid(1, 16):
+                with T.block("A_shared"):
+                    v0 = T.axis.spatial(16, vi + ax0)
+                    v1 = T.axis.spatial(16, ax1)
+                    T.reads(A[v0, v1])
+                    T.writes(A_shared[v0, v1])
+                    A_shared[v0, v1] = A[v0, v1]
+            for j in T.serial(16):
+                with T.block("inner"):
+                    vj = T.axis.reduce(16, j)
+                    T.reads(B[vi], A_shared[vi, vj])
+                    T.writes(B[vi])
+                    with T.init():
+                        B[vi] = T.float32(0)
+                    B[vi] = B[vi] + A_shared[vi, vj]
+
+
+@T.prim_func
+def thread_bound_nested_block_after_cache_read(
+    A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16,), "float32"]
+) -> None:
+    for i in T.thread_binding(16, thread="blockIdx.x"):
+        with T.block("outer"):
+            vi = T.axis.spatial(16, i)
+            A_shared = T.alloc_buffer([1, 16], dtype="float32", scope="shared")
+            T.reads(B[vi], A[vi, 0:16], A_shared[0, 0:16])
+            T.writes(B[vi], A_shared[0, 0:16])
+            for ax0, ax1 in T.grid(1, 16):
+                with T.block("A_shared"):
+                    v0 = T.axis.spatial(16, vi + ax0)
+                    v1 = T.axis.spatial(16, ax1)
+                    T.reads(A[v0, v1])
+                    T.writes(A_shared[v0, v1])
+                    A_shared[v0, v1] = A[v0, v1]
+            for j in T.thread_binding(16, thread="threadIdx.x"):
+                with T.block("inner"):
+                    vj = T.axis.reduce(16, j)
+                    T.reads(B[vi], A_shared[vi, vj])
+                    T.writes(B[vi])
+                    with T.init():
+                        B[vi] = T.float32(0)
+                    B[vi] = B[vi] + A_shared[vi, vj]
+
+
 # pylint: enable=no-member,invalid-name,unused-variable
 
 
@@ -466,6 +562,30 @@ def test_vectorize_after_decompose():
     s.vectorize(jj)
     tvm.ir.assert_structural_equal(s.mod["main"], decomposed_gemm_after_vectorize)
     verify_trace_roundtrip(s, mod=decomposed_gemm)
+
+
+def test_nested_block_bind():
+    s = tir.Schedule(nested_block_bind)
+    block_outer = s.get_block("outer")
+    block_inner = s.get_block("inner")
+    _, j = s.get_loops(block_outer)
+    _, l = s.get_loops(block_inner)
+    s.bind(l, "threadIdx.x")
+    s.bind(j, "blockIdx.x")
+    tvm.ir.assert_structural_equal(s.mod["main"], thread_bound_nested_block)
+    verify_trace_roundtrip(s, mod=nested_block_bind)
+
+
+def test_nexted_block_bind_after_cache_read():
+    s = tir.Schedule(nested_block_bind_after_cache_read)
+    block_outer = s.get_block("outer")
+    block_inner = s.get_block("inner")
+    (i,) = s.get_loops(block_outer)
+    (j,) = s.get_loops(block_inner)
+    s.bind(i, "blockIdx.x")
+    s.bind(j, "threadIdx.x")
+    tvm.ir.assert_structural_equal(s.mod["main"], thread_bound_nested_block_after_cache_read)
+    verify_trace_roundtrip(s, mod=nested_block_bind_after_cache_read)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-function-docstring,missing-module-docstring
-from os import get_blocking
 import sys
 
 import pytest


### PR DESCRIPTION
Previously, we can not bind the loop `i`/`j` to any data-parallel physical threads in the following example because `outer` is neither determined as `CompleteBlock` nor `ReductionBlock`:

1. `outer` writes and reads `b` simultaneously so it's not a complete block.
2. `outer` has no `init` sub-block so it's not a reduction block.

```python
@T.prim_func
def nested_block_bind(a_ptr: T.handle, b_ptr: T.handle):
    a = T.match_buffer(a_ptr, [16, 16, 16, 16], "float32")
    b = T.match_buffer(b_ptr, [16, 16, 16], "float32")
    for i, j in T.grid(16, 16):
        with T.block("outer"):
            vi, vj = T.axis.remap("SS", [i, j])
            for k, l in T.grid(16, 16):
                with T.block("inner"):
                    vk, vl = T.axis.remap("SR", [k, l])
                    with T.init():
                        b[vi, vj, vk] = 0.0
                    b[vi, vj, vk] = b[vi, vj, vk] + a[vi, vj, vk, vl]
```
Such a case might happen after performing blockize or block isolation in Sparse TIR.

In this PR I changed the rule we determine reduction blocks: if there is no init block, and there are sub-blocks, we check the following rules:
1. all block iters in the current block are data-parallel.
2. all sub-blocks are complete/reduction (this implies they are dominant).
3. there must be at least one reduction sub-block (there is a init block inside it).

cc @Hzfengsy @MasterJH5574  @spectrometerHBH 