### PR TITLE
[Metaschedule] Enable continuing tuning after schedule application failure 

### DIFF
--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -131,7 +131,7 @@ void TaskSchedulerNode::Tune() {
     Optional<Array<MeasureCandidate>> candidates = strategy->GenerateMeasureCandidates();
     if (candidates.defined()) {
       // Filter out invalid candidates.
-      // An invalid candidate can arise due to a schdule application failure (e.g. tensorize).
+      // An invalid candidate can arise due to a schedule application failure (e.g. tensorize).
       Array<MeasureCandidate> valid_candidates;
       for (MeasureCandidate candidate : candidates.value()) {
         if (candidate.defined()) {

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -139,6 +139,8 @@ void TaskSchedulerNode::Tune() {
         }
       }
 
+      if (valid_candidates.size() == 0) continue;
+
       task->measure_candidates = std::move(valid_candidates);
       num_trials_already += task->measure_candidates.value().size();
       SendToBuilder(this->builder, task);

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -128,20 +128,7 @@ void TaskSchedulerNode::Tune() {
     ICHECK(!task->is_terminated);
     ICHECK(!task->runner_futures.defined());
     SearchStrategy strategy = task->search_strategy.value();
-    Optional<Array<MeasureCandidate>> candidates = strategy->GenerateMeasureCandidates();
-    if (candidates.defined()) {
-      // Filter out invalid candidates.
-      // An invalid candidate can arise due to a schedule application failure (e.g. tensorize).
-      Array<MeasureCandidate> valid_candidates;
-      for (MeasureCandidate candidate : candidates.value()) {
-        if (candidate.defined()) {
-          valid_candidates.push_back(candidate);
-        }
-      }
-
-      if (valid_candidates.size() == 0) continue;
-
-      task->measure_candidates = std::move(valid_candidates);
+    if ((task->measure_candidates = strategy->GenerateMeasureCandidates()).defined()) {
       num_trials_already += task->measure_candidates.value().size();
       SendToBuilder(this->builder, task);
       SendToRunner(this->runner, task);

--- a/src/support/parallel_for.cc
+++ b/src/support/parallel_for.cc
@@ -118,26 +118,36 @@ void parallel_for_dynamic(int begin, int end, int num_threads,
     futures.emplace_back(task.get_future());
     threads.emplace_back(std::move(task), thread_id);
   }
+
   // Step 2.2. Launch worker 0 inplace
+
+  auto try_await_futures = [&futures]() {
+    try {
+      for (auto&& future : futures) {
+        future.get();
+      }
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "RuntimeError: parallel_for_dynamic error on future get with " << e.what();
+    }
+  };
+
   try {
     worker(0);
   } catch (const std::exception& e) {
     for (auto&& thread : threads) {
       thread.join();
     }
-    LOG(FATAL) << "RuntimeError: parallel_for_dynamic error with " << e.what();
+    LOG(WARNING) << "RuntimeError: parallel_for_dynamic error on thread join with " << e.what();
+    try_await_futures();
+    return;
   }
+
   // Step 3. Join threads and check exceptions
   for (auto&& thread : threads) {
     thread.join();
   }
-  try {
-    for (auto&& future : futures) {
-      future.get();
-    }
-  } catch (const std::exception& e) {
-    LOG(FATAL) << "RuntimeError: parallel_for_dynamic error with " << e.what();
-  }
+
+  try_await_futures();
 }
 
 }  // namespace support

--- a/src/support/parallel_for.cc
+++ b/src/support/parallel_for.cc
@@ -119,8 +119,6 @@ void parallel_for_dynamic(int begin, int end, int num_threads,
     threads.emplace_back(std::move(task), thread_id);
   }
 
-  // Step 2.2. Launch worker 0 inplace
-
   auto try_await_futures = [&futures]() {
     try {
       for (auto&& future : futures) {
@@ -131,6 +129,7 @@ void parallel_for_dynamic(int begin, int end, int num_threads,
     }
   };
 
+  // Step 2.2. Launch worker 0 inplace
   try {
     worker(0);
   } catch (const std::exception& e) {


### PR DESCRIPTION
Currently, when there is a failure in schedule application during tuning (e.g. tensorize), the entire tuning session is killed with an error msg like `RuntimeError: parallel_for_dynamic error with ...`.  We should gracefully handle such errors and let tuning continue on other candidates.

No test is added since I don't know how to get tuning to fail in a controlled manner.

@junrushao1994 @zxybazh 