### PR TITLE
[docs] Disable numpy intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,7 +202,7 @@ latex_documents = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
-    "numpy": ("https://numpy.org/doc/stable", None),
+    # "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
     "matplotlib": ("https://matplotlib.org/", None),
 }
@@ -353,7 +353,7 @@ sphinx_gallery_conf = {
     "reference_url": {
         "tvm": None,
         "matplotlib": "https://matplotlib.org/",
-        "numpy": "https://numpy.org/doc/stable",
+        # "numpy": "https://numpy.org/doc/stable",
     },
     "examples_dirs": examples_dirs,
     "within_subsection_order": WithinSubsectionOrder,


### PR DESCRIPTION
These links usually 403 for us which `task_python_docs.sh` is set up to ignore, however sometimes it hits a 404 error which has been causing CI failures lately (e.g. https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/2832/pipeline/). This disables intersphinx links to numpy entirely until we can sort out a better fix.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
