### PR TITLE
[Relay] Fix handling of TransfromLayout in TE compiler cache

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -374,7 +374,7 @@ class ScheduleBuilder : public ExprVisitor {
             TuningRecord record = opt_record.value();
             for (const Instruction& inst : record->trace->insts) {
               if (inst->kind.same_as(kind_transform_layout)) {
-                ICHECK_EQ(inst->attrs.size(), 3);
+                ICHECK_EQ(inst->attrs.size(), 4);
                 MetaScheduleLayoutRewriter::LayoutQueuePush(Downcast<IndexMap>(inst->attrs[2]));
               }
             }


### PR DESCRIPTION
Because of recent updates `TransformLayout` now has 4 attrs. https://github.com/apache/tvm/blob/main/src/tir/schedule/primitive/layout_transformation.cc#L1348

cc @junrushao 