### PR TITLE
[microNPU] Set output tolerance of codegen and network tests to 0

### DIFF
--- a/tests/python/contrib/test_ethosu/infra.py
+++ b/tests/python/contrib/test_ethosu/infra.py
@@ -44,6 +44,7 @@ from tvm.topi.nn.utils import get_pad_tuple
 from tvm.relay.expr_functor import ExprMutator
 from tvm.relay.op.annotation import compiler_begin, compiler_end
 from tvm.relay.backend.contrib.ethosu import preprocess
+import tvm.relay.testing.tf as tf_testing
 
 from tvm.relay.op.contrib.ethosu import partition_for_ethosu
 from tests.python.relay.aot.aot_test_utils import (
@@ -239,6 +240,14 @@ def generate_ref_data_tflite(model):
     }
 
     return input_data, expected_output_data
+
+
+def get_tflite_model(model_url):
+    """Get a TFLite model from URL."""
+    tflite_model_file = tf_testing.get_workload_official(model_url[0], model_url[1])
+    with open(tflite_model_file, "rb") as f:
+        tflite_model_buf = f.read()
+    return tflite_model_buf
 
 
 def get_tflite_graph(tf_func, shapes, ranges=None):

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -270,7 +270,6 @@ def test_ethosu_binary_elementwise(
         shapes=[ifm_shape, ifm2_shape],
         ranges=[(0, 1), (0, 2)],
         accel_type=accel_type,
-        output_tolerance=1 if operator_type == "MAX" else 0,
     )
 
 
@@ -387,12 +386,7 @@ def test_mean(accel_type, ifm_shape, axis, keep_dims, use_same_quantization):
     )
     mod = partition_for_ethosu(mod)
 
-    # TODO(lhutton1) For now output is not bit exact with TFLite.
-    # This is because TFLite reference kernels are not being used.
-    # For this, TFLite will need upgrading to 2.6.
-    compiled_models = infra.build_source(
-        mod, input_data, output_data, accel_type, output_tolerance=1
-    )
+    compiled_models = infra.build_source(mod, input_data, output_data, accel_type)
 
     # Assumes only two runtime.Modules are created -- i.e. single offload module
     ethosu_module = compiled_models[0].executor_factory.lib.imported_modules[0].imported_modules[0]
@@ -438,9 +432,7 @@ def test_elementwise_add_from_constant_scalar(accel_type, dtype, constant):
     }
     output_data = generate_ref_data(cpu_mod, input_data)
 
-    infra.compare_ethosu_with_reference(
-        ethosu_mod, input_data, output_data, accel_type, output_tolerance=0
-    )
+    infra.compare_ethosu_with_reference(ethosu_mod, input_data, output_data, accel_type)
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
@@ -477,9 +469,7 @@ def test_ethosu_left_shift_binary_elemwise(
     output_data = generate_ref_data(cpu_mod, input_data)
     ethosu_mod = partition_for_ethosu(cpu_mod)
 
-    infra.compare_ethosu_with_reference(
-        ethosu_mod, input_data, output_data, accel_type, output_tolerance=0
-    )
+    infra.compare_ethosu_with_reference(ethosu_mod, input_data, output_data, accel_type)
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
@@ -754,10 +744,7 @@ def test_tflite_concat(shapes, axis, accel_type):
         op = tf.concat(list(inputs), axis)
         return op
 
-    # TODO(lhutton1) For now output is not bit exact with TFLite.
-    # This is because TFLite reference kernels are not being used.
-    # For this, TFLite will need upgrading to 2.6.
-    infra.compare_tvm_with_tflite(concat_func, shapes, accel_type, output_tolerance=1)
+    infra.compare_tvm_with_tflite(concat_func, shapes, accel_type)
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
@@ -892,10 +879,7 @@ def test_tflite_resize2d_bilinear(accel_type, ifm_shape, size, align_corners):
             x, size, align_corners=align_corners, half_pixel_centers=False
         )
 
-    # TODO(lhutton1) For now output is not bit exact with TFLite.
-    # This is because TFLite reference kernels are not being used.
-    # For this, TFLite will need upgrading to 2.6.
-    infra.compare_tvm_with_tflite(resize_model, [ifm_shape], accel_type, output_tolerance=1)
+    infra.compare_tvm_with_tflite(resize_model, [ifm_shape], accel_type)
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
@@ -955,10 +939,7 @@ def test_tflite_pack(accel_type, ifm_shapes, axis):
     def pack_func(*inputs):
         return tf.stack(inputs, axis=axis)
 
-    # TODO(lhutton1) For now output is not bit exact with TFLite.
-    # This is because TFLite reference kernels are not being used.
-    # For this, TFLite will need upgrading to 2.6.
-    infra.compare_tvm_with_tflite(pack_func, ifm_shapes, accel_type, output_tolerance=1)
+    infra.compare_tvm_with_tflite(pack_func, ifm_shapes, accel_type)
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)

