### PR TITLE
[CONTRIB] Add PopenWorker process recycling

### DIFF
--- a/python/tvm/contrib/popen_pool.py
+++ b/python/tvm/contrib/popen_pool.py
@@ -92,12 +92,18 @@ class PopenWorker:
 
     initargs: Tuple[object]
         A tuple of args for the initializer
+
+    maximum_uses: int or None
+        The maximum number of times a process can be used before being recycled
     """
 
-    def __init__(self, initializer=None, initargs=()):
+    def __init__(self, initializer=None, initargs=(), maximum_uses=None):
         self._proc = None
         self._initializer = initializer
         self._initargs = initargs
+        self._maximum_uses = maximum_uses
+        self._remaining_uses = None
+
         if self._initializer is not None and not callable(self._initializer):
             raise TypeError("initializer must be callable for PopenWorker")
 
@@ -133,7 +139,11 @@ class PopenWorker:
                 self._proc.kill()
             except OSError:
                 pass
+
+            # Join the child process to avoid zombie processes
+            self.join(timeout=1.0)
             self._proc = None
+            self._remaining_uses = None
 
     def _start(self):
         """Start a new subprocess if nothing is available"""
@@ -213,12 +223,19 @@ class PopenWorker:
         # pylint: disable=import-outside-toplevel
         import cloudpickle
 
+        if self._proc is not None and self._maximum_uses and self._remaining_uses == 0:
+            # Time to recycle the process.
+            self.kill()
+
         if self._proc is None:
             self._start()
             # init
             if self._initializer is not None:
                 self.send(self._initializer, self._initargs)
                 self.recv()
+
+            # N.B. The initializer doesn't count as a "use"
+            self._remaining_uses = self._maximum_uses
         kwargs = {} if not kwargs else kwargs
         data = cloudpickle.dumps((fn, args, kwargs, timeout), protocol=pickle.HIGHEST_PROTOCOL)
         try:
@@ -227,6 +244,9 @@ class PopenWorker:
             self._writer.flush()
         except IOError:
             pass
+
+        if self._remaining_uses:
+            self._remaining_uses -= 1
 
     def _child_process_error(self):
         """Raise a child process error."""
@@ -292,6 +312,9 @@ class PopenPoolExecutor:
     initargs: Tuple[object]
         A tuple of args for the initializer
 
+    maximum_process_uses: int or None
+        The maximum number of times each process can be used before being recycled
+
     Note
     ----
     If max_workers is NONE then the number returned by
@@ -299,7 +322,14 @@ class PopenPoolExecutor:
     behavior of multiprocessing.pool().
     """
 
-    def __init__(self, max_workers=None, timeout=None, initializer=None, initargs=()):
+    def __init__(
+        self,
+        max_workers=None,
+        timeout=None,
+        initializer=None,
+        initargs=(),
+        maximum_process_uses=None,
+    ):
         if max_workers is None:
             max_workers = os.cpu_count()
         # Use an internal thread pool to send to popen workers
@@ -309,6 +339,7 @@ class PopenPoolExecutor:
         self._lock = threading.Lock()
         self._initializer = initializer
         self._initargs = initargs
+        self._maximum_process_uses = maximum_process_uses
 
         if self._initializer is not None and not callable(self._initializer):
             raise TypeError("initializer must be callable for PopenPoolExecutor")
@@ -328,7 +359,7 @@ class PopenPoolExecutor:
         self._lock.acquire()
         tid = threading.get_ident()
         if tid not in self._worker_map:
-            proc = PopenWorker(self._initializer, self._initargs)
+            proc = PopenWorker(self._initializer, self._initargs, self._maximum_process_uses)
             self._worker_map[tid] = proc
         else:
             proc = self._worker_map[tid]

--- a/python/tvm/contrib/popen_pool.py
+++ b/python/tvm/contrib/popen_pool.py
@@ -93,8 +93,10 @@ class PopenWorker:
     initargs: Tuple[object]
         A tuple of args for the initializer
 
