### PR TITLE
[MetaSchedule] Include te/tensor.h instead of forward declaring te::T…

### DIFF
--- a/include/tvm/meta_schedule/apply_history_best.h
+++ b/include/tvm/meta_schedule/apply_history_best.h
@@ -28,12 +28,7 @@
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/target/target.h>
-
-namespace tvm {
-namespace te {
-class Tensor;
-}  // namespace te
-}  // namespace tvm
+#include <tvm/te/tensor.h>
 
 namespace tvm {
 namespace meta_schedule {


### PR DESCRIPTION
…ensor

`ApplyHistoryBestNode` declares an `Array` of `Tensor`. There are type traits used in `Array` that require that the element type is complete at the time of the declaration. With only a forward declaration compilation fails (clang 14.0.3, libc++).
