### PR TITLE
[Hexagon] Expose gtest output through runtime exception

### DIFF
--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -40,6 +40,8 @@ class HexagonThreadManagerTest : public ::testing::Test {
   const unsigned stack_size{0x4000};  // 16KB
 };
 
+TEST_F(HexagonThreadManagerTest, force_fail) { ASSERT_EQ(42, 43); }
+
 TEST_F(HexagonThreadManagerTest, ctor_errors) {
   // zero threads
   ASSERT_THROW(HexagonThreadManager(0, stack_size, pipe_size), InternalError);

--- a/tests/python/contrib/test_hexagon/test_run_unit_tests.py
+++ b/tests/python/contrib/test_hexagon/test_run_unit_tests.py
@@ -45,5 +45,5 @@ def test_run_unit_tests(hexagon_session: Session, gtest_args):
     gtest_error_code_and_output = func(gtest_args)
     gtest_error_code = int(gtest_error_code_and_output.splitlines()[0])
     gtest_output = gtest_error_code_and_output.split("\n", 1)[-1]
-    print(gtest_output)
-    np.testing.assert_equal(gtest_error_code, 0)
+    if gtest_error_code != 0:
+        raise RuntimeError(f"{gtest_error_code} != 0:\n{gtest_output}")


### PR DESCRIPTION
Expose Hexagon gtest output in CI by raising it as a runtime exception rather than printing it to stdout.