### PR TITLE
[TOPI] Fix nn.lrn result dtype on fp16

### DIFF
--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -1437,16 +1437,16 @@ def test_pad_run_dynamic_pad_value():
 
 
 @tvm.testing.uses_gpu
-def test_lrn():
+@pytest.mark.parametrize("dtype", ["float32", "float16"])
+def test_lrn(dtype):
     n, c, h, w = te.size_var("n"), te.size_var("c"), te.size_var("h"), te.size_var("w")
-    x = relay.var("x", shape=(n, c, h, w))
+    x = relay.var("x", shape=(n, c, h, w), dtype=dtype)
     y = relay.nn.lrn(x, size=10, axis=2, bias=0.5, alpha=0.00001, beta=0.75)
     "alpha=" in y.astext()
     yy = run_infer_type(y)
-    assert yy.checked_type == relay.TensorType((n, c, h, w))
+    assert yy.checked_type == relay.TensorType((n, c, h, w), dtype)
 
     shape = (1, 5, 10, 10)
-    dtype = "float32"
     x = relay.var("x", relay.TensorType(shape, dtype))
     size = 5
     axis = 1


### PR DESCRIPTION
The buggy script as below:
```python
import tvm
from tvm import relay
from tvm.contrib import graph_executor
x = relay.var("x", shape=[1, 3, 224, 224], dtype="float16")
y = relay.nn.lrn(x)
mod = tvm.IRModule.from_expr(relay.Function([x], y))
lib = relay.build(mod, target="llvm")
f = graph_executor.GraphModule(lib["default"](tvm.cpu()))
f.run()
```

The error I get is
```
Check failed: ret == 0 (-1 vs. 0) : Assert fail: (((tir.tvm_struct_get(arg.T_divide, 0, 5) == (uint8)2) && (tir.tvm_struct_get(arg.T_divide, 0, 6) == (uint8)32)) && (tir.tvm_struct_get(arg.T_divide, 0, 7) == (uint16)1)), arg.T_divide.dtype is expected to be float32
```