### PR TITLE
[TIR][Schedule] Add cache_inplace primitive to cache opaque buffer

### DIFF
--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -405,10 +405,11 @@ class ScheduleNode : public runtime::Object {
                              const String& storage_scope) = 0;
   /*!
    * \brief Create 2 blocks that read&write a buffer region into a read/write cache.
-   * \param block_rv The block operates on the target buffer.
+   * It requires the the target block both read & write the target buffer.
+   * \param block_rv The target block operates on the target buffer.
    * \param read_buffer_index The index of the buffer in block's read region.
    * \param storage_scope The target storage scope
-   * \return The reindex stage block.
+   * \return The cache stage blocks, cache read block together with cache write block.
    */
   virtual Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
                                      const String& storage_scope) = 0;

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -404,6 +404,15 @@ class ScheduleNode : public runtime::Object {
   virtual BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                              const String& storage_scope) = 0;
   /*!
+   * \brief Create 2 blocks that read&write a buffer region into a read/write cache.
+   * \param block_rv The block operates on the target buffer.
+   * \param read_buffer_index The index of the buffer in block's read region.
+   * \param storage_scope The target storage scope
+   * \return The reindex stage block.
+   */
+  virtual Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
+                                     const String& storage_scope) = 0;
+  /*!
    * \brief Create a block that read/write a buffer region into a read/write cache with reindexing.
    * The layout of the cache will be the same as by the iterators of the block that reads/writes the
    * buffer. It requires:

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -411,8 +411,8 @@ class ScheduleNode : public runtime::Object {
    * \param storage_scope The target storage scope
    * \return The cache stage blocks, cache read block together with cache write block.
    */
