### PR TITLE
[LLVM] Add "cl-opt" attribute to target_kind "llvm"

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -552,7 +552,7 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
     }
 
     std::string lower;
-    std::transform(s.begin(), s.end(), lower.begin(),
+    std::transform(s.begin(), s.end(), std::back_inserter(lower),
                    [](unsigned char c) { return std::tolower(c); });
     if (lower == "true") {
       return {true, true};

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -463,14 +463,13 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
 
   int part_this = 0, part_end = parts.size();
 
-  const std::string warn_header = "while parsing option \"" + str + "\": ";
-  const std::string warn_ignored = ", option ignored";
+  const std::string error_header = "while parsing option \"" + str + "\": ";
 
   // Check for "-" or "--".
   if (part_this < part_end) {
     auto& p = parts[part_this++];
     if ((p.size() != 1 && p.size() != 2) || p.find_first_not_of('-') != std::string::npos) {
-      LOG(ERROR) << warn_header << "option must start with \"-\" or \"--\"" << warn_ignored;
+      LOG(ERROR) << error_header << "option must start with \"-\" or \"--\"";
       return opt;
     }
   }
@@ -479,7 +478,7 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
   if (part_this < part_end) {
     auto& p = parts[part_this++];
     if (p.empty()) {
-      LOG(ERROR) << warn_header << "option name must not be empty" << warn_ignored;
+      LOG(ERROR) << error_header << "option name must not be empty";
       return opt;
     }
     opt.name = std::move(p);
@@ -509,7 +508,7 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
       }
       // If there was ":", there must be a type.
       if (type == Option::OptType::Invalid) {
-        LOG(ERROR) << warn_header << "invalid type" << warn_ignored;
+        LOG(ERROR) << error_header << "invalid type";
         return opt;
       }
     }
@@ -528,7 +527,7 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
       }
     } else {
       // If there are still any parts left to be processed, there must be "=".
-      LOG(ERROR) << warn_header << "expecting \"=\"" << warn_ignored;
+      LOG(ERROR) << error_header << "expecting \"=\"";
       return opt;
     }
   }
@@ -573,20 +572,19 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
     if (type == Option::OptType::Int || type == Option::OptType::UInt) {
       auto v = to_integer(value.value());
       if (!v.has_value()) {
-        LOG(ERROR) << warn_header << "invalid integer value \"" << value.value() << "\""
-                   << warn_ignored;
+        LOG(ERROR) << error_header << "invalid integer value \"" << value.value() << "\"";
         return opt;
       }
       if (type == Option::OptType::Int) {
         opt.value.i = static_cast<int>(v.value());
         if (opt.value.i != v.value()) {
-          LOG(WARNING) << warn_header << "value exceeds int range, assuming " << opt.value.i;
+          LOG(WARNING) << error_header << "value exceeds int range, assuming " << opt.value.i;
         }
       } else {
         // NOLINTNEXTLINE(runtime/int)
         opt.value.u = static_cast<unsigned>(static_cast<unsigned long long>(v.value()));
         if (opt.value.u != static_cast<unsigned long long>(v.value())) {  // NOLINT(runtime/int)
-          LOG(WARNING) << warn_header << "value exceeds int range, assuming " << opt.value.u;
+          LOG(WARNING) << error_header << "value exceeds int range, assuming " << opt.value.u;
         }
       }
     } else if (type == Option::OptType::String) {
@@ -595,8 +593,7 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
       // "type" is either Bool (given explicitly) or Invalid (type not present in string)
       auto v = to_boolean(value.value());
       if (!v.has_value()) {
-        LOG(ERROR) << warn_header << "invalid boolean value \"" << value.value() << "\""
-                   << warn_ignored;
+        LOG(ERROR) << error_header << "invalid boolean value \"" << value.value() << "\"";
         return opt;
       }
       opt.value.b = v.value();
@@ -608,7 +605,7 @@ LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str)
       opt.value.b = true;
       type = Option::OptType::Bool;
     } else {
-      LOG(ERROR) << warn_header << "must have a value" << warn_ignored;
+      LOG(ERROR) << error_header << "must have a value";
       return opt;
     }
   }

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -39,6 +39,7 @@
 #include <llvm/Support/TargetRegistry.h>
 #endif
 #include <llvm/Support/CodeGen.h>
