### PR TITLE
[Target] Only append default keys if target doesn't have any yet

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -531,7 +531,7 @@ def arm_cpu(model="unknown", options=None):
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 
-    opts = ["-device=arm_cpu"] + pre_defined_opt
+    opts = ["-keys=arm_cpu,cpu"] + pre_defined_opt
     opts = _merge_opts(opts, options)
     return Target(" ".join(["llvm"] + opts))
 
@@ -612,7 +612,7 @@ def riscv_cpu(model="sifive-u54", options=None):
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 
-    opts = ["-device=arm_cpu"] + pre_defined_opt
+    opts = ["-keys=arm_cpu,cpu"] + pre_defined_opt
     opts = _merge_opts(opts, options)
     return Target(" ".join(["llvm"] + opts))
 
@@ -756,22 +756,22 @@ def hexagon(cpu_ver="v66", **kwargs):
 
 STM32_SUPPORTED_SERIES = {
     # High-Performance
-    "stm32H7xx": ["-device=arm_cpu", "-mcpu=cortex-m7", "-march=armv7e-m"],
-    "stm32F7xx": ["-device=arm_cpu", "-mcpu=cortex-m7"],
-    "stm32F4xx": ["-device=arm_cpu", "-mcpu=cortex-m4"],
-    "stm32F2xx": ["-device=arm_cpu", "-mcpu=cortex-m3"],
+    "stm32H7xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m7", "-march=armv7e-m"],
+    "stm32F7xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m7"],
+    "stm32F4xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
+    "stm32F2xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m3"],
     # Mainstream
-    "stm32G0xx": ["-device=arm_cpu", "-mcpu=cortex-m0+"],
-    "stm32F0xx": ["-device=arm_cpu", "-mcpu=cortex-m0"],
-    "stm32F1xx": ["-device=arm_cpu", "-mcpu=cortex-m3"],
-    "stm32G4xx": ["-device=arm_cpu", "-mcpu=cortex-m4"],
-    "stm32F3xx": ["-device=arm_cpu", "-mcpu=cortex-m4"],
+    "stm32G0xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m0+"],
+    "stm32F0xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m0"],
+    "stm32F1xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m3"],
+    "stm32G4xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
+    "stm32F3xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
     # Low-power
-    "stm32U5xx": ["-device=arm_cpu", "-mcpu=cortex-m33"],
-    "stm32L5xx": ["-device=arm_cpu", "-mcpu=cortex-m33"],
-    "stm32L4xx": ["-device=arm_cpu", "-mcpu=cortex-m4"],
-    "stm32L1xx": ["-device=arm_cpu", "-mcpu=cortex-m3"],
-    "stm32L0xx": ["-device=arm_cpu", "-mcpu=cortex-m0+"],
+    "stm32U5xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m33"],
+    "stm32L5xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m33"],
+    "stm32L4xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
+    "stm32L1xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m3"],
+    "stm32L0xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m0+"],
 }
 
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -531,7 +531,7 @@ def arm_cpu(model="unknown", options=None):
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 
-    opts = ["-keys=arm_cpu,cpu"] + pre_defined_opt
+    opts = ["-keys=arm_cpu,cpu", "-device=arm_cpu"] + pre_defined_opt
     opts = _merge_opts(opts, options)
     return Target(" ".join(["llvm"] + opts))
 
@@ -612,7 +612,7 @@ def riscv_cpu(model="sifive-u54", options=None):
     }
     pre_defined_opt = trans_table.get(model, ["-model=%s" % model])
 
-    opts = ["-keys=arm_cpu,cpu"] + pre_defined_opt
+    opts = ["-keys=arm_cpu,cpu", "-device=arm_cpu"] + pre_defined_opt
     opts = _merge_opts(opts, options)
     return Target(" ".join(["llvm"] + opts))
 
@@ -756,22 +756,22 @@ def hexagon(cpu_ver="v66", **kwargs):
 
 STM32_SUPPORTED_SERIES = {
     # High-Performance
-    "stm32H7xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m7", "-march=armv7e-m"],
-    "stm32F7xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m7"],
-    "stm32F4xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
-    "stm32F2xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m3"],
+    "stm32H7xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m7", "-march=armv7e-m"],
+    "stm32F7xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m7"],
+    "stm32F4xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m4"],
+    "stm32F2xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m3"],
     # Mainstream
