### PR TITLE
Canonicalize type annotation during construction of Var and SizeVar

### DIFF
--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -61,6 +61,15 @@ namespace tvm {
 TVM_DLL Type GetType(const PrimExpr& expr);
 
 /*!
+ * \brief Get the type corresponding to DataType
+ * \param dtype The data type
+ * \return The result type
+ *
+ * \sa tvm/ir/type.h for discussion about the relation between Type and runtime::DataType.
+ */
+TVM_DLL Type GetTypeFromRuntimeDataType(const DataType& dtype);
+
+/*!
  * \brief Get the implied DataType for storing values with type during runtime.
  *
  * \param type The input type.

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -100,6 +100,7 @@ Var Var::copy_with_dtype(DataType dtype) const {
   } else {
     new_ptr = make_object<VarNode>(*node);
   }
+  new_ptr->type_annotation = GetTypeFromRuntimeDataType(dtype);
   new_ptr->dtype = std::move(dtype);
   return Var(new_ptr);
 }

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -65,6 +65,7 @@ namespace tir {
 Var::Var(String name_hint, DataType dtype, Span span) {
   auto n = make_object<VarNode>();
   n->name_hint = std::move(name_hint);
+  n->type_annotation = GetTypeFromRuntimeDataType(dtype);
   n->dtype = std::move(dtype);
   n->span = std::move(span);
   data_ = std::move(n);
@@ -126,6 +127,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 SizeVar::SizeVar(String name_hint, DataType dtype, Span span) {
   auto n = make_object<SizeVarNode>();
   n->name_hint = std::move(name_hint);
+  n->type_annotation = GetTypeFromRuntimeDataType(dtype);
   n->dtype = std::move(dtype);
   n->span = std::move(span);
   data_ = std::move(n);

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -73,6 +73,10 @@ Type GetType(const PrimExpr& expr) {
   }
   // Default: return the type indicated by the dtype.
   runtime::DataType dtype = expr.dtype();
+  return GetTypeFromRuntimeDataType(dtype);
+}
+
+Type GetTypeFromRuntimeDataType(const DataType& dtype) {
   if (dtype.is_void()) {
     return VoidType();
   }

--- a/tests/cpp/expr_test.cc
+++ b/tests/cpp/expr_test.cc
@@ -20,6 +20,7 @@
 #include <dmlc/logging.h>
 #include <gtest/gtest.h>
 #include <tvm/te/operation.h>
+#include "tvm/node/structural_equal.h"
 
 TEST(Expr, Basic) {
   using namespace tvm;
@@ -32,6 +33,16 @@ TEST(Expr, Basic) {
   os << z;
   ICHECK(zz.same_as(z));
   ICHECK(os.str() == "max(((x + 1) + 2), 100)");
+}
+
+TEST(Expr, VarTypeAnnotation) {
+  using namespace tvm;
+  using namespace tvm::tir;
+  Var x("x", DataType::Float(32));
+  Var y("y", PrimType(DataType::Float(32)));
+  StructuralEqual checker;
+  ICHECK(checker(x->dtype, y->dtype));
+  ICHECK(checker(x->type_annotation, y->type_annotation));
 }
 
 TEST(ExprNodeRef, Basic) {

--- a/tests/cpp/expr_test.cc
+++ b/tests/cpp/expr_test.cc
@@ -19,8 +19,8 @@
 
 #include <dmlc/logging.h>
 #include <gtest/gtest.h>
-#include <tvm/te/operation.h>
 #include <tvm/node/structural_equal.h>
+#include <tvm/te/operation.h>
 
 TEST(Expr, Basic) {
   using namespace tvm;

--- a/tests/cpp/expr_test.cc
+++ b/tests/cpp/expr_test.cc
@@ -20,7 +20,7 @@
 #include <dmlc/logging.h>
 #include <gtest/gtest.h>
 #include <tvm/te/operation.h>
-#include "tvm/node/structural_equal.h"
+#include <tvm/node/structural_equal.h>
 
 TEST(Expr, Basic) {
   using namespace tvm;


### PR DESCRIPTION
var->type_annotation may be empty when only `runtime::DataType` is passed to the constructor. This PR added canonicalization during the construction of `Var` and `SizeVar`, so that `Var(dtype="float32", type_annotation=PrimType(Float(32)))` is equivalent to `Var(dtype="float32", type_annotation=None)`.

The printer side for `Var` and `SizeVar` is not affected and doesn't need update.
`ReprPrinter` always omit type information: https://github.com/apache/tvm/blob/main/src/tir/ir/expr.cc#L120
`TextPrinter` has already been implicitly converting from `runtime::DataType` to `Type`: https://github.com/apache/tvm/blob/main/src/printer/tir_text_printer.cc#L782

cc @tqchen 