### PR TITLE
[Web][Emscripten] Update EMCC C++ standard to C++17

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -26,7 +26,7 @@ all: dist/wasm/tvmjs_runtime.wasm dist/wasm/tvmjs_runtime.wasi.js
 
 EMCC = emcc
 
-EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++14 -Wno-ignored-attributes --no-entry \
+EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++17 -Wno-ignored-attributes --no-entry \
 	-s ALLOW_MEMORY_GROWTH=1 -s STANDALONE_WASM=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 
 
 EMCC_LDFLAGS = --pre-js emcc/preload.js


### PR DESCRIPTION
As a follow-up to https://github.com/apache/tvm/pull/12337, updating the EMCC flags from `-std=c++14` to `-std=c++17`.