### PR TITLE
[TIR][Schedule] Support for specific consumer block targeting in cache_read

### DIFF
--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -398,6 +398,7 @@ class ScheduleNode : public runtime::Object {
    * \param block_rv The producer of the buffer
    * \param write_buffer_index The index of the buffer in block's write region
    * \param storage_scope The target storage scope
+   * \param consumer_blocks An optional list of consumers of the cache to rewrite.
    * \return The cache stage block.
    */
   virtual BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -389,7 +389,8 @@ class ScheduleNode : public runtime::Object {
    * \return The cache stage block.
    */
   virtual BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                            const String& storage_scope, const Array<BlockRV> consumer_blocks = {}) = 0;
+                            const String& storage_scope,
+                            const Array<BlockRV> consumer_blocks = {}) = 0;
   /*!
    * \brief Create a block that writes a buffer region into a write cache. It requires:
    * 1) There is only one block who writes the target buffer.

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -386,6 +386,7 @@ class ScheduleNode : public runtime::Object {
    * \param block_rv The consumer block of the target buffer.
    * \param read_buffer_index The index of the buffer in block's read region.
    * \param storage_scope The target storage scope.
+   * \param consumer_blocks An optional list of consumers of the cache to rewrite.
    * \return The cache stage block.
    */
   virtual BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
