### PR TITLE
[build][Hexagon] Enable ninja builds for Hexagon

### DIFF
--- a/apps/hexagon_api/CMakeLists.txt
+++ b/apps/hexagon_api/CMakeLists.txt
@@ -28,7 +28,7 @@ file(MAKE_DIRECTORY ${HEXAGON_API_BINARY_DIR})
 
 ExternalProject_Add(x86_tvm_runtime_rpc
   SOURCE_DIR "${TVM_SOURCE_DIR}"
-  BUILD_COMMAND $(MAKE) runtime tvm_rpc
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} runtime tvm_rpc
   CMAKE_ARGS
     "-DUSE_HEXAGON_TOOLCHAIN=${USE_HEXAGON_TOOLCHAIN}"
     "-DCMAKE_CXX_STANDARD=14"
@@ -56,7 +56,7 @@ ExternalProject_Add_Step(x86_tvm_runtime_rpc copy_rpc_server
 
 ExternalProject_Add(android_tvm_runtime_rpc
   SOURCE_DIR "${TVM_SOURCE_DIR}"
-  BUILD_COMMAND $(MAKE) runtime tvm_rpc
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} runtime tvm_rpc
   CMAKE_ARGS
     "-DCMAKE_TOOLCHAIN_FILE=${USE_ANDROID_TOOLCHAIN}"
     "-DANDROID_PLATFORM=${ANDROID_PLATFORM}"
@@ -95,7 +95,7 @@ ExternalProject_Add_Step(android_tvm_runtime_rpc copy_rpc_server
 
 ExternalProject_Add(hexagon_tvm_runtime_rpc
   SOURCE_DIR "${TVM_SOURCE_DIR}"
-  BUILD_COMMAND $(MAKE) runtime hexagon_rpc_sim
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} runtime hexagon_rpc_sim
   CMAKE_ARGS
     "-DCMAKE_C_COMPILER=${USE_HEXAGON_TOOLCHAIN}/bin/hexagon-clang"
     "-DCMAKE_CXX_COMPILER=${USE_HEXAGON_TOOLCHAIN}/bin/hexagon-clang++"

--- a/apps/hexagon_launcher/CMakeLists.txt
+++ b/apps/hexagon_launcher/CMakeLists.txt
@@ -39,7 +39,7 @@ endforeach()
 
 ExternalProject_Add(android_launcher_binaries
   SOURCE_DIR "${LAUNCHER_SOURCE_DIR}/cmake/android"
-  BUILD_COMMAND $(MAKE)
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
   CMAKE_ARGS
   "-DCMAKE_TOOLCHAIN_FILE=${USE_ANDROID_TOOLCHAIN}"
   "-DANDROID_PLATFORM=${ANDROID_PLATFORM}"
@@ -60,7 +60,7 @@ ExternalProject_Add_Step(android_launcher_binaries copy_binaries
 
 ExternalProject_Add(hexagon_launcher_binaries
   SOURCE_DIR "${LAUNCHER_SOURCE_DIR}/cmake/hexagon"
-  BUILD_COMMAND $(MAKE)
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
   CMAKE_ARGS
   "-DCMAKE_C_COMPILER=${USE_HEXAGON_TOOLCHAIN}/bin/hexagon-clang"
   "-DCMAKE_CXX_COMPILER=${USE_HEXAGON_TOOLCHAIN}/bin/hexagon-clang++"

--- a/apps/hexagon_launcher/cmake/android/CMakeLists.txt
+++ b/apps/hexagon_launcher/cmake/android/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(launcher_android
 
 ExternalProject_Add(android_tvm_runtime
   SOURCE_DIR "${TVM_SOURCE_DIR}"
-  BUILD_COMMAND $(MAKE) runtime
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} runtime
   CMAKE_ARGS
   "-DANDROID_ABI=${ANDROID_ABI}"
   "-DANDROID_PLATFORM=${ANDROID_PLATFORM}"

--- a/apps/hexagon_launcher/cmake/hexagon/CMakeLists.txt
+++ b/apps/hexagon_launcher/cmake/hexagon/CMakeLists.txt
@@ -77,7 +77,7 @@ add_library(launcher_rpc_skel SHARED
 
 ExternalProject_Add(static_hexagon_tvm_runtime
   SOURCE_DIR "${TVM_SOURCE_DIR}"
-  BUILD_COMMAND $(MAKE) runtime
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} runtime
   CMAKE_ARGS
   "-DBUILD_STATIC_RUNTIME=ON"
   "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"


### PR DESCRIPTION
Fix a limitation of the `CMakeLists.txt` files that
prevented use of the `ninja` build system.

Now TVM's build system can be configured using `cmake -G Ninja ...`