### PR TITLE
[microTVM] Add config space to dense_dsp schedule

### DIFF
--- a/python/tvm/topi/arm_cpu/dense.py
+++ b/python/tvm/topi/arm_cpu/dense.py
@@ -18,8 +18,6 @@
 """Dense schedule for ARM CPU"""
 
 from tvm import autotvm
-from tvm.topi.nn import dense
-
 from .mprofile.dsp.dense import dense_dsp_schedule, dense_dsp_compute
 
 

--- a/python/tvm/topi/arm_cpu/dense.py
+++ b/python/tvm/topi/arm_cpu/dense.py
@@ -20,16 +20,16 @@
 from tvm import autotvm
 from tvm.topi.nn import dense
 
-from .mprofile.dsp.dense import dense_dsp_schedule
+from .mprofile.dsp.dense import dense_dsp_schedule, dense_dsp_compute
 
 
 @autotvm.register_topi_compute("dense_dsp.arm_cpu")
 def dense_dsp(cfg, data, weight, bias, out_dtype):
     """Compute conv2d_nhwc with v7e-m DSP instructions."""
-    return dense(data, weight, bias=bias, out_dtype=out_dtype)
+    return dense_dsp_compute(cfg, data, weight, bias=bias, out_dtype=out_dtype)
 
 
 @autotvm.register_topi_schedule("dense_dsp.arm_cpu")
 def schedule_dense_dsp(cfg, outs):
     """Create schedule for dense_dsp"""
-    return dense_dsp_schedule(outs)
+    return dense_dsp_schedule(cfg, outs)

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/dense.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/dense.py
@@ -28,6 +28,7 @@ from .... import tag
 
 
 def dense_dsp_compute(cfg, data, weight, bias=None, out_dtype=None):
+    """Defines the v7e-m DSP instructions of dense."""
     M, K = get_const_tuple(data.shape)
     N, _ = get_const_tuple(weight.shape)
 

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/dense.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/dense.py
@@ -18,15 +18,40 @@
 """Direct implementation of dense."""
 
 from tvm import te
-from tvm.topi.utils import traverse_inline
+from tvm.topi.utils import traverse_inline, get_const_tuple
 
 from .micro_kernel.gemm import (
     intrin_gemm_MxKxN,
     gemm_MxKxN_impl,
 )
+from .... import tag
 
 
-def dense_dsp_schedule(outs):
+def dense_dsp_compute(cfg, data, weight, bias=None, out_dtype=None):
+    M, K = get_const_tuple(data.shape)
+    N, _ = get_const_tuple(weight.shape)
+
+    cfg.define_split("tile_x", M, policy="factors", num_outputs=2)
+    cfg.define_split("tile_y", N, policy="factors", num_outputs=2)
+    cfg.define_split("tile_k", K, policy="factors", num_outputs=2)
+
+    k = te.reduce_axis((0, K), "k")
+    C = te.compute(
+        (M, N),
+        lambda x, y: te.sum(
+            data[x, k].astype(out_dtype) * weight[y, k].astype(out_dtype),
+            axis=k,
+        ),
+        name="dense",
+        tag="dense_dsp",
+    )
+
+    if bias is not None:
+        C = te.compute((M, N), lambda i, j: C[i, j] + bias[j].astype(out_dtype), tag=tag.BROADCAST)
+    return C
+
+
+def dense_dsp_schedule(cfg, outs):
     """Schedule function for v7e-m DSP instructions of dense."""
     sched = te.create_schedule([x.op for x in outs])
 
@@ -34,19 +59,27 @@ def dense_dsp_schedule(outs):
         if "dense" not in op.tag:
             return
 
-        # extract tensors
         output = op.output(0)
         dense = op
-        data_vec = dense.input_tensors[0]
-        M, K = data_vec.shape
-        N, _ = dense.input_tensors[1].shape
 
-        n, _ = sched[dense].op.axis
-        no, ni = sched[dense].split(n, nparts=1)
+        data = dense.input_tensors[0]
 
