### PR TITLE
[microTVM] Make Arduino API server obey timeout

### DIFF
--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -507,7 +507,7 @@ class Handler(server.ProjectAPIHandler):
                 break
             time.sleep(0.5)
 
-        self._serial = serial.Serial(port, baudrate=115200, timeout=5)
+        self._serial = serial.Serial(port, baudrate=115200, timeout=10)
 
         return server.TransportTimeouts(
             session_start_retry_timeout_sec=2.0,
@@ -522,13 +522,13 @@ class Handler(server.ProjectAPIHandler):
         self._serial = None
 
     def read_transport(self, n, timeout_sec):
-        # It's hard to set timeout_sec, so we just throw it away
-        # TODO fix this
+        self._serial.timeout = timeout_sec
         if self._serial is None:
             raise server.TransportClosedError()
         return self._serial.read(n)
 
     def write_transport(self, data, timeout_sec):
+        self._serial.timeout = timeout_sec
         if self._serial is None:
             raise server.TransportClosedError()
         return self._serial.write(data)

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -528,7 +528,7 @@ class Handler(server.ProjectAPIHandler):
         return self._serial.read(n)
 
     def write_transport(self, data, timeout_sec):
-        self._serial.timeout = timeout_sec
+        self._serial.write_timeout = timeout_sec
         if self._serial is None:
             raise server.TransportClosedError()
         return self._serial.write(data)

--- a/python/tvm/micro/testing/evaluation.py
+++ b/python/tvm/micro/testing/evaluation.py
@@ -30,6 +30,9 @@ import tempfile
 import tvm
 
 
+AOT_PLATFORM_SPECIFIC_OPTIONS = {"arduino": {}, "zephyr": {"config_main_stack_size": 4096}}
+
+
 def tune_model(
     platform, board, target, mod, params, num_trials, tuner_cls=tvm.autotvm.tuner.GATuner
 ):
@@ -117,6 +120,7 @@ def create_aot_session(
         {
             f"{platform}_board": board,
             "project_type": "host_driven",
+            **(AOT_PLATFORM_SPECIFIC_OPTIONS[platform]),
         },
     )
     project.build()

--- a/python/tvm/micro/testing/evaluation.py
+++ b/python/tvm/micro/testing/evaluation.py
@@ -83,6 +83,7 @@ def create_aot_session(
     params,
     build_dir=Path(tempfile.mkdtemp()),
     tune_logs=None,
+    timeout_override=None,
     use_cmsis_nn=False,
 ):
     """AOT-compiles and uploads a model to a microcontroller, and returns the RPC session"""
@@ -121,7 +122,7 @@ def create_aot_session(
     project.build()
     project.flash()
 
-    return tvm.micro.Session(project.transport())
+    return tvm.micro.Session(project.transport(), timeout_override=timeout_override)
 
 
 # This utility functions was designed ONLY for one input / one output models

--- a/python/tvm/micro/testing/utils.py
+++ b/python/tvm/micro/testing/utils.py
@@ -41,8 +41,11 @@ def get_supported_boards(platform: str):
 
 
 def get_target(platform: str, board: str):
+    """Intentionally simple function for making target strings for microcontrollers.
+    If you need more complex arguments, one should call target.micro directly. Note
+    that almost all, but not all, supported microcontrollers are Arm-based."""
     model = get_supported_boards(platform)[board]["model"]
-    return str(tvm.target.target.micro(model))
+    return str(tvm.target.target.micro(model, options=["-device=arm_cpu"]))
 
 
 def check_tune_log(log_path: Union[Path, str]):


### PR DESCRIPTION
This change makes the Arduino `read_transport` and `write_transport` methods obey the timeout parameters passed into them. This change is required if we wish to run large models multiple times to get a better average runtime. Also contains a few fixes to improve autotuning:
- Adds an optional `timeout_override` parameter to `create_aot_session`, allowing this function to be used to evaluate large models.
- Changes `tvm.micro.testing.get_target` to use `-device=arm_cpu` by default. 

cc @alanmacd @gromero @mehrdadh