### PR TITLE
[ETHOSN] Add support for transpose convolution

### DIFF
--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -233,6 +233,16 @@ def pattern_table():
 
         return input_is_left | input_is_right | two_inputs
 
+    def qnn_conv2d_transpose_pattern():
+        pattern = is_op("qnn.conv2d_transpose")(
+            wildcard(), is_constant(), is_constant(), is_constant(), is_constant(), is_constant()
+        ).has_attr({"data_layout": "NHWC"})
+        pattern = pattern.optional(lambda x: is_op("nn.bias_add")(x, is_constant()))
+        pattern = is_op("qnn.requantize")(
+            pattern, is_constant(), is_constant(), is_constant(), is_constant()
+        )
+        return pattern
+
     def check_conv2d(extract):
         """Check if a conv2d is supported by Ethos-N."""
         if not ethosn_available():
@@ -260,6 +270,13 @@ def pattern_table():
             return False
 
         return _ethosn.mean(extract)
+
+    def check_conv2d_transpose(extract):
+        """Check if mean is supported by Ethos-N."""
+        if not ethosn_available():
+            return False
+
+        return _ethosn.conv2d_transpose(extract)
 
     def check_sigmoid(extract):
         """Check if a sigmoid is supported by Ethos-N."""
@@ -326,6 +343,7 @@ def pattern_table():
         ("ethos-n.qnn_mul", qnn_mul_pattern(), check_mul),
         ("ethos-n.qnn_add", qnn_add_pattern(), check_add),
         ("ethos-n.qnn_conv2d", qnn_conv_pattern(), check_conv2d),
+        ("ethos-n.qnn_conv2d_transpose", qnn_conv2d_transpose_pattern(), check_conv2d_transpose),
         ("ethos-n.qnn_avg_pool2d", qnn_avg_pool2d_pattern(), check_avg_pool2d),
         ("ethos-n.qnn_sigmoid", qnn_sigmoid_pattern(), check_sigmoid),
         ("ethos-n.qnn_fc", qnn_fc_pattern(), check_fc),

--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -272,7 +272,7 @@ def pattern_table():
         return _ethosn.mean(extract)
 
     def check_conv2d_transpose(extract):
-        """Check if mean is supported by Ethos-N."""
+        """Check if conv2d_transpose is supported by Ethos-N."""
         if not ethosn_available():
             return False
 

--- a/src/relay/backend/contrib/ethosn/codegen_ethosn.h
+++ b/src/relay/backend/contrib/ethosn/codegen_ethosn.h
@@ -206,6 +206,7 @@ class ConstructNetworkVisitor : public MixedModeVisitor, private ErrorReportingP
   EthosnError MakeSigmoidLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeMeanLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeTanhLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
+  EthosnError MakeConv2DTransposeLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeConcatenateLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeSplitLayer(const Call& call, sl::TensorsAndId* outs);
   EthosnError MakeDepthToSpaceLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);

--- a/src/relay/backend/contrib/ethosn/convert_equivalent.cc
+++ b/src/relay/backend/contrib/ethosn/convert_equivalent.cc
@@ -32,25 +32,12 @@
 #include "../../../qnn/utils.h"
 #include "../../../transforms/pattern_utils.h"
 #include "../../../transforms/simplify_expr.h"
