### PR TITLE
[PROFILING] Add Likwid Metric Collector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ target_compile_definitions(tvm_runtime PUBLIC DMLC_USE_LOGGING_LIBRARY=<tvm/runt
 include(cmake/modules/Logging.cmake)
 
 include(cmake/modules/contrib/PAPI.cmake)
+include(cmake/modules/contrib/Likwid.cmake)
 
 if(USE_MICRO)
   # NOTE: cmake doesn't track dependencies at the file level across subdirectories. For the

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -357,6 +357,13 @@ set(USE_CCACHE AUTO)
 # - /path/to/folder/containing/: Path to folder containing papi.pc.
 set(USE_PAPI OFF)
 
+# Whether to enable Likwid support in profiling. Likwid provides access to hardware
+# counters while profiling and high level metrics like memory bandwidth.
+# Possible values:
+# - ON: enable Likwid support.
+# - OFF: disable Likwid support.
+set(USE_LIKWID OFF)
+
 # Whether to use GoogleTest for C++ unit tests. When enabled, the generated
 # build file (e.g. Makefile) will have a target "cpptest".
 # Possible values:

--- a/cmake/modules/contrib/Likwid.cmake
+++ b/cmake/modules/contrib/Likwid.cmake
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+if(USE_LIKWID)
+  find_package(likwid REQUIRED COMPONENTS marker)
+  target_link_libraries(tvm_runtime_objs PRIVATE likwid::likwid)
+  target_link_libraries(tvm PRIVATE likwid::likwid)
+  target_link_libraries(tvm_runtime PRIVATE likwid::likwid)
+  target_sources(tvm_runtime_objs PRIVATE src/runtime/contrib/likwid/likwid.cc)
+endif()

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -41,6 +41,9 @@ RUN bash /install/ubuntu_install_dnnl.sh
 COPY install/ubuntu_install_papi.sh /install/ubuntu_install_papi.sh
 RUN bash /install/ubuntu_install_papi.sh ""
 
+COPY install/ubuntu_install_likwid.sh /install/ubuntu_install_likwid.sh
+RUN bash /install/ubuntu_install_likwid.sh
+
 # Install MxNet for access to Gluon Model Zoo.
 COPY install/ubuntu_install_mxnet.sh /install/ubuntu_install_mxnet.sh
 RUN bash /install/ubuntu_install_mxnet.sh

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -119,6 +119,10 @@ RUN bash /install/ubuntu_install_universal.sh
 COPY install/ubuntu_install_papi.sh /install/ubuntu_install_papi.sh
 RUN bash /install/ubuntu_install_papi.sh "cuda rocm"
 
+# likwid profiling deps
+COPY install/ubuntu_install_likwid.sh /install/ubuntu_install_likwid.sh
+RUN bash /install/ubuntu_install_likwid.sh
+
 # sccache
 COPY install/ubuntu_install_sccache.sh /install/ubuntu_install_sccache.sh
 RUN bash /install/ubuntu_install_sccache.sh

--- a/include/tvm/runtime/contrib/likwid.h
+++ b/include/tvm/runtime/contrib/likwid.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \brief Performance counters for profiling via the Likwid library.
+ */
+#ifndef TVM_RUNTIME_CONTRIB_LIKWID_H_
+#define TVM_RUNTIME_CONTRIB_LIKWID_H_
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/map.h>
+#include <tvm/runtime/profiling.h>
+
+namespace tvm {
+namespace runtime {
+namespace profiling {
+
+/*! \brief Construct a metric collector that collects data from hardware
+ * performance counters using Likwid (https://github.com/RRZE-HPC/likwid)
+ *
+ * \param group Name of the group to collect performance counters from.
+ * `likwid-perfctr -a` will list available groups.
+ */
+TVM_DLL MetricCollector CreateLikwidMetricCollector(String group);
+
+/*! \brief Construct a metric collector that adds Likwid markers to function
+ * calls. This reports no information on its own, but can be use in combination
+ * with `likwid-perfctr -m` to report performance metrics at runtime.
+ */
+TVM_DLL MetricCollector CreateLikwidMarkerMetricCollector();
+}  // namespace profiling
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_CONTRIB_LIKWID_H_

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -27,6 +27,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <set>
 
 #if defined(__linux__) || defined(__ANDROID__)
 #if defined(__ANDROID__)
@@ -82,6 +83,11 @@ class ThreadGroup {
    */
   void Join();
 
+  /*! Get the cores used by the thread group
+   * \returns List of cores used by threads in the thread group
+   */
+  std::set<unsigned int> CoresUsed() const;
+
   enum AffinityMode : int {
     kBig = 1,
     kLittle = -1,
@@ -129,6 +135,11 @@ void SetMaxConcurrency(int value);
  * Note that this does nothing when openmp is used.
  */
 void ResetThreadPool();
+
+/*! Get the cores used by the thread group
+ * \returns List of cores used by threads in the thread group
+ */
+std::set<unsigned int> CoresUsed();
 
 /*!
  * \brief Configuring the CPU affinity mode for the working threads.

--- a/python/tvm/runtime/profiling/__init__.py
+++ b/python/tvm/runtime/profiling/__init__.py
@@ -235,3 +235,32 @@ if _ffi.get_global_func("runtime.profiling.PAPIMetricCollector", allow_missing=T
             for dev, names in metric_names.items():
                 wrapped[DeviceWrapper(dev)] = names
             self.__init_handle_by_constructor__(_ffi_api.PAPIMetricCollector, wrapped)
+
+
+if _ffi.get_global_func("runtime.profiling.LikwidMetricCollector", allow_missing=True) is not None:
+
+    @_ffi.register_object("runtime.profiling.LikwidMetricCollector")
+    class LikwidMetricCollector(MetricCollector):
+        """Collects performance counter information using the Likwid library."""
+
+        def __init__(self, group: str):
+            """
+            Parameters
+            ----------
+            group : str
+                Likwid group name to profile. Available groups can be listed
+                with `likwid-perfctr -a`.
+            """
+            self.__init_handle_by_constructor__(_ffi_api.LikwidMetricCollector, group)
+
+    @_ffi.register_object("runtime.profiling.LikwidMarkerMetricCollector")
+    class LikwidMarkerMetricCollector(MetricCollector):
+        """
+        Marks profiling regions with a Likwid Marker so that it can be used to
+        profile an application at runtime. To use, prefix your script like so:
+        `likwid-perfctr -m -g MY_GROUP python3 my_script.py` (the `-m` flag is
+        required). See `likwid-perfctr -h` for more information.
+        """
+
+        def __init__(self):
+            self.__init_handle_by_constructor__(_ffi_api.LikwidMarkerMetricCollector)

--- a/src/runtime/contrib/likwid/likwid.cc
+++ b/src/runtime/contrib/likwid/likwid.cc
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <likwid-marker.h>
+#include <likwid.h>
+#include <tvm/ir/expr.h>
+#include <tvm/runtime/c_backend_api.h>
+#include <tvm/runtime/contrib/likwid.h>
+#include <tvm/runtime/threading_backend.h>
+
+namespace tvm {
+namespace runtime {
+namespace profiling {
+
+struct LikwidMarkerMetricCollectorNode final : public MetricCollectorNode {
+  void Init(Array<DeviceWrapper> devices) {
+    setenv("LIKWID_FORCE", "1", 1);
+    LIKWID_MARKER_INIT;
+    TVMBackendParallelLaunch(
+        [](int task_id, TVMParallelGroupEnv* penv, void* cdata) {
+          LIKWID_MARKER_THREADINIT;
+          return 0;
+        },
+        nullptr, 0);
+  }
+
+  ObjectRef Start(Device dev, CallId id) final {
+    // Need to prefix region name with something. Region with name "0" is
+    // apparently already taken.
+    String region_name("call" + std::to_string(id->id));
+    LIKWID_MARKER_REGISTER(region_name.c_str());
+    // This parallel launch waits for all threads to execute. This may introduce overhead.
+    TVMBackendParallelLaunch(
+        [](int task_id, TVMParallelGroupEnv* penv, void* cdata) {
+          // TODO(tkonolige): markers should be registered first, but we have no way of knowing how
+          // many we will need
+          LIKWID_MARKER_START(static_cast<const char*>(cdata));
+          return 0;
+        },
+        reinterpret_cast<void*>(const_cast<char*>(region_name.c_str())), 0);
+    return std::move(region_name);
+  }
+
+  Map<String, ObjectRef> Stop(ObjectRef obj) final {
+    if (!obj.defined()) {
+      return Map<String, ObjectRef>(nullptr);
+    }
+    String region_name = Downcast<String>(obj);
+    TVMBackendParallelLaunch(
+        [](int task_id, TVMParallelGroupEnv* penv, void* cdata) {
+          LIKWID_MARKER_STOP(static_cast<const char*>(cdata));
+          return 0;
+        },
+        reinterpret_cast<void*>(const_cast<char*>(region_name.c_str())), 0);
+    return Map<String, ObjectRef>(nullptr);
+  }
+
+  Map<CallId, Map<String, ObjectRef>> Finish() final {
+    LIKWID_MARKER_CLOSE;
+    return Map<CallId, Map<String, ObjectRef>>();
+  }
+
+  bool SupportsNested() const final { return false; }
+
+  ~LikwidMarkerMetricCollectorNode() {}
+
+  static constexpr const char* _type_key = "runtime.profiling.LikwidMarkerMetricCollector";
+  TVM_DECLARE_FINAL_OBJECT_INFO(LikwidMarkerMetricCollectorNode, MetricCollectorNode);
+};
+
+class LikwidMarkerMetricCollector : public MetricCollector {
+ public:
+  LikwidMarkerMetricCollector() { data_ = make_object<LikwidMarkerMetricCollectorNode>(); }
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LikwidMarkerMetricCollector, MetricCollector,
+                                            LikwidMarkerMetricCollectorNode);
+};
+
+MetricCollector CreateLikwidMarkerMetricCollector() { return LikwidMarkerMetricCollector(); }
+
+TVM_REGISTER_OBJECT_TYPE(LikwidMarkerMetricCollectorNode);
+
+TVM_REGISTER_GLOBAL("runtime.profiling.LikwidMarkerMetricCollector").set_body_typed([]() {
+  return LikwidMarkerMetricCollector();
+});
+
+struct LikwidMetricCollectorNode final : public MetricCollectorNode {
+  explicit LikwidMetricCollectorNode(String group) {
+    // Tell Likwid to use the performance counters even if they are already in
+    // use. Performance counters are often marked in use when not being used
+    // because the previous using process crashed.
+    setenv("LIKWID_FORCE", "1", 1);
+    topology_init();
+    numa_init();
+    affinity_init();
+    timer_init();
+    for (auto core : tvm::runtime::threading::CoresUsed()) {
+      cores_.push_back(core);
+    }
+    int err = perfmon_init(cores_.size(), cores_.data());
+    CHECK_GE(err, 0) << "Failed to initialize likwid perfmon";
+
+    gid_ = perfmon_addEventSet(group.c_str());
+    CHECK_GE(err, 0) << "Failed to add likwid perfmon event set";
+
+    err = perfmon_setupCounters(gid_);
+    CHECK_GE(err, 0) << "Failed to set up likwid perfmon counters";
+  }
+
+  void Init(Array<DeviceWrapper> devices) {}
+
+  ObjectRef Start(Device dev, CallId id) final {
+    // Likwid only supports CPU and nvidia profiling. The nvidia profiling uses
+    // a different interface, so we only support CPU for now.
+    if (dev.device_type != DLDeviceType::kDLCPU && dev.device_type != DLDeviceType::kDLCUDAHost) {
+      return ObjectRef(nullptr);
+    }
+    int err = perfmon_startCounters();
+    CHECK_GE(err, 0) << "Failed to start likwid perfmon counters";
+    return String();  // Need to return some non-null thing to let the profiler know we are timing
+  }
+
+  Map<String, ObjectRef> Stop(ObjectRef obj) final {
+    int err = perfmon_stopCounters();
+    CHECK_GE(err, 0) << "Could not stop likwid perfmon counters";
+    perfmon_init_maps();
+    perfmon_check_counter_map(0);
+
+    Map<String, ObjectRef> metrics;
+    for (int i = 0; i < perfmon_getNumberOfMetrics(gid_); i++) {
+      // For now we sum all metrics across threads. This may not be appropriate
+      // for some metrics.
+      double sum = 0;
+      for (auto c : cores_) {
+        sum += perfmon_getLastMetric(gid_, i, c);
+      }
+      metrics.Set(String(perfmon_getMetricName(gid_, i)), ObjectRef(make_object<RateNode>(sum)));
+    }
+
+    return metrics;
+  }
+
+  Map<CallId, Map<String, ObjectRef>> Finish() final {
+    return Map<CallId, Map<String, ObjectRef>>();
+  }
+
+  bool SupportsNested() const final {
+    // Likwid supports nested regions via the marker api, but this information
+    // is not available from a programmatic interface.
+    return false;
+  }
+
+  ~LikwidMetricCollectorNode() {
+    perfmon_finalize();
+    timer_finalize();
+    affinity_finalize();
+    numa_finalize();
+    topology_finalize();
+  }
+
+  int gid_;
+  std::vector<int> cores_;
+
+  static constexpr const char* _type_key = "runtime.profiling.LikwidMetricCollector";
+  TVM_DECLARE_FINAL_OBJECT_INFO(LikwidMetricCollectorNode, MetricCollectorNode);
+};
+
+class LikwidMetricCollector : public MetricCollector {
+ public:
+  explicit LikwidMetricCollector(String group) {
+    data_ = make_object<LikwidMetricCollectorNode>(group);
+  }
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(LikwidMetricCollector, MetricCollector,
+                                        LikwidMetricCollectorNode);
+};
+
+MetricCollector CreateLikwidMetricCollector(String group) { return LikwidMetricCollector(group); }
+
+TVM_REGISTER_OBJECT_TYPE(LikwidMetricCollectorNode);
+
+TVM_REGISTER_GLOBAL("runtime.profiling.LikwidMetricCollector").set_body_typed([](String group) {
+  return LikwidMetricCollector(group);
+});
+
+}  // namespace profiling
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/contrib/papi/papi.cc
+++ b/src/runtime/contrib/papi/papi.cc
@@ -215,7 +215,7 @@ struct PAPIMetricCollectorNode final : public MetricCollectorNode {
    * \returns A `PAPIEventSetNode` containing values for the counters at the
    * start of the call. Passed to a corresponding `Stop` call.
    */
-  ObjectRef Start(Device dev) final {
+  ObjectRef Start(Device dev, CallId call_id) final {
     // Record counter values at the start of the call, so we can calculate the
     // metrics for the call by comparing the values at the end of the call.
     auto it = event_sets.find(dev);
@@ -251,6 +251,10 @@ struct PAPIMetricCollectorNode final : public MetricCollectorNode {
       }
     }
     return reported_metrics;
+  }
+
+  bool SupportsNested() const final {
+    return true;
   }
 
   ~PAPIMetricCollectorNode() final {

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -329,6 +329,10 @@ class ThreadPool {
     num_workers_used_ = std::min(num_workers_, num_workers_used_);
   }
 
+  std::set<unsigned int> CoresUsed() const {
+    return threads_->CoresUsed();
+  }
+
  private:
   // Shared initialization code
   void Init() {
@@ -393,6 +397,7 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool").set_body([](TVMArgs args, TVMRe
 
 namespace threading {
 void ResetThreadPool() { tvm::runtime::ThreadPool::ThreadLocal()->Reset(); }
+std::set<unsigned int> CoresUsed() { return tvm::runtime::ThreadPool::ThreadLocal()->CoresUsed();}
 /*!
  * \brief configure the CPU id affinity
  * \param mode The preferred CPU type (1 = big, -1 = little, -2 = kSpecifyOneCorePerThread,


### PR DESCRIPTION
Likwid is a library for reading performance counters. Unlike PAPI it supports more sophisticated metrics calculated from a combination of performance counters. This includes memory bandwidth and total floating point operations. Likwid also supports some platforms not supported by PAPI.

Two MetricCollectors are provided: LikwidMetricCollector and LikwidMarkerMetricCollector. The former adds the requested metric group to the profiling report. The latter adds no information on its own, but can be used in combination with the `likwid-perfctr` command line tool to report different metrics at runtime.

MetricCollectors can now specify if they support nested regions (likwid does not) and can provide metrics after profiling is done using the `Finish` interface. MetricCollectors are also provided with a `CallId` on every start to correlate metrics with a given call in `Finish`.

Note that this adds Likwid to cpu and gpu docker images.

@masahi @mbrookhart 
