### PR TITLE
Replace '> >' in templates with >>, NFC

### DIFF
--- a/docs/arch/convert_layout.rst
+++ b/docs/arch/convert_layout.rst
@@ -150,10 +150,10 @@ First example is for layout agnostic operators. These operators do not have any 
     // 		.set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout);
 
     // Take arbitrary input layouts and copy to outputs.
-    inline Array<Array<Layout> > ElemwiseArbitraryLayout(const Attrs& attrs,
-                                                         const Array<Layout>& new_in_layouts,
-                                                         const Array<Layout>& old_in_layouts,
-                                                         const Array<Array<IndexExpr>> &old_in_shapes) {
+    inline Array<Array<Layout>> ElemwiseArbitraryLayout(const Attrs& attrs,
+                                                        const Array<Layout>& new_in_layouts,
+                                                        const Array<Layout>& old_in_layouts,
+                                                        const Array<Array<IndexExpr>> &old_in_shapes) {
       Layout ret;
 
       if (new_in_layouts.defined()) {
@@ -168,7 +168,7 @@ First example is for layout agnostic operators. These operators do not have any 
         }
       }
 
-      return Array<Array<Layout> >{Array<Layout>(old_in_layouts.size(), ret), {ret}};
+      return Array<Array<Layout>>{Array<Layout>(old_in_layouts.size(), ret), {ret}};
     }
 
 

--- a/docs/arch/inferbound.rst
+++ b/docs/arch/inferbound.rst
@@ -280,7 +280,7 @@ Phase 3: Propagate IntSets to consumer's input tensors
 
    /*
     * Input: Map<IterVar, IntSet> dom_map: consumer root -> IntSet
-    * Output: Map<Tensor, TensorDom> tmap: output tensor -> vector<vector<IntSet> >
+    * Output: Map<Tensor, TensorDom> tmap: output tensor -> vector<vector<IntSet>>
     */
 
 Note that the consumer's input tensors are output tensors of the stage InferBound is working on. So by establishing information about the consumer's input tensors, we actually obtain information about the stage's output tensors too: the consumers require certain regions of these tensors to be computed. This information can then be propagated through the rest of the stage, eventually obtaining Ranges for the stage's root_iter_vars by the end of Phase 4.
@@ -306,7 +306,7 @@ Phase 4: Consolidate across all consumers
 .. code:: cpp
 
    /*
-    * Input: Map<Tensor, TensorDom> tmap: output tensor -> vector<vector<IntSet> >
+    * Input: Map<Tensor, TensorDom> tmap: output tensor -> vector<vector<IntSet>>
     * Output: Map<IterVar, Range> rmap: rmap is populated for all of the stage's root_iter_vars
     */
 

--- a/docs/dev/how_to/relay_bring_your_own_codegen.rst
+++ b/docs/dev/how_to/relay_bring_your_own_codegen.rst
@@ -676,7 +676,7 @@ Again, we first define a customized runtime class as follows. The class has to b
 	  /* \brief The subgraph that being processed. */
 	  std::string curr_subgraph_;
 	  /*! \brief A simple graph from subgraph id to node entries. */
-	  std::map<std::string, std::vector<NodeEntry> > graph_;
+	  std::map<std::string, std::vector<NodeEntry>> graph_;
 	  /* \brief A simple pool to contain the tensor for each node in the graph. */
 	  std::vector<NDArray> data_entry_;
 	  /* \brief A mapping from node id to op name. */

--- a/include/tvm/auto_scheduler/feature.h
+++ b/include/tvm/auto_scheduler/feature.h
@@ -70,7 +70,7 @@ void GetPerStoreFeatureName(int max_n_bufs, std::vector<std::string>* ret);
  */
 void GetPerStoreFeaturesFromStates(const Array<State>& states, const SearchTask& task,
                                    int skip_first_n_feature_extraction, int max_n_bufs,
-                                   std::vector<std::vector<float> >* features);
+                                   std::vector<std::vector<float>>* features);
 
 /*!
  * \brief Get per-store feature from states of different tasks
@@ -83,7 +83,7 @@ void GetPerStoreFeaturesFromStates(const Array<State>& states, const SearchTask&
  */
 void GetPerStoreFeaturesFromStates(const Array<State>& states, const std::vector<SearchTask>& tasks,
                                    int skip_first_n_feature_extraction, int max_n_bufs,
-                                   std::vector<std::vector<float> >* features);
+                                   std::vector<std::vector<float>>* features);
 
 /*!
  * \brief Get per-store features from a log file
@@ -96,7 +96,7 @@ void GetPerStoreFeaturesFromStates(const Array<State>& states, const std::vector
  * \param task_ids The task ids for all states
  */
 void GetPerStoreFeaturesFromFile(const std::string& filename, int max_lines, int max_n_bufs,
-                                 std::vector<std::vector<float> >* features,
+                                 std::vector<std::vector<float>>* features,
                                  std::vector<float>* normalized_throughputs,
                                  std::vector<int>* task_ids);
 
