### PR TITLE
[Frontend][ONNX]support  Pool2D layout is CHW

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -417,7 +417,7 @@ class Pool(OnnxOpConverter):
         attr_cvt, data = cls._run_calculation(inputs, attr, params)
         out = attr_cvt([data], attr, params)
 
-        if ndim == 3 and len(attr["kernel_shape"]) == 2:
+        if ndim - len(attr["kernel_shape"]) == 1:
             out = _op.squeeze(out, axis=[0])
         return out
 
@@ -471,7 +471,7 @@ class Pool(OnnxOpConverter):
                 attr["storage_order"], dims=(len(input_shape) - 2), op_name=cls.name
             )
         else:
-            if ndim == 3 and len(attr["kernel_shape"]) == 2:
+            if ndim - len(attr["kernel_shape"]) == 1:
                 data = _op.expand_dims(data, axis=0)
                 input_shape = [1] + list(input_shape)
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -421,7 +421,6 @@ class Pool(OnnxOpConverter):
             out = _op.squeeze(out, axis=[0])
         return out
 
-
     @classmethod
     def _run_calculation(cls, inputs, attr, params):
         """Helper method to return the processed input data and AttrCvt object"""

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -410,8 +410,17 @@ class Pool(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
+        data = inputs[0]
+        input_shape = infer_shape(data)
+        ndim = len(input_shape)
+
         attr_cvt, data = cls._run_calculation(inputs, attr, params)
-        return attr_cvt([data], attr, params)
+        out = attr_cvt([data], attr, params)
+
+        if ndim == 3 and len(attr["kernel_shape"]) == 2:
+            out = _op.squeeze(out, axis=[0])
+        return out
+
 
     @classmethod
     def _run_calculation(cls, inputs, attr, params):
@@ -463,6 +472,10 @@ class Pool(OnnxOpConverter):
                 attr["storage_order"], dims=(len(input_shape) - 2), op_name=cls.name
             )
         else:
+            if ndim == 3 and len(attr["kernel_shape"]) == 2:
+                data = _op.expand_dims(data, axis=0)
+                input_shape = [1] + list(input_shape)
+
             attr["layout"] = onnx_default_layout(dims=(len(input_shape) - 2), op_name=cls.name)
 
         return (


### PR DESCRIPTION
Hi， my onnx model is superpoint. it's converted  from a pytorch model.
When I import the model. I get the relay as follow:
```
...
%38 = transpose(%37, axes=[0, 1, 3, 2, 4]);
%39 = reshape(%38, newshape=[1, 480, 640]);
%40 = nn.max_pool2d(%39, pool_size=[9, 9], padding=[4, 4, 4, 4], layout="NCW");
%41 = equal(%39, %40);
cast(%41, dtype="float32")
```

The model layer in Netron is:
![image](https://user-images.githubusercontent.com/50271153/163803337-e9cb51ff-363b-4533-915e-5a6d7d39701e.png)
Then we can see the %39 reshape is a 3 dimensions. It is legal in pytorch model. But in ONNX, I will get a error.
Then I will add a `expand_dims` before pool2D and a squeeze after pool2D like the code I commited.

But i don`t know how to add a unit test case. because there will be error in onnxruntime if the pool2D  shape is 3D.
![image](https://user-images.githubusercontent.com/50271153/163803954-d1987128-f4dd-4ce4-96ad-2a04842b5ed6.png)

cc: @MatthewARM @jwfromm @AndrewZhaoLuo 



