### PR TITLE
[Hexagon] Add unit tests executing 2-d VTCM usage

### DIFF
--- a/tests/python/contrib/test_hexagon/infrastructure.py
+++ b/tests/python/contrib/test_hexagon/infrastructure.py
@@ -22,6 +22,40 @@ from tvm import te
 import numpy
 
 
+def allocate_hexagon_array(
+    dev, tensor_shape=None, dtype=None, data=None, axis_separators=None, mem_scope=None
+):
+    if tensor_shape is None:
+        assert data is not None, "Must provide either tensor shape or numpy data array"
+        tensor_shape = data.shape
+    elif data is not None:
+        assert (
+            tensor_shape == data.shape
+        ), "Mismatch between provided tensor shape and numpy data array shape"
+
+    if dtype is None:
+        assert data is not None, "Must provide either dtype or numpy data array"
+        dtype = data.dtype.name
+    elif data is not None:
+        assert dtype == data.dtype, "Mismatch between provided dtype and numpy data array dtype"
+
+    if axis_separators is None:
+        axis_separators = []
+
+    boundaries = [0, *axis_separators, len(tensor_shape)]
+    physical_shape = [
+        numpy.prod(tensor_shape[dim_i:dim_f])
+        for dim_i, dim_f in zip(boundaries[:-1], boundaries[1:])
+    ]
+
+    arr = tvm.nd.empty(physical_shape, dtype=dtype, device=dev)
+
+    if data is not None:
+        arr.copyfrom(data.reshape(physical_shape))
+
+    return arr._create_view(tensor_shape)
+
+
 def ceildiv(o, d):
     assert o >= 0
     assert d >= 0

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -29,38 +29,45 @@ import tvm
 import tvm.testing
 from tvm import te
 from tvm.tir.stmt_functor import post_order_visit
+from tvm.contrib.hexagon.build import HexagonLauncher
 
 from .conftest import requires_hexagon_toolchain
+from .infrastructure import allocate_hexagon_array
 
 # Needed to register the link_shared packedfunc.
 import tvm.contrib.hexagon
 
 
 dtype = tvm.testing.parameter("int8")
-batch_size = tvm.testing.parameter(16)
-input_channels = tvm.testing.parameter(32)
-output_channels = tvm.testing.parameter(32)
-input_image_shape = tvm.testing.parameter((64, 64))
-filter_size = tvm.testing.parameter((5, 5))
+batch_size = tvm.testing.parameter(
+    16,
+    2,
+)
+input_channels = tvm.testing.parameter(
+    32,
+)
+input_image_shape = tvm.testing.parameter(
+    by_dict={
+        "8x8": (8, 8),
+        "32x32": (32, 32),
+    }
+)
 
 input_layout = tvm.testing.parameter(
     "nhwc",
-    "nchw-8h8w32c",
-    "nchw-8h8w32c-flat",
-)
-working_layout = tvm.testing.parameter(
-    "nhwc",
-    "nchw-8h8w32c",
-    "nchw-8h8w32c-flat",
+    "nchw-8h8w32c-1d",
 )
 output_layout = tvm.testing.parameter(
     "nhwc",
-    "nchw-8h8w32c",
-    "nchw-8h8w32c-flat",
+    "nchw-8h8w32c-1d",
 )
