### PR TITLE
[TIR][CompactBufferAllocation] Improve upperbound estimation of buffer compaction

### DIFF
--- a/include/tvm/arith/int_set.h
+++ b/include/tvm/arith/int_set.h
@@ -261,7 +261,29 @@ Array<IntSet> UnionRegionLowerBound(const Array<Array<IntSet>>& nd_int_sets);
 IntSet Intersect(const Array<IntSet>& sets);
 
 /*!
- * \brief Analyze the region with affine map, given the domain of variables and their predicate
+ * \brief Converts the Ranges to IntSets
+ * \param var_dom The ranges of variables
+ * \return The integer sets of the variables
+ */
+Map<Var, arith::IntSet> AsIntSet(const Map<Var, Range>& var_dom);
+
+/*!
+ * \brief Analyze the region with affine map, given the domain of variables and their predicate.
+ * The result should be strict, i.e. no region is discarded or relaxed.
+ * \param region The region to be analyzed
+ * \param var_dom The ranges of the variables
+ * \param predicate The predicate for the affine map
+ * \param analyzer The analyzer used
+ * \return NullOpt if the detection fails, or an array of arith::IntSet as the result of analysis
+ */
+TVM_DLL Optional<Array<IntSet>> EstimateRegionStrictBound(const Array<Range>& region,
+                                                          const Map<Var, Range>& var_dom,
+                                                          const PrimExpr& predicate,
+                                                          arith::Analyzer* analyzer);
+
+/*!
+ * \brief Analyze the region with affine map, given the domain of variables and their predicate.
+ * Some subregion may be discarded during the lower-bound analysis.
  * \param region The region to be analyzed
  * \param var_dom The ranges of the variables
  * \param predicate The predicate for the affine map
@@ -272,6 +294,21 @@ TVM_DLL Optional<Array<IntSet>> EstimateRegionLowerBound(const Array<Range>& reg
                                                          const Map<Var, Range>& var_dom,
                                                          const PrimExpr& predicate,
                                                          arith::Analyzer* analyzer);
+
+/*!
+ * \brief Analyze the region with affine map, given the domain of variables and their predicate
+ * Relaxation of the region may be used in upper-bound analysis, i.e. some extra region may be added
+ * to the result.
+ * \param region The region to be analyzed
+ * \param var_dom The ranges of the variables
+ * \param predicate The predicate for the affine map
+ * \param analyzer The analyzer used
+ * \return an array of arith::IntSet as the result of analysis
+ */
+TVM_DLL Array<IntSet> EstimateRegionUpperBound(const Array<Range>& region,
+                                               const Map<Var, Range>& var_dom,
+                                               const PrimExpr& predicate,
+                                               arith::Analyzer* analyzer);
 
 }  // namespace arith
 }  // namespace tvm

--- a/python/tvm/arith/__init__.py
+++ b/python/tvm/arith/__init__.py
@@ -16,7 +16,13 @@
 # under the License.
 """Integer bound analysis, simplification and pattern detection."""
 
-from .int_set import IntSet, IntervalSet, estimate_region_lower_bound
+from .int_set import (
+    IntSet,
+    IntervalSet,
+    estimate_region_lower_bound,
+    estimate_region_strict_bound,
+    estimate_region_upper_bound,
+)
 from .analyzer import ModularSet, ConstIntBound, Analyzer
 from .bound import deduce_bound
 from .pattern import detect_linear_equation, detect_clip_bound

--- a/python/tvm/arith/int_set.py
+++ b/python/tvm/arith/int_set.py
@@ -83,6 +83,7 @@ class IntervalSet(IntSet):
 
 def estimate_region_lower_bound(region, var_dom, predicate):
     """Analyze the region with affine map, given the domain of variables and their predicate
+    Some subregion may be discarded during the lower-bound analysis.
 
     Parameters
     ----------
@@ -101,6 +102,53 @@ def estimate_region_lower_bound(region, var_dom, predicate):
         None if the detection fails, or an array of IntSets as the result of analysis
     """
     return _ffi_api.EstimateRegionLowerBound(region, var_dom, predicate)
