### PR TITLE
[Hexagon] Remove HexagonBuffer external constructor and support

### DIFF
--- a/src/runtime/hexagon/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.cc
@@ -170,14 +170,6 @@ HexagonBuffer::HexagonBuffer(size_t nallocs, size_t nbytes, size_t alignment,
   managed_allocations_.push_back(std::move(alloca));
 }
 
-HexagonBuffer::HexagonBuffer(void* data, size_t nbytes, Optional<String> scope)
-    : ndim_(1), nbytes_per_allocation_(nbytes) {
-  SetStorageScope(scope);
-  // disallow external VTCM allocations
-  CHECK(GetStorageScope() != HexagonBuffer::StorageScope::kVTCM);
-  allocations_.push_back(data);
-}
-
 HexagonBuffer::~HexagonBuffer() { managed_allocations_.clear(); }
 
 void* HexagonBuffer::GetPointer() {
@@ -283,8 +275,6 @@ void hexagon_buffer_copy_across_regions(const BufferSet& dest, const BufferSet& 
 }
 
 void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
-  CHECK(managed_allocations_.size() && "CopyTo not supported on unmanaged `external` allocations");
-
   BufferSet src(allocations_.data(), allocations_.size(), nbytes_per_allocation_);
   BufferSet dest(&data, 1, nbytes);
 
@@ -292,9 +282,6 @@ void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
 }
 
 void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
-  CHECK(managed_allocations_.size() &&
-        "CopyFrom not supported on unmanaged `external` allocations");
-
   BufferSet src(&data, 1, nbytes);
   BufferSet dest(allocations_.data(), allocations_.size(), nbytes_per_allocation_);
 
@@ -302,11 +289,6 @@ void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
 }
 
 void HexagonBuffer::CopyFrom(const HexagonBuffer& other, size_t nbytes) {
-  CHECK(managed_allocations_.size() &&
-        "CopyFrom not supported on unmanaged `external` allocations");
-  CHECK(other.managed_allocations_.size() &&
-        "CopyFrom not supported on unmanaged `external` allocations");
-
   BufferSet src(other.allocations_.data(), other.allocations_.size(), other.nbytes_per_allocation_);
   BufferSet dest(allocations_.data(), allocations_.size(), nbytes_per_allocation_);
 

--- a/src/runtime/hexagon/hexagon/hexagon_buffer.h
+++ b/src/runtime/hexagon/hexagon/hexagon_buffer.h
@@ -67,18 +67,6 @@ class HexagonBuffer {
    */
   HexagonBuffer(size_t nallocs, size_t nbytes, size_t alignment, Optional<String> scope);
 
-  /* \brief Construct a Hexagon Buffer from an external buffer.
-   *
-   * \param data The pointer to the external buffer.
-   *
-   * \param nbytes The size of the external buffer in bytes.
-   *
-   * \param scope Optional storage scope indicating the memory
-   * space in which to allocate. Defaults to global system
-   * memory (DDR).
-   */
-  explicit HexagonBuffer(void* data, size_t nbytes, Optional<String> scope);
-
   //! \brief Destruction deallocates the underlying allocations.
   ~HexagonBuffer();
 

--- a/tests/cpp/runtime/hexagon_buffer.cc
+++ b/tests/cpp/runtime/hexagon_buffer.cc
@@ -462,37 +462,3 @@ TEST(HexagonBuffer, nd_copy_to) {
     EXPECT_EQ(data_in[i], data_out[i]);
   }
 }
-
-TEST(HexagonBuffer, external) {
-  std::vector<uint8_t> data{0, 1, 2, 3, 4, 5, 6, 7};
-
-  Optional<String> def;
-  HexagonBuffer hb_default(data.data(), data.size(), def);
-  EXPECT_EQ(hb_default.GetPointer(), data.data());
-  EXPECT_EQ(hb_default.GetStorageScope(), HexagonBuffer::StorageScope::kDDR);
-
-  Optional<String> global("global");
-  HexagonBuffer hb_global(data.data(), data.size(), global);
-  EXPECT_EQ(hb_global.GetPointer(), data.data());
-  EXPECT_EQ(hb_global.GetStorageScope(), HexagonBuffer::StorageScope::kDDR);
-
-  Optional<String> vtcm("global.vtcm");
-  EXPECT_THROW(HexagonBuffer hb_vtcm(data.data(), data.size(), vtcm), InternalError);
-
-  Optional<String> invalid("invalid");
-  EXPECT_THROW(HexagonBuffer hb_vtcm(data.data(), data.size(), invalid), InternalError);
-}
-
-TEST(HexagonBuffer, external_copy) {
-  std::vector<uint8_t> data1{0, 1, 2, 3, 4, 5, 6, 7};
-  Optional<String> global("global");
-  HexagonBuffer hb_ext(data1.data(), data1.size(), global);
-
-  std::vector<uint8_t> data2{0, 1, 2, 3, 4, 5, 6, 7};
-  EXPECT_THROW(hb_ext.CopyTo(data2.data(), data2.size()), InternalError);
-  EXPECT_THROW(hb_ext.CopyFrom(data2.data(), data2.size()), InternalError);
-
-  HexagonBuffer hb(8 /* nbytes */, 8 /* alignment */, global);
-  EXPECT_THROW(hb.CopyFrom(hb_ext, 8), InternalError);
-  EXPECT_THROW(hb_ext.CopyFrom(hb, 8), InternalError);
-}


### PR DESCRIPTION
Removes HexagonBuffer external constructor and support given that HexagonBuffer is now a private entity of the Hexagon DeviceAPI as of PR #10910.

cc @mehrdadh