### PR TITLE
[ARM] Fix NCHWc int8 dot product schedule lowering

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -88,14 +88,6 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
     if groups == 1:
         if layout == "NCHW":
             if kernel_layout == "OIHW":
-                # ARM conv2d spatial pack schedule.
-                strategy.add_implementation(
-                    wrap_compute_conv2d(topi.arm_cpu.conv2d_nchw_spatial_pack),
-                    wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nchw_spatial_pack),
-                    name="conv2d_nchw_spatial_pack.arm_cpu",
-                    plevel=10,
-                )
-
                 if (
                     topi.arm_cpu.is_int8_hw_support(data.dtype, kernel.dtype)
                     and kernel.shape[1] >= 64
@@ -107,6 +99,14 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                         plevel=15,
                     )
                 else:
+                    # ARM conv2d spatial pack schedule.
+                    strategy.add_implementation(
+                        wrap_compute_conv2d(topi.arm_cpu.conv2d_nchw_spatial_pack),
+                        wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nchw_spatial_pack),
+                        name="conv2d_nchw_spatial_pack.arm_cpu",
+                        plevel=10,
+                    )
+
                     strategy.add_implementation(
                         wrap_compute_conv2d(topi.x86.conv2d_nchw),
                         wrap_topi_schedule(topi.x86.schedule_conv2d_nchw),

--- a/python/tvm/topi/arm_cpu/conv2d_int8.py
+++ b/python/tvm/topi/arm_cpu/conv2d_int8.py
@@ -152,8 +152,9 @@ def schedule_conv2d_NCHWc_int8(cfg, outs):
             _, _, kh, kw, _, _, _ = get_const_tuple(kernel_vec.shape)
             dtype = "uint" if data.dtype == "uint8" else "int"
             if is_dotprod_available():
-                intrin = dot_int8_int8_int32_neon_82(int32_lanes=4)
+                intrin = dot_int8_int8_int32_neon_82(int32_lanes=4, dtype=dtype)
             elif is_neon_available():
+                assert dtype == "int", "uint8 not supported if dot product is not available"
                 intrin = dot_int8_int8_int32_neon()
             else:
                 raise RuntimeError(

--- a/python/tvm/topi/arm_cpu/tensor_intrin.py
+++ b/python/tvm/topi/arm_cpu/tensor_intrin.py
@@ -516,7 +516,7 @@ def dot_int8_int8_int32_neon_82(int32_lanes, dtype="uint"):
                 int32_lanes * num_int8_elements,
             )
             vdot = tvm.tir.call_llvm_pure_intrin(
-                dtype_c, inst, tvm.tir.const(2, "uint32"), vec_c, vec_a, vec_b
+                dtype_c, inst, tvm.tir.const(3, "uint32"), vec_c, vec_a, vec_b
             )
             ib.emit(outs[0].vstore(0, vdot))
             return ib.get()

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm import meta_schedule as ms
 from tvm.ir.module import IRModule
@@ -151,6 +152,7 @@ def extract_task_qbert():
         assert "vnni" in annotations["schedule_rule"]
 
 
+@tvm.testing.skip_if_32bit(reason="Apparently the LLVM version on i386 image is too old")
 def test_extract_task_arm_conv2d_nchwc():
     data_shape = (1, 64, 128, 128)
     weight_shape = (32, 64, 1, 1)

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -151,7 +151,7 @@ def extract_task_qbert():
         assert "vnni" in annotations["schedule_rule"]
 
 
-def extract_task_arm_conv2d_nchwc():
+def test_extract_task_arm_conv2d_nchwc():
     data_shape = (1, 64, 128, 128)
     weight_shape = (32, 64, 1, 1)
     bias_shape = (weight_shape[0],)


### PR DESCRIPTION
The code path
https://github.com/apache/tvm/blob/6c6e873a1325a32418108daad6e38f3df8c37660/python/tvm/topi/arm_cpu/conv2d_int8.py#L154-L155
is broken because (1) we are not passing `dtype` and (2) the intrin description has a bug in the number of arguments to `sdot/udot`. For example I get this error if I try to run it:
```
  File "/home/masa/projects/dev/tvm/src/target/llvm/codegen_llvm.cc", line 981
TVMError: 
---------------------------------------------------------------
An error occurred during the execution of TVM.
For more information, please see: https://tvm.apache.org/docs/errors.html
---------------------------------------------------------------
  Check failed: (f) is false: Cannot find intrinsic declaration, possible type mismatch: llvm.aarch64.neon.udot
```

The PR that added this intrin, https://github.com/apache/tvm/pull/3978, didn't add a test so this code path was never tested. The PR added something under `apps/topi_recipe/conv`, https://github.com/apache/tvm/blob/main/apps/topi_recipe/conv/test_conv_int8_arm.py, but this script is broken and needs fixing too.

@tkonolige  