### PR TITLE
[MetaSchedule] Logging Interface Unification

### DIFF
--- a/include/tvm/meta_schedule/apply_history_best.h
+++ b/include/tvm/meta_schedule/apply_history_best.h
@@ -34,7 +34,7 @@ class ApplyHistoryBestNode : public runtime::Object {
   /*! \brief The database to be queried from */
   Database database{nullptr};
   /*! \brief The logging function to be used */
-  Optional<PackedFunc> logging_func;
+  PackedFunc logging_func;
 
   void VisitAttrs(AttrVisitor* v) { v->Visit("database", &database); }
   /*!
@@ -62,7 +62,7 @@ class ApplyHistoryBest : public runtime::ObjectRef {
    * \param database The database to be queried from
    * \param logging_func The logging function to use
    */
-  explicit ApplyHistoryBest(Database database, Optional<PackedFunc> logging_func);
+  explicit ApplyHistoryBest(Database database, PackedFunc logging_func);
   /*!
    * \brief The current ApplyHistoryBest in the context
    * \return The ApplyHistoryBest in the current scope.

--- a/include/tvm/meta_schedule/apply_history_best.h
+++ b/include/tvm/meta_schedule/apply_history_best.h
@@ -33,6 +33,8 @@ class ApplyHistoryBestNode : public runtime::Object {
  public:
   /*! \brief The database to be queried from */
   Database database{nullptr};
+  /*! \brief The logging function to be used */
+  Optional<PackedFunc> logging_func;
 
   void VisitAttrs(AttrVisitor* v) { v->Visit("database", &database); }
   /*!
@@ -58,8 +60,9 @@ class ApplyHistoryBest : public runtime::ObjectRef {
   /*!
    * \brief Constructor
    * \param database The database to be queried from
+   * \param logging_func The logging function to use
    */
-  explicit ApplyHistoryBest(Database database);
+  explicit ApplyHistoryBest(Database database, Optional<PackedFunc> logging_func);
   /*!
    * \brief The current ApplyHistoryBest in the context
    * \return The ApplyHistoryBest in the current scope.

--- a/include/tvm/meta_schedule/task_scheduler.h
+++ b/include/tvm/meta_schedule/task_scheduler.h
@@ -84,7 +84,7 @@ class TaskSchedulerNode : public runtime::Object {
   /*! \brief The number of trials already conducted. */
   int num_trials_already;
   /*! \brief The tuning task's logging function. t*/
-  Optional<PackedFunc> logging_func;
+  PackedFunc logging_func;
 
   /*! \brief The default destructor. */
   virtual ~TaskSchedulerNode() = default;
@@ -247,7 +247,7 @@ class TaskScheduler : public runtime::ObjectRef {
                                           int max_trials,                                      //
                                           Optional<CostModel> cost_model,                      //
                                           Optional<Array<MeasureCallback>> measure_callbacks,  //
-                                          Optional<PackedFunc> logging_func);
+                                          PackedFunc logging_func);
   /*!
    * \brief Create a task scheduler that fetches tasks in a gradient based fashion.
    * \param tasks The tasks to be tuned.
@@ -272,7 +272,7 @@ class TaskScheduler : public runtime::ObjectRef {
                                              int max_trials,                                      //
                                              Optional<CostModel> cost_model,                      //
                                              Optional<Array<MeasureCallback>> measure_callbacks,  //
-                                             Optional<PackedFunc> logging_func,                   //
+                                             PackedFunc logging_func,                             //
                                              double alpha,                                        //
                                              int window_size,                                     //
                                              support::LinearCongruentialEngine::TRandState seed);
@@ -301,7 +301,7 @@ class TaskScheduler : public runtime::ObjectRef {
       int max_trials,                                             //
       Optional<CostModel> cost_model,                             //
       Optional<Array<MeasureCallback>> measure_callbacks,         //
-      Optional<PackedFunc> logging_func,                          //
+      PackedFunc logging_func,                                    //
       PyTaskSchedulerNode::FTune f_tune,                          //
       PyTaskSchedulerNode::FInitializeTask f_initialize_task,     //
       PyTaskSchedulerNode::FTouchTask f_touch_task,               //

--- a/include/tvm/meta_schedule/task_scheduler.h
+++ b/include/tvm/meta_schedule/task_scheduler.h
@@ -98,7 +98,7 @@ class TaskSchedulerNode : public runtime::Object {
     v->Visit("cost_model", &cost_model);
     v->Visit("measure_callbacks", &measure_callbacks);
     v->Visit("num_trials_already", &num_trials_already);
-    // v->Visit("logging_func", &logging_func);
+    // `logging_func` is not visited
   }
 
   /*! \brief Auto-tuning. */

