### PR TITLE
[Auto Scheduler]add task name during printing table info

### DIFF
--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -583,8 +583,8 @@ class PrintTableInfo(TaskSchedulerCallback):
             "| Latency (ms) | Speed (GFLOPS) | Trials |"
         )
         print(
-            "-----------------------------------------------------------------"
-            "------------------------------------------------"
+            "----------------------------------------------------------------"
+            "-------------------------------------------------"
         )
 
         # content
@@ -595,7 +595,7 @@ class PrintTableInfo(TaskSchedulerCallback):
                 if task_scheduler.best_costs[i] < 1e9
                 else "-"
             )
-            task_name = task_scheduler.tasks[i].desc
+            task_desc = task_scheduler.tasks[i].desc
             speed_str = (
                 "%.2f"
                 % (task_scheduler.tasks[i].compute_dag.flop_ct / task_scheduler.best_costs[i] / 1e9)
@@ -605,10 +605,11 @@ class PrintTableInfo(TaskSchedulerCallback):
             trials_str = "%d" % (task_scheduler.task_cts[i] * task_scheduler.num_measures_per_round)
             print(
                 "| %4s | %61s | %12s | % 14s | %6s |"
-                % (id_str, task_name, latency_str, speed_str, trials_str)
+                % (id_str, task_desc, latency_str, speed_str, trials_str)
             )
         print(
-            "-----------------------------------------------------------------------------------------------------------------"
+            "----------------------------------------------------------------"
+            "-------------------------------------------------"
         )
 
         # overall info

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -578,10 +578,13 @@ class PrintTableInfo(TaskSchedulerCallback):
 
         _ffi_api.PrintTitle("Task Scheduler")
         print(
-            "|  ID  |                       Task Description                        | Latency (ms) | Speed (GFLOPS) | Trials |"
+            "|  ID  "
+            "|                       Task Description                        "
+            "| Latency (ms) | Speed (GFLOPS) | Trials |"
         )
         print(
-            "-----------------------------------------------------------------------------------------------------------------"
+            "-----------------------------------------------------------------"
+            "------------------------------------------------"
         )
 
         # content

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -592,7 +592,7 @@ class PrintTableInfo(TaskSchedulerCallback):
                 if task_scheduler.best_costs[i] < 1e9
                 else "-"
             )
