### PR TITLE
[relay] Fix missing virtual destructor

### DIFF
--- a/src/relay/transforms/compiler_function_utils.cc
+++ b/src/relay/transforms/compiler_function_utils.cc
@@ -119,6 +119,8 @@ class CallRewriter : public MixedModeMutator {
 
 }  // namespace
 
+GlobalSymbolCache::~GlobalSymbolCache() = default;
+
 GlobalVar ExistingGlobalSymbolCache::GetGlobalSymbol(const Function& function) {
   Optional<String> opt_global_symbol = function->GetAttr<String>(tvm::attr::kGlobalSymbol);
   ICHECK(opt_global_symbol.defined())

--- a/src/relay/transforms/compiler_function_utils.h
+++ b/src/relay/transforms/compiler_function_utils.h
@@ -71,6 +71,7 @@ namespace transforms {
  */
 class GlobalSymbolCache {
  public:
+  virtual ~GlobalSymbolCache();
   virtual GlobalVar GetGlobalSymbol(const Function& function) = 0;
 };
 


### PR DESCRIPTION
Add missing virtual destructor for derived class
`tvm::relay::transforms::ExistingGlobalSymbolCache`.
Fixes a potential problem when deleting an instance
using a pointer-to-base-class.