### PR TITLE
[ci][tvmbot] Ignore irrelevant Actions jobs

### DIFF
--- a/tests/python/ci/sample_prs/pr10786-ignore-jobs.json
+++ b/tests/python/ci/sample_prs/pr10786-ignore-jobs.json
@@ -1,0 +1,130 @@
+{
+    "title": "[Hexagon] 2-d allocation cleanup",
+    "body": "- Added device validity check in allocation. HexagonDeviceAPI should only be called for CPU/Hexagon types.\r\n\r\n- Check for \"global.vtcm\" scope instead of \"vtcm\".  The ccope of N-d allocations produced by `LowerVtcmAlloc` should be `\"global.vtcm\"`.  The previous check allowed unsupported scope such as `\"local.vtcm\"`.\r\n\r\n- Remove `vtcmallocs` entry after calling free. Previously, the vtcm allocation map kept dangling pointers to `HexagonBuffer` objects after they had been freed.\r\n\r\n- Rename N-d alloc and free packed functions.  Since most of the similar device functions use snake case, renaming `*.AllocND` to `*.alloc_nd` and `*.FreeND` to `*.free_nd`.\r\n\r\nCo-authored-by: Adam Straw <astraw@octoml.ai>",
+    "state": "OPEN",
+    "author": {
+      "login": "abc"
+    },
+    "comments": {
+      "pageInfo": {
+        "hasPreviousPage": false
+      },
+      "nodes": []
+    },
+    "authorCommits": {
+      "nodes": [
+        {
+          "commit": {
+            "authors": {
+              "nodes": [
+                {
+                  "name": "Eric Lunderberg",
+                  "email": "elunderberg@octoml.ai"
+                },
+                {
+                  "name": "Adam Straw",
+                  "email": "astraw@octoml.ai"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "commits": {
+      "nodes": [
+        {
+          "commit": {
+            "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd",
+            "statusCheckRollup": {
+              "contexts": {
+                "pageInfo": {
+                  "hasNextPage": false
+                },
+                "nodes": [
+                  {
+                    "name": "MacOS",
+                    "checkSuite": {
+                      "workflowRun": {
+                        "workflow": {
+                          "name": "CI"
+                        }
+                      }
+                    },
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "url": "https://github.com/apache/tvm/runs/5694945392"
+                  },
+                  {
+                    "name": "cc-reviewers",
+                    "checkSuite": {
+                      "workflowRun": {
+                        "workflow": {
+                          "name": "PR"
+                        }
+                      }
+                    },
+                    "status": "COMPLETED",
+                    "conclusion": "FAILED",
+                    "url": "https://github.com/apache/tvm/runs/5694945029"
+                  },
+                  {
+                    "name": "tag-teams",
+                    "checkSuite": {
+                      "workflowRun": {
+                        "workflow": {
+                          "name": "Teams"
+                        }
+                      }
+                    },
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "url": "https://github.com/apache/tvm/runs/5694945030"
+                  },
+                  {
+                    "name": "Windows",
+                    "checkSuite": {
+                      "workflowRun": {
+                        "workflow": {
+                          "name": "CI"
+                        }
+                      }
+                    },
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "url": "https://github.com/apache/tvm/runs/5694945524"
+                  },
+                  {
+                    "state": "SUCCESS",
+                    "context": "tvm-ci/pr-head",
+                    "targetUrl": "https://ci.tlcpack.ai/job/tvm/job/PR-10786/1/display/redirect"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "reviewDecision": "APPROVED",
+    "reviews": {
+      "pageInfo": {
+        "hasPreviousPage": false
+      },
+      "nodes": [
+        {
+          "body": "@tvm-bot merge",
+          "updatedAt": "2022-03-25T22:13:50Z",
+          "authorCanPushToRepository": true,
+          "commit": {
+            "oid": "6f04bcf57d07f915a98fd91178f04d9e92a09fcd"
+          },
+          "id": 123,
+          "author": {
+            "login": "kparzysz-quic"
+          },
+          "state": "APPROVED"
+        }
+      ]
+    }
+  }

--- a/tests/python/ci/test_tvmbot.py
+++ b/tests/python/ci/test_tvmbot.py
@@ -126,6 +126,14 @@ TEST_DATA = {
         "user": "abc",
         "detail": "Start a new CI job",
     },
+    "ignore-jobs": {
+        "number": 10786,
+        "filename": "pr10786-ignore-jobs.json",
+        "expected": "Dry run, would have merged",
+        "comment": "@tvm-bot merge",
+        "user": "abc",
+        "detail": "Ignore GitHub Actions jobs that don't start with CI / ",
+    },
 }
 
 

--- a/tests/scripts/github_tvmbot.py
+++ b/tests/scripts/github_tvmbot.py
@@ -277,11 +277,15 @@ class PR:
                     # If the 'conclusion' isn't filled out the job hasn't
                     # finished yet
                     status = "PENDING"
+                workflow_name = item["checkSuite"]["workflowRun"]["workflow"]["name"]
+                if workflow_name != "CI":
+                    # Ignore all jobs that aren't in the main.yml workflow (these are mostly
+                    # automation jobs that run on PRs for tagging / reviews)
+                    continue
+                check_name = item["name"]
                 jobs.append(
                     {
-                        "name": item["checkSuite"]["workflowRun"]["workflow"]["name"]
-                        + " / "
-                        + item["name"],
+                        "name": f"{workflow_name} / {check_name}",
                         "url": item["url"],
                         "status": status.upper(),
                     }


### PR DESCRIPTION
GitHub associates the automation run on PRs for user tagging and reviews
as CI jobs on that PR, and since these often get re-run, skipped, or may
fail in the background they prevent merges. This PR ignores all of these
jobs so only the ones defined in `main.yml` matter, which are the ones
that actually build / test TVM.

This is a simpler version of #11569

cc @Mousius @areusch @gigiblender