### PR TITLE
[FIX] resolve int64/32 for AttrStmtNode

### DIFF
--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -29,7 +29,6 @@
 
 #include "../../arith/ir_mutator_with_analyzer.h"
 #include "../../arith/ir_visitor_with_analyzer.h"
-#include "tvm/runtime/logging.h"
 
 namespace tvm {
 namespace tir {

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -228,6 +228,7 @@ def test_broadcast_to():
             op_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(x)
             tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-5)
 
+
 @tvm.testing.uses_gpu
 def test_broadcast_to_const_shape_int64():
     shape_like = relay.const(np.array([1, 5]), dtype="int64")
@@ -243,6 +244,7 @@ def test_broadcast_to_const_shape_int64():
         for kind in ["graph", "debug"]:
             op_res = relay.create_executor(kind, device=dev, target=target).evaluate(f)(x)
             tvm.testing.assert_allclose(op_res.numpy(), ref_res)
+
 
 @tvm.testing.uses_gpu
 def test_broadcast_to_like():

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -228,6 +228,21 @@ def test_broadcast_to():
             op_res = relay.create_executor(kind, device=dev, target=target).evaluate(func)(x)
             tvm.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-5)
 
+@tvm.testing.uses_gpu
+def test_broadcast_to_const_shape_int64():
+    shape_like = relay.const(np.array([1, 5]), dtype="int64")
+    x = relay.var("x", shape=(1,), dtype="int64")
+    z = relay.broadcast_to(x, shape=shape_like)
+    z = relay.sum(z, axis=0)
+
+    f = relay.Function([x], z)
+
+    x = np.random.randint(10, size=(1,), dtype="int64")
+    ref_res = np.broadcast_to(x, (5,))
+    for target, dev in tvm.testing.enabled_targets():
+        for kind in ["graph", "debug"]:
+            op_res = relay.create_executor(kind, device=dev, target=target).evaluate(f)(x)
+            tvm.testing.assert_allclose(op_res.numpy(), ref_res)
 
 @tvm.testing.uses_gpu
 def test_broadcast_to_like():


### PR DESCRIPTION
Similar issues as:
https://github.com/apache/tvm/pull/10172
https://github.com/apache/tvm/pull/9582
https://github.com/apache/tvm/pull/10519
https://github.com/apache/tvm/pull/10571
https://github.com/apache/tvm/pull/10584

Integer mismatch when constructing`IterVal`. Triggered when compiling models on GPU (that's why the `AttrStmtNode`'s logic is reached). A triggering example model is attached: [model.onnx.zip](https://github.com/apache/tvm/files/8476414/model.onnx.zip)

@masahi 
