### PR TITLE
Constant name prefix added

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -193,7 +193,7 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     } else {
       const auto* ttype = op->checked_type().as<TensorTypeNode>();
       std::stringstream ss;
-      ss << "cc_constant_" << const_index++;
+      ss << readable_name_stream_.str() << "_constant_" << const_index++;
       tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, ss.str());
       constant_tensors_[op] = tensor;
       return {tensor};

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -194,7 +194,7 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
       const auto* ttype = op->checked_type().as<TensorTypeNode>();
       std::stringstream ss;
       std::string s = readable_name_stream_.str();
-      std::replace( s.begin(), s.end(), '.', '_');
+      std::replace(s.begin(), s.end(), '.', '_');
       ss << s << "_constant_" << const_index++;
       tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, ss.str());
       constant_tensors_[op] = tensor;

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -193,7 +193,9 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     } else {
       const auto* ttype = op->checked_type().as<TensorTypeNode>();
       std::stringstream ss;
-      ss << readable_name_stream_.str() << "_constant_" << const_index++;
+      std::string s = readable_name_stream_.str();
+      std::replace( s.begin(), s.end(), '.', '_'); 
+      ss << s << "_constant_" << const_index++;
       tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, ss.str());
       constant_tensors_[op] = tensor;
       return {tensor};

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -194,7 +194,7 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
       const auto* ttype = op->checked_type().as<TensorTypeNode>();
       std::stringstream ss;
       std::string s = readable_name_stream_.str();
-      std::replace( s.begin(), s.end(), '.', '_'); 
+      std::replace( s.begin(), s.end(), '.', '_');
       ss << s << "_constant_" << const_index++;
       tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, ss.str());
       constant_tensors_[op] = tensor;

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -193,7 +193,7 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     } else {
       const auto* ttype = op->checked_type().as<TensorTypeNode>();
       std::stringstream ss;
-      ss << "constant_" << const_index++;
+      ss << "cc_constant_" << const_index++;
       tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, ss.str());
       constant_tensors_[op] = tensor;
       return {tensor};

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -265,8 +265,9 @@ def test_c_link_params(linkable_dtype):
         src_lines = src.split("\n")
         param = param_init[f"{linkable_dtype}_a"].reshape(np.prod(KERNEL_SHAPE))
         param_def = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) constant_\d+\[{np.prod(param.shape)}\] = {{$"
+        param_def_cc = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) cc_constant_\d+\[{np.prod(param.shape)}\] = {{$"        
         for i, line in enumerate(src_lines):
-            if re.match(param_def, line):
+            if re.match(param_def, line) or re.match(param_def_cc, line):
                 i += 1
                 break
         else:

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -265,7 +265,7 @@ def test_c_link_params(linkable_dtype):
         src_lines = src.split("\n")
         param = param_init[f"{linkable_dtype}_a"].reshape(np.prod(KERNEL_SHAPE))
         param_def = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) constant_\d+\[{np.prod(param.shape)}\] = {{$"
-        param_def_cc = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) cc_constant_\d+\[{np.prod(param.shape)}\] = {{$"        
+        param_def_cc = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) cc_constant_\d+\[{np.prod(param.shape)}\] = {{$"
         for i, line in enumerate(src_lines):
             if re.match(param_def, line) or re.match(param_def_cc, line):
                 i += 1

--- a/tests/python/unittest/test_link_params.py
+++ b/tests/python/unittest/test_link_params.py
@@ -264,10 +264,10 @@ def test_c_link_params(linkable_dtype):
         c_dtype = _get_c_datatype(linkable_dtype)
         src_lines = src.split("\n")
         param = param_init[f"{linkable_dtype}_a"].reshape(np.prod(KERNEL_SHAPE))
-        param_def = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) constant_\d+\[{np.prod(param.shape)}\] = {{$"
-        param_def_cc = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) cc_constant_\d+\[{np.prod(param.shape)}\] = {{$"
+        param_def = rf"^static const {c_dtype} __attribute__\(\(section\(\".rodata.tvm\"\), aligned\(16\)\)\) [a-zA-Z_0-9]*constant_\d+\[{np.prod(param.shape)}\] = {{$"
+
         for i, line in enumerate(src_lines):
-            if re.match(param_def, line) or re.match(param_def_cc, line):
+            if re.match(param_def, line):
                 i += 1
                 break
         else:


### PR DESCRIPTION
This is a proposal to fix the bug reported here: https://discuss.tvm.apache.org/t/problem-with-allocateconstnodes-in-cmsis-nn-code/12806

Bug report: https://github.com/apache/tvm/issues/11394

A prefix "cc" had been added to the "constant_" to distinguish from the constant naming generated in aot_executor_gen.cc 

  @SebastianBoblestETAS @vdkhoi @grant-arm @Mousius @manupa-arm @ashutosh-arm @MJKlaiberBosch
