### PR TITLE
[CMAKE,HEXAGON] Only use hexagon specific logging when building for hexagon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ tvm_option(USE_TENSORRT_CODEGEN "Build with TensorRT Codegen support" OFF)
 tvm_option(USE_TENSORRT_RUNTIME "Build with TensorRT runtime" OFF)
 tvm_option(USE_RUST_EXT "Build with Rust based compiler extensions, STATIC, DYNAMIC, or OFF" OFF)
 tvm_option(USE_VITIS_AI "Build with VITIS-AI Codegen support" OFF)
+tvm_option(USE_CUSTOM_LOGGING "Use a user-provided logging implementation" OFF)
 tvm_option(SUMMARIZE "Print CMake option summary after configuring" OFF)
 
 # include directories
@@ -513,6 +514,16 @@ target_compile_definitions(tvm_runtime_objs PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm
 target_compile_definitions(tvm_libinfo_objs PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 target_compile_definitions(tvm PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 target_compile_definitions(tvm_runtime PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
+
+# This has to come after Hexagon.cmake because it may set USE_CUSTOM_LOGGING.
+if(USE_CUSTOM_LOGGING)
+  message(STATUS "Using user-defined logging")
+  target_compile_definitions(tvm PUBLIC TVM_LOG_CUSTOMIZE=1)
+  target_compile_definitions(tvm_runtime PUBLIC TVM_LOG_CUSTOMIZE=1)
+  target_compile_definitions(tvm_objs PUBLIC TVM_LOG_CUSTOMIZE=1)
+  target_compile_definitions(tvm_runtime_objs PUBLIC TVM_LOG_CUSTOMIZE=1)
+  target_compile_definitions(tvm_libinfo_objs PUBLIC TVM_LOG_CUSTOMIZE=1)
+endif()
 
 # logging option for libbacktrace
 include(cmake/modules/Logging.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,6 @@ include(cmake/modules/StandaloneCrt.cmake)
 include(cmake/modules/Zephyr.cmake)
 include(cmake/modules/Arduino.cmake)
 include(cmake/modules/CUDA.cmake)
-include(cmake/modules/Hexagon.cmake)
 include(cmake/modules/OpenCL.cmake)
 include(cmake/modules/OpenMP.cmake)
 include(cmake/modules/Vulkan.cmake)
@@ -515,6 +514,10 @@ target_compile_definitions(tvm_libinfo_objs PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm
 target_compile_definitions(tvm PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 target_compile_definitions(tvm_runtime PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 
+
+include(cmake/modules/Hexagon.cmake)
+
+
 # This has to come after Hexagon.cmake because it may set USE_CUSTOM_LOGGING.
 if(USE_CUSTOM_LOGGING)
   message(STATUS "Using user-defined logging")
@@ -528,6 +531,7 @@ endif()
 # logging option for libbacktrace
 include(cmake/modules/Logging.cmake)
 
+# Module rules that depend on targets
 include(cmake/modules/contrib/PAPI.cmake)
 
 if(USE_MICRO)

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -96,11 +96,12 @@ if(NOT USE_HEXAGON_DEVICE AND NOT USE_HEXAGON_RPC AND NOT BUILD_FOR_HEXAGON)
   # and some stuff needed by cpptests (this part is a temporary workaround
   # until e2e support for Hexagon is enabled).
   if(BUILD_FOR_HOST)
-    list(APPEND COMPILER_SRCS src/target/opt/build_hexagon_off.cc)
+    target_sources(tvm_objs PRIVATE src/target/opt/build_hexagon_off.cc)
   endif()
-  list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon/hexagon_buffer.cc)
-  list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon/hexagon_common.cc)
-  list(APPEND RUNTIME_SRCS src/runtime/hexagon/hexagon/hexagon_user_dma.cc)
+  target_sources(tvm_runtime_objs PRIVATE
+    src/runtime/hexagon/hexagon/hexagon_buffer.cc
+    src/runtime/hexagon/hexagon/hexagon_common.cc
+    src/runtime/hexagon/hexagon/hexagon_user_dma.cc)
   return()
 endif()
 
@@ -171,7 +172,7 @@ if(USE_HEXAGON_DEVICE)
       "${TVMRT_SOURCE_DIR}/hexagon/android/*.cc"
       "${TVMRT_SOURCE_DIR}/hexagon/android/sim/*.cc"
     )
-    list(APPEND TVM_RUNTIME_LINKER_LIBS "-lwrapper")
+    target_link_libraries(tvm_runtime PRIVATE "-lwrapper")
 
     ExternalProject_Add(sim_dev
       SOURCE_DIR "${TVMRT_SOURCE_DIR}/hexagon/android/sim/driver"
@@ -194,7 +195,7 @@ if(USE_HEXAGON_DEVICE)
       "${TVMRT_SOURCE_DIR}/hexagon/android/target/*.cc"
     )
     # Hexagon runtime uses __android_log_print, which is in liblog.
-    list(APPEND TVM_RUNTIME_LINKER_LIBS dl log cdsprpc)
+    target_link_libraries(tvm_runtime PRIVATE dl log cdsprpc)
 
   elseif(BUILD_FOR_HEXAGON)
     invalid_device_value_for("Hexagon")
@@ -237,7 +238,7 @@ if(USE_HEXAGON_RPC)
     list(APPEND RUNTIME_HEXAGON_SRCS
       "${TVMRT_SOURCE_DIR}/hexagon/rpc/hexagon_rpc_stub.c"
     )
-    list(APPEND TVM_RUNTIME_LINKER_LIBS cdsprpc)
+    target_link_libraries(tvm_runtime PRIVATE cdsprpc)
 
   elseif(BUILD_FOR_HEXAGON)
     # Hexagon part
@@ -278,9 +279,10 @@ if(USE_HEXAGON_RPC)
       "${TVMRT_SOURCE_DIR}/hexagon/host/*.cc"
       "${TVMRT_SOURCE_DIR}/hexagon/rpc/simulator/session.cc"
     )
-    list(APPEND TVM_RUNTIME_LINKER_LIBS "-lwrapper")
+    target_link_libraries(tvm PRIVATE "-lwrapper")
+    target_link_libraries(tvm_runtime PRIVATE "-lwrapper")
   endif()
 endif()   # USE_HEXAGON_RPC
 
 
-list(APPEND RUNTIME_SRCS ${RUNTIME_HEXAGON_SRCS})
+target_sources(tvm_runtime_objs PRIVATE ${RUNTIME_HEXAGON_SRCS})

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -117,6 +117,12 @@ function(add_android_paths)
     ${HEXAGON_RPCMEM_ROOT}/inc
     ${HEXAGON_REMOTE_ROOT}
   )
+  target_include_directories(tvm_runtime_objs SYSTEM PUBLIC
+    ${HEXAGON_SDK_INCLUDES}
+    ${HEXAGON_RPCMEM_ROOT}/inc
+    ${HEXAGON_REMOTE_ROOT}
+  )
+  find_library(CDSPRPC_LIBRARY NAMES cdsprpc HINTS "${HEXAGON_REMOTE_ROOT}" NO_CMAKE_FIND_ROOT_PATH)
   link_directories(${HEXAGON_REMOTE_ROOT})
 endfunction()
 
@@ -172,6 +178,7 @@ if(USE_HEXAGON_DEVICE)
       "${TVMRT_SOURCE_DIR}/hexagon/android/*.cc"
       "${TVMRT_SOURCE_DIR}/hexagon/android/sim/*.cc"
     )
+    target_link_libraries(tvm PRIVATE "-lwrapper")
     target_link_libraries(tvm_runtime PRIVATE "-lwrapper")
 
     ExternalProject_Add(sim_dev
@@ -195,7 +202,8 @@ if(USE_HEXAGON_DEVICE)
       "${TVMRT_SOURCE_DIR}/hexagon/android/target/*.cc"
     )
     # Hexagon runtime uses __android_log_print, which is in liblog.
-    target_link_libraries(tvm_runtime PRIVATE dl log cdsprpc)
+    target_link_libraries(tvm PRIVATE dl log ${CDSPRPC_LIBRARY})
+    target_link_libraries(tvm_runtime PRIVATE dl log ${CDSPRPC_LIBRARY})
 
   elseif(BUILD_FOR_HEXAGON)
     invalid_device_value_for("Hexagon")
@@ -238,7 +246,8 @@ if(USE_HEXAGON_RPC)
     list(APPEND RUNTIME_HEXAGON_SRCS
       "${TVMRT_SOURCE_DIR}/hexagon/rpc/hexagon_rpc_stub.c"
     )
-    target_link_libraries(tvm_runtime PRIVATE cdsprpc)
+    target_link_libraries(tvm PRIVATE dl log ${CDSPRPC_LIBRARY})
+    target_link_libraries(tvm_runtime PRIVATE dl log ${CDSPRPC_LIBRARY})
 
   elseif(BUILD_FOR_HEXAGON)
     # Hexagon part

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -123,7 +123,6 @@ function(add_android_paths)
     ${HEXAGON_REMOTE_ROOT}
   )
   find_library(CDSPRPC_LIBRARY NAMES cdsprpc HINTS "${HEXAGON_REMOTE_ROOT}" NO_CMAKE_FIND_ROOT_PATH)
-  link_directories(${HEXAGON_REMOTE_ROOT})
 endfunction()
 
 function(add_hexagon_wrapper_paths)
@@ -133,7 +132,7 @@ function(add_hexagon_wrapper_paths)
   include_directories(SYSTEM
     "${HEXAGON_TOOLCHAIN}/include/iss"
   )
-  link_directories("${HEXAGON_TOOLCHAIN}/lib/iss")
+  find_library(WRAPPER_LIBRARY NAMES wrapper HINTS "${HEXAGON_TOOLCHAIN}/lib/iss" NO_CMAKE_FIND_ROOT_PATH)
 endfunction()
 
 # Common sources for TVM runtime with Hexagon support
@@ -178,8 +177,8 @@ if(USE_HEXAGON_DEVICE)
       "${TVMRT_SOURCE_DIR}/hexagon/android/*.cc"
       "${TVMRT_SOURCE_DIR}/hexagon/android/sim/*.cc"
     )
