### PR TITLE
[Autoscheduler] Serialize compute dag

### DIFF
--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -52,6 +52,9 @@ class AccessAnalyzerNode : public Object {
   template <class T>
   using OperationMap = std::unordered_map<te::Operation, T, ObjectPtrHash, ObjectPtrEqual>;
 
+  template <class T>
+  using OperationMap2 = Map<te::Operation, T>;
+
   /*! \brief Map an operation to all operations it reads from.
    * For each operation pair, use a two-dimensional array for multiple multi-dimensional accesses
    * The inner vector represents the indices of multi-dimensional access.*/
@@ -62,19 +65,19 @@ class AccessAnalyzerNode : public Object {
   OperationMap<OperationMap<std::vector<std::vector<PrimExpr>>>> read_by;
   /*! \brief Store the number of common outer iterators for operation pairs that have
    * read-write relations. */
-  OperationMap<OperationMap<int>> num_common_outer_iterators;
+  OperationMap2<OperationMap2<Integer>> num_common_outer_iterators;
   /*! \brief Store whether the operation is an op with only simple access.
    *  (e.g., injective, broadcast and elementwise ops without reduction) */
-  OperationMap<bool> is_simple_access;
+  OperationMap2<Bool> is_simple_access;
   /*! \brief Store whether the operation is strictly inlineable
    * (e.g., injective, broadcast and elementwise without reduction, branch or expensive operations)
    */
-  OperationMap<bool> is_strictly_inlineable;
+  OperationMap2<Bool> is_strictly_inlineable;
   /*! \brief Store whether the operation needs multi-level tiling
    * (e.g., computation-intensive ops with data reuse opportunity like matmul, conv2d) */
-  OperationMap<bool> needs_multi_level_tiling;
+  OperationMap2<Bool> needs_multi_level_tiling;
   /*! \brief Store whether the operation is an output operation */
-  OperationMap<bool> is_output;
+  OperationMap2<Bool> is_output;
   /*! \brief Store the topological order of operations */
   Array<te::Operation> ops_topo_order;
 

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -58,7 +58,7 @@ class AccessAnalyzerNode : public Object {
   /*! \brief Map an operation to all operations it reads from.
    * For each operation pair, use a two-dimensional array for multiple multi-dimensional accesses
    * The inner vector represents the indices of multi-dimensional access.*/
-  OperationMap<OperationMap<std::vector<std::vector<PrimExpr>>>> read_from;
+  OperationMap2<OperationMap2<Array<Array<PrimExpr>>>> read_from;
   /*! \brief Map an operation to all operations it is read by.
    * For each operation pair, use a two-dimensional array for multiple multi-dimensional accesses
    * The inner vector represents the indices of multi-dimensional access.*/

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -50,34 +50,31 @@ namespace auto_scheduler {
 class AccessAnalyzerNode : public Object {
  public:
   template <class T>
-  using OperationMap = std::unordered_map<te::Operation, T, ObjectPtrHash, ObjectPtrEqual>;
-
-  template <class T>
-  using OperationMap2 = Map<te::Operation, T>;
+  using OperationMap = Map<te::Operation, T>;
 
   /*! \brief Map an operation to all operations it reads from.
    * For each operation pair, use a two-dimensional array for multiple multi-dimensional accesses
    * The inner vector represents the indices of multi-dimensional access.*/
-  OperationMap2<OperationMap2<Array<Array<PrimExpr>>>> read_from;
+  OperationMap<OperationMap<Array<Array<PrimExpr>>>> read_from;
   /*! \brief Map an operation to all operations it is read by.
    * For each operation pair, use a two-dimensional array for multiple multi-dimensional accesses
    * The inner vector represents the indices of multi-dimensional access.*/
-  OperationMap2<OperationMap2<Array<Array<PrimExpr>>>> read_by;
+  OperationMap<OperationMap<Array<Array<PrimExpr>>>> read_by;
   /*! \brief Store the number of common outer iterators for operation pairs that have
    * read-write relations. */
-  OperationMap2<OperationMap2<Integer>> num_common_outer_iterators;
+  OperationMap<OperationMap<Integer>> num_common_outer_iterators;
   /*! \brief Store whether the operation is an op with only simple access.
    *  (e.g., injective, broadcast and elementwise ops without reduction) */
-  OperationMap2<Bool> is_simple_access;
+  OperationMap<Bool> is_simple_access;
   /*! \brief Store whether the operation is strictly inlineable
    * (e.g., injective, broadcast and elementwise without reduction, branch or expensive operations)
    */
-  OperationMap2<Bool> is_strictly_inlineable;
+  OperationMap<Bool> is_strictly_inlineable;
   /*! \brief Store whether the operation needs multi-level tiling
    * (e.g., computation-intensive ops with data reuse opportunity like matmul, conv2d) */
-  OperationMap2<Bool> needs_multi_level_tiling;
+  OperationMap<Bool> needs_multi_level_tiling;
   /*! \brief Store whether the operation is an output operation */
-  OperationMap2<Bool> is_output;
+  OperationMap<Bool> is_output;
   /*! \brief Store the topological order of operations */
   Array<te::Operation> ops_topo_order;
 

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -62,7 +62,7 @@ class AccessAnalyzerNode : public Object {
   /*! \brief Map an operation to all operations it is read by.
    * For each operation pair, use a two-dimensional array for multiple multi-dimensional accesses
    * The inner vector represents the indices of multi-dimensional access.*/
-  OperationMap<OperationMap<std::vector<std::vector<PrimExpr>>>> read_by;
+  OperationMap2<OperationMap2<Array<Array<PrimExpr>>>> read_by;
   /*! \brief Store the number of common outer iterators for operation pairs that have
    * read-write relations. */
   OperationMap2<OperationMap2<Integer>> num_common_outer_iterators;

--- a/include/tvm/auto_scheduler/compute_dag.h
+++ b/include/tvm/auto_scheduler/compute_dag.h
@@ -78,10 +78,21 @@ class AccessAnalyzerNode : public Object {
   /*! \brief Store the topological order of operations */
   Array<te::Operation> ops_topo_order;
 
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("read_from", &read_from);
+    v->Visit("read_by", &read_by);
+    v->Visit("num_common_outer_iterators", &num_common_outer_iterators);
+    v->Visit("is_simple_access", &is_simple_access);
+    v->Visit("is_strictly_inlineable", &is_strictly_inlineable);
+    v->Visit("needs_multi_level_tiling", &needs_multi_level_tiling);
+    v->Visit("is_output", &is_output);
+    v->Visit("ops_topo_order", &ops_topo_order);
+  }
   static constexpr const char* _type_key = "auto_scheduler.AccessAnalyzer";
   TVM_DECLARE_FINAL_OBJECT_INFO(AccessAnalyzerNode, Object);
 };
 
+TVM_REGISTER_NODE_TYPE(AccessAnalyzerNode);
 /*!
  * \brief Managed reference to AccessAnalyzerNode.
  * \sa AccessAnalyzerNode


### PR DESCRIPTION
This allows `AccessAnalyzerNode` to be serializable via the JSON interface. So we can serialize `ComputeDAG` class in autoscheduler. This will help with debugging and danlyzing performance as it makes it easier to recreate the workloads we are examining.

The way this works is `AccessAnalyzerNode` in constructor fills a bunch of maps and vectors with cached info. These were previously containers from `std` which we cannot serialize. Instead at the very end we copy this info into serializable Map and Array containers.

https://github.com/AndrewZhaoLuo/TVM-Sandbox/blob/main/tir/test_serialize_dag.py <-- example of serializing and deserializing DAG.