### PR TITLE
Register PackedFuncObj with type registry

### DIFF
--- a/src/runtime/packed_func.cc
+++ b/src/runtime/packed_func.cc
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * \file src/runtime/packed_func.cc
+ * \brief Implementation of non-inlinable PackedFunc pieces.
+ */
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+namespace tvm {
+namespace runtime {
+
+TVM_REGISTER_OBJECT_TYPE(PackedFuncObj);
+
+}  // namespace runtime
+}  // namespace tvm


### PR DESCRIPTION
 * Fixes CHECK-fails when trying to use reflection dispatch with PackedFuncObj.
 * Triggered by trying to add PrettyPrint() to StructuralEqual checks.

@junrushao1994 @cyx-6 