### PR TITLE
[PROFILER] Fix percent compute bound calculation

### DIFF
--- a/python/tvm/utils/roofline.py
+++ b/python/tvm/utils/roofline.py
@@ -392,7 +392,7 @@ def roofline_from_existing(
             compute_bound = arith_inten > ridge_point
             call["Bound"] = "compute" if compute_bound else "memory"
             per_mem_bound = (loaded_bytes / runtime) / peak_bandwidth * 100
-            per_compute_bound = flops / peak_flops * 100.0
+            per_compute_bound = (flops / runtime) / peak_flops * 100.0
             # We use ratio here because the percentages should be averaged instead of summed.
             call["Percent of Theoretical Optimal"] = profiling.Ratio(
                 per_compute_bound if compute_bound else per_mem_bound

--- a/tests/python/unittest/test_runtime_profiling.py
+++ b/tests/python/unittest/test_runtime_profiling.py
@@ -325,10 +325,11 @@ def test_roofline_analysis(target, dev):
     assert "Percent of Theoretical Optimal" in report.table()
     for call in report.calls:
         if "Percent of Theoretical Optimal" in call:
+            print(call["Percent of Theoretical Optimal"].ratio)
             # Ideally we'd like a little tighter bound here, but it is hard to
             # know how well this dense will perform without tuning. And we
             # don't have an operator that uses a specific number of flops.
-            assert call["Percent of Theoretical Optimal"].ratio >= 0
+            assert call["Percent of Theoretical Optimal"].ratio >= 5.0
 
 
 @tvm.testing.skip_if_32bit(reason="Cannot allocate enough memory on i386")
@@ -354,7 +355,7 @@ def test_roofline_analysis_rpc():
             # Ideally we'd like a little tighter bound here, but it is hard to
             # know how well this dense will perform without tuning. And we
             # don't have an operator that uses a specific number of flops.
-            assert call["Percent of Theoretical Optimal"].ratio >= 0
+            assert call["Percent of Theoretical Optimal"].ratio >= 5.0
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_runtime_profiling.py
+++ b/tests/python/unittest/test_runtime_profiling.py
@@ -325,7 +325,6 @@ def test_roofline_analysis(target, dev):
     assert "Percent of Theoretical Optimal" in report.table()
     for call in report.calls:
         if "Percent of Theoretical Optimal" in call:
-            print(call["Percent of Theoretical Optimal"].ratio)
             # Ideally we'd like a little tighter bound here, but it is hard to
             # know how well this dense will perform without tuning. And we
             # don't have an operator that uses a specific number of flops.


### PR DESCRIPTION
Somehow the runtime was dropped from the percent compute bound calculation. Tolerances on the test we bumped a little bit higher to try and catch mistakes like this in the future.

@AndrewZhaoLuo 