### PR TITLE
[docs] Add links to v0.8.0 docs

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -33,7 +33,7 @@ pip3 install --upgrade \
     Pillow==9.1.0 \
     psutil \
     pytest \
-    tlcpack-sphinx-addon==0.2.1 \
+    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@14906063f938b7569e40f3d47a0ca39c181fb6ea \
     pytest-profiling \
     pytest-xdist \
     requests \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ sys.path.insert(0, str(tvm_path.resolve() / "docs"))
 # General information about the project.
 project = "tvm"
 author = "Apache Software Foundation"
-copyright = "2020 - 2021, %s" % author
+copyright = "2020 - 2022, %s" % author
 github_doc_root = "https://github.com/apache/tvm/tree/main/docs/"
 
 os.environ["TVM_BUILD_DOC"] = "1"
@@ -383,10 +383,10 @@ tvm_alias_check_map = {
 ## Setup header and other configs
 import tlcpack_sphinx_addon
 
-footer_copyright = "© 2020 Apache Software Foundation | All right reserved"
+footer_copyright = "© 2022 Apache Software Foundation | All rights reserved"
 footer_note = " ".join(
     """
-Copyright © 2020 The Apache Software Foundation. Apache TVM, Apache, the Apache feather,
+Copyright © 2022 The Apache Software Foundation. Apache TVM, Apache, the Apache feather,
 and the Apache TVM project logo are either trademarks or registered trademarks of
 the Apache Software Foundation.""".split(
         "\n"
@@ -425,6 +425,7 @@ html_context = {
     "header_dropdown": header_dropdown,
     "header_logo": header_logo,
     "header_logo_link": header_logo_link,
+    "version_prefixes": ["main", "v0.8.0/"],
 }
 
 # add additional overrides


### PR DESCRIPTION
This uses the new code from https://github.com/tlc-pack/tlcpack-sphinx-addon/pull/5 with a link to the v0.8.0 docs. We can update this in the future as we add more releases. This also updates the docker image to always use the latest tlcpack-sphinx-addon. This should be relatively safe since we own that code anyways

cc @areusch 

