### PR TITLE
[runtime-hexagon-rpc] more Hexagon/Android logging

### DIFF
--- a/src/runtime/hexagon/rpc/android_bash.sh.template
+++ b/src/runtime/hexagon/rpc/android_bash.sh.template
@@ -17,7 +17,13 @@
 # under the License.
 
 export LD_LIBRARY_PATH=.
-./tvm_rpc_android server --port=<RPC_SERVER_PORT> --tracker=<RPC_TRACKER_HOST>:<RPC_TRACKER_PORT> --key=<HEXAGON_REMOTE_DEVICE_KEY>&
+
+# Enable FARF-based logging for Hexagon code invoked by 'tvm_rpc_android_server'.
+export ADSP_LIBRARY_PATH=`pwd`
+echo 0x1f > tvm_rpc_android.farf
+
+./tvm_rpc_android server --port=<RPC_SERVER_PORT> --tracker=<RPC_TRACKER_HOST>:<RPC_TRACKER_PORT> --key=<HEXAGON_REMOTE_DEVICE_KEY> >${PWD}/tvm_rpc_android.log 2>&1 &
+
 rpc_pid=$!
 
 rm -f rpc_pid.txt


### PR DESCRIPTION
- Alter `android_bash.sh` to meet the runtime conditions needed
  for FARF logging.  (Note that FARF logging is also governed
  by certain preprocessor definitions.)

- Alter `android_bash.sh` so that any stdout/stderr emitted
  by `tvm_rpc_android_server` is saved to a log file
  (`tvm_rpc_android.log`). Previously that output was simply
  lost.