### PR TITLE
Fix type checking annotation for Union type

### DIFF
--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -64,6 +64,7 @@ if hasattr(typing, "_GenericAlias"):
                     return list(subtypes)
             return None
 
+
 elif hasattr(typing, "_Union"):
 
     class _Subtype:  # type: ignore
@@ -196,7 +197,7 @@ def _type_check_vtable() -> Dict[str, Callable]:
             error_msg = _type_check(v, name, type_)
             if error_msg is None:
                 return None
-        return _type_check_err(v, name, types)
+        return _type_check_err(v, name, Union[types])
 
     return {
         "none": _type_check_none,

--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -64,7 +64,6 @@ if hasattr(typing, "_GenericAlias"):
                     return list(subtypes)
             return None
 
-
 elif hasattr(typing, "_Union"):
 
     class _Subtype:  # type: ignore

--- a/tests/python/unittest/test_type_annotation_checker.py
+++ b/tests/python/unittest/test_type_annotation_checker.py
@@ -16,7 +16,7 @@
 # under the License.
 """Test type checker based on python's type annotations"""
 
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import pytest
 
@@ -68,6 +68,18 @@ test_cases = [
             ("x", 5, "y"),
             ("x", 5.0),
             (None, 5),
+        ],
+    },
+    {
+        "type_annotation": Union[str, int],
+        "positive_cases": [
+            "x",
+            5,
+        ],
+        "negative_cases": [
+            5.0,
+            ("x", 5, 6),
+            None,
         ],
     },
 ]


### PR DESCRIPTION
When type checking for params of `Union` type fails, another error occurs when printing error message. This PR fixed it.