### PR TITLE
Automatically close open files to prevent ResourceWarning

### DIFF
--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -207,12 +207,13 @@ def load_from_file(filename):
     input: autotvm.measure.MeasureInput
     result: autotvm.measure.MeasureResult
     """
-    for row in open(filename):
-        if row and not row.startswith("#"):
-            ret = decode(row)
-            if ret is None:
-                continue
-            yield ret
+    with open(filename) as f:
+        for row in f:
+            if row and not row.startswith("#"):
+                ret = decode(row)
+                if ret is None:
+                    continue
+                yield ret
 
 
 def split_workload(in_file, clean=True):

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -112,10 +112,11 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
         msg += py_str(out)
         raise RuntimeError(msg)
 
-    data = bytearray(open(file_target, "rb").read())
-    if not data:
-        raise RuntimeError("Compilation error: empty result is generated")
-    return data
+    with open(file_target, "rb") as f:
+        data = bytearray(f.read())
+        if not data:
+            raise RuntimeError("Compilation error: empty result is generated")
+        return data
 
 
 def find_cuda_path():


### PR DESCRIPTION
Python will emit a `ResourceWarning: unclosed file` if files
are not properly closed. This removes this warning by enclosing
file-handling blocks in `with open...` that will automatically
close open files upon leaving the block.