### PR TITLE
[TVMC] Add configuration json files to the Python package

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -69,6 +69,13 @@ def get_lib_path():
                 libs.append(candidate_path)
                 break
 
+        # Add tvmc configuration json files
+        for name in lib_path:
+            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "configs"))
+            if os.path.isdir(candidate_path):
+                libs.append(candidate_path)
+                break
+
     else:
         libs = None
 


### PR DESCRIPTION
Add the `configs` directory to be part of the installed version of TVM in the setuptools configuration, and introduce a new function to load the `configs` directory from the right paths both when TVM is locally installed for development, as well as, when it is installed as a package.

This builds on top of https://github.com/apache/tvm/pull/11012, just adding support for the files to be added in the package. More testing needs to be added (planning for that in future patches) to support some system testing of the packaged version of TVM.

cc @Mousius @gromero @areusch for reviews