### PR TITLE
[microNPU] Improve cascader memory transfer estimates

### DIFF
--- a/python/tvm/contrib/ethosu/cascader/block_config.py
+++ b/python/tvm/contrib/ethosu/cascader/block_config.py
@@ -28,10 +28,20 @@ from . import _ffi_api
 class BlockConfig(Object):
     """BlockConfig class"""
 
-    def __init__(self, output_shape: List[int], compute_cycles: int, output_cycles: int):
+    def __init__(
+        self,
+        input_shape: List[int],
+        output_shape: List[int],
+        compute_cycles: int,
+        output_cycles: int,
+    ):
         self.__init_handle_by_constructor__(
-            _ffi_api.BlockConfig, output_shape, compute_cycles, output_cycles
+            _ffi_api.BlockConfig, input_shape, output_shape, compute_cycles, output_cycles
         )
+
+    @property
+    def input_shape(self) -> List[int]:
+        return list(self._input_shape)
 
     @property
     def output_shape(self) -> List[int]:

--- a/python/tvm/contrib/ethosu/cascader/device_config.py
+++ b/python/tvm/contrib/ethosu/cascader/device_config.py
@@ -551,7 +551,7 @@ class EthosuDeviceConfig:
                 )
                 output_cycles *= reduce(lambda a, b: a * b, output_block, 1)
                 output_cycles = int(math.ceil(output_cycles))
-                block_config.append(BlockConfig(output_block, 0, output_cycles))
+                block_config.append(BlockConfig(output_block, output_block, 0, output_cycles))
                 break
 
             if output_block[split_axis] == 1:
@@ -738,9 +738,10 @@ class EthosuDeviceConfig:
                             ifm_channels,
                             is_partkernel,
                         )
