### PR TITLE
[MetaSchedule] Add JSON Database Validation Scripts

### DIFF
--- a/python/tvm/meta_schedule/profiler.py
+++ b/python/tvm/meta_schedule/profiler.py
@@ -34,7 +34,7 @@ class Profiler(Object):
         )
 
     def get(self) -> Dict[str, float]:
-        """Get the profiling results in minutes"""
+        """Get the profiling results in seconds"""
         return _ffi_api.ProfilerGet(self)  # type: ignore # pylint: disable=no-member
 
     def table(self) -> str:

--- a/python/tvm/meta_schedule/testing/custom_builder_runner.py
+++ b/python/tvm/meta_schedule/testing/custom_builder_runner.py
@@ -143,7 +143,7 @@ def run_module_via_rpc(
     rpc_config: "RPCConfig",
     lib: Union["Module", "Executable"],
     dev_type: str,
-    args: Dict[str, "np.ndarray"],
+    args: Dict[Union[str, int], "np.ndarray"],
     continuation: Callable,
     backend: Optional[str] = "graph",
 ):

--- a/python/tvm/meta_schedule/testing/custom_builder_runner.py
+++ b/python/tvm/meta_schedule/testing/custom_builder_runner.py
@@ -17,7 +17,7 @@
 """Customized builder and runner methods"""
 # pylint: disable=import-outside-toplevel
 
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Any, Optional, Union, Callable
 
 if TYPE_CHECKING:
     import numpy as np  # type: ignore
@@ -143,7 +143,7 @@ def run_module_via_rpc(
     rpc_config: "RPCConfig",
     lib: Union["Module", "Executable"],
     dev_type: str,
-    args: Dict[Union[str, int], "np.ndarray"],
+    args: Dict[Any, "np.ndarray"],
     continuation: Callable,
     backend: Optional[str] = "graph",
 ):

--- a/python/tvm/meta_schedule/testing/custom_builder_runner.py
+++ b/python/tvm/meta_schedule/testing/custom_builder_runner.py
@@ -17,7 +17,7 @@
 """Customized builder and runner methods"""
 # pylint: disable=import-outside-toplevel
 
-from typing import TYPE_CHECKING, Dict, List, Any, Optional, Union, Callable
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, Callable
 
 if TYPE_CHECKING:
     import numpy as np  # type: ignore
@@ -143,7 +143,7 @@ def run_module_via_rpc(
     rpc_config: "RPCConfig",
     lib: Union["Module", "Executable"],
     dev_type: str,
-    args: Dict[Any, "np.ndarray"],
+    args: Dict[Union[int, str], "np.ndarray"],
     continuation: Callable,
     backend: Optional[str] = "graph",
 ):

--- a/python/tvm/meta_schedule/testing/custom_builder_runner.py
+++ b/python/tvm/meta_schedule/testing/custom_builder_runner.py
@@ -143,7 +143,7 @@ def run_module_via_rpc(
     rpc_config: "RPCConfig",
     lib: Union["Module", "Executable"],
     dev_type: str,
-    args: Dict[Union[int, str], "np.ndarray"],
+    args: Union[Dict[int, "np.ndarray"], Dict[str, "np.ndarray"]],
     continuation: Callable,
     backend: Optional[str] = "graph",
 ):

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -236,5 +236,6 @@ def create_computer(backend: str) -> Callable:
             print(
                 f"Run module f_computer via RPC failed, exception: {exc}",
             )
+            return None
 
     return f_computer

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -210,9 +210,9 @@ def create_computer(backend: str) -> Callable:
 
     def f_computer(
         rt_mod: tvm.runtime.Module,
-        dev: tvm.runtime.Device,
+        dev: tvm.runtime.Device,  # pylint: disable=unused-argument
         input_data: Dict[str, NDArray],
-    ) -> None:
+    ) -> List[NDArray]:
         """Fetch the result of running the given runtime module.
 
         Parameters
@@ -226,9 +226,9 @@ def create_computer(backend: str) -> Callable:
         """
         try:
             if backend == "tir":
