### PR TITLE
Fix typo in comment about kill()

### DIFF
--- a/python/tvm/contrib/popen_pool.py
+++ b/python/tvm/contrib/popen_pool.py
@@ -124,7 +124,7 @@ class PopenWorker:
                 self._reader.close()
             except IOError:
                 pass
-            # kill all child processes recurisvely
+            # kill all child processes recursively
             try:
                 kill_child_processes(self._proc.pid)
             except TypeError:


### PR DESCRIPTION
Fix typo in comment about kill method in PopenWorker class used to kill
child processes created by the worker.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
