### PR TITLE
[Relay][TE] Add default param name if needed

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -131,8 +131,9 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     for (Var param : relay_func->params) {
       Array<tvm::te::Tensor> inputs;
       for (const auto& ttype : FlattenTupleType(param->checked_type())) {
-        tvm::te::Tensor tensor =
-            tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, param->vid->name_hint);
+        auto name_hint = param->vid->name_hint;
+        tvm::te::Tensor tensor = tvm::te::placeholder(
+            GetShape(ttype->shape), ttype->dtype, (name_hint == "") ? "placeholder" : name_hint);
         inputs.push_back(tensor);
         fn_inputs_.push_back(tensor);
       }


### PR DESCRIPTION
#10516 used the Relay parameter name when lowering to TE. However, this creates an issue when the parameter name is empty. This is legal in Relay, but results in errors during code generation. For example, this is the generated CUDA kernel for bias add:

```
extern "C" __global__ void __launch_bounds__(1024) fused_raf_op_tvm_add_kernel0(
    float* __restrict__ T_add,
    float* __restrict__ , /* Name is missing and it results in compile errors. */
    float* __restrict__ _1) {
    T_add[((((int)blockIdx.x) * 1024) + ((int)threadIdx.x))] = ([((((int)blockIdx.x) * 1024) + ((int)threadIdx.x))] + _1[((((((int)blockIdx.x) * 16) + (((int)threadIdx.x) >> 6)) % 54) / 9)]);
}
```

This PR adds "placeholder" back as a default to make sure no empty string will be passed when lowering to TE.

cc @Lunderberg @tkonolige 
