### PR TITLE
[BYOC][TENSORRT] minor fix after loading trt engine from disk

### DIFF
--- a/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
@@ -376,7 +376,8 @@ class TensorRTRuntime : public JSONRuntimeBase {
     helper.DeclareField("batch_size", &batch_size);
     helper.ReadAllFields(&reader);
     trt_engine_cache_[std::make_pair(symbol_name_, batch_size)] = engine_and_context;
-    LOG(INFO) << "finished saving engine and context ... ";
+    max_batch_size_ = batch_size;
+    LOG(INFO) << "finished loading engine and context ... ";
     return true;
   }
 


### PR DESCRIPTION
Before the fix, after `GetCachedEnginesFromDisk()`, `max_batch_size_` is `-1` which results in the [batch_size <= max_batch_size_](https://github.com/apache/tvm/blob/main/src/runtime/contrib/tensorrt/tensorrt_runtime.cc#L258) to be `False`. Engine will be rebuilt because [find_engine_flag](https://github.com/apache/tvm/blob/main/src/runtime/contrib/tensorrt/tensorrt_runtime.cc#L276) is `False`.

Log before the fix:
```
[19:41:41] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:356: Loading cached TensorRT engine from ./tvmgen_default_tensorrt_main_0_fp32.plan
[19:41:43] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:379: finished saving engine and context ... 
[19:41:43] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:356: Loading cached TensorRT engine from ./tvmgen_default_tensorrt_main_1_fp32.plan
[19:41:43] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:379: finished saving engine and context ... 
[19:41:43] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:287: Building new TensorRT engine for subgraph tvmgen_default_tensorrt_main_0 with batch size 1
```
Log after the fix:
```
[19:42:46] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:356: Loading cached TensorRT engine from ./tvmgen_default_tensorrt_main_0_fp32.plan
[19:42:48] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:380: finished loading engine and context ... 
[19:42:48] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:356: Loading cached TensorRT engine from ./tvmgen_default_tensorrt_main_1_fp32.plan
[19:42:48] /home/ubuntu/neo-ai/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_runtime.cc:380: finished loading engine and context ... 
```