### PR TITLE
[ci][docker] Automatically update docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ gallery/how_to/work_with_microtvm/micro_tvmc.py
 
 # Test sample data files
 !tests/python/ci/sample_prs/*.json
+
+# Used in CI to communicate between Python and Jenkins
+.docker-image-names/

--- a/jenkins/Deploy.groovy.j2
+++ b/jenkins/Deploy.groovy.j2
@@ -86,7 +86,7 @@ def deploy() {
         }
       }
     }
-    if (env.BRANCH_NAME == 'main' && env.DEPLOY_DOCKER_IMAGES == 'yes' && rebuild_docker_images && upstream_revision != null) {
+    if (env.BRANCH_NAME == 'main' && env.PUSH_DOCKER_IMAGES == 'yes' && rebuild_docker_images && upstream_revision != null) {
       node('CPU') {
         ws({{ m.per_exec_ws('tvm/deploy-docker') }}) {
           try {

--- a/jenkins/Prepare.groovy.j2
+++ b/jenkins/Prepare.groovy.j2
@@ -145,13 +145,6 @@ def prepare() {
         {{ image.name }} = params.{{ image.name }}_param ?: {{ image.name }}
         {% endfor %}
 
-        sh (script: """
-          echo "Docker images being used in this build:"
-          {% for image in images %}
-          echo " {{ image.name }} = ${ {{- image.name -}} }"
-          {% endfor %}
-        """, label: 'Docker image names')
-
         is_docs_only_build = sh (
           returnStatus: true,
           script: './tests/scripts/git_change_docs.sh',
@@ -161,13 +154,32 @@ def prepare() {
         skip_slow_tests = should_skip_slow_tests(env.CHANGE_ID)
         rebuild_docker_images = sh (
           returnStatus: true,
-          script: './tests/scripts/git_change_docker.sh',
+          script: './tests/scripts/should_rebuild_docker.py',
           label: 'Check for any docker changes',
         )
         if (skip_ci) {
           // Don't rebuild when skipping CI
           rebuild_docker_images = false
         }
+        if (!rebuild_docker_images) {
+          // Pull image names from the results of should_rebuild_docker.py
+          if (env.USE_AUTOUPDATED_DOCKER_IMAGES == 'yes') {
+            {% for image in images %}
+            {{ image.name }} = sh(
+              script: "cat .docker-image.names/{{ image.name }}",
+              label: "Find docker image name for {{ image.name }}",
+              returnStdout: true,
+            ).trim()
+            {% endfor %}
+          }
+        }
+
+        sh (script: """
+          echo "Docker images being used in this build:"
+          {% for image in images %}
+          echo " {{ image.name }} = ${ {{- image.name -}} }"
+          {% endfor %}
+        """, label: 'Docker image names')
       }
     }
   }


### PR DESCRIPTION
This activates the code from #11329 behind a couple Jenkins flags:
* `USE_AUTOUPDATED_DOCKER_IMAGES` - whether or not to use the dynamically determined docker images in the build
* `PUSH_DOCKER_IMAGES` - whether or not to push built images to `tlcpack` on `main`

These are there so we can quickly toggle this behavior off it breaks anything. Once this is on though, any docker changes in a PR should be reflected entirely in that build, so there would be no need for a separate PR to update the Docker images.

We will have to see if this works in practice, as the docker image builds do download quite a bit of data (which can flake) and add some runtime overhead (about 30m), so when an update lands all PRs will end up needing to rebuild until the merged commit finishes.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @Mousius @areusch