### PR TITLE
[microTVM] add the option to open a saved micro project for debugging

### DIFF
--- a/python/tvm/micro/build.py
+++ b/python/tvm/micro/build.py
@@ -20,7 +20,6 @@
 import json
 import logging
 import os
-import pathlib
 import contextlib
 import enum
 
@@ -115,7 +114,7 @@ class AutoTvmModuleLoader:
 
     Parameters
     ----------
-    template_project_dir : Union[pathlib.Path, str]
+    template_project_dir : Union[os.PathLike, str]
         project template path
 
     project_options : dict
@@ -131,20 +130,20 @@ class AutoTvmModuleLoader:
 
     def __init__(
         self,
-        template_project_dir: Union[pathlib.Path, str],
+        template_project_dir: Union[os.PathLike, str],
         project_options: dict = None,
-        project_dir: Union[pathlib.Path, str] = None,
+        project_dir: Union[os.PathLike, str] = None,
         use_existing: bool = False,
     ):
         self._project_options = project_options
         self._use_existing = use_existing
 
-        if isinstance(template_project_dir, (pathlib.Path, str)):
+        if isinstance(template_project_dir, (os.PathLike, str)):
             self._template_project_dir = str(template_project_dir)
         elif not isinstance(template_project_dir, str):
             raise TypeError(f"Incorrect type {type(template_project_dir)}.")
 
-        if isinstance(project_dir, (pathlib.Path, str)):
+        if isinstance(project_dir, (os.PathLike, str)):
             self._project_dir = str(project_dir)
         else:
             self._project_dir = None

--- a/python/tvm/micro/build.py
+++ b/python/tvm/micro/build.py
@@ -120,17 +120,34 @@ class AutoTvmModuleLoader:
 
     project_options : dict
         project generation option
+
+    project_dir: str
+        if use_existing is False: The path to save the generated microTVM Project.
+        if use_existing is True: The path to a generated microTVM Project for debugging.
+
+    use_existing: bool
+        skips the project generation and opens transport to the project at the project_dir address.
     """
 
     def __init__(
-        self, template_project_dir: Union[pathlib.Path, str], project_options: dict = None
+        self,
+        template_project_dir: Union[pathlib.Path, str],
+        project_options: dict = None,
+        project_dir: Union[pathlib.Path, str] = None,
+        use_existing: bool = False,
     ):
         self._project_options = project_options
+        self._use_existing = use_existing
 
         if isinstance(template_project_dir, (pathlib.Path, str)):
             self._template_project_dir = str(template_project_dir)
         elif not isinstance(template_project_dir, str):
             raise TypeError(f"Incorrect type {type(template_project_dir)}.")
+
+        if isinstance(project_dir, (pathlib.Path, str)):
+            self._project_dir = str(project_dir)
+        else:
+            self._project_dir = None
 
     @contextlib.contextmanager
     def __call__(self, remote_kw, build_result):
@@ -147,6 +164,8 @@ class AutoTvmModuleLoader:
                 build_result_bin,
                 self._template_project_dir,
                 json.dumps(self._project_options),
+                self._project_dir,
+                self._use_existing,
             ],
         )
         system_lib = remote.get_function("runtime.SystemLib")()

--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -20,6 +20,7 @@
 import json
 import logging
 import sys
+import os
 import pathlib
 import shutil
 from typing import Union
@@ -261,7 +262,7 @@ def compile_and_create_micro_session(
     mod_src_bytes: bytes,
     template_project_dir: str,
     project_options: dict = None,
-    project_dir: Union[pathlib.Path, str] = None,
+    project_dir: Union[os.PathLike, str] = None,
     use_existing: bool = False,
 ):
     """Compile the given libraries and sources into a MicroBinary, then invoke create_micro_session.
@@ -280,7 +281,7 @@ def compile_and_create_micro_session(
     project_options: dict
         Options for the microTVM API Server contained in template_project_dir.
 
-    project_dir: str
+    project_dir: Union[os.PathLike, str]
         if use_existing is False: The path to save the generated microTVM Project.
         if use_existing is True: The path to a generated microTVM Project for debugging.
 

--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -20,7 +20,9 @@
 import json
 import logging
 import sys
-
+import pathlib
+import shutil
+from typing import Union
 from ..error import register_error
 from .._ffi import get_global_func, register_func
 from ..contrib import graph_executor
@@ -259,6 +261,8 @@ def compile_and_create_micro_session(
     mod_src_bytes: bytes,
     template_project_dir: str,
     project_options: dict = None,
+    project_dir: Union[pathlib.Path, str] = None,
+    use_existing: bool = False,
 ):
     """Compile the given libraries and sources into a MicroBinary, then invoke create_micro_session.
 
@@ -275,25 +279,44 @@ def compile_and_create_micro_session(
 
     project_options: dict
         Options for the microTVM API Server contained in template_project_dir.
+
+    project_dir: str
+        if use_existing is False: The path to save the generated microTVM Project.
+        if use_existing is True: The path to a generated microTVM Project for debugging.
+
+    use_existing: bool
+        skips the project generation and opens transport to the project at the project_dir address.
     """
 
-    temp_dir = utils.tempdir()
-    # Keep temp directory for generate project
-    temp_dir.set_keep_for_debug(True)
-    model_library_format_path = temp_dir / "model.tar.gz"
-    with open(model_library_format_path, "wb") as mlf_f:
-        mlf_f.write(mod_src_bytes)
-
-    try:
-        template_project = project.TemplateProject.from_directory(template_project_dir)
-        generated_project = template_project.generate_project_from_mlf(
-            model_library_format_path,
-            str(temp_dir / "generated-project"),
+    if use_existing:
+        project_dir = pathlib.Path(project_dir)
+        assert project_dir.is_dir(), f"{project_dir} does not exist."
+        build_dir = project_dir / "generated-project" / "build"
+        shutil.rmtree(build_dir)
+        generated_project = project.GeneratedProject.from_directory(
+            project_dir / "generated-project",
             options=json.loads(project_options),
         )
-    except Exception as exception:
-        logging.error("Project Generate Error: %s", str(exception))
-        raise exception
+    else:
+        if project_dir:
+            temp_dir = utils.tempdir(custom_path=project_dir, keep_for_debug=True)
+        else:
+            temp_dir = utils.tempdir()
+
+        model_library_format_path = temp_dir / "model.tar.gz"
+        with open(model_library_format_path, "wb") as mlf_f:
+            mlf_f.write(mod_src_bytes)
+
+        try:
+            template_project = project.TemplateProject.from_directory(template_project_dir)
+            generated_project = template_project.generate_project_from_mlf(
+                model_library_format_path,
+                str(temp_dir / "generated-project"),
+                options=json.loads(project_options),
+            )
+        except Exception as exception:
+            logging.error("Project Generate Error: %s", str(exception))
+            raise exception
 
     generated_project.build()
     generated_project.flash()


### PR DESCRIPTION
This PR adds the option to save a generated micro project at a custom path, and to open a saved project and start communicating with it (instead of generating a new one) for debugging.

cc @alanmacd @areusch @gromero @guberti @mehrdadh