### PR TITLE
[MetaSchedule][BugFix] Fix skipped tests

### DIFF
--- a/python/tvm/meta_schedule/__init__.py
+++ b/python/tvm/meta_schedule/__init__.py
@@ -15,23 +15,27 @@
 # specific language governing permissions and limitations
 # under the License.
 """Package `tvm.meta_schedule`. The meta schedule infrastructure."""
-from . import arg_info
-from . import database
-from . import builder
-from . import runner
-from . import mutator
-from . import postproc
-from . import schedule_rule
-from . import space_generator
-from . import search_strategy
-from . import integration
-from . import feature_extractor
-from . import cost_model
-from .search_strategy import (
+from . import (
+    arg_info,
+    builder,
+    cost_model,
+    database,
+    feature_extractor,
+    integration,
+    mutator,
+    postproc,
+    runner,
+    schedule_rule,
+    search_strategy,
+    space_generator,
+)
+from .search_strategy import MeasureCandidate
+from .tune import (
     EvolutionarySearchConfig,
-    MeasureCandidate,
     ReplayFuncConfig,
     ReplayTraceConfig,
+    tune_relay,
+    tune_te,
+    tune_tir,
 )
-from .tune import tune_te, tune_tir, tune_relay
 from .tune_context import TuneContext

--- a/python/tvm/meta_schedule/search_strategy/__init__.py
+++ b/python/tvm/meta_schedule/search_strategy/__init__.py
@@ -20,7 +20,7 @@ Meta Schedule search strategy utilizes the design spaces given
 to generate measure candidates.
 """
 
-from .search_strategy import SearchStrategy, PySearchStrategy, MeasureCandidate
-from .replay_trace import ReplayTrace, ReplayTraceConfig
-from .replay_func import ReplayFunc, ReplayFuncConfig
-from .evolutionary_search import EvolutionarySearch, EvolutionarySearchConfig
+from .evolutionary_search import EvolutionarySearch
+from .replay_func import ReplayFunc
+from .replay_trace import ReplayTrace
+from .search_strategy import MeasureCandidate, PySearchStrategy, SearchStrategy

--- a/python/tvm/meta_schedule/search_strategy/evolutionary_search.py
+++ b/python/tvm/meta_schedule/search_strategy/evolutionary_search.py
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Evolutionary Search Strategy"""
-
-from typing import NamedTuple
-
 from tvm._ffi import register_object
 
 from .. import _ffi_api
@@ -87,32 +84,4 @@ class EvolutionarySearch(SearchStrategy):
             genetic_mutate_prob,
             genetic_max_fail_count,
             eps_greedy,
-        )
-
-
-class EvolutionarySearchConfig(NamedTuple):
-    """Configuration for EvolutionarySearch"""
-
-    num_trials_per_iter: int
-    max_trials_per_task: int
-    max_trials_global: int
-    population_size: int = 2048
-    init_measured_ratio: float = 0.2
-    init_min_unmeasured: int = 50
-    genetic_num_iters: int = 4
-    genetic_mutate_prob: float = 0.85
-    genetic_max_fail_count: int = 10
-    eps_greedy: float = 0.05
-
-    def create_strategy(self) -> EvolutionarySearch:
-        return EvolutionarySearch(
-            num_trials_per_iter=self.num_trials_per_iter,
-            max_trials_per_task=self.max_trials_per_task,
-            population_size=self.population_size,
-            init_measured_ratio=self.init_measured_ratio,
-            init_min_unmeasured=self.init_min_unmeasured,
-            genetic_num_iters=self.genetic_num_iters,
-            genetic_mutate_prob=self.genetic_mutate_prob,
-            genetic_max_fail_count=self.genetic_max_fail_count,
-            eps_greedy=self.eps_greedy,
         )

--- a/python/tvm/meta_schedule/search_strategy/replay_func.py
+++ b/python/tvm/meta_schedule/search_strategy/replay_func.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Replay Trace Search Strategy"""
-from typing import NamedTuple
-
 from tvm._ffi import register_object
 
 from .. import _ffi_api
@@ -34,7 +32,7 @@ class ReplayFunc(SearchStrategy):
     num_trials_per_iter : int
         Number of trials per iteration.
     max_trials_per_task : int
-        Total number of trials.
+        Total number of trials for one task
     """
 
     num_trials_per_iter: int
