### PR TITLE
[Docker][CI][RISC-V] Build riscv-isa-sim (spike) in ci_riscv Docker image to enable RISC-V unit testing

### DIFF
--- a/docker/Dockerfile.ci_cortexm
+++ b/docker/Dockerfile.ci_cortexm
@@ -110,11 +110,5 @@ RUN bash /install/ubuntu_install_ethosu_driver_stack.sh
 COPY install/ubuntu_install_vela.sh /install/ubuntu_install_vela.sh
 RUN bash /install/ubuntu_install_vela.sh
 
-#Install CSI-NN2
-COPY install/ubuntu_download_csinn2_compute_lib.sh /install/ubuntu_download_csinn2_compute_lib.sh
-RUN bash /install/ubuntu_download_csinn2_compute_lib.sh
-
 # Update PATH
 ENV PATH /opt/arm/gcc-arm-none-eabi/bin:/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4:$PATH
-ENV PATH /opt/csi-nn2/tools/gcc-toolchain/bin:$PATH
-ENV PATH /opt/csi-nn2/tools/qemu/bin:$PATH

--- a/docker/Dockerfile.ci_riscv
+++ b/docker/Dockerfile.ci_riscv
@@ -88,6 +88,10 @@ ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
 COPY install/ubuntu_download_xuantie_gcc_linux.sh /install/ubuntu_download_xuantie_gcc_linux.sh
 RUN bash /install/ubuntu_download_xuantie_gcc_linux.sh /opt/riscv/riscv64-unknown-linux-gnu
 
+# Download RISC-V gcc toolchain (baremetal)
+COPY install/ubuntu_download_xuantie_gcc_newlib.sh /install/ubuntu_download_xuantie_gcc_newlib.sh
+RUN bash /install/ubuntu_download_xuantie_gcc_newlib.sh /opt/riscv/riscv64-unknown-elf
+
 # Install RISC-V QEMU
 COPY install/ubuntu_download_xuantie_qemu.sh /install/ubuntu_download_xuantie_qemu.sh
 RUN bash /install/ubuntu_download_xuantie_qemu.sh /opt/riscv/qemu/
@@ -98,4 +102,5 @@ RUN bash /install/ubuntu_download_csinn2_compute_lib.sh
 
 # Update PATH
 ENV PATH /opt/riscv/riscv64-unknown-linux-gnu/bin:$PATH
+ENV PATH /opt/riscv/riscv64-unknown-elf/bin:$PATH
 ENV PATH /opt/riscv/qemu/bin:$PATH

--- a/docker/Dockerfile.ci_riscv
+++ b/docker/Dockerfile.ci_riscv
@@ -84,10 +84,18 @@ COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
 RUN bash /install/ubuntu_install_zephyr.sh
 ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
 
-#Install CSI-NN2
+# Download RISC-V gcc toolchain (linux)
+COPY install/ubuntu_download_xuantie_gcc_linux.sh /install/ubuntu_download_xuantie_gcc_linux.sh
+RUN bash /install/ubuntu_download_xuantie_gcc_linux.sh /opt/riscv/riscv64-unknown-linux-gnu
+
+# Install RISC-V QEMU
+COPY install/ubuntu_download_xuantie_qemu.sh /install/ubuntu_download_xuantie_qemu.sh
+RUN bash /install/ubuntu_download_xuantie_qemu.sh /opt/riscv/qemu/
+
+# Install CSI-NN2
 COPY install/ubuntu_download_csinn2_compute_lib.sh /install/ubuntu_download_csinn2_compute_lib.sh
 RUN bash /install/ubuntu_download_csinn2_compute_lib.sh
 
 # Update PATH
-ENV PATH /opt/csi-nn2/tools/gcc-toolchain/bin:$PATH
-ENV PATH /opt/csi-nn2/tools/qemu/bin:$PATH
+ENV PATH /opt/riscv/riscv64-unknown-linux-gnu/bin:$PATH
+ENV PATH /opt/riscv/qemu/bin:$PATH

--- a/docker/Dockerfile.ci_riscv
+++ b/docker/Dockerfile.ci_riscv
@@ -100,7 +100,12 @@ RUN bash /install/ubuntu_download_xuantie_qemu.sh /opt/riscv/qemu/
 COPY install/ubuntu_download_csinn2_compute_lib.sh /install/ubuntu_download_csinn2_compute_lib.sh
 RUN bash /install/ubuntu_download_csinn2_compute_lib.sh
 
