### PR TITLE
[Hexagon] Create tests to showcase vtcm loading capabilities on Hexagon. 

### DIFF
--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -58,7 +58,7 @@ class Session:
         remote_kw: dict,
         session_name: str = "hexagon-rpc",
         remote_stack_size_bytes: int = 256 * 1024,  # Min size for main thread in QuRT/sim
-        rpc_receive_buffer_size_bytes: int = 1024 * 1024 * 1024,  # Size for passing hexagon tests
+        rpc_receive_buffer_size_bytes: int = 256 * 1024 * 1024,  # Size for passing hexagon tests
     ):
         self._launcher = launcher
         self._session_name: str = session_name

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -58,7 +58,7 @@ class Session:
         remote_kw: dict,
         session_name: str = "hexagon-rpc",
         remote_stack_size_bytes: int = 256 * 1024,  # Min size for main thread in QuRT/sim
-        rpc_receive_buffer_size_bytes: int = 5 * 1024 * 1024,  # Size for passing hexagon tests
+        rpc_receive_buffer_size_bytes: int = 1024 * 1024 * 1024,  # Size for passing hexagon tests
     ):
         self._launcher = launcher
         self._session_name: str = session_name

--- a/src/runtime/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon_buffer.cc
@@ -62,7 +62,7 @@ struct VTCMAllocation : public Allocation {
 
     // allocate nbytes of vtcm on a single page
     HEXAGON_SAFE_CALL(HAP_compute_res_attr_set_vtcm_param(&res_info, /*vtcm_size = */ nbytes,
-                                                          /*b_single_page = */ 1));
+                                                          /*b_single_page = */ 0));
 
     // TODO(HWE): Investigate why a non-zero timeout results in
     // hanging, both in the simulator and on hardware.
