### PR TITLE
[microTVM] Zephyr: Add support for FVP

### DIFF
--- a/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
+++ b/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(ENV{QEMU_BIN_PATH} "${CMAKE_SOURCE_DIR}/qemu-hack")
 
-set(QEMU_PIPE "\${QEMU_PIPE}")  # QEMU_PIPE is set by the calling TVM instance.
+set(QEMU_PIPE <QEMU_PIPE> CACHE PATH "Path to QEMU pipe")
 
 <CMAKE_ARGS>
 

--- a/apps/microtvm/zephyr/template_project/fvp-hack/FVP_Corstone_SSE-300_Ethos-U55
+++ b/apps/microtvm/zephyr/template_project/fvp-hack/FVP_Corstone_SSE-300_Ethos-U55
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -x
+
+ARGS=( "$(basename $0)" )
+
+if [ "${FVP_BIN_PATH}"  != "" ]; then
+    ARGS=( ${FVP_BIN_PATH}/${ARGS[0]} )
+fi
+
+ARGS=( "${ARGS[@]}"
+    --iris-server
+    --print-port-number
+    -C cpu0.semihosting-enable=1
+    -C mps3_board.telnetterminal0.mode=raw
+    -C mps3_board.telnetterminal1.mode=raw
+    -C mps3_board.telnetterminal2.mode=raw
+    -C mps3_board.telnetterminal0.start_telnet=0
+    -C mps3_board.telnetterminal1.start_telnet=0
+    -C mps3_board.telnetterminal2.start_telnet=0
+    )
+
+while [ "$#" -gt 0 ]; do
+    ARGS=( "${ARGS[@]}" "$1" )
+    shift
+done
+
+"${ARGS[@]}"

--- a/apps/microtvm/zephyr/template_project/src/host_driven/fvp/semihost.c
+++ b/apps/microtvm/zephyr/template_project/src/host_driven/fvp/semihost.c
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "semihost.h"
+
+int32_t stdout_fd;
+int32_t stdin_fd;
+
+uint32_t semihost_cmd(uint32_t opcode, void* arg) {
+  uint32_t ret_val;
+  __asm__ volatile(
+      "mov r0, %[opcode]\n\t"
+      "mov r1, %[arg]\n\t"
+      "bkpt #0xab\n\r"
+      "mov %[ret_val], r0"
+      : [ ret_val ] "=r"(ret_val)
+      : [ opcode ] "r"(opcode), [ arg ] "r"(arg)
+      : "r1", "memory");
+
+  return ret_val;
+}
+
+int32_t stdout_fd;
+int32_t stdin_fd;
+
+void init_semihosting() {
+  // https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#sys-open-0x01
+  struct {
+    const char* file_name;
+    uint32_t mode;
+    uint32_t file_name_len;
+  } params;
+  params.file_name = ":tt";
+  params.mode = 5;  // "wb"
+  params.file_name_len = 3;
+  stdout_fd = semihost_cmd(0x01, &params);
+
+  params.mode = 0;
+  stdin_fd = semihost_cmd(0x01, &params);
+}
+
+ssize_t semihost_read(uint8_t* data, size_t size) {
+  struct {
+    uint32_t file_handle;
+    const uint8_t* data;
+    uint32_t size;
+  } read_req;
+  read_req.file_handle = stdin_fd;
+  read_req.data = data;
+  read_req.size = size;
+  uint32_t ret_val = semihost_cmd(0x06, &read_req);
+  return size - ret_val;
+}
+
+ssize_t semihost_write(void* unused_context, const uint8_t* data, size_t size) {
+  struct {
+    uint32_t file_handle;
+    const uint8_t* data;
+    uint32_t size;
+  } write_req;
+  write_req.file_handle = stdout_fd;
+  write_req.data = data;
+  write_req.size = size;
+  uint32_t ret_val = semihost_cmd(0x05, &write_req);
+  return size - ret_val;
+}

