### PR TITLE
[MetaSchedule][Minor] Update CPU Flush ArgParse Type

### DIFF
--- a/python/tvm/auto_scheduler/testing/tune_onnx.py
+++ b/python/tvm/auto_scheduler/testing/tune_onnx.py
@@ -19,6 +19,7 @@ import argparse
 import json
 import os
 
+from distutils.util import strtobool
 import numpy as np  # type: ignore
 import onnx  # type: ignore
 import tvm
@@ -96,8 +97,9 @@ def _parse_args():
     )
     args.add_argument(
         "--cpu-flush",
-        type=int,
+        type=lambda x: bool(strtobool(x)),
         required=True,
+        help="example: `True / False",
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/python/tvm/auto_scheduler/testing/tune_relay.py
+++ b/python/tvm/auto_scheduler/testing/tune_relay.py
@@ -19,6 +19,7 @@ import argparse
 import json
 import os
 
+from distutils.util import strtobool
 import numpy as np  # type: ignore
 import tvm
 from tvm import auto_scheduler
@@ -94,8 +95,9 @@ def _parse_args():
     )
     args.add_argument(
         "--cpu-flush",
-        type=int,
+        type=lambda x: bool(strtobool(x)),
         required=True,
+        help="example: `True / False",
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/python/tvm/auto_scheduler/testing/tune_te.py
+++ b/python/tvm/auto_scheduler/testing/tune_te.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-docstring
 import argparse
 import os
+from distutils.util import strtobool
 
 import tvm
 from tvm import auto_scheduler
@@ -79,8 +80,9 @@ def _parse_args():
     )
     args.add_argument(
         "--cpu-flush",
-        type=int,
+        type=lambda x: bool(strtobool(x)),
         required=True,
+        help="example: `True / False",
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/python/tvm/meta_schedule/testing/tune_onnx.py
+++ b/python/tvm/meta_schedule/testing/tune_onnx.py
@@ -19,6 +19,7 @@ import argparse
 import json
 import logging
 
+from distutils.util import strtobool
 import numpy as np  # type: ignore
 import onnx  # type: ignore
 import tvm
@@ -93,8 +94,9 @@ def _parse_args():
     )
     args.add_argument(
         "--cpu-flush",
-        type=int,
+        type=lambda x: bool(strtobool(x)),
         required=True,
+        help="example: `True / False",
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/python/tvm/meta_schedule/testing/tune_relay.py
+++ b/python/tvm/meta_schedule/testing/tune_relay.py
@@ -19,6 +19,7 @@ import argparse
 import json
 import logging
 
+from distutils.util import strtobool
 import numpy as np  # type: ignore
 import tvm
 from tvm import meta_schedule as ms
@@ -91,8 +92,9 @@ def _parse_args():
     )
     args.add_argument(
         "--cpu-flush",
-        type=int,
+        type=lambda x: bool(strtobool(x)),
         required=True,
+        help="example: `True / False",
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)

--- a/python/tvm/meta_schedule/testing/tune_te.py
+++ b/python/tvm/meta_schedule/testing/tune_te.py
@@ -19,6 +19,7 @@ import argparse
 import logging
 from os import cpu_count
 from typing import Optional
+from distutils.util import strtobool
 
 import tvm
 from tvm import meta_schedule as ms
@@ -81,8 +82,9 @@ def _parse_args():
     )
     args.add_argument(
         "--cpu-flush",
-        type=int,
+        type=lambda x: bool(strtobool(x)),
         required=True,
+        help="example: `True / False",
     )
     parsed = args.parse_args()
     parsed.target = tvm.target.Target(parsed.target)


### PR DESCRIPTION
Previously `cpu-flush` option existed as a boolean or integer argument, which is a bit counter-intuitive because for argparse, any non-empty string such as `False` will be parsed to `True` when using as a boolean and integer a little bit vague here IMHO. This PR used a function from `distutils` to directly parse input string to boolean, which makes the usage more stragiht-forward like `--cpu-flush True` or `--cpu-flush False`. Meanwhile it still supports usage of `0/1` and made sure the argument is always required.

CC: @junrushao1994 