@@ -71,13 +71,14 @@ struct VTCMAllocation : public Allocation {
     if (context_id_) {
       data_ = HAP_compute_res_attr_get_vtcm_ptr(&res_info);
       if (!data_) {
-        LOG(ERROR) << "ERROR: Allocated VTCM ptr is null.";
+        LOG(ERROR) << "ERROR: HAP_compute_res_acquire returned nullptr when allocating VTCM.";
         HEXAGON_SAFE_CALL(HAP_compute_res_release(context_id_));
         return;
       }
     } else {
-      LOG(ERROR) << "ERROR: Unable to acquire requeisted resource.";
-      return;
+      LOG(FATAL) << "FATAL: HAP_compute_res_acquire failed to acquire requested VTCM resource.";
+      throw std::runtime_error(
+          "HAP_compute_res_acquire failed to acquire requested VTCM resource.");
     }
   }
   ~VTCMAllocation() {

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -165,6 +165,17 @@ void HexagonDeviceAPI::CopyDataFromTo(const void* from, size_t from_offset, void
   memcpy(static_cast<char*>(to) + to_offset, static_cast<const char*>(from) + from_offset, size);
 }
 
+TVM_REGISTER_GLOBAL("device_api.hexagon.mem_copy_DLTensor")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      DLTensor* dst = args[0];
+      DLTensor* src = args[1];
+      int size = args[2];
+
+      hexagon_user_dma_1d_sync(dst->data, src->data, size);
+
+      *rv = static_cast<int32_t>(0);
+    });
+
 TVM_REGISTER_GLOBAL("device_api.hexagon.mem_copy").set_body([](TVMArgs args, TVMRetValue* rv) {
   void* dst = args[0];
   void* src = args[1];

--- a/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
+++ b/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
@@ -1,0 +1,538 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Test different strategies for loading data into vtcm before running HVX workloads. """
+
+import numpy as np
+import tvm
+
+from tvm.script import tir as T
+from numpy.random import default_rng
+
+# TEST_OUTPUT_TEMPLATE = "Test with {} MB of data to load... \n    -No VTCM: {} Gops \n    -Basic VTCM: {} Gops \n    -Vectorized: {} Gops\n    -Vectorized and Parallelized: {} Gops\n    -Preallocated and Vectorized: {} Gops\n    -Preallocated, Vectorized, and Parallelized: {} Gops\n    -Single DMA: {} Gops\n    -Preloaded: {} Gops\n"
+TEST_OUTPUT_TEMPLATE = "{}, {}, {}, {}, {}, {}, {}, {}, {}"
+
+
+def apply_parallel_unroll_vectorize(sch, blocks, outer_split, unroll_split, vector_split):
+    for block in blocks:
+        vb, vi = sch.get_loops(block)
+        v = sch.fuse(vb, vi)
+        vbo, vbi, vio, vii = sch.split(v, factors=[outer_split, None, unroll_split, vector_split])
+        sch.vectorize(vii)
+        sch.unroll(vio)
+        sch.parallel(vbo)
+    return sch
+
+
+def apply_unroll_vectorize(sch, blocks, unroll_split, vector_split):
+    for block in blocks:
+        vb, vi = sch.get_loops(block)
+        v = sch.fuse(vb, vi)
+        _, vio, vii = sch.split(v, factors=[None, unroll_split, vector_split])
+        sch.vectorize(vii)
+        sch.unroll(vio)
+    return sch
+
+
+def apply_vrmpy_parallelization(sch):
+    block = sch.get_block("C")
+    b = sch.get_loops(block)
+    bo, _ = sch.split(b[0], factors=[4, None])
+    sch.parallel(bo)
+    return sch
+
+
+def apply_vtcm_cache_read_write(sch):
+    block = sch.get_block("C")
+    sch.cache_read(block, 0, "global.vtcm")
+    sch.cache_read(block, 1, "global.vtcm")
+    sch.cache_write(block, 0, "global.vtcm")
+    return sch
+
+
+def vrmpy(operations):
+    @T.prim_func
+    def operator(a: T.handle, b: T.handle, c: T.handle) -> None:
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        A = T.match_buffer(a, [operations, 128], dtype="uint8", align=128)
+        B = T.match_buffer(b, [operations, 128], dtype="uint8", align=128)
+        C = T.match_buffer(c, [operations, 32], dtype="int32", align=128)
+        for n in T.grid(operations):
+            with T.block("C"):
+                vn = T.axis.remap("S", [n])
+                C[vn, T.ramp(0, 1, 32)] = T.call_llvm_intrin(
+                    T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpyubv.128B"),
+                    T.uint32(2),
+                    T.reinterpret(A[vn, T.ramp(0, 1, 128)], dtype="int32x32"),
+                    T.reinterpret(B[vn, T.ramp(0, 1, 128)], dtype="int32x32"),
+                    dtype="int32x32",
+                )
+
+    return operator
+
+
+def preloaded_vrmpy(operations):
+    @T.prim_func
+    def operator(a: T.handle, b: T.handle, c: T.handle) -> None:
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        A = T.match_buffer(
+            a,
+            [T.cast(operations, "int32") * 128],
+            dtype="uint8",
+            align=128,
+            mem_scope="global.vtcm",
+        )
+        B = T.match_buffer(
+            b,
+            [T.cast(operations, "int32") * 128],
+            dtype="uint8",
+            align=128,
+            mem_scope="global.vtcm",
+        )
+        C = T.match_buffer(
+            c, [T.cast(operations, "int32") * 32], dtype="int32", align=128, mem_scope="global.vtcm"
+        )
+        for n in T.grid(operations):
+            with T.block("C"):
+                vn = T.axis.remap("S", [n])
+                C[T.ramp(T.cast(vn, "int32") * 32, 1, 32)] = T.call_llvm_intrin(
+                    T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpyubv.128B"),
+                    T.uint32(2),
+                    T.reinterpret(A[T.ramp(T.cast(vn, "int32") * 128, 1, 128)], dtype="int32x32"),
+                    T.reinterpret(B[T.ramp(T.cast(vn, "int32") * 128, 1, 128)], dtype="int32x32"),
+                    dtype="int32x32",
+                )
+
+    return operator
+
+
+def preallocated_vrmpy(operations):
+    size = operations * 128
+    out_size = operations * 32
+
+    @T.prim_func
+    def operator(
+        a: T.handle, b: T.handle, c: T.handle, a_v: T.handle, b_v: T.handle, c_v: T.handle
+    ) -> None:
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        A = T.match_buffer(a, [operations, 128], dtype="uint8", align=128, mem_scope="global")
+        B = T.match_buffer(b, [operations, 128], dtype="uint8", align=128, mem_scope="global")
+        C = T.match_buffer(c, [operations, 32], dtype="int32", align=128, mem_scope="global")
+        A_global_vtcm = T.match_buffer(
+            a_v, [size], dtype="uint8", align=128, mem_scope="global.vtcm"
+        )
+        B_global_vtcm = T.match_buffer(
+            b_v, [size], dtype="uint8", align=128, mem_scope="global.vtcm"
+        )
+        C_global_vtcm = T.match_buffer(
+            c_v, [out_size], dtype="int32", align=128, mem_scope="global.vtcm"
+        )
+        for n, i in T.grid(operations, 128):
+            with T.block("A_global.vtcm"):
+                vn, vi = T.axis.remap("SS", [n, i])
+                A_global_vtcm[vn * 128 + vi] = A[vn, vi]
+        for n, i in T.grid(operations, 128):
+            with T.block("B_global.vtcm"):
+                vn, vi = T.axis.remap("SS", [n, i])
+                B_global_vtcm[vn * 128 + vi] = B[vn, vi]
+        for n in T.grid(operations):
+            with T.block("C"):
+                vn = T.axis.remap("S", [n])
+                C_global_vtcm[T.ramp(T.cast(vn, "int32") * 32, 1, 32)] = T.call_llvm_intrin(
+                    T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpyubv.128B"),
+                    T.uint32(2),
+                    T.reinterpret(
+                        A_global_vtcm[T.ramp(T.cast(vn, "int32") * 128, 1, 128)], dtype="int32x32"
+                    ),
+                    T.reinterpret(
+                        B_global_vtcm[T.ramp(T.cast(vn, "int32") * 128, 1, 128)], dtype="int32x32"
+                    ),
+                    dtype="int32x32",
+                )
+        for n, i in T.grid(operations, 32):
+            with T.block("C_global.vtcm"):
+                vn, vi = T.axis.remap("SS", [n, i])
+                C[vn, vi] = C_global_vtcm[vn * 32 + vi]
+
+    return operator
+
+
+def preallocated_single_dma_vrmpy(operations):
+    size = operations * 128
+    out_size = operations * 32
+
+    @T.prim_func
+    def operator(
+        a: T.handle,
+        b: T.handle,
+        c: T.handle,
+        a_v: T.handle,
+        b_v: T.handle,
+        c_v: T.handle,
+    ) -> None:
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        A = T.match_buffer(a, [operations, 128], dtype="uint8", align=128, mem_scope="global")
+        B = T.match_buffer(b, [operations, 128], dtype="uint8", align=128, mem_scope="global")
+        C = T.match_buffer(c, [operations, 32], dtype="int32", align=128, mem_scope="global")
+        A_global_vtcm = T.match_buffer(
+            a_v, [size], dtype="uint8", align=128, mem_scope="global.vtcm"
+        )
+        B_global_vtcm = T.match_buffer(
+            b_v, [size], dtype="uint8", align=128, mem_scope="global.vtcm"
+        )
+        C_global_vtcm = T.match_buffer(
+            c_v, [out_size], dtype="int32", align=128, mem_scope="global.vtcm"
+        )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    A_global_vtcm.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    A_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    A.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    A.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size, dtype="int"),
+                dtype="int32",
+            )
+        )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    B_global_vtcm.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    B_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    B.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    B.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size, dtype="int"),
+                dtype="int32",
+            )
+        )
+        for n in T.grid(operations):
+            with T.block("C"):
+                vn = T.axis.remap("S", [n])
+                C_global_vtcm[T.ramp(T.cast(vn, "int32") * 32, 1, 32)] = T.call_llvm_intrin(
+                    T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpyubv.128B"),
+                    T.uint32(2),
+                    T.reinterpret(
+                        A_global_vtcm[T.ramp(T.cast(vn, "int32") * 128, 1, 128)], dtype="int32x32"
+                    ),
+                    T.reinterpret(
+                        B_global_vtcm[T.ramp(T.cast(vn, "int32") * 128, 1, 128)], dtype="int32x32"
+                    ),
+                    dtype="int32x32",
+                )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    C.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    C.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    C_global_vtcm.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    C_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size, dtype="int"),
+                dtype="int32",
+            )
+        )
+
+    return operator
+
+
+def evaluate_result(operations, tag, time, result, expected_output):
+    transfer_mb = round(3 * operations * 128 / 1e6, 2)
+    gops = round(operations * 128 * 3 / time.mean / 1e9, 3)
+    mean_ms = round(time.mean * 1000, 6)
+
+    print("\ntest_{}MB_{} took {} ms @ GOPS: {}".format(transfer_mb, tag, mean_ms, gops))
+    tvm.testing.assert_allclose(result, expected_output)
+
+
+def setup_and_run(hexagon_session, sch, a, b, c, operations, mem_scope="global"):
+    target_hexagon = tvm.target.hexagon("v69")
+    func_tir = tvm.build(
+        sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon)
+    )
+    module = hexagon_session.load_module(func_tir)
+
+    a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device, mem_scope=mem_scope)
+    b_hexagon = tvm.runtime.ndarray.array(b, device=hexagon_session.device, mem_scope=mem_scope)
+    c_hexagon = tvm.runtime.ndarray.array(c, device=hexagon_session.device, mem_scope=mem_scope)
+    timer = module.time_evaluator("__tvm_main__", hexagon_session.device, number=100, repeat=10)
+    time = timer(a_hexagon, b_hexagon, c_hexagon)
+    gops = round(operations * 128 * 3 / time.mean / 1e9, 4)
+    return gops, c_hexagon.asnumpy()
+
+
+def setup_and_run_preallocated(hexagon_session, sch, a, b, c, operations):
+    target_hexagon = tvm.target.hexagon("v69")
+    func_tir = tvm.build(
+        sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon)
+    )
+    module = hexagon_session.load_module(func_tir)
+
+    a_vtcm = np.zeros((a.size), dtype="uint8")
+    b_vtcm = np.zeros((b.size), dtype="uint8")
+    c_vtcm = np.zeros((c.size), dtype="int32")
+
+    a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device, mem_scope="global")
+    b_hexagon = tvm.runtime.ndarray.array(b, device=hexagon_session.device, mem_scope="global")
+    c_hexagon = tvm.runtime.ndarray.array(c, device=hexagon_session.device, mem_scope="global")
+    a_vtcm_hexagon = tvm.runtime.ndarray.array(
+        a_vtcm, device=hexagon_session.device, mem_scope="global.vtcm"
+    )
+    b_vtcm_hexagon = tvm.runtime.ndarray.array(
+        b_vtcm, device=hexagon_session.device, mem_scope="global.vtcm"
+    )
+    c_vtcm_hexagon = tvm.runtime.ndarray.array(
+        c_vtcm, device=hexagon_session.device, mem_scope="global.vtcm"
+    )
+
+    timer = module.time_evaluator("__tvm_main__", hexagon_session.device, number=100, repeat=10)
+    time = timer(a_hexagon, b_hexagon, c_hexagon, a_vtcm_hexagon, b_vtcm_hexagon, c_vtcm_hexagon)
+    gops = round(operations * 128 * 3 / time.mean / 1e9, 4)
+    return gops, c_hexagon.asnumpy()
+
+
+@tvm.testing.fixture
+def input_a(operations):
+    return default_rng().integers(0, 16, (operations, 128), dtype="uint8")
+
+
+@tvm.testing.fixture
+def input_b(operations):
+    return default_rng().integers(0, 16, (operations, 128), dtype="uint8")
+
+
+@tvm.testing.fixture
+def input_c(operations):
+    return np.zeros((operations, 32), dtype="int32")
+
+
+@tvm.testing.fixture
+def expected_output(operations, input_a, input_b, input_c):
+    expected_output = np.zeros(input_c.shape, dtype="int32")
+    for n in range(operations):
+        for i in range(32):
+            for r in range(4):
+                expected_output[n, i] = expected_output[n, i] + np.uint32(
+                    input_a[n, i * 4 + r]
+                ) * np.uint32(input_b[n, i * 4 + r])
+    return expected_output
+
+
+class TestMatMulVec:
+
+    operations = tvm.testing.parameter(
+        1024,
+        2048,
+        4096,
+        5 * 2048,  # 3.93MB of total transfer
+        16384,
+        5 * 4096,  # 7.86MB of total transfer
+    )
+
+    # Experimentally best configurations for the memcopy
+    outer_split = tvm.testing.parameter(4)
+    unroll_split = tvm.testing.parameter(8)
+    vector_split = tvm.testing.parameter(64)
+    c_vector_split = tvm.testing.parameter(16)
+    c_vector_split_unallocated = tvm.testing.parameter(8)
+
+    @tvm.testing.requires_hexagon
+    def test_loading_vtcm_for_vrmpy(
+        self,
+        hexagon_session,
+        operations,
+        input_a,
+        input_b,
+        input_c,
+        expected_output,
+        outer_split,
+        unroll_split,
+        vector_split,
+        c_vector_split,
+        c_vector_split_unallocated,
+    ):
+
+        # Run parallel vrmpy without loading to VTCM.
+        sch = tvm.tir.Schedule(vrmpy(operations))
+        sch = apply_vrmpy_parallelization(sch)
+        base_runtime, result = setup_and_run(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with basic memory loads to VTCM.
+        sch = tvm.tir.Schedule(vrmpy(operations))
+        sch = apply_vtcm_cache_read_write(sch)
+        sch = apply_vrmpy_parallelization(sch)
+        basic_load_runtime, result = setup_and_run(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with vectorized memory loads to VTCM.
+        sch = tvm.tir.Schedule(vrmpy(operations))
+        sch = apply_vtcm_cache_read_write(sch)
+        sch = apply_vrmpy_parallelization(sch)
+        sch = apply_unroll_vectorize(
+            sch,
+            [sch.get_block("A_global.vtcm"), sch.get_block("B_global.vtcm")],
+            unroll_split,
+            vector_split,
+        )
+        sch = apply_unroll_vectorize(
+            sch, [sch.get_block("C_global.vtcm")], unroll_split, c_vector_split_unallocated
+        )
+        vectorized_runtime, result = setup_and_run(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with vectorized and parallelized memory loads to VTCM.
+        sch = tvm.tir.Schedule(vrmpy(operations))
+        sch = apply_vtcm_cache_read_write(sch)
+        sch = apply_vrmpy_parallelization(sch)
+        sch = apply_parallel_unroll_vectorize(
+            sch,
+            [sch.get_block("A_global.vtcm"), sch.get_block("B_global.vtcm")],
+            outer_split,
+            unroll_split,
+            vector_split,
+        )
+        sch = apply_parallel_unroll_vectorize(
+            sch,
+            [sch.get_block("C_global.vtcm")],
+            outer_split,
+            unroll_split,
+            c_vector_split_unallocated,
+        )
+        vectorized_parallelized_runtime, result = setup_and_run(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with preallocated and vectorized memory loads to VTCM.
+        sch = tvm.tir.Schedule(preallocated_vrmpy(operations))
+        sch = apply_vrmpy_parallelization(sch)
+        sch = apply_unroll_vectorize(
+            sch,
+            [sch.get_block("A_global.vtcm"), sch.get_block("B_global.vtcm")],
+            unroll_split,
+            vector_split,
+        )
+        sch = apply_unroll_vectorize(
+            sch, [sch.get_block("C_global.vtcm")], unroll_split, c_vector_split
+        )
+        preallocated_vectorized_runtime, result = setup_and_run_preallocated(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        result = result.reshape((operations, 32))
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with preallocated, vectorized, and parallelized memory loads to VTCM.
+        sch = tvm.tir.Schedule(preallocated_vrmpy(operations))
+        sch = apply_vrmpy_parallelization(sch)
+        sch = apply_parallel_unroll_vectorize(
+            sch,
+            [sch.get_block("A_global.vtcm"), sch.get_block("B_global.vtcm")],
+            outer_split,
+            unroll_split,
+            vector_split,
+        )
+        sch = apply_parallel_unroll_vectorize(
+            sch, [sch.get_block("C_global.vtcm")], outer_split, unroll_split, c_vector_split
+        )
+        preallocated_vectorized_parallelized_runtime, result = setup_and_run_preallocated(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        result = result.reshape((operations, 32))
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with preallocated single dma memory load to VTCM.
+        sch = tvm.tir.Schedule(preallocated_single_dma_vrmpy(operations))
+        sch = apply_vrmpy_parallelization(sch)
+        single_dma_runtime, result = setup_and_run_preallocated(
+            hexagon_session, sch, input_a, input_b, input_c, operations
+        )
+        result = result.reshape((operations, 32))
+        tvm.testing.assert_allclose(result, expected_output)
+
+        # Run parallel vrmpy with data preloaded in VTCM.
+        sch = tvm.tir.Schedule(preloaded_vrmpy(operations))
+        sch = apply_vrmpy_parallelization(sch)
+        input_a = input_a.reshape(operations * 128)
+        input_b = input_b.reshape(operations * 128)
+        input_c = input_c.reshape(operations * 32)
+        preloaded_runtime, result = setup_and_run(
+            hexagon_session, sch, input_a, input_b, input_c, operations, "global.vtcm"
+        )
+        result = result.reshape((operations, 32))
+        tvm.testing.assert_allclose(result, expected_output)
+
+        transfer_mb = round(3 * operations * 128 / 1e6, 2)
+        print(
+            TEST_OUTPUT_TEMPLATE.format(
+                transfer_mb,
+                base_runtime,
+                basic_load_runtime,
+                vectorized_runtime,
+                vectorized_parallelized_runtime,
+                preallocated_vectorized_runtime,
+                preallocated_vectorized_parallelized_runtime,
+                single_dma_runtime,
+                preloaded_runtime,
+            )
+        )

--- a/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
+++ b/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
@@ -23,8 +23,7 @@ import tvm
 from tvm.script import tir as T
 from numpy.random import default_rng
 
-# TEST_OUTPUT_TEMPLATE = "Test with {} MB of data to load... \n    -No VTCM: {} Gops \n    -Basic VTCM: {} Gops \n    -Vectorized: {} Gops\n    -Vectorized and Parallelized: {} Gops\n    -Preallocated and Vectorized: {} Gops\n    -Preallocated, Vectorized, and Parallelized: {} Gops\n    -Single DMA: {} Gops\n    -Preloaded: {} Gops\n"
-TEST_OUTPUT_TEMPLATE = "{}, {}, {}, {}, {}, {}, {}, {}, {}"
+TEST_OUTPUT_TEMPLATE = "Test with {} MB of data to load... \n    -No VTCM: {} Gops \n    -Basic VTCM: {} Gops \n    -Vectorized: {} Gops\n    -Vectorized and Parallelized: {} Gops\n    -Preallocated and Vectorized: {} Gops\n    -Preallocated, Vectorized, and Parallelized: {} Gops\n    -Single DMA: {} Gops\n    -Preloaded: {} Gops\n"
 
 
 def apply_parallel_unroll_vectorize(sch, blocks, outer_split, unroll_split, vector_split):

--- a/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
+++ b/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
@@ -378,8 +378,8 @@ class TestMatMulVec:
         2048,
         4096,
         5 * 2048,  # 3.93MB of total transfer
-        16384,
-        5 * 4096,  # 7.86MB of total transfer
+        # 16384, #Only works on 8Gen1 HDK's
+        # 5 * 4096,  # 7.86MB of total transfer. Only works on 8Gen1 HDK's
     )
 
     # Experimentally best configurations for the memcopy

--- a/tests/python/contrib/test_hexagon/test_vtcm_bandwidth.py
+++ b/tests/python/contrib/test_hexagon/test_vtcm_bandwidth.py
@@ -122,7 +122,7 @@ class TestMatMulVec:
         2 * MB,
         3 * MB,
         4 * MB,
-        8 * MB,  # Only works on 8gen1 HDKs
+        # 8 * MB,  # Only works on 8gen1 HDKs
     )
 
     outer_split = tvm.testing.parameter(4)

--- a/tests/python/contrib/test_hexagon/test_vtcm_bandwidth.py
+++ b/tests/python/contrib/test_hexagon/test_vtcm_bandwidth.py
@@ -1,0 +1,169 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Test theoretical bandwith for data transfers to VTCM for different strategies."""
+
+import numpy as np
+from tests.python.contrib.test_hexagon.infrastructure import allocate_hexagon_array
+import tvm
+
+from tvm.script import tir as T
+from numpy.random import default_rng
+
+MB = 1024**2
+KB = 1024
+TEST_OUTPUT_TEMPLATE = "Test bandwidth with buffer size {}MB... \n    -Base: {} GBps \n    -Vectorized: {} GBps\n    -Vectorized and Parallelized: {} GBps\n    -Single DMA Copy: {} GBps\n"
+
+
+def memcopy_operator(size):
+    @T.prim_func
+    def operator(a: T.handle, a_v: T.handle) -> None:
+        A = T.match_buffer(a, size, dtype="int8", align=128, scope="global")
+        A_global_vtcm = T.match_buffer(a_v, size, dtype="int8", align=128, scope="global.vtcm")
+        for ax0 in T.serial(size):
+            with T.block("A_global.vtcm"):
+                v0 = T.axis.spatial(size, ax0)
+                T.reads(A[v0])
+                T.writes(A_global_vtcm[v0])
+                A_global_vtcm[v0] = A[v0]
+
+    return operator
+
+
+def single_dma_operator(size):
+    @T.prim_func
+    def operator(a: T.handle, a_v: T.handle) -> None:
+        A = T.match_buffer(a, size, dtype="int8", align=128, scope="global")
+        A_global_vtcm = T.match_buffer(a_v, size, dtype="int8", align=128, scope="global.vtcm")
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    A_global_vtcm.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    A_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    A.data,
+                    T.tvm_stack_make_shape(size, dtype="handle"),
+                    0,
+                    1,
+                    A.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size, dtype="int"),
+                dtype="int32",
+            )
+        )
+
+    return operator
+
+
+def evaluate(hexagon_session, sch, size):
+    a_shape = size
+
+    target_hexagon = tvm.target.hexagon("v69")
+    func_tir = tvm.build(
+        sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon)
+    )
+    module = hexagon_session.load_module(func_tir)
+
+    rng = default_rng()
+    a = rng.integers(-128, 127, a_shape, dtype="int8")
+    a_vtcm = np.zeros(a_shape, dtype="int8")
+
+    a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device, mem_scope="global")
+    a_vtcm_hexagon = tvm.runtime.ndarray.array(
+        a_vtcm, device=hexagon_session.device, mem_scope="global.vtcm"
+    )
+
+    # a_hexagon = allocate_hexagon_array(hexagon_session.device, data=a, mem_scope="global")
+    # a_vtcm_hexagon = allocate_hexagon_array(hexagon_session.device, data=a_vtcm, mem_scope="global.vtcm")
+
+    timer = module.time_evaluator("__tvm_main__", hexagon_session.device, number=100, repeat=10)
+    runtime = timer(a_hexagon, a_vtcm_hexagon)
+
+    gbps = round((size / 2**30) / runtime.mean, 4)
+    tvm.testing.assert_allclose(a_vtcm_hexagon.asnumpy(), a)
+
+    return gbps
+
+
+class TestMatMulVec:
+
+    size = tvm.testing.parameter(
+        10 * KB,
+        20 * KB,
+        40 * KB,
+        80 * KB,
+        160 * KB,
+        320 * KB,
+        640 * KB,
+        MB,
+        2 * MB,
+        3 * MB,
+        4 * MB,
+        8 * MB,  # Only works on 8gen1 HDKs
+    )
+
+    outer_split = tvm.testing.parameter(4)
+    unroll_split = tvm.testing.parameter(2)
+    vector_split = tvm.testing.parameter(128)
+
+    @tvm.testing.requires_hexagon
+    def test_bandwidth(self, hexagon_session, size, outer_split, unroll_split, vector_split):
+
+        # Run the base memcopy operator.
+        sch = tvm.tir.Schedule(memcopy_operator(size))
+        base_gpbs = evaluate(hexagon_session, sch, size)
+
+        # Run with some basic unroll and vectorize scheduling.
+        sch = tvm.tir.Schedule(memcopy_operator(size))
+        vtcm_block_a = sch.get_block("A_global.vtcm")
+        vb = sch.get_loops(vtcm_block_a)
+        vbi_a, vio_a, vii_a = sch.split(vb[0], factors=[None, unroll_split, vector_split])
+        sch.unroll(vio_a)
+        sch.vectorize(vii_a)
+        vectorize_gbps = evaluate(hexagon_session, sch, size)
+
+        # Run with some basic unroll and vectorize scheduling and parallelization.
+        sch = tvm.tir.Schedule(memcopy_operator(size))
+        vtcm_block_a = sch.get_block("A_global.vtcm")
+        vb = sch.get_loops(vtcm_block_a)
+        vbo_a, vbi_a, vio_a, vii_a = sch.split(
+            vb[0], factors=[outer_split, None, unroll_split, vector_split]
+        )
+        sch.unroll(vio_a)
+        sch.vectorize(vii_a)
+        sch.parallel(vbo_a)
+        parallel_gbps = evaluate(hexagon_session, sch, size)
+
+        # Run using a single dma copy to transfer the data.
+        sch = tvm.tir.Schedule(single_dma_operator(size))
+        single_dma_gbps = evaluate(hexagon_session, sch, size)
+
+        mbs = round(size / MB, 2)
+        print(
+            TEST_OUTPUT_TEMPLATE.format(
+                mbs, base_gpbs, vectorize_gbps, parallel_gbps, single_dma_gbps
+            )
+        )


