### PR TITLE
[do not review] Gather tests that have inter-test dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-09-26T10:48:49.577077
+// Generated at 2022-09-27T15:36:19.713848
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -813,7 +813,7 @@ stage('Build') {
             ci_setup(ci_cpu)
             // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
             // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-            sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
+            // sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
           }
         }
       }
@@ -866,10 +866,10 @@ stage('Build') {
           cpp_unittest(ci_wasm)
           timeout(time: max_time, unit: 'MINUTES') {
             ci_setup(ci_wasm)
-            sh (
-              script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
-              label: 'Run WASM lint and tests',
-            )
+            // sh (
+            //   script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
+            //   label: 'Run WASM lint and tests',
+            // )
           }
         }
       }

--- a/ci/jenkins/Build.groovy.j2
+++ b/ci/jenkins/Build.groovy.j2
@@ -114,7 +114,7 @@ stage('Build') {
             ci_setup(ci_cpu)
             // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
             // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
-            sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
+            // sh (script: "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh", label: 'Rust build and test')
           }
         }
       }
@@ -154,10 +154,10 @@ stage('Build') {
           cpp_unittest(ci_wasm)
           timeout(time: max_time, unit: 'MINUTES') {
             ci_setup(ci_wasm)
-            sh (
-              script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
-              label: 'Run WASM lint and tests',
-            )
+            // sh (
+            //   script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
+            //   label: 'Run WASM lint and tests',
+            // )
           }
         }
       }

--- a/conftest.py
+++ b/conftest.py
@@ -115,25 +115,26 @@ def pytest_sessionstart():
         request_hook.init()
 
 
-if HAVE_XDIST:
-    @pytest.hookimpl(hookwrapper=True)
-    def pytest_handlecrashitem(crashitem, report, sched):
-        print("yielding")
-        print("yielding", file=sys.stderr)
-        # run the other pytest_handlecrashitem hooks
-        yield
+# if HAVE_XDIST:
 
-        print("otucome")
-        print("otucome", file=sys.stderr)
+#     @pytest.hookimpl(hookwrapper=True)
+#     def pytest_handlecrashitem(crashitem, report, sched):
+#         print("yielding")
+#         print("yielding", file=sys.stderr)
+#         # run the other pytest_handlecrashitem hooks
+#         yield
 
-        # override the 'rerun' result from pytest-rerunfailures
-        report.outcome = "failed"
+#         print("otucome")
+#         print("otucome", file=sys.stderr)
 
-        print("longre")
-        print("longre", file=sys.stderr)
+#         # override the 'rerun' result from pytest-rerunfailures
+#         report.outcome = "failed"
 
-        # there doesn't seem to be a good way to extract the segfault backtrace here
-        report.longrepr += "\nThis is likely due to a segfault. See the test run logs for details."
+#         print("longre")
+#         print("longre", file=sys.stderr)
 
-        print("returning")
-        print("returning", file=sys.stderr)
+#         # there doesn't seem to be a good way to extract the segfault backtrace here
+#         report.longrepr += "\nThis is likely due to a segfault. See the test run logs for details."
+
+#         print("returning")
+#         print("returning", file=sys.stderr)

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -30,6 +30,7 @@ directory as the test scripts.
      pytest_plugins = ['tvm.testing.plugin']
 
 """
+import sys
 
 import pytest
 import _pytest
@@ -342,6 +343,13 @@ if HAVE_XDIST:
             Scheduler to serializer tests
             """
 
+            def mark_test_pending(self, nodeid):
+                # Empty so it returns a bogus result which is fixed up in
+                # pytest_handlecrashitem in conftest.py
+                print("mark pending")
+                print("mark pending", file=sys.stderr)
+                pass
+
             def _split_scope(self, nodeid):
                 """
                 Returns a specific string for classes of nodeids
@@ -356,8 +364,12 @@ if HAVE_XDIST:
 
                 for nodeid_pattern, suite_name in items.items():
                     if nodeid_pattern in nodeid:
+                        print("split 2scope")
+                        print("split 2scope", file=sys.stderr)
                         return suite_name
 
-                return nodeid
+                print("split scope")
+                print("split scope", file=sys.stderr)
+                return super()._split_scope(nodeid)
 
         return TvmTestScheduler(config, log)

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -30,7 +30,7 @@ directory as the test scripts.
      pytest_plugins = ['tvm.testing.plugin']
 
 """
-import sys
+# import sys
 
 import pytest
 import _pytest
@@ -39,7 +39,7 @@ import tvm
 from tvm.testing import utils
 
 try:
-    from xdist.scheduler.loadscope import LoadScopeScheduling
+    # from xdist.scheduler.loadscope import LoadScopeScheduling
 
     HAVE_XDIST = True
 except ImportError:
@@ -329,47 +329,47 @@ def _parametrize_correlated_parameters(metafunc):
             metafunc.parametrize(names, value_sets, indirect=True, ids=ids)
 
 
-# pytest-xdist isn't required but is used in CI, so guard on its presence
-if HAVE_XDIST:
+# # pytest-xdist isn't required but is used in CI, so guard on its presence
+# if HAVE_XDIST:
 
-    def pytest_xdist_make_scheduler(config, log):
-        """
-        Serialize certain tests for pytest-xdist that have inter-test
-        dependencies
-        """
+#     def pytest_xdist_make_scheduler(config, log):
+#         """
+#         Serialize certain tests for pytest-xdist that have inter-test
+#         dependencies
+#         """
 
-        class TvmTestScheduler(LoadScopeScheduling):
-            """
-            Scheduler to serializer tests
-            """
+#         class TvmTestScheduler(LoadScopeScheduling):
+#             """
+#             Scheduler to serializer tests
+#             """
 
