### PR TITLE
[ci] Bump i386 shards from 2 -> 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-05-09T16:19:42.885533
+// Generated at 2022-05-11T07:57:43.285598
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -727,10 +727,6 @@ stage('Test') {
                 ci_setup(ci_gpu)
                 cpp_unittest(ci_gpu)
                 sh (
-                  script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
-                  label: 'Run Java unit tests',
-                )
-                sh (
                   script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh",
                   label: 'Run Python GPU unit tests',
                 )
@@ -760,12 +756,8 @@ stage('Test') {
                 'PLATFORM=gpu',
                 'TVM_NUM_SHARDS=2',
                 'TVM_SHARD_INDEX=1'], {
-                unpack_lib('gpu2', tvm_multilib)
-                cpp_unittest(ci_gpu)
-
                 unpack_lib('gpu', tvm_multilib)
                 ci_setup(ci_gpu)
-                cpp_unittest(ci_gpu)
                 sh (
                   script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
                   label: 'Run Java unit tests',
@@ -873,7 +865,7 @@ stage('Test') {
       Utils.markStageSkippedForConditional('unittest: CPU')
     }
   },
-  'python: i386 1 of 2': {
+  'python: i386 1 of 3': {
     if (!skip_ci && is_docs_only_build != 1) {
       node('CPU') {
         ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/integration-python-i386") {
@@ -882,7 +874,7 @@ stage('Test') {
             timeout(time: max_time, unit: 'MINUTES') {
               withEnv([
                 'PLATFORM=i386',
-                'TVM_NUM_SHARDS=2',
+                'TVM_NUM_SHARDS=3',
                 'TVM_SHARD_INDEX=0'], {
                 unpack_lib('i386', tvm_multilib)
                 ci_setup(ci_i386)
@@ -901,10 +893,10 @@ stage('Test') {
         }
       }
     } else {
-      Utils.markStageSkippedForConditional('python: i386 1 of 2')
+      Utils.markStageSkippedForConditional('python: i386 1 of 3')
     }
   },
-  'python: i386 2 of 2': {
+  'python: i386 2 of 3': {
     if (!skip_ci && is_docs_only_build != 1) {
       node('CPU') {
         ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/integration-python-i386") {
@@ -913,11 +905,10 @@ stage('Test') {
             timeout(time: max_time, unit: 'MINUTES') {
               withEnv([
                 'PLATFORM=i386',
-                'TVM_NUM_SHARDS=2',
+                'TVM_NUM_SHARDS=3',
                 'TVM_SHARD_INDEX=1'], {
                 unpack_lib('i386', tvm_multilib)
                 ci_setup(ci_i386)
-                cpp_unittest(ci_i386)
                 python_unittest(ci_i386)
                 sh (
                   script: "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh",
@@ -932,7 +923,37 @@ stage('Test') {
         }
       }
     } else {
-      Utils.markStageSkippedForConditional('python: i386 2 of 2')
+      Utils.markStageSkippedForConditional('python: i386 2 of 3')
+    }
+  },
+  'python: i386 3 of 3': {
+    if (!skip_ci && is_docs_only_build != 1) {
+      node('CPU') {
+        ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/integration-python-i386") {
+          try {
+            init_git()
+            timeout(time: max_time, unit: 'MINUTES') {
+              withEnv([
+                'PLATFORM=i386',
+                'TVM_NUM_SHARDS=3',
+                'TVM_SHARD_INDEX=2'], {
+                unpack_lib('i386', tvm_multilib)
+                ci_setup(ci_i386)
+                python_unittest(ci_i386)
+                sh (
+                  script: "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh",
+                  label: 'Run i386 integration tests',
+                )
+                fsim_test(ci_i386)
+              })
+            }
+          } finally {
+            junit 'build/pytest-results/*.xml'
+          }
+        }
+      }
+    } else {
+      Utils.markStageSkippedForConditional('python: i386 3 of 3')
     }
   },
   'test: Hexagon 1 of 4': {
@@ -948,7 +969,7 @@ stage('Test') {
                 'TVM_SHARD_INDEX=0'], {
                 unpack_lib('hexagon', tvm_lib)
                 ci_setup(ci_hexagon)
-                  cpp_unittest(ci_hexagon)
+                cpp_unittest(ci_hexagon)
                 sh (
                   script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_build_hexagon_api.sh",
                   label: 'Build Hexagon API',

--- a/jenkins/Jenkinsfile.j2
+++ b/jenkins/Jenkinsfile.j2
@@ -626,23 +626,30 @@ stage('Test') {
     SKIP_SLOW_TESTS = "${skip_slow_tests}"
   }
   parallel(
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="unittest: GPU",
     num_shards=2,
     node="GPU",
     ws="tvm/ut-python-gpu",
     platform="gpu",
   ) %}
+    {% if shard_index == 1 %}
     unpack_lib('gpu2', tvm_multilib)
     cpp_unittest(ci_gpu)
 
     unpack_lib('gpu', tvm_multilib)
     ci_setup(ci_gpu)
     cpp_unittest(ci_gpu)
+    {% else %}
+    unpack_lib('gpu', tvm_multilib)
+    ci_setup(ci_gpu)
+    {% endif %}
+    {% if shard_index == 2 or num_shards < 2 %}
     sh (
       script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
       label: 'Run Java unit tests',
     )
+    {% endif %}
     sh (
       script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh",
       label: 'Run Python GPU unit tests',
@@ -652,7 +659,7 @@ stage('Test') {
       label: 'Run Python GPU integration tests',
     )
   {% endcall %}
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="integration: CPU",
     node="CPU",
       num_shards=2,
@@ -681,16 +688,18 @@ stage('Test') {
       label: 'Run VTA tests in TSIM',
     )
   {% endcall %}
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="python: i386",
     node="CPU",
-      num_shards=2,
+      num_shards=3,
       ws="tvm/integration-python-i386",
       platform="i386",
     ) %}
     unpack_lib('i386', tvm_multilib)
     ci_setup(ci_i386)
+    {% if shard_index == 1 %}
     cpp_unittest(ci_i386)
+    {% endif %}
     python_unittest(ci_i386)
     sh (
       script: "${docker_run} ${ci_i386} ./tests/scripts/task_python_integration_i386only.sh",
@@ -698,7 +707,7 @@ stage('Test') {
     )
     fsim_test(ci_i386)
   {% endcall %}
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="test: Hexagon",
     node="CPU", ws="tvm/test-hexagon",
     platform="hexagon",
@@ -707,7 +716,7 @@ stage('Test') {
     unpack_lib('hexagon', tvm_lib)
     ci_setup(ci_hexagon)
     {% if shard_index == 1 %}
-      cpp_unittest(ci_hexagon)
+    cpp_unittest(ci_hexagon)
     {% endif %}
     sh (
       script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_build_hexagon_api.sh",
@@ -754,7 +763,7 @@ stage('Test') {
       label: 'Run TOPI tests',
     )
   {% endcall %}
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="integration: aarch64",
     num_shards=2,
     node="ARM", ws="tvm/ut-python-arm",
@@ -768,7 +777,7 @@ stage('Test') {
       label: 'Run CPU integration tests',
     )
   {% endcall %}
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="topi: GPU",
     node="GPU",
     num_shards=2,
@@ -782,7 +791,7 @@ stage('Test') {
       label: 'Run TOPI tests',
     )
   {% endcall %}
-  {% call(shard_index) m.sharded_test_step(
+  {% call(shard_index, num_shards) m.sharded_test_step(
     name="frontend: GPU", node="GPU",
     num_shards=3,
     ws="tvm/frontend-python-gpu",

--- a/jenkins/macros.j2
+++ b/jenkins/macros.j2
@@ -32,7 +32,7 @@
                 'PLATFORM={{ platform }}',
                 'TVM_NUM_SHARDS={{ num_shards }}',
                 'TVM_SHARD_INDEX={{ shard_index - 1 }}'], {
-                {{ caller(shard_index) | trim | indent(width=12) }}
+                {{ caller(shard_index, num_shards) | trim | indent(width=12) }}
               })
             }
           } finally {


### PR DESCRIPTION
i386 is the longest running test step by a small margin and run dangerously close to the 2hr timeout.

<img width="486" alt="image" src="https://user-images.githubusercontent.com/9407960/167732633-3718c7b7-ef1b-4825-9664-d7619c9c69fd.png">


This also only runs the C++/Java tests on a single shard so we don't end up wasting compute minutes running the same tests twice


cc @Mousius @areusch