### PR TITLE
[Hexagon] Remove TVM logging from performance-sensitive parts of runtime

### DIFF
--- a/src/runtime/hexagon/hexagon_common.h
+++ b/src/runtime/hexagon/hexagon_common.h
@@ -36,6 +36,24 @@
 #define HEXAGON_PRINT(level, ...) printf(__VA_ARGS__)
 #endif
 
+// For the purposes of functionality alone, this could just be abort(),
+// but there are GTest tests that check for diagnosing fatal errors,
+// and GTest for Hexagon doesn't support death tests. It does support
+// EXPECT_THROW though, so throw an unhandled exception.
+#define HEXAGON_ABORT_WITH_MSG(message) \
+  throw tvm::runtime::InternalError(__FILE__, __LINE__, message)
+
+#define HEXAGON_ABORT() HEXAGON_ABORT_WITH_MSG("")
+
+// The condition "cond" must always be evaluated (like CHECK, and unlike assert).
+#define HEXAGON_ASSERT(cond, ...)                                           \
+  do {                                                                      \
+    if (!(cond)) {                                                          \
+      HEXAGON_PRINT(ERROR, "Assertion failed \"" #cond "\": " __VA_ARGS__); \
+      HEXAGON_ABORT();                                                      \
+    }                                                                       \
+  } while (0)
+
 #define HEXAGON_SAFE_CALL(api_call)                                               \
   do {                                                                            \
     int result = api_call;                                                        \

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -54,37 +54,37 @@ class HexagonDeviceAPI final : public DeviceAPI {
 
   //! \brief Ensures resource managers are in a good state for the runtime
   void AcquireResources() {
-    CHECK_EQ(runtime_hexbuffs, nullptr);
+    HEXAGON_ASSERT(runtime_hexbuffs == nullptr);
     runtime_hexbuffs = std::make_unique<HexagonBufferManager>();
-    DLOG(INFO) << "runtime_hexbuffs created";
+    HEXAGON_PRINT(ALWAYS, "runtime_hexbuffs created");
     mgr = runtime_hexbuffs.get();
 
-    CHECK_EQ(runtime_threads, nullptr);
+    HEXAGON_ASSERT(runtime_threads == nullptr);
     runtime_threads = std::make_unique<HexagonThreadManager>(threads, stack_size, pipe_size);
-    DLOG(INFO) << "runtime_threads created";
+    HEXAGON_PRINT(ALWAYS, "runtime_threads created");
 
-    CHECK_EQ(runtime_dma, nullptr);
+    HEXAGON_ASSERT(runtime_dma == nullptr);
     runtime_dma = std::make_unique<HexagonUserDMA>();
-    DLOG(INFO) << "runtime_dma created";
+    HEXAGON_PRINT(ALWAYS, "runtime_dma created");
   }
 
   //! \brief Ensures all runtime resources are freed
   void ReleaseResources() {
-    CHECK(runtime_dma) << "runtime_dma was not created in AcquireResources";
+    HEXAGON_ASSERT(runtime_dma, "runtime_dma was not created in AcquireResources");
     runtime_dma.reset();
-    DLOG(INFO) << "runtime_dma reset";
+    HEXAGON_PRINT(ALWAYS, "runtime_dma reset");
 
-    CHECK(runtime_threads) << "runtime_threads was not created in AcquireResources";
+    HEXAGON_ASSERT(runtime_threads, "runtime_threads was not created in AcquireResources");
     runtime_threads.reset();
-    DLOG(INFO) << "runtime_threads reset";
+    HEXAGON_PRINT(ALWAYS, "runtime_threads reset");
 
-    CHECK(runtime_hexbuffs) << "runtime_hexbuffs was not created in AcquireResources";
+    HEXAGON_ASSERT(runtime_hexbuffs, "runtime_hexbuffs was not created in AcquireResources");
     if (runtime_hexbuffs && !runtime_hexbuffs->empty()) {
-      DLOG(INFO) << "runtime_hexbuffs was not empty in ReleaseResources";
+      HEXAGON_PRINT(ALWAYS, "runtime_hexbuffs was not empty in ReleaseResources");
     }
     mgr = &hexbuffs;
-    DLOG(INFO) << "runtime_hexbuffs reset";
     runtime_hexbuffs.reset();
+    HEXAGON_PRINT(ALWAYS, "runtime_hexbuffs reset");
   }
 
   /*! \brief Currently unimplemented interface to specify the active
@@ -159,12 +159,12 @@ class HexagonDeviceAPI final : public DeviceAPI {
   void CopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamHandle stream) final;
 
   HexagonThreadManager* ThreadManager() {
-    CHECK(runtime_threads) << "runtime_threads has not been created";
+    HEXAGON_ASSERT(runtime_threads, "runtime_threads has not been created");
     return runtime_threads.get();
   }
 
   HexagonUserDMA* UserDMA() {
-    CHECK(runtime_dma) << "runtime_dma has not been created";
+    HEXAGON_ASSERT(runtime_dma, "runtime_dma has not been created");
     return runtime_dma.get();
   }
 

--- a/src/runtime/hexagon/hexagon_thread_manager.h
+++ b/src/runtime/hexagon/hexagon_thread_manager.h
@@ -21,7 +21,6 @@
 #define TVM_RUNTIME_HEXAGON_HEXAGON_THREAD_MANAGER_H_
 
 #include <tvm/runtime/c_runtime_api.h>
-#include <tvm/runtime/logging.h>
 #include <tvm/runtime/packed_func.h>
 
 #include <memory>

--- a/src/runtime/hexagon/hexagon_user_dma.cc
+++ b/src/runtime/hexagon/hexagon_user_dma.cc
@@ -103,7 +103,7 @@ uint32_t HexagonUserDMA::DMAsInFlight() {
 HexagonUserDMA::HexagonUserDMA() {
   // reset DMA engine
   unsigned int status = Init();
-  CHECK_EQ(status, DM0_STATUS_IDLE);
+  HEXAGON_ASSERT(status == DM0_STATUS_IDLE);
 
   auto desc_in_flight = [](dma_desc_2d_t* dma_desc) {
     unsigned int done = dma_desc_get_done(dma_desc);

--- a/src/runtime/hexagon/qhl/qhl_wrapper.cc
+++ b/src/runtime/hexagon/qhl/qhl_wrapper.cc
@@ -19,7 +19,8 @@
 #if defined(__hexagon__)
 #include <hexagon_types.h>
 #include <stdio.h>
-#include <tvm/runtime/logging.h>
+
+#include "../hexagon_common.h"
 
 #define restrict __restrict__
 #define LOG2VLEN 7
@@ -61,7 +62,7 @@ template <typename T>
 HVX_Vector wrapper_api(HVX_Vector input, qhlFptr qhl_api, const char* qhl_api_name) {
   HVX_Vector output;
   int32_t res = qhl_api(reinterpret_cast<T*>(&input), reinterpret_cast<T*>(&output), 64);
-  if (res != 0) LOG(FATAL) << "Error. Failed execution of " << qhl_api_name << "  Error=" << res;
+  HEXAGON_ASSERT(res == 0, "Error. Failed execution of %s  Error=%d", qhl_api_name, res);
   return output;
 }
 
@@ -70,7 +71,7 @@ HVX_Vector wrapper_api(HVX_Vector ip1, HVX_Vector ip2, qhlFptr2 qhl_api, const c
   HVX_Vector output;
   int32_t res = qhl_api(reinterpret_cast<T*>(&ip1), reinterpret_cast<T*>(&ip2),
                         reinterpret_cast<T*>(&output), 64);
-  if (res != 0) LOG(FATAL) << "Error. Failed execution of " << qhl_api_name << "Error=" << res;
+  HEXAGON_ASSERT(res == 0, "Error. Failed execution of %s  Error=%d", qhl_api_name, res);
   return output;
 }
 

--- a/src/runtime/hexagon/ring_buffer.h
+++ b/src/runtime/hexagon/ring_buffer.h
@@ -55,11 +55,11 @@ class RingBuffer {
    */
   RingBuffer(uint32_t ring_buff_size, std::function<bool(T*)> in_flight)
       : ring_buff_size_(ring_buff_size), in_flight_(in_flight) {
-    CHECK_NE(ring_buff_size, 0);
+    HEXAGON_ASSERT(ring_buff_size != 0);
     int ret = posix_memalign(reinterpret_cast<void**>(&ring_buff_ptr_), sizeof(T),
                              sizeof(T) * ring_buff_size_);
-    CHECK_EQ(ret, 0);
-    CHECK_NE(ring_buff_ptr_, nullptr);
+    HEXAGON_ASSERT(ret == 0);
+    HEXAGON_ASSERT(ring_buff_ptr_ != nullptr);
   }
 
   ~RingBuffer() { free(ring_buff_ptr_); }

--- a/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
@@ -79,13 +79,17 @@ TEST_F(HexagonDeviceAPITest, free_errors) {
 
   // invalid device
   EXPECT_THROW(hexapi->FreeDataSpace(invalid_dev, buf), InternalError);
-  // invalid pointer
-  EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, &buf), InternalError);
   // nullptr
   EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, nullptr), InternalError);
+  // The following are not checked, because they are not flagged as errors. See
+  // comment in FreeHexagonBuffer in src/runtime/hexagon/hexagon_buffer_manager.h
+  // for more information.
+  //
+  // invalid pointer
+  // EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, &buf), InternalError);
   // double free
-  hexapi->FreeDataSpace(hex_dev, buf);
-  EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, buf), InternalError);
+  // hexapi->FreeDataSpace(hex_dev, buf);
+  // EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, buf), InternalError);
 }
 
 TEST_F(HexagonDeviceAPITest, allocnd_free_cpu) {
@@ -160,7 +164,8 @@ TEST_F(HexagonDeviceAPITest, leak_resources) {
   void* runtime_buf = hexapi->AllocDataSpace(hex_dev, nbytes, alignment, int8);
   CHECK(runtime_buf != nullptr);
   hexapi->ReleaseResources();
-  EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, runtime_buf), InternalError);
+  // Does not throw (see "free_errors" above).
+  // EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, runtime_buf), InternalError);
   hexapi->FreeDataSpace(hex_dev, pre_runtime_buf);
   hexapi->AcquireResources();
 }


### PR DESCRIPTION
Use HAP messaging instead. This greatly reduced execution overhead.