### PR TITLE
[MetaSchedule] exposed method: TuneContextNodeInitialize

### DIFF
--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -129,3 +129,4 @@ class TuneContext(Object):
             rand_state,
             num_threads,
         )
+        _ffi_api.TuneContextNodeInitialize(self)

--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -131,6 +131,6 @@ class TuneContext(Object):
         )
 
     def initialize(self):
-        '''Initialize the tuning context'''
+        """Initialize the tuning context"""
 
         _ffi_api.TuneContextInitialize(self)  # type: ignore # pylint: disable=no-member

--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -129,4 +129,8 @@ class TuneContext(Object):
             rand_state,
             num_threads,
         )
-        _ffi_api.TuneContextNodeInitialize(self)
+
+    def initialize(self):
+        '''Initialize the tuning context'''
+
+        _ffi_api.TuneContextInitialize(self)  # type: ignore # pylint: disable=no-member

--- a/src/meta_schedule/tune_context.cc
+++ b/src/meta_schedule/tune_context.cc
@@ -89,6 +89,8 @@ TVM_REGISTER_GLOBAL("meta_schedule.TuneContext")
     });
 
 TVM_REGISTER_GLOBAL("meta_schedule._SHash2Hex").set_body_typed(SHash2Hex);
+TVM_REGISTER_GLOBAL("meta_schedule.TuneContextNodeInitialize")
+    .set_body_method<TuneContext>(&TuneContextNode::Initialize);
 
 }  // namespace meta_schedule
 }  // namespace tvm

--- a/src/meta_schedule/tune_context.cc
+++ b/src/meta_schedule/tune_context.cc
@@ -89,7 +89,7 @@ TVM_REGISTER_GLOBAL("meta_schedule.TuneContext")
     });
 
 TVM_REGISTER_GLOBAL("meta_schedule._SHash2Hex").set_body_typed(SHash2Hex);
-TVM_REGISTER_GLOBAL("meta_schedule.TuneContextNodeInitialize")
+TVM_REGISTER_GLOBAL("meta_schedule.TuneContextInitialize")
     .set_body_method<TuneContext>(&TuneContextNode::Initialize);
 
 }  // namespace meta_schedule


### PR DESCRIPTION
I exposed the initialize() method for TuneContextNode on the C++ side and added a corresponding method to TuneContext class on the Python side, so that we do not need to call initialize_with_tune_context for every scheduling rule. 