### PR TITLE
[CI][aarch64] Enable ONNX and PyTorch tests on AArch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-08-11T13:17:04.679404
+// Generated at 2022-08-12T16:20:03.163981
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -4290,7 +4290,11 @@ def shard_run_frontend_aarch64_1_of_2() {
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
-                label: 'Run Python frontend tests',
+                label: 'Run General Python frontend tests',
+              )
+              sh (
+                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_aarch64only.sh",
+                label: 'Run AArch64 Python frontend tests',
               )
             })
           }
@@ -4363,7 +4367,11 @@ def shard_run_frontend_aarch64_2_of_2() {
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
-                label: 'Run Python frontend tests',
+                label: 'Run General Python frontend tests',
+              )
+              sh (
+                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_aarch64only.sh",
+                label: 'Run AArch64 Python frontend tests',
               )
             })
           }

--- a/ci/jenkins/Test.groovy.j2
+++ b/ci/jenkins/Test.groovy.j2
@@ -183,7 +183,11 @@
   ci_setup(ci_arm)
   sh (
     script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
-    label: 'Run Python frontend tests',
+    label: 'Run General Python frontend tests',
+  )
+  sh (
+    script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_aarch64only.sh",
+    label: 'Run AArch64 Python frontend tests',
   )
 {% endcall %}
 {% call(shard_index, num_shards) m.sharded_test_step(

--- a/tests/scripts/task_python_frontend_aarch64only.sh
+++ b/tests/scripts/task_python_frontend_aarch64only.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+source tests/scripts/setup-pytest-env.sh
+# to avoid openblas threading error
+export TVM_BIND_THREADS=0
+export OMP_NUM_THREADS=1
+
+export TVM_TEST_TARGETS="llvm"
+
+find . -type f -path "*.pyc" | xargs rm -f
+
+# Rebuild cython
+make cython3
+
+echo "Running relay ONNX frontend test..."
+run_pytest cython python-frontend-onnx tests/python/frontend/onnx
+
+echo "Running relay PyTorch frontend test..."
+run_pytest cython python-frontend-pytorch tests/python/frontend/pytorch


### PR DESCRIPTION
This make use of recent work done in enabling PyTorch and ONNX tests to be run on AArch64 to actually enable the tests to run as part of CI.

Co-Authored-By: Nicola Lancellotti <Nicola.Lancellotti@arm.com>

cc @Mousius @areusch @ashutosh-arm @driazati @gigiblender
