### PR TITLE
Fix command line input process issue.

### DIFF
--- a/docker/install/ubuntu_install_cmsis.sh
+++ b/docker/install/ubuntu_install_cmsis.sh
@@ -27,7 +27,7 @@ INSTALLATION_PATH is the installation path for the CMSIS.
 EOF
 }
 
-if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then
+if [ "$#" -lt 1 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
     show_usage
     exit -1
 fi


### PR DESCRIPTION
I think previously by  " if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then xxx" we are trying to realize when the user input non-para, we will show help_info too? So if use previous one, it may shows unbound variable $1, may not what we hope to do.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
