### PR TITLE
[DOCKER][Adreno]Docker infra for Adreno target with CLML support

### DIFF
--- a/docker/Dockerfile.ci_adreno
+++ b/docker/Dockerfile.ci_adreno
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,23 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
-set -o pipefail
+# CI docker GPU env
+FROM tlcpack/ci-gpu:20220908-060034-62bdc91b1
 
-if [ -z ${1+x} ]; then
-    version=3.18.4
-else
-    version=$1
-fi
+COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
-v=$(echo $version | sed 's/\(.*\)\..*/\1/g')
-echo "Installing cmake $version ($v)"
-wget https://cmake.org/files/v${v}/cmake-${version}.tar.gz
-tar xvf cmake-${version}.tar.gz
-cd cmake-${version}
-./bootstrap
-make -j$(nproc)
-make install
-cd ..
-rm -rf cmake-${version} cmake-${version}.tar.gz
+# Android SDK
+COPY install/ubuntu_install_androidsdk.sh /install/ubuntu_install_androidsdk.sh
+RUN bash /install/ubuntu_install_androidsdk.sh
+ENV ANDROID_HOME=/opt/android-sdk-linux
+ENV ANDROID_NDK_HOME=/opt/android-sdk-linux/ndk/21.3.6528147
+ENV PATH /opt/android-sdk-linux/platform-tools:$PATH

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -453,6 +453,12 @@ if [ -f "${REPO_DIR}/.git" ]; then
     fi
 fi
 
