### PR TITLE
[Hexagon] Add Hexagon-specifc timer to enable using `time_evaluator`

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
@@ -30,7 +30,6 @@
 #include <dmlc/thread_local.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/ndarray.h>
-#include <tvm/runtime/profiling.h>
 #include <tvm/runtime/registry.h>
 
 #include <cstdlib>
@@ -39,10 +38,6 @@
 #include "../../workspace_pool.h"
 #include "hexagon_buffer.h"
 #include "hexagon_common.h"
-
-#if defined(__hexagon__)
-#include "HAP_perf.h"
-#endif
 
 namespace tvm {
 namespace runtime {
@@ -243,28 +238,6 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.v2").set_body([](TVMArgs args, TVMRetVal
   DeviceAPI* ptr = HexagonDeviceAPIv2::Global();
   *rv = static_cast<void*>(ptr);
 });
-
-#if defined(__hexagon__)
-class HexagonTimerNode : public TimerNode {
- public:
-  virtual void Start() { start = HAP_perf_get_time_us(); }
-  virtual void Stop() { end = HAP_perf_get_time_us(); }
-  virtual int64_t SyncAndGetElapsedNanos() { return (end - start) * 1e3; }
-  virtual ~HexagonTimerNode() {}
-
-  static constexpr const char* _type_key = "HexagonTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(HexagonTimerNode, TimerNode);
-
- private:
-  uint64_t start, end;
-};
-
-TVM_REGISTER_OBJECT_TYPE(HexagonTimerNode);
-
-TVM_REGISTER_GLOBAL("profiling.timer.hexagon").set_body_typed([](Device dev) {
-  return Timer(make_object<HexagonTimerNode>());
-});
-#endif
 
 }  // namespace hexagon
 }  // namespace runtime

--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
@@ -30,6 +30,7 @@
 #include <dmlc/thread_local.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/profiling.h>
 #include <tvm/runtime/registry.h>
 
 #include <cstdlib>
@@ -179,6 +180,21 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.mem_copy").set_body([](TVMArgs args, TVM
 
   *rv = static_cast<int32_t>(0);
 });
+
+class HexagonTimerNode : public TimerNode {
+ public:
+  virtual void Start() {}
+  virtual void Stop() {}
+  virtual int64_t SyncAndGetElapsedNanos() { return 0; }
+  virtual ~HexagonTimerNode() {}
+
+  static constexpr const char* _type_key = "HexagonTimerNode";
+  TVM_DECLARE_FINAL_OBJECT_INFO(HexagonTimerNode, TimerNode);
+
+ private:
+};
+
+TVM_REGISTER_OBJECT_TYPE(HexagonTimerNode);
 
 std::map<void*, HexagonBuffer*> vtcmallocs;
 

--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
@@ -44,7 +44,6 @@
 #include "HAP_perf.h"
 #endif
 
-
 namespace tvm {
 namespace runtime {
 namespace hexagon {
@@ -248,15 +247,16 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.v2").set_body([](TVMArgs args, TVMRetVal
 #if defined(__hexagon__)
 class HexagonTimerNode : public TimerNode {
  public:
-  virtual void Start() {}
-  virtual void Stop() {}
-  virtual int64_t SyncAndGetElapsedNanos() { return 0; }
+  virtual void Start() { start = HAP_perf_get_time_us(); }
+  virtual void Stop() { end = HAP_perf_get_time_us(); }
+  virtual int64_t SyncAndGetElapsedNanos() { return (end - start) * 1e3; }
   virtual ~HexagonTimerNode() {}
 
   static constexpr const char* _type_key = "HexagonTimerNode";
   TVM_DECLARE_FINAL_OBJECT_INFO(HexagonTimerNode, TimerNode);
 
  private:
+  uint64_t start, end;
 };
 
 TVM_REGISTER_OBJECT_TYPE(HexagonTimerNode);


### PR DESCRIPTION
`std::chrono` used by default in `time_evaluator` currently doesn't work on the hexagon device. This adds a Hexagon-specific timer which will enable using `time_evalautor` to do perf measurement on the device. I verified it to work on real HVX code and a device.

cc @kparzysz-quic @csullivan @Lunderberg @cconvey @tmoreau89  