+# Build spike (riscv-isa-sim) and proxy kernel (pk)
+COPY install/ubuntu_install_spike_sim.sh /install/ubuntu_install_spike_sim.sh
+RUN bash /install/ubuntu_install_spike_sim.sh /opt/riscv/riscv64-unknown-elf/
+
 # Update PATH
 ENV PATH /opt/riscv/riscv64-unknown-linux-gnu/bin:$PATH
 ENV PATH /opt/riscv/riscv64-unknown-elf/bin:$PATH
 ENV PATH /opt/riscv/qemu/bin:$PATH
+ENV PATH /opt/riscv/spike/bin:$PATH

--- a/docker/install/ubuntu_download_csinn2_compute_lib.sh
+++ b/docker/install/ubuntu_download_csinn2_compute_lib.sh
@@ -23,19 +23,21 @@ install_path="/opt/csi-nn2"
 # Clone CSI-NN2 Compute Library source code
 git clone --depth 1 --branch 1.12.2 https://github.com/T-head-Semi/csi-nn2.git ${install_path}
 
-# download cross-compiler when not building natively.
-# riscv gcc toolchain will be downloaded to "/path/csi-nn2/tools/gcc-toolchain".
+# The toolchain is downloaded in: ubuntu_download_xuantie_gcc_linux.sh
 cd ${install_path}
-./script/download_toolchain.sh
-
-# download custom QEMU to "/path/csi-nn2/tools/qemu".
-./script/download_qemu.sh
 
 # build csinn2 lib for x86 and c906
 # lib will be installed in /path/csi-nn2/install
+
 # for x86
-make -j4; cd x86_build; make install; cd -
+make -j4
+cd x86_build
+make install
+cd -
+
 # for c906
 mkdir -p riscv_build; cd riscv_build
-cmake ../ -DBUILD_RISCV=ON; make -j4; make install; cd -
-
+export RISCV_GNU_GCC_PATH=/opt/riscv/riscv64-unknown-linux-gnu/bin
+cmake ../ -DBUILD_RISCV=ON
+make -j4
+make install; cd -

--- a/docker/install/ubuntu_download_xuantie_gcc_linux.sh
+++ b/docker/install/ubuntu_download_xuantie_gcc_linux.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+ubuntu_install_spike_sim.sh
+
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+function show_usage() {
+    cat <<EOF
+Usage: docker/install/ubuntu_download_xuantie_gcc_linux.sh <INSTALLATION_PATH>
+INSTALLATION_PATH is the installation path for the toolchain.
+EOF
+}
+
+if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then
+    show_usage
+    exit 1
+fi
+
+INSTALLATION_PATH=$1
+shift
+
+# Create installation path directory
+mkdir -p "${INSTALLATION_PATH}"
+
+# Download and extract RISC-V gcc
+RISCV_GCC_VERSION="2.6.0"
+RISCV_GCC_ID="1659325511536"
+RISCV_GCC_KERNEL_VERSION="5.10.4"
+RISCV_GCC_DATE="20220715"
+RISCV_GCC_ARCH="x86_64"
+RISCV_GCC_BASE="Xuantie-900-gcc-linux-${RISCV_GCC_KERNEL_VERSION}-glibc-${RISCV_GCC_ARCH}-V${RISCV_GCC_VERSION}-${RISCV_GCC_DATE}"
+RISCV_GCC_EXT="tar.gz"
+RISCV_GCC_URL="https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//${RISCV_GCC_ID}/${RISCV_GCC_BASE}.${RISCV_GCC_EXT}"
+DOWNLOAD_PATH="/tmp/${RISCV_GCC_BASE}.${RISCV_GCC_EXT}"
+
+wget ${RISCV_GCC_URL} -O "${DOWNLOAD_PATH}"
+tar -xf "${DOWNLOAD_PATH}" -C "${INSTALLATION_PATH}" --strip-components=1
+rm $DOWNLOAD_PATH
+echo "SUCCESS"

