### PR TITLE
[ci] Add a manual retry for conda setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,6 +8,18 @@ runs:
       path: ~/conda_pkgs_dir
       key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/build-environment.yaml') }}
   - uses: conda-incubator/setup-miniconda@v2
+    continue-on-error: true
+    id: conda1
+    with:
+      activate-environment: tvm-build
+      channel-priority: strict
+      environment-file: conda/build-environment.yaml
+      auto-activate-base: false
+      use-only-tar-bz2: true
+      python-version: 3.7
+      condarc-file: conda/condarc
+  - uses: conda-incubator/setup-miniconda@v2
+    if: steps.conda1.outcome == 'failure'
     with:
       activate-environment: tvm-build
       channel-priority: strict


### PR DESCRIPTION
This makes it so the conda setup will re-run entirely in case of failures like in https://github.com/apache/tvm/runs/7287493088. [This issue](https://github.com/conda-incubator/setup-miniconda/issues/129) has some more context but there doesn't seem to be a better way to do a retry than re-running the whole thing since the settings in `conda/condarc` are picked up but they don't help for this particular issue.