### PR TITLE
[MetaSchedule][UX] User Interface for Jupyter Notebook

### DIFF
--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -61,23 +61,23 @@ def _get_network(
         assert layout is None or layout in ["NCHW", "NHWC"]
 
         if name in ["resnet_18", "resnet_50"]:
-            model = getattr(models, name.replace("_", ""))(pretrained=False)
+            model = getattr(models, name.replace("_", ""))(weights=None)
         elif name == "wide_resnet_50":
-            model = getattr(models, "wide_resnet50_2")(pretrained=False)
+            model = getattr(models, "wide_resnet50_2")(weights=None)
         elif name == "resnext_50":
-            model = getattr(models, "resnext50_32x4d")(pretrained=False)
+            model = getattr(models, "resnext50_32x4d")(weights=None)
         elif name == "mobilenet_v2":
-            model = getattr(models, name)(pretrained=False)
+            model = getattr(models, name)(weights=None)
         elif name == "mobilenet_v3":
-            model = getattr(models, name + "_large")(pretrained=False)
+            model = getattr(models, name + "_large")(weights=None)
         elif name == "inception_v3":
-            model = getattr(models, name)(pretrained=False, aux_logits=False)
+            model = getattr(models, name)(weights=None, aux_logits=False)
         elif name == "densenet_121":
-            model = getattr(models, name.replace("_", ""))(pretrained=False)
+            model = getattr(models, name.replace("_", ""))(weights=None)
         elif name == "resnet3d_18":
-            model = models.video.r3d_18(pretrained=False)
+            model = models.video.r3d_18(weights=None)
         elif name == "vgg_16":
-            model = getattr(models, name.replace("_", ""))(pretrained=False)
+            model = getattr(models, name.replace("_", ""))(weights=None)
 
         dtype = "float32"
         input_data = torch.randn(input_shape).type(  # pylint: disable=no-member

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -371,9 +371,25 @@ def make_logging_func(logger: logging.Logger) -> Optional[Callable]:
     }
 
     def logging_func(level: int, msg: str):
-        level2log[level](msg)
+        def clear_notebook_output():
+            from IPython.display import clear_output  # pylint: disable=import-outside-toplevel
+
+            clear_output(wait=True)
+
+        if level < 0:
+            clear_notebook_output()
+        else:
+            level2log[level](msg)
 
     return logging_func
+
+
+@register_func("meta_schedule.using_ipython")
+def _check_ipython_env():
+    try:
+        return get_ipython().__class__.__name__ == "ZMQInteractiveShell"  # type: ignore
+    except NameError:
+        return False
 
 
 def parameterize_config(config: Dict[str, Any], params: Dict[str, str]) -> Dict[str, Any]:

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -372,7 +372,7 @@ def make_logging_func(logger: logging.Logger) -> Optional[Callable]:
 
     def logging_func(level: int, msg: str):
         def clear_notebook_output():
-            from IPython.display import clear_output  # pylint: disable=import-outside-toplevel
+            from IPython.display import clear_output  # type: ignore # pylint: disable=import-outside-toplevel
 
             clear_output(wait=True)
 

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -134,7 +134,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
     int n_tasks = task_records_.size();
     // Round robin
     if (num_rounds_already_ == 0) {
-      TVM_PY_LOG(CLEAR, this->logging_func);
+      TVM_PY_LOG_CLEAR_SCREEN(this->logging_func);
       TVM_PY_LOG(INFO, this->logging_func) << "\n" << this->TuningStatistics();
     }
     if (num_rounds_already_ < n_tasks) {
@@ -201,7 +201,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
     }
     record.best_time_cost_history.push_back(best_time_cost);
     record.trials += results.size();
-    TVM_PY_LOG(CLEAR, this->logging_func);
+    TVM_PY_LOG_CLEAR_SCREEN(this->logging_func);
     TVM_PY_LOG(INFO, this->logging_func)
         << "[Updated] Task #" << task_id << ": " << record.task->task_name << "\n"
         << this->TuningStatistics();

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -61,22 +61,46 @@ class GradientBasedNode final : public TaskSchedulerNode {
     int total_trials = 0;
     double total_latency = 0.0;
     support::TablePrinter p;
-    p.Row() << "ID"
-            << "Name"
-            << "FLOP"
-            << "Weight"
-            << "Speed (GFLOPS)"
-            << "Latency (us)"
-            << "Weighted Latency (us)"
-            << "Trials"
-            << "Terminated";
+    bool using_ipython = false;
+    const auto* f_using_ipython = runtime::Registry::Get("meta_schedule.using_ipython");
+    if (f_using_ipython != nullptr) using_ipython = (*f_using_ipython)();
+
+    if (using_ipython) {
+      p.Row() << "ID"
+              << "Name"
+              << "FLOP"
+              << "Weight"
+              << "GFLOPS"
+              << "Latency (us)"
+              << "Wtd. Latency"
+              << "Trials"
+              << "Terminated";
+    } else {
+      p.Row() << "ID"
+              << "Name"
+              << "FLOP"
+              << "Weight"
+              << "Speed (GFLOPS)"
+              << "Latency (us)"
+              << "Weighted Latency (us)"
+              << "Trials"
+              << "Terminated";
+    }
+
     p.Separator();
+
     for (int i = 0; i < n_tasks; ++i) {
       const TaskRecord& record = task_records_[i];
       auto row = p.Row();
       int trials = record.trials;
+      String task_name = record.task->task_name.value();
+      if (using_ipython && task_name.length() > 23) {
+        std::string temp = task_name.c_str();
+        temp = temp.substr(0, 20) + "...";
+        task_name = String(temp);
+      }
       row << /*id=*/i                                     //
-          << /*name=*/record.task->task_name.value()      //
+          << /*name=*/task_name                           //
           << /*flops=*/static_cast<int64_t>(record.flop)  //
           << /*weight=*/static_cast<int>(record.weight);
       double latency = 1e9;
@@ -101,9 +125,10 @@ class GradientBasedNode final : public TaskSchedulerNode {
       }
     }
     p.Separator();
-    os << p.AsStr()                                  //
-       << "\nTotal trials: " << total_trials         //
-       << "\nTotal latency (us): " << total_latency  //
+    os << p.AsStr()                                                    //
+       << "\nProgress: " << total_trials / (max_trials * 0.01) << "%"  //
+       << "\nTotal Trials: " << total_trials << " / " << max_trials    //
+       << "\nTotal latency (us): " << total_latency                    //
        << "\n";
     return os.str();
   }
@@ -112,6 +137,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
     int n_tasks = task_records_.size();
     // Round robin
     if (num_rounds_already_ == 0) {
+      TVM_PY_LOG(CLEAR, this->logging_func);
       TVM_PY_LOG(INFO, this->logging_func) << "\n" << this->TuningStatistics();
     }
     if (num_rounds_already_ < n_tasks) {
@@ -178,6 +204,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
     }
     record.best_time_cost_history.push_back(best_time_cost);
     record.trials += results.size();
+    TVM_PY_LOG(CLEAR, this->logging_func);
     TVM_PY_LOG(INFO, this->logging_func)
         << "[Updated] Task #" << task_id << ": " << record.task->task_name << "\n"
         << this->TuningStatistics();

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -61,11 +61,8 @@ class GradientBasedNode final : public TaskSchedulerNode {
     int total_trials = 0;
     double total_latency = 0.0;
     support::TablePrinter p;
-    bool using_ipython = false;
-    const auto* f_using_ipython = runtime::Registry::Get("meta_schedule.using_ipython");
-    if (f_using_ipython != nullptr) using_ipython = (*f_using_ipython)();
 
-    if (using_ipython) {
+    if (using_ipython()) {
       p.Row() << "ID"
               << "Name"
               << "FLOP"
@@ -94,7 +91,7 @@ class GradientBasedNode final : public TaskSchedulerNode {
       auto row = p.Row();
       int trials = record.trials;
       String task_name = record.task->task_name.value();
-      if (using_ipython && task_name.length() > 23) {
+      if (using_ipython() && task_name.length() > 23) {
         std::string temp = task_name.c_str();
         temp = temp.substr(0, 20) + "...";
         task_name = String(temp);

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -70,6 +70,7 @@ namespace meta_schedule {
 class PyLogMessage {
  public:
   enum class Level : int32_t {
+    CLEAR = -10,
     DEBUG = 10,
     INFO = 20,
     WARNING = 30,

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -115,11 +115,11 @@ class tvmgen_default_fused_layout_transform_1:
 @pytest.mark.parametrize(
     "model_name, input_shape, target, layout",
     [
-        ("resnet_18", [1, 3, 224, 224], "llvm --num-cores=16", "NHWC"),
+        ("resnet_18", [1, 3, 224, 224], "llvm --num-cores=12", "NHWC"),
         ("resnet_18", [1, 3, 224, 224], "nvidia/geforce-rtx-3070", "NHWC"),
-        ("mobilenet_v2", [1, 3, 224, 224], "llvm --num-cores=16", "NHWC"),
+        ("mobilenet_v2", [1, 3, 224, 224], "llvm --num-cores=12", "NHWC"),
         ("mobilenet_v2", [1, 3, 224, 224], "nvidia/geforce-rtx-3070", "NHWC"),
-        ("bert_base", [1, 64], "llvm --num-cores=16", None),
+        ("bert_base", [1, 64], "llvm --num-cores=12", None),
         ("bert_base", [1, 64], "nvidia/geforce-rtx-3070", None),
     ],
 )
@@ -242,7 +242,7 @@ def test_meta_schedule_te2primfunc_argument_order():
 
     input_name = "data"
     dev = tvm.cpu()
-    target = Target("llvm --num-cores=16")
+    target = Target("llvm --num-cores=12")
     data = tvm.nd.array(data_sample, dev)
 
     database = TestDummyDatabase()
@@ -250,7 +250,7 @@ def test_meta_schedule_te2primfunc_argument_order():
     database.commit_workload(tvmgen_default_fused_layout_transform_1)
     database.commit_workload(tvmgen_default_fused_nn_contrib_conv2d_NCHWc)
 
-    with database, tvm.transform.PassContext(
+    with database, tvm.transform.PassContext(  # pylint: disable=not-context-manager
         opt_level=3,
         config={"relay.backend.use_meta_schedule": True},
     ):
@@ -295,7 +295,7 @@ def test_meta_schedule_relay_lowering():
 
     input_name = "data"
     dev = tvm.cpu()
-    target = Target("llvm --num-cores=16")
+    target = Target("llvm --num-cores=12")
     data = tvm.nd.array(data_sample, dev)
 
     with tempfile.TemporaryDirectory() as work_dir:
@@ -542,11 +542,11 @@ def test_tune_relay_manual_tir_vnni():
 
 
 if __name__ == """__main__""":
-    test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "llvm --num-cores=16", None)
+    test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "llvm --num-cores=12", None)
     test_meta_schedule_tune_relay("resnet_18", [1, 3, 224, 224], "nvidia/geforce-rtx-3070", "NCHW")
-    test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "llvm --num-cores=16", None)
+    test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "llvm --num-cores=12", None)
     test_meta_schedule_tune_relay("mobilenet_v2", [1, 3, 224, 224], "nvidia/geforce-rtx-3070", None)
-    test_meta_schedule_tune_relay("bert_base", [1, 64], "llvm --num-cores=16", None)
+    test_meta_schedule_tune_relay("bert_base", [1, 64], "llvm --num-cores=12", None)
     test_meta_schedule_tune_relay("bert_base", [1, 64], "nvidia/geforce-rtx-3070", None)
     test_meta_schedule_te2primfunc_argument_order()
     test_meta_schedule_relay_lowering()


### PR DESCRIPTION
Previously the tuning process would generate significant amount of logging to screen, which would be troublesome for jupyter notebook usage. This PR proposes several changes to fit in the usage on jupyter:
 - The output would [automatically clean up](http://ipython.org/ipython-doc/dev/api/generated/IPython.display.html#IPython.display.clear_output) each time a new tuning result table is generated, i.e., in the beginning of tuning after initializing all tasks, and after each task join.
 - Slim version of the table is available when ipython environment is used so that the table can fit in output area of the notebook.
   - Sample slim table:
      ```
       ID |                    Name |      FLOP | Weight |   GFLOPS | Latency (us) | Wtd. Latency | Trials | Terminated 
      ------------------------------------------------------------------------------------------------------------------
        0 |     fused_nn_conv2d_add |  12870144 |      1 | 154.0759 |      83.5312 |      83.5312 |     32 |            
        1 |   fused_nn_conv2d_add_1 |  12895232 |      1 | 186.2171 |      69.2484 |      69.2484 |     32 |            
        2 |   fused_nn_conv2d_add_2 |  12945408 |      1 | 212.0639 |      61.0449 |      61.0449 |     32 |            
        3 |  fused_layout_transform |         1 |      1 |   0.0000 |      23.1081 |      23.1081 |      1 |            
        4 | fused_nn_conv2d_add_... | 237633536 |      1 | 180.0741 |    1319.6433 |    1319.6433 |     32 |            
        5 |     fused_nn_max_pool2d |   1806336 |      1 |  40.6316 |      44.4564 |      44.4564 |     32 |            
        6 | fused_nn_conv2d_add_... | 231612416 |      2 | 276.8975 |     836.4555 |    1672.9111 |     32 |            
        7 | fused_nn_conv2d_add_... | 231813120 |      2 | 100.5202 |    2306.1349 |    4612.2697 |     32 |            
        8 | fused_nn_conv2d_add_... | 115806208 |      1 | 139.2956 |     831.3701 |     831.3701 |     32 |            
        9 | fused_nn_contrib_con... |  93227008 |      1 | 125.3350 |     743.8227 |     743.8227 |     32 |            
       10 | fused_nn_contrib_con... |  93327360 |      2 | 152.6041 |     611.5651 |    1223.1302 |     32 |            
       11 | fused_nn_conv2d_add_... | 115705856 |      1 |  92.3480 |    1252.9333 |    1252.9333 |     32 |            
       12 | fused_nn_contrib_con... |  98600960 |      1 | 151.7883 |     649.5951 |     649.5951 |     32 |            
       13 | fused_nn_contrib_con... |  98651136 |      2 |  21.0946 |    4676.5961 |    9353.1921 |     32 |            
       14 | fused_nn_conv2d_add_... | 115655680 |      1 |  50.2975 |    2299.4334 |    2299.4334 |     32 |            
       15 | fused_nn_conv2d_add_... | 231261184 |      1 |  51.0481 |    4530.2563 |    4530.2563 |     32 |            
       16 | fused_nn_conv2d_add_... | 231286272 |      2 | 123.8502 |    1867.4684 |    3734.9369 |     32 |            
       17 | fused_nn_adaptive_av... |     25600 |      1 |   5.5381 |       4.6225 |       4.6225 |     32 |            
       18 | fused_layout_transfo... |         1 |      1 |   0.0002 |       4.4801 |       4.4801 |      1 |            
       19 |      fused_nn_dense_add |   1025000 |      1 |  46.7726 |      21.9145 |      21.9145 |     32 |            
      ------------------------------------------------------------------------------------------------------------------
      ```
 - Added progress of tuning shown as percentage.
     - Example:
       ```
       Progress: 57.8%
       Total Trials: 578 / 1000
       Total latency (us): 32535.9
       ```

