### PR TITLE
[AutoTVM] Add support for text buffers to ApplyHistoryBest

### DIFF
--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -194,20 +194,41 @@ def decode(row, protocol="json"):
     raise RuntimeError("Invalid log protocol: " + protocol)
 
 
-def load_from_file(filename):
+def load_from_io(file):
     """Generator: load records from file.
     This is a generator that yields the records.
 
     Parameters
     ----------
-    filename: str
+    file: os.TextIOBase
 
     Yields
     ------
     input: autotvm.measure.MeasureInput
     result: autotvm.measure.MeasureResult
     """
-    with open(filename) as f:
+    for row in file:
+        if row and not row.startswith("#"):
+            ret = decode(row)
+            if ret is None:
+                continue
+            yield ret
+
+
+def load_from_file(filepath):
+    """Generator: load records from path.
+    This is a generator that yields the records.
+
+    Parameters
+    ----------
+    filepath: str, bytes, os.PathLike
+
+    Yields
+    ------
+    input: autotvm.measure.MeasureInput
+    result: autotvm.measure.MeasureResult
+    """
+    with open(filepath) as f:
         for row in f:
             if row and not row.startswith("#"):
                 ret = decode(row)

--- a/python/tvm/autotvm/record.py
+++ b/python/tvm/autotvm/record.py
@@ -20,10 +20,12 @@
 
 import argparse
 import base64
+from io import TextIOBase
 import logging
 import pickle
 import json
 import time
+from typing import Union
 import os
 import itertools
 from collections import OrderedDict
@@ -194,13 +196,13 @@ def decode(row, protocol="json"):
     raise RuntimeError("Invalid log protocol: " + protocol)
 
 
-def load_from_io(file):
-    """Generator: load records from file.
+def load_from_buffer(file: TextIOBase):
+    """Generator: load records from buffer.
     This is a generator that yields the records.
 
     Parameters
     ----------
-    file: os.TextIOBase
+    file: io.TextIOBase
 
     Yields
     ------
@@ -215,13 +217,13 @@ def load_from_io(file):
             yield ret
 
 
-def load_from_file(filepath):
+def load_from_file(filepath: Union[str, bytes, os.PathLike]):
     """Generator: load records from path.
     This is a generator that yields the records.
 
     Parameters
     ----------
-    filepath: str, bytes, os.PathLike
+    filepath: str, bytes, or os.PathLike
 
     Yields
     ------

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -246,12 +246,12 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : str, list of str, or iterator of (autotvm.measure.MeasureInput,\
-                                                autotvm.measure.MeasureResult)
-        Collection of tuning records.
-        If is str, then it should be the filename of a records log file.
-        Each row of this file is an encoded record pair. If it is a list, it can either be
-        a list of paths to log files that will be loaded jointly or an iterator or records.
+    records : Records or iterator of Records objects, where a Records
+              object is a path-like object, a file-like object, or an
+              iterator of (MeasureInput, MeasureResult).
+
+        Collection of tuning records. If multiple Records objects are passed, their
+        contents will be merged.
     """
 
     def __init__(self, records):
@@ -271,11 +271,9 @@ class ApplyHistoryBest(DispatchContext):
         ----------
         records : str, list of str, or iterator of (autotvm.measure.MeasureInput,\
                                                     autotvm.measure.MeasureResult)
-            Collection of tuning records.
-            If is str, then it should be the filename of a records log file.
-            Each row of this file is an encoded record pair. If it is a list
-            it can either be a list of paths to logs that will be loaded jointly or
-            an iterator of measurement results.
+
+            Collection of tuning records. If multiple Records objects are passed, their
+            contents will be merged.
         """
         # pylint: disable=import-outside-toplevel
         from ..record import load_from_file, load_from_io

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -246,15 +246,15 @@ class ApplyHistoryBest(DispatchContext):
 
     Parameters
     ----------
-    records : Records or iterator of Records objects, where a Records
-              object is a path-like object, a file-like object, or an
-              iterator of (MeasureInput, MeasureResult).
+    records : None, Records, or iterator of Records objects, where a
+              Records object is a path-like object, a file-like object,
+              or an iterator of (MeasureInput, MeasureResult).
 
         Collection of tuning records. If multiple Records objects are passed, their
         contents will be merged.
     """
 
