### PR TITLE
[Arith] Fix DetectIterMap floordiv when IterSum only contains base expr

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -1276,7 +1276,9 @@ IterSumExpr IterMapRewriter::PreprocessDividend(IterMapExpr dividend, PrimExpr o
     return IterSumExpr({split}, make_zero(split.dtype()));
   } else if (dividend->IsInstance<IterSumExprNode>()) {
     auto sum = Downcast<IterSumExpr>(dividend);
-    if (sum->args.size() <= 1) {
+    if (sum->args.empty()) {
+      return IterSumExpr();
+    } else if (sum->args.size() == 1) {
       return sum;
     }
     auto opt_fused = TryFuseIters(sum);
@@ -1552,6 +1554,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorDivNode* op) {
   if (!preprocessed.defined()) {
     return GetRef<PrimExpr>(op);
   }
+  ICHECK_EQ(preprocessed->args.size(), 1U);
   PrimExpr remainder = SplitFloorDivConst(preprocessed->args[0], preprocessed->base, b);
   if (!remainder.defined()) {
     return GetRef<PrimExpr>(op);
@@ -1637,6 +1640,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const FloorModNode* op) {
     return GetRef<PrimExpr>(op);
   }
 
+  ICHECK_EQ(preprocessed->args.size(), 1U);
   PrimExpr remainder = SplitFloorModConst(preprocessed->args[0], preprocessed->base, b);
   if (!remainder.defined()) {
     return GetRef<PrimExpr>(op);

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -172,6 +172,11 @@ def test_split():
 
     assert_iter_sum_failure([fld(x, flm(flm(y, 8), 6))], var_dom([(x, 24), (y, 8)]))
 
+    # domain of x is undefined
+    assert_iter_sum_pattern(
+        {fld(flm(x, 49) + y, 49): (1, fld(flm(x, 49) + y, 49))}, var_dom([(y, 1)])
+    )
+
 
 def test_compound():
     x = tvm.tir.Var("x", "int32")


### PR DESCRIPTION
This PR fixed an issue preprocessing dividend for `FloorDiv / FloorMod`. When `IterSumExpr->args` is empty, it should be treated as a failure. 

cc @wrongtest @spectrometerHBH @junrushao1994 