### PR TITLE
Add needs-triage label to CI Problem template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-problem.md
+++ b/.github/ISSUE_TEMPLATE/ci-problem.md
@@ -2,6 +2,7 @@
 name: "\U0000274C CI Problem"
 about: To help the developers act on these problems, please give us as many details of the CI failure as possible.
 title: "[CI Problem] "
+labels: "needs-triage"
 
 ---
 


### PR DESCRIPTION
These issues are reported as part of the CI monitoring rotation and
usually reflect something contained and actionable. As such we should
track and monitor these issues and make sure that a proper mitigation or
fix is merged soon. This label helps us do this since we can easily
filter by untriaged issues and make sure each one has an assignee.