### PR TITLE
[LLVM][TIR] Propagate variable names to parameters.

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -606,8 +606,8 @@ void CodeGenCPU::UnpackClosureData(TypedPointer cdata, const Array<Var>& vfields
     llvm::Type* field_type = cdata.type->getStructElementType(i);
     llvm::Value* field_addr =
         builder_->CreateInBoundsGEP(cdata.type, cdata.addr, {ConstInt32(0), ConstInt32(i)});
-    llvm::Value* load = builder_->CreateLoad(field_type, field_addr);
-    load->setName(std::string(vfields[i]->name_hint));
+    llvm::Value* load =
+        builder_->CreateLoad(field_type, field_addr, std::string(vfields[i]->name_hint));
     (*vmap)[vfields[i].get()] = load;
   }
 }
@@ -646,11 +646,10 @@ void CodeGenCPU::CreateParallelLaunch(const Stmt& body, int num_task, std::strin
   par_env.task_id = Var("task_id", DataType::Int(32));
   par_env.num_task = Var("num_task", DataType::Int(32));
   new_vmap[par_env.task_id.get()] = task_id;
-  llvm::Value* num_task_value = builder_->CreateLoad(
+  new_vmap[par_env.num_task.get()] = builder_->CreateLoad(
       t_int32_,
-      builder_->CreateInBoundsGEP(t_tvm_parallel_group_env_, penv, {ConstInt32(0), ConstInt32(1)}));
-  num_task_value->setName("num_task");
-  new_vmap[par_env.num_task.get()] = num_task_value;
+      builder_->CreateInBoundsGEP(t_tvm_parallel_group_env_, penv, {ConstInt32(0), ConstInt32(1)}),
+      "num_task");
   par_env.penv = penv;
   auto new_analyzer = std::make_unique<arith::Analyzer>();
   std::swap(function_, f);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -148,6 +148,7 @@ void CodeGenLLVM::AddFunctionInternal(const PrimFunc& f, bool ret_void) {
     llvm::Argument* v = &(*arg_it);
     const Var& var = f->params[i];
     var_map_[var.get()] = v;
+    v->setName(std::string(var->name_hint));
     if (is_restricted_) {
       if (var.dtype().is_handle() && !alias_var_set_.count(var.get())) {
         // set non alias.

--- a/src/tir/transforms/make_packed_api.cc
+++ b/src/tir/transforms/make_packed_api.cc
@@ -209,7 +209,13 @@ PrimFunc MakePackedAPI(PrimFunc&& func, int num_unpacked_args) {
 
   for (int i = 0; i < static_cast<int>(func_ptr->params.size()); ++i) {
     Var param = func_ptr->params[i];
-    Var v_arg = Var("arg" + std::to_string(i), param->dtype);
+    std::string param_name;
+    if (param->name_hint.defined() && (!param->name_hint.empty())) {
+      param_name = "arg." + param->name_hint;
+    } else {
+      param_name = "arg" + std::to_string(i);
+    }
+    Var v_arg = Var(param_name, param->dtype);
 
     // Pluck the device API context out based on name
     if (param->name_hint == kDeviceContextVar) {

--- a/tests/python/unittest/test_tir_transform_make_packed_api.py
+++ b/tests/python/unittest/test_tir_transform_make_packed_api.py
@@ -83,18 +83,20 @@ def test_variable_passed_from_args():
     assert func.body.condition.b == 2
 
     # Arguments unpacking
-    assignment = _find_assignment(func.body, "arg0")
+    assignment = _find_assignment(func.body, "arg.input_buffer")
     assert str(assignment.value) == "@tir.tvm_struct_get(args: handle, 0, 12, dtype=handle)"
 
-    assignment = _find_assignment(func.body, "arg1")
+    assignment = _find_assignment(func.body, "arg.not_device_context")
     assert str(assignment.value) == "@tir.tvm_struct_get(args: handle, 1, 12, dtype=handle)"
 
     assignment = _find_assignment(func.body, "input_buffer")
-    assert str(assignment.value) == "@tir.tvm_struct_get(arg0: handle, 0, 1, dtype=handle)"
+    assert (
+        str(assignment.value) == "@tir.tvm_struct_get(arg.input_buffer: handle, 0, 1, dtype=handle)"
+    )
     unpacked_input_buffer = assignment.var
 
     assignment = _find_assignment(func.body, "not_device_context")
-    assert str(assignment.value) == "arg1: handle"
+    assert str(assignment.value) == "arg.not_device_context: handle"
     unpacked_not_device_context = assignment.var
 
     seq_stmt = _find_next(assignment, tvm.tir.SeqStmt)
@@ -129,11 +131,13 @@ def test_device_api_context_implicit_resource_handle():
     assert func.body.condition.b == 1
 
     # Arguments unpacking
-    assignment = _find_assignment(func.body, "arg0")
+    assignment = _find_assignment(func.body, "arg.input_buffer")
     assert str(assignment.value) == "@tir.tvm_struct_get(args: handle, 0, 12, dtype=handle)"
 
     assignment = _find_assignment(func.body, "input_buffer")
-    assert str(assignment.value) == "@tir.tvm_struct_get(arg0: handle, 0, 1, dtype=handle)"
+    assert (
+        str(assignment.value) == "@tir.tvm_struct_get(arg.input_buffer: handle, 0, 1, dtype=handle)"
+    )
     unpacked_input_buffer = assignment.var
 
     seq_stmt = _find_next(assignment, tvm.tir.SeqStmt)


### PR DESCRIPTION
To aid in debugging, generate the variable names of function/closure parameters based on their TIR names.  These function/closure names can then be observed in the generated LLVM IR.