### PR TITLE
[TF] Add Bincount support

### DIFF
--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -5759,6 +5759,41 @@ def test_invert_permutation():
 
 
 #######################################################################
+# Bincount
+# ----
+
+
+def _test_bincount(in_shape, size, weights):
+    with tf.Graph().as_default():
+        inputs = []
+        data = []
+        inputs.append(tf.placeholder(shape=in_shape, dtype="int32", name="input0"))
+        data.append(np.random.uniform(0, size, size=in_shape).astype("int32"))
+        inputs.append(tf.placeholder(shape=(), dtype="int32", name="size"))
+        data.append(np.array(size, "int32"))
+        if weights:
+            inputs.append(tf.placeholder(shape=in_shape, dtype="float32", name="weights"))
+            data.append(np.reshape(weights, in_shape).astype("float32"))
+        else:
+            inputs.append(tf.placeholder(shape=(0,), dtype="float32", name="weights"))
+            data.append(np.array([], "float32"))
+        result = tf.raw_ops.Bincount(arr=data[0], size=data[1], weights=data[2])
+        compare_tf_with_tvm(data, [a.name for a in inputs], result.name, mode="vm")
+
+
+def test_forward_bincount():
+    """Test Bincount Op"""
+    # 2D input
+    _test_bincount((3, 10), 20, [1.0] * 30)
+    _test_bincount((3, 10), 20, [1.5] * 30)
+    _test_bincount((3, 10), 20, None)
+    # 1D input
+    _test_bincount((10,), 20, [1.0] * 10)
+    _test_bincount((10,), 20, [1.5] * 10)
+    _test_bincount((10,), 20, None)
+
+
+#######################################################################
 # DenseBincount
 # ----
 


### PR DESCRIPTION
### Description
This PR adds TF [Bincount](https://www.tensorflow.org/api_docs/python/tf/raw_ops/Bincount) support. 

Recently [DenseBincount support](https://github.com/apache/tvm/pull/12728) was added. Both `raw_ops.Bincount` and `raw_ops.DenseBincount` are used by `tf.math.bincount()` . One or another raw_op is used depending on the `tf.math.bincount()` parameters.

#### Limitations:
- Requires `relay.vm.compile` because internal data structures shapes depend on the input data content.

#### Known issues:
- Input array should not contain numbers outside of the range `[0, size-1]`. TVM `scatter_add` counts such values, but TF `DenseBincount` ignores them.
- using `tf.math.bincount()` with `weights` and `axis=None` requires operator `UnsortedSegmentSum` to be implemented.

@masahi 