### PR TITLE
[BYOC][DNNL] Improve performance of DNNL BYOC dense operator

### DIFF
--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -150,11 +150,19 @@ def make_dense_pattern(with_bias=True, with_eltwise=None):
     else:
         dense_out = dense
     if with_eltwise == "gelu":
-        div = is_op("divide")(dense_out, is_constant())
+        const1 = wildcard()
+        const2 = wildcard()
+        const3 = wildcard()
+        # div = is_op("divide")(dense_out, is_constant())
+        # erf_val = is_op("erf")(div)
+        # added_erf_val = is_op("add")(erf_val, is_constant())
+        # mul_val = is_op("multiply")(dense_out, added_erf_val)
+        # dense_out = is_op("multiply")(mul_val, is_constant())
+        div = is_op("divide")(dense_out, const1)
         erf_val = is_op("erf")(div)
-        added_erf_val = is_op("add")(erf_val, is_constant())
+        added_erf_val = is_op("add")(erf_val, const2)
         mul_val = is_op("multiply")(dense_out, added_erf_val)
-        dense_out = is_op("multiply")(mul_val, is_constant())
+        dense_out = is_op("multiply")(mul_val, const3)
 
     elif with_eltwise:
         dense_out = is_op(with_eltwise)(dense_out)

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -332,9 +332,7 @@ def get_optimal_layout_for_conv_transpose(
     )
 
 
-def get_optimal_layout_for_dense(
-    data_layout, weight_shape,  out_shape
-):
+def get_optimal_layout_for_dense(data_layout, weight_shape, out_shape):
     """Get the optimal layout of dnnl, given shape of dense.
 
     Parameters
@@ -402,7 +400,6 @@ def tag2layout(input_data, is_weight=False, op_type="Conv1D"):
     elif "Dense" in op_type:
         data_dic = {"a": "N", "b": "C", "c": "H", "d": "W"}
         weight_dic = data_dic
-        
 
     dic = weight_dic if is_weight else data_dic
     res = ""
@@ -419,15 +416,15 @@ def tag2layout(input_data, is_weight=False, op_type="Conv1D"):
         else:
             raise ValueError("Unsupport layout format: %s" % input_data)
 
-    if "Dense" in op_type:    
-        # Post process for dense weight layout 
+    if "Dense" in op_type:
+        # Post process for dense weight layout
         # e.g. NC16c64n => NC64n16c
-        regexN = '\d+n'
-        regexC = '\d+c'
+        regexN = "\d+n"
+        regexC = "\d+c"
 
         matchN = re.findall(regexN, res)
         matchC = re.findall(regexC, res)
-        res =  "NC" + "".join(matchN) + "".join(matchC)
+        res = "NC" + "".join(matchN) + "".join(matchC)
 
     return res
 
@@ -539,20 +536,21 @@ def alter_dense(attrs, inputs, tinfos, out_type):
     weight_shape = ",".join(weight_shape_list)
     out_shape = ",".join(out_shape_list)
 
-    res = get_optimal_layout_for_dense(
-        data_shape,
-        weight_shape,
-        out_shape
-    )
+    res = get_optimal_layout_for_dense(data_shape, weight_shape, out_shape)
 
     _, weight_df, _ = res.split(",")
-   
+
     new_attrs = {}
     new_attrs["weight_layout"] = tag2layout(weight_df, is_weight=True, op_type="Dense")
-    
+
     weight_transform = relay.layout_transform(weight, "NC", dst_layout=new_attrs["weight_layout"])
-    return relay.nn.contrib_dense_pack(data, weight_transform, weight_layout=new_attrs["weight_layout"],
-                                       units=None, out_dtype=out_type.dtype)
+    return relay.nn.contrib_dense_pack(
+        data,
+        weight_transform,
+        weight_layout=new_attrs["weight_layout"],
+        units=None,
+        out_dtype=out_type.dtype,
+    )
 
 
 class IsComputeIntensiveGraph(ExprVisitor):
@@ -716,7 +714,7 @@ def rewrite_layer_norm(mod):
 
 class DenseReshapeBiasGeluRewrite(DFPatternCallback):
     """
-    A callback to reorder reshape operators when the patten is as below: 
+    A callback to reorder reshape operators when the patten is as below:
     1   %76 = nn.dense(%75, meta[relay.Constant][18] /* ty=Tensor[(512, 64), float32] */, units=None, out_dtype="float32") /*  ty=Tensor[(3136, 512), float32] */;
     2   %77 = reshape(%76, newshape=[1, 3136, 512]) /* ty=Tensor[(1, 3136, 512), float32] */;
     3   %78 = add(meta[relay.Constant][15] /* ty=Tensor[(512), float32] */, %77) /* ty=Tensor[(1, 3136, 512), float32] */;
@@ -739,7 +737,7 @@ class DenseReshapeBiasGeluRewrite(DFPatternCallback):
         self.pack_wei = pack_wei
 
         self.attr_map = {}
-        
+
         den = is_op("nn.dense")(self.data, self.weight)
         re_den = is_op("reshape")(den)
         added = is_op("add")(self.bias, re_den)
@@ -762,7 +760,7 @@ class DenseReshapeBiasGeluRewrite(DFPatternCallback):
                 for k in expr.attrs.keys():
                     new_attrs[k] = expr.attrs[k]
                 self.attr_map["nn.dense"] = new_attrs
-        
+
         _analysis.post_order_visit(pre, visit_func)
 
     def callback(self, pre, post, node_map):
