### PR TITLE
[TIR] Fix check for multiple axis separators

### DIFF
--- a/src/tir/ir/buffer.cc
+++ b/src/tir/ir/buffer.cc
@@ -338,7 +338,7 @@ Buffer Buffer::GetFlattenedBuffer() const {
   // input axis.
   for (size_t i = 0; (i + 1) < self->axis_separators.size(); i++) {
     auto sep = self->axis_separators[i]->value;
-    auto next_sep = self->axis_separators[i]->value;
+    auto next_sep = self->axis_separators[i + 1]->value;
     ICHECK_LT(sep, next_sep) << "Axis separators must be in strictly increasing order.";
   }
   if (self->axis_separators.size()) {

--- a/tests/python/unittest/test_transform_layout.py
+++ b/tests/python/unittest/test_transform_layout.py
@@ -225,11 +225,13 @@ class Test2DPhysicalLayout:
         "1d_A",
         "2d_A",
         "2d_rev_A",
+        "3d_A",
     )
     transform_B = tvm.testing.parameter(
         "1d_B",
         "2d_B",
         "2d_rev_B",
+        "3d_B",
     )
 
     @staticmethod
@@ -254,6 +256,8 @@ class Test2DPhysicalLayout:
             return lambda i, j, k: [i, j, te.AXIS_SEPARATOR, k]
         elif name == "2d_rev":
             return lambda i, j, k: [k, j, te.AXIS_SEPARATOR, i]
+        elif name == "3d":
+            return lambda i, j, k: [i, te.AXIS_SEPARATOR, j, te.AXIS_SEPARATOR, k]
         else:
             raise ValueError(f"Unknown transformation: {name}")
 
@@ -268,6 +272,8 @@ class Test2DPhysicalLayout:
             return [i * logical_shape[1] + j, k]
         elif name == "2d_rev":
             return [k * logical_shape[1] + j, i]
+        elif name == "3d":
+            return [i, j, k]
         else:
             raise ValueError(f"Unknown transformation: {name}")
 


### PR DESCRIPTION
This patch ensures that different axis separators are compared when checking for validity of multiple output axis. It also updates the unit test to include a 3d test case.