### PR TITLE
[ci] Disable flaky ethosu + roofline tests

### DIFF
--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -368,7 +368,7 @@ def test_binary_add_with_non_4d_shapes(
     )
 
 
-@pytest.mark.xfail(strict=False, reason="See https://github.com/apache/tvm/issues/10487")
+@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/12634")
 @pytest.mark.parametrize(
     "accel_type",
     ACCEL_TYPES,

--- a/tests/python/contrib/test_ethosu/test_replace_depthwise_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_depthwise_conv2d.py
@@ -75,7 +75,10 @@ from .infra import make_ethosu_depthwise_conv2d, get_convolutional_args
         ],
     ],
 )
-def test_depthwise_conv2d_single(trial):
+@tvm.testing.skip_parameterizations(
+    "trial3", reason="See https://github.com/apache/tvm/issues/12841"
+)
+def test_depthwise_conv2d_single(request, trial):
     def _get_func(
         ifm_shape,
         channels,

--- a/tests/python/unittest/test_roofline.py
+++ b/tests/python/unittest/test_roofline.py
@@ -35,6 +35,7 @@ from tvm.script import tir as T
 
 
 @tvm.testing.parametrize_targets("llvm", "cuda")
+@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/12955")
 def test_estimate_peak_flops(target, dev):
     server = rpc.Server(key="roofline_flops")
     remote = rpc.connect("127.0.0.1", server.port, key="roofline_flops")


### PR DESCRIPTION
These are all segfaulting in main ( see #12955, #12634, and #12841) so they need to be skipped until a fix is merged