### PR TITLE
[Meta Schedule][XGBoost] Update the custom callback function of xgboost in meta schedule

### DIFF
--- a/python/tvm/meta_schedule/cost_model/__init__.py
+++ b/python/tvm/meta_schedule/cost_model/__init__.py
@@ -19,4 +19,4 @@ The tvm.meta_schedule.cost_model package.
 """
 from .cost_model import CostModel, PyCostModel
 from .random_model import RandomModel
-from .xgb_model import XGBModel
+from .xgb_model import XGBModel, XGBoostCustomCallback, PackSum

--- a/python/tvm/meta_schedule/cost_model/__init__.py
+++ b/python/tvm/meta_schedule/cost_model/__init__.py
@@ -19,4 +19,4 @@ The tvm.meta_schedule.cost_model package.
 """
 from .cost_model import CostModel, PyCostModel
 from .random_model import RandomModel
-from .xgb_model import XGBModel, XGBoostCustomCallback, PackSum
+from .xgb_model import XGBModel

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -688,7 +688,9 @@ class XGBoostCustomCallback(TrainingCallback):
             booster.set_attr(best_iteration=str(self.state["best_iteration"]))
             booster.set_attr(best_score=str(self.state["best_score"]))
 
-    def after_iteration(self, model: "xgb.Booster", epoch: int, evals_log: Dict):
+    def after_iteration(
+        self, model: "xgb.Booster", epoch: int, evals_log: Dict
+    ):  # pylint: disable = unused-argument
         """Internal function for after_iteration"""
         # pylint:disable = import-outside-toplevel
         try:

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -645,36 +645,6 @@ class XGBModel(PyCostModel):
         return eval_result
 
 
-def custom_callback(
-    early_stopping_rounds: int,
-    verbose_eval: int,
-    fevals: List[Callable],
-    evals: List[Tuple["xgb.DMatrix", str]],
-    focused_metric: str = "tr-p-rmse",
-):
-    """Callback function for xgboost to support multiple custom evaluation functions"""
-    sort_key = make_metric_sorter(focused_metric=focused_metric)
-
-    state: Dict[str, Any] = {}
-
-    def init(env: "xgb.core.CallbackEnv"):
-        """Internal function"""
-        booster: "xgb.Booster" = env.model
-
-        state["best_iteration"] = 0
-        state["best_score"] = float("inf")
-        if booster is None:
-            assert env.cvfolds is not None
-            return
-        if booster.attr("best_score") is not None:
-            state["best_score"] = float(booster.attr("best_score"))
-            state["best_iteration"] = int(booster.attr("best_iteration"))
-            state["best_msg"] = booster.attr("best_msg")
-        else:
-            booster.set_attr(best_iteration=str(state["best_iteration"]))
-            booster.set_attr(best_score=str(state["best_score"]))
-
-
 class XGBoostCustomCallback(TrainingCallback):
     """Custom callback class for xgboost to support multiple custom evaluation functions"""
 

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -592,19 +592,20 @@ class XGBModel(PyCostModel):
         def avg_peak_score(ys_pred: np.ndarray, d_train: "xgb.DMatrix"):  # type: ignore # pylint: disable = unused-argument
             return self.d_train.average_peak_score(ys_pred, self.average_peak_n)
 
-        xgb_custom_callback = XGBoostCustomCallback(
-            early_stopping_rounds=self.early_stopping_rounds,
-            verbose_eval=self.verbose_eval,
-            fevals=[rmse, avg_peak_score],
-            evals=[(self.d_train.dmatrix, "tr")],
-            cvfolds=None,
-        )
         self.booster = xgb.train(
             self.config.to_dict(),
             self.d_train.dmatrix,
             num_boost_round=10000,
             obj=obj,
-            callbacks=[xgb_custom_callback],
+            callbacks=[
+                XGBoostCustomCallback(
+                    early_stopping_rounds=self.early_stopping_rounds,
+                    verbose_eval=self.verbose_eval,
+                    fevals=[rmse, avg_peak_score],
+                    evals=[(self.d_train.dmatrix, "tr")],
+                    cvfolds=None,
+                )
+            ],
         )
 
         del self.d_train

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -36,7 +36,8 @@ from ..utils import cpu_count, derived_object, shash2hex
 from .metric import max_curve
 
 
