### PR TITLE
[Docker][Pylint] Use regexes for good names

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -32,7 +32,7 @@ RUN pip config set global.no-cache-dir false
 
 RUN apt-get update && apt-get install -y doxygen graphviz curl shellcheck
 
-RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
+RUN pip3 install cpplint pylint==2.9.3 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
 
 # Rust env (build early; takes a while)
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh

--- a/tests/lint/pylintrc
+++ b/tests/lint/pylintrc
@@ -240,9 +240,8 @@ redefining-builtins-modules=six.moves,future.builtins
 
 
 [BASIC]
-
-# Good variable names which should always be accepted, separated by a comma
-good-names=i,j,_,a,b,op,x,y,wd,lr,kv,k,v,s,p,h,c,m,n,X,t,g,f
+# Good variable names regexes, separated by a comma. 
+good-names-rgxs=^[_a-z][_a-z0-9]?$,[A-Z]
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=


### PR DESCRIPTION
Now that we are cleaning up the test directory (see https://github.com/apache/tvm/issues/11414), I thought this might be a good time to update pylint.

Depends on https://github.com/apache/tvm/issues/11733

Furthermore we partially relax rules for variable names to allow most 1-2 lower case character names and 1 character upper case names (which are used a lot in the tests).

Motivation:

A lot of tests are like:
```
def test_multi_kernel():
    # graph
    n = tvm.runtime.convert(1024)
    A = te.placeholder((n,), name="A")
    B = te.placeholder((n,), name="B")
    C = te.compute(A.shape, lambda *i: A(*i) + B(*i), name="C")
    D = te.compute(A.shape, lambda *i: A(*i) + C(*i), name="D")
    s = te.create_schedule(D.op)
    # create iter var and assign them tags.
    px, x = s[C].split(C.op.axis[0], nparts=1)
    s[C].bind(px, te.thread_axis("pipeline"))
    px, x = s[D].split(D.op.axis[0], nparts=1)
    s[D].bind(px, te.thread_axis("pipeline"))

    # one line to build the function.
    def check_device(device, host="llvm"):
        if not tvm.testing.device_enabled(device):
            return
        dev = tvm.device(device, 0)
        fadd = tvm.build(s, [A, B, C, D], device, host, name="myadd")
        dev = tvm.device(device, 0)
        # launch the kernel.
        n = 1024
        a = tvm.nd.array(np.random.uniform(size=n).astype(A.dtype), dev)
        b = tvm.nd.array(np.random.uniform(size=n).astype(B.dtype), dev)
        c = tvm.nd.array(np.random.uniform(size=n).astype(C.dtype), dev)
        d = tvm.nd.array(np.random.uniform(size=n).astype(D.dtype), dev)
        fadd(a, b, c, d)
        tvm.testing.assert_allclose(d.numpy(), a.numpy() * 2 + b.numpy(), rtol=1e-5)
```

Where capital letters represent TE placeholder tensors which seems reasonable to me.