### PR TITLE
[TIR] Disallow vectorization with strides in VerifyGPUCode

### DIFF
--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -1004,6 +1004,7 @@ void CodeGenCUDA::VisitStmt_(const EvaluateNode* op) {
 }
 
 void CodeGenCUDA::VisitExpr_(const RampNode* op, std::ostream& os) {
+  CHECK_LE(op->lanes, 4) << "ValueError: Ramp of more than 4 lanes is not allowed.";
   os << "(make_int" << op->lanes << "(";
   for (int i = 0; i < op->lanes; i++) {
     os << "(" << PrintExpr(op->base) << ")"

--- a/tests/python/unittest/test_tir_analysis_verify_gpu_code.py
+++ b/tests/python/unittest/test_tir_analysis_verify_gpu_code.py
@@ -373,6 +373,33 @@ def test_vectorize_half():
 
 
 @tvm.testing.requires_gpu
+def test_vectorize_strided():
+    N = 1024
+
+    A = te.placeholder((N, N), name="A", dtype="float16")
+    B = te.compute((N, N), lambda i, j: A[j, i])
+
+    s = te.create_schedule([B.op])
+
+    i, j = s[B].op.axis
+
+    s[B].bind(i, te.thread_axis("blockIdx.x"))
+    jo, ji = s[B].split(j, factor=8)
+    s[B].vectorize(ji)
+
+    for target in ["opencl", "cuda"]:
+        if not tvm.testing.device_enabled(target):
+            continue
+
+        valid = [None]
+        with tvm.transform.PassContext(
+            config={"tir.add_lower_pass": [(2, get_verify_pass(valid, max_vector_bytes=16))]}
+        ):
+            tvm.lower(s, [A, B])
+        assert not valid[0]
+
+
+@tvm.testing.requires_gpu
 def test_vthread():
     N = 1024
 
@@ -432,12 +459,4 @@ def test_redundant_kernels():
 
 
 if __name__ == "__main__":
-    test_local_memory()
-    test_shared_memory()
-    test_num_thread()
-    test_multiple_kernels()
-    test_wrong_bind()
-    test_vectorize()
-    test_vectorize_half()
-    test_vthread()
-    test_redundant_kernels()
+    tvm.testing.main()


### PR DESCRIPTION
There are some cases invalid `make_int8` is generated by CUDA codegen. There are `make_int8` API in CUDA. Updated `VerifyGPUCode` to check such case and also throw error when vector size is too large during codegen.

cc @junrushao1994 @masahi @spectrometerHBH @Kathryn-cat 