### PR TITLE
[ONNX][frontend] support gridsample for onnx frontend

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -5270,9 +5270,6 @@ class GridSample(OnnxOpConverter):
     def _impl_v16(cls, inputs, attr, params):
         x = inputs[0]
         grid = inputs[1]
-        # Onnx only support 4D gridsample op
-        ndims = len(infer_shape(grid))
-        assert (ndims == 4, "Grid ndims must be 4")
 
         grid = _op.transpose(grid, axes=[0, 3, 1, 2])
         align_corners = attr.get("align_corners", 0)

--- a/python/tvm/topi/image/grid_sample.py
+++ b/python/tvm/topi/image/grid_sample.py
@@ -200,8 +200,8 @@ def _grid_sample_2d(
 
     def _nearest_sample(n, c, h, w):
         y, x = _compute_source_index(n, h, w)
-        y_new = te.round(y).astype("int32")
-        x_new = te.round(x).astype("int32")
+        y_new = te.nearbyint(y).astype("int32")  # Onnx use nearbyint rounding with nearest sample
+        x_new = te.nearbyint(x).astype("int32")  # Onnx use nearbyint rounding with nearest sample
 
         return _get_pixel_value(n, c, y_new, x_new)
 


### PR DESCRIPTION
This PR supports gridsample op for onnx frontend, and change the rounding method in topi in order to fit onnx. Test data from [ONNX opset](https://github.com/onnx/onnx/blob/main/docs/Operators.md#gridsample) is also adding in this PR. @Mousius 