### PR TITLE
[UnitTest][TIR] Testing utility for before/after transform tests

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -94,7 +94,6 @@ from tvm.contrib import nvcc, cudnn
 import tvm.contrib.hexagon._ci_env_check as hexagon
 from tvm.driver.tvmc.frontends import load_model
 from tvm.error import TVMError
-from tvm.script import tir as T
 
 
 SKIP_SLOW_TESTS = os.getenv("SKIP_SLOW_TESTS", "").lower() in {"true", "1", "yes"}
@@ -1796,16 +1795,19 @@ class CompareBeforeAfter:
         if isinstance(func, tvm.tir.PrimFunc):
 
             def inner(self):
+                # pylint: disable=unused-argument
                 return func
 
         elif cls._is_method(func):
 
             def inner(self):
+                # pylint: disable=unused-argument
                 return func(self)
 
         else:
 
             def inner(self):
+                # pylint: disable=unused-argument
                 source_code = "@T.prim_func\n" + textwrap.dedent(inspect.getsource(func))
                 return tvm.script.from_source(source_code)
 
@@ -1821,16 +1823,19 @@ class CompareBeforeAfter:
         ):
 
             def inner(self):
+                # pylint: disable=unused-argument
                 return func
 
         elif cls._is_method(func):
 
             def inner(self):
+                # pylint: disable=unused-argument
                 return func(self)
 
         else:
 
             def inner(self):
+                # pylint: disable=unused-argument
                 source_code = "@T.prim_func\n" + textwrap.dedent(inspect.getsource(func))
                 return tvm.script.from_source(source_code)
 
@@ -1844,11 +1849,13 @@ class CompareBeforeAfter:
         if isinstance(transform, tvm.ir.transform.Pass):
 
             def inner(self):
+                # pylint: disable=unused-argument
                 return transform
 
         elif cls._is_method(transform):
 
             def inner(self):
+                # pylint: disable=unused-argument
                 return transform(self)
 
         else:
@@ -1865,6 +1872,8 @@ class CompareBeforeAfter:
         return "self" in sig.parameters
 
     def test_compare(self, before, expected, transform):
+        """Unit test to compare the expected TIR PrimFunc to actual"""
+
         before_mod = tvm.IRModule.from_expr(before)
 
         if inspect.isclass(expected) and issubclass(expected, Exception):
@@ -1877,7 +1886,10 @@ class CompareBeforeAfter:
                 after = after_mod["main"]
                 script = tvm.IRModule({"after": after, "before": before}).script()
                 pytest.fail(
-                    msg=f"Expected {expected.__name__} to be raised from transformation, instead received TIR\n:{script}"
+                    msg=(
+                        f"Expected {expected.__name__} to be raised from transformation, "
+                        f"instead received TIR\n:{script}"
+                    )
                 )
 
         elif isinstance(expected, tvm.tir.PrimFunc):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -75,6 +75,7 @@ import pickle
 import platform
 import shutil
 import sys
+import textwrap
 import time
 
 from pathlib import Path
@@ -93,6 +94,7 @@ from tvm.contrib import nvcc, cudnn
 import tvm.contrib.hexagon._ci_env_check as hexagon
 from tvm.driver.tvmc.frontends import load_model
 from tvm.error import TVMError
+from tvm.script import tir as T
 
 
 SKIP_SLOW_TESTS = os.getenv("SKIP_SLOW_TESTS", "").lower() in {"true", "1", "yes"}
