### PR TITLE
[Relay] Fix a corner case of fused identity

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -313,7 +313,7 @@ class ScheduleBuilder : public ExprVisitor {
 
   CachedFunc Create(const Function& relay_func, std::function<std::string(std::string)> renamer) {
     LowerToTECompute lower_te_compute(target_);
-    Array<te::Tensor> outputs = lower_te_compute.Lower(relay_func, renamer);
+    Array<te::Tensor> tensor_outs = lower_te_compute.Lower(relay_func, renamer);
     Array<te::Tensor> fn_inputs = lower_te_compute.fn_inputs_;
     VisitExpr(relay_func->body);
 
@@ -323,12 +323,11 @@ class ScheduleBuilder : public ExprVisitor {
     prim_fn_var->checked_type_ = relay_func->checked_type();
 
     // Fusion over tupled results may leave identity relationships
-    // between inputs and outputs, and those should not be scheduled.
-    // Hence schedule only non PlaceholderOp outputs.
-    tvm::Array<te::Tensor> tensor_outs;
-    for (const auto& tensor : outputs) {
-      if (!tensor->op.as<te::PlaceholderOpNode>()) {
-        tensor_outs.push_back(tensor);
+    // between inputs and outputs, copy identity output tensors,
+    // since tir lowering do not support aliasing output to input buffer.
+    for (size_t i = 0; i < tensor_outs.size(); ++i) {
+      if (tensor_outs[i]->op.as<te::PlaceholderOpNode>()) {
+        tensor_outs.Set(i, topi::identity(tensor_outs[i]));
       }
     }
 
@@ -363,12 +362,10 @@ class ScheduleBuilder : public ExprVisitor {
           ICHECK(anchor_impl != lower_te_compute.op_implementations_.end());
           schedule = anchor_impl->second.Schedule(anchor_attrs_, tensor_outs, target_);
         } else {
-          Array<te::Operation> op_outs;
-          for (size_t i = 0; i < outputs.size(); ++i) {
-            outputs.Set(i, topi::identity(outputs[i]));
-            op_outs.push_back(outputs[i]->op);
-          }
-          schedule = te::create_schedule(op_outs);
+          auto default_sched = GenericFunc::Get("schedule_injective");
+          ICHECK(default_sched.defined()) << "schedule_injective not registered for " << target_;
+          With<Target> tctx(target_);
+          schedule = default_sched(tensor_outs);
         }
       }
       if (schedule.defined()) {
@@ -380,7 +377,7 @@ class ScheduleBuilder : public ExprVisitor {
       }
     }
 
-    return CachedFunc(target_, prim_fn_var, fn_inputs, outputs, schedule, prim_func, {},
+    return CachedFunc(target_, prim_fn_var, fn_inputs, tensor_outs, schedule, prim_func, {},
                       IRModule(Map<GlobalVar, BaseFunc>({})), lower_te_compute.constant_tensors_);
   }
 

--- a/tests/python/relay/test_backend_graph_executor.py
+++ b/tests/python/relay/test_backend_graph_executor.py
@@ -300,17 +300,28 @@ def test_compile_return_empty_tuple():
     mod.run()
 
 
+@tvm.testing.uses_gpu
 def test_compile_fused_identity_cast():
+    # a fused function that would optimized to identity
     x = relay.var("x", shape=[16], dtype="float32")
     y = relay.cast(x, "float32")
-    func = relay.Function([x], y)
-    func = func.with_attr("Primitive", 1)
-    x_param = relay.var("xx", shape=[16], dtype="float32")
-    func = relay.Function([x_param], relay.Call(func, [x_param]))
-    mod = tvm.IRModule.from_expr(func)
-    graph, lib, _ = relay.build(mod, "llvm")
-    mod = graph_executor.create(graph, lib, device=tvm.cpu(0))
-    mod.run()
+    func1 = relay.Function([x], y).with_attr("Primitive", 1)
+
+    # a fused function with param pass-through
+    x = relay.var("x", shape=[16], dtype="float32")
+    y = relay.add(x, relay.const(3.14, "float32"))
+    func2 = relay.Function([x], relay.Tuple([x, y])).with_attr("Primitive", 1)
+
+    x_global = relay.var("xx", shape=[16], dtype="float32")
+    tup = func2(x_global)
+    y_global = func1(relay.TupleGetItem(tup, 0) + relay.TupleGetItem(tup, 1))
+
+    mod = tvm.IRModule.from_expr(relay.Function([x_global], y_global))
+    for target, device in tvm.testing.enabled_targets():
+        with tvm.transform.PassContext(opt_level=2):
+            graph, lib, _ = relay.build(mod, target=target)
+            executor = graph_executor.create(graph, lib, device=device)
+            executor.run()
 
 
 def test_graph_executor_nested_tuples():


### PR DESCRIPTION
Since users can manually build relay graph like useless cast and fuse before optimization, it is possible that the primitive function is identity when relay building process go into te compiler.
