### PR TITLE
[BugFix][MetaSchedule] Fuse only serial loops in rewrite-unbound-block

### DIFF
--- a/src/meta_schedule/postproc/rewrite_unbound_block.cc
+++ b/src/meta_schedule/postproc/rewrite_unbound_block.cc
@@ -61,6 +61,11 @@ BindType GetBindType(const StmtSRef& block_sref, int* fuse_first_num) {
         i_thread_idx = i;
       }
     }
+    if (loop->kind != tir::ForKind::kSerial) {
+      if (i_multi_child == -1) {
+        i_multi_child = i;
+      }
+    }
     if (!IsSingleStmt(loop->body)) {
       if (i_multi_child == -1) {
         i_multi_child = i + 1;


### PR DESCRIPTION
The rewriting rule didn't take into consideration the case where some loops are already unrolled/vectorized/parallelized, and thus could mistakenly fuse them into outer loops. For example,

```python
@T.prim_func
def before_unrolled_loop(
    placeholder: T.Buffer[(1, 56, 56, 64), "float32"],
) -> None:
    # function attr dict
    T.func_attr({"global_symbol": "main", "tir.noalias": True})
    bgemm = T.alloc_buffer([6, 6, 196, 64], dtype="float32")
    inverse = T.alloc_buffer([4, 4, 196, 64], dtype="float32")
    for i2_0, i3_0, i2_1, i3_1 in T.grid(98, 4, 2, 16):
        for i0 in T.unroll(4):  # <=====
            for i1 in T.unroll(4):  # <=====
                for i4 in T.unroll(6):
                    for i5 in T.unroll(6):
                        with T.block("inverse"):
                            vh, vw = T.axis.remap("SS", [i0, i1])
                            p = T.axis.spatial(196, i2_0 * 2 + i2_1)
                            co = T.axis.spatial(64, i3_0 * 16 + i3_1)
                            r_a, r_b = T.axis.remap("RR", [i4, i5])
                            T.reads(bgemm[r_a, r_b, p, co])
                            T.writes(inverse[vh, vw, p, co])
                            with T.init():
                                inverse[vh, vw, p, co] = T.float32(0)
                            inverse[vh, vw, p, co] = inverse[vh, vw, p, co] + bgemm[r_a, r_b, p, co]
```

The loop i0 and i1 will be fused into the outer 4 loops under the rewriting rule, which could lead to potential bugs and performance issue.

CC: @jinhongyii @zxybazh 