-            task_name = task_scheduler.task[i].desc
+            task_name = task_scheduler.tasks[i].desc
             speed_str = (
                 "%.2f"
                 % (task_scheduler.tasks[i].compute_dag.flop_ct / task_scheduler.best_costs[i] / 1e9)
@@ -601,7 +601,7 @@ class PrintTableInfo(TaskSchedulerCallback):
             )
             trials_str = "%d" % (task_scheduler.task_cts[i] * task_scheduler.num_measures_per_round)
             print(
-                "| %4s | %40s | %12s | % 14s | %6s |"
+                "| %4s | %61s | %12s | % 14s | %6s |"
                 % (id_str, task_name, latency_str, speed_str, trials_str)
             )
         print(

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -578,7 +578,7 @@ class PrintTableInfo(TaskSchedulerCallback):
 
         _ffi_api.PrintTitle("Task Scheduler")
         print(
-            "|  ID  |                           Task Name                           | Latency (ms) | Speed (GFLOPS) | Trials |"
+            "|  ID  |                       Task Description                        | Latency (ms) | Speed (GFLOPS) | Trials |"
         )
         print(
             "-----------------------------------------------------------------------------------------------------------------"
@@ -615,7 +615,12 @@ class PrintTableInfo(TaskSchedulerCallback):
             total_latency_str = "-"
         print(
             "Estimated total latency: %s ms\tTrials: %d\tUsed time : %.0f s\tNext ID: %d\t"
-            % (total_latency_str, task_scheduler.ct, time.time() - task_scheduler.tic, task_id,)
+            % (
+                total_latency_str,
+                task_scheduler.ct,
+                time.time() - task_scheduler.tic,
+                task_id,
+            )
         )
 
 
@@ -643,6 +648,10 @@ class LogEstimatedLatency(TaskSchedulerCallback):
         with open(self.log_file, "a") as filep:
             filep.write(
                 "ElapsedTime(s)\t%.0f\tEstimatedLatency(ms)\t%s\tTrials\t%d\n"
-                % (time.time() - task_scheduler.tic, total_latency_str, task_scheduler.ct,)
+                % (
+                    time.time() - task_scheduler.tic,
+                    total_latency_str,
+                    task_scheduler.ct,
+                )
             )
             filep.flush()

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -577,8 +577,12 @@ class PrintTableInfo(TaskSchedulerCallback):
             return
 
         _ffi_api.PrintTitle("Task Scheduler")
-        print("|  ID  | Latency (ms) | Speed (GFLOPS) | Trials |")
-        print("-------------------------------------------------")
+        print(
+            "|  ID  |                           Task Name                           | Latency (ms) | Speed (GFLOPS) | Trials |"
+        )
+        print(
+            "-----------------------------------------------------------------------------------------------------------------"
+        )
 
         # content
         for i in range(len(task_scheduler.tasks)):
@@ -588,6 +592,7 @@ class PrintTableInfo(TaskSchedulerCallback):
                 if task_scheduler.best_costs[i] < 1e9
                 else "-"
             )
+            task_name = task_scheduler.task[i].desc
             speed_str = (
                 "%.2f"
                 % (task_scheduler.tasks[i].compute_dag.flop_ct / task_scheduler.best_costs[i] / 1e9)
@@ -595,8 +600,13 @@ class PrintTableInfo(TaskSchedulerCallback):
                 else "-"
             )
             trials_str = "%d" % (task_scheduler.task_cts[i] * task_scheduler.num_measures_per_round)
-            print("| %4s | %12s | % 14s | %6s |" % (id_str, latency_str, speed_str, trials_str))
-        print("-------------------------------------------------")
+            print(
+                "| %4s | %40s | %12s | % 14s | %6s |"
+                % (id_str, task_name, latency_str, speed_str, trials_str)
+            )
+        print(
+            "-----------------------------------------------------------------------------------------------------------------"
+        )
 
         # overall info
         if all(cost < 1e9 for cost in task_scheduler.best_costs):
@@ -605,12 +615,7 @@ class PrintTableInfo(TaskSchedulerCallback):
             total_latency_str = "-"
         print(
             "Estimated total latency: %s ms\tTrials: %d\tUsed time : %.0f s\tNext ID: %d\t"
-            % (
-                total_latency_str,
-                task_scheduler.ct,
-                time.time() - task_scheduler.tic,
-                task_id,
-            )
+            % (total_latency_str, task_scheduler.ct, time.time() - task_scheduler.tic, task_id,)
         )
 
 
@@ -638,10 +643,6 @@ class LogEstimatedLatency(TaskSchedulerCallback):
         with open(self.log_file, "a") as filep:
             filep.write(
                 "ElapsedTime(s)\t%.0f\tEstimatedLatency(ms)\t%s\tTrials\t%d\n"
-                % (
-                    time.time() - task_scheduler.tic,
-                    total_latency_str,
-                    task_scheduler.ct,
-                )
+                % (time.time() - task_scheduler.tic, total_latency_str, task_scheduler.ct,)
             )
             filep.flush()


### PR DESCRIPTION
This PR intends to add task name within the `PrintTableInfo` callback function of `auto_scheduler` to improve the readability of related logs.

Behavior of `PrintTableInfo` before this change:
```
|  ID  | Latency (ms) | Speed (GFLOPS) | Trials |
-------------------------------------------------
|    0 |   100000.000 |           0.00 |      0 |
|    1 |        0.000 |          12.80 |      0 |
```
After
```
|  ID  |                       Task Description                        | Latency (ms) | Speed (GFLOPS) | Trials |
-----------------------------------------------------------------------------------------------------------------
|    0 |                          vm_mod_fused_nn_conv2d_add_nn_relu_2 |   100000.000 |           0.00 |      0 |
|    1 |                          vm_mod_fused_nn_conv2d_add_nn_relu_4 |        0.000 |          12.80 |      0 |
```

cc: @zxybazh @junrushao1994  
