### PR TITLE
[ROOFLINE] Calculate roofline from existing TIR PrimFunc

### DIFF
--- a/src/auto_scheduler/feature.cc
+++ b/src/auto_scheduler/feature.cc
@@ -740,7 +740,7 @@ class PerStoreFeatureExtractor : public StmtExprVisitor {
     // TODO(tkonolige): add arithmetic counts from this statement to counts of inner stores.
     ana_.Bind(node->var, node->value);
     ICHECK(variable_definition_stack_.size() > 0)
-        << "Variable definition out size of a for loop is not handled by feature extraction";
+        << "Variable definition outside of a for loop is not handled by feature extraction";
     variable_definition_stack_.back().push_back(std::make_tuple(node->var, node->value));
     StmtExprVisitor::VisitStmt_(node);
   }


### PR DESCRIPTION
Refactor roofline_analysis to use a pass instrument to save TIR code from compilation for feature extraction. This should support different compilation pipelines and avoids recompiling the module twice.

@AndrewZhaoLuo @masahi @csullivan 