### PR TITLE
[ci] Fix action expressions for tvm-bot workflow

### DIFF
--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -13,9 +13,8 @@ concurrency:
 
 jobs:
   run-tvm-bot:
-    if: github.repository == 'apache/tvm'
+    if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
     runs-on: ubuntu-20.04
-    if: ${{ github.event.issue.pull_request }}
     steps:
       - uses: actions/checkout@v2
       - name: Run tvm-bot

--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -33,15 +33,15 @@ def compress_query(query: str) -> str:
 def post(url: str, body: Optional[Any] = None, auth: Optional[Tuple[str, str]] = None):
     print(f"Requesting POST to", url, "with", body)
     headers = {}
+    req = request.Request(url, headers=headers, method="POST")
     if auth is not None:
-        auth_str = base64.b64encode(f"{auth[0]}:{auth[1]}")
-        request.add_header("Authorization", f"Basic {auth_str}")
+        auth_str = base64.b64encode(f"{auth[0]}:{auth[1]}".encode())
+        req.add_header("Authorization", f"Basic {auth_str}")
 
     if body is None:
         body = ""
 
     req.add_header("Content-Type", "application/json; charset=utf-8")
-    req = request.Request(url, headers=headers, method="POST")
     data = json.dumps(body)
     data = data.encode("utf-8")
     req.add_header("Content-Length", len(data))


### PR DESCRIPTION
These weren't caught by `actionlint` for some reason but GitHub doesn't merge multiple `if`s, so this combines them into one. This also has some small code fixes to get the rerun requests sent.

cc @Mousius @areusch