### PR TITLE
[BugFix][LLVM] Add UseInitArray flag in target_options_

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -242,6 +242,8 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const Target& target) {
     opt_level_ = defaults::opt_level;
   }
 
+  target_options_.UseInitArray = true;
+
   // Fast math options
 
   auto GetBoolFlag = [&target](llvm::StringRef flag) -> bool {


### PR DESCRIPTION
Pointers to constructor functions will be placed in section ".ctors" or ".init_array" in a binary file. However, the ".ctors" section is deprecated and Glibc is not going to call the constructor functions in it.
If we use GNU linker ld to link objects (by default), it will convert ".ctors" section to ".init_array" automatically, but not every linker has the compatibility. If we use lld (the LLVM linker) for better runtime performance (such as Link-Time-Optimization) and better compilation efficiency, the constructor functions will not be called, which will cause critical problems.
Adding "UseInitArray" option to target_options_ will generate ".init_array" instead of ".ctors" at compile time, which will solve this problem. This is also Clang's default behavior.