### PR TITLE
[QNN][Hexagon] Disable QNN canonicalization pass

### DIFF
--- a/include/tvm/relay/qnn/attrs.h
+++ b/include/tvm/relay/qnn/attrs.h
@@ -199,15 +199,6 @@ struct QConv2DAttrs : public tvm::AttrsNode<QConv2DAttrs> {
     TVM_ATTR_FIELD(out_dtype)
         .set_default(NullValue<DataType>())
         .describe("Output data type, set to explicit type under mixed precision setting");
-
-    TVM_ATTR_FIELD(axis)
-        .describe(
-            "The channel axis for channel wise requantization. Default value is -1,"
-            "which corresponds to the last axis.")
-        .set_default(-1);
-    TVM_ATTR_FIELD(rq_out_dtype)
-        .set_default(NullValue<DataType>())
-        .describe("Requantized output data type");
   }
 };
 
@@ -230,15 +221,6 @@ struct QDenseAttrs : public tvm::AttrsNode<QDenseAttrs> {
     TVM_ATTR_FIELD(out_dtype)
         .set_default(NullValue<DataType>())
         .describe("Output data type, set to explicit type under mixed precision setting");
-
-    TVM_ATTR_FIELD(axis)
-        .describe(
-            "The channel axis for channel wise requantization. Default value is -1,"
-            "which corresponds to the last axis.")
-        .set_default(-1);
-    TVM_ATTR_FIELD(rq_out_dtype)
-        .set_default(NullValue<DataType>())
-        .describe("Requantized output data type");
   }
 };
 

--- a/include/tvm/relay/qnn/attrs.h
+++ b/include/tvm/relay/qnn/attrs.h
@@ -25,6 +25,7 @@
 #define TVM_RELAY_QNN_ATTRS_H_
 
 #include <tvm/ir/attrs.h>
+#include <tvm/relay/base.h>
 
 #include <string>
 
@@ -122,6 +123,120 @@ struct BroadcastAttrs : public tvm::AttrsNode<BroadcastAttrs> {
             "The channel axis for channel wise broadcast. Default value is -1,"
             "which corresponds to the last axis.")
         .set_default(-1);
+  }
+};
+
+/*! \brief Attributes used in QNN convolution operator */
+struct QConv2DAttrs : public tvm::AttrsNode<QConv2DAttrs> {
+  Array<IndexExpr> strides;
+  Array<IndexExpr> padding;
+  Array<IndexExpr> dilation;
+  int groups;
+  IndexExpr channels;
+  Array<IndexExpr> kernel_size;
+  tvm::String data_layout;
+  tvm::String kernel_layout;
+  tvm::String out_layout;
+  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  DataType out_dtype;
+
+  // Optional extra attributes for Hexagon target. Describes requantization parameters.
+  // Note, It is not set up explicitly through qnn._make.conv2d.
+  int axis;
+  DataType rq_out_dtype;
+
+  TVM_DECLARE_ATTRS(QConv2DAttrs, "relay.attrs.QConv2DAttrs") {
+    TVM_ATTR_FIELD(strides)
+        .set_default(Array<IndexExpr>({1, 1}))
+        .describe("Specifies the strides of the convolution.");
+    TVM_ATTR_FIELD(padding)
+        .set_default(Array<IndexExpr>({0, 0}))
+        .describe(
+            "If padding is non-zero, then the input is implicitly zero-padded"
+            "Padding support both symmetric and asymmetric as"
+            "one int : same padding used on all sides"
+            "two int : bottom, right will use same padding as top, left"
+            "four int : padding width in the order of (top, left, bottom, right)");
+    TVM_ATTR_FIELD(dilation)
+        .set_default(Array<IndexExpr>({1, 1}))
+        .describe("Specifies the dilation rate to use for dilated convolution.");
+    TVM_ATTR_FIELD(groups).set_default(1).describe(
+        "Controls the connections between inputs and outputs."
+        "At groups=1, all inputs are convolved to all outputs."
+        "At groups=2, the operation becomes equivalent to having two convolution"
+        "layers side by side, each seeing half the input channels, and producing"
+        "half the output channels, and both subsequently concatenated.");
+    TVM_ATTR_FIELD(channels)
+        .describe(
+            "The number of output channels in the convolution."
+            " If it is not set, inferred by shape of the weight.")
+        .set_default(NullValue<IndexExpr>());
+    TVM_ATTR_FIELD(kernel_size)
+        .describe("Specifies the dimensions of the convolution window.")
+        .set_default(NullValue<Array<IndexExpr>>());
+    TVM_ATTR_FIELD(data_layout)
+        .set_default("NCHW")
+        .describe(
+            "Dimension ordering of input data. Can be 'NCHW', 'NHWC', etc."
+            "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"
+            "dimensions respectively. Convolution is applied on the 'H' and"
+            "'W' dimensions.");
+    TVM_ATTR_FIELD(kernel_layout)
+        .set_default("OIHW")
+        .describe(
+            "Dimension ordering of weight. Can be 'OIHW', 'OIHW16o16i', etc."
+            "'O', 'I', 'H', 'W' stands for num_filter, input_channel, height, and width"
+            "dimensions respectively.");
+    TVM_ATTR_FIELD(out_layout)
+        .set_default("")
+        .describe(
+            "Dimension ordering of output. Can be 'NCHW', 'NHWC', etc."
+            "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"
+            "dimensions respectively. Default to be same as input layout.");
+
+    // use 0 bits to indicate none.
+    TVM_ATTR_FIELD(out_dtype)
+        .set_default(NullValue<DataType>())
+        .describe("Output data type, set to explicit type under mixed precision setting");
+
+    TVM_ATTR_FIELD(axis)
+        .describe(
+            "The channel axis for channel wise requantization. Default value is -1,"
+            "which corresponds to the last axis.")
+        .set_default(-1);
+    TVM_ATTR_FIELD(rq_out_dtype)
+        .set_default(NullValue<DataType>())
+        .describe("Requantized output data type");
+  }
+};
+
+/*! \brief Attributes for QNN dense operator */
+struct QDenseAttrs : public tvm::AttrsNode<QDenseAttrs> {
+  IndexExpr units;
+  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  DataType out_dtype;
+
+  // Optional extra attributes for Hexagon target. Describes requantization parameters.
+  // Note, It is not set up explicitly through qnn._make.dense.
+  int axis;
+  DataType rq_out_dtype;
+
+  TVM_DECLARE_ATTRS(QDenseAttrs, "relay.attrs.QDenseAttrs") {
+    TVM_ATTR_FIELD(units).describe("Number of hidden units of the dense transformation.");
+
+    // use 0 bits to indicate none.
+    TVM_ATTR_FIELD(out_dtype)
+        .set_default(NullValue<DataType>())
+        .describe("Output data type, set to explicit type under mixed precision setting");
+
+    TVM_ATTR_FIELD(axis)
+        .describe(
+            "The channel axis for channel wise requantization. Default value is -1,"
+            "which corresponds to the last axis.")
+        .set_default(-1);
+    TVM_ATTR_FIELD(rq_out_dtype)
+        .set_default(NullValue<DataType>())
+        .describe("Requantized output data type");
   }
 };
 

