### PR TITLE
Added a docstring to missing CMSIS-NN test

### DIFF
--- a/tests/python/contrib/test_cmsisnn/test_generate_constants.py
+++ b/tests/python/contrib/test_cmsisnn/test_generate_constants.py
@@ -51,6 +51,7 @@ class CheckGeneratedConstants(tvm.relay.ExprVisitor):
         self.shift_ = shift
 
     def visit_call(self, call):
+        """Tests if the multiplier and shift constants required by CMSIS-NN API were generated"""
         super().visit_call(call)
         if isinstance(call.op, tvm.ir.expr.GlobalVar):
             multiplier = call.args[2]

--- a/tests/python/contrib/test_cmsisnn/utils.py
+++ b/tests/python/contrib/test_cmsisnn/utils.py
@@ -204,6 +204,7 @@ def get_conv2d_qnn_params(
     return output_scale, output_zp
 
 
+# pylint: disable=inconsistent-return-statements
 def make_qnn_relu(expr, fused_activation_fn, scale, zero_point, dtype):
     """Mimics convert_qnn_fused_activation_function from TFLite frontend"""
     quantize = lambda x: float(int(round(x / scale)) + zero_point)
@@ -224,5 +225,4 @@ def make_qnn_relu(expr, fused_activation_fn, scale, zero_point, dtype):
         )
     if fused_activation_fn == "RELU":
         return tvm.relay.op.clip(expr, a_min=max(qmin, quantize(0.0)), a_max=qmax)
-
     raise ValueError("Invalid argument provided with fused_activation_fn")

--- a/tests/python/contrib/test_cmsisnn/utils.py
+++ b/tests/python/contrib/test_cmsisnn/utils.py
@@ -204,7 +204,6 @@ def get_conv2d_qnn_params(
     return output_scale, output_zp
 
 
-# pylint: disable=inconsistent-return-statements
 def make_qnn_relu(expr, fused_activation_fn, scale, zero_point, dtype):
     """Mimics convert_qnn_fused_activation_function from TFLite frontend"""
     quantize = lambda x: float(int(round(x / scale)) + zero_point)


### PR DESCRIPTION
Added a missing docstring to CMSIS-NN test that checks for CMSIS-NN constants. The issue is related to https://github.com/apache/tvm/pull/11625.