### PR TITLE
Add tensorflow Einsum op converter

### DIFF
--- a/python/tvm/relay/frontend/tensorflow_ops.py
+++ b/python/tvm/relay/frontend/tensorflow_ops.py
@@ -2480,6 +2480,15 @@ def _range():
     return _impl
 
 
+def _einsum():
+    def _impl(inputs, attr, params, mod):
+        einsum_attr = dict(attr)
+        einsum_attr["equation"] = einsum_attr["equation"].decode("utf-8")
+        return AttrCvt(op_name="einsum", ignores=["N"])([inputs], einsum_attr)
+
+    return _impl
+
+
 def _elu():
     def _impl(inputs, attr, params, mod):
         dtype = attr["T"].name
@@ -2907,6 +2916,7 @@ _convert_map = {
     "DepthToSpace": _depth_to_space(),
     "DepthwiseConv2dNative": _conv("depthwise"),
     "Dilation2D": _dilation2d(),
+    "Einsum": _einsum(),
     "Elu": _elu(),
     "Equal": _broadcast("equal"),
     "Erf": AttrCvt("erf"),

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -3686,22 +3686,22 @@ def _test_einsum(equation, dtype, *shape_of_input_tensors):
             input_name = f"input_{idx}"
             inputs_placeholders.append(tf.placeholder(shape=shape, dtype=dtype, name=input_name))
             input_data.append(np.random.normal(size=shape).astype(dtype))
-        
+
         result = tf.einsum(equation, *inputs_placeholders)
-        
+
         compare_tf_with_tvm(input_data, [ph.name for ph in inputs_placeholders], result.name)
 
 
 def test_forward_einsum():
     for dtype in ["float32"]:
-        _test_einsum("ij,jk->ik", dtype, [2, 3], [3, 5])           # Matmul
-        _test_einsum("ij,jk", dtype, [2, 3], [3, 5])               # Matmul
-        _test_einsum("i,i->", dtype, [2], [2])                     # Dot product
-        _test_einsum("i,j->ij", dtype, [3], [5])                   # Outer produce
-        _test_einsum("ij->ji", dtype, [2, 3])                      # Transpose
-        _test_einsum("ii->i", dtype, [3, 3])                       # Diag
-        _test_einsum("ii", dtype, [3, 3])                          # Trace of a square matrix 
-        _test_einsum("bij,bjk->bik", dtype, [7, 5, 3], [7, 3, 2])  # Batch matmul
+        _test_einsum("ij,jk->ik", dtype, [2, 3], [3, 5])  # Matmul
+        _test_einsum("ij,jk", dtype, [2, 3], [3, 5])  # Matmul
+        _test_einsum("i,i->", dtype, [2], [2])  # Dot product
+        _test_einsum("i,j->ij", dtype, [3], [5])  # Outer produce
+        _test_einsum("ij->ji", dtype, [2, 3])  # Transpose
+        _test_einsum("ii->i", dtype, [3, 3])  # Diag
+        _test_einsum("ii", dtype, [3, 3])  # Trace of a square matrix 
+        _test_einsum("bij,bjk->bik", dtype, [7, 5, 3], [7, 3, 2]) # Batch matmul
 
 
 #######################################################################

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -3672,6 +3672,39 @@ def test_forward_range():
 
 
 #######################################################################
+# Einsum
+# -----
+
+
+def _test_einsum(equation, dtype, *shape_of_input_tensors):
+    """Test Einsum Op"""
+
+    with tf.Graph().as_default():
+        inputs_placeholders = []
+        input_data = []
+        for idx, shape in enumerate(shape_of_input_tensors):
+            input_name = f"input_{idx}"
+            inputs_placeholders.append(tf.placeholder(shape=shape, dtype=dtype, name=input_name))
+            input_data.append(np.random.normal(size=shape).astype(dtype))
+        
+        result = tf.einsum(equation, *inputs_placeholders)
+        
+        compare_tf_with_tvm(input_data, [ph.name for ph in inputs_placeholders], result.name)
+
+
+def test_forward_einsum():
+    for dtype in ["float32"]:
+        _test_einsum("ij,jk->ik", dtype, [2, 3], [3, 5])           # Matmul
+        _test_einsum("ij,jk", dtype, [2, 3], [3, 5])               # Matmul
+        _test_einsum("i,i->", dtype, [2], [2])                     # Dot product
+        _test_einsum("i,j->ij", dtype, [3], [5])                   # Outer produce
+        _test_einsum("ij->ji", dtype, [2, 3])                      # Transpose
+        _test_einsum("ii->i", dtype, [3, 3])                       # Diag
+        _test_einsum("ii", dtype, [3, 3])                          # Trace of a square matrix 
+        _test_einsum("bij,bjk->bik", dtype, [7, 5, 3], [7, 3, 2])  # Batch matmul
+
+
+#######################################################################
 # Pad
 # ---
 

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -3700,8 +3700,8 @@ def test_forward_einsum():
         _test_einsum("i,j->ij", dtype, [3], [5])  # Outer produce
         _test_einsum("ij->ji", dtype, [2, 3])  # Transpose
         _test_einsum("ii->i", dtype, [3, 3])  # Diag
-        _test_einsum("ii", dtype, [3, 3])  # Trace of a square matrix 
-        _test_einsum("bij,bjk->bik", dtype, [7, 5, 3], [7, 3, 2]) # Batch matmul
+        _test_einsum("ii", dtype, [3, 3])  # Trace of a square matrix
+        _test_einsum("bij,bjk->bik", dtype, [7, 5, 3], [7, 3, 2])  # Batch matmul
 
 
 #######################################################################


### PR DESCRIPTION
Einsum op is supported in Relay but not in the Tensorflow model importer, which will cause the below error when importing Tensorflow models with Einsum operator.

```
NotImplementedError: The following operators are not implemented: {'Einsum'}
```

This PR is adding Einsum op converter from TF to Relay