### PR TITLE
Install gdb by default, sort packages

### DIFF
--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -22,10 +22,29 @@ set -o pipefail
 
 # install libraries for building c++ core on ubuntu
 apt-get update && apt-get install -y --no-install-recommends \
-        git make google-mock libgtest-dev cmake wget unzip libtinfo-dev libz-dev \
-        libcurl4-openssl-dev libssl-dev libopenblas-dev g++ sudo \
-        apt-transport-https graphviz pkg-config curl ninja-build parallel \
-        lsb-core
+    apt-transport-https \
+    cmake \
+    curl \
+    g++ \
+    gdb \
+    git \
+    google-mock \
+    graphviz \
+    libcurl4-openssl-dev \
+    libgtest-dev \
+    libopenblas-dev \
+    libssl-dev \
+    libtinfo-dev \
+    libz-dev \
+    lsb-core \
+    make \
+    ninja-build \
+    parallel \
+    pkg-config \
+    sudo \
+    unzip \
+    wget \
+
 
 # Get Ubuntu version
 release=$(lsb_release -r)


### PR DESCRIPTION
gdb is helpful to debug segfaults in CI problems and for local development. It's cheap, so I propose we just include it as standard.

cc @driazati @mkatanbaf