### PR TITLE
[TIR] Add tir::builtin::undef

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -729,6 +729,14 @@ TVM_DLL const Op& mem_copy();
  */
 TVM_DLL const Op& assume();
 
+/*!
+ * \brief Returns an initialized but arbitrary value
+ *
+ * Compile-time representation of memory locations whose values may be
+ * altered as a result of optimizations.
+ */
+TVM_DLL const Op& undef();
+
 /*! \brief The kind of structure field info used in intrinsic */
 enum TVMStructFieldKind : int {
   // array head address

--- a/python/tvm/tir/transform/transform.py
+++ b/python/tvm/tir/transform/transform.py
@@ -264,6 +264,17 @@ def RemoveAssume():
     return _ffi_api.RemoveAssume()  # type: ignore
 
 
+def RemoveStoreUndef():
+    """Remove stores of undefined values from the Stmt.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.RemoveStoreUndef()  # type: ignore
+
+
 def BF16Legalize():
     """Legalize bf16 typed Ops.
     Runs BF16Promote, BF16CastElimination and BF16TypeLowering

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -292,6 +292,10 @@ TIR_DEFINE_BUILTIN_FUNC(assume)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kEmbedInfo))
     .set_num_inputs(1);
 
+TIR_DEFINE_BUILTIN_FUNC(undef)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kReadState))
+    .set_num_inputs(0);
+
 }  // namespace builtin
 }  // namespace tir
 }  // namespace tvm

--- a/src/tir/transforms/remove_store_undef.cc
+++ b/src/tir/transforms/remove_store_undef.cc
@@ -144,34 +144,34 @@ class ContainsUndefChecker : public StmtExprVisitor {
 };
 
 namespace transform {
-  Pass RemoveStoreUndefInternal() {
-    auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
-      auto* n = f.CopyOnWrite();
-      n->body = StoreUndefRemover::Apply(std::move(n->body));
-      return f;
-    };
-    return CreatePrimFuncPass(pass_func, 0, "tir.RemoveStoreUndefInternal", {});
-  }
+Pass RemoveStoreUndefInternal() {
+  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+    auto* n = f.CopyOnWrite();
+    n->body = StoreUndefRemover::Apply(std::move(n->body));
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.RemoveStoreUndefInternal", {});
+}
 
-  Pass ValidateAllUndefRemoved() {
-    auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
-      bool contains_undef = ContainsUndefChecker::Check(f->body);
-      ICHECK(!contains_undef) << "Expected removal of BufferStore containing builtin::undef() "
-                              << "to remove all instances of builtin::undef().  "
-                              << "Instead, result was"
-                              << "\n"
-                              << f;
-      return f;
-    };
-    return CreatePrimFuncPass(pass_func, 0, "tir.ValidateAllUndefRemoved", {});
-  }
+Pass ValidateAllUndefRemoved() {
+  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+    bool contains_undef = ContainsUndefChecker::Check(f->body);
+    ICHECK(!contains_undef) << "Expected removal of BufferStore containing builtin::undef() "
+                            << "to remove all instances of builtin::undef().  "
+                            << "Instead, result was"
+                            << "\n"
+                            << f;
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.ValidateAllUndefRemoved", {});
+}
 
-  Pass RemoveStoreUndef() {
-    return Sequential({RemoveStoreUndefInternal(), RemoveNoOp(), ValidateAllUndefRemoved()},
-                      "tir.RemoveStoreUndef");
-  }
+Pass RemoveStoreUndef() {
+  return Sequential({RemoveStoreUndefInternal(), RemoveNoOp(), ValidateAllUndefRemoved()},
+                    "tir.RemoveStoreUndef");
+}
 
-  TVM_REGISTER_GLOBAL("tir.transform.RemoveStoreUndef").set_body_typed(RemoveStoreUndef);
+TVM_REGISTER_GLOBAL("tir.transform.RemoveStoreUndef").set_body_typed(RemoveStoreUndef);
 
 }  // namespace transform
 

--- a/src/tir/transforms/remove_store_undef.cc
+++ b/src/tir/transforms/remove_store_undef.cc
@@ -49,6 +49,9 @@ class StoreUndefLocator : public StmtExprVisitor {
     StmtExprVisitor::VisitExpr(op->value);
     std::swap(has_undef_, stash_undef);
     if (stash_undef) {
+      ICHECK(SideEffect(op->value) <= CallEffectKind::kReadState)
+          << "Error: T.undef() used in BufferStore expressions "
+          << "must not have other side effects";
       undef_stores_.insert(op);
     }
   }
