### PR TITLE
[TIR] Utility function to decide loop mapping for auto tensorization

### DIFF
--- a/python/tvm/tir/schedule/analysis.py
+++ b/python/tvm/tir/schedule/analysis.py
@@ -67,7 +67,7 @@ class TensorizeInfo(Object):
     """Necessary information used for tensorization."""
 
 
-def get_tensorize_loop_mapping(sch: Schedule, block: BlockRV, desc_func: PrimFunc) -> TensorizeInfo:
+def get_tensorize_loop_mapping(sch: Schedule, block: BlockRV, desc_func: PrimFunc) -> Optional[TensorizeInfo]:
     """Establish a mapping between loops in a target block and an intrinsic description
 
     Parameters

--- a/python/tvm/tir/schedule/analysis.py
+++ b/python/tvm/tir/schedule/analysis.py
@@ -67,7 +67,9 @@ class TensorizeInfo(Object):
     """Necessary information used for tensorization."""
 
 
-def get_tensorize_loop_mapping(sch: Schedule, block: BlockRV, desc_func: PrimFunc) -> Optional[TensorizeInfo]:
+def get_tensorize_loop_mapping(
+    sch: Schedule, block: BlockRV, desc_func: PrimFunc
+) -> Optional[TensorizeInfo]:
     """Establish a mapping between loops in a target block and an intrinsic description
 
     Parameters

--- a/python/tvm/tir/schedule/analysis.py
+++ b/python/tvm/tir/schedule/analysis.py
@@ -56,3 +56,8 @@ def suggest_index_map(
         loops,
         predicate,
     )
+
+
+def get_tensorize_loop_mapping(state, block_sref, desc_func):
+    """TODO"""
+    return _ffi_api.GetTensorizeLoopMapping(state, block_sref, desc_func)  # type: ignore

--- a/python/tvm/tir/schedule/analysis.py
+++ b/python/tvm/tir/schedule/analysis.py
@@ -20,9 +20,13 @@ from typing import List, Optional
 from ..buffer import Buffer
 from ..stmt import For
 from ..expr import PrimExpr
-from ..function import IndexMap
+from ..function import IndexMap, PrimFunc
 
 from . import _ffi_api
