### PR TITLE
[Hexagon] Enable broken tests

### DIFF
--- a/tests/python/contrib/test_hexagon/topi/test_add_subtract_multiply.py
+++ b/tests/python/contrib/test_hexagon/topi/test_add_subtract_multiply.py
@@ -158,9 +158,6 @@ class TestAddSubtractMultiplyBroadcast2d:
         input_B_layout,
         op_name,
     ):
-        if hexagon_session._launcher._serial_number != "simulator":
-            pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
-
         target_hexagon = tvm.target.hexagon("v69")
         A = te.placeholder(input_shape_A, name="A", dtype=dtype)
         B = te.placeholder(input_shape_B, name="B", dtype=dtype)

--- a/tests/python/contrib/test_hexagon/topi/test_argmax_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_argmax_slice.py
@@ -77,9 +77,6 @@ class TestArgMaxSlice:
         working_scope,
     ):
         """Top level testing function for argmax"""
-        if hexagon_session._launcher._serial_number != "simulator":
-            pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
-
         target_hexagon = tvm.target.hexagon("v69")
         target = tvm.target.Target(target_hexagon, host=target_hexagon)
         argmax_input = te.placeholder(input_shape, name="A", dtype=dtype)

--- a/tests/python/contrib/test_hexagon/topi/test_resize2d.py
+++ b/tests/python/contrib/test_hexagon/topi/test_resize2d.py
@@ -102,9 +102,6 @@ class TestResize2d:
         method,
         hexagon_session,
     ):
-        if hexagon_session._launcher._serial_number != "simulator":
-            pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
-
         target_hexagon = tvm.target.hexagon("v69")
         A = te.placeholder(input_shape, name="A", dtype=dtype)
 

--- a/tests/python/contrib/test_hexagon/topi/test_softmax_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_softmax_slice.py
@@ -79,9 +79,6 @@ class TestSoftmax2d(Basesoftmax2d):
         axis_sep,
         hexagon_session,
     ):
-        if hexagon_session._launcher._serial_number != "simulator":
-            pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
-
         target_hexagon = tvm.target.hexagon(
             "v69",
             llvm_options="--disable-loop-unrolling-pass",


### PR DESCRIPTION
We have updated HDK boards firmware and they are passing these tests now. Fixes https://github.com/apache/tvm/issues/11957

Thanks to @supersat!
cc @csullivan 