### PR TITLE
[microTVM] Add support for Arduino Portenta H7

### DIFF
--- a/apps/microtvm/arduino/template_project/boards.json
+++ b/apps/microtvm/arduino/template_project/boards.json
@@ -41,6 +41,14 @@
         "vid_hex": "2341",
         "pid_hex": "805a"
     },
+    "portentah7": {
+        "package": "arduino",
+        "architecture": "mbed_portenta",
+        "board": "envie_m7",
+        "model": "stm32h7xx",
+        "vid_hex": "2341",
+        "pid_hex": "025b"
+    },
     "pybadge": {
         "package": "adafruit",
         "architecture": "samd",

--- a/apps/microtvm/reference-vm/arduino/README.md
+++ b/apps/microtvm/reference-vm/arduino/README.md
@@ -32,6 +32,7 @@ This RVM has been tested and is known to work with these boards:
 - Adafruit Pybadge
 - Arduino Due
 - Arduino Nano 33 BLE
+- Arduino Portenta H7
 - Feather S2
 - Sony Spresense
 - Wio Terminal

--- a/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
+++ b/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
@@ -54,9 +54,18 @@ arduino-cli core update-index --additional-urls $ADAFRUIT_BOARDS_URL,$ESP32_BOAR
 arduino-cli version
 arduino-cli core install arduino:mbed_nano@3.0.1
 arduino-cli core install arduino:sam@1.6.12
+arduino-cli core install arduino:mbed_portenta@3.1.1
 arduino-cli core install adafruit:samd@1.7.10 --additional-urls $ADAFRUIT_BOARDS_URL
 arduino-cli core install esp32:esp32@2.0.2 --additional-urls $ESP32_BOARDS_URL
 arduino-cli core install SPRESENSE:spresense@2.5.0 --additional-urls $SPRESENSE_BOARDS_URL
+
+# The Arduino Code API has a major bug that breaks TVM. It has been worked around in
+# most board SDKs (including arduino:sam), but it still exists for the Portenta H7.
+# There is a PR to fix it (https://github.com/arduino/ArduinoCore-API/pull/163), but
+# it may not be merged for a while (and a new release will have to be deployed too).
+# The below sed command avoids the bug, and will be removed when no longer needed.
+PORTENTA_H7_BUGFIX_PATH=~/.arduino15/packages/arduino/hardware/mbed_portenta/3.1.1/cores/arduino/api/Common.h
+sed -i '3 i #include <stdbool.h>' $PORTENTA_H7_BUGFIX_PATH
 
 # Cleanup
 rm -f *.sh

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -428,6 +428,7 @@ MICRO_SUPPORTED_MODELS = {
     "nrf5340dk": ["-mcpu=cortex-m33"],
     "sam3x8e": ["-mcpu=cortex-m3"],
     "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
+    "stm32h7xx": ["-mcpu=cortex-m7"],
     "stm32l4r5zi": ["-mcpu=cortex-m4"],
     "stm32u5xx": ["-mcpu=cortex-m33"],
     "zynq_mp_r5": ["-mcpu=cortex-r5"],


### PR DESCRIPTION
Adds microTVM support for the Arduino Portenta H7, from the Arduino Pro line of boards. I've been asked about this a few times (including at TVMCon) and finally got around to it.

Unfortunately, this is not as easy as it should be, because of [a bug in the Arduino Core API](https://github.com/arduino/ArduinoCore-API/pull/163). I have a PR out to fix it, but it might take some time to get merged and included in a release. Until that occurs, I've included a workaround in `base_box_provision.sh`.

cc @alanmacd @gromero @mehrdadh