-  virtual Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
-                                     const String& storage_scope) = 0;
+  virtual Array<BlockRV> CacheInplace(const BlockRV& block_rv, int read_buffer_index,
+                                      const String& storage_scope) = 0;
   /*!
    * \brief Create a block that read/write a buffer region into a read/write cache with reindexing.
    * The layout of the cache will be the same as by the iterators of the block that reads/writes the

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1190,7 +1190,7 @@ class Schedule(Object):
         )
 
     @type_checked
-    def cache_buffer(
+    def cache_inplace(
         self,
         block: Union[BlockRV, str],
         read_buffer_index: Union[int, str, Buffer],
@@ -1198,6 +1198,7 @@ class Schedule(Object):
     ) -> List[BlockRV]:
         """Create blocks that reads & write a buffer region into a cache block.
         It requires the the target block both read & write the target buffer.
+        Mainly for inplace operation.
 
         Parameters
         ----------
@@ -1220,28 +1221,28 @@ class Schedule(Object):
 
         Examples
         --------
-        Before cache_buffer, in TensorIR, the IR is:
+        Before cache_inplace, in TensorIR, the IR is:
 
         .. code-block:: python
 
             @T.prim_func
-            def before_cache_buffer(data_io: T.Buffer[(64), "int32"]):
+            def before_cache_inplace(data_io: T.Buffer[(64), "int32"]):
                 for i0 in T.serial(1):
                     with T.block("A"):
                         T.reads(data_io[:64])
                         T.writes(data_io[:64])
                         T.evaluate(T.call_extern("call_impl", data_io.data, dtype=""))
 
-        Create the schedule and cache_buffer:
+        Create the schedule and cache_inplace:
 
         .. code-block:: python
 
-            sch = tir.Schedule(before_cache_buffer)
+            sch = tir.Schedule(before_cache_inplace)
             block_a = sch.get_block("A")
-            sch.cache_buffer(block_a, 0, "local")
+            sch.cache_inplace(block_a, 0, "local")
             print(sch.mod["main"].script())
 
-        After applying cache_buffer, the IR becomes:
+        After applying cache_inplace, the IR becomes:
 
         .. code-block:: python
 
@@ -1273,7 +1274,7 @@ class Schedule(Object):
             _, read_buffer_index, _ = self._normalize_buffer_arg(
                 block, read_buffer_index, required_buffer_type="read"
             )
-        return _ffi_api.ScheduleCacheBuffer(  # type: ignore # pylint: disable=no-member
+        return _ffi_api.ScheduleCacheInplace(  # type: ignore # pylint: disable=no-member
             self, block, read_buffer_index, storage_scope
         )
 

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1197,11 +1197,12 @@ class Schedule(Object):
         storage_scope: str,
     ) -> List[BlockRV]:
         """Create blocks that reads & write a buffer region into a cache block.
+        It requires the the target block both read & write the target buffer.
 
         Parameters
         ----------
         block : Union[BlockRV, str]
-            The producer block of the target buffer.
+            The target block operates on the target buffer.
 
         read_buffer_index: int
             The index of the buffer in block's read region, the unique

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1190,6 +1190,93 @@ class Schedule(Object):
         )
 
     @type_checked
+    def cache_buffer(
+        self,
+        block: Union[BlockRV, str],
+        read_buffer_index: Union[int, str, Buffer],
+        storage_scope: str,
+    ) -> List[BlockRV]:
+        """Create blocks that reads & write a buffer region into a cache block.
+
+        Parameters
+        ----------
+        block : Union[BlockRV, str]
+            The producer block of the target buffer.
+
+        read_buffer_index: int
+            The index of the buffer in block's read region, the unique
+            name of a read buffer in the block, or a Buffer object
+            that is within the blocks read region.
+
+        storage_scope: str
+            The target storage scope.
+
+
+        Returns
+        -------
+        cached_blocks : List[BlockRV]
+            The blocks of the cache stage, read cache first, write cache second
+
+        Examples
+        --------
+        Before cache_buffer, in TensorIR, the IR is:
+
+        .. code-block:: python
+
+            @T.prim_func
+            def before_cache_buffer(data_io: T.Buffer[(64), "int32"]):
+                for i0 in T.serial(1):
+                    with T.block("A"):
+                        T.reads(data_io[:64])
+                        T.writes(data_io[:64])
+                        T.evaluate(T.call_extern("call_impl", data_io.data, dtype=""))
+
+        Create the schedule and cache_buffer:
+
+        .. code-block:: python
+
+            sch = tir.Schedule(before_cache_buffer)
+            block_a = sch.get_block("A")
+            sch.cache_buffer(block_a, 0, "local")
+            print(sch.mod["main"].script())
+
+        After applying cache_buffer, the IR becomes:
+
+        .. code-block:: python
+
+            @T.prim_func
+            def cache_inplace(data_io: T.Buffer[64, "int32"]) -> None:
+                data_io_local = T.alloc_buffer([64], dtype="int32", scope="local")
+                for i0 in T.serial(1):
+                    for ax0 in T.serial(64):
+                        with T.block("data_io_local"):
+                            v0 = T.axis.spatial(64, ax0)
+                            T.reads(data_io[v0])
+                            T.writes(data_io_local[v0])
+                            data_io_local[v0] = data_io[v0]
+                    with T.block("A"):
+                        T.reads(data_io_local[0 : 64])
+                        T.writes(data_io_local[0 : 64])
+                        T.evaluate(T.call_extern("call_impl", data_io_local.data, dtype=""))
+                    for ax0 in T.serial(64):
+                        with T.block("data_io_local"):
+                            v0 = T.axis.spatial(64, ax0)
+                            T.reads(data_io_local[v0])
+                            T.writes(data_io[v0])
+                            data_io[v0] = data_io_local[v0]
+
+        """
+        block = self._normalize_block_arg(block)
+
+        if not isinstance(read_buffer_index, int):
+            _, read_buffer_index, _ = self._normalize_buffer_arg(
+                block, read_buffer_index, required_buffer_type="read"
+            )
+        return _ffi_api.ScheduleCacheBuffer(  # type: ignore # pylint: disable=no-member
+            self, block, read_buffer_index, storage_scope
+        )
+
+    @type_checked
     def reindex(
         self,
         block: Union[BlockRV, str],

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -561,6 +561,19 @@ BlockRV ConcreteScheduleNode::CacheWrite(const BlockRV& block_rv, int write_buff
   return CreateRV<BlockRV>(result);
 }
 
+Array<BlockRV> ConcreteScheduleNode::CacheBuffer(const BlockRV& block_rv, int write_buffer_index,
+                                                 const String& storage_scope) {
+  Array<StmtSRef> results;
+  TVM_TIR_SCHEDULE_BEGIN();
+  results = tir::CacheBuffer(state_, this->GetSRef(block_rv), write_buffer_index, storage_scope);
+  TVM_TIR_SCHEDULE_END("cache-buffer", this->error_render_level_);
+  this->state_->DebugVerify();
+  Array<BlockRV> return_blocks;
+  return_blocks.push_back(CreateRV<BlockRV>(results[0]));
+  return_blocks.push_back(CreateRV<BlockRV>(results[1]));
+  return return_blocks;
+}
+
 BlockRV ConcreteScheduleNode::ReIndex(const BlockRV& block_rv, int buffer_index,
                                       BufferIndexType buffer_index_type) {
   StmtSRef result{nullptr};

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -561,11 +561,11 @@ BlockRV ConcreteScheduleNode::CacheWrite(const BlockRV& block_rv, int write_buff
   return CreateRV<BlockRV>(result);
 }
 
-Array<BlockRV> ConcreteScheduleNode::CacheBuffer(const BlockRV& block_rv, int write_buffer_index,
-                                                 const String& storage_scope) {
+Array<BlockRV> ConcreteScheduleNode::CacheInplace(const BlockRV& block_rv, int write_buffer_index,
+                                                  const String& storage_scope) {
   Array<StmtSRef> results;
   TVM_TIR_SCHEDULE_BEGIN();
-  results = tir::CacheBuffer(state_, this->GetSRef(block_rv), write_buffer_index, storage_scope);
+  results = tir::CacheInplace(state_, this->GetSRef(block_rv), write_buffer_index, storage_scope);
   TVM_TIR_SCHEDULE_END("cache-buffer", this->error_render_level_);
   this->state_->DebugVerify();
   Array<BlockRV> return_blocks;

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -116,6 +116,8 @@ class ConcreteScheduleNode : public ScheduleNode {
                     const Array<BlockRV> consumer_blocks = {}) override;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) override;
+  Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
+                             const String& storage_scope) override;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,
                   BufferIndexType buffer_index_type) override;
   /******** Schedule: Compute location ********/

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -116,8 +116,8 @@ class ConcreteScheduleNode : public ScheduleNode {
                     const Array<BlockRV> consumer_blocks = {}) override;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) override;
