### PR TITLE
[PyTorch] Add aten::new_empty

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2506,6 +2506,21 @@ class PyTorchOpConverter:
             dtype = input_types[0]
         return _op.zeros(shape, dtype)
 
+    def new_empty(self, inputs, input_types):
+        size = inputs[1]
+
+        import torch
+
+        if not isinstance(size, (_expr.Expr, list, tuple, torch.Size, np.ndarray)):
+            msg = "Data type %s could not be parsed in empty op" % (type(size))
+            raise AssertionError(msg)
+
+        if inputs[2] is not None:
+            dtype = _convert_dtype_value(inputs[2])
+        else:
+            dtype = input_types[0]
+        return _op.zeros(size, dtype)
+
     def randn(self, inputs, input_types):
         import time  # use current time as seed
 
@@ -3639,6 +3654,7 @@ class PyTorchOpConverter:
             "aten::numel": self.numel,
             "aten::empty": self.empty,
             "aten::empty_like": self.empty_like,
+            "aten::new_empty": self.new_empty,
             "aten::randn": self.randn,
             "aten::bincount": self.bincount,
             "aten::scatter_add": self.scatter_add,

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4162,6 +4162,23 @@ def test_empty_like():
     verify_model_with_input(test_func, [torch.rand([1, 3, 10, 10]).float()], assert_shape_only=True)
 
 
+@tvm.testing.uses_gpu
+def test_new_empty():
+    """test_forward_new_ones"""
+    torch.set_grad_enabled(False)
+    input_shape = [1, 3, 10, 10]
+
+    def test_func(input_tensor):
+        return input_tensor.new_empty([3, 10, 10])
+
+    verify_model_with_input(test_func, [torch.rand(input_shape).float()], assert_shape_only=True)
+
+    def test_func1(input_tensor):
+        return input_tensor.new_empty([3, 10, 10], dtype=torch.int32)
+
+    verify_model_with_input(test_func1, [torch.rand(input_shape).float()], assert_shape_only=True)
+
+
 def test_randn():
     """Test for aten::randn"""
 


### PR DESCRIPTION
This PR intends to add `aten::new_empty` which is used for model like `hf_Longformer`.

cc: @masahi 
