### PR TITLE
[ONNX][Python][VM] Generation and saving ONNX model hash for VirtualMachine

### DIFF
--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -42,6 +42,7 @@
 namespace tvm {
 
 class IRModule;
+const std::string IRMODULE_MODEL_HASH = "model_hash";
 
 /*!
  * \brief IRModule that holds functions and type definitions.
@@ -61,7 +62,7 @@ class IRModuleNode : public Object {
   Map<GlobalTypeVar, TypeData> type_definitions;
   /*! \brief The source map for the module. */
   parser::SourceMap source_map;
-  /* \brief Additional attributes storing meta-data about the module. */
+  /*! \brief Additional attributes storing meta-data about the module. */
   DictAttrs attrs;
 
   /*!

--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -42,7 +42,7 @@
 namespace tvm {
 
 class IRModule;
-const std::string IRMODULE_MODEL_HASH = "model_hash";
+const constexpr char* IRMODULE_MODEL_HASH = "model_hash";
 
 /*!
  * \brief IRModule that holds functions and type definitions.

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -232,6 +232,18 @@ class TVM_DLL Executable : public ModuleNode {
   void SetLib(const runtime::Module& lib);
 
   /*!
+   * \brief Get the hash calculated from model file. It is used to save the hash to disk.
+   *
+   * \return The model hash needed for checking after import.
+   */
+  std::string GetHash() const;
+
+  /*!
+   * \brief Set the hash in an executable.
+   */
+  void SetHash(const std::string& hash);
+
+  /*!
    * \brief Get VMFunction.
    * \param func_name The function's name.
    * \return VMFunction.
@@ -292,6 +304,9 @@ class TVM_DLL Executable : public ModuleNode {
   std::vector<VMFunction> functions;
   /*! \brief The index of the device holding each constant. */
   std::vector<Index> const_device_indexes;
+  // TODO(vchernov): just now hash is calculated from onnx model only.
+  /*! \brief The hash calculated from model file. */
+  std::string hash;
 
  private:
   /*!
@@ -337,6 +352,13 @@ class TVM_DLL Executable : public ModuleNode {
   void SaveCodeSection(dmlc::Stream* strm);
 
   /*!
+   * \brief Save the hash calculated from model file.
+   *
+   * \param strm The output stream.
+   */
+  void SaveHash(dmlc::Stream* strm);
+
+  /*!
    * \brief Load the virtual devices
    *
    * /param strm The input stream.
@@ -363,6 +385,13 @@ class TVM_DLL Executable : public ModuleNode {
    * \param strm The input stream.
    */
   void LoadCodeSection(dmlc::Stream* strm);
+
+  /*!
+   * \brief Load the hash.
+   *
+   * \param strm The input stream.
+   */
+  void LoadHash(dmlc::Stream* strm);
 
   /*! \brief The serialized bytecode. */
   std::string code_;

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -218,6 +218,32 @@ class IRModule(Node):
         ty_data = self.type_definitions[ty_var]
         return tuple([ty_var] + list(ty_data.constructors))
 
+    def set_hash(self, hash):
+        """Add hash attribute to IRModule without copying the latter.
+
+        Parameters
+        ----------
+        hash : str
+            The hash string.
+
+        Returns
+        -------
+        mod : IRModule
+            The IRModule with the onnx model hash attribute
+        """
+
+        return _ffi_api.Module_SetHash(self, hash)
+
+    def get_hash(self):
+        """Return hash from IRModule attributes if it was stored before
+
+        Returns
+        -------
+        hash : Any
+            The onnx model hash
+        """
+        return _ffi_api.Module_GetHash(self)
+
     @staticmethod
     def from_expr(expr, functions=None, type_defs=None):
         """Construct a module from a standalone expression.

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -218,12 +218,12 @@ class IRModule(Node):
         ty_data = self.type_definitions[ty_var]
         return tuple([ty_var] + list(ty_data.constructors))
 
-    def set_hash(self, hash):
+    def set_hash(self, onnx_model_hash):
         """Add hash attribute to IRModule without copying the latter.
 
         Parameters
         ----------
-        hash : str
+        onnx_model_hash : str
             The hash string.
 
         Returns
@@ -232,14 +232,14 @@ class IRModule(Node):
             The IRModule with the onnx model hash attribute
         """
 
-        return _ffi_api.Module_SetHash(self, hash)
+        return _ffi_api.Module_SetHash(self, onnx_model_hash)
 
     def get_hash(self):
         """Return hash from IRModule attributes if it was stored before
 
         Returns
         -------
-        hash : Any
+        onnx_model_hash : str
             The onnx model hash
         """
         return _ffi_api.Module_GetHash(self)

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -64,10 +64,10 @@ def compile(mod, target=None, target_host=None, params=None):
     compiler = VMCompiler()
     if params:
         compiler.set_params(params)
+    vm_hash = mod.get_hash()
     compiler.lower(mod, target, target_host)
     compiler.codegen()
     vm_exec = compiler.get_exec()
-    vm_hash = mod.get_attr("onnx_model_hash")
     if vm_hash:
         vm_exec.set_hash(vm_hash)
     return vm_exec

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -66,7 +66,11 @@ def compile(mod, target=None, target_host=None, params=None):
         compiler.set_params(params)
     compiler.lower(mod, target, target_host)
     compiler.codegen()
-    return compiler.get_exec()
+    vm_exec = compiler.get_exec()
+    vm_hash = mod.get_attr("onnx_model_hash")
+    if vm_hash:
+        vm_exec.set_hash(vm_hash)
+    return vm_exec
 
 
 class VMCompiler(object):

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -69,7 +69,7 @@ def compile(mod, target=None, target_host=None, params=None):
     compiler.codegen()
     vm_exec = compiler.get_exec()
     if vm_hash:
-        vm_exec.set_hash(vm_hash)
+        vm_exec.hash = vm_hash
     return vm_exec
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -6231,8 +6231,8 @@ def from_onnx(
     if freeze_params:
         mod = relay.transform.DynamicToStatic()(mod)
 
-    if (get_hash):
+    if get_hash:
         onnx_model_hash = hashlib.sha256(model.SerializeToString()).hexdigest()
-        mod.with_attr("onnx_model_hash", onnx_model_hash)
+        mod = mod.set_hash(onnx_model_hash)
 
     return mod, params

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -6123,7 +6123,13 @@ class GraphProto:
 
 
 def from_onnx(
-    model, shape=None, dtype="float32", opset=None, freeze_params=True, convert_config=None, get_hash=False
+    model,
+    shape=None,
+    dtype="float32",
+    opset=None,
+    freeze_params=True,
+    convert_config=None,
+    get_hash=False,
 ):
     """Convert a ONNX model into an equivalent Relay Function.
 

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -163,6 +163,9 @@ class Executable(object):
     def set_hash(self, vm_hash):
         self.hash = vm_hash
 
+    def get_hash(self):
+        return self.hash
+
     def save_hash(self, dir):
         """Save hash of the onnx model in the file with path dir/hash.txt.
 
@@ -174,7 +177,7 @@ class Executable(object):
         """
         hash_path = os.path.join(dir, "hash.txt")
         with open(hash_path, "wb") as fh:
-            fh.write(self.hash)
+            fh.write(self.hash.encode())
 
     @staticmethod
     def load_exec(bytecode, lib):

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -20,6 +20,7 @@ The Relay Virtual Machine runtime.
 
 Implements a Python interface to executing the compiled VM object.
 """
+import os
 import numpy as np
 
 import tvm
@@ -91,6 +92,7 @@ class Executable(object):
         self._get_late_bound_consts = self.mod["get_late_bound_consts"]
         self._load_late_bound_consts = self.mod["load_late_bound_consts"]
         self._load_late_bound_consts_from_map = self.mod["load_late_bound_consts_from_map"]
+        self.hash = ""
 
     def save(self):
         """Save the Relay VM Executable.
@@ -157,6 +159,22 @@ class Executable(object):
             print(res.numpy())
         """
         return self._save(), self._get_lib()
+
+    def set_hash(self, vm_hash):
+        self.hash = vm_hash
+
+    def save_hash(self, dir):
+        """Save hash of the onnx model in the file with path dir/hash.txt.
+
+        Parameters
+        ----------
+
+        dir: str
+            The path to directory where file with hash will be saved
+        """
+        hash_path = os.path.join(dir, "hash.txt")
+        with open(hash_path, "wb") as fh:
+            fh.write(self.hash)
 
     @staticmethod
     def load_exec(bytecode, lib):

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -531,10 +531,9 @@ TVM_REGISTER_GLOBAL("ir.Module_GetAttr").set_body_typed([](IRModule mod, String 
   return mod->GetAttr<ObjectRef>(key);
 });
 
-TVM_REGISTER_GLOBAL("ir.Module_SetHash")
-    .set_body_typed([](IRModule mod, String hash) -> IRModule {
-      return WithAttr(std::move(mod), String(IRMODULE_MODEL_HASH), Downcast<ObjectRef>(hash));
-    });
+TVM_REGISTER_GLOBAL("ir.Module_SetHash").set_body_typed([](IRModule mod, String hash) -> IRModule {
+  return WithAttr(std::move(mod), String(IRMODULE_MODEL_HASH), Downcast<ObjectRef>(hash));
+});
 
 TVM_REGISTER_GLOBAL("ir.Module_GetHash").set_body_typed([](IRModule mod) -> ObjectRef {
   return mod->GetAttr<ObjectRef>(String(IRMODULE_MODEL_HASH));

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -531,6 +531,15 @@ TVM_REGISTER_GLOBAL("ir.Module_GetAttr").set_body_typed([](IRModule mod, String 
   return mod->GetAttr<ObjectRef>(key);
 });
 
+TVM_REGISTER_GLOBAL("ir.Module_SetHash")
+    .set_body_typed([](IRModule mod, String hash) -> IRModule {
+      return WithAttr(std::move(mod), String(IRMODULE_MODEL_HASH), Downcast<ObjectRef>(hash));
+    });
+
+TVM_REGISTER_GLOBAL("ir.Module_GetHash").set_body_typed([](IRModule mod) -> ObjectRef {
+  return mod->GetAttr<ObjectRef>(String(IRMODULE_MODEL_HASH));
+});
+
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
     .set_dispatch<IRModuleNode>([](const ObjectRef& ref, ReprPrinter* p) {
       auto* node = static_cast<const IRModuleNode*>(ref.get());

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -241,6 +241,8 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
       std::string path = args[0];
       exec_->LoadLateBoundConstantsFromFile(path);
     });
+  } else if (name == "get_hash") {
+    return PackedFunc([this](TVMArgs args, TVMRetValue* rv) { *rv = exec_->GetHash(); });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;
     return PackedFunc([sptr_to_self, name](TVMArgs args, TVMRetValue* rv) {});


### PR DESCRIPTION
The main idea is to construct some handshake mechanism which can help to check that TVM executor obtained from pre-compiled libraries and other files is corresponded to given model.

There is a part implementation of the idea. Onnx model is assumed only. Virtual Machine is used only.

The feature is switched on by special argument `get_hash` in `from_onnx` method, it is False by default. The pipeline is the following: 1. hash calculation (sha256 algorithm is used) from onnx model file. 2. Saving it inside VM lib 3. The hash can be extracted from VM lib or write in file by it with other exported files (see below).

One important thing which should be highlighted: we do not know anything about onnx model when VM is compiled. It means we can not directly generate hash from it inside compilation method. Due to this in current implementation the hash is generated on line №1 (see below) and saved in IRModule. After that on line №2 it is saved on VM side. 
Of course, there is another way to workaround this problem. It is to transfer responsibility of the hash generation and setting it to VM on client side, but it looks not friendly and convenient.
There is pipeline of VM compilation and exporting:
```
from tvm import relay
mod, params = relay.frontend.from_onnx(onnx_model, freeze_params=True, get_hash = True) # №1
vm_exec = relay.vm.compile(mod, target)                                                 # №2
code, lib = vm_exec.save()
# Save shared lib file.
tmp = tvm.contrib.utils.tempdir()
path_lib = tmp.relpath("lib.so")
lib.export_library(path_lib)
# Save ro-file
with open(tmp.relpath("code.ro"), "wb") as fo:
    fo.write(code)
# Save weights
vm_exec.move_late_bound_consts(consts_path, byte_limit=256)
# SAVE MODEL HASH in hash.txt file
vm_exec.save_hash(tmp)
```
There are two scenarios how the hash can be gotten:
```
# GET MODEL HASH FROM TXT FILE
hash_path = os.path.join(tmp, "hash.txt")
with open(hash_path, "r") as f:
    hash = f.read()
# Load VM exec.
loaded_lib = tvm.runtime.load_module(path_lib)
loaded_code = bytearray(open(tmp.relpath("code.ro"), "rb").read())
des_exec = tvm.runtime.vm.Executable.load_exec(loaded_code, loaded_lib)
# GET MODEL HASH FROM VM LIB
hash = des_exec.hash

des_vm = tvm.runtime.vm.VirtualMachine(des_exec, dev)
...
```
Procedure of hash calculation:
```
import hashlib
onnx_model_hash = hashlib.sha256(onnx_model.SerializeToString()).hexdigest()
```

Important points which can be developed in the future:
1. It is done for VirtualMachine only. It can be easy extended for GraphExecutor
2. It is assumed that onnx model used for pre-compiled library. It requires more careful and considered approach for extraction of model format independent information (instead of or together with hash) for further check.
3. It looks like TVM design did not initialy assume such feature. Due to this the hash is saved in IRModule which is assumed as immutable. I think if it is developed further, updates in TVM design also should be considered in details.
