### PR TITLE
Add methods to get and set late-bound constants.

### DIFF
--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -127,12 +127,25 @@ class TVM_DLL Executable : public ModuleNode {
   void MoveLateBoundConstantsToFile(const std::string& path, size_t byte_limit);
 
   /*!
+   * \brief Get a map of all constants with larger that byte_limit in size.
+   */
+  Map<String, NDArray> GetLateBoundConstants(size_t byte_limit);
+
+  /*!
    * \brief Restores the late-bound constants for the executable (if any) from given byte-stream.
    *
    * Must be called after \p Load but before any other methods if \p MoveLateBoundConstantsToBinary
    * was used when saving. Otherwise can be ignored.
    */
   void LoadLateBoundConstantsFromStream(dmlc::Stream* stream);
+
+  /*!
+   * \brief Restores the late-bound constants for the executable (if any) from given map.
+   *
+   * Must be called after \p Load but before any other methods if \p MoveLateBoundConstantsToBinary
+   * was used when saving. Otherwise can be ignored.
+   */
+  void LoadLateBoundConstantsFromMap(Map<String, NDArray> map);
 
   /*!
    * \brief As for \p LoadLateBoundConstantsFromStream, but load from file at \p path.

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -322,7 +322,7 @@ class Executable(object):
         """Re-load constants previously saved to file at path"""
         return self._load_late_bound_consts(path)
 
-    def load_late_bound_consts(self, map):
+    def load_late_bound_consts_from_map(self, map):
         """Re-load constants supplied in map"""
         return self._load_late_bound_consts_from_map(map)
 

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -86,7 +86,9 @@ class Executable(object):
         self._get_function_arity = self.mod["get_function_arity"]
         self._get_function_param_name = self.mod["get_function_param_name"]
         self._move_late_bound_consts = self.mod["move_late_bound_consts"]
+        self._get_late_bound_consts = self.mod["get_late_bound_consts"]
         self._load_late_bound_consts = self.mod["load_late_bound_consts"]
+        self._load_late_bound_consts_from_map = self.mod["load_late_bound_consts_from_map"]
 
     def save(self):
         """Save the Relay VM Executable.
@@ -312,9 +314,17 @@ class Executable(object):
         """Move all constants of byte size greater or equal to byte_limit to file at path"""
         return self._move_late_bound_consts(path, byte_limit)
 
+    def get_late_bound_consts(self, byte_limit):
+        """Return all constants of byte size greater or equal to byte_limit"""
+        return self._get_late_bound_consts(byte_limit)
+
     def load_late_bound_consts(self, path):
         """Re-load constants previously saved to file at path"""
         return self._load_late_bound_consts(path)
+
+    def load_late_bound_consts(self, map):
+        """Re-load constants supply in map"""
+        return self._load_late_bound_consts_from_map(map)
 
 
 class VirtualMachine(object):

--- a/python/tvm/runtime/vm.py
+++ b/python/tvm/runtime/vm.py
@@ -323,7 +323,7 @@ class Executable(object):
         return self._load_late_bound_consts(path)
 
     def load_late_bound_consts(self, map):
-        """Re-load constants supply in map"""
+        """Re-load constants supplied in map"""
         return self._load_late_bound_consts_from_map(map)
 
 

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -334,7 +334,7 @@ Map<String, NDArray> Executable::GetLateBoundConstants(size_t byte_limit) {
     map.Set(name, Downcast<NDArray>(std::move(constants[const_index])));
     late_bound_constant_names.emplace_back(std::move(name));
   }
-  VLOG(1) << "found " << map.size() << " constants of " << total_late_bound_bytes
+  VLOG(1) << "moved " << map.size() << " constants of " << total_late_bound_bytes
           << " bytes (out of " << constants.size() << " overall) to be late-bound";
   return map;
 }

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -97,11 +97,24 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
       uint64_t byte_limit = args[1];
       MoveLateBoundConstantsToFile(path, static_cast<size_t>(byte_limit));
     });
+  } else if (name == "get_late_bound_consts") {
+    return PackedFunc([this](TVMArgs args, TVMRetValue* rv) {
+      CHECK_EQ(args.size(), 1);
+      uint64_t byte_limit = args[0];
+      Map<String, NDArray> consts = GetLateBoundConstants(static_cast<size_t>(byte_limit));
+      *rv = consts;
+    });
   } else if (name == "load_late_bound_consts") {
     return PackedFunc([this](TVMArgs args, TVMRetValue* rv) {
       CHECK_EQ(args.size(), 1);
       std::string path = args[0];
       LoadLateBoundConstantsFromFile(path);
+    });
+  } else if (name == "load_late_bound_consts_from_map") {
+    return PackedFunc([this](TVMArgs args, TVMRetValue* rv) {
+      CHECK_EQ(args.size(), 1);
+      Map<String, NDArray> map = args[0];
+      LoadLateBoundConstantsFromMap(map);
     });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -1405,5 +1405,53 @@ def test_vm_save_and_load_without_designating_late_bound_consts():
     tvm.testing.assert_allclose(expected, actual.numpy())
 
 
+def test_load_and_save_constants_via_map():
+    """Large constants can be serialized outside of executable"""
+    target = tvm.target.Target("llvm")
+    dev = tvm.cpu()
+
+    # fn(x) { add(x, <large constant>) }
+    x = relay.var("x", shape=(1000, 1000))
+    const_data = np.random.rand(1000, 1000).astype("float32")
+    const = relay.const(const_data, dtype="float32")
+    func = relay.Function([x], relay.op.add(x, const))
+    mod = tvm.IRModule.from_expr(func)
+
+    # Compile to executable.
+    vm_exec = vm.compile(mod, target=target)
+
+    consts_map = vm_exec.get_late_bound_consts(byte_limit=256)
+
+    # Save to constants and library files
+    temp = utils.tempdir()
+    path_dso = temp.relpath("lib.so")
+    vm_exec.mod.export_library(path_dso)
+
+    # Load library files and constants
+    mod = runtime.load_module(path_dso)
+    mod["load_late_bound_consts_from_map"](consts_map)
+
+    # Test main
+    x_data = np.random.rand(1000, 1000).astype("float32")
+    the_vm = runtime.vm.VirtualMachine(mod, dev)
+    actual = the_vm.invoke("main", x_data)
+    expected = x_data + const_data
+    tvm.testing.assert_allclose(expected, actual.numpy())
+
+    # We load the mod again so it's missing the consts.
+    mod = runtime.load_module(path_dso)
+    exe = runtime.vm.Executable(mod)
+
+    # Also test loading consts via the VM's wrapper API.
+    exe.load_late_bound_consts_from_map(consts_map)
+
+    # Test main again with consts now loaded via the above API.
+    x_data = np.random.rand(1000, 1000).astype("float32")
+    the_vm = runtime.vm.VirtualMachine(exe, dev)
+    actual = the_vm.invoke("main", x_data)
+    expected = x_data + const_data
+    tvm.testing.assert_allclose(expected, actual.numpy())
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR adds methods to both get and set late-bound constants.

The current approach for saving and restoring a model's late-bound constants is via the either `MoveLateBoundConstantsToFile` and then this file can be reloaded to the Executable by calling `LoadLateBoundConstantsFromFile`. These methods save the constants to a file `consts`.

I have a need to save and restore the constants in a pre-existing format. In order to write these I added `GetLateBoundConstants`  which returns a Map of all late-bound contants. To restore the constants back to the Executable `LoadLateBoundConstantsFromMap` was added.

The PR arranges the code so that both `GetLateBoundConstants` and `LoadLateBoundConstantsFromMap` are used in the existing methods to write and read late-bound constants. This means there is minimal code change, functions were mostly just rearranged to expose the two new entry points.