### PR TITLE
[docs] Add tvm.driver.tvmc module to Python documentation

### DIFF
--- a/docs/reference/api/python/driver.rst
+++ b/docs/reference/api/python/driver.rst
@@ -19,6 +19,8 @@ tvm.driver
 ----------
 .. automodule:: tvm.driver
 
+.. automodule:: tvm.driver.tvmc
+
 .. autofunction:: tvm.lower
 
 .. autofunction:: tvm.build


### PR DESCRIPTION
This adds tvmc Python API to the docs, which is important
because it gets quite a few questions in the Discuss forum
and it looks more elegant to point to the docs rather than
a permalink to GitHub.

cc @driazati @CircleSpin @areusch @gromero 