### PR TITLE
[TIR] Add unroll_loop_with_partition_hint_no_interval attr in LoopPartitionConfig     to unroll loop

### DIFF
--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -43,11 +43,15 @@ namespace tir {
 struct LoopPartitionConfigNode : public tvm::AttrsNode<LoopPartitionConfigNode> {
   bool partition_const_loop;
   bool no_unroll_loop_with_extent_one;
+  bool unroll_loop_with_partition_hint_no_interval;
 
   TVM_DECLARE_ATTRS(LoopPartitionConfigNode, "tir.transform.LoopPartitionConfig") {
     TVM_ATTR_FIELD(partition_const_loop).describe("Split constant loop").set_default(false);
     TVM_ATTR_FIELD(no_unroll_loop_with_extent_one)
         .describe("Don't unroll loops with extent 1")
+        .set_default(false);
+    TVM_ATTR_FIELD(unroll_loop_with_partition_hint_no_interval)
+        .describe("Unroll loops with pragma_loop_partition_hint and no interval")
         .set_default(false);
   }
 };
@@ -374,9 +378,11 @@ class ThreadPartitionInserter : public StmtMutator {
 // likely conditions
 class LoopPartitioner : public StmtMutator {
  public:
-  explicit LoopPartitioner(bool partition_const_loop, bool no_unroll_loop_with_extent_one)
+  explicit LoopPartitioner(bool partition_const_loop, bool no_unroll_loop_with_extent_one,
+                           bool unroll_loop_with_partition_hint_no_interval)
       : selector(CandidateSelector(partition_const_loop)),
-        no_unroll_loop_with_extent_one_(no_unroll_loop_with_extent_one) {}
+        no_unroll_loop_with_extent_one_(no_unroll_loop_with_extent_one),
+        unroll_loop_with_partition_hint_no_interval_(unroll_loop_with_partition_hint_no_interval) {}
 
   Stmt VisitAndMutate(Stmt stmt) {
     selector(stmt);
@@ -444,6 +450,7 @@ class LoopPartitioner : public StmtMutator {
   arith::Analyzer analyzer_;
   CandidateSelector selector;
   bool no_unroll_loop_with_extent_one_;
+  bool unroll_loop_with_partition_hint_no_interval_;
 };
 
 // Returns an interval (in the first component) in which all the conditions
@@ -584,6 +591,10 @@ Stmt LoopPartitioner::TryPartition(const Stmt& stmt, Var var, PrimExpr min, Prim
   }();
 
   if (!opt_cond_value.has_value()) {
+    if (has_partition_hint_ && unroll_loop_with_partition_hint_no_interval_ &&
+        analyzer_.CanProve(max - min > 0)) {
+      return For(var, min, max - min + 1, ForKind::kUnrolled, body);
+    }
     return Stmt();
   }
   bool cond_value = opt_cond_value.value();
@@ -655,11 +666,11 @@ Stmt LoopPartitioner::TryPartition(const Stmt& stmt, Var var, PrimExpr min, Prim
       Stmt simplified_body = ConditionEliminator(cond_set, cond_value)(body);
       Stmt new_body = Substitute(simplified_body, {{Var{var}, var + body_begin}});
       mid_stmt = MakeFor(stmt.get(), post_doubt_begin - body_begin, new_body);
-
+      // Recurse until partitions is empty
+      mid_stmt = VisitAndMutate(mid_stmt);
       // Recurse for each non-empty subrange only if there are at least
       // two non-empty subranges
       if (pre_stmt.defined() || post_stmt.defined()) {
-        mid_stmt = VisitAndMutate(mid_stmt);
         if (pre_stmt.defined() && pre_stmt_recurse) {
           pre_stmt = VisitAndMutate(pre_stmt);
         }
@@ -711,8 +722,10 @@ class RemoveLikelyTagsAndHints : public StmtExprMutator {
   }
 };
 
-Stmt LoopPartition(Stmt stmt, bool partition_const_loop, bool no_unroll_loop_with_extent_one) {
-  stmt = LoopPartitioner(partition_const_loop, no_unroll_loop_with_extent_one)
+Stmt LoopPartition(Stmt stmt, bool partition_const_loop, bool no_unroll_loop_with_extent_one,
+                   bool unroll_loop_with_partition_hint_no_interval) {
+  stmt = LoopPartitioner(partition_const_loop, no_unroll_loop_with_extent_one,
+                         unroll_loop_with_partition_hint_no_interval)
              .VisitAndMutate(std::move(stmt));
   stmt = RemoveLikelyTagsAndHints()(std::move(stmt));
   return stmt;
@@ -728,7 +741,8 @@ Pass LoopPartition() {
       cfg = AttrsWithDefaultValues<LoopPartitionConfig>();
     }
     n->body = LoopPartition(std::move(n->body), cfg.value()->partition_const_loop,
-                            cfg.value()->no_unroll_loop_with_extent_one);
+                            cfg.value()->no_unroll_loop_with_extent_one,
+                            cfg.value()->unroll_loop_with_partition_hint_no_interval);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tir.LoopPartition", {});

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -619,26 +619,54 @@ def test_condition_mutually_exclusive():
     assert tvm.ir.structural_equal(mod["main"], partitioned_concat_3)
 
 
+def test_loop_partition_unroll_hint():
+    @T.prim_func
+    def main(A: T.Buffer[150528, "int8"], B: T.Buffer[25088, "int8"]) -> None:
+        T.preflattened_buffer(A, [1, 3, 224, 224], "int8", data=A.data)
+        T.preflattened_buffer(B, [1, 224, 7, 16], "int8", data=B.data)
+        for ax0 in T.serial(
+            112,
+            annotations={"pragma_loop_partition_hint": True},
+        ):
+            for ax1, ax2, ax3 in T.grid(224, 7, 16):
+                if 3 <= ax0 * 2 + ax2 and ax0 * 2 + ax2 < 227 and ax3 < 3:
+                    B[ax1 * 112 + ax2 * 16 + ax3] = A[ax3 * 50176 + ax1 * 224 + ax0 * 2 + ax2 - 3]
+
+    @T.prim_func
+    def partitioned_main(A: T.Buffer[150528, "int8"], B: T.Buffer[25088, "int8"]) -> None:
+        T.preflattened_buffer(A, [1, 3, 224, 224], dtype="int8", data=A.data)
+        T.preflattened_buffer(B, [1, 224, 7, 16], dtype="int8", data=B.data)
+        # body
+        for ax1, ax2, ax3 in T.grid(224, 7, 16):
+            if 3 <= ax2 and ax3 < 3:
+                B[ax1 * 112 + ax2 * 16 + ax3] = A[ax3 * 50176 + ax1 * 224 + ax2 - 3]
+        for ax1, ax2, ax3 in T.grid(224, 7, 16):
+            if 1 <= ax2 and ax3 < 3:
+                B[ax1 * 112 + ax2 * 16 + ax3] = A[ax3 * 50176 + ax1 * 224 + ax2 - 1]
+        for ax0, ax1, ax2, ax3 in T.grid(109, 224, 7, 16):
+            if ax3 < 3:
+                B[ax1 * 112 + ax2 * 16 + ax3] = A[ax3 * 50176 + ax1 * 224 + ax0 * 2 + ax2 + 1]
+        for ax1, ax2, ax3 in T.grid(224, 7, 16):
+            if ax2 < 5 and ax3 < 3:
+                B[ax1 * 112 + ax2 * 16 + ax3] = A[ax3 * 50176 + ax1 * 224 + ax2 + 219]
+
+    mod = tvm.ir.module.IRModule.from_expr(main)
+    with tvm.transform.PassContext(
+        config={
+            "tir.LoopPartition": {
+                "partition_const_loop": True,
+                "unroll_loop_with_partition_hint_no_interval": True,
+            }
+        }
+    ):
+        mod = tvm.tir.transform.LowerOpaqueBlock()(mod)
+        mod = tvm.tir.transform.FlattenBuffer()(mod)
+        mod = tvm.tir.transform.LoopPartition()(mod)
+        mod = tvm.tir.transform.UnrollLoop()(mod)
+        mod = tvm.tir.transform.RemoveNoOp()(mod)
+        mod = tvm.tir.transform.Simplify()(mod)
+    assert tvm.ir.structural_equal(mod["main"], partitioned_main)
+
+
 if __name__ == "__main__":
-    test_basic()
-    test_const_loop()
-    test_multi_loop()
-    test_multi_if()
-    test_thread_axis()
-    test_vectorize()
-    test_condition()
-    test_condition_EQ()
-    test_thread_axis2()
-    test_everything_during_deduction()
-    test_single_likely()
-    test_multi_likely()
-    test_oneD_pool()
-    test_cce_loop_1()
-    test_cce_loop_2()
-    test_cce_loop_3()
-    test_conv_tiling()
-    test_double_splitting_with_indivisible_factors()
-    test_multilevel_splitting_with_indivisble_factors()
-    test_simple_rfactor()
-    test_explicit_partition_hint()
-    test_condition_mutually_exclusive()
+    tvm.testing.main()


### PR DESCRIPTION
Current  LoopPartition pass, for multiple conditions, when only part conditions are satisfied, it will be partitioned together.
This PR add a unroll_loop_with_partition_hint_no_interval attr in LoopPartitionConfig, when pragma_loop_partition_hint is set and the interval doesn't exist, the loop will be marked kUnrolled and do unroll actions in the following pass.

cc @Hzfengsy @junrushao1994 @wrongtest-intellif
