### PR TITLE
[CI][ONNX] Set test python.contrib.test_onnx.test_resize as xfail

### DIFF
--- a/tests/python/contrib/test_onnx.py
+++ b/tests/python/contrib/test_onnx.py
@@ -655,6 +655,7 @@ def test_cast():
             verify_cast(i, o_dtype)
 
 
+@pytest.mark.xfail(reason="Known failing test. See issue #12567.")
 def test_resize():
     """Resize unit test."""
 


### PR DESCRIPTION
`python.contrib.test_onnx.test_resize` is failing due to a numerical
accuracy issue, reported in #12567. This patch marks that test as
an xfail, so that other tests can be enabled, while this one is
investigated separately.

cc @Mousius @NicolaLancellotti @areusch @ashutosh-arm @driazati @gigiblender @lhutton1