### PR TITLE
[HEXAGON] Change arch and do not disable assert

### DIFF
--- a/tests/python/contrib/test_hexagon/topi/test_add_subtract_multiply.py
+++ b/tests/python/contrib/test_hexagon/topi/test_add_subtract_multiply.py
@@ -161,7 +161,7 @@ class TestAddSubtractMultiplyBroadcast2d:
         input_B_layout,
         op_name,
     ):
-        target_hexagon = tvm.target.hexagon("v68")
+        target_hexagon = tvm.target.hexagon("v69")
         A = te.placeholder(input_shape_A, name="A", dtype=dtype)
         B = te.placeholder(input_shape_B, name="B", dtype=dtype)
         if op_name == "add":
@@ -182,7 +182,7 @@ class TestAddSubtractMultiplyBroadcast2d:
         else:
             raise RuntimeError(f"Unexpected layout '{output_layout}'")
 
-        with tvm.transform.PassContext(opt_level=3, config={"tir.disable_assert": True}):
+        with tvm.transform.PassContext(opt_level=3):
             func = tvm.build(
                 sch,
                 [A, B, M],


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @mehrdadh

Earlier CI in upstream did not have support for hexagon v69. But since now it supports it, the test can use the updated version.
For testing, we have decided not to disable assert so that it can catch if there's any assert issue.