### PR TITLE
[Metaschedule] Add demonstration of selectively tuning relay ops with TIR schedules 

### DIFF
--- a/python/tvm/script/tir/intrin.py
+++ b/python/tvm/script/tir/intrin.py
@@ -103,6 +103,16 @@ def float64(imm, span):
 
 
 @register
+def int32x16(imm, span):
+    return imm.astype("int32x16", span)
+
+
+@register
+def int32x4(imm, span):
+    return imm.astype("int32x4", span)
+
+
+@register
 def min_value(dtype, span):
     return tvm.tir.min_value(dtype, span)
 

--- a/src/tir/schedule/ir_comparator.cc
+++ b/src/tir/schedule/ir_comparator.cc
@@ -125,9 +125,6 @@ bool TensorizeComparator::VisitStmt_(const BlockNode* op, const Stmt& other) {
     if (!CompareArray(op->iter_vars, rhs->iter_vars, &TensorizeComparator::CompareIterVar)) {
       return false;
     }
-    if (!CompareAnnotationMap(op->annotations, rhs->annotations)) {
-      return false;
-    }
     if (!CompareArray(op->alloc_buffers, rhs->alloc_buffers, &TensorizeComparator::CompareBuffer)) {
       return false;
     }

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -442,6 +442,8 @@ def manual_tir_common(do_tune=False):
     data = relay.var("data", shape=data_shape, dtype=data_dtype)
     weight = relay.var("weight", shape=weight_shape, dtype="int8")
     bias = relay.var("bias", shape=(weight_shape[0],), dtype="int32")
+
+    # dense is tuned by the TIR schedule above, bmm is scheduled by TE (topi/x86/batch_matmul.py)
     dense = relay.nn.dense(data, weight, out_dtype="int32")
     bias_add = relay.nn.bias_add(dense, bias) + relay.const(1, dtype="int32")
     out = relay.nn.batch_matmul(

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -34,7 +34,6 @@ from tvm.meta_schedule.tune import tune_relay, tune_extracted_tasks, extract_tas
 from tvm.meta_schedule.utils import derived_object
 from tvm.target.target import Target
 from tvm.script import tir as T
-from tvm.script.registry import register
 from tvm._ffi import register_func
 import tempfile
 
@@ -324,11 +323,6 @@ def test_meta_schedule_relay_lowering():
         actual_output = get_output(data, rt_mod1)
         expected_output = get_output(data, rt_mod2)
         assert np.allclose(actual_output, expected_output, rtol=1e-4, atol=2e-4)
-
-
-@register
-def int32x16(imm, span):
-    return imm.astype("int32x16", span)
 
 
 @T.prim_func

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -422,7 +422,6 @@ def schedule_dense(block, M, do_tune, sch):
     sch.reorder(a_ko, a_xi, a_ki)
 
     sch.parallel(fused)
-
     dec = sch.decompose_reduction(block, a_ko)
 
     init_loop = sch.get_loops(dec)[-1]
@@ -482,7 +481,9 @@ def manual_tir_common(do_tune=False):
                 num_trials_per_iter=64,
                 num_trials_total=64,
             )
-            database = tune_extracted_tasks(tune_tasks, target, config, work_dir=work_dir)
+            database = tune_extracted_tasks(
+                tune_tasks, target, config, work_dir=work_dir, postprocs=lambda: []
+            )
         else:
             database = JSONDatabase(
                 path_workload=osp.join(work_dir, "database_workload.json"),
@@ -543,8 +544,7 @@ def test_tune_relay_manual_tir_vnni():
 
     register_func("meta_schedule.dense_vnni", schedule_rule_dense_vnni)
 
-    # TODO(masahi): Weird error from tuning with CheckSubtreeCompactDataflow in for_kind.cc turned on
-    # manual_tir_common(do_tune=True)
+    manual_tir_common(do_tune=True)
 
 
 if __name__ == """__main__""":

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -531,16 +531,17 @@ def test_tune_relay_manual_tir_vnni():
 
     register_func("meta_schedule.dense_vnni", schedule_rule_dense_vnni)
 
-    manual_tir_common(do_tune=True)
+    # TODO(masahi): Weird error from tuning with CheckSubtreeCompactDataflow in for_kind.cc turned on
+    # manual_tir_common(do_tune=True)
 
 
 if __name__ == """__main__""":
-    # test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "llvm --num-cores=16")
-    # test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "nvidia/geforce-rtx-3070")
-    # test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "llvm --num-cores=16")
-    # test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "nvidia/geforce-rtx-3070")
-    # test_meta_schedule_tune_relay("bert_base", [1, 64], "llvm --num-cores=16")
-    # test_meta_schedule_tune_relay("bert_base", [1, 64], "nvidia/geforce-rtx-3070")
-    # test_meta_schedule_te2primfunc_argument_order()
-    # test_meta_schedule_relay_lowering()
+    test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "llvm --num-cores=16")
+    test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "nvidia/geforce-rtx-3070")
+    test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "llvm --num-cores=16")
+    test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "nvidia/geforce-rtx-3070")
+    test_meta_schedule_tune_relay("bert_base", [1, 64], "llvm --num-cores=16")
+    test_meta_schedule_tune_relay("bert_base", [1, 64], "nvidia/geforce-rtx-3070")
+    test_meta_schedule_te2primfunc_argument_order()
+    test_meta_schedule_relay_lowering()
     test_tune_relay_manual_tir_vnni()

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -107,6 +107,7 @@ def test_array_vectorize_add(target, dev, dtype):
 
 
 @tvm.testing.parametrize_targets("vulkan")
