### PR TITLE
[ci][docker] Conditionally link sccache to clang

### DIFF
--- a/docker/install/ubuntu_install_sccache.sh
+++ b/docker/install/ubuntu_install_sccache.sh
@@ -26,8 +26,14 @@ cargo install sccache
 mkdir /opt/sccache
 ln "$(which sccache)" /opt/sccache/cc
 ln "$(which sccache)" /opt/sccache/c++
-ln "$(which sccache)" /opt/sccache/clang
-ln "$(which sccache)" /opt/sccache/clang++
+
+# Only add clang if it's on the PATH
+if command -v clang &> /dev/null
+then
+    ln "$(which sccache)" /opt/sccache/clang
+    ln "$(which sccache)" /opt/sccache/clang++
+fi
+
 
 # make rust usable by all users after install during container build
 chmod -R a+rw /opt/rust


### PR DESCRIPTION
This was causing errors with #11314 since it was making it appear as if `clang` was available when it was only the sccache wrapper.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @Mousius @areusch