### PR TITLE
[VM] check DLManagedTensor for conditions to construct NDArray

### DIFF
--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -241,7 +241,7 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
   // fill up content.
   data->manager_ctx = tensor;
   ICHECK(::tvm::runtime::IsContiguous(tensor->dl_tensor))
-      << "DLManagedTensor is not contiguous. It does not support for now";
+      << "DLManagedTensor must be contiguous.";
   ICHECK(IsAligned(tensor->dl_tensor))
       << "Data in DLManagedTensor is not aligned as required by NDArray";
   data->dl_tensor = tensor->dl_tensor;

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -206,8 +206,7 @@ NDArray NDArray::Empty(ShapeTuple shape, DLDataType dtype, Device dev, Optional<
 }
 
 NDArray NDArray::FromExternalDLTensor(const DLTensor& dl_tensor) {
-  ICHECK(::tvm::runtime::IsContiguous(dl_tensor))
-      << "External DLTensor is not contiguous. It does not support for now";
+  ICHECK(::tvm::runtime::IsContiguous(dl_tensor)) << "External DLTensor must be contiguous.";
   ICHECK(IsAligned(dl_tensor)) << "Data in DLTensor is not aligned as required by NDArray";
   NDArray::Container* data = new NDArray::Container();
 
@@ -224,7 +223,7 @@ NDArray NDArray::FromExternalDLTensor(const DLTensor& dl_tensor) {
 
 NDArray NDArray::NewFromDLTensor(DLTensor* tensor, const Device& dev) {
   ICHECK(::tvm::runtime::IsContiguous(*tensor))
-      << "DLTensor is not contiguous. It does not support for now";
+      << "DLTensor is not contiguous. Copying from incontiguous data does not support for now";
   std::vector<int64_t> shape;
   for (int64_t i = 0; i < tensor->ndim; i++) {
     shape.push_back(tensor->shape[i]);
@@ -240,8 +239,7 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
   data->SetDeleter(Internal::DLPackDeleter);
   // fill up content.
   data->manager_ctx = tensor;
-  ICHECK(::tvm::runtime::IsContiguous(tensor->dl_tensor))
-      << "DLManagedTensor must be contiguous.";
+  ICHECK(::tvm::runtime::IsContiguous(tensor->dl_tensor)) << "DLManagedTensor must be contiguous.";
   ICHECK(IsAligned(tensor->dl_tensor))
       << "Data in DLManagedTensor is not aligned as required by NDArray";
   data->dl_tensor = tensor->dl_tensor;

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -240,6 +240,10 @@ NDArray NDArray::FromDLPack(DLManagedTensor* tensor) {
   data->SetDeleter(Internal::DLPackDeleter);
   // fill up content.
   data->manager_ctx = tensor;
+  ICHECK(::tvm::runtime::IsContiguous(tensor->dl_tensor))
+      << "DLManagedTensor is not contiguous. It does not support for now";
+  ICHECK(IsAligned(tensor->dl_tensor))
+      << "Data in DLManagedTensor is not aligned as required by NDArray";
   data->dl_tensor = tensor->dl_tensor;
   // update shape_
   std::vector<ShapeTuple::index_type> shape;

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -223,7 +223,7 @@ NDArray NDArray::FromExternalDLTensor(const DLTensor& dl_tensor) {
 
 NDArray NDArray::NewFromDLTensor(DLTensor* tensor, const Device& dev) {
   ICHECK(::tvm::runtime::IsContiguous(*tensor))
-      << "DLTensor is not contiguous. Copying from incontiguous data does not support for now";
+      << "DLTensor is not contiguous. Copying from non-contiguous data is currently not supported";
   std::vector<int64_t> shape;
   for (int64_t i = 0; i < tensor->ndim; i++) {
     shape.push_back(tensor->shape[i]);


### PR DESCRIPTION
During developing #11003 #11391 It was observed that DLTensor should satisfy some conditions (data contiguous and alignment) for correct construction of NDArray based on it to avoid problems with memory using.
Further analysis of NDArray class methods showed the same problem in other public method. There is fix of it.

@tkonolige could you check it?
