### PR TITLE
[BugFix]: select node type error in NarrowDataType pass

### DIFF
--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -253,6 +253,24 @@ class DataTypeRewriter : public StmtExprMutator {
     return StmtExprMutator::VisitExpr_(op);
   }
 
+  PrimExpr VisitExpr_(const SelectNode* op) final {
+    PrimExpr condition = this->VisitExpr(op->condition);
+    PrimExpr true_value = this->VisitExpr(op->true_value);
+    PrimExpr false_value = this->VisitExpr(op->false_value);
+    if (condition.same_as(op->condition) && true_value.same_as(op->true_value) &&
+        false_value.same_as(op->false_value)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      if (op->true_value.dtype().is_int() && op->false_value.dtype().is_int()) {
+        int bits = std::max(true_value.dtype().bits(), false_value.dtype().bits());
+        DataType dtype = true_value.dtype().with_bits(bits);
+        if (true_value.dtype() != dtype) true_value = cast(dtype, true_value);
+        if (false_value.dtype() != dtype) false_value = cast(dtype, false_value);
+      }
+      return Select(condition, true_value, false_value);
+    }
+  }
+
   PrimExpr VisitExpr_(const RampNode* op) final {
     PrimExpr base = VisitExpr(op->base);
     PrimExpr stride = VisitExpr(op->stride);


### PR DESCRIPTION
Similar issues as: 
https://github.com/apache/tvm/pull/10172
https://github.com/apache/tvm/pull/9582

The select node requires that `ture_value.dtype() == false_value.dtype()`. While sometimes it is not the case when doing "Narrow Datatype" optimization. This usually happens when we have an `argmin` / `argmax` node with some other nodes. The workaround is to make `true_value` and `false_value` type-compatible before creating a `Select` node.

An artificial ONNX model triggering this bug is attached: [model.zip](https://github.com/apache/tvm/files/8200572/model.zip)
 
cc: @masahi 