### PR TITLE
[Relay] Fix output dtype for conv2d wgrad when the original one is void

### DIFF
--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -443,7 +443,7 @@ def conv2d_grad(orig, grad):
         grad_layout=attrs.out_layout if attrs.out_layout else attrs.data_layout,
         data_layout=attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
-        out_dtype=attrs.out_dtype,
+        out_dtype=out_dtype,
     )
 
     return [backward_data, backward_weight]

--- a/python/tvm/relay/op/_tensor_grad.py
+++ b/python/tvm/relay/op/_tensor_grad.py
@@ -414,6 +414,12 @@ def conv2d_grad(orig, grad):
     assert attrs.kernel_layout == "OIHW", "only support OIHW kernel layout"
     assert attrs.out_layout in ["", "NCHW"], "only support NCHW output layout"
 
+    if attrs.out_dtype in ["", None]:
+        assert data.checked_type, "Call InferType first."
+        out_dtype = data.checked_type.dtype
+    else:
+        out_dtype = attrs.out_dtype
+
     backward_data = _nn.conv2d_transpose(
         grad,
         weight,
@@ -422,6 +428,7 @@ def conv2d_grad(orig, grad):
         dilation=attrs.dilation,
         groups=attrs.groups,
         output_padding=output_padding,
+        out_dtype=out_dtype,
     )
 
     backward_weight = _nn.conv2d_backward_weight(

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -1800,7 +1800,7 @@ bool Conv2DBackwardWeightRel(const Array<Type>& types, int num_inputs, const Att
                                param->kernel_size[1]};
   auto wshape = trans_kernel_layout.BackwardShape(wshape_oihw);
 
-  const auto dw_dtype = (param->out_dtype == DataType() or param->out_dtype.is_void())
+  const auto dw_dtype = (param->out_dtype == DataType() || param->out_dtype.is_void())
                             ? grad->dtype
                             : param->out_dtype;
 

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -1800,7 +1800,10 @@ bool Conv2DBackwardWeightRel(const Array<Type>& types, int num_inputs, const Att
                                param->kernel_size[1]};
   auto wshape = trans_kernel_layout.BackwardShape(wshape_oihw);
 
-  const auto dw_dtype = param->out_dtype == DataType() ? grad->dtype : param->out_dtype;
+  const auto dw_dtype = (param->out_dtype == DataType() or param->out_dtype.is_void())
+                            ? grad->dtype
+                            : param->out_dtype;
+
   reporter->Assign(types[2], TensorType(wshape, dw_dtype));
   return true;
 }

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -281,5 +281,37 @@ def test_conv2d_backward_weight():
     )
 
 
+def test_conv2d_backward_weight_infer_type():
+    # From https://github.com/apache/tvm/pull/10439
+    import tvm
+    from tvm import relay
+
+    depthwise_conv_code = """
+    fn (%input0: Tensor[(1, 3, 32, 32), float32], %v0_weight: Tensor[(3, 1, 3, 3), float32], %v0_bias: Tensor[(3), float32]) {
+      %0 = nn.conv2d(%input0, %v0_weight, padding=[1, 1, 1, 1], groups=3, channels=3, kernel_size=[3, 3]);
+      nn.bias_add(%0, %v0_bias)
+    }
+    """
+
+    normal_conv_code = """
+    fn (%input0: Tensor[(1, 3, 32, 32), float32], %v0_weight: Tensor[(3, 3, 3, 3), float32], %v0_bias: Tensor[(3), float32]) {
+      %0 = nn.conv2d(%input0, %v0_weight, padding=[1, 1, 1, 1], groups=1, channels=3, kernel_size=[3, 3]);
+      nn.bias_add(%0, %v0_bias)
+    }
+    """
+
+    SEMVER = '#[version = "0.0.5"]\n'
+
+    for code in [normal_conv_code, depthwise_conv_code]:
+        expr = tvm.parser.parse_expr(SEMVER + code)
+        fmod = tvm.IRModule.from_expr(expr)
+
+        mod = relay.transform.InferType()(fmod)
+        bwd_expr = relay.transform.gradient(mod["main"], mode="first_order")
+
+        bwd_mod = tvm.IRModule.from_expr(bwd_expr)
+        bwd_mod = relay.transform.InferType()(bwd_mod)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -283,9 +283,6 @@ def test_conv2d_backward_weight():
 
 def test_conv2d_backward_weight_infer_type():
     # From https://github.com/apache/tvm/pull/10439
-    import tvm
-    from tvm import relay
-
     depthwise_conv_code = """
     fn (%input0: Tensor[(1, 3, 32, 32), float32], %v0_weight: Tensor[(3, 1, 3, 3), float32], %v0_bias: Tensor[(3), float32]) {
       %0 = nn.conv2d(%input0, %v0_weight, padding=[1, 1, 1, 1], groups=3, channels=3, kernel_size=[3, 3]);


### PR DESCRIPTION
As discussed in https://github.com/apache/tvm/pull/10439, `out_dtype` information is important for `conv2d_backward_weight`. For some reason, the default `out_dtype` for the forward conv2d is apparently `void`, which broke the user's code in https://github.com/apache/tvm/pull/10439. If `out_dtype` is void, we need to use input args dtype to determine the output dtype for wgrad.

cc @Lyken17 @junrushao1994 @YuchenJin 