### PR TITLE
[PY] change hardcoded names of loggers to `__name__`

### DIFF
--- a/apps/topi_recipe/conv/test_conv_int8_arm.py
+++ b/apps/topi_recipe/conv/test_conv_int8_arm.py
@@ -24,7 +24,7 @@ from tvm import te
 from tvm import topi
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-LOGGER = logging.getLogger("test_conv_int8_intel")
+LOGGER = logging.getLogger(__name__)
 LOGGER.disabled = False
 
 # All the WORKLOADS from Resnet except first layer

--- a/apps/topi_recipe/conv/test_conv_int8_intel.py
+++ b/apps/topi_recipe/conv/test_conv_int8_intel.py
@@ -24,7 +24,7 @@ from tvm import te
 from tvm import topi
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-LOGGER = logging.getLogger("test_conv_int8_intel")
+LOGGER = logging.getLogger(__name__)
 LOGGER.disabled = False
 
 # All the WORKLOADS from Resnet except first layer

--- a/docs/arch/relay_op_strategy.rst
+++ b/docs/arch/relay_op_strategy.rst
@@ -278,5 +278,5 @@ model to learn which implementation is used for each operator.
 
 .. code:: python
 
-    logging.getLogger("te_compiler").setLevel(logging.INFO)
-    logging.getLogger("te_compiler").addHandler(logging.StreamHandler(sys.stdout))
+    logging.getLogger("tvm.relay.backend.te_compiler").setLevel(logging.INFO)
+    logging.getLogger("tvm.relay.backend.te_compiler").addHandler(logging.StreamHandler(sys.stdout))

--- a/docs/contribute/code_guide.rst
+++ b/docs/contribute/code_guide.rst
@@ -88,6 +88,7 @@ Python Code Styles
 - The functions and classes are documented in `numpydoc <https://numpydoc.readthedocs.io/en/latest/>`_ format.
 - Check your code style using ``python tests/scripts/ci.py lint``
 - Stick to language features in ``python 3.7``
+- If you use `logging` module, you should use generic logger names, i.e. ``logging.getLogger(__name__)`` instead of ``logging.getLogger("tvm.runtime")``
 
 
 Writing Python Tests

--- a/gallery/how_to/tune_with_autotvm/tune_conv2d_cuda.py
+++ b/gallery/how_to/tune_with_autotvm/tune_conv2d_cuda.py
@@ -182,8 +182,8 @@ def conv2d_no_batching(N, H, W, CO, CI, KH, KW, stride, padding):
 # for this template
 
 # logging config (for printing tuning log to screen)
-logging.getLogger("autotvm").setLevel(logging.DEBUG)
-logging.getLogger("autotvm").addHandler(logging.StreamHandler(sys.stdout))
+logging.getLogger("tvm.autotvm").setLevel(logging.DEBUG)
+logging.getLogger("tvm.autotvm").addHandler(logging.StreamHandler(sys.stdout))
 
 # the last layer in resnet
 N, H, W, CO, CI, KH, KW, strides, padding = 1, 7, 7, 512, 512, 3, 3, (1, 1), (1, 1)

--- a/gallery/how_to/tune_with_autotvm/tune_relay_arm.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_arm.py
@@ -411,6 +411,6 @@ def tune_and_evaluate(tuning_opt):
 #   .. code-block:: python
 #
 #      import logging
-#      logging.getLogger('autotvm').setLevel(logging.DEBUG)
+#      logging.getLogger('tvm.autotvm').setLevel(logging.DEBUG)
 #
 #   Finally, always feel free to ask our community for help on https://discuss.tvm.apache.org

--- a/gallery/how_to/tune_with_autotvm/tune_relay_cuda.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_cuda.py
@@ -302,7 +302,7 @@ def tune_and_evaluate(tuning_opt):
 #   .. code-block:: python
 #
 #      import logging
-#      logging.getLogger('autotvm').setLevel(logging.DEBUG)
+#      logging.getLogger('tvm.autotvm').setLevel(logging.DEBUG)
 #
 #   Finally, always feel free to ask our community for help on https://discuss.tvm.apache.org
 

