### PR TITLE
[ci] Skip CI based on file globs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,6 +132,14 @@ def cancel_previous_build() {
 }
 
 def should_skip_ci(pr_number) {
+  glob_skip_ci_code = sh (
+    returnStatus: true,
+    script: "./tests/scripts/git_skip_ci_globs.py",
+    label: 'Check if CI should be skipped due to changed files',
+  )
+  if (glob_skip_ci_code == 0) {
+    return true
+  }
   withCredentials([string(
     credentialsId: 'tvm-bot-jenkins-reader',
     variable: 'TOKEN',
@@ -143,7 +151,7 @@ def should_skip_ci(pr_number) {
       script: "./tests/scripts/git_skip_ci.py --pr '${pr_number}'",
       label: 'Check if CI should be skipped',
     )
-    }
+  }
   return git_skip_ci_code == 0
 }
 

--- a/tests/scripts/git_change_docs.sh
+++ b/tests/scripts/git_change_docs.sh
@@ -20,23 +20,19 @@
 set -eux
 
 FOUND_ONE_FILE=0
-DOCS_DIR=0
-OTHER_DIR=0
-DOC_DIR="docs/"
+SAW_NON_DOC_CHANGES=0
 
-changed_files=`git diff --no-commit-id --name-only -r origin/main`
+changed_files=$(git diff --no-commit-id --name-only -r origin/main)
 
 for file in $changed_files; do
     FOUND_ONE_FILE=1
-    if grep -q "$DOC_DIR" <<< "$file"; then
-        DOCS_DIR=1
-    else
-        OTHER_DIR=1
+    if ! grep -q "docs/" <<< "$file"; then
+        SAW_NON_DOC_CHANGES=1
         break
     fi
 done
 
-if [ ${FOUND_ONE_FILE} -eq 0 -o ${OTHER_DIR} -eq 1 ]; then
+if [ ${FOUND_ONE_FILE} -eq 0 ] || [ ${SAW_NON_DOC_CHANGES} -eq 1 ]; then
     exit 0
 else
     exit 1

--- a/tests/scripts/git_skip_ci_globs.py
+++ b/tests/scripts/git_skip_ci_globs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import fnmatch
+from typing import Optional
+
+from git_utils import git
+
+
+globs = [
+    "*.md",
+    "docker/*",
+    "conda/*",
+    ".github/*",
+    ".asf.yaml",
+    "LICENSE",
+    "NOTICE",
+    "KEYS",
+]
+
+
+def match_any(f: str) -> Optional[str]:
+    for glob in globs:
+        if fnmatch.fnmatch(f, glob):
+            return glob
+    return None
+
+
+if __name__ == "__main__":
+    help = "Exits with code 1 if a change only touched files, indicating that CI could be skipped for this changeset"
+    parser = argparse.ArgumentParser(description=help)
+    parser.add_argument("--files", help="(testing only) comma separated list of files to check")
+    args = parser.parse_args()
+    print(args)
+    if args.files is not None:
+        diff = [x for x in args.files.split(",") if x.strip() != ""]
+    else:
+        diff = git(["diff", "--no-commit-id", "--name-only", "-r", "origin/main"])
+        diff = diff.split("\n")
+        diff = [d.strip() for d in diff]
+        diff = [d for d in diff if d != ""]
+
+    print(f"Changed files:\n{diff}")
+
+    if len(diff) == 0:
+        print("Found no changed files, skipping CI")
+        exit(0)
+
+    print(f"Checking with globs:\n{globs}")
+
+    for file in diff:
+        match = match_any(file)
+        if match is None:
+            print(f"{file} did not match any globs, running CI")
+            exit(1)
+        else:
+            print(f"{file} matched glob {match}")
+
+    print("All files matched a glob, skipping CI")
+    exit(0)


### PR DESCRIPTION
This skips CI for changes that only touch certain files, such as `.md` files or `docker/*` scripts.

cc @areusch 