+from .schedule import Schedule, BlockRV
+
+import tvm._ffi
+from tvm.runtime import Object
 
 
 def suggest_index_map(
@@ -58,6 +62,27 @@ def suggest_index_map(
     )
 
 
-def get_tensorize_loop_mapping(state, block_sref, desc_func):
-    """TODO"""
-    return _ffi_api.GetTensorizeLoopMapping(state, block_sref, desc_func)  # type: ignore
+@tvm._ffi.register_object("tir.schedule.TensorizeInfo")
+class TensorizeInfo(Object):
+    """Necessary information used for tensorization."""
+    pass
+
+
+def get_tensorize_loop_mapping(sch: Schedule, block: BlockRV, desc_func: PrimFunc) -> TensorizeInfo:
+    """Establish a mapping between loops in a target block and an intrinsic description
+
+    Parameters
+    ----------
+    sch : Schedule
+        The schedule to be tensorized
+    block : BlockRV
+        The target block to match against
+    desc_func : PrimFunc
+        The prim func describing the computation to be tensorized
+
+    Returns
+    -------
+    tensorize_info : Optional[TensorizeInfo]
+        TensorizeInfo structure if a valid mapping is found, None otherwise
+    """
+    return _ffi_api.GetTensorizeLoopMapping(sch, block, desc_func)  # type: ignore

--- a/python/tvm/tir/schedule/analysis.py
+++ b/python/tvm/tir/schedule/analysis.py
@@ -17,6 +17,9 @@
 """Analysis used in TensorIR scheduling"""
 from typing import List, Optional
 
+import tvm._ffi
+from tvm.runtime import Object
+
 from ..buffer import Buffer
 from ..stmt import For
 from ..expr import PrimExpr
@@ -24,9 +27,6 @@ from ..function import IndexMap, PrimFunc
 
 from . import _ffi_api
 from .schedule import Schedule, BlockRV
-
-import tvm._ffi
-from tvm.runtime import Object
 
 
 def suggest_index_map(
@@ -65,8 +65,6 @@ def suggest_index_map(
 @tvm._ffi.register_object("tir.schedule.TensorizeInfo")
 class TensorizeInfo(Object):
     """Necessary information used for tensorization."""
-
-    pass
 
 
 def get_tensorize_loop_mapping(sch: Schedule, block: BlockRV, desc_func: PrimFunc) -> TensorizeInfo:

--- a/python/tvm/tir/schedule/analysis.py
+++ b/python/tvm/tir/schedule/analysis.py
@@ -65,6 +65,7 @@ def suggest_index_map(
 @tvm._ffi.register_object("tir.schedule.TensorizeInfo")
 class TensorizeInfo(Object):
     """Necessary information used for tensorization."""
+
     pass
 
 

--- a/python/tvm/tir/stmt_functor.py
+++ b/python/tvm/tir/stmt_functor.py
@@ -60,11 +60,11 @@ def post_order_visit(stmt, fvisit):
 
 def pre_order_visit(stmt, fvisit):
     """Recursive pre-order visit on stmt AST, applying fvisit on each node.
-       If fvisit returns false, it won't visit the children of the node.
+       If fvisit returns False, it won't visit the children of the node.
 
     Parameters
     ----------
-    fvisit: function
+    fvisit: function of the signature Object -> bool
         The visitor function.
     """
     return _ffi_api.PreOrderVisit(stmt, fvisit)  # type: ignore

--- a/python/tvm/tir/stmt_functor.py
+++ b/python/tvm/tir/stmt_functor.py
@@ -58,6 +58,18 @@ def post_order_visit(stmt, fvisit):
     return _ffi_api.PostOrderVisit(stmt, fvisit)  # type: ignore
 
 
+def pre_order_visit(stmt, fvisit):
+    """Recursive pre-order visit on stmt AST, applying fvisit on each node.
+       If fvisit returns false, it won't visit the children of the node.
+
+    Parameters
+    ----------
+    fvisit: function
+        The visitor function.
+    """
+    return _ffi_api.PreOrderVisit(stmt, fvisit)  # type: ignore
+
+
 def substitute(node, vmap):
     """Substitute the var specified by vmap.
 

--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -792,6 +792,10 @@ TVM_REGISTER_GLOBAL("tir.PostOrderVisit").set_body_typed([](ObjectRef node, Pack
   tir::PostOrderVisit(node, [f](const ObjectRef& n) { f(n); });
 });
 
+TVM_REGISTER_GLOBAL("tir.PreOrderVisit").set_body_typed([](ObjectRef node, PackedFunc f) {
+  tir::PreOrderVisit(node, [f](const ObjectRef& n) { return f(n); });
+});
+
 TVM_REGISTER_GLOBAL("tir.Substitute")
     .set_body_typed([](ObjectRef node, Map<Var, PrimExpr> vmap) -> ObjectRef {
       if (node->IsInstance<StmtNode>()) {

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -659,9 +659,9 @@ Array<arith::IntSet> AnalyzeRegionLowerBound(const BufferRegion& region, const P
 /*! \brief Necessary information used for tensorization */
 class TensorizeInfoNode : public Object {
  public:
-  /*! \brief Maps block loops to desc loops */
+  /*! \brief Maps loops in a target block to the ones in an intrinsic description */
   Map<tir::StmtSRef, tir::For> loop_map;
-  /*! \brief Maps loops in desc to its index, outer to inner */
+  /*! \brief Maps loops in an intrinsic description to its index, outer to inner */
   Map<tir::For, Integer> desc_loop_indexer;
 
   void VisitAttrs(AttrVisitor* v) {
@@ -669,7 +669,7 @@ class TensorizeInfoNode : public Object {
     v->Visit("desc_loop_indexer", &desc_loop_indexer);
   }
 
-  static constexpr const char* _type_key = "tir.analysis.TensorizeInfo";
+  static constexpr const char* _type_key = "tir.schedule.TensorizeInfo";
   TVM_DECLARE_FINAL_OBJECT_INFO(TensorizeInfoNode, Object);
 };
 
@@ -678,6 +678,13 @@ class TensorizeInfo : public ObjectRef {
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TensorizeInfo, ObjectRef, TensorizeInfoNode);
 };
 
+/*!
+ * \brief Establish a mapping between loops in a target block and an intrinsic description
+ * \param self The schedule state to be tensorized
+ * \param block_sref The target block to match against
+ * \param desc_func The prim func describing the computation to be tensorized
+ * \return TensorizeInfo structure if a valid mapping is found, NullOpt otherwise
+ */
 Optional<TensorizeInfo> GetTensorizeLoopMapping(const tir::ScheduleState& self,
                                                 const tir::StmtSRef& block_sref,
                                                 const tir::PrimFunc& desc_func);

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -656,6 +656,32 @@ Array<arith::IntSet> AnalyzeRegionLowerBound(const BufferRegion& region, const P
                                              const StmtSRef& dom_high_exclusive,
                                              arith::Analyzer* analyzer);
 
+/*! \brief Necessary information used for tensorization */
+class TensorizeInfoNode : public Object {
+ public:
+  /*! \brief Maps block loops to desc loops */
+  Map<tir::StmtSRef, tir::For> loop_map;
+  /*! \brief Maps loops in desc to its index, outer to inner */
+  Map<tir::For, Integer> desc_loop_indexer;
+
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("loop_map", &loop_map);
+    v->Visit("desc_loop_indexer", &desc_loop_indexer);
+  }
+
+  static constexpr const char* _type_key = "tir.analysis.TensorizeInfo";
+  TVM_DECLARE_FINAL_OBJECT_INFO(TensorizeInfoNode, Object);
+};
+
+class TensorizeInfo : public ObjectRef {
+ public:
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TensorizeInfo, ObjectRef, TensorizeInfoNode);
+};
+
+Optional<TensorizeInfo> GetTensorizeLoopMapping(const tir::ScheduleState& self,
+                                                const tir::StmtSRef& block_sref,
+                                                const tir::PrimFunc& desc_func);
+
 }  // namespace tir
 }  // namespace tvm
 

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -2130,5 +2130,10 @@ Optional<TensorizeInfo> GetTensorizeLoopMapping(const tir::ScheduleState& self,
   return TensorizeInfo(ret);
 }
 
+TVM_REGISTER_GLOBAL("tir.schedule.GetTensorizeLoopMapping")
+    .set_body_typed([](Schedule sch, BlockRV block, PrimFunc desc_func) {
+      return GetTensorizeLoopMapping(sch->state(), sch->GetSRef(block), desc_func);
+    });
+
 }  // namespace tir
 }  // namespace tvm

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <tvm/runtime/container/optional.h>
 #include <tvm/tir/expr.h>
 
 #include "../utils.h"
@@ -2106,22 +2107,58 @@ Optional<TensorizeInfo> GetTensorizeLoopMapping(const tir::ScheduleState& self,
 
   int next_block_ind = block_loops.size() - 1;
   for (int i_desc = n_desc_vars - 1; i_desc >= 0; --i_desc) {
-    const tir::ForNode* desc_loop = desc_loops[i_desc];
+    // Step 4.2. Find the corresponding loop of the i-th block var of desc
+    const PrimExpr& desc_bind = desc_block->iter_values[i_desc];
+    const tir::ForNode* desc_loop = nullptr;
+    IterVarType iter_type_desc;
+    for (int i = 0, n = desc_loops.size(); i < n; ++i) {
+      // Check if desc_bind = loops[i]->loop_var + stuff-irrelevant-of-loop-vars
+      PrimExpr r = analyzer.Simplify(desc_bind - desc_loops[i]->loop_var);
+      if (!UsesVar(r,
+                   [&desc_loop_vars](const VarNode* var) { return desc_loop_vars.count(var); })) {
+        desc_loop = desc_loops[i];
+        iter_type_desc = iter_types_desc[i];
+        break;
+      }
+    }
+    if (desc_loop == nullptr || desc_loop->extent.as<IntImmNode>() == nullptr) {
+      return NullOpt;
+    }
+
     const IntImmNode* int_desc_extent = desc_loop->extent.as<IntImmNode>();
-    if (!int_desc_extent) continue;
 
+    const tir::ForNode* block_loop = nullptr;
+
+    PrimExpr block_bind;
     for (int i_block = next_block_ind; i_block >= 0; --i_block) {
-      const tir::ForNode* block_loop = block_loops[i_block];
-      const IntImmNode* int_block_extent = block_loop->extent.as<IntImmNode>();
+      if (iter_types_block[i_block] == iter_type_desc) {
+        next_block_ind = i_block - 1;
+        block_bind = block->iter_values[i_block];
+        break;
+      }
+    }
 
-      if (!int_block_extent) continue;
-      if (int_block_extent->value % int_desc_extent->value != 0) continue;
-      if (iter_types_block[i_block] != iter_types_desc[i_desc]) continue;
+    for (int i = 0, n = block_loops.size(); i < n; ++i) {
+      PrimExpr r = analyzer.Simplify(block_bind - block_loops[i]->loop_var);
+      if (!UsesVar(r,
+                   [&block_loop_vars](const VarNode* var) { return block_loop_vars.count(var); })) {
+        block_loop = block_loops[i];
+        const IntImmNode* int_block_extent = block_loop->extent.as<IntImmNode>();
 
-      const tir::StmtSRef& block_loop_sref = self->stmt2ref[block_loop];
-      ret->loop_map.Set(block_loop_sref, GetRef<tir::For>(desc_loop));
-      next_block_ind = i_block - 1;
-      break;
+        if (!int_block_extent || int_block_extent->value % int_desc_extent->value != 0) {
+          return NullOpt;
+        }
+
+        const tir::StmtSRef& block_loop_sref = self->stmt2ref[block_loop];
+        auto it = ret->loop_map.find(block_loop_sref);
+        if (it == ret->loop_map.end()) {
+          ret->loop_map.Set(block_loop_sref, GetRef<tir::For>(desc_loop));
+        } else if ((*it).second.get() != desc_loop) {
+          return NullOpt;
+        }
+
+        break;
+      }
     }
   }
 

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -2101,7 +2101,7 @@ Optional<TensorizeInfo> GetTensorizeLoopMapping(const tir::ScheduleState& self,
   const std::vector<IterVarType> iter_types_block = GetBlockVarTypes(block_sref);
   const std::vector<IterVarType> iter_types_desc = GetBlockVarTypes(desc_block->block.get());
 
-  ICHECK(iter_types_block.size() == iter_types_desc.size());
+  ICHECK(desc_loops.size() == static_cast<size_t>(n_desc_vars));
   ICHECK(block_loops.size() == iter_types_block.size());
 
   int next_block_ind = block_loops.size() - 1;

--- a/tests/python/unittest/test_tir_schedule_analysis.py
+++ b/tests/python/unittest/test_tir_schedule_analysis.py
@@ -23,7 +23,7 @@ from tvm.tir.tensor_intrin.x86 import dot_product_16x4_u8i8i32_desc
 
 from tvm.tir import Evaluate, For, ForKind, IndexMap, Var, decl_buffer, floordiv, floormod, Schedule
 from tvm.tir.analysis import expr_deep_equal
-from tvm.tir.schedule.analysis import suggest_index_map, get_tensorize_loop_mapping
+from tvm.tir.schedule.analysis import suggest_index_map, get_tensorize_loop_mapping, TensorizeInfo
 from tvm.script import tir as T
 from tvm.tir.stmt_functor import pre_order_visit
 from tvm.meta_schedule.testing import te_workload
@@ -183,6 +183,8 @@ def test_get_tensorize_loop_mapping_dense_vnni():
     block = s.get_block("compute")
 
     info = get_tensorize_loop_mapping(s, block, dot_product_16x4_u8i8i32_desc)
+
+    assert isinstance(info, TensorizeInfo)
 
     desc_loop_to_sref = dict((v, k) for k, v in info.loop_map.items())
 

--- a/tests/python/unittest/test_tir_schedule_analysis.py
+++ b/tests/python/unittest/test_tir_schedule_analysis.py
@@ -27,7 +27,11 @@ from tvm.tir.schedule.analysis import suggest_index_map, get_tensorize_loop_mapp
 from tvm.script import tir as T
 from tvm.tir.stmt_functor import pre_order_visit
 from tvm.meta_schedule.testing import te_workload
+from tvm.meta_schedule.relay_integration import extract_task_from_relay
 from tvm.te import create_prim_func
+from tvm import relay
+import numpy as np
+from tvm.meta_schedule.tune import Parse
 
 
 def _make_vars(*args: str) -> List[Var]:
@@ -251,9 +255,91 @@ def test_get_tensorize_loop_mapping_matmul_mma():
     assert s.get(desc_loop_to_sref[desc_loops[2]]) == s.get(i2)
 
 
+def test_get_tensorize_loop_mapping_conv2d_nhwc_arm():
+    @T.prim_func
+    def gemm_4x4x4_i8i8i32(a: T.handle, b: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(a, (4, 4), offset_factor=1, dtype="int8")
+        B = T.match_buffer(b, (4, 4), offset_factor=1, dtype="int8")
+        C = T.match_buffer(c, (4, 4), offset_factor=1, dtype="int8")
+
+        with T.block("root"):
+            T.reads(C[0:4, 0:4], A[0:4, 0:4], B[0:4, 0:4])
+            T.writes(C[0:4, 0:4])
+            for i, j, k in T.grid(4, 4, 4):
+                with T.block("update"):
+                    vii, vjj, vkk = T.axis.remap("SSR", [i, j, k])
+                    C[vii, vjj] = C[vii, vjj] + A[vii, vkk] * B[vjj, vkk]
+
+    data_shape = (8, 64, 56, 56)
+    weight_shape = (64, 64, 3, 3)
+
+    data_dtype = "int8"
+    weight_dtype = "int8"
+    out_dtype = "int32"
+
+    data = relay.var("data", shape=data_shape, dtype=data_dtype)
+    weight = relay.var("weight", shape=weight_shape, dtype=weight_dtype)
+    out_channel = weight_shape[0]
+    conv2d = relay.nn.conv2d(
+        data=data,
+        weight=weight,
+        kernel_size=weight_shape[2:],
+        channels=out_channel,
+        padding=(1, 1),
+        strides=(1, 1),
+        out_dtype=out_dtype,
+    )
+
+    relay_mod = tvm.IRModule.from_expr(conv2d)
+
+    data = np.random.randint(low=-127, high=128, size=data_shape).astype("int8")
+    weight_np = np.random.randint(low=-127, high=128, size=weight_shape).astype("int8")
+
+    def convert_conv2d_layout(mod, desired_layouts):
+        with tvm.transform.PassContext(opt_level=3):
+            seq = tvm.transform.Sequential([relay.transform.ConvertLayout(desired_layouts)])
+            return seq(mod)
+
+    relay_mod = convert_conv2d_layout(relay_mod, {"nn.conv2d": ["NHWC", "HWIO"]})
+
+    params = {"weight": weight_np}
+
+    target = "llvm --device arm_cpu --mtriple aarch64-linux-gnu -mattr=+v8.2a,+dotprod"
+    extracted_tasks = extract_task_from_relay(relay_mod, target, params)
+
+    conv2d_tasks = list(
+        filter(
+            lambda task: "conv2d" in task.task_name,
+            extracted_tasks,
+        )
+    )
+
+    mod = Parse._mod(conv2d_tasks[0].dispatched[0])
+
+    s = tvm.tir.Schedule(mod)
+
+    block = s.get_block("C")
+
+    info = get_tensorize_loop_mapping(s, block, gemm_4x4x4_i8i8i32)
+
+    desc_loop_to_sref = dict((v, k) for k, v in info.loop_map.items())
+
+    desc_loops = collect_loops(gemm_4x4x4_i8i8i32)
+
+    for i in range(3):
+        assert desc_loops[i] in desc_loop_to_sref
+
+    _, i1_5, i2_4, i3_3 = s.get_loops(block)
+
+    assert s.get(desc_loop_to_sref[desc_loops[0]]) == s.get(i1_5)
+    assert s.get(desc_loop_to_sref[desc_loops[1]]) == s.get(i2_4)
+    assert s.get(desc_loop_to_sref[desc_loops[2]]) == s.get(i3_3)
+
+
 if __name__ == "__main__":
     # test_suggest_index_map_simple()
     # test_suggest_index_map_bijective()
     # test_get_tensorize_loop_mapping_dense_vnni()
     # test_get_tensorize_loop_mapping_conv2d_nchwc_vnni()
-    test_get_tensorize_loop_mapping_matmul_mma()
+    # test_get_tensorize_loop_mapping_matmul_mma()
+    test_get_tensorize_loop_mapping_conv2d_nhwc_arm()

--- a/tests/python/unittest/test_tir_schedule_analysis.py
+++ b/tests/python/unittest/test_tir_schedule_analysis.py
@@ -243,7 +243,7 @@ def test_get_tensorize_loop_mapping_matmul_mma():
     i0, i1, i2 = s.get_loops(block)
     desc_loops = collect_loops(matmul_16x16x16xf16f16f16_desc)
 
-    for do_reorder in [True, False]:
+    for do_reorder in [False, True]:
         # Mapping should be invariant to the loop permutation
         if do_reorder:
             s.reorder(i2, i0, i1)


### PR DESCRIPTION
Add `TensorizeInfo` structure and `GetTensorizeLoopMapping` function, that are used for determining the correspondence of loops between a target block and an intrinsic description. 

Matching is based on a heuristic: It works in all cases I tested (CPU dot product for dense / conv2d, CPU / GPU matmul), but there is no guarantee that it always finds the "right" mapping. If the mapping is not correct, tensorize would fail.

The original code is https://github.com/spectrometerHBH/tvm/blob/auto-tensorization/src/tir/schedule/analysis/analysis.cc#L1175, I modified this code to support more cases and added tests. I'm sending this PR on behalf of the team, but most of the work were done by others earlier.  

Co-authored-by: Siyuan Feng [Hzfengsy@sjtu.edu.cn](mailto:Hzfengsy@sjtu.edu.cn)
Co-authored-by: Bohan Hou [32121147+spectrometerHBH@users.noreply.github.com](mailto:32121147+spectrometerHBH@users.noreply.github.com)
Co-authored-by: Hongyi Jin [3231950289@qq.com](mailto:3231950289@qq.com)
Co-authored-by: Ruihang Lai [lairuihangdongdong@qq.com](mailto:lairuihangdongdong@qq.com)
Co-authored-by: Wuwei Lin [wuwei@apache.org](mailto:wuwei@apache.org)

@vinx13 @junrushao1994 @spectrometerHBH @Hzfengsy @MasterJH5574 @jinhongyii 