### PR TITLE
Add utility to replace direct call to pytest.main

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -62,6 +62,7 @@ function in this module. Then targets using this node should be added to the
 `TVM_TEST_TARGETS` environment variable in the CI.
 
 """
+import inspect
 import copy
 import copyreg
 import ctypes
@@ -1513,3 +1514,8 @@ def identity_after(x, sleep):
 def terminate_self():
     """Testing function to terminate the process."""
     sys.exit(-1)
+
+
+def main():
+    test_file = inspect.getsourcefile(sys._getframe(1))
+    sys.exit(pytest.main([test_file] + sys.argv[1:]))

--- a/tests/micro/arduino/test_arduino_error_detection.py
+++ b/tests/micro/arduino/test_arduino_error_detection.py
@@ -21,6 +21,7 @@ import pytest
 from tvm.micro.project_api.server import ServerError
 
 import test_utils
+import tvm.testing
 
 # A new project and workspace dir is created for EVERY test
 @pytest.fixture
@@ -46,4 +47,4 @@ def test_bugged_project_compile_fails(workspace_dir, project):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/micro/arduino/test_arduino_rpc_server.py
+++ b/tests/micro/arduino/test_arduino_rpc_server.py
@@ -29,6 +29,7 @@ import onnx
 import pytest
 
 import tvm
+import tvm.testing
 from PIL import Image
 from tvm import relay
 from tvm.relay.testing import byoc
@@ -367,4 +368,4 @@ def test_rpc_large_array(board, arduino_cli_cmd, tvm_debug, workspace_dir, shape
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/micro/arduino/test_arduino_workflow.py
+++ b/tests/micro/arduino/test_arduino_workflow.py
@@ -21,6 +21,8 @@ import shutil
 import sys
 import pytest
 
+import tvm.testing
+
 import test_utils
 
 """
@@ -218,4 +220,4 @@ def test_project_inference_runtime(serial_output):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/micro/common/test_tvmc.py
+++ b/tests/micro/common/test_tvmc.py
@@ -26,6 +26,7 @@ import os
 import shutil
 
 import tvm
+import tvm.testing
 from tvm.contrib.download import download_testdata
 
 from ..zephyr.test_utils import ZEPHYR_BOARDS
@@ -217,4 +218,4 @@ def test_tvmc_model_run(board, output_dir):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/micro/zephyr/test_zephyr.py
+++ b/tests/micro/zephyr/test_zephyr.py
@@ -26,6 +26,7 @@ import onnx
 from PIL import Image
 
 import tvm
+import tvm.testing
 import tvm.relay as relay
 from tvm.relay.backend import Executor, Runtime
 from tvm.relay.testing import byoc
@@ -504,4 +505,4 @@ def test_autotune_conv2d(temp_dir, board, west_cmd, tvm_debug):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/micro/zephyr/test_zephyr_aot.py
+++ b/tests/micro/zephyr/test_zephyr_aot.py
@@ -135,4 +135,4 @@ def test_qemu_make_fail(temp_dir, board, west_cmd, tvm_debug):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/micro/zephyr/test_zephyr_armv7m.py
+++ b/tests/micro/zephyr/test_zephyr_armv7m.py
@@ -187,4 +187,4 @@ def test_armv7m_intrinsic(temp_dir, board, west_cmd, tvm_debug):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -20,6 +20,7 @@ import sys
 import json
 import textwrap
 import pytest
+import tvm.testing
 
 from test_utils import REPO_ROOT
 
