### PR TITLE
[ci] Manually merge code after checkout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,10 @@ def init_git() {
     script: './tests/scripts/task_show_node_info.sh',
     label: 'Show executor node info',
   )
+  sh (
+    script: 'git fetch origin main && git merge origin/main',
+    label: 'Merge to origin/main'
+  )
   retry(5) {
     timeout(time: 2, unit: 'MINUTES') {
       sh (script: 'git submodule update --init -f', label: 'Update git submodules')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,7 @@ tvm_multilib = 'build/libtvm.so, ' +
 
 tvm_multilib_tsim = 'build/libvta_tsim.so, ' +
                tvm_multilib
+upstream_revision = null
 
 // command to start a docker container
 docker_run = 'docker/bash.sh'
@@ -100,8 +101,21 @@ def init_git() {
     script: './tests/scripts/task_show_node_info.sh',
     label: 'Show executor node info',
   )
+
+  // Determine merge commit to use for all stages
+  sh(
+    script: 'git fetch origin main',
+    label: 'Fetch upstream',
+  )
+  if (upstream_revision == null) {
+    upstream_revision = sh(
+      script: 'git log -1 FETCH_HEAD --format=\'%H\'',
+      label: 'Determine upstream revision',
+      returnStdout: true,
+    ).trim()
+  }
   sh (
-    script: 'git fetch origin main && git merge origin/main',
+    script: "git merge ${upstream_revision}",
     label: 'Merge to origin/main'
   )
   retry(5) {


### PR DESCRIPTION
This is step 1 of 2 to fix the issue where Jenkins schedules a PR rebuild on non-code changes like editing the title. When the title is changed, GitHub sends an `pull_request` webhook to GitHub. Jenkins would ordinarily look at the webhook, query the PR and checks if the commit hash for the build has already been built. However, since we have it set in the Jenkins job to merge with main before this check occurs, the commit hash is different nearly every time. Disabling that setting fixes the issue, but we still need to merge the code with `main` to ensure that the build is valid if it completes successfully.

Also see the Jenkins configuration change here: https://github.com/tlc-pack/ci/pull/22

cc @areusch 