### PR TITLE
[TIR] fix crash when comparing IntImm to None

### DIFF
--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -562,13 +562,9 @@ class IntImm(ConstExpr):
         return self.value != 0
 
     def __eq__(self, other):
-        if not isinstance(other, IntImm):
-            return False
         return _ffi_api._OpEQ(self, other, None)  # type: ignore
 
     def __ne__(self, other):
-        if not isinstance(other, IntImm):
-            return True
         return _ffi_api._OpNE(self, other, None)  # type: ignore
 
     def __bool__(self):

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -562,9 +562,13 @@ class IntImm(ConstExpr):
         return self.value != 0
 
     def __eq__(self, other):
+        if not isinstance(other, IntImm):
+            return False
         return _ffi_api._OpEQ(self, other, None)  # type: ignore
 
     def __ne__(self, other):
+        if not isinstance(other, IntImm):
+            return True
         return _ffi_api._OpNE(self, other, None)  # type: ignore
 
     def __bool__(self):

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -99,6 +99,8 @@ PrimExpr q_multiply_shift(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr s, Span s
 
 // The public function with a quick checking path.
 void BinaryOpMatchTypes(PrimExpr& lhs, PrimExpr& rhs, Span span) {  // NOLINT(*)
+  CHECK(lhs.defined()) << "ValueError: `lhs` is null in the binary operator";
+  CHECK(rhs.defined()) << "ValueError: `rhs` is null in the binary operator";
   if (lhs.dtype() == rhs.dtype()) return;
   DataType ltype = lhs.dtype();
   DataType rtype = rhs.dtype();

--- a/tests/python/unittest/test_tir_base.py
+++ b/tests/python/unittest/test_tir_base.py
@@ -118,6 +118,15 @@ def test_exception():
         x = tir.Var(name=1, dtype="int")
 
 
+def test_eq_ops():
+    a = tir.IntImm("int8", 1)
+    assert a != None
+    assert not a == None
+    b = tir.StringImm("abc")
+    assert b != None
+    assert not b == None
+
+
 if __name__ == "__main__":
     test_scalar_add()
     test_ret_const()

--- a/tests/python/unittest/test_tir_base.py
+++ b/tests/python/unittest/test_tir_base.py
@@ -134,3 +134,4 @@ if __name__ == "__main__":
     test_ret_const()
     test_control_flow_jump()
     test_exception()
+    test_eq_ops()

--- a/tests/python/unittest/test_tir_base.py
+++ b/tests/python/unittest/test_tir_base.py
@@ -120,8 +120,10 @@ def test_exception():
 
 def test_eq_ops():
     a = tir.IntImm("int8", 1)
-    assert a != None
-    assert not a == None
+    with pytest.raises(ValueError):
+        assert a != None
+    with pytest.raises(ValueError):
+        assert not a == None
     b = tir.StringImm("abc")
     assert b != None
     assert not b == None


### PR DESCRIPTION
While it is generally preferred to compare to `None` by using `is not`, I don't think TVM should just crash with a segfault in that case.

The crash stack trace is:

https://github.com/apache/tvm/blob/013d5e8fcbd94fb3a0c5c0cdcaea03af43c464aa/python/tvm/tir/expr.py#L568
https://github.com/apache/tvm/blob/013d5e8fcbd94fb3a0c5c0cdcaea03af43c464aa/src/tir/op/op.cc#L984
https://github.com/apache/tvm/blob/013d5e8fcbd94fb3a0c5c0cdcaea03af43c464aa/src/tir/op/op.cc#L514
https://github.com/apache/tvm/blob/013d5e8fcbd94fb3a0c5c0cdcaea03af43c464aa/src/tir/op/op.cc#L102

where rhs is nullptr.

@tqchen @Hzfengsy @wrongtest 