### PR TITLE
[DOCS] fix `tvm.build` API doc layout.

### DIFF
--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -153,8 +153,7 @@ def build(
 
     Parameters
     ----------
-    inputs : Union[tvm.te.schedule.Schedule,
-        tvm.tir.PrimFunc, IRModule, Mapping[str, IRModule]]
+    inputs : Union[tvm.te.schedule.Schedule, tvm.tir.PrimFunc, IRModule, Mapping[str, IRModule]]
         The input to be built
 
     args : Optional[List[Union[tvm.tir.Buffer, tensor.Tensor, Var]]]


### PR DESCRIPTION
**Why**
The newline in the pydoc breaks the layout of parameter `inputs` in API `tvm.build`,  as shown below,
![infoflow 2022-08-09 15-40-43](https://user-images.githubusercontent.com/2929527/183594398-ef13addb-cfde-4fac-9c1b-1b8d23b23fa0.png)

**How**
Just remove the newline.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
