### PR TITLE
[Hexagon][Codegen] Implement CodeGenHexagon::CreatePrintf

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -69,8 +69,7 @@ class CodeGenHexagon final : public CodeGenLLVM {
   llvm::Module* GetModulePtr() const { return module_.get(); }
 
  protected:
-  void CreatePrintf(const std::string& format,
-                    const llvm::ArrayRef<llvm::Value*>& format_args) final;
+  void CreatePrintf(const std::string& format, llvm::ArrayRef<llvm::Value*> format_args) final;
 
   // meta data
   llvm::MDNode* md_tbaa_ctx_ptr_{nullptr};
@@ -576,7 +575,7 @@ llvm::Value* CodeGenHexagon::CreateIntrinsic(const CallNode* op) {
 }
 
 void CodeGenHexagon::CreatePrintf(const std::string& format,
-                                  const llvm::ArrayRef<llvm::Value*>& format_args) {
+                                  llvm::ArrayRef<llvm::Value*> format_args) {
   // This function generates LLVM instructions to call HAP_debug_v2,
   // as if the FARF macro in `HAP_farf.h` were called as
   // FARF(ALWAYS, format, format_args[0], format_args[1], ...)

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -69,6 +69,8 @@ class CodeGenHexagon final : public CodeGenLLVM {
   llvm::Module* GetModulePtr() const { return module_.get(); }
 
  protected:
+  void CreatePrintf(const std::string& format, const std::vector<llvm::Value*> format_args) final;
+
   // meta data
   llvm::MDNode* md_tbaa_ctx_ptr_{nullptr};
   llvm::FunctionType* ftype_tvm_func_call_{nullptr};
@@ -570,6 +572,43 @@ llvm::Value* CodeGenHexagon::CreateIntrinsic(const CallNode* op) {
   }
 
   return CodeGenLLVM::CreateIntrinsic(op);
+}
+
+void CodeGenHexagon::CreatePrintf(const std::string& format,
+                                  const std::vector<llvm::Value*> format_args) {
+  // This function generates LLVM instructions to call HAP_debug_v2,
+  // as if the FARF macro in `HAP_farf.h` were called as
+  // FARF(ALWAYS, format, format_args[0], format_args[1], ...)
+  std::string func_name = "HAP_debug_v2";
+
+  llvm::Function* func = module_->getFunction(func_name);
+  if (func == nullptr) {
+    llvm::FunctionType* ftype = llvm::FunctionType::get(
+        t_void_, {t_int32_, t_char_->getPointerTo(), t_int32_, t_char_->getPointerTo()}, true);
+    func = llvm::Function::Create(ftype, llvm::Function::ExternalLinkage, func_name, module_.get());
+  }
+
+  llvm::Value* format_str = builder_->CreateGlobalStringPtr(format + "\0");
+  format_str->setName("printf_format_str");
+
+  // The value of FARF_ALWAYS_LEVEL, defined as HAP_LEVEL_HIGH
+  llvm::Value* level = ConstInt32(2);
+  level->setName("farf_always_level");
+
+  // There is no such filename for this print statement
+  llvm::Value* filename = builder_->CreateGlobalStringPtr("generated-LLVM-code");
+  filename->setName("dummy_filename");
+
+  // There is no such line number for this print statement
+  llvm::Value* line_number = ConstInt32(1);
+  line_number->setName("dummy_line_number");
+
+  std::vector<llvm::Value*> func_args = {level, filename, line_number, format_str};
+  for (auto arg : format_args) {
+    func_args.push_back(arg);
+  }
+
+  builder_->CreateCall(func, func_args);
 }
 
 CodeGenLLVM::TypedPointer CodeGenHexagon::CreateBufferPtr(llvm::Value* buffer_ptr,

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -831,7 +831,7 @@ llvm::Value* CodeGenLLVM::GetVarValue(const VarNode* v) const {
 }
 
 void CodeGenLLVM::CreatePrintf(const std::string& format,
-                               const std::vector<llvm::Value*> format_args) {
+                               const llvm::ArrayRef<llvm::Value*>& format_args) {
   llvm::Function* func_printf = module_->getFunction("printf");
   if (func_printf == nullptr) {
     llvm::FunctionType* ftype = llvm::FunctionType::get(t_int32_, true);
@@ -850,9 +850,7 @@ void CodeGenLLVM::CreatePrintf(const std::string& format,
   str->setName("printf_format_str");
 
   std::vector<llvm::Value*> printf_args = {str};
-  for (auto arg : format_args) {
-    printf_args.push_back(arg);
-  }
+  printf_args.insert(printf_args.end(), format_args.begin(), format_args.end());
   builder_->CreateCall(func_printf, printf_args);
 
   // Call fflush() immediately, as this utility is intended for debug

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -831,7 +831,7 @@ llvm::Value* CodeGenLLVM::GetVarValue(const VarNode* v) const {
 }
 
 void CodeGenLLVM::CreatePrintf(const std::string& format,
-                               const llvm::ArrayRef<llvm::Value*>& format_args) {
+                               llvm::ArrayRef<llvm::Value*> format_args) {
   llvm::Function* func_printf = module_->getFunction("printf");
   if (func_printf == nullptr) {
     llvm::FunctionType* ftype = llvm::FunctionType::get(t_int32_, true);

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -238,7 +238,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * printf(), immediately calls fflush() to flush the stdout buffer
    * in case of segfault.
    */
-  void CreatePrintf(const std::string& format, const std::vector<llvm::Value*> format_args);
+  virtual void CreatePrintf(const std::string& format, const std::vector<llvm::Value*> format_args);
 
   /*! \brief Lookup return address, for debugging purposes
    *

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -238,8 +238,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * printf(), immediately calls fflush() to flush the stdout buffer
    * in case of segfault.
    */
-  virtual void CreatePrintf(const std::string& format,
-                            const llvm::ArrayRef<llvm::Value*>& format_args);
+  virtual void CreatePrintf(const std::string& format, llvm::ArrayRef<llvm::Value*> format_args);
 
   /*! \brief Lookup return address, for debugging purposes
    *

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -238,7 +238,8 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * printf(), immediately calls fflush() to flush the stdout buffer
    * in case of segfault.
    */
-  virtual void CreatePrintf(const std::string& format, const std::vector<llvm::Value*> format_args);
+  virtual void CreatePrintf(const std::string& format,
+                            const llvm::ArrayRef<llvm::Value*>& format_args);
 
   /*! \brief Lookup return address, for debugging purposes
    *


### PR DESCRIPTION
`CodeGenLLVM::CreatePrintf` is a debug function for injecting `printf` calls into the generated code.  `CodeGenHexagon` inherits from `CodeGenLLVM`, but debug messages sent through `printf` calls do not make it back across the RPC server.  Instead, the `FARF` preprocess macro provided from the Hexagon SDK should be used.  This implementation of `CodeGenHexagon::CreatePrintf` generates the same `HAP_debug_v2` function call as would be generated by the `FARF` preprocessor macro, using the `ALWAYS` print level.