--- a/gallery/how_to/tune_with_autotvm/tune_relay_mobile_gpu.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_mobile_gpu.py
@@ -409,6 +409,6 @@ def tune_and_evaluate(tuning_opt):
 #   .. code-block:: python
 #
 #      import logging
-#      logging.getLogger('autotvm').setLevel(logging.DEBUG)
+#      logging.getLogger('tvm.autotvm').setLevel(logging.DEBUG)
 #
 #   Finally, always feel free to ask our community for help on https://discuss.tvm.apache.org

--- a/gallery/tutorial/autotvm_matmul_x86.py
+++ b/gallery/tutorial/autotvm_matmul_x86.py
@@ -321,8 +321,8 @@ print(task.config_space)
 # configuration discovered by the tuner later.
 
 # logging config (for printing tuning log to the screen)
-logging.getLogger("autotvm").setLevel(logging.DEBUG)
-logging.getLogger("autotvm").addHandler(logging.StreamHandler(sys.stdout))
+logging.getLogger("tvm.autotvm").setLevel(logging.DEBUG)
+logging.getLogger("tvm.autotvm").addHandler(logging.StreamHandler(sys.stdout))
 
 ################################################################################
 # There are two steps for measuring a config: build and run. By default, we use

--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -30,7 +30,7 @@ from ..measure_record import RecordReader
 
 xgb = None
 
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 
 class XGBDMatrixContext:

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -37,7 +37,7 @@ from .search_policy import PreloadMeasuredStates, SketchPolicy
 from .search_task import SearchTask, TuningOptions
 from .utils import calc_workload_dis_factor, decode_workload_key
 
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 
 class DispatchContext(object):

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -64,7 +64,7 @@ from .workload_registry import (
 )
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 # The time cost for measurements with errors
 # We use 1e10 instead of sys.float_info.max for better readability in log

--- a/python/tvm/auto_scheduler/measure_record.py
+++ b/python/tvm/auto_scheduler/measure_record.py
@@ -30,7 +30,7 @@ from .measure import MeasureErrorNo, MeasureCallback
 from .utils import calc_workload_dis_factor, decode_workload_key
 from . import _ffi_api
 
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 
 @tvm._ffi.register_object("auto_scheduler.RecordToFile")

--- a/python/tvm/auto_scheduler/relay_integration.py
+++ b/python/tvm/auto_scheduler/relay_integration.py
@@ -45,7 +45,7 @@ from .search_task import SearchTask
 from .utils import get_const_tuple
 from .workload_registry import register_workload_tensors
 
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 
 def call_all_topi_funcs(mod, params, target, error_list, opt_level=3):

