### PR TITLE
[Relay][AST] Add WithFields for Constant and GlobalVar 

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -260,9 +260,10 @@ class GlobalVarNode : public RelayExprNode {
  */
 class GlobalVar : public RelayExpr {
  public:
-  TVM_DLL explicit GlobalVar(String name_hint, Type type = {});
+  TVM_DLL explicit GlobalVar(String name_hint, Type type = {}, Span span = {});
 
   TVM_DEFINE_OBJECT_REF_METHODS(GlobalVar, RelayExpr, GlobalVarNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(GlobalVarNode);
 };
 
 // PrimExprs that are useful as runtime containers.

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -39,6 +39,22 @@
 #include "./type.h"
 
 namespace tvm {
+
+/*!
+ * \brief Returns the global_var with given properties. A null property denotes 'no change'.
+ * Returns this if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param global_var The global var to copy
+ * \param opt_name_hint The (optional) op name of the global var
+ * \param opt_type The (optional) type for the global var
+ * \param opt_virtual_device The (optional) virtual_device for the copied constant. If none,
+ * ret_constant->virtual_device = constant->virtual_device.
+ * \param opt_span The (optional) span for the copied global var. If none,
+ * ret_constant->span = constant->span.
+ */
+GlobalVar WithFields(GlobalVar global_var, Optional<String> opt_name_hint = {},
+                     Optional<Type> opt_type = {}, Optional<VirtualDevice> opt_virtual_device = {},
+                     Optional<Span> opt_span = {});
+
 namespace relay {
 
 using Expr = tvm::RelayExpr;
@@ -97,7 +113,22 @@ class Constant : public Expr {
   TVM_DLL explicit Constant(runtime::NDArray data, Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Constant, RelayExpr, ConstantNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(ConstantNode);
 };
+
+/*!
+ * \brief Returns the constant with given properties. A null property denotes 'no change'.
+ * Returns this if all properties are unchanged. Otherwise, returns a copy with the new fields.
+ * \param constant The constant to copy
+ * \param opt_data The (optional) data for the copied constant. If none, ret_constant->data =
+ * constant->data.
+ * \param opt_virtual_device The (optional) virtual_device for the copied constant. If none,
+ * ret_constant->virtual_device = constant->virtual_device.
+ * \param opt_span The (optional) span for the copied constant. If none,
+ * ret_constant->span = constant->span.
+ */
+Constant WithFields(Constant constant, Optional<runtime::NDArray> opt_data = {},
+                    Optional<VirtualDevice> opt_virtual_device = {}, Optional<Span> opt_span = {});
 
 /*! \brief Tuple of multiple Exprs */
 class Tuple;

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -141,10 +141,11 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
       p->stream << "range(min=" << op->min << ", ext=" << op->extent << ')';
     });
 
-GlobalVar::GlobalVar(String name_hint, Type type) {
+GlobalVar::GlobalVar(String name_hint, Type type, Span span) {
   ObjectPtr<GlobalVarNode> n = make_object<GlobalVarNode>();
   n->name_hint = std::move(name_hint);
   n->checked_type_ = std::move(type);
+  n->span = std::move(span);
   data_ = std::move(n);
 }
 

--- a/tests/cpp/withfields_test.cc
+++ b/tests/cpp/withfields_test.cc
@@ -28,25 +28,25 @@ namespace tvm {
 namespace relay {
 namespace {
 
-TEST(WithFields, GlobalVar) {}
+TEST(WithFields, GlobalVar) {
+  auto tensor_type = relay::TensorType({}, DataType::Bool());
+  GlobalVar func_init("dummy_func", tensor_type, {});
+  GlobalVar func_cp = WithFields(func_init);
+  ICHECK(func_init->name_hint == func_cp->name_hint);
+  ICHECK(func_init->span == func_cp->span);
+  ICHECK(func_init->checked_type_ == func_cp->checked_type_);
+}
 
-TEST(WithFields, Constant) {}
-
-TEST(WithFields, Tuple) {}
-
-TEST(WithFields, Var) {}
-
-TEST(WithFields, Let) {}
-
-TEST(WithFields, If) {}
-
-TEST(WithFields, TupleGetItem) {}
-
-TEST(WithFields, RefCreate) {}
-
-TEST(WithFields, RefRead) {}
-
-TEST(WithFields, RefWrite) {}
+TEST(WithFields, Constant) {
+  int64_t out_channels = 64;
+  Device dev{DLDeviceType::kDLCPU, 0};
+  runtime::NDArray multiplier_nda = runtime::NDArray::Empty({out_channels}, DataType::Int(32), dev);
+  Constant constant_init(multiplier_nda, {});
+  Constant constant_cp = WithFields(constant_init);
+  ICHECK(constant_init->checked_type_ == constant_cp->checked_type_);
+  ICHECK_EQ(constant_init->data, constant_cp->data);
+  ICHECK_EQ(constant_init->span, constant_cp->span);
+}
 
 }  // namespace
 }  // namespace relay

--- a/tests/cpp/withfields_test.cc
+++ b/tests/cpp/withfields_test.cc
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <tvm/parser/parser.h>
+#include <tvm/relay/attrs/transform.h>
+#include <tvm/relay/dataflow_matcher.h>
+#include <tvm/relay/dataflow_pattern.h>
+#include <tvm/relay/function.h>
+
+namespace tvm {
+namespace relay {
+namespace {
+
+TEST(WithFields, GlobalVar) {}
+
+TEST(WithFields, Constant) {}
+
+TEST(WithFields, Tuple) {}
+
+TEST(WithFields, Var) {}
+
+TEST(WithFields, Let) {}
+
+TEST(WithFields, If) {}
+
+TEST(WithFields, TupleGetItem) {}
+
+TEST(WithFields, RefCreate) {}
+
+TEST(WithFields, RefRead) {}
+
+TEST(WithFields, RefWrite) {}
+
+}  // namespace
+}  // namespace relay
+}  // namespace tvm


### PR DESCRIPTION
Co-authored-by: Mark Shields <mbs@octoml.ai>

This PR adds `WithFields`  for Constant and GlobalVar. 
It is an addition of the original work described in #9569 and #9533 which provided support for the reminder of the relay nodes.

@mbs-octoml @mbaret 