### PR TITLE
[ci] Box all tests in pytest-forked

### DIFF
--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -73,6 +73,11 @@ function run_pytest() {
     fi
 
     suite_name="${test_suite_name}-${current_shard}-${ffi_type}"
+
+    if [[ ! "${extra_args[@]}" == *" -n"* ]]; then
+        extra_args+=("-n=1")
+    fi
+
     exit_code=0
     TVM_FFI=${ffi_type} python3 -m pytest \
            -o "junit_suite_name=${suite_name}" \


### PR DESCRIPTION
This wraps all tests in pytest-forked (with n=1) so that segfaults and other
process-terminations are properly reported by pytest. With this reporting on issues like #12311 should be much better (segfaults become like any other test failure)

cc @Mousius @areusch @gigiblender 