### PR TITLE
[TVMScript] Print escaped string literal

### DIFF
--- a/src/printer/doc.cc
+++ b/src/printer/doc.cc
@@ -30,6 +30,8 @@
 #include <sstream>
 #include <vector>
 
+#include "../support/str_escape.h"
+
 namespace tvm {
 
 /*!
@@ -129,9 +131,8 @@ Doc Doc::Indent(int indent, Doc doc) {
 }
 
 Doc Doc::StrLiteral(const std::string& value, std::string quote) {
-  // TODO(@M.K.): add escape.
   Doc doc;
-  return doc << quote << value << quote;
+  return doc << quote << support::StrEscape(value) << quote;
 }
 
 Doc Doc::PyBoolLiteral(bool value) {

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3223,6 +3223,24 @@ def int64_support():
     return elementwise_shape_int64
 
 
+def string_annotation_escaping():
+    @T.prim_func
+    def string_annotation_of_special_chars():
+        T.func_attr(
+            {
+                "key1": '"\'hello\t\r"',
+                "key2": """
+            %1 = add i32 %0, %0
+            %2 = add i32 %0, %1
+            %3 = add i32 %1, %2
+            """,
+            }
+        )
+        T.evaluate(0)
+
+    return string_annotation_of_special_chars
+
+
 ir_generator = tvm.testing.parameter(
     opt_gemm_normalize,
     opt_gemm_lower,
@@ -3256,6 +3274,7 @@ ir_generator = tvm.testing.parameter(
     llvm_intrin_call,
     parse_bufferslice_as_range_bound,
     int64_support,
+    string_annotation_escaping,
 )
 
 


### PR DESCRIPTION
It would be great to escape printed python string, so as to make users available to get parsable cases with inline asm / llvm / c code, like the example in 
https://github.com/apache/tvm/blob/c5bd181c3d84de88e390bbce1cbcd6cc77cff310/gallery/how_to/work_with_schedules/tensorize.py#L298

There is already an interface at https://github.com/apache/tvm/blob/main/src/support/str_escape.h, though seems for c string literal originally, it should work on most cases for python string literals.