@@ -398,7 +399,6 @@ class ScheduleNode : public runtime::Object {
    * \param block_rv The producer of the buffer
    * \param write_buffer_index The index of the buffer in block's write region
    * \param storage_scope The target storage scope
-   * \param consumer_blocks An optional list of consumers of the cache to rewrite.
    * \return The cache stage block.
    */
   virtual BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -389,7 +389,7 @@ class ScheduleNode : public runtime::Object {
    * \return The cache stage block.
    */
   virtual BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                            const String& storage_scope) = 0;
+                            const String& storage_scope, const Array<BlockRV> consumer_blocks = {}) = 0;
   /*!
    * \brief Create a block that writes a buffer region into a write cache. It requires:
    * 1) There is only one block who writes the target buffer.

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1016,7 +1016,7 @@ class Schedule(Object):
         block: Union[BlockRV, str],
         read_buffer_index: int,
         storage_scope: str,
-        consumer_blocks: Optional[Union[BlockRV, List[Union[BlockRV, str]]]] = None,
+        consumer_blocks: Optional[List[Union[BlockRV, str]]] = None,
     ) -> BlockRV:
         """Create a block that reads a buffer region into a read cache. It requires:
 
@@ -1035,7 +1035,7 @@ class Schedule(Object):
         storage_scope: str
             The target storage scope.
 
-        consumer_blocks: Optional[Union[BlockRV, List[Union[BlockRV, str]]]]
+        consumer_blocks: Optional[List[Union[BlockRV, str]]]
             An optional list of consumers that should read from the cache. If not specified,
             all consumers will use the cache.
 
@@ -1089,8 +1089,6 @@ class Schedule(Object):
         """
         if consumer_blocks is None:
             consumer_blocks = []
-        if isinstance(consumer_blocks, BlockRV):
-            consumer_blocks = [consumer_blocks]
 
         # Convert any string block names into Block RVs.
         consumer_blocks = [self._normalize_block_arg(b) for b in consumer_blocks]

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1012,7 +1012,7 @@ class Schedule(Object):
 
     @type_checked
     def cache_read(
-        self, block: Union[BlockRV, str], read_buffer_index: int, storage_scope: str
+        self, block: Union[BlockRV, str], read_buffer_index: int, storage_scope: str, consumer_blocks: Optional[List[BlockRV]] = None 
     ) -> BlockRV:
         """Create a block that reads a buffer region into a read cache. It requires:
 
@@ -1030,6 +1030,10 @@ class Schedule(Object):
 
         storage_scope: str
             The target storage scope.
+
+        consumer_blocks: Optional[List[BlockRV]]
+            An optional list of consumers that should read from the cache. If not specified,
+            all consumers will use the cache.
 
         Returns
         -------
@@ -1079,9 +1083,14 @@ class Schedule(Object):
                         B[vi, vj] = A_local[vi, vj] * 2.0
 
         """
+        if consumer_blocks is None:
+            consumer_blocks = []
+        if isinstance(consumer_blocks, BlockRV):
+            consumer_blocks = [consumer_blocks]
+
         block = self._normalize_block_arg(block)
         return _ffi_api.ScheduleCacheRead(  # type: ignore # pylint: disable=no-member
-            self, block, read_buffer_index, storage_scope
+            self, block, read_buffer_index, storage_scope, consumer_blocks
         )
 
     @type_checked

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1012,7 +1012,11 @@ class Schedule(Object):
 
     @type_checked
     def cache_read(
-        self, block: Union[BlockRV, str], read_buffer_index: int, storage_scope: str, consumer_blocks: Optional[List[Union[BlockRV, str]]] = None 
+        self,
+        block: Union[BlockRV, str],
+        read_buffer_index: int,
+        storage_scope: str,
+        consumer_blocks: Optional[List[Union[BlockRV, str]]] = None,
     ) -> BlockRV:
         """Create a block that reads a buffer region into a read cache. It requires:
 

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1012,7 +1012,7 @@ class Schedule(Object):
 
     @type_checked
     def cache_read(
-        self, block: Union[BlockRV, str], read_buffer_index: int, storage_scope: str, consumer_blocks: Optional[List[BlockRV]] = None 
+        self, block: Union[BlockRV, str], read_buffer_index: int, storage_scope: str, consumer_blocks: Optional[List[Union[BlockRV, str]]] = None 
     ) -> BlockRV:
         """Create a block that reads a buffer region into a read cache. It requires:
 
@@ -1031,7 +1031,7 @@ class Schedule(Object):
         storage_scope: str
             The target storage scope.
 
-        consumer_blocks: Optional[List[BlockRV]]
+        consumer_blocks: Optional[List[Union[BlockRV, str]]]
             An optional list of consumers that should read from the cache. If not specified,
             all consumers will use the cache.
 
@@ -1088,6 +1088,8 @@ class Schedule(Object):
         if isinstance(consumer_blocks, BlockRV):
             consumer_blocks = [consumer_blocks]
 
+        # Convert any string block names into Block RVs.
+        consumer_blocks = [self._normalize_block_arg(b) for b in consumer_blocks]
         block = self._normalize_block_arg(block)
         return _ffi_api.ScheduleCacheRead(  # type: ignore # pylint: disable=no-member
             self, block, read_buffer_index, storage_scope, consumer_blocks

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1016,7 +1016,7 @@ class Schedule(Object):
         block: Union[BlockRV, str],
         read_buffer_index: int,
         storage_scope: str,
-        consumer_blocks: Optional[List[Union[BlockRV, str]]] = None,
+        consumer_blocks: Optional[Union[BlockRV, List[Union[BlockRV, str]]]] = None,
     ) -> BlockRV:
         """Create a block that reads a buffer region into a read cache. It requires:
 
@@ -1035,7 +1035,7 @@ class Schedule(Object):
         storage_scope: str
             The target storage scope.
 
-        consumer_blocks: Optional[List[Union[BlockRV, str]]]
+        consumer_blocks: Optional[Union[BlockRV, List[Union[BlockRV, str]]]]
             An optional list of consumers that should read from the cache. If not specified,
             all consumers will use the cache.
 

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -535,7 +535,8 @@ void ConcreteScheduleNode::Unroll(const LoopRV& loop_rv) {
 /******** Schedule: Insert cache stages ********/
 
 BlockRV ConcreteScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                                        const String& storage_scope, const Array<BlockRV> consumer_blocks) {
+                                        const String& storage_scope,
+                                        const Array<BlockRV> consumer_blocks) {
   StmtSRef result{nullptr};
   // Create a new array of SRefs from the consumer block list.
   Array<StmtSRef> consumer_block_refs = {};
@@ -543,7 +544,8 @@ BlockRV ConcreteScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer
     consumer_block_refs.push_back(this->GetSRef(block));
   }
   TVM_TIR_SCHEDULE_BEGIN();
