### PR TITLE
[frontend][onnx]fix pad constant value is none

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1403,7 +1403,7 @@ class Pad(OnnxOpConverter):
     @classmethod
     def _impl_v11(cls, inputs, attr, params):
         pads = inputs[1]
-        if len(inputs) == 3:
+        if len(inputs) == 3 and inputs[2]:
             value = fold_constant(_op.take(inputs[2], _op.const(0)))
         else:
             value = 0.0

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -2027,6 +2027,7 @@ def test_pad(target, dev):
     verify_pad_v11(np.random.randn(2, 2).astype(np.float32), [0, 1, 0, 0], "constant", 0.0)
     verify_pad_v11(np.random.randn(2, 3).astype(np.float32), [1, 0, 0, 1], "constant", 0.0)
     verify_pad_v11(np.random.randn(3, 2).astype(np.float32), [0, 0, 1, 0], "constant", 5.0)
+    verify_pad_v11(np.random.randn(3, 2).astype(np.float32), [0, 0, 1, 0], "constant", False)
     verify_pad_v11(np.random.randn(1, 3, 4, 5).astype(np.float32), [0, 0, 1, 1, 0, 0, 1, 1], "edge")
     verify_pad_v11(
         np.random.randn(1, 3, 4, 5).astype(np.float32), [0, 0, 1, 1, 0, 0, 1, 1], "reflect"


### PR DESCRIPTION
hi, cc @AndrewZhaoLuo 
When I import my onnx model. I found my model get a error with pad. because the `pad` constant value is none. shown as follow:
<img width="729" alt="1661258976676" src="https://user-images.githubusercontent.com/50271153/186162163-c3727f00-1725-43d9-bc0e-09d872afed08.png">
It`s just a very little bug. So I fix it and no unnit test.

