### PR TITLE
[Hexagon] Codegen for 2d Load/Store

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -815,12 +815,12 @@ CodeGenCPU::PackedCall CodeGenCPU::MakeCallPackedLowered(const Array<PrimExpr>& 
       t_tvm_value_, builder_->CreatePointerCast(stack_value, t_tvm_value_->getPointerTo()),
       ConstInt32(begin));
   TypedPointer arg_tcode =
-      CreateBufferPtr(stack_tcode, DataType::Int(32), ConstInt32(begin), DataType::Int(32));
+      CreateBufferPtr(stack_tcode, DataType::Int(32), {ConstInt32(begin)}, DataType::Int(32));
   llvm::Value* ret_value = builder_->CreateInBoundsGEP(
       t_tvm_value_, builder_->CreatePointerCast(stack_value, t_tvm_value_->getPointerTo()),
       ConstInt32(end));
   TypedPointer ret_tcode =
-      CreateBufferPtr(stack_tcode, DataType::Int(32), ConstInt32(end), DataType::Int(32));
+      CreateBufferPtr(stack_tcode, DataType::Int(32), {ConstInt32(end)}, DataType::Int(32));
 
 #if TVM_LLVM_VERSION >= 90
   auto call_callee = llvm::FunctionCallee(ftype_tvm_func_call_, RuntimeTVMFuncCall());

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -77,7 +77,7 @@ class CodeGenHexagon final : public CodeGenLLVM {
 
  private:
   TypedPointer CreateBufferPtr(llvm::Value* buffer_ptr, DataType buffer_element_dtype,
-                               std::vector<llvm::Value*> indices, DataType value_dtype) final;
+                               llvm::ArrayRef<llvm::Value*> indices, DataType value_dtype) final;
   TypedPointer CreateStructRefPtr(DataType t, llvm::Value* buf, llvm::Value* index, int kind);
 
   // Check if the call to packed function is successful
