### PR TITLE
[Virtual Machine] Implementation of 'set_output_zero_copy'

### DIFF
--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -282,6 +282,13 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   void SetOneInput(std::string name, const TVMArgValue& tag, const TVMArgValue& tensor);
 
   /*!
+   * \brief Set pre-allocated outputs to a function.
+   * \param name The function name
+   * \param args outputs to the function.
+   */
+  void SetOutputs(std::string name, TVMArgs args);
+
+  /*!
    * \brief Internal hook for profiling the start of an op.
    *
    * This hook is only called on certain ops that are likely to take a
@@ -356,6 +363,9 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   ObjectPtr<Executable> exec_;
   /*! \brief The function name to inputs mapping. */
   std::unordered_map<std::string, std::vector<ObjectRef>> inputs_;
+  bool set_outputs_enabled_ = false;
+  /*! \brief The function name to pre-allocated outputs mapping. */
+  std::unordered_map<std::string, std::vector<ObjectRef>> outputs_;
   /*!
    * \brief The "physical" devices the VM can execute primitives on. All "device indexes"
    * are w.r.t. this vector. Each entry in this vector must match the corresponding entry

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -233,8 +233,7 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
    * \param output_args The pre-allocated output arguments of the function.
    * \return The object(s) representing the result.
    */
-  ObjectRef Invoke(const VMFunction& func,
-                   const std::vector<ObjectRef>& input_args,
+  ObjectRef Invoke(const VMFunction& func, const std::vector<ObjectRef>& input_args,
                    const std::vector<ObjectRef>& output_args);
 
   /*!
@@ -311,7 +310,8 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
    * \param func_name The function's name.
    * \param outputs set of output tensors.
    */
-  void SetOutputTensorsToRegister(const std::string& func_name, const std::vector<ObjectRef>& outputs);
+  void SetOutputTensorsToRegister(const std::string& func_name,
+                                  const std::vector<ObjectRef>& outputs);
 
   /*!
    * \brief Internal hook for profiling the start of an op.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -300,6 +300,13 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   void SetOutputs(std::string name, TVMArgs args);
 
   /*!
+   * \brief Preparation part of Invoke method before RunLoop.
+   * \param func the function.
+   * \param args input args
+   */
+  void PrintInfoAndSetInputArgs(const VMFunction& func, const std::vector<ObjectRef>& args);
+
+  /*!
    * \brief Set pre-allocated outputs to register for specified function.
    * \param outputs set of output tensors.
    */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -292,9 +292,11 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   void SetOneInput(std::string name, const TVMArgValue& tag, const TVMArgValue& tensor);
 
   /*!
-   * \brief Set pre-allocated outputs to a function.
+   * \brief Set pre-allocated output tensors to a function.
    * It is native implementation of 'set_outputs' python method.
-   * It is used in scenario when output tensors are allocated outside.
+   * It is used in scenario when output tensors are allocated outside each invocation.
+   * Note: it sets set_outputs_enabled_[name] true and fill outputs_[name]
+   * but after invocation the first is switched off and the second is cleared
    * \param name The function name
    * \param args outputs to the function.
    */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -308,9 +308,10 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
 
   /*!
    * \brief Set pre-allocated outputs to register for specified function.
+   * \param func_name The function's name.
    * \param outputs set of output tensors.
    */
-  void SetOutputTensorsToRegister(const std::vector<ObjectRef>& outputs);
+  void SetOutputTensorsToRegister(const std::string& func_name, const std::vector<ObjectRef>& outputs);
 
   /*!
    * \brief Internal hook for profiling the start of an op.
@@ -385,8 +386,16 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   Index GetResultRegisterIndex() const;
 
   /*!
-   * \brief Write new allocated tensor to register_file of frame
-   * \param instr current instruction containing shape and storage info
+   * \brief Collect indices from register_file for output tensors.
+   * It helps to replace output tensors allocated in RunLoop by
+   * tensors pre-allocated outside. Scenario is when `set_output` is used
+   * \param func_name The function's name.
+   */
+  void CollectOutputTensorRegIndices(const std::string& func_name);
+
+  /*!
+   * \brief Write new allocated tensor to register_file of frame.
+   * \param instr current instruction containing shape and storage info.
    */
   void WriteAllocatedTensor(const Instruction& instr);
 
@@ -394,8 +403,9 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
    * \brief 'set_outputs_enabled' is assumed true for using this method.
    * It is expected that result register has already contained tensor from outside,
    * new tensor is not allocated and write, but expected shape is checked.
-   * For other register WriteAllocatedMethod is used.
-   * \param instr current instruction containing shape and storage info
+   * For other register WriteAllocatedTensor method is used.
+   * \param instr current instruction containing shape and storage info.
+   * \param res_index register index of result.
    */
   void WriteAllocatedTensorFromOutside(const Instruction& instr, Index res_index);
 
@@ -416,7 +426,10 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   ObjectPtr<Executable> exec_;
   /*! \brief The function name to inputs mapping. */
   std::unordered_map<std::string, std::vector<ObjectRef>> inputs_;
+  /*! \brief The function name to flag enabling scenario with set outputs. */
   std::unordered_map<std::string, bool> set_outputs_enabled_;
+  /*! \brief The function name to indices of output tensors in register file. */
+  std::unordered_map<std::string, std::vector<Index>> output_tensor_reg_indices_;
   /*! \brief The function name to pre-allocated outputs mapping. */
   std::unordered_map<std::string, std::vector<ObjectRef>> outputs_;
   /*!

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -408,13 +408,11 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   /*!
    * \brief 'set_outputs_enabled' is assumed true for using this method.
    * It is expected that result register has already contained tensor from outside,
-   * new tensor is not allocated and write, but expected shape is checked.
+   * new memory is not allocated and write, but expected shape and data type are checked.
    * For other register WriteAllocatedTensor method is used.
    * \param instr current instruction containing shape and storage info.
-   * \param output_tensor_reg_indices register indices of output tensors.
    */
-  void WriteAllocatedTensorFromOutside(const Instruction& instr,
-                                       const std::vector<Index>& output_tensor_reg_indices);
+  void WriteAllocatedTensorFromOutside(const Instruction& instr);
 
   bool FindIndex(const std::vector<Index>& indices, Index val) const;
 

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -352,6 +352,21 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
    */
   Index GetResultRegisterIndex();
 
+  /*!
+   * \brief Write new allocated tensor to register_file of frame
+   * \param instr current instruction containing shape and storage info
+   */
+  void WriteAllocatedTensor(const Instruction& instr);
+
+  /*!
+   * \brief 'set_outputs_enabled' is assumed true for using this method.
+   * It is expected that result register has already contained tensor from outside,
+   * new tensor is not allocated and write, but expected shape is checked.
+   * For other register WriteAllocatedMethod is used.
+   * \param instr current instruction containing shape and storage info
+   */
+  void WriteAllocatedTensorFromOutside(const Instruction& instr);
+
  protected:
   /*! \brief The virtual machine's packed function table. */
   std::vector<PackedFunc> packed_funcs_;

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -259,7 +259,7 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
             const std::vector<AllocatorType>& alloc_types);
 
   /*! \brief Run VM dispatch loop. */
