### PR TITLE
[microTVM]Fix test util functions

### DIFF
--- a/python/tvm/micro/testing/evaluation.py
+++ b/python/tvm/micro/testing/evaluation.py
@@ -153,7 +153,7 @@ def predict_labels_aot(session, aot_executor, input_data, runs_per_sample=1):
     assert runs_per_sample > 0
 
     for counter, sample in enumerate(input_data):
-        logging.info(f"Evaluating sample {counter}")
+        logging.info("Evaluating sample %d", counter)
         aot_executor.get_input(0).copyfrom(sample)
         result = aot_executor.module.time_evaluator("run", session.device, number=runs_per_sample)()
         predicted_label = aot_executor.get_output(0).numpy().argmax()

--- a/python/tvm/micro/testing/evaluation.py
+++ b/python/tvm/micro/testing/evaluation.py
@@ -22,6 +22,7 @@ tests in the future.
 
 """
 
+import logging
 from io import StringIO
 from pathlib import Path
 from contextlib import ExitStack
@@ -151,7 +152,8 @@ def predict_labels_aot(session, aot_executor, input_data, runs_per_sample=1):
     assert aot_executor.get_num_outputs() == 1
     assert runs_per_sample > 0
 
-    for sample in input_data:
+    for counter, sample in enumerate(input_data):
+        logging.info(f"Evaluating sample {counter}")
         aot_executor.get_input(0).copyfrom(sample)
         result = aot_executor.module.time_evaluator("run", session.device, number=runs_per_sample)()
         predicted_label = aot_executor.get_output(0).numpy().argmax()

--- a/python/tvm/micro/testing/utils.py
+++ b/python/tvm/micro/testing/utils.py
@@ -45,12 +45,12 @@ def get_supported_boards(platform: str):
         return json.load(f)
 
 
-def get_target(platform: str, board: str):
+def get_target(platform: str, board: str) -> tvm.target.Target:
     """Intentionally simple function for making target strings for microcontrollers.
     If you need more complex arguments, one should call target.micro directly. Note
     that almost all, but not all, supported microcontrollers are Arm-based."""
     model = get_supported_boards(platform)[board]["model"]
-    return str(tvm.target.target.micro(model, options=["-device=arm_cpu"]))
+    return tvm.target.target.micro(model, options=["-device=arm_cpu"])
 
 
 def check_tune_log(log_path: Union[Path, str]):

--- a/python/tvm/micro/testing/utils.py
+++ b/python/tvm/micro/testing/utils.py
@@ -46,7 +46,7 @@ def get_supported_boards(platform: str):
 
 
 def get_target(platform: str, board: str) -> tvm.target.Target:
-    """Intentionally simple function for making target strings for microcontrollers.
+    """Intentionally simple function for making Targets for microcontrollers.
     If you need more complex arguments, one should call target.micro directly. Note
     that almost all, but not all, supported microcontrollers are Arm-based."""
     model = get_supported_boards(platform)[board]["model"]


### PR DESCRIPTION
This PR: changes `get_target` to return Target instead of str and also add's logging to the predict function

cc @alanmacd @areusch @gromero @guberti