### PR TITLE
[Bug] narrow thread extents to 32 bits for GPU lowering

### DIFF
--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -836,7 +836,7 @@ def broadcast_to(data, shape):
         The resulting tensor.
     """
     if isinstance(shape, Constant):
-        shape = [int(i) for i in shape.data.numpy()]
+        shape = list(shape.data.numpy())
     if isinstance(shape, Expr):
         return _dyn_make.broadcast_to(data, shape)
     if isinstance(shape, int):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -836,7 +836,7 @@ def broadcast_to(data, shape):
         The resulting tensor.
     """
     if isinstance(shape, Constant):
-        shape = list(shape.data.numpy())
+        shape = [int(i) for i in shape.data.numpy()]
     if isinstance(shape, Expr):
         return _dyn_make.broadcast_to(data, shape)
     if isinstance(shape, int):

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -107,7 +107,12 @@ class DataTypeVisitor final : public StmtExprVisitor {
       IterVar iv = Downcast<IterVar>(op->node);
       ICHECK_NE(iv->thread_tag.length(), 0U);
       analyzer_.Bind(iv->var, Range::FromMinExtent(0, op->value));
-      vextent_[iv->var.as<VarNode>()] = op->value.dtype();
+      if (op->attr_key == attr::thread_extent) {
+        // narrow extents to 32 bits on GPU
+        vextent_[iv->var.as<VarNode>()] = DataType::Int(32);
+      } else {
+        vextent_[iv->var.as<VarNode>()] = op->value.dtype();
+      }
       StmtExprVisitor::VisitStmt_(op);
     } else {
       StmtExprVisitor::VisitStmt_(op);

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -108,7 +108,9 @@ class DataTypeVisitor final : public StmtExprVisitor {
       ICHECK_NE(iv->thread_tag.length(), 0U);
       analyzer_.Bind(iv->var, Range::FromMinExtent(0, op->value));
       if (op->attr_key == attr::thread_extent) {
-        // narrow extents to 32 bits on GPU
+        // Narrow extents to 32 bits on GPU.
+        ICHECK(analyzer_.CanProveLess(op->value, static_cast<int64_t>(INT32_MAX) + 1))
+            << "cannot prove thread extent <= INT32_MAX, which is required for GPU";
         vextent_[iv->var.as<VarNode>()] = DataType::Int(32);
       } else {
         vextent_[iv->var.as<VarNode>()] = op->value.dtype();

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -109,8 +109,6 @@ class DataTypeVisitor final : public StmtExprVisitor {
       analyzer_.Bind(iv->var, Range::FromMinExtent(0, op->value));
       if (op->attr_key == attr::thread_extent) {
         // Narrow extents to 32 bits on GPU.
-        ICHECK(analyzer_.CanProveLess(op->value, static_cast<int64_t>(INT32_MAX) + 1))
-            << "cannot prove thread extent <= INT32_MAX, which is required for GPU";
         vextent_[iv->var.as<VarNode>()] = DataType::Int(32);
       } else {
         vextent_[iv->var.as<VarNode>()] = op->value.dtype();


### PR DESCRIPTION
Occasionally, int64 constants get piped through lowering and end up as thread extents, which can cause a dtype mismatch with the thread IterVar (which should be int32 on GPU). This PR narrows extents to int32 for GPU lowering to avoid the mismatch.

I added a test case for a small `broadcast_to -> sum` program that fails to compile before this fix.

cc @Lunderberg @mbrookhart 
