### PR TITLE
[MetaSchedule] Extend tune_tir to support tuning of specific blocks.

### DIFF
--- a/include/tvm/meta_schedule/space_generator.h
+++ b/include/tvm/meta_schedule/space_generator.h
@@ -132,6 +132,8 @@ class SpaceGenerator : public runtime::ObjectRef {
   SpaceGenerator() = default;
 
  public:
+  /* A callback function that can be used to filter which blocks have generated spaces. */
+  using BlockFilterFunc = runtime::TypedPackedFunc<Optional<Bool>(const tir::BlockNode&)>;
   /*!
    * \brief Create a design space generator with customized methods on the python-side.
    * \param f_initialize_with_tune_context The packed function of `InitializeWithTuneContext`.
@@ -153,7 +155,7 @@ class SpaceGenerator : public runtime::ObjectRef {
    *  to blocks in post-DFS order.
    * \return The design space generator created.
    */
-  TVM_DLL static SpaceGenerator PostOrderApply();
+  TVM_DLL static SpaceGenerator PostOrderApply(BlockFilterFunc f_block_filter = nullptr);
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(SpaceGenerator, ObjectRef, SpaceGeneratorNode);
 };
 

--- a/include/tvm/meta_schedule/space_generator.h
+++ b/include/tvm/meta_schedule/space_generator.h
@@ -132,8 +132,6 @@ class SpaceGenerator : public runtime::ObjectRef {
   SpaceGenerator() = default;
 
  public:
-  /* A callback function that can be used to filter which blocks have generated spaces. */
-  using BlockFilterFunc = runtime::TypedPackedFunc<Optional<Bool>(const tir::BlockNode&)>;
   /*!
    * \brief Create a design space generator with customized methods on the python-side.
    * \param f_initialize_with_tune_context The packed function of `InitializeWithTuneContext`.
@@ -155,7 +153,7 @@ class SpaceGenerator : public runtime::ObjectRef {
    *  to blocks in post-DFS order.
    * \return The design space generator created.
    */
-  TVM_DLL static SpaceGenerator PostOrderApply(BlockFilterFunc f_block_filter = nullptr);
+  TVM_DLL static SpaceGenerator PostOrderApply(runtime::PackedFunc f_block_filter = nullptr);
   TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(SpaceGenerator, ObjectRef, SpaceGeneratorNode);
 };
 

--- a/python/tvm/meta_schedule/space_generator/post_order_apply.py
+++ b/python/tvm/meta_schedule/space_generator/post_order_apply.py
@@ -27,10 +27,18 @@ class PostOrderApply(SpaceGenerator):
     """
     PostOrderApply is the design space generator that generates design spaces by applying schedule
     rules to blocks in post-DFS order.
+
+    Parameters
+    ----------
+    f_block_filter : Optional[function]
+        An optional callback function that is used to filter which blocks have schedules generated
+        for them. The function should take in a block and return True if a schedule should
+        be generated or False if that block should be skipped. If no function is provided
+        all blocks will have schedules generated.
     """
 
-    def __init__(self, filter_fn=None):
+    def __init__(self, f_block_filter=None):
         """Constructor"""
         self.__init_handle_by_constructor__(
-            _ffi_api.SpaceGeneratorPostOrderApply, filter_fn  # type: ignore # pylint: disable=no-member
+            _ffi_api.SpaceGeneratorPostOrderApply, f_block_filter  # type: ignore # pylint: disable=no-member
         )

--- a/python/tvm/meta_schedule/space_generator/post_order_apply.py
+++ b/python/tvm/meta_schedule/space_generator/post_order_apply.py
@@ -29,8 +29,12 @@ class PostOrderApply(SpaceGenerator):
     rules to blocks in post-DFS order.
     """
 
-    def __init__(self):
+    def __init__(self, target_blocks=[]):
         """Constructor"""
+        if target_blocks is None:
+            target_blocks = []
+        if not isinstance(target_blocks, (list, tuple)):
+            target_blocks = [target_blocks]
         self.__init_handle_by_constructor__(
-            _ffi_api.SpaceGeneratorPostOrderApply,  # type: ignore # pylint: disable=no-member
+            _ffi_api.SpaceGeneratorPostOrderApply, target_blocks # type: ignore # pylint: disable=no-member
         )

--- a/python/tvm/meta_schedule/space_generator/post_order_apply.py
+++ b/python/tvm/meta_schedule/space_generator/post_order_apply.py
@@ -29,12 +29,8 @@ class PostOrderApply(SpaceGenerator):
     rules to blocks in post-DFS order.
     """
 
