### PR TITLE
Bump cmake version for GPU build

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -32,6 +32,9 @@ RUN bash /install/ubuntu1804_install_python.sh
 # Globally disable pip cache
 RUN pip config set global.no-cache-dir false
 
+COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source.sh
+RUN bash /install/ubuntu_install_cmake_source.sh
+
 COPY install/ubuntu1804_install_llvm.sh /install/ubuntu1804_install_llvm.sh
 RUN bash /install/ubuntu1804_install_llvm.sh
 


### PR DESCRIPTION
The cmake version (3.10) in Ubuntu 18.04 does not cope well with the
more advanced cmake use in libtorch surrounding the CUDA target.
We switch to a self-built cmake 3.14 (already used by arm and i386 CI).

The context for this is #10758 .

Thank you @masahi @driazati for your helpful discussion, errors are my own.