### PR TITLE
[Arith] Updated arith::DetectIterMap to keep extent=1 components

### DIFF
--- a/include/tvm/arith/iter_affine_map.h
+++ b/include/tvm/arith/iter_affine_map.h
@@ -276,13 +276,15 @@ class IterSumExpr : public IterMapExpr {
  * \param predicate The predicate constraints on the input iterators
  * \param require_bijective A boolean flag that indicates whether the mapping should be bijective.
  * \param analyzer Analyzer used to get context information.
+ * \param simplify_trivial_iterators If true, iterators with extent of
+ *           1 will be replaced with a constant value.
  *
  * \return The detected pattern if a match exists,
  *         otherwise return an empty array.
  */
 Array<IterSumExpr> DetectIterMap(const Array<PrimExpr>& indices, const Map<Var, Range>& input_iters,
                                  const PrimExpr& predicate, bool require_bijective,
-                                 arith::Analyzer* analyzer);
+                                 arith::Analyzer* analyzer, bool simplify_trivial_iterators = true);
 /*!
  * \brief Use IterVarMap detector to rewrite and simplify the indices
  *

--- a/python/tvm/arith/iter_affine_map.py
+++ b/python/tvm/arith/iter_affine_map.py
@@ -88,7 +88,13 @@ class IterSumExpr(IterMapExpr):
         self.__init_handle_by_constructor__(_ffi_api.IterSumExpr, args, base)
 
 
-def detect_iter_map(indices, input_iters, predicate=True, require_bijective=False):
+def detect_iter_map(
+    indices,
+    input_iters,
+    predicate=True,
+    require_bijective=False,
+    simplify_trivial_iterators=True,
+):
     """Detect if indices can be written as mapped iters from input iters
 
     Parameters
@@ -105,13 +111,20 @@ def detect_iter_map(indices, input_iters, predicate=True, require_bijective=Fals
     require_bijective : bool
         A boolean flag that indicates whether the mapping should be bijective
 
+    simplify_trivial_iterators: bool
+        If true, iterators with extent of 1 will be replaced with a
+        constant value.
+
     Returns
     -------
     results : List[IterSumExpr]
         The iter map matching result.
         Empty array if no match can be found.
+
     """
-    return _ffi_api.DetectIterMap(indices, input_iters, predicate, require_bijective)
+    return _ffi_api.DetectIterMap(
+        indices, input_iters, predicate, require_bijective, simplify_trivial_iterators
+    )
 
 
 def normalize_iter_map_to_expr(expr):

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -178,9 +178,7 @@ class IterMapRewriter : public ExprMutator {
     for (auto kv : input_iters) {
       const Var& var = kv.first;
       const Range& vrng = kv.second;
-      if (is_one(vrng->extent)) {
-        var_map_[var] = IterSumExpr({}, vrng->min);
-      } else if (is_zero(vrng->min)) {
+      if (is_zero(vrng->min)) {
         IterMark mark(var, vrng->extent);
         var_map_[var] = IterSplitExpr(mark);
         input_marks_.push_back(mark);

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -943,9 +943,11 @@ Array<IterSumExpr> DetectIterMap(const Array<PrimExpr>& indices, const Map<Var, 
 
 TVM_REGISTER_GLOBAL("arith.DetectIterMap")
     .set_body_typed([](const Array<PrimExpr>& indices, const Map<Var, Range>& input_iters,
-                       const PrimExpr& input_pred, bool is_bijective) {
+                       const PrimExpr& input_pred, bool is_bijective,
+                       bool simplify_trivial_iterators) {
       arith::Analyzer ana;
-      return DetectIterMap(indices, input_iters, input_pred, is_bijective, &ana);
+      return DetectIterMap(indices, input_iters, input_pred, is_bijective, &ana,
+                           simplify_trivial_iterators);
     });
 
 PrimExpr IterMapRewriter::VisitExpr_(const VarNode* op) {

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -76,7 +76,9 @@ IndexMap IndexMap::Inverse(Array<Range> initial_ranges) const {
   // Unpack the output indices into linear combinations of the initial
   // indices.
   arith::Analyzer analyzer;
-  auto iter_map = DetectIterMap((*this)->final_indices, input_iters, 1, true, &analyzer);
+  auto iter_map = DetectIterMap((*this)->final_indices, input_iters, /* predicate = */ 1,
+                                /* require_bijective = */ true, &analyzer,
+                                /* simplify_trivial_iterators = */ false);
   CHECK(iter_map.size()) << "Index transformation was not bijective.";
 
   // Determine expressions for the input variables, in terms of the

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -51,7 +51,7 @@ def convert_iter_expr(expr):
 def assert_iter_sum_pattern(sum_expr, extent, base, scale=1):
     """Check the sum expr have the right pattern."""
     assert isinstance(sum_expr, tvm.arith.IterSumExpr)
-    if extent is None:
+    if extent == 1:
         assert len(sum_expr.args) == 0
     else:
         assert len(sum_expr.args) == 1
@@ -69,12 +69,12 @@ def test_trivial():
     assert len(res) == 3
     assert_iter_sum_pattern(res[0], 3, 0)
     assert_iter_sum_pattern(res[1], 4, 0)
-    assert_iter_sum_pattern(res[2], None, 3)
+    assert_iter_sum_pattern(res[2], 1, 3)
 
     res = tvm.arith.detect_iter_map([x[0], 3], var_dom([x, y]))
     assert len(res) == 2
     assert_iter_sum_pattern(res[0], 3, 0)
-    assert_iter_sum_pattern(res[1], None, 3)
+    assert_iter_sum_pattern(res[1], 1, 3)
 
     # not independent
     res = tvm.arith.detect_iter_map([x[0], x[0], 3], var_dom([x, y]))

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -51,7 +51,7 @@ def convert_iter_expr(expr):
 def assert_iter_sum_pattern(sum_expr, extent, base, scale=1):
     """Check the sum expr have the right pattern."""
     assert isinstance(sum_expr, tvm.arith.IterSumExpr)
-    if extent == 1:
+    if extent is None:
         assert len(sum_expr.args) == 0
     else:
         assert len(sum_expr.args) == 1
@@ -69,12 +69,12 @@ def test_trivial():
     assert len(res) == 3
     assert_iter_sum_pattern(res[0], 3, 0)
     assert_iter_sum_pattern(res[1], 4, 0)
-    assert_iter_sum_pattern(res[2], 1, 3)
+    assert_iter_sum_pattern(res[2], None, 3)
 
     res = tvm.arith.detect_iter_map([x[0], 3], var_dom([x, y]))
     assert len(res) == 2
     assert_iter_sum_pattern(res[0], 3, 0)
-    assert_iter_sum_pattern(res[1], 1, 3)
+    assert_iter_sum_pattern(res[1], None, 3)
 
     # not independent
     res = tvm.arith.detect_iter_map([x[0], x[0], 3], var_dom([x, y]))


### PR DESCRIPTION
Previously, arith::DetectIterMap simplified the output expression by replacing iteration variables with extent==1 with their value.  This prevented the return value from being used in arith::InverseAffineIterMap to solve for the variable, as it no longer existed in the returned expressions.

This commit changes arith::DetectIterMap to keep the iteration variable even if extent==1, and adds a motivating unit test that requires this updated behavior.