### PR TITLE
[TIR][Schedule] Relax cache read/write's restriction and fix unexpected behavior

### DIFF
--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -346,6 +346,7 @@ class BlockInfoCollector : private StmtVisitor {
               if (!ProducerCoversConsumer(buffer->shape, produced_region, consumed_region,
                                           &analyzer_)) {
                 region_cover = false;
+                self_->block_info.at(consumer_block_sref).region_cover = region_cover;
                 break;
               }
             }


### PR DESCRIPTION
Currently, cache read/write requires to be stage pipeline, but it is unnecessary theoretically. 
When there is WAR, the target of cache_read could be specified by the consumer_blocks parameter. This also allows cache_write to handle the write after read of the same buffer.

cc @Hzfengsy @junrushao1994 @wrongtest-intellif