### PR TITLE
[Relay][Pytorch] Add aten::new_ones, aten::new_full, aten::fill_, aten::pad, aten::reshape_as and atem::empty_like

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -703,12 +703,23 @@ class PyTorchOpConverter:
 
     def new_ones(self, inputs, input_types):
         """
-        Returns a Tensor of size size filled with 1. By default, the returned Tensor has the same torch.dtype and torch.device as this tensor.
+        Returns a Tensor of size size filled with 1. By default, the
+        returned Tensor has the same torch.dtype and torch.device
+        as this tensor.
+
         Parameters
-        size (int...) - a list, tuple, or torch.Size of integers defining the shape of the output tensor.
-        dtype (torch.dtype, optional) - the desired type of returned tensor. Default: if None, same torch.dtype as this tensor.
-        device (torch.device, optional) - the desired device of returned tensor. Default: if None, same torch.device as this tensor.
-        requires_grad (bool, optional) - If autograd should record operations on the returned tensor. Default: False.
+        size (int...)
+            a list, tuple, or torch.Size of integers defining the shape of
+            the output tensor.
+        dtype (torch.dtype, optional)
+            the desired type of returned tensor.
+            Default: if None, same torch.dtype as this tensor.
+        device (torch.device, optional)
+            the desired device of returned tensor.
+            Default: if None, same torch.device as this tensor.
+        requires_grad (bool, optional)
+            If autograd should record operations on the returned tensor.
+            Default: False.
 
         """
         size = inputs[1]
@@ -792,18 +803,22 @@ class PyTorchOpConverter:
     def new_full(self, inputs, input_types):
         """
         Returns a Tensor of size size filled with fill_value.
-        By default, the returned Tensor has the same dtype and device as this tensor.
+        By default, the returned Tensor has the same dtype
+        and device as this tensor.
 
         Parameters
         ----------
         fill_value (scalar)
             The number to fill the output tensor with.
         dtype (torch.dtype, optional)
-            The desired type of returned tensor. Default: if None, same torch.dtype as this tensor.
+            The desired type of returned tensor.
+            Default: if None, same torch.dtype as this tensor.
         device (torch.device, optional)
-            The desired device of returned tensor. Default: if None, same torch.device as this tensor.
+            The desired device of returned tensor.
+            Default: if None, same torch.device as this tensor.
         requires_grad (bool, optional)
-            If autograd should record operations on the returned tensor. Default: False.
+            If autograd should record operations on the returned
+            tensor. Default: False.
         """
         data = inputs[0]
         fill_value = inputs[1]
@@ -2407,7 +2422,8 @@ class PyTorchOpConverter:
     def empty_like(self, inputs, input_types):
         """
         Returns an uninitialized tensor with the same size as input.
-        torch.empty_like(input) is equivalent to torch.empty(input.size(), dtype=input.dtype, layout=input.layout, device=input.device).
+        torch.empty_like(input) is equivalent to torch.empty(input.size(),
+        dtype=input.dtype, layout=input.layout, device=input.device).
         """
         shape = self.infer_shape(inputs[0])
         return _op.zeros(shape, _convert_dtype_value(inputs[1]))

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -702,26 +702,6 @@ class PyTorchOpConverter:
         return out
 
     def new_ones(self, inputs, input_types):
-        """
-        Returns a Tensor of size size filled with 1. By default, the
-        returned Tensor has the same torch.dtype and torch.device
-        as this tensor.
-
-        Parameters
-        size (int...)
-            a list, tuple, or torch.Size of integers defining the shape of
-            the output tensor.
-        dtype (torch.dtype, optional)
-            the desired type of returned tensor.
-            Default: if None, same torch.dtype as this tensor.
-        device (torch.device, optional)
-            the desired device of returned tensor.
-            Default: if None, same torch.device as this tensor.
-        requires_grad (bool, optional)
-            If autograd should record operations on the returned tensor.
-            Default: False.
-
-        """
         size = inputs[1]
 
         import torch
@@ -801,25 +781,6 @@ class PyTorchOpConverter:
         return out
 
     def new_full(self, inputs, input_types):
