### PR TITLE
[Runtime][PipelineExecutor] Fix CPU affinity setting issue.

### DIFF
--- a/src/runtime/pipeline/pipeline_struct.h
+++ b/src/runtime/pipeline/pipeline_struct.h
@@ -1003,7 +1003,9 @@ class BackendRuntime : public BasicRuntime {
   void InitializePipeline(ConfigPipelineExecution config,
                           std::vector<std::shared_ptr<BackendRuntime>>* runtimes,
                           std::shared_ptr<GlobalRuntime> global_runtime) {
-    // Getting the 'binding configuration' for each runtime.
+    // Getting the current BackendRuntime's cpu affinity setting.
+    cpu_affinity_ = config.GetCPUAffinity(runtime_idx_);
+    // Getting the 'binding configuration' for each child runtime.
     config.VisitRuntimeOutputConfig(
         [&](int output_idx, int child_idx, std::string child_input_name) {
           std::shared_ptr<BasicRuntime> child_runtime = nullptr;

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -395,8 +395,8 @@ namespace threading {
 void ResetThreadPool() { tvm::runtime::ThreadPool::ThreadLocal()->Reset(); }
 /*!
  * \brief configure the CPU id affinity
- * \param mode The preferred CPU type (1 = big, -1 = little, -2 = specify ,
- *  -3 = kSpecifyOneCorePerThread, -3 = kSpecifyThreadShareAllCore).
+ * \param mode The preferred CPU type (1 = big, -1 = little, -2 = kSpecifyOneCorePerThread,
+ *  -3 = kSpecifyThreadShareAllCore).
  * \param nthreads The number of threads to use (0 = use all).
  * \param cpus cpus A list of CPUs is used to set the 'cpu affinity' for the worker threads.
  *


### PR DESCRIPTION
The CPU affinity setting not work in pipeline executor, the symptom is that there is no perf change after doing cpu affinity
change. the reason is that only the 'ConfigRuntime' class stored the cpu affinity setting but the 'BackendRuntime' class not.
