### PR TITLE
[CODEGEN][OPENCL] Sampler definition should be at outermost scope

### DIFF
--- a/src/target/source/codegen_opencl.h
+++ b/src/target/source/codegen_opencl.h
@@ -42,6 +42,7 @@ class CodeGenOpenCL final : public CodeGenC {
   // override print thread tag.
   void InitFuncState(const PrimFunc& f) final;
   void PrintFuncPrefix() final;                                              // NOLINT(*)
+  void PreFunctionBody(const PrimFunc& f) final;                             // NOLINT(*)
   void BindThreadIndex(const IterVar& iv) final;                             // NOLINT(*)
   void PrintStorageScope(const std::string& scope, std::ostream& os) final;  // NOLINT(*)
   void PrintStorageSync(const CallNode* op) final;                           // NOLINT(*)


### PR DESCRIPTION
Not all OpenCL compiers happy with inline sampler definition.

Specification: "The image read functions take a sampler argument. The sampler can be passed as an argument to the kernel using clSetKernelArg, or can be declared in the outermost scope of kernel functions, or it can be a constant variable of type sampler_t declared in the program source."