### PR TITLE
[CI] Revert #10181 / #11399, use non-versioned scipy intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,7 @@ latex_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
     # "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
     # "matplotlib": ("https://matplotlib.org/", None),
 }
 


### PR DESCRIPTION
Follow-up from https://github.com/apache/tvm/pull/10181 and https://github.com/apache/tvm/pull/11399.  Thank you to @rgommers for [pointing out](https://github.com/apache/tvm/pull/11399#issuecomment-1133874138) that the non-versioned link is stable and working.  The use of the versioned link was only introduced to work around the breakage of the stable link, so this reverts to the pre-breakage behavior.