### PR TITLE
Fix Arduino workspace alignment

### DIFF
--- a/apps/microtvm/arduino/template_project/src/example_project/model.c
+++ b/apps/microtvm/arduino/template_project/src/example_project/model.c
@@ -25,7 +25,7 @@
 
 // AOT memory array, stack allocator wants it aligned
 static uint8_t g_aot_memory[WORKSPACE_SIZE]
-    __attribute__((aligned (TVM_RUNTIME_ALLOC_ALIGNMENT_BYTES)));
+    __attribute__((aligned(TVM_RUNTIME_ALLOC_ALIGNMENT_BYTES)));
 tvm_workspace_t app_workspace;
 
 // Blink code for debugging purposes

--- a/apps/microtvm/arduino/template_project/src/example_project/model.c
+++ b/apps/microtvm/arduino/template_project/src/example_project/model.c
@@ -23,8 +23,9 @@
 #include "standalone_crt/include/dlpack/dlpack.h"
 #include "standalone_crt/include/tvm/runtime/crt/stack_allocator.h"
 
-// AOT memory array
-static uint8_t g_aot_memory[WORKSPACE_SIZE];
+// AOT memory array, stack allocator wants it aligned
+static uint8_t g_aot_memory[WORKSPACE_SIZE]
+    __attribute__((aligned (TVM_RUNTIME_ALLOC_ALIGNMENT_BYTES)));
 tvm_workspace_t app_workspace;
 
 // Blink code for debugging purposes


### PR DESCRIPTION
The `StackMemoryManager` in the `crt` currently requires `g_aot_memory` (the AOT memory array) to be 16 byte aligned. If `g_aot_memory` is **not** 16 byte aligned, then `StackMemoryManager_Init` decreases `workspace_size` (the amount of memory we use) to resolve the issue:
https://github.com/apache/tvm/blob/2b94a7e6b19d4bba0d5e17fc5190e3da701e31db/src/runtime/crt/memory/stack_allocator.c#L89-L91

However, when the size of our AOT memory array (`WORKSPACE_SIZE`) is set, it is drawn from the MLF file to be the smallest possible value. This means that whenever `g_aot_memory` is not 16 byte aligned, the `StackMemoryManager` will decrease its size, which will cause inference to fail.

This occurs in the Arduino backend, and this PR adds code to force `g_aot_memory` to be 16 byte aligned (thus making sure `offset = 0` and solving the issue for Arduino). However, I believe this bug also effects Zephyr and Ethos. @mehrdadh added the following code to circumvent the issue for Zephyr, but I believe Ethos is vulnerable (I don't have a board, so I can't test myself)

https://github.com/apache/tvm/blob/2f937801de21757a409d9d193f43fe5c0ab5a202/tests/micro/zephyr/test_utils.py#L88-L98

I'll make a follow-up PR to fix the issue more nicely for Zephyr and Ethos (and possibly other `crt` users), and to add a unit test. However, for now I'd love to get this merged ASAP so Arduino can avoid this cryptic bug. I've [attached an Arduino sketch](https://github.com/apache/tvm/files/8403683/project.zip) (as a `.zip`) where this bug occurs - to see it happen, compile it and upload it to a Nano 33 BLE. Note that the issue might not happen on other boards/platforms where the bug exists, as if `g_aot_memory` is already 16 byte aligned, inference will work despite the bug.
