### PR TITLE
[microTVM] Zephyr: add mps3_an547 board support

### DIFF
--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -23,6 +23,14 @@
         "vid_hex": "",
         "pid_hex": ""
     },
+    "mps3_an547": {
+        "board": "mps3_an547",
+        "model": "mps3_an547",
+        "is_qemu": true,
+        "fpu": false,
+        "vid_hex": "",
+        "pid_hex": ""
+    },
     "nrf5340dk_nrf5340_cpuapp": {
         "board": "nrf5340dk_nrf5340_cpuapp",
         "model": "nrf5340dk",

--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -28,6 +28,7 @@
         "model": "mps3_an547",
         "is_qemu": true,
         "fpu": false,
+        "note": "FPU is supported by mps3_an547, but full support for FPU+MVE is only available from QEMU v6.2.0 (not present in any zephyr-sdk yet), hence FPU is left disabled.",
         "vid_hex": "",
         "pid_hex": ""
     },

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -515,6 +515,10 @@ class Handler(server.ProjectAPIHandler):
         if options.get("west_cmd"):
             cmake_args.append(f"-DWEST={options['west_cmd']}")
 
+        if self._is_qemu(options):
+            # Some boards support more than one emulator, so ensure QEMU is set.
+            cmake_args.append(f"-DEMU_PLATFORM=qemu")
+
         cmake_args.append(f"-DBOARD:STRING={options['zephyr_board']}")
 
         check_call(cmake_args, cwd=BUILD_DIR)
@@ -527,7 +531,7 @@ class Handler(server.ProjectAPIHandler):
     # A list of all zephyr_board values which are known to launch using QEMU. Many platforms which
     # launch through QEMU by default include "qemu" in their name. However, not all do. This list
     # includes those tested platforms which do not include qemu.
-    _KNOWN_QEMU_ZEPHYR_BOARDS = ("mps2_an521",)
+    _KNOWN_QEMU_ZEPHYR_BOARDS = ("mps2_an521", "mps3_an547")
 
     @classmethod
     def _is_qemu(cls, options):

--- a/apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-i386
+++ b/apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-i386
@@ -17,10 +17,15 @@
 # under the License.
 
 # Zephyr insists on running qemu with a -pidfile option, but that option doesn't appear to
-# work given the way we've configured docker (the underlying filesystem doesn't suppor the
+# work given the way we've configured docker (the underlying filesystem doesn't support the
 # file locking it needs to). This script strips any -pidfile option, then invokes qemu.
 
 ARGS=( "$(basename $0)" )
+
+if [ "${QEMU_BIN_PATH}"  != "" ]; then
+    ARGS=${QEMU_BIN_PATH}/${ARGS}
+fi
+
 while [ "$#" -gt 0 ]; do
     if [ "$1" == "-pidfile" ]; then
         shift

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -340,6 +340,7 @@ MICRO_SUPPORTED_MODELS = {
     "esp32": [],
     "imxrt10xx": ["-mcpu=cortex-m7"],
     "mps2_an521": ["-mcpu=cortex-m33"],
+    "mps3_an547": ["-mcpu=cortex-m55"],
     "nrf52840": ["-mcpu=cortex-m4"],
     "nrf5340dk": ["-mcpu=cortex-m33"],
     "sam3x8e": ["-mcpu=cortex-m3"],

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -96,7 +96,7 @@ def test_tflite(temp_dir, board, west_cmd, tvm_debug):
 @tvm.testing.requires_micro
 def test_qemu_make_fail(temp_dir, board, west_cmd, tvm_debug):
     """Testing QEMU make fail."""
-    if board not in ["qemu_x86", "mps2_an521"]:
+    if board not in ["qemu_x86", "mps2_an521", "mps3_an547"]:
         pytest.skip(msg="Only for QEMU targets.")
 
     model = test_utils.ZEPHYR_BOARDS[board]

--- a/tests/micro/zephyr/test_zephyr_armv7m.py
+++ b/tests/micro/zephyr/test_zephyr_armv7m.py
@@ -113,7 +113,7 @@ def test_armv7m_intrinsic(temp_dir, board, west_cmd, tvm_debug):
         "nucleo_l4r5zi",
         "nrf5340dk_nrf5340_cpuapp",
     ]:
-        pytest.skip(msg="Platform does not support ARM v7m SIMD extenion.")
+        pytest.skip(msg="Platform does not support ARM v7m SIMD extension.")
 
     model = test_utils.ZEPHYR_BOARDS[board]
 
@@ -181,6 +181,7 @@ def test_armv7m_intrinsic(temp_dir, board, west_cmd, tvm_debug):
     # Time performance measurements on QEMU emulator are always equal to zero.
     if board not in [
         "mps2_an521",
+        "mps3_an547",
     ]:
         assert time_no_simd > time_simd
 

--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -28,6 +28,7 @@ make cython3
 run_pytest ctypes python-microtvm-zephyr-qemu_x86 tests/micro/zephyr --zephyr-board=qemu_x86
 run_pytest ctypes python-microtvm-zephyr-qemu_riscv32 tests/micro/zephyr --zephyr-board=qemu_riscv32
 run_pytest ctypes python-microtvm-zephyr-qemu_riscv64 tests/micro/zephyr --zephyr-board=qemu_riscv64
+run_pytest ctypes python-microtvm-zephyr-mps3_an547 tests/micro/zephyr --zephyr-board=mps3_an547
 
 # Temporarily removing mps2_an512 from CI due to issue 8728:
 # https://github.com/apache/tvm/issues/8728


### PR DESCRIPTION
Add mps3_an547 board support to microTVM.

On Zephyr this board is supported by two emulators: QEMU and FVP. This
commit only enables the support for running mps3_an547 on QEMU, since
currently there isn't a FVP transporter on microTVM. The main difference
between these two emulators is that FVP is provided by Arm as a closed
source emulator and it supports the Ethos-U55 accelerator.

The mps3_an547 is an Arm reference board. For more details, please see:
https://developer.arm.com/tools-and-software/development-boards/fpga-prototyping-boards/mps3

Since there are already specific tests enabled on the CI to test
Ethos using the AOT executor, for instance, this commit will only add 
support for mps3_an547 using QEMU for now, also enabling the board to be
tested on the CI. 

The FPU is disabled on this commit ("fpu": false, in boards.json). This
is due to commit d4cc1c2196 ("target/arm: Enable MVE in Cortex-M55")
being absent in QEMU v6.1.1, so it's not available in any zephyr-sdk
release yet. That commit enables MVE (M-Profile Vector Extension) and so
fully enables the instructions to run the code generated when FPU is
enabled on Zephyr. It's available from QEMU v6.2.0.

This commit also adds support for the QEMU_BIN_PATH env variable so it
turns easy setting an alternative QEMU version other than the one that
is available via PATH, when running / testing any virtualized board,
either by the CI in the future or locally by the users/devs.

Finally this commit fixes two typos in comments.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>
