### PR TITLE
[Onnx] Round operator

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4977,21 +4977,21 @@ class Momentum(OnnxOpConverter):
         result = output_tensors + output_momentums
         return _expr.TupleWrapper(_expr.Tuple(result), len(result))
 
- 
+
 class Round(OnnxOpConverter):
     """Operator converter for round op."""
 
     @classmethod
     def _impl_v11(cls, inputs, attr, params):
-        # See the tutorial for full implementation details: 
+        # See the tutorial for full implementation details:
         # https://www.youtube.com/watch?v=fZvNG-oKK5Q&list=PL_4zDggB-DBpynCEnC9hV-1euZrP3xDRK&index=4
 
         # Onnx round uses Banker's rounding which rounds .5 to the nearest even integer
 
         x = inputs[0]
-        half = _expr.const(0.5, dtype='float32')
-        one = _expr.const(1, dtype='float32')
-        two = _expr.const(2, dtype='float32')
+        half = _expr.const(0.5, dtype="float32")
+        one = _expr.const(1, dtype="float32")
+        two = _expr.const(2, dtype="float32")
 
         rounded = _op.ceil(x - half)
         bankers_mask = one - (_op.ceil(x + half) - _op.floor(x + half))

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4983,9 +4983,6 @@ class Round(OnnxOpConverter):
 
     @classmethod
     def _impl_v11(cls, inputs, attr, params):
-        # See the tutorial for full implementation details:
-        # https://www.youtube.com/watch?v=fZvNG-oKK5Q&list=PL_4zDggB-DBpynCEnC9hV-1euZrP3xDRK&index=4
-
         # Onnx round uses Banker's rounding which rounds .5 to the nearest even integer
 
         x = inputs[0]

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4977,10 +4977,30 @@ class Momentum(OnnxOpConverter):
         result = output_tensors + output_momentums
         return _expr.TupleWrapper(_expr.Tuple(result), len(result))
 
+ 
+class Round(OnnxOpConverter):
+    """Operator converter for round op."""
+
+    @classmethod
+    def _impl_v11(cls, inputs, attr, params):
+        # See the tutorial for full implementation details: 
+        # https://www.youtube.com/watch?v=fZvNG-oKK5Q&list=PL_4zDggB-DBpynCEnC9hV-1euZrP3xDRK&index=4
+
+        # Onnx round uses Banker's rounding which rounds .5 to the nearest even integer
+
+        x = inputs[0]
+        half = _expr.const(0.5, dtype='float32')
+        one = _expr.const(1, dtype='float32')
+        two = _expr.const(2, dtype='float32')
+
+        rounded = _op.ceil(x - half)
+        bankers_mask = one - (_op.ceil(x + half) - _op.floor(x + half))
+        non_even = _op.abs(_op.mod(rounded, two))
+        return rounded + (bankers_mask * non_even)
+
 
 # compatible operators that do NOT require any conversion.
 _identity_list = []
-
 
 # _convert_map defines maps of name to converter functor(callable)
 # for 1 to 1 mapping, use Renamer if nothing but name is different
@@ -5026,7 +5046,7 @@ def _get_convert_map(opset):
         "Reciprocal": Reciprocal.get_converter(opset),
         "Floor": Renamer("floor"),
         "Ceil": Renamer("ceil"),
-        "Round": Renamer("round"),
+        "Round": Round.get_converter(opset),
         "IsInf": IsInf.get_converter(opset),
         "IsNaN": Renamer("isnan"),
         "Sqrt": Renamer("sqrt"),

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5092,7 +5092,6 @@ unsupported_onnx_tests = [
     "test_reduce_sum_negative_axes_keepdims_example",
     "test_reduce_sum_negative_axes_keepdims_random",
     "test_rnn_seq_length",
-    "test_round",
     "test_sequence_insert_at_back",
     "test_sequence_insert_at_front",
     "test_simple_rnn_batchwise",


### PR DESCRIPTION
Completed with reference to the tutorial presented at tvmconf: https://www.youtube.com/watch?v=fZvNG-oKK5Q&amp;t=20s

Onnx uses an abnormal round operator where .5 is rounded to the nearest even integer, which differs comparative to other round definitions.

@MargaretQian @jwfromm @sfvaroglu 
