### PR TITLE
[Runtime] Release temp param buffer after creating graph executor

### DIFF
--- a/src/runtime/graph_executor/graph_executor_factory.cc
+++ b/src/runtime/graph_executor/graph_executor_factory.cc
@@ -121,6 +121,8 @@ Module GraphExecutorFactory::ExecutorCreate(const std::vector<Device>& devs) {
   exec->Init(this->graph_json_, this->imports_[0], devs, PackedFunc());
   // set params
   SetParams(exec.get(), this->params_);
+  // release resources since this->params_ will not be used any more during inference.
+  this->params_.clear();
   return Module(exec);
 }
 


### PR DESCRIPTION
```c++
Module GraphExecutorFactory::ExecutorCreate(const std::vector<Device>& devs) {
  auto exec = make_object<GraphExecutor>();
  exec->Init(this->graph_json_, this->imports_[0], devs, PackedFunc());
  // set params
  SetParams(exec.get(), this->params_);
  return Module(exec);
}
```
In the code block above, `params_` is defined as `std::unordered_map<std::string, tvm::runtime::NDArray>` and holds a copy of parameters deserialized from DSO model. After creating the graph executor this copy of parameters still resides in memory. It will waste lots of memory usage if the model is big.
Take `resnet101` as an example. The size of the parameters is about 170.49 MB. The picture below is the reported memory map of the process which inference with `resnet101`. The RSS in the anonymous mapping space is about 350 MB.
![image](https://user-images.githubusercontent.com/18597737/191883103-02ab8e30-966f-4ee7-95fe-f3c3bd3b4a9d.png)

We can release `this->params_` by `this->params_.clear()`. After release, the RSS decreases to 180 MB.
![image](https://user-images.githubusercontent.com/18597737/191882947-59b2a1d7-f381-4c52-819f-3437bbe16041.png)