@@ -574,7 +574,7 @@ llvm::Value* CodeGenHexagon::CreateIntrinsic(const CallNode* op) {
 
 CodeGenLLVM::TypedPointer CodeGenHexagon::CreateBufferPtr(llvm::Value* buffer_ptr,
                                                           DataType buffer_element_dtype,
-                                                          std::vector<llvm::Value*> indices,
+                                                          llvm::ArrayRef<llvm::Value*> indices,
                                                           DataType value_dtype) {
   // Flat indices get delegated to the LLVM codegen.
   if (indices.size() == 1) {

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -320,12 +320,12 @@ CodeGenHexagon::PackedCall CodeGenHexagon::MakeCallPackedLowered(const Array<Pri
       t_tvm_value_, builder_->CreatePointerCast(stack_value, t_tvm_value_->getPointerTo()),
       ConstInt32(begin));
   TypedPointer arg_tcode =
-      CreateBufferPtr(stack_tcode, DataType::Int(32), ConstInt32(begin), DataType::Int(32));
+      CreateBufferPtr(stack_tcode, DataType::Int(32), {ConstInt32(begin)}, DataType::Int(32));
   llvm::Value* ret_value = builder_->CreateInBoundsGEP(
       t_tvm_value_, builder_->CreatePointerCast(stack_value, t_tvm_value_->getPointerTo()),
       ConstInt32(end));
   TypedPointer ret_tcode =
-      CreateBufferPtr(stack_tcode, DataType::Int(32), ConstInt32(end), DataType::Int(32));
+      CreateBufferPtr(stack_tcode, DataType::Int(32), {ConstInt32(end)}, DataType::Int(32));
 
 #if TVM_LLVM_VERSION >= 90
   auto call_callee = llvm::FunctionCallee(ftype_tvm_func_call_, RuntimeTVMFuncCall());

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -791,7 +791,7 @@ llvm::Constant* CodeGenLLVM::GetConstString(const std::string& str) {
 
 CodeGenLLVM::TypedPointer CodeGenLLVM::CreateBufferPtr(llvm::Value* buffer_ptr,
                                                        DataType buffer_element_dtype,
-                                                       std::vector<llvm::Value*> indices,
+                                                       llvm::ArrayRef<llvm::Value*> indices,
                                                        DataType value_dtype) {
   ICHECK_EQ(indices.size(), 1) << "CodeGenLLVM requires all buffers to be flat 1-d buffers.";
   llvm::Value* index = indices[0];

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1284,6 +1284,10 @@ void CodeGenLLVM::BufferAccessHelper(
         make_instruction) {
   DataType buffer_element_dtype = buffer->dtype;
 
+  ICHECK_GE(indices.size(), 1)
+      << "Buffer " << buffer->name << " is accessed with no indices.  "
+      << "0-d scalar buffers are expected to be flattened to 1-d buffers prior to codegen.";
+
   // Only the last index is allowed to be multi-lane.  All earlier
   // indices must be scalar.  This only matters for subclasses of
   // CodeGenLLVM, because the default implementation of GetBufferPtr
@@ -1296,11 +1300,7 @@ void CodeGenLLVM::BufferAccessHelper(
     earlier_index_values.push_back(MakeValue(indices[i]));
   }
 
-  ICHECK_GE(indices.size(), 1)
-      << "Buffer " << buffer->name << " is accessed with no indices.  "
-      << "0-d scalar buffers are expected to be flattened to 1-d buffers prior to codegen.";
   PrimExpr last_index = indices[indices.size() - 1];
-
   ICHECK_EQ(value_dtype.lanes(), last_index.dtype().lanes() * buffer_element_dtype.lanes());
 
   bool is_volatile = volatile_buf_.count(buffer->data.get());

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -791,7 +791,11 @@ llvm::Constant* CodeGenLLVM::GetConstString(const std::string& str) {
 
 CodeGenLLVM::TypedPointer CodeGenLLVM::CreateBufferPtr(llvm::Value* buffer_ptr,
                                                        DataType buffer_element_dtype,
-                                                       llvm::Value* index, DataType value_dtype) {
+                                                       std::vector<llvm::Value*> indices,
+                                                       DataType value_dtype) {
+  ICHECK_EQ(indices.size(), 1) << "CodeGenLLVM requires all buffers to be flat 1-d buffers.";
+  llvm::Value* index = indices[0];
+
   llvm::PointerType* buffer_ptr_type = llvm::dyn_cast<llvm::PointerType>(buffer_ptr->getType());
   ICHECK(buffer_ptr_type != nullptr);
   auto address_space = buffer_ptr_type->getAddressSpace();
@@ -1010,7 +1014,7 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
       index = r->base;
     }
     TypedPointer buffer_ptr = CreateBufferPtr(MakeValue(load->buffer->data), load->buffer->dtype,
-                                              MakeValue(index), load->dtype);
+                                              {MakeValue(index)}, load->dtype);
     unsigned addrspace =
         llvm::dyn_cast<llvm::PointerType>(buffer_ptr.addr->getType())->getAddressSpace();
     return builder_->CreatePointerCast(buffer_ptr.addr, t_char_->getPointerTo(addrspace));
@@ -1274,39 +1278,56 @@ bool CodeGenLLVM::HasAlignmentPadding(DataType dtype) {
 }
 
 void CodeGenLLVM::BufferAccessHelper(
-    Buffer buffer, PrimExpr index, DataType value_dtype,
+    Buffer buffer, Array<PrimExpr> indices, DataType value_dtype,
     std::function<llvm::Instruction*(TypedPointer buffer_ptr, int subelement_i, int alignment,
                                      bool is_volatile)>
         make_instruction) {
   DataType buffer_element_dtype = buffer->dtype;
 
-  ICHECK_EQ(value_dtype.lanes(), index.dtype().lanes() * buffer_element_dtype.lanes());
+  // Only the last index is allowed to be multi-lane.  All earlier
+  // indices must be scalar.  This only matters for subclasses of
+  // CodeGenLLVM, because the default implementation of GetBufferPtr
+  // requires 1-d indices.
+  std::vector<llvm::Value*> earlier_index_values;
+  for (size_t i = 0; i < indices.size() - 1; i++) {
+    ICHECK_EQ(indices[i].dtype().lanes(), 1)
+        << "Buffer " << buffer->name << " is accessed with a multi-lane index at position " << i
+        << ".  Multi-lane indices are only supported as the last index.";
+    earlier_index_values.push_back(MakeValue(indices[i]));
+  }
+
+  ICHECK_GE(indices.size(), 1)
+      << "Buffer " << buffer->name << " is accessed with no indices.  "
+      << "0-d scalar buffers are expected to be flattened to 1-d buffers prior to codegen.";
+  PrimExpr last_index = indices[indices.size() - 1];
+
+  ICHECK_EQ(value_dtype.lanes(), last_index.dtype().lanes() * buffer_element_dtype.lanes());
 
   bool is_volatile = volatile_buf_.count(buffer->data.get());
 
   // If the buffer index is a contiguous ramp node, we only need to
   // access the first element, then cast to the value type.
-  if (const RampNode* ramp_index = index.as<RampNode>()) {
+  if (const RampNode* ramp_index = last_index.as<RampNode>()) {
     if (ramp_index && is_one(ramp_index->stride)) {
-      index = ramp_index->base;
+      last_index = ramp_index->base;
     }
   }
 
   // All TVM arrays are densely packed.  If the vectorized LLVM type
   // contains padding for alignment, we need to index based on the
   // size of the scalar type to avoid introducing that padding.
-  if (index.dtype().lanes() == 1 && HasAlignmentPadding(buffer_element_dtype)) {
-    index = buffer_element_dtype.lanes() * index;
+  if (last_index.dtype().lanes() == 1 && HasAlignmentPadding(buffer_element_dtype)) {
+    last_index = buffer_element_dtype.lanes() * last_index;
     buffer_element_dtype = buffer_element_dtype.element_of();
   }
 
   int alignment;
-  if (index.dtype().lanes() == 1) {
+  if (last_index.dtype().lanes() == 1) {
     // If we are accessing with a single index, then the vectorized
     // element being accessed may require more alignment than the
     // underlying data type.
     int native_bits;
-    GetAlignment(value_dtype, buffer->data.get(), index, &alignment, &native_bits);
+    GetAlignment(value_dtype, buffer->data.get(), last_index, &alignment, &native_bits);
   } else {
     // Otherwise, alignment is based on the return value's scalar
     // type.
@@ -1315,35 +1336,35 @@ void CodeGenLLVM::BufferAccessHelper(
   }
 
   llvm::Value* cached_vector_index = nullptr;
-  for (int i = 0; i < index.dtype().lanes(); ++i) {
-    llvm::Value* index_value;
+  for (int i = 0; i < last_index.dtype().lanes(); ++i) {
+    llvm::Value* last_index_value;
     int subelement_i = i;
-    if (const RampNode* ramp = index.as<RampNode>()) {
+    if (const RampNode* ramp = last_index.as<RampNode>()) {
       PrimExpr offset = ramp->base + (ramp->stride * i);
-      index_value = MakeValue(offset);
-    } else if (index.dtype().lanes() > 1) {
+      last_index_value = MakeValue(offset);
+    } else if (last_index.dtype().lanes() > 1) {
       if (i == 0) {
-        cached_vector_index = MakeValue(index);
+        cached_vector_index = MakeValue(last_index);
       }
-      index_value = builder_->CreateExtractElement(cached_vector_index, i);
+      last_index_value = builder_->CreateExtractElement(cached_vector_index, i);
     } else {
-      index_value = MakeValue(index);
+      last_index_value = MakeValue(last_index);
       subelement_i = -1;
     }
 
+    std::vector<llvm::Value*> all_index_values = earlier_index_values;
+    all_index_values.push_back(last_index_value);
+
     TypedPointer buffer_ptr =
-        CreateBufferPtr(MakeValue(buffer->data), buffer_element_dtype, index_value,
-                        value_dtype.with_lanes(value_dtype.lanes() / index.dtype().lanes()));
+        CreateBufferPtr(MakeValue(buffer->data), buffer_element_dtype, all_index_values,
+                        value_dtype.with_lanes(value_dtype.lanes() / last_index.dtype().lanes()));
     auto instruction = make_instruction(buffer_ptr, subelement_i, alignment, is_volatile);
-    AddAliasInfo(instruction, buffer->data.get(), index);
+    AddAliasInfo(instruction, buffer->data.get(), last_index);
   }
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
-  ICHECK_EQ(op->indices.size(), 1) << "CodeGenLLVM expects flattened 1-d buffers.";
-
   DataType value_dtype = op->dtype;
-  PrimExpr index = op->indices[0];
 
   std::vector<llvm::Value*> loads;
 
@@ -1363,7 +1384,10 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
     return load;
   };
 
-  BufferAccessHelper(op->buffer, index, value_dtype, make_load);
+  // Pass all indices into BufferAccessHelper.  In CodeGenLLVM,
+  // non-flat indices will result in an error in CreateBufferPtr, but
+  // a subclass may override CreateBufferPtr.
+  BufferAccessHelper(op->buffer, op->indices, value_dtype, make_load);
 
   if (loads.size() == 1) {
     return loads[0];
@@ -1441,11 +1465,8 @@ void CodeGenLLVM::VisitStmt_(const StoreNode* op) {
 }
 
 void CodeGenLLVM::VisitStmt_(const BufferStoreNode* op) {
-  ICHECK_EQ(op->indices.size(), 1) << "CodeGenLLVM expects flattened 1-d buffers.";
-
   DataType value_dtype = op->value.dtype();
   Var buffer_var = op->buffer->data;
-  PrimExpr buffer_index = op->indices[0];
 
   llvm::Value* value = MakeValue(op->value);
 
@@ -1463,7 +1484,10 @@ void CodeGenLLVM::VisitStmt_(const BufferStoreNode* op) {
 #endif
   };
 
-  BufferAccessHelper(op->buffer, buffer_index, value_dtype, make_store);
+  // Pass all indices into BufferAccessHelper.  In CodeGenLLVM,
+  // non-flat indices will result in an error in CreateBufferPtr, but
+  // a subclass may override CreateBufferPtr.
+  BufferAccessHelper(op->buffer, op->indices, value_dtype, make_store);
 }
 
 void CodeGenLLVM::VisitStmt_(const ForNode* op) {
@@ -1528,6 +1552,10 @@ void CodeGenLLVM::VisitStmt_(const AllocateConstNode* op) {
 }
 
 void CodeGenLLVM::VisitStmt_(const AllocateNode* op) {
+  ICHECK_EQ(op->extents.size(), 1)
+      << "LLVM codegen only supports flat 1-d buffer allocation, but allocation of "
+      << op->buffer_var->name_hint << " is " << op->extents << "-d";
+
   ICHECK(!is_zero(op->condition));
   llvm::Value* buf = nullptr;
 

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -265,7 +265,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    *
    * \param buffer The buffer being accessed
    *
-   * \param index The index at which the buffer is being accessed.
+   * \param indices The indices at which the buffer is being accessed.
    *
    * \param value_dtype The datatype to be read from (BufferLoad) or
    * written to (BufferStore) the buffer.
@@ -286,7 +286,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    *       - Should return the generated expression.
    */
   void BufferAccessHelper(
-      Buffer buffer, PrimExpr index, DataType value_dtype,
+      Buffer buffer, Array<PrimExpr> indices, DataType value_dtype,
       std::function<llvm::Instruction*(TypedPointer buffer_ptr, int subelement_i, int alignment,
                                        bool is_volatile)>
           make_instruction);
@@ -372,8 +372,8 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   llvm::Value* CreateSub(DataType t, llvm::Value* a, llvm::Value* b);
   llvm::Value* CreateMul(DataType t, llvm::Value* a, llvm::Value* b);
   llvm::Value* CreateBroadcast(llvm::Value* value, int lanes);
-  TypedPointer CreateBufferPtr(llvm::Value* buffer_ptr, DataType buffer_element_dtype,
-                               llvm::Value* index, DataType value_dtype);
+  virtual TypedPointer CreateBufferPtr(llvm::Value* buffer_ptr, DataType buffer_element_dtype,
+                                       std::vector<llvm::Value*> indices, DataType value_dtype);
   // Vector concatenation.
   llvm::Value* CreateVecSlice(llvm::Value* vec, int begin, int extent);
   llvm::Value* CreateVecFlip(llvm::Value* vec);

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -373,7 +373,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   llvm::Value* CreateMul(DataType t, llvm::Value* a, llvm::Value* b);
   llvm::Value* CreateBroadcast(llvm::Value* value, int lanes);
   virtual TypedPointer CreateBufferPtr(llvm::Value* buffer_ptr, DataType buffer_element_dtype,
-                                       std::vector<llvm::Value*> indices, DataType value_dtype);
+                                       llvm::ArrayRef<llvm::Value*> indices, DataType value_dtype);
   // Vector concatenation.
   llvm::Value* CreateVecSlice(llvm::Value* vec, int begin, int extent);
   llvm::Value* CreateVecFlip(llvm::Value* vec);

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+import contextlib
+import sys
+import tempfile
+import pathlib
+
+import pytest
+import numpy as np
+
+import tvm
+import tvm.testing
+from tvm import te
+from tvm.tir.stmt_functor import post_order_visit
+
+from .conftest import requires_hexagon_toolchain
+
+# Needed to register the link_shared packedfunc.
+import tvm.contrib.hexagon.hexagon
+
+
+dtype = tvm.testing.parameter("int8")
+batch_size = tvm.testing.parameter(16)
+input_channels = tvm.testing.parameter(32)
+output_channels = tvm.testing.parameter(32)
+input_image_shape = tvm.testing.parameter((64, 64))
+filter_size = tvm.testing.parameter((5, 5))
+
+input_layout = tvm.testing.parameter(
+    "nhwc",
+    "nchw-8h8w32c",
+    "nchw-8h8w32c-flat",
+)
+working_layout = tvm.testing.parameter(
+    "nhwc",
+    "nchw-8h8w32c",
+    "nchw-8h8w32c-flat",
+)
+output_layout = tvm.testing.parameter(
+    "nhwc",
+    "nchw-8h8w32c",
+    "nchw-8h8w32c-flat",
+)
+working_scope = tvm.testing.parameter(
+    "global",
+    "global.vtcm",
+)
+
+
+@tvm.testing.fixture
+def param_validity_check(target_host, input_layout, working_layout, output_layout, working_scope):
+    is_hexagon = target_host.kind.name == "hexagon"
+
+    uses_2d_memory = "nchw-8h8w32c" in [input_layout, working_layout, output_layout]
+    if uses_2d_memory and not is_hexagon:
+        return pytest.raises(tvm.TVMError)
+
+    return contextlib.nullcontext()
+
+
+@tvm.testing.fixture
+def target_host(target):
+    target = tvm.target.Target(target)
+
+    if target.kind.name == "hexagon":
+        # Shouldn't have to modify the target here, current
+        # workaround.  In the future, should move the parameter
+        # handling from tvm.target to target_kind.cc.
+        target = tvm.target.hexagon("v68", link_params=True)
+        host = target
+    else:
+        host = None
+    return tvm.target.Target(target, host=host)
+
+
+@tvm.testing.fixture
+def input_shape(batch_size, input_channels, input_image_shape):
+    return [batch_size, *input_image_shape, input_channels]
+
+
+def transform_shape(shape, layout):
+    if layout == "nhwc":
+        return shape
+    elif layout in ["nchw-8h8w32c", "nchw-8h8w32c-flat"]:
+        N, H, W, C = shape
+        return [N, (C + 31) // 32, (H + 7) // 8, (W + 7) // 8, 8, 8, 32]
+    else:
+        raise RuntimeError(f"Unexpected layout '{layout}'")
+
+
+@tvm.testing.fixture
+def transformed_input_shape(input_shape, input_layout):
+    return transform_shape(input_shape, input_layout)
+
+
+@tvm.testing.fixture
+def transformed_output_shape(output_shape, output_layout):
+    return transform_shape(output_shape, output_layout)
+
+
+@tvm.testing.fixture
+def input_np(input_shape, dtype):
+    return (100 * np.random.uniform(size=input_shape)).astype(dtype)
+
+
+def layout_transform_1d(n, h, w, c):
+    return [
+        n,
+        c // 32,
+        h // 8,
+        w // 8,
+        h % 8,
+        w % 8,
+        c % 32,
+    ]
+
+
+def layout_transform_2d(n, h, w, c):
+    return [
+        n,
+        c // 32,
+        h // 8,
+        w // 8,
+        te.AXIS_SEPARATOR,
+        h % 8,
+        w % 8,
+        c % 32,
+    ]
+
+
+def extract_buffers(stmt):
+    buffers = []
+
+    def visitor(node):
+        if isinstance(node, (tvm.tir.BufferLoad, tvm.tir.BufferStore, tvm.tir.BufferRealize)):
+            buffers.append(node.buffer)
+
+    post_order_visit(stmt, visitor)
+    return buffers
+
+
+class TestElementWise:
+    @tvm.testing.fixture
+    def output_np(self, input_np):
+        return 2 * input_np
+
+    @tvm.testing.fixture
+    def output_shape(self, input_shape):
+        return input_shape
+
+    @tvm.testing.fixture
+    def schedule_args(
+        self,
+        input_shape,
+        dtype,
+        input_layout,
+        output_layout,
+        working_layout,
+        working_scope,
+    ):
+        InputTensor = te.placeholder(input_shape, dtype, name="Input")
+        OutputTensor = te.compute(
+            shape=InputTensor.shape,
+            fcompute=lambda *indices: 2 * InputTensor[indices],
+            name="Output",
+        )
+        schedule = te.create_schedule(OutputTensor.op)
+
+        WriteCache = schedule.cache_write(OutputTensor, working_scope)
+        ReadCache = schedule.cache_read(InputTensor, working_scope, [WriteCache])
+
+        def apply_transform(tensor, layout):
+            if layout == "nhwc":
+                pass
+            elif layout == "nchw-8h8w32c":
+                return schedule[tensor].transform_layout(layout_transform_2d)
+            elif layout == "nchw-8h8w32c-flat":
+                return schedule[tensor].transform_layout(layout_transform_1d)
+            else:
+                raise RuntimeError(f"Unexpected layout '{layout}'")
+
+        apply_transform(InputTensor, input_layout)
+        compute_loopnest = apply_transform(OutputTensor, output_layout) or OutputTensor.op.axis
+        schedule[WriteCache].compute_at(schedule[OutputTensor], compute_loopnest[0])
+
+        apply_transform(ReadCache, working_layout)
+        apply_transform(WriteCache, working_layout)
+
+        return [schedule, [InputTensor, OutputTensor]]
+
+    @tvm.testing.fixture
+    def ir_module(self, schedule_args):
+        # If the two buffers are accessed with the same indices, CSE
+        # will replace them with a Let binding.  Since this makes it
+        # harder to test what the transformed indices are, disabling
+        # the CSE pass for this test.
+        with tvm.transform.PassContext(disabled_pass=["tir.CommonSubexprElimTIR"]):
+            return tvm.lower(*schedule_args)
+
+    @tvm.testing.fixture
+    def uses_unsupported_physical_dimensions(
+        self, target_host, input_layout, working_layout, output_layout
+    ):
+        uses_2d_memory = "nchw-8h8w32c" in [input_layout, working_layout, output_layout]
+        can_handle_2d_memory = target_host.kind.name == "hexagon"
+
+        return uses_2d_memory and not can_handle_2d_memory
+
+    def test_param_shapes(self, ir_module, transformed_input_shape, transformed_output_shape):
+        func = ir_module["main"]
+        primfunc_input_shape, primfunc_output_shape = [
+            list(func.preflattened_buffer_map[param].shape) for param in func.params
+        ]
+        assert primfunc_input_shape == transformed_input_shape
+        assert primfunc_output_shape == transformed_output_shape
+
+    def test_cache_shape(self, ir_module, input_layout, working_layout, output_layout):
+        func = ir_module["main"]
+        for buffer in extract_buffers(func.body):
+            buffer_layout = {
+                "Input": input_layout,
+                "Input.global": working_layout,
+                "Output.global": working_layout,
+                "Input.global.vtcm": working_layout,
+                "Output.global.vtcm": working_layout,
+                "Output": output_layout,
+            }[buffer.name]
+
+            expected_physical_dimensions = {
+                "nhwc": 1,
+                "nchw-8h8w32c": 2,
+                "nchw-8h8w32c-flat": 1,
+            }[buffer_layout]
+
+            assert len(buffer.shape) == expected_physical_dimensions
+
+    def test_lower(self, schedule_args):
+        return tvm.lower(*schedule_args)
+
+    @requires_hexagon_toolchain
+    def test_build(self, schedule_args, target_host, input_layout, working_layout, output_layout):
+        context = contextlib.nullcontext()
+
+        is_hexagon = target_host.kind.name == "hexagon"
+        uses_2d_memory = "nchw-8h8w32c" in [input_layout, working_layout, output_layout]
+        if uses_2d_memory and not is_hexagon:
+            context = pytest.raises(tvm.TVMError)
+
+        with context:
+            tvm.build(*schedule_args, target=target_host)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import contextlib
 import sys
 import tempfile


### PR DESCRIPTION
The primary goal of this PR is to add codegen for 2d physical layouts in CodeGenHexagon.

* Correctly update buffer objects in `IndexMap`.
* Extend `CodeGenLLVM::BufferAccessHelper` to allow for N-d buffer access.  `CodeGenLLVM` is still limited to flat 1-d memory buffers, but this allows subclasses to support some forms of N-d buffers by overriding `Subclass::CreateBufferPtr`.
* Implement `CodeGenHexagon::CreateBufferPtr` to allow for 2-d buffer access.
* Added unit tests to define desired behavior.  Currently, this only checks that the Hexagon module can be built.  Tests to verify that the generated code will produce expected results depends on allocation support added in #10558.