### PR TITLE
[Frontend][TFLite] Added broadcasting to prelu alpha.

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -2847,11 +2847,15 @@ class OperatorConverter(object):
         alpha_tensor_type = alpha_tensor.tensor.Type()
         alpha_tensor_type_str = self.get_tensor_type_str(alpha_tensor_type)
         alpha_expr = self.exp_tab.new_const(
-            self.get_tensor_value(alpha_tensor).flatten(), dtype=alpha_tensor_type_str
+            self.get_tensor_value(alpha_tensor), dtype=alpha_tensor_type_str
         )
         in_expr = self.get_expr(input_tensor.tensor_idx)
-        out = _op.nn.prelu(in_expr, alpha_expr, axis=3)
+        data_shape = to_int_list(self.get_tensor_shape(input_tensor))
 
+        alpha_expr = _op.broadcast_to(alpha_expr, data_shape)
+        alpha_expr = _op.reshape(alpha_expr, [-1])
+        out = _op.nn.prelu(_op.reshape(in_expr, [-1]), alpha_expr, axis=0)
+        out = _op.reshape(out, data_shape)
         return out
 
     def convert_transpose_conv(self, op):

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -3758,9 +3758,42 @@ def test_forward_prelu():
     )
     _test_prelu(
         np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
+        np.full((1, 3), 0.2, dtype="float32"),
+    )
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
         np.full((1, 1, 3), 0.2, dtype="float32"),
     )
-
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
+        np.full((1, 1, 1, 3), 0.2, dtype="float32"),
+    )
+    #
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
+        np.full((32, 3), 0.2, dtype="float32"),
+    )
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
+        np.full((32, 32, 3), 0.2, dtype="float32"),
+    )
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
+        np.full((1, 32, 1, 3), 0.2, dtype="float32"),
+    )
+    #
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 1, 3)).astype("float32"),
+        np.full((3,), 0.2, dtype="float32"),
+    )
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(1, 32, 3)).astype("float32"),
+        np.full((32, 3), 0.2, dtype="float32"),
+    )
+    _test_prelu(
+        np.random.uniform(-5, 5, size=(32, 3)).astype("float32"),
+        np.full((3), 0.2, dtype="float32"),
+    )
 
 #######################################################################
 # DepthToSpace


### PR DESCRIPTION
![Mobilenetv3_Pose_Estimation](https://user-images.githubusercontent.com/32191045/156285598-a71f5d25-d8ca-46dd-bbed-49575326ba32.png)
I met an error when import this model, error as follow

`The Relay type checker is unable to show the following types match:`
` Tensor[(152), float32]`
` Tensor[(119168), float32]`
`In particular:`
` dimension 0 conflicts: 152 does not match 119168.`
`The Relay type checker is unable to show the following types match.`
`In particular Tensor[(119168), float32] does not match Tensor[(152), float32]`
This seems to be the problem with this line [flatten()](https://github.com/apache/tvm/blob/1115d3d770cf22859117a5462d757edef512c037/python/tvm/relay/frontend/tflite.py#L2850)
So I updtae def convert_prelu():
- add broadcasting to prelu alpha in TFLite
- add test cases in test_forward


