### PR TITLE
[Hexagon] Fix running gtest on Hexagon hardware

### DIFF
--- a/tests/cpp-runtime/hexagon/run_all_tests.cc
+++ b/tests/cpp-runtime/hexagon/run_all_tests.cc
@@ -26,6 +26,14 @@
 
 #include "../src/support/utils.h"
 
+// Workaround for missing symbol in some QuRT builds
+#include "qurt.h"
+extern "C" {
+__attribute__((weak)) int pthread_key_delete(pthread_key_t key) {
+  return qurt_tls_delete_key((int)key);
+}
+}
+
 namespace tvm {
 namespace runtime {
 namespace hexagon {

--- a/tests/scripts/task_build_hexagon_api.sh
+++ b/tests/scripts/task_build_hexagon_api.sh
@@ -43,8 +43,7 @@ cmake -DANDROID_ABI=arm64-v8a \
     -DUSE_HEXAGON_ARCH=v68 \
     -DUSE_HEXAGON_SDK="${HEXAGON_SDK_PATH}" \
     -DUSE_HEXAGON_TOOLCHAIN="${HEXAGON_TOOLCHAIN}" \
-    -DUSE_OUTPUT_BINARY_DIR="${output_binary_directory}" ..
-    # TODO(hexagon-team): enable this once https://github.com/apache/tvm/issues/11237 is fixed.
-    # -DUSE_HEXAGON_GTEST="${HEXAGON_SDK_PATH}/utils/googletest/gtest" ..
+    -DUSE_OUTPUT_BINARY_DIR="${output_binary_directory}" \
+    -DUSE_HEXAGON_GTEST="${HEXAGON_SDK_PATH}/utils/googletest/gtest" ..
 
 make -j$(nproc)


### PR DESCRIPTION
It appears various QuRT images do not include the `pthread_key_delete` function. This fixes #11237 by providing an implementation of `pthread_key_delete`, calling the underlying QuRT API, if it's not already defined. `USE_HEXAGON_GTEST` is once again defined to enable running tests on hardware.

cc @mehrdadh