@@ -732,4 +733,4 @@ def test_github_tag_teams(tmpdir_factory):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_binary_ops.py
+++ b/tests/python/contrib/test_cmsisnn/test_binary_ops.py
@@ -275,4 +275,4 @@ def test_invalid_parameters(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -512,4 +512,4 @@ def test_invalid_parameters(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_extract_constants.py
+++ b/tests/python/contrib/test_cmsisnn/test_extract_constants.py
@@ -21,6 +21,7 @@ import math
 import numpy as np
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 
 tvm._ffi._init_api("relay.ext.cmsisnn.transform", __name__)
@@ -224,4 +225,4 @@ def test_multiple_functions_non_cmsisnn_compiler(external_compiler):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_fully_connected.py
+++ b/tests/python/contrib/test_cmsisnn/test_fully_connected.py
@@ -234,4 +234,4 @@ def test_invalid_parameters(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_generate_constants.py
+++ b/tests/python/contrib/test_cmsisnn/test_generate_constants.py
@@ -21,6 +21,7 @@ import math
 import numpy as np
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay.op.contrib import cmsisnn
 
@@ -225,4 +226,4 @@ def test_op_int8(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_networks.py
+++ b/tests/python/contrib/test_cmsisnn/test_networks.py
@@ -117,4 +117,4 @@ def test_cnn_small(test_runner):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_pooling.py
+++ b/tests/python/contrib/test_cmsisnn/test_pooling.py
@@ -169,6 +169,4 @@ def test_invalid_layout(op):
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_scalar_to_tensor_constant.py
+++ b/tests/python/contrib/test_cmsisnn/test_scalar_to_tensor_constant.py
@@ -21,6 +21,7 @@ import sys
 import numpy as np
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 
 tvm._ffi._init_api("relay.ext.cmsisnn.transform", __name__)
@@ -286,4 +287,4 @@ def test_non_cmsisnn_ext_func():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cmsisnn/test_softmax.py
+++ b/tests/python/contrib/test_cmsisnn/test_softmax.py
@@ -129,4 +129,4 @@ def test_invalid_parameters(in_dtype, out_dtype, zero_point, scale, out_zero_poi
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cudnn.py
+++ b/tests/python/contrib/test_cudnn.py
@@ -20,6 +20,7 @@ import sys
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import te
 from tvm import relay
 from tvm.contrib import cudnn
@@ -623,4 +624,4 @@ def test_relay_cudnn_conv2d_bias_act(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -985,6 +985,4 @@ def test_prune_dnnl_subgraph(run_module):
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/conv2d/test_conv2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/conv2d/test_conv2d_blocked.py
@@ -19,6 +19,7 @@ import sys
 
 import platform
 import tvm
+import tvm.testing
 from tvm import te
 from tvm import topi
 from tvm.topi import testing
@@ -191,4 +192,4 @@ class TestConv2dPackedFilter(BaseConv2d):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/conv2d/test_conv2d_conv2d.py
+++ b/tests/python/contrib/test_hexagon/conv2d/test_conv2d_conv2d.py
@@ -19,6 +19,7 @@ import sys
 
 import platform
 import tvm
+import tvm.testing
 from tvm import te
 from tvm import topi
 from tvm.topi import testing
@@ -236,4 +237,4 @@ class TestConv2dConv2dPackedFilter(BaseConv2dConv2d):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -336,4 +336,4 @@ class TestElementWise:
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/test_launcher.py
+++ b/tests/python/contrib/test_hexagon/test_launcher.py
@@ -388,4 +388,4 @@ def test_aot_executor_multiple_conv2d(hexagon_session: Session, aot_host_target,
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
@@ -18,6 +18,7 @@
 import sys
 
 import tvm
+import tvm.testing
 from tvm import te
 from tvm import topi
 from tvm.topi import testing
@@ -150,4 +151,4 @@ class TestMaxPooling(BaseMaxPooling):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/test_models.py
+++ b/tests/python/contrib/test_hexagon/test_models.py
@@ -135,4 +135,4 @@ def test_mobilenet_aot(hexagon_session: Session, aot_host_target, aot_target, en
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/test_usmp.py
+++ b/tests/python/contrib/test_hexagon/test_usmp.py
@@ -109,4 +109,4 @@ def test_conv2d(hexagon_session: Session, aot_host_target, aot_target, usmp_enab
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_batch_matmul.py
+++ b/tests/python/contrib/test_hexagon/topi/test_batch_matmul.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -139,4 +140,4 @@ class TestMatMulInt8:
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_conv2d_nchw.py
+++ b/tests/python/contrib/test_hexagon/topi/test_conv2d_nchw.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -242,4 +243,4 @@ class TestAsymmetricPadding(BaseConv2DTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_conv2d_nhwc.py
+++ b/tests/python/contrib/test_hexagon/topi/test_conv2d_nhwc.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -121,4 +122,4 @@ class TestConv2dNHWC(BaseConv2DTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_dense.py
+++ b/tests/python/contrib/test_hexagon/topi/test_dense.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -115,4 +116,4 @@ def test_dense(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_pooling.py
+++ b/tests/python/contrib/test_hexagon/topi/test_pooling.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -736,4 +737,4 @@ class TestPool3D:
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_reduce.py
+++ b/tests/python/contrib/test_hexagon/topi/test_reduce.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -163,4 +164,4 @@ def test_reduce_map(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_hexagon/topi/test_softmax.py
+++ b/tests/python/contrib/test_hexagon/topi/test_softmax.py
@@ -20,6 +20,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import topi
 from tvm import te
 from tvm.contrib.hexagon.session import Session
@@ -97,4 +98,4 @@ def test_softmax(hexagon_session: Session, shape, dtype, softmax_operation):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/contrib/test_rpc_server_device.py
+++ b/tests/python/contrib/test_rpc_server_device.py
@@ -440,4 +440,4 @@ def test_check_auto_schedule_tuning(host, port):  # pylint: disable=too-many-loc
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -1402,6 +1402,4 @@ def test_empty_subgraph(run_module):
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_verilator/test_verilator_ops.py
+++ b/tests/python/contrib/test_verilator/test_verilator_ops.py
@@ -19,6 +19,7 @@
 import numpy as np
 
 import tvm
+import tvm.testing
 from tvm import relay
 import pytest
 
@@ -195,6 +196,4 @@ def test_bias_add():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -681,6 +681,4 @@ def test_compile_tflite_module_with_mod_name_and_ethosu(
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/driver/tvmc/test_mlf.py
+++ b/tests/python/driver/tvmc/test_mlf.py
@@ -21,6 +21,7 @@ import shlex
 import sys
 
 import tvm
+import tvm.testing
 from tvm.autotvm.measure.executor import Executor
 from tvm.driver import tvmc
 from tvm.driver.tvmc.main import _main
@@ -164,4 +165,4 @@ def test_tvmc_import_package_mlf_aot(tflite_mobilenet_v1_1_quant, tflite_compile
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/driver/tvmc/test_target.py
+++ b/tests/python/driver/tvmc/test_target.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import pytest
+import tvm.testing
 from tvm.driver.tvmc import TVMCException
 from tvm.driver.tvmc.target import target_from_cli, tokenize_target, parse_target
 
@@ -163,6 +164,4 @@ def test_parse_multiple_target_with_opts_ethos_n78():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/integration/test_arm_mprofile_dsp.py
+++ b/tests/python/integration/test_arm_mprofile_dsp.py
@@ -349,4 +349,4 @@ def test_avgpool_1d(data_shape_ncw, pool_size, strides, padding):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/integration/test_tuning.py
+++ b/tests/python/integration/test_tuning.py
@@ -219,4 +219,4 @@ def test_tuning_cpu():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/aot/test_c_device_api.py
+++ b/tests/python/relay/aot/test_c_device_api.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 import numpy as np
 import pytest
 import re
+import tvm.testing
 
 from tvm import relay
 from tvm.ir.module import IRModule
@@ -245,4 +246,4 @@ def test_without_device_api_packed_api(non_device_api_main_func):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/aot/test_cpp_aot.py
+++ b/tests/python/relay/aot/test_cpp_aot.py
@@ -202,4 +202,4 @@ def test_pass_wrong_device_arg():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/aot/test_crt_aot.py
+++ b/tests/python/relay/aot/test_crt_aot.py
@@ -1073,4 +1073,4 @@ def test_aot_uses_anf():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/aot/test_crt_aot_usmp.py
+++ b/tests/python/relay/aot/test_crt_aot_usmp.py
@@ -630,7 +630,4 @@ def test_u4_usecase_incompatible_interface_api_errors():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/dyn/test_dynamic_op_level10.py
+++ b/tests/python/relay/dyn/test_dynamic_op_level10.py
@@ -151,7 +151,4 @@ def test_dyn_one_hot():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/dyn/test_dynamic_op_level3.py
+++ b/tests/python/relay/dyn/test_dynamic_op_level3.py
@@ -471,6 +471,4 @@ def test_dyn_cast():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/op/annotation/test_annotation.py
+++ b/tests/python/relay/op/annotation/test_annotation.py
@@ -16,6 +16,7 @@
 # under the License.
 """Unit tests for annotations."""
 import tvm
+import tvm.testing
 from tvm import relay
 import pytest
 
@@ -62,6 +63,4 @@ def test_on_device_free():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/op/test_tensor.py
+++ b/tests/python/relay/op/test_tensor.py
@@ -16,6 +16,7 @@
 # under the License.
 """Unit tests for tensor helpers."""
 import tvm
+import tvm.testing
 from tvm import relay
 import pytest
 
@@ -47,6 +48,4 @@ def test_device_copy_via_device():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/strategy/arm_cpu/test_conv2d_nchw.py
+++ b/tests/python/relay/strategy/arm_cpu/test_conv2d_nchw.py
@@ -107,4 +107,4 @@ class TestConv2d_OIHW_small_kernel(BasicConv2dTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/strategy/arm_cpu/test_conv2d_nhwc.py
+++ b/tests/python/relay/strategy/arm_cpu/test_conv2d_nhwc.py
@@ -151,4 +151,4 @@ class TestConv2d_HWIO(BasicConv2dTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
+++ b/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
@@ -150,4 +150,4 @@ class TestDepthwiseConv2d_NHWC_HWOI(BasicDepthwiseConv2dTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/strategy/arm_cpu/test_group_conv2d.py
+++ b/tests/python/relay/strategy/arm_cpu/test_group_conv2d.py
@@ -148,4 +148,4 @@ class TestGroupConv2d_NHWC_HWIO(BasicGroupConv2dTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 import tvm
+import tvm.testing
 import tvm.topi.testing
 from tvm import relay, te
 from tvm.relay.loops import while_loop
@@ -2149,7 +2150,4 @@ def test_searchsorted():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
+++ b/tests/python/relay/test_auto_scheduler_layout_rewrite_networks.py
@@ -214,4 +214,4 @@ def test_batch_matmul(target, dev):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_build_module.py
+++ b/tests/python/relay/test_build_module.py
@@ -18,6 +18,7 @@
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.target.target import Target
 from tvm.relay.backend import Runtime, Executor, graph_executor_codegen
@@ -82,6 +83,4 @@ def test_build_relay_graph_():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_external_codegen.py
+++ b/tests/python/relay/test_external_codegen.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import relay, runtime
 from tvm.relay.build_module import bind_params_by_name
 from tvm.relay.op.annotation import compiler_begin, compiler_end
@@ -351,4 +352,4 @@ def test_load_params_with_constants_in_ext_codegen():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import relay
 import tvm.relay.testing
 from numpy import isclose
@@ -1028,6 +1029,4 @@ def test_init_module_and_metatable():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_ir_structural_equal_hash.py
+++ b/tests/python/relay/test_ir_structural_equal_hash.py
@@ -16,6 +16,7 @@
 # under the License.
 import numpy as np
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay.testing import run_opt_pass
 
@@ -796,7 +797,4 @@ def test_lets():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm.testing
 from tvm import te
 from tvm import relay
 from tvm.relay import testing
@@ -307,7 +308,4 @@ def test_slash_in_identifier():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_grad_level1.py
+++ b/tests/python/relay/test_op_grad_level1.py
@@ -213,4 +213,4 @@ def test_concatenate_grad(target, dev):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_grad_level10.py
+++ b/tests/python/relay/test_op_grad_level10.py
@@ -131,4 +131,4 @@ def test_one_hot_grad(target, dev, index_dtype, val_dtype):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -717,4 +717,4 @@ def test_nll_loss(dev, target):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -1995,4 +1995,4 @@ def test_conv2d_rocm_sdot4():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -2215,4 +2215,4 @@ class TestSTFT:
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level4.py
+++ b/tests/python/relay/test_op_level4.py
@@ -659,4 +659,4 @@ def test_strided_set():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -1612,4 +1612,4 @@ def test_all_class_non_max_suppression():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/relay/test_op_qnn_unary_elementwise.py
+++ b/tests/python/relay/test_op_qnn_unary_elementwise.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 import scipy.special
 import tvm
+import tvm.testing
 from tvm import relay
 
 
@@ -209,6 +210,4 @@ class TestSigmoid:
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_annotate_spans_defuse.py
+++ b/tests/python/relay/test_pass_annotate_spans_defuse.py
@@ -52,7 +52,4 @@ def test_annotate_spans_compatibility():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_dead_code_elimination.py
+++ b/tests/python/relay/test_pass_dead_code_elimination.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm.testing
 from tvm.relay import Function, transform
 from tvm.relay.testing import inception_v3
 import pytest
@@ -347,6 +348,4 @@ def test_complexity():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay.transform import fake_quantization_to_integer
 
@@ -1017,6 +1018,4 @@ def test_fq_qat_intermediate_infertype():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_flatten_atrous_conv.py
+++ b/tests/python/relay/test_pass_flatten_atrous_conv.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.contrib import graph_executor
 
@@ -467,6 +468,4 @@ def test_fac_relay_build():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_fold_constant.py
+++ b/tests/python/relay/test_pass_fold_constant.py
@@ -16,6 +16,7 @@
 # under the License.
 import numpy as np
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay.backend import Executor
 from tvm.relay import transform
@@ -572,7 +573,4 @@ def test_pass_link_params():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_lazy_gradient_init.py
+++ b/tests/python/relay/test_pass_lazy_gradient_init.py
@@ -445,7 +445,4 @@ def test_ones_like():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_manifest_lifetimes.py
+++ b/tests/python/relay/test_pass_manifest_lifetimes.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm.testing
 from tvm.relay import Function, transform
 from tvm.relay.testing import inception_v3
 import pytest
@@ -144,4 +145,4 @@ def test_simple_match():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_partial_eval.py
+++ b/tests/python/relay/test_pass_partial_eval.py
@@ -17,6 +17,7 @@
 
 import numpy as np
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay.prelude import Prelude
 from tvm.relay import op, create_executor, transform
@@ -350,7 +351,4 @@ def test_tuple_match():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -1703,7 +1703,4 @@ def test_stack_overflow():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_to_a_normal_form.py
+++ b/tests/python/relay/test_pass_to_a_normal_form.py
@@ -18,6 +18,7 @@ import pytest
 import sys
 import numpy as np
 import tvm
+import tvm.testing
 from tvm import te
 from tvm import relay
 from tvm.relay.analysis import detect_feature
@@ -228,4 +229,4 @@ def test_gradient_if():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_to_cps.py
+++ b/tests/python/relay/test_pass_to_cps.py
@@ -16,6 +16,7 @@
 # under the License.
 import numpy as np
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.relay.analysis import detect_feature
 from tvm.relay.transform import to_cps, un_cps
@@ -123,7 +124,4 @@ def test_cps_pe():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_prng.py
+++ b/tests/python/relay/test_prng.py
@@ -166,6 +166,4 @@ def test_threefry_generate_out_size():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_relay_te_compiler.py
+++ b/tests/python/relay/test_relay_te_compiler.py
@@ -24,7 +24,6 @@ from tvm import topi
 from tvm.relay.backend import te_compiler
 from tvm.relay.testing import run_infer_type
 from tvm.relay.testing.temp_op_attr import TempOpAttr
-import tvm.testing
 
 
 @autotvm.register_topi_compute("test/conv2d_1")

--- a/tests/python/relay/test_target_hooks.py
+++ b/tests/python/relay/test_target_hooks.py
@@ -19,6 +19,7 @@ import sys
 import numpy as np
 import pytest
 
+import tvm.testing
 from tvm import relay, IRModule
 
 from utils.external_codegen import (
@@ -73,4 +74,4 @@ def test_runtime_module_generation(check_result):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -1406,6 +1406,4 @@ def test_vm_save_and_load_without_designating_late_bound_consts():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/target/test_virtual_device.py
+++ b/tests/python/target/test_virtual_device.py
@@ -16,6 +16,7 @@
 # under the License.
 import pytest
 import tvm
+import tvm.testing
 
 
 def test_make_virtual_device_for_device():
@@ -45,7 +46,4 @@ def test_make_virtual_device_for_device_target_and_memory_scope():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/tir/analysis/test_device_constraint_utils.py
+++ b/tests/python/tir/analysis/test_device_constraint_utils.py
@@ -16,6 +16,7 @@
 # under the License.
 """Test retrieving and applying memory scope constraints to PrimFuncs"""
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm import relay
 from tvm.script import tir as T
@@ -64,7 +65,4 @@ def test_apply_prim_func_arg_and_result_memory_constraints():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_conv1d_transpose_ncw.py
+++ b/tests/python/topi/python/test_topi_conv1d_transpose_ncw.py
@@ -118,4 +118,4 @@ def test_conv1d_transpose_ncw(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_conv2d_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_int8.py
@@ -674,4 +674,4 @@ def test_conv2d_nhwc():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_conv2d_nchw.py
+++ b/tests/python/topi/python/test_topi_conv2d_nchw.py
@@ -351,4 +351,4 @@ class TestBiasRelu(BaseConv2DTests):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_conv2d_nhwc.py
+++ b/tests/python/topi/python/test_topi_conv2d_nhwc.py
@@ -96,4 +96,4 @@ def test_conv2d_nhwc(target, dev, ref_data, dtype, stride, padding, dilation):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_correlation.py
+++ b/tests/python/topi/python/test_topi_correlation.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 
 import tvm
+import tvm.testing
 import tvm.topi.testing
 
 from tvm import autotvm, te, topi
@@ -93,4 +94,4 @@ def test_correlation_nchw(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_dense.py
+++ b/tests/python/topi/python/test_topi_dense.py
@@ -181,4 +181,4 @@ def test_dense_cuda_int8(
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_depthwise_conv2d.py
+++ b/tests/python/topi/python/test_topi_depthwise_conv2d.py
@@ -438,4 +438,4 @@ class TestDepthwiseConv2DArmCompile(BaseDepthwiseConv2D):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_loss.py
+++ b/tests/python/topi/python/test_topi_loss.py
@@ -65,4 +65,4 @@ def test_nll_loss(target, dev, prediction_shape, reduction, ignore_index, dtype)
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_math.py
+++ b/tests/python/topi/python/test_topi_math.py
@@ -237,4 +237,4 @@ def test_cast(target, dev, cast_ref_data, from_dtype, to_dtype):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_reduce.py
+++ b/tests/python/topi/python/test_topi_reduce.py
@@ -184,4 +184,4 @@ def test_complex_reduce(target, dev):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_relu.py
+++ b/tests/python/topi/python/test_topi_relu.py
@@ -113,4 +113,4 @@ def test_prelu(x, w, axis, weight_reshape):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_softmax.py
+++ b/tests/python/topi/python/test_topi_softmax.py
@@ -105,4 +105,4 @@ def test_softmax(target, dev, shape, dtype, ref_data, softmax_operation):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_sort.py
+++ b/tests/python/topi/python/test_topi_sort.py
@@ -159,4 +159,4 @@ def test_topk(target, dev, topk, axis, topk_ret_type, is_ascend, dtype):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_unique.py
+++ b/tests/python/topi/python/test_topi_unique.py
@@ -111,4 +111,4 @@ def test_unique(dev, target, in_dtype, is_sorted, with_counts, arr_size, maxval)
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/topi/python/test_topi_vision.py
+++ b/tests/python/topi/python/test_topi_vision.py
@@ -717,4 +717,4 @@ def test_all_class_non_max_suppression(target, dev):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_auto_scheduler_measure.py
+++ b/tests/python/unittest/test_auto_scheduler_measure.py
@@ -424,7 +424,4 @@ def test_measure_special_inputs_map_by_name_rpc_runner():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_auto_scheduler_sketch_generation.py
+++ b/tests/python/unittest/test_auto_scheduler_sketch_generation.py
@@ -451,4 +451,4 @@ def test_cuda_zero_rank_sketch():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -400,4 +400,4 @@ def test_autotune():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_gen_requirements.py
+++ b/tests/python/unittest/test_gen_requirements.py
@@ -24,6 +24,7 @@ import os
 import sys
 
 import tvm
+import tvm.testing
 
 import pytest
 
@@ -217,4 +218,4 @@ def test_semver():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_index_map.py
+++ b/tests/python/unittest/test_index_map.py
@@ -18,6 +18,7 @@
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.tir import IndexMap
 from tvm.ir import assert_structural_equal
 
@@ -186,4 +187,4 @@ def test_nonsurjective_inverse(padding_test_case):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -382,4 +382,4 @@ def test_crt_link_params(linkable_dtype):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_builder.py
+++ b/tests/python/unittest/test_meta_schedule_builder.py
@@ -22,6 +22,7 @@ import time
 from typing import List
 
 import pytest
+import tvm.testing
 
 from tvm import script
 from tvm._ffi import register_func
@@ -225,4 +226,4 @@ def test_meta_schedule_missing_build_func():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_byoc_tensorrt.py
+++ b/tests/python/unittest/test_meta_schedule_byoc_tensorrt.py
@@ -22,6 +22,7 @@ from typing import List
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import relay
 from tvm.meta_schedule.arg_info import TensorInfo
 from tvm.meta_schedule.builder import BuilderInput, LocalBuilder
@@ -168,4 +169,4 @@ def test_relay_model(model_name: str, input_shape: List[int], use_trt: bool):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_cost_model.py
+++ b/tests/python/unittest/test_meta_schedule_cost_model.py
@@ -25,6 +25,7 @@ from typing import List
 import numpy as np
 import pytest
 import tvm
+import tvm.testing
 from tvm.meta_schedule.cost_model import PyCostModel, RandomModel, XGBModel
 from tvm.meta_schedule.feature_extractor import RandomFeatureExtractor
 from tvm.meta_schedule.runner import RunnerResult
@@ -228,4 +229,4 @@ def test_meta_schedule_xgb_model_reupdate():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_database.py
+++ b/tests/python/unittest/test_meta_schedule_database.py
@@ -23,6 +23,7 @@ from typing import Callable
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.ir.module import IRModule
 from tvm.meta_schedule.arg_info import ArgInfo
@@ -296,4 +297,4 @@ def test_meta_schedule_database_reload():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_feature_extractor_per_store_feature.py
+++ b/tests/python/unittest/test_meta_schedule_feature_extractor_per_store_feature.py
@@ -20,6 +20,7 @@ from typing import Callable, List
 
 import pytest
 import tvm
+import tvm.testing
 from numpy.testing import assert_allclose
 from tvm import meta_schedule as ms
 from tvm import te, tir
@@ -1588,4 +1589,4 @@ def test_cpu_layout_transform():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -286,4 +286,4 @@ def test_extract_task_arm_conv2d_nchwc():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_post_order_apply.py
+++ b/tests/python/unittest/test_meta_schedule_post_order_apply.py
@@ -22,6 +22,7 @@ from typing import List
 
 import pytest
 import tvm
+import tvm.testing
 from tvm._ffi import register_func
 from tvm.error import TVMError
 from tvm.meta_schedule import TuneContext
@@ -388,4 +389,4 @@ def test_meta_schedule_custom_search_space():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_postproc_verify_gpu_code.py
+++ b/tests/python/unittest/test_meta_schedule_postproc_verify_gpu_code.py
@@ -20,6 +20,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.meta_schedule import TuneContext
 from tvm.meta_schedule.postproc import VerifyGPUCode
@@ -452,4 +453,4 @@ def test_postproc_verify_gpu_6():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_runner.py
+++ b/tests/python/unittest/test_meta_schedule_runner.py
@@ -890,4 +890,4 @@ def test_meta_schedule_local_runner_add_test():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_search_strategy.py
+++ b/tests/python/unittest/test_meta_schedule_search_strategy.py
@@ -21,6 +21,7 @@ from typing import List
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import meta_schedule as ms
 from tvm.meta_schedule import TuneContext
 from tvm.meta_schedule.runner import RunnerResult
@@ -242,4 +243,4 @@ def test_meta_schedule_evolutionary_search_early_stop():  # pylint: disable = in
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_space_generator.py
+++ b/tests/python/unittest/test_meta_schedule_space_generator.py
@@ -23,6 +23,7 @@ import math
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.meta_schedule.utils import derived_object
 from tvm.meta_schedule.space_generator import ScheduleFn, PySpaceGenerator, SpaceGeneratorUnion
 from tvm.meta_schedule.tune_context import TuneContext
@@ -101,4 +102,4 @@ def test_meta_schedule_design_space_generator_NIE():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_task_scheduler.py
+++ b/tests/python/unittest/test_meta_schedule_task_scheduler.py
@@ -23,6 +23,7 @@ from typing import Set
 
 import pytest
 import tvm
+import tvm.testing
 from tvm._ffi.base import TVMError
 from tvm.meta_schedule import TuneContext, measure_callback
 from tvm.meta_schedule.search_strategy import ReplayTrace
@@ -365,4 +366,4 @@ def test_meta_schedule_task_scheduler_multiple_gradient_based():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_tune_context.py
+++ b/tests/python/unittest/test_meta_schedule_tune_context.py
@@ -20,6 +20,7 @@ import sys
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.script import tir as T
 from tvm.target import Target
 from tvm.meta_schedule import TuneContext
@@ -56,4 +57,4 @@ def test_tune_context_create():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -429,6 +429,4 @@ def test_export_byoc_c_module():
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_micro_project_api.py
+++ b/tests/python/unittest/test_micro_project_api.py
@@ -25,6 +25,7 @@ from unittest import mock
 import pytest
 
 import tvm
+import tvm.testing
 
 
 # Implementing as a fixture so that the tvm.micro import doesn't occur
@@ -494,4 +495,4 @@ def test_invalid_request(BaseTestHandler):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_micro_transport.py
+++ b/tests/python/unittest/test_micro_transport.py
@@ -222,4 +222,4 @@ def test_write_keyboard_interrupt(transport, transport_logger, get_latest_log):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_node_reflection.py
+++ b/tests/python/unittest/test_node_reflection.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm.testing
 import sys
 import pytest
 from tvm import te
@@ -195,4 +196,4 @@ def test_alloc_const():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_runtime_graph_debug.py
+++ b/tests/python/unittest/test_runtime_graph_debug.py
@@ -256,4 +256,4 @@ def test_run_single_node(graph, n, A, myadd):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_runtime_profiling.py
+++ b/tests/python/unittest/test_runtime_profiling.py
@@ -358,7 +358,4 @@ def test_roofline_analysis_rpc():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_runtime_rpc.py
+++ b/tests/python/unittest/test_runtime_rpc.py
@@ -34,7 +34,7 @@ from tvm.rpc.proxy import Proxy
 
 if __name__ == "__main__":
     # NOTE: must live here to avoid registering PackedFunc with libtvm.so twice.
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()
 
 
 # tkonolige: The issue as I understand it is this: multiprocessing's spawn

--- a/tests/python/unittest/test_runtime_vm_profiler.py
+++ b/tests/python/unittest/test_runtime_vm_profiler.py
@@ -17,6 +17,7 @@
 import numpy as np
 
 import tvm
+import tvm.testing
 from tvm.runtime import profiler_vm
 from tvm import relay
 from tvm.relay.testing import mlp
@@ -54,7 +55,4 @@ def test_vm_reshape_and_copy():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_codegen_bool.py
+++ b/tests/python/unittest/test_target_codegen_bool.py
@@ -17,6 +17,7 @@
 """codegen related to bool types"""
 
 import tvm
+import tvm.testing
 from tvm import te
 import numpy as np
 import tvm.testing
@@ -71,4 +72,4 @@ def test_cmp_load_store(target, dev, arr_size, compute, schedule):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_codegen_hexagon.py
+++ b/tests/python/unittest/test_target_codegen_hexagon.py
@@ -116,4 +116,4 @@ def test_llvm_options():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -977,4 +977,4 @@ def test_llvm_target_attributes():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -554,6 +554,4 @@ def test_shared_mem_alloc(target, dev):
 
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm.target import Target, arm_cpu, bifrost, cuda, intel_graphics, mali, rocm, vta
 
 
@@ -455,4 +456,4 @@ def test_target_attr_bool_value():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_texture_codegen_opencl.py
+++ b/tests/python/unittest/test_target_texture_codegen_opencl.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import autotvm
 from tvm import te
 from tvm.topi import testing
@@ -1397,4 +1398,4 @@ class TestDepthwiseConv2dNCHWcKCRSk(BaseConv2DValidator):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -18,6 +18,7 @@
 import sys
 
 import pytest
+import tvm.testing
 from tvm.ir import IRModule
 from tvm.meta_schedule.testing.te_workload import create_te_workload
 from tvm.tir.analysis import estimate_tir_flops
@@ -48,4 +49,4 @@ def test_te_workload(workload, flops):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_renew_defs.py
+++ b/tests/python/unittest/test_tir_renew_defs.py
@@ -19,6 +19,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm.script import tir as T
 from tvm.tir.buffer import Buffer
 from tvm.tir.function import PrimFunc
@@ -168,4 +169,4 @@ def test_symbolic_func():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_block_scope.py
+++ b/tests/python/unittest/test_tir_schedule_block_scope.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule import DepKind
@@ -151,4 +152,4 @@ def test_war_dependency():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_blockize.py
+++ b/tests/python/unittest/test_tir_schedule_blockize.py
@@ -18,6 +18,7 @@
 import sys
 import pytest
 import tvm
+import tvm.testing
 from tvm.script import tir as T
 from tvm import tir
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -207,4 +208,4 @@ def test_blockize_init_loops():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_cache_read_write.py
+++ b/tests/python/unittest/test_tir_schedule_cache_read_write.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -925,4 +926,4 @@ def test_cache_write_fail_invalid_storage_scope():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_compute_at.py
+++ b/tests/python/unittest/test_tir_schedule_compute_at.py
@@ -20,6 +20,7 @@ import sys
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -1297,4 +1298,4 @@ def test_fail_all_producers_under_loop():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_compute_inline.py
+++ b/tests/python/unittest/test_tir_schedule_compute_inline.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -737,4 +738,4 @@ def test_compute_inline_opaque_access_with_tvm_access_ptr():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_error.py
+++ b/tests/python/unittest/test_tir_schedule_error.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 
@@ -74,4 +75,4 @@ def test_tir_schedule_attribute_error():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_for_kind.py
+++ b/tests/python/unittest/test_tir_schedule_for_kind.py
@@ -656,4 +656,4 @@ def test_scatter_parallelize():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_instruction.py
+++ b/tests/python/unittest/test_tir_schedule_instruction.py
@@ -19,6 +19,7 @@
 import sys
 
 import pytest
+import tvm.testing
 from tvm.tir.schedule import BlockRV, Instruction, InstructionKind, LoopRV
 
 
@@ -65,4 +66,4 @@ def test_inst_construct_2():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_reduction.py
+++ b/tests/python/unittest/test_tir_schedule_reduction.py
@@ -295,4 +295,4 @@ def test_decompose_reduction_ref_hash_check():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_reorder.py
+++ b/tests/python/unittest/test_tir_schedule_reorder.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -368,4 +369,4 @@ def test_reorder_fail_not_affine_bindings():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_rfactor.py
+++ b/tests/python/unittest/test_tir_schedule_rfactor.py
@@ -858,4 +858,4 @@ def test_reduction_rfactor_spatial_only():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_sampling.py
+++ b/tests/python/unittest/test_tir_schedule_sampling.py
@@ -19,6 +19,7 @@ import sys
 
 import numpy
 import pytest
+import tvm.testing
 
 from tvm import tir
 from tvm.script import tir as T
@@ -206,4 +207,4 @@ def test_sample_perfect_tile_after_copy():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_set_axis_separator.py
+++ b/tests/python/unittest/test_tir_schedule_set_axis_separator.py
@@ -18,6 +18,7 @@
 import sys
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -136,4 +137,4 @@ def test_set_axis_separator_subregion():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_split_fuse.py
+++ b/tests/python/unittest/test_tir_schedule_split_fuse.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -524,4 +525,4 @@ def test_fuse_not_affine():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_state.py
+++ b/tests/python/unittest/test_tir_schedule_state.py
@@ -20,6 +20,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.ir import IRModule
 from tvm.script import tir as T
@@ -351,4 +352,4 @@ def test_replace_ir_module():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_state_cached_flags.py
+++ b/tests/python/unittest/test_tir_schedule_state_cached_flags.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.state import CachedFlags
@@ -781,4 +782,4 @@ def test_uncovered_producer_region():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_tensorize.py
+++ b/tests/python/unittest/test_tir_schedule_tensorize.py
@@ -646,4 +646,4 @@ def test_tensorize_dpa4():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_trace.py
+++ b/tests/python/unittest/test_tir_schedule_trace.py
@@ -20,6 +20,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule import BlockRV, Instruction, InstructionKind, LoopRV, Trace
@@ -275,4 +276,4 @@ def test_apply_json_to_schedule_1():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_transform_layout.py
+++ b/tests/python/unittest/test_tir_schedule_transform_layout.py
@@ -20,6 +20,7 @@ import sys
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
@@ -159,4 +160,4 @@ def test_simplify():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_utilities.py
+++ b/tests/python/unittest/test_tir_schedule_utilities.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 
 from tvm import tir
 from tvm.ir import IRModule
@@ -270,4 +271,4 @@ def test_annotate_unannotate_block():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_texture_scope.py
+++ b/tests/python/unittest/test_tir_texture_scope.py
@@ -18,6 +18,7 @@
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.ir.module import IRModule
 from tvm import tir
 from tvm.script import tir as T
@@ -59,4 +60,4 @@ def test_texture_scope():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -17,6 +17,7 @@
 import pytest
 import sys
 import tvm
+import tvm.testing
 from tvm import te
 from tvm.script import tir as T
 
@@ -740,4 +741,4 @@ def test_compact_with_let_binding():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_inject_software_pipeline.py
+++ b/tests/python/unittest/test_tir_transform_inject_software_pipeline.py
@@ -18,6 +18,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import tir, te, TVMError
 from tvm.script import tir as T
 
@@ -1022,4 +1023,4 @@ def test_error_missing_annotation():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_lower_cross_thread_reduction.py
+++ b/tests/python/unittest/test_tir_transform_lower_cross_thread_reduction.py
@@ -18,6 +18,7 @@ import sys
 
 import pytest
 import tvm
+import tvm.testing
 from tvm import te
 from tvm.script import tir as T
 
@@ -895,4 +896,4 @@ def test_lower_te():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_storage_flatten.py
+++ b/tests/python/unittest/test_tir_transform_storage_flatten.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm.testing
 from tvm import te
 from tvm.driver.build_module import schedule_to_module
 from tvm.script import tir as T
@@ -165,4 +166,4 @@ def test_flatten_tir():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_storage_rewrite.py
+++ b/tests/python/unittest/test_tir_transform_storage_rewrite.py
@@ -17,6 +17,7 @@
 import sys
 import pytest
 import tvm
+import tvm.testing
 from tvm import te
 from tvm.driver.build_module import schedule_to_module
 from tvm.script import tir as T
@@ -671,4 +672,4 @@ def test_access_in_let_value():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_unify_thread_binding.py
+++ b/tests/python/unittest/test_tir_transform_unify_thread_binding.py
@@ -18,6 +18,7 @@ import pytest
 import sys
 
 import tvm
+import tvm.testing
 from tvm import te
 from tvm.script import tir as T
 
@@ -256,4 +257,4 @@ def test_lower_te():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_usmp_algo_hill_climb.py
+++ b/tests/python/unittest/test_tir_usmp_algo_hill_climb.py
@@ -18,6 +18,7 @@ import sys
 import pytest
 import random
 import tvm
+import tvm.testing
 from tvm.tir.usmp.utils import BufferInfo, PoolInfo
 
 
@@ -391,4 +392,4 @@ def run_intervals(intervals):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_transform_layout.py
+++ b/tests/python/unittest/test_transform_layout.py
@@ -576,4 +576,4 @@ def test_size_one_buffer(shape, transform):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tvm_testing_features.py
+++ b/tests/python/unittest/test_tvm_testing_features.py
@@ -291,4 +291,4 @@ class TestCacheableTypes:
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -664,4 +664,4 @@ def test_illegal_buffer_slice():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3335,4 +3335,4 @@ def test_roundtrip(ir_generator):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -18,6 +18,7 @@
 import sys
 
 import pytest
+import tvm.testing
 from tvm.ir import assert_structural_equal
 from tvm.script import tir as T
 from tvm.script.parser import from_source
@@ -347,4 +348,4 @@ def test_func_call():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()


### PR DESCRIPTION
This PR replaces the test call to `pytest.main` 
```
sys.exit(pytest.main([test_file] + sys.argv[1:]))
```
with a call to a [utility function:](https://github.com/gigiblender/tvm/blob/056203325589cece8478d4830ec840bec71b5b38/python/tvm/testing/utils.py#L1518) 

#11318 