### PR TITLE
[ci][tvmbot] Fix authorization filtering

### DIFF
--- a/tests/python/ci/test_tvmbot.py
+++ b/tests/python/ci/test_tvmbot.py
@@ -156,7 +156,7 @@ def test_tvmbot(tmpdir_factory, number, filename, expected, comment, user, detai
             "login": user,
         },
     }
-    collaborators = ["abc"]
+    allowed_users = [{"login": "abc"}]
 
     proc = subprocess.run(
         [
@@ -169,9 +169,9 @@ def test_tvmbot(tmpdir_factory, number, filename, expected, comment, user, detai
             "--testing-pr-json",
             json.dumps(test_data),
             "--testing-collaborators-json",
-            json.dumps(collaborators),
+            json.dumps(allowed_users),
             "--testing-mentionable-users-json",
-            json.dumps(collaborators),
+            json.dumps(allowed_users),
             "--trigger-comment-json",
             json.dumps(comment),
         ],

--- a/tests/scripts/github_tvmbot.py
+++ b/tests/scripts/github_tvmbot.py
@@ -23,7 +23,7 @@ import warnings
 import logging
 import traceback
 import re
-from typing import Dict, Any, List, Optional, Callable
+from typing import Dict, Any, List, Optional, Callable, Union
 from pathlib import Path
 
 from git_utils import git, GitHubRepo, parse_remote, post
@@ -551,7 +551,7 @@ class PR:
                     else:
                         raise e
 
-    def comment_failure(self, msg: str, exceptions: Exception):
+    def comment_failure(self, msg: str, exceptions: Union[Exception, List[Exception]]):
         if not isinstance(exceptions, list):
             exceptions = [exceptions]
 


### PR DESCRIPTION
There was a level of unwrapping missing in the check for who is allowed to trigger re-runs causing it to always fail. This also uses a different actions API endpoint to re-run only failed GitHub jobs. This also fixes the text fixtures to match the GitHub API response, also tested live in https://github.com/driazati/tvm/pull/34#issuecomment-1205785109

cc @Mousius @areusch @gigiblender 