### PR TITLE
[Arith][Refactor] Extract And/Or/Not handling from RewriteSimplifier

### DIFF
--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -149,6 +149,20 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
   }
 };
 
+/* Utility for rewriting only boolean portions of an expression
+ *
+ * Intended for application on an expression that has previously been
+ * simplified, but has subsequent manipulations performed.
+ * (e.g. Finding the simplified negation of a conditional without
+ * performing a full simplification.)  Only a single simplication step
+ * is performed.
+ *
+ * \param expr The boolean expression to be simplified
+ *
+ * \returns The simplified boolean expression
+ */
+PrimExpr RewriteBooleanOperators(const PrimExpr& expr);
+
 }  // namespace arith
 }  // namespace tvm
 #endif  // TVM_ARITH_REWRITE_SIMPLIFY_H_


### PR DESCRIPTION
Previously, rewrites of boolean expressions were handled directly within `RewriteSimplifier` visitors.  This commit extracts the handling of `And`, `Or`, and `Not` nodes into an independent internal utility.  The `RewriteBooleanOperators` utility can simplifies these nodes, assuming that the arguments to these expressions are already simplified.  (e.g. Finding the negation of `(a < b)` without needing to recurse into `a` or `b`.)  This will be used as part of additional simplifications required by [buffer layout
padding](https://github.com/apache/tvm/issues/12261).

Because no external functionality should be added or changed by this refactor, this commit does not introduce any additional unit tests.