### PR TITLE
[Hexagon] Correct use of wrong cmake variable

### DIFF
--- a/apps/cpp_rpc/CMakeLists.txt
+++ b/apps/cpp_rpc/CMakeLists.txt
@@ -49,7 +49,7 @@ if (BUILD_FOR_ANDROID AND USE_HEXAGON_SDK)
   get_hexagon_sdk_property("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}"
     DSPRPC_LIB DSPRPC_LIB_DIRS
   )
-  if(REMOTE_DIR)
+  if(DSPRPC_LIB_DIRS)
     link_directories(${DSPRPC_LIB_DIRS})
   else()
     message(WARNING "Could not locate some Hexagon SDK components")


### PR DESCRIPTION
The code should be checking `DSPRPC_LIB_DIRS` instead of `REMOTE_DIR`.