### PR TITLE
[ci] Upload docs with folder structure to S3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-05-31T16:54:56.997402
+// Generated at 2022-06-01T16:34:53.941462
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -2875,7 +2875,10 @@ stage('Test') {
             label: 'Upload artifacts to S3',
           )
 
-          archiveArtifacts(artifacts: 'docs.tgz', fingerprint: true)
+          sh(
+            script: "aws s3 cp --no-progress _docs s3://${s3_prefix}/docs --recursive",
+            label: 'Upload docs to S3',
+          )
         }
       }
     }

--- a/jenkins/Test.groovy.j2
+++ b/jenkins/Test.groovy.j2
@@ -266,7 +266,10 @@ stage('Test') {
             )
           }
           {{ m.upload_artifacts(tag='docs', filenames=["docs.tgz"]) }}
-          archiveArtifacts(artifacts: 'docs.tgz', fingerprint: true)
+          sh(
+            script: "aws s3 cp --no-progress _docs s3://${s3_prefix}/docs --recursive",
+            label: 'Upload docs to S3',
+          )
         }
       }
     }


### PR DESCRIPTION
Keeping the files as-is lets us serve them from S3 + CloudFront e.g. https://d3f1x5ne0bf47p.cloudfront.net/tvm/PR-11528/2/docs/index.html. The tar is still around to provide an easy way to get the whole site for users / later CI jobs.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @Mousius @areusch