-  void RunLoop(bool set_output_enabled = false);
+  void RunLoop(const std::vector<Index>& output_tensor_reg_indices = {});
 
   /*! \brief Get device from the device list based on a given device index. */
   Device GetDevice(Index device_index) const;
@@ -405,9 +405,12 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
    * new tensor is not allocated and write, but expected shape is checked.
    * For other register WriteAllocatedTensor method is used.
    * \param instr current instruction containing shape and storage info.
-   * \param res_index register index of result.
+   * \param output_tensor_reg_indices register indices of output tensors.
    */
-  void WriteAllocatedTensorFromOutside(const Instruction& instr, Index res_index);
+  void WriteAllocatedTensorFromOutside(const Instruction& instr,
+                                       const std::vector<Index>& output_tensor_reg_indices);
+
+  bool FindIndex(const std::vector<Index>& indices, Index val) const;
 
  protected:
   /*! \brief The virtual machine's packed function table. */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -386,6 +386,12 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   Index GetResultRegisterIndex() const;
 
   /*!
+   * \brief Calculate the index of operation which destination is result
+   * \param res_index is the index of op returning result
+   */
+  void CalculatePreResultOpIndex(Index res_index);
+
+  /*!
    * \brief Collect indices from register_file for output tensors.
    * It helps to replace output tensors allocated in RunLoop by
    * tensors pre-allocated outside. Scenario is when `set_output` is used
@@ -431,6 +437,8 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   std::unordered_map<std::string, std::vector<ObjectRef>> inputs_;
   /*! \brief The function name to flag enabling scenario with set outputs. */
   std::unordered_map<std::string, bool> set_outputs_enabled_;
