### PR TITLE
[CI FIX] (Really) Skip test_conv2d in Hexagon (i386)

### DIFF
--- a/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
+++ b/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
@@ -165,7 +165,7 @@ class TestConv2dConv2dPackedFilter(BaseConv2dConv2d):
     @pytest.mark.skipif(
         platform.processor() == "i686", reason="Test known to be flaky on i386 machines"
     )
-    @pytest.mark.xfail(strict=False, reason="See https://github.com/apache/tvm/issues/10665")
+    @pytest.skip(msg="See https://github.com/apache/tvm/issues/10665")
     def test_conv2d(
         self,
         batch,

--- a/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
+++ b/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
@@ -162,9 +162,7 @@ class BaseConv2dConv2d:
 
 class TestConv2dConv2dPackedFilter(BaseConv2dConv2d):
     @tvm.testing.parametrize_targets("llvm")
-    @pytest.mark.skipif(
-        platform.machine() == "i386", reason="Test known to be flaky on i386 machines"
-    )
+    @pytest.mark.skip("Test known to be flaky on i386 machines")
     def test_conv2d(
         self,
         batch,

--- a/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
+++ b/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
@@ -163,9 +163,8 @@ class BaseConv2dConv2d:
 class TestConv2dConv2dPackedFilter(BaseConv2dConv2d):
     @tvm.testing.parametrize_targets("llvm")
     @pytest.mark.skipif(
-        platform.processor() == "i686", reason="Test known to be flaky on i386 machines"
+        platform.machine() == "i386", reason="Test known to be flaky on i386 machines"
     )
-    @pytest.skip(msg="See https://github.com/apache/tvm/issues/10665")
     def test_conv2d(
         self,
         batch,


### PR DESCRIPTION
https://github.com/apache/tvm/pull/10666 marked this `xfail` but it still runs the test causing segfault and CI failure in PR jobs and `main`.

I was told that recent failures like https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10682/1/pipeline are coming from this test (see for example this log https://ci.tlcpack.ai/blue/rest/organizations/jenkins/pipelines/tvm/branches/PR-10682/runs/1/nodes/314/steps/542/log/?start=0 and search for "segmentation fault"). We can try disabling this test entirely to see if it fixes the CI issue.

@driazati @areusch @junrushao1994 