### PR TITLE
[BYOC-DNNL] Bug Fix

### DIFF
--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -77,6 +77,11 @@ def _register_external_op_helper(op_name, supported=True):
         if any([x.checked_type.dtype == "int64" for x in args]):
             logger.info("DNNL does not support int64.")
             return False
+        # DNNL does not support pooling with ceil_mode = True.
+        if "pool" in op_name:
+            attrs = dict(get_attrs(expr))
+            if "ceil_mode" in attrs.keys() and attrs["ceil_mode"]:
+                return False
         return supported
 
     return _func_wrapper

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -288,7 +288,7 @@ def add_checker(attrs, args, op_name):
             return False
         channel = dict(attrs)["channels"]
         const_shape = get_shape(args[1])
-        if channel != reduce(lambda x, y: x * y, const_shape[1::]):
+        if channel != reduce(lambda x, y: x * y, const_shape):
             return False
     return True
 

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -605,7 +605,8 @@ def legalize_pad_avg_pool(attrs, inputs, types):
     if isinstance(data, relay.expr.Call) and data.op.name == "nn.pad":
         new_attrs["padding"] = (1, 1)
         new_attrs["count_include_pad"] = True
-    return relay.nn.avg_pool2d(data.args[0], **new_attrs)
+        return relay.nn.avg_pool2d(data.args[0], **new_attrs)
+    return
 
 
 def legalize_group_conv(attrs, inputs, types):

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -343,8 +343,11 @@ def make_dnnl_pattern(op_name, with_bias, with_eltwise):
     pat_name += "_bias" if with_bias else ""
     pat_name += ("_" + with_eltwise.split(".")[-1]) if with_eltwise else ""
     if "conv" in op_name:
-        dnnl_pattern = (pat_name, make_conv_pattern(op_name, with_bias, with_eltwise),
-                        make_bias_add_pattren_predicate(add_checker),)
+        dnnl_pattern = (
+            pat_name,
+            make_conv_pattern(op_name, with_bias, with_eltwise),
+            make_bias_add_pattren_predicate(add_checker),
+        )
     elif op_name == "nn.dense":
         dnnl_pattern = (pat_name, make_dense_pattern(with_bias, with_eltwise))
     else:
@@ -611,7 +614,7 @@ def legalize_pad_avg_pool(attrs, inputs, types):
         new_attrs["padding"] = (1, 1)
         new_attrs["count_include_pad"] = True
         return relay.nn.avg_pool2d(data.args[0], **new_attrs)
-    return
+    return relay.nn.avg_pool2d(data, **attrs)
 
 
 def legalize_group_conv(attrs, inputs, types):

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -235,7 +235,7 @@ def get_attrs(expr):
     return {}
 
 
-def make_predicate(checker):
+def make_sum_pattren_predicate(checker):
     """Check whether the conv_bias_add_sum pattern is as expected."""
 
     def predicate(expr):
@@ -251,15 +251,39 @@ def make_predicate(checker):
     return predicate
 
 
+def make_bias_add_pattren_predicate(checker):
+    """Check whether the conv_bias pattern is as expected."""
+
+    def predicate(expr):
+        if get_op_name(expr) == "nn.relu":
+            expr = expr.args[0]
+        if get_op_name(expr) == "add":
+            args = get_args(expr)
+            attrs = get_attrs(expr.args[0])
+            if not checker(attrs, args, "bias_add"):
+                return False
+        return True
+
+    return predicate
+
+
 def add_checker(attrs, args, op_name):
-    """Check if add is supported by DNNL."""
+    """Check if add is aligned with elementwise_add and bias_add."""
     if op_name == "sum":
+        if not isinstance(args[0].op, tvm.ir.op.Op):
+            return False
+        if args[0].op.name != "add":
+            return False
         if tuple(get_shape(args[0])) != tuple(get_shape(args[1])):
             return False
     if op_name == "bias_add":
