### PR TITLE
[MicroTVM] fix compile error when the compiler implements char as unsigned

### DIFF
--- a/src/runtime/crt/graph_executor/load_json.c
+++ b/src/runtime/crt/graph_executor/load_json.c
@@ -177,7 +177,7 @@ char JSONReader_PeekNextNonSpace(JSONReader* reader) {
  */
 int JSONReader_ReadString(JSONReader* reader, char* out_str, size_t out_str_size) {
   int status = 0;
-  char ch = reader->NextNonSpace(reader);
+  int ch = reader->NextNonSpace(reader);
   size_t output_counter = 0;
   while (output_counter < out_str_size || out_str == NULL) {
     ch = reader->NextChar(reader);


### PR DESCRIPTION
When compiling tvm with micro on the compiler which implements char as unsigned(such as arm-linux-gcc), there is an error:
`src/runtime/crt/graph_executor/load_json.c:218:12: error: result of comparison of constant -1 with expression of type 'char' is always false [-Werror,-Wtautological-constant-out-of-range-compare]`
`    if (ch == EOF || ch == '\r' || ch == '\n') {`
The reason is because the implementation of char is undefined, so it's better to specify here that it is signed.

cc @alanmacd @gromero @mehrdadh