### PR TITLE
[ci][onnx] Relax more test tolerances

### DIFF
--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5980,10 +5980,7 @@ def test_qlinearleakyrelu(target, dev):
         )
         model = helper.make_model(graph, producer_name="qlinearRelu_test")
         args = (model, ["X"], [in_array.shape], target, dev)
-        if dev == "cuda":
-            quantize_and_verify_with_ort(*args, rtol=1e-2, atol=1e-2)
-        else:
-            quantize_and_verify_with_ort(*args)
+        quantize_and_verify_with_ort(*args, rtol=1e-2, atol=1e-2)
 
     verify_qlinearleakyrelu([2, 4, 5, 6], {"alpha": 0.25})
     verify_qlinearleakyrelu([6, 5, 6, 7], {"alpha": 0.35})
@@ -6008,7 +6005,7 @@ def test_qlinearsigmoid(target, dev):
             outputs=[helper.make_tensor_value_info("B", TensorProto.FLOAT, list(a_shape))],
         )
         model = helper.make_model(graph, producer_name="qlinearsigmoid_test")
-        quantize_and_verify_with_ort(model, ["a"], [a_shape], target, dev)
+        quantize_and_verify_with_ort(model, ["a"], [a_shape], target, dev, rtol=1e-2, atol=1e-2)
 
     verify_qlinearsigmoid([4, 2])
     verify_qlinearsigmoid([5])


### PR DESCRIPTION
Following on #11042, this changes tolerances to fix some other ONNX test failures that have come up in the past several days

| test | link |
| --- | --- |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[llvm] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/3047/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[llvm] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/3044/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/3068/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[llvm] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11032/2/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10833/11/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11035/1/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[llvm] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11074/1/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11068/1/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearsigmoid[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11078/1/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[llvm] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10867/10/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearsigmoid[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-gpu-update/4/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearsigmoid[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/3132/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearsigmoid[cuda] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/3143/pipeline/ |
| tests/python/frontend/onnx/test_forward.py::test_qlinearleakyrelu[llvm] | https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11146/2/pipeline/ |



cc @areusch