### PR TITLE
[FIX] FoldExplicitPadding uint MaxPool case

### DIFF
--- a/src/relay/transforms/fold_explicit_padding.cc
+++ b/src/relay/transforms/fold_explicit_padding.cc
@@ -269,7 +269,8 @@ class SimplifyExplicitPad {
         } else if (node_map.count(avg_pool3d_)) {
           attrs = MakeAvgPoolAttrs(param, call_node->attrs.as<AvgPool3DAttrs>());
         }
-      } else if (node_map.count(max_pool_)) {
+      }
+      if (node_map.count(max_pool_)) {
         // Fold Padding and MaxPool only if pad_value is the min possible value for the dtype
         auto min_value = tvm::min_value(tvm::runtime::DataType(pad_value->data->dtype));
         const FloatImmNode* maybe_min_float = min_value.as<FloatImmNode>();

--- a/tests/python/relay/test_pass_fold_explicit_padding.py
+++ b/tests/python/relay/test_pass_fold_explicit_padding.py
@@ -228,8 +228,8 @@ def test_simplify_pool_pad():
 
     # Check Pool pad folding when pad width on pad op is all zero.
     validate(max_pools, 1, [[0, 0], [0, 0], [0, 0]], float_min_val, [2, 0], "NCW", 2)
-    # Check MaxPool pad folding with int dtype
-    int_min_val = get_min_value("int32")
+    # Check MaxPool pad folding with uint dtype
+    int_min_val = get_min_value("uint8")
     validate(
         max_pools,
         2,
@@ -238,7 +238,7 @@ def test_simplify_pool_pad():
         [2, 0, 0, 0],
         "NCHW",
         2,
-        dtype="int32",
+        dtype="uint8",
     )
     # Fold when original AvgPool has its own padding but count_include_pad=True
     validate(


### PR DESCRIPTION
Fix uint-min (=0) case capture for folding pad into MaxPool in the FoldExplicitPadding pass