### PR TITLE
[PY] refactoring - move devices-related functions from tvm.runtime.ndarray

### DIFF
--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -31,9 +31,7 @@ from ._ffi import register_object, register_func, register_extension, get_global
 # top-level alias
 # tvm.runtime
 from .runtime.object import Object
-from .runtime.ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
-from .runtime.ndarray import vpi, rocm, ext_dev, hexagon
-from .runtime import ndarray as nd
+from .runtime import ndarray as nd, device, cpu, cuda, gpu, rocm, opencl, metal, vpi, vulkan, ext_dev, hexagon, cl, mtl
 
 # tvm.error
 from . import error

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -39,6 +39,7 @@ import multiprocessing
 import logging
 
 import tvm._ffi
+import tvm.runtime
 from tvm.runtime import Object, module, ndarray
 from tvm.driver import build_module
 from tvm.ir import transform
@@ -891,7 +892,7 @@ def _timed_eval_func(
     error_msg = None
     try:
         func = module.load_module(build_res.filename)
-        dev = ndarray.device(str(inp.task.target), device)
+        dev = tvm.runtime.device(str(inp.task.target), device)
         # Limitation:
         # We can not get PackFunction directly in the remote mode as it is wrapped
         # under the std::function. We could lift the restriction later once we fold

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -37,6 +37,7 @@ import warnings
 
 import tvm._ffi
 import tvm.ir.transform
+import tvm.runtime
 from tvm import nd
 from tvm import rpc as _rpc
 from tvm.autotvm.env import AutotvmGlobalScope, reset_global_scope

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -23,6 +23,7 @@ import tempfile
 from typing import Union
 
 import tvm
+import tvm.runtime
 from tvm import rpc as _rpc
 import tvm.contrib.hexagon as hexagon
 from tvm.relay.backend.executor_factory import (

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -23,6 +23,7 @@ import os
 import warnings
 
 import tvm._ffi
+import tvm.runtime
 from tvm.target import Target
 
 from . import utils
@@ -271,8 +272,8 @@ def get_target_compute_version(target=None):
         return major + "." + minor
 
     # 3. GPU compute version
-    if tvm.cuda(0).exist:
-        return tvm.cuda(0).compute_version
+    if tvm.runtime.cuda(0).exist:
+        return tvm.runtime.cuda(0).compute_version
 
     raise ValueError(
         "No CUDA architecture was specified or GPU detected."
@@ -352,8 +353,8 @@ def have_tensorcore(compute_version=None, target=None):
         isn't specified.
     """
     if compute_version is None:
-        if tvm.cuda(0).exist:
-            compute_version = tvm.cuda(0).compute_version
+        if tvm.runtime.cuda(0).exist:
+            compute_version = tvm.runtime.cuda(0).compute_version
         else:
             if target is None or "arch" not in target.attrs:
                 warnings.warn(

--- a/python/tvm/contrib/target/coreml.py
+++ b/python/tvm/contrib/target/coreml.py
@@ -21,6 +21,7 @@ import os
 import shutil
 
 import tvm._ffi
+import tvm.runtime
 from ...relay.expr_functor import ExprVisitor
 from .. import xcode, coreml_runtime
 
@@ -244,5 +245,5 @@ def coreml_compiler(func):
         shutil.rmtree(mlmodelc_path)
     builder.compile(model_dir)
 
-    dev = tvm.cpu(0)
+    dev = tvm.runtime.cpu(0)
     return coreml_runtime.create(name, mlmodelc_path, dev).module

--- a/python/tvm/contrib/torch/pytorch_tvm.py
+++ b/python/tvm/contrib/torch/pytorch_tvm.py
@@ -20,6 +20,7 @@
 """`compile` api that convert torch module to torch tvm module"""
 import os
 import tvm
+import tvm.runtime
 import tvm.testing
 from tvm import relay, autotvm
 from tvm.runtime import load_module
@@ -105,7 +106,7 @@ TVM_ASSETS = ["mod.so", "graph.json", "params"]
 class PyTorchTVMModule:
     """Helper class for compiling pytorch module to tvm module"""
 
-    def __init__(self, target="cuda", device=tvm.cuda(0)) -> None:
+    def __init__(self, target="cuda", device=tvm.runtime.cuda(0)) -> None:
         self.script_module = None
         self.input_infos = None
         self.default_dtype = "float32"
@@ -231,7 +232,7 @@ def compile(script_module, option):
     tuning_n_trials = option.get("tuning_n_trials", 20)
     num_outputs = option.get("num_outputs", 1)
     target = option.get("target", "cuda")
-    device = option.get("device", tvm.cuda(0))
+    device = option.get("device", tvm.runtime.cuda(0))
 
     mod = PyTorchTVMModule(target=target, device=device)
     print("Converting...")

--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -21,10 +21,10 @@ import warnings
 
 from typing import Union, Optional, List, Mapping
 
+import tvm.runtime
 import tvm.tir
 
 from tvm.runtime import Module
-from tvm.runtime import ndarray
 from tvm.ir import container
 from tvm.tir import PrimFunc
 from tvm.ir.module import IRModule
@@ -266,8 +266,8 @@ def build(
     if not target_host:
         for tar, mod in annotated_mods.items():
             tar = Target(tar)
-            device_type = ndarray.device(tar.kind.name, 0).device_type
-            if device_type == ndarray.cpu(0).device_type:
+            device_type = tvm.runtime.device(tar.kind.name, 0).device_type
+            if device_type == tvm.runtime.cpu(0).device_type:
                 target_host = tar
                 break
     if not target_host:

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -26,12 +26,12 @@ import tarfile
 import typing
 
 import tvm
+import tvm.runtime
 from tvm.ir.type import TupleType
 from tvm.micro import get_standalone_crt_dir
 from .._ffi import get_global_func
 from ..contrib import utils
 from ..driver import build_module
-from ..runtime import ndarray as _nd
 from ..relay.backend import executor_factory
 from ..relay.backend.name_transforms import to_c_variable_style, prefix_generated_name
 from ..relay import param_dict
@@ -468,7 +468,7 @@ def _export_operator_model_library_format(mod: build_module.OperatorModule, temp
                 "Model Library Format"
             )
 
-        targets[int(_nd.device(str(target)).device_type)] = target
+        targets[int(tvm.runtime.device(str(target)).device_type)] = target
 
     src_dir = tempdir / "src"
     src_dir.mkdir()

--- a/python/tvm/relay/analysis/analysis.py
+++ b/python/tvm/relay/analysis/analysis.py
@@ -22,7 +22,7 @@ configuring the passes and scripting them in Python.
 """
 from ...ir import IRModule
 from ...relay import transform, build_module
-from ...runtime.ndarray import cpu
+from ...runtime.devices import cpu
 
 from . import _ffi_api
 from .feature import Feature

--- a/python/tvm/relay/backend/graph_executor_codegen.py
+++ b/python/tvm/relay/backend/graph_executor_codegen.py
@@ -33,6 +33,7 @@ To connect to the graph executor, we use a printer that converts our graph forma
 into TVM's JSON format. The resulting string can be loaded by
 contrib.graph_executor or any other TVM runtime compatible systems.
 """
+import tvm.runtime
 from tvm.runtime.ndarray import empty
 from tvm.relay import _build_module
 from tvm.target import Target
@@ -91,7 +92,7 @@ class GraphExecutorCodegen(object):
         params = {}
         for key in param_names:
             arr = self._get_param_by_name(key)
-            param = empty(arr.shape, dtype=arr.dtype, device=arr.device)
+            param = empty(arr.shape, dtype=arr.dtype, device=tvm.runtime.device)
             arr.copyto(param)
             params[key] = param
         return graph_json, lowered_func, params

--- a/python/tvm/relay/backend/graph_executor_codegen.py
+++ b/python/tvm/relay/backend/graph_executor_codegen.py
@@ -92,7 +92,7 @@ class GraphExecutorCodegen(object):
         params = {}
         for key in param_names:
             arr = self._get_param_by_name(key)
-            param = empty(arr.shape, dtype=arr.dtype, device=tvm.runtime.device)
+            param = empty(arr.shape, dtype=arr.dtype, device=arr.device)
             arr.copyto(param)
             params[key] = param
         return graph_json, lowered_func, params

--- a/python/tvm/relay/backend/interpreter.py
+++ b/python/tvm/relay/backend/interpreter.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 import numpy as np
 
 import tvm._ffi
+import tvm.runtime
 from tvm.runtime import container, Object
 
 from . import _backend
@@ -45,7 +46,7 @@ class RefValue(Object):
 
 def _arg_to_ast(mod, arg):
     if isinstance(arg, nd.NDArray):
-        return Constant(arg.copyto(nd.cpu(0)))
+        return Constant(arg.copyto(tvm.runtime.cpu(0)))
     elif isinstance(arg, container.ADT):
         return Tuple([_arg_to_ast(mod, field) for field in arg])
     elif isinstance(arg, tuple):

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -25,6 +25,7 @@ import warnings
 import numpy as np
 
 import tvm
+import tvm.runtime
 import tvm.runtime.ndarray as _nd
 import tvm.runtime.vm as vm_rt
 from tvm import autotvm
@@ -229,7 +230,7 @@ class VMCompiler(object):
 
         tgts = {}
         for dev, tgt in target.items():
-            dev_type = tvm.tir.IntImm("int32", tvm.nd.device(dev).device_type)
+            dev_type = tvm.tir.IntImm("int32", tvm.runtime.device(dev).device_type)
             if isinstance(tgt, str):
                 tgt = tvm.target.Target(tgt)
 
@@ -245,7 +246,7 @@ class VMCompiler(object):
                 if tgt.host is not None:
                     return tgt.host
             for device_type, tgt in target.items():
-                if device_type.value == tvm.nd.cpu(0).device_type:
+                if device_type.value == tvm.runtime.cpu(0).device_type:
                     target_host = tgt
                     break
         if not target_host:

--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -21,6 +21,7 @@ import logging
 import numpy as np
 
 import tvm
+import tvm.runtime
 from tvm.ir import IRModule
 from tvm.topi.utils import get_const_tuple
 
@@ -550,7 +551,7 @@ def infer_value(input_val, params, mod=None):
         func = _function.Function(analysis.free_vars(input_val), input_val)
         with tvm.transform.PassContext(opt_level=0):
             lib = tvm.relay.build(func, target="llvm", params=params)
-        dev = tvm.cpu(0)
+        dev = tvm.runtime.cpu(0)
         m = graph_executor.GraphModule(lib["default"](dev))
         m.run()
         return m.get_output(0)
@@ -563,7 +564,7 @@ def infer_value(input_val, params, mod=None):
         for param in mod["main"].params:
             inputs.append(params[param.name_hint])
         result = tvm.relay.create_executor(
-            "debug", mod=mod, device=tvm.cpu(), target="llvm"
+            "debug", mod=mod, device=tvm.runtime.cpu(), target="llvm"
         ).evaluate()(*inputs)
         return result
 

--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -25,6 +25,7 @@ import warnings
 
 import numpy as np
 import tvm
+import tvm.runtime
 from tvm.ir import IRModule
 from tvm.topi.utils import get_const_tuple
 

--- a/python/tvm/relay/op/annotation/annotation.py
+++ b/python/tvm/relay/op/annotation/annotation.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Annotation operations."""
+import tvm.runtime
 from tvm import target
-from tvm.runtime import ndarray as _nd
 from tvm.runtime import Device as _Device
 
 from . import _make
@@ -27,7 +27,7 @@ def _make_virtual_device(device):
     if isinstance(device, _Device):
         return target.VirtualDevice(device)
     if isinstance(device, str):
-        return target.VirtualDevice(_nd.device(device))
+        return target.VirtualDevice(tvm.runtime.device(device))
     raise ValueError("expecting a Device or device name, but received a %s" % (type(device)))
 
 

--- a/python/tvm/relay/op/tensor.py
+++ b/python/tvm/relay/op/tensor.py
@@ -16,8 +16,8 @@
 # under the License.
 """Basic tensor operations."""
 # pylint: disable=redefined-builtin, unused-argument
+import tvm.runtime
 from tvm import target
-from tvm.runtime import ndarray as _nd
 from tvm.runtime import Device as _Device
 from tvm.te.hybrid import script
 
@@ -31,7 +31,7 @@ def _make_virtual_device(device):
     if isinstance(device, _Device):
         return target.VirtualDevice(device)
     if isinstance(device, str):
-        return target.VirtualDevice(_nd.device(device))
+        return target.VirtualDevice(tvm.runtime.device(device))
     raise ValueError("expecting a Device or device name, but received a %s" % (type(device)))
 
 

--- a/python/tvm/relay/quantize/_calibrate.py
+++ b/python/tvm/relay/quantize/_calibrate.py
@@ -21,6 +21,7 @@ import multiprocessing as mp
 import numpy as np
 import tvm
 import tvm.driver
+import tvm.runtime
 from tvm.ir import IRModule
 
 from . import _quantize
@@ -39,10 +40,10 @@ def _get_profile_runtime(mod):
 
     if tvm.target.Target.current():
         target = tvm.target.Target.current()
-        dev = tvm.device(target.kind.name)
+        dev = tvm.runtime.device(target.kind.name)
     else:
         target = "llvm"
-        dev = tvm.device(target)
+        dev = tvm.runtime.device(target)
 
     with tvm.transform.PassContext(opt_level=3):
         lib = _build_module.build(func, target=target)

--- a/python/tvm/relay/testing/init.py
+++ b/python/tvm/relay/testing/init.py
@@ -19,6 +19,7 @@ from functools import reduce
 import numpy as np
 
 import tvm
+import tvm.runtime
 from tvm import relay
 
 
@@ -176,5 +177,5 @@ def create_workload(net, initializer=None, seed=0):
             continue
         init_value = np.zeros(v.concrete_shape).astype(v.dtype)
         initializer(k, init_value)
-        params[k] = tvm.nd.array(init_value, device=tvm.cpu(0))
+        params[k] = tvm.nd.array(init_value, device=tvm.runtime.cpu(0))
     return mod, params

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -22,9 +22,9 @@ import struct
 import time
 
 import tvm._ffi
+import tvm.runtime
 from tvm._ffi.base import TVMError
 from tvm.contrib import utils
-from tvm.runtime import ndarray as nd
 
 from . import _ffi_api, base, server
 
@@ -84,7 +84,7 @@ class RPCSession(object):
         dev: Device
             The corresponding encoded remote device.
         """
-        dev = nd.device(dev_type, dev_id)
+        dev = tvm.runtime.device(dev_type, dev_id)
         encode = (self._tbl_index + 1) * base.RPC_SESS_MASK
         dev.device_type += encode
         dev._rpc_sess = self

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -26,8 +26,7 @@ from .profiling import Report
 
 # function exposures
 from .object_generic import convert_to_object, convert, const
-from .ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
-from .ndarray import vpi, rocm, ext_dev
+from .devices import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl, vpi, rocm, ext_dev
 from .module import load_module, enabled, system_lib
 from .container import String, ShapeTuple
 from .params import save_param_dict, load_param_dict

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -26,7 +26,7 @@ from .profiling import Report
 
 # function exposures
 from .object_generic import convert_to_object, convert, const
-from .devices import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl, vpi, rocm, ext_dev
+from .devices import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl, vpi, rocm, ext_dev, hexagon
 from .module import load_module, enabled, system_lib
 from .container import String, ShapeTuple
 from .params import save_param_dict, load_param_dict

--- a/python/tvm/runtime/devices.py
+++ b/python/tvm/runtime/devices.py
@@ -1,0 +1,232 @@
+import warnings
+
+from .._ffi.base import string_types
+from .._ffi.runtime_ctypes import Device
+
+
+# function exposures
+
+
+def device(dev_type, dev_id=0):
+    """Construct a TVM device with given device type and id.
+
+    Parameters
+    ----------
+    dev_type: int or str
+        The device type mask or name of the device.
+
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev: tvm.runtime.Device
+        The corresponding device.
+
+    Examples
+    --------
+    Device can be used to create reflection of device by
+    string representation of the device type.
+
+    .. code-block:: python
+
+      assert tvm.device("cpu", 1) == tvm.cpu(1)
+      assert tvm.device("cuda", 0) == tvm.cuda(0)
+    """
+    if isinstance(dev_type, string_types):
+        dev_type = dev_type.split()[0]
+        if dev_type not in Device.STR2MASK:
+            raise ValueError("Unknown device type %s" % dev_type)
+        dev_type = Device.STR2MASK[dev_type]
+    return Device(dev_type, dev_id)
+
+
+def cpu(dev_id=0):
+    """Construct a CPU device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(1, dev_id)
+
+
+def cuda(dev_id=0):
+    """Construct a CUDA GPU device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(2, dev_id)
+
+
+def gpu(dev_id=0):
+    """Construct a CUDA GPU device
+
+        deprecated:: 0.9.0
+        Use :py:func:`tvm.cuda` instead.
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    warnings.warn(
+        "Please use tvm.cuda() instead of tvm.gpu(). tvm.gpu() is going to be deprecated in 0.9.0",
+    )
+    return Device(2, dev_id)
+
+
+def rocm(dev_id=0):
+    """Construct a ROCM device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(10, dev_id)
+
+
+def opencl(dev_id=0):
+    """Construct a OpenCL device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(4, dev_id)
+
+
+def metal(dev_id=0):
+    """Construct a metal device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(8, dev_id)
+
+
+def vpi(dev_id=0):
+    """Construct a VPI simulated device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(9, dev_id)
+
+
+def vulkan(dev_id=0):
+    """Construct a Vulkan device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(7, dev_id)
+
+
+def ext_dev(dev_id=0):
+    """Construct a extension device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+
+    Note
+    ----
+    This API is reserved for quick testing of new
+    device by plugin device API as ext_dev.
+    """
+    return Device(12, dev_id)
+
+
+def hexagon(dev_id=0):
+    """Construct a Hexagon device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(14, dev_id)
+
+
+def webgpu(dev_id=0):
+    """Construct a webgpu device.
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    dev : Device
+        The created device
+    """
+    return Device(15, dev_id)
+
+
+cl = opencl
+mtl = metal

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -291,7 +291,7 @@ def numpyasarray(np_data):
     arr.dtype = DataType(np.dtype(data.dtype).name)
     arr.ndim = data.ndim
     # CPU device
-    arr.device = device(1, 0)
+    arr.device = devices.device(1, 0)
     return arr, shape
 
 

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -295,7 +295,7 @@ def numpyasarray(np_data):
     return arr, shape
 
 
-def empty(shape, dtype="float32", device=device(1, 0), mem_scope=None):
+def empty(shape, dtype="float32", device=devices.device(1, 0), mem_scope=None):
     """Create an empty array given shape and device
 
     Parameters

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -24,7 +24,7 @@ import tvm.runtime
 from tvm.runtime import devices
 
 from tvm._ffi.base import _LIB, check_call, c_array, _FFI_MODE
-from tvm._ffi.runtime_ctypes import DataType, Device, TVMArray
+from tvm._ffi.runtime_ctypes import DataType, DataTypeCode, Device, TVMArray
 from tvm._ffi.runtime_ctypes import tvm_shape_index_t
 from . import _ffi_api
 

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -20,10 +20,12 @@ import ctypes
 import warnings
 import numpy as np
 import tvm._ffi
+import tvm.runtime
+from tvm.runtime import devices
 
-from tvm._ffi.base import _LIB, check_call, c_array, string_types, _FFI_MODE
-from tvm._ffi.runtime_ctypes import DataType, Device, TVMArray, TVMArrayHandle
-from tvm._ffi.runtime_ctypes import DataTypeCode, tvm_shape_index_t
+from tvm._ffi.base import _LIB, check_call, c_array, _FFI_MODE
+from tvm._ffi.runtime_ctypes import DataType, Device, TVMArray
+from tvm._ffi.runtime_ctypes import tvm_shape_index_t
 from . import _ffi_api
 
 try:
@@ -277,40 +279,6 @@ class NDArray(NDArrayBase):
         return _ffi_api.TVMArrayCreateView(self, shape)
 
 
-def device(dev_type, dev_id=0):
-    """Construct a TVM device with given device type and id.
-
-    Parameters
-    ----------
-    dev_type: int or str
-        The device type mask or name of the device.
-
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev: tvm.runtime.Device
-        The corresponding device.
-
-    Examples
-    --------
-    Device can be used to create reflection of device by
-    string representation of the device type.
-
-    .. code-block:: python
-
-      assert tvm.device("cpu", 1) == tvm.cpu(1)
-      assert tvm.device("cuda", 0) == tvm.cuda(0)
-    """
-    if isinstance(dev_type, string_types):
-        dev_type = dev_type.split()[0]
-        if dev_type not in Device.STR2MASK:
-            raise ValueError("Unknown device type %s" % dev_type)
-        dev_type = Device.STR2MASK[dev_type]
-    return Device(dev_type, dev_id)
-
-
 def numpyasarray(np_data):
     """Return a TVMArray representation of a numpy array."""
     data = np_data
@@ -381,198 +349,7 @@ def from_dlpack(dltensor):
     raise AttributeError("Required attribute __dlpack__ not found")
 
 
-def cpu(dev_id=0):
-    """Construct a CPU device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(1, dev_id)
-
-
-def cuda(dev_id=0):
-    """Construct a CUDA GPU device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(2, dev_id)
-
-
-def gpu(dev_id=0):
-    """Construct a CUDA GPU device
-
-        deprecated:: 0.9.0
-        Use :py:func:`tvm.cuda` instead.
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    warnings.warn(
-        "Please use tvm.cuda() instead of tvm.gpu(). tvm.gpu() is going to be deprecated in 0.9.0",
-    )
-    return Device(2, dev_id)
-
-
-def rocm(dev_id=0):
-    """Construct a ROCM device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(10, dev_id)
-
-
-def opencl(dev_id=0):
-    """Construct a OpenCL device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(4, dev_id)
-
-
-def metal(dev_id=0):
-    """Construct a metal device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(8, dev_id)
-
-
-def vpi(dev_id=0):
-    """Construct a VPI simulated device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(9, dev_id)
-
-
-def vulkan(dev_id=0):
-    """Construct a Vulkan device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(7, dev_id)
-
-
-def ext_dev(dev_id=0):
-    """Construct a extension device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-
-    Note
-    ----
-    This API is reserved for quick testing of new
-    device by plugin device API as ext_dev.
-    """
-    return Device(12, dev_id)
-
-
-def hexagon(dev_id=0):
-    """Construct a Hexagon device
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(14, dev_id)
-
-
-def webgpu(dev_id=0):
-    """Construct a webgpu device.
-
-    Parameters
-    ----------
-    dev_id : int, optional
-        The integer device id
-
-    Returns
-    -------
-    dev : Device
-        The created device
-    """
-    return Device(15, dev_id)
-
-
-cl = opencl
-mtl = metal
-
-
-def array(arr, device=cpu(0)):
+def array(arr, device=devices.cpu(0)):
     """Create an array from source arr.
 
     Parameters

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -23,6 +23,7 @@ Implements a Python interface to executing the compiled VM object.
 import numpy as np
 
 import tvm
+import tvm.runtime
 from tvm.runtime import Module
 from tvm._ffi.runtime_ctypes import TVMByteArray
 from tvm._ffi import base as _base
@@ -43,7 +44,7 @@ def _convert(arg, cargs):
     if isinstance(arg, Object):
         cargs.append(arg)
     elif isinstance(arg, np.ndarray):
-        nd_arr = tvm.nd.array(arg, device=tvm.cpu(0))
+        nd_arr = tvm.nd.array(arg, device=tvm.runtime.cpu(0))
         cargs.append(nd_arr)
     elif isinstance(arg, tvm.runtime.NDArray):
         cargs.append(arg)
@@ -54,7 +55,7 @@ def _convert(arg, cargs):
         cargs.append(container.tuple_object(field_args))
     elif isinstance(arg, (_base.numeric_types, bool)):
         dtype = _gettype(arg)
-        value = tvm.nd.array(np.array(arg, dtype=dtype), device=tvm.cpu(0))
+        value = tvm.nd.array(np.array(arg, dtype=dtype), device=tvm.runtime.cpu(0))
         cargs.append(value)
     elif isinstance(arg, str):
         cargs.append(arg)
@@ -400,8 +401,8 @@ class VirtualMachine(object):
             devs = [dev]
 
         # CPU is required for executing shape functions
-        if not any(c.device_type % RPC_SESS_MASK == tvm.cpu().device_type for c in devs):
-            devs.append(tvm.cpu())
+        if not any(c.device_type % RPC_SESS_MASK == tvm.runtime.cpu().device_type for c in devs):
+            devs.append(tvm.runtime.cpu())
 
         default_alloc_type = VirtualMachine.POOLED_ALLOCATOR
         if memory_cfg is None:

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -35,6 +35,7 @@ import pytest
 import _pytest
 
 import tvm
+import tvm.runtime
 from tvm.testing import utils
 
 
@@ -81,7 +82,7 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture
 def dev(target):
     """Give access to the device to tests that need it."""
-    return tvm.device(target)
+    return tvm.runtime.device(target)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -77,6 +77,7 @@ import pytest
 import numpy as np
 import tvm
 import tvm.arith
+import tvm.runtime
 import tvm.tir
 import tvm.te
 import tvm._ffi
@@ -406,7 +407,7 @@ def _get_targets(target_str=None):
             is_runnable = is_enabled and cudnn.exists()
         else:
             is_enabled = tvm.runtime.enabled(target_kind)
-            is_runnable = is_enabled and tvm.device(target_kind).exist
+            is_runnable = is_enabled and tvm.runtime.device(target_kind).exist
 
         targets.append(
             {
@@ -507,7 +508,7 @@ def enabled_targets():
         A list of pairs of all enabled devices and the associated context
 
     """
-    return [(t["target"], tvm.device(t["target"])) for t in _get_targets() if t["is_runnable"]]
+    return [(t["target"], tvm.runtime.device(t["target"])) for t in _get_targets() if t["is_runnable"]]
 
 
 def _compose(args, decs):
@@ -575,11 +576,11 @@ def requires_gpu(*args):
     """
     _requires_gpu = [
         pytest.mark.skipif(
-            not tvm.cuda().exist
-            and not tvm.rocm().exist
-            and not tvm.opencl().exist
-            and not tvm.metal().exist
-            and not tvm.vulkan().exist,
+            not tvm.runtime.cuda().exist
+            and not tvm.runtime.rocm().exist
+            and not tvm.runtime.opencl().exist
+            and not tvm.runtime.metal().exist
+            and not tvm.runtime.vulkan().exist,
             reason="No GPU present",
         ),
         *uses_gpu(),
@@ -840,7 +841,7 @@ def requires_tensorcore(*args):
     _requires_tensorcore = [
         pytest.mark.tensorcore,
         pytest.mark.skipif(
-            not tvm.cuda().exist or not nvcc.have_tensorcore(tvm.cuda(0).compute_version),
+            not tvm.runtime.cuda().exist or not nvcc.have_tensorcore(tvm.runtime.cuda(0).compute_version),
             reason="No tensorcore present",
         ),
         *requires_gpu(),

--- a/python/tvm/topi/cuda/conv2d_alter_op.py
+++ b/python/tvm/topi/cuda/conv2d_alter_op.py
@@ -19,6 +19,7 @@
 
 import logging
 import tvm
+import tvm.runtime
 from tvm import te, relay, autotvm
 
 from .. import nn
@@ -231,7 +232,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
 
     if topi_tmpl == "conv2d_HWNCnc_tensorcore.cuda":
         assert data_layout == "HWNC" and kernel_layout == "HWOI"
-        assert float(tvm.cuda(0).compute_version) >= 7.5
+        assert float(tvm.runtime.cuda(0).compute_version) >= 7.5
         H, W, N, CI = get_const_tuple(data.shape)
         KH, KW, CO, _ = get_const_tuple(kernel.shape)
 


### PR DESCRIPTION
Hello,

I'm not sure whether it needs RFC, but it was little messy in python runtime code (related to my answer, not main thread in this post https://discuss.tvm.apache.org/t/pre-rfc-more-meaningful-names-in-rpc-module-in-python/12618). I have moved `device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl, vpi, rocm, ext_dev` functions from `tvm.runtime.ndarray` to `tvm.runtime.devices` and reimported them in `tvm.runtime`, so we can use following statement:
```
import tvm.runtime
runtime.cpu(0)
```

In previous version there was mix of following:
```
import tvm
tvm.cpu()
```

```
from tvm.runtime import ndarray as _nd
_nd.cuda(0)
```
