### PR TITLE
[Arith] Parse > and >= bounds in ConstIntBoundAnalyzer

### DIFF
--- a/tests/python/unittest/test_arith_const_int_bound.py
+++ b/tests/python/unittest/test_arith_const_int_bound.py
@@ -14,7 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import tvm
+import tvm.testing
+
 from tvm import te
 
 
@@ -336,19 +339,15 @@ def test_floormod_negative_divisor():
     assert bd.max_value == 6
 
 
+def test_multiple_condition():
+    analyzer = tvm.arith.Analyzer()
+    flm, fld = tvm.te.floormod, tvm.te.floordiv
+    a = te.var("a")
+    analyzer.update(a, tvm.arith.ConstIntBound(0, 128))
+    with analyzer.constraint_scope(tvm.tir.all(1 <= flm(a, 58), flm(a, 58) < 57)):
+        bound = analyzer.const_int_bound(flm(a, 58) - 1)
+    assert bound.min_value == 0
+
+
 if __name__ == "__main__":
-    test_let_bound()
-    test_dtype_bound()
-    test_cast_bound()
-    test_add_sub_bound()
-    test_mul_bound()
-    test_truncdiv_bound()
-    test_truncmod_bound()
-    test_floordiv_bound()
-    test_floormod_bound()
-    test_min_max_bound()
-    test_select_bound()
-    test_shift_and_bound()
-    test_mix_index_bound()
-    test_size_var_bound()
-    test_floormod_negative_divisor()
+    tvm.testing.main()


### PR DESCRIPTION
Previously, only `<` and `<=` bounds were parsed, as these are the canonical form produced by the `RewriteSimplifier`.  However, the constraint may also be supplied by the user through the Python API, and may not be canonicalized prior to parsing.

cc @junrushao1994