-                inputs = [v for _, v in sorted(input_data.items(), key=lambda x: x[0])]
-                rt_mod(*inputs)
-                return inputs
+                data = [v for _, v in sorted(input_data.items(), key=lambda x: x[0])]
+                rt_mod(*data)
+                return data
             else:
                 raise ValueError(f"Backend {backend} not supported in f_computer!")
 

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -86,7 +86,7 @@ def create_timer(backend: str) -> Callable:
 
     def f_timer(
         rt_mod: Union[tvm.runtime.Module, tvm.runtime.vm.Executable],
-        dev: tvm.device,
+        dev: tvm.runtime.Device,
         input_data: Dict[str, NDArray],
     ) -> None:
         """Run and benchmark the given runtime module, print out the result.
@@ -95,7 +95,7 @@ def create_timer(backend: str) -> Callable:
         ----------
         rt_mod : Union[tvm.runtime.Module, tvm.runtime.vm.Executable]
             The runtime module or vm executable.
-        dev : tvm.device
+        dev : tvm.runtime.Device
             The device type to run workload.
         input_data : Dict[str, np.ndarray]
             The input data as a dictionary.
@@ -152,7 +152,7 @@ def create_time_per_layer(graph: str) -> Callable:
 
     def f_time_per_layer(
         rt_mod: tvm.runtime.Module,
-        dev: tvm.device,
+        dev: tvm.runtime.Device,
         input_data: Dict[str, NDArray],
     ) -> None:
         """Run and benchmark the per-layer performance of given runtime module,
@@ -162,7 +162,7 @@ def create_time_per_layer(graph: str) -> Callable:
         ----------
         rt_mod : tvm.runtime.Module
             The runtime module.
-        dev : tvm.device
+        dev : tvm.runtime.Device
             The device type to run workload.
         input_data : Dict[str, np.ndarray]
             The input data as a dictionary.
@@ -210,7 +210,7 @@ def create_computer(backend: str) -> Callable:
 
     def f_computer(
         rt_mod: tvm.runtime.Module,
-        dev: tvm.device,
+        dev: tvm.runtime.Device,
         input_data: Dict[str, NDArray],
     ) -> None:
         """Fetch the result of running the given runtime module.
@@ -226,12 +226,11 @@ def create_computer(backend: str) -> Callable:
         """
         try:
             if backend == "tir":
-
-                inputs = [lambda x: x[1] for x in sorted(lambda x: x[0], input_data.items())]
-                rt_mod["default"](dev)(inputs)
-                return [x.cpu().numpy() for x in inputs]
+                inputs = [v for _, v in sorted(input_data.items(), key=lambda x: x[0])]
+                rt_mod(*inputs)
+                return inputs
             else:
