### PR TITLE
[ONNX] Sort axes for unsqueeze op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1499,7 +1499,8 @@ class Unsqueeze(OnnxOpConverter):
 
         rank_input = len(infer_type(inputs[0]).checked_type.shape)
         num_new_axis = int(infer_type(inputs[1]).checked_type.shape[0])
-        axes = relay.split(inputs[1], num_new_axis).astuple()
+        axes = relay.sort(inputs[1])
+        axes = relay.split(axes, num_new_axis).astuple()
         result = inputs[0]
 
         # TODO (AndrewZhaoLuo): investigate performance issues with consecutive

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5132,10 +5132,6 @@ unsupported_onnx_tests = [
     "test_triu_square",
     "test_triu_square_neg",
     "test_triu_zero",
-    # These unsqueeze tests work, but take 2+ hrs to run
-    "test_unsqueeze_three_axes",
-    "test_unsqueeze_two_axes",
-    "test_unsqueeze_unsorted_axes",
     "test_unique_sorted_with_axis",
     "test_unique_sorted_with_axis_3d",
     "test_unique_sorted_with_negative_axis",


### PR DESCRIPTION
Looking at the onnx op documentation, it appears that the axes for unsqueeze are expected to be applied in sorted order internally: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Unsqueeze

Also, although tests are a bit slow, they're taking <5 min when I tried locally for non-llvm targets (cuda, opencl), so I'm uncommenting them.