### PR TITLE
[PyTorch] Fix all_any_common with no default input

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -3252,8 +3252,14 @@ class PyTorchOpConverter:
         return (output, _op.stack(hy, 0), _op.stack(cy, 0))
 
     def all_any_common(self, op, inputs, input_types):
-        dim = inputs[1]
-        keepdim = inputs[2]
+        if len(inputs) >= 2:
+            dim = inputs[1]
+        else:
+            dim = None
+        if len(inputs) >= 3:
+            keepdim = inputs[2]
+        else:
+            keepdim = False
         if self.infer_type(inputs[0]).dtype != "bool":
             # The input dtype can be uint8.
             inp = _op.cast(inputs[0], "bool")

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4357,7 +4357,7 @@ def test_all_any():
     def test_fn(f, dim=None, keepdim=False):
         return lambda x: f(x, dim=dim, keepdim=keepdim)
 
-    def test_fn_no_input(f):
+    def test_fn_no_arg(f):
         return lambda x: f(x)
 
     for f in [torch.all, torch.any]:
@@ -4365,8 +4365,8 @@ def test_all_any():
         verify_model(test_fn(f, 0), [torch.arange(0, 3).to(torch.uint8)])
         verify_model(test_fn(f, 1), [torch.rand(4, 2).bool()])
         verify_model(test_fn(f, 0, keepdim=True), [torch.rand(4, 2).bool()])
-        verify_model(test_fn_no_input(f), [torch.rand(1, 2).bool()])
-        verify_model(test_fn_no_input(f), [torch.arange(0, 3).to(torch.uint8)])
+        verify_model(test_fn_no_arg(f), [torch.rand(1, 2).bool()])
+        verify_model(test_fn_no_arg(f), [torch.arange(0, 3).to(torch.uint8)])
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4357,14 +4357,16 @@ def test_all_any():
     def test_fn(f, dim=None, keepdim=False):
         return lambda x: f(x, dim=dim, keepdim=keepdim)
 
+    def test_fn_no_input(f):
+        return lambda x: f(x)
+
     for f in [torch.all, torch.any]:
         verify_model(test_fn(f, 0), [torch.rand(1, 2).bool()])
         verify_model(test_fn(f, 0), [torch.arange(0, 3).to(torch.uint8)])
         verify_model(test_fn(f, 1), [torch.rand(4, 2).bool()])
         verify_model(test_fn(f, 0, keepdim=True), [torch.rand(4, 2).bool()])
-        # with no default dim and keepdim
-        verify_model(f, [torch.rand(1, 2).bool()])
-        verify_model(f, [torch.arange(0, 3).to(torch.uint8)])
+        verify_model(test_fn_no_input(f), [torch.rand(1, 2).bool()])
+        verify_model(test_fn_no_input(f), [torch.arange(0, 3).to(torch.uint8)])
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4362,6 +4362,9 @@ def test_all_any():
         verify_model(test_fn(f, 0), [torch.arange(0, 3).to(torch.uint8)])
         verify_model(test_fn(f, 1), [torch.rand(4, 2).bool()])
         verify_model(test_fn(f, 0, keepdim=True), [torch.rand(4, 2).bool()])
+        # with no default dim and keepdim
+        verify_model(f, [torch.rand(1, 2).bool()])
+        verify_model(f, [torch.arange(0, 3).to(torch.uint8)])
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
This PR intends to fix the `all_any_common` op in the pytorch frontend for the use case that no arguments are present for those two ops in the models like `timm_vision_transformer`. 

cc: @masahi 
