### PR TITLE
[Frontend][TFLite] Try Infer the value of shape expr to avoid dynamic

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -33,7 +33,7 @@ from .. import qnn as _qnn
 from ..backend.name_transforms import sanitize_name
 from .common import ExprTable
 from .common import infer_shape as _infer_shape
-from .common import lstm_cell, to_int_list, shape_of
+from .common import lstm_cell, to_int_list, shape_of, try_infer_value
 from .tflite_flexbuffer import FlexBufferDecoder
 
 __all__ = ["from_tflite"]
@@ -599,7 +599,21 @@ class OperatorConverter(object):
         if len(input_tensors) == 2:
             shape_tensor = input_tensors[1]
             if self.has_expr(shape_tensor.tensor_idx):
-                target_shape = self.get_expr(shape_tensor.tensor_idx)
+                target_expr = self.get_expr(shape_tensor.tensor_idx)
+                target_value, success = try_infer_value(
+                    target_expr,
+                    parameters={k: _nd.array(np.array(v)) for k, v in self.exp_tab.params.items()},
+                )
+                if success:
+                    # convert to flattened list
+                    from itertools import chain
+
+                    try:
+                        target_shape = list(chain(*target_value))
+                    except TypeError:
+                        target_shape = list(chain(target_value))
+                else:
+                    target_shape = target_expr
             else:
                 target_shape = self.get_tensor_value(shape_tensor)
                 # convert to flattened list


### PR DESCRIPTION
When importing model [yolov4](https://github.com/PINTO0309/PINTO_model_zoo/tree/main/031_yolov4/01_float32) and [seresenet_xx](https://drive.google.com/drive/folders/1k5MtfqbNRA8ziE3f18vu00Q1FQCzk4__).

I got dynamic shape error `Check failed: (pval != nullptr) is false: Cannot allocate memory symbolic tensor shape [?, ?]`.

I firgue out that It happened  when the expression type of shape is [relay.Expr,](https://github.com/blackkker/Pic-host/blob/main/%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_20220805112837.png) `_dyn_make.reshape` is called. Under normal circumstances, `_dyn_make.reshape`  will not be a problem, but it work incorrcetly in these case.
So i infer the value of shape expr to avoid dynamic. The code is refered to #9459 #6504 #7712


Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
