### PR TITLE
[CI][AArch64] Enable ONNX installation in ci_arm image

### DIFF
--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -75,6 +75,10 @@ RUN bash /install/ubuntu_install_boost.sh
 COPY install/ubuntu_install_caffe.sh /install/ubuntu_install_caffe.sh
 RUN bash /install/ubuntu_install_caffe.sh
 
+# ONNX
+COPY install/ubuntu_install_onnx.sh /install/ubuntu_install_onnx.sh
+RUN bash /install/ubuntu_install_onnx.sh
+
 # AutoTVM deps
 COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh
 RUN bash /install/ubuntu_install_redis.sh


### PR DESCRIPTION
This patch enables ONNX and dependencies installation on ci_arm as
a way to enable ONNX and Torch testing.

cc @Mousius @NicolaLancellotti @areusch @driazati @gigiblender