### PR TITLE
[NDArray] Expose NDArray::CreateView to python

### DIFF
--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -250,6 +250,22 @@ class NDArray(NDArrayBase):
         raise ValueError("Unsupported target type %s" % str(type(target)))
 
     def create_view(self, shape):
+        """Create a view into an existing array.
+
+        The view shares the same allocation and datatype as the
+        existing array, but can have a different array shape.  This is
+        useful for runtimes that support non-flat memory, where both
+        the physical shape of an allocation and the logical shape of
+        the tensor it represents may need to be independently
+        specified.
+
+        Parameters
+        ----------
+        shape: Sequence[Union[tir.IntImm, int]]
+
+            The shape of the view.
+
+        """
         shape_imm = []
         for s in shape:
             if isinstance(s, tvm.tir.IntImm):

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -249,7 +249,7 @@ class NDArray(NDArrayBase):
             return self._copyto(res)
         raise ValueError("Unsupported target type %s" % str(type(target)))
 
-    def create_view(self, shape):
+    def _create_view(self, shape):
         """Create a view into an existing array.
 
         The view shares the same allocation and datatype as the
@@ -258,6 +258,11 @@ class NDArray(NDArrayBase):
         the physical shape of an allocation and the logical shape of
         the tensor it represents may need to be independently
         specified.
+
+        Warning: This function should not be used outside of low-level
+        manipulations, as it breaks non-aliasing assumptions made by
+        TVM.  This function may also be removed/replaced in the
+        future.
 
         Parameters
         ----------

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -261,23 +261,15 @@ class NDArray(NDArrayBase):
 
         Parameters
         ----------
-        shape: Sequence[Union[tir.IntImm, int]]
+        shape: Union[tvm.runtime.ShapeTuple, Sequence[typing.SupportsInt]]
 
             The shape of the view.
-
         """
-        shape_imm = []
-        for s in shape:
-            if isinstance(s, tvm.tir.IntImm):
-                shape_imm.append(s.value)
-            else:
-                shape_imm.append(int(s))
-        arr = np.array(shape_imm, "int64")
-        ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int64))
-        shape_ptr = ctypes.cast(ptr, ctypes.c_void_p)
-        ndim = len(shape_imm)
-        arr = _ffi_api.TVMArrayCreateView(self, shape_ptr, ndim)
-        return arr
+
+        if not isinstance(shape, tvm.runtime.ShapeTuple):
+            shape = tvm.runtime.ShapeTuple([int(dim) for dim in shape])
+
+        return _ffi_api.TVMArrayCreateView(self, shape)
 
 
 def device(dev_type, dev_id=0):

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -249,6 +249,20 @@ class NDArray(NDArrayBase):
             return self._copyto(res)
         raise ValueError("Unsupported target type %s" % str(type(target)))
 
+    def create_view(self, shape):
+        shape_imm = []
+        for s in shape:
+            if isinstance(s, tvm.tir.IntImm):
+                shape_imm.append(s.value)
+            else:
+                shape_imm.append(int(s))
+        arr = np.array(shape_imm, "int64")
+        ptr = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int64))
+        shape_ptr = ctypes.cast(ptr, ctypes.c_void_p)
+        ndim = len(shape_imm)
+        arr = _ffi_api.TVMArrayCreateView(self, shape_ptr, ndim)
+        return arr
+
 
 def device(dev_type, dev_id=0):
     """Construct a TVM device with given device type and id.

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -293,13 +293,9 @@ TVM_REGISTER_GLOBAL("runtime.TVMArrayAllocWithScope").set_body([](TVMArgs args, 
   *ret = ndarray;
 });
 
-TVM_REGISTER_GLOBAL("runtime.TVMArrayCreateView").set_body([](TVMArgs args, TVMRetValue* ret) {
-  NDArray arr = args[0];
-  int64_t* shape_ptr = static_cast<int64_t*>(static_cast<void*>(args[1]));
-  int ndim = args[2];
-  ShapeTuple shape(shape_ptr, shape_ptr + ndim);
+TVM_REGISTER_GLOBAL("runtime.TVMArrayCreateView").set_body_typed([](NDArray arr, ShapeTuple shape) {
   NDArray view = arr.CreateView(shape, arr->dtype);
-  *ret = view;
+  return view;
 });
 
 int TVMArrayFree(TVMArrayHandle handle) {

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -293,6 +293,15 @@ TVM_REGISTER_GLOBAL("runtime.TVMArrayAllocWithScope").set_body([](TVMArgs args, 
   *ret = ndarray;
 });
 
+TVM_REGISTER_GLOBAL("runtime.TVMArrayCreateView").set_body([](TVMArgs args, TVMRetValue* ret) {
+  NDArray arr = args[0];
+  int64_t* shape_ptr = static_cast<int64_t*>(static_cast<void*>(args[1]));
+  int ndim = args[2];
+  ShapeTuple shape(shape_ptr, shape_ptr + ndim);
+  NDArray view = arr.CreateView(shape, arr->dtype);
+  *ret = view;
+});
+
 int TVMArrayFree(TVMArrayHandle handle) {
   API_BEGIN();
   NDArray::Internal::FFIDecRef(handle);


### PR DESCRIPTION
Modifying the array view is needed for Hexagon targets, in order to first call `tvm.nd.array` with the physical dimensions, then update the shape to contain the logical dimensions.