### PR TITLE
[docs][tvmc] Fix ResNet50 model URL in tvmc tutorials

### DIFF
--- a/gallery/tutorial/tvmc_command_line_driver.py
+++ b/gallery/tutorial/tvmc_command_line_driver.py
@@ -94,7 +94,7 @@ testing.utils.install_request_hook(depth=3)
 #
 # .. code-block:: bash
 #
-#   wget https://github.com/onnx/models/raw/652f4e4af7975c8e7a505c4b6e0f8ac72d8260ea/vision/classification/resnet/model/resnet50-v2-7.onnx
+#   wget https://github.com/onnx/models/raw/b9a54e89508f101a1611cd64f4ef56b9cb62c7cf/vision/classification/resnet/model/resnet50-v2-7.onnx
 #
 
 ################################################################################

--- a/gallery/tutorial/tvmc_python.py
+++ b/gallery/tutorial/tvmc_python.py
@@ -29,7 +29,7 @@ Follow the steps to download a resnet model via the terminal:
 
      mkdir myscripts
      cd myscripts
-     wget https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v2-7.onnx
+     wget https://github.com/onnx/models/raw/b9a54e89508f101a1611cd64f4ef56b9cb62c7cf/vision/classification/resnet/model/resnet50-v2-7.onnx
      mv resnet50-v2-7.onnx my_model.onnx
      touch tvmcpythonintro.py
 


### PR DESCRIPTION
Fix the ResNet50 Models in both tvmc tutorials so that the commands suggested will work fine.

Co-Authored-By: @Liastu01 

cc @CircleSpin @areusch @manupa-arm @Mousius @gromero for reviews