### PR TITLE
[QNN] Add qnn op for abs to fix wrong scale on quantize

### DIFF
--- a/python/tvm/relay/qnn/op/__init__.py
+++ b/python/tvm/relay/qnn/op/__init__.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=wildcard-import
+# pylint: disable=wildcard-import, redefined-builtin
+
 """QNN dialect related operators."""
 from __future__ import absolute_import as _abs
 from .qnn import *

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -32,6 +32,8 @@ from .. import op as reg
 #################################################
 
 # Registering QNN Conv2D legalization function.
+
+
 @reg.register_qnn_legalize("qnn.conv2d")
 def legalize_qnn_conv2d(attrs, inputs, types):
     return qnn_conv2d_legalize(attrs, inputs, types)
@@ -81,6 +83,7 @@ register_qnn_unary_op_legalize("qnn.sigmoid", lambda arr: 1 / (1 + np.exp(-arr))
 register_qnn_unary_op_legalize("qnn.hardswish", hardswish_func)
 register_qnn_unary_op_legalize("qnn.tanh", np.tanh)
 register_qnn_unary_op_legalize("qnn.log", np.log)
+register_qnn_unary_op_legalize("qnn.abs", np.abs)
 
 
 # Default to None. If overridden by target, this will not be run.

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -963,6 +963,9 @@ def erf(x, scale, zero_point, output_scale, output_zero_point):
     )
 
 
+# pylint: disable=redefined-builtin
+
+
 def abs(x, scale, zero_point, output_scale, output_zero_point):
     """Quantized abs function.
 

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -963,6 +963,41 @@ def erf(x, scale, zero_point, output_scale, output_zero_point):
     )
 
 
+def abs(x, scale, zero_point, output_scale, output_zero_point):
+    """Quantized abs function.
+
+    Parameters
+    ----------
+    x : relay.Expr
+        The quantized input tensor.
+
+    scale: relay.Expr
+        The scale of the quantized expr.
+
+    zero_point: relay.Expr
+       The zero point of quantized expr.
+
+    output_scale: relay.Expr
+        The scale of the output quantized expr.
+
+    output_zero_point: relay.Expr
+       The zero point of output quantized expr.
+
+    Returns
+    -------
+    result : relay.Expr
+        The computed result.
+
+    """
+    return _make.abs(
+        x,
+        scale,
+        zero_point,
+        output_scale,
+        output_zero_point,
+    )
+
+
 def sigmoid(x, scale, zero_point, output_scale, output_zero_point):
     """Quantized sigmoid.
 

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -109,20 +109,6 @@ register_unary_identity("min")
 register_unary_identity("image.resize2d")
 
 
-@register_fake_quantization_to_integer("abs")
-def abs_(expr, type_map):
-    """Rewrite an abs op"""
-    assert len(expr.args) == 1
-    arg = expr.args[0]
-    t = type_map[arg]
-
-    min_value = relay.const(np.iinfo(t.dtype).min, t.dtype)
-    one = relay.const(1, t.dtype)
-    out = relay.op.where(relay.op.equal(min_value, arg), arg + one, arg)
-    out = relay.op.abs(out)
-    return [out, t]
-
-
 @register_fake_quantization_to_integer("nn.adaptive_avg_pool1d")
 def adaptive_avgpool1d(expr, type_map):
     """Rewrite an adaptive avgpool op"""
@@ -379,11 +365,11 @@ def pad(expr, type_map):
     arg = expr.args[0]
     t = type_map[arg]
     pad_value = expr.args[1]
-    ## TF2ONNX will sometimes implement the pad_value as a constant without a quantize
-    ## To support that, the pass lets branches that terminate in a constant through
+    # TF2ONNX will sometimes implement the pad_value as a constant without a quantize
+    # To support that, the pass lets branches that terminate in a constant through
     if pad_value in type_map:
-        ## if the pad value is calcuated from a dequantize op, it should be in the type map
-        ## and we need to make sure it's affine type matches the arg
+        # if the pad value is calcuated from a dequantize op, it should be in the type map
+        # and we need to make sure it's affine type matches the arg
         pad_t = type_map[pad_value]
         if not tvm.ir.structural_equal(t, pad_t):
             pad_value = relay.qnn.op.requantize(
@@ -396,7 +382,7 @@ def pad(expr, type_map):
                 axis=pad_t.axis,
             )
     else:
-        ## If the pad-value is a constant, we need to quantize it
+        # If the pad-value is a constant, we need to quantize it
         assert isinstance(pad_value, relay.expr.Constant)
         pad_value = relay.qnn.op.quantize(pad_value, t.scale, t.zero_point)
 
@@ -418,7 +404,7 @@ def mean(expr, type_map):
 
 def get_binary_types(expr, type_map):
     """Get Affine types of a binary op's inputs and unify them"""
-    ##Support the case where one input is quantized and the other is a constant float
+    # Support the case where one input is quantized and the other is a constant float
     left = expr.args[0]
     right = expr.args[1]
     left_t = None
