### PR TITLE
[Test] Add tvm.testing.requires_libtorch

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -945,6 +945,9 @@ requires_rpc = Feature("rpc", "RPC", cmake_flag="USE_RPC")
 # Mark a test as requiring Arm(R) Ethos(TM)-N to run
 requires_ethosn = Feature("ethosn", "Arm(R) Ethos(TM)-N", cmake_flag="USE_ETHOSN")
 
+# Mark a test as requiring libtorch to run
+requires_libtorch = Feature("libtorch", "LibTorch", cmake_flag="USE_LIBTORCH")
+
 # Mark a test as requiring Hexagon to run
 requires_hexagon = Feature(
     "hexagon",

--- a/tests/python/contrib/test_libtorch_ops.py
+++ b/tests/python/contrib/test_libtorch_ops.py
@@ -19,6 +19,7 @@ import pytest
 
 import tvm.relay
 from tvm.relay.op.contrib import torchop
+from tvm.testing import requires_libtorch
 
 import_torch_error = None
 
@@ -30,6 +31,7 @@ except ImportError as e:
 
 
 @pytest.mark.skipif(torch is None, reason=f"PyTorch is not available: {import_torch_error}")
+@requires_libtorch
 def test_backend():
     @torch.jit.script
     def script_fn(x, y):


### PR DESCRIPTION
Create a specific test dependency to map to USE_LIBTORCH, which is disabled by deafult, and is independent from torch being installed on the underlying machine, so it causes problems in machines that have torch installed but TVM is build with USE_LIBTORCH OFF.

Mark `tests.python.contrib.test_libtorch_ops.test_backend` with this new decorator.

This is to unblock integration tests in AArch64. I also opened #12736 to tackle other minor issues I noticed during the investigation.

cc @driazati @Mousius @lhutton1 @areusch @gigiblender