### PR TITLE
[microTVM][zephyr] skip mps2_an521 for host-driven AoT zephyr tests

### DIFF
--- a/tests/micro/zephyr/test_zephyr_aot_exec.py
+++ b/tests/micro/zephyr/test_zephyr_aot_exec.py
@@ -65,6 +65,7 @@ def _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config):
 
 
 @tvm.testing.requires_micro
+@pytest.mark.skip_boards(["mps2_an521"])
 def test_relay(temp_dir, board, west_cmd, tvm_debug):
     """Testing a simple relay graph"""
 
@@ -98,6 +99,7 @@ def test_relay(temp_dir, board, west_cmd, tvm_debug):
 
 
 @tvm.testing.requires_micro
+@pytest.mark.skip_boards(["mps2_an521"])
 def test_aot_executor(temp_dir, board, west_cmd, tvm_debug):
     """Test use of the AOT executor with microTVM."""
 


### PR DESCRIPTION
Skip mps2_an521 for host-driven AoT zephyr tests.

#11831


cc @gromero @mehrdadh