@@ -1707,3 +1709,195 @@ def fetch_model_from_url(
 def main():
     test_file = inspect.getsourcefile(sys._getframe(1))
     sys.exit(pytest.main([test_file] + sys.argv[1:]))
+
+
+class CompareBeforeAfter:
+    """Utility for comparing before/after of TIR transforms
+
+    A standard framework for writing tests that take a TIR PrimFunc as
+    input, apply a transformation, then either compare against an
+    expected output or assert that the transformation raised an error.
+    A test should subclass CompareBeforeAfter, defining class members
+    `before`, `transform`, and `expected`.  CompareBeforeAfter will
+    then use these members to define a test method and test fixture.
+
+    `transform` may be one of the following.
+
+    - An instance of `tvm.ir.transform.Pass`
+
+    - A method that takes no arguments and returns a `tvm.ir.transform.Pass`
+
+    - A pytest fixture that returns a `tvm.ir.transform.Pass`
+
+    `before` may be any one of the following.
+
+    - An instance of `tvm.tir.PrimFunc`.  This is allowed, but is not
+      the preferred method, as any errors in constructing the
+      `PrimFunc` occur while collecting the test, preventing any other
+      tests in the same file from being run.
+
+    - An TVMScript function, without the ``@T.prim_func`` decoration.
+      The ``@T.prim_func`` decoration will be applied when running the
+      test, rather than at module import.
+
+    - A method that takes no arguments and returns a `tvm.tir.PrimFunc`
+
+    - A pytest fixture that returns a `tvm.tir.PrimFunc`
+
+    `expected` may be any one of the following.  The type of
+    `expected` defines the test being performed.  If `expected`
+    provides a `tvm.tir.PrimFunc`, the result of the transformation
+    must match `expected`.  If `expected` is an exception, then the
+    transformation must raise that exception type.
+
+    - Any option supported for `before`.
+
+    - The `Exception` class object, or a class object that inherits
+      from `Exception`.
+
+    - A method that takes no arguments and returns `Exception` or a
+      class object that inherits from `Exception`.
+
+    - A pytest fixture that returns `Exception` or an class object
+      that inherits from `Exception`.
+
+    Examples
+    --------
+
+    .. python::
+
+        class TestRemoveIf(tvm.testing.CompareBeforeAfter):
+            transform = tvm.tir.transform.Simplify()
+
+            def before(A: T.Buffer[1, "int32"]):
+                if True:
+                    A[0] = 42
+                else:
+                    A[0] = 5
+
+            def expected(A: T.Buffer[1, "int32"]):
+                A[0] = 42
+
+    """
+
+    def __init_subclass__(cls):
+        if hasattr(cls, "before"):
+            cls.before = cls._normalize_before(cls.before)
+        if hasattr(cls, "expected"):
+            cls.expected = cls._normalize_expected(cls.expected)
+        if hasattr(cls, "transform"):
+            cls.transform = cls._normalize_transform(cls.transform)
+
+    @classmethod
+    def _normalize_before(cls, func):
+        if hasattr(func, "_pytestfixturefunction"):
+            return func
+
+        if isinstance(func, tvm.tir.PrimFunc):
+
+            def inner(self):
+                return func
+
+        elif cls._is_method(func):
+
+            def inner(self):
+                return func(self)
+
+        else:
+
+            def inner(self):
+                source_code = "@T.prim_func\n" + textwrap.dedent(inspect.getsource(func))
+                return tvm.script.from_source(source_code)
+
+        return pytest.fixture(inner)
+
+    @classmethod
+    def _normalize_expected(cls, func):
+        if hasattr(func, "_pytestfixturefunction"):
+            return func
+
+        if isinstance(func, tvm.tir.PrimFunc) or (
+            inspect.isclass(func) and issubclass(func, Exception)
+        ):
+
+            def inner(self):
+                return func
+
+        elif cls._is_method(func):
+
+            def inner(self):
+                return func(self)
+
+        else:
+
+            def inner(self):
+                source_code = "@T.prim_func\n" + textwrap.dedent(inspect.getsource(func))
+                return tvm.script.from_source(source_code)
+
+        return pytest.fixture(inner)
+
+    @classmethod
+    def _normalize_transform(cls, transform):
+        if hasattr(transform, "_pytestfixturefunction"):
+            return transform
+
+        if isinstance(transform, tvm.ir.transform.Pass):
+
+            def inner(self):
+                return transform
+
+        elif cls._is_method(transform):
+
+            def inner(self):
+                return transform(self)
+
+        else:
+
+            raise TypeError(
+                "Expected transform to be a tvm.ir.transform.Pass, or a method returning a Pass"
+            )
+
+        return pytest.fixture(inner)
+
+    @staticmethod
+    def _is_method(func):
+        sig = inspect.signature(func)
+        return "self" in sig.parameters
+
+    def test_compare(self, before, expected, transform):
+        before_mod = tvm.IRModule.from_expr(before)
+
+        if inspect.isclass(expected) and issubclass(expected, Exception):
+            with pytest.raises(expected):
+                after_mod = transform(before_mod)
+
+                # This portion through pytest.fail isn't strictly
+                # necessary, but gives a better error message that
+                # includes the before/after.
+                after = after_mod["main"]
+                script = tvm.IRModule({"after": after, "before": before}).script()
+                pytest.fail(
+                    msg=f"Expected {expected.__name__} to be raised from transformation, instead received TIR\n:{script}"
+                )
+
+        elif isinstance(expected, tvm.tir.PrimFunc):
+            after_mod = transform(before_mod)
+            after = after_mod["main"]
+
+            try:
+                tvm.ir.assert_structural_equal(after, expected)
+            except ValueError as err:
+                script = tvm.IRModule(
+                    {"expected": expected, "after": after, "before": before}
+                ).script()
+                raise ValueError(
+                    f"TIR after transformation did not match expected:\n{script}"
+                ) from err
+
+        else:
+            raise TypeError(
+                f"tvm.testing.CompareBeforeAfter requires the `expected` fixture "
+                f"to return either `Exception`, an `Exception` subclass, "
+                f"or an instance of `tvm.tir.PrimFunc`.  "
+                f"Instead, received {type(exception)}."
+            )

--- a/tests/python/unittest/test_tvm_testing_before_after.py
+++ b/tests/python/unittest/test_tvm_testing_before_after.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import tvm
+import tvm.testing
+from tvm.script import tir as T
+
+
+class BaseBeforeAfter(tvm.testing.CompareBeforeAfter):
+    def transform(self):
+        return lambda x: x
+
+
+class TestBeforeAfterPrimFunc(BaseBeforeAfter):
+    @T.prim_func
+    def before():
+        T.evaluate(0)
+
+    expected = before
+
+
+class TestBeforeAfterMethod(BaseBeforeAfter):
+    def before(self):
+        @T.prim_func
+        def func():
+            T.evaluate(0)
+
+        return func
+
+    expected = before
+
+
+class TestBeforeAfterFixture(BaseBeforeAfter):
+    @tvm.testing.fixture
+    def before(self):
+        @T.prim_func
+        def func():
+            T.evaluate(0)
+
+        return func
+
+    expected = before
+
+
+class TestBeforeAfterDelayedPrimFunc(BaseBeforeAfter):
+    def before():
+        T.evaluate(0)
+
+    expected = before
+
+
+class TestBeforeAfterParametrizedFixture(BaseBeforeAfter):
+    n = tvm.testing.parameter(1, 8, 16)
+
+    @tvm.testing.fixture
+    def before(self, n):
+        @T.prim_func
+        def func(A: T.Buffer[n, "float32"]):
+            for i in T.serial(n):
+                A[i] = 0.0
+
+        return func
+
+    expected = before
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR adds `tvm.testing.CompareBeforeAfter`, a generalization of the `BaseBeforeAfter` utility previously used in `test_tir_transform_simplify.py`, which performs unit tests that perform a transformation on a TIR function and compare the results to an expected TIR output.  This arose when minimizing the boilerplate required for unit tests in the implementation of https://github.com/apache/tvm/issues/12261.