### PR TITLE
[CMSIS-NN] Re-enabled skipped tests

### DIFF
--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -216,7 +216,6 @@ def test_conv2d_symmetric_padding_int8(
     )
 
 
-@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/10314")
 @tvm.testing.requires_cmsisnn
 @pytest.mark.parametrize("padding", ["SAME", "VALID"])
 @pytest.mark.parametrize("relu_type", ["RELU", "NONE"])
@@ -342,7 +341,6 @@ def test_conv2d_int8_tflite(ifm_shape, kernel_shape, strides, dilation, padding,
     )
 
 
-@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/10314")
 @tvm.testing.requires_cmsisnn
 @pytest.mark.parametrize("ifm_shape", [(1, 28, 28, 12), (1, 64, 100, 4)])
 @pytest.mark.parametrize("kernel_size", [(3, 3)])

--- a/tests/python/contrib/test_cmsisnn/test_fully_connected.py
+++ b/tests/python/contrib/test_cmsisnn/test_fully_connected.py
@@ -100,7 +100,6 @@ def make_model(
 
 
 @tvm.testing.requires_cmsisnn
-@pytest.mark.xfail(strict=False, reason="Flaky test: https://github.com/apache/tvm/issues/10213")
 @pytest.mark.parametrize("in_shape", [(2, 28), (1, 64)])
 @pytest.mark.parametrize("out_channels", [12, 128])
 @pytest.mark.parametrize("enable_bias", [False, True])

--- a/tests/python/contrib/test_cmsisnn/test_invalid_graphs.py
+++ b/tests/python/contrib/test_cmsisnn/test_invalid_graphs.py
@@ -78,6 +78,4 @@ def @main(%data : Tensor[(16, 29), int8]) -> Tensor[(16, 29), int8] {
         test_runner,
         interface_api,
         use_unpacked_api,
-        verbose=1,
-        test_dir="./test",
     )


### PR DESCRIPTION
After the fixes done in creating tmp dir to run FVP
tests here: https://github.com/apache/tvm/pull/10518,
it makes sense to re-enable skipped CMSIS-NN tests.

