### PR TITLE
[TIR] Avoid all-pairs comparison in subexpr elimination

### DIFF
--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -79,9 +79,11 @@ class StructuralHash : public BaseValueHash {
   /*!
    * \brief Compute structural hashing value for an object.
    * \param key The left operand.
+   * \param map_free_vars Whether to map free variables by their occurrence
+   * number. Otherwise the underlying pointer value is used.
    * \return The hash value.
    */
-  TVM_DLL size_t operator()(const ObjectRef& key) const;
+  TVM_DLL size_t operator()(const ObjectRef& key, bool map_free_vars = false) const;
 };
 
 /*!

--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -57,6 +57,16 @@ struct ExprDeepEqual {
 };
 
 /*!
+ * \brief Hash of primexpr without var remapping.
+ *
+ * \sa ExprDeepEqual
+ *
+ * \param e PrimExpr to hash
+ * \return The hash of the PrimExpr
+ */
+int64_t ExprDeepHash(const PrimExpr& e);
+
+/*!
  * \brief Visit the PrimFuncs in the IRModule
  * \tparam FLambda The type of the PrimFunc visitor
  * \param mod The IRModule to be visited

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -261,8 +261,8 @@ TVM_REGISTER_GLOBAL("node.StructuralHash")
       return static_cast<int64_t>(hashed_value);
     });
 
-size_t StructuralHash::operator()(const ObjectRef& object) const {
-  return VarCountingSHashHandler().Hash(object, false);
+size_t StructuralHash::operator()(const ObjectRef& object, bool map_free_vars) const {
+  return VarCountingSHashHandler().Hash(object, map_free_vars);
 }
 
 // SEQualReduce traits for runtime containers.

--- a/src/tir/analysis/deep_equal.cc
+++ b/src/tir/analysis/deep_equal.cc
@@ -23,6 +23,7 @@
  */
 #include <tvm/node/reflection.h>
 #include <tvm/node/structural_equal.h>
+#include <tvm/node/structural_hash.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/analysis.h>
 
@@ -64,6 +65,8 @@ bool ExprDeepEqual::operator()(const PrimExpr& lhs, const PrimExpr& rhs) const {
   }
   return DeepCmpSEqualHandler().SEqualReduce(lhs, rhs, false);
 }
+
+int64_t ExprDeepHash(const PrimExpr& e) { return StructuralHash()(e, false); }
 
 TVM_REGISTER_GLOBAL("tir.analysis.expr_deep_equal")
     .set_body_typed([](const PrimExpr& lhs, const PrimExpr& rhs) {


### PR DESCRIPTION
Subexpression elimination used a comparison of each subexpression to every other subexpression to determine which to eliminate. This resulted in an O(N^2) algorithm that was slow when there were many LetStmts. Instead we now hash each subexpression and compare the hashes. We reuse structual hashing without remapping free variables to uniquely
determine each subexpression.

@masahi @FranckQC 
