### PR TITLE
[CI] Updated ci.py to use task_build.py

### DIFF
--- a/docs/contribute/ci.rst
+++ b/docs/contribute/ci.rst
@@ -169,7 +169,7 @@ and help in mounting your current directory.
     # the tvm directory is automatically mounted
     # example: build tvm (note: this will overrwrite build/)
     $ ./tests/scripts/task_config_build_cpu.sh
-    $ ./tests/scripts/task_build.sh build -j32
+    $ ./tests/scripts/task_build.py --build-dir build --num-executors 32
 
 
 Reporting Issues

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -238,7 +238,7 @@ def docs(
 
     scripts = extra_setup + [
         config,
-        f"./tests/scripts/task_build.sh build -j{NPROC}",
+        f"./tests/scripts/task_build.py --build-dir build --num-executors {NPROC}",
         "./tests/scripts/task_ci_setup.sh",
         "./tests/scripts/task_python_docs.sh",
     ]


### PR DESCRIPTION
`task_build.sh` was replaced with `task_build.py` in https://github.com/apache/tvm/pull/10359.  This commit updates the `ci.py` script and the contribution documentation to use `task_build.py` instead of `task_build.sh`.