### PR TITLE
[TIR] Expose Vector-related API in Python

### DIFF
--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -52,6 +52,7 @@ from .op import tvm_stack_alloca, tvm_stack_make_shape, tvm_stack_make_array
 from .op import tvm_tuple, tvm_struct_get, tvm_struct_set
 from .op import address_of, lookup_param, assume, undef
 from .op import tvm_thread_allreduce, type_annotation, tvm_access_ptr, tvm_throw_last_error
+from .op import vectorlow, vectorhigh, vectorcombine
 from .op import infinity, reinterpret
 from .op import exp, exp2, exp10, log, log2, log10, log1p, ldexp, clz
 from .op import sin, sinh, asin, asinh

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -595,6 +595,63 @@ def tvm_throw_last_error():
     return call_intrin("handle", "tir.tvm_throw_last_error")
 
 
+def vectorlow(dtype, vec):
+    """Get the low level half of the vector
+
+    Parameters
+    ----------
+    dtype : str
+       The data type of the result.
+
+    vec : list
+       The input vector.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(dtype, "tir.vectorlow", vec)
+
+
+def vectorhigh(dtype, vec):
+    """Get the high level half of the vector
+
+    Parameters
+    ----------
+    dtype : str
+       The data type of the result.
+
+    vec : list
+       The input vector.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(dtype, "tir.vectorhigh", vec)
+
+
+def vectorcombine(dtype, vec1, vec2):
+    """Concat two vectors
+
+    Parameters
+    ----------
+    vec1 : list
+       The input vector.
+
+    vec2 : list
+       The input vector.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(dtype, "tir.vectorcombine", vec1, vec2)
+
+
 def ret(val):
     """Create a tir return expression
 

--- a/tests/python/unittest/test_tir_op_types.py
+++ b/tests/python/unittest/test_tir_op_types.py
@@ -104,6 +104,27 @@ def test_tir_op_tvm_throw_last_error():
     assert expr.op.name == "tir.tvm_throw_last_error"
 
 
+def test_tir_op_vectorlow():
+    buffer = tir.decl_buffer((4, 4), "int8", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="int8x16")
+    expr = tir.vectorlow("int8x8", vec)
+    assert expr.op.name == "tir.vectorlow"
+
+
+def test_tir_op_vectorhigh():
+    buffer = tir.decl_buffer((4, 4), "int8", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="int8x16")
+    expr = tir.vectorhigh("int8x8", vec)
+    assert expr.op.name == "tir.vectorhigh"
+
+
+def test_tir_op_vectorcombine():
+    buffer = tir.decl_buffer((4, 4), "int8", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="int8x16")
+    expr = tir.vectorcombine("int8x8", vec, vec)
+    assert expr.op.name == "tir.vectorcombine"
+
+
 def test_tir_op_TVMBackendAllocWorkspace():
     expr = tir.TVMBackendAllocWorkspace(0, 1, 2, 3, 4)
     assert expr.op.name == "tir.TVMBackendAllocWorkspace"
@@ -130,5 +151,8 @@ if __name__ == "__main__":
     test_tir_op_type_annotation()
     test_tir_op_tvm_access_ptr()
     test_tir_op_tvm_throw_last_error()
+    test_tir_op_vectorlow()
+    test_tir_op_vectorhigh()
+    test_tir_op_vectorcombine()
     test_tir_op_TVMBackendAllocWorkspace()
     test_tir_op_TVMBackendFreeWorkspace()


### PR DESCRIPTION
This PR exposes the following TIR operation in python:

`vectorlow`: tested [here](https://github.com/apache/tvm/blob/592148abf6866a41eefa736efca067d42f5aea86/python/tvm/tir/tensor_intrin/arm_cpu.py#L62)
`vectorhigh`: tested [here](https://github.com/apache/tvm/blob/592148abf6866a41eefa736efca067d42f5aea86/python/tvm/tir/tensor_intrin/arm_cpu.py#L79)
`vectorcombine`: add new unittest

Co-Authored-By: yongwww <yongcale@gmail.com>

cc @Hzfengsy @junrushao @junrushao1994
