### PR TITLE
[Runtime][PipelineExecutor] Setting CPU affinity for the Runtime of pipeline.

### DIFF
--- a/python/tvm/contrib/pipeline_executor.py
+++ b/python/tvm/contrib/pipeline_executor.py
@@ -510,6 +510,7 @@ class PipelineConfig(object):
             self.target = None
             self.name = None
             self.dev = None
+            self.cpu_affinity = ""
             self.idx = None
             self.mod = mod
             self.input_params = InferType()(mod)["main"].params
@@ -685,6 +686,7 @@ class PipelineConfig(object):
                 output_conf.append(output)
 
             mconf["mod_idx"] = module.idx
+            mconf["cpu_affinity"] = module.cpu_affinity
             mconf["output"] = output_conf
 
             module_connection[mod] = {


### PR DESCRIPTION
RFC: https://github.com/apache/tvm-rfcs/blob/main/rfcs/0014-pipeline-executor.md
ISSUE: https://github.com/apache/tvm/issues/8596

This patch add the function to set cpu affinity for the runtime of the pipeline. By using the said function, user for example can let the first runtime of the pipeline to use the cpu [0,1] only, and the second runtime to use the cpu [2, 3] only.