### PR TITLE
[Fix][Docs][PAPI] Removed brackets around 'data'

### DIFF
--- a/docs/how_to/profile/papi.rst
+++ b/docs/how_to/profile/papi.rst
@@ -71,7 +71,7 @@ is an example:
 
     data = tvm.nd.array(np.random.rand(1, 1, 28, 28).astype("float32"), device=dev)
     report = vm.profile(
-        [data],
+        data,
         func_name="main",
         collectors=[tvm.runtime.profiling.PAPIMetricCollector()],
     )


### PR DESCRIPTION
Following [this discussion]( https://discuss.tvm.apache.org/t/error-using-vm-to-profile-downcast-from-runtime-adt-to-runtime-ndarray-failed/13557/2) from apache TVM discuss forums

The code of the tutorial won't run with these brackets