-  Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
-                             const String& storage_scope) override;
+  Array<BlockRV> CacheInplace(const BlockRV& block_rv, int read_buffer_index,
+                              const String& storage_scope) override;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,
                   BufferIndexType buffer_index_type) override;
   /******** Schedule: Compute location ********/

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -277,8 +277,8 @@ TVM_DLL StmtSRef CacheWrite(ScheduleState self, const StmtSRef& block_sref, int 
  * \param storage_scope The target storage scope
  * \return The cache stage blocks, cache read block together with cache write block.
  */
-TVM_DLL Array<StmtSRef> CacheBuffer(ScheduleState self, const StmtSRef& block_sref,
-                                    int read_buffer_index, const String& storage_scope);
+TVM_DLL Array<StmtSRef> CacheInplace(ScheduleState self, const StmtSRef& block_sref,
+                                     int read_buffer_index, const String& storage_scope);
 /*!
  *!
  * \brief Create a block that read/write a buffer region into a read/write cache with reindexing.

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -270,11 +270,12 @@ TVM_DLL StmtSRef CacheWrite(ScheduleState self, const StmtSRef& block_sref, int 
 /*!
  *!
  * \brief Create 2 blocks that read&write a buffer region into a read/write cache.
+ * It requires the the target block both read & write the target buffer.
  * \param self The state of the schedule
- * \param block_sref The block operates on the target buffer.
+ * \param block_sref The target block operates on the target buffer.
  * \param read_buffer_index The index of the buffer in block's read region.
  * \param storage_scope The target storage scope
- * \return The reindex stage block.
+ * \return The cache stage blocks, cache read block together with cache write block.
  */
 TVM_DLL Array<StmtSRef> CacheBuffer(ScheduleState self, const StmtSRef& block_sref,
                                     int read_buffer_index, const String& storage_scope);

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -269,13 +269,24 @@ TVM_DLL StmtSRef CacheWrite(ScheduleState self, const StmtSRef& block_sref, int 
                             const String& storage_scope);
 /*!
  *!
+ * \brief Create 2 blocks that read&write a buffer region into a read/write cache.
+ * \param self The state of the schedule
+ * \param block_sref The block operates on the target buffer.
+ * \param read_buffer_index The index of the buffer in block's read region.
+ * \param storage_scope The target storage scope
+ * \return The reindex stage block.
+ */
+TVM_DLL Array<StmtSRef> CacheBuffer(ScheduleState self, const StmtSRef& block_sref,
+                                    int read_buffer_index, const String& storage_scope);
+/*!
+ *!
  * \brief Create a block that read/write a buffer region into a read/write cache with reindexing.
  * The layout of the cache will be the same as by the iterators of the block that reads/writes the
  * buffer. It requires:
  * 1) There is only one block who reads/writes the target buffer
  * 2) There is only one buffer load/store of this buffer in the block
  * \param self The state of the schedule
- * \param block_rv The block operates on the target buffer.
+ * \param block_sref The block operates on the target buffer.
  * \param buffer_index The index of the buffer in block's read or write region.
  * \param buffer_index_type The type of the buffer index, kRead or kWrite.
  * \return The reindex stage block.

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -179,8 +179,8 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheRead")
     .set_body_method<Schedule>(&ScheduleNode::CacheRead);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheWrite")
     .set_body_method<Schedule>(&ScheduleNode::CacheWrite);
-TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheBuffer")
-    .set_body_method<Schedule>(&ScheduleNode::CacheBuffer);
+TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheInplace")
+    .set_body_method<Schedule>(&ScheduleNode::CacheInplace);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReIndex")
     .set_body_typed([](Schedule self, const BlockRV& block_rv, int buffer_index,
                        int buffer_index_type) {

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -179,6 +179,8 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheRead")
     .set_body_method<Schedule>(&ScheduleNode::CacheRead);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheWrite")
     .set_body_method<Schedule>(&ScheduleNode::CacheWrite);
+TVM_REGISTER_GLOBAL("tir.schedule.ScheduleCacheBuffer")
+    .set_body_method<Schedule>(&ScheduleNode::CacheBuffer);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReIndex")
     .set_body_typed([](Schedule self, const BlockRV& block_rv, int buffer_index,
                        int buffer_index_type) {

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -307,6 +307,22 @@ BlockRV TracedScheduleNode::CacheWrite(const BlockRV& block_rv, int write_buffer
   return result;
 }
 
+Array<BlockRV> TracedScheduleNode::CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
+                                               const String& storage_scope) {
+  Array<BlockRV> result =
+      ConcreteScheduleNode::CacheBuffer(block_rv, read_buffer_index, storage_scope);
+  Array<ObjectRef> results;
+  for (const BlockRV& r : result) {
+    results.push_back(r);
+  }
+  static const InstructionKind& kind = InstructionKind::Get("CacheBuffer");
+  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
+                                      /*inputs=*/{block_rv},
+                                      /*attrs=*/{Integer(read_buffer_index), storage_scope},
+                                      /*outputs=*/results));
+  return result;
+}
+
 BlockRV TracedScheduleNode::ReIndex(const BlockRV& block_rv, int buffer_index,
                                     BufferIndexType buffer_index_type) {
   BlockRV result = ConcreteScheduleNode::ReIndex(block_rv, buffer_index, buffer_index_type);

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -307,15 +307,15 @@ BlockRV TracedScheduleNode::CacheWrite(const BlockRV& block_rv, int write_buffer
   return result;
 }
 
-Array<BlockRV> TracedScheduleNode::CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
-                                               const String& storage_scope) {
+Array<BlockRV> TracedScheduleNode::CacheInplace(const BlockRV& block_rv, int read_buffer_index,
+                                                const String& storage_scope) {
   Array<BlockRV> result =
-      ConcreteScheduleNode::CacheBuffer(block_rv, read_buffer_index, storage_scope);
+      ConcreteScheduleNode::CacheInplace(block_rv, read_buffer_index, storage_scope);
   Array<ObjectRef> results;
   for (const BlockRV& r : result) {
     results.push_back(r);
   }
-  static const InstructionKind& kind = InstructionKind::Get("CacheBuffer");
+  static const InstructionKind& kind = InstructionKind::Get("CacheInplace");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv},
                                       /*attrs=*/{Integer(read_buffer_index), storage_scope},

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -76,6 +76,8 @@ class TracedScheduleNode : public ConcreteScheduleNode {
                     const Array<BlockRV> consumer_blocks = {}) final;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) final;
