### PR TITLE
[Relay][Layout] Add FInferCorrectLayout for L2 norm layout transform.

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -676,7 +676,7 @@ InferCorrectLayoutOutput L2NormalizeInferCorrectLayout(
 
   Layout ret = Layout::Undef();
   if (new_in_layouts.defined() && old_in_layouts.defined()) {
-    for (uint i = 0; i < axis_list.size(); ++i) {
+    for (size_t i = 0; i < axis_list.size(); ++i) {
       const auto& axis_dim = old_in_layouts[0][axis_list[i]];
       auto axis_index = new_in_layouts[0].IndexOf(axis_dim);
       param->axis.Set(i, axis_index);

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -653,10 +653,9 @@ Expr MakeL2Normalize(Expr data, double eps, Array<Integer> axis) {
   return Call(op, {data}, Attrs(attrs), {});
 }
 
-InferCorrectLayoutOutput L2NormalizeInferCorrectLayout(const Attrs& attrs,
-                                                const Array<Layout>& new_in_layouts,
-                                                const Array<Layout>& old_in_layouts,
-                                                const Array<tvm::relay::Type>& old_in_types) {
+InferCorrectLayoutOutput L2NormalizeInferCorrectLayout(
+    const Attrs& attrs, const Array<Layout>& new_in_layouts, const Array<Layout>& old_in_layouts,
+    const Array<tvm::relay::Type>& old_in_types) {
   const auto* attrs_ptr = attrs.as<L2NormalizeAttrs>();
   ICHECK(attrs_ptr);
   ObjectPtr<L2NormalizeAttrs> param = make_object<L2NormalizeAttrs>(*attrs_ptr);

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -667,7 +667,7 @@ InferCorrectLayoutOutput L2NormalizeInferCorrectLayout(const Attrs& attrs,
     old_in_shapes.push_back(old_in_t.as<TensorTypeNode>()->shape);
   }
   std::vector<size_t> axis_list;
-  for(auto i : param->axis) {
+  for (auto i : param->axis) {
     int64_t axis = i->value;
     if (axis < 0) {
       axis = axis + static_cast<size_t>(old_in_shapes[0].size());
@@ -677,7 +677,7 @@ InferCorrectLayoutOutput L2NormalizeInferCorrectLayout(const Attrs& attrs,
 
   Layout ret = Layout::Undef();
   if (new_in_layouts.defined() && old_in_layouts.defined()) {
-    for(uint i = 0; i < axis_list.size(); ++i) {
+    for (uint i = 0; i < axis_list.size(); ++i) {
       const auto& axis_dim = old_in_layouts[0][axis_list[i]];
       auto axis_index = new_in_layouts[0].IndexOf(axis_dim);
       param->axis.Set(i, axis_index);

--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -653,6 +653,43 @@ Expr MakeL2Normalize(Expr data, double eps, Array<Integer> axis) {
   return Call(op, {data}, Attrs(attrs), {});
 }
 
+InferCorrectLayoutOutput L2NormalizeInferCorrectLayout(const Attrs& attrs,
+                                                const Array<Layout>& new_in_layouts,
+                                                const Array<Layout>& old_in_layouts,
+                                                const Array<tvm::relay::Type>& old_in_types) {
+  const auto* attrs_ptr = attrs.as<L2NormalizeAttrs>();
+  ICHECK(attrs_ptr);
+  ObjectPtr<L2NormalizeAttrs> param = make_object<L2NormalizeAttrs>(*attrs_ptr);
+
+  Array<Array<IndexExpr>> old_in_shapes;
+  for (auto old_in_t : old_in_types) {
+    ICHECK(old_in_t.as<TensorTypeNode>());
+    old_in_shapes.push_back(old_in_t.as<TensorTypeNode>()->shape);
+  }
+  std::vector<size_t> axis_list;
+  for(auto i : param->axis) {
+    int64_t axis = i->value;
+    if (axis < 0) {
+      axis = axis + static_cast<size_t>(old_in_shapes[0].size());
+    }
+    axis_list.emplace_back(axis);
+  }
+
+  Layout ret = Layout::Undef();
+  if (new_in_layouts.defined() && old_in_layouts.defined()) {
+    for(uint i = 0; i < axis_list.size(); ++i) {
+      const auto& axis_dim = old_in_layouts[0][axis_list[i]];
+      auto axis_index = new_in_layouts[0].IndexOf(axis_dim);
+      param->axis.Set(i, axis_index);
+    }
+    ret = new_in_layouts[0];
+  } else if (old_in_layouts.defined()) {
+    ret = old_in_layouts[0];
+  }
+
+  return InferCorrectLayoutOutput({ret}, {ret}, Attrs(param));
+}
+
 TVM_REGISTER_GLOBAL("relay.op.nn._make.l2_normalize").set_body_typed(MakeL2Normalize);
 
 RELAY_REGISTER_OP("nn.l2_normalize")
@@ -669,7 +706,7 @@ Normalizes along dimension axis using an L2 norm
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_support_level(2)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", L2NormalizeInferCorrectLayout)
     .add_type_rel("Identity", IdentityRel);
 
 // Dropout

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -2696,59 +2696,45 @@ def test_resnet_convert_layout_nchwc(data_layout, kernel_layout):
     b = run_opt_pass(expected(), transform.InferType())
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a) + "\n Expect = \n" + str(b)
 
+
 def test_conv_l2n_convert_layout():
     """Check that layout transforms are propagated through bn."""
+    axis_list = ([3], [-1], [2, 3])
+    expected_axis = ([1], [1], [3, 1])
+    for i, axis in enumerate(axis_list):
 
-    def before():
-        x = relay.var("x", shape=(1, 56, 56, 64))
-        weight = relay.var("weight", shape=(3, 3, 64, 64))
-        y = relay.nn.conv2d(
-            x,
-            weight,
-            channels=64,
-            kernel_size=(3, 3),
-            padding=(1, 1),
-            data_layout="NHWC",
-            kernel_layout="HWIO",
-        )
-        z = relay.nn.l2_normalize(y, eps=0.001, axis=[3])
-        func = relay.Function(analysis.free_vars(z), z)
-        return func
+        def before():
+            x = relay.var("x", shape=(1, 56, 56, 64))
+            weight = relay.var("weight", shape=(3, 3, 64, 64))
+            y = relay.nn.conv2d(
+                x,
+                weight,
+                channels=64,
+                kernel_size=(3, 3),
+                padding=(1, 1),
+                data_layout="NHWC",
+                kernel_layout="HWIO",
+            )
+            z = relay.nn.l2_normalize(y, eps=0.001, axis=axis)
+            z = relay.Function(analysis.free_vars(z), z)
+            return z
 
-    def before_neg():
-        x = relay.var("x", shape=(1, 56, 56, 64))
-        weight = relay.var("weight", shape=(3, 3, 64, 64))
-        y = relay.nn.conv2d(
-            x,
-            weight,
-            channels=64,
-            kernel_size=(3, 3),
-            padding=(1, 1),
-            data_layout="NHWC",
-            kernel_layout="HWIO",
-        )
-        z = relay.nn.l2_normalize(y, eps=0.001, axis=[-1])
-        func = relay.Function(analysis.free_vars(z), z)
-        return func
-
-    def expected():
-        x = relay.var("x", shape=(1, 56, 56, 64))
-        w = relay.var("weight", shape=(3, 3, 64, 64))
-        x = relay.layout_transform(x, "NHWC", "NCHW")
-        w = relay.layout_transform(w, "HWIO", "OIHW")
-        y = relay.nn.conv2d(x, w, channels=64, kernel_size=(3, 3), padding=(1, 1))
-        z = relay.nn.l2_normalize(y, eps=0.001, axis=[1])
-        z = relay.layout_transform(z, "NCHW", "NHWC")
-        func = relay.Function(analysis.free_vars(z), z)
-        return func
+        def expected():
+            x = relay.var("x", shape=(1, 56, 56, 64))
+            w = relay.var("weight", shape=(3, 3, 64, 64))
+            x = relay.layout_transform(x, "NHWC", "NCHW")
+            w = relay.layout_transform(w, "HWIO", "OIHW")
+            y = relay.nn.conv2d(x, w, channels=64, kernel_size=(3, 3), padding=(1, 1))
+            z = relay.nn.l2_normalize(y, eps=0.001, axis=expected_axis[i])
+            z = relay.layout_transform(z, "NCHW", "NHWC")
+            z = relay.Function(analysis.free_vars(z), z)
+            return z
 
     a = before()
-    a_neg = before_neg()
     a = run_opt_pass(a, transform.ConvertLayout({"nn.conv2d": ["NCHW", "default"]}))
-    a_neg = run_opt_pass(a_neg, transform.ConvertLayout({"nn.conv2d": ["NCHW", "default"]}))
     b = run_opt_pass(expected(), transform.InferType())
     assert tvm.ir.structural_equal(a, b), "Actual = \n" + str(a) + "\n\n Expected = \n" + str(b)
-    assert tvm.ir.structural_equal(a_neg, b), "Actual = \n" + str(a) + "\n\n Expected = \n" + str(b)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
The `FInferCorrectLayout` was set to `ElemwiseArbitraryLayout` which is for layout agnostic operators. While L2norm is a lightly-layout sensitive operator with `attrs-axis`. Refered to [Convert Layout Pass](https://tvm.apache.org/docs/arch/convert_layout.html?highlight=pass).
https://github.com/apache/tvm/blob/72b0f5ee34be6acfadf7afc61264eef42b78c789/src/relay/op/nn/nn.cc#L672
When running model, I met a situation:
`%0 = layout_transform(%x, src_layout="NHWC", dst_layout="NCHW") /* ty=Tensor[(1, 64, 56, 56), float32] */;`
`%1 = layout_transform(%weight, src_layout="HWIO", dst_layout="OIHW") /* ty=Tensor[(64, 64, 3, 3), float32] */;`
`%2 = nn.conv2d(%0, %1, padding=[1, 1, 1, 1], channels=64, kernel_size=[3, 3]) /* ty=Tensor[(1, 64, 56, 56), float32] */;`
`%3 = nn.l2_normalize(%2, eps=0.001f, axis=[3]) /* ty=Tensor[(1, 64, 56, 56), float32] */;`

The nn.l2_normalize 's axis didn't change during `InferCorrectLayout`. So i write a `L2NormalizeInferCorrectLayout` for it.
Also, add some tests.

BTW! I'm still new to cpp, please advise if there is anything inappropriate in code. Thanks!
Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
