### PR TITLE
[AutoTVM] Introducing multi_filter into ConfigSpace autotvm

### DIFF
--- a/python/tvm/autotvm/tuner/ga_tuner.py
+++ b/python/tvm/autotvm/tuner/ga_tuner.py
@@ -21,7 +21,6 @@
 import numpy as np
 
 from .tuner import Tuner
-from .model_based_tuner import knob2point, point2knob
 
 
 class GATuner(Tuner):
@@ -49,41 +48,24 @@ class GATuner(Tuner):
 
         assert elite_num <= pop_size, "The number of elites must be less than population size"
 
-        # space info
-        self.space = task.config_space
-        self.dim_keys = []
-        self.dims = []
-        for k, v in self.space.space_map.items():
-            self.dim_keys.append(k)
-            self.dims.append(len(v))
-
-        self.visited = set([])
+        # random initialization
+        self.pop_size = min(self.pop_size, len(self.space))
+        self.elite_num = min(self.pop_size, self.elite_num)
+        self.visited = set(self.space.sample_ints(self.pop_size))
 
         # current generation
-        self.genes = []
+        self.genes = [self.space.point2knob(idx) for idx in self.visited]
         self.scores = []
         self.elites = []
         self.elite_scores = []
         self.trial_pt = 0
 
-        # random initialization
-        self.pop_size = min(self.pop_size, len(self.space))
-        self.elite_num = min(self.pop_size, self.elite_num)
-        for _ in range(self.pop_size):
-            tmp_gene = point2knob(np.random.randint(len(self.space)), self.dims)
-            while knob2point(tmp_gene, self.dims) in self.visited:
-                tmp_gene = point2knob(np.random.randint(len(self.space)), self.dims)
-
-            self.genes.append(tmp_gene)
-            self.visited.add(knob2point(tmp_gene, self.dims))
-
     def next_batch(self, batch_size):
         ret = []
-        for _ in range(batch_size):
+        while len(ret) < batch_size and self.has_next():
             gene = self.genes[self.trial_pt % self.pop_size]
             self.trial_pt += 1
-            ret.append(self.space.get(knob2point(gene, self.dims)))
-
+            ret.append(self.space.get(self.space.knob2point(gene)))
         return ret
 
     def update(self, inputs, results):
@@ -95,47 +77,43 @@ class GATuner(Tuner):
                 self.scores.append(0.0)
 
         if len(self.scores) >= len(self.genes) and len(self.visited) < len(self.space):
-            genes = self.genes + self.elites
-            scores = np.array(self.scores[: len(self.genes)] + self.elite_scores)
-
-            # reserve elite
-            self.elites, self.elite_scores = [], []
-            elite_indexes = np.argpartition(scores, -self.elite_num)[-self.elite_num :]
-            for ind in elite_indexes:
-                self.elites.append(genes[ind])
-                self.elite_scores.append(scores[ind])
-
-            # cross over
-            indices = np.arange(len(genes))
-            scores += 1e-8
-            scores /= np.max(scores)
-            probs = scores / np.sum(scores)
-            tmp_genes = []
-            for _ in range(self.pop_size):
-                p1, p2 = np.random.choice(indices, size=2, replace=False, p=probs)
-                p1, p2 = genes[p1], genes[p2]
-                point = np.random.randint(len(self.dims))
-                tmp_gene = p1[:point] + p2[point:]
-                tmp_genes.append(tmp_gene)
-
-            # mutation
             next_genes = []
-            for tmp_gene in tmp_genes:
-                for j, dim in enumerate(self.dims):
-                    if np.random.random() < self.mutation_prob:
-                        tmp_gene[j] = np.random.randint(dim)
+            # There is no reason to crossover or mutate since the size of the unvisited
+            # is no larger than the size of the population.
+            if len(self.space) - len(self.visited) <= self.pop_size:
+                for idx in range(self.space.range_length):
+                    if self.space.is_index_valid(idx) and idx not in self.visited:
+                        next_genes.append(self.space.point2knob(idx))
+                        self.visited.add(idx)
+            else:
+                genes = self.genes + self.elites
+                scores = np.array(self.scores[: len(self.genes)] + self.elite_scores)
 
-                if len(self.visited) < len(self.space):
-                    while knob2point(tmp_gene, self.dims) in self.visited:
-                        j = np.random.randint(len(self.dims))
-                        tmp_gene[j] = np.random.randint(
-                            self.dims[j]  # pylint: disable=invalid-sequence-index
-                        )
-                    next_genes.append(tmp_gene)
-                    self.visited.add(knob2point(tmp_gene, self.dims))
-                else:
-                    break
+                # reserve elite
+                self.elites, self.elite_scores = [], []
+                elite_indexes = np.argpartition(scores, -self.elite_num)[-self.elite_num :]
+                for ind in elite_indexes:
+                    self.elites.append(genes[ind])
+                    self.elite_scores.append(scores[ind])
 
