### PR TITLE
[Relay][VM] Fix an ICHECK which never fails in ctor of VMFunction

### DIFF
--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -94,7 +94,7 @@ struct VMFunction {
         instructions(std::move(instructions)),
         register_file_size(register_file_size),
         param_device_indexes(std::move(param_device_indexes)) {
-    ICHECK_EQ(params.size(), param_device_indexes.size());
+    ICHECK_EQ(this->params.size(), this->param_device_indexes.size());
   }
 
   VMFunction() = default;


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.

https://github.com/apache/tvm/blob/dff5c975a082e6f15b556914a029541b63ff1280/include/tvm/runtime/vm/vm.h#L97

Since the referenced parameter `params` and `param_device_indexes` is moved in the member initializer list, 
the assertion `ICHECK_EQ(params.size(), param_device_indexes.size())` is equivalent to `ICHECK_EQ(0, 0)` that never fails,
which makes the `ICHECK` meaningless.

PTAL @ganler @junrushao1994  ❤️ 