### PR TITLE
[OpenCL] Fix type casting error

### DIFF
--- a/src/target/source/codegen_opencl.cc
+++ b/src/target/source/codegen_opencl.cc
@@ -327,6 +327,10 @@ void CodeGenOpenCL::PrintRestrict(const Var& v, std::ostream& os) {
 
 std::string CodeGenOpenCL::CastFromTo(std::string value, DataType from, DataType target) {
   if (from == target) return value;
+  return CastTo(value, target);
+}
+
+std::string CodeGenOpenCL::CastTo(std::string value, DataType target) {
   std::ostringstream os;
   if (target.lanes() == 1) {
     os << "((";
@@ -510,6 +514,30 @@ void CodeGenOpenCL::VisitExpr_(const MinNode* op, std::ostream& os) {
 
 void CodeGenOpenCL::VisitExpr_(const MaxNode* op, std::ostream& os) {
   PrintBinaryExpr(op, "max", os, this);
+}
+
+void CodeGenOpenCL::PrintVecBinaryOp(const std::string& op, DataType t, PrimExpr lhs, PrimExpr rhs,
+                                     std::ostream& os) {
+  std::ostringstream oss;
+  if (isalpha(op[0])) {
+    os << op << "(";
+    this->PrintExpr(lhs, oss);
+    os << CastTo(oss.str(), t);
+    oss.str("");
+    os << ", ";
+    this->PrintExpr(rhs, oss);
+    os << CastTo(oss.str(), t);
+    os << ")";
+  } else {
+    os << "(";
+    this->PrintExpr(lhs, oss);
+    os << CastTo(oss.str(), t);
+    oss.str("");
+    os << ' ' << op << ' ';
+    this->PrintExpr(rhs, oss);
+    os << CastTo(oss.str(), t);
+    os << ")";
+  }
 }
 
 void CodeGenOpenCL::SetTextureScope(

--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -55,6 +55,7 @@ class CodeGenOpenCL final : public CodeGenC {
                     std::ostream& os);                                           // NOLINT(*)
   void PrintRestrict(const Var& v, std::ostream& os) final;                      // NOLINT(*)
   std::string CastFromTo(std::string value, DataType from, DataType target);     // NOLINT(*)
+  std::string CastTo(std::string value, DataType target);                        // NOLINT(*)
   void SetTextureScope(const std::unordered_map<const VarNode*, std::string>&);  // NOLINT(*)
 
   // overload visitor
@@ -69,6 +70,10 @@ class CodeGenOpenCL final : public CodeGenC {
   // overload min and max to avoid ambiguous call errors
   void VisitExpr_(const MinNode* op, std::ostream& os) final;
   void VisitExpr_(const MaxNode* op, std::ostream& os) final;
+
+  // Binary vector op.
+  void PrintVecBinaryOp(const std::string& op, DataType op_type, PrimExpr lhs, PrimExpr rhs,
+                        std::ostream& os) final;
 
  private:
   // whether enable fp16 and fp64 extension


### PR DESCRIPTION
Faced situation when generated OpenCL kernel contained the following if
condition:
```
if (uint4(...) && (int4(...) == int4(...)))
```

In this case, got the following error:
"can't convert between vector values of different size ('uint4' and 'int __attribute__((ext_vector_type(4)))')"

Added casts for binary ops. But it was necessary to modify `CastFromTo`
and add new method `CastTo`. Because with `CastFromTo` the following
code was generated:
```
if (uint4(...) && (convert_uint4(int4(...)) == convert_uint4(int4(...))))
```
But the OpenCL compiler still generated the same error.

This is why added new method `CastTo`. In this method we don't check the
current type of op and just add cast to a new type.

Finally the following code will be generated:
```
if (uint4(...) && convert_uint4(convert_uint4(int4(...)) == convert_uint4(int4(...))))
```



Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
