### PR TITLE
[ETHOSN] Update driver stack version to 22.08

### DIFF
--- a/docker/install/ubuntu_install_ethosn_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosn_driver_stack.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
 repo_dir="ethosn-driver"
-repo_revision="22.05"
+repo_revision="22.08"
 install_path="/opt/arm/$repo_dir"
 
 tmpdir=$(mktemp -d)

--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -102,11 +102,11 @@ def partition_for_ethosn(mod, params=None, **opts):
         raise ValueError("When targeting Ethos(TM)-N78, -variant=n78 should be set.")
 
     api_version = ethosn_api_version()
-    expected_api_version = "3.0.1"
-    if api_version != LooseVersion(expected_api_version):
+    supported_api_versions = ["3.0.1", "3.1.0"]
+    if all(api_version != LooseVersion(exp_ver) for exp_ver in supported_api_versions):
         raise ValueError(
             f"Driver stack version {api_version} is unsupported. "
-            f"Please use version {expected_api_version}."
+            f"Please use version in {supported_api_versions}."
         )
 
     if params:
@@ -397,7 +397,7 @@ def split(expr):
     """Check if a split is supported by Ethos-N."""
     if not ethosn_available():
         return False
-    if ethosn_api_version() >= LooseVersion("3.0.1"):
+    if ethosn_api_version() == LooseVersion("3.0.1"):
         return False
     if not _ethosn.split(expr):
         return False

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position, wrong-import-order
+
 """Arm(R) Ethos(TM)-N integration end-to-end network tests"""
 
 import pytest
@@ -22,11 +23,16 @@ import pytest
 pytest.importorskip("tflite")
 pytest.importorskip("tensorflow")
 
+from distutils.version import LooseVersion
+
 import tflite.Model
+
 from tvm import relay
 from tvm.testing import requires_ethosn
 from tvm.contrib import download
+from tvm.relay.op.contrib.ethosn import ethosn_api_version
 import tvm.relay.testing.tf as tf_testing
+
 from . import infrastructure as tei
 
 
@@ -119,7 +125,10 @@ def test_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"50186822915909303e813205db80e032"}
+    if ethosn_api_version() == LooseVersion("3.1.0"):
+        _compile_hash = {"c37fec1f214c7f93ce49ee4e3b587969"}
+    else:
+        _compile_hash = {"50186822915909303e813205db80e032"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz",
@@ -141,7 +150,10 @@ def test_resnet_50_int8():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"9245965b2c01e7f3d9b478e38a186eb4", "4225fa951c145bb1e48e28cad6a3bdd4"}
+    if ethosn_api_version() == LooseVersion("3.1.0"):
+        _compile_hash = {"12d65aec33594c88b6d0d31dcd5144e6", "6a64d69ccb36dfb6b30dd2abdba4b005"}
+    else:
+        _compile_hash = {"9245965b2c01e7f3d9b478e38a186eb4", "4225fa951c145bb1e48e28cad6a3bdd4"}
     _test_image_network(
         model_url="https://raw.githubusercontent.com/dmlc/web-data/main/tensorflow/"
         "models/Quantized/resnet_50_quantized.tflite",
@@ -162,7 +174,10 @@ def test_inception_v3():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"a5a2b5d2b618de754bf9a01033a020c0"}
+    if ethosn_api_version() == LooseVersion("3.1.0"):
+        _compile_hash = {"cff892eb15944756f22dad4b83c756d2"}
+    else:
+        _compile_hash = {"a5a2b5d2b618de754bf9a01033a020c0"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/tflite_11_05_08/inception_v3_quant.tgz",
@@ -183,7 +198,10 @@ def test_inception_v4():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"61b4ade41898d7cb2451dbdc3340aced"}
+    if ethosn_api_version() == LooseVersion("3.1.0"):
+        _compile_hash = {"2eeae331898f8e94c74868e190077837"}
+    else:
+        _compile_hash = {"61b4ade41898d7cb2451dbdc3340aced"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/inception_v4_299_quant_20181026.tgz",
@@ -204,7 +222,10 @@ def test_ssd_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"789906c7d8ac787809b303d82781fc9d", "6b699f94795785d31b39940a5cf84a81"}
+    if ethosn_api_version() == LooseVersion("3.1.0"):
+        _compile_hash = {"ec2b78852192058f88b64d45c26620d5", "f68cbeaaba03874ea735ce3f5eab9227"}
+    else:
+        _compile_hash = {"789906c7d8ac787809b303d82781fc9d", "6b699f94795785d31b39940a5cf84a81"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip",

--- a/tests/python/contrib/test_ethosn/test_resize.py
+++ b/tests/python/contrib/test_ethosn/test_resize.py
@@ -108,19 +108,10 @@ def test_resize(dtype, shape, size, coordinate_transformation_mode, rounding_met
             (20, 30),
             "Requested width isn't supported",
         ),
-        (
-            (19, 20),
-            "Requested width and height must be both even or both odd",
-        ),
-        (
-            (20, 19),
-            "Requested width and height must be both even or both odd",
-        ),
     ],
 )
 def test_resize_failure(size, err_msg):
     """Check Resize error messages."""
