### PR TITLE
[Target] Fix C5 Target Tag to Include CascadeLake Archs

### DIFF
--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -349,19 +349,18 @@ TVM_REGISTER_CUDA_TAG("nvidia/tegra-x1", "sm_53", 49152, 32768);
 
 #undef TVM_REGISTER_CUDA_TAG
 
-#define TVM_REGISTER_TAG_AWS_C5(Name, Cores)                                    \
-  TVM_REGISTER_TARGET_TAG(Name).set_config({{"kind", String("llvm")},           \
-                                            {"mcpu", String("skylake-avx512")}, \
-                                            {"num-cores", Integer(Cores)}});
+#define TVM_REGISTER_TAG_AWS_C5(Name, Cores, Arch) \
+  TVM_REGISTER_TARGET_TAG(Name).set_config(        \
+      {{"kind", String("llvm")}, {"mcpu", String(Arch)}, {"num-cores", Integer(Cores)}});
 
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.large", 1);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.xlarge", 2);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.2xlarge", 4);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.4xlarge", 8);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.9xlarge", 18);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.12xlarge", 24);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.18xlarge", 36);
-TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.24xlarge", 48);
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.large", 1, "skylake-avx512");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.xlarge", 2, "skylake-avx512");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.2xlarge", 4, "skylake-avx512");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.4xlarge", 8, "skylake-avx512");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.9xlarge", 18, "skylake-avx512");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.12xlarge", 24, "cascadelake");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.18xlarge", 36, "skylake-avx512");
+TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.24xlarge", 48, "cascadelake");
 
 #undef TVM_REGISTER_TAG_AWS_C5
 


### PR DESCRIPTION
>The C5 and C5d 12xlarge, 24xlarge, and metal instances feature custom 2nd generation [Intel](https://aws.amazon.com/intel/) Xeon Scalable Processors (Cascade Lake) with a sustained all-core turbo frequency of 3.6GHz and maximum single core turbo frequency of 3.9GHz. The other C5 and C5d instance sizes will either launch on the 2nd generation Intel Xeon Scalable Processor or the 1st generation Intel Xeon Platinum 8000 series (Skylake-SP) processor with a sustained all core Turbo frequency of up to 3.4GHz, and single core turbo up to 3.5 GHz using Intel Turbo Boost Technology.

>The C5 and C5d 12xlarge, 24xlarge, and metal instance sizes enable Vector Neural Network Instructions (AVX-512 VNNI*) which will help speed up typical machine learning operations like convolution, and automatically improve inference performance over a wide range of deep learning workloads.


According to [introduction to AWS EC2 C5 targets](https://aws.amazon.com/ec2/instance-types/c5/), the C5 12x and 24x machine are `cascade lake` architecture instead of `skylake`, and enable Vector Neural Network Instructions (AVX-512 VNNI*) which can be useful for AutoTensorization.

This PR fixes the target definition of the 2 above mentioned C5 machine to support VNNI.

CC @junrushao1994