--- a/docker/install/ubuntu_download_xuantie_gcc_newlib.sh
+++ b/docker/install/ubuntu_download_xuantie_gcc_newlib.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+ubuntu_install_spike_sim.sh
+
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+function show_usage() {
+    cat <<EOF
+Usage: docker/install/ubuntu_download_xuantie_gcc_newlib.sh <INSTALLATION_PATH>
+INSTALLATION_PATH is the installation path for the toolchain.
+EOF
+}
+
+if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then
+    show_usage
+    exit 1
+fi
+
+INSTALLATION_PATH=$1
+shift
+
+# Create installation path directory
+mkdir -p "${INSTALLATION_PATH}"
+
+# Download and extract RISC-V gcc
+RISCV_GCC_VERSION="2.6.0"
+RISCV_GCC_ID="1659318201401"
+RISCV_GCC_DATE="20220715"
+RISCV_GCC_ARCH="x86_64"
+RISCV_GCC_BASE="Xuantie-900-gcc-elf-newlib-${RISCV_GCC_ARCH}-V${RISCV_GCC_VERSION}-${RISCV_GCC_DATE}"
+RISCV_GCC_EXT="tar.gz"
+# extra forward slash is required somehow
+RISCV_GCC_URL="https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//${RISCV_GCC_ID}/${RISCV_GCC_BASE}.${RISCV_GCC_EXT}"
+DOWNLOAD_PATH="/tmp/${RISCV_GCC_BASE}.${RISCV_GCC_EXT}"
+
+wget ${RISCV_GCC_URL} -O "${DOWNLOAD_PATH}"
+tar -xf "${DOWNLOAD_PATH}" -C "${INSTALLATION_PATH}" --strip-components=1
+rm $DOWNLOAD_PATH
+echo "SUCCESS"

--- a/docker/install/ubuntu_download_xuantie_qemu.sh
+++ b/docker/install/ubuntu_download_xuantie_qemu.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+function show_usage() {
+    cat <<EOF
+Usage: docker/install/ubuntu_download_xuantie_qemu.sh <INSTALLATION_PATH>
+INSTALLATION_PATH is the installation path for the tool.
+EOF
+}
+
+if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then
+    show_usage
+    exit 1
+fi
+
+INSTALLATION_PATH=$1
+
+# Create installation path directory
+mkdir -p "${INSTALLATION_PATH}"
+
+QEMU_RELEASE="1.12"
+QEMU_DATE="20220402-0353"
+QEMU_ARCH="x86_64-Ubuntu-18.04"
+QEMU_BASE="xuantie-qemu-${QEMU_ARCH}-${QEMU_DATE}"
+QEMU_EXT="tar.gz"
+QEMU_URL="https://github.com/T-head-Semi/csi-nn2/releases/download/v${QEMU_RELEASE}/${QEMU_BASE}.${QEMU_EXT}"
+DOWNLOAD_PATH="/tmp/${QEMU_BASE}.${QEMU_EXT}"
+
+wget ${QEMU_URL} -O "${DOWNLOAD_PATH}"
+tar -xf "${DOWNLOAD_PATH}" -C "${INSTALLATION_PATH}" --strip-components=1
+rm $DOWNLOAD_PATH
+
+# Remove non riscv64 binaries? (TODO)
+# ls $INSTALLATION_PATH/bin | grep -v qemu-riscv64 | xargs -i rm -rf $INSTALLATION_PATH/bin/{}
+# ls $INSTALLATION_PATH | grep -v bin | xargs -i rm -rf $INSTALLATION_PATH/{}
+
+echo "SUCCESS"

--- a/docker/install/ubuntu_download_xuantie_qemu.sh
+++ b/docker/install/ubuntu_download_xuantie_qemu.sh
@@ -37,12 +37,12 @@ INSTALLATION_PATH=$1
 # Create installation path directory
 mkdir -p "${INSTALLATION_PATH}"
 
-QEMU_RELEASE="1.12"
-QEMU_DATE="20220402-0353"
+QEMU_DATE="20220623-0307"
+QEMU_SOURCE_ID="1655972947885"
 QEMU_ARCH="x86_64-Ubuntu-18.04"
 QEMU_BASE="xuantie-qemu-${QEMU_ARCH}-${QEMU_DATE}"
 QEMU_EXT="tar.gz"
-QEMU_URL="https://github.com/T-head-Semi/csi-nn2/releases/download/v${QEMU_RELEASE}/${QEMU_BASE}.${QEMU_EXT}"
+QEMU_URL="https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//${QEMU_SOURCE_ID}/${QEMU_BASE}.${QEMU_EXT}"
 DOWNLOAD_PATH="/tmp/${QEMU_BASE}.${QEMU_EXT}"
 
 wget ${QEMU_URL} -O "${DOWNLOAD_PATH}"

--- a/docker/install/ubuntu_install_arduino.sh
+++ b/docker/install/ubuntu_install_arduino.sh
@@ -20,7 +20,6 @@ set -e
 set -u
 set -o pipefail
 
-export DEBIAN_FRONTEND=noninteractive
 apt-install-and-clear -y ca-certificates
 
 ARDUINO_CLI_VERSION="0.21.1"

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -22,6 +22,11 @@ set -u
 set -x
 set -o pipefail
 
