### PR TITLE
[test][do not review] Test local re-run info

### DIFF
--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -86,7 +86,7 @@ microtvm_lib = 'build/microtvm_template_projects.tar.gz, ' + tvm_lib
 upstream_revision = null
 
 // command to start a docker container
-docker_run = 'docker/bash.sh --env CI --env TVM_SHARD_INDEX --env TVM_NUM_SHARDS'
+docker_run = 'docker/bash.sh --env CI --env TVM_SHARD_INDEX --env TVM_NUM_SHARDS --env RUN_DISPLAY_URL --env PLATFORM'
 docker_build = 'docker/build.sh'
 // timeout in minutes
 max_time = 240
@@ -612,7 +612,13 @@ stage('Test') {
     SKIP_SLOW_TESTS = "${skip_slow_tests}"
   }
   parallel(
-  {% call m.sharded_test_step(name="unittest: GPU", num_shards=2, node="GPU", ws="tvm/ut-python-gpu") %}
+  {% call m.sharded_test_step(
+    name="unittest: GPU",
+    num_shards=2,
+    node="GPU",
+    ws="tvm/ut-python-gpu",
+    platform="gpu",
+  ) %}
     unpack_lib('gpu2', tvm_multilib)
     cpp_unittest(ci_gpu)
 
@@ -632,7 +638,13 @@ stage('Test') {
       label: 'Run Python GPU integration tests',
     )
   {% endcall %}
-  {% call m.sharded_test_step(name="integration: CPU", node="CPU", num_shards=2, ws="tvm/integration-python-cpu") %}
+  {% call m.sharded_test_step(
+    name="integration: CPU",
+    node="CPU",
+      num_shards=2,
+      ws="tvm/integration-python-cpu",
+      platform="cpu",
+    ) %}
     unpack_lib('cpu', tvm_multilib_tsim)
     ci_setup(ci_cpu)
     sh (
@@ -640,7 +652,11 @@ stage('Test') {
       label: 'Run CPU integration tests',
     )
   {% endcall %}
-  {% call m.test_step(name="unittest: CPU", node="CPU", ws="tvm/ut-python-cpu") %}
+  {% call m.test_step(
+    name="unittest: CPU",
+    node="CPU", ws="tvm/ut-python-cpu",
+    platform="cpu",
+  ) %}
     unpack_lib('cpu', tvm_multilib_tsim)
     ci_setup(ci_cpu)
     cpp_unittest(ci_cpu)
@@ -651,7 +667,13 @@ stage('Test') {
       label: 'Run VTA tests in TSIM',
     )
   {% endcall %}
-  {% call m.sharded_test_step(name="python: i386", node="CPU", num_shards=2, ws="tvm/integration-python-i386") %}
+  {% call m.sharded_test_step(
+    name="python: i386",
+    node="CPU",
+      num_shards=2,
+      ws="tvm/integration-python-i386",
+      platform="i386",
+    ) %}
     unpack_lib('i386', tvm_multilib)
     ci_setup(ci_i386)
     cpp_unittest(ci_i386)
@@ -662,7 +684,11 @@ stage('Test') {
     )
     fsim_test(ci_i386)
   {% endcall %}
-  {% call m.test_step(name="test: Hexagon", node="CPU", ws="tvm/test-hexagon") %}
+  {% call m.test_step(
+    name="test: Hexagon",
+    node="CPU", ws="tvm/test-hexagon",
+    platform="hexagon",
+  ) %}
     unpack_lib('hexagon', tvm_lib)
     ci_setup(ci_hexagon)
     cpp_unittest(ci_hexagon)
@@ -675,7 +701,11 @@ stage('Test') {
       label: 'Run Hexagon tests',
     )
   {% endcall %}
-  {% call m.test_step(name="test: QEMU", node="CPU", ws="tvm/test-qemu") %}
+  {% call m.test_step(
+    name="test: QEMU",
+    node="CPU", ws="tvm/test-qemu",
+    platform="qemu",
+  ) %}
     unpack_lib('qemu', microtvm_lib)
     sh(
       script: 'cd build && tar -xzvf microtvm_template_projects.tar.gz',
@@ -692,7 +722,12 @@ stage('Test') {
       label: 'Run microTVM demos',
     )
   {% endcall %}
-  {% call m.test_step(name="topi: aarch64", node="ARM", ws="tvm/ut-python-arm") %}
+  {% call m.test_step(
+    name="topi: aarch64",
+    node="ARM",
+    ws="tvm/ut-python-arm",
+    platform="arm",
+) %}
     unpack_lib('arm', tvm_multilib)
     ci_setup(ci_arm)
     cpp_unittest(ci_arm)
@@ -705,7 +740,12 @@ stage('Test') {
       label: 'Run TOPI tests',
     )
   {% endcall %}
-  {% call m.sharded_test_step(name="integration: aarch64", num_shards=2, node="ARM", ws="tvm/ut-python-arm") %}
+  {% call m.sharded_test_step(
+    name="integration: aarch64",
+    num_shards=2,
+    node="ARM", ws="tvm/ut-python-arm",
+    platform="arm",
+  ) %}
     unpack_lib('arm', tvm_multilib)
     ci_setup(ci_arm)
     python_unittest(ci_arm)
@@ -714,7 +754,13 @@ stage('Test') {
       label: 'Run CPU integration tests',
     )
   {% endcall %}
-  {% call m.sharded_test_step(name="topi: GPU", node="GPU", num_shards=2, ws="tvm/topi-python-gpu") %}
+  {% call m.sharded_test_step(
+    name="topi: GPU", 
+    node="GPU",
+    num_shards=2,
+    ws="tvm/topi-python-gpu",
+    platform="gpu",
+  ) %}
     unpack_lib('gpu', tvm_multilib)
     ci_setup(ci_gpu)
     sh (
@@ -722,7 +768,12 @@ stage('Test') {
       label: 'Run TOPI tests',
     )
   {% endcall %}
-  {% call m.sharded_test_step(name="frontend: GPU", node="GPU", num_shards=3, ws="tvm/frontend-python-gpu") %}
+  {% call m.sharded_test_step(
+    name="frontend: GPU", node="GPU",
+    num_shards=3,
+    ws="tvm/frontend-python-gpu",
+    platform="gpu",
+  ) %}
     unpack_lib('gpu', tvm_multilib)
     ci_setup(ci_gpu)
     sh (
@@ -730,7 +781,12 @@ stage('Test') {
       label: 'Run Python frontend tests',
     )
   {% endcall %}
-  {% call m.test_step(name="frontend: CPU", node="CPU", ws="tvm/frontend-python-cpu") %}
+  {% call m.test_step(
+    name="frontend: CPU",
+    node="CPU",
+    ws="tvm/frontend-python-cpu",
+    platform="cpu",
+) %}
     unpack_lib('cpu', tvm_multilib)
     ci_setup(ci_cpu)
     sh (
@@ -738,7 +794,12 @@ stage('Test') {
       label: 'Run Python frontend tests',
     )
   {% endcall %}
-  {% call m.test_step(name="frontend: aarch64", node="ARM", ws="tvm/frontend-python-arm") %}
+  {% call m.test_step(
+    name="frontend: aarch64",
+    node="ARM",
+    ws="tvm/frontend-python-arm",
+    platform="arm",
+) %}
     unpack_lib('arm', tvm_multilib)
     ci_setup(ci_arm)
     sh (

--- a/jenkins/macros.j2
+++ b/jenkins/macros.j2
@@ -19,7 +19,7 @@
   "workspace/exec_${env.EXECUTOR_NUMBER}/{{ folder }}"
 {%- endmacro -%}
 
-{% macro sharded_test_step(name, num_shards, node, ws) %}
+{% macro sharded_test_step(name, num_shards, node, ws, platform) %}
 {% for shard_index in range(1, num_shards + 1) %}
   '{{ name }} {{ shard_index }} of {{ num_shards }}': {
     if (!skip_ci && is_docs_only_build != 1) {
@@ -29,6 +29,7 @@
             init_git()
             timeout(time: max_time, unit: 'MINUTES') {
               withEnv([
+                'PLATFORM={{ platform }}',
                 'TVM_NUM_SHARDS={{ num_shards }}',
                 'TVM_SHARD_INDEX={{ shard_index - 1 }}'], {
                 {{ caller() | trim | indent(width=12) }}
@@ -47,7 +48,7 @@
 {% endmacro %}
 
 
-{% macro test_step(name, node, ws) %}
+{% macro test_step(name, node, ws, platform) %}
   '{{ name }}': {
     if (!skip_ci && is_docs_only_build != 1) {
       node('{{ node }}') {
@@ -55,7 +56,9 @@
           timeout(time: max_time, unit: 'MINUTES') {
             try {
               init_git()
-              {{ caller() | indent(width=10) | trim }}
+              withEnv(['PLATFORM={{ platform }}'], {
+                {{ caller() | indent(width=12) | trim }}
+              })
             } finally {
               junit 'build/pytest-results/*.xml'
             }

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -35,6 +35,7 @@ class TempGit:
 
 
 def test_cc_reviewers(tmpdir_factory):
+    assert 1 == 0
     reviewers_script = REPO_ROOT / "tests" / "scripts" / "github_cc_reviewers.py"
 
     def run(pr_body, requested_reviewers, existing_review_users, expected_reviewers):
@@ -209,6 +210,7 @@ def test_update_branch(tmpdir_factory):
 
 
 def test_skip_ci(tmpdir_factory):
+    assert 1 == 0
     skip_ci_script = REPO_ROOT / "tests" / "scripts" / "git_skip_ci.py"
 
     def test(commands, should_skip, pr_title, why):

--- a/tests/python/unittest/test_lower_build.py
+++ b/tests/python/unittest/test_lower_build.py
@@ -130,6 +130,7 @@ def test_lower_build_tir_module():
 
 
 def test_lower_build_lowered_module():
+    assert 1 == 0
     # check lowering with the CSE pass disabled as otherwise it would do some commoning
     with tvm.transform.PassContext(opt_level=3, disabled_pass=["tir.CommonSubexprElimTIR"]):
         ir_mod = tvm.lower(LoweredTIRModule)

--- a/tests/scripts/pytest_wrapper.py
+++ b/tests/scripts/pytest_wrapper.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import argparse
+import textwrap
+import junitparser
+from pathlib import Path
+from typing import List, Optional
+import os
+import urllib.parse
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def lstrip(s: str, prefix: str) -> str:
+    if s.startswith(prefix):
+        s = s[len(prefix) :]
+    return s
+
+
+def classname_to_file(classname: str) -> str:
+    classname = lstrip(classname, "cython.")
+    classname = lstrip(classname, "ctypes.")
+    return classname.replace(".", "/") + ".py"
+
+
+def failed_test_ids() -> List[str]:
+    FAILURE_TYPES = (junitparser.Failure, junitparser.Error)
+    junit_dir = REPO_ROOT / "build" / "pytest-results"
+    failed_node_ids = []
+    for junit in junit_dir.glob("*.xml"):
+        xml = junitparser.JUnitXml.fromfile(str(junit))
+        for suite in xml:
+            # handle suites
+            for case in suite:
+                if len(case.result) > 0 and isinstance(case.result[0], FAILURE_TYPES):
+                    node_id = classname_to_file(case.classname) + "::" + case.name
+                    failed_node_ids.append(node_id)
+
+    return list(set(failed_node_ids))
+
+
+def repro_command(build_type: str, failed_node_ids: List[str]) -> Optional[str]:
+    """
+    Parse available JUnit XML files and output a command that users can run to
+    reproduce CI failures locally
+    """
+    test_args = [f"--tests {node_id}" for node_id in failed_node_ids]
+    test_args_str = " ".join(test_args)
+    return f"python3 tests/scripts/ci.py {build_type} {test_args_str}"
+
+
+def make_issue_url(failed_node_ids: List[str]) -> str:
+    names = [f"`{node_id}`" for node_id in failed_node_ids]
+    run_url = os.getenv("RUN_DISPLAY_URL", "<insert run URL>")
+    test_bullets = [f"  - `{node_id}`" for node_id in failed_node_ids]
+    params = {
+        "labels": "test: flaky",
+        "title": "[Flaky Test] " + ", ".join(names),
+        "body": textwrap.dedent(
+            f"""
+            These tests were found to be flaky (intermittently failing on `main` or failed in a PR with unrelated changes). See [the docs](https://github.com/apache/tvm/blob/main/docs/contribute/ci.rst#handling-flaky-failures) for details.
+
+            ### Tests(s)\n
+            """
+        )
+        + "\n".join(test_bullets)
+        + f"\n\n### Jenkins Links\n\n  - {run_url}",
+    }
+    return "https://github.com/apache/tvm/issues/new?" + urllib.parse.urlencode(params)
+
+
+def show_failure_help(failed_suites: List[str]) -> None:
+    failed_node_ids = failed_test_ids()
+
+    if len(failed_node_ids) == 0:
+        return
+
+    build_type = os.getenv("PLATFORM")
+
+    if build_type is None:
+        raise RuntimeError("build type was None, cannot show command")
+
+    repro = repro_command(build_type=build_type, failed_node_ids=failed_node_ids)
+    if repro is None:
+        print("No test failures detected")
+        return
+
+    print("=============================== PYTEST FAILURES ================================")
+    print(
+        "These pytest suites failed to execute. The results can be found in the "
+        "Jenkins 'Tests' tab or by scrolling up through the raw logs here. "
+        "If there is no test listed below, the failure likely came from a segmentation "
+        "fault which you can find in the logs above.\n"
+    )
+    if len(failed_suites) > 0:
+        print("\n".join([f"    - {suite}" for suite in failed_suites]))
+        print("")
+
+    print("You can reproduce these specific failures locally with this command:\n")
+    print(textwrap.indent(repro, prefix="    "))
+    print("")
+
+    print(
+        "If you believe these test failures are spurious or are not due to this change, "
+        f"please file an issue: {make_issue_url(failed_node_ids)}"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Print information about a failed pytest run")
+    args, other = parser.parse_known_args()
+    try:
+        show_failure_help(failed_suites=other)
+    except Exception as e:
+        # This script shouldn't ever introduce failures since it's just there to
+        # add extra information, so ignore any errors
+        print(e)

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -39,10 +39,7 @@ function cleanup() {
     set +x
     if [ "${#pytest_errors[@]}" -gt 0 ]; then
         echo "These pytest invocations failed, the results can be found in the Jenkins 'Tests' tab or by scrolling up through the raw logs here."
-        echo ""
-        for e in "${pytest_errors[@]}"; do
-            echo "  ${e}"
-        done
+        python3 tests/scripts/pytest_wrapper.py "${pytest_errors[@]}"
         exit 1
     fi
     set -x


### PR DESCRIPTION
This adds a note about `ci.py` with relevant tests when failures are detected. This should help advertise `ci.py` and make it more clear how to reproduce failures locally. This also adds a long link that makes it a short process to report a test on a build as flaky.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
