### PR TITLE
[QNN] Fix qnn.dequantize scale and zp shape

### DIFF
--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -63,13 +63,13 @@ bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   bool zp_is_scalar = (types[2].as<TensorTypeNode>())->shape.size() == 0 ||
                       get_const_int((types[2].as<TensorTypeNode>())->Size()) == 1;
 
-  if (!(scale_is_scalar && zp_is_scalar)) {
+  if (!scale_is_scalar || !zp_is_scalar) {
     ICHECK_LT(axis, rank > 0 ? rank : 1) << "axis " << dequantize_attrs->axis << " is out of range";
     ICHECK_GE(axis, 0) << "axis " << dequantize_attrs->axis << " is out of range";
   }
 
   PrimExpr axis_shape;
-  if (!(scale_is_scalar && zp_is_scalar)) {
+  if (!scale_is_scalar || !zp_is_scalar) {
     axis_shape = data->shape[axis];
   } else {
     axis_shape = Integer(1);

--- a/src/relay/qnn/op/dequantize.cc
+++ b/src/relay/qnn/op/dequantize.cc
@@ -65,8 +65,9 @@ bool DequantizeRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     ICHECK_GE(axis, 0) << "axis " << dequantize_attrs->axis << " is out of range";
   }
 
+  // We assume per-channel dequantization if rank > 1, otherwise it's per tensor.
   PrimExpr axis_shape;
-  if (rank > 0) {
+  if ((!(scale_is_scalar && zp_is_scalar)) && (rank > 1)) {
     axis_shape = data->shape[axis];
   } else {
     axis_shape = Integer(1);

--- a/tests/python/relay/test_op_qnn_dequantize.py
+++ b/tests/python/relay/test_op_qnn_dequantize.py
@@ -128,6 +128,20 @@ def test_channelwise_axis_0():
     )
 
 
+def test_per_tensor_vector_args():
+    data = np.array([0, 1, 2, 3, 4, 251, 252, 253, 254, 255]).astype("uint8")
+    output = np.array([-63.5, -63, -62.5, -62, -61.5, 62, 62.5, 63, 63.5, 64]).astype("float32")
+
+    quant_args = {
+        "in_zero_point": np.array([127]).astype("int32"),
+        "in_scale": np.array([0.5]).astype("float32"),
+    }
+
+    dequantize_test_driver(
+        in_dtype="uint8", quant_args=quant_args, in_data=data, verify_output_data=output, axis=-1
+    )
+
+
 def test_dynamic_dequantize():
     x = relay.var("x", shape=(1, 2, 3, 4), dtype="int8")
     scale_var = relay.var("scale", shape=(), dtype="float32")


### PR DESCRIPTION
The type checker fails with:
```
data = relay.const(np.ones(16, dtype="int8"))
scale = relay.const(np.ones(1, dtype="float32"))
zp = relay.const(np.ones(1, dtype="int32"))
op = relay.qnn.op.dequantize(data, scale, zp) 

print(relay.transform.InferType()(tvm.ir.IRModule.from_expr(op)))
```
This PR provides a fix.
