### PR TITLE
[CI] github_cc_reviewers: Catch all exceptions so all reviewers can be processed

### DIFF
--- a/tests/scripts/github_cc_reviewers.py
+++ b/tests/scripts/github_cc_reviewers.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
 import os
 import json
 import argparse
@@ -106,5 +107,8 @@ if __name__ == "__main__":
         for reviewer in to_add:
             try:
                 github.post(f"pulls/{number}/requested_reviewers", {"reviewers": [reviewer]})
-            except error.HTTPError as e:
+            except KeyboardInterrupt:
+                sys.exit()
+            except Exception as e:  # pylint: disable=broad-except
+                # Catch any exception so other reviewers can be processed
                 print(f"Failed to add reviewer {reviewer}: {e}")

--- a/tests/scripts/github_cc_reviewers.py
+++ b/tests/scripts/github_cc_reviewers.py
@@ -109,6 +109,6 @@ if __name__ == "__main__":
                 github.post(f"pulls/{number}/requested_reviewers", {"reviewers": [reviewer]})
             except KeyboardInterrupt:
                 sys.exit()
-            except Exception as e:  # pylint: disable=broad-except
+            except (RuntimeError, error.HTTPError) as e:
                 # Catch any exception so other reviewers can be processed
                 print(f"Failed to add reviewer {reviewer}: {e}")


### PR DESCRIPTION
In a recent change, `github.post` throws `RuntimeError` instead of `HTTPError` when the requested reviewer isn't a project collaborator. This prevents other reviewers to be added to the PR, for example, https://github.com/apache/tvm/runs/8001367110?check_suite_focus=true.

This PR changes the caller to catch any exception so the execution won't be interrupted.

cc @Mousius @areusch @driazati @gigiblender