### PR TITLE
query rpc tracker - sort servers by key name

### DIFF
--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -332,7 +332,7 @@ class TrackerSession(object):
         sorted_server = sorted(data["server_info"], key=lambda x: x["key"])
         for item in sorted_server:
             addr = item["addr"]
-            res += "%21s    " % ':'.join(addr)
+            res += "%21s    " % ":".join(addr)
             res += item["key"] + "\n"
             key = item["key"].split(":")[1]  # 'server:rasp3b` -> 'rasp3b'
             if key not in total_ct:

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -326,18 +326,19 @@ class TrackerSession(object):
 
         res = ""
         res += "Server List\n"
-        res += "----------------------------\n"
-        res += "server-address\tkey\n"
-        res += "----------------------------\n"
-        for item in data["server_info"]:
+        res += "------------------------------\n"
+        res += "server-address           key\n"
+        res += "------------------------------\n"
+        sorted_server = sorted(data["server_info"], key=lambda x: x["key"])
+        for item in sorted_server:
             addr = item["addr"]
-            res += str(addr[0]) + ":" + str(addr[1]) + "\t"
+            res += "%21s    " % ':'.join(addr)
             res += item["key"] + "\n"
             key = item["key"].split(":")[1]  # 'server:rasp3b` -> 'rasp3b'
             if key not in total_ct:
                 total_ct[key] = 0
             total_ct[key] += 1
-        res += "----------------------------\n"
+        res += "------------------------------\n"
         res += "\n"
 
         # compute max length of device key


### PR DESCRIPTION
Hello,

I have created simple PR, currenly when I have multiple RPC server I can see then in random order, another issue is that ip address can have different length, e.g. 1.1.1.1 is 7, and 255.255.255.255 is 15, so the output may looks like:
```
Server List
----------------------------
server-address     key
----------------------------
172.31.8.8:5001 server:prague
172.31.8.3:5001 server:plex
172.31.8.12:5001        server:plex
172.31.8.4:5001 server:prague
172.31.8.13:5001        server:plex
172.31.8.5:5001 server:prague
172.31.8.13:5001        server:plex
----------------------------
```

after my changes:
```
Server List
------------------------------
server-address           key
------------------------------
     172.31.8.12:5001    server:plex
      172.31.8.3:5001    server:plex
     172.31.8.13:5001    server:plex
     172.31.8.13:5001    server:plex
      172.31.8.8:5001    server:prague
      172.31.8.4:5001    server:prague
      172.31.8.5:5001    server:prague
------------------------------

```