### PR TITLE
[TIR] [bfloat16] add bfloat16 promotion for CallNode

### DIFF
--- a/tests/python/relay/test_cpp_build_module.py
+++ b/tests/python/relay/test_cpp_build_module.py
@@ -127,7 +127,9 @@ def test_bf16_build():
     relu_bf16 = relay.nn.relu(bn_bf16[0])
     maxpool_bf16 = relay.nn.max_pool2d(relu_bf16, pool_size=(2, 2), strides=(2, 2))
     avgpool_bf16 = relay.nn.avg_pool2d(maxpool_bf16, pool_size=(2, 2), strides=(2, 2))
-    mod_bf16 = tvm.IRModule.from_expr(avgpool_bf16)
+    flattened_bf16 = relay.nn.batch_flatten(avgpool_bf16)
+    softmax_bf16 = relay.nn.softmax(flattened_bf16)
+    mod_bf16 = tvm.IRModule.from_expr(softmax_bf16)
     with tvm.transform.PassContext(opt_level=3):
         relay.build(mod_bf16, target="llvm", params=params)
 


### PR DESCRIPTION
So far, the `softmax` in the following test
``` python
import tvm
from tvm import relay
data = relay.var("data", shape=(1, 1000), dtype="bfloat16")
expr = relay.nn.softmax(data)
mod = tvm.IRModule.from_expr(expr)
with tvm.transform.PassContext(opt_level=3):
    relay.build(mod, target="llvm")
```
will be lowered to
``` swift
@tvmgen_default_fused_nn_softmax = primfn(placeholder_1: handle, T_softmax_norm_1: handle) -> ()
  attr = {"from_legacy_te_schedule": True, "global_symbol": "tvmgen_default_fused_nn_softmax", "tir.noalias": True}
  buffers = {placeholder: Buffer(placeholder_2: Pointer(uint16), uint16, [1000], []),
             T_softmax_norm: Buffer(T_softmax_norm_2: Pointer(uint16), uint16, [1000], [])}
  buffer_map = {placeholder_1: placeholder, T_softmax_norm_1: T_softmax_norm}
  preflattened_buffer_map = {placeholder_1: placeholder_3: Buffer(placeholder_2, uint16, [1, 1000], []), T_softmax_norm_1: T_softmax_norm_3: Buffer(T_softmax_norm_2, uint16, [1, 1000], [])} {
  allocate(T_softmax_maxelem: Pointer(uint16), uint16, [1]), storage_scope =  {
     {
      T_softmax_maxelem_1: Buffer(T_softmax_maxelem, uint16, [1], [], align=2)[0] = 65408u16
      for (k: int32, 0, 1000) {
        T_softmax_maxelem_1[0] = cast(uint16, @tir.shift_right((@tir.reinterpret(max(@tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_maxelem_1[0]), 16u32, dtype=uint32), dtype=float32), @tir.reinterpret(@tir.shift_left(cast(uint32, placeholder[k]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32) + (@tir.bitwise_and(@tir.shift_right(@tir.reinterpret(max(@tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_maxelem_1[0]), 16u32, dtype=uint32), dtype=float32), @tir.reinterpret(@tir.shift_left(cast(uint32, placeholder[k]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32), 16u32, dtype=uint32), 1u32, dtype=uint32) + 32767u32)), 16u32, dtype=uint32))
      }
    }
    allocate(T_softmax_exp: Pointer(uint16), uint16, [1000]), storage_scope =  {
      for (i1: int32, 0, 1000) {
        T_softmax_exp_1: Buffer(T_softmax_exp, uint16, [1000], [])[i1] = @tir.exp(cast(uint16, @tir.shift_right((@tir.reinterpret((@tir.reinterpret(@tir.shift_left(cast(uint32, placeholder[i1]), 16u32, dtype=uint32), dtype=float32) - @tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_maxelem_1[0]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32) + (@tir.bitwise_and(@tir.shift_right(@tir.reinterpret((@tir.reinterpret(@tir.shift_left(cast(uint32, placeholder[i1]), 16u32, dtype=uint32), dtype=float32) - @tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_maxelem_1[0]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32), 16u32, dtype=uint32), 1u32, dtype=uint32) + 32767u32)), 16u32, dtype=uint32)), dtype=bfloat16)
      }
      allocate(T_softmax_expsum: Pointer(uint16), uint16, [1]), storage_scope =  {
         {
          T_softmax_expsum_1: Buffer(T_softmax_expsum, uint16, [1], [], align=2)[0] = 0u16
          for (k_1: int32, 0, 1000) {
            T_softmax_expsum_1[0] = cast(uint16, @tir.shift_right((@tir.reinterpret((@tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_expsum_1[0]), 16u32, dtype=uint32), dtype=float32) + @tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_exp_1[k_1]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32) + (@tir.bitwise_and(@tir.shift_right(@tir.reinterpret((@tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_expsum_1[0]), 16u32, dtype=uint32), dtype=float32) + @tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_exp_1[k_1]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32), 16u32, dtype=uint32), 1u32, dtype=uint32) + 32767u32)), 16u32, dtype=uint32))
          }
        }
        for (i1_1: int32, 0, 1000) {
          T_softmax_norm[i1_1] = cast(uint16, @tir.shift_right((@tir.reinterpret((@tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_exp_1[i1_1]), 16u32, dtype=uint32), dtype=float32) / @tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_expsum_1[0]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32) + (@tir.bitwise_and(@tir.shift_right(@tir.reinterpret((@tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_exp_1[i1_1]), 16u32, dtype=uint32), dtype=float32) / @tir.reinterpret(@tir.shift_left(cast(uint32, T_softmax_expsum_1[0]), 16u32, dtype=uint32), dtype=float32)), dtype=uint32), 16u32, dtype=uint32), 1u32, dtype=uint32) + 32767u32)), 16u32, dtype=uint32))
        }
      }
    }
  }
}
```
Note that `@tir.exp` is not legalized properly, which leads to an invalid LLVM intrinsic call codegen and rise segmentation fault finally.
This is solved by adding bfloat16 promotion for `CallNode`.

cc @junrushao1994