### PR TITLE
[ONNX] Reshape op

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -118,9 +118,12 @@ struct TransposeAttrs : public tvm::AttrsNode<TransposeAttrs> {
 /*! \brief Attributes used in reshape operators */
 struct ReshapeAttrs : public tvm::AttrsNode<ReshapeAttrs> {
   Array<Integer> newshape;
+  bool allowzero;
   TVM_DECLARE_ATTRS(ReshapeAttrs, "relay.attrs.ReshapeAttrs") {
     TVM_ATTR_FIELD(newshape).describe(
         "The new shape. Should be compatible with the original shape.");
+    TVM_ATTR_FIELD(allowzero).set_default(0).describe(
+        "Whether to honor the value of zero in newshape.");
   }
 };  // struct ReshapeAttrs
 

--- a/include/tvm/topi/detail/ravel_unravel.h
+++ b/include/tvm/topi/detail/ravel_unravel.h
@@ -70,8 +70,8 @@ inline Array<PrimExpr> UnravelIndex(PrimExpr idx, Array<PrimExpr> shape) {
   std::vector<PrimExpr> indices;
 
   for (int i = static_cast<int>(shape.size()) - 1; i >= 0; --i) {
-      indices.push_back(indexmod(idx, shape[i]));
-      idx = indexdiv(idx, shape[i]);
+    indices.push_back(indexmod(idx, shape[i]));
+    idx = indexdiv(idx, shape[i]);
   }
   std::reverse(indices.begin(), indices.end());
   return indices;

--- a/include/tvm/topi/detail/ravel_unravel.h
+++ b/include/tvm/topi/detail/ravel_unravel.h
@@ -70,8 +70,12 @@ inline Array<PrimExpr> UnravelIndex(PrimExpr idx, Array<PrimExpr> shape) {
   std::vector<PrimExpr> indices;
 
   for (int i = static_cast<int>(shape.size()) - 1; i >= 0; --i) {
-    indices.push_back(indexmod(idx, shape[i]));
-    idx = indexdiv(idx, shape[i]);
+    if (shape[i].as<IntImmNode>()->value == 0){
+      indices.push_back(0);
+    } else {
+      indices.push_back(indexmod(idx, shape[i]));
+      idx = indexdiv(idx, shape[i]);
+    }
   }
   std::reverse(indices.begin(), indices.end());
   return indices;

--- a/include/tvm/topi/detail/ravel_unravel.h
+++ b/include/tvm/topi/detail/ravel_unravel.h
@@ -70,7 +70,7 @@ inline Array<PrimExpr> UnravelIndex(PrimExpr idx, Array<PrimExpr> shape) {
   std::vector<PrimExpr> indices;
 
   for (int i = static_cast<int>(shape.size()) - 1; i >= 0; --i) {
-    if (shape[i].as<IntImmNode>()->value == 0){
+    if (shape[i].as<IntImmNode>()->value == 0) {
       indices.push_back(0);
     } else {
       indices.push_back(indexmod(idx, shape[i]));

--- a/include/tvm/topi/detail/ravel_unravel.h
+++ b/include/tvm/topi/detail/ravel_unravel.h
@@ -70,12 +70,8 @@ inline Array<PrimExpr> UnravelIndex(PrimExpr idx, Array<PrimExpr> shape) {
   std::vector<PrimExpr> indices;
 
   for (int i = static_cast<int>(shape.size()) - 1; i >= 0; --i) {
-    if (shape[i].as<IntImmNode>()->value == 0) {
-      indices.push_back(0);
-    } else {
       indices.push_back(indexmod(idx, shape[i]));
       idx = indexdiv(idx, shape[i]);
-    }
   }
   std::reverse(indices.begin(), indices.end());
   return indices;

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -329,7 +329,8 @@ inline Tensor reshape(const Tensor& x, Array<PrimExpr> newshape, std::string nam
     }
   }
 
-  if (is_empty_shape(target_shape)) {
+  // If either the input shape or the target shape contains a zero, return an empty tensor.
+  if (is_empty_shape(target_shape) || is_empty_shape(x->shape)) {
     return compute(
         target_shape, [&](const Array<Var>& indices) { return tvm::cast(x->dtype, 0); }, name, tag);
   } else {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -321,6 +321,11 @@ inline Tensor reshape(const Tensor& x, Array<PrimExpr> newshape, std::string nam
   auto x_shape = x->shape;
   Array<PrimExpr> target_shape;
 
+  // if newshape is an empty tensor make it [0] instead.
+  if (newshape.empty()){
+    newshape.push_back(0); 
+  }
+
   for (const auto& ele : newshape) {
     if (ele.as<IntImmNode>()) {
       target_shape.push_back(cast(DataType::Int(32), ele));

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -322,8 +322,8 @@ inline Tensor reshape(const Tensor& x, Array<PrimExpr> newshape, std::string nam
   Array<PrimExpr> target_shape;
 
   // if newshape is an empty tensor make it [0] instead.
-  if (newshape.empty()){
-    newshape.push_back(0); 
+  if (newshape.empty()) {
+    newshape.push_back(0);
   }
 
   for (const auto& ele : newshape) {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -321,11 +321,6 @@ inline Tensor reshape(const Tensor& x, Array<PrimExpr> newshape, std::string nam
   auto x_shape = x->shape;
   Array<PrimExpr> target_shape;
 
-  // if newshape is an empty tensor make it [0] instead.
-  if (newshape.empty()) {
-    newshape.push_back(0);
-  }
-
   for (const auto& ele : newshape) {
     if (ele.as<IntImmNode>()) {
       target_shape.push_back(cast(DataType::Int(32), ele));

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1427,7 +1427,7 @@ class Reshape(OnnxOpConverter):
 
     @classmethod
     def _impl_v5(cls, inputs, attr, params):
-        allowzero = attr.get('allowzero', False)
+        allowzero = attr.get("allowzero", False)
         if get_name(inputs[1]) in params:
             shape = tuple(params[inputs[1].name_hint].numpy().astype("int32"))
             out = _op.reshape(inputs[0], shape, allowzero=allowzero)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1427,9 +1427,9 @@ class Reshape(OnnxOpConverter):
 
     @classmethod
     def _impl_v5(cls, inputs, attr, params):
-        allowzero = False 
-        if 'allowzero' in attr:
-            allowzero = attr['allowzero']
+        allowzero = False
+        if "allowzero" in attr:
+            allowzero = attr["allowzero"]
         if get_name(inputs[1]) in params:
             shape = tuple(params[inputs[1].name_hint].numpy().astype("int32"))
             out = _op.reshape(inputs[0], shape, allowzero=allowzero)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1427,11 +1427,14 @@ class Reshape(OnnxOpConverter):
 
     @classmethod
     def _impl_v5(cls, inputs, attr, params):
+        allowzero = False 
+        if 'allowzero' in attr:
+            allowzero = attr['allowzero']
         if get_name(inputs[1]) in params:
             shape = tuple(params[inputs[1].name_hint].numpy().astype("int32"))
-            out = _op.reshape(inputs[0], shape)
+            out = _op.reshape(inputs[0], shape, allowzero=allowzero)
         else:
-            out = _op.reshape(*inputs)
+            out = _op.reshape(*inputs, allowzero=allowzero)
         return out
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1427,9 +1427,7 @@ class Reshape(OnnxOpConverter):
 
     @classmethod
     def _impl_v5(cls, inputs, attr, params):
-        allowzero = False
-        if "allowzero" in attr:
-            allowzero = attr["allowzero"]
+        allowzero = attr.get('allowzero', False)
         if get_name(inputs[1]) in params:
             shape = tuple(params[inputs[1].name_hint].numpy().astype("int32"))
             out = _op.reshape(inputs[0], shape, allowzero=allowzero)

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -470,7 +470,11 @@ def _reshape_shape_func_input_shape(data_shape, newshape, ndim, allowzero):
 def reshape_shape_func(attrs, inputs, out_ndims):
     newshape = get_const_tuple(attrs.newshape)
     allowzero = attrs.allowzero
-    return [_reshape_shape_func_input_shape(inputs[0], convert(newshape), out_ndims[0], convert(allowzero))]
+    return [
+        _reshape_shape_func_input_shape(
+            inputs[0], convert(newshape), out_ndims[0], convert(allowzero)
+        )
+    ]
 
 
 @script

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -395,7 +395,7 @@ def concatenate_shape_func(attrs, inputs, _):
 
 
 @script
-def _reshape_shape_func_input_shape(data_shape, newshape, ndim):
+def _reshape_shape_func_input_shape(data_shape, newshape, ndim, allowzero):
     out = output_tensor((ndim,), "int64")
     src_idx = 0
     dst_idx = 0
@@ -410,7 +410,10 @@ def _reshape_shape_func_input_shape(data_shape, newshape, ndim):
             src_idx += 1
             dst_idx += 1
         elif newshape[i] == 0:
-            out[dst_idx] = data_shape[src_idx]
+            if allowzero:
+                out[dst_idx] = int64(newshape[i])
+            else:
+                out[dst_idx] = data_shape[src_idx]
             src_idx += 1
             dst_idx += 1
         elif newshape[i] == -1:
@@ -466,7 +469,8 @@ def _reshape_shape_func_input_shape(data_shape, newshape, ndim):
 @_reg.register_shape_func("reshape", False)
 def reshape_shape_func(attrs, inputs, out_ndims):
     newshape = get_const_tuple(attrs.newshape)
-    return [_reshape_shape_func_input_shape(inputs[0], convert(newshape), out_ndims[0])]
+    allowzero = attrs.allowzero
+    return [_reshape_shape_func_input_shape(inputs[0], convert(newshape), out_ndims[0], convert(allowzero))]
 
 
 @script

--- a/python/tvm/relay/op/dyn/_transform.py
+++ b/python/tvm/relay/op/dyn/_transform.py
@@ -45,7 +45,7 @@ def _reshape_shape_func_input_data(data_shape, newshape, ndim, allowzero):
     for i in const_range(len(newshape)):
         if skip > 0:
             skip -= 1
-        elif newshape[i] == 0:
+        elif newshape[i] > 0:
             out[dst_idx] = int64(newshape[i])
             src_idx += 1
             dst_idx += 1

--- a/python/tvm/relay/op/dyn/_transform.py
+++ b/python/tvm/relay/op/dyn/_transform.py
@@ -45,7 +45,7 @@ def _reshape_shape_func_input_data(data_shape, newshape, ndim, allowzero):
     for i in const_range(len(newshape)):
         if skip > 0:
             skip -= 1
-        elif newshape[i] >= 0:
+        elif newshape[i] == 0:
             out[dst_idx] = int64(newshape[i])
             src_idx += 1
             dst_idx += 1

--- a/python/tvm/relay/op/dyn/_transform.py
+++ b/python/tvm/relay/op/dyn/_transform.py
@@ -35,7 +35,7 @@ _reg.register_injective_schedule("dyn.sparse_to_dense")
 
 
 @script
-def _reshape_shape_func_input_data(data_shape, newshape, ndim):
+def _reshape_shape_func_input_data(data_shape, newshape, ndim, allowzero):
     out = output_tensor((ndim,), "int64")
     src_idx = 0
     dst_idx = 0
@@ -45,12 +45,15 @@ def _reshape_shape_func_input_data(data_shape, newshape, ndim):
     for i in const_range(len(newshape)):
         if skip > 0:
             skip -= 1
-        elif newshape[i] > 0:
+        elif newshape[i] >= 0:
             out[dst_idx] = int64(newshape[i])
             src_idx += 1
             dst_idx += 1
         elif newshape[i] == 0:
-            out[dst_idx] = data_shape[src_idx]
+            if allowzero:
+                out[dst_idx] = int64(newshape[i])
+            else:
+                out[dst_idx] = data_shape[src_idx]
             src_idx += 1
             dst_idx += 1
         elif newshape[i] == -1:
@@ -89,7 +92,8 @@ def _reshape_shape_func_input_data(data_shape, newshape, ndim):
 
 @_reg.register_shape_func("dyn.reshape", [False, True])
 def dynamic_reshape_shape_func(attrs, inputs, out_ndims):
-    return [_reshape_shape_func_input_data(*inputs, out_ndims[0])]
+    allowzero = attrs.allowzero
+    return [_reshape_shape_func_input_data(*inputs, out_ndims[0], convert(allowzero))]
 
 
 @script

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -224,7 +224,7 @@ def squeeze(data, axis=None):
     return _make.squeeze(data, axis)
 
 
-def reshape(data, newshape):
+def reshape(data, newshape, allowzero=False):
     """Reshape the input array.
 
     To give user more convenience in without doing manual shape inference,
@@ -237,6 +237,9 @@ def reshape(data, newshape):
 
             data.shape = (2,3,4), newshape = (4,0,2), result.shape = (4,3,2)
             data.shape = (2,3,4), newshape = (2,0,0), result.shape = (2,3,4)
+
+    Note: If the parameter allowzero is manually set to true, it specifies a
+    special case where 0 actually means a true empty tensor.
 
     ``-1`` infers the dimension of the output shape by using the remainder of
     the input dimensions keeping the size of the new array same as that of the input array.
@@ -282,6 +285,9 @@ def reshape(data, newshape):
     newshape : Union[int, Tuple[int], List[int]] or relay.Expr
         The new shape. Should be compatible with the original shape.
 
+    allowzero : Bool, optional
+        If true, then treat zero as true empty tensor rather than a copy instruction. 
+
     Returns
     -------
     result : relay.Expr
@@ -304,7 +310,7 @@ def reshape(data, newshape):
                 except ValueError as err:
                     raise RuntimeError("Unrecognized shape type: %s" % err)
         newshape = tempshape
-    return _make.reshape(data, list(newshape))
+    return _make.reshape(data, list(newshape), allowzero)
 
 
 def argwhere(condition):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -296,7 +296,7 @@ def reshape(data, newshape, allowzero=False):
     if isinstance(newshape, Constant):
         newshape = list(newshape.data.numpy())
     if isinstance(newshape, Expr):
-        return _dyn_make.reshape(data, newshape)
+        return _dyn_make.reshape(data, newshape, allowzero)
     if isinstance(newshape, int):
         newshape = [newshape]
     if isinstance(newshape, (tuple, list)):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -286,7 +286,7 @@ def reshape(data, newshape, allowzero=False):
         The new shape. Should be compatible with the original shape.
 
     allowzero : Bool, optional
-        If true, then treat zero as true empty tensor rather than a copy instruction. 
+        If true, then treat zero as true empty tensor rather than a copy instruction.
 
     Returns
     -------

--- a/src/relay/op/dyn/tensor/transform.cc
+++ b/src/relay/op/dyn/tensor/transform.cc
@@ -89,8 +89,9 @@ Array<te::Tensor> ReshapeCompute(const Attrs& attrs, const Array<te::Tensor>& in
   return {topi::reshape(inputs[0], newshape)};
 }
 
-Expr MakeReshape(Expr data, Expr newshape) {
+Expr MakeReshape(Expr data, Expr newshape, bool allowzero=false) {
   auto attrs = make_object<ReshapeAttrs>();
+  attrs->allowzero = allowzero;
   static const Op& op = Op::Get("dyn.reshape");
   return Call(op, {data, newshape}, Attrs(attrs), {});
 }

--- a/src/relay/op/dyn/tensor/transform.cc
+++ b/src/relay/op/dyn/tensor/transform.cc
@@ -89,7 +89,7 @@ Array<te::Tensor> ReshapeCompute(const Attrs& attrs, const Array<te::Tensor>& in
   return {topi::reshape(inputs[0], newshape)};
 }
 
-Expr MakeReshape(Expr data, Expr newshape, bool allowzero=false) {
+Expr MakeReshape(Expr data, Expr newshape, bool allowzero = false) {
   auto attrs = make_object<ReshapeAttrs>();
   attrs->allowzero = allowzero;
   static const Op& op = Op::Get("dyn.reshape");

--- a/src/relay/op/make_op.h
+++ b/src/relay/op/make_op.h
@@ -67,7 +67,7 @@ Expr MakeReduce(Expr data, Array<Integer> axis, bool keepdims, bool exclude, Str
 
 Expr MakeRepeat(Expr data, int repeats, int axis);
 
-Expr MakeReshape(Expr data, Array<Integer> newshape);
+Expr MakeReshape(Expr data, Array<Integer> newshape, int allowzero=0);
 
 Expr MakeReshapeLike(Expr lhs, Expr rhs, int lhs_begin, Integer lhs_end, int rhs_begin,
                      Integer rhs_end);

--- a/src/relay/op/make_op.h
+++ b/src/relay/op/make_op.h
@@ -67,7 +67,7 @@ Expr MakeReduce(Expr data, Array<Integer> axis, bool keepdims, bool exclude, Str
 
 Expr MakeRepeat(Expr data, int repeats, int axis);
 
-Expr MakeReshape(Expr data, Array<Integer> newshape, int allowzero = 0);
+Expr MakeReshape(Expr data, Array<Integer> newshape, bool allowzero = false);
 
 Expr MakeReshapeLike(Expr lhs, Expr rhs, int lhs_begin, Integer lhs_end, int rhs_begin,
                      Integer rhs_end);

--- a/src/relay/op/make_op.h
+++ b/src/relay/op/make_op.h
@@ -67,7 +67,7 @@ Expr MakeReduce(Expr data, Array<Integer> axis, bool keepdims, bool exclude, Str
 
 Expr MakeRepeat(Expr data, int repeats, int axis);
 
-Expr MakeReshape(Expr data, Array<Integer> newshape, int allowzero=0);
+Expr MakeReshape(Expr data, Array<Integer> newshape, int allowzero = 0);
 
 Expr MakeReshapeLike(Expr lhs, Expr rhs, int lhs_begin, Integer lhs_end, int rhs_begin,
                      Integer rhs_end);

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -637,11 +637,11 @@ Array<IndexExpr> InferNewShape(const Array<IndexExpr>& data_shape, const Attrs& 
       ++src_idx;
     } else if (svalue == 0) {
       if (allowzero) {
-        // keep same as > 0
+        // 0 means empty tensor, thus default behavior
         oshape.push_back(newshape[i]);
         ++src_idx;
       } else {
-        // treat zero as copy input axis shape
+        // 0 means to copy at equivilant position in data tensor
         ICHECK_LT(src_idx, ishape.size());
         used_input_dims.insert(src_idx);
         used_output_dims.insert(oshape.size());
@@ -916,7 +916,7 @@ Array<te::Tensor> ReshapeCompute(const Attrs& attrs, const Array<te::Tensor>& in
   return {topi::reshape(inputs[0], newshape)};
 }
 
-Expr MakeReshape(Expr data, Array<Integer> newshape, int allowzero) {
+Expr MakeReshape(Expr data, Array<Integer> newshape, bool allowzero) {
   auto attrs = make_object<ReshapeAttrs>();
   attrs->newshape = std::move(newshape);
   attrs->allowzero = allowzero;

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -645,7 +645,7 @@ Array<IndexExpr> InferNewShape(const Array<IndexExpr>& data_shape, const Attrs& 
         ICHECK_LT(src_idx, ishape.size());
         used_input_dims.insert(src_idx);
         used_output_dims.insert(oshape.size());
-        oshape.push_back(ishape[src_idx++]); 
+        oshape.push_back(ishape[src_idx++]);
       }
     } else if (svalue == -1) {
       // inference based on rest

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -622,6 +622,8 @@ Array<IndexExpr> InferNewShape(const Array<IndexExpr>& data_shape, const Attrs& 
     newshape = param->newshape;
   }
 
+  bool allowzero = param->allowzero;
+
   std::unordered_set<size_t> used_input_dims;
   std::unordered_set<size_t> used_output_dims;
   size_t src_idx = 0;
@@ -634,11 +636,17 @@ Array<IndexExpr> InferNewShape(const Array<IndexExpr>& data_shape, const Attrs& 
       oshape.push_back(newshape[i]);
       ++src_idx;
     } else if (svalue == 0) {
-      // keep same
-      ICHECK_LT(src_idx, ishape.size());
-      used_input_dims.insert(src_idx);
-      used_output_dims.insert(oshape.size());
-      oshape.push_back(ishape[src_idx++]);
+      if (allowzero) {
+        // keep same as > 0
+        oshape.push_back(newshape[i]);
+        ++src_idx;
+      } else {
+        // treat zero as copy input axis shape
+        ICHECK_LT(src_idx, ishape.size());
+        used_input_dims.insert(src_idx);
+        used_output_dims.insert(oshape.size());
+        oshape.push_back(ishape[src_idx++]); 
+      }
     } else if (svalue == -1) {
       // inference based on rest
       ICHECK_LT(infer_idx, 0) << "One and only one dim can be inferred";
@@ -908,9 +916,10 @@ Array<te::Tensor> ReshapeCompute(const Attrs& attrs, const Array<te::Tensor>& in
   return {topi::reshape(inputs[0], newshape)};
 }
 
-Expr MakeReshape(Expr data, Array<Integer> newshape) {
+Expr MakeReshape(Expr data, Array<Integer> newshape, int allowzero) {
   auto attrs = make_object<ReshapeAttrs>();
   attrs->newshape = std::move(newshape);
+  attrs->allowzero = allowzero;
   static const Op& op = Op::Get("reshape");
   return Call(op, {data}, Attrs(attrs), {});
 }

--- a/tests/python/contrib/test_arm_compute_lib/test_reshape.py
+++ b/tests/python/contrib/test_arm_compute_lib/test_reshape.py
@@ -50,6 +50,7 @@ def _get_expected_codegen(input_shape, output_shape, dtype):
             "newshape": [[str(s) for s in output_shape]],
             "shape": [[list(output_shape)]],
             "dtype": [[dtype]],
+            "allowzero": [["0"]],
         },
     }
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -72,7 +72,7 @@ def get_tvm_output_with_vm(
         convert_config=convert_config,
     )
     print("HELLLOOOOOO", input_data)
-    exit()
+    print("HELLLOOOOOO", mod)
 
     result = relay.create_executor("vm", mod=mod, device=dev, target=target).evaluate()(
         *input_data, **params

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -71,6 +71,8 @@ def get_tvm_output_with_vm(
         freeze_params=freeze_params,
         convert_config=convert_config,
     )
+    print("HELLLOOOOOO", input_data)
+    exit()
 
     result = relay.create_executor("vm", mod=mod, device=dev, target=target).evaluate()(
         *input_data, **params
@@ -5080,7 +5082,7 @@ unsupported_onnx_tests = [
     "test_reduce_sum_keepdims_random",
     "test_reduce_sum_negative_axes_keepdims_example",
     "test_reduce_sum_negative_axes_keepdims_random",
-    "test_reshape_allowzero_reordered",
+    # "test_reshape_allowzero_reordered",
     "test_rnn_seq_length",
     "test_round",
     "test_sequence_insert_at_back",

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5187,7 +5187,7 @@ def test_onnx_nodes(target, dev, onnx_test):
                 outputs.append(numpy_helper.to_array(new_tensor))
             else:
                 raise ImportError(str(tensor) + " not labeled as an import or an output")
-
+                
     tvm_val = get_tvm_output_with_vm(onnx_model, inputs, target, dev)
     if len(outputs) == 1:
         tvm.testing.assert_allclose(outputs[0], tvm_val, rtol=rtol, atol=atol)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5080,7 +5080,6 @@ unsupported_onnx_tests = [
     "test_reduce_sum_keepdims_random",
     "test_reduce_sum_negative_axes_keepdims_example",
     "test_reduce_sum_negative_axes_keepdims_random",
-    # "test_reshape_allowzero_reordered",
     "test_rnn_seq_length",
     "test_round",
     "test_sequence_insert_at_back",

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5187,7 +5187,7 @@ def test_onnx_nodes(target, dev, onnx_test):
                 outputs.append(numpy_helper.to_array(new_tensor))
             else:
                 raise ImportError(str(tensor) + " not labeled as an import or an output")
-                
+
     tvm_val = get_tvm_output_with_vm(onnx_model, inputs, target, dev)
     if len(outputs) == 1:
         tvm.testing.assert_allclose(outputs[0], tvm_val, rtol=rtol, atol=atol)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -71,8 +71,6 @@ def get_tvm_output_with_vm(
         freeze_params=freeze_params,
         convert_config=convert_config,
     )
-    print("HELLLOOOOOO", input_data)
-    print("HELLLOOOOOO", mod)
 
     result = relay.create_executor("vm", mod=mod, device=dev, target=target).evaluate()(
         *input_data, **params


### PR DESCRIPTION
This PR adds the new allowzero parameter described in onnx opset 14 for reshape: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Reshape

allowzero set to true means that a zero in the shape tensor will be treated as a true zero value (aka an empty tensor), as opposed to it signifying to copy the value at the equivalent position in the data tensor. 


It's been a journey. Thanks @jwfromm for co-venturing :ship: :world_map: 

Thoughts? @MargaretQian @anwang2009 @sfvaroglu 
