### PR TITLE
[Hexagon] [runtime] Protect access to global HexagonBufferManager map

### DIFF
--- a/src/runtime/hexagon/hexagon_buffer_manager.h
+++ b/src/runtime/hexagon/hexagon_buffer_manager.h
@@ -43,7 +43,10 @@ class HexagonBufferManager {
     CHECK(it != hexagon_buffer_map_.end())
         << "Attempt made to free unknown or already freed dataspace allocation";
     CHECK(it->second != nullptr);
-    hexagon_buffer_map_.erase(it);
+    {
+      std::lock_guard<std::mutex> lock(map_mutex_);
+      hexagon_buffer_map_.erase(it);
+    }
   }
   /*!
    * \brief Allocate a HexagonBuffer.
@@ -53,15 +56,22 @@ class HexagonBufferManager {
   void* AllocateHexagonBuffer(Args&&... args) {
     auto buf = std::make_unique<HexagonBuffer>(std::forward<Args>(args)...);
     void* ptr = buf->GetPointer();
-    hexagon_buffer_map_.insert({ptr, std::move(buf)});
+    {
+      std::lock_guard<std::mutex> lock(map_mutex_);
+      hexagon_buffer_map_.insert({ptr, std::move(buf)});
+    }
     return ptr;
   }
 
   //! \brief Returns whether the HexagonBuffer is in the map.
-  size_t count(void* ptr) { return hexagon_buffer_map_.count(ptr); }
+  size_t count(void* ptr) {
+    std::lock_guard<std::mutex> lock(map_mutex_);
+    return hexagon_buffer_map_.count(ptr);
+  }
 
   //! \brief Returns an iterator to the HexagonBuffer within the map.
   HexagonBuffer* find(void* ptr) {
+    std::lock_guard<std::mutex> lock(map_mutex_);
     auto it = hexagon_buffer_map_.find(ptr);
     if (it != hexagon_buffer_map_.end()) {
       return it->second.get();
@@ -69,9 +79,18 @@ class HexagonBufferManager {
     return nullptr;
   }
 
+  //! \brief Returns whether the HexagonBufferManager has any allocations.
+  bool empty() {
+    std::lock_guard<std::mutex> lock(map_mutex_);
+    return hexagon_buffer_map_.empty(); 
+  }
+
  private:
   //! \brief Contains the HexagonBuffer objects managed by this class.
   std::unordered_map<void*, std::unique_ptr<HexagonBuffer>> hexagon_buffer_map_;
+
+  //! \brief Protects updates to the map.
+  std::mutex map_mutex_;
 };
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_buffer_manager.h
+++ b/src/runtime/hexagon/hexagon_buffer_manager.h
@@ -82,7 +82,7 @@ class HexagonBufferManager {
   //! \brief Returns whether the HexagonBufferManager has any allocations.
   bool empty() {
     std::lock_guard<std::mutex> lock(map_mutex_);
-    return hexagon_buffer_map_.empty(); 
+    return hexagon_buffer_map_.empty();
   }
 
  private:


### PR DESCRIPTION
Each thread has its own thread local storage for workspace and pool objects.  But those perform allocations from a global HexagonBufferManager.  We found a case where the map was not getting updated during AllocWorkspace, which then later caused FreeWorkspace to fail.

Added a mutex to protect all access to the map.

cc:  @nverke @JosephTheOctonaut @adstraw @supersat 


cc @areusch @mehrdadh