### PR TITLE
[Frontend][ONNX]fix dropout  have 3 arguments

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4559,8 +4559,9 @@ class Unique(OnnxOpConverter):
         # ONNX unique returns unique, indices, inverse_indices, (optional) counts
         return _expr.TupleWrapper(_expr.Tuple([unique_vals, indices, inverse_indices, counts]), 4)
 
+
 class Dropout(OnnxOpConverter):
-    '''Operator converter for Dropout'''
+    """Operator converter for Dropout"""
 
     @classmethod
     def _impl_v12(cls, inputs, attr, params):
@@ -4572,7 +4573,10 @@ class Dropout(OnnxOpConverter):
             if isinstance(inputs[1], _expr.Constant):
                 ratio = inputs[1].data.numpy().item()
                 return _op.nn.dropout(data, ratio)
+            else:
+                raise ValueError("Dynamic dropouty is not supported yet!")
         return _op.nn.dropout(data)
+
 
 class Einsum(OnnxOpConverter):
     """Operator converter for Einsum"""

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4573,8 +4573,9 @@ class Dropout(OnnxOpConverter):
             if isinstance(inputs[1], _expr.Constant):
                 ratio = inputs[1].data.numpy().item()
                 return _op.nn.dropout(data, ratio)
-            else:
-                raise ValueError("Dynamic dropouty is not supported yet!")
+
+            raise ValueError("Dynamic dropouty is not supported yet!")
+
         return _op.nn.dropout(data)
 
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6561,6 +6561,7 @@ def test_LinearRegressor(target, dev):
     verify_LinearRegressor((10, 3), (30), (10), targets=10, batch=10)
     verify_LinearRegressor((1, 4), (3), (1))
 
+
 @tvm.testing.parametrize_targets
 def test_dropout(target, dev):
     def verify_dropout_radio(input_shape, ratio=0.5):
@@ -6569,9 +6570,7 @@ def test_dropout(target, dev):
         seed = np.random.randint(low, high)
         data = np.random.uniform(size=input_shape).astype("float32")
 
-        nodes = [
-             make_constant_node("ratio", onnx.TensorProto.FLOAT, (), [ratio])
-        ]
+        nodes = [make_constant_node("ratio", onnx.TensorProto.FLOAT, (), [ratio])]
         nodes.append(helper.make_node("Dropout", ["data", "ratio"], ["output"], seed=seed))
 
         graph = helper.make_graph(
@@ -6580,16 +6579,15 @@ def test_dropout(target, dev):
             inputs=[
                 helper.make_tensor_value_info("data", TensorProto.FLOAT, list(input_shape)),
             ],
-            outputs=[
-                helper.make_tensor_value_info(
-                    "output", TensorProto.FLOAT, list(input_shape)
-                )
-            ],
+            outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT, list(input_shape))],
         )
         model = helper.make_model(graph, producer_name="dropout_test")
-        verify_with_ort_with_inputs(model, [data], freeze_params=True, target=target, dev=dev, use_vm=True)
-    verify_dropout_radio((1,1,64,64))
-    verify_dropout_radio((1,1,64,64), 0.4)
+        verify_with_ort_with_inputs(
+                model, [data], freeze_params=True, target=target, dev=dev, use_vm=True
+        )
+
+    verify_dropout_radio((1, 1, 64, 64))
+    verify_dropout_radio((1, 1, 64, 64), 0.4)
 
 
 if __name__ == "__main__":

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6583,7 +6583,7 @@ def test_dropout(target, dev):
         )
         model = helper.make_model(graph, producer_name="dropout_test")
         verify_with_ort_with_inputs(
-                model, [data], freeze_params=True, target=target, dev=dev, use_vm=True
+            model, [data], freeze_params=True, target=target, dev=dev, use_vm=True
         )
 
     verify_dropout_radio((1, 1, 64, 64))


### PR DESCRIPTION
According to the file:
https://github.com/onnx/onnx/blob/main/docs/Operators.md#Dropout
The `dropout` have 1-3 inputs `data , ratio , training_mode `.
My model is:
![image](https://user-images.githubusercontent.com/50271153/164975749-8daff8d5-88d3-4c4c-9bfe-d28916cc0da9.png)
But when I import the model and run.
I got a error:
```
dropout() takes from 1 to 2 positional arguments but 3 were given
```
Therefore I reimplemented this Dropout class.