### PR TITLE
[TOPI] Add layer norm operator

### DIFF
--- a/include/tvm/topi/nn/layer_norm.h
+++ b/include/tvm/topi/nn/layer_norm.h
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \brief layer normalization op constructions
+ * \file nn/layer_norm.h
+ */
+#ifndef TVM_TOPI_NN_LAYER_NORM_H_
+#define TVM_TOPI_NN_LAYER_NORM_H_
+
+#include <tvm/te/operation.h>
+#include <tvm/topi/tags.h>
+
+#include <string>
+
+namespace tvm {
+namespace topi {
+namespace nn {
+
+using namespace tvm::te;
+
+/*!
+ * \brief Layer normalization.
+ * \param data N-D tensor with shape [d_0, d_1, ..., d_n]
+ * \param gamma R-D tensor with shape [r_0, r_1, ..., r_k] where R == len(axis) and d_{axis_i} ==
+ *              r_i
+ * \param beta Optional, R-D tensor with shape [r_0, r_1, ..., r_k] where R == len(axis) and
+ *             d_{axis_i} == r_i
+ * \param axis The axis to normalize over.
+ * \param epsilon The epsilon value to avoid division by zero.
+ * \param name The name of the operation.
+ * \param tag The tag to mark the operation.
+ * \return The normalized tensor, with the same shape as data.
+ */
+inline Tensor layer_norm(const Tensor& data, const Tensor& gamma, const Tensor& beta,
+                         const Array<Integer>& axis, double epsilon,
+                         std::string name = "T_layer_norm", std::string tag = kInjective) {
+  // sum x and x^2
+  auto ndim = data->shape.size();
+  ICHECK_NE(ndim, 0) << "Cannot reduce a 0 dim Tensor";
+  auto real_axis = GetRealAxis(static_cast<int>(ndim), axis);
+  auto reduce_axes = MakeReduceAxes(real_axis, data);
+  auto target_shape =
+      MakeReduceTargetShape(real_axis, data, /*keepdims=*/false, /*atleast1d=*/true);
+  auto func = MakeTupleSumReducer();
+
+  auto compute = [ndim, &real_axis, &reduce_axes, &func, &data](const Array<Var>& indices) {
+    Array<PrimExpr> eval_range;
+    int arg_counter = 0;
+    int red_counter = 0;
+
+    for (size_t i = 0; i < ndim; ++i) {
+      if (std::find(real_axis.begin(), real_axis.end(), i) != real_axis.end()) {
+        // real_axis contains i
+        eval_range.push_back(reduce_axes[red_counter]);
+        red_counter++;
+      } else {
+        eval_range.push_back(indices[arg_counter]);
+        arg_counter++;
+      }
+    }
+    auto square = [](const PrimExpr& x) { return x * x; };
+    return func({data(eval_range), square(data(eval_range))}, reduce_axes, nullptr);
+  };
+
+  auto temp_x_x2 =
+      tvm::te::compute(target_shape, compute, data->op->name + "_red_temp", kCommReduce);
+
+  auto temp_x = temp_x_x2[0];
+  auto temp_x2 = temp_x_x2[1];
+
+  auto reduce_extent = make_const(data->dtype, 1);
+  for (int i : real_axis) {
+    reduce_extent *= data->shape[i];
+  }
+  auto layer_norm_func = [&](const Array<Var>& indices) {
+    Array<Var> reduce_indices, non_reduce_indices;
+    for (int i = 0, n = static_cast<int>(indices.size()); i < n; ++i) {
+      if (std::find(real_axis.begin(), real_axis.end(), i) != real_axis.end()) {
+        reduce_indices.push_back(indices[i]);
+      } else {
+        non_reduce_indices.push_back(indices[i]);
+      }
+    }
+    auto mean = temp_x(non_reduce_indices) / reduce_extent;
+    auto var = temp_x2(non_reduce_indices) / reduce_extent - mean * mean;
+    auto layer_norm = (data(indices) - mean) * tvm::rsqrt(var + make_const(var->dtype, epsilon));
+    layer_norm = topi::multiply(layer_norm, gamma(reduce_indices));
+    if (beta.defined()) {
+      layer_norm = topi::add(layer_norm, beta(reduce_indices));
+    }
+    return layer_norm;
+  };
+  return tvm::te::compute(data->shape, layer_norm_func, name, tag);
+};
+
+}  // namespace nn
+}  // namespace topi
+}  // namespace tvm
+
+#endif  // TVM_TOPI_NN_LAYER_NORM_H_

