### PR TITLE
[Hexagon] 3-stage pipeline; multi queue async DMA for cache read / write

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -209,7 +209,6 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.mem_copy").set_body([](TVMArgs args, TVM
 
 TVM_REGISTER_GLOBAL("device_api.hexagon.dma_copy").set_body([](TVMArgs args, TVMRetValue* rv) {
   int queue_id = args[0];
-  ICHECK(queue_id == 0 && "Hexagon supports just a single asynchronous queue for DMA");
   void* dst = args[1];
   void* src = args[2];
   int size = args[3];
@@ -217,17 +216,16 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.dma_copy").set_body([](TVMArgs args, TVM
 
   int ret = DMA_RETRY;
   do {
-    ret = HexagonDeviceAPI::Global()->UserDMA()->Copy(dst, src, size);
+    ret = HexagonDeviceAPI::Global()->UserDMA()->Copy(queue_id, dst, src, size);
   } while (ret == DMA_RETRY);
   *rv = static_cast<int32_t>(ret);
 });
 
 TVM_REGISTER_GLOBAL("device_api.hexagon.dma_wait").set_body([](TVMArgs args, TVMRetValue* rv) {
   int queue_id = args[0];
-  ICHECK(queue_id == 0 && "Hexagon supports just a single asynchronous queue for DMA");
   int inflight = args[1];
   ICHECK(inflight >= 0);
-  HexagonDeviceAPI::Global()->UserDMA()->Wait(inflight);
+  HexagonDeviceAPI::Global()->UserDMA()->Wait(queue_id, inflight);
   *rv = static_cast<int32_t>(0);
 });
 

--- a/src/runtime/hexagon/hexagon_user_dma.cc
+++ b/src/runtime/hexagon/hexagon_user_dma.cc
@@ -32,7 +32,7 @@ unsigned int HexagonUserDMA::Init() {
   return status;
 }
 
