### PR TITLE
[TIR] CSE pass : Restrict the equivalence to be decided by a normal form - avoids comparison of terms

### DIFF
--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -472,7 +472,7 @@ TVM_DLL Pass LowerVtcmAlloc();
  * \param enable_cse_tir Whether common subexpression elimination is enabled.
  * \return The pass.
  */
-TVM_DLL Pass CommonSubexprElimTIR(bool enable_cse_tir = true);
+TVM_DLL Pass CommonSubexprElimTIR(bool enable_cse_tir = true, bool identify_equiv_terms = false);
 
 /*!
  * \brief Unify all the thread bindings for "blockIdx.x/y/z", "threadIdx.x/y/z", and

--- a/python/tvm/tir/transform/transform.py
+++ b/python/tvm/tir/transform/transform.py
@@ -323,8 +323,7 @@ def BF16TypeLowering():
     """
     return _ffi_api.BF16TypeLowering()  # type: ignore
 
-
-def CommonSubexprElimTIR(enable_cse_tir: bool = True):
+def CommonSubexprElimTIR(enable_cse_tir: bool = True, identify_equiv_terms: bool = False):
     """Replace redundant computations by new variables.
 
     Returns
@@ -332,7 +331,7 @@ def CommonSubexprElimTIR(enable_cse_tir: bool = True):
     fpass : tvm.transform.Pass
         The result pass
     """
-    return _ffi_api.CommonSubexprElimTIR(enable_cse_tir)  # type: ignore
+    return _ffi_api.CommonSubexprElimTIR(enable_cse_tir, identify_equiv_terms)  # type: ignore
 
 
 def RewriteUnsafeSelect():

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -45,6 +45,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION("tir.instrument_bound_checkers", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.disable_assert", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.disable_vectorize", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.disable_cse_tir", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tir.enable_equiv_terms_in_cse_tir", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.disable_storage_rewrite", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.is_entry_func", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.add_lower_pass", Array<Array<ObjectRef>>);
@@ -198,6 +199,8 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   bool instrument_bound_checkers =
       pass_ctx->GetConfig<Bool>("tir.instrument_bound_checkers", Bool(false)).value();
   bool disable_cse_tir = pass_ctx->GetConfig<Bool>("tir.disable_cse_tir", Bool(false)).value();
+  bool enable_equiv_terms_in_cse_tir = 
+      pass_ctx->GetConfig<Bool>("tir.enable_equiv_terms_in_cse_tir", Bool(false)).value();
 
   // Get any user-added passes
   Array<Array<ObjectRef>> add_lower_pass =
@@ -289,7 +292,7 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
     pass_list.push_back(tir::transform::InstrumentBoundCheckers());
   }
 
-  pass_list.push_back(tir::transform::CommonSubexprElimTIR(!disable_cse_tir));
+  pass_list.push_back(tir::transform::CommonSubexprElimTIR(!disable_cse_tir, enable_equiv_terms_in_cse_tir));
 
   return pass_list;
 }

--- a/src/tir/transforms/common_subexpr_elim.cc
+++ b/src/tir/transforms/common_subexpr_elim.cc
@@ -122,6 +122,42 @@ bool CommonSubexpressionEliminator::CanContainEligibleComputations(const PrimExp
 }
 
 /*!
+ * \brief Implements an order on pairs (expression,frequency). First attempts to compare them
+          using the size of the expression. If the is the same, decides something else still 
+          deterministic.
+ * \param a The first pair
+ * \param b The second pair
+ * \return A boolean telling if the first pair `a` comes before the second pair `b`
+ * \note We need this order to be deterministic in order to have a fully deterministic pass,
+ *       as we will deal with elements that are coming from a hashtable, but the order in which
+ *       they appeared in the hashtable was based on some runtime addresses, so it can potentially
+ *       change with every execution.
+ */
+bool CommonSubexpressionEliminator::OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a,
+                                                            std::pair<PrimExpr, size_t> b) {
+  size_t a_size = CalculateExprComplexity(a.first);
+  size_t b_size = CalculateExprComplexity(b.first);
+
+  // Criteria 1 - Size of the expression comes first
+  // `a` comes before `b` if the size of `a` is bigger
+  if (a_size > b_size)
+    return true;
+  // `a` does NOT come before `b` if the size of `b` is bigger
+  else if (b_size > a_size)
+    return false;
+
+  // Criteria 2 - If they had the same size, use the lexicographic order as a last resort
+  // as we need a deterministic order
+  else {
+    std::stringstream a_stream;
+    std::stringstream b_stream;
+    a_stream << a.first;
+    b_stream << b.first;
+    return (a_stream.str().compare(b_stream.str()) < 0);
+  }
+}
+
+/*!
  * \brief Generates a new fresh variable, whose name will be cse_var_i.
  * \param type_annotation The type of the new variable to generate
  * \return A new variable of type `type_annotation` called cse_var_i where i is the first available
@@ -206,9 +242,7 @@ PrimExpr CommonSubexpressionEliminator::VisitExpr(const PrimExpr& expr) {
 
   // Sort the vector of semantic entities by decreasing size
   std::sort(semantic_comp_done_by_expr.begin(), semantic_comp_done_by_expr.end(),
-            [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
-              return (CalculateExprComplexity(a.first) > CalculateExprComplexity(b.first));
-            });
+            OrderOnExprAndFrequency);
 
   // For each computation done (considering them from biggest to smallest)
   for (size_t i = 0; i < semantic_comp_done_by_expr.size(); i++) {
@@ -388,9 +422,7 @@ Stmt CommonSubexpressionEliminator::VisitStmt(const Stmt& stmt) {
 
   // Sort the vector of semantic entities by decreasing size
   std::sort(semantic_comp_done_by_stmt.begin(), semantic_comp_done_by_stmt.end(),
-            [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
-              return (CalculateExprComplexity(a.first) > CalculateExprComplexity(b.first));
-            });
+            OrderOnExprAndFrequency);
 
   // For each computation done (considering them from biggest to smallest)
   for (size_t i = 0; i < semantic_comp_done_by_stmt.size(); i++) {

--- a/src/tir/transforms/common_subexpr_elim.cc
+++ b/src/tir/transforms/common_subexpr_elim.cc
@@ -46,6 +46,7 @@
 #include <unordered_map>  // For the hashtable datatype
 #include <utility>        // For std::pair and std::move
 #include <vector>
+#include <chrono> 						// Added for perf tests. To remove later.
 
 #include "../analysis/check_contains.h"  // For the visitor CheckContains
 #include "common_subexpr_elim_tools.h"   // For the auxiliary analysis (visitors) and tools
@@ -601,9 +602,16 @@ Pass CommonSubexprElimTIR(bool enable_cse_tir) {
         context_init.push_back({current_param, MaybeValue()});
       }
 
+auto start = std::chrono::high_resolution_clock::now();
+
       // Do the Common Subexpression Elimination on the body of the function, with the initial
       // context that we have prepared
       n->body = CommonSubexpressionEliminator::PerformCSE(std::move(f->body), context_init);
+
+auto stop = std::chrono::high_resolution_clock::now();
+
+auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
+std::cout << "THE DURATION OF THE CSE PASS IS : " << duration.count() << std::endl;
     }
 
     return f;

--- a/src/tir/transforms/common_subexpr_elim.cc
+++ b/src/tir/transforms/common_subexpr_elim.cc
@@ -46,7 +46,6 @@
 #include <unordered_map>  // For the hashtable datatype
 #include <utility>        // For std::pair and std::move
 #include <vector>
-#include <chrono> 						// Added for perf tests. To remove later.
 
 #include "../analysis/check_contains.h"  // For the visitor CheckContains
 #include "common_subexpr_elim_tools.h"   // For the auxiliary analysis (visitors) and tools
@@ -646,17 +645,10 @@ Pass CommonSubexprElimTIR(bool enable_cse_tir, bool identify_equiv_terms) {
         context_init.push_back({current_param, MaybeValue()});
       }
 
-      auto start = std::chrono::high_resolution_clock::now();
-
       // Do the Common Subexpression Elimination on the body of the function, with the initial
       // context that we have prepared
       n->body = CommonSubexpressionEliminator::PerformCSE(std::move(f->body), context_init,
                                                                             identify_equiv_terms);
-
-      auto stop = std::chrono::high_resolution_clock::now();
-
-      auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
-      std::cout << "THE DURATION OF THE CSE PASS IS : " << duration.count() << std::endl;
     }
 
     return f;

--- a/src/tir/transforms/common_subexpr_elim.cc
+++ b/src/tir/transforms/common_subexpr_elim.cc
@@ -122,6 +122,51 @@ bool CommonSubexpressionEliminator::CanContainEligibleComputations(const PrimExp
 }
 
 /*!
+ * \brief Implements an order on pairs (expression,frequency). First attempts to compare them
+          using the size of the expression. When they are the same, uses the frequency to break
+          the tie. If the frequency is also the same, decides something else still deterministic.
+ * \param a The first pair
+ * \param b The second pair
+ * \return A boolean telling if the first pair `a` comes before the second pair `b`
+ * \note We need this order to be deterministic in order to have a fully deterministic pass,
+ *       as we will deal with elements that are coming from a hashtable, but the order in which
+ *       they appeared in the hashtable was based on some runtime addresses, so it can potentially
+ *       change with every execution.
+ */
+bool CommonSubexpressionEliminator::OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a,
+                                                            std::pair<PrimExpr, size_t> b) {
+  size_t a_size = CalculateExprComplexity(a.first);
+  size_t b_size = CalculateExprComplexity(b.first);
+
+  // Criteria 1 - Size of the expression comes first
+  // `a` comes before `b` if the size of `a` is bigger
+  if (a_size > b_size)
+    return true;
+  // `a` does NOT come before `b` if the size of `b` is bigger
+  else if (b_size > a_size)
+    return false;
+
+  // Criteria 2 - When they are the same, we use their frequencies (i.e. number of time seen) to
+  // break the tie.
+  // `a` comes before `b` if the frequency of `a` is bigger
+  else if(a.second > b.second)
+    return true;
+  // `a` does NOT come before `b` if the frequency of `b` is bigger
+  else if(b.second > a.second)
+    return false;
+
+  // Criteria 3 - If they also had the same frequency, use the lexicographic order as a last resort
+  // as we need a deterministic order
+  else {
+    std::stringstream a_stream;
+    std::stringstream b_stream;
+    a_stream << a.first;
+    b_stream << b.first;
+    return (a_stream.str().compare(b_stream.str()) < 0);
+  }
+}
+
+/*!
  * \brief Generates a new fresh variable, whose name will be cse_var_i.
  * \param type_annotation The type of the new variable to generate
  * \return A new variable of type `type_annotation` called cse_var_i where i is the first available
@@ -205,9 +250,7 @@ PrimExpr CommonSubexpressionEliminator::VisitExpr(const PrimExpr& expr) {
 
   // Sort the vector of semantic entities by decreasing size
   std::sort(semantic_comp_done_by_expr.begin(), semantic_comp_done_by_expr.end(),
-            [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
-              return (CalculateExprComplexity(a.first) > CalculateExprComplexity(b.first));
-            });
+      OrderOnExprAndFrequency);
 
   // For each computation done (considering them from biggest to smallest)
   for (size_t i = 0; i < semantic_comp_done_by_expr.size(); i++) {
@@ -383,9 +426,7 @@ Stmt CommonSubexpressionEliminator::VisitStmt(const Stmt& stmt) {
 
   // Sort the vector of semantic entities by decreasing size
   std::sort(semantic_comp_done_by_stmt.begin(), semantic_comp_done_by_stmt.end(),
-            [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
-              return (CalculateExprComplexity(a.first) > CalculateExprComplexity(b.first));
-            });
+      OrderOnExprAndFrequency);
 
   // For each computation done (considering them from biggest to smallest)
   for (size_t i = 0; i < semantic_comp_done_by_stmt.size(); i++) {

--- a/src/tir/transforms/common_subexpr_elim.h
+++ b/src/tir/transforms/common_subexpr_elim.h
@@ -83,7 +83,6 @@ class CommonSubexpressionEliminator : public StmtExprMutator {
   static bool ForbiddenComputation(const PrimExpr& expr);
   static bool IsEligibleComputation(const PrimExpr& expr);
   static bool CanContainEligibleComputations(const PrimExpr& expr);
-  static bool OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b);
   Var GenerateNewVar(DataType type_annotation);
 };
 

--- a/src/tir/transforms/common_subexpr_elim.h
+++ b/src/tir/transforms/common_subexpr_elim.h
@@ -83,7 +83,8 @@ class CommonSubexpressionEliminator : public StmtExprMutator {
   static bool ForbiddenComputation(const PrimExpr& expr);
   static bool IsEligibleComputation(const PrimExpr& expr);
   static bool CanContainEligibleComputations(const PrimExpr& expr);
-  static bool OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b);
+  static bool OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a, 
+                                      std::pair<PrimExpr, size_t> b);
   Var GenerateNewVar(DataType type_annotation);
 };
 

--- a/src/tir/transforms/common_subexpr_elim.h
+++ b/src/tir/transforms/common_subexpr_elim.h
@@ -55,7 +55,7 @@ using Context = std::vector<std::pair<Var, MaybeValue>>;
 class CommonSubexpressionEliminator : public StmtExprMutator {
  public:
   // Toplevel (static) function
-  static Stmt PerformCSE(const Stmt& stmt, const Context& context_init);
+  static Stmt PerformCSE(const Stmt& stmt, const Context& context_init, bool identify_equiv_terms);
 
   PrimExpr VisitExpr(const PrimExpr& expr) override;
   Stmt VisitStmt(const Stmt& stmt) override;
@@ -64,7 +64,8 @@ class CommonSubexpressionEliminator : public StmtExprMutator {
 
  protected:
   // Constructor
-  CommonSubexpressionEliminator(const Stmt& stmt, const Context& context_init);
+  CommonSubexpressionEliminator(const Stmt& stmt, const Context& context_init,
+                                                  bool identify_equiv_terms);
 
   PrimExpr VisitExpr_(const LetNode* op) override;
 
@@ -76,6 +77,8 @@ class CommonSubexpressionEliminator : public StmtExprMutator {
   Context context_;       // Context associating variables to (maybe) definitions
   int num_last_try_ = 0;  // Number of the last variable tried
   int nb_var_ = 0;        // Number of variables introduced by the CSE pass
+
+  bool identify_equiv_terms_ = false;
 
   static bool ForbiddenComputation(const PrimExpr& expr);
   static bool IsEligibleComputation(const PrimExpr& expr);

--- a/src/tir/transforms/common_subexpr_elim.h
+++ b/src/tir/transforms/common_subexpr_elim.h
@@ -80,6 +80,7 @@ class CommonSubexpressionEliminator : public StmtExprMutator {
   static bool ForbiddenComputation(const PrimExpr& expr);
   static bool IsEligibleComputation(const PrimExpr& expr);
   static bool CanContainEligibleComputations(const PrimExpr& expr);
+  static bool OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b);
   Var GenerateNewVar(DataType type_annotation);
 };
 

--- a/src/tir/transforms/common_subexpr_elim.h
+++ b/src/tir/transforms/common_subexpr_elim.h
@@ -83,6 +83,7 @@ class CommonSubexpressionEliminator : public StmtExprMutator {
   static bool ForbiddenComputation(const PrimExpr& expr);
   static bool IsEligibleComputation(const PrimExpr& expr);
   static bool CanContainEligibleComputations(const PrimExpr& expr);
+  static bool OrderOnExprAndFrequency(std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b);
   Var GenerateNewVar(DataType type_annotation);
 };
 

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -783,7 +783,8 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
   // normalized. This normalized table will keep the count for each set of equivalent terms
   // (i.e. each equivalence class), together with a term that did appear in this equivalence class
   // (in practice, the first term of the equivalence class that was encoutered).
-  std::unordered_map<PrimExpr, std::pair<PrimExpr, size_t>, StructuralHash, ExprDeepEqual> norm_table;
+  std::unordered_map<PrimExpr, std::pair<PrimExpr, size_t>, StructuralHash, ExprDeepEqual>
+      norm_table;
 
   // In order to avoid frequent rehashing if the norm_table becomes big, we immediately ask for
   // enough space to store the amount of elements that the input table has, as it's clearly an
@@ -797,7 +798,7 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
   // (otherwise {x+y, y+x} could be both replaced by x+y, and on another run by y+x).
   std::vector<std::pair<PrimExpr, size_t>> sorted_items_of_table(table.begin(), table.end());
 
-  // We do the ordering by comparing the string repr of each PrimExpr to get a determinstic ordering
+  // We do the ordering by comparing the string repr of each expr to get a determinstic ordering
   sort(sorted_items_of_table.begin(), sorted_items_of_table.end(),
        [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
          std::stringstream a_stream;
@@ -835,7 +836,8 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
   // Careful : the pairs will never change (the canonical represantants chosen will always be the
   // same), but the order in which the pairs are produced can vary as we are iterating through the
   // hashtable `norm_table`. It is not an issue as the called will be sorting the result anyway.
-  std::unordered_map<PrimExpr, std::pair<PrimExpr, size_t>, StructuralHash, ExprDeepEqual>::const_iterator it_norm_table;
+  std::unordered_map<PrimExpr, std::pair<PrimExpr, size_t>, StructuralHash, ExprDeepEqual>
+      ::const_iterator it_norm_table;
   for( it_norm_table = norm_table.begin(); it_norm_table != norm_table.end(); ++it_norm_table ) {
     result.push_back( it_norm_table->second );
   }

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -812,6 +812,7 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
   // string repr of each PrimExpr) in order to have a fully determinstic pass (as the order
   // currently depends on the previous order of appearance in the hastable, which was based
   // on some runtime addresses, so it potentially changed with every execution)
+/*
   sort(result.begin(), result.end(),
        [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
          std::stringstream a_stream;
@@ -820,6 +821,7 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
          b_stream << b.first;
          return a_stream.str().compare(b_stream.str()) < 0;
        });
+*/
 
   return result;
 }

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -796,8 +796,8 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
     }
   }
 
