### PR TITLE
[skip ci][ci] Fix stale test in teams tagging

### DIFF
--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -605,25 +605,6 @@ def test_github_tag_teams(tmpdir_factory):
             "title": "A title",
             "number": 1234,
             "user": {
-                "login": "person6",
-            },
-            "labels": [{"name": "something"}],
-            "body": textwrap.dedent(
-                """
-                hello
-
-                something"""
-            ),
-        },
-        check="Author person6 is not opted in, quitting",
-    )
-
-    run(
-        type="ISSUE",
-        data={
-            "title": "A title",
-            "number": 1234,
-            "user": {
                 "login": "person5",
             },
             "labels": [{"name": "something"}],


### PR DESCRIPTION
This is failing in `main` but as of 8e438683a4a815ae2d5b528360ae0f111501b607 it's not used anymore https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/2989/pipeline

Tested with

```bash
python tests/scripts/ci.py cpu --tests tests/python/ci/test_ci.py
```

cc @areusch