### PR TITLE
[Minor][MetaSchedule] Fix Summary Format for Invalid Runs

### DIFF
--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -79,10 +79,14 @@ class GradientBasedNode final : public TaskSchedulerNode {
           << /*name=*/record.task->task_name.value()      //
           << /*flops=*/static_cast<int64_t>(record.flop)  //
           << /*weight=*/static_cast<int>(record.weight);
-      if (trials == 0) {
+      double latency = 1e9;
+      if (trials > 0) {
+        latency = record.best_time_cost_history.back();
+      }
+      if (latency >= 1e9) {
         row << /*speed=*/"N/A" << /*latency=*/"N/A" << /*weighted_latency=*/"N/A";
       } else {
-        double latency = record.best_time_cost_history.back() * 1000.0;
+        latency *= 1000.0;
         double speed = record.flop / latency / 1000.0;
         double weighted_latency = latency * record.weight;
         row << /*speed=*/speed << /*latency=*/latency << /*weighted_latency=*/weighted_latency;
@@ -139,10 +143,15 @@ class GradientBasedNode final : public TaskSchedulerNode {
       int n = record.best_time_cost_history.size();
       ICHECK_GE(n, 1);
       double best = record.best_time_cost_history[n - 1];
-      double g1 = (n >= 1 + w) ? (record.best_time_cost_history[n - 1 - w] - best) / w : 0.0;
-      double g2 = best / n;
-      double g = alpha * g1 + (1 - alpha) * g2;
-      grad.push_back(g * record.weight);
+      if (best < 1e9) {
+        double g1 = (n >= 1 + w) ? (record.best_time_cost_history[n - 1 - w] - best) / w : 0.0;
+        double g2 = best / n;
+        double g = alpha * g1 + (1 - alpha) * g2;
+        grad.push_back(g * record.weight);
+      } else {
+        // If the best time cost is unavailable, it means some task is not valid. Skip it.
+        grad.push_back(-1e9);
+      }
     }
     auto max_grad = std::max_element(grad.begin(), grad.end());
     auto min_grad = std::min_element(grad.begin(), grad.end());


### PR DESCRIPTION
Previously for invalid tasks, MetaSchedule prints a huge number in
latency which is aesthetically unacceptable. For example,

```
 69 |  fused_cast_add_cast_3 | 16777216 | 2 | 0.0000 | 10000000000000000019156750857346687362159551272651920111528035145993793242039887559612361451081803235328.0000 | 20000000000000000038313501714693374724319102545303840223056070291987586484079775119224722902163606470656.0000 |     64 |
```

This PR fixes this behavior and turns the huge number into "N/A".