### PR TITLE
Manually add libtorch op test

### DIFF
--- a/tests/python/contrib/test_libtorch_ops.py
+++ b/tests/python/contrib/test_libtorch_ops.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import tvm.testing
+
 import pytest
 
 import tvm.relay
@@ -28,7 +30,7 @@ except ImportError as e:
     torch = None
     import_torch_error = str(e)
 
-
+@tvm.testing.requires_gpu
 @pytest.mark.skipif(torch is None, reason=f"PyTorch is not available: {import_torch_error}")
 def test_backend():
     @torch.jit.script

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -64,6 +64,9 @@ run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-integration tests/python/int
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto
 
+# we want this to run in particular in integration-gpu because there we have PyTorch
+run_pytest cython libtorch tests/python/contrib/test_libtorch_ops.py
+
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
     run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay


### PR DESCRIPTION
We want the test to run in integration-gpu in the CI, but currently it is not picked up there and on the CPU, we do not have PyTorch. I would not know why it is not tried on the gpu-enabled CI run.