### PR TITLE
Support `qnn.conv2d` in FoldExplicitPading

### DIFF
--- a/src/relay/transforms/fold_explicit_padding.cc
+++ b/src/relay/transforms/fold_explicit_padding.cc
@@ -49,7 +49,8 @@ class SimplifyConvPad {
     conv1d_ = IsOp("nn.conv1d");
     conv2d_ = IsOp("nn.conv2d");
     conv3d_ = IsOp("nn.conv3d");
-    conv_ = (conv1d_ || conv2d_ || conv3d_)({pad_, w_});
+    qconv2d_ = IsOp("qnn.conv2d");
+    conv_ = (conv1d_ || conv2d_ || conv3d_ || qconv2d_)({pad_, w_});
     pattern_ = conv_;
   }
 
@@ -131,6 +132,8 @@ class SimplifyConvPad {
         attrs = GetAttrs(param, call_node->attrs.as<Conv2DAttrs>());
       } else if (node_map.count(conv3d_)) {
         attrs = GetAttrs(param, call_node->attrs.as<Conv3DAttrs>());
+      } else if (node_map.count(qconv2d_)) {
+        attrs = GetAttrs(param, call_node->attrs.as<Conv2DAttrs>());
       } else {
         return post;
       }
@@ -158,6 +161,7 @@ class SimplifyConvPad {
   DFPattern conv1d_;
   DFPattern conv2d_;
   DFPattern conv3d_;
+  DFPattern qconv2d_;
 };
 
 class SimplifyExplicitPadding {

--- a/tests/python/relay/test_pass_fold_explicit_padding.py
+++ b/tests/python/relay/test_pass_fold_explicit_padding.py
@@ -141,12 +141,9 @@ def fold_pad_qconv2d():
     a = run_opt_pass(before(), relay.transform.FoldExplicitPadding())
     b = run_opt_pass(expected(), transform.InferType())
 
-    print(a)
-    print(b)
-
-    assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
+    assert tvm.ir.structural_equal(a, b, map_free_vars=True), "Actual = \n" + str(a)
 
 
 if __name__ == "__main__":
-    # test_simplify_conv_pad()
+    test_simplify_conv_pad()
     fold_pad_qconv2d()

--- a/tests/python/relay/test_pass_fold_explicit_padding.py
+++ b/tests/python/relay/test_pass_fold_explicit_padding.py
@@ -100,5 +100,53 @@ def test_simplify_conv_pad():
     validate(ndim, [[0, 0]] * 2 + [i_pad] * ndim, 0, "edge", orig_pad * ndim, "NCHW")
 
 
+def fold_pad_qconv2d():
+    def before():
+        x = relay.var("x", shape=(1, 56, 56, 64), dtype="int8")
+        weight = relay.var("weight", shape=(3, 3, 64, 64), dtype="int8")
+        input_zero_point = 10
+        pad = relay.nn.pad(x, [[0, 0], [1, 1], [1, 1], [0, 0]], pad_value=input_zero_point)
+        return relay.qnn.op.conv2d(
+            pad,
+            weight,
+            relay.const(input_zero_point, "int32"),
+            relay.const(1, "int32"),
+            relay.const(1, "float32"),
+            relay.const(1, "float32"),
+            channels=64,
+            kernel_size=(3, 3),
+            padding=(0, 0),
+            data_layout="NHWC",
+            kernel_layout="HWIO",
+        )
+
+    def expected():
+        x = relay.var("x", shape=(1, 56, 56, 64), dtype="int8")
+        weight = relay.var("weight", shape=(3, 3, 64, 64), dtype="int8")
+        input_zero_point = 10
+        return relay.qnn.op.conv2d(
+            x,
+            weight,
+            relay.const(input_zero_point, "int32"),
+            relay.const(1, "int32"),
+            relay.const(1, "float32"),
+            relay.const(1, "float32"),
+            channels=64,
+            kernel_size=(3, 3),
+            padding=(1, 1),
+            data_layout="NHWC",
+            kernel_layout="HWIO",
+        )
+
+    a = run_opt_pass(before(), relay.transform.FoldExplicitPadding())
+    b = run_opt_pass(expected(), transform.InferType())
+
+    print(a)
+    print(b)
+
+    assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a)
+
+
 if __name__ == "__main__":
-    test_simplify_conv_pad()
+    # test_simplify_conv_pad()
+    fold_pad_qconv2d()


### PR DESCRIPTION
@mbrookhart @AndrewZhaoLuo @anwang2009 

I think we should enable this pass by default. The only concern is that it would break existing tuning logs.