### PR DESCRIPTION
## Background
In order to learn more about efficiently running on Hexagon, an investigation into how to properly utilize VTCM was performed. These are the initial results of that investigation and should serve as a good starting point for others looking to leverage VTCM while running on Hexagon. 

## Results
Below are the results from running a simple parallel vrmpy operation in several different configurations. Each configuration is described below. 

**Without VTCM:** This is just running the vrmpy operator without loading any data into VTCM 

**Basic VTCM Loads:** This introduces loops to copy the data into VTCM before running the compute without any scheduling of those data copy loops. 

**Vec Loads:** This applies the following scheduling to the data copy loops.  For the DDR -> VTCM loops it uses unroll_split = 8 and vector_split = 64. For VTCM -> DDR loop it uses unroll_split = 8 and vector_split = 8
```
vb, vi = sch.get_loops(block)
v = sch.fuse(vb, vi)
_, vio, vii = sch.split(v, factors=[None, unroll_split, vector_split])
sch.vectorize(vii)
sch.unroll(vio)
```

**Vec + Para Loads:** This applies the same schedule as above except it also parallelizes on an outer loop. The outer_split is always 4. 

```
vb, vi = sch.get_loops(block)
v = sch.fuse(vb, vi)
vbo, vbi, vio, vii = sch.split(v, factors=[outer_split, None, unroll_split, vector_split])
sch.vectorize(vii)
sch.unroll(vio)
sch.parallel(vbo)
```

