### PR TITLE
[Testing] Add model loader for int8 BERT

### DIFF
--- a/python/tvm/meta_schedule/testing/tlcbench.py
+++ b/python/tvm/meta_schedule/testing/tlcbench.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=invalid-name,import-outside-toplevel
+# type: ignore
 """Model loader for TLCBench."""
 import os
 import logging

--- a/python/tvm/meta_schedule/testing/tlcbench.py
+++ b/python/tvm/meta_schedule/testing/tlcbench.py
@@ -25,7 +25,7 @@ from tvm.error import TVMError
 from tvm.contrib.download import download_testdata
 
 
-log = logging.getLogger("tlcbench")
+log = logging.getLogger(__name__)
 
 
 def convert_to_qnn(onnx_path, json_path, params_path, batch_size, seq_len):

--- a/python/tvm/meta_schedule/testing/tlcbench.py
+++ b/python/tvm/meta_schedule/testing/tlcbench.py
@@ -97,8 +97,8 @@ def load_quantized_bert_base(batch_size=1, seq_len=384):
     onnx_path = download_testdata(url, "bert-base-qat.onnx", module="tlcbench")
     data_dir = os.path.dirname(onnx_path)
 
-    json_path = os.path.join(data_dir, "bert_base_int8.json")
-    params_path = os.path.join(data_dir, "bert_base_int8.params")
+    json_path = os.path.join(data_dir, "bert_base_int8_b%d_s%d.json" % (batch_size, seq_len))
+    params_path = os.path.join(data_dir, "bert_base_int8_b%d_s%d.params" % (batch_size, seq_len))
 
     # Input names and order encoded in the ONNX model
     input_info = [

--- a/python/tvm/meta_schedule/testing/tlcbench.py
+++ b/python/tvm/meta_schedule/testing/tlcbench.py
@@ -63,6 +63,10 @@ def deserialize_relay(json_path, params_path):
 
 
 def load_quantized_bert_base(batch_size=1, seq_len=384):
+    """
+    Load the quantized bert-base model from TLCBench, possibly downloading it from github
+    and caching the converted int8 QNN module to disk.
+    """
     url = "https://github.com/tlc-pack/TLCBench/raw/main/models/bert-base-qat.onnx"
     log.info("Downloading quantized bert-base model.")
     onnx_path = download_testdata(url, "bert-base-qat.onnx", module="tlcbench")

--- a/python/tvm/meta_schedule/testing/tlcbench.py
+++ b/python/tvm/meta_schedule/testing/tlcbench.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name,import-outside-toplevel
 """Model loader for TLCBench."""
 import os
 import logging
@@ -27,6 +28,7 @@ log = logging.getLogger("tlcbench")
 
 
 def convert_to_qnn(onnx_path, json_path, params_path, batch_size, seq_len):
+    """Run the ONNX frontend and the FQ2I pass. The output is serialized to disk."""
     import onnx
 
     onnx_model = onnx.load(onnx_path)

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -32,6 +32,8 @@ from tvm.meta_schedule.utils import derived_object
 from tvm.script import tir as T
 from tvm.target import Target
 from tvm.tir import Schedule
+from tvm.meta_schedule.testing.tlcbench import load_quantized_bert_base
+from tvm.meta_schedule.tune import extract_task_from_relay
 
 # pylint: disable=no-member,line-too-long,too-many-nested-blocks,unbalanced-tuple-unpacking,no-self-argument,missing-docstring,invalid-name
 
@@ -152,6 +154,21 @@ def test_meta_schedule_integration_apply_history_best():
     )
     mod = env.query(task_name="mock-task", mod=mod, target=target, dispatched=[MockModule])
     assert tvm.ir.structural_equal(mod, workload.mod)
+
+
+@pytest.mark.skip("Too slow on CI")
+def extract_task_qbert():
+    mod, params = load_quantized_bert_base(batch_size=1, seq_len=128)
+    target = "llvm"
+    extracted_tasks = extract_task_from_relay(mod, target, params)
+    tune_tasks = list(
+        filter(
+            lambda task: "dense" in task.task_name or "batch_matmul" in task.task_name,
+            extracted_tasks,
+        )
+    )
+    # three int8 dense, two int8 bmm, and one fp32 dense
+    assert len(tune_tasks) == 6
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -158,7 +158,7 @@ def test_meta_schedule_integration_apply_history_best():
 
 @pytest.mark.skip("Too slow on CI")
 def extract_task_qbert():
-    mod, params = load_quantized_bert_base(batch_size=1, seq_len=128)
+    mod, params, _ = load_quantized_bert_base(batch_size=1, seq_len=128)
     target = "llvm"
     extracted_tasks = extract_task_from_relay(mod, target, params)
     tune_tasks = list(


### PR DESCRIPTION
Following https://github.com/tlc-pack/TLCBench/pull/5, add an easy API to load the int8 BERT model. Currently it sits under `meta_schedule/testing/tlcbench.py` but `relay/testing/tlcbench.py` is also fine.

@junrushao1994 @sunggg @AndrewZhaoLuo @mbrookhart @jwfromm 