### PR TITLE
[Frontend][TFLite] PreLU alpha can be an expr

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -3009,8 +3009,15 @@ class OperatorConverter(object):
 
         input_tensor = input_tensors[0]
         alpha_tensor = input_tensors[1]
+        if self.has_expr(alpha_tensor.tensor_idx):
+            alpha_expr = self.get_expr(alpha_tensor.tensor_idx)
+        else:
+            alpha_tensor_type = alpha_tensor.tensor.Type()
+            alpha_tensor_type_str = self.get_tensor_type_str(alpha_tensor_type)
+            alpha_expr = self.exp_tab.new_const(
+                self.get_tensor_value(alpha_tensor), dtype=alpha_tensor_type_str
+            )
         in_expr = self.get_expr(input_tensor.tensor_idx)
-        alpha_expr = self.get_expr(alpha_tensor.tensor_idx)
         data_shape = to_int_list(self.get_tensor_shape(input_tensor))
 
         alpha_expr = _op.broadcast_to(alpha_expr, data_shape)

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -3009,12 +3009,8 @@ class OperatorConverter(object):
 
         input_tensor = input_tensors[0]
         alpha_tensor = input_tensors[1]
-        alpha_tensor_type = alpha_tensor.tensor.Type()
-        alpha_tensor_type_str = self.get_tensor_type_str(alpha_tensor_type)
-        alpha_expr = self.exp_tab.new_const(
-            self.get_tensor_value(alpha_tensor), dtype=alpha_tensor_type_str
-        )
         in_expr = self.get_expr(input_tensor.tensor_idx)
+        alpha_expr = self.get_expr(alpha_tensor.tensor_idx)
         data_shape = to_int_list(self.get_tensor_shape(input_tensor))
 
         alpha_expr = _op.broadcast_to(alpha_expr, data_shape)


### PR DESCRIPTION
Reading the following model did not work for me: https://github.com/google/mediapipe/blob/master/mediapipe/modules/face_landmark/face_landmark.tflite

with the error:

```
  File "tvm/python/tvm/relay/frontend/tflite.py", line 3092, in convert_prelu
    self.get_tensor_value(alpha_tensor), dtype=alpha_tensor_type_str
  File "tvm/python/tvm/relay/frontend/tflite.py", line 520, in get_tensor_value
    return np.frombuffer(data, dtype=dtype).reshape(shape)
TypeError: memoryview: a bytes-like object is required, not 'int'
```

The input of the PreLU op is the output of a Dequantize op, so not a constant, therefore its tensor buffer is not set.

I was unable to test this successfully because the existing test failed with the following error, even before any changes.

```
The Relay type checker is unable to show the following types match.
In particular dimension 0 conflicts: 3 does not match 96.
The Relay type checker is unable to show the following types match.
In particular `Tensor[(96), float32]` does not match `Tensor[(3), float32]`
```

on

```
_test_prelu(
        np.random.uniform(-5, 5, size=(1, 32, 32, 3)).astype("float32"),
        np.full((32, 3), 0.2, dtype="float32"),
    )
```

@FrozenGene @tqchen 