### PR TITLE
[ci] Build GPU libraries on CPU nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,6 @@ def make(docker_type, path, make_flag) {
     try {
       cmake_build(docker_type, path, make_flag)
       // always run cpp test when build
-      cpp_unittest(docker_type)
     } catch (hudson.AbortException ae) {
       // script exited due to user abort, directly throw instead of retry
       if (ae.getMessage().contains('script returned exit code 143')) {
@@ -235,7 +234,6 @@ def make(docker_type, path, make_flag) {
         label: 'Clear old cmake workspace',
       )
       cmake_build(docker_type, path, make_flag)
-      cpp_unittest(docker_type)
     }
   }
 }
@@ -288,7 +286,7 @@ def cmake_build(image, path, make_flag) {
 
 def cpp_unittest(image) {
   sh (
-    script: "${docker_run} ${image} ./tests/scripts/task_cpp_unittest.sh",
+    script: "${docker_run} --env CI_NUM_EXECUTORS ${image} ./tests/scripts/task_cpp_unittest.sh",
     label: 'Build and run C++ tests',
   )
 }
@@ -299,15 +297,16 @@ stage('Build') {
   }
   parallel 'BUILD: GPU': {
     if (!skip_ci) {
-      node('GPUBUILD') {
+      node('CPU') {
         ws(per_exec_ws('tvm/build-gpu')) {
           init_git()
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
-          make(ci_gpu, 'build', '-j2')
+          sh "${docker_run} --no-gpu ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh"
+          make("${ci_gpu} --no-gpu", 'build', '-j2')
           pack_lib('gpu', tvm_multilib)
           // compiler test
-          sh "${docker_run} ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
-          make(ci_gpu, 'build2', '-j2')
+          sh "${docker_run} --no-gpu ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh"
+          make("${ci_gpu} --no-gpu", 'build2', '-j2')
+          pack_lib('gpu2', tvm_multilib)
         }
       }
     }
@@ -345,6 +344,7 @@ stage('Build') {
             label: 'Create WASM cmake config',
           )
           make(ci_wasm, 'build', '-j2')
+          cpp_unittest(ci_wasm)
           timeout(time: max_time, unit: 'MINUTES') {
             ci_setup(ci_wasm)
             sh (
@@ -403,6 +403,7 @@ stage('Build') {
           )
           try {
             make(ci_qemu, 'build', '-j2')
+            cpp_unittest(ci_qemu)
             timeout(time: max_time, unit: 'MINUTES') {
               ci_setup(ci_qemu)
               sh (
@@ -434,6 +435,7 @@ stage('Build') {
           )
           try {
             make(ci_hexagon, 'build', '-j2')
+            cpp_unittest(ci_hexagon)
             sh (
               script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_build_hexagon_api.sh",
               label: 'Build Hexagon API',
@@ -467,9 +469,13 @@ stage('Test') {
         ws(per_exec_ws('tvm/ut-python-gpu')) {
           try {
             init_git()
+            unpack_lib('gpu2', tvm_multilib)
+            cpp_unittest(ci_gpu)
+
             unpack_lib('gpu', tvm_multilib)
             timeout(time: max_time, unit: 'MINUTES') {
               ci_setup(ci_gpu)
+              cpp_unittest(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
                 label: 'Run Java unit tests',
@@ -524,6 +530,7 @@ stage('Test') {
             unpack_lib('cpu', tvm_multilib_tsim)
             timeout(time: max_time, unit: 'MINUTES') {
               ci_setup(ci_cpu)
+              cpp_unittest(ci_cpu)
               python_unittest(ci_cpu)
               fsim_test(ci_cpu)
               sh (
@@ -549,6 +556,7 @@ stage('Test') {
             unpack_lib('i386', tvm_multilib)
             timeout(time: max_time, unit: 'MINUTES') {
               ci_setup(ci_i386)
+              cpp_unittest(ci_i386)
               python_unittest(ci_i386)
               sh (
                 script: "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh",
@@ -574,6 +582,7 @@ stage('Test') {
             unpack_lib('arm', tvm_multilib)
             timeout(time: max_time, unit: 'MINUTES') {
               ci_setup(ci_arm)
+              cpp_unittest(ci_arm)
               python_unittest(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh",

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -81,6 +81,10 @@ Usage: docker/bash.sh [-i|--interactive] [--net=host] [-t|--tty]
     as the external location of the repository, to maintain
     compatibility with git-worktree.
 
+--no-gpu
+
+    Do not use GPU device drivers even if using an CUDA Docker image
+
 --dry-run
 
     Print the docker command to be run, but do not execute it.
@@ -124,6 +128,7 @@ DRY_RUN=false
 INTERACTIVE=false
 TTY=false
 USE_NET_HOST=false
+USE_GPU=true
 DOCKER_IMAGE_NAME=
 COMMAND=bash
 MOUNT_DIRS=( )
@@ -207,6 +212,11 @@ while (( $# )); do
 
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+
+        --no-gpu)
+            USE_GPU=false
             shift
             ;;
 
@@ -349,7 +359,7 @@ done
 # Use nvidia-docker for GPU container.  If nvidia-docker is not
 # available, fall back to using "--gpus all" flag, requires docker
 # version 19.03 or higher.
-if [[ "${DOCKER_IMAGE_NAME}" == *"gpu"* || "${DOCKER_IMAGE_NAME}" == *"cuda"* ]]; then
+if [ "$USE_GPU" == "true" ] && [[ "${DOCKER_IMAGE_NAME}" == *"gpu"* || "${DOCKER_IMAGE_NAME}" == *"cuda"* ]]; then
     if type nvidia-docker 1> /dev/null 2> /dev/null; then
         DOCKER_BINARY=nvidia-docker
     else

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -359,7 +359,7 @@ done
 # Use nvidia-docker for GPU container.  If nvidia-docker is not
 # available, fall back to using "--gpus all" flag, requires docker
 # version 19.03 or higher.
-if [ "$USE_GPU" == "true" ] && [[ "${DOCKER_IMAGE_NAME}" == *"gpu"* || "${DOCKER_IMAGE_NAME}" == *"cuda"* ]]; then
+if [[ "$USE_GPU" == "true" ]] && [[ "${DOCKER_IMAGE_NAME}" == *"gpu"* || "${DOCKER_IMAGE_NAME}" == *"cuda"* ]]; then
     if type nvidia-docker 1> /dev/null 2> /dev/null; then
         DOCKER_BINARY=nvidia-docker
     else

--- a/tests/scripts/task_build.py
+++ b/tests/scripts/task_build.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     parser.add_argument("--sccache-bucket", required=False, help="sccache bucket name")
     parser.add_argument("--num-executors", required=True, help="number of Jenkins executors")
     parser.add_argument("--build-dir", default="build", help="build folder")
-    parser.add_argument("--target", help="optional build target")
+    parser.add_argument("--cmake-target", help="optional build target")
     args = parser.parse_args()
 
     env = {"VTA_HW_PATH": str(Path(os.getcwd()) / "3rdparty" / "vta-hw")}
@@ -72,8 +72,8 @@ if __name__ == "__main__":
 
     sh.run("cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..", cwd=build_dir)
     target = ""
-    if args.target:
-        target = args.target
+    if args.cmake_target:
+        target = args.cmake_target
     sh.run(f"cmake --build . -- {target} VERBOSE=1 -j{num_cpus}", cwd=build_dir)
 
     if use_sccache:

--- a/tests/scripts/task_build.py
+++ b/tests/scripts/task_build.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
     parser.add_argument("--sccache-bucket", required=False, help="sccache bucket name")
     parser.add_argument("--num-executors", required=True, help="number of Jenkins executors")
     parser.add_argument("--build-dir", default="build", help="build folder")
+    parser.add_argument("--target", help="optional build target")
     args = parser.parse_args()
 
     env = {"VTA_HW_PATH": str(Path(os.getcwd()) / "3rdparty" / "vta-hw")}
@@ -70,7 +71,10 @@ if __name__ == "__main__":
     num_cpus = max(available_cpus, 1)
 
     sh.run("cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..", cwd=build_dir)
-    sh.run(f"cmake --build . -- VERBOSE=1 -j{num_cpus}", cwd=build_dir)
+    target = ""
+    if args.target:
+        target = args.target
+    sh.run(f"cmake --build . -- {target} VERBOSE=1 -j{num_cpus}", cwd=build_dir)
 
     if use_sccache:
         logging.info("===== sccache stats =====")

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -34,7 +34,7 @@ export OMP_NUM_THREADS=1
 python3 tests/scripts/task_build.py \
     --num-executors "${CI_NUM_EXECUTORS}" \
     --sccache-bucket tvm-sccache-prod \
-    --target cpptest
+    --cmake-target cpptest
 
 # "make crttest" requires USE_MICRO to be enabled, which is not always the case.
 if grep crttest build/Makefile > /dev/null; then

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -31,7 +31,10 @@ export TVM_BIND_THREADS=0
 export OMP_NUM_THREADS=1
 
 # Build cpptest suite
-make cpptest -j2
+python3 tests/scripts/task_build.py \
+    --num-executors "${CI_NUM_EXECUTORS}" \
+    --sccache-bucket tvm-sccache-prod \
+    --target cpptest
 
 # "make crttest" requires USE_MICRO to be enabled, which is not always the case.
 if grep crttest build/Makefile > /dev/null; then


### PR DESCRIPTION
GPU capacity is more strained and expensive so we should stick to CPU when possible. This moves the GPU build to a CPU node (which is fine so long as the cuda libraries are present) and splits the C++ unit tests out to relevant areas (test steps where possible, otherwise it runs after the build).

cc @areusch 