### PR TITLE
[FQ2I] Add abs to FQ2I

### DIFF
--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -110,25 +110,13 @@ register_unary_identity("image.resize2d")
 
 
 @register_fake_quantization_to_integer("abs")
-def abs(expr, type_map):
+def abs_(expr, type_map):
+    """Rewrite an abs op"""
     assert len(expr.args) == 1
     arg = expr.args[0]
     t = type_map[arg]
 
-    if t.dtype == "int8":
-        bits = 8
-    elif t.dtype == "int16":
-        bits = 16
-    elif t.dtype == "int32":
-        bits = 32
-    elif t.dtype == "int64":
-        bits = 64
-    else:
-        raise AssertionError(
-            "Attempted to take absolute value of int with bitwidth not in [8, 16, 32, 64]"
-        )
-
-    min_value = relay.const(-(2 ** (bits - 1)), t.dtype)
+    min_value = relay.const(np.iinfo(t.dtype).min, t.dtype)
     one = relay.const(1, t.dtype)
     out = relay.op.where(relay.op.equal(min_value, arg), arg + one, arg)
     out = relay.op.abs(out)

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -107,6 +107,7 @@ register_unary_identity("nn.depth_to_space")
 register_unary_identity("max")
 register_unary_identity("min")
 register_unary_identity("image.resize2d")
+register_unary_identity("abs")
 
 
 @register_fake_quantization_to_integer("nn.adaptive_avg_pool1d")

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -107,7 +107,32 @@ register_unary_identity("nn.depth_to_space")
 register_unary_identity("max")
 register_unary_identity("min")
 register_unary_identity("image.resize2d")
-register_unary_identity("abs")
+
+
+@register_fake_quantization_to_integer("abs")
+def abs(expr, type_map):
+    assert len(expr.args) == 1
+    arg = expr.args[0]
+    t = type_map[arg]
+
+    if t.dtype == "int8":
+        bits = 8
+    elif t.dtype == "int16":
+        bits = 16
+    elif t.dtype == "int32":
+        bits = 32
+    elif t.dtype == "int64":
+        bits = 64
+    else:
+        raise AssertionError(
+            "Attempted to take absolute value of int with bitwidth not in [8, 16, 32, 64]"
+        )
+
+    min_value = relay.const(-(2 ** (bits - 1)), t.dtype)
+    one = relay.const(1, t.dtype)
+    out = relay.op.where(relay.op.equal(min_value, arg), arg + one, arg)
+    out = relay.op.abs(out)
+    return [out, t]
 
 
 @register_fake_quantization_to_integer("nn.adaptive_avg_pool1d")

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -653,27 +653,7 @@ PrimExpr abs(PrimExpr x, Span span) {
     if (px) {
       return IntImm(x.dtype(), std::abs(px->value), px->span);
     }
-
-    // Clip int minimum representable values to minimum + 1, so that the absolute
-    // value is the maximum representable value
-    int bits = x.dtype().bits();
-    int64_t min_value = 0;
-    if (bits == 8) {
-      min_value = INT8_MIN;
-    } else if (bits == 16) {
-      min_value = INT16_MIN;
-    } else if (bits == 32) {
-      min_value = INT32_MIN;
-    } else if (bits == 64) {
-      min_value = INT64_MIN;
-    } else {
-      ICHECK(false) << "Attempted to take absolute value of int with bitwidth not in "
-                    << "[8, 16, 32, 64";
-    }
-
-    auto min = make_const(x.dtype(), min_value, span);
-    auto neg_term = tir::Select(x == min, x + 1, x, span);
-    return tir::Select(x >= make_zero(x.dtype()), x, -neg_term, span);
+    return tir::Select(x >= make_zero(x.dtype()), x, -x, span);
   } else if (x.dtype().is_float()) {
     using tir::FloatImmNode;
     const FloatImmNode* fx = x.as<FloatImmNode>();

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -657,7 +657,7 @@ PrimExpr abs(PrimExpr x, Span span) {
     // Clip int minimum representable values to minimum + 1, so that the absolute
     // value is the maximum representable value
     int bits = x.dtype().bits();
-    long min_value = 0;
+    int64_t min_value = 0;
     if (bits == 8) {
       min_value = INT8_MIN;
     } else if (bits == 16) {

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -653,7 +653,27 @@ PrimExpr abs(PrimExpr x, Span span) {
     if (px) {
       return IntImm(x.dtype(), std::abs(px->value), px->span);
     }
-    return tir::Select(x >= make_zero(x.dtype()), x, -x, span);
+
+    // Clip int minimum representable values to minimum + 1, so that the absolute
+    // value is the maximum representable value
+    int bits = x.dtype().bits();
+    long min_value = 0;
+    if (bits == 8) {
+      min_value = INT8_MIN;
+    } else if (bits == 16) {
+      min_value = INT16_MIN;
+    } else if (bits == 32) {
+      min_value = INT32_MIN;
+    } else if (bits == 64) {
+      min_value = INT64_MIN;
+    } else {
+      ICHECK(false) << "Attempted to take absolute value of int with bitwidth not in "
+                    << "[8, 16, 32, 64";
+    }
+
+    auto min = make_const(x.dtype(), min_value, span);
+    auto neg_term = tir::Select(x == min, x + 1, x, span);
+    return tir::Select(x >= make_zero(x.dtype()), x, -neg_term, span);
   } else if (x.dtype().is_float()) {
     using tir::FloatImmNode;
     const FloatImmNode* fx = x.as<FloatImmNode>();

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -374,6 +374,19 @@ def test_fake_quantize_image_resize_bilinear():
     compare_fq_to_int(op, [x_np], allow_rounding_error=True)
 
 
+def test_fake_quantize_abs():
+    x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
+
+    zero = relay.const(0)
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), zero)
+    op = relay.op.abs(x)
+    op = relay.qnn.op.quantize(op, relay.const(2.0), zero)
+
+    x_np = np.random.randint(-128, 127, size=[1, 3, 224, 224], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
 def test_fake_quantize_expand_dims():
     x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
 


### PR DESCRIPTION
Adds `abs` to the FakeQuantizationToInteger pass.
Note that the FQ2I int abs implementation should not overflow, but rather clip when the absolute value of the minimum representable int value is taken. The FQ2I registration reflects this. Otherwise, in the fq2i test I was seeing abs(-128) => -128