### PR TITLE
[Frontend][TFLite] update logical_binary using new function

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1424,9 +1424,9 @@ class OperatorConverter(object):
         assert len(input_tensors) == 2, "input tensors length should be 2"
 
         lhs_tensor = input_tensors[0]
-        lhs_expr = self.get_expr(lhs_tensor.tensor_idx)
+        lhs_expr = self.get_tensor_expr(lhs_tensor)
         rhs_tensor = input_tensors[1]
-        rhs_expr = self.get_expr(rhs_tensor.tensor_idx)
+        rhs_expr = self.get_tensor_expr(rhs_tensor)
         out = relay_op(lhs_expr, rhs_expr)
 
         return out


### PR DESCRIPTION
When importing the [MoveNet_MultiPose](https://github.com/PINTO0309/PINTO_model_zoo/tree/main/137_MoveNet_MultiPose) model. 
I met a keyerror as the pic shows:
![image](https://user-images.githubusercontent.com/32191045/164647902-14cb5184-ae9b-45e7-9636-1e8f6e19b3a2.png)
it seems to be the error of `self.get_expr()`.
But, I can't reproduce the test case for the logical_and op that is consistent with the model.
Also, i found [PR#7048](https://github.com/apache/tvm/pull/7048) updated the `def get_tensor_expr`, and some op have used the latest functions.
So, i update it! And my model complie successful.
