### PR TITLE
[frontend][ONNX]support ConvTranspose explicitly specified output_shape

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -622,19 +622,47 @@ class ConvTranspose(OnnxOpConverter):
         data = inputs[0]
         input_shape = infer_shape(data)
         ndim = len(input_shape)
-        if "auto_pad" in attr:
-            attr["auto_pad"] = attr["auto_pad"].decode("utf-8")
-            if attr["auto_pad"] in ("SAME_UPPER", "SAME_LOWER"):
+        if "pads" not in attr:
+            assert "auto_pad" in attr or "output_shape" in attr
+        if "auto_pad" in attr or "output_shape" in attr:
+            if "auto_pad" in attr:
+                attr["auto_pad"] = attr["auto_pad"].decode("utf-8")
+            if "output_shape" in attr or attr["auto_pad"] in ("SAME_UPPER", "SAME_LOWER"):
                 # Warning: Convolution does not yet support dynamic shapes,
                 # one will need to run dynamic_to_static on this model after import
-                data = autopad(
-                    data,
-                    attr.get("strides", [1] * (ndim - 2)),
-                    attr["kernel_shape"],
-                    attr.get("dilations", [1] * (ndim - 2)),
-                    deconv=True,
-                    mode=attr["auto_pad"],
-                )
+                kernel_shape = attr["kernel_shape"]
+                kndim = len(kernel_shape)
+                dilations = attr.get("dilations", [1] * kndim)
+                output_padding = attr.get("output_padding", [0] * kndim)
+                strides = attr["strides"]
+                total_pad = [0] * kndim
+                # https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose
+                if "output_shape" in attr:
+                    for i in range(kndim):
+                        total_pad[i] = (
+                            strides[i] * (input_shape[ndim - kndim + i] - 1)
+                            + output_padding[i]
+                            + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                            - attr["output_shape"][i]
+                        )
+                    left = [p // 2 for p in total_pad]
+                    right = [total_pad[i] - left[i] for i in range(kndim)]
+                    if "output_shape" in attr and "auto_pad" not in attr:
+                        pad = right + left
+                    elif "LOWER" in attr["auto_pad"]:
+                        pad = left + right
+                    else:
+                        pad = right + left
+                    attr["pads"] = pad
+                else:
+                    data = autopad(
+                        data,
+                        attr.get("strides", [1] * (ndim - 2)),
+                        attr["kernel_shape"],
+                        attr.get("dilations", [1] * (ndim - 2)),
+                        deconv=True,
+                        mode=attr["auto_pad"],
+                    )
             elif attr["auto_pad"] == "VALID":
                 attr["pads"] = tuple([0 for i in range(ndim - 2)])
             elif attr["auto_pad"] == "NOTSET":
@@ -642,7 +670,8 @@ class ConvTranspose(OnnxOpConverter):
             else:
                 msg = 'Value {} in attribute "auto_pad" of operator Conv is invalid.'
                 raise tvm.error.OpAttributeInvalid(msg.format(attr["auto_pad"]))
-            attr.pop("auto_pad")
+            if "auto_pad" in attr:
+                attr.pop("auto_pad")
 
         out = AttrCvt(
             op_name=dimension_picker("conv", "_transpose"),
@@ -691,7 +720,7 @@ class ConvTranspose(OnnxOpConverter):
                 output_padding = attr.get("output_padding", [0] * kndim)
                 strides = attr["strides"]
                 total_pad = [0] * kndim
-                ## https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose
+                # https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose
                 if "output_shape" in attr:
                     for i in range(kndim):
                         total_pad[i] = (
@@ -710,7 +739,7 @@ class ConvTranspose(OnnxOpConverter):
                 left = [p // 2 for p in total_pad]
                 right = [total_pad[i] - left[i] for i in range(kndim)]
                 if "output_shape" in attr and "auto_pad" not in attr:
-                    pad = left + right
+                    pad = right + left
                 elif "LOWER" in attr["auto_pad"]:
                     pad = left + right
                 else:

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -622,8 +622,6 @@ class ConvTranspose(OnnxOpConverter):
         data = inputs[0]
         input_shape = infer_shape(data)
         ndim = len(input_shape)
-        if "pads" not in attr:
-            assert "auto_pad" in attr or "output_shape" in attr
         if "auto_pad" in attr or "output_shape" in attr:
             if "auto_pad" in attr:
                 attr["auto_pad"] = attr["auto_pad"].decode("utf-8")
@@ -706,8 +704,6 @@ class ConvTranspose(OnnxOpConverter):
         data = inputs[0]
         input_shape = infer_shape(data)
         ndim = len(input_shape)
-        if "pads" not in attr:
-            assert "auto_pad" in attr or "output_shape" in attr
         if "auto_pad" in attr or "output_shape" in attr:
             if "auto_pad" in attr:
                 attr["auto_pad"] = attr["auto_pad"].decode("utf-8")

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -678,7 +678,7 @@ class ConvTranspose(OnnxOpConverter):
         input_shape = infer_shape(data)
         ndim = len(input_shape)
         if "pads" not in attr:
-             assert "auto_pad" in attr or "output_shape" in attr
+            assert "auto_pad" in attr or "output_shape" in attr
         if "auto_pad" in attr or "output_shape" in attr:
             if "auto_pad" in attr:
                 attr["auto_pad"] = attr["auto_pad"].decode("utf-8")
@@ -693,8 +693,10 @@ class ConvTranspose(OnnxOpConverter):
                 total_pad = [0] * kndim
                 for i in range(kndim):
                     total_pad[i] = (
-                        strides[i] * (input_shape[ndim - kndim + i] - 1) + output_padding[i] + \
-                            ((kernel_shape[i] - 1) * dilations[i] + 1) - attr["output_shape"][i]
+                        strides[i] * (input_shape[ndim - kndim + i] - 1)
+                        + output_padding[i]
+                        + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                        - attr["output_shape"][i]
                     )
                 left = [p // 2 for p in total_pad]
                 right = [total_pad[i] - left[i] for i in range(kndim)]

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -702,7 +702,9 @@ class ConvTranspose(OnnxOpConverter):
                 else:
                     for i in range(kndim):
                         total_pad[i] = (
-                            output_padding[i] + ((kernel_shape[i] - 1) * dilations[i] + 1) - strides[i]
+                            output_padding[i]
+                            + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                            - strides[i]
                         )
                 left = [p // 2 for p in total_pad]
                 right = [total_pad[i] - left[i] for i in range(kndim)]

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -691,6 +691,7 @@ class ConvTranspose(OnnxOpConverter):
                 output_padding = attr.get("output_padding", [0] * kndim)
                 strides = attr["strides"]
                 total_pad = [0] * kndim
+                ## https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose
                 if "output_shape" in attr:
                     for i in range(kndim):
                         total_pad[i] = (
@@ -709,8 +710,6 @@ class ConvTranspose(OnnxOpConverter):
                 left = [p // 2 for p in total_pad]
                 right = [total_pad[i] - left[i] for i in range(kndim)]
                 if "output_shape" in attr and "auto_pad" not in attr:
-                    # assert left[0] == right[0] and left[1] == right[1],\
-                    #     "attribute auto_pad is not configured!"
                     pad = left + right
                 elif "LOWER" in attr["auto_pad"]:
                     pad = left + right

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -691,13 +691,19 @@ class ConvTranspose(OnnxOpConverter):
                 output_padding = attr.get("output_padding", [0] * kndim)
                 strides = attr["strides"]
                 total_pad = [0] * kndim
-                for i in range(kndim):
-                    total_pad[i] = (
-                        strides[i] * (input_shape[ndim - kndim + i] - 1)
-                        + output_padding[i]
-                        + ((kernel_shape[i] - 1) * dilations[i] + 1)
-                        - attr["output_shape"][i]
-                    )
+                if "output_shape" in attr:
+                    for i in range(kndim):
+                        total_pad[i] = (
+                            strides[i] * (input_shape[ndim - kndim + i] - 1)
+                            + output_padding[i]
+                            + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                            - attr["output_shape"][i]
+                        )
+                else:
+                    for i in range(kndim):
+                        total_pad[i] = (
+                            output_padding[i] + ((kernel_shape[i] - 1) * dilations[i] + 1) - strides[i]
+                        )
                 left = [p // 2 for p in total_pad]
                 right = [total_pad[i] - left[i] for i in range(kndim)]
                 if "output_shape" in attr and "auto_pad" not in attr:

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5101,7 +5101,6 @@ unsupported_onnx_tests = [
     "test_castlike_STRING_to_FLOAT_expanded",
     "test_convtranspose_autopad_same",
     "test_convtranspose_dilations",
-    "test_convtranspose_output_shape",
     "test_cumsum_1d",
     "test_cumsum_1d_exclusive",
     "test_cumsum_1d_reverse",

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -3032,15 +3032,15 @@ def test_convtranspose(target, dev):
                 repeat(1, D),
             )
 
-        verify_convtranspose_with_output_shape(
-            (1, 1) + repeat(32, D),
-            (1, 1) + repeat(4, D),
-            repeat(N, D),
-            repeat(4, D),
-            repeat(2, D),
-            repeat(1, D),
-            auto_pad="SAME_LOWER",
-        )
+            verify_convtranspose_with_output_shape(
+                (1, 1) + repeat(32, D),
+                (1, 1) + repeat(4, D),
+                repeat(N, D),
+                repeat(4, D),
+                repeat(2, D),
+                repeat(1, D),
+                auto_pad="SAME_LOWER",
+            )
 
 @tvm.testing.parametrize_targets
 def test_unsqueeze_constant(target, dev):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2815,6 +2815,48 @@ def test_conv(target, dev):
 
 @tvm.testing.parametrize_targets
 def test_convtranspose(target, dev):
+    def verify_convtranspose_with_output_shape(
+        x_shape,
+        w_shape,
+        output_shape,
+        kernel_shape,
+        strides,
+        dilations,
+        auto_pad="SAME_UPPER",
+        group=1,
+    ):
+        node = helper.make_node(
+            "ConvTranspose",
+            inputs=["x", "W"],
+            outputs=["y"],
+            kernel_shape=kernel_shape,
+            # Default values for other attributes:
+            strides=strides,
+            dilations=dilations,
+            output_shape=output_shape,
+            auto_pad=auto_pad,
+        )
+
+        if group is not None:
+            group_attr = helper.make_attribute("group", group)
+            node.attribute.append(group_attr)
+
+        graph = helper.make_graph(
+            [node],
+            "ConvTranspose_with_output_shape_test",
+            inputs=[
+                helper.make_tensor_value_info("x", TensorProto.FLOAT, list(x_shape)),
+                helper.make_tensor_value_info("W", TensorProto.FLOAT, list(w_shape)),
+            ],
+            outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1] + list(output_shape))],
+        )
+
+        model = helper.make_model(graph, producer_name="convtranspose_output_shape_test")
+
+        verify_with_ort(
+            model, [x_shape, w_shape], use_vm=True, target=target, dev=dev
+        )
+
     def verify_convtranspose_with_padding(
         x_shape,
         w_shape,
@@ -2978,6 +3020,27 @@ def test_convtranspose(target, dev):
         #     repeat(2, D),
         # )
 
+    # Convolution with output_shape
+    for D in [1, 2, 3]:
+        for N in range(60, 66):
+            verify_convtranspose_with_output_shape(
+                (1, 1) + repeat(32, D),
+                (1, 1) + repeat(4, D),
+                repeat(N, D),
+                repeat(4, D),
+                repeat(2, D),
+                repeat(1, D),
+            )
+
+        verify_convtranspose_with_output_shape(
+            (1, 1) + repeat(32, D),
+            (1, 1) + repeat(4, D),
+            repeat(N, D),
+            repeat(4, D),
+            repeat(2, D),
+            repeat(1, D),
+            auto_pad="SAME_LOWER",
+        )
 
 @tvm.testing.parametrize_targets
 def test_unsqueeze_constant(target, dev):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2848,14 +2848,14 @@ def test_convtranspose(target, dev):
                 helper.make_tensor_value_info("x", TensorProto.FLOAT, list(x_shape)),
                 helper.make_tensor_value_info("W", TensorProto.FLOAT, list(w_shape)),
             ],
-            outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1] + list(output_shape))],
+            outputs=[
+                helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1] + list(output_shape))
+            ],
         )
 
         model = helper.make_model(graph, producer_name="convtranspose_output_shape_test")
 
