### PR TITLE
[TVMScript] Infer T.match_buffer parameters for region

### DIFF
--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -464,7 +464,7 @@ def fail_match_load(a: T.handle) -> None:
         with T.block():
             T.reads(A[i, j])
             T.writes([])
-            sub_A = T.match_buffer(A[i, j], ())
+            sub_A = T.match_buffer(A[i, j], (), elem_offset=0)
             T.evaluate(sub_A[()])
 
 
@@ -475,7 +475,7 @@ def fail_match_store(a: T.handle) -> None:
         with T.block():
             T.reads([])
             T.writes(A[i, j])
-            sub_A = T.match_buffer(A[i, j], ())
+            sub_A = T.match_buffer(A[i, j], (), elem_offset=0)
             sub_A[()] = 1
 
 

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -251,6 +251,31 @@ def test_match_buffer_int64():
     assert_structural_equal(original, after_roundtrip, True)
 
 
+def test_match_buffer_region_has_implicit_shape_dtype():
+    @T.prim_func
+    def explicit_shape_dtype(A: T.Buffer[(16, 64), "int32"]):
+        with T.block():
+            B = T.match_buffer(A[8:16, 32:64], shape=(8, 32), dtype="int32")
+            T.evaluate(0)
+
+    @T.prim_func
+    def implicit_shape_dtype(A: T.Buffer[(16, 64), "int32"]):
+        with T.block():
+            B = T.match_buffer(A[8:16, 32:64])
+            T.evaluate(0)
+
+    assert_structural_equal(explicit_shape_dtype, implicit_shape_dtype)
+
+
+def test_match_buffer_input_requires_shape_arg():
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @T.prim_func
+        def func(a: T.handle):
+            A = T.match_buffer(a, dtype="int32")
+            T.evaluate(0)
+
+
 def test_letstmt_bufferload_without_type_annotation():
     # Variable assignment of PrimExpr types uses the dtype of the
     # PrimExpr to determine the variable's dtype.  Parsing of


### PR DESCRIPTION
When using `T.match_buffer` to define a view into another buffer, default shape and dtype parameters can be inferred.