### PR TITLE
Fixed pylint issues after moving to venv in ci_lint docker

### DIFF
--- a/python/tvm/relay/testing/darknet.py
+++ b/python/tvm/relay/testing/darknet.py
@@ -23,9 +23,9 @@ This functions will not be loaded by default.
 These are utility functions used for testing and tutorial file.
 """
 from __future__ import division
+from cffi import FFI
 import numpy as np
 import cv2
-from cffi import FFI
 
 
 def convert_image(image):

--- a/tests/python/frontend/darknet/test_forward.py
+++ b/tests/python/frontend/darknet/test_forward.py
@@ -22,6 +22,7 @@ This article is a test script to test darknet models with Relay.
 All the required models and libraries will be downloaded from the internet
 by the script.
 """
+from cffi import FFI
 import numpy as np
 import tvm
 from tvm.contrib import graph_executor
@@ -31,7 +32,6 @@ from tvm.relay.testing.darknet import LAYERTYPE
 from tvm.relay.testing.darknet import __darknetffi__
 from tvm.relay.frontend.darknet import ACTIVATION
 from tvm import relay
-from cffi import FFI
 
 REPO_URL = "https://github.com/dmlc/web-data/blob/main/darknet/"
 DARKNET_LIB = "libdarknet2.0.so"

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -26,11 +26,11 @@ from distutils.version import LooseVersion
 import threading
 import platform
 import os.path
+from packaging import version as package_version
 import numpy as np
 import pytest
 
 from PIL import Image
-from packaging import version as package_version
 from tvm import relay
 from tvm.runtime.vm import VirtualMachine
 from tvm.relay.frontend.tensorflow import from_tensorflow

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -26,11 +26,11 @@ from distutils.version import LooseVersion
 
 import os
 import tempfile
+from packaging import version as package_version
 import pytest
 import numpy as np
 
 from PIL import Image
-from packaging import version as package_version
 
 import tvm
 import tvm.relay.testing.tf as tf_testing


### PR DESCRIPTION
PR https://github.com/apache/tvm/pull/12663 introduced
virtual environment in ci_lint docker image. At present, this
is not updated on docker hub. In the old docker image prior
to the above PR, pylint picked up a different version of python
that didn't catch the issues fixed in this commit.


cc @leandron @areusch 
