### PR TITLE
[ci] Look for any tags in issues before adding new tags

### DIFF
--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -633,7 +633,7 @@ def test_github_tag_teams(tmpdir_factory):
                 cc @person1 @person2 @person4"""
             ),
         },
-        check="Everyone to cc is already cc'ed, no update needed",
+        check="No one to cc, exiting",
     )
 
     run(
@@ -671,7 +671,7 @@ def test_github_tag_teams(tmpdir_factory):
                 cc @person1 @person2 @person4"""
             ),
         },
-        check="Everyone to cc is already cc'ed, no update needed",
+        check="No one to cc, exiting",
     )
 
     run(
@@ -691,7 +691,7 @@ def test_github_tag_teams(tmpdir_factory):
                 cc @person1 @person2 @person4"""
             ),
         },
-        check="Everyone to cc is already cc'ed, no update needed",
+        check="No one to cc, exiting",
     )
 
     run(
@@ -712,6 +712,26 @@ def test_github_tag_teams(tmpdir_factory):
             ),
         },
         check="Terminating since 1234 is a draft",
+    )
+
+    run(
+        type="ISSUE",
+        data={
+            "title": "[something] A title",
+            "number": 1234,
+            "user": {
+                "login": "person5",
+            },
+            "labels": [{"name": "something2"}],
+            "body": textwrap.dedent(
+                """
+                `mold` and `lld` can be a much faster alternative to `ld` from gcc. We should modify our CMakeLists.txt to detect and use these when possible. cc @person1
+
+                cc @person4
+                """
+            ),
+        },
+        check="would have updated issues/1234 with {'body': '\\n`mold` and `lld` can be a much faster alternative to `ld` from gcc. We should modify our CMakeLists.txt to detect and use these when possible. cc @person1\\n\\ncc @person2 @person4\\n'}",
     )
 
 

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -499,6 +499,7 @@ def test_github_tag_teams(tmpdir_factory):
         [temporary] opt-in: @person5
 
         - something: @person1 @person2
+        - something3: @person1 @person2 @SOME1-ONE-
         - something else @person1 @person2
         - something else2: @person1 @person2
         - something-else @person1 @person2
@@ -732,6 +733,20 @@ def test_github_tag_teams(tmpdir_factory):
             ),
         },
         check="would have updated issues/1234 with {'body': '\\n`mold` and `lld` can be a much faster alternative to `ld` from gcc. We should modify our CMakeLists.txt to detect and use these when possible. cc @person1\\n\\ncc @person2 @person4\\n'}",
+    )
+
+    run(
+        type="ISSUE",
+        data={
+            "title": "[something3] A title",
+            "number": 1234,
+            "user": {
+                "login": "person5",
+            },
+            "labels": [{"name": "something2"}],
+            "body": "@person2 @SOME1-ONE-",
+        },
+        check="Dry run, would have updated issues/1234 with {'body': '@person2 @SOME1-ONE-\\n\\ncc @person1'}",
     )
 
 

--- a/tests/scripts/github_tag_teams.py
+++ b/tests/scripts/github_tag_teams.py
@@ -244,6 +244,9 @@ if __name__ == "__main__":
     to_cc = [teams.get(t, []) for t in tags]
     to_cc = list(set(item for sublist in to_cc for item in sublist))
     to_cc = [user for user in to_cc if user != author]
+    existing_tags = list(set(re.findall(r"@[a-zA-Z0-9]+\w", body)))
+    existing_tags = set(tag.replace("@", "") for tag in existing_tags)
+    to_cc = [user for user in to_cc if user not in existing_tags]
     print("Users to cc based on labels", to_cc)
 
     # Create the new PR/issue body

--- a/tests/scripts/github_tag_teams.py
+++ b/tests/scripts/github_tag_teams.py
@@ -27,6 +27,9 @@ from typing import Dict, Any, List, Tuple
 from git_utils import git, GitHubRepo, parse_remote, find_ccs
 
 
+GITHUB_NAME_REGEX = r"@[a-zA-Z0-9-]+"
+
+
 def parse_line(line: str) -> Tuple[str, List[str]]:
     line = line.lstrip(" -")
     line = line.split()
@@ -244,8 +247,9 @@ if __name__ == "__main__":
     to_cc = [teams.get(t, []) for t in tags]
     to_cc = list(set(item for sublist in to_cc for item in sublist))
     to_cc = [user for user in to_cc if user != author]
-    existing_tags = list(set(re.findall(r"@[a-zA-Z0-9]+\w", body)))
+    existing_tags = list(set(re.findall(GITHUB_NAME_REGEX, body)))
     existing_tags = set(tag.replace("@", "") for tag in existing_tags)
+    print(f"Found existing tags: {existing_tags}")
     to_cc = [user for user in to_cc if user not in existing_tags]
     print("Users to cc based on labels", to_cc)
 

--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -36,3 +36,4 @@ run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME}-platform-minimal-test-1 tests/p
 # Then run all unittests on both ctypes and cython.
 run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME}-0 tests/python/unittest
 run_pytest cython ${TVM_UNITTEST_TESTSUITE_NAME}-1 tests/python/unittest
+run_pytest ctypes ${TVM_UNITTEST_TESTSUITE_NAME}-ci tests/python/ci


### PR DESCRIPTION
Previously this searched for a specific `cc @abc` line by itself before looking for people to tag. This led to a double-tag in #10679. The change here updates it to check for `@`-ed people anywhere in the PR/issue body and filters those out.

cc @areusch 