### PR TITLE
[Pylint] Making hexagon tests pylint compliant Part 1 of N

### DIFF
--- a/tests/lint/pylint.sh
+++ b/tests/lint/pylint.sh
@@ -24,3 +24,11 @@ python3 -m pylint tests/python/contrib/test_cmsisnn --rcfile="$(dirname "$0")"/p
 python3 -m pylint tests/python/relay/aot/*.py --rcfile="$(dirname "$0")"/pylintrc
 python3 -m pylint tests/python/ci --rcfile="$(dirname "$0")"/pylintrc
 python3 -m pylint tests/python/integration/ --rcfile="$(dirname "$0")"/pylintrc
+
+# tests/python/contrib/test_hexagon tests
+python3 -m pylint tests/python/contrib/test_hexagon/benchmark_util.py --rcfile="$(dirname "$0")"/pylintrc
+python3 -m pylint tests/python/contrib/test_hexagon/conftest.py --rcfile="$(dirname "$0")"/pylintrc
+python3 -m pylint tests/python/contrib/test_hexagon/conv2d/test_conv2d_blocked.py --rcfile="$(dirname "$0")"/pylintrc
+python3 -m pylint tests/python/contrib/test_hexagon/conv2d/test_conv2d_conv2d.py --rcfile="$(dirname "$0")"/pylintrc
+python3 -m pylint tests/python/contrib/test_hexagon/infrastructure.py --rcfile="$(dirname "$0")"/pylintrc
+python3 -m pylint tests/python/contrib/test_hexagon/test_2d_physical_buffers.py --rcfile="$(dirname "$0")"/pylintrc

--- a/tests/python/contrib/test_hexagon/conftest.py
+++ b/tests/python/contrib/test_hexagon/conftest.py
@@ -19,11 +19,6 @@
     values from testing parameters """
 
 
-import pytest
-
-import tvm
-import tvm.testing
-
 pytest_plugins = [
     "tvm.contrib.hexagon.pytest_plugin",
 ]

--- a/tests/python/contrib/test_hexagon/conftest.py
+++ b/tests/python/contrib/test_hexagon/conftest.py
@@ -18,7 +18,8 @@
 """ Hexagon testing fixtures used to deduce testing argument
     values from testing parameters """
 
-
+# Disabling invalid-name check as the name is expected to be exactly this by pytest
+# pylint: disable=invalid-name
 pytest_plugins = [
     "tvm.contrib.hexagon.pytest_plugin",
 ]

--- a/tests/python/contrib/test_hexagon/conv2d/test_conv2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/conv2d/test_conv2d_blocked.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import sys
+""" Hexagon contrib tests for blocked conv2d """
 
-import platform
+
+import numpy as np
 import tvm
 import tvm.testing
-from tvm import te
-from tvm import topi
+from tvm import te, topi
 from tvm.topi import testing
 
 from ..infrastructure import (
@@ -32,9 +32,6 @@ from ..infrastructure import (
     get_packed_filter_shape,
     get_packed_shape,
 )
-
-import numpy as np
-import pytest
 
 
 def conv2d_nhwc8h8w32c(
@@ -57,72 +54,84 @@ def conv2d_nhwc8h8w32c(
     """
 
     # nhwc layout
-    X = te.placeholder(shape_input, dtype=dtype, name="logical_input")
+    logical_input = te.placeholder(shape_input, dtype=dtype, name="logical_input")
 
     # oihw8i32o4i layout
     filt_packed = te.placeholder(shape_filter, dtype=dtype, name="packed_filter")
 
-    block_H, block_W, block_C = get_block_shape()
+    block_h, block_w, block_c = get_block_shape()
 
     # Calculate padded input
-    N, H, W, C = shape_input
-    pad_h = (block_H - ((H + pad[1]) % block_H)) % block_H
-    pad_w = (block_W - ((W + pad[3]) % block_W)) % block_W
-    X_pad = topi.nn.pad(
-        X, [0, pad[0], pad[2], 0], [0, pad_h, pad_w, 0], pad_value=0, name="padded_input"
+    _, height, width, _ = shape_input
+    pad_h = (block_h - ((height + pad[1]) % block_h)) % block_h
+    pad_w = (block_w - ((width + pad[3]) % block_w)) % block_w
+    padded_input = topi.nn.pad(
+        logical_input,
+        [0, pad[0], pad[2], 0],
+        [0, pad_h, pad_w, 0],
+        pad_value=0,
+        name="padded_input",
     )
 
     # Calculate packed input
-    packed_shape = get_packed_shape(X_pad.shape)
-    X_packed = te.compute(
+    packed_shape = get_packed_shape(padded_input.shape)
+    packed_input = te.compute(
         packed_shape,
-        lambda n, ho, wo, co, hi, wi, ci: X_pad[
-            n, ho * block_H + hi, wo * block_W + wi, co * block_C + ci
+        lambda n, ho, wo, co, hi, wi, ci: padded_input[
+            n, ho * block_h + hi, wo * block_w + wi, co * block_c + ci
         ],
         name="packed_input",
     )
 
-    output_shape, compute = conv2d_compute(X_packed, filt_packed, pad, stride, dilation)
-    Y = te.compute(output_shape, compute, name="packed_output")
-    s = te.create_schedule(Y.op)
+    output_shape, compute = conv2d_compute(packed_input, filt_packed, pad, stride, dilation)
+    packed_output = te.compute(output_shape, compute, name="packed_output")
+    s = te.create_schedule(packed_output.op)
 
     # Ensure the padding and array packing is performed inline
-    s[X_pad].compute_inline()
-    s[X_packed].compute_inline()
+    s[padded_input].compute_inline()
+    s[packed_input].compute_inline()
 
     # cache reads and writes
-    Xl = s.cache_read(X_packed, storage_scope, [Y])
-    Fl = s.cache_read(filt_packed, storage_scope, [Y])
-    Yl = s.cache_write(Y, storage_scope)
+    cached_input = s.cache_read(packed_input, storage_scope, [packed_output])
+    cached_filt = s.cache_read(filt_packed, storage_scope, [packed_output])
+    cached_output = s.cache_write(packed_output, storage_scope)
 
     # cache write schedule
-    n, ho, wo, ko, hi, wi, ki = s[Y].op.axis
-    koo, koi = s[Y].split(ko, factor=k_split_factor)
-    hoo, hoi = s[Y].split(ho, factor=h_split_factor)
-    s[Y].reorder(n, koo, hoo, koi, hoi, wo, hi, wi, ki)
-    s[Yl].compute_at(s[Y], hoo)
+    batch, h_outer, w_outer, k_outer, h_inner, w_inner, k_inner = s[packed_output].op.axis
+    koo, koi = s[packed_output].split(k_outer, factor=k_split_factor)
+    hoo, hoi = s[packed_output].split(h_outer, factor=h_split_factor)
+    s[packed_output].reorder(batch, koo, hoo, koi, hoi, w_outer, h_inner, w_inner, k_inner)
+    s[cached_output].compute_at(s[packed_output], hoo)
 
     # compute schedule
-    n, ho, wo, ko, hi, wi, ki = s[Yl].op.axis
-    rh, rw, rc = s[Yl].op.reduce_axis
-    rco, rci = s[Yl].split(rc, factor=block_C)
-    koo, koi = s[Yl].split(ko, factor=k_split_factor)
-    hoo, hoi = s[Yl].split(ho, factor=h_split_factor)
-    s[Yl].reorder(n, koo, hoo, koi, hoi, wo, rco, hi, wi, ki, rci)
-    s[Xl].compute_at(s[Yl], hoo)
-    s[Fl].compute_at(s[Yl], hoo)
+    batch, h_outer, w_outer, k_outer, h_inner, w_inner, k_inner = s[cached_output].op.axis
+    _, _, reduce_c = s[cached_output].op.reduce_axis
+    rco, rci = s[cached_output].split(reduce_c, factor=block_c)
+    koo, koi = s[cached_output].split(k_outer, factor=k_split_factor)
+    hoo, hoi = s[cached_output].split(h_outer, factor=h_split_factor)
+    s[cached_output].reorder(
+        batch, koo, hoo, koi, hoi, w_outer, rco, h_inner, w_inner, k_inner, rci
+    )
+    s[cached_input].compute_at(s[cached_output], hoo)
+    s[cached_filt].compute_at(s[cached_output], hoo)
 
     binds = {}
     if storage_scope and storage_scope != "global":
         with tvm.transform.PassContext():
-            Xb = tvm.tir.decl_buffer(packed_shape, name="Xb", dtype=dtype, scope=storage_scope)
-            Yb = tvm.tir.decl_buffer(output_shape, name="Yb", dtype=dtype, scope=storage_scope)
-            binds = {X: Xb, Y: Yb}
+            input_buffer = tvm.tir.decl_buffer(
+                packed_shape, name="Xb", dtype=dtype, scope=storage_scope
+            )
+            output_buffer = tvm.tir.decl_buffer(
+                output_shape, name="Yb", dtype=dtype, scope=storage_scope
+            )
+            binds = {logical_input: input_buffer, packed_output: output_buffer}
 
-    return (s, [X, filt_packed, Y], binds)
+    return (s, [logical_input, filt_packed, packed_output], binds)
 
 
 class BaseConv2d:
+    """Base class for conv2d tests"""
+
     # input
     batch = tvm.testing.parameter(1)
     in_size = tvm.testing.parameter(64)
@@ -139,6 +148,8 @@ class BaseConv2d:
 
 
 class TestConv2dPackedFilter(BaseConv2d):
+    """Conv2d packed filter test class"""
+
     @tvm.testing.parametrize_targets("llvm")
     @tvm.testing.skip_if_32bit(reason="Test known to be flaky on i386 machines")
     def test_conv2d(
@@ -155,6 +166,7 @@ class TestConv2dPackedFilter(BaseConv2d):
         dtype,
         target,
     ):
+        """conv2d test"""
         # TODO: no support for dilation
         dilation = 1
 

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -17,24 +17,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+""" Test 2d physical buffers """
+
 import contextlib
-import sys
 
-import pytest
 import numpy as np
-
+import pytest
 import tvm
-import tvm.testing
-from tvm import te
-from tvm.tir.stmt_functor import post_order_visit
-from tvm.contrib.hexagon.build import HexagonLauncher
-
-from tvm.contrib.hexagon.pytest_plugin import requires_hexagon_toolchain
-from .infrastructure import allocate_hexagon_array
 
 # Needed to register the link_shared packedfunc.
 import tvm.contrib.hexagon
+import tvm.testing
+from tvm import te
+from tvm.contrib.hexagon.pytest_plugin import requires_hexagon_toolchain
+from tvm.tir.stmt_functor import post_order_visit
 
+from .infrastructure import allocate_hexagon_array
 
 dtype = tvm.testing.parameter("int8")
 batch_size = tvm.testing.parameter(
@@ -71,6 +69,7 @@ working_layout, working_scope = tvm.testing.parameters(
 
 @tvm.testing.fixture
 def target_host(target):
+    """Return tvm target.Target with host attached"""
     target = tvm.target.Target(target)
 
     if target.kind.name == "hexagon":
@@ -84,6 +83,12 @@ def target_host(target):
     return tvm.target.Target(target, host=host)
 
 
+# Disabling redefined-outer-name for the whole file as there isn't any easy
+# solution yet to refactor tvm.testing.fixture fixtures that avoid redefining
+# outer variable names
+# pylint: disable=redefined-outer-name
+
+
 @tvm.testing.fixture
 def input_shape(batch_size, input_channels, input_image_shape):
     return [batch_size, *input_image_shape, input_channels]
@@ -92,21 +97,21 @@ def input_shape(batch_size, input_channels, input_image_shape):
 def transform_shape(shape, layout):
     if layout == "nhwc":
         return shape
-    elif layout in ["nchw-8h8w32c-1d", "nchw-8h8w32c-2d"]:
-        N, H, W, C = shape
-        return [N, (C + 31) // 32, (H + 7) // 8, (W + 7) // 8, 8, 8, 32]
-    else:
-        raise RuntimeError(f"Unexpected layout '{layout}'")
+    if layout in ["nchw-8h8w32c-1d", "nchw-8h8w32c-2d"]:
+        batch, height, width, channel = shape
+        return [batch, (channel + 31) // 32, (height + 7) // 8, (width + 7) // 8, 8, 8, 32]
+    raise RuntimeError(f"Unexpected layout '{layout}'")
 
 
 def transform_numpy(arr_np, layout):
     if layout == "nhwc":
         return arr_np
-    elif layout in ["nchw-8h8w32c-1d", "nchw-8h8w32c-2d"]:
-        N, H, W, C = arr_np.shape
-        return arr_np.reshape([N, H // 8, 8, W // 8, 8, C // 32, 32]).transpose(0, 5, 1, 3, 2, 4, 6)
-    else:
-        raise RuntimeError(f"Unexpected layout '{layout}'")
+    if layout in ["nchw-8h8w32c-1d", "nchw-8h8w32c-2d"]:
+        batch, height, width, channel = arr_np.shape
+        return arr_np.reshape([batch, height // 8, 8, width // 8, 8, channel // 32, 32]).transpose(
+            0, 5, 1, 3, 2, 4, 6
+        )
+    raise RuntimeError(f"Unexpected layout '{layout}'")
 
 
 @tvm.testing.fixture
@@ -134,28 +139,28 @@ def transformed_expected_output_np(expected_output_np, output_layout):
     return transform_numpy(expected_output_np, output_layout)
 
 
-def layout_transform_1d(n, h, w, c):
+def layout_transform_1d(batch, height, width, channel):
     return [
-        n,
-        c // 32,
-        h // 8,
-        w // 8,
-        h % 8,
-        w % 8,
-        c % 32,
+        batch,
+        channel // 32,
+        height // 8,
+        width // 8,
+        height % 8,
+        width % 8,
+        channel % 32,
     ]
 
 
-def layout_transform_2d(n, h, w, c):
+def layout_transform_2d(batch, height, width, channel):
     return [
-        n,
-        c // 32,
-        h // 8,
-        w // 8,
+        batch,
+        channel // 32,
+        height // 8,
+        width // 8,
         te.AXIS_SEPARATOR,
-        h % 8,
-        w % 8,
-        c % 32,
+        height % 8,
+        width % 8,
+        channel % 32,
     ]
 
 
@@ -171,6 +176,8 @@ def extract_buffers(stmt):
 
 
 class TestElementWise:
+    """TestElementWise"""
+
     @tvm.testing.fixture
     def expected_output_np(self, input_np):
         return 2 * input_np
@@ -189,18 +196,19 @@ class TestElementWise:
         working_layout,
         working_scope,
     ):
-        InputTensor = te.placeholder(input_shape, dtype, name="Input")
-        OutputTensor = te.compute(
-            shape=InputTensor.shape,
-            fcompute=lambda *indices: (2 * InputTensor[indices]).astype(dtype),
+        """Create and return the schedule and input args after applying layout transform"""
+        input_tensor = te.placeholder(input_shape, dtype, name="Input")
+        output_tensor = te.compute(
+            shape=input_tensor.shape,
+            fcompute=lambda *indices: (2 * input_tensor[indices]).astype(dtype),
             name="Output",
         )
-        schedule = te.create_schedule(OutputTensor.op)
+        schedule = te.create_schedule(output_tensor.op)
 
-        WriteCache = schedule.cache_write(OutputTensor, working_scope)
-        ReadCache = schedule.cache_read(InputTensor, working_scope, [WriteCache])
+        write_cache = schedule.cache_write(output_tensor, working_scope)
+        read_cache = schedule.cache_read(input_tensor, working_scope, [write_cache])
 
-        def apply_transform(tensor, layout):
+        def apply_transform(tensor, layout):  # pylint: disable=inconsistent-return-statements
             if layout == "nhwc":
                 pass
             elif layout == "nchw-8h8w32c-1d":
@@ -210,14 +218,14 @@ class TestElementWise:
             else:
                 raise RuntimeError(f"Unexpected layout '{layout}'")
 
-        apply_transform(InputTensor, input_layout)
-        compute_loopnest = apply_transform(OutputTensor, output_layout) or OutputTensor.op.axis
-        schedule[WriteCache].compute_at(schedule[OutputTensor], compute_loopnest[0])
+        apply_transform(input_tensor, input_layout)
+        compute_loopnest = apply_transform(output_tensor, output_layout) or output_tensor.op.axis
+        schedule[write_cache].compute_at(schedule[output_tensor], compute_loopnest[0])
 
-        apply_transform(ReadCache, working_layout)
-        apply_transform(WriteCache, working_layout)
+        apply_transform(read_cache, working_layout)
+        apply_transform(write_cache, working_layout)
 
-        return [schedule, [InputTensor, OutputTensor]]
+        return [schedule, [input_tensor, output_tensor]]
 
     @tvm.testing.fixture
     def ir_module(self, schedule_args):
@@ -229,7 +237,7 @@ class TestElementWise:
             return tvm.lower(*schedule_args)
 
     @tvm.testing.fixture
-    def uses_unsupported_physical_dimensions(
+    def uses_unsupported_physical_dimensions(  # pylint: disable=invalid-name
         self, target_host, input_layout, working_layout, output_layout
     ):
         uses_2d_memory = "nchw-8h8w32c-2d" in [input_layout, working_layout, output_layout]
@@ -246,6 +254,7 @@ class TestElementWise:
         assert primfunc_output_shape == transformed_output_shape
 
     def test_cache_shape(self, ir_module, input_layout, working_layout, output_layout):
+        """Test function to check expected_physical_dimensions for cached buffers"""
         func = ir_module["main"]
         for buffer in extract_buffers(func.body):
             buffer_layout = {
@@ -306,6 +315,7 @@ class TestElementWise:
         output_layout,
         hexagon_session,
     ):
+        """Test execution of computes with 2d physical buffers"""
         if input_layout == "nchw-8h8w32c-2d":
             input_axis_separators = [4]
         else:

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -34,6 +34,13 @@ from tvm.tir.stmt_functor import post_order_visit
 
 from .infrastructure import allocate_hexagon_array
 
+# Disabling invalid name as pylint assumes global variables as constants and
+# expects them to be all upper-case. Since these are used as
+# tvm.testing.parameters, if they are made upper-case, the functions which take
+# them as arguments would also need to be upper-case, and pylint would complain
+# there as well
+# pylint: disable=invalid-name
+
 dtype = tvm.testing.parameter("int8")
 batch_size = tvm.testing.parameter(
     16,
@@ -65,6 +72,8 @@ working_layout, working_scope = tvm.testing.parameters(
     # 2-d memory may only occur in vtcm memory
     ("nchw-8h8w32c-2d", "global.vtcm"),
 )
+
+# pylint: enable=invalid-name
 
 
 @tvm.testing.fixture

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -208,15 +208,14 @@ class TestElementWise:
         write_cache = schedule.cache_write(output_tensor, working_scope)
         read_cache = schedule.cache_read(input_tensor, working_scope, [write_cache])
 
-        def apply_transform(tensor, layout):  # pylint: disable=inconsistent-return-statements
+        def apply_transform(tensor, layout):
             if layout == "nhwc":
-                pass
-            elif layout == "nchw-8h8w32c-1d":
+                return None
+            if layout == "nchw-8h8w32c-1d":
                 return schedule[tensor].transform_layout(layout_transform_1d)
-            elif layout == "nchw-8h8w32c-2d":
+            if layout == "nchw-8h8w32c-2d":
                 return schedule[tensor].transform_layout(layout_transform_2d)
-            else:
-                raise RuntimeError(f"Unexpected layout '{layout}'")
+            raise RuntimeError(f"Unexpected layout '{layout}'")
 
         apply_transform(input_tensor, input_layout)
         compute_loopnest = apply_transform(output_tensor, output_layout) or output_tensor.op.axis

--- a/tests/python/contrib/test_hexagon/test_benchmark_elemwise_add.py
+++ b/tests/python/contrib/test_hexagon/test_benchmark_elemwise_add.py
@@ -14,20 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+""" benchmark_elemwise_add """
 
 import os
 import os.path
 import sys
-import pytest
-import numpy as np
-import logging
 import tempfile
 
-import tvm.testing
+import numpy as np
+import pytest
 import tvm.script
-from tvm.script import tir as T
-from tvm import te
+import tvm.testing
 from tvm.contrib.hexagon.build import HexagonLauncherRPC
+from tvm.script import tir as T
+
 from . import benchmark_util as bu
 
 _SHOULD_SKIP_BENCHMARKS, _SKIP_BENCHMARKS_REASON = bu.skip_bencharks_flag_and_reason()
@@ -90,12 +90,8 @@ print("OUTPUT DIRECTORY: {}".format(_HOST_OUTPUT_DIR))
 print("-" * 80)
 print()
 
-from typing import Tuple
 
-
-def _get_irmod_elemwise_add(
-    _PRIMFUNC_NAME: str, shape: list, dtype: str, mem_scope: str
-) -> tvm.ir.module.IRModule:
+def _get_irmod_elemwise_add(shape: list, dtype: str, mem_scope: str) -> tvm.ir.module.IRModule:
     """
     Return an IRModule containing a single primfunc, expressed as NS-TIR.
 
@@ -113,7 +109,6 @@ def _get_irmod_elemwise_add(
         dim0_size,
         dim1_size,
     ) = shape
-    dtype_str = str(dtype)
 
     if mem_scope == "global.vtcm":
         raise bu.UnsupportedException("This benchmark kernel does not yet support VTCM buffers.")
@@ -124,6 +119,7 @@ def _get_irmod_elemwise_add(
         # Also: The VTCM budget is a very rough estimate, based only on experience.
         # Assuming that it's even reasonable to use a hard-coded estimate AT ALL, this number
         # may need tweaking.
+        # pylint: disable=unreachable
         estimated_vtcm_budget_bytes = HVX_VECTOR_BYTES * 1024
 
         dtype_bits = tvm._ffi.runtime_ctypes.DataType(dtype).bits
@@ -135,9 +131,13 @@ def _get_irmod_elemwise_add(
 
         if estimated_vtcm_needed_bytes > estimated_vtcm_budget_bytes:
             raise bu.UnsupportedException("Expect to exceed VTCM budget.")
+        # pylint: enable=unreachable
 
     @tvm.script.ir_module
     class BenchmarkModule:
+        """Elementwise STIR module for benchmarking"""
+
+        # pylint: disable=no-self-argument,invalid-name,missing-function-docstring
         @T.prim_func
         def main(a: T.handle, b: T.handle, c: T.handle):
             # We exchange data between function by handles, which are similar to pointer.
@@ -151,6 +151,7 @@ def _get_irmod_elemwise_add(
                 for j in range(dim1_size):
                     C[i, j] = A[i, j] + B[i, j]
 
+    # pylint: enable=no-self-argument,invalid-name,missing-function-docstring
     return BenchmarkModule
 
 
@@ -187,12 +188,12 @@ def _benchmark_hexagon_elementwise_add_kernel(
     keys_dict["host_files_dir_path"] = host_files_dir_path
 
     log_file_path = os.path.join(host_files_dir_path, "out.txt")
-    with open(log_file_path, "w") as log_file:
+    with open(log_file_path, "w", encoding="UTF-8") as log_file:
         print(f"CONFIGURATION: {desc}")
         log_file.write(f"CONFIGURATION: {desc}\n")
 
         try:
-            ns_tir_module = _get_irmod_elemwise_add(_PRIMFUNC_NAME, shape, dtype, mem_scope)
+            ns_tir_module = _get_irmod_elemwise_add(shape, dtype, mem_scope)
 
             # Dump the primfunc NS-TIR (as text) to the log file...
             lowered_mod = tvm.lower(ns_tir_module, _PRIMFUNC_NAME)
@@ -201,16 +202,16 @@ def _benchmark_hexagon_elementwise_add_kernel(
             log_file.write("\n")
 
             # Lower the primfunc's IRModule to Hexagon object code...
-            A = tvm.te.placeholder(shape, dtype=dtype)
-            B = tvm.te.placeholder(shape, dtype=dtype)
-            C = tvm.te.placeholder(shape, dtype=dtype)
+            input1 = tvm.te.placeholder(shape, dtype=dtype)
+            input2 = tvm.te.placeholder(shape, dtype=dtype)
+            output = tvm.te.placeholder(shape, dtype=dtype)
 
             built_module: tvm.driver.build_module.OperatorModule = tvm.build(
                 ns_tir_module,
                 [
-                    A,
-                    B,
-                    C,
+                    input1,
+                    input2,
+                    output,
                 ],
                 _SUPER_TARGET,
                 name=_PRIMFUNC_NAME,
@@ -231,9 +232,9 @@ def _benchmark_hexagon_elementwise_add_kernel(
 
             # Generate our testing / validation data...
             (
-                host_numpy_A_data,
-                host_numpy_B_data,
-                host_numpy_C_data_expected,
+                host_numpy_input1_data,
+                host_numpy_input2_data,
+                host_numpy_output_data_expected,
             ) = _get_elemwise_add_reference_value_tensors(shape, dtype)
 
             with hexagon_launcher.start_session() as sess:
@@ -244,25 +245,25 @@ def _benchmark_hexagon_elementwise_add_kernel(
                 )
 
                 # Create the target-side tensors to hold the primfunc's inputs and outputs...
-                A_data = tvm.nd.empty(shape, dtype, sess.device, mem_scope)
-                B_data = tvm.nd.empty(shape, dtype, sess.device, mem_scope)
-                C_data = tvm.nd.empty(shape, dtype, sess.device, mem_scope)
+                input1_data = tvm.nd.empty(shape, dtype, sess.device, mem_scope)
+                input2_data = tvm.nd.empty(shape, dtype, sess.device, mem_scope)
+                output_data = tvm.nd.empty(shape, dtype, sess.device, mem_scope)
 
                 # Populate the primfunc's input tensors...
-                A_data.copyfrom(host_numpy_A_data)
-                B_data.copyfrom(host_numpy_B_data)
+                input1_data.copyfrom(host_numpy_input1_data)
+                input2_data.copyfrom(host_numpy_input2_data)
 
                 # Actually benchmark the primfunc...
                 timer = loaded_hexagon_module.time_evaluator(
                     "main", sess.device, number=10, repeat=1
                 )
-                timing_result = timer(A_data, B_data, C_data)
+                timing_result = timer(input1_data, input2_data, output_data)
 
                 print(f"TIMING RESULT: {timing_result}")
                 log_file.write(f"TIMING RESULT: {timing_result}\n")
 
                 # Verify that the computation actually happened, and produced the correct result.
-                result = C_data.numpy()
+                result = output_data.numpy()
 
                 if dtype == "float16":
                     # These are the closest tolerance we currently expect / require for these
@@ -282,30 +283,30 @@ def _benchmark_hexagon_elementwise_add_kernel(
                 # kill the overall script.
                 try:
                     tvm.testing.assert_allclose(
-                        result, host_numpy_C_data_expected, rel_tolerance, abs_tolerance
+                        result, host_numpy_output_data_expected, rel_tolerance, abs_tolerance
                     )
-                except AssertionError as e:
-                    raise bu.NumericalAccuracyException(str(e))
+                except AssertionError as err:
+                    raise bu.NumericalAccuracyException(str(err))
 
                 _BT.record_success(timing_result, **keys_dict)
 
-        except bu.NumericalAccuracyException as e:
+        except bu.NumericalAccuracyException as err:
             print()
-            print(f"FAIL: Numerical accuracy error. See log file.")
+            print("FAIL: Numerical accuracy error. See log file.")
 
             log_file.write("\n")
-            log_file.write(f"FAIL: {e}\n")
+            log_file.write(f"FAIL: {err}\n")
 
-            _BT.record_fail(**keys_dict, comments=f"Numerical accuracy error. See log file.")
+            _BT.record_fail(**keys_dict, comments="Numerical accuracy error. See log file.")
 
-        except bu.UnsupportedException as e:
+        except bu.UnsupportedException as err:
             print()
-            print(f"SKIP: {e}")
+            print(f"SKIP: {err}")
 
             log_file.write("\n")
-            log_file.write(f"SKIP: {e}\n")
+            log_file.write(f"SKIP: {err}\n")
 
-            _BT.record_skip(**keys_dict, comments=f"Unsupported configuration: {e}")
+            _BT.record_skip(**keys_dict, comments=f"Unsupported configuration: {err}")
 
 
 def _get_elemwise_add_reference_value_tensors(shape: list, dtype: str):
@@ -321,10 +322,10 @@ def _get_elemwise_add_reference_value_tensors(shape: list, dtype: str):
     """
     assert len(shape) == 2
 
-    A = np.ndarray(shape, dtype=dtype)
-    B = np.ndarray(shape, dtype=dtype)
+    input1 = np.ndarray(shape, dtype=dtype)
+    input2 = np.ndarray(shape, dtype=dtype)
 
-    np_dtype = A.dtype
+    np_dtype = input1.dtype
 
     if np_dtype.kind in ["i", "u"]:
         # We allow overflow for integer types because it tends to be well-behaved
@@ -336,8 +337,8 @@ def _get_elemwise_add_reference_value_tensors(shape: list, dtype: str):
 
         for i in range(shape[0]):
             for j in range(shape[1]):
-                A[i, j] = next_value
-                B[i, j] = next_value * 2
+                input1[i, j] = next_value
+                input2[i, j] = next_value * 2
                 next_value += 1
 
     elif np_dtype.kind == "f":
@@ -355,24 +356,25 @@ def _get_elemwise_add_reference_value_tensors(shape: list, dtype: str):
 
         for i in range(shape[0]):
             for j in range(shape[1]):
-                A[i, j] = next_value
-                B[i, j] = next_value + 1
+                input1[i, j] = next_value
+                input2[i, j] = next_value + 1
                 next_value += delta
 
     else:
         assert False, f"Unexpected data type: {np_dtype}"
 
-    C = A + B
+    output = input1 + input2
     return [
-        A,
-        B,
-        C,
+        input1,
+        input2,
+        output,
     ]
 
 
 @pytest.mark.skipif(_SHOULD_SKIP_BENCHMARKS, reason=_SKIP_BENCHMARKS_REASON)
 @tvm.testing.requires_hexagon
 def test_elemwise_add(hexagon_launcher: HexagonLauncherRPC):
+    """Main elementwise add test function"""
     for dtype in [
         "int8",
         "float16",
@@ -413,7 +415,7 @@ def test_elemwise_add(hexagon_launcher: HexagonLauncherRPC):
     print()
 
     tabular_output_filename = os.path.join(_HOST_OUTPUT_DIR, "benchmark-results.csv")
-    with open(tabular_output_filename, "w") as csv_file:
+    with open(tabular_output_filename, "w", encoding="UTF-8") as csv_file:
         _BT.print_csv(csv_file, _CSV_COLUMN_ORDER)
 
     print(f"BENCHMARK RESULTS FILE: {tabular_output_filename}")

--- a/tests/python/contrib/test_hexagon/test_benchmark_elemwise_add.py
+++ b/tests/python/contrib/test_hexagon/test_benchmark_elemwise_add.py
@@ -119,19 +119,24 @@ def _get_irmod_elemwise_add(shape: list, dtype: str, mem_scope: str) -> tvm.ir.m
         # Also: The VTCM budget is a very rough estimate, based only on experience.
         # Assuming that it's even reasonable to use a hard-coded estimate AT ALL, this number
         # may need tweaking.
-        # pylint: disable=unreachable
-        estimated_vtcm_budget_bytes = HVX_VECTOR_BYTES * 1024
 
-        dtype_bits = tvm._ffi.runtime_ctypes.DataType(dtype).bits
-        assert dtype_bits % 8 == 0
-        dtype_bytes = dtype_bits // 8
+        # The below code is commented is commented to avoid unreachable error
+        # with pylint. Please enable this once the kernel starts supporting
+        # VTCM buffers
 
-        num_vtcm_tensors = 3
-        estimated_vtcm_needed_bytes = shape[0] * shape[1] * dtype_bytes * num_vtcm_tensors
+        # Code starts below:
+        # ---- ------ -----
+        # estimated_vtcm_budget_bytes = HVX_VECTOR_BYTES * 1024
 
-        if estimated_vtcm_needed_bytes > estimated_vtcm_budget_bytes:
-            raise bu.UnsupportedException("Expect to exceed VTCM budget.")
-        # pylint: enable=unreachable
+        # dtype_bits = tvm._ffi.runtime_ctypes.DataType(dtype).bits
+        # assert dtype_bits % 8 == 0
+        # dtype_bytes = dtype_bits // 8
+
+        # num_vtcm_tensors = 3
+        # estimated_vtcm_needed_bytes = shape[0] * shape[1] * dtype_bytes * num_vtcm_tensors
+
+        # if estimated_vtcm_needed_bytes > estimated_vtcm_budget_bytes:
+        #     raise bu.UnsupportedException("Expect to exceed VTCM budget.")
 
     @tvm.script.ir_module
     class BenchmarkModule:
@@ -151,7 +156,8 @@ def _get_irmod_elemwise_add(shape: list, dtype: str, mem_scope: str) -> tvm.ir.m
                 for j in range(dim1_size):
                     C[i, j] = A[i, j] + B[i, j]
 
-    # pylint: enable=no-self-argument,invalid-name,missing-function-docstring
+        # pylint: enable=no-self-argument,invalid-name,missing-function-docstring
+
     return BenchmarkModule
 
 


### PR DESCRIPTION
This is the first of a few PRs I'll raise to update the hexagon tests pylint compliant.

This patch fixes the below 7 files
* [X]  tests/python/contrib/test_hexagon/benchmark_elemwise_add.py
* [X]  tests/python/contrib/test_hexagon/benchmark_util.py
* [X]  tests/python/contrib/test_hexagon/conftest.py
* [X]  tests/python/contrib/test_hexagon/conv2d/test_conv2d_blocked.py
* [X]  tests/python/contrib/test_hexagon/conv2d/test_conv2d_conv2d.py
* [X]  tests/python/contrib/test_hexagon/infrastructure.py
* [x]  tests/python/contrib/test_hexagon/test_2d_physical_buffers.py

This is part of the larger effort tracked in #11414 to make all tests in TVM pylint compliant