### PR TITLE
[Doc] Fix URL link error in pipeline executor tutorial

### DIFF
--- a/gallery/how_to/work_with_relay/using_pipeline_executor.py
+++ b/gallery/how_to/work_with_relay/using_pipeline_executor.py
@@ -17,7 +17,7 @@
 """
 Using Pipeline Executor in Relay
 =================================
-**Author**: `Hua Jiang <https://https://github.com/huajsj>`_
+**Author**: `Hua Jiang <https://github.com/huajsj>`_
 
 This is a short tutorial on how to use "Pipeline Executor" with Relay.
 """


### PR DESCRIPTION
Fix the link error.

