### PR TITLE
[MetaSchedule][Minor] Fix Median Number

### DIFF
--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -357,7 +357,7 @@ inline double GetRunMsMedian(const RunnerResult& runner_result) {
   std::sort(v.begin(), v.end());
   int n = v.size();
   if (n % 2 == 0) {
-    return (v[n / 2] + v[n / 2 + 1]) * 0.5 * 1000.0;
+    return (v[n / 2 - 1] + v[n / 2]) * 0.5 * 1000.0;
   } else {
     return v[n / 2] * 1000.0;
   }


### PR DESCRIPTION
The previous median number calculation util function used the wrong index which could cause out of bound issue as mentioned in #12199 . This PR fixed this issue.

CC @junrushao1994 