### PR TITLE
[VirtualMachine] Zero copy in set_input when input is DLTensor

### DIFF
--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -156,19 +156,19 @@ class NDArray : public ObjectRef {
   TVM_DLL static NDArray Empty(ShapeTuple shape, DLDataType dtype, Device dev,
                                Optional<String> mem_scope = NullOpt);
   /*!
-   * \brief Create a NDArray backed by an external dlpack tensor.
+   * \brief Create a NDArray backed by an external DLTensor.
    *
    * This allows us to create a NDArray using the memory
    * allocated by an external source. Responsibility for memory
    * retaining lies with the external source.
-   * \param dl_tensor The DLPack tensor to copy from.
+   * \param dl_tensor The DLTensor to copy from.
    * \return The created NDArray view.
    */
   TVM_DLL static NDArray FromExternalDLTensor(const DLTensor& dl_tensor);
   /*!
-   * \brief Create new NDArray, data is copied from dlpack tensor.
+   * \brief Create new NDArray, data is copied from DLTensor.
    *
-   * \param dl_tensor The DLPack tensor to copy from.
+   * \param dl_tensor The DLTensor to copy from.
    * \param dev device location of the created NDArray.
    * \return The created NDArray view.
    */

--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -166,6 +166,14 @@ class NDArray : public ObjectRef {
    */
   TVM_DLL static NDArray FromExternalDLTensor(const DLTensor& dl_tensor);
   /*!
+   * \brief Create new NDArray, data is copied from dlpack tensor.
+   *
+   * \param dl_tensor The DLPack tensor to copy from.
+   * \param dev device location of the created NDArray.
+   * \return The created NDArray view.
+   */
+  TVM_DLL static NDArray NewFromDLTensor(DLTensor* dl_tensor, Device dev);
+  /*!
    * \brief Create a NDArray backed by a dlpack tensor.
    *
    * This allows us to create a NDArray using the memory

--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -156,6 +156,16 @@ class NDArray : public ObjectRef {
   TVM_DLL static NDArray Empty(ShapeTuple shape, DLDataType dtype, Device dev,
                                Optional<String> mem_scope = NullOpt);
   /*!
+   * \brief Create a NDArray backed by an external dlpack tensor.
+   *
+   * This allows us to create a NDArray using the memory
+   * allocated by an external source. Responsibility for memory
+   * retaining lies with the external source.
+   * \param dl_tensor The DLPack tensor to copy from.
+   * \return The created NDArray view.
+   */
+  TVM_DLL static NDArray FromExternalDLTensor(const DLTensor& dl_tensor);
+  /*!
    * \brief Create a NDArray backed by a dlpack tensor.
    *
    * This allows us to create a NDArray using the memory

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -426,6 +426,10 @@ class VirtualMachine(object):
 
     def set_input(self, func_name, *args, **kwargs):
         """Set the input to a function.
+        If device type and device id for input tensor are the same as
+        for target one the zero copy is used. It means that internal
+        tensor is reference to memory allocated by input one.
+        Otherwise new internal NDarray is created and data is copied
 
         Parameters
         ----------

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -171,9 +171,7 @@ struct NDArray::Internal {
     delete tensor;
   }
 
-  static void DLManagedTensorSelfDeleter(DLManagedTensor* tensor) {
-    delete tensor;
-  }
+  static void DLManagedTensorSelfDeleter(DLManagedTensor* tensor) { delete tensor; }
 };
 
 NDArray NDArray::CreateView(ShapeTuple shape, DLDataType dtype) {
@@ -220,6 +218,16 @@ NDArray NDArray::FromExternalDLTensor(const DLTensor& dl_tensor) {
   data->dl_tensor.shape = const_cast<ShapeTuple::index_type*>(data->shape_.data());
 
   return NDArray(GetObjectPtr<Object>(data));
+}
+
+NDArray NDArray::NewFromDLTensor(DLTensor* tensor, Device dev) {
+  std::vector<int64_t> shape;
+  for (int64_t i = 0; i < tensor->ndim; i++) {
+    shape.push_back(tensor->shape[i]);
+  }
+  NDArray ary = NDArray::Empty(shape, tensor->dtype, dev);
+  ary.CopyFrom(tensor);
+  return ary;
 }
 
 NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -70,8 +70,15 @@ inline ObjectRef CopyTo(ObjectRef src, const DLDevice& dev) {
   if (src->IsInstance<NDArray::ContainerType>()) {
     auto nd_array = Downcast<NDArray>(src);
     // TODO(mbs): Should respect device id also.
-    if (nd_array->device.device_type != dev.device_type) {
-      VLOG(2) << "copying from " << nd_array->device.device_type << " to " << dev.device_type;
+    // TODO(vvchernov): it still does not work for different device id
+    // due to simple implementation of Get() and AllocDataSpace() methods
+    // see tvm/src/runtime/c_runtime_api.cc: L139
+    // tvm/src/runtime/cpu_device_api.cc: L47
+    if (nd_array->device.device_type != dev.device_type ||
+        nd_array->device.device_id != dev.device_id) {
+      VLOG(2) << "copying from " << nd_array->device.device_type << "["
+              << nd_array->device.device_id << "] to " << dev.device_type << "[" << dev.device_id
+              << "]";
       return nd_array.CopyTo(dev);
     }
     return src;

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -303,13 +303,12 @@ void VirtualMachine::SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,
   if (inp_tensor.type_code() == kTVMDLTensorHandle) {
     // Automatically convert input DLTensors to NDArray
     DLTensor* tensor = inp_tensor;
-    std::vector<int64_t> shape;
-    for (int64_t i = 0; i < tensor->ndim; i++) {
-      shape.push_back(tensor->shape[i]);
+    if (dev.device_type == tensor->device.device_type &&
+        dev.device_id == tensor->device.device_id) {
+      tensors[index] = NDArray::FromExternalDLTensor(*tensor);
+    } else {
+      tensors[index] = NDArray::NewFromDLTensor(tensor, dev);
     }
-    NDArray ary = NDArray::Empty(shape, tensor->dtype, dev);
-    ary.CopyFrom(tensor);
-    tensors[index] = ary;
   } else {
     tensors[index] = CopyTo(inp_tensor, dev);
   }


### PR DESCRIPTION
I observed that VirtualMachine::SetInputTensorWithIndex(...) method has discrepancy between description (also see description for VirtualMachine::SetInput(...) which assumes zero copy if possible and uses the method) and implementation. It always create new NDArray and copies data to it if source input is DLTensor even if devices are the same. It reduces performance of multiple input models due to excess copying. The PR fixes this issue.

Note: I have a remark about current design. VirtualMachine has only `set_input` python method, the same method is used inside `run` and `invoke` methods with input args. But there is no `set_input_zero_copy`. In description I obsrved that `set_input` tries to not use copying if possible. Theoretically we can have problem if `set_input` is used, input tensors are released after that and when `run` or `invoke` are launched. As I know GraphExecutor does not have such problem.
