### PR TITLE
[microNPU] Remove unused import and command stream printing

### DIFF
--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -460,7 +460,7 @@ def test_ethosu_pooling(
             op = tf.nn.relu(op)
         return op
 
-    _compare_tvm_with_tflite(pooling, [ifm_shape], accel_type, print_cmm=True)
+    _compare_tvm_with_tflite(pooling, [ifm_shape], accel_type)
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)

--- a/tests/python/contrib/test_ethosu/test_replace_identity.py
+++ b/tests/python/contrib/test_ethosu/test_replace_identity.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from numpy.core.shape_base import block
 import pytest
 
 pytest.importorskip("ethosu.vela")


### PR DESCRIPTION
This is a follow up to https://github.com/apache/tvm/pull/10695.