+if [[ "${DOCKER_IMAGE_NAME}" == *"ci_adreno"* && ! -z "${ADRENO_OPENCL}" ]]; then
+    DOCKER_MOUNT+=( --volume ${ADRENO_OPENCL}:/adreno-opencl)
+    DOCKER_ENV+=( --env ADRENO_OPENCL=/adreno-opencl )
+    DOCKER_ENV+=( --net=host)
+fi
+
 # Print arguments.
 echo "REPO_DIR: ${REPO_DIR}"
 echo "DOCKER CONTAINER NAME: ${DOCKER_IMAGE_NAME}"

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -161,6 +161,7 @@ function parse_error() {
 break_joined_flag='if (( ${#1} == 2 )); then shift; else set -- -"${1#-i}" "${@:2}"; fi'
 
 DOCKER_ENV=( )
+DOCKER_FLAGS=( )
 
 while (( $# )); do
     case "$1" in
@@ -182,6 +183,11 @@ while (( $# )); do
         --net=host)
             USE_NET_HOST=true
             shift
+            ;;
+
+        --net)
+            DOCKER_FLAGS+=( --net "$2" )
+            shift 2
             ;;
 
         --mount)
@@ -209,6 +215,11 @@ while (( $# )); do
 
         --env)
             DOCKER_ENV+=( --env "$2" )
+            shift 2
+            ;;
+
+        --volume)
+            DOCKER_FLAGS+=( --volume "$2" )
             shift 2
             ;;
 
@@ -284,7 +295,6 @@ fi
 
 source "$(dirname $0)/dev_common.sh" || exit 2
 
-DOCKER_FLAGS=( )
 DOCKER_MOUNT=( )
 DOCKER_DEVICES=( )
 
@@ -453,19 +463,12 @@ if [ -f "${REPO_DIR}/.git" ]; then
     fi
 fi
 
-if [[ "${DOCKER_IMAGE_NAME}" == *"ci_adreno"* && ! -z "${ADRENO_OPENCL}" ]]; then
-    DOCKER_MOUNT+=( --volume ${ADRENO_OPENCL}:/adreno-opencl)
-    DOCKER_ENV+=( --env ADRENO_OPENCL=/adreno-opencl )
-    DOCKER_ENV+=( --net=host)
-fi
-
 # Print arguments.
 echo "REPO_DIR: ${REPO_DIR}"
 echo "DOCKER CONTAINER NAME: ${DOCKER_IMAGE_NAME}"
 echo ""
 
 echo Running \'${COMMAND[@]+"${COMMAND[@]}"}\' inside ${DOCKER_IMAGE_NAME}...
-
 
 DOCKER_CMD=(${DOCKER_BINARY} run
             ${DOCKER_FLAGS[@]+"${DOCKER_FLAGS[@]}"}

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -933,6 +933,15 @@ requires_vulkan = Feature(
     parent_features="gpu",
 )
 
+# Mark a test as requiring OpenCLML support in build.
+requires_openclml = Feature(
+    "OpenCLML",
+    "CLML",
+    cmake_flag="USE_CLML",
+    target_kind_enabled="opencl",
+)
+
+
 # Mark a test as requiring microTVM to run
 requires_micro = Feature("micro", "MicroTVM", cmake_flag="USE_MICRO")
 

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -899,8 +899,8 @@ requires_opencl = Feature(
     "OpenCL",
     cmake_flag="USE_OPENCL",
     target_kind_enabled="opencl",
-    target_kind_hardware="opencl",
-    parent_features="gpu",
+    target_kind_hardware="opencl" if "RPC_TARGET" not in os.environ else None,
+    parent_features="gpu" if "RPC_TARGET" not in os.environ else None,
 )
 
 # Mark a test as requiring the rocm runtime

--- a/tests/python/contrib/test_clml/conftest.py
+++ b/tests/python/contrib/test_clml/conftest.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+import tvm
+import pytest
+from test_clml.infrastructure import Device
+
+
+@pytest.fixture(scope="session")
+def device():
+    return Device()

--- a/tests/python/contrib/test_clml/test_network.py
+++ b/tests/python/contrib/test_clml/test_network.py
@@ -16,13 +16,13 @@
 # under the License.
 """OpenCL ML network tests."""
 
-import numpy as np
-import pytest
-from tvm import testing
-from tvm import relay
-
 import tvm
-from test_clml.infrastructure import skip_runtime_test, build_and_run, Device
+import numpy as np
+from tvm import relay
+from tvm.relay import testing
+from tvm.contrib import utils
+from test_clml.infrastructure import build_and_run, Device
+import pytest
 
 
 def _build_and_run_network(mod, params, inputs, data, device, atol, rtol, tvm_log=""):
@@ -59,15 +59,9 @@ def _get_keras_model(keras_model, inputs_dict, data):
     return mod, params, ref_output
 
 
-def test_mobilenet():
-    Device.load("test_config.json")
-
-    if skip_runtime_test():
-        return
-
-    device = Device()
-    dtype = "float16"
-
+@pytest.mark.parametrize("dtype", ["float16"])
+@tvm.testing.requires_openclml
+def test_mobilenet(device, dtype):
     def get_model():
         from tensorflow.keras.applications import MobileNet
         import tensorflow as tf
@@ -107,15 +101,9 @@ def test_mobilenet():
     tvm.testing.assert_allclose(opencl_sort[:10], clml_sort[:10], rtol=1e-5, atol=1e-5)
 
 
-def test_inception_v3():
-    Device.load("test_config.json")
-
-    if skip_runtime_test():
-        return
-
-    device = Device()
-    dtype = "float16"
-
+@pytest.mark.parametrize("dtype", ["float16"])
+@tvm.testing.requires_openclml
+def test_inception_v3(device, dtype):
     def get_model():
         from tensorflow.keras.applications import InceptionV3
         import tensorflow as tf
@@ -150,15 +138,9 @@ def test_inception_v3():
     tvm.testing.assert_allclose(opencl_sort[:5], clml_sort[:5], rtol=1e-5, atol=1e-5)
 
 
-def test_resnet50v2():
-    Device.load("test_config.json")
-
-    if skip_runtime_test():
-        return
-
-    device = Device()
-    dtype = "float16"
-
+@pytest.mark.parametrize("dtype", ["float16"])
+@tvm.testing.requires_openclml
+def test_resnet50v2(device, dtype):
     def get_model():
         from tensorflow.keras.applications import ResNet50V2
         import tensorflow as tf
@@ -202,9 +184,3 @@ def test_resnet50v2():
     clml_sort = np.argsort(outputs[0].asnumpy()).flatten()
 
     tvm.testing.assert_allclose(opencl_sort[:10], clml_sort[:10], rtol=1e-5, atol=1e-5)
-
-
-if __name__ == "__main__":
-    test_mobilenet()
-    test_resnet50v2()
-    test_inception_v3()

--- a/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
+++ b/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
@@ -577,7 +577,6 @@ def test_residual_block(target, dtype):
         "global.texture-weight",
         "global.texture",
         "global.texture-weight",
-        "global",
         "global.texture",
         "global.texture-weight",
         "",

--- a/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
+++ b/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
@@ -479,7 +479,6 @@ def test_conv2d_winograd_conv(target, dtype):
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-@pytest.mark.skipif(tvm.testing.utils.IS_IN_CI, reason="failed due to nvidia libOpencl in the CI")
 def test_residual_block(target, dtype):
     """
     - some kind of residual block followed by convolution to have texture after residual block
@@ -569,19 +568,33 @@ def test_residual_block(target, dtype):
         "weight2": tvm.nd.array(filter_data2),
         "weight3": tvm.nd.array(filter_data3),
     }
-
-    static_memory_scope = [
-        "global",
-        "global.texture",
-        "global.texture-weight",
-        "global.texture-weight",
-        "global.texture",
-        "global.texture-weight",
-        "global.texture",
-        "global.texture-weight",
-        "",
-        "",
-    ]
+    if dtype == "float16":
+        static_memory_scope = [
+            "global",
+            "global.texture",
+            "global.texture-weight",
+            "global.texture-weight",
+            "global.texture",
+            "global.texture-weight",
+            "global",
+            "global.texture",
+            "global.texture-weight",
+            "",
+            "",
+        ]
+    else:
+        static_memory_scope = [
+            "global",
+            "global.texture",
+            "global.texture-weight",
+            "global.texture-weight",
+            "global.texture",
+            "global.texture-weight",
+            "global.texture",
+            "global.texture-weight",
+            "",
+            "",
+        ]
 
     build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
 

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -169,6 +169,7 @@ def docker(name: str, image: str, scripts: List[str], env: Dict[str, str], inter
         "ci_arm",
         "ci_hexagon",
         "ci_riscv",
+        "ci_adreno",
     }
 
     if image in sccache_images and os.getenv("USE_SCCACHE", "1") == "1":
@@ -683,6 +684,19 @@ generated = [
                 "run full Python tests",
                 [
                     "./tests/scripts/task_riscv_microtvm.sh",
+                ],
+            ),
+        },
+    ),
+    generate_command(
+        name="adreno",
+        help="Run Adreno build and test(s)",
+        post_build=["./tests/scripts/task_build_adreno_bins.sh"],
+        options={
+            "test": (
+                "run Adreno API/Python tests",
+                [
+                    "./tests/scripts/task_python_adreno.sh " + os.environ.get("ANDROID_SERIAL", ""),
                 ],
             ),
         },

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -147,7 +147,14 @@ def gen_name(s: str) -> str:
     return f"{s}-{suffix}"
 
 
-def docker(name: str, image: str, scripts: List[str], env: Dict[str, str], interactive: bool):
+def docker(
+    name: str,
+    image: str,
+    scripts: List[str],
+    env: Dict[str, str],
+    interactive: bool,
+    additional_flags: Dict[str, str],
+):
     """
     Invoke a set of bash scripts through docker/bash.sh
 
@@ -196,6 +203,10 @@ def docker(name: str, image: str, scripts: List[str], env: Dict[str, str], inter
     for key, value in env.items():
         command.append("--env")
         command.append(f"{key}={value}")
+
+    for key, value in additional_flags.items():
+        command.append(key)
+        command.append(value)
 
     SCRIPT_DIR.mkdir(exist_ok=True)
 
@@ -346,6 +357,7 @@ def generate_command(
     help: str,
     precheck: Optional[Callable[[], None]] = None,
     post_build: Optional[List[str]] = None,
+    additional_flags: Dict[str, str] = {},
 ):
     """
     Helper to generate CLIs that:
@@ -412,6 +424,7 @@ def generate_command(
                 "VERBOSE": "true" if verbose else "false",
             },
             interactive=interactive,
+            additional_flags=additional_flags,
         )
 
     fn.__name__ = name
@@ -692,6 +705,11 @@ generated = [
         name="adreno",
         help="Run Adreno build and test(s)",
         post_build=["./tests/scripts/task_build_adreno_bins.sh"],
+        additional_flags={
+            "--volume": os.environ.get("ADRENO_OPENCL", "") + ":/adreno-opencl",
+            "--env": "ADRENO_OPENCL=/adreno-opencl",
+            "--net": "host",
+        },
         options={
             "test": (
                 "run Adreno API/Python tests",

--- a/tests/scripts/task_build_adreno_bins.sh
+++ b/tests/scripts/task_build_adreno_bins.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+
+output_directory=$(realpath ${PWD}/build-adreno-target)
+rm -rf ${output_directory}
+
+mkdir -p ${output_directory}
+cd ${output_directory}
+
+cp ../cmake/config.cmake .
+
+echo set\(USE_CLML ON\) >> config.cmake
+echo set\(USE_CLML_GRAPH_EXECUTOR "${ADRENO_OPENCL}"\) >> config.cmake
+echo set\(USE_RPC ON\) >> config.cmake
+echo set\(USE_CPP_RPC ON\) >> config.cmake
+echo set\(USE_GRAPH_EXECUTOR ON\) >> config.cmake
+echo set\(USE_LIBBACKTRACE AUTO\) >> config.cmake
+
+echo set\(ANDROID_ABI arm64-v8a\) >> config.cmake
+echo set\(ANDROID_PLATFORM android-28\) >> config.cmake
+echo set\(MACHINE_NAME aarch64-linux-gnu\) >> config.cmake
+
+cmake -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
+      -DANDROID_ABI=arm64-v8a \
+      -DANDROID_PLATFORM=android-28 \
+      -DCMAKE_SYSTEM_VERSION=1 \
+      -DCMAKE_FIND_ROOT_PATH="${ADRENO_OPENCL}" \
+      -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+      -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+      -DCMAKE_CXX_COMPILER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang++" \
+      -DCMAKE_C_COMPILER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang" \
+      -DMACHINE_NAME="aarch64-linux-gnu" ..
+
+make -j$(nproc) tvm_rpc

--- a/tests/scripts/task_build_adreno_bins.sh
+++ b/tests/scripts/task_build_adreno_bins.sh
@@ -18,6 +18,7 @@
 
 set -e
 set -u
+set -x
 
 output_directory=$(realpath ${PWD}/build-adreno-target)
 rm -rf ${output_directory}

--- a/tests/scripts/task_config_build_adreno.sh
+++ b/tests/scripts/task_config_build_adreno.sh
@@ -16,23 +16,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
-set -o pipefail
+set -euxo pipefail
 
-if [ -z ${1+x} ]; then
-    version=3.18.4
-else
-    version=$1
-fi
+BUILD_DIR=$1
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+cp ../cmake/config.cmake .
 
-v=$(echo $version | sed 's/\(.*\)\..*/\1/g')
-echo "Installing cmake $version ($v)"
-wget https://cmake.org/files/v${v}/cmake-${version}.tar.gz
-tar xvf cmake-${version}.tar.gz
-cd cmake-${version}
-./bootstrap
-make -j$(nproc)
-make install
-cd ..
-rm -rf cmake-${version} cmake-${version}.tar.gz
+echo set\(USE_OPENCL ON\) >> config.cmake
+echo set\(USE_CLML ON\) >> config.cmake
+echo set\(USE_RPC ON\) >> config.cmake
+echo set\(USE_GRAPH_EXECUTOR ON\) >> config.cmake
+echo set\(USE_LIBBACKTRACE AUTO\) >> config.cmake
+echo set\(USE_LLVM ON\) >> config.cmake

--- a/tests/scripts/task_python_adreno.sh
+++ b/tests/scripts/task_python_adreno.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+export TVM_TEST_TARGETS="opencl"
+export TVM_RELAY_OPENCL_TEXTURE_TARGETS="opencl -device=adreno"
+
+source tests/scripts/setup-pytest-env.sh
+export PYTHONPATH=${PYTHONPATH}:${TVM_PATH}/apps/extension/python
+export LD_LIBRARY_PATH="build:${LD_LIBRARY_PATH:-}"
+export TVM_INTEGRATION_TESTSUITE_NAME=python-integration-adreno
+
+export TVM_TRACKER_HOST=127.0.0.1
+export TVM_TRACKER_PORT=$(((RANDOM % 100) + 9100))
+export RPC_TARGET="adreno"
+export TVM_NDK_CC="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
+
+env PYTHONPATH=python python3 -m tvm.exec.rpc_tracker --host "${TVM_TRACKER_HOST}" --port "${TVM_TRACKER_PORT}" &
+TRACKER_PID=$!
+sleep 5   # Wait for tracker to bind
+
+export ANDROID_SERIAL=$1
+
+adb shell "mkdir -p /data/local/tmp/tvm_ci"
+adb push build-adreno-target/tvm_rpc /data/local/tmp/tvm_ci
+adb push build-adreno-target/libtvm_runtime.so /data/local/tmp/tvm_ci
+
+adb reverse tcp:${TVM_TRACKER_PORT} tcp:${TVM_TRACKER_PORT}
+adb forward tcp:5000 tcp:5000
+adb forward tcp:5001 tcp:5001
+adb forward tcp:5002 tcp:5002
+env adb shell "cd /data/local/tmp/tvm_ci; killall -9 tvm_rpc; sleep 2; LD_LIBRARY_PATH=/data/local/tmp/tvm_ci/ ./tvm_rpc server --host=0.0.0.0 --port=5000 --port-end=5010 --tracker=127.0.0.1:${TVM_TRACKER_PORT} --key=android" &
+DEVICE_PID=$!
+sleep 5 # Wait for the device connections
+
+# cleanup pycache
+find . -type f -path "*.pyc" | xargs rm -f
+
+# Test TVM
+make cython3
+
+# OpenCL texture test on Adreno
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-opencl-texture tests/python/relay/opencl_texture
+
+kill ${TRACKER_PID}
+kill ${DEVICE_PID}

--- a/tests/scripts/task_python_adreno.sh
+++ b/tests/scripts/task_python_adreno.sh
@@ -48,12 +48,10 @@ adb forward tcp:5002 tcp:5002
 env adb shell "cd /data/local/tmp/tvm_ci; killall -9 tvm_rpc_ci; sleep 2; LD_LIBRARY_PATH=/data/local/tmp/tvm_ci/ ./tvm_rpc_ci server --host=0.0.0.0 --port=5000 --port-end=5010 --tracker=127.0.0.1:${TVM_TRACKER_PORT} --key=android" &
 DEVICE_PID=$!
 sleep 5 # Wait for the device connections
-
 trap "{ kill ${TRACKER_PID}; kill ${DEVICE_PID}; }" 0
 
 # cleanup pycache
 find . -type f -path "*.pyc" | xargs rm -f
-
 # Test TVM
 make cython3
 

--- a/tests/scripts/task_python_adreno.sh
+++ b/tests/scripts/task_python_adreno.sh
@@ -38,14 +38,14 @@ sleep 5   # Wait for tracker to bind
 export ANDROID_SERIAL=$1
 
 adb shell "mkdir -p /data/local/tmp/tvm_ci"
-adb push build-adreno-target/tvm_rpc /data/local/tmp/tvm_ci
+adb push build-adreno-target/tvm_rpc /data/local/tmp/tvm_ci/tvm_rpc_ci
 adb push build-adreno-target/libtvm_runtime.so /data/local/tmp/tvm_ci
 
 adb reverse tcp:${TVM_TRACKER_PORT} tcp:${TVM_TRACKER_PORT}
 adb forward tcp:5000 tcp:5000
 adb forward tcp:5001 tcp:5001
 adb forward tcp:5002 tcp:5002
-env adb shell "cd /data/local/tmp/tvm_ci; killall -9 tvm_rpc; sleep 2; LD_LIBRARY_PATH=/data/local/tmp/tvm_ci/ ./tvm_rpc server --host=0.0.0.0 --port=5000 --port-end=5010 --tracker=127.0.0.1:${TVM_TRACKER_PORT} --key=android" &
+env adb shell "cd /data/local/tmp/tvm_ci; killall -9 tvm_rpc_ci; sleep 2; LD_LIBRARY_PATH=/data/local/tmp/tvm_ci/ ./tvm_rpc_ci server --host=0.0.0.0 --port=5000 --port-end=5010 --tracker=127.0.0.1:${TVM_TRACKER_PORT} --key=android" &
 DEVICE_PID=$!
 sleep 5 # Wait for the device connections
 
@@ -57,6 +57,9 @@ make cython3
 
 # OpenCL texture test on Adreno
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-opencl-texture tests/python/relay/opencl_texture
+
+# Adreno CLML test
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-openclml tests/python/contrib/test_clml
 
 kill ${TRACKER_PID}
 kill ${DEVICE_PID}

--- a/tests/scripts/task_python_adreno.sh
+++ b/tests/scripts/task_python_adreno.sh
@@ -49,6 +49,8 @@ env adb shell "cd /data/local/tmp/tvm_ci; killall -9 tvm_rpc_ci; sleep 2; LD_LIB
 DEVICE_PID=$!
 sleep 5 # Wait for the device connections
 
+trap "{ kill ${TRACKER_PID}; kill ${DEVICE_PID}; }" 0
+
 # cleanup pycache
 find . -type f -path "*.pyc" | xargs rm -f
 


### PR DESCRIPTION
New docker for Adreno that inherits gpu docker and amends android-sdk.

For CLML, we need to specify ADRENO_OPENCL via environment variable. CLML SDK can be downlaoded from Qualcomm Developer Network by following
https://developer.qualcomm.com/blog/accelerate-your-models-our-opencl-ml-sdk
Adreno device is shared with host, hence networking is enabled for Adreno Docker.