### PR TITLE
[ci] Add mechanism for trust on certain CI scripts

### DIFF
--- a/ci/jenkins/Prepare.groovy.j2
+++ b/ci/jenkins/Prepare.groovy.j2
@@ -38,6 +38,7 @@ def init_git() {
     """,
     label: 'Update git submodules',
   )
+  checkout_trusted_files()
 }
 
 def docker_init(image) {
@@ -95,6 +96,30 @@ def cancel_previous_build() {
     // with the same milestone number
     if (buildNumber > 1) milestone(buildNumber - 1)
     milestone(buildNumber)
+  }
+}
+
+def checkout_trusted_files() {
+  // trust everything from branch builds
+  if (!env.BRANCH_NAME.startsWith('PR-')) {
+    return;
+  }
+
+  // trust peoople listed in CONTRIBUTING.md
+  grep_code = sh(
+    returnStatus: true,
+    script: "git show '${upstream_revision}:CONTRIBUTORS.md' | grep '@${env.CHANGE_AUTHOR}'",
+    label: 'Check if change is from a contributor',
+  )
+
+  if (grep_code == 1) {
+    // Any scripts that run on the bare host and not inside a Docker container
+    // (especially those that access secrets) should be checked out here so
+    // only trusted versions are used in CI
+    sh(
+      script: "git checkout ${upstream_revision} ci/scripts/.",
+      label: 'Check out trusted files',
+    )
   }
 }
 


### PR DESCRIPTION
This makes it so changes to certain files from users not listed in
`CONTRIBUTING.md` are not tested in CI. This is necessary since these
scripts run on the baremetal EC2 instances and not inside Docker
containers, so they can affect other builds and potentially grab Jenkins
secrets. This checks out the version from the upstream for the listed
files after running `git checkout`. Tested in CI: [positive](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-12604/6/pipeline/) and [negative](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-12604/9/pipeline/)



cc @Mousius @areusch @gigiblender