### PR TITLE
[QNN] Enable constant folding for QNN operations

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -105,9 +105,11 @@ TVM_DLL Pass LazyGradientInit();
 /*!
  * \brief Fold constant expressions.
  *
+ * \param fskip The callback argument that allows to skip certain expressions.
+ *
  * \return The pass.
  */
-TVM_DLL Pass FoldConstant();
+TVM_DLL Pass FoldConstant(runtime::PackedFunc fskip = nullptr);
 
 /*!
  * \brief Split function with huge number of arguments to smaller pieces.

--- a/python/tvm/relay/transform/transform.py
+++ b/python/tvm/relay/transform/transform.py
@@ -261,7 +261,7 @@ def LazyGradientInit():
     return _ffi_api.LazyGradientInit()
 
 
-def FoldConstantExpr(expr, mod):
+def FoldConstantExpr(expr, mod, fskip=None):
     """Fold the constant expressions in a Relay program.
     Parameters
     ----------
@@ -269,24 +269,32 @@ def FoldConstantExpr(expr, mod):
         The expression to fold
     mod: IRModule
         The module the expr lives in (for global calls)
+    fskip: Callback
+        Callback whether to skip given Expr
 
     Returns
     -------
     new_expr: Expr
         The expr after Constant Folding
     """
-    return _ffi_api.FoldConstantExpr(expr, mod)
+    return _ffi_api.FoldConstantExpr(expr, mod, fskip)
 
 
-def FoldConstant():
+def FoldConstant(fskip=None):
     """Fold the constant expressions in a Relay program.
+
+    Parameters
+    ----------
+    fskip: Callable
+        The callback function that decides whether an expression should be
+        skipped.
 
     Returns
     -------
     ret : tvm.transform.Pass
         The registered pass for constant folding.
     """
-    return _ffi_api.FoldConstant()
+    return _ffi_api.FoldConstant(fskip)
 
 
 def FuseOps(fuse_opt_level=-1):

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -31,6 +31,7 @@
 #include <tvm/relay/feature.h>
 #include <tvm/relay/interpreter.h>
 #include <tvm/relay/pattern_functor.h>
+#include <tvm/relay/qnn/transform.h>
 #include <tvm/relay/transform.h>
 #include <tvm/runtime/container/map.h>
 #include <tvm/runtime/device_api.h>
@@ -948,7 +949,7 @@ IRModule Prepare(IRModule mod, CompilationConfig config) {
   VirtualDevice host_virtual_device = config->host_virtual_device;
   // Run minimal transforms on module to establish invariants needed by interpreter.
   transform::Sequential seq(
-      {transform::SimplifyInference(),
+      {transform::SimplifyInference(), qnn::transform::Legalize(),
        // Figure out which devices should be used to execute.
        // TODO(mbs): Should ignore all existing annotations when constant folding
        transform::PlanDevices(std::move(config)),


### PR DESCRIPTION
This PR is an attempt to revive [PR#9164](https://github.com/apache/tvm/pull/9164) . It enables folding of constants for QNN operations. Motivation to have this feature is BYOC use cases.

One important thing: for the case when we call `FoldConstant` before `FakeQuantizationToInteger` pass, we can prevent FQ2I from converting some ops to qnn equivalent. To avoid this, callback argument was added in `FoldConstant` pass that allows to skip expressions from folding.

Co-authored-by: Alexander Peskov <peskovnn@gmail.com>
