### PR TITLE
[CI] Add Zephyr-SDK binaries to PATH env. in ci_cortexm

### DIFF
--- a/docker/Dockerfile.ci_cortexm
+++ b/docker/Dockerfile.ci_cortexm
@@ -79,6 +79,7 @@ COPY install/ubuntu_init_zephyr_project.sh /install/ubuntu_init_zephyr_project.s
 COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
 RUN bash /install/ubuntu_install_zephyr.sh
 ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
+ENV PATH /opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
 
 # FreeRTOS deps
 COPY install/ubuntu_install_freertos.sh /install/ubuntu_install_freertos.sh


### PR DESCRIPTION
In recent test rounds with updated images, it seems Zephyr-SDK binaries such as various QEMU related files are missing from $PATH, which makes Zephyr tests to fail with, e.g. "qemu-system-i386: command not found".

This PR adds those missing binaries to $PATH.

cc @areusch @gromero @mehrdadh @driazati for reviews