### PR TITLE
[Test]fix type bug about topi unitest

### DIFF
--- a/tests/python/topi/python/test_topi_image.py
+++ b/tests/python/topi/python/test_topi_image.py
@@ -339,7 +339,7 @@ def test_grid_sample():
 
 
 if __name__ == "__main__":
-    test_resize()
+    test_resize2d()
     test_resize3d()
     test_crop_and_resize()
     test_affine_grid()


### PR DESCRIPTION
This PR aim to fix the naming bug caused by #8346. In #8346, `test_resize()` was changed to `test_resize2d()`, but it forgot to change the function name in main block. Just fix it. 