### PR TITLE
[HotFix] Op is not bound to any variables

### DIFF
--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1465,10 +1465,11 @@ class VectorTypeRewriter : public StmtExprMutator {
     auto it = rewrite_map_.find(op->var.get());
     PrimExpr value = this->VisitExpr(op->value);
     Stmt body = this->VisitStmt(op->body);
-    if (value.same_as(op->value) && body.same_as(op->body) && it == rewrite_map_.end()) {
+    Var var = (it == rewrite_map_.end()) ? op->var : it->second.new_buffer_var;
+    if (var.same_as(op->var) && value.same_as(op->value) && body.same_as(op->body)) {
       return GetRef<Stmt>(op);
     }
-    return LetStmt(it->second.new_buffer_var, op->value, op->body);
+    return LetStmt(var, value, body);
   }
 
   Buffer RemapBuffer(Buffer buf) {

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1463,7 +1463,9 @@ class VectorTypeRewriter : public StmtExprMutator {
 
   Stmt VisitStmt_(const LetStmtNode* op) final {
     auto it = rewrite_map_.find(op->var.get());
-    if (it == rewrite_map_.end()) {
+    PrimExpr value = this->VisitExpr(op->value);
+    Stmt body = this->VisitStmt(op->body);
+    if (value.same_as(op->value) && body.same_as(op->body) && it == rewrite_map_.end()) {
       return GetRef<Stmt>(op);
     }
     return LetStmt(it->second.new_buffer_var, op->value, op->body);

--- a/tests/python/unittest/test_tir_transform_storage_rewrite.py
+++ b/tests/python/unittest/test_tir_transform_storage_rewrite.py
@@ -691,8 +691,8 @@ class TestLetBufferRewrite(tvm.testing.CompareBeforeAfter):
 
     def expected() -> None:
         A_data: T.Ptr[T.int32x8] = T.call_extern("dummy_func", dtype="handle")
-        A = T.buffer_decl([8], "int32", data=A_data)
-        A[0:8] = T.broadcast(42, 8)
+        A = T.buffer_decl([1], "int32x8", data=A_data)
+        A[0] = T.broadcast(42, 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After PR #12349 inference of some Adreno networks was broken. In the
output it was the following error:
```
TVMError: Not all Vars are passed in api_args: 'compute' is not bound
to any variables
```

cc: @tkonolige, @Lunderberg  


cc @driazati