### PR TITLE
[Hexagon] Fix RPC session close by adding shutdown PackedFunc

### DIFF
--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -106,6 +106,8 @@ class Session:
             )
         finally:
             # close session to the tracker
+            shutdown_func = self._rpc._sess.get_function("Shutdown")
+            shutdown_func()
             del self._rpc
 
     @property

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -106,7 +106,7 @@ class Session:
             )
         finally:
             # close session to the tracker
-            shutdown_func = self._rpc._sess.get_function("Shutdown")
+            shutdown_func = self._rpc._sess.get_function("CloseRPCConnection")
             shutdown_func()
             del self._rpc
 

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -624,7 +624,8 @@ class RPCEndpoint::EventHandler : public dmlc::Stream {
 RPCCode RPCEndpoint::HandleUntilReturnEvent(bool client_mode, RPCSession::FEncodeReturn setreturn) {
   RPCCode code = RPCCode::kCallFunc;
 
-  ICHECK(channel_ != nullptr) << "channel is already closed";
+  CHECK(channel_) << "Expected connection to server " << name_
+                  << " to be active, but the connection was previously closed";
   while (code != RPCCode::kReturn && code != RPCCode::kShutdown && code != RPCCode::kCopyAck) {
     while (writer_.bytes_available() != 0) {
       writer_.ReadWithCallback(

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -623,6 +623,8 @@ class RPCEndpoint::EventHandler : public dmlc::Stream {
 
 RPCCode RPCEndpoint::HandleUntilReturnEvent(bool client_mode, RPCSession::FEncodeReturn setreturn) {
   RPCCode code = RPCCode::kCallFunc;
+
+  ICHECK(channel_ != nullptr) << "channel is already closed";
   while (code != RPCCode::kReturn && code != RPCCode::kShutdown && code != RPCCode::kCopyAck) {
     while (writer_.bytes_available() != 0) {
       writer_.ReadWithCallback(
@@ -1125,6 +1127,8 @@ class RPCClientSession : public RPCSession, public DeviceAPI {
   DeviceAPI* GetDeviceAPI(Device dev, bool allow_missing) final { return this; }
 
   bool IsLocalSession() const final { return false; }
+
+  void Shutdown() final { endpoint_->Shutdown(); }
 
  private:
   uint64_t GetRPCMaxTransferSize() {

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -70,6 +70,12 @@ class RPCEndpoint {
  public:
   /*! \brief virtual destructor */
   ~RPCEndpoint();
+
+  /*!
+   *  \brief The server shutdown cleanup function.
+   */
+  void Shutdown();
+
   /*!
    *  \brief The server loop that server runs to handle RPC calls.
    */
@@ -177,8 +183,6 @@ class RPCEndpoint {
   RPCCode HandleUntilReturnEvent(bool client_mode, RPCSession::FEncodeReturn setreturn);
   // Initalization
   void Init();
-  // Shutdown
-  void Shutdown();
   // Internal channel.
   std::unique_ptr<RPCChannel> channel_;
 

--- a/src/runtime/rpc/rpc_endpoint.h
+++ b/src/runtime/rpc/rpc_endpoint.h
@@ -68,11 +68,19 @@ enum class TrackerCode : int {
  */
 class RPCEndpoint {
  public:
-  /*! \brief virtual destructor */
+  /*! \brief virtual destructor
+   * Closes the connection if the connection hasn't already been closed.
+   */
   ~RPCEndpoint();
 
   /*!
-   *  \brief The server shutdown cleanup function.
+   *  \brief Shutdown RPC connection.
+   *
+   *  Shutdown has no effect if the connection has already been shut down.
+   *  Shutdown will wait for all output currently queued from the RPC connection (i.e. The user
+   * doesn't need to wait for completion before calling Shutdown.) Any further use of objects that
+   * depended on the endpoint (e.g. A tvm.nd.array allocated on the remote RPC session) may throw an
+   * exception when used.
    */
   void Shutdown();
 

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -177,6 +177,10 @@ class RPCModuleNode final : public ModuleNode {
   const char* type_key() const final { return "rpc"; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
+    if (name == "Shutdown") {
+      return PackedFunc([this](TVMArgs, TVMRetValue*) { sess_->Shutdown(); });
+    }
+
     if (module_handle_ == nullptr) {
       return WrapRemoteFunc(sess_->GetFunction(name));
     } else {

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -177,7 +177,7 @@ class RPCModuleNode final : public ModuleNode {
   const char* type_key() const final { return "rpc"; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
-    if (name == "Shutdown") {
+    if (name == "CloseRPCConnection") {
       return PackedFunc([this](TVMArgs, TVMRetValue*) { sess_->Shutdown(); });
     }
 

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -253,6 +253,9 @@ class RPCSession {
    */
   static std::shared_ptr<RPCSession> Get(int table_index);
 
+  /*!
+   * \brief Shutdown RPC connection.
+   */
   virtual void Shutdown() {}
 
  protected:

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -253,6 +253,8 @@ class RPCSession {
    */
   static std::shared_ptr<RPCSession> Get(int table_index);
 
+  virtual void Shutdown() {}
+
  protected:
   /*!
    * \brief Send an exception to the callback.

--- a/tests/scripts/task_python_hexagon.sh
+++ b/tests/scripts/task_python_hexagon.sh
@@ -51,7 +51,7 @@ export ANDROID_SERIAL_NUMBER=${device_serial}
 if [ "${device_serial}" == "simulator" ]; then
     run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon
 else
-    run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon --tx $num_of_devices*popen --dist=load
+    run_pytest ctypes python-contrib-hexagon tests/python/contrib/test_hexagon -n=$num_of_devices
 fi
 
 if [[ "${device_serial}" == "simulator" ]]; then


### PR DESCRIPTION
This PR adds a shutdown packed function to RPC module so we can force close the RPC session from python side.

cc @areusch @Lunderberg 