### PR TITLE
[CI][Docker] Update scripts for Hexagon CI image with 20.04

### DIFF
--- a/docker/install/ubuntu2004_install_python.sh
+++ b/docker/install/ubuntu2004_install_python.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+
+cleanup() {
+  rm -rf base-requirements.txt
+}
+
+trap cleanup 0
+
+# Install python and pip. Don't modify this to add Python package dependencies,
+# instead modify install_python_package.sh
+apt-get update
+apt-get install -y software-properties-common
+apt-get install -y python3.8 python3.8-dev python3-pip
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+
+# Pin pip and setuptools versions
+# Hashes generated via:
+#   $ pip download <package>==<version>
+#   $ pip hash --algorithm sha512 <package>.whl
+cat <<EOF > base-requirements.txt
+pip==19.3.1 --hash=sha256:6917c65fc3769ecdc61405d3dfd97afdedd75808d200b2838d7d961cebc0c2c7
+setuptools==58.4.0 --hash=sha256:e8b1d3127a0441fb99a130bcc3c2bf256c2d3ead3aba8fd400e5cbbaf788e036
+EOF
+pip3 install -r base-requirements.txt

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -24,9 +24,18 @@ set -o pipefail
 apt-get update && apt-get install -y --no-install-recommends \
         git make google-mock libgtest-dev cmake wget unzip libtinfo-dev libz-dev \
         libcurl4-openssl-dev libssl-dev libopenblas-dev g++ sudo \
-        apt-transport-https graphviz pkg-config curl ninja-build parallel
+        apt-transport-https graphviz pkg-config curl ninja-build parallel \
+        lsb-core
 
-if [[ -d /usr/src/googletest ]]; then
+# Get Ubuntu version
+release=$(lsb_release -r)
+version_number=$(cut -f2 <<< "$release")
+
+if [ "$version_number" == "20.04" ]; then
+  # Single package source (Ubuntu 20.04)
+  # googletest is installed via libgtest-dev
+  cd /usr/src/googletest && cmake CMakeLists.txt && make && cp -v lib/*.a /usr/lib
+elif [ "$version_number" == "18.04" ]; then
   # Single package source (Ubuntu 18.04)
   # googletest is installed via libgtest-dev
   cd /usr/src/googletest && cmake CMakeLists.txt && make && cp -v {googlemock,googlemock/gtest}/*.a /usr/lib


### PR DESCRIPTION
This PR makes required adjustments to update Hexagon CI image to ubuntu 20.04. The base image is built by Ubuntu 20.04


cc @areusch @driazati