### PR TITLE
[RPC] Add Data & Time For RPC Tracker / Server Logging

### DIFF
--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -49,6 +49,15 @@ from . import testing
 from .base import TrackerCode
 
 logger = logging.getLogger("RPCServer")
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(
+    logging.Formatter(
+        fmt="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+)
+logger.addHandler(console_handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
 
 
 def _server_env(load_library, work_path=None):

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -64,6 +64,15 @@ from . import base
 from .base import RPC_TRACKER_MAGIC, TrackerCode
 
 logger = logging.getLogger("RPCTracker")
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(
+    logging.Formatter(
+        fmt="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+)
+logger.addHandler(console_handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
 
 
 class Scheduler(object):


### PR DESCRIPTION
I notice that the TVM RPC tracker and server's logging does not have date and time details, like the following snippet from server:
```
INFO:RPCServer:Finish serving ('172.34.51.174', 37306)
INFO:RPCServer:connection from ('172.34.51.174', 37308)
```
This PR introduces a stream handler to format the logging out with new format as follows:
```
2022-06-29 12:19:34.003 INFO bind to 172.34.54.88:4445
```
This is could help user monitor RPC traffic and workload time usage.