### PR TITLE
[Hexagon] Improved ergonomics of HexagonLauncher in unit tests.

### DIFF
--- a/python/tvm/contrib/hexagon/build.py
+++ b/python/tvm/contrib/hexagon/build.py
@@ -195,19 +195,27 @@ class HexagonLauncherRPC(metaclass=abc.ABCMeta):
             "timeout": 0,
             "key": self.HEXAGON_REMOTE_DEVICE_KEY,
         }
-        return Session(hexagon_remote_kw)
+        return Session(self, hexagon_remote_kw)
 
-    def load_module(self, module_name: Union[str, pathlib.Path], session: Session):
+    def load_module(self, module: Union[str, pathlib.Path], session: Session):
         """Load TVM module.
 
         Parameters
         ----------
-        module_name : str or pathlib.Path
-            Name of the module to load. It must be either a bare file name
-            (without any path components), or a full path in the remote
-            system. If it is a file name, the file must be placed in the
-            remote workspace.
+        module : Union[str, pathlib.Path, tvm.runtime.Module]
+
+            The module to load.  If `module` is a
+            `tvm.runtime.Module`, it will be uploaded to the remote
+            session and loaded.
+
+            If the object passed is a string or pathlib.Path, it must
+            be either a bare file name (without any path components),
+            or a full path in the remote system. If it is a file name,
+            the file must already have been uploaded to the remote,
+            and be placed in the remote workspace.
+
         session : Session
+
             Remote session. The session must be established (via __enter__)
             prior to calling this function.
 
@@ -215,8 +223,9 @@ class HexagonLauncherRPC(metaclass=abc.ABCMeta):
         -------
         TVMModule :
             TVM module object.
+
         """
-        return session.load_module(module_name)
+        return session.load_module(module)
 
     def get_graph_executor(
         self, graph_json: str, module_name: Union[str, pathlib.Path], session: Session

--- a/python/tvm/contrib/hexagon/build.py
+++ b/python/tvm/contrib/hexagon/build.py
@@ -197,7 +197,7 @@ class HexagonLauncherRPC(metaclass=abc.ABCMeta):
         }
         return Session(self, hexagon_remote_kw)
 
-    def load_module(self, module: Union[str, pathlib.Path], session: Session):
+    def load_module(self, module: Union[str, pathlib.Path, tvm.runtime.Module], session: Session):
         """Load TVM module.
 
         Parameters

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -91,7 +91,7 @@ class Session:
         """
         self._launcher.upload(local_path, remote_filename)
 
