### PR TITLE
Removing header arm_math.h which  was moved after CMSIS upgrade

### DIFF
--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -449,7 +449,6 @@ class Handler(server.ProjectAPIHandler):
                     header in lib_content
                     for header in [
                         "<arm_nnsupportfunctions.h>",
-                        "<arm_math.h>",
                         "arm_nn_types.h",
                         "arm_nnfunctions.h",
                     ]

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
@@ -24,7 +24,6 @@ common_includes = """
 #include <stdlib.h>
 #include <string.h>
 
-#include <arm_math.h>
 #include <arm_nnsupportfunctions.h>
 
 #include <tvm/runtime/crt/error_codes.h>


### PR DESCRIPTION
Removing arm_math.h which is not available
post CMSIS upgrade and is not in use by NN
tests.

cc: @leandron 