### PR TITLE
[rust] update ndarray version

### DIFF
--- a/rust/tvm-graph-rt/Cargo.toml
+++ b/rust/tvm-graph-rt/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1"
 
 itertools = "0.8"
 lazy_static = "1.4"
-ndarray="0.12"
+ndarray="0.15"
 nom = "5.0"
 num_cpus = "1.10"
 serde = { version = "^1.0", features = ["derive"] }

--- a/rust/tvm-rt/Cargo.toml
+++ b/rust/tvm-rt/Cargo.toml
@@ -85,7 +85,7 @@ build-static-runtime = ["tvm-sys/build-static-runtime"]
 
 [dependencies]
 thiserror = "^1.0"
-ndarray = "0.12"
+ndarray = "0.15"
 num-traits = "0.2"
 tvm-macros = { version = "0.1.1-alpha", path = "../tvm-macros" }
 paste = "0.1"

--- a/rust/tvm-sys/Cargo.toml
+++ b/rust/tvm-sys/Cargo.toml
@@ -79,7 +79,7 @@ build-static-runtime = []
 [dependencies]
 thiserror = "^1.0"
 anyhow = "^1.0"
-ndarray = "0.12"
+ndarray = "0.15"
 enumn = "^0.1"
 
 [build-dependencies]

--- a/rust/tvm/Cargo.toml
+++ b/rust/tvm/Cargo.toml
@@ -90,7 +90,7 @@ path = "../tvm-rt/"
 thiserror = "^1.0"
 anyhow = "^1.0"
 lazy_static = "1.1"
-ndarray = "0.12"
+ndarray = "0.15"
 num-traits = "0.2"
 tvm-macros = { version = "0.1.1-alpha", path = "../tvm-macros/" }
 paste = "0.1"


### PR DESCRIPTION
Update the ndarray version to the latest, otherwise there are conflicts, the error message is `note: perhaps two different versions of crate `ndarray` are being used?` @nhynes 

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