-                        valid_block_configs.append(
-                            BlockConfig(output_block, compute_cycles, output_cycles)
+                        block_config = BlockConfig(
+                            input_block_shape.as_list(), output_block, compute_cycles, output_cycles
                         )
+                        valid_block_configs.append(block_config)
                     else:
                         # Block config does not fit into SHRAM
                         # Any Block config that is strictly larger than this one will also fail

--- a/python/tvm/contrib/ethosu/cascader/graph.py
+++ b/python/tvm/contrib/ethosu/cascader/graph.py
@@ -57,6 +57,10 @@ class PerformanceInfo(Object):
     def write_bytes(self):
         return self._write_bytes
 
+    @property
+    def block_config(self):
+        return self._block_config
+
 
 @tvm._ffi.register_object("contrib.ethosu.cascader.Tensor")
 class Tensor(Object):

--- a/python/tvm/contrib/ethosu/cascader/tensor_config.py
+++ b/python/tvm/contrib/ethosu/cascader/tensor_config.py
@@ -58,9 +58,25 @@ class MemoryRegion(Object):
 
     """
 
-    def __init__(self, name: str, size: int, read_bandwidth: int, write_bandwidth: int):
+    def __init__(
+        self,
+        name: str,
+        size: int,
+        read_bandwidth: int,
+        write_bandwidth: int,
+        read_latency: int = 0,
+        write_latency: int = 0,
+        burst_length: int = 1,
+    ):
         self.__init_handle_by_constructor__(
-            _ffi_api.MemoryRegion, name, size, read_bandwidth, write_bandwidth
+            _ffi_api.MemoryRegion,
+            name,
+            size,
+            read_bandwidth,
+            write_bandwidth,
+            read_latency,
+            write_latency,
+            burst_length,
         )
 
 

--- a/src/contrib/ethosu/cascader/block_config.cc
+++ b/src/contrib/ethosu/cascader/block_config.cc
@@ -33,13 +33,16 @@ namespace ethosu {
 namespace cascader {
 
 void BlockConfigNode::VisitAttrs(AttrVisitor* v) {
-  Array<Integer> tmp_arr = make_array(output_shape_);
+  Array<Integer> tmp_arr = make_array(input_shape_);
+  v->Visit("_input_shape", &tmp_arr);
+  tmp_arr = make_array(output_shape_);
   v->Visit("_output_shape", &tmp_arr);
 }
 
-BlockConfig::BlockConfig(const std::vector<int>& output_shape, int compute_cycles,
-                         int output_cycles) {
+BlockConfig::BlockConfig(const std::vector<int>& input_shape, const std::vector<int>& output_shape,
+                         int compute_cycles, int output_cycles) {
   auto n = make_object<BlockConfigNode>();
+  n->input_shape_ = std::move(input_shape);
   n->output_shape_ = std::move(output_shape);
   n->compute_cycles_ = compute_cycles;
   n->output_cycles_ = output_cycles;
@@ -47,9 +50,11 @@ BlockConfig::BlockConfig(const std::vector<int>& output_shape, int compute_cycle
 }
 
 TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.BlockConfig")
-    .set_body_typed([](Array<Integer> output_shape, int compute_cycles, int output_cycles) {
+    .set_body_typed([](Array<Integer> input_shape, Array<Integer> output_shape, int compute_cycles,
+                       int output_cycles) {
+      std::vector<int> vinput_shape = make_vector<int, Integer>(input_shape);
       std::vector<int> voutput_shape = make_vector<int, Integer>(output_shape);
-      return BlockConfig(voutput_shape, compute_cycles, output_cycles);
+      return BlockConfig(vinput_shape, voutput_shape, compute_cycles, output_cycles);
     });
 
 TVM_REGISTER_NODE_TYPE(BlockConfigNode);

--- a/src/contrib/ethosu/cascader/block_config.h
+++ b/src/contrib/ethosu/cascader/block_config.h
@@ -43,6 +43,12 @@ class BlockConfigNode : public Object {
   void VisitAttrs(AttrVisitor* v);
 
   /*!
+   * \brief Get the shape of input block.
+   * \return The input shape of the block config.
+   */
+  inline std::vector<int> GetInputBlockShape() const { return input_shape_; }
+
+  /*!
    * \brief Get the shape of output block.
    * \return The output shape of the block config.
    */
@@ -66,6 +72,8 @@ class BlockConfigNode : public Object {
  protected:
   friend class BlockConfig;
 
+  /*! \brief The shape of the input block */
+  std::vector<int> input_shape_;
   /*! \brief The shape of the output block */
   std::vector<int> output_shape_;
   /*! \brief Cycles required to compute this block */
@@ -80,7 +88,8 @@ class BlockConfigNode : public Object {
  */
 class BlockConfig : public ObjectRef {
  public:
-  BlockConfig(const std::vector<int>& output_shape, int compute_cycles, int output_cycles);
+  BlockConfig(const std::vector<int>& input_shape, const std::vector<int>& output_shape,
+              int compute_cycles, int output_cycles);
 
   TVM_DEFINE_OBJECT_REF_METHODS(BlockConfig, ObjectRef, BlockConfigNode);
 };

--- a/src/contrib/ethosu/cascader/graph.cc
+++ b/src/contrib/ethosu/cascader/graph.cc
@@ -42,6 +42,7 @@ void PerformanceInfoNode::VisitAttrs(AttrVisitor* v) {
   Array<IntImm> tmp_reads = make_array(read_bytes);
   v->Visit("_read_bytes", &tmp_reads);
   v->Visit("_write_bytes", &write_bytes);
+  v->Visit("_block_config", &block_config);
 }
 
 TVM_REGISTER_NODE_TYPE(PerformanceInfoNode);

--- a/src/contrib/ethosu/cascader/graph.h
+++ b/src/contrib/ethosu/cascader/graph.h
@@ -33,6 +33,7 @@
 #include <utility>
 #include <vector>
 
+#include "block_config.h"
 #include "propagator.h"
 
 namespace tvm {
@@ -71,6 +72,8 @@ class PerformanceInfoNode : public Object {
   std::vector<int64_t> read_bytes;
   /*! \brief The number of bytes written to the output tensor */
   int64_t write_bytes;
+  /*! \brief The block config used for this performance point */
+  BlockConfig block_config;
 
   static constexpr const char* _type_key = "contrib.ethosu.cascader.PerformanceInfo";
   TVM_DECLARE_FINAL_OBJECT_INFO(PerformanceInfoNode, Object);
@@ -85,11 +88,13 @@ class PerformanceInfoNode : public Object {
  */
 class PerformanceInfo : public ObjectRef {
  public:
-  PerformanceInfo(int64_t compute_cycles, std::vector<int64_t> read_bytes, int64_t write_bytes) {
+  PerformanceInfo(int64_t compute_cycles, std::vector<int64_t> read_bytes, int64_t write_bytes,
+                  BlockConfig block_config) {
     auto n = make_object<PerformanceInfoNode>();
     n->compute_cycles = compute_cycles;
     n->read_bytes = std::move(read_bytes);
     n->write_bytes = write_bytes;
+    n->block_config = block_config;
     data_ = std::move(n);
   }
 

--- a/src/contrib/ethosu/cascader/parts/ethosu.cc
+++ b/src/contrib/ethosu/cascader/parts/ethosu.cc
@@ -57,7 +57,8 @@ const std::vector<int64_t> EthosuPartNode::GetBytesRead(const std::vector<int>& 
   for (const auto& input_block_config : input_block_configs) {
     std::map<std::vector<int>, int> input_blocks = CountStripes(input_block_config, false);
     for (const auto& block : input_blocks) {
-      bytes_per_input[i] += mul_reduce(block.first) * block.second;
+      bytes_per_input[i] +=
+          mul_reduce(block.first) * block.second * input_tensors_[i]->GetDataType().bytes();
     }
     i++;
   }
@@ -136,7 +137,7 @@ const PerformanceInfo EthosuPartNode::GetPerformanceInfo(const StripeConfig& out
     total_cycles = (block_compute_cycles * num_blocks) + block_output_cycles;
   }
 
-  PerformanceInfo info(total_cycles, read_bytes, write_bytes);
+  PerformanceInfo info(total_cycles, read_bytes, write_bytes, block_config);
   return info;
 }
 

--- a/src/contrib/ethosu/cascader/parts/inline.cc
+++ b/src/contrib/ethosu/cascader/parts/inline.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "../block_config.h"
 #include "../common.h"
 
 namespace tvm {
@@ -33,7 +34,8 @@ namespace cascader {
 const PerformanceInfo InlinePartNode::GetPerformanceInfo(const StripeConfig& output_stripe_config,
                                                          BufferMode buffer_mode) {
   std::vector<int64_t> read_bytes(input_tensors_.size());
-  PerformanceInfo info(0, read_bytes, 0);
+  BlockConfig block_config = BlockConfig(std::vector<int>(1, 1), std::vector<int>(1, 1), 0, 0);
+  PerformanceInfo info(0, read_bytes, 0, block_config);
   return info;
 }
 

--- a/src/contrib/ethosu/cascader/tensor_config.cc
+++ b/src/contrib/ethosu/cascader/tensor_config.cc
@@ -38,11 +38,16 @@ void MemoryRegionNode::VisitAttrs(AttrVisitor* v) {
   v->Visit("size", &size);
   v->Visit("read_bandwidth", &read_bandwidth);
   v->Visit("write_bandwidth", &write_bandwidth);
+  v->Visit("read_latency", &read_latency);
+  v->Visit("write_latency", &write_latency);
+  v->Visit("burst_length", &burst_length);
 }
 
 TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.MemoryRegion")
-    .set_body_typed([](String name, int size, int read_bandwidth, int write_bandwidth) {
-      return MemoryRegion(name, size, read_bandwidth, write_bandwidth);
+    .set_body_typed([](String name, int size, int read_bandwidth, int write_bandwidth,
+                       int read_latency, int write_latency, int burst_length) {
+      return MemoryRegion(name, size, read_bandwidth, write_bandwidth, read_latency, write_latency,
+                          burst_length);
     });
 
 TVM_REGISTER_NODE_TYPE(MemoryRegionNode);

--- a/src/contrib/ethosu/cascader/tensor_config.h
+++ b/src/contrib/ethosu/cascader/tensor_config.h
@@ -52,6 +52,12 @@ class MemoryRegionNode : public Object {
   int read_bandwidth;
   /*! \brief The write bandwidth of the region in bytes per cycle */
   int write_bandwidth;
+  /*! \brief The read bandwidth of the region in bytes per cycle */
+  int read_latency;
+  /*! \brief The write bandwidth of the region in bytes per cycle */
+  int write_latency;
+  /*! \brief Length of memory burst */
+  int burst_length;
 
   static constexpr const char* _type_key = "contrib.ethosu.cascader.MemoryRegion";
   TVM_DECLARE_FINAL_OBJECT_INFO(MemoryRegionNode, Object)
@@ -59,12 +65,16 @@ class MemoryRegionNode : public Object {
 
 class MemoryRegion : public ObjectRef {
  public:
-  MemoryRegion(std::string name, int size, int read_bandwidth, int write_bandwidth) {
+  MemoryRegion(std::string name, int size, int read_bandwidth, int write_bandwidth,
+               int read_latency, int write_latency, int burst_length) {
     auto n = make_object<MemoryRegionNode>();
     n->name = name;
     n->size = size;
     n->read_bandwidth = read_bandwidth;
     n->write_bandwidth = write_bandwidth;
+    n->read_latency = read_latency;
+    n->write_latency = write_latency;
+    n->burst_length = burst_length;
     data_ = std::move(n);
   }
 

--- a/tests/python/contrib/test_ethosu/cascader/conftest.py
+++ b/tests/python/contrib/test_ethosu/cascader/conftest.py
@@ -27,17 +27,41 @@ import tvm.contrib.ethosu.cascader as cs
 
 @pytest.fixture
 def FLASH():
-    return cs.MemoryRegion(name="FLASH", size=10 ** 7, read_bandwidth=4, write_bandwidth=4)
+    return cs.MemoryRegion(
+        name="FLASH",
+        size=10 ** 7,
+        read_bandwidth=4,
+        write_bandwidth=4,
+        read_latency=0,
+        write_latency=0,
+        burst_length=1,
+    )
 
 
 @pytest.fixture
 def DRAM():
-    return cs.MemoryRegion(name="DRAM", size=10 ** 9, read_bandwidth=8, write_bandwidth=8)
+    return cs.MemoryRegion(
+        name="DRAM",
+        size=10 ** 9,
+        read_bandwidth=8,
+        write_bandwidth=8,
+        read_latency=0,
+        write_latency=0,
+        burst_length=1,
+    )
 
 
 @pytest.fixture
 def SRAM():
-    return cs.MemoryRegion(name="SRAM", size=10 ** 6, read_bandwidth=16, write_bandwidth=16)
+    return cs.MemoryRegion(
+        name="SRAM",
+        size=10 ** 6,
+        read_bandwidth=16,
+        write_bandwidth=16,
+        read_latency=0,
+        write_latency=0,
+        burst_length=1,
+    )
 
 
 if ethosu_enabled:

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
@@ -318,6 +318,15 @@ def test_best_block_config(
         block_configs,
         1,
     )
+    # Add tensors
+    input_tensor = cs.Tensor(in_shape, "int8")
+    part.set_input(0, input_tensor)
+    if op_type in ("ethosu_conv2d", "ethosu_depthwise_conv2d"):
+        weight_tensor = cs.Tensor([ofm_channels, kernel[0], kernel[1], ifm_channels], "int8")
+        part.set_input(1, weight_tensor)
+
+    output_tensor = cs.Tensor(out_shape, "int8")
+    part.set_output(output_tensor)
 
     order = [1, 2, 3, 4] if layouts[1] == "NHCWB16" else [1, 2, 4, 3, 0]
     stripes = [1] * len(output_quantum)

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_part.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_part.py
@@ -35,7 +35,7 @@ def test_ethosu_part():
     )
     subkernels = 3
 
-    valid_block_configs = [cs.BlockConfig([1, 2, 4, 16], 15000, 7500)]
+    valid_block_configs = [cs.BlockConfig([1, 2, 4, 16], [1, 2, 4, 16], 15000, 7500)]
 
     part = EthosuPart(
         te_subgraph,

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_part_performance.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_part_performance.py
@@ -200,7 +200,9 @@ def test_conv_performance(
         "int8",
         is_partkernel,
     )
-    block_configs = [cs.BlockConfig(block_shape, compute_cycles, int(output_cycles))]
+    block_configs = [
+        cs.BlockConfig(input_block_shape, block_shape, compute_cycles, int(output_cycles))
+    ]
 
     output_quantum = [1, 1, 2, 8]
     te_subgraph = cs.TESubgraph([], None)
@@ -212,6 +214,8 @@ def test_conv_performance(
         block_configs,
         1,
     )
+    part.set_input(0, cs.Tensor(in_shape, "int8"))
+    part.set_input(1, cs.Tensor([ifm_channels, kernel[0], kernel[1], out_shape[-1]], "int8"))
 
     stripes = [1] * len(output_quantum)
     offset = [0] * len(output_quantum)


### PR DESCRIPTION
This PR improves the cascader's memory transfer cycle estimates by taking memory burst length and latency into account. Copying tensors between external memories are also more accurately modeled. 