### PR TITLE
[AUTOTVM] Log autotvm tuning errors

### DIFF
--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -149,6 +149,7 @@ class Tuner(object):
                     else:
                         errors.append(tb + "\n" + str(error))
                     result_msg = errors[-1]
+                    logger.debug("Encountered the following error in tuning:\n" + errors[-1])
 
                 if flops > self.best_flops:
                     self.best_flops = flops


### PR DESCRIPTION
Log errors that occur when building or running autotvm tuning jobs. Debug logging is used to not spam the loggers. Note that if the number of errors exceeds `error_ct_threshold` then debug logging is turned on and all these errors will be logged on the next outer iteration of the tuner. A large number of errors normally indicates something is wrong with the operator, and this will show what is going on.

@jwfromm @petersalas 