### PR TITLE
[PyTorch] Add aten::embedding_bag

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -40,7 +40,11 @@ from ..loops import while_loop
 from ..prelude import Prelude, StaticTensorArrayOps
 from ..ty import Any, TensorType, TupleType
 from . import qnn_torch
+<<<<<<< HEAD
 from .common import AttrCvt, get_relay_op, gru_cell, logger, rnn_cell
+=======
+from .common import AttrCvt, get_relay_op, gru_cell, logger
+>>>>>>> d9690c3cd (fix lint)
 from .common import infer_shape as _infer_shape
 from .common import infer_value as _infer_value
 from .common import fold_constant as _fold_constant
@@ -2263,11 +2267,11 @@ class PyTorchOpConverter:
         ) = inputs
 
         assert scale_grad_by_freq == 0, "scale_grad_by_freq not supported in embedding_bag."
-        assert padding_idx == None, "padding_idx not supported in embedding_bag."
+        assert padding_idx is None, "padding_idx not supported in embedding_bag."
 
-        assert len(infer_shape(indices)) == 1, "Expects 1D indices for aten::embedding_bag."
+        assert len(_infer_shape(indices)) == 1, "Expects 1D indices for aten::embedding_bag."
 
-        offsets_const_fold = fold_constant(offsets_1d)
+        offsets_const_fold = _fold_constant(offsets_1d)
 
         assert isinstance(
             offsets_const_fold, _expr.Constant

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -40,11 +40,7 @@ from ..loops import while_loop
 from ..prelude import Prelude, StaticTensorArrayOps
 from ..ty import Any, TensorType, TupleType
 from . import qnn_torch
-<<<<<<< HEAD
 from .common import AttrCvt, get_relay_op, gru_cell, logger, rnn_cell
-=======
-from .common import AttrCvt, get_relay_op, gru_cell, logger
->>>>>>> d9690c3cd (fix lint)
 from .common import infer_shape as _infer_shape
 from .common import infer_value as _infer_value
 from .common import fold_constant as _fold_constant
@@ -2551,7 +2547,7 @@ class PyTorchOpConverter:
 
     def numel(self, inputs, input_types):
         shape = self.infer_shape(inputs[0])
-        if isinstance(shape, tuple):
+        if isinstance(shape, tuple) and isinstance(shape[0], int):
             res = 1
             for s in shape:
                 res *= s

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2287,7 +2287,7 @@ class PyTorchOpConverter:
 
         reduce_op = mode_map[mode]
 
-        # TOOD(masahi): Implementing embedding_bag in terms of gather and reduce defeats the
+        # TODO(masahi): Implementing embedding_bag in terms of gather and reduce defeats the
         # purpose of using this op. Implement Relay / topi op for fused gather and reduce.
         gather = _op.take(weights, indices_2d, axis=0)
         if per_sample_weights is not None:

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2870,6 +2870,7 @@ def test_embedding_bag():
         [inp, embedding_matrix],
     )
 
+
 @tvm.testing.uses_gpu
 def test_forward_onehot():
     torch.set_grad_enabled(False)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -2862,6 +2862,14 @@ def test_forward_embedding():
     verify_model(torch.nn.Embedding(4, 5, sparse=True).float().eval(), input_data=input_data)
 
 
+def test_embedding_bag():
+    embedding_matrix = torch.rand(10, 3)
+    inp = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9], [6, 7, 8, 9]])
+    verify_model(
+        F.embedding_bag,
+        [inp, embedding_matrix],
+    )
+
 @tvm.testing.uses_gpu
 def test_forward_onehot():
     torch.set_grad_enabled(False)


### PR DESCRIPTION
This PR intends to add `aten::embedding_bag` for the pytorch frontend. Note that the implementation of `aten::numel` is also changed under the condition that any input that can be evaluated to a constant value will be evaluated at compile time.

Co-authored-by: Masahiro Masuda [masahi@129@gmail.com](mailto:masahi@129@gmail.com)

cc: @masahi @vinx13 
