### PR TITLE
[TESTING] Check for toolchain when marking reference system tests

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -69,6 +69,7 @@ import functools
 import logging
 import os
 import platform
+import shutil
 import sys
 import time
 import pickle
@@ -763,7 +764,12 @@ def requires_corstone300(*args):
     f : function
         Function to mark
     """
-    _requires_corstone300 = [pytest.mark.corstone300]
+    _requires_corstone300 = [
+        pytest.mark.corstone300,
+        pytest.mark.skipif(
+            shutil.which("arm-none-eabi-gcc") is None, reason="ARM embedded toolchain unavailable"
+        ),
+    ]
     return _compose(args, _requires_corstone300)
 
 


### PR DESCRIPTION
This mimics the behaviour of aot_test_utils.py to ensure the tests don't start running when the toolchain isn't available.