### PR TITLE
[FIX,ROOFLINE] Handle mismatched compiled and TIR hash

### DIFF
--- a/python/tvm/utils/roofline.py
+++ b/python/tvm/utils/roofline.py
@@ -370,7 +370,7 @@ def roofline_from_existing(
 
     new_calls = []
     for call in report.calls:
-        if "Hash" in call.keys():
+        if "Hash" in call.keys() and call["Hash"] in all_features:
             _, features = all_features[call["Hash"]]
 
             flops = np.sum(features["float_addsub"] + features["float_mul"] + features["float_mad"])
@@ -440,7 +440,7 @@ def roofline_analysis(
     Parameters
     ----------
     mod : IRModule
-      Uncompiled input module>
+      Uncompiled input module
 
     params : Dict[str, nd.NDArray]
 


### PR DESCRIPTION
Fix a bug where roofline analysis would crash if the provided tir functions do no match the profiling report.

@AndrewZhaoLuo 