### PR TITLE
[Hexagon] Allow execution on target or simulator from HexagonLauncher

### DIFF
--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -18,8 +18,9 @@
 """Defines a Session class for Hexagon devices."""
 
 import os
+import pathlib
+from typing import Union
 from tvm import rpc as _rpc
-
 
 class Session:
     """Hexagon Device Session
@@ -72,6 +73,6 @@ class Session:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         pass
 
-    def load_module(self, path: str):
-        assert isinstance(path, str), f"Invalid path type, {type(path)} != str"
-        return self._rpc.get_function("tvm.hexagon.load_module")(path)
+    def load_module(self, path: Union[str, pathlib.Path]):
+        assert isinstance(path, (str, pathlib.Path)), "Invalid path type:" + str(type(path))
+        return self._rpc.get_function("tvm.hexagon.load_module")(str(path))


### PR DESCRIPTION
Setting `ANDROID_SERIAL_NUMBER=simulator` will execute the tests on simulator instead of a hardware device.

This patch also introduces an environment variable `HEXAGON_RPC_LIB_DIR` to specify the location of the hexagon_api binaries. If unset, the code will look for the binaries in the same way as before this patch.
