### PR TITLE
[docs] Add instructions for uploading CI resources to S3

### DIFF
--- a/docs/contribute/code_guide.rst
+++ b/docs/contribute/code_guide.rst
@@ -148,12 +148,14 @@ server can go down or be slow), so try to avoid using the network at all during 
 this isn't a reasonable proposition (e.g. the docs tutorials which need to download models).
 
 In these cases you can re-host files in S3 for fast access in CI. A committer can upload a file,
-specified by a name, hash, and path in S3, using the `workflow_dispatch` event on `the
+specified by a name, hash, and path in S3, using the ``workflow_dispatch`` event on `the
 upload_ci_resource.yml GitHub Actions workflow
 <https://github.com/apache/tvm/actions/workflows/upload_ci_resource.yml>`_.  The sha256 must match
 the file or it will not be uploaded. The upload path is user-defined so it can be any path (no
 trailing or leading slashes allowed) but be careful not to collide with existing resources on
-accident.
+accident. Once uploaded you should send a PR to update the ``URL_MAP`` in
+`request_hook.py <https://github.com/apache/tvm/blob/main/tests/scripts/request_hook/request_hook.py>`_
+with the new URL.
 
 
 Handle Integer Constant Expression


### PR DESCRIPTION
These were missing the final step to use the uploaded resources.
