### PR TITLE
[ci] Specify permissions for tvm bot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,10 @@ on:
   push:
     branches:
       - main
-
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: CI-${{ github.event.pull_request.number || github.sha }}
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   MacOS:
+    if: ${{ github.repository == 'apache/tvm' }}
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
@@ -78,6 +79,7 @@ jobs:
           python -m pytest -v tests/python/contrib/test_rpc_server_device.py
 
   Windows:
+    if: ${{ github.repository == 'apache/tvm' }}
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -96,6 +98,7 @@ jobs:
           python -m pytest -v tests/python/all-platform-minimal-test
 
   Android:
+    if: ${{ github.repository == 'apache/tvm' }}
     runs-on: Ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -13,6 +13,14 @@ concurrency:
 
 jobs:
   run-tvm-bot:
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+      statuses: write
     if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
     runs-on: ubuntu-20.04
     steps:

--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -87,10 +87,17 @@ class GitHubRepo:
 
         try:
             with request.urlopen(req, data) as response:
-                response = json.loads(response.read())
+                content = response.read()
         except error.HTTPError as e:
             logging.info(f"Error response: {e.read().decode()}")
+            e.seek(0)
             raise e
+
+        logging.info(f"Got response from {full_url}: {content}")
+        try:
+            response = json.loads(content)
+        except json.decoder.JSONDecodeError as e:
+            return content
 
         return response
 


### PR DESCRIPTION
This adjusts some error reporting for tvm-bot and manually specifies the permissions it should run with to hopefully alleviate the 403 errors when merging PRs

cc @Mousius @areusch