**Pre + Vec Loads:** Same as "Vec Loads" except the VTCM buffers are allocated before runtime and passed into the operator. 

**Pre + Vec + Para Loads:** Same as "Vec + Para Loads" except the VTCM buffers are allocated before runtime and passed into the operator. 

**Single DMA Load:** A single DMA command is used to copy all of the data over to VTCM. This was preallocated since I could not get it to work without preallocation. 

**Preloaded:** All of the data is already loaded into VTCM before the test starts. 

### 8Gen1 HDK
Total Vrmpy Operations | Total Transfer (MB) | Without VTCM (Gops) | Basic VTCM Loads (Gops) | Vec Loads (Gops) | Vec + Para Loads (Gops) | Pre + Vec Loads (Gops) | Pre + Vec + Para Loads (Gops) | Single DMA Load (Gops) | Preloaded (Gops)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1024 | 0.39 | 95.0256 | 0.345 | 0.5408 | 0.5905 | 44.4814 | 32.8886 | 15.0813 | 124.7117
2048 | 0.79 | 124.2389 | 0.4002 | 0.7063 | 0.8826 | 43.5238 | 47.2871 | 16.1339 | 209.2688
4096 | 1.57 | 41.5497 | 0.4215 | 0.8664 | 1.1977 | 10.9374 | 26.5749 | 18.1754 | 241.1628
10240 | 3.93 | 33.2139 | 0.4419 | 1.0506 | 1.7311 | 11.7886 | 34.0405 | 25.4214 | 370.2948
16384 | 6.29 | 20.7683 | 0.4195 | 1.0568 | 1.898 | 7.7292 | 22.5898 | 29.7011 | 397.4137
20480 | 7.86 | 20.2128 | 0.4406 | 1.069 | 1.9779 | 6.6829 | 17.7941 | 25.4929 | 338.294


