### PR TITLE
[TIR] CSE-TIR Pass - More deterministic behavior

### DIFF
--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -751,11 +751,8 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
 
   // Traverse through map in a sorted order on keys to maintain deterministic behavior
   // We do this by comparing the string repr of each PrimExpr to get a determinstic ordering
-  std::vector<std::pair<PrimExpr, size_t>> sorted_map_items;
-  sorted_map_items.reserve(table.size());
-  for (auto elem : table) {
-    sorted_map_items.push_back(elem);
-  }
+  std::vector<std::pair<PrimExpr, size_t>> sorted_map_items(table.begin(), table.end());
+
   sort(sorted_map_items.begin(), sorted_map_items.end(),
        [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
          std::stringstream a_stream;

--- a/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
+++ b/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
@@ -158,9 +158,9 @@ def test_deterministic_cse():
     x = te.var("x")
     result = te.var("result")
 
-    rand_ints = sorted([random.randint(1, 10) for i in range(NUM_TERMS)])
-    inc1 = [(x + rand_ints[i]) for i in range(NUM_TERMS)]
-    inc2 = [(x + rand_ints[i]) for i in range(NUM_TERMS)]
+    offsets = sorted([i + 1 for i in range(NUM_TERMS)])
+    inc1 = [(x + offsets[i]) for i in range(NUM_TERMS)]
+    inc2 = [(x + offsets[i]) for i in range(NUM_TERMS)]
 
     expression = x
     for add in inc1 + inc2:
@@ -171,7 +171,6 @@ def test_deterministic_cse():
     initial_hash = None
     for _ in range(REPEATS):
         body = tvm.tir.transform.CommonSubexprElimTIR()(mod)["main"]
-        print(body)
 
         # Hash and ensure serialize json is the same every time
         json_val = save_json(body)

--- a/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
+++ b/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
@@ -14,8 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import hashlib
+
 import tvm
 from tvm import te
+from tvm.ir.base import save_json
+from tvm.ir.module import IRModule
+
 
 # A test program which gives the opportunity for the CSE pass to introduce two new variables, at two different levels
 def test_cse():
@@ -131,6 +136,50 @@ def test_cse():
     assert tvm.ir.structural_equal(body.value, cse_var_2 + z3)
 
     assert isinstance(body.body, tvm.tir.BufferStore)
+
+
+def test_deterministic_cse():
+    import random
+
+    """Test deterministic allocation of CSE vars
+
+    We expect something like
+
+        result = (x + 1) + (x + 2) + (x + 3) + (x + 1) + (x + 2) + (x + 3)
+            -->
+        cse_var_3 = (x + 1)
+        cse_var_2 = (x + 2)
+        cse_var_1 = (x + 3)
+        result = cse_var_3 + cse_var_2 + cse_var_1 + cse_var_3 + cse_var_2 + cse_var_1
+    """
+    NUM_TERMS = 10
+    REPEATS = 10
+
+    x = te.var("x")
+    result = te.var("result")
+
+    rand_ints = sorted([random.randint(1, 10) for i in range(NUM_TERMS)])
+    inc1 = [(x + rand_ints[i]) for i in range(NUM_TERMS)]
+    inc2 = [(x + rand_ints[i]) for i in range(NUM_TERMS)]
+
+    expression = x
+    for add in inc1 + inc2:
+        expression = expression + add
+    let_stmt = tvm.tir.LetStmt(result, expression, tvm.tir.Evaluate(result))
+    mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([x], let_stmt))
+
+    initial_hash = None
+    for _ in range(REPEATS):
+        body = tvm.tir.transform.CommonSubexprElimTIR()(mod)["main"]
+        print(body)
+
+        # Hash and ensure serialize json is the same every time
+        json_val = save_json(body)
+        json_hash = hashlib.sha256(json_val.encode()).hexdigest()
+
+        if initial_hash is None:
+            initial_hash = json_hash
+        assert json_hash == initial_hash
 
 
 # First specific test for if nodes : Some duplicated computations appear only in one branch (here the Then branch), not in both branches.


### PR DESCRIPTION
Running the CSE-TIR pass led to some variation in lowering to TIR from the same schedule multiple times. I tracked this down to iterating over an unordered map. I think having consistency in lowering to TIR is a desirable property to have so I made the offending code a little better in this regard.

Example test script:
https://github.com/AndrewZhaoLuo/TVM-Sandbox/blob/19284ddbd6bb28af61c0c2aa8bb334c5c53731a7/tir/test_inconsistent_tir_lowering.py#L1 

^--- Running the above off main produces different hashes every time, running after this diff it produces the same hash.

There may be more examples of non-determinism in CSE-TIR but this is what I found for now 👀