### PR TITLE
[TIR] Restrict Buffer indices, only last index can be multi-lane

### DIFF
--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -1059,7 +1059,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 // BufferLoad
 void BufferLoadNode::LegalizeDType() {
-  for (int i = 0; i < int(indices.size()) - 1; i++) {
+  for (int i = 0; i < static_cast<int>(indices.size()) - 1; i++) {
     ICHECK(indices[i].dtype().is_scalar())
         << "Only the last index of a buffer access may be a vector type.";
   }

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -1059,11 +1059,13 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 // BufferLoad
 void BufferLoadNode::LegalizeDType() {
-  int index_lanes = 1;
-  for (const auto& index : indices) {
-    index_lanes *= index.dtype().lanes();
+  for (size_t i = 0; i < indices.size(); i++) {
+    int lanes = indices[i].dtype().lanes();
+    ICHECK((lanes == 1) || (i + 1 == indices.size()))
+        << "Only the last index of a buffer access may have multiple lanes.";
   }
 
+  int index_lanes = indices.size() ? indices.back().dtype().lanes() : 1;
   int buffer_lanes = buffer->dtype.lanes();
 
   this->dtype = buffer->dtype.with_lanes(index_lanes * buffer_lanes);

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -1059,10 +1059,9 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 // BufferLoad
 void BufferLoadNode::LegalizeDType() {
-  for (size_t i = 0; i < indices.size(); i++) {
-    int lanes = indices[i].dtype().lanes();
-    ICHECK((lanes == 1) || (i + 1 == indices.size()))
-        << "Only the last index of a buffer access may have multiple lanes.";
+  for (int i = 0; i < int(indices.size()) - 1; i++) {
+    ICHECK(indices[i].dtype().is_scalar())
+        << "Only the last index of a buffer access may be a vector type.";
   }
 
   int index_lanes = indices.size() ? indices.back().dtype().lanes() : 1;

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -676,10 +676,9 @@ BufferStore::BufferStore(Buffer buffer, PrimExpr value, Array<PrimExpr> indices,
       << "-dimensional, cannot be indexed with the " << indices.size()
       << "-dimensional indices provided.";
 
-  for (size_t i = 0; i < indices.size(); i++) {
-    int lanes = indices[i].dtype().lanes();
-    ICHECK((lanes == 1) || (i + 1 == indices.size()))
-        << "Only the last index of a buffer access may have multiple lanes.";
+  for (int i = 0; i < int(indices.size()) - 1; i++) {
+    ICHECK(indices[i].dtype().is_scalar())
+        << "Only the last index of a buffer access may be a vector type.";
   }
 
   int index_lanes = indices.size() ? indices.back().dtype().lanes() : 1;

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -676,7 +676,7 @@ BufferStore::BufferStore(Buffer buffer, PrimExpr value, Array<PrimExpr> indices,
       << "-dimensional, cannot be indexed with the " << indices.size()
       << "-dimensional indices provided.";
 
-  for (int i = 0; i < int(indices.size()) - 1; i++) {
+  for (int i = 0; i < static_cast<int>(indices.size()) - 1; i++) {
     ICHECK(indices[i].dtype().is_scalar())
         << "Only the last index of a buffer access may be a vector type.";
   }

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1205,10 +1205,9 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
       var_info.element_dtype = value_dtype.element_of();
     }
 
-    for (size_t i = 0; i < indices.size(); i++) {
-      int lanes = indices[i].dtype().lanes();
-      ICHECK((lanes == 1) || (i + 1 == indices.size()))
-          << "Only the last index of a buffer access may have multiple lanes.";
+    for (int i = 0; i < int(indices.size()) - 1; i++) {
+      ICHECK(indices[i].dtype().is_scalar())
+          << "Only the last index of a buffer access may be a vector type.";
     }
     int index_lanes = indices.size() ? indices.back().dtype().lanes() : 1;
 

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1205,10 +1205,12 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
       var_info.element_dtype = value_dtype.element_of();
     }
 
-    int index_lanes = 1;
-    for (const auto& index : indices) {
-      index_lanes *= index.dtype().lanes();
+    for (size_t i = 0; i < indices.size(); i++) {
+      int lanes = indices[i].dtype().lanes();
+      ICHECK((lanes == 1) || (i + 1 == indices.size()))
+          << "Only the last index of a buffer access may have multiple lanes.";
     }
+    int index_lanes = indices.size() ? indices.back().dtype().lanes() : 1;
 
     DataType access_dtype = value_dtype;
 

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1205,7 +1205,7 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
       var_info.element_dtype = value_dtype.element_of();
     }
 
-    for (int i = 0; i < int(indices.size()) - 1; i++) {
+    for (int i = 0; i < static_cast<int>(indices.size()) - 1; i++) {
       ICHECK(indices[i].dtype().is_scalar())
           << "Only the last index of a buffer access may be a vector type.";
     }


### PR DESCRIPTION
Part of tracking issue https://github.com/apache/tvm/issues/10505, restrict multi-lane indexing to at most one index per buffer
access. This removes ambiguity as an expression such as `A[T.ramp(i,1,2), T.ramp(j,1,2)]`, which could be interpreted either
as `[A[i,j], A[i+1,j+1]]` or as `[A[i,j], A[i,j+1], A[i+1,j], A[i+1,j+1]]`, depending on whether the implied iterators of the two ramp nodes are shared.

This is a alternate draft PR to https://github.com/apache/tvm/pull/10512, which instead introduces a less restrictive condition that allows a single multi-lane index in any location.