### PR TITLE
[skip ci] Fix scipy intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,7 @@ latex_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
     # "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/", None),
     # "matplotlib": ("https://matplotlib.org/", None),
 }
 


### PR DESCRIPTION
Follow-up from https://github.com/apache/tvm/pull/10181, as the URL has changed again in https://github.com/scipy/scipy/pull/16221.  From [this comment](https://github.com/scipy/scipy/issues/14267#issuecomment-1034196161), the `html-scipyorg` portion wasn't intended to be part of the URL.

This should resolve the HTTP 404 occurring in `Docs: GPU` step (e.g. [here](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11269/13/pipeline/405#step-975-log-73)), by accessing `https://docs.scipy.org/doc/scipy-1.8.0/objects.inv`
instead of `https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/objects.inv`