+
+
+def estimate_region_strict_bound(region, var_dom, predicate):
+    """Analyze the region with affine map, given the domain of variables and their predicate
+    The result should be strict, i.e. no region is discarded or relaxed.
+
+    Parameters
+    ----------
+    region : List[Range]
+        The region to be analyzed.
+
+    var_dom : Dict[Var, Range]
+        The ranges of the variables
+
+    predicate : PrimExpr
+        The predicate for the affine map
+
+    Returns
+    ----------
+    region_int_set : Optional[List[IntSet]]
+        None if the detection fails, or an array of IntSets as the result of analysis
+    """
+    return _ffi_api.EstimateRegionStrictBound(region, var_dom, predicate)
+
+
+def estimate_region_upper_bound(region, var_dom, predicate):
+    """Analyze the region with affine map, given the domain of variables and their predicate
+    Relaxation of the region may be used in upper-bound analysis,
+    i.e. some extra region may be added to the result.
+
+    Parameters
+    ----------
+    region : List[Range]
+        The region to be analyzed.
+
+    var_dom : Dict[Var, Range]
+        The ranges of the variables
+
+    predicate : PrimExpr
+        The predicate for the affine map
+
+    Returns
+    ----------
+    region_int_set : List[IntSet]
+        an array of IntSets as the result of analysis
+    """
+    return _ffi_api.EstimateRegionUpperBound(region, var_dom, predicate)
 
 
 def pos_inf():