-def optional_xgboost_callback(XGBoostCustomCallback):
+def optional_xgboost_callback(cls):
+    """Decorator for importing TraningCallback from xgboost"""
     # pylint:disable = import-outside-toplevel
     try:
         from xgboost.callback import TrainingCallback  # type: ignore
@@ -46,7 +47,7 @@ def optional_xgboost_callback(XGBoostCustomCallback):
         class TrainingCallback:  # type: ignore
             pass
 
-    class OptXGBoostCustomCallback(XGBoostCustomCallback, TrainingCallback):  # type: ignore
+    class OptXGBoostCustomCallback(cls, TrainingCallback):  # type: ignore
         pass
 
     return OptXGBoostCustomCallback

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -724,6 +724,8 @@ class XGBoostCustomCallback:
             from xgboost.training import aggcv  # type: ignore
         except ImportError:
             from xgboost.callback import _aggcv as aggcv  # type: ignore
+        
+        # pylint:enable = import-outside-toplevel
         if not self.state:
             self.init(model)
         booster: xgb.Booster = model

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -774,7 +774,7 @@ class XGBoostCallback(TrainingCallback):
     """Base class for XGBoost callbacks."""
 
     def __call__(self, env: "xgb.core.CallbackEnv"):
-        """Compatibility with xgboost<1.3"""
+        # Compatibility with xgboost < 1.3
         return self.after_iteration(env.model, env.iteration, env.evaluation_result_list)
 
     def after_iteration(self, model: "xgb.Booster", epoch: int, evals_log: Dict):
@@ -805,6 +805,7 @@ class XGBoostCustomCallback(XGBoostCallback):
             self.aggregated_cv = None
 
     def init(self, model: "xgb.Booster"):
+        """Internal function for intialization"""
         booster: "xgb.Booster" = model
         self.state["best_iteration"] = 0
         self.state["best_score"] = float("inf")
@@ -820,10 +821,12 @@ class XGBoostCustomCallback(XGBoostCallback):
             booster.set_attr(best_score=str(self.state["best_score"]))
 
     def after_iteration(self, model: "xgb.Booster", epoch: int, evals_log: Dict):
+        """Internal function for after_iteration"""
+        # pylint:disable = import-outside-toplevel
         try:
             from xgboost.callback import _fmt_metric  # type: ignore
         except ImportError:
-            """Compatibility with xgboost>=1.6"""
+            # Compatibility with xgboost >= 1.6
 
             def _fmt_metric(value, show_stdv=True):
                 if len(value) == 2:
@@ -834,6 +837,7 @@ class XGBoostCustomCallback(XGBoostCallback):
                     return f"{value[0]}:{value[1]:.5f}"
                 raise ValueError("wrong metric value", value)
 
+        import xgboost as xgb
         from xgboost import rabit  # type: ignore
 
         try:

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -724,7 +724,7 @@ class XGBoostCustomCallback:
             from xgboost.training import aggcv  # type: ignore
         except ImportError:
             from xgboost.callback import _aggcv as aggcv  # type: ignore
-        
+
         # pylint:enable = import-outside-toplevel
         if not self.state:
             self.init(model)

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -40,6 +40,7 @@ def optional_xgboost_callback(XGBoostCustomCallback):
     # pylint:disable = import-outside-toplevel
     try:
         from xgboost.callback import TrainingCallback  # type: ignore
+    # pylint:enable = import-outside-toplevel
     except ImportError:
 
         class TrainingCallback:  # type: ignore

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -46,7 +46,7 @@ def optional_xgboost_callback(XGBoostCustomCallback):
         class TrainingCallback:  # type: ignore
             pass
 
