### PR TITLE
[TIR] Fix temp obj reference typo in manifest_shared_memory_local_stage

### DIFF
--- a/src/tir/transforms/manifest_shared_memory_local_stage.cc
+++ b/src/tir/transforms/manifest_shared_memory_local_stage.cc
@@ -46,7 +46,7 @@ namespace tir {
  */
 class IntermediateStageRewriter {
  public:
-  explicit IntermediateStageRewriter(const Array<Stmt>& ancestor_loop_or_blocks)
+  explicit IntermediateStageRewriter(const std::vector<Stmt>& ancestor_loop_or_blocks)
       : ancestor_loop_or_blocks_(ancestor_loop_or_blocks) {}
 
   std::tuple<Buffer, Buffer, Block, Stmt> Rewrite(const BlockNode* block) {
@@ -165,7 +165,7 @@ class IntermediateStageRewriter {
     return {new_buffer, buffer_indices};
   }
 
-  const Array<Stmt>& ancestor_loop_or_blocks_;
+  const std::vector<Stmt>& ancestor_loop_or_blocks_;
 };
 
 class SharedMemoryLocalStageInserter : public StmtMutator {


### PR DESCRIPTION
Just an issue of temp reference, may crash on certain environments. The actual constructor argument passed in is `std::vector<Stmt>`.


cc @junrushao1994