### PR TITLE
[TIR] Restrict Buffer indices to at most one multi-lane index.

### DIFF
--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -1061,7 +1061,11 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 void BufferLoadNode::LegalizeDType() {
   int index_lanes = 1;
   for (const auto& index : indices) {
-    index_lanes *= index.dtype().lanes();
+    int lanes = index.dtype().lanes();
+    if (lanes > 1) {
+      ICHECK_EQ(index_lanes, 1) << "Buffer indices may only include a single multi-lane index.";
+    }
+    index_lanes *= lanes;
   }
 
   int buffer_lanes = buffer->dtype.lanes();

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1207,7 +1207,11 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
 
     int index_lanes = 1;
     for (const auto& index : indices) {
-      index_lanes *= index.dtype().lanes();
+      int lanes = index.dtype().lanes();
+      if (lanes > 1) {
+        ICHECK_EQ(index_lanes, 1) << "Buffer indices may only include a single multi-lane index.";
+      }
+      index_lanes *= lanes;
     }
 
     DataType access_dtype = value_dtype;


### PR DESCRIPTION
Part of tracking issue https://github.com/apache/tvm/issues/10505, restrict multi-lane indexing to at most one index per buffer access.  This removes ambiguity as an expression such as `A[T.ramp(i,1,2), T.ramp(j,1,2)]`, which could be interpreted either as `[A[i,j], A[i+1,j+1]]` or as `[A[i,j], A[i,j+1], A[i+1,j], A[i+1,j+1]]`, depending on whether the implied iterators of the two ramp nodes are shared.

This is a alternate draft PR to https://github.com/apache/tvm/pull/10513, which instead introduces a more restrictive condition that allows the last index to have multiple lanes.