-  result = tir::CacheRead(state_, this->GetSRef(block_rv), read_buffer_index, storage_scope, consumer_block_refs);
+  result = tir::CacheRead(state_, this->GetSRef(block_rv), read_buffer_index, storage_scope,
+                          consumer_block_refs);
   TVM_TIR_SCHEDULE_END("cache-read", this->error_render_level_);
   this->state_->DebugVerify();
   return CreateRV<BlockRV>(result);

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -537,8 +537,13 @@ void ConcreteScheduleNode::Unroll(const LoopRV& loop_rv) {
 BlockRV ConcreteScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer_index,
                                         const String& storage_scope, const Array<BlockRV> consumer_blocks) {
   StmtSRef result{nullptr};
+  // Create a new array of SRefs from the consumer block list.
+  Array<StmtSRef> consumer_block_refs = {};
+  for (BlockRV block : consumer_blocks) {
+    consumer_block_refs.push_back(this->GetSRef(block));
+  }
   TVM_TIR_SCHEDULE_BEGIN();
-  result = tir::CacheRead(state_, this->GetSRef(block_rv), read_buffer_index, storage_scope, consumer_blocks);
+  result = tir::CacheRead(state_, this->GetSRef(block_rv), read_buffer_index, storage_scope, consumer_block_refs);
   TVM_TIR_SCHEDULE_END("cache-read", this->error_render_level_);
   this->state_->DebugVerify();
   return CreateRV<BlockRV>(result);

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -535,10 +535,10 @@ void ConcreteScheduleNode::Unroll(const LoopRV& loop_rv) {
 /******** Schedule: Insert cache stages ********/
 
 BlockRV ConcreteScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                                        const String& storage_scope) {
+                                        const String& storage_scope, const Array<BlockRV> consumer_blocks) {
   StmtSRef result{nullptr};
   TVM_TIR_SCHEDULE_BEGIN();
-  result = tir::CacheRead(state_, this->GetSRef(block_rv), read_buffer_index, storage_scope);
+  result = tir::CacheRead(state_, this->GetSRef(block_rv), read_buffer_index, storage_scope, consumer_blocks);
   TVM_TIR_SCHEDULE_END("cache-read", this->error_render_level_);
   this->state_->DebugVerify();
   return CreateRV<BlockRV>(result);

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -112,8 +112,8 @@ class ConcreteScheduleNode : public ScheduleNode {
   void Bind(const LoopRV& loop_rv, const String& thread_axis) override;
   void Unroll(const LoopRV& loop_rv) override;
   /******** Schedule: Insert cache stages ********/
-  BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                    const String& storage_scope, const Array<BlockRV> consumer_blocks = {}) override;
+  BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index, const String& storage_scope,
+                    const Array<BlockRV> consumer_blocks = {}) override;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) override;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -113,7 +113,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   void Unroll(const LoopRV& loop_rv) override;
   /******** Schedule: Insert cache stages ********/
   BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                    const String& storage_scope) override;
+                    const String& storage_scope, const Array<BlockRV> consumer_blocks = {}) override;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) override;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -250,10 +250,11 @@ TVM_DLL void Unroll(ScheduleState self, const StmtSRef& loop_sref);
  * \param block_sref The consumer block of the target buffer.
  * \param read_buffer_index The index of the buffer in block's read region.
  * \param storage_scope The target storage scope.
+ * \param consumer_blocks Array of blocks that consume the cache.
  * \return The cache stage block.
  */
 TVM_DLL StmtSRef CacheRead(ScheduleState self, const StmtSRef& block_sref, int read_buffer_index,
-                           const String& storage_scope);
+                           const String& storage_scope, const Array<BlockRV> consumer_blocks = {});
 /*!
  * \brief Create a block that writes a buffer region into a write cache. It requires:
  * 1) There is only one block that writes the target buffer.

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -254,7 +254,7 @@ TVM_DLL void Unroll(ScheduleState self, const StmtSRef& loop_sref);
  * \return The cache stage block.
  */
 TVM_DLL StmtSRef CacheRead(ScheduleState self, const StmtSRef& block_sref, int read_buffer_index,
-                           const String& storage_scope, const Array<BlockRV> consumer_blocks = {});
+                           const String& storage_scope, const Array<StmtSRef> consumer_blocks = {});
 /*!
  * \brief Create a block that writes a buffer region into a write cache. It requires:
  * 1) There is only one block that writes the target buffer.

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -1196,12 +1196,13 @@ struct CacheReadTraits : public UnpackedInstTraits<CacheReadTraits> {
   static constexpr size_t kNumAttrs = 2;
   static constexpr size_t kNumDecisions = 0;
 
-  static BlockRV UnpackedApplyToSchedule(Schedule sch, BlockRV block, Array<BlockRV> consumer_blocks, Integer read_buffer_index,
+  static BlockRV UnpackedApplyToSchedule(Schedule sch, BlockRV block,
+                                         Array<BlockRV> consumer_blocks, Integer read_buffer_index,
                                          String storage_scope) {
     return sch->CacheRead(block, read_buffer_index->value, storage_scope, consumer_blocks);
   }
 
-  static String UnpackedAsPython(Array<String> outputs, String block, Array<String> consumer_blocks ,
+  static String UnpackedAsPython(Array<String> outputs, String block, Array<String> consumer_blocks,
                                  Integer read_buffer_index, String storage_scope) {
     PythonAPICall py("cache_read");
     py.Input("block", block);

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -1207,7 +1207,7 @@ struct CacheReadTraits : public UnpackedInstTraits<CacheReadTraits> {
     py.Input("block", block);
     py.Input("read_buffer_index", read_buffer_index->value);
     py.Input("storage_scope", storage_scope);
-    py.Input("consumer_block", consumer_blocks);
+    py.Input("consumer_blocks", consumer_blocks);
     py.SingleOutput(outputs);
     return py.Str();
   }

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -77,8 +77,6 @@ struct CacheStageInfo {
   Map<Block, Block> block_reuse;
   /*! \brief A list of blocks that will consume the new cache. */
   Array<BlockRV> consumer_blocks;
