### PR TITLE
Fix onnx round import with float64 inputs.

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -5095,9 +5095,10 @@ class Round(OnnxOpConverter):
         # Onnx round uses Banker's rounding which rounds .5 to the nearest even integer
 
         x = inputs[0]
-        half = _expr.const(0.5, dtype="float32")
-        one = _expr.const(1, dtype="float32")
-        two = _expr.const(2, dtype="float32")
+        dtype = infer_type(x).checked_type.dtype
+        half = _expr.const(0.5, dtype=dtype)
+        one = _expr.const(1, dtype=dtype)
+        two = _expr.const(2, dtype=dtype)
 
         rounded = _op.ceil(x - half)
         bankers_mask = one - (_op.ceil(x + half) - _op.floor(x + half))

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -973,17 +973,13 @@ def _test_onnx_op_elementwise(
 
     y = helper.make_node(opname, ["in"], ["out"], **kwargs)
 
-    onnx_dtype = {
-        'float16': TensorProto.FLOAT16,
-        'float32': TensorProto.FLOAT,
-        'float64': TensorProto.DOUBLE,
-    }[dtype]
+    ONNX_DTYPE = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(dtype)]
 
     graph = helper.make_graph(
         [y],
         opname + "_test",
-        inputs=[helper.make_tensor_value_info("in", onnx_dtype, list(indata.shape))],
-        outputs=[helper.make_tensor_value_info("out", onnx_dtype, list(outdata.shape))],
+        inputs=[helper.make_tensor_value_info("in", ONNX_DTYPE, list(indata.shape))],
+        outputs=[helper.make_tensor_value_info("out", ONNX_DTYPE, list(outdata.shape))],
     )
 
     model = helper.make_model(graph, producer_name=opname + "_test")
@@ -1002,7 +998,6 @@ def _test_onnx_op_elementwise(
             opset=opset,
             opt_level=3,
         )
-
 
 
 @tvm.testing.parametrize_targets
@@ -1077,7 +1072,9 @@ def test_clip_min_max_as_inputs(target, dev):
 @tvm.testing.parametrize_targets
 def test_round(target, dev):
     _test_onnx_op_elementwise(target, dev, (2, 4, 5, 6), np.round, {}, "float32", "Round", {})
-    _test_onnx_op_elementwise(target, dev, (2, 4, 5, 6), np.round, {}, "float64", "Round", {}, verify=False) # enable verification once ORT supports float64
+    _test_onnx_op_elementwise(
+        target, dev, (2, 4, 5, 6), np.round, {}, "float64", "Round", {}, verify=False
+    )  # TODO: enable verification once ORT supports float64
 
 
 def _test_finite_ops(target, dev, inshape, outfunc, npargs, dtype, opname, kwargs):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -966,24 +966,43 @@ def test_slice(target, dev):
 
 
 def _test_onnx_op_elementwise(
-    target, dev, inshape, outfunc, npargs, dtype, opname, kwargs, opset=None
+    target, dev, inshape, outfunc, npargs, dtype, opname, kwargs, opset=None, verify=True
 ):
     indata = np.random.uniform(-1, 1, size=inshape).astype(dtype)
     outdata = outfunc(indata, **npargs)
 
     y = helper.make_node(opname, ["in"], ["out"], **kwargs)
 
+    onnx_dtype = {
+        'float16': TensorProto.FLOAT16,
+        'float32': TensorProto.FLOAT,
+        'float64': TensorProto.DOUBLE,
+    }[dtype]
+
     graph = helper.make_graph(
         [y],
         opname + "_test",
-        inputs=[helper.make_tensor_value_info("in", TensorProto.FLOAT, list(indata.shape))],
-        outputs=[helper.make_tensor_value_info("out", TensorProto.FLOAT, list(outdata.shape))],
+        inputs=[helper.make_tensor_value_info("in", onnx_dtype, list(indata.shape))],
+        outputs=[helper.make_tensor_value_info("out", onnx_dtype, list(outdata.shape))],
     )
 
     model = helper.make_model(graph, producer_name=opname + "_test")
-    verify_with_ort_with_inputs(
-        model, [indata], [outdata.shape], opset=opset, dtype=dtype, target=target, dev=dev
-    )
+    if verify:
+        verify_with_ort_with_inputs(
+            model, [indata], [outdata.shape], opset=opset, dtype=dtype, target=target, dev=dev
+        )
+    else:
+        get_tvm_output(
+            model,
+            [indata],
+            target,
+            dev,
+            [outdata.shape],
+            dtype,
+            opset=opset,
+            opt_level=3,
+        )
+
 
 
 @tvm.testing.parametrize_targets
@@ -1058,6 +1077,7 @@ def test_clip_min_max_as_inputs(target, dev):
 @tvm.testing.parametrize_targets
 def test_round(target, dev):
     _test_onnx_op_elementwise(target, dev, (2, 4, 5, 6), np.round, {}, "float32", "Round", {})
+    _test_onnx_op_elementwise(target, dev, (2, 4, 5, 6), np.round, {}, "float64", "Round", {}, verify=False) # enable verification once ORT supports float64
 
 
 def _test_finite_ops(target, dev, inshape, outfunc, npargs, dtype, opname, kwargs):


### PR DESCRIPTION
This simple PR fixes the unhandled float64 case introduced by #11446. Without the change, TVM won't be able to import any ONNX Round operator with float64 inputs, and will complain with error `data types float64 and float32 do not match in BroadcastRel`.
cc: @AndrewZhaoLuo @jwfromm @CircleSpin 