@@ -66,6 +69,9 @@ class StoreUndefLocator : public StmtExprVisitor {
     StmtExprVisitor::VisitExpr(op->value);
     std::swap(has_undef_, stash_undef);
     if (stash_undef) {
+      ICHECK(SideEffect(op->value) <= CallEffectKind::kReadState)
+          << "Error: T.undef() used in Let expressions "
+          << "must not have other side effects";
       var_bindings_with_undef_.insert(op->var.get());
     }
 

--- a/src/tir/transforms/remove_store_undef.cc
+++ b/src/tir/transforms/remove_store_undef.cc
@@ -103,7 +103,8 @@ class StoreUndefRemover : public StmtExprMutator {
  private:
   using Parent = StmtExprMutator;
 
-  StoreUndefRemover(std::unordered_set<const BufferStoreNode*> to_remove) : to_remove_(to_remove) {}
+  explicit StoreUndefRemover(std::unordered_set<const BufferStoreNode*> to_remove)
+      : to_remove_(to_remove) {}
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {
     if (to_remove_.count(op)) {

--- a/src/tir/transforms/remove_store_undef.cc
+++ b/src/tir/transforms/remove_store_undef.cc
@@ -96,14 +96,14 @@ class StoreUndefRemover : public StmtExprMutator {
  public:
   static Stmt Apply(Stmt stmt) {
     auto to_remove = StoreUndefLocator::Locate(stmt);
-    StoreUndefRemover mutator(std::move(to_remove));
+    StoreUndefRemover mutator(to_remove);
     return mutator(std::move(stmt));
   }
 
  private:
   using Parent = StmtExprMutator;
 
-  explicit StoreUndefRemover(std::unordered_set<const BufferStoreNode*> to_remove)
+  explicit StoreUndefRemover(const std::unordered_set<const BufferStoreNode*>& to_remove)
       : to_remove_(to_remove) {}
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {
@@ -114,7 +114,7 @@ class StoreUndefRemover : public StmtExprMutator {
     }
   }
 
-  std::unordered_set<const BufferStoreNode*> to_remove_;
+  const std::unordered_set<const BufferStoreNode*>& to_remove_;
 };
 
 // Remove any BufferStores whose value depends on T.undef

--- a/src/tir/transforms/remove_store_undef.cc
+++ b/src/tir/transforms/remove_store_undef.cc
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file remove_store_undef.cc
+ * \brief Remove stores of tir::builtin::undef
+ */
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+namespace tvm {
+namespace tir {
+
+// Remove any BufferStores whose value depends on T.undef
+class StoreUndefRemover : public StmtExprMutator {
+ public:
+  static Stmt Apply(Stmt stmt) {
+    StoreUndefRemover visitor;
+    return visitor(std::move(stmt));
+  }
+
+ private:
+  using Parent = StmtExprMutator;
+  using Parent::Parent;
+  using Parent::VisitStmt;
+  using Parent::VisitStmt_;
+
+  Stmt VisitStmt_(const BufferStoreNode* op) final {
+    has_undef = false;
+    Parent::VisitExpr(op->value);
+    if (has_undef) {
+      return Evaluate(0);
+    } else {
+      return GetRef<Stmt>(op);
+    }
+  }
+
+  PrimExpr VisitExpr_(const CallNode* op) final {
+    if (op->op.same_as(builtin::undef())) {
+      has_undef = true;
+    }
+    return GetRef<PrimExpr>(op);
+  }
+
+  bool has_undef{false};
+};
+
+namespace transform {
+
+Pass RemoveStoreUndef() {
+  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+    auto* n = f.CopyOnWrite();
+    n->body = StoreUndefRemover::Apply(std::move(n->body));
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.RemoveStoreUndef", {});
+}
+
+TVM_REGISTER_GLOBAL("tir.transform.RemoveStoreUndef").set_body_typed(RemoveStoreUndef);
+
+}  // namespace transform
+
+}  // namespace tir
+}  // namespace tvm

--- a/tests/python/unittest/test_tir_transform_remove_undef.py
+++ b/tests/python/unittest/test_tir_transform_remove_undef.py
@@ -55,5 +55,16 @@ class TestKeepOtherCallNodes(BaseBeforeAfter):
     expected = before
 
 
+class TestRemoveStoreUndef(BaseBeforeAfter):
+    """Remove a store a store whose value is bound to T.undef()"""
+
+    def before(A: T.Buffer[1, "int32"]):
+        val = T.undef(dtype="int32")
+        A[0] = val
+
+    def expected(A: T.Buffer[1, "int32"]):
+        T.evaluate(0)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_remove_undef.py
+++ b/tests/python/unittest/test_tir_transform_remove_undef.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm.script import tir as T
+
+
+class BaseBeforeAfter(tvm.testing.CompareBeforeAfter):
+    @tvm.testing.fixture
+    def transform(self):
+        return tvm.tir.transform.RemoveStoreUndef()
+
+
+class TestRemoveStoreUndef(BaseBeforeAfter):
+    """Remove a store whose value is T.undef()"""
+
+    def before(A: T.Buffer[1, "int32"]):
+        A[0] = T.undef(dtype="int32")
+
+    def expected(A: T.Buffer[1, "int32"]):
+        T.evaluate(0)
+
+
+class TestRemoveStoreUndefExpression(BaseBeforeAfter):
+    """Expressions containing T.undef() are removed"""
+
+    def before(A: T.Buffer[1, "int32"]):
+        A[0] = 1 + T.undef(dtype="int32")
+
+    def expected(A: T.Buffer[1, "int32"]):
+        T.evaluate(0)
+
+
+class TestKeepOtherCallNodes(BaseBeforeAfter):
+    """Expressions containing other CallNodes are not removed"""
+
+    def before(A: T.Buffer[1, "int32"], n: T.int32):
+        A[0] = T.shift_left(n, 1, dtype="int32")
+
+    expected = before
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR introduces `tir::builtin::undef`, which is used to represent values that are an arbitrary value of a known datatype, along with a transformation to remove instances of `tir::builtin::undef`.

This PR is part of the handling of padded buffer layout transformations ([tracking issue](https://github.com/apache/tvm/issues/12261), [rfc](https://github.com/apache/tvm-rfcs/pull/77)).