### PR TITLE
[skip ci][wasm][ci] Fix WASM build and JS doc build

### DIFF
--- a/tests/scripts/task_web_wasm.sh
+++ b/tests/scripts/task_web_wasm.sh
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
+set -euxo pipefail
 
 export PYTHONPATH=`pwd`/python
 

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,8 +6,9 @@
 		"rootDir": "src",
 		"declaration": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"skipLibCheck": true,
 	},
     "include": ["src"],
-    "exclude": ["node_modules"]
+    "exclude": ["**/node_modules/**"]
 }

--- a/web/typedoc.json
+++ b/web/typedoc.json
@@ -7,5 +7,5 @@
     "listInvalidSymbolLinks": true,
     "module": "umd",
     "includes": ["src"],
-    "exclude": ["node_modules"]
+    "exclude": ["**/node_modules/**"]
 }


### PR DESCRIPTION
Fixes #11300. Tested locally via

```bash
python tests/scripts/ci.py wasm -i
bash tests/scripts/task_web_wasm.sh
```
and

```
python tests/scripts/ci.py docs -i
cd web
npm install
npm run typedoc
```

cc @Mousius @areusch