### PR TITLE
Use local complete block and local reduction block to identify compact dataflow

### DIFF
--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -168,16 +168,11 @@ void CheckCompleteOrReductionBlock(const ScheduleState& self, const StmtSRef& bl
 /*!
  * \brief Check the subtree compact dataflow property. The scope root may have one or more subtrees
  *        rooted at its direct children, and this property requires all the blocks of the subtree
- *        that the specified sref is in to be complete block or reduction block.
+ *        that the specified sref is in to be local complete block or local reduction block.
  * \param self The schedule state
  * \param subtree_root The sref of the subtree root to be checked
- * \param scope_root_sref The scope root of the block
- * \throw ScheduleError If the subtree that the sref is in doesn't satisfy the compact
- *        dataflow condition, i.e. a block in the subtree is neither complete block nor
- *        reduction block
  */
-void CheckSubtreeCompactDataflow(const ScheduleState& self, const StmtSRef& subtree_root,
-                                 const StmtSRef& scope_root_sref);
+void CheckSubtreeCompactDataflow(const ScheduleState& self, const StmtSRef& subtree_root);
 /*!
  * \brief Check if the block is an output block, i.e. the block writes to at least a buffer that is
  * not allocated under the current scope

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -156,12 +156,10 @@ bool IsDominantBlock(const BlockScope& scope, const StmtSRef& block_sref) {
   const std::unordered_map<Buffer, Array<StmtSRef>, ObjectPtrHash, ObjectPtrEqual>& buffer_writers =
       scope->buffer_writers;
   for (const BufferRegion& write_region : block->writes) {
-    ICHECK(buffer_writers.count(write_region->buffer))
-        << "InternalError: buffer \"" << write_region->buffer->name
-        << "\" does not exist in the current scope, when querying block:\n"
-        << GetRef<Block>(block);
-    if (buffer_writers.at(write_region->buffer).size() != 1) {
-      return false;
+    if (buffer_writers.count(write_region->buffer)) {
+      if (buffer_writers.at(write_region->buffer).size() != 1) {
+        return false;
+      }
     }
   }
   return true;
@@ -395,6 +393,7 @@ void CheckSubtreeCompactDataflow(const ScheduleState& self, const StmtSRef& subt
   for (const StmtSRef& block_sref : child_block_srefs) {
     // Local complete: complete block under the subtree.
     // Local reduction: reduction block under the subtree.
+    const BlockNode* block = TVM_SREF_TO_BLOCK(block, block_sref);
     if (!IsCompleteBlock(self, block_sref, block_sref) &&
         !IsReductionBlock(self, block_sref, block_sref)) {
       const BlockNode* block = TVM_SREF_TO_BLOCK(block, block_sref);

--- a/src/tir/schedule/primitive/for_kind.cc
+++ b/src/tir/schedule/primitive/for_kind.cc
@@ -157,9 +157,7 @@ void ParallelizeComputation(const ScheduleState& self, const StmtSRef& loop_sref
    * parallelized/vectorized/bound.
    */
   // Step 1. Check whether the subtree rooted from the `loop` in sref tree has compact data flow.
-  StmtSRef scope_root_sref = GetScopeRoot(self, loop_sref,
-                                          /*require_stage_pipeline=*/true);
-  CheckSubtreeCompactDataflow(self, loop_sref, scope_root_sref);
+  CheckSubtreeCompactDataflow(self, loop_sref);
 
   // Step 2. Check whether the loop can be parallelized/vectorized/bound with regard to each
   // underlying block.

--- a/tests/python/unittest/test_te_create_primfunc.py
+++ b/tests/python/unittest/test_te_create_primfunc.py
@@ -395,7 +395,7 @@ def tir_argmax_idx_val(
     for i0, i1 in T.grid(m, n):
         with T.block("argmax"):
             i, k = T.axis.remap("SR", [i0, i1])
-            T.reads(argmax_v1[i], val[i, k], argmax_v0[i], idx[i, k])
+            T.reads(val[i, k], idx[i, k])
             T.writes(argmax_v0[i], argmax_v1[i])
             with T.init():
                 argmax_v0[i] = T.int32(-1)
@@ -442,7 +442,7 @@ def tir_argmax_val_idx(
     for i0, i1 in T.grid(m, n):
         with T.block("argmax"):
             i, k = T.axis.remap("SR", [i0, i1])
-            T.reads(argmax_v0[i], val[i, k], argmax_v1[i], idx[i, k])
+            T.reads(val[i, k], idx[i, k])
             T.writes(argmax_v0[i], argmax_v1[i])
             with T.init():
                 argmax_v0[i] = T.min_value("float32")

--- a/tests/python/unittest/test_te_create_primfunc.py
+++ b/tests/python/unittest/test_te_create_primfunc.py
@@ -395,7 +395,7 @@ def tir_argmax_idx_val(
     for i0, i1 in T.grid(m, n):
         with T.block("argmax"):
             i, k = T.axis.remap("SR", [i0, i1])
-            T.reads(val[i, k], idx[i, k])
+            T.reads(argmax_v1[i], val[i, k], argmax_v0[i], idx[i, k])
             T.writes(argmax_v0[i], argmax_v1[i])
             with T.init():
                 argmax_v0[i] = T.int32(-1)
@@ -442,7 +442,7 @@ def tir_argmax_val_idx(
     for i0, i1 in T.grid(m, n):
         with T.block("argmax"):
             i, k = T.axis.remap("SR", [i0, i1])
-            T.reads(val[i, k], idx[i, k])
+            T.reads(argmax_v0[i], val[i, k], argmax_v1[i], idx[i, k])
             T.writes(argmax_v0[i], argmax_v1[i])
             with T.init():
                 argmax_v0[i] = T.min_value("float32")

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -541,7 +541,6 @@ def test_vectorize_init():
     _, _, ii_0, jj_0 = s.get_loops(init_blk)
     _, _, k_1, ii_1, jj_1 = s.get_loops(upd_blk)
     s.vectorize(jj_0)
-    print(s.mod["main"].script())
     tvm.ir.assert_structural_equal(s.mod["main"], decomposed_gemm_parallelize_init)
     verify_trace_roundtrip(s, mod=decomposed_gemm)
 
@@ -554,7 +553,6 @@ def test_scatter_parallelize():
     (i_1,) = s.get_loops(last)
     s.parallel(i_0)
     s.parallel(i_1)
-    print(s.mod["main"].script())
     tvm.ir.assert_structural_equal(s.mod["main"], scatter_compute_parallelize)
     verify_trace_roundtrip(s, mod=scatter_compute)
 

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -468,5 +468,18 @@ def test_vectorize_after_decompose():
     verify_trace_roundtrip(s, mod=decomposed_gemm)
 
 
+def test_compact_data_flow_local_complete_reduction():
+    s = tir.Schedule(decomposed_gemm, debug_mask="all")
+    init_blk = s.get_block("init")
+    upd_blk = s.get_block("update")
+    ii_0, jj_0 = s.get_loops(init_blk)
+    k_1, ii_1, jj_1 = s.get_child_blocks(upd_blk) 
+    s.vectorize(jj_0)
+    s.bind(jj_1, "threadIdx.x")
+    print(s.mod["main"].script())
+    tvm.ir.assert_structural_equal(s.mod["main"], decomposed_gemm_double_bound) 
+    verify_trace_roundtrip(s, mod=decomposed_gemm)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -330,6 +330,72 @@ def decomposed_gemm_after_vectorize(
                     C[vi, vj] = local[vi, vj]
 
 
+@T.prim_func
+def decomposed_gemm_parallelize_init(
+    A: T.Buffer[(16, 16), "float32"],
+    B: T.Buffer[(16, 16), "float32"],
+    C: T.Buffer[(16, 16), "float32"],
+) -> None:
+    local = T.alloc_buffer([16, 16], dtype="float32")
+    for i, j in T.grid(4, 4):
+        for ii in T.serial(4):
+            for jj in T.vectorized(4):
+                with T.block("init"):
+                    vi = T.axis.spatial(16, i * 4 + ii)
+                    vj = T.axis.spatial(16, j * 4 + jj)
+                    T.reads()
+                    T.writes(local[vi, vj])
+                    local[vi, vj] = 0
+        for k, ii, jj in T.grid(16, 4, 4):
+            with T.block("update"):
+                vi = T.axis.spatial(16, i * 4 + ii)
+                vj = T.axis.spatial(16, j * 4 + jj)
+                vk = T.axis.reduce(16, k)
+                T.reads(local[vi, vj], A[vi, vk], B[vj, vk])
+                T.writes(local[vi, vj])
+                local[vi, vj] = local[vi, vj] + A[vi, vk] * B[vj, vk]
+        for ii, jj in T.grid(4, 4):
+            with T.block("C"):
+                vi = T.axis.spatial(16, i * 4 + ii)
+                vj = T.axis.spatial(16, j * 4 + jj)
+                T.reads(local[vi, vj])
+                T.writes(C[vi, vj])
+                C[vi, vj] = local[vi, vj]
+
+
+@T.prim_func
+def scatter_compute(A: T.Buffer[(16,), "float32"], B: T.Buffer[(16,), "float32"]):
+    for i in T.grid(8):
+        with T.block("first_half"):
+            vi = T.axis.spatial(16, 8 + i)
+            B[vi] = A[vi - 8]
+
+    for i in T.grid(8):
+        with T.block("last_half"):
+            vi = T.axis.spatial(16, i)
+            B[vi] = A[vi + 8]
+
+
+@T.prim_func
+def scatter_compute_parallelize(
+    A: T.Buffer[(16,), "float32"], B: T.Buffer[(16,), "float32"]
+) -> None:
+    # body
+    # with T.block("root")
+    for i in T.parallel(8):
+        with T.block("first_half"):
+            vi = T.axis.spatial(16, 8 + i)
+            T.reads(A[vi - 8])
+            T.writes(B[vi])
+            B[vi] = A[vi - 8]
+    for i in T.parallel(8):
+        with T.block("last_half"):
+            vi = T.axis.spatial(16, i)
+            T.reads(A[vi + 8])
+            T.writes(B[vi])
+            B[vi] = A[vi + 8]
+
+
 # pylint: enable=no-member,invalid-name,unused-variable
 
 
@@ -468,17 +534,29 @@ def test_vectorize_after_decompose():
     verify_trace_roundtrip(s, mod=decomposed_gemm)
 
 
-def test_compact_data_flow_local_complete_reduction():
+def test_vectorize_init():
     s = tir.Schedule(decomposed_gemm, debug_mask="all")
     init_blk = s.get_block("init")
     upd_blk = s.get_block("update")
-    ii_0, jj_0 = s.get_loops(init_blk)
-    k_1, ii_1, jj_1 = s.get_child_blocks(upd_blk) 
+    _, _, ii_0, jj_0 = s.get_loops(init_blk)
+    _, _, k_1, ii_1, jj_1 = s.get_loops(upd_blk)
     s.vectorize(jj_0)
-    s.bind(jj_1, "threadIdx.x")
     print(s.mod["main"].script())
-    tvm.ir.assert_structural_equal(s.mod["main"], decomposed_gemm_double_bound) 
+    tvm.ir.assert_structural_equal(s.mod["main"], decomposed_gemm_parallelize_init)
     verify_trace_roundtrip(s, mod=decomposed_gemm)
+
+
+def test_scatter_parallelize():
+    s = tir.Schedule(scatter_compute, debug_mask="all")
+    first = s.get_block("first_half")
+    last = s.get_block("last_half")
+    (i_0,) = s.get_loops(first)
+    (i_1,) = s.get_loops(last)
+    s.parallel(i_0)
+    s.parallel(i_1)
+    print(s.mod["main"].script())
+    tvm.ir.assert_structural_equal(s.mod["main"], scatter_compute_parallelize)
+    verify_trace_roundtrip(s, mod=scatter_compute)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Per @Hzfengsy 's proposal: https://gist.github.com/Hzfengsy/eab83a98c0b034af1c6c7fac44bae741,
We use the concept of "local" complete block and "local" reduction block to identify whether a subtree has compact dataflow or not.
Compared to the original concept of complete block and reduction block, we only require a block to dominate a given subtree.