### PR TITLE
[tir] remove unused member variable

### DIFF
--- a/src/tir/transforms/legalize_packed_calls.cc
+++ b/src/tir/transforms/legalize_packed_calls.cc
@@ -111,8 +111,7 @@ class PackedCallLegalizer : public StmtExprMutator {
 
  private:
   IRModule mod_;
-  InputMap inputs_;      // Store the inputs to the primfunc that don't need to be packed.
-  int tvm_value_index_;  // Index of the actual tvm_value variable
+  InputMap inputs_;  // Store the inputs to the primfunc that don't need to be packed.
 };
 
 namespace transform {


### PR DESCRIPTION
Remove unused member variable
`tvm::tir::PackedCallLegalizer::tvm_value_index_`.
This also fixes a GCC 7.5 compiler warning.