### PR TITLE
[ci][build] Use ninja instead of Makefiles

### DIFF
--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -189,7 +189,12 @@ def docker(name: str, image: str, scripts: List[str], env: Dict[str, str], inter
 
     docker_bash = REPO_ROOT / "docker" / "bash.sh"
 
-    command = [docker_bash, "-t", "--name", name]
+    command = [docker_bash]
+    if sys.stdout.isatty():
+        command.append("-t")
+
+    command.append("--name")
+    command.append(name)
     if interactive:
         command.append("-i")
         scripts = ["interact() {", "  bash", "}", "trap interact 0", ""] + scripts
@@ -286,7 +291,6 @@ def docs(
     scripts = extra_setup + [
         config + f" {build_dir}",
         f"./tests/scripts/task_build.py --build-dir {build_dir}",
-        "python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0",
     ]
 
     if skip_build:
@@ -385,9 +389,6 @@ def generate_command(
             scripts = [
                 f"./tests/scripts/task_config_build_{name}.sh {get_build_dir(name)}",
                 f"./tests/scripts/task_build.py --build-dir {get_build_dir(name)}",
-                # This can be removed once https://github.com/apache/tvm/pull/10257
-                # is merged and added to the Docker images
-                "python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0",
             ]
 
         # Check that a test suite was not used alongside specific test names

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -189,10 +189,9 @@ def docker(name: str, image: str, scripts: List[str], env: Dict[str, str], inter
 
     docker_bash = REPO_ROOT / "docker" / "bash.sh"
 
-    command = [docker_bash, "--name", name]
+    command = [docker_bash, "-t", "--name", name]
     if interactive:
         command.append("-i")
-        command.append("-t")
         scripts = ["interact() {", "  bash", "}", "trap interact 0", ""] + scripts
 
     for key, value in env.items():
@@ -366,6 +365,7 @@ def generate_command(
         skip_build: bool = False,
         interactive: bool = False,
         docker_image: Optional[str] = None,
+        verbose: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -374,6 +374,7 @@ def generate_command(
         skip_build -- skip build and setup scripts
         interactive -- start a shell after running build / test scripts
         docker-image -- manually specify the docker image to use
+        verbose -- run verbose build
         """
         if precheck is not None:
             precheck()
@@ -411,6 +412,7 @@ def generate_command(
                 # determine which build directory to use (i.e. if there are
                 # multiple copies of libtvm.so laying around)
                 "TVM_LIBRARY_PATH": str(REPO_ROOT / get_build_dir(name)),
+                "VERBOSE": "true" if verbose else "false",
             },
             interactive=interactive,
         )

--- a/tests/scripts/task_build.py
+++ b/tests/scripts/task_build.py
@@ -70,11 +70,16 @@ if __name__ == "__main__":
     available_cpus = nproc // executors
     num_cpus = max(available_cpus, 1)
 
-    sh.run("cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..", cwd=build_dir)
+    sh.run("cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..", cwd=build_dir)
     target = ""
     if args.cmake_target:
         target = args.cmake_target
-    sh.run(f"cmake --build . -- {target} VERBOSE=1 -j{num_cpus}", cwd=build_dir)
+
+    verbose = os.environ.get("VERBOSE", "true").lower() in {"1", "true", "yes"}
+    ninja_args = [target, f"-j{num_cpus}"]
+    if verbose:
+        ninja_args.append("-v")
+    sh.run(f"cmake --build . -- " + " ".join(ninja_args), cwd=build_dir)
 
     if use_sccache:
         logging.info("===== sccache stats =====")

--- a/tests/scripts/task_ci_setup.sh
+++ b/tests/scripts/task_ci_setup.sh
@@ -30,13 +30,14 @@ set -o pipefail
 #
 echo "Additional setup in ${CI_IMAGE_NAME}"
 
-# If these are changed also update tests/scripts/ci.py
-python3 -m pip install --user tlcpack-sphinx-addon==0.2.1 synr==0.6.0
-
 # Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
 # Jenkinsfile. We expect config.cmake to be present from pack_lib().
 # TODO(areusch): Make pack_lib() pack all the data dependencies of TVM.
-(cd build && cmake .. && make standalone_crt)
+python3 tests/scripts/task_build.py \
+    --sccache-bucket tvm-sccache-prod \
+    --cmake-target standalone_crt
 
 # Ensure no stale pytest-results remain from a previous test run.
-(cd build && rm -rf pytest-results)
+pushd build
+rm -rf pytest-results
+popd

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -34,16 +34,11 @@ python3 tests/scripts/task_build.py \
     --sccache-bucket tvm-sccache-prod \
     --cmake-target cpptest
 
-# "make crttest" requires USE_MICRO to be enabled, which is not always the case.
-if grep crttest build/Makefile > /dev/null; then
-    make crttest  # NOTE: don't parallelize, due to issue with build deps.
-fi
-
-if grep crttest build/build.ninja > /dev/null; then
-    pushd build
-    ninja crttest
-    popd
-fi
+# crttest requires USE_MICRO to be enabled, which is currently the case
+# with all CI configs
+pushd build
+ninja crttest
+popd
 
 
 pushd build

--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
 # Python is required by apps/bundle_deploy
 source tests/scripts/setup-pytest-env.sh
@@ -40,10 +39,20 @@ if grep crttest build/Makefile > /dev/null; then
     make crttest  # NOTE: don't parallelize, due to issue with build deps.
 fi
 
-cd build && ctest --gtest_death_test_style=threadsafe && cd ..
+if grep crttest build/build.ninja > /dev/null; then
+    pushd build
+    ninja crttest
+    popd
+fi
+
+
+pushd build
+ctest --gtest_death_test_style=threadsafe
+popd
 
 # Test MISRA-C runtime
-cd apps/bundle_deploy
+pushd apps/bundle_deploy
 rm -rf build
 make test_dynamic test_static
-cd ../..
+popd
+


### PR DESCRIPTION
This switches the CI build to use Ninja which has slightly nicer output and faster behavior in the face of re-runs. This also adds a `--verbose` flag to `ci.py` to control build output accordingly.

cc @Mousius @areusch

