### PR TITLE
[ci] Rebuild docker images on docker changes

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -24,6 +24,7 @@
 #                [--dockerfile <DOCKERFILE_PATH>] [-it]
 #                [--net=host] [--cache-from <IMAGE_NAME>]
 #                [--name CONTAINER_NAME] [--context-path <CONTEXT_PATH>]
+#                [--spec DOCKER_IMAGE_SPEC]
 #                [<COMMAND>]
 #
 # CONTAINER_TYPE: Type of the docker container used the run the build,
@@ -35,6 +36,9 @@
 # DOCKERFILE_PATH: (Optional) Path to the Dockerfile used for docker build.  If
 #                  this optional value is not supplied (via the --dockerfile
 #                  flag), will use Dockerfile.CONTAINER_TYPE in default
+#
+# DOCKER_IMAGE_SPEC: Override the default logic to determine the image name and
+#                    tag
 #
 # IMAGE_NAME: An image to be as a source for cached layers when building the
 #             Docker image requested.
@@ -71,6 +75,11 @@ fi
 if [[ "$1" == "-it" ]]; then
     CI_DOCKER_EXTRA_PARAMS+=('-it')
     shift 1
+fi
+
+if [[ "$1" == "--spec" ]]; then
+    OVERRIDE_IMAGE_SPEC="$2"
+    shift 2
 fi
 
 if [[ "$1" == "--net=host" ]]; then
@@ -161,6 +170,10 @@ DOCKER_IMG_NAME=$(echo "${DOCKER_IMG_NAME}" | tr '[:upper:]' '[:lower:]')
 
 # Compose the full image spec with "name:tag" e.g. "tvm.ci_cpu:v0.03"
 DOCKER_IMG_SPEC="${DOCKER_IMG_NAME}:${DOCKER_IMAGE_TAG}"
+
+if [[ -n ${OVERRIDE_IMAGE_SPEC+x} ]]; then
+    DOCKER_IMG_SPEC="$OVERRIDE_IMAGE_SPEC"
+fi
 
 # Print arguments.
 echo "WORKSPACE: ${WORKSPACE}"

--- a/tests/scripts/git_change_docker.sh
+++ b/tests/scripts/git_change_docker.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eux
+
+changed_files=$(git diff --no-commit-id --name-only -r origin/main)
+
+for file in $changed_files; do
+    echo "Checking $file"
+    if grep -q "docker/" <<< "$file"; then
+        exit 1
+    fi
+done
+
+# No docker changes
+exit 0


### PR DESCRIPTION
The actual use of these is left for a follow up, this just validates that the images correctly build in the face of docker image changes. This will eventually subsume the job defined here https://github.com/tlc-pack/tlcpack/blob/main/jenkins/JenkinsFile-rebuild-docker-images

cc @manupa-arm @areusch 