-        """
-        Returns a Tensor of size size filled with fill_value.
-        By default, the returned Tensor has the same dtype
-        and device as this tensor.
-
-        Parameters
-        ----------
-        fill_value (scalar)
-            The number to fill the output tensor with.
-        dtype (torch.dtype, optional)
-            The desired type of returned tensor.
-            Default: if None, same torch.dtype as this tensor.
-        device (torch.device, optional)
-            The desired device of returned tensor.
-            Default: if None, same torch.device as this tensor.
-        requires_grad (bool, optional)
-            If autograd should record operations on the returned
-            tensor. Default: False.
-        """
         data = inputs[0]
         fill_value = inputs[1]
 
@@ -2420,11 +2381,6 @@ class PyTorchOpConverter:
         return _op.zeros(shape, _convert_dtype_value(inputs[1]))
 
     def empty_like(self, inputs, input_types):
-        """
-        Returns an uninitialized tensor with the same size as input.
-        torch.empty_like(input) is equivalent to torch.empty(input.size(),
-        dtype=input.dtype, layout=input.layout, device=input.device).
-        """
         shape = self.infer_shape(inputs[0])
         return _op.zeros(shape, _convert_dtype_value(inputs[1]))
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -828,23 +828,6 @@ class PyTorchOpConverter:
         dtype = self.infer_type(data)
         return self.full_impl(data, fill_value, dtype)
 
-    def pad(self, inputs, input_types):
-        data = inputs[0]
-        pad = inputs[1]
-        if len(inputs) > 2:
-            mode = inputs[2]
-        else:
-            mode = "constant"
-        if len(inputs) == 4:
-            pad_value = inputs[3]
-        else:
-            pad_value = 0
-        if mode == "replicate" or mode == "circular":
-            raise ValueError(
-                "replicate and circular mode for torch.nn.functional.pad are not supported in TVM"
-            )
-        return _op.nn.pad(data, pad, pad_value=pad_value, pad_mode=mode)
-
     def linspace(self, inputs, input_types):
         start = inputs[0]
         stop = inputs[1]
@@ -3153,7 +3136,6 @@ class PyTorchOpConverter:
             "aten::full_like": self.full_like,
             "aten::new_full": self.new_full,
             "aten::fill_": self.fill_,
-            "aten::pad": self.pad,
             "aten::linspace": self.linspace,
             "aten::reciprocal": self.reciprocal,
             "aten::repeat": self.repeat,

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -837,10 +837,7 @@ class PyTorchOpConverter:
                 "replicate and circular mode for torch.nn.functional.pad are not supported in TVM"
             )
         pad_value = inputs[3]
-        if pad_value == None:
-            return _op.nn.pad(data, pad, pad_mode=mode)
-        else:
-            return _op.nn.pad(data, pad, pad_value=pad_value, pad_mode=mode)
+        return _op.nn.pad(data, pad, pad_value=pad_value, pad_mode=mode)
 
     def linspace(self, inputs, input_types):
         start = inputs[0]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -801,8 +801,7 @@ class PyTorchOpConverter:
     def fill_(self, inputs, input_types):
         data = inputs[0]
         fill_value = inputs[1]
-        dtype = self.infer_type(data)
-        return self.full_impl(data, fill_value, dtype)
+        return self.full_impl(self.infer_shape(data), fill_value, input_types[0])
 
     def linspace(self, inputs, input_types):
         start = inputs[0]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -831,12 +831,18 @@ class PyTorchOpConverter:
     def pad(self, inputs, input_types):
         data = inputs[0]
         pad = inputs[1]
-        mode = inputs[2]
+        if len(inputs) > 2:
+            mode = inputs[2]
+        else:
+            mode = "constant"
+        if len(inputs) == 4:
+            pad_value = inputs[3]
+        else:
+            pad_value = 0
         if mode == "replicate" or mode == "circular":
             raise ValueError(
                 "replicate and circular mode for torch.nn.functional.pad are not supported in TVM"
             )
