### PR TITLE
[ci] Clean up non-build stuff in builds

### DIFF
--- a/ci/jenkins/Build.groovy.j2
+++ b/ci/jenkins/Build.groovy.j2
@@ -19,7 +19,7 @@ def fsim_test(image) {
   )
 }
 
-def cmake_build(image, path, make_flag) {
+def cmake_build(image, path) {
   sh (
     script: "${docker_run} --env CI_NUM_EXECUTORS ${image} ./tests/scripts/task_build.py --sccache-bucket tvm-sccache-prod",
     label: 'Run cmake build',
@@ -55,10 +55,10 @@ def add_hexagon_permissions() {
 // Run make. First try to do an incremental make from a previous workspace in hope to
 // accelerate the compilation. If something is wrong, clean the workspace and then
 // build from scratch.
-def make(docker_type, path, make_flag) {
+def make(docker_type, path) {
   timeout(time: max_time, unit: 'MINUTES') {
     try {
-      cmake_build(docker_type, path, make_flag)
+      cmake_build(docker_type, path)
     } catch (hudson.AbortException ae) {
       // script exited due to user abort, directly throw instead of retry
       if (ae.getMessage().contains('script returned exit code 143')) {
@@ -69,7 +69,7 @@ def make(docker_type, path, make_flag) {
         script: "${docker_run} ${docker_type} ./tests/scripts/task_clean.sh ${path}",
         label: 'Clear old cmake workspace',
       )
-      cmake_build(docker_type, path, make_flag)
+      cmake_build(docker_type, path)
     }
   }
 }
@@ -88,12 +88,12 @@ stage('Build') {
           docker_init(ci_gpu)
           init_git()
           sh "${docker_run} --no-gpu ${ci_gpu} ./tests/scripts/task_config_build_gpu.sh build"
-          make("${ci_gpu} --no-gpu", 'build', '-j2')
+          make("${ci_gpu} --no-gpu", 'build')
           {{ m.upload_artifacts(tag='gpu', filenames=tvm_multilib, folders=microtvm_template_projects) }}
 
           // compiler test
           sh "${docker_run} --no-gpu ${ci_gpu} ./tests/scripts/task_config_build_gpu_other.sh build2"
-          make("${ci_gpu} --no-gpu", 'build2', '-j2')
+          make("${ci_gpu} --no-gpu", 'build2')
           {{ m.upload_artifacts(tag='gpu2', filenames=tvm_multilib) }}
         }
       }
@@ -109,14 +109,8 @@ stage('Build') {
             script: "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh build",
             label: 'Create CPU cmake config',
           )
-          make(ci_cpu, 'build', '-j2')
+          make(ci_cpu, 'build')
           {{ m.upload_artifacts(tag='cpu', filenames=tvm_multilib_tsim) }}
-          timeout(time: max_time, unit: 'MINUTES') {
-            ci_setup(ci_cpu)
-            // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
-            // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-            sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
-          }
         }
       }
     } else {
@@ -133,7 +127,7 @@ stage('Build') {
             script: "${docker_run} ${ci_wasm} ./tests/scripts/task_config_build_wasm.sh build",
             label: 'Create WASM cmake config',
           )
-          make(ci_wasm, 'build', '-j2')
+          make(ci_wasm, 'build')
           cpp_unittest(ci_wasm)
           timeout(time: max_time, unit: 'MINUTES') {
             ci_setup(ci_wasm)
@@ -158,7 +152,7 @@ stage('Build') {
             script: "${docker_run} ${ci_i386} ./tests/scripts/task_config_build_i386.sh build",
             label: 'Create i386 cmake config',
           )
-          make(ci_i386, 'build', '-j2')
+          make(ci_i386, 'build')
           {{ m.upload_artifacts(tag='i386', filenames=tvm_multilib_tsim) }}
         }
       }
@@ -194,7 +188,7 @@ stage('Build') {
             script: "${docker_run} ${ci_qemu} ./tests/scripts/task_config_build_qemu.sh build",
             label: 'Create QEMU cmake config',
           )
-          make(ci_qemu, 'build', '-j2')
+          make(ci_qemu, 'build')
           {{ m.upload_artifacts(tag='qemu', filenames=tvm_lib, folders=microtvm_template_projects) }}
         }
       }
@@ -212,7 +206,7 @@ stage('Build') {
             script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_config_build_hexagon.sh build",
             label: 'Create Hexagon cmake config',
           )
-          make(ci_hexagon, 'build', '-j2')
+          make(ci_hexagon, 'build')
           sh (
             script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_build_hexagon_api.sh",
             label: 'Build Hexagon API',

--- a/ci/jenkins/Test.groovy.j2
+++ b/ci/jenkins/Test.groovy.j2
@@ -42,7 +42,7 @@
 {% call(shard_index, num_shards) m.sharded_test_step(
   name="integration: CPU",
   node="CPU-SMALL",
-  num_shards=6,
+  num_shards=8,
   ws="tvm/integration-python-cpu",
   platform="cpu",
   docker_image="ci_cpu",
@@ -215,6 +215,7 @@ stage('Test') {
       script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta_tsim.sh",
       label: 'Run VTA tests in TSIM',
     )
+    sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
   {% endcall %}
   {% call m.test_step(
     name="test: QEMU",

--- a/tests/scripts/task_build_hexagon_api.sh
+++ b/tests/scripts/task_build_hexagon_api.sh
@@ -39,15 +39,13 @@ if [ "$use_cache" = false ]; then
     rm -rf build
 fi
 mkdir -p build
-cd build
 
-cmake -DANDROID_ABI=arm64-v8a \
+python3 ../../tests/scripts/task_build.py --use-make \
+    -DANDROID_ABI=arm64-v8a \
     -DANDROID_PLATFORM=android-28 \
     -DUSE_ANDROID_TOOLCHAIN="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
     -DUSE_HEXAGON_ARCH=v68 \
     -DUSE_HEXAGON_SDK="${HEXAGON_SDK_ROOT}" \
     -DUSE_HEXAGON_TOOLCHAIN="${HEXAGON_TOOLCHAIN}" \
     -DUSE_OUTPUT_BINARY_DIR="${output_directory}" \
-    -DUSE_HEXAGON_GTEST="${HEXAGON_SDK_ROOT}/utils/googletest/gtest" ..
-
-make -j$(nproc)
+    -DUSE_HEXAGON_GTEST="${HEXAGON_SDK_ROOT}/utils/googletest/gtest"


### PR DESCRIPTION
This moves the rust build and test to the CPU unittest (CPU was sometimes bottlenecking the builds) and makes the Hexagon build use `task_build.py` so it gets sccache when the compiler isn't overridden

