### PR TITLE
[ci][docker] Use CMake 3.20.0 for cortexm

### DIFF
--- a/docker/Dockerfile.ci_cortexm
+++ b/docker/Dockerfile.ci_cortexm
@@ -33,7 +33,7 @@ COPY install/ubuntu1804_install_python.sh /install/ubuntu1804_install_python.sh
 RUN bash /install/ubuntu1804_install_python.sh
 
 COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source.sh
-RUN bash /install/ubuntu_install_cmake_source.sh
+RUN bash /install/ubuntu_install_cmake_source.sh 3.20.0
 
 COPY install/ubuntu1804_install_python_venv.sh /install/ubuntu1804_install_python_venv.sh
 RUN bash /install/ubuntu1804_install_python_venv.sh

--- a/docker/install/ubuntu_install_cmake_source.sh
+++ b/docker/install/ubuntu_install_cmake_source.sh
@@ -20,13 +20,19 @@ set -e
 set -u
 set -o pipefail
 
-v=3.18
-version=3.18.4
+if [ -z ${1+x} ]; then
+    version=3.18.4
+else
+    version=$1
+fi
+
+v=$(echo $version | sed 's/\(.*\)\..*/\1/g')
+echo "Installing cmake $version ($v)"
 wget https://cmake.org/files/v${v}/cmake-${version}.tar.gz
 tar xvf cmake-${version}.tar.gz
 cd cmake-${version}
 ./bootstrap
-make -j$(nproc)
+make -j"$(nproc)"
 make install
 cd ..
 rm -rf cmake-${version} cmake-${version}.tar.gz


### PR DESCRIPTION
The Zephyr project builds require 3.20.0 to work correctly

cc @Mousius @areusch @gigiblender