--- a/python/tvm/auto_scheduler/search_task.py
+++ b/python/tvm/auto_scheduler/search_task.py
@@ -38,7 +38,7 @@ from .workload_registry import WORKLOAD_FUNC_REGISTRY, register_workload_tensors
 from . import _ffi_api
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 
 @tvm._ffi.register_object("auto_scheduler.HardwareParams")

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -36,7 +36,7 @@ from .measure import ProgramMeasurer
 from .measure_record import RecordReader
 from . import _ffi_api
 
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 
 def make_search_policies(

--- a/python/tvm/auto_scheduler/workload_registry.py
+++ b/python/tvm/auto_scheduler/workload_registry.py
@@ -39,7 +39,7 @@ from tvm.runtime._ffi_node_api import LoadJSON, SaveJSON
 
 from .utils import deserialize_args, get_func_name, serialize_args
 
-logger = logging.getLogger("auto_scheduler")
+logger = logging.getLogger(__name__)
 
 # Global workload function and hash key registry
 # It stores two types of workload:

--- a/python/tvm/autotvm/graph_tuner/base_graph_tuner.py
+++ b/python/tvm/autotvm/graph_tuner/base_graph_tuner.py
@@ -137,7 +137,7 @@ class BaseGraphTuner(object):
 
         # Set up logger
         self._verbose = verbose
-        self._logger = logging.getLogger(name + "_logger")
+        self._logger = logging.getLogger(__name__ + self._name)
         need_file_handler = need_console_handler = True
         for handler in self._logger.handlers:
             if handler.__class__.__name__ == "FileHandler":

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -51,7 +51,7 @@ from ..task.space import InstantiationError
 from ..utils import get_const_tuple
 from .measure import Builder, MeasureErrorNo, MeasureResult, Runner
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 class BuildResult(namedtuple("BuildResult", ("filename", "arg_info", "error", "time_cost"))):

--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -39,7 +39,7 @@ from .measure import MeasureInput, MeasureResult
 
 AUTOTVM_LOG_VERSION = 0.2
 _old_version_warning = True
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 try:  # convert unicode to str for python2
     _unicode = unicode

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -37,7 +37,7 @@ import numpy as np
 from .space import FallbackConfigEntity
 from .. import env as _env
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 class DispatchContext(object):

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -30,7 +30,7 @@ from tvm.target import Target
 from .task import create
 from .topi_integration import TaskExtractEnv
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 # TODO(moreau89) find a more elegant way to lower for VTAs

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -59,7 +59,7 @@ PACKAGE_VERSION = {
     "amd_apu": "v0.01",
 }
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 def _alias(name):

--- a/python/tvm/autotvm/tuner/callback.py
+++ b/python/tvm/autotvm/tuner/callback.py
@@ -25,7 +25,7 @@ import numpy as np
 from .. import record
 from ..utils import format_si_prefix
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 def log_to_file(file_out, protocol="json"):

--- a/python/tvm/autotvm/tuner/sa_model_optimizer.py
+++ b/python/tvm/autotvm/tuner/sa_model_optimizer.py
@@ -28,7 +28,7 @@ import numpy as np
 from ..utils import sample_ints
 from .model_based_tuner import ModelOptimizer, knob2point, point2knob
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 class SimulatedAnnealingOptimizer(ModelOptimizer):

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -26,7 +26,7 @@ from ..utils import format_si_prefix
 
 from ..env import GLOBAL_SCOPE
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 class Tuner(object):

--- a/python/tvm/autotvm/tuner/xgboost_cost_model.py
+++ b/python/tvm/autotvm/tuner/xgboost_cost_model.py
@@ -31,7 +31,7 @@ from .model_based_tuner import CostModel, FeatureCache
 
 xgb = None
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 class XGBoostCostModel(CostModel):

--- a/python/tvm/autotvm/utils.py
+++ b/python/tvm/autotvm/utils.py
@@ -26,7 +26,7 @@ import tvm.arith
 from tvm.tir import expr
 from tvm.contrib.popen_pool import PopenPoolExecutor
 
-logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
 
 
 class EmptyContext(object):

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -26,7 +26,7 @@ from .gen_gemm import CutlassGemmProfiler
 from .gen_conv2d import CutlassConv2DProfiler
 from .library import ConvKind
 
-logger = logging.getLogger("cutlass")
+logger = logging.getLogger(__name__)
 
 
 def _get_cutlass_path():

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -30,7 +30,7 @@ from .library import (
     EpilogueFunctor,
 )
 
-logger = logging.getLogger("cutlass")
+logger = logging.getLogger(__name__)
 
 
 dtype_map = {

--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -23,7 +23,7 @@ import shutil
 import tempfile
 import time
 
-LOG = logging.getLogger("download")
+LOG = logging.getLogger(__name__)
 
 
 def download(url, path, overwrite=False, size_compare=False, retries=3):

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -43,7 +43,7 @@ from .transform import convert_graph_layout
 
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 
 @register_parser

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -39,7 +39,7 @@ from .transform import convert_graph_layout
 from .shape_parser import parse_shape_string
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 
 @register_parser

--- a/python/tvm/driver/tvmc/composite_target.py
+++ b/python/tvm/driver/tvmc/composite_target.py
@@ -35,7 +35,7 @@ from tvm.driver.tvmc import TVMCException
 
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 
 # Global dictionary to map targets

--- a/python/tvm/driver/tvmc/frontends.py
+++ b/python/tvm/driver/tvmc/frontends.py
@@ -36,7 +36,7 @@ from tvm.driver.tvmc.model import TVMCModel
 
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 
 class Frontend(ABC):

--- a/python/tvm/driver/tvmc/main.py
+++ b/python/tvm/driver/tvmc/main.py
@@ -88,7 +88,7 @@ def _main(argv):
     if args.verbose > 4:
         args.verbose = 4
 
-    logging.getLogger("TVMC").setLevel(40 - args.verbose * 10)
+    logging.getLogger("tvm.driver.tvmc").setLevel(40 - args.verbose * 10)
 
     if args.version:
         sys.stdout.write("%s\n" % tvm.__version__)

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -56,7 +56,7 @@ except (ImportError, AttributeError) as exception:
     SUPPORT_MICRO = False
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 
 @register_parser

--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -32,7 +32,7 @@ from tvm.ir.transform import PassContext
 from tvm.target import Target, TargetKind
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 # We can't tell the type inside an Array but all current options are strings so
 # it can default to that. Bool is used alongside Integer but aren't distinguished

--- a/python/tvm/driver/tvmc/tracker.py
+++ b/python/tvm/driver/tvmc/tracker.py
@@ -21,7 +21,7 @@ import logging
 from urllib.parse import urlparse
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("TVMC")
+logger = logging.getLogger(__name__)
 
 
 def tracker_host_port_from_cli(rpc_tracker_str):

--- a/python/tvm/relay/backend/contrib/ethosu/vela_api.py
+++ b/python/tvm/relay/backend/contrib/ethosu/vela_api.py
@@ -32,7 +32,7 @@ from tvm.relay.backend.contrib.ethosu import util  # type: ignore
 from tvm.relay.backend.contrib.ethosu import tir_to_cs_translator as tirtocs
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("Ethos-U")
+logger = logging.getLogger(__name__)
 
 VELA_TO_NP_DTYPES = {
     vapi.NpuDataType.UINT8: np.uint8,

--- a/python/tvm/relay/backend/te_compiler.py
+++ b/python/tvm/relay/backend/te_compiler.py
@@ -30,8 +30,8 @@ from .. import function as _function
 from .. import ty as _ty
 from . import _backend
 
-logger = logging.getLogger("te_compiler")
-autotvm_logger = logging.getLogger("autotvm")
+logger = logging.getLogger(__name__)
+autotvm_logger = logging.getLogger(__name__)
 
 _first_warning = True
 

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -44,7 +44,7 @@ class DuplicateFilter:
 
 
 # pylint: disable=invalid-name
-logger = logging.getLogger("Frontend")
+logger = logging.getLogger(__name__)
 logger.addFilter(DuplicateFilter())
 # Uncomment below line to print all debug msgs
 # logger.setLevel(logging.DEBUG)

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -44,7 +44,7 @@ from ... import _ffi_api
 from ...dataflow_pattern import wildcard, is_op
 from .register import register_pattern_table
 
-logger = logging.getLogger("DNNL")
+logger = logging.getLogger(__name__)
 
 
 def _register_external_op_helper(op_name, supported=True):

--- a/python/tvm/relay/op/contrib/tensorrt.py
+++ b/python/tvm/relay/op/contrib/tensorrt.py
@@ -29,7 +29,7 @@ from tvm.relay.expr import Call, Constant, GlobalVar, Tuple
 from tvm.relay.expr_functor import ExprMutator, ExprVisitor
 from tvm.relay.op.contrib.register import register_pattern_table
 
-logger = logging.getLogger("TensorRT")
+logger = logging.getLogger(__name__)
 supported_types = ["float32", "float16"]
 
 

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -26,7 +26,7 @@ from ....auto_scheduler import is_auto_scheduler_enabled
 from .generic import *
 from .. import op as _op
 
-logger = logging.getLogger("strategy")
+logger = logging.getLogger(__name__)
 
 
 @schedule_reduce.register("arm_cpu")

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -25,7 +25,7 @@ from tvm.topi.utils import get_const_float, get_const_int, get_const_tuple, get_
 
 from .. import op as _op
 
-logger = logging.getLogger("strategy")
+logger = logging.getLogger(__name__)
 
 
 def naive_schedule(_, outs, target):

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -28,7 +28,7 @@ from tvm.target import Target
 from .generic import *
 from .. import op as _op
 
-logger = logging.getLogger("strategy")
+logger = logging.getLogger(__name__)
 
 _NCHWc_matcher = re.compile("^NCHW[0-9]+c$")
 _OIHWio_matcher = re.compile("^OIHW[0-9]+i[0-9]+o$")

--- a/python/tvm/rpc/base.py
+++ b/python/tvm/rpc/base.py
@@ -38,7 +38,7 @@ RPC_CODE_DUPLICATE = RPC_MAGIC + 1
 # cannot found matched key in server
 RPC_CODE_MISMATCH = RPC_MAGIC + 2
 
-logger = logging.getLogger("RPCServer")
+logger = logging.getLogger(__name__)
 
 
 class TrackerCode(object):

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -48,7 +48,7 @@ from . import base
 from . import testing
 from .base import TrackerCode
 
-logger = logging.getLogger("RPCServer")
+logger = logging.getLogger(__name__)
 
 
 def _server_env(load_library, work_path=None):

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -63,7 +63,7 @@ from .._ffi.base import py_str
 from . import base
 from .base import RPC_TRACKER_MAGIC, TrackerCode
 
-logger = logging.getLogger("RPCTracker")
+logger = logging.getLogger(__name__)
 
 
 class Scheduler(object):

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -32,7 +32,7 @@ from .conv2d_int8 import is_int8_hw_support
 from .arm_utils import get_tiling_B_interleaved_t
 from ..generic.conv2d import conv2d_alter_int8_common
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 def interleave_transpose_weights(inputs, data, kernel, interleave_A):

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/pool.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/pool.py
@@ -33,7 +33,7 @@ from .micro_kernel.avg_pool import (
     sum_impl,
 )
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 def schedule_maxpool_1d_nwc(s, op):

--- a/python/tvm/topi/cuda/argwhere.py
+++ b/python/tvm/topi/cuda/argwhere.py
@@ -30,7 +30,7 @@ from ..broadcast import not_equal
 from ..math import cast
 
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 fdiv = tvm.tir.floordiv
 fmod = tvm.tir.floormod

--- a/python/tvm/topi/cuda/conv2d_alter_op.py
+++ b/python/tvm/topi/cuda/conv2d_alter_op.py
@@ -28,7 +28,7 @@ from .tensorcore_alter_op import pad_to_tensorcore
 from ..nn import conv2d_legalize
 
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 @nn.conv2d_alter_layout.register(["cuda", "gpu"])

--- a/python/tvm/topi/cuda/conv2d_winograd.py
+++ b/python/tvm/topi/cuda/conv2d_winograd.py
@@ -27,7 +27,7 @@ from ..nn.conv2d import _conv2d_winograd_nhwc_impl, conv2d_winograd_nhwc
 from ..nn.winograd_util import winograd_transform_matrices
 from ..utils import get_const_int, get_const_tuple, traverse_inline
 
-logger = logging.getLogger("conv2d_winograd")
+logger = logging.getLogger(__name__)
 
 
 def _infer_tile_size(data, kernel, layout="NCHW"):

--- a/python/tvm/topi/cuda/conv3d_alter_op.py
+++ b/python/tvm/topi/cuda/conv3d_alter_op.py
@@ -27,7 +27,7 @@ from .. import nn
 from ..utils import get_const_tuple
 from .conv3d_winograd import _infer_tile_size
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 @nn.conv3d_alter_layout.register(["cuda", "gpu"])

--- a/python/tvm/topi/cuda/conv3d_winograd.py
+++ b/python/tvm/topi/cuda/conv3d_winograd.py
@@ -26,7 +26,7 @@ from .. import nn
 from ..utils import get_const_int, get_const_tuple, traverse_inline, simplify
 from ..nn.winograd_util import winograd_transform_matrices
 
-logger = logging.getLogger("conv3d_winograd")
+logger = logging.getLogger(__name__)
 
 
 def _infer_tile_size(data, kernel):

--- a/python/tvm/topi/cuda/dense.py
+++ b/python/tvm/topi/cuda/dense.py
@@ -26,7 +26,7 @@ from .. import tag
 from .. import generic
 from ..utils import traverse_inline, get_const_tuple, is_target
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 def _matmul_cublas_common(

--- a/python/tvm/topi/cuda/tensorcore_alter_op.py
+++ b/python/tvm/topi/cuda/tensorcore_alter_op.py
@@ -23,7 +23,7 @@ from tvm import relay, tir
 
 from .. import nn
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 @nn.batch_matmul_legalize.register("cuda")

--- a/python/tvm/topi/gpu/dense.py
+++ b/python/tvm/topi/gpu/dense.py
@@ -26,7 +26,7 @@ from tvm.autotvm.task.space import SplitEntity
 from .. import nn
 from ..utils import traverse_inline, get_const_tuple
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 @autotvm.register_topi_compute("dense_small_batch.gpu")

--- a/python/tvm/topi/mali/conv2d.py
+++ b/python/tvm/topi/mali/conv2d.py
@@ -32,7 +32,7 @@ from ..nn.conv2d import conv2d_winograd_nhwc, _conv2d_winograd_nhwc_impl
 from ..arm_cpu.conv2d_spatial_pack import conv2d_spatial_pack_nchw
 from ..arm_cpu.conv2d_spatial_pack import conv2d_spatial_pack_nhwc
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 @autotvm.register_topi_compute("conv2d_nchw_spatial_pack.mali")

--- a/python/tvm/topi/nn/batch_matmul.py
+++ b/python/tvm/topi/nn/batch_matmul.py
@@ -21,7 +21,7 @@ import tvm
 from tvm import te, auto_scheduler
 from ..utils import get_const_tuple
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 def batch_matmul(

--- a/python/tvm/topi/x86/conv2d.py
+++ b/python/tvm/topi/x86/conv2d.py
@@ -31,7 +31,7 @@ from ..nn.utils import get_pad_tuple
 from ..utils import get_const_tuple, traverse_inline
 from . import conv2d_avx_1x1, conv2d_avx_common
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 
 def _get_default_config(

--- a/python/tvm/topi/x86/conv2d_alter_op.py
+++ b/python/tvm/topi/x86/conv2d_alter_op.py
@@ -30,7 +30,7 @@ from ..utils import get_const_tuple
 from ..nn import conv2d_legalize, conv2d_alter_layout
 from ..generic.conv2d import conv2d_alter_int8_common
 
-logger = logging.getLogger("topi")
+logger = logging.getLogger(__name__)
 
 _NCHWc_matcher = re.compile("^NCHW[0-9]+c$")
 _OIHWio_matcher = re.compile("^OIHW[0-9]+i[0-9]+o$")

--- a/tests/python/unittest/test_micro_transport.py
+++ b/tests/python/unittest/test_micro_transport.py
@@ -71,7 +71,7 @@ def transport():
 
 @tvm.testing.fixture
 def transport_logger(transport):
-    logger = logging.getLogger("transport_logger_test")
+    logger = logging.getLogger(__name__)
     return tvm.micro.transport.TransportLogger("foo", transport, logger=logger)
 
 


### PR DESCRIPTION
This is PR related to RFC posted here: https://discuss.tvm.apache.org/t/pre-rfc-generic-logger-names-in-python/12611 . I've changed hardcoded logger names to generic `__name__`.  I've changed most of the examples, but few I didn't touch - let's discuss them, because I'm not sure wether change it. 

Points to discuss:
1. `./autotvm/graph_tuner/base_graph_tuner.py:        self._logger = logging.getLogger(name + "_logger")`
2. `./meta_schedule/testing/tune_te_meta_schedule.py:logging.getLogger("tvm.meta_schedule").setLevel(logging.DEBUG)`
3. `./meta_schedule/testing/tune_relay_meta_schedule.py:logging.getLogger("tvm.meta_schedule").setLevel(logging.DEBUG)`
4. `./driver/tvmc/main.py:    logging.getLogger("tvm.driver.tvmc").setLevel(40 - args.verbose * 10)`

I hope I didn't break your workflows:)