--- a/tests/python/contrib/test_ethosu/test_networks.py
+++ b/tests/python/contrib/test_ethosu/test_networks.py
@@ -14,25 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name, unused-argument
+# pylint: disable=invalid-name, unused-argument, wrong-import-position
 import pytest
 
 pytest.importorskip("ethosu.vela")
-from tests.python.relay.aot.aot_test_utils import (
-    convert_to_relay,
-    generate_ref_data,
-)
+
 import numpy as np
 
-import tvm
-import tvm.micro as micro
-from tvm import relay
-from tvm.relay.backend.contrib.ethosu import util
 from tvm.relay.op.contrib.ethosu import partition_for_ethosu
-from tests.python.relay.aot.aot_test_utils import create_relay_module_and_inputs_from_tflite_file
 from tvm.micro import model_library_format as mlf
 
-import tvm.relay.testing.tf as tf_testing
+from tests.python.relay.aot.aot_test_utils import (
+    get_tflite_model,
+    convert_to_relay,
+)
 
 from . import infra
 
@@ -49,25 +44,25 @@ MOBILENET_V2_URL = (
 
 
 @pytest.mark.parametrize(
-    "accel_type, model_url, workspace_size, tolerance",
+    "accel_type, model_url, workspace_size",
     [
-        ("ethos-u65-256", MOBILENET_V1_URL, 1423344, 10),
-        ("ethos-u65-256", MOBILENET_V2_URL, 2185584, 5),
-        ("ethos-u55-256", MOBILENET_V1_URL, 1423344, 10),
-        ("ethos-u55-256", MOBILENET_V2_URL, 2185584, 5),
-        ("ethos-u55-128", MOBILENET_V2_URL, 2185584, 5),
-        ("ethos-u55-64", MOBILENET_V2_URL, 2185584, 5),
-        ("ethos-u55-32", MOBILENET_V2_URL, 2185584, 5),
+        ("ethos-u65-256", MOBILENET_V1_URL, 1423344),
+        ("ethos-u65-256", MOBILENET_V2_URL, 2185584),
+        ("ethos-u55-256", MOBILENET_V1_URL, 1423344),
+        ("ethos-u55-256", MOBILENET_V2_URL, 2185584),
+        ("ethos-u55-128", MOBILENET_V2_URL, 2185584),
+        ("ethos-u55-64", MOBILENET_V2_URL, 2185584),
+        ("ethos-u55-32", MOBILENET_V2_URL, 2185584),
     ],
 )
-def test_networks_without_usmp(accel_type, model_url, workspace_size, tolerance):
+def test_networks_without_usmp(accel_type, model_url, workspace_size):
     np.random.seed(23)
-    tflite_model_file = tf_testing.get_workload_official(model_url[0], model_url[1])
-    mod, input_data, params = create_relay_module_and_inputs_from_tflite_file(tflite_model_file)
-    output_data = generate_ref_data(mod, input_data, params)
+    tflite_model_buf = get_tflite_model(model_url)
+    input_data, output_data = infra.generate_ref_data_tflite(tflite_model_buf)
+    mod, params = convert_to_relay(tflite_model_buf)
     mod = partition_for_ethosu(mod, params)
     compiled_models = infra.build_source(
-        mod, input_data, output_data, accel_type, output_tolerance=tolerance, enable_usmp=False
+        mod, input_data, output_data, accel_type, enable_usmp=False
     )
     mlf_memory_map = mlf._build_function_memory_map(
         compiled_models[0].executor_factory.function_metadata
@@ -77,21 +72,19 @@ def test_networks_without_usmp(accel_type, model_url, workspace_size, tolerance)
 
 
 @pytest.mark.parametrize(
-    "accel_type, model_url, workspace_size, tolerance",
+    "accel_type, model_url, workspace_size",
     [
-        ("ethos-u65-256", MOBILENET_V1_URL, 1205872, 10),
-        ("ethos-u55-256", MOBILENET_V2_URL, 1507152, 5),
+        ("ethos-u65-256", MOBILENET_V1_URL, 1205872),
+        ("ethos-u55-256", MOBILENET_V2_URL, 1507152),
     ],
 )
-def test_networks_with_usmp(accel_type, model_url, workspace_size, tolerance):
+def test_networks_with_usmp(accel_type, model_url, workspace_size):
     np.random.seed(23)
-    tflite_model_file = tf_testing.get_workload_official(model_url[0], model_url[1])
-    mod, input_data, params = create_relay_module_and_inputs_from_tflite_file(tflite_model_file)
-    output_data = generate_ref_data(mod, input_data, params)
+    tflite_model_buf = get_tflite_model(model_url)
+    input_data, output_data = infra.generate_ref_data_tflite(tflite_model_buf)
+    mod, params = convert_to_relay(tflite_model_buf)
     mod = partition_for_ethosu(mod, params)
-    compiled_models = infra.build_source(
-        mod, input_data, output_data, accel_type, output_tolerance=tolerance, enable_usmp=True
-    )
+    compiled_models = infra.build_source(mod, input_data, output_data, accel_type, enable_usmp=True)
     allocated_pool_info = list(
         dict(compiled_models[0].executor_factory.executor_codegen_metadata.pool_inputs).values()
     )[0]

--- a/tests/python/contrib/test_ethosu/test_networks.py
+++ b/tests/python/contrib/test_ethosu/test_networks.py
@@ -24,10 +24,7 @@ import numpy as np
 from tvm.relay.op.contrib.ethosu import partition_for_ethosu
 from tvm.micro import model_library_format as mlf
 
-from tests.python.relay.aot.aot_test_utils import (
-    get_tflite_model,
-    convert_to_relay,
-)
+from tests.python.relay.aot.aot_test_utils import convert_to_relay
 
 from . import infra
 
@@ -57,7 +54,7 @@ MOBILENET_V2_URL = (
 )
 def test_networks_without_usmp(accel_type, model_url, workspace_size):
     np.random.seed(23)
-    tflite_model_buf = get_tflite_model(model_url)
+    tflite_model_buf = infra.get_tflite_model(model_url)
     input_data, output_data = infra.generate_ref_data_tflite(tflite_model_buf)
     mod, params = convert_to_relay(tflite_model_buf)
     mod = partition_for_ethosu(mod, params)
@@ -80,7 +77,7 @@ def test_networks_without_usmp(accel_type, model_url, workspace_size):
 )
 def test_networks_with_usmp(accel_type, model_url, workspace_size):
     np.random.seed(23)
-    tflite_model_buf = get_tflite_model(model_url)
+    tflite_model_buf = infra.get_tflite_model(model_url)
     input_data, output_data = infra.generate_ref_data_tflite(tflite_model_buf)
     mod, params = convert_to_relay(tflite_model_buf)
     mod = partition_for_ethosu(mod, params)

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -18,9 +18,11 @@
 import sys
 import datetime
 import itertools
+import json
 import logging
 import os
 import pathlib
+import platform
 import re
 import shutil
 import subprocess
@@ -35,12 +37,13 @@ pytest.importorskip("tvm.micro")
 
 import tvm
 from tvm import relay
+from tvm import te
 from tvm.contrib import utils, graph_executor
-from tvm.relay.backend import Executor, Runtime
+from tvm.relay.backend import te_compiler, Executor, Runtime
+from tvm.relay.backend.te_compiler import TECompiler
 from tvm.relay.backend.utils import mangle_module_name
 from tvm.micro import export_model_library_format
 from tvm.micro.testing import mlf_extract_workspace_size_bytes
-import tvm.relay.testing.tf as tf_testing
 
 _LOG = logging.getLogger(__name__)
 
@@ -937,14 +940,6 @@ def generate_ref_data(mod, input_data, params=None, target="llvm"):
         output_tensor_names = main.attrs["output_tensor_names"]
 
     return dict(zip(output_tensor_names, out))
-
-
-def get_tflite_model(model_url):
-    """Get a TFLite model from URL."""
-    tflite_model_file = tf_testing.get_workload_official(model_url[0], model_url[1])
-    with open(tflite_model_file, "rb") as f:
-        tflite_model_buf = f.read()
-    return tflite_model_buf
 
 
 def create_relay_module_and_inputs_from_tflite_file(tflite_model_file):

--- a/tests/python/relay/aot/aot_test_utils.py
+++ b/tests/python/relay/aot/aot_test_utils.py
@@ -18,11 +18,9 @@
 import sys
 import datetime
 import itertools
-import json
 import logging
 import os
 import pathlib
-import platform
 import re
 import shutil
 import subprocess
@@ -37,13 +35,12 @@ pytest.importorskip("tvm.micro")
 
 import tvm
 from tvm import relay
-from tvm import te
 from tvm.contrib import utils, graph_executor
-from tvm.relay.backend import te_compiler, Executor, Runtime
-from tvm.relay.backend.te_compiler import TECompiler
+from tvm.relay.backend import Executor, Runtime
 from tvm.relay.backend.utils import mangle_module_name
 from tvm.micro import export_model_library_format
 from tvm.micro.testing import mlf_extract_workspace_size_bytes
+import tvm.relay.testing.tf as tf_testing
 
 _LOG = logging.getLogger(__name__)
 
@@ -940,6 +937,14 @@ def generate_ref_data(mod, input_data, params=None, target="llvm"):
         output_tensor_names = main.attrs["output_tensor_names"]
 
     return dict(zip(output_tensor_names, out))
+
+
+def get_tflite_model(model_url):
+    """Get a TFLite model from URL."""
+    tflite_model_file = tf_testing.get_workload_official(model_url[0], model_url[1])
+    with open(tflite_model_file, "rb") as f:
+        tflite_model_buf = f.read()
+    return tflite_model_buf
 
 
 def create_relay_module_and_inputs_from_tflite_file(tflite_model_file):


### PR DESCRIPTION
After the recent upgrade of Tensorflow to 2.6, we are now able to use reference kernels in order to verify the output. Thus, removing the tolerances previously added.

Additionally, the network tests have been altered to use TFLite as a reference, rather than TVM.

cc @manupa-arm @ekalda @NicolaLancellotti @dchauhan-arm 
