### PR TITLE
[Arith] Allow unused trivial iterators in bijective check

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -256,7 +256,7 @@ class IterMapRewriter : public ExprMutator {
     if (require_bijective) {
       // all input marks must be visited
       for (const IterMark& mark : input_marks_) {
-        if (collector.visited_.count(mark) == 0) {
+        if (collector.visited_.count(mark) == 0 && !is_one(mark->extent)) {
           return false;
         }
       }

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -63,6 +63,7 @@ def assert_iter_sum_pattern(sum_expr, extent, base, scale=1):
 def test_trivial():
     x = tvm.tir.Var("x", "int32"), 3
     y = tvm.tir.Var("y", "int32"), 4
+    z = tvm.tir.Var("z", "int32"), 1
 
     res = tvm.arith.detect_iter_map([x[0], y[0], 3], var_dom([x, y]))
 
@@ -78,6 +79,24 @@ def test_trivial():
 
     # not independent
     res = tvm.arith.detect_iter_map([x[0], x[0], 3], var_dom([x, y]))
+    assert len(res) == 0
+
+    res = tvm.arith.detect_iter_map(
+        [x[0], y[0]], var_dom([x, y, z]), require_bijective=True, simplify_trivial_iterators=True
+    )
+    assert len(res) == 2
+    assert_iter_sum_pattern(res[0], 3, 0)
+    assert_iter_sum_pattern(res[1], 4, 0)
+
+    res = tvm.arith.detect_iter_map(
+        [x[0], y[0]], var_dom([x, y, z]), require_bijective=True, simplify_trivial_iterators=False
+    )
+    assert len(res) == 2
+    assert_iter_sum_pattern(res[0], 3, 0)
+    assert_iter_sum_pattern(res[1], 4, 0)
+
+    # not bijective
+    res = tvm.arith.detect_iter_map([x[0], z[0]], var_dom([x, y, z]), require_bijective=True)
     assert len(res) == 0
 
 
@@ -926,13 +945,4 @@ def test_free_variables():
 
 
 if __name__ == "__main__":
-    test_split()
-    test_trivial()
-    test_fuse()
-    test_compound()
-    test_predicate()
-    test_normalize_iter_map_to_expr()
-    test_subspace_division()
-    test_complex()
-    test_inverse_affine_iter_map()
-    test_free_variables()
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_compute_inline.py
+++ b/tests/python/unittest/test_tir_schedule_compute_inline.py
@@ -216,10 +216,10 @@ def elementwise_reverse_affine_load_unit_iter(
         with T.block("B"):
             vi, vj = T.axis.remap("SS", [i, j])
             C[vi, vj] = A[vi, vj] * 2.0
-    for i, j, k in T.grid(8, 16, 128):
+    for i, j, k, l in T.grid(1, 8, 16, 128):
         with T.block("C"):
-            vi, vj, vk = T.axis.remap("SSS", [i, j, k])
-            D[0, vi, vj, vk] = C[vi * 16 + vj, vk] + B[vi, vj, 0]
+            vi, vj, vk, vl = T.axis.remap("SSSS", [i, j, k, l])
+            D[vi, vj, vk, vl] = C[vi * 16 + vj, vk] + B[vj, vk, vi]
 
 
 @T.prim_func
@@ -232,6 +232,67 @@ def elementwise_reverse_affine_load_unit_iter_inlined(
         with T.block("B"):
             vi, vj = T.axis.remap("SS", [i, j])
             D[0, vi // 16, vi % 16, vj] = A[vi, vj] * 2.0 + B[vi // 16, vi % 16, 0]
+
+
+@T.prim_func
+def elementwise_reverse_affine_load_unit_iter_simplified(
+    A: T.Buffer[(128, 128), "float32"],
+    B: T.Buffer[(8, 16, 1), "float32"],
+    D: T.Buffer[(1, 8, 16, 128), "float32"],
+) -> None:
+    C = T.alloc_buffer((128, 128))
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            C[vi, vj] = A[vi, vj] * 2.0
+    for i, j, k in T.grid(8, 16, 128):
+        with T.block("C"):
+            vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+            D[0, vi, vj, vk] = C[vi * 16 + vj, vk] + B[vi, vj, 0]
+
+
+@T.prim_func
+def elementwise_reverse_affine_load_unit_iter_simplified_inlined(
+    A: T.Buffer[(128, 128), "float32"],
+    B: T.Buffer[(8, 16, 1), "float32"],
+    D: T.Buffer[(1, 8, 16, 128), "float32"],
+) -> None:
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            D[0, vi // 16, vi % 16, vj] = A[vi, vj] * 2.0 + B[vi // 16, vi % 16, 0]
+
+
+@T.prim_func
+def elementwise_reverse_affine_chain(
+    A: T.Buffer[(128, 128), "float32"],
+    D: T.Buffer[(1, 8, 16, 128), "float32"]
+):
+    B = T.alloc_buffer((128, 128))
+    C = T.alloc_buffer((8, 16, 128))
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            B[vi, vj] = A[vi, vj] * 2.0
+    for i, j, k in T.grid(8, 16, 128):
+        with T.block("C"):
+            vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+            C[vi, vj, vk] = B[vi * 16 + vj, vk] + B[vi * 16 + vj, vk]
+    for i, j, k, l in T.grid(1, 8, 16, 128):
+        with T.block("D"):
+            vi, vj, vk, vl = T.axis.remap("SSSS", [i, j, k, l])
+            D[vi, vj, vk, vl] = C[vj, vk, vl]
+
+
+@T.prim_func
+def elementwise_reverse_affine_chain_inlined(
+    A: T.Buffer[(128, 128), "float32"],
+    D: T.Buffer[(1, 8, 16, 128), "float32"]
+) -> None:
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            D[0, vi // 16, vi % 16, vj] = A[vi, vj] * 2.0
 
 
 @T.prim_func
@@ -647,11 +708,32 @@ def test_reverse_compute_inline_affine_load_unit_iter():
     sch = tir.Schedule(elementwise_reverse_affine_load_unit_iter, debug_mask="all")
     block_c = sch.get_block("C")
     sch.reverse_compute_inline(block_c)
-    print(sch.mod.script())
     tvm.ir.assert_structural_equal(
         elementwise_reverse_affine_load_unit_iter_inlined, sch.mod["main"]
     )
     verify_trace_roundtrip(sch=sch, mod=elementwise_reverse_affine_load_unit_iter)
+
+
+def test_reverse_compute_inline_affine_load_unit_iter_simplified():
+    sch = tir.Schedule(elementwise_reverse_affine_load_unit_iter_simplified, debug_mask="all")
+    block_c = sch.get_block("C")
+    sch.reverse_compute_inline(block_c)
+    tvm.ir.assert_structural_equal(
+        elementwise_reverse_affine_load_unit_iter_simplified_inlined, sch.mod["main"]
+    )
+    verify_trace_roundtrip(sch=sch, mod=elementwise_reverse_affine_load_unit_iter_simplified)
+
+
+def test_reverse_compute_inline_affine_chain():
+    sch = tir.Schedule(elementwise_reverse_affine_chain, debug_mask="all")
+    block_c = sch.get_block("C")
+    block_d = sch.get_block("D")
+    sch.reverse_compute_inline(block_c)
+    sch.reverse_compute_inline(block_d)
+    tvm.ir.assert_structural_equal(
+        elementwise_reverse_affine_chain_inlined, sch.mod["main"]
+    )
+    verify_trace_roundtrip(sch=sch, mod=elementwise_reverse_affine_chain)
 
 
 def test_reverse_compute_fail_non_affine_load():


### PR DESCRIPTION
This PR extends `DetectIterMap` bijective check to allow unused zero-constant iterators (trivial iterators). For example, `i, j, k => i, j` are treated as bijective if `k \in [0, 1)`, even though `k` is not used in the mapping result.
Previously, when trivial iterators are simplified, the above iter map can pass bijective check. When `simplify_trivial_iterators==False`, `k` will not be simplified and `DetectIterMap` will fail if `require_bijective` is set. This PR make the behavior of `DetectIterMap` consistent with different setting of `simplify_trivial_iteraotor`.
Regression tests for `reverse_compute_inline` is also added.

cc @spectrometerHBH @junrushao1994 @Lunderberg @wrongtest 