-            def mark_test_pending(self, nodeid):
-                # Empty so it returns a bogus result which is fixed up in
-                # pytest_handlecrashitem in conftest.py
-                print("mark pending")
-                print("mark pending", file=sys.stderr)
-                pass
+#             def mark_test_pending(self, nodeid):
+#                 # Empty so it returns a bogus result which is fixed up in
+#                 # pytest_handlecrashitem in conftest.py
+#                 print("mark pending")
+#                 print("mark pending", file=sys.stderr)
+#                 pass
 
-            def _split_scope(self, nodeid):
-                """
-                Returns a specific string for classes of nodeids
-                """
-                # NOTE: these tests contain inter-test dependencies and must be
-                # serialized
-                items = {
-                    "test_tvm_testing_features": "functional-tests",
-                    "tests/python/unittest/test_crt": "crt-tests",
-                    "tests/python/driver/tvmc": "tvmc-tests",
-                }
+#             def _split_scope(self, nodeid):
+#                 """
+#                 Returns a specific string for classes of nodeids
+#                 """
+#                 # NOTE: these tests contain inter-test dependencies and must be
+#                 # serialized
+#                 items = {
+#                     "test_tvm_testing_features": "functional-tests",
+#                     "tests/python/unittest/test_crt": "crt-tests",
+#                     "tests/python/driver/tvmc": "tvmc-tests",
+#                 }
 
-                for nodeid_pattern, suite_name in items.items():
-                    if nodeid_pattern in nodeid:
-                        print("split 2scope")
-                        print("split 2scope", file=sys.stderr)
-                        return suite_name
+#                 for nodeid_pattern, suite_name in items.items():
+#                     if nodeid_pattern in nodeid:
+#                         print("split 2scope")
+#                         print("split 2scope", file=sys.stderr)
+#                         return suite_name
 
-                print("split scope")
-                print("split scope", file=sys.stderr)
-                return super()._split_scope(nodeid)
+#                 print("split scope")
+#                 print("split scope", file=sys.stderr)
+#                 return super()._split_scope(nodeid)
 
-        return TvmTestScheduler(config, log)
+#         return TvmTestScheduler(config, log)

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -201,6 +201,11 @@ Var WithFields(Var var, Optional<Id> opt_vid, Optional<Type> opt_type_annotation
 TVM_REGISTER_NODE_TYPE(VarNode);
 
 TVM_REGISTER_GLOBAL("relay.ir.Var").set_body_typed([](String str, Type type_annotation) {
+  std::cout << "running var\n";
+  if (str == std::string("test88")) {
+    int* x = nullptr;
+    std::cout << *x;
+  }
   return Var(str, type_annotation);
 });
 

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -331,12 +331,6 @@ def test_cc_reviewers(
     assert f"After filtering existing reviewers, adding: {expected_reviewers}" in proc.stdout
 
 
-def test_something():
-    # assert 1 == 2
-    a = tvm.relay.Var(name_hint="test88")
-    assert a == 2
-
-
 @parameterize_named(
     # Missing expected tvm-ci/branch test
     missing_tvm_ci_branch=dict(

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pytest
 import tvm.testing
+import tvm.relay
 
 from .test_utils import REPO_ROOT, TempGit, run_script
 
@@ -328,6 +329,12 @@ def test_cc_reviewers(
     )
 
     assert f"After filtering existing reviewers, adding: {expected_reviewers}" in proc.stdout
+
+
+def test_something():
+    # assert 1 == 2
+    a = tvm.relay.Var(name_hint="test88")
+    assert a == 2
 
 
 @parameterize_named(

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -359,6 +359,7 @@ def generate_command(
         skip_build: bool = False,
         interactive: bool = False,
         docker_image: Optional[str] = None,
+        commands: Optional[List[str]] = None,
         verbose: bool = False,
         **kwargs,
     ) -> None:
@@ -368,6 +369,7 @@ def generate_command(
         skip_build -- skip build and setup scripts
         interactive -- start a shell after running build / test scripts
         docker-image -- manually specify the docker image to use
+        commands -- a shell command to run
         verbose -- run verbose build
         """
         if precheck is not None:
@@ -392,7 +394,11 @@ def generate_command(
             clean_exit(f"{option_flags} cannot be used with --tests")
 
         if tests is not None:
-            scripts.append(f"python3 -m pytest {' '.join(tests)}")
+            scripts.append(f"source tests/scripts/setup-pytest-env.sh")
+            scripts.append(f"run_pytest ctypes ad-hoc-test {' '.join(tests)}")
+
+        if commands is not None:
+            scripts.extend(commands)
 
         # Add named test suites
         for option_name, (_, extra_scripts) in options.items():
@@ -409,6 +415,7 @@ def generate_command(
                 # multiple copies of libtvm.so laying around)
                 "TVM_LIBRARY_PATH": str(REPO_ROOT / get_build_dir(name)),
                 "VERBOSE": "true" if verbose else "false",
+                "PLATFORM": name,
             },
             interactive=interactive,
         )

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -84,7 +84,7 @@ function run_pytest() {
     exit_code=0
     set +e
     TVM_FFI=${ffi_type} python3 -m pytest \
-           -o "junit_suite_name=${suite_name}" \
+           -o "junit_suite_name=${suite_name}" -vvv \
            "--junit-xml=${TVM_PYTEST_RESULT_DIR}/${suite_name}.xml" \
            "--junit-prefix=${ffi_type}" \
            "${extra_args[@]}" || exit_code=$?


### PR DESCRIPTION
The need for a `LoadScopeScheduling` instance to handle test scheduling is making proper reporting + retries difficult, so check if we can just fix the tests so they don't actually need a special scheduler.