-    class OptXGBoostCustomCallback(XGBoostCustomCallback, TrainingCallback):
+    class OptXGBoostCustomCallback(XGBoostCustomCallback, TrainingCallback):  # type: ignore
         pass
 
     return OptXGBoostCustomCallback

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -39,7 +39,7 @@ try:
     from xgboost.callback import TrainingCallback  # type: ignore
 except ImportError:
 
-    class TrainingCallback:
+    class TrainingCallback:  # type: ignore
         pass
 
 

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -22,7 +22,7 @@ import os
 import tempfile
 from collections import OrderedDict
 from itertools import chain as itertools_chain
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np  # type: ignore
 
@@ -36,7 +36,7 @@ from ..utils import cpu_count, derived_object, shash2hex
 from .metric import max_curve
 
 try:
-    from xgboost.callback import TrainingCallback
+    from xgboost.callback import TrainingCallback  # type: ignore
 except ImportError:
 
     class TrainingCallback:
@@ -791,7 +791,7 @@ class XGBoostCustomCallback(XGBoostCallback):
         fevals: List[Callable],
         evals: List[Tuple["xgb.DMatrix", str]],
         focused_metric: str = "tr-p-rmse",
-        cvfolds: Sequence["xgb.training.CVPack"] = None,
+        cvfolds: List["xgb.training.CVPack"] = None,
     ):
         self.early_stopping_rounds = early_stopping_rounds
         self.verbose_eval = verbose_eval

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -36,13 +36,22 @@ from ..utils import cpu_count, derived_object, shash2hex
 from .metric import max_curve
 
 
-if TYPE_CHECKING:
+def optional_xgboost_callback(XGBoostCustomCallback):
+    # pylint:disable = import-outside-toplevel
     try:
         from xgboost.callback import TrainingCallback  # type: ignore
     except ImportError:
 
         class TrainingCallback:  # type: ignore
             pass
+
+    class OptXGBoostCustomCallback(XGBoostCustomCallback, TrainingCallback):
+        pass
+
+    return OptXGBoostCustomCallback
+
+
+if TYPE_CHECKING:
 
     import xgboost as xgb  # type: ignore
 
@@ -645,7 +654,8 @@ class XGBModel(PyCostModel):
         return eval_result
 
 
-class XGBoostCustomCallback(TrainingCallback):
+@optional_xgboost_callback
+class XGBoostCustomCallback:
     """Custom callback class for xgboost to support multiple custom evaluation functions"""
 
     def __init__(

--- a/tests/python/unittest/test_meta_schedule_cost_model.py
+++ b/tests/python/unittest/test_meta_schedule_cost_model.py
@@ -26,13 +26,8 @@ import numpy as np
 import pytest
 import tvm
 import tvm.testing
-from tvm.meta_schedule.cost_model import (
-    PyCostModel,
-    RandomModel,
-    XGBModel,
-    XGBoostCustomCallback,
-    PackSum,
-)
+from tvm.meta_schedule.cost_model import PyCostModel, RandomModel, XGBModel
+from tvm.meta_schedule.cost_model.xgb_model import XGBoostCustomCallback, PackSum
 from tvm.meta_schedule.feature_extractor import RandomFeatureExtractor
 from tvm.meta_schedule.runner import RunnerResult
 from tvm.meta_schedule.search_strategy import MeasureCandidate

--- a/tests/python/unittest/test_meta_schedule_cost_model.py
+++ b/tests/python/unittest/test_meta_schedule_cost_model.py
@@ -26,7 +26,13 @@ import numpy as np
 import pytest
 import tvm
 import tvm.testing
-from tvm.meta_schedule.cost_model import PyCostModel, RandomModel, XGBModel
+from tvm.meta_schedule.cost_model import (
+    PyCostModel,
+    RandomModel,
+    XGBModel,
+    XGBoostCustomCallback,
+    PackSum,
+)
 from tvm.meta_schedule.feature_extractor import RandomFeatureExtractor
 from tvm.meta_schedule.runner import RunnerResult
 from tvm.meta_schedule.search_strategy import MeasureCandidate
@@ -226,6 +232,90 @@ def test_meta_schedule_xgb_model_reupdate():
         [_dummy_result() for i in range(update_sample_count)],
     )
     model.predict(TuneContext(), [_dummy_candidate() for i in range(predict_sample_count)])
