### PR TITLE
[tests][hexagon] Fix `allocate_hexagon_array` bug.

### DIFF
--- a/tests/python/contrib/test_hexagon/infrastructure.py
+++ b/tests/python/contrib/test_hexagon/infrastructure.py
@@ -48,7 +48,7 @@ def allocate_hexagon_array(
         for dim_i, dim_f in zip(boundaries[:-1], boundaries[1:])
     ]
 
-    arr = tvm.nd.empty(physical_shape, dtype=dtype, device=dev)
+    arr = tvm.nd.empty(physical_shape, dtype=dtype, device=dev, mem_scope=mem_scope)
 
     if data is not None:
         arr.copyfrom(data.reshape(physical_shape))


### PR DESCRIPTION
Fix bug where `allocate_hexagon_array` in `tests/python/contrib/test_hexagon/infrastructure.py` wasn't respecting the caller-specified `memory_scope`.

cc @mehrdadh