### PR TITLE
[TIR] Allow multiple element offsets in Buffer

### DIFF
--- a/include/tvm/tir/buffer.h
+++ b/include/tvm/tir/buffer.h
@@ -76,18 +76,33 @@ class BufferNode : public Object {
    *  This can be an empty array, indicating array is contiguous
    */
   Array<PrimExpr> strides;
-  /*! \brief The offset in terms of number of dtype elements (including lanes) */
-  PrimExpr elem_offset;
+
+  /*! \brief The offset for each physical dimension of the buffer.
+   *
+   * This is the offset of the start of the buffer, relative to the
+   * `data` variable.  This is typically used to represent offsets
+   * between two buffers that are backed by the same allocation, such
+   * as a buffer bind in a tensorized computation.  The offset is in
+   * terms of the scalar type of the buffer (e.g. an offset of 8 in a
+   * buffer of dtype float16x4 is a byte offset of 16 (8 elements) *
+   * (2 bytes/float16)).
+   */
+  Array<PrimExpr> elem_offsets;
+
   // Meta data
   /*! \brief optional name of the buffer */
   String name;
   /*! \brief Alignment requirement of data pointer in bytes. */
   int data_alignment;
+
   /*!
-   * \brief Factor of elem_offset field,
-   *  elem_offset is guaranteed to be multiple of offset_factor.
+   * \brief Factor of elem_offset field.
+   *
+   *  Each value in `elem_offsets` is guaranteed to be multiple of the
+   *  corresponding element in `offset_factors`.
    */
-  int offset_factor;
+  Array<IntImm> offset_factors;
+
   /*! \brief buffer type */
   BufferType buffer_type;
   /*!

--- a/include/tvm/topi/detail/extern.h
+++ b/include/tvm/topi/detail/extern.h
@@ -122,12 +122,19 @@ inline PrimExpr pack_buffer(Buffer buf) {
   } else {
     strides = 0;
   }
+
+  CHECK(buf->axis_separators.empty())
+      << "Cannot represent " << buf->axis_separators.size() + 1 << "-d buffer as a DLTensor";
+  ICHECK_LE(buf->elem_offsets.size(), 1);
+
+  PrimExpr elem_offset = buf->elem_offsets.size() ? buf->elem_offsets[0] : 0;
+
   Array<PrimExpr> pack_args{buf->data,
                             shape,
                             strides,
                             make_const(DataType::Int(32), static_cast<int64_t>(buf->shape.size())),
                             make_const(buf->dtype, 0),
-                            buf->elem_offset};
+                            elem_offset};
   return tvm::tir::Call(DataType::Handle(), tvm::tir::builtin::tvm_stack_make_array(), pack_args);
 }
 

--- a/python/tvm/script/tir/special_stmt.py
+++ b/python/tvm/script/tir/special_stmt.py
@@ -143,9 +143,19 @@ class MatchBuffer(SpecialStmt):
             if strides is None:
                 strides = []
             align = convert_to_int(align, "align", self.context.report_error, self.node.span)
-            offset_factor = convert_to_int(
-                offset_factor, "offset_factor", self.context.report_error, self.node.span
-            )
+
+            if offset_factor != 0:
+                try:
+                    offset_factor = list(offset_factor)
+                except TypeError:
+                    offset_factor = [offset_factor]
+
+                offset_factor = [
+                    convert_to_int(
+                        factor, "offset_factor", self.context.report_error, self.node.span
+                    )
+                    for factor in offset_factor
+                ]
             buffer_name: str = self.node.lhs[0].id.name
             buffer = tvm.tir.decl_buffer(
                 shape,

--- a/src/printer/tir_text_printer.cc
+++ b/src/printer/tir_text_printer.cc
@@ -220,8 +220,8 @@ Doc TIRTextPrinter::PrintProducer(const DataProducerNode* op) {
 Doc TIRTextPrinter::BufferNode2Doc(const BufferNode* buf, Doc doc) {
   doc << Doc::Text(": Buffer(") << Print(buf->data) << ", " << PrintDType(buf->dtype) << ", "
       << Print(buf->shape) << ", " << Print(buf->strides);
-  if (!is_zero(buf->elem_offset)) {
-    doc << ", elem_offset=" << Print(buf->elem_offset);
+  if (buf->elem_offsets.size()) {
+    doc << ", elem_offsets=" << Print(buf->elem_offsets);
   }
   if (buf->axis_separators.size()) {
     doc << ", axis_separators=" << Print(buf->axis_separators);
@@ -232,9 +232,18 @@ Doc TIRTextPrinter::BufferNode2Doc(const BufferNode* buf, Doc doc) {
   if (buf->data_alignment != 128) {
     doc << ", align=" << buf->data_alignment;
   }
-  if (buf->offset_factor != 1) {
-    doc << ", offset_factor=" << buf->offset_factor;
+
+  bool has_non_default_offset_factor = false;
+  for (const auto& offset_factor : buf->offset_factors) {
+    if (offset_factor->value != 1) {
+      has_non_default_offset_factor = true;
+      break;
+    }
   }
+  if (has_non_default_offset_factor) {
+    doc << ", offset_factor=" << Print(buf->offset_factors);
+  }
+
   if (buf->buffer_type != 1) {
     doc << ", type=" << Doc::StrLiteral("auto");
   }

--- a/src/te/schedule/schedule_postproc_to_primfunc.cc
+++ b/src/te/schedule/schedule_postproc_to_primfunc.cc
@@ -337,8 +337,9 @@ class AxisSeparatorsAttrUnwrapper : StmtExprMutator {
     if (lookup) {
       Array<IntImm> axis_separators = lookup.value();
       if (axis_separators.size()) {
-        auto write_ptr = buf.CopyOnWrite();
-        write_ptr->axis_separators = axis_separators;
+        buf = Buffer(buf->data, buf->dtype, buf->shape, buf->strides, buf->elem_offsets, buf->name,
+                     buf->data_alignment, buf->offset_factors, buf->buffer_type,
+                     buf->axis_separators, buf->span);
       }
     }
 

--- a/src/tir/analysis/verify_ssa.cc
+++ b/src/tir/analysis/verify_ssa.cc
@@ -100,16 +100,19 @@ class SSAVerifier final : public StmtExprVisitor {
   void DefineBuffer(const Buffer& buffer) {
     match_scope_ = true;
     this->VisitExpr(buffer->data);
-    for (size_t i = 0; i < buffer->shape.size(); ++i) {
-      this->VisitExpr(buffer->shape[i]);
+    for (const auto& dim : buffer->shape) {
+      this->VisitExpr(dim);
     }
 
     if (buffer->strides.defined()) {
-      for (size_t i = 0; i < buffer->strides.size(); ++i) {
-        this->VisitExpr(buffer->strides[i]);
+      for (const auto& stride : buffer->strides) {
+        this->VisitExpr(stride);
       }
     }
-    this->VisitExpr(buffer->elem_offset);
+
+    for (const auto& offset : buffer->elem_offsets) {
+      this->VisitExpr(offset);
+    }
 
     match_scope_ = false;
   }

--- a/src/tir/ir/buffer.cc
+++ b/src/tir/ir/buffer.cc
@@ -554,7 +554,7 @@ Buffer::Buffer(Var data, DataType dtype, Array<PrimExpr> shape, Array<PrimExpr> 
       elem_offsets.Set(i, make_const(index_dtype, 0));
     }
   }
-  if (elem_offsets.size() == 0) {
+  if (elem_offsets.size() == 0 || (elem_offsets.size() == 1 && is_zero(elem_offsets[0]))) {
     elem_offsets = Array<PrimExpr>(n_physical_dim, IntImm(index_dtype, 0));
   }
 

--- a/src/tir/transforms/arg_binder.h
+++ b/src/tir/transforms/arg_binder.h
@@ -122,7 +122,25 @@ class ArgBinder {
   const Map<Var, PrimExpr>& def_handle_dtype() const { return def_handle_dtype_; }
 
  private:
-  // Internal bind function
+  /* \brief Internal bind function
+   *
+   * \param arg The expression that occurs within a function body.
+   *
+   * \param value The expression that whose value is bound to arg for
+   *     the duration of the function.
+   *
+   * \param arg_name The name of the argument being bound.  This is
+   *     used for creating error messages.
+   *
+   * \param with_lets If true, variable definitions should be done by
+   *     inserting a let statement with the function initialiation in
+   *     `init_nest_`.  If false, variable definitions should be
+   *     performed by adding a substitution to `def_map_`.  If `arg`
+   *     is not a `VarNode`, `with_lets` is unused.
+   *
+   * \return True if arg is a VarNode being defined by this binding,
+   *     otherwise false.
+   */
   bool Bind_(const PrimExpr& arg, const PrimExpr& value, const std::string& arg_name,
              bool with_lets);
   /*! \brief The definition map, can be uses to substitute */

--- a/src/tir/transforms/bf16_legalize.cc
+++ b/src/tir/transforms/bf16_legalize.cc
@@ -276,9 +276,9 @@ class BF16LowerRewriter : public StmtExprMutator {
       if (oldbuf->dtype.is_bfloat16()) {
         DataType dtype = DataType::UInt(16, oldbuf->dtype.lanes());
         Var buffer_var = Var(oldbuf->data->name_hint, PointerType(PrimType(dtype)));
-        auto newbuf = Buffer(buffer_var, dtype, oldbuf->shape, oldbuf->strides, oldbuf->elem_offset,
-                             oldbuf->name, oldbuf->data_alignment, oldbuf->offset_factor,
-                             oldbuf->buffer_type);
+        auto newbuf = Buffer(buffer_var, dtype, oldbuf->shape, oldbuf->strides,
+                             oldbuf->elem_offsets, oldbuf->name, oldbuf->data_alignment,
+                             oldbuf->offset_factors, oldbuf->buffer_type);
         buffer_remap_[oldbuf] = newbuf;
         var_remap_[oldbuf->data] = buffer_var;
         new_buffer_map.Set(param_var, newbuf);
@@ -306,8 +306,8 @@ class BF16LowerRewriter : public StmtExprMutator {
         const Buffer& flatbuf = (*it).second;
         DataType dtype = DataType::UInt(16, oldbuf->dtype.lanes());
         auto newbuf = Buffer(flatbuf->data, dtype, oldbuf->shape, oldbuf->strides,
-                             oldbuf->elem_offset, oldbuf->name, oldbuf->data_alignment,
-                             oldbuf->offset_factor, oldbuf->buffer_type);
+                             oldbuf->elem_offsets, oldbuf->name, oldbuf->data_alignment,
+                             oldbuf->offset_factors, oldbuf->buffer_type);
         buffer_remap_[oldbuf] = newbuf;
         new_preflattened_buffer_map.Set(param_var, newbuf);
       } else {
@@ -334,8 +334,8 @@ class BF16LowerRewriter : public StmtExprMutator {
     if (var_it != var_remap_.end()) {
       DataType dtype =
           buf->dtype.is_bfloat16() ? DataType::UInt(16, buf->dtype.lanes()) : buf->dtype;
-      new_buf = Buffer(var_it->second, dtype, buf->shape, buf->strides, buf->elem_offset, buf->name,
-                       buf->data_alignment, buf->offset_factor, buf->buffer_type,
+      new_buf = Buffer(var_it->second, dtype, buf->shape, buf->strides, buf->elem_offsets,
+                       buf->name, buf->data_alignment, buf->offset_factors, buf->buffer_type,
                        buf->axis_separators, buf->span);
     }
 

--- a/src/tir/transforms/inject_copy_intrin.cc
+++ b/src/tir/transforms/inject_copy_intrin.cc
@@ -174,7 +174,7 @@ class CopyIntrinInjector : public StmtMutator {
       auto writer = dst.CopyOnWrite();
       writer->shape = dst_shape;
       writer->strides = dst_strides;
-      writer->elem_offset = store_strides[loop_var_size];
+      writer->elem_offsets = {store_strides[loop_var_size]};
     }
 
     Buffer src = load->buffer;
@@ -182,7 +182,7 @@ class CopyIntrinInjector : public StmtMutator {
       auto writer = src.CopyOnWrite();
       writer->shape = src_shape;
       writer->strides = src_strides;
-      writer->elem_offset = src_elem_offset;
+      writer->elem_offsets = {src_elem_offset};
     }
     *out = flower_copy_fromto_(src, dst, pad_before, pad_after, pad_value);
     if (!out->defined()) {

--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -170,8 +170,8 @@ class IRConvertSSA final : public StmtExprMutator {
     // new buffer, pushing it onto the scoped stack of existing
     // buffers.  This will be popped when the new_buffer_var
     // redefinition is popped.
-    Buffer new_buf(new_buffer_var, buf->dtype, buf->shape, buf->strides, buf->elem_offset,
-                   buf->name, buf->data_alignment, buf->offset_factor, buf->buffer_type,
+    Buffer new_buf(new_buffer_var, buf->dtype, buf->shape, buf->strides, buf->elem_offsets,
+                   buf->name, buf->data_alignment, buf->offset_factors, buf->buffer_type,
                    buf->axis_separators, buf->span);
     buffers.push_back(new_buf);
     return new_buf;

--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -143,8 +143,8 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       auto it = var_remap_.find(op->buffer->data.get());
       if (it != var_remap_.end()) {
         Buffer remapped_buffer(it->second, op->buffer->dtype, op->buffer->shape,
-                               op->buffer->strides, op->buffer->elem_offset, op->buffer->name,
-                               op->buffer->data_alignment, op->buffer->offset_factor,
+                               op->buffer->strides, op->buffer->elem_offsets, op->buffer->name,
+                               op->buffer->data_alignment, op->buffer->offset_factors,
                                op->buffer->buffer_type, op->buffer->axis_separators,
                                op->buffer->span);
         buf_remap_[op->buffer.get()] = remapped_buffer;
@@ -179,9 +179,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       auto it = var_remap_.find(store->buffer->data.get());
       if (it != var_remap_.end()) {
         Buffer remapped_buffer(it->second, store->buffer->dtype, store->buffer->shape,
-                               store->buffer->strides, store->buffer->elem_offset,
+                               store->buffer->strides, store->buffer->elem_offsets,
                                store->buffer->name, store->buffer->data_alignment,
-                               store->buffer->offset_factor, store->buffer->buffer_type,
+                               store->buffer->offset_factors, store->buffer->buffer_type,
                                store->buffer->axis_separators, store->buffer->span);
         buf_remap_[store->buffer.get()] = remapped_buffer;
         return BufferStore(remapped_buffer, store->value, store->indices, store->span);

--- a/src/tir/transforms/simplify.cc
+++ b/src/tir/transforms/simplify.cc
@@ -93,7 +93,7 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
     if (const BufferLoadNode* load = op->value.as<BufferLoadNode>()) {
       if (load->buffer->data.same_as(op->buffer->data) &&
           ArrayDeepEqual(load->indices, op->indices) &&
-          tir::ExprDeepEqual()(load->buffer->elem_offset, op->buffer->elem_offset) &&
+          ArrayDeepEqual(load->buffer->elem_offsets, op->buffer->elem_offsets) &&
           ArrayDeepEqual(load->buffer->shape, op->buffer->shape) &&
           ArrayDeepEqual(load->buffer->strides, op->buffer->strides)) {
         return Evaluate(0);

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -1426,9 +1426,11 @@ class StorageFlattener : public StmtExprMutator {
         }
       }
 
+      size_t n_flattened_dims = op->buffer->axis_separators.size() + 1;
       e.buffer = Buffer(op->buffer->data, op->buffer->dtype, op->buffer->shape, op->buffer->strides,
-                        PrimExpr(), op->buffer->name, align, 0, kDefault,
-                        op->buffer->axis_separators, op->buffer->span);
+                        Array<PrimExpr>(n_flattened_dims, PrimExpr()), op->buffer->name, align,
+                        Array<IntImm>(n_flattened_dims, IntImm(op->buffer->DefaultIndexType(), 0)),
+                        kDefault, op->buffer->axis_separators, op->buffer->span);
       e.flattened_buffer = e.buffer.GetFlattenedBuffer();
 
       // TODO(Lunderberg): Move the handling of boolean into a

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -430,9 +430,10 @@ class StoragePlanRewriter : public StmtExprMutator {
       return it->second;
     }
 
-    Buffer remapped = Buffer(new_backing_array, buf->dtype, buf->shape, buf->strides,
-                             buf->elem_offset, new_backing_array->name_hint, buf->data_alignment,
-                             buf->offset_factor, buf->buffer_type, buf->axis_separators, buf->span);
+    Buffer remapped =
+        Buffer(new_backing_array, buf->dtype, buf->shape, buf->strides, buf->elem_offsets,
+               new_backing_array->name_hint, buf->data_alignment, buf->offset_factors,
+               buf->buffer_type, buf->axis_separators, buf->span);
     buffer_remap_[key] = remapped;
     return remapped;
   }

--- a/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
+++ b/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
@@ -356,8 +356,8 @@ Buffer PoolAllocationToOffsetConverter::GetRemappedBuffer(Buffer original) {
   auto it = allocate_var_to_let_var_.find(original->data);
   if (it != allocate_var_to_let_var_.end()) {
     remapped = Buffer((*it).second, original->dtype, original->shape, original->strides,
-                      original->elem_offset, original->name, original->data_alignment,
-                      original->offset_factor, original->buffer_type, original->axis_separators,
+                      original->elem_offsets, original->name, original->data_alignment,
+                      original->offset_factors, original->buffer_type, original->axis_separators,
                       original->span);
   }
 


### PR DESCRIPTION
Follow-up from https://github.com/apache/tvm/pull/9727.  When using `Stage.tensorize`, the element offset of the array view has one offset for each physical dimension of the buffer.  This change replaces `BufferNode::elem_offset` and `BufferNode::offset_factor` with arrays.  The commits in this PR are separated by category, to help in review.

Updates to Buffer class, to handle multiple elem_offsets

- Includes size checks to ensure that each parameter that depends on the number of physical dimensions (`elem_offsets`, `offset_factors`, and `axis_separators`) are consistent.

- Support previous Buffer constructor with a single `elem_offset` and `offset_factor`, delegating to the array-based constructor.

Update python calls, with backwards compatibility

- `Buffer.elem_offset` and `Buffer.offset_factor` are implemented as properties, to avoid breakage of calling code.

- `decl_buffer` handles single or multiple `elem_offset` and `offset_factor` parameters.  The parameter name is unchanged, to avoid breaking call sites that use named arguments.

Updated TVMScript parser and printer

Other C++ changes

- Several other locations that referenced either `elem_offsets` or `offset_factors`, which required only minor updates to maintain existing behavior.