### PR TITLE
ONNX Opset 14 Support - HardSwish

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1841,6 +1841,18 @@ class HardSigmoid(OnnxOpConverter):
         return AttrCvt("clip")([transformX], attr)
 
 
+class HardSwish(OnnxOpConverter):
+    """Operator converter for HardSwish."""
+
+    @classmethod
+    def _impl_v14(cls, inputs, attr, params):
+        alpha = attr.get("alpha", 1/6)
+        beta = attr.get("beta", 0.5)
+        transformX = (inputs[0] * _expr.const(alpha) + _expr.const(beta))
+        attr = {"a_min": 0, "a_max": 1}
+        return inputs[0] * AttrCvt("clip")([transformX], attr)
+
+
 class Reduce(OnnxOpConverter):
     """Operator converter for reduce ops."""
 
@@ -4674,6 +4686,7 @@ def _get_convert_map(opset):
         "PRelu": Prelu.get_converter(opset),
         "Sigmoid": Renamer("sigmoid"),
         "HardSigmoid": HardSigmoid.get_converter(opset),
+        "HardSwish": HardSwish.get_converter(opset),
         "Max": Maximum.get_converter(opset),
         "Min": Minimum.get_converter(opset),
         "Sum": Sum.get_converter(opset),

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1846,9 +1846,9 @@ class HardSwish(OnnxOpConverter):
 
     @classmethod
     def _impl_v14(cls, inputs, attr, params):
-        alpha = attr.get("alpha", 1/6)
+        alpha = attr.get("alpha", 1 / 6)
         beta = attr.get("beta", 0.5)
-        transformX = (inputs[0] * _expr.const(alpha) + _expr.const(beta))
+        transformX = inputs[0] * _expr.const(alpha) + _expr.const(beta)
         attr = {"a_min": 0, "a_max": 1}
         return inputs[0] * AttrCvt("clip")([transformX], attr)
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5061,7 +5061,6 @@ unsupported_onnx_tests = [
     "test_dropout_default_mask_ratio",
     "test_dropout_default_ratio",
     "test_gru_batchwise",
-    "test_hardswish",
     "test_identity_sequence",
     "test_if_seq",
     "test_loop11",


### PR DESCRIPTION
Added hardswish support to TVM CI and fixed unit test.

- Add class **HardSwish** and its reference to **convert_map** in **onnx.py**;
- Removed **test_hardswish** entry from **test_forward.py**;

@AndrewZhaoLuo PTAL