### PR TITLE
[Apps] Pin android_camera TensorFlow/Keras dependency version

### DIFF
--- a/apps/android_camera/models/requirements.txt
+++ b/apps/android_camera/models/requirements.txt
@@ -1,4 +1,4 @@
-keras
+keras==2.9
 mxnet
 scipy
-tensorflow
+tensorflow==2.9.1


### PR DESCRIPTION
At the moment, android camera is installing latest TF and Keras
which is causing the following issue in CI:

```
  File ".../keras/dtensor/lazy_variable.py", line 26, in <module>
    from tensorflow.python.trackable import base as trackable
ModuleNotFoundError: No module named 'tensorflow.python.trackable'
```

This patch fixes the versions in the last known working versions
of both: TF 2.9.1 and Keras 2.9.

cc @driazati @lhutton1 @areusch