### PR TITLE
Add sort_by_time flag to debug_executor.run method

### DIFF
--- a/python/tvm/contrib/debugger/debug_executor.py
+++ b/python/tvm/contrib/debugger/debug_executor.py
@@ -274,6 +274,7 @@ class GraphModuleDebug(graph_executor.GraphModule):
         min_repeat_ms=1,
         cooldown_interval_ms=0,
         repeats_to_cooldown=1,
+        sort_by_time=True,
         **input_dict,
     ):
         """Run forward execution of the graph with debug
@@ -306,6 +307,9 @@ class GraphModuleDebug(graph_executor.GraphModule):
         repeats_to_cooldown: int, optional
             The number of repeats before the cooldown is activated.
 
+        sort_by_time: bool, optional
+            Whether to sort the debug output by time.
+
         input_dict : dict of str to NDArray
             List of input values to be feed to
         """
@@ -325,7 +329,7 @@ class GraphModuleDebug(graph_executor.GraphModule):
         # Step 3. Dump the Chrome trace to the dump folder
         self.debug_datum.dump_chrome_trace()
         # Step 4. Display the collected information
-        self.debug_datum.display_debug_result()
+        self.debug_datum.display_debug_result(sort_by_time)
 
     def run_individual(
         self, number, repeat=1, min_repeat_ms=0, cooldown_interval_ms=0, repeats_to_cooldown=1


### PR DESCRIPTION
Sometimes you may want to disable time sorting if you want to compare some outputs with each other.

CC @echuraev