### PR TITLE
[Hexagon] Make local symbols visible to loaded modules in RPC server

### DIFF
--- a/src/runtime/hexagon/rpc/simulator/rpc_server.cc
+++ b/src/runtime/hexagon/rpc/simulator/rpc_server.cc
@@ -18,6 +18,7 @@
  */
 
 #include <HAP_farf.h>
+#include <dlfcn.h>
 
 #include <algorithm>
 #include <cassert>
@@ -288,7 +289,16 @@ int DISPATCH_FUNCTION_NAME(void* serverp) {
   return 0;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
+  // Load C++RT and ourselves as "global" to make all the symbols defined
+  // there be visible to any subsequent libraries loaded via dlopen.
+  void* cxx_abi = dlopen("libc++abi.so", RTLD_GLOBAL);
+  ICHECK(cxx_abi != nullptr);
+  void* cxx = dlopen("libc++.so", RTLD_GLOBAL);
+  ICHECK(cxx != nullptr);
+  void* self = dlopen(argv[0], RTLD_GLOBAL);
+  ICHECK(self != nullptr);
+
   const auto* api = tvm::runtime::Registry::Get("device_api.hexagon");
   ICHECK(api != nullptr);
   tvm::runtime::Registry::Register("device_api.cpu", true).set_body(*api);
@@ -308,6 +318,9 @@ int main() {
     // nothing
   }
 
+  dlclose(self);
+  dlclose(cxx);
+  dlclose(cxx_abi);
   return 0;
 }
 


### PR DESCRIPTION
The simulator library `libhexagon_rpc_sim.so` contains TVM runtime built into it, but since it's loaded as a "local" library these symbols are not visible to shared libraries loaded by subsequent dlopens. (Same applies to symbols from the C++ runtime.)

To make these symbols visible, dlopen the defining libraries as "global". (Re-dlopeninig an already loaded library is a well-defined operation.)

cc @mehrdadh