### PR TITLE
[Hexagon] Don't use alternative linker for non-x86 API binaries

### DIFF
--- a/apps/hexagon_api/CMakeLists.txt
+++ b/apps/hexagon_api/CMakeLists.txt
@@ -68,6 +68,7 @@ ExternalProject_Add(android_tvm_runtime_rpc
     "-DUSE_CPP_RPC=ON"
     "-DUSE_HEXAGON_RPC=ON"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    "-DUSE_ALTERNATIVE_LINKER=OFF"
   INSTALL_COMMAND ""
   BUILD_ALWAYS ON
 )
@@ -103,6 +104,7 @@ ExternalProject_Add(hexagon_tvm_runtime_rpc
     "-DUSE_HEXAGON_RPC=ON"
     "-DBUILD_STATIC_RUNTIME=ON"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    "-DUSE_ALTERNATIVE_LINKER=OFF"
   INSTALL_COMMAND ""
   BUILD_ALWAYS ON
 )


### PR DESCRIPTION
This just fails for Hexagon.  Make sure we don't try to use host linker for cross-compiling.