### PR TITLE
[Relay][Op] Register some forgotten op in Python side

### DIFF
--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -622,3 +622,63 @@ class FixedPointMultiplyAttrs(Attrs):
 @tvm._ffi.register_object("relay.attrs.TriluAttrs")
 class TriluAttrs(Attrs):
     """Attributes used in trilu operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.SlidingWindowAttrs")
+class SlidingWindowAttrs(Attrs):
+    """Attributes used in sliding_window operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.DynExpandDimsAttrs")
+class DynExpandDimsAttrs(Attrs):
+    """Attributes used in dynamic expand_dims operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.ScatterAddAttrs")
+class ScatterAddAttrs(Attrs):
+    """Attributes used in scatter_add operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.ScatterNDAttrs")
+class ScatterNDAttrs(Attrs):
+    """Attributes used in scatter_nd operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.GatherNDAttrs")
+class GatherNDAttrs(Attrs):
+    """Attributes used in gather_nd operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.AutoSchedulerLayoutTransformAttrs")
+class AutoSchedulerLayoutTransformAttrs(Attrs):
+    """Attributes used in AutoSchedulerLayoutTransform operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.MetaScheduleLayoutTransformAttrs")
+class MetaScheduleLayoutTransformAttrs(Attrs):
+    """Attributes used in MetaScheduleLayoutTransform operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.MatrixSetDiagAttrs")
+class MatrixSetDiagAttrs(Attrs):
+    """Attributes used in matrix_set_diag operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.ScanopAttrs")
+class ScanopAttrs(Attrs):
+    """Attributes used in cumsum and cumprod operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.UniqueAttrs")
+class UniqueAttrs(Attrs):
+    """Attributes used in unique operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.EinsumAttrs")
+class EinsumAttrs(Attrs):
+    """Attributes used in einsum operators"""
+
+
+@tvm._ffi.register_object("relay.attrs.StftAttrs")
+class StftAttrs(Attrs):
+    """Attributes used in stft operators"""


### PR DESCRIPTION
It is noticed that many Attrs declared in this [file](https://github.com/apache/tvm/blob/main/include/tvm/relay/attrs/transform.h) are not registered [on Python side](https://github.com/apache/tvm/blob/main/python/tvm/relay/op/op_attrs.py). This will cause these Attrs having type `Object` when running with Python.

Therefore, this PR registers the missing operators in `op_attrs.py`, to make them have right types during runtime.

cc @spectrometerHBH @vinx13 