### PR TITLE
[microTVM] Replace static fixtures with parameterization

### DIFF
--- a/python/tvm/micro/testing/pytest_plugin.py
+++ b/python/tvm/micro/testing/pytest_plugin.py
@@ -62,10 +62,14 @@ def pytest_addoption(parser):
     )
 
 
-# We have to dynamically parameterize based on platform. This is superior to
-# using regular fixtures, as it ensures the platform and board will be included
-# in the resulting Junit XML file.
 def pytest_generate_tests(metafunc):
+    """Hooks into pytest to add platform and board fixtures to tests that
+    require them. To make sure that "platform" and "board" are treated as
+    parameters for the appropriate tests (and included in the test names),
+    we add them as function level parametrizations. This prevents data
+    from being overwritten in Junit XML files if multiple platforms
+    or boards are tested. """
+
     for argument in ["platform", "board"]:
         if argument in metafunc.fixturenames:
             value = metafunc.config.getoption(f"--{argument}", default=None)

--- a/python/tvm/micro/testing/pytest_plugin.py
+++ b/python/tvm/micro/testing/pytest_plugin.py
@@ -68,13 +68,15 @@ def pytest_addoption(parser):
 def pytest_generate_tests(metafunc):
     for argument in ["platform", "board"]:
         if argument in metafunc.fixturenames:
-            if f"--{argument}" in metafunc.config.invocation_params.args:
-                metafunc.parametrize(argument, [metafunc.config.getoption(f"--{argument}")])
-            else:
+            value = metafunc.config.getoption(f"--{argument}", default=None)
+
+            if not value:
                 raise ValueError(
                     f"Test {metafunc.function.__name__} in module {metafunc.module.__name__} "
                     f"requires a --{argument} argument, but none was given."
                 )
+
+            metafunc.parametrize(argument, [metafunc.config.getoption(f"--{argument}")])
 
 
 @pytest.fixture(scope="session")

--- a/python/tvm/micro/testing/pytest_plugin.py
+++ b/python/tvm/micro/testing/pytest_plugin.py
@@ -76,6 +76,7 @@ def pytest_generate_tests(metafunc):
                     f"requires a --{argument} argument, but none was given."
                 )
 
+
 @pytest.fixture(scope="session")
 def microtvm_debug(request):
     return request.config.getoption("--microtvm-debug")

--- a/python/tvm/micro/testing/pytest_plugin.py
+++ b/python/tvm/micro/testing/pytest_plugin.py
@@ -68,7 +68,7 @@ def pytest_generate_tests(metafunc):
     parameters for the appropriate tests (and included in the test names),
     we add them as function level parametrizations. This prevents data
     from being overwritten in Junit XML files if multiple platforms
-    or boards are tested. """
+    or boards are tested."""
 
     for argument in ["platform", "board"]:
         if argument in metafunc.fixturenames:

--- a/python/tvm/micro/testing/utils.py
+++ b/python/tvm/micro/testing/utils.py
@@ -34,6 +34,11 @@ TIMEOUT_SEC = 10
 
 
 @lru_cache(maxsize=None)
+def get_supported_platforms():
+    return ["arduino", "platforms"]
+
+
+@lru_cache(maxsize=None)
 def get_supported_boards(platform: str):
     template = Path(tvm.micro.get_microtvm_template_projects(platform))
     with open(template / "boards.json") as f:

--- a/python/tvm/micro/testing/utils.py
+++ b/python/tvm/micro/testing/utils.py
@@ -35,7 +35,7 @@ TIMEOUT_SEC = 10
 
 @lru_cache(maxsize=None)
 def get_supported_platforms():
-    return ["arduino", "platforms"]
+    return ["arduino", "zephyr"]
 
 
 @lru_cache(maxsize=None)

--- a/tests/micro/arduino/test_arduino_workflow.py
+++ b/tests/micro/arduino/test_arduino_workflow.py
@@ -37,9 +37,12 @@ This unit test simulates a simple user workflow, where we:
 """
 
 # Since these tests are sequential, we'll use the same project/workspace
-# directory for all tests in this file
+# directory for all tests in this file. Note that --board can't be loaded
+# from the fixture, since the fixture is function scoped (it has to be
+# for the tests to be named correctly via parameterization).
 @pytest.fixture(scope="module")
-def workflow_workspace_dir(request, board):
+def workflow_workspace_dir(request):
+    board = request.config.getoption("--board")
     return test_utils.make_workspace_dir("arduino_workflow", board)
 
 
@@ -48,9 +51,11 @@ def project_dir(workflow_workspace_dir):
     return workflow_workspace_dir / "project"
 
 
-# We MUST pass workspace_dir, not project_dir, or the workspace will be dereferenced too soon
+# We MUST pass workspace_dir, not project_dir, or the workspace will be dereferenced
+# too soon. We can't use the board fixture either for the reason mentioned above.
 @pytest.fixture(scope="module")
-def project(board, arduino_cli_cmd, microtvm_debug, workflow_workspace_dir):
+def project(request, arduino_cli_cmd, microtvm_debug, workflow_workspace_dir):
+    board = request.config.getoption("--board")
     return test_utils.make_kws_project(
         board, arduino_cli_cmd, microtvm_debug, workflow_workspace_dir
     )

--- a/tests/micro/common/conftest.py
+++ b/tests/micro/common/conftest.py
@@ -17,19 +17,3 @@
 pytest_plugins = [
     "tvm.micro.testing.pytest_plugin",
 ]
-
-import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--platform",
-        required=True,
-        choices=["arduino", "zephyr"],
-        help="Platform to run tests with",
-    )
-
-
-@pytest.fixture
-def platform(request):
-    return request.config.getoption("--platform")


### PR DESCRIPTION
#12207 went a long way to improving microTVM code reuse, but introduced an unintentional? change. Previously, the full `pytest` names of microTVM tests included the value of `board`, prepended to any paremeterization. For example, `test_rpc_large_array` would have the name:
```
tests.micro.zephyr.test_zephyr.test_rpc_large_array[nucleo_f746zg-(4*1024)]
```
This behavior was useful, as it meant that exported Junit XML files would correctly record which board the test was run on. However, after #12207 the names of tests stopped including this information:
```
tests.micro.zephyr.test_zephyr.test_rpc_large_array[(4*1024)]
```
This prevented Junit from differentiating between the tests when they were run on different boards, and instead just overwrote results on previous boards. Additionally, we never made this distinction for `common` tests that were parameterized by `platform`, so tests like `tests.micro.common.test_autotune.test_kws_autotune_workflow` would have one of the platforms overwrite the other (with whichever one finished last being the one that was ultimately reported).

---

This PR uses the `pytest_generate_tests` hook to fix this issue. Now, the `board` parameter is included in the test name as before, and the `platform` parameter will be included for any tests that use that fixture (e.g. common tests).

cc @alanmacd @gromero @mehrdadh