### PR TITLE
[Metaschedule] New relay backend for meta schedule task extraction

### DIFF
--- a/include/tvm/meta_schedule/integration.h
+++ b/include/tvm/meta_schedule/integration.h
@@ -92,7 +92,7 @@ class MetaScheduleContextNode : public runtime::Object {
    *         3) relay::Function if `mod` should be dispatched to BYOC workflow
    *         4) IRModule for unified dispatch
    */
-  virtual Optional<ObjectRef> Query(runtime::String task_name, IRModule mod, Target target,
+  virtual IRModule Query(runtime::String task_name, IRModule mod, Target target,
                                     Optional<Array<IRModule>> dispatched) = 0;
 
   static constexpr const char* _type_key = "meta_schedule.MetaScheduleContext";
@@ -129,7 +129,7 @@ class MetaScheduleContext : public runtime::ObjectRef {
    *         3) relay::Function if `mod` should be dispatched to BYOC workflow
    *         4) IRModule for unified dispatch
    */
-  static Optional<ObjectRef> QueryInsideWithScope(runtime::String task_name, IRModule mod,
+  static IRModule QueryInsideWithScope(runtime::String task_name, IRModule mod,
                                                   Target target,
                                                   Optional<Array<IRModule>> dispatched);
 
@@ -143,38 +143,6 @@ class MetaScheduleContext : public runtime::ObjectRef {
   void EnterWithScope();
   /*! \brief Exiting the scope of the context manager */
   void ExitWithScope();
-};
-
-/**************** TaskExtraction ****************/
-
-/*!
- * \brief An integration context for task extraction
- */
-class TaskExtractionNode : public MetaScheduleContextNode {
- public:
-  /*! \brief The extracted tasks */
-  Array<ExtractedTask> tasks{nullptr};
-
-  void VisitAttrs(AttrVisitor* v) { v->Visit("tasks", &tasks); }
-
-  // Inherited from base class
-  Optional<ObjectRef> Query(runtime::String task_name, IRModule mod, Target target,
-                            Optional<Array<IRModule>> dispatched) final;
-
-  static constexpr const char* _type_key = "meta_schedule.TaskExtraction";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TaskExtractionNode, MetaScheduleContextNode);
-};
-
-/*!
- * \brief Managed reference to TaskExtractionNode
- * \sa TaskExtractionNode
- */
-class TaskExtraction : public MetaScheduleContext {
- public:
-  /*! \brief The path to a cache file storing extracted tasks */
-  TaskExtraction();
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TaskExtraction, MetaScheduleContext,
-                                                    TaskExtractionNode);
 };
 
 /**************** ApplyHistoryBest ****************/
@@ -193,7 +161,7 @@ class ApplyHistoryBestNode : public MetaScheduleContextNode {
   }
 
   // Inherited from base class
-  Optional<ObjectRef> Query(runtime::String task_name, IRModule mod, Target target,
+  IRModule Query(runtime::String task_name, IRModule mod, Target target,
                             Optional<Array<IRModule>> dispatched) final;
 
   static constexpr const char* _type_key = "meta_schedule.ApplyHistoryBest";

--- a/include/tvm/meta_schedule/integration.h
+++ b/include/tvm/meta_schedule/integration.h
@@ -86,11 +86,12 @@ class MetaScheduleContextNode : public runtime::Object {
    * \param target Target info
    * \param dispatched A list of low-level IRs that the high-level IR could potentially dispatch to.
    *                   NullOpt means the dispatch needs to be done in the context.
-   * \return IRModule Currently we only have to return tir::PrimFunc, but we wrap it
-   *                  under IRModule for more general future use.
+   * \return IRModule or NullOpt Currently we only have to return tir::PrimFunc, but we wrap it
+   *                             under IRModule for more general future use. NullOpt is returned
+   *                             if there is no feedback hint.
    */
-  virtual IRModule Query(runtime::String task_name, IRModule mod, Target target,
-                         Optional<Array<IRModule>> dispatched) = 0;
+  virtual Optional<IRModule> Query(runtime::String task_name, IRModule mod, Target target,
+                                   Optional<Array<IRModule>> dispatched) = 0;
 
   static constexpr const char* _type_key = "meta_schedule.MetaScheduleContext";
   TVM_DECLARE_BASE_OBJECT_INFO(MetaScheduleContextNode, runtime::Object);
@@ -120,11 +121,13 @@ class MetaScheduleContext : public runtime::ObjectRef {
    * \param mod The high-level IR
    * \param target Target info
    * \param dispatched A list of low-level IRs that the high-level IR could potentially dispatch to
-   * \return IRModule Currently we only have to return tir::PrimFunc, but we wrap it
-   *                  under IRModule for more general future use.
+   * \return IRModule or NullOpt Currently we only have to return tir::PrimFunc, but we wrap it
+   *                     under IRModule for more general future use. NullOpt is returned
+   *                     if there is no feedback hint
    */
-  static IRModule QueryInsideWithScope(runtime::String task_name, IRModule mod, Target target,
-                                       Optional<Array<IRModule>> dispatched);
+  static Optional<IRModule> QueryInsideWithScope(runtime::String task_name, IRModule mod,
+                                                 Target target,
+                                                 Optional<Array<IRModule>> dispatched);
 
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(MetaScheduleContext, runtime::ObjectRef,
                                                     MetaScheduleContextNode);
@@ -154,8 +157,8 @@ class ApplyHistoryBestNode : public MetaScheduleContextNode {
   }
 
   // Inherited from base class
-  IRModule Query(runtime::String task_name, IRModule mod, Target target,
-                 Optional<Array<IRModule>> dispatched) final;
+  Optional<IRModule> Query(runtime::String task_name, IRModule mod, Target target,
+                           Optional<Array<IRModule>> dispatched) final;
 
   static constexpr const char* _type_key = "meta_schedule.ApplyHistoryBest";
   TVM_DECLARE_FINAL_OBJECT_INFO(ApplyHistoryBestNode, MetaScheduleContextNode);

--- a/include/tvm/meta_schedule/integration.h
+++ b/include/tvm/meta_schedule/integration.h
@@ -86,14 +86,11 @@ class MetaScheduleContextNode : public runtime::Object {
    * \param target Target info
    * \param dispatched A list of low-level IRs that the high-level IR could potentially dispatch to.
    *                   NullOpt means the dispatch needs to be done in the context.
-   * \return There are different types of the output
-   *         1) NullOpt if there is no feedback hint
-   *         2) tir::PrimFunc if `mod` should be lowered to a PrimFunc
-   *         3) relay::Function if `mod` should be dispatched to BYOC workflow
-   *         4) IRModule for unified dispatch
+   * \return IRModule Currently we only have to return tir::PrimFunc, but we wrap it
+   *                  under IRModule for more general future use.
    */
   virtual IRModule Query(runtime::String task_name, IRModule mod, Target target,
-                                    Optional<Array<IRModule>> dispatched) = 0;
+                         Optional<Array<IRModule>> dispatched) = 0;
 
   static constexpr const char* _type_key = "meta_schedule.MetaScheduleContext";
   TVM_DECLARE_BASE_OBJECT_INFO(MetaScheduleContextNode, runtime::Object);
