### PR TITLE
[BugFix][Pattern] Fixed a bug in PatternGrouper

### DIFF
--- a/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
+++ b/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
@@ -117,7 +117,8 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
   // operand tensor in a binary op (add or multiply supported via CMSIS-NN path). This applies only
   // to 1st and 2nd arguments of the ops.
   Call ReplaceScalarWithTensorVariable(Call call) {
-    if (!WorthyOfScalarToTensorReplacement(call)) {
+    // Returns if the operands of the binary operator come from the same input.
+    if (!WorthyOfScalarToTensorReplacement(call) || call->args.size() < 2) {
       return call;
     }
     Array<Expr> new_args(call->args);
@@ -146,7 +147,8 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
   // operand tensor in a binary op (add or multiply supported via CMSIS-NN path). This applies only
   // to 1st and 2nd arguments of the ops.
   Call ReplaceScalarWithTensorConstant(Call call, Function func) {
-    if (!WorthyOfScalarToTensorReplacement(func)) {
+    // Returns if the operands of the binary operator come from the same input.
+    if (!WorthyOfScalarToTensorReplacement(func) || call->args.size() < 2) {
       return call;
     }
     Array<Expr> new_args(call->args);

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -646,6 +646,11 @@ void PatternGrouper::CreateGroup(const Expr& expr) {
     auto make_input = [&](const Expr& input) {
       if (fuzzy_matches.count(input) == 0 && input.as<OpNode>() == nullptr &&
           input.as<FunctionNode>() == nullptr && !EmbedConst(input, node->ref())) {
+        // Avoid adding parameters repeatedly because multiple operatorss in the partition
+        // may use the same input.
+        if (inputs.find(input) != inputs.end()) {
+          return;
+        }
         inputs[input] =
             Var("FunctionVar_" + std::to_string(graph_number_) + "_" + std::to_string(var_number),
                 NullValue<Type>());

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -915,14 +915,13 @@ def test_type_check():
         b = relay.var("b", shape=(8,))
 
         x0 = relay.var("x")
-        y0 = relay.var("y")
 
-        add = relay.op.add(y0, y0)
+        add = relay.op.add(x0, x0)
         relu = relay.nn.relu(add)
-        func = relay.Function([x0, y0], relu)
+        func = relay.Function([x0], relu)
         func = func.with_attr("PartitionedFromPattern", "add_nn.relu_")
         func = func.with_attr("Composite", "add_relu")
-        call = relay.Call(func, [x, x])
+        call = relay.Call(func, [x])
 
         conv = relay.nn.conv2d(
             call, w, kernel_size=(3, 3), kernel_layout="OIHW", data_layout="NHWC"
@@ -937,14 +936,13 @@ def test_type_check():
         b = relay.var("b", shape=(8,))
 
         x0 = relay.var("x")
-        y0 = relay.var("y")
 
-        add = relay.op.add(y0, y0)
+        add = relay.op.add(x0, x0)
         relu = relay.nn.relu(add)
-        func = relay.Function([x0, y0], relu)
+        func = relay.Function([x0], relu)
         func = func.with_attr("PartitionedFromPattern", "add_nn.relu_")
         func = func.with_attr("Composite", "add_relu")
-        call = relay.Call(func, [x, x])
+        call = relay.Call(func, [x])
 
         x2 = relay.var("x")
         w1 = relay.var("w")


### PR DESCRIPTION
This commit adds a duplicate check for make_input in PatternGrouper::CreateGroup, fixes a bug where the partitioned function created by CreateGroup would have an unused redundant variable when multiple operators in the partition share an input.