### PR TITLE
[microTVM] Arduino retry on flash failure

### DIFF
--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -15,23 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import collections
-import functools
 import json
 import logging
-import os
 import os.path
 import pathlib
 import re
-import shlex
 import shutil
 import subprocess
-import sys
 import tarfile
 import tempfile
 import time
 from string import Template
-import re
 
 from packaging import version
 
@@ -202,7 +196,7 @@ class Handler(server.ProjectAPIHandler):
             # Copy C files from model. The filesnames and quantity
             # depend on the target string, so we just copy all c files
             source_dir = mlf_unpacking_dir / "codegen" / "host" / "src"
-            for file in source_dir.rglob(f"*.c"):
+            for file in source_dir.rglob("*.c"):
                 shutil.copy(file, model_dir)
 
             # Return metadata.json for use in templating
@@ -243,7 +237,7 @@ class Handler(server.ProjectAPIHandler):
             for filename in source_dir.rglob(f"*.{ext}"):
                 filename.rename(filename.with_suffix(".cpp"))
 
-        for filename in source_dir.rglob(f"*.inc"):
+        for filename in source_dir.rglob("*.inc"):
             filename.rename(filename.with_suffix(".h"))
 
     def _convert_includes(self, project_dir, source_dir):
@@ -265,7 +259,7 @@ class Handler(server.ProjectAPIHandler):
                 with filename.open("rb") as src_file:
                     lines = src_file.readlines()
                     with filename.open("wb") as dst_file:
-                        for i, line in enumerate(lines):
+                        for line in lines:
                             line_str = str(line, "utf-8")
                             # Check if line has an include
                             result = re.search(r"#include\s*[<\"]([^>]*)[>\"]", line_str)
@@ -491,7 +485,7 @@ class Handler(server.ProjectAPIHandler):
         if options.get("verbose"):
             upload_cmd.append("--verbose")
 
-        for i in range(self.FLASH_MAX_RETRIES):
+        for _ in range(self.FLASH_MAX_RETRIES):
             try:
                 subprocess.run(upload_cmd, check=True, timeout=self.FLASH_TIMEOUT_SEC)
                 break
@@ -505,7 +499,9 @@ class Handler(server.ProjectAPIHandler):
                 )
 
         else:
-            raise RuntimeError("Unable to flash Arduino board after {self.FLASH_MAX_RETRIES} attempts")
+            raise RuntimeError(
+                "Unable to flash Arduino board after {self.FLASH_MAX_RETRIES} attempts"
+            )
 
     def open_transport(self, options):
         import serial
@@ -519,7 +515,7 @@ class Handler(server.ProjectAPIHandler):
 
         # It takes a moment for the Arduino code to finish initializing
         # and start communicating over serial
-        for attempts in range(10):
+        for _ in range(10):
             if any(serial.tools.list_ports.grep(port)):
                 break
             time.sleep(0.5)


### PR DESCRIPTION
Previously, the `flash` function would sometimes lock up indefinitely without failing, stalling for hours or more. This pull request changes it to have a 60-second timeout (more than enough time to upload a sketch), and adds the ability to retry the command if it fails.

This pull request also adds a unit test for this functionality, and also makes a few changes to `microtvm_api_server.py` to better comply with `pylint`. 

cc @alanmacd @gromero @mehrdadh