-                raise ValueError(f"Backend {backend} not supported in f_timer!")
+                raise ValueError(f"Backend {backend} not supported in f_computer!")
 
         except Exception as exc:  # pylint: disable=broad-except
             print(

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -194,13 +194,13 @@ def create_time_per_layer(graph: str) -> Callable:
     return f_time_per_layer
 
 
-def create_computer(backend: str) -> Callable:
+def create_calculator(backend: str) -> Callable:
     """Create a function to fetch the computing result of running the given runtime module.
 
     Parameters
     ----------
     backend : str
-        The backend to use, graph / vm.
+        The backend to use, only tir is supported for now.
 
     Returns
     -------
@@ -208,7 +208,7 @@ def create_computer(backend: str) -> Callable:
         The function to fetch the computing result.
     """
 
-    def f_computer(
+    def f_calculator(
         rt_mod: tvm.runtime.Module,
         dev: tvm.runtime.Device,  # pylint: disable=unused-argument
         input_data: Dict[str, NDArray],
@@ -230,12 +230,12 @@ def create_computer(backend: str) -> Callable:
                 rt_mod(*data)
                 return data
             else:
-                raise ValueError(f"Backend {backend} not supported in f_computer!")
+                raise ValueError(f"Backend {backend} not supported in f_calculator!")
 
         except Exception as exc:  # pylint: disable=broad-except
             print(
-                f"Run module f_computer via RPC failed, exception: {exc}",
+                f"Run module f_calculator via RPC failed, exception: {exc}",
             )
             return None
 
-    return f_computer
+    return f_calculator

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -270,7 +270,8 @@ def main():
                     )
             if flag:
                 print(
-                    f"Progress {i+1: 6d} / {len(records): 6d} checked, used {float(profiler.get()[scope_name]): 3.3f} sec."
+                    f"Progress {i+1: 6d} / {len(records): 6d} checked,"
+                    f" used {float(profiler.get()[scope_name]): 3.3f} sec."
                 )
             else:
                 return

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -1,0 +1,256 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""JSON Database validation script"""
+from typing import Union, Callable, List
+from distutils.util import strtobool
+import argparse
+import logging
+import warnings
+import numpy as np
+
+import tvm
+from tvm.target import Target
+from tvm.ir import IRModule
+from tvm.tir import Schedule
+from tvm import meta_schedule as ms
+from tvm.meta_schedule.testing.custom_builder_runner import run_module_via_rpc
+from tvm.meta_schedule.testing.tune_utils import create_computer, generate_input_data
+from tvm._ffi import get_global_func, register_func
+from tvm.support import describe
+
+
+def _parse_args():
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        "--path-workload",
+        type=str,
+        required=True,
+        help="The path to the database workload file.",
+    )
+    args.add_argument(
+        "--path-tuning-record",
+        type=str,
+        required=True,
+        help="The path to the database tuning record file.",
+    )
+    args.add_argument(
+        "--target",
+        type=str,
+        required=True,
+    )
+    args.add_argument(
+        "--baseline-target",
+        type=str,
+        default="llvm -num-cores=1",
+        required=False,
+        help="The baseline target to compile the original module.",
+    )
+    args.add_argument(
+        "--rpc-host",
+        type=str,
+        required=True,
+    )
+    args.add_argument(
+        "--rpc-port",
+        type=int,
+        required=True,
+    )
+    args.add_argument(
+        "--rpc-key",
+        type=str,
+        required=True,
+    )
+    args.add_argument(
+        "--number",
+        type=int,
+        default=3,
+    )
+    args.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+    )
+    args.add_argument(
+        "--min-repeat-ms",
+        type=int,
+        default=100,
+    )
+    args.add_argument(
+        "--cpu-flush",
+        type=lambda x: bool(strtobool(x)),
+        help="example: True / False",
+        required=True,
+    )
+    parsed = args.parse_args()
+    parsed.target = tvm.target.Target(parsed.target)
+    parsed.rpc_config = ms.runner.RPCConfig(
+        tracker_host=parsed.rpc_host,
+        tracker_port=parsed.rpc_port,
+        tracker_key=parsed.rpc_key,
+        session_timeout_sec=600,
+    )
+    if parsed.cpu_flush and parsed.target.kind.name != "llvm":
+        warnings.warn("cpu_flush is only supported on llvm target")
+    return parsed
+
+
+# logging
+logging.basicConfig(
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
+logging.getLogger("tvm.meta_schedule").setLevel(logging.INFO)
+
+# arg parser
+ARGS = _parse_args()
+
+
+@register_func("tvm.meta_schedule.testing.default_input_generator")
+def default_input_generator(mod: IRModule) -> List[np.ndarray]:
+    args_info = ms.arg_info.TensorInfo.from_prim_func(mod["main"])
+    inputs = [
+        generate_input_data(input_shape=arg_info.shape, input_dtype=arg_info.dtype)
+        for arg_info in args_info
+    ]
+    return inputs
+
+
+@register_func("tvm.meta_schedule.testing.default_check_metric")
+def default_check_metric(a: np.ndarray, b: np.ndarray) -> bool:
+    return np.allclose(a, b, rtol=1e-3, atol=2e-3)
+
+
+def validate_correctness(
+    original_mod: IRModule,  # compiled for "baseline_target"
+    scheduled_mod: IRModule,  # compiled for "target"
+    *,
+    baseline_target: Union[str, Target],
+    target: Union[str, Target],
+    dev_type: str,
+    rpc_config: ms.runner.RPCConfig,
+    f_input_generator: Union[str, Callable] = "tvm.meta_schedule.testing.default_input_generator",
+    f_check_metric: Union[str, Callable] = "tvm.meta_schedule.testing.default_check_metric",
+) -> bool:
+    """Function to validate the correctness of a scheduled module.
+
+    Parameters
+    ----------
+    original_mod : IRModule
+        The original module to be compiled.
+    scheduled_mod : IRModule
+        The scheduled module to be compiled.
+    target : Target
+        The target to compile the scheduled module.
+    rpc_config : RPCConfig
+        The RPCConfig to run the scheduled module.
+    f_input_generator : Union[str, Callable]
+        The function to generate the input data.
+    f_check_metric : Union[str, Callable]
+        The function to check the metric.
+
+    Returns
+    -------
+    result : ...
+        The result of the validation.
+    """
+
+    def build_and_run(mod: IRModule, target: Target, dev_type: str) -> np.ndarray:
+        """Build and run the module on the target device."""
+        rt_mod = tvm.build(mod, target=target)
+        args = {i: arg for i, arg in enumerate(inputs)}
+        return run_module_via_rpc(
+            rpc_config=rpc_config,
+            lib=rt_mod,
+            dev_type=dev_type,
+            args=args,
+            continuation=create_computer(backend="tir"),
+            backend="tir",
+        )
+
+    # make targets
+    target = Target(target)
+    baseline_target = Target(baseline_target)
+    # fetch functions & prepare inputs
+    if isinstance(f_input_generator, str):
+        input_generator_func = get_global_func(f_input_generator)
+    if isinstance(f_check_metric, str):
+        check_metric_func = get_global_func(f_check_metric)
+    inputs = input_generator_func(original_mod)
+    # build & run original result
+    original_res = build_and_run(original_mod, target=baseline_target, dev_type="cpu")
+    scheduled_res = build_and_run(scheduled_mod, target=target, dev_type=dev_type)
+    # check metric
+    if not check_metric_func(original_res, scheduled_res):
+        return True
+    else:
+        print(
+            ("\n\n").join(
+                [
+                    "Validation failed!",
+                    "Original Result:\n" + "-" * 10 + str(original_res),
+                    "Scheduled Result:\n" + "-" * 10 + str(scheduled_res),
+                    "Input:\n" + "-" * 10 + str(inputs),
+                    "Original IRModule:\n" + "-" * 10 + original_mod.script(),
+                    "Scheduled IRModule:\n" + "-" * 10 + scheduled_mod.script(),
+                ]
+            )
+        )
+        return False
+
+
+def main():
+    """Main function"""
+    describe()
+    database = ms.database.JSONDatabase(
+        path_workload=ARGS.path_workload, path_tuning_record=ARGS.path_tuning_record
+    )
+    assert Target(ARGS.target).kind.name in ["llvm", "cuda"]
+    dev_type = "cpu" if Target(ARGS.target).kind.name == "llvm" else "cuda"
+    records = database.get_all_tuning_records()
+    for i, record in enumerate(records):
+        original_mod = record.workload.mod
+        sch = Schedule(original_mod)
+        scheduled_mod = record.trace.apply_to_schedule(sch=sch, remove_postproc=False)
+        try:
+            flag = validate_correctness(
+                original_mod=original_mod,
+                scheduled_mod=scheduled_mod,
+                target=ARGS.target,
+                baseline_target=ARGS.baseline_target,
+                dev_type=dev_type,
+                rpc_config=ARGS.rpc_config,
+            )
+        except Exception as e:  # pylint: disable=broad-except, invalid-name
+            print(
+                ("\n\n").join(
+                    [
+                        "Validation failed!",
+                        "Original IRModule:\n" + "-" * 10 + original_mod.script(),
+                        "Scheduled IRModule:\n" + "-" * 10 + scheduled_mod.script(),
+                        "Exception\n" + "-" * 10 + str(e),
+                    ]
+                )
+            )
+        if flag:
+            print(f"Progress {i+1: 6d} / {len(records): 6d} checked.")
+        else:
+            return
+
+    print("Validation passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -275,6 +275,7 @@ def main():
                 return
 
     print("Validation passed!")
+    print(f"Total time spent: {float(profiler.get()['Total']): 3.3f} sec.")
 
 
 if __name__ == "__main__":

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -194,7 +194,7 @@ def validate_correctness(
             rpc_config=rpc_config,
             lib=rt_mod,
             dev_type=dev_type,
-            args={i: v for i, v in enumerate(inputs)},  # type: ignore
+            args={i: v for i, v in enumerate(inputs)},  # pylint: disable=unnecessary-comprehension
             continuation=create_computer(backend="tir"),
             backend="tir",
         )

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -194,7 +194,7 @@ def validate_correctness(
             rpc_config=rpc_config,
             lib=rt_mod,
             dev_type=dev_type,
-            args=inputs,
+            args={i: v for i, v in enumerate(inputs)},
             continuation=create_computer(backend="tir"),
             backend="tir",
         )

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -20,7 +20,7 @@ from distutils.util import strtobool
 import argparse
 import logging
 import warnings
-import numpy as np
+import numpy as np  # type: ignore
 
 import tvm
 from tvm.target import Target
@@ -190,12 +190,11 @@ def validate_correctness(
     def build_and_run(mod: IRModule, target: Target, dev_type: str) -> np.ndarray:
         """Build and run the module on the target device."""
         rt_mod = tvm.build(mod, target=target)
-        args = {i: arg for i, arg in enumerate(inputs)}
         return run_module_via_rpc(
             rpc_config=rpc_config,
             lib=rt_mod,
             dev_type=dev_type,
-            args=args,
+            args=inputs,
             continuation=create_computer(backend="tir"),
             backend="tir",
         )
@@ -208,12 +207,12 @@ def validate_correctness(
         f_input_generator = get_global_func(f_input_generator)
     if isinstance(f_check_metric, str):
         f_check_metric = get_global_func(f_check_metric)
-    inputs = to_numpy(f_input_generator(original_mod))
+    inputs = to_numpy(f_input_generator(original_mod))  # type: ignore
     # build & run original result
     original_res = to_numpy(build_and_run(original_mod, target=baseline_target, dev_type="cpu"))
     scheduled_res = to_numpy(build_and_run(scheduled_mod, target=target, dev_type=dev_type))
     # check metric
-    if f_check_metric(to_tvm_ndarray(original_res), to_tvm_ndarray(scheduled_res)):
+    if f_check_metric(to_tvm_ndarray(original_res), to_tvm_ndarray(scheduled_res)):  # type: ignore
         return True
     else:
         print(

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -194,7 +194,7 @@ def validate_correctness(
             rpc_config=rpc_config,
             lib=rt_mod,
             dev_type=dev_type,
-            args={i: v for i, v in enumerate(inputs)},
+            args={i: v for i, v in enumerate(inputs)},  # type: ignore
             continuation=create_computer(backend="tir"),
             backend="tir",
         )


### PR DESCRIPTION
This PR introduces a validation script to check result accuracy between the scheduled IRModules and original IRModule stored in MetaSchedule database. The validate function could also be reused for other type of databases in MetaSchedule. The result would be printed out on the screen as validation passed or failed at some records.

CC @junrushao

When running checks the expected output looks like:
```bash
Progress      1 /   1003 checked.
Progress      2 /   1003 checked.
Progress      3 /   1003 checked.
Progress      4 /   1003 checked.
Progress      5 /   1003 checked.
...
```
If everything runs well, the script will print out a `Validation passed!` in the end.
If there's any unexpected error or unmatched results, it will print out the IRModules, inputs or exceptions.

```python
Progress     74 /   1003 checked.
Validation failed!

Original Result:
------------------------------
[array([[[[0.5871589 , 0.47408924, 0.60046124, ..., 0.12766571,
          0.3109562 , 0.663565  ],
         [0.14416751, 0.41065693, 0.86465174, ..., 0.67013186,
          0.93802315, 0.9002784 ],
         ...

Scheduled Result:
------------------------------
[array([[[[0.5871589 , 0.47408924, 0.60046124, ..., 0.12766571,
          0.3109562 , 0.663565  ],
         [0.14416751, 0.41065693, 0.86465174, ..., 0.67013186,
          0.93802315, 0.9002784 ],
         [0.32672247, 0.51320565, 0.07578897, ..., 0.8171424 ,
          0.835486  , 0.26994228],
         ...,

Input:
------------------------------
[array([[[[0.5871589 , 0.47408924, 0.60046124, ..., 0.12766571,
          ...

Original IRModule:
------------------------------
# from tvm.script import tir as T
@tvm.script.ir_module
class Module:
    @T.prim_func
    def main(p0: T.Buffer[(1, 7, 7, 512), "float32"], tensor: T.Buffer[(1, 1, 1, 512), "float32"]) -> None:
        # function attr dict
        T.func_attr({"tir.noalias": True, "global_symbol": "main"})
        # body
        # with T.block("root")
        tensor_1 = T.alloc_buffer([1, 1, 1, 512], dtype="float32")
        for i0, i1, i2, i3, i4, i5 in T.grid(1, 1, 1, 512, 7, 7):
            with T.block("tensor"):
                ax0, ax1, ax2, ax3, rv0, rv1 = T.axis.remap("SSSSRR", [i0, i1, i2, i3, i4, i5])
                T.reads(p0[ax0, ax1 * 7 + rv0, ax2 * 7 + rv1, ax3])
                T.writes(tensor_1[ax0, ax1, ax2, ax3])
                with T.init():
                    tensor_1[ax0, ax1, ax2, ax3] = T.float32(0)
                tensor_1[ax0, ax1, ax2, ax3] = tensor_1[ax0, ax1, ax2, ax3] + p0[ax0, ax1 * 7 + rv0, ax2 * 7 + rv1, ax3]
        for i0, i1, i2, i3 in T.grid(1, 1, 1, 512):
            with T.block("tensor_1"):
                ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
                T.reads(tensor_1[ax0, ax1, ax2, ax3])
                T.writes(tensor[ax0, ax1, ax2, ax3])
                tensor[ax0, ax1, ax2, ax3] = tensor_1[ax0, ax1, ax2, ax3] * T.float32(0.020408163265306121)
    


Scheduled IRModule:
------------------------------
# from tvm.script import tir as T
@tvm.script.ir_module
class Module:
    @T.prim_func
    def main(p0: T.Buffer[(1, 7, 7, 512), "float32"], tensor: T.Buffer[(1, 1, 1, 512), "float32"]) -> None:
        # function attr dict
        T.func_attr({"tir.noalias": True, "global_symbol": "main"})
        # body
        # with T.block("root")
        tensor_shared = T.alloc_buffer([1, 1, 1, 512], dtype="float32", scope="shared")
        for i0_i1_i2_i3_0_fused in T.thread_binding(2, thread="blockIdx.x", annotations={"pragma_auto_unroll_max_step":T.int64(64), "pragma_unroll_explicit":T.int64(1)}):
            for ax0, ax1, ax2, ax3, ax4_ax5_fused_0 in T.grid(1, 1, 1, 256, 1):
                for ax4_ax5_fused_1 in T.thread_binding(256, thread="threadIdx.x"):
                    with T.block("tensor"):
                        T.where(ax4_ax5_fused_0 * 256 + ax4_ax5_fused_1 < 49)
                        ax0_1, ax1_1, ax2_1 = T.axis.remap("SSS", [ax0, ax1, ax2])
                        ax3_1 = T.axis.spatial(512, i0_i1_i2_i3_0_fused * 256 + ax3)
                        rv0 = T.axis.reduce(7, (ax4_ax5_fused_0 * 256 + ax4_ax5_fused_1) // 7)
                        rv1 = T.axis.reduce(7, (ax4_ax5_fused_0 * 256 + ax4_ax5_fused_1) % 7)
                        T.reads(p0[ax0_1, ax1_1 * 7 + rv0, ax2_1 * 7 + rv1, ax3_1])
                        T.writes(tensor_shared[ax0_1, ax1_1, ax2_1, ax3_1])
                        with T.init():
                            tensor_shared[ax0_1, ax1_1, ax2_1, ax3_1] = T.float32(0)
                        tensor_shared[ax0_1, ax1_1, ax2_1, ax3_1] = tensor_shared[ax0_1, ax1_1, ax2_1, ax3_1] + p0[ax0_1, ax1_1 * 7 + rv0, ax2_1 * 7 + rv1, ax3_1]
            for i3_1 in T.thread_binding(256, thread="threadIdx.x"):
                with T.block("tensor_1"):
                    ax0 = T.axis.spatial(1, 0)
                    ax1 = T.axis.spatial(1, 0)
                    ax2 = T.axis.spatial(1, 0)
                    ax3 = T.axis.spatial(512, i0_i1_i2_i3_0_fused * 256 + i3_1)
                    T.reads(tensor_shared[ax0, ax1, ax2, ax3])
                    T.writes(tensor[ax0, ax1, ax2, ax3])
                    tensor[ax0, ax1, ax2, ax3] = tensor_shared[ax0, ax1, ax2, ax3] * T.float32(0.020408163265306121)
```