### PR TITLE
[PROFILING] Various fixes for profile_function

### DIFF
--- a/python/tvm/runtime/profiling/__init__.py
+++ b/python/tvm/runtime/profiling/__init__.py
@@ -163,7 +163,7 @@ class DeviceWrapper(Object):
         self.__init_handle_by_constructor__(_ffi_api.DeviceWrapper, dev)
 
 
-def profile_function(mod, dev, collectors, func_name="main", warmup_iters=10):
+def profile_function(mod, dev, collectors, func_name=None, warmup_iters=10):
     """Collect performance information of a function execution. Usually used with
     a compiled PrimFunc.
 
@@ -194,8 +194,8 @@ def profile_function(mod, dev, collectors, func_name="main", warmup_iters=10):
 
     collectors: List[MetricCollector]
         :py:class:`MetricCollector`s which will collect performance information.
-    func_name: str
-        Name of the function in `mod` to profile. Defaults to "main".
+    func_name: Optional[str]
+        Name of the function in `mod` to profile. Defaults to the `entry_name` of `mod`.
     warmup_iters: int
         Number of iterations to run the function before collecting performance
         information. Recommended to set this larger than 0 for consistent cache
@@ -208,6 +208,8 @@ def profile_function(mod, dev, collectors, func_name="main", warmup_iters=10):
         returns performance metrics as a `Dict[str, ObjectRef]` where values
         can be `CountNode`, `DurationNode`, `PercentNode`.
     """
+    if func_name is None:
+        func_name = mod.entry_name
     return _ffi_api.ProfileFunction(
         mod, func_name, dev.device_type, dev.device_id, warmup_iters, collectors
     )

--- a/src/runtime/profiling.cc
+++ b/src/runtime/profiling.cc
@@ -683,6 +683,7 @@ PackedFunc ProfileFunction(Module mod, std::string func_name, int device_type, i
   // Module::GetFunction is not const, so this lambda has to be mutable
   return PackedFunc([=](TVMArgs args, TVMRetValue* ret) mutable {
     PackedFunc f = mod.GetFunction(func_name);
+    CHECK(f.defined()) << "There is no function called \"" << func_name << "\" in the module";
     Device dev{static_cast<DLDeviceType>(device_type), device_id};
 
     // warmup
@@ -695,17 +696,21 @@ PackedFunc ProfileFunction(Module mod, std::string func_name, int device_type, i
     }
     std::vector<Map<String, ObjectRef>> results;
     results.reserve(collectors.size());
-    std::vector<ObjectRef> collector_data;
+    std::vector<std::pair<MetricCollector, ObjectRef>> collector_data;
     collector_data.reserve(collectors.size());
     for (auto& collector : collectors) {
-      collector_data.push_back(collector->Start(dev));
+      ObjectRef o = collector->Start(dev);
+      // If not defined, then the collector cannot time this device.
+      if (o.defined()) {
+        collector_data.push_back({collector, o});
+      }
     }
 
     // TODO(tkonolige): repeated calls if the runtime is small?
     f.CallPacked(args, ret);
 
-    for (size_t i = 0; i < collectors.size(); i++) {
-      results.push_back(collectors[i]->Stop(collector_data[i]));
+    for (auto& kv : collector_data) {
+      results.push_back(kv.first->Stop(kv.second));
     }
     Map<String, ObjectRef> combined_results;
     for (auto m : results) {


### PR DESCRIPTION
Check that the function to be profiled is actually defined.

Check that the MetricCollector used actually can time the region
requested.

Default to using the module's entry_name instead of "main".

@mbrookhart @masahi 
