### PR TITLE
[ETHOSN] Supply output tensor to issupported checks

### DIFF
--- a/src/relay/backend/contrib/ethosn/ethosn_api.h
+++ b/src/relay/backend/contrib/ethosn/ethosn_api.h
@@ -50,9 +50,10 @@ namespace sl = ::ethosn::support_library;
 
 struct ConvolutionParams {
   sl::ConvolutionInfo conv_info;
-  sl::TensorInfo activation_info;
+  sl::TensorInfo input_info;
   sl::TensorInfo weights_info;
   sl::TensorInfo bias_info;
+  sl::TensorInfo output_info;
   void* raw_weights = nullptr;
   void* raw_bias = nullptr;
   bool is_depthwise = false;
@@ -63,6 +64,7 @@ struct FullyConnectedParams {
   sl::TensorInfo input_info;
   sl::TensorInfo weights_info;
   sl::TensorInfo bias_info;
+  sl::TensorInfo output_info;
   void* raw_weights = nullptr;
   void* raw_bias = nullptr;
 };
@@ -70,60 +72,72 @@ struct FullyConnectedParams {
 struct MaxPool2DParams {
   sl::PoolingInfo pool_info = sl::PoolingInfo(0, 0, 0, 0, sl::Padding(), sl::PoolingType::MAX);
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct AvgPool2DParams {
   sl::PoolingInfo pool_info = sl::PoolingInfo(0, 0, 0, 0, sl::Padding(), sl::PoolingType::AVG);
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct ReshapeParams {
   sl::TensorShape new_shape{};
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct AdditionParams {
   sl::QuantizationInfo output_quantization_info;
   sl::TensorInfo lhs_info;
   sl::TensorInfo rhs_info;
+  sl::TensorInfo output_info;
 };
 
 struct SigmoidParams {
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct MeanParams {
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct TanhParams {
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct LeakyReLUParams {
   sl::LeakyReluInfo leaky_relu_info;
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct ConcatenateParams {
   sl::QuantizationInfo qInfo;
   sl::ConcatenationInfo concat_info = sl::ConcatenationInfo(1, qInfo);
   std::vector<sl::TensorInfo> input_infos;
+  sl::TensorInfo output_info;
 };
 
 struct SplitParams {
   sl::SplitInfo split_info = sl::SplitInfo(0, {});
   sl::TensorInfo input_info;
+  std::vector<sl::TensorInfo> output_infos;
 };
 
 struct DepthToSpaceParams {
   sl::DepthToSpaceInfo depth_info = sl::DepthToSpaceInfo(0);
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 struct ReluParams {
   sl::ReluInfo relu_info;
   sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
 };
 
 /*!
@@ -242,10 +256,14 @@ class EthosnAPI {
   static EthosnError Tvm2Npu(const Array<Array<Integer>>& padding, sl::Padding* npu_padding);
   /*! \brief Convert a TVM Integer array to a SL tensor shape */
   static EthosnError Tvm2Npu(const Array<Integer>& shape, sl::TensorShape* npu_shape);
+  /*! \brief Convert a TVM Type to SL tensor info. */
+  static EthosnError Tvm2Npu(const tvm::Type& type, sl::TensorInfo* npu_tinfo);
+
   /*! \brief Convert a TVM pooling call to SL pooling information */
-  static EthosnError Pool2d(const Call& pool, Array<IndexExpr> size, Array<IndexExpr> strides,
-                            Array<IndexExpr> padding, sl::PoolingType pooling_type,
-                            sl::PoolingInfo* pool_info, sl::TensorInfo* input_info,
+  static EthosnError Pool2d(const Call& input, const Call& output, Array<IndexExpr> size,
+                            Array<IndexExpr> strides, Array<IndexExpr> padding,
+                            sl::PoolingType pooling_type, sl::PoolingInfo* pool_info,
+                            sl::TensorInfo* input_info, sl::TensorInfo* output_info,
                             std::string layout);
 
   // Convert an array of IntImmNodes into ValueT

--- a/tests/python/contrib/test_ethosn/test_concatenate.py
+++ b/tests/python/contrib/test_ethosn/test_concatenate.py
@@ -99,7 +99,7 @@ def test_concatenate_failure():
             "batch size=2, batch size must = 1; batch size=2, batch size must = 1;",
         ),
         (
-            [(1, 4, 4, 4), (1, 4, 4, 4)],
+            [(1, 4, 4, 4)],
             "uint8",
             0,
             "Concatenation cannot be performed along batch axis (axis 0);",

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -143,7 +143,6 @@ def test_mobilenet_v1():
     )
 
 
-@pytest.mark.skip(reason="very slow test")
 @requires_ethosn
 def test_resnet_50_int8():
     # If this test is failing due to a hash mismatch, please notify @mbaret and
@@ -153,7 +152,7 @@ def test_resnet_50_int8():
     # on hardware that isn't available in CI.
     if tei.get_ethosn_api_version() > 2011:
         if tei.get_ethosn_variant() == "Ethos-N78_1TOPS_2PLE_RATIO":
-            _compile_hash = {"de6723dc69f5f3015c4ab5cb8f288221", "dc2ed339583a59f0c3d38dc5ff069ec9"}
+            _compile_hash = {"c0a01c547ed1b2e3308094508fa1bfea", "434f0c65c41e24d5482142c88b3438fe"}
             _test_image_network(
                 model_url="https://raw.githubusercontent.com/dmlc/web-data/main/tensorflow/"
                 "models/Quantized/resnet_50_quantized.tflite",
@@ -163,7 +162,6 @@ def test_resnet_50_int8():
                 output_count=1,
                 host_ops=11,
                 npu_partitions=2,
-                run=True,
             )
 
 


### PR DESCRIPTION
Some operations were being offloaded when they are not supported by the NPU, for example mean could get offloaded with different quantization parameters for the input and output which is not supported. Consequently, this meant that there would be a failure during compilation or an output mismatch at runtime. Fixing this by supplying the output information to the issupported checks that determine whether an operation should be offloaded.

cc @Leo-arm @manupa-arm 
