### PR TITLE
[TVMScript] Support inlined function call as a sugar

### DIFF
--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -552,7 +552,8 @@ class TVMScriptParser(Transformer):
             3. (Store)       Var[PrimExpr] = PrimExpr
             4. with scope handlers with concise scoping and var def
                 4.1 var = T.allocate()
-            5. A call to a pure python function, consuming and producing TVMScript values
+            5. A call to a pure python function, consuming and producing TVMScript values.
+               The outputs are inlined into the following body (no variable is created).
                x, y = f(...)
         """
 

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -552,7 +552,7 @@ class TVMScriptParser(Transformer):
             3. (Store)       Var[PrimExpr] = PrimExpr
             4. with scope handlers with concise scoping and var def
                 4.1 var = T.allocate()
-            5. An invocation of an arbitrary python callable
+            5. A call to a pure python function, consuming and producing TVMScript values
                x, y = f(...)
         """
 

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -630,7 +630,7 @@ class TVMScriptParser(Transformer):
             return tvm.tir.LetStmt(var, value, body, span=tvm_span_from_synr(node.span))
 
         self.report_error(
-            """Assignments should be either
+            """Assignments should be one of:
             1. A "special statement" with return value
                 1.1 Buffer = T.match_buffer()/T.buffer_decl()
                 1.2 Var = T.var()
@@ -638,7 +638,10 @@ class TVMScriptParser(Transformer):
             2. A store into a buffer: Buffer[PrimExpr, PrimExpr, ..., PrimExpr] = PrimExpr
             3. A store into a variable: Var[PrimExpr] = PrimExpr
             4. A with scope handler with concise scoping and var def
-                4.1 var = T.allocate()""",
+                4.1 var = T.allocate()
+            5. The right-hand side being a call to a pure python function, consuming and
+               producing TVMScript values.
+               x, y = f(...)""",
             node.span,
         )
 

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -20,7 +20,7 @@ We use [synr](https://synr.readthedocs.io) to get an AST that is stable over
 different python versions. Synr also provides an error handling context that we
 use for error reporting.
 """
-# pylint: disable=invalid-name, inconsistent-return-statements, no-else-return
+# pylint: disable=invalid-name, inconsistent-return-statements, no-else-return, broad-except
 import types
 import json
 import operator

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -584,7 +584,16 @@ class TVMScriptParser(Transformer):
             elif isinstance(func, types.FunctionType):
                 # Pattern 5
                 args = [self.transform(arg) for arg in node.rhs.params]
-                out = func(*args)
+                try:
+                    out = func(*args)
+                except Exception as e:
+                    self.report_error(
+                        "Error occured when invoking the function "
+                        + func.__name__
+                        + ": \n"
+                        + str(e),
+                        node.rhs.span,
+                    )
 
                 if len(node.lhs) == 1 and not isinstance(out, list):
                     out = [out]

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -591,7 +591,7 @@ class TVMScriptParser(Transformer):
                 body = self.parse_body(node)
 
                 for var, value in zip(node.lhs, out):
-                    self.context.remove_symbol(var.name)
+                    self.context.remove_symbol(var.id.name)
 
                 return body
 

--- a/python/tvm/script/parser.py
+++ b/python/tvm/script/parser.py
@@ -21,6 +21,7 @@ different python versions. Synr also provides an error handling context that we
 use for error reporting.
 """
 # pylint: disable=invalid-name, inconsistent-return-statements, no-else-return
+import types
 import json
 import operator
 import inspect
@@ -580,10 +581,14 @@ class TVMScriptParser(Transformer):
                 arg_list = self.parse_arg_list(func, node.rhs)
                 func.handle(node, self.context, arg_list, node.rhs.func_name.span)
                 return self.parse_body(node)
-            elif callable(func):
+            elif isinstance(func, types.FunctionType):
                 # Pattern 5
                 args = [self.transform(arg) for arg in node.rhs.params]
                 out = func(*args)
+
+                if len(node.lhs) == 1 and not isinstance(out, list):
+                    out = [out]
+
                 assert len(out) == len(node.lhs)
 
                 for var, value in zip(node.lhs, out):

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -323,6 +323,28 @@ def test_func_call():
 
     assert_structural_equal(mma_sync_m16n16k16_desc, mma_sync_m16n16k16_desc_manual)
 
+    # The following is an example of an error message from calling an invalid function
+
+    # error: Error occured when invoking the function sqrt:
+    # loop of ufunc does not support argument 0 of type Var which has no callable sqrt method
+    #  --> test_tvmscript_syntax_sugar.py:334:19
+    #      |
+    #  334 |              ind = sqrt(i)
+    #      |                    ^^^^^^^
+    # note: run with `TVM_BACKTRACE=1` environment variable to display a backtrace.
+
+    # Uncomment to see the error above.
+    # def sqrt(x):
+    #     import numpy as np
+    #     return np.sqrt(x)
+
+    # @T.prim_func
+    # def loop(a: T.handle) -> None:
+    #     A = T.match_buffer(a, (128,))
+    #     for i in T.serial(128):
+    #         ind = sqrt(i)
+    #         A[i] = A[ind]
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -265,5 +265,36 @@ def test_letstmt_bind_with_constant():
     assert_structural_equal(constant_binds, constant_binds_wrapped)
 
 
+def test():
+    def shared_16x16_to_ldmatrix_32x8_layout(i, j):
+        thread_id = 4 * (i % 8) + (j % 8) // 2
+        return thread_id, 4 * (j // 8) + (i // 8) * 2 + (j % 2)
+
+    @T.prim_func
+    def mma_sync_m16n16k16desc(a: T.handle, b: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(a, (32, 8), "float16", align=128, offset_factor=16, scope="warp")
+        B = T.match_buffer(b, (32, 8), "float16", align=128, offset_factor=16, scope="warp")
+        C = T.match_buffer(c, (32, 8), "float16", align=128, offset_factor=16, scope="warp")
+
+        with T.block("root"):
+            T.reads(C[0:32, 0:8], A[0:32, 0:8], B[0:32, 0:8])
+            T.writes(C[0:32, 0:8])
+            for i, j, k in T.grid(16, 16, 16):
+                with T.block("C"):
+                    i, j, k = T.axis.remap("SSR", [i, j, k])
+                    thread_id_C, local_id_C = shared_16x16_to_ldmatrix_32x8_layout(i, j)
+                    thread_id_A, local_id_A = shared_16x16_to_ldmatrix_32x8_layout(i, k)
+                    thread_id_B, local_id_B = shared_16x16_to_ldmatrix_32x8_layout(k, j)
+
+                    T.reads(
+                        C[thread_id_C, local_id_C],
+                        A[thread_id_A, local_id_A],
+                        B[thread_id_B, local_id_B],
+                    )
+                    T.writes(C[thread_id_C, local_id_C])
+
+                    C[thread_id_C, local_id_C] += A[thread_id_A, local_id_A] * B[thread_id_B, local_id_B]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
I came across a use case where being able to call a python function as a sugar to construct AST fragments is extremely handy. 

The attached test case illustrates two ways of describing the same TVMScript function, one of which is using the proposed syntax sugar. Here, the called function does some complicated index transformation - Calling a function to construct such mapping, rather than spelling them out by hand, significantly cleans up the TVMScript description.

Moreover, since the index map is just a normal python function, it can also be used in the layout transformation primitive in a schedule:  

```
def index_map(i, j):
   # The same index map shared between TVMScript and Python schedule
    return (i // 16, j // 16, *shared_16x16_to_ldmatrix_32x8_layout(i % 16, j % 16) ) 

sch.transform_layout(C_warp, 0, "read", index_map)
```

This way, we can be sure that tensorize pattern matching will not fail, since the intrinsic description (written in TVMScript) and the schedule are using exactly the same index map. Without this capability, we need to keep the index map used in a schedule and its explicit description in TVMScript always in sync manually. 

Note:
* The outputs of the called function are inlined into the following body, i.e. no variable or let binding is created.
* The called function cannot be arbitrary - it must be a "pure" function consuming and producing TIR expressions. In particular, I don't think we can (or should) construct TIR stmt with this approach. Besides index transformation, describing various activations could be a good use case. 

@Hzfengsy @spectrometerHBH @vinx13 @junrushao1994 @Lunderberg @csullivan             