### PR TITLE
[TESTING] Mark x86 specific test

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -68,6 +68,7 @@ import ctypes
 import functools
 import logging
 import os
+import platform
 import sys
 import time
 import pickle
@@ -543,6 +544,22 @@ def uses_gpu(*args):
     """
     _uses_gpu = [pytest.mark.gpu]
     return _compose(args, _uses_gpu)
+
+
+def requires_x86(*args):
+    """Mark a test as requiring the x86 Architecture to run.
+
+    Tests with this mark will not be run unless on an x86 platform.
+
+    Parameters
+    ----------
+    f : function
+        Function to mark
+    """
+    _requires_x86 = [
+        pytest.mark.skipif(platform.machine() != "x86_64", reason="x86 Architecture Required"),
+    ]
+    return _compose(args, _requires_x86)
 
 
 def requires_gpu(*args):

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -1644,6 +1644,7 @@ def test_upsampling3d():
     _test_upsampling3d("NDHWC", "trilinear", "align_corners")
 
 
+@tvm.testing.requires_x86
 @pytest.mark.skipif(tvm.target.codegen.llvm_version_major() < 8, reason="Requires LLVM 8")
 class TestConv2DInt8Intrinsics:
     supported_targets = [


### PR DESCRIPTION
Currently this test crashes pytest on any other architecture, this introduces a decorator which can be used to mark future x86 tests.
