### PR TITLE
[HEXAGON][TOPI] This PR adjusts schedules so >64 length vector loads/…

### DIFF
--- a/python/tvm/topi/hexagon/slice_ops/cast.py
+++ b/python/tvm/topi/hexagon/slice_ops/cast.py
@@ -68,9 +68,10 @@ def cast_f16_f32_stir_schedule_nc(func, in_layout, out_layout, c_split_factor):
     block_name = "CastF16F32"
     _, c_orig = sch.get_loops(sch.get_block(block_name))
     _, c_inner = sch.split(c_orig, [None, c_split_factor])
+    _, c_inner_inner = sch.split(c_inner, [None, 64])
     sch.transform_layout(block_name, "A", in_layout)
     sch.transform_layout(block_name, block_name, out_layout)
-    sch.vectorize(c_inner)
+    sch.vectorize(c_inner_inner)
     return sch
 
 
@@ -122,9 +123,10 @@ def cast_f32_f16_stir_schedule_nc(func, in_layout, out_layout, c_split_factor):
     block_name = "CastF32F16"
     _, c_orig = sch.get_loops(sch.get_block(block_name))
     _, c_inner = sch.split(c_orig, [None, c_split_factor])
+    _, c_inner_inner = sch.split(c_inner, [None, 64])
     sch.transform_layout(block_name, "A", in_layout)
     sch.transform_layout(block_name, block_name, out_layout)
-    sch.vectorize(c_inner)
+    sch.vectorize(c_inner_inner)
     return sch
 
 

--- a/tests/python/contrib/test_hexagon/topi/test_cast_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_cast_slice.py
@@ -75,7 +75,7 @@ class TestCastF16F32Slice2d:
         """
         if hexagon_session._launcher._serial_number != "simulator":
             pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
-        target_hexagon = tvm.target.hexagon("v68")
+        target_hexagon = tvm.target.hexagon("v69")
         target = tvm.target.Target(target_hexagon, host=target_hexagon)
         cast_input = te.placeholder(input_shape, name="A", dtype=dtype)
         cast_output = sl.cast_f16_f32_compute(cast_input)
@@ -161,7 +161,7 @@ class TestCastF32F16Slice2d:
         if hexagon_session._launcher._serial_number != "simulator":
             pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
 
-        target_hexagon = tvm.target.hexagon("v68")
+        target_hexagon = tvm.target.hexagon("v69")
         target = tvm.target.Target(target_hexagon, host=target_hexagon)
         cast_input = te.placeholder(input_shape, name="A", dtype=dtype)
         cast_output = sl.cast_f32_f16_compute(cast_input)


### PR DESCRIPTION
…stores are not generated at LLVM level. This is a workaround for an instruction selection issue in current version of llvm for hexagon

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.


cc @mehrdadh