-    def load_module(self, module: Union[str, pathlib.Path, tvm.IRModule]):
+    def load_module(self, module: Union[str, pathlib.Path, tvm.runtime.Module]):
         """Load TVM module.
 
         Parameters

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -31,11 +31,18 @@ class Session:
 
     Parameters
     ----------
+    launcher : HexagonLauncherRPC
+        The launcher from which this session was started.
+
     remote_kw : dict
         Remote configs for RPC tracker.
 
     session_name : str
         Hexagon RPC session name.
+
+    remote_stack_size_bytes : int
+        The stack size of the remote device, to be passed to
+        tvm.contrib.hexagon.create_hexagon_session.
     """
 
     def __init__(

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -19,7 +19,10 @@
 
 import os
 import pathlib
+import tempfile
 from typing import Union
+
+import tvm
 from tvm import rpc as _rpc
 
 
@@ -37,10 +40,12 @@ class Session:
 
     def __init__(
         self,
+        launcher: "HexagonLauncherRPC",
         remote_kw: dict,
         session_name: str = "hexagon-rpc",
         remote_stack_size_bytes: int = 128 * 1024,
     ):
+        self._launcher = launcher
         self._session_name = session_name
         self._remote_stack_size_bytes = remote_stack_size_bytes
         self._remote_kw = remote_kw
@@ -74,6 +79,53 @@ class Session:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         pass
 
-    def load_module(self, path: Union[str, pathlib.Path]):
-        assert isinstance(path, (str, pathlib.Path)), "Invalid path type:" + str(type(path))
-        return self._rpc.get_function("tvm.hexagon.load_module")(str(path))
+    def upload(self, local_path: Union[str, pathlib.Path], remote_filename: str):
+        """Upload a local file to the remote workspace.
+
+        Parameters
+        ----------
+        local_path : str or pathlib.Path
+            Path to the local file to be copied.
+        remote_filename : str
+            Name of the file in the remote workspace.
+        """
+        self._launcher.upload(local_path, remote_filename)
+
+    def load_module(self, module: Union[str, pathlib.Path, tvm.IRModule]):
+        """Load TVM module.
+
+        Parameters
+        ----------
+        module : Union[str, pathlib.Path, tvm.runtime.Module]
+
+            The module to load.  If `module` is a
+            `tvm.runtime.Module`, it will be uploaded to the remote
+            session and loaded.
+
+            If the object passed is a string or pathlib.Path, it must
+            be either a bare file name (without any path components),
+            or a full path in the remote system. If it is a file name,
+            the file must already have been uploaded to the remote,
+            and be placed in the remote workspace.
+
+        session : Session
+
+            Remote session. The session must be established (via __enter__)
+            prior to calling this function.
+
+        Returns
+        -------
+        TVMModule :
+            TVM module object.
+        """
+        if isinstance(module, tvm.runtime.Module):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_dir = pathlib.Path(temp_dir)
+                binary_name = "test_binary.so"
+                binary_path = temp_dir / binary_name
+                module.save(str(binary_path))
+                self.upload(binary_path, binary_name)
+                module = binary_name
+
+        assert isinstance(module, (str, pathlib.Path)), "Invalid path type:" + str(type(module))
+        return self._rpc.get_function("tvm.hexagon.load_module")(str(module))

--- a/python/tvm/topi/arm_cpu/tensor_intrin.py
+++ b/python/tvm/topi/arm_cpu/tensor_intrin.py
@@ -713,7 +713,7 @@ def gemm_acc_4x4_int8_int8_int32(dtype):
 
         void gemm_acc_4x4_int8_int8_int32(int8 A[4][4], int8 B[4][4], int32 C[4][4]){
             for (int i = 0; i < 4; i++){
-                for (int j = 0; i < 4; i++){
+                for (int j = 0; j < 4; j++){
                     for (int k = 0; k < 4; k++){
                         C[i][j] += A[i][k] * B[j][k]
                     }
@@ -840,7 +840,7 @@ def gemm_acc_nx16_int8_int8_int32(dtype, rows):
 
         void mmla_nx16_int8_int8_int32(int8 A[n][16], int8 B[4][16][4], int32 output[n][16]){
             for (int i = 0; i < n; i++){
-                for (int j = 0; i < 16; i++){
+                for (int j = 0; j < 16; j++){
                     for (int k = 0; k < 16; k++){
                         out[i][j] += A[i][k] * B[k//4][j][k%4]
                     }
@@ -1058,7 +1058,7 @@ def gemm_acc_2x2_int8_int8_int32(dtype):
 
         void mmla_2x2_int8_int8_int32(int8 A[2][8], int8 B[2][8], int32 C[2][2]){
             for (int i = 0; i < 2; i++){
-                for (int j = 0; i < 2; i++){
+                for (int j = 0; j < 2; j++){
                     for (int k = 0; k < 8; k++){
                         C[i][j] += A[i][k] * B[j][k]
                     }

--- a/tests/python/contrib/test_hexagon/conftest.py
+++ b/tests/python/contrib/test_hexagon/conftest.py
@@ -81,7 +81,7 @@ def android_serial_number() -> Optional[str]:
 
 listen_port_min = 2000  # Well above the privileged ports (1024 or lower)
 listen_port_max = 9000  # Below the search range end (port_end=9199) of RPC server
-previous_port = [None]
+previous_port = None
 
 
 def get_free_port():
@@ -90,15 +90,16 @@ def get_free_port():
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex(("localhost", port)) == 0
 
-    if previous_port[0] is None:
+    global previous_port
+    if previous_port is None:
         port = random.randint(listen_port_min, listen_port_max)
     else:
-        port = previous_port[0] + 1
+        port = previous_port + 1
 
     while is_port_in_use(port):
         port = port + 1 if port < listen_port_max else listen_port_min
 
-    previous_port[0] = port
+    previous_port = port
     return port
 
 

--- a/tests/python/contrib/test_hexagon/conftest.py
+++ b/tests/python/contrib/test_hexagon/conftest.py
@@ -164,8 +164,11 @@ def hexagon_launcher(android_serial_number, tvm_tracker, rpc_server_port, adb_se
 
 @tvm.testing.fixture
 def hexagon_session(hexagon_launcher):
-    with hexagon_launcher.start_session() as session:
-        yield session
+    if hexagon_launcher is None:
+        yield None
+    else:
+        with hexagon_launcher.start_session() as session:
+            yield session
 
 
 # If the execution aborts while an RPC server is running, the python

--- a/tests/python/contrib/test_hexagon/test_cache_read_write.py
+++ b/tests/python/contrib/test_hexagon/test_cache_read_write.py
@@ -63,9 +63,7 @@ def intrin_mem_copy(shape, dtype, dst_scope, src_scope):
 
 
 @requires_hexagon_toolchain
-def test_cache_read_write(
-    android_serial_number, tvm_tracker_host, tvm_tracker_port, adb_server_socket
-):
+def test_cache_read_write(hexagon_session):
     size = 128
     outer_shape = (size,)
     factor = 16
@@ -105,37 +103,24 @@ def test_cache_read_write(
     func = tvm.build(
         s, [x, y, z], tvm.target.Target(target_hexagon, host=target_hexagon), name="dmacpy"
     )
-    temp = utils.tempdir()
-    dso_binary = "test_binary.so"
-    dso_binary_path = temp.relpath(dso_binary)
-    func.save(dso_binary_path)
 
-    if not android_serial_number:
+    if hexagon_session is None:
         pytest.skip("Skip hardware test since ANDROID_SERIAL_NUMBER is not set.")
 
-    rpc_info = {
-        "rpc_tracker_host": tvm_tracker_host,
-        "rpc_tracker_port": tvm_tracker_port,
-        "rpc_server_port": 7070,
-        "adb_server_socket": adb_server_socket,
-    }
-    launcher = HexagonLauncher(serial_number=android_serial_number, rpc_info=rpc_info)
-    launcher.upload(dso_binary_path, dso_binary)
-    launcher.start_server()
-
-    with launcher.start_session() as sess:
-        mod = launcher.load_module(dso_binary, sess)
-        xt = tvm.nd.array(
-            np.random.randint(-128, high=127, size=size, dtype=x.dtype), device=sess.device
-        )
-        yt = tvm.nd.array(
-            np.random.randint(-128, high=127, size=size, dtype=x.dtype), device=sess.device
-        )
-        zt = tvm.nd.array(
-            np.random.randint(-128, high=127, size=size, dtype=x.dtype), device=sess.device
-        )
-        mod["dmacpy"](xt, yt, zt)
-    launcher.stop_server()
+    mod = hexagon_session.load_module(func)
+    xt = tvm.nd.array(
+        np.random.randint(low=-128, high=127, size=size, dtype=x.dtype),
+        device=hexagon_session.device,
+    )
+    yt = tvm.nd.array(
+        np.random.randint(low=-128, high=127, size=size, dtype=y.dtype),
+        device=hexagon_session.device,
+    )
+    zt = tvm.nd.array(
+        np.random.randint(low=-128, high=127, size=size, dtype=z.dtype),
+        device=hexagon_session.device,
+    )
+    mod["dmacpy"](xt, yt, zt)
 
     ref = xt.numpy() + yt.numpy()
     np.testing.assert_equal(zt.numpy(), ref)


### PR DESCRIPTION
The goal of this commit is to reduce/eliminate common code required through unit tests that interact with Hexagon hardware.

- New testing fixtures in `tests/python/contrib/test_hexagon`.  A test   running on hexagon hardware should only need to use the   `hexagon_session` fixture.

  - `rpc_server_port`: Iterates through port numbers, selecting an unused port for each unit test.  Avoids needing to explicitly specify unique ports for each unit test.

  - `tvm_tracker`: Starts a tracker on use, exits after test.  Avoids needing to manually start a tracker prior to running the unit test.

  - `hexagon_launcher`: Starts a `HexagonLauncher` server on use, stops server after test.  Avoids needing to call `start_server()` and `stop_server()` in each test.

  - `hexagon_session`: Starts a hexagon session using `hexagon_launcher.start_session()`, exits after test.

- Added `Session.upload` function, which delegates to `HexagonLauncher.upload`.  Avoids needing to interact with both the launcher and the session.

- Allowed `tvm.IRModule` as argument passed to `Session.load_module`, which will automatically save/upload the module, then load it. Avoids needing to handle save/upload of temporary files in each unit test.