### PR TITLE
[skip ci] Fix RVM build

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -57,6 +57,7 @@ EXTRA_SCRIPTS = {
         "apps/microtvm/reference-vm/base_box_setup_common.sh",
         "docker/install/ubuntu_install_core.sh",
         "docker/install/ubuntu_install_python.sh",
+        "docker/utils/apt-install-and-clear.sh",
     ),
     "zephyr": (
         "apps/microtvm/reference-vm/base_box_setup_common.sh",
@@ -65,6 +66,7 @@ EXTRA_SCRIPTS = {
         "docker/install/ubuntu_init_zephyr_project.sh",
         "docker/install/ubuntu_install_zephyr_sdk.sh",
         "docker/install/ubuntu_install_cmsis.sh",
+        "docker/utils/apt-install-and-clear.sh",
     ),
 }
 

--- a/apps/microtvm/reference-vm/base_box_setup_common.sh
+++ b/apps/microtvm/reference-vm/base_box_setup_common.sh
@@ -23,8 +23,11 @@ set -x
 sudo sed -i 's/DNSSEC=yes/DNSSEC=no/' /etc/systemd/resolved.conf
 sudo systemctl restart systemd-resolved
 
+sudo mv ~/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
+sudo chmod +x /usr/local/bin/apt-install-and-clear
+
 sudo apt update
-sudo apt install -y build-essential
+sudo apt-install-and-clear -y build-essential
 sudo apt-get --purge remove modemmanager  # required to access serial ports.
 
 # Core


### PR DESCRIPTION
Fix missing apt-install-and-clear utility clobbered by #11753.

Skipping ci because nothing in this PR is tested in CI.

cc @mehrdadh 