### PR TITLE
Change new concat

### DIFF
--- a/python/tvm/topi/x86/concat.py
+++ b/python/tvm/topi/x86/concat.py
@@ -23,7 +23,8 @@ from ..utils import get_const_int, const_vector
 
 
 def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):
-    """Join a sequence of arrays along an existing axis. Optimized for CPU exeution.
+    """Join a sequence of arrays along an existing axis.
+    Optimized for CPU execution.
 
     Parameters
     ----------
@@ -42,7 +43,7 @@ def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):
     in_outers_cumsum = [0, *np.cumsum(in_outers, dtype="int64")[0:-1]]
 
     def gen_ir_1d(data_bufs, out_buf):
-        """Custom conactenation execution."""
+        """Custom concatenation execution."""
         i_b = tvm.tir.ir_builder.create()
         data_bufs1 = [i_b.buffer_ptr(data_buf) for data_buf in data_bufs]
         out_buf = i_b.buffer_ptr(out_buf)
@@ -53,7 +54,7 @@ def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):
         return i_b.get()
 
     def gen_ir(data_bufs, out_buf, inner, outer):
-        """Common case of conactenation execution."""
+        """Common case of concatenation execution."""
         i_b = tvm.tir.ir_builder.create()
         data_bufs1 = [i_b.buffer_ptr(data_buf) for data_buf in data_bufs]
         out_buf = i_b.buffer_ptr(out_buf)

--- a/python/tvm/topi/x86/concat.py
+++ b/python/tvm/topi/x86/concat.py
@@ -19,7 +19,7 @@ from typing import Optional
 import tvm
 from tvm import te
 import numpy as np
-from ..utils import get_const_int, const_vector
+from ..utils import get_const_int
 
 
 def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):

