### PR TITLE
[skip ci] Revert "Fix function number datatype from char to uint16_t (#10014)"

### DIFF
--- a/include/tvm/runtime/crt/func_registry.h
+++ b/include/tvm/runtime/crt/func_registry.h
@@ -42,38 +42,13 @@ typedef struct TVMFuncRegistry {
   /*! \brief Names of registered functions, concatenated together and separated by \0.
    * An additional \0 is present at the end of the concatenated blob to mark the end.
    *
-   * Byte 0 and 1 are the number of functions in `funcs`.
+   * Byte 0 is the number of functions in `funcs`.
    */
   const char* names;
 
   /*! \brief Function pointers, in the same order as their names in `names`. */
   const TVMBackendPackedCFunc* funcs;
 } TVMFuncRegistry;
-
-/*!
- * \brief Get the of the number of functions from registry.
- *
- * \param reg TVMFunctionRegistry instance that contains the function.
- * \return The number of functions from registry.
- */
-uint16_t TVMFuncRegistry_GetNumFuncs(const TVMFuncRegistry* reg);
-
-/*!
- * \brief Set the number of functions to registry.
- *
- * \param reg TVMFunctionRegistry instance that contains the function.
- * \param num_funcs The number of functions
- * \return 0 when successful.
- */
-int TVMFuncRegistry_SetNumFuncs(const TVMFuncRegistry* reg, const uint16_t num_funcs);
-
-/*!
- * \brief Get the address of 0th function from registry.
- *
- * \param reg TVMFunctionRegistry instance that contains the function.
- * \return the address of 0th function from registry
- */
-const char* TVMFuncRegistry_Get0thFunctionName(const TVMFuncRegistry* reg);
 
 /*!
  * \brief Get packed function from registry by name.

--- a/src/target/func_registry_generator.cc
+++ b/src/target/func_registry_generator.cc
@@ -31,13 +31,7 @@ namespace target {
 
 std::string GenerateFuncRegistryNames(const Array<String>& function_names) {
   std::stringstream ss;
-
-  unsigned char function_nums[sizeof(uint16_t)];
-  *reinterpret_cast<uint16_t*>(function_nums) = function_names.size();
-  for (auto f : function_nums) {
-    ss << f;
-  }
-
+  ss << (unsigned char)(function_names.size());
   for (auto f : function_names) {
     ss << f << '\0';
   }

--- a/tests/crt/func_registry_test.cc
+++ b/tests/crt/func_registry_test.cc
@@ -82,7 +82,7 @@ TEST(StrCmpScan, Test) {
 }
 
 TEST(FuncRegistry, Empty) {
-  TVMFuncRegistry registry{"\000\000", NULL};
+  TVMFuncRegistry registry{"\000", NULL};
 
   EXPECT_EQ(kTvmErrorFunctionNameNotFound, TVMFuncRegistry_Lookup(&registry, "foo", NULL));
   EXPECT_EQ(kTvmErrorFunctionIndexInvalid,
@@ -101,7 +101,7 @@ static int Bar(TVMValue* args, int* type_codes, int num_args, TVMValue* out_ret_
 }
 
 // Matches the style of registry defined in generated C modules.
-const char* kBasicFuncNames = "\002\000Foo\0Bar\0";  // NOTE: final \0
+const char* kBasicFuncNames = "\002Foo\0Bar\0";  // NOTE: final \0
 const TVMBackendPackedCFunc funcs[2] = {&Foo, &Bar};
 const TVMFuncRegistry kConstRegistry = {kBasicFuncNames, (const TVMBackendPackedCFunc*)funcs};
 
@@ -111,8 +111,7 @@ TEST(FuncRegistry, ConstGlobalRegistry) {
 
   // Foo
   EXPECT_EQ(kBasicFuncNames[0], 2);
-  EXPECT_EQ(kBasicFuncNames[1], 0);
-  EXPECT_EQ(kBasicFuncNames[2], 'F');
+  EXPECT_EQ(kBasicFuncNames[1], 'F');
   EXPECT_EQ(kTvmErrorNoError, TVMFuncRegistry_Lookup(&kConstRegistry, "Foo", &func_index));
   EXPECT_EQ(0, func_index);
 


### PR DESCRIPTION
This reverts commit f34bd22ddc4e7064eabe9fac42c4c04f54ede399 (#10014)

Located via a git bisect, likely happened since the PR is pretty old. Tested revert via

```
python3 tests/scripts/ci.py cpu --tests tests/python/unittest/test_crt.py::test_aot_executor --tests tests/python/unittest/test_crt.py::test_graph_executor
```