### PR TITLE
[Keras] Adjust Keras frontend for Keras 2.6 support

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1423,10 +1423,6 @@ def from_keras(model, shape=None, layout="NCHW"):
                 if (
                     hasattr(model, "_node_key")
                     and not model._node_key(keras_layer, node_idx) in model._network_nodes
-                ) or (
-                    # TFlite >=2.6
-                    not keras.engine.functional._make_node_key(keras_layer.name, node_idx)
-                    in model._network_nodes
                 ):
                     continue
             inexpr = []
@@ -1447,6 +1443,7 @@ def from_keras(model, shape=None, layout="NCHW"):
                 node_attributes = zip_node
             else:
                 node_attributes = node.iterate_inbound()
+
             for inbound_layer, n_idx, t_idx, _ in node_attributes:
                 if isinstance(inbound_layer, input_layer_class):
                     expr_name = inbound_layer.name

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -113,6 +113,17 @@ def verify_keras_frontend(keras_model, need_transpose=True, layout="NCHW"):
             tvm.testing.assert_allclose(kout, tout, rtol=1e-5, atol=1e-5)
 
 
+def get_mobilenet(keras):
+    if hasattr(keras.applications, "MobileNet"):
+        # Keras 2.4.x and older
+        MobileNet = keras.applications.MobileNet
+    else:
+        # Keras 2.6.x and newer
+        MobileNet = keras.applications.mobilenet.MobileNet
+
+    return MobileNet
+
+
 @tvm.testing.uses_gpu
 class TestKeras:
     scenarios = [using_classic_keras, using_tensorflow_keras]
@@ -466,25 +477,48 @@ class TestKeras:
             verify_keras_frontend(keras_model, need_transpose=False)
 
     def test_forward_vgg16(self, keras, layout="NCHW"):
-        keras_model = keras.applications.VGG16(
+        if hasattr(keras.applications, "VGG16"):
+            # Keras 2.4.x and older
+            VGG16 = keras.applications.VGG16
+        else:
+            # Keras 2.6.x and newer
+            VGG16 = keras.applications.vgg16.VGG16
+
+        keras_model = VGG16(
             include_top=True, weights="imagenet", input_shape=(224, 224, 3), classes=1000
         )
         verify_keras_frontend(keras_model, layout=layout)
 
     def test_forward_xception(self, keras, layout="NCHW"):
-        keras_model = keras.applications.Xception(
+        if hasattr(keras.applications, "Xception"):
+            # Keras 2.4.x and older
+            Xception = keras.applications.Xception
+        else:
+            # Keras 2.6.x and newer
+            Xception = keras.applications.xception.Xception
+
+        keras_model = Xception(
             include_top=True, weights="imagenet", input_shape=(299, 299, 3), classes=1000
         )
         verify_keras_frontend(keras_model, layout=layout)
 
     def test_forward_resnet50(self, keras, layout="NCHW"):
-        keras_model = keras.applications.ResNet50(
+        if hasattr(keras.applications, "ResNet50"):
+            # Keras 2.4.x and older
+            ResNet50 = keras.applications.ResNet50
+        else:
+            # Keras 2.6.x and newer
+            ResNet50 = keras.applications.resnet.ResNet50
+
+        keras_model = ResNet50(
             include_top=True, weights="imagenet", input_shape=(224, 224, 3), classes=1000
         )
         verify_keras_frontend(keras_model, layout=layout)
 
     def test_forward_mobilenet(self, keras, layout="NCHW"):
-        keras_model = keras.applications.MobileNet(
+        MobileNet = get_mobilenet(keras)
+
+        keras_model = MobileNet(
             include_top=True, weights="imagenet", input_shape=(224, 224, 3), classes=1000
         )
         verify_keras_frontend(keras_model, layout=layout)
@@ -608,9 +642,9 @@ class TestKeras:
             verify_keras_frontend(keras_model, layout="NDHWC")
 
     def test_forward_nested_layers(self, keras):
-        sub_model = keras.applications.MobileNet(
-            include_top=False, weights="imagenet", input_shape=(224, 224, 3)
-        )
+        MobileNet = get_mobilenet(keras)
+
+        sub_model = MobileNet(include_top=False, weights="imagenet", input_shape=(224, 224, 3))
         keras_model = keras.Sequential(
             [
                 sub_model,


### PR DESCRIPTION
Add support for the Keras frontend to be tested and used with both Keras 2.4 and 2.6, as we plan for migration.

Co-Authored-By: @lhutton1.

cc @areusch @manupa-arm @ekalda for reviews