### PR TITLE
Fix infercorrect layout in Layoutrewrite and improve naming.

### DIFF
--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -368,7 +368,8 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   // new_in2, new_out = op.infer(new_in)
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
-    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in_inferred, old_in_inferred, types);
+    std::tie(infer_out, success) =
+        InferCorrectLayouts(new_call, new_in_inferred, old_in_inferred, types);
     new_in2 = infer_out->input_layouts;
     new_out = infer_out->output_layouts;
     if (!success) {

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -319,14 +319,23 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
     }
   }
 
-  // old_in, new_in = state[inputs]
-  // naming rule:
-  // old_in, new_in: the input layouts given by downstream node.
-  // old_in2, new_in2: the input layouts inferred by the current node.
-  Array<Layout> old_in, old_in2, old_out, new_in, new_out, new_in2;
+  // old_prd, new_prd = state[inputs]
+  // different ops can view a tensor with different layouts, e.g. conv_1->transpose(H, W)->conv_2
+  // transpose view its output having NCWH layout, but conv_2 still views it as NCHW to operate
+  // old_prd, new_prd: the input layouts from the perspective of the producer (transpose)
+  // old_cur, new_cur: the input layouts from the perspective of the current node (conv_2)
+  // old_prd->new_prd tells how producer changed the layout
+  // old_cur->new_cur tells what change the current node wants to see
+  // No layout transforms are needed when they mean the same (NCHW->NCHW4c == NCWH->NCWH4c)
+
+  // The workflow:
+  // 1. Run InferCorrectLayouts(NULL, old_prd) to get old_cur
+  // 2. Run InferCorrectLayouts(new_prd, old_prd) to get new_cur and rewrite the current op
+
+  Array<Layout> old_prd, old_cur, old_out, new_prd, new_out, new_cur;
   for (auto inp : inputs) {
-    old_in.push_back(inp->old_layout);
-    new_in.push_back(inp->new_layout);
+    old_prd.push_back(inp->old_layout);
+    new_prd.push_back(inp->new_layout);
   }
 
   // Collect input types to pass on to Infer Correct Layout.
@@ -338,39 +347,39 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   bool success = false;
   InferCorrectLayoutOutput infer_out;
   std::tie(infer_out, success) =
-      InferCorrectLayouts(ref_call, Array<Layout>(nullptr), old_in, types);
-  old_in2 = infer_out->input_layouts;
+      InferCorrectLayouts(ref_call, Array<Layout>(nullptr), old_prd, types);
+  old_cur = infer_out->input_layouts;
   old_out = infer_out->output_layouts;
   if (!success) {
     return Expr(nullptr);
   }
-  ICHECK_EQ(old_in2.size(), new_in.size());
+  ICHECK_EQ(old_cur.size(), new_prd.size());
 
