### PR TITLE
[MetaSchedule] Handle deserializing empty string RVs in trace

### DIFF
--- a/src/tir/schedule/trace.cc
+++ b/src/tir/schedule/trace.cc
@@ -153,7 +153,7 @@ Array<ObjectRef> TranslateInputRVs(const Array<ObjectRef>& inputs,
     const char* name = str->data;
     int64_t size = str->size;
     // Case 2. string
-    if (size > 2 && name[0] == '"' && name[size - 1] == '"') {
+    if (size >= 2 && name[0] == '"' && name[size - 1] == '"') {
       results.push_back(String(std::string(name + 1, size - 2)));
       continue;
     }

--- a/tests/python/unittest/test_tir_schedule_trace.py
+++ b/tests/python/unittest/test_tir_schedule_trace.py
@@ -101,6 +101,15 @@ def _make_enter_postproc():
     )
 
 
+def _make_annotate(block: BlockRV, annotation: str):
+    return Instruction(
+        kind=InstructionKind.get("Annotate"),
+        inputs=[block, annotation],
+        attrs=["meta_schedule.auto_tensorize"],
+        outputs=[],
+    )
+
+
 def _make_trace_1(b0, l1, l2):  # pylint: disable=invalid-name
     return Trace(
         insts=[
@@ -273,6 +282,40 @@ def test_apply_json_to_schedule_1():
     sch = tir.Schedule(elementwise, debug_mask="all")
     Trace.apply_json_to_schedule(json_obj, sch)
     tvm.ir.assert_structural_equal(elementwise_inlined, sch.mod["main"])
+
+
+def _test_apply_annotation_trace_from_json(annotation: str):
+    """Test applying an annotation works without crashing.
+
+    Designed to handle some previously failing edge cases like the
+    empty string.
+    """
+    b0 = BlockRV()
+    trace = Trace(
+        insts=[
+            _make_get_block(name="B", output=b0),
+            _make_annotate(block=b0, annotation=annotation),
+        ],
+        decisions={},
+    )
+    json_obj = trace.as_json()
+    sch = tir.Schedule(elementwise, debug_mask="all")
+    Trace.apply_json_to_schedule(json_obj, sch)
+    tvm.ir.assert_structural_equal(elementwise_inlined, sch.mod["main"])
+
+
+def test_apply_annotation_from_json():
+    # Something reasonable
+    _test_apply_annotation_trace_from_json("SSRSSR")
+
+    # The empty string
+    _test_apply_annotation_trace_from_json("")
+
+    # A string of two quotation marks
+    _test_apply_annotation_trace_from_json('""')
+
+    # A string of one quotation mark
+    _test_apply_annotation_trace_from_json('"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It seems sometimes we can have random variables with names such as "" (this is not the empty string, but two quotation marks). 

I believe this is suppose to hit "Case 2" in `TranslateInputRVs` and become an empty string but this does not seem to be the case.

Unsure if having an RV as "" may be problematic, if it is, this will certainly hide another bug

cc @junrushao1994