### PR TITLE
[CMSIS-NN] Support for int16 conv2d

### DIFF
--- a/python/tvm/relay/op/contrib/cmsisnn.py
+++ b/python/tvm/relay/op/contrib/cmsisnn.py
@@ -146,17 +146,19 @@ def pattern_table():
         # check if dtypes are supported for the following entities
         # (input_dtype, weight_dtype, bias_dtype, out_dtype, pattern_dtype)
         are_dtypes_valid = False
+        conv2d_input_dtype = conv2d_input.checked_type.dtype
         if bias_add:
             bias_dtype = bias_add.args[1].checked_type.dtype
         else:
-            bias_dtype = "int32" if conv2d_input.checked_type.dtype == "int8" else "int64"
+            # this is only to enable to following check that validates all sorts of dtypes
+            bias_dtype = "int32" if conv2d_input_dtype == "int8" else "int64"
         valid_dtypes = None
-        if conv2d_input.checked_type.dtype == "int8":
+        if conv2d_input_dtype == "int8":
             valid_dtypes = ("int8", "int8", "int32", "int32", "int8")
-        elif conv2d_input.checked_type.dtype == "int16":
+        elif conv2d_input_dtype == "int16":
             valid_dtypes = ("int16", "int8", "int64", "int64", "int16")
         if (
-            conv2d_input.checked_type.dtype,
+            conv2d_input_dtype,
             conv2d_weight.checked_type.dtype,
             bias_dtype,
             conv2d.attrs.out_dtype,
@@ -164,6 +166,7 @@ def pattern_table():
         ) == valid_dtypes:
             are_dtypes_valid = True
 
