### PR TITLE
[TIR][Arith] Prove conditionals by transitively applying knowns

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -390,7 +390,7 @@ class TransitiveComparisonAnalyzer {
   TVM_DLL ~TransitiveComparisonAnalyzer();
   class Impl;
   /*! \brief Internal impl */
-  std::unique_ptr<Impl> impl_{nullptr};
+  std::unique_ptr<Impl> impl_;
 };
 
 /*!

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -273,7 +273,7 @@ class RewriteSimplifier {
    *
    * \return an exit function that must be called to cleanup the constraint can be nullptr.
    */
-  std::function<void()> EnterConstraint(const PrimExpr& constraint);
+  TVM_DLL std::function<void()> EnterConstraint(const PrimExpr& constraint);
 
   /*! \brief Flags to enable more computationally-intensive simplifications
    *
@@ -304,10 +304,10 @@ class RewriteSimplifier {
    * \param flags A bitwise OR of all optional extensions that should
    * be enabled.
    */
-  void SetEnabledExtensions(Extension flags);
+  TVM_DLL void SetEnabledExtensions(Extension flags);
 
   /*! \brief Return the currently enabled extensions */
-  Extension GetEnabledExtensions() const;
+  TVM_DLL Extension GetEnabledExtensions() const;
 
  private:
   friend class Analyzer;
