### PR TITLE
[MISC] Add miss Type2Str and remove compile warnings

### DIFF
--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -232,6 +232,8 @@ class ExprMutator : public ::tvm::relay::ExprFunctor<Expr(const Expr&)> {
  */
 class MixedModeVisitor : public ::tvm::relay::ExprVisitor {
  public:
+  using ::tvm::relay::ExprFunctor<void(const Expr& n)>::VisitExpr_;
+
   /*! \brief The constructor of MixedModeVisitor
    *  \param visit_limit The number of times to allow visitation to a node. Usually 1, ocassionally
    * higher (i.e., 2 for dead code elimiation), limited to 10 as a sanity check.
@@ -277,6 +279,8 @@ class MixedModeVisitor : public ::tvm::relay::ExprVisitor {
  */
 class MixedModeMutator : public ::tvm::relay::ExprMutator {
  public:
+  using ::tvm::relay::ExprFunctor<Expr(const Expr&)>::VisitExpr_;
+
   MixedModeMutator(bool pre = false) : pre_{pre} {};
   Expr VisitExpr(const Expr& expr) final;
 

--- a/include/tvm/runtime/container/shape_tuple.h
+++ b/include/tvm/runtime/container/shape_tuple.h
@@ -133,7 +133,7 @@ class ShapeTuple : public ObjectRef {
    * \return the i-th element.
    */
   index_type operator[](size_t idx) const {
-    ICHECK(0 <= idx && idx < this->size())
+    ICHECK(idx < this->size())
         << "IndexError: indexing " << idx << " on an array of size " << this->size();
     return this->data()[idx];
   }

--- a/include/tvm/runtime/container/shape_tuple.h
+++ b/include/tvm/runtime/container/shape_tuple.h
@@ -133,8 +133,8 @@ class ShapeTuple : public ObjectRef {
    * \return the i-th element.
    */
   index_type operator[](size_t idx) const {
-    ICHECK(idx < this->size())
-        << "IndexError: indexing " << idx << " on an array of size " << this->size();
+    ICHECK(idx < this->size()) << "IndexError: indexing " << idx << " on an array of size "
+                               << this->size();
     return this->data()[idx];
   }
 

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1448,6 +1448,10 @@ struct Type2Str<DataType> {
   static std::string v() { return "DataType"; }
 };
 template <>
+struct Type2Str<DLDataType> {
+  static std::string v() { return "DLDataType"; }
+};
+template <>
 struct Type2Str<TVMRetValue> {
   static std::string v() { return "TVMRetValue"; }
 };


### PR DESCRIPTION
After #10326, we now require the argument type of PackFunc to have a corresponding template of Type2Str. Otherwise we will get the following error during compilation (note that my argument type is `DLDataType`).

```
include/tvm/runtime/packed_func.h:1400:22: note: candidate: template<class> static std::__cxx11::string tvm::runtime::detail::type2str::Type2Str<T>::v() [with <template-parameter-2-1> = <template-parameter-1-1>; T = DLDataType]
   static std::string v() {
                      ^
/include/tvm/runtime/packed_func.h:1400:22: note:   template argument deduction/substitution failed
```

This PR adds a Type2Str template for DLDataType to remove my blocker. However, this doesn't solve the root problem. Ideally, we should not error out only if the Type2Str template is missing but the argument type of a PackFunc is actually supported. A straightforward solution to this issue is adding all templates for the types supported by TVMArgValue (e.g., intX_t, uintX_t for X in 8, 16, 32, 64; basically everything covered in https://github.com/apache/tvm/blob/main/include/tvm/runtime/packed_func.h#L1225). While it is tedious, I'm wondering if we could have a default template that simply prints "unknown_type" for non-ObjectRef types. It might be possible to leverage `std::enable_if_t<!std::is_base_of<ObjectRef, T>::value>`, but I'm not sure how to achieve it in the case of Type2Str struct.

(nit) In addition, this PR also removes some compiler warnings reported by Clang:
1. `size_t` is always larger or equal than zero, so no need to check `idx >= 0`.
2. The derived mutator and visitor don't implement all virtual functions.

cc @cyx-6 @junrushao1994 