### PR TITLE
[TOPI][OP]change float multiplication of resize op to integer division

### DIFF
--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -23,6 +23,22 @@ from tvm.topi.utils import nchw_pack_layout, nchw_xc_layout
 from .. import tag
 
 
+def can_multiple2div(image, target):
+    """Check whether can transform multiplion to division"""
+    # Only support IntImm type
+    if not isinstance(target, tvm.tir.expr.IntImm):
+        return False
+
+    div = target / image.astype("float")
+    if div.value % 1 != 0:
+        return False
+    epsilon = 1e-5
+    check = 1 / (epsilon * image + epsilon)
+    if div > check:
+        return False
+    return True
+
+
 def get_1d_indices(indices, layout="NCW"):
     """Get 1d indices"""
     (cc, inum, ic) = (0, 0, 0)
@@ -119,7 +135,15 @@ def get_3d_pixel(data, layout, image_depth, image_height, image_width, n, c, z, 
     return data(n, c, z, y, x, cc).astype("float")
 
 
-def get_inx(x, image_width, target_width, coordinate_transformation_mode, start_x=0, end_x=-1):
+def get_inx(
+    x,
+    image_width,
+    target_width,
+    coordinate_transformation_mode,
+    start_x=0,
+    end_x=-1,
+    use_int_div=False,
+):
     """Infer input x from output x with various coordinate transformation methods"""
     scale_x = te.div(image_width.astype("float"), target_width.astype("float"))
     if coordinate_transformation_mode == "half_pixel":
@@ -127,7 +151,10 @@ def get_inx(x, image_width, target_width, coordinate_transformation_mode, start_
     elif coordinate_transformation_mode == "align_corners":
         in_x = (image_width - 1).astype("float") / (target_width - 1) * x
     elif coordinate_transformation_mode == "asymmetric":
-        in_x = scale_x * x
+        if use_int_div:
+            in_x = te.div(x, te.div(target_width, image_width))
+        else:
+            in_x = scale_x * x
     elif coordinate_transformation_mode == "pytorch_half_pixel":
         in_x = te.if_then_else(target_width > 1, (x + 0.5) * scale_x - 0.5, 0.0)
     elif coordinate_transformation_mode == "tf_half_pixel_for_nn":
@@ -146,8 +173,12 @@ def get_inx(x, image_width, target_width, coordinate_transformation_mode, start_
     return in_x
 
 
-def get_closest_index(in_x, rounding_method, boxes):
+def get_closest_index(in_x, rounding_method, boxes, use_int_div=False):
     """get the closest index to a value based on a certain rounding method"""
+    if use_int_div:
+        closest_x_index = in_x.astype("int32")
+        return closest_x_index
+
     if rounding_method == "round" or boxes is not None:
         closest_x_index = te.round(in_x).astype("int32")
     elif rounding_method == "round_prefer_floor":
@@ -595,6 +626,12 @@ def _resize_2d(
             dtype = data_dtype
         return value.astype(dtype)
 
+    height_use_int_div = False
+    width_use_int_div = False
+    if method == "nearest_neighbor" and coordinate_transformation_mode == "asymmetric":
+        height_use_int_div = can_multiple2div(image_height, target_height)
+        width_use_int_div = can_multiple2div(image_width, target_width)
+
     n, c, y, x, cc, inum, ic = get_2d_indices(indices, layout)
     box_idx = box_indices(n) if box_indices is not None else n
     if boxes is not None:
@@ -609,9 +646,23 @@ def _resize_2d(
         in_y = y1 * (image_height - 1) + h_scale * y
         in_x = x1 * (image_width - 1) + w_scale * x
     else:
-        in_x = get_inx(x, image_width, target_width, coordinate_transformation_mode, roi[1], roi[3])
+        in_x = get_inx(
+            x,
+            image_width,
+            target_width,
+            coordinate_transformation_mode,
+            roi[1],
+            roi[3],
+            width_use_int_div,
+        )
         in_y = get_inx(
-            y, image_height, target_height, coordinate_transformation_mode, roi[0], roi[2]
+            y,
+            image_height,
+            target_height,
+            coordinate_transformation_mode,
+            roi[0],
+            roi[2],
+            height_use_int_div,
         )
 
     if method == "nearest_neighbor":
@@ -621,8 +672,8 @@ def _resize_2d(
             else:
                 rounding_method = "floor"
 
-        closest_x_index = get_closest_index(in_x, rounding_method, boxes)
-        closest_y_index = get_closest_index(in_y, rounding_method, boxes)
+        closest_x_index = get_closest_index(in_x, rounding_method, boxes, width_use_int_div)
+        closest_y_index = get_closest_index(in_y, rounding_method, boxes, height_use_int_div)
 
         value = get_2d_pixel(
             data,

--- a/tests/python/topi/python/test_topi_image.py
+++ b/tests/python/topi/python/test_topi_image.py
@@ -86,6 +86,9 @@ def test_resize2d():
     verify_resize2d(6, 32, 64, 64, 20, 20, "NHWC")
     for layout in ["NCHW", "NHWC"]:
         verify_resize2d(4, 16, 32, 32, 50, 50, layout, "asymmetric", method="nearest_neighbor")
+        verify_resize2d(4, 16, 32, 32, 64, 50, layout, "asymmetric", method="nearest_neighbor")
+        verify_resize2d(4, 16, 32, 32, 50, 96, layout, "asymmetric", method="nearest_neighbor")
+        verify_resize2d(4, 16, 32, 32, 96, 96, layout, "asymmetric", method="nearest_neighbor")
         verify_resize2d(4, 16, 32, 32, 50, 50, layout, "align_corners", method="nearest_neighbor")
         verify_resize2d(4, 16, 32, 32, 50, 50, layout, "half_pixel", method="nearest_neighbor")
         verify_resize2d(4, 16, 32, 32, 50, 50, layout, "asymmetric", method="linear")

--- a/tests/python/topi/python/test_topi_upsampling.py
+++ b/tests/python/topi/python/test_topi_upsampling.py
@@ -101,8 +101,16 @@ def verify_upsampling(
         check_target(target, dev)
 
 
-@tvm.testing.uses_gpu
 def test_int_div_upsampling():
+    """Test whether upsampling op is tilable when scale_h and scale_w is integer.
+
+    Compute_at cannot work correctly in the original floating-point multiplication.
+    After using integer division,compute_at can work correctly and reduce the
+    capacity of cache buffer.
+
+    In this test case, scale_h and scale_w are set to integers, the size
+    of cache buffer should be equal to (h_i/scale_h * w_i/scale_w * c_i).
+    """
     dtype = "int8"
     scale_h = 2
     scale_w = 2


### PR DESCRIPTION
This PR is aim to change floating point multiplication of resize operator to integer division when `method` is nearest_neighbor and `coordinate_transformation_mode` is asymmetric.

**Why this change?**  

When using `create_prim_func` to convert topi.upsampling into primfunc, tir analyzer cannot parse complex floating point operations in tir block body. In the following case, the dimensions of read buffer are inferred as 0 : 128. We expect to be `tir.reads([x[i0_1, i1_1, i2_1/scale_h, i3_1/scale_w]])`in line 18，so it can perform compute_at schedule on this prim_func.

```python
scale_h = 2
scale_w = 2
x = te.placeholder([1, 128, 128, 128], "int8", "x")
y = topi.nn.upsampling(x, scale_h , scale_w)
func = te.create_prim_func([x, y])
print(func)
```

```Python
primfn(var_x: handle, var_resize: handle) -> ()
  attr = {"global_symbol": "main", "tir.noalias": True}
  buffers = {x: Buffer(x_1: Pointer(global int8), int8, [1, 128, 128, 128], []),
             resize: Buffer(resize_1: Pointer(global int8), int8, [1, 128, 256, 256], [])}
  buffer_map = {var_x: x, var_resize: resize} {
  block([], "root") {
    tir.reads([])
    tir.writes([])
    for (i0: int32, 0, 1) {
      for (i1: int32, 0, 128) {
        for (i2: int32, 0, 256) {
          for (i3: int32, 0, 256) {
            block([1, 128, 256, 256], "resize") as [i0_1, i1_1, i2_1, i3_1] {
              bind(i0_1, i0)
              bind(i1_1, i1)
              bind(i2_1, i2)
              bind(i3_1, i3)
              tir.reads([x[i0_1, i1_1, 0:128, 0:128]])
              tir.writes([resize[i0_1, i1_1, i2_1, i3_1]])
              resize[i0_1, i1_1, i2_1, i3_1] = cast(int8, cast(float32, x[i0_1, i1_1, max(min(cast(int32, @tir.floor(((0.5f32*cast(float32, i2_1)) + 1e-05f32), dtype=float32)), 127), 0), max(min(cast(int32, @tir.floor(((0.5f32*cast(float32, i3_1)) + 1e-05f32), dtype=float32)), 127), 0)]))
          }
        }
      }
    }
}
```

**Why can it be changed?** 

This PR only modify float multiplication to integer division when `method`  is `nearest_neighbor` and `coordinate_transformation_mode` is `asymmetric`(it's default setting for topi.upsampling op).

Go further, we expect to convert $\lfloor s * x + \epsilon_1 \rfloor$ to $x//a$, $s$ is scale, a float number, $x$ is input, $\epsilon_1$ is 1e-5 in resize op, $a$ is the reciprocal of $s$, an integer.

 So, we can represent output as this: 
$y = \lfloor s * x + \epsilon_1 \rfloor = \lfloor ( \frac{1}{a} + \epsilon_0 ) * x + \epsilon_1 \rfloor = \lfloor \frac{x}{a} + \epsilon_0 * x + \epsilon_1 \rfloor$, let $x = a * m + n$, where $m = x // a, n = x \% a$ , then we can get $y = m + \lfloor \frac{n}{a} + \epsilon_0 * x + \epsilon_1 \rfloor$. In the case of upsampling op, $x$ and $a$ are always integers, so inequality $\frac{n}{a} \le \frac{a-1}{a}$ always holds. If $\epsilon_0 * x + \epsilon_1 < \frac{1}{a}$, we can get $0 < \frac{n}{a} + \epsilon_0 * x + \epsilon_1 < 1$，then $y = m + \lfloor \frac{n}{a} + \epsilon_0 * x + \epsilon_1 \rfloor = m = x // a$.

To sum up, when $\epsilon_0 * x + \epsilon_1 < \frac{1}{a}$, we can get $y = \lfloor s*x + \epsilon_1 \rfloor = x // a$.

In this PR,  we assume $\epsilon_0 = \epsilon_1 = 1e-5$ and `can_convert_multiply_to_intdiv`to check $\epsilon_0 * x + \epsilon_1 < \frac{1}{a}$.