### PR TITLE
[BugFix][LLVM] Fix the bug that the generated systemlib cannot register ```__tvm_module_ctx``` symbol sometimes

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -178,9 +178,9 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target, b
         llvm::Function::Create(ftype_tvm_parallel_barrier_, llvm::Function::ExternalLinkage,
                                "TVMBackendParallelBarrier", module_.get());
   }
-  InitGlobalContext(dynamic_lookup);
   target_c_runtime_ = target_c_runtime;
   is_system_lib_ = system_lib;
+  InitGlobalContext(dynamic_lookup);
 }
 
 void CodeGenCPU::AddFunction(const PrimFunc& f) {


### PR DESCRIPTION
File ```src/target/llvm/codegen_cpu.cc```: The member variable ```target_c_runtime_``` is uninitialized when used in function ```CodeGenCPU::Init```. So when calling the function ```CodeGenCPU::InitGlobalContext```, the value of ```target_c_runtime_``` may be ```true``` or ```false```,  this will lead to the bug as the title described.