--- a/apps/microtvm/zephyr/template_project/src/host_driven/fvp/semihost.h
+++ b/apps/microtvm/zephyr/template_project/src/host_driven/fvp/semihost.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TVM_APPS_MICROTVM_ZEPHYR_HOST_DRIVEN_SEMIHOST_H_
+#define TVM_APPS_MICROTVM_ZEPHYR_HOST_DRIVEN_SEMIHOST_H_
+
+#include <kernel.h>
+#include <unistd.h>
+#include <zephyr.h>
+
+void init_semihosting();
+
+ssize_t semihost_read(uint8_t* data, size_t size);
+
+ssize_t semihost_write(void* unused_context, const uint8_t* data, size_t size);
+
+#endif /* TVM_APPS_MICROTVM_ZEPHYR_HOST_DRIVEN_SEMIHOST_H_ */

--- a/cmake/modules/Zephyr.cmake
+++ b/cmake/modules/Zephyr.cmake
@@ -26,6 +26,8 @@ if(USE_MICRO)
       "apps/microtvm/zephyr/template_project/src/aot_standalone_demo *.c -> zephyr/src/aot_standalone_demo"
       "apps/microtvm/zephyr/template_project/src/aot_standalone_demo *.h -> zephyr/src/aot_standalone_demo"
       "apps/microtvm/zephyr/template_project/src/host_driven *.c -> zephyr/src/host_driven"
+      "apps/microtvm/zephyr/template_project/src/host_driven *.h -> zephyr/src/host_driven"
+      "apps/microtvm/zephyr/template_project/fvp-hack * -> zephyr/fvp-hack"
       "apps/microtvm/zephyr/template_project/qemu-hack * -> zephyr/qemu-hack"
       "apps/microtvm/zephyr/template_project/crt_config *.h -> zephyr/crt_config"
     )

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -147,6 +147,7 @@ ALLOW_SPECIFIC_FILE = {
     "apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-i386",
     "apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-riscv32",
     "apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-riscv64",
+    "apps/microtvm/zephyr/template_project/fvp-hack/FVP_Corstone_SSE-300_Ethos-U55",
     # microTVM Virtual Machines
     "apps/microtvm/poetry.lock",
     "apps/microtvm/reference-vm/Vagrantfile",
@@ -236,7 +237,7 @@ def main():
     if error_list:
         report = "------File type check report----\n"
         report += "\n".join(error_list)
-        report += "\nFound %d files that are now allowed\n" % len(error_list)
+        report += "\nFound %d files that are not allowed\n" % len(error_list)
         report += (
             "We do not check in binary files into the repo.\n"
             "If necessary, please discuss with committers and"

--- a/tests/micro/zephyr/test_zephyr.py
+++ b/tests/micro/zephyr/test_zephyr.py
@@ -40,7 +40,7 @@ _LOG = logging.getLogger(__name__)
 
 
 def _make_sess_from_op(
-    temp_dir, model, zephyr_board, west_cmd, op_name, sched, arg_bufs, build_config
+    temp_dir, model, zephyr_board, west_cmd, op_name, sched, arg_bufs, build_config, use_fvp
 ):
     runtime = Runtime("crt", {"system-lib": True})
     target = tvm.target.target.micro(model)
@@ -48,10 +48,10 @@ def _make_sess_from_op(
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         mod = tvm.build(sched, arg_bufs, target=target, runtime=runtime, name=op_name)
 
-    return _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config)
+    return _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config, use_fvp)
 
 
-def _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config):
+def _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config, use_fvp):
     config_main_stack_size = None
     if test_utils.qemu_boards(zephyr_board):
         config_main_stack_size = 1536
@@ -61,6 +61,8 @@ def _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config):
         "west_cmd": west_cmd,
         "verbose": bool(build_config.get("debug")),
         "zephyr_board": zephyr_board,
+        "arm_fvp_path": "/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55",
+        "use_fvp": bool(use_fvp),
     }
     if config_main_stack_size is not None:
         project_options["config_main_stack_size"] = config_main_stack_size
@@ -76,20 +78,21 @@ def _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config):
     return tvm.micro.Session(project.transport())
 
 