+  /*! \brief The index of operation which destination is result. */
+  Index preresult_op_index_ = -1;
   /*! \brief The function name to indices of output tensors in register file. */
   std::unordered_map<std::string, std::vector<Index>> output_tensor_reg_indices_;
   /*! \brief The function name to pre-allocated outputs mapping. */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -392,12 +392,12 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   void CalculatePreResultOpIndex(Index res_index);
 
   /*!
-   * \brief Collect indices from register_file for output tensors.
+   * \brief Get indices from register_file for output tensors.
    * It helps to replace output tensors allocated in RunLoop by
    * tensors pre-allocated outside. Scenario is when `set_output` is used
-   * \param func_name The function's name.
+   * \return indices from register_file for output tensors.
    */
-  void CollectOutputTensorRegIndices(const std::string& func_name);
+  std::vector<Index> GetOutputTensorRegIndices();
 
   /*!
    * \brief Write new allocated tensor to register_file of frame.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -293,6 +293,8 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
 
   /*!
    * \brief Set pre-allocated outputs to a function.
+   * It is native implementation of 'set_outputs' python method.
+   * It is used in scenario when output tensors are allocated outside.
    * \param name The function name
    * \param args outputs to the function.
    */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -346,6 +346,12 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   void SetInputTensorWithIndex(std::vector<ObjectRef>& tensors,  // NOLINT(*)
                                const TVMArgValue& tensor, int index, Device dev);
 
+  /*!
+   * \brief Get index of outputs in register_file from frame
+   * \return index
+   */
+  Index GetResultRegisterIndex();
+
  protected:
   /*! \brief The virtual machine's packed function table. */
   std::vector<PackedFunc> packed_funcs_;

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -562,7 +562,9 @@ class VirtualMachine(object):
         self._invoke_stateful(func_name)
 
     def invoke_with_outputs(self, func_name, input_args, output_args):
-        """Invoke a function with pre-allocated outputs tensors.
+        # TODO(vvchernov): consider scenario then output tensors set once
+        """Invoke a function with pre-allocated output tensors.
+        The output tensors should be set every invocation.
         input_args can be None if set_input method was used before.
 
         This invoke method allows to avoid excess copying if memory for output tensors

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -588,14 +588,8 @@ class VirtualMachine(object):
                     idx = func_params.index(k)
                     new_args[idx] = input_args[k]
                     cnt += 1
-            assert len(args) + cnt == len(func_params)
-            idx = 0
-            for i, arg in enumerate(new_args):
-                if arg is None:
-                    new_args[i] = args[idx]
-                    idx += 1
-            args = new_args
-        cargs = convert(args)
+            assert cnt == len(func_params)
+        cargs = convert(new_args)
         self._set_input(func_name, *cargs)
         self._set_outputs(func_name, *output_args)
         self._invoke(func_name)

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -399,6 +399,7 @@ class VirtualMachine(object):
         self._get_input_index = self.module["get_input_index"]
         self._set_input = self.module["set_input"]
         self._set_one_input = self.module["set_one_input"]
+        self._set_outputs = self.module["set_outputs"]
         self._setup_device(device, memory_cfg)
 
     def _setup_device(self, dev, memory_cfg):
@@ -559,6 +560,24 @@ class VirtualMachine(object):
         if args or kwargs:
             self.set_input(func_name, *args, **kwargs)
         self._invoke_stateful(func_name)
