### PR TITLE
Correctly enable architecture extensions in CMSIS-NN Zephyr Demo

### DIFF
--- a/apps/microtvm/zephyr_cmsisnn/CMakeLists.txt
+++ b/apps/microtvm/zephyr_cmsisnn/CMakeLists.txt
@@ -57,11 +57,11 @@ set(CMSIS_SOURCES
     ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
     ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
     ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
     ${CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
     ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
 )
 
 add_custom_command(

--- a/apps/microtvm/zephyr_cmsisnn/prj.conf
+++ b/apps/microtvm/zephyr_cmsisnn/prj.conf
@@ -20,3 +20,6 @@ CONFIG_NEWLIB_LIBC=y
 
 # emulate finite stack size
 CONFIG_MAIN_STACK_SIZE=256
+
+# Enables architecture extensions
+CONFIG_FPU=y

--- a/apps/microtvm/zephyr_cmsisnn/prj.conf
+++ b/apps/microtvm/zephyr_cmsisnn/prj.conf
@@ -18,8 +18,5 @@
 # newlib needed for math.h
 CONFIG_NEWLIB_LIBC=y
 
-# emulate finite stack size
-CONFIG_MAIN_STACK_SIZE=256
-
 # Enables architecture extensions
 CONFIG_FPU=y

--- a/apps/microtvm/zephyr_cmsisnn/src/main.c
+++ b/apps/microtvm/zephyr_cmsisnn/src/main.c
@@ -34,7 +34,8 @@ extern float output_storage[12];
 
 extern const size_t output_len;
 
-static uint8_t g_crt_workspace[TVMGEN_DEFAULT_WORKSPACE_SIZE];
+static uint8_t __attribute__((aligned(TVM_RUNTIME_ALLOC_ALIGNMENT_BYTES)))
+g_crt_workspace[TVMGEN_DEFAULT_WORKSPACE_SIZE];
 tvm_workspace_t app_workspace;
 
 void TVMLogf(const char* msg, ...) {


### PR DESCRIPTION
Without `CONFIG_FPU` being set the correct architecture extensions weren't being applied which means the buffer sizes didn't necessarily match up - this corrects it so that they align.
