### PR TITLE
[FIX,METASCHEDULER] Fix tune_te

### DIFF
--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -404,6 +404,7 @@ def tune_tir(
     )
 
     # pylint: disable=protected-access
+    mod = default_config.mod(mod)
     target = default_config.target(target)
     # pylint: enable=protected-access
     database = tune_extracted_tasks(

--- a/tests/python/unittest/test_meta_schedule_tune_te.py
+++ b/tests/python/unittest/test_meta_schedule_tune_te.py
@@ -28,7 +28,6 @@ logging.basicConfig()
 logging.getLogger("tvm.meta_schedule").setLevel(logging.DEBUG)
 
 
-@pytest.mark.skip("Integration test")
 def test_tune_matmul():
     with tempfile.TemporaryDirectory() as work_dir:
         sch: Schedule = tune_te(
@@ -36,9 +35,9 @@ def test_tune_matmul():
             target=Target("llvm --num-cores=16"),
             config=TuneConfig(
                 strategy="replay_trace",
-                num_trials_per_iter=32,
-                max_trials_per_task=32,
-                max_trials_global=32,
+                num_trials_per_iter=1,
+                max_trials_per_task=1,
+                max_trials_global=1,
             ),
             work_dir=work_dir,
         )


### PR DESCRIPTION
`tune_te` was broken because it passed a primfunc to `tune_tir`. Now it is wrapped in an IRModule. Also the test is re-enabled.

@junrushao1994 @zxybazh 