### PR TITLE
[TVMScript] Fixing T.buffer with typed positional arguments other than int32

### DIFF
--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -56,6 +56,9 @@ class ConcreteType(TypeGeneric):  # pylint: disable=too-few-public-methods, abst
         else:
             self.type = tvm.ir.PrimType(vtype)
 
+    def __call__(self, *args):
+        pass
+
     def evaluate(self):
         return self.type
 

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -56,7 +56,7 @@ class ConcreteType(TypeGeneric):  # pylint: disable=too-few-public-methods, abst
         else:
             self.type = tvm.ir.PrimType(vtype)
 
-    def __call__(self, *args):
+    def __call__(self, *args):  # pylint: disable=arguments-differ
         pass
 
     def evaluate(self):

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -577,6 +577,9 @@ bool TVMScriptPrinter::IsSimpleBuffer(const Buffer& buf) {
     return false;
   }
   for (const PrimExpr& shp_i : buf->shape) {
+    if (shp_i.dtype() != DataType::Int(32)) {
+      return false;
+    }
     if (!UndefinedVars(shp_i).empty()) {
       return false;
     }

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -577,9 +577,6 @@ bool TVMScriptPrinter::IsSimpleBuffer(const Buffer& buf) {
     return false;
   }
   for (const PrimExpr& shp_i : buf->shape) {
-    if (shp_i.dtype() != DataType::Int(32)) {
-      return false;
-    }
     if (!UndefinedVars(shp_i).empty()) {
       return false;
     }

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -196,11 +196,26 @@ def match_buffer_int64(a: T.handle, c: T.handle) -> None:
             C[vi, vj] = B[vi, vj] + 1.0
 
 
+@T.prim_func
+def match_buffer_int64_after_roundtrip(
+    A: T.Buffer[(T.int64(128), T.int64(128)), "float32"],
+    C: T.Buffer[(T.int64(128), T.int64(128)), "float32"],
+) -> None:
+    B = T.alloc_buffer((T.int64(128), T.int64(128)), dtype="float32")
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            B[vi, vj] = A[vi, vj] * 2.0
+    for i, j in T.grid(T.int64(128), T.int64(128)):
+        with T.block("C"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            C[vi, vj] = B[vi, vj] + 1.0
+
+
 def test_match_buffer_int64():
     original = match_buffer_int64
-    after_roundtrip = from_source(original.script(show_meta=True))
-    after_roundtrip_back = from_source(after_roundtrip.script(show_meta=True))
-    assert_structural_equal(after_roundtrip, after_roundtrip_back, True)
+    after_roundtrip = match_buffer_int64_after_roundtrip
+    assert_structural_equal(original, after_roundtrip, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a temporary fix for python not handling this case `T.Buffer[(T.int64(xx), T.int64(xx)), "float32"]` well. For now, `TVMScriptPrinter` will not print `match_buffer` with syntax sugar if the `shape` argument is typed other than `int32`.

Root cause of this behavior is that we defined `T.Buffer` as `__getitem__(self, args)` in which `args` is a list of all arguments. But adding `T.int64` to the list will make Python think there is more than one positional arguments and raise a TypeError. TVMScript with such semantics could actually pass our parser check but not the type checker of Python, meaning only handwritten script with typed args in  `T.buffer` will raise this error.

@MasterJH5574 @vinx13 @junrushao1994 