### PR TITLE
[VM] Export symbols for VirtualMachine on Windows

### DIFF
--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -145,7 +145,7 @@ struct VMFrame {
  * multiple threads, or serialize them to disk or over the
  * wire.
  */
-class VirtualMachine : public runtime::ModuleNode {
+class TVM_DLL VirtualMachine : public runtime::ModuleNode {
  public:
   /*!
    * \brief Get a PackedFunc from module.


### PR DESCRIPTION
When using the native C++ API of the `VirtualMachine`, link error occurred when building the project: `undefined symbols for the VirtualMachine`.
This is due to the fact that these symbols were not exported from `tvm.dll`.
This patch fixes this issue.
