### PR TITLE
Add function to get type index from Python class

### DIFF
--- a/python/tvm/_ffi/__init__.py
+++ b/python/tvm/_ffi/__init__.py
@@ -27,4 +27,4 @@ and have a ctypes fallback implementation.
 from . import _pyversion
 from .base import register_error
 from .registry import register_object, register_func, register_extension
-from .registry import _init_api, get_global_func
+from .registry import _init_api, get_global_func, get_object_type_index

--- a/python/tvm/_ffi/_ctypes/object.py
+++ b/python/tvm/_ffi/_ctypes/object.py
@@ -25,8 +25,11 @@ from .ndarray import _register_ndarray, NDArrayBase
 ObjectHandle = ctypes.c_void_p
 __init_by_constructor__ = None
 
-"""Maps object type to its constructor"""
+"""Maps object type index to its constructor"""
 OBJECT_TYPE = {}
+
+"""Maps object type to its type index"""
+OBJECT_INDEX = {}
 
 _CLASS_OBJECT = None
 
@@ -42,6 +45,12 @@ def _register_object(index, cls):
         _register_ndarray(index, cls)
         return
     OBJECT_TYPE[index] = cls
+    OBJECT_INDEX[cls] = index
+
+
+def _get_object_type_index(cls):
+    """get the type index of object class"""
+    return OBJECT_INDEX.get(cls)
 
 
 def _return_object(x):

--- a/python/tvm/_ffi/_cython/object.pxi
+++ b/python/tvm/_ffi/_cython/object.pxi
@@ -15,8 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Maps object type to its constructor"""
+"""Maps object type index to its constructor"""
 cdef list OBJECT_TYPE = []
+"""Maps object type to its type index"""
+cdef dict OBJECT_INDEX = {}
 
 def _register_object(int index, object cls):
     """register object class"""
@@ -28,7 +30,11 @@ def _register_object(int index, object cls):
     while len(OBJECT_TYPE) <= index:
         OBJECT_TYPE.append(None)
     OBJECT_TYPE[index] = cls
+    OBJECT_INDEX[cls] = index
 
+def _get_object_type_index(object cls):
+    """get the type index of object class"""
+    return OBJECT_INDEX.get(cls)
 
 cdef inline object make_ret_object(void* chandle):
     global OBJECT_TYPE

--- a/python/tvm/_ffi/registry.py
+++ b/python/tvm/_ffi/registry.py
@@ -26,14 +26,14 @@ try:
     # pylint: disable=wrong-import-position,unused-import
     if _FFI_MODE == "ctypes":
         raise ImportError()
-    from ._cy3.core import _register_object
+    from ._cy3.core import _register_object, _get_object_type_index
     from ._cy3.core import _reg_extension
     from ._cy3.core import convert_to_tvm_func, _get_global_func, PackedFuncBase
 except (RuntimeError, ImportError) as error:
     # pylint: disable=wrong-import-position,unused-import
     if _FFI_MODE == "cython":
         raise error
-    from ._ctypes.object import _register_object
+    from ._ctypes.object import _register_object, _get_object_type_index
     from ._ctypes.ndarray import _reg_extension
     from ._ctypes.packed_func import convert_to_tvm_func, _get_global_func, PackedFuncBase
 
@@ -80,6 +80,23 @@ def register_object(type_key=None):
         return register
 
     return register(type_key)
+
+
+def get_object_type_index(cls):
+    """
+    Get type index of object type
+
+    Parameters
+    ----------
+    cls : type
+        The object type to get type index for.
+
+    Returns
+    -------
+    type_index : Optional[int]
+        The type index, or None if type not found in the registry.
+    """
+    return _get_object_type_index(cls)
 
 
 def register_extension(cls, fcreate=None):


### PR DESCRIPTION
This PR adds a Python function to get type index from Python class object. It's useful when type index needs to be passed from Python to C++. For example, in #11912 we need to get the type index from Python class in order to register a printing function in Python.

cc @junrushao1994 
