### PR TITLE
[Hexagon] Support both 1-d and 2-d VTCM allocations

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_buffer.h
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.h
@@ -94,11 +94,24 @@ class HexagonBuffer {
   //! \brief Prevent move assignment.
   HexagonBuffer& operator=(HexagonBuffer&&) = delete;
 
-  //! \brief Return pointer to allocations.
-  void** GetPointer();
+  /*! \brief Return data pointer
+   *
+   * The return type depends on the buffer being
+   */
+  void* GetPointer();
 
-  //! \brief Return number of allocations.
-  size_t GetNumAllocs() { return nallocs_; }
+  // //! \brief Return number of allocations.
+  // size_t GetNumAllocs() { return nallocs_; }
+
+  /*! \brief Return dimensionality of buffer
+   *
+   * Will always be either 1 or 2.  If the buffer is 1-d, allocation
+   * returns a pointer to data, which is accessed by
+   * ((value_type*)ptr)[i].  If the buffer is 2-d, allocation returns
+   * a pointer to an array of pointers, which is accessed by
+   * ((value_type**)ptr)[i][j].
+   */
+  size_t GetBufferDimension() { return ndim_; }
 
   //! \brief Memory scopes managed by a Hexagon Buffer.
   enum class StorageScope {
@@ -138,6 +151,9 @@ class HexagonBuffer {
   void CopyFrom(const HexagonBuffer& other, size_t nbytes);
 
  private:
+  //! \brief Return the total number of bytes in this buffer
+  size_t TotalBytes() const { return nbytes_per_allocation_ * allocations_.size(); }
+
   //! \brief Assign a storage scope to the buffer.
   void SetStorageScope(Optional<String> scope);
   /*! \brief Array of raw pointer allocations required by the buffer.
@@ -153,8 +169,8 @@ class HexagonBuffer {
   /*! \brief The underlying storage type in which the allocation
    *  resides.
    */
-  size_t nallocs_;
-  size_t nbytes_;
+  size_t ndim_;
+  size_t nbytes_per_allocation_;
   StorageScope storage_scope_;
 };
 

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.h
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.h
@@ -97,6 +97,9 @@ class HexagonBuffer {
   //! \brief Return pointer to allocations.
   void** GetPointer();
 
+  //! \brief Return number of allocations.
+  size_t GetNumAllocs() { return nallocs_; }
+
   //! \brief Memory scopes managed by a Hexagon Buffer.
   enum class StorageScope {
     //! \brief System DDR corresponding to global storage.

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.h
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.h
@@ -100,19 +100,6 @@ class HexagonBuffer {
    */
   void* GetPointer();
 
-  // //! \brief Return number of allocations.
-  // size_t GetNumAllocs() { return nallocs_; }
-
-  /*! \brief Return dimensionality of buffer
-   *
-   * Will always be either 1 or 2.  If the buffer is 1-d, allocation
-   * returns a pointer to data, which is accessed by
-   * ((value_type*)ptr)[i].  If the buffer is 2-d, allocation returns
-   * a pointer to an array of pointers, which is accessed by
-   * ((value_type**)ptr)[i][j].
-   */
-  size_t GetBufferDimension() { return ndim_; }
-
   //! \brief Memory scopes managed by a Hexagon Buffer.
   enum class StorageScope {
     //! \brief System DDR corresponding to global storage.

--- a/src/runtime/hexagon/hexagon/hexagon_common.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_common.cc
@@ -95,9 +95,9 @@ PackedFunc WrapPackedFunc(TVMBackendPackedCFunc faddr, const ObjectPtr<Object>& 
       if (args.type_codes[i] == kTVMDLTensorHandle) {
         DLTensor* tensor = static_cast<DLTensor*>(arg_values[i].v_handle);
         buffer_args.emplace_back(i, static_cast<HexagonBuffer*>(tensor->data));
-        // Assumes a single contiguous allocation
-        // TODO(Straw): Enable discontiguous allocation
-        tensor->data = buffer_args.back().second->GetPointer()[0];
+        HexagonBuffer* hexbuf = buffer_args.back().second;
+        CHECK_EQ(hexbuf->GetNumAllocs(), 1);
+        tensor->data = hexbuf->GetPointer()[0];
       }
     }
     int ret = (*faddr)(const_cast<TVMValue*>(args.values), const_cast<int*>(args.type_codes),

--- a/src/runtime/hexagon/hexagon/hexagon_common.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_common.cc
@@ -96,8 +96,7 @@ PackedFunc WrapPackedFunc(TVMBackendPackedCFunc faddr, const ObjectPtr<Object>& 
         DLTensor* tensor = static_cast<DLTensor*>(arg_values[i].v_handle);
         buffer_args.emplace_back(i, static_cast<HexagonBuffer*>(tensor->data));
         HexagonBuffer* hexbuf = buffer_args.back().second;
-        CHECK_EQ(hexbuf->GetNumAllocs(), 1);
-        tensor->data = hexbuf->GetPointer()[0];
+        tensor->data = hexbuf->GetPointer();
       }
     }
     int ret = (*faddr)(const_cast<TVMValue*>(args.values), const_cast<int*>(args.type_codes),

--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.cc
@@ -59,6 +59,10 @@ void HexagonDeviceAPIv2::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* r
 // DataSpace: static allocations for Hexagon
 void* HexagonDeviceAPIv2::AllocDataSpace(Device dev, int ndim, const int64_t* shape,
                                          DLDataType dtype, Optional<String> mem_scope) {
+  if (!mem_scope.defined() || mem_scope.value() == "global") {
+    return DeviceAPI::AllocDataSpace(dev, ndim, shape, dtype, mem_scope);
+  }
+
   CHECK(TVMDeviceExtType(dev.device_type) == kDLHexagon) << "dev.device_type: " << dev.device_type;
 
   size_t typesize = (dtype.bits / 8) * dtype.lanes;

--- a/src/runtime/hexagon/hexagon/hexagon_device_api_v2.h
+++ b/src/runtime/hexagon/hexagon/hexagon_device_api_v2.h
@@ -75,6 +75,15 @@ class HexagonDeviceAPIv2 final : public DeviceAPI {
 
   /*!
    * \brief Allocate an Nd data space on device with memory scope support.
+   *
+   * If mem_scope is undefined or is "global", treat shape as the
+   * tensor shape, to be flattened into an allocation of 1-d physical
+   * memory.  This is done to maintain the semantics expected by callers of
+   * DeviceAPI::AllocDataSpace, in cases where it has a valid return value.
+   *
+   * For other values of mem_scope, the shape is the N-d physical
+   * shape of the allocation.
+   *
    * \param dev The device to perform the operation.
    * \param ndim The number of dimensions of allocated tensor.
    * \param shape The shape of allocated tensor.

--- a/tests/cpp/runtime/hexagon_buffer.cc
+++ b/tests/cpp/runtime/hexagon_buffer.cc
@@ -54,7 +54,7 @@ TEST(HexagonBuffer, copy_from) {
   std::vector<uint8_t> data{0, 1, 2, 3, 4, 5, 6, 7};
   hb.CopyFrom(data.data(), data.size());
 
-  uint8_t* ptr = static_cast<uint8_t*>(hb.GetPointer()[0]);
+  uint8_t* ptr = static_cast<uint8_t*>(hb.GetPointer());
   for (size_t i = 0; i < data.size(); ++i) {
     EXPECT_EQ(ptr[i], data[i]);
   }
@@ -103,17 +103,15 @@ TEST(HexagonBuffer, nd_copy_from) {
   std::vector<uint8_t> data{0, 1, 2, 3, 4, 5, 6, 7};
   hb.CopyFrom(data.data(), data.size());
 
-  uint8_t* ptr = static_cast<uint8_t*>(hb.GetPointer()[0]);
-  EXPECT_EQ(ptr[0], data[0]);
-  EXPECT_EQ(ptr[1], data[1]);
-  EXPECT_EQ(ptr[2], data[2]);
-  EXPECT_EQ(ptr[3], data[3]);
-
-  ptr = static_cast<uint8_t*>(hb.GetPointer()[1]);
-  EXPECT_EQ(ptr[0], data[4]);
-  EXPECT_EQ(ptr[1], data[5]);
-  EXPECT_EQ(ptr[2], data[6]);
-  EXPECT_EQ(ptr[3], data[7]);
+  uint8_t** ptr = static_cast<uint8_t**>(hb.GetPointer());
+  EXPECT_EQ(ptr[0][0], data[0]);
+  EXPECT_EQ(ptr[0][1], data[1]);
+  EXPECT_EQ(ptr[0][2], data[2]);
+  EXPECT_EQ(ptr[0][3], data[3]);
+  EXPECT_EQ(ptr[1][0], data[4]);
+  EXPECT_EQ(ptr[1][1], data[5]);
+  EXPECT_EQ(ptr[1][2], data[6]);
+  EXPECT_EQ(ptr[1][3], data[7]);
 }
 
 TEST(HexagonBuffer, 1d_copy_from_1d) {
@@ -127,7 +125,7 @@ TEST(HexagonBuffer, 1d_copy_from_1d) {
   from.CopyFrom(data.data(), data.size());
   to.CopyFrom(from, 8);
 
-  uint8_t* ptr = static_cast<uint8_t*>(to.GetPointer()[0]);
+  uint8_t* ptr = static_cast<uint8_t*>(to.GetPointer());
   for (size_t i = 0; i < data.size(); ++i) {
     EXPECT_EQ(ptr[i], data[i]);
   }
@@ -144,17 +142,15 @@ TEST(HexagonBuffer, 2d_copy_from_1d) {
   hb1d.CopyFrom(data.data(), data.size());
   hb2d.CopyFrom(hb1d, 8);
 
-  uint8_t* ptr = static_cast<uint8_t*>(hb2d.GetPointer()[0]);
-  EXPECT_EQ(ptr[0], data[0]);
-  EXPECT_EQ(ptr[1], data[1]);
-  EXPECT_EQ(ptr[2], data[2]);
-  EXPECT_EQ(ptr[3], data[3]);
-
-  ptr = static_cast<uint8_t*>(hb2d.GetPointer()[1]);
-  EXPECT_EQ(ptr[0], data[4]);
-  EXPECT_EQ(ptr[1], data[5]);
-  EXPECT_EQ(ptr[2], data[6]);
-  EXPECT_EQ(ptr[3], data[7]);
+  uint8_t** ptr = static_cast<uint8_t**>(hb2d.GetPointer());
+  EXPECT_EQ(ptr[0][0], data[0]);
+  EXPECT_EQ(ptr[0][1], data[1]);
+  EXPECT_EQ(ptr[0][2], data[2]);
+  EXPECT_EQ(ptr[0][3], data[3]);
+  EXPECT_EQ(ptr[1][0], data[4]);
+  EXPECT_EQ(ptr[1][1], data[5]);
+  EXPECT_EQ(ptr[1][2], data[6]);
+  EXPECT_EQ(ptr[1][3], data[7]);
 }
 
 TEST(HexagonBuffer, 1d_copy_from_2d) {
@@ -168,7 +164,7 @@ TEST(HexagonBuffer, 1d_copy_from_2d) {
   hb2d.CopyFrom(data.data(), data.size());
   hb1d.CopyFrom(hb2d, 8);
 
-  uint8_t* ptr = static_cast<uint8_t*>(hb1d.GetPointer()[0]);
+  uint8_t* ptr = static_cast<uint8_t*>(hb1d.GetPointer());
   for (size_t i = 0; i < data.size(); ++i) {
     EXPECT_EQ(ptr[i], data[i]);
   }
@@ -245,12 +241,12 @@ TEST(HexagonBuffer, external) {
 
   Optional<String> def;
   HexagonBuffer hb_default(data.data(), data.size(), def);
-  EXPECT_EQ(hb_default.GetPointer()[0], data.data());
+  EXPECT_EQ(hb_default.GetPointer(), data.data());
   EXPECT_EQ(hb_default.GetStorageScope(), HexagonBuffer::StorageScope::kDDR);
 
   Optional<String> global("global");
   HexagonBuffer hb_global(data.data(), data.size(), global);
-  EXPECT_EQ(hb_global.GetPointer()[0], data.data());
+  EXPECT_EQ(hb_global.GetPointer(), data.data());
   EXPECT_EQ(hb_global.GetStorageScope(), HexagonBuffer::StorageScope::kDDR);
 
   Optional<String> vtcm("global.vtcm");


### PR DESCRIPTION
This change allows allocation of buffers with `"global.vtcm"` to be either 1-d (flat) or 2-d (non-flat) memory allocations.