### PR TITLE
[ONNX] Add imports for BERT contrib operators

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -28,7 +28,7 @@ set -o pipefail
 # to onnx>=1.9, onnxoptimizer should also be installed.
 pip3 install \
     onnx==1.10.2 \
-    onnxruntime==1.11.0 \
+    onnxruntime==1.9.0 \
     onnxoptimizer==0.2.6
 
 # torch depends on a number of other packages, but unhelpfully, does

--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -28,7 +28,7 @@ set -o pipefail
 # to onnx>=1.9, onnxoptimizer should also be installed.
 pip3 install \
     onnx==1.10.2 \
-    onnxruntime==1.9.0 \
+    onnxruntime==1.11.0 \
     onnxoptimizer==0.2.6
 
 # torch depends on a number of other packages, but unhelpfully, does

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -807,9 +807,10 @@ class Gelu(OnnxOpConverter):
         x = inputs[0]
 
         # Declare consts
-        half = _expr.const(0.5)
-        one = _expr.const(1.0)
-        sqrt2 = _expr.const(math.sqrt(2))
+        const_dtype = infer_type(x).checked_type.dtype
+        half = _expr.const(0.5, dtype=const_dtype)
+        one = _expr.const(1.0, dtype=const_dtype)
+        sqrt2 = _expr.const(math.sqrt(2), dtype=const_dtype)
 
         # Compute gelu
         term1 = _op.multiply(half, x)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -838,6 +838,11 @@ class BiasGelu(OnnxOpConverter):
 
 
 class EmbedLayerNormalization(OnnxOpConverter):
+    """Operator converter for EmbedLayerNormalization from Microsoft onnxruntime contrib opset.
+
+    This layer embeds the input tokens, sums them, and applies layer normalization.
+    """
+
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
         input_ids = inputs[0]
@@ -887,6 +892,12 @@ class EmbedLayerNormalization(OnnxOpConverter):
 
 
 class SkipLayerNormalization(OnnxOpConverter):
+    """Operator converter for SkipLayerNormalization from Microsoft onnxruntime contrib opset.
+
+    This layer sums the two input tensors (along with optional bias), and applies layer
+    normalization.
+    """
+
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
         data = inputs[0]
@@ -918,6 +929,11 @@ class SkipLayerNormalization(OnnxOpConverter):
 
 
 class Attention(OnnxOpConverter):
+    """Operator converter for Attention from Microsoft onnxruntime contrib opset.
+
+    This is the self-attention mechanism used in transformer models.
+    """
+
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
         num_heads = attr["num_heads"]
@@ -949,7 +965,7 @@ class Attention(OnnxOpConverter):
         # (batch, num_heads, seq, seq)
         extra_add = inputs[5]
 
-        (batch_size, seq_len, in_hidden) = infer_shape(input_emb)
+        (batch_size, seq_len, _) = infer_shape(input_emb)
         (out_hidden_x3,) = infer_shape(bias)
         assert out_hidden_x3 % 3 == 0, "bias shape should be divisible by 3"
         out_hidden = out_hidden_x3 // 3

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -856,7 +856,7 @@ class EmbedLayerNormalization(OnnxOpConverter):
         mask = inputs[7]
         pos_ids = inputs[8]
 
-        eps = attr["epsilon"] if "epsilon" in attr else 1e-12
+        eps = attr.get('epsilon', 1e-12)
 
         (batch_size, seq_len) = infer_shape(input_ids)
 
@@ -4940,6 +4940,9 @@ def _get_convert_map(opset):
         "Elu": Elu.get_converter(opset),
         "Gelu": Gelu.get_converter(opset),
         "BiasGelu": BiasGelu.get_converter(opset),
+        # TODO: We need a better way to handle different domains, in case
+        # of name collisions. EmbedLayerNormalization, SkipLayerNormalization, and Attention
+        # are in the `com.microsoft` domain.
         "EmbedLayerNormalization": EmbedLayerNormalization.get_converter(opset),
         "SkipLayerNormalization": SkipLayerNormalization.get_converter(opset),
         "Attention": Attention.get_converter(opset),

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -856,7 +856,7 @@ class EmbedLayerNormalization(OnnxOpConverter):
         mask = inputs[7]
         pos_ids = inputs[8]
 
