### PR TITLE
Improve TVM_LOG_DEBUG specs

### DIFF
--- a/tests/cpp/runtime/logging_test.cc
+++ b/tests/cpp/runtime/logging_test.cc
@@ -51,7 +51,7 @@ TEST(TvmLogDebugSettings, VLogEnabledDefault) {
 
 TEST(TvmLogDebugSettings, VLogEnabledComplex) {
   TvmLogDebugSettings settings =
-      TvmLogDebugSettings::ParseSpec("foo/bar.cc=3;baz.cc=-1;DEFAULT=2;another/file.cc=4");
+      TvmLogDebugSettings::ParseSpec("foo/bar.cc=3,baz.cc=-1,DEFAULT=2,another/file.cc=4");
   EXPECT_TRUE(settings.dlog_enabled());
   EXPECT_TRUE(settings.VerboseEnabled("my/filesystem/src/foo/bar.cc", 3));
   EXPECT_FALSE(settings.VerboseEnabled("my/filesystem/src/foo/bar.cc", 4));
@@ -62,6 +62,15 @@ TEST(TvmLogDebugSettings, VLogEnabledComplex) {
 
 TEST(TvmLogDebugSettings, IllFormed) {
   EXPECT_THROW(TvmLogDebugSettings::ParseSpec("foo/bar.cc=bogus;"), InternalError);
+}
+
+TEST(TvmLogDebugSettings, SpecPrefix) {
+  TvmLogDebugSettings settings = TvmLogDebugSettings::ParseSpec(
+      "../src/foo/bar.cc=3,src/baz.cc=-1,foo/bar/src/another/file.cc=4");
+  EXPECT_TRUE(settings.dlog_enabled());
+  EXPECT_TRUE(settings.VerboseEnabled("my/filesystem/src/foo/bar.cc", 3));
+  EXPECT_FALSE(settings.VerboseEnabled("my/filesystem/src/baz.cc", 0));
+  EXPECT_TRUE(settings.VerboseEnabled("my/filesystem/src/another/file.cc", 4));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR makes two changes to TVM_LOG_DEBUG:

1. Strips the file name in the same way it does `__FILE__`, so that users can just copy-paste full paths to files and include them in the TVM_LOG_DEBUG spec without having to know to strip the `src/` prefix.
2. Changes the separator to `,` so that it can be more easily used without quoting in `docker/bash.sh` command strings, which can require a number of backslash-escapes that can be hard to determine when running commands like:
`docker/bash.sh  -it ci-cpu-with-ninja /bin/bash -c 'cd build && cmake -GNinja .. && ninja && cd .. && TVM_LOG_DEBUG=src/target/target.cc=1,src/runtime/module.cc=2 python3 -mpytest tests/python/relay/aot//test_crt_aot.py -n 8'`

cc @mbs-octoml 