### PR TITLE
[ARM,TOPI] Allow auto scheduler layout rewritting in dense

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -22,6 +22,7 @@ import logging
 from tvm import relay, topi
 from ....target import arm_isa
 from ....topi.generic import conv2d as conv2d_generic
+from ....auto_scheduler import is_auto_scheduler_enabled
 from .generic import *
 from .. import op as _op
 
@@ -463,7 +464,7 @@ def schedule_dense_arm_cpu(attrs, inputs, out_type, target):
         )
     else:
         strategy.add_implementation(
-            wrap_compute_dense(topi.nn.dense),
+            wrap_compute_dense(topi.nn.dense, need_auto_scheduler_layout=is_auto_scheduler_enabled()),
             wrap_topi_schedule(topi.generic.schedule_dense),
             name="dense.generic",
         )

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -464,7 +464,9 @@ def schedule_dense_arm_cpu(attrs, inputs, out_type, target):
         )
     else:
         strategy.add_implementation(
-            wrap_compute_dense(topi.nn.dense, need_auto_scheduler_layout=is_auto_scheduler_enabled()),
+            wrap_compute_dense(
+                topi.nn.dense, need_auto_scheduler_layout=is_auto_scheduler_enabled()
+            ),
             wrap_topi_schedule(topi.generic.schedule_dense),
             name="dense.generic",
         )

--- a/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test layout rewrite support for whole neural networks"""
+import sys
 import tempfile
 
 import numpy as np
@@ -135,9 +136,8 @@ def get_relay_batchmm(batch=4, m=128, n=128, k=128):
     return mod, data, weight
 
 
-def tune_and_check(mod, data, weight):
+def tune_and_check(mod, data, weight, target, dev):
     # Extract tasks from a relay program
-    target = tvm.target.Target("llvm")
     tasks, task_weights = auto_scheduler.extract_tasks(
         mod, target=target, params={"weight": weight}
     )
@@ -168,7 +168,6 @@ def tune_and_check(mod, data, weight):
             lib2 = relay.build(mod, target=target, params={"weight": weight})
 
         def get_output(data, lib):
-            dev = tvm.cpu()
             module = graph_executor.GraphModule(lib["default"](dev))
             module.set_input("data", data)
             module.run()
@@ -182,34 +181,30 @@ def tune_and_check(mod, data, weight):
         tvm.testing.assert_allclose(actual_output, expected_output, rtol=1e-4, atol=2e-4)
 
 
-def test_conv2d():
+def test_conv2d(target, dev):
     mod, data, weight = get_relay_conv2d(kh=1, kw=1)
-    tune_and_check(mod, data, weight)
+    tune_and_check(mod, data, weight, target, dev)
 
 
-def test_conv2d_winograd():
+def test_conv2d_winograd(target, dev):
     mod, data, weight = get_relay_conv2d(outc=128, kh=3, kw=3)
-    tune_and_check(mod, data, weight)
+    tune_and_check(mod, data, weight, target, dev)
 
 
-def test_conv3d():
+def test_conv3d(target, dev):
     mod, data, weight = get_relay_conv3d()
-    tune_and_check(mod, data, weight)
+    tune_and_check(mod, data, weight, target, dev)
 
 
-def test_dense():
+def test_dense(target, dev):
     mod, data, weight = get_relay_dense()
-    tune_and_check(mod, data, weight)
+    tune_and_check(mod, data, weight, target, dev)
 
 
-def test_batch_matmul():
+def test_batch_matmul(target, dev):
     mod, data, weight = get_relay_batchmm()
-    tune_and_check(mod, data, weight)
+    tune_and_check(mod, data, weight, target, dev)
 
 
 if __name__ == "__main__":
-    test_conv2d()
-    test_conv2d_winograd()
-    test_conv3d()
-    test_dense()
-    test_batch_matmul()
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
Auto scheduler was already rewritting the layouts of inputs to dense, but the dense operators was not passed the correct flag to take advantage of these inputs. This could cause a crash when the rewritten inputs did not match the size expected by dense.

I've also enabled the auto_scheduler layout rewriting tests to run on any platforms in `TVM_TEST_TARGETS`. Currently, these tests are not run on arm because `TVM_RELAY_TEST_TARGETS` does not include arm and the relay tests are not enabled (tracking issue: https://github.com/apache/tvm/issues/10673).

@masahi @mbrookhart 