-  Array<Layout> new_in_inferred = new_in;  // for backward compatibility of InferCorrectLayouts
-  // if new_in_inferred == 'undef':  new_in_inferred = old_in2
-  for (size_t i = 0; i < new_in_inferred.size(); ++i) {
-    if (!new_in_inferred[i].defined()) {
-      new_in_inferred.Set(i, old_in2[i]);
+  // for backward compatibility of InferCorrectLayouts
+  Array<Layout> new_prd_inferred = new_prd;
+  // if new_prd_inferred == 'undef':  new_prd_inferred = old_cur
+  for (size_t i = 0; i < new_prd_inferred.size(); ++i) {
+    if (!new_prd_inferred[i].defined()) {
+      new_prd_inferred.Set(i, old_cur[i]);
     }
   }
-
-  Array<Layout> old_in_inferred = old_in;  // for backward compatibility of InferCorrectLayouts
-  // if old_in_inferred == 'undef':  old_in_inferred = old_in2
-  for (size_t i = 0; i < old_in_inferred.size(); ++i) {
-    if (!old_in_inferred[i].defined()) {
-      old_in_inferred.Set(i, old_in2[i]);
+  Array<Layout> old_prd_inferred = old_prd;
+  // if old_prd_inferred == 'undef':  old_prd_inferred = old_cur
+  for (size_t i = 0; i < old_prd_inferred.size(); ++i) {
+    if (!old_prd_inferred[i].defined()) {
+      old_prd_inferred.Set(i, old_cur[i]);
     }
   }
 
   // new_op = alter(op)
   Call new_call = memorizer->CallWithNewLayouts(ref_call, infer_out->new_attrs, normal_new_args);
 
-  // new_in2, new_out = op.infer(new_in)
+  // new_cur, new_out = op.infer(new_prd)
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
     std::tie(infer_out, success) =
-        InferCorrectLayouts(new_call, new_in_inferred, old_in_inferred, types);
-    new_in2 = infer_out->input_layouts;
+        InferCorrectLayouts(new_call, new_prd_inferred, old_prd_inferred, types);
+    new_cur = infer_out->input_layouts;
     new_out = infer_out->output_layouts;
     if (!success) {
       return Expr(nullptr);
@@ -381,27 +390,27 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
 
   ICHECK_EQ(new_out.size(), old_out.size())
       << "The number of output nodes should keep the same during alter_op_layout";
-  ICHECK_EQ(new_in.size(), new_in2.size())
+  ICHECK_EQ(new_prd.size(), new_cur.size())
       << "The number of input nodes should keep the same during alter_op_layout";
 
-  auto transform_layout = [&memorizer](Expr arg_item, const Layout& old_in, const Layout& old_in2,
-                                       const Layout& new_in, const Layout& new_in2) {
-    if (old_in2.Equals(old_in)) {  // the two transforms can be fused to one
-      arg_item = memorizer.Transform(arg_item, new_in, new_in2);
+  auto transform_layout = [&memorizer](Expr arg_item, const Layout& old_prd, const Layout& old_cur,
+                                       const Layout& new_prd, const Layout& new_cur) {
+    if (old_cur.Equals(old_prd)) {  // the two transforms can be fused to one
+      arg_item = memorizer.Transform(arg_item, new_prd, new_cur);
     } else {
-      if (old_in.defined()) arg_item = memorizer.Transform(arg_item, new_in, old_in);
-      arg_item = memorizer.Transform(arg_item, old_in2, new_in2);
+      if (old_prd.defined()) arg_item = memorizer.Transform(arg_item, new_prd, old_prd);
+      arg_item = memorizer.Transform(arg_item, old_cur, new_cur);
     }
     return arg_item;
   };
 
   DLOG(INFO) << "Transforming layout for `" << ref_call->op << "`";
-  DLOG(INFO) << " old_in=" << old_in;
-  DLOG(INFO) << " new_in=" << new_in;
-  DLOG(INFO) << " old_in2=" << old_in2;
-  DLOG(INFO) << " new_in2=" << new_in2;
+  DLOG(INFO) << " old_prd=" << old_prd;
+  DLOG(INFO) << " new_prd=" << new_prd;
+  DLOG(INFO) << " old_cur=" << old_cur;
+  DLOG(INFO) << " new_cur=" << new_cur;
 
-  // if (new_in != new_in2): insert transform (new_in -> new_in2)
+  // if (new_prd != new_cur): insert transform (new_prd -> new_cur)
   Array<Expr> transformed_args;
   size_t pt = 0;
   for (auto arg : new_call->args) {
@@ -411,13 +420,13 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
       transformed_tuple_arg.reserve(tuple_arg->fields.size());
       for (auto arg_item : tuple_arg->fields) {
         transformed_tuple_arg.push_back(
-            transform_layout(arg_item, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
+            transform_layout(arg_item, old_prd[pt], old_cur[pt], new_prd[pt], new_cur[pt]));
         pt++;
       }
       transformed_args.push_back(WithFields(tuple_arg, transformed_tuple_arg));
     } else {
       transformed_args.push_back(
-          transform_layout(arg, old_in[pt], old_in2[pt], new_in[pt], new_in2[pt]));
+          transform_layout(arg, old_prd[pt], old_cur[pt], new_prd[pt], new_cur[pt]));
       pt++;
     }
   }

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -346,11 +346,19 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   }
   ICHECK_EQ(old_in2.size(), new_in.size());
 
-  Array<Layout> new_in_tmp = new_in;  // for backward compatibility of InferCorrectLayouts
-  // if new_in_tmp == 'undef':  new_in_tmp = old_in2
-  for (size_t i = 0; i < new_in_tmp.size(); ++i) {
-    if (!new_in_tmp[i].defined()) {
-      new_in_tmp.Set(i, old_in2[i]);
+  Array<Layout> new_in_inferred = new_in;  // for backward compatibility of InferCorrectLayouts
+  // if new_in_inferred == 'undef':  new_in_inferred = old_in2
+  for (size_t i = 0; i < new_in_inferred.size(); ++i) {
+    if (!new_in_inferred[i].defined()) {
+      new_in_inferred.Set(i, old_in2[i]);
+    }
+  }
+
+  Array<Layout> old_in_inferred = old_in;  // for backward compatibility of InferCorrectLayouts
+  // if old_in_inferred == 'undef':  old_in_inferred = old_in2
+  for (size_t i = 0; i < old_in_inferred.size(); ++i) {
+    if (!old_in_inferred[i].defined()) {
+      old_in_inferred.Set(i, old_in2[i]);
     }
   }
 
@@ -360,7 +368,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   // new_in2, new_out = op.infer(new_in)
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
-    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in_tmp, old_in, types);
+    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in_inferred, old_in_inferred, types);
     new_in2 = infer_out->input_layouts;
     new_out = infer_out->output_layouts;
     if (!success) {

--- a/src/relay/transforms/transform_layout.h
+++ b/src/relay/transforms/transform_layout.h
@@ -360,7 +360,7 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
   // new_in2, new_out = op.infer(new_in)
   if (new_call->op->IsInstance<OpNode>()) {
     success = false;
-    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in_tmp, old_in2, types);
+    std::tie(infer_out, success) = InferCorrectLayouts(new_call, new_in_tmp, old_in, types);
     new_in2 = infer_out->input_layouts;
     new_out = infer_out->output_layouts;
     if (!success) {
@@ -385,6 +385,12 @@ Expr LayoutRewriter(const Call& ref_call, const Array<Expr>& new_args, const Obj
     }
     return arg_item;
   };
+
+  DLOG(INFO) << "Transforming layout for `" << ref_call->op << "`";
+  DLOG(INFO) << " old_in=" << old_in;
+  DLOG(INFO) << " new_in=" << new_in;
+  DLOG(INFO) << " old_in2=" << old_in2;
+  DLOG(INFO) << " new_in2=" << new_in2;
 
   // if (new_in != new_in2): insert transform (new_in -> new_in2)
   Array<Expr> transformed_args;

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1935,5 +1935,17 @@ def test_alter_with_subfunc():
     assert tvm.ir.structural_equal(relay.transform.AlterOpLayout()(mod), mod)
 
 
+def test_alter_with_reduce():
+    x = relay.var("x", shape=(1, 1, 1, 1))
+    y = relay.image.resize2d(x, (2, 4))
+    z = relay.mean(y, axis=0)
+    a = relay.image.resize1d(z, (1,))
+    func = relay.Function((x,), a)
+    mod = tvm.IRModule.from_expr(func)
+    mod = relay.transform.InferType()(mod)
+    with tvm.transform.PassContext(opt_level=4):
+        relay.build(mod, target="llvm")
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This model
```python
def @main(%x: Tensor[(1, 1, 1, 1), float32] /* ty=Tensor[(1, 1, 1, 1), float32] */) -> Tensor[(1, 1, 1), float32] {
  %0 = image.resize2d(%x, size=[2, 4], roi=[0f, 0f, 0f, 0f], rounding_method="") /* ty=Tensor[(1, 1, 2, 4), float32] */;
  %1 = mean(%0, axis=[3]) /* ty=Tensor[(1, 1, 2), float32] */;
  image.resize1d(%1, size=[1], roi=[0f, 0f], rounding_method="") /* ty=Tensor[(1, 1, 1), float32] */
}
```
fails with error `  Check failed: (tir::BijectiveLayout(new_src_layout, dst_layout).defined()) is false: Cannot insert layout transform because there are inconvertible layouts: NCW v.s. NCH`. This should be a bug introduced in https://github.com/apache/tvm/pull/10118. This line https://github.com/apache/tvm/pull/12007/commits/7805d6fb113c9a68dd4628bb136416349f211ca2#diff-c3bb97b7e813244d6dae39925cc10bb9d50e8b7a280556b423068b3705f9f114R363 fixes it.

In short, there should be no layout rewriting here since no conv etc. are used. But when the pass is checking resize1d, the previous code do not pass consistent layouts for the argument `old_in_layouts` for the two calls of `ResizeInferCorrectLayout` (the first time NCH from `old_in`https://github.com/apache/tvm/blob/ef08c36294dc7c90f9d4536948507eca515012bd/src/relay/transforms/transform_layout.h#L341, second time NCW from `old_in_2`https://github.com/apache/tvm/blob/ef08c36294dc7c90f9d4536948507eca515012bd/src/relay/transforms/transform_layout.h#L363), misleading the optimizer into thinking that the layout has changed and hence an ill-formed layout_transform is inserted.

This PR also improves the naming based on suggestions from @masahi in https://github.com/apache/tvm/pull/10118, as well as adds several comments and logging statements to help people understand. (Hope this helps you understand that change better too @masahi :-)).