### PR TITLE
[skip ci][ci][actions] Hardcode Python version to 3.7 for miniconda setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,6 +14,7 @@ runs:
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
       use-only-tar-bz2: true
+      python-version: 3.7
   - name: Conda info
     shell: pwsh
     run: |


### PR DESCRIPTION
Fixes #11131

Tested here: https://github.com/driazati/tvm/runs/6180972568?check_suite_focus=true

cc @areusch