### PR TITLE
[FFI][CYTHON] Release GIL when calling into long running functions

### DIFF
--- a/python/tvm/_ffi/_cython/base.pxi
+++ b/python/tvm/_ffi/_cython/base.pxi
@@ -94,17 +94,34 @@ ctypedef int (*TVMPackedCFunc)(
 
 ctypedef void (*TVMPackedCFuncFinalizer)(void* resource_handle)
 
+# NOTE: All of TVM's C API function can be called without gil.
+# for API functions that can be run long(e.g. FuncCall)
+# we need to explicitly release the GIL as follows.
+#
+# cdef myfunc():
+#     cdef int c_api_ret_code
+#     with nogil:
+#         c_api_ret_code = TVMAPIFunc(...)
+#     CHECK_CALL(c_apt_ret_code)
+#
+# Explicitly releasing the GIL enables other python threads
+# to continue running while we are in TVMAPIFunc.
+# Not releasing GIL explicitly is OK(and perhaps desirable)
+# for short-running functions, as frequent unlocking also takes time,
+# the python interpreter will release GIL in a set period.
+#
+# We mark the possibly long running function as nogil below.
 cdef extern from "tvm/runtime/c_runtime_api.h":
     void TVMAPISetLastError(const char* msg)
     const char *TVMGetLastError()
     int TVMFuncGetGlobal(const char* name,
-                         TVMPackedFuncHandle* out);
+                         TVMPackedFuncHandle* out)
     int TVMFuncCall(TVMPackedFuncHandle func,
                     TVMValue* arg_values,
                     int* type_codes,
                     int num_args,
                     TVMValue* ret_val,
-                    int* ret_type_code)
+                    int* ret_type_code) nogil
     int TVMFuncFree(TVMPackedFuncHandle func)
     int TVMCFuncSetReturn(TVMRetValueHandle ret,
                           TVMValue* value,
@@ -119,15 +136,15 @@ cdef extern from "tvm/runtime/c_runtime_api.h":
                       tvm_index_t ndim,
                       DLDataType dtype,
                       DLDevice dev,
-                      DLTensorHandle* out)
-    int TVMArrayFree(DLTensorHandle handle)
+                      DLTensorHandle* out) nogil
+    int TVMArrayFree(DLTensorHandle handle) nogil
     int TVMArrayCopyFromTo(DLTensorHandle src,
                            DLTensorHandle to,
-                           TVMStreamHandle stream)
+                           TVMStreamHandle stream) nogil
     int TVMArrayFromDLPack(DLManagedTensor* arr_from,
-                           DLTensorHandle* out)
+                           DLTensorHandle* out) nogil
     int TVMArrayToDLPack(DLTensorHandle arr_from,
-                         DLManagedTensor** out)
+                         DLManagedTensor** out) nogil
     void TVMDLManagedTensorCallDeleter(DLManagedTensor* dltensor)
     int TVMObjectFree(ObjectHandle obj)
     int TVMObjectGetTypeIndex(ObjectHandle obj, unsigned* out_index)
@@ -155,7 +172,8 @@ cdef inline c_str(pystr):
     return pystr.encode("utf-8")
 
 
-cdef inline int CALL(int ret) except -2:
+cdef inline int CHECK_CALL(int ret) except -2:
+    """Check the return code of the C API function call"""
     # -2 brings exception
     if ret == -2:
         return -2
@@ -193,6 +211,6 @@ cdef _init_env_api():
     #
     # When the functions are not registered, the signals will be handled
     # only when the FFI function returns.
-    CALL(TVMBackendRegisterEnvCAPI(c_str("PyErr_CheckSignals"), <void*>PyErr_CheckSignals))
+    CHECK_CALL(TVMBackendRegisterEnvCAPI(c_str("PyErr_CheckSignals"), <void*>PyErr_CheckSignals))
 
 _init_env_api()

--- a/python/tvm/_ffi/_cython/object.pxi
+++ b/python/tvm/_ffi/_cython/object.pxi
@@ -38,7 +38,7 @@ cdef inline object make_ret_object(void* chandle):
     cdef object handle
     object_type = OBJECT_TYPE
     handle = ctypes_handle(chandle)
-    CALL(TVMObjectGetTypeIndex(chandle, &tindex))
+    CHECK_CALL(TVMObjectGetTypeIndex(chandle, &tindex))
 
     if tindex < len(OBJECT_TYPE):
         cls = OBJECT_TYPE[tindex]
@@ -101,7 +101,7 @@ cdef class ObjectBase:
             self._set_handle(value)
 
     def __dealloc__(self):
-        CALL(TVMObjectFree(self.chandle))
+        CHECK_CALL(TVMObjectFree(self.chandle))
 
     def __init_handle_by_constructor__(self, fconstructor, *args):
         """Initialize the handle by calling constructor function.

--- a/python/tvm/testing/popen_pool.py
+++ b/python/tvm/testing/popen_pool.py
@@ -16,8 +16,8 @@
 # under the License.
 # pylint: disable=invalid-name, missing-function-docstring
 """Common functions for popen_pool test cases"""
-import time
 import tvm
+from . import _ffi_api
 
 TEST_GLOBAL_STATE_1 = 0
 TEST_GLOBAL_STATE_2 = 0
@@ -72,4 +72,4 @@ def slow_summation(n):
 
 
 def timeout_job(n):
-    time.sleep(n * 1.5)
+    _ffi_api.sleep_in_ffi(n * 1.5)

--- a/src/support/ffi_testing.cc
+++ b/src/support/ffi_testing.cc
@@ -28,6 +28,7 @@
 #include <tvm/te/tensor.h>
 #include <tvm/tir/expr.h>
 
+#include <chrono>
 #include <thread>
 
 namespace tvm {
@@ -158,5 +159,10 @@ runtime::Module NewFrontendTestModule() {
 }
 
 TVM_REGISTER_GLOBAL("testing.FrontendTestModule").set_body_typed(NewFrontendTestModule);
+
+TVM_REGISTER_GLOBAL("testing.sleep_in_ffi").set_body_typed([](double timeout) {
+  std::chrono::duration<int64_t, std::nano> duration(static_cast<int64_t>(timeout * 1e9));
+  std::this_thread::sleep_for(duration);
+});
 
 }  // namespace tvm


### PR DESCRIPTION
Unlike ctypes, Cython by default do not release GIL when
calling into C API functions. This causes problems when the
function is long running. As the particular calling thread will
block other python threads by holding the GIL.

This PR explicitly releases GIL when calling into possible
long running functions. It fixes the timeout issue in
PopenPool which previously relied on another python thread
for timeout.

This PR is covered by a regression test-case by changing time.sleep to sleep
in FFI, which previously will indefinitely block the popen tests.
