### PR TITLE
[TE] Update buffer binds if axis separators exist

### DIFF
--- a/src/te/schedule/schedule_postproc_to_primfunc.cc
+++ b/src/te/schedule/schedule_postproc_to_primfunc.cc
@@ -289,6 +289,13 @@ class AxisSeparatorsAttrUnwrapper : StmtExprMutator {
 
     if (op->attr_key == tir::attr::axis_separators) {
       return op->body;
+    } else if (op->attr_key == tir::attr::buffer_bind_scope) {
+      Array<ObjectRef> tuple = Downcast<Array<ObjectRef>>(op->node);
+      Buffer view_buffer = Downcast<Buffer>(tuple[0]);
+      Buffer source_buffer = Downcast<Buffer>(tuple[1]);
+      return AttrStmt(
+          Array<ObjectRef>{GetRemappedBuffer(view_buffer), GetRemappedBuffer(source_buffer)},
+          op->attr_key, op->value, op->body);
     } else {
       return ret;
     }


### PR DESCRIPTION
In SchedulePostProcToPrimfunc, when the axis separator attribute is moved to the buffer properties, it doesn't update buffers that are in the buffer bind scope.  This occurs if `Stage.tensorize` is called for a stage whose layout transformation includes `te.AXIS_SEPARATOR`.