### PR TITLE
[Hexagon] Skip test_avg_pool2d_slice because of segfault

### DIFF
--- a/tests/python/contrib/test_hexagon/topi/test_avg_pool2d_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_avg_pool2d_slice.py
@@ -23,6 +23,7 @@ from tvm import te, topi
 import tvm.testing
 from tvm.topi import testing
 from tvm.contrib.hexagon.build import HexagonLauncher
+from tvm.contrib.hexagon.session import Session
 import tvm.topi.hexagon.slice_ops as sl
 from ..infrastructure import allocate_hexagon_array, transform_numpy
 
@@ -310,8 +311,10 @@ class TestAvgPool2dSlice:
         transformed_input_np_padded,
         transformed_expected_output_np,
         expected_output_np,
-        hexagon_session,
+        hexagon_session: Session,
     ):
+        if hexagon_session._launcher._serial_number != "simulator":
+            pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11928")
 
         target_hexagon = tvm.target.hexagon("v69")
         A = te.placeholder(input_shape_padded, name="A", dtype=dtype)


### PR DESCRIPTION
cc @csullivan 