### PR TITLE
[TIR] Remove unused iters from the result of reindex

### DIFF
--- a/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -487,6 +487,9 @@ Optional<LoopRV> MultiLevelTilingTensorCoreNode::TransformWithTensorIntrin(
 
   std::unordered_set<tir::Buffer, ObjectPtrHash, ObjectPtrEqual> visited_buffers;
 
+  Map<tir::Buffer, tir::IndexMap> buffer_sub_index_map;  // cache of the sub index map associated
+                                                         // with each buffer
+
   auto f_transform_buffer_layout = [&](tir::BufferIndexType index_type, int buffer_index) {
     const tir::Buffer& lhs_buffer = tir::GetNthAccessBuffer(
         state->sch->state(), block_before_reindex, buffer_index, index_type);
@@ -499,6 +502,7 @@ Optional<LoopRV> MultiLevelTilingTensorCoreNode::TransformWithTensorIntrin(
     const tir::BufferRegion& reindexed_buffer_region = tir::GetNthAccessBufferRegion(
         state->sch->state(), GetRef<tir::Block>(block), buffer_index, index_type);
     auto sub_index_map = f_get_sub_index_map(lhs_buffer, reindexed_buffer_region->region);
+    buffer_sub_index_map.Set(lhs_buffer, sub_index_map);
     state->sch->TransformLayout(state->block_rv, buffer_index, index_type, sub_index_map, NullOpt);
   };
 
@@ -510,11 +514,17 @@ Optional<LoopRV> MultiLevelTilingTensorCoreNode::TransformWithTensorIntrin(
   }
 
   // Transform the layout of current block and reindex blocks
-  state->sch->TransformBlockLayout(state->tensor_core_reindex_store, index_map);
-  state->sch->TransformBlockLayout(state->tensor_core_reindex_A, index_map);
-  state->sch->TransformBlockLayout(state->tensor_core_reindex_B, index_map);
+  auto f_transform_reindex_block_layout = [&](const BlockRV& block_rv,
+                                              tir::BufferIndexType buffer_type) {
+    tir::Buffer buffer =
+        tir::GetNthAccessBuffer(state->sch->state(), state->sch->Get(block_rv), 0, buffer_type);
+    const auto& sub_index_map = buffer_sub_index_map.at(buffer);
+    state->sch->TransformBlockLayout(block_rv, sub_index_map);
+  };
+  f_transform_reindex_block_layout(state->tensor_core_reindex_store, tir::BufferIndexType::kWrite);
+  f_transform_reindex_block_layout(state->tensor_core_reindex_A, tir::BufferIndexType::kRead);
+  f_transform_reindex_block_layout(state->tensor_core_reindex_B, tir::BufferIndexType::kRead);
   state->sch->TransformBlockLayout(state->block_rv, index_map);
-
   return tir::TileWithTensorIntrin(state->sch, state->block_rv, intrin_name,
                                    /*allow_padding=*/true);
 }

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -195,14 +195,18 @@ Block MakeReIndexStage(const Block& block, CacheStageInfo* info,
 
   // Step 1: Create block iters, access regions of the reindex block, and accessing indices to the
   // reindex buffer.
-  for (const IterVar& iter : block->iter_vars) {
+  std::unordered_set<int> skipped_block_iters;
+  for (int i = 0, n = block->iter_vars.size(); i < n; ++i) {
+    const IterVar& iter = block->iter_vars[i];
     Var var("v" + std::to_string(new_block_iters.size()), iter->var->dtype);
     bool used = covered.count(iter->var);
-    new_block_iters.push_back(
-        IterVar(/*dom=*/used ? iter->dom
-                             : Range::FromMinExtent(IntImm(var->dtype, 0), IntImm(var->dtype, 1)),
-                /*var=*/var,
-                /*IterVarType=*/kDataPar));
+    if (used) {
+      new_block_iters.push_back(IterVar(/*dom=*/used ? iter->dom : Range::FromMinExtent(0, 1),
+                                        /*var=*/var,
+                                        /*IterVarType=*/kDataPar));
+    } else {
+      skipped_block_iters.insert(i);
+    }
     if (used) {
       reindex_indices.push_back(var);
       reindex_region.push_back(Range::FromMinExtent(var, IntImm(var->dtype, 1)));
@@ -256,6 +260,9 @@ Block MakeReIndexStage(const Block& block, CacheStageInfo* info,
   std::vector<Var> loop_vars;         // loop variables
   std::vector<PrimExpr> iter_values;  // bindings in block realize
   for (int i = 0; i < static_cast<int>(block->iter_vars.size()); ++i) {
+    if (skipped_block_iters.count(i)) {
+      continue;
+    }
     Var loop_var("ax" + std::to_string(loop_vars.size()), block->iter_vars[i]->var->dtype);
     loop_vars.push_back(loop_var);
     iter_values.push_back(loop_var);


### PR DESCRIPTION
The existence of unused block iters make it difficult for block layout transformation. Previous it relies the flag `simplify_trivial_iter=true` in affine analysis, which is unsafe because simplifying trivial iterators during scheduling stage lose the information of iterators.

cc @spectrometerHBH @junrushao @Hzfengsy 