### PR TITLE
[CI] Remove `llvm -device=arm_cpu` and `cuda -libs=cudnn` from the default test target list

### DIFF
--- a/tests/scripts/task_python_topi.sh
+++ b/tests/scripts/task_python_topi.sh
@@ -21,7 +21,7 @@ set -u
 
 source tests/scripts/setup-pytest-env.sh
 
-export TVM_TEST_TARGETS="llvm; llvm -device=arm_cpu; cuda; cuda -model=unknown -libs=cudnn"
+export TVM_TEST_TARGETS="llvm; cuda"
 
 # to avoid CI thread throttling.
 export TVM_BIND_THREADS=0


### PR DESCRIPTION
After recent improvement in GPU frontend tests, I found that `topi: GPU` has become a bottleneck. From the log https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10391/14/pipeline/319, it is clear that topi tests are running on target `llvm -device=arm_cpu` and `cuda -libs=cudnn`, which I claim is completely redundant since we already run on `llvm` and `cuda` targets. 

In https://github.com/apache/tvm/pull/9905, I've already removed them from `DEFAULT_TEST_TARGETS`, but `topi: GPU` uses its own list of targets which still includes `llvm -device=arm_cpu` and `cuda -libs=cudnn`. I propose to remove them from topi test targets, which hopefully will cut topi GPU tests time by half. 