+                indices = np.arange(len(genes))
+                scores += 1e-8
+                scores /= np.max(scores)
+                probs = scores / np.sum(scores)
+                while len(next_genes) < self.pop_size:
+                    # cross over
+                    p1, p2 = np.random.choice(indices, size=2, replace=False, p=probs)
+                    p1, p2 = genes[p1], genes[p2]
+                    point = np.random.randint(len(self.space.dims))
+                    tmp_gene = p1[:point] + p2[point:]
+                    # mutation
+                    for j, dim in enumerate(self.space.dims):
+                        if np.random.random() < self.mutation_prob:
+                            tmp_gene[j] = np.random.randint(dim)
+
+                    if self.space.is_index_valid(self.space.knob2point(tmp_gene)):
+                        next_genes.append(tmp_gene)
+                        self.visited.add(self.space.knob2point(tmp_gene))
             self.genes = next_genes
             self.trial_pt = 0
             self.scores = []

--- a/python/tvm/autotvm/tuner/sa_model_optimizer.py
+++ b/python/tvm/autotvm/tuner/sa_model_optimizer.py
@@ -25,8 +25,7 @@ import time
 
 import numpy as np
 
-from ..utils import sample_ints
-from .model_based_tuner import ModelOptimizer, knob2point, point2knob
+from .model_based_tuner import ModelOptimizer
 
 logger = logging.getLogger("autotvm")
 
@@ -60,10 +59,7 @@ class SimulatedAnnealingOptimizer(ModelOptimizer):
         log_interval=50,
     ):
         super(SimulatedAnnealingOptimizer, self).__init__()
-
         self.task = task
-        self.dims = [len(x) for x in self.task.config_space.space_map.values()]
-
         self.n_iter = n_iter
         self.temp = temp
         self.persistent = persistent
@@ -84,7 +80,7 @@ class SimulatedAnnealingOptimizer(ModelOptimizer):
         if self.persistent and self.points is not None:
             points = self.points
         else:
-            points = np.array(sample_ints(0, len(self.task.config_space), self.parallel_size))
+            points = self.task.config_space.sample_ints(self.parallel_size)
 
         scores = model.predict(points)
 
@@ -113,7 +109,7 @@ class SimulatedAnnealingOptimizer(ModelOptimizer):
         while k < n_iter and k < k_last_modify + early_stop:
             new_points = np.empty_like(points)
             for i, p in enumerate(points):
-                new_points[i] = random_walk(p, self.dims)
+                new_points[i] = self.task.config_space.random_walk(p)
 
             new_scores = model.predict(new_points)
 
@@ -157,32 +153,3 @@ class SimulatedAnnealingOptimizer(ModelOptimizer):
             self.points = points
 
         return [x[1] for x in heap_items]
-
-
-def random_walk(p, dims):
-    """random walk as local transition
-
-    Parameters
-    ----------
-    p: int
-        index of the ConfigEntity
-    dims: Array of int
-        sizes of each dimension
-
-    Returns
-    -------
-    new_p: int
-        new neighborhood index
-    """
-    # transform to knob form
-    old = point2knob(p, dims)
-    new = list(old)
-
-    # mutate
-    while new == old:
-        from_i = np.random.randint(len(old))
-        to_v = np.random.randint(dims[from_i])
-        new[from_i] = to_v
-
-    # transform to index form
-    return knob2point(new, dims)

--- a/python/tvm/autotvm/tuner/tuner.py
+++ b/python/tvm/autotvm/tuner/tuner.py
@@ -43,6 +43,7 @@ class Tuner(object):
         self.recorder = None
 
         self.task = task
+        self.space = self.task.config_space
 
         # keep the current best
         self.best_config = None

--- a/python/tvm/autotvm/utils.py
+++ b/python/tvm/autotvm/utils.py
@@ -19,8 +19,6 @@
 import logging
 import time
 
-from random import randrange
-
 import numpy as np
 import tvm.arith
 from tvm.tir import expr
@@ -55,36 +53,6 @@ def get_rank(values):
     ranks = np.empty_like(tmp)
     ranks[tmp] = np.arange(len(tmp))
     return ranks
