### PR TITLE
[Hybrid] Fix sys version check

### DIFF
--- a/python/tvm/te/hybrid/parser.py
+++ b/python/tvm/te/hybrid/parser.py
@@ -374,7 +374,7 @@ class HybridParser(ast.NodeVisitor):
 
     def visit_Subscript(self, node):
         args = self.visit(node.slice)
-        if sys.version_info > (3, 8):
+        if sys.version_info >= (3, 9):
             if not isinstance(node.slice, ast.Tuple):
                 args = [args]
 


### PR DESCRIPTION
This is a follow-up to #12769 The check for sys version of python 3.9 is not correct.
Fixed #12814 