### PR TITLE
[MetaSchedule] Mark two tests as xfail

### DIFF
--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -64,6 +64,7 @@ def test_meta_schedule_dynamic_loop_extent():
     assert not extracted_tasks
 
 
+@pytest.mark.xfail(strict=True, reason="See https://github.com/apache/tvm/issues/12732")
 @requires_torch
 def test_meta_schedule_integration_extract_from_resnet():
     mod, params, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
@@ -198,6 +199,7 @@ def test_meta_schedule_integration_extract_from_bert_base():
         assert expected_shape == shape, t.task_name
 
 
+@pytest.mark.xfail(strict=True, reason="See https://github.com/apache/tvm/issues/12732")
 @requires_torch
 def test_meta_schedule_integration_extract_from_resnet_with_filter_func():
     @register_func("relay.backend.tir_converter.remove_purely_spatial", override=True)


### PR DESCRIPTION
This patch marks two tests as xfail for further investigation:
* `test_meta_schedule_integration_extract_from_resnet_with_filter_func`
* `test_meta_schedule_integration_extract_from_resnet`

The errors are reported in #12732

cc @Hzfengsy @Mousius @areusch @driazati @junrushao @junrushao1994 @lhutton1