-
-
-def sample_ints(low, high, m):
-    """
-    Sample m different integer numbers from [low, high) without replacement
-    This function is an alternative of `np.random.choice` when (high - low) > 2 ^ 32, in
-    which case numpy does not work.
-
-    Parameters
-    ----------
-    low: int
-        low point of sample range
-    high: int
-        high point of sample range
-    m: int
-        The number of sampled int
-
-    Returns
-    -------
-    ints: an array of size m
-    """
-    vis = set()
-    assert m <= high - low
-    while len(vis) < m:
-        new = randrange(low, high)
-        while new in vis:
-            new = randrange(low, high)
-        vis.add(new)
-
-    return list(vis)
 
 
 def pool_map(func, args, batch_size, verbose=False, pool=None):

--- a/python/tvm/topi/adreno/conv2d_nchw.py
+++ b/python/tvm/topi/adreno/conv2d_nchw.py
@@ -260,7 +260,11 @@ def schedule_conv2d_NCHWc_KCRSk(cfg, s, output):
     cfg.define_split("tile_rx", rx, num_outputs=2)
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
-
+    cfg.multi_filter(
+        filter=lambda entity: 32
+        <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
+        < 1024
+    )
     if cfg.is_fallback:
         get_default_conv2d_config(cfg, conv.shape[1], conv.shape[2], conv.shape[3])
     ##### space definition end #####

--- a/python/tvm/topi/adreno/conv2d_nchw.py
+++ b/python/tvm/topi/adreno/conv2d_nchw.py
@@ -261,7 +261,11 @@ def schedule_conv2d_NCHWc_KCRSk(cfg, s, output):
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
     cfg.multi_filter(
-        filter=lambda entity: 32
+        filter=lambda entity: (  # pylint: disable=chained-comparison
+            entity["tile_fc"].size[1] * entity["tile_y"].size[1] * entity["tile_x"].size[1]
+        )
+        <= 24
+        and 32
         <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
         < 1024
     )

--- a/python/tvm/topi/adreno/conv2d_nhwc.py
+++ b/python/tvm/topi/adreno/conv2d_nhwc.py
@@ -259,7 +259,11 @@ def schedule_conv2d_NHWC(cfg, s, output):
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
     cfg.multi_filter(
-        filter=lambda entity: 32
+        filter=lambda entity: (  # pylint: disable=chained-comparison
+            entity["tile_fc"].size[1] * entity["tile_y"].size[1] * entity["tile_x"].size[1]
+        )
+        <= 24
+        and 32
         <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
         < 1024
     )

--- a/python/tvm/topi/adreno/conv2d_nhwc.py
+++ b/python/tvm/topi/adreno/conv2d_nhwc.py
@@ -258,7 +258,11 @@ def schedule_conv2d_NHWC(cfg, s, output):
     cfg.define_split("tile_rx", rx, num_outputs=2)
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
-
+    cfg.multi_filter(
+        filter=lambda entity: 32
+        <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
+        < 1024
+    )
     if cfg.is_fallback:
         get_default_conv2d_config(cfg, conv.shape[3], conv.shape[1], conv.shape[2])
     ##### space definition end #####

--- a/python/tvm/topi/adreno/conv2d_winograd_common.py
+++ b/python/tvm/topi/adreno/conv2d_winograd_common.py
@@ -440,10 +440,9 @@ def schedule_conv2d_winograd(cfg, s, output, pre_computed):
         and entry.size[1] <= 16,
     )
     cfg.define_split("tile_rc", rcc, num_outputs=2)
-    # TODO: Uncomment the following lines when multi_filter will be introduced
-    # cfg.multi_filter(
-    # filter=lambda entity: entity["tile_y"].size[2] * entity["tile_x"].size[2] in range(32,1024)
-    # )
+    cfg.multi_filter(
+        filter=lambda entity: 32 <= (entity["tile_y"].size[2] * entity["tile_x"].size[2]) < 1024
+    )
     ##### space definition end #####
 
     # batch gemm

--- a/python/tvm/topi/adreno/depthwise_conv2d_nchw.py
+++ b/python/tvm/topi/adreno/depthwise_conv2d_nchw.py
@@ -214,6 +214,11 @@ def schedule_depthwise_conv2d_NCHWc_KCRSk(cfg, s, output):
     cfg.define_split("tile_rx", rx, num_outputs=2)
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
+    cfg.multi_filter(
+        filter=lambda entity: 32
+        <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
+        < 1024
+    )
 
     if cfg.is_fallback:
         get_default_conv2d_config(cfg, conv.shape[1], conv.shape[2], conv.shape[3])

