### PR TITLE
Fix an apparent bug in the [web] timer.

### DIFF
--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1069,7 +1069,7 @@ export class Instance implements Disposable {
         do {
           if (durationMs > 0.0) {
             setupNumber = Math.floor(
-              Math.max(minRepeatMs / (durationMs / nstep) + 1, nstep * 1.618)
+              Math.max(minRepeatMs / (durationMs / setupNumber) + 1, setupNumber * 1.618)
             );
           }
           const tstart: number = perf.now();


### PR DESCRIPTION
I've never worked in TypeScript before, so it's possible I'm wrong, but the behavior of this timer script appears to be inconsistent with the earlier(?) code in tvm/src/runtime/rpc/rpc_module.cc#L387-388.

As far as I can tell, what this code is *supposed* to be doing is scaling up the number of runs measured per trial if minRepeatMs hasn't been reached. The `max` condition seems to be intended to make sure that the number of replicates run on subsequent trials is no less than 1.618 times the previous attempt's trials -- presumably as a failsafe against somehow getting stuck in a very tight loop. The version of the code in web/src/runtime.ts wouldn't actually avoid that problem, though.