### PR TITLE
[ci][tvmbot] Search more users when checking usernames

### DIFF
--- a/tests/scripts/github_tvmbot.py
+++ b/tests/scripts/github_tvmbot.py
@@ -49,7 +49,7 @@ def to_json_str(obj: Any) -> str:
 COLLABORATORS_QUERY = """
 query ($owner: String!, $name: String!, $user: String!) {
   repository(owner: $owner, name: $name) {
-    collaborators(query: $user, first: 1) {
+    collaborators(query: $user, first: 100) {
       nodes {
         login
       }
@@ -61,7 +61,7 @@ query ($owner: String!, $name: String!, $user: String!) {
 MENTIONABLE_QUERY = """
 query ($owner: String!, $name: String!, $user: String!) {
   repository(owner: $owner, name: $name) {
-    mentionableUsers(query: $user, first: 1) {
+    mentionableUsers(query: $user, first: 100) {
       nodes {
         login
       }


### PR DESCRIPTION
To figure out a user's association with the repo this code before
searched the associations in the repo filtered by the relevant username.
GitHub doesn't return the exact match only though, so we have to instead
collect many results and search through all of them to avoid issues like in
https://github.com/apache/tvm/pull/12397#issuecomment-1219214243

cc @Mousius @areusch @gigiblender