### PR TITLE
[UnitTest] Fuzz based on seed rather than random value.

### DIFF
--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -28,14 +28,8 @@ from tvm import relay, te
 from tvm.topi.math import cast
 
 
-def randint_loguniform(low=1, high=32768, size=None):
-    logN = np.random.uniform(low=np.log(low), high=np.log(high), size=size)
-    N = np.exp(logN).astype(int)
-    return np.unique(N)
-
-
 dtype = tvm.testing.parameter("float32", "int32", "float16", "int8")
-fuzz_arr_size = tvm.testing.parameter(*randint_loguniform(size=25))
+fuzz_seed = tvm.testing.parameter(range(25))
 
 
 # Explicitly specify a target, as this test is looking at the
@@ -80,9 +74,13 @@ def test_vector_comparison(target, dtype):
     assert len(matches) == 1
 
 
-def test_array_copy(dev, dtype, fuzz_arr_size):
-    a_np = np.random.uniform(size=(fuzz_arr_size,)).astype(dtype)
-    a = tvm.nd.empty((fuzz_arr_size,), dtype, dev).copyfrom(a_np)
+def test_array_copy(dev, dtype, fuzz_seed):
+    np.random.seed(fuzz_seed)
+
+    log_arr_size = np.random.uniform(low=np.log(1), high=np.log(32768))
+    arr_size = np.exp(log_arr_size).astype(int)
+    a_np = np.random.uniform(size=(arr_size,)).astype(dtype)
+    a = tvm.nd.empty((arr_size,), dtype, dev).copyfrom(a_np)
     b_np = a.numpy()
     tvm.testing.assert_allclose(a_np, b_np)
     tvm.testing.assert_allclose(a_np, a.numpy())


### PR DESCRIPTION
Some extensions to run tests in parallel (e.g. `pytest-xdist`) require that test collection be deterministic.  Using the random seed as the test parameter instead of the random value makes the test collection be deterministic.