### PR TITLE
[ci] Break out test steps for Hexagon / microTVM

### DIFF
--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -82,6 +82,7 @@ tvm_multilib = 'build/libtvm.so, ' +
 
 tvm_multilib_tsim = 'build/libvta_tsim.so, ' +
                tvm_multilib
+microtvm_lib = 'build/microtvm_template_projects.tar.gz, ' + tvm_lib
 upstream_revision = null
 
 // command to start a docker container
@@ -573,23 +574,12 @@ stage('Build') {
             script: "${docker_run} ${ci_qemu} ./tests/scripts/task_config_build_qemu.sh build",
             label: 'Create QEMU cmake config',
           )
-          try {
-            make(ci_qemu, 'build', '-j2')
-            cpp_unittest(ci_qemu)
-            timeout(time: max_time, unit: 'MINUTES') {
-              ci_setup(ci_qemu)
-              sh (
-                script: "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh",
-                label: 'Run microTVM tests',
-              )
-              sh (
-                script: "${docker_run} ${ci_qemu} ./tests/scripts/task_demo_microtvm.sh",
-                label: 'Run microTVM demos',
-              )
-            }
-          } finally {
-            junit 'build/pytest-results/*.xml'
-          }
+          make(ci_qemu, 'build', '-j2')
+          sh(
+            script: 'cd build && tar -czvf microtvm_template_projects.tar.gz microtvm_template_projects/',
+            label: 'Compress microtvm_template_projects'
+          )
+          pack_lib('qemu', microtvm_lib)
         }
       }
      } else {
@@ -605,24 +595,8 @@ stage('Build') {
             script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_config_build_hexagon.sh build",
             label: 'Create Hexagon cmake config',
           )
-          try {
-            make(ci_hexagon, 'build', '-j2')
-            cpp_unittest(ci_hexagon)
-            sh (
-              script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_build_hexagon_api.sh",
-              label: 'Build Hexagon API',
-            )
-            sh (
-              script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
-              label: 'Run Hexagon tests',
-            )
-            sh (
-              script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon_simulator.sh",
-              label: 'Run Hexagon tests on simulator',
-            )
-          } finally {
-            junit 'build/pytest-results/*.xml'
-          }
+          make(ci_hexagon, 'build', '-j2')
+          pack_lib('hexagon', tvm_lib)
         }
       }
      } else {
@@ -730,6 +704,40 @@ stage('Test') {
       Utils.markStageSkippedForConditional('python3: i386')
     }
   },
+  {% call m.test_step(name="test: Hexagon", node="CPU", ws="tvm/test-hexagon") %}
+    unpack_lib('hexagon', tvm_lib)
+    ci_setup(ci_hexagon)
+    cpp_unittest(ci_hexagon)
+    sh (
+      script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_build_hexagon_api.sh",
+      label: 'Build Hexagon API',
+    )
+    sh (
+      script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
+      label: 'Run Hexagon tests',
+    )
+    sh (
+      script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon_simulator.sh",
+      label: 'Run Hexagon tests on simulator',
+    )
+  {% endcall %}
+  {% call m.test_step(name="test: QEMU", node="CPU", ws="tvm/test-qemu") %}
+    unpack_lib('qemu', microtvm_lib)
+    sh(
+      script: 'cd build && tar -xzvf microtvm_template_projects.tar.gz',
+      label: 'Unpack microtvm_template_projects'
+    )
+    ci_setup(ci_qemu)
+    cpp_unittest(ci_qemu)
+    sh (
+      script: "${docker_run} ${ci_qemu} ./tests/scripts/task_python_microtvm.sh",
+      label: 'Run microTVM tests',
+    )
+    sh (
+      script: "${docker_run} ${ci_qemu} ./tests/scripts/task_demo_microtvm.sh",
+      label: 'Run microTVM demos',
+    )
+  {% endcall %}
   {% call m.test_step(name="topi: aarch64", node="ARM", ws="tvm/ut-python-arm") %}
     unpack_lib('arm', tvm_multilib)
     ci_setup(ci_arm)


### PR DESCRIPTION
Since we gate all tests on all builds currently in Jenkins, the longest running build is a bottleneck for overall runtime. This moves them to their own test steps so that the longer-running GPU/CPU tests can start earlier. This should shave off another 30 minutes or so of CI time.

As a follow up we can investigate per-platform parallelism, e.g. the CPU tests only wait on the CPU build, but Jenkins doesn't have good support for this so we might have to work on the UX a bit first.



cc @areusch