### PR TITLE
[microNPU] Force compute_cycles_hint to be interpreted as an int64 value

### DIFF
--- a/python/tvm/contrib/ethosu/cascader/scheduler.py
+++ b/python/tvm/contrib/ethosu/cascader/scheduler.py
@@ -154,7 +154,11 @@ def apply_proposal(proposal: Proposal, sch: te.Schedule) -> None:
 
                 # Attach AttrStmt directly to npu op so it isn't removed by ReplaceOperators
                 npu_op = part.subgraph.output_tensor.op.input_tensors[0].op.input_tensors[0]
-                sch[npu_op].pragma(npu_op.op.axis[0], "compute_cycles_hint", compute_cycles)
+                # Force the pragma to interpret the compute cycles as an int64 value
+                compute_cycles_int64_cast = tvm.tir.IntImm("int64", compute_cycles)
+                sch[npu_op].pragma(
+                    npu_op.op.axis[0], "compute_cycles_hint", compute_cycles_int64_cast
+                )
 
         output_tensor_config = plan.output_config
         output_tensor = output_tensor_config.tensor


### PR DESCRIPTION
`compute_cycles` can be the size of an int64 value, however it seems that when that value is attached to the IR as a pragma from Python, it is interpreted as an `int`, rather than `int64_t`. This commit adds an explicit cast to ensure the value is interpreted correctly.

The reason these values started appearing very large and randomly is still yet to be solved, although the hope is that this fix will unblock CI.

The hope is that this will fix: #12511

cc @Mousius @ekalda @leandron @shingjan @cconvey