### PR TITLE
[CI][DOCKER] Add pytest-lazy-fixture to images

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -42,4 +42,5 @@ pip3 install --upgrade \
     synr==0.6.0 \
     junitparser==2.4.2 \
     six \
-    tornado
+    tornado \
+    pytest-lazy-fixture


### PR DESCRIPTION
Install lazy-fixture pytest plugin. This is needed for PR #10865.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>

