### PR TITLE
[JIT] Force finalization of JITed code, expose sf/hf runtime functions

### DIFF
--- a/include/tvm/runtime/builtin_fp16.h
+++ b/include/tvm/runtime/builtin_fp16.h
@@ -31,6 +31,8 @@
 extern "C" {
 TVM_DLL uint16_t __gnu_f2h_ieee(float);
 TVM_DLL float __gnu_h2f_ieee(uint16_t);
+TVM_DLL uint16_t __truncsfhf2(float v);
+TVM_DLL float __extendhfsf2(uint16_t v);
 }
 
 #endif  // TVM_RUNTIME_BUILTIN_FP16_H_

--- a/src/runtime/builtin_fp16.cc
+++ b/src/runtime/builtin_fp16.cc
@@ -48,4 +48,7 @@ TVM_DLL float __gnu_h2f_ieee(uint16_t a) {
 }
 
 #endif
+
+TVM_DLL uint16_t __truncsfhf2(float v) { return __gnu_f2h_ieee(v); }
+TVM_DLL float __extendhfsf2(uint16_t v) { return __gnu_h2f_ieee(v); }
 }

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -432,6 +432,12 @@ class LLVMModuleNode final : public runtime::ModuleNode {
     }
     runtime::InitContextFunctions(
         [this](const char* name) { return reinterpret_cast<void*>(GetGlobalAddr(name)); });
+    // There is a problem when a JITed function contains a call to a runtime function.
+    // The runtime function (e.g. __truncsfhf2) may not be resolved, and calling it will
+    // lead to a runtime crash.
+    // Do name lookup on a symbol that doesn't exist. This will force MCJIT to finalize
+    // all loaded objects, which will resolve symbols in JITed code.
+    ee_->getFunctionAddress("__some_name_that_hopefully_doesnt_exist__b49f8aaade5877eaba7583b91");
   }
 
   // Get global address from execution engine.


### PR DESCRIPTION
Code that handles fp16 and fp32 may end up calling builtins that do the conversions between these types. LLVM emits calls to `__truncsfhf2`, and `__extendhfsf2`, which are not present in TVM or TVM runtime. This creates two problems:
- Problem 1: JITed code that does the conversions will fail because it calls non-existent functions.

Adding these functions to libtvm.so/libtvm_runtime.so solves this part, but there is another issue:
- Problem 2: JITed code may still not call these functions, because the generated object may not be fully resolved.

To force full resolution, try to obtain an address of a non-existent symbol.