### PR TITLE
[microTVM] Generalize depthwise_conv2d schedule

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -241,13 +241,18 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
 
             elif (
                 target.features.has_dsp
-                and kernel.shape[0] == kernel.shape[1] == 3
                 and dilation_w == dilation_h == 1
                 and kernel.shape[3] == 1  # channel_multiplier == 1
-                and data.dtype == "int8"
+                and data.dtype in ["int8", "int16"]
                 and out_type.dtype == "int32"
-                and data.shape[3] % 4 == 0
-                and (padding != "SAME" or data.shape[1] % stride_h == data.shape[2] % stride_w == 0)
+                and (
+                    data.shape[3] % 4 == 0 and data.dtype == "int8" or
+                    data.shape[3] % 2 == 0 and data.dtype == "int16"
+                )
+                and (
+                    padding != "SAME" or
+                    data.shape[1] % stride_h == data.shape[2] % stride_w == 0
+                )
             ):
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nhwc_dsp),

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -119,8 +119,6 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                 is_winograd_applicable = (
                     "float" in data.dtype
                     and "float" in kernel.dtype
-                    and kh == 3
-                    and kw == 3
                     and stride_h == 1
                     and stride_w == 1
                     and dilation_h == 1

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -252,6 +252,8 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                     or (data.shape[3] % 2 == 0 and data.dtype == "int16")
                 )
                 and (padding != "SAME" or data.shape[1] % stride_h == data.shape[2] % stride_w == 0)
