### PR TITLE
[frontend][torch] Support aten::relu6 operator

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -840,6 +840,10 @@ class PyTorchOpConverter:
             return qnn_torch.quantized_relu(data, input_zero_point)
         return _op.nn.relu(data)
 
+    def relu6(self, inputs, input_types):
+        data = inputs[0]
+        return _op.tensor.clip(data, 0.0, 6.0)
+
     def prelu(self, inputs, input_types):
         # Reference: https://pytorch.org/docs/stable/generated/torch.nn.PReLU.html#torch.nn.PReLU
         data = inputs[0]
@@ -3477,6 +3481,7 @@ class PyTorchOpConverter:
             "aten::where": self.where,
             "aten::topk": self.topk,
             "aten::relu": self.relu,
+            "aten::relu6": self.relu6,
             "aten::prelu": self.prelu,
             "aten::leaky_relu": self.leaky_relu,
             "aten::elu": self.elu,

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -699,6 +699,15 @@ def test_forward_relu():
 
 
 @tvm.testing.uses_gpu
+def test_forward_relu6():
+    """test_forward_relu6"""
+    torch.set_grad_enabled(False)
+    input_shape = [10, 10]
+    input_data = torch.rand(input_shape).float()
+    verify_model(torch.nn.ReLU6().eval(), input_data=input_data)
+
+
+@tvm.testing.uses_gpu
 def test_forward_prelu():
     """test_forward_prelu"""
     torch.set_grad_enabled(False)


### PR DESCRIPTION
Hi, tvm：
    When I use tvm pytorch frontend  to load  model `vovnet19`. I get a error:    `NotImplementedError: The following operators are not implemented: ['aten::relu6_']`.
    I tried adding an implementation of this operator,and then i success load my model and run success.
    Hope to get your advice and review. Thanks.