### PR TITLE
[TOPI][Bugfix] Make semantics of empty `axis` in `squeeze` consistent with Relay

### DIFF
--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -396,7 +396,7 @@ inline Tensor unravel_index(const Tensor& x, const Tensor& shape, std::string na
  * The removed dimensions must have a constant size of 1.
  *
  * \param x The input tensor
- * \param axis Indices of the dimensions to remove. If this is empty,
+ * \param axis Indices of the dimensions to remove. If this is None,
  * all entries with a constant size of 1 will be removed.
  * \param atleast1d Whether the output need to be atleast1d.
  * \param name The name of the operation
@@ -408,7 +408,7 @@ inline Tensor squeeze(const Tensor& x, Array<Integer> axis, bool atleast1d = fal
                       std::string name = "T_squeeze", std::string tag = kInjective) {
   auto ndim = x->shape.size();
   std::vector<int> axis_val;
-  if (!axis.defined() || axis.size() == 0) {
+  if (!axis.defined()) {
     for (size_t i = 0; i < ndim; ++i) {
       if (IsConstInt(x->shape[i]) && GetConstInt(x->shape[i]) == 1) {
         axis_val.push_back(static_cast<int>(i));

--- a/tests/python/topi/python/test_topi_transform.py
+++ b/tests/python/topi/python/test_topi_transform.py
@@ -940,7 +940,7 @@ def test_where():
     verify_where((1, 2, 3, 4))
 
 
-@tvm.testing.requires_gpu
+@tvm.testing.uses_gpu
 def test_squeeze():
     verify_squeeze((1, 2, 3, 4), 0)
     verify_squeeze((1, 2, 1, 4), None)
@@ -952,7 +952,7 @@ def test_squeeze():
     A = te.placeholder((2,), "float32", "A")
     E = topi.squeeze(A)
     C = te.compute((1,), lambda i: E[(2 * A[0] - 1).astype("int32")])
-    for target in ["cuda", "opencl"]:
+    for target in ["llvm", "cuda", "opencl"]:
         dev = tvm.device(target, 0)
         if tvm.testing.device_enabled(target):
             with tvm.target.Target(target):

--- a/tests/python/topi/python/test_topi_transform.py
+++ b/tests/python/topi/python/test_topi_transform.py
@@ -946,6 +946,7 @@ def test_squeeze():
     verify_squeeze((1, 2, 1, 4), None)
     verify_squeeze((1, 1, 1, 4), (1, 2))
     verify_squeeze((1, 1, 1, 1), None)
+    verify_squeeze((1, 1, 1, 1), ())
 
     # a special case to trigger inline let expression
     A = te.placeholder((2,), "float32", "A")


### PR DESCRIPTION
This PR fixes #11697. The analysis of the bug is elaborated in #12400. The key problem is whether `axis` in `squeeze` means doing nothing or squeezing all one-dimensional axes. 

In #12400, I provide two possible fixes. I choose to fix TOPI finally. The meaning of `axis` is clearly described here (commit #2020):
https://github.com/apache/tvm/blob/fb7cf97fbc2cc19a7eea879a3a1598780f6aa6aa/include/tvm/relay/attrs/transform.h#L319-L327
The later commit to TOPI (#2147), however, does not follow this description. It seems that there is a mistake in this commit and should be corrected. 

CC: @masahi