### PR TITLE
[CI] Set default value for CI_NUM_EXECUTORS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,7 +279,7 @@ def fsim_test(image) {
 
 def cmake_build(image, path, make_flag) {
   sh (
-    script: "${docker_run} ${image} ./tests/scripts/task_build.py --num-executors ${CI_NUM_EXECUTORS} --sccache-bucket tvm-sccache-prod",
+    script: "${docker_run} ${image} ./tests/scripts/task_build.py --sccache-bucket tvm-sccache-prod",
     label: 'Run cmake build',
   )
 }

--- a/tests/scripts/task_build.py
+++ b/tests/scripts/task_build.py
@@ -30,9 +30,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="List pytest nodeids for a folder")
     parser.add_argument("--sccache-bucket", required=False, help="sccache bucket name")
-    parser.add_argument(
-        "--num-executors", required=False, default=1, help="number of Jenkins executors"
-    )
     parser.add_argument("--build-dir", default="build", help="build folder")
     parser.add_argument("--cmake-target", help="optional build target")
     args = parser.parse_args()
@@ -66,7 +63,11 @@ if __name__ == "__main__":
         logging.info("===== sccache stats =====")
         sh.run("sccache --show-stats")
 
-    executors = int(args.num_executors)
+    if "CI" in os.environ:
+        executors = int(os.environ["CI_NUM_EXECUTORS"])
+    else:
+        executors = int(os.environ.get("CI_NUM_EXECUTORS", 1))
+
     nproc = multiprocessing.cpu_count()
 
     available_cpus = nproc // executors

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -32,7 +32,6 @@ export OMP_NUM_THREADS=1
 
 # Build cpptest suite
 python3 tests/scripts/task_build.py \
-    --num-executors "${CI_NUM_EXECUTORS:-1}" \
     --sccache-bucket tvm-sccache-prod \
     --cmake-target cpptest
 

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -32,7 +32,7 @@ export OMP_NUM_THREADS=1
 
 # Build cpptest suite
 python3 tests/scripts/task_build.py \
-    --num-executors "${CI_NUM_EXECUTORS}" \
+    --num-executors "${CI_NUM_EXECUTORS:-1}" \
     --sccache-bucket tvm-sccache-prod \
     --cmake-target cpptest
 


### PR DESCRIPTION
`task_cpp_unittest.sh` relies on `CI_NUM_EXECUTORS` being set as an environment variable, which causes the script to fail if the value is not set. To prevent this, setting the default as 1.
