### PR TITLE
[ci] Fix diff condition for docker builds

### DIFF
--- a/tests/scripts/git_change_docker.sh
+++ b/tests/scripts/git_change_docker.sh
@@ -19,7 +19,12 @@
 
 set -eux
 
-changed_files=$(git diff --no-commit-id --name-only -r origin/main)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" == "main" ]; then
+    changed_files=$(git diff --no-commit-id --name-only -r HEAD~1)
+else
+    changed_files=$(git diff --no-commit-id --name-only -r origin/main)
+fi
 
 for file in $changed_files; do
     echo "Checking $file"


### PR DESCRIPTION
Docker builds weren't triggering on main since it was diffing changes from `main` (and there weren't any), so this fixes it so the diff is checked against the previous commit for builds on `main`.

cc @areusch