-    target_link_libraries(tvm PRIVATE "-lwrapper")
-    target_link_libraries(tvm_runtime PRIVATE "-lwrapper")
+    target_link_libraries(tvm PRIVATE "${WRAPPER_LIBRARY}")
+    target_link_libraries(tvm_runtime PRIVATE "${WRAPPER_LIBRARY}")
 
     ExternalProject_Add(sim_dev
       SOURCE_DIR "${TVMRT_SOURCE_DIR}/hexagon/android/sim/driver"
@@ -288,8 +287,8 @@ if(USE_HEXAGON_RPC)
       "${TVMRT_SOURCE_DIR}/hexagon/host/*.cc"
       "${TVMRT_SOURCE_DIR}/hexagon/rpc/simulator/session.cc"
     )
-    target_link_libraries(tvm PRIVATE "-lwrapper")
-    target_link_libraries(tvm_runtime PRIVATE "-lwrapper")
+    target_link_libraries(tvm PRIVATE "${WRAPPER_LIBRARY}")
+    target_link_libraries(tvm_runtime PRIVATE "${WRAPPER_LIBRARY}")
   endif()
 endif()   # USE_HEXAGON_RPC
 

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -142,6 +142,12 @@ if(BUILD_FOR_HEXAGON)
   include_directories(SYSTEM ${HEXAGON_SDK_INCLUDES} ${HEXAGON_QURT_INCLUDES})
 
   list(APPEND RUNTIME_HEXAGON_SRCS ${RUNTIME_HEXAGON_COMMON_SRCS})