+        if not isinstance(args[0].op, tvm.ir.op.Op):
+            return False
+        if args[0].op.name != "nn.conv2d":
+            return False
         channel = dict(attrs)["channels"]
         const_shape = get_shape(args[1])
-        if channel != reduce(lambda x, y: x * y, const_shape):
+        if channel != reduce(lambda x, y: x * y, const_shape[1::]):
             return False
     return True
 
@@ -314,7 +338,8 @@ def make_dnnl_pattern(op_name, with_bias, with_eltwise):
     pat_name += "_bias" if with_bias else ""
     pat_name += ("_" + with_eltwise.split(".")[-1]) if with_eltwise else ""
     if "conv" in op_name:
-        dnnl_pattern = (pat_name, make_conv_pattern(op_name, with_bias, with_eltwise))
+        dnnl_pattern = (pat_name, make_conv_pattern(op_name, with_bias, with_eltwise),
+                        make_bias_add_pattren_predicate(add_checker),)
     elif op_name == "nn.dense":
         dnnl_pattern = (pat_name, make_dense_pattern(with_bias, with_eltwise))
     else:
@@ -407,14 +432,14 @@ def pattern_table():
         (
             "dnnl.conv2d_bias_sum_relu",
             make_conv_bias_sum_relu_pattern("nn.conv2d"),
-            make_predicate(add_checker),
+            make_sum_pattren_predicate(add_checker),
         )
     )
     dnnl_patterns.append(
         (
             "dnnl.conv2d_bias_sum",
             make_conv_bias_sum_relu_pattern("nn.conv2d", False),
-            make_predicate(add_checker),
+            make_sum_pattren_predicate(add_checker),
         )
     )
 

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -919,39 +919,17 @@ def test_mixed_single_multiple_outputs():
 
 def test_dnnl_fuse():
     dnnl_patterns = get_pattern_table("dnnl")
-    valid_pats = list()
     for pattern in dnnl_patterns:
-        if len(pattern) == 2:
-            valid_pats.append(pattern)
-    dnnl_pat_dic = dict(valid_pats)
-    (
-        conv2d_bias_relu_pat,
-        conv2d_bias_sigmoid_pat,
-        conv2d_bias_pat,
-        conv2d_relu_pat,
-        conv2d_sigmoid_pat,
-    ) = (
-        (
-            "dnnl.conv2d_bias_relu",
-            dnnl_pat_dic["dnnl.conv2d_bias_relu"],
-        ),
-        (
-            "dnnl.conv2d_bias_sigmoid",
-            dnnl_pat_dic["dnnl.conv2d_bias_sigmoid"],
-        ),
-        (
-            "dnnl.conv2d_bias",
-            dnnl_pat_dic["dnnl.conv2d_bias"],
-        ),
-        (
-            "dnnl.conv2d_relu",
-            dnnl_pat_dic["dnnl.conv2d_relu"],
-        ),
-        (
-            "dnnl.conv2d_sigmoid",
-            dnnl_pat_dic["dnnl.conv2d_sigmoid"],
-        ),
-    )
+        if pattern[0] == "dnnl.conv2d_bias_relu":
+            conv2d_bias_relu_pat = pattern
+        elif pattern[0] == "dnnl.conv2d_bias_sigmoid":
+            conv2d_bias_sigmoid_pat = pattern
+        elif pattern[0] == "dnnl.conv2d_bias":
+            conv2d_bias_pat = pattern
+        elif pattern[0] == "dnnl.conv2d_relu":
+            conv2d_relu_pat = pattern
+        elif pattern[0] == "dnnl.conv2d_sigmoid":
+            conv2d_sigmoid_pat = pattern
 
     def get_blocks(
         prefix,


### PR DESCRIPTION
This PR fixes some bugs exist in BYOC-DNNL.
1. add checks for `bias` pattern and `sum` pattern, to ensure the catched pattern obeys the pre-defined order.
2. fix return error of `pad_pool` legalize.
3. add checks for op `pooling`. Only `ceil_mode=False` is supported. Currently, onednn pooling primitive has no attrs to support `ceil_mode=True`.