### PR TITLE
[TIR] Expose TVM Backend API-related Builtins and Misc

### DIFF
--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -51,6 +51,7 @@ from .op import call_llvm_intrin, call_llvm_pure_intrin, ret, all, any, min_valu
 from .op import tvm_stack_alloca, tvm_stack_make_shape, tvm_stack_make_array
 from .op import tvm_tuple, tvm_struct_get, tvm_struct_set
 from .op import address_of, lookup_param, assume, undef
+from .op import tvm_thread_allreduce, type_annotation, tvm_access_ptr, tvm_throw_last_error
 from .op import infinity, reinterpret
 from .op import exp, exp2, exp10, log, log2, log10, log1p, ldexp, clz
 from .op import sin, sinh, asin, asinh
@@ -62,6 +63,7 @@ from .op import likely, isnan, isnullptr, isfinite, isinf, copysign
 from .op import div, indexdiv, indexmod, truncdiv, truncmod, floordiv, floormod, ceildiv
 from .op import comm_reducer, min, max, sum
 from .op import q_multiply_shift
+from .op import TVMBackendAllocWorkspace, TVMBackendFreeWorkspace
 
 from .schedule import StmtSRef, BlockScope, ScheduleState, Schedule, ScheduleError
 

--- a/tests/python/unittest/test_tir_op_types.py
+++ b/tests/python/unittest/test_tir_op_types.py
@@ -79,6 +79,42 @@ def test_tir_op_call_likely():
     assert expr.op.name == "tir.likely"
 
 
+def test_tir_op_tvm_thread_allreduce():
+    x = tir.Var("x", "int32")
+    buffer = tir.decl_buffer((128), "float32")
+    y = tir.Var("y", "handle")
+    z = tir.Var("z", "int32")
+    expr = tir.tvm_thread_allreduce(x, buffer[0], True, y, z)
+    assert expr.op.name == "tir.tvm_thread_allreduce"
+
+
+def test_tir_op_type_annotation():
+    expr = tir.type_annotation("int32")
+    assert expr.op.name == "tir.type_annotation"
+
+
+def test_tir_op_tvm_access_ptr():
+    buffer = tir.decl_buffer((128), "float32")
+    expr = tir.tvm_access_ptr("float32", buffer.data, 0, 1, 2)
+    assert expr.op.name == "tir.tvm_access_ptr"
+
+
+def test_tir_op_tvm_throw_last_error():
+    expr = tir.tvm_throw_last_error()
+    assert expr.op.name == "tir.tvm_throw_last_error"
+
+
+def test_tir_op_TVMBackendAllocWorkspace():
+    expr = tir.TVMBackendAllocWorkspace(0, 1, 2, 3, 4)
+    assert expr.op.name == "tir.TVMBackendAllocWorkspace"
+
+
+def test_tir_op_TVMBackendFreeWorkspace():
+    buffer = tir.decl_buffer((128), "float32")
+    expr = tir.TVMBackendFreeWorkspace(0, 1, buffer.data)
+    assert expr.op.name == "tir.TVMBackendFreeWorkspace"
+
+
 if __name__ == "__main__":
     test_tir_op_tvm_tuple()
     test_tir_op_tvm_struct_get()
@@ -90,3 +126,9 @@ if __name__ == "__main__":
     test_tir_op_call_assume()
     test_tir_op_call_undef()
     test_tir_op_call_likely()
+    test_tir_op_tvm_thread_allreduce()
+    test_tir_op_type_annotation()
+    test_tir_op_tvm_access_ptr()
+    test_tir_op_tvm_throw_last_error()
+    test_tir_op_TVMBackendAllocWorkspace()
+    test_tir_op_TVMBackendFreeWorkspace()


### PR DESCRIPTION
This PR exposes the following TIR operation in python:

`tvm_thread_allreduce`: tested [here](https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/tests/python/unittest/test_tvmscript_type.py#L135)
`type_annotation`: tested [here](https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/tests/python/unittest/test_tvmscript_roundtrip.py#L718)
`tvm_access_ptr`: tested [here](https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/tests/python/unittest/test_tvmscript_roundtrip.py#L717)
`tvm_throw_last_error`: tested [here](https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/tests/python/unittest/test_tvmscript_roundtrip.py#L343)
`TVMBackendAllocWorkspace`: tested [here](https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/tests/python/unittest/test_tvmscript_roundtrip.py#L340)
`TVMBackendAllocWorkspace`: tested [here](https://github.com/apache/tvm/blob/bcc7cde95c1e84b85f18c07110489350865b8cfe/tests/python/unittest/test_tvmscript_roundtrip.py#L465)

Co-Authored-By: yongwww <yongcale@gmail.com>

cc @junrushao1994