### PR TITLE
[CI] Fix apt install command text in check_arm_qemu()

### DIFF
--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -428,7 +428,7 @@ def check_arm_qemu() -> None:
                 """
         You must run a one-time setup to use ARM containers on x86 via QEMU:
 
-            sudo apt install -y sudo apt-get install qemu binfmt-support qemu-user-static
+            sudo apt install -y qemu binfmt-support qemu-user-static
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
         See https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/ for details""".strip(


### PR DESCRIPTION
Fix the recommended command text for installing qemu packages for ARM support.

Fixes #11150

cc: @driazati @areusch
