### PR TITLE
[ci] Fix condition for skipping tests in i386

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -708,6 +708,16 @@ def requires_nvcc_version(major_version, minor_version=0, release_version=0):
     return inner
 
 
+def skip_if_32bit(reason):
+    def decorator(*args):
+        if "32bit" in platform.architecture()[0]:
+            return _compose(args, [pytest.mark.skip(reason=reason)])
+
+        return _compose(args, [])
+
+    return decorator
+
+
 def requires_cudagraph(*args):
     """Mark a test as requiring the CUDA Graph Feature
 

--- a/tests/python/contrib/test_cmsisnn/utils.py
+++ b/tests/python/contrib/test_cmsisnn/utils.py
@@ -29,9 +29,7 @@ from tvm import relay
 
 
 def skip_if_no_reference_system(func):
-    return pytest.mark.skipif(
-        platform.machine() == "i686", reason="Reference system unavailable in i386 container"
-    )(func)
+    return tvm.testing.skip_if_32bit(reason="Reference system unavailable in i386 container")(func)
 
 
 def count_num_calls(mod):

--- a/tests/python/contrib/test_hexagon/test_conv2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/test_conv2d_blocked.py
@@ -139,9 +139,7 @@ class BaseConv2d:
 
 class TestConv2dPackedFilter(BaseConv2d):
     @tvm.testing.parametrize_targets("llvm")
-    @pytest.mark.skipif(
-        platform.processor() == "i686", reason="Test known to be flaky on i386 machines"
-    )
+    @tvm.testing.skip_if_32bit(reason="Test known to be flaky on i386 machines")
     def test_conv2d(
         self,
         batch,

--- a/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
+++ b/tests/python/contrib/test_hexagon/test_conv2d_conv2d.py
@@ -162,7 +162,7 @@ class BaseConv2dConv2d:
 
 class TestConv2dConv2dPackedFilter(BaseConv2dConv2d):
     @tvm.testing.parametrize_targets("llvm")
-    @pytest.mark.skip("Test known to be flaky on i386 machines")
+    @tvm.testing.skip_if_32bit(reason="Test known to be flaky on i386 machines")
     def test_conv2d(
         self,
         batch,


### PR DESCRIPTION
The Python and base image update for the i386 container changed the results of the various functions in `platform` as found in #10687. This updates them to work correctly with the new container and updates the relevant parts of the codebase to use the new check. Verified tests locally with `ci.py` for the various tests, e.g.:

```bash
# not skipped
python tests/scripts/ci.py cpu --tests tests/python/relay/aot/test_crt_aot.py::test_conv_with_params

# skipped
python tests/scripts/ci.py i386 --tests tests/python/relay/aot/test_crt_aot.py::test_conv_with_params
```

This also has some tacked-on changes to `ci.py` that I found make it easier to use (short args, fix the broken docs build)

cc @masahi @Mousius 

