### PR TITLE
[ETHOSN] Remove support for 22.05 version of the driver stack

### DIFF
--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -102,7 +102,7 @@ def partition_for_ethosn(mod, params=None, **opts):
         raise ValueError("When targeting Ethos(TM)-N78, -variant=n78 should be set.")
 
     api_version = ethosn_api_version()
-    supported_api_versions = ["3.0.1", "3.1.0"]
+    supported_api_versions = ["3.1.0"]
     if all(api_version != LooseVersion(exp_ver) for exp_ver in supported_api_versions):
         raise ValueError(
             f"Driver stack version {api_version} is unsupported. "

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -23,14 +23,11 @@ import pytest
 pytest.importorskip("tflite")
 pytest.importorskip("tensorflow")
 
-from distutils.version import LooseVersion
-
 import tflite.Model
 
 from tvm import relay
 from tvm.testing import requires_ethosn
 from tvm.contrib import download
-from tvm.relay.op.contrib.ethosn import ethosn_api_version
 import tvm.relay.testing.tf as tf_testing
 
 from . import infrastructure as tei
@@ -125,10 +122,7 @@ def test_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    if ethosn_api_version() == LooseVersion("3.1.0"):
-        _compile_hash = {"c37fec1f214c7f93ce49ee4e3b587969"}
-    else:
-        _compile_hash = {"50186822915909303e813205db80e032"}
+    _compile_hash = {"c37fec1f214c7f93ce49ee4e3b587969"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224_quant.tgz",
@@ -150,10 +144,7 @@ def test_resnet_50_int8():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    if ethosn_api_version() == LooseVersion("3.1.0"):
-        _compile_hash = {"12d65aec33594c88b6d0d31dcd5144e6", "6a64d69ccb36dfb6b30dd2abdba4b005"}
-    else:
-        _compile_hash = {"9245965b2c01e7f3d9b478e38a186eb4", "4225fa951c145bb1e48e28cad6a3bdd4"}
+    _compile_hash = {"12d65aec33594c88b6d0d31dcd5144e6", "6a64d69ccb36dfb6b30dd2abdba4b005"}
     _test_image_network(
         model_url="https://raw.githubusercontent.com/dmlc/web-data/main/tensorflow/"
         "models/Quantized/resnet_50_quantized.tflite",
@@ -174,10 +165,7 @@ def test_inception_v3():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    if ethosn_api_version() == LooseVersion("3.1.0"):
-        _compile_hash = {"cff892eb15944756f22dad4b83c756d2"}
-    else:
-        _compile_hash = {"a5a2b5d2b618de754bf9a01033a020c0"}
+    _compile_hash = {"cff892eb15944756f22dad4b83c756d2"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/tflite_11_05_08/inception_v3_quant.tgz",
@@ -198,10 +186,7 @@ def test_inception_v4():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    if ethosn_api_version() == LooseVersion("3.1.0"):
-        _compile_hash = {"2eeae331898f8e94c74868e190077837"}
-    else:
-        _compile_hash = {"61b4ade41898d7cb2451dbdc3340aced"}
+    _compile_hash = {"2eeae331898f8e94c74868e190077837"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/inception_v4_299_quant_20181026.tgz",
@@ -222,10 +207,7 @@ def test_ssd_mobilenet_v1():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    if ethosn_api_version() == LooseVersion("3.1.0"):
-        _compile_hash = {"ec2b78852192058f88b64d45c26620d5", "f68cbeaaba03874ea735ce3f5eab9227"}
-    else:
-        _compile_hash = {"789906c7d8ac787809b303d82781fc9d", "6b699f94795785d31b39940a5cf84a81"}
+    _compile_hash = {"ec2b78852192058f88b64d45c26620d5", "f68cbeaaba03874ea735ce3f5eab9227"}
     _test_image_network(
         model_url="https://storage.googleapis.com/download.tensorflow.org/"
         "models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip",

--- a/tests/python/contrib/test_ethosn/test_split.py
+++ b/tests/python/contrib/test_ethosn/test_split.py
@@ -17,15 +17,12 @@
 
 """Split tests for Arm(R) Ethos(TM)-N"""
 
-from distutils.version import LooseVersion
-
 import numpy as np
 import pytest
 
 import tvm
 from tvm import relay
 from tvm.testing import requires_ethosn
-from tvm.relay.op.contrib.ethosn import ethosn_api_version
 
 from . import infrastructure as tei
 
@@ -47,11 +44,6 @@ def _get_model(shape, dtype, splits, axis):
 )
 def test_split(dtype, shape, splits, axis):
     """Compare Split output with TVM."""
-    if ethosn_api_version() == LooseVersion("3.0.1"):
-        pytest.skip(
-            "Split is not supported by the 3.0.1 version of the driver stack.",
-        )
-
     np.random.seed(0)
 
     outputs = []
@@ -89,11 +81,6 @@ def test_split(dtype, shape, splits, axis):
 )
 def test_split_failure(shape, dtype, splits, axis, err_msg):
     """Check Split error messages."""
-    if ethosn_api_version() == LooseVersion("3.0.1"):
-        pytest.skip(
-            "Split is not supported by the 3.0.1 version of the driver stack.",
-        )
-
     model = _get_model(shape, dtype, splits, axis)
     mod = tei.make_ethosn_partition(model)
     tei.test_error(mod, {}, err_msg)

--- a/tests/python/contrib/test_ethosn/test_topologies.py
+++ b/tests/python/contrib/test_ethosn/test_topologies.py
@@ -17,15 +17,13 @@
 
 """Arm(R) Ethos(TM)-N tests for complex network topologies."""
 
-from distutils.version import LooseVersion
-
 import numpy as np
 import pytest
 
 import tvm
 from tvm import relay
 from tvm.testing import requires_ethosn
-from tvm.relay.op.contrib.ethosn import Available, ethosn_available, ethosn_api_version
+from tvm.relay.op.contrib.ethosn import Available, ethosn_available
 
 from . import infrastructure as tei
 
@@ -80,8 +78,8 @@ def test_split_add_concat(dtype):
         model = get_model(inputs["a"].shape, dtype, iter(inputs))
         mod = tei.make_module(model, [])
 
-        expected_host_ops = 1 if ethosn_api_version() == LooseVersion("3.0.1") else 0
-        npu_partitions = 2 if ethosn_api_version() == LooseVersion("3.0.1") else 1
+        expected_host_ops = 0
+        npu_partitions = 1
 
         # Mock inference is only supported when the whole graph is offloaded to the NPU
         if ethosn_available() == Available.SW_ONLY:
@@ -282,8 +280,8 @@ def test_split_with_asym_concats(dtype, shape, splits, axis):
         model = get_model(shape, dtype, splits, axis)
         mod = tei.make_module(model, {})
 
-        expected_host_ops = 1 if ethosn_api_version() == LooseVersion("3.0.1") else 0
-        npu_partitions = 2 if ethosn_api_version() == LooseVersion("3.0.1") else 1
+        expected_host_ops = 0
+        npu_partitions = 1
 
         # Mock inference is only supported when the whole graph is offloaded to the NPU
         if ethosn_available() == Available.SW_ONLY:
@@ -316,11 +314,6 @@ def test_split_with_asym_concats(dtype, shape, splits, axis):
 def test_output_tuple_propagation(dtype):
     """This tests the case where the output tuple must be inferred
     as having dummy tensor information."""
-
-    if ethosn_api_version() == LooseVersion("3.0.1"):
-        pytest.skip(
-            "Split is not supported by the 3.0.1 version of the driver stack.",
-        )
 
     def get_model(dtype):
         a = relay.var("a", shape=(1, 4, 4, 16), dtype=dtype)


### PR DESCRIPTION
After the upgrade of the driver stack to 22.08 (3.1.0), this commit removes support for the 22.05 (3.0.1) version.

cc @leandron @ashutosh-arm