--- a/include/tvm/topi/nn/layer_norm.h
+++ b/include/tvm/topi/nn/layer_norm.h
@@ -37,11 +37,11 @@ using namespace tvm::te;
 
 /*!
  * \brief Layer normalization.
- * \param data N-D tensor with shape [d_0, d_1, ..., d_n]
- * \param gamma R-D tensor with shape [r_0, r_1, ..., r_k] where R == len(axis) and d_{axis_i} ==
- *              r_i
- * \param beta Optional, R-D tensor with shape [r_0, r_1, ..., r_k] where R == len(axis) and
- *             d_{axis_i} == r_i
+ * \param data N-D tensor with shape [d_0, d_1, ..., d_{N-1}]
+ * \param gamma K-D tensor with shape [r_0, r_1, ..., r_{K-1}] where K == len(axis) and
+ *              d_{axis_k} == r_k
+ * \param beta Optional, K-D tensor with shape [r_0, r_1, ..., r_{K-1}] where
+ *             d_{axis_k} == r_k
  * \param axis The axis to normalize over.
  * \param epsilon The epsilon value to avoid division by zero.
  * \param name The name of the operation.

--- a/include/tvm/topi/nn/layer_norm.h
+++ b/include/tvm/topi/nn/layer_norm.h
@@ -108,7 +108,7 @@ inline Tensor layer_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
     return layer_norm;
   };
   return tvm::te::compute(data->shape, layer_norm_func, name, tag);
-};
+}
 
 }  // namespace nn
 }  // namespace topi

--- a/python/tvm/topi/nn/__init__.py
+++ b/python/tvm/topi/nn/__init__.py
@@ -38,6 +38,7 @@ from .conv1d_transpose import *
 from .bnn import *
 from .qnn import *
 from .upsampling import *
+from .layer_norm import layer_norm
 from .local_response_norm import *
 from .bitserial_conv2d import *
 from .bitserial_dense import *

--- a/python/tvm/topi/nn/layer_norm.py
+++ b/python/tvm/topi/nn/layer_norm.py
@@ -24,13 +24,13 @@ def layer_norm(data, gamma, beta, axis, epsilon=1e-5):
     Parameters
     ----------
     data : tvm.te.Tensor
-        N-D with shape (d_0, d_1, ..., d_n)
+        N-D with shape (d_0, d_1, ..., d_{N-1})
 
     gamma: tvm.te.Tensor
-        R-D with shape (r_0, r_1, ..., r_k) where R == len(axis) and d_{axis_i} == r_i
+        K-D with shape (r_0, r_1, ..., r_{K-1}) where K == len(axis) and d_{axis_k} == r_k
 
     beta: tvm.te.Tensor
-        Optional, R-D with shape (r_0, r_1, ..., r_k) where R == len(axis) and d_{axis_i} == r_i
+        Optional, K-D with shape (r_0, r_1, ..., r_{K-1}) where K == len(axis) and d_{axis_k} == r_k
 
     axis : list of int
         Axis over the normalization applied
@@ -41,6 +41,6 @@ def layer_norm(data, gamma, beta, axis, epsilon=1e-5):
     Returns
     -------
     result : tvm.te.Tensor
-        N-D with shape (d_0, d_1, ..., d_n)
+        N-D with shape (d_0, d_1, ..., d_{N-1})
     """
     return cpp.nn.layer_norm(data, gamma, beta, axis, epsilon)

--- a/python/tvm/topi/nn/layer_norm.py
+++ b/python/tvm/topi/nn/layer_norm.py
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Layer normalization operator."""
-import tvm
-from .. import tag, cpp
+from .. import cpp
 
 
 def layer_norm(data, gamma, beta, axis, epsilon=1e-5):

--- a/python/tvm/topi/nn/layer_norm.py
+++ b/python/tvm/topi/nn/layer_norm.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""TVM operator flatten compute."""
+import tvm
+from .. import tag, cpp
+
+
+def layer_norm(data, gamma, beta, axis, epsilon=1e-5):
+    """Layer normalization operator.
+
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+        N-D with shape (d_0, d_1, ..., d_n)
+
+    gamma: tvm.te.Tensor
+        R-D with shape (r_0, r_1, ..., r_k) where R == len(axis) and d_{axis_i} == r_i
+
+    beta: tvm.te.Tensor
+        Optional, R-D with shape (r_0, r_1, ..., r_k) where R == len(axis) and d_{axis_i} == r_i
+
+    axis : list of int
+        Axis over the normalization applied
+
+    epsilon : float
+        The epsilon value to avoid division by zero.
+
+    Returns
+    -------
+    result : tvm.te.Tensor
+        N-D with shape (d_0, d_1, ..., d_n)
+    """
+    return cpp.nn.layer_norm(data, gamma, beta, axis, epsilon)

--- a/python/tvm/topi/nn/layer_norm.py
+++ b/python/tvm/topi/nn/layer_norm.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""TVM operator flatten compute."""
+"""Layer normalization operator."""
 import tvm
 from .. import tag, cpp
 

--- a/python/tvm/topi/testing/__init__.py
+++ b/python/tvm/topi/testing/__init__.py
@@ -43,6 +43,7 @@ from .resize_python import resize1d_python, resize2d_python, resize3d_python
 from .reorg_python import reorg_python
 from .roi_align_python import roi_align_nchw_python, roi_align_nhwc_python
 from .roi_pool_python import roi_pool_nchw_python
+from .layer_norm_python import layer_norm_python
 from .lrn_python import lrn_python
 from .l2_normalize_python import l2_normalize_python
 from .gather_python import gather_python

--- a/python/tvm/topi/testing/layer_norm_python.py
+++ b/python/tvm/topi/testing/layer_norm_python.py
@@ -33,7 +33,7 @@ def layer_norm_python(data, gamma, beta, axis, epsilon=1e-5):
     beta: numpy.ndarray
         Optional, R-D with shape (r_0, r_1, ..., r_r) where R == len(axis) and d_{axis_i} == r_i
 
-    axis : list of int
+    axis : int or tuple of ints
         Axis over the normalization applied
 
     epsilon : float

--- a/python/tvm/topi/testing/layer_norm_python.py
+++ b/python/tvm/topi/testing/layer_norm_python.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, line-too-long, unused-variable, too-many-locals
+"""Layer normalization in python"""
+import numpy as np
+
+
+def layer_norm_python(data, gamma, beta, axis, epsilon=1e-5):
+    """Layer normalization operator in Python.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        N-D with shape (d_0, d_1, ..., d_n)
+
+    gamma: numpy.ndarray
+        R-D with shape (r_0, r_1, ..., r_r) where R == len(axis) and d_{axis_i} == r_i
+
+    beta: numpy.ndarray
+        Optional, R-D with shape (r_0, r_1, ..., r_r) where R == len(axis) and d_{axis_i} == r_i
+
+    axis : list of int
+        Axis over the normalization applied
+
+    epsilon : float
+        The epsilon value to avoid division by zero.
+
+    Returns
+    -------
+    result : np.ndarray
+        N-D with shape (d_0, d_1, ..., d_n)
+    """
+    mean = np.mean(data, axis, keepdims=True)
+    var = np.var(data, axis, keepdims=True)
+    result = (data - mean) / np.sqrt(var + epsilon)
+    result *= gamma
+    if beta is not None:
+        result += beta
+    return result

--- a/python/tvm/topi/testing/layer_norm_python.py
+++ b/python/tvm/topi/testing/layer_norm_python.py
@@ -25,13 +25,13 @@ def layer_norm_python(data, gamma, beta, axis, epsilon=1e-5):
     Parameters
     ----------
     data : numpy.ndarray
-        N-D with shape (d_0, d_1, ..., d_n)
+        N-D with shape (d_0, d_1, ..., d_{N-1})
 
     gamma: numpy.ndarray
-        R-D with shape (r_0, r_1, ..., r_r) where R == len(axis) and d_{axis_i} == r_i
+        K-D with shape (r_0, r_1, ..., r_{K-1}) where K == len(axis) and d_{axis_k} == r_k
 
     beta: numpy.ndarray
-        Optional, R-D with shape (r_0, r_1, ..., r_r) where R == len(axis) and d_{axis_i} == r_i
+        Optional, K-D with shape (r_0, r_1, ..., r_{K-1}) where K == len(axis) and d_{axis_k} == r_k
 
     axis : int or tuple of ints
         Axis over the normalization applied
@@ -42,7 +42,7 @@ def layer_norm_python(data, gamma, beta, axis, epsilon=1e-5):
     Returns
     -------
     result : np.ndarray
-        N-D with shape (d_0, d_1, ..., d_n)
+        N-D with shape (d_0, d_1, ..., d_{N-1})
     """
     mean = np.mean(data, axis, keepdims=True)
     var = np.var(data, axis, keepdims=True)

--- a/src/tir/schedule/primitive/reduction.cc
+++ b/src/tir/schedule/primitive/reduction.cc
@@ -333,6 +333,15 @@ struct ReducerRegistry {
             CreateReducerGetter(
                 /*n_buffers=*/2,
                 [](const Array<Var>& x, const Array<Var>& y) {
+                  return Array<PrimExpr>{x[0] + y[0], x[1] + y[1]};
+                },
+                [](const Array<PrimExpr>& values) {
+                  return Array<PrimExpr>{make_const(values[0]->dtype, 0),
+                                         make_const(values[1]->dtype, 0)};
+                }),
+            CreateReducerGetter(
+                /*n_buffers=*/2,
+                [](const Array<Var>& x, const Array<Var>& y) {
                   PrimExpr idx = Select(x[1] >= y[1], x[0], y[0]);
                   PrimExpr val = Select(x[1] >= y[1], x[1], y[1]);
                   return Array<PrimExpr>{idx, val};

--- a/src/topi/nn.cc
+++ b/src/topi/nn.cc
@@ -29,6 +29,7 @@
 #include <tvm/topi/nn/dense.h>
 #include <tvm/topi/nn/dilate.h>
 #include <tvm/topi/nn/flatten.h>
+#include <tvm/topi/nn/layer_norm.h>
 #include <tvm/topi/nn/local_response_norm.h>
 #include <tvm/topi/nn/mapping.h>
 #include <tvm/topi/nn/pooling.h>
@@ -155,6 +156,11 @@ TVM_REGISTER_GLOBAL("topi.nn.binarize_pack").set_body([](TVMArgs args, TVMRetVal
 
 TVM_REGISTER_GLOBAL("topi.nn.binary_dense").set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = nn::binary_dense(args[0], args[1]);
+});
+
+/* Ops from nn/layer_norm.h */
+TVM_REGISTER_GLOBAL("topi.nn.layer_norm").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = nn::layer_norm(args[0], args[1], args[2], args[3], static_cast<double>(args[4]));
 });
 
 }  // namespace topi

