### PR TITLE
[CI] fix ci_gpu dockerfile

### DIFF
--- a/docker/install/ubuntu_install_papi.sh
+++ b/docker/install/ubuntu_install_papi.sh
@@ -23,11 +23,15 @@ set -o pipefail
 apt-get update --fix-missing
 
 # deps
-apt-get install -y linux-tools-common linux-tools-generic
+apt-get install -y linux-tools-common linux-tools-generic kmod
 
 cd /
 git clone https://bitbucket.org/icl/papi.git
-cd papi/src
+# Pulling the latest version of this has broken the images before. Checkout the tagged version below for now.
+cd papi
+git checkout papi-6-0-0-1-t
+cd src
 export PAPI_CUDA_ROOT=/usr/local/cuda
+export PAPI_ROCM_ROOT=/opt/rocm
 ./configure --with-components="$1"
 make -j $(nproc) && make install

--- a/docs/how_to/profile/papi.rst
+++ b/docs/how_to/profile/papi.rst
@@ -34,6 +34,7 @@ PAPI can either be installed using your package manager (``apt-get install libpa
 on Ubuntu), or from source here:
 https://bitbucket.org/icl/papi/src/master/.
 
+Pulling the latest version of PAPI from source has caused build issues before. Therefore, it is recommended to checkout tagged version ``papi-6-0-0-1-t``.
 
 Building TVM With PAPI
 ----------------------


### PR DESCRIPTION
It seems that [this PR](https://bitbucket.org/icl/papi/pull-requests/251/20220111-rocm-rewrite) broke our installation of papi in the `ci_gpu` docker image.

This PR fixes it.

Edit: check [this build](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11470/16/pipeline/50) for the failure. The same error occurs when building the image locally on main. 

@areusch @driazati 

cc @Mousius