### PR TITLE
[microNPU] Remove xfail from tests relating to #12511

### DIFF
--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -347,7 +347,6 @@ def test_ethosu_binary_elementwise(
         ([1, 4, 4], [4, 1]),
     ],
 )
-@pytest.mark.xfail(reason="See https://github.com/apache/tvm/issues/12511")
 def test_binary_add_with_non_4d_shapes(
     request,
     accel_type,
@@ -606,7 +605,6 @@ def test_ethosu_right_shift_binary_elemwise(
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
 @pytest.mark.parametrize("ifm_shape", [(3, 2), (1, 15, 11, 7), (3, 1, 12), (400,)])
 @pytest.mark.parametrize("ifm_scale, ifm_zp, ofm_scale, ofm_zp", [(1, 0, 1, 0), (0.015, 3, 0.2, 5)])
-@pytest.mark.xfail(reason="See https://github.com/apache/tvm/issues/12511")
 def test_ethosu_identity_codegen(
     request, ifm_shape, ifm_scale, ifm_zp, ofm_scale, ofm_zp, accel_type
 ):
@@ -655,7 +653,6 @@ def test_ethosu_identity_codegen(
         ((8, 7, 3), (-4, 1, 8, -2)),
     ],
 )
-@pytest.mark.xfail(reason="See https://github.com/apache/tvm/issues/12511")
 def test_relay_reshape_codegen(ifm_shape, new_shape, accel_type):
     np.random.seed(0)
 
@@ -688,7 +685,6 @@ def test_relay_reshape_codegen(ifm_shape, new_shape, accel_type):
         ([5000], [123], [2151]),
     ],
 )
-@pytest.mark.xfail(reason="See https://github.com/apache/tvm/issues/12511")
 def test_tflite_slice(request, accel_type, ifm_shape, begin, size):
     np.random.seed(0)
 
@@ -724,7 +720,6 @@ def test_tflite_strided_slice(accel_type, ifm_shape, begin, end):
     "ifm_shape",
     [[1, 5, 12, 4], [1, 1, 2], [4, 3, 2], [10, 20], [345]],
 )
-@pytest.mark.xfail(reason="See https://github.com/apache/tvm/issues/12511")
 def test_ethosu_unary_elementwise(
     request,
     accel_type,


### PR DESCRIPTION
Simply removes tests previously marked as xfail since the issue has now been resolved.

~Note: marked as draft since we should check recent CI runs after #12558 to make sure these tests are not silently failing.~



cc @Mousius