@@ -51,14 +49,3 @@ class ReplayFunc(SearchStrategy):
             num_trials_per_iter,
             max_trials_per_task,
         )
-
-
-class ReplayFuncConfig(NamedTuple):
-    """Configuration for ReplayFunc"""
-
-    num_trials_per_iter: int
-    max_trials_per_task: int
-    max_trials_global: int
-
-    def create_strategy(self) -> ReplayFunc:
-        return ReplayFunc(self.num_trials_per_iter, self.max_trials_per_task)

--- a/python/tvm/meta_schedule/search_strategy/replay_trace.py
+++ b/python/tvm/meta_schedule/search_strategy/replay_trace.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Replay Trace Search Strategy"""
-from typing import NamedTuple
-
 from tvm._ffi import register_object
 
 from .. import _ffi_api
@@ -34,7 +32,7 @@ class ReplayTrace(SearchStrategy):
     num_trials_per_iter : int
         Number of trials per iteration.
     max_trials_per_task : int
-        Total number of trials.
+        Total number of trials for one task
     """
 
     num_trials_per_iter: int
@@ -47,14 +45,3 @@ class ReplayTrace(SearchStrategy):
             num_trials_per_iter,
             max_trials_per_task,
         )
-
-
-class ReplayTraceConfig(NamedTuple):
-    """Configuration for ReplayTrace"""
-
-    num_trials_per_iter: int
-    max_trials_per_task: int
-    max_trials_global: int
-
-    def create_strategy(self) -> ReplayTrace:
-        return ReplayTrace(self.num_trials_per_iter, self.max_trials_per_task)

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -18,7 +18,7 @@
 # pylint: disable=import-outside-toplevel
 import logging
 import os.path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from tvm._ffi.registry import register_func
 from tvm.ir import IRModule, structural_hash
@@ -40,11 +40,7 @@ from .mutator import Mutator
 from .postproc import Postproc
 from .runner import LocalRunner, Runner
 from .schedule_rule import ScheduleRule
-from .search_strategy import (
-    EvolutionarySearchConfig,
-    ReplayFuncConfig,
-    ReplayTraceConfig,
-)
+from .search_strategy import EvolutionarySearch, ReplayFunc, ReplayTrace
 from .space_generator import PostOrderApply, SpaceGenerator
 from .task_scheduler import GradientBased, TaskScheduler
 from .tune_context import TuneContext
@@ -52,11 +48,6 @@ from .utils import autotvm_silencer
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-SearchStrategyConfig = Union[
-    ReplayFuncConfig,
-    ReplayTraceConfig,
-    EvolutionarySearchConfig,
-]
 FnSpaceGenerator = Callable[[], SpaceGenerator]
 FnScheduleRule = Callable[[], List[ScheduleRule]]
 FnPostproc = Callable[[], List[Postproc]]
@@ -72,6 +63,107 @@ FnTaskScheduler = Callable[
         List[MeasureCallback],
     ],
     TaskScheduler,
