### PR TITLE
[Docker][Pylint] Upgrade ci lint docker file

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -32,7 +32,7 @@ RUN pip config set global.no-cache-dir false
 
 RUN apt-get update && apt-get install -y doxygen graphviz curl shellcheck
 
-RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
+RUN pip3 install cpplint pylint==2.9.3 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
 
 # Rust env (build early; takes a while)
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh


### PR DESCRIPTION
Upgrading pylint allows the use of `good-names-rgxs` which allows us to create regexes which match "good" names in pylint as opposed to manually listing them all out using `good-names` in the current version. 

Follow up issue: https://github.com/apache/tvm/issues/11733

See https://github.com/apache/tvm/pull/11712/files for a potential example