### PR TITLE
[skip ci][CI] Bump Python version from 3.6 to 3.7 in VitisAI.cmake

### DIFF
--- a/cmake/modules/contrib/VitisAI.cmake
+++ b/cmake/modules/contrib/VitisAI.cmake
@@ -17,9 +17,9 @@
 
 if(USE_VITIS_AI)
   set(PYXIR_SHARED_LIB libpyxir.so)
-  find_package(PythonInterp 3.6 REQUIRED)
+  find_package(PythonInterp 3.7 REQUIRED)
   if(NOT PYTHON)
-    find_program(PYTHON NAMES python3 python3.6)
+    find_program(PYTHON NAMES python3 python3.7)
   endif()
   execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
     "import pyxir as px; print(px.get_include_dir()); print(px.get_lib_dir());"


### PR DESCRIPTION
This is required because we migrated the default version in which dependencies are installed, due to Python 3.6 coming to EOL.

Otherwise, when running on machines updated to use Python 3.7 by default, you'll see:
```

 -- Found PythonInterp: /usr/bin/python3.6 (found suitable version "3.6.9", minimum required is "3.6") 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
 ModuleNotFoundError: No module named 'pyxir'
 CMake Error at cmake/modules/contrib/VitisAI.cmake:36 (message):
   Can't build TVM with Vitis-AI because PyXIR can't be found
 Call Stack (most recent call first):
   CMakeLists.txt:480 (include)
 
```

It needs to be merged after #10654.

cc @jtuyls @areusch @driazati 

