### PR TITLE
[TVMC] tune: Check if FILE exists (#10608)

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -236,6 +236,11 @@ def drive_tune(args):
     args: argparse.Namespace
         Arguments from command line parser.
     """
+    if not os.path.isfile(args.FILE):
+        raise TVMCException(
+            f"Input file '{args.FILE}' doesn't exist, is a broken symbolic link, or a directory."
+        )
+
     tvmc_model = frontends.load_model(args.FILE, args.model_format, shape_dict=args.input_shapes)
 
     # Specify hardware parameters, although they'll only be used if autoscheduling.

--- a/tests/python/driver/tvmc/test_autotuner.py
+++ b/tests/python/driver/tvmc/test_autotuner.py
@@ -20,6 +20,7 @@ import os
 from unittest import mock
 
 from os import path
+from pathlib import Path
 
 from tvm import autotvm
 from tvm.driver import tvmc
@@ -163,8 +164,15 @@ def test_tune_tasks__invalid_tuner(onnx_mnist, tmpdir_factory):
 def test_tune_rpc_tracker_parsing(mock_load_model, mock_tune_model, mock_auto_scheduler):
     cli_args = mock.MagicMock()
     cli_args.rpc_tracker = "10.0.0.1:9999"
+    # FILE is not used but it's set to a valid value here to avoid it being set
+    # by mock to a MagicMock class, which won't pass the checks for valid FILE.
+    fake_input_file = "./fake_input_file.tflite"
+    Path(fake_input_file).touch()
+    cli_args.FILE = fake_input_file
 
     tvmc.autotuner.drive_tune(cli_args)
+
+    os.remove(fake_input_file)
 
     mock_tune_model.assert_called_once()
 

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -14,11 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
 import platform
 import pytest
-import os
+import shutil
 
+from pytest_lazyfixture import lazy_fixture
 from tvm.driver.tvmc.main import _main
+from tvm.driver.tvmc.model import TVMCException
 
 
 @pytest.mark.skipif(
@@ -92,3 +95,63 @@ def test_tvmc_cl_workflow_json_config(keras_simple, tmpdir_factory):
     run_args = run_str.split(" ")[1:]
     _main(run_args)
     assert os.path.exists(output_path)
+
+
+@pytest.fixture
+def missing_file():
+    missing_file_name = "missing_file_as_invalid_input.tfite"
+    return missing_file_name
+
+
+@pytest.fixture
+def broken_symlink(tmp_path):
+    broken_symlink = "broken_symlink_as_invalid_input.tflite"
+    os.symlink("non_existing_file", tmp_path / broken_symlink)
+    yield broken_symlink
+    os.unlink(tmp_path / broken_symlink)
+
+
+@pytest.fixture
+def fake_directory(tmp_path):
+    dir_as_invalid = "dir_as_invalid_input.tflite"
+    os.mkdir(tmp_path / dir_as_invalid)
+    yield dir_as_invalid
+    shutil.rmtree(tmp_path / dir_as_invalid)
+
+
+@pytest.mark.parametrize(
+    "invalid_input",
+    [lazy_fixture("missing_file"), lazy_fixture("broken_symlink"), lazy_fixture("fake_directory")],
+)
+def test_tvmc_compile_file_check(capsys, invalid_input):
+    compile_cmd = f"tvmc compile --target 'c' {invalid_input}"
+    run_arg = compile_cmd.split(" ")[1:]
+
+    _main(run_arg)
+
+    captured = capsys.readouterr()
+    expected_err = (
+        f"Error: Input file '{invalid_input}' doesn't exist, "
+        "is a broken symbolic link, or a directory.\n"
+    )
+    on_assert_error = f"'tvmc compile' failed to check invalid FILE: {invalid_input}"
+    assert captured.err == expected_err, on_assert_error
+
+
+@pytest.mark.parametrize(
+    "invalid_input",
+    [lazy_fixture("missing_file"), lazy_fixture("broken_symlink"), lazy_fixture("fake_directory")],
+)
+def test_tvmc_tune_file_check(capsys, invalid_input):
+    tune_cmd = f"tvmc tune --target 'llvm' --output output.json {invalid_input}"
+    run_arg = tune_cmd.split(" ")[1:]
+
+    _main(run_arg)
+
+    captured = capsys.readouterr()
+    expected_err = (
+        f"Error: Input file '{invalid_input}' doesn't exist, "
+        "is a broken symbolic link, or a directory.\n"
+    )
+    on_assert_error = f"'tvmc tune' failed to check invalid FILE: {invalid_input}"
+    assert captured.err == expected_err, on_assert_error


### PR DESCRIPTION
Currently when a non-existing FILE is passed to 'tvmc tune' it throws
a traceback because a FileNotFoundError exception is not handled. Since
there is no need for such abrupt exit, and the trace can also confuse
users, this commit fixes it by checking if FILE indeed exists, kindly
informing the user about the non-existing FILE before exiting.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
