### PR TITLE
[FIX,TOPI] Default to inlining fused operations for conv NCHWc int8

### DIFF
--- a/python/tvm/topi/generic/conv2d.py
+++ b/python/tvm/topi/generic/conv2d.py
@@ -131,7 +131,7 @@ def schedule_conv_NCHWc_cpu_common_int8(
     int32_lanes=16,
     int8_elems=4,
     intrin=None,
-    inline_fused=False,
+    inline_fused=True,
 ):
     """
     Defines the schedule for INT8 for Intel and ARM machines

--- a/python/tvm/topi/x86/conv2d_avx_common.py
+++ b/python/tvm/topi/x86/conv2d_avx_common.py
@@ -176,4 +176,5 @@ def _schedule_conv_NCHWc_int8(s, cfg, data_vec, kernel_vec, conv_out, last):
         last,
         int32_lanes=get_simd_32bit_lanes(),
         intrin=dot_16x1x16_uint8_int8_int32(),
+        inline_fused=True,
     )


### PR DESCRIPTION
Inlining fused operations used to be the default and performs better on x86. I accidentally had turned it off.

@masahi