### PR TITLE
[microTVM][Zephyr] Add missing CMSIS-NN source files to cmake file

### DIFF
--- a/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
+++ b/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
@@ -32,7 +32,7 @@ if(${ENABLE_CMSIS})
   set(CMSIS_PATH <CMSIS_PATH>)
 
   file(GLOB_RECURSE cmsis_lib_srcs
-    ${CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/*.c]
+    ${CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/BasicMathFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/ConcatenationFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/*.c

--- a/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
+++ b/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
@@ -32,11 +32,16 @@ if(${ENABLE_CMSIS})
   set(CMSIS_PATH <CMSIS_PATH>)
 
   file(GLOB_RECURSE cmsis_lib_srcs
-    ${CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/*.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/*.c]
+    ${CMSIS_PATH}/CMSIS/NN/Source/BasicMathFunctions/*.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/ConcatenationFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/*.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/ReshapeFunctions/*.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/SVDFunctions/*.c
+    ${CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/*.c
   )
 
   set(cmsis_includes

--- a/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
+++ b/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
@@ -40,7 +40,6 @@ if(${ENABLE_CMSIS})
     ${CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/ReshapeFunctions/*.c
-    ${CMSIS_PATH}/CMSIS/NN/Source/SVDFunctions/*.c
     ${CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/*.c
   )
 


### PR DESCRIPTION
This PR adds missing CMSIS-NN source files to Zephyr cmake template file for models like keyword spotting, anomaly detection, VWW and image classification.

cc @alanmacd @areusch @gromero