@@ -391,7 +391,7 @@ class TransitiveComparisonAnalyzer {
    * \return The most specific result that can be proven about the
    * comparison.  If nothing can be proven, returns kUnknown.
    */
-  CompareResult TryCompare(const PrimExpr& lhs, const PrimExpr& rhs);
+  TVM_DLL CompareResult TryCompare(const PrimExpr& lhs, const PrimExpr& rhs);
 
   /*! \brief Bind a variable as being equal to a known expression
    *
@@ -399,7 +399,7 @@ class TransitiveComparisonAnalyzer {
    * \param expr The bound expression
    * \param allow_override Whether to allow override of existing information.
    */
-  void Bind(const Var& var, const PrimExpr& expr, bool allow_override = false);
+  TVM_DLL void Bind(const Var& var, const PrimExpr& expr, bool allow_override = false);
 
   /*! \brief Bind a variable as being within a specified range
    *
@@ -407,7 +407,7 @@ class TransitiveComparisonAnalyzer {
    * \param range The known range
    * \param allow_override Whether to allow override of existing information.
    */
-  void Bind(const Var& var, const Range& range, bool allow_override = false);
+  TVM_DLL void Bind(const Var& var, const Range& range, bool allow_override = false);
 
   /*!
    * \brief Update the internal state to enter constraint.
@@ -415,7 +415,7 @@ class TransitiveComparisonAnalyzer {
    *
    * \return an exit function that must be called to cleanup the constraint can be nullptr.
    */
-  std::function<void()> EnterConstraint(const PrimExpr& constraint);
+  TVM_DLL std::function<void()> EnterConstraint(const PrimExpr& constraint);
 
  private:
   friend class Analyzer;

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -275,6 +275,36 @@ class RewriteSimplifier {
    */
   std::function<void()> EnterConstraint(const PrimExpr& constraint);
 
+  /*! \brief Flags to enable more computationally-intensive simplifications
+   *
+   * These simplifications may be required for specific schedules, but
+   * would impose too high a compile-time cost to enable by default.
+   * They can be enabled on an as-needed basis by calling
+   * `RewriteSimplifier::SetEnabledFeatures` prior to using
+   * `RewriteSimplifier::operator()`.
+   */
+  enum Feature {
+    // No features enabled
+    kNone = 0,
+
+    /* When simplifying an inequality, attempt to use scope-based knowns.
+     *
+     * Example:
+     * if_then_else(i<j && j<k, i<k, false) => if_then_else(i<j && j<k, true, false)
+     */
+    kTransitivelyProveInequalities = (1 << 0),
+  };
+
+  /*! \brief Enable an optional feature or features
+   *
+   * \param flags A bitwise OR of all optional features that should be
+   * enabled.
+   */
+  void SetEnabledFeatures(Feature flags);
+
+  /*! \brief Return the currently enabled features */
+  Feature GetEnabledFeatures() const;
+
  private:
   friend class Analyzer;
   friend class ConstraintContext;

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -280,15 +280,15 @@ class RewriteSimplifier {
    * These simplifications may be required for specific schedules, but
    * would impose too high a compile-time cost to enable by default.
    * They can be enabled on an as-needed basis by calling
-   * `RewriteSimplifier::SetEnabledFeatures` prior to using
+   * `RewriteSimplifier::SetEnabledExtensions` prior to using
    * `RewriteSimplifier::operator()`.
    *
    * Flags are defined as powers of two to allow future expansion.  To
-   * enable multiple features, a user should pass a bitwise OR of the
-   * desired feature flags.
+   * enable multiple extensions, a user should pass a bitwise OR of the
+   * flags for each desired extension.
    */
-  enum Feature {
-    // No features enabled
+  enum Extension {
+    // No extensions enabled
     kNone = 0,
 
     /* When simplifying an inequality, attempt to use scope-based knowns.
@@ -299,15 +299,15 @@ class RewriteSimplifier {
     kTransitivelyProveInequalities = (1 << 0),
   };
 
-  /*! \brief Enable an optional feature or features
+  /*! \brief Enable an optional extension or extensions
    *
-   * \param flags A bitwise OR of all optional features that should be
-   * enabled.
+   * \param flags A bitwise OR of all optional extensions that should
+   * be enabled.
    */
-  void SetEnabledFeatures(Feature flags);
+  void SetEnabledExtensions(Extension flags);
 
-  /*! \brief Return the currently enabled features */
-  Feature GetEnabledFeatures() const;
+  /*! \brief Return the currently enabled extensions */
+  Extension GetEnabledExtensions() const;
 
  private:
   friend class Analyzer;

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -282,6 +282,10 @@ class RewriteSimplifier {
    * They can be enabled on an as-needed basis by calling
    * `RewriteSimplifier::SetEnabledFeatures` prior to using
    * `RewriteSimplifier::operator()`.
+   *
+   * Flags are defined as powers of two to allow future expansion.  To
+   * enable multiple features, a user should pass a bitwise OR of the
+   * desired feature flags.
    */
   enum Feature {
     // No features enabled

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -45,6 +45,7 @@ void Analyzer::Bind(const Var& var, const PrimExpr& expr, bool allow_override) {
   this->rewrite_simplify.Update(var, new_expr, allow_override);
   this->canonical_simplify.Update(var, new_expr, allow_override);
   this->int_set.Update(var, this->int_set(new_expr), allow_override);
+  this->transitive_comparisons.Bind(var, expr, allow_override);
 }
 
 void Analyzer::Bind(const Var& var, const Range& range, bool allow_override) {
@@ -54,6 +55,7 @@ void Analyzer::Bind(const Var& var, const Range& range, bool allow_override) {
   } else {
     this->const_int_bound.Bind(var, range, allow_override);
     this->int_set.Bind(var, range, allow_override);
+    this->transitive_comparisons.Bind(var, range, allow_override);
   }
   // skip modular_set
   // skip rewrite simplify
@@ -72,6 +74,7 @@ void ConstraintContext::EnterWithScope() {
   recovery_functions_.push_back(analyzer_->modular_set.EnterConstraint(constraint_));
   recovery_functions_.push_back(analyzer_->rewrite_simplify.EnterConstraint(constraint_));
   recovery_functions_.push_back(analyzer_->int_set.EnterConstraint(constraint_));
+  recovery_functions_.push_back(analyzer_->transitive_comparisons.EnterConstraint(constraint_));
 }
 
 void ConstraintContext::ExitWithScope() {

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -891,7 +891,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const DivNode* op) {
           lhs.CopyOnWrite()->AddToSelf(pconst->value / cval);
         } else {
           // if 0 <= extra < cval, it means the extra can be eliminated.
-          if (TryCompare(temp, cval) != kLT) {
+          if (TryCompare(temp, cval) != CompareResult::kLT) {
             lhs.CopyOnWrite()->AddToSelf(SplitDivConst(ToSplitExpr(temp), cval, kTruncDiv), 1);
           }
         }
@@ -945,7 +945,8 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
         lhs.CopyOnWrite()->AddToSelf(floordiv(pconst->value, cval));
       } else {
         // if 0 <= extra < cval, it means the extra can be eliminated.
-        if (!(TryCompare(temp, cval) == kLT && analyzer_->CanProveGreaterEqual(temp, 0))) {
+        if (!(TryCompare(temp, cval) == CompareResult::kLT &&
+              analyzer_->CanProveGreaterEqual(temp, 0))) {
           lhs.CopyOnWrite()->AddToSelf(SplitDivConst(ToSplitExpr(temp), cval, kFloorDiv), 1);
         }
       }
@@ -1052,7 +1053,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const ModNode* op) {
           return truncmod(temp, c1.Eval());
         } else {
           // If temp < cval && temp >=0 then can remove the mod.
-          if (TryCompare(temp, cval) == kLT) {
+          if (TryCompare(temp, cval) == CompareResult::kLT) {
             return temp;
           } else {
             // contonue to use logic below.
@@ -1113,7 +1114,8 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
         return floormod(temp, c1.Eval());
       } else {
         // If temp < cval && temp >=0 then can remove the mod.
-        if (TryCompare(temp, cval) == kLT && analyzer_->CanProveGreaterEqual(temp, 0)) {
+        if (TryCompare(temp, cval) == CompareResult::kLT &&
+            analyzer_->CanProveGreaterEqual(temp, 0)) {
           return temp;
         } else {
           // contonue to use logic below.

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -83,7 +83,7 @@ CompareResult RewriteSimplifier::Impl::TryCompare(const PrimExpr& x, const PrimE
 
   if (is_finished()) return output;
 
-  if (flags_ & kTransitivelyProveInequalities) {
+  if (enabled_extensions_ & kTransitivelyProveInequalities) {
     output = CompareResult(output & TryCompareUsingKnownInequalities(x, y));
   }
 
@@ -282,15 +282,11 @@ std::function<void()> RewriteSimplifier::Impl::EnterConstraint(const PrimExpr& c
   return frecover;
 }
 
-/*! \brief Enable an optional feature or features
- *
- * \param flags A bitwise OR of all optional features that should be
- * enabled.
- */
-void RewriteSimplifier::Impl::SetEnabledFeatures(Feature flags) { flags_ = flags; }
+void RewriteSimplifier::Impl::SetEnabledExtensions(Extension flags) { enabled_extensions_ = flags; }
 
-/*! \brief Return the currently enabled features */
-RewriteSimplifier::Feature RewriteSimplifier::Impl::GetEnabledFeatures() const { return flags_; }
+RewriteSimplifier::Extension RewriteSimplifier::Impl::GetEnabledExtensions() const {
+  return enabled_extensions_;
+}
 
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const SubNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
@@ -1782,9 +1778,11 @@ std::function<void()> RewriteSimplifier::EnterConstraint(const PrimExpr& constra
   return impl_->EnterConstraint(constraint);
 }
 
-void RewriteSimplifier::SetEnabledFeatures(Feature flags) { impl_->SetEnabledFeatures(flags); }
-RewriteSimplifier::Feature RewriteSimplifier::GetEnabledFeatures() const {
-  return impl_->GetEnabledFeatures();
+void RewriteSimplifier::SetEnabledExtensions(Extension flags) {
+  impl_->SetEnabledExtensions(flags);
+}
+RewriteSimplifier::Extension RewriteSimplifier::GetEnabledExtensions() const {
+  return impl_->GetEnabledExtensions();
 }
 
 RewriteSimplifier::RewriteSimplifier(Analyzer* parent) : impl_(new Impl(parent)) {}

--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -77,15 +77,15 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
 
   std::function<void()> EnterConstraint(const PrimExpr& constraint);
 
-  /*! \brief Enable an optional feature or features
+  /*! \brief Enable an optional extension or extensions
    *
-   * \param flags A bitwise OR of all optional features that should be
-   * enabled.
+   * \param flags A bitwise OR of all optional extensions that should
+   * be enabled.
    */
-  void SetEnabledFeatures(Feature flags);
+  void SetEnabledExtensions(Extension flags);
 
-  /*! \brief Return the currently enabled features */
-  Feature GetEnabledFeatures() const;
+  /*! \brief Return the currently enabled extensions */
+  Extension GetEnabledExtensions() const;
 
  protected:
   // counter to record recursive rewrite depth.
@@ -95,8 +95,8 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
 
   std::vector<PrimExpr> literal_constraints_;
 
-  // Optionally enabled features
-  Feature flags_{kNone};
+  // Optionally enabled extensions
+  Extension enabled_extensions_{kNone};
 
   // maximum number of recursion allowed during a single pass.
   static const constexpr int kMaxRecurDepth = 5;

--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -77,6 +77,16 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
 
   std::function<void()> EnterConstraint(const PrimExpr& constraint);
 
+  /*! \brief Enable an optional feature or features
+   *
+   * \param flags A bitwise OR of all optional features that should be
+   * enabled.
+   */
+  void SetEnabledFeatures(Feature flags);
+
+  /*! \brief Return the currently enabled features */
+  Feature GetEnabledFeatures() const;
+
  protected:
   // counter to record recursive rewrite depth.
   int recur_depth_{0};
@@ -84,6 +94,9 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
   std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> var_map_;
 
   std::vector<PrimExpr> literal_constraints_;
+
+  // Optionally enabled features
+  Feature flags_{kNone};
 
   // maximum number of recursion allowed during a single pass.
   static const constexpr int kMaxRecurDepth = 5;

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -74,10 +74,62 @@ class TransitiveComparisonAnalyzer::Impl {
   std::function<void()> EnterConstraint(const PrimExpr& expr);
 
  private:
-  // Utility class to avoid needing to repeatedly call ExprDeepEqual
+  /* \brief Internal representation of a PrimExpr
+   *
+   * The Key enum serves two purposes.
+   *
+   * 1. Providing efficiency, as compared to a PrimExpr.  Two keys are
+   *    equal if and only if the corresponding PrimExprs would satisfy
+   *    ExprDeepEqual.  This allows two expressions to be checked for
+   *    equivalency, without requiring a call to ExprDeepEqual for
+   *    each comparison.
+   *
+   * 2. Providing type-safety, as compared to using `size_t` directly.
+   *    Requiring an explicit conversion from an integer to a Key
+   *    prevents accidental comparisons, especially if both loop
+   *    iterators and Keys are used in the same scope.
+   *
+   * A Key should only be obtained using the methods `ExprToKey` and
+   * `ExprToPreviousKey`.
+   */
   enum class Key : size_t {};
-  std::optional<Key> ExprToPreviousKey(const PrimExpr& expr) const;
+
+  /*! \brief Convert an expression to internal representation
+   *
+   * If the expression has previously been converted to the internal
+   * representation, returns the same Key as has been used previously.
+   * Otherwise, generate and return a new Key.
+   *
+   * \param expr The PrimExpr to be converted
+   *
+   * \returns The Key representing the expression
+   *
+   * \see ExprToPreviousKey
+   */
   Key ExprToKey(const PrimExpr& expr);
+
+  /*! \brief Convert an expression to internal representation
+   *
+   * If the expression has previously been converted to the internal
+   * representation, returns the same Key as has been used previously.
+   * Otherwise, return `std::nullopt`.
+   *
+   * \param expr The PrimExpr to be converted
+   *
+   * \returns The Key representing the expression, if one exists.
+   *
+   * \see ExprToKey
+   */
+  std::optional<Key> ExprToPreviousKey(const PrimExpr& expr) const;
+
+  /*! \brief The mapping from expression to Key
+   *
+   * Should not be used directly.  Instead, use the helper functions
+   * `ExprToKey` and `ExprToPreviousKey`.
+   *
+   * \see ExprToKey
+   * \see ExprToPreviousKey
+   */
   std::unordered_map<PrimExpr, Key, StructuralHash, StructuralEqual> expr_to_key;
 
   /*! \brief Internal representation of a comparison operator */

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -1,0 +1,683 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file tvm/arith/transitive_comparison_analyzer.cc
+ */
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/expr.h>
+
+#include <optional>
+#include <vector>
+
+#include "constraint_extract.h"
+#include "pattern_match.h"
+
+namespace tvm {
+namespace arith {
+
+using namespace tir;
+
+class TransitiveComparisonAnalyzer::Impl {
+ public:
+  /* \brief Using previously specified knowns, compare the expressions provided
+   *
+   * \param lhs The left-hand side of the comparison
+   *
+   * \param rhs The right-hand side of the comparison
+   *
+   * \return The most specific result that can be proven about the
+   * comparison.  If nothing can be proven, returns kUnknown.
+   */
+  CompareResult TryCompare(const PrimExpr& lhs, const PrimExpr& rhs) const;
+
+  /*! \brief Bind a variable as being equal to a known expression
+   *
+   * \param var The variable of interest.
+   * \param expr The bound expression
+   * \param allow_override Whether to allow override of existing information.
+   */
+  void Bind(const tir::Var& var, const PrimExpr& expr, bool allow_override = false);
+
+  /*! \brief Bind a variable as being within a specified range
+   *
+   * \param var The variable of interest.
+   * \param range The known range
+   * \param allow_override Whether to allow override of existing information.
+   */
+  void Bind(const tir::Var& var, const Range& expr, bool allow_override = false);
+
+  /*!
+   * \brief Update the internal state to enter constraint.
+   * \param constraint A constraint expression.
+   *
+   * \return An exit function that must be called to cleanup.  May be
+   * `nullptr`, if no cleanup is required.
+   */
+  std::function<void()> EnterConstraint(const PrimExpr& expr);
+
+ private:
+  // Utility class to avoid needing to repeatedly call ExprDeepEqual
+  enum class Key : size_t {};
+  std::optional<Key> ExprToPreviousKey(const PrimExpr& expr) const;
+  Key ExprToKey(const PrimExpr& expr);
+  std::unordered_map<PrimExpr, Key, StructuralHash, StructuralEqual> expr_to_key;
+
+  /*! \brief Internal representation of a comparison operator */
+  struct Comparison {
+    /*! \brief Construct a comparison that represents `lhs OP rhs +
+     * offset`, where the operation is specified by the CompareResult.
+     */
+    Comparison(Key lhs, Key rhs, int64_t offset, CompareResult result);
+
+    /*! \brief Utility function to validate that all GT and LT results
+     *  have been normalized out
+     */
+    bool IsNormalized() const;
+
+    /*! \brief Move the specified expression to the LHS.
+     *
+     * \param new_lhs The argument that should be moved to the LHS of the
+     * comparison.
+     *
+     * \return If possible, returns a comparison that is equivalent to
+     * the current comparison, but with the specified LHS.  If not
+     * possible, returns nullopt.
+     */
+    std::optional<Comparison> WithLHS(Key new_lhs) const;
+
+    /*! \brief Create the negation of the current comparison */
+    Comparison Negated() const;
+
+    /*! \brief Check the this comparison implies
+     *
+     * Returns true if this comparison being true implies that the
+     * other comparison must also be true.  Returns false if the other
+     * comparison cannot be shown to be true.
+     */
+    bool Implies(const Comparison& other) const;
+
+    // The LHS of the comparison
+    Key lhs_;
+
+    // The RHS of the comparison, not including any constant offset.
+    Key rhs_;
+
+    // Additive offset on rhs
+    int64_t offset_{0};
+
+    // The comparison operator.
+    CompareResult result_{CompareResult::kInconsistent};
+  };
+
+  /*! \brief Generate a Comparison representing the given expression */
+  std::optional<Comparison> FromExpr(const PrimExpr& expr);
+
+  /*! \brief Utility function used by Bind and EnterConstraint
+   *
+   * \param expr The comparison expression, to be converted into
+   * internal Comparison objects.
+   *
+   * \param vec The vector to which the Comparison objects should be
+   * appended.
+   */
+  void AddKnown(const PrimExpr& expr, std::vector<Comparison>& vec);
+
+  /*! \brief Attempt to compare, starting at the lhs.
+   *
+   * Taking each available `Comparison` as a node edge, search for a
+   * path from lhs to rhs.  For example, the priors (a<=b), (b<=c+1)
+   * and (c<=d-5) can be used to prove that (a<=d-4).
+   *
+   * \param lhs The left-hand side of the comparison
+   *
+   * \param rhs The right-hand side of the comparison
+   *
+   * \return The result of the comparison
+   */
+  CompareResult TryCompareFromLHS(Key lhs_key, Key rhs_key, int64_t offset, const PrimExpr& lhs,
+                                  const PrimExpr& rhs) const;
+
+  /*! \brief Previous Range bindings
+   *
+   * Tracked separatedly to handle the `allow_override` option used by
+   * all sub-analyzers when binding variables.
+   */
+  Map<Var, Range> prev_bindings_;
+
+  /*! \brief Known comparisons based on definitionally-true statements
+   *
+   * For example, a Let binding, or the range of an iterator.
+   */
+  std::vector<Comparison> knowns_;
+
+  /*! \brief Known comparisons based on of scope-based statements
+   *
+   * For example, the condition of an IfThenElse, which is known to be
+   * true while within the if scope.
+   */
+  std::vector<Comparison> scoped_knowns_;
+};
+
+namespace {
+
+// Internal utility, return the CompareResult resulting from swapping
+// the left-hand side with the right-hand side.
+CompareResult Reverse(CompareResult res) {
+  switch (res) {
+    case CompareResult::kInconsistent:
+      return CompareResult::kInconsistent;
+    case CompareResult::kEQ:
+      return CompareResult::kEQ;
+    case CompareResult::kLT:
+      return CompareResult::kGT;
+    case CompareResult::kLE:
+      return CompareResult::kGE;
+    case CompareResult::kGT:
+      return CompareResult::kLT;
+    case CompareResult::kGE:
+      return CompareResult::kLE;
+    case CompareResult::kNE:
+      return CompareResult::kNE;
+    case CompareResult::kUnknown:
+      return CompareResult::kUnknown;
+    default:
+      LOG(FATAL) << "Invalid CompareResult: " << static_cast<int>(res);
+      return CompareResult::kInconsistent;
+  }
+}
+
+// Internal utility, return the CompareResult resulting from negating
+// the comparison.
+CompareResult Negate(CompareResult res) {
+  switch (res) {
+    case CompareResult::kInconsistent:
+      return CompareResult::kInconsistent;
+    case CompareResult::kUnknown:
+      return CompareResult::kUnknown;
+    default:
+      return CompareResult(~static_cast<int>(res) & static_cast<int>(CompareResult::kUnknown));
+  }
+}
+
+// Internal utility, extract constant offsets out of the two sides of
+// a comparison.  Given lhs and rhs, return a tuple of three elements
+// (lhs_inner, rhs_inner, offset), such that (lhs OP rhs) and
+// (lhs_inner OP rhs_inner + offset) are equivalent.
+std::tuple<PrimExpr, PrimExpr, int64_t> ExtractOffsets(const PrimExpr& lhs, const PrimExpr& rhs) {
+  auto extract_offset = [](const PrimExpr& expr) -> std::pair<PrimExpr, int64_t> {
+    PVar<PrimExpr> x;
+    PVar<IntImm> c;
+    if ((x + c).Match(expr)) {
+      return {x.Eval(), c.Eval()->value};
+    } else if ((x - c).Match(expr)) {
+      return {x.Eval(), -c.Eval()->value};
+    } else if (c.Match(expr)) {
+      return {0, c.Eval()->value};
+    } else {
+      return {expr, 0};
+    }
+  };
+
+  auto lhs_split = extract_offset(lhs);
+  auto rhs_split = extract_offset(rhs);
+  return {lhs_split.first, rhs_split.first, rhs_split.second - lhs_split.second};
+}
+
+}  // namespace
+
+std::optional<TransitiveComparisonAnalyzer::Impl::Comparison>
+TransitiveComparisonAnalyzer::Impl::FromExpr(const PrimExpr& expr) {
+  CompareResult res;
+  PVar<PrimExpr> x, y;
+  if ((x <= y).Match(expr)) {
+    res = CompareResult::kLE;
+  } else if ((x >= y).Match(expr)) {
+    res = CompareResult::kGE;
+  } else if ((x < y).Match(expr)) {
+    res = CompareResult::kLT;
+  } else if ((x > y).Match(expr)) {
+    res = CompareResult::kGT;
+  } else if ((x == y).Match(expr)) {
+    res = CompareResult::kEQ;
+  } else if ((x != y).Match(expr)) {
+    res = CompareResult::kNE;
+  } else {
+    return std::nullopt;
+  }
+
+  PrimExpr lhs_expr = x.Eval();
+  PrimExpr rhs_expr = y.Eval();
+
+  if (lhs_expr.as<IntImmNode>() && rhs_expr.as<IntImmNode>()) {
+    return std::nullopt;
+  }
+
+  auto [lhs, rhs, offset] = ExtractOffsets(lhs_expr, rhs_expr);
+  Key lhs_key = ExprToKey(lhs);
+  Key rhs_key = ExprToKey(rhs);
+
+  return Comparison(lhs_key, rhs_key, offset, res);
+}
+
+TransitiveComparisonAnalyzer::Impl::Comparison::Comparison(Key lhs, Key rhs, int64_t offset,
+                                                           CompareResult result)
+    : lhs_(lhs), rhs_(rhs), offset_(offset), result_(result) {
+  if (result_ == CompareResult::kLT) {
+    result_ = CompareResult::kLE;
+    offset_ -= 1;
+  }
+  if (result_ == CompareResult::kGT) {
+    result_ = CompareResult::kGE;
+    offset_ += 1;
+  }
+}
+
+std::optional<TransitiveComparisonAnalyzer::Impl::Key>
+TransitiveComparisonAnalyzer::Impl::ExprToPreviousKey(const PrimExpr& expr) const {
+  auto it = expr_to_key.find(expr);
+  if (it != expr_to_key.end()) {
+    return it->second;
+  } else {
+    return std::nullopt;
+  }
+}
+
+TransitiveComparisonAnalyzer::Impl::Key TransitiveComparisonAnalyzer::Impl::ExprToKey(
+    const PrimExpr& expr) {
+  if (auto prev = ExprToPreviousKey(expr)) {
+    return prev.value();
+  } else {
+    Key new_key = Key(expr_to_key.size());
+    expr_to_key[expr] = new_key;
+    return new_key;
+  }
+}
+
+bool TransitiveComparisonAnalyzer::Impl::Comparison::IsNormalized() const {
+  // These < and > should be removed during normalization.
+  return result_ != CompareResult::kLT && result_ != CompareResult::kGT;
+}
+
+std::optional<TransitiveComparisonAnalyzer::Impl::Comparison>
+TransitiveComparisonAnalyzer::Impl::Comparison::WithLHS(Key new_lhs) const {
+  if (new_lhs == lhs_) {
+    return *this;
+  } else if (new_lhs == rhs_) {
+    return Comparison(rhs_, lhs_, -offset_, Reverse(result_));
+  } else {
+    return std::nullopt;
+  }
+}
+
+TransitiveComparisonAnalyzer::Impl::Comparison
+TransitiveComparisonAnalyzer::Impl::Comparison::Negated() const {
+  return Comparison(lhs_, rhs_, offset_, Negate(result_));
+}
+
+bool TransitiveComparisonAnalyzer::Impl::Comparison::Implies(
+    const TransitiveComparisonAnalyzer::Impl::Comparison& other) const {
+  ICHECK(lhs_ == other.lhs_);
+  ICHECK(rhs_ == other.rhs_);
+  ICHECK(IsNormalized());
+  ICHECK(other.IsNormalized());
+
+  if (result_ == other.result_ && offset_ == other.offset_) {
+    // if c1 == c2, x != y + c1 => x != y + c2
+    // if c1 == c2, x == y + c1 => x == y + c2
+    return true;
+  }
+
+  if (other.result_ == CompareResult::kLE && offset_ <= other.offset_) {
+    if (result_ == CompareResult::kEQ || result_ == CompareResult::kLE) {
+      // if c1 <= c2, x <= y + c1 => x <= y + c2
+      // if c1 <= c2, x == y + c1 => x <= y + c2
+      return true;
+    }
+  }
+
+  if (other.result_ == CompareResult::kGE && offset_ >= other.offset_) {
+    if (result_ == CompareResult::kEQ || result_ == CompareResult::kGE) {
+      // if c1 >= c2, x == y + c1 => x >= y + c2
+      // if c1 >= c2, x >= y + c1 => x >= y + c2
+      return true;
+    }
+  }
+
+  if (other.result_ == CompareResult::kNE) {
+    if (result_ == CompareResult::kEQ && offset_ != other.offset_) {
+      // if c1 != c2, x == y + c1 => x != y + c2
+      return true;
+    }
+
+    if (result_ == CompareResult::kLE && offset_ < other.offset_) {
+      // if c1 < c2, x <= y + c1 => x < y + c2 => x != y + c2
+      return true;
+    }
+
+    if (result_ == CompareResult::kGE && offset_ > other.offset_) {
+      // if c1 != c2, x >= y + c1 => x > y + c2 => x != y + c2
+      return true;
+    }
+  }
+
+  return false;
+}
+
+TransitiveComparisonAnalyzer::TransitiveComparisonAnalyzer() : impl_(std::make_unique<Impl>()) {}
+TransitiveComparisonAnalyzer::~TransitiveComparisonAnalyzer() {}
+
+CompareResult TransitiveComparisonAnalyzer::TryCompare(const PrimExpr& lhs, const PrimExpr& rhs) {
+  return impl_->TryCompare(lhs, rhs);
+}
+
+void TransitiveComparisonAnalyzer::Bind(const Var& var, const PrimExpr& expr, bool allow_override) {
+  impl_->Bind(var, expr, allow_override);
+}
+void TransitiveComparisonAnalyzer::Bind(const Var& var, const Range& range, bool allow_override) {
+  impl_->Bind(var, range, allow_override);
+}
+
+std::function<void()> TransitiveComparisonAnalyzer::EnterConstraint(const PrimExpr& constraint) {
+  return impl_->EnterConstraint(constraint);
+}
+
+void TransitiveComparisonAnalyzer::Impl::AddKnown(const PrimExpr& expr,
+                                                  std::vector<Comparison>& vec) {
+  for (const auto& subexpr : ExtractConstraints(expr)) {
+    if (tir::SideEffect(expr) <= tir::CallEffectKind::kPure) {
+      if (auto cmp = FromExpr(subexpr)) {
+        vec.push_back(cmp.value());
+      }
+    }
+  }
+}
+
+void TransitiveComparisonAnalyzer::Impl::Bind(const tir::Var& var, const Range& range,
+                                              bool allow_override) {
+  auto it = prev_bindings_.find(var);
+  if (it != prev_bindings_.end()) {
+    ExprDeepEqual expr_equal;
+    bool differs_from_previous = !expr_equal(range->min, (*it).second->min) ||
+                                 !expr_equal(range->extent, (*it).second->extent);
+    if (differs_from_previous) {
+      ICHECK(allow_override) << "Binding of variable " << var << " as " << range
+                             << " conflicts with previous binding as " << (*it).second;
+      if (auto key = ExprToPreviousKey(var)) {
+        knowns_.erase(std::remove_if(knowns_.begin(), knowns_.end(),
+                                     [&](const auto& known) { return known.lhs_ == key.value(); }),
+                      knowns_.end());
+      }
+    }
+  }
+
+  prev_bindings_.Set(var, range);
+
+  if (is_const_int(range->extent, 1)) {
+    AddKnown(var == range->min, knowns_);
+  } else {
+    AddKnown(var >= range->min, knowns_);
+    AddKnown(var < range->min + range->extent, knowns_);
+  }
+}
+
+void TransitiveComparisonAnalyzer::Impl::Bind(const tir::Var& var, const PrimExpr& expr,
+                                              bool allow_override) {
+  Bind(var, Range::FromMinExtent(expr, 1), allow_override);
+}
+
+std::function<void()> TransitiveComparisonAnalyzer::Impl::EnterConstraint(const PrimExpr& expr) {
+  size_t old_literal_size = scoped_knowns_.size();
+  AddKnown(expr, scoped_knowns_);
+  size_t new_literal_size = scoped_knowns_.size();
+
+  PrimExpr temp = expr;
+  auto frecover = [old_literal_size, new_literal_size, this, temp]() {
+    ICHECK_EQ(scoped_knowns_.size(), new_literal_size);
+    scoped_knowns_.erase(scoped_knowns_.begin() + old_literal_size, scoped_knowns_.end());
+  };
+  return frecover;
+}
+
+CompareResult TransitiveComparisonAnalyzer::Impl::TryCompare(const PrimExpr& lhs_expr,
+                                                             const PrimExpr& rhs_expr) const {
+  // Currently only supports integer checks
+  if (!lhs_expr.dtype().is_int() || !rhs_expr.dtype().is_int()) {
+    return CompareResult::kUnknown;
+  }
+
+  // Bail out early if possible.  This int check should have been
+  // constant-folded earlier, so this check shouldn't occur.
+  auto* x_int = lhs_expr.as<IntImmNode>();
+  auto* y_int = rhs_expr.as<IntImmNode>();
+  if (x_int && y_int) {
+    if (x_int->value < y_int->value) {
+      return CompareResult::kLT;
+    } else if (x_int->value > y_int->value) {
+      return CompareResult::kGT;
+    } else {
+      return CompareResult::kEQ;
+    }
+  }
+
+  auto [lhs, rhs, offset] = ExtractOffsets(lhs_expr, rhs_expr);
+  auto lhs_key = ExprToPreviousKey(lhs);
+  auto rhs_key = ExprToPreviousKey(rhs);
+
+  if (!lhs_key.has_value() || !rhs_key.has_value()) {
+    return CompareResult::kUnknown;
+  }
+
+  auto from_lhs = TryCompareFromLHS(lhs_key.value(), rhs_key.value(), offset, lhs, rhs);
+  auto from_rhs = Reverse(TryCompareFromLHS(rhs_key.value(), lhs_key.value(), -offset, rhs, lhs));
+  auto output = from_lhs & from_rhs;
+
+  return output;
+}
+
+CompareResult TransitiveComparisonAnalyzer::Impl::TryCompareFromLHS(
+    Key lhs_key_input, Key rhs_key_input, int64_t offset_input, const PrimExpr& lhs_input,
+    const PrimExpr& rhs_input) const {
+  Key lhs_key = lhs_key_input;
+  Key rhs_key = rhs_key_input;
+  int64_t offset = offset_input;
+
+  // Everything in `to_visit` has lhs as its lhs.
+  std::unordered_set<Key> seen;
+  std::unordered_set<Key> to_visit;
+  std::unordered_map<Key, std::vector<Comparison>> compared_to_x;
+
+  // Utility function to add a new known statement
+  auto declare_known = [&](Comparison cmp) {
+    auto& prev_knowns = compared_to_x[cmp.rhs_];
+
+    for (auto& prev_known : prev_knowns) {
+      if (prev_known.Implies(cmp)) {
+        return;
+      }
+    }
+
+    if (cmp.rhs_ != rhs_key && !seen.count(cmp.rhs_)) {
+      to_visit.insert(cmp.rhs_);
+      seen.insert(cmp.rhs_);
+    }
+
+    for (auto& prev_known : prev_knowns) {
+      if (cmp.Implies(prev_known)) {
+        prev_known = cmp;
+        return;
+      }
+    }
+
+    prev_knowns.push_back(cmp);
+  };
+
+  // Initialize the search based on any known (in)equalities that use
+  // the LHS of the comparison.
+  for (const auto& known : knowns_) {
+    if (auto normalized = known.WithLHS(lhs_key)) {
+      declare_known(normalized.value());
+    }
+  }
+  for (const auto& known : scoped_knowns_) {
+    if (auto normalized = known.WithLHS(lhs_key)) {
+      declare_known(normalized.value());
+    }
+  }
+
+  // Walk through the space of all comparisons that can be made with
+  // LHS.
+  while (to_visit.size()) {
+    Key middle_key = *to_visit.begin();
+    to_visit.erase(to_visit.begin());
+
+    std::vector<Comparison>& prev_knowns_using_middle = compared_to_x.at(middle_key);
+    ICHECK(compared_to_x.count(middle_key));
+
+    std::vector<Comparison> new_knowns_using_lhs;
+
+    auto attempt_transitive = [&](Comparison cmp) {
+      ICHECK(cmp.IsNormalized());
+
+      Key right_key = cmp.rhs_;
+
+      if (right_key == lhs_key) {
+        return;
+      }
+
+      for (const auto& prev : prev_knowns_using_middle) {
+        CompareResult new_result = CompareResult::kUnknown;
+        int64_t new_offset = prev.offset_ + cmp.offset_;
+
+        if (prev.result_ == CompareResult::kEQ) {
+          // x == y + c1 && y OP z + c2, x OP z + (c1 + c2)
+          new_result = cmp.result_;
+        } else if (cmp.result_ == CompareResult::kEQ) {
+          // x OP y + c1 && y == z + c2, x OP z + (c1 + c2)
+          new_result = prev.result_;
+        } else if (prev.result_ == cmp.result_ &&
+                   (prev.result_ == CompareResult::kLE || prev.result_ == CompareResult::kGE)) {
+          // x <= y + c1 && y <= z + c2, x <= z + (c1 + c2)
+          // x >= y + c1 && y >= z + c2, x >= z + (c1 + c2)
+          //
+          // This condition is much simpler to write than the
+          // equivalent handling of < or of >, which is why the
+          // inequalities are normalized to <= and to >=.
+          new_result = prev.result_;
+        }
+
+        if (new_result != CompareResult::kUnknown) {
+          Comparison new_known(lhs_key, right_key, new_offset, new_result);
+          new_knowns_using_lhs.push_back(new_known);
+        }
+      }
+    };
+
+    // Attempt to prove a new comparison using one of the original
+    // known comparisons.  We want to find a known such that
+    // `(LHS OP1 middle) && (middle OP2 right)` can be simplified
+    // into `(LHS OP3 right)`.
+    for (const auto& known : knowns_) {
+      if (auto cmp = known.WithLHS(middle_key)) {
+        attempt_transitive(cmp.value());
+      }
+    }
+
+    for (const auto& known : scoped_knowns_) {
+      if (auto cmp = known.WithLHS(middle_key)) {
+        attempt_transitive(cmp.value());
+      }
+    }
+
+    // Collect together all new knowns, marking new nodes for visiting
+    // as needed.
+    for (const auto& new_known : new_knowns_using_lhs) {
+      declare_known(new_known);
+    }
+  }
+
+  // It's possible that we don't have any transitive comparisons that
+  // can prove something about LHS and RHS.
+  auto it = compared_to_x.find(rhs_key);
+  if (it == compared_to_x.end()) {
+    return CompareResult::kUnknown;
+  }
+
+  const std::vector<Comparison>& known_between_lhs_and_rhs = it->second;
+
+  // Just because we found a comparison involving LHS and RHS doesn't
+  // mean that it's useful.  e.g. Knowing that `x < y` doesn't let us
+  // prove whether `x + 5 < y`.
+  CompareResult result = CompareResult::kUnknown;
+  for (const auto& known : known_between_lhs_and_rhs) {
+    switch (known.result_) {
+      case CompareResult::kInconsistent:
+        result = CompareResult::kInconsistent;
+        break;
+
+      case CompareResult::kEQ:
+        if (offset == known.offset_) {
+          result = result & CompareResult::kEQ;
+        } else {
+          result = result & CompareResult::kNE;
+        }
+        break;
+
+      case CompareResult::kLE:
+        if (known.offset_ < offset) {
+          result = result & CompareResult::kLT;
+        } else if (known.offset_ <= offset) {
+          result = result & CompareResult::kLE;
+        }
+        break;
+
+      case CompareResult::kGE:
+        if (known.offset_ > offset) {
+          result = result & CompareResult::kGT;
+        } else if (known.offset_ >= offset) {
+          result = result & CompareResult::kGE;
+        }
+        break;
+
+      case CompareResult::kNE:
+        if (offset == known.offset_) {
+          result = result & CompareResult::kNE;
+        }
+        break;
+
+      case CompareResult::kUnknown:
+        break;
+
+      case CompareResult::kGT:
+      case CompareResult::kLT:
+        LOG(FATAL) << "Internal error, normalized comparisons should only include <= and >=";
+        return CompareResult::kInconsistent;
+
+      default:
+        LOG(FATAL) << "Invalid CompareResult: " << static_cast<int>(known.result_);
+        return CompareResult::kInconsistent;
+    }
+  }
+
+  return result;
+}
+
+}  // namespace arith
+}  // namespace tvm

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -693,6 +693,14 @@ CompareResult TransitiveComparisonAnalyzer::Impl::TryCompareFromLHS(
     // known comparisons.  We want to find a known such that
     // `(LHS OP1 middle) && (middle OP2 right)` can be simplified
     // into `(LHS OP3 right)`.
+    //
+    // Note: The right side is this step is not necessarily the RHS of
+    // the comparison we're trying to prove, as we may need to find
+    // intermediate comparisons first.  For example, if we know that
+    // `a<=b`, `b<=c`, and `c<=d`, and we wish to prove that `a<=d`,
+    // we must first combine `a<=b` and `b<=c` into `a<=c`.  During
+    // this first step, `b` is the "middle" and `c` is the "right".
+    // The next step can then combind `a<=c` and `c<=d` into `a<=d`.
     for (const auto& known : knowns_) {
       if (auto cmp = known.WithLHS(middle_key)) {
         attempt_transitive(cmp.value());

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -174,14 +174,19 @@ class TransitiveComparisonAnalyzer::Impl {
 
   /*! \brief Known comparisons based on definitionally-true statements
    *
-   * For example, a Let binding, or the range of an iterator.
+   * For example, a Let binding, or the range of an iterator.  These
+   * known statements are always true, based on the definition site of
+   * the variable.  e.g. A loop iterator may never exceed the bounds
+   * of its loop.
    */
   std::vector<Comparison> knowns_;
 
-  /*! \brief Known comparisons based on of scope-based statements
+  /*! \brief Known comparisons based on scoped conditions
    *
-   * For example, the condition of an IfThenElse, which is known to be
-   * true while within the if scope.
+   * For example, the condition of an IfThenElse.  These known
+   * statements may only be used within the scope of the statement
+   * from which they were derived.  e.g. After exiting an IfThenElse,
+   * the condition may no longer be true.
    */
   std::vector<Comparison> scoped_knowns_;
 };

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -142,9 +142,19 @@ class TransitiveComparisonAnalyzer::Impl {
 
   /*! \brief Attempt to compare, starting at the lhs.
    *
-   * Taking each available `Comparison` as a node edge, search for a
-   * path from lhs to rhs.  For example, the priors (a<=b), (b<=c+1)
-   * and (c<=d-5) can be used to prove that (a<=d-4).
+   * Perform a depth-first search through the space of known
+   * expressions, starting at the LHS of a comparison.  In this
+   * search, each expression is a node of a graph, and each known
+   * comparison is an edge of the graph.
+   *
+   * For example, suppose we have previous knowns of (A<=B), (B<=C+1)
+   * and (C<=D-5).  The expressions [A,B,C,D] are the nodes of the
+   * search space.  Each comparison is an edge connecting two
+   * expressions, such as (B<=C+1) connecting the expressions B and D.
+   * If we are attempting to compare expressions A and D, a search
+   * starting at expression A could follow each edge until reaching
+   * expression D, then combine the comparisons that compose the path
+   * into the expression A<=D-4.
    *
    * \param lhs The left-hand side of the comparison
    *

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -539,8 +539,7 @@ std::function<void()> TransitiveComparisonAnalyzer::Impl::EnterConstraint(const 
   AddKnown(expr, &scoped_knowns_);
   size_t new_literal_size = scoped_knowns_.size();
 
-  PrimExpr temp = expr;
-  auto frecover = [old_literal_size, new_literal_size, this, temp]() {
+  auto frecover = [old_literal_size, new_literal_size, this]() {
     ICHECK_EQ(scoped_knowns_.size(), new_literal_size);
     scoped_knowns_.erase(scoped_knowns_.begin() + old_literal_size, scoped_knowns_.end());
   };

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -192,7 +192,7 @@ class TransitiveComparisonAnalyzer::Impl {
    */
   void AddKnown(const PrimExpr& expr, std::vector<Comparison>* vec);
 
-  /*! \brief Attempt to compare, starting at the lhs.
+  /*! \brief Attempt to compare the expressions, starting at the lhs.
    *
    * Perform a depth-first search through the space of known
    * expressions, starting at the LHS of a comparison.  In this
@@ -214,8 +214,8 @@ class TransitiveComparisonAnalyzer::Impl {
    *
    * \return The result of the comparison
    */
-  CompareResult TryCompareFromLHS(Key lhs_key, Key rhs_key, int64_t offset, const PrimExpr& lhs,
-                                  const PrimExpr& rhs) const;
+  CompareResult DFSFromLHS(Key lhs_key, Key rhs_key, int64_t offset, const PrimExpr& lhs,
+                           const PrimExpr& rhs) const;
 
   /*! \brief Previous Range bindings
    *
@@ -575,16 +575,17 @@ CompareResult TransitiveComparisonAnalyzer::Impl::TryCompare(const PrimExpr& lhs
     return CompareResult::kUnknown;
   }
 
-  auto from_lhs = TryCompareFromLHS(lhs_key.value(), rhs_key.value(), offset, lhs, rhs);
-  auto from_rhs = Reverse(TryCompareFromLHS(rhs_key.value(), lhs_key.value(), -offset, rhs, lhs));
+  auto from_lhs = DFSFromLHS(lhs_key.value(), rhs_key.value(), offset, lhs, rhs);
+  auto from_rhs = Reverse(DFSFromLHS(rhs_key.value(), lhs_key.value(), -offset, rhs, lhs));
   auto output = from_lhs & from_rhs;
 
   return output;
 }
 
-CompareResult TransitiveComparisonAnalyzer::Impl::TryCompareFromLHS(
-    Key lhs_key_input, Key rhs_key_input, int64_t offset_input, const PrimExpr& lhs_input,
-    const PrimExpr& rhs_input) const {
+CompareResult TransitiveComparisonAnalyzer::Impl::DFSFromLHS(Key lhs_key_input, Key rhs_key_input,
+                                                             int64_t offset_input,
+                                                             const PrimExpr& lhs_input,
+                                                             const PrimExpr& rhs_input) const {
   Key lhs_key = lhs_key_input;
   Key rhs_key = rhs_key_input;
   int64_t offset = offset_input;

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -676,7 +676,9 @@ CompareResult TransitiveComparisonAnalyzer::Impl::TryCompareFromLHS(
           //
           // This condition is much simpler to write than the
           // equivalent handling of < or of >, which is why the
-          // inequalities are normalized to <= and to >=.
+          // inequalities are normalized to <= and to >=.  See
+          // `TransitiveComparisonAnalyzer::Impl::Comparison::Comparison`
+          // for further details.
           new_result = prev.result_;
         }
 

--- a/src/tir/transforms/simplify.cc
+++ b/src/tir/transforms/simplify.cc
@@ -46,10 +46,11 @@ struct SimplifyConfigNode : public tvm::AttrsNode<SimplifyConfigNode> {
         .set_default(false);
   }
 
-  RewriteSimplifier::Feature GetFeatureFlags() const {
-    RewriteSimplifier::Feature flags = RewriteSimplifier::kNone;
+  RewriteSimplifier::Extension GetEnabledExtensions() const {
+    RewriteSimplifier::Extension flags = RewriteSimplifier::kNone;
     if (transitively_prove_inequalities) {
-      flags = RewriteSimplifier::Feature(flags | RewriteSimplifier::kTransitivelyProveInequalities);
+      flags =
+          RewriteSimplifier::Extension(flags | RewriteSimplifier::kTransitivelyProveInequalities);
     }
     return flags;
   }
@@ -189,7 +190,7 @@ Pass Simplify() {
     arith::Analyzer analyzer;
     auto cfg = ctx->GetConfig<arith::SimplifyConfig>("tir.Simplify")
                    .value_or(AttrsWithDefaultValues<arith::SimplifyConfig>());
-    analyzer.rewrite_simplify.SetEnabledFeatures(cfg->GetFeatureFlags());
+    analyzer.rewrite_simplify.SetEnabledExtensions(cfg->GetEnabledExtensions());
 
     auto* n = f.CopyOnWrite();
     n->body = arith::StmtSimplifier(&analyzer).Simplify(std::move(n->body));

--- a/src/tir/transforms/simplify.cc
+++ b/src/tir/transforms/simplify.cc
@@ -36,6 +36,33 @@ namespace arith {
 
 using namespace tir;
 
+struct SimplifyConfigNode : public tvm::AttrsNode<SimplifyConfigNode> {
+  bool transitively_prove_inequalities;
+
+  TVM_DECLARE_ATTRS(SimplifyConfigNode, "tir.transform.SimplifyConfig") {
+    TVM_ATTR_FIELD(transitively_prove_inequalities)
+        .describe(
+            "If true, simplify conditionals with transitive combinations of scoped constraints")
+        .set_default(false);
+  }
+
+  RewriteSimplifier::Feature GetFeatureFlags() const {
+    RewriteSimplifier::Feature flags = RewriteSimplifier::kNone;
+    if (transitively_prove_inequalities) {
+      flags = RewriteSimplifier::Feature(flags | RewriteSimplifier::kTransitivelyProveInequalities);
+    }
+    return flags;
+  }
+};
+
+class SimplifyConfig : public Attrs {
+ public:
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(SimplifyConfig, Attrs, SimplifyConfigNode);
+};
+
+TVM_REGISTER_NODE_TYPE(SimplifyConfigNode);
+TVM_REGISTER_PASS_CONFIG_OPTION("tir.Simplify", SimplifyConfig);
+
 class StmtSimplifier : public IRMutatorWithAnalyzer {
  public:
   explicit StmtSimplifier(Analyzer* analyzer) : IRMutatorWithAnalyzer(analyzer) {}
@@ -159,8 +186,12 @@ namespace transform {
 
 Pass Simplify() {
   auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
-    auto* n = f.CopyOnWrite();
     arith::Analyzer analyzer;
+    auto cfg = ctx->GetConfig<arith::SimplifyConfig>("tir.Simplify")
+                   .value_or(AttrsWithDefaultValues<arith::SimplifyConfig>());
+    analyzer.rewrite_simplify.SetEnabledFeatures(cfg->GetFeatureFlags());
+
+    auto* n = f.CopyOnWrite();
     n->body = arith::StmtSimplifier(&analyzer).Simplify(std::move(n->body));
     return f;
   };

--- a/tests/python/unittest/test_tir_transform_simplify.py
+++ b/tests/python/unittest/test_tir_transform_simplify.py
@@ -137,7 +137,6 @@ def test_complex_likely_elimination():
 
 
 class BaseBeforeAfter(tvm.testing.CompareBeforeAfter):
-    transform = tvm.tir.transform.Simplify()
     transitively_prove_inequalities = True
 
     def transform(self):

--- a/tests/python/unittest/test_tir_transform_simplify.py
+++ b/tests/python/unittest/test_tir_transform_simplify.py
@@ -614,7 +614,7 @@ class TestRemoveTransitivelyProvableCondition(BaseBeforeAfter):
         (tvm.tir.all(i == j, j != k), i > k, False),
         # Because these are integers, x<y is equivalent to x <= y-1,
         # and may be used in equivalent simplifications.
-        (tvm.tir.all(i < j, j < k), i < k, True),
+        (tvm.tir.all(i <= j - 1, j < k), i < k, True),
         (tvm.tir.all(i <= j - 1, j == k), i < k, True),
         (tvm.tir.all(i <= j - 1, j <= k), i < k, True),
         (tvm.tir.all(i <= j - 1, j > k), i < k, False),

--- a/tests/python/unittest/test_tir_transform_simplify.py
+++ b/tests/python/unittest/test_tir_transform_simplify.py
@@ -137,7 +137,7 @@ def test_complex_likely_elimination():
 
 
 class BaseBeforeAfter(tvm.testing.CompareBeforeAfter):
-    transitively_prove_inequalities = True
+    transitively_prove_inequalities = False
 
     def transform(self):
         def inner(mod):
@@ -566,6 +566,8 @@ class TestRemoveTransitivelyProvableCondition(BaseBeforeAfter):
     For example, the `0 < i` and `i <= j` conditions can be used to prove
     that `0 < j`.
     """
+
+    transitively_prove_inequalities = True
 
     i, j, k = [tvm.tir.Var(name, "int32") for name in "ijk"]
     zero = tvm.tir.IntImm("int32", 0)


### PR DESCRIPTION
This commit adds a new sub-analyzer, `TransitiveComparisonAnalyzer`, which attempts to apply multiple known comparisons to prove an unknown.  For example, `a <= b` and `b <= c` imply that `a <= c`. These simplifications are necessary for simplifying conditionals resulting from padded layout transformations (https://github.com/apache/tvm/issues/12261).

While some of these conditions may be proven using `ConstIntBoundAnalyzer` or `IntSetAnalyzer`, each has some limitations.  `ConstIntBoundAnalyzer` can only compare against a constant, `IntSetAnalyzer` internally calls `RewriteSimplifier` which can result in infinite recursion, and neither can handle not-equal conditions because it would require tracking multiple intervals per expression.  Therefore, introducing a new sub-analyzer for these simplifications.