### PR TITLE
[ONNX] Make `freeze_param = True` and run `DynamicToStatic` by default

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3720,12 +3720,14 @@ class QLinearConv(OnnxOpConverter):
             if attr["auto_pad"] in ("SAME_UPPER", "SAME_LOWER"):
                 # Warning: Convolution does not yet support dynamic shapes,
                 # one will need to run dynamic_to_static on this model after import
+                zp = fold_constant(x_zero_point), "Zero point expected to be a constant"
+                assert isinstance(zp, relay.Constant)
                 data = autopad(
                     data,
                     attr.get("strides", [1] * (ndim - 2)),
                     attr["kernel_shape"],
                     attr.get("dilations", [1] * (ndim - 2)),
-                    pad_value=x_zero_point.data,
+                    pad_value=zp.data,
                     mode=attr["auto_pad"],
                 )
             elif attr["auto_pad"] == "VALID":

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3720,8 +3720,8 @@ class QLinearConv(OnnxOpConverter):
             if attr["auto_pad"] in ("SAME_UPPER", "SAME_LOWER"):
                 # Warning: Convolution does not yet support dynamic shapes,
                 # one will need to run dynamic_to_static on this model after import
-                zp = fold_constant(x_zero_point), "Zero point expected to be a constant"
-                assert isinstance(zp, relay.Constant)
+                zp = fold_constant(x_zero_point)
+                assert isinstance(zp, relay.Constant), "Zero point expected to be a constant"
                 data = autopad(
                     data,
                     attr.get("strides", [1] * (ndim - 2)),

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -5133,7 +5133,7 @@ class GraphProto:
 
 
 def from_onnx(
-    model, shape=None, dtype="float32", opset=None, freeze_params=False, convert_config=None
+    model, shape=None, dtype="float32", opset=None, freeze_params=True, convert_config=None
 ):
     """Convert a ONNX model into an equivalent Relay Function.
 
@@ -5223,4 +5223,8 @@ def from_onnx(
     # Use the graph proto as a scope so that ops can access other nodes if needed.
     with g:
         mod, params = g.from_onnx(graph, opset)
+
+    if freeze_params:
+        mod = relay.transform.DynamicToStatic()(mod)
+
     return mod, params


### PR DESCRIPTION
The ONNX frontend is written to produce a dynamic graph and it is expected that the `DynamicToStatic` pass be applied after model import to make thing as static as possible. Until now we are implicitly relying on users to take this assumption into account, but I believe it is better to run `DynamicToStatic` inside the frontend since it is practically required anyway. This is especially important since in https://github.com/apache/tvm/pull/10691 I removed the "last minute fix-up".

For `DynamicToStatic` to work, `freeze_param` needs to be True. So I also changed its default value, but this can be reverted if there are some concerns in making `freeze_param = True` by default (which will disable `DynamicToStatic` too).

@mbrookhart @AndrewZhaoLuo @kparzysz-quic 