### PR TITLE
Improve error messages with TVM_LOG_DEBUG and add docs

### DIFF
--- a/docs/dev/how_to/debugging_tvm.rst
+++ b/docs/dev/how_to/debugging_tvm.rst
@@ -1,0 +1,72 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _debugging-tvm:
+
+Debuggging TVM
+==============
+
+**NOTE**: This page is a work in-progress. Everyone is welcomed to add suggestions and tips via
+sending a PR to modify this page. The goal with this page is to centralize the commonly-used
+techniques being used to debug TVM and to spread awareness to the community. To that end, we may
+seek to promote more broadly-used techniques to the top of this doc.
+
+VLOGging
+--------
+
+TVM provides a verbose-logging facility that allows you to commit trace-level debugging messages
+without impacting the binary size or runtime of TVM in production. You can use VLOG in your code
+as follows:
+
+.. code-block:: c++
+
+    void Foo(const std::string& bar) {
+      VLOG(2) << "Running Foo(" << bar << ")";
+      // ...
+    }
+
+In this example, the integer ``2`` passed to ``VLOG()`` indicates a verbosity level. The higher the
+level, the more logs printed. In general, TVM levels range from 0 to 2, with 3 being used only for
+extremely low-level core runtime properties. The VLOG system is configured at startup time to print
+VLOG statements between ``0`` and some integer ``N``. ``N`` can be set per-file or globally.
+
+VLOGs don't print or impact binary size or runtime by default (when compiled with proper
+optimization). To enable VLOGging, do the following:
+
+1. In ``config/cmake``, ensure you ``set(USE_RELAY_DEBUG ON)``. This flag is used to enable
+   VLOGging.
+2. Launch Python passing ``TVM_LOG_DEBUG=<spec>``, where ``<spec>>`` is a comma-separated list of
+   level assignments of the form ``<file_name>=<level>``. Here are some specializations:
+
+    - The special filename ``DEFAULT`` sets the VLOG level setting for all files.
+    - ``<level>>`` can be set to ``-1`` to disable VLOG in that file.
+    - ``<file_name>`` is the name of the c++ source file (e.g. ``.cc``, not ``.h``) relative to the
+      ``src/`` directory in the TVM repo. You do not need to supply ``src/`` when specifying the
+      file path, but if you do, VLOG will still interpret the path correctly.
+
+Examples:
+
+.. code-block: shell
+
+   # enable VLOG(0), VLOG(1), VLOG(2) in all files.
+   $ TVM_LOG_DEBUG=DEFAULT=2 python3 -c 'import tvm'
+
+   # enable VLOG(0), VLOG(1), VLOG(2) in all files, except not VLOG(2) in src/bar/baz.cc.
+   $ TVM_LOG_DEBUG=DEFAULT=2,bar/baz.cc=1 python3 -c 'import tvm'
+
+   # enable VLOG(0), VLOG(1), VLOG(2) in all files, except not in src/foo/bar.cc.
+   $ TVM_LOG_DEBUG=DEFAULT=2,src/foo/bar.cc=-1 python3 -c 'import tvm'

--- a/docs/dev/how_to/how_to.rst
+++ b/docs/dev/how_to/how_to.rst
@@ -25,6 +25,7 @@ various areas of the TVM stack.
 .. toctree::
    :maxdepth: 1
 