--- a/include/tvm/meta_schedule/task_scheduler.h
+++ b/include/tvm/meta_schedule/task_scheduler.h
@@ -83,6 +83,8 @@ class TaskSchedulerNode : public runtime::Object {
   Array<MeasureCallback> measure_callbacks;
   /*! \brief The number of trials already conducted. */
   int num_trials_already;
+  /*! \brief The tuning task's logging function. t*/
+  Optional<PackedFunc> logging_func;
 
   /*! \brief The default destructor. */
   virtual ~TaskSchedulerNode() = default;
@@ -96,6 +98,7 @@ class TaskSchedulerNode : public runtime::Object {
     v->Visit("cost_model", &cost_model);
     v->Visit("measure_callbacks", &measure_callbacks);
     v->Visit("num_trials_already", &num_trials_already);
+    // v->Visit("logging_func", &logging_func);
   }
 
   /*! \brief Auto-tuning. */
@@ -234,15 +237,17 @@ class TaskScheduler : public runtime::ObjectRef {
    * \param max_trials The maximum number of trials.
    * \param cost_model The cost model of the scheduler.
    * \param measure_callbacks The measure callbacks of the scheduler.
+   * \param logging_func The tuning task's logging function.
    * \return The task scheduler created.
    */
-  TVM_DLL static TaskScheduler RoundRobin(Array<TuneContext> tasks,        //
-                                          Builder builder,                 //
-                                          Runner runner,                   //
-                                          Database database,               //
-                                          int max_trials,                  //
-                                          Optional<CostModel> cost_model,  //
-                                          Optional<Array<MeasureCallback>> measure_callbacks);
+  TVM_DLL static TaskScheduler RoundRobin(Array<TuneContext> tasks,                            //
+                                          Builder builder,                                     //
+                                          Runner runner,                                       //
+                                          Database database,                                   //
+                                          int max_trials,                                      //
+                                          Optional<CostModel> cost_model,                      //
+                                          Optional<Array<MeasureCallback>> measure_callbacks,  //
+                                          Optional<PackedFunc> logging_func);
   /*!
    * \brief Create a task scheduler that fetches tasks in a gradient based fashion.
    * \param tasks The tasks to be tuned.
@@ -253,6 +258,7 @@ class TaskScheduler : public runtime::ObjectRef {
    * \param max_trials The maximum number of trials.
    * \param cost_model The cost model of the scheduler.
    * \param measure_callbacks The measure callbacks of the scheduler.
+   * \param logging_func The tuning task's logging function.
    * \param alpha The parameter alpha to control gradient computation.
    * \param window_size The parameter to control backward window size.
    * \param seed The random seed.
@@ -266,6 +272,7 @@ class TaskScheduler : public runtime::ObjectRef {
                                              int max_trials,                                      //
                                              Optional<CostModel> cost_model,                      //
                                              Optional<Array<MeasureCallback>> measure_callbacks,  //
+                                             Optional<PackedFunc> logging_func,                   //
                                              double alpha,                                        //
                                              int window_size,                                     //
                                              support::LinearCongruentialEngine::TRandState seed);
@@ -278,6 +285,7 @@ class TaskScheduler : public runtime::ObjectRef {
    * \param max_trials The maximum number of trials.
    * \param cost_model The cost model of the scheduler.
    * \param measure_callbacks The measure callbacks of the scheduler.
+   * \param logging_func The tuning task's logging function.
    * \param f_tune The packed function of `Tune`.
    * \param f_initialize_task The packed function of `InitializeTask`.
    * \param f_touch_task The packed function of `TouchTask`.
@@ -293,6 +301,7 @@ class TaskScheduler : public runtime::ObjectRef {
       int max_trials,                                             //
       Optional<CostModel> cost_model,                             //
       Optional<Array<MeasureCallback>> measure_callbacks,         //
+      Optional<PackedFunc> logging_func,                          //
       PyTaskSchedulerNode::FTune f_tune,                          //
       PyTaskSchedulerNode::FInitializeTask f_initialize_task,     //
       PyTaskSchedulerNode::FTouchTask f_touch_task,               //

--- a/include/tvm/meta_schedule/tune_context.h
+++ b/include/tvm/meta_schedule/tune_context.h
@@ -55,7 +55,7 @@ class TuneContextNode : public runtime::Object {
   /*! \brief The name of the tuning task. */
   Optional<String> task_name;
   /*! \brief The tuning task's logging function. t*/
-  Optional<PackedFunc> logging_func;
+  PackedFunc logging_func;
   /*! \brief The random state. */
   support::LinearCongruentialEngine::TRandState rand_state;
   /*! \brief The number of threads to be used. */
@@ -125,7 +125,7 @@ class TuneContext : public runtime::ObjectRef {
                                Optional<Array<Postproc>> postprocs,                       //
                                Optional<Map<Mutator, FloatImm>> mutator_probs,            //
                                Optional<String> task_name,                                //
-                               Optional<PackedFunc> logging_func,                         //
+                               PackedFunc logging_func,                                   //
                                support::LinearCongruentialEngine::TRandState rand_state,  //
                                int num_threads);
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TuneContext, ObjectRef, TuneContextNode);

--- a/include/tvm/meta_schedule/tune_context.h
+++ b/include/tvm/meta_schedule/tune_context.h
@@ -87,7 +87,7 @@ class TuneContextNode : public runtime::Object {
     v->Visit("builder_results", &builder_results);
     v->Visit("runner_futures", &runner_futures);
     v->Visit("measure_candidates", &measure_candidates);
-    // v->Visit("logging_func", &logging_func);
+    // `logging_func` is not visited
   }
 
   /*! \brief Initialize members that needs initialization with tune context. */

--- a/include/tvm/meta_schedule/tune_context.h
+++ b/include/tvm/meta_schedule/tune_context.h
@@ -54,6 +54,8 @@ class TuneContextNode : public runtime::Object {
   Map<Mutator, FloatImm> mutator_probs;
   /*! \brief The name of the tuning task. */
   Optional<String> task_name;
+  /*! \brief The tuning task's logging function. t*/
+  Optional<PackedFunc> logging_func;
   /*! \brief The random state. */
   support::LinearCongruentialEngine::TRandState rand_state;
   /*! \brief The number of threads to be used. */
@@ -85,6 +87,7 @@ class TuneContextNode : public runtime::Object {
     v->Visit("builder_results", &builder_results);
     v->Visit("runner_futures", &runner_futures);
     v->Visit("measure_candidates", &measure_candidates);
+    // v->Visit("logging_func", &logging_func);
   }
 
   /*! \brief Initialize members that needs initialization with tune context. */
@@ -110,6 +113,7 @@ class TuneContext : public runtime::ObjectRef {
    * \param postprocs The postprocessors.
    * \param mutator_probs The probability of using certain mutator.
    * \param task_name The name of the tuning task.
+   * \param logging_func The tuning task's logging function.
    * \param rand_state The random state.
    * \param num_threads The number of threads to be used.
    */
@@ -121,6 +125,7 @@ class TuneContext : public runtime::ObjectRef {
                                Optional<Array<Postproc>> postprocs,                       //
                                Optional<Map<Mutator, FloatImm>> mutator_probs,            //
                                Optional<String> task_name,                                //
+                               Optional<PackedFunc> logging_func,                         //
                                support::LinearCongruentialEngine::TRandState rand_state,  //
                                int num_threads);
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TuneContext, ObjectRef, TuneContextNode);

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 """A context manager that injects the best tuning record in the database into compilation"""
+import logging
 from typing import List, Optional, Union
 
 from tvm._ffi import register_object
 from tvm.ir import IRModule
+from tvm.meta_schedule.utils import get_global_logger, make_logging_func
 from tvm.runtime import Object
 from tvm.target import Target
 
@@ -34,15 +36,17 @@ class ApplyHistoryBest(Object):
     ----------
     database : Database
         The database to be queried from
+    logger : logging.Logger
+        The logger to be used
     """
 
     database: Database
+    logger: logging.Logger
 
-    def __init__(
-        self,
-        database: Database,
-    ) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.ApplyHistoryBest, database)  # type: ignore # pylint: disable=no-member
+    def __init__(self, database: Database, logger: logging.Logger = get_global_logger()) -> None:
+        self.__init_handle_by_constructor__(
+            _ffi_api.ApplyHistoryBest, database, make_logging_func(logger)  # type: ignore # pylint: disable=no-member
+        )
 
     def query(
         self,

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -20,14 +20,13 @@ from typing import List, Optional, Union
 
 from tvm._ffi import register_object
 from tvm.ir import IRModule
-from tvm.meta_schedule.utils import make_logging_func
 from tvm.runtime import Object
 from tvm.target import Target
 
 from . import _ffi_api
 from .database import Database
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 
 @register_object("meta_schedule.ApplyHistoryBest")

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -20,12 +20,14 @@ from typing import List, Optional, Union
 
 from tvm._ffi import register_object
 from tvm.ir import IRModule
-from tvm.meta_schedule.utils import get_global_logger, make_logging_func
+from tvm.meta_schedule.utils import make_logging_func
 from tvm.runtime import Object
 from tvm.target import Target
 
 from . import _ffi_api
 from .database import Database
+
+logger = logging.getLogger("tvm.meta_schedule")
 
 
 @register_object("meta_schedule.ApplyHistoryBest")
@@ -43,9 +45,9 @@ class ApplyHistoryBest(Object):
     database: Database
     logger: logging.Logger
 
-    def __init__(self, database: Database, logger: logging.Logger = get_global_logger()) -> None:
+    def __init__(self, database: Database) -> None:
         self.__init_handle_by_constructor__(
-            _ffi_api.ApplyHistoryBest, database, make_logging_func(logger)  # type: ignore # pylint: disable=no-member
+            _ffi_api.ApplyHistoryBest, database, logger  # type: ignore # pylint: disable=no-member
         )
 
     def query(

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -25,6 +25,7 @@ from tvm.target import Target
 
 from . import _ffi_api
 from .database import Database
+from .utils import make_logging_func
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -43,7 +44,7 @@ class ApplyHistoryBest(Object):
 
     def __init__(self, database: Database) -> None:
         self.__init_handle_by_constructor__(
-            _ffi_api.ApplyHistoryBest, database, logger  # type: ignore # pylint: disable=no-member
+            _ffi_api.ApplyHistoryBest, database, make_logging_func(logger)  # type: ignore # pylint: disable=no-member
         )
 
     def query(

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -26,7 +26,7 @@ from tvm.target import Target
 from . import _ffi_api
 from .database import Database
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @register_object("meta_schedule.ApplyHistoryBest")
@@ -37,12 +37,9 @@ class ApplyHistoryBest(Object):
     ----------
     database : Database
         The database to be queried from
-    logger : logging.Logger
-        The logger to be used
     """
 
     database: Database
-    logger: logging.Logger
 
     def __init__(self, database: Database) -> None:
         self.__init_handle_by_constructor__(

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Local builder that compile on the local host"""
+import logging
 import os
 import tempfile
 from typing import Callable, Dict, List, Optional, Union
@@ -29,11 +30,10 @@ from ..utils import (
     cpu_count,
     derived_object,
     get_global_func_with_default_on_worker,
-    get_global_logger,
 )
 from .builder import BuilderInput, BuilderResult, PyBuilder
 
-logger = get_global_logger()  # pylint: disable=invalid-name
+logger = logging.getLogger("tvm.meta_schedule")
 
 
 T_BUILD = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -33,7 +33,7 @@ from ..utils import (
 )
 from .builder import BuilderInput, BuilderResult, PyBuilder
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 
 T_BUILD = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Local builder that compile on the local host"""
-import logging
 import os
 import tempfile
 from typing import Callable, Dict, List, Optional, Union
@@ -26,10 +25,15 @@ from tvm.runtime import Module, NDArray, load_param_dict, save_param_dict
 from tvm.target import Target
 
 from ...contrib.popen_pool import MapResult, PopenPoolExecutor, StatusKind
-from ..utils import cpu_count, derived_object, get_global_func_with_default_on_worker
+from ..utils import (
+    cpu_count,
+    derived_object,
+    get_global_func_with_default_on_worker,
+    get_global_logger,
+)
 from .builder import BuilderInput, BuilderResult, PyBuilder
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = get_global_logger()  # pylint: disable=invalid-name
 
 
 T_BUILD = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -33,7 +33,7 @@ from ..utils import (
 )
 from .builder import BuilderInput, BuilderResult, PyBuilder
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 T_BUILD = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from ..tune_context import TuneContext
 
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 def make_metric_sorter(focused_metric):

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from ..tune_context import TuneContext
 
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 
 def make_metric_sorter(focused_metric):

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -17,6 +17,7 @@
 """
 XGBoost-based cost model
 """
+import logging
 import os
 import tempfile
 from collections import OrderedDict
@@ -31,7 +32,7 @@ from ..cost_model import PyCostModel
 from ..feature_extractor import FeatureExtractor
 from ..runner import RunnerResult
 from ..search_strategy import MeasureCandidate
-from ..utils import cpu_count, derived_object, get_global_logger, shash2hex
+from ..utils import cpu_count, derived_object, shash2hex
 from .metric import max_curve
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
     from ..tune_context import TuneContext
 
 
-logger = get_global_logger()
+logger = logging.getLogger("tvm.meta_schedule")
 
 
 def make_metric_sorter(focused_metric):

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -17,7 +17,6 @@
 """
 XGBoost-based cost model
 """
-import logging
 import os
 import tempfile
 from collections import OrderedDict
@@ -32,7 +31,7 @@ from ..cost_model import PyCostModel
 from ..feature_extractor import FeatureExtractor
 from ..runner import RunnerResult
 from ..search_strategy import MeasureCandidate
-from ..utils import cpu_count, derived_object, shash2hex
+from ..utils import cpu_count, derived_object, get_global_logger, shash2hex
 from .metric import max_curve
 
 if TYPE_CHECKING:
@@ -41,7 +40,7 @@ if TYPE_CHECKING:
     from ..tune_context import TuneContext
 
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = get_global_logger()
 
 
 def make_metric_sorter(focused_metric):

--- a/python/tvm/meta_schedule/runner/local_runner.py
+++ b/python/tvm/meta_schedule/runner/local_runner.py
@@ -34,7 +34,7 @@ from .utils import (
 )
 
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 T_ALLOC_ARGUMENT = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/runner/local_runner.py
+++ b/python/tvm/meta_schedule/runner/local_runner.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Local Runner"""
+import logging
 from contextlib import contextmanager
 from typing import Callable, List, Optional, Union
 
@@ -22,7 +23,7 @@ import tvm
 
 from ...contrib.popen_pool import PopenPoolExecutor
 from ...runtime import Device, Module
-from ..utils import derived_object, get_global_func_with_default_on_worker, get_global_logger
+from ..utils import derived_object, get_global_func_with_default_on_worker
 from .config import EvaluatorConfig
 from .runner import PyRunner, RunnerFuture, RunnerInput, RunnerResult, PyRunnerFuture
 from .utils import (
@@ -32,7 +33,8 @@ from .utils import (
     run_evaluator_common,
 )
 
-logger = get_global_logger()
+
+logger = logging.getLogger("tvm.meta_schedule")
 
 
 T_ALLOC_ARGUMENT = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/runner/local_runner.py
+++ b/python/tvm/meta_schedule/runner/local_runner.py
@@ -34,7 +34,7 @@ from .utils import (
 )
 
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 
 T_ALLOC_ARGUMENT = Callable[  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/runner/local_runner.py
+++ b/python/tvm/meta_schedule/runner/local_runner.py
@@ -16,14 +16,13 @@
 # under the License.
 """Local Runner"""
 from contextlib import contextmanager
-import logging
 from typing import Callable, List, Optional, Union
 
 import tvm
 
 from ...contrib.popen_pool import PopenPoolExecutor
 from ...runtime import Device, Module
-from ..utils import derived_object, get_global_func_with_default_on_worker
+from ..utils import derived_object, get_global_func_with_default_on_worker, get_global_logger
 from .config import EvaluatorConfig
 from .runner import PyRunner, RunnerFuture, RunnerInput, RunnerResult, PyRunnerFuture
 from .utils import (
@@ -33,7 +32,7 @@ from .utils import (
     run_evaluator_common,
 )
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = get_global_logger()
 
 
 T_ALLOC_ARGUMENT = Callable[  # pylint: disable=invalid-name
@@ -293,7 +292,7 @@ class LocalRunner(PyRunner):
             try:
                 result: List[float] = future.result()
                 error_message: str = None
-            except TimeoutError as exception:
+            except TimeoutError:
                 result = None
                 error_message = f"LocalRunner: Timeout, killed after {self.timeout_sec} seconds\n"
             except Exception as exception:  # pylint: disable=broad-except

--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -40,7 +40,7 @@ from .utils import (
 )
 
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 T_CREATE_SESSION = Callable[  # pylint: disable=invalid-name
     [RPCConfig],  # The RPC configuration

--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """RPC Runner"""
+import logging
 import concurrent.futures
 import os.path as osp
 from contextlib import contextmanager
@@ -28,7 +29,6 @@ from ..utils import (
     derived_object,
     get_global_func_on_rpc_session,
     get_global_func_with_default_on_worker,
-    get_global_logger,
 )
 from .config import EvaluatorConfig, RPCConfig
 from .runner import PyRunner, PyRunnerFuture, RunnerFuture, RunnerInput, RunnerResult
@@ -39,7 +39,8 @@ from .utils import (
     run_evaluator_common,
 )
 
-logger = get_global_logger()
+
+logger = logging.getLogger("tvm.meta_schedule")
 
 T_CREATE_SESSION = Callable[  # pylint: disable=invalid-name
     [RPCConfig],  # The RPC configuration

--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -16,7 +16,6 @@
 # under the License.
 """RPC Runner"""
 import concurrent.futures
-import logging
 import os.path as osp
 from contextlib import contextmanager
 from typing import Callable, List, Optional, Union
@@ -29,6 +28,7 @@ from ..utils import (
     derived_object,
     get_global_func_on_rpc_session,
     get_global_func_with_default_on_worker,
+    get_global_logger,
 )
 from .config import EvaluatorConfig, RPCConfig
 from .runner import PyRunner, PyRunnerFuture, RunnerFuture, RunnerInput, RunnerResult
@@ -39,8 +39,7 @@ from .utils import (
     run_evaluator_common,
 )
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
+logger = get_global_logger()
 
 T_CREATE_SESSION = Callable[  # pylint: disable=invalid-name
     [RPCConfig],  # The RPC configuration

--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -40,7 +40,7 @@ from .utils import (
 )
 
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 T_CREATE_SESSION = Callable[  # pylint: disable=invalid-name
     [RPCConfig],  # The RPC configuration

--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -39,8 +39,8 @@ from .utils import (
     run_evaluator_common,
 )
 
-
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
 
 T_CREATE_SESSION = Callable[  # pylint: disable=invalid-name
     [RPCConfig],  # The RPC configuration

--- a/python/tvm/meta_schedule/task_scheduler/gradient_based.py
+++ b/python/tvm/meta_schedule/task_scheduler/gradient_based.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, List, Optional
 
 from tvm._ffi import register_object
+from tvm.meta_schedule.utils import make_logging_func
 
 from .. import _ffi_api
 from ..builder import Builder
@@ -91,7 +92,7 @@ class GradientBased(TaskScheduler):
             max_trials,
             cost_model,
             measure_callbacks,
-            logger,
+            make_logging_func(logger),
             alpha,
             window_size,
             seed,

--- a/python/tvm/meta_schedule/task_scheduler/gradient_based.py
+++ b/python/tvm/meta_schedule/task_scheduler/gradient_based.py
@@ -19,7 +19,6 @@ import logging
 from typing import TYPE_CHECKING, List, Optional
 
 from tvm._ffi import register_object
-from tvm.meta_schedule.utils import make_logging_func
 
 from .. import _ffi_api
 from ..builder import Builder
@@ -27,10 +26,13 @@ from ..cost_model import CostModel
 from ..database import Database
 from ..measure_callback import MeasureCallback
 from ..runner import Runner
+from ..utils import make_logging_func
 from .task_scheduler import TaskScheduler
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @register_object("meta_schedule.GradientBased")
@@ -48,7 +50,6 @@ class GradientBased(TaskScheduler):
         *,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
-        logger: Optional[logging.Logger] = None,
         alpha: float = 0.2,
         window_size: int = 3,
         seed: int = -1,
@@ -73,8 +74,6 @@ class GradientBased(TaskScheduler):
             The cost model of the scheduler.
         measure_callbacks : Optional[List[MeasureCallback]] = None
             The list of measure callbacks of the scheduler.
-        logger: Optional[logging.Logger]
-            The logger of the task scheduler.
         alpha : float = 0.2
             The parameter alpha in gradient computation.
         window_size : int = 3

--- a/python/tvm/meta_schedule/task_scheduler/gradient_based.py
+++ b/python/tvm/meta_schedule/task_scheduler/gradient_based.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Gradient Based Task Scheduler"""
+import logging
 from typing import TYPE_CHECKING, List, Optional
 
 from tvm._ffi import register_object
@@ -46,6 +47,7 @@ class GradientBased(TaskScheduler):
         *,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
+        logger: Optional[logging.Logger] = None,
         alpha: float = 0.2,
         window_size: int = 3,
         seed: int = -1,
@@ -70,6 +72,8 @@ class GradientBased(TaskScheduler):
             The cost model of the scheduler.
         measure_callbacks : Optional[List[MeasureCallback]] = None
             The list of measure callbacks of the scheduler.
+        logger: Optional[logging.Logger]
+            The logger of the task scheduler.
         alpha : float = 0.2
             The parameter alpha in gradient computation.
         window_size : int = 3
@@ -87,6 +91,7 @@ class GradientBased(TaskScheduler):
             max_trials,
             cost_model,
             measure_callbacks,
+            logger,
             alpha,
             window_size,
             seed,

--- a/python/tvm/meta_schedule/task_scheduler/round_robin.py
+++ b/python/tvm/meta_schedule/task_scheduler/round_robin.py
@@ -16,6 +16,7 @@
 # under the License.
 """Round Robin Task Scheduler"""
 
+import logging
 from typing import TYPE_CHECKING, List, Optional
 
 from tvm._ffi import register_object
@@ -48,6 +49,8 @@ class RoundRobin(TaskScheduler):
         The database of the scheduler.
     measure_callbacks: Optional[List[MeasureCallback]] = None
         The list of measure callbacks of the scheduler.
+    logger: Optional[logging.Logger]
+        The logger of the task scheduler.
     """
 
     def __init__(
@@ -61,6 +64,7 @@ class RoundRobin(TaskScheduler):
         *,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Constructor.
 
@@ -82,6 +86,8 @@ class RoundRobin(TaskScheduler):
             The cost model.
         measure_callbacks: Optional[List[MeasureCallback]]
             The list of measure callbacks of the scheduler.
+        logger: Optional[logging.Logger]
+            The logger of the task scheduler.
         """
         del task_weights
         self.__init_handle_by_constructor__(
@@ -93,4 +99,5 @@ class RoundRobin(TaskScheduler):
             max_trials,
             cost_model,
             measure_callbacks,
+            logger,
         )

--- a/python/tvm/meta_schedule/task_scheduler/round_robin.py
+++ b/python/tvm/meta_schedule/task_scheduler/round_robin.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from tvm._ffi import register_object
 from tvm.meta_schedule.measure_callback.measure_callback import MeasureCallback
+from tvm.meta_schedule.utils import make_logging_func
 
 from .. import _ffi_api
 from ..builder import Builder
@@ -99,5 +100,5 @@ class RoundRobin(TaskScheduler):
             max_trials,
             cost_model,
             measure_callbacks,
-            logger,
+            make_logging_func(logger),
         )

--- a/python/tvm/meta_schedule/task_scheduler/round_robin.py
+++ b/python/tvm/meta_schedule/task_scheduler/round_robin.py
@@ -21,17 +21,19 @@ from typing import TYPE_CHECKING, List, Optional
 
 from tvm._ffi import register_object
 from tvm.meta_schedule.measure_callback.measure_callback import MeasureCallback
-from tvm.meta_schedule.utils import make_logging_func
 
 from .. import _ffi_api
 from ..builder import Builder
 from ..cost_model import CostModel
 from ..database import Database
 from ..runner import Runner
+from ..utils import make_logging_func
 from .task_scheduler import TaskScheduler
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @register_object("meta_schedule.RoundRobin")
@@ -50,8 +52,6 @@ class RoundRobin(TaskScheduler):
         The database of the scheduler.
     measure_callbacks: Optional[List[MeasureCallback]] = None
         The list of measure callbacks of the scheduler.
-    logger: Optional[logging.Logger]
-        The logger of the task scheduler.
     """
 
     def __init__(
@@ -65,7 +65,6 @@ class RoundRobin(TaskScheduler):
         *,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
-        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Constructor.
 
@@ -87,8 +86,6 @@ class RoundRobin(TaskScheduler):
             The cost model.
         measure_callbacks: Optional[List[MeasureCallback]]
             The list of measure callbacks of the scheduler.
-        logger: Optional[logging.Logger]
-            The logger of the task scheduler.
         """
         del task_weights
         self.__init_handle_by_constructor__(

--- a/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
+++ b/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
@@ -16,9 +16,11 @@
 # under the License.
 """Auto-tuning Task Scheduler"""
 
+import logging
 from typing import Callable, List, Optional
 
 from tvm._ffi import register_object
+from tvm.meta_schedule.utils import make_logging_func
 from tvm.runtime import Object
 
 from .. import _ffi_api
@@ -50,6 +52,8 @@ class TaskScheduler(Object):
         The cost model used for search.
     measure_callbacks: List[MeasureCallback] = None
         The list of measure callbacks of the scheduler.
+    logger: Optional[logging.Logger]
+        The logger of the task scheduler.
     num_trials_already : int
         The number of trials already conducted.
     """
@@ -62,6 +66,7 @@ class TaskScheduler(Object):
     cost_model: Optional[CostModel]
     measure_callbacks: List[MeasureCallback]
     num_trials_already: int
+    logger: Optional[logging.Logger]
 
     def tune(self) -> None:
         """Auto-tuning."""
@@ -131,6 +136,7 @@ class _PyTaskScheduler(TaskScheduler):
         max_trials: int,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
+        logger: Optional[logging.Logger] = None,
         f_tune: Callable = None,
         f_initialize_task: Callable = None,
         f_touch_task: Callable = None,
@@ -148,6 +154,7 @@ class _PyTaskScheduler(TaskScheduler):
             max_trials,
             cost_model,
             measure_callbacks,
+            make_logging_func(logger),
             f_tune,
             f_initialize_task,
             f_touch_task,
@@ -174,6 +181,7 @@ class PyTaskScheduler:
             "max_trials",
             "cost_model",
             "measure_callbacks",
+            "logger",
         ],
         "methods": [
             "tune",
@@ -193,6 +201,7 @@ class PyTaskScheduler:
         max_trials: int,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         self.tasks = tasks
         self.builder = builder
@@ -201,6 +210,7 @@ class PyTaskScheduler:
         self.max_trials = max_trials
         self.cost_model = cost_model
         self.measure_callbacks = measure_callbacks
+        self.logger = logger
 
     def tune(self) -> None:
         """Auto-tuning."""

--- a/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
+++ b/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
@@ -32,6 +32,9 @@ from ..runner import Runner, RunnerResult
 from ..tune_context import TuneContext
 
 
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
 @register_object("meta_schedule.TaskScheduler")
 class TaskScheduler(Object):
     """The abstract task scheduler interface.
@@ -52,8 +55,6 @@ class TaskScheduler(Object):
         The cost model used for search.
     measure_callbacks: List[MeasureCallback] = None
         The list of measure callbacks of the scheduler.
-    logger: Optional[logging.Logger]
-        The logger of the task scheduler.
     num_trials_already : int
         The number of trials already conducted.
     """
@@ -66,7 +67,6 @@ class TaskScheduler(Object):
     cost_model: Optional[CostModel]
     measure_callbacks: List[MeasureCallback]
     num_trials_already: int
-    logger: Optional[logging.Logger]
 
     def tune(self) -> None:
         """Auto-tuning."""
@@ -136,7 +136,6 @@ class _PyTaskScheduler(TaskScheduler):
         max_trials: int,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
-        logger: Optional[logging.Logger] = None,
         f_tune: Callable = None,
         f_initialize_task: Callable = None,
         f_touch_task: Callable = None,
@@ -181,7 +180,6 @@ class PyTaskScheduler:
             "max_trials",
             "cost_model",
             "measure_callbacks",
-            "logger",
         ],
         "methods": [
             "tune",
@@ -201,7 +199,6 @@ class PyTaskScheduler:
         max_trials: int,
         cost_model: Optional[CostModel] = None,
         measure_callbacks: Optional[List[MeasureCallback]] = None,
-        logger: Optional[logging.Logger] = None,
     ):
         self.tasks = tasks
         self.builder = builder
@@ -210,7 +207,6 @@ class PyTaskScheduler:
         self.max_trials = max_trials
         self.cost_model = cost_model
         self.measure_callbacks = measure_callbacks
-        self.logger = logger
 
     def tune(self) -> None:
         """Auto-tuning."""

--- a/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
+++ b/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
@@ -20,7 +20,6 @@ import logging
 from typing import Callable, List, Optional
 
 from tvm._ffi import register_object
-from tvm.meta_schedule.utils import make_logging_func
 from tvm.runtime import Object
 
 from .. import _ffi_api
@@ -30,6 +29,7 @@ from ..database import Database
 from ..measure_callback import MeasureCallback
 from ..runner import Runner, RunnerResult
 from ..tune_context import TuneContext
+from ..utils import make_logging_func
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Workloads in Relay IR"""
+import logging
 import multiprocessing
 import os
 import pickle
@@ -25,11 +26,11 @@ import tvm.relay.testing
 from tvm import relay
 from tvm.ir import IRModule
 from tvm.meta_schedule import ExtractedTask, extract_task_from_relay
-from tvm.meta_schedule.utils import get_global_logger
 from tvm.runtime import NDArray, load_param_dict, save_param_dict
 from tvm.target import Target
 
-logger = get_global_logger()
+
+logger = logging.getLogger("tvm.meta_schedule")
 
 
 def _get_network(

--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Workloads in Relay IR"""
+# pylint: disable=import-outside-toplevel
 import logging
 import multiprocessing
 import os
@@ -30,7 +31,7 @@ from tvm.runtime import NDArray, load_param_dict, save_param_dict
 from tvm.target import Target
 
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 def _get_network(
@@ -54,8 +55,6 @@ def _get_network(
         "resnet3d_18",
         "vgg_16",
     ]:
-        # pylint: disable=import-outside-toplevel
-
         import torch  # type: ignore
         from torchvision import models  # type: ignore
 
@@ -106,7 +105,6 @@ def _get_network(
     elif name in ["bert_tiny", "bert_base", "bert_medium", "bert_large"]:
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
         # pip3 install transformers==3.5 torch==1.7
-        # pylint: disable=import-outside-toplevel
         import torch  # type: ignore
         import transformers  # type: ignore
 

--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Workloads in Relay IR"""
-# pylint: disable=import-outside-toplevel
-import logging
 import multiprocessing
 import os
 import pickle
@@ -27,10 +25,11 @@ import tvm.relay.testing
 from tvm import relay
 from tvm.ir import IRModule
 from tvm.meta_schedule import ExtractedTask, extract_task_from_relay
+from tvm.meta_schedule.utils import get_global_logger
 from tvm.runtime import NDArray, load_param_dict, save_param_dict
 from tvm.target import Target
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = get_global_logger()
 
 
 def _get_network(
@@ -54,6 +53,8 @@ def _get_network(
         "resnet3d_18",
         "vgg_16",
     ]:
+        # pylint: disable=import-outside-toplevel
+
         import torch  # type: ignore
         from torchvision import models  # type: ignore
 
@@ -104,6 +105,7 @@ def _get_network(
     elif name in ["bert_tiny", "bert_base", "bert_medium", "bert_large"]:
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
         # pip3 install transformers==3.5 torch==1.7
+        # pylint: disable=import-outside-toplevel
         import torch  # type: ignore
         import transformers  # type: ignore
 

--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -30,7 +30,6 @@ from tvm.meta_schedule import ExtractedTask, extract_task_from_relay
 from tvm.runtime import NDArray, load_param_dict, save_param_dict
 from tvm.target import Target
 
-
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 

--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -30,7 +30,7 @@ from tvm.runtime import NDArray, load_param_dict, save_param_dict
 from tvm.target import Target
 
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 
 def _get_network(

--- a/python/tvm/meta_schedule/testing/tune_relay_meta_schedule.py
+++ b/python/tvm/meta_schedule/testing/tune_relay_meta_schedule.py
@@ -90,8 +90,10 @@ def _parse_args():
     return parsed
 
 
-logging.basicConfig()
-logging.getLogger("tvm.meta_schedule").setLevel(logging.DEBUG)
+logging.basicConfig(
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
+logging.getLogger("tvm.meta_schedule").setLevel(logging.INFO)
 ARGS = _parse_args()
 
 

--- a/python/tvm/meta_schedule/testing/tune_te_meta_schedule.py
+++ b/python/tvm/meta_schedule/testing/tune_te_meta_schedule.py
@@ -79,8 +79,10 @@ def _parse_args():
     return parsed
 
 
-logging.basicConfig()
-logging.getLogger("tvm.meta_schedule").setLevel(logging.DEBUG)
+logging.basicConfig(
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
+logging.getLogger("tvm.meta_schedule").setLevel(logging.INFO)
 ARGS = _parse_args()
 
 

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -516,6 +516,7 @@ def tune_extracted_tasks(
     measure_callbacks = Parse._callbacks(measure_callbacks)
     # parse the tuning contexts
     tune_contexts = []
+    max_width = len(str(len(extracted_tasks) - 1))
     for i, task in enumerate(extracted_tasks):
         assert len(task.dispatched) == 1, "Only size 1 dispatched task list is supported for now"
         tune_contexts.append(
@@ -529,7 +530,7 @@ def tune_extracted_tasks(
                 mutator_probs=Parse._mutator_probs(mutator_probs, task.target),
                 task_name=task.task_name,
                 logger=Parse._logger(
-                    name="_".join(["task", str(i).zfill(4), task.task_name]),
+                    name="_".join(["task", str(i).zfill(max_width), task.task_name]),
                     stream=False,
                     **logger_config,
                 ),

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -185,26 +185,6 @@ class Parse:
     """Parse tuning configuration from user inputs."""
 
     @staticmethod
-    def _logger(name: str, **kwargs) -> logging.Logger:
-        if "log_dir" not in kwargs:
-            raise ValueError("Cannot find log directory `log_dir` in the logging configuration!")
-        logger = logging.getLogger(name)  # pylint: disable=redefined-outer-name
-        handler = logging.FileHandler(osp.join(kwargs["log_dir"], name + ".log"))
-        logger.addHandler(handler)
-        if "propagate" in kwargs:
-            logger.propagate = kwargs["propagate"]
-        if "formatter" in kwargs:
-            handler.setFormatter(kwargs["formatter"])
-        if "task_level" in kwargs:
-            logger.setLevel(getattr(logging, kwargs["task_level"]))
-        if "task_stream" in kwargs and kwargs["task_stream"]:
-            stream_handler = logging.StreamHandler()
-            stream_handler.setFormatter(kwargs["formatter"])
-            logger.addHandler(stream_handler)
-        logger.info("Log printing %s to %s", name, osp.join(kwargs["log_dir"], name + ".log"))
-        return logger
-
-    @staticmethod
     @register_func("tvm.meta_schedule.tune.parse_mod")  # for use in ApplyHistoryBest
     def _mod(mod: Union[PrimFunc, IRModule]) -> IRModule:
         if isinstance(mod, PrimFunc):
@@ -458,7 +438,7 @@ class TuneConfig(NamedTuple):
             p_config = {"version": 1, "disable_existing_loggers": disable_existing_loggers}
             for k, v in config.items():
                 if k in ["formatters", "handlers", "loggers"]:
-                    p_config[k] = batch_parameterize_config(v, params)
+                    p_config[k] = batch_parameterize_config(v, params)  # type: ignore
                 else:
                     p_config[k] = v
             logging.config.dictConfig(p_config)

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -44,7 +44,7 @@ from .search_strategy import EvolutionarySearch, ReplayFunc, ReplayTrace
 from .space_generator import PostOrderApply, SpaceGenerator
 from .task_scheduler import GradientBased, RoundRobin
 from .tune_context import TuneContext
-from .utils import autotvm_silencer
+from .utils import autotvm_silencer, get_global_logger
 
 FnSpaceGenerator = Callable[[], SpaceGenerator]
 FnScheduleRule = Callable[[], List[ScheduleRule]]
@@ -182,13 +182,6 @@ class Parse:
     """Parse tuning configuration from user inputs."""
 
     @staticmethod
-    def _get_task_scheduler_logger():
-        logger = logging.getLogger("task_scheduler")
-        if logger is None:
-            raise ValueError("Task scheduler logger is not instantiated.")
-        return logger
-
-    @staticmethod
     def _logger(log_dir: str, name: str, **kwargs) -> logging.Logger:
         handler = logging.FileHandler(osp.join(log_dir, name + ".log"))
         if "formatter" in kwargs:
@@ -247,7 +240,7 @@ class Parse:
         if database is None:
             path_workload = osp.join(path, "database_workload.json")
             path_tuning_record = osp.join(path, "database_tuning_record.json")
-            logger = Parse._get_task_scheduler_logger()
+            logger = get_global_logger()
             logger.info(
                 "Creating JSONDatabase. Workload at: %s. Tuning records at: %s",
                 path_workload,
@@ -537,6 +530,7 @@ def tune_extracted_tasks(
         database=database,
         cost_model=cost_model,
         measure_callbacks=measure_callbacks,
+        logger=logger,
     )
     task_scheduler.tune()
     cost_model.save(osp.join(work_dir, "cost_model.xgb"))

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -17,8 +17,8 @@
 """User-facing Tuning API"""
 # pylint: disable=import-outside-toplevel
 import logging
-from pathlib import Path
-import os.path as osp
+import os
+from os import path as osp
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union
 
 from tvm._ffi.registry import register_func
@@ -502,7 +502,7 @@ def tune_extracted_tasks(
     """
     # pylint: disable=protected-access
     log_dir = osp.join(work_dir, "logs")
-    Path(log_dir).mkdir(parents=True, exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
     logger_config = config.create_logger_config(
         log_dir=log_dir,
         propagate=False,
@@ -545,7 +545,8 @@ def tune_extracted_tasks(
                 mutator_probs=Parse._mutator_probs(mutator_probs, task.target),
                 task_name=task.task_name,
                 logger=Parse._logger(
-                    name="tvm.meta_schedule."
+                    name=__name__
+                    + "."
                     + "_".join(["task", str(i).zfill(max_width), task.task_name]),
                     **logger_config,
                 ),

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -198,9 +198,9 @@ class Parse:
         if "task_level" in kwargs:
             logger.setLevel(getattr(logging, kwargs["task_level"]))
         if "task_stream" in kwargs and kwargs["task_stream"]:
-            handler = logging.StreamHandler()
-            handler.setFormatter(kwargs["formatter"])
-            logger.addHandler(handler)
+            stream_handler = logging.StreamHandler()
+            stream_handler.setFormatter(kwargs["formatter"])
+            logger.addHandler(stream_handler)
         logger.info("Log printing %s to %s", name, osp.join(kwargs["log_dir"], name + ".log"))
         return logger
 

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -52,7 +52,7 @@ FnScheduleRule = Callable[[], List[ScheduleRule]]
 FnPostproc = Callable[[], List[Postproc]]
 FnMutatorProb = Callable[[], Dict[Mutator, float]]
 
-logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class DefaultLLVM:
@@ -513,10 +513,12 @@ def tune_extracted_tasks(
             "%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
         ),
     )
-    handler = logging.FileHandler(osp.join(log_dir, "tvm.meta_schedule.task_scheduler.log"))
-    logger.addHandler(handler)
-    if logger.level not in [logging.DEBUG, logging.INFO]:
-        logger.critical(
+    global_logger = logging.getLogger("tvm.meta_schedule")
+    global_logger.addHandler(
+        logging.FileHandler(osp.join(log_dir, "tvm.meta_schedule.task_scheduler.log"))
+    )
+    if global_logger.level not in [logging.DEBUG, logging.INFO]:
+        global_logger.critical(
             "Logging level set to %s, please set to logging.INFO"
             " or logging.DEBUG to view full log.",
             logging._levelToName[logger.level],
@@ -561,7 +563,6 @@ def tune_extracted_tasks(
         database=database,
         cost_model=cost_model,
         measure_callbacks=measure_callbacks,
-        logger=logger,
     )
     task_scheduler.tune()
     cost_model.save(osp.join(work_dir, "cost_model.xgb"))

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -52,7 +52,7 @@ FnScheduleRule = Callable[[], List[ScheduleRule]]
 FnPostproc = Callable[[], List[Postproc]]
 FnMutatorProb = Callable[[], Dict[Mutator, float]]
 
-logger = logging.getLogger("tvm.meta_schedule")
+logger = logging.getLogger("tvm.meta_schedule")  # pylint: disable=invalid-name
 
 
 class DefaultLLVM:

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -186,12 +186,11 @@ class Parse:
 
     @staticmethod
     def _logger(name: str, **kwargs) -> logging.Logger:
-        logger = logging.getLogger(name)  # pylint: disable=redefined-outer-name
         if "log_dir" not in kwargs:
-            raise ValueError("Cannot find log directory `log_dir` in the logging config")
-        else:
-            handler = logging.FileHandler(osp.join(kwargs["log_dir"], name + ".log"))
-            logger.addHandler(handler)
+            raise ValueError("Cannot find log directory `log_dir` in the logging configuration!")
+        logger = logging.getLogger(name)  # pylint: disable=redefined-outer-name
+        handler = logging.FileHandler(osp.join(kwargs["log_dir"], name + ".log"))
+        logger.addHandler(handler)
         if "propagate" in kwargs:
             logger.propagate = kwargs["propagate"]
         if "formatter" in kwargs:

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -46,13 +46,12 @@ from .task_scheduler import GradientBased, RoundRobin
 from .tune_context import TuneContext
 from .utils import autotvm_silencer
 
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 FnSpaceGenerator = Callable[[], SpaceGenerator]
 FnScheduleRule = Callable[[], List[ScheduleRule]]
 FnPostproc = Callable[[], List[Postproc]]
 FnMutatorProb = Callable[[], Dict[Mutator, float]]
-
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class DefaultLLVM:

--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -87,7 +87,7 @@ class TuneContext(Object):
     postprocs: List["Postproc"]
     mutator_probs: Optional[Dict["Mutator", float]]
     task_name: str
-    logger: logging.Logger
+    logger: Optional[logging.Logger]
     rand_state: int
     num_threads: int
 
@@ -102,15 +102,18 @@ class TuneContext(Object):
         postprocs: Optional[List["Postproc"]] = None,
         mutator_probs: Optional[Dict["Mutator", float]] = None,
         task_name: str = "main",
+        logger: Optional[logging.Logger] = None,
         rand_state: int = -1,
         num_threads: Optional[int] = None,
-        logger: logging.Logger = None,
     ):
         if isinstance(mod, PrimFunc):
             mod = IRModule.from_expr(mod)
         if num_threads is None:
             num_threads = cpu_count()
-        self.logger = logger
+        if logger is None:
+            self.logger = logging.getLogger(__name__)
+        else:
+            self.logger = None
 
         self.__init_handle_by_constructor__(
             _ffi_api.TuneContext,  # type: ignore # pylint: disable=no-member

--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -63,6 +63,8 @@ class TuneContext(Object):
         Mutators and their probability mass.
     task_name : Optional[str] = None
         The name of the tuning task.
+    logger : logging.Logger
+        The logger for the tuning task.
     rand_state : int = -1
         The random state.
         Need to be in integer in [1, 2^31-1], -1 means using random number.
@@ -120,7 +122,7 @@ class TuneContext(Object):
             postprocs,
             mutator_probs,
             task_name,
-            make_logging_func(self.logger),
+            make_logging_func(logger),
             rand_state,
             num_threads,
         )

--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -16,11 +16,12 @@
 # under the License.
 """Meta Schedule tuning context."""
 
+import logging
 from typing import Optional, List, Dict, TYPE_CHECKING
 
 from tvm import IRModule
 from tvm._ffi import register_object
-from tvm.meta_schedule.utils import cpu_count
+from tvm.meta_schedule.utils import cpu_count, make_logging_func
 from tvm.runtime import Object
 from tvm.target import Target
 from tvm.tir import PrimFunc
@@ -84,6 +85,7 @@ class TuneContext(Object):
     postprocs: List["Postproc"]
     mutator_probs: Optional[Dict["Mutator", float]]
     task_name: str
+    logger: logging.Logger
     rand_state: int
     num_threads: int
 
@@ -100,11 +102,13 @@ class TuneContext(Object):
         task_name: str = "main",
         rand_state: int = -1,
         num_threads: Optional[int] = None,
+        logger: logging.Logger = None,
     ):
         if isinstance(mod, PrimFunc):
             mod = IRModule.from_expr(mod)
         if num_threads is None:
             num_threads = cpu_count()
+        self.logger = logger
 
         self.__init_handle_by_constructor__(
             _ffi_api.TuneContext,  # type: ignore # pylint: disable=no-member
@@ -116,6 +120,7 @@ class TuneContext(Object):
             postprocs,
             mutator_probs,
             task_name,
+            make_logging_func(self.logger),
             rand_state,
             num_threads,
         )

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -389,14 +389,14 @@ def make_logging_func(logger: logging.Logger):
         return None
 
     level2log = {
-        "INFO": logger.info,
-        "WARNING": logger.warning,
-        "ERROR": logger.error,
-        # "FATAL": logger.critical,
+        logging.INFO: logger.info,
+        logging.WARNING: logger.warning,
+        logging.ERROR: logger.error,
+        # logging.FATAL not included
     }
 
-    def logging_func(level: str, msg: str):
-        level2log[level.upper()](msg)
+    def logging_func(level: int, msg: str):
+        level2log[level](msg)
 
     return logging_func
 

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -17,7 +17,9 @@
 """Utilities for meta schedule"""
 import ctypes
 import json
+import logging
 import os
+from re import I
 import shutil
 from contextlib import contextmanager
 from typing import Any, Callable, List, Optional, Union
@@ -368,3 +370,30 @@ def autotvm_silencer():
         yield
     finally:
         autotvm.GLOBAL_SCOPE.silent = silent
+
+
+def make_logging_func(logger: logging.Logger):
+    """Get the logging function.
+    Parameters
+    ----------
+    logger : logging.Logger
+        The logger instance.
+    Returns
+    -------
+    result : Callable
+        The function to do the specified level of logging.
+    """
+    if logger is None:
+        return None
+
+    level2log = {
+        "INFO": logger.info,
+        "WARNING": logger.warning,
+        "ERROR": logger.error,
+        # "FATAL": logger.critical,
+    }
+
+    def logging_func(level: str, msg: str):
+        level2log[level.upper()](msg)
+
+    return logging_func

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -399,10 +399,3 @@ def make_logging_func(logger: logging.Logger):
         level2log[level](msg)
 
     return logging_func
-
-
-def get_global_logger():
-    logger = logging.getLogger("task_scheduler")
-    if logger is None:
-        raise ValueError("Task scheduler logger is not instantiated.")
-    return logger

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -19,10 +19,9 @@ import ctypes
 import json
 import logging
 import os
-from re import I
 import shutil
 from contextlib import contextmanager
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, List, Callable, Optional, Union
 
 import psutil  # type: ignore
 from tvm._ffi import get_global_func, register_func
@@ -341,8 +340,11 @@ def shash2hex(mod: IRModule) -> str:
 
 def _get_default_str(obj: Any) -> str:
     return (
-        f"meta_schedule.{obj.__class__.__name__}" + f"({_to_hex_address(obj._outer().handle)})"
-    )  # type: ignore
+        # pylint: disable=protected-access
+        f"meta_schedule.{obj.__class__.__name__}"
+        + f"({_to_hex_address(obj._outer().handle)})"  # type: ignore
+        # pylint: enable=protected-access
+    )
 
 
 def _to_hex_address(handle: ctypes.c_void_p) -> str:
@@ -397,3 +399,10 @@ def make_logging_func(logger: logging.Logger):
         level2log[level.upper()](msg)
 
     return logging_func
+
+
+def get_global_logger():
+    logger = logging.getLogger("task_scheduler")
+    if logger is None:
+        raise ValueError("Task scheduler logger is not instantiated.")
+    return logger

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -374,7 +374,7 @@ def autotvm_silencer():
         autotvm.GLOBAL_SCOPE.silent = silent
 
 
-def make_logging_func(logger: logging.Logger):
+def make_logging_func(logger: logging.Logger) -> Optional[Callable]:
     """Get the logging function.
     Parameters
     ----------
@@ -382,13 +382,14 @@ def make_logging_func(logger: logging.Logger):
         The logger instance.
     Returns
     -------
-    result : Callable
+    result : Optional[Callable]
         The function to do the specified level of logging.
     """
     if logger is None:
         return None
 
     level2log = {
+        logging.DEBUG: logger.debug,
         logging.INFO: logger.info,
         logging.WARNING: logger.warning,
         logging.ERROR: logger.error,

--- a/src/meta_schedule/apply_history_best.cc
+++ b/src/meta_schedule/apply_history_best.cc
@@ -87,7 +87,7 @@ void ApplyHistoryBest::ExitWithScope() {
 
 /**************** ApplyHistoryBest ****************/
 
-ApplyHistoryBest::ApplyHistoryBest(Database database, Optional<PackedFunc> logging_func) {
+ApplyHistoryBest::ApplyHistoryBest(Database database, PackedFunc logging_func) {
   ObjectPtr<ApplyHistoryBestNode> n = make_object<ApplyHistoryBestNode>();
   n->database = database;
   n->logging_func = logging_func;
@@ -129,7 +129,7 @@ Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModu
 
 TVM_REGISTER_NODE_TYPE(ApplyHistoryBestNode);
 TVM_REGISTER_GLOBAL("meta_schedule.ApplyHistoryBest")
-    .set_body_typed([](Database database, Optional<PackedFunc> logging_func) -> ApplyHistoryBest {
+    .set_body_typed([](Database database, PackedFunc logging_func) -> ApplyHistoryBest {
       return ApplyHistoryBest(database, logging_func);
     });
 TVM_REGISTER_GLOBAL("meta_schedule.ApplyHistoryBestEnterScope")

--- a/src/meta_schedule/apply_history_best.cc
+++ b/src/meta_schedule/apply_history_best.cc
@@ -124,7 +124,6 @@ Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModu
     }
   }
   TVM_PY_LOG(WARNING, logging_func) << "Cannot find workload: " << task_name;
-  TVM_PY_LOG(INFO, logging_func) << tir::AsTVMScript(prim_mod);
   return NullOpt;
 }
 

--- a/src/meta_schedule/apply_history_best.cc
+++ b/src/meta_schedule/apply_history_best.cc
@@ -87,9 +87,10 @@ void ApplyHistoryBest::ExitWithScope() {
 
 /**************** ApplyHistoryBest ****************/
 
-ApplyHistoryBest::ApplyHistoryBest(Database database) {
+ApplyHistoryBest::ApplyHistoryBest(Database database, Optional<PackedFunc> logging_func) {
   ObjectPtr<ApplyHistoryBestNode> n = make_object<ApplyHistoryBestNode>();
   n->database = database;
+  n->logging_func = logging_func;
   data_ = n;
 }
 
@@ -122,15 +123,15 @@ Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModu
       return IRModule({{gv, func}});
     }
   }
-  LOG(WARNING) << "Cannot find workload: " << task_name;
-  DLOG(INFO) << tir::AsTVMScript(prim_mod);
+  TVM_PY_LOG(WARNING, logging_func) << "Cannot find workload: " << task_name;
+  TVM_PY_LOG(INFO, logging_func) << tir::AsTVMScript(prim_mod);
   return NullOpt;
 }
 
 TVM_REGISTER_NODE_TYPE(ApplyHistoryBestNode);
 TVM_REGISTER_GLOBAL("meta_schedule.ApplyHistoryBest")
-    .set_body_typed([](Database database) -> ApplyHistoryBest {
-      return ApplyHistoryBest(database);
+    .set_body_typed([](Database database, Optional<PackedFunc> logging_func) -> ApplyHistoryBest {
+      return ApplyHistoryBest(database, logging_func);
     });
 TVM_REGISTER_GLOBAL("meta_schedule.ApplyHistoryBestEnterScope")
     .set_body_typed(ApplyHistoryBestInternal::EnterScope);

--- a/src/meta_schedule/measure_callback/echo_statistics.cc
+++ b/src/meta_schedule/measure_callback/echo_statistics.cc
@@ -39,8 +39,10 @@ struct TaskInfo {
   double best_ms = kMaxTime;
   double best_gflops = 0.0;
   int error_count = 0;
+  Optional<PackedFunc> logging_func;
 
-  explicit TaskInfo(const String& name) : name(name) {}
+  explicit TaskInfo(const String& name, Optional<PackedFunc> logging_func)
+      : name(name), logging_func(logging_func) {}
 
   void Update(double run_ms) {
     ++trials;
@@ -49,11 +51,11 @@ struct TaskInfo {
       best_round = trials;
       best_gflops = flop / run_ms / 1e6;
     }
-    LOG(INFO) << "[" << name << "] Trial #" << trials   //
-              << std::fixed << std::setprecision(4)     //
-              << ": GFLOPs: " << (flop / run_ms / 1e6)  //
-              << ". Time: " << run_ms << " ms"          //
-              << ". Best GFLOPs: " << best_gflops;
+    TVM_PY_LOG(INFO, logging_func) << "[" << name << "] Trial #" << trials   //
+                                   << std::fixed << std::setprecision(4)     //
+                                   << ": GFLOPs: " << (flop / run_ms / 1e6)  //
+                                   << ". Time: " << run_ms << " ms"          //
+                                   << ". Best GFLOPs: " << best_gflops;
   }
 
   void UpdateError(std::string err, const MeasureCandidate& candidate) {
@@ -62,11 +64,12 @@ struct TaskInfo {
     err = (*f_proc)(err).operator std::string();
     ++error_count;
     ++trials;
-    LOG(INFO) << "[" << name << "] Trial #" << trials  //
-              << std::fixed << std::setprecision(4)    //
-              << ": Error in building: " << err << "\n"
-              << tir::AsTVMScript(candidate->sch->mod()) << "\n"
-              << Concat(candidate->sch->trace().value()->AsPython(false), "\n");
+    TVM_PY_LOG(INFO, logging_func)
+        << "[" << name << "] Trial #" << trials  //
+        << std::fixed << std::setprecision(4)    //
+        << ": Error in building: " << err << "\n"
+        << tir::AsTVMScript(candidate->sch->mod()) << "\n"
+        << Concat(candidate->sch->trace().value()->AsPython(false), "\n");
   }
 };
 
@@ -104,7 +107,7 @@ class EchoStatisticsNode : public MeasureCallbackNode {
     task_info.reserve(tasks.size());
     int task_id = 0;
     for (const TuneContext& task : tasks) {
-      task_info.push_back(TaskInfo(GetTaskName(task, task_id)));
+      task_info.push_back(TaskInfo(GetTaskName(task, task_id), task->logging_func));
       TaskInfo& info = task_info.back();
       info.flop = tir::EstimateTIRFlops(task->mod.value());
       ++task_id;

--- a/src/meta_schedule/measure_callback/echo_statistics.cc
+++ b/src/meta_schedule/measure_callback/echo_statistics.cc
@@ -39,9 +39,9 @@ struct TaskInfo {
   double best_ms = kMaxTime;
   double best_gflops = 0.0;
   int error_count = 0;
-  Optional<PackedFunc> logging_func;
+  PackedFunc logging_func;
 
-  explicit TaskInfo(const String& name, Optional<PackedFunc> logging_func)
+  explicit TaskInfo(const String& name, PackedFunc logging_func)
       : name(name), logging_func(logging_func) {}
 
   void Update(double run_ms) {

--- a/src/meta_schedule/schedule_rule/cross_thread_reduction.cc
+++ b/src/meta_schedule/schedule_rule/cross_thread_reduction.cc
@@ -32,12 +32,14 @@ class CrossThreadReductionNode : public ScheduleRuleNode {
     Optional<Integer> opt_warp_size = target->GetAttr<Integer>("thread_warp_size");
 
     if (!opt_max_threads_per_block.defined()) {
-      LOG(WARNING) << "Target does not have attribute \"max_threads_per_block\", therefore the "
-                      "rule CrossThreadReduction will not be applied";
+      TVM_PY_LOG(WARNING, context->logging_func)
+          << "Target does not have attribute \"max_threads_per_block\", therefore the "
+             "rule CrossThreadReduction will not be applied";
     }
     if (!opt_warp_size.defined()) {
-      LOG(WARNING) << "Target does not have attribute \"thread_warp_size\", therefore the rule "
-                      "CrossThreadReduction will not be applied";
+      TVM_PY_LOG(WARNING, context->logging_func)
+          << "Target does not have attribute \"thread_warp_size\", therefore the rule "
+             "CrossThreadReduction will not be applied";
     }
     max_threads_per_block = opt_max_threads_per_block.value_or(Integer(-1))->value;
     warp_size = opt_warp_size.value_or(Integer(-1))->value;

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -68,7 +68,7 @@ void MultiLevelTilingNode::InitializeWithTuneContext(const TuneContext& context)
     if (Optional<Integer> v = context->target.value()->GetAttr<Integer>("thread_warp_size")) {
       this->thread_warp_size_ = v.value()->value;
     } else {
-      LOG(INFO) << "'thread_warp_size' is not defined in the target";
+      TVM_PY_LOG(INFO, context->logging_func) << "'thread_warp_size' is not defined in the target";
     }
   }
 }

--- a/src/meta_schedule/search_strategy/evolutionary_search.cc
+++ b/src/meta_schedule/search_strategy/evolutionary_search.cc
@@ -491,7 +491,8 @@ std::vector<Schedule> EvolutionarySearchNode::State::SampleInitPopulation(int nu
         out_schs.push_back(results[i]);
       }
     }
-    LOG(INFO) << "Sample-Init-Population summary:\n" << pp.SummarizeFailures();
+    TVM_PY_LOG(INFO, self->context_->logging_func) << "Sample-Init-Population summary:\n"
+                                                   << pp.SummarizeFailures();
   }
   return out_schs;
 }
@@ -568,7 +569,8 @@ std::vector<Schedule> EvolutionarySearchNode::State::EvolveWithCostModel(
     };
     support::parallel_for_dynamic(0, self->population_size, self->num_threads_, f_find_candidate);
     population.swap(next_population);
-    LOG(INFO) << "Evolve iter #" << iter << " done. Summary:\n" << pp.SummarizeFailures();
+    TVM_PY_LOG(INFO, self->context_->logging_func) << "Evolve iter #" << iter << " done. Summary:\n"
+                                                   << pp.SummarizeFailures();
   }
   // Return the best states from the heap, sorting from higher score to lower ones
   std::sort(heap.heap.begin(), heap.heap.end());
@@ -592,7 +594,8 @@ std::vector<Schedule> EvolutionarySearchNode::State::EvolveWithCostModel(
       os << std::fixed << std::setprecision(4) << heap.heap.at(i).score;
     }
   }
-  LOG(INFO) << "Scores of the best " << n << " candidates:" << os.str();
+  TVM_PY_LOG(INFO, self->context_->logging_func)
+      << "Scores of the best " << n << " candidates:" << os.str();
   return results;
 }
 
@@ -653,17 +656,21 @@ Optional<Array<MeasureCandidate>> EvolutionarySearchNode::State::GenerateMeasure
   std::vector<Schedule> inits;
   inits.reserve(pop);
 
-  LOG(INFO) << "Generating candidates......";
+  TVM_PY_LOG(INFO, self->context_->logging_func) << "Generating candidates......";
   std::vector<Schedule> measured = PickBestFromDatabase(pop * self->init_measured_ratio);
-  LOG(INFO) << "Picked top " << measured.size() << " candidate(s) from database";
+  TVM_PY_LOG(INFO, self->context_->logging_func)
+      << "Picked top " << measured.size() << " candidate(s) from database";
   std::vector<Schedule> unmeasured = SampleInitPopulation(pop - measured.size());
-  LOG(INFO) << "Sampled " << unmeasured.size() << " candidate(s)";
+  TVM_PY_LOG(INFO, self->context_->logging_func)
+      << "Sampled " << unmeasured.size() << " candidate(s)";
   inits.insert(inits.end(), measured.begin(), measured.end());
   inits.insert(inits.end(), unmeasured.begin(), unmeasured.end());
   std::vector<Schedule> bests = EvolveWithCostModel(inits, sample_num);
-  LOG(INFO) << "Got " << bests.size() << " candidate(s) with evolutionary search";
+  TVM_PY_LOG(INFO, self->context_->logging_func)
+      << "Got " << bests.size() << " candidate(s) with evolutionary search";
   std::vector<Schedule> picks = PickWithEpsGreedy(unmeasured, bests, sample_num);
-  LOG(INFO) << "Sending " << picks.size() << " candidates(s) for measurement";
+  TVM_PY_LOG(INFO, self->context_->logging_func)
+      << "Sending " << picks.size() << " candidates(s) for measurement";
   if (picks.empty()) {
     ++this->num_empty_iters;
     if (this->num_empty_iters >= self->num_empty_iters_before_early_stop) {

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -80,7 +80,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
   /*! \brief The schedule rules to be applied in order. */
   Array<ScheduleRule> sch_rules_{nullptr};
   /*! \brief The logging function to use. */
-  Optional<PackedFunc> logging_func;
+  PackedFunc logging_func;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     // `rand_state_` is not visited

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -146,7 +146,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
         const bool has_schedule_rule = custom_schedule_fn != nullptr;
 
         if (ann.defined() && !has_schedule_rule) {
-          TVM_PY_LOG(WARNING, logging_func)
+          TVM_PY_LOG(WARNING, this->logging_func)
               << "Custom schedule rule not found, ignoring schedule_rule annotation: "
               << ann.value();
         }

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -79,6 +79,8 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
   TRandState rand_state_ = -1;
   /*! \brief The schedule rules to be applied in order. */
   Array<ScheduleRule> sch_rules_{nullptr};
+  /*! \brief The logging function to use. */
+  Optional<PackedFunc> logging_func;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     // `rand_state_` is not visited
@@ -90,6 +92,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
     CHECK(context->sch_rules.defined())
         << "ValueError: Schedules rules not given in PostOrderApply!";
     this->sch_rules_ = context->sch_rules;
+    this->logging_func = context->logging_func;
   }
 
   Array<tir::Schedule> GenerateDesignSpace(const IRModule& mod_) final {
@@ -143,8 +146,9 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
         const bool has_schedule_rule = custom_schedule_fn != nullptr;
 
         if (ann.defined() && !has_schedule_rule) {
-          LOG(WARNING) << "Custom schedule rule not found, ignoring schedule_rule annotation: "
-                       << ann.value();
+          TVM_PY_LOG(WARNING, logging_func)
+              << "Custom schedule rule not found, ignoring schedule_rule annotation: "
+              << ann.value();
         }
 
         if ((has_schedule_rule && sch_rule.defined()) ||

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -184,7 +184,7 @@ TaskScheduler TaskScheduler::GradientBased(Array<TuneContext> tasks,            
                                            int max_trials,                                      //
                                            Optional<CostModel> cost_model,                      //
                                            Optional<Array<MeasureCallback>> measure_callbacks,  //
-                                           Optional<PackedFunc> logging_func,                   //
+                                           PackedFunc logging_func,                             //
                                            double alpha,                                        //
                                            int window_size,                                     //
                                            support::LinearCongruentialEngine::TRandState seed) {

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -108,7 +108,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
     int n_tasks = task_records_.size();
     // Round robin
     if (num_rounds_already_ == 0) {
-      LOG(INFO) << "\n" << this->TuningStatistics();
+      TVM_PY_LOG(INFO, this->logging_func) << "\n" << this->TuningStatistics();
     }
     if (num_rounds_already_ < n_tasks) {
       return num_rounds_already_++;
@@ -169,21 +169,24 @@ class GradientBasedNode final : public TaskSchedulerNode {
     }
     record.best_time_cost_history.push_back(best_time_cost);
     record.trials += results.size();
-    LOG(INFO) << "[Updated] Task #" << task_id << ": " << record.task->task_name << "\n"
-              << this->TuningStatistics();
+    TVM_PY_LOG(INFO, this->logging_func)
+        << "[Updated] Task #" << task_id << ": " << record.task->task_name << "\n"
+        << this->TuningStatistics();
     return results;
   }
 };
 
-TaskScheduler TaskScheduler::GradientBased(Array<TuneContext> tasks,        //
-                                           Array<FloatImm> task_weights,    //
-                                           Builder builder,                 //
-                                           Runner runner,                   //
-                                           Database database,               //
-                                           int max_trials,                  //
-                                           Optional<CostModel> cost_model,  //
-                                           Optional<Array<MeasureCallback>> measure_callbacks,
-                                           double alpha, int window_size,
+TaskScheduler TaskScheduler::GradientBased(Array<TuneContext> tasks,                            //
+                                           Array<FloatImm> task_weights,                        //
+                                           Builder builder,                                     //
+                                           Runner runner,                                       //
+                                           Database database,                                   //
+                                           int max_trials,                                      //
+                                           Optional<CostModel> cost_model,                      //
+                                           Optional<Array<MeasureCallback>> measure_callbacks,  //
+                                           Optional<PackedFunc> logging_func,                   //
+                                           double alpha,                                        //
+                                           int window_size,                                     //
                                            support::LinearCongruentialEngine::TRandState seed) {
   CHECK_EQ(tasks.size(), task_weights.size())
       << "The size of `tasks` should have the same as `task_weights`.";
@@ -207,6 +210,7 @@ TaskScheduler TaskScheduler::GradientBased(Array<TuneContext> tasks,        //
   n->max_trials = max_trials;
   n->cost_model = cost_model;
   n->measure_callbacks = measure_callbacks.value_or({});
+  n->logging_func = logging_func;
   n->num_trials_already = 0;
   n->alpha = alpha;
   n->window_size = window_size;

--- a/src/meta_schedule/task_scheduler/round_robin.cc
+++ b/src/meta_schedule/task_scheduler/round_robin.cc
@@ -55,13 +55,14 @@ class RoundRobinNode final : public TaskSchedulerNode {
   }
 };
 
-TaskScheduler TaskScheduler::RoundRobin(Array<TuneContext> tasks,        //
-                                        Builder builder,                 //
-                                        Runner runner,                   //
-                                        Database database,               //
-                                        int max_trials,                  //
-                                        Optional<CostModel> cost_model,  //
-                                        Optional<Array<MeasureCallback>> measure_callbacks) {
+TaskScheduler TaskScheduler::RoundRobin(Array<TuneContext> tasks,                            //
+                                        Builder builder,                                     //
+                                        Runner runner,                                       //
+                                        Database database,                                   //
+                                        int max_trials,                                      //
+                                        Optional<CostModel> cost_model,                      //
+                                        Optional<Array<MeasureCallback>> measure_callbacks,  //
+                                        Optional<PackedFunc> logging_func) {
   ObjectPtr<RoundRobinNode> n = make_object<RoundRobinNode>();
   n->tasks = tasks;
   n->builder = builder;
@@ -70,6 +71,7 @@ TaskScheduler TaskScheduler::RoundRobin(Array<TuneContext> tasks,        //
   n->max_trials = max_trials;
   n->cost_model = cost_model;
   n->measure_callbacks = measure_callbacks.value_or({});
+  n->logging_func = logging_func;
   n->num_trials_already = 0;
   n->task_id = -1;
   for (const TuneContext& task : tasks) {

--- a/src/meta_schedule/task_scheduler/round_robin.cc
+++ b/src/meta_schedule/task_scheduler/round_robin.cc
@@ -62,7 +62,7 @@ TaskScheduler TaskScheduler::RoundRobin(Array<TuneContext> tasks,               
                                         int max_trials,                                      //
                                         Optional<CostModel> cost_model,                      //
                                         Optional<Array<MeasureCallback>> measure_callbacks,  //
-                                        Optional<PackedFunc> logging_func) {
+                                        PackedFunc logging_func) {
   ObjectPtr<RoundRobinNode> n = make_object<RoundRobinNode>();
   n->tasks = tasks;
   n->builder = builder;

--- a/src/meta_schedule/tune_context.cc
+++ b/src/meta_schedule/tune_context.cc
@@ -31,6 +31,7 @@ TuneContext::TuneContext(Optional<IRModule> mod,                                
                          Optional<Array<Postproc>> postprocs,                       //
                          Optional<Map<Mutator, FloatImm>> mutator_probs,            //
                          Optional<String> task_name,                                //
+                         Optional<PackedFunc> logging_func,                         //
                          support::LinearCongruentialEngine::TRandState rand_state,  //
                          int num_threads) {
   ObjectPtr<TuneContextNode> n = make_object<TuneContextNode>();
@@ -42,6 +43,7 @@ TuneContext::TuneContext(Optional<IRModule> mod,                                
   n->postprocs = postprocs.value_or({});
   n->mutator_probs = mutator_probs.value_or({});
   n->task_name = task_name;
+  n->logging_func = logging_func;
   support::LinearCongruentialEngine(&n->rand_state).Seed(rand_state);
   n->num_threads = num_threads;
   n->is_terminated = false;
@@ -79,10 +81,11 @@ TVM_REGISTER_GLOBAL("meta_schedule.TuneContext")
                        Optional<Array<Postproc>> postprocs,                       //
                        Optional<Map<Mutator, FloatImm>> mutator_probs,            //
                        Optional<String> task_name,                                //
+                       Optional<PackedFunc> logging_func,                         //
                        support::LinearCongruentialEngine::TRandState rand_state,  //
                        int num_threads) -> TuneContext {
       return TuneContext(mod, target, space_generator, search_strategy, sch_rules, postprocs,
-                         mutator_probs, task_name, rand_state, num_threads);
+                         mutator_probs, task_name, logging_func, rand_state, num_threads);
     });
 
 TVM_REGISTER_GLOBAL("meta_schedule._SHash2Hex").set_body_typed(SHash2Hex);

--- a/src/meta_schedule/tune_context.cc
+++ b/src/meta_schedule/tune_context.cc
@@ -31,7 +31,7 @@ TuneContext::TuneContext(Optional<IRModule> mod,                                
                          Optional<Array<Postproc>> postprocs,                       //
                          Optional<Map<Mutator, FloatImm>> mutator_probs,            //
                          Optional<String> task_name,                                //
-                         Optional<PackedFunc> logging_func,                         //
+                         PackedFunc logging_func,                                   //
                          support::LinearCongruentialEngine::TRandState rand_state,  //
                          int num_threads) {
   ObjectPtr<TuneContextNode> n = make_object<TuneContextNode>();
@@ -81,7 +81,7 @@ TVM_REGISTER_GLOBAL("meta_schedule.TuneContext")
                        Optional<Array<Postproc>> postprocs,                       //
                        Optional<Map<Mutator, FloatImm>> mutator_probs,            //
                        Optional<String> task_name,                                //
-                       Optional<PackedFunc> logging_func,                         //
+                       PackedFunc logging_func,                                   //
                        support::LinearCongruentialEngine::TRandState rand_state,  //
                        int num_threads) -> TuneContext {
       return TuneContext(mod, target, space_generator, search_strategy, sch_rules, postprocs,

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -360,7 +360,8 @@ struct ThreadedTraceApply {
           return NullOpt;
         }
       } catch (const std::exception& e) {
-        DLOG(WARNING) << "ThreadedTraceApply::Apply failed with error " << e.what();
+        // Used in multi-thread, only output to screen but failure summary sent to logging
+        LOG(WARNING) << "ThreadedTraceApply::Apply failed with error " << e.what();
         return NullOpt;
       }
     }

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -70,19 +70,19 @@ class PyLogMessage {
   }
   TVM_NO_INLINE ~PyLogMessage() {
     if (this->logging_func.defined()) {
-      if (logging_level == "INFO")
-        LOG_INFO << stream_.str();
-      else if (logging_level == "WARNING")
-        LOG_WARNING << stream_.str();
-      else if (logging_level == "ERROR")
-        LOG_ERROR << stream_.str();
-      else if (logging_level == "FATAL")
-        LOG_FATAL << stream_.str();
-      else
-        LOG_FATAL << "Wrong logging level, expected (INFO, WARNING, ERROR, FATAL), but got \""
-                  << logging_level << "\"!";
-    } else {
       logging_func.value()(logging_level, stream_.str());
+    } else {
+      if (logging_level == "INFO")
+        LOG(INFO) << stream_.str();
+      else if (logging_level == "WARNING")
+        LOG(WARNING) << stream_.str();
+      else if (logging_level == "ERROR")
+        LOG(ERROR) << stream_.str();
+      else if (logging_level == "FATAL")
+        LOG(FATAL) << stream_.str();
+      else
+        LOG(FATAL) << "Wrong logging level, expected (INFO, WARNING, ERROR, FATAL), but got \""
+                   << logging_level << "\"!";
     }
   }
   std::ostringstream& stream() { return stream_; }

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -89,6 +89,8 @@ class PyLogMessage {
         LOG(WARNING) << stream_.str();
       else if (logging_level == Level::ERROR)
         LOG(ERROR) << stream_.str();
+      else if (logging_level == Level::DEBUG)
+        DLOG(INFO) << stream_.str();
       else
         LOG(FATAL) << stream_.str();
     }

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -53,17 +53,22 @@
 #include "../tir/schedule/primitive.h"
 #include "../tir/schedule/utils.h"
 
-#define TVM_PY_LOG(logging_level, logging_func) \
-  PyLogMessage(__FILE__, __LINE__, logging_func, PyLogMessage::Level::logging_level).stream()
+#define TVM_PY_LOG(logging_level, logging_func)                          \
+  ::tvm::meta_schedule::PyLogMessage(__FILE__, __LINE__, logging_func,   \
+                                     PyLogMessage::Level::logging_level) \
+      .stream()
+
 namespace tvm {
+namespace meta_schedule {
 
 /*!
  * \brief Class to accumulate an log message on the python side. Do not use directly, instead use
- * TVM_PY_LOG(INFO), TVM_PY_LOG(WARNING), TVM_PY_ERROR(INFO).
+ * TVM_PY_LOG(DEBUG), TVM_PY_LOG(INFO), TVM_PY_LOG(WARNING), TVM_PY_ERROR(ERROR).
  */
 class PyLogMessage {
  public:
   enum class Level : int32_t {
+    DEBUG = 10,
     INFO = 20,
     WARNING = 30,
     ERROR = 40,
@@ -95,8 +100,6 @@ class PyLogMessage {
   PackedFunc logging_func;
   Level logging_level;
 };
-
-namespace meta_schedule {
 
 /*! \brief The type of the random state */
 using TRandState = support::LinearCongruentialEngine::TRandState;

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -360,7 +360,7 @@ struct ThreadedTraceApply {
           return NullOpt;
         }
       } catch (const std::exception& e) {
-        LOG(WARNING) << "ThreadedTraceApply::Apply failed with error " << e.what();
+        DLOG(WARNING) << "ThreadedTraceApply::Apply failed with error " << e.what();
         return NullOpt;
       }
     }
@@ -394,6 +394,8 @@ struct ThreadedTraceApply {
   int n_;
   /*! \brief The pointer to the list of postprocessor items. */
   Item* items_;
+  /*! \brief The logging function to use. */
+  Optional<PackedFunc> logging_func;
 };
 
 /*!

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -403,8 +403,6 @@ struct ThreadedTraceApply {
   int n_;
   /*! \brief The pointer to the list of postprocessor items. */
   Item* items_;
-  /*! \brief The logging function to use. */
-  PackedFunc logging_func;
 };
 
 /*!

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -40,7 +40,9 @@ from tvm.tir.schedule import BlockRV, Schedule
 from tvm.tir.schedule.trace import Trace
 from tvm.tir.tensor_intrin.x86 import VNNI_DOT_16x4_INTRIN as VNNI_INTRIN
 
-logging.basicConfig()
+logging.basicConfig(
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
 logging.getLogger("tvm.meta_schedule").setLevel(logging.DEBUG)
 
 # pylint: disable=invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument


### PR DESCRIPTION
This PR introduces a new interface to unify meta schedule logging from both c++ and python side. It will be easier to control logging level and format content. From now on, only task scheduler level will be printed to screen by default, and task level information will be logged to a file in given folder. We still support any logging configuration from outside, and use `tvm.meta_schedule` as the main logger.

The interface uses logger on the python side while on the c++ side we created a new macro called `TVM_PY_LOG` to work int the following style where `logging_func` is the optional packed function for logging (thanks to #10032 ):
```
TVM_PY_LOG(DEBUG, logging_func)
TVM_PY_LOG(INFO, logging_func)
TVM_PY_LOG(WARNING, logging_func)
TVM_PY_LOG(ERROR, logging_func)
```
The logger would fall back to original c++ logger function `LOG(Level)` if given logging function is not defined.

Recomended setup of logger is as follows:
```
logging.getLogger("tvm.meta_schedule").setLevel(logging.INFO)
# Use logging.DEBUG if debugging
```

And further configuration of task level loggers can be set in `TuneConfig` for features like whether to stream to screen, whether to propagate to main logger, patterns, etc, by passing a Dict to `TuneConfig` as follows:
```
TuneConfig(
    ...,
    logger_config = {
        "loggers": ...,
        "handlers": ...,
        "formatters": ...
    }
    # None if use default setting.
)
```
Default setting is to output to files in `log_dir` folder and the logging structure looks like the following directory:
```
tvm.meta_schedule.tune.task_00_fused_nn_conv2d_add.log
tvm.meta_schedule.tune.task_01_fused_nn_conv2d_add_1.log
tvm.meta_schedule.tune.task_02_fused_nn_conv2d_add_2.log
tvm.meta_schedule.tune.task_03_fused_layout_transform.log
tvm.meta_schedule.tune.task_04_fused_nn_conv2d_add_nn_relu.log
tvm.meta_schedule.tune.task_05_fused_nn_max_pool2d.log
tvm.meta_schedule.tune.task_06_fused_nn_conv2d_add_nn_relu_1.log
tvm.meta_schedule.tune.task_07_fused_nn_conv2d_add_add_nn_relu.log
tvm.meta_schedule.tune.task_08_fused_nn_conv2d_add_nn_relu_2.log
tvm.meta_schedule.tune.task_09_fused_nn_contrib_conv2d_winograd_without_weight_transform_add_nn_relu.log
tvm.meta_schedule.tune.task_10_fused_nn_contrib_conv2d_winograd_without_weight_transform_add_add_nn_relu.log
tvm.meta_schedule.tune.task_11_fused_nn_conv2d_add_nn_relu_3.log
tvm.meta_schedule.tune.task_12_fused_nn_contrib_conv2d_winograd_without_weight_transform_add_nn_relu_1.log
tvm.meta_schedule.tune.task_13_fused_nn_contrib_conv2d_winograd_without_weight_transform_add_add_nn_relu_1.log
tvm.meta_schedule.tune.task_14_fused_nn_conv2d_add_nn_relu_4.log
tvm.meta_schedule.tune.task_15_fused_nn_conv2d_add_nn_relu_5.log
tvm.meta_schedule.tune.task_16_fused_nn_conv2d_add_add_nn_relu_1.log
tvm.meta_schedule.tune.task_17_fused_nn_adaptive_avg_pool2d.log
tvm.meta_schedule.tune.task_18_fused_layout_transform_reshape_squeeze.log
tvm.meta_schedule.tune.task_19_fused_nn_dense_add.log
tvm.meta_schedule.tune.task_scheduler.log
```
Suggestions are welcome!

CC: @junrushao1994 @shingjan @comaniac 