### PR TITLE
Fix shape func for Reshape

### DIFF
--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -417,6 +417,7 @@ def _reshape_shape_func_input_shape(data_shape, newshape, ndim):
             assert infer_idx < 0, "One and only one dim can be inferred"
             out[dst_idx] = int64(1)
             infer_idx = i
+            src_idx += 1
             dst_idx += 1
         elif newshape[i] == -2:
             copy = True

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -233,6 +233,7 @@ def verify_any_reshape(x_shape, newshape, x_np_shape, out_shape, variable_newsha
     x = relay.var("x", shape=x_shape, dtype="float32")
     relu_x = relay.nn.relu(x)
     data = np.random.uniform(size=x_np_shape).astype("float32")
+    expected = data.reshape(out_shape)
     params = [x]
     args = [data]
 
@@ -245,7 +246,7 @@ def verify_any_reshape(x_shape, newshape, x_np_shape, out_shape, variable_newsha
     y = relay.reshape(relu_x, newshape=newshape)
     mod = tvm.IRModule()
     mod["main"] = relay.Function(params, y)
-    check_result(args, mod, data, flatten=True)
+    check_result(args, mod, expected)
 
 
 @tvm.testing.uses_gpu
@@ -257,6 +258,8 @@ def test_any_reshape():
     verify_any_reshape(any_dims(3), (0, -2), (2, 3, 4), (2, 3, 4))
     verify_any_reshape(any_dims(3), (-4, -1, 2, -3), (6, 3, 4), (3, 2, 12))
     verify_any_reshape(any_dims(3), (-4, 2, -1, -2), (6, 3, 4), (2, 3, 3, 4))
+    verify_any_reshape(any_dims(3), (1, -1, 0), (2, 3, 4), (1, 6, 4))
+    verify_any_reshape(any_dims(3), (-1, 1, 0), (2, 3, 4), (6, 1, 4))
 
 
 def verify_any_one_hot(indices_shape, indices_np_shape, depth, on_value, off_value, axis, dtype):


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

When I use Realy VM and the newshape of Reshape is [1, -1, 0] (the -1 is behind 0), the output shape is wrong. The test code is as follows:
```
import tvm 
from tvm import relay
import numpy as np

target = "llvm"
dtype = "float32"
executor_kind = "vm"
dev = tvm.runtime.ndarray.device(str(target), 0)

def build_module(x_shape, new_shape):
    x = relay.var("x", shape=x_shape, dtype=dtype)
    y = relay.reshape(x, newshape=new_shape)
    func = relay.Function([x], y)
    mod = tvm.ir.IRModule.from_expr(func)
    print("mod:", mod)
    executable = relay.vm.compile(mod, target)
    vm = tvm.runtime.vm.VirtualMachine(executable, dev)
    return vm

def run(vm, x_np_shape):
    x_np = np.random.uniform(size=x_np_shape).astype('float32')
    z = vm.run(x_np)
    print("tvm input:", x_np.shape)
    print("tvm output:", z.numpy().shape)
    print("")

def test(new_shape):
    vm = build_module([relay.Any(), relay.Any(), relay.Any()], new_shape=new_shape)
    run(vm, (2, 3, 4)) 

if __name__ == "__main__":
    test(new_shape=[0, 1, -1]) # correct
    test(new_shape=[0, -1, 1]) # correct
    test(new_shape=[1, -1, 0]) # wrong
    test(new_shape=[-1, 1, 0]) # wrong
```
The output is
```
mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[0, 1, -1])
}

tvm input: (2, 3, 4)
tvm output: (2, 1, 12)

mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[0, -1, 1])
}

tvm input: (2, 3, 4)
tvm output: (2, 12, 1)

mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[1, -1, 0])
}

tvm input: (2, 3, 4)
tvm output: (1, 8, 3)

mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[-1, 1, 0])
}

tvm input: (2, 3, 4)
tvm output: (8, 1, 3)
```
The problem is derived from https://github.com/apache/tvm/blob/main/python/tvm/relay/op/_transform.py#L420, where only `dst_idx` increases but `src_idx` does not. After fix it, the output shape is correct:
```
mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[0, 1, -1])
}

tvm input: (2, 3, 4)
tvm output: (2, 1, 12)

mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[0, -1, 1])
}

tvm input: (2, 3, 4)
tvm output: (2, 12, 1)

mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[1, -1, 0])
}

tvm input: (2, 3, 4)
tvm output: (1, 6, 4)

mod: def @main(%x: Tensor[(?, ?, ?), float32]) {
  reshape(%x, newshape=[-1, 1, 0])
}

tvm input: (2, 3, 4)
tvm output: (6, 1, 4)
```

Thanks for your review! @tqchen @junrushao1994 @icemelon 