### PR TITLE
[ONNX] Fix test_roi_align failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,16 +49,16 @@
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:20220908-060034-62bdc91b1'
-ci_gpu = 'tlcpack/ci-gpu:20220908-060034-62bdc91b1'
-ci_cpu = 'tlcpack/ci-cpu:20220908-060034-62bdc91b1'
-ci_minimal = 'tlcpack/ci-minimal:20220908-060034-62bdc91b1'
-ci_wasm = 'tlcpack/ci-wasm:20220908-060034-62bdc91b1'
-ci_i386 = 'tlcpack/ci-i386:20220908-060034-62bdc91b1'
-ci_cortexm = 'tlcpack/ci-cortexm:20220909-090211-cb08a1251'
-ci_arm = 'tlcpack/ci-arm:20220908-060034-62bdc91b1'
-ci_hexagon = 'tlcpack/ci-hexagon:20220908-060034-62bdc91b1'
-ci_riscv = 'tlcpack/ci-riscv:20220908-060034-62bdc91b1'
+ci_lint = 'tlcpack/ci-lint:20220925-060158-71f25b3d6'
+ci_gpu = 'tlcpack/ci-gpu:20220925-060158-71f25b3d6'
+ci_cpu = 'tlcpack/ci-cpu:20220925-060158-71f25b3d6'
+ci_minimal = 'tlcpack/ci-minimal:20220925-060158-71f25b3d6'
+ci_wasm = 'tlcpack/ci-wasm:20220925-060158-71f25b3d6'
+ci_i386 = 'tlcpack/ci-i386:20220925-060158-71f25b3d6'
+ci_cortexm = 'tlcpack/ci-cortexm:20220925-060158-71f25b3d6'
+ci_arm = 'tlcpack/ci-arm:20220925-060158-71f25b3d6'
+ci_hexagon = 'tlcpack/ci-hexagon:20220925-060158-71f25b3d6'
+ci_riscv = 'tlcpack/ci-riscv:20220925-060158-71f25b3d6'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -51,16 +51,16 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 {% import 'ci/jenkins/macros.j2' as m with context -%}
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:20220908-060034-62bdc91b1'
-ci_gpu = 'tlcpack/ci-gpu:20220908-060034-62bdc91b1'
-ci_cpu = 'tlcpack/ci-cpu:20220908-060034-62bdc91b1'
-ci_minimal = 'tlcpack/ci-minimal:20220908-060034-62bdc91b1'
-ci_wasm = 'tlcpack/ci-wasm:20220908-060034-62bdc91b1'
-ci_i386 = 'tlcpack/ci-i386:20220908-060034-62bdc91b1'
-ci_cortexm = 'tlcpack/ci-cortexm:20220909-090211-cb08a1251'
-ci_arm = 'tlcpack/ci-arm:20220908-060034-62bdc91b1'
-ci_hexagon = 'tlcpack/ci-hexagon:20220908-060034-62bdc91b1'
-ci_riscv = 'tlcpack/ci-riscv:20220908-060034-62bdc91b1'
+ci_lint = 'tlcpack/ci-lint:20220925-060158-71f25b3d6'
+ci_gpu = 'tlcpack/ci-gpu:20220925-060158-71f25b3d6'
+ci_cpu = 'tlcpack/ci-cpu:20220925-060158-71f25b3d6'
+ci_minimal = 'tlcpack/ci-minimal:20220925-060158-71f25b3d6'
+ci_wasm = 'tlcpack/ci-wasm:20220925-060158-71f25b3d6'
+ci_i386 = 'tlcpack/ci-i386:20220925-060158-71f25b3d6'
+ci_cortexm = 'tlcpack/ci-cortexm:20220925-060158-71f25b3d6'
+ci_arm = 'tlcpack/ci-arm:20220925-060158-71f25b3d6'
+ci_hexagon = 'tlcpack/ci-hexagon:20220925-060158-71f25b3d6'
+ci_riscv = 'tlcpack/ci-riscv:20220925-060158-71f25b3d6'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -4481,6 +4481,7 @@ def test_roi_align(target, dev):
 
         node = helper.make_node(
             "RoiAlign",
+            coordinate_transformation_mode="output_half_pixel",
             inputs=["X", "rois", "batch_indices"],
             outputs=["Y"],
             mode=mode,


### PR DESCRIPTION
RoiAlign-16 introduces `coordinate_transformation_mode`, which should be set to 'output_half_pixel' to omit the pixel shift for the input (for a backward-compatible behavior). This PR should fix the failure in https://ci.tlcpack.ai/job/docker-images-ci/job/docker-image-run-tests/231/testReport/junit/cython.tests.python.frontend.onnx/test_forward/Test___frontend__GPU_3_of_6___test_roi_align_cuda_/ 

Moved #12869 to an in-repo branch