### PR TITLE
Delete `from __future__ import annotations` since it requires Python …

### DIFF
--- a/python/tvm/meta_schedule/profiler.py
+++ b/python/tvm/meta_schedule/profiler.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """A context manager that profiles tuning time cost for different parts."""
-from __future__ import annotations
 
 import logging
 from contextlib import contextmanager


### PR DESCRIPTION
…3.7+
