### PR TITLE
[BugFix][UMA] Fix order issue in uma_lower 

### DIFF
--- a/apps/uma/_template/patterns.py
+++ b/apps/uma/_template/patterns.py
@@ -23,3 +23,8 @@ def conv2d_pattern():
     pattern = is_op("nn.conv2d")(wildcard(), wildcard())
     pattern = pattern.has_attr({"strides": [1, 1], "groups": 1})
     return pattern
+
+
+def dense_pattern():
+    pattern = is_op("nn.dense")(wildcard(), wildcard())
+    return pattern

--- a/python/tvm/relay/backend/contrib/uma/api/lower.py
+++ b/python/tvm/relay/backend/contrib/uma/api/lower.py
@@ -60,27 +60,7 @@ class UMALower:
         """
 
         def _get_tensors(te_cached_func):
-            outputs = list(te_cached_func.outputs)
-            stack = []
-            visited = set()
-            for output_ in outputs:
-                if output_ not in visited:
-                    visited.add(output_)
-                    stack.append(output_)
-
-            args = []
-            while len(stack) != 0:
-                tensor = stack.pop()
-                if isinstance(tensor.op, tvm.te.tensor.PlaceholderOp):
-                    args.append(tensor)
-                elif isinstance(tensor.op, tvm.te.tensor.ComputeOp):
-                    inputs = tensor.op.input_tensors
-                    for input_ in inputs:
-                        if input_ not in visited:
-                            visited.add(input_)
-                            stack.append(input_)
-
-            return args + outputs
+            return list(te_cached_func.inputs) + list(te_cached_func.outputs)
 
         lower_to_te = tvm._ffi.get_global_func("relay.backend.LowerToTE")
         te_cached_func = lower_to_te(relay_prim_func)

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -942,18 +942,18 @@ def create_relay_module_and_inputs_from_tflite_file(tflite_model_file, bind_para
         name = str(param.name_hint)
         data_shape = [int(i) for i in param.type_annotation.shape]
         dtype = str(param.type_annotation.dtype)
-        if dtype in ("float32", "float64"):
+        if np.issubdtype(dtype, np.floating):
             # Since np.random.uniform only allows the ranges of float32,
-            # at first float32 is used and scaled afterwards, if necessary
-            in_min, in_max = (np.finfo("float32").min, np.finfo("float32").max)
+            # at first float16 is used and scaled afterwards, if necessary.
+            in_min, in_max = (np.finfo("float16").min, np.finfo("float16").max)
             data = np.random.uniform(low=in_min, high=in_max, size=data_shape).astype(dtype)
-            scale = np.finfo(dtype).min / np.finfo("float32").min
+            scale = np.finfo(dtype).min / np.finfo("float16").min
             data *= scale
-        elif dtype in ("int16", "int32", "int64"):
+        elif np.issubdtype(dtype, np.integer):
             in_min, in_max = (np.iinfo(dtype).min, np.iinfo(dtype).max)
             data = np.random.randint(in_min, high=in_max, size=data_shape, dtype=dtype)
         else:
-            raise TypeError("Unsupported type used")
+            raise TypeError(f"Type {dtype} not supported")
         inputs[name] = data
 
     return mod, inputs, params

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -943,7 +943,8 @@ def create_relay_module_and_inputs_from_tflite_file(tflite_model_file, bind_para
         data_shape = [int(i) for i in param.type_annotation.shape]
         dtype = str(param.type_annotation.dtype)
         if dtype == "float32":
-            data = np.random.uniform(size=data_shape).astype("float32")
+            in_min, in_max = (np.finfo(dtype).min, np.finfo(dtype).max)
+            data = np.random.uniform(low=in_min, high=in_max, size=data_shape).astype("float32")
         else:
             in_min, in_max = (np.iinfo(dtype).min, np.iinfo(dtype).max)
             data = np.random.randint(in_min, high=in_max, size=data_shape, dtype=dtype)

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -835,7 +835,7 @@ def run_and_check(
             assert AOT_SUCCESS_TOKEN in run_log.read()
 
     if test_dir is None:
-        tmpdir = utils.tempdir(keep_for_debug=True)
+        tmpdir = utils.tempdir()
         run_and_check_body(os.path.join(tmpdir.path, "test"))
     else:
         run_and_check_body(test_dir)

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -571,9 +571,7 @@ def _create_header_file(tensor_name, npy_data, output_path, data_linkage):
         header_file.write("};\n\n")
 
 
-def convert_to_relay(
-    tflite_model_buf, bind_params_by_name=True
-):
+def convert_to_relay(tflite_model_buf, bind_params_by_name=True):
     """Convert a tflite model buffer in a Relay module"""
     # TFLite.Model.Model has changed to TFLite.Model from 1.14 to 2.1
     try:
@@ -838,7 +836,6 @@ def run_and_check(
 
     if test_dir is None:
         tmpdir = utils.tempdir(keep_for_debug=True)
-        print(tmpdir.path)
         run_and_check_body(os.path.join(tmpdir.path, "test"))
     else:
         run_and_check_body(test_dir)

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -942,12 +942,18 @@ def create_relay_module_and_inputs_from_tflite_file(tflite_model_file, bind_para
         name = str(param.name_hint)
         data_shape = [int(i) for i in param.type_annotation.shape]
         dtype = str(param.type_annotation.dtype)
-        if dtype == "float32":
-            in_min, in_max = (np.finfo(dtype).min, np.finfo(dtype).max)
-            data = np.random.uniform(low=in_min, high=in_max, size=data_shape).astype("float32")
-        else:
+        if dtype == "float32" or dtype == "float64":
+            # Since np.random.uniform only allows the ranges of float32,
+            # at first float32 is used and scaled afterwards, if necessary
+            in_min, in_max = (np.finfo("float32").min, np.finfo("float32").max)
+            data = np.random.uniform(low=in_min, high=in_max, size=data_shape).astype(dtype)
+            scale = np.finfo(dtype).min / np.finfo("float32").min
+            data *= scale
+        elif dtype == "int32" or dtype == "int64" or dtype == "int16":
             in_min, in_max = (np.iinfo(dtype).min, np.iinfo(dtype).max)
             data = np.random.randint(in_min, high=in_max, size=data_shape, dtype=dtype)
+        else:
+            raise TypeError("Unsupported type used")
         inputs[name] = data
 
     return mod, inputs, params

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -942,14 +942,14 @@ def create_relay_module_and_inputs_from_tflite_file(tflite_model_file, bind_para
         name = str(param.name_hint)
         data_shape = [int(i) for i in param.type_annotation.shape]
         dtype = str(param.type_annotation.dtype)
-        if dtype == "float32" or dtype == "float64":
+        if dtype in ("float32", "float64"):
             # Since np.random.uniform only allows the ranges of float32,
             # at first float32 is used and scaled afterwards, if necessary
             in_min, in_max = (np.finfo("float32").min, np.finfo("float32").max)
             data = np.random.uniform(low=in_min, high=in_max, size=data_shape).astype(dtype)
             scale = np.finfo(dtype).min / np.finfo("float32").min
             data *= scale
-        elif dtype == "int32" or dtype == "int64" or dtype == "int16":
+        elif dtype in ("int16", "int32", "int64"):
             in_min, in_max = (np.iinfo(dtype).min, np.iinfo(dtype).max)
             data = np.random.randint(in_min, high=in_max, size=data_shape, dtype=dtype)
         else:

--- a/tests/python/contrib/test_uma/test_uma_pipeline.py
+++ b/tests/python/contrib/test_uma/test_uma_pipeline.py
@@ -186,6 +186,7 @@ def generate_tflite_file(tflite_filename):
     mnist = tf.keras.datasets.mnist
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
     x_train, x_test = x_train / 255.0, x_test / 255.0
+    x_train, x_test = x_train.reshape(-1, 28, 28, 1), x_test.reshape(-1, 28, 28, 1)
     tf_model = tf.keras.models.Sequential(
         [
             tf.keras.Input(shape=(28, 28, 1)),
@@ -198,12 +199,10 @@ def generate_tflite_file(tflite_filename):
     )
     output = tf_model(x_train[:1])
     output = output.numpy()
-    tf.nn.softmax(output).numpy()
-    loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
-    loss_fn(y_train[:1], output).numpy()
-    tf_model.compile(metrics=["accuracy"], optimizer="adam", loss=loss_fn)
+    loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+    loss(y_train[:1], output).numpy()
+    tf_model.compile(metrics=["accuracy"], optimizer="adam", loss=loss)
     tf_model.fit(x_train, y_train, epochs=1)
-    tf_model.evaluate(x_test, y_test, verbose=2)
 
     tflite_converter = tf.lite.TFLiteConverter.from_keras_model(tf_model)
     tflite_model = tflite_converter.convert()

--- a/tests/python/contrib/test_uma/test_uma_pipeline.py
+++ b/tests/python/contrib/test_uma/test_uma_pipeline.py
@@ -16,6 +16,9 @@
 # under the License.
 
 import pytest
+pytest.importorskip("tflite")
+pytest.importorskip("tensorflow")
+
 import os
 import tensorflow as tf
 from tvm.micro.testing.aot_test_utils import AOT_DEFAULT_RUNNER

--- a/tests/python/contrib/test_uma/test_uma_pipeline.py
+++ b/tests/python/contrib/test_uma/test_uma_pipeline.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import pytest
+
 pytest.importorskip("tflite")
 pytest.importorskip("tensorflow")
 

--- a/tests/python/contrib/test_uma/test_uma_vanilla_accelerator.py
+++ b/tests/python/contrib/test_uma/test_uma_vanilla_accelerator.py
@@ -24,7 +24,7 @@ from apps.uma._template.passes import (
 )
 from apps.uma._template.codegen import gen_includes
 
-from apps.uma._template.patterns import conv2d_pattern
+from apps.uma._template.patterns import conv2d_pattern, dense_pattern
 from tvm.relay.backend.contrib.uma import uma_available
 
 pytestmark = pytest.mark.skipif(not uma_available(), reason="UMA not available")
@@ -40,6 +40,7 @@ class VanillaAcceleratorBackend(UMABackend):
         # Relay to Relay function registration
         #######################################################################
         self._register_pattern("conv2d", conv2d_pattern())
+        self._register_pattern("dense", dense_pattern())
 
         #######################################################################
         # Relay to TIR function registration


### PR DESCRIPTION
There was a flaw in uma_lower (see issue #12410) that lead in some case to a different  argument ordering of the  cached_func and the Relay function. This results in an incorrect  lowering of the primfunc and eventually a wrong result of a run-time error, in some cases.

This commit adds code to correct the described misbehavior and a unit test case to check this end-to-end functionality with a TFLITE model. 