### PR TITLE
[ONNX] Fix test_roi_align failure

### DIFF
--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4481,6 +4481,7 @@ def test_roi_align(target, dev):
 
         node = helper.make_node(
             "RoiAlign",
+            coordinate_transformation_mode="output_half_pixel",
             inputs=["X", "rois", "batch_indices"],
             outputs=["Y"],
             mode=mode,


### PR DESCRIPTION
RoiAlign-16 introduces `coordinate_transformation_mode`, which should be set to 'output_half_pixel' to omit the pixel shift for the input (for a backward-compatible behavior). This PR should fix the failure in https://ci.tlcpack.ai/job/docker-images-ci/job/docker-image-run-tests/231/testReport/junit/cython.tests.python.frontend.onnx/test_forward/Test___frontend__GPU_3_of_6___test_roi_align_cuda_/ 