### PR TITLE
[PyTorch] fix unit8 in _convert_dtype_value

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3575,7 +3575,7 @@ def _convert_dtype_value(val):
         3: "torch.int32",
         2: "torch.int16",
         1: "torch.int8",
-        0: "torch.unit8",
+        0: "torch.uint8",
         None: "torch.int64",
     }  # Default is torch.int64
     if val in convert_torch_dtype_map:


### PR DESCRIPTION
Hitting this error with `vision_maskrcnn` in torchbench. Stacktrace below:
```
ERROR:torchdynamo.optimizations.backends:tvm error
Traceback (most recent call last):
  File "/home/xx/torchdynamo/torchdynamo/optimizations/backends.py", line 640, in tvm_compile_inner
    mod, params = relay.frontend.from_pytorch(jit_mod, shape_list)
  File "/home/xx/tvm/python/tvm/relay/frontend/pytorch.py", line 4320, in from_pytorch
    outputs = converter.convert_operators(_get_operator_nodes(graph.nodes()), outputs, ret_name)
  File "/home/xx/tvm/python/tvm/relay/frontend/pytorch.py", line 3694, in convert_operators
    relay_out = relay_op(
  File "/home/xx/tvm/python/tvm/relay/frontend/pytorch.py", line 856, in new_full
    dtype = _convert_dtype_value(inputs[2])
  File "/home/xx/tvm/python/tvm/relay/frontend/pytorch.py", line 3765, in _convert_dtype_value
    return _convert_data_type(convert_torch_dtype_map[val])
  File "/home/xx/tvm/python/tvm/relay/frontend/pytorch.py", line 3806, in _convert_data_type
    raise NotImplementedError("input_type {} is not handled yet".format(input_type))
NotImplementedError: input_type torch.unit8 is not handled yet
input_type torch.unit8 is not handled yet
```

reference: https://pytorch.org/docs/stable/tensors.html

cc: @masahi 