### PR TITLE
[Hexagon] Support template-free meta schedule tuning

### DIFF
--- a/python/tvm/meta_schedule/default_config.py
+++ b/python/tvm/meta_schedule/default_config.py
@@ -310,7 +310,7 @@ class _DefaultHexagon:
                 ),
             ),
             M.ParallelizeVectorizeUnroll(
-                max_jobs_per_core=-1,
+                max_jobs_per_core=16,
                 max_vectorize_extent=128,
                 unroll_max_steps=[0, 16, 64, 512],
                 unroll_explicit=True,

--- a/python/tvm/meta_schedule/default_config.py
+++ b/python/tvm/meta_schedule/default_config.py
@@ -326,7 +326,7 @@ class _DefaultHexagon:
             M.RewriteParallelVectorizeUnroll(),
             M.RewriteReductionBlock(),
             # TODO(masahi): Fix RewriteLayout for link-params=True case
-            M.RewriteLayout(),
+            # M.RewriteLayout(),
         ]
 
 

--- a/python/tvm/meta_schedule/default_config.py
+++ b/python/tvm/meta_schedule/default_config.py
@@ -325,6 +325,8 @@ class _DefaultHexagon:
             M.DisallowDynamicLoop(),
             M.RewriteParallelVectorizeUnroll(),
             M.RewriteReductionBlock(),
+            # TODO(masahi): Fix RewriteLayout for link-params=True case
+            M.RewriteLayout(),
         ]
 
 

--- a/python/tvm/meta_schedule/default_config.py
+++ b/python/tvm/meta_schedule/default_config.py
@@ -174,10 +174,12 @@ def schedule_rules(  # pylint: disable=redefined-outer-name
         return sch_rules()
     if sch_rules is not None:
         raise TypeError(f"Expected `sch_rules` to be None or callable, but gets: {sch_rules}")
-    if target.kind.name in ["llvm", "hexagon"]:
+    if target.kind.name == "llvm":
         return _DefaultLLVM.schedule_rules()
     if target.kind.name in ["cuda", "rocm", "vulkan"]:
         return _DefaultCUDA.schedule_rules()
+    if target.kind.name == "hexagon":
+        return _DefaultHexagon.schedule_rules()
     raise ValueError(f"Unsupported target: {target}")
 
 
@@ -190,10 +192,12 @@ def postproc(  # pylint: disable=redefined-outer-name
         return postproc()
     if postproc is not None:
         raise TypeError(f"Expected `postproc` to be None or callable, but gets: {postproc}")
-    if target.kind.name in ["llvm", "hexagon"]:
+    if target.kind.name == "llvm":
         return _DefaultLLVM.postprocs()
     if target.kind.name in ["cuda", "rocm", "vulkan"]:
         return _DefaultCUDA.postprocs()
+    if target.kind.name == "hexagon":
+        return _DefaultHexagon.postprocs()
     raise ValueError(f"Unsupported target: {target}")
 
 
@@ -275,6 +279,53 @@ class _DefaultLLVM:
             M.MutateUnroll(): 0.03,
             M.MutateParallel(max_jobs_per_core=16): 0.02,
         }
+
+
+class _DefaultHexagon:
+    """Default tuning configuration for Hexagon."""
+
+    @staticmethod
+    def schedule_rules() -> List[ScheduleRule]:
+        from tvm.meta_schedule import schedule_rule as M
+
+        return [
+            M.AutoInline(
+                into_producer=False,
+                into_consumer=True,
+                inline_const_tensor=True,
+                disallow_if_then_else=True,
+                require_injective=True,
+                require_ordered=True,
+                disallow_op=["tir.exp"],
+            ),
+            M.MultiLevelTilingWideVector(
+                structure="SRSRS",
+                vector_length_in_bits=1024,
+                max_innermost_factor=128,
+                reuse_read=None,
+                reuse_write=M.ReuseType(
+                    req="may",
+                    levels=[1, 2],
+                    scope="global",
+                ),
+            ),
+            M.ParallelizeVectorizeUnroll(
+                max_jobs_per_core=-1,
+                max_vectorize_extent=128,
+                unroll_max_steps=[0, 16, 64, 512],
+                unroll_explicit=True,
+            ),
+        ]
+
+    @staticmethod
+    def postprocs() -> List[Postproc]:
+        from tvm.meta_schedule import postproc as M
+
+        return [
+            M.DisallowDynamicLoop(),
+            M.RewriteParallelVectorizeUnroll(),
+            M.RewriteReductionBlock(),
+        ]
 
 
 class _DefaultCUDA:


### PR DESCRIPTION
Building on https://github.com/apache/tvm/pull/12845, this PR adds an initial support for template-free auto tuning on Hexagon.

Test cases demonstrate:
* Auto-scheduler style, template free tuning for fp16 conv2d in NHWC layout.
* `vrmpy` auto tensorization for TE int8 `dense` (weight pre-packed), achieving 440 GOPs on SD888. 

Known issues:
* Due to the issue explained in https://github.com/apache/tvm/pull/12706, `link-params = True`, required by Hexagon, causes identical workloads to be tuned as distinct tasks. So e2d tuning is very slow without the changes from 12706.
* Tuning `nn.dense` essentially requires metaschedule `RewriteLayout` postproc: I found that the memory access pattern of `nn.dense`, `C[i, j] += A[i, k] * B[j, k]`, where the `j` axis is vectorized, performs terribly on Hexagon. But the implementation of `RewriteLayout` is completely incompatible with `link-params = True`. Until we fix this, we cannot  enable `RewriteLayout` for Hexagon and hence tuning `nn.dense` (and `nn.batch_matmul`) is not supported for now.

cc @kparzysz-quic @junrushao @tmoreau89 