### PR TITLE
[RUNTIME] Api to get number of runtime threads

### DIFF
--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -140,6 +140,12 @@ void ResetThreadPool();
 void Configure(tvm::runtime::threading::ThreadGroup::AffinityMode mode, int nthreads,
                std::vector<unsigned int> cpus);
 
+/*!
+ * \brief Get the number of threads being used by the TVM runtime
+ * \returns The number of threads used.
+ */
+int32_t NumThreads();
+
 }  // namespace threading
 }  // namespace runtime
 }  // namespace tvm

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -21,7 +21,7 @@ from .packed_func import PackedFunc
 from .object import Object
 from .object_generic import ObjectGeneric, ObjectTypes
 from .ndarray import NDArray, DataType, DataTypeCode, Device
-from .module import Module
+from .module import Module, num_threads
 from .profiling import Report
 
 # function exposures

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -574,4 +574,15 @@ def enabled(target):
     return _ffi_api.RuntimeEnabled(target)
 
 
+def num_threads() -> int:
+    """Get the number of threads in use by the TVM runtime.
+
+    Returns
+    -------
+    int
+        Number of threads in use.
+    """
+    return _ffi_api.NumThreads()
+
+
 _set_class_module(Module)

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -329,6 +329,8 @@ class ThreadPool {
     num_workers_used_ = std::min(num_workers_, num_workers_used_);
   }
 
+  int32_t NumThreads() const { return num_workers_used_; }
+
  private:
   // Shared initialization code
   void Init() {
@@ -391,6 +393,10 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool").set_body([](TVMArgs args, TVMRe
   threading::Configure(mode, nthreads, cpus);
 });
 
+TVM_REGISTER_GLOBAL("runtime.NumThreads").set_body_typed([]() -> int32_t {
+  return threading::NumThreads();
+});
+
 namespace threading {
 void ResetThreadPool() { tvm::runtime::ThreadPool::ThreadLocal()->Reset(); }
 /*!
@@ -406,6 +412,7 @@ void Configure(tvm::runtime::threading::ThreadGroup::AffinityMode mode, int nthr
   tvm::runtime::threading::SetMaxConcurrency(cpus.size());
   tvm::runtime::ThreadPool::ThreadLocal()->UpdateWorkerConfiguration(mode, nthreads, cpus);
 }
+int32_t NumThreads() { return tvm::runtime::ThreadPool::ThreadLocal()->NumThreads(); }
 }  // namespace threading
 }  // namespace runtime
 }  // namespace tvm

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -684,8 +684,8 @@ def test_num_threads():
     elif omp_env_threads is not None:
         assert reported == omp_env_threads
     else:
-        hardware_threads = os.cpu_count() / 2
-        assert reported == hardware_threads
+        hardware_threads = os.cpu_count()
+        assert reported == hardware_threads or reported == hardware_threads // 2
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_runtime_module_based_interface.py
+++ b/tests/python/unittest/test_runtime_module_based_interface.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import numpy as np
+import os
 from tvm import relay, runtime
 from tvm.relay import testing
 import tvm
@@ -672,6 +673,19 @@ def test_multiple_imported_modules():
     module_main.import_module(module_b)
     module_main.get_function("func_a", query_imports=True)
     module_main.get_function("func_b", query_imports=True)
+
+
+def test_num_threads():
+    reported = tvm.runtime.num_threads()
+    env_threads = os.getenv("TVM_NUM_THREADS")
+    omp_env_threads = os.getenv("OMP_NUM_THREADS")
+    if env_threads is not None:
+        assert reported == env_threads
+    elif omp_env_threads is not None:
+        assert reported == omp_env_threads
+    else:
+        hardware_threads = os.cpu_count() / 2
+        assert reported == hardware_threads
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `tvm::runtime::threading::NumThreads` and `tvm.runtime.num_threads` as a way to get the number of threads in use by the TVM runtime.

@jwfromm @masahi 
