### PR TITLE
[CI][CMSIS-NN] Running tests parallel using pytest-xdist

### DIFF
--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -57,5 +57,5 @@ python3 gallery/how_to/work_with_microtvm/micro_aot.py
 
 run_pytest ctypes python-relay-strategy-arm_cpu tests/python/relay/strategy/arm_cpu --enable-corstone300-tests
 run_pytest ctypes python-integration-m7-simd tests/python/integration/test_arm_mprofile_dsp.py --enable-corstone300-tests
-run_pytest ctypes python-integration-contrib-test_cmsisnn tests/python/contrib/test_cmsisnn
+run_pytest ctypes python-integration-contrib-test_cmsisnn tests/python/contrib/test_cmsisnn -n auto
 run_pytest ctypes python-integration-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto


### PR DESCRIPTION
Introducing -n auto for CMSIS-NN tests to
run them parallel with pytest-xdist. This
is needed because of additional parameterization
done over cpu variants.

cc @Mousius @areusch @driazati @gigiblender @leandron @lhutton1