+
+  # Hexagon provides its own logging. Currently this logging cannot be
+  # overridden by a user.
+  set(USE_CUSTOM_LOGGING ON)
+  target_compile_definitions(tvm_objs PRIVATE USE_HEXAGON_LOGGING=1)
+  target_compile_definitions(tvm_runtime_objs PRIVATE USE_HEXAGON_LOGGING=1)
 endif()
 
 

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#define TVM_LOG_CUSTOMIZE 1
-
 #include "hexagon_buffer.h"
 
 #include <tvm/runtime/module.h>

--- a/src/runtime/hexagon/hexagon/hexagon_common.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_common.cc
@@ -20,8 +20,6 @@
 /*!
  * \file hexagon_common.cc
  */
-#define TVM_LOG_CUSTOMIZE 1
-
 #include "hexagon_common.h"
 
 #include <tvm/runtime/logging.h>
@@ -108,6 +106,7 @@ PackedFunc WrapPackedFunc(TVMBackendPackedCFunc faddr, const ObjectPtr<Object>& 
 }
 }  // namespace hexagon
 
+#if USE_HEXAGON_LOGGING
 namespace {
 std::vector<std::string> SplitString(const std::string& str, char delim) {
   std::vector<std::string> lines;
@@ -135,6 +134,7 @@ void LogMessageImpl(const std::string& file, int lineno, const std::string& mess
   HexagonLog(file, lineno, message);
 }
 }  // namespace detail
+#endif
 
 TVM_REGISTER_GLOBAL("tvm.runtime.hexagon.lookup_linked_params")
     .set_body(hexagon::HexagonLookupLinkedParam);

--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
@@ -20,8 +20,6 @@
 /*!
  * \file hexagon_device_api_v2.cc
  */
-#define TVM_LOG_CUSTOMIZE 1
-
 #include "hexagon_device_api_v2.h"
 
 #include <dmlc/thread_local.h>

--- a/src/runtime/hexagon/rpc/hexagon/rpc_server.cc
+++ b/src/runtime/hexagon/rpc/hexagon/rpc_server.cc
@@ -43,8 +43,6 @@ extern "C" {
 // TODO(mehrdadh): make this configurable.
 #define TVM_HEXAGON_RPC_BUFF_SIZE_BYTES 2 * 1024 * 1024
 
-#define TVM_LOG_CUSTOMIZE 1
-
 namespace tvm {
 namespace runtime {
 namespace hexagon {


### PR DESCRIPTION
Hexagon provides its own logging implementation that is included by every tvm build regardless of if hexagon is being built or not. If TVM_LOG_CUSTOMIZE is set, then this implementation is used, conflicting with the one provided by the user. This patch puts the hexagon logging implementation behind a flag that is only set when hexagon is built.

@adstraw @csullivan
