### PR TITLE
[Hexagon] Remove timeout on HAP_compute_res_acquire

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -84,7 +84,7 @@ struct VTCMAllocation : public Allocation {
     // allocate nbytes of vtcm on a single page
     HEXAGON_SAFE_CALL(HAP_compute_res_attr_set_vtcm_param(&res_info, /*vtcm_size = */ nbytes,
                                                           /*b_single_page = */ 1));
-    context_id_ = HAP_compute_res_acquire(&res_info, /*timeout = */ 10000);
+    context_id_ = HAP_compute_res_acquire(&res_info, /*timeout = */ 0);
 
     if (context_id_) {
       data_ = HAP_compute_res_attr_get_vtcm_ptr(&res_info);

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -84,6 +84,9 @@ struct VTCMAllocation : public Allocation {
     // allocate nbytes of vtcm on a single page
     HEXAGON_SAFE_CALL(HAP_compute_res_attr_set_vtcm_param(&res_info, /*vtcm_size = */ nbytes,
                                                           /*b_single_page = */ 1));
+
+    // TODO(HWE): Investigate why a non-zero timeout results in
+    // hanging, both in the simulator and on hardware.
     context_id_ = HAP_compute_res_acquire(&res_info, /*timeout = */ 0);
 
     if (context_id_) {


### PR DESCRIPTION
When run on the simulator, a non-zero timeout for this call will busy-loop.