### PR TITLE
[microTVM] Add support for the Raspberry Pi Pico via Arduino

### DIFF
--- a/apps/microtvm/arduino/template_project/boards.json
+++ b/apps/microtvm/arduino/template_project/boards.json
@@ -57,6 +57,14 @@
         "vid_hex": "",
         "pid_hex": ""
     },
+    "rpipico": {
+        "package": "rp2040",
+        "architecture": "rp2040",
+        "board": "rpipico",
+        "model": "rp2040",
+        "vid_hex": "2e8a",
+        "pid_hex": "000a",
+    },
     "teensy40": {
         "package": "teensy",
         "architecture": "avr",

--- a/apps/microtvm/arduino/template_project/boards.json
+++ b/apps/microtvm/arduino/template_project/boards.json
@@ -63,7 +63,7 @@
         "board": "rpipico",
         "model": "rp2040",
         "vid_hex": "2e8a",
-        "pid_hex": "000a",
+        "pid_hex": "000a"
     },
     "teensy40": {
         "package": "teensy",

--- a/apps/microtvm/reference-vm/arduino/README.md
+++ b/apps/microtvm/reference-vm/arduino/README.md
@@ -34,6 +34,7 @@ This RVM has been tested and is known to work with these boards:
 - Arduino Nano 33 BLE
 - Arduino Portenta H7
 - Feather S2
+- Raspberry Pi Pico
 - Sony Spresense
 - Wio Terminal
 

--- a/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
+++ b/apps/microtvm/reference-vm/arduino/base-box/base_box_provision.sh
@@ -46,9 +46,10 @@ sudo usermod -a -G dialout $USER
 
 # 3rd party board URLs
 ADAFRUIT_BOARDS_URL="https://raw.githubusercontent.com/adafruit/arduino-board-index/7840c768/package_adafruit_index.json"
-ESP32_BOARDS_URL="https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
+ESP32_BOARDS_URL="https://github.com/espressif/arduino-esp32/releases/download/2.0.3/package_esp32_dev_index.json"
+RP2040_BOARDS_URL="https://github.com/earlephilhower/arduino-pico/releases/download/2.0.3/package_rp2040_index.json"
 SPRESENSE_BOARDS_URL="https://github.com/sonydevworld/spresense-arduino-compatible/releases/download/v2.5.0/package_spresense_index.json"
-arduino-cli core update-index --additional-urls $ADAFRUIT_BOARDS_URL,$ESP32_BOARDS_URL,$SPRESENSE_BOARDS_URL
+arduino-cli core update-index --additional-urls $ADAFRUIT_BOARDS_URL,$ESP32_BOARDS_URL,$RP2040_BOARDS_URL,$SPRESENSE_BOARDS_URL
 
 # Install supported cores from those URLS
 arduino-cli version
@@ -57,6 +58,7 @@ arduino-cli core install arduino:sam@1.6.12
 arduino-cli core install arduino:mbed_portenta@3.1.1
 arduino-cli core install adafruit:samd@1.7.10 --additional-urls $ADAFRUIT_BOARDS_URL
 arduino-cli core install esp32:esp32@2.0.2 --additional-urls $ESP32_BOARDS_URL
+arduino-cli core install rp2040:rp2040@2.0.3 --additional-urls $RP2040_BOARDS_URL
 arduino-cli core install SPRESENSE:spresense@2.5.0 --additional-urls $SPRESENSE_BOARDS_URL
 
 # The Arduino Code API has a major bug that breaks TVM. It has been worked around in

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -432,6 +432,7 @@ MICRO_SUPPORTED_MODELS = {
     "mps3_an547": ["-mcpu=cortex-m55"],
     "nrf52840": ["-mcpu=cortex-m4"],
     "nrf5340dk": ["-mcpu=cortex-m33"],
+    "rp2040": ["-mcpu=cortex-m0"],
     "sam3x8e": ["-mcpu=cortex-m3"],
     "stm32f746xx": ["-mcpu=cortex-m7", "-march=armv7e-m"],
     "stm32h7xx": ["-mcpu=cortex-m7"],


### PR DESCRIPTION
Adds microTVM support for the Raspberry Pi Pico, which uses the Raspberry Pi foundation's RP2040 microcontroller. It worked out of the box when using the [community-built SDK](https://github.com/earlephilhower/arduino-pico), so this PR only includes changes to add it to the RVM and allow `rpipico` to be passed to TVMC.

It is worth noting that there is a [different, now-deprecated SDK](https://github.com/arduino/ArduinoCore-mbed) written by Arduino, which was also for the Raspberry Pi Pico. However, this SDK has [a major bug](https://github.com/arduino/ArduinoCore-API/pull/163) that stops microTVM from working on it. It's not an issue though, as the RP2040 version of this SDK is deprecated anyway.

This PR also fixes the ESP32 base URL to use a fixed version, instead of a floating one.

cc @alanmacd @gromero @mehrdadh