### PR TITLE
[ci][actions] Add more HTTP retries for conda

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,6 +15,7 @@ runs:
       auto-activate-base: false
       use-only-tar-bz2: true
       python-version: 3.7
+      condarc-file: conda/condarc
   - name: Conda info
     shell: pwsh
     run: |

--- a/conda/condarc
+++ b/conda/condarc
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# See https://docs.conda.io/projects/conda/en/latest/configuration.html for details
+
+# remote_connect_timeout_secs (float)
+#   The number seconds conda will wait for your client to establish a
+#   connection to a remote url resource.
+# 
+remote_connect_timeout_secs: 10
+
+# remote_max_retries (int)
+#   The maximum number of retries each HTTP connection should attempt.
+# 
+remote_max_retries: 6
+
+# remote_backoff_factor (int)
+#   The factor determines the time HTTP connection should wait for
+#   attempt.
+# 
+remote_backoff_factor: 5
+
+# remote_read_timeout_secs (float)
+#   Once conda has connected to a remote resource and sent an HTTP
+#   request, the read timeout is the number of seconds conda will wait for
+#   the server to send a response.
+# 
+remote_read_timeout_secs: 60.0

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -100,6 +100,7 @@ ALLOW_FILE_NAME = {
     "Makefile",
     "Doxyfile",
     "pylintrc",
+    "condarc",
     "rat-excludes",
     "log4j.properties",
     ".clang-format",


### PR DESCRIPTION
This should help alleviate some of the GitHub Actions failures like
* https://github.com/apache/tvm/runs/6487878471?check_suite_focus=true
* https://github.com/apache/tvm/runs/6478323571?check_suite_focus=true

Test run: https://github.com/driazati/tvm/runs/6493421090?check_suite_focus=true

cc @Mousius @areusch