### PR TITLE
[TIR][CodeGen] Process buffer elem_offset in target codegen

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1261,7 +1261,6 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const LetNode* op) {
   auto var_value = MakeValue(op->value);
   var_map_[op->var.get()] = var_value;
   var_value->setName(op->var->name_hint.c_str());
-  analyzer_->Bind(op->var, op->value);
   return MakeValue(op->body);
 }
 
@@ -1640,7 +1639,6 @@ void CodeGenLLVM::VisitStmt_(const LetStmtNode* op) {
   llvm::Value* value = MakeValue(op->value);
   value->setName(v->name_hint.c_str());
   var_map_[v] = value;
-  analyzer_->Bind(op->var, op->value);
   if (alloc_storage_info_.count(v) && alloc_storage_info_[v].alignment > 1) {
     builder_->CreateAlignmentAssumption(*data_layout_, GetVarValue(v),
                                         alloc_storage_info_[v].alignment);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1253,10 +1253,10 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const SelectNode* op) {
 llvm::Value* CodeGenLLVM::VisitExpr_(const LetNode* op) {
   auto it = let_binding_.find(op->var);
   if (it != let_binding_.end()) {
-    ICHECK(deep_equal_(it->second->value, op->value))
+    ICHECK(deep_equal_(it->second, op->value))
         << "Let cannot bind the same var to two different values";
   } else {
-    let_binding_[op->var] = op;
+    let_binding_[op->var] = op->value;
   }
   auto var_value = MakeValue(op->value);
   var_map_[op->var.get()] = var_value;

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -439,7 +439,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   // deep comparison of PrimExpr
   ExprDeepEqual deep_equal_;
   // binding of let variables. Enables duplicate var defs that map to same value
-  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
+  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> let_binding_;
   // Cache potential common path ops to slightly improve lookup time.
   // global symbol table.
   OpAttrMap<TGlobalSymbol> op_attr_global_symbol_ = Op::GetAttrMap<TGlobalSymbol>("TGlobalSymbol");

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -787,10 +787,10 @@ void CodeGenC::VisitStmt_(const BufferStoreNode* op) {
 void CodeGenC::VisitExpr_(const LetNode* op, std::ostream& os) {  // NOLINT(*)
   auto it = let_binding_.find(op->var);
   if (it != let_binding_.end()) {
-    ICHECK(deep_equal_(it->second->value, op->value))
+    ICHECK(deep_equal_(it->second, op->value))
         << "Let cannot bind the same var to two different values";
   } else {
-    let_binding_[op->var] = op;
+    let_binding_[op->var] = op->value;
   }
   std::string value = PrintExpr(op->value);
   var_idmap_[op->var.get()] = value;

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -281,7 +281,7 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
   // deep comparison of PrimExpr
   ExprDeepEqual deep_equal_;
   // binding of let variables. Enables duplicate var defs that map to same value
-  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
+  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> let_binding_;
   // analyzer
   arith::Analyzer analyzer_;
 };

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -24,6 +24,7 @@
 #ifndef TVM_TARGET_SOURCE_CODEGEN_C_H_
 #define TVM_TARGET_SOURCE_CODEGEN_C_H_
 
+#include <tvm/arith/analyzer.h>
 #include <tvm/ir/op.h>
 #include <tvm/target/codegen.h>
 #include <tvm/tir/analysis.h>
@@ -281,6 +282,8 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
   ExprDeepEqual deep_equal_;
   // binding of let variables. Enables duplicate var defs that map to same value
   std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
+  // analyzer
+  arith::Analyzer analyzer_;
 };
 
 }  // namespace codegen

--- a/src/target/source/codegen_opencl.cc
+++ b/src/target/source/codegen_opencl.cc
@@ -382,7 +382,9 @@ void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
     // Overload tvm_address_of to add storage scope (e.g. __global).
     const BufferLoadNode* load = op->args[0].as<BufferLoadNode>();
     ICHECK(op->args.size() == 1 && load);
-    ICHECK_EQ(load->indices.size(), 0) << "CodeGenOpenCL only supports flat memory allocations.";
+    ICHECK_EQ(load->indices.size(), 1) << "CodeGenOpenCL only supports flat memory allocations.";
+    PrimExpr index = analyzer_.Simplify(load->buffer->elem_offset + load->indices[0]);
+
     os << "((";
     auto it = alloc_storage_scope_.find(load->buffer->data.get());
     if (it != alloc_storage_scope_.end()) {
@@ -390,7 +392,7 @@ void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
     }
     this->PrintType(load->dtype.element_of(), os);
     os << " *)" << this->GetVarID(load->buffer->data.get()) << " + ";
-    this->PrintExpr(load->indices[0], os);
+    this->PrintExpr(index, os);
     os << ')';
   } else if (op->op.same_as(builtin::texture2d_store())) {
     auto* ptr_type = op->args[0].as<VarNode>()->type_annotation.as<PointerTypeNode>();

--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -24,6 +24,7 @@
 #ifndef TVM_TARGET_SOURCE_CODEGEN_OPENCL_H_
 #define TVM_TARGET_SOURCE_CODEGEN_OPENCL_H_
 
+#include <tvm/arith/analyzer.h>
 #include <tvm/target/codegen.h>
 
 #include <string>
@@ -85,6 +86,8 @@ class CodeGenOpenCL final : public CodeGenC {
   // Mapping from buffer to allocation size.
   // Useful to track when a scalar store of a vectorized texture load is required.
   std::unordered_map<const Object*, size_t> allocation_size_;
+  // analyzer
+  arith::Analyzer analyzer_;
 };
 
 }  // namespace codegen

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -293,7 +293,6 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const LetNode* op) {
     let_binding_[op->var] = op;
   }
   var_map_[op->var.get()] = MakeValue(op->value);
