### PR TITLE
Fix bug that disabled cuda integer dot product.

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -197,7 +197,7 @@ class Target(Object):
     def supports_integer_dot_product(self):
         if self.attrs.get("supports_integer_dot_product", []):
             return bool(self.attrs["supports_integer_dot_product"])
-        if self.kind == "cuda":
+        if self.kind.name == "cuda":
             sm_version = int(self.arch.split("_")[1])
             if sm_version >= 61:
                 return True


### PR DESCRIPTION
PR #11389 introduced a bug that effectively disabled cuda integer dot products by comparing `self.kind` (which is type Target) to the string `"cuda"`. This extremely small PR fixes the check by instead using `self.kind.name`. This will lead to significant performance improvements for int8 models.
