### PR TITLE
[Docker] Move psutil installation to ubuntu_install_python_package

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -31,6 +31,7 @@ pip3 install --upgrade \
     orderedset \
     packaging \
     Pillow \
+    psutil \
     pytest \
     pytest-profiling \
     pytest-xdist \

--- a/docker/install/ubuntu_install_redis.sh
+++ b/docker/install/ubuntu_install_redis.sh
@@ -22,5 +22,4 @@ set -o pipefail
 
 apt-get update && apt-get install -y redis-server
 pip3 install \
-    psutil \
     xgboost==1.4.2


### PR DESCRIPTION
Previously, psutil was installed as part of `ubuntu_install_redis.sh`, which was included as part of the ci_arm, ci_gpu, ci_gpu, ci_qemu, and ci_i386 docker images.  However, it was not included as part of the ci_hexagon docker image.  Since this is a more general python package used in terminating rpc server/tracker children, moving it to the more general location.