### PR TITLE
[microtvm][Zephyr] Add project overlay to overwrite device tree configs

### DIFF
--- a/apps/microtvm/zephyr/template_project/app-overlay/nucleo_l4r5zi.overlay
+++ b/apps/microtvm/zephyr/template_project/app-overlay/nucleo_l4r5zi.overlay
@@ -1,3 +1,23 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 &rcc {
 	clock-frequency = <DT_FREQ_M(120)>;
 };

--- a/apps/microtvm/zephyr/template_project/app-overlay/nucleo_l4r5zi.overlay
+++ b/apps/microtvm/zephyr/template_project/app-overlay/nucleo_l4r5zi.overlay
@@ -1,0 +1,3 @@
+&rcc {
+	clock-frequency = <DT_FREQ_M(120)>;
+};

--- a/cmake/modules/Zephyr.cmake
+++ b/cmake/modules/Zephyr.cmake
@@ -29,6 +29,7 @@ if(USE_MICRO)
       "apps/microtvm/zephyr/template_project/src/host_driven *.h -> zephyr/src/host_driven"
       "apps/microtvm/zephyr/template_project/fvp-hack * -> zephyr/fvp-hack"
       "apps/microtvm/zephyr/template_project/qemu-hack * -> zephyr/qemu-hack"
+      "apps/microtvm/zephyr/template_project/app-overlay * -> zephyr/app-overlay"
       "apps/microtvm/zephyr/template_project/crt_config *.h -> zephyr/crt_config"
     )
 

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -148,6 +148,7 @@ ALLOW_SPECIFIC_FILE = {
     "apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-riscv32",
     "apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-riscv64",
     "apps/microtvm/zephyr/template_project/fvp-hack/FVP_Corstone_SSE-300_Ethos-U55",
+    "apps/microtvm/zephyr/template_project/app-overlay/nucleo_l4r5zi.overlay",
     # microTVM Virtual Machines
     "apps/microtvm/poetry.lock",
     "apps/microtvm/reference-vm/Vagrantfile",


### PR DESCRIPTION
This PR adds a mechanism to overwrite device tree configs in zephyr project. It also adds an overlay for nucleo_l4r5zi board to change processor frequency from 80MHz which is the default to 120MHz.

cc @alanmacd @areusch @gromero @guberti