### PR TITLE
use python3.7 install script in ci-qemu

### DIFF
--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -24,6 +24,9 @@ RUN apt-get update --fix-missing
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
+RUN bash /install/ubuntu1804_install_python.sh
+
 COPY install/ubuntu1804_install_python_venv.sh /install/ubuntu1804_install_python_venv.sh
 RUN bash /install/ubuntu1804_install_python_venv.sh
 ENV PATH=/opt/tvm-venv/bin:/opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH

--- a/docker/install/ubuntu1804_install_python_venv.sh
+++ b/docker/install/ubuntu1804_install_python_venv.sh
@@ -23,7 +23,7 @@ set -o pipefail
 # install python and pip, don't modify this, modify install_python_package.sh
 apt-get update
 apt-get install -y software-properties-common
-apt-get install -y python3.7-dev python3.7-setuptools python3.7-venv
+apt-get install -y python3.7-dev python3-setuptools python3.7-venv
 
 python3 -mvenv /opt/tvm-venv
 

--- a/docker/install/ubuntu1804_install_python_venv.sh
+++ b/docker/install/ubuntu1804_install_python_venv.sh
@@ -23,7 +23,7 @@ set -o pipefail
 # install python and pip, don't modify this, modify install_python_package.sh
 apt-get update
 apt-get install -y software-properties-common
-apt-get install -y python3-dev python3-setuptools python3-venv
+apt-get install -y python3.7-dev python3.7-setuptools python3.7-venv
 
 python3 -mvenv /opt/tvm-venv
 

--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -36,7 +36,8 @@ sudo apt-get install -y --no-install-recommends \
 wget --no-verbose https://apt.kitware.com/keys/kitware-archive-latest.asc
 sudo apt-key add kitware-archive-latest.asc
 
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+echo deb https://apt.kitware.com/ubuntu/ bionic main\
+     >> /etc/apt/sources.list.d/kitware.list
 sudo apt-get update
 
 sudo apt-get install -y cmake


### PR DESCRIPTION
This adds installing python3.7 (rather than the default, but EOL 3.6) to the qemu CI docker by using the script introduced in #10247 for the other ci components.
This is in the context of bumping PyTorch to 1.11 (#10794), but probably a good idea generally (if it works).

Thank you @leandron @driazati @masahi for advice in this, all errors are my own.