### PR TITLE
[CI] Run frontend tests for aarch64 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -851,6 +851,29 @@ stage('Test') {
       Utils.markStageSkippedForConditional('frontend: CPU')
     }
   },
+  'frontend: aarch64': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('ARM') {
+        ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
+          try {
+            init_git()
+            unpack_lib('arm', tvm_multilib)
+            timeout(time: max_time, unit: 'MINUTES') {
+              ci_setup(ci_arm)
+              sh (
+                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
+                label: 'Run Python frontend tests',
+              )
+            }
+          } finally {
+            junit 'build/pytest-results/*.xml'
+          }
+        }
+      }
+    } else {
+      Utils.markStageSkippedForConditional('frontend: aarch64')
+    }
+  },
   'docs: GPU': {
     if (!skip_ci) {
       node('TensorCore') {

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -848,6 +848,29 @@ stage('Test') {
       Utils.markStageSkippedForConditional('frontend: CPU')
     }
   },
+  'frontend: aarch64': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('ARM') {
+        ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
+          try {
+            init_git()
+            unpack_lib('arm', tvm_multilib)
+            timeout(time: max_time, unit: 'MINUTES') {
+              ci_setup(ci_arm)
+              sh (
+                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
+                label: 'Run Python frontend tests',
+              )
+            }
+          } finally {
+            junit 'build/pytest-results/*.xml'
+          }
+        }
+      }
+    } else {
+      Utils.markStageSkippedForConditional('frontend: aarch64')
+    }
+  },
   'docs: GPU': {
     if (!skip_ci) {
       node('TensorCore') {


### PR DESCRIPTION
Using `task_python_frontend_cpu.sh` to begin with to match those used
in `ci_cpu` - can add more frontends after this initial set is
functional.

Closes #10866