-def _make_add_sess(temp_dir, model, zephyr_board, west_cmd, build_config, dtype="int8"):
+def _make_add_sess(temp_dir, model, zephyr_board, west_cmd, build_config, use_fvp, dtype="int8"):
     A = tvm.te.placeholder((2,), dtype=dtype)
     B = tvm.te.placeholder((1,), dtype=dtype)
     C = tvm.te.compute(A.shape, lambda i: A[i] + B[0], name="C")
     sched = tvm.te.create_schedule(C.op)
     return _make_sess_from_op(
-        temp_dir, model, zephyr_board, west_cmd, "add", sched, [A, B, C], build_config
+        temp_dir, model, zephyr_board, west_cmd, "add", sched, [A, B, C], build_config, use_fvp
     )
 
 
 # The same test code can be executed on both the QEMU simulation and on real hardware.
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_add_uint(workspace_dir, board, west_cmd, microtvm_debug):
+@pytest.mark.xfail_on_fvp()
+def test_add_uint(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """Test compiling the on-device runtime."""
 
     model = test_utils.ZEPHYR_BOARDS[board]
@@ -108,14 +111,15 @@ def test_add_uint(workspace_dir, board, west_cmd, microtvm_debug):
         system_lib.get_function("add")(A_data, B_data, C_data)
         assert (C_data.numpy() == np.array([6, 7])).all()
 
-    with _make_add_sess(workspace_dir, model, board, west_cmd, build_config) as sess:
+    with _make_add_sess(workspace_dir, model, board, west_cmd, build_config, use_fvp) as sess:
         test_basic_add(sess)
 
 
 # The same test code can be executed on both the QEMU simulation and on real hardware.
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_add_float(workspace_dir, board, west_cmd, microtvm_debug):
+@pytest.mark.xfail_on_fvp()
+def test_add_float(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """Test compiling the on-device runtime."""
     model = test_utils.ZEPHYR_BOARDS[board]
     if not test_utils.has_fpu(board):
@@ -137,14 +141,15 @@ def test_add_float(workspace_dir, board, west_cmd, microtvm_debug):
         assert (C_data.numpy() == np.array([7, 8])).all()
 
     with _make_add_sess(
-        workspace_dir, model, board, west_cmd, build_config, dtype="float32"
+        workspace_dir, model, board, west_cmd, build_config, use_fvp, dtype="float32"
     ) as sess:
         test_basic_add(sess)
 
 
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_platform_timer(workspace_dir, board, west_cmd, microtvm_debug):
+@pytest.mark.xfail_on_fvp()
+def test_platform_timer(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """Test compiling the on-device runtime."""
 
     model = test_utils.ZEPHYR_BOARDS[board]
@@ -168,13 +173,14 @@ def test_platform_timer(workspace_dir, board, west_cmd, microtvm_debug):
         assert result.mean > 0
         assert len(result.results) == 3
 
-    with _make_add_sess(workspace_dir, model, board, west_cmd, build_config) as sess:
+    with _make_add_sess(workspace_dir, model, board, west_cmd, build_config, use_fvp) as sess:
         test_basic_add(sess)
 
 
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_relay(workspace_dir, board, west_cmd, microtvm_debug):
+@pytest.mark.xfail_on_fvp()
+def test_relay(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """Testing a simple relay graph"""
     model = test_utils.ZEPHYR_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -193,7 +199,7 @@ def test_relay(workspace_dir, board, west_cmd, microtvm_debug):
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         mod = tvm.relay.build(ir_mod, target=target, runtime=runtime)
 
-    with _make_session(workspace_dir, board, west_cmd, mod, build_config) as session:
+    with _make_session(workspace_dir, board, west_cmd, mod, build_config, use_fvp) as session:
         graph_mod = tvm.micro.create_local_graph_executor(
             mod.get_graph_json(), session.get_system_lib(), session.device
         )
@@ -207,7 +213,8 @@ def test_relay(workspace_dir, board, west_cmd, microtvm_debug):
 
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_onnx(workspace_dir, board, west_cmd, microtvm_debug):
+@pytest.mark.xfail_on_fvp()
+def test_onnx(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """Testing a simple ONNX model."""
     model = test_utils.ZEPHYR_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -239,7 +246,7 @@ def test_onnx(workspace_dir, board, west_cmd, microtvm_debug):
         lowered = relay.build(relay_mod, target, params=params, executor=executor, runtime=runtime)
         graph = lowered.get_graph_json()
 
-    with _make_session(workspace_dir, board, west_cmd, lowered, build_config) as session:
+    with _make_session(workspace_dir, board, west_cmd, lowered, build_config, use_fvp) as session:
         graph_mod = tvm.micro.create_local_graph_executor(
             graph, session.get_system_lib(), session.device
         )
@@ -258,7 +265,16 @@ def test_onnx(workspace_dir, board, west_cmd, microtvm_debug):
 
 
 def check_result(
-    temp_dir, relay_mod, model, zephyr_board, west_cmd, map_inputs, out_shape, result, build_config
+    temp_dir,
+    relay_mod,
+    model,
+    zephyr_board,
+    west_cmd,
+    map_inputs,
+    out_shape,
+    result,
+    build_config,
+    use_fvp,
 ):
     """Helper function to verify results"""
     TOL = 1e-5
@@ -267,7 +283,7 @@ def check_result(
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         mod = tvm.relay.build(relay_mod, target=target, runtime=runtime)
 
-    with _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config) as session:
+    with _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config, use_fvp) as session:
         rt_mod = tvm.micro.create_local_graph_executor(
             mod.get_graph_json(), session.get_system_lib(), session.device
         )
@@ -288,7 +304,8 @@ def check_result(
 
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_byoc_microtvm(workspace_dir, board, west_cmd, microtvm_debug):
+@pytest.mark.xfail_on_fvp()
+def test_byoc_microtvm(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """This is a simple test case to check BYOC capabilities of microTVM"""
     model = test_utils.ZEPHYR_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -347,15 +364,18 @@ def test_byoc_microtvm(workspace_dir, board, west_cmd, microtvm_debug):
         zephyr_board=board,
         west_cmd=west_cmd,
         build_config=build_config,
+        use_fvp=use_fvp,
     )
 
 
-def _make_add_sess_with_shape(temp_dir, model, zephyr_board, west_cmd, shape, build_config):
+def _make_add_sess_with_shape(
+    temp_dir, model, zephyr_board, west_cmd, shape, build_config, use_fvp
+):
     A = tvm.te.placeholder(shape, dtype="int8")
     C = tvm.te.compute(A.shape, lambda i: A[i] + A[i], name="C")
     sched = tvm.te.create_schedule(C.op)
     return _make_sess_from_op(
-        temp_dir, model, zephyr_board, west_cmd, "add", sched, [A, C], build_config
+        temp_dir, model, zephyr_board, west_cmd, "add", sched, [A, C], build_config, use_fvp
     )
 
 
@@ -369,7 +389,8 @@ def _make_add_sess_with_shape(temp_dir, model, zephyr_board, west_cmd, shape, bu
 )
 @tvm.testing.requires_micro
 @pytest.mark.skip_boards(["mps2_an521"])
-def test_rpc_large_array(workspace_dir, board, west_cmd, microtvm_debug, shape):
+@pytest.mark.xfail_on_fvp()
+def test_rpc_large_array(workspace_dir, board, west_cmd, microtvm_debug, shape, use_fvp):
     """Test large RPC array transfer."""
     model = test_utils.ZEPHYR_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -384,14 +405,14 @@ def test_rpc_large_array(workspace_dir, board, west_cmd, microtvm_debug, shape):
         assert (C_data.numpy() == np.zeros(shape)).all()
 
     with _make_add_sess_with_shape(
-        workspace_dir, model, board, west_cmd, shape, build_config
+        workspace_dir, model, board, west_cmd, shape, build_config, use_fvp
     ) as sess:
         test_tensors(sess)
 
 
 @pytest.mark.xfail(strict=False, reason="See https://github.com/apache/tvm/issues/10297")
 @tvm.testing.requires_micro
-def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug):
+def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug, use_fvp):
     """Test AutoTune for microTVM Zephyr"""
     if board != "qemu_x86":
         pytest.xfail(f"Autotune fails on {board}.")
@@ -440,6 +461,7 @@ def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug):
         "west_cmd": west_cmd,
         "verbose": 1,
         "project_type": "host_driven",
+        "use_fvp": bool(use_fvp),
     }
     if config_main_stack_size is not None:
         project_options["config_main_stack_size"] = config_main_stack_size
@@ -489,7 +511,7 @@ def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug):
         lowered = tvm.relay.build(mod, target=target, runtime=runtime, params=params)
 
     temp_dir = utils.tempdir()
