### PR TITLE
[microTVM] Zephyr: Fix gdbserver_port option

### DIFF
--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -746,17 +746,15 @@ class ZephyrQemuTransport:
         os.mkfifo(self.write_pipe)
         os.mkfifo(self.read_pipe)
 
-        if "gdbserver_port" in self.options:
-            if "env" in self.kwargs:
-                self.kwargs["env"] = copy.copy(self.kwargs["env"])
-            else:
-                self.kwargs["env"] = os.environ.copy()
-
-            self.kwargs["env"]["TVM_QEMU_GDBSERVER_PORT"] = str(self.options["gdbserver_port"])
+        env = None
+        if self.options.get("gdbserver_port"):
+            env = os.environ.copy()
+            env["TVM_QEMU_GDBSERVER_PORT"] = self.options["gdbserver_port"]
 
         self.proc = subprocess.Popen(
             ["make", "run", f"QEMU_PIPE={self.pipe}"],
             cwd=BUILD_DIR,
+            env=env,
             stdout=subprocess.PIPE,
         )
         self._wait_for_qemu()


### PR DESCRIPTION
Currently 'gdbserver_port' option is not working properly and if it's
passed to the API server it takes not effect, being ignored silently by
the server, hence no debug port for GDB is created when QEMU runs.

This commit fixes it by correctly setting 'TVM_QEMU_GDBSERVER_PORT' env
variable so when Zephyr runs QEMU to create a virtualized board the GDB
port is set correctly to the port passed to the Project API server.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>