+   debugging_tvm
    relay_add_op
    relay_add_pass
    relay_bring_your_own_codegen

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -197,6 +197,12 @@ std::string FileToVLogMapKey(const std::string& filename) {
   // Canonicalize the filename.
   // TODO(mbs): Not Windows friendly.
   size_t last_src = filename.rfind(kSrcPrefix, std::string::npos, kSrcPrefixLength);
+  if (last_src == std::string::npos) {
+    std::string no_slash_src{kSrcPrefix + 1};
+    if (filename.substr(0, no_slash_src.size()) == no_slash_src) {
+      return filename.substr(no_slash_src.size());
+    }
+  }
   // Strip anything before the /src/ prefix, on the assumption that will yield the
   // TVM project relative filename. If no such prefix fallback to filename without
   // canonicalization.

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -222,6 +222,15 @@ TvmLogDebugSettings TvmLogDebugSettings::ParseSpec(const char* opt_spec) {
     return settings;
   }
   std::istringstream spec_stream(spec);
+  auto tell_pos = [&](const std::string& last_read) {
+    int pos = spec_stream.tellg();
+    if (pos == -1) {
+      LOG(INFO) << "override pos: " << last_read;
+      // when pos == -1, failbit was set due to std::getline reaching EOF without seeing delimiter.
+      pos = spec.size() - last_read.size();
+    }
+    return pos;
+  };
   while (spec_stream) {
     std::string name;
     if (!std::getline(spec_stream, name, '=')) {
@@ -229,7 +238,7 @@ TvmLogDebugSettings TvmLogDebugSettings::ParseSpec(const char* opt_spec) {
       break;
     }
     if (name.empty()) {
-      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed, empty name";
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(name) << ": empty filename";
       return settings;
     }
 
@@ -237,18 +246,21 @@ TvmLogDebugSettings TvmLogDebugSettings::ParseSpec(const char* opt_spec) {
 
     std::string level;
     if (!std::getline(spec_stream, level, ',')) {
-      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed, expecting level";
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(level)
+                 << ": expecting \"=<level>\" after \"" << name << "\"";
       return settings;
     }
     if (level.empty()) {
-      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed, empty level";
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(level)
+                 << ": empty level after \"" << name << "\"";
       return settings;
     }
     // Parse level, default to 0 if ill-formed which we don't detect.
     char* end_of_level = nullptr;
     int level_val = static_cast<int>(strtol(level.c_str(), &end_of_level, 10));
     if (end_of_level != level.c_str() + level.size()) {
-      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed, invalid level";
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(level)
+                 << ": invalid level: \"" << level << "\"";
       return settings;
     }
     LOG(INFO) << "TVM_LOG_DEBUG enables VLOG statements in '" << name << "' up to level " << level;

--- a/tests/cpp/runtime/logging_test.cc
+++ b/tests/cpp/runtime/logging_test.cc
@@ -86,11 +86,14 @@ TEST(TvmLogDebugSettings, IllFormed) {
 
 TEST(TvmLogDebugSettings, SpecPrefix) {
   TvmLogDebugSettings settings = TvmLogDebugSettings::ParseSpec(
-      "../src/foo/bar.cc=3,src/baz.cc=-1,foo/bar/src/another/file.cc=4");
+      "../src/foo/bar.cc=3,src/baz.cc=3,foo/bar/src/another/file.cc=4");
   EXPECT_TRUE(settings.dlog_enabled());
   EXPECT_TRUE(settings.VerboseEnabled("my/filesystem/src/foo/bar.cc", 3));
-  EXPECT_FALSE(settings.VerboseEnabled("my/filesystem/src/baz.cc", 0));
+  EXPECT_TRUE(settings.VerboseEnabled("foo/bar.cc", 3));
+  EXPECT_TRUE(settings.VerboseEnabled("my/filesystem/src/baz.cc", 3));
+  EXPECT_TRUE(settings.VerboseEnabled("baz.cc", 3));
   EXPECT_TRUE(settings.VerboseEnabled("my/filesystem/src/another/file.cc", 4));
+  EXPECT_TRUE(settings.VerboseEnabled("another/file.cc", 4));
 }
 
 }  // namespace

--- a/tests/cpp/runtime/logging_test.cc
+++ b/tests/cpp/runtime/logging_test.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <tvm/runtime/logging.h>
 
@@ -60,8 +61,27 @@ TEST(TvmLogDebugSettings, VLogEnabledComplex) {
   EXPECT_FALSE(settings.VerboseEnabled("my/filesystem/src/baz.cc", 0));
 }
 
+#define MATCH_THROW(stmt, err_type, matcher)            \
+  try {                                                 \
+    stmt;                                               \
+  } catch (const err_type& e) {                         \
+    EXPECT_THAT(e.what(), matcher);                     \
+  } catch (...) {                                       \
+    EXPECT_FALSE("stmt threw an unexpected exception"); \
+  }
+
 TEST(TvmLogDebugSettings, IllFormed) {
-  EXPECT_THROW(TvmLogDebugSettings::ParseSpec("foo/bar.cc=bogus;"), InternalError);
+  MATCH_THROW(
+      TvmLogDebugSettings::ParseSpec("foo/bar.cc=bogus;"), InternalError,
+      ::testing::HasSubstr("TVM_LOG_DEBUG ill-formed at position 11: invalid level: \"bogus;\""));
+
+  MATCH_THROW(TvmLogDebugSettings::ParseSpec("DEFAULT=2;bar/baz.cc=2"), InternalError,
+              ::testing::HasSubstr(
+                  "TVM_LOG_DEBUG ill-formed at position 8: invalid level: \"2;bar/baz.cc=2\""));
+
+  MATCH_THROW(TvmLogDebugSettings::ParseSpec("DEFAULT=2,bar/baz.cc+2"), InternalError,
+              ::testing::HasSubstr("TVM_LOG_DEBUG ill-formed at position 22: expecting "
+                                   "\"=<level>\" after \"bar/baz.cc+2\""));
 }
 
 TEST(TvmLogDebugSettings, SpecPrefix) {


### PR DESCRIPTION
This PR makes it easier to use TVM_LOG_DEBUG and documents it underneath Developer How-To.

@mbs-octoml