+  Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
+                             const String& storage_scope) final;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,
                   BufferIndexType buffer_index_type) final;
   /******** Schedule: Compute location ********/

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -76,8 +76,8 @@ class TracedScheduleNode : public ConcreteScheduleNode {
                     const Array<BlockRV> consumer_blocks = {}) final;
   BlockRV CacheWrite(const BlockRV& block_rv, int write_buffer_index,
                      const String& storage_scope) final;
-  Array<BlockRV> CacheBuffer(const BlockRV& block_rv, int read_buffer_index,
-                             const String& storage_scope) final;
+  Array<BlockRV> CacheInplace(const BlockRV& block_rv, int read_buffer_index,
+                              const String& storage_scope) final;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,
                   BufferIndexType buffer_index_type) final;
   /******** Schedule: Compute location ********/

--- a/tests/python/unittest/test_tir_schedule_cache_read_write.py
+++ b/tests/python/unittest/test_tir_schedule_cache_read_write.py
@@ -241,6 +241,15 @@ def inplace_func(data_io: T.Buffer[(64), "int32"]):
             data_io[v0] = data_1d[v0]
 
 
+@T.prim_func
+def inplace_call(data_io: T.Buffer[(64), "int32"]):
+    for i0 in T.serial(1):
+        with T.block("ext_call"):
+            T.reads(data_io[:64])
+            T.writes(data_io[:64])
+            T.evaluate(T.call_extern("call_impl", data_io.data, dtype=""))
+
+
 ########## Expected function after cache_read ##########
 
 
