### PR TITLE
[Hexagon] Resolve breakage in test_hexagon/test_cache_read_write

### DIFF
--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -76,7 +76,6 @@ class BuiltinLower : public StmtExprMutator {
   StackSizes GetMaxStack(Stmt stmt) {
     BuiltinLower precheck;
     precheck.is_precheck_ = true;
-    precheck.VisitBodyAndRealizeAlloca(stmt);
 
     precheck.alloca_scope_.emplace_back();
     auto& scope = precheck.alloca_scope_.back();
@@ -87,7 +86,7 @@ class BuiltinLower : public StmtExprMutator {
 
     precheck.VisitStmt(stmt);
 
-    ICHECK_EQ(alloca_scope_.size(), 1);
+    ICHECK_EQ(precheck.alloca_scope_.size(), 1);
     return precheck.alloca_scope_[0].max_sizes;
   }
 

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -76,6 +76,8 @@ class BuiltinLower : public StmtExprMutator {
   StackSizes GetMaxStack(Stmt stmt) {
     BuiltinLower precheck;
     precheck.is_precheck_ = true;
+    precheck.device_id_ = this->device_id_;
+    precheck.device_type_ = this->device_type_;
 
     precheck.alloca_scope_.emplace_back();
     auto& scope = precheck.alloca_scope_.back();

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -85,6 +85,8 @@ class StackSizeChecker : public StmtExprVisitor {
     } else if (op->op.same_as(builtin::tvm_stack_make_array())) {
       return MakeArray(op);
     } else if (op->op.same_as(builtin::mem_copy())) {
+      // The 3 arguments to mem_copy require 4 arguments to
+      // tvm_call_packed, so we cannot re-use MakeCallPacked here.
       return MakeMemCopy(op);
     } else {
       return StmtExprVisitor::VisitExpr_(op);

--- a/tests/python/contrib/test_hexagon/test_cache_read_write.py
+++ b/tests/python/contrib/test_hexagon/test_cache_read_write.py
@@ -63,7 +63,7 @@ def intrin_mem_copy(shape, dtype, dst_scope, src_scope):
 
 
 @requires_hexagon_toolchain
-def test_cache_read_write(android_serial_number, tvm_tracker_host, tvm_tracker_port):
+def test_cache_read_write(android_serial_number, tvm_tracker_host, tvm_tracker_port, adb_server_socket):
     size = 128
     outer_shape = (size,)
     factor = 16
@@ -115,6 +115,7 @@ def test_cache_read_write(android_serial_number, tvm_tracker_host, tvm_tracker_p
         "rpc_tracker_host": tvm_tracker_host,
         "rpc_tracker_port": tvm_tracker_port,
         "rpc_server_port": 7070,
+        "adb_server_socket": adb_server_socket,
     }
     launcher = HexagonLauncher(serial_number=android_serial_number, rpc_info=rpc_info)
     launcher.upload(dso_binary_path, dso_binary)

--- a/tests/python/contrib/test_hexagon/test_cache_read_write.py
+++ b/tests/python/contrib/test_hexagon/test_cache_read_write.py
@@ -63,7 +63,9 @@ def intrin_mem_copy(shape, dtype, dst_scope, src_scope):
 
 
 @requires_hexagon_toolchain
-def test_cache_read_write(android_serial_number, tvm_tracker_host, tvm_tracker_port, adb_server_socket):
+def test_cache_read_write(
+    android_serial_number, tvm_tracker_host, tvm_tracker_port, adb_server_socket
+):
     size = 128
     outer_shape = (size,)
     factor = 16

--- a/tests/scripts/task_python_hexagon.sh
+++ b/tests/scripts/task_python_hexagon.sh
@@ -24,4 +24,4 @@ source tests/scripts/setup-pytest-env.sh
 
 make cython3
 
-run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon/test_launcher.py
+run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon

--- a/tests/scripts/task_python_hexagon_simulator.sh
+++ b/tests/scripts/task_python_hexagon_simulator.sh
@@ -35,6 +35,6 @@ export HEXAGON_SHARED_LINK_FLAGS="-Lbuild/hexagon_api_output -lhexagon_rpc_sim"
 # HEXAGON_TOOLCHAIN is already set
 export HEXAGON_SDK_ROOT=${HEXAGON_SDK_PATH}
 export ANDROID_SERIAL_NUMBER=simulator
-run_pytest ctypes python-contrib-hexagon-simulator tests/python/contrib/test_hexagon/test_launcher.py
+run_pytest ctypes python-contrib-hexagon-simulator tests/python/contrib/test_hexagon
 
 kill ${TRACKER_PID}


### PR DESCRIPTION
Breakage was caused by https://github.com/apache/tvm/pull/9727, which didn't account for the new `builtin::mem_copy()` when computing the stack size in `StackSizeChecker`.  This wasn't caught in CI, because the test requires the hexagon toolchain/hardware to be present.