### PR TITLE
[CI] Apply linting rules to AOT tests

### DIFF
--- a/tests/lint/pylint.sh
+++ b/tests/lint/pylint.sh
@@ -21,4 +21,5 @@ python3 -m pylint python/tvm --rcfile="$(dirname "$0")"/pylintrc
 python3 -m pylint vta/python/vta --rcfile="$(dirname "$0")"/pylintrc
 python3 -m pylint tests/python/unittest/test_tvmscript_type.py --rcfile="$(dirname "$0")"/pylintrc
 python3 -m pylint tests/python/contrib/test_cmsisnn --rcfile="$(dirname "$0")"/pylintrc
+python3 -m pylint tests/python/relay/aot/*.py --rcfile="$(dirname "$0")"/pylintrc
 


### PR DESCRIPTION
This enables pylint against the AOT test cases.

One issue I found was with the `tvm.testing.parameter` which breaks the naming convention rules in pylint (constants are upper case and function parameters are lower case). It may be worth a syntax similar to:

```
tvm.testing.parameter("enable_usmp", [True, False])
```


cc @areusch @driazati