### PR TITLE
[microTVM] Use default Project Options in template projects and add Makefile for Arduino template project

### DIFF
--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -41,12 +41,12 @@ build: $(ELF)
 .PHONY: build
 
 $(ELF): $(SRC)
-	$(ARUINO_CLI_CMD) compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VFLAG)
+	$(ARUINO_CLI_CMD) compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VERBOSE_FLAG)
 
 flash:
 	if [ -z $(PORT) ] ; then \
 	echo "---> ERROR: Please set the device port environment variable PORT"; \
-	else $(ARUINO_CLI_CMD) upload --fqbn $(FQBN) --input-dir $(BUILD_DIR) --port $(PORT) $(VFLAG); \
+	else $(ARUINO_CLI_CMD) upload --fqbn $(FQBN) --input-dir $(BUILD_DIR) --port $(PORT) $(VERBOSE_FLAG); \
 	fi
 
 clean:

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -3,6 +3,7 @@ FQBN       		?= <FQBN>
 VERBOSE_FLAG	?= <VERBOSE_FLAG>
 BUILD_DIR  		:= $(subst :,.,build)
 PORT			?=
+ARUINO_CLI_CMD	?= <ARUINO_CLI_CMD>
 
 SRC        	:= $(wildcard *.ino)
 BIN        	:= $(BUILD_DIR)/$(SRC).bin
@@ -22,12 +23,12 @@ build: $(ELF)
 .PHONY: build
 
 $(ELF): $(SRC)
-	arduino-cli compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VFLAG)
+	$(ARUINO_CLI_CMD) compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VFLAG)
 
 flash:
 	if [ -z $(PORT) ] ; then \
 	echo "---> ERROR: Please set the device port environment variable PORT"; \
-	else arduino-cli upload --fqbn $(FQBN) --input-dir $(BUILD_DIR) --port $(PORT) $(VFLAG); \
+	else $(ARUINO_CLI_CMD) upload --fqbn $(FQBN) --input-dir $(BUILD_DIR) --port $(PORT) $(VFLAG); \
 	fi
 
 clean:

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -15,13 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-MAKE_DIR		:= $(PWD)
-FQBN			?= <FQBN>
-VERBOSE_FLAG	?= <VERBOSE_FLAG>
-BUILD_DIR		:= $(subst :,.,build)
-PORT			?=
-ARUINO_CLI_CMD	?= <ARUINO_CLI_CMD>
-BOARD			:= <BOARD>
+MAKE_DIR		    := $(PWD)
+FQBN			    ?= <FQBN>
+VERBOSE_FLAG	    ?= <VERBOSE_FLAG>
+BUILD_DIR		    := $(subst :,.,build)
+PORT			    ?=
+ARUINO_CLI_CMD	    ?= <ARUINO_CLI_CMD>
+BOARD			    := <BOARD>
+BUILD_EXTRA_FLAGS   := <BUILD_EXTRA_FLAGS>
 
 SRC        	:= $(wildcard *.ino)
 BIN        	:= $(BUILD_DIR)/$(SRC).bin
@@ -41,7 +42,10 @@ build: $(ELF)
 .PHONY: build
 
 $(ELF): $(SRC)
-	$(ARUINO_CLI_CMD) compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VERBOSE_FLAG)
+	$(ARUINO_CLI_CMD) compile --fqbn $(FQBN) \
+    --build-path $(BUILD_DIR) \
+    --build-properties build.extra_flags="$(BUILD_EXTRA_FLAGS)" \
+    $(VERBOSE_FLAG)
 
 flash:
 	if [ -z $(PORT) ] ; then \

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -1,20 +1,21 @@
 MAKE_DIR   		:= $(PWD)
 FQBN       		?= <FQBN>
-VERBOSE_FLAG	?= <VERBOSE_FLAG> 
+VERBOSE_FLAG	?= <VERBOSE_FLAG>
 BUILD_DIR  		:= $(subst :,.,build)
+PORT			?=
 
 SRC        	:= $(wildcard *.ino)
 BIN        	:= $(BUILD_DIR)/$(SRC).bin
 ELF        	:= $(BUILD_DIR)/$(SRC).elf
 
-$(info FQBN       is [${FQBN}])
-$(info MAKE_DIR   is [${MAKE_DIR}])
-$(info BUILD_DIR  is [${BUILD_DIR}])
-$(info SRC        is [${SRC}])
-$(info BIN        is [${BIN}])
-$(info DEV_PORT is [${DEV_PORT}])
+$(info FQBN       	is [${FQBN}])
+$(info MAKE_DIR   	is [${MAKE_DIR}])
+$(info BUILD_DIR  	is [${BUILD_DIR}])
+$(info SRC        	is [${SRC}])
+$(info BIN        	is [${BIN}])
+$(info PORT 	is [${PORT}])
 
-all: $(ELF) upload
+all: $(ELF) flash
 .PHONY: all
 
 build: $(ELF)
@@ -23,11 +24,10 @@ build: $(ELF)
 $(ELF): $(SRC)
 	arduino-cli compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VFLAG)
 
-upload:
-	@if [ ! -c $(DEV_PORT) ] ; \
-	then echo "---> ERROR: Serial Device not available, please set the SERIAL_DEV environment variable" ; \
-	else echo "---> Uploading sketch\n"; \
-	arduino-cli upload -b $(FQBN) -p $(DEV_PORT) $(VFLAG); \
+flash:
+	if [ -z $(PORT) ] ; then \
+	echo "---> ERROR: Please set the device port environment variable PORT"; \
+	else arduino-cli upload --fqbn $(FQBN) --input-dir $(BUILD_DIR) --port $(PORT) $(VFLAG); \
 	fi
 
 clean:

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 MAKE_DIR   		:= $(PWD)
 FQBN       		?= <FQBN>
 VERBOSE_FLAG	?= <VERBOSE_FLAG>

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-MAKE_DIR   		:= $(PWD)
-FQBN       		?= <FQBN>
+MAKE_DIR		:= $(PWD)
+FQBN			?= <FQBN>
 VERBOSE_FLAG	?= <VERBOSE_FLAG>
-BUILD_DIR  		:= $(subst :,.,build)
+BUILD_DIR		:= $(subst :,.,build)
 PORT			?=
 ARUINO_CLI_CMD	?= <ARUINO_CLI_CMD>
 
@@ -26,12 +26,12 @@ SRC        	:= $(wildcard *.ino)
 BIN        	:= $(BUILD_DIR)/$(SRC).bin
 ELF        	:= $(BUILD_DIR)/$(SRC).elf
 
