### PR TITLE
[ETHOSN] Add support for concatenate with negative axis

### DIFF
--- a/src/relay/backend/contrib/ethosn/ethosn_api.cc
+++ b/src/relay/backend/contrib/ethosn/ethosn_api.cc
@@ -520,7 +520,12 @@ EthosnError EthosnAPI::LeakyReLU(const Expr& expr, LeakyReLUParams* params) {
 EthosnError EthosnAPI::Concatenate(const Expr& expr, ConcatenateParams* params) {
   Call call = Downcast<Call>(expr);
   const auto& attrs = call->attrs.as<ConcatenateAttrs>();
-  params->concat_info.m_Axis = attrs->axis;
+  int axis = attrs->axis;
+  if (axis < 0) {
+    int output_dims = Downcast<TensorType>(call->checked_type())->shape.size();
+    axis = output_dims + axis;
+  }
+  params->concat_info.m_Axis = axis;
 
   float output_sc;
   int output_zp;

--- a/tests/python/contrib/test_ethosn/test_concatenate.py
+++ b/tests/python/contrib/test_ethosn/test_concatenate.py
@@ -56,33 +56,35 @@ def _get_model(shapes, dtype, axis):
 
 @requires_ethosn
 @pytest.mark.parametrize("dtype", ["uint8", "int8"])
-def test_concatenate(dtype):
-    """Compare Concatenate output with TVM."""
-
-    trials = [
+@pytest.mark.parametrize(
+    "shapes,axis",
+    [
         ([(1, 4), (1, 6)], 1),
         ([(1, 16, 4), (1, 16, 4)], 1),
         ([(1, 25, 4, 16)] * 3, 3),
         ([(1, 25, 4, 16), (1, 25, 5, 16), (1, 25, 6, 16)], 2),
-    ]
-
+        ([(1, 4), (1, 6)], -1),
+        ([(1, 16, 4), (1, 16, 4)], -2),
+    ],
+)
+def test_concatenate(dtype, shapes, axis):
+    """Compare Concatenate output with TVM."""
     np.random.seed(0)
-    for shapes, axis in trials:
-        outputs = []
-        inputs = _get_inputs(shapes, dtype)
-        for npu in [False, True]:
-            model = _get_model(shapes, dtype, axis)
-            mod = tei.make_module(model, {})
-            outputs.append(tei.build_and_run(mod, inputs, 1, {}, npu=npu))
+
+    outputs = []
+    inputs = _get_inputs(shapes, dtype)
+    for npu in [False, True]:
+        model = _get_model(shapes, dtype, axis)
+        mod = tei.make_module(model, {})
+        outputs.append(tei.build_and_run(mod, inputs, 1, {}, npu=npu))
 
         tei.verify(outputs, dtype, 0)
 
 
 @requires_ethosn
-def test_concatenate_failure():
-    """Check Concatenate error messages."""
-
-    trials = [
+@pytest.mark.parametrize(
+    "shapes,dtype,axis,err_msg",
+    [
         ([(1, 4, 4, 4, 4), (1, 4, 4, 4, 4)], "uint8", 1, "dimensions=5, dimensions must be <= 4;"),
         (
             [(1, 4, 4, 4), (1, 4, 4, 4)],
@@ -110,9 +112,10 @@ def test_concatenate_failure():
             0,
             "Concatenation cannot be performed along batch axis (axis 0);",
         ),
-    ]
-
-    for shapes, dtype, axis, err_msg in trials:
-        model = _get_model(shapes, dtype, axis)
-        mod = tei.make_ethosn_partition(model)
-        tei.test_error(mod, {}, err_msg)
+    ],
+)
+def test_concatenate_failure(shapes, dtype, axis, err_msg):
+    """Check Concatenate error messages."""
+    model = _get_model(shapes, dtype, axis)
+    mod = tei.make_ethosn_partition(model)
+    tei.test_error(mod, {}, err_msg)


### PR DESCRIPTION
Supports offloading concatenate with a negative axis to the NPU. In addition, parameterized the concatenate unit tests.

cc @leandron @NicolaLancellotti 