### PR TITLE
Better version handling for Arduino

### DIFF
--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -34,6 +34,8 @@ from string import Template
 import re
 
 import serial
+import serial.tools.list_ports
+
 from tvm.micro.project_api import server
 
 _LOG = logging.getLogger(__name__)
@@ -445,7 +447,6 @@ class Handler(server.ProjectAPIHandler):
 
         desired_fqbn = self._get_fqbn(options)
         for device in self._parse_connected_boards(list_cmd_output):
-            print(device)
             if device["fqbn"] == desired_fqbn:
                 return device["port"]
 

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -33,7 +33,6 @@ import time
 from string import Template
 import re
 
-import serial
 import serial.tools.list_ports
 
 from tvm.micro.project_api import server
@@ -430,14 +429,14 @@ class Handler(server.ProjectAPIHandler):
         assert len(column_headers) > 0
 
         for str_row in str_rows[1:]:
-            if not str_row.strip(): continue
+            if not str_row.strip():
+                continue
             device = {}
 
             for column in column_headers:
                 col_name = column.group(0).strip().lower()
-                device[col_name] = str_row[column.start():column.end()].strip()
+                device[col_name] = str_row[column.start() : column.end()].strip()
             yield device
-
 
     def _auto_detect_port(self, options):
         list_cmd = [self._get_arduino_cli_cmd(options), "board", "list"]

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -360,8 +360,11 @@ class Handler(server.ProjectAPIHandler):
         version_output = subprocess.run(
             [arduino_cli_path, "version"], check=True, stdout=subprocess.PIPE
         ).stdout.decode("utf-8")
-
         str_version = re.search(r"Version: ([\.0-9]*)", version_output).group(1)
+
+        # Using too low a version should raise an error. Note that naively
+        # comparing floats will fail here: 0.7 > 0.21, but 0.21 is a higher
+        # version (hence we need version.parse)
         return version.parse(str_version)
 
     # This will only be run for build and upload

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -318,7 +318,7 @@ class Handler(server.ProjectAPIHandler):
         # sample output of this command:
         # 'arduino-cli alpha Version: 0.18.3 Commit: d710b642 Date: 2021-05-14T12:36:58Z\n'
         version_output = subprocess.check_output([arduino_cli_path, "version"], encoding="utf-8")
-        full_version = re.findall("version: ([\.0-9]*)", version_output.lower())
+        full_version = re.findall(r"version: ([\.0-9]*)", version_output.lower())
         full_version = full_version[0].split(".")
         version = float(f"{full_version[0]}.{full_version[1]}")
 

--- a/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
@@ -86,15 +86,16 @@ class TestGenerateProject:
     def test_parse_connected_boards(self):
         h = microtvm_api_server.Handler()
         boards = h._parse_connected_boards(self.BOARD_CONNECTED_V21)
-        assert list(boards) == [{
-            "port": "/dev/ttyACM0",
-            "protocol": "serial",
-            "type": "",
-            "board name": "",
-            "fqbn": "arduino:mbed_nano:nano33ble",
-            "core": "arduino:mbed_nano",
-        }]
-
+        assert list(boards) == [
+            {
+                "port": "/dev/ttyACM0",
+                "protocol": "serial",
+                "type": "",
+                "board name": "",
+                "fqbn": "arduino:mbed_nano:nano33ble",
+                "core": "arduino:mbed_nano",
+            }
+        ]
 
     @mock.patch("subprocess.run")
     def test_auto_detect_port(self, sub_mock):
@@ -136,8 +137,8 @@ class TestGenerateProject:
 
         # Test we checked version then called upload
         assert mock_run.call_count == 2
-        assert mock_run.call_args_list[0][0] == (['arduino-cli', 'version'],)
-        assert mock_run.call_args_list[1][0][0][0:2] == ['arduino-cli', 'upload']
+        assert mock_run.call_args_list[0][0] == (["arduino-cli", "version"],)
+        assert mock_run.call_args_list[1][0][0][0:2] == ["arduino-cli", "upload"]
         mock_run.reset_mock()
 
         # Test exception raised when `arduino-cli upload` returns error code
@@ -147,4 +148,4 @@ class TestGenerateProject:
 
         # Version information should be cached and not checked again
         mock_run.assert_called_once()
-        assert mock_run.call_args[0][0][0:2] == ['arduino-cli', 'upload']
+        assert mock_run.call_args[0][0][0:2] == ["arduino-cli", "upload"]

--- a/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
@@ -136,9 +136,6 @@ class TestGenerateProject:
         handler._check_platform_version(self.DEFAULT_OPTIONS)
         assert handler._version == version.parse("0.21.1")
 
-        # Using too low a version should raise an error. Note that naively
-        # comparing floats will fail here: 0.7 > 0.21, but 0.21 is a higher
-        # version (hence we need packaging.version)
         handler = microtvm_api_server.Handler()
         mock_run.return_value.stdout = bytes(self.BAD_CLI_VERSION, "utf-8")
         with pytest.raises(server.ServerError) as error:


### PR DESCRIPTION
This pull request contains three small changes:
- Fix bug allowing `microTVM` to be used with Arduino version `v0.20` and above (see changes to `_parse_connected_boards`) and adds relevant unit tests.
- Only perform version check when calling `build` or `flash` (things that actually require `arduino-cli`), and adds relevant unit tests.
- Only raise a warning if the `arduino-cli` version present is **below** the min version (previously any version other than `v0.18` would cause an error).
- Change version comparison to use `version.check`, like the rest of TVM