+#include "ethosn_api.h"
 
 namespace tvm {
 namespace relay {
 namespace contrib {
 namespace ethosn {
-
-/*!
- * \brief Apply constant folding on an expression.
- *
- * \param expr The expression to fold.
- * \param fold_qnn Whether to fold constants for QNN operations.
- * \returns The new folded expression.
- */
-Expr FoldConstantExpr(const Expr& expr, bool fold_qnn = true) {
-  auto mod = IRModule::FromExpr(expr);
-  mod = transform::FoldConstant(fold_qnn)(mod);
-  auto entry_func = Downcast<Function>(mod->Lookup("main"));
-  return expr.as<FunctionNode>() == nullptr ? entry_func->body : entry_func;
-}
 
 /*!
  * \brief Converts qnn.mul to mathematically equivalent

--- a/src/relay/backend/contrib/ethosn/ethosn_api.h
+++ b/src/relay/backend/contrib/ethosn/ethosn_api.h
@@ -24,6 +24,7 @@
 #ifndef TVM_RELAY_BACKEND_CONTRIB_ETHOSN_ETHOSN_API_H_
 #define TVM_RELAY_BACKEND_CONTRIB_ETHOSN_ETHOSN_API_H_
 
+#include <tvm/relay/attrs/nn.h>
 #include <tvm/relay/expr.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/transform.h>
@@ -113,6 +114,16 @@ struct LeakyReLUParams {
   sl::LeakyReluInfo leaky_relu_info;
   sl::TensorInfo input_info;
   sl::TensorInfo output_info;
+};
+
+struct QnnConv2dTransposeParams {
+  sl::ConvolutionInfo conv_info;
+  sl::TensorInfo input_info;
+  sl::TensorInfo weights_info;
+  sl::TensorInfo bias_info;
+  sl::TensorInfo output_info;
+  runtime::NDArray raw_weights;
+  runtime::NDArray raw_bias;
 };
 
 struct ConcatenateParams {
@@ -237,6 +248,9 @@ class EthosnAPI {
   static EthosnError Tanh(const Expr& expr, TanhParams* params);
   /*! \brief Extract the Support Library leaky relu params from an ethos-n leaky relu Relu call. */
   static EthosnError LeakyReLU(const Expr& expr, LeakyReLUParams* params);
+  /*! \brief Extract the Support Library transpose params from a Relay
+   * ethos-n.qnn_conv2d_transpose func */
+  static EthosnError QnnConv2dTranspose(const Expr& expr, QnnConv2dTransposeParams* params);
   /*! \brief Extract the Support Library concatenate params from a Relay qnn.concatenate call */
   static EthosnError Concatenate(const Expr& expr, ConcatenateParams* params);
   /*! \brief Extract the Support Library split params from a Relay split call */
@@ -293,6 +307,15 @@ class EthosnAPI {
   static EthosnError AsConstant(const Expr& expr, T* out);
   static EthosnError AsConstant(const Expr& expr, std::valarray<float>* out);
 };
+
+/*!
+ * \brief Apply constant folding on an expression.
+ *
+ * \param expr The expression to fold.
+ * \param fold_qnn Whether to fold constants for QNN operations.
+ * \returns The new folded expression.
+ */
+Expr FoldConstantExpr(const Expr& expr, bool fold_qnn = true);
 
 }  // namespace ethosn
 }  // namespace contrib

--- a/tests/python/contrib/test_ethosn/test_conv2d_transpose.py
+++ b/tests/python/contrib/test_ethosn/test_conv2d_transpose.py
@@ -1,0 +1,234 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Arm(R) Ethos(TM)-N integration conv2d tests"""
+
+import pytest
+import numpy as np
+
+import tvm
+from tvm import relay
+from tvm.testing import requires_ethosn
+from . import infrastructure as tei
+
+
+def _get_model(
+    shape,
+    kernel_h,
+    kernel_w,
+    input_zp,
+    input_sc,
+    kernel_zp,
+    kernel_sc,
+    output_zp,
+    output_sc,
+    stride,
+    dilation,
+    groups,
+    kernel_layout,
+    dtype,
+    out_channels,
+    bias,
+):
+    """Return a model and any parameters it may have"""
+    a = relay.var("a", shape=shape, dtype=dtype)
+    p = tei.get_same_padding((shape[1], shape[2]), (kernel_h, kernel_w), dilation, stride)
+    weight_shape = (shape[3], out_channels // groups, kernel_h, kernel_w)
+
+    weight_data = tvm.nd.array(
+        np.random.randint(
+            np.iinfo(dtype).min,
+            high=(np.iinfo(dtype).max + 1),
+            size=weight_shape,
+            dtype=dtype,
+        )
+    )
+    weights = relay.const(weight_data, dtype)
+    op = relay.qnn.op.conv2d_transpose(
+        a,
+        weights,
+        input_zero_point=relay.const(input_zp, "int32"),
+        input_scale=relay.const(input_sc, "float32"),
+        kernel_zero_point=relay.const(kernel_zp, "int32"),
+        kernel_scale=relay.const(kernel_sc, "float32"),
+        kernel_size=(kernel_h, kernel_w),
+        padding=p,
+        strides=stride,
+        dilation=dilation,
+        data_layout="NHWC",
+        kernel_layout=kernel_layout,
+        out_dtype="int32",
+        channels=out_channels,
+        groups=groups,
+    )
+    if bias:
+        bias_data = tvm.nd.array(
+            np.random.randint(
+                np.iinfo(dtype).min,
+                high=np.iinfo(dtype).max + 1,
+                size=(out_channels,),
+                dtype="int32",
+            )
+        )
+        biasc = relay.const(bias_data, "int32")
+        op = relay.nn.bias_add(op, biasc, axis=3)
+
+    if isinstance(kernel_sc, tvm.runtime.ndarray.NDArray):
+        req_input_sc = [sc * input_sc for sc in kernel_sc.numpy()]
+    else:
+        req_input_sc = input_sc * kernel_sc
+
+    op = relay.qnn.op.requantize(
+        op,
+        input_zero_point=relay.const(input_zp, "int32"),
+        input_scale=relay.const(req_input_sc, "float32"),
+        output_zero_point=relay.const(output_zp, "int32"),
+        output_scale=relay.const(output_sc, "float32"),
+        axis=3,
+        rounding="UPWARD",
+        out_dtype=dtype,
+    )
+    params = {"w": weight_data}
+    if bias:
+        params["b"] = bias_data
+    return op, params
+
+
+@requires_ethosn
+@pytest.mark.parametrize("dtype", ["uint8", "int8"])
+@pytest.mark.parametrize(
+    "ifm_shape,strides,kernel_size,out_channels,bias",
+    [
+        ((1, 2, 2, 1), (2, 2), (1, 1), 1, False),
+        ((1, 2, 2, 5), (2, 2), (3, 5), 4, False),
+        ((1, 7, 7, 4), (2, 2), (7, 9), 8, True),
+    ],
+)
+def test_conv2d_transpose(ifm_shape, strides, kernel_size, out_channels, dtype, bias):
+    """Check transpose convolution output with TVM."""
+    np.random.seed(0)
+
+    kernel_layout = "IOHW"
+    dilation = (1, 1)
+    groups = 1
+
+    iinfo = np.iinfo(dtype)
+    data_min = iinfo.min
+    data_max = iinfo.max
+
+    input_zp = np.random.randint(data_min, data_max)
+    input_sc = np.random.random() * 2
+    kernel_zp = np.random.randint(data_min, data_max)
+    kernel_sc = np.random.random() * 4
+    output_zp, output_sc = tei.get_conv2d_qnn_params(
+        dtype, input_zp, input_sc, kernel_zp, kernel_sc, ifm_shape[1], ifm_shape[2], ifm_shape[3]
+    )
+
+    model, params = _get_model(
+        shape=ifm_shape,
+        kernel_h=kernel_size[0],
+        kernel_w=kernel_size[1],
+        input_zp=input_zp,
+        input_sc=input_sc,
+        kernel_zp=kernel_zp,
+        kernel_sc=kernel_sc,
+        output_zp=output_zp,
+        output_sc=output_sc,
+        stride=strides,
+        dilation=dilation,
+        groups=groups,
+        kernel_layout=kernel_layout,
+        dtype=dtype,
+        out_channels=out_channels,
+        bias=bias,
+    )
+
+    outputs = []
+    inputs = {
+        "a": tvm.nd.array(np.random.randint(data_min, data_max + 1, size=ifm_shape, dtype=dtype))
+    }
+
+    for npu in [False, True]:
+        mod = tei.make_module(model, params)
+        outputs.append(tei.build_and_run(mod, inputs, 1, params, npu=npu))
+
+    tei.verify(outputs, dtype, 1)
+
+
+@requires_ethosn
+@pytest.mark.parametrize("dtype", ["uint8", "int8"])
+@pytest.mark.parametrize(
+    "shape, stride, dilation, groups, err_msg",
+    [
+        (
+            (1, 4, 4, 4),
+            (1, 1, 1),
+            (1, 1),
+            1,
+            "stride size=3, stride size must = 2",
+        ),
+        (
+            (1, 4, 4, 4),
+            (2, 2),
+            (2, 2),
+            2,
+            "dilation=[2, 2], dilation must = [1, 1]",
+        ),
+        (
+            (2, 4, 4, 4),
+            (1, 1),
+            (1, 1),
+            1,
+            "batch size=2, batch size must = 1",
+        ),
+    ],
+)
+def test_conv2d_transpose_failure(
+    shape,
+    stride,
+    dilation,
+    groups,
+    err_msg,
+    dtype,
+):
+    """
+    Test transpose_conv2d error messages.
+    """
+    np.random.seed(0)
+    out_channels = 8
+
+    model, _ = _get_model(
+        shape=shape,
+        kernel_h=1,
+        kernel_w=1,
+        input_zp=0,
+        input_sc=1,
+        kernel_zp=0,
+        kernel_sc=1,
+        output_zp=0,
+        output_sc=1,
+        stride=stride,
+        dilation=dilation,
+        groups=groups,
+        kernel_layout="IOHW",
+        dtype=dtype,
+        out_channels=out_channels,
+        bias=False,
+    )
+    model = tei.make_ethosn_composite(model, "ethos-n.qnn_conv2d_transpose")
+    mod = tei.make_ethosn_partition(model)
+    tei.test_error(mod, {}, err_msg)


### PR DESCRIPTION
Adds support for offloading transpose convolution with an optional bias to the NPU.

Co-authored-by: Samuel Panijel <samuel.panijel@arm.com>
Co-authored-by: Leo Blonk <leo.blonk@arm.com>

cc @leandron @Leo-arm @spanijel 
