### PR TITLE
[TFLite] Fix _test_tflite2_quantized_depthwise_convolution is unused

### DIFF
--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -974,43 +974,29 @@ def test_forward_quantized_convolution():
             int_quant_dtype=int_quant_dtype,
         )
 
+
 def test_forward_quantized_depthwise_convolution():
     for int_quant_dtype in [tf.int8, tf.int16]:
         _test_tflite2_quantized_depthwise_convolution(
-            [1, 8, 8, 128],
-            [1, 1, 128, 1],
-            [1, 1],
-            [1, 1],
-            'SAME',
-            'NHWC',
-            1,
-            int_quant_dtype
+            [1, 8, 8, 128], [1, 1, 128, 1], [1, 1], [1, 1], "SAME", "NHWC", 1, int_quant_dtype
         )
         _test_tflite2_quantized_depthwise_convolution(
-            [1, 17, 17, 12],
-            [3, 3, 12, 1],
-            [1, 1],
-            [2, 2],
-            'VALID',
-            'NHWC',
-            1,
-            int_quant_dtype
+            [1, 17, 17, 12], [3, 3, 12, 1], [1, 1], [2, 2], "VALID", "NHWC", 1, int_quant_dtype
         )
         _test_tflite2_quantized_depthwise_convolution(
-            [1, 24, 24, 3],
-            [7, 7, 3, 8],
-            [1, 1],
-            [2, 2],
-            'SAME',
-            'NHWC',
-            8,
-            int_quant_dtype
+            [1, 24, 24, 3], [7, 7, 3, 8], [1, 1], [2, 2], "SAME", "NHWC", 8, int_quant_dtype
         )
 
 
 def _test_tflite2_quantized_depthwise_convolution(
-    input_shape, kernel_shape, dilations, strides, padding, data_format, depth_multiplier,
-    int_quant_dtype=tf.int8
+    input_shape,
+    kernel_shape,
+    dilations,
+    strides,
+    padding,
+    data_format,
+    depth_multiplier,
+    int_quant_dtype=tf.int8,
 ):
     """One iteration of TFLite2 quantized depthwise convolution with given shapes and attributes"""
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -959,6 +959,39 @@ def test_forward_quantized_convolution():
             int_quant_dtype=int_quant_dtype,
         )
 
+def test_forward_quantized_depthwise_convolution():
+    for int_quant_dtype in [tf.int8, tf.int16]:
+        _test_tflite2_quantized_depthwise_convolution(
+            [1, 8, 8, 128],
+            [1, 1, 128, 1],
+            [1, 1],
+            [1, 1],
+            'SAME',
+            'NHWC',
+            1,
+            int_quant_dtype
+        )
+        _test_tflite2_quantized_depthwise_convolution(
+            [1, 17, 17, 12],
+            [3, 3, 12, 1],
+            [1, 1],
+            [2, 2],
+            'VALID',
+            'NHWC',
+            1,
+            int_quant_dtype
+        )
+        _test_tflite2_quantized_depthwise_convolution(
+            [1, 24, 24, 3],
+            [7, 7, 3, 8],
+            [1, 1],
+            [2, 2],
+            'SAME',
+            'NHWC',
+            8,
+            int_quant_dtype
+        )
+
 
 def _test_tflite2_quantized_depthwise_convolution(
     input_shape, kernel_shape, dilations, strides, padding, data_format, depth_multiplier
@@ -1230,15 +1263,6 @@ def test_forward_convolution():
         _test_convolution(
             [1, 17, 17, 124], [1, 1, 124, 19], [1, 1], [1, 1], "SAME", "NHWC", quantized=True
         )
-
-        # Disable as tests are flaky - https://github.com/apache/tvm/issues/6064
-        # depthwise convolution
-        # _test_tflite2_quantized_depthwise_convolution([1, 8, 8, 128], [1, 1, 128, 1], [1, 1], [1, 1],
-        #                                               'SAME', 'NHWC', 1)
-        # _test_tflite2_quantized_depthwise_convolution([1, 17, 17, 12], [3, 3, 12, 1], [1, 1], [2, 2],
-        #                                               'VALID', 'NHWC', 1)
-        # _test_tflite2_quantized_depthwise_convolution([1, 24, 24, 3], [7, 7, 3, 8], [1, 1], [2, 2],
-        #                                               'SAME', 'NHWC', 8)
 
 
 #######################################################################
@@ -5106,6 +5130,7 @@ if __name__ == "__main__":
     test_forward_qnn_coco_ssd_mobilenet_v1()
 
     # TFLite 2.1.0 quantized tests
+    test_forward_quantized_depthwise_convolution()
     test_forward_tflite2_qnn_resnet50()
     test_forward_tflite2_qnn_inception_v1()
     test_forward_tflite2_qnn_mobilenet_v2()

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -5168,6 +5168,7 @@ if __name__ == "__main__":
     test_forward_qnn_coco_ssd_mobilenet_v1()
 
     # TFLite 2.1.0 quantized tests
+    test_forward_quantized_convolution()
     test_forward_quantized_depthwise_convolution()
     test_forward_tflite2_qnn_resnet50()
     test_forward_tflite2_qnn_inception_v1()


### PR DESCRIPTION
1. As #11356 said. The entry of the ` _test_tflite2_quantized_depthwise_convolution` has been completed.

2. And an input_node error has also been fixed, because the input name of the tflite model quantized by the `_quantize_keras_model()` will be rewritten(no longer `data_in.name.replace(":0", "")`)