-        eps = attr.get('epsilon', 1e-12)
+        eps = attr.get("epsilon", 1e-12)
 
         (batch_size, seq_len) = infer_shape(input_ids)
 
@@ -906,7 +906,7 @@ class SkipLayerNormalization(OnnxOpConverter):
         beta = inputs[3]
         bias = inputs[4]
 
-        eps = attr["epsilon"] if "epsilon" in attr else 1e-12
+        eps = attr.get("epsilon", 1e-12)
 
         x = _op.add(data, skip)
         if bias is not None:

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -897,7 +897,8 @@ class EmbedLayerNormalization(OnnxOpConverter):
             # calculate number of words per sentence
             mask_index = _op.sum(mask, axis=1)
 
-        return _expr.TupleWrapper(_expr.Tuple([ln, mask_index, vec_sum]), 3)
+        # TODO(@anwang2009): onnxruntime v1.10.0 requires a third output of vec_sum
+        return _expr.TupleWrapper(_expr.Tuple([ln, mask_index]), 2)
 
 
 class SkipLayerNormalization(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -880,7 +880,7 @@ class EmbedLayerNormalization(OnnxOpConverter):
             assert segment_emb
 
         if pos_ids is None:
-            pos_ids = _op.const([list(range(seq_len))] * seq_len, dtype="int64")
+            pos_ids = _op.const([list(range(seq_len))] * seq_len, dtype="int32")
 
         word_vec = _op.take(word_emb, input_ids, axis=0)
         segment_vec = _op.take(segment_emb, segment_ids, axis=0)
@@ -892,7 +892,7 @@ class EmbedLayerNormalization(OnnxOpConverter):
 
         ln = layer_norm(vec_sum, eps, gamma, beta)
 
-        mask_index = _op.const(np.zeros((batch_size,), dtype="int64"))
+        mask_index = _op.const(np.zeros((batch_size,), dtype="int32"))
         if mask:
             # calculate number of words per sentence
             mask_index = _op.sum(mask, axis=1)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -39,6 +39,10 @@ def get_input_data_shape_dict(graph_def, input_data):
         shape_dict = {}
         for i, _ in enumerate(input_data):
             input_names[i] = graph_def.graph.input[i].name
+            if input_data[i] is None:
+                # Skip adding input shape data when the input data is None;
+                # This is to enable optional arguments for onnx operators.
+                continue
             shape_dict[input_names[i]] = input_data[i].shape
     else:
         input_names = graph_def.graph.input[0].name
@@ -5448,10 +5452,10 @@ def test_embedlayernormalization(target, dev):
             "EmbedLayerNormalization",
             inputs=[
                 "input_ids",
-                "segment_ids",
+                "" if segment_ids is None else "segment_ids",
                 "word_embedding",
                 "position_embedding",
-                "segment_embedding",
+                "" if segment_embedding is None else "segment_embedding",
                 "gamma",
                 "beta",
             ],
@@ -5461,6 +5465,9 @@ def test_embedlayernormalization(target, dev):
 
         node.attribute.append(onnx.helper.make_attribute("epsilon", 1e-4))
 
+        segment_ids_shape = [] if segment_ids is None else segment_ids.shape
+        segment_embedding_shape = [] if segment_embedding is None else segment_embedding.shape
+
         graph = helper.make_graph(
             [node],
             "embedlayernormalization_test",
@@ -5468,9 +5475,7 @@ def test_embedlayernormalization(target, dev):
                 helper.make_tensor_value_info(
                     "input_ids", TensorProto.INT32, list(input_ids.shape)
                 ),
-                helper.make_tensor_value_info(
-                    "segment_ids", TensorProto.INT32, list(segment_ids.shape)
-                ),
+                helper.make_tensor_value_info("segment_ids", TensorProto.INT32, segment_ids_shape),
                 helper.make_tensor_value_info(
                     "word_embedding", TensorProto.FLOAT, list(word_embedding.shape)
                 ),
@@ -5478,7 +5483,7 @@ def test_embedlayernormalization(target, dev):
                     "position_embedding", TensorProto.FLOAT, list(position_embedding.shape)
                 ),
                 helper.make_tensor_value_info(
-                    "segment_embedding", TensorProto.FLOAT, list(segment_embedding.shape)
+                    "segment_embedding", TensorProto.FLOAT, segment_embedding_shape
                 ),
                 helper.make_tensor_value_info("gamma", TensorProto.FLOAT, list(gamma.shape)),
                 helper.make_tensor_value_info("beta", TensorProto.FLOAT, list(beta.shape)),
@@ -5535,6 +5540,11 @@ def test_embedlayernormalization(target, dev):
 
     verify_embedlayernormalization(
         input_ids, segment_ids, word_embedding, position_embedding, segment_embedding, gamma, beta
+    )
+
+    # Test with undefined segment embedding
+    verify_embedlayernormalization(
+        input_ids, None, word_embedding, position_embedding, None, gamma, beta
     )
 
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -39,7 +39,7 @@ def get_input_data_shape_dict(graph_def, input_data):
         shape_dict = {}
         for i, _ in enumerate(input_data):
             input_names[i] = graph_def.graph.input[i].name
-            if input_data[i] is None or len(input_data[i]) == 0:
+            if input_data[i] is None or input_data[i].shape == ():
                 # Skip adding input shape data when the input data is None;
                 # This is to enable optional arguments for onnx operators.
                 continue
@@ -5504,10 +5504,10 @@ def test_embedlayernormalization(target, dev):
             model,
             [
                 input_ids,
-                [] if segment_ids is None else segment_ids,
+                np.empty(0, dtype="int32") if segment_ids is None else segment_ids,
                 word_embedding,
                 position_embedding,
-                [] if segment_embedding is None else segment_embedding,
+                np.empty(0, dtype="float32") if segment_embedding is None else segment_embedding,
                 gamma,
                 beta,
             ],

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5436,7 +5436,13 @@ def test_biasgelu(target, dev):
 @tvm.testing.parametrize_targets
 def test_embedlayernormalization(target, dev):
     def verify_embedlayernormalization(
-        input_ids, segment_ids, word_embedding, position_embedding, segment_embedding, gamma, beta,
+        input_ids,
+        segment_ids,
+        word_embedding,
+        position_embedding,
+        segment_embedding,
+        gamma,
+        beta,
     ):
         node = onnx.helper.make_node(
             "EmbedLayerNormalization",
@@ -5481,11 +5487,11 @@ def test_embedlayernormalization(target, dev):
                 helper.make_tensor_value_info(
                     "output", TensorProto.FLOAT, list((batch_size, sequence_length, hidden_size))
                 ),
+                helper.make_tensor_value_info("mask_index", TensorProto.INT32, [batch_size]),
                 helper.make_tensor_value_info(
-                    "mask_index", TensorProto.INT32, [batch_size]
-                ),
-                helper.make_tensor_value_info(
-                    "embedding_sum", TensorProto.FLOAT, list((batch_size, sequence_length, hidden_size))
+                    "embedding_sum",
+                    TensorProto.FLOAT,
+                    list((batch_size, sequence_length, hidden_size)),
                 ),
             ],
         )
