### PR TITLE
Fix vta-config inaccurate same check

### DIFF
--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -101,11 +101,10 @@ def server_start():
         cfg["TARGET"] = env.TARGET
         pkg = pkg_config(cfg)
         # check if the configuration is already the same
-        if os.path.isfile(cfg_path):
-            old_cfg = json.loads(open(cfg_path, "r").read())
-            if pkg.same_config(old_cfg):
-                logging.info("Skip reconfig_runtime due to same config.")
-                return
+        old_cfg = env.pkg.cfg_dict
+        if pkg.same_config(old_cfg):
+            logging.info("Skip reconfig_runtime due to same config.")
+            return
         cflags = ["-O2", "-std=c++14"]
         cflags += pkg.cflags
         ldflags = pkg.ldflags

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -101,10 +101,11 @@ def server_start():
         cfg["TARGET"] = env.TARGET
         pkg = pkg_config(cfg)
         # check if the configuration is already the same
-        old_cfg = env.pkg.cfg_dict
-        if pkg.same_config(old_cfg):
-            logging.info("Skip reconfig_runtime due to same config.")
-            return
+        if os.path.isfile(cfg_path):
+            old_cfg = json.loads(env.pkg.cfg_json)
+            if pkg.same_config(old_cfg):
+                logging.info("Skip reconfig_runtime due to same config.")
+                return
         cflags = ["-O2", "-std=c++14"]
         cflags += pkg.cflags
         ldflags = pkg.ldflags


### PR DESCRIPTION
Even if the `vta_config.json` on the host side and the hardware side are the same, it will be judged as a different configuration, and the `libvta.so` file will be rebuilt.
I found that the reason is that `old_cfg` is the original json object parsed from the file, but the obtained `cfg` is no longer the original json object, it adds some fields when building pkg. As the following code:
```
    # 3rdparty/vta-hw/config/pkg_config.py
    def __init__(self, cfg):

        # Derived parameters
        cfg["LOG_BLOCK_IN"] = cfg["LOG_BLOCK"]
        cfg["LOG_BLOCK_OUT"] = cfg["LOG_BLOCK"]
        cfg["LOG_OUT_WIDTH"] = cfg["LOG_INP_WIDTH"]
        cfg["LOG_OUT_BUFF_SIZE"] = (
            cfg["LOG_ACC_BUFF_SIZE"] +
            cfg["LOG_OUT_WIDTH"] -
            cfg["LOG_ACC_WIDTH"])

        # Update cfg now that we've extended it
        self.__dict__.update(cfg)
```
Potential run failures are encountered due to rebuilding the `libvta.so` file.
I think this solves the problem FIXME (tmoreau89) in the docs:
https://tvm.apache.org/docs/topic/vta/install.html#xilinx-pynq-fpga-setup
