### PR TITLE
[TVMC] Allow output module name to be passed as a command line argument

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -137,6 +137,11 @@ def add_compile_parser(subparsers, _):
         type=parse_pass_list_str,
         default="",
     )
+    parser.add_argument(
+        "--module-name",
+        default="default",
+        help="The output module name. Defaults to 'default'.",
+    )
 
 
 def drive_compile(args):
@@ -179,6 +184,7 @@ def drive_compile(args):
         disabled_pass=args.disabled_pass,
         pass_context_configs=args.pass_config,
         additional_target_options=reconstruct_target_args(args),
+        mod_name=args.module_name,
     )
 
     return 0
@@ -202,6 +208,7 @@ def compile_model(
     pass_context_configs: Optional[List[str]] = None,
     additional_target_options: Optional[Dict[str, Dict[str, Any]]] = None,
     use_vm: bool = False,
+    mod_name: Optional[str] = "default",
 ):
     """Compile a model from a supported framework into a TVM module.
 
@@ -251,6 +258,8 @@ def compile_model(
         Additional target options in a dictionary to combine with initial Target arguments
     use_vm: bool
         Whether to use the VM to compile the model as opposed to the graph executor
+    mod_name: str, optional
+        The module name
 
     Returns
     -------
@@ -275,7 +284,7 @@ def compile_model(
         if codegen["config_key"] is not None:
             config[codegen["config_key"]] = codegen_from_cli["opts"]
         with tvm.transform.PassContext(config=config):
-            mod = partition_function(mod, params, **codegen_from_cli["opts"])
+            mod = partition_function(mod, params, mod_name=mod_name, **codegen_from_cli["opts"])
 
     if tuning_records and os.path.exists(tuning_records):
         logger.debug("tuning records file provided: %s", tuning_records)
@@ -300,6 +309,7 @@ def compile_model(
                         runtime=runtime,
                         params=params,
                         use_vm=use_vm,
+                        mod_name=mod_name,
                     )
         else:
             with autotvm.apply_history_best(tuning_records):
@@ -314,6 +324,7 @@ def compile_model(
                         runtime=runtime,
                         params=params,
                         use_vm=use_vm,
+                        mod_name=mod_name,
                     )
     else:
         with tvm.transform.PassContext(
@@ -327,6 +338,7 @@ def compile_model(
                 runtime=runtime,
                 params=params,
                 use_vm=use_vm,
+                mod_name=mod_name,
             )
 
     # Generate output dump files with sources
@@ -364,6 +376,7 @@ def build(
     runtime: Runtime,
     params: Dict[str, tvm.nd.NDArray],
     use_vm: bool,
+    mod_name: str,
 ):
     """
     Builds the model with the provided executor.
