### PR TITLE
[TVMScript] Make classes derived from ObjectPath non-nullable

### DIFF
--- a/include/tvm/node/object_path.h
+++ b/include/tvm/node/object_path.h
@@ -147,7 +147,7 @@ class RootPathNode final : public ObjectPathNode {
 
 class RootPath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(RootPath, ObjectPath, RootPathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(RootPath, ObjectPath, RootPathNode);
 };
 
 // ----- Attribute access -----
@@ -169,7 +169,8 @@ class AttributeAccessPathNode final : public ObjectPathNode {
 
 class AttributeAccessPath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(AttributeAccessPath, ObjectPath, AttributeAccessPathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AttributeAccessPath, ObjectPath,
+                                            AttributeAccessPathNode);
 };
 
 // ----- Unknown attribute access -----
@@ -188,8 +189,8 @@ class UnknownAttributeAccessPathNode final : public ObjectPathNode {
 
 class UnknownAttributeAccessPath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(UnknownAttributeAccessPath, ObjectPath,
-                                UnknownAttributeAccessPathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(UnknownAttributeAccessPath, ObjectPath,
+                                            UnknownAttributeAccessPathNode);
 };
 
 // ----- Array element access by index -----
@@ -211,7 +212,7 @@ class ArrayIndexPathNode : public ObjectPathNode {
 
 class ArrayIndexPath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(ArrayIndexPath, ObjectPath, ArrayIndexPathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ArrayIndexPath, ObjectPath, ArrayIndexPathNode);
 };
 
 // ----- Missing array element -----
@@ -233,7 +234,8 @@ class MissingArrayElementPathNode : public ObjectPathNode {
 
 class MissingArrayElementPath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(MissingArrayElementPath, ObjectPath, MissingArrayElementPathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(MissingArrayElementPath, ObjectPath,
+                                            MissingArrayElementPathNode);
 };
 
 // ----- Map value -----
@@ -255,7 +257,7 @@ class MapValuePathNode : public ObjectPathNode {
 
 class MapValuePath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(MapValuePath, ObjectPath, MapValuePathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(MapValuePath, ObjectPath, MapValuePathNode);
 };
 
 // ----- Missing map entry -----
@@ -274,7 +276,8 @@ class MissingMapEntryPathNode : public ObjectPathNode {
 
 class MissingMapEntryPath : public ObjectPath {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(MissingMapEntryPath, ObjectPath, MissingMapEntryPathNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(MissingMapEntryPath, ObjectPath,
+                                            MissingMapEntryPathNode);
 };
 
 }  // namespace tvm


### PR DESCRIPTION
`ObjectPath` is marked as non-nullable, which causes it not to have a default constructor. The derived classes, on the other hand, are not marked as such, thus getting an explicitly defaulted default constructor (via TVM macros). This constructor can't actually be called since it ends up being deleted, so the derived classes are effectively non-nullable.