### PR TITLE
[microTVM] Arduino: Fix f-strings on flash warning/error messages

### DIFF
--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -495,12 +495,12 @@ class Handler(server.ProjectAPIHandler):
             # be caught.
             except subprocess.TimeoutExpired:
                 _LOG.warning(
-                    "Upload attempt to port {port} timed out after {self.FLASH_TIMEOUT_SEC} seconds"
+                    f"Upload attempt to port {port} timed out after {self.FLASH_TIMEOUT_SEC} seconds"
                 )
 
         else:
             raise RuntimeError(
-                "Unable to flash Arduino board after {self.FLASH_MAX_RETRIES} attempts"
+                f"Unable to flash Arduino board after {self.FLASH_MAX_RETRIES} attempts"
             )
 
     def open_transport(self, options):


### PR DESCRIPTION
This commit fixes two f-strings on flash timeout exception and runtime
error so the proper variables (like port, number of retries, and timeout
value) are correctly printed to the warning / error messages.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>


cc @alanmacd @mehrdadh