### PR TITLE
[CI] Set test dependency on "transformers" package with pytest.importorskip

### DIFF
--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -108,6 +108,10 @@ def test_meta_schedule_integration_extract_from_resnet():
 
 @requires_torch
 def test_meta_schedule_integration_extract_from_bert_base():
+    pytest.importorskip(
+        "transformers", reason="transformers package is required to import bert_base"
+    )
+
     expected = {
         "fused_nn_dense_2": (
             12,


### PR DESCRIPTION
`test_meta_schedule_integration_extract_from_bert_base` depends on the `transformers` package, which is not currently installed in our Docker images.

When running this test currently, it fails with an ImportError. This patch makes this dependency explicit and will make the test to be skipped when the dependency is not installed.

`test_meta_schedule_integration_extract_from_bert_base` is part of the integration tests, which is currently only running on AArch64 and CPU image (both not at the moment with torch installed in the live CI system), so this is another issue to be understood/fixed.

cc @Mousius @NicolaLancellotti @areusch @ashutosh-arm @driazati @gigiblender