### PR TITLE
[Bugfix] Simultaneous layout transform and axis separators.

### DIFF
--- a/src/te/schedule/schedule_postproc_to_primfunc.cc
+++ b/src/te/schedule/schedule_postproc_to_primfunc.cc
@@ -256,6 +256,9 @@ class AxisSeparatorsAttrUnwrapper : StmtExprMutator {
       auto pass = AxisSeparatorsAttrUnwrapper(axis_separators_map);
       write_ptr->buffer_map = pass.UpdateExternBufferMap(func->buffer_map);
       write_ptr->body = pass(func->body);
+      if (auto map = func->attrs.GetAttr<Map<Buffer, Array<IndexMap>>>("layout_transform_map")) {
+        func = WithAttr(std::move(func), "layout_transform_map", pass.UpdateIndexMap(map.value()));
+      }
     }
 
     return func;
@@ -268,6 +271,14 @@ class AxisSeparatorsAttrUnwrapper : StmtExprMutator {
     Map<Var, Buffer> output;
     for (const auto& kv : orig) {
       output.Set(kv.first, GetRemappedBuffer(kv.second));
+    }
+    return output;
+  }
+
+  Map<Buffer, Array<IndexMap>> UpdateIndexMap(const Map<Buffer, Array<IndexMap>>& orig) {
+    Map<Buffer, Array<IndexMap>> output;
+    for (const auto& kv : orig) {
+      output.Set(GetRemappedBuffer(kv.first), kv.second);
     }
     return output;
   }


### PR DESCRIPTION
Previously, SchedulePostProcToPrimFunc would first generate the map from buffer object to layout transformation, then would update buffers with the axis separators.  However, it failed to replace the buffer objects in the layout transformation map, so the transformation wasn't applied.

This PR correctly updates the layout transformation map, and adds a unit test to catch this failure mode.