### PR TITLE
[FIX,PROFILING] Fix PAPI docs

### DIFF
--- a/docs/how_to/profile/papi.rst
+++ b/docs/how_to/profile/papi.rst
@@ -62,6 +62,12 @@ is an example:
 
 .. code:: python
 
+    import tvm
+    from tvm import relay
+    from tvm.relay.testing import mlp
+    from tvm.runtime import profiler_vm
+    import numpy as np
+
     target = "llvm"
     dev = tvm.cpu()
     mod, params = mlp.get_workload(1)
@@ -71,7 +77,7 @@ is an example:
 
     data = tvm.nd.array(np.random.rand(1, 1, 28, 28).astype("float32"), device=dev)
     report = vm.profile(
-        [data],
+        data,
         func_name="main",
         collectors=[tvm.runtime.profiling.PAPIMetricCollector()],
     )
@@ -94,7 +100,7 @@ You can also change which metrics are collected:
 .. code:: python
 
     report = vm.profile(
-        [data],
+        data,
         func_name="main",
         collectors=[tvm.runtime.profiling.PAPIMetricCollector({dev: ["PAPI_FP_OPS"])],
     )


### PR DESCRIPTION
The VM requires arguements to not be wrapped in an array. Passing the arguments unwrapped now. Also added relevant imports.

@AndrewZhaoLuo 