### PR TITLE
Fix eltwise alter op layout for broadcast axis

### DIFF
--- a/src/relay/transforms/infer_layout_utils.cc
+++ b/src/relay/transforms/infer_layout_utils.cc
@@ -64,7 +64,8 @@ Layout AdjustSubordinateFactors(const Layout& src_layout, const Layout& old_layo
 
         // 4) a) Check if this shape element is 1.
         if (auto* shape_int = shape_val.as<IntImmNode>()) {
-          if (shape_int->value == 1) {
+          // We can treat 1 as broadcast only if axis was not split before
+          if (shape_int->value == 1 && old_layout.IndexOf(LayoutAxis::Get(axis)) == -1) {
             new_layout += "1";
             is_shape_one = true;
           }


### PR DESCRIPTION
The issue appeared after implementation of handling broadcast axis on dependent eltwise operators in alter op layout.
The pattern that I had `conv->add` and it happened that the block size was equal to the number of output channels. In one moment during network compilation we got a situation when we have already blocked layout and alter_op_layout is called one more time. During this second invocation the part dedicated for determination of the layout for second input of `add` detects `1` unconditionally as broadcast axis and puts wrong `layout_transform(->NCHW1c)`. This is wrong. In our case 1 was a reminder. Need to take into account block part as well in such cases.

I believe test `test_alter_layout_blocked_no_broadcast` shows situation clearly. The second test `test_alter_layout_re_blocking_broadcast` is not required on 100% but let's have it as well - it reproduce scenario of re-blocking of axises and verifies that our algos are correct.

+@lazycal