### PR TITLE
TVMC: Add new text/relay frontend

### DIFF
--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -320,7 +320,10 @@ class RelayFrontend(Frontend):
             type_dict = {p.name_hint: p.checked_type.dtype for p in main_func.params}
             params = {}
             for name, shape in shape_dict.items():
-                data = np.ones(shape).astype(type_dict[name])
+                if "int" in type_dict[name]:
+                    data = np.random.randint(128, size=shape, dtype=type_dict[name])
+                else:
+                    data = np.random.uniform(-1, 1, size=shape).astype(type_dict[name])
                 params[name] = data
             return params
 

--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -106,6 +106,12 @@ def test_guess_frontend_paddle():
     assert type(sut) is tvmc.frontends.PaddleFrontend
 
 
+def test_guess_frontend_relay():
+
+    sut = tvmc.frontends.guess_frontend("relay.relay")
+    assert type(sut) is tvmc.frontends.RelayFrontend
+
+
 def test_guess_frontend_invalid():
     with pytest.raises(TVMCException):
         tvmc.frontends.guess_frontend("not/a/file.txt")
@@ -188,6 +194,13 @@ def test_load_model__paddle(paddle_resnet50):
     pytest.importorskip("paddle")
 
     tvmc_model = tvmc.load(paddle_resnet50, model_format="paddle")
+    assert type(tvmc_model) is TVMCModel
+    assert type(tvmc_model.mod) is IRModule
+    assert type(tvmc_model.params) is dict
+
+
+def test_load_model__relay(relay_text_conv2d):
+    tvmc_model = tvmc.load(relay_text_conv2d, model_format="relay")
     assert type(tvmc_model) is TVMCModel
     assert type(tvmc_model.mod) is IRModule
     assert type(tvmc_model.params) is dict


### PR DESCRIPTION
This feature enables passing a textural representation of a relay module to the tvmc command line.

Example: `tvmc compile relay.txt --target c --runtime=crt --executor=aot --executor-aot-unpacked-api=1 --pass-config tir.disable_vectorize=1 -f mlf`

Currently it is not possible to supply parameters as it is mainly intended to be used for testing certain relay functions or operators. In the future (with minor changes to the tvmc frontend api) params could be passed via an additional i.e. `params.bin` file

This commit also adds minimal unit testing of the added feature.