### PR TITLE
[BYOC-DNNL] Enhance GetRootCall function

### DIFF
--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -449,11 +449,12 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
   }
 
   ICHECK_GT(current_call->args.size(), 0);
-  int i = 0;
-  while (i < current_call->args.size() && current_call->args[i].as<VarNode>()) {
-      i++;
+  int valid_node_idx = 0;
+  while (valid_node_idx < current_call->args.size() &&
+         current_call->args[valid_node_idx].as<VarNode>()) {
+    valid_node_idx++;
   }
-  const auto* next_call = current_call->args[i].as<CallNode>();
+  const auto* next_call = current_call->args[valid_node_idx].as<CallNode>();
   return GetRootCall(next_call, depth - 1, expected_op_names);
 }
 

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -449,7 +449,7 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
   }
 
   ICHECK_GT(current_call->args.size(), 0);
-  int valid_node_idx = 0;
+  size_t valid_node_idx = 0;
   while (valid_node_idx < current_call->args.size() &&
          current_call->args[valid_node_idx].as<VarNode>()) {
     valid_node_idx++;

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -449,8 +449,11 @@ inline const CallNode* GetRootCall(const CallNode* current_call, int depth,
   }
 
   ICHECK_GT(current_call->args.size(), 0);
-
-  const auto* next_call = current_call->args[0].as<CallNode>();
+  int i = 0;
+  while (i < current_call->args.size() && current_call->args[i].as<VarNode>()) {
+      i++;
+  }
+  const auto* next_call = current_call->args[i].as<CallNode>();
   return GetRootCall(next_call, depth - 1, expected_op_names);
 }
 

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -399,6 +399,13 @@ def get_conv2d_bias_bn_relu(x_shape=(1, 32, 8, 8), k_shape=(16, 32, 3, 3), dtype
     return relay.nn.relu(conv2d_bias_bn), dic, param_lst
 
 
+def get_conv2d_bias_sum_relu(x_shape=(1, 32, 8, 8), k_shape=(16, 32, 3, 3), dtype="float32"):
+    conv2d_bias, dic, param_lst = get_conv2d_bias(x_shape, k_shape, dtype=dtype)
+    sum_data = relay.const(np.random.randint(x_shape).astype(dtype))
+    conv2d_bias_sum = relay.add(sum_data, conv2d_bias)
+    return relay.nn.relu(conv2d_bias_sum), dic, param_lst
+
+
 def get_conv3d(
     x_shape=(1, 32, 8, 8, 8),
     k_shape=(16, 32, 3, 3, 3),
@@ -695,6 +702,11 @@ def test_conv2d_pattern(run_module, dtype="float32"):
         conv2d_bias = tvm.IRModule.from_expr(conv2d_bias)
         config = conv2d_bias, dic, param_lst
         run_and_verify_func(config, run_module=run_module, dtype=dtype)
+
+    conv2d_bias_bn_relu, dic, param_lst = get_conv2d_bias_bn_relu(x_shape, k_shape, dtype=dtype)
+    conv2d_bias_bn_relu = tvm.IRModule.from_expr(conv2d_bias_bn_relu)
+    config = conv2d_bias_bn_relu, dic, param_lst
+    run_and_verify_func(config, run_module=run_module, dtype=dtype)
 
     conv2d_bias_bn_relu, dic, param_lst = get_conv2d_bias_bn_relu(x_shape, k_shape, dtype=dtype)
     conv2d_bias_bn_relu = tvm.IRModule.from_expr(conv2d_bias_bn_relu)


### PR DESCRIPTION
This PR aims to enhance the `GetRootCall` function to support various topology.

The original `GetRootCall` only supports dnnl_pattern like `add(add(conv(data, weight), bias), sum_data)`.
But we encountered `add(sum_data, add(conv(data, weight), bias))` in `ResNetV2`, which cannot be supported by the original design.
Enhance this function can simply solve this issue.