### PR TITLE
[ci] Clarify message in ping-reviewers bot

### DIFF
--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -23,6 +23,12 @@ from urllib import request
 from typing import Dict, Tuple, Any, Optional, List
 
 
+def compress_query(query: str) -> str:
+    query = query.replace("\n", "")
+    query = re.sub("\s+", " ", query)
+    return query
+
+
 class GitHubRepo:
     def __init__(self, user, repo, token):
         self.token = token
@@ -36,6 +42,7 @@ class GitHubRepo:
         }
 
     def graphql(self, query: str, variables: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        query = compress_query(query)
         if variables is None:
             variables = {}
         response = self._post(


### PR DESCRIPTION
This makes the next actions more clear (i.e. convert the PR to a draft if you don't plan to address it soon) and also fixes a bug where `@`-ed users would get double-tagged.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @areusch