### PR TITLE
[Relay] Fix bug in resize2d unittest func name

### DIFF
--- a/tests/python/relay/dyn/test_dynamic_op_level5.py
+++ b/tests/python/relay/dyn/test_dynamic_op_level5.py
@@ -77,5 +77,5 @@ def test_resize2d(executor_kind):
 
 
 if __name__ == "__main__":
-    test_resize_infer_type()
-    test_resize()
+    test_resize2d_infer_type()
+    test_resize2d()


### PR DESCRIPTION
hi, In the main function,  `resize2d` case name is wrong
Fix  resize2d  case name, replace `resize` to `resize2d`,
cc  @masahi @gaurav1086 