### PR TITLE
Fix TorchScript fallback build

### DIFF
--- a/include/tvm/runtime/contrib/libtorch_runtime.h
+++ b/include/tvm/runtime/contrib/libtorch_runtime.h
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \brief runtime implementation for LibTorch/TorchScript.
+ */
+#ifndef TVM_RUNTIME_CONTRIB_LIBTORCH_RUNTIME_H_
+#define TVM_RUNTIME_CONTRIB_LIBTORCH_RUNTIME_H_
+#include <tvm/runtime/module.h>
+
+#include <string>
+
+namespace tvm {
+namespace runtime {
+namespace contrib {
+
+runtime::Module TorchRuntimeCreate(const String& symbol_name,
+                                   const std::string& serialized_function);
+
+}  // namespace contrib
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_CONTRIB_LIBTORCH_RUNTIME_H_

--- a/src/relay/backend/contrib/libtorch/libtorch_codegen.cc
+++ b/src/relay/backend/contrib/libtorch/libtorch_codegen.cc
@@ -32,7 +32,7 @@
 #include <tvm/relay/op.h>
 #include <tvm/relay/transform.h>
 #include <tvm/relay/type.h>
-#include <tvm/runtime/contrib/libtorch/libtorch_runtime.h>
+#include <tvm/runtime/contrib/libtorch_runtime.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/op.h>

--- a/src/runtime/contrib/libtorch/libtorch_runtime.cc
+++ b/src/runtime/contrib/libtorch/libtorch_runtime.cc
@@ -27,6 +27,7 @@
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/runtime/contrib/libtorch_runtime.h>
 
 #include <ATen/dlpack.h>
 #include <ATen/DLConvertor.h>

--- a/tests/python/contrib/test_libtorch_ops.py
+++ b/tests/python/contrib/test_libtorch_ops.py
@@ -20,13 +20,16 @@ import pytest
 import tvm.relay
 from tvm.relay.op.contrib import torchop
 
+import_torch_error = None
+
 try:
     import torch
-except ImportError as _:
+except ImportError as e:
     torch = None
+    import_torch_error = str(e)
 
 
-@pytest.mark.skipif(torch is None, reason="PyTorch is not available")
+@pytest.mark.skipif(torch is None, reason=f"PyTorch is not available: {import_torch_error}")
 def test_backend():
     @torch.jit.script
     def script_fn(x, y):


### PR DESCRIPTION
This was missing a header `libtorch_runtime.h` after #7401. The test in `test_libtorch_ops.py` is also currently being skipped in CI since `torch` isn't available but that's left for a follow up

cc @t-vi @masahi

