### PR TITLE
[PyTorch][Relay] Add aten::cross_entropy_loss

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -884,7 +884,7 @@ class PyTorchOpConverter:
             else:
                 reduction = "sum"
             num_class = self.infer_shape(input)[1]
-            if weights == None:
+            if weights is None:
                 weights = _op.full(_expr.const(1), (num_class,), dtype=input_types[0])
             return _op.nn.nll_loss(
                 _op.nn.log_softmax(input), target, weights, reduction, ignore_index

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -876,7 +876,7 @@ class PyTorchOpConverter:
         label_smoothing = inputs[5]
         assert weight is None, "weight not supported in cross_entropy_loss"
         assert reduction == 1, "reduction not supported in cross_entropy_loss"
-        assert ignore_index == -100, "reduce not supported in cross_entropy_loss"
+        assert ignore_index == -100, "ignore_index not supported in cross_entropy_loss"
         assert label_smoothing == 0.0, "label_smoothing not supported in cross_entropy_loss"
         input_shape = self.infer_shape(input)
         target_shape = self.infer_shape(input)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -890,7 +890,7 @@ class PyTorchOpConverter:
                 _op.nn.log_softmax(input), target, weights, reduction, ignore_index
             )
         assert reduction == 1, "reduction not supported in cross_entropy_loss"
-        assert ignore_index == -100, "reduce not supported in cross_entropy_loss"
+        assert ignore_index == -100, "ignore_index not supported in cross_entropy_loss"
         assert label_smoothing == 0.0, "label_smoothing not supported in cross_entropy_loss"
         assert weights is None, "weight not supported in cross_entropy_loss"
         return _op.nn.cross_entropy_with_logits(_op.nn.log_softmax(input), target)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -867,6 +867,11 @@ class PyTorchOpConverter:
         data = inputs[0]
         return _op.log(_op.tensor.sigmoid(data))
 
+    def cross_entropy_loss_with_logits(self, inputs, input_types):
+        input = inputs[0]
+        target = inputs[2]
+        return _op.nn.cross_entropy_with_logits(input, target)
+
     def hard_sigmoid(self, inputs, input_types):
         def _relu6(x):
             return _op.tensor.clip(x, 0.0, 6.0)
@@ -3119,6 +3124,7 @@ class PyTorchOpConverter:
             "aten::silu": self.silu,
             "aten::glu": self.glu,
             "aten::log_sigmoid": self.log_sigmoid,
+            "aten::cross_entropy_loss": self.cross_entropy_loss_with_logits,
             "aten::adaptive_avg_pool1d": functools.partial(
                 self.adaptive_avg_pool, _op.nn.adaptive_avg_pool1d
             ),

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -867,7 +867,7 @@ class PyTorchOpConverter:
         data = inputs[0]
         return _op.log(_op.tensor.sigmoid(data))
 
-    def cross_entropy_loss(self, inputs, input_types):
+    def cross_entropy_loss_with_logits(self, inputs, input_types):
         input = inputs[0]
         target = inputs[1]
         weights = inputs[2]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -867,10 +867,22 @@ class PyTorchOpConverter:
         data = inputs[0]
         return _op.log(_op.tensor.sigmoid(data))
 
-    def cross_entropy_loss_with_logits(self, inputs, input_types):
+    def cross_entropy_loss(self, inputs, input_types):
         input = inputs[0]
-        target = inputs[2]
-        return _op.nn.cross_entropy_with_logits(input, target)
+        target = inputs[1]
+        weight = inputs[2]
+        reduction = inputs[3]
+        ignore_index = inputs[4]
+        label_smoothing = inputs[5]
+        assert weight is None, "weight not supported in cross_entropy_loss"
+        assert reduction == 1, "reduction not supported in cross_entropy_loss"
+        assert ignore_index == -100, "reduce not supported in cross_entropy_loss"
+        assert label_smoothing == 0.0, "label_smoothing not supported in cross_entropy_loss"
+        input_shape = self.infer_shape(input)
+        target_shape = self.infer_shape(input)
+        if input_shape != target_shape:
+            raise NotImplementedError("class indices for cross_entropy_loss is not supported")
+        return _op.nn.cross_entropy_with_logits(_op.nn.log_softmax(input), target)
 
     def hard_sigmoid(self, inputs, input_types):
         def _relu6(x):

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -727,6 +727,20 @@ def test_forward_log_sigmoid():
     verify_model(torch.nn.LogSigmoid().eval(), input_data=input_data)
 
 
+def test_cross_entropy_loss():
+    def test_func_cross_entropy_loss(input, target):
+        loss = torch.nn.CrossEntropyLoss()
+        return loss(input, target)
+
+    verify_model(
+        test_func_cross_entropy_loss,
+        input_data=[
+            torch.randn(3, 5),
+            torch.randn(3, 5).softmax(dim=1),
+        ],
+    )
+
+
 @tvm.testing.uses_gpu
 def test_forward_adaptive_avgpool():
     torch.set_grad_enabled(False)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -727,20 +727,6 @@ def test_forward_log_sigmoid():
     verify_model(torch.nn.LogSigmoid().eval(), input_data=input_data)
 
 
-def test_cross_entropy_loss():
-    def test_func_cross_entropy_loss(input, target):
-        loss = torch.nn.CrossEntropyLoss()
-        return loss(input, target)
-
-    verify_model(
-        test_func_cross_entropy_loss,
-        input_data=[
-            torch.randn(3, 5),
-            torch.randn(3, 5).softmax(dim=1),
-        ],
-    )
-
-
 @tvm.testing.uses_gpu
 def test_forward_adaptive_avgpool():
     torch.set_grad_enabled(False)
@@ -4095,6 +4081,24 @@ def test_forward_nll_loss():
     verify_model(torch.nn.NLLLoss(ignore_index=1).eval(), input_data=[predictions, targets])
     verify_model(torch.nn.NLLLoss(reduction="sum").eval(), input_data=[predictions, targets])
     verify_model(torch.nn.NLLLoss(reduction="none").eval(), input_data=[predictions, targets])
+
+
+def test_cross_entropy_loss():
+    torch.set_grad_enabled(False)
+    N, C = 10, 3
+    # class indices
+    predictions = torch.rand((N, C)).float()
+    targets = torch.randint(0, 3, (N,))
+    weights = torch.tensor([1, 2, 3]).float()
+    verify_model(torch.nn.CrossEntropyLoss().eval(), input_data=[predictions, targets])
+    verify_model(
+        torch.nn.CrossEntropyLoss(weight=weights).eval(), input_data=[predictions, targets]
+    )
+
+    # class probabilities
+    predictions = torch.randn(N, C).float()
+    targets = torch.randn(N, C)
+    verify_model(torch.nn.CrossEntropyLoss().eval(), input_data=[predictions, targets])
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
This PR intends to add `aten::cross_entropy_loss` for the pytorch frontend. This is related to previous correctness issue of `cross_entropy_loss_with_logits` [here](https://github.com/apache/tvm/issues/9109).

cc: @masahi 
