### PR TITLE
[Hexagon] 2-d allocation cleanup

### DIFF
--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -438,7 +438,7 @@ void OpenCLWorkspace::Init(const std::string& type_key, const std::string& devic
   initialized_ = true;
 }
 
-TVM_REGISTER_GLOBAL("device_api.opencl.AllocNd").set_body([](TVMArgs args, TVMRetValue* rv) {
+TVM_REGISTER_GLOBAL("device_api.opencl.alloc_nd").set_body([](TVMArgs args, TVMRetValue* rv) {
   int32_t device_type = args[0];
   int32_t device_id = args[1];
   int32_t dtype_code_hint = args[2];
@@ -465,7 +465,7 @@ TVM_REGISTER_GLOBAL("device_api.opencl.AllocNd").set_body([](TVMArgs args, TVMRe
                                    type_hint);
 });
 
-TVM_REGISTER_GLOBAL("device_api.opencl.FreeNd").set_body([](TVMArgs args, TVMRetValue* rv) {
+TVM_REGISTER_GLOBAL("device_api.opencl.free_nd").set_body([](TVMArgs args, TVMRetValue* rv) {
   int32_t device_type = args[0];
   int32_t device_id = args[1];
   std::string scope = args[2];

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -475,7 +475,7 @@ class BuiltinLower : public StmtExprMutator {
     fdevapi_prefix += runtime::DeviceName(device_type_.as<IntImmNode>()->value);
 
     Array<PrimExpr> args = {
-        StringImm(fdevapi_prefix + ".AllocNd"),
+        StringImm(fdevapi_prefix + ".alloc_nd"),
         device_type_,
         device_id_,
         IntImm(DataType::Int(32), dtype.code()),
@@ -490,9 +490,9 @@ class BuiltinLower : public StmtExprMutator {
     Stmt alloca = LetStmt(let->var, call_packed, body);
 
     PrimExpr storage_scope = call->args[0];
-    Call free_op = Call(
-        DataType::Int(32), builtin::tvm_call_packed(),
-        {StringImm(fdevapi_prefix + ".FreeNd"), device_type_, device_id_, storage_scope, let->var});
+    Call free_op = Call(DataType::Int(32), builtin::tvm_call_packed(),
+                        {StringImm(fdevapi_prefix + ".free_nd"), device_type_, device_id_,
+                         storage_scope, let->var});
 
     Stmt free_stmt = IfThenElse(free_op != make_zero(DataType::Int(32)), throw_last_error);
     body = SeqStmt({alloca, free_stmt});


### PR DESCRIPTION
- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.

- Check for "global.vtcm" scope instead of "vtcm".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `"global.vtcm"`.  The previous check allowed unsupported scope such as `"local.vtcm"`.

- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.

- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.

Co-authored-by: Adam Straw <astraw@octoml.ai>