### PR TITLE
[TIR][BugFix] Do not bind non-index type value of lets in CompactBufferAllocation

### DIFF
--- a/src/tir/transforms/compact_buffer_region.cc
+++ b/src/tir/transforms/compact_buffer_region.cc
@@ -150,18 +150,26 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
 
   void VisitStmt_(const LetStmtNode* op) final {
     StmtExprVisitor::VisitExpr(op->value);
-    dom_analyzer_.Bind(op->var, op->value);
-    dom_map_.emplace(op->var.get(), arith::IntSet::SinglePoint(op->value));
+    if (arith::IsIndexType(op->value->dtype)) {
+      dom_analyzer_.Bind(op->var, op->value);
+      dom_map_.emplace(op->var.get(), arith::IntSet::SinglePoint(op->value));
+    }
     StmtExprVisitor::VisitStmt(op->body);
-    dom_map_.erase(op->var.get());
+    if (arith::IsIndexType(op->value->dtype)) {
+      dom_map_.erase(op->var.get());
+    }
   }
 
   void VisitExpr_(const LetNode* op) final {
     StmtExprVisitor::VisitExpr(op->value);
-    dom_analyzer_.Bind(op->var, op->value);
-    dom_map_.emplace(op->var.get(), arith::IntSet::SinglePoint(op->value));
+    if (arith::IsIndexType(op->value->dtype)) {
+      dom_analyzer_.Bind(op->var, op->value);
+      dom_map_.emplace(op->var.get(), arith::IntSet::SinglePoint(op->value));
+    }
     StmtExprVisitor::VisitExpr(op->body);
-    dom_map_.erase(op->var.get());
+    if (arith::IsIndexType(op->value->dtype)) {
+      dom_map_.erase(op->var.get());
+    }
   }
 
   void VisitStmt_(const IfThenElseNode* op) final {

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -737,6 +737,21 @@ def test_compact_with_let_binding():
 
     _check(func_with_let_binding, func_with_let_binding)
 
+    @T.prim_func
+    def func_with_non_index_let_binding():
+        x1 = T.call_extern("get", dtype="float16")
+        x2 = T.call_extern("get", dtype="float32")
+        x3 = T.call_extern("get", dtype="float64")
+        x4 = T.call_extern("get", dtype="uint8")
+        x5 = T.call_extern("get", dtype="int32x16")
+        x6 = T.call_extern("get", dtype="handle")
+        x7 = T.call_extern("get", dtype="")
+        A = T.alloc_buffer((64), "float32")
+        for rk in range(64):
+            A[rk] = T.call_extern("load_ptr", x1, x2, x3, x4, x5, x6, x7, dtype="float32")
+
+    _check(func_with_non_index_let_binding, func_with_non_index_let_binding)
+
 
 def test_compact_spatial_tiled_pad_and_pooling():
     @T.prim_func


### PR DESCRIPTION
Fix a bug for let support, it should not put non-index typed values into `dom_map`.
