### PR TITLE
set FLUSH_TO_ZERO ON by default

### DIFF
--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -36,6 +36,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <vector>
+#include <xmmintrin.h>
 
 namespace tvm {
 namespace codegen {
@@ -54,6 +55,13 @@ runtime::Module Build(IRModule mod, Target target) {
 
   // the build function.
   std::string build_f_name = "target.build." + target->kind->name;
+  if (target->kind->name == "llvm" && !(_mm_getcsr() & 0x8040)) {
+    LOG(WARNING) << "Set FLUSH_TO_ZERO ON by default in Build on LLVM."<< std::endl;
+    //DAZ
+    _mm_setcsr( _mm_getcsr() | 0x0040 );
+    //FTZ
+    _mm_setcsr( _mm_getcsr() | 0x8000 );
+  }
   const PackedFunc* bf = runtime::Registry::Get(build_f_name);
   ICHECK(bf != nullptr) << build_f_name << " is not enabled";
   return (*bf)(mod, target);


### PR DESCRIPTION
This PR aims to start a discussion on how to enable a `set_flush_to_zero` interface that is user friendly. 
(The initial solution is provided.)
The interface is supposed to meet the following requirements:

1. Target should be checked. This solution can only be applied to CPU.
2. Developers can easily set flust_to_zero on or off.
3. The function can only be called once.
