### PR TITLE
[CI] Update GoogleTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,7 @@ if(USE_GTEST)
         # GTest::gtest.
         get_target_property(GTEST_LIB_PATH GTest::gtest IMPORTED_LOCATION)
         if("${GTEST_LIB_PATH}" STREQUAL "GTEST_LIB_PATH-NOTFOUND")
-          message(FATAL_ERROR "Neither GTest::GTest nor GTets::gtest targets defined IMPORTED_LOCATION")
+          message(FATAL_ERROR "Neither GTest::GTest nor GTest::gtest targets defined IMPORTED_LOCATION")
         endif()
       endif()
       get_filename_component(GTEST_LIB_DIR "${GTEST_LIB_PATH}" DIRECTORY)

--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -26,6 +26,9 @@ RUN apt-get install -y ca-certificates gnupg2
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh
+
 # Rust env
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
 RUN bash /install/ubuntu_install_rust.sh

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -23,6 +23,9 @@ RUN apt-get update --fix-missing
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh
+
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
 

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -30,6 +30,9 @@ RUN apt-get update --fix-missing
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh
+
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
 

--- a/docker/Dockerfile.ci_hexagon
+++ b/docker/Dockerfile.ci_hexagon
@@ -25,6 +25,9 @@ RUN apt-get install -y ca-certificates gnupg2 libxml2-dev
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh
+
 COPY install/ubuntu2004_install_python.sh /install/ubuntu2004_install_python.sh
 RUN bash /install/ubuntu2004_install_python.sh
 

--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -25,6 +25,9 @@ RUN apt-get update --fix-missing && apt-get install -y ca-certificates
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh
+
 COPY install/ubuntu_install_llvm.sh /install/ubuntu_install_llvm.sh
 RUN bash /install/ubuntu_install_llvm.sh
 

--- a/docker/Dockerfile.ci_qemu
+++ b/docker/Dockerfile.ci_qemu
@@ -24,6 +24,9 @@ RUN apt-get update --fix-missing
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 
+COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh
+
 COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
 

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -28,10 +28,8 @@ apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     gdb \
     git \
-    google-mock \
     graphviz \
     libcurl4-openssl-dev \
-    libgtest-dev \
     libopenblas-dev \
     libssl-dev \
     libtinfo-dev \
@@ -44,24 +42,3 @@ apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     unzip \
     wget \
-
-
-# Get Ubuntu version
-release=$(lsb_release -r)
-version_number=$(cut -f2 <<< "$release")
-
-if [ "$version_number" == "20.04" ]; then
-  # Single package source (Ubuntu 20.04)
-  # googletest is installed via libgtest-dev
-  cd /usr/src/googletest && cmake CMakeLists.txt && make && cp -v lib/*.a /usr/lib
-  cd /usr/src/gmock && make install
-elif [ "$version_number" == "18.04" ]; then
-  # Single package source (Ubuntu 18.04)
-  # googletest is installed via libgtest-dev
-  cd /usr/src/googletest && cmake CMakeLists.txt && make && cp -v {googlemock,googlemock/gtest}/*.a /usr/lib
-else
-  # Split source package (Ubuntu 16.04)
-  # libgtest-dev and google-mock
-  cd /usr/src/gtest && cmake CMakeLists.txt && make && cp -v *.a /usr/lib
-  cd /usr/src/gmock && cmake CMakeLists.txt && make && cp -v *.a /usr/lib
-fi

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -23,6 +23,7 @@ set -o pipefail
 # install libraries for building c++ core on ubuntu
 apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
+    ca-certificates \
     cmake \
     curl \
     g++ \

--- a/docker/install/ubuntu_install_googletest.sh
+++ b/docker/install/ubuntu_install_googletest.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+tmpdir=$(mktemp -d)
+
+cleanup()
+{
+  rm -rf "$tmpdir"
+}
+
+trap cleanup 0
+
+# GoogleTest uses a Live-at-Head philosophy:
+# https://github.com/google/googletest#live-at-head
+# therefore we need to grab a specific hash and update it
+# periodically to match the head of the repo
+repo_url="https://github.com/google/googletest"
+repo_revision="830fb567285c63ab5b5873e2e8b02f2249864916"
+
+archive_name="${repo_revision}.tar.gz"
+archive_url="${repo_url}/archive/${archive_name}"
+archive_folder="googletest-${repo_revision}"
+archive_hash="10f10ed771efc64a1d8234a7e4801838a468f8990e5d6d8fcf63e89f8d1455c4f9c5adc0bb829669f381609a9abf84e4c91a7fdd7404630f375f38fb485ef0eb"
+
+cd "$tmpdir"
+
+curl -sL "${archive_url}" -o "${archive_name}"
+echo "$archive_hash" ${archive_name} | sha512sum -c
+tar xf "${archive_name}"
+
+cd ${archive_folder}
+mkdir build
+cd build
+
+# CMake doesn't search /usr/local/lib/<arch> properly for GoogleTest
+# so we use /usr/lib where it does search
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib ..
+cmake --build . --target install


### PR DESCRIPTION
This updates GoogleTest across all our images which also has the side
effect of using the same version for any host OS.

Rather than updating to a fixed version, I've followed the best practice
advertised by GoogleTest itself which is the Live-at-Head philosophy:
https://github.com/google/googletest#live-at-head

Closes #11002


cc @areusch @driazati