### PR TITLE
[CI] Pin numpy version in image build

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -27,7 +27,7 @@ pip3 install --upgrade \
     cython \
     decorator \
     mypy \
-    numpy \
+    numpy~=1.19.5 \
     orderedset \
     packaging \
     Pillow \


### PR DESCRIPTION
Tensorflow `2.4.2` expects the version of numpy to be `~=1.19.5`, however pip installing numpy will attempt to install `1.21.5` by default. Therefore, pinning the version of numpy when building the docker image to be `~=1.19.5` until the version of Tensorflow is upgraded.

cc @leandron @driazati @areusch 
