### PR TITLE
[TIR] Expose `Struct/Tuple`-related TVM Builtins

### DIFF
--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -49,6 +49,7 @@ from .op import call_packed_lowered, call_cpacked_lowered
 from .op import call_packed, call_cpacked, call_intrin, call_pure_extern, call_extern
 from .op import call_llvm_intrin, call_llvm_pure_intrin, ret, all, any, min_value, max_value, trace
 from .op import tvm_stack_alloca, tvm_stack_make_shape, tvm_stack_make_array
+from .op import tvm_tuple, tvm_struct_get, tvm_struct_set
 from .op import assume, undef
 from .op import exp, exp2, exp10, log, log2, log10, log1p, ldexp, clz
 from .op import sin, sinh, asin, asinh

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -400,6 +400,72 @@ def undef():
     return call_intrin("int32", "tir.undef")
 
 
+def tvm_tuple(*value):
+    """Create a tuple structure in value field of AttrStmt
+
+    Parameters
+    ----------
+    value : Expr
+        The value in tuple.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin("handle", "tir.tvm_tuple", *value)
+
+
+def tvm_struct_get(arr, index, field, dtype):
+    """Get struct field value in array
+
+    Parameters
+    ----------
+    dtype : str
+        The date type of the result.
+
+    arr : StructType*
+        The array of struct.
+
+    index : int
+        The index of struct.
+
+    field : int
+        The field of struct.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(dtype, "tir.tvm_struct_get", arr, index, field)
+
+
+def tvm_struct_set(arr, index, field, value):
+    """Set value in struct field in array
+
+    Parameters
+    ----------
+    arr : StructType*
+        The array of struct.
+
+    index : int
+        The index of struct.
+
+    field : int
+        The field of struct.
+
+    value : Expr
+        The value to be set in field.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin("handle", "tir.tvm_struct_set", arr, index, field, value)
+
+
 def ret(val):
     """Create a tir return expression
 

--- a/tests/python/unittest/test_tir_op_types.py
+++ b/tests/python/unittest/test_tir_op_types.py
@@ -19,6 +19,26 @@ import tvm
 from tvm import tir
 
 
+def test_tir_op_tvm_tuple():
+    x = tir.Var("x", dtype="float32")
+    y = tir.Var("y", dtype="float32")
+    z = tir.Var("z", dtype="float32")
+    expr = tir.tvm_tuple(x, y, z, 1, 2, 3)
+    assert expr.op.name == "tir.tvm_tuple"
+
+
+def test_tir_op_tvm_struct_get():
+    x = tir.Var("x", dtype="handle")
+    expr = tir.tvm_struct_get(x, 1, 2, dtype="int32")
+    assert expr.op.name == "tir.tvm_struct_get"
+
+
+def test_tir_op_tvm_struct_set():
+    x = tir.Var("x", dtype="handle")
+    expr = tir.tvm_struct_set(x, 1, 2, 3)
+    assert expr.op.name == "tir.tvm_struct_set"
+
+
 def test_tir_op_call_assume():
     x = tir.Var("x", dtype="int32")
     expr = tir.assume(cond=x)
@@ -37,6 +57,9 @@ def test_tir_op_call_likely():
 
 
 if __name__ == "__main__":
+    test_tir_op_tvm_tuple()
+    test_tir_op_tvm_struct_get()
+    test_tir_op_tvm_struct_set()
     test_tir_op_call_assume()
     test_tir_op_call_undef()
     test_tir_op_call_likely()


### PR DESCRIPTION
This PR exposes the following TIR operation in python:

`tvm_tuple`: tested [here](https://github.com/apache/tvm/blob/c477c763c37adf29b34528ca52d231d622719b3e/tests/python/unittest/test_tvmscript_roundtrip.py#L554)
`tvm_struct_get`: tested [here](https://github.com/apache/tvm/blob/c477c763c37adf29b34528ca52d231d622719b3e/tests/python/unittest/test_tvmscript_roundtrip.py#L200)
`tvm_struct_set`: tested [here](https://github.com/apache/tvm/blob/c477c763c37adf29b34528ca52d231d622719b3e/tests/python/unittest/test_tvmscript_roundtrip.py#L2432)

Co-Authored-By: yongwww <[yongcale@gmail.com](mailto:yongcale@gmail.com)>

cc @junrushao1994 