### PR TITLE
[microNPU] Fix flaky compute cycle annotation test

### DIFF
--- a/tests/python/contrib/test_ethosu/cascader/test_scheduler.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_scheduler.py
@@ -48,7 +48,6 @@ def test_cascade(SRAM, FLASH, TwoConv2DWithSliceTE, TwoConv2DTE, MobileNetv1Star
         cs.cascade(sch, te_graph, const_dict, options, SRAM, FLASH, [SRAM], device_config)
 
 
-@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/11483")
 def test_compute_cycles_annotation(SRAM, FLASH, TwoConv2DTE):
     device_config = cs.EthosuDeviceConfig("ethos-u55-256")
     options = infra.make_options(
@@ -61,6 +60,7 @@ def test_compute_cycles_annotation(SRAM, FLASH, TwoConv2DTE):
         always_copy_size=1024,
         disable_pareto_plans=False,
         disable_pareto_proposals=False,
+        enable_striping=False,
     )
     sch, te_graph, const_dict = TwoConv2DTE
     cs.cascade(sch, te_graph, const_dict, options, SRAM, FLASH, [SRAM], device_config)
@@ -69,7 +69,7 @@ def test_compute_cycles_annotation(SRAM, FLASH, TwoConv2DTE):
     # [copy, copy, conv2d, copy, conv2d]
     stages = [6, 8, 9, 18, 19]
     # Expected hints for each operation
-    compute_cycles_hints = [4096, 5120, 1632, 2560, 3072]
+    compute_cycles_hints = [4096, 5120, 1440, 2560, 3072]
 
     for stage, compute_cycles_hint in zip(stages, compute_cycles_hints):
         op = sch.stages[stage]


### PR DESCRIPTION
Fixes non-deterministic test by disabling striping when running the cascader.

Previously the test was failing ~1/10 times. Tested with changes locally by repeating the test 100 times, all of which pass. Closes #11483.

cc @Mousius @NicolaLancellotti @ekalda @manupa-arm
