### PR TITLE
[ONNX] Dynamic Batch Softmax Support

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2405,12 +2405,7 @@ class Softmax(OnnxOpConverter):
         ndim = len(in_shape)
         if axis < 0:
             axis += ndim
-        if axis == 0:
-            reshape_shape = [-1]
-        else:
-            axis_val = [in_shape[i] for i in range(axis)]
-            reshape_shape = [np.prod(axis_val)] + [-1]
-        data_reshape = _op.reshape(inputs[0], newshape=reshape_shape)
+        data_reshape = _op.reshape(inputs[0], newshape=[-1])
         out = _op.nn.softmax(data_reshape, axis=-1)
         out = _op.reshape(out, newshape=in_shape)
         return out

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -232,8 +232,7 @@ def verify_with_ort(
 def quantize_and_verify_with_ort(
     onnx_model, input_names, input_shapes, target, dev, rtol=1e-5, atol=1e-5
 ):
-    from onnxruntime.quantization import (CalibrationDataReader, QuantType,
-                                          quantize_static)
+    from onnxruntime.quantization import CalibrationDataReader, QuantType, quantize_static
 
     input_arrays = [np.random.random(shape).astype("float32") for shape in input_shapes]
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -232,7 +232,8 @@ def verify_with_ort(
 def quantize_and_verify_with_ort(
     onnx_model, input_names, input_shapes, target, dev, rtol=1e-5, atol=1e-5
 ):
-    from onnxruntime.quantization import CalibrationDataReader, QuantType, quantize_static
+    from onnxruntime.quantization import (CalibrationDataReader, QuantType,
+                                          quantize_static)
 
     input_arrays = [np.random.random(shape).astype("float32") for shape in input_shapes]
 
@@ -1593,6 +1594,13 @@ def test_upsample3d_trilinear(target, dev):
 def test_softmax(target, dev):
     def verify_softmax(inshape, axis):
         opname = "Softmax"
+        inshape = list(inshape)
+
+        # Set dynamic batch size for anys
+        for i in range(len(inshape)):
+            if not isinstance(inshape[i], int):
+                inshape[i] = 3
+
         indata = np.random.uniform(size=inshape).astype(np.float32)
         outshape = inshape
         y = helper.make_node(opname, ["in"], ["out"])
@@ -1616,6 +1624,7 @@ def test_softmax(target, dev):
     verify_softmax((1, 2, 3, 10), 2)
     verify_softmax((1, 2, 3, 4, 10), 3)
     verify_softmax((1, 2, 3, 4, 10), 4)
+    verify_softmax((relay.Any(), 2, 3, 4, 10), 4)
 
 
 @tvm.testing.parametrize_targets


### PR DESCRIPTION
https://github.com/apache/tvm/pull/11123/files 

Added support for onnx softmax for many dimensions. However, it did not work with dynamic axis size. This does this (_op.reshape dispatches to a dynamic op as appropriate)