-
     dtype = "int8"
     zp_min = np.iinfo(dtype).min
 

--- a/tests/python/contrib/test_ethosn/test_split.py
+++ b/tests/python/contrib/test_ethosn/test_split.py
@@ -17,12 +17,15 @@
 
 """Split tests for Arm(R) Ethos(TM)-N"""
 
+from distutils.version import LooseVersion
+
 import numpy as np
 import pytest
 
 import tvm
 from tvm import relay
 from tvm.testing import requires_ethosn
+from tvm.relay.op.contrib.ethosn import ethosn_api_version
 
 from . import infrastructure as tei
 
@@ -33,7 +36,6 @@ def _get_model(shape, dtype, splits, axis):
     return split.astuple()
 
 
-@pytest.mark.skip("Split is not supported by the 3.0.1 version of the driver stack.")
 @requires_ethosn
 @pytest.mark.parametrize("dtype", ["uint8", "int8"])
 @pytest.mark.parametrize(
@@ -45,6 +47,11 @@ def _get_model(shape, dtype, splits, axis):
 )
 def test_split(dtype, shape, splits, axis):
     """Compare Split output with TVM."""
+    if ethosn_api_version() == LooseVersion("3.0.1"):
+        pytest.skip(
+            "Split is not supported by the 3.0.1 version of the driver stack.",
+        )
+
     np.random.seed(0)
 
     outputs = []
@@ -62,7 +69,6 @@ def test_split(dtype, shape, splits, axis):
         tei.verify(outputs, dtype, 0)
 
 
-@pytest.mark.skip("Split is not supported by the 3.0.1 version of the driver stack.")
 @requires_ethosn
 @pytest.mark.parametrize(
     "shape,dtype,splits,axis,err_msg",
@@ -83,6 +89,11 @@ def test_split(dtype, shape, splits, axis):
 )
 def test_split_failure(shape, dtype, splits, axis, err_msg):
     """Check Split error messages."""
+    if ethosn_api_version() == LooseVersion("3.0.1"):
+        pytest.skip(
+            "Split is not supported by the 3.0.1 version of the driver stack.",
+        )
+
     model = _get_model(shape, dtype, splits, axis)
     mod = tei.make_ethosn_partition(model)
     tei.test_error(mod, {}, err_msg)


### PR DESCRIPTION
Updates the driver stack used by the NPU to the latest released version (semantic version 3.1.0), while maintaining backwards compatibility for the previous version 22.05 (semantic 3.0.1) during the migration period. In addition, support for split is re introduced as this is now supported in 22.08.

cc @leandron @NicolaLancellotti 