-        pad_value = inputs[3]
         return _op.nn.pad(data, pad, pad_value=pad_value, pad_mode=mode)
 
     def linspace(self, inputs, input_types):

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -199,6 +199,28 @@ def verify_model(
         torch.cuda.empty_cache()
 
 
+def verify_model_with_input(test_func, input_data, input_dict={}):
+    baseline_outputs = test_func(*input_data)
+    trace = torch.jit.trace(test_func, [input.clone() for input in input_data])
+    input_names = ["input{}".format(idx) for idx, inp in enumerate(input_data)]
+    input_shapes = list(zip(input_names, [inp.shape for inp in input_data]))
+    mod, params = relay.frontend.from_pytorch(trace, input_shapes, {})
+    with tvm.transform.PassContext(opt_level=3):
+        for target in ["llvm", "cuda"]:
+            if not tvm.runtime.enabled(target):
+                continue
+            dev = tvm.device(target, 0)
+            lib = relay.build(mod, target=target, params=params)
+            relay_model = graph_executor.GraphModule(lib["default"](dev))
+            for name, value in input_dict.items():
+                relay_model.set_input(name, value)
+            relay_model.run()
+
+            compiled_output = relay_model.get_output(0).numpy()
+            assert_shapes_match(baseline_outputs, compiled_output)
+            tvm.testing.assert_allclose(baseline_outputs, compiled_output, rtol=1e-5, atol=1e-5)
+
+
 # Single operator tests
 @tvm.testing.uses_gpu
 def test_forward_pixel_shuffle():
@@ -1273,6 +1295,16 @@ def test_forward_reshape():
     verify_model(Reshape1(), input_data=input_data)
     verify_model(Reshape2(), input_data=input_data)
     verify_model(Reshape3(), input_data=torch.randn(2, 3, 4))
+
+
+@tvm.testing.uses_gpu
+def test_forward_reshape_as():
+    def test_func(input_tensor, other_tensor):
+        return input_tensor.reshape_as(other_tensor)
+
+    input_data = [torch.rand([2, 1, 10, 1, 10]), torch.rand([2, 1, 10, 10])]
+
+    verify_model_with_input(test_func, input_data, {"input0": input_data[0]})
 
 
 @tvm.testing.uses_gpu
@@ -2962,6 +2994,17 @@ def test_forward_ones_like():
 
 
 @tvm.testing.uses_gpu
+def test_forward_new_ones():
+    torch.set_grad_enabled(False)
+    input_shape = [1, 3, 10, 10]
+
+    def test_func(input_tensor):
+        return input_tensor.new_ones([3, 10, 10])
+
+    verify_model_with_input(test_func, [torch.rand(input_shape).float()])
+
+
+@tvm.testing.uses_gpu
 def test_forward_zeros():
     torch.set_grad_enabled(False)
 
@@ -3032,6 +3075,24 @@ def test_forward_full_like():
     verify_model(FullLike1().float().eval(), input_data=input_data)
     verify_model(FullLike2().float().eval(), input_data=input_data)
     verify_model(FullLike3().float().eval(), input_data=input_data)
+
+
+@tvm.testing.uses_gpu
+def test_forward_new_full():
+    torch.set_grad_enabled(False)
+    input_shape = [1, 3, 10, 10]
+
+    def test_func(input_tensor):
+        return input_tensor.new_full([2, 3], 1)
+
+    verify_model_with_input(test_func, [torch.rand(input_shape).float()])
+
+
+def test_forward_fill_():
+    def test_func(x):
+        return x.fill_(3)
+
+    verify_model_with_input(test_func, [torch.rand([1, 3, 10, 10]).float()])
 
 
 @tvm.testing.uses_gpu
@@ -3750,6 +3811,20 @@ def test_numel():
     verify_script_model(Numel(), [(1,)], targets)
     verify_script_model(Numel(), [(3, 5)], targets)
     verify_script_model(Numel(), [(3, 5, 8)], targets)
+
+
+def test_empty():
+    def test_func():
+        return torch.empty([1, 3, 10, 10])
+
+    verify_model_with_input(test_func, [])
+
+
+def test_empty_like():
+    def test_func(data):
+        return torch.empty_like(data)
+
+    verify_model_with_input(test_func, [torch.rand([1, 3, 10, 10]).float()])
 
 
 def test_forward_pretrained_bert_base_uncased():


### PR DESCRIPTION
This PR intends to add the following five ops for the pytorch frontend:
- aten::new_ones
- aten::new_full
- aten::fill_
~~- aten::pad~~ (This op is relocated to #11922 )
- aten::reshape_as
- aten::empty_like

Note that arguments to the above ops will be changed by relay at runtime so `verify_model` won't work on them. 

cc: @masahi @junrushao1994 @zxybazh 
