### PR TITLE
[CI] Update Docker images to bring TF 2.9 and integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,16 +49,16 @@
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:20220810-060142-fae79bbc3'
-ci_gpu = 'tlcpack/ci-gpu:20220810-060142-fae79bbc3'
-ci_cpu = 'tlcpack/ci-cpu:20220810-060142-fae79bbc3'
-ci_minimal = 'tlcpack/ci-minimal:20220725-133226-d3cefdaf1'
-ci_wasm = 'tlcpack/ci-wasm:20220810-060142-fae79bbc3'
-ci_i386 = 'tlcpack/ci-i386:20220810-060142-fae79bbc3'
-ci_cortexm = 'tlcpack/ci-cortexm:20220810-060142-fae79bbc3'
-ci_arm = 'tlcpack/ci-arm:20220810-060142-fae79bbc3'
-ci_hexagon = 'tlcpack/ci-hexagon:20220825-145056-fb7cf97f'
-ci_riscv = 'tlcpack/ci-riscv:20220810-060142-fae79bbc3'
+ci_lint = 'tlcpack/ci-lint:20220908-060034-62bdc91b1'
+ci_gpu = 'tlcpack/ci-gpu:20220908-060034-62bdc91b1'
+ci_cpu = 'tlcpack/ci-cpu:20220908-060034-62bdc91b1'
+ci_minimal = 'tlcpack/ci-minimal:20220908-060034-62bdc91b1'
+ci_wasm = 'tlcpack/ci-wasm:20220908-060034-62bdc91b1'
+ci_i386 = 'tlcpack/ci-i386:20220908-060034-62bdc91b1'
+ci_cortexm = 'tlcpack/ci-cortexm:20220909-090211-cb08a1251'
+ci_arm = 'tlcpack/ci-arm:20220908-060034-62bdc91b1'
+ci_hexagon = 'tlcpack/ci-hexagon:20220908-060034-62bdc91b1'
+ci_riscv = 'tlcpack/ci-riscv:20220908-060034-62bdc91b1'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -51,16 +51,16 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 {% import 'ci/jenkins/macros.j2' as m with context -%}
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:20220810-060142-fae79bbc3'
-ci_gpu = 'tlcpack/ci-gpu:20220810-060142-fae79bbc3'
-ci_cpu = 'tlcpack/ci-cpu:20220810-060142-fae79bbc3'
-ci_minimal = 'tlcpack/ci-minimal:20220725-133226-d3cefdaf1'
-ci_wasm = 'tlcpack/ci-wasm:20220810-060142-fae79bbc3'
-ci_i386 = 'tlcpack/ci-i386:20220810-060142-fae79bbc3'
-ci_cortexm = 'tlcpack/ci-cortexm:20220810-060142-fae79bbc3'
-ci_arm = 'tlcpack/ci-arm:20220810-060142-fae79bbc3'
-ci_hexagon = 'tlcpack/ci-hexagon:20220825-145056-fb7cf97f'
-ci_riscv = 'tlcpack/ci-riscv:20220810-060142-fae79bbc3'
+ci_lint = 'tlcpack/ci-lint:20220908-060034-62bdc91b1'
+ci_gpu = 'tlcpack/ci-gpu:20220908-060034-62bdc91b1'
+ci_cpu = 'tlcpack/ci-cpu:20220908-060034-62bdc91b1'
+ci_minimal = 'tlcpack/ci-minimal:20220908-060034-62bdc91b1'
+ci_wasm = 'tlcpack/ci-wasm:20220908-060034-62bdc91b1'
+ci_i386 = 'tlcpack/ci-i386:20220908-060034-62bdc91b1'
+ci_cortexm = 'tlcpack/ci-cortexm:20220909-090211-cb08a1251'
+ci_arm = 'tlcpack/ci-arm:20220908-060034-62bdc91b1'
+ci_hexagon = 'tlcpack/ci-hexagon:20220908-060034-62bdc91b1'
+ci_riscv = 'tlcpack/ci-riscv:20220908-060034-62bdc91b1'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -37,7 +37,16 @@ echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 echo set\(USE_VTA_TSIM ON\) >> config.cmake
 echo set\(USE_VTA_FSIM ON\) >> config.cmake
-echo set\(USE_TFLITE ON\) >> config.cmake
+
+# This conditional is just to support the transition to cope
+# with the change in the way TFLite is built. It can be
+# removed once we migrate to TensorFlow and TFLite > 2.9.1
+if [ -d "/opt/tflite" ]; then
+  echo set\(USE_TFLITE \"/opt/tflite\"\) >> config.cmake
+else
+  echo set\(USE_TFLITE ON\) >> config.cmake
+fi
+
 echo set\(USE_TENSORFLOW_PATH \"/tensorflow\"\) >> config.cmake
 echo set\(USE_FLATBUFFERS_PATH \"/flatbuffers\"\) >> config.cmake
 echo set\(USE_ETHOSN /opt/arm/ethosn-driver\) >> config.cmake

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -88,6 +88,7 @@ IGNORED_WARNINGS=(
     'autotvm:Cannot find config for target=cuda -keys=cuda,gpu'
     # Warning is thrown during TFLite quantization for micro_train tutorial
     'absl:For model inputs containing unsupported operations which cannot be quantized, the `inference_input_type` attribute will default to the original type.'
+    'absl:Found untraced functions such as _jit_compiled_convolution_op'
 )
 
 JOINED_WARNINGS=$(join_by '|' "${IGNORED_WARNINGS[@]}")


### PR DESCRIPTION
Updates Docker (all but `ci_cortexm`) images to tag
`20220908-060034-62bdc91b1`, to update TensorFlow/
TFLite/Keras to 2.9, and cascaded dependencies such as numpy.
Updates ethos-u-vela to 3.4.0.

It standardises (all but `ci_cortexm`) the minimum CMake version
required in CI to be 3.18.4.

`ci_cortexm` is updated to `20220909-090211-cb08a1251` as
it requires at least CMake 3.20 to comply with Zephyr requirements.

It also brings ONNX and PyTorch to ci_arm, to enable Integration tests
to be run in CI.

cc @Mousius @areusch @driazati @ekalda @gigiblender @lhutton1