### PR TITLE
[ETHOSN] Support conversion of add/mul to requantize where possible

### DIFF
--- a/src/relay/backend/contrib/ethosn/codegen_ethosn.h
+++ b/src/relay/backend/contrib/ethosn/codegen_ethosn.h
@@ -213,6 +213,7 @@ class ConstructNetworkVisitor : public MixedModeVisitor, private ErrorReportingP
   EthosnError MakeReluLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeLeakyReLULayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeRequantizeLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
+  EthosnError MakeReinterpretQuantizeLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
   EthosnError MakeResizeLayer(const Call& call, sl::TensorAndId<sl::Operand>* out);
 
   /*! \brief A look-up table from Expr to layers. */

--- a/src/relay/backend/contrib/ethosn/ethosn_api.h
+++ b/src/relay/backend/contrib/ethosn/ethosn_api.h
@@ -157,6 +157,12 @@ struct RequantizeParams {
   sl::TensorInfo output_info;
 };
 
+struct ReinterpretQuantizationParams {
+  sl::ReinterpretQuantizationInfo reinterpret_quantize_info;
+  sl::TensorInfo input_info;
+  sl::TensorInfo output_info;
+};
+
 struct ResizeParams {
   sl::ResizeInfo resize_info;
   sl::TensorInfo input_info;
@@ -261,6 +267,16 @@ class EthosnAPI {
   static EthosnError Relu(const Expr& expr, ReluParams* params);
   /*! \brief Extract the Support Library requantize params from a Relay qnn.requantize call */
   static EthosnError Requantize(const Expr& expr, RequantizeParams* params);
+
+  /*!
+   * \brief Extact the Support Library reinterpret quantization params from a Relay qnn.requantize
+   * call.
+   *
+   * \note This is used for the conversion from add and mul to a reinterpret quantization operator.
+   * This is effectively an identity operation, as not the same as 'requantize'.
+   */
+  static EthosnError ReinterpretQuantize(const Expr& expr, ReinterpretQuantizationParams* params);
+
   /*! \brief Extract the Support Library resize params from a Relay resize call */
   static EthosnError Resize(const Expr& expr, ResizeParams* params);
 

--- a/tests/python/contrib/test_ethosn/test_convert_equivalents.py
+++ b/tests/python/contrib/test_ethosn/test_convert_equivalents.py
@@ -74,7 +74,7 @@ def test_multiply_to_depthwise(dtype, shape, channels, reverse_inputs):
             relay.const(output_sc, "float32"),
             relay.const(output_zp, "int32"),
         )
-        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_mul")
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_mul_to_depthwise")
         return tei.make_ethosn_partition(composite)
 
     def expected():
@@ -118,6 +118,165 @@ def test_multiply_to_depthwise(dtype, shape, channels, reverse_inputs):
 
 
 @requires_ethosn
+@pytest.mark.parametrize(
+    "dtype,shape,constant_shape",
+    [("int8", (1, 4, 4), (4,)), ("int16", (1, 16, 12, 4), (1, 1, 1, 4))],
+)
+def test_unsupported_multiply_to_depthwise(dtype, shape, constant_shape):
+    """Check that unsupported variants of multiply to depthwise are not converted."""
+    np.random.seed(0)
+
+    iinfo = np.iinfo(dtype)
+    data_min = iinfo.min
+    data_max = iinfo.max
+    input_zp = np.random.randint(data_min, data_max)
+    input_sc = np.random.random() * 2
+    input2_zp = np.random.randint(data_min, data_max)
+    input2_sc = np.random.random() * 2
+    output_zp, output_sc = tei.get_conv2d_qnn_params(
+        dtype, input_zp, input_sc, input2_zp, input2_sc, 1, 1, shape[-1]
+    )
+    x = relay.var("x", shape=shape, dtype=dtype)
+    y_data = np.random.randint(data_min, data_max + 1, size=constant_shape, dtype=dtype)
+
+    def before():
+        y = relay.const(y_data, dtype=dtype)
+        expr = relay.qnn.op.mul(
+            x,
+            y,
+            relay.const(input_sc, "float32"),
+            relay.const(input_zp, "int32"),
+            relay.const(input2_sc, "float32"),
+            relay.const(input2_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_mul_to_depthwise")
+        return tei.make_ethosn_partition(composite)
+
+    mod = before()
+
+    error_regex = (
+        r'Operation "ethos-n.qnn_mul_to_depthwise" was marked '
+        r"as having a valid conversion, but it could not be converted."
+    )
+
+    with pytest.raises(tvm.TVMError, match=error_regex):
+        mod = ConvertEquivalents()(mod)
+
+
+@requires_ethosn
+@pytest.mark.parametrize(
+    "shape,constant_shape",
+    [((1, 4, 4, 8), (1, 1, 1, 1)), ((1, 16, 12, 4), None)],
+)
+@pytest.mark.parametrize("reverse_inputs", [True, False])
+def test_multiply_to_reinterpret_quantize(shape, constant_shape, reverse_inputs):
+    """Check that multiply is correctly converted to a reinterpret quantize operation."""
+    np.random.seed(0)
+
+    dtype = "uint8"
+
+    # Multiply can only be offloaded as a reinterpret quantize operation if
+    # it is an identity option. We must choose the quantization and constant
+    # data carefully to make sure that this is the case.
+    input_zp = 0
+    input_sc = 0.007814894430339336
+    input2_zp = 0
+    input2_sc = 0.5
+    output_zp = 0
+    output_sc = 0.9963990449905396
+    constant_data = 255
+
+    x = relay.var("x", shape=shape, dtype=dtype)
+    y_data = np.array(constant_data, dtype=dtype).reshape(constant_shape)
+
+    def before():
+        y = relay.const(y_data, dtype=dtype)
+        expr = relay.qnn.op.mul(
+            y if reverse_inputs else x,
+            x if reverse_inputs else y,
+            relay.const(input2_sc if reverse_inputs else input_sc, "float32"),
+            relay.const(input2_zp if reverse_inputs else input_zp, "int32"),
+            relay.const(input_sc if reverse_inputs else input2_sc, "float32"),
+            relay.const(input_zp if reverse_inputs else input2_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_mul_to_reinterpret_quantize")
+        return tei.make_ethosn_partition(composite)
+
+    def expected():
+        expr = relay.qnn.op.requantize(
+            x,
+            relay.const(input_sc, "float32"),
+            relay.const(input_zp if reverse_inputs else input_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+            out_dtype=dtype,
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_reinterpret_quantize")
+        return tei.make_ethosn_partition(composite)
+
+    mod = before()
+    mod = ConvertEquivalents()(mod)
+    expected_mod = expected()
+    _assert_structural_equal(mod["ethos-n_0"], expected_mod["ethos-n_0"])
+
+
+@requires_ethosn
+@pytest.mark.parametrize(
+    "dtype,shape,constant_shape",
+    [("int16", (1, 16, 12, 4), None)],
+)
+def test_unsupported_multiply_to_reinterpret_quantize(dtype, shape, constant_shape):
+    """
+    Check that unsupported variants of multiply conversion to reinterpret
+    quantize are not converted.
+    """
+    np.random.seed(0)
+
+    # Multiply can only be offloaded as a reinterpret quantize operation if
+    # it is an identity option. We must choose the quantization and constant
+    # data carefully to make sure that this is the case.
+    input_zp = 0
+    input_sc = 0.007814894430339336
+    input2_zp = 0
+    input2_sc = 0.5
+    output_zp = 0
+    output_sc = 0.9963990449905396
+    constant_data = 255
+
+    x = relay.var("x", shape=shape, dtype=dtype)
+    y_data = np.array(constant_data, dtype=dtype).reshape(constant_shape)
+
+    def before():
+        y = relay.const(y_data, dtype=dtype)
+        expr = relay.qnn.op.mul(
+            x,
+            y,
+            relay.const(input_sc, "float32"),
+            relay.const(input_zp, "int32"),
+            relay.const(input2_sc, "float32"),
+            relay.const(input2_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_mul_to_reinterpret_quantize")
+        return tei.make_ethosn_partition(composite)
+
+    mod = before()
+
+    error_regex = (
+        r'Operation "ethos-n.qnn_mul_to_reinterpret_quantize" was marked '
+        r"as having a valid conversion, but it could not be converted."
+    )
+
+    with pytest.raises(tvm.TVMError, match=error_regex):
+        mod = ConvertEquivalents()(mod)
+
+
+@requires_ethosn
 @pytest.mark.parametrize("reverse_inputs", [True, False])
 def test_add_to_depthwise(reverse_inputs):
     """
@@ -148,7 +307,7 @@ def test_add_to_depthwise(reverse_inputs):
             output_scale=relay.const(out_sc, "float32"),
             output_zero_point=relay.const(out_zp, "int32"),
         )
-        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_add")
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_add_to_depthwise")
         return tei.make_ethosn_partition(composite)
 
     class ConversionChecker(ExprVisitor):
@@ -176,3 +335,158 @@ def test_add_to_depthwise(reverse_inputs):
     mod = before()
     mod = ConvertEquivalents()(mod)
     mod = ConversionChecker().visit(mod["ethos-n_0"].body.op)
+
+
+@requires_ethosn
+@pytest.mark.parametrize(
+    "dtype,lhs_shape,rhs_shape", [("uint8", (1, 4, 4), (1, 1, 4)), ("int16", (1, 4, 4, 4), (4,))]
+)
+def test_unsupported_add_to_depthwise(dtype, lhs_shape, rhs_shape):
+    """Check that unsupported variants of add are not converted."""
+    np.random.seed(0)
+
+    iinfo = np.iinfo(dtype)
+    data_min = iinfo.min
+    data_max = iinfo.max
+    lhs_zp, lhs_sc, rhs_zp, rhs_sc, out_zp, out_sc = _get_addition_qnn_params(dtype)
+
+    x = relay.var("x", shape=lhs_shape, dtype=dtype)
+    y_data = np.random.randint(data_min, data_max + 1, size=rhs_shape, dtype=dtype)
+
+    def before():
+        y = relay.const(y_data)
+        expr = relay.qnn.op.add(
+            lhs=x,
+            rhs=y,
+            lhs_scale=relay.const(lhs_sc, "float32"),
+            lhs_zero_point=relay.const(lhs_zp, "int32"),
+            rhs_scale=relay.const(rhs_sc, "float32"),
+            rhs_zero_point=relay.const(rhs_zp, "int32"),
+            output_scale=relay.const(out_sc, "float32"),
+            output_zero_point=relay.const(out_zp, "int32"),
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_add_to_depthwise")
+        return tei.make_ethosn_partition(composite)
+
+    mod = before()
+
+    error_regex = (
+        r'Operation "ethos-n.qnn_add_to_depthwise" was marked '
+        r"as having a valid conversion, but it could not be converted."
+    )
+
+    with pytest.raises(tvm.TVMError, match=error_regex):
+        mod = ConvertEquivalents()(mod)
+
+
+@requires_ethosn
+@pytest.mark.parametrize(
+    "shape,constant_shape",
+    [
+        ((1, 4, 4, 8), (1, 1, 1, 1)),
+        ((1, 16, 12, 4), None),
+    ],
+)
+@pytest.mark.parametrize("reverse_inputs", [True, False])
+def test_add_to_reinterpret_quantize(shape, constant_shape, reverse_inputs):
+    """Check that add is correctly converted to a reinterpret quantize operation."""
+    np.random.seed(0)
+
+    dtype = "uint8"
+
+    # Add can only be offloaded as a reinterpret quantize operation if
+    # it is an identity option. We must choose the quantization and constant
+    # data carefully to make sure that this is the case.
+    input_zp = 128
+    input_sc = 0.0078125
+    input2_zp = 0
+    input2_sc = 0.003921568859368563
+    output_zp = 0
+    output_sc = 0.007814894430339336
+    constant_data = 255
+
+    x = relay.var("x", shape=shape, dtype=dtype)
+    y_data = np.array(constant_data, dtype=dtype).reshape(constant_shape)
+
+    def before():
+        y = relay.const(y_data, dtype=dtype)
+        expr = relay.qnn.op.add(
+            y if reverse_inputs else x,
+            x if reverse_inputs else y,
+            relay.const(input2_sc if reverse_inputs else input_sc, "float32"),
+            relay.const(input2_zp if reverse_inputs else input_zp, "int32"),
+            relay.const(input_sc if reverse_inputs else input2_sc, "float32"),
+            relay.const(input_zp if reverse_inputs else input2_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_add_to_reinterpret_quantize")
+        return tei.make_ethosn_partition(composite)
+
+    def expected():
+        expr = relay.qnn.op.requantize(
+            x,
+            relay.const(input_sc, "float32"),
+            relay.const(input_zp if reverse_inputs else input_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+            out_dtype=dtype,
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_reinterpret_quantize")
+        return tei.make_ethosn_partition(composite)
+
+    mod = before()
+    mod = ConvertEquivalents()(mod)
+    expected_mod = expected()
+    _assert_structural_equal(mod["ethos-n_0"], expected_mod["ethos-n_0"])
+
+
+@requires_ethosn
+@pytest.mark.parametrize(
+    "dtype,shape,constant_shape",
+    [
+        ("int16", (1, 16, 12, 4), None),
+    ],
+)
+def test_unsupported_add_to_reinterpret_quantize(dtype, shape, constant_shape):
+    """Check that unsupported variants of add to reinterpret quantize are not converted."""
+    np.random.seed(0)
+
+    # Add can only be offloaded as a reinterpret quantize operation if
+    # it is an identity option. We must choose the quantization and constant
+    # data carefully to make sure that this is the case.
+    input_zp = 128
+    input_sc = 0.0078125
+    input2_zp = 0
+    input2_sc = 0.003921568859368563
+    output_zp = 0
+    output_sc = 0.007814894430339336
+    constant_data = 255
+
+    x = relay.var("x", shape=shape, dtype=dtype)
+    y_data = np.array(constant_data, dtype=dtype).reshape(constant_shape)
+
+    def before():
+        y = relay.const(y_data, dtype=dtype)
+        expr = relay.qnn.op.add(
+            x,
+            y,
+            relay.const(input_sc, "float32"),
+            relay.const(input_zp, "int32"),
+            relay.const(input2_sc, "float32"),
+            relay.const(input2_zp, "int32"),
+            relay.const(output_sc, "float32"),
+            relay.const(output_zp, "int32"),
+        )
+        composite = tei.make_ethosn_composite(expr, "ethos-n.qnn_add_to_reinterpret_quantize")
+        return tei.make_ethosn_partition(composite)
+
+    mod = before()
+
+    error_regex = (
+        r'Operation "ethos-n.qnn_add_to_reinterpret_quantize" was marked '
+        r"as having a valid conversion, but it could not be converted."
+    )
+
+    with pytest.raises(tvm.TVMError, match=error_regex):
+        mod = ConvertEquivalents()(mod)

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -144,7 +144,11 @@ def test_resnet_50_int8():
     # codegen, which could come about from either a change in Support Library
     # version or a change in the Ethos-N codegen. To update this requires running
     # on hardware that isn't available in CI.
-    _compile_hash = {"12d65aec33594c88b6d0d31dcd5144e6", "6a64d69ccb36dfb6b30dd2abdba4b005"}
+    _compile_hash = {
+        "6b130a99397715156d5fb833809a92d2",
+        "6e5fcbab831607b9da1039aff4e56871",
+        "41acecca37b2735bd580f6ec38d8c2e0",
+    }
     _test_image_network(
         model_url="https://raw.githubusercontent.com/dmlc/web-data/main/tensorflow/"
         "models/Quantized/resnet_50_quantized.tflite",
@@ -152,8 +156,8 @@ def test_resnet_50_int8():
         input_dict={"input": (1, 224, 224, 3)},
         compile_hash=_compile_hash,
         output_count=1,
-        host_ops=10,
-        npu_partitions=2,
+        host_ops=9,
+        npu_partitions=3,
     )
 
 


### PR DESCRIPTION
Add/mul operations that correspond to identity operations can be converted to a simple reinterpret quantize operation. This conversion takes place in the convert equivalents pass similar to the depthwise counter-part.

In addtion, an issue was noticed that would cause unsupported operations to raise an error rather than not being offloaded. This has been fixed by allowing the conversion to return Null when the conversion is not supported.

cc @ashutosh-arm @leandron