### PR TITLE
[CI] Remove mps3_an547 from the CI

### DIFF
--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -28,11 +28,6 @@ make cython3
 run_pytest ctypes python-microtvm-zephyr-qemu_x86 tests/micro/zephyr --zephyr-board=qemu_x86
 run_pytest ctypes python-microtvm-zephyr-qemu_riscv32 tests/micro/zephyr --zephyr-board=qemu_riscv32
 run_pytest ctypes python-microtvm-zephyr-qemu_riscv64 tests/micro/zephyr --zephyr-board=qemu_riscv64
-run_pytest ctypes python-microtvm-zephyr-mps3_an547 tests/micro/zephyr --zephyr-board=mps3_an547
-
-# Temporarily removing mps2_an512 from CI due to issue 8728:
-# https://github.com/apache/tvm/issues/8728
-# run_pytest ctypes python-microtvm-zephyr tests/micro/zephyr --zephyr-board=mps2_an521
 
 # Arduino
 run_pytest ctypes python-microtvm-arduino apps/microtvm/arduino/template_project/tests


### PR DESCRIPTION
Mark tests/micro/zephyr/test_zephyr.py::test_platform_timer test as
flaky on virtualized board mps3_an547 (QEMU), since it seems to be
specially flaky when running in the CI environment.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