-    def __init__(self, target_blocks=[]):
+    def __init__(self, filter_fn=None):
         """Constructor"""
-        if target_blocks is None:
-            target_blocks = []
-        if not isinstance(target_blocks, (list, tuple)):
-            target_blocks = [target_blocks]
         self.__init_handle_by_constructor__(
-            _ffi_api.SpaceGeneratorPostOrderApply, target_blocks # type: ignore # pylint: disable=no-member
+            _ffi_api.SpaceGeneratorPostOrderApply, filter_fn  # type: ignore # pylint: disable=no-member
         )

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -428,11 +428,11 @@ def tune_tir(
     if blocks is not None:
         assert space is None, "Can not specify blocks to tune when a search space is given."
         # Create a filter function to identify named blocks.
-        def _filter_fn(block, target_names) -> bool:
+        def _f_block_filter(block, target_names) -> bool:
             return block.name_hint in target_names
 
         # Create a space generator that targets specific blocks.
-        space = PostOrderApply(filter_fn=lambda block: _filter_fn(block, blocks))
+        space = PostOrderApply(f_block_filter=lambda block: _f_block_filter(block, blocks))
 
     # pylint: disable=protected-access
     mod = default_config.mod(mod)

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union
 
 from tvm.ir import IRModule
 from tvm.ir.transform import PassContext
+from tvm.meta_schedule.space_generator.post_order_apply import PostOrderApply
 from tvm.runtime import Module, NDArray, vm
 from tvm.target import Target
 from tvm.te import Tensor, create_prim_func
@@ -364,6 +365,7 @@ def tune_tir(
     cost_model: Optional[CostModel] = None,
     measure_callbacks: Optional[List[MeasureCallback]] = None,
     space: Optional[FnSpaceGenerator] = None,
+    blocks: Optional[List[str]] = None,
     sch_rules: Optional[FnScheduleRule] = None,
     postprocs: Optional[FnPostproc] = None,
     mutator_probs: Optional[FnMutatorProb] = None,
@@ -392,6 +394,21 @@ def tune_tir(
         The cost model to use.
     measure_callbacks : Optional[List[MeasureCallback]]
         The callbacks used during tuning.
+    space : Optional[FnSpaceGenerator]
+        The space generator to use.
+    blocks : Optional[List[str]]
+        A list of block names to tune. If provided, other blocks
+        will not be optimized.
+    sch_rules : Optional[FnScheduleRule]
+        The search rules to use.
+    postprocs : Optional[FnPostproc]
+        The postprocessors to use.
+    mutator_probs : Optional[FnMutatorProb]
+        The probability distribution to use different mutators.
+    task_name : str
+        The name of the function to extract schedules from.
+    num_threads : Optional[int]
+        The number of threads to use
 
     Returns
     -------
@@ -406,6 +423,15 @@ def tune_tir(
         log_dir=log_dir,
         params=[{"log_dir": log_dir, "logger_name": __name__ + f".task_{task_name}"}],
     )
+
+    if blocks is not None:
+        assert space is None, "Only one of blocks and space can be specified."
+        # Create a filter function to identify named blocks.
+        def _filter_fn(block, target_names) -> bool:
+            return block.name_hint in target_names
+
+        # Create a space generator that targets specific blocks.
+        space = PostOrderApply(filter_fn=lambda block: _filter_fn(block, blocks))
 
     # pylint: disable=protected-access
     mod = default_config.mod(mod)

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -397,8 +397,9 @@ def tune_tir(
     space : Optional[FnSpaceGenerator]
         The space generator to use.
     blocks : Optional[List[str]]
-        A list of block names to tune. If provided, other blocks
-        will not be optimized.
+        A list of block names specifying blocks to be tuned. Note that if
+        the list is not None, blocks outside this list will not be tuned.
+        Only one of this argument and space may be provided.
     sch_rules : Optional[FnScheduleRule]
         The search rules to use.
     postprocs : Optional[FnPostproc]
@@ -425,7 +426,7 @@ def tune_tir(
     )
 
     if blocks is not None:
-        assert space is None, "Only one of blocks and space can be specified."
+        assert space is None, "Can not specify blocks to tune when a search space is given."
         # Create a filter function to identify named blocks.
         def _filter_fn(block, target_names) -> bool:
             return block.name_hint in target_names

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -24,7 +24,8 @@ namespace meta_schedule {
 /*! \brief Collecting all the blocks */
 class BlockCollector : public tir::StmtVisitor {
  public:
-  static Array<tir::BlockRV> Collect(const tir::Schedule& sch, const runtime::PackedFunc f_block_filter = nullptr) {  //
+  static Array<tir::BlockRV> Collect(const tir::Schedule& sch,
+                                     const runtime::PackedFunc f_block_filter = nullptr) {  //
     return BlockCollector(sch, f_block_filter).Run();
   }
 
@@ -48,7 +49,9 @@ class BlockCollector : public tir::StmtVisitor {
     return results;
   }
   /*! \brief Constructor */
-  explicit BlockCollector(const tir::Schedule& sch, const runtime::PackedFunc f_block_filter = nullptr) : sch_(sch), f_block_filter_(f_block_filter) {}
+  explicit BlockCollector(const tir::Schedule& sch,
+                          const runtime::PackedFunc f_block_filter = nullptr)
+      : sch_(sch), f_block_filter_(f_block_filter) {}
   /*! \brief Override the Stmt visiting behaviour */
   void VisitStmt_(const tir::BlockNode* block) override {
     tir::StmtVisitor::VisitStmt_(block);
@@ -92,7 +95,8 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
   Array<ScheduleRule> sch_rules_{nullptr};
   /*! \brief The logging function to use. */
   PackedFunc logging_func;
-  /*! \brief Optional block names to target. If not specified all blocks will have spaces generated. */
+  /*! \brief Optional block names to target. If not specified all blocks will have spaces generated.
+   */
   runtime::PackedFunc f_block_filter_ = nullptr;
 
   void VisitAttrs(tvm::AttrVisitor* v) {

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -24,7 +24,7 @@ namespace meta_schedule {
 /*! \brief Collecting all the blocks */
 class BlockCollector : public tir::StmtVisitor {
  public:
-  static Array<tir::BlockRV> Collect(const tir::Schedule& sch, const SpaceGenerator::BlockFilterFunc f_block_filter = nullptr) {  //
+  static Array<tir::BlockRV> Collect(const tir::Schedule& sch, const runtime::PackedFunc f_block_filter = nullptr) {  //
     return BlockCollector(sch, f_block_filter).Run();
   }
 
@@ -48,7 +48,7 @@ class BlockCollector : public tir::StmtVisitor {
     return results;
   }
   /*! \brief Constructor */
-  explicit BlockCollector(const tir::Schedule& sch, const SpaceGenerator::BlockFilterFunc f_block_filter = nullptr) : sch_(sch), f_block_filter_(f_block_filter) {}
+  explicit BlockCollector(const tir::Schedule& sch, const runtime::PackedFunc f_block_filter = nullptr) : sch_(sch), f_block_filter_(f_block_filter) {}
   /*! \brief Override the Stmt visiting behaviour */
   void VisitStmt_(const tir::BlockNode* block) override {
     tir::StmtVisitor::VisitStmt_(block);
@@ -56,13 +56,14 @@ class BlockCollector : public tir::StmtVisitor {
         << "Duplicated block name " << block->name_hint << " in function " << func_name_
         << " not supported!";
     block_names_.insert(block->name_hint);
+
     // If filter function is provided, use it to selectively collect blocks.
+    // Otherwise collect all blocks.
+    Bool collect_block = Bool(true);
     if (f_block_filter_ != nullptr) {
-      Optional<Bool> collect_block = f_block_filter_(*block);
-      if (collect_block.defined() && collect_block) {
-        blocks_to_collect_.push_back(block->name_hint);
-      }
-    } else {
+      collect_block = f_block_filter_(GetRef<tir::Block>(block));
+    }
+    if (collect_block) {
       blocks_to_collect_.push_back(block->name_hint);
     }
   }
@@ -70,7 +71,7 @@ class BlockCollector : public tir::StmtVisitor {
   /*! \brief The schedule to be collected */
   const tir::Schedule& sch_;
   /*! \brief An optional packed func that allows only certain blocks to be collected. */
-  const SpaceGenerator::BlockFilterFunc f_block_filter_;
+  const runtime::PackedFunc f_block_filter_;
   /*! \brief The set of func name and block name pair */
   std::unordered_set<String> block_names_;
   /* \brief The list of blocks to collect in order */
@@ -92,7 +93,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
   /*! \brief The logging function to use. */
   PackedFunc logging_func;
   /*! \brief Optional block names to target. If not specified all blocks will have spaces generated. */
-  SpaceGenerator::BlockFilterFunc f_block_filter_ = nullptr;
+  runtime::PackedFunc f_block_filter_ = nullptr;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     // `rand_state_` is not visited
@@ -189,7 +190,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
   TVM_DECLARE_FINAL_OBJECT_INFO(PostOrderApplyNode, SpaceGeneratorNode);
 };
 
-SpaceGenerator SpaceGenerator::PostOrderApply(SpaceGenerator::BlockFilterFunc f_block_filter) {
+SpaceGenerator SpaceGenerator::PostOrderApply(runtime::PackedFunc f_block_filter) {
   ObjectPtr<PostOrderApplyNode> n = make_object<PostOrderApplyNode>();
   n->f_block_filter_ = f_block_filter;
   return SpaceGenerator(n);

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -48,7 +48,7 @@ class BlockCollector : public tir::StmtVisitor {
     return results;
   }
   /*! \brief Constructor */
-  explicit BlockCollector(const tir::Schedule& sch) : sch_(sch) {}
+  explicit BlockCollector(const tir::Schedule& sch, const Array<String> target_blocks = {}) : sch_(sch), target_blocks_(target_blocks) {}
   /*! \brief Override the Stmt visiting behaviour */
   void VisitStmt_(const tir::BlockNode* block) override {
     tir::StmtVisitor::VisitStmt_(block);
@@ -56,11 +56,23 @@ class BlockCollector : public tir::StmtVisitor {
         << "Duplicated block name " << block->name_hint << " in function " << func_name_
         << " not supported!";
     block_names_.insert(block->name_hint);
-    blocks_to_collect_.push_back(block->name_hint);
+    // If target blocks are specified, only collect them. Otherwise collect all blocks.
+    if (target_blocks_.empty()) {
+      blocks_to_collect_.push_back(block->name_hint);
+    } else {
+      // Iterate over specified blocks and check if this is one of them.
+      for (String name : target_blocks_) {
+        if (name.compare(block->name_hint) == 0) {
+          blocks_to_collect_.push_back(block->name_hint);
+        }
+      }
+    }
   }
 
   /*! \brief The schedule to be collected */
   const tir::Schedule& sch_;
+  /*! \brief An optional list of block names that will be collected, if not provided all blocks are collected. */
+  const Array<String> target_blocks_;
   /*! \brief The set of func name and block name pair */
   std::unordered_set<String> block_names_;
   /* \brief The list of blocks to collect in order */

--- a/tests/python/unittest/test_meta_schedule_post_order_apply.py
+++ b/tests/python/unittest/test_meta_schedule_post_order_apply.py
@@ -22,7 +22,6 @@ from typing import List
 
 import pytest
 import tvm
-from tvm.meta_schedule.default_config import target
 import tvm.testing
 from tvm._ffi import register_func
 from tvm.error import TVMError

--- a/tests/python/unittest/test_meta_schedule_post_order_apply.py
+++ b/tests/python/unittest/test_meta_schedule_post_order_apply.py
@@ -397,7 +397,7 @@ def test_target_blocks_search_space():
             mod=mod,
             target=Target("llvm"),
             task_name="Custom Search Space Task",
-            space_generator=PostOrderApply(filter_fn=filter_fn),
+            space_generator=PostOrderApply(f_block_filter=filter_fn),
             sch_rules=[TrinityDoubleRule()],
         )
         post_order_apply = context.space_generator

--- a/tests/python/unittest/test_meta_schedule_tune_tir.py
+++ b/tests/python/unittest/test_meta_schedule_tune_tir.py
@@ -66,6 +66,7 @@ def test_tune_matmul_cpu():
                 max_trials_global=32,
             ),
             work_dir=work_dir,
+            blocks=["update"],
         )
         if sch is None:
             print("No valid schedule found!")


### PR DESCRIPTION
This PR extends `PostOrderApply` to allow passing in a function that filters which blocks have schedules generated. Although this could be used in many ways, I implement one example where blocks are filtered by name. This can be useful for hand optimizing part of a primfunc, and using metaschedule to tune other parts. I've added a new `Blocks` argument to `tune_tir` that allows users to optionally specify the names of blocks that should be tuned. If not provided, the behavior of `tune_tir` is exactly the same as before this PR.