### PR TITLE
[docs] Fixed the error in install/from_source.rst file

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -115,7 +115,7 @@ The configuration of TVM can be modified by editing `config.cmake` and/or by pas
 
       .. code:: bash
 
-          export TVM_LOG_DEBUG="ir/transform.cc=1;relay/ir/transform.cc=1"
+          export TVM_LOG_DEBUG="ir/transform.cc=1,relay/ir/transform.cc=1"
 
 - TVM requires LLVM for CPU codegen. We highly recommend you to build with the LLVM support on.
 


### PR DESCRIPTION
#10755 changed the TVM_LOG_DEBUG separator from ';' to ','.  This PR changes installation guide file accordingly.

@areusch 