### PR TITLE
[TIR] Fix Tensorization IR-Comparator for Annotations

### DIFF
--- a/src/tir/schedule/ir_comparator.cc
+++ b/src/tir/schedule/ir_comparator.cc
@@ -216,7 +216,6 @@ bool TensorizeComparator::DefEqual(const Var& lhs, const Var& rhs) {
 bool TensorizeComparator::CompareAnnotation(const std::pair<String, ObjectRef>& lhs,
                                             const std::pair<String, ObjectRef>& rhs) {
   if (lhs.first != rhs.first) return false;
-  if (!lhs.second.same_as(rhs.second)) return false;
   return VisitExpr(Downcast<PrimExpr>(lhs.second), Downcast<PrimExpr>(rhs.second));
 }
 


### PR DESCRIPTION
This PR fixes the way of comparison in which the tensorization IR-comparator deals with annotations.

Prior to this PR, the comparator requires the annotation values from LHS and RHS to be exactly the same, which is, in fact, never possible. And this PR removes this comparison requirement (with a regression unit test).

```c++
bool TensorizeComparator::CompareAnnotation(const std::pair<String, ObjectRef>& lhs,
                                            const std::pair<String, ObjectRef>& rhs) {
  if (lhs.first != rhs.first) return false;
  if (!lhs.second.same_as(rhs.second)) return false;  // <== The values would never be the same.
                                                      //     Thus this line should be removed.
  return VisitExpr(Downcast<PrimExpr>(lhs.second), Downcast<PrimExpr>(rhs.second));
}
```

cc @spectrometerHBH @vinx13 