### PR TITLE
[CI] Update all Docker Images to 20220505-060045-500703308

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,18 +45,18 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-04-30T10:10:58.528075
+// Generated at 2022-05-05T13:07:33.276898
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:v0.71'
-ci_gpu = 'tlcpack/ci-gpu:v0.87'
-ci_cpu = 'tlcpack/ci-cpu:v0.84'
-ci_wasm = 'tlcpack/ci-wasm:v0.73'
-ci_i386 = 'tlcpack/ci-i386:v0.77'
-ci_qemu = 'tlcpack/ci-qemu:v0.13'
-ci_arm = 'tlcpack/ci-arm:v0.10'
-ci_hexagon = 'tlcpack/ci-hexagon:v0.03'
+ci_lint = 'tlcpack/ci-lint:20220505-060045-500703308'
+ci_gpu = 'tlcpack/ci-gpu:20220505-060045-500703308'
+ci_cpu = 'tlcpack/ci-cpu:20220505-060045-500703308'
+ci_wasm = 'tlcpack/ci-wasm:20220505-060045-500703308'
+ci_i386 = 'tlcpack/ci-i386:20220505-060045-500703308'
+ci_qemu = 'tlcpack/ci-qemu:20220505-060045-500703308'
+ci_arm = 'tlcpack/ci-arm:20220505-060045-500703308'
+ci_hexagon = 'tlcpack/ci-hexagon:20220505-060045-500703308'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -51,14 +51,14 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 {% import 'jenkins/macros.j2' as m with context -%}
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:v0.71'
-ci_gpu = 'tlcpack/ci-gpu:v0.87'
-ci_cpu = 'tlcpack/ci-cpu:v0.84'
-ci_wasm = 'tlcpack/ci-wasm:v0.73'
-ci_i386 = 'tlcpack/ci-i386:v0.77'
-ci_qemu = 'tlcpack/ci-qemu:v0.13'
-ci_arm = 'tlcpack/ci-arm:v0.10'
-ci_hexagon = 'tlcpack/ci-hexagon:v0.03'
+ci_lint = 'tlcpack/ci-lint:20220505-060045-500703308'
+ci_gpu = 'tlcpack/ci-gpu:20220505-060045-500703308'
+ci_cpu = 'tlcpack/ci-cpu:20220505-060045-500703308'
+ci_wasm = 'tlcpack/ci-wasm:20220505-060045-500703308'
+ci_i386 = 'tlcpack/ci-i386:20220505-060045-500703308'
+ci_qemu = 'tlcpack/ci-qemu:20220505-060045-500703308'
+ci_arm = 'tlcpack/ci-arm:20220505-060045-500703308'
+ci_hexagon = 'tlcpack/ci-hexagon:20220505-060045-500703308'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images


### PR DESCRIPTION
This gives us GoogleTest for #11202 and blocklint for #11200 but most importantly it makes use of the new and improved tags from @leandron in https://github.com/apache/tvm-rfcs/pull/66

Closes #11202
Closes #11200

cc @areusch @driazati