### PR TITLE
Revert "[CI] Fix build android rpc failure in CI"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,7 @@ jobs:
         working-directory: apps/android_rpc
         continue-on-error: true
         run: |
-          set -eux
-          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_HOME}:$PATH"
           gradle clean build
       - name: Upload android_rpc APK
         uses: actions/upload-artifact@v2
@@ -136,8 +135,7 @@ jobs:
         working-directory: apps/android_deploy
         continue-on-error: true
         run: |
-          set -eux
-          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_HOME}:$PATH"
           gradle clean build
       - name: Upload android_deploy APK
         uses: actions/upload-artifact@v2
@@ -149,9 +147,8 @@ jobs:
         working-directory: apps/android_camera
         continue-on-error: true
         run: |
-          set -eux
           mkdir -p app/src/main/assets/models/
-          export TVM_NDK_CC=${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
+          export TVM_NDK_CC=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
           export TVM_HOME=~/work/tvm/tvm
           export PYTHONPATH=$TVM_HOME/python:${PYTHONPATH}
           python3 ${TVM_HOME}/python/gen_requirements.py
@@ -160,7 +157,7 @@ jobs:
           pip3 install -r requirements.txt
           python3 prepare_model.py
           cd ..
-          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_HOME}:$PATH"
           gradle clean build
       - name: Upload android_camera APK
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,47 +121,44 @@ jobs:
           make jvmpkg
       - name: Build android_rpc
         working-directory: apps/android_rpc
-        continue-on-error: true
         run: |
-          export PATH="${ANDROID_NDK_HOME}:$PATH"
+          set -eux
+          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_rpc APK
         uses: actions/upload-artifact@v2
-        continue-on-error: true
         with:
           name: android_rpc-debug.apk
           path: ./apps/android_rpc/app/build/outputs/apk/debug/app-debug.apk
       - name: Build android_deploy
         working-directory: apps/android_deploy
-        continue-on-error: true
         run: |
-          export PATH="${ANDROID_NDK_HOME}:$PATH"
+          set -eux
+          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_deploy APK
         uses: actions/upload-artifact@v2
-        continue-on-error: true
         with:
           name: android_deploy-debug.apk
           path: ./apps/android_deploy/app/build/outputs/apk/debug/app-debug.apk
       - name: Build android_camera
         working-directory: apps/android_camera
-        continue-on-error: true
         run: |
-          mkdir -p app/src/main/assets/models/
-          export TVM_NDK_CC=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
           export TVM_HOME=~/work/tvm/tvm
           export PYTHONPATH=$TVM_HOME/python:${PYTHONPATH}
+          set -eux
+          mkdir -p app/src/main/assets/models/
+          export TVM_NDK_CC=${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
           python3 ${TVM_HOME}/python/gen_requirements.py
           pip3 install -r ${TVM_HOME}/python/requirements/core.txt
           cd models
           pip3 install -r requirements.txt
           python3 prepare_model.py
           cd ..
-          export PATH="${ANDROID_NDK_HOME}:$PATH"
+          export PATH="${ANDROID_NDK_LATEST_HOME}:$PATH"
           gradle clean build
       - name: Upload android_camera APK
         uses: actions/upload-artifact@v2
-        continue-on-error: true
         with:
           name: android_camera-debug.apk
           path: ./apps/android_camera/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Reverts apache/tvm#12216

Addition to my previous changes.
After the previous changes, the android camera build failed because by default `PYTHONPATH` is empty, and after `set -eux` it is fails:
https://github.com/apache/tvm/blob/759a648cd5237885a8205b1ee4508dabcc3af2d5/.github/workflows/main.yml#L152-L156

This error was not noticed because the flag `continue-on-error` is true.


cc @Mousius @areusch @driazati