### PR TITLE
[git] Ignore auto-generated micro_tvmc.py example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/_staging/
+gallery/how_to/work_with_microtvm/micro_tvmc.py
 
 # PyBuilder
 /target/


### PR DESCRIPTION
This file is generated automatically by `tests/scripts/task_convert_scripts_to_python.sh`, added in https://github.com/apache/tvm/pull/10555, and can be generated when running the `ci.py lint` script locally.