### 888 HDK
Total Vrmpy Operations | Total Transfer (MB) | Without VTCM (Gops) | Basic VTCM Loads (Gops) | Vec Loads (Gops) | Vec + Para Loads (Gops) | Pre + Vec Loads (Gops) | Pre + Vec + Para Loads (Gops) | Single DMA Load (Gops) | Preloaded (Gops)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1024 | 0.39 | 92.2826 | 0.5363 | 1.1438 | 1.3951 | 42.2813 | 37.2929 | 13.1085 | 121.4004
2048 | 0.79 | 98.8228 | 0.5269 | 1.1818 | 1.6554 | 43.9298 | 43.1773 | 14.5703 | 205.442
4096 | 1.57 | 22.1415 | 0.4095 | 0.988 | 1.5843 | 6.3227 | 16.1113 | 15.397 | 271.1367
10240 | 3.93 | 15.3377 | 0.4323 | 1.1091 | 1.9689 | 6.4958 | 18.68 | 17.9959 | 360.6824


Below are the results from copying data to vtcm with various strategies. The strategies are described below. 

**Base:** This copies the data into VTCM with a simple loop. 

**Unroll + Vectorize:** This applies the following scheduling to the data copy loop.  These tests use unroll_split=2 and vector_split=128 
```
vb = sch.get_loops(vtcm_block_a)
vbi_a, vio_a, vii_a = sch.split(vb[0], factors=[None, unroll_split, vector_split])
sch.unroll(vio_a)
sch.vectorize(vii_a)
```

