### PR TITLE
[TIR, analysis] Add CommutativeDeepEqual to handle commutativity in expression comparison

### DIFF
--- a/python/tvm/tir/analysis/analysis.py
+++ b/python/tvm/tir/analysis/analysis.py
@@ -331,3 +331,33 @@ def OOBChecker():
         The result pass
     """
     return _ffi_api.OOBChecker()  # type: ignore
+
+
+def commutative_deep_equal(lhs: PrimExpr, rhs: PrimExpr) -> bool:
+    """Deeply compare two nested expressions that have commutative equality.
+
+    Parameters
+    ----------
+    lhs : PrimExpr
+        The left operand.
+
+    rhs : PrimExpr
+        The right operand.
+
+    Returns
+    -------
+    result : bool
+        The comparison result
+
+    Note
+    ----
+
+    This function is an extension of py:func:`tvm.ir.expr_deep_equal`, it can
+    handle commutativity. This function will return true for (x + y) vs (y + x)
+    but the py:func:`tvm.ir.expr_deep_equal` will return false for (x + y) vs (y + x).
+
+    See Also
+    --------
+    tvm.ir.expr_deep_equal
+    """
+    return _ffi_api.commutative_deep_equal(lhs, rhs)  # type: ignore

--- a/src/tir/analysis/deep_equal.cc
+++ b/src/tir/analysis/deep_equal.cc
@@ -26,9 +26,323 @@
 #include <tvm/node/structural_equal.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/analysis.h>
-
+#include <tvm/tir/expr.h>
+#include <tvm/tir/expr_functor.h>
+#include <tvm/tir/stmt.h>
+#include <tvm/tir/stmt_functor.h>  // For the class StmtExprMutator
 namespace tvm {
 namespace tir {
+
+class SortExprByHashVisitor : public ExprVisitor {
+ public:
+  void VisitExpr_(const VarNode* op) final;
+  void VisitExpr_(const SizeVarNode* op) final;
+  void VisitExpr_(const LoadNode* op) final;
+  void VisitExpr_(const BufferLoadNode* op) final;
+  void VisitExpr_(const ProducerLoadNode* op) final;
+  void VisitExpr_(const LetNode* op) final;
+  void VisitExpr_(const CallNode* op) final;
+  void VisitExpr_(const AddNode* op) final;
+  void VisitExpr_(const SubNode* op) final;
+  void VisitExpr_(const MulNode* op) final;
+  void VisitExpr_(const DivNode* op) final;
+  void VisitExpr_(const ModNode* op) final;
+  void VisitExpr_(const FloorDivNode* op) final;
+  void VisitExpr_(const FloorModNode* op) final;
+  void VisitExpr_(const MinNode* op) final;
+  void VisitExpr_(const MaxNode* op) final;
+  void VisitExpr_(const EQNode* op) final;
+  void VisitExpr_(const NENode* op) final;
+  void VisitExpr_(const LTNode* op) final;
+  void VisitExpr_(const LENode* op) final;
+  void VisitExpr_(const GTNode* op) final;
+  void VisitExpr_(const GENode* op) final;
+  void VisitExpr_(const AndNode* op) final;
+  void VisitExpr_(const OrNode* op) final;
+  void VisitExpr_(const ReduceNode* op) final;
+  void VisitExpr_(const CastNode* op) final;
+  void VisitExpr_(const NotNode* op) final;
+  void VisitExpr_(const SelectNode* op) final;
+  void VisitExpr_(const RampNode* op) final;
+  void VisitExpr_(const BroadcastNode* op) final;
+  void VisitExpr_(const ShuffleNode* op) final;
+  void VisitExpr_(const IntImmNode* op) final;
+  void VisitExpr_(const FloatImmNode* op) final;
+  void VisitExpr_(const StringImmNode* op) final;
+  void VisitExpr_(const AnyNode* op) final;
+
+  std::vector<std::pair<int, std::vector<PrimExpr>>> op_stack;
+  int cur_max_tree_idx = 0;
+  int pre_max_tree_idx = 0;
+
+ private:
+  std::string pre_bin_op = "null";
+  int stack_idx = 0;
+  int cur_tree_idx = 0;
+};
+
+#define TVM_DEFINE_BIN_OP_SORT_BY_HASH_VISITOR(OpName)                 \
+  void SortExprByHashVisitor::VisitExpr_(const OpName* op) {           \
+    std::string cur_bin_op = op->_type_key;                            \
+    std::string cur_pre_bin_op = pre_bin_op;                           \
+    int cur_stack_idx = stack_idx;                                     \
+    if (cur_bin_op != cur_pre_bin_op || cur_pre_bin_op == "null") {    \
+      std::vector<PrimExpr> expr_stack;                                \
+      if (cur_tree_idx + 1 > pre_max_tree_idx) {                       \
+        return;                                                        \
+      }                                                                \
+      op_stack.emplace_back(std::make_pair(cur_tree_idx, expr_stack)); \
+      cur_tree_idx += 1;                                               \
+      cur_max_tree_idx = std::max(cur_max_tree_idx, cur_tree_idx);     \
+      cur_stack_idx = op_stack.size();                                 \
+      stack_idx = cur_stack_idx;                                       \
+      cur_pre_bin_op = cur_bin_op;                                     \
+      pre_bin_op = cur_pre_bin_op;                                     \
+    }                                                                  \
+    int cur_tree_idx_temp = cur_tree_idx;                              \
+    if ((op->a).as<OpName>() == nullptr) {                             \
+      op_stack[stack_idx - 1].second.emplace_back(op->a);              \
+    }                                                                  \
+    if ((op->b).as<OpName>() == nullptr) {                             \
+      op_stack[stack_idx - 1].second.emplace_back(op->b);              \
+    }                                                                  \
+    this->VisitExpr(op->a);                                            \
+    pre_bin_op = cur_pre_bin_op;                                       \
+    stack_idx = cur_stack_idx;                                         \
+    cur_tree_idx = cur_tree_idx_temp;                                  \
+    this->VisitExpr(op->b);                                            \
+    pre_bin_op = cur_pre_bin_op;                                       \
+    stack_idx = cur_stack_idx;                                         \
+    cur_tree_idx = cur_tree_idx_temp;                                  \
+  }
+
+#define TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(OpName)    \
+  void SortExprByHashVisitor::VisitExpr_(const OpName* op) { \
+    std::string cur_pre_bin_op = "null";                     \
+    pre_bin_op = cur_pre_bin_op;                             \
+    this->VisitExpr(op->a);                                  \
+    pre_bin_op = cur_pre_bin_op;                             \
+    this->VisitExpr(op->b);                                  \
+  }
+
+#define TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(OpName) \
+  void SortExprByHashVisitor::VisitExpr_(const OpName* op) { return; }
+
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_VISITOR(AddNode)
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_VISITOR(MulNode)
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_VISITOR(AndNode)
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_VISITOR(OrNode)
+
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(SubNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(DivNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(ModNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(FloorDivNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(FloorModNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(MinNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(MaxNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(EQNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(NENode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(LTNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(LENode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(GTNode)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_VISITOR(GENode)
+
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(VarNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(SizeVarNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(LoadNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(BufferLoadNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(ProducerLoadNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(LetNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(CallNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(ReduceNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(CastNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(NotNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(SelectNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(RampNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(BroadcastNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(ShuffleNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(IntImmNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(FloatImmNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(StringImmNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_VISITOR(AnyNode)
+
+class SortExprByHashMutator : public StmtExprMutator {
+ public:
+  void Init() {
+    pre_bin_op = "null";
+    stack_idx = 0;
+    cur_tree_idx = 0;
+    full_stack_size = 0;
+  }
+
+  PrimExpr Rewrite(const PrimExpr& op) {
+    Init();
+    SortExprByHashVisitor sort_visitor;
+    sort_visitor.pre_max_tree_idx = pre_max_tree_idx;
+    sort_visitor(op);
+    for (auto& stack_pair : sort_visitor.op_stack) {
+      if (stack_pair.first == sort_visitor.cur_max_tree_idx - 1) {
+        std::sort(stack_pair.second.begin(), stack_pair.second.end(),
+                  [](PrimExpr expr_a, PrimExpr expr_b) {
+                    int64_t hash_a = tvm::StructuralHash()(expr_a);
+                    int64_t hash_b = tvm::StructuralHash()(expr_b);
+                    return hash_a < hash_b;
+                  });
+      }
+    }
+    op_stack.swap(sort_visitor.op_stack);
+    pre_max_tree_idx = sort_visitor.cur_max_tree_idx;
+    PrimExpr result = StmtExprMutator::VisitExpr(op);
+    pre_max_tree_idx = sort_visitor.cur_max_tree_idx - 1;
+    return result;
+  }
+
+  PrimExpr VisitExpr_(const VarNode* op) final;
+  PrimExpr VisitExpr_(const SizeVarNode* op) final;
+  PrimExpr VisitExpr_(const LoadNode* op) final;
+  PrimExpr VisitExpr_(const BufferLoadNode* op) final;
+  PrimExpr VisitExpr_(const ProducerLoadNode* op) final;
+  PrimExpr VisitExpr_(const LetNode* op) final;
+  PrimExpr VisitExpr_(const CallNode* op) final;
+  PrimExpr VisitExpr_(const AddNode* op) final;
+  PrimExpr VisitExpr_(const SubNode* op) final;
+  PrimExpr VisitExpr_(const MulNode* op) final;
+  PrimExpr VisitExpr_(const DivNode* op) final;
+  PrimExpr VisitExpr_(const ModNode* op) final;
+  PrimExpr VisitExpr_(const FloorDivNode* op) final;
+  PrimExpr VisitExpr_(const FloorModNode* op) final;
+  PrimExpr VisitExpr_(const MinNode* op) final;
+  PrimExpr VisitExpr_(const MaxNode* op) final;
+  PrimExpr VisitExpr_(const EQNode* op) final;
+  PrimExpr VisitExpr_(const NENode* op) final;
+  PrimExpr VisitExpr_(const LTNode* op) final;
+  PrimExpr VisitExpr_(const LENode* op) final;
+  PrimExpr VisitExpr_(const GTNode* op) final;
+  PrimExpr VisitExpr_(const GENode* op) final;
+  PrimExpr VisitExpr_(const AndNode* op) final;
+  PrimExpr VisitExpr_(const OrNode* op) final;
+  PrimExpr VisitExpr_(const ReduceNode* op) final;
+  PrimExpr VisitExpr_(const CastNode* op) final;
+  PrimExpr VisitExpr_(const NotNode* op) final;
+  PrimExpr VisitExpr_(const SelectNode* op) final;
+  PrimExpr VisitExpr_(const RampNode* op) final;
+  PrimExpr VisitExpr_(const BroadcastNode* op) final;
+  PrimExpr VisitExpr_(const ShuffleNode* op) final;
+  PrimExpr VisitExpr_(const IntImmNode* op) final;
+  PrimExpr VisitExpr_(const FloatImmNode* op) final;
+  PrimExpr VisitExpr_(const StringImmNode* op) final;
+  PrimExpr VisitExpr_(const AnyNode* op) final;
+
+  int pre_max_tree_idx = 0;
+
+ private:
+  std::vector<std::pair<int, std::vector<PrimExpr>>> op_stack;
+  std::string pre_bin_op = "null";
+  int stack_idx = 0;
+  int full_stack_size = 0;
+  int cur_tree_idx = 0;
+};
+
+#define TVM_DEFINE_BIN_OP_SORT_BY_HASH_MUTATOR(Op)                                            \
+  PrimExpr SortExprByHashMutator::VisitExpr_(const Op##Node* op) {                            \
+    std::string cur_bin_op = op->_type_key;                                                   \
+    std::string cur_pre_bin_op = pre_bin_op;                                                  \
+    int cur_stack_idx = stack_idx;                                                            \
+    if (cur_bin_op != cur_pre_bin_op) {                                                       \
+      if (cur_tree_idx + 1 > pre_max_tree_idx) {                                              \
+        return GetRef<PrimExpr>(op);                                                          \
+      }                                                                                       \
+      if (cur_tree_idx + 1 == pre_max_tree_idx) {                                             \
+        PrimExpr expr_sorted =                                                                \
+            Op(op_stack[full_stack_size].second[0], op_stack[full_stack_size].second[1]);     \
+        for (std::size_t idx = 0; idx < op_stack[full_stack_size].second.size() - 2; idx++) { \
+          expr_sorted = Op(expr_sorted, op_stack[full_stack_size].second[idx + 2]);           \
+        }                                                                                     \
+        full_stack_size += 1;                                                                 \
+        cur_stack_idx = full_stack_size;                                                      \
+        cur_tree_idx += 1;                                                                    \
+        return expr_sorted;                                                                   \
+      }                                                                                       \
+      full_stack_size += 1;                                                                   \
+      cur_stack_idx = full_stack_size;                                                        \
+      cur_tree_idx += 1;                                                                      \
+      stack_idx = cur_stack_idx;                                                              \
+      cur_pre_bin_op = cur_bin_op;                                                            \
+      pre_bin_op = cur_pre_bin_op;                                                            \
+    }                                                                                         \
+    PrimExpr a;                                                                               \
+    PrimExpr b;                                                                               \
+    int cur_tree_idx_temp = cur_tree_idx;                                                     \
+    GetRef<PrimExpr>(op);                                                                     \
+    if (!((op->a).as<Op##Node>() == nullptr && cur_tree_idx == pre_max_tree_idx)) {           \
+      a = this->VisitExpr(op->a);                                                             \
+    } else {                                                                                  \
+      a = op->a;                                                                              \
+    }                                                                                         \
+    pre_bin_op = cur_pre_bin_op;                                                              \
+    stack_idx = cur_stack_idx;                                                                \
+    cur_tree_idx = cur_tree_idx_temp;                                                         \
+    if (!((op->b).as<Op##Node>() == nullptr && cur_tree_idx == pre_max_tree_idx)) {           \
+      b = this->VisitExpr(op->b);                                                             \
+    } else {                                                                                  \
+      b = op->b;                                                                              \
+    }                                                                                         \
+    pre_bin_op = cur_pre_bin_op;                                                              \
+    stack_idx = cur_stack_idx;                                                                \
+    cur_tree_idx = cur_tree_idx_temp;                                                         \
+    return Op(a, b);                                                                          \
+  }
+
+#define TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(Op)              \
+  PrimExpr SortExprByHashMutator::VisitExpr_(const Op##Node* op) { \
+    std::string cur_pre_bin_op = "null";                           \
+    pre_bin_op = cur_pre_bin_op;                                   \
+    PrimExpr a = this->VisitExpr(op->a);                           \
+    pre_bin_op = cur_pre_bin_op;                                   \
+    PrimExpr b = this->VisitExpr(op->b);                           \
+    return Op(a, b);                                               \
+  }
+
+#define TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(OpName) \
+  PrimExpr SortExprByHashMutator::VisitExpr_(const OpName* op) { return GetRef<PrimExpr>(op); }
+
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_MUTATOR(Add)
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_MUTATOR(Mul)
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_MUTATOR(And)
+TVM_DEFINE_BIN_OP_SORT_BY_HASH_MUTATOR(Or)
+
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(Sub)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(Div)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(Mod)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(FloorDiv)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(FloorMod)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(Min)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(Max)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(EQ)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(NE)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(LT)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(LE)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(GT)
+TVM_DEFINE_BIN_OP_NO_SORT_BY_HASH_MUTATOR(GE)
+
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(VarNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(SizeVarNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(LoadNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(BufferLoadNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(ProducerLoadNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(LetNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(CallNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(ReduceNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(CastNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(NotNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(SelectNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(RampNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(BroadcastNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(ShuffleNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(IntImmNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(FloatImmNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(StringImmNode)
+TVM_DEFINE_PASS_OP_SORT_BY_HASH_MUTATOR(AnyNode)
 
 class DeepCmpSEqualHandler : public SEqualReducer::Handler {
  public:
@@ -70,9 +384,44 @@ bool ExprDeepEqual::operator()(const PrimExpr& lhs, const PrimExpr& rhs) const {
   return DeepCmpSEqualHandler().SEqualReduce(lhs, rhs, false, NullOpt);
 }
 
+class CommutativeDeepEqual : public ExprDeepEqual {
+ public:
+  bool operator()(const PrimExpr& lhs, const PrimExpr& rhs) const {
+    // quick path
+    if (lhs.same_as(rhs)) return true;
+    if (!lhs.defined() && rhs.defined()) return false;
+    if (!rhs.defined() && lhs.defined()) return false;
+    if (lhs->type_index() != rhs->type_index()) return false;
+    if (auto* plhs = lhs.as<IntImmNode>()) {
+      auto* prhs = rhs.as<IntImmNode>();
+      return plhs->dtype == prhs->dtype && plhs->value == prhs->value;
+    }
+    if (lhs.as<AnyNode>()) {
+      return false;
+    }
+    SortExprByHashMutator sort;
+    sort.pre_max_tree_idx = INT32_MAX;
+    auto sort_lhs = sort.Rewrite(lhs);
+    while (sort.pre_max_tree_idx != -1) {
+      sort_lhs = sort.Rewrite(sort_lhs);
+    }
+    sort.pre_max_tree_idx = INT32_MAX;
+    auto sort_rhs = sort.Rewrite(rhs);
+    while (sort.pre_max_tree_idx != -1) {
+      sort_rhs = sort.Rewrite(sort_rhs);
+    }
+    return DeepCmpSEqualHandler().SEqualReduce(sort_lhs, sort_rhs, false, NullOpt);
+  }
+};
+
 TVM_REGISTER_GLOBAL("tir.analysis.expr_deep_equal")
     .set_body_typed([](const PrimExpr& lhs, const PrimExpr& rhs) {
       return ExprDeepEqual()(lhs, rhs);
+    });
+
+TVM_REGISTER_GLOBAL("tir.analysis.commutative_deep_equal")
+    .set_body_typed([](const PrimExpr& lhs, const PrimExpr& rhs) {
+      return CommutativeDeepEqual()(lhs, rhs);
     });
 
 }  // namespace tir

--- a/tests/python/unittest/test_tir_analysis_commutative_deep_equal.py
+++ b/tests/python/unittest/test_tir_analysis_commutative_deep_equal.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+from tvm import te
+
+
+def test_commutative_equal():
+    x = te.var("x")
+    y = te.var("y")
+    m = te.var("m")
+    a = te.var("a")
+    b = te.var("b")
+    c = te.var("c")
+    int_imm = tvm.te.const(3, "int32")
+    ana = tvm.arith.Analyzer()
+
+    def func1():
+        return x + y + 1
+
+    def func2():
+        return te.exp(tvm.tir.truncdiv((x + y + 1) * y, 4))
+
+    assert tvm.tir.analysis.commutative_deep_equal(func1(), func1())
+    assert tvm.tir.analysis.commutative_deep_equal(func2(), func2())
+    assert not tvm.tir.analysis.commutative_deep_equal(func2(), func1())
+
+    def func3():
+        return x * m + y * c - a + b * m
+
+    def func4():
+        return c * y + m * x - a + m * b
+
+    assert tvm.tir.analysis.commutative_deep_equal(func3(), func4())
+
+    def func5():
+        return a * b * c + x + y
+
+    def func6():
+        return b * a * c + y + x
+
+    assert tvm.tir.analysis.commutative_deep_equal(func5(), func6())
+
+    def func7():
+        return x // int_imm * a * b * c
+
+    def func8():
+        return x // int_imm * c * a * b
+
+    assert tvm.tir.analysis.commutative_deep_equal(func7(), func8())
+
+    def func9():
+        return x // (int_imm + y + m) * a * b * c
+
+    def func10():
+        return x // (m + int_imm + y) * c * a * b
+
+    assert tvm.tir.analysis.commutative_deep_equal(func9(), func10())
+
+    def func11():
+        return x * y * a * b
+
+    def func12():
+        return a * y * x * b
+
+    assert tvm.tir.analysis.commutative_deep_equal(func11(), func12())
+
+    def func13():
+        return x * m + y * (c + a) - a + b * m
+
+    def func14():
+        return (a + c) * y + m * x - a + m * b
+
+    assert tvm.tir.analysis.commutative_deep_equal(func13(), func14())
+
+    def func15():
+        return a * (b * 3)
+
+    def func16():
+        return (a * 3) * b
+
+    assert tvm.tir.analysis.commutative_deep_equal(func15(), func16())
+
+
+if __name__ == "__main__":
+    test_commutative_equal()


### PR DESCRIPTION
Refer to issue https://github.com/apache/tvm/issues/10211. The CSE pass can't handle commutativity because the arith system may not be able to do the commutativity。

The determination of the equality of two expressions (PrimExpr) is to use the method of structured determination, that is, to traverse the hierarchical structure of the two expressions, and to judge while traversing, if the structures of the two expressions are the same, and the smallest If the child nodes (nodes that cannot be traversed, generally such as Var) are the same, the expressions are considered to be the same.

Before performing PrimExpr comparison, a series of rewrite rules will be used to rewrite expressions to solve some operational problems, such as x * y + x * z will be rewritten as x * (y + z), so that to deal with distributivity.
However, commutativity cannot be rewritten due to the characteristics of rewrite (it will fall into an infinite loop). This makes it impossible to compare the equality of some expressions, such as a * b *c != a * c * b, (a * b) * c != a * (b * c).

To solve this problem, one solution is to sort and rewrite the expressions according to the `StructuralHash` of the Var nodes in the expressions before comparing the expressions. If two expressions are equivalent if they satisfy the commutativity, then they will definitely produce equivalent expressions of the same structure after sorting.

Under the assumption that the two expressions have the same structure, the determination condition that the two expressions satisfying the commutativity are the same can be further refined to the same set of all elements in the sub-expressions satisfying the commutativity. The sub-expressions satisfying the commutativity in the expression can be grasped by constructing the expression syntax tree. The sub-expressions satisfying the commutativity are the sub-trees of the expression tree whose child nodes are identical (the child nodes are OP).

An example:
```
    Var： a, b, c, d, e

    StructuralHash(a > b >c >d > e)

    cse_var_1  = a * b *c + d + e

    cse_var_2 = b * a * c + e + d
```
Sort and rewrite cse_var_1 and cse_var_2, first extract their first subexpressions a * b *c and b * a * c, and rewrite them as a * b * c, and then extract the sub-expressions again ( a * b *c) + d + e and (a *b * c) + e + d, rewriting the sort as (a * b *c) + d + e, get the same expression.

cc @masahi @Hzfengsy @tqchen @FranckQC 