### PR TITLE
Add group_conv2d_transpose_nchw to CUDA backend

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -594,18 +594,11 @@ def conv2d_transpose_strategy_cuda(attrs, inputs, out_type, target):
     num_strategies = 0
 
     if layout == "NCHW":
-        if groups == 1:
-            strategy.add_implementation(
-                wrap_compute_conv2d_transpose(topi.cuda.conv2d_transpose_nchw),
-                wrap_topi_schedule(topi.cuda.schedule_conv2d_transpose_nchw),
-                name="conv2d_transpose_nchw.cuda",
-            )
-        else:
-            strategy.add_implementation(
-                wrap_compute_conv2d_transpose(topi.cuda.group_conv2d_transpose_nchw, has_groups=True),
-                wrap_topi_schedule(topi.cuda.schedule_group_conv2d_transpose_nchw),
-                name="group_conv2d_transpose_nchw.cuda",
-            )
+        strategy.add_implementation(
+            wrap_compute_conv2d_transpose(topi.cuda.conv2d_transpose_nchw, has_groups=True),
+            wrap_topi_schedule(topi.cuda.schedule_conv2d_transpose_nchw),
+            name="conv2d_transpose_nchw.cuda",
+        )
         num_strategies += 1
 
     if (

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -593,12 +593,19 @@ def conv2d_transpose_strategy_cuda(attrs, inputs, out_type, target):
     strategy = _op.OpStrategy()
     num_strategies = 0
 
-    if layout == "NCHW" and groups == 1:
-        strategy.add_implementation(
-            wrap_compute_conv2d_transpose(topi.cuda.conv2d_transpose_nchw),
-            wrap_topi_schedule(topi.cuda.schedule_conv2d_transpose_nchw),
-            name="conv2d_transpose_nchw.cuda",
-        )
+    if layout == "NCHW":
+        if groups == 1:
+            strategy.add_implementation(
+                wrap_compute_conv2d_transpose(topi.cuda.conv2d_transpose_nchw),
+                wrap_topi_schedule(topi.cuda.schedule_conv2d_transpose_nchw),
+                name="conv2d_transpose_nchw.cuda",
+            )
+        else:
+            strategy.add_implementation(
+                wrap_compute_conv2d_transpose(topi.cuda.group_conv2d_transpose_nchw, has_groups=True),
+                wrap_topi_schedule(topi.cuda.schedule_group_conv2d_transpose_nchw),
+                name="group_conv2d_transpose_nchw.cuda",
+            )
         num_strategies += 1
 
     if (

--- a/python/tvm/topi/cuda/conv2d_transpose.py
+++ b/python/tvm/topi/cuda/conv2d_transpose.py
@@ -23,11 +23,11 @@ from tvm.contrib import cudnn
 from tvm import autotvm
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 from .. import nn
-from ..utils import get_const_int, get_const_tuple, traverse_inline
+from ..utils import get_const_tuple, traverse_inline
 
 
 @autotvm.register_topi_compute("conv2d_transpose_nchw.cuda")
-def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_padding):
+def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_padding, groups=1):
     """Transposed 2D convolution nchw forward operator.
 
     Parameters
@@ -46,6 +46,8 @@ def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_
         The output type. This is used in mixed precision
     output_padding : tuple of two ints
         Used to disambiguate output shape.
+    groups : int
+        number of groups
 
     Returns
     -------
@@ -57,6 +59,7 @@ def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_
     stride_height, stride_width = stride
     outpad_height, outpad_width = output_padding
     assert outpad_height < stride_height and outpad_width < stride_width
+    assert inp_channels % groups == 0, f"input channels {inp_channels} must divide group size {groups}"
     cfg.stride = stride
     pad_top, pad_left, pad_bottom, pad_right = nn.get_pad_tuple(
         padding, (kernel_height, kernel_width)
@@ -103,14 +106,21 @@ def conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_
     )
 
     # compute transposed conv
-    dc = te.reduce_axis((0, inp_channels), name="dc")
+    dc = te.reduce_axis((0, inp_channels // groups), name="dc")
     dh = te.reduce_axis((0, kernel_height), name="dh")
     dw = te.reduce_axis((0, kernel_width), name="dw")
     data_out = te.compute(
-        (batch, out_channels, out_height, out_width),
+        (batch, out_channels * groups, out_height, out_width),
         lambda b, c, h, w: te.sum(
-            data[b, dc, h + dh, w + dw].astype(out_dtype)
-            * kernel[dc, c, kernel_height - 1 - dh, kernel_width - 1 - dw].astype(out_dtype),
+            data[
+                b,  c // out_channels * (inp_channels // groups) + dc, h + dh, w + dw
+            ].astype(out_dtype)
+            * kernel[
+                c // out_channels * (inp_channels // groups) + dc,
+                c % out_channels,
+                kernel_height - 1 - dh,
+                kernel_width - 1 - dw
+            ].astype(out_dtype),
             axis=[dc, dh, dw],
         ),
         tag="conv2d_transpose_nchw",
@@ -139,17 +149,6 @@ def schedule_conv2d_transpose_nchw(cfg, outs):
     """
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
-
-    def _callback(op):
-        if op.tag == "conv2d_transpose_nchw":
-            _schedule_conv2d_transpose_nchw(cfg, s, op)
-
-    traverse_inline(s, outs[0].op, _callback)
-
-    return s
-
-
-def _schedule_conv2d_transpose_nchw(cfg, s, op):
 
     def _fallback_schedule(N, F, Y, X):
         # pylint: disable=unused-argument
@@ -182,359 +181,122 @@ def _schedule_conv2d_transpose_nchw(cfg, s, op):
         cfg["unroll_explicit"] = OtherOptionEntity(True)
         cfg["auto_unroll_max_step"] = OtherOptionEntity(1500)
 