@@ -546,6 +555,42 @@ def cache_read_inplace(data_io: T.Buffer[64, "int32"]) -> None:
             T.reads(data_1d[v0])
             T.writes(data_io[v0])
             data_io[v0] = data_1d[v0]
+
+
+@T.prim_func
+def cache_buffer_inplace(data_io: T.Buffer[64, "int32"]) -> None:
+    data_io_local = T.alloc_buffer([64], dtype="int32", scope="local")
+    data_io_global = T.alloc_buffer([64], dtype="int32")
+    data_io_global_1 = T.alloc_buffer([64], dtype="int32")
+    for ax0 in T.serial(64):
+        with T.block("data_io_global"):
+            v0 = T.axis.spatial(64, ax0)
+            T.reads(data_io[v0])
+            T.writes(data_io_global[v0])
+            data_io_global[v0] = data_io[v0]
+    for i0 in T.serial(1):
+        for ax0 in T.serial(64):
+            with T.block("data_io_local"):
+                v0 = T.axis.spatial(64, ax0)
+                T.reads(data_io_global[v0])
+                T.writes(data_io_local[v0])
+                data_io_local[v0] = data_io_global[v0]
+        with T.block("ext_call"):
+            T.reads(data_io_local[0:64])
+            T.writes(data_io_local[0:64])
+            T.evaluate(T.call_extern("call_impl", data_io_local.data, dtype=""))
+        for ax0 in T.serial(64):
+            with T.block("data_io_local"):
+                v0 = T.axis.spatial(64, ax0)
+                T.reads(data_io_local[v0])
+                T.writes(data_io_global_1[v0])
+                data_io_global_1[v0] = data_io_local[v0]
+    for ax0 in T.serial(64):
+        with T.block("data_io_global"):
+            v0 = T.axis.spatial(64, ax0)
+            T.reads(data_io_global_1[v0])
+            T.writes(data_io[v0])
+            data_io[v0] = data_io_global_1[v0]
 
 
 ########## Expected function after cache_write ##########
