### PR TITLE
[ci] Add branch protections to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,3 +47,14 @@ github:
   collaborators:
     - denise-k
     - tvm-bot  # For automated feedback in PR review.
+
+  # See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection
+  protected_branches:
+    main:
+      required_status_checks:
+        contexts:
+          # Require a passing run from Jenkins
+          - tvm-ci/pr-merge
+
+      required_pull_request_reviews:
+        required_approving_review_count: 1


### PR DESCRIPTION
Moving these into the repo means we will be able to change them at-will.
`tvm-ci/pr-merge` will change soon into `tvm-ci/pr-head` to fix an
unrelated bug, but codifying it here means we can more easily coordinate
the change.


cc @areusch