### PR TITLE
[Analysis] Readability/Deduplication in Analyzer CanProve/Simplify

### DIFF
--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -108,29 +108,25 @@ bool Analyzer::CanProveEqual(const PrimExpr& lhs, const PrimExpr& rhs) {
 }
 
 bool Analyzer::CanProve(const PrimExpr& expr) {
-  if (const auto* ptr = expr.as<IntImmNode>()) {
-    return ptr->value != 0;
-  }
-  auto res = this->rewrite_simplify(expr);
-  if (const auto* ptr = res.as<IntImmNode>()) {
-    return ptr->value != 0;
-  }
-  res = this->canonical_simplify(expr);
-  if (const auto* ptr = res.as<IntImmNode>()) {
-    return ptr->value != 0;
-  }
-  return false;
+  PrimExpr simplified = Simplify(expr);
+  const int64_t* as_int = tir::as_const_int(simplified);
+  return as_int && *as_int;
 }
 
 PrimExpr Analyzer::Simplify(const PrimExpr& expr, int steps) {
-  if (tir::is_const_int(expr)) return expr;
   PrimExpr res = expr;
-  for (int i = 0; i < steps; ++i) {
-    res = this->rewrite_simplify(res);
-    if (tir::is_const_int(res) || ++i == steps) return res;
-    res = this->canonical_simplify(res);
-    if (tir::is_const_int(res)) return res;
+
+  for (int i = 0; i < steps; i++) {
+    if (tir::is_const_int(res)) {
+      break;
+    }
+    if (i % 2 == 0) {
+      res = this->rewrite_simplify(res);
+    } else {
+      res = this->canonical_simplify(res);
+    }
   }
+
   return res;
 }
 

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -108,6 +108,11 @@ bool Analyzer::CanProveEqual(const PrimExpr& lhs, const PrimExpr& rhs) {
 }
 
 bool Analyzer::CanProve(const PrimExpr& expr) {
+  // Avoid potentially expensive simplification unless required.
+  if (const auto* ptr = expr.as<IntImmNode>()) {
+    return ptr->value != 0;
+  }
+
   PrimExpr simplified = Simplify(expr);
   const int64_t* as_int = tir::as_const_int(simplified);
   return as_int && *as_int;
@@ -116,9 +121,9 @@ bool Analyzer::CanProve(const PrimExpr& expr) {
 PrimExpr Analyzer::Simplify(const PrimExpr& expr, int steps) {
   PrimExpr res = expr;
 
-  for (int i = 0; i < steps; i++) {
+  for (int i = 0; i < steps; ++i) {
     if (tir::is_const_int(res)) {
-      break;
+      return res;
     }
     if (i % 2 == 0) {
       res = this->rewrite_simplify(res);


### PR DESCRIPTION
- Remove duplication between `Analyzer::CanProve` and `Analyzer::Simplify`.

- Simplify loop iteration in `Analyzer::Simplify`.  The `++i`  previously in the middle of the loop was easy to miss.