### PR TITLE
[skip ci][hotfix] Fix broken lint

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2044,7 +2044,7 @@ class PyTorchOpConverter:
             data0, data1, alpha = self.pytorch_promote_types(inputs, input_types)
             return get_relay_op("subtract")(data0, alpha * data1)
         else:
-            data0, data1= self.pytorch_promote_types(inputs, input_types)
+            data0, data1 = self.pytorch_promote_types(inputs, input_types)
             return get_relay_op("subtract")(data0, data1)
 
     def rsub(self, inputs, input_types):


### PR DESCRIPTION
Broken by #10794 since CI didn't run correctly. Right now lint is skipped in order to build the docker images with the intent of re-running later on the new image, but this is not entirely implemented yet (#10664 should fix it so this doesn't happen again)

cc @masahi