-  /*! \brief The schedule corresponding to the graph. */
-  ScheduleState schedule;
 };
 
 /*! \brief Return the buffer region realted with the buffer */
@@ -537,8 +535,6 @@ class CacheReadRewriter : public StmtExprMutator {
     for (BlockRV consumer : info_->consumer_blocks) {
       std::cout << "Consumer: " << consumer << std::endl;
       std::cout << "Same: " << old_stmt.same_as(consumer) << std::endl;
-      Block test = info_->schedule.get(consumer);
-      std::cout << "Same 2: " << old_stmt.same_as(test) << std::endl;
       if (old_stmt.same_as(consumer)) {
         is_consumer = true;
       }
@@ -1015,8 +1011,6 @@ StmtSRef CacheRead(ScheduleState self, const StmtSRef& block_sref, int read_buff
   info.alloc = info.write_buffer;
   // Indicate which buffers should consume the cache.
   info.consumer_blocks = consumer_blocks;
-  // Note the schedule in pass info.
-  info.schedule = self;
 
   // Step 3. Update cache stage info.
   BufferRegion cache_region{nullptr};

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -1208,7 +1208,10 @@ struct CacheReadTraits : public UnpackedInstTraits<CacheReadTraits> {
     py.Input("block", block);
     py.Input("read_buffer_index", read_buffer_index->value);
     py.Input("storage_scope", storage_scope);
-    py.Input("consumer_blocks", consumer_blocks);
+    // Only write out consumer blocks if provided.
+    if (!consumer_blocks.empty()) {
+      py.Input("consumer_blocks", consumer_blocks);
+    }
     py.SingleOutput(outputs);
     return py.Str();
   }

--- a/src/tir/schedule/trace.cc
+++ b/src/tir/schedule/trace.cc
@@ -79,6 +79,9 @@ Array<ObjectRef> TranslateInputRVs(const Array<ObjectRef>& inputs,
                 << "TypeError: Expect 'tir.Var', but gets: " << dst->GetTypeKey();
             return GetRef<Var>(static_cast<const VarNode*>(dst));
           }));
+    } else if (input->IsInstance<ArrayNode>()) {
+      // Recursively convert elements of the array into a new list of ObjectRefs.
+      result.push_back(TranslateInputRVs(Downcast<Array<ObjectRef>>(input), rv_map));
     } else {
       ICHECK(false) << "TypeError: Cannot recognize the type of an input random variable: "
                     << input->GetTypeKey();

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -282,13 +282,13 @@ void TracedScheduleNode::Unroll(const LoopRV& loop_rv) {
 
 /******** Schedule: Insert cache stages ********/
 BlockRV TracedScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                                      const String& storage_scope) {
-  BlockRV result = ConcreteScheduleNode::CacheRead(block_rv, read_buffer_index, storage_scope);
+                                      const String& storage_scope, const Array<BlockRV> consumer_blocks) {
+  BlockRV result = ConcreteScheduleNode::CacheRead(block_rv, read_buffer_index, storage_scope, consumer_blocks);
 
   static const InstructionKind& kind = InstructionKind::Get("CacheRead");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv},
-                                      /*attrs=*/{Integer(read_buffer_index), storage_scope},
+                                      /*attrs=*/{Integer(read_buffer_index), storage_scope, consumer_blocks},
                                       /*outputs=*/{result}));
   return result;
 }

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -282,8 +282,10 @@ void TracedScheduleNode::Unroll(const LoopRV& loop_rv) {
 
 /******** Schedule: Insert cache stages ********/
 BlockRV TracedScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                                      const String& storage_scope, const Array<BlockRV> consumer_blocks) {
-  BlockRV result = ConcreteScheduleNode::CacheRead(block_rv, read_buffer_index, storage_scope, consumer_blocks);
+                                      const String& storage_scope,
+                                      const Array<BlockRV> consumer_blocks) {
+  BlockRV result =
+      ConcreteScheduleNode::CacheRead(block_rv, read_buffer_index, storage_scope, consumer_blocks);
 
   static const InstructionKind& kind = InstructionKind::Get("CacheRead");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -287,8 +287,8 @@ BlockRV TracedScheduleNode::CacheRead(const BlockRV& block_rv, int read_buffer_i
 
   static const InstructionKind& kind = InstructionKind::Get("CacheRead");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv},
-                                      /*attrs=*/{Integer(read_buffer_index), storage_scope, consumer_blocks},
+                                      /*inputs=*/{block_rv, consumer_blocks},
+                                      /*attrs=*/{Integer(read_buffer_index), storage_scope},
                                       /*outputs=*/{result}));
   return result;
 }

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -72,8 +72,8 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   void Bind(const LoopRV& loop_rv, const String& thread_axis) final;
   void Unroll(const LoopRV& loop_rv) final;
   /******** Schedule: Insert cache stages ********/
