### PR TITLE
[Runtime][ThreadPool] Handle the default value of affinity mode.

### DIFF
--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -280,7 +280,14 @@ void Yield() { std::this_thread::yield(); }
 /*!
  * \bief Set the maximum number of available cores.
  */
-void SetMaxConcurrency(int value) { max_concurrency = std::max(0, value); }
+void SetMaxConcurrency(int value) {
+  if (value < 0) {
+    LOG(WARNING) << "The value of maximum concurrency '" << value << "' is negative, "
+                 << "and the setting is not success.";
+    return;
+  }
+  max_concurrency = value;
+}
 int MaxConcurrency() {
   int max_concurrency = 1;
   if (tvm::runtime::threading::max_concurrency != 0) {

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -282,8 +282,8 @@ void Yield() { std::this_thread::yield(); }
  */
 void SetMaxConcurrency(int value) {
   if (value < 0) {
-    LOG(WARNING) << "The value of maximum concurrency '" << value << "' is negative, "
-                 << "and the setting is not success.";
+    LOG(WARNING) << "The value of maximum concurrency '" << value << "' can not be negative "
+                 << "the setting of maximum concurrency is not success.";
     return;
   }
   max_concurrency = value;

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -136,6 +136,7 @@ class ThreadGroup::Impl {
           break;
         case kLittle:
         case kBig:
+        default:
           LOG(WARNING) << "The thread affinity cannot be set when the number of workers"
                        << "is larger than the number of available cores in the system.";
           break;
@@ -279,11 +280,7 @@ void Yield() { std::this_thread::yield(); }
 /*!
  * \bief Set the maximum number of available cores.
  */
-void SetMaxConcurrency(int value) {
-  if (value > 0) {
-    max_concurrency = value;
-  }
-}
+void SetMaxConcurrency(int value) { max_concurrency = std::max(0, value); }
 int MaxConcurrency() {
   int max_concurrency = 1;
   if (tvm::runtime::threading::max_concurrency != 0) {


### PR DESCRIPTION
1. Handle the default value of affinity mode.
2. After calling the function 'SetMaxConcurrency' with a non-zero value,if calling the function 'SetMaxConcurrency' again with a zero value ,then the second setting can not correctly set the max_concurrency value into zero. use new logic to fix this issue.