### PR TITLE
Fix clang llvm 12.0.1 warnings

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1265,7 +1265,7 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const LetNode* op) {
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const LoadNode* op) {
   LOG(FATAL) << "Unexpected deprecated LoadNode.  Use BufferLoadNode instead.";
-  return NULL;
+  return nullptr;
 }
 
 bool CodeGenLLVM::HasAlignmentPadding(DataType dtype) {

--- a/src/tir/transforms/bind_params.cc
+++ b/src/tir/transforms/bind_params.cc
@@ -82,7 +82,6 @@ class ParamsCollector : public StmtExprVisitor {
  private:
   std::vector<const tir::VarNode*> constant_list_;
   Map<tir::Var, runtime::NDArray> constant_map_;
-  bool first_for_ = true;
 };
 
 namespace transform {


### PR DESCRIPTION
Fix a couple simple clang warnings, detailed in commit messages.