--- a/python/tvm/topi/adreno/depthwise_conv2d_nchw.py
+++ b/python/tvm/topi/adreno/depthwise_conv2d_nchw.py
@@ -215,7 +215,11 @@ def schedule_depthwise_conv2d_NCHWc_KCRSk(cfg, s, output):
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
     cfg.multi_filter(
-        filter=lambda entity: 32
+        filter=lambda entity: (  # pylint: disable=chained-comparison
+            entity["tile_fc"].size[1] * entity["tile_y"].size[1] * entity["tile_x"].size[1]
+        )
+        <= 32
+        and 32
         <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
         < 1024
     )

--- a/python/tvm/topi/adreno/depthwise_conv2d_nhwc.py
+++ b/python/tvm/topi/adreno/depthwise_conv2d_nhwc.py
@@ -212,7 +212,11 @@ def schedule_depthwise_conv2d_NHWC_HWOI(cfg, s, output):
     cfg.define_knob("unroll_explicit", [0, 1])
 
     cfg.multi_filter(
-        filter=lambda entity: 32
+        filter=lambda entity: (  # pylint: disable=chained-comparison
+            entity["tile_fc"].size[1] * entity["tile_y"].size[1] * entity["tile_x"].size[1]
+        )
+        <= 32
+        and 32
         <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
         < 1024
     )

--- a/python/tvm/topi/adreno/depthwise_conv2d_nhwc.py
+++ b/python/tvm/topi/adreno/depthwise_conv2d_nhwc.py
@@ -211,6 +211,11 @@ def schedule_depthwise_conv2d_NHWC_HWOI(cfg, s, output):
     cfg.define_knob("auto_unroll_max_step", [0, 512, 1500])
     cfg.define_knob("unroll_explicit", [0, 1])
 
+    cfg.multi_filter(
+        filter=lambda entity: 32
+        <= (entity["tile_fc"].size[2] * entity["tile_y"].size[2] * entity["tile_x"].size[2])
+        < 1024
+    )
     if cfg.is_fallback:
         get_default_conv2d_config(cfg, conv.shape[3], conv.shape[1], conv.shape[2])
     ##### space definition end #####

--- a/tests/python/topi/python/test_topi_conv2d_hwnc_tensorcore.py
+++ b/tests/python/topi/python/test_topi_conv2d_hwnc_tensorcore.py
@@ -175,8 +175,8 @@ def verify_feature_length():
 
     space = task.config_space
 
-    idx1 = np.random.randint(len(space))
-    idx2 = np.random.randint(len(space))
+    idx1 = space.get_rand_index()
+    idx2 = space.get_rand_index()
 
     cfg = space.get(idx1)
     sch, arg_bufs = task.instantiate(cfg)

