### PR TITLE
[MetaSchedule][Minor] Fix EvaluatorConfig Argument Description

### DIFF
--- a/python/tvm/meta_schedule/runner/config.py
+++ b/python/tvm/meta_schedule/runner/config.py
@@ -28,9 +28,14 @@ class EvaluatorConfig(NamedTuple):
     Parameters
     ----------
     number: int
-        The number of runs.
+        The number of times to run this function for taking average.
+        We call these runs as one `repeat` of measurement.
     repeat: int
-        The number of times to repeat in each run.
+        The number of times to repeat the measurement.
+        In total, the function will be invoked (1 + number x repeat) times,
+        where the first one is warm up and will be discarded.
+        The returned result contains `repeat` costs,
+        each of which is an average of `number` costs.
     min_repeat_ms: int
         Minimum repeat time in ms. if the execution latency is too short,
         increase the number of runs to the given time (in ms) to reduce the measurement error.


### PR DESCRIPTION
Pointed out by @sunggg that the description of `number` and `repeat` for evaluator configuration is not accurate, updated to a version more consistent with `TimeEvaluator`.

![TimeEvaluator](https://user-images.githubusercontent.com/3203174/174385966-74d3dbf6-dcca-43ea-9c0b-a91b4a281687.png)

