### PR TITLE
[CI] Add setup-pytest-env.sh call to task_demo_microtvm.sh

### DIFF
--- a/tests/scripts/task_demo_microtvm.sh
+++ b/tests/scripts/task_demo_microtvm.sh
@@ -18,6 +18,8 @@
 
 set -euxo pipefail
 
+source tests/scripts/setup-pytest-env.sh
+
 pushd apps/microtvm/cmsisnn
  timeout 5m ./run_demo.sh
 popd


### PR DESCRIPTION
`task_demo_microtvm.sh` fails when running on a container because it can't find TVM. Adding a regular `source ...task_demo_microtvm.sh` will make the proper test environment setup.

cc @Mousius @areusch @driazati for reviews.