@@ -5502,7 +5508,11 @@ def test_embedlayernormalization(target, dev):
                 gamma,
                 beta,
             ],
-            [(batch_size, sequence_length, hidden_size), batch_size, (batch_size, sequence_length, hidden_size)],
+            [
+                (batch_size, sequence_length, hidden_size),
+                batch_size,
+                (batch_size, sequence_length, hidden_size),
+            ],
             target=target,
             dev=dev,
             rtol=1e-4,
@@ -5617,7 +5627,9 @@ def test_skiplayernormalization(target, dev):
         )
 
         model = helper.make_model(graph, producer_name="skiplayernormalization_test")
-        verify_with_ort_with_inputs(model, [input, skip, gamma, beta, bias], [input.shape], target=target, dev=dev)
+        verify_with_ort_with_inputs(
+            model, [input, skip, gamma, beta, bias], [input.shape], target=target, dev=dev
+        )
 
     hidden_size = 384
     batch_size = 4

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5589,6 +5589,7 @@ def test_attention(target, dev):
     verify_attention(input, weight, bias, mask_index, num_heads)
 
 
+@tvm.testing.parametrize_targets
 def test_skiplayernormalization(target, dev):
     def verify_skiplayernormalization(input, skip, gamma, beta, bias):
         node = onnx.helper.make_node(


### PR DESCRIPTION
- Add imports for `Attention`, `EmbedLayerNormalization`, `SkipLayerNormalization`
- Fix small dtype bug in `Gelu` import

cc @AndrewZhaoLuo @MargaretQian @sfvaroglu 