### PR TITLE
[TIR][Schedule] Refactor Tensorize

### DIFF
--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -584,7 +584,7 @@ void Tensorize(ScheduleState self, const StmtSRef& sref, const TensorIntrin& int
     block->match_buffers = std::move(match_buffer_regions);
   }
   if (old_block.defined()) {
-    self->Replace(sref, block_realize, {{old_block.value(), block_realize->block}});
+    self->Replace(sref, block_realize->block, {{old_block.value(), block_realize->block}});
   } else {
     self->Replace(sref, block_realize, {});
   }

--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -78,9 +78,9 @@ class SubspaceNotDivisibleError : public ScheduleError {
  *
  * \param iter_vars The input iterators
  * \param bindings The values of iter_vars
- * \param outer_loops Iterators outside the subspace.
- * \param loops Iterators of the subspace
  * \param predicate The predicate constraint on the input iterators.
+ * \param outer_iters The iters of the outer space
+ * \param inner_iters The iters of the inner space
  * \return The result of the subspace division.
  */
 Array<Array<arith::IterMark>> TrivialSubspaceDivision(const Array<IterVar>& iter_vars,
@@ -246,6 +246,7 @@ Map<Var, PrimExpr> DeriveBlockBinding(const Array<IterVar>& iter_vars,          
 
 /*!
  * \brief Generate the inner block for blockization
+ * \param is_write_reduction Whether the write regions of the inner block are actually reduction.
  * \param iter_vars IterVars used in the inner block.
  * \param iter_values IterVar bindings used in the inner block.
  * \param predicate The predicate of the inner block.

--- a/tests/python/unittest/test_tir_schedule_blockize.py
+++ b/tests/python/unittest/test_tir_schedule_blockize.py
@@ -15,12 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-function-docstring,missing-module-docstring
-import sys
-import pytest
 import tvm
 import tvm.testing
-from tvm.script import tir as T
 from tvm import tir
+from tvm.script import tir as T
 from tvm.tir.schedule.testing import verify_trace_roundtrip
 
 # fmt: off
@@ -33,177 +31,219 @@ def single_elementwise(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128
             vi, vj = T.axis.remap("SS", [i, j])
             B[vi, vj] = A[vi, vj] * 2.0
 
-
-@T.prim_func
-def single_elementwise_blockized1(
-    A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"]
-) -> None:
-    with T.block("blockized_B"):
-        vio = T.axis.spatial(1, 0)
-        vjo = T.axis.spatial(1, 0)
-        T.reads(A[0:128, 0:128])
-        T.writes(B[0:128, 0:128])
-        for i, j in T.grid(128, 128):
-            with T.block("B"):
-                vi, vj = T.axis.remap("SS", [i, j])
-                T.reads(A[vi, vj])
-                T.writes(B[vi, vj])
-                B[vi, vj] = A[vi, vj] * T.float32(2)
-
-
-@T.prim_func
-def single_elementwise_blockized2(
-    A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128, 128), "float32"]
-) -> None:
-    for i in T.serial(128):
-        with T.block("blockized_B"):
-            vi = T.axis.spatial(128, i)
-            vjo = T.axis.spatial(1, 0)
-            T.reads(A[vi, 0:128])
-            T.writes(B[vi, 0:128])
-            for j in T.serial(128):
-                with T.block("B"):
-                    vj = T.axis.remap("S", [j])
-                    T.reads(A[vi, vj])
-                    T.writes(B[vi, vj])
-                    B[vi, vj] = A[vi, vj] * T.float32(2)
-
-
-@T.prim_func
-def two_elementwise(A: T.Buffer[(128, 128), "float32"], C: T.Buffer[(128, 128), "float32"]) -> None:
-    B = T.alloc_buffer([128, 128], dtype="float32")
-    for i, j in T.grid(128, 128):
-        with T.block("B"):
-            vi, vj = T.axis.remap("SS", [i, j])
-            T.reads(A[vi, vj])
-            T.writes(B[vi, vj])
-            B[vi, vj] = A[vi, vj] * T.float32(2)
-    for i, j in T.grid(128, 128):
-        with T.block("C"):
-            vi, vj = T.axis.remap("SS", [i, j])
-            T.reads(B[vi, vj])
-            T.writes(C[vi, vj])
-            C[vi, vj] = B[vi, vj] + T.float32(1)
-
-
-@T.prim_func
-def two_elementwise_blockized(
-    A: T.Buffer[(128, 128), "float32"],
-    C: T.Buffer[(128, 128), "float32"]
-) -> None:
-    B = T.alloc_buffer([128, 128], dtype="float32")
-    for i_0, j_0 in T.grid(8, 8):
-        with T.block("blockized_B"):
-            vio, vjo = T.axis.remap("SS", [i_0, j_0])
-            T.reads(A[vio * 16 : vio * 16 + 16, vjo * 16 : vjo * 16 + 16])
-            T.writes(B[vio * 16 : vio * 16 + 16, vjo * 16 : vjo * 16 + 16])
-            for i_1, j_1 in T.grid(16, 16):
-                with T.block("B"):
-                    vi, vj = T.axis.remap("SS", [i_1, j_1])
-                    T.reads(A[vio * 16 + vi, vjo * 16 + vj])
-                    T.writes(B[vio * 16 + vi, vjo * 16 + vj])
-                    B[vio * 16 + vi, vjo * 16 + vj] = A[vio * 16 + vi, vjo * 16 + vj] * T.float32(2)
-        with T.block("blockized_C"):
-            vio, vjo = T.axis.remap("SS", [i_0, j_0])
-            T.reads(B[vio * 16 : vio * 16 + 16, vjo * 16 : vjo * 16 + 16])
-            T.writes(C[vio * 16 : vio * 16 + 16, vjo * 16 : vjo * 16 + 16])
-            for ax0, ax1 in T.grid(16, 16):
-                with T.block("C"):
-                    vi, vj = T.axis.remap("SS", [ax0, ax1])
-                    T.reads(B[vio * 16 + vi, vjo * 16 + vj])
-                    T.writes(C[vio * 16 + vi, vjo * 16 + vj])
-                    C[vio * 16 + vi, vjo * 16 + vj] = B[vio * 16 + vi, vjo * 16 + vj] + T.float32(1)
-
-
-@T.prim_func
-def rowsum(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128,), "float32"]) -> None:
-    for k, i in T.grid(128, 128):
-        with T.block("B"):
-            vk, vi = T.axis.remap("RS", [k, i])
-            with T.init():
-                B[vi] = 0.0
-            B[vi] = B[vi] + A[vi, vk]
-
-
-@T.prim_func
-def rowsum_blockized(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128,), "float32"]) -> None:
-    with T.block("blockized_B"):
-        vko = T.axis.R(1, 0)
-        vio = T.axis.S(1, 0)
-        with T.init():
-            for i1 in T.serial(0, 128):
-                with T.block("B_init"):
-                    vi_init = T.axis.S(128, i1)
-                    B[vi_init] = T.float32(0)
-        for i0, i1_1 in T.grid(128, 128):
-            with T.block("B"):
-                vk, vi = T.axis.remap("RS", [i0, i1_1])
-                B[vi] = B[vi] + A[vi, vk]
-
-
-# fmt: off
+# fmt: on
 # pylint: disable=no-member,invalid-name,unused-variable,line-too-long,redefined-outer-name,unexpected-keyword-arg,too-many-nested-blocks
 
+
 def test_blockize_outer():
+    @T.prim_func
+    def after_blockize_outer(
+        A: T.Buffer[(128, 128), "float32"],
+        B: T.Buffer[(128, 128), "float32"],
+    ) -> None:
+        with T.block("blockized_B"):
+            vio = T.axis.spatial(1, 0)
+            vjo = T.axis.spatial(1, 0)
+            for i, j in T.grid(128, 128):
+                with T.block("B"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vi, vj] * 2.0
+
     func = single_elementwise
-    # schedule
     s = tir.Schedule(func, debug_mask="all")
-    B = s.get_block("B")
-    x, y = s.get_loops(B)
+    x, _ = s.get_loops(s.get_block("B"))
     s.blockize(x)
-    print(s.mod['main'].script())
-    tvm.ir.assert_structural_equal(s.mod["main"], single_elementwise_blockized1)
+    tvm.ir.assert_structural_equal(s.mod["main"], after_blockize_outer)
     verify_trace_roundtrip(sch=s, mod=func)
 
 
 def test_blockize_inner():
+    @T.prim_func
+    def after_blockize_inner(
+        A: T.Buffer[(128, 128), "float32"],
+        B: T.Buffer[(128, 128), "float32"],
+    ) -> None:
+        for i in T.serial(128):
+            with T.block("blockized_B"):
+                vi = T.axis.spatial(128, i)
+                vjo = T.axis.spatial(1, 0)
+                for j in T.serial(128):
+                    with T.block("B"):
+                        vj = T.axis.remap("S", [j])
+                        B[vi, vj] = A[vi, vj] * 2.0
+
     func = single_elementwise
-    # schedule
     s = tir.Schedule(func, debug_mask="all")
-    B = s.get_block("B")
-    x, y = s.get_loops(B)
+    _, y = s.get_loops(s.get_block("B"))
     s.blockize(y)
-    tvm.ir.assert_structural_equal(s.mod["main"], single_elementwise_blockized2)
+    tvm.ir.assert_structural_equal(s.mod["main"], after_blockize_inner)
     verify_trace_roundtrip(sch=s, mod=func)
 
 
 def test_two_elementwise_blockize_reverse_compute_at():
-    func = two_elementwise
+    @T.prim_func
+    def before_blockize_rca(
+        A: T.Buffer[(128, 128), "float32"],
+        C: T.Buffer[(128, 128), "float32"],
+    ) -> None:
+        B = T.alloc_buffer([128, 128], dtype="float32")
+        for i, j in T.grid(8, 8):
+            with T.block("B_o"):
+                vi, vj = T.axis.remap("SS", [i, j])
+                T.reads(A[vi * 16 : vi * 16 + 16, vj * 16 : vj * 16 + 16])
+                T.writes(B[vi * 16 : vi * 16 + 16, vj * 16 : vj * 16 + 16])
+                for i_1, j_1 in T.grid(16, 16):
+                    with T.block("B"):
+                        vi_i, vj_i = T.axis.remap("SS", [i_1, j_1])
+                        T.reads(A[vi * 16 + vi_i, vj * 16 + vj_i])
+                        T.writes(B[vi * 16 + vi_i, vj * 16 + vj_i])
+                        B[vi * 16 + vi_i, vj * 16 + vj_i] = A[vi * 16 + vi_i, vj * 16 + vj_i] * 2.0
+            for ax0, ax1 in T.grid(16, 16):
+                with T.block("C"):
+                    vi = T.axis.spatial(128, i * 16 + ax0)
+                    vj = T.axis.spatial(128, j * 16 + ax1)
+                    T.reads(B[vi, vj])
+                    T.writes(C[vi, vj])
+                    C[vi, vj] = B[vi, vj] + 1.0
+
+    @T.prim_func
+    def after_blockize_rca(
+        A: T.Buffer[(128, 128), "float32"],
+        C: T.Buffer[(128, 128), "float32"],
+    ) -> None:
+        B = T.alloc_buffer([128, 128], dtype="float32")
+        for i, j in T.grid(8, 8):
+            with T.block("B_o"):
+                vi, vj = T.axis.remap("SS", [i, j])
+                T.reads(A[vi * 16 : vi * 16 + 16, vj * 16 : vj * 16 + 16])
+                T.writes(B[vi * 16 : vi * 16 + 16, vj * 16 : vj * 16 + 16])
+                for i_1, j_1 in T.grid(16, 16):
+                    with T.block("B"):
+                        vi_i, vj_i = T.axis.remap("SS", [i_1, j_1])
+                        T.reads(A[vi * 16 + vi_i, vj * 16 + vj_i])
+                        T.writes(B[vi * 16 + vi_i, vj * 16 + vj_i])
+                        B[vi * 16 + vi_i, vj * 16 + vj_i] = A[vi * 16 + vi_i, vj * 16 + vj_i] * 2.0
+            with T.block("C_o"):
+                vi, vj = T.axis.remap("SS", [i, j])
+                T.reads(B[vi * 16 : vi * 16 + 16, vj * 16 : vj * 16 + 16])
+                T.writes(C[vi * 16 : vi * 16 + 16, vj * 16 : vj * 16 + 16])
+                for ax0, ax1 in T.grid(16, 16):
+                    with T.block("C"):
+                        vi_i, vj_i = T.axis.remap("SS", [ax0, ax1])
+                        T.reads(B[vi * 16 + vi_i, vj * 16 + vj_i])
+                        T.writes(C[vi * 16 + vi_i, vj * 16 + vj_i])
+                        C[vi * 16 + vi_i, vj * 16 + vj_i] = B[vi * 16 + vi_i, vj * 16 + vj_i] + 1.0
+
+    func = before_blockize_rca
     s = tir.Schedule(func, debug_mask="all")
-    B = s.get_block("B")
-    C = s.get_block("C")
-    x, y = s.get_loops(B)
-    xo, xi = s.split(x, factors=[None, 16])
-    yo, yi = s.split(y, factors=[None, 16])
-    s.reorder(xo, yo, xi, yi)
-    s.blockize(xi)
-    s.reverse_compute_at(C, yo)
-    s.blockize(s.get_loops(C)[-2])
-    tvm.ir.assert_structural_equal(s.mod["main"], two_elementwise_blockized)
+    _, _, x, _ = s.get_loops(s.get_block("C"))
+    s.blockize(x)
+    tvm.ir.assert_structural_equal(s.mod["main"], after_blockize_rca)
     verify_trace_roundtrip(sch=s, mod=func)
 
 
 def test_two_elementwise_blockize_compute_at():
-    func = two_elementwise
+    @T.prim_func
+    def before_blockize_compute_at(
+        A: T.Buffer[(128, 128), "float32"],
+        C: T.Buffer[(128, 128), "float32"],
+    ) -> None:
+        # body
+        # with T.block("root")
+        B = T.alloc_buffer([128, 128], dtype="float32")
+        for i_0, j_0 in T.grid(8, 8):
+            for ax0, ax1 in T.grid(16, 16):
+                with T.block("B"):
+                    vi = T.axis.spatial(128, i_0 * 16 + ax0)
+                    vj = T.axis.spatial(128, j_0 * 16 + ax1)
+                    T.reads(A[vi, vj])
+                    T.writes(B[vi, vj])
+                    B[vi, vj] = A[vi, vj] * 2.0
+            with T.block("C_o"):
+                vi_o, vj_o = T.axis.remap("SS", [i_0, j_0])
+                T.reads(B[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                T.writes(C[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                for i_1, j_1 in T.grid(16, 16):
+                    with T.block("C"):
+                        vi_i, vj_i = T.axis.remap("SS", [i_1, j_1])
+                        T.reads(B[vi_o * 16 + vi_i, vj_o * 16 + vj_i])
+                        T.writes(C[vi_o * 16 + vi_i, vj_o * 16 + vj_i])
+                        C[vi_o * 16 + vi_i, vj_o * 16 + vj_i] = (
+                            B[vi_o * 16 + vi_i, vj_o * 16 + vj_i] + 1.0
+                        )
+
+    @T.prim_func
+    def after_blockize_compute_at(
+        A: T.Buffer[(128, 128), "float32"],
+        C: T.Buffer[(128, 128), "float32"],
+    ) -> None:
+        B = T.alloc_buffer([128, 128], dtype="float32")
+        for i_0, j_0 in T.grid(8, 8):
+            with T.block("B_o"):
+                vi_o, vj_o = T.axis.remap("SS", [i_0, j_0])
+                T.reads(A[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                T.writes(B[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                for ax0, ax1 in T.grid(16, 16):
+                    with T.block("B"):
+                        vi_i, vj_i = T.axis.remap("SS", [ax0, ax1])
+                        T.reads(A[vi_o * 16 + vi_i, vj_o * 16 + vj_i])
+                        T.writes(B[vi_o * 16 + vi_i, vj_o * 16 + vj_i])
+                        B[vi_o * 16 + vi_i, vj_o * 16 + vj_i] = (
+                            A[vi_o * 16 + vi_i, vj_o * 16 + vj_i] * 2.0
+                        )
+            with T.block("C_o"):
+                vi_o, vj_o = T.axis.remap("SS", [i_0, j_0])
+                T.reads(B[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                T.writes(C[vi_o * 16 : vi_o * 16 + 16, vj_o * 16 : vj_o * 16 + 16])
+                for i_1, j_1 in T.grid(16, 16):
+                    with T.block("C"):
+                        vi_i, vj_i = T.axis.remap("SS", [i_1, j_1])
+                        T.reads(B[vi_o * 16 + vi_i, vj_o * 16 + vj_i])
+                        T.writes(C[vi_o * 16 + vi_i, vj_o * 16 + vj_i])
+                        C[vi_o * 16 + vi_i, vj_o * 16 + vj_i] = (
+                            B[vi_o * 16 + vi_i, vj_o * 16 + vj_i] + 1.0
+                        )
+
+    func = before_blockize_compute_at
     s = tir.Schedule(func, debug_mask="all")
-    B = s.get_block("B")
-    C = s.get_block("C")
-    x, y = s.get_loops(C)
-    xo, xi = s.split(x, factors=[None, 16])
-    yo, yi = s.split(y, factors=[None, 16])
-    s.reorder(xo, yo, xi, yi)
-    s.blockize(xi)
-    s.compute_at(B, yo)
-    s.blockize(s.get_loops(B)[-2])
-    tvm.ir.assert_structural_equal(s.mod["main"], two_elementwise_blockized)
+    _, _, x, _ = s.get_loops(s.get_block("B"))
+    s.blockize(x)
+    tvm.ir.assert_structural_equal(s.mod["main"], after_blockize_compute_at)
     verify_trace_roundtrip(sch=s, mod=func)
 
 
 def test_blockize_init_loops():
+    @T.prim_func
+    def rowsum(A: T.Buffer[(128, 128), "float32"], B: T.Buffer[(128,), "float32"]) -> None:
+        for k, i in T.grid(128, 128):
+            with T.block("B"):
+                vk, vi = T.axis.remap("RS", [k, i])
+                with T.init():
+                    B[vi] = 0.0
+                B[vi] = B[vi] + A[vi, vk]
+
+    @T.prim_func
+    def after_rowsum_blockize(
+        A: T.Buffer[(128, 128), "float32"],
+        B: T.Buffer[(128,), "float32"],
+    ) -> None:
+        with T.block("blockized_B"):
+            vko = T.axis.R(1, 0)
+            vio = T.axis.S(1, 0)
+            with T.init():
+                for i1 in T.serial(0, 128):
+                    with T.block("B_init"):
+                        vi_init = T.axis.S(128, i1)
+                        B[vi_init] = T.float32(0)
+            for i0, i1_1 in T.grid(128, 128):
+                with T.block("B"):
+                    vk, vi = T.axis.remap("RS", [i0, i1_1])
+                    B[vi] = B[vi] + A[vi, vk]
+
     s = tir.Schedule(rowsum, debug_mask="all")
     k, _ = s.get_loops(s.get_block("B"))
     s.blockize(k)
-    tvm.ir.assert_structural_equal(s.mod["main"], rowsum_blockized)
+    tvm.ir.assert_structural_equal(s.mod["main"], after_rowsum_blockize)
     verify_trace_roundtrip(sch=s, mod=rowsum)
 
 


### PR DESCRIPTION
This PR refactors the key schedule primitive `tensorize`, cleaning up the logic and brings the following benefits:
1) `tensorize` is now failure-safe: previously if a failure happens between `blockize` and structural pattern matching, the sref tree is left unmaintained
2) `tensorize` is now correct if a TIR is tensorized multiple times with the same tensor intrin: previously the intrin is not deep copied, so the pointer equality used in ScheduleState will fail if the TIR is tensorized multiple times

Per discussion with @vinx13 @yzh119 @spectrometerHBH 