### PR TITLE
[DNNL] Enable conv family fused with gelu

### DIFF
--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -191,6 +191,7 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     std::regex sigmoid_pat(".*_sigmoid.*");
     std::regex clip_pat(".*_clip.*");
     std::regex gelu_pat(".*_gelu.*");
+    std::regex swish_pat(".*_swish.*");
 
     // Parsing post-ops.
     dnnl::post_ops ops;
@@ -206,11 +207,10 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
       ops.append_eltwise(1.f, dnnl::algorithm::eltwise_clip, a_min, a_max);
     }
     if (std::regex_match(op_name, sigmoid_pat)) {
-      if (op_name.find("_sigmoid_mul") != std::string::npos) {
-        ops.append_eltwise(1.f, dnnl::algorithm::eltwise_swish, 1.f, 1.f);
-      } else {
-        ops.append_eltwise(1.f, dnnl::algorithm::eltwise_logistic, 0.f, 0.f);
-      }
+      ops.append_eltwise(1.f, dnnl::algorithm::eltwise_logistic, 0.f, 0.f);
+    }
+    if (std::regex_match(op_name, swish_pat)) {
+      ops.append_eltwise(1.f, dnnl::algorithm::eltwise_swish, 1.f, 1.f);
     }
     if (std::regex_match(op_name, gelu_pat)) {
       ops.append_eltwise(1.f, dnnl::algorithm::eltwise_gelu_erf, 0.f, 0.f);

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -249,6 +249,9 @@ def add_activation(activation, out, dic, param_lst):
         sig_out = relay.sigmoid(out)
         out = relay.multiply(out, sig_out)
         return out, dic, param_lst
+    elif activation == "gelu":
+        out = gelu_helper(out)
+        return out, dic, param_lst
     else:
         return out, dic, param_lst
 
@@ -762,7 +765,7 @@ def test_conv2d_weights_const(run_module, dtype="float32"):
 def test_conv2d_pattern(run_module, dtype="float32"):
     x_shape = (1, 32, 8, 8)
     k_shape = (16, 32, 3, 3)
-    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish"]
+    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish", "gelu"]
     for a in activation_lst:
         conv2d, dic, param_lst = get_conv2d(x_shape, k_shape, activation=a, dtype=dtype)
         conv2d = tvm.IRModule.from_expr(conv2d)
@@ -804,7 +807,7 @@ def test_conv2d_transpose(run_module, dtype="float32"):
 
 
 def test_conv2d_transpose_pattern(run_module, dtype="float32"):
-    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish"]
+    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish", "gelu"]
     for a in activation_lst:
         conv2d, dic, param_lst = get_conv2d_transpose(activation=a, dtype=dtype)
         conv2d = tvm.IRModule.from_expr(conv2d)
@@ -837,7 +840,7 @@ def test_conv3d(run_module, dtype="float32"):
 
 
 def test_conv3d_pattern(run_module, dtype="float32"):
-    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish"]
+    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish", "gelu"]
     for a in activation_lst:
         conv3d, dic, param_lst = get_conv3d(activation=a, dtype=dtype)
         conv3d = tvm.IRModule.from_expr(conv3d)
@@ -870,7 +873,7 @@ def test_conv3d_transpose(run_module, dtype="float32"):
 
 
 def test_conv3d_transpose_pattern(run_module, dtype="float32"):
-    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish"]
+    activation_lst = [None, "relu", "tanh", "sigmoid", "clip", "swish", "gelu"]
     for a in activation_lst:
         conv3d, dic, param_lst = get_conv3d_transpose(activation=a, dtype=dtype)
         conv3d = tvm.IRModule.from_expr(conv3d)


### PR DESCRIPTION
This patch is to enable convolution family (conv2d, conv3d, conv2d_transpose, conv3d_transpose) fused with gelu activation. Some unittests are also included.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
