### PR TITLE
[Arith] Support dtype promotion in TIR comparison expr creation

### DIFF
--- a/src/arith/int_constraints.cc
+++ b/src/arith/int_constraints.cc
@@ -49,13 +49,13 @@ Array<PrimExpr> AsConditions(const Array<Var>& variables, const Map<Var, IntGrou
     const auto& bnds = bounds[v];
     PrimExpr lhs = bnds->coef * v;
     for (const PrimExpr& rhs : bnds->equal) {
-      res.push_back(tir::EQ(lhs, rhs));
+      res.push_back(lhs == rhs);
     }
     for (const PrimExpr& rhs : bnds->lower) {
-      res.push_back(tir::GE(lhs, rhs));
+      res.push_back(lhs >= rhs);
     }
     for (const PrimExpr& rhs : bnds->upper) {
-      res.push_back(tir::LE(lhs, rhs));
+      res.push_back(lhs <= rhs);
     }
   }
   for (const PrimExpr& e : relations) {


### PR DESCRIPTION
I got an error below when working on a model. This change fixes it.

These operator overload are "dtype-promotion aware", see https://github.com/apache/tvm/blob/7e2467ac44945b8c4aa951574c3623b455987f76/src/tir/op/op.cc#L471

Unfortunately, I've hit this problem on a very large model (QAT BERT-large) and I don't know why it is happening at all. So I don't have a minimum repro test.

@junrushao1994 @vinx13 @spectrometerHBH @wrongtest 

```
  7: tvm::tir::BufferAccessRegionCollector::VisitStmt_(tvm::tir::BufferStoreNode const*)
  6: tvm::tir::ExprFunctor<void (tvm::PrimExpr const&)>::VisitExpr(tvm::PrimExpr const&)
  5: tvm::tir::BufferAccessRegionCollector::VisitExpr_(tvm::tir::CallNode const*)
  4: tvm::tir::ConditionalBoundsContext::EnterWithScope()
  3: tvm::tir::ConditionalBoundsContext::GetVarBoundsFromCondition()
  2: tvm::arith::SolveInequalitiesToRange(tvm::arith::IntConstraints const&)
  1: tvm::arith::AsConditions(tvm::runtime::Array<tvm::tir::Var, void> const&, tvm::runtime::Map<tvm::tir::Var, tvm::arith::IntGroupBounds, void, void> const&, tvm::runtime::Array<tvm::PrimExpr, void> const&)
  0: tvm::tir::LE::LE(tvm::PrimExpr, tvm::PrimExpr, tvm::Span)
  File "/home/masa/projects/dev/tvm/src/tir/ir/expr.cc", line 447
TypeError: Check failed: (a.dtype() == b.dtype()) is false: mismatched types. int32 vs. int64
```