### PR TITLE
[ETHOSN] Roll CI forward to Ethos(TM)-N release 21.11

### DIFF
--- a/docker/install/ubuntu_install_ethosn_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosn_driver_stack.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
 repo_dir="ethosn-driver"
-repo_revision="21.08"
+repo_revision="21.11"
 install_path="/opt/arm/$repo_dir"
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
The updated code is already in the repo; this merely switches the CI over.