### PR TITLE
Hide registration errors in `test_myfloat`

### DIFF
--- a/tests/python/unittest/test_custom_datatypes.py
+++ b/tests/python/unittest/test_custom_datatypes.py
@@ -513,7 +513,12 @@ def run_batchnorm(src_dtype, dst_dtype, rtol=1e-6, atol=1e-6):
 
 
 def test_myfloat():
-    setup_myfloat()
+    try:
+        setup_myfloat()
+    except tvm._ffi.base.TVMError as e:
+        if "float is already registered" not in str(e):
+            # Ignore this specific error which can happen if this test runs twice within the same process
+            raise e
     run_ops("float32", "custom[myfloat]32", rtol=1e-6, atol=1e-6)
     run_conv2d("float32", "custom[myfloat]32", rtol=1e-6, atol=1e-6)
     run_batchnorm("float32", "custom[myfloat]32", rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
This should fix the error from #11580, the test will still get run but
the registration failing will be ignored if it happens