+
+    def invoke_with_outputs(self, func_name, *args):
+        """Invoke a function with pre-allocated outputs tensors.
+        It requires use set_input method before.
+
+        This invoke method allows to avoid excess copying if memory for output tensors
+        was allocated before inference.
+
+        Parameters
+        ----------
+        func_name : str
+            The name of the function.
+
+        args : list[tvm.runtime.NDArray] or list[DLTensor]
+            The output tensors of the function.
+        """
+        self._set_outputs(func_name, *args)
+        self._invoke(func_name)
 
     def get_outputs(self):
         """Get the outputs from a call to :py:func`invoke_stateful`.

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -298,6 +298,18 @@ void VirtualMachine::SetOutputs(std::string func_name, TVMArgs args) {
   outputs_.emplace(func_name, func_args);
 }
 
+
+void VirtualMachine::PrintInfoAndSetInputArgs(const VMFunction& func, const std::vector<ObjectRef>& args) {
+  VLOG(2) << "Executing Function: " << std::endl << func;
+  for (int i = 0; i < static_cast<int>(devices_.size()); ++i) {
+    VLOG(2) << "Device " << i << " has device type " << devices_[i].device_type
+            << " and device id " << devices_[i].device_id
+            << (i == exec_->host_device_index ? " (using as host device)" : "");
+  }
+
+  InvokeGlobal(func, args);
+}
+
 void VirtualMachine::SetOutputTensorsToRegister(const std::vector<ObjectRef>& outputs) {
   size_t size = outputs.size();
 
@@ -411,14 +423,7 @@ void VirtualMachine::InvokeGlobal(const VMFunction& func, const std::vector<Obje
 }
 
 ObjectRef VirtualMachine::Invoke(const VMFunction& func, const std::vector<ObjectRef>& args) {
-  VLOG(2) << "Executing Function: " << std::endl << func;
-  for (int i = 0; i < static_cast<int>(devices_.size()); ++i) {
-    VLOG(2) << "Device " << i << " has device type " << devices_[i].device_type << " and device id "
-            << devices_[i].device_id
-            << (i == exec_->host_device_index ? " (using as host device)" : "");
-  }
-
-  InvokeGlobal(func, args);
+  PrintInfoAndSetInputArgs(func, args);
   RunLoop();
   return return_register_;
 }
@@ -435,14 +440,7 @@ ObjectRef VirtualMachine::Invoke(const std::string& name, const std::vector<Obje
 ObjectRef VirtualMachine::Invoke(const VMFunction& func,
                                  const std::vector<ObjectRef>& input_args,
                                  const std::vector<ObjectRef>& output_args) {
-  DLOG(INFO) << "Executing Function: " << std::endl << func;
-  for (int i = 0; i < static_cast<int>(devices_.size()); ++i) {
-    DLOG(INFO) << "Device " << i << " has device type " << devices_[i].device_type
-               << " and device id " << devices_[i].device_id
-               << (i == exec_->host_device_index ? " (using as host device)" : "");
-  }
-
-  InvokeGlobal(func, input_args);
+  PrintInfoAndSetInputArgs(func, input_args);
   SetOutputTensorsToRegister(output_args);
   RunLoop(set_outputs_enabled_[func.name]);
   return return_register_;

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -314,7 +314,9 @@ void VirtualMachine::SetOutputTensorsToRegister(const std::string& func_name,
                                                 const std::vector<ObjectRef>& outputs) {
   size_t size = outputs.size();
 
-  CollectOutputTensorRegIndices(func_name);
+  if (output_tensor_reg_indices_[func_name].empty()) {
+    output_tensor_reg_indices_[func_name] = GetOutputTensorRegIndices();
+  }
   auto& reg_indices = output_tensor_reg_indices_[func_name];
   ICHECK_EQ(reg_indices.size(), size)
       << "Number of outside output tensors should be equal to model outputs number";
@@ -602,12 +604,8 @@ void VirtualMachine::CalculatePreResultOpIndex(Index res_index) {
   }
 }
 
-void VirtualMachine::CollectOutputTensorRegIndices(const std::string& func_name) {
-  if (!output_tensor_reg_indices_[func_name].empty()) {
-    return;
-  }
-
-  auto& reg_indices = output_tensor_reg_indices_[func_name];
+std::vector<Index> VirtualMachine::GetOutputTensorRegIndices() {
+  std::vector<Index> reg_indices;
   Index res_index = GetResultRegisterIndex();
   CalculatePreResultOpIndex(res_index);
   auto& preres_instr = code_[preresult_op_index_];
@@ -623,6 +621,7 @@ void VirtualMachine::CollectOutputTensorRegIndices(const std::string& func_name)
   } else {
     LOG(FATAL) << "Operation " << size_t(op_code) << " is not supported for set_outputs method";
   }
+  return reg_indices;
 }
 
 void VirtualMachine::RunLoop(const std::vector<Index>& output_tensor_reg_indices) {

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -292,7 +292,6 @@ void VirtualMachine::SetOutputs(std::string func_name, TVMArgs args) {
   std::vector<ObjectRef> func_args(outputs_size - 1);
   for (size_t i = 1; i < outputs_size; ++i) {
     // TODO(vvchernov): device?
-    // TODO(vvchernov): correct index sequence for multiple outputs?
     func_args[i - 1] = TensorFromTVMArgValueToObjectRef(args[i]);
   }
   outputs_.erase(func_name);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -525,6 +525,15 @@ int64_t VirtualMachine::LoadScalarInt(Index r) const {
   return result;
 }
 
+Index VirtualMachine::GetResultRegisterIndex() {
+  Index op_index = 0;
+  while (code_[op_index].op != Opcode::Ret) {
+    ++op_index;
+  }
+
+  return code_[op_index].result;
+}
+
 void VirtualMachine::RunLoop() {
   ICHECK(this->exec_);
   ICHECK(this->code_);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -148,6 +148,7 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
           ICHECK(outputs_.count(func_name))
               << "Outputs have not been set for function " << func_name;
           *rv = Invoke(func, input_args, outputs_[func_name]);
+          outputs_[func_name].clear();
           set_outputs_enabled_[func_name] = false;
         } else {
           *rv = Invoke(func, input_args);

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -621,7 +621,7 @@ void VirtualMachine::CollectOutputTensorRegIndices(const std::string& func_name)
   } else if (op_code == Opcode::ReshapeTensor) {
     reg_indices.push_back(preres_instr.reshape_tensor.tensor);
   } else {
-    LOG(WARNING) << "Operation " << size_t(op_code) << " is not supported for set_outputs method";
+    LOG(FATAL) << "Operation " << size_t(op_code) << " is not supported for set_outputs method";
   }
 }
 
@@ -981,7 +981,7 @@ void VirtualMachine::WriteAllocatedTensorFromOutside(const Instruction& instr) {
       auto reshaped_tensor = ex_arr.CreateView(ref_shape, ex_dtype);
       WriteRegister(instr.dst, reshaped_tensor);
     } else {
-      LOG_ERROR << "Internal and external output tensor shapes are mismatched";
+      LOG(FATAL) << "Internal and external output tensor shapes are mismatched";
     }
   }
 }

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -846,16 +846,15 @@ def test_constant_shape_with_external_codegen():
     assert "shape_func" in opt_mod.astext(False)
 
 
-def test_vm_rpc():
+def prepare_vm_model(path, tensor_shape):
     """
