### PR TITLE
[testing] Remove wrapper from @slow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-08-10T09:54:08.733518
+// Generated at 2022-08-10T11:53:48.439484
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -91,7 +91,7 @@ properties([
 upstream_revision = null
 
 // command to start a docker container
-docker_run = 'docker/bash.sh --env CI --env TVM_SHARD_INDEX --env TVM_NUM_SHARDS --env RUN_DISPLAY_URL --env PLATFORM'
+docker_run = 'docker/bash.sh --env CI --env TVM_SHARD_INDEX --env TVM_NUM_SHARDS --env RUN_DISPLAY_URL --env PLATFORM --env SKIP_SLOW_TESTS'
 docker_build = 'docker/build.sh'
 // timeout in minutes
 max_time = 180
@@ -568,7 +568,8 @@ def lint() {
         timeout(time: max_time, unit: 'MINUTES') {
           withEnv([
             'TVM_NUM_SHARDS=2',
-            'TVM_SHARD_INDEX=0'], {
+            'TVM_SHARD_INDEX=0',
+            "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
             sh (
                 script: "${docker_run} ${ci_lint} ./tests/scripts/task_lint.sh",
                 label: 'Run lint',
@@ -586,7 +587,8 @@ def lint() {
         timeout(time: max_time, unit: 'MINUTES') {
           withEnv([
             'TVM_NUM_SHARDS=2',
-            'TVM_SHARD_INDEX=1'], {
+            'TVM_SHARD_INDEX=1',
+            "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
             sh (
                 script: "${docker_run} ${ci_lint} ./tests/scripts/task_lint.sh",
                 label: 'Run lint',
@@ -1082,7 +1084,8 @@ def shard_run_unittest_GPU_1_of_3() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=3',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1196,7 +1199,8 @@ def shard_run_unittest_GPU_2_of_3() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=3',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1276,7 +1280,8 @@ def shard_run_unittest_GPU_3_of_3() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=3',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1353,7 +1358,8 @@ def shard_run_integration_CPU_1_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1427,7 +1433,8 @@ def shard_run_integration_CPU_2_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1501,7 +1508,8 @@ def shard_run_integration_CPU_3_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1575,7 +1583,8 @@ def shard_run_integration_CPU_4_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1649,7 +1658,8 @@ def shard_run_integration_CPU_5_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=4'], {
+              'TVM_SHARD_INDEX=4',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1723,7 +1733,8 @@ def shard_run_integration_CPU_6_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=5'], {
+              'TVM_SHARD_INDEX=5',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1797,7 +1808,8 @@ def shard_run_integration_CPU_7_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=6'], {
+              'TVM_SHARD_INDEX=6',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1871,7 +1883,8 @@ def shard_run_integration_CPU_8_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=7'], {
+              'TVM_SHARD_INDEX=7',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -1945,7 +1958,8 @@ def shard_run_integration_CPU_9_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=8'], {
+              'TVM_SHARD_INDEX=8',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2019,7 +2033,8 @@ def shard_run_integration_CPU_10_of_10() {
             withEnv([
               'PLATFORM=cpu',
               'TVM_NUM_SHARDS=10',
-              'TVM_SHARD_INDEX=9'], {
+              'TVM_SHARD_INDEX=9',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2094,7 +2109,8 @@ def shard_run_python_i386_1_of_5() {
             withEnv([
               'PLATFORM=i386',
               'TVM_NUM_SHARDS=5',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2168,7 +2184,8 @@ def shard_run_python_i386_2_of_5() {
             withEnv([
               'PLATFORM=i386',
               'TVM_NUM_SHARDS=5',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2242,7 +2259,8 @@ def shard_run_python_i386_3_of_5() {
             withEnv([
               'PLATFORM=i386',
               'TVM_NUM_SHARDS=5',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2315,7 +2333,8 @@ def shard_run_python_i386_4_of_5() {
             withEnv([
               'PLATFORM=i386',
               'TVM_NUM_SHARDS=5',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2388,7 +2407,8 @@ def shard_run_python_i386_5_of_5() {
             withEnv([
               'PLATFORM=i386',
               'TVM_NUM_SHARDS=5',
-              'TVM_SHARD_INDEX=4'], {
+              'TVM_SHARD_INDEX=4',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2462,7 +2482,8 @@ def shard_run_test_Hexagon_1_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2535,7 +2556,8 @@ def shard_run_test_Hexagon_2_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2607,7 +2629,8 @@ def shard_run_test_Hexagon_3_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2679,7 +2702,8 @@ def shard_run_test_Hexagon_4_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2751,7 +2775,8 @@ def shard_run_test_Hexagon_5_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=4'], {
+              'TVM_SHARD_INDEX=4',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2823,7 +2848,8 @@ def shard_run_test_Hexagon_6_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=5'], {
+              'TVM_SHARD_INDEX=5',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2895,7 +2921,8 @@ def shard_run_test_Hexagon_7_of_7() {
             withEnv([
               'PLATFORM=hexagon',
               'TVM_NUM_SHARDS=7',
-              'TVM_SHARD_INDEX=6'], {
+              'TVM_SHARD_INDEX=6',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -2968,7 +2995,8 @@ def shard_run_integration_aarch64_1_of_4() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3041,7 +3069,8 @@ def shard_run_integration_aarch64_2_of_4() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3114,7 +3143,8 @@ def shard_run_integration_aarch64_3_of_4() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3187,7 +3217,8 @@ def shard_run_integration_aarch64_4_of_4() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3261,7 +3292,8 @@ def shard_run_topi_GPU_1_of_4() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3333,7 +3365,8 @@ def shard_run_topi_GPU_2_of_4() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3405,7 +3438,8 @@ def shard_run_topi_GPU_3_of_4() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3477,7 +3511,8 @@ def shard_run_topi_GPU_4_of_4() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=4',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3550,7 +3585,8 @@ def shard_run_frontend_GPU_1_of_6() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=6',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3622,7 +3658,8 @@ def shard_run_frontend_GPU_2_of_6() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=6',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3694,7 +3731,8 @@ def shard_run_frontend_GPU_3_of_6() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=6',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3766,7 +3804,8 @@ def shard_run_frontend_GPU_4_of_6() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=6',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3838,7 +3877,8 @@ def shard_run_frontend_GPU_5_of_6() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=6',
-              'TVM_SHARD_INDEX=4'], {
+              'TVM_SHARD_INDEX=4',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3910,7 +3950,8 @@ def shard_run_frontend_GPU_6_of_6() {
             withEnv([
               'PLATFORM=gpu',
               'TVM_NUM_SHARDS=6',
-              'TVM_SHARD_INDEX=5'], {
+              'TVM_SHARD_INDEX=5',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -3983,7 +4024,8 @@ def shard_run_topi_aarch64_1_of_2() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=2',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4060,7 +4102,8 @@ def shard_run_topi_aarch64_2_of_2() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=2',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4137,7 +4180,8 @@ def shard_run_frontend_aarch64_1_of_2() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=2',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4209,7 +4253,8 @@ def shard_run_frontend_aarch64_2_of_2() {
             withEnv([
               'PLATFORM=arm',
               'TVM_NUM_SHARDS=2',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4282,7 +4327,8 @@ def shard_run_test_Cortex_M_1_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=0'], {
+              'TVM_SHARD_INDEX=0',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4359,7 +4405,8 @@ def shard_run_test_Cortex_M_2_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=1'], {
+              'TVM_SHARD_INDEX=1',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4431,7 +4478,8 @@ def shard_run_test_Cortex_M_3_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=2'], {
+              'TVM_SHARD_INDEX=2',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4503,7 +4551,8 @@ def shard_run_test_Cortex_M_4_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=3'], {
+              'TVM_SHARD_INDEX=3',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4575,7 +4624,8 @@ def shard_run_test_Cortex_M_5_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=4'], {
+              'TVM_SHARD_INDEX=4',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4647,7 +4697,8 @@ def shard_run_test_Cortex_M_6_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=5'], {
+              'TVM_SHARD_INDEX=5',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4719,7 +4770,8 @@ def shard_run_test_Cortex_M_7_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=6'], {
+              'TVM_SHARD_INDEX=6',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -4791,7 +4843,8 @@ def shard_run_test_Cortex_M_8_of_8() {
             withEnv([
               'PLATFORM=cortexm',
               'TVM_NUM_SHARDS=8',
-              'TVM_SHARD_INDEX=7'], {
+              'TVM_SHARD_INDEX=7',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               sh(
                         script: """
                           set -eux
@@ -5021,7 +5074,8 @@ stage('Test') {
             try {
               docker_init(ci_cpu)
               init_git()
-              withEnv(['PLATFORM=cpu'], {
+              withEnv(['PLATFORM=cpu',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
                 sh(
                         script: """
                           set -eux
@@ -5094,7 +5148,8 @@ stage('Test') {
             try {
               docker_init(ci_cpu)
               init_git()
-              withEnv(['PLATFORM=cpu'], {
+              withEnv(['PLATFORM=cpu',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
                 sh(
                         script: """
                           set -eux

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -83,7 +83,7 @@ properties([
 upstream_revision = null
 
 // command to start a docker container
-docker_run = 'docker/bash.sh --env CI --env TVM_SHARD_INDEX --env TVM_NUM_SHARDS --env RUN_DISPLAY_URL --env PLATFORM'
+docker_run = 'docker/bash.sh --env CI --env TVM_SHARD_INDEX --env TVM_NUM_SHARDS --env RUN_DISPLAY_URL --env PLATFORM --env SKIP_SLOW_TESTS'
 docker_build = 'docker/build.sh'
 // timeout in minutes
 max_time = 180

--- a/ci/jenkins/macros.j2
+++ b/ci/jenkins/macros.j2
@@ -45,7 +45,8 @@ def {{ method_name }}() {
             withEnv([
               'PLATFORM={{ platform }}',
               'TVM_NUM_SHARDS={{ num_shards }}',
-              'TVM_SHARD_INDEX={{ shard_index - 1 }}'], {
+              'TVM_SHARD_INDEX={{ shard_index - 1 }}',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
               {{ caller(shard_index, num_shards) | trim | indent(width=12) }}
             })
           }
@@ -74,7 +75,8 @@ def {{ method_name }}() {
         timeout(time: max_time, unit: 'MINUTES') {
           withEnv([
             'TVM_NUM_SHARDS={{ num_shards }}',
-            'TVM_SHARD_INDEX={{ shard_index - 1 }}'], {
+            'TVM_SHARD_INDEX={{ shard_index - 1 }}',
+            "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
             {{ caller() | trim | indent(width=6) }}
           })
         }
@@ -95,7 +97,8 @@ def {{ method_name }}() {
             try {
               docker_init({{ docker_image }})
               init_git()
-              withEnv(['PLATFORM={{ platform }}'], {
+              withEnv(['PLATFORM={{ platform }}',
+              "SKIP_SLOW_TESTS=${skip_slow_tests}"], {
                 {{ caller() | indent(width=12) | trim }}
               })
             } finally {

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1006,15 +1006,10 @@ def _compose(args, decs):
     return decs
 
 
-def slow(fn):
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        if SKIP_SLOW_TESTS:
-            pytest.skip("Skipping slow test since RUN_SLOW_TESTS environment variables is 'true'")
-        else:
-            fn(*args, **kwargs)
-
-    return wrapper
+slow = pytest.mark.skipif(
+    SKIP_SLOW_TESTS,
+    reason="Skipping slow test since the SKIP_SLOW_TESTS environment variable is 'true'",
+)
 
 
 def requires_nvcc_version(major_version, minor_version=0, release_version=0):

--- a/tests/scripts/should_run_slow_tests.py
+++ b/tests/scripts/should_run_slow_tests.py
@@ -30,12 +30,12 @@ from git_utils import GitHubRepo, parse_remote, git
 
 
 SLOW_TEST_TRIGGERS = [
-    "@ci run slow tests",
-    "@ci run slow test",
-    "@ci run slow",
-    "@ci slow tests",
-    "@ci slow test",
-    "@ci slow",
+    "@tvm-bot run slow tests",
+    "@tvm-bot run slow test",
+    "@tvm-bot run slow",
+    "@tvm-bot slow tests",
+    "@tvm-bot slow test",
+    "@tvm-bot slow",
 ]
 
 
@@ -69,18 +69,6 @@ if __name__ == "__main__":
         print(f"Branch {branch} is in {skip_branches}, running slow tests")
         exit(1)
     print(f"Branch {branch} is not in {skip_branches}, checking last commit...")
-
-    log = git(["log", "--format=%B", "-1"])
-
-    # Check if anything in the last commit's body message matches
-    log_match, reason = check_match(log, SLOW_TEST_TRIGGERS)
-    if log_match:
-        print(f"Matched {reason} in commit message:\n{display(log)}, running slow tests")
-        exit(1)
-
-    print(
-        f"Last commit:\n{display(log)}\ndid not have any of {SLOW_TEST_TRIGGERS}, checking PR body..."
-    )
 
     if args.pr_body:
         body = args.pr_body


### PR DESCRIPTION
This makes it a normal pytest decorator so it doesn't incur test set up / tear down. This also makes the PR body the source of truth for skipping slow tests or not since it can be confusing sourcing it both from the PR and commit message.