### PR TITLE
[CI][arm] Fix tensorflow-aarch64 repository URL

### DIFF
--- a/docker/install/ubuntu_install_tensorflow_aarch64.sh
+++ b/docker/install/ubuntu_install_tensorflow_aarch64.sh
@@ -21,11 +21,27 @@ set -euxo pipefail
 # Build dependencies
 apt-install-and-clear -y --no-install-recommends libhdf5-dev
 
+# Downloading Tensorflow and installing it manually is needed
+# just as a temporary workaround while we move to a newer
+# version (>2.7) that is hosted in the official PyPI repository.
+linaro_repo="https://snapshots.linaro.org/ldcg/python/tensorflow-manylinux/43/tensorflow-aarch64"
+tensorflow_package="tensorflow_aarch64-2.6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+tmpdir=$(mktemp -d)
+
+cleanup()
+{
+  rm -rf "$tmpdir"
+}
+
+trap cleanup 0
+
+cd "${tmpdir}"
+wget -q "${linaro_repo}/${tensorflow_package}"
+
 # We're only using the TensorFlow wheel snapshot here as the
 # h5py wheel tries to use the wrong .so file
 pip3 install \
+    ${tensorflow_package} \
     "h5py==3.1.0" \
     keras==2.6 \
-    tensorflow-aarch64==2.6.3 \
-    "protobuf<4" \
-    -f https://snapshots.linaro.org/ldcg/python-cache/tensorflow-aarch64/
+    "protobuf<4"


### PR DESCRIPTION
Update the custom repository URL used to pull TensorFlow-aarch64. The mechanism of installation is also changed to a file based, as a temporary workaround before we update to a newer version (>=2.7) that can be pulled from the official PyPI repository.

Closes #11773

cc @Mousius @areusch @lhutton1 @driazati 
