### PR TITLE
[ci][wip] Break up lint step

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -95,8 +95,12 @@ def pytest_collection_modifyitems(config, items):
     items_copy = list(items)
     for item in items_copy:
         item_shard_index = find_shard_index(item.nodeid, num_shards=num_shards)
-        if item_shard_index != shard_index:
-            items.remove(item)
+        item.add_marker(
+            pytest.mark.skipif(
+                item_shard_index != shard_index,
+                reason=f"Test running on shard {item_shard_index} of {num_shards}",
+            )
+        )
 
 
 def pytest_sessionstart():


### PR DESCRIPTION
This part of CI fails most often and dependably, plus we need several
machines for the following build steps anyways so there's no harm in
parallelizing the lint more to decrease runtime