@@ -544,4 +530,5 @@ register_unary_qnn("erf", relay.qnn.op.erf)
 register_unary_qnn("sigmoid", relay.qnn.op.sigmoid)
 register_unary_qnn("hardswish", relay.qnn.op.hardswish)
 register_unary_qnn("tanh", relay.qnn.op.tanh)
+register_unary_qnn("abs", relay.qnn.op.abs)
 register_unary_qnn("log", relay.qnn.op.log)

--- a/src/relay/qnn/op/unary_elementwise_op.cc
+++ b/src/relay/qnn/op/unary_elementwise_op.cc
@@ -53,6 +53,9 @@ QNN_CREATE_UNARY_ELEMENTWISE_OP("hardswish")
 QNN_CREATE_UNARY_ELEMENTWISE_OP("log").set_attr<FTVMLegalize>(
     "FTVMQnnCanonicalize", QNN_UNARY_OP_DEFAULT_CANONICALIZATION(Log));
 
+QNN_CREATE_UNARY_ELEMENTWISE_OP("abs").set_attr<FTVMLegalize>(
+    "FTVMQnnCanonicalize", QNN_UNARY_OP_DEFAULT_CANONICALIZATION(Abs));
+
 }  // namespace qnn
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/transforms/pattern_utils.h
+++ b/src/relay/transforms/pattern_utils.h
@@ -562,6 +562,11 @@ inline Expr Tanh(Expr e) {
   static const Op& op = Op::Get("tanh");
   return Call(op, {e});
 }
+
+inline Expr Abs(Expr e) {
+  static const Op& op = Op::Get("abs");
+  return Call(op, {e});
+}
 /*!
  * \brief Get an immediate scalar from a Constant expr.
  *

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -403,25 +403,6 @@ def test_fake_quantize_abs():
     compare_fq_to_int(op, [x_np])
 
 
-def test_fake_quantize_abs_qnn():
-    x = relay.var("x", shape=[1, 960, 512, 64], dtype="int8")
-
-    zero = 0
-    x = relay.qnn.op.dequantize(x, relay.const(6.4712), relay.const(119))
-    op = relay.op.abs(x)
-    op = relay.qnn.op.requantize(
-        op,
-        relay.const(6.4712),
-        relay.const(119),
-        output_scale=relay.const(3.46196),
-        output_zero_point=relay.const(0),
-        out_dtype="uint8",
-    )
-
-    x_np = np.random.randint(0 + zero, 255 + zero, size=[1, 960, 512, 64], dtype="uint8")
-    compare_fq_to_int(op, [x_np])
-
-
 def test_fake_quantize_expand_dims():
     x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
 

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -403,6 +403,25 @@ def test_fake_quantize_abs():
     compare_fq_to_int(op, [x_np])
 
 
+def test_fake_quantize_abs_qnn():
+    x = relay.var("x", shape=[1, 960, 512, 64], dtype="int8")
+
+    zero = 0
+    x = relay.qnn.op.dequantize(x, relay.const(6.4712), relay.const(119))
+    op = relay.op.abs(x)
+    op = relay.qnn.op.requantize(
+        op,
+        relay.const(6.4712),
+        relay.const(119),
+        output_scale=relay.const(3.46196),
+        output_zero_point=relay.const(0),
+        out_dtype="uint8",
+    )
+
+    x_np = np.random.randint(0 + zero, 255 + zero, size=[1, 960, 512, 64], dtype="uint8")
+    compare_fq_to_int(op, [x_np])
+
+
 def test_fake_quantize_expand_dims():
     x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
 


### PR DESCRIPTION
Prior implementation caused the FQI pass to produce the following graph when `abs` was used:

```
  %14 = qnn.dequantize(%13, 6.4712f /* ty=float32 */, 119 /* ty=int32 */, axis=1) /* ty=Tensor[(1, 960, 512, 64), float32] */;
  %15 = abs(%14) /* ty=Tensor[(1, 960, 512, 64), float32] */;
  %16 = qnn.quantize(%15, 3.46196f /* ty=float32 */, 0 /* ty=int32 */, out_dtype="uint8", axis=1) /* ty=Tensor[(1, 960, 512, 64), uint8] */;
```
It seems that the output scale and zero point are different from the input scale and zero point. So, we doubled the precision. 

By adding a qnn op for `abs` we manage requantize on the right values.

```
 def @main(%x: Tensor[(1, 960, 512, 64), int8] /* ty=Tensor[(1, 960, 512, 64), int8] */) -> Tensor[(1, 960, 512, 64), int8] {
  %0 = qnn.abs(%x, 6.4712f /* ty=float32 */, 119 /* ty=int32 */, 6.4712f /* ty=float32 */, 0 /* ty=int32 */) /* ty=Tensor[(1, 960, 512, 64), int8] */;
  qnn.requantize(%0, 6.4712f /* ty=float32 */, 119 /* ty=int32 */, 3.46196f /* ty=float32 */, 0 /* ty=int32 */, out_dtype="int8") /* ty=Tensor[(1, 960, 512, 64), int8] */
}
```

@sfvaroglu @mbrookhart @AndrewZhaoLuo @anwang2009 
