### PR TITLE
[TIR] Use IndexMap to transform NDArray

### DIFF
--- a/include/tvm/tir/index_map.h
+++ b/include/tvm/tir/index_map.h
@@ -141,7 +141,7 @@ class IndexMapNode : public Object {
    * \param arr_src The NDArray whose layout is transformed by this index map.
    *
    * \returns The transformed NDArray.
-  */
+   */
   runtime::NDArray MapNDArray(runtime::NDArray arr_src) const;
 
   /*!

--- a/include/tvm/tir/index_map.h
+++ b/include/tvm/tir/index_map.h
@@ -136,6 +136,11 @@ class IndexMapNode : public Object {
    */
   Array<PrimExpr> MapShape(const Array<PrimExpr>& shape, arith::Analyzer* analyzer = nullptr) const;
 
+  /*
+    TODO
+  */
+  runtime::NDArray MapNDArray(runtime::NDArray constant) const;
+
   /*!
    * \brief Convert to string representation in Python.
    * \return The stringified lambda expression in Python.

--- a/include/tvm/tir/index_map.h
+++ b/include/tvm/tir/index_map.h
@@ -136,10 +136,13 @@ class IndexMapNode : public Object {
    */
   Array<PrimExpr> MapShape(const Array<PrimExpr>& shape, arith::Analyzer* analyzer = nullptr) const;
 
-  /*
-    TODO
+  /* \brief Map an NDArray according to this index map
+   *
+   * \param arr_src The NDArray whose layout is transformed by this index map.
+   *
+   * \returns The transformed NDArray.
   */
-  runtime::NDArray MapNDArray(runtime::NDArray constant) const;
+  runtime::NDArray MapNDArray(runtime::NDArray arr_src) const;
 
   /*!
    * \brief Convert to string representation in Python.

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -515,6 +515,12 @@ class IndexMap(Object):
         """
         return _ffi_api.IndexMapMapShape(self, shape)
 
+    def map_ndarray(self, arr):
+        """
+        TODO
+        """
+        return _ffi_api.IndexMapMapNDArray(self, arr)
+
     def inverse(self, shape: List[Union[Range, PrimExpr]]) -> "IndexMap":
         """Return the inverse of the map
 

--- a/python/tvm/tir/function.py
+++ b/python/tvm/tir/function.py
@@ -28,6 +28,7 @@ from tvm.ir import BaseFunc, Range
 from .buffer import Buffer
 from .expr import Var, PrimExpr
 from . import _ffi_api
+from ..runtime.ndarray import NDArray
 
 
 @tvm._ffi.register_object("tir.PrimFunc")
@@ -515,11 +516,20 @@ class IndexMap(Object):
         """
         return _ffi_api.IndexMapMapShape(self, shape)
 
-    def map_ndarray(self, arr):
+    def map_ndarray(self, arr_src: NDArray) -> NDArray:
+        """Apply thie index map to transform the layout of the input NDArray
+
+        Parameters
+        ----------
+        arr_src : runtime.NDArray
+            The NDArray to be transformed
+
+        Returns
+        -------
+        arr_dst : runtime.NDArray
+            The transformed NDArray
         """
-        TODO
-        """
-        return _ffi_api.IndexMapMapNDArray(self, arr)
+        return _ffi_api.IndexMapMapNDArray(self, arr_src)
 
     def inverse(self, shape: List[Union[Range, PrimExpr]]) -> "IndexMap":
         """Return the inverse of the map

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -210,6 +210,9 @@ Array<PrimExpr> IndexMapNode::MapShape(const Array<PrimExpr>& shape,
 
 runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
   auto shape = arr_src.Shape();
+  ICHECK(shape.size() == initial_indices.size())
+      << "The rank of the input array should be " << initial_indices.size() << " but got "
+      << shape.size();
   size_t size_1d = 1;
   Array<PrimExpr> orig_shape;
   for (int i = 0; i < shape.size(); ++i) {

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -217,7 +217,7 @@ runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
   Array<PrimExpr> orig_shape;
   for (int i = 0; i < shape.size(); ++i) {
     size_1d *= shape[i];
-    orig_shape.push_back(PrimExpr(int(shape[i])));
+    orig_shape.push_back(PrimExpr(static_cast<int>((shape[i]))));
   }
   auto dst_shape = MapShape(orig_shape);
 
@@ -240,7 +240,7 @@ runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
     auto src_linear_index = i;
     for (auto s : shape) {
       div_factor /= s;
-      src_indices.push_back(PrimExpr(int(src_linear_index / div_factor)));
+      src_indices.push_back(PrimExpr(static_cast<int>((src_linear_index / div_factor))));
       src_linear_index %= div_factor;
     }
     auto dst_indices = MapIndices(src_indices);

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -215,14 +215,14 @@ runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
       << shape.size();
   size_t size_1d = 1;
   Array<PrimExpr> orig_shape;
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     size_1d *= shape[i];
     orig_shape.push_back(PrimExpr(static_cast<int>((shape[i]))));
   }
   auto dst_shape = MapShape(orig_shape);
 
   std::vector<int64_t> dst_shape_int;
-  for (int i = 0; i < dst_shape.size(); ++i) {
+  for (size_t i = 0; i < dst_shape.size(); ++i) {
     dst_shape_int.push_back(dst_shape[i].as<IntImmNode>()->value);
   }
 
@@ -249,7 +249,7 @@ runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
     // (z, y, x) -> z * height * width + y * width + x
     size_t dst_linear_index = 0;
     auto mul_factor = size_1d;
-    for (int j = 0; j < dst_indices.size(); ++j) {
+    for (size_t j = 0; j < dst_indices.size(); ++j) {
       mul_factor /= dst_shape_int[j];
       dst_linear_index += dst_indices[j].as<IntImmNode>()->value * mul_factor;
     }

--- a/tests/python/unittest/test_index_map.py
+++ b/tests/python/unittest/test_index_map.py
@@ -243,7 +243,8 @@ def test_map_ndarray():
     I = 64
     O = 64
     inp = np.random.randn(kH, kW, I, O).astype("float32")
-    out = index_map.map_ndarray(tvm.nd.array(inp)).numpy()
+    arr = tvm.nd.array(inp)
+    out = index_map.map_ndarray(arr).numpy()
 
     ref = np.zeros(out.shape).astype("float32")
 
@@ -255,6 +256,9 @@ def test_map_ndarray():
                     ref[i3 // 32, i0, i2 // 8, (i3 % 32) // 16, i1, i2 % 8, i3 % 16] = v
 
     np.testing.assert_equal(ref, out)
+
+    inverse_map = index_map.inverse(inp.shape)
+    np.testing.assert_equal(inverse_map.map_ndarray(index_map.map_ndarray(arr)).numpy(), inp)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_index_map.py
+++ b/tests/python/unittest/test_index_map.py
@@ -243,8 +243,7 @@ def test_map_ndarray():
     I = 64
     O = 64
     inp = np.random.randn(kH, kW, I, O).astype("float32")
-    arr = tvm.nd.array(inp)
-    out = index_map.map_ndarray(arr).numpy()
+    out = index_map.map_ndarray(tvm.nd.array(inp)).numpy()
 
     ref = np.zeros(out.shape).astype("float32")
 


### PR DESCRIPTION
I've hit a weird use case where I want to manually transform `runtime::NDArray` (attached to `AllocateConst` node) according to the index map used in `transform_layout`. This is needed to support `AllocateConst` node in Metaschedule `RewriteLayout` postproc.

I can define it as a free function in the file where it is actually used. Having it available as part of the `IndexMap` interface makes it convenient to expose this to python and unit-test it. Let me know if this is a reasonable API addition. 

cc @vinx13 @Lunderberg @junrushao 