### PR TITLE
[ci] Delay pytest errors until all invocations have run

### DIFF
--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -29,19 +29,19 @@ set -u
 export TVM_PATH=`pwd`
 export PYTHONPATH="${TVM_PATH}/python"
 
-BUILD_DIR="${TVM_PATH}/build"
-export TVM_PYTEST_RESULT_DIR="${BUILD_DIR}/pytest-results"
-rm -f "${BUILD_DIR}"/failed_tests
+export TVM_PYTEST_RESULT_DIR="${TVM_PATH}/build/pytest-results"
 mkdir -p "${TVM_PYTEST_RESULT_DIR}"
+pytest_errors=()
 
 # This ensures that all pytest invocations that are run through run_pytest will
 # complete and errors will be reported once Bash is done executing all scripts.
 function cleanup() {
-    if [ -f "${BUILD_DIR}"/failed_tests ]; then
-        echo "These pytest invocations failed."
-        echo "The results can be found in the Jenkins 'tests' tab or by scrolling up through the raw logs here."
+    if [ "${#pytest_errors[@]}" -gt 0 ]; then
+        echo "These pytest invocations failed, the results can be found in the Jenkins 'Tests' tab or by scrolling up through the raw logs here."
         echo ""
-        cat "${BUILD_DIR}"/failed_tests
+        for e in "${pytest_errors[@]}"; do
+            echo "  ${e}"
+        done
         exit 1
     fi
 }
@@ -64,6 +64,6 @@ function run_pytest() {
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${suite_name}.xml" \
            "--junit-prefix=${ffi_type}" \
            "$@")" ]; then
-        echo "  pytest run for ${suite_name} failed" >> "${BUILD_DIR}"/failed_tests
+        pytest_errors+=("${suite_name}")
     fi
 }


### PR DESCRIPTION
This makes it a little easier to gather CI signal on a PR by ensuring that all pytest invocations run. Currently pytest runs through to completion for a single invocation so some failures are gathered, but not all. This is annoying for development since its hard to guage how a PR actually fared in CI without seeing the full picture. This will increase demands on CI since failures won't cause the skip the following pytests, but we can monitor CI to see if this has a big impact on queue times. This may make finding failures in CI logs harder too since there will probably be more scrolling involved, though coalescing pytest invocations, Jenkins' `Tests` viewer, and #10476 will help make it easier to find failed tests.

This also also kind of a stop-gap since this wouldn't be an issue if we used a single pytest invocation, but that is difficult to do completely since we rely on loading `tvm` multiple times over the course of the test suite (e.g. for tensorflow memory tests and `cython` vs `ctypes` ffi).

Example failure from #10523: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10523/2/pipeline/110

cc @areusch 