### PR TITLE
[MetaSchedule] Support ApplyHistoryBest Direct Dispatch

### DIFF
--- a/include/tvm/meta_schedule/apply_history_best.h
+++ b/include/tvm/meta_schedule/apply_history_best.h
@@ -44,6 +44,7 @@ class ApplyHistoryBestNode : public runtime::Object {
       runtime::TypedPackedFunc<Optional<tir::PrimFunc>(const Array<te::Tensor, void>&)>;
   /*! \brief  A callback function that takes a tuning record and does something with it */
   using FTakeTuningRecord = runtime::TypedPackedFunc<void(const TuningRecord&)>;
+  using FDirectDispatch = runtime::TypedPackedFunc<Optional<tir::Schedule>(const IRModule&)>;
 
   /*! \brief The database to be queried from */
   Database database{nullptr};
@@ -64,11 +65,13 @@ class ApplyHistoryBestNode : public runtime::Object {
    * \param target The target to be queried
    * \param dispatched The IRs after dispatch
    * \param f_take_tuning_record A callback function that takes a tuning record and does something
-   * with it
+   * \param f_direct_dispatch A function that directly dispatches a schedule to the given workload
+   *   as result if available, skipping the database query.
    */
   Optional<IRModule> Query(runtime::String task_name, IRModule mod, Target target,
                            Optional<Array<IRModule>> dispatched,
-                           FTakeTuningRecord f_take_tuning_record);
+                           FTakeTuningRecord f_take_tuning_record,
+                           FDirectDispatch f_direct_dispatch = nullptr);
 
   static constexpr const char* _type_key = "meta_schedule.ApplyHistoryBest";
   TVM_DECLARE_FINAL_OBJECT_INFO(ApplyHistoryBestNode, runtime::Object);

--- a/include/tvm/meta_schedule/apply_history_best.h
+++ b/include/tvm/meta_schedule/apply_history_best.h
@@ -29,7 +29,6 @@
 #include <tvm/runtime/packed_func.h>
 #include <tvm/target/target.h>
 #include <tvm/te/tensor.h>
-#include <tvm/tir/schedule/schedule.h>
 
 namespace tvm {
 namespace meta_schedule {
@@ -45,7 +44,7 @@ class ApplyHistoryBestNode : public runtime::Object {
       runtime::TypedPackedFunc<Optional<tir::PrimFunc>(const Array<te::Tensor, void>&)>;
   /*! \brief  A callback function that takes a tuning record and does something with it */
   using FTakeTuningRecord = runtime::TypedPackedFunc<void(const TuningRecord&)>;
-  using FDirectDispatch = runtime::TypedPackedFunc<Optional<tir::Schedule>(const IRModule&)>;
+  using FDirectDispatch = runtime::TypedPackedFunc<Optional<IRModule>(const IRModule&)>;
 
   /*! \brief The database to be queried from */
   Database database{nullptr};
@@ -67,7 +66,7 @@ class ApplyHistoryBestNode : public runtime::Object {
    * \param dispatched The IRs after dispatch
    * \param f_take_tuning_record A callback function that takes a tuning record and does something
    *   with it.
-   * \param f_direct_dispatch A function that directly dispatches a schedule to the given workload
+   * \param f_direct_dispatch A function that directly dispatches an IRModule to the given workload
    *   as result if available, skipping the database query.
    */
   Optional<IRModule> Query(runtime::String task_name, IRModule mod, Target target,

--- a/include/tvm/meta_schedule/apply_history_best.h
+++ b/include/tvm/meta_schedule/apply_history_best.h
@@ -29,6 +29,7 @@
 #include <tvm/runtime/packed_func.h>
 #include <tvm/target/target.h>
 #include <tvm/te/tensor.h>
+#include <tvm/tir/schedule/schedule.h>
 
 namespace tvm {
 namespace meta_schedule {
@@ -65,6 +66,7 @@ class ApplyHistoryBestNode : public runtime::Object {
    * \param target The target to be queried
    * \param dispatched The IRs after dispatch
    * \param f_take_tuning_record A callback function that takes a tuning record and does something
+   *   with it.
    * \param f_direct_dispatch A function that directly dispatches a schedule to the given workload
    *   as result if available, skipping the database query.
    */

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -72,7 +72,7 @@ class ApplyHistoryBest(Object):
         target: Target,
         dispatched: Optional[List[IRModule]],
         f_take_tuning_record: Optional[Callable[[TuningRecord], None]] = None,
-        f_direct_dispatch: Optional[Callable[[IRModule], Optional[Schedule]]] = None,
+        f_direct_dispatch: Optional[Callable[[IRModule], Optional[IRModule]]] = None,
     ) -> Union[IRModule, None]:
         """The entry point of the integration
 
@@ -88,8 +88,8 @@ class ApplyHistoryBest(Object):
             A list of low-level IRs that the high-level IR could potentially dispatch to
         f_take_tuning_record : Optional[Callable[[TuningRecord], None]] = None
             A callback function that takes a tuning record and does something with it
-        f_direct_dispatch : Optional[Callable[[IRModule], Optional[Schedule]]] = None
-            A function that directly dispatches a schedule to the given workload as result if
+        f_direct_dispatch : Optional[Callable[[IRModule], Optional[IRModule]]] = None
+            A function that directly dispatches an IRModule to the given workload as result if
             available, skipping the database query.
 
         Returns

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -23,7 +23,7 @@ from tvm.ir import IRModule
 from tvm.runtime import Object
 from tvm.target import Target
 from tvm.te import Tensor
-from tvm.tir import PrimFunc, Schedule
+from tvm.tir import PrimFunc
 
 from . import _ffi_api
 from .database import Database, TuningRecord

--- a/python/tvm/meta_schedule/apply_history_best.py
+++ b/python/tvm/meta_schedule/apply_history_best.py
@@ -23,7 +23,7 @@ from tvm.ir import IRModule
 from tvm.runtime import Object
 from tvm.target import Target
 from tvm.te import Tensor
-from tvm.tir import PrimFunc
+from tvm.tir import PrimFunc, Schedule
 
 from . import _ffi_api
 from .database import Database, TuningRecord
@@ -71,7 +71,8 @@ class ApplyHistoryBest(Object):
         mod: IRModule,
         target: Target,
         dispatched: Optional[List[IRModule]],
-        f_take_tuning_record: Callable[[TuningRecord], None] = None,
+        f_take_tuning_record: Optional[Callable[[TuningRecord], None]] = None,
+        f_direct_dispatch: Optional[Callable[[IRModule], Optional[Schedule]]] = None,
     ) -> Union[IRModule, None]:
         """The entry point of the integration
 
@@ -85,8 +86,11 @@ class ApplyHistoryBest(Object):
             Target Info
         dispatched : Optional[List[IRModule]]
             A list of low-level IRs that the high-level IR could potentially dispatch to
-        f_take_tuning_record : Callable[[TuningRecord], None] = None
+        f_take_tuning_record : Optional[Callable[[TuningRecord], None]] = None
             A callback function that takes a tuning record and does something with it
+        f_direct_dispatch : Optional[Callable[[IRModule], Optional[Schedule]]] = None
+            A function that directly dispatches a schedule to the given workload as result if
+            available, skipping the database query.
 
         Returns
         -------
@@ -101,6 +105,7 @@ class ApplyHistoryBest(Object):
             target,
             dispatched,
             f_take_tuning_record,
+            f_direct_dispatch,
         )
 
     @staticmethod

--- a/src/meta_schedule/apply_history_best.cc
+++ b/src/meta_schedule/apply_history_best.cc
@@ -121,10 +121,10 @@ Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModu
   prim_mod = (*parse_mod_func)(prim_mod);
 
   if (f_direct_dispatch != nullptr) {
-    Optional<tir::Schedule> sch = f_direct_dispatch(prim_mod);
-    if (sch.defined()) {
+    Optional<IRModule> mod = f_direct_dispatch(prim_mod);
+    if (mod.defined()) {
       TVM_PY_LOG(INFO, logging_func) << "Direct dispatch applied for workload: " << task_name;
-      return IRModule(sch.value()->mod());
+      return mod.value();
     }
   }
   if (database->HasWorkload(prim_mod)) {

--- a/src/meta_schedule/apply_history_best.cc
+++ b/src/meta_schedule/apply_history_best.cc
@@ -104,7 +104,8 @@ ApplyHistoryBest::ApplyHistoryBest(Database database,
 
 Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModule mod,
                                                Target target, Optional<Array<IRModule>> dispatched,
-                                               FTakeTuningRecord f_take_tuning_record) {
+                                               FTakeTuningRecord f_take_tuning_record,
+                                               FDirectDispatch f_direct_dispatch) {
   ICHECK(dispatched.defined());
   ICHECK_EQ(dispatched.value().size(), 1);
   ICHECK(HasOnlyOneFunction<relay::Function>(mod)) << mod;
@@ -119,6 +120,13 @@ Optional<IRModule> ApplyHistoryBestNode::Query(runtime::String task_name, IRModu
   ICHECK(parse_mod_func) << "Parse mod function not defined!";
   prim_mod = (*parse_mod_func)(prim_mod);
 
+  if (f_direct_dispatch != nullptr) {
+    Optional<tir::Schedule> sch = f_direct_dispatch(prim_mod);
+    if (sch.defined()) {
+      TVM_PY_LOG(INFO, logging_func) << "Direct dispatch applied for workload: " << task_name;
+      return IRModule(sch.value()->mod());
+    }
+  }
   if (database->HasWorkload(prim_mod)) {
     Array<TuningRecord> records = database->GetTopK(database->CommitWorkload(prim_mod), 1);
     if (records.size() == 1) {

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -290,9 +290,9 @@ def test_meta_schedule_integration_apply_history_best():
 
 @requires_torch
 def test_meta_schedule_integration_apply_history_best_direct_dispatch():
-    def direct_dispatch(mod: IRModule) -> Optional[Schedule]:
+    def direct_dispatch(mod: IRModule) -> Optional[IRModule]:
         if tvm.ir.structural_equal(mod, MockModule):
-            return Schedule(MockModule)
+            return MockModule
         return None
 
     mod, _, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Integration test for MetaSchedule"""
+from typing import Optional
 import numpy as np
 import pytest
 import tvm
@@ -283,6 +284,28 @@ def test_meta_schedule_integration_apply_history_best():
         mod=mod,
         target=target,
         dispatched=[MockModule],
+    )
+    assert tvm.ir.structural_equal(mod, workload.mod)
+
+
+@requires_torch
+def test_meta_schedule_integration_apply_history_best_direct_dispatch():
+    def direct_dispatch(mod: IRModule) -> Optional[Schedule]:
+        if tvm.ir.structural_equal(mod, MockModule):
+            return Schedule(MockModule)
+        return None
+
+    mod, _, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
+    database = ms.database.MemoryDatabase()
+    env = ms.ApplyHistoryBest(database)
+    target = Target("llvm")
+    workload = database.commit_workload(MockModule)
+    mod = env.query(
+        task_name="mock-task-direct-dispatch",
+        mod=mod,
+        target=target,
+        dispatched=[MockModule],
+        f_direct_dispatch=direct_dispatch,
     )
     assert tvm.ir.structural_equal(mod, workload.mod)
 


### PR DESCRIPTION
This PR introduced a new argument for `ApplyHistoryBest`'s `Query` interface to allow direct dispatch without querying the database, would be useful for debugging and benchmarking without interference.