### PR TITLE
[Hexagon] Do not pass lookup_linked_params to graph executor

### DIFF
--- a/apps/hexagon_launcher/launcher_core.cc
+++ b/apps/hexagon_launcher/launcher_core.cc
@@ -170,10 +170,6 @@ tvm::runtime::Module create_graph_executor(const std::string& graph_json,
   uint64_t device_type = device.device_type;
   uint64_t device_id = device.device_id;
 
-  std::string linked_params = "tvm.runtime.hexagon.lookup_linked_params";
-  const tvm::runtime::PackedFunc lookup_linked_params = get_runtime_func(linked_params);
-  // Use default param lookup function (linked into the module).
-  tvm::runtime::TVMRetValue rv =
-      create_executor(graph_json, graph_module, lookup_linked_params, device_type, device_id);
+  tvm::runtime::TVMRetValue rv = create_executor(graph_json, graph_module, device_type, device_id);
   return rv.operator tvm::runtime::Module();
 }


### PR DESCRIPTION
This function is no longer used or generated, so it comes from the registry as an "empty" `PackedFunc`. If the lookup function is provided, the executor will expect it not to be empty, which leads to a failed assertion.


cc @mehrdadh