### PR TITLE
[Minor] fix redundant compute in cuda batch matmul tensorcore

### DIFF
--- a/python/tvm/topi/cuda/batch_matmul_tensorcore.py
+++ b/python/tvm/topi/cuda/batch_matmul_tensorcore.py
@@ -177,6 +177,8 @@ def schedule_batch_matmul_tensorcore(cfg, outs):
         bb, bbii = s[CS].split(bb, factor=warp_row_tiles)
         oo, ooii = s[CS].split(oo, factor=warp_col_tiles)
         s[CS].reorder(bs, bb, oo, bbii, ooii, bbi, ooi)
+        s[CS].bind(bb, thread_z)
+        s[CS].bind(oo, thread_y)
 
         # Schedule for wmma computation
         s[CF].compute_at(s[CS], oo)


### PR DESCRIPTION
we should bind axis in CS stage to threadIdx in each warp, otherwise a
warp will compute all the tiles in a block.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
