### PR TITLE
[CI] update oneDNN to v2.6

### DIFF
--- a/docker/install/ubuntu_install_dnnl.sh
+++ b/docker/install/ubuntu_install_dnnl.sh
@@ -51,4 +51,7 @@ install_dir="/usr/local/"
 cd ${src_dir}
 cmake . -DCMAKE_INSTALL_PREFIX=${install_dir} && make -j16 && make install
 
+cd ${current_dir}
+rm -rf ${tar_file} ${src_dir}
+
 cd ${old_dir}

--- a/docker/install/ubuntu_install_dnnl.sh
+++ b/docker/install/ubuntu_install_dnnl.sh
@@ -49,7 +49,10 @@ else
 fi
 
 cd ${src_dir}
-cmake . -DCMAKE_INSTALL_PREFIX=${install_dir} && make -j16 && make install
+NPROC=$(nproc)
+cmake . -GNinja -DCMAKE_INSTALL_PREFIX=${install_dir}
+make -j"$NPROC"
+make install
 
 cd ${build_dir}
 rm -rf ${tar_file} ${src_dir}

--- a/docker/install/ubuntu_install_dnnl.sh
+++ b/docker/install/ubuntu_install_dnnl.sh
@@ -24,6 +24,7 @@ pre_dir=`pwd`
 
 build_dir="/usr/local/"
 install_dir="/usr/local/"
+pinned_tag="v2.6" # unset or set to "" to build latest release
 
 cd ${build_dir}
 rls_tag=$(curl -s https://github.com/oneapi-src/oneDNN/releases/latest \
@@ -31,6 +32,12 @@ rls_tag=$(curl -s https://github.com/oneapi-src/oneDNN/releases/latest \
     | grep -o '[^\/]*$')
 dnnl_ver=`echo ${rls_tag} | sed 's/v//g'`
 echo "The latest oneDNN release is version ${dnnl_ver} with tag '${rls_tag}'"
+
+if [[ -v pinned_tag && -n ${pinned_tag} ]]; then
+    rls_tag=${pinned_tag}
+    dnnl_ver=`echo ${rls_tag} | sed 's/v//g'`
+    echo "Using pinned oneDNN release version ${dnnl_ver} with tag '${rls_tag}'"
+fi
 
 tar_file="${rls_tag}.tar.gz"
 src_dir="${build_dir}/oneDNN-${dnnl_ver}"
@@ -45,16 +52,16 @@ else
         tar_url="https://github.com/oneapi-src/oneDNN/archive/refs/tags/${tar_file}"
         wget ${tar_url}
     fi
+    echo "extracting source files."
     tar -xzvf ${tar_file}
 fi
 
 cd ${src_dir}
-NPROC=$(nproc)
-cmake . -GNinja -DCMAKE_INSTALL_PREFIX=${install_dir}
-make -j"$NPROC"
+cmake . -DCMAKE_INSTALL_PREFIX="${install_dir}"
+make -j"$(nproc)"
 make install
 
 cd ${build_dir}
-rm -rf ${tar_file} ${src_dir}
+rm -rfv ${tar_file} ${src_dir}
 
 cd ${pre_dir}

--- a/docker/install/ubuntu_install_dnnl.sh
+++ b/docker/install/ubuntu_install_dnnl.sh
@@ -20,11 +20,12 @@ set -e
 set -u
 set -o pipefail
 
-old_dir=`pwd`
+pre_dir=`pwd`
 
-cd /usr/local/
-current_dir=`pwd`
+build_dir="/usr/local/"
+install_dir="/usr/local/"
 
+cd ${build_dir}
 rls_tag=$(curl -s https://github.com/oneapi-src/oneDNN/releases/latest \
     | cut -d '"' -f 2 \
     | grep -o '[^\/]*$')
@@ -32,7 +33,7 @@ dnnl_ver=`echo ${rls_tag} | sed 's/v//g'`
 echo "The latest oneDNN release is version ${dnnl_ver} with tag '${rls_tag}'"
 
 tar_file="${rls_tag}.tar.gz"
-src_dir="${current_dir}/oneDNN-${dnnl_ver}"
+src_dir="${build_dir}/oneDNN-${dnnl_ver}"
 
 if [ -d ${src_dir} ]; then
     echo "source files exist."
@@ -42,16 +43,15 @@ else
     else 
         echo "downloading ${tar_file}."
         tar_url="https://github.com/oneapi-src/oneDNN/archive/refs/tags/${tar_file}"
-        wget ${tar_url} ${tar_file}
+        wget ${tar_url}
     fi
     tar -xzvf ${tar_file}
 fi
 
-install_dir="/usr/local/"
 cd ${src_dir}
 cmake . -DCMAKE_INSTALL_PREFIX=${install_dir} && make -j16 && make install
 
-cd ${current_dir}
+cd ${build_dir}
 rm -rf ${tar_file} ${src_dir}
 
-cd ${old_dir}
+cd ${pre_dir}


### PR DESCRIPTION
I submitted the PR to enable bfloat16 in DNNL BYOC(https://github.com/apache/tvm/pull/11111). But the PR failed to be built due to the version of the oneDNN in CI is limited to v2.2, which is a relative old one. So I update the CI script to get and build the latest oneDNN release.
I had tested the script on my own PC and it works fine, but I don't know how to test the script in CI environment. So let me know if I did something inappropriate, thanks!

cc @Mousius @areusch @driazati