### PR TITLE
[skip ci][ci] Skip flaky test_auto_scheduler_layout_rewrite_networks test

### DIFF
--- a/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
@@ -17,6 +17,7 @@
 """Test layout rewrite support for whole neural networks"""
 import sys
 import tempfile
+import pytest
 
 import numpy as np
 
@@ -187,6 +188,8 @@ def test_conv2d(target, dev):
 
 
 def test_conv2d_winograd(target, dev):
+    if target == "cuda":
+        pytest.skip(reason="See https://github.com/apache/tvm/issues/10707")
     mod, data, weight = get_relay_conv2d(outc=128, kh=3, kw=3)
     tune_and_check(mod, data, weight, target, dev)
 


### PR DESCRIPTION
See #10707

Tested locally, the CUDA test is successfully skipped. Skipping CI on the PR since `main` is broken already

```bash
python tests/scripts/ci.py gpu -t 'tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py::test_conv2d_winograd'
```