### PR TITLE
Add member object accessors to With<>

### DIFF
--- a/include/tvm/support/with.h
+++ b/include/tvm/support/with.h
@@ -67,6 +67,14 @@ class With {
   /*! \brief destructor, leaves the scope of the context. */
   ~With() DMLC_THROW_EXCEPTION { ctx_.ExitWithScope(); }
 
+  ContextType* get() { return &ctx_; }
+  const ContextType* get() const { return &ctx_; }
+
+  ContextType* operator->() { return get(); }
+  const ContextType* operator->() const { return get(); }
+  ContextType& operator*() { return *get(); }
+  const ContextType* operator*() const { return *get(); }
+
  private:
   /*! \brief internal context type. */
   ContextType ctx_;


### PR DESCRIPTION
Currently the With<> template constructs an object, but gives no access to it, so it's only applicable to situations where we rely on the side-effects of creating the object.