### PR TITLE
[ci][tvmbot] Enable re-run for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,12 @@ concurrency:
 
 jobs:
   MacOS:
-    if: ${{ github.repository == 'apache/tvm' }}
-    runs-on: macOS-latest
+    if: ${{ github.repository == 'driazati/tvm' }}
+    runs-on: ubuntu-latest
     steps:
+      - name: Start
+        run: |
+          exit 1
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,15 +36,12 @@ concurrency:
 
 jobs:
   MacOS:
-    if: ${{ github.repository == 'driazati/tvm' }}
-    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'apache/tvm' }}
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: fail
-        run: |
-          exit 1
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Conda Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,12 +36,9 @@ concurrency:
 
 jobs:
   MacOS:
-    if: ${{ github.repository == 'driazati/tvm' }}
-    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'apache/tvm' }}
+    runs-on: macOS-latest
     steps:
-      - name: Start
-        run: |
-          exit 1
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,12 +36,15 @@ concurrency:
 
 jobs:
   MacOS:
-    if: ${{ github.repository == 'apache/tvm' }}
-    runs-on: macOS-latest
+    if: ${{ github.repository == 'driazati/tvm' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: fail
+        run: |
+          exit 1
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Conda Build

--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -1,7 +1,6 @@
 
 name: tvm-bot
 on:
-  status:
   pull_request_review:
     types:
       - submitted
@@ -21,13 +20,14 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
+    if: ${{ github.event.issue.pull_request && github.repository == 'driazati/tvm' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Run tvm-bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           TVM_BOT_JENKINS_TOKEN: ${{ secrets.TVM_BOT_JENKINS_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_COMMENT: ${{ toJson(github.event.comment) }}

--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    if: ${{ github.event.issue.pull_request && github.repository == 'driazati/tvm' }}
+    if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
+    if: ${{ github.event.issue.pull_request && github.repository == 'driazati/tvm' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -20,14 +20,14 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    if: ${{ github.event.issue.pull_request && github.repository == 'driazati/tvm' }}
+    if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Run tvm-bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          GH_ACTIONS_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
           TVM_BOT_JENKINS_TOKEN: ${{ secrets.TVM_BOT_JENKINS_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           ISSUE_COMMENT: ${{ toJson(github.event.comment) }}

--- a/tests/python/ci/test_tvmbot.py
+++ b/tests/python/ci/test_tvmbot.py
@@ -81,7 +81,7 @@ TEST_DATA = {
     "invalid-author": {
         "number": 10786,
         "filename": "pr10786-invalid-author.json",
-        "expected": "Comment is not from from PR author or collaborator, quitting",
+        "expected": "Failed auth check 'collaborators', quitting",
         "comment": "@tvm-bot merge",
         "user": "not-abc",
         "detail": "Merge requester is not a committer and cannot merge",
@@ -89,7 +89,7 @@ TEST_DATA = {
     "unauthorized-comment": {
         "number": 11244,
         "filename": "pr11244-unauthorized-comment.json",
-        "expected": "Comment is not from from PR author or collaborator, quitting",
+        "expected": "Failed auth check 'collaborators'",
         "comment": "@tvm-bot merge",
         "user": "not-abc2",
         "detail": "Check that a merge comment not from a CONTRIBUTOR is rejected",
@@ -135,7 +135,7 @@ TEST_DATA = {
     [tuple(d.values()) for d in TEST_DATA.values()],
     ids=TEST_DATA.keys(),
 )
-def test_mergebot(tmpdir_factory, number, filename, expected, comment, user, detail):
+def test_tvmbot(tmpdir_factory, number, filename, expected, comment, user, detail):
     """
     Test the mergebot test cases
     """
@@ -156,7 +156,7 @@ def test_mergebot(tmpdir_factory, number, filename, expected, comment, user, det
             "login": user,
         },
     }
-    collaborators = []
+    collaborators = ["abc"]
 
     proc = subprocess.run(
         [
@@ -170,6 +170,8 @@ def test_mergebot(tmpdir_factory, number, filename, expected, comment, user, det
             json.dumps(test_data),
             "--testing-collaborators-json",
             json.dumps(collaborators),
+            "--testing-mentionable-users-json",
+            json.dumps(collaborators),
             "--trigger-comment-json",
             json.dumps(comment),
         ],
@@ -178,6 +180,7 @@ def test_mergebot(tmpdir_factory, number, filename, expected, comment, user, det
         encoding="utf-8",
         env={
             "TVM_BOT_JENKINS_TOKEN": "123",
+            "GH_ACTIONS_TOKEN": "123",
         },
         cwd=git.cwd,
         check=False,

--- a/tests/scripts/git_utils.py
+++ b/tests/scripts/git_utils.py
@@ -89,9 +89,9 @@ class GitHubRepo:
             with request.urlopen(req, data) as response:
                 content = response.read()
         except error.HTTPError as e:
-            logging.info(f"Error response: {e.read().decode()}")
-            e.seek(0)
-            raise e
+            msg = str(e)
+            error_data = e.read().decode()
+            raise RuntimeError(f"Error response: {msg}\n{error_data}")
 
         logging.info(f"Got response from {full_url}: {content}")
         try:

--- a/tests/scripts/github_tvmbot.py
+++ b/tests/scripts/github_tvmbot.py
@@ -350,7 +350,7 @@ class PR:
                 "name": self.repo_name,
                 "user": user,
             },
-        )["data"]["repository"]["collaborators"]["nodes"]
+        )["data"]["repository"]
 
     def search_mentionable_users(self, user: str) -> List[Dict[str, Any]]:
         return self.search_users(user, MENTIONABLE_QUERY)["mentionableUsers"]["nodes"]
@@ -657,6 +657,9 @@ if __name__ == "__main__":
     parser.add_argument("--testing-pr-json", help="(testing only) manual data for testing")
     parser.add_argument(
         "--testing-collaborators-json", help="(testing only) manual data for testing"
+    )
+    parser.add_argument(
+        "--testing-mentionable-users-json", help="(testing only) manual data for testing"
     )
     parser.add_argument(
         "--dry-run",


### PR DESCRIPTION
This adds the right permissions so anyone associated with the repo can trigger a re-run (GitHub hasn't flagged all committers as repo `COLLABORATORS` for some reason so it's difficult to determine from a username who has commit rights) and makes it so `@tvm-bot rerun` also re-runs all the Actions on a PR.

cc @Mousius @areusch