### PR TITLE
[CI] Add alexnet and googlenet caffe model to request hook

### DIFF
--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -37,6 +37,8 @@ URL_MAP = {
     "http://images.cocodataset.org/zips/val2017.zip": f"{BASE}/cocodataset-val2017.zip",
     "https://bj.bcebos.com/x2paddle/models/paddle_resnet50.tar": f"{BASE}/bcebos-paddle_resnet50.tar",
     "https://data.deepai.org/stanfordcars.zip": f"{BASE}/deepai-stanfordcars.zip",
+    "http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel": f"{BASE}/bvlc_alexnet.caffemodel",
+    "http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel": f"{BASE}/bvlc_googlenet.caffemodel",
 }
 
 

--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -39,6 +39,7 @@ URL_MAP = {
     "https://data.deepai.org/stanfordcars.zip": f"{BASE}/deepai-stanfordcars.zip",
     "http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel": f"{BASE}/bvlc_alexnet.caffemodel",
     "http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel": f"{BASE}/bvlc_googlenet.caffemodel",
+    "https://github.com/dmlc/web-data/blob/main/darknet/data/dog.jpg": f"{BASE}/dog.jpg",
 }
 
 


### PR DESCRIPTION
This PR intends to move the alexnet and googlenet caffe models from the old link to s3, therefore getting rid of the flakiness in `caffe/test_forward.py` introduced by external url timeouts. 

Fixes #12465

cc: @driazati @areusch 

cc @Mousius @gigiblender