+@pytest.mark.skip("Flaky, https://github.com/apache/tvm/issues/10779")
 def test_vulkan_stress(target, dev):
     """
     Launch a randomized test with multiple kernels per stream, multiple uses of

--- a/tests/python/unittest/test_tvmscript_type.py
+++ b/tests/python/unittest/test_tvmscript_type.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=missing-function-docstring,missing-module-docstring,invalid-name,pointless-string-statement
 from tvm.script import tir as T
-from tvm.script.registry import register
 
 """
 This prim func include necessary buffer types that need to be checked
@@ -176,38 +175,6 @@ def different_access_indices(a: T.handle, b: T.handle) -> None:
                 with T.init():
                     B[vj, vi] = T.exp(B[vj, vi], dtype="float32")
                 B[vi, vj] = B[vi, vj] + A[vi, vj, vk]
-
-
-@register
-def int32x16(imm, span):
-    return imm.astype("int32x16", span)
-
-
-# Test assignment statements work without type annotation
-@T.prim_func
-def dot_product_intrin_vnni(a: T.handle, b: T.handle, c: T.handle) -> None:
-    A = T.match_buffer(a, (4,), "uint8", offset_factor=1)
-    B = T.match_buffer(b, (16, 4), "int8", offset_factor=1)
-    C = T.match_buffer(c, (16,), "int32", offset_factor=1)
-
-    with T.block("root"):
-        T.reads(C[0:16], A[0:4], B[0:16, 0:4])
-        T.writes(C[0:16])
-
-        A_u8x4 = A.vload([0], "uint8x4")  # type: ignore
-        A_i32 = T.reinterpret(A_u8x4, dtype="int32")
-
-        B_i8x64 = B.vload([0, 0], dtype="int8x64")  # type: ignore
-        B_i32x16 = T.reinterpret(B_i8x64, dtype="int32x16")
-
-        C[T.ramp(T.int32(0), 1, 16)] += T.call_llvm_pure_intrin(  # type: ignore
-            T.llvm_lookup_intrinsic_id("llvm.x86.avx512.vpdpbusd.512"),
-            T.uint32(0),
-            T.int32x16(0),  # type: ignore
-            T.broadcast(A_i32, 16),
-            B_i32x16,
-            dtype="int32x16",
-        )
 
 
 # Not running any test as we only want to type-check here


### PR DESCRIPTION
This demonstrates how to selectively extract and tune tasks from a whole relay mod, and apply the tuned schedule during the final `relay.build(...)`. 

This flow is entirely different from existing tests in `test_meta_schedule_tune_relay.py` where ALL ops are extracted and auto-scheduled by MS. My test extracts only int8 `dense` op, applies a manual TIR schedule on it, and leaves int8 `batch_matmul` to be scheduled by TE. 

This also serves as an example of autotvm style manual template + tensorization. The manual TIR schedule is equivalent to TE VNNI `dense` schedule in https://github.com/apache/tvm/blob/ce335c3a74185df6cc1152e53c60695d8a418d8e/python/tvm/topi/x86/dense.py#L366-L375

@junrushao1994 @vinx13 @csullivan @comaniac @jwfromm @TejashShah