### PR TITLE
[CodeGen][CUDA] use hrint for cuda half rounding

### DIFF
--- a/src/target/source/intrin_rule_cuda.cc
+++ b/src/target/source/intrin_rule_cuda.cc
@@ -43,6 +43,8 @@ struct CUDAMath {
         case 16: {
           if (name == "fabs") {
             return "__habs";
+          } else if (name == "round") {
+            return "hrint";
           } else {
             return "h" + name;
           }

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -57,6 +57,10 @@ class TestUnaryOp:
         "sin": (tvm.relay.sin, np.sin),
         "tan": (tvm.relay.tan, np.tan),
         "atan": (tvm.relay.atan, np.arctan),
+        "ceil": (tvm.relay.ceil, np.ceil),
+        "floor": (tvm.relay.floor, np.floor),
+        "trunc": (tvm.relay.trunc, np.trunc),
+        "round": (tvm.relay.round, np.round),
     }
 
     dtype = tvm.testing.parameter("float16", "float32")


### PR DESCRIPTION
When cuda c codegen generate `tir.round` for fp16, there is no function named `hround`, but `hrint` for cuda half arithmetics. https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____HALF__FUNCTIONS.html#group__CUDA__MATH____HALF__FUNCTIONS_1gbbf7a989130edcbdbfbb4730f61c79b1

Testcase to reproduce:
```python
import tvm
from tvm import relay
from tvm.ir.module import IRModule
x = relay.var("x", shape=[16], dtype="float16")
y = relay.round(x)
f = relay.Function([x], y)
m = IRModule.from_expr(f)
m = relay.transform.InferType()(m)
relay.build(m, target="cuda")
```
