### PR TITLE
[ci][docker] Send a PR to bump the Docker images nightly

### DIFF
--- a/.github/workflows/nightly_docker_update.yml
+++ b/.github/workflows/nightly_docker_update.yml
@@ -1,0 +1,31 @@
+
+name: Nightly Docker Update
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-docker-update
+  cancel-in-progress: true
+
+jobs:
+  open_update_pr:
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+      statuses: write
+    if: github.repository == 'driazati/tvm'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Open PR to update Docker images
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eux
+          python tests/scripts/open_docker_update_pr.py

--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -21,7 +21,7 @@ import subprocess
 import re
 import base64
 import logging
-from urllib import request
+from urllib import request, error
 from typing import Dict, Tuple, Any, Optional, List
 
 
@@ -60,7 +60,7 @@ class GitHubRepo:
 
     def headers(self):
         return {
-            "Authorization": f"Bearer {self.token}",
+            "Authorization": f"token {self.token}",
         }
 
     def graphql(self, query: str, variables: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
@@ -85,8 +85,13 @@ class GitHubRepo:
         data = data.encode("utf-8")
         req.add_header("Content-Length", len(data))
 
-        with request.urlopen(req, data) as response:
-            response = json.loads(response.read())
+        try:
+            with request.urlopen(req, data) as response:
+                response = json.loads(response.read())
+        except error.HTTPError as e:
+            logging.info(f"Error response: {e.read().decode()}")
+            raise e
+
         return response
 
     def put(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/scripts/open_docker_update_pr.py
+++ b/tests/scripts/open_docker_update_pr.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import re
+import logging
+import datetime
+import os
+import json
+from urllib import error
+from typing import List, Dict, Any, Optional, Callable
+from git_utils import git, parse_remote, GitHubRepo
+from cmd_utils import REPO_ROOT, init_log
+from should_rebuild_docker import docker_api
+
+JENKINSFILE = REPO_ROOT / "jenkins" / "Jenkinsfile.j2"
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+BRANCH = "nightly-docker-update"
+
+
+def _testing_docker_api(data: Dict[str, Any]) -> Callable[[str], Dict[str, Any]]:
+    def mock(url: str) -> Dict[str, Any]:
+        if url in data:
+            return data[url]
+        else:
+            raise error.HTTPError(url, 404, f"Not found: {url}", {}, None)
+
+    return mock
+
+
+def parse_docker_date(d: str) -> datetime.datetime:
+    return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def latest_tag(user: str, repo: str) -> List[Dict[str, Any]]:
+    r = docker_api(f"repositories/{user}/{repo}/tags")
+    results = r["results"]
+
+    for result in results:
+        result["last_updated"] = parse_docker_date(result["last_updated"])
+
+    results = list(sorted(results, key=lambda d: d["last_updated"]))
+    return results[-1]
+
+
+def latest_tlcpackstaging_image(source: str) -> Optional[str]:
+    name, current_tag = source.split(":")
+    user, repo = name.split("/")
+    logging.info(
+        f"Running with name: {name}, current_tag: {current_tag}, user: {user}, repo: {repo}"
+    )
+
+    staging_repo = repo.replace("-", "_")
+    latest_tlcpackstaging_tag = latest_tag(user="tlcpackstaging", repo=staging_repo)
+    logging.info(f"Found latest tlcpackstaging tag:\n{latest_tlcpackstaging_tag}")
+
+    if latest_tlcpackstaging_tag["name"] == current_tag:
+        logging.info(f"tlcpackstaging tag is the same as the one in the Jenkinsfile")
+
+    latest_tlcpack_tag = latest_tag(user="tlcpack", repo=repo)
+    logging.info(f"Found latest tlcpack tag:\n{latest_tlcpack_tag}")
+
+    if latest_tlcpack_tag["name"] == latest_tlcpackstaging_tag["name"]:
+        logging.info("Tag names were the same, no update needed")
+        return None
+
+    if latest_tlcpack_tag["last_updated"] > latest_tlcpackstaging_tag["last_updated"]:
+        new_spec = f"tlcpack/{repo}:{latest_tlcpack_tag['name']}"
+    else:
+        # Even if the image doesn't exist in tlcpack, it will fall back to tlcpackstaging
+        # so hardcode the username here
+        new_spec = f"tlcpack/{repo}:{latest_tlcpackstaging_tag['name']}"
+        logging.info("Using tlcpackstaging tag on tlcpack")
+
+    logging.info(f"Found newer image, using: {new_spec}")
+    return new_spec
+
+
+if __name__ == "__main__":
+    init_log()
+    help = "Open a PR to update the Docker images to use the latest available in tlcpackstaging"
+    parser = argparse.ArgumentParser(description=help)
+    parser.add_argument("--remote", default="origin", help="ssh remote to parse")
+    parser.add_argument("--dry-run", action="store_true", help="don't send PR to GitHub")
+    parser.add_argument("--testing-docker-data", help="JSON data to mock Docker Hub API response")
+    args = parser.parse_args()
+
+    # Install test mock
+    if args.testing_docker_data is not None:
+        docker_api = _testing_docker_api(data=json.loads(args.testing_docker_data))
+
+    remote = git(["config", "--get", f"remote.{args.remote}.url"])
+    user, repo = parse_remote(remote)
+
+    logging.info(f"Reading {JENKINSFILE}")
+    with open(JENKINSFILE) as f:
+        content = f.readlines()
+
+    new_content = []
+    for line in content:
+        m = re.match(r"^(ci_[a-zA-Z0-9]+) = \'(.*)\'", line.strip())
+        if m is not None:
+            logging.info(f"Found match on line {line.strip()}")
+            groups = m.groups()
+            new_image = latest_tlcpackstaging_image(groups[1])
+            if new_image is None:
+                logging.info(f"No new image found")
+                new_content.append(line)
+            else:
+                logging.info(f"Using new image {new_image}")
+                new_content.append(f"{groups[0]} = '{new_image}'\n")
+        else:
+            new_content.append(line)
+
+    if args.dry_run:
+        logging.info(f"Dry run, would have written new content to {JENKINSFILE}")
+    else:
+        logging.info(f"Writing new content to {JENKINSFILE}")
+        with open(JENKINSFILE, "w") as f:
+            f.write("".join(new_content))
+
+    title = "[ci][docker] Nightly Docker image update"
+    body = "This bumps the Docker images to the latest versions from Docker Hub."
+    message = f"{title}\n\n\n{body}"
+
+    if args.dry_run:
+        logging.info("Dry run, would have committed Jenkinsfile")
+    else:
+        logging.info(f"Creating git commit")
+        git(["checkout", "-B", BRANCH])
+        git(["add", str(JENKINSFILE.relative_to(REPO_ROOT))])
+        git(["config", "user.name", "tvm-bot"])
+        git(["config", "user.email", "95660001+tvm-bot@users.noreply.github.com"])
+        git(["commit", "-m", message])
+        git(["push", "--set-upstream", args.remote, BRANCH, "--force"])
+
+    logging.info(f"Sending PR to GitHub")
+    github = GitHubRepo(user=user, repo=repo, token=GITHUB_TOKEN)
+    data = {
+        "title": title,
+        "body": body,
+        "head": BRANCH,
+        "base": "main",
+        "maintainer_can_modify": True,
+    }
+    url = "pulls"
+    if args.dry_run:
+        logging.info(f"Dry run, would have sent {data} to {url}")
+    else:
+        try:
+            github.post(url, data=data)
+        except error.HTTPError as e:
+            # Ignore the exception if the PR already exists (which gives a 422). The
+            # existing PR will have been updated in place
+            if e.code == 422:
+                logging.info("PR already exists, ignoring error")
+                logging.exception(e)
+            else:
+                raise e


### PR DESCRIPTION
See #11768 for details

This adds a GitHub Action to check for the latest images on Docker Hub via the Docker API and update the `Jenkinsfile` accordingly. It sends this in as PR for a committer to review and merge.

