### PR TITLE
[ci] Attempt to fix post-merge builds on main

### DIFF
--- a/tests/scripts/git_change_docker.sh
+++ b/tests/scripts/git_change_docker.sh
@@ -19,8 +19,7 @@
 
 set -eux
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$BRANCH" == "main" ]; then
+if [ "${BRANCH_NAME}" == "main" ]; then
     changed_files=$(git diff --no-commit-id --name-only -r HEAD~1)
 else
     changed_files=$(git diff --no-commit-id --name-only -r origin/main)


### PR DESCRIPTION
* This patch addresses #12097 by referencing the branch from the `BRANCH_NAME` environment variable, which is also used in the Jenkinsfile
* This avoids git rev-parse, which assumes the local repo contains a git branch that matches the name of the branch being merged. I think this is in spirit of what the script was trying for.

cc @Mousius @driazati @yongwww