### PR TITLE
[ci] Re-run failed tests on failure

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -36,6 +36,7 @@ pip3 install --upgrade \
     git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@7f69989f1c6a6713d0bd7c27f8da2b48344117d3 \
     pytest-profiling \
     pytest-xdist \
+    pytest-rerunfailures==10.2 \
     requests \
     scipy \
     Jinja2 \

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -24,13 +24,10 @@ if [[ ! -z $CI_PYTEST_ADD_OPTIONS ]]; then
 else
     export PYTEST_ADDOPTS="-s -vv $PYTEST_ADDOPTS"
 fi
-set -ux
+set -u
 
 export TVM_PATH=`pwd`
 export PYTHONPATH="${TVM_PATH}/python"
-
-# TODO: Remove this line once https://github.com/apache/tvm/pull/12055 is merged into the Docker images
-python3 -m pip install --user pytest-rerunfailures==10.2
 
 export TVM_PYTEST_RESULT_DIR="${TVM_PATH}/build/pytest-results"
 mkdir -p "${TVM_PYTEST_RESULT_DIR}"
@@ -54,15 +51,10 @@ function run_pytest() {
     shift
     local test_suite_name="$1"
     shift
-    extra_args=( "$@" )
     if [ -z "${ffi_type}" -o -z "${test_suite_name}" ]; then
-        echo "error: run_pytest called incorrectly: run_pytest ${ffi_type} ${test_suite_name} $extra_args"
+        echo "error: run_pytest called incorrectly: run_pytest ${ffi_type} ${test_suite_name} $@"
         echo "usage: run_pytest <FFI_TYPE> <TEST_SUITE_NAME> [pytest args...]"
         exit 2
-    fi
-    has_help=$(python3 -m pytest --help 2>&1 | grep 'reruns=' || true)
-    if [ -n "$has_help" ]; then
-        extra_args+=('--reruns=3')
     fi
 
     suite_name="${test_suite_name}-${ffi_type}"
@@ -71,7 +63,7 @@ function run_pytest() {
            -o "junit_suite_name=${suite_name}" \
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${suite_name}.xml" \
            "--junit-prefix=${ffi_type}" \
-           "${extra_args[@]}" || exit_code=$?
+           "$@" || exit_code=$?
     if [ "$exit_code" -ne "0" ]; then
         pytest_errors+=("${suite_name}: $@")
     fi

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -24,10 +24,13 @@ if [[ ! -z $CI_PYTEST_ADD_OPTIONS ]]; then
 else
     export PYTEST_ADDOPTS="-s -vv $PYTEST_ADDOPTS"
 fi
-set -u
+set -ux
 
 export TVM_PATH=`pwd`
 export PYTHONPATH="${TVM_PATH}/python"
+
+# TODO: Remove this line once https://github.com/apache/tvm/pull/12055 is merged into the Docker images
+python3 -m pip install --user pytest-rerunfailures==10.2
 
 export TVM_PYTEST_RESULT_DIR="${TVM_PATH}/build/pytest-results"
 mkdir -p "${TVM_PYTEST_RESULT_DIR}"
@@ -51,10 +54,15 @@ function run_pytest() {
     shift
     local test_suite_name="$1"
     shift
+    extra_args=( "$@" )
     if [ -z "${ffi_type}" -o -z "${test_suite_name}" ]; then
-        echo "error: run_pytest called incorrectly: run_pytest ${ffi_type} ${test_suite_name} $@"
+        echo "error: run_pytest called incorrectly: run_pytest ${ffi_type} ${test_suite_name} $extra_args"
         echo "usage: run_pytest <FFI_TYPE> <TEST_SUITE_NAME> [pytest args...]"
         exit 2
+    fi
+    has_help=$(python3 -m pytest --help 2>&1 | grep 'reruns=' || true)
+    if [ -n "$has_help" ]; then
+        extra_args+=('--reruns=3')
     fi
 
     suite_name="${test_suite_name}-${ffi_type}"
@@ -63,7 +71,7 @@ function run_pytest() {
            -o "junit_suite_name=${suite_name}" \
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${suite_name}.xml" \
            "--junit-prefix=${ffi_type}" \
-           "$@" || exit_code=$?
+           "${extra_args[@]}" || exit_code=$?
     if [ "$exit_code" -ne "0" ]; then
         pytest_errors+=("${suite_name}: $@")
     fi


### PR DESCRIPTION
This uses [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures) to retry failed tests. This should help alleviate flakiness for issues like segfaults in ethosu tests or flaky numerics. This obviously isn't as good as fixing the tests themselves, but it's an easy way to fix the most pressing issue (the cost of developer time to wait for, check, and re-run CI) while keeping the signal from the times the tests do fail consistently. 

cc @Mousius @areusch