### PR TITLE
[ci][docker] Run build/test with Docker changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-09-26T10:48:49.577077
+// Generated at 2022-09-27T13:05:59.848280
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -607,6 +607,20 @@ def build_docker_images() {
     )
   }
 }
+
+def use_built_docker_images() {
+  ci_arm = built_ci_arm
+  ci_cortexm = built_ci_cortexm
+  ci_cpu = built_ci_cpu
+  ci_gpu = built_ci_gpu
+  ci_hexagon = built_ci_hexagon
+  ci_i386 = built_ci_i386
+  ci_lint = built_ci_lint
+  ci_minimal = built_ci_minimal
+  ci_riscv = built_ci_riscv
+  ci_wasm = built_ci_wasm
+}
+
 def lint() {
   stage('Lint') {
     parallel(
@@ -725,8 +739,8 @@ def make(docker_type, path, make_flag) {
 }
 
 
-def build() {
-stage('Build') {
+def build(stage_name) {
+stage(stage_name) {
   environment {
     SKIP_SLOW_TESTS = "${skip_slow_tests}"
   }
@@ -3818,8 +3832,8 @@ def run_unittest_minimal() {
   }
 }
 
-def test() {
-stage('Test') {
+def test(stage_name) {
+stage(stage_name) {
   environment {
     SKIP_SLOW_TESTS = "${skip_slow_tests}"
   }
@@ -4471,8 +4485,16 @@ if (rebuild_docker_images) {
 
 lint()
 
-build()
+build('Build')
 
-test()
+test('Test')
+
+if (rebuild_docker_images) {
+  use_built_docker_images()
+
+  build('Build (with new Docker images)')
+
+  test('Test (with new Docker images)')
+}
 
 deploy()

--- a/ci/jenkins/Build.groovy.j2
+++ b/ci/jenkins/Build.groovy.j2
@@ -74,8 +74,8 @@ def make(docker_type, path, make_flag) {
 }
 
 
-def build() {
-stage('Build') {
+def build(stage_name) {
+stage(stage_name) {
   environment {
     SKIP_SLOW_TESTS = "${skip_slow_tests}"
   }

--- a/ci/jenkins/DockerBuild.groovy.j2
+++ b/ci/jenkins/DockerBuild.groovy.j2
@@ -116,3 +116,10 @@ def build_docker_images() {
     )
   }
 }
+
+def use_built_docker_images() {
+  {% for image in images %}
+  {{ image.name }} = built_{{ image.name }}
+  {% endfor %}
+}
+

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -124,8 +124,16 @@ if (rebuild_docker_images) {
 
 lint()
 
-build()
+build('Build')
 
-test()
+test('Test')
+
+if (rebuild_docker_images) {
+  use_built_docker_images()
+
+  build('Build (with new Docker images)')
+
+  test('Test (with new Docker images)')
+}
 
 deploy()

--- a/ci/jenkins/Test.groovy.j2
+++ b/ci/jenkins/Test.groovy.j2
@@ -245,8 +245,8 @@ def run_unittest_minimal() {
   {% endcall %}
 }
 
-def test() {
-stage('Test') {
+def test(stage_name) {
+stage(stage_name) {
   environment {
     SKIP_SLOW_TESTS = "${skip_slow_tests}"
   }


### PR DESCRIPTION
This re-runs the build with newly built images (so the build + test runs twice) to ensure that Docker image changes won't break anything once they're actually deployed. Testing changes in #12740

cc @Mousius @areusch @gigiblender