-  BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                    const String& storage_scope, const Array<BlockRV> consumer_blocks = {}) final;
+  BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index, const String& storage_scope,
+                    const Array<BlockRV> consumer_blocks = {}) final;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) final;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -73,7 +73,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   void Unroll(const LoopRV& loop_rv) final;
   /******** Schedule: Insert cache stages ********/
   BlockRV CacheRead(const BlockRV& block_rv, int read_buffer_index,
-                    const String& storage_scope) final;
+                    const String& storage_scope, const Array<BlockRV> consumer_blocks = {}) final;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) final;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,

--- a/tests/python/unittest/test_tir_schedule_cache_read_write.py
+++ b/tests/python/unittest/test_tir_schedule_cache_read_write.py
@@ -404,6 +404,32 @@ def cache_read_multi_consumer() -> None:
 
 
 @T.prim_func
+def cache_read_multi_consumer_target() -> None:
+    A = T.alloc_buffer((128))
+    B = T.alloc_buffer((128))
+    C = T.alloc_buffer((128))
+    A_global = T.alloc_buffer((128))
+    for i in T.grid(8):
+        for j in T.grid(16):
+            with T.block("A"):
+                vi = T.axis.S(128, i * 16 + j)
+                A[vi] = 1.0
+        for j in T.grid(16):
+            with T.block("A"):
+                vi = T.axis.S(128, i * 16 + j)
+                A_global[vi] = A[vi]
+        for j in T.grid(16):
+            with T.block("B"):
+                vi = T.axis.S(128, i * 16 + j)
+                B[vi] = A[vi] + 1.0
+
+    for i in T.grid(128):
+        with T.block("C"):
+            vi = T.axis.S(128, i)
+            C[vi] = A_global[vi]
+
+
+@T.prim_func
 def continuous_cache_read(a: T.handle, c: T.handle) -> None:
     A = T.match_buffer(a, (128, 128))
     C = T.match_buffer(c, (128, 128))
@@ -780,6 +806,22 @@ def test_cache_read_location(use_block_name):
     sch = tir.Schedule(func_multi_consumer, debug_mask="all")
     block_b = "B" if use_block_name else sch.get_block("B")
     sch.cache_read(block_b, 0, "global")
+    tvm.ir.assert_structural_equal(cache_read_multi_consumer, sch.mod["main"])
+    verify_trace_roundtrip(sch=sch, mod=func_multi_consumer)
+
+    # Test that specific consumer block targetting works.
+    sch = tir.Schedule(func_multi_consumer, debug_mask="all")
+    block_b = "B" if use_block_name else sch.get_block("B")
+    block_c = "C" if use_block_name else sch.get_block("C")
+    sch.cache_read(block_b, 0, "global", consumer_blocks=[block_c])
+    tvm.ir.assert_structural_equal(cache_read_multi_consumer_target, sch.mod["main"])
+    verify_trace_roundtrip(sch=sch, mod=func_multi_consumer)
+
+    # Also test setting multiple consumers yields same result as unspecified.
+    sch = tir.Schedule(func_multi_consumer, debug_mask="all")
+    block_b = "B" if use_block_name else sch.get_block("B")
+    block_c = "C" if use_block_name else sch.get_block("C")
+    sch.cache_read(block_b, 0, "global", consumer_blocks=[block_b, block_c])
     tvm.ir.assert_structural_equal(cache_read_multi_consumer, sch.mod["main"])
     verify_trace_roundtrip(sch=sch, mod=func_multi_consumer)
 


### PR DESCRIPTION
Currently in tir, using `cache_read` will rewrite all consumer blocks of the specified buffer in the current scope. However, there may be cases where we want to apply that transformation only to a subset of consumer blocks. In the te version of cache_read, this is explicitly specified through a list of `consumer_blocks`. This PR extends the tir version of `cache_read` with an optional `consumer_blocks` argument. When provided, only blocks listed in `consumer_blocks` will be rewritten. If not provided, the current behavior of `cache_read` remains the same.

cc @junrushao1994