### PR TITLE
[TVMScript] Allow `val = buf[index]` without type annotation

### DIFF
--- a/python/tvm/script/tir/node.py
+++ b/python/tvm/script/tir/node.py
@@ -157,3 +157,15 @@ class BufferSlice(ObjectGeneric):
 
     def astype(self, dtype: str, span: Optional[Span] = None) -> PrimExpr:
         return self.asobject().astype(dtype, span)
+
+    @property
+    def dtype(self) -> str:
+        """Return the dtype referenced by the slice.
+
+        Implemented as a property so that ``slice.dtype`` has the same
+        calling convention as ``primexpr.dtype``.  This allows a
+        BufferSlice object can be assigned to a variable without
+        requiring a type annotation on the variable, similar to other
+        expressions.
+        """
+        return self.asobject().dtype

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -63,9 +63,16 @@ namespace tir {
 
 // Var
 Var::Var(String name_hint, DataType dtype, Span span) {
+  // If the dtype uniquely determines the allowed type, then set it.
+  // If dtype is handle, the type annotation should be PointerType,
+  // but this constructor doesn't have enough information to determine
+  // the pointed-to type.
+  Type type_annotation = dtype.is_handle() ? Type() : PrimType(dtype);
+
   auto n = make_object<VarNode>();
   n->name_hint = std::move(name_hint);
   n->dtype = std::move(dtype);
+  n->type_annotation = std::move(type_annotation);
   n->span = std::move(span);
   data_ = std::move(n);
 }

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -63,16 +63,9 @@ namespace tir {
 
 // Var
 Var::Var(String name_hint, DataType dtype, Span span) {
-  // If the dtype uniquely determines the allowed type, then set it.
-  // If dtype is handle, the type annotation should be PointerType,
-  // but this constructor doesn't have enough information to determine
-  // the pointed-to type.
-  Type type_annotation = dtype.is_handle() ? Type() : PrimType(dtype);
-
   auto n = make_object<VarNode>();
   n->name_hint = std::move(name_hint);
   n->dtype = std::move(dtype);
-  n->type_annotation = std::move(type_annotation);
   n->span = std::move(span);
   data_ = std::move(n);
 }

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -235,5 +235,26 @@ def test_match_buffer_int64():
     assert_structural_equal(original, after_roundtrip, True)
 
 
+def test_letstmt_bufferload_without_type_annotation():
+    # Variable assignment of PrimExpr types uses the dtype of the
+    # PrimExpr to determine the variable's dtype.  Parsing of
+    # buf[indices] is done by generating a BufferSlice object, which
+    # handles both store and load cases.  BufferSlice is not a
+    # PrimExpr, and implements BufferSlice.dtype explicitly.
+    @T.prim_func
+    def func_without_type_annotation(A: T.Buffer[(1,), "int32"]):
+        x: T.int32 = A[0]
+        T.evaluate(x)
+
+    @T.prim_func
+    def func_with_type_annotation(A: T.Buffer[(1,), "int32"]):
+        x = A[0]
+        T.evaluate(x)
+
+    assert_structural_equal(
+        func_without_type_annotation, func_with_type_annotation, map_free_vars=True
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -241,19 +241,12 @@ def test_letstmt_bufferload_without_type_annotation():
     # buf[indices] is done by generating a BufferSlice object, which
     # handles both store and load cases.  BufferSlice is not a
     # PrimExpr, and implements BufferSlice.dtype explicitly.
+
+    # Failure occurred during parsing of the tvmscript.
     @T.prim_func
     def func_without_type_annotation(A: T.Buffer[(1,), "int32"]):
-        x: T.int32 = A[0]
-        T.evaluate(x)
-
-    @T.prim_func
-    def func_with_type_annotation(A: T.Buffer[(1,), "int32"]):
         x = A[0]
         T.evaluate(x)
-
-    assert_structural_equal(
-        func_without_type_annotation, func_with_type_annotation, map_free_vars=True
-    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Other instances of `var = expr` were previously allowed without requiring a type annotation, by using the dtype of the expression as the dtype of `var`.  This behavior didn't work for `buf[index]` expressions, which are internally represented as `BufferSlice` python objects, and only converted to `BufferLoad` primexprs when used as an expression.

This commit adds a `dtype` property to `BufferSlice`, allowing `buf[index]` to be used in a let statement without a type annotation.