### PR TITLE
[Hexagon] Add optimized schedule for nn.pad

### DIFF
--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -701,7 +701,7 @@ reg.register_injective_schedule("nn.upsampling3d")
 
 
 # pad
-reg.register_broadcast_schedule("nn.pad")
+reg.register_schedule("nn.pad", strategy.schedule_pad)
 
 
 # mirror_pad

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -205,6 +205,14 @@ def schedule_lrn(attrs, outs, target):
         return topi.generic.schedule_lrn(outs)
 
 
+# pad
+@generic_func
+def schedule_pad(attrs, outs, target):
+    """Schedule PAD op"""
+    with target:
+        return schedule_injective(attrs, outs, target)
+
+
 # bitpack
 @generic_func
 def schedule_bitpack(attrs, outs, target):

--- a/python/tvm/relay/op/strategy/hexagon.py
+++ b/python/tvm/relay/op/strategy/hexagon.py
@@ -168,6 +168,13 @@ def schedule_concatenate_hexagon(attrs, outs, target):
         return topi.hexagon.schedule_injective(outs)
 
 
+@schedule_pad.register("hexagon")
+def schedule_pad_hexagon(attrs, outs, target):
+    """Schedule pad ops for Hexagon"""
+    with target:
+        return topi.hexagon.schedule_pad(outs)
+
+
 @schedule_pool.register("hexagon")
 def schedule_pool_hexagon(attrs, outs, target):
     """Schedule pool ops for Hexagon"""

--- a/python/tvm/topi/hexagon/__init__.py
+++ b/python/tvm/topi/hexagon/__init__.py
@@ -23,6 +23,7 @@ from .batch_matmul import *
 from .conv2d import *
 from .dense import *
 from .injective import *
+from .pad import *
 from .pooling import *
 from .reduce import *
 from .resize2d import *

--- a/python/tvm/topi/hexagon/pad.py
+++ b/python/tvm/topi/hexagon/pad.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Schedule for nn.pad operator"""
+
+import tvm
+
+import numpy as np
+
+
+def schedule_pad(outs):
+    """Schedule for pad op.
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+        The computation graph description of injective in the format
+        of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    outs = [outs] if isinstance(outs, tvm.te.tensor.Tensor) else outs
+    s = tvm.te.create_schedule([x.op for x in outs])
+    tvm.te.schedule.AutoInlineInjective(s)
+
+    # Fuse axes and vectorize only if last output tensor dimension is divisible by a factor:
+    factor = 128 // np.dtype(outs[0].dtype).itemsize
+    last_dim = outs[0].shape[-1]
+    if last_dim % factor == 0 and last_dim // factor >= 0:
+        fused = s[outs[0]].fuse(*outs[0].op.axis)
+        _, inner = s[outs[0]].split(fused, factor=factor)
+        s[outs[0]].vectorize(inner)
+
+    return s

--- a/tests/python/contrib/test_hexagon/topi/test_pad.py
+++ b/tests/python/contrib/test_hexagon/topi/test_pad.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test code for reduce"""
+import numpy as np
+
+import tvm
+from tvm import te, topi
+from tvm.contrib.hexagon.session import Session
+from tvm.topi.utils import get_const_tuple
+
+
+@tvm.testing.requires_hexagon
+def test_nn_pad(hexagon_session: Session):
+    dtype = "uint8"
+    in_shape = (1, 56, 56, 32)
+
+    data_in = np.ones(in_shape).astype(dtype)
+
+    A = te.placeholder(shape=in_shape, name="A", dtype=dtype)
+
+    C = topi.nn.pad(A, [0, 1, 1, 0], [0, 1, 1, 0], pad_value=0)
+
+    target_hexagon = tvm.target.hexagon("v68")
+    with tvm.target.Target(target_hexagon):
+        fschedule = topi.hexagon.schedule_pad
+        s = fschedule(C)
+
+    func = tvm.build(s, [A, C], tvm.target.Target(target_hexagon, host=target_hexagon), name="pad")
+    mod = hexagon_session.load_module(func)
+
+    dev = hexagon_session.device
+    a = tvm.nd.array(data_in, dev)
+    b = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), dev)
+    mod["pad"](a, b)
+
+    # Reference numpy pad output
+    ref_out = np.pad(data_in, pad_width=((0, 0), (1, 1), (1, 1), (0, 0)))
+
+    tvm.testing.assert_allclose(b.numpy(), ref_out)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
**Motivation**:
In case of quantized models nn.pad operation typically is not fused with QNN ops and lives as a standalone operation. In this case it uses default injective schedule for Hexagon target and it is not optimized very well for some shapes/layouts (based on analysis of real models like ResNet50 INT8).

**What was done:**
New schedule for Pad operation was implemented instead of default injective schedule. For Hexagon target injective schedule does fusion of all axis and vectorization on 128/64/32 (depends on dtype). It works fine for Add, Sub, etc... but not for Pad. New optimized schedule does these steps (fusion+vectorization) only if last tensor dimension is divisible by 128/64/32 (depends on dtype). It was done only for Hexagon, for other targets (x86, cuda, etc.) there is no changes and it uses default injective schedule.

**Benchmark results on Snapdragon 888:**

4d NHWC layout with ((0, 0), (1, 1), (1, 1), (0, 0)) padding, "uint8" dtype:

shape              | default schedule, ms | optimized schedule, ms |      speedup      |
-------------------|----------------------|------------------------|-------------------|
(1, 112, 112, 32)  |         10,03        |           0.2          |    50.1x times    |
(1, 56, 56, 128)   |         0,099        |          0,085         |  ~1x (no speedup) |


4d NCHW layout with ((0, 0), (0, 0), (1, 1), (1, 1)) padding, "uint8" dtype:

shape              | default schedule, ms | optimized schedule, ms |      speedup      |
-------------------|----------------------|------------------------|-------------------|
(1, 128, 56, 56)   |         10.96        |          1.38          |    7.9x times     |
(1, 32, 126, 126)  |          1.66        |          1.58          |  ~1x (no speedup) |
(1, 32, 128, 128)  |         13.98        |          2.66          |    5.25x times    |


5d NCHWc layout with ((0, 0), (0, 0), (1, 1), (1, 1), (0, 0)) padding, "uint8" dtype:

shape              | default schedule, ms | optimized schedule, ms |      speedup      |
-------------------|----------------------|------------------------|-------------------|
(1, 4, 56, 56, 32) |          6.39        |          0.29          |     22x times     |
(1, 56, 56, 128)   |          0.15        |          0.15          |  ~1x (no speedup) |


**Summary:**
For some input tensors we get up to 50x times speedup, for other performance is the same.
No performance degradations were detected.



cc @mehrdadh