### PR TITLE
[Adreno] Define memory_info for global.texture*

### DIFF
--- a/include/tvm/target/target_info.h
+++ b/include/tvm/target/target_info.h
@@ -37,11 +37,11 @@ namespace tvm {
 class MemoryInfoNode : public Object {
  public:
   /*! \brief The addressable unit */
-  int unit_bits;
+  int64_t unit_bits;
   /*! \brief Maximum number of bits supported in the memory */
-  int max_num_bits;
+  int64_t max_num_bits;
   /*! \brief maximum number of bits to be used in simd op */
-  int max_simd_bits;
+  int64_t max_simd_bits;
   /*!
    * \brief head address of the buffer, if visible to CPU
    *  This address can be None.

--- a/python/tvm/topi/adreno/utils.py
+++ b/python/tvm/topi/adreno/utils.py
@@ -20,6 +20,7 @@
 import tvm
 import numpy
 from tvm import te
+from tvm._ffi.registry import register_func
 from tvm.topi.utils import simplify
 from tvm.topi import nn
 from tvm.autotvm.task.space import SplitEntity
@@ -569,6 +570,19 @@ def get_texture_storage(shape):
         return "global.texture-nhwc"
     else:
         return "global.texture-weight"
+
+
+@register_func("tvm.info.mem.global.texture")
+@register_func("tvm.info.mem.global.texture-nhwc")
+@register_func("tvm.info.mem.global.texture-weight")
+def mem_info_global_texture_variants():
+    return tvm.ir.make_node(
+        "MemoryInfo",
+        unit_bits=16,
+        max_num_bits=16384 * 16384 * 4 * 32,
+        max_simd_bits=4 * 32,
+        head_address=None,
+    )
 
 
 def infer_tile_size(data, layout):


### PR DESCRIPTION
There are now many warnings in the tuning process about undefined memory information when using textures. A definition is required as textures* are tagged.