### PR TITLE
Add missing Slice layout fallback check of `stride=1`.

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2711,6 +2711,13 @@ InferCorrectLayoutOutput StridedSliceInferCorrectLayout(
             new_begin.push_back(begin[i]);
             new_end.push_back(end[i]);
           } else {
+            if (strides.defined() && i < strides.size()) {
+              auto stride = strides[i];
+              // arbitrary stride is not supported
+              if (stride.defined() && stride->value != 1) {
+                return out_default;
+              }
+            }
             int64_t bg = begin[i];
             int64_t ed = end[i];
             if (bg % factor || ed % factor) {

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1498,6 +1498,7 @@ def test_conv2d_strided_slice_packed_to_unpacked():
         b = run_opt_pass(expected(), transform.InferType())
         assert tvm.ir.structural_equal(a, b)
 
+
 def test_conv2d_strided_slice_arbitrary_stride():
     """Test rewriting strided_slice with arbitrary stride"""
 

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1498,6 +1498,26 @@ def test_conv2d_strided_slice_packed_to_unpacked():
         b = run_opt_pass(expected(), transform.InferType())
         assert tvm.ir.structural_equal(a, b)
 
+def test_conv2d_strided_slice_arbitrary_stride():
+    """Test rewriting strided_slice with arbitrary stride"""
+
+    def before():
+        x = relay.var("x", shape=(4, 12, 1, 1))
+        weight = relay.var("weight", shape=(9, 12, 1, 1))
+        y = relay.nn.conv2d(x, weight, channels=9, kernel_size=(1, 1), padding=(0, 0))
+        y = relay.strided_slice(y, begin=[3], end=[6], strides=[3], axes=[1])
+        y = relay.Function(analysis.free_vars(y), y)
+        return y
+
+    def alter_conv2d(attrs, inputs, tinfos, out_type):
+        data, weight = inputs
+        new_attrs = dict(attrs)
+        new_attrs["data_layout"] = "NCHW3c"
+        return relay.nn.conv2d(data, weight, **new_attrs)
+
+    with TempOpAttr("nn.conv2d", "FTVMAlterOpLayout", alter_conv2d):
+        run_opt_pass(before(), transform.AlterOpLayout())
+
 
 def test_conv2d_reduce_channels():
     x = relay.var("data", shape=(1, 8, 48, 48))


### PR DESCRIPTION
When doing layout optimization for slice, if `start` or `end` are divisibly by the pack factor and `stride=1`, a `layout_transform` can be saved. However, previous code only checks `stride=1` when `axes` is not specified, as in https://github.com/apache/tvm/blob/2fc7d16e99cf1d1df148e8db03296409916bd134/src/relay/op/tensor/transform.cc#L2735-L2741. This PR adds the same check to the other branch. 

The following model can trigger this bug with error message ``...In particular `Tensor[(4, 1, 1, 1), float32]` does not match `Tensor[(4, 3, 1, 1), float32]` ``.

```python
import tvm
from tvm import relay
import numpy as np
from tvm.relay import testing

x = relay.var("data", shape=(4, 12, 1, 1), dtype="float32")
O, I, H, W = 9, 12, 1, 1
conv_out = relay.nn.conv2d(
    x,
    relay.const(np.ones([O, I, H, W], dtype="float32")),
    strides=[1, 1],
    padding=0,
    channels=O,
    kernel_size=[H, W],
)
bias_out = relay.nn.bias_add(
    conv_out, relay.const(np.ones([O], dtype="float32")))
y = relay.strided_slice(bias_out, begin=[3], end=[6], strides=[3], axes=[1])

mod, _ = testing.create_workload(y)
with tvm.transform.PassContext(opt_level=3):
    with tvm.target.Target("llvm"):
        mod = relay.transform.CanonicalizeOps()(mod)
        mod = relay.transform.AlterOpLayout()(mod)
```

cc @masahi 