### PR TITLE
[BugFix] Generate unique names for reduction blocks

### DIFF
--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -136,7 +136,7 @@ BlockRealize GenerateBlockFromTensors(const te::ComputeOp& compute_op,
   Stmt body;
   if (const auto* reduce = expr_body.as<ReduceNode>()) {
     // Case 1. Reduce compute
-    block_name = compute_op->name;
+    block_name = info->GetUniqueName(compute_op->name);
     int n_buffers = buffers.size();
 
     Array<PrimExpr> lhs;


### PR DESCRIPTION
This PR fixes a bug in #10671 which didn’t generate unique block names for reduction blocks. Sorry that I didn’t notice the bug before :sob:.

cc @Hzfengsy 