### PR TITLE
[CI] Update GPU image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,12 +45,12 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-04-11T12:22:12.040444
+// Generated at 2022-04-13T17:46:58.845847
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = 'tlcpack/ci-lint:v0.71'
-ci_gpu = 'tlcpack/ci-gpu:v0.84'
+ci_gpu = 'tlcpack/ci-gpu:v0.85'
 ci_cpu = 'tlcpack/ci-cpu:v0.83'
 ci_wasm = 'tlcpack/ci-wasm:v0.73'
 ci_i386 = 'tlcpack/ci-i386:v0.76'

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -52,7 +52,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = 'tlcpack/ci-lint:v0.71'
-ci_gpu = 'tlcpack/ci-gpu:v0.84'
+ci_gpu = 'tlcpack/ci-gpu:v0.85'
 ci_cpu = 'tlcpack/ci-cpu:v0.83'
 ci_wasm = 'tlcpack/ci-wasm:v0.73'
 ci_i386 = 'tlcpack/ci-i386:v0.76'


### PR DESCRIPTION
Validated in https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/247/pipeline/.

Update the PyTorch version used in `ci-gpu` to a cpu-only build, to avoid CUDA driver related problems. We never need CUDA-enabled PT to run our tests. See
https://github.com/apache/tvm/pull/10758#issuecomment-1086262813
https://github.com/apache/tvm/pull/10914

cc @areusch @driazati @leandron @Mousius @t-vi 