### PR TITLE
[TE] Bind a rank-0 tensor in `decl_tensor_intrin`

### DIFF
--- a/tests/python/unittest/test_te_schedule.py
+++ b/tests/python/unittest/test_te_schedule.py
@@ -272,18 +272,17 @@ def test_tensor_intrin_red():
     n = 16
     x = te.placeholder((n,), name="x")
     k = te.reduce_axis((0, n), "k")
-    z = te.compute((), lambda : te.sum(x[k], axis=k), name="z")
+    z = te.compute((), lambda: te.sum(x[k], axis=k), name="z")
 
     def intrin_func(ins, outs):
         assert isinstance(ins[0], tvm.te.schedule.Buffer)
         assert ins[0].shape[0].value == n
         return tvm.tir.call_packed("vsum", ins[0].data, outs[0].data, ins[0].shape[0])
 
-    intrin = te.decl_tensor_intrin(z.op, intrin_func,
-        binds={
-            x : tvm.tir.decl_buffer(x.shape, x.dtype),
-            z : tvm.tir.decl_buffer(z.shape, z.dtype)
-        }
+    intrin = te.decl_tensor_intrin(
+        z.op,
+        intrin_func,
+        binds={x: tvm.tir.decl_buffer(x.shape, x.dtype), z: tvm.tir.decl_buffer(z.shape, z.dtype)},
     )
     assert intrin.op == z.op
     assert intrin.reduce_init is None


### PR DESCRIPTION
Hi All,

This PR addressed issue 1 in https://github.com/apache/tvm/pull/9829. This can solve the following error.
```bash
~/project/apache/tvm/tests/python/unittest$ pytest test_te_schedule.py -k test_tensor_intrin_red
[14:40:10] ../src/target/target_kind.cc:163: Warning: Unable to detect CUDA version, default to "-arch=sm_20" instead
enabled targets: llvm
pytest marker: 
======================================= test session starts ========================================
platform linux -- Python 3.7.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: ~/project/apache/tvm/tests/python/unittest
collected 18 items / 17 deselected / 1 selected                                                    

test_te_schedule.py F                                                                        [100%]

============================================= FAILURES =============================================
______________________________________ test_tensor_intrin_red ______________________________________

    def test_tensor_intrin_red():
        # not keepdims
        n = 16
        x = te.placeholder((n,), name="x")
        k = te.reduce_axis((0, n), "k")
        z = te.compute((), lambda : te.sum(x[k], axis=k), name="z")
    
        def intrin_func(ins, outs):
            assert isinstance(ins[0], tvm.te.schedule.Buffer)
            assert ins[0].shape[0].value == n
            return tvm.tir.call_packed("vsum", ins[0].data, outs[0].data, ins[0].shape[0])
    
        intrin = te.decl_tensor_intrin(z.op, intrin_func,
            binds={
                x : tvm.tir.decl_buffer(x.shape, x.dtype),
>               z : tvm.tir.decl_buffer(z.shape, z.dtype)
            }
        )

test_te_schedule.py:285: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../python/tvm/te/tensor_intrin.py:131: in decl_tensor_intrin
    if t in binds
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Tensor(shape=[], op.name=z), other = Tensor(shape=[], op.name=z)

    def __eq__(self, other):
        if not isinstance(other, Tensor):
            if isinstance(other, _expr.ExprOp):
                return _expr.EqualOp(self, other)
            return False
        if self.ndim == 0 and other.ndim == 0:
            raise ValueError(
>               "Equal == comparison among rank-0 tensor is ambiguous, "
                "use Tensor.equal for content expression equvalence, "
                "use Tensor.same_as for exact reference comparison"
            )
E           ValueError: Equal == comparison among rank-0 tensor is ambiguous, use Tensor.equal for content expression equvalence, use Tensor.same_as for exact reference comparison

../../../python/tvm/te/tensor.py:91: ValueError
===================================== short test summary info ======================================
FAILED test_te_schedule.py::test_tensor_intrin_red - ValueError: Equal == comparison among rank-0...
================================= 1 failed, 17 deselected in 0.09s =================================
```