### PR TITLE
[hexagon][tests] re-enable maxpool hardware test

### DIFF
--- a/tests/python/contrib/test_hexagon/topi/test_max_pool2d_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/test_max_pool2d_slice.py
@@ -330,9 +330,6 @@ class TestmaxPool2dSlice:
         expected_output_np,
         hexagon_session: Session,
     ):
-        if hexagon_session._launcher._serial_number != "simulator":
-            pytest.skip(msg="Due to https://github.com/apache/tvm/issues/11928")
-
         target_hexagon = tvm.target.hexagon("v69")
         A = te.placeholder(input_shape_padded, name="A", dtype=dtype)
 


### PR DESCRIPTION
- Re-enable test_max_pool2d_slice.py when run on Hexagon
  hardware (as opposed to hexagon-sim).

  This is now safe because https://github.com/apache/tvm/issues/11928
  has been fixed.

cc @mehrdadh