### PR TITLE
[CMSIS-NN] Fix memory alignment bug in CMSIS-NN demo

### DIFF
--- a/apps/microtvm/cmsisnn/convert_image.py
+++ b/apps/microtvm/cmsisnn/convert_image.py
@@ -34,7 +34,7 @@ def create_header_file(name, tensor_name, tensor_data, output_path):
         header_file.write(
             "\n"
             + f"const size_t {tensor_name}_len = {tensor_data.size};\n"
-            + f'int8_t {tensor_name}[] = "'
+            + f'__attribute__((section(".data.tvm"), aligned(16))) int8_t {tensor_name}[] = "'
         )
 
         data_hexstr = tensor_data.tobytes().hex()


### PR DESCRIPTION
There is a latent bug in the CMSIS-NN demo app where the input and output tensors generated by the `create_image.py` script are not 16-byte aligned in memory. Although this does not cause an issue in the demo using the current `person_detect` model, if a different model is substituted with a larger output tensor, it causes the FVP to hang in certain cases.

This PR updates `create_image.py` to correct the issue.

@Mousius @ashutosh-arm @areusch 
