### PR TITLE
Let remote RPCModule get function recursively

### DIFF
--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -432,7 +432,7 @@ TVM_REGISTER_GLOBAL("runtime.RPCTimeEvaluator")
                 << "Cannot find " << f_preproc_name << " in the global function";
             f_preproc = *pf_preproc;
           }
-          PackedFunc pf = m.GetFunction(name, false);
+          PackedFunc pf = m.GetFunction(name, true);
           CHECK(pf != nullptr) << "Cannot find " << name << " in the global registry";
           return WrapTimeEvaluator(pf, dev, number, repeat, min_repeat_ms, f_preproc);
         }


### PR DESCRIPTION
Same reason as we changed the get_function to recursive searching #10881 . 

This is useful when we treat the local module as a data segment and wrap it in another empty LLVM module to reuse the export_lib API. After de-serialization in remote, the data segment will be translated as an imported module. Thus we need to fetch the function recursively.

Also, it will not affect the correctness in previous cases, as the searching process is performed in a BFS order.