### PR TITLE
[LLVM] Remove PrintModule (defined in llvm_common.cc)

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -319,7 +319,6 @@ void CodeGenLLVM::Optimize() {
     fpass.run(*it);
   }
   fpass.doFinalization();
-  // PrintModule(module_.get());
   mpass.run(*module_);
 }
 

--- a/src/target/llvm/llvm_common.cc
+++ b/src/target/llvm/llvm_common.cc
@@ -189,13 +189,6 @@ std::string LLVMTargetToString(const Target& target) {
   return os.str();
 }
 
-void PrintModule(const llvm::Module* mod) {
-  std::string modpe_str;
-  llvm::raw_string_ostream rso(modpe_str);
-  mod->print(rso, nullptr);
-  LOG(INFO) << rso.str();
-}
-
 }  // namespace codegen
 }  // namespace tvm
 #endif  // TVM_LLVM_VERSION

--- a/src/target/llvm/llvm_common.h
+++ b/src/target/llvm/llvm_common.h
@@ -126,8 +126,6 @@ std::unique_ptr<llvm::TargetMachine> GetLLVMTargetMachine(const Target& target,
  */
 std::string LLVMTargetToString(const Target& target);
 
-void PrintModule(const llvm::Module* mod);
-
 }  // namespace codegen
 }  // namespace tvm
 


### PR DESCRIPTION
The only use of that function is commented out. `llvm::Module` can be printed directly to `llvm::raw_ostream` via <<, so it's quite easy to insert printing code when needed:
```
  std::string s;
  llvm::raw_string_ostream os(s);
  os << module;   // s (or os.str()) has the LLVM IR text
```