### PR TITLE
[LLVM] Remove use of deprecated `PointerType::getPointerElementType()`

### DIFF
--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -190,10 +190,9 @@ class CodeGenCPU : public CodeGenLLVM {
 
   // Get the DWARF type corresponding to the LLVM type |ty|. The current API in practice only
   // generates |int32|, and |int8*|.
-  static llvm::DIType* getDebugType(IRBuilder* builder, llvm::DIBuilder* di_builder,
-                                    llvm::Type* ty);
+  llvm::DIType* GetDebugType(const Type& ty_tir, llvm::Type* ty_llvm);
   // Adds the DWARF debug information for |function| to |dbg_info_|.
-  void AddDebugInformation(llvm::Function* function);
+  void AddDebugInformation(PrimFunc f_tir, llvm::Function* f_llvm);
 };
 
 }  // namespace codegen


### PR DESCRIPTION
With LLVM switching to opaque (typeless) pointer types, some functions related to handling typed pointers are being deprecated (and will be removed).
The DWARF debug information does express pointee type. When constructing this information from opaque pointers in LLVM IR, the pointee type needs to be obtained from somewhere else (not the pointer).
Change the debug info generation to use the original PrimFunc to obtain the necessary type information. This will work with older versions of LLVM as well.
