### PR TITLE
[microNPU] Remove xfail from test_clz

### DIFF
--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -926,7 +926,6 @@ def test_ethosu_section_name():
     )
 
 
-@pytest.mark.xfail(strict=False, reason="See https://github.com/apache/tvm/issues/10487")
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
 def test_ethosu_clz(accel_type):
     np.random.seed(0)


### PR DESCRIPTION
After #10640 we can re-enable the flaky clz test, mentioned in #10487.

cc @ekalda @manupa-arm 