-    maximum_uses: int or None
-        The maximum number of times a process can be used before being recycled
+    maximum_uses: Optional[int]
+        The maximum number of times a process can be used before being recycled,
+        i.e. killed and restarted. If `None`, the process will be reused until
+        an operation times out.
     """
 
     def __init__(self, initializer=None, initargs=(), maximum_uses=None):
@@ -312,8 +314,10 @@ class PopenPoolExecutor:
     initargs: Tuple[object]
         A tuple of args for the initializer
 
-    maximum_process_uses: int or None
-        The maximum number of times each process can be used before being recycled
+    maximum_process_uses: Optional[int]
+        The maximum number of times each process can be used before being recycled,
+        i.e. killed and restarted. If `None`, processes will be reused until an
+        operation times out.
 
     Note
     ----

--- a/tests/python/contrib/test_popen_pool.py
+++ b/tests/python/contrib/test_popen_pool.py
@@ -16,6 +16,8 @@
 # under the License.
 """Test PopenPoolExecutor."""
 import pytest
+import os
+import psutil
 import time
 from tvm.contrib.popen_pool import PopenWorker, PopenPoolExecutor
 from tvm.testing import (
@@ -49,6 +51,32 @@ def test_popen_worker():
 
     proc.send(identity_after, [4, 0.0001])
     assert proc.recv() == 4
+
+
+def test_popen_worker_reuses():
+    proc = PopenWorker(maximum_uses=None)
+
+    proc.send(os.getpid)
+    initial_pid = proc.recv()
+
+    proc.send(os.getpid)
+    assert proc.recv() == initial_pid
+
+
+def test_popen_worker_recycles():
+    proc = PopenWorker(maximum_uses=2)
+
+    proc.send(os.getpid)
+    initial_pid = proc.recv()
+    assert psutil.pid_exists(initial_pid)
+
+    proc.send(os.getpid)
+    assert proc.recv() == initial_pid
+    assert psutil.pid_exists(initial_pid)
+
+    proc.send(os.getpid)
+    assert proc.recv() != initial_pid
+    assert not psutil.pid_exists(initial_pid)
 
 
 def test_popen_pool_executor():
@@ -88,6 +116,28 @@ def test_popen_initializer():
     assert test_global_state_3 == initargs[2]
 
 
+def test_popen_worker_recycles_with_initializer():
+    initargs = [1, 2, 3]
+    proc = PopenWorker(initializer=initializer, initargs=initargs, maximum_uses=3)
+
+    proc.send(os.getpid)
+    initial_pid = proc.recv()
+
+    proc.send(after_initializer)
+    assert list(proc.recv()) == initargs
+
+    proc.send(os.getpid)
+    assert proc.recv() == initial_pid
+
+    # The process should be recycled with this send.
+    proc.send(os.getpid)
+    assert proc.recv() != initial_pid
+
+    # But the initializer should've run this time as well.
+    proc.send(after_initializer)
+    assert list(proc.recv()) == initargs
+
+
 def test_popen_ffi():
     proc = PopenWorker(register_ffi)
 
@@ -121,9 +171,20 @@ def test_popen_pool_executor_timeout():
         assert isinstance(ex, TimeoutError)
 
 
+def test_popen_pool_executor_recycles():
+    pool = PopenPoolExecutor(max_workers=1, timeout=None, maximum_process_uses=2)
+
+    initial_pid = pool.submit(os.getpid).result()
+    assert initial_pid == pool.submit(os.getpid).result()
+    assert initial_pid != pool.submit(os.getpid).result()
+
+
 if __name__ == "__main__":
     test_popen_worker()
+    test_popen_worker_recycles()
     test_popen_pool_executor()
     test_popen_initializer()
+    test_popen_worker_recycles_with_initializer()
     test_popen_ffi()
     test_popen_pool_executor_timeout()
+    test_popen_pool_executor_recycles()


### PR DESCRIPTION
Background processes (e.g. builds during autotuning) can sometimes accumulate state or leak memory. This adds the ability for `PopenWorker` processes to optionally be recycled after a specified number of uses.
