### PR TITLE
[ci] Revert "upgrade ci lint docker file (#11734)"

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -34,7 +34,7 @@ RUN pip config set global.no-cache-dir false
 
 RUN apt-get update && apt-install-and-clear -y doxygen graphviz curl shellcheck
 
-RUN pip3 install cpplint pylint==2.9.3 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
+RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
 
 # Rust env (build early; takes a while)
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh


### PR DESCRIPTION
This reverts commit 7bfbc74c65684d1e25e235335da41c94372a561a, as it generates near 500 code violations when PyLint was updated from 2.4.4 to 2.9.3.

Issue #11785 for details.

cc @AndrewZhaoLuo @Mousius @areusch @driazati @lhutton1 @manupa-arm
