### PR TITLE
[microTVM][Zephyr] Enable -O2 optimization on build by default

### DIFF
--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -491,6 +491,7 @@ class Handler(server.ProjectAPIHandler):
                 if options["zephyr_board"] in board_list:
                     f.write(f"{line}\n")
 
+            f.write("# For setting -O2 in compiler.\n" "CONFIG_SPEED_OPTIMIZATIONS=y\n")
             f.write("\n")
 
     API_SERVER_CRT_LIBS_TOKEN = "<API_SERVER_CRT_LIBS>"


### PR DESCRIPTION
This PR adds `CONFIG_SPEED_OPTIMIZATIONS=y` to zephyr project generation by default which results in `-O2` optimization for the zephyr project

cc @areusch @gromero @guberti 