### PR TITLE
[AOT] Return module list from AotExecutorFactory

### DIFF
--- a/src/runtime/aot_executor/aot_executor_factory.cc
+++ b/src/runtime/aot_executor/aot_executor_factory.cc
@@ -52,6 +52,11 @@ PackedFunc AotExecutorFactory::GetFunction(
       }
       *rv = this->ExecutorCreate(devices);
     });
+  } else if (name == "module_list") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      Array<String> names = {module_name_};
+      *rv = names;
+    });
   } else if (name == "remove_params") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       std::unordered_map<std::string, tvm::runtime::NDArray> empty_params{};

--- a/src/runtime/aot_executor/aot_executor_factory.cc
+++ b/src/runtime/aot_executor/aot_executor_factory.cc
@@ -52,7 +52,7 @@ PackedFunc AotExecutorFactory::GetFunction(
       }
       *rv = this->ExecutorCreate(devices);
     });
-  } else if (name == "module_list") {
+  } else if (name == "list_module_names") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
       Array<String> names = {module_name_};
       *rv = names;

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -152,17 +152,16 @@ def test_module_list():
         tvm.IRModule.from_expr(tvm.relay.Function([x], expr)),
         target="c",
         executor=tvm.relay.backend.Executor("aot", {"interface-api": "packed"}),
+        mod_name="unusual_module_name_fred",
     )
     temp_dir = tvm.contrib.utils.TempDirectory()
     test_so_path = temp_dir / "test.so"
     mod.export_library(test_so_path, cc="gcc", options=["-std=c11"])
     loaded_mod = tvm.runtime.load_module(test_so_path)
-    module_list = loaded_mod.get_function("module_list")
+    list_module_names = loaded_mod.get_function("list_module_names")
     # At the moment, relay produces a single module with the name "default".
-    names_expected = ["default"]
-    names_obtained = sorted(module_list())
-    assert len(names_obtained) == len(names_expected)
-    assert all([x == y for (x, y) in zip(names_obtained, names_expected)])
+    names_expected = ["unusual_module_name_fred"]
+    assert list(sorted(names_expected)) == list(sorted(list_module_names()))
 
 
 def test_create_executor():

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -159,7 +159,6 @@ def test_module_list():
     mod.export_library(test_so_path, cc="gcc", options=["-std=c11"])
     loaded_mod = tvm.runtime.load_module(test_so_path)
     list_module_names = loaded_mod.get_function("list_module_names")
-    # At the moment, relay produces a single module with the name "default".
     names_expected = ["unusual_module_name_fred"]
     assert list(sorted(names_expected)) == list(sorted(list_module_names()))
 


### PR DESCRIPTION
Add a function `module_list` to `AotExecutorFactory` that returns `Array<String>` containing names of all modules. At the moment there will be only one entry in that list, most commonly "default".

cc @Mousius