### PR TITLE
Fix a typo in rpc/client.py

### DIFF
--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -32,7 +32,7 @@ from . import _ffi_api, base, server
 class RPCSession(object):
     """RPC Client session module
 
-    Do not directly create the obhect, call connect
+    Do not directly create the object, call connect
     """
 
     # pylint: disable=invalid-name


### PR DESCRIPTION
This PR fixes a typo in rpc/client.py