### PR TITLE
Deploy docs to tvm-site/asf-site on main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ jvm/target
 src/runtime/hexagon/rpc/hexagon_rpc.h
 src/runtime/hexagon/rpc/hexagon_rpc_skel.c
 src/runtime/hexagon/rpc/hexagon_rpc_stub.c
+
+# Local tvm-site checkout
+tvm-site/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -765,13 +765,12 @@ def deploy_docs() {
   }
 }
 
-
 stage('Deploy') {
   if (env.BRANCH_NAME == 'main' && env.DOCS_DEPLOY_ENABLED == 'yes') {
     node('CPU') {
       ws(per_exec_ws('tvm/deploy-docs')) {
         unpack_lib('docs', 'docs.tgz')
-        deploy_docs(env.DOCS_DEPLOY_BRANCH)
+        deploy_docs()
       }
     }
   }

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -166,6 +166,7 @@ mv docs/doxygen/html _docs/reference/api/doxygen
 mv jvm/core/target/site/apidocs _docs/reference/api/javadoc
 # mv rust/target/doc _docs/api/rust
 mv web/dist/docs _docs/reference/api/typedoc
+git rev-parse --short HEAD > _docs/shorthash
 
 if [ "$IS_LOCAL" != "1" ]; then
     echo "Start creating the docs tarball.."

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -166,7 +166,7 @@ mv docs/doxygen/html _docs/reference/api/doxygen
 mv jvm/core/target/site/apidocs _docs/reference/api/javadoc
 # mv rust/target/doc _docs/api/rust
 mv web/dist/docs _docs/reference/api/typedoc
-git rev-parse --short HEAD > _docs/shorthash
+git rev-parse HEAD > _docs/commit_hash
 
 if [ "$IS_LOCAL" != "1" ]; then
     echo "Start creating the docs tarball.."


### PR DESCRIPTION
This enables updates of the docs hosted at apache/tvm-site based on commits to main. After building the docs, they are added to the tvm-site repo's `docs/` folder and then pushed to the repo.

This behavior is also gated behind a kill switch in Jenkins via the `DOCS_DEPLOY_ENABLED` global env variable. To deploy we will first run this and push to the `asf-site2` branch (as configured in Jenkins). Once we see that the output is valid, we can flip the switch in Jenkins to start updating the `asf-site` branch instead. This way we can quickly revert this change if necessary.

cc @areusch 