@@ -782,20 +780,23 @@ class DenseReshapeBiasGeluRewrite(DFPatternCallback):
             data_shape = ",".join(data_shape_list)
             weight_shape = ",".join(weight_shape_list)
             out_shape = ",".join([data_shape_list[0], weight_shape_list[0]])
-            
-            res = get_optimal_layout_for_dense(
-                data_shape,
-                weight_shape,
-                out_shape
-            )
+
+            res = get_optimal_layout_for_dense(data_shape, weight_shape, out_shape)
 
             _, weight_df, _ = res.split(",")
             reco_weight_layout = tag2layout(weight_df, is_weight=True, op_type="Dense")
-            
+
             weight_transform = relay.layout_transform(weight, "NC", dst_layout=reco_weight_layout)
-        
-            den = relay.op.nn.contrib_dense_pack(data, weight_transform, weight_layout=reco_weight_layout, 
-                    units=None, out_dtype=self.attr_map["nn.dense"]["out_dtype"] if 'out_dtype' in self.attr_map['nn.dense'] else "")
+
+            den = relay.op.nn.contrib_dense_pack(
+                data,
+                weight_transform,
+                weight_layout=reco_weight_layout,
+                units=None,
+                out_dtype=self.attr_map["nn.dense"]["out_dtype"]
+                if "out_dtype" in self.attr_map["nn.dense"]
+                else "",
+            )
         else:
             den = relay.op.nn.dense(data, weight)
         added = relay.op.add(bias, den)
@@ -804,11 +805,11 @@ class DenseReshapeBiasGeluRewrite(DFPatternCallback):
         added_erf = relay.op.add(val_erf, const2)
         mul1 = relay.op.multiply(added, added_erf)
         mul2 = relay.op.multiply(mul1, const3)
-        return relay.op.reshape(mul2, self.attr_map['reshape']['newshape'])
+        return relay.op.reshape(mul2, self.attr_map["reshape"]["newshape"])
 
 
 def rewrite_dense_bias_gelu_reshape_last(mod, pack_wei=False):
-    """Rewrite the input graph to reorder reshape operators so that 
+    """Rewrite the input graph to reorder reshape operators so that
     we can perform dense_bias_gelu fusion and then offload them to byoc part.
     """
     mod["main"] = rewrite(DenseReshapeBiasGeluRewrite(pack_wei), mod["main"])
@@ -817,7 +818,7 @@ def rewrite_dense_bias_gelu_reshape_last(mod, pack_wei=False):
 
 class DenseReshapeBiasRewrite(DFPatternCallback):
     """
-    A callback to reorder reshape operators when the patten is as below: 
+    A callback to reorder reshape operators when the patten is as below:
     1   %62 = nn.dense(%61, meta[relay.Constant][13] /* ty=Tensor[(64, 64), float32] */, units=None, out_dtype="float32") /* ty=Tensor[(3136, 64), float32] */;
     2   %63 = reshape(%62, newshape=[1, 3136, 64]) /* ty=Tensor[(1, 3136, 64), float32] */;
     3   %64 = add(meta[relay.Constant][4] /* ty=Tensor[(64), float32] */, %63) /* ty=Tensor[(1, 3136, 64), float32] */;
@@ -828,10 +829,10 @@ class DenseReshapeBiasRewrite(DFPatternCallback):
         self.data = wildcard()
         self.weight = wildcard()
         self.bias = wildcard()
-        
+
         self.pack_wei = pack_wei
         self.attr_map = {}
-        
+
         den = is_op("nn.dense")(self.data, self.weight)
         re_den = is_op("reshape")(den)
         added = is_op("add")(self.bias, re_den)
@@ -849,7 +850,7 @@ class DenseReshapeBiasRewrite(DFPatternCallback):
                 for k in expr.attrs.keys():
                     new_attrs[k] = expr.attrs[k]
                 self.attr_map["nn.dense"] = new_attrs
-        
+
         _analysis.post_order_visit(pre, visit_func)
 
     def callback(self, pre, post, node_map):
@@ -858,7 +859,7 @@ class DenseReshapeBiasRewrite(DFPatternCallback):
         data = node_map[self.data][0]
         weight = node_map[self.weight][0]
         bias = node_map[self.bias][0]
-        
+
         if self.pack_wei:
             weight_shape_list = [str(x) for x in get_shape(weight)]
             data_shape_list = [str(x) for x in get_shape(data)]
@@ -866,28 +867,31 @@ class DenseReshapeBiasRewrite(DFPatternCallback):
             data_shape = ",".join(data_shape_list)
             weight_shape = ",".join(weight_shape_list)
             out_shape = ",".join([data_shape_list[0], weight_shape_list[0]])
-            
-            res = get_optimal_layout_for_dense(
-                data_shape,
-                weight_shape,
-                out_shape
-            )
+
+            res = get_optimal_layout_for_dense(data_shape, weight_shape, out_shape)
 
             _, weight_df, _ = res.split(",")
             reco_weight_layout = tag2layout(weight_df, is_weight=True, op_type="Dense")
             weight_transform = relay.layout_transform(weight, "NC", dst_layout=reco_weight_layout)
 
