### PR TITLE
[microTVM] Remove micro_dev

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -36,14 +36,14 @@ def schedule_reduce_cpu(attrs, outs, target):
         return topi.x86.schedule_reduce(outs)
 
 
-@schedule_injective.register(["arm_cpu", "micro_dev"])
+@schedule_injective.register("arm_cpu")
 def schedule_injective_arm_cpu(_, outs, target):
     """schedule injective ops for arm cpu"""
     with target:
         return topi.arm_cpu.schedule_injective(outs)
 
 
-@schedule_concatenate.register(["arm_cpu", "micro_dev"])
+@schedule_concatenate.register("arm_cpu")
 def schedule_concatenate_arm_cpu(_, outs, target):
     """schedule concatenate for arm cpu"""
     with target:
@@ -69,7 +69,7 @@ def schedule_pool_arm_cpu(attrs, outs, target):
         return topi.generic.schedule_pool(outs, layout)
 
 
-@conv2d_strategy.register(["arm_cpu", "micro_dev"])
+@conv2d_strategy.register("arm_cpu")
 def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
     """conv2d arm cpu strategy"""
     strategy = _op.OpStrategy()
@@ -163,7 +163,7 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.arm_cpu.conv2d_nhwc_dsp),
                     wrap_topi_schedule(topi.arm_cpu.schedule_conv2d_nhwc_dsp),
-                    name="conv2d_nhwc_dsp.micro_dev",
+                    name="conv2d_nhwc_dsp.arm_cpu",
                 )
             elif kernel_layout == "HWIO":
                 is_aarch64 = topi.arm_cpu.arm_utils.is_aarch64_arm()
@@ -408,7 +408,7 @@ def conv2d_gemm_without_weight_transform_strategy_arm_cpu(attrs, inputs, out_typ
     return strategy
 
 
-@conv2d_transpose_strategy.register(["arm_cpu", "micro_dev"])
+@conv2d_transpose_strategy.register("arm_cpu")
 def conv2d_transpose_strategy_arm_cpu(attrs, inputs, out_type, target):
     """conv2d_transpose arm cpu strategy"""
     layout = attrs.data_layout

--- a/tests/python/contrib/test_ethosu/test_attr_passing.py
+++ b/tests/python/contrib/test_ethosu/test_attr_passing.py
@@ -27,7 +27,7 @@ def test_compiler_attr():
         "accelerator_config": "ethos-u55-32",
     }
     with tvm.transform.PassContext(opt_level=3, config={"relay.ext.ethos-u.options": config}):
-        with tvm.target.Target("c -device=micro_dev"):
+        with tvm.target.Target("c"):
             compiler_attrs = tvm.get_global_func("relay.ext.ethos-u.get_compiler_attrs")()
             accel_config_str = compiler_attrs.accelerator_config
             assert accel_config_str == config["accelerator_config"]
@@ -38,7 +38,7 @@ def test_compiler_attr_default():
         "accelerator_config": "ethos-u55-256",
     }
     with tvm.transform.PassContext(opt_level=3):
-        with tvm.target.Target("c -device=micro_dev"):
+        with tvm.target.Target("c"):
             compiler_attrs = tvm.get_global_func("relay.ext.ethos-u.get_compiler_attrs")()
             accel_config_str = compiler_attrs.accelerator_config
             assert accel_config_str == default_config["accelerator_config"]


### PR DESCRIPTION
This PR cleans up `micro_dev` in some test files and one schedule name.
cc @areusch @gromero