### PR TITLE
[TIR][CUDA] Fix sub-warp reduction using "max"

### DIFF
--- a/tests/python/unittest/test_subwarp_reduction_cuda.py
+++ b/tests/python/unittest/test_subwarp_reduction_cuda.py
@@ -84,7 +84,7 @@ def test_cuda_subwarp_reduction():
         f = tvm.build(sch.mod["main"], target="cuda")
 
         # prepare input and output array
-        a_np = np.random.randn(1, d1, d2, d3).astype("float32")
+        a_np = -np.random.rand(1, d1, d2, d3).astype("float32")
         b_np = a_np.max(axis=-1).astype("float32")
         a = tvm.nd.array(a_np, tvm.cuda(0))
         b = tvm.nd.array(np.zeros_like(b_np), tvm.cuda(0))

--- a/tests/python/unittest/test_subwarp_reduction_cuda.py
+++ b/tests/python/unittest/test_subwarp_reduction_cuda.py
@@ -36,7 +36,7 @@ def reduce(a: T.handle, b: T.handle, d1: T.int32, d2: T.int32, d3: T.int32) -> N
 @tvm.testing.requires_gpu
 @tvm.testing.requires_cuda
 def test_cuda_subwarp_reduction():
-    def check(d1: int, d2: int, d3: int):
+    def check_sum(d1: int, d2: int, d3: int):
         _, _, _d1, _d2, _d3 = reduce.params
         mod = reduce.specialize({_d1: d1, _d2: d2, _d3: d3})
         sch = tvm.tir.Schedule(mod)
@@ -58,10 +58,33 @@ def test_cuda_subwarp_reduction():
         f(a, b)
         tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
 
+    def check_max(d1: int, d2: int, d3: int):
+        _, _, _d1, _d2, _d3 = reduce.params
+        mod = reduce.specialize({_d1: d1, _d2: d2, _d3: d3})
+        sch = tvm.tir.Schedule(mod)
+        blk = sch.get_block("reduce")
+        i, j, k, l = sch.get_loops(blk)
+        sch.bind(i, "blockIdx.x")
+        sch.bind(j, "threadIdx.z")
+        sch.bind(k, "threadIdx.y")
+        sch.bind(l, "threadIdx.x")
+        f = tvm.build(sch.mod["main"], target="cuda")
+
+        # prepare input and output array
+        a_np = np.random.randn(1, d1, d2, d3).astype("float32")
+        b_np = a_np.max(axis=-1).astype("float32")
+        a = tvm.nd.array(a_np, tvm.cuda(0))
+        b = tvm.nd.array(np.zeros_like(b_np), tvm.cuda(0))
+
+        # launch kernel
+        f(a, b)
+        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+
     for d1 in range(1, 5):
         for d2 in range(1, 5):
             for d3 in range(2, 33):
-                check(d1, d2, d3)
+                check_sum(d1, d2, d3)
+                check_max(d1, d2, d3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR proposes a fix to #12274 by adding a single range check statement in sub-warp reduction.

### Before
```cuda
extern "C" __global__ void __launch_bounds__(11) default_function_kernel0(float* __restrict__ A, float* __restrict__ B) {
  float red_buf0[1];
  uint mask[1];
  float t0[1];
  red_buf0[0] = A[((((int)blockIdx.x) * 11) + ((int)threadIdx.x))];
  mask[0] = __activemask();
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 8, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 4, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 2, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 1, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  red_buf0[0] = __shfl_sync(mask[0], red_buf0[0], 0, 32);
  B[((int)blockIdx.x)] = red_buf0[0];
}
```

### After
```cuda
extern "C" __global__ void __launch_bounds__(11) default_function_kernel0(float* __restrict__ A, float* __restrict__ B) {
  float red_buf0[1];
  uint mask[1];
  float t0[1];
  red_buf0[0] = A[((((int)blockIdx.x) * 11) + ((int)threadIdx.x))];
  mask[0] = __activemask();
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 8, 32);
  if (((int)threadIdx.x) < 3) {
    red_buf0[0] = max(red_buf0[0], t0[0]);
  }
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 4, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 2, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  t0[0] = __shfl_down_sync(mask[0], red_buf0[0], 1, 32);
  red_buf0[0] = max(red_buf0[0], t0[0]);
  red_buf0[0] = __shfl_sync(mask[0], red_buf0[0], 0, 32);
  B[((int)blockIdx.x)] = red_buf0[0];
}
```

### Analysis

We cannot put `__shfl_down_sync` in the if-then-else case, but we can decide whether the returned value is used.

Only the first shuffle call needs range check considering the procedure. (the "dirty" values will not affect thread 0). Therefore, this fix only brings little performance overhead.


In addiction, there is no need to check when performing the full warp reduce.

An additional unit test for `max` reduction is also added to `tests/python/unittest/test_subwarp_reduction_cuda.py`.


cc @vinx13 @junrushao1994  @yzh119 