--- a/python/tvm/topi/x86/concat.py
+++ b/python/tvm/topi/x86/concat.py
@@ -38,48 +38,45 @@ def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):
     ret : tvm.te.Tensor
     """
 
-    def gen_ir_1d(data_bufs, in_outers_tensor, in_cumsum_tensor, out_buf):
+    in_outers = [int(np.prod(i.shape[axis:])) for i in data]
+    in_outers_cumsum = [0, *np.cumsum(in_outers, dtype="int64")[0:-1]]
+
+    def gen_ir_1d(data_bufs, out_buf):
         """Custom conactenation execution."""
         i_b = tvm.tir.ir_builder.create()
         data_bufs1 = [i_b.buffer_ptr(data_buf) for data_buf in data_bufs]
         out_buf = i_b.buffer_ptr(out_buf)
-        outers = i_b.buffer_ptr(in_outers_tensor)
-        cumsum = i_b.buffer_ptr(in_cumsum_tensor)
+
         for i in range(len(data)):
-            with i_b.for_range(0, outers[i], name="j") as j:
-                out_buf[cumsum[i] + j] = data_bufs1[i][j]
+            with i_b.for_range(0, in_outers[i], name="j") as j:
+                out_buf[in_outers_cumsum[i] + j] = data_bufs1[i][j]
         return i_b.get()
 
-    def gen_ir(data_bufs, in_outers_tensor, in_cumsum_tensor, out_buf, inner, outer):
+    def gen_ir(data_bufs, out_buf, inner, outer):
         """Common case of conactenation execution."""
         i_b = tvm.tir.ir_builder.create()
         data_bufs1 = [i_b.buffer_ptr(data_buf) for data_buf in data_bufs]
         out_buf = i_b.buffer_ptr(out_buf)
-        outers = i_b.buffer_ptr(in_outers_tensor)
-        cumsum = i_b.buffer_ptr(in_cumsum_tensor)
         if inner > 1:
             with i_b.for_range(0, inner, name="inn", kind="parallel") as inn:
                 pos = inn * outer
                 for i in range(len(data)):
-                    offset = inn * outers[i]
-                    with i_b.for_range(0, outers[i], name="j") as j:
-                        out_buf[pos + cumsum[i] + j] = data_bufs1[i][offset + j]
+                    offset = inn * in_outers[i]
+                    with i_b.for_range(0, in_outers[i], name="j") as j:
+                        out_buf[pos + in_outers_cumsum[i] + j] = data_bufs1[i][offset + j]
         else:
             for i in range(len(data)):
-                with i_b.for_range(0, outers[i], name="j", kind="parallel") as j:
-                    out_buf[cumsum[i] + j] = data_bufs1[i][j]
+                with i_b.for_range(0, in_outers[i], name="j", kind="parallel") as j:
+                    out_buf[in_outers_cumsum[i] + j] = data_bufs1[i][j]
         return i_b.get()
 
     if axis < 0:
         axis += len(data[0].shape)
     concat_axis_sizes = [int(t.shape[axis]) for t in data]
     join_size = int(np.sum(concat_axis_sizes))
-    in_outers = [int(np.prod(i.shape[axis:])) for i in data]
-    in_outers_cumsum = [0, *np.cumsum(in_outers, dtype="int64")[0:-1]]
+
     dtype = data[0].dtype
     out_shape = data[0].shape[:axis] + [join_size] + data[0].shape[axis + 1 :]
-    in_outers_tensor = const_vector(in_outers)
-    in_cumsum_tensor = const_vector(in_outers_cumsum, name="cumsum")
     right_val = np.prod(out_shape[axis:])
     left_val = np.prod(out_shape[:axis])
 
@@ -92,8 +89,8 @@ def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):
         # badly parallelized case
         return te.extern(
             [out_shape],
-            list(data) + [in_outers_tensor, in_cumsum_tensor],
-            lambda ins, outs: gen_ir_1d(ins, ins[-2], ins[-1], outs[0]),
+            list(data),
+            lambda ins, outs: gen_ir_1d(ins, outs[0]),
             dtype=dtype,
             name="concatenate_ext",
         )
@@ -102,8 +99,8 @@ def concatenate(data: tvm.te.Tensor, axis: Optional[int] = 0):
     outer = get_const_int(int(right_val))
     return te.extern(
         [out_shape],
-        list(data) + [in_outers_tensor, in_cumsum_tensor],
-        lambda ins, outs: gen_ir(ins, ins[-2], ins[-1], outs[0], inner, outer),
+        list(data),
+        lambda ins, outs: gen_ir(ins, outs[0], inner, outer),
         dtype=dtype,
         name="concatenate_ext",
     )

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -469,7 +469,7 @@ def test_export_byoc_c_module():
                     "constants_size_bytes": 0,
                     "device": 1,
                     "io_size_bytes": 4800,
-                    "workspace_size_bytes": 1216,
+                    "workspace_size_bytes": 1200,
                 }
             ]
 

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -460,7 +460,7 @@ def test_export_byoc_c_module():
                     "constants_size_bytes": 0,
                     "device": 1,
                     "io_size_bytes": 4800,
-                    "workspace_size_bytes": 1264,
+                    "workspace_size_bytes": 1200,
                 }
             ]
         else:
@@ -469,7 +469,7 @@ def test_export_byoc_c_module():
                     "constants_size_bytes": 0,
                     "device": 1,
                     "io_size_bytes": 4800,
-                    "workspace_size_bytes": 1248,
+                    "workspace_size_bytes": 1216,
                 }
             ]
 


### PR DESCRIPTION
This is a proposed change to the new topi x86 concat implementation in #11341. It uses simple lists of int instead of `te.tensor.Tensor` for the array offsets and loop variable extents. I have only looked at the generated C code and made sure that the relevant unit tests pass.
New version:
```
 for (int32_t j = 0; j < 4; ++j) {
    concatenate_ext[j] = placeholder[j];
  }
  for (int32_t j1 = 0; j1 < 4; ++j1) {
    concatenate_ext[(j1 + 4)] = placeholder1[j1];
  }
  return 0;
```

Old version: 
```
  void* const_vector_let = (&(global_workspace_6_var[64]));
  void* cumsum_let = (&(global_workspace_6_var[48]));
  for (int32_t i = 0; i < 2; ++i) {
    ((int64_t*)const_vector_let)[i] = ((i == 1) ? (int64_t)4 : ((i == 0) ? (int64_t)4 : (int64_t)0));
  }
  for (int32_t i1 = 0; i1 < 2; ++i1) {
    ((int64_t*)cumsum_let)[i1] = ((i1 == 1) ? (int64_t)4 : (int64_t)0);
  }

  int64_t cumsum_let[2] = {0, 4};

  for (int64_t j = 0; j < ((int64_t*)const_vector_let)[0]; ++j) {
    concatenate_ext[(((int64_t*)cumsum_let)[0] + j)] = placeholder[j];
  }
  for (int64_t j1 = 0; j1 < ((int64_t*)const_vector_let)[1]; ++j1) {
    concatenate_ext[(((int64_t*)cumsum_let)[1] + j1)] = placeholder1[j1];
  }
  return 0;
```

@DzAvril @shtinsa @MichaelJKlaiber @UlrikHjort-Bosch @vdkhoi @masahi 
