### PR TITLE
[MetaSchedule] Keep Task / Trial / Iter / Postproc Number Consistent in Log

### DIFF
--- a/src/meta_schedule/measure_callback/echo_statistics.cc
+++ b/src/meta_schedule/measure_callback/echo_statistics.cc
@@ -225,7 +225,7 @@ constexpr const double kMaxTime = 1e10;
 
 std::string GetTaskName(const TuneContext& task, int task_id) {
   std::ostringstream os;
-  os << '#' << task_id << ": " << task->task_name;
+  os << "Task #" << task_id << ": " << task->task_name;
   return os.str();
 }
 
@@ -240,7 +240,7 @@ double GetRunMs(const Array<FloatImm>& run_secs) {
 struct TaskInfo {
   std::string name;
   double flop = 0.0;
-  int trials = 0;
+  int trials = -1;
   int best_round = -1;
   double best_ms = kMaxTime;
   double best_gflops = 0.0;

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -93,7 +93,7 @@ Array<RunnerFuture> SendToRunner(const Runner& runner, const TuneContext& contex
 
 void TaskSchedulerNode::InitializeTask(int task_id) {
   TuneContext task = this->tasks[task_id];
-  LOG(INFO) << "Initializing task " << task_id << ": " << task->task_name << ", mod =\n"
+  LOG(INFO) << "Initializing Task #" << task_id << ": " << task->task_name << ", mod =\n"
             << tir::AsTVMScript(task->mod);
   this->tasks[task_id]->Initialize();
 }
@@ -124,7 +124,7 @@ void TaskSchedulerNode::Tune() {
 
   int running_tasks = tasks.size();
   for (int task_id; (task_id = NextTaskId()) != -1;) {
-    LOG(INFO) << "Scheduler picks Task #" << task_id + 1 << ": " << tasks[task_id]->task_name;
+    LOG(INFO) << "Scheduler picks Task #" << task_id << ": " << tasks[task_id]->task_name;
     TuneContext task = tasks[task_id];
     ICHECK(!task->is_stopped);
     ICHECK(!task->runner_futures.defined());
@@ -138,7 +138,7 @@ void TaskSchedulerNode::Tune() {
     } else {
       SetTaskStopped(task_id);
       --running_tasks;
-      LOG(INFO) << "Task #" << task_id + 1 << " has finished. Remaining task(s): " << running_tasks;
+      LOG(INFO) << "Task #" << task_id << " has finished. Remaining task(s): " << running_tasks;
     }
   }
   ICHECK_EQ(running_tasks, 0) << "Not all tasks are finished";


### PR DESCRIPTION
This PR fixes some inconsistency in log printing and make sure all numbers **start from zero** for tasks, trials, iters and postprocs. I think it's better for debugging if any task or trail went wrong in the future.

CC @jinhongyii @junrushao1994 