-        verify_with_ort(
-            model, [x_shape, w_shape], use_vm=True, target=target, dev=dev
-        )
+        verify_with_ort(model, [x_shape, w_shape], use_vm=True, target=target, dev=dev)
 
     def verify_convtranspose_with_padding(
         x_shape,
@@ -3041,6 +3041,7 @@ def test_convtranspose(target, dev):
                 repeat(1, D),
                 auto_pad="SAME_LOWER",
             )
+
 
 @tvm.testing.parametrize_targets
 def test_unsqueeze_constant(target, dev):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -3041,7 +3041,7 @@ def test_convtranspose(target, dev):
                 repeat(1, D),
                 auto_pad="SAME_LOWER",
             )
- 
+
 
 @tvm.testing.parametrize_targets
 def test_unsqueeze_constant(target, dev):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -3041,7 +3041,7 @@ def test_convtranspose(target, dev):
                 repeat(1, D),
                 auto_pad="SAME_LOWER",
             )
-
+ 
 
 @tvm.testing.parametrize_targets
 def test_unsqueeze_constant(target, dev):


### PR DESCRIPTION
When I import the onnx model efficientdet_lite.onnx. There are some ConvTranspose operator just provide `output_shape` attributes. no `pads`. As shown in the picture below:
![image](https://user-images.githubusercontent.com/50271153/164190563-340e13a6-9623-4ac3-85be-3591a8d6fd67.png)
Then i get a error is the
 ```
AssertionError: Output shapes (1, 256, 256, 16) and (1, 270, 270, 16) don't match
```
According the doc: https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose
```
total_padding[i] = stride[i] * (input_size[i] - 1) + output_padding[i] + ((kernel_shape[i] - 1) * dilations[i] + 1) - output_shape[i]
```
I updated how `total_padding` is calculated. And support  explicitly specified the ```output_shape```.

cc: @MatthewARM  @jwfromm  @AndrewZhaoLuo  


