### PR TITLE
[ci] Enable sccache for clang in hexagon

### DIFF
--- a/docker/Dockerfile.ci_hexagon
+++ b/docker/Dockerfile.ci_hexagon
@@ -60,6 +60,7 @@ ENV PATH /opt/android-sdk-linux/platform-tools:$PATH
 COPY install/ubuntu_install_hexagon.sh /install/ubuntu_install_hexagon.sh
 RUN bash /install/ubuntu_install_hexagon.sh
 ENV CLANG_LLVM_HOME /opt/clang-llvm
+ENV PATH /opt/clang-llvm/bin:$PATH
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/opt/clang-llvm/lib
 ENV HEXAGON_TOOLCHAIN "${HEXAGON_SDK_PATH}/tools/HEXAGON_Tools/8.5.08/Tools"
 

--- a/docker/install/ubuntu_install_sccache.sh
+++ b/docker/install/ubuntu_install_sccache.sh
@@ -26,6 +26,8 @@ cargo install sccache
 mkdir /opt/sccache
 ln "$(which sccache)" /opt/sccache/cc
 ln "$(which sccache)" /opt/sccache/c++
+ln "$(which sccache)" /opt/sccache/clang
+ln "$(which sccache)" /opt/sccache/clang++
 
 # make rust usable by all users after install during container build
 chmod -R a+rw /opt/rust


### PR DESCRIPTION
This sets up a symlink to the `clang++` used in the hexagon build. In a follow up PR once the images are updated we can set the compiler to the symlink'ed clang

cc @Mousius @areusch @mehrdadh