### PR TITLE
[ci] Use xdist with 1 CPU for all tests

### DIFF
--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -62,10 +62,15 @@ function run_pytest() {
 
     suite_name="${test_suite_name}-${ffi_type}"
     exit_code=0
+    # Default to 1 CPU for all tests so they run under pytest. This makes it so
+    # pytest runs them in another process so segfaults don't crash pytest's
+    # test reporting
+    ncpus=${PYTEST_CPUS:=1}
     TVM_FFI=${ffi_type} python3 -m pytest \
            -o "junit_suite_name=${suite_name}" \
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${suite_name}.xml" \
            "--junit-prefix=${ffi_type}" \
+           -n "$ncpus" \
            "$@" || exit_code=$?
     if [ "$exit_code" -ne "0" ]; then
         pytest_errors+=("${suite_name}: $@")

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -62,7 +62,7 @@ run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-integration tests/python/int
 
 # Ignoring Arm(R) Ethos(TM)-U NPU tests in the collective to run to run them in parallel in the next step.
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto
+PYTEST_CPUS=auto run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib-test_ethosu tests/python/contrib/test_ethosu
 
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \


### PR DESCRIPTION
This makes it so we get segfaults reported properly in JUnit test
reports rather than just an `exit 1` on the overall process
