### PR TITLE
[Bugfix][Frontend][ONNX] fix incorrect pos_ids generation in EmbedLayerNormalization

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -892,7 +892,7 @@ class EmbedLayerNormalization(OnnxOpConverter):
             assert segment_emb
 
         if pos_ids is None:
-            pos_ids = _op.const([list(range(seq_len))] * seq_len, dtype="int32")
+            pos_ids = _op.const([list(range(seq_len))] * batch_size, dtype="int32")
 
         word_vec = _op.take(word_emb, input_ids, axis=0)
         segment_vec = _op.take(segment_emb, segment_ids, axis=0)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5512,7 +5512,7 @@ def test_embedlayernormalization(target, dev):
 
     hidden_size = 384
     batch_size = 4
-    sequence_length = 4
+    sequence_length = 3
     vocab_size = 5
 
     input_ids = np.full((batch_size, sequence_length), 3).astype("int32")


### PR DESCRIPTION
Accidentally used sequence length instead of batch size when generating the static position ids tensor. Was missed by unit test coincidentally as `seq_len == batch_size`. Updated test to catch it.

cc @anwang2009 @AndrewZhaoLuo 