@@ -383,13 +396,17 @@ def build(
         A parameter dictionary for the model.
     use_vm: bool
         Whether to use the VM to compile the model as opposed to the graph executor
+    mod_name: str
+        The module name
 
     """
     if use_vm:
         logger.debug("building with vm compile")
         return relay.vm.compile(mod, target=tvm_target, params=params)
     logger.debug("building with relay build")
-    return relay.build(mod, target=tvm_target, executor=executor, runtime=runtime, params=params)
+    return relay.build(
+        mod, target=tvm_target, executor=executor, runtime=runtime, params=params, mod_name=mod_name
+    )
 
 
 def save_dumps(module_name: str, dumps: Dict[str, str], dump_root: str = "."):

--- a/python/tvm/driver/tvmc/model.py
+++ b/python/tvm/driver/tvmc/model.py
@@ -393,7 +393,7 @@ class TVMCPackage(object):
 
             has_graph_executor = "graph" in metadata["executors"]
             graph = temp.relpath("executor-config/graph/graph.json") if has_graph_executor else None
-            params = temp.relpath("parameters/default.params")
+            params = temp.relpath(f'parameters/{metadata["model_name"]}.params')
 
             self.type = "mlf"
         else:

--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -31,7 +31,7 @@ def enabled():
     return "cmsis-nn" in Target.list_kinds()
 
 
-def partition_for_cmsisnn(mod, params=None, **opts):
+def partition_for_cmsisnn(mod, params=None, mod_name="default", **opts):
     """Partition the graph greedily offloading supported
     operators on Cortex-M using CMSIS-NN
 
@@ -41,6 +41,8 @@ def partition_for_cmsisnn(mod, params=None, **opts):
         The module to run passes on.
     params : Optional[Dict[str, NDArray]]
         Constant input parameters.
+    mod_name: str, optional
+        The module name
 
     Returns
     -------
@@ -55,7 +57,7 @@ def partition_for_cmsisnn(mod, params=None, **opts):
             transform.InferType(),
             transform.MergeComposite(pattern_table()),
             transform.AnnotateTarget("cmsis-nn"),
-            transform.PartitionGraph(),
+            transform.PartitionGraph(mod_name=mod_name),
             GenerateCMSISNNConstants(),
             ScalarToTensorConstants(),
             ExtractConstantsFromPartitionedFunction(),

--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -1767,7 +1767,10 @@ def pattern_table() -> List[Tuple[str, tvm.relay.dataflow_pattern.DFPattern, Cal
 # pylint: disable=unused-argument
 @requires_vela
 def partition_for_ethosu(
-    mod: tvm.ir.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None, **opts
+    mod: tvm.ir.IRModule,
+    params: Optional[Dict[str, tvm.runtime.NDArray]] = None,
+    mod_name: str = "default",
+    **opts,
 ):
     """This helper function partition the relay graph as produced by the
     relay frontend for a given model into external functions
@@ -1779,6 +1782,8 @@ def partition_for_ethosu(
         The IRModule that gets generated from a relay frontend
     params : Optional[Dict[str, tvm.runtime.NDArray]]
         Constant input parameters.
+    mod_name: str, optional
+        The module name
 
     Returns
     -------
@@ -1796,7 +1801,7 @@ def partition_for_ethosu(
     mod = relay.transform.AnnotateTarget("ethos-u")(mod)
     mod = relay.transform.MergeCompilerRegions()(mod)
     mod = relay.transform.InferType()(mod)
-    mod = relay.transform.PartitionGraph()(mod)
+    mod = relay.transform.PartitionGraph(mod_name)(mod)
     mod = relay.transform.InferType()(mod)
     mod = preprocess.preprocess_ext_io()(mod)
     return mod


### PR DESCRIPTION
Currently there is no way to pass an output module name to tvmc on the command line when compiling a model.
This means that (for the use cases we are interested in) generated C code is always placed in files named `default_lib*.c` and that functions are named `tvmgen_default*()`.
If we want to compile multiple models for use with a single application, the C source file names and function names are not unique, resulting in failure when building the generated C code.

This PR allows module-name to be passed to tvmc on the command line, for example:
```
tvmc compile --target=cmsis-nn,c \
    --target-cmsis-nn-mcpu=cortex-m55 \
    --runtime=crt \
    --executor=aot \
    --executor-aot-interface-api=c \
    --executor-aot-unpacked-api=1 \
    --pass-config tir.usmp.enable=1 \
    --pass-config tir.usmp.algorithm=hill_climb \
    --pass-config tir.disable_storage_rewrite=1 \
    --pass-config tir.disable_vectorize=1 ./mobilenet_v2_1.0_224_INT8.tflite \
    --output-format=mlf \
    --module-name=classify
```
In this case, the generated C code is placed in files named `classify_lib*.c` and functions are named `tvmgen_classify*()`.

Additionally, this PR updates the microNPU and CMSIS-NN graph partitioners to pass the module name to PartitionGraph().
This is necessary to ensure that the C code function names generated for microNPU and CMSIS-NN include the module name and not `default`.

@leandron @Mousius @manupa-arm @areusch 


cc @gromero