### PR TITLE
[MetaSchedule] PyDatabase Complete Function Reload Support

### DIFF
--- a/include/tvm/meta_schedule/database.h
+++ b/include/tvm/meta_schedule/database.h
@@ -28,6 +28,7 @@
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/target/target.h>
+#include <tvm/tir/schedule/schedule.h>
 #include <tvm/tir/schedule/trace.h>
 
 namespace tvm {
@@ -268,6 +269,33 @@ class PyDatabaseNode : public DatabaseNode {
    */
   using FGetAllTuningRecords = runtime::TypedPackedFunc<Array<TuningRecord>()>;
   /*!
+   * \brief The function type of `QueryTuningRecord` method.
+   * \param mod The IRModule to be searched for.
+   * \param target The target to be searched for.
+   * \param workload_name The name of the workload to be searched for.
+   * \return The best record of the given workload; NullOpt if not found.
+   */
+  using FQueryTuningRecord = runtime::TypedPackedFunc<Optional<TuningRecord>(
+      const IRModule&, const Target&, const String&)>;
+  /*!
+   * \brief The function type of `QuerySchedule` method.
+   * \param mod The IRModule to be searched for.
+   * \param target The target to be searched for.
+   * \param workload_name The name of the workload to be searched for.
+   * \return The schedule in the best schedule of the given workload; NullOpt if not found.
+   */
+  using FQuerySchedule = runtime::TypedPackedFunc<Optional<tir::Schedule>(
+      const IRModule&, const Target&, const String&)>;
+  /*!
+   * \brief The function type of `QueryIRModule` method.
+   * \param mod The IRModule to be searched for.
+   * \param target The target to be searched for.
+   * \param workload_name The name of the workload to be searched for.
+   * \return The IRModule in the best IRModule of the given workload; NullOpt if not found.
+   */
+  using FQueryIRModule =
+      runtime::TypedPackedFunc<Optional<IRModule>(const IRModule&, const Target&, const String&)>;
+  /*!
    * \brief The function type of `Size` method.
    * \return The size of the database.
    */
@@ -283,6 +311,12 @@ class PyDatabaseNode : public DatabaseNode {
   FGetTopK f_get_top_k;
   /*! \brief The packed function to the `GetAllTuningRecords` function. */
   FGetAllTuningRecords f_get_all_tuning_records;
+  /*! \brief The packed function to the `QueryTuningRecord` function. */
+  FQueryTuningRecord f_query_tuning_record;
+  /*! \brief The packed function to the `QuerySchedule` function. */
+  FQuerySchedule f_query_schedule;
+  /*! \brief The packed function to the `QueryIRModule` function. */
+  FQueryIRModule f_query_ir_module;
   /*! \brief The packed function to the `Size` function. */
   FSize f_size;
 
@@ -295,6 +329,9 @@ class PyDatabaseNode : public DatabaseNode {
     // `f_commit_tuning_record` is not visited
     // `f_get_top_k` is not visited
     // `f_get_all_tuning_records` is not visited
+    // `f_query_tuning_record` is not visited
+    // `f_query_schedule` is not visited
+    // `f_query_ir_module` is not visited
     // `f_size` is not visited
   }
 
@@ -323,6 +360,25 @@ class PyDatabaseNode : public DatabaseNode {
     ICHECK(f_get_all_tuning_records != nullptr)
         << "PyDatabase's GetAllTuningRecords method not implemented!";
     return f_get_all_tuning_records();
+  }
+
+  Optional<TuningRecord> QueryTuningRecord(const IRModule& mod, const Target& target,
+                                           const String& workload_name) final {
+    ICHECK(f_query_tuning_record != nullptr)
+        << "PyDatabase's QueryTuningRecord method not implemented!";
+    return f_query_tuning_record(mod, target, workload_name);
+  }
+
+  Optional<tir::Schedule> QuerySchedule(const IRModule& mod, const Target& target,
+                                        const String& workload_name) final {
+    ICHECK(f_query_schedule != nullptr) << "PyDatabase's QuerySchedule method not implemented!";
+    return f_query_schedule(mod, target, workload_name);
+  }
+
+  Optional<IRModule> QueryIRModule(const IRModule& mod, const Target& target,
+                                   const String& workload_name) final {
+    ICHECK(f_query_ir_module != nullptr) << "PyDatabase's QueryIRModule method not implemented!";
+    return f_query_ir_module(mod, target, workload_name);
   }
 
   int64_t Size() final {
@@ -380,6 +436,9 @@ class Database : public runtime::ObjectRef {
    * \param f_commit_tuning_record The packed function of `CommitTuningRecord`.
    * \param f_get_top_k The packed function of `GetTopK`.
    * \param f_get_all_tuning_records The packed function of `GetAllTuningRecords`.
+   * \param f_query_tuning_record The packed function of `QueryTuningRecord`.
+   * \param f_query_schedule The packed function of `QuerySchedule`.
+   * \param f_query_ir_module The packed function of `QueryIRModule`.
    * \param f_size The packed function of `Size`.
    * \return The created database.
    */
@@ -388,6 +447,9 @@ class Database : public runtime::ObjectRef {
                                      PyDatabaseNode::FCommitTuningRecord f_commit_tuning_record,
                                      PyDatabaseNode::FGetTopK f_get_top_k,
                                      PyDatabaseNode::FGetAllTuningRecords f_get_all_tuning_records,
+                                     PyDatabaseNode::FQueryTuningRecord f_query_tuning_record,
+                                     PyDatabaseNode::FQuerySchedule f_query_schedule,
+                                     PyDatabaseNode::FQueryIRModule f_query_ir_module,
                                      PyDatabaseNode::FSize f_size);
   /*! \return The current Database in the scope. */
   static Optional<Database> Current();

--- a/include/tvm/meta_schedule/database.h
+++ b/include/tvm/meta_schedule/database.h
@@ -364,21 +364,29 @@ class PyDatabaseNode : public DatabaseNode {
 
   Optional<TuningRecord> QueryTuningRecord(const IRModule& mod, const Target& target,
                                            const String& workload_name) final {
-    ICHECK(f_query_tuning_record != nullptr)
-        << "PyDatabase's QueryTuningRecord method not implemented!";
-    return f_query_tuning_record(mod, target, workload_name);
+    if (f_query_tuning_record == nullptr) {
+      return DatabaseNode::QueryTuningRecord(mod, target, workload_name);
+    } else {
+      return f_query_tuning_record(mod, target, workload_name);
+    }
   }
 
   Optional<tir::Schedule> QuerySchedule(const IRModule& mod, const Target& target,
                                         const String& workload_name) final {
-    ICHECK(f_query_schedule != nullptr) << "PyDatabase's QuerySchedule method not implemented!";
-    return f_query_schedule(mod, target, workload_name);
+    if (f_query_schedule == nullptr) {
+      return DatabaseNode::QuerySchedule(mod, target, workload_name);
+    } else {
+      return f_query_schedule(mod, target, workload_name);
+    }
   }
 
   Optional<IRModule> QueryIRModule(const IRModule& mod, const Target& target,
                                    const String& workload_name) final {
-    ICHECK(f_query_ir_module != nullptr) << "PyDatabase's QueryIRModule method not implemented!";
-    return f_query_ir_module(mod, target, workload_name);
+    if (f_query_ir_module == nullptr) {
+      return DatabaseNode::QueryIRModule(mod, target, workload_name);
+    } else {
+      return f_query_ir_module(mod, target, workload_name);
+    }
   }
 
   int64_t Size() final {

--- a/python/tvm/meta_schedule/database/database.py
+++ b/python/tvm/meta_schedule/database/database.py
@@ -559,42 +559,6 @@ class PyDatabase:
             self._outer(), mod, target, workload_name  # pylint: disable=no-member
         )
 
-    def query(
-        self,
-        mod: IRModule,
-        target: Target,
-        *,
-        workload_name: str = "main",
-        kind: Union[
-            Literal["schedule"],
-            Literal["record"],
-            Literal["ir_module"],
-        ] = "schedule",
-    ) -> Union[Schedule, IRModule, TuningRecord]:
-        """Query the database to retrieve the best optimization outcome of the given workload.
-
-        Parameters
-        ----------
-        mod : IRModule
-            The IRModule to be searched for.
-        target : Target
-            The target to be searched for.
-        kind : str = "schedule" | "record" | "ir_module"
-            The kind of the optimization outcome to be returned.
-
-        Returns
-        -------
-        result : Union[Schedule, IRModule, TuningRecord]
-            The best optimization outcome of the given workload.
-        """
-        if kind == "schedule":
-            return self.query_schedule(mod, target, workload_name)
-        if kind == "record":
-            return self.query_tuning_record(mod, target, workload_name)
-        if kind == "ir_module":
-            return self.query_ir_module(mod, target, workload_name)
-        raise ValueError(f'Unknown kind: {kind}. Candidates are: "schedule", "record", "ir_module"')
-
     def __len__(self) -> int:
         """Get the number of records in the database.
 
@@ -604,20 +568,6 @@ class PyDatabase:
             The number of records in the database
         """
         raise NotImplementedError
-
-    def __enter__(self) -> Database:
-        """Entering the scope of the context manager"""
-        _ffi_api.DatabaseEnterWithScope(self.outer())  # type: ignore # pylint: disable=no-member
-        return self  # type: ignore
-
-    def __exit__(self, ptype, value, trace) -> None:
-        """Exiting the scope of the context manager"""
-        _ffi_api.DatabaseExitWithScope(self.outer())  # type: ignore # pylint: disable=no-member
-
-    @staticmethod
-    def current() -> Optional[Database]:
-        """Get the current database under scope."""
-        return _ffi_api.DatabaseCurrent()  # type: ignore # pylint: disable=no-member
 
 
 def create(  # pylint: disable=keyword-arg-before-vararg

--- a/python/tvm/meta_schedule/database/database.py
+++ b/python/tvm/meta_schedule/database/database.py
@@ -378,6 +378,9 @@ class _PyDatabase(Database):
         f_commit_tuning_record: Callable = None,
         f_get_top_k: Callable = None,
         f_get_all_tuning_records: Callable = None,
+        f_query_tuning_record: Callable = None,
+        f_query_schedule: Callable = None,
+        f_query_ir_module: Callable = None,
         f_size: Callable = None,
     ):
         """Constructor."""
@@ -389,6 +392,9 @@ class _PyDatabase(Database):
             f_commit_tuning_record,
             f_get_top_k,
             f_get_all_tuning_records,
+            f_query_tuning_record,
+            f_query_schedule,
+            f_query_ir_module,
             f_size,
         )
 
@@ -409,6 +415,9 @@ class PyDatabase:
             "commit_tuning_record",
             "get_top_k",
             "get_all_tuning_records",
+            "query_tuning_record",
+            "query_schedule",
+            "query_ir_module",
             "__len__",
         ],
     }
@@ -478,6 +487,108 @@ class PyDatabase:
         """
         raise NotImplementedError
 
+    def query_tuning_record(
+        self, mod: IRModule, target: Target, workload_name: Optional[str] = None
+    ) -> Optional[TuningRecord]:
+        """Query a tuning record from the database.
+
+        Parameters
+        ----------
+        mod : IRModule
+            The IRModule to be searched for.
+        target : Target
+            The target to be searched for.
+        workload_name : Optional[str]
+            The workload name to be searched for.
+
+        Returns
+        -------
+        record : Optional[TuningRecord]
+            The tuning record corresponding to the given workload.
+        """
+        # Using self._outer to replace the self pointer
+        _ffi_api.DatabaseQueryTuningRecord(self._outer(), mod, target, workload_name)  # type: ignore # pylint: disable=no-member
+
+    def query_schedule(
+        self, mod: IRModule, target: Target, workload_name: Optional[str] = None
+    ) -> Optional[Schedule]:
+        """Query a schedule from the database.
+
+        Parameters
+        ----------
+        mod : IRModule
+            The IRModule to be searched for.
+        target : Target
+            The target to be searched for.
+        workload_name : Optional[str]
+            The workload name to be searched for.
+
+        Returns
+        -------
+        schedule : Optional[Schedule]
+            The schedule corresponding to the given workload.
+        """
+        # Using self._outer to replace the self pointer
+        _ffi_api.DatabaseQuerySchedule(self._outer(), mod, target, workload_name)  # type: ignore # pylint: disable=no-member
+
+    def query_ir_module(
+        self, mod: IRModule, target: Target, workload_name: Optional[str] = None
+    ) -> Optional[IRModule]:
+        """Query an IRModule from the database.
+
+        Parameters
+        ----------
+        mod : IRModule
+            The IRModule to be searched for.
+        target : Target
+            The target to be searched for.
+        workload_name : Optional[str]
+            The workload name to be searched for.
+
+        Returns
+        -------
+        mod : Optional[IRModule]
+            The IRModule corresponding to the given workload.
+        """
+        # Using self._outer to replace the self pointer
+        _ffi_api.DatabaseQueryIRModule(self._outer(), mod, target, workload_name)  # type: ignore # pylint: disable=no-member
+
+    def query(
+        self,
+        mod: IRModule,
+        target: Target,
+        *,
+        workload_name: str = "main",
+        kind: Union[
+            Literal["schedule"],
+            Literal["record"],
+            Literal["ir_module"],
+        ] = "schedule",
+    ) -> Union[Schedule, IRModule, TuningRecord]:
+        """Query the database to retrieve the best optimization outcome of the given workload.
+
+        Parameters
+        ----------
+        mod : IRModule
+            The IRModule to be searched for.
+        target : Target
+            The target to be searched for.
+        kind : str = "schedule" | "record" | "ir_module"
+            The kind of the optimization outcome to be returned.
+
+        Returns
+        -------
+        result : Union[Schedule, IRModule, TuningRecord]
+            The best optimization outcome of the given workload.
+        """
+        if kind == "schedule":
+            return self.query_schedule(mod, target, workload_name)
+        if kind == "record":
+            return self.query_tuning_record(mod, target, workload_name)
+        if kind == "ir_module":
+            return self.query_ir_module(mod, target, workload_name)
+        raise ValueError(f'Unknown kind: {kind}. Candidates are: "schedule", "record", "ir_module"')
+
     def __len__(self) -> int:
         """Get the number of records in the database.
 
@@ -487,6 +598,20 @@ class PyDatabase:
             The number of records in the database
         """
         raise NotImplementedError
+
+    def __enter__(self) -> Database:
+        """Entering the scope of the context manager"""
+        _ffi_api.DatabaseEnterWithScope(self.outer())  # type: ignore # pylint: disable=no-member
+        return self
+
+    def __exit__(self, ptype, value, trace) -> None:
+        """Exiting the scope of the context manager"""
+        _ffi_api.DatabaseExitWithScope(self.outer())  # type: ignore # pylint: disable=no-member
+
+    @staticmethod
+    def current() -> Optional[Database]:
+        """Get the current database under scope."""
+        return _ffi_api.DatabaseCurrent()  # type: ignore # pylint: disable=no-member
 
 
 def create(  # pylint: disable=keyword-arg-before-vararg

--- a/python/tvm/meta_schedule/database/database.py
+++ b/python/tvm/meta_schedule/database/database.py
@@ -507,7 +507,9 @@ class PyDatabase:
             The tuning record corresponding to the given workload.
         """
         # Using self._outer to replace the self pointer
-        _ffi_api.DatabaseQueryTuningRecord(self._outer(), mod, target, workload_name)  # type: ignore # pylint: disable=no-member
+        return _ffi_api.DatabaseQueryTuningRecord(  # type: ignore # pylint: disable=no-member
+            self._outer(), mod, target, workload_name  # pylint: disable=no-member
+        )
 
     def query_schedule(
         self, mod: IRModule, target: Target, workload_name: Optional[str] = None
@@ -529,7 +531,9 @@ class PyDatabase:
             The schedule corresponding to the given workload.
         """
         # Using self._outer to replace the self pointer
-        _ffi_api.DatabaseQuerySchedule(self._outer(), mod, target, workload_name)  # type: ignore # pylint: disable=no-member
+        return _ffi_api.DatabaseQuerySchedule(  # type: ignore # pylint: disable=no-member
+            self._outer(), mod, target, workload_name  # pylint: disable=no-member
+        )
 
     def query_ir_module(
         self, mod: IRModule, target: Target, workload_name: Optional[str] = None
@@ -551,7 +555,9 @@ class PyDatabase:
             The IRModule corresponding to the given workload.
         """
         # Using self._outer to replace the self pointer
-        _ffi_api.DatabaseQueryIRModule(self._outer(), mod, target, workload_name)  # type: ignore # pylint: disable=no-member
+        return _ffi_api.DatabaseQueryIRModule(  # type: ignore # pylint: disable=no-member
+            self._outer(), mod, target, workload_name  # pylint: disable=no-member
+        )
 
     def query(
         self,
@@ -602,7 +608,7 @@ class PyDatabase:
     def __enter__(self) -> Database:
         """Entering the scope of the context manager"""
         _ffi_api.DatabaseEnterWithScope(self.outer())  # type: ignore # pylint: disable=no-member
-        return self
+        return self  # type: ignore
 
     def __exit__(self, ptype, value, trace) -> None:
         """Exiting the scope of the context manager"""

--- a/python/tvm/meta_schedule/database/database.py
+++ b/python/tvm/meta_schedule/database/database.py
@@ -508,7 +508,7 @@ class PyDatabase:
         """
         # Using self._outer to replace the self pointer
         return _ffi_api.DatabaseQueryTuningRecord(  # type: ignore # pylint: disable=no-member
-            self._outer(), mod, target, workload_name  # pylint: disable=no-member
+            self._outer(), mod, target, workload_name  # type: ignore # pylint: disable=no-member
         )
 
     def query_schedule(
@@ -532,7 +532,7 @@ class PyDatabase:
         """
         # Using self._outer to replace the self pointer
         return _ffi_api.DatabaseQuerySchedule(  # type: ignore # pylint: disable=no-member
-            self._outer(), mod, target, workload_name  # pylint: disable=no-member
+            self._outer(), mod, target, workload_name  # type: ignore # pylint: disable=no-member
         )
 
     def query_ir_module(
@@ -556,7 +556,7 @@ class PyDatabase:
         """
         # Using self._outer to replace the self pointer
         return _ffi_api.DatabaseQueryIRModule(  # type: ignore # pylint: disable=no-member
-            self._outer(), mod, target, workload_name  # pylint: disable=no-member
+            self._outer(), mod, target, workload_name  # type: ignore # pylint: disable=no-member
         )
 
     def __len__(self) -> int:

--- a/src/meta_schedule/database/database.cc
+++ b/src/meta_schedule/database/database.cc
@@ -217,6 +217,9 @@ Database Database::PyDatabase(PyDatabaseNode::FHasWorkload f_has_workload,
                               PyDatabaseNode::FCommitTuningRecord f_commit_tuning_record,
                               PyDatabaseNode::FGetTopK f_get_top_k,
                               PyDatabaseNode::FGetAllTuningRecords f_get_all_tuning_records,
+                              PyDatabaseNode::FQueryTuningRecord f_query_tuning_record,
+                              PyDatabaseNode::FQuerySchedule f_query_schedule,
+                              PyDatabaseNode::FQueryIRModule f_query_ir_module,
                               PyDatabaseNode::FSize f_size) {
   ObjectPtr<PyDatabaseNode> n = make_object<PyDatabaseNode>();
   n->f_has_workload = f_has_workload;
@@ -224,6 +227,9 @@ Database Database::PyDatabase(PyDatabaseNode::FHasWorkload f_has_workload,
   n->f_commit_tuning_record = f_commit_tuning_record;
   n->f_get_top_k = f_get_top_k;
   n->f_get_all_tuning_records = f_get_all_tuning_records;
+  n->f_query_tuning_record = f_query_tuning_record;
+  n->f_query_schedule = f_query_schedule;
+  n->f_query_ir_module = f_query_ir_module;
   n->f_size = f_size;
   return Database(n);
 }

--- a/tests/python/unittest/test_meta_schedule_database.py
+++ b/tests/python/unittest/test_meta_schedule_database.py
@@ -532,8 +532,8 @@ def test_meta_schedule_pydatabase_override_query():
 
 def test_meta_schedule_pydatabase_current():
     db = PyMemoryDatabaseDefault()  # pylint: disable=invalid-name
-    with db:
-        assert ms.database.PyDatabase.current() == db
+    with db:  # pylint: disable=not-context-manager
+        assert ms.database.Database.current() == db
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_meta_schedule_database.py
+++ b/tests/python/unittest/test_meta_schedule_database.py
@@ -18,11 +18,14 @@
 """Test Meta Schedule Database"""
 import os.path as osp
 import tempfile
-from typing import Callable
+from tkinter.messagebox import NO
+from typing import Callable, Optional, List
 
 import tvm
 import tvm.testing
+from tvm.target import Target
 from tvm import meta_schedule as ms
+from tvm.meta_schedule.database import TuningRecord, Workload
 from tvm import tir
 from tvm.ir.module import IRModule
 from tvm.script import tir as T
@@ -104,6 +107,121 @@ def _equal_record(a: ms.database.TuningRecord, b: ms.database.TuningRecord):
     assert tvm.ir.structural_equal(a.workload.mod, b.workload.mod)
     for arg0, arg1 in zip(a.args_info, b.args_info):
         assert str(arg0.as_json()) == str(arg1.as_json())
+
+
+@ms.utils.derived_object
+class PyMemoryDatabaseDefault(ms.database.PyDatabase):
+    def __init__(self):
+        super().__init__()
+        self.tuning_records_: List[TuningRecord] = []
+        self.workloads_: List[Workload] = []
+
+    def has_workload(self, mod: IRModule) -> bool:
+        for workload in self.workloads_:
+            if tvm.ir.structural_equal(mod, workload.mod):
+                return True
+
+    def commit_workload(self, mod: IRModule) -> ms.database.Workload:
+        if self.has_workload(mod):
+            for workload in self.workloads_:
+                if tvm.ir.structural_equal(mod, workload.mod):
+                    return workload
+        else:
+            workload = ms.database.Workload(mod)
+            self.workloads_.append(workload)
+            return workload
+
+    def commit_tuning_record(self, record: TuningRecord) -> None:
+        self.tuning_records_.append(record)
+
+    def get_all_tuning_records(self) -> List[TuningRecord]:
+        return self.tuning_records_
+
+    def get_top_k(self, workload: ms.database.Workload, top_k: int) -> List[TuningRecord]:
+        return sorted(
+            list(
+                filter(
+                    lambda x: tvm.ir.structural_equal(workload.mod, x.workload.mod),
+                    self.tuning_records_,
+                )
+            ),
+            key=lambda x: sum(x.run_secs) / len(x.run_secs) if x.run_secs else 1e9,
+        )[:top_k]
+
+    def __len__(self) -> int:
+        return len(self.tuning_records_)
+
+
+@ms.utils.derived_object
+class PyMemoryDatabaseOverride(ms.database.PyDatabase):
+    def __init__(self):
+        super().__init__()
+        self.tuning_records_: List[TuningRecord] = []
+        self.workloads_: List[Workload] = []
+
+    def has_workload(self, mod: IRModule) -> bool:
+        for workload in self.workloads_:
+            if tvm.ir.structural_equal(mod, workload.mod):
+                return True
+
+    def commit_workload(self, mod: IRModule) -> ms.database.Workload:
+        if self.has_workload(mod):
+            for workload in self.workloads_:
+                if tvm.ir.structural_equal(mod, workload.mod):
+                    return workload
+        else:
+            workload = ms.database.Workload(mod)
+            self.workloads_.append(workload)
+            return workload
+
+    def commit_tuning_record(self, record: TuningRecord) -> None:
+        self.tuning_records_.append(record)
+
+    def get_all_tuning_records(self) -> List[TuningRecord]:
+        return self.tuning_records_
+
+    def get_top_k(self, workload: ms.database.Workload, top_k: int) -> List[TuningRecord]:
+        return sorted(
+            list(
+                filter(
+                    lambda x: tvm.ir.structural_equal(workload.mod, x.workload.mod),
+                    self.tuning_records_,
+                )
+            ),
+            key=lambda x: sum(x.run_secs) / len(x.run_secs) if x.run_secs else 1e9,
+        )[:top_k]
+
+    def __len__(self) -> int:
+        return len(self.tuning_records_)
+
+    def query_tuning_record(
+        self, mod: IRModule, target: Target, workload_name: Optional[str] = None
+    ) -> Optional[TuningRecord]:
+        if self.has_workload(mod):
+            records = self.get_top_k(self.commit_workload(mod), 1)
+            if len(records) == 1:
+                return records[0]
+        return None
+
+    def query_schedule(
+        self, mod: IRModule, target: Target, workload_name: Optional[str] = None
+    ) -> Optional[Schedule]:
+        record = self.query_tuning_record(mod, target, workload_name)
+        if record is not None:
+            sch = Schedule(record.workload.mod)
+            record.trace.apply_to_schedule(sch, remove_postproc=False)
+            return sch
+        return None
+
+    def query_ir_module(
+        self, mod: IRModule, target: Target, workload_name: Optional[str] = None
+    ) -> Optional[IRModule]:
+        record = self.query_tuning_record(mod, target, workload_name)
+        if record is not None:
+            sch = Schedule(record.workload.mod)
+            record.trace.apply_to_schedule(sch, remove_postproc=False)
+            return sch.mod
+        return None
 
 
 def test_meta_schedule_tuning_record_round_trip():
@@ -302,10 +420,10 @@ def test_meta_schedule_database_union():
     db_2 = ms.database.MemoryDatabase()
     trace = _create_schedule(mod, _schedule_matmul).trace
 
-    def query(db):
+    def query(db):  # pylint: disable=invalid-name
         return db.query_tuning_record(mod=mod, target=target, workload_name="main").run_secs
 
-    def commit_record(db, run_sec):
+    def commit_record(db, run_sec):  # pylint: disable=invalid-name
         db.commit_tuning_record(
             ms.database.TuningRecord(
                 trace,
@@ -329,6 +447,92 @@ def test_meta_schedule_database_union():
 
     (run_secs,) = query(ms.database.OrderedUnionDatabase(db_1, db_2))
     assert run_secs.value == 1.0
+
+
+def test_meta_schedule_pydatabase_default_query():
+
+    mod: IRModule = Matmul
+    target = tvm.target.Target("llvm")
+    arg_info = ms.arg_info.ArgInfo.from_prim_func(func=mod["main"])
+    db = PyMemoryDatabaseDefault()  # pylint: disable=invalid-name
+    sch = _create_schedule(mod, _schedule_matmul)
+    trace = sch.trace
+
+    def query(db, mod, target, kind):  # pylint: disable=invalid-name
+        return db.query(mod=mod, target=target, workload_name="main", kind=kind)
+
+    def commit_record(trace, db, run_sec):  # pylint: disable=invalid-name
+        db.commit_tuning_record(
+            ms.database.TuningRecord(
+                trace,
+                workload=db.commit_workload(mod),
+                run_secs=[run_sec],
+                target=target,
+                args_info=arg_info,
+            )
+        )
+
+    commit_record(trace, db, 1.0)
+    record = query(db, mod, target, "record")
+    assert record is not None and record.run_secs[0].value == 1.0
+    sch_res = query(db, mod, target, "schedule")
+    assert sch_res is not None and tvm.ir.structural_equal(sch_res.mod, sch.mod)
+    mod_res = query(db, mod, target, "ir_module")
+    assert mod_res is not None and tvm.ir.structural_equal(mod_res, sch.mod)
+
+    commit_record(Schedule(mod).trace, db, 0.2)  # Empty Trace
+    record = query(db, mod, target, "record")
+    assert record is not None and record.run_secs[0].value == 0.2
+    sch_res = query(db, mod, target, "schedule")
+    assert sch_res is not None and tvm.ir.structural_equal(sch_res.mod, mod)
+    mod_res = query(db, mod, target, "ir_module")
+    assert mod_res is not None and tvm.ir.structural_equal(mod_res, mod)
+
+
+def test_meta_schedule_pydatabase_override_query():
+
+    mod: IRModule = Matmul
+    target = tvm.target.Target("llvm")
+    arg_info = ms.arg_info.ArgInfo.from_prim_func(func=mod["main"])
+    db = PyMemoryDatabaseOverride()  # pylint: disable=invalid-name
+    sch = _create_schedule(mod, _schedule_matmul)
+    trace = sch.trace
+
+    def query(db, mod, target, kind):  # pylint: disable=invalid-name
+        return db.query(mod=mod, target=target, workload_name="main", kind=kind)
+
+    def commit_record(trace, db, run_sec):  # pylint: disable=invalid-name
+        db.commit_tuning_record(
+            ms.database.TuningRecord(
+                trace,
+                workload=db.commit_workload(mod),
+                run_secs=[run_sec],
+                target=target,
+                args_info=arg_info,
+            )
+        )
+
+    commit_record(trace, db, 1.14)
+    record = query(db, mod, target, "record")
+    assert record is not None and record.run_secs[0].value == 1.14
+    sch_res = query(db, mod, target, "schedule")
+    assert sch_res is not None and tvm.ir.structural_equal(sch_res.mod, sch.mod)
+    mod_res = query(db, mod, target, "ir_module")
+    assert mod_res is not None and tvm.ir.structural_equal(mod_res, sch.mod)
+
+    commit_record(Schedule(mod).trace, db, 0.514)  # Empty Trace
+    record = query(db, mod, target, "record")
+    assert record is not None and record.run_secs[0].value == 0.514
+    sch_res = query(db, mod, target, "schedule")
+    assert sch_res is not None and tvm.ir.structural_equal(sch_res.mod, mod)
+    mod_res = query(db, mod, target, "ir_module")
+    assert mod_res is not None and tvm.ir.structural_equal(mod_res, mod)
+
+
+def test_meta_schedule_pydatabase_current():
+    db = PyMemoryDatabaseDefault()  # pylint: disable=invalid-name
+    with db:
+        assert ms.database.PyDatabase.current() == db
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_meta_schedule_database.py
+++ b/tests/python/unittest/test_meta_schedule_database.py
@@ -18,7 +18,6 @@
 """Test Meta Schedule Database"""
 import os.path as osp
 import tempfile
-from tkinter.messagebox import NO
 from typing import Callable, Optional, List
 
 import tvm


### PR DESCRIPTION
This PR follows up #12520 and completes the functions in PyDatabase class and make sure we can override the `query_tuning_records`, `query_schedule` and `query_ir_module` function. Meanwhile, user can also use `query` function or use PyDatabase as a context.