### PR TITLE
[Docker] Update onnxoptimizer to 0.2.7

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -29,7 +29,7 @@ set -o pipefail
 pip3 install \
     onnx==1.10.2 \
     onnxruntime==1.9.0 \
-    onnxoptimizer==0.2.6
+    onnxoptimizer==0.2.7
 
 # torch depends on a number of other packages, but unhelpfully, does
 # not expose that in the wheel!!!


### PR DESCRIPTION
This pr updates onnxoptimizer to 0.2.7 to support AArch64.

We need this pr because we want to enable ONNX tests on AArch64, but the current version of onnxoptimizer does not support AArch64.
