### PR TITLE
[BugFix] Add lock for ModuleNode::GetFuncFromEnv

### DIFF
--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -32,10 +32,10 @@
 #include <tvm/runtime/object.h>
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <mutex>
 
 namespace tvm {
 namespace runtime {

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <mutex>
 
 namespace tvm {
 namespace runtime {
@@ -206,6 +207,7 @@ class TVM_DLL ModuleNode : public Object {
  private:
   /*! \brief Cache used by GetImport */
   std::unordered_map<std::string, std::shared_ptr<PackedFunc> > import_cache_;
+  std::mutex mutex_;
 };
 
 /*!

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -106,6 +106,7 @@ std::string ModuleNode::GetSource(const std::string& format) {
 }
 
 const PackedFunc* ModuleNode::GetFuncFromEnv(const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex_);
   auto it = import_cache_.find(name);
   if (it != import_cache_.end()) return it->second.get();
   PackedFunc pf;


### PR DESCRIPTION
Hi, i find ModuleNode::GetFuncFromEnv will read from and write to one std::unordered_map<std::string, std::shared_ptr<PackedFunc> > import_cache_; by multi thread. As the class instance created with constexpr const char* tvm_module_ctx = "__tvm_module_ctx";