-    "stm32G0xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m0+"],
-    "stm32F0xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m0"],
-    "stm32F1xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m3"],
-    "stm32G4xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
-    "stm32F3xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
+    "stm32G0xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m0+"],
+    "stm32F0xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m0"],
+    "stm32F1xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m3"],
+    "stm32G4xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m4"],
+    "stm32F3xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m4"],
     # Low-power
-    "stm32U5xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m33"],
-    "stm32L5xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m33"],
-    "stm32L4xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m4"],
-    "stm32L1xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m3"],
-    "stm32L0xx": ["-keys=arm_cpu,cpu", "-mcpu=cortex-m0+"],
+    "stm32U5xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m33"],
+    "stm32L5xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m33"],
+    "stm32L4xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m4"],
+    "stm32L1xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m3"],
+    "stm32L0xx": ["-keys=arm_cpu,cpu", "-device=arm_cpu", "-mcpu=cortex-m0+"],
 }
 
 

--- a/src/target/parsers/mprofile.cc
+++ b/src/target/parsers/mprofile.cc
@@ -105,15 +105,17 @@ static TargetFeatures GetFeatures(TargetJSON target) {
 }
 
 static Array<String> MergeKeys(Optional<Array<String>> existing_keys) {
-  const String kExtraKey = "arm_cpu";
+  const Array<String> kExtraKeys = {"arm_cpu", "cpu"};
 
   if (!existing_keys) {
-    return {kExtraKey};
+    return kExtraKeys;
   }
 
   Array<String> keys = existing_keys.value();
-  if (std::find(keys.begin(), keys.end(), kExtraKey) == keys.end()) {
-    keys.push_back(kExtraKey);
+  for (String key : kExtraKeys) {
+    if (std::find(keys.begin(), keys.end(), key) == keys.end()) {
+      keys.push_back(key);
+    }
   }
   return keys;
 }

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -885,7 +885,8 @@ ObjectPtr<Object> TargetInternal::FromConfig(Map<String, ObjectRef> config) {
   // parse "keys"
   {
     std::vector<String> keys;
-    if (config.count(kKeys)) {
+    bool has_user_keys = config.count(kKeys);
+    if (has_user_keys) {
       // user provided keys
       if (const auto* cfg_keys = config[kKeys].as<ArrayNode>()) {
         for (const ObjectRef& e : *cfg_keys) {
@@ -909,9 +910,11 @@ ObjectPtr<Object> TargetInternal::FromConfig(Map<String, ObjectRef> config) {
         keys.push_back(GetRef<String>(device));
       }
     }
-    // add default keys
-    for (const auto& key : target->kind->default_keys) {
-      keys.push_back(key);
+    if (!has_user_keys) {
+      // add default keys
+      for (const auto& key : target->kind->default_keys) {
+        keys.push_back(key);
+      }
     }
     // de-duplicate keys
     target->keys = DeduplicateKeys(keys);

--- a/tests/cpp/target/parsers/mprofile_test.cc
+++ b/tests/cpp/target/parsers/mprofile_test.cc
@@ -69,8 +69,9 @@ TEST(MProfileParser, ParseTarget) {
   TargetJSON target = ParseTarget({});
   TargetFeatures features = Downcast<TargetFeatures>(target.at("features"));
   Array<String> keys = Downcast<Array<String>>(target.at("keys"));
-  ASSERT_EQ(keys.size(), 1);
+  ASSERT_EQ(keys.size(), 2);
   ASSERT_EQ(keys[0], "arm_cpu");
+  ASSERT_EQ(keys[1], "cpu");
 
   ASSERT_EQ(Downcast<Bool>(features.at("has_mve")), false);
   ASSERT_EQ(Downcast<Bool>(features.at("has_dsp")), false);

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -170,9 +170,8 @@ TEST(TargetCreationFail, TargetKindNotFound) {
 TEST(TargetCreation, TargetParser) {
   Target test_target("TestTargetParser -mcpu=woof");
   ASSERT_EQ(test_target->GetAttr<String>("mcpu").value(), "super_woof");
-  ASSERT_EQ(test_target->keys.size(), 2);
+  ASSERT_EQ(test_target->keys.size(), 1);
   ASSERT_EQ(test_target->keys[0], "super");
-  ASSERT_EQ(test_target->keys[1], "cpu");
 }
 
 TEST(TargetCreation, TargetFeatures) {


### PR DESCRIPTION
This allows target parsers to provide their own target keys. Without this change, the default keys would always be appended, which may or may not be desirable.