### PR TITLE
[TIR] Simplify indices in layout transform

### DIFF
--- a/tests/python/unittest/test_tir_schedule_transform_layout.py
+++ b/tests/python/unittest/test_tir_schedule_transform_layout.py
@@ -118,5 +118,45 @@ def test_two_elementwise_transform_output_buffer():
     verify_trace_roundtrip(sch=sch, mod=two_elementwise)
 
 
+def test_simplify():
+    sch = tir.Schedule(two_elementwise, debug_mask="all")
+
+    i, j = sch.get_loops(sch.get_block("C"))
+    i, i_inner = sch.split(i, factors=[None, 16])
+    j, j_inner = sch.split(j, factors=[None, 16])
+
+    sch.reorder(
+        i,
+        j,
+        i_inner,
+        j_inner,
+    )
+
+    block_outer = sch.blockize(i_inner)
+
+    B = sch.cache_read(block_outer, 0, "global")
+    sch.transform_layout(B, 0, "write", lambda i, j: (i // 16, j // 16, i % 16, j % 16))
+
+    @T.prim_func
+    def ref(B: T.Buffer[(8, 8, 16, 16), "float32"], C: T.Buffer[(128, 128), "float32"]):
+        for i_0, j_0 in T.grid(8, 8):
+            with T.block("C_o"):
+                vi_o, vj_o = T.axis.remap("SS", [i_0, j_0])
+                T.reads(B[vi_o, vj_o, 0:16, 0:16])
+                T.writes(C[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                for i_1, j_1 in T.grid(16, 16):
+                    with T.block("C"):
+                        vi, vj = T.axis.remap("SS", [i_1, j_1])
+                        T.reads(B[vi_o, vj_o, vi, vj])
+                        T.writes(C[vi_o * 16 + vi, vj_o * 16 + vj])
+                        C[vi_o * 16 + vi, vj_o * 16 + vj] = B[vi_o, vj_o, vi, vj] + T.float32(1)
+
+                        # Without simplification
+                        # T.reads(B[vi // 16 + vi_o, vj // 16 + vj_o, vi % 16, vj % 16])
+                        # C[...] = B[vi // 16 + vi_o, vj // 16 + vj_o, vi % 16, vj % 16] + T.float32(1)
+
+    tvm.ir.assert_structural_equal(ref.body.block.body, sch.get(sch.get_loops(block_outer)[0]))
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__] + sys.argv[1:]))


### PR DESCRIPTION
Without this, a sequence of `blockize -> transform_layout -> tensorize` would likely lead to a tensorize pattern match failure, since there is no simplification done between ` transform_layout -> tensorize` but intrinsic descriptions are always written without taking extra factors like `% 16` into account.  

Co-authored-by: Yuanjing Shi <yuanjing@octoml.ai>

@vinx13 @shingjan 
