### PR TITLE
[git] Remove duplicate .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/_staging/
-gallery/how_to/work_with_microtvm/micro_tvmc.py
 
 # PyBuilder
 /target/


### PR DESCRIPTION
The ignore for `gallery/how_to/work_with_microtvm/micro_tvmc.py` was added in both https://github.com/apache/tvm/pull/10701 and https://github.com/apache/tvm/pull/10729.  This removes the duplicate entry.