### PR TITLE
[Utils] Handled Callable in tir.schedule._type_checker

### DIFF
--- a/tests/python/unittest/test_type_annotation_checker.py
+++ b/tests/python/unittest/test_type_annotation_checker.py
@@ -17,11 +17,20 @@
 """Test type checker based on python's type annotations"""
 
 import sys
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Callable
 
 import pytest
+import _pytest
 
 from tvm.tir.schedule._type_checker import type_checked
+
+
+def int_func(x: int) -> int:
+    return 2 * x
+
+
+def str_func(x: str) -> str:
+    return 2 * x
 
 
 test_cases = [
@@ -90,30 +99,71 @@ test_cases = [
             None,
         ],
     },
+    {
+        "type_annotation": Callable,
+        "positive_cases": [str_func, int_func],
+        "negative_cases": [
+            None,
+            "x",
+            42,
+        ],
+    },
+    {
+        "type_annotation": Callable[[int], int],
+        "positive_cases": [int_func],
+        "negative_cases": [
+            None,
+            "x",
+            42,
+            pytest.param(
+                str_func,
+                marks=pytest.mark.xfail(
+                    reason="Signature of Callable arguments not currently checked"
+                ),
+            ),
+        ],
+    },
 ]
 
+
+def make_parametrization(type_annotation, case):
+    if isinstance(case, _pytest.mark.structures.ParameterSet):
+        marks = case.marks
+        (case,) = case.values
+    else:
+        marks = []
+
+    try:
+        annotation_name = type_annotation.__name__
+    except AttributeError:
+        annotation_name = str(type_annotation).replace("typing.", "")
+
+    if hasattr(case, "__name__"):
+        case_name = case.__name__
+    else:
+        case_name = str(case)
+
+    name = f"{annotation_name}, {case_name}"
+
+    return pytest.param(type_annotation, case, marks=marks, id=name)
+
+
 positive_cases = [
-    (config["type_annotation"], case) for config in test_cases for case in config["positive_cases"]
+    make_parametrization(config["type_annotation"], case)
+    for config in test_cases
+    for case in config["positive_cases"]
 ]
 
 negative_cases = [
-    (config["type_annotation"], case) for config in test_cases for case in config["negative_cases"]
+    make_parametrization(config["type_annotation"], case)
+    for config in test_cases
+    for case in config["negative_cases"]
 ]
-
-
-def format_name(type_annotation, case):
-    try:
-        name = type_annotation.__name__
-    except AttributeError:
-        name = str(type_annotation).replace("typing.", "")
-
-    return f"{name}_{case}"
 
 
 @pytest.mark.parametrize(
     ["type_annotation", "case"],
     positive_cases,
-    ids=[format_name(t, c) for t, c in positive_cases],
 )
 def test_matches_type(type_annotation, case):
     @type_checked
@@ -126,7 +176,6 @@ def test_matches_type(type_annotation, case):
 @pytest.mark.parametrize(
     ["type_annotation", "case"],
     negative_cases,
-    ids=[format_name(t, c) for t, c in negative_cases],
 )
 def test_not_matches(type_annotation, case):
     @type_checked


### PR DESCRIPTION
Previously, `Callable` was handled as an atomic type.  This worked when it was included as last element of a `Union[]` annotation with no subtypes, but raised an error for other use cases, including `Optional[Callable]`.

This commit adds explicit checks for `Callable` type annotations to validate whether the argument is callable, but doesn't recursively validate the signature of the callable object, because lambda functions cannot have type annotations. (https://peps.python.org/pep-3107/#lambda)