### PR TITLE
[TIR] Avoid loop dependent allocation in buffer compaction

### DIFF
--- a/src/tir/transforms/compact_buffer_region.cc
+++ b/src/tir/transforms/compact_buffer_region.cc
@@ -63,6 +63,7 @@ Region SimplifyAndNarrowBufferRegionFromNDIntSet(const NDIntSet& nd_int_set,
 /*! \brief a more constrained bound estimate for n-dimentional int set */
 NDIntSet NDIntSetEval(Region region, PrimExpr predicate,
                       const std::unordered_map<const VarNode*, arith::IntSet>& dom_map,
+                      const std::vector<const VarNode*>& ancestor_loop_vars,
                       arith::Analyzer* analyzer) {
   std::unordered_map<Var, Range, ObjectPtrHash, ObjectEqual> var_dom;
   for (const auto& it : dom_map) {
@@ -72,8 +73,20 @@ NDIntSet NDIntSetEval(Region region, PrimExpr predicate,
       arith::EstimateRegionLowerBound(region, var_dom, predicate, analyzer);
   if (eval_res.defined()) {
     NDIntSet res(0);
-    for (const auto& it : eval_res.value()) res.push_back(it);
-    return res;
+    for (const auto& it : eval_res.value()) {
+      PrimExpr extent = analyzer->Simplify(it.max() - it.min() + 1);
+      // skip accurate region analysis result if there are outer loop dependencies.
+      if (UsesVar(extent, [&ancestor_loop_vars](const VarNode* v) {
+            return std::find(ancestor_loop_vars.begin(), ancestor_loop_vars.end(), v) !=
+                   ancestor_loop_vars.end();
+          })) {
+        break;
+      }
+      res.push_back(it);
+    }
+    if (res.size() == region.size()) {
+      return res;
+    }
   }
   return support::NDIntSetEval(support::NDIntSetFromRegion(region), dom_map);
 }
@@ -249,6 +262,7 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
       // Step 1. Stop ancestor loop vars out of the allocation block from
       // being relaxed unless NeedRelaxThread() is true.
       std::vector<arith::IntSet> non_relaxed(n_ancestor_loops);
+      std::vector<const VarNode*> ancestor_loop_vars(n_ancestor_loops);
       for (size_t i = 0; i < n_ancestor_loops; ++i) {
         const ForNode* loop = ancestor_loops_[i];
         const VarNode* v = loop->loop_var.get();
@@ -259,11 +273,12 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
         ICHECK(dom_it != dom_map_.end())
             << "Could not find domain for loop variable " << v->name_hint;
         non_relaxed[i] = dom_it->second;
+        ancestor_loop_vars[i] = v;
         dom_map_.erase(dom_it);
       }
       // Step 2. Relax the access region
-      NDIntSet nd_int_set =
-          NDIntSetEval(buffer_region->region, predicate_in_scope, dom_map_, &dom_analyzer_);
+      NDIntSet nd_int_set = NDIntSetEval(buffer_region->region, predicate_in_scope, dom_map_,
+                                         ancestor_loop_vars, &dom_analyzer_);
       // Step 3. Restore the non-relaxed ancestor loops domain
       for (size_t i = 0; i < n_ancestor_loops; ++i) {
         const VarNode* v = ancestor_loops_[i]->loop_var.get();


### PR DESCRIPTION
When we use `EstimateRegionLowerBound` to determine allocation extents, sometimes it gives "too accurate" dynamic region extents (dependent by outer loop vars).  However, the lowering (`StorageRewrite`) would lift buffer allocation to the global scope, bring the loop vars out of it's def scope illegally.

For the padded and tiled pooling case in the test, the h-dimension's region extent could be infered as `h_o * 8 + 8 - max(h_o * 8 - 1, 0)`, it is correct since with padding, the edge tiles do not need same buffer size as others. (h_o = 0 => extent = 8, h_o > 0 => extent = 9). But the dynamic allocation for this extent expression can not get properly handled afterwards... 

Here is just one work-around, very glad to see any robust solutions. @Hzfengsy @spectrometerHBH 