### PR TITLE
[ONNX] Fix test to disable default ONNX frontend constant folding

### DIFF
--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -169,7 +169,7 @@ def verify_load_model__onnx(model, **kwargs):
 def test_load_model__onnx(onnx_resnet50):
     # some CI environments wont offer onnx, so skip in case it is not present
     pytest.importorskip("onnx")
-    tvmc_model = verify_load_model__onnx(onnx_resnet50)
+    tvmc_model = verify_load_model__onnx(onnx_resnet50, freeze_params=False)
     # check whether one known value is part of the params dict
     assert "resnetv24_batchnorm0_gamma" in tvmc_model.params.keys()
     tvmc_model = verify_load_model__onnx(onnx_resnet50, freeze_params=True)


### PR DESCRIPTION
In TVM ONNX frontend, constants are folded by default, which makes `test_load_model__onnx` to fail because it is looking for "params" that were already converted into constants.

This patch fixes the test to disable constant folding so that we can assert that "params" in the model are present as expected.

cc @ashutosh-arm @driazati @areusch @Mousius @NicolaLancellotti 