### PR TITLE
[DNNL][BYOC] Enable Altering Dense Weight Layout

### DIFF
--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -502,6 +502,9 @@ class DNNLJSONSerializer : public backend::contrib::JSONSerializer {
       } else if (name.find("dnnl.dense") != std::string::npos) {
         call = GetRootCall(fn->body.as<CallNode>(), 10, "nn.dense");
         ICHECK(call->op.as<OpNode>()) << "Not op node";
+      } else if (name.find("dnnl.packeddense") != std::string::npos) {
+        call = GetRootCall(fn->body.as<CallNode>(), 10, "nn.contrib_dense_pack");
+        ICHECK(call->op.as<OpNode>()) << "Not op node";
       } else if (name.find("dnnl.qnn.conv2d") != std::string::npos ||
                  name.find("dnnl.qnn.dense") != std::string::npos) {
         std::vector<Expr> args_loc;

--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -468,6 +468,13 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     // Assumption that bias is correct and can be squeezed to 1D
     bias_tr = bias_tr.Reshape({dst_tr.dims()[1]});
 
+    auto wgh_layout = GetNodeAttr<std::string>(node, "weight_layout", {"NC"});
+    wgh_tr = wgh_tr.TreatAs(wgh_layout, "NC");
+
+    // Crop the weight tensor on demand
+    auto zero_offset = dnnl::memory::dims(wgh_tr.dims().size(), 0);
+    wgh_tr = wgh_tr.Crop({dst_tr.dims()[1], src_tr.dims()[1]}, zero_offset);
+
     // Dense description.
     auto dense_desc = dnnl::inner_product_forward::desc(
         dnnl::prop_kind::forward_inference, src_tr.LayoutAny().desc(), wgh_tr.LayoutAny().desc(),

--- a/src/runtime/contrib/dnnl/dnnl_tensor_requisite.h
+++ b/src/runtime/contrib/dnnl/dnnl_tensor_requisite.h
@@ -256,7 +256,7 @@ class TensorRequisite {
     if (layout.find("G") != std::string::npos) return "GOI" + sparse_dims[rank - 4];
     if (layout.find("O") != std::string::npos) return "OI" + sparse_dims[rank - 3];
 
-    LOG(FATAL) << "Unknown layout " << layout << "There is no default scheme to handle it";
+    LOG(FATAL) << "Unknown layout: " << layout << ". There is no default scheme to handle it";
     return {};
   }
 


### PR DESCRIPTION
The patch including four parts:
1. Enable nn.contrib_dense_pack to be partitioned and offloaded by dnnl byoc.
1. Enable alter dense layout function during build relay model by introducing nn.contrib_dense_pack.
2. Make some minor fixes in tensor_requisite.h.
3. Add UT for pack dense.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
