### PR TITLE
[ci] Add GitHub Actions bot to merge PRs on demand

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,28 @@
+
+name: Merge
+on:
+  status:
+  pull_request_review:
+    types:
+      - submitted
+  issue_comment:
+
+concurrency:
+  group: merge-${{ github.event.pull_request.number }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  maybe-merge:
+    if: github.repository == 'driazati/tvm'
+    # if: github.repository == 'apache/tvm' # TODO: uncomment after testing
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Merge if requested and possible
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -eux
+          python tests/scripts/github_mergebot.py --pr "$PR_NUMBER" --run-url "$RUN_URL"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,8 +13,7 @@ concurrency:
 
 jobs:
   maybe-merge:
-    if: github.repository == 'driazati/tvm'
-    # if: github.repository == 'apache/tvm' # TODO: uncomment after testing
+    if: github.repository == 'apache/tvm'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,5 @@ tvm-site/
 # Generated docs files
 gallery/how_to/work_with_microtvm/micro_tvmc.py
 
+# Test sample data files
+!tests/python/ci/sample_prs/*.json

--- a/tests/python/ci/sample_prs/pr10786-badci.json
+++ b/tests/python/ci/sample_prs/pr10786-badci.json
@@ -1,0 +1,123 @@
+{
+  "title": "[Hexagon] 2-d allocation cleanup",
+  "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+  "state": "OPEN",
+  "comments": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": []
+  },
+  "authorCommits": {
+    "nodes": [
+      {
+        "commit": {
+          "authors": {
+            "nodes": [
+              {
+                "name": "Eric Lunderberg",
+                "email": "elunderberg@octoml.ai"
+              },
+              {
+                "name": "Adam Straw",
+                "email": "astraw@octoml.ai"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "commits": {
+    "nodes": [
+      {
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+          "statusCheckRollup": {
+            "contexts": {
+              "pageInfo": {
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "name": "MacOS",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "FAILED",
+                  "url": "https://github.com/apache/tvm/runs/5694945029"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945030"
+                },
+                {
+                  "name": "Windows",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945524"
+                },
+                {
+                  "state": "SUCCESS",
+                  "context": "tvm-ci/pr-merge",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reviewDecision": "APPROVED",
+  "reviews": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "body": "@tvm-bot merge",
+        "updatedAt": "2022-03-25T22:13:50Z",
+        "authorCanPushToRepository": true,
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "state": "APPROVED"
+      }
+    ]
+  }
+}

--- a/tests/python/ci/sample_prs/pr10786-badci.json
+++ b/tests/python/ci/sample_prs/pr10786-badci.json
@@ -96,7 +96,7 @@
                 },
                 {
                   "state": "FAILED",
-                  "context": "tvm-ci/pr-merge",
+                  "context": "tvm-ci/pr-head",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
               ]

--- a/tests/python/ci/sample_prs/pr10786-badci.json
+++ b/tests/python/ci/sample_prs/pr10786-badci.json
@@ -2,6 +2,9 @@
   "title": "[Hexagon] 2-d allocation cleanup",
   "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
   "state": "OPEN",
+  "author": {
+    "login": "Lunderberg"
+  },
   "comments": {
     "pageInfo": {
       "hasPreviousPage": false
@@ -62,7 +65,7 @@
                     }
                   },
                   "status": "COMPLETED",
-                  "conclusion": "FAILED",
+                  "conclusion": "SUCCESS",
                   "url": "https://github.com/apache/tvm/runs/5694945029"
                 },
                 {
@@ -92,7 +95,7 @@
                   "url": "https://github.com/apache/tvm/runs/5694945524"
                 },
                 {
-                  "state": "SUCCESS",
+                  "state": "FAILED",
                   "context": "tvm-ci/pr-merge",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
@@ -115,6 +118,9 @@
         "authorCanPushToRepository": true,
         "commit": {
           "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "author": {
+          "login": "kparzysz-quic"
         },
         "state": "APPROVED"
       }

--- a/tests/python/ci/sample_prs/pr10786-changes-requested.json
+++ b/tests/python/ci/sample_prs/pr10786-changes-requested.json
@@ -106,15 +106,16 @@
       }
     ]
   },
-  "reviewDecision": "APPROVED",
+  "reviewDecision": "CHANGES_REQUESTED",
   "reviews": {
     "pageInfo": {
       "hasPreviousPage": false
     },
     "nodes": [
       {
-        "body": "",
+        "body": "@tvm-bot merge",
         "updatedAt": "2022-03-25T22:13:50Z",
+        "url": "https://github.com/apache/tvm/pull/10786#pullrequestreview-922186273",
         "authorCanPushToRepository": true,
         "commit": {
           "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
@@ -122,7 +123,7 @@
         "author": {
           "login": "kparzysz-quic"
         },
-        "state": "APPROVED"
+        "state": "CHANGES_REQUESTED"
       }
     ]
   }

--- a/tests/python/ci/sample_prs/pr10786-co-authors.json
+++ b/tests/python/ci/sample_prs/pr10786-co-authors.json
@@ -22,8 +22,8 @@
                 "email": "elunderberg@octoml.ai"
               },
               {
-                "name": "Adam Straw",
-                "email": "astraw@octoml.ai"
+                "name": "Some One",
+                "email": "someone@email.com"
               }
             ]
           }
@@ -113,7 +113,7 @@
     },
     "nodes": [
       {
-        "body": "",
+        "body": "@tvm-bot merge",
         "updatedAt": "2022-03-25T22:13:50Z",
         "authorCanPushToRepository": true,
         "commit": {

--- a/tests/python/ci/sample_prs/pr10786-invalid-author.json
+++ b/tests/python/ci/sample_prs/pr10786-invalid-author.json
@@ -115,9 +115,9 @@
       {
         "body": "@tvm-bot merge",
         "updatedAt": "2022-03-25T22:13:50Z",
-        "authorCanPushToRepository": true,
+        "authorCanPushToRepository": false,
         "commit": {
-          "oid": "abc12345"
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
         },
         "author": {
           "login": "kparzysz-quic"

--- a/tests/python/ci/sample_prs/pr10786-invalid-author.json
+++ b/tests/python/ci/sample_prs/pr10786-invalid-author.json
@@ -96,7 +96,7 @@
                 },
                 {
                   "state": "SUCCESS",
-                  "context": "tvm-ci/pr-merge",
+                  "context": "tvm-ci/pr-head",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
               ]

--- a/tests/python/ci/sample_prs/pr10786-merges.json
+++ b/tests/python/ci/sample_prs/pr10786-merges.json
@@ -1,0 +1,123 @@
+{
+  "title": "[Hexagon] 2-d allocation cleanup",
+  "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+  "state": "OPEN",
+  "comments": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": []
+  },
+  "authorCommits": {
+    "nodes": [
+      {
+        "commit": {
+          "authors": {
+            "nodes": [
+              {
+                "name": "Eric Lunderberg",
+                "email": "elunderberg@octoml.ai"
+              },
+              {
+                "name": "Adam Straw",
+                "email": "astraw@octoml.ai"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "commits": {
+    "nodes": [
+      {
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+          "statusCheckRollup": {
+            "contexts": {
+              "pageInfo": {
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "name": "MacOS",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945029"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945030"
+                },
+                {
+                  "name": "Windows",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945524"
+                },
+                {
+                  "state": "SUCCESS",
+                  "context": "tvm-ci/pr-merge",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reviewDecision": "APPROVED",
+  "reviews": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "body": "@tvm-bot merge",
+        "updatedAt": "2022-03-25T22:13:50Z",
+        "authorCanPushToRepository": true,
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "state": "APPROVED"
+      }
+    ]
+  }
+}

--- a/tests/python/ci/sample_prs/pr10786-merges.json
+++ b/tests/python/ci/sample_prs/pr10786-merges.json
@@ -2,6 +2,9 @@
   "title": "[Hexagon] 2-d allocation cleanup",
   "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
   "state": "OPEN",
+  "author": {
+    "login": "Lunderberg"
+  },
   "comments": {
     "pageInfo": {
       "hasPreviousPage": false
@@ -115,6 +118,9 @@
         "authorCanPushToRepository": true,
         "commit": {
           "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "author": {
+          "login": "kparzysz-quic"
         },
         "state": "APPROVED"
       }

--- a/tests/python/ci/sample_prs/pr10786-merges.json
+++ b/tests/python/ci/sample_prs/pr10786-merges.json
@@ -96,7 +96,7 @@
                 },
                 {
                   "state": "SUCCESS",
-                  "context": "tvm-ci/pr-merge",
+                  "context": "tvm-ci/pr-head",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
               ]

--- a/tests/python/ci/sample_prs/pr10786-missing-job.json
+++ b/tests/python/ci/sample_prs/pr10786-missing-job.json
@@ -96,7 +96,7 @@
                 },
                 {
                   "state": "SUCCESS",
-                  "context": "tvm-ci/definitely-not-pr-merge",
+                  "context": "tvm-ci/definitely-not-pr-head",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
               ]

--- a/tests/python/ci/sample_prs/pr10786-missing-job.json
+++ b/tests/python/ci/sample_prs/pr10786-missing-job.json
@@ -2,6 +2,9 @@
   "title": "[Hexagon] 2-d allocation cleanup",
   "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
   "state": "OPEN",
+  "author": {
+    "login": "Lunderberg"
+  },
   "comments": {
     "pageInfo": {
       "hasPreviousPage": false
@@ -115,6 +118,9 @@
         "authorCanPushToRepository": true,
         "commit": {
           "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "author": {
+          "login": "kparzysz-quic"
         },
         "state": "APPROVED"
       }

--- a/tests/python/ci/sample_prs/pr10786-missing-job.json
+++ b/tests/python/ci/sample_prs/pr10786-missing-job.json
@@ -93,7 +93,7 @@
                 },
                 {
                   "state": "SUCCESS",
-                  "context": "tvm-ci/pr-merge",
+                  "context": "tvm-ci/definitely-not-pr-merge",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
               ]
@@ -114,7 +114,7 @@
         "updatedAt": "2022-03-25T22:13:50Z",
         "authorCanPushToRepository": true,
         "commit": {
-          "oid": "abc12345"
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
         },
         "state": "APPROVED"
       }

--- a/tests/python/ci/sample_prs/pr10786-nottriggered.json
+++ b/tests/python/ci/sample_prs/pr10786-nottriggered.json
@@ -1,0 +1,123 @@
+{
+  "title": "[Hexagon] 2-d allocation cleanup",
+  "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+  "state": "OPEN",
+  "comments": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": []
+  },
+  "authorCommits": {
+    "nodes": [
+      {
+        "commit": {
+          "authors": {
+            "nodes": [
+              {
+                "name": "Eric Lunderberg",
+                "email": "elunderberg@octoml.ai"
+              },
+              {
+                "name": "Adam Straw",
+                "email": "astraw@octoml.ai"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "commits": {
+    "nodes": [
+      {
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+          "statusCheckRollup": {
+            "contexts": {
+              "pageInfo": {
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "name": "MacOS",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945029"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945030"
+                },
+                {
+                  "name": "Windows",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945524"
+                },
+                {
+                  "state": "SUCCESS",
+                  "context": "tvm-ci/pr-merge",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reviewDecision": "APPROVED",
+  "reviews": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "body": "",
+        "updatedAt": "2022-03-25T22:13:50Z",
+        "authorCanPushToRepository": true,
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "state": "APPROVED"
+      }
+    ]
+  }
+}

--- a/tests/python/ci/sample_prs/pr10786-nottriggered.json
+++ b/tests/python/ci/sample_prs/pr10786-nottriggered.json
@@ -2,6 +2,9 @@
   "title": "[Hexagon] 2-d allocation cleanup",
   "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
   "state": "OPEN",
+  "author": {
+    "login": "Lunderberg"
+  },
   "comments": {
     "pageInfo": {
       "hasPreviousPage": false
@@ -115,6 +118,9 @@
         "authorCanPushToRepository": true,
         "commit": {
           "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "author": {
+          "login": "kparzysz-quic"
         },
         "state": "APPROVED"
       }

--- a/tests/python/ci/sample_prs/pr10786-oldreview.json
+++ b/tests/python/ci/sample_prs/pr10786-oldreview.json
@@ -1,0 +1,123 @@
+{
+  "title": "[Hexagon] 2-d allocation cleanup",
+  "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+  "state": "OPEN",
+  "comments": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": []
+  },
+  "authorCommits": {
+    "nodes": [
+      {
+        "commit": {
+          "authors": {
+            "nodes": [
+              {
+                "name": "Eric Lunderberg",
+                "email": "elunderberg@octoml.ai"
+              },
+              {
+                "name": "Adam Straw",
+                "email": "astraw@octoml.ai"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "commits": {
+    "nodes": [
+      {
+        "commit": {
+          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+          "statusCheckRollup": {
+            "contexts": {
+              "pageInfo": {
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "name": "MacOS",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945029"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945030"
+                },
+                {
+                  "name": "Windows",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/5694945524"
+                },
+                {
+                  "state": "SUCCESS",
+                  "context": "tvm-ci/pr-merge",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reviewDecision": "APPROVED",
+  "reviews": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "body": "@tvm-bot merge",
+        "updatedAt": "2022-03-25T22:13:50Z",
+        "authorCanPushToRepository": true,
+        "commit": {
+          "oid": "6f24bcf57d07f915a98fd91178f04d9e92a09fcd"
+        },
+        "state": "APPROVED"
+      }
+    ]
+  }
+}

--- a/tests/python/ci/sample_prs/pr10786-oldreview.json
+++ b/tests/python/ci/sample_prs/pr10786-oldreview.json
@@ -96,7 +96,7 @@
                 },
                 {
                   "state": "SUCCESS",
-                  "context": "tvm-ci/pr-merge",
+                  "context": "tvm-ci/pr-head",
                   "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
                 }
               ]

--- a/tests/python/ci/sample_prs/pr11244-unauthorized-comment.json
+++ b/tests/python/ci/sample_prs/pr11244-unauthorized-comment.json
@@ -1,0 +1,103 @@
+{
+  "title": "[CRT runtime] Added functions TVMPlatformPreFuncCall and TVMPlatformPostFuncCall",
+  "body": "See [this thread ](https://discuss.tvm.apache.org/t/crt-add-platform-specific-pre-and-post-function-calls-in-crt-runtime/12723)for an explanation.",
+  "state": "OPEN",
+  "author": {
+    "login": "fPecc"
+  },
+  "comments": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "authorAssociation": "NONE",
+        "author": {
+          "login": "abc"
+        },
+        "updatedAt": "2022-05-09T13:39:04Z",
+        "body": "@tvm-bot merge"
+      },
+      {
+        "authorAssociation": "CONTRIBUTOR",
+        "author": {
+          "login": "areusch"
+        },
+        "updatedAt": "2022-05-11T19:22:01Z",
+        "body": "i commented on the discuss forum thread. let's resolve there and then continue this PR."
+      }
+    ]
+  },
+  "authorCommits": {
+    "nodes": [
+      {
+        "commit": {
+          "authors": {
+            "nodes": [
+              {
+                "name": "Federico Peccia",
+                "email": "peccia@fzi.de"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "commits": {
+    "nodes": [
+      {
+        "commit": {
+          "oid": "79d355c5f837b3bdadb5d25b2a5d0d2802783ae2",
+          "statusCheckRollup": {
+            "contexts": {
+              "pageInfo": {
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6352791017"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6352791014"
+                },
+                {
+                  "state": "ERROR",
+                  "context": "tvm-ci/pr-head",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-11244/1/display/redirect"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reviewDecision": "REVIEW_REQUIRED",
+  "reviews": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": []
+  }
+}

--- a/tests/python/ci/sample_prs/pr11267-no-review.json
+++ b/tests/python/ci/sample_prs/pr11267-no-review.json
@@ -1,15 +1,32 @@
 {
-  "title": "[Hexagon] 2-d allocation cleanup",
-  "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+  "title": "[ci][docker] Use sccache everywhere by default",
+  "body": "This adds `/opt/sccache` to the PATH of each of the CI docker images so when cmake looks for a C compiler it will pick up the sccache wrapper by default. This fixes some issues where compiler invocations weren't being run though sccache. With this approach the invoker doesn't need to do anything specific to set up sccache.\n\nThis will require a follow up PR to update the Docker images and remove some of the sccache logic in `task_build.py`\n\n\n\ncc @Mousius @areusch",
   "state": "OPEN",
   "author": {
-    "login": "Lunderberg"
+    "login": "driazati"
   },
   "comments": {
     "pageInfo": {
       "hasPreviousPage": false
     },
-    "nodes": []
+    "nodes": [
+      {
+        "authorAssociation": "CONTRIBUTOR",
+        "author": {
+          "login": "areusch"
+        },
+        "updatedAt": "2022-05-11T16:54:32Z",
+        "body": "just confirming--we can disable this when doing a local build, correct? what's the mechanism by which we do that?"
+      },
+      {
+        "authorAssociation": "COLLABORATOR",
+        "author": {
+          "login": "driazati"
+        },
+        "updatedAt": "2022-05-11T18:46:54Z",
+        "body": "@tvm-bot merge"
+      }
+    ]
   },
   "authorCommits": {
     "nodes": [
@@ -18,12 +35,8 @@
           "authors": {
             "nodes": [
               {
-                "name": "Eric Lunderberg",
-                "email": "elunderberg@octoml.ai"
-              },
-              {
-                "name": "Adam Straw",
-                "email": "astraw@octoml.ai"
+                "name": "driazati",
+                "email": "driazati@users.noreply.github.com"
               }
             ]
           }
@@ -35,7 +48,7 @@
     "nodes": [
       {
         "commit": {
-          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+          "oid": "bb7f51d3e0fd50997012dfcce3c9b2b852cd3136",
           "statusCheckRollup": {
             "contexts": {
               "pageInfo": {
@@ -53,7 +66,7 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                  "url": "https://github.com/apache/tvm/runs/6377784092"
                 },
                 {
                   "name": "cc-reviewers",
@@ -66,7 +79,20 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945029"
+                  "url": "https://github.com/apache/tvm/runs/6377778488"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6390508806"
                 },
                 {
                   "name": "tag-teams",
@@ -79,7 +105,7 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945030"
+                  "url": "https://github.com/apache/tvm/runs/6390511833"
                 },
                 {
                   "name": "Windows",
@@ -92,12 +118,12 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945524"
+                  "url": "https://github.com/apache/tvm/runs/6377784248"
                 },
                 {
                   "state": "SUCCESS",
                   "context": "tvm-ci/pr-head",
-                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-11267/2/display/redirect"
                 }
               ]
             }
@@ -106,24 +132,11 @@
       }
     ]
   },
-  "reviewDecision": "APPROVED",
+  "reviewDecision": "REVIEW_REQUIRED",
   "reviews": {
     "pageInfo": {
       "hasPreviousPage": false
     },
-    "nodes": [
-      {
-        "body": "",
-        "updatedAt": "2022-03-25T22:13:50Z",
-        "authorCanPushToRepository": true,
-        "commit": {
-          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
-        },
-        "author": {
-          "login": "kparzysz-quic"
-        },
-        "state": "APPROVED"
-      }
-    ]
+    "nodes": []
   }
 }

--- a/tests/python/ci/sample_prs/pr11276-no-review.json
+++ b/tests/python/ci/sample_prs/pr11276-no-review.json
@@ -1,9 +1,9 @@
 {
-  "title": "[Hexagon] 2-d allocation cleanup",
-  "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+  "title": "[COMMUNITY] mikepapadim -> Reviewer",
+  "body": "Please join us to welcome Michalis Papadimitriou (@mikepapadim) as a new reviewer to TVM. Michalis has contributed a lot to BYOC and TensorRT backend.\r\n\r\n- [Commits History](https://github.com/apache/tvm/commits?author=mikepapadim)\r\n- [Code Review](https://github.com/apache/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by:mikepapadim)\r\n- [Community Forum Summary](https://github.com/apache/tvm/commits?author=mikepapadim)",
   "state": "OPEN",
   "author": {
-    "login": "Lunderberg"
+    "login": "ZihengJiang"
   },
   "comments": {
     "pageInfo": {
@@ -18,12 +18,8 @@
           "authors": {
             "nodes": [
               {
-                "name": "Eric Lunderberg",
-                "email": "elunderberg@octoml.ai"
-              },
-              {
-                "name": "Adam Straw",
-                "email": "astraw@octoml.ai"
+                "name": "ZihengJiang",
+                "email": "ziheng@apache.org"
               }
             ]
           }
@@ -35,7 +31,7 @@
     "nodes": [
       {
         "commit": {
-          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+          "oid": "96075744cc687caafc131361d006c5967edddbc6",
           "statusCheckRollup": {
             "contexts": {
               "pageInfo": {
@@ -53,7 +49,7 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                  "url": "https://github.com/apache/tvm/runs/6391733373"
                 },
                 {
                   "name": "cc-reviewers",
@@ -66,7 +62,20 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945029"
+                  "url": "https://github.com/apache/tvm/runs/6391732791"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6391754960"
                 },
                 {
                   "name": "tag-teams",
@@ -79,7 +88,20 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945030"
+                  "url": "https://github.com/apache/tvm/runs/6391732788"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6391754947"
                 },
                 {
                   "name": "Windows",
@@ -92,12 +114,17 @@
                   },
                   "status": "COMPLETED",
                   "conclusion": "SUCCESS",
-                  "url": "https://github.com/apache/tvm/runs/5694945524"
+                  "url": "https://github.com/apache/tvm/runs/6391733127"
+                },
+                {
+                  "state": "SUCCESS",
+                  "context": "tvm-ci/branch",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/ziheng%252Fcommunity/1/display/redirect"
                 },
                 {
                   "state": "SUCCESS",
                   "context": "tvm-ci/pr-head",
-                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-11276/1/display/redirect"
                 }
               ]
             }
@@ -114,13 +141,14 @@
     "nodes": [
       {
         "body": "",
-        "updatedAt": "2022-03-25T22:13:50Z",
+        "updatedAt": "2022-05-11T16:50:16Z",
+        "url": "https://github.com/apache/tvm/pull/11276#pullrequestreview-969701502",
         "authorCanPushToRepository": true,
         "commit": {
-          "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+          "oid": "96075744cc687caafc131361d006c5967edddbc6"
         },
         "author": {
-          "login": "kparzysz-quic"
+          "login": "tqchen"
         },
         "state": "APPROVED"
       }

--- a/tests/python/ci/test_mergebot.py
+++ b/tests/python/ci/test_mergebot.py
@@ -40,36 +40,47 @@ test_data = {
         "number": 10786,
         "filename": "pr10786-merges.json",
         "expected": "Dry run, would have merged with url=pulls/10786/merge",
+        "detail": "Everything is fine so this PR will merge",
     },
     "no-request": {
         "number": 10786,
         "filename": "pr10786-nottriggered.json",
         "expected": "No merge requested, exiting",
+        "detail": "A PR for which the mergebot runs but no merge is requested",
     },
     "bad-ci": {
         "number": 10786,
         "filename": "pr10786-badci.json",
         "expected": "Cannot merge, these CI jobs are not successful on",
+        "detail": "A PR which failed CI and cannot merge",
     },
     "old-review": {
         "number": 10786,
         "filename": "pr10786-oldreview.json",
         "expected": "Cannot merge, did not find any approving reviews",
+        "detail": "A PR with passing CI and approving reviews on an old commit so it cannot merge",
     },
     "missing-job": {
         "number": 10786,
         "filename": "pr10786-missing-job.json",
         "expected": "Cannot merge, missing expected jobs",
+        "detail": "PR missing an expected CI job and cannot merge",
+    },
+    "invalid-author": {
+        "number": 10786,
+        "filename": "pr10786-invalid-author.json",
+        "expected": "No merge requested, exiting",
+        "detail": "Merge requester is not a committer and cannot merge",
     },
 }
 
 
 @pytest.mark.parametrize(
-    ["number", "filename", "expected"],
+    ["number", "filename", "expected", "detail"],
     [tuple(d.values()) for d in test_data.values()],
     ids=test_data.keys(),
 )
-def test_mergebot(tmpdir_factory, number, filename, expected):
+def test_mergebot(tmpdir_factory, number, filename, expected, detail):
     mergebot_script = REPO_ROOT / "tests" / "scripts" / "github_mergebot.py"
     test_json_dir = Path(__file__).resolve().parent / "sample_prs"
 

--- a/tests/python/ci/test_mergebot.py
+++ b/tests/python/ci/test_mergebot.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+import json
+import sys
+import pytest
+
+from pathlib import Path
+
+from test_utils import REPO_ROOT
+
+
+class TempGit:
+    def __init__(self, cwd):
+        self.cwd = cwd
+
+    def run(self, *args):
+        proc = subprocess.run(["git"] + list(args), cwd=self.cwd)
+        if proc.returncode != 0:
+            raise RuntimeError(f"git command failed: '{args}'")
+
+
+def test_mergebot(tmpdir_factory):
+    mergebot_script = REPO_ROOT / "tests" / "scripts" / "github_mergebot.py"
+    test_json_dir = Path(__file__).resolve().parent / "sample_prs"
+
+    def run(number, filename, expected):
+        git = TempGit(tmpdir_factory.mktemp("tmp_git_dir"))
+        git.run("init")
+        git.run("checkout", "-b", "main")
+        git.run("remote", "add", "origin", "https://github.com/apache/tvm.git")
+        with open(test_json_dir / filename) as f:
+            test_data = json.load(f)
+
+        proc = subprocess.run(
+            [
+                str(mergebot_script),
+                "--pr",
+                str(number),
+                "--dry-run",
+                "--run-url",
+                "https://example.com",
+                "--testing-pr-json",
+                json.dumps(test_data),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            cwd=git.cwd,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"Process failed:\nstdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}")
+
+        if expected not in proc.stderr:
+            raise RuntimeError(f"{proc.stderr}\ndid not contain\n{expected}")
+
+    run(
+        number=10786,
+        filename="pr10786-merges.json",
+        expected="Dry run, would have merged with url=pulls/10786/merge",
+    )
+    run(
+        number=10786,
+        filename="pr10786-nottriggered.json",
+        expected="No merge requested, exiting",
+    )
+    run(
+        number=10786,
+        filename="pr10786-badci.json",
+        expected="Cannot merge, these CI jobs failed on",
+    )
+    run(
+        number=10786,
+        filename="pr10786-oldreview.json",
+        expected="Cannot merge, did not find any approving reviews",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/ci/test_mergebot.py
+++ b/tests/python/ci/test_mergebot.py
@@ -72,6 +72,30 @@ test_data = {
         "expected": "No merge requested, exiting",
         "detail": "Merge requester is not a committer and cannot merge",
     },
+    "unauthorized-comment": {
+        "number": 11244,
+        "filename": "pr11244-unauthorized-comment.json",
+        "expected": "No merge requested, exiting",
+        "detail": "Check that a merge comment not from a CONTRIBUTOR is rejected",
+    },
+    "no-review": {
+        "number": 11267,
+        "filename": "pr11267-no-review.json",
+        "expected": "Cannot merge, did not find any approving reviews from users with write access",
+        "detail": "Check that a merge request without any reviews is rejected",
+    },
+    "changes-requested": {
+        "number": 10786,
+        "filename": "pr10786-changes-requested.json",
+        "expected": "Cannot merge, found [this review]",
+        "detail": "Check that a merge request with a 'Changes Requested' review on HEAD is rejected",
+    },
+    "co-authors": {
+        "number": 10786,
+        "filename": "pr10786-co-authors.json",
+        "expected": "Co-authored-by: Some One <someone@email.com>",
+        "detail": "Check that a merge request with co-authors generates the correct commit message",
+    },
 }
 
 

--- a/tests/python/ci/test_mergebot.py
+++ b/tests/python/ci/test_mergebot.py
@@ -35,60 +35,72 @@ class TempGit:
             raise RuntimeError(f"git command failed: '{args}'")
 
 
-def test_mergebot(tmpdir_factory):
+test_data = {
+    "successful-merge": {
+        "number": 10786,
+        "filename": "pr10786-merges.json",
+        "expected": "Dry run, would have merged with url=pulls/10786/merge",
+    },
+    "no-request": {
+        "number": 10786,
+        "filename": "pr10786-nottriggered.json",
+        "expected": "No merge requested, exiting",
+    },
+    "bad-ci": {
+        "number": 10786,
+        "filename": "pr10786-badci.json",
+        "expected": "Cannot merge, these CI jobs are not successful on",
+    },
+    "old-review": {
+        "number": 10786,
+        "filename": "pr10786-oldreview.json",
+        "expected": "Cannot merge, did not find any approving reviews",
+    },
+    "missing-job": {
+        "number": 10786,
+        "filename": "pr10786-missing-job.json",
+        "expected": "Cannot merge, missing expected jobs",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ["number", "filename", "expected"],
+    [tuple(d.values()) for d in test_data.values()],
+    ids=test_data.keys(),
+)
+def test_mergebot(tmpdir_factory, number, filename, expected):
     mergebot_script = REPO_ROOT / "tests" / "scripts" / "github_mergebot.py"
     test_json_dir = Path(__file__).resolve().parent / "sample_prs"
 
-    def run(number, filename, expected):
-        git = TempGit(tmpdir_factory.mktemp("tmp_git_dir"))
-        git.run("init")
-        git.run("checkout", "-b", "main")
-        git.run("remote", "add", "origin", "https://github.com/apache/tvm.git")
-        with open(test_json_dir / filename) as f:
-            test_data = json.load(f)
+    git = TempGit(tmpdir_factory.mktemp("tmp_git_dir"))
+    git.run("init")
+    git.run("checkout", "-b", "main")
+    git.run("remote", "add", "origin", "https://github.com/apache/tvm.git")
+    with open(test_json_dir / filename) as f:
+        test_data = json.load(f)
 
-        proc = subprocess.run(
-            [
-                str(mergebot_script),
-                "--pr",
-                str(number),
-                "--dry-run",
-                "--run-url",
-                "https://example.com",
-                "--testing-pr-json",
-                json.dumps(test_data),
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-            cwd=git.cwd,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(f"Process failed:\nstdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}")
+    proc = subprocess.run(
+        [
+            str(mergebot_script),
+            "--pr",
+            str(number),
+            "--dry-run",
+            "--run-url",
+            "https://example.com",
+            "--testing-pr-json",
+            json.dumps(test_data),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        cwd=git.cwd,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"Process failed:\nstdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}")
 
-        if expected not in proc.stderr:
-            raise RuntimeError(f"{proc.stderr}\ndid not contain\n{expected}")
-
-    run(
-        number=10786,
-        filename="pr10786-merges.json",
-        expected="Dry run, would have merged with url=pulls/10786/merge",
-    )
-    run(
-        number=10786,
-        filename="pr10786-nottriggered.json",
-        expected="No merge requested, exiting",
-    )
-    run(
-        number=10786,
-        filename="pr10786-badci.json",
-        expected="Cannot merge, these CI jobs failed on",
-    )
-    run(
-        number=10786,
-        filename="pr10786-oldreview.json",
-        expected="Cannot merge, did not find any approving reviews",
-    )
+    if expected not in proc.stderr:
+        raise RuntimeError(f"{proc.stderr}\ndid not contain\n{expected}")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -45,17 +45,19 @@ class GitHubRepo:
         query = compress_query(query)
         if variables is None:
             variables = {}
-        response = self._post(
-            "https://api.github.com/graphql", {"query": query, "variables": variables}
+        response = self._request(
+            "https://api.github.com/graphql",
+            {"query": query, "variables": variables},
+            method="POST",
         )
         if "data" not in response:
             msg = f"Error fetching data with query:\n{query}\n\nvariables:\n{variables}\n\nerror:\n{json.dumps(response, indent=2)}"
             raise RuntimeError(msg)
         return response
 
-    def _post(self, full_url: str, body: Dict[str, Any]) -> Dict[str, Any]:
-        print("Requesting POST to", full_url, "with", body)
-        req = request.Request(full_url, headers=self.headers(), method="POST")
+    def _request(self, full_url: str, body: Dict[str, Any], method: str) -> Dict[str, Any]:
+        print(f"Requesting {method} to", full_url, "with", body)
+        req = request.Request(full_url, headers=self.headers(), method=method.upper())
         req.add_header("Content-Type", "application/json; charset=utf-8")
         data = json.dumps(body)
         data = data.encode("utf-8")
@@ -65,8 +67,11 @@ class GitHubRepo:
             response = json.loads(response.read())
         return response
 
+    def put(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        return self._request(self.base + url, data, method="PUT")
+
     def post(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:
-        return self._post(self.base + url, data)
+        return self._request(self.base + url, data, method="POST")
 
     def get(self, url: str) -> Dict[str, Any]:
         url = self.base + url

--- a/tests/scripts/github_mergebot.py
+++ b/tests/scripts/github_mergebot.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import json
+import argparse
+import warnings
+import logging
+import traceback
+from typing import Dict, Any, List, Optional
+from pathlib import Path
+
+from git_utils import git, GitHubRepo, parse_remote
+from cmd_utils import init_log
+
+
+Review = Dict[str, Any]
+CIJob = Dict[str, Any]
+
+
+def js(obj: Any) -> str:
+    return json.dumps(obj, indent=2)
+
+
+PR_QUERY = """
+    query ($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          title
+          body
+          state
+          comments(last: 100) {
+            pageInfo {
+              hasPreviousPage
+            }
+            nodes {
+              author {
+                login
+              }
+              updatedAt
+              body
+            }
+          }
+          authorCommits:commits(last:100) {
+            nodes {
+              commit {
+                authors(first:100) {
+                  nodes {
+                    name
+                    email
+                  }
+                }
+              }
+            }
+          }
+          commits(last: 1) {
+            nodes {
+              commit {
+                oid
+                statusCheckRollup {
+                  contexts(first: 100) {
+                    pageInfo {
+                      hasNextPage
+                    }
+                    nodes {
+                      ... on CheckRun {
+                        name
+                        checkSuite {
+                          workflowRun {
+                            workflow {
+                              name
+                            }
+                          }
+                        }
+                        status
+                        conclusion
+                        url
+                      }
+                      ... on StatusContext {
+                        state
+                        context
+                        targetUrl
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          reviewDecision
+          reviews(last: 100) {
+            pageInfo {
+              hasPreviousPage
+            }
+            nodes {
+              body
+              updatedAt
+              authorCanPushToRepository
+              commit {
+                oid
+              }
+              state
+            }
+          }
+        }
+      }
+    }
+    """
+
+
+def walk(obj, visitor, parent_key=None):
+    """
+    Recursively call 'visitor' on all the children of a dictionary
+    """
+    visitor(obj, parent_key)
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            walk(v, visitor, parent_key=k)
+    elif isinstance(obj, list):
+        for v in obj:
+            walk(v, visitor)
+
+
+class PR:
+    def __init__(
+        self,
+        number: int,
+        owner: str,
+        repo: str,
+        dry_run: bool = False,
+        raw_data: Dict[str, Any] = None,
+    ):
+        self.owner = owner
+        self.number = number
+        self.repo_name = repo
+        self.dry_run = dry_run
+
+        self.github = GitHubRepo(user=owner, repo=repo, token=os.environ["GITHUB_TOKEN"])
+
+        if dry_run and raw_data:
+            # In test mode there is no need to fetch anything
+            self.raw = raw_data
+        else:
+            if os.getenv("DEBUG", "0") == "1":
+                # For local runs fill in the requested data but cache it for
+                # later use
+                cached_path = Path("pr.json")
+                if not cached_path.exists():
+                    self.raw = self.fetch_data()
+                    with open(cached_path, "w") as f:
+                        json.dump(self.raw, f, indent=2)
+                else:
+                    with open(cached_path) as f:
+                        self.raw = json.load(f)
+            else:
+                # Usual path, fetch the PR's data based on the number from
+                # GitHub
+                self.raw = self.fetch_data()
+
+        def checker(obj, parent_key):
+            """
+            Verify that any paged results don't have extra data (if so the bot
+            may still work since most relevant comments will be more recent)
+            """
+            if parent_key == "pageInfo":
+                if obj.get("hasPreviousPage", False):
+                    warnings.warn(f"Found {obj} with a previous page, bot may be missing data")
+                if obj.get("hasNextPage", False):
+                    warnings.warn(f"Found {obj} with a next page, bot may be missing data")
+
+        walk(self.raw, checker)
+
+        logging.info(f"Verified data, running with PR {js(self.raw)}")
+
+    def __repr__(self):
+        return json.dumps(self.raw, indent=2)
+
+    def head_commit(self):
+        return self.raw["commits"]["nodes"][0]["commit"]
+
+    def co_authors(self) -> List[str]:
+        authors = []
+        for commit in self.raw["authorCommits"]["nodes"]:
+            # Co-authors always come after the main author according to the
+            # GitHub docs, so ignore the first item
+            for author in commit["commit"]["authors"]["nodes"][1:]:
+                name = author["name"]
+                email = author["email"]
+                authors.append(f"{name} <{email}>")
+
+        return list(set(authors))
+
+    def head_oid(self):
+        return self.head_commit()["oid"]
+
+    def ci_jobs(self) -> List[CIJob]:
+        """
+        Get a list of all CI jobs (GitHub Actions and other) in a unified format
+        """
+        jobs = []
+        for item in self.head_commit()["statusCheckRollup"]["contexts"]["nodes"]:
+            if "checkSuite" in item:
+                # GitHub Actions job, parse separately
+                status = item["conclusion"]
+                if status is None:
+                    # If the 'conclusion' isn't filled out the job hasn't
+                    # finished yet
+                    status = "PENDING"
+                jobs.append(
+                    {
+                        "name": item["checkSuite"]["workflowRun"]["workflow"]["name"]
+                        + " / "
+                        + item["name"],
+                        "url": item["url"],
+                        "status": status.upper(),
+                    }
+                )
+            else:
+                # GitHub Status (e.g. from Jenkins)
+                jobs.append(
+                    {
+                        "name": item["context"],
+                        "url": item["targetUrl"],
+                        "status": item["state"].upper(),
+                    }
+                )
+
+        logging.info(f"Found CI jobs for {self.head_commit()['oid']} {js(jobs)}")
+        return jobs
+
+    def reviews(self) -> List[Review]:
+        return self.raw["reviews"]["nodes"]
+
+    def head_commit_reviews(self) -> List[Review]:
+        """
+        Find reviews associated with the head commit
+        """
+        commits_to_review_status: Dict[str, List[Review]] = {}
+
+        for review in self.reviews():
+            if not review["authorCanPushToRepository"]:
+                # ignore reviews from non-committers
+                continue
+
+            oid = review["commit"]["oid"]
+            if oid in commits_to_review_status:
+                commits_to_review_status[oid].append(review)
+            else:
+                commits_to_review_status[oid] = [review]
+
+        # Only use the data for the head commit of the PR
+        head_reviews = commits_to_review_status.get(self.head_oid(), [])
+        return head_reviews
+
+    def fetch_data(self):
+        """
+        Fetch the data for this PR from GitHub
+        """
+        return self.github.graphql(
+            query=PR_QUERY,
+            variables={
+                "owner": self.owner,
+                "name": self.repo_name,
+                "number": self.number,
+            },
+        )["data"]["repository"]["pullRequest"]
+
+    def comment(self, text: str) -> None:
+        """
+        Leave the comment 'text' on this PR
+        """
+        logging.info(f"Commenting:\n{text}")
+        # TODO: Update latest comment in-place if there has been no activity
+        data = {"body": text}
+        url = f"issues/{self.number}/comments"
+        if self.dry_run:
+            logging.info(
+                f"Dry run, would have commented on url={url} commenting with data={js(data)}"
+            )
+            return
+
+        self.github.post(url, data=data)
+
+    def state(self) -> str:
+        """
+        PR state (OPEN, CLOSED, MERGED, etc)
+        """
+        return self.raw["state"]
+
+    def lint_commit_message(self, subject: str, body: str) -> bool:
+        # TODO: NYI (Add rules as decided in https://discuss.tvm.apache.org/t/commit-message-guideline/12334)
+        return True
+
+    def processed_body(self) -> str:
+        body = self.raw["body"].strip().replace("\r", "")
+        body = body.replace(
+            "Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.",
+            "",
+        )
+        return body
+
+    def body_with_co_authors(self) -> str:
+        """
+        Add 'Co-authored-by' strings to the PR body based on the prior commits
+        in the PR
+        """
+        body = self.processed_body()
+        author_lines = self.co_authors()
+        logging.info(f"Found co-authors: author_lines={author_lines}")
+        for author_line in author_lines:
+            if author_line not in body:
+                # If the line isn't already in the PR body (it could have been
+                # added manually), put it in
+                body = f"{body}\n\nCo-authored-by: {author_line}"
+
+        return body
+
+    def merge(self) -> None:
+        """
+        Request a merge of this PR via the GitHub API
+        """
+        url = f"pulls/{self.number}/merge"
+
+        title = self.raw["title"]
+        body = self.body_with_co_authors()
+        self.lint_commit_message(title, body)
+        logging.info(f"Full commit:\n{title}\n\n{body}")
+
+        data = {
+            "commit_title": title,
+            "commit_message": body,
+            # The SHA is necessary in case there was an update right when this
+            # script ran, GitHub will sort out who won
+            "sha": self.head_oid(),
+            "merge_method": "squash",
+        }
+        if self.dry_run:
+            logging.info(f"Dry run, would have merged with url={url} and data={js(data)}")
+            return
+
+        self.github.put(url, data=data)
+
+    def merge_requested(self) -> bool:
+        """
+        Check if this PR has had a merge requested
+        """
+        merge_commands = [
+            "merge",
+            "merge this",
+            "merge this pr",
+        ]
+        cancel_commands = [
+            "cancel",
+            "cancel merge",
+            "cancel the merge",
+            "stop",
+            "stop merge",
+            "stop the merge",
+        ]
+
+        def parse_action(s: str) -> Optional[str]:
+            if any(f"@tvm-bot {c}" in s for c in merge_commands):
+                return "merge"
+
+            if any(f"@tvm-bot {c}" in s for c in cancel_commands):
+                return "cancel"
+
+            return None
+
+        # Check regular comments
+        all_comments = []
+        for comment in self.raw["comments"]["nodes"]:
+            all_comments.append((comment["updatedAt"], comment["body"]))
+
+        # Check top-level review comments
+        for review in self.reviews():
+            all_comments.append((review["updatedAt"], review["body"]))
+
+        all_comments = sorted(all_comments, key=lambda x: x[0])
+        actions = [parse_action(body) for _, body in all_comments]
+        logging.info(f"Found these tvm-bot actions: {actions}")
+        actions = [a for a in actions if a is not None]
+
+        if len(actions) == 0:
+            return False
+
+        return actions[-1] == "merge"
+
+    def merge_if_passed_checks(self):
+        # NEUTRAL is GitHub Action's way of saying cancelled
+        failed_ci_jobs = [
+            job
+            for job in self.ci_jobs()
+            if job["status"] not in {"SUCCESS", "SUCCESSFUL", "NEUTRAL", "SKIPPED"}
+        ]
+        all_ci_passed = False
+        has_one_approval = False
+        if len(failed_ci_jobs) > 0:
+            failed_jobs_msg = "\n".join(
+                [f" * [{job['name']} (`{job['status']}`)]({job['url']})" for job in failed_ci_jobs]
+            )
+            self.comment(
+                f"Cannot merge, these CI jobs are not successful on {self.head_oid()}:\n{failed_jobs_msg}"
+            )
+            return
+        else:
+            all_ci_passed = True
+
+        head_commit_reviews = self.head_commit_reviews()
+        for review in head_commit_reviews:
+            if review["state"] == "CHANGES_REQUESTED":
+                self.comment(
+                    f"Cannot merge, found [this review]({review['url']}) on {self.head_oid()} with changes requested"
+                )
+                return
+
+            if review["state"] == "APPROVED":
+                has_one_approval = True
+                logging.info(f"Found approving review: {js(review)}")
+
+        if has_one_approval and all_ci_passed:
+            self.merge()
+        elif not has_one_approval:
+            self.comment(
+                f"Cannot merge, did not find any approving reviews from users with write access on {self.head_oid()}"
+            )
+            return
+        elif not all_ci_passed:
+            self.comment(f"Cannot merge, CI did not pass on on {self.head_oid()}")
+            return
+
+
+if __name__ == "__main__":
+    help = "Automatically tag people based on PR / issue labels"
+    parser = argparse.ArgumentParser(description=help)
+    parser.add_argument("--remote", default="origin", help="ssh remote to parse")
+    parser.add_argument("--pr", required=True, help="pr number to check")
+    parser.add_argument("--run-url", required=True, help="workflow run URL")
+    parser.add_argument("--testing-pr-json", help="(testing only) manual data for testing")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="run but don't send any request to GitHub",
+    )
+    args = parser.parse_args()
+    init_log()
+
+    remote = git(["config", "--get", f"remote.{args.remote}.url"])
+    logging.info(f"Using remote remote={remote}")
+    owner, repo = parse_remote(remote)
+
+    if args.pr.strip() == "":
+        logging.info("No PR number passed")
+        exit(0)
+
+    logging.info(f"Checking owner={owner} repo={repo}")
+    if args.testing_pr_json:
+        pr = PR(
+            number=int(args.pr),
+            owner=owner,
+            repo=repo,
+            dry_run=args.dry_run,
+            raw_data=json.loads(args.testing_pr_json),
+        )
+    else:
+        pr = PR(number=int(args.pr), owner=owner, repo=repo, dry_run=args.dry_run)
+
+    state = pr.state()
+
+    if state != "OPEN":
+        logging.info(f"Ignoring event on PR, state was not OPEN, instead was state={state}")
+        exit(0)
+
+    if pr.merge_requested():
+        try:
+            pr.merge_if_passed_checks()
+        except Exception as e:
+            if not args.dry_run:
+                msg = traceback.format_exc()
+                pr.comment(
+                    f"Failed to process merge request in {args.run_url}\n\n<details>\n\n```\n{msg}\n```\n\n</details>"
+                )
+            raise e
+    else:
+        logging.info("No merge requested, exiting")


### PR DESCRIPTION
This implements https://discuss.tvm.apache.org/t/rfc-allow-merging-via-pr-comments/12220. The bot can be invoked from a top-level review comment or via a regular PR comment. The text `@tvm-bot merge` anywhere in the body will trigger the bot. Right now it checks that the latest commit is reviewed and that all CI jobs that have run on that commit are successful. If it fails, it will leave a comment on the PR with the reason.

This is just a start and some features are left for followups:
* Various TODOs throughout the code
* "Scheduled" merges that happen once CI finishes
* Allowing committers to merge without getting a fresh review for changes after an approval

Test PRs
Description | Link
------ | -----
ci passed: no, then yes<br>approved: no, then yes  | https://github.com/driazati/tvm/pull/13
ci passed: yes<br>approved: yes, then PR is updated, then re-approved  | https://github.com/driazati/tvm/pull/17
commit with a message | https://github.com/driazati/tvm/pull/16
cancelled merge | https://github.com/driazati/tvm/pull/18

cc @areusch @Mousius @gromero @kparzysz-quic 