### PR TITLE
[ci] Lint PR title/body for @ tags

### DIFF
--- a/ci/scripts/check_pr.py
+++ b/ci/scripts/check_pr.py
@@ -69,19 +69,17 @@ def trailing_period(s: str):
 title_checks = [
     Check(check=non_empty, error_fn=lambda d: "PR must have a title but title was empty"),
     Check(check=trailing_period, error_fn=lambda d: "PR must not end in a tailing '.'"),
-    # TODO(driazati): enable this check once https://github.com/apache/tvm/issues/12637 is done
-    # Check(
-    #     check=usernames,
-    #     error_fn=lambda d: f"PR title must not tag anyone but found these usernames: {d}",
-    # ),
+    Check(
+        check=usernames,
+        error_fn=lambda d: f"PR title must not tag anyone but found these usernames: {d}",
+    ),
 ]
 body_checks = [
     Check(check=non_empty, error_fn=lambda d: "PR must have a body but body was empty"),
-    # TODO(driazati): enable this check once https://github.com/apache/tvm/issues/12637 is done
-    # Check(
-    #     check=usernames,
-    #     error_fn=lambda d: f"PR body must not tag anyone but found these usernames: {d}",
-    # ),
+    Check(
+        check=usernames,
+        error_fn=lambda d: f"PR body must not tag anyone but found these usernames: {d}",
+    ),
 ]
 
 

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -1327,6 +1327,18 @@ def test_should_rebuild_docker(tmpdir_factory, changed_files, name, check, expec
         expected="non_empty: FAILED",
         expected_code=1,
     ),
+    user_title=dict(
+        title="[something] a change @someon",
+        body="hello",
+        expected="usernames: FAILED: PR title must not tag",
+        expected_code=1,
+    ),
+    user_body=dict(
+        title="[something] a change",
+        body="hello\n\n cc @someone",
+        expected="usernames: FAILED: PR body must not tag",
+        expected_code=1,
+    ),
 )
 def test_pr_linter(title, body, expected, expected_code):
     """


### PR DESCRIPTION
This ensures that no users are tagged directly in PR titles or
descriptions, which lets us finally turn this on
https://github.blog/changelog/2022-08-23-new-options-for-controlling-the-default-commit-message-when-merging-a-pull-request/