### PR TITLE
[Hexagon][Runtime] Better support for 2-tier memory

### DIFF
--- a/src/runtime/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon_buffer.cc
@@ -161,17 +161,16 @@ void* HexagonBuffer::GetPointer() {
 HexagonBuffer::StorageScope HexagonBuffer::GetStorageScope() const { return storage_scope_; }
 
 void HexagonBuffer::SetStorageScope(Optional<String> scope) {
-  if (!scope.defined()) {
+  const std::string s = scope.value_or("global");
+
+  if (s == "global") {
     storage_scope_ = StorageScope::kDDR;
+  } else if (s == "global.ddr") {
+    storage_scope_ = StorageScope::kDDR;
+  } else if (s == "global.vtcm") {
+    storage_scope_ = StorageScope::kVTCM;
   } else {
-    if (scope.value() == "global") {
-      storage_scope_ = StorageScope::kDDR;
-    } else if (scope.value() == "global.vtcm") {
-      storage_scope_ = StorageScope::kVTCM;
-    } else {
-      CHECK(false) << "Encountered unknown HexagonBuffer storage scope: "
-                   << std::string(scope.value());
-    }
+    CHECK(false) << "Encountered unknown HexagonBuffer storage scope: " << std::string(s);
   }
 }
 

--- a/tests/python/contrib/test_hexagon/test_memory_alloc.py
+++ b/tests/python/contrib/test_hexagon/test_memory_alloc.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import os.path
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+
+import tvm
+from tvm.script import tir as T
+
+from .infrastructure import allocate_hexagon_array
+
+_HEXAGON_TARGET = tvm.target.hexagon("v69", link_params=True)
+
+
+@tvm.testing.fixture
+def generated_func(shape, scope, dtype, axis_separators):
+    dim0, dim1 = shape
+
+    @T.prim_func
+    def elwise(a: T.handle, b: T.handle):
+        A = T.match_buffer(a, shape, dtype=dtype, axis_separators=axis_separators)
+        B = T.match_buffer(b, shape, dtype=dtype, axis_separators=axis_separators)
+
+        for i, j in T.grid(dim0, dim1):
+            with T.block("compute"):
+                B[i, j] = A[i, j] * T.cast(2, dtype=dtype)
+
+    return elwise
+
+
+class TestMemoryAlloc:
+    dtype = tvm.testing.parameter("int8")
+    shape = tvm.testing.parameter((128, 128))
+
+    (scope, axis_separators,) = tvm.testing.parameters(
+        ("global", []),
+        ("global.vtcm", []),
+        ("global.vtcm", [1]),
+        ("global.ddr", []),
+        ("global.ddr", [1]),
+    )
+
+    def test_global_axis_separator(
+        self, hexagon_session, generated_func, shape, dtype, scope, axis_separators
+    ):
+        mod1 = tvm.build(
+            generated_func, target=tvm.target.Target(_HEXAGON_TARGET, host=_HEXAGON_TARGET)
+        )
+        mod2 = hexagon_session.load_module(mod1)
+
+        a_np = np.ones(shape=shape, dtype=dtype)
+        a = allocate_hexagon_array(
+            hexagon_session.device, data=a_np, mem_scope=scope, axis_separators=axis_separators
+        )
+
+        b_np = np.zeros(shape=shape, dtype=dtype)
+        b = allocate_hexagon_array(
+            hexagon_session.device, data=b_np, mem_scope=scope, axis_separators=axis_separators
+        )
+
+        mod2(a, b)
+        tvm.testing.assert_allclose(a.numpy() * 2, b.numpy(), atol=1e-4, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
[hexagon][runtime] better support for 2-tier memory

- Introduce 'global.ddr' memory scope:
  - Like 'global', this allocates memory from the Hexagon SoC's
    DDR memory.
  - Like 'global.vtcm', the specified tensor shape must be 1d
    or 2d, where 2d indicates Hexagon's "indirect tensor"
    (i.e., discontiguous) allocation scheme.

- Change memory-alignment strategy to always be 2048-byte aligned
  on Hexagon.  (This can be refined in the future, but for now it
  ensures all allocations meet the strictest alignment requirements
  for any Hexagon operations.)


cc @areusch @mehrdadh