### PR TITLE
Fix array pointers releasing with `delete` operator

### DIFF
--- a/src/contrib/tf_op/tvm_dso_op_kernels.cc
+++ b/src/contrib/tf_op/tvm_dso_op_kernels.cc
@@ -207,7 +207,7 @@ class TVMDSOOpTrait<GPUDevice> {
     tensorflow::int64* dims = new tensorflow::int64[num_dims];
     cudaMemcpy(dims, flat, sizeof(tensorflow::int64) * num_dims, cudaMemcpyDeviceToHost);
     tensorflow::TensorShapeUtils::MakeShape(dims, num_dims, output_shape);
-    delete dims;
+    delete[] dims;
   }
 };
 #endif

--- a/src/target/metadata.h
+++ b/src/target/metadata.h
@@ -134,11 +134,11 @@ class InMemoryMetadataNode : public ::tvm::target::metadata::VisitableMetadataNo
   }
 
  private:
-  ::std::unique_ptr<struct TVMTensorInfo> inputs_;
+  ::std::unique_ptr<struct TVMTensorInfo[]> inputs_;
   std::vector<::tvm::runtime::metadata::TensorInfo> inputs_objs_;
-  ::std::unique_ptr<struct TVMTensorInfo> outputs_;
+  ::std::unique_ptr<struct TVMTensorInfo[]> outputs_;
   std::vector<::tvm::runtime::metadata::TensorInfo> outputs_objs_;
-  ::std::unique_ptr<struct TVMTensorInfo> pools_;
+  ::std::unique_ptr<struct TVMTensorInfo[]> pools_;
   std::vector<::tvm::runtime::metadata::TensorInfo> pools_objs_;
   ::std::string mod_name_;
   struct ::TVMMetadata storage_;
@@ -186,7 +186,7 @@ class InMemoryTensorInfoNode : public ::tvm::target::metadata::VisitableTensorIn
 
  private:
   ::std::string name_;
-  ::std::unique_ptr<int64_t> shape_;
+  ::std::unique_ptr<int64_t[]> shape_;
   struct ::TVMTensorInfo storage_;
 };
 


### PR DESCRIPTION
It may be safe to release POD-types array with `delete`
operator, but `delete[]` is always better.