### PR TITLE
[LLVM] Make sure all functions have target-related attributes set

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -142,6 +142,7 @@ void CodeGenLLVM::AddFunctionInternal(const PrimFunc& f, bool ret_void) {
   }
   function_->setCallingConv(llvm::CallingConv::C);
   function_->setDLLStorageClass(llvm::GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
+  SetTargetAttributes(function_);
 
   // set var map and align information
   auto arg_it = function_->arg_begin();
@@ -179,11 +180,6 @@ void CodeGenLLVM::AddFunctionInternal(const PrimFunc& f, bool ret_void) {
     }
   }
 #endif
-
-  llvm::StringRef fs = target_machine_->getTargetFeatureString();
-  if (!fs.empty()) {
-    function_->addFnAttr("target-features", fs);
-  }
 
   if (ret_void) {
     builder_->CreateRetVoid();
@@ -895,6 +891,17 @@ llvm::Function* CodeGenLLVM::GetIntrinsicDecl(llvm::Intrinsic::ID id, llvm::Type
   }
   return llvm::Intrinsic::getDeclaration(module, id, overload_types);
 #endif  // TVM_LLVM_VERSION
+}
+
+void CodeGenLLVM::SetTargetAttributes(llvm::Function* func) {
+  llvm::StringRef cpu = target_machine_->getTargetCPU();
+  if (!cpu.empty()) {
+    func->addFnAttr("target-cpu", cpu);
+  }
+  llvm::StringRef features = target_machine_->getTargetFeatureString();
+  if (!features.empty()) {
+    func->addFnAttr("target-features", features);
+  }
 }
 
 llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -338,6 +338,13 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   llvm::Function* GetIntrinsicDecl(llvm::Intrinsic::ID id, llvm::Type* ret_type,
                                    llvm::ArrayRef<llvm::Type*> arg_types);
   /*!
+   * \brief Set target-related attributes on the LLVM function \p func. This
+   *        includes "target-cpu" and "target-features" if present.
+   *
+   * \param func The function to set attributes on.
+   */
+  void SetTargetAttributes(llvm::Function* func);
+  /*!
    * \brief Get the number of elements in the given vector value.
    * \param vec The value, must be of a vector type.
    */

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -932,5 +932,48 @@ def test_raise_exception_during_codegen():
     assert msg.find("Nested parallel loop is not supported") != -1
 
 
+@tvm.testing.requires_llvm
+def test_llvm_target_attributes():
+    """Check that when LLVM codegen creates new functions, they get the same target
+    attributes as the original function.
+    """
+    n = te.var()
+    A = te.placeholder((n,), name="A", dtype="float32")
+    B = te.compute((n,), lambda i: A[i], name="B")
+    C = te.compute((n,), lambda i: B[i] + tvm.tir.const(1, A.dtype), name="C")
+    s = te.create_schedule(C.op)
+    xo, xi = s[C].split(C.op.axis[0], nparts=2)
+    s[C].parallel(xo)
+
+    target_llvm = "llvm -mcpu=skylake -mattr=+avx512f"
+    target = tvm.target.Target(target_llvm, host=target_llvm)
+    module = tvm.build(s, [A, B, C, n], target=target, name="test_func")
+
+    llvm_ir = module.get_source()
+    llvm_ir_lines = llvm_ir.split("\n")
+
+    attribute_definitions = dict()
+    attributes_with_target = dict()
+    functions_with_target = []
+
+    for line in llvm_ir_lines:
+        func_def = re.match("define.* @(?P<func_name>[^(]*)\(.* #(?P<attr_num>[0-9]+) {$", line)
+        if func_def:
+            functions_with_target.append(func_def.group("func_name"))
+            attributes_with_target[func_def.group("attr_num")] = True
+            continue
+        attr_def = re.match("attributes #(?P<attr_num>[0-9]+) = {(?P<attr_list>.*)}", line)
+        if attr_def:
+            attribute_definitions[attr_def.group("attr_num")] = attr_def.group("attr_list")
+
+    for k in list(attributes_with_target.keys()):
+        assert re.match('.*"target-cpu"="skylake".*', attribute_definitions[k])
+        assert re.match('.*"target-features"=".*\+avx512f.*".*', attribute_definitions[k])
+
+    expected_functions = ["test_func", "test_func_compute_", "__tvm_parallel_lambda"]
+    for n in expected_functions:
+        assert n in functions_with_target
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
LLVM codegen create new function, e.g. the "_compute_" function for a compute_scope attribute, etc. These function did not have function attributes defining the target properties, specifically "target-cpu" or "target-features". Make sure this information is present on all functions created in CodeGenLLVM.