-$(info FQBN       	is [${FQBN}])
-$(info MAKE_DIR   	is [${MAKE_DIR}])
-$(info BUILD_DIR  	is [${BUILD_DIR}])
-$(info SRC        	is [${SRC}])
-$(info BIN        	is [${BIN}])
-$(info PORT 	is [${PORT}])
+$(info FQBN			is [${FQBN}])
+$(info MAKE_DIR		is [${MAKE_DIR}])
+$(info BUILD_DIR	is [${BUILD_DIR}])
+$(info SRC			is [${SRC}])
+$(info BIN			is [${BIN}])
+$(info PORT			is [${PORT}])
 
 all: $(ELF) flash
 .PHONY: all

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -1,0 +1,34 @@
+MAKE_DIR   		:= $(PWD)
+FQBN       		?= <FQBN>
+VERBOSE_FLAG	?= <VERBOSE_FLAG> 
+BUILD_DIR  		:= $(subst :,.,build)
+
+SRC        	:= $(wildcard *.ino)
+BIN        	:= $(BUILD_DIR)/$(SRC).bin
+ELF        	:= $(BUILD_DIR)/$(SRC).elf
+
+$(info FQBN       is [${FQBN}])
+$(info MAKE_DIR   is [${MAKE_DIR}])
+$(info BUILD_DIR  is [${BUILD_DIR}])
+$(info SRC        is [${SRC}])
+$(info BIN        is [${BIN}])
+$(info DEV_PORT is [${DEV_PORT}])
+
+all: $(ELF) upload
+.PHONY: all
+
+build: $(ELF)
+.PHONY: build
+
+$(ELF): $(SRC)
+	arduino-cli compile --fqbn $(FQBN) --build-path $(BUILD_DIR) $(VFLAG)
+
+upload:
+	@if [ ! -c $(DEV_PORT) ] ; \
+	then echo "---> ERROR: Serial Device not available, please set the SERIAL_DEV environment variable" ; \
+	else echo "---> Uploading sketch\n"; \
+	arduino-cli upload -b $(FQBN) -p $(DEV_PORT) $(VFLAG); \
+	fi
+
+clean:
+	rm -rf build

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -21,6 +21,7 @@ VERBOSE_FLAG	?= <VERBOSE_FLAG>
 BUILD_DIR		:= $(subst :,.,build)
 PORT			?=
 ARUINO_CLI_CMD	?= <ARUINO_CLI_CMD>
+BOARD			:= <BOARD>
 
 SRC        	:= $(wildcard *.ino)
 BIN        	:= $(BUILD_DIR)/$(SRC).bin

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-MAKE_DIR		    := $(PWD)
 FQBN			    ?= <FQBN>
 VERBOSE_FLAG	    ?= <VERBOSE_FLAG>
 BUILD_DIR		    := $(subst :,.,build)
@@ -28,12 +27,13 @@ SRC        	:= $(wildcard *.ino)
 BIN        	:= $(BUILD_DIR)/$(SRC).bin
 ELF        	:= $(BUILD_DIR)/$(SRC).elf
 
-$(info FQBN			is [${FQBN}])
-$(info MAKE_DIR		is [${MAKE_DIR}])
-$(info BUILD_DIR	is [${BUILD_DIR}])
-$(info SRC			is [${SRC}])
-$(info BIN			is [${BIN}])
-$(info PORT			is [${PORT}])
+$(info FQBN                 `fully qualified board name` => [${FQBN}])
+$(info BUILD_DIR            `build directory for this project` => [${BUILD_DIR}])
+$(info SRC                  `Arduino .ino file for this project` => [${SRC}])
+$(info BIN                  `generated binary file path` => [${BIN}])
+$(info PORT                 `board's port` => [${PORT}])
+$(info BOARD                `board name` => [${BOARD}])
+$(info BUILD_EXTRA_FLAGS    `build extra flags including header include directories and other compiler flags` => [${BUILD_EXTRA_FLAGS}])
 
 all: $(ELF) flash
 .PHONY: all
@@ -52,6 +52,13 @@ flash:
 	echo "---> ERROR: Please set the device port environment variable PORT"; \
 	else $(ARUINO_CLI_CMD) upload --fqbn $(FQBN) --input-dir $(BUILD_DIR) --port $(PORT) $(VERBOSE_FLAG); \
 	fi
+
+info:
+	$(info --------------------------------------INFO--------------------------------------)
+	$(info This makefile is for building and flashing an Arduino project with TVM.)
+	$(info To build run: `make build`)
+	$(info To upload the sketch run: `make flash PORT=<Arduino board port path>`)
+	$(info --------------------------------------INFO--------------------------------------)
 
 clean:
 	rm -rf build

--- a/apps/microtvm/arduino/template_project/Makefile.template
+++ b/apps/microtvm/arduino/template_project/Makefile.template
@@ -44,7 +44,7 @@ build: $(ELF)
 $(ELF): $(SRC)
 	$(ARUINO_CLI_CMD) compile --fqbn $(FQBN) \
     --build-path $(BUILD_DIR) \
