### PR TITLE
Add using directives for otherwise hidden virtual functions, NFC

### DIFF
--- a/src/relay/backend/annotate_used_memory.cc
+++ b/src/relay/backend/annotate_used_memory.cc
@@ -110,7 +110,7 @@ class AnnotateUsedMemoryMutator : public transform::DeviceAwareExprMutator {
   /*!
    * \brief Establish which let bindings have primitive function values.
    */
-  std::pair<Var, Expr> PreVisitLetBinding_(const Var& var, const Expr& value) {
+  std::pair<Var, Expr> PreVisitLetBinding_(const Var& var, const Expr& value) override {
     if (const auto* func_node = value.as<FunctionNode>()) {
       ICHECK(func_node->attrs.HasNonzeroAttr(attr::kPrimitive))
           << "Expect top-level functions to be primitive.";

--- a/src/relay/transforms/annotate_texture_storage.cc
+++ b/src/relay/transforms/annotate_texture_storage.cc
@@ -117,6 +117,8 @@ class StorageInfo : private transform::DeviceAwareExprVisitor {
   }
 
  private:
+  using transform::DeviceAwareExprVisitor::VisitExpr_;
+
   void Visit(const Expr& expr) {
     // Pre-order traversal to enable upward propagation
     // of consumer storage scopes to producers when desirable.
@@ -426,6 +428,8 @@ class RewriteVDStorageScopes : public transform::DeviceAwareExprMutator {
   using VarMap = std::unordered_map<Expr, Var, ObjectPtrHash, ObjectPtrEqual>;
 
  public:
+  using transform::DeviceAwareExprMutator::VisitExpr_;
+
   explicit RewriteVDStorageScopes(const Map<Expr, Map<Expr, Array<String>>>& storage_scope)
       : transform::DeviceAwareExprMutator(Optional<IRModule>()), storage_scope_(storage_scope) {}
 

--- a/src/relay/transforms/compiler_function_utils.cc
+++ b/src/relay/transforms/compiler_function_utils.cc
@@ -54,6 +54,8 @@ const FunctionNode* AsFunctionNode(const Expr& expr, const std::string& compiler
  */
 class Outliner : public MixedModeMutator {
  public:
+  using MixedModeMutator::VisitExpr_;
+
   Outliner(GlobalSymbolCache* cache, std::string compiler_filter, IRModule mod)
       : cache_(cache), compiler_filter_(std::move(compiler_filter)), mod_(std::move(mod)) {}
 


### PR DESCRIPTION
This silences warning
```
warning: 'foo' hides overloaded virtual functions [-Woverloaded-virtual]
```
typically caused by overriding only some overloads of `VisitExpr_` from a set defined in the base class.