### PR TITLE
[ci][mergebot] De-duplicate GitHub Actions tests

### DIFF
--- a/tests/python/ci/sample_prs/pr10786-badci.json
+++ b/tests/python/ci/sample_prs/pr10786-badci.json
@@ -44,6 +44,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -57,6 +58,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -70,6 +72,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -83,6 +86,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr10786-badci.json
+++ b/tests/python/ci/sample_prs/pr10786-badci.json
@@ -53,6 +53,20 @@
                     }
                   },
                   "status": "COMPLETED",
+                  "conclusion": "NEUTRAL",
+                  "url": "https://github.com/apache/tvm/runs/5694945392"
+                },
+                {
+                  "name": "MacOS",
+                  "completedAt": "2022-05-29T00:52:07Z",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
                   "conclusion": "SUCCESS",
                   "url": "https://github.com/apache/tvm/runs/5694945392"
                 },
@@ -95,7 +109,7 @@
                     }
                   },
                   "status": "COMPLETED",
-                  "conclusion": "SUCCESS",
+                  "conclusion": "FAILED",
                   "url": "https://github.com/apache/tvm/runs/5694945524"
                 },
                 {

--- a/tests/python/ci/sample_prs/pr10786-changes-requested.json
+++ b/tests/python/ci/sample_prs/pr10786-changes-requested.json
@@ -44,6 +44,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -57,6 +58,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -70,6 +72,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -83,6 +86,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr10786-co-authors.json
+++ b/tests/python/ci/sample_prs/pr10786-co-authors.json
@@ -44,6 +44,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -57,6 +58,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -70,6 +72,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -83,6 +86,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr10786-merges.json
+++ b/tests/python/ci/sample_prs/pr10786-merges.json
@@ -44,6 +44,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -57,6 +58,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -70,6 +72,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -83,6 +86,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr10786-missing-job.json
+++ b/tests/python/ci/sample_prs/pr10786-missing-job.json
@@ -44,6 +44,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -57,6 +58,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -70,6 +72,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -83,6 +86,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr10786-oldreview.json
+++ b/tests/python/ci/sample_prs/pr10786-oldreview.json
@@ -44,6 +44,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -57,6 +58,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -70,6 +72,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -83,6 +86,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr11267-no-review.json
+++ b/tests/python/ci/sample_prs/pr11267-no-review.json
@@ -59,6 +59,7 @@
               "nodes": [
                 {
                   "name": "MacOS",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -72,6 +73,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -85,6 +87,7 @@
                 },
                 {
                   "name": "cc-reviewers",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -98,6 +101,7 @@
                 },
                 {
                   "name": "tag-teams",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {
@@ -111,6 +115,7 @@
                 },
                 {
                   "name": "Windows",
+                  "completedAt": "2022-05-28T00:52:07Z",
                   "checkSuite": {
                     "workflowRun": {
                       "workflow": {

--- a/tests/python/ci/sample_prs/pr11455-duplicate-jobs.json
+++ b/tests/python/ci/sample_prs/pr11455-duplicate-jobs.json
@@ -1,0 +1,294 @@
+{
+  "title": "[ci] Add filter to teams",
+  "body": "This improves the parsing to avoid issues like in #11454\r\n\r\ncc @Mousius @areusch",
+  "state": "OPEN",
+  "author": {
+    "login": "abc"
+  },
+  "comments": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "authorAssociation": "CONTRIBUTOR",
+        "author": {
+          "login": "Lunderberg"
+        },
+        "id": "IC_kwDOBDeBdM5Dy9eD",
+        "updatedAt": "2022-05-25T15:22:18Z",
+        "body": "Ooh, nice.  So that was triggered by the empty square brackets in the PR title?"
+      },
+      {
+        "authorAssociation": "COLLABORATOR",
+        "author": {
+          "login": "driazati"
+        },
+        "id": "IC_kwDOBDeBdM5Dy--Y",
+        "updatedAt": "2022-05-25T15:27:45Z",
+        "body": "> Ooh, nice. So that was triggered by the empty square brackets in the PR title?\r\n\r\nright, that plus some bad parsing logic of the source teams issue (more details [in the logs](https://github.com/apache/tvm/runs/6594725752?check_suite_focus=true#step:3:429)), I'd like to clean it up a bit but I don't have permissions to edit other people's comments out"
+      },
+      {
+        "authorAssociation": "COLLABORATOR",
+        "author": {
+          "login": "driazati"
+        },
+        "id": "IC_kwDOBDeBdM5EMVgS",
+        "updatedAt": "2022-06-01T20:08:36Z",
+        "body": "@tvm-bot merge"
+      },
+      {
+        "authorAssociation": "NONE",
+        "author": {
+          "login": "github-actions"
+        },
+        "id": "IC_kwDOBDeBdM5EMVkn",
+        "updatedAt": "2022-06-01T20:08:55Z",
+        "body": "Cannot merge, these CI jobs are not successful on 8b000d0a4c9789f42ed4e8f3fc797e7bd76452ce:\n * [PR / cc-reviewers (`CANCELLED`)](https://github.com/apache/tvm/runs/6692618718)\n * [Teams / tag-teams (`CANCELLED`)](https://github.com/apache/tvm/runs/6692618705)"
+      }
+    ]
+  },
+  "authorCommits": {
+    "nodes": [
+      {
+        "commit": {
+          "authors": {
+            "nodes": [
+              {
+                "name": "driazati",
+                "email": "driazati@users.noreply.github.com"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "commits": {
+    "nodes": [
+      {
+        "commit": {
+          "oid": "8b000d0a4c9789f42ed4e8f3fc797e7bd76452ce",
+          "statusCheckRollup": {
+            "contexts": {
+              "pageInfo": {
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-06-01T15:32:23Z",
+                  "conclusion": "CANCELLED",
+                  "url": "https://github.com/apache/tvm/runs/6692618718"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-06-01T15:32:21Z",
+                  "conclusion": "CANCELLED",
+                  "url": "https://github.com/apache/tvm/runs/6692618705"
+                },
+                {
+                  "name": "MacOS",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-28T00:52:07Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633016151"
+                },
+                {
+                  "name": "maybe-merge",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Merge"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-06-01T20:08:01Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6697027810"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-27T23:21:28Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633016519"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-27T23:22:11Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633020322"
+                },
+                {
+                  "name": "cc-reviewers",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "PR"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-06-01T15:34:03Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6692623314"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-27T23:21:23Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633016525"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-27T23:22:25Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633020321"
+                },
+                {
+                  "name": "tag-teams",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "Teams"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-06-01T15:33:09Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6692621919"
+                },
+                {
+                  "name": "Windows",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-28T00:48:58Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633016091"
+                },
+                {
+                  "name": "Android",
+                  "checkSuite": {
+                    "workflowRun": {
+                      "workflow": {
+                        "name": "CI"
+                      }
+                    }
+                  },
+                  "status": "COMPLETED",
+                  "completedAt": "2022-05-28T00:31:19Z",
+                  "conclusion": "SUCCESS",
+                  "url": "https://github.com/apache/tvm/runs/6633016015"
+                },
+                {
+                  "state": "SUCCESS",
+                  "context": "tvm-ci/pr-head",
+                  "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-11455/4/display/redirect"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "reviewDecision": "APPROVED",
+  "reviews": {
+    "pageInfo": {
+      "hasPreviousPage": false
+    },
+    "nodes": [
+      {
+        "body": "",
+        "updatedAt": "2022-05-25T15:23:30Z",
+        "url": "https://github.com/apache/tvm/pull/11455#pullrequestreview-985024880",
+        "id": "PRR_kwDOBDeBdM46tklw",
+        "authorCanPushToRepository": true,
+        "commit": {
+          "oid": "1b9747f58ebd170f4c2fc75c2f4cf3700d7cc131"
+        },
+        "author": {
+          "login": "Lunderberg"
+        },
+        "state": "COMMENTED"
+      },
+      {
+        "body": "",
+        "updatedAt": "2022-06-01T20:07:39Z",
+        "url": "https://github.com/apache/tvm/pull/11455#pullrequestreview-992618832",
+        "id": "PRR_kwDOBDeBdM47KilQ",
+        "authorCanPushToRepository": true,
+        "commit": {
+          "oid": "8b000d0a4c9789f42ed4e8f3fc797e7bd76452ce"
+        },
+        "author": {
+          "login": "areusch"
+        },
+        "state": "APPROVED"
+      }
+    ]
+  }
+}

--- a/tests/python/ci/sample_prs/pr11455-duplicate-jobs.json
+++ b/tests/python/ci/sample_prs/pr11455-duplicate-jobs.json
@@ -198,7 +198,7 @@
                   },
                   "status": "COMPLETED",
                   "completedAt": "2022-05-27T23:22:25Z",
-                  "conclusion": "SUCCESS",
+                  "conclusion": "FAILED",
                   "url": "https://github.com/apache/tvm/runs/6633020321"
                 },
                 {

--- a/tests/python/ci/test_mergebot.py
+++ b/tests/python/ci/test_mergebot.py
@@ -134,6 +134,14 @@ test_data = {
         "user": "abc",
         "detail": "Start a new CI job",
     },
+    "duplicate-jobs": {
+        "number": 11455,
+        "filename": "pr11455-duplicate-jobs.json",
+        "expected": "Dry run, would have merged",
+        "comment": "@tvm-bot merge",
+        "user": "abc",
+        "detail": "Check that only the most recent run of GitHub Actions jobs is used",
+    },
 }
 
 

--- a/tests/python/ci/test_mergebot.py
+++ b/tests/python/ci/test_mergebot.py
@@ -65,7 +65,10 @@ test_data = {
     "bad-ci": {
         "number": 10786,
         "filename": "pr10786-badci.json",
-        "expected": "Cannot merge, these CI jobs are not successful on",
+        "expected": "Cannot merge, these CI jobs are not successful on "
+        "6f04bcf57d07f915a98fd91178f04d9e92a09fcd:\n * [tvm-ci/pr-head "
+        "(`FAILED`)](https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect)\n"
+        " * [CI / Windows (`FAILED`)](https://github.com/apache/tvm/runs/5694945524)",
         "comment": "@tvm-bot merge",
         "user": "abc",
         "detail": "A PR which failed CI and cannot merge",

--- a/tests/scripts/github_tvmbot.py
+++ b/tests/scripts/github_tvmbot.py
@@ -435,7 +435,7 @@ class PR:
         return self.raw["author"]["login"]
 
     def find_failed_ci_jobs(self) -> List[CIJob]:
-        def is_important_job(job):
+        def does_job_run_tests(job):
             # Ignore GitHub workflows that operate on PRs but don't run tests
             if job["source"] != "github actions":
                 return True
@@ -444,7 +444,7 @@ class PR:
         return [
             job
             for job in self.ci_jobs()
-            if is_important_job(job) and job["status"] not in {"SUCCESS", "SUCCESSFUL", "SKIPPED"}
+            if does_job_run_tests(job) and job["status"] not in {"SUCCESS", "SUCCESSFUL", "SKIPPED"}
         ]
 
     def find_missing_expected_jobs(self) -> List[str]:


### PR DESCRIPTION
A lot of the GitHub Actions automation counts as a job on a PR (e.g. the
tag teams workflow) and they run multiple times. This would lead to
skipped/cancelled workflows showing up as errors when trying to merge,
which this PR fixes by only looking at the most recent run of each
action.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @Mousius @areusch