### PR TITLE
[TIR] More consistent TIR printing

### DIFF
--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -91,9 +91,19 @@ Doc TIRTextPrinter::PrintPrimFunc(const PrimFunc& prim_func) {
   // collect buffers in buffer_map
   memo_var_.clear();
   memo_buf_.clear();
-  for (const auto& it : op->buffer_map) {
-    memo_buf_[it.second] = AllocBuf(it.second);
+
+  // ordered vars associated with buffers, for consistent printing
+  std::vector<Var> buffer_vars_ordered;
+
+  for (Var v : op->params) {
+    auto buffer_map_find = op->buffer_map.find(v);
+    if (buffer_map_find != op->buffer_map.end()) {
+      auto map_data = *buffer_map_find;
+      buffer_vars_ordered.push_back(map_data.first);
+      memo_buf_[map_data.second] = AllocBuf(map_data.second);
+    }
   }
+
   // print PrimFunc
   Doc doc;
   doc << "primfn"
@@ -122,8 +132,8 @@ Doc TIRTextPrinter::PrintPrimFunc(const PrimFunc& prim_func) {
   if (memo_buf_.size() != 0) {
     Doc buffer_doc;
     std::vector<Doc> buffer_docs;
-    for (const auto& it : memo_buf_) {
-      const auto& buf = it.first;
+    for (const Var& v : buffer_vars_ordered) {
+      const Buffer buf = op->buffer_map[v];
       buffer_docs.push_back(BufferNode2Doc(buf.get(), Print(buf)));
     }
     buffer_doc << Doc::NewLine() << "buffers = {";
@@ -134,8 +144,9 @@ Doc TIRTextPrinter::PrintPrimFunc(const PrimFunc& prim_func) {
   if (op->buffer_map.size() != 0) {
     // print buffer_map
     std::vector<Doc> buffer_map_doc;
-    for (const auto& it : op->buffer_map) {
-      buffer_map_doc.push_back(Print(it.first) << ": " << Print(it.second));
+    for (const Var& v : buffer_vars_ordered) {
+      const Buffer buf = op->buffer_map[v];
+      buffer_map_doc.push_back(Print(v) << ": " << Print(buf));
     }
     doc << Doc::Indent(
         2, Doc::NewLine() << "buffer_map = {" << PrintSep(buffer_map_doc, Doc::Text(", ")) << "}");


### PR DESCRIPTION
If you print the same primfunc twice it can output different results if they have the same name.. This is due to iterating over unordered collections. This fixes this.

Example: 
https://github.com/AndrewZhaoLuo/TVM-Sandbox/blob/main/tir/test_inconsistent_tir_printing.py

Before the hashed text would be occasionally different, now it is all the same.