### PR TITLE
[TIR, Schedule] Check consumer in-bound and covered in reverse_compute_inline

### DIFF
--- a/tests/python/unittest/test_tir_schedule_compute_inline.py
+++ b/tests/python/unittest/test_tir_schedule_compute_inline.py
@@ -611,6 +611,22 @@ def elementwise_overcomputed_producer_reverse_inlined(
             C[vi, vj] = A[vi, vj] * 2.0 + 1.0
 
 
+@T.prim_func
+def elementwise_producer_not_cover_consumer(
+    A: T.Buffer[(128, 128), "float32"],
+    D: T.Buffer[(256, 128), "float32"]
+) -> None:
+    B = T.alloc_buffer((128, 128))
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            B[vi, vj] = A[vi, vj] * 2.0
+    for i, j in T.grid(256, 128):
+        with T.block("C"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            D[vi, vj] = T.if_then_else(vi >= 128, B[vi - 128, vj], T.float32(0), dtype="float32")
+
+
 # pylint: enable=no-member,invalid-name,unused-variable
 
 use_block_name = tvm.testing.parameter(by_dict={"block_obj": False, "block_name": True})
@@ -856,6 +872,16 @@ def test_reverse_compute_inline_overcomputed_producer(use_block_name):
     tvm.ir.assert_structural_equal(
         elementwise_overcomputed_producer_reverse_inlined, sch.mod["main"]
     )
+
+
+def test_reverse_compute_inline_error_producer_not_cover_consumer(use_block_name):
+    """Test reverse compute inline failure when the inlined block iter domains are not covered by
+    its producer
+    """
+    sch = tir.Schedule(elementwise_producer_not_cover_consumer, debug_mask="all")
+    compute = "C" if use_block_name else sch.get_block("C")
+    with pytest.raises(tvm.tir.ScheduleError):
+        sch.reverse_compute_inline(compute)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_schedule_compute_inline.py
+++ b/tests/python/unittest/test_tir_schedule_compute_inline.py
@@ -613,8 +613,7 @@ def elementwise_overcomputed_producer_reverse_inlined(
 
 @T.prim_func
 def elementwise_producer_not_cover_consumer(
-    A: T.Buffer[(128, 128), "float32"],
-    D: T.Buffer[(256, 128), "float32"]
+    A: T.Buffer[(128, 128), "float32"], D: T.Buffer[(256, 128), "float32"]
 ) -> None:
     B = T.alloc_buffer((128, 128))
     for i, j in T.grid(128, 128):

--- a/tests/python/unittest/test_tir_schedule_compute_inline.py
+++ b/tests/python/unittest/test_tir_schedule_compute_inline.py
@@ -585,6 +585,32 @@ def exp_exp_opaque_access_with_tvm_access_ptr_inlined(
             )
 
 
+@T.prim_func
+def elementwise_overcomputed_producer(
+    A: T.Buffer[(128, 128), "float32"], C: T.Buffer[(127, 127), "float32"]
+) -> None:
+    B = T.alloc_buffer((128, 128))
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            B[vi, vj] = A[vi, vj] * 2.0
+    for i, j in T.grid(127, 127):
+        with T.block("C"):
+            cvi, cvj = T.axis.remap("SS", [i, j])
+            C[cvi, cvj] = B[cvi, cvj] + 1.0
+
+
+@T.prim_func
+def elementwise_overcomputed_producer_reverse_inlined(
+    A: T.Buffer[(128, 128), "float32"], C: T.Buffer[(127, 127), "float32"]
+) -> None:
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            T.where(i < 127 and j < 127)
+            C[vi, vj] = A[vi, vj] * 2.0 + 1.0
+
+
 # pylint: enable=no-member,invalid-name,unused-variable
 
 use_block_name = tvm.testing.parameter(by_dict={"block_obj": False, "block_name": True})
@@ -819,6 +845,16 @@ def test_compute_inline_opaque_access_with_tvm_access_ptr(use_block_name):
     sch.compute_inline(compute)
     tvm.ir.assert_structural_equal(
         exp_exp_opaque_access_with_tvm_access_ptr_inlined, sch.mod["main"]
+    )
+
+
+def test_reverse_compute_inline_overcomputed_producer(use_block_name):
+    """Test reverse compute inline overcomputed producer"""
+    sch = tir.Schedule(elementwise_overcomputed_producer, debug_mask="all")
+    compute = "C" if use_block_name else sch.get_block("C")
+    sch.reverse_compute_inline(compute)
+    tvm.ir.assert_structural_equal(
+        elementwise_overcomputed_producer_reverse_inlined, sch.mod["main"]
     )
 
 


### PR DESCRIPTION
* When the producer region is larger than the consumer region, `reverse_compute_inline` should generate predicates to prevent out-of-bound access to the consumer region.
* Check the consumer block iter domains are covered by the producer after inlining.
cc @spectrometerHBH @Hzfengsy @jwfromm 