### PR TITLE
[Node][Metaschedule] Allow ignoring NDArray raw data in StructuralEqual / Hash

### DIFF
--- a/include/tvm/meta_schedule/database.h
+++ b/include/tvm/meta_schedule/database.h
@@ -94,7 +94,7 @@ struct WorkloadHash {
 /*! \brief The equality check for Workload */
 struct WorkloadEqual {
   bool operator()(const Workload& a, const Workload& b) const {
-    return a->shash == b->shash && tvm::StructuralEqual()(a->mod, b->mod);
+    return a->shash == b->shash && tvm::StructuralEqual(false)(a->mod, b->mod);
   }
 };
 

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -102,6 +102,8 @@ class ObjectPathPair : public ObjectRef {
  */
 class StructuralEqual : public BaseValueEqual {
  public:
+  StructuralEqual(bool compare_ndarray_data = true) : compare_ndarray_data_(compare_ndarray_data) {}
+
   // inheritate operator()
   using BaseValueEqual::operator();
   /*!
@@ -111,6 +113,9 @@ class StructuralEqual : public BaseValueEqual {
    * \return The comparison result.
    */
   TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs) const;
+
+ private:
+  bool compare_ndarray_data_;
 };
 
 /*!

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -102,6 +102,10 @@ class ObjectPathPair : public ObjectRef {
  */
 class StructuralEqual : public BaseValueEqual {
  public:
+  /*!
+   * \brief Constructor
+   * \param compare_ndarray_data Whether or not we compare ndarray data to determine equality.
+   */
   StructuralEqual(bool compare_ndarray_data = true) : compare_ndarray_data_(compare_ndarray_data) {}
 
   // inheritate operator()
@@ -115,6 +119,7 @@ class StructuralEqual : public BaseValueEqual {
   TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs) const;
 
  private:
+  /*! \brief Whether or not we compare ndarray data to determine equality. */
   bool compare_ndarray_data_;
 };
 

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -106,7 +106,8 @@ class StructuralEqual : public BaseValueEqual {
    * \brief Constructor
    * \param compare_ndarray_data Whether or not we compare ndarray data to determine equality.
    */
-  StructuralEqual(bool compare_ndarray_data = true) : compare_ndarray_data_(compare_ndarray_data) {}
+  explicit StructuralEqual(bool compare_ndarray_data = true)
+      : compare_ndarray_data_(compare_ndarray_data) {}
 
   // inheritate operator()
   using BaseValueEqual::operator();

--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -74,6 +74,7 @@ class BaseValueHash {
  */
 class StructuralHash : public BaseValueHash {
  public:
+  StructuralHash(bool hash_ndarray_data = true) : hash_ndarray_data_(hash_ndarray_data) {}
   // inheritate operator()
   using BaseValueHash::operator();
   /*!
@@ -82,6 +83,9 @@ class StructuralHash : public BaseValueHash {
    * \return The hash value.
    */
   TVM_DLL size_t operator()(const ObjectRef& key) const;
+
+ private:
+  bool hash_ndarray_data_;
 };
 
 /*!

--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -74,7 +74,12 @@ class BaseValueHash {
  */
 class StructuralHash : public BaseValueHash {
  public:
+  /*!
+   * \brief Constructor
+   * \param hash_ndarray_data Whether or not we hash ndarray data.
+   */
   StructuralHash(bool hash_ndarray_data = true) : hash_ndarray_data_(hash_ndarray_data) {}
+
   // inheritate operator()
   using BaseValueHash::operator();
   /*!
@@ -85,6 +90,7 @@ class StructuralHash : public BaseValueHash {
   TVM_DLL size_t operator()(const ObjectRef& key) const;
 
  private:
+  /*! \brief Whether or not we hash ndarray data. */
   bool hash_ndarray_data_;
 };
 

--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -78,7 +78,7 @@ class StructuralHash : public BaseValueHash {
    * \brief Constructor
    * \param hash_ndarray_data Whether or not we hash ndarray data.
    */
-  StructuralHash(bool hash_ndarray_data = true) : hash_ndarray_data_(hash_ndarray_data) {}
+  explicit StructuralHash(bool hash_ndarray_data = true) : hash_ndarray_data_(hash_ndarray_data) {}
 
   // inheritate operator()
   using BaseValueHash::operator();

--- a/python/tvm/ir/base.py
+++ b/python/tvm/ir/base.py
@@ -194,6 +194,9 @@ def structural_equal(lhs, rhs, map_free_vars=False, compare_ndarray_data=True):
         Whether free variables (i.e. variables without a definition site) should be mapped
         as equal to each other.
 
+    compare_ndarray_data : bool
+        Whether or not we compare ndarray data to determine equality.
+
     Return
     ------
     result : bool
@@ -243,7 +246,7 @@ def get_first_structural_mismatch(lhs, rhs, map_free_vars=False):
         return mismatch.lhs_path, mismatch.rhs_path
 
 
-def assert_structural_equal(lhs, rhs, map_free_vars=False):
+def assert_structural_equal(lhs, rhs, map_free_vars=False, compare_ndarray_data=True):
     """Assert lhs and rhs are structurally equal to each other.
 
     Parameters
@@ -258,6 +261,9 @@ def assert_structural_equal(lhs, rhs, map_free_vars=False):
         Whether or not shall we map free vars that does
         not bound to any definitions as equal to each other.
 
+    compare_ndarray_data : bool
+        Whether or not we compare ndarray data to determine equality.
+
     Raises
     ------
     ValueError : if assertion does not hold.
@@ -268,7 +274,7 @@ def assert_structural_equal(lhs, rhs, map_free_vars=False):
     """
     lhs = tvm.runtime.convert(lhs)
     rhs = tvm.runtime.convert(rhs)
-    tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, True, map_free_vars)
+    tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, True, map_free_vars, compare_ndarray_data)
 
 
 def structural_hash(node, map_free_vars=False, hash_ndarray_data=True):
@@ -300,6 +306,9 @@ def structural_hash(node, map_free_vars=False, hash_ndarray_data=True):
         If map_free_vars is set to true, we will hash free variables
         by the order of their occurrences. Otherwise, we will hash by
         their in-memory pointer address.
+
+    hash_ndarray_data : bool
+        Whether or not we hash ndarray data.
 
     Return
     ------

--- a/python/tvm/ir/base.py
+++ b/python/tvm/ir/base.py
@@ -157,7 +157,7 @@ def save_json(node):
     return tvm.runtime._ffi_node_api.SaveJSON(node)
 
 
-def structural_equal(lhs, rhs, map_free_vars=False):
+def structural_equal(lhs, rhs, map_free_vars=False, compare_ndarray_data=True):
     """Check structural equality of lhs and rhs.
 
     The structural equality is recursively defined in the DAG of IRNodes.
@@ -206,7 +206,7 @@ def structural_equal(lhs, rhs, map_free_vars=False):
     """
     lhs = tvm.runtime.convert(lhs)
     rhs = tvm.runtime.convert(rhs)
-    return bool(tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, False, map_free_vars))
+    return bool(tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, False, map_free_vars, compare_ndarray_data))
 
 
 def get_first_structural_mismatch(lhs, rhs, map_free_vars=False):