-            den = relay.op.nn.contrib_dense_pack(data, weight_transform, weight_layout=reco_weight_layout, 
-                    units=None, out_dtype=self.attr_map["nn.dense"]["out_dtype"] if 'out_dtype' in self.attr_map['nn.dense'] else "")
+            den = relay.op.nn.contrib_dense_pack(
+                data,
+                weight_transform,
+                weight_layout=reco_weight_layout,
+                units=None,
+                out_dtype=self.attr_map["nn.dense"]["out_dtype"]
+                if "out_dtype" in self.attr_map["nn.dense"]
+                else "",
+            )
         else:
             den = relay.op.nn.dense(data, weight)
         added = relay.op.add(bias, den)
-        return relay.op.reshape(added, self.attr_map['reshape']['newshape'])
+        return relay.op.reshape(added, self.attr_map["reshape"]["newshape"])
 
 
 def rewrite_dense_bias_reshape_last(mod, pack_wei=False):
-    """Rewrite the input graph to reorder reshape operators so that 
-       we can perform dense_bias fusion and then offload them to byoc part.
+    """Rewrite the input graph to reorder reshape operators so that
+    we can perform dense_bias fusion and then offload them to byoc part.
     """
     mod["main"] = rewrite(DenseReshapeBiasRewrite(pack_wei), mod["main"])
     return mod
@@ -900,9 +904,9 @@ class PackDenseRewrite(DFPatternCallback):
         super(PackDenseRewrite, self).__init__()
         self.data = wildcard()
         self.weight = wildcard()
-        
+
         self.attr_map = {}
-        
+
         den = is_op("nn.dense")(self.data, self.weight)
         self.pattern = den
 
@@ -913,7 +917,7 @@ class PackDenseRewrite(DFPatternCallback):
                 for k in expr.attrs.keys():
                     new_attrs[k] = expr.attrs[k]
                 self.attr_map["nn.dense"] = new_attrs
-        
+
         _analysis.post_order_visit(pre, visit_func)
 
     def callback(self, pre, post, node_map):
@@ -921,32 +925,35 @@ class PackDenseRewrite(DFPatternCallback):
 
         data = node_map[self.data][0]
         weight = node_map[self.weight][0]
-        
+
         weight_shape_list = [str(x) for x in get_shape(weight)]
         data_shape_list = [str(x) for x in get_shape(data)]
 
         data_shape = ",".join(data_shape_list)
         weight_shape = ",".join(weight_shape_list)
         out_shape = ",".join([data_shape_list[0], weight_shape_list[0]])
-        
-        res = get_optimal_layout_for_dense(
-            data_shape,
-            weight_shape,
-            out_shape
-        )
+
+        res = get_optimal_layout_for_dense(data_shape, weight_shape, out_shape)
 
         _, weight_df, _ = res.split(",")
-    
+
         reco_weight_layout = tag2layout(weight_df, is_weight=True, op_type="Dense")
-        
+
         weight_transform = relay.layout_transform(weight, "NC", dst_layout=reco_weight_layout)
-        return relay.op.nn.contrib_dense_pack(data, weight_transform, weight_layout=reco_weight_layout, 
-                units=None, out_dtype=self.attr_map["nn.dense"]["out_dtype"] if 'out_dtype' in self.attr_map['nn.dense'] else "")
-        
+        return relay.op.nn.contrib_dense_pack(
+            data,
+            weight_transform,
+            weight_layout=reco_weight_layout,
+            units=None,
+            out_dtype=self.attr_map["nn.dense"]["out_dtype"]
+            if "out_dtype" in self.attr_map["nn.dense"]
+            else "",
+        )
+
 
 def rewrite_dense_to_pack(mod):
-    """Rewrite the input graph to use packed dense operators so that 
-       we can gain better performance boost in dnnl byoc part.
+    """Rewrite the input graph to use packed dense operators so that
+    we can gain better performance boost in dnnl byoc part.
     """
     mod["main"] = rewrite(PackDenseRewrite(), mod["main"])
     return mod

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -700,15 +700,10 @@ class DenseReshapeBiasGeluRewrite(DFPatternCallback):
 
 def rewrite_dense_bias_gelu_reshape_last(mod):
     """Rewrite the input graph to reorder reshape operators so that
-    we can perform dense_bias_gelu fusion and then offload them to byoc part.
+    we can perform dense_bias_gelu/dense_bias fusion and then offload
+    them to byoc part.
     """
-    mod["main"] = rewrite(DenseReshapeBiasGeluRewrite(), mod["main"])
-    return mod
-
-
-def rewrite_dense_bias_reshape_last(mod):
-    """Rewrite the input graph to reorder reshape operators so that
-    we can perform dense_bias fusion and then offload them to byoc part.
-    """
-    mod["main"] = rewrite(DenseReshapeBiasGeluRewrite(has_gelu=False), mod["main"])
+    mod["main"] = rewrite(
+        [DenseReshapeBiasGeluRewrite(), DenseReshapeBiasGeluRewrite(has_gelu=False)], mod["main"]
+    )
     return mod

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -540,12 +540,8 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
         std::vector<std::string> op_list = ParsingOpList(name);
         call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
         ICHECK(call->op.as<OpNode>()) << "Not op node";
