### PR TITLE
[Relay] Fix data_dependent flag for dyn.sparse_to_dense.

### DIFF
--- a/python/tvm/relay/op/dyn/_transform.py
+++ b/python/tvm/relay/op/dyn/_transform.py
@@ -256,7 +256,7 @@ def _sparse_to_dense_shape_func(output_shape, ndim):
     return out
 
 
-@_reg.register_shape_func("dyn.sparse_to_dense", True)
+@_reg.register_shape_func("dyn.sparse_to_dense", [False, False, False, True])
 def sparse_to_dense_shape_func(attrs, inputs, out_ndims):
     return [_sparse_to_dense_shape_func(inputs[3], out_ndims[0])]
 


### PR DESCRIPTION
Hello, sparse value in dyn.sparse_to_dense inputs may contain many elements, fix data_dependent flag for dyn.sparse_to_dense to avoid data copy.
