### PR TITLE
[skip ci][ci] Remove -i from lint scripts

### DIFF
--- a/tests/lint/python_format.sh
+++ b/tests/lint/python_format.sh
@@ -18,5 +18,5 @@
 
 set -e
 
-./tests/lint/git-black.sh -i HEAD~1
-./tests/lint/git-black.sh -i origin/main
+./tests/lint/git-black.sh HEAD~1
+./tests/lint/git-black.sh origin/main


### PR DESCRIPTION
This was changed in #8509 to run without checking the file formatting, which would lead to pylint errors like we saw on `main` in https://github.com/apache/tvm/commit/0c836b73ffd9669bcc416515dce6436cbd7d7ebe.

cc @areusch
