### PR TITLE
[MetaSchedule] Handle 'warp_execution' implied extend of threadIdx.x in VerifyGpuCode

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1526,6 +1526,12 @@ constexpr const char* meta_schedule_auto_tensorize = "meta_schedule.auto_tensori
 constexpr const char* meta_schedule_layout_rewrite_preproc = "meta_schedule.layout_rewrite_preproc";
 
 /*!
+ * \brief Mark that a block is executed by a warp. This implies the extend of threadIdx.x is
+ * warp size.
+ */
+constexpr const char* warp_execution = "warp_execution";
+
+/*!
  * \brief Check if attr_key is a pragma key extension
  * \param attr_key The attr key to be compared
  * \return true if it is a pragma key


### PR DESCRIPTION
Added annotation `warp_execution` to indicates a block is executed by a warp (e.g. tensor core instructions).
Updated `VerifyGPUCode` to support the annotation implied extend of `threadIdx.x`

cc @junrushao1994 @spectrometerHBH @Hzfengsy 