-    pad_data = op.input_tensors[0]
-    kernel = op.input_tensors[1]
-    conv = op.output(0)
-
-    ##### space definition begin #####
-    n, f, y, x = s[conv].op.axis
-    rc = s[conv].op.reduce_axis[0]
-    # TODO(@kevinthesun): Support tuning/optimization for dynamic shape.
-    bs = pad_data.shape[0]
-    n_tuning_axis = n if isinstance(bs, tvm.tir.IntImm) else 1
-    cfg.define_split("tile_n", cfg.axis(n_tuning_axis), num_outputs=4)
-    cfg.define_split("tile_f", cfg.axis(f), num_outputs=4)
-    cfg.define_split("tile_y", cfg.axis(y), num_outputs=4)
-    cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
-    cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
-    cfg.define_knob("auto_unroll_max_step", [64, 512, 1500])
-
-    target = tvm.target.Target.current()
-    if target.kind.name in ["nvptx", "rocm"]:
-        cfg.define_knob("unroll_explicit", [1])
-    else:
-        cfg.define_knob("unroll_explicit", [0, 1])
-
-    if cfg.is_fallback:
-        N, F, Y, X = get_const_tuple(conv.shape)
-        if not isinstance(N, int):
-            N = 1
-        _fallback_schedule(N, F, Y, X)
-
-    ##### space definition end #####
-
-    if isinstance(kernel.op, tvm.te.ComputeOp) and "dilate" in kernel.op.tag:
-        s[kernel].compute_inline()
-
-    if conv.op in s.outputs:
-        output = conv
-        OL = s.cache_write(conv, "local")
-    else:
-        output = s.outputs[0].output(0)
-        s[conv].set_scope("local")
-        OL = conv
-
-    # create cache stage
-    s[pad_data].set_scope("shared")
-    AA = pad_data
-    WW = s.cache_read(kernel, "shared", [OL])
-
-    # tile and bind spatial axes
-    n, f, y, x = s[output].op.axis
-    kernel_scope, n = s[output].split(n, nparts=1)
-    bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
-    bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
-    by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
-    bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
-
-    s[output].reorder(bn, bf, by, bx, vn, vf, vy, vx, tn, tf, ty, tx, ni, fi, yi, xi)
-    s[output].bind(bn, te.thread_axis("blockIdx.z"))
-    s[output].bind(bf, te.thread_axis("blockIdx.y"))
-    s[output].bind(s[output].fuse(by, bx), te.thread_axis("blockIdx.x"))
-    s[output].bind(vn, te.thread_axis("vthread"))
-    s[output].bind(vf, te.thread_axis("vthread"))
-    s[output].bind(vy, te.thread_axis("vthread"))
-    s[output].bind(vx, te.thread_axis("vthread"))
-
-    cfg.define_knob("fuse_yx", [0, 1])  # fuse ty,tx or tn,tf
-
-    if cfg["fuse_yx"].val:
-        s[output].bind(tn, te.thread_axis("threadIdx.z"))
-        s[output].bind(tf, te.thread_axis("threadIdx.y"))
-        tyx = s[output].fuse(ty, tx)
-        s[output].bind(s[output].fuse(ty, tx), te.thread_axis("threadIdx.x"))
-        s[OL].compute_at(s[output], tyx)
-
-        # number of threads
-        n_tz = cfg["tile_n"].size[2]
-        n_ty = cfg["tile_f"].size[2]
-        n_tx = cfg["tile_y"].size[2] * cfg["tile_x"].size[2]
-    else:
-        s[output].bind(s[output].fuse(tn, tf), te.thread_axis("threadIdx.z"))
-        s[output].bind(ty, te.thread_axis("threadIdx.y"))
-        s[output].bind(tx, te.thread_axis("threadIdx.x"))
-        s[OL].compute_at(s[output], tx)
-
-        # number of threads
-        n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
-        n_ty = cfg["tile_y"].size[2]
-        n_tx = cfg["tile_x"].size[2]
-
-    # tile reduction axes
-    n, f, y, x = s[OL].op.axis
-    rc, ry, rx = s[OL].op.reduce_axis
-    rco, rcm, rci = cfg["tile_rc"].apply(s, OL, rc)
-    s[OL].reorder(rco, rcm, ry, rx, rci, n, f, y, x)
-
-    s[AA].compute_at(s[OL], rx)
-    s[WW].compute_at(s[OL], rx)
-
-    # cooperative fetching
-    for load in [AA, WW]:
-        n, f, y, x = s[load].op.axis
-        fused = s[load].fuse(f, y, x)
-        tz, fused = s[load].split(fused, nparts=n_tz)
-        ty, fused = s[load].split(fused, nparts=n_ty)
-        tx, fused = s[load].split(fused, nparts=n_tx)
-        s[load].bind(tz, te.thread_axis("threadIdx.z"))
-        s[load].bind(ty, te.thread_axis("threadIdx.y"))
-        s[load].bind(tx, te.thread_axis("threadIdx.x"))
-
-    s[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
-    s[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
-
-
-@autotvm.register_topi_compute("group_conv2d_transpose_nchw.cuda")
-def group_conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_padding, groups):
-    """Transposed 2D convolution nchw forward operator.
-
-    Parameters
-    ----------
-    cfg: ConfigEntity
-        The config for this template
-    Input : tvm.te.Tensor
-        4-D with shape [batch, in_channel, in_height, in_width]
-    Filter : tvm.te.Tensor
-        4-D with shape [in_channel, num_filter, filter_height, filter_width]
-    strides : tuple of two ints
-        The spatial stride along height and width
-    padding : int or str
-        Padding size, or ['VALID', 'SAME']
-    out_dtype: str
-        The output type. This is used in mixed precision
-    output_padding : tuple of two ints
-        Used to disambiguate output shape.
-    groups : int
-        number of groups
-
-    Returns
-    -------
-    Output : tvm.te.Tensor
-        4-D with shape [batch, out_channel, out_height, out_width]
-    """
-    if groups == 1:
-        return conv2d_transpose_nchw(data, kernel, stride, padding, out_dtype, output_padding)
-
-    batch, inp_channels, inp_height, inp_width = get_const_tuple(data.shape)
-    assert inp_channels % groups == 0, f"input channels {inp_channels} must divide group size {groups}"
-    _, out_channels, kernel_height, kernel_width = get_const_tuple(kernel.shape)
-    stride_height, stride_width = stride
-    outpad_height, outpad_width = output_padding
-    assert outpad_height < stride_height and outpad_width < stride_width
-    cfg.stride = stride
-    pad_top, pad_left, pad_bottom, pad_right = nn.get_pad_tuple(
-        padding, (kernel_height, kernel_width)
-    )
-
-    out_width = (inp_width - 1) * stride_width + kernel_width - pad_left - pad_right + outpad_width
-    pad_left = kernel_width - 1 - pad_left
-    pad_right = kernel_width - 1 - pad_right + outpad_width
-    dilated_width = stride_width * (inp_width - 1) + 1
-
-    out_height = (
-        (inp_height - 1) * stride_height + kernel_height - pad_top - pad_bottom + outpad_height
-    )
-    pad_top = kernel_height - 1 - pad_top
-    pad_bottom = kernel_height - 1 - pad_bottom + outpad_height
-    dilated_height = stride_height * (inp_height - 1) + 1
-
-    # compute pad
-    data = te.compute(
-        (
-            batch,
-            inp_channels,
-            pad_top + dilated_height + pad_bottom,
-            pad_left + dilated_width + pad_right,
-        ),
-        lambda n, c, y, x: tvm.tir.if_then_else(
-            tvm.tir.all(
-                x >= pad_left,
-                x < pad_left + dilated_width,
-                tvm.tir.indexmod(x - pad_left, stride_width).equal(0),
-                y >= pad_top,
-                y < pad_top + dilated_height,
-                tvm.tir.indexmod(y - pad_top, stride_height).equal(0),
-            ),
-            data[
-                n,
-                c,
-                tvm.tir.indexdiv(y - pad_top, stride_height),
-                tvm.tir.indexdiv(x - pad_left, stride_width),
-            ],
-            tvm.tir.const(0.0, data.dtype),
-        ),
-        name="data_pad",
-    )
-
-    # transform kernel layout from IOHW to OIHW, and rotate kernel by 180 degrees
-    kernel_transform = te.compute(
-        (out_channels, inp_channels, kernel_height, kernel_width),
-        lambda i, o, h, w: kernel[o][i][kernel_height - 1 - h][kernel_width - 1 - w],
-        name="kernel_transform",
-    )
-    
-    dc = te.reduce_axis((0, inp_channels // groups), name="dc")
-    dh = te.reduce_axis((0, kernel_height), name="dh")
-    dw = te.reduce_axis((0, kernel_width), name="dw")
-    data_out = te.compute(
-        (batch, out_channels * groups, out_height, out_width),
-        lambda b, c, h, w: te.sum(
-            data[
-                b, c // out_channels * (inp_channels // groups) + dc, h + dh, w + dw
-            ].astype(out_dtype)
-            * kernel_transform[
-                c % out_channels,
-                c // out_channels * (inp_channels // groups) + dc,
-                dh,
-                dw
-            ].astype(out_dtype),
-            axis=[dc, dh, dw],
-        ),
-        tag="group_conv2d_transpose_nchw",
-    )
-
-    return data_out
-
-
-@autotvm.register_topi_schedule("group_conv2d_transpose_nchw.cuda")
-def schedule_group_conv2d_transpose_nchw(cfg, outs):
-    outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
-    s = te.create_schedule([x.op for x in outs])
-
     def _callback(op):
-        if op.tag == "group_conv2d_transpose_nchw":
-            _schedule_group_conv2d_transpose_nchw(cfg, s, op)
+        if op.tag == "conv2d_transpose_nchw":
+            pad_data = op.input_tensors[0]
+            kernel = op.input_tensors[1]
+            conv = op.output(0)
 
-        elif op.tag == "conv2d_transpose_nchw":  # groups == 1 cases delegate to regular conv2d_transpose
-            _schedule_conv2d_transpose_nchw(cfg, s, op)
+            ##### space definition begin #####
+            n, f, y, x = s[conv].op.axis
+            rc = s[conv].op.reduce_axis[0]
+            # TODO(@kevinthesun): Support tuning/optimization for dynamic shape.
+            bs = pad_data.shape[0]
+            n_tuning_axis = n if isinstance(bs, tvm.tir.IntImm) else 1
+            cfg.define_split("tile_n", cfg.axis(n_tuning_axis), num_outputs=4)
+            cfg.define_split("tile_f", cfg.axis(f), num_outputs=4)
+            cfg.define_split("tile_y", cfg.axis(y), num_outputs=4)
+            cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
+            cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
+            cfg.define_knob("auto_unroll_max_step", [64, 512, 1500])
+
+            target = tvm.target.Target.current()
+            if target.kind.name in ["nvptx", "rocm"]:
+                cfg.define_knob("unroll_explicit", [1])
+            else:
+                cfg.define_knob("unroll_explicit", [0, 1])
+
+            if cfg.is_fallback:
+                N, F, Y, X = get_const_tuple(conv.shape)
+                if not isinstance(N, int):
+                    N = 1
+                _fallback_schedule(N, F, Y, X)
+
+            ##### space definition end #####
+
+            if isinstance(kernel.op, tvm.te.ComputeOp) and "dilate" in kernel.op.tag:
+                s[kernel].compute_inline()
+
+            if conv.op in s.outputs:
+                output = conv
+                OL = s.cache_write(conv, "local")
+            else:
+                output = s.outputs[0].output(0)
+                s[conv].set_scope("local")
+                OL = conv
+
+            # create cache stage
+            s[pad_data].set_scope("shared")
+            AA = pad_data
+            WW = s.cache_read(kernel, "shared", [OL])
+
+            # tile and bind spatial axes
+            n, f, y, x = s[output].op.axis
+            kernel_scope, n = s[output].split(n, nparts=1)
+            bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
+            bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
+            by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
+            bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
+
+            s[output].reorder(bn, bf, by, bx, vn, vf, vy, vx, tn, tf, ty, tx, ni, fi, yi, xi)
+            s[output].bind(bn, te.thread_axis("blockIdx.z"))
+            s[output].bind(bf, te.thread_axis("blockIdx.y"))
+            s[output].bind(s[output].fuse(by, bx), te.thread_axis("blockIdx.x"))
+            s[output].bind(vn, te.thread_axis("vthread"))
+            s[output].bind(vf, te.thread_axis("vthread"))
+            s[output].bind(vy, te.thread_axis("vthread"))
+            s[output].bind(vx, te.thread_axis("vthread"))
+
+            cfg.define_knob("fuse_yx", [0, 1])  # fuse ty,tx or tn,tf
+
+            if cfg["fuse_yx"].val:
+                s[output].bind(tn, te.thread_axis("threadIdx.z"))
+                s[output].bind(tf, te.thread_axis("threadIdx.y"))
+                tyx = s[output].fuse(ty, tx)
+                s[output].bind(s[output].fuse(ty, tx), te.thread_axis("threadIdx.x"))
+                s[OL].compute_at(s[output], tyx)
+
+                # number of threads
+                n_tz = cfg["tile_n"].size[2]
+                n_ty = cfg["tile_f"].size[2]
+                n_tx = cfg["tile_y"].size[2] * cfg["tile_x"].size[2]
+            else:
+                s[output].bind(s[output].fuse(tn, tf), te.thread_axis("threadIdx.z"))
+                s[output].bind(ty, te.thread_axis("threadIdx.y"))
+                s[output].bind(tx, te.thread_axis("threadIdx.x"))
+                s[OL].compute_at(s[output], tx)
+
+                # number of threads
+                n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
+                n_ty = cfg["tile_y"].size[2]
+                n_tx = cfg["tile_x"].size[2]
+
+            # tile reduction axes
+            n, f, y, x = s[OL].op.axis
+            rc, ry, rx = s[OL].op.reduce_axis
+            rco, rcm, rci = cfg["tile_rc"].apply(s, OL, rc)
+            s[OL].reorder(rco, rcm, ry, rx, rci, n, f, y, x)
+
+            s[AA].compute_at(s[OL], rx)
+            s[WW].compute_at(s[OL], rx)
+
+            # cooperative fetching
+            for load in [AA, WW]:
+                n, f, y, x = s[load].op.axis
+                fused = s[load].fuse(f, y, x)
+                tz, fused = s[load].split(fused, nparts=n_tz)
+                ty, fused = s[load].split(fused, nparts=n_ty)
+                tx, fused = s[load].split(fused, nparts=n_tx)
+                s[load].bind(tz, te.thread_axis("threadIdx.z"))
+                s[load].bind(ty, te.thread_axis("threadIdx.y"))
+                s[load].bind(tx, te.thread_axis("threadIdx.x"))
+
+            s[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
+            s[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
 
     traverse_inline(s, outs[0].op, _callback)
 
     return s
-
-
-def _schedule_group_conv2d_transpose_nchw(cfg, s, op):
-    pad_data, kernel_transform = op.input_tensors
-    conv = op.output(0)
-    workload = conv.op.attrs["workload"]
-    groups = get_const_int(workload[7])
-    num_filters = get_const_int(conv.shape[1])
-
-    ##### space definition begin #####
-    n, f, y, x = s[conv].op.axis
-    rc = s[conv].op.reduce_axis[0]
-    cfg.define_split("tile_n", cfg.axis(n), num_outputs=4)
-    cfg.define_split("tile_g", cfg.axis(groups), num_outputs=2)
-    cfg.define_split("tile_f", cfg.axis(num_filters // groups), num_outputs=4)
-    cfg.define_split("tile_y", cfg.axis(y), num_outputs=4)
-    cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
-    cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
-    cfg.define_knob("auto_unroll_max_step", [0, 64, 512, 1500])
-
-    target = tvm.target.Target.current()
-    if target.kind.name in ["nvptx", "rocm"]:
-        cfg.define_knob("unroll_explicit", [1])
-    else:
-        cfg.define_knob("unroll_explicit", [0, 1])
-
-    ##### space definition end #####
-    s[kernel_transform].compute_inline() 
-
-    if conv.op in s.outputs:
-        output = conv
-        OL = s.cache_write(conv, "local")
-    else:
-        output = s.outputs[0].output(0)
-        s[conv].set_scope("local")
-        OL = conv
-
-    # create cache stage
-    s[pad_data].set_scope("shared")
-    AA = pad_data
-    s[kernel_transform].set_scope("shared")
-    WW = kernel_transform
-
-    # tile and bind spatial axes
-    n, f, y, x = s[output].op.axis
-    kernel_scope, n = s[output].split(n, nparts=1)
-
-    g, f = s[output].split(f, nparts=groups)
-    bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
-    bg, vg = cfg["tile_g"].apply(s, output, g)
-    bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
-    by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
-    bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
-
-    s[output].reorder(bn, bg, bf, by, bx, vn, vg, vf, vy, vx, tn, tf, ty, tx, ni, fi, yi, xi)
-    s[output].bind(bn, te.thread_axis("blockIdx.z"))
-    s[output].bind(s[output].fuse(bg, bf), te.thread_axis("blockIdx.y"))
-    s[output].bind(s[output].fuse(by, bx), te.thread_axis("blockIdx.x"))
-    s[output].bind(vn, te.thread_axis("vthread"))
-    s[output].bind(vg, te.thread_axis("vthread"))
-    s[output].bind(vf, te.thread_axis("vthread"))
-    s[output].bind(vy, te.thread_axis("vthread"))
-    s[output].bind(vx, te.thread_axis("vthread"))
-
-    cfg.define_knob("fuse_yx", [0, 1])  # fuse ty,tx or tn,tf
-    if cfg["fuse_yx"].val:
-        s[output].bind(tn, te.thread_axis("threadIdx.z"))
-        s[output].bind(tf, te.thread_axis("threadIdx.y"))
-        tyx = s[output].fuse(ty, tx)
-        s[output].bind(tyx, te.thread_axis("threadIdx.x"))
-        s[OL].compute_at(s[output], tyx)
-
-        # number of threads
-        n_tz = cfg["tile_n"].size[2]
-        n_ty = cfg["tile_f"].size[2]
-        n_tx = cfg["tile_y"].size[2] * cfg["tile_x"].size[2]
-    else:
-        s[output].bind(s[output].fuse(tn, tf), te.thread_axis("threadIdx.z"))
-        s[output].bind(ty, te.thread_axis("threadIdx.y"))
-        s[output].bind(tx, te.thread_axis("threadIdx.x"))
-        s[OL].compute_at(s[output], tx)
-
-        # number of threads
-        n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
-        n_ty = cfg["tile_y"].size[2]
-        n_tx = cfg["tile_x"].size[2]
-
-    # tile reduction axes
-    n, f, y, x = s[OL].op.axis
-    rc, ry, rx = s[OL].op.reduce_axis
-    rco, rcm, rci = cfg["tile_rc"].apply(s, OL, rc)
-    s[OL].reorder(rco, rcm, ry, rx, rci, n, f, y, x)
-
-    s[AA].compute_at(s[OL], rx)
-    s[WW].compute_at(s[OL], rx)
-
-    # cooperative fetching
-    for load in [AA, WW]:
-        n, f, y, x = s[load].op.axis
-        fused = s[load].fuse(n, f, y, x)
-        fused, tx = s[load].split(fused, factor=n_tx)
-        fused, ty = s[load].split(fused, factor=n_ty)
-        fused, tz = s[load].split(fused, factor=n_tz)
-        s[load].bind(tz, te.thread_axis("threadIdx.z"))
-        s[load].bind(ty, te.thread_axis("threadIdx.y"))
-        s[load].bind(tx, te.thread_axis("threadIdx.x"))
-
-    # unroll
-    s[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
-    s[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
-
-    N, CO, OH, OW = get_const_tuple(output.shape)
-    _, CI_div_groups, KH, KW = get_const_tuple(kernel_transform.shape)
-    cfg.add_flop(2 * N * OH * OW * CO * CI_div_groups * KH * KW)
 
 
 def conv2d_transpose_cudnn(

--- a/python/tvm/topi/cuda/conv2d_transpose.py
+++ b/python/tvm/topi/cuda/conv2d_transpose.py
@@ -23,7 +23,7 @@ from tvm.contrib import cudnn
 from tvm import autotvm
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 from .. import nn
-from ..utils import get_const_tuple, traverse_inline
+from ..utils import get_const_int, get_const_tuple, traverse_inline
 
 
 @autotvm.register_topi_compute("conv2d_transpose_nchw.cuda")
@@ -140,6 +140,17 @@ def schedule_conv2d_transpose_nchw(cfg, outs):
     outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
     s = te.create_schedule([x.op for x in outs])
 
+    def _callback(op):
+        if op.tag == "conv2d_transpose_nchw":
+            _schedule_conv2d_transpose_nchw(cfg, s, op)
+
+    traverse_inline(s, outs[0].op, _callback)
+
+    return s
+
+
+def _schedule_conv2d_transpose_nchw(cfg, s, op):
+
     def _fallback_schedule(N, F, Y, X):
         # pylint: disable=unused-argument
         # split N (batch dimension)
@@ -171,122 +182,359 @@ def schedule_conv2d_transpose_nchw(cfg, outs):
         cfg["unroll_explicit"] = OtherOptionEntity(True)
         cfg["auto_unroll_max_step"] = OtherOptionEntity(1500)
 
+    pad_data = op.input_tensors[0]
+    kernel = op.input_tensors[1]
+    conv = op.output(0)
+
+    ##### space definition begin #####
+    n, f, y, x = s[conv].op.axis
+    rc = s[conv].op.reduce_axis[0]
+    # TODO(@kevinthesun): Support tuning/optimization for dynamic shape.
+    bs = pad_data.shape[0]
+    n_tuning_axis = n if isinstance(bs, tvm.tir.IntImm) else 1
+    cfg.define_split("tile_n", cfg.axis(n_tuning_axis), num_outputs=4)
+    cfg.define_split("tile_f", cfg.axis(f), num_outputs=4)
+    cfg.define_split("tile_y", cfg.axis(y), num_outputs=4)
+    cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
+    cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
+    cfg.define_knob("auto_unroll_max_step", [64, 512, 1500])
+
+    target = tvm.target.Target.current()
+    if target.kind.name in ["nvptx", "rocm"]:
+        cfg.define_knob("unroll_explicit", [1])
+    else:
+        cfg.define_knob("unroll_explicit", [0, 1])
+
+    if cfg.is_fallback:
+        N, F, Y, X = get_const_tuple(conv.shape)
+        if not isinstance(N, int):
+            N = 1
+        _fallback_schedule(N, F, Y, X)
+
+    ##### space definition end #####
+
+    if isinstance(kernel.op, tvm.te.ComputeOp) and "dilate" in kernel.op.tag:
+        s[kernel].compute_inline()
+
+    if conv.op in s.outputs:
+        output = conv
+        OL = s.cache_write(conv, "local")
+    else:
+        output = s.outputs[0].output(0)
+        s[conv].set_scope("local")
+        OL = conv
+
+    # create cache stage
+    s[pad_data].set_scope("shared")
+    AA = pad_data
+    WW = s.cache_read(kernel, "shared", [OL])
+
+    # tile and bind spatial axes
+    n, f, y, x = s[output].op.axis
+    kernel_scope, n = s[output].split(n, nparts=1)
+    bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
+    bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
+    by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
+    bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
+
+    s[output].reorder(bn, bf, by, bx, vn, vf, vy, vx, tn, tf, ty, tx, ni, fi, yi, xi)
+    s[output].bind(bn, te.thread_axis("blockIdx.z"))
+    s[output].bind(bf, te.thread_axis("blockIdx.y"))
+    s[output].bind(s[output].fuse(by, bx), te.thread_axis("blockIdx.x"))
+    s[output].bind(vn, te.thread_axis("vthread"))
+    s[output].bind(vf, te.thread_axis("vthread"))
+    s[output].bind(vy, te.thread_axis("vthread"))
+    s[output].bind(vx, te.thread_axis("vthread"))
+
+    cfg.define_knob("fuse_yx", [0, 1])  # fuse ty,tx or tn,tf
+
+    if cfg["fuse_yx"].val:
+        s[output].bind(tn, te.thread_axis("threadIdx.z"))
+        s[output].bind(tf, te.thread_axis("threadIdx.y"))
+        tyx = s[output].fuse(ty, tx)
+        s[output].bind(s[output].fuse(ty, tx), te.thread_axis("threadIdx.x"))
+        s[OL].compute_at(s[output], tyx)
+
+        # number of threads
+        n_tz = cfg["tile_n"].size[2]
+        n_ty = cfg["tile_f"].size[2]
+        n_tx = cfg["tile_y"].size[2] * cfg["tile_x"].size[2]
+    else:
+        s[output].bind(s[output].fuse(tn, tf), te.thread_axis("threadIdx.z"))
+        s[output].bind(ty, te.thread_axis("threadIdx.y"))
+        s[output].bind(tx, te.thread_axis("threadIdx.x"))
+        s[OL].compute_at(s[output], tx)
+
+        # number of threads
+        n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
+        n_ty = cfg["tile_y"].size[2]
+        n_tx = cfg["tile_x"].size[2]
+
+    # tile reduction axes
+    n, f, y, x = s[OL].op.axis
+    rc, ry, rx = s[OL].op.reduce_axis
+    rco, rcm, rci = cfg["tile_rc"].apply(s, OL, rc)
+    s[OL].reorder(rco, rcm, ry, rx, rci, n, f, y, x)
+
+    s[AA].compute_at(s[OL], rx)
+    s[WW].compute_at(s[OL], rx)
+
+    # cooperative fetching
+    for load in [AA, WW]:
+        n, f, y, x = s[load].op.axis
+        fused = s[load].fuse(f, y, x)
+        tz, fused = s[load].split(fused, nparts=n_tz)
+        ty, fused = s[load].split(fused, nparts=n_ty)
+        tx, fused = s[load].split(fused, nparts=n_tx)
+        s[load].bind(tz, te.thread_axis("threadIdx.z"))
+        s[load].bind(ty, te.thread_axis("threadIdx.y"))
+        s[load].bind(tx, te.thread_axis("threadIdx.x"))
+
+    s[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
+    s[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
+
+
+@autotvm.register_topi_compute("group_conv2d_transpose_nchw.cuda")
+def group_conv2d_transpose_nchw(cfg, data, kernel, stride, padding, out_dtype, output_padding, groups):
+    """Transposed 2D convolution nchw forward operator.
+
+    Parameters
+    ----------
+    cfg: ConfigEntity
+        The config for this template
+    Input : tvm.te.Tensor
+        4-D with shape [batch, in_channel, in_height, in_width]
+    Filter : tvm.te.Tensor
+        4-D with shape [in_channel, num_filter, filter_height, filter_width]
+    strides : tuple of two ints
+        The spatial stride along height and width
+    padding : int or str
+        Padding size, or ['VALID', 'SAME']
+    out_dtype: str
+        The output type. This is used in mixed precision
+    output_padding : tuple of two ints
+        Used to disambiguate output shape.
+    groups : int
+        number of groups
+
+    Returns
+    -------
+    Output : tvm.te.Tensor
+        4-D with shape [batch, out_channel, out_height, out_width]
+    """
+    if groups == 1:
+        return conv2d_transpose_nchw(data, kernel, stride, padding, out_dtype, output_padding)
+
+    batch, inp_channels, inp_height, inp_width = get_const_tuple(data.shape)
+    assert inp_channels % groups == 0, f"input channels {inp_channels} must divide group size {groups}"
+    _, out_channels, kernel_height, kernel_width = get_const_tuple(kernel.shape)
+    stride_height, stride_width = stride
+    outpad_height, outpad_width = output_padding
+    assert outpad_height < stride_height and outpad_width < stride_width
+    cfg.stride = stride
+    pad_top, pad_left, pad_bottom, pad_right = nn.get_pad_tuple(
+        padding, (kernel_height, kernel_width)
+    )
+
+    out_width = (inp_width - 1) * stride_width + kernel_width - pad_left - pad_right + outpad_width
+    pad_left = kernel_width - 1 - pad_left
+    pad_right = kernel_width - 1 - pad_right + outpad_width
+    dilated_width = stride_width * (inp_width - 1) + 1
+
+    out_height = (
+        (inp_height - 1) * stride_height + kernel_height - pad_top - pad_bottom + outpad_height
+    )
+    pad_top = kernel_height - 1 - pad_top
+    pad_bottom = kernel_height - 1 - pad_bottom + outpad_height
+    dilated_height = stride_height * (inp_height - 1) + 1
+
+    # compute pad
+    data = te.compute(
+        (
+            batch,
+            inp_channels,
+            pad_top + dilated_height + pad_bottom,
+            pad_left + dilated_width + pad_right,
+        ),
+        lambda n, c, y, x: tvm.tir.if_then_else(
+            tvm.tir.all(
+                x >= pad_left,
+                x < pad_left + dilated_width,
+                tvm.tir.indexmod(x - pad_left, stride_width).equal(0),
+                y >= pad_top,
+                y < pad_top + dilated_height,
+                tvm.tir.indexmod(y - pad_top, stride_height).equal(0),
+            ),
+            data[
+                n,
+                c,
+                tvm.tir.indexdiv(y - pad_top, stride_height),
+                tvm.tir.indexdiv(x - pad_left, stride_width),
+            ],
+            tvm.tir.const(0.0, data.dtype),
+        ),
+        name="data_pad",
+    )
+
+    # transform kernel layout from IOHW to OIHW, and rotate kernel by 180 degrees
+    kernel_transform = te.compute(
+        (out_channels, inp_channels, kernel_height, kernel_width),
+        lambda i, o, h, w: kernel[o][i][kernel_height - 1 - h][kernel_width - 1 - w],
+        name="kernel_transform",
+    )
+    
+    dc = te.reduce_axis((0, inp_channels // groups), name="dc")
+    dh = te.reduce_axis((0, kernel_height), name="dh")
+    dw = te.reduce_axis((0, kernel_width), name="dw")
+    data_out = te.compute(
+        (batch, out_channels * groups, out_height, out_width),
+        lambda b, c, h, w: te.sum(
+            data[
+                b, c // out_channels * (inp_channels // groups) + dc, h + dh, w + dw
+            ].astype(out_dtype)
+            * kernel_transform[
+                c % out_channels,
+                c // out_channels * (inp_channels // groups) + dc,
+                dh,
+                dw
+            ].astype(out_dtype),
+            axis=[dc, dh, dw],
+        ),
+        tag="group_conv2d_transpose_nchw",
+    )
+
+    return data_out
+
+
+@autotvm.register_topi_schedule("group_conv2d_transpose_nchw.cuda")
+def schedule_group_conv2d_transpose_nchw(cfg, outs):
+    outs = [outs] if isinstance(outs, te.tensor.Tensor) else outs
+    s = te.create_schedule([x.op for x in outs])
+
     def _callback(op):
-        if op.tag == "conv2d_transpose_nchw":
-            pad_data = op.input_tensors[0]
-            kernel = op.input_tensors[1]
-            conv = op.output(0)
+        if op.tag == "group_conv2d_transpose_nchw":
+            _schedule_group_conv2d_transpose_nchw(cfg, s, op)
 
-            ##### space definition begin #####
-            n, f, y, x = s[conv].op.axis
-            rc = s[conv].op.reduce_axis[0]
-            # TODO(@kevinthesun): Support tuning/optimization for dynamic shape.
-            bs = pad_data.shape[0]
-            n_tuning_axis = n if isinstance(bs, tvm.tir.IntImm) else 1
-            cfg.define_split("tile_n", cfg.axis(n_tuning_axis), num_outputs=4)
-            cfg.define_split("tile_f", cfg.axis(f), num_outputs=4)
-            cfg.define_split("tile_y", cfg.axis(y), num_outputs=4)
-            cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
-            cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
-            cfg.define_knob("auto_unroll_max_step", [64, 512, 1500])
-
-            target = tvm.target.Target.current()
-            if target.kind.name in ["nvptx", "rocm"]:
-                cfg.define_knob("unroll_explicit", [1])
-            else:
-                cfg.define_knob("unroll_explicit", [0, 1])
-
-            if cfg.is_fallback:
-                N, F, Y, X = get_const_tuple(conv.shape)
-                if not isinstance(N, int):
-                    N = 1
-                _fallback_schedule(N, F, Y, X)
-
-            ##### space definition end #####
-
-            if isinstance(kernel.op, tvm.te.ComputeOp) and "dilate" in kernel.op.tag:
-                s[kernel].compute_inline()
-
-            if conv.op in s.outputs:
-                output = conv
-                OL = s.cache_write(conv, "local")
-            else:
-                output = s.outputs[0].output(0)
-                s[conv].set_scope("local")
-                OL = conv
-
-            # create cache stage
-            s[pad_data].set_scope("shared")
-            AA = pad_data
-            WW = s.cache_read(kernel, "shared", [OL])
-
-            # tile and bind spatial axes
-            n, f, y, x = s[output].op.axis
-            kernel_scope, n = s[output].split(n, nparts=1)
-            bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
-            bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
-            by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
-            bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
-
-            s[output].reorder(bn, bf, by, bx, vn, vf, vy, vx, tn, tf, ty, tx, ni, fi, yi, xi)
-            s[output].bind(bn, te.thread_axis("blockIdx.z"))
-            s[output].bind(bf, te.thread_axis("blockIdx.y"))
-            s[output].bind(s[output].fuse(by, bx), te.thread_axis("blockIdx.x"))
-            s[output].bind(vn, te.thread_axis("vthread"))
-            s[output].bind(vf, te.thread_axis("vthread"))
-            s[output].bind(vy, te.thread_axis("vthread"))
-            s[output].bind(vx, te.thread_axis("vthread"))
-
-            cfg.define_knob("fuse_yx", [0, 1])  # fuse ty,tx or tn,tf
-
-            if cfg["fuse_yx"].val:
-                s[output].bind(tn, te.thread_axis("threadIdx.z"))
-                s[output].bind(tf, te.thread_axis("threadIdx.y"))
-                tyx = s[output].fuse(ty, tx)
-                s[output].bind(s[output].fuse(ty, tx), te.thread_axis("threadIdx.x"))
-                s[OL].compute_at(s[output], tyx)
-
-                # number of threads
-                n_tz = cfg["tile_n"].size[2]
-                n_ty = cfg["tile_f"].size[2]
-                n_tx = cfg["tile_y"].size[2] * cfg["tile_x"].size[2]
-            else:
-                s[output].bind(s[output].fuse(tn, tf), te.thread_axis("threadIdx.z"))
-                s[output].bind(ty, te.thread_axis("threadIdx.y"))
-                s[output].bind(tx, te.thread_axis("threadIdx.x"))
-                s[OL].compute_at(s[output], tx)
-
-                # number of threads
-                n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
-                n_ty = cfg["tile_y"].size[2]
-                n_tx = cfg["tile_x"].size[2]
-
-            # tile reduction axes
-            n, f, y, x = s[OL].op.axis
-            rc, ry, rx = s[OL].op.reduce_axis
-            rco, rcm, rci = cfg["tile_rc"].apply(s, OL, rc)
-            s[OL].reorder(rco, rcm, ry, rx, rci, n, f, y, x)
-
-            s[AA].compute_at(s[OL], rx)
-            s[WW].compute_at(s[OL], rx)
-
-            # cooperative fetching
-            for load in [AA, WW]:
-                n, f, y, x = s[load].op.axis
-                fused = s[load].fuse(f, y, x)
-                tz, fused = s[load].split(fused, nparts=n_tz)
-                ty, fused = s[load].split(fused, nparts=n_ty)
-                tx, fused = s[load].split(fused, nparts=n_tx)
-                s[load].bind(tz, te.thread_axis("threadIdx.z"))
-                s[load].bind(ty, te.thread_axis("threadIdx.y"))
-                s[load].bind(tx, te.thread_axis("threadIdx.x"))
-
-            s[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
-            s[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
+        elif op.tag == "conv2d_transpose_nchw":  # groups == 1 cases delegate to regular conv2d_transpose
+            _schedule_conv2d_transpose_nchw(cfg, s, op)
 
     traverse_inline(s, outs[0].op, _callback)
 
     return s
+
+
+def _schedule_group_conv2d_transpose_nchw(cfg, s, op):
+    pad_data, kernel_transform = op.input_tensors
+    conv = op.output(0)
+    workload = conv.op.attrs["workload"]
+    groups = get_const_int(workload[7])
+    num_filters = get_const_int(conv.shape[1])
+
+    ##### space definition begin #####
+    n, f, y, x = s[conv].op.axis
+    rc = s[conv].op.reduce_axis[0]
+    cfg.define_split("tile_n", cfg.axis(n), num_outputs=4)
+    cfg.define_split("tile_g", cfg.axis(groups), num_outputs=2)
+    cfg.define_split("tile_f", cfg.axis(num_filters // groups), num_outputs=4)
+    cfg.define_split("tile_y", cfg.axis(y), num_outputs=4)
+    cfg.define_split("tile_x", cfg.axis(x), num_outputs=4)
+    cfg.define_split("tile_rc", cfg.axis(rc), num_outputs=3)
+    cfg.define_knob("auto_unroll_max_step", [0, 64, 512, 1500])
+
+    target = tvm.target.Target.current()
+    if target.kind.name in ["nvptx", "rocm"]:
+        cfg.define_knob("unroll_explicit", [1])
+    else:
+        cfg.define_knob("unroll_explicit", [0, 1])
+
+    ##### space definition end #####
+    s[kernel_transform].compute_inline() 
+
+    if conv.op in s.outputs:
+        output = conv
+        OL = s.cache_write(conv, "local")
+    else:
+        output = s.outputs[0].output(0)
+        s[conv].set_scope("local")
+        OL = conv
+
+    # create cache stage
+    s[pad_data].set_scope("shared")
+    AA = pad_data
+    s[kernel_transform].set_scope("shared")
+    WW = kernel_transform
+
+    # tile and bind spatial axes
+    n, f, y, x = s[output].op.axis
+    kernel_scope, n = s[output].split(n, nparts=1)
+
+    g, f = s[output].split(f, nparts=groups)
+    bn, vn, tn, ni = cfg["tile_n"].apply(s, output, n)
+    bg, vg = cfg["tile_g"].apply(s, output, g)
+    bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
+    by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
+    bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
+
+    s[output].reorder(bn, bg, bf, by, bx, vn, vg, vf, vy, vx, tn, tf, ty, tx, ni, fi, yi, xi)
+    s[output].bind(bn, te.thread_axis("blockIdx.z"))
+    s[output].bind(s[output].fuse(bg, bf), te.thread_axis("blockIdx.y"))
+    s[output].bind(s[output].fuse(by, bx), te.thread_axis("blockIdx.x"))
+    s[output].bind(vn, te.thread_axis("vthread"))
+    s[output].bind(vg, te.thread_axis("vthread"))
+    s[output].bind(vf, te.thread_axis("vthread"))
+    s[output].bind(vy, te.thread_axis("vthread"))
+    s[output].bind(vx, te.thread_axis("vthread"))
+
+    cfg.define_knob("fuse_yx", [0, 1])  # fuse ty,tx or tn,tf
+    if cfg["fuse_yx"].val:
+        s[output].bind(tn, te.thread_axis("threadIdx.z"))
+        s[output].bind(tf, te.thread_axis("threadIdx.y"))
+        tyx = s[output].fuse(ty, tx)
+        s[output].bind(tyx, te.thread_axis("threadIdx.x"))
+        s[OL].compute_at(s[output], tyx)
+
+        # number of threads
+        n_tz = cfg["tile_n"].size[2]
+        n_ty = cfg["tile_f"].size[2]
+        n_tx = cfg["tile_y"].size[2] * cfg["tile_x"].size[2]
+    else:
+        s[output].bind(s[output].fuse(tn, tf), te.thread_axis("threadIdx.z"))
+        s[output].bind(ty, te.thread_axis("threadIdx.y"))
+        s[output].bind(tx, te.thread_axis("threadIdx.x"))
+        s[OL].compute_at(s[output], tx)
+
+        # number of threads
+        n_tz = cfg["tile_n"].size[2] * cfg["tile_f"].size[2]
+        n_ty = cfg["tile_y"].size[2]
+        n_tx = cfg["tile_x"].size[2]
+
+    # tile reduction axes
+    n, f, y, x = s[OL].op.axis
+    rc, ry, rx = s[OL].op.reduce_axis
+    rco, rcm, rci = cfg["tile_rc"].apply(s, OL, rc)
+    s[OL].reorder(rco, rcm, ry, rx, rci, n, f, y, x)
+
+    s[AA].compute_at(s[OL], rx)
+    s[WW].compute_at(s[OL], rx)
+
+    # cooperative fetching
+    for load in [AA, WW]:
+        n, f, y, x = s[load].op.axis
+        fused = s[load].fuse(n, f, y, x)
+        fused, tx = s[load].split(fused, factor=n_tx)
+        fused, ty = s[load].split(fused, factor=n_ty)
+        fused, tz = s[load].split(fused, factor=n_tz)
+        s[load].bind(tz, te.thread_axis("threadIdx.z"))
+        s[load].bind(ty, te.thread_axis("threadIdx.y"))
+        s[load].bind(tx, te.thread_axis("threadIdx.x"))
+
+    # unroll
+    s[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
+    s[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
+
+    N, CO, OH, OW = get_const_tuple(output.shape)
+    _, CI_div_groups, KH, KW = get_const_tuple(kernel_transform.shape)
+    cfg.add_flop(2 * N * OH * OW * CO * CI_div_groups * KH * KW)
 
 
 def conv2d_transpose_cudnn(

--- a/tests/python/topi/python/test_topi_group_conv2d_transpose.py
+++ b/tests/python/topi/python/test_topi_group_conv2d_transpose.py
@@ -26,7 +26,7 @@ from tvm.topi.utils import get_const_tuple
 
 _group_conv2d_nchw_implement = {
     "generic": (topi.nn.group_conv2d_transpose_nchw, topi.generic.schedule_group_conv2d_transpose_nchw),
-    "cuda": (topi.cuda.group_conv2d_transpose_nchw, topi.cuda.schedule_group_conv2d_transpose_nchw),
+    "cuda": (topi.cuda.conv2d_transpose_nchw, topi.cuda.schedule_conv2d_transpose_nchw),
 }
 
 

--- a/tests/python/topi/python/test_topi_group_conv2d_transpose.py
+++ b/tests/python/topi/python/test_topi_group_conv2d_transpose.py
@@ -25,10 +25,8 @@ from tvm.contrib.pickle_memoize import memoize
 from tvm.topi.utils import get_const_tuple
 
 _group_conv2d_nchw_implement = {
-    "generic": (
-        topi.nn.group_conv2d_transpose_nchw,
-        topi.generic.schedule_group_conv2d_transpose_nchw,
-    ),
+    "generic": (topi.nn.group_conv2d_transpose_nchw, topi.generic.schedule_group_conv2d_transpose_nchw),
+    "cuda": (topi.cuda.group_conv2d_transpose_nchw, topi.cuda.schedule_group_conv2d_transpose_nchw),
 }
 
 
@@ -92,16 +90,23 @@ def verify_group_conv2d_transpose_nchw(
             s,
             [A, W, C],
             target,
-            name="group_conv2d_transpose_%d_%d_%s_%d_%s_%s_%s_%s_%d"
+            name="group_conv2d_transpose_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d_%d"
             % (
                 batch,
                 in_channel,
-                in_size,
+                in_size[0],
+                in_size[1],
                 num_filter,
-                kernel,
-                stride,
-                padding,
-                output_padding,
+                kernel[0],
+                kernel[1],
+                stride[0],
+                stride[1],
+                padding[0],
+                padding[1],
+                padding[2],
+                padding[3],
+                output_padding[0],
+                output_padding[1],
                 groups,
             ),
         )
@@ -110,46 +115,26 @@ def verify_group_conv2d_transpose_nchw(
         for measurement, reference in zip(c, c_np):
             tvm.testing.assert_allclose(measurement, reference, rtol=1e-5)
 
-    for target in ["llvm"]:
+    for target in ["llvm", "cuda"]:
         check_target(target)
 
 
 @tvm.testing.uses_gpu
 def test_group_conv2d_transpose_nchw():
-    verify_group_conv2d_transpose_nchw(1, 1, (224, 224), 1, (1, 1), (1, 1), (0, 0, 0, 0), (0, 0), 1)
-    verify_group_conv2d_transpose_nchw(
-        1, 3, (224, 224), 32, (3, 3), (1, 1), (0, 0, 0, 0), (0, 0), 1
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 3, (224, 224), 32, (3, 3), (3, 3), (0, 0, 0, 0), (0, 0), 1
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 3, (224, 224), 32, (3, 3), (1, 1), (0, 0, 0, 0), (0, 0), 1
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 3, (224, 224), 32, (3, 3), (2, 2), (1, 1, 1, 1), (0, 0), 1
-    )
     verify_group_conv2d_transpose_nchw(1, 4, (32, 32), 4, (5, 5), (1, 1), (0, 0, 0, 0), (0, 0), 2)
     verify_group_conv2d_transpose_nchw(1, 9, (32, 32), 9, (5, 5), (1, 1), (0, 0, 0, 0), (0, 0), 3)
     verify_group_conv2d_transpose_nchw(1, 4, (32, 32), 16, (5, 5), (2, 2), (1, 1, 1, 1), (0, 0), 4)
-    verify_group_conv2d_transpose_nchw(
-        1, 32, (8192, 1), 8, (31, 1), (2, 1), (14, 0, 15, 0), (0, 0), 2
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 512, (8, 1), 256, (31, 1), (2, 1), (14, 0, 15, 0), (0, 0), 16
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 512, (8, 1), 256, (31, 1), (2, 1), (14, 0, 15, 0), (1, 0), 16
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 64, (64, 64), 64, (4, 4), (1, 1), (0, 0, 0, 0), (0, 0), 64
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 128, (32, 32), 128, (4, 4), (1, 1), (0, 0, 0, 0), (0, 0), 128
-    )
-    verify_group_conv2d_transpose_nchw(
-        1, 256, (16, 16), 256, (4, 4), (1, 1), (0, 0, 0, 0), (0, 0), 256
-    )
+    verify_group_conv2d_transpose_nchw(1, 32, (8192, 1), 8, (31, 1), (2, 1), (14, 0, 15, 0), (0, 0), 2)
+    verify_group_conv2d_transpose_nchw(1, 512, (8, 1), 256, (31, 1), (2, 1), (14, 0, 15, 0), (0, 0), 16)
+    verify_group_conv2d_transpose_nchw(1, 512, (8, 1), 256, (31, 1), (2, 1), (14, 0, 15, 0), (1, 0), 16)
+    verify_group_conv2d_transpose_nchw(1, 64, (64, 64), 64, (4, 4), (1, 1), (0, 0, 0, 0), (0, 0), 64)
+    verify_group_conv2d_transpose_nchw(1, 128, (32, 32), 128, (4, 4), (1, 1), (0, 0, 0, 0), (0, 0), 128)
+    verify_group_conv2d_transpose_nchw(1, 256, (16, 16), 256, (4, 4), (1, 1), (0, 0, 0, 0), (0, 0), 256)
+    verify_group_conv2d_transpose_nchw(1, 1, (224, 224), 1, (1, 1), (1, 1), (0, 0, 0, 0), (0, 0), 1)
+    verify_group_conv2d_transpose_nchw(1, 3, (224, 224), 32, (3, 3), (1, 1), (0, 0, 0, 0), (0, 0), 1)
+    verify_group_conv2d_transpose_nchw(1, 3, (224, 224), 32, (3, 3), (3, 3), (0, 0, 0, 0), (0, 0), 1)
+    verify_group_conv2d_transpose_nchw(1, 3, (224, 224), 32, (3, 3), (1, 1), (0, 0, 0, 0), (0, 0), 1)
+    verify_group_conv2d_transpose_nchw(1, 3, (224, 224), 32, (3, 3), (2, 2), (1, 1, 1, 1), (0, 0), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following @masahi's advice in #10223, I've added a grouped version of `conv2d_transpose_nchw` to the CUDA backend.

The tests pass and I've verified on a larger model which makes use of `group_conv2d_transpose_nchw` ops that the output is correct.

I wasn't quite sure how to implement the topi schedule for the op, so I've done my best to merge the regular `conv2d_transpose_nchw.cuda` schedule with the `group_conv2d_nchw.cuda` schedule.

So far it seems that the CUDNN backend `group_conv2d_transpose` is quite a bit faster (although I guess it's to be expected if my schedule isn't very efficient). I haven't tried a full auto-scheduling run without CUDNN yet.

PS: the diff between the topi schedules is a little confusing. I haven't made any changes to the `conv2d_transpose_nchw.cuda` schedule, just factored it out into a helper function `_schedule_conv2d_transpose_nchw` (similar to `_schedule_group_conv2d_nchw` in topi/cuda/group_conv2d.py) so that it can also be called from `schedule_group_conv2d_transpose_nchw` when there is only 1 group.