### PR TITLE
[Hexagon][CI] Re-enable Hexagon tests in CI

### DIFF
--- a/python/tvm/contrib/hexagon/_ci_env_check.py
+++ b/python/tvm/contrib/hexagon/_ci_env_check.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Hexagon environment checks for CI usage
+
+These may be required by either tvm.testing or
+tvm.contrib.hexagon.pytest_plugin, and are separated here to avoid a
+circular dependency.
+"""
+
+import os
+
+import tvm
+
+ANDROID_SERIAL_NUMBER = "ANDROID_SERIAL_NUMBER"
+HEXAGON_TOOLCHAIN = "HEXAGON_TOOLCHAIN"
+
+
+def _compile_time_check():
+    """Return True if compile-time support for Hexagon is present, otherwise
+    error string.
+
+    Designed for use as a the ``compile_time_check`` argument to
+    `tvm.testing.Feature`.
+    """
+    if (
+        tvm.testing.utils._cmake_flag_enabled("USE_LLVM")
+        and tvm.target.codegen.llvm_version_major() < 7
+    ):
+        return "Hexagon requires LLVM 7 or later"
+
+    if "HEXAGON_TOOLCHAIN" not in os.environ:
+        return f"Missing environment variable {HEXAGON_TOOLCHAIN}."
+
+    return True
+
+
+def _run_time_check():
+    """Return True if run-time support for Hexagon is present, otherwise
+    error string.
+
+    Designed for use as a the ``run_time_check`` argument to
+    `tvm.testing.Feature`.
+    """
+    if ANDROID_SERIAL_NUMBER not in os.environ:
+        return f"Missing environment variable {ANDROID_SERIAL_NUMBER}."
+
+    return True

--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -26,7 +26,6 @@ from typing import Optional, Union
 import pytest
 
 import tvm
-import tvm.testing
 import tvm.rpc.tracker
 from tvm.contrib.hexagon.build import HexagonLauncher, HexagonLauncherRPC
 from tvm.contrib.hexagon.session import Session
@@ -52,35 +51,6 @@ def _compose(args, decs):
             func = dec(func)
         return func
     return decs
-
-
-def _compile_time_check():
-    """Return True if compile-time support for Hexagon is present, otherwise
-    error string.
-
-    Designed for use as a the ``compile_time_check`` argument to
-    `tvm.testing.Feature`.
-    """
-    if _cmake_flag_enabled("USE_LLVM") and tvm.target.codegen.llvm_version_major() < 7:
-        return "Hexagon requires LLVM 7 or later"
-
-    if "HEXAGON_TOOLCHAIN" not in os.environ:
-        return f"Missing environment variable {HEXAGON_TOOLCHAIN}."
-
-    return True
-
-
-def _run_time_check():
-    """Return True if run-time support for Hexagon is present, otherwise
-    error string.
-
-    Designed for use as a the ``run_time_check`` argument to
-    `tvm.testing.Feature`.
-    """
-    if ANDROID_SERIAL_NUMBER not in os.environ:
-        return f"Missing environment variable {ANDROID_SERIAL_NUMBER}."
-
-    return True
 
 
 requires_hexagon_toolchain = tvm.testing.requires_hexagon(support_required="compile-only")

--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -26,6 +26,7 @@ from typing import Optional, Union
 import pytest
 
 import tvm
+import tvm.testing
 import tvm.rpc.tracker
 from tvm.contrib.hexagon.build import HexagonLauncher, HexagonLauncherRPC
 from tvm.contrib.hexagon.session import Session
@@ -53,15 +54,36 @@ def _compose(args, decs):
     return decs
 
 
-def requires_hexagon_toolchain(*args):
-    _requires_hexagon_toolchain = [
-        pytest.mark.skipif(
-            os.environ.get(HEXAGON_TOOLCHAIN) is None,
-            reason=f"Missing environment variable {HEXAGON_TOOLCHAIN}.",
-        ),
-    ]
+def _compile_time_check():
+    """Return True if compile-time support for Hexagon is present, otherwise
+    error string.
 
-    return _compose(args, _requires_hexagon_toolchain)
+    Designed for use as a the ``compile_time_check`` argument to
+    `tvm.testing.Feature`.
+    """
+    if _cmake_flag_enabled("USE_LLVM") and tvm.target.codegen.llvm_version_major() < 7:
+        return "Hexagon requires LLVM 7 or later"
+
+    if "HEXAGON_TOOLCHAIN" not in os.environ:
+        return f"Missing environment variable {HEXAGON_TOOLCHAIN}."
+
+    return True
+
+
+def _run_time_check():
+    """Return True if run-time support for Hexagon is present, otherwise
+    error string.
+
+    Designed for use as a the ``run_time_check`` argument to
+    `tvm.testing.Feature`.
+    """
+    if ANDROID_SERIAL_NUMBER not in os.environ:
+        return f"Missing environment variable {ANDROID_SERIAL_NUMBER}."
+
+    return True
+
+
+requires_hexagon_toolchain = tvm.testing.requires_hexagon(support_required="compile-only")
 
 
 @tvm.testing.fixture

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -88,6 +88,7 @@ import tvm.te
 import tvm._ffi
 
 from tvm.contrib import nvcc, cudnn
+from tvm.contrib.hexagon import pytest_plugin as hexagon
 from tvm.error import TVMError
 
 
@@ -937,11 +938,8 @@ requires_hexagon = Feature(
     "Hexagon",
     cmake_flag="USE_HEXAGON",
     target_kind_enabled="hexagon",
-    compile_time_check=lambda: (
-        (_cmake_flag_enabled("USE_LLVM") and tvm.target.codegen.llvm_version_major() >= 7)
-        or "Hexagon requires LLVM 7 or later"
-    ),
-    target_kind_hardware="hexagon",
+    compile_time_check=hexagon._compile_time_check,
+    run_time_check=hexagon._run_time_check,
     parent_features="llvm",
 )
 

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -88,7 +88,7 @@ import tvm.te
 import tvm._ffi
 
 from tvm.contrib import nvcc, cudnn
-from tvm.contrib.hexagon import pytest_plugin as hexagon
+import tvm.contrib.hexagon._ci_env_check as hexagon
 from tvm.error import TVMError
 
 


### PR DESCRIPTION
These were enabled in https://github.com/apache/tvm/pull/11294, then erroneously disabled in https://github.com/apache/tvm/pull/11313.  This applies the same fix as in https://github.com/apache/tvm/pull/11294, checking the `ANDROID_SERIAL_NUMBER` to determine if Hexagon tests can execute at runtime, but using the refactored `pytest.skipif` messages introduced in https://github.com/apache/tvm/pull/11313.

cc @Mousius @areusch @driazati @mehrdadh