### PR TITLE
[Hexagon] Guard UserDMA code with architecture check

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_user_dma.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_user_dma.cc
@@ -29,7 +29,7 @@ namespace runtime {
 namespace hexagon {
 
 int init_hexagon_user_dma() {
-#if defined(__hexagon__)
+#if defined(__hexagon__) && __HEXAGON_ARCH__ >= 68
   // reset DMA engine
   unsigned int status = dmpause() & DM0_STATUS_MASK;
   if (status != DM0_STATUS_IDLE) {
@@ -40,7 +40,7 @@ int init_hexagon_user_dma() {
 }
 
 int hexagon_user_dma_1d_sync(void* dst, void* src, uint32_t length) {
-#if defined(__hexagon__)
+#if defined(__hexagon__) && __HEXAGON_ARCH__ >= 68
   static int config_dma = init_hexagon_user_dma();
   if (config_dma != DMA_SUCCESS) {
     return DMA_FAILURE;

--- a/src/runtime/hexagon/hexagon/hexagon_user_dma_instructions.h
+++ b/src/runtime/hexagon/hexagon/hexagon_user_dma_instructions.h
@@ -24,7 +24,7 @@ namespace tvm {
 namespace runtime {
 namespace hexagon {
 
-#if defined(__hexagon__)
+#if defined(__hexagon__) && __HEXAGON_ARCH__ >= 68
 
 inline unsigned int dmpause() {
   unsigned int dm0 = 0;


### PR DESCRIPTION
UserDMA is only available in Hexagon V68 and later.
This fixes issue https://github.com/apache/tvm/issues/10768.