### PR TITLE
[TVMC] compile: Check if FILE exists

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -29,7 +29,7 @@ from tvm.driver.tvmc.registry import generate_registry_args, reconstruct_registr
 from tvm.target import Target
 from tvm.relay.backend import Executor, Runtime
 
-from . import composite_target, frontends
+from . import composite_target, frontends, TVMCException
 from .model import TVMCModel, TVMCPackage
 from .main import register_parser
 from .target import target_from_cli, generate_target_args, reconstruct_target_args
@@ -153,6 +153,11 @@ def drive_compile(args):
         Zero if successfully completed
 
     """
+    if not os.path.isfile(args.FILE):
+        raise TVMCException(
+            f"Input file '{args.FILE}' doesn't exist, is a broken symbolic link, or a directory."
+        )
+
     tvmc_model = frontends.load_model(args.FILE, args.model_format, args.input_shapes)
 
     dump_code = [x.strip() for x in args.dump_code.split(",")] if args.dump_code else None


### PR DESCRIPTION
Currently when a non-existing FILE is passed to 'tvmc compile' it throws
a traceback because a FileNotFoundError exception is not handled. Since
there is no need for such abrupt exit, and the trace can also confuse
users, this commit fixes it by checking if FILE indeed exists, informing
the user about the non-existing FILE before exiting.