### PR TITLE
[skip ci][ci][docker] Pin Pillow version

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -30,7 +30,7 @@ pip3 install --upgrade \
     numpy~=1.19.5 \
     orderedset \
     packaging \
-    Pillow \
+    Pillow==9.1.0 \
     psutil \
     pytest \
     tlcpack-sphinx-addon==0.2.1 \


### PR DESCRIPTION
A recent release depends on some things we don't have installed, so don't use it.

e.g. https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11319/5/pipeline/

Skipped CI to unblock other docker PRs, successful run: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11348/1/pipeline


cc @Mousius @areusch