### PR TITLE
[Pass] Fix printer formatting for PassInfo

### DIFF
--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -454,15 +454,19 @@ TVM_REGISTER_GLOBAL("transform.Info").set_body([](TVMArgs args, TVMRetValue* ret
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<PassInfoNode>([](const ObjectRef& ref, tvm::ReprPrinter* p) {
       auto* node = static_cast<const PassInfoNode*>(ref.get());
-      p->stream << "The meta data of the pass: ";
+      p->stream << "The meta data of the pass - ";
       p->stream << "pass name: " << node->name;
-      p->stream << "opt_level: " << node->opt_level;
-      p->stream << "required passes: ["
-                << "\n";
-      for (const auto& it : node->required) {
-        p->stream << it << ", ";
+      p->stream << ", opt_level: " << node->opt_level;
+      if (node->required.empty()) {
+        p->stream << ", required passes: []\n";
+      } else {
+        p->stream << ", required passes: ["
+                  << "\n";
+        for (const auto& it : node->required) {
+          p->stream << it << ", ";
+        }
+        p->stream << "]\n";
       }
-      p->stream << "]\n";
     });
 
 TVM_REGISTER_NODE_TYPE(ModulePassNode);


### PR DESCRIPTION
The format of the printed PassInfoNode was difficult to read as there
was no separation between the different attributes of the node

Before this change, PassInfo is printed as:
```
The meta data of the pass: pass name: tir.ApplyLayoutTransformsopt_level: 0required passes: [
]
```

After this change, PassInfo is printed as:
```
The meta data of the pass - pass name: tir.ApplyLayoutTransforms, opt_level: 0, required passes: []
```
