### PR TITLE
[Metaschedule] Add test case for multi-anchor subgraph

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -337,7 +337,7 @@ class ScheduleBuilder : public ExprVisitor {
           schedule = Downcast<te::Schedule>(obj);
         }
       }
-      if (use_auto_scheduler_) {
+      if (use_meta_scheduler_) {
         IRModule relay_mod({{prim_fn_var, relay_func}});
         IRModule tir_mod({{prim_fn_var, tir::CreatePrimFunc(Concat(fn_inputs, tensor_outs))}});
         Optional<IRModule> scheduled_mod = meta_schedule::MetaScheduleContext::QueryInsideWithScope(

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -299,6 +299,7 @@ class ScheduleBuilder : public ExprVisitor {
   explicit ScheduleBuilder(Target target) : target_(target) {
     // Whether to use auto_scheduler schedule.
     use_auto_scheduler_ = backend::IsAutoSchedulerEnabled();
+    use_meta_scheduler_ = backend::IsMetaScheduleEnabled();
   }
 
   CachedFunc Create(const Function& relay_func, std::function<std::string(std::string)> renamer) {
@@ -336,7 +337,7 @@ class ScheduleBuilder : public ExprVisitor {
           schedule = Downcast<te::Schedule>(obj);
         }
       }
-      if (backend::IsMetaScheduleEnabled()) {
+      if (use_auto_scheduler_) {
         IRModule relay_mod({{prim_fn_var, relay_func}});
         IRModule tir_mod({{prim_fn_var, tir::CreatePrimFunc(Concat(fn_inputs, tensor_outs))}});
         Optional<IRModule> scheduled_mod = meta_schedule::MetaScheduleContext::QueryInsideWithScope(
@@ -377,7 +378,7 @@ class ScheduleBuilder : public ExprVisitor {
     }
 
     int op_pattern = fpattern[op];
-    if (!use_auto_scheduler_ && op_pattern >= kCommReduce) {
+    if (!use_auto_scheduler_ && !use_meta_scheduler_ && op_pattern >= kCommReduce) {
       ICHECK(!anchor_op_.defined() || anchor_op_pattern_ < kCommReduce)
           << "Cannot apply TOPI schedule to a primitive function with two complicated ops"
           << " anchor=" << anchor_op_ << " current=" << op;
@@ -395,6 +396,7 @@ class ScheduleBuilder : public ExprVisitor {
   Attrs anchor_attrs_;
   int anchor_op_pattern_{0};
   bool use_auto_scheduler_;
+  bool use_meta_scheduler_;
 };
 
 /*!

--- a/tests/python/unittest/test_meta_schedule_multi_anchor.py
+++ b/tests/python/unittest/test_meta_schedule_multi_anchor.py
@@ -100,7 +100,7 @@ def test_dense_dense():
 
         schedule_dense_dense(sch)
 
-        print(sch.mod.script())
+        # print(sch.mod.script())
 
         tune_rec = TuningRecord(sch.trace, [0.0], workload, tvm.target.Target(target), [])
 

--- a/tests/python/unittest/test_meta_schedule_multi_anchor.py
+++ b/tests/python/unittest/test_meta_schedule_multi_anchor.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import numpy as np
+
+import tvm
+from tvm import relay
+
+
+def get_dense_dense():
+    M, N, K = 128, 128, 128
+    data_shape = (M, K)
+    weight_shape = (N, K)
+
+    def multi_dense():
+        p_data = relay.var("p_data", shape=data_shape, dtype="uint8")
+        p_weight1 = relay.var("p_weight1", shape=weight_shape, dtype="int8")
+        p_weight2 = relay.var("p_weight2", shape=weight_shape, dtype="int8")
+
+        dense1 = relay.nn.dense(p_data, p_weight1, out_dtype="int32")
+        dense2 = relay.nn.dense(relay.cast(dense1, "uint8"),
+                                p_weight2, out_dtype="int32")
+
+        f = relay.Function([p_data, p_weight1, p_weight2], dense2)
+        f = f.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
+        return f
+
+    data = relay.var("data", shape=data_shape, dtype="uint8")
+    weight1 = relay.var("weight1", shape=weight_shape, dtype="int8")
+    weight2 = relay.var("weight2", shape=weight_shape, dtype="int8")
+
+    out = relay.Call(multi_dense(), [data, weight1, weight2])
+    return relay.Function([data, weight1, weight2], out)
+
+
+mod = tvm.IRModule.from_expr(get_dense_dense())
+
+print(relay.transform.InferType()(mod))

--- a/tests/python/unittest/test_meta_schedule_multi_anchor.py
+++ b/tests/python/unittest/test_meta_schedule_multi_anchor.py
@@ -51,10 +51,16 @@ def get_ref(data_np, weight1_np, weight2_np):
 
 
 def schedule_dense_dense(sch):
-    pass
+    dense1 = sch.get_block("T_matmul_NT")
+    dense2 = sch.get_block("T_matmul_NT_1")
+
+    y1, x1, k1 = sch.get_loops(dense1)
+    y2, x2, k2 = sch.get_loops(dense2)
+
+    # ...
 
 
-def test():
+def test_dense_dense():
     M, N, K = 128, 128, 128
     data_shape = (M, K)
     weight_shape = (N, K)
@@ -118,4 +124,4 @@ def test():
 
 
 if __name__ == "__main__":
-    test()
+    test_dense_dense()


### PR DESCRIPTION
This adds a demonstration of extracting, scheduling, and e2e-compiling relay subgraphs with multiple anchor ops. Since task extraction is not associated with TE scheduling anymore, extracting a subgraph with multiple anchor TE compute just works.

The test case manually creates a simple fused mod with two `relay.dense`. But in the future, an effort like https://github.com/apache/tvm/pull/9628 should make it easier to construct multi-anchor subgraphs.

The extracted TensorIR block corresponding to two TE `dense` compute looks like this:

```
@tvm.script.ir_module
class Module:
    @T.prim_func
    def main(placeholder: T.Buffer[(128, 128), "float32"], placeholder_1: T.Buffer[(128, 128), "float32"], placeholder_2: T.Buffer[(128, 128), "float32"], T_matmul_NT: T.Buffer[(128, 128), "float32"]) -> None:
        # function attr dict
        T.func_attr({"global_symbol": "main", "tir.noalias": True})
        # body
        # with T.block("root")
        T_matmul_NT_1 = T.alloc_buffer([128, 128], dtype="float32")
        for i0, i1, i2 in T.grid(128, 128, 128):
            with T.block("T_matmul_NT"):
                i, j, k = T.axis.remap("SSR", [i0, i1, i2])
                T.reads(placeholder[i, k], placeholder_1[j, k])
                T.writes(T_matmul_NT_1[i, j])
                T.block_attr({"layout_free_placeholders":[placeholder_1]})
                with T.init():
                    T_matmul_NT_1[i, j] = T.float32(0)
                T_matmul_NT_1[i, j] = T_matmul_NT_1[i, j] + placeholder[i, k] * placeholder_1[j, k]
        for i0, i1, i2 in T.grid(128, 128, 128):
            with T.block("T_matmul_NT_1"):
                i, j, k = T.axis.remap("SSR", [i0, i1, i2])
                T.reads(T_matmul_NT_1[i, k], placeholder_2[j, k])
                T.writes(T_matmul_NT[i, j])
                T.block_attr({"layout_free_placeholders":[placeholder_2]})
                with T.init():
                    T_matmul_NT[i, j] = T.float32(0)
                T_matmul_NT[i, j] = T_matmul_NT[i, j] + T_matmul_NT_1[i, k] * placeholder_2[j, k]
    
```

@junrushao1994 @csullivan @comaniac @mbs-octoml @mikepapadim 
