### PR TITLE
[VM] class Executable does not export symbols to dll

### DIFF
--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -54,7 +54,7 @@ struct VMFunction;
  *  used by the virtual machine.
  *  - Code section, handling the VM functions and bytecode.
  */
-class Executable : public ModuleNode {
+class TVM_DLL Executable : public ModuleNode {
  public:
   /*!
    * \brief Get a PackedFunc from an executable module.


### PR DESCRIPTION
It continues patch from #11947 
When using the native C++ API of the `Executable` of `Virtual Machine`, sometimes link error occurred when building the project: `undefined symbols for the Executable`.
This is due to the fact that these symbols were not exported from `tvm.dll`.
This patch fixes this issue.
