### PR TITLE
[Hexagon] Fix missing pytest import

### DIFF
--- a/tests/python/contrib/test_hexagon/topi/test_cast_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_cast_slice.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """ Tests for Hexagon slice cast ops """
+import pytest
 import numpy as np
 
 import tvm
@@ -75,6 +76,7 @@ class TestCastF16F32Slice2d:
         """
         if hexagon_session._launcher._serial_number != "simulator":
             pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
+        
         target_hexagon = tvm.target.hexagon("v69")
         target = tvm.target.Target(target_hexagon, host=target_hexagon)
         cast_input = te.placeholder(input_shape, name="A", dtype=dtype)

--- a/tests/python/contrib/test_hexagon/topi/test_cast_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_cast_slice.py
@@ -76,7 +76,7 @@ class TestCastF16F32Slice2d:
         """
         if hexagon_session._launcher._serial_number != "simulator":
             pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11957")
-        
+
         target_hexagon = tvm.target.hexagon("v69")
         target = tvm.target.Target(target_hexagon, host=target_hexagon)
         cast_input = te.placeholder(input_shape, name="A", dtype=dtype)


### PR DESCRIPTION
Fix missing `import pytest` in a test file.

cc @driazati  