### PR TITLE
[Hexagon] Introduce TVM code generation flags to Hexagon target

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -534,6 +534,8 @@ def hexagon(cpu_ver="v66", **kwargs):
         error if invalid. Does not affect codegen.
     llvm_options : str or list of str (default: None)
         User defined compiler arguments.
+    codegen_options : str or list of str (default: None)
+        Options for TVM codegen.
     use_qfloat : bool (default: True for cpu_ver >= v68, False otherwise)
         Whether to use QFloat HVX instructions.
     use_ieee_fp : bool (default: False)
@@ -572,6 +574,7 @@ def hexagon(cpu_ver="v66", **kwargs):
         "hvx": 128,
         "sim_options": None,
         "llvm_options": None,
+        "codegen_options": None,
         "use_qfloat": arch_version >= 68,
         "use_ieee_fp": False,
         "link_params": False,
@@ -682,7 +685,7 @@ def hexagon(cpu_ver="v66", **kwargs):
     def create_llvm_options(cpu_ver, config):  # pylint: disable=unused-argument
         """Create LLVM options string."""
 
-        llvm_options = config["llvm_options"]
+        llvm_options = config["llvm_options"] or ""
 
         # TVM's option parser doesn't allow '=' in values, but '=' can
         # appear in LLVM flags. Replace it with '@', since it's unlikely
@@ -696,10 +699,10 @@ def hexagon(cpu_ver="v66", **kwargs):
     def create_tvm_options(cpu_ver, config):  # pylint: disable=unused-argument
         """Create TVM target features string."""
 
-        features = {
-            "link_params": "link-params",
-        }
-        opts = ""
+        codegen_options = (config["codegen_options"] or "").strip()
+        opts = "--codegen-options=" + ",".join(codegen_options.split()) if codegen_options else ""
+
+        features = {"link_params": "link-params"}
         for k in config:
             if k in features:
                 opts += " --" + features[k] + "=" + str(config[k])

--- a/src/runtime/hexagon/hexagon_module.cc
+++ b/src/runtime/hexagon/hexagon_module.cc
@@ -61,6 +61,7 @@ std::string HexagonModuleNode::GetSource(const std::string& format) {
 void HexagonModuleNode::SaveToFile(const std::string& file_name, const std::string& format) {
   std::string fmt = runtime::GetFileFormat(file_name, format);
   if (fmt == "so" || fmt == "dll" || fmt == "hexagon") {
+    ICHECK(!data_.empty()) << "Module code not available";
     std::string meta_file = GetMetaFilePath(file_name);
     SaveMetaDataToFile(meta_file, fmap_);
 #if !defined(__APPLE__)

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -398,6 +398,7 @@ TVM_REGISTER_TARGET_KIND("hexagon", kDLHexagon)
     .add_attr_option<Bool>("system-lib")
     .add_attr_option<Bool>("link-params", Bool(false))
     .add_attr_option<Array<String>>("llvm-options")
+    .add_attr_option<Array<String>>("codegen-options")
     .set_default_keys({"hexagon"});
 
 TVM_REGISTER_TARGET_KIND("stackvm", kDLCPU)  // line break


### PR DESCRIPTION
These options would take effect at the TVM level, much like the LLVM codegen options take effect within LLVM. The current set of options is `emit-asm`, `emit-llvm`, `emit-obj`, and `emit-so`, and each one can take an optional value 0 or 1 (the default is 1). These options determine whether the particular type of output is generated, although options with any other use relevant to code generation (i.e. applicable in `BuildHexagon`) would be appropriate.

Right now, the Hexagon codegen emits both the object code and the assembly text, which runs the LLVM codegen twice (extending compilation time). Even if the LLVM pass pipeline was constructed in a way to allow using different code emitters without repeating the codegen passes, it may still be useful to have control over whether the different types of output are generated or not. The primary motivation of this patch, though, is to reduce time spent in code generation.

There is a plan to change the `hexagon` target to become a variant of the `llvm` target, and this may serve as a use case for some additional options that may be added to `llvm`.

cc @mehrdadh