### PR TITLE
[TIR] Bugfix in StorageFlatten, index flattening in PrefetchNode

### DIFF
--- a/tests/python/unittest/test_tir_transform_storage_flatten.py
+++ b/tests/python/unittest/test_tir_transform_storage_flatten.py
@@ -57,6 +57,12 @@ def test_flatten_prefetch():
     assert isinstance(stmt.body, tvm.tir.For)
     assert stmt.body.extent.value == 2
 
+    def assert_flat_loads(stmt):
+        if isinstance(stmt, tvm.tir.BufferLoad):
+            assert len(stmt.indices) == 1, "All prefetch indices should be flattened"
+
+    tvm.tir.stmt_functor.post_order_visit(stmt, assert_flat_loads)
+
 
 def test_flatten_storage_align():
     m = 8


### PR DESCRIPTION
This resolves a bug introduced in https://github.com/apache/tvm/pull/9727, and adds a test to catch this failure mode.  This bug occurred because StorageFlatten's visitor for PrefetchNode inserted additional pre-flattened `BufferLoad` nodes after visiting the body of the Prefetch, preventing those `BufferLoad` nodes from being flattened.  Moving this visit to after the insertion of the `BufferLoad` nodes allows the usual buffer flattening to apply to the newly inserted nodes.