### PR TITLE
[ci][docker] Remove nvidia ml repository before updating

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -20,6 +20,7 @@
 FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 
 # Base scripts
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list && apt-get clean
 RUN apt-get update --fix-missing
 
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh


### PR DESCRIPTION
`bash docker/build.sh ci_gpu` fails locally as well as in CI: https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdaily-docker-image-rebuild/detail/daily-docker-image-rebuild/273/pipeline/57

From [this post](https://forums.developer.nvidia.com/t/failed-to-fetch-https-developer-download-nvidia-com-compute-machine-learning-repos-ubuntu1804-x86-64-packages-gz/156287), so long as the build completes (meaning we don't use any apt packages from this repo), it should be fine

cc @areusch @masahi