-    --build-properties build.extra_flags="$(BUILD_EXTRA_FLAGS)" \
+    --build-properties $(BUILD_EXTRA_FLAGS) \
     $(VERBOSE_FLAG)
 
 flash:

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -62,13 +62,13 @@ class BoardAutodetectFailed(Exception):
 PROJECT_TYPES = ["example_project", "host_driven"]
 
 PROJECT_OPTIONS = [
-    server.ProjectOption(
-        "arduino_board",
-        required=["build", "flash", "open_transport"],
-        choices=list(BOARD_PROPERTIES),
-        type="str",
-        help="Name of the Arduino board to build for.",
-    ),
+    # server.ProjectOption(
+    #     "arduino_board",
+    #     required=["build", "flash", "open_transport"],
+    #     choices=list(BOARD_PROPERTIES),
+    #     type="str",
+    #     help="Name of the Arduino board to build for.",
+    # ),
     server.ProjectOption(
         "arduino_cli_cmd",
         required=(
@@ -89,19 +89,19 @@ PROJECT_OPTIONS = [
         type="int",
         help="Port to use for connecting to hardware.",
     ),
-    server.ProjectOption(
-        "project_type",
-        required=["generate_project"],
-        choices=tuple(PROJECT_TYPES),
-        type="str",
-        help="Type of project to generate.",
-    ),
-    server.ProjectOption(
-        "verbose",
-        optional=["build", "flash"],
-        type="bool",
-        help="Run arduino-cli compile and upload with verbose output.",
-    ),
+    # server.ProjectOption(
+    #     "project_type",
+    #     required=["generate_project"],
+    #     choices=tuple(PROJECT_TYPES),
+    #     type="str",
+    #     help="Type of project to generate.",
+    # ),
+    # server.ProjectOption(
+    #     "verbose",
+    #     optional=["build", "flash"],
+    #     type="bool",
+    #     help="Run arduino-cli compile and upload with verbose output.",
+    # ),
     server.ProjectOption(
         "warning_as_error",
         optional=["build", "flash"],

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -462,7 +462,7 @@ class Handler(server.ProjectAPIHandler):
         self._check_platform_version(options)
         port = self._get_arduino_port(options)
 
-        upload_cmd = ["make", "flash" f"PORT={port}"]
+        upload_cmd = ["make", "flash", f"PORT={port}"]
 
         for _ in range(self.FLASH_MAX_RETRIES):
             try:

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -82,14 +82,15 @@ PROJECT_OPTIONS = server.default_project_options(
         optional=(
             ["generate_project", "build", "flash", "open_transport"] if ARDUINO_CLI_CMD else None
         ),
-        default=ARDUINO_CLI_CMD,
         type="str",
+        default=ARDUINO_CLI_CMD,
         help="Path to the arduino-cli tool.",
     ),
     server.ProjectOption(
         "port",
         optional=["flash", "open_transport"],
         type="int",
+        default=None,
         help="Port to use for connecting to hardware.",
     ),
 ]

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -61,14 +61,11 @@ class BoardAutodetectFailed(Exception):
 
 PROJECT_TYPES = ["example_project", "host_driven"]
 
-PROJECT_OPTIONS = [
-    # server.ProjectOption(
-    #     "arduino_board",
-    #     required=["build", "flash", "open_transport"],
-    #     choices=list(BOARD_PROPERTIES),
-    #     type="str",
-    #     help="Name of the Arduino board to build for.",
-    # ),
+PROJECT_OPTIONS = server.default_project_options(
+    project_type={"choices": tuple(PROJECT_TYPES)},
+    board={"choices": list(BOARD_PROPERTIES), "required": ["build", "flash", "open_transport"]},
+    verbose={"optional": ["build", "flash"]},
+) + [
     server.ProjectOption(
         "arduino_cli_cmd",
         required=(
@@ -89,19 +86,6 @@ PROJECT_OPTIONS = [
         type="int",
         help="Port to use for connecting to hardware.",
     ),
-    # server.ProjectOption(
-    #     "project_type",
-    #     required=["generate_project"],
-    #     choices=tuple(PROJECT_TYPES),
-    #     type="str",
-    #     help="Type of project to generate.",
-    # ),
-    # server.ProjectOption(
-    #     "verbose",
-    #     optional=["build", "flash"],
-    #     type="bool",
-    #     help="Run arduino-cli compile and upload with verbose output.",
-    # ),
     server.ProjectOption(
         "warning_as_error",
         optional=["build", "flash"],
@@ -383,7 +367,7 @@ class Handler(server.ProjectAPIHandler):
             _LOG.warning(message)
 
     def _get_fqbn(self, options):
-        o = BOARD_PROPERTIES[options["arduino_board"]]
+        o = BOARD_PROPERTIES[options["board"]]
         return f"{o['package']}:{o['architecture']}:{o['board']}"
 
     def build(self, options):

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -404,7 +404,7 @@ class Handler(server.ProjectAPIHandler):
         self._check_platform_version(arduino_cli_cmd, warning_as_error)
         compile_cmd = ["make", "build"]
         # Specify project to compile
-        subprocess.run(compile_cmd, check=True)
+        subprocess.run(compile_cmd, check=True, cwd=API_SERVER_DIR)
 
     POSSIBLE_BOARD_LIST_HEADERS = ("Port", "Protocol", "Type", "Board Name", "FQBN", "Core")
 
@@ -440,7 +440,7 @@ class Handler(server.ProjectAPIHandler):
                 device[col_name] = str_row[column.start() : column.end()].strip()
             yield device
 
-    def _auto_detect_port(self, arduino_cli_cmd: str, board: str):
+    def _auto_detect_port(self, arduino_cli_cmd: str, board: str) -> str:
         list_cmd = [self._get_arduino_cli_cmd(arduino_cli_cmd), "board", "list"]
         list_cmd_output = subprocess.run(
             list_cmd, check=True, stdout=subprocess.PIPE
@@ -488,10 +488,11 @@ class Handler(server.ProjectAPIHandler):
         port = self._get_arduino_port(arduino_cli_cmd, board, port)
 
         upload_cmd = ["make", "flash", f"PORT={port}"]
-
         for _ in range(self.FLASH_MAX_RETRIES):
             try:
-                subprocess.run(upload_cmd, check=True, timeout=self.FLASH_TIMEOUT_SEC)
+                subprocess.run(
+                    upload_cmd, check=True, timeout=self.FLASH_TIMEOUT_SEC, cwd=API_SERVER_DIR
+                )
                 break
 
             # We only catch timeout errors - a subprocess.CalledProcessError

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -163,7 +163,7 @@ class Handler(server.ProjectAPIHandler):
     ]
 
     FQBN_TOKEN = "<FQBN>"
-    VERBOSE_FLAG_TOKEN = "<VFLAG>"
+    VERBOSE_FLAG_TOKEN = "<VERBOSE_FLAG>"
 
     def _remove_unused_components(self, source_dir, project_type):
         unused_components = []
@@ -393,10 +393,7 @@ class Handler(server.ProjectAPIHandler):
 
     def build(self, options):
         self._check_platform_version(options)
-        compile_cmd = [
-            "make",
-            "build"
-        ]
+        compile_cmd = ["make", "build"]
         # Specify project to compile
         subprocess.run(compile_cmd, check=True)
 
@@ -464,23 +461,8 @@ class Handler(server.ProjectAPIHandler):
         self._check_platform_version(options)
         port = self._get_arduino_port(options)
 
-        # TODO: add support for flash
-        upload_cmd = [
-            self._get_arduino_cli_cmd(options),
-            "upload",
-            "./project",
-            "--fqbn",
-            self._get_fqbn(options),
-            "--input-dir",
-            BUILD_DIR.resolve(),
-            "--port",
-            port,
-        ]
+        upload_cmd = ["make", "flash" f"PORT={port}"]
 
-        if options.get("verbose"):
-            upload_cmd.append("--verbose")
-
-        import pdb; pdb.set_trace()
         for _ in range(self.FLASH_MAX_RETRIES):
             try:
                 subprocess.run(upload_cmd, check=True, timeout=self.FLASH_TIMEOUT_SEC)

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -65,6 +65,7 @@ PROJECT_OPTIONS = server.default_project_options(
     project_type={"choices": tuple(PROJECT_TYPES)},
     board={"choices": list(BOARD_PROPERTIES), "required": ["build", "flash", "open_transport"]},
     verbose={"optional": ["build", "flash"]},
+    warning_as_error={"optional": ["build", "flash"]},
 ) + [
     server.ProjectOption(
         "arduino_cli_cmd",

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -70,11 +70,7 @@ PROJECT_OPTIONS = server.default_project_options(
 ) + [
     server.ProjectOption(
         "arduino_cli_cmd",
-        required=(
-            ["generate_project", "build", "flash", "open_transport"]
-            if not ARDUINO_CLI_CMD
-            else None
-        ),
+        required=(["generate_project", "flash", "open_transport"] if not ARDUINO_CLI_CMD else None),
         optional=(
             ["generate_project", "build", "flash", "open_transport"] if ARDUINO_CLI_CMD else None
         ),
@@ -164,6 +160,7 @@ class Handler(server.ProjectAPIHandler):
 
     FQBN_TOKEN = "<FQBN>"
     VERBOSE_FLAG_TOKEN = "<VERBOSE_FLAG>"
+    ARUINO_CLI_CMD_TOKEN = "<ARUINO_CLI_CMD>"
 
     def _remove_unused_components(self, source_dir, project_type):
         unused_components = []
@@ -352,6 +349,10 @@ class Handler(server.ProjectAPIHandler):
                             flag = ""
                         line = line.replace(self.VERBOSE_FLAG_TOKEN, flag)
 
+                    if self.ARUINO_CLI_CMD_TOKEN in line:
+                        line = line.replace(
+                            self.ARUINO_CLI_CMD_TOKEN, self._get_arduino_cli_cmd(options)
+                        )
                     makefile_f.write(line)
 
     def _get_arduino_cli_cmd(self, options: dict):

--- a/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
@@ -32,7 +32,7 @@ sys.path.pop(0)
 
 
 class TestGenerateProject:
-    DEFAULT_OPTIONS = {"arduino_cli_cmd": "arduino-cli", "arduino_board": "nano33ble"}
+    DEFAULT_OPTIONS = {"arduino_cli_cmd": "arduino-cli", "board": "nano33ble"}
 
     def _set_pathlib_path_exists(self, value):
         with mock.patch.object(Path, "exists") as mock_exists:
@@ -122,7 +122,7 @@ class TestGenerateProject:
         handler._get_fqbn = mock.MagicMock(return_value="arduino:mbed_nano:nano33")
         mock_run.return_value.stdout = bytes(self.BOARD_CONNECTED_V18, "utf-8")
         assert (
-            handler._auto_detect_port({**self.DEFAULT_OPTIONS, "arduino_board": "nano33"})
+            handler._auto_detect_port({**self.DEFAULT_OPTIONS, "board": "nano33"})
             == "/dev/ttyACM1"
         )
 

--- a/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
@@ -122,8 +122,7 @@ class TestGenerateProject:
         handler._get_fqbn = mock.MagicMock(return_value="arduino:mbed_nano:nano33")
         mock_run.return_value.stdout = bytes(self.BOARD_CONNECTED_V18, "utf-8")
         assert (
-            handler._auto_detect_port({**self.DEFAULT_OPTIONS, "board": "nano33"})
-            == "/dev/ttyACM1"
+            handler._auto_detect_port({**self.DEFAULT_OPTIONS, "board": "nano33"}) == "/dev/ttyACM1"
         )
 
     BAD_CLI_VERSION = "arduino-cli  Version: 0.7.1 Commit: 7668c465 Date: 2019-12-31T18:24:32Z\n"

--- a/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
@@ -135,15 +135,14 @@ class TestGenerateProject:
         arduino_cli_cmd = self.DEFAULT_OPTIONS.get("arduino_cli_cmd")
         warning_as_error = self.DEFAULT_OPTIONS.get("warning_as_error")
 
-        handler._check_platform_version(
-            arduino_cli_cmd=arduino_cli_cmd, warning_as_error=warning_as_error
-        )
+        cli_command = handler._get_arduino_cli_cmd(arduino_cli_cmd)
+        handler._check_platform_version(cli_command=cli_command, warning_as_error=warning_as_error)
         assert handler._version == version.parse("0.21.1")
 
         handler = microtvm_api_server.Handler()
         mock_run.return_value.stdout = bytes(self.BAD_CLI_VERSION, "utf-8")
         with pytest.raises(server.ServerError) as error:
-            handler._check_platform_version(arduino_cli_cmd=arduino_cli_cmd, warning_as_error=True)
+            handler._check_platform_version(cli_command=cli_command, warning_as_error=True)
         mock_run.reset_mock()
 
     @mock.patch("subprocess.run")

--- a/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/tests/test_arduino_microtvm_api_server.py
@@ -132,13 +132,18 @@ class TestGenerateProject:
     def test_auto_detect_port(self, mock_run):
         handler = microtvm_api_server.Handler()
         mock_run.return_value.stdout = bytes(self.GOOD_CLI_VERSION, "utf-8")
-        handler._check_platform_version(self.DEFAULT_OPTIONS)
+        arduino_cli_cmd = self.DEFAULT_OPTIONS.get("arduino_cli_cmd")
+        warning_as_error = self.DEFAULT_OPTIONS.get("warning_as_error")
+
+        handler._check_platform_version(
+            arduino_cli_cmd=arduino_cli_cmd, warning_as_error=warning_as_error
+        )
         assert handler._version == version.parse("0.21.1")
 
         handler = microtvm_api_server.Handler()
         mock_run.return_value.stdout = bytes(self.BAD_CLI_VERSION, "utf-8")
         with pytest.raises(server.ServerError) as error:
-            handler._check_platform_version({"warning_as_error": True})
+            handler._check_platform_version(arduino_cli_cmd=arduino_cli_cmd, warning_as_error=True)
         mock_run.reset_mock()
 
     @mock.patch("subprocess.run")
@@ -146,7 +151,7 @@ class TestGenerateProject:
         mock_run.return_value.stdout = bytes(self.GOOD_CLI_VERSION, "utf-8")
 
         def side_effect(cmd, *args, **kwargs):
-            if cmd[1] == "upload":
+            if cmd[1] == "flash":
                 raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
             return mock.DEFAULT
 
@@ -177,7 +182,7 @@ class TestGenerateProject:
         # Test we checked version then called upload
         assert mock_run.call_count == 2
         assert mock_run.call_args_list[0][0] == (["arduino-cli", "version"],)
-        assert mock_run.call_args_list[1][0][0][0:2] == ["arduino-cli", "upload"]
+        assert mock_run.call_args_list[1][0][0][0:2] == ["make", "flash"]
         mock_run.reset_mock()
 
         # Test exception raised when `arduino-cli upload` returns error code
@@ -187,4 +192,4 @@ class TestGenerateProject:
 
         # Version information should be cached and not checked again
         mock_run.assert_called_once()
-        assert mock_run.call_args[0][0][0:2] == ["arduino-cli", "upload"]
+        assert mock_run.call_args[0][0][0:2] == ["make", "flash"]

--- a/apps/microtvm/reference-vm/base-box/base_box_test.sh
+++ b/apps/microtvm/reference-vm/base-box/base_box_test.sh
@@ -28,15 +28,15 @@ platform=$1
 board=$2
 
 if [ "${platform}" == "zephyr" ]; then
-    pytest tests/micro/zephyr --zephyr-board=${board}
+    pytest tests/micro/zephyr --board=${board}
 fi
 
 if [ "${platform}" == "arduino" ]; then
-    pytest tests/micro/arduino/test_arduino_workflow.py --arduino-board=${board}
+    pytest tests/micro/arduino/test_arduino_workflow.py --board=${board}
     if [ $board == "nano33ble" ]; then
         # https://github.com/apache/tvm/issues/8730
         echo "NOTE: skipped test_arduino_rpc_server.py on $board -- known failure"
     else
-        pytest tests/micro/arduino/test_arduino_rpc_server.py --arduino-board=${board}
+        pytest tests/micro/arduino/test_arduino_rpc_server.py --board=${board}
     fi
 fi

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -304,27 +304,30 @@ PROJECT_OPTIONS = server.default_project_options(
 ) + [
     server.ProjectOption(
         "gdbserver_port",
-        help=("If given, port number to use when running the local gdbserver."),
         optional=["open_transport"],
         type="int",
+        default=None,
+        help=("If given, port number to use when running the local gdbserver."),
     ),
     server.ProjectOption(
         "nrfjprog_snr",
         optional=["open_transport"],
         type="int",
+        default=None,
         help=("When used with nRF targets, serial # of the attached board to use, from nrfjprog."),
     ),
     server.ProjectOption(
         "openocd_serial",
         optional=["open_transport"],
         type="int",
+        default=None,
         help=("When used with OpenOCD targets, serial # of the attached board to use."),
     ),
     server.ProjectOption(
         "west_cmd",
         optional=["generate_project"],
-        default=WEST_CMD,
         type="str",
+        default=WEST_CMD,
         help=(
             "Path to the west tool. If given, supersedes both the zephyr_base "
             "option and ZEPHYR_BASE environment variable."
@@ -334,32 +337,36 @@ PROJECT_OPTIONS = server.default_project_options(
         "zephyr_base",
         required=(["generate_project", "open_transport"] if not ZEPHYR_BASE else None),
         optional=(["generate_project", "open_transport"] if ZEPHYR_BASE else ["build"]),
-        default=ZEPHYR_BASE,
         type="str",
+        default=ZEPHYR_BASE,
         help="Path to the zephyr base directory.",
     ),
     server.ProjectOption(
         "config_main_stack_size",
         optional=["generate_project"],
         type="int",
+        default=None,
         help="Sets CONFIG_MAIN_STACK_SIZE for Zephyr board.",
     ),
     server.ProjectOption(
         "arm_fvp_path",
         optional=["generate_project", "open_transport"],
         type="str",
+        default=None,
         help="Path to the FVP binary to invoke.",
     ),
     server.ProjectOption(
         "use_fvp",
         optional=["generate_project"],
         type="bool",
+        default=False,
         help="Run on the FVP emulator instead of hardware.",
     ),
     server.ProjectOption(
         "heap_size_bytes",
         optional=["generate_project"],
         type="int",
+        default=None,
         help="Sets the value for HEAP_SIZE_BYTES passed to K_HEAP_DEFINE() to service TVM memory allocation requests.",
     ),
 ]

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -303,12 +303,6 @@ PROJECT_OPTIONS = server.default_project_options(
     verbose={"optional": ["generate_project"]},
 ) + [
     server.ProjectOption(
-        "extra_files_tar",
-        optional=["generate_project"],
-        type="str",
-        help="If given, during generate_project, uncompress the tarball at this path into the project dir.",
-    ),
-    server.ProjectOption(
         "gdbserver_port",
         help=("If given, port number to use when running the local gdbserver."),
         optional=["open_transport"],
@@ -349,12 +343,6 @@ PROJECT_OPTIONS = server.default_project_options(
         optional=["generate_project"],
         type="int",
         help="Sets CONFIG_MAIN_STACK_SIZE for Zephyr board.",
-    ),
-    server.ProjectOption(
-        "compile_definitions",
-        optional=["generate_project"],
-        type="str",
-        help="Extra definitions added project compile.",
     ),
     server.ProjectOption(
         "arm_fvp_path",

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -297,8 +297,11 @@ if IS_TEMPLATE:
         if d.is_dir():
             PROJECT_TYPES.append(d.name)
 
-
-PROJECT_OPTIONS = server.default_project_options() + [
+PROJECT_OPTIONS = server.default_project_options(
+    project_type={"choices": tuple(PROJECT_TYPES)},
+    board={"choices": list(BOARD_PROPERTIES)},
+    verbose={"optional": ["generate_project"]},
+) + [
     server.ProjectOption(
         "extra_files_tar",
         optional=["generate_project"],
@@ -323,19 +326,6 @@ PROJECT_OPTIONS = server.default_project_options() + [
         type="int",
         help=("When used with OpenOCD targets, serial # of the attached board to use."),
     ),
-    # server.ProjectOption(
-    #     "project_type",
-    #     choices=tuple(PROJECT_TYPES),
-    #     required=["generate_project"],
-    #     type="str",
-    #     help="Type of project to generate.",
-    # ),
-    # server.ProjectOption(
-    #     "verbose",
-    #     optional=["generate_project"],
-    #     type="bool",
-    #     help="Run build with verbose output.",
-    # ),
     server.ProjectOption(
         "west_cmd",
         optional=["generate_project"],
@@ -354,13 +344,6 @@ PROJECT_OPTIONS = server.default_project_options() + [
         type="str",
         help="Path to the zephyr base directory.",
     ),
-    # server.ProjectOption(
-    #     "board",
-    #     required=["generate_project"],
-    #     choices=list(BOARD_PROPERTIES),
-    #     type="str",
-    #     help="Name of the Zephyr board to build for.",
-    # ),
     server.ProjectOption(
         "config_main_stack_size",
         optional=["generate_project"],
@@ -379,12 +362,6 @@ PROJECT_OPTIONS = server.default_project_options() + [
         type="str",
         help="Extra definitions added project compile.",
     ),
-    # server.ProjectOption(
-    #     "cmsis_path",
-    #     optional=["generate_project"],
-    #     type="str",
-    #     help="Path to the CMSIS directory.",
-    # ),
     server.ProjectOption(
         "arm_fvp_path",
         optional=["generate_project", "open_transport"],
@@ -397,12 +374,12 @@ PROJECT_OPTIONS = server.default_project_options() + [
         type="bool",
         help="Run on the FVP emulator instead of hardware.",
     ),
-    # server.ProjectOption(
-    #     "heap_size_bytes",
-    #     optional=["generate_project"],
-    #     type="int",
-    #     help="Sets the value for HEAP_SIZE_BYTES passed to K_HEAP_DEFINE() to service TVM memory allocation requests.",
-    # ),
+    server.ProjectOption(
+        "heap_size_bytes",
+        optional=["generate_project"],
+        type="int",
+        help="Sets the value for HEAP_SIZE_BYTES passed to K_HEAP_DEFINE() to service TVM memory allocation requests.",
+    ),
 ]
 
 

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -351,12 +351,6 @@ PROJECT_OPTIONS = server.default_project_options(
         help="Sets CONFIG_MAIN_STACK_SIZE for Zephyr board.",
     ),
     server.ProjectOption(
-        "warning_as_error",
-        optional=["generate_project"],
-        type="bool",
-        help="Treat warnings as errors and raise an Exception.",
-    ),
-    server.ProjectOption(
         "compile_definitions",
         optional=["generate_project"],
         type="str",

--- a/cmake/modules/Arduino.cmake
+++ b/cmake/modules/Arduino.cmake
@@ -28,6 +28,7 @@ if(USE_MICRO)
       "apps/microtvm/arduino/template_project/src/host_driven *.c -> arduino/src/host_driven"
       "apps/microtvm/arduino/template_project/src/host_driven *.ino -> arduino/src/host_driven"
       "apps/microtvm/arduino/template_project/crt_config *.h -> arduino/crt_config"
+      "apps/microtvm/arduino/template_project Makefile.template -> arduino"
     )
 
     foreach(job_spec IN LISTS ARDUINO_FILE_COPY_JOBS)

--- a/gallery/how_to/work_with_microtvm/micro_aot.py
+++ b/gallery/how_to/work_with_microtvm/micro_aot.py
@@ -133,7 +133,7 @@ project_options = {}  # You can use options to provide platform-specific options
 
 if use_physical_hw:
     template_project_path = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr"))
-    project_options = {"project_type": "host_driven", "zephyr_board": BOARD}
+    project_options = {"project_type": "host_driven", "board": BOARD}
 
 temp_dir = tvm.contrib.utils.tempdir()
 generated_project_dir = temp_dir / "project"

--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -152,7 +152,7 @@ if use_physical_hw:
     module_loader = tvm.micro.AutoTvmModuleLoader(
         template_project_dir=pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")),
         project_options={
-            "zephyr_board": BOARD,
+            "board": BOARD,
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
@@ -219,7 +219,7 @@ if use_physical_hw:
         lowered,
         temp_dir / "project",
         {
-            "zephyr_board": BOARD,
+            "board": BOARD,
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
@@ -262,7 +262,7 @@ if use_physical_hw:
         lowered_tuned,
         temp_dir / "project",
         {
-            "zephyr_board": BOARD,
+            "board": BOARD,
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",

--- a/gallery/how_to/work_with_microtvm/micro_reference_vm.py
+++ b/gallery/how_to/work_with_microtvm/micro_reference_vm.py
@@ -143,7 +143,7 @@ Once the VM has been provisioned, tests can be executed using ``poetry``:
 .. code-block:: bash
 
     $ cd apps/microtvm/reference-vm/zephyr
-    $ poetry run python3 ../../../../tests/micro/zephyr/test_zephyr.py --zephyr-board=stm32f746g_disco
+    $ poetry run python3 ../../../../tests/micro/zephyr/test_zephyr.py --board=stm32f746g_disco
 
 If you do not have physical hardware attached, but wish to run the tests using the
 local QEMU emulator running within the VM, run the following commands instead:
@@ -152,7 +152,7 @@ local QEMU emulator running within the VM, run the following commands instead:
 
     $ cd /Users/yourusername/path/to/tvm
     $ cd apps/microtvm/reference-vm/zephyr/
-    $ poetry run pytest ../../../../tests/micro/zephyr/test_zephyr.py --zephyr-board=qemu_x86
+    $ poetry run pytest ../../../../tests/micro/zephyr/test_zephyr.py --board=qemu_x86
 
 
 

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -291,7 +291,7 @@ project_options = {}  # You can use options to provide platform-specific options
 
 if use_physical_hw:
     template_project_path = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr"))
-    project_options = {"project_type": "host_driven", "zephyr_board": BOARD}
+    project_options = {"project_type": "host_driven", "board": BOARD}
 
 # Create a temporary directory
 

--- a/gallery/how_to/work_with_microtvm/micro_train.py
+++ b/gallery/how_to/work_with_microtvm/micro_train.py
@@ -478,7 +478,7 @@ arduino_project = tvm.micro.generate_project(
     mod,
     f"{FOLDER}/models/project",
     {
-        "arduino_board": "nano33ble",
+        "board": "nano33ble",
         "arduino_cli_cmd": "/content/bin/arduino-cli",
         "project_type": "example_project",
     },

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -758,6 +758,40 @@ def write_with_timeout(fd, data, timeout_sec):  # pylint: disable=invalid-name
 
     return num_written
 
+def default_project_options() -> typing.List[ProjectOption]:
+    return [
+        ProjectOption(
+            "verbose",
+            optional=["build", "flash"],
+            type="bool",
+            help="Run build with verbose output.",
+        ),
+        ProjectOption(
+            "project_type",
+            required=["generate_project"],
+            type="str",
+            help="Type of project to generate.",
+        ),
+        ProjectOption(
+            "board",
+            required=["generate_project"],
+            type="str",
+            help="Name of the board to build for.",
+        ),
+        ProjectOption(
+            "cmsis_path",
+            optional=["generate_project"],
+            type="str",
+            help="Path to the CMSIS directory.",
+        ),
+        ProjectOption(
+            "heap_size_bytes",
+            optional=["generate_project"],
+            type="int",
+            # TODO: fix help message
+            help="Sets the value for HEAP_SIZE_BYTES passed to K_HEAP_DEFINE() to service TVM memory allocation requests.",
+        ),
+    ]
 
 def main(handler: ProjectAPIHandler, argv: typing.List[str] = None):
     """Start a Project API server.

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -780,6 +780,21 @@ def write_with_timeout(fd, data, timeout_sec):  # pylint: disable=invalid-name
 
 
 def default_project_options(**kw) -> typing.List[ProjectOption]:
+    """Get default Project Options
+
+    Attributes of any default option can be updated. Here is an example
+    when attribute `optional` from `verbose` option needs to be updates:
+
+        default_project_options(verbose={"optional": ["build"]})
+
+    This will update the `optional` attribute of `verbose` ProjectOption
+    to be `["build"]`.
+
+    Returns
+    -------
+    options: List[ProjectOption]
+        A list of default ProjectOption with modifications.
+    """
     options = [
         ProjectOption(
             "verbose",
@@ -813,9 +828,14 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
         ),
     ]
     for name, config in kw.items():
+        option_found = False
         for ind, option in enumerate(options):
             if option.name == name:
                 options[ind] = option.replace(**config)
+                option_found = True
+                break
+        if not option_found:
+            raise ValueError("Option {} was not found in default ProjectOptions.".format(name))
 
     return options
 

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -785,6 +785,7 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             "verbose",
             optional=["generate_project"],
             type="bool",
+            default=False,
             help="Run build with verbose output.",
         ),
         ProjectOption(
@@ -803,6 +804,7 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             "cmsis_path",
             optional=["generate_project"],
             type="str",
+            default=None,
             help="Path to the CMSIS directory.",
         ),
         ProjectOption(

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -64,10 +64,10 @@ class ProjectOption(_ProjectOption):
 
         return super().__new__(cls, **kw)
 
-    def replace(self, kw):
+    def replace(self, attributes):
         """Update attributes associated to the project option."""
         updated_option = self
-        return updated_option._replace(**kw)
+        return updated_option._replace(**attributes)
 
 
 ServerInfo = collections.namedtuple(

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -824,7 +824,8 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             optional=["generate_project"],
             type="str",
             default=None,
-            help="If given, during generate_project, uncompress the tarball at this path into the project dir.",
+            help="If given, during generate_project, "
+            "uncompress the tarball at this path into the project dir.",
         ),
     ]
     for name, config in kw.items():

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -805,6 +805,12 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             type="str",
             help="Path to the CMSIS directory.",
         ),
+        ProjectOption(
+            "warning_as_error",
+            optional=["generate_project"],
+            type="bool",
+            help="Treat warnings as errors and raise an Exception.",
+        ),
     ]
     for name, config in kw.items():
         for ind, option in enumerate(options):

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -824,6 +824,7 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             "warning_as_error",
             optional=["generate_project"],
             type="bool",
+            default=False,
             help="Treat warnings as errors and raise an Exception.",
         ),
     ]

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -812,6 +812,20 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             default=False,
             help="Treat warnings as errors and raise an Exception.",
         ),
+        ProjectOption(
+            "compile_definitions",
+            optional=["generate_project"],
+            type="str",
+            default=None,
+            help="Extra definitions added project compile.",
+        ),
+        ProjectOption(
+            "extra_files_tar",
+            optional=["generate_project"],
+            type="str",
+            default=None,
+            help="If given, during generate_project, uncompress the tarball at this path into the project dir.",
+        ),
     ]
     for name, config in kw.items():
         option_found = False

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -64,25 +64,10 @@ class ProjectOption(_ProjectOption):
 
         return super().__new__(cls, **kw)
 
-    def replace(self, **kw):
+    def replace(self, kw):
         """Update attributes associated to the project option."""
         updated_option = self
-        for key, val in kw.items():
-            if key == "choices":
-                updated_option = updated_option._replace(choices=val)
-            elif key == "default":
-                updated_option = updated_option._replace(default=val)
-            elif key == "type":
-                updated_option = updated_option._replace(type=val)
-            elif key == "required":
-                updated_option = updated_option._replace(required=val)
-            elif key == "optional":
-                updated_option = updated_option._replace(optional=val)
-            elif key == "help":
-                updated_option = updated_option._replace(help=val)
-            else:
-                raise ValueError("Attribute {} is not supported.".format(key))
-        return updated_option
+        return updated_option._replace(**kw)
 
 
 ServerInfo = collections.namedtuple(
@@ -832,7 +817,7 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
         option_found = False
         for ind, option in enumerate(options):
             if option.name == name:
-                options[ind] = option.replace(**config)
+                options[ind] = option.replace(config)
                 option_found = True
                 break
         if not option_found:

--- a/python/tvm/micro/testing/evaluation.py
+++ b/python/tvm/micro/testing/evaluation.py
@@ -50,7 +50,7 @@ def tune_model(
     assert isinstance(params, dict)
 
     project_options = {
-        f"{platform}_board": board,
+        "board": board,
         "project_type": "host_driven",
         **(project_options or {}),
     }
@@ -129,7 +129,7 @@ def create_aot_session(
     print(f"Model parameter size: {parameter_size}")
 
     project_options = {
-        f"{platform}_board": board,
+        "board": board,
         "project_type": "host_driven",
         # {} shouldn't be the default value for project options ({}
         # is mutable), so we use this workaround

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -149,6 +149,8 @@ ALLOW_SPECIFIC_FILE = {
     "apps/microtvm/zephyr/template_project/qemu-hack/qemu-system-riscv64",
     "apps/microtvm/zephyr/template_project/fvp-hack/FVP_Corstone_SSE-300_Ethos-U55",
     "apps/microtvm/zephyr/template_project/app-overlay/nucleo_l4r5zi.overlay",
+    # microTVM Arduino runtime
+    "apps/microtvm/arduino/template_project/Makefile.template",
     # microTVM Virtual Machines
     "apps/microtvm/poetry.lock",
     "apps/microtvm/reference-vm/Vagrantfile",

--- a/tests/micro/arduino/README.md
+++ b/tests/micro/arduino/README.md
@@ -22,14 +22,14 @@ all of the appropriate TVM dependencies installed. You can run the test with:
 
 ```
 $ cd tvm/tests/micro/arduino
-$ pytest --arduino-board=spresense
+$ pytest --board=spresense
 ```
 
 Most of these tests require a supported Arduino board to be connected.
 If you don't want to run these tests, you can pass the flag
 `--test-build-only` to only test project generation and compilation.
 
-To see the list of supported values for `--arduino-board`, run:
+To see the list of supported values for `--board`, run:
 ```
 $ pytest --help
 ```

--- a/tests/micro/arduino/test_arduino_rpc_server.py
+++ b/tests/micro/arduino/test_arduino_rpc_server.py
@@ -44,7 +44,7 @@ def _make_session(model, arduino_board, arduino_cli_cmd, workspace_dir, mod, bui
         mod,
         workspace_dir / "project",
         {
-            "arduino_board": arduino_board,
+            "board": arduino_board,
             "arduino_cli_cmd": arduino_cli_cmd,
             "project_type": "host_driven",
             "verbose": bool(build_config.get("debug")),

--- a/tests/micro/arduino/test_utils.py
+++ b/tests/micro/arduino/test_utils.py
@@ -84,7 +84,7 @@ def make_kws_project(board, arduino_cli_cmd, microtvm_debug, workspace_dir):
         mod,
         workspace_dir / "project",
         {
-            "arduino_board": board,
+            "board": board,
             "arduino_cli_cmd": arduino_cli_cmd,
             "project_type": "example_project",
             "verbose": bool(build_config.get("debug")),

--- a/tests/micro/common/test_tvmc.py
+++ b/tests/micro/common/test_tvmc.py
@@ -103,14 +103,12 @@ def test_tvmc_model_build_only(platform, board, output_dir):
         "project_type=host_driven",
     ]
     if platform == "zephyr":
-        create_project_cmd.append(f"{platform}_board={board}")
+        create_project_cmd.append(f"board={board}")
 
     cmd_result = _run_tvmc(create_project_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: create-project"
 
     build_cmd = ["micro", "build", project_dir, platform]
-    if platform == "arduino":
-        build_cmd += ["--project-option", f"{platform}_board={board}"]
     cmd_result = _run_tvmc(build_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: build"
     shutil.rmtree(output_dir)
@@ -170,21 +168,17 @@ def test_tvmc_model_run(platform, board, output_dir):
         "project_type=host_driven",
     ]
     if platform == "zephyr":
-        create_project_cmd.append(f"{platform}_board={board}")
+        create_project_cmd.append(f"board={board}")
 
     cmd_result = _run_tvmc(create_project_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: create-project"
 
     build_cmd = ["micro", "build", project_dir, platform]
-    if platform == "arduino":
-        build_cmd += ["--project-option", f"{platform}_board={board}"]
     cmd_result = _run_tvmc(build_cmd)
 
     assert cmd_result == 0, "tvmc micro failed in step: build"
 
     flash_cmd = ["micro", "flash", project_dir, platform]
-    if platform == "arduino":
-        flash_cmd += ["--project-option", f"{platform}_board={board}"]
     cmd_result = _run_tvmc(flash_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: flash"
 
@@ -194,8 +188,6 @@ def test_tvmc_model_run(platform, board, output_dir):
         "micro",
         project_dir,
     ]
-    if platform == "arduino":
-        run_cmd += ["--project-option", f"{platform}_board={board}"]
     run_cmd += ["--fill-mode", "random"]
     cmd_result = _run_tvmc(run_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: run"

--- a/tests/micro/common/test_tvmc.py
+++ b/tests/micro/common/test_tvmc.py
@@ -101,9 +101,8 @@ def test_tvmc_model_build_only(platform, board, output_dir):
         platform,
         "--project-option",
         "project_type=host_driven",
+        f"board={board}",
     ]
-    if platform == "zephyr":
-        create_project_cmd.append(f"board={board}")
 
     cmd_result = _run_tvmc(create_project_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: create-project"
@@ -166,9 +165,8 @@ def test_tvmc_model_run(platform, board, output_dir):
         platform,
         "--project-option",
         "project_type=host_driven",
+        f"board={board}",
     ]
-    if platform == "zephyr":
-        create_project_cmd.append(f"board={board}")
 
     cmd_result = _run_tvmc(create_project_cmd)
     assert cmd_result == 0, "tvmc micro failed in step: create-project"

--- a/tests/micro/project_api/test_arduino_microtvm_api_server.py
+++ b/tests/micro/project_api/test_arduino_microtvm_api_server.py
@@ -23,9 +23,10 @@ from unittest import mock
 from packaging import version
 import pytest
 
+import tvm
 from tvm.micro.project_api import server
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, tvm.micro.get_microtvm_template_projects("arduino"))
 import microtvm_api_server
 
 sys.path.pop(0)
@@ -192,3 +193,7 @@ class TestGenerateProject:
         # Version information should be cached and not checked again
         mock_run.assert_called_once()
         assert mock_run.call_args[0][0][0:2] == ["make", "flash"]
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/micro/project_api/test_project_api.py
+++ b/tests/micro/project_api/test_project_api.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+
+import tvm
+from tvm.micro.project_api import server
+
+API_GENERATE_PROJECT = "generate_project"
+API_BUILD = "build"
+API_FLASH = "flash"
+API_OPEN_TRANSPORT = "open_transport"
+
+PLATFORM_ARDUINO = "arduino"
+PLATFORM_ZEPHYR = "zephyr"
+
+
+platform = tvm.testing.parameter(PLATFORM_ARDUINO, PLATFORM_ZEPHYR)
+
+
+def test_default_options_exist(platform):
+    sys.path.insert(0, tvm.micro.get_microtvm_template_projects(platform))
+    import microtvm_api_server
+
+    platform_options = microtvm_api_server.PROJECT_OPTIONS
+    default_options = server.default_project_options()
+
+    option_names = []
+    for option in platform_options:
+        option_names.append(option.name)
+
+    for option in default_options:
+        assert option.name in option_names
+
+
+def test_default_options_requirements(platform):
+    sys.path.insert(0, tvm.micro.get_microtvm_template_projects(platform))
+    import microtvm_api_server
+
+    platform_options = microtvm_api_server.PROJECT_OPTIONS
+    for option in platform_options:
+        if option.name == "verbose":
+            assert option.optional == [API_GENERATE_PROJECT]
+        if option.name == "project_type":
+            option.required == [API_GENERATE_PROJECT]
+        if option.name == "board":
+            option.required == [API_GENERATE_PROJECT]
+            if platform == PLATFORM_ARDUINO:
+                option.optional == [API_FLASH, API_OPEN_TRANSPORT]
+        if option.name == "cmsis_path":
+            assert option.optional == [API_GENERATE_PROJECT]
+        if option.name == "compile_definitions":
+            assert option.optional == [API_GENERATE_PROJECT]
+        if option.name == "extra_files_tar":
+            assert option.optional == [API_GENERATE_PROJECT]
+
+
+def test_extra_options_requirements(platform):
+    sys.path.insert(0, tvm.micro.get_microtvm_template_projects(platform))
+    import microtvm_api_server
+
+    platform_options = microtvm_api_server.PROJECT_OPTIONS
+
+    if platform == PLATFORM_ZEPHYR:
+        for option in platform_options:
+            if option.name == "gdbserver_port":
+                assert option.optional == [API_OPEN_TRANSPORT]
+            if option.name == "nrfjprog_snr":
+                assert option.optional == [API_OPEN_TRANSPORT]
+            if option.name == "openocd_serial":
+                assert option.optional == [API_OPEN_TRANSPORT]
+            if option.name == "west_cmd":
+                assert option.optional == [API_GENERATE_PROJECT]
+            if option.name == "config_main_stack_size":
+                assert option.optional == [API_GENERATE_PROJECT]
+            if option.name == "arm_fvp_path":
+                assert option.optional == [API_GENERATE_PROJECT]
+            if option.name == "use_fvp":
+                assert option.optional == [API_GENERATE_PROJECT]
+            if option.name == "heap_size_bytes":
+                assert option.optional == [API_GENERATE_PROJECT]
+
+    if platform == PLATFORM_ARDUINO:
+        for option in platform_options:
+            if option.name == "port":
+                assert option.optional == [API_FLASH, API_OPEN_TRANSPORT]
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/micro/zephyr/README.md
+++ b/tests/micro/zephyr/README.md
@@ -32,11 +32,11 @@ device) using:
 
 ```
 $ cd tvm/tests/micro/zephyr
-$ pytest test_zephyr.py --zephyr-board=qemu_x86       # For QEMU emulation
-$ pytest test_zephyr.py --zephyr-board=nrf5340dk_nrf5340_cpuapp  # For nRF5340DK
+$ pytest test_zephyr.py --board=qemu_x86       # For QEMU emulation
+$ pytest test_zephyr.py --board=nrf5340dk_nrf5340_cpuapp  # For nRF5340DK
 ```
 
-To see the list of supported values for `--zephyr-board`, run:
+To see the list of supported values for `--board`, run:
 ```
 $ pytest test_zephyr.py --help
 ```

--- a/tests/micro/zephyr/test_utils.py
+++ b/tests/micro/zephyr/test_utils.py
@@ -90,7 +90,7 @@ def build_project(
             "project_type": "aot_standalone_demo",
             "west_cmd": west_cmd,
             "verbose": bool(build_config.get("debug")),
-            "zephyr_board": zephyr_board,
+            "board": zephyr_board,
             "compile_definitions": [
                 # TODO(mehrdadh): It fails without offset.
                 f"-DWORKSPACE_SIZE={workspace_size + 128}",

--- a/tests/micro/zephyr/test_zephyr.py
+++ b/tests/micro/zephyr/test_zephyr.py
@@ -59,7 +59,7 @@ def _make_session(temp_dir, zephyr_board, west_cmd, mod, build_config, use_fvp):
         "project_type": "host_driven",
         "west_cmd": west_cmd,
         "verbose": bool(build_config.get("debug")),
-        "zephyr_board": zephyr_board,
+        "board": zephyr_board,
         "arm_fvp_path": "/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55",
         "use_fvp": bool(use_fvp),
     }

--- a/tests/micro/zephyr/test_zephyr.py
+++ b/tests/micro/zephyr/test_zephyr.py
@@ -456,7 +456,7 @@ def test_autotune_conv2d(workspace_dir, board, west_cmd, microtvm_debug, use_fvp
         config_main_stack_size = 1536
 
     project_options = {
-        "zephyr_board": board,
+        "board": board,
         "west_cmd": west_cmd,
         "verbose": 1,
         "project_type": "host_driven",
@@ -577,7 +577,7 @@ def test_schedule_build_with_cmsis_dependency(
         "project_type": "host_driven",
         "west_cmd": west_cmd,
         "verbose": bool(build_config.get("debug")),
-        "zephyr_board": board,
+        "board": board,
         "cmsis_path": os.getenv("CMSIS_PATH"),
         "use_fvp": bool(use_fvp),
     }

--- a/tests/micro/zephyr/test_zephyr_aot_exec.py
+++ b/tests/micro/zephyr/test_zephyr_aot_exec.py
@@ -51,7 +51,7 @@ def _make_session(workspace_dir, zephyr_board, west_cmd, mod, build_config, use_
         "project_type": "host_driven",
         "west_cmd": west_cmd,
         "verbose": bool(build_config.get("debug")),
-        "zephyr_board": zephyr_board,
+        "board": zephyr_board,
         "arm_fvp_path": "/opt/arm/FVP_Corstone_SSE-300/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55",
         "use_fvp": bool(use_fvp),
     }

--- a/tests/python/unittest/test_micro_project_api.py
+++ b/tests/python/unittest/test_micro_project_api.py
@@ -494,5 +494,40 @@ def test_invalid_request(BaseTestHandler):
     }
 
 
+@tvm.testing.requires_micro
+def test_default_project_options():
+    from tvm.micro import project_api
+
+    default_options = project_api.server.default_project_options()
+    names = []
+    for option in default_options:
+        names.append(option.name)
+        if option.name == "verbose":
+            assert "generate_project" in option.optional
+        if option.name in ["project_type", "board"]:
+            assert "generate_project" in option.required
+        if option.name == "warning_as_error":
+            assert "generate_project" in option.optional
+
+    for name in ["verbose", "project_type", "board", "cmsis_path", "warning_as_error"]:
+        assert name in names
+
+
+@tvm.testing.requires_micro
+def test_modified_project_options():
+    from tvm.micro import project_api
+
+    modified_options = project_api.server.default_project_options(
+        verbose={"optional": ["flash"], "required": ["build"]},
+        board={"choices": ["board1", "board2"]},
+    )
+    for option in modified_options:
+        if option.name == "verbose":
+            assert option.optional == ["flash"]
+            assert option.required == ["build"]
+        if option.name == "board":
+            assert option.choices == ["board1", "board2"]
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -31,7 +31,6 @@ run_pytest ctypes python-microtvm-zephyr-mps2_an521 tests/micro/zephyr --board=m
 run_pytest ctypes python-microtvm-zephyr-mps3_an547 tests/micro/zephyr --board=mps3_an547 --use-fvp
 
 # Arduino
-run_pytest ctypes python-microtvm-arduino apps/microtvm/arduino/template_project/tests
 run_pytest ctypes python-microtvm-arduino-nano33ble tests/micro/arduino --board=nano33ble --test-build-only
 run_pytest ctypes python-microtvm-arduino-due tests/micro/arduino --board=due --test-build-only
 
@@ -41,6 +40,9 @@ run_pytest ctypes python-microtvm-stm32 tests/micro/stm32
 # Common Tests
 run_pytest ctypes python-microtvm-common-qemu_x86 tests/micro/common --platform=zephyr --board=qemu_x86
 run_pytest ctypes python-microtvm-common-due tests/micro/common --platform=arduino --board=due --test-build-only
+
+# Project API
+run_pytest ctypes python-microtvm-project_api tests/micro/project_api
 
 # Tutorials
 python3 gallery/how_to/work_with_microtvm/micro_tflite.py


### PR DESCRIPTION
This PR:
- Refactors common project options to a single place for template projects
- Adds a feature to update project options for customization
- Adds a Makefile for Arduino project to make the build/flash process more standalone
- Adds CMSIS support to Arduino template project
- Refactors `zephyr_board` and `arduino_board` to `board`

cc @alanmacd @areusch @gromero @guberti