### PR TITLE
[DRAFT][LLVM] Introduce RAII config option to config LLVM global config

### DIFF
--- a/src/target/llvm/llvm_common.cc
+++ b/src/target/llvm/llvm_common.cc
@@ -196,6 +196,18 @@ void PrintModule(const llvm::Module* mod) {
   LOG(INFO) << rso.str();
 }
 
+// Testing CLI option
+void LLVMIntOptTest(std::string name, int value) {
+  int old_value = *LLVMCLOption<int>::GetRegistered(name);
+  {
+    With<LLVMCLOption<int>> scope(name, value);
+    ICHECK_EQ(*LLVMCLOption<int>::GetRegistered(name), value);
+  }
+  ICHECK_EQ(*LLVMCLOption<int>::GetRegistered(name), old_value);
+}
+
+TVM_REGISTER_GLOBAL("testing.llvm_opt_int_test").set_body_typed(LLVMIntOptTest);
+
 }  // namespace codegen
 }  // namespace tvm
 #endif  // TVM_LLVM_VERSION

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -975,5 +975,11 @@ def test_llvm_target_attributes():
         assert n in functions_with_target
 
 
+@tvm.testing.requires_llvm
+def test_llvm_cli_int_opt():
+    tvm.testing._ffi_api.llvm_opt_int_test("unroll-max-count", 2)
+    tvm.testing._ffi_api.llvm_opt_int_test("unroll-max-count", 3)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
LLVM comes with global cli configurations which can persist through
out the process. Direct setting these parameters can affect future LLVM codegens.

While an ideal approach is to config compilation pipeline in a way that is
independent of such global configs, it is hard to do so given the state of LLVM project itself and its passes are being configed.

To work around this problem. This PR introduced a helper scope
to set these configurations in RAII style and recover the settings
after the scope ends.