**Unroll + Vectorize + Parallel:** This applies the same schedule as above except it also parallelizes on an outer loop. The outer_split is 4. 
```
vb = sch.get_loops(vtcm_block_a)
vbo_a, vbi_a, vio_a, vii_a = sch.split(vb[0], factors=[outer_split, None, unroll_split, vector_split])
sch.unroll(vio_a)
sch.vectorize(vii_a)
sch.parallel(vbo_a)
```

**Single DMA:** Copies the data into VTCM with a single DMA instruction. 

### 8Gen1 HDK
Total Transfer (MB) | Base (GBps) | Unroll + Vectorize (GBps) | Unroll + Vectorize + Parallel (GBps) | Single DMA (GBps)
-- | -- | -- | -- | --
0.01 | 2.2122 | 15.9211 | 4.8287 | 2.2524
0.02 | 2.3207 | 26.1998 | 9.5082 | 4.6669
0.04 | 2.4425 | 38.1089 | 17.5147 | 6.4492
0.08 | 2.5067 | 48.5949 | 32.507 | 9.1469
0.16 | 2.5507 | 57.6021 | 55.1855 | 11.1598
0.31 | 2.7053 | 62.8063 | 83.4726 | 15.2878
0.62 | 2.9199 | 74.3696 | 114.7925 | 17.6438
1 | 2.2645 | 49.8653 | 63.8026 | 18.8814
2 | 1.1232 | 10.3933 | 29.1977 | 20.6719
4 | 1.0683 | 9.6105 | 26.5143 | 25.201
8 | 0.6814 | 6.1916 | 24.049 | 26.1883

### 888 HDK
Total Transfer (MB) | Base (GBps) | Unroll + Vectorize (GBps) | Unroll + Vectorize + Parallel (GBps) | Single DMA (GBps)
-- | -- | -- | -- | --
0.01MB | 2.6699 | 12.1178 | 4.3369 | 1.8245
0.02MB | 2.7955 | 24.6427 | 8.6658 | 3.4972
0.04MB | 3.0016 | 35.7516 | 14.4496 | 5.0863
0.08MB | 3.1047 | 37.8442 | 25.2964 | 7.2166
0.16MB | 3.2119 | 55.4663 | 43.0918 | 9.4149
0.31MB | 3.2614 | 61.023 | 65.6292 | 9.8254
0.62MB | 3.4791 | 70.5527 | 111.0134 | 10.7716
1.0MB | 1.5253 | 42.0009 | 45.3035 | 11.5082
2.0MB | 0.7137 | 5.29 | 17.3306 | 13.3808
4.0MB | 0.721 | 5.2936 | 19.2567 | 13.639



cc @csullivan @mehrdadh