+export DEBIAN_FRONTEND=noninteractive
+export TZ=Etc/UTC
+ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+echo $TZ > /etc/timezone
+
 # install libraries for building c++ core on ubuntu
 apt-get update && apt-install-and-clear -y --no-install-recommends \
     apt-transport-https \

--- a/docker/install/ubuntu_install_spike_sim.sh
+++ b/docker/install/ubuntu_install_spike_sim.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+ubuntu_install_spike_sim.sh
+
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+set -x
+
+function show_usage() {
+    cat <<EOF
+Usage: docker/install/ubuntu_install_spike_sim.sh <RISCV_PATH>
+RISCV_PATH is the installation path of the risc-v gcc.
+EOF
+}
+
+if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then
+    show_usage
+    exit -1
+fi
+
+export RISCV=$1
+export PATH=$RISCV/bin:$PATH
+shift
+
+export DEBIAN_FRONTEND=noninteractive
+export TZ=Etc/UTC
+sudo ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+echo $TZ > /etc/timezone
+
+sudo apt-install-and-clear -y --no-install-recommends device-tree-compiler
+
+# Install spike
+mkdir /tmp/spike
+cd /tmp/spike
+# TODO: freeze version?
+git clone https://github.com/riscv/riscv-isa-sim.git
+pushd riscv-isa-sim
+mkdir build
+cd build
+../configure --prefix=$RISCV --with-isa=RV32IMAC
+make -j`nproc`
+make install
+popd
+
+# Install pk
+git clone https://github.com/riscv/riscv-pk.git
+pushd riscv-pk
+
+# rv32imac
+mkdir build
+pushd build
+../configure --prefix=`pwd`/install --host=riscv64-unknown-elf --with-arch=rv32imac
+make -j`nproc`
+make install
+cp ./pk $RISCV/riscv64-unknown-elf/bin/pk
+popd
+
+git status
+
+# rv64imac
+mkdir build64
+pushd build64
+../configure --prefix=`pwd`/install --host=riscv64-unknown-elf --with-arch=rv64imac
+make -j`nproc`
+make install
+cp ./pk $RISCV/riscv64-unknown-elf/bin/pk64
+
+# cleanup
+rm -rf /tmp/spike

--- a/docker/install/ubuntu_install_spike_sim.sh
+++ b/docker/install/ubuntu_install_spike_sim.sh
@@ -39,11 +39,6 @@ export RISCV=$1
 export PATH=$RISCV/bin:$PATH
 shift
 
-export DEBIAN_FRONTEND=noninteractive
-export TZ=Etc/UTC
-sudo ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
-echo $TZ > /etc/timezone
-
 sudo apt-install-and-clear -y --no-install-recommends device-tree-compiler
 
 # Install spike

--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -21,11 +21,6 @@ set -u
 set -o pipefail
 set -x
 
-export DEBIAN_FRONTEND=noninteractive
-export TZ=Etc/UTC
-sudo ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
-echo $TZ > /etc/timezone
-
 sudo apt-install-and-clear -y --no-install-recommends \
      libsdl2-dev ca-certificates gnupg software-properties-common wget \
      git cmake ninja-build gperf \


### PR DESCRIPTION
## Context

See Discussion in https://discuss.tvm.apache.org/t/coordination-of-risc-v-integration-in-tvm/13133

## Summary

1. Update `Dockerfile.ci_riscv` to download RISC-V toolchain and compile Spike simulator (including proxy kernel)

   - Using SiFives GCC toolchain for Embedded targets (See below)
   - Two variants of proxy kernel (`pk`, `pk64`) are build to support `rv32gc` as well as `rv64gc` targets

2. Introduce AotTestRunner to use spike in unit tests (currently `rv32gc` only)

3. Enable spike based AoTTestRunner for AoT/CRT related test cases

## Future work

I have a followup ready based on this PR, which enable usage of spike for MicroTVM deployment (ProjectAPI Server).

## Questions

- Why not use existing CSI-NN GCC toolchain?

That toolchain (`Xuantie-900-gcc-linux`) is mainly targeting 64-bit devices capable of running Linux. While it could be used for 32-bit bare metal targets as well (using the `-static` compile flag), it is missing relevant multilib arches, such as `rv32gc+ilp32d` to be  usable. Thus, I use Sifives GCC (which does currenlty not support the RVV1.0 extension)

- Should we fix the version of spike being build or just use the latest development branch?


cc @Mousius @areusch @driazati @gigiblender