--- a/include/tvm/relay/qnn/attrs.h
+++ b/include/tvm/relay/qnn/attrs.h
@@ -214,7 +214,7 @@ struct QConv2DAttrs : public tvm::AttrsNode<QConv2DAttrs> {
 /*! \brief Attributes for QNN dense operator */
 struct QDenseAttrs : public tvm::AttrsNode<QDenseAttrs> {
   IndexExpr units;
-  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  tvm::String auto_scheduler_rewritten_layout;   // The layout after auto-scheduler's layout rewrite
   Array<PrimExpr> meta_schedule_original_shape;  // The original shape of the weights
   DataType out_dtype;
 

--- a/include/tvm/relay/qnn/attrs.h
+++ b/include/tvm/relay/qnn/attrs.h
@@ -137,7 +137,8 @@ struct QConv2DAttrs : public tvm::AttrsNode<QConv2DAttrs> {
   tvm::String data_layout;
   tvm::String kernel_layout;
   tvm::String out_layout;
-  tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  tvm::String auto_scheduler_rewritten_layout;   // The layout after auto-scheduler's layout rewrite
+  Array<PrimExpr> meta_schedule_original_shape;  // The original shape of the weights
   DataType out_dtype;
 
   // Optional extra attributes for Hexagon target. Describes requantization parameters.
@@ -214,6 +215,7 @@ struct QConv2DAttrs : public tvm::AttrsNode<QConv2DAttrs> {
 struct QDenseAttrs : public tvm::AttrsNode<QDenseAttrs> {
   IndexExpr units;
   tvm::String auto_scheduler_rewritten_layout;  // The layout after auto-scheduler's layout rewrite
+  Array<PrimExpr> meta_schedule_original_shape;  // The original shape of the weights
   DataType out_dtype;
 
   // Optional extra attributes for Hexagon target. Describes requantization parameters.

--- a/include/tvm/runtime/data_type.h
+++ b/include/tvm/runtime/data_type.h
@@ -125,6 +125,16 @@ class DataType {
    */
   DataType element_of() const { return with_lanes(1); }
   /*!
+   * \brief Assignment operator.
+   */
+  DataType& operator=(const DataType& rhs) {
+    if (this == &rhs) {
+      return *this;
+    }
+    data_ = rhs.data_;
+    return *this;
+  }
+  /*!
    * \brief Equal comparator.
    * \param other The data type to compare against.
    * \return The comparison result.

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -529,6 +529,16 @@ class RequantizeAttrs(Attrs):
     """Attributes used in requantize operators"""
 
 
+@tvm._ffi.register_object("relay.attrs.QConv2DAttrs")
+class QConv2DAttrs(Attrs):
+    """Attributes used in QNN conv2d operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.QDenseAttrs")
+class QDenseAttrs(Attrs):
+    """Attributes used in QNN dense operators"""
+
+
 @tvm._ffi.register_object("relay.attrs.ScatterAttrs")
 class ScatterAttrs(Attrs):
     """Attributes used in scatter operators"""

--- a/python/tvm/relay/qnn/op/_qnn.py
+++ b/python/tvm/relay/qnn/op/_qnn.py
@@ -79,3 +79,7 @@ register_pattern("qnn.conv2d", OpPattern.OUT_ELEMWISE_FUSABLE)
 # qnn.dense
 register_strategy("qnn.dense", strategy.qnn_dense_strategy)
 register_pattern("qnn.dense", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+# qnn.batch_matmul
+register_strategy("qnn.batch_matmul", strategy.qnn_batch_matmul_strategy)
+register_pattern("qnn.batch_matmul", OpPattern.OUT_ELEMWISE_FUSABLE)

--- a/python/tvm/relay/qnn/op/_qnn.py
+++ b/python/tvm/relay/qnn/op/_qnn.py
@@ -19,9 +19,10 @@
 
 from tvm import topi
 
+from .. import strategy
 from ...op.op import register_compute
 from ...op.op import register_injective_schedule
-from ...op.op import register_pattern, OpPattern
+from ...op.op import register_strategy, register_pattern, OpPattern
 
 
 @register_compute("qnn.simulated_quantize")
@@ -50,3 +51,27 @@ def simulated_dequantize_compute(attrs, inputs, output_type):
 
 register_injective_schedule("qnn.simulated_dequantize")
 register_pattern("qnn.simulated_dequantize", OpPattern.ELEMWISE)
+
+# qnn.quantize
+register_strategy("qnn.quantize", strategy.qnn_quantize_strategy)
+register_pattern("qnn.quantize", OpPattern.ELEMWISE)
+
+# qnn.dequantize
+register_strategy("qnn.dequantize", strategy.qnn_dequantize_strategy)
+register_pattern("qnn.dequantize", OpPattern.ELEMWISE)
+
+# qnn.requantize
+register_strategy("qnn.requantize", strategy.qnn_requantize_strategy)
+register_pattern("qnn.requantize", OpPattern.ELEMWISE)
+
+# qnn.add
+register_strategy("qnn.add", strategy.qnn_add_strategy)
+register_pattern("qnn.add", OpPattern.BROADCAST)
+
+# qnn.conv2d
+register_strategy("qnn.conv2d", strategy.qnn_conv2d_strategy)
+register_pattern("qnn.conv2d", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+# qnn.dense
+register_strategy("qnn.dense", strategy.qnn_dense_strategy)
+register_pattern("qnn.dense", OpPattern.OUT_ELEMWISE_FUSABLE)

--- a/python/tvm/relay/qnn/op/_qnn.py
+++ b/python/tvm/relay/qnn/op/_qnn.py
@@ -68,6 +68,10 @@ register_pattern("qnn.requantize", OpPattern.ELEMWISE)
 register_strategy("qnn.add", strategy.qnn_add_strategy)
 register_pattern("qnn.add", OpPattern.BROADCAST)
 
+# qnn.concatenate
+register_strategy("qnn.concatenate", strategy.qnn_concatenate_strategy)
+register_pattern("qnn.concatenate", OpPattern.INJECTIVE)
+
 # qnn.conv2d
 register_strategy("qnn.conv2d", strategy.qnn_conv2d_strategy)
 register_pattern("qnn.conv2d", OpPattern.OUT_ELEMWISE_FUSABLE)

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -228,7 +228,8 @@ def helper_no_fast_int8_hw_legalization(attrs, inputs, types, relay_op):
             -relay.cast(kernel_zero_point, dtype="int16"),
             output_axis,
         )
-    new_attrs = {k: attrs[k] for k in attrs.keys()}
+    # Skip optional extra attributes:
+    new_attrs = {k: attrs[k] for k in attrs.keys() if k not in ("axis", "rq_out_dtype")}
     return relay_op(shift_data, shift_kernel, **new_attrs)
 
 

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -228,8 +228,7 @@ def helper_no_fast_int8_hw_legalization(attrs, inputs, types, relay_op):
             -relay.cast(kernel_zero_point, dtype="int16"),
             output_axis,
         )
-    # Skip optional extra attributes:
-    new_attrs = {k: attrs[k] for k in attrs.keys() if k not in ("axis", "rq_out_dtype")}
+    new_attrs = {k: attrs[k] for k in attrs.keys()}
     return relay_op(shift_data, shift_kernel, **new_attrs)
 
 

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -29,8 +29,6 @@ from tvm.target import Target
 from tvm.topi.nn.qnn import SQNN_DTYPE_TO_CODE
 from tvm.topi.x86.utils import target_has_sse41
 
-from ... import op as reg
-from ...op import OpPattern
 from . import _make, _requantize
 
 
@@ -1210,11 +1208,6 @@ def batch_matmul(x, y, x_zero_point, y_zero_point, x_scale, y_scale, out_dtype="
         The computed result.
     """
     return _make.batch_matmul(x, y, x_zero_point, y_zero_point, x_scale, y_scale, out_dtype)
-
-
-# register fuse pattern for qnn ops
-reg.register_pattern("qnn.quantize", OpPattern.OPAQUE)
-reg.register_pattern("qnn.dequantize", OpPattern.OPAQUE)
 
 
 def leaky_relu(x, alpha, input_scale, input_zero_point, output_scale, output_zero_point):

--- a/python/tvm/relay/qnn/strategy/__init__.py
+++ b/python/tvm/relay/qnn/strategy/__init__.py
@@ -15,15 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-""" Schedules for Hexagon. """
-
 # pylint: disable=wildcard-import
+"""QNN op strategies."""
+from __future__ import absolute_import as _abs
 
-from .batch_matmul import *
-from .conv2d import *
-from .dense import *
-from .injective import *
-from .pooling import *
-from .qnn import *
-from .reduce import *
-from .resize2d import *
+from .generic import *
+from . import hexagon

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -39,11 +39,12 @@ def wrap_topi_compute(topi_compute):
 
 
 def wrap_compute_quantize(topi_compute):
-    """Wrap TOPI compute which use out data type from attrs"""
+    """Wrap TOPI compute which use axis and out data type from attrs"""
 
     def wrapper(attrs, inputs, _out_type):
+        axis = attrs.axis
         out_dtype = attrs.out_dtype
-        args = [*inputs, out_dtype]
+        args = [*inputs, axis, out_dtype]
         return [topi_compute(*args)]
 
     return wrapper
@@ -54,12 +55,13 @@ def wrap_topi_qnn_conv2d(topi_compute):
 
     def wrapper(attrs, inputs, out_type):
         oshape = out_type.shape
-        out_dtype = attrs.out_dtype
+        out_dtype = attrs.rq_out_dtype
         strides = attrs.strides
         padding = attrs.padding
         dilation = attrs.dilation
+        axis = attrs.axis
         if len([*inputs]) == 11:
-            args = [*inputs, strides, padding, dilation, oshape, out_dtype]
+            args = [*inputs, axis, strides, padding, dilation, oshape, out_dtype]
         elif len([*inputs]) == 10:
             args = [  # QNN Conv2d params:
                 inputs[0],
@@ -75,6 +77,8 @@ def wrap_topi_qnn_conv2d(topi_compute):
                 inputs[7],
                 inputs[8],
                 inputs[9],
+                axis,
+                # Conv2d attrs:
                 strides,
                 padding,
                 dilation,
@@ -92,6 +96,7 @@ def wrap_topi_qnn_conv2d(topi_compute):
                 None,
                 None,
                 None,
+                axis,
                 strides,
                 padding,
                 dilation,
@@ -107,9 +112,10 @@ def wrap_topi_qnn_dense(topi_compute):
     """Wrap TOPI compute which use qnn.dense attrs"""
 
     def wrapper(attrs, inputs, _out_type):
-        out_dtype = attrs.out_dtype
+        out_dtype = attrs.rq_out_dtype
+        axis = attrs.axis
         if len([*inputs]) == 11:
-            args = [*inputs, out_dtype]
+            args = [*inputs, axis, out_dtype]
         elif len([*inputs]) == 10:
             args = [  # QNN Dense params:
                 inputs[0],
@@ -125,6 +131,7 @@ def wrap_topi_qnn_dense(topi_compute):
                 inputs[7],
                 inputs[8],
                 inputs[9],
+                axis,
                 out_dtype,
             ]
         else:
@@ -138,6 +145,7 @@ def wrap_topi_qnn_dense(topi_compute):
                 None,
                 None,
                 None,
+                axis,
                 out_dtype,
             ]
         return [topi_compute(*args)]

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -163,6 +163,15 @@ def wrap_topi_qnn_dense(topi_compute):
     return wrapper
 
 
+def wrap_topi_concatenate(topi_compute):
+    """Wrap TOPI compute which use qnn.concatenate attrs"""
+
+    def wrapper(attrs, inputs, out_type):
+        return [topi_compute(inputs, attrs.axis, out_type.dtype)]
+
+    return wrapper
+
+
 @override_native_generic_func("qnn_quantize_strategy")
 def qnn_quantize_strategy(attrs, inputs, out_type, target):
     """qnn.quantize generic strategy"""
@@ -195,6 +204,15 @@ def qnn_add_strategy(attrs, inputs, out_type, target):
     """qnn.add generic strategy"""
     raise RuntimeError(
         "qnn.add is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_concatenate_strategy")
+def qnn_concatenate_strategy(attrs, inputs, out_type, target):
+    """qnn.concatenate generic strategy"""
+    raise RuntimeError(
+        "qnn.concatenate is currently only supported with Hexagon. "
         "Please run QNN Canonicalize pass to decompose this op into supported ops."
     )
 

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -16,7 +16,12 @@
 # under the License.
 """Definition of generic operator strategy."""
 
+from tvm import _ffi
 from tvm.target import override_native_generic_func
+
+
+GET_RQ_OUT_DTYPE = _ffi.get_global_func("relay.attrs.get_rq_out_dtype")
+GET_RQ_AXIS = _ffi.get_global_func("relay.attrs.get_rq_axis")
 
 
 def wrap_topi_schedule(topi_schedule):
@@ -64,12 +69,12 @@ def wrap_topi_qnn_conv2d(topi_compute):
     """Wrap TOPI compute which use conv2d attrs and output data type"""
 
     def wrapper(attrs, inputs, out_type):
+        out_dtype = GET_RQ_OUT_DTYPE(attrs)
+        axis = GET_RQ_AXIS(attrs)
         oshape = out_type.shape
-        out_dtype = attrs.rq_out_dtype
         strides = attrs.strides
         padding = attrs.padding
         dilation = attrs.dilation
-        axis = attrs.axis
         if len([*inputs]) == 11:
             args = [*inputs, axis, strides, padding, dilation, oshape, out_dtype]
         elif len([*inputs]) == 10:
@@ -122,8 +127,8 @@ def wrap_topi_qnn_dense(topi_compute):
     """Wrap TOPI compute which use qnn.dense attrs"""
 
     def wrapper(attrs, inputs, _out_type):
-        out_dtype = attrs.rq_out_dtype
-        axis = attrs.axis
+        out_dtype = GET_RQ_OUT_DTYPE(attrs)
+        axis = GET_RQ_AXIS(attrs)
         if len([*inputs]) == 11:
             args = [*inputs, axis, out_dtype]
         elif len([*inputs]) == 10:

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -50,6 +50,16 @@ def wrap_compute_quantize(topi_compute):
     return wrapper
 
 
+def wrap_compute_dequantize(topi_compute):
+    """Wrap TOPI compute which use axis from attrs"""
+
+    def wrapper(attrs, inputs, _out_type):
+        args = [*inputs, attrs.axis]
+        return [topi_compute(*args)]
+
+    return wrapper
+
+
 def wrap_topi_qnn_conv2d(topi_compute):
     """Wrap TOPI compute which use conv2d attrs and output data type"""
 

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -172,6 +172,17 @@ def wrap_topi_concatenate(topi_compute):
     return wrapper
 
 
+def wrap_topi_qnn_batch_matmul(topi_compute):
+    """Wrap TOPI compute which use qnn.batch_matmul attrs"""
+
+    def wrapper(attrs, inputs, _out_type):
+        assert len([*inputs]) == 6
+        args = [*inputs, attrs.transpose_a, attrs.transpose_b, attrs.out_dtype]
+        return [topi_compute(*args)]
+
+    return wrapper
+
+
 @override_native_generic_func("qnn_quantize_strategy")
 def qnn_quantize_strategy(attrs, inputs, out_type, target):
     """qnn.quantize generic strategy"""
@@ -231,5 +242,14 @@ def qnn_dense_strategy(attrs, inputs, out_type, target):
     """qnn.dense generic strategy"""
     raise RuntimeError(
         "qnn.dense is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_batch_matmul_strategy")
+def qnn_batch_matmul_strategy(attrs, inputs, out_type, target):
+    """qnn.batch_matmul generic strategy"""
+    raise RuntimeError(
+        "qnn.batch_matmul is currently only supported with Hexagon. "
         "Please run QNN Canonicalize pass to decompose this op into supported ops."
     )

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -103,6 +103,48 @@ def wrap_topi_qnn_conv2d(topi_compute):
     return wrapper
 
 
+def wrap_topi_qnn_dense(topi_compute):
+    """Wrap TOPI compute which use qnn.dense attrs"""
+
+    def wrapper(attrs, inputs, _out_type):
+        out_dtype = attrs.out_dtype
+        if len([*inputs]) == 11:
+            args = [*inputs, out_dtype]
+        elif len([*inputs]) == 10:
+            args = [  # QNN Dense params:
+                inputs[0],
+                inputs[1],
+                inputs[2],
+                inputs[3],
+                inputs[4],
+                inputs[5],
+                # Bias argument
+                None,
+                # Requantization params:
+                inputs[6],
+                inputs[7],
+                inputs[8],
+                inputs[9],
+                out_dtype,
+            ]
+        else:
+            assert len([*inputs]) == 6
+            args = [  # QNN Dense params:
+                *inputs,
+                # Bias argument:
+                None,
+                # Requantization params:
+                None,
+                None,
+                None,
+                None,
+                out_dtype,
+            ]
+        return [topi_compute(*args)]
+
+    return wrapper
+
+
 @override_native_generic_func("qnn_quantize_strategy")
 def qnn_quantize_strategy(attrs, inputs, out_type, target):
     """qnn.quantize generic strategy"""

--- a/python/tvm/relay/qnn/strategy/generic.py
+++ b/python/tvm/relay/qnn/strategy/generic.py
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Definition of generic operator strategy."""
+
+from tvm.target import override_native_generic_func
+
+
+def wrap_topi_schedule(topi_schedule):
+    """Wrap TOPI schedule which doesn't use attrs"""
+
+    def wrapper(_attrs, outs, target):
+        with target:
+            return topi_schedule(outs)
+
+    return wrapper
+
+
+def wrap_topi_compute(topi_compute):
+    """Wrap TOPI compute which doesn't use attrs"""
+
+    def wrapper(_attrs, inputs, _out_type):
+        return [topi_compute(*inputs)]
+
+    return wrapper
+
+
+def wrap_compute_quantize(topi_compute):
+    """Wrap TOPI compute which use out data type from attrs"""
+
+    def wrapper(attrs, inputs, _out_type):
+        out_dtype = attrs.out_dtype
+        args = [*inputs, out_dtype]
+        return [topi_compute(*args)]
+
+    return wrapper
+
+
+def wrap_topi_qnn_conv2d(topi_compute):
+    """Wrap TOPI compute which use conv2d attrs and output data type"""
+
+    def wrapper(attrs, inputs, out_type):
+        oshape = out_type.shape
+        out_dtype = attrs.out_dtype
+        strides = attrs.strides
+        padding = attrs.padding
+        dilation = attrs.dilation
+        if len([*inputs]) == 11:
+            args = [*inputs, strides, padding, dilation, oshape, out_dtype]
+        elif len([*inputs]) == 10:
+            args = [  # QNN Conv2d params:
+                inputs[0],
+                inputs[1],
+                inputs[2],
+                inputs[3],
+                inputs[4],
+                inputs[5],
+                # Bias argument
+                None,
+                # Requantization params:
+                inputs[6],
+                inputs[7],
+                inputs[8],
+                inputs[9],
+                strides,
+                padding,
+                dilation,
+                oshape,
+                out_dtype,
+            ]
+        else:
+            assert len([*inputs]) == 6
+            args = [  # QNN Conv2d params:
+                *inputs,
+                # Bias argument:
+                None,
+                # Requantization params:
+                None,
+                None,
+                None,
+                None,
+                strides,
+                padding,
+                dilation,
+                oshape,
+                out_dtype,
+            ]
+        return [topi_compute(*args)]
+
+    return wrapper
+
+
+@override_native_generic_func("qnn_quantize_strategy")
+def qnn_quantize_strategy(attrs, inputs, out_type, target):
+    """qnn.quantize generic strategy"""
+    raise RuntimeError(
+        "qnn.quantize is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_dequantize_strategy")
+def qnn_dequantize_strategy(attrs, inputs, out_type, target):
+    """qnn.dequantize generic strategy"""
+    raise RuntimeError(
+        "qnn.dequantize is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_requantize_strategy")
+def qnn_requantize_strategy(attrs, inputs, out_type, target):
+    """qnn.requantize generic strategy"""
+    raise RuntimeError(
+        "qnn.requantize is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_add_strategy")
+def qnn_add_strategy(attrs, inputs, out_type, target):
+    """qnn.add generic strategy"""
+    raise RuntimeError(
+        "qnn.add is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_conv2d_strategy")
+def qnn_conv2d_strategy(attrs, inputs, out_type, target):
+    """qnn.conv2d generic strategy"""
+    raise RuntimeError(
+        "qnn.conv2d is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )
+
+
+@override_native_generic_func("qnn_dense_strategy")
+def qnn_dense_strategy(attrs, inputs, out_type, target):
+    """qnn.dense generic strategy"""
+    raise RuntimeError(
+        "qnn.dense is currently only supported with Hexagon. "
+        "Please run QNN Canonicalize pass to decompose this op into supported ops."
+    )

--- a/python/tvm/relay/qnn/strategy/hexagon.py
+++ b/python/tvm/relay/qnn/strategy/hexagon.py
@@ -23,8 +23,7 @@ from ... import op as _op
 from ...op.strategy.generic import is_depthwise_conv2d
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_quantize_strategy.register("cpu")
+@qnn_quantize_strategy.register("hexagon")
 def qnn_quantize_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.quantize strategy for Hexagon"""
     strategy = _op.OpStrategy()
@@ -36,8 +35,7 @@ def qnn_quantize_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_dequantize_strategy.register("cpu")
+@qnn_dequantize_strategy.register("hexagon")
 def qnn_dequantize_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.dequantize strategy for Hexagon"""
     strategy = _op.OpStrategy()
@@ -49,8 +47,7 @@ def qnn_dequantize_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_requantize_strategy.register("cpu")
+@qnn_requantize_strategy.register("hexagon")
 def qnn_requantize_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.requantize strategy for Hexagon"""
     strategy = _op.OpStrategy()
@@ -62,8 +59,7 @@ def qnn_requantize_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_add_strategy.register("cpu")
+@qnn_add_strategy.register("hexagon")
 def qnn_add_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.add strategy for Hexagon"""
     strategy = _op.OpStrategy()
@@ -75,8 +71,7 @@ def qnn_add_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_concatenate_strategy.register("cpu")
+@qnn_concatenate_strategy.register("hexagon")
 def qnn_concatenate_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.concatenate strategy for Hexagon"""
     strategy = _op.OpStrategy()
@@ -88,8 +83,7 @@ def qnn_concatenate_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_conv2d_strategy.register("cpu")
+@qnn_conv2d_strategy.register("hexagon")
 def qnn_conv2d_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.conv2d strategy for Hexagon"""
     data = inputs[0]
@@ -118,8 +112,7 @@ def qnn_conv2d_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_dense_strategy.register("cpu")
+@qnn_dense_strategy.register("hexagon")
 def qnn_dense_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.dense strategy for Hexagon"""
     strategy = _op.OpStrategy()
@@ -131,8 +124,7 @@ def qnn_dense_strategy_hexagon(attrs, inputs, out_type, target):
     return strategy
 
 
-# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
-@qnn_batch_matmul_strategy.register("cpu")
+@qnn_batch_matmul_strategy.register("hexagon")
 def qnn_batch_matmul_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.batch_matmul strategy for Hexagon"""
     strategy = _op.OpStrategy()

--- a/python/tvm/relay/qnn/strategy/hexagon.py
+++ b/python/tvm/relay/qnn/strategy/hexagon.py
@@ -42,7 +42,7 @@ def qnn_dequantize_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.dequantize strategy for Hexagon"""
     strategy = _op.OpStrategy()
     strategy.add_implementation(
-        wrap_topi_compute(topi.hexagon.qnn_dequantize),
+        wrap_compute_dequantize(topi.hexagon.qnn_dequantize),
         wrap_topi_schedule(topi.hexagon.schedule_qnn_dequantize),
         name="qnn_dequantize.hexagon",
     )

--- a/python/tvm/relay/qnn/strategy/hexagon.py
+++ b/python/tvm/relay/qnn/strategy/hexagon.py
@@ -97,7 +97,7 @@ def qnn_dense_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.dense strategy for Hexagon"""
     strategy = _op.OpStrategy()
     strategy.add_implementation(
-        wrap_compute_quantize(topi.hexagon.qnn_dense),
+        wrap_topi_qnn_dense(topi.hexagon.qnn_dense),
         wrap_topi_schedule(topi.hexagon.schedule_qnn_dense),
         name="qnn_dense.hexagon",
     )

--- a/python/tvm/relay/qnn/strategy/hexagon.py
+++ b/python/tvm/relay/qnn/strategy/hexagon.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Definition of Hexagon operator strategy."""
+# pylint: disable=unused-argument,wildcard-import,unused-wildcard-import
+
+from tvm import topi
+from .generic import *
+from ... import op as _op
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_quantize_strategy.register("cpu")
+def qnn_quantize_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.quantize strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_quantize(topi.hexagon.qnn_quantize),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_quantize),
+        name="qnn_quantize.hexagon",
+    )
+    return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_dequantize_strategy.register("cpu")
+def qnn_dequantize_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.dequantize strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_topi_compute(topi.hexagon.qnn_dequantize),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_dequantize),
+        name="qnn_dequantize.hexagon",
+    )
+    return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_requantize_strategy.register("cpu")
+def qnn_requantize_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.requantize strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_quantize(topi.hexagon.qnn_requantize),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_requantize),
+        name="qnn_requantize.hexagon",
+    )
+    return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_add_strategy.register("cpu")
+def qnn_add_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.add strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_topi_compute(topi.hexagon.qnn_add),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_add),
+        name="qnn_add.hexagon",
+    )
+    return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_conv2d_strategy.register("cpu")
+def qnn_conv2d_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.conv2d strategy for Hexagon"""
+    data_layout = attrs.data_layout
+    groups = attrs.groups
+    strategy = _op.OpStrategy()
+    if groups == 1:
+        if data_layout == "NCHW":
+            strategy.add_implementation(
+                wrap_topi_qnn_conv2d(topi.hexagon.qnn_conv2d),
+                wrap_topi_schedule(topi.hexagon.schedule_qnn_conv2d),
+                name="qnn_conv2d.hexagon",
+            )
+    return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_dense_strategy.register("cpu")
+def qnn_dense_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.dense strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_quantize(topi.hexagon.qnn_dense),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_dense),
+        name="qnn_dense.hexagon",
+    )
+    return strategy

--- a/python/tvm/relay/qnn/strategy/hexagon.py
+++ b/python/tvm/relay/qnn/strategy/hexagon.py
@@ -76,6 +76,19 @@ def qnn_add_strategy_hexagon(attrs, inputs, out_type, target):
 
 
 # TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_concatenate_strategy.register("cpu")
+def qnn_concatenate_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.concatenate strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_topi_concatenate(topi.hexagon.qnn_concatenate),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_concatenate),
+        name="qnn_concatenate.hexagon",
+    )
+    return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
 @qnn_conv2d_strategy.register("cpu")
 def qnn_conv2d_strategy_hexagon(attrs, inputs, out_type, target):
     """qnn.conv2d strategy for Hexagon"""

--- a/python/tvm/relay/qnn/strategy/hexagon.py
+++ b/python/tvm/relay/qnn/strategy/hexagon.py
@@ -129,3 +129,16 @@ def qnn_dense_strategy_hexagon(attrs, inputs, out_type, target):
         name="qnn_dense.hexagon",
     )
     return strategy
+
+
+# TODO: This is POC code. Change it on "hexagon" instead of "cpu"
+@qnn_batch_matmul_strategy.register("cpu")
+def qnn_batch_matmul_strategy_hexagon(attrs, inputs, out_type, target):
+    """qnn.batch_matmul strategy for Hexagon"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_topi_qnn_batch_matmul(topi.hexagon.qnn_batch_matmul),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_batch_matmul),
+        name="qnn_batch_matmul.hexagon",
+    )
+    return strategy

--- a/python/tvm/te/__init__.py
+++ b/python/tvm/te/__init__.py
@@ -26,6 +26,7 @@ from tvm.tir import trunc, abs, round, nearbyint, power, popcount, fmod, if_then
 from tvm.tir import isnan, isfinite, isinf
 from tvm.tir import div, indexdiv, indexmod, truncdiv, truncmod, floordiv, floormod
 from tvm.tir import comm_reducer, min, max, sum
+from tvm.tir import add, subtract, multiply
 
 from .schedule import (
     Schedule,

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -57,6 +57,7 @@ from .op import isnan, isfinite, isinf, copysign
 from .op import div, indexdiv, indexmod, truncdiv, truncmod, floordiv, floormod, ceildiv
 from .op import comm_reducer, min, max, sum
 from .op import q_multiply_shift
+from .generic import add, subtract, multiply
 
 from .schedule import StmtSRef, BlockScope, ScheduleState, Schedule, ScheduleError
 

--- a/python/tvm/topi/hexagon/qnn.py
+++ b/python/tvm/topi/hexagon/qnn.py
@@ -1,0 +1,314 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Hexagon QNN operators"""
+# pylint: disable=invalid-name
+
+import tvm
+from tvm import te
+from ..generic.default import default_schedule as _default_schedule
+from ..utils import get_const_tuple
+from ..nn.utils import get_pad_tuple
+from ..nn.pad import pad
+
+
+def qnn_quantize(data, output_scale, output_zero_point, out_dtype):
+    """Compute for qnn.quantize
+    Q_output = clamp((round(input_tensor/output_scale) + output_zero_point),
+                     out_dtype::min,
+                     out_dtype::max)
+    TODO: Support 'axis' argument.
+    """
+
+    def _compute(*indices):
+        value = data(*indices)
+        const_min = tvm.tir.min_value(out_dtype)
+        const_max = tvm.tir.max_value(out_dtype)
+        val = te.add(te.round(te.div(value, output_scale)), output_zero_point)
+        return te.max(tvm.te.min(val, const_max), const_min).astype(out_dtype)
+
+    return te.compute(data.shape, _compute)
+
+
+def schedule_qnn_quantize(outs):
+    """Schedule for qnn.quantize
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of qnn.quantize
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+def qnn_dequantize(data, input_scale, input_zero_point):
+    """Compute for qnn.dequantize
+    fp_output = input_scale * (Q_input - input_zero_point)
+    TODO: Support 'axis' argument.
+    """
+
+    def _compute(*indices):
+        value = data(*indices)
+        return te.multiply(input_scale, te.subtract(value, input_zero_point))
+
+    return te.compute(data.shape, _compute)
+
+
+def schedule_qnn_dequantize(outs):
+    """Schedule for qnn.dequantize
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of qnn.dequantize
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+def qnn_requantize(data, input_scale, input_zero_point, output_scale, output_zero_point, out_dtype):
+    """Compute for qnn.requantize
+    Q_output = zp_output + round((scale_input)/(scale_output) * (Q_input - zp_input))
+
+    TODO: support 'axis', 'rounding' and 'compute_dtype' arguments.
+    """
+
+    def _compute(*indices):
+        value = data(*indices)
+        sub = te.subtract(value, input_zero_point)
+        mul = te.div(input_scale, output_scale)
+        val = te.add(te.round(te.multiply(mul, sub)), output_zero_point)
+
+        # clip + cast:
+        const_min = tvm.tir.min_value(out_dtype)
+        const_max = tvm.tir.max_value(out_dtype)
+        return te.max(tvm.te.min(val, const_max), const_min).astype(out_dtype)
+
+    return te.compute(data.shape, _compute)
+
+
+def schedule_qnn_requantize(outs):
+    """Schedule for qnn.requantize
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of qnn.requantize
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+def qnn_add(
+    lhs, rhs, lhs_scale, lhs_zero_point, rhs_scale, rhs_zero_point, output_scale, output_zero_point
+):
+    """Compute for qnn.add
+    Q_output = zp_output + round((lhs_scale)/(scale_output) * (lhs_input - lhs_zp_input))
+                         + round((rhs_scale)/(scale_output) * (rhs_input - rhs_zp_input))
+
+    TODO: support 'axis' argument.
+    """
+
+    assert lhs.dtype == rhs.dtype
+    dtype = lhs.dtype
+
+    def _compute(*indices):
+        lvalue = lhs(*indices)
+        rvalue = rhs(*indices)
+        q_lv = te.round(
+            te.multiply(te.div(lhs_scale, output_scale), te.subtract(lvalue, lhs_zero_point))
+        ).astype(dtype)
+        q_rv = te.round(
+            te.multiply(te.div(rhs_scale, output_scale), te.subtract(rvalue, rhs_zero_point))
+        ).astype(dtype)
+        return te.add(te.add(q_lv, q_rv), output_zero_point).astype(dtype)
+
+    return te.compute(lhs.shape, _compute)
+
+
+def schedule_qnn_add(outs):
+    """Schedule for qnn.add
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of qnn.add
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+def qnn_conv2d(  # Conv2d inputs
+    data,
+    weight,
+    # Conv2d quantization params:
+    input_zero_point,
+    kernel_zero_point,
+    _input_scale,
+    _kernel_scale,
+    # bias
+    bias,
+    # Requantization params:
+    rq_input_scale,
+    rq_input_zero_point,
+    rq_output_scale,
+    rq_output_zero_point,
+    # Conv2d attributes:
+    strides,
+    padding,
+    dilation,
+    oshape,
+    odtype,
+):
+    """Compute for qnn.conv2d with NCHW layout"""
+    in_channel = data.shape[1]  # NCHW layout
+    kernel_height = weight.shape[2]  # OIHW layout
+    kernel_width = weight.shape[3]  # OIHW layout
+
+    height_stride, width_stride = strides
+    dilation_h, dilation_w = dilation
+
+    dilated_kernel_h = (kernel_height - 1) * dilation_h + 1
+    dilated_kernel_w = (kernel_width - 1) * dilation_w + 1
+
+    pad_top, pad_left, pad_down, pad_right = get_pad_tuple(
+        get_const_tuple(padding), (dilated_kernel_h, dilated_kernel_w)
+    )
+
+    # DOPAD
+    if pad_top != 0 or pad_down != 0 or pad_left != 0 or pad_right != 0:
+        pad_before = (0, 0, pad_top, pad_left)
+        pad_after = (0, 0, pad_down, pad_right)
+        data_pad = pad(data, pad_before, pad_after, name="data_pad")
+    else:
+        data_pad = data
+
+    ic = te.reduce_axis((0, in_channel), name="ic")
+    kh = te.reduce_axis((0, kernel_height), name="kh")
+    kw = te.reduce_axis((0, kernel_width), name="kw")
+
+    out = te.compute(
+        oshape,
+        lambda n, oc, oh, ow: te.sum(
+            te.subtract(
+                data_pad[
+                    n,
+                    ic,
+                    oh * height_stride + kh * dilation_h,
+                    ow * width_stride + kw * dilation_w,
+                ],
+                input_zero_point,
+            ).astype("int32")
+            * te.subtract(weight[oc, ic, kh, kw], kernel_zero_point).astype("int32"),
+            axis=[ic, kh, kw],
+        ),
+    )
+
+    # Add bias
+    if bias is not None:
+        assert len(out.shape) == len(bias.shape)
+        assert bias.shape[2] == 1 and bias.shape[3] == 1
+        out = te.compute(out.shape, lambda n, c, h, w: out[n, c, h, w] + bias[n, c, 1, 1])
+
+    def _rq_compute(*indices):
+        value = out(*indices)
+        sub = te.subtract(value, rq_input_zero_point)
+        mul = te.div(rq_input_scale, rq_output_scale)
+        val = te.add(te.round(te.multiply(mul, sub)), rq_output_zero_point)
+
+        # clip + cast:
+        const_min = tvm.tir.min_value(odtype)
+        const_max = tvm.tir.max_value(odtype)
+        return te.max(tvm.te.min(val, const_max), const_min).astype(odtype)
+
+    # Requantize output of convolution
+    # Q_output = zp_output + round((scale_input)/(scale_output) * (Q_input - zp_input))
+    if rq_input_scale is not None and rq_output_scale is not None:
+        return te.compute(out.shape, _rq_compute)
+
+    return out
+
+
+def schedule_qnn_conv2d(outs):
+    """Schedule for qnn.conv2d
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of qnn.conv2d
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+def qnn_dense(
+    data, weight, input_zero_point, kernel_zero_point, _input_scale, _kernel_scale, out_dtype
+):
+    """Compute for qnn.dense"""
+    M, K = get_const_tuple(data.shape)
+    N, _ = get_const_tuple(weight.shape)
+    k = te.reduce_axis((0, K), "k")
+    return te.compute(
+        (M, N),
+        lambda m, n: te.sum(
+            te.subtract(data[m, k], input_zero_point).astype(out_dtype)
+            * te.subtract(weight[n, k], kernel_zero_point).astype(out_dtype),
+            axis=k,
+        ),
+    )
+
+
+def schedule_qnn_dense(outs):
+    """Schedule for qnn.dense
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of qnn.dense
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)

--- a/python/tvm/topi/hexagon/qnn.py
+++ b/python/tvm/topi/hexagon/qnn.py
@@ -267,7 +267,7 @@ def qnn_conv2d(  # Conv2d inputs
     if bias is not None:
         assert len(out.shape) == len(bias.shape)
         assert bias.shape[2] == 1 and bias.shape[3] == 1
-        out = te.compute(out.shape, lambda n, c, h, w: out[n, c, h, w] + bias[n, c, 1, 1])
+        out = te.compute(out.shape, lambda n, c, h, w: out[n, c, h, w] + bias[n, c, 0, 0])
 
     # Requantize output of convolution
     # Q_output = zp_output + round((scale_input)/(scale_output) * (Q_input - zp_input))

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -328,7 +328,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     backend::BindParamsInModule(relay_module, params_);
 
     Array<Pass> pass_seqs =
-        GetPassPrefix(/*is_homogenous=*/config_->primitive_targets.size() == 1, /*is_vm=*/false);
+        GetPassPrefix(/*homogeneous target=*/config_->optional_homogeneous_target, /*is_vm=*/false);
     transform::PassContext pass_ctx = PassContext::Current();
 
     if (config_->optional_homogeneous_target.defined()) {

--- a/src/relay/backend/contrib/cmsisnn/convolutions.cc
+++ b/src/relay/backend/contrib/cmsisnn/convolutions.cc
@@ -29,7 +29,7 @@ namespace relay {
 namespace contrib {
 namespace cmsisnn {
 
-bool IsCMSISNNDepthwise(const Conv2DAttrs* conv2d_attrs, const Array<PrimExpr>& input_shape,
+bool IsCMSISNNDepthwise(const qnn::QConv2DAttrs* conv2d_attrs, const Array<PrimExpr>& input_shape,
                         const Array<PrimExpr>& kernel_shape) {
   std::string kernel_layout = conv2d_attrs->kernel_layout.c_str();
   int kernel_pos_o = kernel_layout.find("O");

--- a/src/relay/backend/contrib/cmsisnn/convolutions.h
+++ b/src/relay/backend/contrib/cmsisnn/convolutions.h
@@ -49,7 +49,7 @@ namespace cmsisnn {
  * attributes
  */
 
-bool IsCMSISNNDepthwise(const Conv2DAttrs* conv2d_attrs, const Array<PrimExpr>& input_shape,
+bool IsCMSISNNDepthwise(const qnn::QConv2DAttrs* conv2d_attrs, const Array<PrimExpr>& input_shape,
                         const Array<PrimExpr>& kernel_shape);
 
 }  // namespace cmsisnn

--- a/src/relay/backend/contrib/cmsisnn/generate_constants.cc
+++ b/src/relay/backend/contrib/cmsisnn/generate_constants.cc
@@ -50,7 +50,8 @@ class GenerateConstantsMutator : public MixedModeMutator {
 
  private:
   /*!  * \brief Converts Kernel layout from HWIO to OHWI to align to CMSIS-NN requirements */
-  Expr ConvertKernelLayout(Expr kernel_expr, const Conv2DAttrs* conv2d_attrs, Attrs* new_attrs) {
+  Expr ConvertKernelLayout(Expr kernel_expr, const qnn::QConv2DAttrs* conv2d_attrs,
+                           Attrs* new_attrs) {
     auto attrs = make_object<Conv2DAttrs>();
     attrs->strides = std::move(conv2d_attrs->strides);
     attrs->padding = std::move(conv2d_attrs->padding);
@@ -106,7 +107,7 @@ class GenerateConstantsMutator : public MixedModeMutator {
       conv2d_call = requantize_input;
     }
 
-    auto* conv2d_attrs = conv2d_call->attrs.as<Conv2DAttrs>();
+    auto* conv2d_attrs = conv2d_call->attrs.as<qnn::QConv2DAttrs>();
     tvm::Attrs new_conv2d_attrs = conv2d_call->attrs;
     Expr conv2d_kernel = conv2d_call->args[1];
 

--- a/src/relay/backend/contrib/cmsisnn/relay_to_tir.cc
+++ b/src/relay/backend/contrib/cmsisnn/relay_to_tir.cc
@@ -163,7 +163,7 @@ class RelayToTIRVisitor : public MixedModeMutator {
     // https://github.com/ARM-software/CMSIS_5/blob/def6f800f95661eb3451d317f7d0dde504f6020d/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c#L50
 
     // prepare cmsis_nn_conv_params
-    const Conv2DAttrs* conv2d_attrs = conv2d_call->attrs.as<Conv2DAttrs>();
+    const qnn::QConv2DAttrs* conv2d_attrs = conv2d_call->attrs.as<qnn::QConv2DAttrs>();
     int32_t input_offset = -GetScalarFromConstant<int32_t>(conv2d_call->args[2]);
     int32_t output_offset = GetScalarFromConstant<int32_t>(requantize_call->args[4]);
     int32_t stride_w = qnn::get_const_int(conv2d_attrs->strides[1]);
@@ -310,7 +310,7 @@ class RelayToTIRVisitor : public MixedModeMutator {
     // https://github.com/ARM-software/CMSIS_5/blob/def6f800f95661eb3451d317f7d0dde504f6020d/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c#L50
 
     // prepare cmsis_nn_fc_params
-    const DenseAttrs* dense_attrs = fc_call->attrs.as<DenseAttrs>();
+    const qnn::QDenseAttrs* dense_attrs = fc_call->attrs.as<qnn::QDenseAttrs>();
     int32_t input_offset = -GetScalarFromConstant<int32_t>(fc_call->args[2]);
     int32_t filter_offset = -GetScalarFromConstant<int32_t>(fc_call->args[3]);
     int32_t output_offset = GetScalarFromConstant<int32_t>(requantize_call->args[4]);

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -40,7 +40,7 @@ Array<meta_schedule::ExtractedTask> ExtractTask(
   }
   backend::BindParamsInModule(mod, params);
   // is_vm=true for backward compatibility
-  Array<Pass> pass_seqs = relay::backend::GetPassPrefix(/*is_homogenous=*/true, /*is_vm=*/true);
+  Array<Pass> pass_seqs = relay::backend::GetPassPrefix(target, /*is_vm=*/true);
   pass_seqs.push_back(transform::FuseOps());
   mod = transform::Sequential(pass_seqs)(std::move(mod));
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -198,6 +198,8 @@ class PatternMatcher {
 
   const CallNode* GetAnchorOp() { return anchor_op_; }
 
+  void Clear() { registered_ops_.clear(); }
+
  private:
   const Op& qnn_conv2d_op_;
   const Op& qnn_dense_op_;
@@ -337,6 +339,8 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
         outputs = lowered_out->outputs;
         Op a_op = Downcast<Op>(anchor_op->op);
         op_implementations_[a_op.operator->()] = lowered_out->implementation;
+
+        pattern_matcher_.Clear();
       } else {
         // Forward inputs as "outputs" for successor.
         readable_name_stream_ << '_' << op->name;

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -316,12 +316,6 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
       }
     }
 
-    if (count_tuple) {
-      ICHECK_EQ(call_node->args.size(), 1U)
-          << "Only functions with a single tuple input are allowed, but " << count_tuple
-          << " were provided.";
-    }
-
     ICHECK(call_node->op.as<OpNode>()) << "Primitive function only allows call into primitive ops";
     Op op = Downcast<Op>(call_node->op);
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -301,7 +301,8 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     static auto flower_call = tvm::runtime::Registry::Get("relay.backend.lower_call");
     ICHECK(flower_call) << "relay.backend.lower_call is not registered.";
 
-    pattern_matcher_.Register(call_node);
+    // Should be changed on kDLHexagon
+    if (target_->kind->device_type == kDLCPU) pattern_matcher_.Register(call_node);
 
     Array<te::Tensor> inputs;
     int count_tuple = 0;

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -310,8 +310,7 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     static auto flower_call = tvm::runtime::Registry::Get("relay.backend.lower_call");
     ICHECK(flower_call) << "relay.backend.lower_call is not registered.";
 
-    // Should be changed on kDLHexagon
-    if (target_->kind->device_type == kDLCPU) pattern_matcher_.Register(call_node);
+    if (target_->kind->device_type == kDLHexagon) pattern_matcher_.Register(call_node);
 
     Array<te::Tensor> inputs;
     int count_tuple = 0;

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -226,8 +226,8 @@ Array<Pass> GetPassPrefix(Target homogeneous_target, bool is_vm) {
   pass_seqs.push_back(transform::RemoveUnusedFunctions(entry_functions));
   pass_seqs.push_back(transform::ToBasicBlockNormalForm());
   // Run all dialect legalization passes.
-  // Should be changed on kDLHexagon
-  if ((is_homogeneous && homogeneous_target->kind->device_type != kDLCPU) || !is_homogeneous)
+  // Skip these passes for Hexagon target.
+  if ((is_homogeneous && homogeneous_target->kind->device_type != kDLHexagon) || !is_homogeneous)
     pass_seqs.push_back(relay::qnn::transform::Legalize());
 
   // Legalize pass is restricted to homogeneous execution for now.

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -214,17 +214,21 @@ ExecutorCodegenMetadata::ExecutorCodegenMetadata(
 
 TVM_REGISTER_NODE_TYPE(ExecutorCodegenMetadataNode);
 
-Array<Pass> GetPassPrefix(bool is_homogeneous, bool is_vm) {
+Array<Pass> GetPassPrefix(Target homogeneous_target, bool is_vm) {
   Array<Pass> pass_seqs;
   // TODO(mbs): Would be nice to get spans on all diagnostics, but since they arg forgotton
   // by most passes there's little utility in including this now. Plus we'd need to only do
   // this if there's no existing spans to work from.
   // pass_seqs.push_back(parser::AnnotateSpans());
   Array<runtime::String> entry_functions{"main"};
+  // Can be undefined in case of heterogeneous execution
+  bool is_homogeneous = homogeneous_target.defined();
   pass_seqs.push_back(transform::RemoveUnusedFunctions(entry_functions));
   pass_seqs.push_back(transform::ToBasicBlockNormalForm());
   // Run all dialect legalization passes.
-  // pass_seqs.push_back(relay::qnn::transform::Legalize());
+  // Should be changed on kDLHexagon
+  if ((is_homogeneous && homogeneous_target->kind->device_type != kDLCPU) || !is_homogeneous)
+    pass_seqs.push_back(relay::qnn::transform::Legalize());
 
   // Legalize pass is restricted to homogeneous execution for now.
   if (is_homogeneous) {

--- a/src/relay/backend/utils.cc
+++ b/src/relay/backend/utils.cc
@@ -224,7 +224,7 @@ Array<Pass> GetPassPrefix(bool is_homogeneous, bool is_vm) {
   pass_seqs.push_back(transform::RemoveUnusedFunctions(entry_functions));
   pass_seqs.push_back(transform::ToBasicBlockNormalForm());
   // Run all dialect legalization passes.
-  pass_seqs.push_back(relay::qnn::transform::Legalize());
+  // pass_seqs.push_back(relay::qnn::transform::Legalize());
 
   // Legalize pass is restricted to homogeneous execution for now.
   if (is_homogeneous) {

--- a/src/relay/backend/utils.h
+++ b/src/relay/backend/utils.h
@@ -564,11 +564,11 @@ inline bool IsMetaScheduleEnabled() {
  * difference. This function unifies the shared optimization pass prefix between vm and graph
  * runtime, and returns the pass prefix given the backend type.
  *
- * \param is_homogeneous True if all primitives are to be executed on the same device and target.
+ * \param homogeneous_target Execution target (can be undefined in case of heterogeneous execution).
  * \param is_vm True if passes are to be used for the vm executor.
  * \return An array of passes.
  */
-Array<Pass> GetPassPrefix(bool is_homogeneous, bool is_vm);
+Array<Pass> GetPassPrefix(Target homogeneous_target, bool is_vm);
 
 /*! \brief Target hash function */
 struct TargetStrHash {

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -1054,7 +1054,7 @@ transform::Sequential VMCompiler::FuseAndLowerOperators(const CompilationConfig&
 IRModule VMCompiler::OptimizeModuleImpl(IRModule mod) {
   backend::BindParamsInModule(mod, params_);
   Array<Pass> pass_seqs = relay::backend::GetPassPrefix(
-      /*is_homogeneous=*/config_->optional_homogeneous_target.defined(), /*is_vm=*/true);
+      /*homogeneous target=*/config_->optional_homogeneous_target, /*is_vm=*/true);
 
   // Always plan devices so the remaining passes don't need to distinguish homogeneous vs
   // heterogeneous execution.

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -98,6 +98,7 @@ bool QnnConv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   conv2d_attrs->out_layout = param->out_layout;
   conv2d_attrs->out_dtype = param->out_dtype;
   conv2d_attrs->auto_scheduler_rewritten_layout = param->auto_scheduler_rewritten_layout;
+  conv2d_attrs->meta_schedule_original_shape = param->meta_schedule_original_shape;
 
   // Collect the input tensor and output tensor devoid of scale and zero points to reuse Relay
   // Conv2D infer type function.

--- a/src/relay/qnn/op/dense.cc
+++ b/src/relay/qnn/op/dense.cc
@@ -35,6 +35,8 @@ namespace tvm {
 namespace relay {
 namespace qnn {
 
+TVM_REGISTER_NODE_TYPE(QDenseAttrs);
+
 // relay.op.qnn.dense
 
 bool QnnDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
@@ -45,8 +47,8 @@ bool QnnDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   const auto* data = types[0].as<TensorTypeNode>();
   const auto* weight = types[1].as<TensorTypeNode>();
   if (data == nullptr || weight == nullptr) return false;
-  const auto* param = attrs.as<DenseAttrs>();
-  ICHECK(param != nullptr) << "DenseAttrs cannot be nullptr.";
+  const auto* param = attrs.as<QDenseAttrs>();
+  ICHECK(param != nullptr) << "QDenseAttrs cannot be nullptr.";
   ICHECK(data->dtype == DataType::Int(8) || data->dtype == DataType::UInt(8))
       << "Expected quantized dense type(int8, uint8) for input but was " << data->dtype;
   ICHECK(weight->dtype == DataType::Int(8) || weight->dtype == DataType::UInt(8))
@@ -70,22 +72,27 @@ bool QnnDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   // Collect the input tensor and output tensor devoid of scale and zero points to reuse Relay
   // Dense infer type function.
   Array<Type> tensor_types = {types[0], types[1], types[6]};
-  return MatmulRel<DenseAttrs>(tensor_types, 3, attrs, reporter);
+  return MatmulRel<QDenseAttrs>(tensor_types, 3, attrs, reporter);
 }
 
 // Positional relay function to create quantized dense operator used by frontend FFI.
 Expr MakeQuantizedDense(Expr data, Expr weight, Expr input_zero_point, Expr kernel_zero_point,
                         Expr input_scale, Expr kernel_scale, IndexExpr units, DataType out_dtype) {
-  auto attrs = make_object<DenseAttrs>();
+  auto attrs = make_object<QDenseAttrs>();
   attrs->units = std::move(units);
   attrs->out_dtype = out_dtype;
+
+  // Optional extra attributes for requantization.
+  attrs->axis = -1;
+  attrs->rq_out_dtype = attrs->out_dtype;
+
   static const Op& op = Op::Get("qnn.dense");
   return Call(op, {data, weight, input_zero_point, kernel_zero_point, input_scale, kernel_scale},
               Attrs(attrs), {});
 }
 
 Expr DenseFirstTerm(const Expr& quantized_data, const Expr& quantized_kernel,
-                    const DenseAttrs* attrs) {
+                    const QDenseAttrs* attrs) {
   return Dense(quantized_data, quantized_kernel, attrs->units, attrs->out_dtype);
 }
 
@@ -170,7 +177,7 @@ Expr QnnDenseCanonicalize(const Attrs& attrs, const Array<Expr>& new_args,
   const int reduction_dim_size = get_const_int(in_shape[1]);
   const int out_dim_size = get_const_int(w_shape[0]);
 
-  const auto* qnn_dense_attrs = attrs.as<DenseAttrs>();
+  const auto* qnn_dense_attrs = attrs.as<QDenseAttrs>();
 
   auto term1 = DenseFirstTerm(quantized_data, quantized_kernel, qnn_dense_attrs);
   auto term2 = DenseSecondTerm(quantized_data, kernel_zero_point, out_dim_size);
@@ -210,7 +217,7 @@ RELAY_REGISTER_OP("qnn.dense")
 - **weight**: quantized(int8, unit8) `(units, input_dim)`
 - **out**: quantized(int32) `(x1, x2, ..., xn, units)`.
 )code" TVM_ADD_FILELINE)
-    .set_attrs_type<DenseAttrs>()
+    .set_attrs_type<QDenseAttrs>()
     .set_num_inputs(6)
     .add_argument("data", "quantized nD Tensor", "Input data.")
     .add_argument("weight", "quantized 2D Tensor", "Weight matrix.")

--- a/src/relay/qnn/utils.cc
+++ b/src/relay/qnn/utils.cc
@@ -215,6 +215,28 @@ std::string SelectRequntizeParameter(const std::string& arg_value, const std::st
   }
 }
 
+TVM_REGISTER_GLOBAL("relay.attrs.get_rq_out_dtype").set_body_typed([](const Attrs& attrs) {
+  if (attrs->IsInstance<QConv2DAttrs>()) {
+    return attrs.as<QConv2DAttrs>()->rq_out_dtype;
+  } else if (attrs->IsInstance<QDenseAttrs>()) {
+    return attrs.as<QDenseAttrs>()->rq_out_dtype;
+  } else {
+    LOG(FATAL) << "Unhandled attribute: " << attrs;
+  }
+  return DataType();
+});
+
+TVM_REGISTER_GLOBAL("relay.attrs.get_rq_axis").set_body_typed([](const Attrs& attrs) {
+  if (attrs->IsInstance<QConv2DAttrs>()) {
+    return attrs.as<QConv2DAttrs>()->axis;
+  } else if (attrs->IsInstance<QDenseAttrs>()) {
+    return attrs.as<QDenseAttrs>()->axis;
+  } else {
+    LOG(FATAL) << "Unhandled attribute: " << attrs;
+  }
+  return -1;
+});
+
 }  // namespace qnn
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -885,8 +885,10 @@ class FuseMutator : private MixedModeMutator {
   Expr Rewrite_(const CallNode* call, const Expr& post) {
     if (call->op.as<OpNode>()) {
       static auto fnoncomputational = Op::GetAttrMap<TNonComputational>("TNonComputational");
+      static auto fqnncanonicalize = Op::GetAttrMap<FTVMLegalize>("FTVMQnnCanonicalize");
 
-      if (fnoncomputational.get(Downcast<Op>(call->op), false)) {
+      Op op = Downcast<Op>(call->op);
+      if (fnoncomputational.get(op, false) && !fqnncanonicalize.count(op)) {
         return ExprMutator::VisitExpr_(call);
       }
 

--- a/tests/python/contrib/test_hexagon/test_wo_qnn_canonicalization.py
+++ b/tests/python/contrib/test_hexagon/test_wo_qnn_canonicalization.py
@@ -1,0 +1,153 @@
+import pytest
+import numpy as np
+
+import tvm.testing
+from tvm import relay
+from tvm.contrib.hexagon.session import Session
+from tvm.contrib import graph_executor
+from tvm.relay.backend import Executor
+
+
+@tvm.testing.requires_hexagon
+def test_no_qnn_pass():
+    x = relay.var("x", shape=(4, 8), dtype="float32")
+    op0 = relay.qnn.op.quantize(x, relay.const(2.0), relay.const(10), out_dtype="uint8")
+    op1 = relay.qnn.op.dequantize(op0, relay.const(0.5), relay.const(5))
+    mod = tvm.IRModule.from_expr(op1)
+
+    target_hexagon = tvm.target.hexagon("v68")
+    # Default compilation flow
+    with tvm.transform.PassContext(opt_level=3):
+        opt_mod_1, _ = relay.optimize(mod, tvm.target.Target(target_hexagon, host=target_hexagon))
+
+    # Disable QNN legalization and canonicalization passes
+    with tvm.transform.PassContext(opt_level=3, disabled_pass=["Legalize"]):
+        opt_mod_2, _ = relay.optimize(mod, tvm.target.Target(target_hexagon, host=target_hexagon))
+
+    # Check that during Default compilation flow we do not call qnn::canonicalization pass.
+    tvm.ir.assert_structural_equal(opt_mod_1, opt_mod_2)
+
+
+def execute(executor, data_np, weight_np, bias_np = None):
+    executor.set_input("data", data_np)
+    executor.set_input("weight", weight_np)
+    if bias_np is not None:
+        executor.set_input("bias", bias_np)
+    executor.run()
+    return executor.get_output(0)
+
+
+@tvm.testing.requires_hexagon
+def test_qnn_conv2d_rq(hexagon_session: Session):
+    data_shape = [1, 64, 64, 64]
+    weight_shape = [64, 64, 3, 3]
+    data = relay.var("data", shape=data_shape, dtype="float32")
+    weight = relay.var("weight", shape=weight_shape, dtype="float32")
+    op0 = relay.qnn.op.quantize(data, relay.const(0.078), relay.const(0), out_dtype="int8")
+    op1 = relay.qnn.op.quantize(weight, relay.const(0.07), relay.const(0), out_dtype="int8")
+    op2 = relay.qnn.op.conv2d(op0,
+                              op1,
+                              input_zero_point=relay.const(0),
+                              kernel_zero_point=relay.const(0),
+                              input_scale=relay.const(0.078),
+                              kernel_scale=relay.const(0.07),
+                              padding=[0, 0, 0, 0],
+                              channels=64,
+                              kernel_size=[3, 3])
+    op5 = relay.qnn.op.requantize(op2,
+                                  input_scale=relay.const(0.05),
+                                  input_zero_point=relay.const(0),
+                                  output_scale=relay.const(0.21),
+                                  output_zero_point=relay.const(61),
+                                  out_dtype="int8")
+    relay_mod = tvm.IRModule.from_expr(op5)
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target_llvm = tvm.target.Target("llvm")
+    executor = Executor("graph", {"link-params": True})
+    with tvm.transform.PassContext(opt_level=3):
+        hexagon_lowered = tvm.relay.build(
+            relay_mod,
+            tvm.target.Target(target_hexagon, host=target_hexagon),
+            executor=executor,
+        )
+
+        llvm_lowered = tvm.relay.build(
+            relay_mod,
+            tvm.target.Target(target_llvm, host=target_llvm),
+            executor=executor,
+        )
+    
+    data_np = np.random.rand(*data_shape) - 0.5
+    weight_np = np.random.rand(*weight_shape) - 0.5
+
+    hx_m = hexagon_session.get_executor_from_factory(hexagon_lowered)
+    hexagon_output = execute(hx_m, data_np, weight_np)
+
+    dev = tvm.cpu(0)
+    llvm_m = graph_executor.GraphModule(llvm_lowered["default"](dev))
+    llvm_out = execute(llvm_m, data_np, weight_np)
+
+    np.testing.assert_equal(hexagon_output.numpy(), llvm_out.numpy())
+
+
+@tvm.testing.requires_hexagon
+def test_qnn_dense_bias_rq(hexagon_session: Session):
+    data_shape = [8, 8]
+    weight_shape = [16, 8]
+    bias_shape = [16]
+    data = relay.var("data", shape=data_shape, dtype="float32")
+    weight = relay.var("weight", shape=weight_shape, dtype="float32")
+    bias = relay.var("bias", shape=bias_shape, dtype="float32")
+
+    op0 = relay.qnn.op.quantize(data, relay.const(0.08), relay.const(0), out_dtype="int8")
+    op1 = relay.qnn.op.quantize(weight, relay.const(0.07), relay.const(0), out_dtype="int8")
+    op2 = relay.qnn.op.dense(op0,
+                             op1,
+                             input_zero_point=relay.const(0),
+                             kernel_zero_point=relay.const(0),
+                             input_scale=relay.const(0.08),
+                             kernel_scale=relay.const(0.07),
+                             units=None)
+    op3 = relay.qnn.op.quantize(bias, relay.const(0.5), relay.const(0), out_dtype="int32")
+    op4 = relay.nn.bias_add(op2, op3)
+    op5 = relay.qnn.op.requantize(op4,
+                                  input_scale=relay.const(0.05),
+                                  input_zero_point=relay.const(0),
+                                  output_scale=relay.const(0.212),
+                                  output_zero_point=relay.const(10),
+                                  out_dtype="int8")
+    relay_mod = tvm.IRModule.from_expr(op5)
+
+    target_hexagon = tvm.target.hexagon("v68")
+    target_llvm = tvm.target.Target("llvm")
+    executor = Executor("graph", {"link-params": True})
+    with tvm.transform.PassContext(opt_level=3):
+        hexagon_lowered = tvm.relay.build(
+            relay_mod,
+            tvm.target.Target(target_hexagon, host=target_hexagon),
+            executor=executor,
+        )
+
+        llvm_lowered = tvm.relay.build(
+            relay_mod,
+            tvm.target.Target(target_llvm, host=target_llvm),
+            executor=executor,
+        )
+    
+    data_np = np.random.rand(*data_shape) - 0.5
+    weight_np = np.random.rand(*weight_shape) - 0.5
+    bias_np = np.random.rand(*bias_shape)
+
+    hx_m = hexagon_session.get_executor_from_factory(hexagon_lowered)
+    hexagon_output = execute(hx_m, data_np, weight_np, bias_np)
+
+    dev = tvm.cpu(0)
+    llvm_m = graph_executor.GraphModule(llvm_lowered["default"](dev))
+    llvm_out = execute(llvm_m, data_np, weight_np, bias_np)
+
+    np.testing.assert_equal(hexagon_output.numpy(), llvm_out.numpy())
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Main goals for this PR are the following:

1. E2E compilation should work without QNN canonicalization on the Hexagon target.
2. Enable int8 -> int8 computation for dense/conv2d operation.

What was done:
1. Disabled qnn::Legalize for Hexagon target. For other targets QNN passes keep working.
2. Implemented new strategies (compute and schedules) for QNN ops. This is POC code. There was no goal to implement high performance compute/schedule functions. This will be done in future.
3. To enable int8 -> int8 computation for dense/conv2d operation we need to merge dense|conv2d + [bias]! + requantize.
There are two ways how to implement this:
A) Implement new IRModule -> IRModule pass that will pattern match combination conv2d+requantize/conv2d+bias+requantize and etc.
B) Change TECompiler and lower sequence of QNN operation into one TOPI op.
Possibly, A) is more natural but A) implies adding dozens of new Relay ops which only make sense for Hexagon target, not genetic and overloaded with a huge number of arguments (inputs, quantization parameters, bias, requantization parameters etc.)
That's why B) approach was implemented in this PR.


cc @mehrdadh