### PR TITLE
Fix for import requests and import caffe failures

### DIFF
--- a/ci/scripts/github_skipped_tests_comment.py
+++ b/ci/scripts/github_skipped_tests_comment.py
@@ -24,8 +24,6 @@ import sys
 from urllib import error
 from xml.etree import ElementTree
 
-import requests
-
 from git_utils import git, GitHubRepo, parse_remote
 from cmd_utils import init_log
 

--- a/docker/install/ubuntu_install_caffe.sh
+++ b/docker/install/ubuntu_install_caffe.sh
@@ -18,6 +18,11 @@
 
 set -euxo pipefail
 
+if [ -z "${TVM_VENV+x}" ]; then
+    echo "ERROR: expect TVM_VENV env var to be set"
+    exit 2
+fi
+
 apt-get update --fix-missing
 
 # # Install dependencies
@@ -60,4 +65,5 @@ cd / && rm -rf /caffe_src
 
 PYCAFFE_ROOT=${CAFFE_HOME}/python
 echo "${CAFFE_HOME}/lib" >> /etc/ld.so.conf.d/caffe.conf && ldconfig
-ln -s ${PYCAFFE_ROOT}/caffe /usr/local/lib/python3.7/dist-packages/caffe
+VENV_SITE_PACKAGE=$(pip3 show numpy | grep "Location:" | cut -d ' ' -f 2)
+ln -s ${PYCAFFE_ROOT}/caffe ${VENV_SITE_PACKAGE}/caffe


### PR DESCRIPTION
Fix for import caffe and import requests failures

Recently virtual environments were introduced in the
docker images which was a great contribution to
localize errors: https://github.com/apache/tvm/pull/12663. In this fix, link to the caffe is
created inside this virtual env instead of adding it
to the system path of python. This fix also removes
importing request package where not needed.

Fixes #12663

cc @leandron @areusch @driazati 