### PR TITLE
[Hexagon] 2-Stage Pipeline; Lower Async TIR primitives to Hexagon User DMA

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -721,6 +721,16 @@ TVM_DLL const Op& texture2d_load();
 TVM_DLL const Op& mem_copy();
 
 /*!
+ * \brief Initiate a non-blocking DMA copy from source to destination
+ */
+TVM_DLL const Op& dma_copy();
+
+/*!
+ * \brief Wait until the number of DMAs in flight is less than or equal to some maximum
+ */
+TVM_DLL const Op& dma_wait();
+
+/*!
  * \brief Provide a true statement that can be used for simplifications
  *
  * Compile-time representation of known constraints about function

--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -486,6 +486,11 @@ TVM_DLL Pass TextureFlatten();
 TVM_DLL Pass LowerVtcmAlloc();
 
 /*!
+ * \brief Lower Async TIR primitives to DMA copy and wait builtins
+ */
+TVM_DLL Pass LowerAsyncDMA();
+
+/*!
  * \brief Implements a Common Subexpression Elimination (CSE) for TIR
  *        which introduces let-in bindings for duplicated sub-expressions.
  * \param enable_cse_tir Whether common subexpression elimination is enabled.

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -225,6 +225,7 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   }
   // LowerVtcmAlloc must occur after any transformations that modify memory allocation locations
   pass_list.push_back(tir::transform::LowerVtcmAlloc());
+  pass_list.push_back(tir::transform::LowerAsyncDMA());
   pass_list.push_back(tir::transform::UnrollLoop());
 
   // Add user-defined phase-2 passes

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -50,7 +50,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION("tir.disable_storage_rewrite", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.is_entry_func", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.add_lower_pass", Array<Array<ObjectRef>>);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.debug_keep_trivial_loop", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tir.use_ptx_async_copy", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tir.use_async_copy", Bool);
 
 using runtime::PackedFunc;
 using runtime::TVMArgs;
@@ -225,7 +225,11 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   }
   // LowerVtcmAlloc must occur after any transformations that modify memory allocation locations
   pass_list.push_back(tir::transform::LowerVtcmAlloc());
-  pass_list.push_back(tir::transform::LowerAsyncDMA());
+  bool use_async_copy = pass_ctx->GetConfig<Bool>("tir.use_async_copy", Bool(false)).value();
+
+  if (use_async_copy) {
+    pass_list.push_back(tir::transform::LowerAsyncDMA());
+  }
   pass_list.push_back(tir::transform::UnrollLoop());
 
   // Add user-defined phase-2 passes
@@ -544,10 +548,9 @@ transform::Sequential MixedModulePassManager(IRModule mixed_mod, Target target) 
   mixed_pass_list.push_back(tir::transform::InferFragment());
   mixed_pass_list.push_back(tir::transform::LowerThreadAllreduce());
 
-  bool use_ptx_async_copy =
-      pass_ctx->GetConfig<Bool>("tir.use_ptx_async_copy", Bool(false)).value();
+  bool use_async_copy = pass_ctx->GetConfig<Bool>("tir.use_async_copy", Bool(false)).value();
 
-  if (use_ptx_async_copy) {
+  if (use_async_copy) {
     mixed_pass_list.push_back(tir::transform::InjectPTXAsyncCopy());
   }
 

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -33,6 +33,7 @@
 
 #include "../workspace_pool.h"
 #include "hexagon_common.h"
+#include "hexagon_user_dma.h"
 
 namespace tvm {
 namespace runtime {
@@ -203,6 +204,30 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.mem_copy").set_body([](TVMArgs args, TVM
   int error_code = hexagon_user_dma_1d_sync(dst, src, size);
   CHECK_EQ(error_code, 0);
 
+  *rv = static_cast<int32_t>(0);
+});
+
+TVM_REGISTER_GLOBAL("device_api.hexagon.dma_copy").set_body([](TVMArgs args, TVMRetValue* rv) {
+  int queue_id = args[0];
+  ICHECK(queue_id == 0 && "Hexagon supports just a single asynchronous queue for DMA");
+  void* dst = args[1];
+  void* src = args[2];
+  int size = args[3];
+  ICHECK(size >= 0);
+
+  int ret = DMA_RETRY;
+  do {
+    ret = HexagonUserDMA::Get().Copy(dst, src, size);
+  } while (ret == DMA_RETRY);
+  *rv = static_cast<int32_t>(ret);
+});
+
+TVM_REGISTER_GLOBAL("device_api.hexagon.dma_wait").set_body([](TVMArgs args, TVMRetValue* rv) {
+  int queue_id = args[0];
+  ICHECK(queue_id == 0 && "Hexagon supports just a single asynchronous queue for DMA");
+  int inflight = args[1];
+  ICHECK(inflight >= 0);
+  HexagonUserDMA::Get().Wait(inflight);
   *rv = static_cast<int32_t>(0);
 });
 

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -213,7 +213,7 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.dma_copy").set_body([](TVMArgs args, TVM
   void* dst = args[1];
   void* src = args[2];
   int size = args[3];
-  ICHECK(size >= 0);
+  ICHECK(size > 0);
 
   int ret = DMA_RETRY;
   do {

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -288,6 +288,12 @@ TIR_DEFINE_BUILTIN_FUNC(texture2d_load)
 TIR_DEFINE_BUILTIN_FUNC(mem_copy).set_attr<TCallEffectKind>("TCallEffectKind",
                                                             Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_BUILTIN_FUNC(dma_copy).set_attr<TCallEffectKind>("TCallEffectKind",
+                                                            Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_BUILTIN_FUNC(dma_wait).set_attr<TCallEffectKind>("TCallEffectKind",
+                                                            Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_BUILTIN_FUNC(assume)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kEmbedInfo))
     .set_num_inputs(1);

--- a/src/tir/transforms/lower_async_dma.cc
+++ b/src/tir/transforms/lower_async_dma.cc
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file lower_async_dma.cc
+ */
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include "ir_utils.h"
+
+namespace tvm {
+namespace tir {
+
+class AsyncDMALowerer : public StmtExprMutator {
+ public:
+  AsyncDMALowerer() {}
+
+  Stmt VisitStmt_(const AttrStmtNode* op) final {
+    // Convert this, for example:
+    // attr [0] "async_wait_queue_scope" = 0;
+    // attr [0] "async_wait_inflight_count" = 0;
+    //
+    // To this:
+    // @tir.dma_wait(
+    //   0, /* queue id */
+    //   0, /* in flight count */
+    //   dtype=int32
+    // )
+    if (op->attr_key == tir::attr::async_wait_queue_scope) {
+      auto async_wait = op->body.as<AttrStmtNode>();
+      ICHECK(async_wait && async_wait->attr_key == tir::attr::async_wait_inflight_count);
+
+      auto call_dma_wait =
+          Evaluate(Call(DataType::Int(32), builtin::dma_wait(), {op->value, async_wait->value}));
+
+      // concatenate the call with the body and return
+      return SeqStmt({call_dma_wait, async_wait->body});
+
+      // Convert this, for example:
+      // attr [0] "async_commit_queue_scope" = 0;
+      // attr [0] "async_scope" = 1;
+      // for (ax0: int32, 0, 128) {
+      //   A_global[ax0] = A[ax0]
+      // }
+      //
+      // To this:
+      // @tir.dma_copy(
+      //   0, /* queue id */
+      //   @tir.address_of(A_global[0], dtype=handle),
+      //   @tir.address_of(A[0], dtype=handle),
+      //   128, /* size */
+      //   dtype=int32
+      // )
+    } else if (op->attr_key == tir::attr::async_commit_queue_scope) {
+      auto async_scope = op->body.as<AttrStmtNode>();
+      ICHECK(async_scope && async_scope->attr_key == tir::attr::async_scope);
+
+      auto for_loop = async_scope->body.as<ForNode>();
+      if (!for_loop) {
+        return StmtExprMutator::VisitStmt_(op);
+      }
+
+      auto bufferstorenode = for_loop->body.as<BufferStoreNode>();
+      if (!bufferstorenode) {
+        return StmtExprMutator::VisitStmt_(op);
+      }
+
+      ICHECK(bufferstorenode->indices.size() == 1);
+
+      auto bufferloadnode = bufferstorenode->value.as<BufferLoadNode>();
+      if (!bufferloadnode) {
+        return StmtExprMutator::VisitStmt_(op);
+      }
+
+      ICHECK(bufferloadnode->indices.size() == 1);
+
+      auto bufferstore = bufferstorenode->buffer.as<BufferNode>();
+      ICHECK(bufferstore && bufferstore->strides.empty());
+
+      auto bufferload = bufferloadnode->buffer.as<BufferNode>();
+      ICHECK(bufferload && bufferload->strides.empty());
+
+      // map loop variable to zero
+      Map<Var, PrimExpr> loop_var_remap = {{for_loop->loop_var, IntImm(DataType::Int(32), 0)}};
+
+      Array<PrimExpr> store_indices = bufferstorenode->indices;
+      store_indices.MutateByApply([&](PrimExpr expr) {
+        arith::Analyzer analyzer;
+        return analyzer.Simplify(Substitute(std::move(expr), loop_var_remap));
+      });
+
+      Array<PrimExpr> load_indices = bufferloadnode->indices;
+      load_indices.MutateByApply([&](PrimExpr expr) {
+        arith::Analyzer analyzer;
+        return analyzer.Simplify(Substitute(std::move(expr), loop_var_remap));
+      });
+
+      return Evaluate(Call(DataType::Int(32), builtin::dma_copy(),
+                           {op->value,
+                            Call(DataType::Handle(), builtin::address_of(),
+                                 {BufferLoad(bufferstorenode->buffer, store_indices)}),
+                            Call(DataType::Handle(), builtin::address_of(),
+                                 {BufferLoad(bufferloadnode->buffer, load_indices)}),
+                            for_loop->extent * bufferloadnode->dtype.bytes()}));
+    }
+    return StmtExprMutator::VisitStmt_(op);
+  }
+};
+
+namespace transform {
+
+Pass LowerAsyncDMA() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    auto fptr = f.CopyOnWrite();
+    fptr->body = AsyncDMALowerer()(std::move(fptr->body));
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.LowerAsyncDMA", {});
+}
+
+TVM_REGISTER_GLOBAL("tir.transform.LowerAsyncDMA").set_body_typed(LowerAsyncDMA);
+}  // namespace transform
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/transforms/lower_async_dma.cc
+++ b/src/tir/transforms/lower_async_dma.cc
@@ -53,11 +53,19 @@ class AsyncDMALowerer : public StmtExprMutator {
 
       // abort if we have not seen this queue ID in `copy` transform
       if (queue_ids.find(queue_id) == queue_ids.end()) {
+        LOG(INFO) << "AsyncDMALowerer exiting because the queue ID observed in the "
+                     "`async_wait_queue_scope` transform has not been previously observed in the "
+                     "`async_commit_queue_scope` transform";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       auto async_wait = op->body.as<AttrStmtNode>();
-      ICHECK(async_wait && async_wait->attr_key == tir::attr::async_wait_inflight_count);
+      if (!async_wait || async_wait->attr_key != tir::attr::async_wait_inflight_count) {
+        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
+                     "`async_wait_queue_scope` does not contain an `AttrStmtNode` with key "
+                     "`async_wait_inflight_count`";
+        return StmtExprMutator::VisitStmt_(op);
+      }
 
       auto call_dma_wait =
           Evaluate(Call(DataType::Int(32), builtin::dma_wait(), {queue_id, async_wait->value}));
@@ -92,37 +100,50 @@ class AsyncDMALowerer : public StmtExprMutator {
       // walk the graph to verify this is a mem copy ...
       // 1) async_commit_queue_scope contains async_scope
       auto async_scope = op->body.as<AttrStmtNode>();
-      ICHECK(async_scope && async_scope->attr_key == tir::attr::async_scope);
+      if (!async_scope || async_scope->attr_key != tir::attr::async_scope) {
+        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
+                     "`async_commit_queue_scope` does not contain an `AttrStmtNode` with key "
+                     "`async_scope`";
+        return StmtExprMutator::VisitStmt_(op);
+      }
 
       // 2) async_scope contains single for loop
       auto for_loop = async_scope->body.as<ForNode>();
       if (!for_loop) {
+        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
+                     "`async_scope` does not contain a single `ForNode`";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       // 3) for loop contains buffer store with single index
       auto bufferstorenode = for_loop->body.as<BufferStoreNode>();
       if (!bufferstorenode || bufferstorenode->indices.size() != 1) {
+        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `ForNode` does not contain a "
+                     "single `BufferStoreNode` with a single index variable";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       // 4) buffer store value is a buffer load with single index
       auto bufferloadnode = bufferstorenode->value.as<BufferLoadNode>();
       if (!bufferloadnode || bufferloadnode->indices.size() != 1) {
+        LOG(INFO) << "AsyncDMALowerer exiting because the value of the `BufferStoreNode` is not a "
+                     "single `BufferLoadNode` with a single index variable";
         return StmtExprMutator::VisitStmt_(op);
       }
 
-      // get store buffer and assert that it is contiguous
+      // get store buffer; assert it exists and is contiguous given it uses a single index
       auto bufferstore = bufferstorenode->buffer.as<BufferNode>();
       ICHECK(bufferstore && bufferstore->strides.empty());
 
-      // get load buffer and assert that it is contiguous
+      // get load buffer; assert it exists and is contiguous given it uses a single index
       auto bufferload = bufferloadnode->buffer.as<BufferNode>();
       ICHECK(bufferload && bufferload->strides.empty());
 
       // we will be replacing the entire for loop including its index
       // with a DMA copy instrinsic that spans the entire index space of the for loop
-      // so we will need to repace the for loop index with value zero in the buffer indices
+      // so we will need to replace the for loop index with value zero in the buffer indices
+      // thus we eliminate the index from the expression so the DMA copy receives the buffer range
+      // base address
       Map<Var, PrimExpr> loop_var_remap = {{for_loop->loop_var, IntImm(DataType::Int(32), 0)}};
 
       // map loop variable to zero for the store index & simplify

--- a/src/tir/transforms/lower_async_dma.cc
+++ b/src/tir/transforms/lower_async_dma.cc
@@ -53,17 +53,17 @@ class AsyncDMALowerer : public StmtExprMutator {
 
       // abort if we have not seen this queue ID in `copy` transform
       if (queue_ids.find(queue_id) == queue_ids.end()) {
-        LOG(INFO) << "AsyncDMALowerer exiting because the queue ID observed in the "
-                     "`async_wait_queue_scope` transform has not been previously observed in the "
-                     "`async_commit_queue_scope` transform";
+        DLOG(INFO) << "AsyncDMALowerer exiting because the queue ID observed in the "
+                      "`async_wait_queue_scope` transform has not been previously observed in the "
+                      "`async_commit_queue_scope` transform";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       auto async_wait = op->body.as<AttrStmtNode>();
       if (!async_wait || async_wait->attr_key != tir::attr::async_wait_inflight_count) {
-        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
-                     "`async_wait_queue_scope` does not contain an `AttrStmtNode` with key "
-                     "`async_wait_inflight_count`";
+        DLOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
+                      "`async_wait_queue_scope` does not contain an `AttrStmtNode` with key "
+                      "`async_wait_inflight_count`";
         return StmtExprMutator::VisitStmt_(op);
       }
 
@@ -101,33 +101,34 @@ class AsyncDMALowerer : public StmtExprMutator {
       // 1) async_commit_queue_scope contains async_scope
       auto async_scope = op->body.as<AttrStmtNode>();
       if (!async_scope || async_scope->attr_key != tir::attr::async_scope) {
-        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
-                     "`async_commit_queue_scope` does not contain an `AttrStmtNode` with key "
-                     "`async_scope`";
+        DLOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
+                      "`async_commit_queue_scope` does not contain an `AttrStmtNode` with key "
+                      "`async_scope`";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       // 2) async_scope contains single for loop
       auto for_loop = async_scope->body.as<ForNode>();
       if (!for_loop) {
-        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
-                     "`async_scope` does not contain a single `ForNode`";
+        DLOG(INFO) << "AsyncDMALowerer exiting because the body of the `AttrStmtNode` with key "
+                      "`async_scope` does not contain a single `ForNode`";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       // 3) for loop contains buffer store with single index
       auto bufferstorenode = for_loop->body.as<BufferStoreNode>();
       if (!bufferstorenode || bufferstorenode->indices.size() != 1) {
-        LOG(INFO) << "AsyncDMALowerer exiting because the body of the `ForNode` does not contain a "
-                     "single `BufferStoreNode` with a single index variable";
+        DLOG(INFO)
+            << "AsyncDMALowerer exiting because the body of the `ForNode` does not contain a "
+               "single `BufferStoreNode` with a single index variable";
         return StmtExprMutator::VisitStmt_(op);
       }
 
       // 4) buffer store value is a buffer load with single index
       auto bufferloadnode = bufferstorenode->value.as<BufferLoadNode>();
       if (!bufferloadnode || bufferloadnode->indices.size() != 1) {
-        LOG(INFO) << "AsyncDMALowerer exiting because the value of the `BufferStoreNode` is not a "
-                     "single `BufferLoadNode` with a single index variable";
+        DLOG(INFO) << "AsyncDMALowerer exiting because the value of the `BufferStoreNode` is not a "
+                      "single `BufferLoadNode` with a single index variable";
         return StmtExprMutator::VisitStmt_(op);
       }
 

--- a/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
+++ b/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
@@ -64,7 +64,10 @@ def test_software_pipeline_with_cache_read(hexagon_launcher, compute, outer, inn
     ref = compute[1](a_np)
 
     target_hexagon = tvm.target.hexagon("v68", link_params=True)
-    func = tvm.build(sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon))
+    with tvm.transform.PassContext(config={"tir.use_async_copy": 1}):
+        func = tvm.build(
+            sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon)
+        )
 
     with hexagon_launcher.start_session() as hexagon_session:
         dev = hexagon_session.device

--- a/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
+++ b/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
@@ -50,6 +50,8 @@ def test_software_pipeline_with_cache_read(hexagon_launcher):
     sch.annotate(i, "software_pipeline_order", [0, 1])
     sch.annotate(i, "software_pipeline_async_stages", [0])
 
+    tvm.lower(sch.mod["main"]).show()
+
     target_hexagon = tvm.target.hexagon("v68", link_params=True)
     func = tvm.build(sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon))
 

--- a/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
+++ b/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+import pytest
+import numpy as np
+
+import tvm
+from tvm import tir
+from tvm.contrib.hexagon.session import Session
+from tvm.script import tir as T
+
+outer = 16
+inner = 128
+
+
+@T.prim_func
+def plus_one_primfunc(A: T.Buffer[(outer, inner), "uint8"], B: T.Buffer[(outer, inner), "uint8"]):
+    for i in T.serial(outer):
+        for j in T.serial(inner):
+            with T.block("plus_one"):
+                with T.block():
+                    B[i, j] = A[i, j] + T.uint8(1)
+
+
+@tvm.testing.requires_hexagon
+def test_software_pipeline_with_cache_read(hexagon_launcher):
+    sch = tir.Schedule(plus_one_primfunc)
+    root = sch.get_block("root")
+    plus_one = sch.get_block("plus_one")
+    cache_read_block = sch.cache_read(plus_one, 0, "global")
+
+    i, j = sch.get_loops(plus_one)
+    sch.compute_at(cache_read_block, i)
+    sch.annotate(i, "software_pipeline_stage", [0, 1])
+    sch.annotate(i, "software_pipeline_order", [0, 1])
+    sch.annotate(i, "software_pipeline_async_stages", [0])
+
+    target_hexagon = tvm.target.hexagon("v68", link_params=True)
+    func = tvm.build(sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon))
+
+    with hexagon_launcher.start_session() as hexagon_session:
+        mod = hexagon_session.load_module(func)
+        dev = hexagon_session.device
+
+        a_np = np.random.uniform(low=0, high=128, size=(outer, inner)).astype("uint8")
+        b_np = np.random.uniform(low=0, high=128, size=(outer, inner)).astype("uint8")
+        a = tvm.nd.array(a_np, dev)
+        b = tvm.nd.array(b_np, dev)
+        mod(a, b)
+        ref = a_np + 1
+        np.testing.assert_equal(b.numpy(), ref)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv))

--- a/tests/python/unittest/test_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/unittest/test_tir_transform_inject_ptx_async_copy.py
@@ -138,7 +138,7 @@ def test_inject_async_copy():
         if not tvm.testing.is_ampere_or_newer():
             continue
 
-        with tvm.transform.PassContext(config={"tir.use_ptx_async_copy": 1}):
+        with tvm.transform.PassContext(config={"tir.use_async_copy": 1}):
             mod = tvm.build(tvm.IRModule.from_expr(f), target="cuda")
 
         A_np = np.random.rand(32, 128).astype(dtype)
@@ -166,7 +166,7 @@ def test_inject_async_copy_shared_dyn():
     if not tvm.testing.is_ampere_or_newer():
         return
 
-    with tvm.transform.PassContext(config={"tir.use_ptx_async_copy": 1}):
+    with tvm.transform.PassContext(config={"tir.use_async_copy": 1}):
         mod = tvm.build(tvm.IRModule.from_expr(f), target="cuda")
 
     A_np = np.random.rand(32, 128).astype("float16")

--- a/tests/python/unittest/test_tir_transform_inject_software_pipeline.py
+++ b/tests/python/unittest/test_tir_transform_inject_software_pipeline.py
@@ -1390,7 +1390,7 @@ def get_mma_schedule():
 
 def build_and_run(sch):
     if tvm.testing.is_ampere_or_newer():
-        with tvm.transform.PassContext(config={"tir.use_ptx_async_copy": 1}):
+        with tvm.transform.PassContext(config={"tir.use_async_copy": 1}):
             f = tvm.build(sch.mod["main"], target="cuda")
 
         dev = tvm.device("cuda", 0)


### PR DESCRIPTION
Creates a 2-stage pipeline (DMA, compute) by lowering Async TIR primitives (see [RFC](https://github.com/apache/tvm-rfcs/blob/main/rfcs/0077-async-pipeline.md)) with memory copy semantics to builtin functions for DMA `Copy` and `Wait`.  These builtins can then be lowered through the device API, with example lowering on Hexagon to the `HexagonUserDMA` class. The example test case contained in this PR creates a 2 stage pipeline which lowers to the following TIR which is built and run on Hexagon.