### PR TITLE
[skip ci][ci] Fix black version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:v0.70'
+ci_lint = 'tlcpack/ci-lint:v0.69'
 ci_gpu = 'tlcpack/ci-gpu:v0.84'
 ci_cpu = 'tlcpack/ci-cpu:v0.83'
 ci_wasm = 'tlcpack/ci-wasm:v0.73'
@@ -214,6 +214,10 @@ stage('Sanity Check') {
           script: './tests/scripts/git_change_docker.sh',
           label: 'Check for any docker changes',
         )
+        if (skip_ci) {
+          // Don't rebuild when skipping CI
+          rebuild_docker_images = false
+        }
         if (rebuild_docker_images) {
           // Exit before linting so we can use the newly created Docker images
           // to run the lint

--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -32,7 +32,7 @@ RUN pip config set global.no-cache-dir false
 
 RUN apt-get update && apt-get install -y doxygen graphviz curl shellcheck
 
-RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==20.8b1 flake8==3.9.2
+RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==22.3.0 flake8==3.9.2
 
 # Rust env (build early; takes a while)
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -48,7 +48,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 {% import 'jenkins/macros.j2' as m with context -%}
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:v0.70'
+ci_lint = 'tlcpack/ci-lint:v0.69'
 ci_gpu = 'tlcpack/ci-gpu:v0.84'
 ci_cpu = 'tlcpack/ci-cpu:v0.83'
 ci_wasm = 'tlcpack/ci-wasm:v0.73'
@@ -211,6 +211,10 @@ stage('Sanity Check') {
           script: './tests/scripts/git_change_docker.sh',
           label: 'Check for any docker changes',
         )
+        if (skip_ci) {
+          // Don't rebuild when skipping CI
+          rebuild_docker_images = false
+        }
         if (rebuild_docker_images) {
           // Exit before linting so we can use the newly created Docker images
           // to run the lint

--- a/tests/lint/git-black.sh
+++ b/tests/lint/git-black.sh
@@ -47,7 +47,8 @@ if [ ! -x "$(command -v black)" ]; then
 fi
 
 # Print out specific version
-echo "Version Information: $(black --version)"
+VERSION=$(black --version)
+echo "black version: $VERSION"
 
 # Compute Python files which changed to compare.
 IFS=$'\n' read -a FILES -d'\n' < <(git diff --name-only --diff-filter=ACMRTUX $1 -- "*.py" "*.pyi") || true

--- a/tests/lint/python_format.sh
+++ b/tests/lint/python_format.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
+set -eux
 
 ./tests/lint/git-black.sh HEAD~1
 ./tests/lint/git-black.sh origin/main


### PR DESCRIPTION
See https://github.com/psf/black/issues/2964, this is broken in CI now after the update in c2744704bec3cc914fa96dc4f4c9b0ccfaa8ace4. This rolls back the Docker change and includes a fix for when we update to `ci_lint:v0.71`

cc @areusch @leandron 
