### PR TITLE
[skip ci][ci] hotfix Jenkinsfile to never skip CI on main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,6 +132,10 @@ def cancel_previous_build() {
 }
 
 def should_skip_ci(pr_number) {
+  if (!env.BRANCH_NAME.startsWith('PR-')) {
+    // never skip CI on build sourced from a branch
+    return false
+  }
   glob_skip_ci_code = sh (
     returnStatus: true,
     script: "./tests/scripts/git_skip_ci_globs.py",


### PR DESCRIPTION
This was broken by #10456 since that did not have a case for ignoring the `main` and staging branches. This adds it at the Jenkins level so the further scripts won't even be run if not necessary. This is marked `skip ci` but since the changes all happen before lint this is being tested.

Breakage: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/2674/pipeline (nothing ran, docs failed when it tried to load built files)

