### PR TITLE
[ci] Switch to requiring `pr-head` for merges

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -56,7 +56,7 @@ github:
       required_status_checks:
         contexts:
           # Require a passing run from Jenkins
-          - tvm-ci/pr-merge
+          - tvm-ci/pr-head
 
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
This is necessary to fix the bug where PRs rebuild when editing the description.s

cc @areusch 