@@ -123,15 +120,11 @@ class MetaScheduleContext : public runtime::ObjectRef {
    * \param mod The high-level IR
    * \param target Target info
    * \param dispatched A list of low-level IRs that the high-level IR could potentially dispatch to
-   * \return There are different types of the output
-   *         1) NullOpt if there is no feedback hint
-   *         2) tir::PrimFunc if `mod` should be lowered to a PrimFunc
-   *         3) relay::Function if `mod` should be dispatched to BYOC workflow
-   *         4) IRModule for unified dispatch
+   * \return IRModule Currently we only have to return tir::PrimFunc, but we wrap it
+   *                  under IRModule for more general future use.
    */
-  static IRModule QueryInsideWithScope(runtime::String task_name, IRModule mod,
-                                                  Target target,
-                                                  Optional<Array<IRModule>> dispatched);
+  static IRModule QueryInsideWithScope(runtime::String task_name, IRModule mod, Target target,
+                                       Optional<Array<IRModule>> dispatched);
 
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(MetaScheduleContext, runtime::ObjectRef,
                                                     MetaScheduleContextNode);
@@ -162,7 +155,7 @@ class ApplyHistoryBestNode : public MetaScheduleContextNode {
 
   // Inherited from base class
   IRModule Query(runtime::String task_name, IRModule mod, Target target,
-                            Optional<Array<IRModule>> dispatched) final;
+                 Optional<Array<IRModule>> dispatched) final;
 
   static constexpr const char* _type_key = "meta_schedule.ApplyHistoryBest";
   TVM_DECLARE_FINAL_OBJECT_INFO(ApplyHistoryBestNode, MetaScheduleContextNode);

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -222,6 +222,7 @@ def extract_task_from_relay(
     for name, param in params.items():
         if isinstance(param, np.ndarray):
             param = nd.array(param)
+        relay_params[name] = param
 
     if disabled_pass is None:
         disabled_pass = []

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -233,6 +233,8 @@ def extract_task_from_relay(
 
     if disabled_pass is None:
         disabled_pass = []
+    if pass_config is None:
+        pass_config = {"relay.backend.use_meta_schedule": True}
 
     if isinstance(mod, RelayFunc):
         mod = IRModule.from_expr(mod)

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -78,7 +78,7 @@ class MetaScheduleContext(Object):
         mod: IRModule,
         target: Target,
         dispatched: Optional[List[IRModule]],
-    ) -> Union[IRModule, RelayFunc, PrimFunc, None]:
+    ) -> IRModule:
         """The entry point of the integration
 
         Parameters
@@ -94,12 +94,9 @@ class MetaScheduleContext(Object):
 
         Returns
         -------
-        result : Union[IRModule, RelayFunc, PrimFunc, None]
-            There are different types of the output:
-            1) NullOpt if there is no feedback hint;
-            2) tir::PrimFunc if `mod` should be lowered to a PrimFunc;
-            3) relay::Function if `mod` should be dispatched to BYOC workflow;
-            4) IRModule for unified dispatch
+        result : IRModule
+            Currently we only have to return tir::PrimFunc, but we wrap it under IRModule for
+            more general future use
         """
         return _ffi_api.MetaScheduleContextQuery(  # type: ignore # pylint: disable=no-member
             self,
@@ -127,7 +124,7 @@ class MetaScheduleContext(Object):
         mod: IRModule,
         target: Target,
         dispatched: Optional[List[IRModule]],
-    ) -> Union[IRModule, RelayFunc, PrimFunc, None]:
+    ) -> IRModule:
         """The entry point of the integration workflow. The compilation process of the high-level
         IR should call this method for task extraction and for feedback hints
 
@@ -138,7 +135,7 @@ class MetaScheduleContext(Object):
             def query_inside_with_scope(task_name, mod, dispatched):
                 ctx = MetaScheduleContext.current()
                 assert ctx is not None
-                ctx.query(task_name, mod, target, dispatched)
+                mod = ctx.query(task_name, mod, target, dispatched)
 
         Parameters
         ----------
@@ -153,12 +150,9 @@ class MetaScheduleContext(Object):
 
         Returns
         -------
-        result : Union[IRModule, RelayFunc, PrimFunc, None]
-            There are different types of the output:
-            1) NullOpt if there is no feedback hint;
-            2) tir::PrimFunc if `mod` should be lowered to a PrimFunc;
-            3) relay::Function if `mod` should be dispatched to BYOC workflow;
-            4) IRModule for unified dispatch
+        result : IRModule
+            Currently we only have to return tir::PrimFunc, but we wrap it under IRModule for
+            more general future use
         """
         return _ffi_api.MetaScheduleContextQueryInsideWithScope(  # type: ignore # pylint: disable=no-member
             task_name,

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -17,7 +17,7 @@
 """Meta schedule integration with high-level IR"""
 from typing import Dict, List, Optional, Union
 
-import numpy as np
+import numpy as np  # type: ignore
 import tvm.runtime.ndarray as nd
 
 from tvm._ffi import register_object, get_global_func

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -77,7 +77,7 @@ class MetaScheduleContext(Object):
         mod: IRModule,
         target: Target,
         dispatched: Optional[List[IRModule]],
-    ) -> IRModule:
+    ) -> Union[IRModule, None]:
         """The entry point of the integration
 
         Parameters
@@ -93,9 +93,9 @@ class MetaScheduleContext(Object):
 
         Returns
         -------
-        result : IRModule
+        result : IRModule or None
             Currently we only have to return tir::PrimFunc, but we wrap it under IRModule for
-            more general future use
+            more general future use. None is returned if there is no feedback hint.
         """
         return _ffi_api.MetaScheduleContextQuery(  # type: ignore # pylint: disable=no-member
             self,
@@ -123,7 +123,7 @@ class MetaScheduleContext(Object):
         mod: IRModule,
         target: Target,
         dispatched: Optional[List[IRModule]],
-    ) -> IRModule:
+    ) -> Union[IRModule, None]:
         """The entry point of the integration workflow. The compilation process of the high-level
         IR should call this method for task extraction and for feedback hints
 
@@ -149,9 +149,9 @@ class MetaScheduleContext(Object):
 
         Returns
         -------
-        result : IRModule
+        result : IRModule or None
             Currently we only have to return tir::PrimFunc, but we wrap it under IRModule for
-            more general future use
+            more general future use. None is returned if there is no feedback hint.
         """
         return _ffi_api.MetaScheduleContextQueryInsideWithScope(  # type: ignore # pylint: disable=no-member
             task_name,

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Meta schedule integration with high-level IR"""
-from contextlib import contextmanager
-from typing import Callable, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import tvm.runtime.ndarray as nd
@@ -25,7 +24,6 @@ from tvm._ffi import register_object, get_global_func
 from tvm.ir import IRModule, transform
 from tvm.relay import Any, const
 from tvm.relay import Function as RelayFunc
-from tvm.relay import vm
 from tvm.runtime import NDArray, Object
 from tvm.target import Target
 from tvm.tir import PrimFunc

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -26,7 +26,6 @@ from tvm.relay import Any, const
 from tvm.relay import Function as RelayFunc
 from tvm.runtime import NDArray, Object
 from tvm.target import Target
-from tvm.tir import PrimFunc
 
 from . import _ffi_api
 from .database import Database

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -22,7 +22,7 @@ import tvm.runtime.ndarray as nd
 
 from tvm._ffi import register_object, get_global_func
 from tvm.ir import IRModule, transform
-from tvm.relay import Any, const
+from tvm.relay import Any
 from tvm.relay import Function as RelayFunc
 from tvm.runtime import NDArray, Object
 from tvm.target import Target
@@ -222,7 +222,6 @@ def extract_task_from_relay(
     for name, param in params.items():
         if isinstance(param, np.ndarray):
             param = nd.array(param)
-        relay_params[name] = const(param)
 
     if disabled_pass is None:
         disabled_pass = []

--- a/python/tvm/topi/x86/batch_matmul.py
+++ b/python/tvm/topi/x86/batch_matmul.py
@@ -47,7 +47,7 @@ def batch_matmul_vnni_compute(cfg, x, y):
             axis=ak,
         ),
         tag="batch_matmul_vnni",
-        attrs={"schedule_rule": "batch_matmul_vnni"},
+        attrs={"schedule_rule": "meta_schedule.batch_matmul_vnni"},
     )
 
     _, a_y, _ = z.op.axis

--- a/python/tvm/topi/x86/batch_matmul.py
+++ b/python/tvm/topi/x86/batch_matmul.py
@@ -47,6 +47,7 @@ def batch_matmul_vnni_compute(cfg, x, y):
             axis=ak,
         ),
         tag="batch_matmul_vnni",
+        attrs={"schedule_rule": "batch_matmul_vnni"},
     )
 
     _, a_y, _ = z.op.axis

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -296,7 +296,7 @@ def dense_vnni_compute(cfg, X, packed_w, bias=None):
             axis=ak,
         ),
         tag="dense_vnni",
-        attrs={"schedule_rule": "dense_vnni"},
+        attrs={"schedule_rule": "meta_schedule.dense_vnni"},
     )
 
     if bias is not None:

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -296,6 +296,7 @@ def dense_vnni_compute(cfg, X, packed_w, bias=None):
             axis=ak,
         ),
         tag="dense_vnni",
+        attrs={"schedule_rule": "dense_vnni"},
     )
 
     if bias is not None:

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -26,9 +26,8 @@ namespace tvm {
 namespace meta_schedule {
 
 /**************** Utility functions ****************/
-
-template <class FunctionType>
-Optional<FunctionType> GetOnlyOneFunction(const IRModule& mod) {
+template <class FunctionType, class RetType, class Callback>
+Optional<RetType> GetOnlyOneFunctionCommon(const IRModule& mod, Callback on_found) {
   if (mod->functions.size() != 1) {
     return NullOpt;
   }
@@ -37,10 +36,21 @@ Optional<FunctionType> GetOnlyOneFunction(const IRModule& mod) {
     if (!func->IsInstance<typename FunctionType::ContainerType>()) {
       return NullOpt;
     } else {
-      return Downcast<FunctionType>(func);
+      return on_found(kv);
     }
   }
   return NullOpt;
+}
+
+template <class FunctionType>
+Optional<GlobalVar> GetOnlyOneFunctionKey(const IRModule& mod) {
+  return GetOnlyOneFunctionCommon<FunctionType, GlobalVar>(mod, [](auto kv) { return kv.first; });
+}
+
+template <class FunctionType>
+Optional<FunctionType> GetOnlyOneFunction(const IRModule& mod) {
+  return GetOnlyOneFunctionCommon<FunctionType, FunctionType>(
+      mod, [](auto kv) { return Downcast<FunctionType>(kv.second); });
 }
 
 template <class FunctionType>
@@ -86,31 +96,13 @@ void MetaScheduleContext::ExitWithScope() {
   ctx = NullOpt;
 }
 
-Optional<ObjectRef> MetaScheduleContext::QueryInsideWithScope(
-    runtime::String task_name, IRModule mod, Target target, Optional<Array<IRModule>> dispatched) {
+IRModule MetaScheduleContext::QueryInsideWithScope(runtime::String task_name, IRModule mod,
+                                                   Target target,
+                                                   Optional<Array<IRModule>> dispatched) {
   if (Optional<MetaScheduleContext> ctx = MetaScheduleContext::Current()) {
     return ctx.value()->Query(task_name, mod, target, dispatched);
   }
-  return NullOpt;
-}
-
-/**************** TaskExtraction ****************/
-
-TaskExtraction::TaskExtraction() {
-  ObjectPtr<TaskExtractionNode> n = make_object<TaskExtractionNode>();
-  n->tasks = Array<ExtractedTask>();
-  data_ = n;
-}
-
-Optional<ObjectRef> TaskExtractionNode::Query(runtime::String task_name, IRModule mod,
-                                              Target target, Optional<Array<IRModule>> dispatched) {
-  ICHECK(dispatched.defined());
-  ICHECK_EQ(dispatched.value().size(), 1);
-  IRModule prim_mod = dispatched.value()[0];
-  ICHECK(HasOnlyOneFunction<tir::PrimFunc>(prim_mod)) << prim_mod;
-  ICHECK(HasOnlyOneFunction<relay::Function>(mod)) << mod;
-  tasks.push_back(ExtractedTask(task_name, mod, target, {prim_mod}));
-  return NullOpt;
+  return IRModule{nullptr};
 }
 
 /**************** ApplyHistoryBest ****************/
@@ -121,14 +113,18 @@ ApplyHistoryBest::ApplyHistoryBest(Database database) {
   data_ = n;
 }
 
-Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod,
-                                                Target target,
-                                                Optional<Array<IRModule>> dispatched) {
+IRModule ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Target target,
+                                     Optional<Array<IRModule>> dispatched) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);
   ICHECK(HasOnlyOneFunction<relay::Function>(mod)) << mod;
   IRModule prim_mod = dispatched.value()[0];
   ICHECK(HasOnlyOneFunction<tir::PrimFunc>(prim_mod)) << prim_mod;
+  // TODO(masahi): parse_mod below replaces the orginal function key with "main".
+  // This is necessary because some scheduling primitives requires the PrimFunc key be "main".
+  // If we can remove this restriction, there would no need for GetOnlyOneFunction* calls below
+  // and we can directly return sch->mod().
+  auto gv = GetOnlyOneFunctionKey<tir::PrimFunc>(prim_mod).value();
   // Unify func name to make sure it can be found in database
   const auto* parse_mod_func = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
   ICHECK(parse_mod_func) << "Parse mod function not defined!";
@@ -141,11 +137,11 @@ Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRMod
                                 /*error_render_level=*/tir::ScheduleErrorRenderLevel::kNone);
       records[0]->trace->ApplyToSchedule(sch, false);
       tir::PrimFunc func = GetOnlyOneFunction<tir::PrimFunc>(sch->mod()).value();
-      return func;
+      return IRModule({{gv, func}});
     }
   }
   LOG(WARNING) << "Cannot find workload: " << task_name << "\n" << tir::AsTVMScript(prim_mod);
-  return NullOpt;
+  return IRModule{nullptr};
 }
 
 /**************** FFI ****************/
@@ -158,7 +154,6 @@ class MetaScheduleContextInternal {
 
 TVM_REGISTER_NODE_TYPE(ExtractedTaskNode);
 TVM_REGISTER_OBJECT_TYPE(MetaScheduleContextNode);
-TVM_REGISTER_NODE_TYPE(TaskExtractionNode);
 TVM_REGISTER_NODE_TYPE(ApplyHistoryBestNode);
 
 TVM_REGISTER_GLOBAL("meta_schedule.ExtractedTask")
@@ -176,9 +171,6 @@ TVM_REGISTER_GLOBAL("meta_schedule.MetaScheduleContextQueryInsideWithScope")
     .set_body_typed(MetaScheduleContext::QueryInsideWithScope);
 TVM_REGISTER_GLOBAL("meta_schedule.MetaScheduleContextQuery")
     .set_body_method<MetaScheduleContext>(&MetaScheduleContextNode::Query);
-TVM_REGISTER_GLOBAL("meta_schedule.TaskExtraction").set_body_typed([]() -> TaskExtraction {
-  return TaskExtraction();
-});
 TVM_REGISTER_GLOBAL("meta_schedule.ApplyHistoryBest")
     .set_body_typed([](Database database) -> ApplyHistoryBest {
       return ApplyHistoryBest(database);

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -21,6 +21,7 @@
 #include <tvm/tir/function.h>
 
 #include "./utils.h"
+#include "tvm/runtime/container/optional.h"
 
 namespace tvm {
 namespace meta_schedule {
@@ -96,13 +97,13 @@ void MetaScheduleContext::ExitWithScope() {
   ctx = NullOpt;
 }
 
-IRModule MetaScheduleContext::QueryInsideWithScope(runtime::String task_name, IRModule mod,
-                                                   Target target,
-                                                   Optional<Array<IRModule>> dispatched) {
+Optional<IRModule> MetaScheduleContext::QueryInsideWithScope(runtime::String task_name,
+                                                             IRModule mod, Target target,
+                                                             Optional<Array<IRModule>> dispatched) {
   if (Optional<MetaScheduleContext> ctx = MetaScheduleContext::Current()) {
     return ctx.value()->Query(task_name, mod, target, dispatched);
   }
-  return IRModule{nullptr};
+  return NullOpt;
 }
 
 /**************** ApplyHistoryBest ****************/
@@ -113,8 +114,9 @@ ApplyHistoryBest::ApplyHistoryBest(Database database) {
   data_ = n;
 }
 
-IRModule ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Target target,
-                                     Optional<Array<IRModule>> dispatched) {
+Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod,
+                                               Target target,
+                                               Optional<Array<IRModule>> dispatched) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);
   ICHECK(HasOnlyOneFunction<relay::Function>(mod)) << mod;
@@ -149,7 +151,7 @@ IRModule ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Ta
   }
   LOG(WARNING) << "Cannot find workload: " << task_name;
   DLOG(INFO) << tir::AsTVMScript(prim_mod);
-  return IRModule{nullptr};
+  return NullOpt;
 }
 
 /**************** FFI ****************/

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -140,7 +140,8 @@ IRModule ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Ta
       return IRModule({{gv, func}});
     }
   }
-  LOG(WARNING) << "Cannot find workload: " << task_name << "\n" << tir::AsTVMScript(prim_mod);
+  LOG(WARNING) << "Cannot find workload: " << task_name;
+  DLOG(INFO) << tir::AsTVMScript(prim_mod);
   return IRModule{nullptr};
 }
 

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -123,12 +123,6 @@ Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModu
   IRModule prim_mod = dispatched.value()[0];
   ICHECK(HasOnlyOneFunction<tir::PrimFunc>(prim_mod)) << prim_mod;
 
-  // TODO(masahi): parse_mod below replaces the original function key with "main".
-  // This is necessary because, in practice, most uses of the scheduling primitive "get_block"
-  // assume that the function name is "main".
-  // If we do not have this requirement, we can remove the call to parse_mod and
-  // GetOnlyOneFunction* calls below and instead we can directly return sch->mod().
-
   // Keep the original func name to be returned later.
   GlobalVar gv = GetOnlyOneFunctionKey<tir::PrimFunc>(prim_mod).value();
 

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -124,7 +124,7 @@ IRModule ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Ta
   // This is necessary because some scheduling primitives requires the PrimFunc key be "main".
   // If we can remove this restriction, there would no need for GetOnlyOneFunction* calls below
   // and we can directly return sch->mod().
-  auto gv = GetOnlyOneFunctionKey<tir::PrimFunc>(prim_mod).value();
+  GlobalVar gv = GetOnlyOneFunctionKey<tir::PrimFunc>(prim_mod).value();
   // Unify func name to make sure it can be found in database
   const auto* parse_mod_func = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
   ICHECK(parse_mod_func) << "Parse mod function not defined!";

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -121,9 +121,9 @@ IRModule ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod, Ta
   IRModule prim_mod = dispatched.value()[0];
   ICHECK(HasOnlyOneFunction<tir::PrimFunc>(prim_mod)) << prim_mod;
 
-  // TODO(masahi): parse_mod below replaces the orginal function key with "main".
-  // This is necessary because, in practice, most use of the scheduling primitive "get_block"
-  // assumes that the function name is "main".
+  // TODO(masahi): parse_mod below replaces the original function key with "main".
+  // This is necessary because, in practice, most uses of the scheduling primitive "get_block"
+  // assume that the function name is "main".
   // If we do not have this requirement, we can remove the call to parse_mod and
   // GetOnlyOneFunction* calls below and instead we can directly return sch->mod().
 

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -333,14 +333,7 @@ class RelayBuildModule : public runtime::ModuleNode {
   IRModule OptimizeImpl(IRModule relay_module) {
     ICHECK(relay_module.defined()) << "The IRModule must be defined for the Relay compiler.";
 
-    if (!params_.empty()) {
-      ICHECK(relay_module->ContainGlobalVar("main")) << "Missing the main entry function";
-      GlobalVar main_glb_var = relay_module->GetGlobalVar("main");
-      Function main_func = Downcast<Function>(relay_module->Lookup(main_glb_var));
-      auto new_main = BindParamsByName(main_func, params_);
-      IRModuleNode* relay_module_ptr = relay_module.CopyOnWrite();
-      relay_module_ptr->Update(main_glb_var, new_main);
-    }
+    backend::BindParamsInModule(relay_module, params_);
 
     Array<Pass> pass_seqs = GetPassPrefix(
         /*is_homogenous=*/config_->optional_homogeneous_target.defined(), /*is_vm=*/false);

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -54,10 +54,10 @@ Array<ExtractedTask> ExtractTask(IRModule mod, Target target, Map<String, Consta
       Function relay_func = Downcast<Function>(exp);
       tec::CCacheKey cache_key(relay_func, target);
       if (relay_func->HasNonzeroAttr(attr::kPrimitive) && cache.find(cache_key) == cache.end()) {
-        Array<te::Tensor> outputs;
+        Array<te::Tensor> inputs_outputs;
         std::string fused_name;
-        std::tie(outputs, fused_name) =
-            tec::LowerTECompute(relay_func, target, /*return_inputs*/ true);
+        std::tie(inputs_outputs, fused_name) =
+            tec::LowerTECompute(relay_func, target, /*return_inputs=*/true);
         auto prim_func = tir::CreatePrimFunc(outputs);
         auto prim_fn_var = GlobalVar(fused_name);
         auto relay_mod = IRModule({{prim_fn_var, relay_func}});

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -61,9 +61,9 @@ Array<ExtractedTask> ExtractTask(IRModule mod, Target target,
         std::tie(inputs_outputs, fused_name) =
             tec::LowerTECompute(relay_func, target, /*return_inputs=*/true);
         auto prim_func = tir::CreatePrimFunc(inputs_outputs);
-        auto prim_fn_var = GlobalVar(fused_name);
-        auto relay_mod = IRModule({{prim_fn_var, relay_func}});
-        auto tir_mod = IRModule({{prim_fn_var, prim_func}});
+        GlobalVar prim_fn_var(fused_name);
+        IRModule relay_mod({{prim_fn_var, relay_func}});
+        IRModule tir_mod({{prim_fn_var, prim_func}});
         auto task_name = tec::GetUniqueName(fused_name, &name_map);
         tasks.push_back(ExtractedTask(task_name, relay_mod, target, {tir_mod}));
         cache.insert(cache_key);

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -58,7 +58,7 @@ Array<ExtractedTask> ExtractTask(IRModule mod, Target target, Map<String, Consta
         std::string fused_name;
         std::tie(inputs_outputs, fused_name) =
             tec::LowerTECompute(relay_func, target, /*return_inputs=*/true);
-        auto prim_func = tir::CreatePrimFunc(outputs);
+        auto prim_func = tir::CreatePrimFunc(inputs_outputs);
         auto prim_fn_var = GlobalVar(fused_name);
         auto relay_mod = IRModule({{prim_fn_var, relay_func}});
         auto tir_mod = IRModule({{prim_fn_var, prim_func}});

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/meta_schedule/integration.h>
+#include <tvm/relay/expr.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/function.h>
+#include <tvm/target/target.h>
+
+#include "../../te/operation/create_primfunc.h"
+#include "te_compiler_cache.h"
+#include "utils.h"
+
+namespace tvm {
+namespace relay {
+namespace backend {
+
+namespace metaschedule {
+
+using meta_schedule::ExtractedTask;
+
+Array<ExtractedTask> ExtractTask(IRModule mod, Target target, Map<String, Constant> params) {
+  backend::BindParamsInModule(mod, params);
+
+  // is_vm=true for backward compatibility
+  Array<Pass> pass_seqs = relay::backend::GetPassPrefix(/*is_homogenous=*/true, /*is_vm=*/true);
+  pass_seqs.push_back(transform::FuseOps());
+
+  transform::Sequential seq(pass_seqs);
+  auto opt_mod = seq(std::move(mod));
+
+  Array<ExtractedTask> tasks;
+  std::unordered_set<tec::CCacheKey> cache_;
+  std::unordered_map<std::string, int> name_map;
+
+  PostOrderVisit(opt_mod->Lookup("main"), [target, &tasks, &cache_, &name_map](const Expr& exp) {
+    if (exp->IsInstance<FunctionNode>()) {
+      Function relay_func = Downcast<Function>(exp);
+      tec::CCacheKey cache_key(relay_func, target);
+      if (relay_func->HasNonzeroAttr(attr::kPrimitive) && cache_.find(cache_key) == cache_.end()) {
+        Array<te::Tensor> outputs;
+        std::string fused_name;
+        std::tie(outputs, fused_name) =
+            tec::LowerTECompute(relay_func, target, /*return_inputs*/ true);
+        auto prim_func = tir::CreatePrimFunc(outputs);
+        auto prim_fn_var = GlobalVar(fused_name);
+        auto relay_mod = IRModule({{prim_fn_var, relay_func}});
+        auto tir_mod = IRModule({{prim_fn_var, prim_func}});
+        auto task_name = tec::GetUniqueName(fused_name, &name_map);
+        tasks.push_back(ExtractedTask(task_name, relay_mod, target, {tir_mod}));
+        cache_.insert(cache_key);
+      }
+    }
+  });
+
+  return tasks;
+}
+
+}  // namespace metaschedule
+
+TVM_REGISTER_GLOBAL("relay.backend.MetaScheduleExtractTask")
+    .set_body_typed([](IRModule mod, Target target, Map<String, Constant> params) {
+      return metaschedule::ExtractTask(mod, target, params);
+    });
+
+}  // namespace backend
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -25,6 +25,7 @@
 
 #include "../../te/operation/create_primfunc.h"
 #include "te_compiler_cache.h"
+#include "tvm/runtime/ndarray.h"
 #include "utils.h"
 
 namespace tvm {
@@ -35,7 +36,8 @@ namespace metaschedule {
 
 using meta_schedule::ExtractedTask;
 
-Array<ExtractedTask> ExtractTask(IRModule mod, Target target, Map<String, Constant> params) {
+Array<ExtractedTask> ExtractTask(IRModule mod, Target target,
+                                 Map<String, runtime::NDArray> params) {
   backend::BindParamsInModule(mod, params);
 
   // is_vm=true for backward compatibility
@@ -75,7 +77,7 @@ Array<ExtractedTask> ExtractTask(IRModule mod, Target target, Map<String, Consta
 }  // namespace metaschedule
 
 TVM_REGISTER_GLOBAL("relay.backend.MetaScheduleExtractTask")
-    .set_body_typed([](IRModule mod, Target target, Map<String, Constant> params) {
+    .set_body_typed([](IRModule mod, Target target, Map<String, runtime::NDArray> params) {
       return metaschedule::ExtractTask(mod, target, params);
     });
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -337,11 +337,11 @@ class ScheduleBuilder : public ExprVisitor {
       if (backend::IsMetaScheduleEnabled()) {
         IRModule relay_mod({{prim_fn_var, relay_func}});
         IRModule tir_mod({{prim_fn_var, tir::CreatePrimFunc(Concat(fn_inputs, tensor_outs))}});
-        IRModule scheduled_mod = meta_schedule::MetaScheduleContext::QueryInsideWithScope(
+        Optional<IRModule> scheduled_mod = meta_schedule::MetaScheduleContext::QueryInsideWithScope(
             prim_fn_var->name_hint, relay_mod, target_, Array<IRModule>{tir_mod});
-        if (scheduled_mod.defined()) {
-          ICHECK_EQ(scheduled_mod->functions.count(prim_fn_var), 1);
-          prim_func = Downcast<tir::PrimFunc>(scheduled_mod->functions[prim_fn_var]);
+        if (scheduled_mod) {
+          ICHECK_EQ(scheduled_mod.value()->functions.count(prim_fn_var), 1);
+          prim_func = Downcast<tir::PrimFunc>(scheduled_mod.value()->functions[prim_fn_var]);
         }
       }
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -47,7 +47,6 @@
 #include "../../te/operation/create_primfunc.h"
 #include "../op/memory/memory.h"
 #include "../transforms/pass_utils.h"
-#include "tvm/runtime/object.h"
 #include "utils.h"
 
 namespace tvm {
@@ -756,7 +755,8 @@ CachedFunc ShapeFuncFor(const Function& prim_func, const Target& target,
 std::pair<Array<te::Tensor>, std::string> LowerTECompute(const Function& source_func, Target target,
                                                          bool return_inputs) {
   LowerToTECompute lower_te_compute(target);
-  Array<te::Tensor> outputs = lower_te_compute.Lower(source_func, [&](std::string name) { return name; });
+  Array<te::Tensor> outputs =
+      lower_te_compute.Lower(source_func, [](std::string name) { return name; });
   // Following ScheduleBuilder, remove placeholder ops from outputs.
   tvm::Array<te::Tensor> tensor_outs;
   for (const auto& tensor : outputs) {

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -336,9 +336,8 @@ class ScheduleBuilder : public ExprVisitor {
         }
       }
       if (backend::IsMetaScheduleEnabled()) {
-        auto relay_mod = IRModule({{prim_fn_var, relay_func}});
-        auto tir_mod =
-            IRModule({{prim_fn_var, tir::CreatePrimFunc(Concat(fn_inputs, tensor_outs))}});
+        IRModule relay_mod({{prim_fn_var, relay_func}});
+        IRModule tir_mod({{prim_fn_var, tir::CreatePrimFunc(Concat(fn_inputs, tensor_outs))}});
         IRModule scheduled_mod = meta_schedule::MetaScheduleContext::QueryInsideWithScope(
             prim_fn_var->name_hint, relay_mod, target_, Array<IRModule>{tir_mod});
         if (scheduled_mod.defined()) {
@@ -757,7 +756,7 @@ CachedFunc ShapeFuncFor(const Function& prim_func, const Target& target,
 std::pair<Array<te::Tensor>, std::string> LowerTECompute(const Function& source_func, Target target,
                                                          bool return_inputs) {
   LowerToTECompute lower_te_compute(target);
-  auto outputs = lower_te_compute.Lower(source_func, [&](std::string name) { return name; });
+  Array<te::Tensor> outputs = lower_te_compute.Lower(source_func, [&](std::string name) { return name; });
   // Following ScheduleBuilder, remove placeholder ops from outputs.
   tvm::Array<te::Tensor> tensor_outs;
   for (const auto& tensor : outputs) {

--- a/src/relay/backend/te_compiler_cache.h
+++ b/src/relay/backend/te_compiler_cache.h
@@ -37,6 +37,7 @@
 #include <functional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "../transforms/infer_layout_utils.h"
 
@@ -203,6 +204,16 @@ class CCacheValue : public ObjectRef {
 };
 
 Array<IndexExpr> GetShape(const Array<IndexExpr>& shape);
+
+/*!
+ * \brief Lowers Relay primitive Function to TE Compute
+ * \param source_func The primitive function to be lowered.
+ * \param target The target we want to create schedule for.
+ * \param return_inputs If true, prepend input tensors to the output array of tensors.
+ * \return Pair of schedule and fused function name.
+ */
+std::pair<Array<te::Tensor>, std::string> LowerTECompute(const Function& source_func, Target target,
+                                                         bool return_inputs = true);
 
 /*!
  * \brief Create schedule for target.

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -308,6 +308,56 @@ std::vector<int64_t> ShapeToJSON(tvm::Array<IndexExpr> shape) {
   return ret;
 }
 
+relay::Function BindParamsByName(relay::Function func,
+                                 const std::unordered_map<std::string, runtime::NDArray>& params) {
+  std::unordered_map<std::string, relay::Var> name_dict;
+  std::unordered_set<relay::Var, ObjectPtrHash, ObjectPtrEqual> repeat_var;
+  for (auto arg : func->params) {
+    const auto& name = arg->name_hint();
+    if (name_dict.count(name)) {
+      repeat_var.insert(name_dict[name]);
+    } else {
+      name_dict[name] = arg;
+    }
+  }
+
+  std::unordered_map<relay::Var, Expr, ObjectPtrHash, ObjectPtrEqual> bind_dict;
+  for (auto& kv : params) {
+    if (name_dict.count(kv.first) == 0) {
+      continue;
+    }
+    auto arg = name_dict.at(kv.first);
+    if (repeat_var.count(arg)) {
+      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
+    }
+    bind_dict[arg] = Constant(kv.second);
+  }
+  Expr bound_expr = relay::Bind(func, bind_dict);
+  Function ret = Downcast<Function>(bound_expr);
+  ICHECK(ret.defined()) << "The returning type is expected to be a Relay Function."
+                        << "\n";
+  return ret;
+}
+
+void BindParamsInModule(IRModule mod,
+                        const std::unordered_map<std::string, runtime::NDArray>& params) {
+  if (!params.empty()) {
+    BaseFunc base_func = mod->Lookup("main");
+    ICHECK(base_func->IsInstance<FunctionNode>());
+    auto f = relay::backend::BindParamsByName(Downcast<Function>(base_func), params);
+    auto gvar = mod->GetGlobalVar("main");
+    mod->Add(gvar, f);
+  }
+}
+
+void BindParamsInModule(IRModule mod, Map<String, Constant> params) {
+  std::unordered_map<std::string, runtime::NDArray> params_tmp;
+  for (const auto& kv : params) {
+    params_tmp[kv.first] = kv.second->data;
+  }
+  BindParamsInModule(mod, params_tmp);
+}
+
 }  // namespace backend
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -29,6 +29,7 @@
 #include <tvm/relay/qnn/transform.h>
 
 #include "te_compiler.h"
+#include "tvm/runtime/ndarray.h"
 
 namespace tvm {
 namespace relay {
@@ -350,10 +351,10 @@ void BindParamsInModule(IRModule mod,
   }
 }
 
-void BindParamsInModule(IRModule mod, Map<String, Constant> params) {
+void BindParamsInModule(IRModule mod, Map<String, runtime::NDArray> params) {
   std::unordered_map<std::string, runtime::NDArray> params_tmp;
   for (const auto& kv : params) {
-    params_tmp[kv.first] = kv.second->data;
+    params_tmp[kv.first] = kv.second;
   }
   BindParamsInModule(mod, params_tmp);
 }

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -46,6 +46,7 @@
 
 #include "../../runtime/meta_data.h"
 #include "../../target/metadata.h"
+#include "tvm/runtime/ndarray.h"
 
 namespace tvm {
 namespace relay {
@@ -397,7 +398,7 @@ relay::Function BindParamsByName(relay::Function func,
 void BindParamsInModule(IRModule mod,
                         const std::unordered_map<std::string, runtime::NDArray>& params);
 
-void BindParamsInModule(IRModule mod, Map<String, Constant> params);
+void BindParamsInModule(IRModule mod, Map<String, runtime::NDArray> params);
 
 /*!
  * \brief Extract the shape from a Relay tensor type.

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -386,36 +386,18 @@ inline std::string DType2String(const tvm::DataType dtype) {
  * \param params params dict
  * \return relay::Function
  */
-inline relay::Function BindParamsByName(
-    relay::Function func, const std::unordered_map<std::string, runtime::NDArray>& params) {
-  std::unordered_map<std::string, relay::Var> name_dict;
-  std::unordered_set<relay::Var, ObjectPtrHash, ObjectPtrEqual> repeat_var;
-  for (auto arg : func->params) {
-    const auto& name = arg->name_hint();
-    if (name_dict.count(name)) {
-      repeat_var.insert(name_dict[name]);
-    } else {
-      name_dict[name] = arg;
-    }
-  }
+relay::Function BindParamsByName(relay::Function func,
+                                 const std::unordered_map<std::string, runtime::NDArray>& params);
 
-  std::unordered_map<relay::Var, Expr, ObjectPtrHash, ObjectPtrEqual> bind_dict;
-  for (auto& kv : params) {
-    if (name_dict.count(kv.first) == 0) {
-      continue;
-    }
-    auto arg = name_dict.at(kv.first);
-    if (repeat_var.count(arg)) {
-      LOG(FATAL) << "Multiple args in the function have name " << kv.first;
-    }
-    bind_dict[arg] = Constant(kv.second);
-  }
-  Expr bound_expr = relay::Bind(func, bind_dict);
-  Function ret = Downcast<Function>(bound_expr);
-  ICHECK(ret.defined()) << "The returning type is expected to be a Relay Function."
-                        << "\n";
-  return ret;
-}
+/*!
+ * \brief Bind params to the main function in Relay module, using BindParamsByName
+ * \param mod Relay module
+ * \param params params dict
+ */
+void BindParamsInModule(IRModule mod,
+                        const std::unordered_map<std::string, runtime::NDArray>& params);
+
+void BindParamsInModule(IRModule mod, Map<String, Constant> params);
 
 /*!
  * \brief Extract the shape from a Relay tensor type.

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -1034,14 +1034,7 @@ IRModule VMCompiler::OptimizeModule(IRModule mod, const TargetMap& targets,
 
 IRModule VMCompiler::OptimizeModuleImpl(IRModule mod) {
   VLOG_CONTEXT << "VM Optimize";
-  if (params_.size()) {
-    BaseFunc base_func = mod->Lookup("main");
-    ICHECK(base_func->IsInstance<FunctionNode>())
-        << "VM compiler expects to compile relay::Function";
-    auto f = relay::backend::BindParamsByName(Downcast<Function>(base_func), params_);
-    auto gvar = mod->GetGlobalVar("main");
-    mod->Add(gvar, f);
-  }
+  backend::BindParamsInModule(mod, params_);
 
   Array<Pass> pass_seqs = relay::backend::GetPassPrefix(
       /*is_homogenous=*/config_->optional_homogeneous_target.defined(), /*is_vm=*/true);

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -62,6 +62,10 @@ def _has_torch():
 requires_torch = pytest.mark.skipif(not _has_torch(), reason="torch is not installed")
 
 
+def test_meta_schedule_integration_no_current():
+    assert MetaScheduleContext.current() is None
+
+
 @requires_torch
 def test_meta_schedule_integration_extract_from_resnet():
     mod, params, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
@@ -69,24 +73,24 @@ def test_meta_schedule_integration_extract_from_resnet():
     expected_task_names = [
         "fused_" + s
         for s in [
-            "nn_conv2d_add_2",
-            "nn_conv2d_add_1",
-            "nn_conv2d_add",
-            "nn_conv2d_add_nn_relu_7",
             "nn_max_pool2d",
-            "nn_conv2d_add_nn_relu_6",
-            "nn_conv2d_add_add_nn_relu_3",
-            "nn_conv2d_add_nn_relu_5",
-            "nn_conv2d_add_nn_relu_4",
-            "nn_conv2d_add_add_nn_relu_2",
-            "nn_conv2d_add_nn_relu_3",
-            "nn_conv2d_add_nn_relu_2",
-            "nn_conv2d_add_add_nn_relu_1",
-            "nn_conv2d_add_nn_relu_1",
-            "nn_conv2d_add_nn_relu",
-            "nn_conv2d_add_add_nn_relu",
             "nn_adaptive_avg_pool2d",
-            "nn_contrib_dense_pack_add",
+            "nn_dense_add",
+            "nn_conv2d_add",
+            "nn_conv2d_add_1",
+            "nn_conv2d_add_2",
+            "nn_conv2d_add_add_nn_relu",
+            "nn_conv2d_add_add_nn_relu_1",
+            "nn_conv2d_add_nn_relu",
+            "nn_conv2d_add_nn_relu_1",
+            "nn_conv2d_add_nn_relu_2",
+            "nn_conv2d_add_nn_relu_3",
+            "nn_conv2d_add_nn_relu_4",
+            "nn_conv2d_add_nn_relu_5",
+            "nn_contrib_conv2d_winograd_without_weight_transform_add_add_nn_relu",
+            "nn_contrib_conv2d_winograd_without_weight_transform_add_add_nn_relu_1",
+            "nn_contrib_conv2d_winograd_without_weight_transform_add_nn_relu",
+            "nn_contrib_conv2d_winograd_without_weight_transform_add_nn_relu_1",
             # The two tasks below are purely spatial and are ruled out by AutoScheduler
             "layout_transform",
             "layout_transform_reshape_squeeze",

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -26,7 +26,6 @@ from tvm.meta_schedule.integration import (
     ApplyHistoryBest,
     ExtractedTask,
     MetaScheduleContext,
-    TaskExtraction,
 )
 from tvm.meta_schedule.testing.relay_workload import get_network
 from tvm.meta_schedule.utils import derived_object
@@ -63,80 +62,31 @@ def _has_torch():
 requires_torch = pytest.mark.skipif(not _has_torch(), reason="torch is not installed")
 
 
-def _check_mock_task(tasks: List[ExtractedTask], mod: IRModule):
-    (task,) = tasks
-    assert isinstance(task, ExtractedTask)
-    assert task.task_name == "mock-task"
-    tvm.ir.assert_structural_equal(task.mod, mod)
-    (tir_mod,) = task.dispatched
-    tvm.ir.assert_structural_equal(tir_mod, MockModule)
-
-
-@requires_torch
-def test_meta_schedule_integration_task_extraction_query():
-    mod, _, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
-    env = TaskExtraction()
-    env.query(task_name="mock-task", mod=mod, target=Target("llvm"), dispatched=[MockModule])
-    _check_mock_task(env.tasks, mod)
-
-
-def test_meta_schedule_integration_current():
-    env = TaskExtraction()
-    with env:
-        assert MetaScheduleContext.current() == env
-
-
-def test_meta_schedule_integration_no_current():
-    assert MetaScheduleContext.current() is None
-
-
-def test_meta_schedule_integration_multiple_current():
-    env = TaskExtraction()
-    with env:
-        with pytest.raises(ValueError):
-            with env:
-                ...
-
-
-@requires_torch
-def test_meta_schedule_integration_query_inside_with_scope():
-    mod, _, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
-    env = TaskExtraction()
-    with env:
-        MetaScheduleContext.query_inside_with_scope(
-            task_name="mock-task",
-            mod=mod,
-            target=Target("llvm"),
-            dispatched=[MockModule],
-        )
-    _check_mock_task(env.tasks, mod)
-
-
 @requires_torch
 def test_meta_schedule_integration_extract_from_resnet():
     mod, params, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
     extracted_tasks = ms.integration.extract_task_from_relay(mod, target="llvm", params=params)
     expected_task_names = [
-        "vm_mod_fused_" + s
+        "fused_" + s
         for s in [
-            "nn_max_pool2d",
-            "nn_adaptive_avg_pool2d",
-            "nn_dense_add",
-            "nn_conv2d_add",
-            "nn_conv2d_add_1",
             "nn_conv2d_add_2",
-            "nn_conv2d_add_add_nn_relu",
-            "nn_conv2d_add_add_nn_relu_1",
-            "nn_conv2d_add_nn_relu",
-            "nn_conv2d_add_nn_relu_1",
-            "nn_conv2d_add_nn_relu_2",
-            "nn_conv2d_add_nn_relu_3",
-            "nn_conv2d_add_nn_relu_4",
+            "nn_conv2d_add_1",
+            "nn_conv2d_add",
+            "nn_conv2d_add_nn_relu_7",
+            "nn_max_pool2d",
+            "nn_conv2d_add_nn_relu_6",
+            "nn_conv2d_add_add_nn_relu_3",
             "nn_conv2d_add_nn_relu_5",
-            "nn_contrib_conv2d_winograd_without_weight_transform_add_add_nn_relu",
-            "nn_contrib_conv2d_winograd_without_weight_transform_add_add_nn_relu_1",
-            "nn_contrib_conv2d_winograd_without_weight_transform_add_nn_relu",
-            "nn_contrib_conv2d_winograd_without_weight_transform_add_nn_relu_1",
+            "nn_conv2d_add_nn_relu_4",
+            "nn_conv2d_add_add_nn_relu_2",
+            "nn_conv2d_add_nn_relu_3",
+            "nn_conv2d_add_nn_relu_2",
+            "nn_conv2d_add_add_nn_relu_1",
+            "nn_conv2d_add_nn_relu_1",
+            "nn_conv2d_add_nn_relu",
+            "nn_conv2d_add_add_nn_relu",
+            "nn_adaptive_avg_pool2d",
+            "nn_contrib_dense_pack_add",
             # The two tasks below are purely spatial and are ruled out by AutoScheduler
             "layout_transform",
             "layout_transform_reshape_squeeze",
@@ -197,7 +147,6 @@ def test_meta_schedule_integration_apply_history_best():
         TuningRecord(Schedule(MockModule).trace, [1.0], workload, target, [])
     )
     mod = env.query(task_name="mock-task", mod=mod, target=target, dispatched=[MockModule])
-    mod = IRModule({"main": mod})
     assert tvm.ir.structural_equal(mod, workload.mod)
 
 


### PR DESCRIPTION
Building on https://github.com/apache/tvm/pull/10561, add a new interface for task extraction that doesn't require the whole `VMCompiler.lower()`. Extracted tasks are the same as ones from the existing flow. Currently only enabled for meta schedule, but I believe it is worth adapting for autotvm / ansor cc @comaniac @tkonolige 

I'm currently working on a model where TE scheduling leads to an error during lowering, but TIR scheduling might work. I wanted to try the latter, but currently task extraction entails (for no reason) TE schedule application and lowering, which leads to the said error. This motivated this work, which aims to remove the unnecessary TE scheduling steps from the task extraction process.

Please review @junrushao1994 @mbs-octoml @jroesch 