### PR TITLE
[runtime][hexagon] improved file-copy logic

### DIFF
--- a/src/runtime/file_utils.cc
+++ b/src/runtime/file_utils.cc
@@ -159,7 +159,27 @@ void LoadMetaDataFromFile(const std::string& file_name,
   fs.close();
 }
 
-void RemoveFile(const std::string& file_name) { std::remove(file_name.c_str()); }
+void RemoveFile(const std::string& file_name) {
+  // FIXME: This doesn't check the return code.
+  std::remove(file_name.c_str());
+}
+
+void CopyFile(const std::string& src_file_name, const std::string& dest_file_name) {
+  std::ifstream src(src_file_name, std::ios::binary);
+  ICHECK(src) << "Unable to open source file '" << src_file_name << "'";
+
+  std::ofstream dest(dest_file_name, std::ios::binary | std::ios::trunc);
+  ICHECK(dest) << "Unable to destination source file '" << src_file_name << "'";
+
+  dest << src.rdbuf();
+
+  src.close();
+  dest.close();
+
+  ICHECK(dest) << "File-copy operation failed."
+               << " src='" << src_file_name << "'"
+               << " dest='" << dest_file_name << "'";
+}
 
 Map<String, NDArray> LoadParams(const std::string& param_blob) {
   dmlc::MemoryStringStream strm(const_cast<std::string*>(&param_blob));

--- a/src/runtime/file_utils.h
+++ b/src/runtime/file_utils.h
@@ -91,6 +91,14 @@ void LoadMetaDataFromFile(const std::string& file_name,
                           std::unordered_map<std::string, FunctionInfo>* fmap);
 
 /*!
+ * \brief Copy the content of an existing file to another file.
+ * \param src_file_name Path to the source file.
+ * \param dest_file_name Path of the destination file.  If this file already exists,
+ *    replace its content.
+ */
+void CopyFile(const std::string& src_file_name, const std::string& dest_file_name);
+
+/*!
  * \brief Remove (unlink) a file.
  * \param file_name The file name.
  */

--- a/src/runtime/hexagon/hexagon_module.cc
+++ b/src/runtime/hexagon/hexagon_module.cc
@@ -63,10 +63,7 @@ void HexagonModuleNode::SaveToFile(const std::string& file_name, const std::stri
   if (fmt == "so" || fmt == "dll" || fmt == "hexagon") {
     std::string meta_file = GetMetaFilePath(file_name);
     SaveMetaDataToFile(meta_file, fmap_);
-#if !defined(__APPLE__)
-    std::string c = "cp " + data_ + " " + file_name;
-    ICHECK(std::system(c.c_str()) == 0) << "Cannot create " + file_name;
-#endif
+    CopyFile(data_, file_name);
   } else if (fmt == "s" || fmt == "asm") {
     ICHECK(!asm_.empty()) << "Assembler source not available";
     SaveBinaryToFile(file_name, asm_);


### PR DESCRIPTION
- Add `tvm::runtime::CopyFile` function.

- Change `HexagonModuleNode::SaveToFile` to use new function
  instead of a shell `cp` invocation.

  This fixes a problem where the `cp`-based implementation
  couldn't handle certain valid filenames.

  This also fixes a bug where `SaveToFile` simply skips the
  file-copying step on Mac OSX.

cc @areusch @mehrdadh