### PR TITLE
[TIR] Simplify indices in InjectVirtualThread

### DIFF
--- a/src/tir/transforms/inject_virtual_thread.cc
+++ b/src/tir/transforms/inject_virtual_thread.cc
@@ -28,6 +28,7 @@
 
 #include <unordered_set>
 
+#include "../../arith/ir_mutator_with_analyzer.h"
 #include "ir_utils.h"
 
 namespace tvm {
@@ -181,12 +182,16 @@ class VarTouchedAnalysis : public StmtVisitor {
 
 // Inject virtual thread loop
 // rewrite the buffer access pattern when necessary.
-class VTInjector : public StmtExprMutator {
+class VTInjector : public arith::IRMutatorWithAnalyzer {
  public:
+  using IRMutatorWithAnalyzer::VisitExpr_;
+  using IRMutatorWithAnalyzer::VisitStmt_;
+
   // constructor
-  VTInjector(Var var, int num_threads, const std::unordered_set<const VarNode*>& touched_var,
-             bool allow_share)
-      : var_(var),
+  VTInjector(arith::Analyzer* analyzer, Var var, int num_threads,
+             const std::unordered_set<const VarNode*>& touched_var, bool allow_share)
+      : IRMutatorWithAnalyzer(analyzer),
+        var_(var),
         num_threads_(num_threads),
         touched_var_(touched_var),
         allow_share_(allow_share) {}
@@ -212,7 +217,7 @@ class VTInjector : public StmtExprMutator {
     return GetRef<PrimExpr>(op);
   }
   PrimExpr RewriteIndex(PrimExpr index, PrimExpr alloc_extent) const {
-    return index + var_ * alloc_extent;
+    return analyzer_->Simplify(index + var_ * alloc_extent);
   }
   // Expression.
   PrimExpr VisitExpr_(const CallNode* op) final {
@@ -500,8 +505,11 @@ class VTInjector : public StmtExprMutator {
   std::unordered_map<const BufferNode*, Buffer> buf_remap_;
 };
 
-class VirtualThreadInjector : public StmtMutator {
+class VirtualThreadInjector : public arith::IRMutatorWithAnalyzer {
  public:
+  using IRMutatorWithAnalyzer::IRMutatorWithAnalyzer;
+  using IRMutatorWithAnalyzer::VisitStmt_;
+
   Stmt VisitStmt_(const AttrStmtNode* op) final {
     Stmt stmt = StmtMutator::VisitStmt_(op);
     op = stmt.as<AttrStmtNode>();
@@ -511,7 +519,7 @@ class VirtualThreadInjector : public StmtMutator {
       int nthread = static_cast<int>(op->value.as<IntImmNode>()->value);
       VarTouchedAnalysis vs;
       auto touched = vs.TouchedVar(op->body, iv->var.get());
-      VTInjector injector(iv->var, nthread, touched, allow_share);
+      VTInjector injector(analyzer_, iv->var, nthread, touched, allow_share);
       return injector(op->body);
     } else {
       return stmt;
@@ -529,7 +537,11 @@ namespace transform {
 Pass InjectVirtualThread() {
   auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
     auto* n = f.CopyOnWrite();
-    n->body = ConvertSSA(VirtualThreadInjector()(std::move(n->body)));
+
+    arith::Analyzer analyzer;
+
+    n->body = VirtualThreadInjector(&analyzer)(std::move(n->body));
+    n->body = ConvertSSA(std::move(n->body));
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tir.InjectVirtualThread", {});

--- a/tests/python/unittest/test_tir_transform_inject_virtual_thread.py
+++ b/tests/python/unittest/test_tir_transform_inject_virtual_thread.py
@@ -17,6 +17,8 @@
 import tvm
 from tvm import te
 
+from tvm.script import tir as T
+
 vthread_name = tvm.testing.parameter("vthread", "cthread")
 
 
@@ -132,7 +134,62 @@ def test_vthread_if_then_else():
     assert stmt.body.body.body[1].else_case == None
 
 
+def test_vthread_simplified():
+    """Indices resulting from vthread injection should simplified
+
+    This ensures that downstream passes that check for Ramp nodes do
+    not need to each simplify the indices.
+    """
+
+    @T.prim_func
+    def before_func():
+        vthread = T.env_thread("vthread")
+        T.launch_thread(vthread, 4)
+        B = T.allocate([4], "int32", "shared")
+        B[0:4] = T.broadcast(vthread, 4)
+
+    @T.prim_func
+    def expected_func():
+        B = T.allocate([16], "int32", "shared")
+        # The indices for B should each be a single Ramp node, and
+        # should not be the sum of a Ramp and Broadcast node.
+        B[0 * 4 : 0 * 4 + 4] = T.broadcast(0, 4)
+        B[1 * 4 : 1 * 4 + 4] = T.broadcast(1, 4)
+        B[2 * 4 : 2 * 4 + 4] = T.broadcast(2, 4)
+        B[3 * 4 : 3 * 4 + 4] = T.broadcast(3, 4)
+
+    before_mod = tvm.IRModule.from_expr(before_func)
+    after_mod = tvm.tir.transform.InjectVirtualThread()(before_mod)
+    after_func = after_mod["main"]
+
+    tvm.ir.assert_structural_equal(after_func, expected_func)
+
+
+def test_vthread_vectorized():
+    """Use of vthread is compatible with vector allocations"""
+
+    @T.prim_func
+    def before_func():
+        vthread = T.env_thread("vthread")
+        T.launch_thread(vthread, 4)
+        B = T.allocate([4], "int32", "shared")
+        B[0:4] = T.broadcast(vthread, 4)
+
+    @T.prim_func
+    def expected_func():
+        B = T.allocate([4], "int32x4", "shared")
+        B[0 * 4 / 4] = T.broadcast(0, 4)
+        B[1 * 4 / 4] = T.broadcast(1, 4)
+        B[2 * 4 / 4] = T.broadcast(2, 4)
+        B[3 * 4 / 4] = T.broadcast(3, 4)
+
+    before_mod = tvm.IRModule.from_expr(before_func)
+    intermediate_mod = tvm.tir.transform.InjectVirtualThread()(before_mod)
+    after_mod = tvm.tir.transform.StorageRewrite()(intermediate_mod)
+    after_func = after_mod["main"]
+
+    tvm.ir.assert_structural_equal(after_func, expected_func)
+
+
 if __name__ == "__main__":
-    test_vthread_extern()
-    test_vthread()
-    test_vthread_if_then_else()
+    tvm.testing.main()


### PR DESCRIPTION
If the injected index expressions can be simplified to Ramp nodes (e.g. `Ramp(0,1,4)` resulting in `Ramp(vthread*4, 1, 4)` instead of `Ramp(0,1,4) + Broadcast(vthread*4, 4)`), these can be identified as vector access in later passes.  Simplifying at the time of substitution avoids requiring all downstream passes to perform the simplification.