### PR TITLE
[microNPU] Fix bug in microNPU demo app

### DIFF
--- a/apps/microtvm/ethosu/convert_image.py
+++ b/apps/microtvm/ethosu/convert_image.py
@@ -57,7 +57,8 @@ def create_headers(image_name):
     img_data = np.expand_dims(img_data, axis=0)
 
     # Create input header file
-    input_data = img_data.astype(np.int8)
+    input_data = img_data - 128
+    input_data = input_data.astype(np.int8)
     create_header_file("inputs", "ethosu_scratch", "input", input_data, "./include")
     # Create output header file
     output_data = np.zeros([1001], np.int8)

--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -162,11 +162,11 @@ curl -sS  https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorf
     -o ./labels_mobilenet_quant_v1_224.txt
 
 # Get input image
-curl -sS https://upload.wikimedia.org/wikipedia/commons/1/18/Falkland_Islands_Penguins_29.jpg -o penguin.jpg
+curl -sS https://s3.amazonaws.com/model-server/inputs/kitten.jpg -o kitten.jpg
 
 # Create C header files
 cd ..
-python3 ./convert_image.py ./build/penguin.jpg
+python3 ./convert_image.py ./build/kitten.jpg
 python3 ./convert_labels.py ./build/labels_mobilenet_quant_v1_224.txt
 
 # Build demo executable


### PR DESCRIPTION
The microNPU demo is failing to successfully classify images other than the one provided with the demo.
This PR fixes a bug in convert_image.py where the uint8 range image was cast to int8 without subtracting 128 first.
The demo is also updated to use an image that previously failed to be classified correctly but is now successfully classified.

@manupa-arm @Mousius @leandron @areusch 


cc @lhutton1