### PR TITLE
[TIR] Require dtype.is_float() inside FloatImm

### DIFF
--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -118,8 +118,9 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 FloatImm::FloatImm(DataType dtype, double value, Span span) {
   ICHECK_EQ(dtype.lanes(), 1) << "ValueError: FloatImm can only take scalar.";
-  ICHECK(dtype.is_float()) << "ValueError: FloatImm supports only float, but " << dtype
-                           << " was supplied.";
+
+  ICHECK(dtype.is_float() || dtype.is_bfloat16() || dtype.code() >= DataType::kCustomBegin)
+      << "ValueError: FloatImm supports only float, but " << dtype << " was supplied.";
 
   // check range for float32 and float16 since they have specified range.
   if (!std::isinf(value) && !std::isnan(value)) {

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -118,6 +118,8 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 FloatImm::FloatImm(DataType dtype, double value, Span span) {
   ICHECK_EQ(dtype.lanes(), 1) << "ValueError: FloatImm can only take scalar.";
+  ICHECK(dtype.is_float()) << "ValueError: FloatImm supports only float, but " << dtype
+                           << " was supplied.";
 
   // check range for float32 and float16 since they have specified range.
   if (!std::isinf(value) && !std::isnan(value)) {

--- a/tests/python/unittest/test_tir_constructor.py
+++ b/tests/python/unittest/test_tir_constructor.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import pytest
+
 import tvm
 from tvm import te
 
@@ -189,6 +192,10 @@ def test_stmt_constructor():
     assert isinstance(x, tvm.tir.Prefetch)
 
 
+def test_float_constructor_requires_float_dtype():
+    with pytest.raises(tvm.TVMError):
+        tvm.tir.FloatImm("int32", 1.0)
+
+
 if __name__ == "__main__":
-    test_expr_constructor()
-    test_stmt_constructor()
+    tvm.testing.main()


### PR DESCRIPTION
Previously, a `tir::FloatImm` could have a dtype passed to it that was not a floating point value.  This commit introduces a check, similar to what is already done in `tir::IntImm`, that requires the dtype to satisfy `DataType::is_float()`.