### PR TITLE
[TIR] Simplify final indices from transform_layout

### DIFF
--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -126,9 +126,11 @@ Array<Range> IndexMapNode::MapRanges(const Array<Range>& ranges) const {
   }
 
   Array<Range> output;
+  arith::Analyzer analyzer;
   for (const auto& final_index : final_indices) {
     auto int_set = arith::EvalSet(final_index, dom_map);
-    output.push_back(Range::FromMinExtent(int_set.min(), int_set.max() - int_set.min() + 1));
+    output.push_back(Range::FromMinExtent(analyzer.Simplify(int_set.min()),
+                                          analyzer.Simplify(int_set.max() - int_set.min() + 1)));
   }
 
   return output;


### PR DESCRIPTION
The final indices returned from transform_layout when applied on a
`te.compute` are not simplified. Thus the returned index ranges are
harder understand

Eg: When applying NHWC to NCHWc transform_layout

```python
   iter_vars = s[B].transform_layout(lambda n,h,w,c: [n, c//4, h, w, c%4])
   print(iter_vars)
```

iter_vars before simplification:
```python
[iter_var(axis0, range(min=0, ext=((w - 1) + 1))), iter_var(axis1, range(min=0, ext=(floordiv(((z_div*4) - 1), 4) + 1))), iter_var(axis2, range(min=0, ext=((x - 1) + 1))), iter_var(axis3, range(min=0, ext=((y - 1) + 1))), iter_var(axis4, range(min=0, ext=4))]
```

iter_vars after simplification:
```python
[iter_var(axis0, range(min=0, ext=w)), iter_var(axis1, range(min=0, ext=z_div)), iter_var(axis2, range(min=0, ext=x)), iter_var(axis3, range(min=0, ext=y)), iter_var(axis4, range(min=0, ext=4))]
```

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
