### PR TITLE
[Frontend][Pytorch] Add axis N when maxpool3d layout is (C,D,H,W)

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1071,13 +1071,17 @@ class PyTorchOpConverter:
     def maxpool_3d(self, inputs, input_types):
         data = inputs[0]
 
+        need_squeeze = False
+        if len(self.get_dims(data)) == 4:
+            need_squeeze = True
+            data = _op.expand_dims(data, 0)
         pool_size = inputs[1]
         strides = inputs[2] if inputs[2] else pool_size
         padding = inputs[3]
         dilation = inputs[4]
         ceil_mode = int(inputs[5])
 
-        return _op.nn.max_pool3d(
+        res = _op.nn.max_pool3d(
             data,
             pool_size=pool_size,
             strides=strides,
@@ -1085,6 +1089,7 @@ class PyTorchOpConverter:
             padding=padding,
             ceil_mode=ceil_mode,
         )
+        return res if not need_squeeze else _op.squeeze(res, [0])
 
     def hardtanh(self, inputs, input_types):
         a = inputs[0]

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -906,13 +906,17 @@ def test_forward_maxpool1d():
 def test_forward_maxpool3d():
     """test_forward_maxpool3d"""
     torch.set_grad_enabled(False)
-    input_shape = [1, 3, 10, 10, 10]
-    input_data = torch.rand(input_shape).float()
+    for input_shape in [(1, 3, 10, 10, 10), (3, 10, 10, 10)]:
+        input_data = torch.rand(input_shape).float()
 
-    verify_model(torch.nn.MaxPool3d(kernel_size=[1, 1, 1]).eval(), input_data)
-    verify_model(torch.nn.MaxPool3d(kernel_size=[2, 2, 2], dilation=[1, 2, 3]).eval(), input_data)
-    verify_model(torch.nn.MaxPool3d(kernel_size=[10, 10, 10]).eval(), input_data)
-    verify_model(torch.nn.MaxPool3d(kernel_size=[4, 4, 4], padding=2, stride=2).eval(), input_data)
+        verify_model(torch.nn.MaxPool3d(kernel_size=[1, 1, 1]).eval(), input_data)
+        verify_model(
+            torch.nn.MaxPool3d(kernel_size=[2, 2, 2], dilation=[1, 2, 3]).eval(), input_data
+        )
+        verify_model(torch.nn.MaxPool3d(kernel_size=[10, 10, 10]).eval(), input_data)
+        verify_model(
+            torch.nn.MaxPool3d(kernel_size=[4, 4, 4], padding=2, stride=2).eval(), input_data
+        )
 
     # A functional variant (default strides = None case)
     class MaxPool3D(Module):


### PR DESCRIPTION
According to the pytorch doc [torch.nn.MaxPool3d](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool3d.html?highlight=pool3d#torch.nn.MaxPool3d). The shape of input can be `(N,C,D,H,W) or (C,D,H,W)`. While the MaxPool3DAttrs  thinks the dimension should be 5. When importing a model contains MaxPool3d with shape (C,D,H,W)`,

https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/include/tvm/relay/attrs/nn.h#L985-L996

which could leads to out of bound error `Check failed: (0 <= i && i < p->size_) is false: IndexError: indexing 4 on an array of size 4` when `ii == 4 and dshape == 4`.
https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/src/relay/op/nn/pooling.cc#L1211-L1216

Therefore, I simply add an expand_dims op on the frontend to avoid this situation.
