### PR TITLE
[MetaSchedule] Apply-History-Best Task Filtering

### DIFF
--- a/include/tvm/meta_schedule/extracted_task.h
+++ b/include/tvm/meta_schedule/extracted_task.h
@@ -27,6 +27,15 @@
 #include <tvm/target/target.h>
 
 namespace tvm {
+namespace tir {
+class PrimFunc;
+}  // namespace tir
+namespace te {
+class Tensor;
+}  // namespace te
+}  // namespace tvm
+
+namespace tvm {
 namespace meta_schedule {
 
 /*! \brief A tuning task extracted from the high-level IR */
@@ -66,6 +75,20 @@ class ExtractedTask : public runtime::ObjectRef {
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ExtractedTask, runtime::ObjectRef,
                                                     ExtractedTaskNode);
 };
+
+/*!
+ * \brief The default TE task filter
+ * \param args The input/output arguments of the TE compute graph
+ * \return NullOpt if the task is filtered out, otherwise the task in PrimFunc
+ */
+Optional<tvm::tir::PrimFunc> DefaultTaskFilter(const Array<tvm::te::Tensor, void>& args);
+
+/*!
+ * \brief The default TE task filter, with `te.extern` allowed
+ * \param args The input/output arguments of the TE compute graph
+ * \return NullOpt if the task is filtered out, otherwise the task in PrimFunc
+ */
+Optional<tir::PrimFunc> DefaultTaskFilterAllowExtern(const Array<tvm::te::Tensor, void>& args);
 
 }  // namespace meta_schedule
 }  // namespace tvm

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -26,6 +26,7 @@
 #include <tvm/meta_schedule/builder.h>
 #include <tvm/meta_schedule/cost_model.h>
 #include <tvm/meta_schedule/database.h>
+#include <tvm/meta_schedule/extracted_task.h>
 #include <tvm/meta_schedule/feature_extractor.h>
 #include <tvm/meta_schedule/measure_callback.h>
 #include <tvm/meta_schedule/profiler.h>

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -31,48 +31,12 @@ namespace tvm {
 namespace relay {
 namespace backend {
 
-bool DefaultTaskFilter(const Array<te::Tensor>& args) {
-  using namespace ::tvm::te;
-  std::vector<Tensor> stack;
-  std::unordered_set<const TensorNode*> visited;
-  for (const Tensor& v : args) {
-    for (const PrimExpr& e : v->shape) {
-      // Dynamic shape is not supported for now
-      if (!e->IsInstance<IntImmNode>()) {
-        return false;
-      }
-    }
-    if (!visited.count(v.get())) {
-      visited.insert(v.get());
-      stack.push_back(v);
-    }
-  }
-  while (!stack.empty()) {
-    Tensor tensor = stack.back();
-    stack.pop_back();
-    if (tensor->op->IsInstance<PlaceholderOpNode>()) {
-      // do nothing
-    } else if (tensor->op->IsInstance<ComputeOpNode>() || tensor->op->IsInstance<ExternOpNode>()) {
-      Array<Tensor> inputs = tensor->op->InputTensors();
-      for (const Tensor& v : inputs) {
-        if (!visited.count(v.get())) {
-          visited.insert(v.get());
-          stack.push_back(v);
-        }
-      }
-    } else {
-      return false;
-    }
-  }
-  return true;
-}
-
 Array<meta_schedule::ExtractedTask> ExtractTask(
     IRModule mod, Target target, Map<String, runtime::NDArray> params,
-    runtime::TypedPackedFunc<bool(const Array<te::Tensor>&)> filter_func) {
+    runtime::TypedPackedFunc<Optional<tir::PrimFunc>(const Array<te::Tensor>&)> filter_func) {
   using meta_schedule::ExtractedTask;
   if (filter_func == nullptr) {
-    filter_func = DefaultTaskFilter;
+    filter_func = tvm::meta_schedule::DefaultTaskFilter;
   }
   backend::BindParamsInModule(mod, params);
   // is_vm=true for backward compatibility
@@ -98,11 +62,10 @@ Array<meta_schedule::ExtractedTask> ExtractTask(
       std::string fused_name;
       std::tie(inputs_outputs, fused_name) =
           tec::LowerTECompute(relay_func, target, /*return_inputs=*/true);
-      if (filter_func(inputs_outputs)) {
-        tir::PrimFunc prim_func = tir::CreatePrimFunc(inputs_outputs);
+      if (Optional<tir::PrimFunc> prim_func = filter_func(inputs_outputs)) {
         GlobalVar prim_fn_var(fused_name);
         IRModule relay_mod({{prim_fn_var, relay_func}});
-        IRModule tir_mod({{prim_fn_var, prim_func}});
+        IRModule tir_mod({{prim_fn_var, prim_func.value()}});
         ExtractedTask extracted_task(fused_name, relay_mod, target, {tir_mod}, 1);
         tasks.push_back(extracted_task);
         cache.emplace(cache_key, extracted_task);

--- a/tests/python/unittest/test_meta_schedule_relay_tir_compute.py
+++ b/tests/python/unittest/test_meta_schedule_relay_tir_compute.py
@@ -18,7 +18,7 @@ import numpy as np
 import tvm
 import tvm.testing
 import tvm.topi.testing
-from tvm import autotvm, relay, te, tir
+from tvm import autotvm, relay, te
 from tvm.meta_schedule import ApplyHistoryBest
 from tvm.meta_schedule.testing.utils import apply_fixed_schedules
 from tvm.relay.testing.temp_op_attr import TempOpAttr
@@ -147,8 +147,17 @@ def test_conv2d():
         return False
 
     with TempOpAttr("nn.conv2d", "FTVMStrategy", _tmp_strategy):
-        database = apply_fixed_schedules(relay_mod, target, params, schedule_fn)
-        with ApplyHistoryBest(database):
+        database = apply_fixed_schedules(
+            relay_mod,
+            target,
+            params,
+            schedule_fn,
+            te_filter_func="meta_schedule.DefaultTaskFilterAllowExtern",
+        )
+        with ApplyHistoryBest(
+            database,
+            te_filter_func="meta_schedule.DefaultTaskFilterAllowExtern",
+        ):
             with tvm.transform.PassContext(
                 opt_level=3,
                 config={"relay.backend.use_meta_schedule": True},


### PR DESCRIPTION
This PR enables task filtering in Apply-History-Best, which is used in
Relay/Relax integration. Previously, even though a task is ruled out
during task extraction, it still shows up in Relay compilation due to
the lack of filtering on `Apply-History-Best`. However, TE-to-TIR
conversion `te.CreatePrimFunc` doesn't support all cases with hybrid
operators involved, which leads to post-tuning failure affecting
multiple models.