### PR TITLE
[CI] Fix build android rpc failure in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Build android_rpc
         working-directory: apps/android_rpc
         run: |
-          export PATH="${ANDROID_NDK_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_rpc APK
         uses: actions/upload-artifact@v2
@@ -132,7 +132,7 @@ jobs:
       - name: Build android_deploy
         working-directory: apps/android_deploy
         run: |
-          export PATH="${ANDROID_NDK_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_deploy APK
         uses: actions/upload-artifact@v2
@@ -143,7 +143,7 @@ jobs:
         working-directory: apps/android_camera
         run: |
           mkdir -p app/src/main/assets/models/
-          export TVM_NDK_CC=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
+          export TVM_NDK_CC=${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
           export TVM_HOME=~/work/tvm/tvm
           export PYTHONPATH=$TVM_HOME/python:${PYTHONPATH}
           python3 ${TVM_HOME}/python/gen_requirements.py
@@ -152,7 +152,7 @@ jobs:
           pip3 install -r requirements.txt
           python3 prepare_model.py
           cd ..
-          export PATH="${ANDROID_NDK_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_camera APK
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Build android_rpc
         working-directory: apps/android_rpc
         run: |
+          set -eux
           export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_rpc APK
@@ -132,6 +133,7 @@ jobs:
       - name: Build android_deploy
         working-directory: apps/android_deploy
         run: |
+          set -eux
           export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_deploy APK
@@ -142,6 +144,7 @@ jobs:
       - name: Build android_camera
         working-directory: apps/android_camera
         run: |
+          set -eux
           mkdir -p app/src/main/assets/models/
           export TVM_NDK_CC=${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
           export TVM_HOME=~/work/tvm/tvm


### PR DESCRIPTION
android_rpc build problem: https://github.com/apache/tvm/issues/12191

The problem with the build appeared due to the fact that the `ANDROID_NDK_HOME` environment variable was removed in the current version of github actions. 
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md

But this variable is used here:

https://github.com/apache/tvm/blob/ee319d9d23c80091da9c4fb764b1e6d49d462714/.github/workflows/main.yml#L122-L127

Now only `ANDROID_NDK_LATEST_HOME` is available for ndk.

cc @Mousius @areusch @driazati