### PR TITLE
[MicroTVM] add heap-size to project options

### DIFF
--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -54,7 +54,8 @@
         "is_qemu": false,
         "fpu": true,
         "vid_hex": "0483",
-        "pid_hex": "374b"
+        "pid_hex": "374b",
+        "recommended_heap_size": 262400
     },
     "qemu_cortex_r5": {
         "board": "qemu_cortex_r5",

--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -55,7 +55,7 @@
         "fpu": true,
         "vid_hex": "0483",
         "pid_hex": "374b",
-        "recommended_heap_size": 512000
+        "recommended_heap_size_bytes": 512000
     },
     "qemu_cortex_r5": {
         "board": "qemu_cortex_r5",

--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -55,7 +55,7 @@
         "fpu": true,
         "vid_hex": "0483",
         "pid_hex": "374b",
-        "recommended_heap_size": 262400
+        "recommended_heap_size": 221184
     },
     "qemu_cortex_r5": {
         "board": "qemu_cortex_r5",

--- a/apps/microtvm/zephyr/template_project/boards.json
+++ b/apps/microtvm/zephyr/template_project/boards.json
@@ -55,7 +55,7 @@
         "fpu": true,
         "vid_hex": "0483",
         "pid_hex": "374b",
-        "recommended_heap_size": 221184
+        "recommended_heap_size": 512000
     },
     "qemu_cortex_r5": {
         "board": "qemu_cortex_r5",

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -212,11 +212,14 @@ def _get_board_mem_size(options):
     return None
 
 
+DEFAULT_HEAP_SIZE = 216 * 1024
+
+
 def _get_recommended_heap_size(options):
     prop = BOARD_PROPERTIES[options["zephyr_board"]]
     if "recommended_heap_size" in prop:
         return prop["recommended_heap_size"]
-    return 216 * 1024
+    return DEFAULT_HEAP_SIZE
 
 
 def generic_find_serial_port(serial_number=None):
@@ -622,9 +625,11 @@ class Handler(server.ProjectAPIHandler):
                 heap_size = _get_recommended_heap_size(options)
                 if options.get("heap_size"):
                     board_mem_size = _get_board_mem_size(options)
-                    if board_mem_size is not None:
-                        assert options["heap_size"] < board_mem_size, "heap size is too large"
                     heap_size = options["heap_size"]
+                    if board_mem_size is not None:
+                        assert (
+                            heap_size < board_mem_size
+                        ), f"Heap size {heap_size} is larger than memory size {board_mem_size} on this board."
                 cmake_f.write(f"target_compile_definitions(app PUBLIC -DHEAP_SIZE={heap_size})\n")
 
                 if options.get("compile_definitions"):

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -195,7 +195,7 @@ def _get_device_args(options):
     )
 
 