-  analyzer_->Bind(op->var, op->value);
   return MakeValue(op->body);
 }
 
@@ -716,7 +715,6 @@ void CodeGenSPIRV::VisitStmt_(const LetStmtNode* op) {
   ICHECK(!var_map_.count(op->var.get()));
   ICHECK(!op->var.dtype().is_handle());
   var_map_[op->var.get()] = MakeValue(op->value);
-  analyzer_->Bind(op->var, op->value);
   this->VisitStmt(op->body);
 }
 

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -287,10 +287,10 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const SelectNode* op) {
 spirv::Value CodeGenSPIRV::VisitExpr_(const LetNode* op) {
   auto it = let_binding_.find(op->var);
   if (it != let_binding_.end()) {
-    ICHECK(deep_equal_(it->second->value, op->value))
+    ICHECK(deep_equal_(it->second, op->value))
         << "Let cannot bind the same var to two different values";
   } else {
-    let_binding_[op->var] = op;
+    let_binding_[op->var] = op->value;
   }
   var_map_[op->var.get()] = MakeValue(op->value);
   return MakeValue(op->body);

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -428,7 +428,7 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const BroadcastNode* op) {
 spirv::Value CodeGenSPIRV::VisitExpr_(const BufferLoadNode* op) {
   ICHECK_EQ(op->indices.size(), 1) << "SPIR-V codegen expects flat memory buffers";
   Var buffer_var = op->buffer->data;
-  PrimExpr prim_index = op->indices[0];
+  PrimExpr prim_index = analyzer_->Simplify(op->buffer->elem_offset + op->indices[0]);
 
   DataType desired_read_type = op->dtype;
   if (desired_read_type == DataType::Bool()) {
@@ -501,7 +501,7 @@ void CodeGenSPIRV::Scalarize(const PrimExpr& e, std::function<void(int i, spirv:
 void CodeGenSPIRV::VisitStmt_(const BufferStoreNode* op) {
   ICHECK_EQ(op->indices.size(), 1) << "SPIR-V codegen expects flat memory buffers";
   Var buffer_var = op->buffer->data;
-  PrimExpr prim_index = op->indices[0];
+  PrimExpr prim_index = analyzer_->Simplify(op->buffer->elem_offset + op->indices[0]);
 
   auto it = storage_info_.find(buffer_var.get());
   ICHECK(it != storage_info_.end());

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -213,7 +213,7 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
   ExprDeepEqual deep_equal_;
 
   // binding of let variables. Enables duplicate var defs that map to same value
-  std::unordered_map<Var, const LetNode*, ObjectPtrHash, ObjectPtrEqual> let_binding_;
+  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> let_binding_;
 
   // Running total of the number of bytes of shared memory used.
   // Checked against the max_shared_memory_per_group

--- a/src/target/stackvm/codegen_stackvm.h
+++ b/src/target/stackvm/codegen_stackvm.h
@@ -24,6 +24,7 @@
 #ifndef TVM_TARGET_STACKVM_CODEGEN_STACKVM_H_
 #define TVM_TARGET_STACKVM_CODEGEN_STACKVM_H_
 
+#include <tvm/arith/analyzer.h>
 #include <tvm/target/codegen.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/function.h>
@@ -156,6 +157,8 @@ class CodeGenStackVM : public ExprFunctor<void(const PrimExpr&)>,
   std::unordered_map<std::string, int> str_idmap_;
   /*! \brief id of each global function */
   std::unordered_map<std::string, int> extern_fun_idmap_;
+  /*! \brief analyzer */
+  arith::Analyzer analyzer_;
 
   Op backend_alloc_workspace_op_ = Op::Get("tir.TVMBackendAllocWorkspace");
   Op backend_free_workspace_op_ = Op::Get("tir.TVMBackendFreeWorkspace");

--- a/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
+++ b/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
@@ -200,7 +200,7 @@ PoolAllocationToOffsetConverter::ScopeInfo PoolAllocationToOffsetConverter::Upda
 
     int pool_size = all_pools_sizes_[pool_info];
     String buffer_var_name = pool_ref_name + "_buffer_var";
-    si.buffer_map.Set(pool_var, Buffer(buffer_var, elem_dtype, {pool_size}, {1}, 1, buffer_var_name,
+    si.buffer_map.Set(pool_var, Buffer(buffer_var, elem_dtype, {pool_size}, {1}, 0, buffer_var_name,
                                        16, 1, BufferType::kDefault));
   }
   if (resource_handle) {

--- a/tests/python/unittest/test_tir_usmp_transform_convert_pool_allocations_to_offsets.py
+++ b/tests/python/unittest/test_tir_usmp_transform_convert_pool_allocations_to_offsets.py
@@ -141,8 +141,8 @@ class LinearStructure:
 class LinearStructurePlanned:
     @T.prim_func
     def __tvm_main__(input: T.handle, fast_memory_0_var: T.Ptr[T.uint8], slow_memory_1_var: T.Ptr[T.uint8],  output: T.handle) -> None:
-        fast_memory_0_buffer_var = T.match_buffer(fast_memory_0_var, [200704], dtype="uint8", strides=[1], elem_offset=1, align=16)
-        slow_memory_1_buffer_var = T.match_buffer(slow_memory_1_var, [1418528], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        fast_memory_0_buffer_var = T.match_buffer(fast_memory_0_var, [200704], dtype="uint8", strides=[1], elem_offset=0, align=16)
+        slow_memory_1_buffer_var = T.match_buffer(slow_memory_1_var, [1418528], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         T.attr("default", "device_id", 0)
         T.attr("default", "device_type", 1)
@@ -156,8 +156,8 @@ class LinearStructurePlanned:
     def tvmgen_default_fused_nn_max_pool2d_cast(placeholder_28: T.handle, T_cast_6: T.handle, fast_memory_6_var: T.Ptr[T.uint8], slow_memory_7_var: T.Ptr[T.uint8]) -> None:
         placeholder_29 = T.match_buffer(placeholder_28, [802816], dtype="uint8")
         T_cast_7 = T.match_buffer(T_cast_6, [177], dtype="int16")
-        fast_memory_6_buffer_var = T.match_buffer(fast_memory_6_var, [200704], dtype="uint8", strides=[1], elem_offset=1, align=16)
-        slow_memory_7_buffer_var = T.match_buffer(slow_memory_7_var, [1418528], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        fast_memory_6_buffer_var = T.match_buffer(fast_memory_6_var, [200704], dtype="uint8", strides=[1], elem_offset=0, align=16)
+        slow_memory_7_buffer_var = T.match_buffer(slow_memory_7_var, [1418528], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         tensor_2_let = T.buffer_decl([200704], dtype="uint8")
         with T.let(tensor_2_let.data, T.address_of(fast_memory_6_buffer_var[0], dtype="handle")):
@@ -174,8 +174,8 @@ class LinearStructurePlanned:
         placeholder_4 = T.match_buffer(placeholder_2, [150528], dtype="uint8")
         placeholder_5 = T.match_buffer(placeholder_3, [1], dtype="int16")
         T_subtract_1 = T.match_buffer(T_subtract, [452], dtype="int16")
-        fast_memory_2_buffer_var = T.match_buffer(fast_memory_2_var, [200704], dtype="uint8", strides=[1], elem_offset=1, align=16)
-        slow_memory_3_buffer_var = T.match_buffer(slow_memory_3_var, [1418528], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        fast_memory_2_buffer_var = T.match_buffer(fast_memory_2_var, [200704], dtype="uint8", strides=[1], elem_offset=0, align=16)
+        slow_memory_3_buffer_var = T.match_buffer(slow_memory_3_var, [1418528], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         for ax0_ax1_fused_1, ax2_1, ax3_inner_1 in T.grid(224, 224, 3):
             T_subtract_1[ax0_ax1_fused_1 * 672 + ax2_1 * 3 + ax3_inner_1] = T.cast(placeholder_4[ax0_ax1_fused_1 * 672 + ax2_1 * 3 + ax3_inner_1], "int16") - placeholder_5[0]
@@ -186,8 +186,8 @@ class LinearStructurePlanned:
         placeholder_66 = T.match_buffer(placeholder_63, [9408], dtype="int16")
         placeholder_67 = T.match_buffer(placeholder_64, [64], dtype="int32")
         T_cast_21 = T.match_buffer(T_cast_20, [289], dtype="uint8")
-        fast_memory_4_buffer_var = T.match_buffer(fast_memory_4_var, [200704], dtype="uint8", strides=[1], elem_offset=1, align=16)
-        slow_memory_5_buffer_var = T.match_buffer(slow_memory_5_var, [1418528], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        fast_memory_4_buffer_var = T.match_buffer(fast_memory_4_var, [200704], dtype="uint8", strides=[1], elem_offset=0, align=16)
+        slow_memory_5_buffer_var = T.match_buffer(slow_memory_5_var, [1418528], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         PaddedInput_7_let = T.buffer_decl([157323], "int16")
         with T.let(PaddedInput_7_let.data, T.address_of(slow_memory_5_buffer_var[802816], dtype="handle")):
@@ -371,7 +371,7 @@ class ResnetStructurePlanned:
         placeholder_2 = T.match_buffer(placeholder, [360000], dtype="uint8")
         placeholder_3 = T.match_buffer(placeholder_1, [64], dtype="int32")
         T_cast_1 = T.match_buffer(T_cast, [215], dtype="int16")
-        global_workspace_1_buffer_var = T.match_buffer(global_workspace_1_var, [7920256], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        global_workspace_1_buffer_var = T.match_buffer(global_workspace_1_var, [7920256], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         for ax0_ax1_fused, ax2, ax3_outer, ax3_inner in T.grid(75, 75, 4, 16):
             T_cast_1[ax0_ax1_fused * 4800 + ax2 * 64 + ax3_outer * 16 + ax3_inner] = T.cast(T.cast(T.max(T.min(T.q_multiply_shift(T.cast(placeholder_2[ax0_ax1_fused * 4800 + ax2 * 64 + ax3_outer * 16 + ax3_inner], "int32") - 94, 1843157232, 31, 1, dtype="int32") + placeholder_3[ax3_outer * 16 + ax3_inner], 255), 0), "uint8"), "int16")
@@ -383,7 +383,7 @@ class ResnetStructurePlanned:
         placeholder_26 = T.match_buffer(placeholder_24, [256], dtype="int32")
         placeholder_28 = T.match_buffer(placeholder_25, [1440000], dtype="int32")
         T_cast_7 = T.match_buffer(T_cast_6, [407], dtype="uint8")
-        global_workspace_5_buffer_var = T.match_buffer(global_workspace_5_var, [7920256], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        global_workspace_5_buffer_var = T.match_buffer(global_workspace_5_var, [7920256], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         PaddedInput_3_let = T.buffer_decl([360000], 'int16')
         with T.let(PaddedInput_3_let.data, T.address_of(global_workspace_5_buffer_var[6480000], dtype="handle")):
@@ -406,7 +406,7 @@ class ResnetStructurePlanned:
         placeholder_20 = T.match_buffer(placeholder_17, [16384], dtype="int16")
         placeholder_21 = T.match_buffer(placeholder_18, [256], dtype="int32")
         T_add_1 = T.match_buffer(T_add, [407], dtype="int32")
-        global_workspace_4_buffer_var = T.match_buffer(global_workspace_4_var, [7920256], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        global_workspace_4_buffer_var = T.match_buffer(global_workspace_4_var, [7920256], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         PaddedInput_2_let = T.buffer_decl([360000], "int16")
         with T.let(PaddedInput_2_let.data, T.address_of(global_workspace_4_buffer_var[7200000], dtype="handle")):
@@ -429,7 +429,7 @@ class ResnetStructurePlanned:
         placeholder_8 = T.match_buffer(placeholder_5, [4096], dtype="int16")
         placeholder_9 = T.match_buffer(placeholder_6, [64], dtype="int32")
         T_cast_3 = T.match_buffer(T_cast_2, [215], dtype="int16")
-        global_workspace_2_buffer_var = T.match_buffer(global_workspace_2_var, [7920256], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        global_workspace_2_buffer_var = T.match_buffer(global_workspace_2_var, [7920256], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         PaddedInput_let = T.buffer_decl([360000], "int16")
         with T.let(PaddedInput_let.data, T.address_of(global_workspace_2_buffer_var[7200000], dtype="handle")):
@@ -451,7 +451,7 @@ class ResnetStructurePlanned:
         placeholder_14 = T.match_buffer(placeholder_11, [36864], dtype="int16")
         placeholder_15 = T.match_buffer(placeholder_12, [64], dtype="int32")
         T_cast_5 = T.match_buffer(T_cast_4, [215], dtype="int16")
-        global_workspace_3_buffer_var = T.match_buffer(global_workspace_3_var, [7920256], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        global_workspace_3_buffer_var = T.match_buffer(global_workspace_3_var, [7920256], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         PaddedInput_1_let = T.buffer_decl([379456], "int16")
         with T.let(PaddedInput_1_let.data, T.address_of(global_workspace_3_buffer_var[0], dtype="handle")):
@@ -469,7 +469,7 @@ class ResnetStructurePlanned:
 
     @T.prim_func
     def __tvm_main__(input: T.handle, global_workspace_0_var: T.Ptr[T.uint8], output: T.handle) -> None:
-        global_workspace_0_buffer_var = T.match_buffer(global_workspace_0_var, [7920256], dtype="uint8", strides=[1], elem_offset=1, align=16)
+        global_workspace_0_buffer_var = T.match_buffer(global_workspace_0_var, [7920256], dtype="uint8", strides=[1], elem_offset=0, align=16)
         # body
         T.attr("default", "device_id", 0)
         T.attr("default", "device_type", 1)

--- a/vta/python/vta/transform.py
+++ b/vta/python/vta/transform.py
@@ -948,7 +948,7 @@ def InjectALUIntrin():
                     nest_size += 1
                 # Get the src/dst arguments
                 dst_var = loop_body.buffer.data
-                dst_idx = loop_body.indices[0]
+                dst_idx = loop_body.buffer.elem_offset + loop_body.indices[0]
                 # Derive loop variables and extents
                 tmp_body = stmt.body
                 indices = []
@@ -1008,19 +1008,23 @@ def InjectALUIntrin():
                 imm_val = None
                 if isinstance(rhs, tvm.tir.IntImm):
                     assert lhs.buffer.data.same_as(dst_var)
-                    src_coeff = tvm.arith.detect_linear_equation(lhs.indices[0], indices)
+                    lhs_index = lhs.buffer.elem_offset + lhs.indices[0]
+                    src_coeff = tvm.arith.detect_linear_equation(lhs_index, indices)
                     use_imm = True
                     imm_val = rhs
                 if isinstance(lhs, tvm.tir.IntImm):
                     assert rhs.buffer.data.same_as(dst_var)
-                    src_coeff = tvm.arith.detect_linear_equation(rhs.indices[0], indices)
+                    rhs_index = rhs.buffer.elem_offset + rhs.indices[0]
+                    src_coeff = tvm.arith.detect_linear_equation(rhs_index, indices)
                     use_imm = True
                     imm_val = lhs
                 if imm_val is None:
                     imm_val = 0
+                    lhs_index = lhs.buffer.elem_offset + lhs.indices[0]
+                    rhs_index = rhs.buffer.elem_offset + rhs.indices[0]
                     assert lhs.buffer.data.same_as(dst_var) and rhs.buffer.data.same_as(dst_var)
-                    src_lhs_coeff = tvm.arith.detect_linear_equation(lhs.indices[0], indices)
-                    src_rhs_coeff = tvm.arith.detect_linear_equation(rhs.indices[0], indices)
+                    src_lhs_coeff = tvm.arith.detect_linear_equation(lhs_index, indices)
+                    src_rhs_coeff = tvm.arith.detect_linear_equation(rhs_index, indices)
                     # Determine which side has the same coefficients
                     lhs_equal = True
                     rhs_equal = True


### PR DESCRIPTION
- After https://github.com/apache/tvm/pull/9727, the low level TIR memory access is on `Buffer` objects. The `Buffer` has `elem_offset` 
https://github.com/apache/tvm/blob/e34985b5b89e13cbbb7ebddee1ec5c1470a952f6/include/tvm/tir/buffer.h#L79-L80
Thus the addressing rule for `BufferLoad`, `BufferStore` and `T.address_of` should also take this offset field into consideration.

- Also, the buffer combine functionality in `StorageRewrite` pass currently create alias buffers to the alloc buffer var, which denotes the start offset of the merged buffer. But it seems illness since the alias buffer's accessed indices exceed the alias buffer extent.
    ```python
    # example from ut 
    @T.prim_func
    def func(A: T.Buffer[(4,), "float32"], A4: T.Buffer[(8,), "float32"]) -> None:
        A0 = T.allocate([16], "float32", "global:tag")
        A0_1 = T.buffer_decl([8], dtype="float32", data=A0.data, scope="global:tag")
        A0_2 = T.buffer_decl([8], dtype="float32", data=A0.data, scope="global:tag")
        A0_3 = T.buffer_decl([8], dtype="float32", data=A0.data, scope="global:tag")
        A0_4 = T.buffer_decl([8], dtype="float32", data=A0.data, scope="global:tag")
        for i in T.serial(8):
            A0_1[i] = A[i] + A[0] + T.float32(1)
        for i in T.serial(8):
            A0_2[8 + i] = A0_1[i] + A0_1[0] + T.float32(2)
        for i in T.serial(8):
            A0_3[i] = A0_2[8 + i] + A0_2[8] + T.float32(3)
        for i in T.serial(8):
            A0_4[8 + i] = A0_3[i] + A0_3[0] + T.float32(4)
        for i in T.serial(8):
            A4[i] = A0_4[8 + i] + A0_4[8] + T.float32(5)
    ```
    It would be great to set `elem_offset` to alias buffers, thus each alias buffer's address range is marked explicitly.
    ```python
    @T.prim_func
    def func(A: T.Buffer[(4,), "float32"], A4: T.Buffer[(8,), "float32"]) -> None:
        A0 = T.allocate([16], "float32", "global:tag")
        A0_1 = T.buffer_decl([8], dtype="float32", data=A0.data, scope="global:tag")
        A0_2 = T.buffer_decl([8], dtype="float32", data=A0.data, elem_offset=8, scope="global:tag")
        A0_3 = T.buffer_decl([8], dtype="float32", data=A0.data, scope="global:tag")
        A0_4 = T.buffer_decl([8], dtype="float32", data=A0.data, elem_offset=8, scope="global:tag")
        for i in T.serial(8):
            A0_1[i] = A[i] + A[0] + T.float32(1)
        for i in T.serial(8):
            A0_2[i] = A0_1[i] + A0_1[0] + T.float32(2)
        for i in T.serial(8):
            A0_3[i] = A0_2[i] + A0_2[0] + T.float32(3)
        for i in T.serial(8):
            A0_4[i] = A0_3[i] + A0_3[0] + T.float32(4)
        for i in T.serial(8):
            A4[i] = A0_4[i] + A0_4[0] + T.float32(5)
    ```