### PR TITLE
[Arith][IndexMap] Correct MapShape result for small vectorized dims

### DIFF
--- a/tests/python/unittest/test_index_map.py
+++ b/tests/python/unittest/test_index_map.py
@@ -103,7 +103,7 @@ padding_test_case = tvm.testing.parameter(
             forward=lambda i: [i // 4, i % 4],
             inverse=lambda i, j: [4 * i + j],
             pre_shape=[dynamic_N],
-            post_shape=[(dynamic_N - 1) // 4 + 1, 4],
+            post_shape=[(dynamic_N - dynamic_N % (-4)) // 4, 4],
             padding=lambda i, j: tvm.tir.And(
                 dynamic_N % (-4) != 0,
                 tvm.tir.And(i == dynamic_N // 4, j >= dynamic_N % 4),
@@ -160,6 +160,13 @@ padding_test_case = tvm.testing.parameter(
             pre_shape=[123],
             post_shape=[8, 4, 4],
             padding=lambda j, i, k: tvm.tir.And(i == 0, j * 4 + k < 5),
+        ),
+        "outer_loop_extent_one": dict(
+            forward=lambda i: [i // 4, i % 4],
+            inverse=lambda i, j: [i * 4 + j],
+            pre_shape=[3],
+            post_shape=[1, 4],
+            padding=lambda i, j: 3 <= j,
         ),
     }
 )


### PR DESCRIPTION
Prior to this commit, `IndexMap::MapShape` could produce incorrect results when the split factor is greater than the size of the dimension being split.  For example, a buffer of shape `[N]` mapped transformed with `lambda i: [i//4, i%4]` should result in shape `[ceildiv(N,4), 4]`.  However, for `N<4`, the transformed shape was instead `[1, N%4]`.  This results in unexpected shapes when attempting to prepare a buffer for vectorized access.

This commit preferentially uses the result of `arith::DetectIterMap` to determine the mapped buffer shape, similar to what is done when computing the inverse.  The old method of `MapShape`, which relied on `arith::EvalSet`, is maintained for transformations that aren't recognized by `arith::DetectIterMap`.