### PR TITLE
[TIR] Fix pragma_loop_partition_hint attrs should check it's value

### DIFF
--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -139,14 +139,16 @@ class CandidateSelector final : public StmtExprVisitor {
         return;
       }
     } else if (op->attr_key == attr::pragma_loop_partition_hint) {
-      const VarNode* var = nullptr;
-      if (op->node->IsInstance<VarNode>()) {
-        var = op->node.as<VarNode>();
-      } else if (op->node->IsInstance<IterVarNode>()) {
-        var = op->node.as<IterVarNode>()->var.get();
+      if (analyzer_.CanProve(op->value)) {
+        const VarNode* var = nullptr;
+        if (op->node->IsInstance<VarNode>()) {
+          var = op->node.as<VarNode>();
+        } else if (op->node->IsInstance<IterVarNode>()) {
+          var = op->node.as<IterVarNode>()->var.get();
+        }
+        ICHECK(var);
+        partition_hint_vars.insert(var);
       }
-      ICHECK(var);
-      partition_hint_vars.insert(var);
     }
     StmtExprVisitor::VisitStmt_(op);
   }
@@ -191,6 +193,7 @@ class CandidateSelector final : public StmtExprVisitor {
   bool no_split_{false};
   bool partition_const_loop_{false};
   std::unordered_map<const VarNode*, VarIsUsed> record_;
+  arith::Analyzer analyzer_;
 };
 
 // Finder try best to find partitions for hinted vars

--- a/tests/python/unittest/test_tir_transform_loop_partition.py
+++ b/tests/python/unittest/test_tir_transform_loop_partition.py
@@ -559,7 +559,7 @@ def test_explicit_partition_hint():
     C = te.compute((32,), lambda i: te.if_then_else(i < 16, A[i], B[i]), name="C")
     s = te.create_schedule(C.op)
     s.normalize()
-    s[C].pragma(s[C].op.axis[0], "loop_partition_hint")
+    s[C].pragma(s[C].op.axis[0], "loop_partition_hint", True)
     mod = tvm.driver.build_module.schedule_to_module(s, [A, B, C], "main", None)
     with tvm.transform.PassContext(config={"tir.LoopPartition": {"partition_const_loop": True}}):
         mod = tvm.tir.transform.StorageFlatten(64)(mod)


### PR DESCRIPTION
Current LoopPartition doesn't check the value of attribute key "pragma_loop_partition_hint". Whatever I set pragma_loop_partition_hint to True or False, the result is same, which is confused for debug.

This PR fix pragma_loop_partition_hint attribute key should check it's value.

@Hzfengsy 

cc @junrushao1994