### PR TITLE
[Torch] fix torch version check bug

### DIFF
--- a/python/tvm/relay/frontend/pytorch_utils.py
+++ b/python/tvm/relay/frontend/pytorch_utils.py
@@ -32,11 +32,9 @@ from ..dataflow_pattern import (
 
 def is_version_greater_than(ver):
     import torch
-    import re
+    from distutils.version import LooseVersion
 
-    return int("".join(re.findall(r"(\d+)\.(\d+)\.(\d)", torch.__version__)[0])) > int(
-        "".join(re.findall(r"(\d+)\.(\d+)\.(\d)", ver)[0])
-    )
+    return LooseVersion(torch.__version__) > ver
 
 
 def getattr_attr_name(node):


### PR DESCRIPTION
old code checkout "1.10.2" greater_than "1.5.0" is false, fix it.
