### PR TITLE
[frontend][pytorch] Add a new test case for torch aten::fill_ operator implementation

### DIFF
--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -3332,6 +3332,16 @@ def test_forward_fill_():
     verify_model_with_input(test_func, [torch.rand([1, 3, 10, 10]).float()])
 
 
+def test_forward_fill_with_div():
+    """test_forward_fill_with_div"""
+
+    def test_func(x):
+        y = torch.div(torch.tensor(6.0), torch.tensor(2.0))
+        return x.fill_(y)
+
+    verify_model_with_input(test_func, [torch.rand([1, 3, 10, 10]).float()])
+
+
 @tvm.testing.uses_gpu
 def test_forward_linspace():
     """test_forward_linspace"""


### PR DESCRIPTION
Add a new test case for torch `aten::fill_` operator implementation.

This new test is testing a case of usage of a sequence of operators `aten::div()` and `aten::fill_() `that was causing a failure during the deployment of Mask R-CNN model (torchvision 0.13.0 version of the model).

Issue: #12844 