### PR TITLE
[Relay] Add RecoverVirtualDeviceMap helper

### DIFF
--- a/src/relay/transforms/device_aware_visitors.h
+++ b/src/relay/transforms/device_aware_visitors.h
@@ -348,6 +348,14 @@ class DeviceAwareExprMutator : public ExprMutator, public LexicalOnDeviceMixin {
   virtual Expr PostVisitLetBlock_(const LetNode* pre_let_node, const LetNode* post_let_node);
 };
 
+/*!
+ * \brief Returs a map from Relay expression node to its virtual device using the annotations
+ * and \p virtual_device fields of \p expr. The map's lifetime must not exceed that of
+ * \p expr itself.
+ */
+std::unordered_map<const ExprNode*, VirtualDevice> RecoverVirtualDeviceMap(const IRModule& mod,
+                                                                           const Expr& expr);
+
 }  // namespace transform
 }  // namespace relay
 }  // namespace tvm

--- a/tests/python/relay/test_pass_plan_devices.py
+++ b/tests/python/relay/test_pass_plan_devices.py
@@ -52,6 +52,8 @@ CTXT = tvm.transform.PassContext(config={"relay.fallback_device_type": DEFAULT.d
 core = tvm.IRModule()
 core.import_from_std("core.rly")
 
+recover_virtual_device_map = tvm._ffi.get_global_func("relay.transform.RecoverVirtualDeviceMap")
+
 
 def rewrite_and_assert(in_mod, expected_mod):
     """Manually run the pass and assert it's structurally equals to the expected."""
@@ -239,6 +241,70 @@ def test_left_add_on_cpu_via_copy():
         return np.subtract(np.add(a, b), np.add(c, d))
 
     exercise(input(), expected(), ref, rands((5, 7), 4))
+
+
+def test_left_add_on_cpu_via_copy_as_map():
+    metatable = {"VirtualDevice": [CPU, GPU]}
+
+    # As for test_left_add_on_cpu, but with an explicit device_copy.
+    def input():
+        return tvm.parser.parse(
+            """
+            #[version = "0.0.5"]
+            def @main(%a: Tensor[(5, 7), float32], %b: Tensor[(5, 7), float32],
+                      %c: Tensor[(5, 7), float32], %d: Tensor[(5, 7), float32]) {
+              %0 = add(%a, %b);
+              %1 = device_copy(%0, src_virtual_device=meta[VirtualDevice][0], dst_virtual_device=meta[VirtualDevice][1]);
+              %2 = add(%c, %d);
+              subtract(%1, %2)
+            }
+        """,
+            "from_string",
+            None,
+            metatable,
+        )
+
+    config = tvm.target.make_compilation_config(CTXT, TARGETS, HOST_TARGET)
+    actual_mod = relay.transform.InferType()(input())
+    actual_mod = relay.transform.PlanDevices(config)(actual_mod)
+    actual_mod = relay.transform.CapturePostDfsIndexInSpans()(actual_mod)
+
+    # Actual looks like:
+    #   def @main(%a {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], // index 0
+    #             %b {virtual_device=meta[VirtualDevice][0]}: Tensor[(5, 7), float32], // index 1
+    #             %c {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], // index 2
+    #             %d {virtual_device=meta[VirtualDevice][1]}: Tensor[(5, 7), float32], // index 3
+    #             virtual_device=meta[VirtualDevice][1]) {
+    #     %0 = add(%a, %b);                                                            // index 8
+    #     %1 = on_device(%0,
+    #                    virtual_device=meta[VirtualDevice][0],
+    #                    constrain_result=True);                                       // index 9
+    #     %2 = device_copy(%1,
+    #                      src_virtual_device=meta[VirtualDevice][0],
+    #                      dst_virtual_device=meta[VirtualDevice][1]);                 // index 10
+    #     %3 = add(%c, %d);                                                            // index 11
+    #     subtract(%2, %3)                                                             // index 12
+    #  }                                                                               // index 13
+    # (tested by test_left_add_on_cpu_via_copy above).
+
+    # Recover all the inferred virtual devices in map form
+    raw_map = recover_virtual_device_map(actual_mod, actual_mod["main"])
+    # Rewrite the map to be from post-dfs indexes to device types
+    map = {e.span.line: d.device_type for e, d in raw_map.items()}
+    # Now we can express the expected map
+    expected_map = {
+        0: CPU.device_type,  # %a
+        1: CPU.device_type,  # %b
+        2: GPU.device_type,  # %c
+        3: GPU.device_type,  # %d
+        8: CPU.device_type,  # first add
+        9: CPU.device_type,  # on_device
+        10: GPU.device_type,  # device_copy
+        11: GPU.device_type,  # second add
+        12: GPU.device_type,  # subtract
+        13: GPU.device_type,  # @main
+    }
+    assert map == expected_map
 
 
 def test_both_adds_on_cpu():


### PR DESCRIPTION
Device planning is halfway through the transition to using the virtual_device_
field on every expression node to capture device/target/etc info. In the meantime
it is necessary to derive from a 'device aware' visitor so as to track device
information. In Collage this is not feasible, so as a stop gap allow the map
from expression nodes to virtual devices to be reconstructed as a stand alone
map.

This code can be removed once expr->virtual_device() is the canonical representation.
