### PR TITLE
[skip ci][ci] Add missing guard to skip CI check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ def cancel_previous_build() {
 }
 
 def should_skip_ci(pr_number) {
-  if (!env.BRANCH_NAME.startsWith('PR-')) {
+  if (env.BRANCH_NAME == null || !env.BRANCH_NAME.startsWith('PR-')) {
     // never skip CI on build sourced from a branch
     return false
   }


### PR DESCRIPTION
This was failing in the docker image validation since the `BRANCH_NAME` environment variable wasn't set. The part in question still runs even with the `skip ci`

https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdocker-image-run-tests/detail/docker-image-run-tests/62/pipeline/

cc @areusch

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