-int HexagonUserDMA::Copy(void* dst, void* src, uint32_t length) {
+int HexagonUserDMA::Copy(int queue_id, void* dst, void* src, uint32_t length) {
   // length limited to 24 bits
   if (length > DESC_LENGTH_MASK) {
     return DMA_FAILURE;
@@ -54,7 +54,7 @@ int HexagonUserDMA::Copy(void* dst, void* src, uint32_t length) {
   uint32_t dst32 = static_cast<uint32_t>(dst64);
 
   // get pointer to next descriptor
-  dma_desc_2d_t* dma_desc = descriptors_->Next();
+  dma_desc_2d_t* dma_desc = descriptors_->Next(queue_id);
   if (!dma_desc) {
     return DMA_RETRY;
   }
@@ -87,17 +87,17 @@ int HexagonUserDMA::Copy(void* dst, void* src, uint32_t length) {
   return DMA_SUCCESS;
 }
 
-void HexagonUserDMA::Wait(uint32_t max_dmas_in_flight) {
+void HexagonUserDMA::Wait(int queue_id, uint32_t max_dmas_in_flight) {
   // wait (forever) until max DMAs in flight <= actual DMAs in flight
-  while (DMAsInFlight() > max_dmas_in_flight) {
+  while (DMAsInFlight(queue_id) > max_dmas_in_flight) {
   }
 }
 
-uint32_t HexagonUserDMA::Poll() { return DMAsInFlight(); }
+uint32_t HexagonUserDMA::Poll(int queue_id) { return DMAsInFlight(queue_id); }
 
-uint32_t HexagonUserDMA::DMAsInFlight() {
+uint32_t HexagonUserDMA::DMAsInFlight(int queue_id) {
   dmpoll();  // update DMA engine status
-  return descriptors_->InFlight();
+  return descriptors_->InFlight(queue_id);
 }
 
 HexagonUserDMA::HexagonUserDMA() {
@@ -109,7 +109,7 @@ HexagonUserDMA::HexagonUserDMA() {
     unsigned int done = dma_desc_get_done(dma_desc);
     return (done != DESC_DONE_COMPLETE);
   };
-  descriptors_ = new RingBuffer<dma_desc_2d_t>(MAX_DMA_DESCRIPTORS, desc_in_flight);
+  descriptors_ = new QueuedRingBuffer<dma_desc_2d_t>(MAX_DMA_DESCRIPTORS, desc_in_flight);
 }
 
 HexagonUserDMA::~HexagonUserDMA() {
@@ -124,9 +124,9 @@ int hexagon_user_dma_1d_sync(void* dst, void* src, uint32_t length) {
   // Make the common case quick.
   if (length <= DESC_LENGTH_MASK) {
     // sync DMA -> `Copy` and then `Wait(0)`
-    int ret_val = user_dma->Copy(dst, src, length);
+    int ret_val = user_dma->Copy(SYNC_DMA_QUEUE, dst, src, length);
     if (ret_val != DMA_SUCCESS) return ret_val;
-    user_dma->Wait(0);
+    user_dma->Wait(SYNC_DMA_QUEUE, 0);
     return DMA_SUCCESS;
   }
 
@@ -137,9 +137,9 @@ int hexagon_user_dma_1d_sync(void* dst, void* src, uint32_t length) {
     // Ensure there is no overflow while updating i
     uint32_t cur_len = std::min<uint32_t>(length - i, DESC_LENGTH_MASK);
     // sync DMA -> `Copy` and then `Wait(0)`
-    int ret_val = user_dma->Copy(&cast_dst[i], &cast_src[i], cur_len);
+    int ret_val = user_dma->Copy(SYNC_DMA_QUEUE, &cast_dst[i], &cast_src[i], cur_len);
     if (ret_val != DMA_SUCCESS) return ret_val;
-    user_dma->Wait(0);
+    user_dma->Wait(SYNC_DMA_QUEUE, 0);
     // 2 cases for new val for i:
     // 1. length - i <= DESC_LENGTH_MASK (<= MAX_UINT)
     //    new_i = i + (length - i) = length, no more iter

--- a/src/runtime/hexagon/hexagon_user_dma.h
+++ b/src/runtime/hexagon/hexagon_user_dma.h
@@ -34,6 +34,7 @@ namespace hexagon {
 #define DMA_FAILURE -1
 #define DMA_RETRY 1
 #define MAX_DMA_DESCRIPTORS 100
+#define SYNC_DMA_QUEUE -1
 
 class HexagonUserDMA {
  public:
@@ -51,36 +52,36 @@ class HexagonUserDMA {
    * \param length Length in bytes to copy
    * \returns Status: DMA_SUCCESS or DMA_FAILURE
    */
-  int Copy(void* dst, void* src, uint32_t length);
+  int Copy(int queue_id, void* dst, void* src, uint32_t length);
 
   /*!
    * \brief Wait until the number of DMAs in flight is less than or equal to some maximum
    * \param max_dmas_in_flight Maximum number of DMAs allowed to be in flight
    * to satisfy the `Wait` e.g. use `Wait(0)` to wait on "all" outstanding DMAs to complete
    */
-  void Wait(uint32_t max_dmas_in_flight);
+  void Wait(int queue_id, uint32_t max_dmas_in_flight);
 
   /*!
    * \brief Poll the number of DMAs in flight
    * \returns Number of DMAs in flight
    */
-  uint32_t Poll();
+  uint32_t Poll(int queue_id);
 
  private:
   //! \brief Initializes the Hexagon User DMA engine
   unsigned int Init();
 
   //! \brief Calculates and returns the number of DMAs in flight
-  uint32_t DMAsInFlight();
+  uint32_t DMAsInFlight(int queue_id);
 
   //! \brief Tracks whether the very first DMA has been executed
-  bool first_dma_{true};
+  bool first_dma_ = true;
 
   //! \brief Tracks the tail DMA descriptor
-  void* tail_dma_desc_{nullptr};
+  void* tail_dma_desc_ = nullptr;
 
   //! \brief Storage for all DMA descriptors
-  RingBuffer<dma_desc_2d_t>* descriptors_{nullptr};
+  QueuedRingBuffer<dma_desc_2d_t>* descriptors_ = nullptr;
 };
 
 }  // namespace hexagon

--- a/tests/cpp-runtime/hexagon/hexagon_user_dma_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_user_dma_tests.cc
@@ -46,38 +46,39 @@ class HexagonUserDMATest : public ::testing::Test {
 
  public:
   HexagonUserDMA* user_dma;
-  int ret{0};
-  void* src{nullptr};
-  void* dst{nullptr};
-  char* src_char{nullptr};
-  char* dst_char{nullptr};
-  uint32_t length{0x4000};  // 16KB
+  int ret = 0;
+  int queue_id = 0;
+  void* src = nullptr;
+  void* dst = nullptr;
+  char* src_char = nullptr;
+  char* dst_char = nullptr;
+  uint32_t length = 0x4000;  // 16KB
 };
 
 TEST_F(HexagonUserDMATest, wait) {
-  user_dma->Wait(0);
-  user_dma->Wait(10);
+  user_dma->Wait(queue_id, 0);
+  user_dma->Wait(queue_id, 10);
 }
 
-TEST_F(HexagonUserDMATest, poll) { ASSERT_EQ(user_dma->Poll(), 0); }
+TEST_F(HexagonUserDMATest, poll) { ASSERT_EQ(user_dma->Poll(queue_id), 0); }
 
 TEST_F(HexagonUserDMATest, bad_copy) {
   uint64_t bigaddr = 0x100000000;
   void* src64 = reinterpret_cast<void*>(bigaddr);
   void* dst64 = reinterpret_cast<void*>(bigaddr);
   uint32_t biglength = 0x1000000;
-  ASSERT_NE(user_dma->Copy(dst64, src, length), DMA_SUCCESS);
-  ASSERT_NE(user_dma->Copy(dst, src64, length), DMA_SUCCESS);
-  ASSERT_NE(user_dma->Copy(dst, src, biglength), DMA_SUCCESS);
+  ASSERT_NE(user_dma->Copy(queue_id, dst64, src, length), DMA_SUCCESS);
+  ASSERT_NE(user_dma->Copy(queue_id, dst, src64, length), DMA_SUCCESS);
+  ASSERT_NE(user_dma->Copy(queue_id, dst, src, biglength), DMA_SUCCESS);
 }
 
 TEST_F(HexagonUserDMATest, sync_dma) {
   // kick off 1 DMA
-  ret = user_dma->Copy(dst, src, length);
+  ret = user_dma->Copy(queue_id, dst, src, length);
   ASSERT_EQ(ret, DMA_SUCCESS);
 
   // wait for DMA to complete
-  user_dma->Wait(0);
+  user_dma->Wait(queue_id, 0);
 
   // verify
   for (uint32_t i = 0; i < length; ++i) {
@@ -88,12 +89,12 @@ TEST_F(HexagonUserDMATest, sync_dma) {
 TEST_F(HexagonUserDMATest, async_dma_wait) {
   // kick off 10x duplicate DMAs
   for (uint32_t i = 0; i < 10; ++i) {
-    ret = user_dma->Copy(dst, src, length);
+    ret = user_dma->Copy(queue_id, dst, src, length);
     ASSERT_EQ(ret, DMA_SUCCESS);
   }
 
   // wait for at least 1 DMA to complete
-  user_dma->Wait(9);
+  user_dma->Wait(queue_id, 9);
 
   // verify
   for (uint32_t i = 0; i < length; ++i) {
@@ -101,18 +102,18 @@ TEST_F(HexagonUserDMATest, async_dma_wait) {
   }
 
   // empty the DMA queue
-  user_dma->Wait(0);
+  user_dma->Wait(queue_id, 0);
 }
 
 TEST_F(HexagonUserDMATest, async_dma_poll) {
   // kick off 10x duplicate DMAs
   for (uint32_t i = 0; i < 10; ++i) {
-    ret = user_dma->Copy(dst, src, length);
+    ret = user_dma->Copy(queue_id, dst, src, length);
     ASSERT_EQ(ret, DMA_SUCCESS);
   }
 
   // poll until at least 1 DMA is complete
-  while (user_dma->Poll() == 10) {
+  while (user_dma->Poll(queue_id) == 10) {
   };
 
   // verify
@@ -121,35 +122,34 @@ TEST_F(HexagonUserDMATest, async_dma_poll) {
   }
 
   // empty the DMA queue
-  user_dma->Wait(0);
+  user_dma->Wait(queue_id, 0);
 }
 
-// TODO: Run non-pipelined case with sync DMA and execution time vs. pipelined case
 TEST_F(HexagonUserDMATest, pipeline) {
   uint32_t pipeline_depth = 4;
   uint32_t pipeline_length = length / pipeline_depth;
 
   for (uint32_t i = 0; i < pipeline_depth; ++i) {
-    ret |= user_dma->Copy(dst_char + i * pipeline_length, src_char + i * pipeline_length,
+    ret |= user_dma->Copy(queue_id, dst_char + i * pipeline_length, src_char + i * pipeline_length,
                           pipeline_length);
   }
 
-  user_dma->Wait(3);
+  user_dma->Wait(queue_id, 3);
   for (uint32_t i = 0; i < pipeline_length; ++i) {
     dst_char[i]++;
   }
 
-  user_dma->Wait(2);
+  user_dma->Wait(queue_id, 2);
   for (uint32_t i = pipeline_length; i < 2 * pipeline_length; ++i) {
     dst_char[i]++;
   }
 
-  user_dma->Wait(1);
+  user_dma->Wait(queue_id, 1);
   for (uint32_t i = 2 * pipeline_length; i < 3 * pipeline_length; ++i) {
     dst_char[i]++;
   }
 
-  user_dma->Wait(0);
+  user_dma->Wait(queue_id, 0);
   for (uint32_t i = 3 * pipeline_length; i < 4 * pipeline_length; ++i) {
     dst_char[i]++;
   }
@@ -161,14 +161,60 @@ TEST_F(HexagonUserDMATest, pipeline) {
   }
 }
 
+TEST_F(HexagonUserDMATest, pipeline_write_queue) {
+  int write_queue = queue_id + 1;
+  uint32_t pipeline_depth = 4;
+  uint32_t pipeline_length = length / pipeline_depth;
+
+  for (uint32_t i = 0; i < pipeline_depth; ++i) {
+    ret |= user_dma->Copy(queue_id, dst_char + i * pipeline_length, src_char + i * pipeline_length,
+                          pipeline_length);
+  }
+
+  user_dma->Wait(queue_id, 3);
+  for (uint32_t i = 0; i < pipeline_length; ++i) {
+    dst_char[i]++;
+  }
+  ret |= user_dma->Copy(write_queue, src_char, dst_char, pipeline_length);
+
+  user_dma->Wait(queue_id, 2);
+  for (uint32_t i = pipeline_length; i < 2 * pipeline_length; ++i) {
+    dst_char[i]++;
+  }
+  ret |= user_dma->Copy(write_queue, src_char + pipeline_length, dst_char + pipeline_length,
+                        pipeline_length);
+
+  user_dma->Wait(queue_id, 1);
+  for (uint32_t i = 2 * pipeline_length; i < 3 * pipeline_length; ++i) {
+    dst_char[i]++;
+  }
+  ret |= user_dma->Copy(write_queue, src_char + 2 * pipeline_length, dst_char + 2 * pipeline_length,
+                        pipeline_length);
+
+  user_dma->Wait(queue_id, 0);
+  for (uint32_t i = 3 * pipeline_length; i < 4 * pipeline_length; ++i) {
+    dst_char[i]++;
+  }
+  ret |= user_dma->Copy(write_queue, src_char + 3 * pipeline_length, dst_char + 3 * pipeline_length,
+                        pipeline_length);
+  user_dma->Wait(write_queue, 0);
+
+  // verify
+  ASSERT_EQ(ret, DMA_SUCCESS);
+  for (uint32_t i = 0; i < length; ++i) {
+    ASSERT_EQ(2, dst_char[i]);
+    ASSERT_EQ(2, src_char[i]);
+  }
+}
+
 TEST_F(HexagonUserDMATest, overflow_ring_buffer) {
   uint32_t number_of_dmas = 0x400;  // 1k
   uint32_t length_of_each_dma = length / number_of_dmas;
 
   for (uint32_t i = 0; i < number_of_dmas; ++i) {
     do {
-      ret = user_dma->Copy(dst_char + i * length_of_each_dma, src_char + i * length_of_each_dma,
-                           length_of_each_dma);
+      ret = user_dma->Copy(queue_id, dst_char + i * length_of_each_dma,
+                           src_char + i * length_of_each_dma, length_of_each_dma);
     } while (ret == DMA_RETRY);
     ASSERT_EQ(ret, DMA_SUCCESS);
   }

--- a/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
+++ b/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
@@ -26,8 +26,9 @@ from tvm.script import tir as T
 
 outer = tvm.testing.parameter(8, 16)
 inner = tvm.testing.parameter(64, 128)
-scope = tvm.testing.parameter("global", "global.vtcm")
 dtype = tvm.testing.parameter("uint8", "float16")
+scope = tvm.testing.parameter("global", "global.vtcm")
+sched = tvm.testing.parameter("cache_read", "cache_read_write")
 
 
 @tvm.testing.fixture
@@ -46,18 +47,33 @@ def compute(outer, inner, dtype):
     return plus_one_primfunc, plus_one_ref
 
 
-@tvm.testing.requires_hexagon
-def test_software_pipeline_with_cache_read(hexagon_launcher, compute, outer, inner, dtype, scope):
+@tvm.testing.fixture
+def schedule(compute, sched, scope):
     sch = tir.Schedule(compute[0])
-    root = sch.get_block("root")
+
     compute_block = sch.get_block("compute")
     cache_read_block = sch.cache_read(compute_block, 0, scope)
 
     i, _ = sch.get_loops(compute_block)
     sch.compute_at(cache_read_block, i)
-    sch.annotate(i, "software_pipeline_stage", [0, 1])
-    sch.annotate(i, "software_pipeline_order", [0, 1])
-    sch.annotate(i, "software_pipeline_async_stages", [0])
+
+    if sched == "cache_read":
+        sch.annotate(i, "software_pipeline_stage", [0, 1])
+        sch.annotate(i, "software_pipeline_order", [0, 1])
+        sch.annotate(i, "software_pipeline_async_stages", [0])
+    elif sched == "cache_read_write":
+        cache_write_block = sch.cache_write(compute_block, 0, scope)
+        sch.reverse_compute_at(cache_write_block, i)
+        sch.annotate(i, "software_pipeline_stage", [0, 1, 2])
+        sch.annotate(i, "software_pipeline_order", [0, 1, 2])
+        sch.annotate(i, "software_pipeline_async_stages", [0, 2])
+
+    return sch
+
+
+@tvm.testing.requires_hexagon
+def test_async_software_pipeline(hexagon_launcher, compute, schedule, outer, inner, dtype, scope):
+    sch = schedule
 
     a_np = np.random.uniform(low=0, high=128, size=(outer, inner)).astype(dtype)
     b_np = np.random.uniform(low=0, high=128, size=(outer, inner)).astype(dtype)


### PR DESCRIPTION
Add `HexagonUserDMA` support for multiple virtual queues which enables Async DMA for both `cache_read` and `cache_write` while maintaining a single descriptor chain to maintain overall FIFO ordering between virtual queues.  Tested with runtime unit tests and at the python level for a simple operator.