### PR TITLE
[Metaschedule] Make custom schedule_rule registration optional

### DIFF
--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -145,7 +145,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
                        << ann.value();
         }
 
-        if ((!sch_rule.defined() && !has_schedule_rule) ||
+        if ((ann.defined() && sch_rule.defined()) || (!has_schedule_rule && !sch_rule.defined()) ||
             (ann.defined() && ann.value() == "None")) {
           stack.emplace_back(sch, blocks);
           continue;

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -158,7 +158,8 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
         if (sch_rule.defined()) {
           applied = sch_rule.value()->Apply(sch, /*block=*/block_rv);
         } else {
-          ICHECK(custom_schedule_fn) << "ValueError: Custom schedule rule not found: " << ann.value();
+          ICHECK(custom_schedule_fn)
+              << "ValueError: Custom schedule rule not found: " << ann.value();
           applied = (*custom_schedule_fn)(sch, block_rv);
         }
 

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -136,19 +136,30 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
           stack.emplace_back(sch, blocks);
           continue;
         }
+
         Optional<String> ann = tir::GetAnn<String>(sch->GetSRef(block_rv), "schedule_rule");
-        if (ann.defined() == sch_rule.defined() || (ann.defined() && ann.value() == "None")) {
+        bool has_schedule_rule = ann.defined() && runtime::Registry::Get(ann.value()) != nullptr;
+
+        if (ann.defined() && !has_schedule_rule) {
+          LOG(WARNING) << "Custom schedule rule not found, ignoring schedule_rule annotation: "
+                       << ann.value();
+        }
+
+        if ((!sch_rule.defined() && !has_schedule_rule) ||
+            (ann.defined() && ann.value() == "None")) {
           stack.emplace_back(sch, blocks);
           continue;
         }
+
         Array<tir::Schedule> applied{nullptr};
         if (sch_rule.defined()) {
           applied = sch_rule.value()->Apply(sch, /*block=*/block_rv);
-        } else {
+        } else if (has_schedule_rule) {
           const runtime::PackedFunc* f = runtime::Registry::Get(ann.value());
           CHECK(f) << "ValueError: Custom schedule rule not found: " << ann.value();
           applied = (*f)(sch, block_rv);
         }
+
         for (const tir::Schedule& sch : applied) {
           stack.emplace_back(sch, blocks);
         }

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -145,7 +145,8 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
                        << ann.value();
         }
 
-        if ((ann.defined() && sch_rule.defined()) || (!has_schedule_rule && !sch_rule.defined()) ||
+        if ((has_schedule_rule && sch_rule.defined()) ||
+            (!has_schedule_rule && !sch_rule.defined()) ||
             (ann.defined() && ann.value() == "None")) {
           stack.emplace_back(sch, blocks);
           continue;

--- a/tests/python/unittest/test_meta_schedule_post_order_apply.py
+++ b/tests/python/unittest/test_meta_schedule_post_order_apply.py
@@ -371,8 +371,8 @@ def test_meta_schedule_custom_search_space():
     )
     post_order_apply = PostOrderApply()
     post_order_apply.initialize_with_tune_context(context)
-    with pytest.raises(ValueError, match="Custom schedule rule not found"):
-        post_order_apply.generate_design_space(mod)
+
+    post_order_apply.generate_design_space(mod)
 
     called = False
 


### PR DESCRIPTION
See the discussion in https://github.com/apache/tvm/pull/10793#discussion_r837626566 for the context.

Now I'm doing auto-tensorization on VNNI, I do need to be able to switch on / off `schedule_rule` freely.

@junrushao1994 @zxybazh 