### PR TITLE
[TVMScript][TIR] Clarify scope of BlockNode::iter_vars

### DIFF
--- a/tests/python/unittest/test_tir_transform_convert_blocks_to_opaque.py
+++ b/tests/python/unittest/test_tir_transform_convert_blocks_to_opaque.py
@@ -82,6 +82,18 @@ def test_lower_te():
     tvm.ir.assert_structural_equal(mod, orig_mod)  # ConvertBlocksToOpaque should do nothing on TE
 
 
+class TestErrorIfPredicateUsesBlockVariables(tvm.testing.CompareBeforeAfter):
+    transform = tvm.tir.transform.ConvertBlocksToOpaque()
+
+    def before(A: T.Buffer[8, "int32"]):
+        for i in T.serial(8):
+            with T.block():
+                vi = T.axis.remap("S", [i])
+                T.where(vi < 6)
+                T.evaluate(0)
+
+    expected = tvm.TVMError
+
+
 if __name__ == "__main__":
-    test_elementwise()
-    test_lower_te()
+    tvm.testing.main()


### PR DESCRIPTION
Previously, it was ambiguous whether `BlockNode::iter_vars` were in-scope for `BlockRealizeNode::predicate`.  `ConvertBlocksToOpaque` treated them as in-scope, and applied a mapping from `iter_vars` to `iter_values`.  Similarly, TVMScript printing places `T.where` statements below the `T.axis` statements, where `T.axis` definitions are in scope.  However, `BlockRealizeNode::SEqualReduce` and `BlockRealizeNode::SHashReduce` do not visit the block and `iter_vars` until after visiting the predicate, placing the `iter_vars` out of scope.

This commit updates the printing of `T.where` to be above `T.axis`, and updates `ConvertBlocksToOpaque` to report an error if the predicate contains references to `BlockNode::iter_vars`.  After this commit, these three usages all consistently treat
`BlockNode::iter_vars` as out of scope for `BlockRealizeNode::predicate`.

cc @Hzfengsy @junrushao1994