### PR TITLE
[TOPI] Fix dtype legalize logic for CPU dot product instruction

### DIFF
--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2137,6 +2137,7 @@ def test_conv2d_nhwc_dnnl():
             np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.skip("Requires cascadelake or ARM v8.2")
 def test_conv2d_int8_alter_dtype():
     def get_conv2d_nchw(
         d_shape,
@@ -2191,27 +2192,23 @@ def test_conv2d_int8_alter_dtype():
 
         dev = tvm.cpu(0)
 
-        try:
-            with tvm.transform.PassContext(
-                opt_level=3,
-            ):
-                lib = relay.build(mod, target=target, params=params)
+        with tvm.transform.PassContext(
+            opt_level=3,
+        ):
+            lib = relay.build(mod, target=target, params=params)
 
-            assert dot_product_instr in lib.lib.get_source("asm")
+        assert dot_product_instr in lib.lib.get_source("asm")
 
-            rt_mod = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
+        rt_mod = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
 
-            rt_mod.set_input("data", data_np)
+        rt_mod.set_input("data", data_np)
 
-            rt_mod.run()
+        rt_mod.run()
 
-            out = rt_mod.get_output(0).numpy()
+        out = rt_mod.get_output(0).numpy()
 
-            np.testing.assert_equal(out, ref)
-        except Exception as _:
-            print("skipping target", target)
+        np.testing.assert_equal(out, ref)
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_conv2d_int8_alter_dtype()
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2145,7 +2145,7 @@ def test_conv2d_int8_alter_dtype():
         data_dtype,
     ):
         out_dtype = "int32"
-        strides=(1, 1)
+        strides = (1, 1)
         padding = (1, 1)
         data = relay.var("data", shape=d_shape, dtype=data_dtype)
         weight = relay.var("weight", shape=w_shape, dtype="int8")
@@ -2171,8 +2171,10 @@ def test_conv2d_int8_alter_dtype():
     bias_np = np.random.randint(low=-127, high=128, size=bias_shape).astype("int32")
     weight_np = np.random.uniform(-128, 127, size=weight_shape).astype("int8")
 
-    for data_dtype, target, dot_product_instr in [("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot"),
-                                                  ("int8", "llvm -mcpu=cascadelake", "vpdpbusd")]:
+    for data_dtype, target, dot_product_instr in [
+        ("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot"),
+        ("int8", "llvm -mcpu=cascadelake", "vpdpbusd"),
+    ]:
         conv2d = get_conv2d_nchw(data_shape, weight_shape, data_dtype)
         bias_add = relay.add(conv2d, bias)
         mod = tvm.IRModule.from_expr(bias_add)


### PR DESCRIPTION
The logic in https://github.com/apache/tvm/blob/52d6b59a39f503fe382b4d7cbac4b02f9e44aae0/python/tvm/topi/generic/conv2d.py#L480-L499 is supposed to legalize the input dtype to be able to apply target-specific intrinsics that only support one of int8 or uint8. For example, the x86 VNNI instruction only supports uint8 activation. 

But the logic is incorrect (two cases are flipped) and leads to incorrect result in the following case:

* The input activation is int8, and we want to use the x86 VNNI intrinsic which only supports uint8 activations.
* The input activation is uint8, and we want to use the ARM `sdot` intrinsic which only supports int8 activations.

The first case also applies to the Hexagon `vrmpy` intrinsic. I found this bug while testing `vrmpy` conv2d on int8 input.

To test this on CI, we need to be running on a cascadelake or ARM v8.2 (with dot product support) instance. I cannot find a way to detect such cpu feature from a python script. `try / catch` doesn't work because the error is raised from LLVM (`LLVM ERROR: Do not know how to split the result of this operator`) that I don't know how to catch. So for now the test is skipped. Any suggestion on this? @areusch @driazati 

cc @tkonolige @mbrookhart    