-def _get_board_mem_size(options):
+def _get_board_mem_size_bytes(options):
     board_file_path = (
         pathlib.Path(get_zephyr_base(options))
         / "boards"
@@ -215,10 +215,10 @@ def _get_board_mem_size(options):
 DEFAULT_HEAP_SIZE_BYTES = 216 * 1024
 
 
-def _get_recommended_heap_size(options):
+def _get_recommended_heap_size_bytes(options):
     prop = BOARD_PROPERTIES[options["zephyr_board"]]
-    if "recommended_heap_size" in prop:
-        return prop["recommended_heap_size"]
+    if "recommended_heap_size_bytes" in prop:
+        return prop["recommended_heap_size_bytes"]
     return DEFAULT_HEAP_SIZE_BYTES
 
 
@@ -622,9 +622,9 @@ class Handler(server.ProjectAPIHandler):
 
                     cmake_f.write(line)
 
-                heap_size = _get_recommended_heap_size(options)
+                heap_size = _get_recommended_heap_size_bytes(options)
                 if options.get("heap_size_bytes"):
-                    board_mem_size = _get_board_mem_size(options)
+                    board_mem_size = _get_board_mem_size_bytes(options)
                     heap_size = options["heap_size_bytes"]
                     if board_mem_size is not None:
                         assert (

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -212,14 +212,14 @@ def _get_board_mem_size(options):
     return None
 
 
-DEFAULT_HEAP_SIZE = 216 * 1024
+DEFAULT_HEAP_SIZE_BYTES = 216 * 1024
 
 
 def _get_recommended_heap_size(options):
     prop = BOARD_PROPERTIES[options["zephyr_board"]]
     if "recommended_heap_size" in prop:
         return prop["recommended_heap_size"]
-    return DEFAULT_HEAP_SIZE
+    return DEFAULT_HEAP_SIZE_BYTES
 
 
 def generic_find_serial_port(serial_number=None):
@@ -398,10 +398,10 @@ PROJECT_OPTIONS = [
         help="Run on the FVP emulator instead of hardware.",
     ),
     server.ProjectOption(
-        "heap_size",
+        "heap_size_bytes",
         optional=["generate_project"],
         type="int",
-        help="Sets HEAP_SIZE for Zephyr board.",
+        help="Sets the value for HEAP_SIZE_BYTES passed to K_HEAP_DEFINE() to service TVM memory allocation requests.",
     ),
 ]
 
@@ -623,14 +623,16 @@ class Handler(server.ProjectAPIHandler):
                     cmake_f.write(line)
 
                 heap_size = _get_recommended_heap_size(options)
-                if options.get("heap_size"):
+                if options.get("heap_size_bytes"):
                     board_mem_size = _get_board_mem_size(options)
-                    heap_size = options["heap_size"]
+                    heap_size = options["heap_size_bytes"]
                     if board_mem_size is not None:
                         assert (
                             heap_size < board_mem_size
                         ), f"Heap size {heap_size} is larger than memory size {board_mem_size} on this board."
-                cmake_f.write(f"target_compile_definitions(app PUBLIC -DHEAP_SIZE={heap_size})\n")
+                cmake_f.write(
+                    f"target_compile_definitions(app PUBLIC -DHEAP_SIZE_BYTES={heap_size})\n"
+                )
 
                 if options.get("compile_definitions"):
                     flags = options.get("compile_definitions")

--- a/apps/microtvm/zephyr/template_project/src/host_driven/main.c
+++ b/apps/microtvm/zephyr/template_project/src/host_driven/main.c
@@ -142,7 +142,7 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
 }
 
 // Heap for use by TVMPlatformMemoryAllocate.
-K_HEAP_DEFINE(tvm_heap, HEAP_SIZE);
+K_HEAP_DEFINE(tvm_heap, HEAP_SIZE_BYTES);
 
 // Called by TVM to allocate memory.
 tvm_crt_error_t TVMPlatformMemoryAllocate(size_t num_bytes, DLDevice dev, void** out_ptr) {

--- a/apps/microtvm/zephyr/template_project/src/host_driven/main.c
+++ b/apps/microtvm/zephyr/template_project/src/host_driven/main.c
@@ -142,7 +142,7 @@ tvm_crt_error_t TVMPlatformGenerateRandom(uint8_t* buffer, size_t num_bytes) {
 }
 
 // Heap for use by TVMPlatformMemoryAllocate.
-K_HEAP_DEFINE(tvm_heap, 216 * 1024);
+K_HEAP_DEFINE(tvm_heap, HEAP_SIZE);
 
 // Called by TVM to allocate memory.
 tvm_crt_error_t TVMPlatformMemoryAllocate(size_t num_bytes, DLDevice dev, void** out_ptr) {


### PR DESCRIPTION
This PR adds heap-size to the microTVM project options. So far the heap size has been fixed (216KB) for all boards. Exposing it as a project option allows the user to modify the value based on each specific board's available memory.
A "recommended_heap_size" is added for the "stm32l4r5zi" in "boards.json". The recommended value is tested on 4 boards (10 times on each board) and the result is compared against the default value of 216KB. The average failure rate has remained almost constant for all boards.

cc @gromero , @mehrdadh , @alanmacd , @areusch  