+        # combination of all checks to decide if pattern is eligible for partitioning
         ret = (
             are_dtypes_valid
             and all([zp == 0 for zp in kernel_zp])

--- a/src/relay/backend/contrib/cmsisnn/buffer_size.cc
+++ b/src/relay/backend/contrib/cmsisnn/buffer_size.cc
@@ -29,10 +29,27 @@ namespace relay {
 namespace contrib {
 namespace cmsisnn {
 
-int Conv2dBufferSize(Target target, int32_t padding_w, int32_t padding_h, int32_t input_n,
-                     int32_t input_h, int32_t input_c, int32_t output_h, int32_t output_w,
-                     int32_t stride_w, int32_t stride_h, int32_t dilation_w, int32_t dilation_h,
-                     int32_t filter_w, int32_t filter_h) {
+int Conv2dBufferSize(bool is_int16, Target target, int32_t padding_w, int32_t padding_h,
+                     int32_t input_n, int32_t input_h, int32_t input_c, int32_t output_h,
+                     int32_t output_w, int32_t stride_w, int32_t stride_h, int32_t dilation_w,
+                     int32_t dilation_h, int32_t filter_w, int32_t filter_h) {
+  int size = -1;
+  if (is_int16) {
+    size = Conv2dBufferSizeInt16(target, padding_w, padding_h, input_n, input_h, input_c, output_h,
+                                 output_w, stride_w, stride_h, dilation_w, dilation_h, filter_w,
+                                 filter_h);
+  } else {
+    size = Conv2dBufferSizeInt8(target, padding_w, padding_h, input_n, input_h, input_c, output_h,
+                                output_w, stride_w, stride_h, dilation_w, dilation_h, filter_w,
+                                filter_h);
+  }
+  return size;
+}
+
+int Conv2dBufferSizeInt8(Target target, int32_t padding_w, int32_t padding_h, int32_t input_n,
+                         int32_t input_h, int32_t input_c, int32_t output_h, int32_t output_w,
+                         int32_t stride_w, int32_t stride_h, int32_t dilation_w, int32_t dilation_h,
+                         int32_t filter_w, int32_t filter_h) {
   bool is1x1 = (padding_w == 0) && (padding_h == 0) && (input_c % 4 == 0) && (stride_w == 1) &&
                (stride_h == 1) && (filter_w == 1) && (filter_h == 1) && (dilation_w == 1) &&
                (dilation_h == 1);
@@ -62,9 +79,38 @@ int Conv2dBufferSize(Target target, int32_t padding_w, int32_t padding_h, int32_
   return 0;
 }
 
-int DepthwiseConv2dBufferSize(Target target, int32_t input_n, int32_t input_c, int32_t output_c,
-                              int32_t filter_w, int32_t filter_h, int32_t dilation_w,
-                              int32_t dilation_h) {
+int Conv2dBufferSizeInt16(Target target, int32_t padding_w, int32_t padding_h, int32_t input_n,
+                          int32_t input_h, int32_t input_c, int32_t output_h, int32_t output_w,
+                          int32_t stride_w, int32_t stride_h, int32_t dilation_w,
+                          int32_t dilation_h, int32_t filter_w, int32_t filter_h) {
+  bool has_mve = target->GetFeature<Bool>("has_mve").value_or(Bool(false));
+  bool has_dsp = target->GetFeature<Bool>("has_dsp").value_or(Bool(false));
+
+  if (has_dsp && !has_mve) {
+    if ((filter_w * filter_h * input_c < 512) && dilation_w == 1 && dilation_h == 1) {
+      return (2 * input_c * filter_w * filter_h) * (int32_t)sizeof(int16_t);
+    }
+  }
+  return 0;
+}
+
+int DepthwiseConv2dBufferSize(bool is_int16, Target target, int32_t input_n, int32_t input_c,
+                              int32_t output_c, int32_t filter_w, int32_t filter_h,
+                              int32_t dilation_w, int32_t dilation_h, int32_t depth_multiplier) {
+  int size = -1;
+  if (is_int16) {
+    size = DepthwiseConv2dBufferSizeInt16(target, input_n, input_c, output_c, filter_w, filter_h,
+                                          dilation_w, dilation_h, depth_multiplier);
+  } else {
+    size = DepthwiseConv2dBufferSizeInt8(target, input_n, input_c, output_c, filter_w, filter_h,
+                                         dilation_w, dilation_h, depth_multiplier);
+  }
+  return size;
+}
+
+int DepthwiseConv2dBufferSizeInt8(Target target, int32_t input_n, int32_t input_c, int32_t output_c,
+                                  int32_t filter_w, int32_t filter_h, int32_t dilation_w,
+                                  int32_t dilation_h, int32_t depth_multiplier) {
   bool has_mve = target->GetFeature<Bool>("has_mve").value_or(Bool(false));
   bool has_dsp = target->GetFeature<Bool>("has_dsp").value_or(Bool(false));
 
@@ -73,6 +119,26 @@ int DepthwiseConv2dBufferSize(Target target, int32_t input_n, int32_t input_c, i
       return (4 * CH_IN_BLOCK_MVE * filter_w * filter_h) * (int32_t)sizeof(int8_t);
     } else if (has_dsp) {
       return (input_c * filter_w * filter_h) * (int32_t)sizeof(int16_t);
+    }
+  }
+  return 0;
+}
+
+int DepthwiseConv2dBufferSizeInt16(Target target, int32_t input_n, int32_t input_c,
+                                   int32_t output_c, int32_t filter_w, int32_t filter_h,
+                                   int32_t dilation_w, int32_t dilation_h,
+                                   int32_t depth_multiplier) {
+  bool has_mve = target->GetFeature<Bool>("has_mve").value_or(Bool(false));
+  bool has_dsp = target->GetFeature<Bool>("has_dsp").value_or(Bool(false));
+
+  if (depth_multiplier == 1 && dilation_w == 1 && dilation_h == 1 &&
+      filter_w * filter_h * input_c < 512) {
+    if (has_dsp) {
+      if (has_mve) {
+        return 4 * input_c * filter_w * filter_h * (int32_t)sizeof(int16_t) + 8;
+      } else {
+        return input_c * filter_w * filter_h * (int32_t)sizeof(int16_t);
+      }
     }
   }
   return 0;

--- a/src/relay/backend/contrib/cmsisnn/buffer_size.h
+++ b/src/relay/backend/contrib/cmsisnn/buffer_size.h
@@ -41,6 +41,7 @@ namespace cmsisnn {
  * See:
  * https://github.com/ARM-software/CMSIS_5/blob/8c60448c0e1e50e426180b26db9bc31ddf774361/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c#L108-L127
  *
+ * \param is_int16 - type of conv2d
  * \param target - CMSIS-NN Target
  * \param padding_w - Width padding
  * \param padding_h - Height padding
@@ -56,16 +57,27 @@ namespace cmsisnn {
  *
  * \return Size of buffer to allocate for convolution
  */
-int Conv2dBufferSize(Target target, int32_t padding_w, int32_t padding_h, int32_t input_n,
-                     int32_t input_h, int32_t input_c, int32_t output_h, int32_t output_w,
-                     int32_t stride_w, int32_t stride_h, int32_t dilation_w, int32_t dilation_h,
-                     int32_t filter_w, int32_t filter_h);
+int Conv2dBufferSize(bool is_int16, Target target, int32_t padding_w, int32_t padding_h,
+                     int32_t input_n, int32_t input_h, int32_t input_c, int32_t output_h,
+                     int32_t output_w, int32_t stride_w, int32_t stride_h, int32_t dilation_w,
+                     int32_t dilation_h, int32_t filter_w, int32_t filter_h);
+
+int Conv2dBufferSizeInt8(Target target, int32_t padding_w, int32_t padding_h, int32_t input_n,
+                         int32_t input_h, int32_t input_c, int32_t output_h, int32_t output_w,
+                         int32_t stride_w, int32_t stride_h, int32_t dilation_w, int32_t dilation_h,
+                         int32_t filter_w, int32_t filter_h);
+
+int Conv2dBufferSizeInt16(Target target, int32_t padding_w, int32_t padding_h, int32_t input_n,
+                          int32_t input_h, int32_t input_c, int32_t output_h, int32_t output_w,
+                          int32_t stride_w, int32_t stride_h, int32_t dilation_w,
+                          int32_t dilation_h, int32_t filter_w, int32_t filter_h);
 
 /*!
  * \brief Calculates the appropriate buffer size for CMSIS-NN Depthwise Convolutions
  * See:
  * https://github.com/ARM-software/CMSIS_5/blob/325443e52637b6c7eedbd160d238a6c462e89c9f/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c#L115-L129
  *
+ * \param is_int16 - type of conv2d
  * \param target - CMSIS-NN Target
  * \param input_n - Input batch size
  * \param input_c - Input channels
@@ -74,12 +86,22 @@ int Conv2dBufferSize(Target target, int32_t padding_w, int32_t padding_h, int32_
  * \param filter_h - Filter height
  * \param dilation_w - Dilation width
  * \param dilation_h - Dilation height
+ * \param depth_multiplier - Depth Multiplier for Depthwise Convolution
  *
  * \return Size of buffer to allocate for depthwise convolution
  */
-int DepthwiseConv2dBufferSize(Target target, int32_t input_n, int32_t input_c, int32_t output_c,
-                              int32_t filter_w, int32_t filter_h, int32_t dilation_w,
-                              int32_t dilation_h);
+int DepthwiseConv2dBufferSize(bool is_int16, Target target, int32_t input_n, int32_t input_c,
+                              int32_t output_c, int32_t filter_w, int32_t filter_h,
+                              int32_t dilation_w, int32_t dilation_h, int32_t depth_multiplier);
+
+int DepthwiseConv2dBufferSizeInt8(Target target, int32_t input_n, int32_t input_c, int32_t output_c,
+                                  int32_t filter_w, int32_t filter_h, int32_t dilation_w,
+                                  int32_t dilation_h, int32_t depth_multiplier);
+
+int DepthwiseConv2dBufferSizeInt16(Target target, int32_t input_n, int32_t input_c,
+                                   int32_t output_c, int32_t filter_w, int32_t filter_h,
+                                   int32_t dilation_w, int32_t dilation_h,
+                                   int32_t depth_multiplier);
 
 /*!
  * \brief Calculates the appropriate buffer size for CMSIS-NN Average Pooling

--- a/src/relay/backend/contrib/cmsisnn/tir_to_runtime.cc
+++ b/src/relay/backend/contrib/cmsisnn/tir_to_runtime.cc
@@ -111,7 +111,9 @@ class CodeGenCMSISNN : public codegen::CodeGenCHost {
         cmsis_func_name == "arm_elementwise_add_s8") {
       CodeGenC::VisitExpr_(op, os);
     } else if (cmsis_func_name == "arm_convolve_wrapper_s8" ||
-               cmsis_func_name == "arm_depthwise_conv_wrapper_s8") {
+               cmsis_func_name == "arm_convolve_wrapper_s16" ||
+               cmsis_func_name == "arm_depthwise_conv_wrapper_s8" ||
+               cmsis_func_name == "arm_depthwise_conv_wrapper_s16") {
       EmitConv2D(op);
     } else if (cmsis_func_name == "arm_fully_connected_s8") {
       EmitFullyConnected(op);

--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -947,17 +947,20 @@ def parameterize_for_invalid_model(test):
     in_dtype = ["uint8", "int8", "int16"]
     kernel_dtype = ["uint8", "int8"]
     kernel_zero_point = [-33, 10, 0]
-    all_combinations = itertools.product(in_dtype, kernel_dtype, kernel_zero_point)
+    input_zero_point = [64, 0]
+    all_combinations = itertools.product(
+        in_dtype, kernel_dtype, kernel_zero_point, input_zero_point
+    )
     all_combinations = filter(
         lambda parameters: not (
-            (parameters[0] == "int8" or parameters[0] == "int16")
+            (parameters[0] == "int8" or (parameters[0] == "int16" and parameters[3] == 0))
             and parameters[1] == "int8"
             and parameters[2] == 0
         ),
         all_combinations,
     )
     return pytest.mark.parametrize(
-        ["in_dtype", "kernel_dtype", "kernel_zero_point"],
+        ["in_dtype", "kernel_dtype", "kernel_zero_point", "input_zero_point"],
         all_combinations,
     )(test)
 
@@ -968,12 +971,12 @@ def test_invalid_parameters(
     in_dtype,
     kernel_dtype,
     kernel_zero_point,
+    input_zero_point,
 ):
     """Tests Depthwise op for non int8 inputs"""
     ifm_shape = (1, 28, 28, 12)
     out_channels = 2
     input_scale = 1
-    input_zero_point = 24
     kernel_scale = [0.11, 0.0237]
 
     kernel_layout = "HWIO"

--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -257,6 +257,7 @@ def test_conv2d_symmetric_padding(
     strides = (1, 1)
     dilation = (1, 1)
     groups = 1
+    # input_zero_point is not handled by TFLM when int16
     input_zero_point = input_zero_point if dtype == "int8" else 0
     kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
@@ -942,7 +943,7 @@ def test_relay_conv2d_cmsisnn_depthwise_int8(
 
 
 def parameterize_for_invalid_model(test):
-    """Generates non int8 inputs"""
+    """Generates non-int8 non-int16 inputs"""
     in_dtype = ["uint8", "int8", "int16"]
     kernel_dtype = ["uint8", "int8"]
     kernel_zero_point = [-33, 10, 0]

--- a/tests/python/contrib/test_cmsisnn/test_conv2d.py
+++ b/tests/python/contrib/test_cmsisnn/test_conv2d.py
@@ -36,6 +36,7 @@ from .utils import (
     get_range_for_dtype_str,
     get_same_padding,
     get_conv2d_qnn_params,
+    get_kernel_bias_dtype,
     make_qnn_relu,
     assert_partitioned_function,
     assert_no_external_function,
@@ -59,8 +60,9 @@ def make_model(
     groups,
     dtype,
     kernel_dtype,
+    bias_dtype,
     out_channels,
-    weight_format,
+    kernel_layout,
     enable_bias,
     relu_type,
     input_op=None,
@@ -71,8 +73,8 @@ def make_model(
     else:
         op = relay.var("input", shape=shape, dtype=dtype)
 
-    h_index = weight_format.index("H")
-    w_index = weight_format.index("W")
+    h_index = kernel_layout.index("H")
+    w_index = kernel_layout.index("W")
     kernel_h = kernel_shape[h_index]
     kernel_w = kernel_shape[w_index]
     p = (0, 0, 0, 0)
@@ -80,7 +82,7 @@ def make_model(
         p = get_same_padding((shape[1], shape[2]), (kernel_h, kernel_w), dilation, strides)
 
     rng = np.random.default_rng(12321)
-    weight = tvm.nd.array(
+    kernel = tvm.nd.array(
         rng.integers(
             np.iinfo(kernel_dtype).min,
             high=np.iinfo(kernel_dtype).max,
@@ -88,27 +90,27 @@ def make_model(
             dtype=kernel_dtype,
         )
     )
-    weight_const = relay.const(weight, kernel_dtype)
+    kernel_const = relay.const(kernel, kernel_dtype)
     conv2d_kernel_sc = kernel_scale[0] if out_channels == 1 else kernel_scale
     conv = relay.qnn.op.conv2d(
         op,
-        weight_const,
+        kernel_const,
         input_zero_point=relay.const(input_zero_point, "int32"),
         kernel_zero_point=relay.const(kernel_zero_point, "int32"),
         input_scale=relay.const(input_scale, "float32"),
         kernel_scale=relay.const(conv2d_kernel_sc, "float32"),
         kernel_size=(kernel_h, kernel_w),
         data_layout="NHWC",
-        kernel_layout=weight_format,
+        kernel_layout=kernel_layout,
         dilation=dilation,
         strides=strides,
         groups=groups,
         channels=out_channels,
         padding=p,
-        out_dtype="int32",
+        out_dtype=bias_dtype,
     )
-    bias = tvm.nd.array(rng.integers(0, high=10, size=(out_channels,), dtype="int32"))
-    bias_const = relay.const(bias, "int32")
+    bias = tvm.nd.array(rng.integers(0, high=10, size=(out_channels,), dtype=bias_dtype))
+    bias_const = relay.const(bias, bias_dtype)
     last_op = relay.nn.bias_add(conv, bias_const, axis=3) if enable_bias else conv
     requant_input_sc = [sc * input_scale for sc in kernel_scale]
     requant_input_sc = requant_input_sc[0] if out_channels == 1 else requant_input_sc
@@ -121,7 +123,7 @@ def make_model(
         out_dtype=dtype,
     )
     last_op = make_qnn_relu(last_op, relu_type, output_scale, output_zero_point, dtype)
-    params = {"w": weight, "b": bias}
+    params = {"w": kernel, "b": bias}
     return last_op, params
 
 
@@ -150,13 +152,15 @@ def test_conv2d_number_primfunc_args(
     dilation = (1, 1)
     dtype = "int8"
     groups = 1
-    weight_format = "HWIO"
+    kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
     kernel_w = kernel_size[1]
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3] // groups, out_channels)
     kernel_zero_point = 0
     in_min, in_max = get_range_for_dtype_str(dtype)
     relu_type = "RELU"
+
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
 
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
@@ -165,7 +169,7 @@ def test_conv2d_number_primfunc_args(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
     )
 
@@ -183,9 +187,10 @@ def test_conv2d_number_primfunc_args(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
     )
@@ -220,6 +225,7 @@ def test_conv2d_number_primfunc_args(
 
 
 @tvm.testing.requires_cmsisnn
+@pytest.mark.parametrize("dtype", ["int8", "int16"])
 @pytest.mark.parametrize("padding", ["SAME", "VALID"])
 @pytest.mark.parametrize("relu_type", ["RELU"])
 @pytest.mark.parametrize("enable_bias", [True, False])
@@ -230,7 +236,8 @@ def test_conv2d_number_primfunc_args(
 @pytest.mark.parametrize(
     "compiler_cpu, cpu_flags", [("cortex-m55", "+nomve"), ("cortex-m55", ""), ("cortex-m7", "")]
 )
-def test_conv2d_symmetric_padding_int8(
+def test_conv2d_symmetric_padding(
+    dtype,
     padding,
     enable_bias,
     relu_type,
@@ -249,14 +256,16 @@ def test_conv2d_symmetric_padding_int8(
     kernel_size = (3, 3)
     strides = (1, 1)
     dilation = (1, 1)
-    dtype = "int8"
     groups = 1
-    weight_format = "HWIO"
+    input_zero_point = input_zero_point if dtype == "int8" else 0
+    kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
     kernel_w = kernel_size[1]
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3] // groups, out_channels)
     kernel_zero_point = 0
     in_min, in_max = get_range_for_dtype_str(dtype)
+
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
 
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
@@ -265,7 +274,7 @@ def test_conv2d_symmetric_padding_int8(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
     )
 
@@ -283,9 +292,10 @@ def test_conv2d_symmetric_padding_int8(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
     )
@@ -321,7 +331,7 @@ def test_conv2d_symmetric_padding_int8(
     "input_zero_point, input_scale, kernel_scale, out_channels",
     [(10, 0.0128, [0.11, 0.22], 2), (-64, 1, [1, 0.0256, 1.37], 3)],
 )
-def test_conv2d_asymmetric_padding_int8(
+def test_conv2d_asymmetric_padding(
     padding,
     enable_bias,
     relu_type,
@@ -335,18 +345,21 @@ def test_conv2d_asymmetric_padding_int8(
     use_unpacked_api = True
     test_runner = AOT_USMP_CORSTONE300_RUNNER
 
+    dtype = "int8"
     ifm_shape = (1, 25, 25, 12)
     kernel_size = (5, 5)
     strides = (2, 2)
     dilation = (1, 1)
-    dtype = "int8"
     groups = 1
-    weight_format = "HWIO"
+    input_zero_point = input_zero_point if dtype == "int8" else 0
+    kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
     kernel_w = kernel_size[1]
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3] // groups, out_channels)
     kernel_zero_point = 0
     in_min, in_max = get_range_for_dtype_str(dtype)
+
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
 
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
@@ -355,7 +368,7 @@ def test_conv2d_asymmetric_padding_int8(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
     )
 
@@ -373,9 +386,10 @@ def test_conv2d_asymmetric_padding_int8(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
     )
@@ -434,13 +448,14 @@ def test_pad_conv2d_fusion_int8(
     kernel_scale = [0.11, 0.22]
     out_channels = 2
     groups = 1
-    weight_format = "HWIO"
+    kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
     kernel_w = kernel_size[1]
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3] // groups, out_channels)
     kernel_zero_point = 0
     in_min, in_max = get_range_for_dtype_str(dtype)
 
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
         input_scale,
@@ -448,7 +463,7 @@ def test_pad_conv2d_fusion_int8(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
     )
 
@@ -474,9 +489,10 @@ def test_pad_conv2d_fusion_int8(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
         input_op=pad,
@@ -545,12 +561,14 @@ def test_invalid_pad_conv2d_fusion_int8(
     kernel_scale = [0.11, 0.22]
     out_channels = 2
     groups = 1
-    weight_format = "HWIO"
+    kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
     kernel_w = kernel_size[1]
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3] // groups, out_channels)
     kernel_zero_point = 0
     in_min, in_max = get_range_for_dtype_str(dtype)
+
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
 
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
@@ -559,7 +577,7 @@ def test_invalid_pad_conv2d_fusion_int8(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
     )
 
@@ -585,9 +603,10 @@ def test_invalid_pad_conv2d_fusion_int8(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
         input_op=pad,
@@ -675,6 +694,7 @@ def test_conv2d_int8_tflite(ifm_shape, kernel_shape, strides, dilation, padding,
 
 
 @tvm.testing.requires_cmsisnn
+@pytest.mark.parametrize("dtype", ["int8", "int16"])
 @pytest.mark.parametrize("ifm_shape", [(1, 28, 28, 12), (1, 64, 100, 4)])
 @pytest.mark.parametrize("kernel_size", [(3, 3)])
 @pytest.mark.parametrize("padding", ["SAME", "VALID"])
@@ -691,7 +711,8 @@ def test_conv2d_int8_tflite(ifm_shape, kernel_shape, strides, dilation, padding,
 @pytest.mark.parametrize(
     "compiler_cpu, cpu_flags", [("cortex-m55", "+nomve"), ("cortex-m55", ""), ("cortex-m7", "")]
 )
-def test_depthwise_int8(
+def test_depthwise(
+    dtype,
     ifm_shape,
     kernel_size,
     padding,
@@ -711,9 +732,9 @@ def test_depthwise_int8(
     interface_api = "c"
     use_unpacked_api = True
 
-    dtype = "int8"
     groups = 1
-    weight_format = "HWIO"
+    input_zero_point = input_zero_point if dtype == "int8" else 0
+    kernel_layout = "HWIO"
     kernel_h = kernel_size[0]
     kernel_w = kernel_size[1]
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3] // groups, out_channels)
@@ -721,11 +742,13 @@ def test_depthwise_int8(
     in_min, in_max = get_range_for_dtype_str(dtype)
 
     groups = ifm_shape[3]
-    weight_format = "HWOI"
+    kernel_layout = "HWOI"
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3], depth_multiplier)
     out_channels = ifm_shape[3] * depth_multiplier
     ks_len = len(kernel_scale)
     kernel_scale = [kernel_scale[i % ks_len] for i in range(out_channels)]
+
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
 
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
@@ -734,7 +757,7 @@ def test_depthwise_int8(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
         is_depthwise=True,
     )
@@ -753,9 +776,10 @@ def test_depthwise_int8(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
     )
@@ -823,7 +847,8 @@ def test_relay_conv2d_cmsisnn_depthwise_int8(
 
     ifm_shape = (1, 24, 24, 1)
     groups = ifm_shape[3]
-    weight_format = "HWIO"
+    input_zero_point = input_zero_point if dtype == "int8" else 0
+    kernel_layout = "HWIO"
     (kernel_h, kernel_w) = (3, 3)
     kernel_shape = (kernel_h, kernel_w, ifm_shape[3], depth_multiplier)
     out_channels = ifm_shape[3] * depth_multiplier
@@ -832,6 +857,8 @@ def test_relay_conv2d_cmsisnn_depthwise_int8(
     kernel_zero_point = 0
     kernel_scale = [kernel_scale[i % ks_len] for i in range(out_channels)]
 
+    kernel_dtype, bias_dtype = get_kernel_bias_dtype(dtype)
+
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
         input_scale,
@@ -839,7 +866,7 @@ def test_relay_conv2d_cmsisnn_depthwise_int8(
         kernel_scale,
         kernel_zero_point,
         input_dtype=dtype,
-        weights_dtype=dtype,
+        kernel_dtype=kernel_dtype,
         output_dtype=dtype,
         is_depthwise=True,
     )
@@ -858,9 +885,10 @@ def test_relay_conv2d_cmsisnn_depthwise_int8(
         dilation,
         groups,
         dtype,
-        dtype,
+        kernel_dtype,
+        bias_dtype,
         out_channels,
-        weight_format,
+        kernel_layout,
         enable_bias,
         relu_type,
     )
@@ -915,13 +943,15 @@ def test_relay_conv2d_cmsisnn_depthwise_int8(
 
 def parameterize_for_invalid_model(test):
     """Generates non int8 inputs"""
-    in_dtype = ["uint8", "int8"]
+    in_dtype = ["uint8", "int8", "int16"]
     kernel_dtype = ["uint8", "int8"]
     kernel_zero_point = [-33, 10, 0]
     all_combinations = itertools.product(in_dtype, kernel_dtype, kernel_zero_point)
     all_combinations = filter(
         lambda parameters: not (
-            parameters[0] == "int8" and parameters[1] == "int8" and parameters[2] == 0
+            (parameters[0] == "int8" or parameters[0] == "int16")
+            and parameters[1] == "int8"
+            and parameters[2] == 0
         ),
         all_combinations,
     )
@@ -947,6 +977,7 @@ def test_invalid_parameters(
 
     kernel_layout = "HWIO"
     kernel_shape = [3, 3, ifm_shape[3], out_channels]
+    _, bias_dtype = get_kernel_bias_dtype(in_dtype)
     output_scale, output_zero_point = get_conv2d_qnn_params(
         kernel_shape,
         input_scale,
@@ -973,8 +1004,9 @@ def test_invalid_parameters(
         groups=1,
         dtype=in_dtype,
         kernel_dtype=kernel_dtype,
+        bias_dtype=bias_dtype,
         out_channels=out_channels,
-        weight_format=kernel_layout,
+        kernel_layout=kernel_layout,
         enable_bias=True,
         relu_type="NONE",
     )


### PR DESCRIPTION
Support for int16 Conv2d via CMSIS-NN

-Pattern matching and RelayToTIR introduce int16 support
-Added new context buffer size APIs for int16 Conv2d
-Added int16 variants to integration and buffer size tests

cc @lhutton1 @Mousius @leandron @grant-arm 