### PR TITLE
[C Codegen] Remove global packed variables when interface_api="packed" and target="c"

### DIFF
--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -66,8 +66,6 @@ class CodeGenCHost : public CodeGenC {
   struct FunctionInfo {
     /* \brief function name */
     std::string func_name;
-    /* packed name of the function */
-    std::string func_name_packed;
     /* number of arguments required by the function */
     int64_t num_args;
     /* \brief name of resource_handle to pass */
@@ -81,7 +79,8 @@ class CodeGenCHost : public CodeGenC {
   /*! \brief whether to emit asserts in the resulting C code */
   bool emit_asserts_;
 
-  FunctionInfo GetFunctionInfo(const CallNode* op, bool has_resource_handle = false);
+  FunctionInfo GetFunctionInfo(const CallNode* op, bool has_resource_handle);
+  std::string GetPackedName(const CallNode* op);
   void PrintGetFuncFromBackend(const std::string& func_name, const std::string& packed_func_name);
   void PrintFuncCall(const std::string& packed_func_name, int num_args);
   void PrintFuncCallC(const std::string& packed_func_name, int num_args,

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -18,18 +18,24 @@
 from collections import OrderedDict
 import re
 import sys
+import os
+import tarfile
+import pathlib
+import re
 
 import numpy as np
 import pytest
 
 import tvm
 from tvm import relay, TVMError
+from tvm.contrib import utils
 from tvm.ir.module import IRModule
 from tvm.relay import testing, transform
 from tvm.relay.testing import byoc
 from tvm.relay.op.annotation import compiler_begin, compiler_end
 from tvm.relay.backend import Executor, Runtime
 from tvm.micro import model_library_format as mlf
+from tvm.micro import export_model_library_format
 from aot_test_utils import (
     AOTTestModel,
     AOT_DEFAULT_RUNNER,
@@ -160,6 +166,69 @@ def test_conv2d(interface_api, use_unpacked_api, test_runner, groups, weight_sha
         interface_api,
         use_unpacked_api,
     )
+
+
+def test_packed_global_variables():
+    """Check packed global variables in codegen output."""
+    dtype = "float32"
+    ishape = (1, 32, 14, 14)
+    wshape = (32, 32, 3, 3)
+    interface_api = "packed"
+    use_unpacked_api = False
+
+    data0 = relay.var("data", shape=ishape, dtype=dtype)
+    weight0 = relay.var("weight", shape=wshape, dtype=dtype)
+    out = relay.nn.conv2d(data0, weight0, kernel_size=(3, 3), padding=(1, 1), groups=1)
+    main_f = relay.Function([data0, weight0], out)
+    mod = tvm.IRModule()
+    mod["main"] = main_f
+    mod = transform.InferType()(mod)
+
+    i_data = np.random.uniform(0, 1, ishape).astype(dtype)
+    w1_data = np.random.uniform(0, 1, wshape).astype(dtype)
+
+    inputs = OrderedDict([("data", i_data), ("weight", w1_data)])
+
+    output_list = generate_ref_data(mod, inputs)
+    compiled_models_list = compile_models(
+        models=AOTTestModel(module=mod, inputs=inputs, outputs=output_list),
+        interface_api=interface_api,
+        use_unpacked_api=use_unpacked_api,
+        workspace_byte_alignment=8,
+        enable_op_fusion=True,
+        pass_config=AOT_DEFAULT_RUNNER.pass_config,
+        use_runtime_executor=True,
+        target=tvm.target.Target("c"),
+    )
+    compiled_model = compiled_models_list[0]
+
+    tmp_path = utils.tempdir()
+    base_path = tmp_path.temp_dir
+
+    model = compiled_model.model
+    tar_file = os.path.join(base_path, f"{model.name}.tar")
+    export_model_library_format(compiled_model.executor_factory, tar_file)
+    t = tarfile.open(tar_file)
+    t.extractall(base_path)
+
+    with open(
+        pathlib.Path(base_path) / "codegen" / "host" / "src" / f"{model.name}_lib1.c", "r"
+    ) as lib1_f:
+        lib1 = lib1_f.readlines()
+
+    tvmgen_names = []
+    tvmgen_funcs = []
+    for line in lib1:
+        for item in line.split(" "):
+            if item.startswith("tvmgen_default"):
+                # collect any variable names start with tvmgen_default
+                tvmgen_names.append(item)
+                # collect all function names start with tvmgen_default
+                tvmgen_funcs += re.findall(r"(?<=).*(?=\()", item)
+
+    # check if any function name has a packed variable name
+    for func in tvmgen_funcs:
+        assert f"{func}_packed" not in tvmgen_names
 
 
 @parametrize_aot_options


### PR DESCRIPTION
This PR removes adding global variables `_packed` from lib1.c output. It also adds a test to check this. This test finds all function names (`tvmgen_default_X`) and checks if there's any global variable `tvmgen_default_X_packed` in lib1.c output.

cc @areusch 