### PR TITLE
Use std::move to avoid warnings on clang-13

### DIFF
--- a/src/relay/backend/vm/manifest_lifetimes.cc
+++ b/src/relay/backend/vm/manifest_lifetimes.cc
@@ -201,7 +201,7 @@ class AliasEliminator : public MixedModeMutator {
     if (alias_.count(var)) {
       return alias_[var];
     }
-    return var;
+    return std::move(var);
   }
 
   Expr VisitExpr_(const FunctionNode* func_node) override {

--- a/src/relay/quantize/calibrate.cc
+++ b/src/relay/quantize/calibrate.cc
@@ -158,7 +158,7 @@ class StatsCollector : private ExprMutator {
     // indistinguishable from NullValue<Type>(), so we can't express "update to nullptr" in
     // WithFields.
     ret_func.CopyOnWrite()->ret_type = NullValue<Type>();
-    return ret_func;
+    return std::move(ret_func);
   }
 
  private:

--- a/src/relay/transforms/device_planner.cc
+++ b/src/relay/transforms/device_planner.cc
@@ -1026,7 +1026,7 @@ class DeviceCapturer : public ExprMutator {
     VLOG(4) << "Func with bound params: " << func;
     func->virtual_device_ = result_virtual_device;
     VLOG(4) << "Func with bound params & result vid set: " << func;
-    return func;
+    return std::move(func);
   }
 
   Expr VisitExpr_(const CallNode* call_node) final {

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -118,7 +118,7 @@ class LayoutFreePlaceholdersNormalizer : public StmtMutator {
       }
       block.CopyOnWrite()->annotations.erase(topi_attr);
     }
-    return block;
+    return std::move(block);
   }
 
   std::unordered_map<tir::Buffer, int, ObjectPtrHash, ObjectPtrEqual> buffer2index_;

--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -374,7 +374,7 @@ Stmt Substitute(const Stmt& stmt, const Map<Var, PrimExpr>& sub,
       if (!src.same_as(tgt)) {
         block_sref_reuse_->Set(src, tgt);
       }
-      return tgt;
+      return std::move(tgt);
     }
 
     const Map<Var, PrimExpr>& sub_;

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -888,7 +888,7 @@ class ReIndexRewriter : public StmtExprMutator {
       n->alloc_buffers.push_back(info_->alloc);
       stmt = Block(n);
       info_->block_reuse.Set(old_stmt, stmt);
-      return stmt;
+      return std::move(stmt);
     }
 
     // Visiting the blokc being reindexed
@@ -917,9 +917,9 @@ class ReIndexRewriter : public StmtExprMutator {
         stmt = Block(n);
       }
       info_->block_reuse.Set(old_stmt, stmt);
-      return stmt;
+      return std::move(stmt);
     }
-    return old_stmt;
+    return std::move(old_stmt);
   }
 
   template <typename Node>

--- a/src/tir/transforms/flatten_buffer.cc
+++ b/src/tir/transforms/flatten_buffer.cc
@@ -107,9 +107,9 @@ class BufferFlattener : public StmtExprMutator {
           << "Expected int8 backing array for boolean tensor";
       auto writer = store.CopyOnWrite();
       writer->value = tvm::cast(DataType::Int(8), store->value);
-      return store;
+      return std::move(store);
     }
-    return store;
+    return std::move(store);
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/transforms/remove_weight_layout_rewrite_block.cc
+++ b/src/tir/transforms/remove_weight_layout_rewrite_block.cc
@@ -69,7 +69,7 @@ class WeightLayoutRewriteBlockRemover : public StmtMutator {
         n->alloc_buffers = std::move(alloc_buffers);
         return Stmt(n);
       } else {
-        return block;
+        return std::move(block);
       }
     }
 

--- a/src/tir/usmp/transform/assign_pool_info.cc
+++ b/src/tir/usmp/transform/assign_pool_info.cc
@@ -140,7 +140,7 @@ Stmt PoolInfoAssigner::VisitStmt_(const AllocateNode* op) {
   Stmt body = VisitStmt(op->body);
   auto allocate =
       Allocate(op->buffer_var, op->dtype, op->extents, op->condition, body, annotations);
-  return allocate;
+  return std::move(allocate);
 }
 
 Stmt PoolInfoAssigner::VisitStmt_(const AllocateConstNode* op) {
@@ -157,7 +157,7 @@ Stmt PoolInfoAssigner::VisitStmt_(const AllocateConstNode* op) {
   Stmt body = VisitStmt(op->body);
   auto allocate_const =
       AllocateConst(op->buffer_var, op->dtype, op->extents, op->data, body, annotations);
-  return allocate_const;
+  return std::move(allocate_const);
 }
 
 IRModule PoolInfoAssigner::operator()() {


### PR DESCRIPTION
Returning an instance of a subclass of the return type disable copy elision, `std::move` is needed in this case.