### PR TITLE
[OpenCL] Fix profiling hang for OpenCL device

### DIFF
--- a/src/runtime/graph_executor/debug/graph_executor_debug.cc
+++ b/src/runtime/graph_executor/debug/graph_executor_debug.cc
@@ -117,7 +117,7 @@ class GraphExecutorDebug : public GraphExecutor {
       LOG(FATAL) << "RPC measurements should not use RunIndividualNode!";
     }
 
-    if (!op_execs_[node_index]) {
+    if (!op_execs_[node_index] || nodes_[node_index].param.func_name == "__nop") {
       // don't return anything...
       std::ostringstream os;
       double zero = 0;

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -451,7 +451,6 @@ class OpenCLTimerNode : public TimerNode {
     if (event_start_idxs.size() < count_timer_execs) {
       event_start_idxs.push_back(0);
     }
-
   }
   // Timer stop
   virtual void Stop() {
@@ -473,12 +472,10 @@ class OpenCLTimerNode : public TimerNode {
     // update event index for current call nesting
     event_start_idxs[count_timer_execs - 1] = evt_queue.size();
     --count_timer_execs;
-
   }
   virtual int64_t SyncAndGetElapsedNanos() { return this->duration; }
   // destructor
   virtual ~OpenCLTimerNode() {
-
     // Profiling session ends, recreate clCommandQueue in non-profiling mode
     // This will disable collection of cl_events in case of executing inference after profile
     if (count_timer_execs == 0) {

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -439,19 +439,30 @@ class OpenCLTimerNode : public TimerNode {
  public:
   // Timer start
   virtual void Start() {
-    cl::OpenCLWorkspace::Global()->GetEventQueue(dev_).clear();
-    this->duration = 0;
-    // Very first call of Start() leads to the recreation of
-    // OpenCL command queue in profiling mode. This allows to run profile after inference.
-    recreateCommandQueue();
+    if (count_timer_execs == 0) {
+      cl::OpenCLWorkspace::Global()->GetEventQueue(dev_).clear();
+      this->duration = 0;
+      // Very first call of Start() leads to the recreation of
+      // OpenCL command queue in profiling mode. This allows to run profile after inference.
+      recreateCommandQueue();
+    }
+    ++count_timer_execs;
+    // set new first idx in event queue
+    if (event_start_idxs.size() < count_timer_execs) {
+      event_start_idxs.push_back(0);
+    }
+
   }
   // Timer stop
   virtual void Stop() {
     std::vector<cl_event> evt_queue = cl::OpenCLWorkspace::Global()->GetEventQueue(dev_);
     cl_ulong start, end;
+    int64_t start_idx = event_start_idxs[count_timer_execs - 1];
+
     if (cl::OpenCLWorkspace::Global()->GetEventQueue(dev_).size() > 0) {
       OPENCL_CALL(clWaitForEvents(1, &(cl::OpenCLWorkspace::Global()->GetEventQueue(dev_).back())));
-      for (auto& kevt : evt_queue) {
+      for (int i = start_idx; i < evt_queue.size(); ++i) {
+        auto& kevt = evt_queue[i];
         OPENCL_CALL(clGetEventProfilingInfo(kevt, CL_PROFILING_COMMAND_START, sizeof(cl_ulong),
                                             &start, nullptr));
         OPENCL_CALL(clGetEventProfilingInfo(kevt, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &end,
@@ -459,19 +470,29 @@ class OpenCLTimerNode : public TimerNode {
         this->duration += (end - start);
       }
     }
+    // update event index for current call nesting
+    event_start_idxs[count_timer_execs - 1] = evt_queue.size();
+    --count_timer_execs;
+
   }
   virtual int64_t SyncAndGetElapsedNanos() { return this->duration; }
   // destructor
   virtual ~OpenCLTimerNode() {
+
     // Profiling session ends, recreate clCommandQueue in non-profiling mode
     // This will disable collection of cl_events in case of executing inference after profile
-    recreateCommandQueue();
+    if (count_timer_execs == 0) {
+      recreateCommandQueue();
+      event_start_idxs.clear();
+    }
   }
   // constructor
   OpenCLTimerNode() {}
   explicit OpenCLTimerNode(Device dev) : dev_(dev) {}
 
   static constexpr const char* _type_key = "OpenCLTimerNode";
+  static int64_t count_timer_execs;
+  static std::vector<int64_t> event_start_idxs;
   TVM_DECLARE_FINAL_OBJECT_INFO(OpenCLTimerNode, TimerNode);
 
  private:
@@ -480,6 +501,7 @@ class OpenCLTimerNode : public TimerNode {
 
   void recreateCommandQueue() {
     cl_command_queue_properties prop;
+
     if (!cl::OpenCLWorkspace::Global()->IsProfiling(dev_)) {
       prop = CL_QUEUE_PROFILING_ENABLE;
     } else {

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -485,7 +485,6 @@ TVM_REGISTER_GLOBAL("device_api.opencl").set_body([](TVMArgs args, TVMRetValue* 
   *rv = static_cast<void*>(ptr);
 });
 
-
 TVM_REGISTER_OBJECT_TYPE(OpenCLTimerNode);
 
 TVM_REGISTER_GLOBAL("profiling.timer.opencl").set_body_typed([](Device dev) {

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -485,6 +485,7 @@ TVM_REGISTER_GLOBAL("device_api.opencl").set_body([](TVMArgs args, TVMRetValue* 
   *rv = static_cast<void*>(ptr);
 });
 
+
 TVM_REGISTER_OBJECT_TYPE(OpenCLTimerNode);
 
 TVM_REGISTER_GLOBAL("profiling.timer.opencl").set_body_typed([](Device dev) {
@@ -492,5 +493,7 @@ TVM_REGISTER_GLOBAL("profiling.timer.opencl").set_body_typed([](Device dev) {
 });
 
 }  // namespace cl
+int64_t OpenCLTimerNode::count_timer_execs = 0;
+std::vector<int64_t> OpenCLTimerNode::event_start_idxs;
 }  // namespace runtime
 }  // namespace tvm

--- a/tests/cpp-runtime/opencl/opencl_timer_test.cc
+++ b/tests/cpp-runtime/opencl/opencl_timer_test.cc
@@ -29,11 +29,10 @@ using namespace tvm::runtime::cl;
 #define NUM_REPEAT 10
 
 TEST(OpenCLTimerNode, nested_timers) {
-  
   OpenCLWorkspace* workspace = OpenCLWorkspace::Global();
   OpenCLThreadEntry* thr = workspace->GetThreadEntry();
   cl_command_queue queue = workspace->GetQueue(thr->device);
-  
+
   int err;
   cl_int* tmp_buf = new cl_int[BUFF_SIZE];
   int64_t nested_time_sum = 0;
@@ -41,12 +40,14 @@ TEST(OpenCLTimerNode, nested_timers) {
   Timer init_timer = Timer::Start(thr->device);
   for (int i = 0; i < NUM_REPEAT; ++i) {
     Timer nested_timer = Timer::Start(thr->device);
-    //create some events
+    // create some events
     cl_event ev = clCreateUserEvent(workspace->context, &err);
     OPENCL_CHECK_ERROR(err);
-    cl_mem cl_buf = clCreateBuffer(workspace->context, CL_MEM_READ_ONLY, BUFF_SIZE * sizeof(cl_int), NULL, &err);
+    cl_mem cl_buf = clCreateBuffer(workspace->context, CL_MEM_READ_ONLY, BUFF_SIZE * sizeof(cl_int),
+                                   NULL, &err);
     OPENCL_CHECK_ERROR(err);
-    OPENCL_CALL(clEnqueueWriteBuffer(queue, cl_buf, false, 0, BUFF_SIZE * sizeof(cl_int), tmp_buf, 0, NULL, &ev));
+    OPENCL_CALL(clEnqueueWriteBuffer(queue, cl_buf, false, 0, BUFF_SIZE * sizeof(cl_int), tmp_buf,
+                                     0, NULL, &ev));
     OPENCL_CALL(clReleaseMemObject(cl_buf));
     workspace->events[thr->device.device_id].push_back(ev);
     nested_timer->Stop();

--- a/tests/cpp-runtime/opencl/opencl_timer_test.cc
+++ b/tests/cpp-runtime/opencl/opencl_timer_test.cc
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <tvm/runtime/profiling.h>
+
+#include "../src/runtime/opencl/opencl_common.h"
+
+using namespace tvm::runtime;
+using namespace tvm::runtime::cl;
+
+#define BUFF_SIZE 1024
+#define NUM_REPEAT 10
+
+TEST(OpenCLTimerNode, nested_timers) {
+  
+  OpenCLWorkspace* workspace = OpenCLWorkspace::Global();
+  OpenCLThreadEntry* thr = workspace->GetThreadEntry();
+  cl_command_queue queue = workspace->GetQueue(thr->device);
+  
+  int err;
+  cl_int* tmp_buf = new cl_int[BUFF_SIZE];
+  int64_t nested_time_sum = 0;
+
+  Timer init_timer = Timer::Start(thr->device);
+  for (int i = 0; i < NUM_REPEAT; ++i) {
+    Timer nested_timer = Timer::Start(thr->device);
+    //create some events
+    cl_event ev = clCreateUserEvent(workspace->context, &err);
+    OPENCL_CHECK_ERROR(err);
+    cl_mem cl_buf = clCreateBuffer(workspace->context, CL_MEM_READ_ONLY, BUFF_SIZE * sizeof(cl_int), NULL, &err);
+    OPENCL_CHECK_ERROR(err);
+    OPENCL_CALL(clEnqueueWriteBuffer(queue, cl_buf, false, 0, BUFF_SIZE * sizeof(cl_int), tmp_buf, 0, NULL, &ev));
+    OPENCL_CALL(clReleaseMemObject(cl_buf));
+    workspace->events[thr->device.device_id].push_back(ev);
+    nested_timer->Stop();
+    nested_time_sum += nested_timer->SyncAndGetElapsedNanos();
+  }
+  init_timer->Stop();
+
+  free(tmp_buf);
+  int64_t elapsed = init_timer->SyncAndGetElapsedNanos();
+  CHECK_EQ(elapsed, nested_time_sum);
+}

--- a/tests/cpp-runtime/opencl/opencl_timer_test.cc
+++ b/tests/cpp-runtime/opencl/opencl_timer_test.cc
@@ -55,7 +55,7 @@ TEST(OpenCLTimerNode, nested_timers) {
   }
   init_timer->Stop();
 
-  free(tmp_buf);
+  delete[] tmp_buf;
   int64_t elapsed = init_timer->SyncAndGetElapsedNanos();
   CHECK_EQ(elapsed, nested_time_sum);
 }


### PR DESCRIPTION
Profiling for OpenCL runs was hanging because nested timer runs were not correctly handled. This is because each call to the `Timer::Start` function on OpenCL device causes the OpenCL event queue to be cleared.

The hang was due to the fact that the minimum run time was not reached for profiling, if it is set greater than zero. Since the queue is cleared every `Start` call, the time of only one run is returned, not `number`.

It happens in this cycle:

https://github.com/apache/tvm/blob/75ec1cffa9f160dd3165fedbf4408731ebfa797a/src/runtime/profiling.cc#L876-L891

Here `pf.CallPacked(args, &temp)` call function which contains one more call `Timer::Start` and `Timer::End`.

Also profiling was hanging for `__nop` functions like `reshape` due to there are no OpenCL calls for this node. So that OpenCL timer returns 0, which is less than the minimum time value.

The `__nop` functions are now skipped for profiling.

