### PR TITLE
RPCModule get function by searching a symbol recursively

### DIFF
--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -179,7 +179,7 @@ class RPCModuleNode final : public ModuleNode {
       return WrapRemoteFunc(sess_->GetFunction(name));
     } else {
       InitRemoteFunc(&remote_mod_get_function_, "tvm.rpc.server.ModuleGetFunction");
-      return remote_mod_get_function_(GetRef<Module>(this), name, false);
+      return remote_mod_get_function_(GetRef<Module>(this), name, true);
     }
   }
 


### PR DESCRIPTION
Sometimes the locally built module is wrapped as a submodule after de-serialization of the top module, while the top module is compiled from an empty llvm module to reuse the export_lib API before RPC loading. In such cases, we want to fetch the symbol from the imported modules, other than only searching in the top level.

For the concern that this modification will lead to mismatched symbol that be held by both the top module and a submodule, the symbol search process is implemented with a BFS algo., thus it will not affect the correctness as symbols in the higher level have higher priority.
