### PR TITLE
[Hexagon] Add default constructor to struct Optional in session.cc

### DIFF
--- a/src/runtime/hexagon/rpc/simulator/session.cc
+++ b/src/runtime/hexagon/rpc/simulator/session.cc
@@ -62,6 +62,7 @@ struct Optional : public dmlc::optional<T> {
   using dmlc::optional<T>::optional;
   using dmlc::optional<T>::operator=;
   Optional(const T& val) : dmlc::optional<T>(val) {}  // NOLINT(*)
+  Optional() = default;
 
   T* operator->() { return &this->operator*(); }
   const T* operator->() const { return &this->operator*(); }


### PR DESCRIPTION
It's needed for older compilers.