### PR TITLE
[CI] Update tensorflow to version 2.6.5

### DIFF
--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -21,6 +21,6 @@ set -u
 set -o pipefail
 
 pip3 install \
-    "h5py==3.1.0" \
+    h5py==3.1.0 \
     keras==2.6 \
-    tensorflow==2.6.2
+    tensorflow==2.6.5


### PR DESCRIPTION
Updating from 2.6.2 to 2.6.5 due to a breaking change in the protobuf package not being handled correctly by tensorflow dependencies: https://github.com/protocolbuffers/protobuf/issues/10051. This was fixed in 2.6.5.

cc @Mousius @areusch @driazati @leandron
