### PR TITLE
[TIR] Fix wmma index in CUDA tensor intrins

### DIFF
--- a/python/tvm/tir/tensor_intrin/cuda.py
+++ b/python/tvm/tir/tensor_intrin/cuda.py
@@ -489,10 +489,13 @@ TensorIntrin.register(
 ######## WMMA intrinsics ########
 
 
-def get_wmma_fragment_index(buffer, m_dim, n_dim):
+def get_wmma_fragment_index(buffer, stride, m_dim, n_dim):
     """Compute wmma fragment index using elem_offset of the buffer"""
-    frag_size = lift(m_dim * n_dim)
-    return buffer.elem_offset // frag_size + (buffer.elem_offset % frag_size) // n_dim
+    frag_index_m = buffer.elem_offset // stride // m_dim
+    frag_index_n = buffer.elem_offset % stride // n_dim
+
+    num_fragments_per_row = stride // n_dim
+    return frag_index_m * num_fragments_per_row + frag_index_n
 
 
 def get_wmma_load_intrin(
@@ -526,6 +529,8 @@ def get_wmma_load_intrin(
     def wmma_load_impl(a: T.handle, c: T.handle) -> None:
         s1 = T.var("int32")
         s0 = T.var("int32")
+        d1 = T.var("int32")
+        d0 = T.var("int32")
         A = T.match_buffer(
             a,
             (m_dim, n_dim),
@@ -536,7 +541,13 @@ def get_wmma_load_intrin(
             strides=[s1, s0],
         )
         C = T.match_buffer(
-            c, (m_dim, n_dim), dtype, align=64, offset_factor=16, scope=wmma_fragment_scope
+            c,
+            (m_dim, n_dim),
+            dtype,
+            align=64,
+            offset_factor=16,
+            scope=wmma_fragment_scope,
+            strides=[d1, d0],
         )
         with T.block("root"):
             T.reads(A[0:m_dim, 0:n_dim])
@@ -547,7 +558,7 @@ def get_wmma_load_intrin(
                     m_dim,
                     n_dim,
                     k_dim,
-                    get_wmma_fragment_index(C, m_dim, n_dim),
+                    get_wmma_fragment_index(C, d1, m_dim, n_dim),
                     A.access_ptr("r"),
                     s1,
                     layout,
@@ -579,8 +590,16 @@ def get_wmma_fill_intrin(
 
     @T.prim_func
     def wmma_fill_impl(c: T.handle) -> None:
+        d1 = T.var("int32")
+        d0 = T.var("int32")
         C = T.match_buffer(
-            c, (m_dim, n_dim), dtype, align=64, offset_factor=16, scope="wmma.accumulator"
+            c,
+            (m_dim, n_dim),
+            dtype,
+            align=64,
+            offset_factor=16,
+            scope="wmma.accumulator",
+            strides=[d1, d0],
         )
         with T.block("root"):
             T.reads()
@@ -591,7 +610,7 @@ def get_wmma_fill_intrin(
                     m_dim,
                     n_dim,
                     k_dim,
-                    get_wmma_fragment_index(C, m_dim, n_dim),
+                    get_wmma_fragment_index(C, d1, m_dim, n_dim),
                     T.float32(0),
                     dtype="handle",
                 )
@@ -623,8 +642,16 @@ def get_wmma_store_intrin(
     def wmma_store_impl(a: T.handle, c: T.handle) -> None:
         s1 = T.var("int32")
         s0 = T.var("int32")
+        d1 = T.var("int32")
+        d0 = T.var("int32")
         A = T.match_buffer(
-            a, (m_dim, n_dim), dtype, align=64, offset_factor=16, scope="wmma.accumulator"
+            a,
+            (m_dim, n_dim),
+            dtype,
+            align=64,
+            offset_factor=16,
+            scope="wmma.accumulator",
+            strides=[d1, d0],
         )
         C = T.match_buffer(
             c, (m_dim, n_dim), dtype, align=64, offset_factor=16, scope=scope, strides=[s1, s0]
@@ -638,7 +665,7 @@ def get_wmma_store_intrin(
                     m_dim,
                     n_dim,
                     k_dim,
-                    get_wmma_fragment_index(A, m_dim, n_dim),
+                    get_wmma_fragment_index(A, d1, m_dim, n_dim),
                     C.access_ptr("w"),
                     s1,
                     "row_major",
@@ -696,8 +723,21 @@ def get_wmma_sync_intrin(
 
     @T.prim_func
     def wmma_sync_impl(a: T.handle, b: T.handle, c: T.handle) -> None:
+        a1 = T.var("int32")
+        a0 = T.var("int32")
+        b1 = T.var("int32")
+        b0 = T.var("int32")
+        c1 = T.var("int32")
+        c0 = T.var("int32")
+
         A = T.match_buffer(
-            a, (m_dim, k_dim), in_dtype, align=64, offset_factor=16, scope="wmma.matrix_a"
+            a,
+            (m_dim, k_dim),
+            in_dtype,
+            align=64,
+            offset_factor=16,
+            scope="wmma.matrix_a",
+            strides=[a1, a0],
         )
         B = T.match_buffer(
             b,
@@ -706,9 +746,16 @@ def get_wmma_sync_intrin(
             align=64,
             offset_factor=16,
             scope="wmma.matrix_b",
+            strides=[b1, b0],
         )
         C = T.match_buffer(
-            c, (m_dim, n_dim), out_dtype, align=64, offset_factor=16, scope="wmma.accumulator"
+            c,
+            (m_dim, n_dim),
+            out_dtype,
+            align=64,
+            offset_factor=16,
+            scope="wmma.accumulator",
+            strides=[c1, c0],
         )
 
         with T.block("root"):
@@ -717,13 +764,13 @@ def get_wmma_sync_intrin(
             T.evaluate(
                 T.tvm_mma_sync(
                     C.data,
-                    get_wmma_fragment_index(C, m_dim, n_dim),
+                    get_wmma_fragment_index(C, c1, m_dim, n_dim),
                     A.data,
-                    get_wmma_fragment_index(A, m_dim, k_dim),
+                    get_wmma_fragment_index(A, a1, m_dim, k_dim),
                     B.data,
-                    get_wmma_fragment_index(B, b_shape_0, b_shape_1),
+                    get_wmma_fragment_index(B, b1, b_shape_0, b_shape_1),
                     C.data,
-                    get_wmma_fragment_index(C, m_dim, n_dim),
+                    get_wmma_fragment_index(C, c1, m_dim, n_dim),
                     dtype="handle",
                 )
             )


### PR DESCRIPTION
There are some corner cases `get_wmma_fragment_index` returns wrong result when the size of shared memory is large. In practice, such case usually won't happen because the size of the shared memory is limited.

cc @spectrometerHBH 