### PR TITLE
[CI] Update `ci-qemu` to use python 3.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ ci_gpu = 'tlcpack/ci-gpu:v0.82'
 ci_cpu = 'tlcpack/ci-cpu:v0.82'
 ci_wasm = 'tlcpack/ci-wasm:v0.72'
 ci_i386 = 'tlcpack/ci-i386:v0.75'
-ci_qemu = 'tlcpack/ci-qemu:v0.11'
+ci_qemu = 'tlcpack/ci-qemu:v0.12'
 ci_arm = 'tlcpack/ci-arm:v0.08'
 ci_hexagon = 'tlcpack/ci-hexagon:v0.02'
 // <--- End of regex-scanned config.

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -53,7 +53,7 @@ ci_gpu = 'tlcpack/ci-gpu:v0.82'
 ci_cpu = 'tlcpack/ci-cpu:v0.82'
 ci_wasm = 'tlcpack/ci-wasm:v0.72'
 ci_i386 = 'tlcpack/ci-i386:v0.75'
-ci_qemu = 'tlcpack/ci-qemu:v0.11'
+ci_qemu = 'tlcpack/ci-qemu:v0.12'
 ci_arm = 'tlcpack/ci-arm:v0.08'
 ci_hexagon = 'tlcpack/ci-hexagon:v0.02'
 // <--- End of regex-scanned config.


### PR DESCRIPTION
As discussed in https://github.com/apache/tvm/pull/10794#issuecomment-1079899687, `ci-qemu` hasn't been updated to use python 3.7. This update fixes that. Validated in https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/238/pipeline/

I'm not sure if I updated `jenkins/Jenkinsfile.j2` correctly... This seems like a new thing since https://github.com/apache/tvm/pull/10740

@leandron @driazati @areusch @t-vi 