### PR TITLE
[HEXAGON] Disable automatic unrolling in LLVM

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -517,7 +517,8 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   // TODO(joshherr-quic): figure out why unroll is causing significant compile
   // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
-  llvm_options_vec.insert({"-unroll-threshold=0"});
+  llvm_options_vec.insert(std::next(llvm_options_vec.begin()),
+                          {"-unroll-threshold=0"});
 #endif
 
   // Process extra command line options for LLVM. Make sure it's only

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -517,8 +517,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   // TODO(joshherr-quic): figure out why unroll is causing significant compile
   // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
-  llvm_options_vec.insert(std::next(llvm_options_vec.begin()),
-                          {"-unroll-threshold=0"});
+  llvm_options_vec.insert(std::next(llvm_options_vec.begin()), {"-unroll-threshold=0"});
 #endif
 
   // Process extra command line options for LLVM. Make sure it's only

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -518,7 +518,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
   llvm_options_vec.insert(std::next(llvm_options_vec.begin()),
-                          {"-unroll-threshold=32"});
+                          {"-unroll-threshold=0"});
 #endif
 
   // Process extra command line options for LLVM. Make sure it's only

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -518,7 +518,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
   llvm_options_vec.insert(std::next(llvm_options_vec.begin()),
-                          {"-unroll-threshold=0"});
+                          {"-unroll-threshold=32"});
 #endif
 
   // Process extra command line options for LLVM. Make sure it's only

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -514,7 +514,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
                            "-force-target-max-vector-interleave=1", "-hexagon-autohvx=1"});
 
   // Disable unrolling (bug fix in LLVM 16 for int8 vectors)
-  // TODO: figure out why unroll is causing significant compile
+  // TODO(joshherr-quic): figure out why unroll is causing significant compile
   // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
   llvm_options_vec.insert({"-unroll-threshold=0"})

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -510,8 +510,13 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   std::vector<std::string> llvm_options_vec = split(llvm_options_str);
   assert(llvm_options_vec.size() >= 1 && llvm_options_vec[0] == "llvm");
   llvm_options_vec.insert(std::next(llvm_options_vec.begin()),
-                          {"-hexagon-small-data-threshold=0", "-unroll-threshold=0",
+                          {"-hexagon-small-data-threshold=0",
                            "-force-target-max-vector-interleave=1", "-hexagon-autohvx=1"});
+
+  // Disable unrolling (bug fix in LLVM 16 for int8 vectors)
+#if TVM_LLVM_VERSION >= 160
+  llvm_options_vec.insert({"-unroll-threshold=0"})
+#endif
 
   // Process extra command line options for LLVM. Make sure it's only
   // done once.

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -517,7 +517,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   // TODO(joshherr-quic): figure out why unroll is causing significant compile
   // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
-  llvm_options_vec.insert({"-unroll-threshold=0"})
+  llvm_options_vec.insert({"-unroll-threshold=0"});
 #endif
 
   // Process extra command line options for LLVM. Make sure it's only

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -514,6 +514,8 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
                            "-force-target-max-vector-interleave=1", "-hexagon-autohvx=1"});
 
   // Disable unrolling (bug fix in LLVM 16 for int8 vectors)
+  // TODO: figure out why unroll is causing significant compile
+  // time and binary size issues for bert int8 model among others.
 #if TVM_LLVM_VERSION >= 160
   llvm_options_vec.insert({"-unroll-threshold=0"})
 #endif

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -510,7 +510,7 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
   std::vector<std::string> llvm_options_vec = split(llvm_options_str);
   assert(llvm_options_vec.size() >= 1 && llvm_options_vec[0] == "llvm");
   llvm_options_vec.insert(std::next(llvm_options_vec.begin()),
-                          {"-hexagon-small-data-threshold=0",
+                          {"-hexagon-small-data-threshold=0", "-unroll-threshold=0",
                            "-force-target-max-vector-interleave=1", "-hexagon-autohvx=1"});
 
   // Process extra command line options for LLVM. Make sure it's only


### PR DESCRIPTION
Automatic unrolling in LLVM was causing significant issues with compile time and binary size of a bert int8 model. This patch disables unrolling in LLVM for the hexagon backend. While not a permanent solution, this should unblock some development efforts on this path.


cc @mehrdadh