-    This test checks to make sure you can export a VMExecutable,
-    upload it to a remote machine using RPC and then execute it
-    on the other machine.
+    Virtual Machine is compiled for simple topology and
+    exported as library to given path
     """
     target = tvm.target.Target("llvm --host=llvm")
 
     # Build a IRModule.
-    x = relay.var("x", shape=(10, 1))
+    x = relay.var("x", shape=tensor_shape)
     f = relay.Function([x], x + x)
     mod = IRModule.from_expr(f)
 
@@ -863,9 +862,22 @@ def test_vm_rpc():
     vm_exec = vm.compile(mod, target=target)
 
     # Export to Disk
+    vm_exec.mod.export_library(path)
+
+
+def test_vm_rpc():
+    """
+    This test checks to make sure you can export a VMExecutable,
+    upload it to a remote machine using RPC and then execute it
+    on the other machine.
+    """
+    # Shape for input and output tensors
+    shape = (10,1)
+
+    # Export to Disk
     temp = utils.tempdir()
     path = temp.relpath("vm_library.so")
-    vm_exec.mod.export_library(path)
+    prepare_vm_model(path, shape)
 
     # Use local rpc server for testing.
     # Server must use popen so it doesn't inherit the current process state. It
@@ -881,7 +893,7 @@ def test_vm_rpc():
         device = remote.cpu()
         # Build a VM out of the executable and context.
         vm_factory = runtime.vm.VirtualMachine(rexec, device)
-        np_input = np.random.uniform(size=(10, 1)).astype("float32")
+        np_input = np.random.uniform(size=shape).astype("float32")
         input_tensor = tvm.nd.array(np_input, device)
         # Invoke its "main" function.
         out = vm_factory.invoke("main", input_tensor)
@@ -889,6 +901,46 @@ def test_vm_rpc():
         np.testing.assert_allclose(out.numpy(), np_input + np_input)
 
     check_remote(rpc.Server("127.0.0.1"))
+
+
+def test_vm_invoke_with_outputs_rpc():
+    """
+    This test checks to make sure you can export a VMExecutable,
+    upload it to a remote machine using RPC and then execute it
+    on the other machine with preallocated outputs.
+    """
+    # Shape for input and output tensors
+    shape = (3,2)
+
+    # Export to Disk
+    temp = utils.tempdir()
+    path = temp.relpath("vm_library.so")
+    prepare_vm_model(path, shape)
+
+    # Use local rpc server for testing.
+    # Server must use popen so it doesn't inherit the current process state. It
+    # will crash otherwise.
+    def check_remote_invoke_with_outputs(server):
+        remote = rpc.connect(server.host, server.port, session_timeout=10)
+
+        # Upload the serialized Executable.
+        remote.upload(path)
+        # Get a handle to remote Executable.
+        rexec = remote.load_module("vm_library.so")
+
+        device = remote.cpu()
+        # Build a VM out of the executable and context.
+        vm_factory = runtime.vm.VirtualMachine(rexec, device)
+        np_input = np.random.uniform(size=shape).astype("float32")
+        input_tensor = tvm.nd.array(np_input, device)
+        np_output = np.empty(shape, dtype="float32")
+        output_tensor = tvm.nd.array(np_output, device)
+        # Invoke its "main" function.
+        vm_factory.invoke_with_outputs("main", input_args={"x": input_tensor}, output_args=[output_tensor])
+        # Check the result.
+        np.testing.assert_allclose(output_tensor.numpy(), np_input + np_input)
+
+    check_remote_invoke_with_outputs(rpc.Server("127.0.0.1"))
 
 
 def test_get_output_single():

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -872,7 +872,7 @@ def test_vm_rpc():
     on the other machine.
     """
     # Shape for input and output tensors
