### PR TITLE
[Pattern] add optional pattern to C++ syntatic sugar

### DIFF
--- a/include/tvm/relay/dataflow_pattern.h
+++ b/include/tvm/relay/dataflow_pattern.h
@@ -50,27 +50,29 @@ class DFPatternNode : public Object {
 class DFPattern : public ObjectRef {
  public:
   /*! \brief Syntatic Sugar for creating a CallPattern */
-  DFPattern operator()(const std::vector<DFPattern>& args);
+  DFPattern operator()(const std::vector<DFPattern>& args) const;
   /*! \brief Syntatic Sugar for creating a CallPattern with an "add" op */
-  DFPattern operator+(const DFPattern& other);
+  DFPattern operator+(const DFPattern& other) const;
   /*! \brief Syntatic Sugar for creating a CallPattern with a "subtract" op */
-  DFPattern operator-(const DFPattern& other);
+  DFPattern operator-(const DFPattern& other) const;
   /*! \brief Syntatic Sugar for creating a CallPattern with a "multiply" op */
-  DFPattern operator*(const DFPattern& other);
+  DFPattern operator*(const DFPattern& other) const;
   /*! \brief Syntatic Sugar for creating a CallPattern with a "divide" op */
-  DFPattern operator/(const DFPattern& other);
+  DFPattern operator/(const DFPattern& other) const;
   /*! \brief Syntatic Sugar for creating an AltPattern */
-  DFPattern operator||(const DFPattern& other);
+  DFPattern operator||(const DFPattern& other) const;
+  /*! \brief Syntatic Sugar for creating an Optional Pattern */
+  DFPattern Optional(const std::function<DFPattern(const DFPattern&)>& func) const;
   /*! \brief Syntatic Sugar for creating an AttrPattern */
-  DFPattern HasAttr(const Map<String, ObjectRef>& attrs);
+  DFPattern HasAttr(const Map<String, ObjectRef>& attrs) const;
   /*! \brief Syntatic Sugar for creating a TypePattern */
-  DFPattern HasType(const Type& type);
+  DFPattern HasType(const Type& type) const;
   /*! \brief Syntatic Sugar for creating a DataTypePattern with a DataType */
-  DFPattern HasDtype(const DataType& dtype);
+  DFPattern HasDtype(const DataType& dtype) const;
   /*! \brief Syntatic Sugar for creating a DataTypePattern with a data type's name */
-  DFPattern HasDtype(const std::string& dtype);
+  DFPattern HasDtype(const std::string& dtype) const;
   /*! \brief Syntatic Sugar for creating a ShapePattern */
-  DFPattern HasShape(const Array<PrimExpr> shape);
+  DFPattern HasShape(const Array<PrimExpr> shape) const;
 
   TVM_DEFINE_OBJECT_REF_METHODS(DFPattern, ObjectRef, DFPatternNode);
 };

--- a/src/relay/ir/dataflow_pattern.cc
+++ b/src/relay/ir/dataflow_pattern.cc
@@ -321,38 +321,43 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     });
 
 // Syntatic Sugar
-DFPattern DFPattern::operator()(const std::vector<DFPattern>& args) {
+DFPattern DFPattern::operator()(const std::vector<DFPattern>& args) const {
   return CallPattern(GetRef<DFPattern>(this->get()), Array<DFPattern>(args));
 }
-DFPattern DFPattern::operator+(const DFPattern& other) {
+DFPattern DFPattern::operator+(const DFPattern& other) const {
   return IsOp("add")({GetRef<DFPattern>(this->get()), other});
 }
-DFPattern DFPattern::operator-(const DFPattern& other) {
+DFPattern DFPattern::operator-(const DFPattern& other) const {
   return IsOp("subtract")({GetRef<DFPattern>(this->get()), other});
 }
-DFPattern DFPattern::operator*(const DFPattern& other) {
+DFPattern DFPattern::operator*(const DFPattern& other) const {
   return IsOp("multiply")({GetRef<DFPattern>(this->get()), other});
 }
-DFPattern DFPattern::operator/(const DFPattern& other) {
+DFPattern DFPattern::operator/(const DFPattern& other) const {
   return IsOp("divide")({GetRef<DFPattern>(this->get()), other});
 }
-DFPattern DFPattern::operator||(const DFPattern& other) {
+DFPattern DFPattern::operator||(const DFPattern& other) const {
   return AltPattern(GetRef<DFPattern>(this->get()), other);
 }
 
-DFPattern DFPattern::HasAttr(const Map<String, ObjectRef>& attrs) {
+DFPattern DFPattern::Optional(const std::function<DFPattern(const DFPattern&)>& func) const {
+  DFPattern current = GetRef<DFPattern>(this->get());
+  return current || func(current);
+}
+
+DFPattern DFPattern::HasAttr(const Map<String, ObjectRef>& attrs) const {
   return AttrPattern(GetRef<DFPattern>(this->get()), DictAttrs(attrs));
 }
-DFPattern DFPattern::HasType(const Type& type) {
+DFPattern DFPattern::HasType(const Type& type) const {
   return TypePattern(GetRef<DFPattern>(this->get()), type);
 }
-DFPattern DFPattern::HasDtype(const DataType& dtype) {
+DFPattern DFPattern::HasDtype(const DataType& dtype) const {
   return DataTypePattern(GetRef<DFPattern>(this->get()), dtype);
 }
-DFPattern DFPattern::HasDtype(const std::string& dtype) {
+DFPattern DFPattern::HasDtype(const std::string& dtype) const {
   return HasDtype(DataType(runtime::String2DLDataType(dtype)));
 }
-DFPattern DFPattern::HasShape(const Array<PrimExpr> shape) {
+DFPattern DFPattern::HasShape(const Array<PrimExpr> shape) const {
   return ShapePattern(GetRef<DFPattern>(this->get()), shape);
 }
 DFPattern IsVar(const String& name) { return VarPattern(name); }

--- a/tests/cpp/dataflow_pattern_test.cc
+++ b/tests/cpp/dataflow_pattern_test.cc
@@ -144,6 +144,25 @@ TEST(DFPattern, OR) {
   ICHECK(node->right == b);
 }
 
+TEST(DFPattern, Optional) {
+  using namespace tvm;
+  using namespace tvm::relay;
+  DFPattern a = WildcardPattern();
+  DFPattern b = WildcardPattern();
+  auto pattern = a.Optional([b](const DFPattern& other) { return other + b; });
+  auto* node = pattern.as<AltPatternNode>();
+  ICHECK(node);
+  ICHECK(node->left == a);
+  auto* right_node = node->right.as<CallPatternNode>();
+  ICHECK(right_node);
+  ICHECK(right_node->args.size() == 2);
+  ICHECK(right_node->args[0] == a);
+  ICHECK(right_node->args[1] == b);
+  auto* expr_pattern = right_node->op.as<ExprPatternNode>();
+  ICHECK(expr_pattern);
+  ICHECK(expr_pattern->expr == Op::Get("add"));
+}
+
 TEST(DFPattern, HasAttr) {
   using namespace tvm;
   using namespace tvm::relay;


### PR DESCRIPTION
Add an optional pattern syntatic sugar to the C++ pattern language to match python. While writing the tests, I noticed that the const definitions on the methods weren't quite right (I couldn't do nested syntatic sugar calls), so I fixed that as well.

cc @mbs-octoml @masahi 