-    with _make_session(temp_dir, board, west_cmd, lowered, build_config) as session:
+    with _make_session(temp_dir, board, west_cmd, lowered, build_config, use_fvp) as session:
         graph_mod = tvm.micro.create_local_graph_executor(
             lowered.get_graph_json(), session.get_system_lib(), session.device
         )
@@ -504,7 +526,7 @@ def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug):
             lowered_tuned = tvm.relay.build(mod, target=target, runtime=runtime, params=params)
 
     temp_dir = utils.tempdir()
-    with _make_session(temp_dir, board, west_cmd, lowered_tuned, build_config) as session:
+    with _make_session(temp_dir, board, west_cmd, lowered_tuned, build_config, use_fvp) as session:
         graph_mod = tvm.micro.create_local_graph_executor(
             lowered_tuned.get_graph_json(), session.get_system_lib(), session.device
         )
@@ -517,7 +539,9 @@ def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug):
 
 
 @tvm.testing.requires_micro
-def test_schedule_build_with_cmsis_dependency(workspace_dir, board, west_cmd, microtvm_debug):
+def test_schedule_build_with_cmsis_dependency(
+    workspace_dir, board, west_cmd, microtvm_debug, use_fvp
+):
     """Test Relay schedule with CMSIS dependency. This test shows if microTVM Auto tuning
     with Zephyr breaks if CMSIS dependency was required for a schedule.
     """
