### PR TITLE
[Topi][Relay] Support for FP16 ERF on CPU.

### DIFF
--- a/include/tvm/topi/elemwise.h
+++ b/include/tvm/topi/elemwise.h
@@ -538,8 +538,7 @@ inline Tensor fast_erf(const Tensor& x, std::string name = "T_fast_erf",
   } else if (x->dtype == DataType::Float(16)) {
     auto ret = fast_erf_float16(x, name, tag);
     return ret;
-  } 
-  else {
+  } else {
     return topi::erf(x);
   }
 }

--- a/include/tvm/topi/elemwise.h
+++ b/include/tvm/topi/elemwise.h
@@ -513,6 +513,15 @@ inline Tensor fast_erf_float32(const Tensor& data, std::string name, std::string
 }
 
 /*!
+ * \brief Fast_erf_float expression from Eigen for float16.
+ */
+inline Tensor fast_erf_float16(const Tensor& data, std::string name, std::string tag) {
+  return compute(
+      data->shape, [&](const Array<Var>& i) { return fast_erf_float_expr(data(i), 16); }, name,
+      tag);
+}
+
+/*!
  * \brief Fast erf implementation
  *
  * \param x The input tensor
@@ -526,7 +535,11 @@ inline Tensor fast_erf(const Tensor& x, std::string name = "T_fast_erf",
   if (x->dtype == DataType::Float(32)) {
     auto ret = fast_erf_float32(x, name, tag);
     return ret;
-  } else {
+  } else if (x->dtype == DataType::Float(16)) {
+    auto ret = fast_erf_float16(x, name, tag);
+    return ret;
+  } 
+  else {
     return topi::erf(x);
   }
 }

--- a/python/tvm/relay/op/_tensor.py
+++ b/python/tvm/relay/op/_tensor.py
@@ -21,7 +21,7 @@ from tvm.te.hybrid import script
 from tvm import topi
 from tvm.runtime import convert
 
-from .op import register_compute, register_shape_func
+from .op import register_compute, register_shape_func, register_legalize
 from .op import register_broadcast_schedule, register_injective_schedule
 from .op import register_pattern, OpPattern
 
@@ -91,6 +91,27 @@ register_injective_schedule("device_copy")
 register_broadcast_schedule("fast_exp")
 register_broadcast_schedule("fast_tanh")
 register_broadcast_schedule("fast_erf")
+
+
+@register_legalize("erf")
+def legalize_erf(attrs, inputs, types):
+    """Legalize ERF op.
+    
+    Parameters
+    ----------
+    attrs : tvm.ir.Attrs
+        Attributes of current convolution
+    inputs : list of tvm.relay.Expr
+        The args of the Relay expr to be legalized
+    types : list of types
+        List of input and output types
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The legalized expr
+    """
+    return topi.math.erf_legalize(attrs, inputs, types)
 
 
 # zeros

--- a/python/tvm/relay/op/_tensor.py
+++ b/python/tvm/relay/op/_tensor.py
@@ -96,7 +96,7 @@ register_broadcast_schedule("fast_erf")
 @register_legalize("erf")
 def legalize_erf(attrs, inputs, types):
     """Legalize ERF op.
-    
+
     Parameters
     ----------
     attrs : tvm.ir.Attrs

--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -92,6 +92,28 @@ def erf(x):
     return te.compute(x.shape, lambda *i: te.erf(x(*i)))
 
 
+@tvm.target.generic_func
+def erf_legalize(attrs, inputs, types):
+    """Legalizes ERF op.
+
+    Parameters
+    ----------
+    attrs : tvm.ir.Attrs
+        Attributes of current convolution
+    inputs : list of tvm.relay.Expr
+        The args of the Relay expr to be legalized
+    types : list of types
+        List of input and output types
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The legalized expr.
+    """
+    # Note changed by default.
+    return None
+
+
 @tvm.te.tag_scope(tag=tag.ELEMWISE)
 def tanh(x):
     """Take hyperbolic tanh of input x.

--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Elementwise operators"""
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,unused-arguments
 import tvm
 from tvm import te
 from . import tag

--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Elementwise operators"""
-# pylint: disable=redefined-builtin,unused-arguments
+# pylint: disable=redefined-builtin,unused-argument
 import tvm
 from tvm import te
 from . import tag

--- a/python/tvm/topi/x86/__init__.py
+++ b/python/tvm/topi/x86/__init__.py
@@ -42,3 +42,4 @@ from .conv2d_alter_op import *
 from .dense_alter_op import *
 from .scatter import *
 from .group_conv2d import *
+from .math_alter_op import *

--- a/python/tvm/topi/x86/math_alter_op.py
+++ b/python/tvm/topi/x86/math_alter_op.py
@@ -50,9 +50,9 @@ def _erf_legalize(attrs, inputs, arg_types):
     data_dtype = data_tensor.dtype
     # If input is not fp32, we must cast to it.
     if data_dtype != "float32":
-       data = relay.cast(data, "float32")
-       output = relay.erf(data)
-       return relay.cast(output, data_dtype)
-    
+        data = relay.cast(data, "float32")
+        output = relay.erf(data)
+        return relay.cast(output, data_dtype)
+
     # Otherwise do nothing.
     return None

--- a/python/tvm/topi/x86/math_alter_op.py
+++ b/python/tvm/topi/x86/math_alter_op.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+"""Legalization transforms for math operations on x86"""
+
+import logging
+
+from tvm import relay
+from ..math import erf_legalize
+
+logger = logging.getLogger("topi")
+
+
+@erf_legalize.register("cpu")
+def _erf_legalize(attrs, inputs, arg_types):
+    """Legalizes ERF op if needed.
+
+    Parameters
+    ----------
+    attrs : tvm.ir.Attrs
+        Attributes of current convolution
+    inputs : list of tvm.relay.Expr
+        The args of the Relay expr to be legalized
+    types : list of types
+        List of input and output types
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The legalized expr
+    """
+    # Extract types and expressions.
+    data = inputs[0]
+    data_tensor = arg_types[0]
+    # Check if the input type is supported.
+    data_dtype = data_tensor.dtype
+    # If input is not fp32, we must cast to it.
+    if data_dtype != "float32":
+       data = relay.cast(data, "float32")
+       output = relay.erf(data)
+       return relay.cast(output, data_dtype)
+    
+    # Otherwise do nothing.
+    return None

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -108,7 +108,8 @@ class TestUnaryOp:
             # use graph by execuor default for testing, as we need
             # create function explicitly to avoid constant-folding.
             op_res = relay.create_executor("graph", device=dev, target=target).evaluate(func)(data)
-            np.testing.assert_allclose(op_res.numpy(), ref_res, rtol=1e-5)
+            tolerance = 1e-2 if dtype == "float16" else 1e-5
+            np.testing.assert_allclose(op_res.numpy(), ref_res, rtol=tolerance)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -44,30 +44,31 @@ def rsqrt(x):
 
 
 class TestUnaryOp:
+    # Tuple of (operator, reference op, supports fp16)
     op_list = {
-        "log": (tvm.relay.log, np.log),
-        "exp": (tvm.relay.exp, np.exp),
-        "erf": (tvm.relay.erf, scipy.special.erf),
-        "sqrt": (tvm.relay.sqrt, np.sqrt),
-        "rqsrt": (tvm.relay.rsqrt, rsqrt),
-        "sigmoid": (tvm.relay.sigmoid, sigmoid),
-        "tanh": (tvm.relay.tanh, np.tanh),
-        "relu": (relay.nn.relu, relu),
-        "cos": (tvm.relay.cos, np.cos),
-        "sin": (tvm.relay.sin, np.sin),
-        "tan": (tvm.relay.tan, np.tan),
-        "atan": (tvm.relay.atan, np.arctan),
-        "ceil": (tvm.relay.ceil, np.ceil),
-        "floor": (tvm.relay.floor, np.floor),
-        "trunc": (tvm.relay.trunc, np.trunc),
-        "round": (tvm.relay.round, np.round),
+        "log": (tvm.relay.log, np.log, True),
+        "exp": (tvm.relay.exp, np.exp, True),
+        "erf": (tvm.relay.erf, scipy.special.erf, True),
+        "sqrt": (tvm.relay.sqrt, np.sqrt, True),
+        "rqsrt": (tvm.relay.rsqrt, rsqrt, True),
+        "sigmoid": (tvm.relay.sigmoid, sigmoid, True),
+        "tanh": (tvm.relay.tanh, np.tanh, False),
+        "relu": (relay.nn.relu, relu, True),
+        "cos": (tvm.relay.cos, np.cos, True),
+        "sin": (tvm.relay.sin, np.sin, True),
+        "tan": (tvm.relay.tan, np.tan, False),
+        "atan": (tvm.relay.atan, np.arctan, False),
+        "ceil": (tvm.relay.ceil, np.ceil, True),
+        "floor": (tvm.relay.floor, np.floor, True),
+        "trunc": (tvm.relay.trunc, np.trunc, True),
+        "round": (tvm.relay.round, np.round, False),
     }
 
     dtype = tvm.testing.parameter("float16", "float32")
 
-    relay_op, ref_func = tvm.testing.parameters(*op_list.values(), ids=op_list.keys())
+    relay_op, ref_func, supports_fp16 = tvm.testing.parameters(*op_list.values(), ids=op_list.keys())
 
-    def test_unary_op(self, target, dev, relay_op, ref_func, dtype):
+    def test_unary_op(self, target, dev, relay_op, ref_func, supports_fp16, dtype):
         target = tvm.target.Target(target)
         if dtype == "float16":
             if target.kind.name == "cuda":
@@ -77,7 +78,7 @@ class TestUnaryOp:
                     )
             elif target.kind.name == "vulkan" and not target.attrs.get("supports_float16", False):
                 pytest.xfail("No float16 support on vulkan target (supports_float16=False)")
-            else:
+            elif not supports_fp16:
                 pytest.xfail(f"No float16 support on {target.kind.name} target")
 
         if target.kind.name == "vulkan" and relay_op in [

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -66,7 +66,9 @@ class TestUnaryOp:
 
     dtype = tvm.testing.parameter("float16", "float32")
 
-    relay_op, ref_func, supports_fp16 = tvm.testing.parameters(*op_list.values(), ids=op_list.keys())
+    relay_op, ref_func, supports_fp16 = tvm.testing.parameters(
+        *op_list.values(), ids=op_list.keys()
+    )
 
     def test_unary_op(self, target, dev, relay_op, ref_func, supports_fp16, dtype):
         target = tvm.target.Target(target)

--- a/tests/python/topi/python/test_topi_math.py
+++ b/tests/python/topi/python/test_topi_math.py
@@ -161,7 +161,7 @@ def ewise_ref_data(topi_name, dtype):
         a_np += ((np.abs(np.fmod(a_np, 1)) - 0.5) < 1e-6) * 1e-4
 
     b_np = config["ref"](a_np)
-    
+
     if config.get("cast_output", False):
         b_np = b_np.astype(dtype)
 

--- a/tests/python/topi/python/test_topi_math.py
+++ b/tests/python/topi/python/test_topi_math.py
@@ -117,8 +117,11 @@ ewise_operations = {
         "skip_name_check": True,
         "input_range": (-10, 10),
         "step": 0.01,
+        "dtypes": ["float32", "float16"],
+        "cast_output": True,
+        "tolerance": [1e-5, 1e-1],
     },
-    "fast_erf": {
+    "fast_tanh": {
         "topi": topi.fast_tanh,
         "ref": np.tanh,
         "skip_name_check": True,
@@ -127,11 +130,11 @@ ewise_operations = {
     },
 }
 
-topi_name, dtype = tvm.testing.parameters(
+topi_name, dtype, tolerance = tvm.testing.parameters(
     *[
-        (name, dtype)
+        (name, dtype, config.get("tolerance", [1e-5] * len(dtype))[i])
         for name, config in ewise_operations.items()
-        for dtype in config.get("dtypes", ["float32"])
+        for i, dtype in enumerate(config.get("dtypes", ["float32"]))
     ]
 )
 
@@ -158,11 +161,14 @@ def ewise_ref_data(topi_name, dtype):
         a_np += ((np.abs(np.fmod(a_np, 1)) - 0.5) < 1e-6) * 1e-4
 
     b_np = config["ref"](a_np)
+    
+    if config.get("cast_output", False):
+        b_np = b_np.astype(dtype)
 
     return a_np, b_np
 
 
-def test_ewise(target, dev, topi_name, dtype, ewise_ref_data):
+def test_ewise(target, dev, topi_name, dtype, tolerance, ewise_ref_data):
     target = tvm.target.Target(target)
     if target.kind.name == "vulkan" and topi_name in ["tan", "erf", "isnan", "isfinite", "isinf"]:
         pytest.xfail(f"Vulkan runtime doesn't support {topi_name} yet")
@@ -187,7 +193,7 @@ def test_ewise(target, dev, topi_name, dtype, ewise_ref_data):
     a = tvm.nd.array(a_np, dev)
     b = tvm.nd.array(np.zeros_like(b_np), dev)
     foo(a, b)
-    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5, atol=1e-5)
+    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=tolerance, atol=tolerance)
 
 
 from_dtype, to_dtype = tvm.testing.parameters(


### PR DESCRIPTION
X86 targets don't have an FP16 erf intrinsic. This causes compilation to fail when such an op is encountered. This PR adds two cases to avoid this failure. I've added an FP16 ERF legalization pass that will just cast to FP32 for the ERF call. I've also extended fast_erf to support FP16 directly. This does lose some precision compared to doing FP32 wrapping around ERF, but since the desire is to be faster I think it's acceptable behavior.