### PR TITLE
unify ssize_t definition

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -76,18 +76,6 @@ extern "C" {
 #endif
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <sys/types.h>
-
-#if defined(_MSC_VER)
-#if defined(_WIN64)
-typedef int64_t tvm_ssize_t;
-#else
-typedef int32_t tvm_ssize_t;
-#endif
-#else
-typedef ssize_t tvm_ssize_t;
-#endif
 
 /*! \brief type of array index. */
 typedef int64_t tvm_index_t;

--- a/src/runtime/minrpc/minrpc_server.h
+++ b/src/runtime/minrpc/minrpc_server.h
@@ -150,7 +150,7 @@ class MinRPCReturns : public MinRPCReturnInterface {
     const uint8_t* buf = static_cast<const uint8_t*>(data);
     size_t ndone = 0;
     while (ndone < size) {
-      tvm_ssize_t ret = io_->PosixWrite(buf, size - ndone);
+      ssize_t ret = io_->PosixWrite(buf, size - ndone);
       if (ret <= 0) {
         this->ThrowError(RPCServerStatus::kWriteError);
       }
@@ -526,7 +526,7 @@ class MinRPCExecute : public MinRPCExecInterface {
     uint8_t* buf = static_cast<uint8_t*>(data);
     size_t ndone = 0;
     while (ndone < size) {
-      tvm_ssize_t ret = io_->PosixRead(buf, size - ndone);
+      ssize_t ret = io_->PosixRead(buf, size - ndone);
       if (ret <= 0) return ret;
       ndone += ret;
       buf += ret;
@@ -757,7 +757,7 @@ class MinRPCServer {
     uint8_t* buf = static_cast<uint8_t*>(data);
     size_t ndone = 0;
     while (ndone < size) {
-      tvm_ssize_t ret = io_->PosixRead(buf, size - ndone);
+      ssize_t ret = io_->PosixRead(buf, size - ndone);
       if (ret == 0) {
         if (allow_clean_shutdown_) {
           Shutdown();

--- a/src/runtime/minrpc/minrpc_server_logging.h
+++ b/src/runtime/minrpc/minrpc_server_logging.h
@@ -140,7 +140,7 @@ class MinRPCSniffer {
     uint8_t* buf = reinterpret_cast<uint8_t*>(data);
     size_t ndone = 0;
     while (ndone < size) {
-      tvm_ssize_t ret = io_->PosixRead(buf, size - ndone);
+      ssize_t ret = io_->PosixRead(buf, size - ndone);
       if (ret <= 0) {
         this->ThrowError(RPCServerStatus::kReadError);
         return false;

--- a/src/runtime/rpc/rpc_channel_logger.h
+++ b/src/runtime/rpc/rpc_channel_logger.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <utility>
 
+#include "../../support/ssize.h"
 #include "../minrpc/minrpc_server_logging.h"
 #include "rpc_channel.h"
 
@@ -98,11 +99,11 @@ class SnifferIOHandler {
 
   void MessageStart(size_t message_size_bytes) {}
 
-  tvm_ssize_t PosixWrite(const uint8_t* buf, size_t buf_size_bytes) { return 0; }
+  ssize_t PosixWrite(const uint8_t* buf, size_t buf_size_bytes) { return 0; }
 
   void MessageDone() {}
 
-  tvm_ssize_t PosixRead(uint8_t* buf, size_t buf_size_bytes) {
+  ssize_t PosixRead(uint8_t* buf, size_t buf_size_bytes) {
     return receive_buffer_->Read(buf, buf_size_bytes);
   }
 

--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -34,7 +34,6 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-using ssize_t = int;
 #ifdef _MSC_VER
 #pragma comment(lib, "Ws2_32.lib")
 #endif
@@ -57,6 +56,7 @@ using ssize_t = int;
 #include <unordered_map>
 #include <vector>
 
+#include "../support/ssize.h"
 #include "../support/utils.h"
 
 #if defined(_WIN32)

--- a/src/support/ssize.h
+++ b/src/support/ssize.h
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file ssize.h
+ * \brief this file aims to define ssize_t for Windows platform
+ */
+
+#ifndef TVM_SUPPORT_SSIZE_H_
+#define TVM_SUPPORT_SSIZE_H_
+
+#if defined(_MSC_VER)
+#if defined(_WIN32)
+using ssize_t = int32_t;
+#else
+using ssize_t = int64_t;
+#endif
+#endif
+
+#endif  // TVM_SUPPORT_SSIZE_H_


### PR DESCRIPTION
This PR removes the type tvm_ssize_t introduced in ([PR11232](https://github.com/apache/tvm/pull/11232/)) , and unifies the definition of ssize_t.
Initially, there was an issue with the Windows build in ([PR10967](https://github.com/apache/tvm/pull/10967)) , since the ssize_t was not properly defined in rpc_channel_logger.h 
our initial solution was to define the ssize_t in that specific file. but we got a redefinition error, since ssize_t was also defined in socket.h. We also tried to include socket.h in rpc_channel_logger.h but we got some errors on hexagon build. ([PR11223](https://github.com/apache/tvm/pull/11223))
Next attempt, we added another type, tvm_ssize_t, in c_runtime_api.h to resolve the redefinition issue ([PR11232](https://github.com/apache/tvm/pull/11232/)) and the plan was to propagate tvm_ssize_t to most of other ssize_t mentions to minimize confusion. The PR got merged, however, there are two issues with this solution. First, the c_runtime_api.h doesn't seem to be the appropriate place for the definition and required header files ([here](https://github.com/apache/tvm/pull/11232/#discussion_r876954435)), and ssize_t is widely used in the codebase, so propagating the tvm_ssize_t requires changes all over the codebase.
This brings us to this current solution. It is basically back to our initial solution of defining ssize_t where it is needed (rpc_channel_logger.h ), and resolving the redefinition error by placing the definition in ssize.h file, and including it in both places. I believe this solution makes more sense because it doesn't add an unnecessary and potentially confusing type tvm_ssize_t and keeps the ssize_t definitions consistent.
@areusch, @mehrdadh, @manupa-arm 