-        gemm, uniq_id = intrin_gemm_MxKxN(M, K, N, data_vec.dtype, output.dtype)
-        sched[output].tensorize(ni, gemm)
-        sched[output].pragma(no, "import_c", gemm_MxKxN_impl(M, K, N, uniq_id))
+        M = cfg["tile_x"].size[-1]
+        N = cfg["tile_y"].size[-1]
+        K = cfg["tile_k"].size[-1]
+
+        x, y = sched[dense].op.axis
+        k = sched[dense].op.reduce_axis[0]
+
+        x_o, x_i = cfg["tile_x"].apply(sched, dense, x)
+        y_o, y_i = cfg["tile_y"].apply(sched, dense, y)
+        k_o, k_i = cfg["tile_k"].apply(sched, dense, k)
+
+        sched[dense].reorder(x_o, y_o, k_o, x_i, y_i, k_i)
+
+        gemm, uniq_id = intrin_gemm_MxKxN(M, K, N, data.dtype, output.dtype, stride_w=1)
+        sched[output].tensorize(x_i, gemm)
+        sched[output].pragma(x_o, "import_c", gemm_MxKxN_impl(M, K, N, uniq_id))
 
     traverse_inline(sched, outs[-1].op, _callback)
     return sched

--- a/tests/python/relay/strategy/arm_cpu/test_dense_dsp.py
+++ b/tests/python/relay/strategy/arm_cpu/test_dense_dsp.py
@@ -26,36 +26,35 @@ from tvm.micro.testing.aot_test_utils import (
 
 class BasicDenseTests:
     @tvm.testing.requires_corstone300
-    def test_dense(self, shape, weight_shape, dtype, schedule_name):
+    def test_dense(self, shape, weight_shape, dtype, schedule_name, enable_bias):
         """Test a subgraph with a single dense operator."""
         ishape = shape
         wshape = weight_shape
+        out_dtype = "int32"
         units = weight_shape[0]
         weight_data = np.random.randint(low=-10, high=10, size=wshape, dtype=dtype)
+        if enable_bias:
+            bias_data = np.random.randint(low=-10, high=10, size=(wshape[0]), dtype=out_dtype)
 
-        input0 = relay.var("input", relay.TensorType(ishape, dtype))
-        weight0 = relay.const(weight_data)
-        out0 = relay.op.nn.dense(
-            input0,
-            weight0,
+        input = relay.var("input", relay.TensorType(ishape, dtype))
+        weight = relay.const(weight_data)
+        dense = relay.op.nn.dense(
+            input,
+            weight,
             units=units,
-            out_dtype="int32",
+            out_dtype=out_dtype,
         )
-        ref_mod = tvm.IRModule.from_expr(relay.Function([input0], out0))
-
-        input1 = relay.var("input", relay.TensorType(ishape, dtype))
-        weight1 = relay.const(weight_data)
-        out1 = relay.op.nn.dense(
-            input1,
-            weight1,
-            units=units,
-            out_dtype="int32",
-        )
-        mod = tvm.IRModule.from_expr(relay.Function([input1], out1))
+        if enable_bias:
+            bias = relay.const(bias_data)
+            relay_op = relay.op.nn.bias_add(dense, bias)
+        else:
+            relay_op = dense
 
         inputs = {"input": np.random.randint(low=-128, high=127, size=ishape, dtype=dtype)}
+        ref_mod = tvm.IRModule.from_expr(relay.Function([input], relay_op))
         output_list = generate_ref_data(ref_mod, inputs)
 
+        mod = tvm.IRModule.from_expr(relay.Function([input], relay_op))
         compile_and_run(
             AOTTestModel(module=mod, inputs=inputs, outputs=output_list),
             runner=AOT_CORSTONE300_RUNNER,
@@ -73,7 +72,7 @@ class TestDense(BasicDenseTests):
     """This test is for dense_dsp schedule."""
 
     shape, weight_shape = tvm.testing.parameters(
-        ((1, 128), (16, 128)),
+        ((8, 128), (32, 128)),
         ((32, 32), (32, 32)),
         ((1, 64), (1, 64)),
         ((11, 2), (2, 2)),
@@ -81,7 +80,8 @@ class TestDense(BasicDenseTests):
         ((3, 12), (10, 12)),
     )
     dtype = tvm.testing.parameter("int8", "int16")
-    schedule_name = tvm.testing.parameter("dense_dsp")
+    schedule_name = tvm.testing.parameter("dense_dsp.arm_cpu")
+    enable_bias = tvm.testing.parameter(False, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds loop split to dense_dsp schedule. It has been tested on Anomaly detection model which significantly improves the performance.
Also modified the dense_dsp test to have bias operator as well.

cc @alanmacd @areusch @gromero @guberti