### PR TITLE
[ci][docker] Use RFC image tags only

### DIFF
--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -832,7 +832,7 @@ def test_github_tag_teams(tmpdir_factory):
             "results": [
                 {
                     "last_updated": "2022-06-01T00:00:00.123456Z",
-                    "name": "abc-abc-123",
+                    "name": "123-123-abc",
                 },
             ]
         },
@@ -840,7 +840,7 @@ def test_github_tag_teams(tmpdir_factory):
             "results": [
                 {
                     "last_updated": "2022-06-01T00:00:00.123456Z",
-                    "name": "abc-abc-123",
+                    "name": "123-123-abc",
                 },
             ]
         },
@@ -851,8 +851,12 @@ def test_github_tag_teams(tmpdir_factory):
         tlcpackstaging_body={
             "results": [
                 {
+                    "last_updated": "2022-06-01T01:00:00.123456Z",
+                    "name": "234-234-abc-staging",
+                },
+                {
                     "last_updated": "2022-06-01T00:00:00.123456Z",
-                    "name": "abc-abc-234-staging",
+                    "name": "456-456-abc",
                 },
             ]
         },
@@ -860,13 +864,13 @@ def test_github_tag_teams(tmpdir_factory):
             "results": [
                 {
                     "last_updated": "2022-06-01T00:00:00.123456Z",
-                    "name": "abc-abc-123",
+                    "name": "123-123-abc",
                 },
             ]
         },
         expected="Using tlcpackstaging tag on tlcpack",
         expected_images=[
-            "ci_arm = 'tlcpack/ci-arm:abc-abc-234-staging'",
+            "ci_arm = 'tlcpack/ci-arm:456-456-abc'",
         ],
     ),
     dict(
@@ -874,7 +878,7 @@ def test_github_tag_teams(tmpdir_factory):
             "results": [
                 {
                     "last_updated": "2022-06-01T00:00:00.123456Z",
-                    "name": "abc-abc-123",
+                    "name": "123-123-abc",
                 },
             ]
         },
@@ -882,13 +886,13 @@ def test_github_tag_teams(tmpdir_factory):
             "results": [
                 {
                     "last_updated": "2022-06-01T00:01:00.123456Z",
-                    "name": "abc-abc-234",
+                    "name": "234-234-abc",
                 },
             ]
         },
         expected="Found newer image, using: tlcpack",
         expected_images=[
-            "ci_arm = 'tlcpack/ci-arm:abc-abc-234'",
+            "ci_arm = 'tlcpack/ci-arm:234-234-abc'",
         ],
     ),
 )

--- a/tests/scripts/open_docker_update_pr.py
+++ b/tests/scripts/open_docker_update_pr.py
@@ -22,6 +22,7 @@ import logging
 import datetime
 import os
 import json
+import re
 from urllib import error
 from typing import List, Dict, Any, Optional, Callable
 from git_utils import git, parse_remote, GitHubRepo
@@ -52,6 +53,10 @@ def parse_docker_date(d: str) -> datetime.datetime:
     return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%fZ")
 
 
+def check_tag(tag: Dict[str, Any]) -> bool:
+    return re.match(r"^[0-9]+-[0-9]+-[a-z0-9]+$", tag["name"]) is not None
+
+
 def latest_tag(user: str, repo: str) -> List[Dict[str, Any]]:
     """
     Queries Docker Hub and finds the most recent tag for the specified image/repo pair
@@ -63,6 +68,7 @@ def latest_tag(user: str, repo: str) -> List[Dict[str, Any]]:
         result["last_updated"] = parse_docker_date(result["last_updated"])
 
     results = list(sorted(results, key=lambda d: d["last_updated"]))
+    results = [tag for tag in results if check_tag(tag)]
     return results[-1]
 
 


### PR DESCRIPTION
This ignores any images that don't match the pattern laid out in https://github.com/apache/tvm-rfcs/pull/66

cc @Mousius @areusch