-      } else if (name.find("gelu") != std::string::npos) {
-        call = FindCallWithName(fn->body.as<CallNode>(), 10, "nn.dense");
-        ICHECK(call->op.as<OpNode>()) << "Not op node";
       } else if (name.find("dnnl.dense") != std::string::npos) {
-        std::vector<std::string> op_list = ParsingOpList(name);
-        call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
+        call = FindCallWithName(fn->body.as<CallNode>(), 10, "nn.dense");
         ICHECK(call->op.as<OpNode>()) << "Not op node";
       } else {
         LOG(FATAL) << "Unrecognized DNNL pattern: " << name;

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -436,6 +436,38 @@ class DNNLModuleCodegen : public CSourceModuleCodegenBase {
 
 #else  // DNNL JSON runtime
 
+/*!
+ * \brief Retrieve the expected "root" op nested inside a fused call, such as conv2d in
+ *        relu(add(conv2d))
+ * \param call A Relay call node. Typically nn.relu when called the first time.
+ * \param max_depth The maximum number of calls before the root op, counting from current_call.
+ * \param root_name The name of expected "root" op in this fused call.
+ * \return A CallNode corresponding to the root op
+ */
+inline const CallNode* FindCallWithName(const CallNode* current_call, int max_depth,
+                                        const std::string& root_name) {
+  ICHECK(current_call && max_depth >= 0);
+
+  if (max_depth == 0) {
+    ICHECK(current_call && IsOp(current_call, root_name));
+    return current_call;
+  }
+  if (IsOp(current_call, root_name)) {
+    return current_call;
+  }
+
+  ICHECK_GT(current_call->args.size(), 0);
+
+  size_t valid_node_idx = 0;
+  while (valid_node_idx < current_call->args.size() &&
+         current_call->args[valid_node_idx].as<VarNode>()) {
+    valid_node_idx++;
+  }
+
+  const auto* next_call = current_call->args[valid_node_idx].as<CallNode>();
+  return FindCallWithName(next_call, max_depth - 1, root_name);
+}
+
 class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
   using JSONGraphNode = tvm::runtime::json::JSONGraphNode;
   using JSONGraphNodeEntry = tvm::runtime::json::JSONGraphNodeEntry;
@@ -447,9 +479,6 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
       {"sigmoid", "sigmoid"},
       {"nn.deconv2d", "nn.conv2d_transpose"},
       {"nn.deconv3d", "nn.conv3d_transpose"},
-      {"add", "add"},
-      {"multiply", "multiply"},
-      {"nn.packeddense", "nn.contrib_dense_pack"},
   };
 
   std::vector<std::string> ParsingOpList(const std::string& pattern_name,
@@ -458,18 +487,11 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
     std::vector<std::string> op_list;
     size_t pos = 0, start = 0;
 
-    std::string raw_name = pattern_name;
-    if (raw_name.find("gelu") != std::string::npos) {
-      //TODO(billishyahao): Remove me after introducing new gelu operator
-      raw_name.replace(raw_name.find("gelu"), 4, "multiply_multiply_");
-    } 
-    while ((pos = raw_name.find(interval, start)) != std::string::npos) {
-      std::string op_name = raw_name.substr(start, pos - start);
+    while ((pos = pattern_name.find(interval, start)) != std::string::npos) {
+      std::string op_name = pattern_name.substr(start, pos - start);
       if (op_name.find("dnnl") != std::string::npos) {
         op_name.replace(op_name.find("dnnl"), 4, "nn");
         if (op_name.find("deconv") != std::string::npos) {
-          op_name = op_map[op_name];
-        } else if (op_name.find("packeddense") != std::string::npos) {
           op_name = op_map[op_name];
         }
       } else {
@@ -478,8 +500,8 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
       if (pos > start) op_list.push_back(op_name);
       start = pos + interval.size();
     }
-    if (raw_name.size() > start) {
-      op_list.push_back(op_map[raw_name.substr(start)]);
+    if (pattern_name.size() > start) {
+      op_list.push_back(op_map[pattern_name.substr(start)]);
     }
     return op_list;
   }
@@ -518,11 +540,10 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
         std::vector<std::string> op_list = ParsingOpList(name);
         call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
         ICHECK(call->op.as<OpNode>()) << "Not op node";
-      } else if (name.find("dnnl.dense") != std::string::npos) {
-        std::vector<std::string> op_list = ParsingOpList(name);
-        call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
+      } else if (name.find("gelu") != std::string::npos) {
+        call = FindCallWithName(fn->body.as<CallNode>(), 10, "nn.dense");
         ICHECK(call->op.as<OpNode>()) << "Not op node";
-      } else if (name.find("dnnl.packeddense") != std::string::npos) {
+      } else if (name.find("dnnl.dense") != std::string::npos) {
         std::vector<std::string> op_list = ParsingOpList(name);
         call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
         ICHECK(call->op.as<OpNode>()) << "Not op node";

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -447,6 +447,9 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
       {"sigmoid", "sigmoid"},
       {"nn.deconv2d", "nn.conv2d_transpose"},
       {"nn.deconv3d", "nn.conv3d_transpose"},
+      {"add", "add"},
+      {"multiply", "multiply"},
+      {"nn.packeddense", "nn.contrib_dense_pack"},
   };
 
   std::vector<std::string> ParsingOpList(const std::string& pattern_name,
@@ -454,11 +457,19 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
     ICHECK_NE(pattern_name, "");
     std::vector<std::string> op_list;
     size_t pos = 0, start = 0;
-    while ((pos = pattern_name.find(interval, start)) != std::string::npos) {
-      std::string op_name = pattern_name.substr(start, pos - start);
+
+    std::string raw_name = pattern_name;
+    if (raw_name.find("gelu") != std::string::npos) {
+      //TODO(billishyahao): Remove me after introducing new gelu operator
+      raw_name.replace(raw_name.find("gelu"), 4, "multiply_multiply_");
+    } 
+    while ((pos = raw_name.find(interval, start)) != std::string::npos) {
+      std::string op_name = raw_name.substr(start, pos - start);
       if (op_name.find("dnnl") != std::string::npos) {
         op_name.replace(op_name.find("dnnl"), 4, "nn");
         if (op_name.find("deconv") != std::string::npos) {
+          op_name = op_map[op_name];
+        } else if (op_name.find("packeddense") != std::string::npos) {
           op_name = op_map[op_name];
         }
       } else {
@@ -467,8 +478,8 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
       if (pos > start) op_list.push_back(op_name);
       start = pos + interval.size();
     }
-    if (pattern_name.size() > start) {
-      op_list.push_back(op_map[pattern_name.substr(start)]);
+    if (raw_name.size() > start) {
+      op_list.push_back(op_map[raw_name.substr(start)]);
     }
     return op_list;
   }
@@ -508,6 +519,10 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
         call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
         ICHECK(call->op.as<OpNode>()) << "Not op node";
       } else if (name.find("dnnl.dense") != std::string::npos) {
+        std::vector<std::string> op_list = ParsingOpList(name);
+        call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
+        ICHECK(call->op.as<OpNode>()) << "Not op node";
+      } else if (name.find("dnnl.packeddense") != std::string::npos) {
         std::vector<std::string> op_list = ParsingOpList(name);
         call = GetRootCall(fn->body.as<CallNode>(), op_list.size() - 1, op_list);
         ICHECK(call->op.as<OpNode>()) << "Not op node";

--- a/src/relay/backend/contrib/dnnl/query_layout.cc
+++ b/src/relay/backend/contrib/dnnl/query_layout.cc
@@ -362,6 +362,43 @@ std::string get_optimal_layout_for_conv_transpose(std::string data_layout,
   return res;
 }
 
+std::string get_optimal_layout_for_dense(std::string data_layout, std::string weight_shape,
+                                         std::string out_shape) {
+  dnnl::engine eng(dnnl::engine::kind::cpu, 0);
+  dnnl::stream s(eng);
+  using tag = dnnl::memory::format_tag;
+  using dt = dnnl::memory::data_type;
+
+  dnnl::memory::dims data_dims = str2dims(data_layout);
+  dnnl::memory::dims weight_dims = str2dims(weight_shape);
+  dnnl::memory::dims out_dims = str2dims(out_shape);
+  dnnl::memory::dims bias_dims = {out_dims[1]};
+  
+  // Memory descriptions.
+  auto data_md = dnnl::memory::desc({data_dims, dt::f32, tag::any});
+  auto weight_md = dnnl::memory::desc({weight_dims, dt::f32, tag::any});
+  auto bias_md = dnnl::memory::desc({bias_dims, dt::f32, tag::any});
+  auto dst_md = dnnl::memory::desc({out_dims, dt::f32, tag::any});
+
+  // Dense description.
+  auto dense_desc = dnnl::inner_product_forward::desc(dnnl::prop_kind::forward_inference, data_md,
+                                                        weight_md, bias_md, dst_md);
+
+  dnnl::primitive_attr attr;
+  auto dense_prim_desc = dnnl::inner_product_forward::primitive_desc(dense_desc, attr, eng);
+
+  auto src_format = dense_prim_desc.src_desc();
+  auto weights_format = dense_prim_desc.weights_desc();
+  auto dst_format = dense_prim_desc.dst_desc();
+  std::string src_df, weight_df, dst_df;
+
+  src_df = md2fmt_tag_str(&src_format);
+  weight_df = md2fmt_tag_str(&weights_format);
+  dst_df = md2fmt_tag_str(&dst_format);
+  std::string res = src_df + "," + weight_df + "," + dst_df;
+  return res;
+}
+
 TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv")
     .set_body([](TVMArgs args, TVMRetValue* rv) {
       *rv = get_optimal_layout_for_conv(args[0], args[1], args[2], args[3], args[4], args[5],
@@ -372,6 +409,11 @@ TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv_transpose")
     .set_body([](TVMArgs args, TVMRetValue* rv) {
       *rv = get_optimal_layout_for_conv_transpose(args[0], args[1], args[2], args[3], args[4],
                                                   args[5], args[6], args[7], args[8], args[9]);
+    });
+
+TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_dense")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      *rv = get_optimal_layout_for_dense(args[0], args[1], args[2]);
     });
 
 }  // namespace contrib

--- a/src/relay/backend/contrib/dnnl/query_layout.cc
+++ b/src/relay/backend/contrib/dnnl/query_layout.cc
@@ -362,43 +362,6 @@ std::string get_optimal_layout_for_conv_transpose(std::string data_layout,
   return res;
 }
 
-std::string get_optimal_layout_for_dense(std::string data_layout, std::string weight_shape,
-                                         std::string out_shape) {
-  dnnl::engine eng(dnnl::engine::kind::cpu, 0);
-  dnnl::stream s(eng);
-  using tag = dnnl::memory::format_tag;
-  using dt = dnnl::memory::data_type;
-
-  dnnl::memory::dims data_dims = str2dims(data_layout);
-  dnnl::memory::dims weight_dims = str2dims(weight_shape);
-  dnnl::memory::dims out_dims = str2dims(out_shape);
-  dnnl::memory::dims bias_dims = {out_dims[1]};
-  
-  // Memory descriptions.
-  auto data_md = dnnl::memory::desc({data_dims, dt::f32, tag::any});
-  auto weight_md = dnnl::memory::desc({weight_dims, dt::f32, tag::any});
-  auto bias_md = dnnl::memory::desc({bias_dims, dt::f32, tag::any});
-  auto dst_md = dnnl::memory::desc({out_dims, dt::f32, tag::any});
-
-  // Dense description.
-  auto dense_desc = dnnl::inner_product_forward::desc(dnnl::prop_kind::forward_inference, data_md,
-                                                        weight_md, bias_md, dst_md);
-
-  dnnl::primitive_attr attr;
-  auto dense_prim_desc = dnnl::inner_product_forward::primitive_desc(dense_desc, attr, eng);
-
-  auto src_format = dense_prim_desc.src_desc();
-  auto weights_format = dense_prim_desc.weights_desc();
-  auto dst_format = dense_prim_desc.dst_desc();
-  std::string src_df, weight_df, dst_df;
-
-  src_df = md2fmt_tag_str(&src_format);
-  weight_df = md2fmt_tag_str(&weights_format);
-  dst_df = md2fmt_tag_str(&dst_format);
-  std::string res = src_df + "," + weight_df + "," + dst_df;
-  return res;
-}
-
 TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv")
     .set_body([](TVMArgs args, TVMRetValue* rv) {
       *rv = get_optimal_layout_for_conv(args[0], args[1], args[2], args[3], args[4], args[5],
@@ -409,11 +372,6 @@ TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv_transpose")
     .set_body([](TVMArgs args, TVMRetValue* rv) {
       *rv = get_optimal_layout_for_conv_transpose(args[0], args[1], args[2], args[3], args[4],
                                                   args[5], args[6], args[7], args[8], args[9]);
-    });
-
-TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_dense")
-    .set_body([](TVMArgs args, TVMRetValue* rv) {
-      *rv = get_optimal_layout_for_dense(args[0], args[1], args[2]);
     });
 
 }  // namespace contrib

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -481,6 +481,38 @@ inline const CallNode* GetRootCall(const CallNode* current_call, const std::stri
 }
 
 /*!
+ * \brief Retrieve the expected "root" op nested inside a fused call, such as conv2d in
+ *        relu(add(conv2d))
+ * \param call A Relay call node. Typically nn.relu when called the first time.
+ * \param max_depth The maximum number of calls before the root op, counting from current_call.
+ * \param op_name The name of expected "root" op in this fused call.
+ * \return A CallNode corresponding to the root op
+ */
+inline const CallNode* GetRootCall(const CallNode* current_call, int max_depth,
+                                        const std::string& op_name) {
+  ICHECK(current_call && max_depth >= 0);
+
+  if (max_depth == 0) {
+    ICHECK(current_call && IsOp(current_call, op_name));
+    return current_call;
+  }
+  if (IsOp(current_call, op_name)) {
+    return current_call;
+  }
+
+  ICHECK_GT(current_call->args.size(), 0);
+
+  size_t valid_node_idx = 0;
+  while (valid_node_idx < current_call->args.size() &&
+         current_call->args[valid_node_idx].as<VarNode>()) {
+    valid_node_idx++;
+  }
+
+  const auto* next_call = current_call->args[valid_node_idx].as<CallNode>();
+  return GetRootCall(next_call, max_depth - 1, op_name);
+}
+
+/*!
  * \brief Get the external symbol of the Relay function name.
  *
  * \param func The provided function.

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -489,7 +489,7 @@ inline const CallNode* GetRootCall(const CallNode* current_call, const std::stri
  * \return A CallNode corresponding to the root op
  */
 inline const CallNode* GetRootCall(const CallNode* current_call, int max_depth,
-                                        const std::string& op_name) {
+                                   const std::string& op_name) {
   ICHECK(current_call && max_depth >= 0);
 
   if (max_depth == 0) {

--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -439,6 +439,8 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     dnnl::memory::dims out_dims = out_shape;
 
     // Memory descriptions.
+    auto dl_dtype = nodes_[data_entry.id_].GetOpDataType()[data_entry.index_];
+    auto dtype = dtype_dl2dnnl(dl_dtype);
     auto data_md = dnnl::memory::desc({data_dims, dt::f32, tag::nc});
     auto weight_md = dnnl::memory::desc({weight_dims, dt::f32, layout2tag(weight_layout)});
     auto bias_md = dnnl::memory::desc({bias_dims, dt::f32, tag::x});
@@ -465,7 +467,7 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
       BindDNNLMemory(bias_entry, bias_memory);
     } else {
       float bias[OC] = {0};
-      write_to_dnnl_memory(bias, bias_memory, OC * sizeof(float));
+      write_to_dnnl_memory(bias, bias_memory, OC * ((dl_dtype.bits + 7) / 8));
     }
 
     // Output memory.

--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -83,7 +83,6 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
       // Find proper dnnl::memory buffers
       std::unordered_map<int, dnnl::memory> mem_args;
       for (const auto& kvp : arg_reqs) mem_args[kvp.first] = mem_solver(kvp.second);
-
       prim.execute(stream_, mem_args);
     }
   }
@@ -179,7 +178,6 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     std::regex deconv_pat(".*deconv[1-3]d.*");
     std::regex conv_transpose_pat(".*conv[1-3]d_transpose.*");
     std::regex dense_pat(".*dense.*");
-    std::regex dense_pack_pat(".*packeddense.*");
     std::regex max_pool_pat(".*max_pool[1-3]d");
     std::regex avg_pool_pat(".*avg_pool[1-3]d");
 
@@ -194,9 +192,6 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
           Deconvolution(nid);
         } else if (std::regex_match(op_name, conv_pat)) {
           Convolution(nid);
-        } else if (std::regex_match(op_name, dense_pack_pat) ||
-                   "nn.contrib_dense_pack" == op_name) {
-          // DensePack(nid);
         } else if (std::regex_match(op_name, dense_pat)) {
           Dense(nid);
         } else if ("nn.batch_norm" == op_name) {
@@ -414,7 +409,6 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
                                                           {DNNL_ARG_SCRATCHPAD, scratchpad_tr},
                                                           {DNNL_ARG_DST, dst_tr}});
   }
-
 
   void BatchNorm(const size_t& nid) {
     auto node = nodes_[nid];

--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -158,7 +158,7 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     if (std::regex_match(op_name, gelu_pat)) {
       ops.append_eltwise(1.f, dnnl::algorithm::eltwise_gelu_erf, 0.f, 0.f);
     }
-    if (ops.len() != 0){
+    if (ops.len() != 0) {
       attr.set_post_ops(ops);
     }
 

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -912,7 +912,7 @@ def test_dense(run_module, dtype="float32"):
     config = dense, dic, param_lst
     run_and_verify_func(config, run_module=run_module, dtype=dtype)
 
-    dense, dic, param_lst = get_dense(x_shape, k_shape,  activation="gelu", dtype=dtype)
+    dense, dic, param_lst = get_dense(x_shape, k_shape, activation="gelu", dtype=dtype)
     dense = tvm.IRModule.from_expr(dense)
     config = dense, dic, param_lst
     run_and_verify_func(config, run_module=run_module, dtype=dtype)
@@ -932,7 +932,7 @@ def test_dense_pattern(run_module, dtype="float32"):
     config = dense_bias, dic, param_lst
     run_and_verify_func(config, run_module=run_module, dtype=dtype)
 
-    dense_bias, dic, param_lst = get_dense_bias(x_shape, k_shape,  activation="gelu", dtype=dtype)
+    dense_bias, dic, param_lst = get_dense_bias(x_shape, k_shape, activation="gelu", dtype=dtype)
     dense_bias = tvm.IRModule.from_expr(dense_bias)
     config = dense_bias, dic, param_lst
     run_and_verify_func(config, run_module=run_module, dtype=dtype)

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -57,7 +57,7 @@ def bf16_supported():
     return _bf16_supported
 
 
-def partition_for_dnnl(mod, params=None, alter_layout=True):
+def partition_for_dnnl(mod, params=None, alter_layout=True, prune_subgraphs=True):
     """Partition the graph greedily offloading supported operators to DNNL.
 
     Parameters
@@ -113,6 +113,7 @@ def partition_for_dnnl(mod, params=None, alter_layout=True):
                                 mod = alter_layout_seq(mod)
 
     mod = dnnl.rewrite_layer_norm(mod)
+    mod = dnnl.rewrite_dense_bias_gelu_reshape_last(mod)
 
     byoc_seq = tvm.transform.Sequential(
         [
@@ -125,7 +126,8 @@ def partition_for_dnnl(mod, params=None, alter_layout=True):
 
     with tvm.transform.PassContext(opt_level=3):
         mod = byoc_seq(mod)
-        mod = dnnl.prune_dnnl_subgraphs(mod)
+        if prune_subgraphs:
+            mod = dnnl.prune_dnnl_subgraphs(mod)
     return mod
 
 
@@ -152,16 +154,15 @@ def assert_result_dict_holds(result_dict):
                 tvm.testing.assert_allclose(r1, r2, rtol=1e-3, atol=1e-3)
 
 
-def run_and_verify(mod, input, params, target, run_module, subgraph_num=None, test_bf16=True):
-    def check_dnnl_used(mod, subgraph_num=None):
-        num_dnnl_subgraphs = sum(
-            [1 if "dnnl" in gv.name_hint else 0 for gv in mod.get_global_vars()]
-        )
-        if subgraph_num:
-            assert num_dnnl_subgraphs == subgraph_num
-        else:
-            assert num_dnnl_subgraphs >= 1
+def check_dnnl_used(mod, subgraph_num=None):
+    num_dnnl_subgraphs = sum([1 if "dnnl" in gv.name_hint else 0 for gv in mod.get_global_vars()])
+    if subgraph_num:
+        assert num_dnnl_subgraphs == subgraph_num
+    else:
+        assert num_dnnl_subgraphs >= 1
 
+
+def run_and_verify(mod, input, params, target, run_module, subgraph_num=None, test_bf16=True):
     dev = tvm.cpu()
     result_dict = dict()
     for mode in ["graph", "vm"]:
@@ -600,10 +601,15 @@ def gelu_helper(data):
     return out
 
 
-def get_dense(x_shape=(1, 16), k_shape=(32, 16), activation=None, dtype="float32"):
+def get_dense(
+    x_shape=(1, 16), k_shape=(32, 16), activation=None, has_reshape=False, dtype="float32"
+):
     x = relay.var("x", shape=(x_shape), dtype=dtype)
     kernel = relay.var("kernel", shape=(k_shape), dtype=dtype)
     out = relay.nn.dense(x, kernel, units=k_shape[0])
+    # out = relay.nn.dense(x, kernel, units=None)
+    if has_reshape:
+        out = relay.reshape(out, newshape=(1, x_shape[0], k_shape[0]))
     dic = {"x": x_shape, "kernel": k_shape}
     param_lst = ["kernel"]
 
@@ -612,10 +618,22 @@ def get_dense(x_shape=(1, 16), k_shape=(32, 16), activation=None, dtype="float32
     return out, dic, param_lst
 
 
-def get_dense_bias(x_shape=(1, 16), k_shape=(32, 16), activation=None, dtype="float32"):
-    dense, dic, param_lst = get_dense(x_shape=x_shape, k_shape=k_shape, dtype=dtype)
+def get_dense_bias(
+    x_shape=(1, 16),
+    k_shape=(32, 16),
+    activation=None,
+    has_reshape=False,
+    use_add=False,
+    dtype="float32",
+):
+    dense, dic, param_lst = get_dense(
+        x_shape=x_shape, k_shape=k_shape, has_reshape=has_reshape, dtype=dtype
+    )
     bias = relay.var("bias", shape=(k_shape[0],), dtype=dtype)
-    out = relay.nn.bias_add(dense, bias)
+    if use_add:
+        out = relay.add(dense, bias)
+    else:
+        out = relay.nn.bias_add(dense, bias)
     dic["bias"] = (k_shape[0],)
     param_lst += ["bias"]
 
@@ -1082,6 +1100,30 @@ def test_layer_norm(run_module, dtype="float32"):
     ln = tvm.IRModule.from_expr(ln)
     config = ln, dic, param_lst
     run_and_verify_func(config, run_module=run_module, dtype=dtype)
+
+
+def test_rewrite_dense_bias_gelu_reshape_last(run_module, dtype="float32"):
+    def get_graph(act=None):
+        x_shape = (1, 16)
+        k_shape = (32, 16)
+
+        dense_bias, dic, param_lst = get_dense_bias(
+            x_shape, k_shape, activation=act, has_reshape=True, use_add=True, dtype=dtype
+        )
+        dense_bias = tvm.IRModule.from_expr(dense_bias)
+        processed_dense_bias = partition_for_dnnl(
+            dense_bias, params=None, alter_layout=False, prune_subgraphs=False
+        )
+        check_dnnl_used(processed_dense_bias, 1)
+
+        return dense_bias, dic, param_lst
+
+    run_and_verify_func(
+        get_graph("gelu"), subgraph_num=1, run_module=run_module, dtype=dtype, test_bf16=False
+    )
+    run_and_verify_func(
+        get_graph(), subgraph_num=1, run_module=run_module, dtype=dtype, test_bf16=False
+    )
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -188,8 +188,6 @@ def run_and_verify(mod, input, params, target, run_module, subgraph_num=None, te
                     continue
             if use_dnnl:
                 processed_mod = partition_for_dnnl(processed_mod, params, alter_layout)
-                print("hebi-dbg: processed_mod: ", result_key)
-                print(processed_mod)
                 check_dnnl_used(processed_mod)
 
             with tvm.transform.PassContext(opt_level=3):
@@ -199,10 +197,6 @@ def run_and_verify(mod, input, params, target, run_module, subgraph_num=None, te
             if run_module:
                 if isinstance(input, dict):
                     result_dict[result_key] = func(**input, **params)
-                    print("input:", input)
-                    print("params:", params)
-                    print("result_dict[result_key]:")
-                    print(result_dict[result_key])
                 else:
                     result_dict[result_key] = func(input, **params)
 
@@ -914,6 +908,11 @@ def test_dense(run_module, dtype="float32"):
     run_and_verify_func(config, run_module=run_module, dtype=dtype)
 
     dense, dic, param_lst = get_dense(x_shape, k_shape=(1, 16), dtype=dtype)
+    dense = tvm.IRModule.from_expr(dense)
+    config = dense, dic, param_lst
+    run_and_verify_func(config, run_module=run_module, dtype=dtype)
+
+    dense, dic, param_lst = get_dense(x_shape, k_shape,  activation="gelu", dtype=dtype)
     dense = tvm.IRModule.from_expr(dense)
     config = dense, dic, param_lst
     run_and_verify_func(config, run_module=run_module, dtype=dtype)

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -928,9 +928,9 @@ def test_dnnl_fuse():
     ) = (
         dnnl_patterns[1],
         dnnl_patterns[13],
-        dnnl_patterns[19],
-        dnnl_patterns[25],
-        dnnl_patterns[37],
+        dnnl_patterns[20],
+        dnnl_patterns[26],
+        dnnl_patterns[38],
     )
 
     def get_blocks(


### PR DESCRIPTION
This patch is to enhance the performance of DNNL BYOC dense operators by 1) introducing gelu fusion and ~~2) introducing alter dense weight layout.~~ (Implemented after merging PR https://github.com/apache/tvm/pull/11345, Thanks @apeskov )

Why do we introduce gelu fusion:
For the model family of BERT, GELU (Gaussian Error Linear Unit) activation is used heavily so if we perform gelu fusion in those models, then we gain a better performance boost. 

Why do we introduce automatically packed dense and its altered weight layout:
Format tag::ab (aka. tag::NC) is not the best format selected by DNNL inner_product primitive. It is a drawback in current DNNL BYOC module.

For what model it fit in:
Dense intensity type such as Bert family

With this patch, I benchmarked the inference performance of a kind of vision-tranformer called PCPVT (https://arxiv.org/abs/2104.13840) on ICX-8352Y. Here is some boost data:

| 32 cores |Latency (dev)  |
|--|--|
| baseline byoc | 11.45ms | 
| byoc w/ patch|  7.93ms |


Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
