### PR TITLE
[Hexagon] Don't print simulator protocol messages

### DIFF
--- a/src/runtime/hexagon/rpc/simulator/session.cc
+++ b/src/runtime/hexagon/rpc/simulator/session.cc
@@ -681,7 +681,6 @@ Message SimulatorRPCChannel::SendMsg(Message msg) {
   };
 
   Message_ msg_ = {msg};
-  LOG(INFO) << "Sending message: " << msg_.str();
 
   WriteToProcess(message_buffer_v_, &msg, sizeof msg);
   run();


### PR DESCRIPTION
They flood the standard error, and are only useful when debugging protocol issues. Remove them, they are easy to add back if needed.