### PR TITLE
[BugFix] Fix PopenWorker Memory Leak

### DIFF
--- a/python/tvm/exec/popen_worker.py
+++ b/python/tvm/exec/popen_worker.py
@@ -50,18 +50,20 @@ def main():
             # pylint: disable=import-outside-toplevel
             import msvcrt
 
-            return os.fdopen(msvcrt.open_osfhandle(int(sys.argv[1]), os.O_BINARY), "rb")
+            reader = os.fdopen(msvcrt.open_osfhandle(int(sys.argv[1]), os.O_BINARY), "rb")
         else:
-            return os.fdopen(int(sys.argv[1]), "rb")
+            reader = os.fdopen(int(sys.argv[1]), "rb")
+        return reader
 
     def get_writer():
         if sys.platform == "win32":
             # pylint: disable=import-outside-toplevel
             import msvcrt
 
-            return os.fdopen(msvcrt.open_osfhandle(int(sys.argv[2]), os.O_BINARY), "wb")
+            writer = os.fdopen(msvcrt.open_osfhandle(int(sys.argv[2]), os.O_BINARY), "wb")
         else:
-            return os.fdopen(int(sys.argv[2]), "wb")
+            writer = os.fdopen(int(sys.argv[2]), "wb")
+        return writer
 
     def _respond(ret_value):
         """Send data back to the client."""

--- a/python/tvm/exec/popen_worker.py
+++ b/python/tvm/exec/popen_worker.py
@@ -52,7 +52,7 @@ def main():
 
             return os.fdopen(msvcrt.open_osfhandle(int(sys.argv[1]), os.O_BINARY), "rb")
         else:
-            return os.fdopen(int(sys.argv[1]), "rb", 0)
+            return os.fdopen(int(sys.argv[1]), "rb")
 
     def get_writer():
         if sys.platform == "win32":
@@ -61,7 +61,7 @@ def main():
 
             return os.fdopen(msvcrt.open_osfhandle(int(sys.argv[2]), os.O_BINARY), "wb")
         else:
-            return os.fdopen(int(sys.argv[2]), "wb", 0)
+            return os.fdopen(int(sys.argv[2]), "wb")
 
     def _respond(ret_value):
         """Send data back to the client."""


### PR DESCRIPTION
During tuning of meta schedule I found a memory leak from PopenWorker. The cause is related to the use of reader and writer inside of the class. I rewrote the Popenworker to create a new reader / writer before usage. There might slightly impact the overhead of tuning but avoids the memory leak.

CC: @tqchen @junrushao1994 @shingjan 