### PR TITLE
[microTVM] Fix `build` directory exists error

### DIFF
--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -628,6 +628,8 @@ class Handler(server.ProjectAPIHandler):
                 tf.extractall(project_dir)
 
     def build(self, options):
+        if BUILD_DIR.exists():
+            shutil.rmtree(BUILD_DIR)
         BUILD_DIR.mkdir()
 
         zephyr_board = _find_board_from_cmake_file(API_SERVER_DIR / CMAKELIST_FILENAME)


### PR DESCRIPTION
When you build a project from existing project directory using `tvm.micro.project.GeneratedProject.from_directory` it would show up error if build directory previously existed.

cc @alanmacd @gromero