### PR TITLE
fix accuracy issue of misalignment between arm's q_multiply_shift and x86's

### DIFF
--- a/python/tvm/topi/arm_cpu/tensor_intrin.py
+++ b/python/tvm/topi/arm_cpu/tensor_intrin.py
@@ -1188,6 +1188,49 @@ def _q_multiply_shift_arm(op):
     return tvm.tir.Select(s < 0, out_1, out_2)
 
 
+def _q_multiply_shift_arm2(op):
+    """
+    Implementation of q_multiply_shift_arm through arm intrinsics
+    sqrdmulh and srshl when q == 31.
+
+    Please note that this is introducing a small round-up error for
+    some corner cases. This is because we are rounding twice instead
+    than only once. I.e.:
+
+        * original q_multiply_shift: round(x*y*2^-s)
+        * arm q_multiply_shift: round(round(x*y)*2^-s)
+    """
+    x = op.args[0]
+    y = op.args[1]
+    q = op.args[2]
+    s = op.args[3]
+
+    # Don't use this intrinsic if we don't have a int32x4 vector
+    # or if we are not multiplying q31 numbers
+    if x.dtype != "int32x4" or q.value != 31:
+        return op
+
+    # Case 1, shift is negative
+    sqrdmulh = tvm.tir.call_llvm_intrin(
+        op.dtype, "llvm.aarch64.neon.sqdmulh", tvm.tir.const(2, "uint32"), x, y
+    )
+
+    fixup = (sqrdmulh & (-s)) >> 31
+    fixed_up_x = sqrdmulh + fixup
+    out_1 = tvm.tir.call_llvm_intrin(
+        op.dtype, "llvm.aarch64.neon.srshl", tvm.tir.const(2, "uint32"), sqrdmulh, s
+    )
+
+    # Case 2, shift is positive
+    x = x * (1 << (s))
+    out_2 = tvm.tir.call_llvm_intrin(
+        op.dtype, "llvm.aarch64.neon.sqrdmulh", tvm.tir.const(2, "uint32"), x, y
+    )
+
+    # Select depending on the shift
+    return tvm.tir.Select(s < 0, out_1, out_2)
+
+
 register_intrin_lowering(
-    "tir.q_multiply_shift", target="llvm.aarch64", f=_q_multiply_shift_arm, level=99
+    "tir.q_multiply_shift", target="llvm.aarch64", f=_q_multiply_shift_arm2, level=99
 )


### PR DESCRIPTION

**Problems introduced by the “two rounding” behavior on arm_cpu**
op:`q_multiply_shift`, used in re-quantization.

The DEFAULT path:

- file: [src/target/intrin_rule.cc 2](https://github.com/apache/tvm/blob/main/src/target/intrin_rule.cc#L154)

The NEON path:

- file: [python/tvm/topi/arm_cpu/tensor_intrin.py](https://github.com/apache/tvm/blob/main/python/tvm/topi/arm_cpu/tensor_intrin.py#L1147)

The NEON path may produce some different values (due to two rounding)[1], compared with the _DEFAULT_ path, within a single layer.

The problem is, on`arm_cpu`, it will sometimes use the DEAULT path, sometimes use the NEON path:

- If the innermost axis, is a multiple of four and vectorization applied, the NEON path is enabled
- Otherwise, the DEFAULT path

BTW, it looks like “two rounding” is important to make a “bit exact result” of TFLite qnnpack, see

- [Supporting bit exact TFLite QNN inference](https://discuss.tvm.apache.org/t/supporting-bit-exact-tflite-qnn-inference/5528)
- [TFLite Rounding](https://discuss.tvm.apache.org/t/tflite-rounding/6287)

Discussion in TVM forum: https://discuss.tvm.apache.org/t/quantization-aligning-result-of-tvm-to-torchs/12225

P.S. The patch in this PR is created by @wangxunx, I helped to send this PR.