+]
+
+
+class ReplayFuncConfig(NamedTuple):
+    """Configuration for ReplayFunc
+
+    Parameters
+    ----------
+    num_trials_per_iter : int
+        Number of trials per iteration.
+    max_trials_per_task : int
+        Total number of trials for one task
+    max_trials_global : int
+        Total number of trials for all tasks in the task scheduler
+    """
+
+    num_trials_per_iter: int
+    max_trials_per_task: int
+    max_trials_global: int
+
+    def create_strategy(self) -> ReplayFunc:
+        return ReplayFunc(self.num_trials_per_iter, self.max_trials_per_task)
+
+
+class ReplayTraceConfig(NamedTuple):
+    """Configuration for ReplayTrace
+
+    Parameters
+    ----------
+    num_trials_per_iter : int
+        Number of trials per iteration.
+    max_trials_per_task : int
+        Total number of trials for one task
+    max_trials_global : int
+        Total number of trials for all tasks in the task scheduler
+    """
+
+    num_trials_per_iter: int
+    max_trials_per_task: int
+    max_trials_global: int
+
+    def create_strategy(self) -> ReplayTrace:
+        return ReplayTrace(self.num_trials_per_iter, self.max_trials_per_task)
+
+
+class EvolutionarySearchConfig(NamedTuple):
+    """Configuration for EvolutionarySearch
+
+    Parameters
+    ----------
+    num_trials_per_iter : int
+        Number of trials per iteration.
+    max_trials_per_task : int
+        Total number of trials.
+    max_trials_global : int
+        Total number of trials for all tasks in the task scheduler
+    population_size : int
+        The initial population of traces from measured samples and randomly generated samples.
+    init_measured_ratio : int
+        The ratio of measured samples in the initial population.
+    init_min_unmeasured : int
+        The minimal size of unmeasured population in the initial sampling.
+    genetic_num_iters : int
+        The number of iterations for genetic algorithm.
+    genetic_mutate_prob : float
+        The probability of mutation.
+    genetic_max_fail_count : int
+        The maximum number to retry mutation.
+    eps_greedy : float
+        The ratio of greedy selected samples in the final picks.
+    """
+
+    num_trials_per_iter: int
+    max_trials_per_task: int
+    max_trials_global: int
+    population_size: int = 2048
+    init_measured_ratio: float = 0.2
+    init_min_unmeasured: int = 50
+    genetic_num_iters: int = 4
+    genetic_mutate_prob: float = 0.85
+    genetic_max_fail_count: int = 10
+    eps_greedy: float = 0.05
+
+    def create_strategy(self) -> EvolutionarySearch:
+        return EvolutionarySearch(
+            num_trials_per_iter=self.num_trials_per_iter,
+            max_trials_per_task=self.max_trials_per_task,
+            population_size=self.population_size,
+            init_measured_ratio=self.init_measured_ratio,
+            init_min_unmeasured=self.init_min_unmeasured,
+            genetic_num_iters=self.genetic_num_iters,
+            genetic_mutate_prob=self.genetic_mutate_prob,
+            genetic_max_fail_count=self.genetic_max_fail_count,
+            eps_greedy=self.eps_greedy,
+        )
+
+
+SearchStrategyConfig = Union[
+    ReplayFuncConfig,
+    ReplayTraceConfig,
+    EvolutionarySearchConfig,
 ]
 
 

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -149,6 +149,7 @@ def test_meta_schedule_tune_relay(
             config=ReplayTraceConfig(
                 num_trials_per_iter=32,
                 max_trials_per_task=32,
+                max_trials_global=20000,
             ),
             work_dir=work_dir,
             database=JSONDatabase(
@@ -493,7 +494,8 @@ def manual_tir_common(do_tune=False):
         if do_tune:
             config = ReplayTraceConfig(
                 num_trials_per_iter=64,
-                num_trials_total=64,
+                max_trials_per_task=64,
+                max_trials_global=20000,
             )
             # postprocs=lambda: [] is important to prevent default post processors from
             # tampering with the manual schedule.

--- a/tests/python/unittest/test_meta_schedule_tune_te.py
+++ b/tests/python/unittest/test_meta_schedule_tune_te.py
@@ -37,6 +37,7 @@ def test_tune_matmul():
             config=ReplayTraceConfig(
                 num_trials_per_iter=32,
                 max_trials_per_task=32,
+                max_trials_global=32,
             ),
             work_dir=work_dir,
         )

--- a/tests/python/unittest/test_meta_schedule_tune_tir.py
+++ b/tests/python/unittest/test_meta_schedule_tune_tir.py
@@ -20,10 +20,9 @@ import tempfile
 
 import pytest
 import tvm
-from tvm.meta_schedule import ReplayTraceConfig, postproc, schedule_rule, tune_tir
+from tvm.meta_schedule import ReplayTraceConfig, schedule_rule, tune_tir
 from tvm.meta_schedule.space_generator import PostOrderApply
 from tvm.meta_schedule.testing import te_workload
-from tvm.meta_schedule.tune_context import TuneContext
 from tvm.script import tir as T
 from tvm.target.target import Target
 from tvm.te.operation import create_prim_func
@@ -61,6 +60,7 @@ def test_tune_matmul_cpu():
             config=ReplayTraceConfig(
                 num_trials_per_iter=32,
                 max_trials_per_task=32,
+                max_trials_global=32,
             ),
             work_dir=work_dir,
         )
