### PR TITLE
[Frontend][Paddle] Fix op in paddle did't transmit layout information

### DIFF
--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -1193,6 +1193,7 @@ def convert_pool2d(g, op, block):
     paddings = op.attr("paddings")
     padding_algorithm = op.attr("padding_algorithm")
     pooling_type = op.attr("pooling_type")
+    data_format = op.attr("data_format")
 
     if global_pooling:
         adaptive = True
@@ -1260,7 +1261,9 @@ def convert_pool2d(g, op, block):
                 input_x, pool_size=ksize, strides=strides, padding=paddings, ceil_mode=ceil_mode
             )
     else:
-        out = getattr(_op.nn, "adaptive_" + op_map[pooling_type])(input_x, output_size=ksize)
+        out = getattr(_op.nn, "adaptive_" + op_map[pooling_type])(
+            input_x, output_size=ksize, layout=data_format
+        )
     g.add_node(op.output("Out")[0], out)
 
 


### PR DESCRIPTION
Related to #12645.
I noticed that in the front-end conversion of paddle, all operators do not pass data_format information. 
I want to know whether data_format needs to be passed, or the operators in the paddle model are all set according to the default layout of the `python/tvm/relay/op/nn/nn.py`? And the author of #12645 should not diy the layout ? 
Please let me know if anything is wrong.