@@ -267,7 +267,7 @@ def assert_structural_equal(lhs, rhs, map_free_vars=False):
     tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, True, map_free_vars)
 
 
-def structural_hash(node, map_free_vars=False):
+def structural_hash(node, map_free_vars=False, hash_ndarray_data=True):
     """Compute structural hash of node
 
     The structural hash value is recursively defined in the DAG of IRNodes.
@@ -306,4 +306,4 @@ def structural_hash(node, map_free_vars=False):
     --------
     structrual_equal
     """
-    return tvm.runtime._ffi_node_api.StructuralHash(node, map_free_vars)
+    return tvm.runtime._ffi_node_api.StructuralHash(node, map_free_vars, hash_ndarray_data)

--- a/python/tvm/ir/base.py
+++ b/python/tvm/ir/base.py
@@ -206,7 +206,11 @@ def structural_equal(lhs, rhs, map_free_vars=False, compare_ndarray_data=True):
     """
     lhs = tvm.runtime.convert(lhs)
     rhs = tvm.runtime.convert(rhs)
-    return bool(tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, False, map_free_vars, compare_ndarray_data))
+    return bool(
+        tvm.runtime._ffi_node_api.StructuralEqual(
+            lhs, rhs, False, map_free_vars, compare_ndarray_data
+        )
+    )
 
 
 def get_first_structural_mismatch(lhs, rhs, map_free_vars=False):

--- a/rust/tvm-rt/src/object/mod.rs
+++ b/rust/tvm-rt/src/object/mod.rs
@@ -104,7 +104,7 @@ external! {
     #[name("ir.DebugPrint")]
     pub fn debug_print(object: ObjectRef) -> CString;
     #[name("node.StructuralHash")]
-    fn structural_hash(object: ObjectRef, map_free_vars: bool) -> i64;
+    fn structural_hash(object: ObjectRef, map_free_vars: bool, hash_ndarray_data : bool) -> i64;
     #[name("node.StructuralEqual")]
-    fn structural_equal(lhs: ObjectRef, rhs: ObjectRef, assert_mode: bool, map_free_vars: bool) -> bool;
+    fn structural_equal(lhs: ObjectRef, rhs: ObjectRef, assert_mode: bool, map_free_vars: bool, compare_ndarray_data : bool) -> bool;
 }

--- a/src/meta_schedule/database/database.cc
+++ b/src/meta_schedule/database/database.cc
@@ -25,7 +25,7 @@ namespace meta_schedule {
 
 Workload::Workload(IRModule mod) {
   ObjectPtr<WorkloadNode> n = runtime::make_object<WorkloadNode>();
-  n->shash = tvm::StructuralHash()(mod);
+  n->shash = tvm::StructuralHash(/*hash_ndarray_data*/ false)(mod);
   n->mod = mod;
   data_ = std::move(n);
 }
@@ -61,7 +61,7 @@ Workload Workload::FromJSON(const ObjectRef& json_obj) {
       mod = Downcast<IRModule>(LoadJSON(json_mod));
     }
     // Verify SHash(mod) == shash
-    shash = tvm::StructuralHash()(mod);
+    shash = tvm::StructuralHash(/*hash_ndarray_data*/ false)(mod);
     String recalc_shash = SHash2Str(shash);
     CHECK_EQ(recalc_shash, str_shash) << "ValueError: Structural hash changed. Given: " << str_shash
                                       << "; Recalculated: " << recalc_shash;

--- a/src/meta_schedule/database/json_database.cc
+++ b/src/meta_schedule/database/json_database.cc
@@ -88,13 +88,14 @@ class JSONDatabaseNode : public DatabaseNode {
 
  public:
   bool HasWorkload(const IRModule& mod) {
-    return workloads2idx_.find(Workload(mod, tvm::StructuralHash()(mod))) != workloads2idx_.end();
+    return workloads2idx_.find(Workload(
+               mod, tvm::StructuralHash(/*hash_ndarray_data*/ false)(mod))) != workloads2idx_.end();
   }
 
   Workload CommitWorkload(const IRModule& mod) {
     // Try to insert `mod` into `workloads_`
-    auto [it, inserted] =
-        this->workloads2idx_.emplace(Workload(mod, tvm::StructuralHash()(mod)), -1);
+    auto [it, inserted] = this->workloads2idx_.emplace(
+        Workload(mod, tvm::StructuralHash(/*hash_ndarray_data*/ false)(mod)), -1);
     Workload workload = it->first;
     // If `mod` is new in `workloads2idx_`, append it to the workload file
     if (inserted) {

--- a/src/meta_schedule/database/memory_database.cc
+++ b/src/meta_schedule/database/memory_database.cc
@@ -46,7 +46,7 @@ class MemoryDatabaseNode : public DatabaseNode {
 
   Workload CommitWorkload(const IRModule& mod) final {
     for (const auto& workload : workloads) {
-      if (StructuralEqual(/*compare_ndarray_data*/false)(workload->mod, mod)) {
+      if (StructuralEqual(/*compare_ndarray_data*/ false)(workload->mod, mod)) {
         return workload;
       }
     }

--- a/src/meta_schedule/database/memory_database.cc
+++ b/src/meta_schedule/database/memory_database.cc
@@ -37,7 +37,7 @@ class MemoryDatabaseNode : public DatabaseNode {
  public:
   bool HasWorkload(const IRModule& mod) final {
     for (const auto& workload : workloads) {
-      if (StructuralEqual()(workload->mod, mod)) {
+      if (StructuralEqual(/*compare_ndarray_data*/ false)(workload->mod, mod)) {
         return true;
       }
     }
@@ -46,7 +46,7 @@ class MemoryDatabaseNode : public DatabaseNode {
 
   Workload CommitWorkload(const IRModule& mod) final {
     for (const auto& workload : workloads) {
-      if (StructuralEqual()(workload->mod, mod)) {
+      if (StructuralEqual(/*compare_ndarray_data*/false)(workload->mod, mod)) {
         return workload;
       }
     }

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -189,6 +189,39 @@ bool SEqualReducer::ObjectAttrsEqual(const ObjectRef& lhs, const ObjectRef& rhs,
   }
 }
 
+bool NDArrayEqual(const runtime::NDArray::Container* lhs, const runtime::NDArray::Container* rhs,
+                  SEqualReducer equal, bool compare_data) {
+  if (lhs == rhs) return true;
+
+  auto ldt = lhs->dl_tensor.dtype;
+  auto rdt = rhs->dl_tensor.dtype;
+  ICHECK_EQ(lhs->dl_tensor.device.device_type, kDLCPU) << "can only compare CPU tensor";
+  ICHECK_EQ(rhs->dl_tensor.device.device_type, kDLCPU) << "can only compare CPU tensor";
+  ICHECK(runtime::IsContiguous(lhs->dl_tensor)) << "Can only compare contiguous tensor";
+  ICHECK(runtime::IsContiguous(rhs->dl_tensor)) << "Can only compare contiguous tensor";
+
+  if (lhs->dl_tensor.ndim != rhs->dl_tensor.ndim) return false;
+  for (int i = 0; i < lhs->dl_tensor.ndim; ++i) {
+    if (!equal(lhs->dl_tensor.shape[i], rhs->dl_tensor.shape[i])) return false;
+  }
+  if (ldt.code == rdt.code && ldt.lanes == rdt.lanes && ldt.bits == rdt.bits) {
+    size_t data_size = runtime::GetDataSize(lhs->dl_tensor);
+    if (compare_data) {
+      return std::memcmp(lhs->dl_tensor.data, rhs->dl_tensor.data, data_size) == 0;
+    } else {
+      return true;
+    }
+  } else {
+    return false;
+  }
+}
+
+bool NDArrayContainerTrait::SEqualReduce(const runtime::NDArray::Container* lhs,
+                                         const runtime::NDArray::Container* rhs,
+                                         SEqualReducer equal) {
+  return NDArrayEqual(lhs, rhs, equal, true);
+}
+
 /*!
  * \brief A non recursive stack based SEqual handler that can remaps vars.
  *
@@ -362,19 +395,30 @@ class RemapVarSEqualHandler : public SEqualReducer::Handler {
       if (equal_map_rhs_.count(rhs)) return false;
 
       // Run reduce check for free nodes.
-      if (!IsPathTracingEnabled()) {
-        return vtable_->SEqualReduce(lhs.get(), rhs.get(),
-                                     SEqualReducer(this, nullptr, map_free_vars));
+      SEqualReducer reducer = GetReducer(lhs, rhs, map_free_vars, current_paths);
+
+      if (auto lhs_ptr = lhs.as<runtime::NDArray::Container>(),
+          rhs_ptr = rhs.as<runtime::NDArray::Container>();
+          lhs_ptr && rhs_ptr) {
+        return NDArrayEqual(lhs_ptr, rhs_ptr, reducer, /*compare_data*/ false);
       } else {
-        PathTracingData tracing_data = {current_paths.value(), lhs, rhs, first_mismatch_};
-        return vtable_->SEqualReduce(lhs.get(), rhs.get(),
-                                     SEqualReducer(this, &tracing_data, map_free_vars));
+        return vtable_->SEqualReduce(lhs.get(), rhs.get(), reducer);
       }
     };
     return CheckResult(compute(), lhs, rhs, current_paths);
   }
 
  private:
+  SEqualReducer GetReducer(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
+                           const Optional<ObjectPathPair>& current_paths) {
+    if (!IsPathTracingEnabled()) {
+      return SEqualReducer(this, nullptr, map_free_vars);
+    } else {
+      PathTracingData tracing_data = {current_paths.value(), lhs, rhs, first_mismatch_};
+      return SEqualReducer(this, &tracing_data, map_free_vars);
+    }
+  }
+
   /*! \brief Pending reduce tasks. */
   struct Task {
     /*! \brief The lhs operand to be compared. */

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -470,7 +470,7 @@ class RemapVarSEqualHandler : public SEqualReducer::Handler {
   std::unordered_map<ObjectRef, ObjectRef, ObjectPtrHash, ObjectPtrEqual> equal_map_lhs_;
   // map from rhs to lhs
   std::unordered_map<ObjectRef, ObjectRef, ObjectPtrHash, ObjectPtrEqual> equal_map_rhs_;
-  // TODO
+  // Whether or not compare ndarray raw data
   bool compare_ndarray_data_;
 };
 

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -277,7 +277,7 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
   ReflectionVTable* vtable_ = ReflectionVTable::Global();
   // map from lhs to rhs
   std::unordered_map<ObjectRef, size_t, ObjectPtrHash, ObjectPtrEqual> hash_memo_;
-  // TODO
+  // Whether or not hash ndarray raw data
   bool hash_ndarray_data_;
 };
 

--- a/src/relay/backend/task_extraction.cc
+++ b/src/relay/backend/task_extraction.cc
@@ -49,7 +49,7 @@ Array<meta_schedule::ExtractedTask> ExtractTask(IRModule mod, Target target,
       if (!relay_func->HasNonzeroAttr(attr::kPrimitive)) {
         return;
       }
-      tec::CCacheKey cache_key(relay_func, target);
+      tec::CCacheKey cache_key(relay_func, target, /*ignore_ndarray_data*/ true);
       auto it = cache.find(cache_key);
       if (it != cache.end()) {
         it->second->weight += 1;

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -918,7 +918,7 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     } else {
       // Cases 1 and 2: lower the primitive function for the desired target, possibly using external
       // codegen.
-      CCacheKey key(Downcast<Function>(primitive_func), target,
+      CCacheKey key(Downcast<Function>(primitive_func), target, /*ignore_ndarray_data*/ false,
                     GetVirtualDevice(GetRef<Call>(call_node)));
       CachedFunc cfunc = compiler_->Lower(key);
       ICHECK(cfunc.defined());

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -69,10 +69,11 @@ LoweredOutput::LoweredOutput(tvm::Array<te::Tensor> outputs, OpImplementation im
   data_ = std::move(n);
 }
 
-CCacheKey::CCacheKey(Function source_func, Target target, VirtualDevice vd) {
+CCacheKey::CCacheKey(Function source_func, Target target, bool ignore_ndarray_data, VirtualDevice vd) {
   auto n = make_object<CCacheKeyNode>();
   n->source_func = std::move(source_func);
   n->target = std::move(target);
+  n->ignore_ndarray_data = ignore_ndarray_data;
   n->virtual_device = std::move(vd);
   data_ = std::move(n);
 }

--- a/src/relay/backend/te_compiler_cache.h
+++ b/src/relay/backend/te_compiler_cache.h
@@ -238,7 +238,7 @@ CachedFunc ShapeFuncFor(const Function& prim_func, const Target& target,
 inline size_t CCacheKeyNode::Hash() const {
   if (hash_ != 0) return hash_;
   // do structral hash, avoid 0.
-  hash_ = tvm::StructuralHash()(this->source_func);
+  hash_ = tvm::StructuralHash(/*hash_ndarray_data*/ false)(this->source_func);
   hash_ = dmlc::HashCombine(hash_, std::hash<std::string>()(target->str()));
   if (hash_ == 0) hash_ = 1;
   return hash_;
@@ -248,7 +248,8 @@ inline bool CCacheKeyNode::Equal(const CCacheKeyNode* other) const {
   if (Hash() != other->Hash()) return false;
   return this->target->str() == other->target->str() &&
          this->virtual_device == other->virtual_device &&
-         tvm::StructuralEqual()(this->source_func, other->source_func);
+         tvm::StructuralEqual(/*compare_ndarray_data*/ false)(this->source_func,
+                                                              other->source_func);
 }
 
 }  // namespace tec

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -111,7 +111,7 @@ bool MatchRetValue(const ObjectRef& lhs, const TVMRetValue& rhs) {
         // Compare the objects for structural equality
         static auto* structural_equal = runtime::Registry::Get("node.StructuralEqual");
         ICHECK(structural_equal) << "node.StructuralEqual is not registered.";
-        if ((*structural_equal)(lhs, GetRef<ObjectRef>(rhs.ptr<Object>()), false, true)) {
+        if ((*structural_equal)(lhs, GetRef<ObjectRef>(rhs.ptr<Object>()), false, true, true)) {
           return true;
         }
       }
@@ -815,7 +815,7 @@ Expr PatternRewriter::Rewrite(const Array<DFPatternCallback>& callbacks, const E
       VLOG(1) << "post rewritten:" << std::endl << PrettyPrint(post);
       count++;
     }
-    equal = (*structural_equal)(last, post, false, true);
+    equal = (*structural_equal)(last, post, false, true, true);
   } while (!equal && count < 100 && !callback_->rewrite_once);
   if (count >= 100) {
     LOG(FATAL) << "Observed 100 rewrite passes, possible conflicting passes?";

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -339,5 +339,22 @@ def test_extract_task_arm_conv2d_nchwc():
     assert list(out_type.shape) == [1, 8, 130, 130, 4]
 
 
+@requires_torch
+def test_link_params():
+    target = "llvm --num-cores=10"
+    mod, params, _ = get_network(name="resnet_50", input_shape=[1, 3, 224, 224])
+
+    pass_config = {"relay.FuseOps.link_params": True,
+                    "relay.backend.use_meta_schedule": True,
+                    "relay.backend.tir_converter": "default"
+                    }
+
+    extracted_tasks = ms.extract_task_from_relay(mod, target, params, pass_config=pass_config)
+
+    conv2d_tasks = list(filter(lambda task: "conv2d" in task.task_name, extracted_tasks))
+
+    assert len(conv2d_tasks) == 24
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -344,10 +344,11 @@ def test_link_params():
     target = "llvm --num-cores=10"
     mod, params, _ = get_network(name="resnet_50", input_shape=[1, 3, 224, 224])
 
-    pass_config = {"relay.FuseOps.link_params": True,
-                    "relay.backend.use_meta_schedule": True,
-                    "relay.backend.tir_converter": "default"
-                    }
+    pass_config = {
+        "relay.FuseOps.link_params": True,
+        "relay.backend.use_meta_schedule": True,
+        "relay.backend.tir_converter": "default",
+    }
 
     extracted_tasks = ms.extract_task_from_relay(mod, target, params, pass_config=pass_config)
 


### PR DESCRIPTION
Motivation: Currently, `StructuralEqual/Hash` take into account NDArray raw data to determine equality / compute hash. This is problematic for `link-params = True` case, because meta schedule task extraction and database look up will treat the following subgraphs as distinct, even though the only difference is the content of NDArray constants. 
```
def @fused_nn.conv2d_add(%p0: Tensor[(1, 32, 32, 256), float32] /* ty=Tensor[(1, 32, 32, 256), float32] */, Primitive=1) -> Tensor[(1, 32, 32, 256), fl
oat32] {                                                                                                                      
  %0 = nn.conv2d(%p0, meta[relay.Constant][0] /* ty=Tensor[(3, 3, 256, 256), float32] */, padding=[1, 1, 1, 1], channels=256, kernel_size=[3, 3], data_
layout="NHWC", kernel_layout="HWIO") /* ty=Tensor[(1, 32, 32, 256), float32] */;                                                                       
  add(%0, meta[relay.Constant][1] /* ty=Tensor[(1, 1, 1, 256), float32] */) /* ty=Tensor[(1, 32, 32, 256), float32] */        
}

def @fused_nn.conv2d_add(%p0: Tensor[(1, 32, 32, 256), float32] /* ty=Tensor[(1, 32, 32, 256), float32] */, Primitive=1) -> Tensor[(1, 32, 32, 256), fl
oat32] {                                                                                                                      
  %0 = nn.conv2d(%p0, meta[relay.Constant][0] /* ty=Tensor[(3, 3, 256, 256), float32] */, padding=[1, 1, 1, 1], channels=256, kernel_size=[3, 3], data_
layout="NHWC", kernel_layout="HWIO") /* ty=Tensor[(1, 32, 32, 256), float32] */;                                                                       
  add(%0, meta[relay.Constant][1] /* ty=Tensor[(1, 1, 1, 256), float32] */) /* ty=Tensor[(1, 32, 32, 256), float32] */  
} 
```  

This PR adds options to `StructuralEqual/Hash` to allow ignoring NDArray raw data when comparing / hashing. MS task extraction and database look up are now using these options, since NDArray raw data doesn't matter to them.


cc @Hzfengsy @junrushao1994