### PR TITLE
[ci] Remove commit check on ci skipping logic

### DIFF
--- a/docs/contribute/ci.rst
+++ b/docs/contribute/ci.rst
@@ -80,9 +80,12 @@ Skip CI for Reverts
 -------------------
 
 For reverts and trivial forward fixes, adding ``[skip ci]`` to the revert's
-commit message will cause CI to shortcut and only run lint. Committers should
+PR title will cause CI to shortcut and only run lint. Committers should
 take care that they only merge CI-skipped PRs to fix a failure on ``main`` and
 not in cases where the submitter wants to shortcut CI to merge a change faster.
+The PR title is checked when the build is first run (specifically during the lint
+step, so changes after that has run do not affect CI and will require the job to
+be re-triggered by another ``git push``).
 
 .. code:: bash
 

--- a/tests/python/unittest/test_ci.py
+++ b/tests/python/unittest/test_ci.py
@@ -233,9 +233,9 @@ def test_skip_ci(tmpdir_factory):
             ["commit", "--allow-empty", "--message", "[skip ci] commit 1"],
             ["commit", "--allow-empty", "--message", "commit 2"],
         ],
-        should_skip=False,
+        should_skip=True,
         pr_title="[skip ci] test",
-        why="ci should not be skipped on a branch without [skip ci] in the last commit",
+        why="ci should not be skipped with [skip ci] in the PR title",
     )
 
     test(
@@ -244,9 +244,9 @@ def test_skip_ci(tmpdir_factory):
             ["commit", "--allow-empty", "--message", "[skip ci] commit 1"],
             ["commit", "--allow-empty", "--message", "commit 2"],
         ],
-        should_skip=False,
+        should_skip=True,
         pr_title="[skip ci] test",
-        why="ci should not be skipped on a branch without [skip ci] in the last commit",
+        why="ci should not be skipped with [skip ci] in the PR title",
     )
 
     test(
@@ -257,9 +257,9 @@ def test_skip_ci(tmpdir_factory):
             ["commit", "--allow-empty", "--message", "commit 3"],
             ["commit", "--allow-empty", "--message", "commit 4"],
         ],
-        should_skip=False,
+        should_skip=True,
         pr_title="[skip ci] test",
-        why="ci should not be skipped on a branch without [skip ci] in the last commit",
+        why="ci should not be skipped with [skip ci] in the PR title",
     )
 
 

--- a/tests/scripts/git_skip_ci.py
+++ b/tests/scripts/git_skip_ci.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         return title.startswith("[skip ci]")
 
     if args.pr != "null" and args.pr.strip() != "" and branch != "main" and check_pr_title():
-        print("Commit and PR start with '[skip ci]', skipping...")
+        print("PR title starts with '[skip ci]', skipping...")
         exit(0)
     else:
         print(f"Not skipping CI:\nargs.pr: {args.pr}\nbranch: {branch}\ncommit: {log}")

--- a/tests/scripts/git_skip_ci.py
+++ b/tests/scripts/git_skip_ci.py
@@ -49,13 +49,7 @@ if __name__ == "__main__":
         print("pr title:", title)
         return title.startswith("[skip ci]")
 
-    if (
-        args.pr != "null"
-        and args.pr.strip() != ""
-        and branch != "main"
-        and log.startswith("[skip ci]")
-        and check_pr_title()
-    ):
+    if args.pr != "null" and args.pr.strip() != "" and branch != "main" and check_pr_title():
         print("Commit and PR start with '[skip ci]', skipping...")
         exit(0)
     else:


### PR DESCRIPTION
The commit message check makes `[skip ci]` very hard to use and sometimes out of the submitter's control (e.g. when Jenkins decides to add a merge commit before running CI) for dubious benefit (the PR title is where people are looking after-the-fact anyways, so having it in the commit message doesn't make much sense). This removes the check for the commit message in order to make the process smoother.
