### PR TITLE
[AOT] Get input name from module/prim func

### DIFF
--- a/tests/python/relay/aot/test_c_device_api.py
+++ b/tests/python/relay/aot/test_c_device_api.py
@@ -133,6 +133,7 @@ def non_device_api_main_func():
 def test_device_api_hooks_unpacked_api(device_api_main_func):
     """Check for Device API hooks with unpacked internal calls"""
     main_func = device_api_main_func(interface_api="c", use_unpacked_api=True)
+    input_name = main_func.params[0].name
 
     # Activate Device
     assert (
@@ -153,7 +154,7 @@ def test_device_api_hooks_unpacked_api(device_api_main_func):
         str(main_func.body[1][0][0][1])
         == "tir.tvm_check_return(0, -1, tir.call_extern("
         + '"tvmgen_default_ethos_u_main_0",'
-        + " x_int8_buffer_var, output_buffer_var, device_context_ethos_u))\n"
+        + f" {input_name}_buffer_var, output_buffer_var, device_context_ethos_u))\n"
     )
     # Close Device
     assert (

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -905,7 +905,8 @@ def test_output_tensor_names():
 
     in_min, in_max = (-128, 127)
     data = np.random.randint(in_min, high=in_max, size=ifm_shape, dtype="int8")
-    inputs = {"x_int8": data}
+    input_name = mod["main"].params[0].name_hint
+    inputs = {input_name: data}
     output_list = generate_ref_data(mod, inputs, params)
     compile_and_run(
         AOTTestModel(module=mod, inputs=inputs, outputs=output_list, params=params),


### PR DESCRIPTION
The input name generated in each of these test cases changes depending on the version of tensorflow being used. v2.4 = "x_int8", while v2.6 = "x". Making these tests agnostic of input name so that they work with both v2.4 and v2.6.

cc @leandron @Mousius @grant-arm 
