### PR TITLE
[runtime-rpc] Detect time_evaluator infinite loop

### DIFF
--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -21,6 +21,10 @@
  * \file rpc_module.cc
  * \brief RPC runtime module.
  */
+#if defined(__hexagon__)
+#define TVM_LOG_CUSTOMIZE 1
+#endif
+
 #include <tvm/runtime/container/string.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/profiling.h>
@@ -397,10 +401,9 @@ PackedFunc WrapTimeEvaluator(PackedFunc pf, Device dev, int number, int repeat, 
         int64_t t_nanos = t->SyncAndGetElapsedNanos();
 
         if ((min_repeat_ms > 0) && (t_nanos == 0)) {
-          // We're almost certainly caught in an infinite loop, perahsp because something
+          // We're almost certainly caught in an infinite loop, perhaps because something
           // in the timing mechanism isn't working as expected.
-          LOG(FATAL) << __FILE__ << ":" << __LINE__ << ": "
-                     << "Time evaluation will be stuck in an infinite loop: "
+          LOG(FATAL) << "Time evaluation will be stuck in an infinite loop: "
                      << "min_repeat_ms=" << min_repeat_ms
                      << ", but the function of interest supposedly has a running time of 0ns.";
         }

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -395,6 +395,16 @@ PackedFunc WrapTimeEvaluator(PackedFunc pf, Device dev, int number, int repeat, 
         }
         t->Stop();
         int64_t t_nanos = t->SyncAndGetElapsedNanos();
+
+        if ((min_repeat_ms > 0) && (t_nanos == 0)) {
+          // We're almost certainly caught in an infinite loop, perahsp because something
+          // in the timing mechanism isn't working as expected.
+          LOG(FATAL) << __FILE__ << ":" << __LINE__ << ": "
+                     << "Time evaluation will be stuck in an infinite loop: "
+                     << "min_repeat_ms=" << min_repeat_ms
+                     << ", but the function of interest supposedly has a running time of 0ns.";
+        }
+
         duration_ms = t_nanos / 1e6;
       } while (duration_ms < min_repeat_ms);
 


### PR DESCRIPTION
Reports/terminates when the RPC runtime's `time_evaluator`
is stuck in an infinite loop because `min_repeat_ms` > 0,
but the platform's timers are reporting the target-function's
running time as 0 nanoseconds.