### PR TITLE
[Topi] add x86 schedule for batch_norm

### DIFF
--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -836,3 +836,14 @@ def concatenate_strategy_cpu(attrs, inputs, out_type, target):
             name="concatenate.generic",
         )
     return strategy
+
+@batch_norm_strategy.register(["cpu"])
+def batch_norm_strategy_cpu(attrs, inputs, out_type, target):
+    """batch_norm x86 strategy"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_concat(topi.nn.batch_norm),
+        wrap_topi_schedule(topi.x86.schedule_batch_norm),
+        name="batch_norm.cpu",
+    )
+    return strategy

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -843,7 +843,7 @@ def batch_norm_strategy_cpu(attrs, inputs, out_type, target):
     """batch_norm x86 strategy"""
     strategy = _op.OpStrategy()
     strategy.add_implementation(
-        wrap_compute_concat(topi.nn.batch_norm),
+        wrap_compute_batch_norm(topi.nn.batch_norm),
         wrap_topi_schedule(topi.x86.schedule_batch_norm),
         name="batch_norm.cpu",
     )

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -837,6 +837,7 @@ def concatenate_strategy_cpu(attrs, inputs, out_type, target):
         )
     return strategy
 
+
 @batch_norm_strategy.register(["cpu"])
 def batch_norm_strategy_cpu(attrs, inputs, out_type, target):
     """batch_norm x86 strategy"""

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -107,3 +107,19 @@ def schedule_softmax(outs):
 
     traverse_inline(s, outs[0].op, _callback)
     return s
+
+def schedule_batch_norm(outs):
+    s = te.create_schedule([x.op for x in outs])
+    # only parallelize outer dimensions up to axis
+    output_op=outs[0].op
+    axis = output_op.axis
+    outer_axes = [output_op.axis[i] for i in range(0, len(axis)-1)]
+    fused_outer_axes = s[output_op].fuse(*outer_axes)
+    s[output_op].parallel(fused_outer_axes)
+    # when scale or center is enabled
+    if 'divide' not in output_op.name:
+        div = output_op.input_tensors[0]
+        substract = s[div].op.input_tensors[0]
+        s[div].compute_inline()
+        s[substract].compute_inline()
+    return s

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -110,6 +110,19 @@ def schedule_softmax(outs):
 
 
 def schedule_batch_norm(outs):
+    """Schedule for batch_norm
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of batch_norm
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
     s = te.create_schedule([x.op for x in outs])
     # only parallelize outer dimensions up to axis
     output_op = outs[0].op

--- a/python/tvm/topi/x86/nn.py
+++ b/python/tvm/topi/x86/nn.py
@@ -108,16 +108,17 @@ def schedule_softmax(outs):
     traverse_inline(s, outs[0].op, _callback)
     return s
 
+
 def schedule_batch_norm(outs):
     s = te.create_schedule([x.op for x in outs])
     # only parallelize outer dimensions up to axis
-    output_op=outs[0].op
+    output_op = outs[0].op
     axis = output_op.axis
-    outer_axes = [output_op.axis[i] for i in range(0, len(axis)-1)]
+    outer_axes = [output_op.axis[i] for i in range(0, len(axis) - 1)]
     fused_outer_axes = s[output_op].fuse(*outer_axes)
     s[output_op].parallel(fused_outer_axes)
     # when scale or center is enabled
-    if 'divide' not in output_op.name:
+    if "divide" not in output_op.name:
         div = output_op.input_tensors[0]
         substract = s[div].op.input_tensors[0]
         s[div].compute_inline()

--- a/tests/python/topi/python/test_topi_batch_norm.py
+++ b/tests/python/topi/python/test_topi_batch_norm.py
@@ -28,6 +28,7 @@ import tvm.topi.testing
 _DEVICE = "llvm"
 _BATCH_NORM_IMPLEMENT = {
     "generic": (topi.nn.batch_norm, topi.generic.schedule_batch_norm),
+    "cpu": (topi.nn.batch_norm, topi.x86.schedule_batch_norm),
 }
 
 


### PR DESCRIPTION
Follow up of https://github.com/apache/tvm/pull/9694. 
1. batch_norm returns a list and it might be tricky to 
- apply autotvm and add tiling stages. Need to unpack list object. (here node is a list)
https://github.com/apache/tvm/blob/ca46f21f5168f937cf9b1d205118c770c46aa8c5/python/tvm/autotvm/task/topi_integration.py#L168
- fuse with other kElemwise ops. I found that when batch_norm+relu, all 3 outputs [output, moving_mean, moving_var] are fused with relu and the latter 2 make no sense. Is it possible to select which node to fuse?
2. observed better perf with larger workloads due to parallism (Intel(R) Xeon(R) CPU @ 2.30GHz, 8cores)
```
shape=160, key=generic= {'mean': 0.48806950988364406, 'median': 0.02051979972748086, 'std': 1.402288376912746}
shape=160, key=cpu= {'mean': 0.49737747001927346, 'median': 0.04554405022645369, 'std': 1.3545420627182678}
shape=1600, key=generic= {'mean': 4.354905650106957, 'median': 0.03478030048427172, 'std': 12.959578536273051}
shape=1600, key=cpu= {'mean': 1.4397647402074654, 'median': 0.0432861503213644, 'std': 4.19046676508887}
shape=16000, key=generic= {'mean': 2.161924099782482, 'median': 0.051916949450969696, 'std': 6.330056129490704}
shape=16000, key=cpu= {'mean': 1.2180674902629107, 'median': 0.054580300638917834, 'std': 3.488364687811132}
shape=160000, key=generic= {'mean': 2.184136709984159, 'median': 0.23043325054459274, 'std': 5.860211833531447}
shape=160000, key=cpu= {'mean': 1.2610028796189, 'median': 0.1792462993762456, 'std': 3.2444646099107004}
```
