### PR TITLE
[CMSIS-NN] Stop test generating 1x1 and 1xn Conv2d

### DIFF
--- a/tests/cpp/relay/backend/contrib/cmsisnn/buffer_size_test.cc
+++ b/tests/cpp/relay/backend/contrib/cmsisnn/buffer_size_test.cc
@@ -37,7 +37,7 @@ namespace cmsisnn {
 
 static std::random_device rd;
 static std::mt19937 gen(rd());
-static std::uniform_int_distribution<> fake_parameters(1, 100);
+static std::uniform_int_distribution<> fake_parameters(2, 100);
 
 class CMSISNNCalculatedBufferSize : public testing::TestWithParam<std::array<int32_t, 3>> {};
 
@@ -97,8 +97,7 @@ TEST(CMSISNNConv2dBufferSize, Conv1xN) {
   ASSERT_EQ(conv2d_1xn(kHasMVE, 32), 0);
 }
 
-// Test disabled, see https://github.com/apache/tvm/issues/10748
-TEST(DISABLED_CMSISNNConv2dBufferSize, Default) {
+TEST(CMSISNNConv2dBufferSize, Default) {
   int32_t any = fake_parameters(gen);
 
   int32_t input_c = fake_parameters(gen);


### PR DESCRIPTION
I believe the flakiness in #10748 is the small chance of generating a
1x1 or 1xn convolution which allows for a different buffer size:

https://github.com/apache/tvm/blob/63461c0c97c307e581271708c3490f5275675a1a/src/relay/backend/contrib/cmsisnn/buffer_size.cc#L38-L47

Therefore, careful selection of the distribution should alleviate
this issue.

Closes #10748 

cc @driazati