--- a/tests/python/unittest/test_autotvm_ga_tuner.py
+++ b/tests/python/unittest/test_autotvm_ga_tuner.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test genetic algorithm tuner"""
+
+from tvm.testing.autotvm import DummyRunner, get_sample_task
+from tvm import autotvm
+
+
+def test_ga_tuner():
+    """Test GATuner"""
+    # Test population size smaller than space size tuning configuration
+    task, _ = get_sample_task()
+    tuner = autotvm.tuner.GATuner(task, pop_size=32)
+    valid_indexes = list(
+        filter(lambda idx: tuner.space.is_index_valid(idx), range(tuner.space.range_length))
+    )
+    assert tuner.visited.issubset(valid_indexes)
+    assert tuner.pop_size == len(tuner.visited) == len(tuner.genes)
+    assert len(tuner.space) == 64
+
+    measure_option = autotvm.measure_option(builder=autotvm.LocalBuilder(), runner=DummyRunner())
+    tuner.tune(n_trial=len(tuner.space), measure_option=measure_option)
+    assert tuner.visited.issubset(valid_indexes)
+
+    # Test population size bigger than space size tuning configuration
+    task, _ = get_sample_task()
+    tuner = autotvm.tuner.GATuner(task, pop_size=100)
+    valid_indexes = list(
+        filter(lambda idx: tuner.space.is_index_valid(idx), range(tuner.space.range_length))
+    )
+    assert tuner.visited.issubset(valid_indexes)
+    assert tuner.pop_size == len(tuner.visited) == len(tuner.genes)
+    assert len(tuner.space) == 64
+
+    measure_option = autotvm.measure_option(builder=autotvm.LocalBuilder(), runner=DummyRunner())
+    tuner.tune(n_trial=len(tuner.space), measure_option=measure_option)
+    assert tuner.visited.issubset(valid_indexes)
+
+    # Test population size smaller than multi-filtered space size tuning configuration
+    task, _ = get_sample_task()
+    task.config_space.multi_filter(
+        filter=lambda entity: 8 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+    tuner = autotvm.tuner.GATuner(task, pop_size=32)
+    valid_indexes = list(
+        filter(lambda idx: tuner.space.is_index_valid(idx), range(tuner.space.range_length))
+    )
+    assert tuner.visited.issubset(valid_indexes)
+    assert tuner.pop_size == len(tuner.visited) == len(tuner.genes)
+    assert len(tuner.space) == 43
+
+    measure_option = autotvm.measure_option(builder=autotvm.LocalBuilder(), runner=DummyRunner())
+    tuner.tune(n_trial=len(tuner.space), measure_option=measure_option)
+    assert tuner.visited.issubset(valid_indexes)
+
+    # Test population size bigger than multi-filtered space size tuning configuration
+    task, _ = get_sample_task()
+    task.config_space.multi_filter(
+        filter=lambda entity: 8 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+    tuner = autotvm.tuner.GATuner(task, pop_size=100)
+    valid_indexes = list(
+        filter(lambda idx: tuner.space.is_index_valid(idx), range(tuner.space.range_length))
+    )
+    assert tuner.visited.issubset(valid_indexes)
+    assert tuner.pop_size == len(tuner.visited) == len(tuner.genes)
+    assert len(tuner.space) == 43
+
+    measure_option = autotvm.measure_option(builder=autotvm.LocalBuilder(), runner=DummyRunner())
+    tuner.tune(n_trial=len(tuner.space), measure_option=measure_option)
+    assert tuner.visited.issubset(valid_indexes)
+
+
+if __name__ == "__main__":
+    test_ga_tuner()

--- a/tests/python/unittest/test_autotvm_index_tuner.py
+++ b/tests/python/unittest/test_autotvm_index_tuner.py
@@ -19,10 +19,9 @@
 import multiprocessing
 from tvm.testing.autotvm import DummyRunner, get_sample_task
 from tvm import autotvm
-from tvm.autotvm.tuner import GridSearchTuner, RandomTuner
 
 
-def test_gridsearch_tuner():
+def test_grid_search_tuner():
     """Test GridSearchTuner"""
 
     task, _ = get_sample_task()
@@ -30,28 +29,60 @@ def test_gridsearch_tuner():
 
     # When no range index, range_length should be the length of config space
     tuner = autotvm.tuner.GridSearchTuner(task)
-    assert tuner.range_length == len(task.config_space)
-    assert tuner.index_offset == 0
+    assert tuner.begin_idx == 0
+    assert tuner.end_idx == 64
+    assert tuner.index == 0
+    assert tuner.range_length == 64
+    assert tuner.visited_max == 64
 
     # With range index, range_length should be the length of the specified range
     tuner = autotvm.tuner.GridSearchTuner(task, range_idx=(8, 15))
+    assert tuner.begin_idx == 8
+    assert tuner.end_idx == 16
+    assert tuner.index == 8
     assert tuner.range_length == 8
-    assert tuner.index_offset == 8
+    assert tuner.visited_max == 8
 
     # Tuner should only focus on the specified range
     tuner.tune(n_trial=8, measure_option=measure_option)
-    assert tuner.counter == 8
+    assert len(tuner.visited) == 8
+    assert not tuner.has_next()
+
+    # With multi-filter
+    task, _ = get_sample_task()
+    task.config_space.multi_filter(
+        filter=lambda entity: 32 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+
+    tuner = autotvm.tuner.GridSearchTuner(task)
+    assert tuner.begin_idx == 0
+    assert tuner.end_idx == 64
+    assert tuner.index == 5
+    assert tuner.range_length == 64
+    assert tuner.visited_max == 34
+
+    # With range index, range_length should be the length of the specified range
+    tuner = autotvm.tuner.GridSearchTuner(task, range_idx=(8, 15))
+    assert tuner.begin_idx == 8
+    assert tuner.end_idx == 16
+    assert tuner.index == 12
+    assert tuner.range_length == 8
+    assert tuner.visited_max == 4
+
+    # Tuner should only focus on the specified range
+    tuner.tune(n_trial=8, measure_option=measure_option)
+    assert len(tuner.visited) == 4
     assert not tuner.has_next()
 
 
 def grid_search_spawn():
     assert multiprocessing.get_spawn_method(False) == "spawn"
-    test_gridsearch_tuner()
+    test_grid_search_tuner()
 
 
 def test_grid_search_tuner_spawn():
     ctx = multiprocessing.get_context("spawn")
-    p = ctx.Process(target=test_gridsearch_tuner)
+    p = ctx.Process(target=test_grid_search_tuner)
     p.start()
     p.join()
 
@@ -63,20 +94,38 @@ def test_random_tuner():
     measure_option = autotvm.measure_option(builder=autotvm.LocalBuilder(), runner=DummyRunner())
 
     tuner = autotvm.tuner.RandomTuner(task, range_idx=(8, 15))
+    assert tuner.begin_idx == 8
+    assert tuner.end_idx == 16
     assert tuner.range_length == 8
-    assert tuner.index_offset == 8
+    assert tuner.visited_max == 8
 
     # Tuner should only focus on the specified range and should visit all indices
     tuner.tune(n_trial=8, measure_option=measure_option)
-    assert tuner.counter == 8
+    assert len(tuner.visited) == 8
     assert not tuner.has_next()
-    visited = set()
     for idx in tuner.visited:
-        assert idx not in visited
+        assert 8 <= idx <= 15
+
+    # With multi-filter
+    task, _ = get_sample_task()
+    task.config_space.multi_filter(
+        filter=lambda entity: 32 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+    tuner = autotvm.tuner.RandomTuner(task, range_idx=(8, 15))
+    assert tuner.begin_idx == 8
+    assert tuner.end_idx == 16
+    assert tuner.range_length == 8
+    assert tuner.visited_max == 4
+
+    # Tuner should only focus on the specified range and should visit all indices
+    tuner.tune(n_trial=8, measure_option=measure_option)
+    assert len(tuner.visited) == 4
+    assert not tuner.has_next()
+    for idx in tuner.visited:
         assert 8 <= idx <= 15
 
 
 if __name__ == "__main__":
-    test_gridsearch_tuner()
-    test_gridsearch_tuner_spawn()
+    test_grid_search_tuner()
+    test_grid_search_tuner_spawn()
     test_random_tuner()

--- a/tests/python/unittest/test_autotvm_space.py
+++ b/tests/python/unittest/test_autotvm_space.py
@@ -16,12 +16,11 @@
 # under the License.
 """Test space definition primitives"""
 
-import tvm
 from tvm import te
 from tvm.autotvm.task.space import ConfigSpace, FallbackConfigEntity
 
 
-def gemm_func(cfg, N):
+def gemm_func(cfg, N, filter_y=None, filter_x=None):
     A = te.placeholder((N, N), name="A")
     B = te.placeholder((N, N), name="B")
 
@@ -32,8 +31,8 @@ def gemm_func(cfg, N):
 
     y, x = s[C].op.axis
 
-    cfg.define_split("tile_y", cfg.axis(y), num_outputs=2)
-    cfg.define_split("tile_x", cfg.axis(x), num_outputs=2)
+    cfg.define_split("tile_y", cfg.axis(y), num_outputs=2, filter=filter_y)
+    cfg.define_split("tile_x", cfg.axis(x), num_outputs=2, filter=filter_x)
 
     return s, [A, B, C]
 
@@ -42,7 +41,7 @@ def test_split():
     cfg = ConfigSpace()
 
     gemm_func(cfg, 128)
-    assert len(cfg) == 64
+    assert cfg.range_length == 64
     assert len(cfg.space_map["tile_y"]) == 8
 
     # test policy
@@ -102,5 +101,163 @@ def test_split():
         pass
 
 
+def _raises_exception(f):
+    try:
+        f()
+    except Exception:
+        return True
+    return False
+
+
+def test_multi_filter():
+    # create config without multi_filter
+    cfg = ConfigSpace()
+    gemm_func(cfg, 128)
+    # create config with multi_filter
+    cfg_mf = ConfigSpace()
+    gemm_func(cfg_mf, 128)
+    cfg_mf.multi_filter(
+        filter=lambda entity: 32 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+    # test len
+    assert len(cfg) == 64
+    assert len(cfg_mf) == 34
+    # test range_length
+    assert cfg.range_length == 64
+    assert cfg_mf.range_length == 64
+    # test dims
+    assert cfg.dims == [8, 8]
+    assert cfg_mf.dims == [8, 8]
+    # test is_index_valid
+    assert cfg.is_index_valid(0) is True
+    assert cfg.is_index_valid(15) is True
+    assert cfg_mf.is_index_valid(0) is False
+    assert cfg_mf.is_index_valid(15) is True
+    # test get
+    assert _raises_exception(lambda: cfg.get(0)) is False
+    assert _raises_exception(lambda: cfg.get(15)) is False
+    assert _raises_exception(lambda: cfg_mf.get(0)) is True
+    assert _raises_exception(lambda: cfg_mf.get(15)) is False
+    # test subrange_length
+    assert cfg.subrange_length(0, 64) == 64
+    assert cfg.subrange_length(0, 32) == 32
+    assert cfg.subrange_length(16, 32) == 16
+    assert cfg.subrange_length(16, 16) == 0
+    assert _raises_exception(lambda: cfg.subrange_length(0, 128))
+    assert _raises_exception(lambda: cfg.subrange_length(-64, 64))
+    assert _raises_exception(lambda: cfg.subrange_length(64, 0))
+    assert cfg_mf.subrange_length(0, 64) == 34
+    assert cfg_mf.subrange_length(0, 32) == 17
+    assert cfg_mf.subrange_length(16, 32) == 10
+    assert cfg_mf.subrange_length(16, 16) == 0
+    assert _raises_exception(lambda: cfg_mf.subrange_length(0, 128))
+    assert _raises_exception(lambda: cfg_mf.subrange_length(-64, 64))
+    assert _raises_exception(lambda: cfg_mf.subrange_length(64, 0))
+    # test point2knob
+    assert cfg.point2knob(0) == [0, 0]
+    assert cfg.point2knob(4) == [4, 0]
+    assert cfg.point2knob(8) == [0, 1]
+    assert cfg.point2knob(12) == [4, 1]
+    assert cfg_mf.point2knob(0) == [0, 0]
+    assert cfg_mf.point2knob(4) == [4, 0]
+    assert cfg_mf.point2knob(8) == [0, 1]
+    assert cfg_mf.point2knob(12) == [4, 1]
+    # test knob2point
+    assert cfg.knob2point([0, 0]) == 0
+    assert cfg.knob2point([4, 0]) == 4
+    assert cfg.knob2point([0, 1]) == 8
+    assert cfg.knob2point([4, 1]) == 12
+    assert cfg_mf.knob2point([0, 0]) == 0
+    assert cfg_mf.knob2point([4, 0]) == 4
+    assert cfg_mf.knob2point([0, 1]) == 8
+    assert cfg_mf.knob2point([4, 1]) == 12
+    # get_rand_index
+    cfg_valid_indexes = list(filter(lambda idx: cfg.is_index_valid(idx), range(cfg.range_length)))
+    assert cfg.get_rand_index() in cfg_valid_indexes
+    assert cfg.get_rand_index(start=15, end=16) == 15
+    assert 10 <= cfg.get_rand_index(start=10, end=20) < 20
+    assert cfg.get_rand_index(to_exclude=cfg_valid_indexes[:-1]) == cfg_valid_indexes[-1:][0]
+    cfg_mf_valid_indexes = list(
+        filter(lambda idx: cfg_mf.is_index_valid(idx), range(cfg_mf.range_length))
+    )
+    assert cfg_mf.get_rand_index() in cfg_mf_valid_indexes
+    assert cfg_mf.get_rand_index(start=15, end=16) == 15
+    assert 10 <= cfg_mf.get_rand_index(start=10, end=20) < 20
+    assert (
+        cfg_mf.get_rand_index(to_exclude=cfg_mf_valid_indexes[:-1]) == cfg_mf_valid_indexes[-1:][0]
+    )
+    # get_next_index
+    assert cfg.get_next_index(0) == 1
+    assert cfg.get_next_index(0, 1) == 1
+    assert cfg.get_next_index(0, 2) == 2
+    assert cfg.get_next_index(0, -1) is None
+    assert cfg.get_next_index(0, -2) is None
+    assert cfg.get_next_index(63) is None
+    assert cfg.get_next_index(63, 1) is None
+    assert cfg.get_next_index(63, 2) is None
+    assert cfg.get_next_index(63, -1) == 62
+    assert cfg.get_next_index(63, -2) == 61
+    assert cfg.get_next_index(60, 1, end=63) == 61
+    assert cfg.get_next_index(63, -1, start=60) == 62
+    assert cfg_mf.get_next_index(0) == 5
+    assert cfg_mf.get_next_index(0, 1) == 5
+    assert cfg_mf.get_next_index(0, 2) == 6
+    assert cfg_mf.get_next_index(0, -1) is None
+    assert cfg_mf.get_next_index(0, -2) is None
+    assert cfg_mf.get_next_index(63) is None
+    assert cfg_mf.get_next_index(63, 1) is None
+    assert cfg_mf.get_next_index(63, 2) is None
+    assert cfg_mf.get_next_index(63, -1) == 58
+    assert cfg_mf.get_next_index(63, -2) == 57
+    assert cfg_mf.get_next_index(60, 1, end=63) is None
+    assert cfg_mf.get_next_index(63, -1, start=60) is None
+    # test sample_ints
+    cfg_ints = cfg.sample_ints(5)
+    assert len(cfg_ints) == 5
+    assert set(cfg_ints).issubset(cfg_valid_indexes)
+    cfg_mf_ints = cfg_mf.sample_ints(5)
+    assert len(cfg_mf_ints) == 5
+    assert set(cfg_mf_ints).issubset(cfg_mf_valid_indexes)
+    # test random_walk
+    cfg_walk = cfg.random_walk(15)
+    assert cfg_walk != 15
+    assert cfg_walk in cfg_valid_indexes
+    cfg_mf_walk = cfg_mf.random_walk(15)
+    assert cfg_mf_walk != 15
+    assert cfg_mf_walk in cfg_mf_valid_indexes
+
+
+def test_filter_and_multi_filter():
+    # test the order: filter -> multi_filter
+    cfg = ConfigSpace()
+    gemm_func(cfg, 128, filter_y=lambda y: y.size[-1] < 64)
+    # after adding filter
+    assert len(cfg) == 48
+    assert cfg.range_length == 48
+    cfg.multi_filter(
+        filter=lambda entity: 32 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+    # after adding multi_filter
+    assert len(cfg) == 27
+    assert cfg.range_length == 48
+
+    # test the order: multi_filter -> filter
+    cfg = ConfigSpace()
+    s, (A, B, C) = gemm_func(cfg, 128, filter_y=None)
+    cfg.multi_filter(
+        filter=lambda entity: 32 <= (entity["tile_x"].size[1] * entity["tile_y"].size[1]) < 1024
+    )
+    # after adding multi_filter
+    assert len(cfg) == 34
+    assert cfg.range_length == 64
+    y, x = s[C].op.axis
+    cfg.define_split("tile_y", cfg.axis(y), num_outputs=2, filter=lambda y: y.size[-1] < 64)
+    # after adding filter
+    assert len(cfg) == 27
+    assert cfg.range_length == 48
+
+
 if __name__ == "__main__":
     test_split()
+    test_multi_filter()
+    test_filter_and_multi_filter()


### PR DESCRIPTION
### multi_filter can restrict combination of parameters in difference to the knob filter, that restricts only single parameter.

Here is a small example to show the workflow and the difference:

**Pre-requisites**
```
candidates = [[16, 64], [32, 32], [64, 16]]
filter = lambda v: v.size[0] != 16
multi_filter = lambda e: (e["tile_x"].size[0] + e["tile_y"].size[0]) <= 64
```
**Case 1 - without filtering**
```
cfg.define_split("tile_x", x, num_outputs=2, policy="candidate", candidate=candidates)
cfg.define_split("tile_y", y, num_outputs=2, policy="candidate", candidate=candidates)
```

> [('tile_x', [16, 64]), ('tile_y', [16, 64])],None,0
> [('tile_x', [32, 32]), ('tile_y', [16, 64])],None,1
> [('tile_x', [64, 16]), ('tile_y', [16, 64])],None,2
> [('tile_x', [16, 64]), ('tile_y', [32, 32])],None,3
> [('tile_x', [32, 32]), ('tile_y', [32, 32])],None,4
> [('tile_x', [64, 16]), ('tile_y', [32, 32])],None,5
> [('tile_x', [16, 64]), ('tile_y', [64, 16])],None,6
> [('tile_x', [32, 32]), ('tile_y', [64, 16])],None,7
> [('tile_x', [64, 16]), ('tile_y', [64, 16])],None,8

**Case 2 - with filter**
```
cfg.define_split("tile_x", x, num_outputs=2, policy="candidate", candidate=candidates, filter=filter)
cfg.define_split("tile_y", y, num_outputs=2, policy="candidate", candidate=candidates, filter=filter)
```

> [('tile_x', [32, 32]), ('tile_y', [32, 32])],None,0
> [('tile_x', [64, 16]), ('tile_y', [32, 32])],None,1
> [('tile_x', [32, 32]), ('tile_y', [64, 16])],None,2
> [('tile_x', [64, 16]), ('tile_y', [64, 16])],None,3

**Case 3 - with filter and multi_filter**
```
cfg.define_split("tile_x", x, num_outputs=2, policy="candidate", candidate=candidates, filter=filter)
cfg.define_split("tile_y", y, num_outputs=2, policy="candidate", candidate=candidates, filter=filter)
cfg.multi_filter(filter=multi_filter)
```

> [('tile_x', [32, 32]), ('tile_y', [32, 32])],None,0


Co-authored-by: Andrey Malyshev <elvin.nnov@gmail.com>
Co-authored-by: Egor Churaev <egor.churaev@gmail.com>