--- a/tests/python/topi/python/test_topi_layer_norm.py
+++ b/tests/python/topi/python/test_topi_layer_norm.py
@@ -46,7 +46,6 @@ def test_layer_norm(target, dev, shape, axis, episilon=1e-5, dtype="float32", rt
     beta_np = np.random.uniform(size=scale_shape).astype(dtype)
     b_np = tvm.topi.testing.layer_norm_python(data_np, gamma_np, beta_np, axis, episilon)
 
-    print("Running on target: %s" % target)
     with tvm.target.Target(target):
         s_func = tvm.topi.testing.dispatch(target, _layer_norm_schedule)
         s = s_func([B])

--- a/tests/python/topi/python/test_topi_layer_norm.py
+++ b/tests/python/topi/python/test_topi_layer_norm.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test code for layer_norm."""
+import numpy as np
+import pytest
+import tvm
+from tvm import te
+from tvm import topi
+from tvm.topi.utils import get_const_tuple
+import tvm.topi.testing
+
+import tvm.testing
+
+
+_layer_norm_schedule = {
+    "generic": topi.generic.schedule_injective,
+}
+
+
+# only test on llvm because schedule is missing
+@tvm.testing.parametrize_targets("llvm")
+@pytest.mark.parametrize("shape,axis", [([4, 16], (1,)), ([4, 16, 16], (1, 2))])
+def test_layer_norm(target, dev, shape, axis, episilon=1e-5, dtype="float32", rtol=1e-5, atol=1e-5):
+    data = te.placeholder(shape, dtype=dtype, name="data")
+    scale_shape = [shape[dim] for dim in axis]
+    gamma = te.placeholder(scale_shape, dtype=dtype, name="gamma")
+    beta = te.placeholder(scale_shape, dtype=dtype, name="beta")
+    B = topi.nn.layer_norm(data, gamma, beta, axis, episilon)
+
+    data_np = np.random.uniform(size=shape).astype(dtype)
+    gamma_np = np.random.uniform(size=scale_shape).astype(dtype)
+    beta_np = np.random.uniform(size=scale_shape).astype(dtype)
+    b_np = tvm.topi.testing.layer_norm_python(data_np, gamma_np, beta_np, axis, episilon)
+
+    print("Running on target: %s" % target)
+    with tvm.target.Target(target):
+        s_func = tvm.topi.testing.dispatch(target, _layer_norm_schedule)
+        s = s_func([B])
+    data_tvm = tvm.nd.array(data_np, dev)
+    gamma_tvm = tvm.nd.array(gamma_np, dev)
+    beta_tvm = tvm.nd.array(beta_np, dev)
+    b_tvm = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=dtype), dev)
+    f = tvm.build(s, [data, gamma, beta, B], target)
+    f(data_tvm, gamma_tvm, beta_tvm, b_tvm)
+    tvm.testing.assert_allclose(b_tvm.asnumpy(), b_np, rtol=rtol, atol=atol)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR added a tuple-sum based implementation of layer norm. It performs one-pass reduction to compute mean and variance at the same time.
Reducer pattern is also added to allow `LowerCrossThreadReduction` to handle this case.
On CUDA, it will generate two kernels: one for reduction and one for elemwise operations. Because of some limitation of `compute_at` currently we are not able to fuse them into one kernel. 

cc @MasterJH5574 @junrushao @AndrewZhaoLuo 