### PR TITLE
Update Docker images with TF 2.6 and pyxir update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,13 +46,13 @@
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:v0.69'
-ci_gpu = 'tlcpack/ci-gpu:v0.83'
-ci_cpu = 'tlcpack/ci-cpu:v0.82'
-ci_wasm = 'tlcpack/ci-wasm:v0.72'
-ci_i386 = 'tlcpack/ci-i386:v0.75'
-ci_qemu = 'tlcpack/ci-qemu:v0.12'
-ci_arm = 'tlcpack/ci-arm:v0.08'
+ci_lint = 'tlcpack/ci-lint:v0.70'
+ci_gpu = 'tlcpack/ci-gpu:v0.84'
+ci_cpu = 'tlcpack/ci-cpu:v0.83'
+ci_wasm = 'tlcpack/ci-wasm:v0.73'
+ci_i386 = 'tlcpack/ci-i386:v0.76'
+ci_qemu = 'tlcpack/ci-qemu:v0.13'
+ci_arm = 'tlcpack/ci-arm:v0.09'
 ci_hexagon = 'tlcpack/ci-hexagon:v0.02'
 // <--- End of regex-scanned config.
 

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -48,13 +48,13 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 {% import 'jenkins/macros.j2' as m with context -%}
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:v0.69'
-ci_gpu = 'tlcpack/ci-gpu:v0.83'
-ci_cpu = 'tlcpack/ci-cpu:v0.82'
-ci_wasm = 'tlcpack/ci-wasm:v0.72'
-ci_i386 = 'tlcpack/ci-i386:v0.75'
-ci_qemu = 'tlcpack/ci-qemu:v0.12'
-ci_arm = 'tlcpack/ci-arm:v0.08'
+ci_lint = 'tlcpack/ci-lint:v0.70'
+ci_gpu = 'tlcpack/ci-gpu:v0.84'
+ci_cpu = 'tlcpack/ci-cpu:v0.83'
+ci_wasm = 'tlcpack/ci-wasm:v0.73'
+ci_i386 = 'tlcpack/ci-i386:v0.76'
+ci_qemu = 'tlcpack/ci-qemu:v0.13'
+ci_arm = 'tlcpack/ci-arm:v0.09'
 ci_hexagon = 'tlcpack/ci-hexagon:v0.02'
 // <--- End of regex-scanned config.
 


### PR DESCRIPTION
Updates docker image with tlcpackstaging 20220404-055909-fcdf4636d to update TensorFlow to 2.6 and solve Vitis-AI build fixes caused by an allocation error from TensorFlow 2.6.

Also updates Keras, h5py and pyxir.

Validation results with this images: https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdocker-image-run-tests/detail/docker-image-run-tests/82/pipeline

`ci_hexagon` is intentionally left out of this update due to https://github.com/tlc-pack/tlcpack/issues/103 (cc @mehrdadh)


cc @driazati @areusch @manupa-arm @Mousius @jtuyls 

Closes #10696