### PR TITLE
[skip ci][Bugfix] Allow constant folding of 0U - 0U

### DIFF
--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -108,7 +108,8 @@ inline PrimExpr TryConstFold<tir::Add>(PrimExpr a, PrimExpr b) {
 template <>
 inline PrimExpr TryConstFold<tir::Sub>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    ICHECK(!(pa && pa->dtype.is_uint() && pa->value == 0U && b.dtype().is_uint()))
+    ICHECK(!((pa && pa->dtype.is_uint() && pa->value == 0U) &&
+             (pb && pb->dtype.is_uint() && pb->value > 0U)))
         << "Checked failed. Minuend 's value is 0U and it's dtype is uint "
         << "while Subtrahend's dtype is uint; which will cause a negative uint";
     const DataType& rtype = a.dtype();


### PR DESCRIPTION
A check for unsigned integer overflow would throw an error if it encountered `0U - 0U`.

https://github.com/apache/tvm/pull/10484, which introduced the check, and https://github.com/apache/tvm/pull/9727, which introduced this edge case, were in CI at the same time, and each was tested against a merge candidate that did not include the other.  The unittest failure only occurred when both PRs were merged.