--- a/src/tir/schedule/primitive/compute_at.cc
+++ b/src/tir/schedule/primitive/compute_at.cc
@@ -356,7 +356,7 @@ void RelaxBufferRegions(const Map<Var, PrimExpr>& binding,
     runtime::StorageRank rank = scope.rank;
     if (rank != previous_rank || !var_dom.defined()) {
       previous_rank = rank;
-      var_dom = AsIntSet(LoopDomainOfSRefTreePath(
+      var_dom = arith::AsIntSet(LoopDomainOfSRefTreePath(
           /*low_inclusive=*/relax_path_low_inclusive,
           /*high_exclusive=*/relax_path_high_exclusive,
           /*extra_relax_scope=*/scope));

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "./utils.h"
+#include <tvm/arith/int_set.h>
 
+#include "./utils.h"
 namespace tvm {
 namespace tir {
 
@@ -44,13 +45,10 @@ Array<arith::IntSet> AnalyzeRegionUpperBound(const BufferRegion& region,        
       /*low_inclusive=*/dom_low_inclusive,
       /*high_exclusive=*/dom_high_exclusive,
       /*extra_relax_scope=*/runtime::StorageScope::Create(region->buffer.scope()));
-  if (Optional<Array<arith::IntSet>> result = EstimateRegionLowerBound(
-          /*region=*/region->region,
-          /*var_dom=*/var_dom,
-          /*predicate=*/predicate, /*analyzer=*/analyzer)) {
-    return result.value();
-  }
-  return arith::EvalSet(region->region, AsIntSet(var_dom));
+  return EstimateRegionUpperBound(
+      /*region=*/region->region,
+      /*var_dom=*/var_dom,
+      /*predicate=*/predicate, /*analyzer=*/analyzer);
 }
 
 /*!

--- a/src/tir/schedule/utils.h
+++ b/src/tir/schedule/utils.h
@@ -249,24 +249,6 @@ inline bool IsThreadIdx(const runtime::ThreadScope& thread_scope) {
   return thread_scope.rank == 1 && thread_scope.dim_index >= 0;
 }
 
-/******** Integer set ********/
-
-/*!
- * \brief Converts the Ranges to IntSets
- * \param var_dom The ranges of variables
- * \return The integer sets of the variables
- */
-inline Map<Var, arith::IntSet> AsIntSet(const Map<Var, Range>& var_dom) {
-  std::unordered_map<Var, arith::IntSet, ObjectPtrHash, ObjectPtrEqual> result;
-  result.reserve(var_dom.size());
-  for (auto kv : var_dom) {
-    Var& var = kv.first;
-    Range& range = kv.second;
-    result.emplace(std::move(var), arith::IntSet::FromRange(std::move(range)));
-  }
-  return {result.begin(), result.end()};
-}
-
 /**************** Loop extents ****************/
 
 /*!

--- a/src/tir/transforms/compact_buffer_region.cc
+++ b/src/tir/transforms/compact_buffer_region.cc
@@ -88,7 +88,7 @@ NDIntSet NDIntSetEval(Region region, PrimExpr predicate,
     var_dom[GetRef<Var>(it.first)] = it.second.CoverRange(Range::FromMinExtent(0, 0));
   }
   Optional<Array<arith::IntSet>> eval_res =
-      arith::EstimateRegionLowerBound(region, var_dom, predicate, analyzer);
+      arith::EstimateRegionUpperBound(region, var_dom, predicate, analyzer);
   if (eval_res.defined()) {
     return NDIntSet(eval_res.value().begin(), eval_res.value().end());
   }

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -911,6 +911,7 @@ def test_complex_case_1():
 
 def test_compact_dependent_buffer_indices():
     """Check the upper bound on different indices could be independently estimated."""
+
     @T.prim_func
     def diagonal_access():
         for i in range(8):
@@ -936,6 +937,7 @@ def test_compact_dependent_buffer_indices():
 
 def test_compact_dependent_buffer_indices_of_packed_matmul():
     """Check the outer dimension of the packed M-dim should be compacted to 1 wrt split condition."""
+
     @T.prim_func
     def nonuniform_packed_matmul_write_cache(
         A: T.Buffer[(1020, 64), "float32"],

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -909,5 +909,103 @@ def test_complex_case_1():
     _check(func, compacted_func)
 
 
+def test_compact_dependent_buffer_indices():
+    """Check the upper bound on different indices could be independently estimated."""
+    @T.prim_func
+    def diagonal_access():
+        for i in range(8):
+            with T.block():
+                A = T.alloc_buffer((256, 256), "float32")
+                for j, k in T.grid(8, 8):
+                    with T.block():
+                        T.where(j * 8 + k < 60)
+                        A[i * 64 + j * 8 + k, i * 64 + j * 8 + k] = 1.0
+
+    @T.prim_func
+    def diagonal_access_compacted() -> None:
+        for i in T.serial(8):
+            with T.block():
+                A = T.alloc_buffer([60, 60], dtype="float32")
+                for j, k in T.grid(8, 8):
+                    with T.block():
+                        T.where(j * 8 + k < 60)
+                        A[j * 8 + k, j * 8 + k] = 1.0
+
+    _check(diagonal_access, diagonal_access_compacted)
+
+
+def test_compact_dependent_buffer_indices_of_packed_matmul():
+    """Check the outer dimension of the packed M-dim should be compacted to 1 wrt split condition."""
+    @T.prim_func
+    def nonuniform_packed_matmul_write_cache(
+        A: T.Buffer[(1020, 64), "float32"],
+        B: T.Buffer[(1000, 64), "float32"],
+        C: T.Buffer[(1020, 1000), "float32"],
+    ):
+        for i0, i1 in T.grid(4, 1):
+            with T.block():
+                C_local2 = T.alloc_buffer([4, 1, 16, 1000, 16], dtype="float32", scope="local")
+                C_local1 = T.alloc_buffer([1020, 1000], dtype="float32", scope="local")
+                for ax0, ax1, ax2 in T.grid(255, 1000, 64):
+                    with T.block("matmul"):
+                        if ax2 == 0:
+                            C_local1[i0 * 255 + ax0, ax1] = 0
+                        C_local1[i0 * 255 + ax0, ax1] = (
+                            C_local1[i0 * 255 + ax0, ax1] + A[i0 * 255 + ax0, ax2] * B[ax1, ax2]
+                        )
+                for ax0, ax1 in T.grid(255, 1000):
+                    with T.block("st1"):
+                        C_local2[
+                            (i0 * 255 + ax0) // 255,
+                            0,
+                            (i0 * 255 + ax0) % 255 // 16,
+                            ax1,
+                            (i0 * 255 + ax0) % 255 % 16,
+                        ] = C_local1[i0 * 255 + ax0, ax1]
+                for ax0, ax1, ax2 in T.grid(16, 16, 1000):
+                    with T.block("st2"):
+                        T.where(ax0 * 16 + ax1 < 255)
+                        C[i0 * 255 + (ax0 * 16 + ax1), i1 * 1000 + ax2] = C_local2[
+                            (i0 * 255 + ax0 * 16 + ax1) // 255,
+                            0,
+                            (i0 * 255 + ax0 * 16 + ax1) % 255 // 16,
+                            i1 * 1000 + ax2,
+                            (i0 * 255 + ax0 * 16 + ax1) % 255 % 16,
+                        ]
+
+    @T.prim_func
+    def nonuniform_packed_matmul_write_cache_compacted(
+        A: T.Buffer[(1020, 64), "float32"],
+        B: T.Buffer[(1000, 64), "float32"],
+        C: T.Buffer[(1020, 1000), "float32"],
+    ) -> None:
+        for i0, i1 in T.grid(4, 1):
+            with T.block():
+                C_local2 = T.alloc_buffer([1, 1, 15, 1000, 16], dtype="float32", scope="local")
+                C_local1 = T.alloc_buffer([255, 1000], dtype="float32", scope="local")
+                for ax0, ax1, ax2 in T.grid(255, 1000, 64):
+                    with T.block("matmul"):
+                        if ax2 == 0:
+                            C_local1[ax0, ax1] = 0
+                        C_local1[ax0, ax1] = (
+                            C_local1[ax0, ax1] + A[i0 * 255 + ax0, ax2] * B[ax1, ax2]
+                        )
+                for ax0, ax1 in T.grid(255, 1000):
+                    with T.block("st1"):
+                        C_local2[0, 0, ax0 // 16, ax1, ax0 % 16] = C_local1[ax0, ax1]
+                for ax0, ax1, ax2 in T.grid(16, 16, 1000):
+                    with T.block("st2"):
+                        T.where(ax0 * 16 + ax1 < 255)
+                        C[i0 * 255 + ax0 * 16 + ax1, ax2] = C_local2[
+                            (ax0 * 16 + ax1) // 255,
+                            0,
+                            (ax0 * 16 + ax1) % 255 // 16,
+                            ax2,
+                            (ax0 * 16 + ax1) % 255 % 16,
+                        ]
+
+    _check(nonuniform_packed_matmul_write_cache, nonuniform_packed_matmul_write_cache_compacted)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Hi, this change wants to add some minor updation to region estimator used by buffer compaction:
- Add and clearify among `EstimateRegionStrictBound`, `EstimateRegionLowerBound` and `EstimateRegionUpperBound`
   
  Originally we have `EstimateRegionLowerBound`, actually it implements strict bound estimation IMO. Now add `upper` and `strict` version for where we actually want them.

- When estimating upperbounds (eg. in buffer compaction), try estimate each dimension independently when they are dependent accesses where `EstimateRegionLowerBound` is expected to fail. 

  Eg, `A[i, i], 3 < i < 16`  fails via `EstimateRegionLowerBound` who check indices be independent. But we can still try best to invoke strict bound analysis on each dimension individually.

- If range->extent == 1 for `EvalSet(range, dom)`, invoke `EvalSet(range->min, dom)` instead.
  
  Eg, `EvalSet([k*k, k*k+1), dom_k)` results to [-inf, +inf] due to current algorithm limitation but  `EvalSet(k*k, dom_k)` results to a range which makes more sense.
    
cc @Hzfengsy @junrushao @junrushao1994 @spectrometerHBH