### PR TITLE
[CI] Bump pyxir version to avoid bad cleanup error with pyxir and TF 2.6

### DIFF
--- a/docker/install/ubuntu_install_vitis_ai_packages_ci.sh
+++ b/docker/install/ubuntu_install_vitis_ai_packages_ci.sh
@@ -25,5 +25,5 @@ mkdir "$PYXIR_HOME"
 
 pip3 install progressbar
 
-git clone --recursive --branch v0.3.1 --depth 1 https://github.com/Xilinx/pyxir.git "${PYXIR_HOME}"
+git clone --recursive --branch v0.3.5 --depth 1 https://github.com/Xilinx/pyxir.git "${PYXIR_HOME}"
 cd "${PYXIR_HOME}" && python3 setup.py install

--- a/tests/python/contrib/test_vitis_ai/infrastructure.py
+++ b/tests/python/contrib/test_vitis_ai/infrastructure.py
@@ -24,7 +24,6 @@ import numpy as np
 import pytest
 
 pytest.importorskip("pyxir")
-import pyxir.contrib.target.DPUCADX8G
 import pyxir.contrib.target.DPUCZDX8G
 
 import tvm


### PR DESCRIPTION
This PR provides a fix for the following issue: https://github.com/apache/tvm/issues/10696

@leandron I verified with tlcpackstaging/ci_cpu:20220321-061034-bd684deb5 and manually updated the pyxir version inside that docker container to v0.3.5. After this I don't see the issue anymore with following scripts:

```
./tests/scripts/task_rust.sh
./tests/scripts/task_cpp_unittest.sh
```

Could you also verify that this would run through the entire CI? 
If tried a bunch of other task scripts to verify but let me know if there are specific other scripts I need to run through.
 