@@ -80,6 +80,7 @@ def test_tune_matmul_cuda():
             config=ReplayTraceConfig(
                 num_trials_per_iter=32,
                 max_trials_per_task=32,
+                max_trials_global=32,
             ),
             work_dir=work_dir,
         )
@@ -98,6 +99,7 @@ def test_tune_matmul_cuda_tensor_core():
     config = ReplayTraceConfig(
         num_trials_per_iter=32,
         max_trials_per_task=320,
+        max_trials_global=320,
     )
 
     class DefaultTensorCore:


### PR DESCRIPTION
After https://github.com/apache/tvm/pull/10366 is merged, all the search configurations (`EvolutionarySearchConfig`, `ReplayFuncConfig`, `ReplayTraceConfig`) are updated with a new field `max_trials_global` to be consistent with AutoScheduler's gradient-based task scheduler, which allows users to control the total number of trials of a model, while the scheduler distribute them unevenly according to task importance. This PR fixes the test cases that are not updated with this change, which are left undetected previously because they are not run in the CI.

For example, when tuning BERT-base, we could set `max_trials_global` to `20000`, and the task scheduler will distribute trials to each task by preferring tasks with more potential performance growth:

```
 ID |                                                              Name |      FLOP | Weight | Speed (GFLOPS) | Latency (us) | Weighted Latency (us) | Trials | Terminated
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  0 |                                                        fused_take |         1 |      1 |         0.0005 |       2.1504 |                2.1504 |      5 |          Y
  1 |                                      fused_nn_dense_add_fast_tanh |   1204224 |      1 |       139.7438 |       8.6174 |                8.6174 |    192 |          Y
  2 |                       fused_reshape_add_reshape_transpose_reshape |     49152 |     12 |        19.5901 |       2.5090 |               30.1083 |      5 |          Y
  3 |                                                    fused_variance |    147520 |     25 |        68.8360 |       2.1431 |               53.5766 |     45 |          Y
  4 |                                                        fused_mean |     49216 |     25 |        22.8079 |       2.1578 |               53.9462 |     45 |          Y
  5 |                                               fused_cast_take_add |     49152 |      1 |        21.4777 |       2.2885 |                2.2885 |      5 |          Y
  6 |                     fused_reshape_add_reshape_transpose_reshape_1 |     49152 |     24 |        22.7076 |       2.1646 |               51.9496 |      5 |          Y
  7 |                                          fused_reshape_divide_add |     98304 |     12 |        45.9483 |       2.1394 |               25.6734 |      5 |          Y
  8 |                                             fused_nn_fast_softmax |   4374528 |     12 |      1350.8093 |       3.2384 |               38.8614 |    125 |          Y
  9 |                                                     fused_reshape |         1 |     12 |         0.0005 |       2.1827 |               26.1925 |      5 |          Y
 10 |                                             fused_nn_batch_matmul |   6291456 |     24 |      1427.9791 |       4.4058 |              105.7403 |    960 |          Y
 11 |                                   fused_reshape_transpose_reshape |         1 |     12 |         0.0005 |       2.1435 |               25.7225 |      5 |          Y
 12 |                                                    fused_nn_dense |  75497472 |     48 |      3810.7617 |      19.8116 |              950.9591 |   7424 |
 13 |                                                   fused_reshape_1 |         1 |     24 |         0.0005 |       2.1412 |               51.3892 |      5 |          Y
 14 |                                                  fused_nn_dense_1 | 301989888 |     12 |      6289.6575 |      48.0137 |              576.1647 |   4544 |
 15 | fused_reshape_add_multiply_fast_erf_multiply_add_multiply_reshape |  15532032 |     12 |      4535.0678 |       3.4249 |               41.0985 |      5 |
 16 |                                                  fused_nn_dense_2 | 301989888 |     12 |      4206.6203 |      71.7892 |              861.4703 |   6656 |
 17 |                                             fused_reshape_add_add |     98304 |     24 |        39.9511 |       2.4606 |               59.0547 |      5 |          Y
 18 |                       fused_subtract_add_sqrt_divide_multiply_add |    196672 |     25 |        72.8936 |       2.6981 |               67.4517 |      5 |          Y
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total trials: 20046
Total latency (us): 3032.42
``` 

CC @masahi 