### PR TITLE
[microNPU] Use TF reference kernels for codegen tests where possible

### DIFF
--- a/tests/python/contrib/test_ethosu/infra.py
+++ b/tests/python/contrib/test_ethosu/infra.py
@@ -23,6 +23,7 @@ This class include methods to parse the custom operator to extract
 the command stream and perform an equivalency check for single operator
 test cases.
 """
+from distutils.version import LooseVersion
 from typing import List
 
 import os
@@ -195,7 +196,16 @@ def generate_ref_data_tflite(model):
     The random input data and generated output data are returned.
     """
     expected_output_data = {}
-    interpreter = tf.lite.Interpreter(model_content=model)
+
+    # older versions of TFLite don't give access to reference kernels
+    if tf.__version__ < LooseVersion("2.5.0"):
+        interpreter = tf.lite.Interpreter(model_content=model)
+    else:
+        interpreter = tf.lite.Interpreter(
+            model_content=model,
+            experimental_op_resolver_type=tf.lite.experimental.OpResolverType.BUILTIN_REF,
+        )
+
     interpreter.allocate_tensors()
 
     input_details = interpreter.get_input_details()


### PR DESCRIPTION
Uses reference kernels for the codegen tests when the version of Tensorflow is >= 2.5.0 (as this is the first version this functionality was added). Otherwise, fallback to running the tests without.

cc @leandron @manupa-arm @ekalda @NicolaLancellotti 
