### PR TITLE
Fix python setup error

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -169,13 +169,21 @@ if not CONDA_BUILD:
     with open("MANIFEST.in", "w") as fo:
         for path in LIB_LIST:
             if os.path.isfile(path):
-                shutil.copy(path, os.path.join(CURRENT_DIR, "tvm"))
+                try:
+                    shutil.copy(path, os.path.join(CURRENT_DIR, "tvm"))
+                except shutil.SameFileError:
+                    print("WARNING: Ignore copy file: %s" % path)
+                    pass
                 _, libname = os.path.split(path)
                 fo.write(f"include tvm/{libname}\n")
 
             if os.path.isdir(path):
                 _, libname = os.path.split(path)
-                shutil.copytree(path, os.path.join(CURRENT_DIR, "tvm", libname))
+                try:
+                    shutil.copytree(path, os.path.join(CURRENT_DIR, "tvm", libname))
+                except OSError:
+                    print("WARNING: Ignore copy dir: %s" % path)
+                    pass
                 fo.write(f"recursive-include tvm/{libname} *\n")
 
     setup_kwargs = {"include_package_data": True}


### PR DESCRIPTION
Build from source and install TVM python bindings by setup.py, SameFileError occurs. 
I think it should ignore copying when there exists the same file,  avoid breaking the process of installation.

```
Traceback (most recent call last):
  File "setup.py", line 174, in <module>
    shutil.copy(path, os.path.join(CURRENT_DIR, "tvm"))
  File "/usr/local/lib/python3.8/shutil.py", line 409, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/local/lib/python3.8/shutil.py", line 239, in copyfile
    raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
shutil.SameFileError: '/workspace/tvm/python/tvm/libtvm.so' and 'tvm/libtvm.so' are the same file
```
