### PR TITLE
[Releay] Fix on_device call for explicit virtual_device

### DIFF
--- a/python/tvm/relay/op/annotation/annotation.py
+++ b/python/tvm/relay/op/annotation/annotation.py
@@ -28,6 +28,8 @@ def _make_virtual_device(device):
         return target.VirtualDevice(device)
     if isinstance(device, str):
         return target.VirtualDevice(_nd.device(device))
+    if isinstance(device, target.VirtualDevice):
+        return device
     raise ValueError("expecting a Device or device name, but received a %s" % (type(device)))
 
 


### PR DESCRIPTION
Previously it was expected that python on_device accept device that is wrong, by fact real on_device op expects virtual_device. If we want to pass memory scope, we have to create explicit virtual_device, but is declined by python wrapper of on_device. Fixed this case