### PR TITLE
[FIX,PROFILING] Fix gpu timer name and lookup

### DIFF
--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -255,6 +255,8 @@ TVM_REGISTER_GLOBAL("device_api.cuda_host").set_body([](TVMArgs args, TVMRetValu
 class GPUTimerNode : public TimerNode {
  public:
   virtual void Start() {
+    // This initial cudaEventRecord is sometimes pretty slow (~100us). Does
+    // cudaEventRecord do some stream synchronization?
     CUDA_CALL(cudaEventRecord(start_, CUDAThreadEntry::ThreadLocal()->stream));
   }
   virtual void Stop() { CUDA_CALL(cudaEventRecord(stop_, CUDAThreadEntry::ThreadLocal()->stream)); }
@@ -283,7 +285,7 @@ class GPUTimerNode : public TimerNode {
 
 TVM_REGISTER_OBJECT_TYPE(GPUTimerNode);
 
-TVM_REGISTER_GLOBAL("profiling.timer.gpu").set_body_typed([](Device dev) {
+TVM_REGISTER_GLOBAL("profiling.timer.cuda").set_body_typed([](Device dev) {
   return Timer(make_object<GPUTimerNode>());
 });
 

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -252,7 +252,7 @@ TVM_REGISTER_GLOBAL("device_api.cuda_host").set_body([](TVMArgs args, TVMRetValu
   *rv = static_cast<void*>(ptr);
 });
 
-class GPUTimerNode : public TimerNode {
+class CUDATimerNode : public TimerNode {
  public:
   virtual void Start() {
     // This initial cudaEventRecord is sometimes pretty slow (~100us). Does
@@ -266,27 +266,27 @@ class GPUTimerNode : public TimerNode {
     CUDA_CALL(cudaEventElapsedTime(&milliseconds, start_, stop_));
     return milliseconds * 1e6;
   }
-  virtual ~GPUTimerNode() {
+  virtual ~CUDATimerNode() {
     CUDA_CALL(cudaEventDestroy(start_));
     CUDA_CALL(cudaEventDestroy(stop_));
   }
-  GPUTimerNode() {
+  CUDATimerNode() {
     CUDA_CALL(cudaEventCreate(&start_));
     CUDA_CALL(cudaEventCreate(&stop_));
   }
 
-  static constexpr const char* _type_key = "GPUTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(GPUTimerNode, TimerNode);
+  static constexpr const char* _type_key = "CUDATimerNode";
+  TVM_DECLARE_FINAL_OBJECT_INFO(CUDATimerNode, TimerNode);
 
  private:
   cudaEvent_t start_;
   cudaEvent_t stop_;
 };
 
-TVM_REGISTER_OBJECT_TYPE(GPUTimerNode);
+TVM_REGISTER_OBJECT_TYPE(CUDATimerNode);
 
 TVM_REGISTER_GLOBAL("profiling.timer.cuda").set_body_typed([](Device dev) {
-  return Timer(make_object<GPUTimerNode>());
+  return Timer(make_object<CUDATimerNode>());
 });
 
 TVM_DLL String GetCudaFreeMemory() {


### PR DESCRIPTION
In the switch from gpu to cuda naming, the cuda timer was passed over. Renaming it to "profiling.timer.cuda" so it is correctly picked up by the timing mechanisms.

@AndrewZhaoLuo 