### PR TITLE
[Hexagon] Add support for Hexagon v69, deprecate v60 and v62

### DIFF
--- a/apps/hexagon_launcher/README.md
+++ b/apps/hexagon_launcher/README.md
@@ -45,7 +45,7 @@ following variables set:
 ```
 cmake -DCMAKE_C_COMPILER=/path/to/hexagon-clang \
       -DCMAKE_CXX_COMPILER=/path/to/hexagon-clang++ \
-      -DUSE_HEXAGON_ARCH=v65|v66|v68 \
+      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69 \
       -DUSE_HEXAGON_SDK=/path/to/hexagon/SDK \
       /path/to/apps/hexagon_launcher/cmake/hexagon
 ```
@@ -63,7 +63,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/android-ndk/build/cmake/android.toolchain.
       -DANDROID_ABI=arm64-v8a \
       -DANDROID_PLATFORM=android-28 \
       -DUSE_HEXAGON_SDK=/p/Hexagon_SDK/4.3.0.0
-      -DUSE_HEXAGON_ARCH=v65|v66|v68
+      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69
       /path/to/apps/hexagon_launcher/cmake/android
 ```
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -307,7 +307,7 @@ set(USE_HEXAGON_PROXY_RPC OFF)
 # compiling _by_ TVM). This applies to components like the TVM runtime, but is
 # also used to select correct include/library paths from the Hexagon SDK when
 # building offloading runtime for Android.
-# Valid values are v60, v62, v65, v66, v68.
+# Valid values are v65, v66, v68, v69.
 set(USE_HEXAGON_ARCH "v66")
 
 # Whether to use ONNX codegen

--- a/cmake/modules/HexagonSDK.cmake
+++ b/cmake/modules/HexagonSDK.cmake
@@ -72,11 +72,12 @@ function(_get_hexagon_sdk_property_impl
   set(_hexarch_dir_v65 "computev65")
   set(_hexarch_dir_v66 "computev66")
   set(_hexarch_dir_v68 "computev68")
+  set(_hexarch_dir_v69 "computev68")   # Use computev68 for v69
   set(_hexarch_dir_str "_hexarch_dir_${_hexagon_arch}")
   set(_hexarch_dir "${${_hexarch_dir_str}}")
 
   if(NOT _hexarch_dir)
-    message(SEND_ERROR "Please set Hexagon architecture to one of v65, v66, v68")
+    message(SEND_ERROR "Please set Hexagon architecture to one of v65, v66, v68, v69")
   endif()
 
   if(_property STREQUAL "VERSION")

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -547,7 +547,7 @@ def hexagon(cpu_ver="v66", **kwargs):
     # llvm -mtriple=hexagon -mcpu=hexagonv66 -mattr=+hvxv66,+hvx-length128b
 
     # Check for valid codegen cpu
-    valid_hex = ["v60", "v62", "v65", "v66", "v67", "v67t", "v68"]
+    valid_hex = ["v65", "v66", "v67", "v67t", "v68", "v69"]
     try:
         cpu_ver = cpu_ver[cpu_ver.index("v") :].lower()
         assert cpu_ver in valid_hex

--- a/tests/python/contrib/test_hexagon/test_launcher.md
+++ b/tests/python/contrib/test_hexagon/test_launcher.md
@@ -43,7 +43,7 @@ cd build
 cmake -DUSE_ANDROID_TOOLCHAIN="path to `android-ndk/build/cmake/android.toolchain.cmake` file" \
         -DANDROID_PLATFORM=android-28 \
         -DANDROID_ABI=arm64-v8a \
-        -DUSE_HEXAGON_ARCH=v65|v66|v68 \
+        -DUSE_HEXAGON_ARCH=v65|v66|v68|v69 \
         -DUSE_HEXAGON_SDK="path to Hexagon SDK" \
         -DUSE_HEXAGON_TOOLCHAIN="path to Hexagon toolchain `Tools` sub-directory which explained above" \
         -DUSE_OUTPUT_BINARY_DIR="path to `build/hexagon_api_output` which is a sub-directory of `tvm`" ..
@@ -62,7 +62,7 @@ cmake -DUSE_LLVM="path to `llvm/bin/llvm-config`" \
         -DCMAKE_CXX_COMPILER="path to `clang++` executable" \
         -DCMAKE_CXX_FLAGS='-stdlib=libc++' \
         -DUSE_HEXAGON_SDK="path to Hexagon SDK" \
-        -DUSE_HEXAGON_ARCH="choose from v65|v66|v68" \
+        -DUSE_HEXAGON_ARCH="choose from v65|v66|v68|v69" \
         -DUSE_HEXAGON_DEVICE=sim ..
 ```
 


### PR DESCRIPTION
- The `tvm.target.hexagon()` function now accepts v69.
- Hexagon SDK 4.x does not support v60 and v62, so they have been removed.