### PR TITLE
[MetaSchedule] Add Profiler Support For Tuning Efficiency Optimization

### DIFF
--- a/include/tvm/meta_schedule/profiler.h
+++ b/include/tvm/meta_schedule/profiler.h
@@ -28,6 +28,8 @@
 #include <tvm/runtime/packed_func.h>
 #include <tvm/target/target.h>
 
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/include/tvm/meta_schedule/profiler.h
+++ b/include/tvm/meta_schedule/profiler.h
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef TVM_META_SCHEDULE_PROFILER_H_
+#define TVM_META_SCHEDULE_PROFILER_H_
+
+#include <tvm/ir/module.h>
+#include <tvm/node/reflection.h>
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/optional.h>
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/target/target.h>
+
+#include <utility>
+#include <vector>
+
+namespace tvm {
+namespace meta_schedule {
+
+struct ScopedTimer {
+  std::function<void()> func;
+  explicit ScopedTimer(std::function<void()> func) : func(func) {}
+  ~ScopedTimer() { func(); }
+};
+
+/*!
+ * \brief A profiler to count tuning time cost in different parts.
+ */
+class ProfilerNode : public runtime::Object {
+ public:
+  void VisitAttrs(tvm::AttrVisitor* v) { v->Visit("stats", &stats); }
+
+  /*!
+   * \brief Profile the time usage in the given scope in the given name.
+   * \param name Name for the scope.
+   * \return A scope timer for time profiling.
+   */
+  static ScopedTimer TimeScope(String name);
+
+  /*!
+   * \brief Get the profiling results.
+   * \return The tuning profiling results as a dict.
+   */
+  Map<String, FloatImm> Get() const { return stats; }
+
+  /*!
+   * \brief Start the timer for a new context.
+   * \param name Name of the context.
+   */
+  void StartContextTimer(String name);
+
+  /*! \brief End the timer for the most recent context. */
+  void EndContextTimer();
+
+  static constexpr const char* _type_key = "meta_schedule.Profiler";
+  TVM_DECLARE_FINAL_OBJECT_INFO(ProfilerNode, runtime::Object);
+
+ protected:
+  Map<String, FloatImm> stats;
+  std::vector<std::pair<String, std::chrono::time_point<std::chrono::high_resolution_clock>>> stack;
+};
+
+/*!
+ * \brief Managed reference to ProfilerNode
+ * \sa ProfilerNode
+ */
+class Profiler : public runtime::ObjectRef {
+ public:
+  Profiler();
+  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Profiler, runtime::ObjectRef, ProfilerNode);
+
+ protected:
+  friend class ProfilerInternal;
+
+  /*! \brief Entering the scope of the context manager */
+  void EnterWithScope();
+  /*! \brief Exiting the scope of the context manager */
+  void ExitWithScope();
+};
+
+struct ProfilerThreadLocalEntry {
+  Optional<Profiler> ctx;
+};
+using ProfilerThreadLocalStore = dmlc::ThreadLocalStore<ProfilerThreadLocalEntry>;
+
+}  // namespace meta_schedule
+}  // namespace tvm
+
+#endif  // TVM_META_SCHEDULE_PROFILER_H_

--- a/include/tvm/meta_schedule/profiler.h
+++ b/include/tvm/meta_schedule/profiler.h
@@ -54,9 +54,12 @@ class ProfilerNode : public runtime::Object {
  public:
   /*! \brief The segments that are already profiled */
   std::unordered_map<std::string, double> stats_sec;
+  /*! \brief Counter for the total time used */
+  runtime::PackedFunc total_timer;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     // `stats_sec` is not visited.
+    // `total_timer` is not visited.
   }
 
   static constexpr const char* _type_key = "meta_schedule.Profiler";

--- a/python/tvm/meta_schedule/__init__.py
+++ b/python/tvm/meta_schedule/__init__.py
@@ -30,6 +30,7 @@ from . import (
     search_strategy,
     space_generator,
 )
+from .profiler import Profiler
 from .apply_history_best import ApplyHistoryBest
 from .extracted_task import ExtractedTask
 from .relay_integration import extract_task_from_relay

--- a/python/tvm/meta_schedule/profiler.py
+++ b/python/tvm/meta_schedule/profiler.py
@@ -67,7 +67,7 @@ class Profiler(Object):
         @contextmanager
         def _timeit():
             try:
-                f = _ffi_api.ProfilerTimedScope(  # pylint:type: ignore # pylint: disable=no-member
+                f = _ffi_api.ProfilerTimedScope(  # type: ignore # pylint: disable=no-member
                     name
                 )
                 yield

--- a/python/tvm/meta_schedule/profiler.py
+++ b/python/tvm/meta_schedule/profiler.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""A context manager that profiles tuning time cost for different parts."""
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from tvm._ffi import register_object
+from tvm.runtime import Object
+
+from . import _ffi_api
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class TimeItContext:
+    """The context to profile given scope."""
+
+    profiler: Profiler
+    name: str
+
+    def __init__(self, profiler: "Profiler", name: str):
+        self.profiler = profiler
+        self.name = name
+
+    def __enter__(self):
+        _ffi_api.ProfilerStartContextTimer(self.profiler, self.name)  # type: ignore # pylint: disable=no-member
+        return self
+
+    def __exit__(self, exctype, excinst, exctb):
+        _ffi_api.ProfilerEndContextTimer(self.profiler)  # type: ignore # pylint: disable=no-member
+
+
+@register_object("meta_schedule.Profiler")
+class Profiler(Object):
+    """A profiler to count tuning time cost in different parts."""
+
+    def __init__(self) -> None:
+        self.__init_handle_by_constructor__(
+            _ffi_api.Profiler,  # type: ignore # pylint: disable=no-member
+        )
+
+    def get(self) -> Dict[str, float]:
+        """Get the profiling results in minutes"""
+        return _ffi_api.ProfilerGet(self)  # type: ignore # pylint: disable=no-member
+
+    def timeit(self, name: str) -> TimeItContext:
+        return TimeItContext(self, name)
+
+    def __enter__(self) -> "Profiler":
+        """Entering the scope of the context manager"""
+        _ffi_api.ProfilerEnterScope(self)  # type: ignore # pylint: disable=no-member
+        return self
+
+    def __exit__(self, ptype, value, trace) -> None:
+        """Exiting the scope of the context manager"""
+        _ffi_api.ProfilerExitScope(self)  # type: ignore # pylint: disable=no-member

--- a/python/tvm/meta_schedule/profiler.py
+++ b/python/tvm/meta_schedule/profiler.py
@@ -67,9 +67,7 @@ class Profiler(Object):
         @contextmanager
         def _timeit():
             try:
-                f = _ffi_api.ProfilerTimedScope(  # type: ignore # pylint: disable=no-member
-                    name
-                )
+                f = _ffi_api.ProfilerTimedScope(name)  # type: ignore # pylint: disable=no-member
                 yield
             finally:
                 if f:

--- a/python/tvm/meta_schedule/testing/tune_relay_meta_schedule.py
+++ b/python/tvm/meta_schedule/testing/tune_relay_meta_schedule.py
@@ -122,19 +122,22 @@ def main():
         alloc_repeat=alloc_repeat,
         max_workers=ARGS.rpc_workers,
     )
-    lib = ms.tune_relay(
-        mod=mod,
-        target=ARGS.target,
-        config=ms.TuneConfig(
-            strategy="evolutionary",
-            num_trials_per_iter=64,
-            max_trials_per_task=ARGS.num_trials,
-            max_trials_global=ARGS.num_trials,
-        ),
-        runner=runner,  # type: ignore
-        work_dir=ARGS.work_dir,
-        params=params,
-    )
+    with ms.Profiler() as profiler:
+        lib = ms.tune_relay(
+            mod=mod,
+            target=ARGS.target,
+            config=ms.TuneConfig(
+                strategy="evolutionary",
+                num_trials_per_iter=64,
+                max_trials_per_task=ARGS.num_trials,
+                max_trials_global=ARGS.num_trials,
+            ),
+            runner=runner,  # type: ignore
+            work_dir=ARGS.work_dir,
+            params=params,
+        )
+    print("Tuning Time:")
+    print(profiler.table())
     graph, rt_mod, params = lib.graph_json, lib.lib, lib.params
     for input_name, input_shape in input_info.items():
         if input_dtype.startswith("float"):

--- a/src/meta_schedule/measure_callback/add_to_database.cc
+++ b/src/meta_schedule/measure_callback/add_to_database.cc
@@ -30,6 +30,7 @@ class AddToDatabaseNode : public MeasureCallbackNode {
     if (!task_scheduler->database.defined()) {
       return;
     }
+    auto _ = Profiler::TimedScope("AddToDatabase");
     TuneContext task = task_scheduler->tasks[task_id];
     Database database = task_scheduler->database.value();
     Workload workload = database->CommitWorkload(task->mod.value());

--- a/src/meta_schedule/measure_callback/echo_statistics.cc
+++ b/src/meta_schedule/measure_callback/echo_statistics.cc
@@ -82,6 +82,7 @@ class EchoStatisticsNode : public MeasureCallbackNode {
     if (this->task_info.empty()) {
       SetupTaskInfo(task_scheduler->tasks);
     }
+    auto _ = Profiler::TimedScope("EchoStatistics");
     ICHECK_EQ(measure_candidates.size(), builder_results.size());
     ICHECK_EQ(measure_candidates.size(), runner_results.size());
     int n = measure_candidates.size();

--- a/src/meta_schedule/measure_callback/measure_callback.cc
+++ b/src/meta_schedule/measure_callback/measure_callback.cc
@@ -27,6 +27,7 @@ void PyMeasureCallbackNode::Apply(const TaskScheduler& task_scheduler,          
                                   const Array<BuilderResult>& builds,                 //
                                   const Array<RunnerResult>& results) {
   ICHECK(f_apply != nullptr) << "PyMeasureCallback's Apply method not implemented!";
+  auto _ = Profiler::TimedScope(this->f_as_string());
   return f_apply(task_scheduler, task_id, measure_candidates, builds, results);
 }
 

--- a/src/meta_schedule/measure_callback/remove_build_artifact.cc
+++ b/src/meta_schedule/measure_callback/remove_build_artifact.cc
@@ -28,6 +28,7 @@ class RemoveBuildArtifactNode : public MeasureCallbackNode {
              const Array<BuilderResult>& builder_results,
              const Array<RunnerResult>& runner_results) final {
     static const PackedFunc* f_rm = runtime::Registry::Get("meta_schedule.remove_build_dir");
+    auto _ = Profiler::TimedScope("RemoveBuildArtifact");
     for (const BuilderResult& build_result : builder_results) {
       if (Optional<String> path = build_result->artifact_path) {
         (*f_rm)(path.value());

--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -27,11 +27,11 @@ class UpdateCostModelNode : public MeasureCallbackNode {
              const Array<MeasureCandidate>& measure_candidates,
              const Array<BuilderResult>& builder_results,
              const Array<RunnerResult>& runner_results) final {
+    auto _ = Profiler::TimedScope("UpdateCostModel");
     TuneContext task = task_scheduler->tasks[task_id];
-    ICHECK(task_scheduler->cost_model.defined())  //
+    ICHECK(task_scheduler->cost_model.defined())
         << "Cost model must be defined for the task scheduler!";
-    ICHECK(task->measure_candidates.defined())  //
-        << "Task's measure candidates must be present!";
+    ICHECK(task->measure_candidates.defined()) << "Task's measure candidates must be present!";
     CostModel cost_model = task_scheduler->cost_model.value();
     ICHECK_EQ(measure_candidates.size(), builder_results.size());
     ICHECK_EQ(runner_results.size(), builder_results.size());

--- a/src/meta_schedule/profiler.cc
+++ b/src/meta_schedule/profiler.cc
@@ -84,9 +84,9 @@ TVM_REGISTER_GLOBAL("meta_schedule.ProfilerEnterWithScope")
 TVM_REGISTER_GLOBAL("meta_schedule.ProfilerExitWithScope")
     .set_body_method(&Profiler::ExitWithScope);
 TVM_REGISTER_GLOBAL("meta_schedule.ProfilerCurrent").set_body_typed(Profiler::Current);
-TVM_REGISTER_GLOBAL("meta_schedule.ProfilerTimedScope").set_body_typed(ProfilerTimedScope);
 TVM_REGISTER_GLOBAL("meta_schedule.ProfilerGet").set_body_method<Profiler>(&ProfilerNode::Get);
 TVM_REGISTER_GLOBAL("meta_schedule.ProfilerTable").set_body_method<Profiler>(&ProfilerNode::Table);
+TVM_REGISTER_GLOBAL("meta_schedule.ProfilerTimedScope").set_body_typed(ProfilerTimedScope);
 
 }  // namespace meta_schedule
 }  // namespace tvm

--- a/src/meta_schedule/profiler.cc
+++ b/src/meta_schedule/profiler.cc
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "./utils.h"
+
+namespace tvm {
+namespace meta_schedule {
+
+/**************** Context Manager ****************/
+
+class ProfilerInternal {
+ public:
+  static void EnterScope(Profiler ctx) { ctx.EnterWithScope(); }
+  static void ExitScope(Profiler ctx) { ctx.ExitWithScope(); }
+};
+
+void Profiler::EnterWithScope() {
+  Optional<Profiler>& ctx = ProfilerThreadLocalStore::Get()->ctx;
+  CHECK(!ctx.defined()) << "ValueError: Nested Profiler context managers are not allowed";
+  ctx = *this;
+}
+
+void Profiler::ExitWithScope() {
+  Optional<Profiler>& ctx = ProfilerThreadLocalStore::Get()->ctx;
+  ICHECK(ctx.defined());
+  ctx = NullOpt;
+}
+
+/**************** Profiler ****************/
+
+Profiler::Profiler() {
+  ObjectPtr<ProfilerNode> n = make_object<ProfilerNode>();
+  data_ = n;
+}
+
+ScopedTimer ProfilerNode::TimeScope(String name) {
+  return ScopedTimer([name, tick = std::chrono::high_resolution_clock::now()]() -> void {
+    Optional<Profiler> profiler = ProfilerThreadLocalStore::Get()->ctx;
+    if (profiler.defined()) {
+      Map<String, FloatImm>& stats = profiler.value()->stats;
+      double duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::high_resolution_clock::now() - tick)
+                            .count() /
+                        1e9 / 60;
+      if (stats.find(name) != stats.end()) {
+        stats.Set(name, FloatImm(DataType::Float(64), stats.at(name)->value + duration));
+      } else {
+        stats.Set(name, FloatImm(DataType::Float(64), duration));
+      }
+    }
+  });
+}
+
+void ProfilerNode::StartContextTimer(String name) {
+  stack.push_back(std::make_pair(name, std::chrono::high_resolution_clock::now()));
+}
+
+void ProfilerNode::EndContextTimer() {
+  ICHECK(stack.size() > 0) << "There is no timer context running!";
+  String name = stack.back().first;
+  double duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::high_resolution_clock::now() - stack.back().second)
+                        .count() /
+                    1e9 / 60;
+  if (stats.find(name) != stats.end()) {
+    stats.Set(name, FloatImm(DataType::Float(64), stats.at(name)->value + duration));
+  } else {
+    stats.Set(name, FloatImm(DataType::Float(64), duration));
+  }
+  stack.pop_back();
+}
+
+TVM_REGISTER_NODE_TYPE(ProfilerNode);
+TVM_REGISTER_GLOBAL("meta_schedule.Profiler").set_body_typed([]() -> Profiler {
+  return Profiler();
+});
+TVM_REGISTER_GLOBAL("meta_schedule.ProfilerEnterScope")
+    .set_body_typed(ProfilerInternal::EnterScope);
+TVM_REGISTER_GLOBAL("meta_schedule.ProfilerExitScope").set_body_typed(ProfilerInternal::ExitScope);
+TVM_REGISTER_GLOBAL("meta_schedule.ProfilerStartContextTimer")
+    .set_body_method<Profiler>(&ProfilerNode::StartContextTimer);
+TVM_REGISTER_GLOBAL("meta_schedule.ProfilerEndContextTimer")
+    .set_body_method<Profiler>(&ProfilerNode::EndContextTimer);
+TVM_REGISTER_GLOBAL("meta_schedule.ProfilerGet").set_body_method<Profiler>(&ProfilerNode::Get);
+
+}  // namespace meta_schedule
+}  // namespace tvm

--- a/src/meta_schedule/tune_context.cc
+++ b/src/meta_schedule/tune_context.cc
@@ -75,6 +75,7 @@ void TuneContextNode::_SetMeasureCandidates(const Array<MeasureCandidate>& candi
 }
 
 void TuneContextNode::_SendToBuilder(const Builder& builder) {
+  auto _ = Profiler::TimedScope("SendToBuilder");
   Array<MeasureCandidate> candidates = this->measure_candidates.value();
   Target target = this->target.value();
   Array<BuilderInput> inputs;
@@ -86,6 +87,7 @@ void TuneContextNode::_SendToBuilder(const Builder& builder) {
 }
 
 void TuneContextNode::_SendToRunner(const Runner& runner) {
+  auto _ = Profiler::TimedScope("SendToRunner");
   Array<MeasureCandidate> candidates = this->measure_candidates.value();
   Array<BuilderResult> builder_results = this->builder_results.value();
   Target target = this->target.value();
@@ -133,9 +135,12 @@ Array<RunnerResult> TuneContextNode::_Join() {
   Array<RunnerFuture> futures = this->runner_futures.value();
   int n = futures.size();
   Array<RunnerResult> results;
-  results.reserve(n);
-  for (RunnerFuture future : futures) {
-    results.push_back(future->Result());
+  {
+    auto _ = Profiler::TimedScope("JoinRunnerFutures");
+    results.reserve(n);
+    for (RunnerFuture future : futures) {
+      results.push_back(future->Result());
+    }
   }
   this->search_strategy.value()->NotifyRunnerResults(this->measure_candidates.value(), results);
   ICHECK(this->measure_candidates.defined());

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -28,6 +28,7 @@
 #include <tvm/meta_schedule/database.h>
 #include <tvm/meta_schedule/feature_extractor.h>
 #include <tvm/meta_schedule/measure_callback.h>
+#include <tvm/meta_schedule/profiler.h>
 #include <tvm/meta_schedule/runner.h>
 #include <tvm/meta_schedule/schedule_rule.h>
 #include <tvm/meta_schedule/search_strategy.h>

--- a/tests/python/unittest/test_meta_schedule_profiler.py
+++ b/tests/python/unittest/test_meta_schedule_profiler.py
@@ -22,6 +22,7 @@ from tvm import meta_schedule as ms
 
 def test_meta_schedule_profiler_context_manager():
     with ms.Profiler() as profiler:
+        time.sleep(1)
         with ms.Profiler.timeit("Level0"):
             time.sleep(1)
             with ms.Profiler.timeit("Level1"):
@@ -29,7 +30,8 @@ def test_meta_schedule_profiler_context_manager():
     # Note that the results are in seconds
 
     result = profiler.get()
-    assert len(result) == 2
+    assert len(result) == 3
+    assert 3.9 <= result["Total"] <= 4.1
     assert 2.9 <= result["Level0"] <= 3.1
     assert 1.9 <= result["Level1"] <= 2.1
 

--- a/tests/python/unittest/test_meta_schedule_profiler.py
+++ b/tests/python/unittest/test_meta_schedule_profiler.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" Test Meta Schedule Profiler """
+from typing import List
+import time
+
+import tvm
+from tvm.meta_schedule.search_strategy import ReplayTrace
+from tvm import meta_schedule as ms
+from tvm.tir.schedule import Schedule
+from tvm.script import tir as T
+
+
+MATMUL_M = 32
+
+# pylint: disable=missing-class-docstring,invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument, unbalanced-tuple-unpacking
+# fmt: off
+
+@tvm.script.ir_module
+class Matmul:
+    @T.prim_func
+    def main(a: T.handle, b: T.handle, c: T.handle) -> None: # type: ignore
+        T.func_attr({"global_symbol": "main"})
+        A = T.match_buffer(a, (32, 32), "float32")
+        B = T.match_buffer(b, (32, 32), "float32")
+        C = T.match_buffer(c, (32, 32), "float32")
+        for i, j, k in T.grid(32, 32, 32):
+            with T.block("matmul"):
+                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                with T.init():
+                    C[vi, vj] = 0.0 # type: ignore
+                C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+
+# fmt: on
+# pylint: enable=missing-class-docstring,invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument
+
+
+def test_meta_schedule_profiler_replay_trace():
+    def _schedule_matmul(sch: Schedule):
+        block = sch.get_block("matmul")
+        i, j, k = sch.get_loops(block=block)
+        i_0, i_1, i_2, i_3 = sch.split(i, sch.sample_perfect_tile(i, n=4))
+        j_0, j_1, j_2, j_3 = sch.split(j, sch.sample_perfect_tile(j, n=4))
+        k_0, k_1 = sch.split(k, sch.sample_perfect_tile(k, n=2))
+        sch.reorder(i_0, j_0, i_1, j_1, k_0, i_2, j_2, k_1, i_3, j_3)
+
+    with ms.Profiler() as profiler:
+        num_trials_per_iter = 7
+        max_trials_per_task = 20
+
+        context = ms.TuneContext(
+            mod=Matmul,
+            space_generator=ms.space_generator.ScheduleFn(sch_fn=_schedule_matmul),
+            search_strategy=ReplayTrace(
+                num_trials_per_iter=num_trials_per_iter, max_trials_per_task=max_trials_per_task
+            ),
+        )
+        context.initialize()
+        strategy = context.search_strategy
+        spaces = context.generate_design_space()
+        strategy.pre_tuning(spaces)
+        num_trials_each_iter: List[int] = []
+        candidates = strategy.generate_measure_candidates()
+        while candidates is not None:
+            num_trials_each_iter.append(len(candidates))
+            runner_results: List[ms.runner.RunnerResult] = []
+            for _ in candidates:
+                runner_results.append(
+                    ms.runner.RunnerResult(
+                        run_secs=[1.0],
+                        error_msg=None,
+                    )
+                )
+            strategy.notify_runner_results(candidates, runner_results)
+            candidates = strategy.generate_measure_candidates()
+        strategy.post_tuning()
+
+    for term in [
+        "ReplayTraceNode::NotifyRunnerResults",
+        "ReplayTraceNode::GenerateMeasureCandidates",
+        "ReplayTraceNode::PostTuning",
+        "ReplayTraceNode::PreTuning",
+    ]:
+        assert term in profiler.get()
+        assert profiler.get()[term] > 0
+
+
+def test_meta_schedule_profiler_context_manager():
+    with ms.Profiler() as profiler:
+        with profiler.timeit("Level0"):
+            time.sleep(2)
+            with profiler.timeit("Level1"):
+                time.sleep(3)
+    # Note that the results are in minutes
+    assert 5 <= profiler.get()["Level0"] * 60 <= 6
+    assert 3 <= profiler.get()["Level1"] * 60 <= 4
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_profiler.py
+++ b/tests/python/unittest/test_meta_schedule_profiler.py
@@ -15,100 +15,30 @@
 # specific language governing permissions and limitations
 # under the License.
 """ Test Meta Schedule Profiler """
-from typing import List
 import time
 
-import tvm
-from tvm.meta_schedule.search_strategy import ReplayTrace
 from tvm import meta_schedule as ms
-from tvm.tir.schedule import Schedule
-from tvm.script import tir as T
-
-
-MATMUL_M = 32
-
-# pylint: disable=missing-class-docstring,invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument, unbalanced-tuple-unpacking
-# fmt: off
-
-@tvm.script.ir_module
-class Matmul:
-    @T.prim_func
-    def main(a: T.handle, b: T.handle, c: T.handle) -> None: # type: ignore
-        T.func_attr({"global_symbol": "main"})
-        A = T.match_buffer(a, (32, 32), "float32")
-        B = T.match_buffer(b, (32, 32), "float32")
-        C = T.match_buffer(c, (32, 32), "float32")
-        for i, j, k in T.grid(32, 32, 32):
-            with T.block("matmul"):
-                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
-                with T.init():
-                    C[vi, vj] = 0.0 # type: ignore
-                C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
-
-# fmt: on
-# pylint: enable=missing-class-docstring,invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument
-
-
-def test_meta_schedule_profiler_replay_trace():
-    def _schedule_matmul(sch: Schedule):
-        block = sch.get_block("matmul")
-        i, j, k = sch.get_loops(block=block)
-        i_0, i_1, i_2, i_3 = sch.split(i, sch.sample_perfect_tile(i, n=4))
-        j_0, j_1, j_2, j_3 = sch.split(j, sch.sample_perfect_tile(j, n=4))
-        k_0, k_1 = sch.split(k, sch.sample_perfect_tile(k, n=2))
-        sch.reorder(i_0, j_0, i_1, j_1, k_0, i_2, j_2, k_1, i_3, j_3)
-
-    with ms.Profiler() as profiler:
-        num_trials_per_iter = 7
-        max_trials_per_task = 20
-
-        context = ms.TuneContext(
-            mod=Matmul,
-            space_generator=ms.space_generator.ScheduleFn(sch_fn=_schedule_matmul),
-            search_strategy=ReplayTrace(
-                num_trials_per_iter=num_trials_per_iter, max_trials_per_task=max_trials_per_task
-            ),
-        )
-        context.initialize()
-        strategy = context.search_strategy
-        spaces = context.generate_design_space()
-        strategy.pre_tuning(spaces)
-        num_trials_each_iter: List[int] = []
-        candidates = strategy.generate_measure_candidates()
-        while candidates is not None:
-            num_trials_each_iter.append(len(candidates))
-            runner_results: List[ms.runner.RunnerResult] = []
-            for _ in candidates:
-                runner_results.append(
-                    ms.runner.RunnerResult(
-                        run_secs=[1.0],
-                        error_msg=None,
-                    )
-                )
-            strategy.notify_runner_results(candidates, runner_results)
-            candidates = strategy.generate_measure_candidates()
-        strategy.post_tuning()
-
-    for term in [
-        "ReplayTraceNode::NotifyRunnerResults",
-        "ReplayTraceNode::GenerateMeasureCandidates",
-        "ReplayTraceNode::PostTuning",
-        "ReplayTraceNode::PreTuning",
-    ]:
-        assert term in profiler.get()
-        assert profiler.get()[term] > 0
 
 
 def test_meta_schedule_profiler_context_manager():
     with ms.Profiler() as profiler:
-        with profiler.timeit("Level0"):
-            time.sleep(2)
-            with profiler.timeit("Level1"):
-                time.sleep(3)
-    # Note that the results are in minutes
-    assert 5 <= profiler.get()["Level0"] * 60 <= 6
-    assert 3 <= profiler.get()["Level1"] * 60 <= 4
+        with ms.Profiler.timeit("Level0"):
+            time.sleep(1)
+            with ms.Profiler.timeit("Level1"):
+                time.sleep(2)
+    # Note that the results are in seconds
+
+    result = profiler.get()
+    assert len(result) == 2
+    assert 2.9 <= result["Level0"] <= 3.1
+    assert 1.9 <= result["Level1"] <= 2.1
+
+
+def test_meta_schedule_no_context():
+    with ms.Profiler.timeit("Level0"):
+        assert ms.Profiler.current() is None
 
 
 if __name__ == "__main__":
-    tvm.testing.main()
+    test_meta_schedule_profiler_context_manager()
+    test_meta_schedule_no_context()

--- a/tests/python/unittest/test_meta_schedule_search_strategy.py
+++ b/tests/python/unittest/test_meta_schedule_search_strategy.py
@@ -119,7 +119,7 @@ def test_meta_schedule_replay_func(
     assert num_trials_each_iter == [7, 7, 6]
 
 
-def test_meta_schedule_evolutionary_search():  # pylint: disable = invalid-name]
+def test_meta_schedule_evolutionary_search():  # pylint: disable = invalid-name
     def _schedule_matmul_small(sch: Schedule):
         block = sch.get_block("matmul")
         _, j, k = sch.get_loops(block=block)
@@ -185,7 +185,7 @@ def test_meta_schedule_evolutionary_search():  # pylint: disable = invalid-name]
     assert num_trials_each_iter.count(0) < 5
 
 
-def test_meta_schedule_evolutionary_search_early_stop():  # pylint: disable = invalid-name]
+def test_meta_schedule_evolutionary_search_early_stop():  # pylint: disable = invalid-name
     def _schedule_matmul_empty(sch: Schedule):
         return sch
 


### PR DESCRIPTION
Similar to our current performance statistics table, a tuning efficiency statistics table could be extremely helpful. The output result looks like the following example:
```
Tuning Efficiency Statistics:
 ID |                   Module Name | Time Usage(s) | Time Ratio(%) 
--------------------------------------------------------------------
  0 |                    Total Time |        2.2824 |      100.0000 
  1 | TaskScheduler::InitializeTask |        2.2819 |       99.9786 
--------------------------------------------------------------------
```