### PR TITLE
[usmp] Also remap VarNode to USMP-allocated buffer

### DIFF
--- a/src/tir/usmp/analysis/extract_buffer_info.cc
+++ b/src/tir/usmp/analysis/extract_buffer_info.cc
@@ -429,15 +429,17 @@ void BufferInfoExtractor::VisitExpr_(const VarNode* op) {
 
 Array<Var> static GetMatchedBuffers(const PrimFunc& func) {
   Array<Var> buffer_vars;
-  for (unsigned int i = 0; i < func->params.size() - 1; i++) {
-    Var param = func->params[i];
-    buffer_vars.push_back(func->buffer_map[param]->data);
-  }
-  Var last_param = func->params.back();
-  // Checks whether last var is present in the buffer map
-  // because it could be the resource handle
-  if (func->buffer_map.find(last_param) != func->buffer_map.end()) {
-    buffer_vars.push_back(func->buffer_map[last_param]->data);
+  if (func->params.size() > 0) {
+    for (unsigned int i = 0; i < func->params.size() - 1; i++) {
+      Var param = func->params[i];
+      buffer_vars.push_back(func->buffer_map[param]->data);
+    }
+    Var last_param = func->params.back();
+    // Checks whether last var is present in the buffer map
+    // because it could be the resource handle
+    if (func->buffer_map.find(last_param) != func->buffer_map.end()) {
+      buffer_vars.push_back(func->buffer_map[last_param]->data);
+    }
   }
   return buffer_vars;
 }

--- a/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
+++ b/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
@@ -344,14 +344,8 @@ LetStmt PoolAllocationToOffsetConverter::ToLetStmt(const PoolAllocation& pool_al
     let_var_type = PointerType(Downcast<PointerType>(let_var_type)->element_type);
   }
   Var let_var(buffer_var->name_hint + "_let", let_var_type);
-  if (buffer_var->name_hint == "dense") {
-    LOG(INFO) << " Set buffer var: " << let_var;
-  }
   allocate_var_to_let_var_.Set(buffer_var, let_var);
   Stmt new_body = VisitStmt(body);
-  if (buffer_var->name_hint == "dense") {
-    LOG(INFO) << " Erase buffer var: " << let_var;
-  }
   allocate_var_to_let_var_.erase(buffer_var);
   return LetStmt(let_var, address_of_load, new_body);
 }
@@ -404,9 +398,6 @@ PrimExpr PoolAllocationToOffsetConverter::VisitExpr_(const BufferLoadNode* op) {
 
 PrimExpr PoolAllocationToOffsetConverter::VisitExpr_(const VarNode* op) {
   auto it = allocate_var_to_let_var_.find(GetRef<Var>(op));
-  if (op->name_hint == "dense") {
-    LOG(INFO) << "Lookup dense var: " << (it != allocate_var_to_let_var_.end());
-  }
   if (it != allocate_var_to_let_var_.end()) {
     return (*it).second;
   }


### PR DESCRIPTION
This PR fixes cases where a USMP buffer is used with tensorization intrinsics. In these cases, it is common to
write schedules that pass Buffers to extern functions using `access_ptr()`. When transforming tir.allocate into
offsets into global_workspace buffers, USMP inserts a let expression that replaces the old Buffer var with a new
var named "<buffer_var>_let." It then attempts to replace all references to the old var with the new one. When
a Buffer was passed via `access_ptr`, USMP would would previously ignore such instances, producing this error
later on in codegen (dense being the name of the Buffer in use):

```
  "src/target/source/codegen_source_base.cc", line 67
  Check failed: (it != var_idmap_.end()) is false: Find undefined
    Variable dense
```

This patch fixes the problem by replacing the old VarNode with the new one.

cc @lhutton1 @Mousius @leandron @manupak @mehrdadh 