@@ -929,6 +974,19 @@ def test_inplace_cache_read():
     sch.cache_read(block, 0, "local", [block])
     tvm.ir.assert_structural_equal(cache_read_inplace, sch.mod["main"])
     verify_trace_roundtrip(sch=sch, mod=inplace_func)
+
+
+def test_inplace_cache_buffer():
+    # cache buffer could introduce WAR, which is expected but stage pipeline property changes
+    debug_mask = tvm.tir.schedule.state.ScheduleDebugMask.VERIFY_SREF_TREE
+    sch = tvm.tir.Schedule(inplace_call, debug_mask=debug_mask)
+    block = sch.get_block("ext_call")
+    blocks = sch.cache_buffer(block, 0, "local")
+    block = sch.cache_read(blocks[0], 0, "global", [blocks[0]])
+    block = sch.cache_write(blocks[1], 0, "global")
+
+    tvm.ir.assert_structural_equal(cache_buffer_inplace, sch.mod["main"])
+    verify_trace_roundtrip(sch=sch, mod=inplace_call, debug_mask=debug_mask)
 
 
 ########## Testcases for cache_write ##########

--- a/tests/python/unittest/test_tir_schedule_cache_read_write.py
+++ b/tests/python/unittest/test_tir_schedule_cache_read_write.py
@@ -558,7 +558,7 @@ def cache_read_inplace(data_io: T.Buffer[64, "int32"]) -> None:
 
 
 @T.prim_func
-def cache_buffer_inplace(data_io: T.Buffer[64, "int32"]) -> None:
+def cache_inplace_buffer(data_io: T.Buffer[64, "int32"]) -> None:
     data_io_local = T.alloc_buffer([64], dtype="int32", scope="local")
     data_io_global = T.alloc_buffer([64], dtype="int32")
     data_io_global_1 = T.alloc_buffer([64], dtype="int32")
@@ -976,16 +976,16 @@ def test_inplace_cache_read():
     verify_trace_roundtrip(sch=sch, mod=inplace_func)
 
 
-def test_inplace_cache_buffer():
-    # cache buffer could introduce WAR, which is expected but stage pipeline property changes
+def test_cache_inplace():
+    # cache_inplace could introduce WAR, which is expected but stage pipeline property changes
     debug_mask = tvm.tir.schedule.state.ScheduleDebugMask.VERIFY_SREF_TREE
     sch = tvm.tir.Schedule(inplace_call, debug_mask=debug_mask)
     block = sch.get_block("ext_call")
-    blocks = sch.cache_buffer(block, 0, "local")
+    blocks = sch.cache_inplace(block, 0, "local")
     block = sch.cache_read(blocks[0], 0, "global", [blocks[0]])
     block = sch.cache_write(blocks[1], 0, "global")
 
-    tvm.ir.assert_structural_equal(cache_buffer_inplace, sch.mod["main"])
+    tvm.ir.assert_structural_equal(cache_inplace_buffer, sch.mod["main"])
     verify_trace_roundtrip(sch=sch, mod=inplace_call, debug_mask=debug_mask)
 
 


### PR DESCRIPTION
If a block both read and write a buffer, it cannot do cache read/write separately, otherwise dependency breaks. This primitive perform cache read & write together to keep IR correct.
cc @Hzfengsy @wrongtest-intellif 