### PR TITLE
[Runtime][ThreadPool] Remove a cout log output.

### DIFF
--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -386,7 +386,6 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool").set_body([](TVMArgs args, TVMRe
     for (auto cpu : cpu_array) {
       ICHECK(IsNumber(cpu)) << "The CPU core information '" << cpu << "' is not a number.";
       cpus.push_back(std::stoi(cpu));
-      std::cout << "cpu is " << cpu << std::endl;
     }
   }
   threading::Configure(mode, nthreads, cpus);


### PR DESCRIPTION
There is a debug std::cout logic left in thread_pool.cc, remove it.
