### PR TITLE
Fix reboot include for Zephyr version >=2.6.0

### DIFF
--- a/apps/microtvm/zephyr/template_project/src/aot_standalone_demo/main.c
+++ b/apps/microtvm/zephyr/template_project/src/aot_standalone_demo/main.c
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <float.h>
 #include <kernel.h>
-#include <power/reboot.h>
+#include <sys/reboot.h>
 #include <stdio.h>
 #include <string.h>
 #include <tvm/runtime/c_runtime_api.h>

--- a/apps/microtvm/zephyr/template_project/src/host_driven/main.c
+++ b/apps/microtvm/zephyr/template_project/src/host_driven/main.c
@@ -33,7 +33,7 @@
 #include <drivers/uart.h>
 #include <fatal.h>
 #include <kernel.h>
-#include <power/reboot.h>
+#include <sys/reboot.h>
 #include <random/rand32.h>
 #include <stdio.h>
 #include <sys/printk.h>


### PR DESCRIPTION
This is a proposal to fix the changes of header reboot file locations in zephyr version 2.6.0. 
 Reboot functionality has been moved to subsys/os from subsys/power. A consequence of this movement is that the <power/reboot.h> header has been moved to <sys/reboot.h>. <power/reboot.h> is still provided for compatibility, but it will produce a warning to inform users of the relocation.

Since the microtvm demo zephyr dependency is 2.7.0 this should not be a breaking changes. Problem is that from zephyr version 3 there is no more a relocation warning and compilation will fail with old location of reboot.h