### PR TITLE
[TVMScript] Allow parameters in @T.prim_func definition

### DIFF
--- a/python/tvm/script/tir/prim_func.py
+++ b/python/tvm/script/tir/prim_func.py
@@ -17,27 +17,47 @@
 """TVM Script Interface for PrimFunc"""
 
 import inspect
-from typing import Callable
+from typing import Callable, Dict, Any, Optional
 
 from tvm.tir.function import PrimFunc
 from ..parser import from_source
 
 
-def prim_func(input_func: Callable) -> PrimFunc:
+def prim_func(
+    input_func: Optional[Callable] = None, *, params: Optional[Dict[str, Any]] = None
+) -> PrimFunc:
     """Decorate a python function as tvm script.
 
     Parameters
     ----------
-    func : input_func
+    input_func : Optional[Callable]
+
         The function to be parsed.
+
+    params: Optional[Dict[str,Any]]
+
+        A variable look-up table.  Variables defined within the body
+        of the function take precedence over the variables in the
+        params dictionary.  Variable types should be supported by
+        tvm.runtime.convert.
+
+        This is a keyword-only argument, to require explicit opt-in to
+        using parameters.
 
     Returns
     -------
     output : PrimFunc
         The result functions.
     """
+    if input_func is None:
+
+        def wrapper(input_func: Callable):
+            return prim_func(input_func=input_func, params=params)
+
+        return wrapper
+
     if inspect.isfunction(input_func):
-        result = from_source(input_func)
+        result = from_source(input_func, params=params)
         result.__name__ = input_func.__name__
         result.__qualname__ = input_func.__qualname__
         return result


### PR DESCRIPTION
This extends the existing `@T.prim_func` decorator to accept a keyword-only argument `@T.prim_func(params=param_dict)`, defining a string to object mapping.  This mapping can be used to refer to external parameters from within the `PrimFunc` definition.