### PR TITLE
[GraphExecutor] Add API get_output_info to graph_executor

### DIFF
--- a/src/runtime/graph_executor/graph_executor.cc
+++ b/src/runtime/graph_executor/graph_executor.cc
@@ -151,7 +151,8 @@ int GraphExecutor::GetOutputIndex(const std::string& name) {
  * \brief Get the output info of Graph by parsing the output nodes.
  * \return The shape and dtype tuple.
  */
-std::tuple<GraphExecutor::ShapeInfo, GraphExecutor::DtypeInfo> GraphExecutor::GetOutputInfo() const {
+std::tuple<GraphExecutor::ShapeInfo, GraphExecutor::DtypeInfo> GraphExecutor::GetOutputInfo()
+    const {
   GraphExecutor::ShapeInfo shape_dict;
   GraphExecutor::DtypeInfo dtype_dict;
   for (const auto& output : outputs_) {

--- a/src/runtime/graph_executor/graph_executor.cc
+++ b/src/runtime/graph_executor/graph_executor.cc
@@ -146,6 +146,29 @@ int GraphExecutor::GetOutputIndex(const std::string& name) {
   }
   return -1;
 }
+
+/*!
+ * \brief Get the output info of Graph by parsing the output nodes.
+ * \return The shape and dtype tuple.
+ */
+std::tuple<GraphExecutor::ShapeInfo, GraphExecutor::DtypeInfo> GraphExecutor::GetOutputInfo() const {
+  GraphExecutor::ShapeInfo shape_dict;
+  GraphExecutor::DtypeInfo dtype_dict;
+  for (const auto& output : outputs_) {
+    uint32_t nid = output.node_id;
+    CHECK_LE(nid, nodes_.size());
+    std::string name = nodes_[nid].name;
+    if (param_names_.find(name) == param_names_.end()) {
+      CHECK_LE(nid, attrs_.shape.size());
+      auto shape = attrs_.shape[nid];
+      shape_dict.Set(name, ShapeTuple(shape));
+      CHECK_LE(nid, attrs_.dltype.size());
+      auto dtype = attrs_.dltype[nid];
+      dtype_dict.Set(name, String(dtype));
+    }
+  }
+  return std::make_tuple(shape_dict, dtype_dict);
+}
 /*!
  * \brief set index-th input to the graph.
  * \param index The input index.

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -125,6 +125,12 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   int GetOutputIndex(const std::string& name);
 
   /*!
+   * \brief Get the output info of Graph by parsing the output nodes.
+   * \return The shape and dtype tuple.
+   */
+  std::tuple<ShapeInfo, DtypeInfo> GetOutputInfo() const;
+
+  /*!
    * \brief set index-th input to the graph.
    * \param index The input index.
    * \param data_in The input data.
@@ -200,6 +206,8 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   uint32_t GetNumOfNodes() const { return static_cast<uint32_t>(nodes_.size()); }
 
   std::string GetNodeName(uint32_t nid) const { return nodes_[nid].name; }
+
+  std::unordered_set<std::string> GetParamNames() const { return param_names_; }
 
  protected:
   // Memory pool entry.


### PR DESCRIPTION
Add get_output_info in GraphExecutor C++ API similar as [#9889](https://github.com/apache/tvm/pull/9889)