### PR TITLE
[TIR][Fix] Handle iter vars in block predicate for SHash/SEqual

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1323,19 +1323,22 @@ class BlockRealizeNode : public StmtNode {
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("iter_values", &iter_values);
-    v->Visit("predicate", &predicate);
     v->Visit("block", &block);
+    v->Visit("predicate", &predicate);
   }
 
   bool SEqualReduce(const BlockRealizeNode* other, SEqualReducer equal) const {
-    return equal(iter_values, other->iter_values) && equal(predicate, other->predicate) &&
-           equal(block, other->block);
+    // Need to reduce the block before the predicate, because the
+    // predicate may be in terms of the iter_vars defined in the
+    // block.
+    return equal(iter_values, other->iter_values) && equal(block, other->block) &&
+           equal(predicate, other->predicate);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce(iter_values);
-    hash_reduce(predicate);
     hash_reduce(block);
+    hash_reduce(predicate);
   }
 
   static constexpr const char* _type_key = "tir.BlockRealize";


### PR DESCRIPTION
When lowering a non-opaque TIR block to an opaque block in `tir.transform.ConvertBlocksToOpaque`, the iter vars in BlockNode::iter_vars` are replaced by their values in `BlockRealizeNode::iter_values` wherever they occur in `BlockRealize`. However, prior to this commit, the `BlockRealizeNode::predicate` was visited before the variable definition of `BlockNode::iter_vars`.  As a result, StructuralHash and StructuralEqual would treat any occurrences as undefined variables, which is inconsistent with how they are handled in `ConvertBlocksToOpaque`.

This commit resolves the inconsistency by changing the visit order such that `BlockRealizeNode::block` is visited before `BlockRealizeNode::predicate`.

cc @Hzfengsy @junrushao1994