### PR TITLE
[Hexagon] Use single allocation to back 2-d arrays

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -151,16 +151,19 @@ HexagonBuffer::HexagonBuffer(size_t nallocs, size_t nbytes, size_t alignment,
     : ndim_(2), nbytes_per_allocation_(nbytes) {
   SetStorageScope(scope);
 
+  size_t nbytes_aligned = ((nbytes + (alignment - 1)) / alignment) * alignment;
+  size_t nbytes_monolithic = nallocs * nbytes_aligned;
+
   std::unique_ptr<Allocation> alloca = nullptr;
   if (GetStorageScope() == StorageScope::kDDR) {
-    alloca = Allocator<StorageScope::kDDR>(nallocs * nbytes, alignment);
+    alloca = Allocator<StorageScope::kDDR>(nbytes_monolithic, alignment);
   } else if (GetStorageScope() == StorageScope::kVTCM) {
-    alloca = Allocator<StorageScope::kVTCM>(nallocs * nbytes, alignment);
+    alloca = Allocator<StorageScope::kVTCM>(nbytes_monolithic, alignment);
   }
   CHECK(alloca) << "could not create allocation";
 
   for (size_t i = 0; i < nallocs; ++i) {
-    void* alloc_offset = static_cast<unsigned char*>(alloca->data_) + i * nbytes;
+    void* alloc_offset = static_cast<unsigned char*>(alloca->data_) + i * nbytes_aligned;
     allocations_.push_back(alloc_offset);
   }
 


### PR DESCRIPTION
Currently, each allocation allocates an entire page, so even a relatively small number of allocations can use very large amounts of VTCM.  This commit changes calls to `AllocVtcmWorkspace` of shape `[N,M]` from performing `N` allocations of size `M`, to 1 allocation of size `N*M`.  Since `N` is usually much smaller than a page, this reduces the total amount of memory required.

This is an intermediate step, where the long-term solution is to use static planning for VTCM allocations.  This returns the same `void**` type as the static planning eventually will, but avoids excess memory use in the meantime.