### PR TITLE
Improved recompilation times by utilizing CCache.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "3rdparty/cutlass"]
 	path = 3rdparty/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
+[submodule "cmake/3rdparty/CCache"]
+	path = cmake/3rdparty/CCache
+	url = https://github.com/TheLartians/Ccache.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(tvm C CXX)
 
+add_subdirectory("cmake/3rdparty/CCache")
+
 # Utility functions
 include(cmake/utils/Utils.cmake)
 include(cmake/utils/Summary.cmake)


### PR DESCRIPTION
Utilizing CCache is especially useful when one realizes he misses a feature and so recompiles the tool with that feature enabled. Or when one realizes he has accidentially enabled a feature unavalable on his platform, so compilation fails and one has to recompile. In that case without CCache CMake has to cause recompile from scratch since it alters the preprocessor. CCache is capable to detect the recompilation from scratch is not needed and to reuse the suitable artifacts from previous builds.