### PR TITLE
[skip ci][ci] Fix broken test skips

### DIFF
--- a/tests/python/frontend/paddlepaddle/test_forward.py
+++ b/tests/python/frontend/paddlepaddle/test_forward.py
@@ -707,7 +707,7 @@ def test_forward_gather_nd():
         verify_model(GatherNd(), [x_data, y_data])
 
 
-@pytest.skip(reason="See https://github.com/apache/tvm/issues/11435")
+@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/11435")
 @tvm.testing.uses_gpu
 def test_forward_group_norm():
     class GroupNorm(nn.Layer):

--- a/tests/python/unittest/test_auto_scheduler_evolutionary_search.py
+++ b/tests/python/unittest/test_auto_scheduler_evolutionary_search.py
@@ -68,7 +68,7 @@ def test_mutate_tile_size():
     assert found
 
 
-@pytest.skip(reason="See https://github.com/apache/tvm/issues/11440")
+@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/11440")
 def test_mutate_parallel():
     """
     The test case initializes evo search with a batch of "bad" states and check whether

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -526,7 +526,7 @@ def add_subparser(
             kwargs["required"] = not is_optional and not has_default
 
         if str(arg_type).startswith("typing.List"):
-            kwargs["nargs"] = "+"
+            kwargs["action"] = "append"
 
         if arg_cli_name[0] not in seen_prefixes:
             subparser.add_argument(f"-{arg_cli_name[0]}", f"--{arg_cli_name}", **kwargs)


### PR DESCRIPTION
Actually tested locally this time via, both tests are successfully skipped

```bash
python tests/scripts/ci.py gpu \
    --tests tests/python/frontend/paddlepaddle/test_forward.py::test_forward_group_norm \
    --tests tests/python/unittest/test_auto_scheduler_evolutionary_search.py::test_mutate_parallel
```

cc @Mousius @areusch