### PR TITLE
[ci] Increase timeout for git submodule update

### DIFF
--- a/jenkins/Prepare.groovy.j2
+++ b/jenkins/Prepare.groovy.j2
@@ -34,11 +34,28 @@ def init_git() {
     label: 'Merge to origin/main'
   )
 
-  retry(5) {
-    timeout(time: 2, unit: 'MINUTES') {
-      sh (script: 'git submodule update --init -f', label: 'Update git submodules')
-    }
-  }
+  sh(
+    script: '''
+      set -eux
+      n=0
+      max_retries=3
+      backoff_max=30
+      until [ "$n" -ge $max_retries ]
+      do
+          timeout 5m git submodule update --init -f --jobs 0 && break
+          n=$((n+1))
+          if [ "$n" -eq $max_retries ]; then
+              echo "failed to update $n / $max_retries, giving up"
+              exit 1
+          fi
+
+          WAIT=$((RANDOM % "$backoff_max"))
+          echo "failed to update $n / $max_retries, waiting $WAIT to try again"
+          sleep $WAIT
+      done
+    ''',
+    label: 'Update git submodules',
+  )
 }
 
 def should_skip_slow_tests(pr_number) {


### PR DESCRIPTION
This adds more time to the timeouts for fetching git modules and moves the logic from groovy into bash. This should help with issues like https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/3375/pipeline/423#step-1396-log-1 by making them happen less often and making it more clear what went wrong (Jenkin's `retry` doesn't say what it's doing in the blueocean step logs)

cc @Mousius @areusch