+                # Ideally we should check that kernel is a Relay constant, but strategy functions
+                # don't have access to the data needed to check this.
             ):
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nhwc_dsp),

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -119,6 +119,8 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                 is_winograd_applicable = (
                     "float" in data.dtype
                     and "float" in kernel.dtype
+                    and kh == 3
+                    and kw == 3
                     and stride_h == 1
                     and stride_w == 1
                     and dilation_h == 1

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -237,22 +237,19 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
             # Optimized special case depthwiseConv2D operation. Requires NHWC layout,
             # a HWOI kernel layout (which we rearrange to a custom layout) no dilation,
             # int8/16 inputs, int32 output, and the same number of input and output channels.
-            # and for that channel
-            # count to be divisible by 4. Additional work could remove these restrictions.
+            # The int8 implementation DOES need the DSP unit (for SXTB16), but it is not
+            # possible to use the DSP unit to speed up a NHWC depthwise convolution (though
+            # an NCHW convolution would benefit).
 
             elif (
-                and dilation_w == dilation_h == 1
+                dilation_w == dilation_h == 1
                 and kernel.shape[3] == 1  # channel_multiplier == 1
-                and data.dtype in ["int8", "int16"]
                 and out_type.dtype == "int32"
                 and (
-                    (data.shape[3] % 4 == 0 and data.dtype == "int8" and target.features.has_dsp) or
-                    (data.shape[3] % 2 == 0 and data.dtype == "int16")
+                    (data.shape[3] % 4 == 0 and data.dtype == "int8" and target.features.has_dsp)
+                    or (data.shape[3] % 2 == 0 and data.dtype == "int16")
                 )
-                and (
-                    padding != "SAME" or
-                    data.shape[1] % stride_h == data.shape[2] % stride_w == 0
-                )
+                and (padding != "SAME" or data.shape[1] % stride_h == data.shape[2] % stride_w == 0)
             ):
                 strategy.add_implementation(
                     wrap_compute_conv2d(topi.arm_cpu.depthwise_conv2d_nhwc_dsp),

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -134,6 +134,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
         CHWc_kernel_np = np.zeros((channels // simd_width, KH, KW, simd_width), dtype=kernel.dtype)
         for i in range(channels // simd_width):
             CHWc_kernel_np[i] = HWOI_kernel_np[:, :, simd_width * i : simd_width * (i + 1), 0]
+        reshaped_new_kernel = CHWc_kernel_np.reshape(KH, KW, channels, 1)
 
         # Store the same config for the altered operator (workload)
         new_data = data
@@ -145,7 +146,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
         dispatch_ctx.update(target, new_workload, cfg)
         return relay.nn.conv2d(
             inputs[0],
-            relay.Constant(tvm.nd.array(CHWc_kernel_np.reshape(KH, KW, channels, 1))),
+            relay.Constant(tvm.nd.array(reshaped_new_kernel)),
             **new_attrs,
         )
 

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -124,7 +124,6 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
 
     idxd = tvm.tir.indexdiv
 
-
     if topi_tmpl == "depthwise_conv2d_nhwc_dsp.arm_cpu":
         assert data_layout == "NHWC" and kernel_layout == "HWOI"
         channels = get_const_tuple(data.shape)[3]
@@ -134,7 +133,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
         HWOI_kernel_np = inputs[1].data.numpy()
         CHWc_kernel_np = np.zeros((channels // simd_width, KH, KW, simd_width), dtype=kernel.dtype)
         for i in range(channels // simd_width):
-            CHWc_kernel_np[i] = HWOI_kernel_np[:, :, simd_width*i:simd_width*(i+1), 0]
+            CHWc_kernel_np[i] = HWOI_kernel_np[:, :, simd_width * i : simd_width * (i + 1), 0]
 
         # Store the same config for the altered operator (workload)
         new_data = data
@@ -147,7 +146,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
         return relay.nn.conv2d(
             inputs[0],
             relay.Constant(tvm.nd.array(CHWc_kernel_np.reshape(KH, KW, channels, 1))),
-            **new_attrs
+            **new_attrs,
         )
 
     # Only microTVM does layout alteration for NHWC layout with real data types

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -129,7 +129,9 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
 
         # We are not able to check if inputs[1] (the kernel) is a constant in the
         # strategy function, so as a stopgap solution we use an assert here.
-        assert isinstance(inputs[1], relay.Constant)
+        assert isinstance(
+            inputs[1], relay.Constant
+        ), "depthwise_conv2d_nhwc_dsp.arm_cpu requires kernel be a relay Constant"
 
         channels = get_const_tuple(data.shape)[3]
         KH, KW, _, _ = get_const_tuple(kernel.shape)

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -126,7 +126,11 @@ def _alter_conv2d_layout(attrs, inputs, tinfos, out_type):
 
     if topi_tmpl == "depthwise_conv2d_nhwc_dsp.arm_cpu":
         assert data_layout == "NHWC" and kernel_layout == "HWOI"
+
+        # We are not able to check if inputs[1] (the kernel) is a constant in the
+        # strategy function, so as a stopgap solution we use an assert here.
         assert isinstance(inputs[1], relay.Constant)
+
         channels = get_const_tuple(data.shape)[3]
         KH, KW, _, _ = get_const_tuple(kernel.shape)
         simd_lanes = num_simd_lanes_per_word(data.dtype)

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
@@ -30,17 +30,17 @@ common_includes = """
 
 """
 
-MICRO_WORD_LENGTH = 32
+MICRO_WORD_LENGTH_BITS = 32
 
 
-def get_dtype_simd_width(dtype: str) -> int:
+def num_simd_lanes_per_word(dtype: str) -> int:
     """Takes a dtype, and returns how many of that dtype fit into a single microcontroller word.
 
-    >>> get_dtype_simd_width("int8")
+    >>> num_simd_lanes_per_word("int8")
     4
-    >>> get_dtype_simd_width("int16")
+    >>> num_simd_lanes_per_word("int16")
     2
     """
-    assert dtype[0:3] == "int"
+    assert dtype.startswith("int")
     dtype_width = int(dtype[3:])
-    return MICRO_WORD_LENGTH // dtype_width
+    return MICRO_WORD_LENGTH_BITS // dtype_width

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
@@ -29,3 +29,17 @@ common_includes = """
 #include <tvm/runtime/crt/error_codes.h>
 
 """
+
+MICRO_WORD_LENGTH = 32
+
+def get_dtype_simd_width(dtype: str) -> int:
+    """Takes a dtype, and returns how many of that dtype fit into a single microcontroller word.
+
+    >>> get_dtype_simd_width("int8")
+    4
+    >>> get_dtype_simd_width("int16")
+    2
+    """
+    assert dtype[0:3] == "int"
+    dtype_width = int(dtype[3:])
+    return MICRO_WORD_LENGTH // dtype_width

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/common.py
@@ -32,6 +32,7 @@ common_includes = """
 
 MICRO_WORD_LENGTH = 32
 
+
 def get_dtype_simd_width(dtype: str) -> int:
     """Takes a dtype, and returns how many of that dtype fit into a single microcontroller word.
 

--- a/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
+++ b/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
@@ -167,10 +167,11 @@ class TestDepthwiseConv2d_NHWC_HWOI_DSP(BasicDepthwiseConv2dTests):
         ((1, 25, 5, 64), (3, 3), 64, (1, 1), 1, 1),
         # Larger kernel
         ((1, 24, 24, 8), (5, 5), 8, (1, 1), 1, 1),
+        # Asymmetric kernel
         ((1, 24, 24, 8), (3, 5), 8, (1, 1), 1, 1),
     )
     data_layout = tvm.testing.parameter("NHWC")
-    dtype = tvm.testing.parameter("int8")
+    dtype = tvm.testing.parameter("int8", "int16")
     kernel_layout = tvm.testing.parameter("HWOI")
     schedule_name = tvm.testing.parameter("depthwise_conv2d_nhwc_dsp.arm_cpu")
 

--- a/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
+++ b/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
@@ -150,28 +150,37 @@ class TestDepthwiseConv2d_NHWC_HWOI(BasicDepthwiseConv2dTests):
 class TestDepthwiseConv2d_NHWC_HWOI_DSP(BasicDepthwiseConv2dTests):
     """This test is for depthwise_conv2d_nhwc_dsp.arm_cpu schedule."""
 
-    data_shape, kernel_size, num_filter, strides, padding, dilation = tvm.testing.parameters(
-        # The LLVM implementation doesn't support "SAME" and "VALID" padding,
-        # so padding must be explicitly specified.
-        # Depthwise_conv2d parameters from MobileNetV1 0.25x
-        ((1, 48, 48, 8), (3, 3), 8, (1, 1), 1, 1),
-        ((1, 48, 48, 16), (3, 3), 16, (2, 2), (1, 1, 0, 0), 1),
-        ((1, 24, 24, 32), (3, 3), 32, (1, 1), 1, 1),
-        ((1, 24, 24, 32), (3, 3), 32, (2, 2), (1, 1, 0, 0), 1),
-        ((1, 12, 12, 64), (3, 3), 64, (1, 1), 1, 1),
-        ((1, 12, 12, 64), (3, 3), 64, (2, 2), (1, 1, 0, 0), 1),
-        ((1, 6, 6, 128), (3, 3), 128, (1, 1), 1, 1),
-        ((1, 6, 6, 128), (3, 3), 128, (2, 2), (1, 1, 0, 0), 1),
-        ((1, 3, 3, 256), (3, 3), 256, (1, 1), 1, 1),
+    # Tests that work with both int8 and int16 data types. Tuple elements are:
+    # data_shape, kernel_size, num_filter, strides, padding
+    dtype_parameterized_tests = [
+        # Depthwise_conv2d parameters from MobileNetV1 0.25x. The LLVM implementation doesn't
+        # support "SAME" and "VALID" padding, so padding must be explicitly specified.
+        ((1, 48, 48, 8), (3, 3), 8, (1, 1), 1),
+        ((1, 48, 48, 16), (3, 3), 16, (2, 2), (1, 1, 0, 0)),
+        ((1, 24, 24, 32), (3, 3), 32, (1, 1), 1),
+        ((1, 24, 24, 32), (3, 3), 32, (2, 2), (1, 1, 0, 0)),
+        ((1, 12, 12, 64), (3, 3), 64, (1, 1), 1),
+        ((1, 12, 12, 64), (3, 3), 64, (2, 2), (1, 1, 0, 0)),
+        ((1, 6, 6, 128), (3, 3), 128, (1, 1), 1),
+        ((1, 6, 6, 128), (3, 3), 128, (2, 2), (1, 1, 0, 0)),
+        ((1, 3, 3, 256), (3, 3), 256, (1, 1), 1),
         # Asymmetric height and width
-        ((1, 25, 5, 64), (3, 3), 64, (1, 1), 1, 1),
+        ((1, 25, 5, 64), (3, 3), 64, (1, 1), 1),
         # Larger kernel
-        ((1, 24, 24, 8), (5, 5), 8, (1, 1), 1, 1),
+        ((1, 24, 24, 8), (5, 5), 8, (1, 1), 1),
         # Asymmetric kernel
-        ((1, 24, 24, 8), (3, 5), 8, (1, 1), 1, 1),
+        ((1, 24, 24, 8), (3, 5), 8, (1, 1), 1),
+    ]
+
+    data_shape, kernel_size, num_filter, strides, padding, dtype = tvm.testing.parameters(
+        # Make a copy of each parameterized test for int8 and one for int16
+        *map(lambda t: t + ("int8",), dtype_parameterized_tests),
+        *map(lambda t: t + ("int16",), dtype_parameterized_tests),
+        # Test the int16 implementation with channel numbers not divisible by four
+        ((1, 48, 48, 6), (3, 3), 6, (1, 1), 1, "int16"),
     )
+    dilation = tvm.testing.parameter(1)
     data_layout = tvm.testing.parameter("NHWC")
-    dtype = tvm.testing.parameter("int8", "int16")
     kernel_layout = tvm.testing.parameter("HWOI")
     schedule_name = tvm.testing.parameter("depthwise_conv2d_nhwc_dsp.arm_cpu")
 

--- a/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
+++ b/tests/python/relay/strategy/arm_cpu/test_depthwise_conv2d.py
@@ -165,6 +165,9 @@ class TestDepthwiseConv2d_NHWC_HWOI_DSP(BasicDepthwiseConv2dTests):
         ((1, 3, 3, 256), (3, 3), 256, (1, 1), 1, 1),
         # Asymmetric height and width
         ((1, 25, 5, 64), (3, 3), 64, (1, 1), 1, 1),
+        # Larger kernel
+        ((1, 24, 24, 8), (5, 5), 8, (1, 1), 1, 1),
+        ((1, 24, 24, 8), (3, 5), 8, (1, 1), 1, 1),
     )
     data_layout = tvm.testing.parameter("NHWC")
     dtype = tvm.testing.parameter("int8")


### PR DESCRIPTION
This pull request removes a number of restrictions on the usage of the `depthwise_conv2d` schedule for microTVM. It:
- Adds support for the `int16` input data type
- Adds support for arbitrarily-sized (including asymmetric) kernels
- Allows the `int16` version to run on Cortex-M0 and M3 (which do not have SIMD instructions)
  - This is accomplished without performance loss
  - Adds unit tests for these features
 
It also removes use of the `SMLAD` instruction, which cannot improve performance on `NHWC` layouts (discussion about why in the comments below). This results in a slight performance boost for depthwise convolutions where `kernel_width * kernel_height` is odd, and no change otherwise. It also contains some readability improvements.

Known issue: [my call to `topi.reshape` in `depthwise_conv2d.py`](https://github.com/guberti/tvm/blob/5bba3d0524491fe74cf33932170110768e35cf43/python/tvm/topi/arm_cpu/mprofile/dsp/depthwise_conv2d.py#L116) results in useless C code being generated that unnecessarily duplicates an array. The performance hit  from this is small, but it is a gross issue.