+#include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ErrorOr.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/MemoryBuffer.h>
@@ -56,9 +57,13 @@
 #include <tvm/target/target.h>
 
 #include <atomic>
+#include <cctype>
+#include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <system_error>
+#include <utility>
 
 namespace tvm {
 namespace codegen {
@@ -136,10 +141,27 @@ std::unique_ptr<llvm::Module> LLVMInstance::ParseBuffer(const llvm::MemoryBuffer
   return module;
 }
 
-// LLVMTarget
+// LLVMTargetInfo
 
-LLVMTarget::LLVMTarget(LLVMInstance& instance, const Target& target)
-    : instance_(instance), ctx_(instance.GetContext()) {
+std::ostream& operator<<(std::ostream& os, const LLVMTargetInfo::Option& opt) {
+  os << '-' << opt.name;
+  switch (opt.type) {
+    case LLVMTargetInfo::Option::OptType::Bool:
+      return os << ":bool=" << (opt.value.b ? "true" : "false");
+    case LLVMTargetInfo::Option::OptType::Int:
+      return os << ":int=" << opt.value.i;
+    case LLVMTargetInfo::Option::OptType::UInt:
+      return os << ":uint=" << opt.value.u;
+    case LLVMTargetInfo::Option::OptType::String:
+      return os << ":string=" << opt.value.s;
+    default:
+      os << ":?(" << static_cast<int>(opt.type) << ")";
+      break;
+  }
+  return os;
+}
+
+LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const Target& target) {
   triple_ = target->GetAttr<String>("mtriple").value_or("default");
 
   if (triple_.empty() || triple_ == "default") {
@@ -150,6 +172,21 @@ LLVMTarget::LLVMTarget(LLVMInstance& instance, const Target& target)
   if (const Optional<Array<String>>& v = target->GetAttr<Array<String>>("mattr")) {
     for (const String& s : v.value()) {
       attrs_.push_back(s);
+    }
+  }
+
+  if (const Optional<Array<String>>& v = target->GetAttr<Array<String>>("cl-opt")) {
+    llvm::StringMap<llvm::cl::Option*>& options = llvm::cl::getRegisteredOptions();
+    for (const String& s : v.value()) {
+      Option opt = ParseOptionString(s);
+      if (opt.type == Option::OptType::Invalid) {
+        continue;
+      }
+      if (options.count(opt.name)) {
+        llvm_options_.push_back(opt);
+      } else {
+        LOG(WARNING) << "\"" << opt.name << "\" is not an LLVM option, option ignored";
+      }
     }
   }
 
@@ -238,17 +275,12 @@ LLVMTarget::LLVMTarget(LLVMInstance& instance, const Target& target)
   }
 }
 
-LLVMTarget::LLVMTarget(LLVMInstance& scope, const std::string& target_str)
-    : LLVMTarget(scope, Target(target_str)) {}
+LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& scope, const std::string& target_str)
+    : LLVMTargetInfo(scope, Target(target_str)) {}
 
-LLVMTarget::~LLVMTarget() = default;
+LLVMTargetInfo::~LLVMTargetInfo() = default;
 
-llvm::LLVMContext* LLVMTarget::GetContext() const {
-  ICHECK(!ctx_.expired()) << "LLVM scope has been deleted";
-  return ctx_.lock().get();
-}
-
-llvm::TargetMachine* LLVMTarget::GetOrCreateTargetMachine(bool allow_missing) {
+llvm::TargetMachine* LLVMTargetInfo::GetOrCreateTargetMachine(bool allow_missing) {
   if (target_machine_) return target_machine_.get();
 
   std::string error;
@@ -264,11 +296,11 @@ llvm::TargetMachine* LLVMTarget::GetOrCreateTargetMachine(bool allow_missing) {
   return target_machine_.get();
 }
 
-std::string LLVMTarget::GetTargetFeatureString() const {  //
+std::string LLVMTargetInfo::GetTargetFeatureString() const {  //
   return Join(",", attrs_);
 }
 
-std::string LLVMTarget::str() const {
+std::string LLVMTargetInfo::str() const {
   std::ostringstream os;
   os << "llvm";
   if (!triple_.empty()) {
@@ -340,7 +372,324 @@ std::string LLVMTarget::str() const {
     }
   }
 
+  if (size_t num = llvm_options_.size(); num > 0) {
+    os << " -cl-opt=";
+    std::vector<std::string> opts;
+    for (const Option& opt : llvm_options_) {
+      std::stringstream os;
+      os << opt;
+      opts.emplace_back(os.str());
+    }
+    auto* quote = num > 1 ? "'" : "";
+    os << quote << Join(",", opts) << quote;
+  }
+
   return os.str();
+}
+
+LLVMTargetInfo::Option LLVMTargetInfo::ParseOptionString(const std::string& str) {
+  Option opt;
+  opt.type = Option::OptType::Invalid;
+
+  // Option string: "-"+ <option_name> ":" <type> "=" <value>
+  //
+  // Note: "-"+ means 1 or more dashes, but only "-" are "--" valid.
+
+  // The first step is to do "lexing" of the option string, i.e. to break
+  // it up into parts (like "tokens") according to the syntax above. These
+  // parts will be non-overlapping substrings of the option string, and
+  // concatenated together, they will be equal to the option string.
+  // The literal elements are parts on their own.
+  //
+  // Note that the option string may be malformed, so any of the literal
+  // elements in the syntax may be missing.
+
+  std::vector<std::string> parts;
+
+  auto find_first_of = [](const std::string& str, const std::string& chars, auto start = 0) {
+    auto pos = str.find_first_of(chars, start);
+    return pos != std::string::npos ? pos : str.size();
+  };
+  auto find_first_not_of = [](const std::string& str, const std::string& chars, auto start = 0) {
+    auto pos = str.find_first_not_of(chars, start);
+    return pos != std::string::npos ? pos : str.size();
+  };
+
+  // "-"+
+  std::string::size_type pos_start = 0, pos_end = str.size();
+  std::string::size_type pos_at = find_first_not_of(str, "-", pos_start);
+  if (pos_at > 0) {
+    parts.push_back(str.substr(pos_start, pos_at));
+  }
+  // <option_name>, always present, may be empty string
+  pos_start = pos_at;
+  pos_at = find_first_of(str, ":=", pos_start);
+  parts.push_back(str.substr(pos_start, pos_at - pos_start));
+
+  // ":" or "=", if any
+  pos_start = pos_at;
+  char c = pos_start < pos_end ? str[pos_start] : 0;
+  if (c != 0) {
+    parts.emplace_back(1, c);
+    pos_start++;
+  }
+  // If the character found in the previous step wasn't '=', look for '='.
+  if (c == ':') {
+    // <type>
+    pos_at = find_first_of(str, "=", pos_start);
+    if (pos_at > pos_start) {  // if non-empty
+      parts.push_back(str.substr(pos_start, pos_at - pos_start));
+    }
+
+    // "="
+    if (pos_at < pos_end) {
+      parts.emplace_back(1, str[pos_at]);
+      pos_start = pos_at + 1;
+    }
+  }
+  if (pos_start < pos_end) {
+    // <value>
+    parts.push_back(str.substr(pos_start));
+  }
+
+  // After breaking up the option string, examine and validate the individual
+  // parts.
+
+  int part_this = 0, part_end = parts.size();
+
+  const std::string warn_header = "while parsing option \"" + str + "\": ";
+  const std::string warn_ignored = ", option ignored";
+
+  // Check for "-" or "--".
+  if (part_this < part_end) {
+    auto& p = parts[part_this++];
+    if ((p.size() != 1 && p.size() != 2) || p.find_first_not_of('-') != std::string::npos) {
+      LOG(WARNING) << warn_header << "option must start with \"-\" or \"--\"" << warn_ignored;
+      return opt;
+    }
+  }
+
+  // Validate option name.
+  if (part_this < part_end) {
+    auto& p = parts[part_this++];
+    if (p.empty()) {
+      LOG(WARNING) << warn_header << "option name must not be empty" << warn_ignored;
+      return opt;
+    }
+    opt.name = std::move(p);
+  }
+
+  // Check type, if present.
+  Option::OptType type = Option::OptType::Invalid;
+  if (part_this < part_end) {
+    auto& p0 = parts[part_this];
+    if (p0 == ":") {
+      part_this++;  // Only advance if we saw ":".
+      if (part_this < part_end) {
+        auto& p1 = parts[part_this];
+        ICHECK(!p1.empty()) << "tokenizing error";  // This shouldn't happen.
+        if (p1 != "=") {
+          part_this++;
+          if (p1 == "bool") {
+            type = Option::OptType::Bool;
+          } else if (p1 == "int") {
+            type = Option::OptType::Int;
+          } else if (p1 == "uint") {
+            type = Option::OptType::UInt;
+          } else if (p1 == "string") {
+            type = Option::OptType::String;
+          }
+        }
+      }
+      // If there was ":", there must be a type.
+      if (type == Option::OptType::Invalid) {
+        LOG(WARNING) << warn_header << "invalid type" << warn_ignored;
+        return opt;
+      }
+    }
+  }
+
+  // Check value, if present.
+  std::pair<std::string, bool> value = {"", false};
+  if (part_this < part_end) {
+    auto& p0 = parts[part_this];
+    if (p0 == "=") {
+      part_this++;
+      if (part_this < part_end) {
+        value.first = std::move(parts[part_this]);
+      }
+      value.second = true;
+    } else {
+      // If there are still any parts left to be processed, there must be "=".
+      LOG(WARNING) << warn_header << "expecting \"=\"" << warn_ignored;
+      return opt;
+    }
+  }
+
+  // NOLINTNEXTLINE(runtime/int)
+  auto to_integer = [](const std::string& s) -> std::pair<long long, bool> {
+    // std::stoll takes "long long"
+    long long number;  // NOLINT(runtime/int)
+    size_t pos;
+    try {
+      number = std::stoll(s, &pos);
+    } catch (...) {
+      return {0, false};
+    }
+    if (pos == s.size()) {
+      return {number, true};
+    } else {
+      return {0, false};
+    }
+  };
+
+  auto to_boolean = [&to_integer](const std::string& s) -> std::pair<bool, bool> {
+    // Return 0 or 1, if string corresponds to a valid boolean value,
+    // otherwise return 2.
+    auto ti = to_integer(s);
+    if (ti.second && (ti.first == 0 || ti.first == 1)) {
+      return {static_cast<bool>(ti.first), true};
+    }
+
+    std::string lower;
+    std::transform(s.begin(), s.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower == "true") {
+      return {true, true};
+    } else if (lower == "false") {
+      return {false, true};
+    }
+    return {false, false};
+  };
+
+  if (value.second) {
+    if (type == Option::OptType::Int || type == Option::OptType::UInt) {
+      auto v = to_integer(value.first);
+      if (!v.second) {
+        LOG(WARNING) << warn_header << "invalid integer value \"" << value.first << "\""
+                     << warn_ignored;
+        return opt;
+      }
+      if (type == Option::OptType::Int) {
+        opt.value.i = static_cast<int>(v.first);
+        if (opt.value.i != v.first) {
+          LOG(WARNING) << warn_header << "value exceeds int range, assuming " << opt.value.i;
+        }
+      } else {
+        // NOLINTNEXTLINE(runtime/int)
+        opt.value.u = static_cast<unsigned>(static_cast<unsigned long long>(v.first));
+        if (opt.value.u != static_cast<unsigned long long>(v.first)) {  // NOLINT(runtime/int)
+          LOG(WARNING) << warn_header << "value exceeds int range, assuming " << opt.value.u;
+        }
+      }
+    } else if (type == Option::OptType::String) {
+      opt.value.s = std::move(value.first);
+    } else {
+      // "type" is either Bool (given explicitly) or Invalid (type not present in string)
+      auto v = to_boolean(value.first);
+      if (!v.second) {
+        LOG(WARNING) << warn_header << "invalid boolean value \"" << value.first << "\""
+                     << warn_ignored;
+        return opt;
+      }
+      opt.value.b = v.first;
+      type = Option::OptType::Bool;
+    }
+  } else {
+    // Value was not present in string. Assume "true" if "type" is Bool or Invalid
+    if (type == Option::OptType::Bool || type == Option::OptType::Invalid) {
+      opt.value.b = true;
+      type = Option::OptType::Bool;
+    } else {
+      LOG(WARNING) << warn_header << "must have a value" << warn_ignored;
+      return opt;
+    }
+  }
+
+  ICHECK(type != Option::OptType::Invalid);
+  opt.type = type;
+  return opt;
+}
+
+bool LLVMTargetInfo::MatchesGlobalState() const {
+  for (const Option& opt : GetCommandLineOptions()) {
+    Option current_opt = opt;
+    GetOptionValue(&current_opt);
+    ICHECK(current_opt.type != Option::OptType::Invalid);
+    switch (current_opt.type) {
+      case Option::OptType::Bool:
+        if (current_opt.value.b != opt.value.b) return false;
+        continue;
+      case Option::OptType::Int:
+        if (current_opt.value.i != opt.value.i) return false;
+        continue;
+      case Option::OptType::UInt:
+        if (current_opt.value.u != opt.value.u) return false;
+        continue;
+      case Option::OptType::String:
+        if (current_opt.value.s != opt.value.s) return false;
+        continue;
+      default:;  // NOLINT(whitespace/semicolon)
+    }
+  }
+  return true;
+}
+
+void LLVMTargetInfo::GetOptionValue(LLVMTargetInfo::Option* opt) const {
+  llvm::StringMap<llvm::cl::Option*>& options = llvm::cl::getRegisteredOptions();
+  llvm::cl::Option* base_op = options[opt->name];
+
+  if (opt->type == Option::OptType::Bool) {
+    auto* bool_op = static_cast<llvm::cl::opt<bool>*>(base_op);
+    opt->value.b = bool_op->getValue();
+  } else if (opt->type == Option::OptType::Int) {
+    auto* int_op = static_cast<llvm::cl::opt<int>*>(base_op);
+    opt->value.i = int_op->getValue();
+  } else if (opt->type == Option::OptType::UInt) {
+    auto* uint_op = static_cast<llvm::cl::opt<unsigned>*>(base_op);
+    opt->value.u = uint_op->getValue();
+  } else if (opt->type == Option::OptType::String) {
+    auto* str_op = static_cast<llvm::cl::opt<std::string>*>(base_op);
+    opt->value.s = str_op->getValue();
+  } else {
+    opt->type = Option::OptType::Invalid;
+  }
+}
+
+// LLVMTarget
+
+bool LLVMTarget::modified_llvm_state_ = false;
+
+LLVMTarget::LLVMTarget(LLVMInstance& instance, const LLVMTargetInfo& target_info)
+    : LLVMTargetInfo(target_info), instance_(instance), ctx_(instance.GetContext()) {
+  // Populate the list of saved options with the current values.
+  for (const Option& opt : GetCommandLineOptions()) {
+    GetOptionValue(&saved_llvm_options_.emplace_back(opt));
+  }
+
+  if (modified_llvm_state_) {
+    ICHECK(!ApplyLLVMOptions(true));
+  } else {
+    modified_llvm_state_ = ApplyLLVMOptions(true);
+  }
+}
+
+LLVMTarget::LLVMTarget(LLVMInstance& instance, const Target& target)
+    : LLVMTarget(instance, LLVMTargetInfo(instance, target)) {}
+
+LLVMTarget::LLVMTarget(LLVMInstance& scope, const std::string& target_str)
+    : LLVMTarget(scope, Target(target_str)) {}
+
+LLVMTarget::~LLVMTarget() {
+  // Revert all applied LLVM options.
+  if (ApplyLLVMOptions(false)) {
+    modified_llvm_state_ = false;
+  }
+}
+
+llvm::LLVMContext* LLVMTarget::GetContext() const {
+  ICHECK(!ctx_.expired()) << "LLVM scope has been deleted";
+  return ctx_.lock().get();
 }
 
 std::string LLVMTarget::GetTargetMetadata(const llvm::Module& module) {
@@ -357,6 +706,55 @@ std::string LLVMTarget::GetTargetMetadata(const llvm::Module& module) {
 void LLVMTarget::SetTargetMetadata(llvm::Module* module) const {
   module->addModuleFlag(llvm::Module::Warning, "tvm_target",
                         llvm::MDString::get(*GetContext(), str()));
+}
+
+bool LLVMTarget::ApplyLLVMOptions(bool apply_otherwise_revert, bool dry_run) {
+  llvm::StringMap<llvm::cl::Option*>& options = llvm::cl::getRegisteredOptions();
+  bool changed = false;
+
+#define HANDLE_OPTION_VALUE(option, new_val, saved_val)                  \
+  do {                                                                   \
+    auto current = (option)->getValue();                                 \
+    auto replacement = apply_otherwise_revert ? (new_val) : (saved_val); \
+    if (current != replacement) {                                        \
+      changed = true;                                                    \
+      if (!dry_run) {                                                    \
+        (option)->setValue(replacement);                                 \
+      }                                                                  \
+    }                                                                    \
+  } while (false);
+
+  const auto& new_options = GetCommandLineOptions();
+  for (size_t i = 0, e = saved_llvm_options_.size(); i != e; ++i) {
+    const Option& new_opt = new_options[i];
+    const Option& saved_opt = saved_llvm_options_[i];
+
+    llvm::cl::Option* base_op = options[new_opt.name];
+
+    if (new_opt.type == Option::OptType::Bool) {
+      auto* bool_op = static_cast<llvm::cl::opt<bool>*>(base_op);
+      HANDLE_OPTION_VALUE(bool_op, new_opt.value.b, saved_opt.value.b);
+    } else if (new_opt.type == Option::OptType::Int) {
+      auto* int_op = static_cast<llvm::cl::opt<int>*>(base_op);
+      HANDLE_OPTION_VALUE(int_op, new_opt.value.i, saved_opt.value.i);
+    } else if (new_opt.type == Option::OptType::UInt) {
+      auto* uint_op = static_cast<llvm::cl::opt<unsigned>*>(base_op);
+      HANDLE_OPTION_VALUE(uint_op, new_opt.value.u, saved_opt.value.u);
+    } else if (new_opt.type == Option::OptType::String) {
+      auto* str_op = static_cast<llvm::cl::opt<std::string>*>(base_op);
+      HANDLE_OPTION_VALUE(str_op, new_opt.value.s, saved_opt.value.s);
+    } else {
+      LOG(FATAL) << "unexpected type in option " << new_opt;
+    }
+
+    if (dry_run && changed) {
+      return true;
+    }
+  }
+
+#undef HANDLE_OPTION_VALUE
+
+  return changed;
 }
 
 }  // namespace codegen

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -390,8 +390,8 @@ void LLVMModuleNode::LazyInitJIT() {
 }
 
 bool LLVMModuleNode::IsCompatibleWithHost(const llvm::TargetMachine* tm) const {
-  With<LLVMTarget> host_target(*llvm_instance_, "llvm");  // FIXME(kparzysz-quic): nesting
-  auto tm_host = host_target->GetOrCreateTargetMachine();
+  LLVMTargetInfo host_target(*llvm_instance_, "llvm");
+  auto tm_host = host_target.GetOrCreateTargetMachine();
   if (tm_host->getTargetTriple().getArch() != tm->getTargetTriple().getArch()) {
     LOG(INFO) << "Architecture mismatch: module=" << tm->getTargetTriple().str()
               << " host=" << tm_host->getTargetTriple().str();

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -279,11 +279,35 @@ TVM_REGISTER_TARGET_KIND("llvm", kDLCPU)
     .add_attr_option<Bool>("fast-math-contract")
     .add_attr_option<Bool>("fast-math-reassoc")
     .add_attr_option<Integer>("opt-level")
+    // LLVM command line flags, see below
+    .add_attr_option<Array<String>>("cl-opt")
     .set_default_keys({"cpu"})
     // Force the external codegen kind attribute to be registered, even if no external
     // codegen targets are enabled by the TVM build.
     .set_attr<Bool>(tvm::attr::kIsExternalCodegen, Bool(false))
     .set_target_parser(tvm::target::parsers::cpu::ParseTarget);
+
+// Note regarding the "cl-opt" attribute:
+// Each string in the array has the format
+//   -optionname[[:type]=value]
+// where
+//   * optionname is the actual LLVM option (e.g. "unroll-threshold")
+//   * type is one of "bool", "int", "uint", or "string"
+//   * value is the corresponding option value (for "bool" type is can be 0 or "false"
+//     for false value, or 1 or "true" for true value)
+// If type is omitted, it is assumed to be "bool". If value is omitted, it is assumed
+// to be "true".
+//
+// The type must match the option type in LLVM. To find the type, search the LLVM
+// repository (https://github.com/llvm/llvm-project) for optionname, and look for
+// its definition: it will be a declaration of a variable of type cl::opt<T> with
+// optionname being an argument to the constructor. The T in the declaration is
+// the type.
+// For example, for unroll-threshold, we get the following declaration:
+// static cl::opt<unsigned>
+//     UnrollThreshold("unroll-threshold", cl::Hidden,
+//                     cl::desc("The cost threshold for loop unrolling"));
+// Hence the type is "uint".
 
 TVM_REGISTER_TARGET_KIND("c", kDLCPU)
     .add_attr_option<Bool>("system-lib")

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -295,12 +295,14 @@ TEST(TargetCreation, LLVMCommandLineFatal) {
   tvm::codegen::LLVMInstance inst;
 
   // Check that malformed options cause an assertion.
-  EXPECT_THROW({
-    Target test_target(
-        "llvm -cl-opt='-heh:,-hah:=,-print-after-all:bool=,"
-        "---unroll-factor=0,\\\'-blah:string=ha ha\\\''");
-    tvm::codegen::LLVMTargetInfo info(inst, test_target);
-  }, std::exception);
+  EXPECT_THROW(
+      {
+        Target test_target(
+            "llvm -cl-opt='-heh:,-hah:=,-print-after-all:bool=,"
+            "---unroll-factor=0,\\\'-blah:string=ha ha\\\''");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
 }
 
 TEST(TargetCreation, LLVMCommandLineError) {

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -26,6 +26,8 @@
 #include <cmath>
 #include <string>
 
+#include "../../../src/target/llvm/llvm_instance.h"
+
 using namespace tvm;
 
 TVM_REGISTER_TARGET_KIND("TestTargetKind", kDLCPU)
@@ -287,6 +289,37 @@ TEST(TargetCreation, ProcessStrings) {
   ASSERT_EQ(array7[1][0][0], "zing0");
   ASSERT_EQ(array7[1][0][1], "zing1");
   ASSERT_EQ(array7[1][1][0], "fred");
+}
+
+TEST(TargetCreation, LLVMCommandLine) {
+  tvm::codegen::LLVMInstance inst;
+  {
+    // Check that malformed options are ignored.
+    Target test_target(
+        "llvm -cl-opt='-heh:,-hah:=,-print-after-all:bool=,"
+        "---unroll-factor=0,\\\'-blah:string=ha ha\\\''");
+    tvm::codegen::LLVMTargetInfo info(inst, test_target);
+    ASSERT_TRUE(info.GetCommandLineOptions().empty());
+  }
+  {
+    // Check that invalid LLVM options are ignored.
+    Target test_target("llvm -cl-opt=-not-an-option:uint=123");
+    tvm::codegen::LLVMTargetInfo info(inst, test_target);
+    ASSERT_TRUE(info.GetCommandLineOptions().empty());
+  }
+  {
+    // Check detection of modified global state
+    Target test_target("llvm -cl-opt=-print-after-all");  // "false" by default
+    tvm::codegen::LLVMTargetInfo info(inst, test_target);
+    ASSERT_FALSE(info.MatchesGlobalState());
+    {
+      // Check that we can modify global state.
+      tvm::codegen::LLVMTarget llvm_target(inst, info);
+      ASSERT_TRUE(info.MatchesGlobalState());
+    }
+    // Check that we restored global state.
+    ASSERT_FALSE(info.MatchesGlobalState());
+  }
 }
 
 TVM_REGISTER_TARGET_KIND("test_external_codegen_0", kDLCUDA)

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -291,15 +291,134 @@ TEST(TargetCreation, ProcessStrings) {
   ASSERT_EQ(array7[1][1][0], "fred");
 }
 
-TEST(TargetCreation, LLVMCommandLineFatal) {
+// Checks that malformed options cause an assertion.
+TEST(TargetCreation, LLVMCommandLineParseFatalDashDashDash) {
   tvm::codegen::LLVMInstance inst;
 
-  // Check that malformed options cause an assertion.
+  // Too many dashes in an otherwise valid option.
   EXPECT_THROW(
       {
-        Target test_target(
-            "llvm -cl-opt='-heh:,-hah:=,-print-after-all:bool=,"
-            "---unroll-factor=0,\\\'-blah:string=ha ha\\\''");
+        Target test_target("llvm -cl-opt='---unroll-factor:uint=0'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalColonNoType) {
+  tvm::codegen::LLVMInstance inst;
+
+  // : not followed by type.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalColonNoTypeEqNoValue) {
+  tvm::codegen::LLVMInstance inst;
+
+  // : and = without type/value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:='");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalColonTypeNoEqNoValue) {
+  tvm::codegen::LLVMInstance inst;
+
+  // Option with type, but no = and no value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:bool'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalColonTypeEqNoValue) {
+  tvm::codegen::LLVMInstance inst;
+
+  // Option with type and =, but no value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:bool='");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalInvalidType) {
+  tvm::codegen::LLVMInstance inst;
+
+  // Option with invalid type.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:invalidtype=xyz'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalInvalidValue1) {
+  tvm::codegen::LLVMInstance inst;
+
+  // (Implicit) bool option without type, but with invalid value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option=2'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalInvalidValue2) {
+  tvm::codegen::LLVMInstance inst;
+
+  // Bool option without type, but with invalid value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option=fred'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalInvalidValue3) {
+  tvm::codegen::LLVMInstance inst;
+
+  // Bool option with type and =, but invalid value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:bool=2'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalInvalidValue4) {
+  tvm::codegen::LLVMInstance inst;
+
+  // Int option with invalid value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:int=haha'");
+        tvm::codegen::LLVMTargetInfo info(inst, test_target);
+      },
+      std::exception);
+}
+
+TEST(TargetCreation, LLVMCommandLineParseFatalInvalidValue5) {
+  tvm::codegen::LLVMInstance inst;
+
+  // UInt option with invalid value.
+  EXPECT_THROW(
+      {
+        Target test_target("llvm -cl-opt='-option:uint=haha'");
         tvm::codegen::LLVMTargetInfo info(inst, test_target);
       },
       std::exception);

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -162,6 +162,13 @@ def test_target_string_with_spaces():
     assert target.attrs["device_type"] == "discrete"
 
 
+def test_target_llvm_options():
+    target = tvm.target.Target("llvm -cl-opt='-unroll-threshold:uint=100,-unroll-count:uint=3'")
+    assert sorted(target.attrs["cl-opt"]) == sorted(
+        ["-unroll-threshold:uint=100", "-unroll-count:uint=3"]
+    )
+
+
 def test_target_create():
     targets = [cuda(), rocm(), mali(), intel_graphics(), arm_cpu("rk3399"), vta(), bifrost()]
     for tgt in targets:


### PR DESCRIPTION
Add `LLVMTargetInfo` class that can be used to query the LLVM configuration without forcing an `LLVMTarget` to be created.

There is no programmatic way to obtain the actual type of an LLVM option. The type is necessary to obtain the value of the option, hence it must be provided as a part of the option string.
See `src/target/llvm/target_kind.cc` for more information about the syntax.
