### PR TITLE
[AUTOSCHEDULER,FIX] Calculate arithmetic intensity without log scale

### DIFF
--- a/src/auto_scheduler/feature.cc
+++ b/src/auto_scheduler/feature.cc
@@ -1232,7 +1232,7 @@ void GetPerStoreFeature(const PrimFunc& func, int cache_line_size, int max_n_buf
 
     /***** Group 3: Arithmetic intensity related features *****/
     for (size_t i = 0; i < ARITH_INTENSITY_CURVE_SAMPLE_N; ++i) {
-      ret->push_back(fea_set.arith_intensity_curve[i]);
+      ret->push_back(slog(fea_set.arith_intensity_curve[i]));
     }
 
     /***** Group 4: Allocation related features *****/

--- a/src/auto_scheduler/feature.cc
+++ b/src/auto_scheduler/feature.cc
@@ -884,9 +884,9 @@ class PerStoreFeatureExtractor : public StmtExprVisitor {
         mem_bytes += touched_size * buffer_dtypes.at(t).bytes();
       }
 
-      mem_bytes_list->push_back(std::log2(mem_bytes));
+      mem_bytes_list->push_back(mem_bytes);
       *cur_compute_ops *= GetLoopExtent(for_loop_stack_[i], local_analyzer);
-      compute_ops_list->push_back(std::log2(*cur_compute_ops));
+      compute_ops_list->push_back(*cur_compute_ops);
     }
 
     //  Buffer access related features (per buffer)


### PR DESCRIPTION
In autoscheduler's featurization, arithmetic intensity was incorrectly calculated as log(FLOPs) / log(bytes). This change removes the logs so arithmetic intensity is FLOPs / bytes.

@junrushao1994 @merrymercy @octoJon 