@@ -557,6 +581,7 @@ def test_schedule_build_with_cmsis_dependency(workspace_dir, board, west_cmd, mi
         "verbose": bool(build_config.get("debug")),
         "zephyr_board": board,
         "cmsis_path": os.getenv("CMSIS_PATH"),
+        "use_fvp": bool(use_fvp),
     }
 
     project_dir = workspace_dir / "project"

--- a/tests/micro/zephyr/test_zephyr_aot_exec_standalone.py
+++ b/tests/micro/zephyr/test_zephyr_aot_exec_standalone.py
@@ -38,7 +38,7 @@ import test_utils
 
 
 @tvm.testing.requires_micro
-@pytest.mark.skip_boards(["mps2_an521"])
+@pytest.mark.skip_boards(["mps2_an521", "mps3_an547"])
 def test_tflite(workspace_dir, board, west_cmd, microtvm_debug):
     """Testing a TFLite model."""
     model = test_utils.ZEPHYR_BOARDS[board]
@@ -94,7 +94,7 @@ def test_tflite(workspace_dir, board, west_cmd, microtvm_debug):
 
 
 @tvm.testing.requires_micro
-@pytest.mark.skip_boards(["mps2_an521"])
+@pytest.mark.skip_boards(["mps2_an521", "mps3_an547"])
 def test_qemu_make_fail(workspace_dir, board, west_cmd, microtvm_debug):
     """Testing QEMU make fail."""
     if board not in ["qemu_x86", "mps2_an521", "mps3_an547"]:
@@ -131,9 +131,7 @@ def test_qemu_make_fail(workspace_dir, board, west_cmd, microtvm_debug):
         load_cmsis=False,
     )
 
-    file_path = (
-        pathlib.Path(project_dir) / "build" / "zephyr" / "CMakeFiles" / "run.dir" / "build.make"
-    )
+    file_path = pathlib.Path(project_dir) / "build" / "build.ninja"
     assert file_path.is_file(), f"[{file_path}] does not exist."
 
     # Remove a file to create make failure.

--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -28,6 +28,7 @@ run_pytest ctypes python-microtvm-zephyr-qemu_x86 tests/micro/zephyr --board=qem
 run_pytest ctypes python-microtvm-zephyr-qemu_riscv32 tests/micro/zephyr --board=qemu_riscv32
 run_pytest ctypes python-microtvm-zephyr-qemu_riscv64 tests/micro/zephyr --board=qemu_riscv64
 run_pytest ctypes python-microtvm-zephyr-mps2_an521 tests/micro/zephyr --board=mps2_an521
+run_pytest ctypes python-microtvm-zephyr-mps3_an547 tests/micro/zephyr --board=mps3_an547 --use-fvp
 
 # Arduino
 run_pytest ctypes python-microtvm-arduino apps/microtvm/arduino/template_project/tests


### PR DESCRIPTION
This PR adds corstone300 FVP to the platforms supported by the zephyr. We use the Iris debugger to communicate with the emulator via semihosting, due to the FVP serial port's faulty behavior (It might drop a byte in messages longer than 1 byte).
This PR also changes the generated micro-projects build system from make to ninja.

cc @alanmacd @gromero @mehrdadh