### PR TITLE
[micro] Fix pytest fixture

### DIFF
--- a/python/tvm/micro/testing/pytest_plugin.py
+++ b/python/tvm/micro/testing/pytest_plugin.py
@@ -44,6 +44,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--test-build-only",
         action="store_true",
+        default=False,
         help="Only run tests that don't require physical hardware.",
     )
     parser.addoption(


### PR DESCRIPTION
Add default value for `--test-build-only` pytest fixture.

cc @areusch 