+
+
+def test_meta_schedule_xgb_model_callback():
+    import xgboost as xgb
+    from itertools import chain as itertools_chain
+    from functools import partial
+
+    extractor = RandomFeatureExtractor()
+    model = XGBModel(extractor=extractor, num_warmup_samples=10)
+    update_sample_count = 20
+    predict_sample_count = 30
+
+    model.update(
+        TuneContext(),
+        [_dummy_candidate() for i in range(update_sample_count)],
+        [_dummy_result() for i in range(update_sample_count)],
+    )
+    model.predict(TuneContext(), [_dummy_candidate() for i in range(predict_sample_count)])
+    with tempfile.NamedTemporaryFile() as path:
+        # Backup and train on new TrainingCallBack api
+        random_state = model.extractor.random_state  # save feature extractor's random state
+
+        model.save(path.name)
+
+        old_booster = model.booster
+        xs = [
+            x.numpy().astype("float32")
+            for x in extractor.extract_from(
+                TuneContext(),
+                [_dummy_candidate() for i in range(predict_sample_count)],
+            )
+        ]
+        d_test = PackSum(xs=xs, ys=None)
+        pred1 = old_booster.predict(d_test.dmatrix)
+
+        # Load and train on deprecated TrainingCallBack api
+        model.extractor.random_state = random_state  # load feature extractor's random state
+        model.load(path.name)
+        d_train = PackSum(
+            xs=list(itertools_chain.from_iterable([g.features for g in model.data.values()])),
+            ys=np.concatenate(
+                [g.min_cost / g.costs for g in model.data.values()],
+                axis=0,
+            ),
+        )
+
+        def obj(ys_pred: np.ndarray, d_train1: "xgb.DMatrix"):  # type: ignore # pylint: disable = unused-argument
+            return d_train.obj_square_error(ys_pred)
+
+        def rmse(ys_pred: np.ndarray, d_train1: "xgb.DMatrix"):  # type: ignore # pylint: disable = unused-argument
+            return d_train.rmse(ys_pred)
+
+        def avg_peak_score(ys_pred: np.ndarray, d_train1: "xgb.DMatrix"):  # type: ignore # pylint: disable = unused-argument
+            return d_train.average_peak_score(ys_pred, model.average_peak_n)
+
+        new_booster = xgb.train(
+            model.config.to_dict(),
+            d_train.dmatrix,
+            num_boost_round=10000,
+            obj=obj,
+            callbacks=[
+                partial(
+                    XGBoostCustomCallback(
+                        early_stopping_rounds=model.early_stopping_rounds,
+                        verbose_eval=model.verbose_eval,
+                        fevals=[rmse, avg_peak_score],
+                        evals=[(d_train.dmatrix, "tr")],
+                        cvfolds=None,
+                    )
+                )
+            ],
+        )
+
+        xs = [
+            x.numpy().astype("float32")
+            for x in extractor.extract_from(
+                TuneContext(),
+                [_dummy_candidate() for i in range(predict_sample_count)],
+            )
+        ]
+        d_test = PackSum(xs=xs, ys=None)
+        pred2 = new_booster.predict(d_test.dmatrix)
+
+    assert np.allclose(pred1, pred2, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR intends to update the custom callback function of xgboost in meta schedule.

This change is tested against xgboost==(1.2.0, 1.5.2 & 1.6.0) to ensure backwards compatibility on `tests/python/unittest/test_meta_schedule_cost_model.py`. 

This is related to the second action item in #12009.

cc: @zxybazh @junrushao1994 