-working_scope = tvm.testing.parameter(
-    "global",
-    "global.vtcm",
+working_layout, working_scope = tvm.testing.parameters(
+    ("nhwc", "global"),
+    ("nhwc", "global.vtcm"),
+    ("nchw-8h8w32c-1d", "global"),
+    ("nchw-8h8w32c-1d", "global.vtcm"),
+    # 2-d memory may only occur in vtcm memory
+    ("nchw-8h8w32c-2d", "global.vtcm"),
 )
 
 
@@ -87,9 +94,19 @@ def input_shape(batch_size, input_channels, input_image_shape):
 def transform_shape(shape, layout):
     if layout == "nhwc":
         return shape
-    elif layout in ["nchw-8h8w32c", "nchw-8h8w32c-flat"]:
+    elif layout in ["nchw-8h8w32c-1d", "nchw-8h8w32c-2d"]:
         N, H, W, C = shape
         return [N, (C + 31) // 32, (H + 7) // 8, (W + 7) // 8, 8, 8, 32]
+    else:
+        raise RuntimeError(f"Unexpected layout '{layout}'")
+
+
+def transform_numpy(arr_np, layout):
+    if layout == "nhwc":
+        return arr_np
+    elif layout in ["nchw-8h8w32c-1d", "nchw-8h8w32c-2d"]:
+        N, H, W, C = arr_np.shape
+        return arr_np.reshape([N, H // 8, 8, W // 8, 8, C // 32, 32]).transpose(0, 5, 1, 3, 2, 4, 6)
     else:
         raise RuntimeError(f"Unexpected layout '{layout}'")
 
@@ -107,6 +124,16 @@ def transformed_output_shape(output_shape, output_layout):
 @tvm.testing.fixture
 def input_np(input_shape, dtype):
     return (100 * np.random.uniform(size=input_shape)).astype(dtype)
+
+
+@tvm.testing.fixture
+def transformed_input_np(input_np, input_layout):
+    return transform_numpy(input_np, input_layout)
+
+
+@tvm.testing.fixture
+def transformed_expected_output_np(expected_output_np, output_layout):
+    return transform_numpy(expected_output_np, output_layout)
 
 
 def layout_transform_1d(n, h, w, c):
@@ -147,7 +174,7 @@ def extract_buffers(stmt):
 
 class TestElementWise:
     @tvm.testing.fixture
-    def output_np(self, input_np):
+    def expected_output_np(self, input_np):
         return 2 * input_np
 
     @tvm.testing.fixture
@@ -167,7 +194,7 @@ class TestElementWise:
         InputTensor = te.placeholder(input_shape, dtype, name="Input")
         OutputTensor = te.compute(
             shape=InputTensor.shape,
-            fcompute=lambda *indices: 2 * InputTensor[indices],
+            fcompute=lambda *indices: (2 * InputTensor[indices]).astype(dtype),
             name="Output",
         )
         schedule = te.create_schedule(OutputTensor.op)
@@ -178,10 +205,10 @@ class TestElementWise:
         def apply_transform(tensor, layout):
             if layout == "nhwc":
                 pass
-            elif layout == "nchw-8h8w32c":
-                return schedule[tensor].transform_layout(layout_transform_2d)
-            elif layout == "nchw-8h8w32c-flat":
+            elif layout == "nchw-8h8w32c-1d":
                 return schedule[tensor].transform_layout(layout_transform_1d)
+            elif layout == "nchw-8h8w32c-2d":
+                return schedule[tensor].transform_layout(layout_transform_2d)
             else:
                 raise RuntimeError(f"Unexpected layout '{layout}'")
 
@@ -207,7 +234,7 @@ class TestElementWise:
     def uses_unsupported_physical_dimensions(
         self, target_host, input_layout, working_layout, output_layout
     ):
-        uses_2d_memory = "nchw-8h8w32c" in [input_layout, working_layout, output_layout]
+        uses_2d_memory = "nchw-8h8w32c-2d" in [input_layout, working_layout, output_layout]
         can_handle_2d_memory = target_host.kind.name == "hexagon"
 
         return uses_2d_memory and not can_handle_2d_memory
@@ -234,8 +261,8 @@ class TestElementWise:
 
             expected_physical_dimensions = {
                 "nhwc": 1,
-                "nchw-8h8w32c": 2,
-                "nchw-8h8w32c-flat": 1,
+                "nchw-8h8w32c-1d": 1,
+                "nchw-8h8w32c-2d": 2,
             }[buffer_layout]
 
             assert len(buffer.shape) == expected_physical_dimensions
@@ -252,11 +279,56 @@ class TestElementWise:
 
         with stack:
             is_hexagon = target_host.kind.name == "hexagon"
-            uses_2d_memory = "nchw-8h8w32c" in [input_layout, working_layout, output_layout]
+            uses_2d_memory = "nchw-8h8w32c-2d" in [input_layout, working_layout, output_layout]
             if uses_2d_memory and not is_hexagon:
                 stack.enter_context(pytest.raises(tvm.TVMError))
 
             tvm.build(*schedule_args, target=target_host)
+
+    @tvm.testing.fixture
+    def runtime_module(self, schedule_args, target_host):
+        if target_host.kind.name != "hexagon":
+            pytest.skip("Only running on hexagon")
+
+        return tvm.build(*schedule_args, target=target_host)
+
+    @requires_hexagon_toolchain
+    def test_execute(
+        self,
+        runtime_module,
+        transformed_input_np,
+        transformed_expected_output_np,
+        input_layout,
+        output_layout,
+        hexagon_session,
+    ):
+        if input_layout == "nchw-8h8w32c-2d":
+            input_axis_separators = [4]
+        else:
+            input_axis_separators = []
+
+        if output_layout == "nchw-8h8w32c-2d":
+            output_axis_separators = [4]
+        else:
+            output_axis_separators = []
+
+        input_arr = allocate_hexagon_array(
+            hexagon_session.device,
+            data=transformed_input_np,
+            axis_separators=input_axis_separators,
+        )
+        output_arr = allocate_hexagon_array(
+            hexagon_session.device,
+            data=np.zeros_like(transformed_expected_output_np),
+            axis_separators=output_axis_separators,
+        )
+
+        mod = hexagon_session.load_module(runtime_module)
+
+        mod(input_arr, output_arr)
+        output_np = output_arr.numpy()
+
+        np.testing.assert_array_equal(output_np, transformed_expected_output_np)
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -302,6 +302,9 @@ class TestElementWise:
         output_layout,
         hexagon_session,
     ):
+        if hexagon_session is None:
+            pytest.skip(msg="Skip hardware test, ANDROID_SERIAL_NUMBER is not set.")
+
         if input_layout == "nchw-8h8w32c-2d":
             input_axis_separators = [4]
         else:


### PR DESCRIPTION
Previously, the schedules in `test_2d_physical_buffers.py` were lowered and built into a `runtime::Module`, but were not executed.