### PR TITLE
[microTVM] Remove microTVM RVM version suffix

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -479,7 +479,7 @@ def release_command(args):
     if args.release_full_name:
         vm_name = args.release_full_name
     else:
-        vm_name = f"tlcpack/microtvm-{args.platform}-{args.platform_version}"
+        vm_name = f"tlcpack/microtvm-{args.platform}"
 
     if not args.skip_creating_release_version:
         subprocess.check_call(
@@ -605,29 +605,17 @@ def parse_args():
         help="Skip creating the version and just upload for this provider.",
     )
     parser_release.add_argument(
-        "--platform-version",
-        required=False,
-        help=(
-            "For Zephyr, the platform version to release, in the form 'x.y'. "
-            "For Arduino, the version of arduino-cli that's being used, in the form 'x.y.z'."
-        ),
-    )
-    parser_release.add_argument(
         "--release-full-name",
         required=False,
         type=str,
         default=None,
         help=(
             "If set, it will use this as the full release name and version for the box. "
-            "If this set, it will ignore `--platform-version` and `--release-version`."
+            "If this set, it will ignore `--release-version`."
         ),
     )
 
     args = parser.parse_args()
-
-    if args.action == "release" and not args.release_full_name:
-        parser.error("--platform-version is requireed.")
-
     return args
 
 


### PR DESCRIPTION
This PR removes the version from the names of the microTVM reference VMs on Vagrant Cloud.

In the past, the reference VMs for microTVM had names like `microtvm-zephyr-2.7` or `microtvm-arduino-0.18.3`. This made some sense for Zephyr, as much of the functionality of Zephyr is tied only to the version number. However, it never made much sense for Arduino (as the `arduino-cli` SDK version does not affect behavior very much - only the board SDK versions do), and it is unlikely this naming scheme would make sense as we add more types of RVMs.

Even for Zephyr, this naming scheme forces us to have multiple RVMs listed on Vagrant Hub, even though we only update one (microtvm-zephyr-2.7, the least downloaded one). By changing the RVM names to `microtvm-zephyr` and `microtvm-arduino`, the naming scheme will make more sense for non-Zephyr boards, and will make the Zephyr RVM versioning less confusing. 

With this change, versions for `arduino-cli` and Zephyr will instead be set by the scripts that build the reference VMs (the same way we do board SDK versioning).

cc @alanmacd @gromero @mehrdadh