### PR TITLE
[CI] Update Hexagon image to install boost

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-08-19T15:38:38.311410
+// Generated at 2022-08-26T15:09:39.104767
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -57,7 +57,7 @@ ci_wasm = 'tlcpack/ci-wasm:20220810-060142-fae79bbc3'
 ci_i386 = 'tlcpack/ci-i386:20220810-060142-fae79bbc3'
 ci_cortexm = 'tlcpack/ci-cortexm:20220810-060142-fae79bbc3'
 ci_arm = 'tlcpack/ci-arm:20220810-060142-fae79bbc3'
-ci_hexagon = 'tlcpack/ci-hexagon:20220810-060142-fae79bbc3'
+ci_hexagon = 'tlcpack/ci-hexagon:20220825-145056-fb7cf97f'
 ci_riscv = 'tlcpack/ci-riscv:20220810-060142-fae79bbc3'
 // <--- End of regex-scanned config.
 

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -59,7 +59,7 @@ ci_wasm = 'tlcpack/ci-wasm:20220810-060142-fae79bbc3'
 ci_i386 = 'tlcpack/ci-i386:20220810-060142-fae79bbc3'
 ci_cortexm = 'tlcpack/ci-cortexm:20220810-060142-fae79bbc3'
 ci_arm = 'tlcpack/ci-arm:20220810-060142-fae79bbc3'
-ci_hexagon = 'tlcpack/ci-hexagon:20220810-060142-fae79bbc3'
+ci_hexagon = 'tlcpack/ci-hexagon:20220825-145056-fb7cf97f'
 ci_riscv = 'tlcpack/ci-riscv:20220810-060142-fae79bbc3'
 // <--- End of regex-scanned config.
 


### PR DESCRIPTION
The new image has xgboost installed, which I need for https://github.com/apache/tvm/pull/12587

Validated in https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/ci-docker-staging/279/pipeline

cc @Mousius @areusch @driazati @gigiblender