### PR TITLE
[FIX,STORAGE REWRITE] Rewrite buffers in let statements

### DIFF
--- a/python/tvm/script/tir/__init__.py
+++ b/python/tvm/script/tir/__init__.py
@@ -22,10 +22,10 @@ from .ty import void, boolean, handle, Ptr, Tuple, Buffer
 from .prim_func import prim_func
 
 # add all floating point and integer datatypes to the module
-for dtype in ["float", "uint", "int"]:
-    for size in ["8", "16", "32", "64"]:
-        for lanes in ["", "x4", "x8", "x16", "x32"]:
+for _dtype in ["float", "uint", "int"]:
+    for _size in ["8", "16", "32", "64"]:
+        for _lanes in ["", "x4", "x8", "x16", "x32"]:
             from . import ty
 
-            name = dtype + size + lanes
-            globals()[name] = getattr(ty, name)
+            _name = _dtype + _size + _lanes
+            globals()[_name] = getattr(ty, _name)

--- a/python/tvm/script/tir/__init__.py
+++ b/python/tvm/script/tir/__init__.py
@@ -17,7 +17,15 @@
 """TVMScript for TIR"""
 
 # Type system
-from .ty import uint8, int8, int16, int32, int64, float16, float32, float64, void
-from .ty import boolean, handle, Ptr, Tuple, Buffer
+from .ty import void, boolean, handle, Ptr, Tuple, Buffer
 
 from .prim_func import prim_func
+
+# add all floating point and integer datatypes to the module
+for dtype in ["float", "uint", "int"]:
+    for size in ["8", "16", "32", "64"]:
+        for lanes in ["", "x4", "x8", "x16", "x32"]:
+            from . import ty
+
+            name = dtype + size + lanes
+            globals()[name] = getattr(ty, name)

--- a/python/tvm/script/tir/intrin.py
+++ b/python/tvm/script/tir/intrin.py
@@ -42,74 +42,18 @@ def bool(imm, span):
     return imm.astype("bool", span)
 
 
-@register
-def int8(imm, span):
-    return imm.astype("int8", span)
+# register all datatypes
+for dtype in ["float", "uint", "int"]:
+    for size in ["8", "16", "32", "64"]:
+        for lanes in ["", "x4", "x8", "x16", "x32"]:
+            name = dtype + size + lanes
+            print(name)
 
+            def f(imm, span):
+                return imm.astype(name, span)
 
-@register
-def int16(imm, span):
-    return imm.astype("int16", span)
-
-
-@register
-def int32(imm, span):
-    return imm.astype("int32", span)
-
-
-@register
-def int64(imm, span):
-    return imm.astype("int64", span)
-
-
-@register
-def uint8(imm, span):
-    return imm.astype("uint8", span)
-
-
-@register
-def uint16(imm, span):
-    return imm.astype("uint16", span)
-
-
-@register
-def uint32(imm, span):
-    return imm.astype("uint32", span)
-
-
-@register
-def uint64(imm, span):
-    return imm.astype("uint64", span)
-
-
-@register
-def float8(imm, span):
-    return imm.astype("float8", span)
-
-
-@register
-def float16(imm, span):
-    return imm.astype("float16", span)
-
-
-@register
-def float32(imm, span):
-    return imm.astype("float32", span)
-
-
-@register
-def float64(imm, span):
-    return imm.astype("float64", span)
-
-
-@register
-def int32x16(imm, span):
-    return imm.astype("int32x16", span)
-
-
-@register
-def int32x4(imm, span):
-    return imm.astype("int32x4", span)
+            f.__name__ = name
+            register(f)
 
 
 @register

--- a/python/tvm/script/tir/intrin.py
+++ b/python/tvm/script/tir/intrin.py
@@ -43,17 +43,21 @@ def bool(imm, span):
 
 
 # register all datatypes
-for dtype in ["float", "uint", "int"]:
-    for size in ["8", "16", "32", "64"]:
-        for lanes in ["", "x4", "x8", "x16", "x32"]:
-            name = dtype + size + lanes
-            print(name)
+for _dtype in ["float", "uint", "int"]:
+    for _size in ["8", "16", "32", "64"]:
+        for _lanes in ["", "x4", "x8", "x16", "x32"]:
+            _name = _dtype + _size + _lanes
 
-            def f(imm, span):
-                return imm.astype(name, span)
+            # nest closures so we copy the name string
+            def wrap(name):
+                def f(imm, span):
+                    return imm.astype(name, span)
 
-            f.__name__ = name
-            register(f)
+                f.__name__ = name
+                return f
+
+            _intrin = wrap(_name)
+            register(_intrin)
 
 
 @register

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -200,11 +200,11 @@ class GenericBufferType(SpecialStmt):  # pylint: disable=too-few-public-methods,
 
 
 # add all floating point and integer datatypes to the module
-for dtype in ["float", "uint", "int"]:
-    for size in ["8", "16", "32", "64"]:
-        for lanes in ["", "x4", "x8", "x16", "x32"]:
-            name = dtype + size + lanes
-            globals()[name] = ConcreteType(name)
+for _dtype in ["float", "uint", "int"]:
+    for _size in ["8", "16", "32", "64"]:
+        for _lanes in ["", "x4", "x8", "x16", "x32"]:
+            _name = _dtype + _size + _lanes
+            globals()[_name] = ConcreteType(_name)
 
 boolean = ConcreteType("bool")
 handle = ConcreteType("handle")

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -199,14 +199,13 @@ class GenericBufferType(SpecialStmt):  # pylint: disable=too-few-public-methods,
             )
 
 
-uint8 = ConcreteType("uint8")
-int8 = ConcreteType("int8")
-int16 = ConcreteType("int16")
-int32 = ConcreteType("int32")
-int64 = ConcreteType("int64")
-float16 = ConcreteType("float16")
-float32 = ConcreteType("float32")
-float64 = ConcreteType("float64")
+# add all floating point and integer datatypes to the module
+for dtype in ["float", "uint", "int"]:
+    for size in ["8", "16", "32", "64"]:
+        for lanes in ["", "x4", "x8", "x16", "x32"]:
+            name = dtype + size + lanes
+            globals()[name] = ConcreteType(name)
+
 boolean = ConcreteType("bool")
 handle = ConcreteType("handle")
 void = VoidType()

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1461,6 +1461,14 @@ class VectorTypeRewriter : public StmtExprMutator {
     return VisitBufferAccess(std::move(node));
   }
 
+  Stmt VisitStmt_(const LetStmtNode* op) final {
+    auto it = rewrite_map_.find(op->var.get());
+    if (it == rewrite_map_.end()) {
+      return GetRef<Stmt>(op);
+    }
+    return LetStmt(it->second.new_buffer_var, op->value, op->body);
+  }
+
   Buffer RemapBuffer(Buffer buf) {
     auto cache_key = buf.get();
 


### PR DESCRIPTION
Storage rewrite was missing a visitor for let statements so buffers added in them would still refer to the pre-rewritten version. This error was originally noticed when using `global.vtcm` buffers which get changed to let statements by LowerVtcmAlloc.

Implementing the test for this change also required adding support for vectorized datatypes to tvmscript. The solution included is a little hacky and involes adding the datatypes to the `global()` table of each module they need to be defined in.

@Lunderberg @spectrometerHBH 
