### PR TITLE
[MetaSchedule] Fix autoinline for single const consumer block

### DIFF
--- a/src/meta_schedule/schedule_rule/auto_inline.cc
+++ b/src/meta_schedule/schedule_rule/auto_inline.cc
@@ -104,7 +104,10 @@ inline InlineType AutoInlineNode::CheckInline(const tir::Schedule& sch,
   }
   // Cond 2. For a block that generates a constant tensor, ignore all other conditions
   if (inline_const_tensor && block->reads.empty()) {
-    return InlineType::kInlineIntoConsumer;
+    Array<tir::StmtSRef> consumer_srefs = GetConsumers(state, block_sref);
+    if (!consumer_srefs.empty() && CanComputeInline(state, block_sref)) {
+      return InlineType::kInlineIntoConsumer;
+    }
   }
   // Cond 3. The block doesn't contain any disallowed operators
   if (!is_pure_sptial && !disallow_op.empty() && HasOp(realize, disallow_op)) {


### PR DESCRIPTION
This PR intends to fix the CUDA auto-inline schedule rule while processing TIR block with one single constant consumer block. 
Before this PR, the TIR added in the test will throw the following error while being auto-inlined as it shouldn't be.:
```
E           ScheduleError: An error occurred in the schedule primitive 'compute-inline'.
E           The IR with diagnostic is:
E           # from tvm.script import tir as T
E           @tvm.script.ir_module
E           class Module:
E               @T.prim_func
E               def main(T_full: T.Buffer[(1, 12, 4096), "int64"]) -> None:
E                   # function attr dict
E                   T.func_attr({"global_symbol": "main", "tir.noalias": True})
E                   # body
E                   # with T.block("root")
E                   for i0, i1, i2 in T.grid(1, 12, 4096):
E                       # tir.Block#0
E                       with T.block("T_full"):
E                       ^^^^^^^^^^^^^^^^^^^^^^^
E                           ax0, ax1, ax2 = T.axis.remap("SSS", [i0, i1, i2])
E                           T.reads()
E                           T.writes(T_full[ax0, ax1, ax2])
E                           T_full[ax0, ax1, ax2] = T.int64(0)
E               
E           Error message: The block tir.Block#0 is an output block
```
Models that is impacted by this fix: `vision_maskrcnn` & `hf_Reformer`

cc: @zxybazh @junrushao @vinx13 

cc @Hzfengsy @junrushao1994