### PR TITLE
[Relay] Flexible shape dispatch transformation

### DIFF
--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -130,11 +130,13 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str or iterator of (auto_scheduler.measure.MeasureInput,\
-                                  auto_scheduler.measure.MeasureResult)
+    records : str, list of str, or iterator of (auto_scheduler.measure.MeasureInput,\
+                                                auto_scheduler.measure.MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
-        Each row of this file is an encoded record pair. Otherwise, it is an iterator.
+        Each row of this file is an encoded record pair. If it is an iterator,
+        it can either be a set of str filenames which will be applied jointly,
+        or a set of (input, result) tuples.
     n_lines: Optional[int]
         if it is not None, only load the first `n_lines` lines of log.
     include_compatible: bool
@@ -196,20 +198,28 @@ class ApplyHistoryBest(DispatchContext):
         n_lines: Optional[int]
             if it is not None, only load the first `n_lines` lines of log
         """
-        if isinstance(records, pathlib.Path):
-            records = str(records)
+        joint_records = []
+        if not isinstance(records, (list, tuple)):
+            records = [records]
 
-        if isinstance(records, str):
-            records = load_records(records)
+        for rec in records:
+            if isinstance(rec, pathlib.Path):
+                rec = str(rec)
 
-        if not records:
+            if isinstance(rec, str):
+                rec = load_records(rec)
+                joint_records += rec
+            else:
+                joint_records.append(rec)
+
+        if not joint_records:
             return
 
         best_by_targetkey = self.best_by_targetkey
         best_by_model = self.best_by_model
 
         counter = 0
-        for inp, res in records:
+        for inp, res in joint_records:
             if n_lines is not None and counter >= n_lines:
                 break
             counter += 1

--- a/python/tvm/auto_scheduler/dispatcher.py
+++ b/python/tvm/auto_scheduler/dispatcher.py
@@ -210,7 +210,8 @@ class ApplyHistoryBest(DispatchContext):
                 rec = load_records(rec)
                 joint_records += rec
             else:
-                joint_records.append(rec)
+                if rec is not None:
+                    joint_records.append(rec)
 
         if not joint_records:
             return

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -184,10 +184,11 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
+    records : str, list of str, or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
-        Each row of this file is an encoded record pair. Otherwise, it is an iterator.
+        Each row of this file is an encoded record pair. If it is a list, it can either be
+        a list of paths to log files that will be loaded jointly or an iterator or records.
     """
 
     def __init__(self, records):
@@ -205,28 +206,39 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
+        records : str, list of str, or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
-            Each row of this file is an encoded record pair. Otherwise, it is an iterator.
+            Each row of this file is an encoded record pair. If it is a list
+            it can either be a list of paths to logs that will loaded jointly or
+            an iterator of measurement results.
         """
         # pylint: disable=import-outside-toplevel
         from pathlib import Path
         from ..record import load_from_file
 
-        if isinstance(records, Path):
-            records = str(records)
+        joint_records = []
+        if not isinstance(records, (list, tuple)):
+            records = [records]
 
-        if isinstance(records, str):
-            records = load_from_file(records)
-        if not records:
+        for rec in records:
+            if isinstance(rec, Path):
+                rec = str(rec)
+
+            if isinstance(rec, str):
+                rec = load_from_file(rec)
+                joint_records += rec
+            else:
+                joint_records.append(rec)
+
+        if not joint_records:
             return
 
         best_by_targetkey = self.best_by_targetkey
         best_by_model = self.best_by_model
 
         counter = 0
-        for inp, res in records:
+        for inp, res in joint_records:
             counter += 1
             if res.error_no != 0:
                 continue

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -184,7 +184,7 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str, list of str, or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
+    records : str, list of str, or iterator of (MeasureInput, MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
         Each row of this file is an encoded record pair. If it is a list, it can either be
@@ -206,7 +206,7 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str, list of str, or iterator of (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
+        records : str, list of str, or iterator of (MeasureInput, MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
             Each row of this file is an encoded record pair. If it is a list

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -231,7 +231,8 @@ class ApplyHistoryBest(DispatchContext):
                 rec = load_from_file(rec)
                 joint_records += rec
             else:
-                joint_records.append(rec)
+                if rec is not None:
+                    joint_records.append(rec)
 
         if not joint_records:
             return

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -207,8 +207,8 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str, list of str, or iterator of 
-                  (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
+        records : str, list of str, or iterator of (autotvm.measure.MeasureInput,\
+                                                    autotvm.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
             Each row of this file is an encoded record pair. If it is a list

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -184,7 +184,8 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str, list of str, or iterator of (MeasureInput, MeasureResult)
+    records : str, list of str, or iterator of (autotvm.measure.MeasureInput,\
+                                                autotvm.measure.MeasureResult)
         Collection of tuning records.
         If is str, then it should be the filename of a records log file.
         Each row of this file is an encoded record pair. If it is a list, it can either be
@@ -206,7 +207,8 @@ class ApplyHistoryBest(DispatchContext):
 
         Parameters
         ----------
-        records : str, list of str, or iterator of (MeasureInput, MeasureResult)
+        records : str, list of str, or iterator of 
+                  (autotvm.measure.MeasureInput, autotvm.measure.MeasureResult)
             Collection of tuning records.
             If is str, then it should be the filename of a records log file.
             Each row of this file is an encoded record pair. If it is a list

--- a/python/tvm/relay/transform/__init__.py
+++ b/python/tvm/relay/transform/__init__.py
@@ -20,3 +20,4 @@
 from .transform import *
 from .recast import recast
 from . import fake_quantization_to_integer, mixed_precision
+from .flexible_shape import FlexibleShapeDispatch

--- a/python/tvm/relay/transform/flexible_shape.py
+++ b/python/tvm/relay/transform/flexible_shape.py
@@ -1,0 +1,103 @@
+from tvm import relay
+
+
+def override_shape(ty, dim, value):
+    """Change a value in a tensor shape."""
+    new_dims = list(ty.shape)
+    new_dims[dim] = value
+    return relay.TensorType(new_dims, ty.dtype)
+
+
+def specialize_body(mod, fn, dim, value):
+    """Create a subgraph to handle a specific input shape"""
+    data = fn.params[0]
+    flex_ty = override_shape(data.type_annotation, dim, value)
+    dyn_data = relay.Var(data.name_hint, type_annotation=flex_ty)
+    new_params = [dyn_data] + fn.params[1:]
+    new_body = relay.expr.bind(fn.body, {data: dyn_data})
+    new_ret_ty = override_shape(fn.ret_type, dim, value)
+    gvar = relay.GlobalVar("main_" + str(value))
+    mod[gvar] = relay.Function(new_params, new_body, new_ret_ty, fn.type_params, fn.attrs)
+    return gvar, dyn_data.type_annotation
+
+
+def flexible_dispatch(mod, dim=0, buckets=[]):
+    """
+    Implement a batching transform for Relay.
+
+    Constructs a tree which splits on the batch dimension dispatching
+    to specialized versions of Relay code which execute for each batch
+    dimension.
+
+    This enables us to ship a single Relay model which supports performance
+    specialization for a batch dimension without needing Relax and defaults
+    to a slow but reliable performance path.
+
+    This also allows for us to tune all batch sizes in a single program
+    increasing effectiveness of TRS or other caching by filling/hitting.
+    """
+    main_fn = mod["main"]
+    data = main_fn.params[0]
+    dyn_shape = override_shape(data.type_annotation, dim, relay.Any())
+    dyn_data = relay.Var(data.name_hint, type_annotation=dyn_shape)
+    rt_sh = relay.op.shape_of(dyn_data)
+    flex_value = relay.op.take(rt_sh, relay.const(dim))
+    if_exprs = []
+
+    for bucket in buckets:
+        spec_call, spec_ty = specialize_body(mod, main_fn, dim, bucket)
+        spec_data = relay.op.reshape(dyn_data, spec_ty.shape)
+        call_args = [spec_data] + main_fn.params[1:]
+        if_exprs.append((relay.op.equal(flex_value, relay.const(bucket)), spec_call(*call_args)))
+
+    default_dyn_call, _ = specialize_body(mod, main_fn, dim, relay.Any())
+    call_args = [dyn_data] + main_fn.params[1:]
+
+    new_body = default_dyn_call(*call_args)
+
+    for cond, true_branch in if_exprs:
+        new_body = relay.If(cond, true_branch, new_body)
+
+    new_params = [dyn_data] + main_fn.params[1:]
+    dyn_ret_type = override_shape(main_fn.ret_type, dim, relay.Any())
+    new_main = relay.Function(
+        new_params, new_body, dyn_ret_type, main_fn.type_params, main_fn.attrs
+    )
+    mod["main"] = new_main
+    mod = relay.transform.InferType()(mod)
+    return mod
+
+
+class FlexibleShapeDispatch(object):
+    """Enable inference of multiple shaped inputs in one module.
+
+    This transformation adds a handler around a module that
+    checks input shapes and dispatches to a subgraph specialized
+    to handle the specific shapes of that input. If no exactly matching
+    subgraph is available, the input will be run using full dynamism.
+    For best performance, specify all the sizes the module will
+    be likely to see using the buckets argument.
+
+    Parameters
+    ----------
+    dim: int
+        The dimension of the input that should be made flexible. This will
+        most often be used for the batch dimension.
+    buckets: list[int]
+        The sizes of the input dimension that should be explicitly handled.
+        Each value in buckets will have a corresponding subgraph constructed to
+        handle it.
+
+    Returns
+    -------
+    ret : FlexibleShapeDispatch
+        A pass that can be applied to a module to add flexible shape handling.
+    """
+
+    def __init__(self, dim=0, buckets=[]):
+        self.dim = dim
+        self.buckets = buckets
+        super(FlexibleShapeDispatch, self).__init__()
+
+    def __call__(self, mod):
+        return flexible_dispatch(mod, self.dim, self.buckets)

--- a/python/tvm/relay/transform/flexible_shape.py
+++ b/python/tvm/relay/transform/flexible_shape.py
@@ -25,13 +25,21 @@ def override_shape(ty, dim, value):
     return relay.TensorType(new_dims, ty.dtype)
 
 
-def specialize_body(mod, fn, dim, value, affects_output=True):
+def specialize_body(mod, fn, dim, value, input_indices=[0], affects_output=True):
     """Create a subgraph to handle a specific input shape"""
-    data = fn.params[0]
-    flex_ty = override_shape(data.type_annotation, dim, value)
-    dyn_data = relay.Var(data.name_hint, type_annotation=flex_ty)
-    new_params = [dyn_data] + fn.params[1:]
-    new_body = relay.expr.bind(fn.body, {data: dyn_data})
+    # Iterate through specified inputs and construct specialized shapes.
+    new_params = list(fn.params)
+    data_binding = {}
+    dyn_data_array = []
+    for inp in input_indices:
+        data = fn.params[inp]
+        flex_ty = override_shape(data.type_annotation, dim, value)
+        dyn_data = relay.Var(data.name_hint, type_annotation=flex_ty)
+        new_params[inp] = dyn_data
+        data_binding[data] = dyn_data
+        dyn_data_array.append(dyn_data)
+
+    new_body = relay.expr.bind(fn.body, data_binding)
     # Only change the output shape if the input shape affects it.
     if affects_output:
         new_ret_ty = override_shape(fn.ret_type, dim, value)
@@ -39,7 +47,7 @@ def specialize_body(mod, fn, dim, value, affects_output=True):
         new_ret_ty = fn.ret_type
     gvar = relay.GlobalVar("main_" + str(value))
     mod[gvar] = relay.Function(new_params, new_body, new_ret_ty, fn.type_params, fn.attrs)
-    return gvar, dyn_data.type_annotation
+    return gvar, [d.type_annotation for d in dyn_data_array]
 
 
 def flexible_dispatch(mod, dim=0, buckets=[], auto_pad=False, pad_value=0, input_indices=[0], affects_output=True):
@@ -58,10 +66,17 @@ def flexible_dispatch(mod, dim=0, buckets=[], auto_pad=False, pad_value=0, input
     increasing effectiveness of TRS or other caching by filling/hitting.
     """
     main_fn = mod["main"]
-    data = main_fn.params[0]
-    dyn_shape = override_shape(data.type_annotation, dim, relay.Any())
-    dyn_data = relay.Var(data.name_hint, type_annotation=dyn_shape)
-    rt_sh = relay.op.shape_of(dyn_data)
+
+    # Extract all input data and create a new dynamic variable for each.
+    data = []
+    dyn_data = []
+    for i in input_indices:
+        data.append(main_fn.params[i])
+        dyn_shape = override_shape(data[i].type_annotation, dim, relay.Any())
+        dyn_data.append(relay.Var(data[i].name_hint, type_annotation=dyn_shape))
+
+    # Extract the dynamic shape value from one of the inputs.
+    rt_sh = relay.op.shape_of(dyn_data[0])
     flex_value = relay.op.take(rt_sh, relay.const(dim))
 
     if_exprs = []
@@ -72,29 +87,37 @@ def flexible_dispatch(mod, dim=0, buckets=[], auto_pad=False, pad_value=0, input
 
         # Apply automatic padding if specified.
         if auto_pad:
+            input_data = []
             # Construct padding expression for inputs.
-            pad_width = relay.const(bucket) - flex_value
-            rank = len(data.type_annotation.shape)
-            pads = relay.zeros([rank, 2], 'int32')
-            pads = relay.scatter_nd(pads, relay.const([dim, 1]), pad_width)
-            padded_value = relay.nn.pad(dyn_data, pads, pad_value)
+            for j, inp in enumerate(dyn_data):
+                pad_width = relay.const(bucket) - flex_value
+                rank = len(data[j].type_annotation.shape)
+                pads = relay.zeros([rank, 2], 'int32')
+                pads = relay.scatter_nd(pads, relay.const([dim, 1]), pad_width)
+                padded_value = relay.nn.pad(inp, pads, pad_value)
 
-            # Determine if this is the proper bucket to pad to. Do this by checking if the
-            # input shape is between this bucket and the previous.
-            if i == 0:
-                padded_value = relay.If(relay.op.less_equal(flex_value, relay.const(bucket)), padded_value, dyn_data)
-            else:
-                padded_value = relay.If(relay.op.logical_and(relay.op.less_equal(flex_value, relay.const(bucket)), relay.op.greater(flex_value, relay.const(buckets[i - 1]))), padded_value, dyn_data)
-            # Update input value and test dimension to reflect possible padding.
-            input_data = padded_value
-            check_dim = relay.op.take(relay.op.shape_of(input_data), relay.const(dim))
+                # Determine if this is the proper bucket to pad to. Do this by checking if the
+                # input shape is between this bucket and the previous.
+                if i == 0:
+                    padded_value = relay.If(relay.op.less_equal(flex_value, relay.const(bucket)), padded_value, inp)
+                else:
+                    padded_value = relay.If(relay.op.logical_and(relay.op.less_equal(flex_value, relay.const(bucket)), relay.op.greater(flex_value, relay.const(buckets[i - 1]))), padded_value, inp)
+                # Update input value and test dimension to reflect possible padding.
+                input_data.append(padded_value)
+            # Grab the new possibly padded shape for checking bucket size.
+            check_dim = relay.op.take(relay.op.shape_of(input_data[0]), relay.const(dim))
 
         # Create a specialized subgraph for the current bucket.
-        spec_call, spec_ty = specialize_body(mod, main_fn, dim, bucket, affects_output=affects_output)
-        spec_data = relay.op.reshape(input_data, spec_ty.shape)
+        spec_call, spec_ty = specialize_body(mod, main_fn, dim, bucket, input_indices=input_indices, affects_output=affects_output)
+        # Apply hard casting to shape to create statically typed graphs.
+        spec_data = []
+        for j, inp in enumerate(input_data):
+            spec_data.append(relay.op.reshape(inp, spec_ty[j].shape))
 
         # Create a dispatch statement for the current specialized graph.
-        call_args = [spec_data] + main_fn.params[1:]
+        call_args = list(main_fn.params)
+        for j, inp in enumerate(input_indices):
+            call_args[inp] = spec_data[j]
         new_call = spec_call(*call_args)
 
         # Remove meaningless padded outputs if applicable.
@@ -104,16 +127,25 @@ def flexible_dispatch(mod, dim=0, buckets=[], auto_pad=False, pad_value=0, input
         # Add this new case to the dispatch handler.
         if_exprs.append((relay.op.equal(check_dim, relay.const(bucket)), new_call))
 
-    default_dyn_call, _ = specialize_body(mod, main_fn, dim, relay.Any(), affects_output=affects_output)
-    call_args = [dyn_data] + main_fn.params[1:]
-
+    # Create a subgraph to handle all other shapes.
+    default_dyn_call, _ = specialize_body(mod, main_fn, dim, relay.Any(), input_indices=input_indices, affects_output=affects_output)
+    call_args = list(main_fn.params)
+    for j, inp in enumerate(input_indices):
+        call_args[inp] = dyn_data[j]
     new_body = default_dyn_call(*call_args)
 
     for cond, true_branch in if_exprs:
         new_body = relay.If(cond, true_branch, new_body)
 
-    new_params = [dyn_data] + main_fn.params[1:]
-    dyn_ret_type = override_shape(main_fn.ret_type, dim, relay.Any())
+    new_params = list(main_fn.params)
+    for j, inp in enumerate(input_indices):
+        new_params[inp] = dyn_data[j]
+
+    if affects_output:
+        dyn_ret_type = override_shape(main_fn.ret_type, dim, relay.Any())
+    else:
+        dyn_ret_type = main_fn.ret_type
+
     new_main = relay.Function(
         new_params, new_body, dyn_ret_type, main_fn.type_params, main_fn.attrs
     )

--- a/python/tvm/relay/transform/flexible_shape.py
+++ b/python/tvm/relay/transform/flexible_shape.py
@@ -263,6 +263,8 @@ def flexible_dispatch(
         new_params, new_body, dyn_ret_type, main_fn.type_params, main_fn.attrs
     )
     mod["main"] = new_main
+    # Do type inference to make sure everything worked.
+    mod = relay.transform.InferType()(mod)
     return mod
 
 

--- a/python/tvm/relay/transform/flexible_shape.py
+++ b/python/tvm/relay/transform/flexible_shape.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=invalid-name, dangerous-default-value
 """Relay functions for wrapping a module with flexible shape dispatch."""
 from tvm import relay
 

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -56,6 +56,12 @@ def tune_network(network, target):
             ):
                 lib = relay.build(mod, target=target, params=params)
 
+        # Also test that multiple log files can be loaded.
+        with auto_scheduler.ApplyHistoryBest([log_file, log_file]) as best:
+            assert isinstance(
+                best, auto_scheduler.dispatcher.ApplyHistoryBest
+            ), "Unable to load multiple log files jointly."
+
         # Sample a schedule when missing
         with auto_scheduler.ApplyHistoryBestOrSample(None, num_measure=2):
             with tvm.transform.PassContext(

--- a/tests/python/relay/test_pass_flexible_shape_dispatch.py
+++ b/tests/python/relay/test_pass_flexible_shape_dispatch.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test flexible shape dispatch pass"""
+import numpy as np
+import pytest
+import tvm
+from tvm import relay
+from tvm.relay.testing.resnet import get_workload
+from tvm.relay import vm
+from tvm import runtime
+
+
+def test_end_to_end():
+    # Load a resnet model.
+    mod, params = get_workload()
+    # Apply flexible dispatch pass.
+    mod = relay.transform.FlexibleShapeDispatch(dim=0, buckets=[1, 4], auto_pad=True)(mod)
+    # Compile and confirm result supports multiple shapes.
+    exe = relay.vm.compile(mod, "llvm", params=params)
+    vm = runtime.vm.VirtualMachine(exe, tvm.cpu())
+
+    # Evaluate various batch sizes
+    batch_1 = np.random.normal(size=[1, 3, 224, 224]).astype("float32")
+    assert list(vm.invoke("main", batch_1).shape) == [1, 1000]
+
+    batch_4 = np.random.normal(size=[4, 3, 224, 224]).astype("float32")
+    assert list(vm.invoke("main", batch_4).shape) == [4, 1000]
+
+    # Apply autopadding to an input.
+    batch_3 = np.random.normal(size=[3, 3, 224, 224]).astype("float32")
+    assert list(vm.invoke("main", batch_3).shape) == [3, 1000]
+
+
+def test_multiple_inputs():
+    # Create a small relay module with multiple inputs to dispatch over.
+    x = relay.var("x", shape=[10, 10], dtype="float32")
+    w = relay.var("w", shape=[10, 10], dtype="float32")
+    y = x + w
+    mod = tvm.IRModule.from_expr(y)
+
+    # Apply flexible dispatch to dim 1 for both inputs.
+    mod = relay.transform.FlexibleShapeDispatch(dim=1, buckets=[5, 10], input_indices=[0, 1])(mod)
+
+    # Compile and confirm that output shapes are correct.
+    exe = relay.vm.compile(mod, "llvm")
+    vm = runtime.vm.VirtualMachine(exe, tvm.cpu())
+
+    x_w_5 = np.random.normal(size=[10, 5]).astype("float32")
+    assert list(vm.invoke("main", x_w_5, x_w_5).shape) == [10, 5]
+
+    x_w_10 = np.random.normal(size=[10, 10]).astype("float32")
+    assert list(vm.invoke("main", x_w_10, x_w_10).shape) == [10, 10]
+
+
+def test_fixed_output():
+    # Test a graph where the output shape is not based on input dynamism.
+    x = relay.var("x", shape=[10, 10], dtype="float32")
+    w = relay.var("w", shape=[10, 10], dtype="float32")
+    y = relay.nn.dense(x, w)
+    mod = tvm.IRModule.from_expr(y)
+
+    # Apply flexible dispatch to dimension 1 for both inputs.
+    mod = relay.transform.FlexibleShapeDispatch(
+        dim=1, buckets=[5, 7], input_indices=[0, 1], affects_output=False
+    )(mod)
+
+    # Compile and confirm that output shapes are correct.
+    exe = relay.vm.compile(mod, "llvm")
+    vm = runtime.vm.VirtualMachine(exe, tvm.cpu())
+
+    x_w_5 = np.random.normal(size=[10, 5]).astype("float32")
+    assert list(vm.invoke("main", x_w_5, x_w_5).shape) == [10, 10]
+
+    x_w_7 = np.random.normal(size=[10, 7]).astype("float32")
+    assert list(vm.invoke("main", x_w_7, x_w_7).shape) == [10, 10]
+
+    return
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relay/test_pass_flexible_shape_dispatch.py
+++ b/tests/python/relay/test_pass_flexible_shape_dispatch.py
@@ -28,7 +28,7 @@ def test_end_to_end():
     # Load a resnet model.
     mod, params = get_workload()
     # Apply flexible dispatch pass.
-    mod = relay.transform.FlexibleShapeDispatch(dim=0, buckets=[1, 4], auto_pad=True)(mod)
+    mod = relay.transform.FlexibleShapeDispatch(axis=0, buckets=[1, 4], auto_pad=True)(mod)
     # Compile and confirm result supports multiple shapes.
     exe = relay.vm.compile(mod, "llvm", params=params)
     vm = runtime.vm.VirtualMachine(exe, tvm.cpu())
@@ -53,7 +53,7 @@ def test_multiple_inputs():
     mod = tvm.IRModule.from_expr(y)
 
     # Apply flexible dispatch to dim 1 for both inputs.
-    mod = relay.transform.FlexibleShapeDispatch(dim=1, buckets=[5, 10], input_indices=[0, 1])(mod)
+    mod = relay.transform.FlexibleShapeDispatch(axis=1, buckets=[5, 10], input_indices=[0, 1])(mod)
 
     # Compile and confirm that output shapes are correct.
     exe = relay.vm.compile(mod, "llvm")
@@ -75,7 +75,7 @@ def test_fixed_output():
 
     # Apply flexible dispatch to dimension 1 for both inputs.
     mod = relay.transform.FlexibleShapeDispatch(
-        dim=1, buckets=[5, 7], input_indices=[0, 1], affects_output=False
+        axis=1, buckets=[5, 7], input_indices=[0, 1], affects_output=False
     )(mod)
 
     # Compile and confirm that output shapes are correct.

--- a/tests/python/unittest/test_autotvm_record.py
+++ b/tests/python/unittest/test_autotvm_record.py
@@ -72,6 +72,11 @@ def test_file_io():
     for x, y in zip(ref, autotvm.record.load_from_file(file_path)):
         assert x[1] == y[1]
 
+    # Confirm functionality of multiple file loads
+    hist_best = ApplyHistoryBest([file_path, file_path])
+    x = hist_best.query(target, tsk.workload)
+    assert str(x) == str(inputs[0][2])
+
 
 def test_apply_history_best():
     tsk, target = get_sample_task()


### PR DESCRIPTION
This PR adds a new pass to `relay.transform` that creates a dispatcher around an input module to handle multiple input shapes. For example consider a case where I'd like to optimize my model to handle both `batch_size=1` and `batch_size=4`. I can now do so elegantly as follows:
```
shape_dict = {'data': [1, 3, 224, 224]}
model_bs1 = tvmc.load('my_model.onnx', shape_dict=shape_dict)
tvmc.tune(model, log_file='batch_1.logs')

shape_dict = {'data': [4, 3, 224, 224]}
model_bs4 = tvmc.load('my_model.onnx', shape_dict=shape_dict)
tvmc.tune(model, log_file='batch_4.logs')

# Create dispatcher for multiple batch sizes.
flex_mod = relay.transform.FlexibleShapeDispatch(buckets=[1, 4])(model_bs1.mod)

with ApplyHistoryBest(['batch_1.logs', 'batch_4.logs']):
    exe = relay.vm.compile(flex_mod, "llvm")

# Now we can run inputs with either batch 1 or batch 4 and get the tuned performance!
batch_1 = np.random.rand(1, 3, 224, 224).astype("float32")
vm.benchmark(tvm.cpu(), batch_2, func_name="main")

batch_4 = np.random.rand(4, 3, 224, 224).astype("float32")
vm.benchmark(tvm.cpu(), batch_4, func_name="main")
```

As seen above `FlexibleShapeDispatch` is a simple halfway point between fully static and fully dynamic graphs that allows us to leverage TVM tuning. If an input shape is not provided in `buckets`, it will either run fully dynamically using `relay.Any`, or if the `auto_pad` argument is set for `FlexibleShapeDispatch`, padding will be applied to match the closest bucket.

There are a few special cases that this pass handles. Multiple dynamic inputs (like those you might see in BERT) can be handled by setting `input_indices` to indicate which inputs have a dynamic axis. `affects_output` can be set to `False` for cases where the output shape is not dependent on input dynamism which could occur in dynamic resolution cases or something.

To make applying tuning logs more convenient, I also added the ability to load and merge multiple files to both autotvm and autoscheduler.

Thanks @jroesch for providing the backbone of this implementation.