### PR TITLE
[Runtime][Bugfix] Added type-checking for Array::insert

### DIFF
--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -325,6 +325,8 @@ class Array : public ObjectRef {
    */
   template <typename IterType>
   Array(IterType first, IterType last) {
+    static_assert(is_valid_iterator_v<T, IterType>,
+                  "IterType cannot be inserted into a tvm::Array<T>");
     Assign(first, last);
   }
 
@@ -481,6 +483,9 @@ class Array : public ObjectRef {
    */
   template <typename IterType>
   void insert(iterator position, IterType first, IterType last) {
+    static_assert(is_valid_iterator_v<T, IterType>,
+                  "IterType cannot be inserted into a tvm::Array<T>");
+
     if (first == last) {
       return;
     }

--- a/src/te/schedule/schedule_lang.cc
+++ b/src/te/schedule/schedule_lang.cc
@@ -200,7 +200,7 @@ Stage& Stage::env_threads(Array<IterVar> threads) {
   ICHECK_EQ(self->env_threads.size(), 0U) << "Already set env_threads";
   Array<IterVar>& leaf_vars = self->leaf_iter_vars;
   Array<IterVar>& all_vars = self->all_iter_vars;
-  std::vector<ObjectRef> temp;
+  std::vector<IterVar> temp;
   for (IterVar iv : threads) {
     temp.push_back(iv);
   }


### PR DESCRIPTION
Prior to this commit, the following code would compile and run without error.  This occurs because the typed `Array<T>::insert` calls the untyped `ArrayNode::InitRange`, with no type-checking done before the call.

```c++
Var x("x");
Var y("y");
Array<Var> var_arr{x, y};
Array<PrimExpr> expr_arr{x + 1, y + 2};
// Erroneously inserts static-type PrimExpr, runtime-type Add, even
// though neither PrimExpr is a type of Var.
var_arr.insert(var_arr.begin(), expr_arr.begin(), expr_arr.end());
```

After this commit, a `static_assert` in `Array<T>::insert` and in `Array<T>::Array(IterType,IterTYpe)` restricts the iterators, such that they must dereference to `T`, `Optional<T>`, a subclass of `T`, or `Optional<U>` where `U` is a subclass of `T`.

The public method `ArrayNode::SetItem` exposes a similar issue.  In the future, we may want to make it be private, accessed only through type-safe method in `Array<T>::Set`.

cc @areusch