### PR TITLE
[LLVM] Retrieve entire target string from LLVMModule

### DIFF
--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -291,7 +291,7 @@ std::string PackImportsToC(const runtime::Module& mod, bool system_lib) {
 }
 
 runtime::Module PackImportsToLLVM(const runtime::Module& mod, bool system_lib,
-                                  const std::string& target_triple) {
+                                  const std::string& llvm_target_string) {
   std::string bin = SerializeModule(mod);
 
   uint64_t nbytes = bin.length();
@@ -309,7 +309,7 @@ runtime::Module PackImportsToLLVM(const runtime::Module& mod, bool system_lib,
   // the codegen function.
   const PackedFunc* codegen_f = runtime::Registry::Get(codegen_f_name);
   ICHECK(codegen_f != nullptr) << "codegen.codegen_blob is not presented.";
-  return (*codegen_f)(blob_byte_array, system_lib, target_triple);
+  return (*codegen_f)(blob_byte_array, system_lib, llvm_target_string);
 }
 
 TVM_REGISTER_GLOBAL("target.Build").set_body_typed(Build);

--- a/src/target/llvm/codegen_blob.cc
+++ b/src/target/llvm/codegen_blob.cc
@@ -32,9 +32,9 @@ namespace tvm {
 namespace codegen {
 
 std::pair<std::unique_ptr<llvm::Module>, std::shared_ptr<llvm::LLVMContext>> CodeGenBlob(
-    const std::string& data, bool system_lib, const std::string& target_triple) {
+    const std::string& data, bool system_lib, const std::string& llvm_target_string) {
   InitializeLLVM();
-  Target target = Target("llvm -mtriple " + target_triple);
+  Target target(llvm_target_string);
   auto tm = GetLLVMTargetMachine(target);
   auto triple = tm->getTargetTriple();
   auto ctx = std::make_shared<llvm::LLVMContext>();

--- a/src/target/llvm/codegen_blob.h
+++ b/src/target/llvm/codegen_blob.h
@@ -42,7 +42,7 @@ namespace codegen {
  * \return LLVM module and LLVM context
  */
 std::pair<std::unique_ptr<llvm::Module>, std::shared_ptr<llvm::LLVMContext>> CodeGenBlob(
-    const std::string& data, bool system_lib, const std::string& target_triple);
+    const std::string& data, bool system_lib, const std::string& llvm_target_string);
 
 }  // namespace codegen
 }  // namespace tvm


### PR DESCRIPTION
The blob-embedding code creates a new LLVM module for which is needs more information than just the target triple. The `_get_target_triple` function in LLVMModule returned the triple with additional options appended to the string. Instead of piggy-backing those extra options on top of the triple, replace `_get_target_triple` with `_get_target_string`, which will return the entire target string.
