### PR TITLE
[CRT runtime] Fix memset of memory pool in PageMemoryManagerCreate

### DIFF
--- a/src/runtime/crt/memory/page_allocator.c
+++ b/src/runtime/crt/memory/page_allocator.c
@@ -280,7 +280,7 @@ tvm_crt_error_t PageMemoryManager_Free(MemoryManagerInterface* interface, void* 
 tvm_crt_error_t PageMemoryManagerCreate(MemoryManagerInterface** interface, uint8_t* memory_pool,
                                         size_t memory_pool_size_bytes,
                                         size_t page_size_bytes_log2) {
-  memset(memory_pool, 0, sizeof(memory_pool_size_bytes));
+  memset(memory_pool, 0, memory_pool_size_bytes);
 
   // Allocate enough space for MAX_PAGES.
   size_t page_size_bytes = 1 << page_size_bytes_log2;


### PR DESCRIPTION
Fix the memset during creation of memory manager. It should clear the whole memory pool, otherwise the next invocation will create a manager with some attributes using old values.

I found this issue when trying to call `tvm_runtime_create` the second time led to error. (my codes are similar to `apps/bundle_deploy/bundle_static.c`). Internal checking would fail due to manager attributes being only partially cleared.

cc @areusch 
