### PR TITLE
Fix 1d-softmax schedule.

### DIFF
--- a/python/tvm/topi/cuda/softmax.py
+++ b/python/tvm/topi/cuda/softmax.py
@@ -63,7 +63,7 @@ def _schedule_softmax(softmax_op, s, outs, tgt):
             return False
         return True
 
-    if len(outs[0].shape) > 2:
+    if len(outs[0].shape) != 2:
         ops = [max_elem.op, expsum.op, softmax_op]
         if delta is not None:
             ops.append(delta.op)


### PR DESCRIPTION
One sophisticated softmax's TE schedule assumes >= 2D input (eg, https://github.com/apache/tvm/blob/d92a7731a28d87d6644d18619f94f341250318b3/python/tvm/topi/cuda/softmax.py#L86), and raises IndexError for 1D input. This PR checks tensor rank and falls back to default schedule when rank=1.

@masahi 