### PR TITLE
[CI] Upgrade Python dependencies as part of Docker image build

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -21,7 +21,7 @@ set -u
 set -o pipefail
 
 # install libraries for python package on ubuntu
-pip3 install \
+pip3 install --upgrade \
     attrs \
     cloudpickle \
     cython \


### PR DESCRIPTION
Make sure that Python package dependencies we install as part of the Docker image setup take precedence over previously Ubuntu installed packages that might be installed (e.g python3-***) via apt.

cc @lhutton1 @Mousius @areusch @driazati 
