### PR TITLE
Fix submodule URLs.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "dmlc-core"]
 	path = 3rdparty/dmlc-core
-	url = https://github.com/dmlc/dmlc-core
+	url = https://github.com/dmlc/dmlc-core.git
 [submodule "dlpack"]
 	path = 3rdparty/dlpack
-	url = https://github.com/dmlc/dlpack
+	url = https://github.com/dmlc/dlpack.git
 [submodule "3rdparty/rang"]
 	path = 3rdparty/rang
-	url = https://github.com/agauniyal/rang
+	url = https://github.com/agauniyal/rang.git
 [submodule "3rdparty/vta-hw"]
 	path = 3rdparty/vta-hw
-	url = https://github.com/apache/incubator-tvm-vta
+	url = https://github.com/apache/tvm-vta.git
 [submodule "3rdparty/libbacktrace"]
 	path = 3rdparty/libbacktrace
 	url = https://github.com/tlc-pack/libbacktrace.git
 [submodule "3rdparty/cutlass"]
 	path = 3rdparty/cutlass
-	url = https://github.com/NVIDIA/cutlass
+	url = https://github.com/NVIDIA/cutlass.git


### PR DESCRIPTION
- Add `.git` suffix.
- Remove incubator prefix.