@@ -114,7 +114,7 @@ void GetPerStoreFeaturesFromFile(const std::string& filename, int max_lines, int
 void GetPerStoreFeaturesFromMeasurePairs(const Array<MeasureInput>& inputs,
                                          const Array<MeasureResult>& results,
                                          int skip_first_n_feature_extraction, int max_n_bufs,
-                                         std::vector<std::vector<float> >* features,
+                                         std::vector<std::vector<float>>* features,
                                          std::vector<float>* normalized_throughputs,
                                          std::vector<int>* task_ids);
 

--- a/include/tvm/relay/attrs/image.h
+++ b/include/tvm/relay/attrs/image.h
@@ -46,9 +46,9 @@ struct Resize1DAttrs : public tvm::AttrsNode<Resize1DAttrs> {
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Resize1DAttrs, "relay.attrs.Resize1DAttrs") {
-    TVM_ATTR_FIELD(size).set_default(NullValue<Array<IndexExpr> >()).describe("Output Size.");
+    TVM_ATTR_FIELD(size).set_default(NullValue<Array<IndexExpr>>()).describe("Output Size.");
     TVM_ATTR_FIELD(roi)
-        .set_default(NullValue<Array<FloatImm> >())
+        .set_default(NullValue<Array<FloatImm>>())
         .describe("Region of Interest for coordinate transformation mode 'tf_crop_and_resize'");
     TVM_ATTR_FIELD(layout).set_default("NCW").describe(
         "Dimension ordering of input data. Can be 'NCW', 'NWC', etc."
@@ -99,9 +99,9 @@ struct Resize2DAttrs : public tvm::AttrsNode<Resize2DAttrs> {
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Resize2DAttrs, "relay.attrs.Resize2DAttrs") {
-    TVM_ATTR_FIELD(size).set_default(NullValue<Array<IndexExpr> >()).describe("Output Size.");
+    TVM_ATTR_FIELD(size).set_default(NullValue<Array<IndexExpr>>()).describe("Output Size.");
     TVM_ATTR_FIELD(roi)
-        .set_default(NullValue<Array<FloatImm> >())
+        .set_default(NullValue<Array<FloatImm>>())
         .describe("Region of Interest for coordinate transformation mode 'tf_crop_and_resize'");
     TVM_ATTR_FIELD(layout).set_default("NCHW").describe(
         "Dimension ordering of input data. Can be 'NCHW', 'NHWC', etc."
@@ -152,9 +152,9 @@ struct Resize3DAttrs : public tvm::AttrsNode<Resize3DAttrs> {
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(Resize3DAttrs, "relay.attrs.Resize3DAttrs") {
-    TVM_ATTR_FIELD(size).set_default(NullValue<Array<IndexExpr> >()).describe("Output Size.");
+    TVM_ATTR_FIELD(size).set_default(NullValue<Array<IndexExpr>>()).describe("Output Size.");
     TVM_ATTR_FIELD(roi)
-        .set_default(NullValue<Array<FloatImm> >())
+        .set_default(NullValue<Array<FloatImm>>())
         .describe("Region of Interest for coordinate transformation mode 'tf_crop_and_resize'");
     TVM_ATTR_FIELD(layout).set_default("NCDHW").describe(
         "Dimension ordering of input data. Can be 'NCDHW', 'NDHWC', etc."
@@ -200,7 +200,7 @@ struct CropAndResizeAttrs : public tvm::AttrsNode<CropAndResizeAttrs> {
   DataType out_dtype;
 
   TVM_DECLARE_ATTRS(CropAndResizeAttrs, "relay.attrs.CropAndResizeAttrs") {
-    TVM_ATTR_FIELD(crop_size).set_default(NullValue<Array<IndexExpr> >()).describe("Target Size.");
+    TVM_ATTR_FIELD(crop_size).set_default(NullValue<Array<IndexExpr>>()).describe("Target Size.");
     TVM_ATTR_FIELD(layout).set_default("NCHW").describe(
         "Dimension ordering of input data. Can be 'NCHW', 'NHWC', etc."
         "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -234,7 +234,7 @@ class TVM_DLL ModuleNode : public Object {
 
  private:
   /*! \brief Cache used by GetImport */
-  std::unordered_map<std::string, std::shared_ptr<PackedFunc> > import_cache_;
+  std::unordered_map<std::string, std::shared_ptr<PackedFunc>> import_cache_;
   std::mutex mutex_;
 };
 

--- a/include/tvm/support/span.h
+++ b/include/tvm/support/span.h
@@ -68,7 +68,7 @@ class Span {
 
     inline bool operator!=(iterator_base<W1> other) { return !(*this == other); }
 
-    template <class X = W1, typename = std::enable_if_t<!std::is_const<X>::value> >
+    template <class X = W1, typename = std::enable_if_t<!std::is_const<X>::value>>
     inline operator iterator_base<const_W>() const {
       return iterator_base<const_W>(ptr_, end_);
     }

--- a/include/tvm/te/operation.h
+++ b/include/tvm/te/operation.h
@@ -47,7 +47,7 @@ struct TensorDom {
   // constructor
   explicit TensorDom(int ndim) : data(ndim) {}
   /*! \brief The domain data */
-  std::vector<std::vector<IntSet> > data;
+  std::vector<std::vector<IntSet>> data;
 };
 
 /*!

--- a/include/tvm/topi/detail/extern.h
+++ b/include/tvm/topi/detail/extern.h
@@ -75,7 +75,7 @@ using FExtern = std::function<PrimExpr(Array<Buffer>, Array<Buffer>)>;
  * be one output Tensor for each element of out_shapes, with dtype equal to the corresponding
  * element of out_types.
  */
-inline Array<Tensor> make_extern(const Array<Array<PrimExpr> >& out_shapes,
+inline Array<Tensor> make_extern(const Array<Array<PrimExpr>>& out_shapes,
                                  const std::vector<DataType>& out_types,
                                  const Array<Tensor>& inputs, FExtern fextern, std::string name,
                                  std::string tag, ::tvm::Map<String, ObjectRef> attrs) {

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -592,7 +592,7 @@ inline Array<Tensor> split(const Tensor& x, Array<PrimExpr> split_indices, int a
     begin_ids.push_back(idx);
   }
 
-  Array<Array<PrimExpr> > out_shapes;
+  Array<Array<PrimExpr>> out_shapes;
   for (size_t i = 0; i < begin_ids.size(); ++i) {
     PrimExpr out_axis_size;
     if (i == begin_ids.size() - 1) {

--- a/jvm/native/src/main/native/org_apache_tvm_native_c_api.cc
+++ b/jvm/native/src/main/native/org_apache_tvm_native_c_api.cc
@@ -42,8 +42,8 @@ struct TVMFuncArgsThreadLocalEntry {
   std::vector<TVMValue> tvmFuncArgValues;
   std::vector<int> tvmFuncArgTypes;
   // for later release
-  std::vector<std::pair<jstring, const char*> > tvmFuncArgPushedStrs;
-  std::vector<std::pair<jbyteArray, TVMByteArray*> > tvmFuncArgPushedBytes;
+  std::vector<std::pair<jstring, const char*>> tvmFuncArgPushedStrs;
+  std::vector<std::pair<jbyteArray, TVMByteArray*>> tvmFuncArgPushedBytes;
 };
 typedef dmlc::ThreadLocalStore<TVMFuncArgsThreadLocalEntry> TVMFuncArgsThreadLocalStore;
 

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -186,7 +186,7 @@ TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValu
       return PackedFunc([self](TVMArgs args, TVMRetValue* ret) {
         // can't use make_shared due to noexcept(false) decl in destructor,
         // see https://stackoverflow.com/a/43907314
-        auto ctx = std::shared_ptr<With<ConstraintContext> >(
+        auto ctx = std::shared_ptr<With<ConstraintContext>>(
             new With<ConstraintContext>(self.get(), args[0]));
         auto fexit = [ctx](TVMArgs, TVMRetValue*) mutable { ctx.reset(); };
         *ret = PackedFunc(fexit);

--- a/src/autotvm/touch_extractor.cc
+++ b/src/autotvm/touch_extractor.cc
@@ -220,7 +220,7 @@ void TouchExtractor::ExitMem_() {}
  * \note If you want to flatten these features as the input of your model,
  * You can use the faster one GetItervarFeatureFlatten below.
  */
-void GetItervarFeature(Stmt stmt, bool take_log, Array<Array<Array<PrimExpr> > >* ret_feature) {
+void GetItervarFeature(Stmt stmt, bool take_log, Array<Array<Array<PrimExpr>>>* ret_feature) {
   // extract
   TouchExtractor touch_analyzer;
   touch_analyzer.Analyze(stmt);
@@ -248,7 +248,7 @@ void GetItervarFeature(Stmt stmt, bool take_log, Array<Array<Array<PrimExpr> > >
 
   // serialize for front end
   for (auto var : vars) {
-    Array<Array<PrimExpr> > feature_row;
+    Array<Array<PrimExpr>> feature_row;
     ItervarFeature& fea = touch_analyzer.itervar_map[var];
     feature_row.push_back(Array<PrimExpr>{tvm::tir::StringImm("_itervar_"), var});
 
@@ -389,10 +389,10 @@ void GetCurveSampleFeatureFlatten(Stmt stmt, int sample_n, std::vector<float>* r
   });
 
   int max_depth = 0;
-  std::map<TouchedBuffer, std::vector<double> > reuse_curve;
-  std::map<TouchedBuffer, std::vector<double> > count_curve;
-  std::map<TouchedBuffer, std::vector<double> > topdown_curve;
-  std::map<TouchedBuffer, std::vector<double> > bottomup_curve;
+  std::map<TouchedBuffer, std::vector<double>> reuse_curve;
+  std::map<TouchedBuffer, std::vector<double>> count_curve;
+  std::map<TouchedBuffer, std::vector<double>> topdown_curve;
+  std::map<TouchedBuffer, std::vector<double>> bottomup_curve;
   std::set<TouchedBuffer> innermost_buffers;
   std::set<std::string> added;
 
@@ -485,7 +485,7 @@ TVM_REGISTER_GLOBAL("autotvm.feature.GetItervarFeature")
     .set_body([](TVMArgs args, TVMRetValue* ret) {
       Stmt stmt = args[0];
       bool take_log = args[1];
-      Array<Array<Array<PrimExpr> > > ret_feature;
+      Array<Array<Array<PrimExpr>>> ret_feature;
 
       GetItervarFeature(stmt, take_log, &ret_feature);
 

--- a/src/contrib/ethosu/cascader/propagator.cc
+++ b/src/contrib/ethosu/cascader/propagator.cc
@@ -34,7 +34,7 @@ namespace ethosu {
 namespace cascader {
 
 void PropagatorNode::VisitAttrs(AttrVisitor* v) {
-  Array<Array<FloatImm> > tmp_transform;
+  Array<Array<FloatImm>> tmp_transform;
   for (const auto& vec : transform_) {
     tmp_transform.push_back(make_array(vec));
   }
@@ -43,7 +43,7 @@ void PropagatorNode::VisitAttrs(AttrVisitor* v) {
   v->Visit("_offset", &tmp_arr);
 }
 
-Propagator::Propagator(const std::vector<std::vector<float> >& transform,
+Propagator::Propagator(const std::vector<std::vector<float>>& transform,
                        const std::vector<int>& offset) {
   auto n = make_object<PropagatorNode>();
   size_t rows = transform.size();
@@ -102,8 +102,8 @@ StripeConfig PropagatorNode::propagate(const StripeConfig& stripe_config) const 
 }
 
 TVM_REGISTER_GLOBAL("contrib.ethosu.cascader.Propagator")
-    .set_body_typed([](Array<Array<FloatImm> > transform, Array<Integer> offset) {
-      std::vector<std::vector<float> > vtransform;
+    .set_body_typed([](Array<Array<FloatImm>> transform, Array<Integer> offset) {
+      std::vector<std::vector<float>> vtransform;
       for (const auto& vec : transform) {
         vtransform.push_back(make_vector<float, FloatImm>(vec));
       }

--- a/src/contrib/ethosu/cascader/propagator.h
+++ b/src/contrib/ethosu/cascader/propagator.h
@@ -43,7 +43,7 @@ class PropagatorNode : public Object {
   void VisitAttrs(AttrVisitor* v);
 
   /*! \return The transform matrix to apply to the StripeConfigs */
-  const std::vector<std::vector<float> > GetTransform() const { return transform_; }
+  const std::vector<std::vector<float>> GetTransform() const { return transform_; }
   /*! \return The offset vector to apply to the StripeConfigs */
   const std::vector<int> GetOffset() const { return offset_; }
   /*! \return The number of input dimensions */
@@ -92,7 +92,7 @@ class PropagatorNode : public Object {
   friend class Propagator;
 
   /*! \brief The transform matrix to apply to the StripeConfigs */
-  std::vector<std::vector<float> > transform_;
+  std::vector<std::vector<float>> transform_;
   /*! \brief The offset vector to apply to the StripeConfigs */
   std::vector<int> offset_;
 };
@@ -124,7 +124,7 @@ class PropagatorNode : public Object {
  */
 class Propagator : public ObjectRef {
  public:
-  Propagator(const std::vector<std::vector<float> >& transform, const std::vector<int>& offset);
+  Propagator(const std::vector<std::vector<float>>& transform, const std::vector<int>& offset);
 
   TVM_DEFINE_OBJECT_REF_METHODS(Propagator, ObjectRef, PropagatorNode);
 };

--- a/src/ir/span.cc
+++ b/src/ir/span.cc
@@ -30,7 +30,7 @@ namespace tvm {
 ObjectPtr<Object> GetSourceNameNode(const String& name) {
   // always return pointer as the reference can change as map re-allocate.
   // or use another level of indirection by creating a unique_ptr
-  static std::unordered_map<String, ObjectPtr<SourceNameNode> > source_map;
+  static std::unordered_map<String, ObjectPtr<SourceNameNode>> source_map;
 
   auto sn = source_map.find(name);
   if (sn == source_map.end()) {

--- a/src/node/reflection.cc
+++ b/src/node/reflection.cc
@@ -254,7 +254,7 @@ void NodeListAttrNames(TVMArgs args, TVMRetValue* ret) {
   Object* self = static_cast<Object*>(args[0].value().v_handle);
 
   auto names =
-      std::make_shared<std::vector<std::string> >(ReflectionVTable::Global()->ListAttrNames(self));
+      std::make_shared<std::vector<std::string>>(ReflectionVTable::Global()->ListAttrNames(self));
 
   *ret = PackedFunc([names](TVMArgs args, TVMRetValue* rv) {
     int64_t i = args[0];

--- a/src/printer/meta_data.h
+++ b/src/printer/meta_data.h
@@ -136,7 +136,7 @@ class TextMetaDataContext {
 
  private:
   /*! \brief additional metadata stored in TVM json format */
-  std::unordered_map<String, Array<ObjectRef> > meta_data_;
+  std::unordered_map<String, Array<ObjectRef>> meta_data_;
   /*! \brief map from meta data into its string representation */
   std::unordered_map<ObjectRef, Doc, ObjectPtrHash, ObjectPtrEqual> meta_repr_;
 };

--- a/src/relay/analysis/dependency_graph.cc
+++ b/src/relay/analysis/dependency_graph.cc
@@ -56,11 +56,11 @@ class DependencyGraph::Creator : private MixedModeVisitor {
   }
 
   void Depend(DependencyGraph::Node* parent, DependencyGraph::Node* child) {
-    auto* parent_link = arena_->make<LinkNode<DependencyGraph::Node*> >();
+    auto* parent_link = arena_->make<LinkNode<DependencyGraph::Node*>>();
     parent_link->value = parent;
     child->parents.Push(parent_link);
 
-    auto* child_link = arena_->make<LinkNode<DependencyGraph::Node*> >();
+    auto* child_link = arena_->make<LinkNode<DependencyGraph::Node*>>();
     child_link->value = child;
     parent->children.Push(child_link);
   }

--- a/src/relay/ir/transform.cc
+++ b/src/relay/ir/transform.cc
@@ -126,7 +126,7 @@ IRModule FunctionPassNode::operator()(IRModule mod, const PassContext& pass_ctx)
 
   IRModule updated_mod = mod->ShallowCopy();
 
-  std::vector<std::pair<GlobalVar, Function> > updates;
+  std::vector<std::pair<GlobalVar, Function>> updates;
   for (const auto& kv : mod->functions) {
     // only process optimizable Relay Functions
     if (const auto* function_node = AsOptimizableFunctionNode(kv.second)) {

--- a/src/relay/transforms/convert_sparse_dense.cc
+++ b/src/relay/transforms/convert_sparse_dense.cc
@@ -73,7 +73,7 @@ TVM_REGISTER_GLOBAL("relay.analysis.search_dense_op_weight").set_body_typed(Sear
 class DenseToSparseDenseMutator : public ExprRewriter {
  public:
   DenseToSparseDenseMutator(const Array<ObjectRef>& weight_name,
-                            const Array<Array<PrimExpr> >& weight_shape)
+                            const Array<Array<PrimExpr>>& weight_shape)
       : dense_op_(Op::Get("nn.dense")), sparse_dense_op_(Op::Get("nn.sparse_dense")) {
     ICHECK_EQ(weight_name.size(), weight_shape.size());
     for (size_t i = 0; i < weight_name.size(); ++i) {
@@ -117,11 +117,11 @@ class DenseToSparseDenseMutator : public ExprRewriter {
   // Cached op
   const Op& dense_op_;
   const Op& sparse_dense_op_;
-  std::unordered_map<std::string, std::vector<int> > target_weights_;
+  std::unordered_map<std::string, std::vector<int>> target_weights_;
 };  // class DenseToSparseDenseAlter
 
 Expr DenseToSparse(const Expr& e, const Array<ObjectRef>& weight_name,
-                   const Array<Array<PrimExpr> >& weight_shape) {
+                   const Array<Array<PrimExpr>>& weight_shape) {
   auto rewriter = DenseToSparseDenseMutator(weight_name, weight_shape);
   return PostOrderRewrite(e, &rewriter);
 }
@@ -129,7 +129,7 @@ Expr DenseToSparse(const Expr& e, const Array<ObjectRef>& weight_name,
 namespace transform {
 
 Pass DenseToSparse(const Array<ObjectRef>& weight_name,
-                   const Array<Array<PrimExpr> >& weight_shape) {
+                   const Array<Array<PrimExpr>>& weight_shape) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
         // Remove FreeVar warnings

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -180,7 +180,7 @@ class IndexedForwardGraph::Creator : private ExprVisitor {
       graph_.node_map[key] = current;
     }
     if (parent != nullptr) {
-      auto* link = arena_->make<LinkNode<IndexedForwardGraph::Edge> >();
+      auto* link = arena_->make<LinkNode<IndexedForwardGraph::Edge>>();
       link->value.node = parent;
       link->value.pattern = pattern;
       current->outputs.Push(link);

--- a/src/relay/transforms/let_list.h
+++ b/src/relay/transforms/let_list.h
@@ -145,7 +145,7 @@ class LetList {
   }
 
  private:
-  std::vector<std::pair<Var, Expr> > lets_;
+  std::vector<std::pair<Var, Expr>> lets_;
   bool used_ = false;
 };
 

--- a/src/relay/transforms/partial_eval.cc
+++ b/src/relay/transforms/partial_eval.cc
@@ -772,7 +772,7 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
     if (func->HasNonzeroAttr(attr::kPrimitive)) {
       return ConstEvaluateFunc(func);
     }
-    std::vector<std::pair<Var, PStatic> > free_vars;
+    std::vector<std::pair<Var, PStatic>> free_vars;
     for (const auto& v : FreeVars(func)) {
       if (v != var) {
         free_vars.push_back(std::pair<Var, PStatic>(v, env_.Lookup(v)));

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -829,7 +829,7 @@ void EnsureCheckedType(const Expr& e) { AllCheckTypePopulated().VisitExpr(e); }
 
 // TODO(@jroesch): Can we optimize this?
 void AddGlobalTypes(IRModule mod) {
-  std::vector<std::pair<GlobalVar, Function> > updates;
+  std::vector<std::pair<GlobalVar, Function>> updates;
   for (const auto& it : mod->functions) {
     // Currently we don't type check TIR.
     // The inferencer will only check Relay functions
@@ -961,7 +961,7 @@ Pass InferType() {
         // Add all the type annotations to the functions in the model.
         AddGlobalTypes(mod);
 
-        std::vector<std::pair<GlobalVar, Function> > updates;
+        std::vector<std::pair<GlobalVar, Function>> updates;
         for (const auto& it : updated_mod->functions) {
           // Currently we don't type check TIR.
           //

--- a/src/runtime/contrib/ethosn/ethosn_device.cc
+++ b/src/runtime/contrib/ethosn/ethosn_device.cc
@@ -87,7 +87,7 @@ void CopyOutput(dl::Buffer* source_buffers[], std::vector<DLTensor*>* outputs) {
   }
 }
 
-void CreateBuffers(std::vector<std::shared_ptr<dl::Buffer> >* fm,
+void CreateBuffers(std::vector<std::shared_ptr<dl::Buffer>>* fm,
                    const std::vector<DLTensor*>& tensors, const std::vector<uint32_t>& tensor_sizes,
                    bool input) {
   for (size_t i = 0; i < tensors.size(); i++) {
@@ -118,11 +118,11 @@ bool Inference(tvm::runtime::TVMArgs args, dl::Network* npu,
   }
 
   // Set up input buffers
-  std::vector<std::shared_ptr<dl::Buffer> > ifm(inputs.size());
+  std::vector<std::shared_ptr<dl::Buffer>> ifm(inputs.size());
   CreateBuffers(&ifm, inputs, input_sizes, true);
 
   // Set up output buffers
-  std::vector<std::shared_ptr<dl::Buffer> > ofm(outputs.size());
+  std::vector<std::shared_ptr<dl::Buffer>> ofm(outputs.size());
   CreateBuffers(&ofm, outputs, output_sizes, false);
 
   // Raw pointers for the inference

--- a/src/runtime/graph_executor/graph_executor.cc
+++ b/src/runtime/graph_executor/graph_executor.cc
@@ -519,8 +519,8 @@ void GraphExecutor::SetupOpExecs() {
   }
 }
 
-std::pair<std::function<void()>, std::shared_ptr<GraphExecutor::OpArgs> >
-GraphExecutor::CreateTVMOp(const TVMOpParam& param, const std::vector<DLTensor>& args) {
+std::pair<std::function<void()>, std::shared_ptr<GraphExecutor::OpArgs>> GraphExecutor::CreateTVMOp(
+    const TVMOpParam& param, const std::vector<DLTensor>& args) {
   std::shared_ptr<GraphExecutor::OpArgs> arg_ptr = std::make_shared<GraphExecutor::OpArgs>();
   // setup address.
   arg_ptr->args = args;

--- a/src/runtime/metal/metal_common.h
+++ b/src/runtime/metal/metal_common.h
@@ -133,7 +133,7 @@ class Stream {
 class MetalWorkspace final : public DeviceAPI {
  public:
   // the devices
-  std::vector<id<MTLDevice> > devices;
+  std::vector<id<MTLDevice>> devices;
   // Warp size constant
   std::vector<int> warp_size;
   // Whether it is initialized.
@@ -186,7 +186,7 @@ class MetalThreadEntry {
   /*! \brief The current stream */
   std::vector<Stream*> stream;
   /*! \brief The shared buffer used for copy. */
-  std::vector<id<MTLBuffer> > temp_buffer_;
+  std::vector<id<MTLBuffer>> temp_buffer_;
   /*! \brief workspace pool */
   WorkspacePool pool;
   // constructor

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -369,7 +369,7 @@ class ThreadPool {
   int num_workers_used_;
   // if or not to exclude worker 0 and use main to run task 0
   bool exclude_worker0_{true};
-  std::vector<std::unique_ptr<SpscTaskQueue> > queues_;
+  std::vector<std::unique_ptr<SpscTaskQueue>> queues_;
   std::unique_ptr<tvm::runtime::threading::ThreadGroup> threads_;
 };
 

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -285,7 +285,7 @@ class ThreadGroup::Impl {
     // is not supported in earlier versions of QuRT. In such cases assume 4.
     if (threads == 0) threads = 4;
 #endif
-    std::vector<std::pair<unsigned int, int64_t> > max_freqs;
+    std::vector<std::pair<unsigned int, int64_t>> max_freqs;
 
     for (unsigned int i = 0; i < threads; ++i) {
       int64_t cur_freq = 0;

--- a/src/runtime/vm/pooled_allocator.h
+++ b/src/runtime/vm/pooled_allocator.h
@@ -99,7 +99,7 @@ class PooledAllocator final : public Allocator {
  private:
   size_t page_size_;
   std::atomic<size_t> used_memory_;
-  std::unordered_map<size_t, std::vector<Buffer> > memory_pool_;
+  std::unordered_map<size_t, std::vector<Buffer>> memory_pool_;
   std::recursive_mutex mu_;
   Device device_;
 };

--- a/src/target/source/codegen_vhls.cc
+++ b/src/target/source/codegen_vhls.cc
@@ -157,7 +157,7 @@ runtime::Module BuildSDAccel(IRModule mod, Target target) {
   std::string whole_code = cg.Finish();
 
   // Generate source code for compilation.
-  Array<Array<runtime::String> > kernel_info;
+  Array<Array<runtime::String>> kernel_info;
 
   for (auto kv : mod->functions) {
     ICHECK(kv.second->IsInstance<PrimFuncNode>()) << "CodeGenOpenCL: Can only take PrimFunc";

--- a/src/te/operation/compute_op.cc
+++ b/src/te/operation/compute_op.cc
@@ -357,10 +357,10 @@ Stmt MakeComputeStmt(const ComputeOpNode* self, const Stage& stage,
     init = MergeNest(n.init_nest, init);
     init = Substitute(init, n.init_vmap);
     // common nest
-    std::vector<std::vector<Stmt> > common(n.main_nest.begin(),
-                                           n.main_nest.begin() + n.num_common_loop + 1);
-    std::vector<std::vector<Stmt> > reduce(n.main_nest.begin() + n.num_common_loop + 1,
-                                           n.main_nest.end());
+    std::vector<std::vector<Stmt>> common(n.main_nest.begin(),
+                                          n.main_nest.begin() + n.num_common_loop + 1);
+    std::vector<std::vector<Stmt>> reduce(n.main_nest.begin() + n.num_common_loop + 1,
+                                          n.main_nest.end());
     provide = MergeNest(reduce, provide);
     if (debug_keep_trivial_loop) {
       provide = MergeNest(common, provide);

--- a/src/te/operation/compute_op.h
+++ b/src/te/operation/compute_op.h
@@ -41,13 +41,13 @@ struct ComputeLoopNest {
   // predicates for the initialize loop
   std::vector<PrimExpr> init_predicates;
   // Initialization nest involved.
-  std::vector<std::vector<Stmt> > init_nest;
+  std::vector<std::vector<Stmt>> init_nest;
   // Value map for the init code
   std::unordered_map<IterVar, PrimExpr> init_vmap;
   // Predicates for the main update loop
   std::vector<PrimExpr> main_predicates;
   // The general loop nest
-  std::vector<std::vector<Stmt> > main_nest;
+  std::vector<std::vector<Stmt>> main_nest;
   // Value map for the IterVar.
   std::unordered_map<IterVar, PrimExpr> main_vmap;
 

--- a/src/te/operation/tensor_compute_op.cc
+++ b/src/te/operation/tensor_compute_op.cc
@@ -202,7 +202,7 @@ Stmt TensorComputeOpNode::BuildProvide(const Stage& stage,
   ComputeLoopNest n = ComputeLoopNest::Create(this, stage, dom_map, debug_keep_trivial_loop);
 
   if (this->reduce_axis.size() == 0) {
-    std::vector<std::vector<Stmt> > nest(n.main_nest.begin(), n.main_nest.begin() + tloc + 1);
+    std::vector<std::vector<Stmt>> nest(n.main_nest.begin(), n.main_nest.begin() + tloc + 1);
     nest.emplace_back(MakeIfNest(n.main_predicates));
     ICHECK_EQ(n.init_predicates.size(), 0U);
     ICHECK(this->intrin->body.defined())
@@ -219,16 +219,15 @@ Stmt TensorComputeOpNode::BuildProvide(const Stage& stage,
     ICHECK(this->intrin->reduce_update.defined()) << "Reduction update op is not defined";
     // Need init and update steps
     ICHECK_NE(this->reduce_axis.size(), 0U);
-    std::vector<std::vector<Stmt> > common(n.main_nest.begin(),
-                                           n.main_nest.begin() + n.num_common_loop + 1);
-    std::vector<std::vector<Stmt> > update_nest(n.main_nest.begin() + n.num_common_loop + 1,
-                                                n.main_nest.begin() + tloc + 1);
+    std::vector<std::vector<Stmt>> common(n.main_nest.begin(),
+                                          n.main_nest.begin() + n.num_common_loop + 1);
+    std::vector<std::vector<Stmt>> update_nest(n.main_nest.begin() + n.num_common_loop + 1,
+                                               n.main_nest.begin() + tloc + 1);
     update_nest.emplace_back(MakeIfNest(n.main_predicates));
 
     if (this->intrin->reduce_init.defined()) {
       // init nest
-      std::vector<std::vector<Stmt> > init_nest(n.init_nest.begin(),
-                                                n.init_nest.begin() + tloc + 1);
+      std::vector<std::vector<Stmt>> init_nest(n.init_nest.begin(), n.init_nest.begin() + tloc + 1);
       init_nest.emplace_back(MakeIfNest(n.init_predicates));
       Stmt init = MergeNest(output_bind_nest, this->intrin->reduce_init);
       init = te::Substitute(init, n.init_vmap);

--- a/src/te/operation/tensorize.cc
+++ b/src/te/operation/tensorize.cc
@@ -42,7 +42,7 @@ using namespace tir;
 size_t InferTensorizeRegion(const ComputeOpNode* self, const Stage& stage,
                             const std::unordered_map<IterVar, Range>& dom_map,
                             std::unordered_map<IterVar, Range>* out_dom,
-                            std::unordered_map<Tensor, Array<Range> >* in_region) {
+                            std::unordered_map<Tensor, Array<Range>>* in_region) {
   // Get the bound of the tensorized scope.
   bool found_point = false;
   size_t loc_scope = 0;
@@ -198,7 +198,7 @@ class TensorIntrinMatcher final : public StmtExprMutator {
   void Init(const ComputeOpNode* self, const Stage& stage,
             const std::unordered_map<IterVar, Range>& dom_map,
             const std::unordered_map<IterVar, Range>& out_dom,
-            const std::unordered_map<Tensor, Array<Range> >& in_region, const TensorIntrin& intrin,
+            const std::unordered_map<Tensor, Array<Range>>& in_region, const TensorIntrin& intrin,
             Map<Var, Range>* compute_intrin_iter_space) {
     ICHECK(self == stage->op.get());
 
@@ -298,7 +298,7 @@ class TensorIntrinMatcher final : public StmtExprMutator {
 Array<PrimExpr> MatchTensorizeBody(const ComputeOpNode* self, const Stage& stage,
                                    const std::unordered_map<IterVar, Range>& dom_map,
                                    const std::unordered_map<IterVar, Range>& out_dom,
-                                   const std::unordered_map<Tensor, Array<Range> >& in_region,
+                                   const std::unordered_map<Tensor, Array<Range>>& in_region,
                                    const TensorIntrin& intrin,
                                    Map<Var, Range>* compute_intrin_iter_space) {
   TensorIntrinMatcher matcher;
@@ -314,7 +314,7 @@ void VerifyTensorizeBody(const ComputeOpNode* self, const Stage& stage,
                          const std::unordered_map<IterVar, PrimExpr>& value_map,
                          const std::unordered_map<IterVar, Range>& dom_map,
                          const std::unordered_map<IterVar, Range>& out_dom,
-                         const std::unordered_map<Tensor, Array<Range> >& in_region,
+                         const std::unordered_map<Tensor, Array<Range>>& in_region,
                          const TensorIntrin& intrin) {
   StructuralEqual expr_equal;
   Map<Var, Range> compute_intrin_iter_space;
@@ -346,7 +346,7 @@ Stmt MakeTensorize(const ComputeOpNode* self, const Stage& stage,
                    const std::unordered_map<IterVar, Range>& dom_map,
                    bool debug_keep_trivial_loop) {
   std::unordered_map<IterVar, Range> out_dom;
-  std::unordered_map<Tensor, Array<Range> > in_region;
+  std::unordered_map<Tensor, Array<Range>> in_region;
   size_t tloc = InferTensorizeRegion(self, stage, dom_map, &out_dom, &in_region);
   TensorIntrin intrin = stage->iter_var_attrs.at(stage->leaf_iter_vars[tloc])->tensor_intrin;
   ICHECK(intrin.defined());
@@ -418,7 +418,7 @@ Stmt MakeTensorize(const ComputeOpNode* self, const Stage& stage,
   }
   if (tloc <= n.num_common_loop) {
     // Do no need to split reduction
-    std::vector<std::vector<Stmt> > nest(n.main_nest.begin(), n.main_nest.begin() + tloc + 1);
+    std::vector<std::vector<Stmt>> nest(n.main_nest.begin(), n.main_nest.begin() + tloc + 1);
     nest.emplace_back(MakeIfNest(n.main_predicates));
     ICHECK_EQ(n.init_predicates.size(), 0U);
     ICHECK(intrin->body.defined()) << "Normal store op for intrin " << intrin << " is not defined";
@@ -434,16 +434,15 @@ Stmt MakeTensorize(const ComputeOpNode* self, const Stage& stage,
         << "Reduction update op for intrin " << intrin << " is not defined";
     // Need init and update steps
     ICHECK_NE(self->reduce_axis.size(), 0U);
-    std::vector<std::vector<Stmt> > common(n.main_nest.begin(),
-                                           n.main_nest.begin() + n.num_common_loop + 1);
-    std::vector<std::vector<Stmt> > update_nest(n.main_nest.begin() + n.num_common_loop + 1,
-                                                n.main_nest.begin() + tloc + 1);
+    std::vector<std::vector<Stmt>> common(n.main_nest.begin(),
+                                          n.main_nest.begin() + n.num_common_loop + 1);
+    std::vector<std::vector<Stmt>> update_nest(n.main_nest.begin() + n.num_common_loop + 1,
+                                               n.main_nest.begin() + tloc + 1);
     update_nest.emplace_back(MakeIfNest(n.main_predicates));
 
     if (intrin->reduce_init.defined()) {
       // init nest
-      std::vector<std::vector<Stmt> > init_nest(n.init_nest.begin(),
-                                                n.init_nest.begin() + tloc + 1);
+      std::vector<std::vector<Stmt>> init_nest(n.init_nest.begin(), n.init_nest.begin() + tloc + 1);
       init_nest.emplace_back(MakeIfNest(n.init_predicates));
       Stmt init = MergeNest(output_bind_nest, intrin->reduce_init);
       init = te::Substitute(init, n.init_vmap);
@@ -476,17 +475,17 @@ TVM_REGISTER_GLOBAL("test.op.InferTensorizeRegion").set_body([](TVMArgs args, TV
   Stage stage = args[0];
   Map<IterVar, Range> dmap = args[1];
   std::unordered_map<IterVar, Range> out_dom;
-  std::unordered_map<Tensor, Array<Range> > in_region;
+  std::unordered_map<Tensor, Array<Range>> in_region;
   ICHECK(stage->op.as<ComputeOpNode>());
   InferTensorizeRegion(stage->op.as<ComputeOpNode>(), stage, as_unordered_map(dmap), &out_dom,
                        &in_region);
-  *ret = Array<ObjectRef>{Map<IterVar, Range>(out_dom), Map<Tensor, Array<Range> >(in_region)};
+  *ret = Array<ObjectRef>{Map<IterVar, Range>(out_dom), Map<Tensor, Array<Range>>(in_region)};
 });
 
 TVM_REGISTER_GLOBAL("test.op.MatchTensorizeBody").set_body([](TVMArgs args, TVMRetValue* ret) {
   Stage stage = args[0];
   Map<IterVar, Range> out_dom = args[1];
-  Map<Tensor, Array<Range> > in_region = args[2];
+  Map<Tensor, Array<Range>> in_region = args[2];
   TensorIntrin intrin = args[3];
   Map<Var, Range> vrange;
   ICHECK(stage->op.as<ComputeOpNode>());

--- a/src/te/schedule/graph.h
+++ b/src/te/schedule/graph.h
@@ -38,17 +38,17 @@ namespace te {
 /*!
  * \brief data structure of Operation->Tensors it reads
  */
-using ReadGraph = Map<Operation, Array<Tensor> >;
+using ReadGraph = Map<Operation, Array<Tensor>>;
 
 /*!
  * \brief AttachPath maps op-> a list of IterVar
  */
-using AttachPath = Map<Operation, Array<IterVar> >;
+using AttachPath = Map<Operation, Array<IterVar>>;
 
 /*!
  * \brief The map between tensor and operation it feeds to.
  */
-using FeedGraph = std::unordered_map<Tensor, std::vector<Operation> >;
+using FeedGraph = std::unordered_map<Tensor, std::vector<Operation>>;
 
 /*!
  * \brief Get read graph of each operation to all the

--- a/src/te/schedule/schedule_dataflow_rewrite.cc
+++ b/src/te/schedule/schedule_dataflow_rewrite.cc
@@ -507,7 +507,7 @@ void RebaseNonZeroMinLoop(ScheduleNode* sch) {
 void InjectInline(ScheduleNode* sch, bool feature_extraction_mode) {
   sch->InvalidateCache();
 
-  std::vector<Array<PrimExpr> > new_body(sch->stages.size());
+  std::vector<Array<PrimExpr>> new_body(sch->stages.size());
   std::vector<bool> changed(sch->stages.size(), false);
   std::vector<Stmt> new_hybrid_body(sch->stages.size());
   std::vector<bool> hybrid_changed(sch->stages.size(), false);

--- a/src/tir/ir/buffer.cc
+++ b/src/tir/ir/buffer.cc
@@ -152,7 +152,7 @@ inline std::pair<bool, PrimExpr> MergeMulModInner(arith::Analyzer* analyzer,
 // Otherwise, the elements will be added to the no_opt_sum variable
 inline void MergeMulModInsertElements(const std::vector<const PrimExpr*>& eles,
                                       std::list<PrimExpr>* mult_exprs,
-                                      std::list<std::pair<PrimExpr, PrimExpr> >* mod_exprs,
+                                      std::list<std::pair<PrimExpr, PrimExpr>>* mod_exprs,
                                       PrimExpr* no_opt_sum, bool* has_mult, bool* has_mod) {
   using namespace tir;
   *has_mult = false;
@@ -194,13 +194,13 @@ inline PrimExpr MergeMulMod(arith::Analyzer* analyzer, const PrimExpr& base) {
   simplified_base = analyzer->Simplify(simplified_base);
   std::vector<const PrimExpr*> eles = ExprSplitAddition(simplified_base);
   std::list<PrimExpr> mult_exprs;
-  std::list<std::pair<PrimExpr, PrimExpr> > mod_exprs;
+  std::list<std::pair<PrimExpr, PrimExpr>> mod_exprs;
   PrimExpr no_opt_sum;
   bool has_mult;
   bool has_mod;
   MergeMulModInsertElements(eles, &mult_exprs, &mod_exprs, &no_opt_sum, &has_mult, &has_mod);
   bool find_opt = false;
-  std::list<std::pair<PrimExpr, PrimExpr> >::iterator search_mod_it = mod_exprs.begin();
+  std::list<std::pair<PrimExpr, PrimExpr>>::iterator search_mod_it = mod_exprs.begin();
   // 2. Exhaustive Search
   while (search_mod_it != mod_exprs.end()) {
     std::list<PrimExpr>::iterator mult_it = mult_exprs.begin();
@@ -238,7 +238,7 @@ inline PrimExpr MergeMulMod(arith::Analyzer* analyzer, const PrimExpr& base) {
   for (std::list<PrimExpr>::iterator it = mult_exprs.begin(); it != mult_exprs.end(); ++it) {
     no_opt_sum = no_opt_sum.get() ? no_opt_sum + *it : *it;
   }
-  for (std::list<std::pair<PrimExpr, PrimExpr> >::iterator it = mod_exprs.begin();
+  for (std::list<std::pair<PrimExpr, PrimExpr>>::iterator it = mod_exprs.begin();
        it != mod_exprs.end(); ++it) {
     no_opt_sum = no_opt_sum.get() ? no_opt_sum + indexmod(it->first, it->second)
                                   : indexmod(it->first, it->second);

--- a/src/tir/transforms/coproc_sync.cc
+++ b/src/tir/transforms/coproc_sync.cc
@@ -111,7 +111,7 @@ class CoProcSyncPlanner : public StorageAccessVisitor {
   }
 
   // Write synchronization to be inserted before or after stmt.
-  std::unordered_map<const Object*, std::vector<Stmt> > sync_;
+  std::unordered_map<const Object*, std::vector<Stmt>> sync_;
 
  protected:
   bool Enabled(const VarNode* buf, const StorageScope& scope) const final {
@@ -230,8 +230,8 @@ class CoProcBarrierDetector : public StorageAccessVisitor {
     PlanWriteBarrier(scope_.back(), nullptr);
   }
 
-  std::unordered_map<const Object*, std::vector<Stmt> > barrier_before_;
-  std::unordered_map<const Object*, std::vector<Stmt> > barrier_after_;
+  std::unordered_map<const Object*, std::vector<Stmt>> barrier_before_;
+  std::unordered_map<const Object*, std::vector<Stmt>> barrier_after_;
 
  protected:
   bool Enabled(const VarNode* buf, const StorageScope& scope) const final {
@@ -251,7 +251,7 @@ class CoProcBarrierDetector : public StorageAccessVisitor {
   // Plan write barrier at Read after write point.
   std::vector<AccessEntry> PlanWriteBarrier(std::vector<StmtEntry> seq, const ForNode* loop) {
     std::vector<AccessEntry> read_seq;
-    std::unordered_map<const VarNode*, std::vector<AccessEntry> > write_set;
+    std::unordered_map<const VarNode*, std::vector<AccessEntry>> write_set;
 
     auto fupdate = [&](size_t i, const AccessEntry& acc) {
       auto it = write_set.find(acc.buffer.get());
@@ -289,7 +289,7 @@ class CoProcBarrierDetector : public StorageAccessVisitor {
 
   std::vector<AccessEntry> PlanReadBarrier(std::vector<StmtEntry> seq, const ForNode* loop) {
     std::vector<AccessEntry> write_seq;
-    std::unordered_map<const VarNode*, std::vector<AccessEntry> > read_set;
+    std::unordered_map<const VarNode*, std::vector<AccessEntry>> read_set;
 
     auto fupdate = [&](size_t i, const AccessEntry& acc) {
       auto it = read_set.find(acc.buffer.get());
@@ -443,8 +443,8 @@ class CoProcInstDepDetector : public StmtVisitor {
 
   // insert before is stored in reverse order
   // the first element is closest to the node.
-  std::unordered_map<const Object*, std::vector<Stmt> > insert_before_;
-  std::unordered_map<const Object*, std::vector<Stmt> > insert_after_;
+  std::unordered_map<const Object*, std::vector<Stmt>> insert_before_;
+  std::unordered_map<const Object*, std::vector<Stmt>> insert_after_;
 
  private:
   // state in the sync entry
@@ -456,9 +456,9 @@ class CoProcInstDepDetector : public StmtVisitor {
     // Set of all possible contexts in the exit moment.
     std::unordered_set<int> exit_ctx;
     // existing pop performed at enter
-    std::vector<std::pair<int, int> > enter_pop;
+    std::vector<std::pair<int, int>> enter_pop;
     // existing push performed at exit
-    std::vector<std::pair<int, int> > exit_push;
+    std::vector<std::pair<int, int>> exit_push;
     // clear the state
     void clear() {
       node = nullptr;
@@ -473,8 +473,8 @@ class CoProcInstDepDetector : public StmtVisitor {
   // return the push/pop message at enter/exit of the Block
   // after considering the existing unmatcheded events and added events
   void InjectSync(const SyncState& prev, const SyncState& next,
-                  std::vector<std::pair<int, int> >* prev_exit_push,
-                  std::vector<std::pair<int, int> >* next_enter_pop) {
+                  std::vector<std::pair<int, int>>* prev_exit_push,
+                  std::vector<std::pair<int, int>>* next_enter_pop) {
     prev_exit_push->clear();
     next_enter_pop->clear();
     // quick path
@@ -491,9 +491,9 @@ class CoProcInstDepDetector : public StmtVisitor {
       return;
     }
     // complicate path.
-    std::vector<std::pair<int, int> > vpush = prev.exit_push;
-    std::vector<std::pair<int, int> > vpop = next.enter_pop;
-    std::vector<std::pair<int, int> > pending;
+    std::vector<std::pair<int, int>> vpush = prev.exit_push;
+    std::vector<std::pair<int, int>> vpop = next.enter_pop;
+    std::vector<std::pair<int, int>> pending;
     for (int from : prev.exit_ctx) {
       for (int to : next.enter_ctx) {
         if (from != to) {
@@ -556,7 +556,7 @@ class CoProcInstDepDetector : public StmtVisitor {
 
   void UpdateState() {
     if (last_state_.node != nullptr) {
-      std::vector<std::pair<int, int> > t1, t2;
+      std::vector<std::pair<int, int>> t1, t2;
       InjectSync(last_state_, curr_state_, &t1, &t2);
       std::swap(last_state_, curr_state_);
     } else {
@@ -642,8 +642,8 @@ class CoProcSyncInserter : public StmtMutator {
  private:
   // insert before is stored in reverse order
   // the first element is closest to the node.
-  std::unordered_map<const Object*, std::vector<Stmt> > insert_before_;
-  std::unordered_map<const Object*, std::vector<Stmt> > insert_after_;
+  std::unordered_map<const Object*, std::vector<Stmt>> insert_before_;
+  std::unordered_map<const Object*, std::vector<Stmt>> insert_after_;
 };
 
 Stmt CoProcSync(Stmt stmt) { return CoProcSyncInserter().Insert(std::move(stmt)); }

--- a/src/tir/transforms/inject_double_buffer.cc
+++ b/src/tir/transforms/inject_double_buffer.cc
@@ -299,9 +299,9 @@ class DoubleBufferInjector : public StmtExprMutator {
   // The current loop next
   std::vector<const ForNode*> loop_nest_;
   // The allocs to be appended before the loop
-  std::unordered_map<const ForNode*, std::vector<Stmt> > loop_allocs_;
+  std::unordered_map<const ForNode*, std::vector<Stmt>> loop_allocs_;
   // The stmt to be appended before the loop
-  std::unordered_map<const ForNode*, std::vector<Stmt> > loop_pre_;
+  std::unordered_map<const ForNode*, std::vector<Stmt>> loop_pre_;
   // The allocation size of the buffer
   std::unordered_map<const VarNode*, StorageEntry> dbuffer_info_;
   // The updated Buffer objects

--- a/src/tir/transforms/inject_virtual_thread.cc
+++ b/src/tir/transforms/inject_virtual_thread.cc
@@ -177,7 +177,7 @@ class VarTouchedAnalysis : public StmtVisitor {
   // Whether variable is touched by the thread variable.
   std::unordered_set<const VarNode*> touched_var_;
   // x -> all the buffers x read from
-  std::unordered_map<const VarNode*, std::vector<const VarNode*> > affect_;
+  std::unordered_map<const VarNode*, std::vector<const VarNode*>> affect_;
 };
 
 // Inject virtual thread loop

--- a/src/tir/transforms/ir_utils.h
+++ b/src/tir/transforms/ir_utils.h
@@ -54,7 +54,7 @@ Stmt MergeNest(const std::vector<Stmt>& nest, Stmt body);
  * \param body body
  * \return The combined Stmt
  */
-Stmt MergeNest(const std::vector<std::vector<Stmt> >& nest, Stmt body);
+Stmt MergeNest(const std::vector<std::vector<Stmt>>& nest, Stmt body);
 
 /*!
  * \brief update array with an unary function

--- a/src/tir/transforms/make_packed_api.cc
+++ b/src/tir/transforms/make_packed_api.cc
@@ -204,8 +204,8 @@ PrimFunc MakePackedAPI(PrimFunc&& func, int num_unpacked_args) {
   }
 
   // Need to re-declare vars, in case some arguments also appears in the buffer.
-  std::vector<std::pair<Var, Var> > var_def;
-  std::vector<std::pair<Var, Buffer> > buffer_def;
+  std::vector<std::pair<Var, Var>> var_def;
+  std::vector<std::pair<Var, Buffer>> buffer_def;
 
   for (int i = 0; i < static_cast<int>(func_ptr->params.size()); ++i) {
     Var param = func_ptr->params[i];
@@ -343,7 +343,7 @@ Pass MakePackedAPI(int num_unpacked_args) {
   // packed arguments anyway while `num_unpacked_args` is -1
   auto pass_func = [num_unpacked_args](IRModule m, PassContext ctx) {
     IRModuleNode* mptr = m.CopyOnWrite();
-    std::vector<std::pair<GlobalVar, PrimFunc> > updates;
+    std::vector<std::pair<GlobalVar, PrimFunc>> updates;
 
     for (const auto& kv : mptr->functions) {
       if (auto* n = kv.second.as<PrimFuncNode>()) {

--- a/src/tir/transforms/storage_access.h
+++ b/src/tir/transforms/storage_access.h
@@ -125,7 +125,7 @@ class StorageAccessVisitor : public StmtExprVisitor {
    */
   StorageScope GetScope(Var buffer_var) const;
   // access scope
-  std::vector<std::vector<StmtEntry> > scope_;
+  std::vector<std::vector<StmtEntry>> scope_;
 
  private:
   // whether access appending is enabled.

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1010,11 +1010,11 @@ class StoragePlanRewriter : public StmtExprMutator {
   // symbolic free list, for non constant items.
   std::list<StorageEntry*> sym_free_list_;
   // The allocation attach map
-  std::unordered_map<const Object*, std::vector<StorageEntry*> > attach_map_;
+  std::unordered_map<const Object*, std::vector<StorageEntry*>> attach_map_;
   // The allocation assign map
   std::unordered_map<const VarNode*, StorageEntry*> alloc_map_;
   // The allocations
-  std::vector<std::unique_ptr<StorageEntry> > alloc_vec_;
+  std::vector<std::unique_ptr<StorageEntry>> alloc_vec_;
   // The buffer objects being remapped
   std::unordered_map<const BufferNode*, Buffer> buffer_remap_;
   // analyzer


### PR DESCRIPTION
The problem with greedy lexing of `>>` as an operator was solved in C++11, and now templates no longer require spaces between `>`'s.
