### PR TITLE
Unbreak CI image build (tensorflow 2.6.5, ci_gpu bugfix)

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -24,7 +24,7 @@ FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
 # Base scripts
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list && apt-get clean
+RUN rm -f /etc/apt/sources.list.d/nvidia-ml.list && apt-get clean
 RUN apt-get update --fix-missing
 
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh

--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -20,7 +20,9 @@ set -e
 set -u
 set -o pipefail
 
+# NOTE: protobuf is pinned to an older version due to https://github.com/apache/tvm/issues/11545.
 pip3 install \
     "h5py==3.1.0" \
     keras==2.6 \
-    tensorflow==2.6.2
+    tensorflow==2.6.2 \
+    protobuf==3.20.1

--- a/docker/install/ubuntu_install_tensorflow.sh
+++ b/docker/install/ubuntu_install_tensorflow.sh
@@ -20,9 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-# NOTE: protobuf is pinned to an older version due to https://github.com/apache/tvm/issues/11545.
 pip3 install \
     "h5py==3.1.0" \
     keras==2.6 \
-    tensorflow==2.6.2 \
-    protobuf==3.20.1
+    tensorflow==2.6.5

--- a/docker/install/ubuntu_install_tensorflow_aarch64.sh
+++ b/docker/install/ubuntu_install_tensorflow_aarch64.sh
@@ -23,8 +23,10 @@ apt-get install -y --no-install-recommends libhdf5-dev
 
 # We're only using the TensorFlow wheel snapshot here as the
 # h5py wheel tries to use the wrong .so file
+# NOTE: protobuf is pinned to an older version due to https://github.com/apache/tvm/issues/11545.
 pip3 install \
     "h5py==3.1.0" \
     keras==2.6 \
     tensorflow-aarch64==2.6.2 \
+    protobuf==3.20.1 \
     -f https://snapshots.linaro.org/ldcg/python-cache/tensorflow-aarch64/

--- a/docker/install/ubuntu_install_tensorflow_aarch64.sh
+++ b/docker/install/ubuntu_install_tensorflow_aarch64.sh
@@ -27,5 +27,5 @@ pip3 install \
     "h5py==3.1.0" \
     keras==2.6 \
     tensorflow-aarch64==2.6.3 \
-    protobuf<4 \
+    "protobuf<4" \
     -f https://snapshots.linaro.org/ldcg/python-cache/tensorflow-aarch64/

--- a/docker/install/ubuntu_install_tensorflow_aarch64.sh
+++ b/docker/install/ubuntu_install_tensorflow_aarch64.sh
@@ -23,10 +23,8 @@ apt-get install -y --no-install-recommends libhdf5-dev
 
 # We're only using the TensorFlow wheel snapshot here as the
 # h5py wheel tries to use the wrong .so file
-# NOTE: protobuf is pinned to an older version due to https://github.com/apache/tvm/issues/11545.
 pip3 install \
     "h5py==3.1.0" \
     keras==2.6 \
-    tensorflow-aarch64==2.6.2 \
-    protobuf==3.20.1 \
+    tensorflow-aarch64==2.6.5 \
     -f https://snapshots.linaro.org/ldcg/python-cache/tensorflow-aarch64/

--- a/docker/install/ubuntu_install_tensorflow_aarch64.sh
+++ b/docker/install/ubuntu_install_tensorflow_aarch64.sh
@@ -26,5 +26,6 @@ apt-get install -y --no-install-recommends libhdf5-dev
 pip3 install \
     "h5py==3.1.0" \
     keras==2.6 \
-    tensorflow-aarch64==2.6.5 \
+    tensorflow-aarch64==2.6.3 \
+    protobuf<4 \
     -f https://snapshots.linaro.org/ldcg/python-cache/tensorflow-aarch64/


### PR DESCRIPTION
Context is in the attached bug.

cc @driazati @tqchen @jwfromm 