### PR TITLE
[ROOFLINE] Bug Fixes

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2225,9 +2225,15 @@ class HardSwish(OnnxOpConverter):
 
     @classmethod
     def _impl_v14(cls, inputs, attr, params):
+<<<<<<< HEAD
         alpha = attr.get("alpha", 1 / 6)
         beta = attr.get("beta", 0.5)
         transformX = inputs[0] * _expr.const(alpha) + _expr.const(beta)
+=======
+        alpha = attr.get("alpha", 1/6)
+        beta = attr.get("beta", 0.5)
+        transformX = (inputs[0] * _expr.const(alpha) + _expr.const(beta))
+>>>>>>> ONNX Opset 14 - HardSwish
         attr = {"a_min": 0, "a_max": 1}
         return inputs[0] * AttrCvt("clip")([transformX], attr)
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2225,15 +2225,9 @@ class HardSwish(OnnxOpConverter):
 
     @classmethod
     def _impl_v14(cls, inputs, attr, params):
-<<<<<<< HEAD
         alpha = attr.get("alpha", 1 / 6)
         beta = attr.get("beta", 0.5)
         transformX = inputs[0] * _expr.const(alpha) + _expr.const(beta)
-=======
-        alpha = attr.get("alpha", 1/6)
-        beta = attr.get("beta", 0.5)
-        transformX = (inputs[0] * _expr.const(alpha) + _expr.const(beta))
->>>>>>> ONNX Opset 14 - HardSwish
         attr = {"a_min": 0, "a_max": 1}
         return inputs[0] * AttrCvt("clip")([transformX], attr)
 

--- a/python/tvm/utils/roofline.py
+++ b/python/tvm/utils/roofline.py
@@ -187,7 +187,7 @@ def peak_bandwidth_tir(a: T.handle, b: T.handle, threads: T.int32, vec_width: T.
     # pylint: disable=invalid-name, missing-function-docstring
     N = T.var("int32")
     A = T.match_buffer(a, [threads, N, 4, vec_width], "float32")
-    B = T.match_buffer(b, [threads, vec_width, 4], "float32")
+    B = T.match_buffer(b, [threads, 4, vec_width], "float32")
     # Parallelism is necessary to hit all cores/nodes
     for i in T.parallel(threads):
         for k in T.serial(N):


### PR DESCRIPTION
This PR fixes two bugs in the Roofline code:

- In the estimate_peak_bandwidth function, the threads argument (non-array) was not passed via specialize call;

- In the estimate_peak_bandwidth function, the last dimensions of tensor B mismatch the tensor A. Changing from [threads, vec_width, 4] to [threads, 4, vec_width]. The current version adds cache misses and impacts the final kernel performance.

@tkonolige PTAL
