### PR TITLE
[MetaSchedule][Minor] Fix Comments

### DIFF
--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -530,7 +530,7 @@ def tune_relay(
     mutator_probs: Optional[FnMutatorProb] = None,
     num_threads: Optional[int] = None,
 ) -> Union[Module, vm.Executable]:
-    """Tune a TIR IRModule with a given target.
+    """Tune a Relay IRModule with a given target.
 
     Parameters
     ----------

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -21,7 +21,7 @@
 namespace tvm {
 namespace meta_schedule {
 
-/*! \brief Collecting all the non-root blocks */
+/*! \brief Collecting all the blocks */
 class BlockCollector : public tir::StmtVisitor {
  public:
   static Array<tir::BlockRV> Collect(const tir::Schedule& sch) {  //


### PR DESCRIPTION
This PR fixes 2 incorrect description to the functions, one is `tune_relay` api, and the other one is for post order apply space generator, which does collect the root block. CC @sunggg 