### PR TITLE
[bug fix] skip "__nop" functions in graph_executor_debug

### DIFF
--- a/src/runtime/graph_executor/debug/graph_executor_debug.cc
+++ b/src/runtime/graph_executor/debug/graph_executor_debug.cc
@@ -140,6 +140,11 @@ class GraphExecutorDebug : public GraphExecutor {
       return 0;
     }
 
+    if (nodes_[index].param.func_name == "__nop") {
+      LOG_INFO << "Skipping __nop function";
+      return 0;
+    }
+
     const Device& dev = data_entry_[entry_id(index, 0)]->device;
     TVMOpParam param = nodes_[index].param;
     std::string name = param.func_name;


### PR DESCRIPTION
checks the function name in graph_executor_debug and skips the "__nop" functions. 