-    shape = (10,1)
+    shape = (10, 1)
 
     # Export to Disk
     temp = utils.tempdir()
@@ -910,7 +910,7 @@ def test_vm_invoke_with_outputs_rpc():
     on the other machine with preallocated outputs.
     """
     # Shape for input and output tensors
-    shape = (3,2)
+    shape = (3, 2)
 
     # Export to Disk
     temp = utils.tempdir()
@@ -936,7 +936,9 @@ def test_vm_invoke_with_outputs_rpc():
         np_output = np.empty(shape, dtype="float32")
         output_tensor = tvm.nd.array(np_output, device)
         # Invoke its "main" function.
-        vm_factory.invoke_with_outputs("main", input_args={"x": input_tensor}, output_args=[output_tensor])
+        vm_factory.invoke_with_outputs(
+            "main", input_args={"x": input_tensor}, output_args=[output_tensor]
+        )
         # Check the result.
         np.testing.assert_allclose(output_tensor.numpy(), np_input + np_input)
 
@@ -945,7 +947,7 @@ def test_vm_invoke_with_outputs_rpc():
 
 def test_vm_invoke_with_outputs():
     target = tvm.target.Target("llvm")
-    shape=(3, 2)
+    shape = (3, 2)
 
     # Build a IRModule.
     x = relay.var("x", shape=shape)
@@ -960,7 +962,9 @@ def test_vm_invoke_with_outputs():
     np_output = np.empty(shape, dtype="float32")
     output_tensor = tvm.nd.array(np_output)
     # Invoke
-    vm_factory.invoke_with_outputs("main", input_args={"x": input_tensor}, output_args=[output_tensor])
+    vm_factory.invoke_with_outputs(
+        "main", input_args={"x": input_tensor}, output_args=[output_tensor]
+    )
     # Check the result.
     np.testing.assert_allclose(output_tensor.numpy(), np_input + np_input)
 


### PR DESCRIPTION
This is a draft of implementation of 'set_output_zero_copy' method on VirtualMachine side.

Brief description of approach.
1. There is python API function 'set_output' which save external outputs in VM outputs_ field (map) for specified func name. It looks like 'set_input' method.
2. During 'invoke' outputs_ are saved in register_file. For this the register indices of output tensors are found from code_ field. I observed in tests for different models that AllocTensor and AllocADT ops are used for result tensors. Let's consider these two cases: result index is destination for AllocTensor op or AllocADT op. At the first case instead of construction new NDArray the outside output tensor is used. At the second one the fields of AllocADT are analyzed and register indices are extracted. During tests I observed that ReshapeTensor operation is rarely used as final one (SqueezeNet-v1.0 and DUC). Mechanism for replacement by external output tensors was also implemented for this op.  

Notes: 1. I'm not sure that it works for many frames. Practically it looks like we need code_ not frame and any number of frames does not change ops stack (code_). Other thing I observed that code_ does not depend on func_name, may be it should, it is not threadsafe just now.
2. It was implemented for CPU, I plan to check GPU specifics.
3. It seems that tensor(s) is(are) allocated over storage with prepared memory. It means that skipped AllocTensor and AllocADT can keep memory in RAM, it is not good thing but it generates questions about scenarios and VM flexibility.
4. Possibly CI tests are needed to cover some base scenarios

Hello @altanh and @mbs-octoml! Could you see the draft?