### PR TITLE
[ci] Better reporting on invalid JUnits

### DIFF
--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -40,6 +40,7 @@ function cleanup() {
     if [ "${#pytest_errors[@]}" -gt 0 ]; then
         echo "These pytest invocations failed, the results can be found in the Jenkins 'Tests' tab or by scrolling up through the raw logs here."
         python3 tests/scripts/pytest_wrapper.py "${pytest_errors[@]}"
+        echo "pytest failures found, exiting with error"
         exit 1
     fi
     set -x


### PR DESCRIPTION
This makes it so parsing JUnits is not an all-or-nothing proposition. Now failures are put into a side channel and reported but they do not affect other JUnits. This also improves reporting a bit so we can see if the `pytest_wrapper.py` script has failed or not.

Fixes #11749

cc @Mousius @areusch