### PR TITLE
[BYOC-DNNL] enhance GetRootCall to support more topology

### DIFF
--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -449,11 +449,12 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
   }
 
   ICHECK_GT(current_call->args.size(), 0);
-  int i = 0;
-  while (i < current_call->args.size() && current_call->args[i].as<VarNode>()) {
-      i++;
+  int valid_node_idx = 0;
+  while (valid_node_idx < current_call->args.size() &&
+         current_call->args[valid_node_idx].as<VarNode>()) {
+    valid_node_idx++;
   }
-  const auto* next_call = current_call->args[i].as<CallNode>();
+  const auto* next_call = current_call->args[valid_node_idx].as<CallNode>();
   return GetRootCall(next_call, depth - 1, expected_op_names);
 }
 

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -449,8 +449,11 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
   }
 
   ICHECK_GT(current_call->args.size(), 0);
-
-  const auto* next_call = current_call->args[0].as<CallNode>();
+  int i = 0;
+  while (i < current_call->args.size() && current_call->args[i].as<VarNode>()) {
+      i++;
+  }
+  const auto* next_call = current_call->args[i].as<CallNode>();
   return GetRootCall(next_call, depth - 1, expected_op_names);
 }
 


### PR DESCRIPTION
This PR aims to enhance the `GetRootCall` function to support various topology.

The original `GetRootCall` only supports dnnl_pattern like `add(add(conv(data, weight), bias), sum_data)`.
But we encountered `add(sum_data, add(conv(data, weight), bias))` in `ResNetV2`, which cannot be supported by the original design.
Enhance this function can simply solve this issue.