### PR TITLE
[MetaSchedule][Minor] Fix Integer Overflow in Tuning Statistics

### DIFF
--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -77,7 +77,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
       int trials = record.trials;
       row << /*id=*/i                                 //
           << /*name=*/record.task->task_name.value()  //
-          << /*flops=*/static_cast<int>(record.flop)  //
+          << /*flops=*/static_cast<int64_t>(record.flop)  //
           << /*weight=*/static_cast<int>(record.weight);
       if (trials == 0) {
         row << /*speed=*/"N/A" << /*latency=*/"N/A" << /*weighted_latency=*/"N/A";

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -75,8 +75,8 @@ class GradientBasedNode final : public TaskSchedulerNode {
       const TaskRecord& record = task_records_[i];
       auto row = p.Row();
       int trials = record.trials;
-      row << /*id=*/i                                 //
-          << /*name=*/record.task->task_name.value()  //
+      row << /*id=*/i                                     //
+          << /*name=*/record.task->task_name.value()      //
           << /*flops=*/static_cast<int64_t>(record.flop)  //
           << /*weight=*/static_cast<int>(record.weight);
       if (trials == 0) {

--- a/src/support/table_printer.h
+++ b/src/support/table_printer.h
@@ -74,6 +74,7 @@ class TablePrinter {
   /*! \brief A helper class to print a specific row in the table */
   struct Line {
     inline Line& operator<<(int x);
+    inline Line& operator<<(int64_t x);
     inline Line& operator<<(double x);
     inline Line& operator<<(const std::string& x);
 
@@ -84,6 +85,11 @@ class TablePrinter {
 };
 
 inline TablePrinter::Line& TablePrinter::Line::operator<<(int x) {
+  p->tab_.back().push_back(std::to_string(x));
+  return *this;
+}
+
+inline TablePrinter::Line& TablePrinter::Line::operator<<(int64_t x) {
   p->tab_.back().push_back(std::to_string(x));
   return *this;
 }


### PR DESCRIPTION
This PR fixes the integer overflow when the flop count of a given workload is larger than `MAX_INT` during tuning statistics printing.