### PR TITLE
[hexagon][benchmark] Add workload with [1,?] shape

### DIFF
--- a/tests/python/contrib/test_hexagon/benchmark_hexagon.py
+++ b/tests/python/contrib/test_hexagon/benchmark_hexagon.py
@@ -163,19 +163,6 @@ def test_elemwise_add(android_serial_number, hexagon_launcher):
         version_name = f"dtype:{dtype}-schedtype:{sched_type}-memscope:{mem_scope}-numvecs:{num_vectors_per_tensor}"
         print(f"CONFIGURATION: {version_name}")
 
-        if num_vectors_per_tensor == 1 and mem_scope == "global.vtcm":
-            # 2022-04-12 (cconvey): There's currently a bug in which TVM doesn't
-            # recognize the mapping of 1D memory <--> 2D memory as being bijective
-            # when num_vectors_per_tensor == 1.
-            br.record_skip(
-                dtype,
-                sched_type,
-                mem_scope,
-                num_vectors_per_tensor,
-                f"Expect to hit bug where 1D-2D bijective transform not recognized.",
-            )
-            return
-
         if num_vectors_per_tensor == 2048 and mem_scope == "global.vtcm":
             br.record_skip(
                 dtype,


### PR DESCRIPTION
Re-enable a benchmark configuration that was failing because
of a bug in TVM's new dimension-mapping code.

Here's the new output:
```
CONFIGURATION: dtype:int8-schedtype:2-memscope:global.vtcm-numvecs:2048
dtype   sched_type      mem_scope       num_vecs_per_tensor     status  median(µsec)    min(µsec)       max(µsec)       comment
int8    1       global  1       OK      0.7     0.7     0.7
int8    1       global  16      OK      0.5     0.5     0.5
int8    1       global  64      OK      1.2     1.2     1.2
int8    1       global  512     OK      3.0     3.0     3.0
int8    1       global  2048    OK      16.5    16.5    16.5
int8    1       global.vtcm     1       OK      0.7     0.7     0.7
int8    1       global.vtcm     16      OK      0.8     0.8     0.8
int8    1       global.vtcm     64      OK      1.4     1.4     1.4
int8    1       global.vtcm     512     OK      5.4     5.4     5.4
int8    1       global.vtcm     2048    SKIP                            Expect to exceed VTCM budget.
int8    2       global  1       OK      0.6     0.6     0.6
int8    2       global  16      OK      0.6     0.6     0.6
int8    2       global  64      OK      0.8     0.8     0.8
int8    2       global  512     OK      2.5     2.5     2.5
int8    2       global  2048    OK      17.2    17.2    17.2
int8    2       global.vtcm     1       OK      0.8     0.8     0.8
int8    2       global.vtcm     16      OK      0.7     0.7     0.7
int8    2       global.vtcm     64      OK      1.3     1.3     1.3
int8    2       global.vtcm     512     OK      5.3     5.3     5.3
int8    2       global.vtcm     2048    SKIP                            Expect to exceed VTCM budget.
```


cc @mehrdadh