### PR TITLE
[topi]fix group conv3d pack kernel shape error

### DIFF
--- a/python/tvm/topi/x86/conv3d.py
+++ b/python/tvm/topi/x86/conv3d.py
@@ -272,10 +272,14 @@ def _conv3d_ndhwc(cfg, data, kernel, strides, padding, dilation, groups, out_dty
         shape, lambda n, C, d, h, c, w: data_pad[n, d, h, w, C * ic_bn + c], name="data_vec"
     )
 
+    ci_tile = in_channel // groups // ic_bn
+    if ci_tile == 0 or ci_tile * ic_bn * groups < in_channel:
+        ci_tile += 1
+
     # pack kernel
     shape = (
         num_filter // oc_bn,
-        in_channel // groups // ic_bn if (in_channel // groups // ic_bn) else 1,
+        ci_tile,
         kernel_depth,
         kernel_height,
         kernel_width,
@@ -389,10 +393,14 @@ def _conv3d_ncdhw(cfg, data, kernel, strides, padding, dilation, layout, groups,
         shape, lambda n, C, d, h, c, w: data_pad[n, C * ic_bn + c, d, h, w], name="data_vec"
     )
 
+    ci_tile = in_channel // groups // ic_bn
+    if ci_tile == 0 or ci_tile * ic_bn * groups < in_channel:
+        ci_tile += 1
+
     # pack kernel
     shape = (
         num_filter // oc_bn,
-        in_channel // groups // ic_bn if (in_channel // groups // ic_bn) else 1,
+        ci_tile,
         kernel_depth,
         kernel_height,
         kernel_width,

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2980,6 +2980,17 @@ def test_conv(target, dev):
             group=8,
         )
 
+        verify_conv(
+            (1, 12) + repeat(5, dims),
+            (30, 4) + repeat(3, dims),
+            (1, 30) + repeat(5, dims),
+            2 * repeat(1, dims),
+            repeat(3, dims),
+            repeat(1, dims),
+            repeat(1, dims),
+            group=3,
+        )
+
 
 @tvm.testing.parametrize_targets
 def test_convtranspose(target, dev):


### PR DESCRIPTION
Related PR: #12500 
hi, 
I am sorry i made a mistake about group_conv3d.
There is three case about caculate  `in_channel // groups // ic_bn`.
1. if `in_channel // groups // ic_bn`  == 0, It means that we only need to tile to `1`
2. if `out = in_channel // groups // ic_bn` ！= 0, but  the `out * ic_bn * group < in_channel` . It means that we  need to tile to `out +1`
3.   if `out = in_channel // groups // ic_bn`  ！= 0, but  the `out * ic_bn * group == in_channel` . It means that we  need to tile to `out `

In the last PR, I didn`t consider the second case.  So this PR I fix it.

CC: @masahi 