-    def __init__(self, records):
+    def __init__(self, records: Union[None, Records, Iterable[Records]]):
         super(ApplyHistoryBest, self).__init__()
 
         self.best_by_targetkey = {}
@@ -471,7 +471,7 @@ class ApplyGraphBest(DispatchContext):
         from ..record import load_from_file, load_from_buffer
 
         super(ApplyGraphBest, self).__init__()
-        if isinstance(records, str, bytes, PathLike):
+        if isinstance(records, (str, bytes, PathLike)):
             records = load_from_file(records)
         elif isinstance(records, TextIOBase):
             records = load_from_buffer(records)

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -468,11 +468,16 @@ class ApplyGraphBest(DispatchContext):
             Otherwise, it is an iterator.
         """
         # pylint: disable=import-outside-toplevel
-        from ..record import load_from_file
+        from ..record import load_from_file, load_from_buffer
 
         super(ApplyGraphBest, self).__init__()
-        if isinstance(records, str):
+        if isinstance(records, str, bytes, PathLike):
             records = load_from_file(records)
+        elif isinstance(records, TextIOBase):
+            records = load_from_buffer(records)
+        else:
+            records = list(records)
+
         self._records = list(records)
         self._counter = 0
         self._global_cfg_dict = {}

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -276,7 +276,7 @@ class ApplyHistoryBest(DispatchContext):
             contents will be merged.
         """
         # pylint: disable=import-outside-toplevel
-        from ..record import load_from_file, load_from_io
+        from ..record import load_from_file, load_from_buffer
 
         def _unpack_records(
             records: Union[Records, Iterable[Records]]
@@ -286,7 +286,7 @@ class ApplyHistoryBest(DispatchContext):
                 return load_from_file(records)
 
             if isinstance(records, TextIOBase):
-                return load_from_io(records)
+                return load_from_buffer(records)
 
             joint_records = []
             for record in records:

--- a/tests/micro/common/test_autotune.py
+++ b/tests/micro/common/test_autotune.py
@@ -61,6 +61,7 @@ def test_kws_autotune_workflow(platform, board, tmp_path):
     assert logs[0]["config"]["entity"] != logs[1]["config"]["entity"]
 
     # Compile the best model with AOT and connect to it
+    str_io_logs.seek(0)
     with tvm.micro.testing.create_aot_session(
         platform,
         board,


### PR DESCRIPTION
Currently, AutoTVM's `ApplyHistoryBest` class does not support loading tuning logs from memory. This is a pet peeve of mine, as it requires you to work with a `tempfile` whenever writing autotuning tests. This is also just strange, as the rest of AutoTVM has support for text buffers (e.g. `tvm.autotvm.callback.log_to_file` supports passing in a text buffer, letting us write to but not read from them).

Additionally, `ApplyHistoryBest` handles input arguments very unintuitively. Before this PR, it allowed users to pass string filepaths, a list of string filepaths, or an `Iterable` (such as a list) of input and result tuples. However, it did not support taking in `StringIO` objects as mentioned above, nor `pathlib.Path` objects, nor combinations of a filepath and an `Iterable` of tuples.

In a perfect world, we would change `ApplyHistoryBest` to take as input a path-like object, file-like object, or an `Iterable` of input and result tuples (similar to what `ApplyGraphBest` takes as an argument). However, this would break the existing functionality to take as input a list of filepaths.

To be backwards compatible, while fixing this issue, this pull request defines a new type inside `dispatcher.py`:

```python
Records = Union[
    Union[str, bytes, Path],  # Path-like objects
    TextIOBase,  # File-like objects
    Iterable[Tuple[MeasureInput, MeasureResult]],
]
```
It then rewrites `ApplyHistoryBest.load` so it takes the following arguments:
```python
def load(self, records: Union[Records, Iterable[Records]]):
```

This PR also adds unit tests for this new functionality, and fixes a relevant bug in `tests/micro/common/test_autotune.py` in which a `StringIO` object was passed to `apply_history_best`, causing it to appear to pass but not actually read any data.