### PR TITLE
[RPC] Don't use existence of USE_HEXAGON_SDK as enablement check

### DIFF
--- a/apps/cpp_rpc/CMakeLists.txt
+++ b/apps/cpp_rpc/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(
   PUBLIC DMLC_PATH
 )
 
-if (BUILD_FOR_ANDROID AND USE_HEXAGON_SDK)
+if (BUILD_FOR_ANDROID AND USE_HEXAGON)
   get_hexagon_sdk_property("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}"
     DSPRPC_LIB DSPRPC_LIB_DIRS
   )


### PR DESCRIPTION
Use `USE_HEXAGON` to check if Hexagon support is enabled or not.

This fixes https://github.com/apache/tvm/issues/11059.