### PR TITLE
[UX][TIR][Schedule] enhance function annotation for tir primitive

### DIFF
--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -17,7 +17,7 @@
 """Type checking functionality"""
 import functools
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 import typing
 
 
@@ -216,7 +216,9 @@ def _type_check(v: Any, name: str, type_: Any) -> Optional[str]:
     return _TYPE_CHECK[key](v, name, *subtypes)
 
 
-def type_checked(func: Callable) -> Callable:
+_F_TYPE = TypeVar('_F_TYPE', bound=Callable[..., Any])
+
+def type_checked(func: _F_TYPE) -> _F_TYPE:
     """Type check the input arguments of a function."""
     sig = inspect.signature(func)
 

--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -216,10 +216,10 @@ def _type_check(v: Any, name: str, type_: Any) -> Optional[str]:
     return _TYPE_CHECK[key](v, name, *subtypes)
 
 
-_F_TYPE = TypeVar("_F_TYPE", bound=Callable[..., Any])
+FType = TypeVar("FType", bound=Callable[..., Any])
 
 
-def type_checked(func: _F_TYPE) -> _F_TYPE:
+def type_checked(func: FType) -> FType:
     """Type check the input arguments of a function."""
     sig = inspect.signature(func)
 

--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -239,4 +239,4 @@ def type_checked(func: _F_TYPE) -> _F_TYPE:
                     raise TypeError(error_msg)
         return func(*args, **kwargs)
 
-    return wrap
+    return wrap  # type: ignore

--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -216,7 +216,8 @@ def _type_check(v: Any, name: str, type_: Any) -> Optional[str]:
     return _TYPE_CHECK[key](v, name, *subtypes)
 
 
-_F_TYPE = TypeVar('_F_TYPE', bound=Callable[..., Any])
+_F_TYPE = TypeVar("_F_TYPE", bound=Callable[..., Any])
+
 
 def type_checked(func: _F_TYPE) -> _F_TYPE:
     """Type check the input arguments of a function."""

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -2328,10 +2328,10 @@ class Schedule(Object):
         self, block: BlockRV, buffer: Union[Tuple[str, int], str, Buffer]
     ) -> Tuple[str, int, Buffer]:
 
-        block_name = self.get(block).name_hint
+        block_obj: Block = self.get(block)
+        block_name = block_obj.name_hint
 
         def iter_buffers():
-            block_obj = self.get(block)
             for i, read in enumerate(block_obj.reads):
                 yield "read", i, read.buffer
             for i, write in enumerate(block_obj.writes):
@@ -2367,9 +2367,7 @@ class Schedule(Object):
                 f"Expected 'read' or 'write', "
                 f"but received {buffer_index_type}"
             )
-            buffer_list = (
-                self.get(block).reads if buffer_index_type == "read" else self.get(block).writes
-            )
+            buffer_list = block_obj.reads if buffer_index_type == "read" else block_obj.writes
             assert 0 <= buffer_index < len(buffer_list), (
                 f"Invalid buffer_index {buffer_index}.  "
                 f"Block {block_name} has only "


### PR DESCRIPTION
We do have type annotations for tir primitives
```Python
@type_checked
def get_block(
    self,
    name: str,
    func_name: Optional[str] = None,
) -> BlockRV:
```

However, after calling the decorator `@type_checked`, all functions become `(func: (...) -> Any) -> ((...) -> Any)`. So there are no code suggestions during programming. Please see the following screenshot:
<img width="615" alt="Screen Shot 2022-07-20 at 20 06 15" src="https://user-images.githubusercontent.com/25500082/179981888-6162ab3c-f25a-4d18-a1af-a115e2cce485.png">

After the fix, it becomes
<img width="615" alt="Screen Shot 2022-07-20 at 20 05 36" src="https://user-images.githubusercontent.com/25500082/179981949-fb946e62-e29d-4bdd-a1ef-5ea146956fa0.png">

cc @junrushao1994 