### PR TITLE
[AutoTVM] [TVMC] Visualize tuning progress

### DIFF
--- a/gallery/tutorial/tvmc_command_line_driver.py
+++ b/gallery/tutorial/tvmc_command_line_driver.py
@@ -417,6 +417,9 @@ testing.utils.install_request_hook(depth=3)
 # process, in terms of number of repetitions (``--repeat`` and ``--number``, for example), the tuning
 # algorithm to be used, and so on. Check ``tvmc tune --help`` for more information.
 #
+# The `--visualize ARG` flag allows showing the tuning progress in a graph which can be
+# written to a file (ARG: `filename.png`), displayed as a live plot window (ARG: `live`)
+# or both (ARG: `live,filename.png`).
 
 ################################################################################
 # Compiling an Optimized Model with Tuning Data

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -157,6 +157,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
             [
                 "ethos-u-vela",
                 "future",  # Hidden dependency of torch.
+                "matplotlib",
                 "onnx",
                 "onnxoptimizer",
                 "onnxruntime",

--- a/python/tvm/autotvm/tuner/callback.py
+++ b/python/tvm/autotvm/tuner/callback.py
@@ -180,7 +180,9 @@ def progress_bar(total, prefix="", si_prefix="G"):
     return _callback
 
 
-def visualize_progress(idx, title="AutoTVM Progress", si_prefix="G", keep_open=False):
+def visualize_progress(
+    idx, title="AutoTVM Progress", si_prefix="G", keep_open=False, live=True, out_path=None
+):
     """Display tuning progress in graph
 
     Parameters
@@ -192,7 +194,11 @@ def visualize_progress(idx, title="AutoTVM Progress", si_prefix="G", keep_open=F
     si_prefix: str
         SI prefix for flops
     keep_open: bool
-        TODO
+        Wait until the matplotlib window was closed by the user.
+    live: bool
+        If false, the graph is only written to the file specified in out_path.
+    out_path: str
+        Path where the graph image should be written (if defined).
     """
     import matplotlib.pyplot as plt
 
@@ -201,7 +207,8 @@ def visualize_progress(idx, title="AutoTVM Progress", si_prefix="G", keep_open=F
 
         def __init__(self):
             self.keep_open = keep_open
-            self.out_file = "/tmp/plot.png"
+            self.live = live
+            self.out_path = out_path
             self.best_flops = [0]
             self.all_flops = []
             if idx > 0:
@@ -213,13 +220,14 @@ def visualize_progress(idx, title="AutoTVM Progress", si_prefix="G", keep_open=F
             plt.xlabel("Iterations")
             plt.ylabel(f"{si_prefix}FLOPS")
             plt.legend(loc="upper left")
-            plt.pause(0.05)
+            if self.live:
+                plt.pause(0.05)
 
         def __del__(self):
-            if self.out_file:
-                print(f"Writing plot to file {self.out_file}...")
-                plt.savefig(self.out_file)
-            if self.keep_open:
+            if self.out_path:
+                print(f"Writing plot to file {self.out_path}...")
+                plt.savefig(self.out_path)
+            if self.live and self.keep_open:
                 print("Close matplotlib window to continue...")
                 plt.show()
 
@@ -245,6 +253,7 @@ def visualize_progress(idx, title="AutoTVM Progress", si_prefix="G", keep_open=F
             plt.axis([0, max(len(ctx.all_flops) + 1, xmax), 0, max(ctx.best_flops[-1] * 1.1, ymax)])
             plt.scatter(len(ctx.all_flops), flops, color=ctx.color, marker=m, s=15)
             ctx.p.set_data(list(range(0, len(ctx.all_flops) + 1)), ctx.best_flops)
+        if live:
             plt.pause(0.05)
 
     return _callback

--- a/python/tvm/autotvm/tuner/callback.py
+++ b/python/tvm/autotvm/tuner/callback.py
@@ -180,7 +180,7 @@ def progress_bar(total, prefix="", si_prefix="G"):
     return _callback
 
 
-def visualize_progress(idx, title="AutoTVM Progress", multi=False,  si_prefix="G"):
+def visualize_progress(idx, title="AutoTVM Progress", multi=False, si_prefix="G"):
     """Display tuning progress in graph
 
     Parameters

--- a/python/tvm/autotvm/tuner/callback.py
+++ b/python/tvm/autotvm/tuner/callback.py
@@ -180,7 +180,7 @@ def progress_bar(total, prefix="", si_prefix="G"):
     return _callback
 
 
-def visualize_progress(idx, title="AutoTVM Progress", multi=False, si_prefix="G"):
+def visualize_progress(idx, title="AutoTVM Progress", si_prefix="G", keep_open=False):
     """Display tuning progress in graph
 
     Parameters
@@ -189,11 +189,10 @@ def visualize_progress(idx, title="AutoTVM Progress", multi=False, si_prefix="G"
         Index of the current task.
     title: str
         Specify the title of the matplotlib figure.
-    multi: bool
-        Add traces for alls tuned tasks into a single plot.
-        If False, one plot is generated for each task.
     si_prefix: str
         SI prefix for flops
+    keep_open: bool
+        TODO
     """
     import matplotlib.pyplot as plt
 
@@ -201,9 +200,11 @@ def visualize_progress(idx, title="AutoTVM Progress", multi=False, si_prefix="G"
         """Context to store local variables"""
 
         def __init__(self):
+            self.keep_open = keep_open
+            self.out_file = "/tmp/plot.png"
             self.best_flops = [0]
             self.all_flops = []
-            if multi and idx > 0:
+            if idx > 0:
                 plt.figure(title)
             else:
                 plt.figure(title).clear()
@@ -213,6 +214,14 @@ def visualize_progress(idx, title="AutoTVM Progress", multi=False, si_prefix="G"
             plt.ylabel(f"{si_prefix}FLOPS")
             plt.legend(loc="upper left")
             plt.pause(0.05)
+
+        def __del__(self):
+            if self.out_file:
+                print(f"Writing plot to file {self.out_file}...")
+                plt.savefig(self.out_file)
+            if self.keep_open:
+                print("Close matplotlib window to continue...")
+                plt.show()
 
     ctx = _Context()
 

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -635,7 +635,7 @@ def schedule_tasks(
     if log_estimated_latency:
         callbacks.append(auto_scheduler.task_scheduler.LogEstimatedLatency(("total_latency.tsv")))
     if visualize:
-        callbacks.append(auto_scheduler.task_scheduler.VisualizeProgress())
+        callbacks.append(auto_scheduler.task_scheduler.VisualizeProgress(keep_open=True))
 
     # Create the scheduler
     tuner = auto_scheduler.TaskScheduler(tasks, task_weights, load_log_file=prior_records, callbacks=callbacks)
@@ -716,8 +716,8 @@ def tune_tasks(
             autotvm.callback.log_to_file(log_file),
         ]
         if visualize:
-            # callbacks.append(autotvm.callback.visualize_progress(i, title=f"AutoTVM Progress [Task {i+1}/{len(tasks)}]", si_prefix=si_prefix)
-            callbacks.append(autotvm.callback.visualize_progress(i, multi=True, si_prefix=si_prefix))
+            keep_open = i == len(tasks) - 1
+            callbacks.append(autotvm.callback.visualize_progress(i, si_prefix=si_prefix, keep_open=keep_open))
         tuner_obj.tune(
             n_trial=min(trials, len(tsk.config_space)),
             early_stopping=early_stopping,

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -319,6 +319,7 @@ def tune_model(
     include_simple_tasks: bool = False,
     log_estimated_latency: bool = False,
     additional_target_options: Optional[Dict[str, Dict[str, Any]]] = None,
+    si_prefix: str = "G",
 ):
     """Use tuning to automatically optimize the functions in a model.
 
@@ -377,6 +378,8 @@ def tune_model(
         If using the autoscheduler, write the estimated latency at each step of tuning to file.
     additional_target_options: Optional[Dict[str, Dict[str, Any]]]
         Additional target options in a dictionary to combine with initial Target arguments
+    si_prefix : str
+        SI prefix for FLOPS.
 
     Returns
     -------
@@ -643,6 +646,7 @@ def tune_tasks(
     trials: int,
     early_stopping: Optional[int] = None,
     tuning_records: Optional[str] = None,
+    si_prefix: str = "G",
 ):
     """Tune a list of tasks and output the history to a log file.
 
@@ -664,6 +668,8 @@ def tune_tasks(
     tuning_records: str, optional
         Path to the file produced by the tuning, to be used during
         tuning.
+    si_prefix : str
+        SI prefix for FLOPS.
     """
     if not tasks:
         logger.warning("there were no tasks found to be tuned")
@@ -701,7 +707,8 @@ def tune_tasks(
             early_stopping=early_stopping,
             measure_option=measure_option,
             callbacks=[
-                autotvm.callback.progress_bar(trials, prefix=prefix),
+                autotvm.callback.progress_bar(trials, prefix=prefix, si_prefix=si_prefix),
                 autotvm.callback.log_to_file(log_file),
             ],
+            si_prefix=si_prefix,
         )

--- a/tests/python/driver/tvmc/test_autotuner.py
+++ b/tests/python/driver/tvmc/test_autotuner.py
@@ -207,3 +207,18 @@ def test_autotune_pass_context(mock_pc, onnx_mnist, tmpdir_factory):
     # AutoTVM overrides the pass context later in the pipeline to disable AlterOpLayout
     assert mock_pc.call_count == 2
     assert mock_pc.call_args_list[0][1]["opt_level"] == 3
+
+
+def test_parse_visualize_arg_valid():
+    tvmc.autotuner.parse_visualize_arg("live") == "live", None
+    tvmc.autotuner.parse_visualize_arg("plot.png") == "file", Path("plot.png")
+    tvmc.autotuner.parse_visualize_arg("live2") == "file", Path("live2")
+    tvmc.autotuner.parse_visualize_arg("live,plot.png") == "both", Path("plot.png")
+    tvmc.autotuner.parse_visualize_arg("plot.png,live") == "both", Path("plot.png")
+
+
+def test_parse_visualize_arg_invalid():
+    invalid = ["foo,bar,baz", "plot.png,plot2.png", "plot.png,", "live,", ","]
+    for arg in invalid:
+        with pytest.raises(AssertionError):
+            tvmc.autotuner.parse_visualize_arg(arg)


### PR DESCRIPTION
This change adds a callback for visualizing the FLOPS during tuning (AutoTVM & AutoScheduler (**NEW**)) over time using Matplotlib.

## Usage

### With Python

Create callback (`multi=False`: 1 window per Task, `multi=True`: all tasks in a single window):

```
visualize_callback = autotvm.callback.visualize_progress(task_idx, live=True, out_path="plot.png")
```

Pass callback to tuner:

```
tuner.tune(
  n_trial=100,
  measure_option=measure_option,
  callbacks=[visualize_callback],
)
```


### With TVM command line

~~Just add a `--visualize` to the `tvmc tune` command.~~

There are three modes available:

- *Live only:* add `--visualize live` to `tvmc tune` command
- *File only:* add `--visualize /pah/to/file.png` to `tvmc tune` command
- *Both:* add `--visualize live,/path/to/file.png` to `tvmc tune` command

## Screenshots

![tvmc_tune_visualize](https://user-images.githubusercontent.com/7712605/185800229-2b84a914-b5df-4afd-86e6-a57747cb81d4.png)



## Additional changes

- Make `si_prefix` in `tvmc/autotuner.py` variable (Prerequisite for a later PR)

## Open Questions
- ~~How to handle the `matplotlib` python dependency? Should I change `python/gen_requirements.py` and if yes which groups (tvmc/dev/?)?~~
- ~~The graph window automatically closes when the tuning is finished. Do we need an option to keep it open until closed?~~ Solved by newly introduced `keep_open` option
- ~~A similar feature for the AutoScheduler would be nice, too. I can look into it if there is interest.~~
- ~~Saving the plot to a file would also be possible. We only need to decide how to expose this to the cmdline (i.e. `--visualize plot.png`)~~

cc @Mousius @gromero