### PR TITLE
[BUG] Disable second PlanDevices pass

### DIFF
--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -244,6 +244,7 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
         host_virtual_device_(std::move(host_virtual_device)) {}
 
   VMFunction Compile(const GlobalVar& var, const Function& func) {
+    VLOG(1) << "Compiling:" << std::endl << PrettyPrint(func);
     std::vector<Index> param_device_indexes;
     if (IsClosure(func)) {
       // After lifting we'll have functions of the form:

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -1103,9 +1103,8 @@ IRModule VMCompiler::OptimizeModuleImpl(IRModule mod) {
   // let-bound functions.
   pass_seqs.push_back(DeadCodeElimination(/*inline_once=*/false));
 
-  // Now that we have PrimFuncs, flow and solve VirtualDevice constraints again to account for
-  // any memory scopes which lowering has settled on.
-  pass_seqs.push_back(transform::PlanDevices(config_));
+  // At this point it's possible to run PlanDevices again to pick up any additional constraints
+  // introduced during lowering. However we'll not do this until more testing has been done.
 
   // Inline the functions that are lifted to the module scope. We perform this
   // pass after all other optimization passes but before the memory allocation

--- a/tests/python/relay/test_mre_ssd.py
+++ b/tests/python/relay/test_mre_ssd.py
@@ -1,0 +1,37 @@
+"""SSD Minimum Reproducible Example"""
+from os import path as osp
+
+import tvm
+from tvm.meta_schedule import ApplyHistoryBest
+from tvm.meta_schedule.database import JSONDatabase
+from tvm.meta_schedule.utils import autotvm_silencer
+from tvm.relay.frontend import from_onnx
+from tvm.relay import vm
+from tvm.ir.transform import PassContext
+import numpy as np
+import onnx
+
+
+if __name__ == "__main__":
+    work_dir = "/home/mbs/github/mbs-tvm/tests/python/relay/"
+    onnx_model = onnx.load_model(osp.join(work_dir, "ssd.onnx"))
+    database = JSONDatabase(
+        osp.join(work_dir, "database_workload.json"),
+        osp.join(work_dir, "database_tuning_record.json"),
+    )
+    target = tvm.target.Target("nvidia/geforce-rtx-3070")
+    dev = tvm.cuda()
+    shape_dict = {"image": [1, 3, 1200, 1200]}
+    datas = {
+        "image": tvm.nd.array(np.random.randn(1, 3, 1200, 1200).astype("float32"), dev),
+    }
+    mod, params = from_onnx(onnx_model, shape_dict, freeze_params=True)
+    print("----------------------")
+    print(mod)
+    print("----------------------")
+    with target, autotvm_silencer(), ApplyHistoryBest(database):
+        with PassContext(
+                opt_level=3,
+                config={"relay.backend.use_meta_schedule": True},
+        ):
+            vm_exec = vm.compile(mod, target=target, params=params)


### PR DESCRIPTION
Though started with the best of intentions, the second
PlanDevices pass to account for memory scope's introduced
by lowering is buggy and not ready for prime time. It
has caused an ICHECK fail since for some reason the new
constraints are not flowing into device_copies.