### PR TITLE
fix locale("")

### DIFF
--- a/src/runtime/profiling.cc
+++ b/src/runtime/profiling.cc
@@ -418,12 +418,12 @@ static String print_metric(ObjectRef metric) {
   std::string val;
   if (metric.as<CountNode>()) {
     std::stringstream s;
-    s.imbue(std::locale(""));  // for 1000s seperators
+    s.imbue(std::locale());  // for 1000s seperators
     s << std::fixed << metric.as<CountNode>()->value;
     val = s.str();
   } else if (metric.as<DurationNode>()) {
     std::stringstream s;
-    s.imbue(std::locale(""));  // for 1000s seperators
+    s.imbue(std::locale());  // for 1000s seperators
     s << std::fixed << std::setprecision(2) << metric.as<DurationNode>()->microseconds;
     val = s.str();
   } else if (metric.as<PercentNode>()) {
@@ -432,7 +432,7 @@ static String print_metric(ObjectRef metric) {
     val = s.str();
   } else if (metric.as<RatioNode>()) {
     std::stringstream s;
-    s.imbue(std::locale(""));  // for 1000s seperators
+    s.imbue(std::locale());  // for 1000s seperators
     s << std::setprecision(2) << metric.as<RatioNode>()->ratio;
     val = s.str();
   } else if (metric.as<StringObj>()) {


### PR DESCRIPTION
std::locale("") would failed  in some env like: LC_ALL=zh_CN.UTF-8 
`tvm._ffi.base.TVMError: locale: :facet::_S_create_c_locale name not valid>`

locale has its default constructor function, no need to set input to empty string `""`