### PR TITLE
[FIX,TIR] Handle allocations of variable size

### DIFF
--- a/include/tvm/arith/int_set.h
+++ b/include/tvm/arith/int_set.h
@@ -97,6 +97,10 @@ class IntSet : public ObjectRef {
   bool HasUpperBound() const;
   /*! \return Whether the set has lower bound. */
   bool HasLowerBound() const;
+  /*! \return Whether the set has a non-variable upper bound. */
+  bool HasConstUpperBound() const;
+  /*! \return Whether the set has a non-variable lower bound. */
+  bool HasConstLowerBound() const;
 
   /*!
    * \brief The single point value, call only if IsSinglePoint is true

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -785,6 +785,20 @@ bool IntSet::HasUpperBound() const {
   return false;
 }
 
+bool IntSet::HasConstLowerBound() const {
+  if (const IntervalSetNode* s_int = (*this).as<IntervalSetNode>()) {
+    return s_int->HasConstLowerBound();
+  }
+  return false;
+}
+
+bool IntSet::HasConstUpperBound() const {
+  if (const IntervalSetNode* s_int = (*this).as<IntervalSetNode>()) {
+    return s_int->HasConstUpperBound();
+  }
+  return false;
+}
+
 SignType IntSet::GetSignType() const {
   if (CanProvePositive()) {
     return kPositive;

--- a/src/arith/interval_set.h
+++ b/src/arith/interval_set.h
@@ -58,6 +58,14 @@ class IntervalSetNode : public IntSetNode {
   bool HasUpperBound() const { return !is_pos_inf(max_value) && !IsEmpty(); }
   /*! \return Whether the interval has lower bound. */
   bool HasLowerBound() const { return !is_neg_inf(min_value) && !IsEmpty(); }
+  /*! \return Whether the interval has a non-variable upper bound. */
+  bool HasConstUpperBound() const {
+    return HasUpperBound() && max_value.as<IntImmNode>() != nullptr;
+  }
+  /*! \return Whether the interval has a non-variable lower bound. */
+  bool HasConstLowerBound() const {
+    return HasLowerBound() && min_value.as<IntImmNode>() != nullptr;
+  }
   /*! \return Whether the interval is a single point. */
   bool IsSinglePoint() const {
     if (min_value.same_as(max_value)) {

--- a/src/arith/ir_visitor_with_analyzer.h
+++ b/src/arith/ir_visitor_with_analyzer.h
@@ -34,8 +34,8 @@ namespace arith {
 
 class IRVisitorWithAnalyzer : public tir::StmtExprVisitor {
  public:
-   using StmtExprVisitor::VisitExpr_;
-   using StmtExprVisitor::VisitStmt_;
+  using StmtExprVisitor::VisitExpr_;
+  using StmtExprVisitor::VisitStmt_;
   PrimExpr Simplify(const PrimExpr& expr) { return analyzer_.Simplify(expr); }
 
   void VisitStmt_(const tir::ForNode* op);

--- a/src/arith/ir_visitor_with_analyzer.h
+++ b/src/arith/ir_visitor_with_analyzer.h
@@ -34,10 +34,9 @@ namespace arith {
 
 class IRVisitorWithAnalyzer : public tir::StmtExprVisitor {
  public:
+   using StmtExprVisitor::VisitExpr_;
+   using StmtExprVisitor::VisitStmt_;
   PrimExpr Simplify(const PrimExpr& expr) { return analyzer_.Simplify(expr); }
-
-  using StmtExprVisitor::VisitExpr_;
-  using StmtExprVisitor::VisitStmt_;
 
   void VisitStmt_(const tir::ForNode* op);
   void VisitStmt_(const tir::BlockNode* op);


### PR DESCRIPTION
Variable size allocations like `T.allocate([10 * i])` were incorrectly
moved up to where they were outside the scope of any variables in their
size. For example:

```
for i in range(8):
    T.allocate([10 * i])
    ...
```
became
```
T.allocate([10 * i])
for i in range(8):
    ...
```

Now variable sized allocations will use the constant upper bound on
their size. With the above example:

```
T.allocate([80])
for i in range(8):
    ...
```

Variable size allocations occur because earlier passes move constant
size allocations to where the are accessed and update the allocation
size to match the access size.

@Lunderberg @masahi 
