### PR TITLE
[CMSIS-NN] Fixed error in finding input's dtype in maxpool

### DIFF
--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -206,17 +206,17 @@ def pattern_table():
     def check_qnn_avg_pool2d(pattern):
         """Check if avg pool2d is supported by CMSIS-NN."""
         output = pattern
-        input_var = _find_last(pattern)
 
         if str(pattern.op.name) == "clip":
             pooling = pattern.args[0].args[0]
         else:
             pooling = pattern.args[0]
+        input_op = pooling.args[0].args[0]
 
         return (
             pooling.attrs.layout == "NHWC"
-            and bool(input_var.checked_type.shape[0] == 1)
-            and input_var.checked_type.dtype == "int8"
+            and int(input_op.checked_type.shape[0]) == 1
+            and input_op.checked_type.dtype == "int8"
             and output.checked_type.dtype == "int8"
         )
 
@@ -229,17 +229,18 @@ def pattern_table():
     def check_qnn_max_pool2d(pattern):
         """Check if max pool2d is supported by CMSIS-NN."""
         output = pattern
-        input_var = _find_last(pattern)
+        input_op = None
 
         if str(pattern.op.name) == "clip":
             pooling = pattern.args[0]
         else:
             pooling = pattern
+        input_op = pooling.args[0]
 
         return (
             pooling.attrs.layout == "NHWC"
-            and bool(input_var.checked_type.shape[0] == 1)
-            and input_var.checked_type.dtype == "int8"
+            and int(input_op.checked_type.shape[0]) == 1
+            and input_op.checked_type.dtype == "int8"
             and output.checked_type.dtype == "int8"
         )
 

--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -31,12 +31,6 @@ def enabled():
     return "cmsis-nn" in Target.list_kinds()
 
 
-def _find_last(pattern):
-    if hasattr(pattern, "args"):
-        return _find_last(pattern.args[0])
-    return pattern
-
-
 def partition_for_cmsisnn(mod, params=None, mod_name="default", **opts):
     """Partition the graph greedily offloading supported
     operators on Cortex-M using CMSIS-NN


### PR DESCRIPTION
In case of mixed dtypes appearing in the network,
pattern checker was not able to find correct dtype
of the input in the qnn maxpool sequence of ops.



cc @areusch