### PR TITLE
[ci] Always assume num executors == 1

### DIFF
--- a/tests/scripts/task_build.py
+++ b/tests/scripts/task_build.py
@@ -63,10 +63,7 @@ if __name__ == "__main__":
         logging.info("===== sccache stats =====")
         sh.run("sccache --show-stats")
 
-    if "CI" in os.environ:
-        executors = int(os.environ["CI_NUM_EXECUTORS"])
-    else:
-        executors = int(os.environ.get("CI_NUM_EXECUTORS", 1))
+    executors = int(os.environ.get("CI_NUM_EXECUTORS", 1))
 
     nproc = multiprocessing.cpu_count()
 


### PR DESCRIPTION
This is true now and we've seen problems like https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10753/17/pipeline/. This could have arisen from the EC2 user data script that is supposed to set up this env variable failing or something, but we don't really need it in the first place.





cc @areusch