### PR TITLE
[AOT] Re-enable AOT output name test on AArch64

### DIFF
--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -819,10 +819,6 @@ def test_constants_alignment(constants_byte_alignment):
     assert f'__attribute__((section(".rodata.tvm"), aligned({constants_byte_alignment})))' in source
 
 
-@pytest.mark.skipif(
-    platform.machine() == "aarch64",
-    reason="Currently failing on AArch64 - see https://github.com/apache/tvm/issues/10673",
-)
 def test_output_tensor_names():
     """Test that the output names generated match those in the model"""
     pytest.importorskip("tflite")


### PR DESCRIPTION
This was fixed in https://github.com/apache/tvm/pull/10731 as it was the mismatch of tensorflow versions in use by the different CI containers.
