### PR TITLE
[TIR][Arith] Additional Simplifications Inside Conditionals

### DIFF
--- a/src/arith/const_int_bound.cc
+++ b/src/arith/const_int_bound.cc
@@ -598,6 +598,9 @@ class ConstIntBoundAnalyzer::Impl
     if ((x < c).Match(cond)) {
       return {BoundInfo(x.Eval(), MakeBound(kNegInf, c.Eval()->value - 1))};
     }
+    if ((x == c).Match(cond) || (c == x).Match(cond)) {
+      return {BoundInfo(x.Eval(), MakeBound(c.Eval()->value, c.Eval()->value))};
+    }
     if ((x && y).Match(cond)) {
       auto ret1 = DetectBoundInfo(x.Eval());
       auto ret2 = DetectBoundInfo(y.Eval());

--- a/src/arith/constraint_extract.cc
+++ b/src/arith/constraint_extract.cc
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/arith/constraint_extract.cc
+ */
+
+#include "constraint_extract.h"
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/expr.h>
+
+#include "pattern_match.h"
+
+namespace tvm {
+namespace arith {
+
+void CollectConstraints(const PrimExpr& expr, Analyzer* analyzer, std::vector<PrimExpr>* collect) {
+  collect->push_back(expr);
+
+  PVar<PrimExpr> x, y;
+  if ((x && y).Match(expr)) {
+    CollectConstraints(x.Eval(), analyzer, collect);
+    CollectConstraints(y.Eval(), analyzer, collect);
+  } else if ((!(x || y)).Match(expr)) {
+    CollectConstraints(analyzer->rewrite_simplify(tir::Not(x.Eval())), analyzer, collect);
+    CollectConstraints(analyzer->rewrite_simplify(tir::Not(y.Eval())), analyzer, collect);
+  }
+}
+
+std::vector<PrimExpr> ExtractConstraints(const PrimExpr& expr) {
+  std::vector<PrimExpr> out;
+  Analyzer analyzer;
+  CollectConstraints(expr, &analyzer, &out);
+  return out;
+}
+
+}  // namespace arith
+}  // namespace tvm

--- a/src/arith/constraint_extract.h
+++ b/src/arith/constraint_extract.h
@@ -28,6 +28,8 @@
 
 #include <tvm/tir/expr.h>
 
+#include <vector>
+
 namespace tvm {
 namespace arith {
 

--- a/src/arith/constraint_extract.h
+++ b/src/arith/constraint_extract.h
@@ -38,7 +38,7 @@ namespace arith {
  * Utility to break up a boolean expression into independent
  * constraints.
  *
- * Example: `i==5 && j==3` => `[i==5 && j==3, * i==5, j==3]`
+ * Example: `i==5 && j==3` => `[i==5 && j==3, i==5, j==3]`
  * Example: `i==5 || j==3` => `[i==5 || j==3]`
  * Example: `!(i>5 || j==3)` => `[!(i==5 || j==3), i<=5, j!=3]`
  *

--- a/src/arith/constraint_extract.h
+++ b/src/arith/constraint_extract.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file contraint_extract.h
+ *
+ * \brief Centralized location for extraction of constraints from a boolean expression.
+ */
+
+#ifndef TVM_ARITH_CONSTRAINT_EXTRACT_H_
+#define TVM_ARITH_CONSTRAINT_EXTRACT_H_
+
+#include <tvm/tir/expr.h>
+
+namespace tvm {
+namespace arith {
+
+/* \brief Returns constraints that are true if the expression is true.
+ *
+ * Utility to break up a boolean expression into independent
+ * constraints.
+ *
+ * Example: `i==5 && j==3` => `[i==5 && j==3, * i==5, j==3]`
+ * Example: `i==5 || j==3` => `[i==5 || j==3]`
+ * Example: `!(i>5 || j==3)` => `[!(i==5 || j==3), i<=5, j!=3]`
+ *
+ * Intended for use in bounds analysis or simplification within a
+ * conditional, or identifying independent conditionals that may be
+ * hoisted.
+ *
+ * \param expr The expression to be analyzers
+ *
+ * \returns A vector of independent constraints
+ */
+std::vector<PrimExpr> ExtractConstraints(const PrimExpr& expr);
+
+}  // namespace arith
+}  // namespace tvm
+
+#endif  // TVM_ARITH_CONSTRAINT_EXTRACT_H_

--- a/src/arith/modular_set.cc
+++ b/src/arith/modular_set.cc
@@ -112,6 +112,10 @@ class ModularSetAnalyzer::Impl : public ExprFunctor<ModularSetAnalyzer::Entry(co
       Entry entry(coeff.Eval()->value, base.Eval()->value);
       return UpdateByIntersect(var.Eval(), entry);
     }
+    if ((var == base).Match(constraint) || (base == var).Match(constraint)) {
+      Entry entry(1, base.Eval()->value);
+      return UpdateByIntersect(var.Eval(), entry);
+    }
     return nullptr;
   }
 

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -32,6 +32,7 @@
 
 #include "../target/datatype/registry.h"
 #include "const_fold.h"
+#include "constraint_extract.h"
 #include "pattern_match.h"
 
 namespace tvm {
@@ -229,8 +230,10 @@ std::function<void()> RewriteSimplifier::Impl::EnterConstraint(const PrimExpr& c
   // we will compare the already simplified result with the constraint,
   // so simplify the constarint as well
   PrimExpr new_constraint = operator()(constraint);
-  if (SideEffect(new_constraint) <= CallEffectKind::kPure) {
-    literal_constraints_.push_back(new_constraint);
+  for (const PrimExpr& subconstraint : ExtractConstraints(new_constraint)) {
+    if (SideEffect(subconstraint) <= CallEffectKind::kPure) {
+      literal_constraints_.push_back(subconstraint);
+    }
   }
   size_t new_literal_size = literal_constraints_.size();
   auto frecover = [old_literal_size, new_literal_size, this]() {

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -237,7 +237,13 @@ std::function<void()> RewriteSimplifier::Impl::EnterConstraint(const PrimExpr& c
       // that would require performing a rewrite of each expression
       // being checked.  This way, we only apply a rewrite for each
       // constraint being applied.
-      auto negation = operator()(Not(subconstraint));
+      PrimExpr negation;
+      if (subconstraint.dtype().is_bool()) {
+        negation = Not(subconstraint);
+      } else {
+        negation = subconstraint == make_zero(subconstraint.dtype());
+      }
+      negation = operator()(negation);
       literal_constraints_.push_back(Not(negation));
     }
   }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -228,7 +228,10 @@ std::function<void()> RewriteSimplifier::Impl::EnterConstraint(const PrimExpr& c
   size_t old_literal_size = literal_constraints_.size();
   // we will compare the already simplified result with the constraint,
   // so simplify the constarint as well
-  literal_constraints_.push_back(operator()(constraint));
+  PrimExpr new_constraint = operator()(constraint);
+  if (SideEffect(new_constraint) <= CallEffectKind::kPure) {
+    literal_constraints_.push_back(new_constraint);
+  }
   size_t new_literal_size = literal_constraints_.size();
   auto frecover = [old_literal_size, new_literal_size, this]() {
     ICHECK_EQ(literal_constraints_.size(), new_literal_size);

--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -105,8 +105,14 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
    */
   bool CanInlineLet(const LetNode* op);
 
-  // Whether the expression matches a previously defined constraint.
-  bool MatchesLiteralConstraint(const PrimExpr& expr) const;
+  /*! \brief Internal function to apply constraints
+   *
+   * Tests whether the expression is known to be true or false based
+   * on existing constraints.  If the expression or its negation
+   * matches a constraint, return the boolean it should be replaced
+   * with.  Otherwise, return false.
+   */
+  Optional<PrimExpr> TryMatchLiteralConstraint(const PrimExpr& expr) const;
 
  private:
   // Whether x >= val

--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -105,6 +105,9 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
    */
   bool CanInlineLet(const LetNode* op);
 
+  // Whether the expression matches a previously defined constraint.
+  bool MatchesLiteralConstraint(const PrimExpr& expr) const;
+
  private:
   // Whether x >= val
   bool CanProveGreaterEqual(const PrimExpr& x, int64_t val) {

--- a/tests/python/unittest/test_tir_transform_simplify.py
+++ b/tests/python/unittest/test_tir_transform_simplify.py
@@ -136,7 +136,24 @@ def test_complex_likely_elimination():
     assert "if" not in str(stmt)
 
 
-def test_load_store_noop():
+class BaseBeforeAfter:
+    def test_simplify(self):
+        before = self.before
+        before_mod = tvm.IRModule.from_expr(before)
+        after_mod = tvm.tir.transform.Simplify()(before_mod)
+        after = after_mod["main"]
+        expected = self.expected
+
+        try:
+            tvm.ir.assert_structural_equal(after, expected)
+        except ValueError as err:
+            script = tvm.IRModule({"expected": expected, "after": after, "before": before}).script()
+            raise ValueError(
+                f"Function after simplification did not match expected:\n{script}"
+            ) from err
+
+
+class TestLoadStoreNoop(BaseBeforeAfter):
     """Store of a value that was just read from the same location is a no-op."""
 
     @T.prim_func
@@ -147,11 +164,8 @@ def test_load_store_noop():
     def expected(A: T.Buffer[(1,), "float32"]):
         T.evaluate(0)
 
-    after = tvm.tir.transform.Simplify()(tvm.IRModule.from_expr(before))["main"]
-    tvm.ir.assert_structural_equal(after, expected)
 
-
-def test_load_store_noop_after_simplify():
+class TestLoadStoreNoopAfterSimplify(BaseBeforeAfter):
     """As test_load_store_noop, but requiring simplification to identify.
 
     Previously, a bug caused the self-assignment of a buffer to
@@ -168,8 +182,213 @@ def test_load_store_noop_after_simplify():
     def expected(A: T.Buffer[(1,), "float32"]):
         T.evaluate(0)
 
-    after = tvm.tir.transform.Simplify()(tvm.IRModule.from_expr(before))["main"]
-    tvm.ir.assert_structural_equal(after, expected)
+
+class TestNestedCondition(BaseBeforeAfter):
+    """Nested IfThenElse with the same condition can be simplified.
+
+    Requires const_int_bound to narrow scope of i within the
+    conditional, or for rewrite_simplify to recognize the literal
+    constraint.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16,), "float32"]):
+        for i in T.serial(16):
+            if i == 5:
+                if i == 5:
+                    A[i] = 0.0
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16,), "float32"]):
+        for i in T.serial(16):
+            if i == 5:
+                A[i] = 0.0
+
+
+class TestNestedProvableCondition(BaseBeforeAfter):
+    """Simplify inner conditional using constraint from outer.
+
+    Requires const_int_bound to narrow scope of i within the
+    conditional.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16,), "float32"]):
+        for i in T.serial(16):
+            if i == 5:
+                if i < 7:
+                    A[i] = 0.0
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16,), "float32"]):
+        for i in T.serial(16):
+            if i == 5:
+                A[i] = 0.0
+
+
+class TestNestedVarCondition(BaseBeforeAfter):
+    """Simplify inner conditional using constraint from outer.
+
+    Requires for rewrite_simplify to recognize the repeated
+    constraint.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16,), "float32"], n: T.int32):
+        for i in T.serial(16):
+            if i == n:
+                if i == n:
+                    A[i] = 0.0
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16,), "float32"], n: T.int32):
+        for i in T.serial(16):
+            if i == n:
+                A[i] = 0.0
+
+
+class TestAlteredBufferContents(BaseBeforeAfter):
+    """No simplification of data-dependent conditionals.
+
+    A literal constraint must not be propagated if the values
+    referenced may change.  TIR requires single assignment of
+    variables, so Var objects may be assumed constant, but BufferLoad
+    may not.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(1,), "int32"], n: T.int32):
+        if A[0] == n:
+            A[0] = A[0] + 1
+            if A[0] == n:
+                A[0] = 0
+
+    expected = before
+
+
+class TestNegationOfCondition(BaseBeforeAfter):
+    """Use negation of outer condition to simplify innner.
+
+    Within the body of an if statement, the negation of the
+    condition is known to be false.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16,), "int32"]):
+        for i in T.serial(16):
+            if i == 5:
+                if i != 5:
+                    A[i] = 0
+                else:
+                    A[i] = 1
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16,), "int32"]):
+        for i in T.serial(16):
+            if i == 5:
+                A[i] = 1
+
+
+class TestNegationOfNotEqual(BaseBeforeAfter):
+    """As TestNegationOfVarCondition, but with a != outer condition.
+
+    Because ConstIntBoundAnalyzer only tracks the min and max allowed
+    values, the outer i!=5 condition does provide a constraint on the
+    bounds.  This test relies on RewriteSimplifier to recognize
+    ``i==5`` as the negation of a literal constraint.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16,), "int32"]):
+        for i in T.serial(16):
+            if i != 5:
+                if i == 5:
+                    A[i] = 0
+                else:
+                    A[i] = 1
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16,), "int32"]):
+        for i in T.serial(16):
+            if i != 5:
+                A[i] = 1
+
+
+class TestNegationOfVarCondition(BaseBeforeAfter):
+    """As TestNegationOfVarCondition, but with a dynamic condition.
+
+    This simplification cannot be done with ConstIntBoundAnalyzer, and
+    must rely on RewriteSimplifier recognizing the repeated literal.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16,), "int32"], n: T.int32):
+        for i in T.serial(16):
+            if i == n:
+                if i != n:
+                    A[i] = 0
+                else:
+                    A[i] = 1
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16,), "int32"], n: T.int32):
+        for i in T.serial(16):
+            if i == n:
+                A[i] = 1
+
+
+class TestLiteralConstraintSplitBooleanAnd(BaseBeforeAfter):
+    """Split a boolean AND into independent constraints
+
+    A single if condition may impose multiple literal constraints.
+    Each constraint that is ANDed together to form the condition
+    should be treated as an independent constraint.  The use of n in
+    the condition is to ensure we exercise RewriteSimplifier.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16, 16), "int32"], n: T.int32):
+        for i, j in T.grid(16, 16):
+            if i == n and j == n:
+                if i == n:
+                    A[i, j] = 0
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16, 16), "int32"], n: T.int32):
+        for i, j in T.grid(16, 16):
+            if i == n and j == n:
+                A[i, j] = 0
+
+
+class TestLiteralConstraintSplitBooleanOr(BaseBeforeAfter):
+    """Split a boolean OR into independent constraints
+
+    Similar to TestLiteralConstraintSplitBooleanAnd, but splitting a
+    boolean OR into independent conditions.  This uses the
+    simplification that ``!(x || y) == !x && !y``.
+
+    The use of ``n`` in the condition is to ensure we exercise
+    RewriteSimplifier.
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer[(16, 16), "int32"], n: T.int32):
+        for i, j in T.grid(16, 16):
+            if i == n or j == n:
+                A[i, j] = 0
+            else:
+                if i == n:
+                    A[i, j] = 1
+                else:
+                    A[i, j] = 2
+
+    @T.prim_func
+    def expected(A: T.Buffer[(16, 16), "int32"], n: T.int32):
+        for i, j in T.grid(16, 16):
+            if i == n or j == n:
+                A[i, j] = 0
+            else:
+                A[i, j] = 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds additional simplifications to `RewriteSimplifier` while inside a conditional statement.  These are simplifications that are expected to be necessary for simplifying conditionals for padding buffer transforms.  The main additions are below:

* Use of `RewriteSimplifier::literal_constraints_` for simplifications of boolean expressions.  Previously, this was only used for simplifications inside a `tir.likely` annotation.
* Use of `RewriteSimplifier::literal_constraints_` to identify known false constraints.  This allows a constraint of `i!=n` to simplify `i==n` to false.
* Use of `EqNode` constraints in `ConstIntBoundAnalyzer`.  Previously, inequalities were used as comparisons.  With this change an `i==5` constraint be used to reduce the bounds of `i` to `[5,5]`.