-  // norm_table.size() is the number of equivalence class that we have built, so it's also exactly
-  // the number of items that we will return in the vector of semantical entities
+  // norm_table.size() is the number of equivalence class that we have built, so it's exactly the
+  // number of items that we will return in the vector of semantical entities
   result.reserve(norm_table.size());
 
   // Transform the intermediate hashtable `norm_table` into a vector, forgetting the keys,

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -808,21 +808,6 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
     result.push_back( it_norm_table->second );
   }
 
-  // Order the result using the effective canonical representant (using a comparison of the
-  // string repr of each PrimExpr) in order to have a fully determinstic pass (as the order
-  // currently depends on the previous order of appearance in the hastable, which was based
-  // on some runtime addresses, so it potentially changed with every execution)
-/*
-  sort(result.begin(), result.end(),
-       [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
-         std::stringstream a_stream;
-         std::stringstream b_stream;
-         a_stream << a.first;
-         b_stream << b.first;
-         return a_stream.str().compare(b_stream.str()) < 0;
-       });
-*/
-
   return result;
 }
 

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -732,14 +732,14 @@ PrimExpr NormalizeTerm(const PrimExpr& expr) {
   // associativity (like (x+y)+z and x+(y+z)), etc. For that, a normalization procedure (or an 
   // incomplete "pseudo-normalization" like arith::Analyzer::Simplify) will be used.
 
-  //return expr;
+  return expr;
 
   // Just an attempt to do more commonings by using the pseudo-normalization function
   // offered by arith::Analyzer::Simplify(). "pseudo" because while it is correct (i.e. 
   // the simplification is indeed equivalent to the original term), it is incomplete (i.e. 
   // the returned term is not guaranteed to be a normal form).
-  arith::Analyzer analyzer;
-  return analyzer.Simplify(expr);
+  //arith::Analyzer analyzer;
+  //return analyzer.Simplify(expr);
 }
 
 /*!

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -786,7 +786,20 @@ std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
   // equivalence classes as there are elements)
   norm_table.reserve(table.size());
 
-  for(const auto& elem : table) {
+  // Traverse through map in a sorted order on keys to maintain deterministic behavior
+  // We do this by comparing the string repr of each PrimExpr to get a determinstic ordering
+  std::vector<std::pair<PrimExpr, size_t>> sorted_map_items(table.begin(), table.end());
+
+  sort(sorted_map_items.begin(), sorted_map_items.end(),
+       [](std::pair<PrimExpr, size_t> a, std::pair<PrimExpr, size_t> b) {
+         std::stringstream a_stream;
+         std::stringstream b_stream;
+         a_stream << a.first;
+         b_stream << b.first;
+         return a_stream.str().compare(b_stream.str()) < 0;
+       });
+
+  for(const auto& elem : sorted_map_items) {
     PrimExpr norm_elem = NormalizeTerm(elem.first, identify_equiv_terms);
     // If the normalized term is not already a key in the normalized table
     auto it_found = norm_table.find(norm_elem);

--- a/src/tir/transforms/common_subexpr_elim_tools.h
+++ b/src/tir/transforms/common_subexpr_elim_tools.h
@@ -180,10 +180,12 @@ void PrintComputationTable(const ComputationTable& table);
 using MaybeValue = dmlc::optional<PrimExpr>;
 
 bool EqualTerms(const PrimExpr& a, const PrimExpr& b);
-inline PrimExpr NormalizeTerm(const PrimExpr& expr); // Used for deciding the (decidable) equivalence relation
-bool EquivalentTerms(const PrimExpr& a, const PrimExpr& b);
+// Used for deciding the (decidable) equivalence relation
+PrimExpr NormalizeTerm(const PrimExpr& expr, bool do_normalization);
+// The equivalence relation, which is the syntactical equality when `identify_equiv_terms` is false
+bool EquivalentTerms(const PrimExpr& a, const PrimExpr& b, bool identify_equiv_terms);
 std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
-    const ComputationTable& table);
+    const ComputationTable& table, bool identify_equiv_terms);
 bool PredicateIntroVarForComputation(const PrimExpr& computation, size_t nb_times_seen);
 
 // Polymorphic (functional) map on a vector, which builds a news vector with the same number of
@@ -210,7 +212,7 @@ template std::vector<Var> VectorMap(const std::vector<std::pair<Var, MaybeValue>
 void InsertElemToSortedSemanticComputations(std::vector<std::pair<PrimExpr, size_t>>* sorted_vec,
                                             const std::pair<PrimExpr, size_t>& pair);
 void InsertVectorToSortedSemanticComputations(std::vector<std::pair<PrimExpr, size_t>>* sorted_vec,
-                                              const std::vector<PrimExpr>& vec_to_add);
+                              const std::vector<PrimExpr>& vec_to_add, bool identify_equiv_terms);
 
 }  // namespace tir
 }  // namespace tvm

--- a/src/tir/transforms/common_subexpr_elim_tools.h
+++ b/src/tir/transforms/common_subexpr_elim_tools.h
@@ -180,6 +180,7 @@ void PrintComputationTable(const ComputationTable& table);
 using MaybeValue = dmlc::optional<PrimExpr>;
 
 bool EqualTerms(const PrimExpr& a, const PrimExpr& b);
+PrimExpr NormalizeTerm(const PrimExpr& expr); // Used for deciding the (decidable) equivalence relation
 bool EquivalentTerms(const PrimExpr& a, const PrimExpr& b);
 std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
     const ComputationTable& table);

--- a/src/tir/transforms/common_subexpr_elim_tools.h
+++ b/src/tir/transforms/common_subexpr_elim_tools.h
@@ -180,7 +180,7 @@ void PrintComputationTable(const ComputationTable& table);
 using MaybeValue = dmlc::optional<PrimExpr>;
 
 bool EqualTerms(const PrimExpr& a, const PrimExpr& b);
-PrimExpr NormalizeTerm(const PrimExpr& expr); // Used for deciding the (decidable) equivalence relation
+inline PrimExpr NormalizeTerm(const PrimExpr& expr); // Used for deciding the (decidable) equivalence relation
 bool EquivalentTerms(const PrimExpr& a, const PrimExpr& b);
 std::vector<std::pair<PrimExpr, size_t>> SyntacticToSemanticComputations(
     const ComputationTable& table);

--- a/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
+++ b/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
@@ -357,7 +357,7 @@ def func_distributivity_expected(
 ) -> None:
     B = T.buffer_decl((50,), "int32")
     cse_var_1 = T.var("int32")
-    with T.let(cse_var_1, x * (y + z)):
+    with T.let(cse_var_1, x * y + x * z):
         B[i1] = cse_var_1
         B[i2] = cse_var_1
 

--- a/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
+++ b/tests/python/unittest/test_tir_transform_common_subexpr_elim.py
@@ -25,7 +25,8 @@ from tvm.script import tir as T
 # -----------------------------------------------------
 # Basic test for the expected Behavior of the CSE pass
 # -----------------------------------------------------
-# A test program which gives the opportunity for the CSE pass to introduce two new variables, at two different levels
+# A test program which gives the opportunity for the CSE pass to introduce two new variables,
+# at two different levels
 def test_cse():
     z1 = te.var("z1")
     z2 = te.var("z2")
@@ -73,9 +74,9 @@ def test_cse():
             ),
         ),
     )
-    # This test program gives the opportunity to introduce two new variables, at two different levels
-    # and to perform replacements in the value of "a" and "b", using these new variables
-    # We will check all of that underneath and more, making also sure that nothing else has been changed
+    # This test program gives the opportunity to introduce two new variables, at two different
+    # levels and to perform replacements in the value of "a" and "b", using these new variables.
+    # We will check all of that underneath and more, making also sure that nothing else has changed
 
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([i1, i2, z3], body))
     body = tvm.tir.transform.CommonSubexprElimTIR()(mod)
@@ -144,9 +145,11 @@ def test_cse():
 # -----------------------------------------------------
 # Tests related to If nodes
 # -----------------------------------------------------
-# First specific test for if nodes : Some duplicated computations appear only in one branch (here the Then branch), not in both branches.
-# In this case, the CSE pass should introduce the redundant computation at the top of the Then branch, not before the whole If
-# (otherwise that would lead to some computations being computed for nothing when it is the Else branch that is executed).
+# First specific test for if nodes : Some duplicated computations appear only in one branch (here
+# the Then branch), not in both branches.
+# In this case, the CSE pass should introduce the redundant computation at the top of the Then
+# branch, not before the whole If (otherwise that would lead to some computations being computed
+# for nothing when it is the Else branch that is executed).
 def test_cse_ifNode_1():
     b = te.var("b")
     i1 = te.var("i1")
@@ -171,7 +174,10 @@ def test_cse_ifNode_1():
         tvm.tir.IfThenElse(
             b,
             tvm.tir.SeqStmt(
-                [tvm.tir.BufferStore(buffer, y + z, [i1]), tvm.tir.BufferStore(buffer, y + z, [i2])]
+                [
+                    tvm.tir.BufferStore(buffer, y + z, [i1]),
+                    tvm.tir.BufferStore(buffer, y + z, [i2])
+                ]
             ),
             tvm.tir.BufferStore(buffer, y, [i3]),
         ),
@@ -200,9 +206,9 @@ def test_cse_ifNode_1():
     assert tvm.ir.structural_equal(body.value, y + z)
 
 
-# Second test for if nodes : Some duplicated computations appear in both the Then and the Else branch.
-# In this case, the CSE pass should introduce the redundant computation before the whole If node, because
-# regardless of the execution path, it is going to be computed.
+# Second test for if nodes : Some duplicated computations appear in both the Then and Else branch.
+# In this case, the CSE pass should introduce the redundant computation before the whole If node,
+# because regardless of the execution path, it is going to be computed.
 def test_cse_ifNode_2():
     b = te.var("b")
     i1 = te.var("i1")
@@ -228,7 +234,7 @@ def test_cse_ifNode_2():
             b,
             tvm.tir.SeqStmt(
                 [
-                    tvm.tir.BufferStore(buffer, y + z, [i1]),  # (y+z) is present in the Then branch
+                    tvm.tir.BufferStore(buffer, y + z, [i1]),  # (y+z) is present in Then branch
                     tvm.tir.BufferStore(buffer, y, [i2]),
                 ]
             ),
@@ -445,8 +451,19 @@ def test_deterministic_cse():
         assert json_hash == initial_hash
 
 
-# Things needed for the second test on determinism
-LOG_LINE = '{"i": [["[\\"conv2d_layer\\", 1, 7, 7, 512, 512, 3, 3, [1, 1], [1, 1]]", "llvm -keys=cpu -link-params=0 -mcpu=broadwell -num-cores=2", [8, 64, 64, 0, 0, 0, 0, 0], "", 1, []], [[], [["CI", 5], ["SP", 3, 0, 1, [1, 1, 1], 1], ["SP", 3, 4, 512, [1, 32, 16], 1], ["SP", 3, 8, 7, [7, 1, 1], 1], ["SP", 3, 12, 7, [1, 1, 1], 1], ["SP", 3, 16, 512, [1], 1], ["SP", 3, 18, 3, [1], 1], ["SP", 3, 20, 3, [3], 1], ["RE", 3, [0, 4, 8, 12, 1, 5, 9, 13, 16, 18, 20, 2, 6, 10, 14, 17, 19, 21, 3, 7, 11, 15]], ["FSP", 6, 0, 1, 2], ["FSP", 6, 3, 2, 2], ["FSP", 6, 6, 3, 2], ["FSP", 6, 9, 4, 2], ["RE", 6, [0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11]], ["CA", 3, 6, 7], ["CA", 1, 6, 5], ["FU", 6, [0, 1, 2, 3, 4, 5]], ["AN", 6, 0, 3], ["PR", 3, 0, "auto_unroll_max_step$512"], ["AN", 1, 3, 2], ["AN", 3, 21, 2], ["AN", 6, 6, 2]]]], "r": [[0.0331129], 0, 0.900362, 1647464342], "v": "v0.6"}\n'
+# Needed for the second test on determinism
+LOG_LINE = '{"i": [["[\\"conv2d_layer\\", 1, 7, 7, 512, 512, 3, 3, [1, 1], [1, 1]]", \
+            "llvm -keys=cpu -link-params=0 -mcpu=broadwell -num-cores=2", \
+            [8, 64, 64, 0, 0, 0, 0, 0], "", 1, []], [[], [["CI", 5], \
+            ["SP", 3, 0, 1, [1, 1, 1], 1], ["SP", 3, 4, 512, [1, 32, 16], 1], \
+            ["SP", 3, 8, 7, [7, 1, 1], 1], ["SP", 3, 12, 7, [1, 1, 1], 1], \
+            ["SP", 3, 16, 512, [1], 1], ["SP", 3, 18, 3, [1], 1], ["SP", 3, 20, 3, [3], 1], \
+            ["RE", 3, [0, 4, 8, 12, 1, 5, 9, 13, 16, 18, 20, 2, 6, 10, 14, 17, 19, 21, 3, 7, \
+            11, 15]], ["FSP", 6, 0, 1, 2], ["FSP", 6, 3, 2, 2], ["FSP", 6, 6, 3, 2], \
+            ["FSP", 6, 9, 4, 2], ["RE", 6, [0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11]], \
+            ["CA", 3, 6, 7], ["CA", 1, 6, 5], ["FU", 6, [0, 1, 2, 3, 4, 5]], ["AN", 6, 0, 3], \
+            ["PR", 3, 0, "auto_unroll_max_step$512"], ["AN", 1, 3, 2], ["AN", 3, 21, 2], \
+            ["AN", 6, 6, 2]]]], "r": [[0.0331129], 0, 0.900362, 1647464342], "v": "v0.6"}\n'
 
 # The workload associated with the log
 @auto_scheduler.register_workload


### PR DESCRIPTION
NOTE : NOT READY FOR REVIEW YET. USING CI FOR FIXING FORMATTING, ETC.
I WILL REMOVE THIS TAG WHEN IT'S READY FOR REVIEW.

This PR addresses the issue described in https://github.com/apache/tvm/pull/11423/ .
Here is some context : 

The CSE pass had been designed for potentially allowing comparisons (and commonings) of equivalent terms (like (x+y)+z and x+(y+z)), where **the notion of being equivalent was customizable, and no assumption was made about it**. That means that the implementation of the equality test function `EquivalentTerms()` - which was at the moment just calling the syntactical equality test `EqualTerms()` - could be replaced later by a cleverer equality test.

However, having such a generic way of comparing elements meant that in the function `SyntacticToSemanticComputations()`, where we were going from a hashtable of syntactical entities to what I called a vector of "semantical entites" (which are just canonical forms/representants of classes of equivalence of terms), **the only way was to compare each pair**.
That resulted in a quadratic behavior of this function, but there was no way around it as in order to merge equivalent entities into their class of equivalence, we had to compare them.

**This PR essentially does the following:**

    - When computing the classes of equivalences of terms (therefore transforming a ComputationTable (i.e. a hashtable) into a vector of classes of equivalence) : **instead of comparing each pair of terms, relies on a normalization procedure to obtain a normal form for each of them**.
That transforms a small part of the algorithm that was quadratic to n.logn. However, it's difficult to see improvements in practice, in particular for average sized programs, as that part was a "small" quadratic to a "big" n.logn (finding things in a hash-table, copying it to a vector, etc).
It was probably going from a complexity of ~O(((n²-n)/2) + n.logn) to a complexity of ~O(3n + n.logn), so potential gains would only be expected for very large programs.

    - Completely gives the user the possibility to turn ON/OFF the semantical comparisons of terms. It is turned OFF by default (as it's quite longer to compile with it ON, unsurprisingly), which means that by default, the equivalence coincides with the (syntactical) equality of terms.
    As the pass was written with the possibility to do these additional commonings (like (x+y)+z and x+(y+z)), it was a good time to fully plug that completely, up to the Python user who can now turn that ON if he wants to. But again, it is OFF by default, so no real change on that.

To run it ON, simply do:
`with tvm.transform.PassContext(config={'tir.enable_equiv_terms_in_cse_tir':True}):`
before calling `build()`

    - When this boolean is set to ON, it uses a simple implementation of the normalization function with equivalences that uses `arith::Analyzer::Simplify` as noted by @yuanfz98 on his PR https://github.com/apache/tvm/pull/10544 . Note that this is not a real normalization procedure as it is incomplete (i.e., it is not guarantee to converge to the normal form), but it is correct, and it works well with most properties : associativity of +, distributivity of * on +, etc.

    - Clarifies and enhance the test base for the pass. In particular, it adds the tests that were written in https://github.com/apache/tvm/pull/10544 but which did not make it through.

    - Also add the test ( https://github.com/AndrewZhaoLuo/TVM-Sandbox/blob/19284ddbd6bb28af61c0c2aa8bb334c5c53731a7/tir/test_inconsistent_tir_lowering.py#L1 ) from @AndrewZhaoLuo demonstrating the (older) non-deterministic lowering and put it into a proper test, as I found it useful for making sure that this does not happen again. It has been copied from https://github.com/apache/tvm/pull/10663 and only slightly adapted (in particular for doing the comparison of hashes automatically instead of printing them and relying on a human to compare them).

Many thanks!