### PR TITLE
[TIR] Preserve annotations after lower opaque block

### DIFF
--- a/tests/python/unittest/test_tir_transform_lower_opaque_block.py
+++ b/tests/python/unittest/test_tir_transform_lower_opaque_block.py
@@ -321,6 +321,47 @@ def test_annotated_loops():
     tvm.ir.assert_structural_equal(attr3.value, tvm.tir.FloatImm("float32", 0.0))
 
 
+def test_annotated_block():
+    @T.prim_func
+    def annotated_block() -> None:
+        with T.block():
+            T.block_attr({"pragma_1": "str_value", "pragma_2": 1, "pragma_3": 0.0})
+            T.evaluate(0)
+
+    mod = tvm.IRModule.from_expr(annotated_block)
+    mod = tvm.tir.transform.LowerOpaqueBlock()(mod)
+    attr1 = mod["main"].body
+    attr2 = attr1.body
+    attr3 = attr2.body
+    assert attr1.attr_key == "pragma_1" and attr1.value == "str_value"
+    assert attr2.attr_key == "pragma_2"
+    tvm.ir.assert_structural_equal(attr2.value, tvm.tir.IntImm("int32", 1))
+    assert attr3.attr_key == "pragma_3"
+    tvm.ir.assert_structural_equal(attr3.value, tvm.tir.FloatImm("float32", 0.0))
+
+
+def test_preserved_annotations():
+    @T.prim_func
+    def before(A: T.Buffer[8, "float32"], B: T.Buffer[8, "float32"]):
+        for i in T.serial(8, annotations={"k_0": 1, "k_1": [2, 3], "k_2": 4}):
+            with T.block("block"):
+                T.block_attr({"k_3": 3.14, "k_4": ""})
+                B[i] = A[i] + 1.0
+
+    @T.prim_func
+    def after(A: T.Buffer[8, "float32"], B: T.Buffer[8, "float32"]):
+        for i in T.serial(8, annotations={"k_0": 1, "k_1": [2, 3]}):
+            for _ in range(1, annotations={"k_3": 3.14}):
+                B[i] = A[i] + T.float32(1)
+
+    mod = tvm.IRModule.from_expr(before)
+    with tvm.transform.PassContext(
+        config={"tir.LowerOpaqueBlock": {"preserved_annotations": ["k_0", "k_1", "k_3"]}}
+    ):
+        mod = tvm.tir.transform.LowerOpaqueBlock()(mod)
+    tvm.ir.assert_structural_equal(mod["main"], after)
+
+
 def test_boolean_handling():
     _check(boolean_handling_before, boolean_handling_after)
 


### PR DESCRIPTION
Hi, there. The change aims to improve customization experience of TIR lowering using annotations.

Currently, we have `LowerOpaqueBlock` pass to convert s-tir(schedulable tir with blocks) to non-stir. All annotations are dropped then except those used by legacy TE pragma attributes, they are converted to legacy AttrStmt. For example:
```python
# before
for i in range(10, annotations={"pragma_myattr0": 1, "my_attr0": 1}): ....

# after
with T.attr(i, "pragma_myattr0", 1):
    for i in range(10): ....
```

This introduce difficulties when we want to leverage schedule phase annotations in lowering passes.
1. `pragma_` annotations are converted to legacy AttrStmt, which only accepts `PrimExpr` typed value. But the loop/block annotations before are originally much flexible, one could use list/dict to encode more rich compile time hints.
2. Using `AttrStmt` loses the roundtrip property of TIR, thus we fail to write testcases of lowering pass with friendly before/after script comparations.
3. It is more cohesive to encode annotations just with related IR node (like `ForNode`). Or else the developers always have to write separate logics handling attr node and for node.

The change just add a pass configuration `"tir.LowerOpaqueBlock": {"preserved_annotations": List[str]}}`. For each annotation key value of loop or block:
1. if key starts with `pragma_`, keep the original behaviour.
2. if key is registered in `preserved_annotations` list, the annotation is preserved.
3. or else it is dropped.

The alternative may be preserve all annotations without any extra configuration. But I think current way take the least impact on overall lowering stream. If we do not add customized pass config into pass context, all things should be same.


cc @Hzfengsy @junrushao1994