### PR TITLE
[microTVM] Add Cortex-M DSP schedules for optimal conv2d layouts

### DIFF
--- a/python/tvm/topi/arm_cpu/mprofile/dsp/conv2d.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/conv2d.py
@@ -25,32 +25,14 @@ from tvm.topi.nn.pad import pad
 from tvm.topi.nn.utils import get_pad_tuple
 from tvm.tir.expr import Mul
 
-from .micro_kernel.gemm import (
-    intrin_gemm_MxKxN,
-    gemm_MxKxN_impl,
+from .micro_kernel.tensordot import (
+    make_intrin_tensordot,
+    tensordot_impl,
 )
 
 
-def conv2d_nhwc_dsp(*args, **kwargs):
-    """Defines the v7e-m DSP instructions of conv2d."""
-    assert not kwargs, "Do not support kwargs in template function call"
-    args = deserialize_args(args)
-    data, kernel = args[:2]
-    layout = args[-2]
-    cfg = autotvm.get_config()
-    args = [cfg] + args
-    assert layout == "NHWC"
-    conv = conv2d_nhwc_dsp_compute(*args)
-    sched = conv2d_nhwc_dsp_schedule(cfg, [data, kernel, conv])
-    return sched, [data, kernel, conv]
-
-
-conv2d_nhwc_dsp.template_key = "dsp"
-conv2d_nhwc_dsp.default_data_layout = "NHWC"
-conv2d_nhwc_dsp.default_kernel_layout = "HWOI"
-
-
 def conv2d_nhwc_dsp_compute(cfg, data, kernel, strides, padding, dilation, out_dtype):
+    print("Activating Conv2D NHWC schedule")
     """Compute function for v7e-m DSP instructions of conv2d."""
     assert isinstance(strides, int) or len(strides) == 2
     assert isinstance(dilation, int) or len(dilation) == 2
@@ -66,7 +48,8 @@ def conv2d_nhwc_dsp_compute(cfg, data, kernel, strides, padding, dilation, out_d
         dilation_h, dilation_w = dilation
 
     batch_size, in_height, in_width, in_channels = data.shape
-    kernel_h, kernel_w, out_channels, _ = kernel.shape
+    out_channels, kernel_h, kernel_w, _ = kernel.shape
+    assert kernel.shape[3] == in_channels
 
     # compute the output shape
     dilated_kernel_h = (kernel_h - 1) * dilation_h + 1
@@ -81,9 +64,9 @@ def conv2d_nhwc_dsp_compute(cfg, data, kernel, strides, padding, dilation, out_d
     pad_after = [0, pad_down, pad_right, 0]
     padded_data = pad(data, pad_before, pad_after, name="padded_data")
 
-    rc = te.reduce_axis((0, in_channels), name="rc")
     ry = te.reduce_axis((0, kernel_h), name="ry")
     rx = te.reduce_axis((0, kernel_w), name="rx")
+    rc = te.reduce_axis((0, in_channels), name="rc")
 
     conv = te.compute(
         (batch_size, out_height, out_width, out_channels),
@@ -91,104 +74,81 @@ def conv2d_nhwc_dsp_compute(cfg, data, kernel, strides, padding, dilation, out_d
             padded_data[
                 nn, yy * stride_h + ry * dilation_h, xx * stride_w + rx * dilation_w, rc
             ].astype(out_dtype)
-            * kernel[ry, rx, ff, rc].astype(out_dtype),
+            * kernel[ff, ry, rx, rc].astype(out_dtype),
             axis=[ry, rx, rc],
         ),
         name="conv2d",
         tag="conv2d_nhwc",
     )
 
-    ###########################
-    # Config Space Definition #
-    ###########################
-    n, oh, ow, co = (
-        cfg.axis(batch_size.value),
-        cfg.axis(out_height.value),
-        cfg.axis(out_width.value),
-        cfg.axis(out_channels.value),
-    )
-    kh, kw, ci = (
-        cfg.reduce_axis(kernel_h.value),
-        cfg.reduce_axis(kernel_w.value),
-        cfg.reduce_axis(in_channels.value),
-    )
-
-    owo, owi = cfg.define_split("tile_ow", ow, policy="factors", num_outputs=2)
-    cio, cii = cfg.define_split(
-        "tile_ci",
-        ci,
-        policy="factors",
-        num_outputs=2,
-        # TODO: check case with in_channels.value % 4 != 0 with AutoTVM
-        filter=None if cfg.is_fallback else lambda x: x.size[-1] % 4 == 0,
-    )
-    coo, coi = cfg.define_split("tile_co", co, policy="factors", num_outputs=2)
-
-    cfg.define_reorder(
-        "reorder_0_simd",
-        [n, oh, owo, owi, coo, coi, kh, kw, cio, cii],
-        policy="candidate",
-        candidate=[
-            [n, oh, kh, kw, owo, coo, cio, owi, coi, cii],
-            [n, oh, kh, kw, coo, owo, cio, owi, coi, cii],
-            [n, kh, kw, oh, owo, coo, cio, owi, coi, cii],
-            [n, kh, kw, oh, coo, owo, cio, owi, coi, cii],
-        ],
-    )
-
-    cfg.define_knob("auto_unroll_max_step", [0, 2, 4, 8, 16, 32])
-    cfg.define_knob("unroll_explicit", [0, 1])
-
-    if cfg.is_fallback:
-        cfg.fallback_split("tile_ow", [-1, out_width.value])
-        cfg.fallback_split("tile_ci", [-1, in_channels.value])
-        cfg.fallback_split("tile_co", [-1, out_channels.value])
-
     return conv
+
+
+def _make_tensorization(padded_data, kernel, suffix):
+    _, padded_h, padded_w, in_channels = padded_data.shape
+    _, kernel_h, kernel_w, _ = kernel.shape
+
+    data_slice = te.placeholder((kernel_h, kernel_w, in_channels), name="a", dtype=in_dtype)
+    kernel_slice = te.placeholder((kernel_h, kernel_w, in_channels), name="b", dtype=in_dtype)
+
+    kh_i = te.reduce_axis((0, kernel_h), name="kh_i")
+    kw_i = te.reduce_axis((0, kernel_w), name="kw_i")
+    kc_i = te.reduce_axis((0, in_channels), name="kc_i")
+
+    output_slice = te.compute((1,),
+        lambda k: te.sum(
+            data_slice[kh_i, kw_i, kc_i].astype("int32")
+            * kernel_slice[kh_i, kw_i, kc_i].astype("int32"),
+            axis=[kh_i, kw_i, kc_i],
+        ),
+        name="c",
+    )
+
+    data_buf = tir.decl_buffer(
+        data_slice.shape, data_slice.dtype, name="data", offset_factor=1,
+        strides=[tensor_w * in_channels, in_channels, 1],
+    )
+    kernel_buf = tir.decl_buffer(
+        kernel_slice.shape, kernel_slice.dtype, name="kernel", offset_factor=1,
+        strides=[kernel_w * in_channels, in_channels, 1]
+    )
+    output_buf = tir.decl_buffer(
+        output_slice.shape, output_slice.dtype, name="output", offset_factor=1, strides=[1]
+    )
+
+    jump = (tensor_w - kernel_w) * in_channels
+    tensordot_params = (kernel_h, jump, kernel_w * in_channels, suffix)
+
+    intrin_tensordot = make_intrin_tensordot(
+        output_slice.op,
+        (data_buf, kernel_buf, output_buf),
+        tensordot_params
+    )
+
+    tensordot_code = tensordot_impl(tensordot_params)
+    return (intrin_tensordot, tensordot_code)
 
 
 def conv2d_nhwc_dsp_schedule(cfg, outs):
     """Schedule function for v7e-m DSP instructions of conv2d."""
-    sched = te.create_schedule([x.op for x in outs])
+    schedule = te.create_schedule([x.op for x in outs])
 
-    def _callback(op):
-        if "conv2d_nhwc" not in op.tag:
+    def _callback(operator):
+        if "conv2d_nhwc" not in operator.tag:
             return
 
         # extract tensors
-        output = op.output(0)
-        conv = op
-        data_vec = conv.input_tensors[0]
-        kernel = conv.input_tensors[1]  # pylint: disable=unused-variable
-        last = outs[0]  # pylint: disable=unused-variable
+        output = operator.output(0)
+        padded_data = output.op.input_tensors[0]
+        kernel = output.op.input_tensors[1]
 
-        source_index_w = output.op.body[0].source[0].a.value.indices[2].a
-        stride_w = source_index_w.b.value if isinstance(source_index_w, Mul) else 1
+        b_ax, y_ax, x_ax, co_ax = schedule[output].op.axis
+        kh_ax, kw_ax, ci_ax = schedule[output].op.reduce_axis
+        schedule[output].reorder(b_ax, y_ax, x_ax, co_ax, kh_ax, kw_ax, ci_ax)
 
-        # tile reduction axes
-        n, oh, ow, co = sched[conv].op.axis
-        kh, kw, ci = sched[conv].op.reduce_axis
+        intrin, code = _make_tensorization(padded_data, kernel, suffix)
+        schedule[output].tensorize(kh_ax, intrin)
+        schedule[output].pragma(n, "import_c", code)
 
-        M = cfg["tile_ow"].size[-1]
-        K = cfg["tile_ci"].size[-1]
-        N = cfg["tile_co"].size[-1]
-
-        owo, owi = cfg["tile_ow"].apply(sched, conv, ow)
-        cio, cii = cfg["tile_ci"].apply(sched, conv, ci)
-        coo, coi = cfg["tile_co"].apply(sched, conv, co)
-
-        cfg["reorder_0_simd"].apply(sched, conv, [n, oh, owo, owi, coo, coi, kh, kw, cio, cii])
-
-        gemm, uniq_id = intrin_gemm_MxKxN(M, K, N, data_vec.dtype, output.dtype, stride_w)
-        sched[output].tensorize(owi, gemm)
-        sched[output].pragma(n, "import_c", gemm_MxKxN_impl(M, K, N, uniq_id))
-
-        # this is the scope to attach global config inside this kernel
-        kernel_scope = n
-
-        # tune unroll
-        sched[output].pragma(kernel_scope, "auto_unroll_max_step", cfg["auto_unroll_max_step"].val)
-        sched[output].pragma(kernel_scope, "unroll_explicit", cfg["unroll_explicit"].val)
-
-    traverse_inline(sched, outs[-1].op, _callback)
-    return sched
+    traverse_inline(schedule, outs[-1].op, _callback)
+    return schedule

--- a/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/tensordot.py
+++ b/python/tvm/topi/arm_cpu/mprofile/dsp/micro_kernel/tensordot.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Computes a "jumpy tensordot" operator, which can/should be used to
+tensorize ANY aritrarily grouped conv2D, provided the data and kernel
+layouts are the optimal ones. When groups=1, the optimal data layout
+is NHWC and kernel layout is OHWI. When this is a depthwise convolution,
+the optimal data layout is NCHW and kernel layout is OIHW."""
+
+import textwrap
+
+from tvm import te, tir
+
+
+def _get_func_name(in_dtype, tensor_h, jump, tensor_w, suffix):
+    """Gets the C function name of the tensorized function."""
+    return f"tensordot_{in_dtype}_h{tensor_h}_j{jump}_w{tensor_w}_{suffix}"
+
+
+def make_intrin_tensordot(operator, buffers, tensordot_params):
+    data, kernel, output = buffers
+    #tensor_h, jump, tensor_w, suffix = tensordot_params
+
+    def intrin_func(ins, outs):
+        builder = tir.ir_builder.create()
+        builder.emit(
+            tir.call_extern(
+                "int32",
+                _get_func_name(data.dtype, *tensordot_params),
+                outs[0].access_ptr("w"),
+                ins[0].access_ptr("r"),
+                ins[1].access_ptr("r"),
+            )
+        )
+        return builder.get()
+
+    return te.decl_tensor_intrin(
+        operator,
+        intrin_func,
+        binds={data_slice: data, kernel_slice: kernel, output_slice: output},
+    )
+
+
+def intrin_depthwise_conv2d_tensordot(in_dtype, tensor_w, kernel_h, kernel_w, suffix):
+    data_slice = te.placeholder((kernel_h, kernel_w), name="a", dtype=in_dtype)
+    kernel_slice = te.placeholder((kernel_h, kernel_w), name="b", dtype=in_dtype)
+
+    kh_i = te.reduce_axis((0, kernel_h), name="kh_i")
+    kw_i = te.reduce_axis((0, kernel_w), name="kw_i")
+
+    output_slice = te.compute((1,),
+        lambda k: te.sum(
+            data_slice[kh_i, kw_i].astype("int32")
+            * kernel_slice[kh_i, kw_i].astype("int32"),
+            axis=[kh_i, kw_i],
+        ),
+        name="c",
+    )
+
+    data_buf = tir.decl_buffer(
+        data_slice.shape,
+        data_slice.dtype,
+        name="data",
+        offset_factor=1,
+        strides=[tensor_w, 1],
+    )
+    kernel_buf = tir.decl_buffer(
+        kernel_slice.shape, kernel_slice.dtype, name="kernel", offset_factor=1, strides=[kernel_w, 1]
+    )
+    output_buf = tir.decl_buffer(
+        output_slice.shape, output_slice.dtype, name="output", offset_factor=1, strides=[1]
+    )
+
+    def intrin_func(ins, outs):
+        builder = tir.ir_builder.create()
+        builder.emit(
+            tir.call_extern(
+                "int32",
+                _get_func_name(in_dtype, tensor_w, channels, kernel_h, kernel_w, suffix),
+                outs[0].access_ptr("w"),
+                ins[0].access_ptr("r"),
+                ins[1].access_ptr("r"),
+            )
+        )
+        return builder.get()
+
+    return te.decl_tensor_intrin(
+        output_slice.op,
+        intrin_func,
+        binds={data_slice: data_buf, kernel_slice: kernel_buf, output_slice: output_buf},
+    )
+
+
+def tensordot_impl(in_dtype, tensor_h, jump, tensor_w, suffix):
+    assert in_dtype in ["int8", "int16", "int32"]
+    simd_lanes = num_simd_lanes_per_word(in_dtype)
+    assert tensor_w % simd_lanes == 0
+    assert jump % simd_lanes == 0
+
+    if in_dtype == "int8":
+        inner_loop = """
+              uint32_t tensor_c20 = __SXTB16(tensor_batch);
+              uint32_t kernel_c20 = __SXTB16(kernel_batch);
+              sum = __SMLAD(tensor_c20, kernel_c20, sum);
+
+              uint32_t tensor_c31 = __SXTB16(__ROR(tensor_batch, 8));
+              uint32_t kernel_c31 = __SXTB16(__ROR(kernel_batch, 8));
+              sum = __SMLAD(tensor_c31, kernel_c31, sum);"""
+
+    elif in_dtype == "int16":
+        inner_loop = """
+              sum = __SMLAD(tensor_batch, kernel_batch, sum);"""
+
+    elif in_dtype == "int32":
+        inner_loop = """
+              sum = __MLA(tensor_batch, kernel_batch, sum);"""
+
+    function_name = _get_func_name(in_dtype, tensor_h, jump, tensor_w, suffix)
+    return textwrap.dedent(
+        (
+            f"""
+        #include <stdint.h>
+        #include <arm_nnsupportfunctions.h>
+
+        #ifdef __cplusplus
+        extern "C"
+        #endif
+        __STATIC_FORCEINLINE int32_t {function_name}(
+            uint32_t *out,
+            uint32_t *tensor,
+            uint32_t *kernel) {{
+
+          uint32_t sum = 0;
+
+          #pragma GCC unroll {tensor_h}
+          for (int i = 0; i < {tensor_h}; i++) {{
+            #pragma GCC unroll {length // simd_width}
+            for (int j = 0; j < {length // simd_width}; i++) {{
+              uint32_t tensor_batch = *tensor++;
+              uint32_t kernel_batch = *kernel++;
+              {inner_loop.trim()}
+            }}
+            tensor += {jump // simd_width};
+          }}
+          out[0] = sum;
+          return 0;
+        }}
+        """
+        )
+    )

--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -22,9 +22,8 @@ from numbers import Integral
 
 import numpy as np
 import tvm
-from tvm import te
+from tvm import relay, te
 from tvm.tir import bijective_layout, layout
-
 from . import cpp, tag
 
 
@@ -431,6 +430,32 @@ def get_shape(src_shape, src_layout, dst_layout):
 
     return get_const_tuple(tuple([src_shape[i.value] for i in dst_indices]))
 
+
+def change_constant_shape(src, src_layout, dst_layout):
+    """Makes a copy of a Relay constant, reshaping it to a new data layout.
+
+    Parameter
+    ---------
+    src : relay.Constant
+        The Constant to be reformatted.
+
+    src_layout : str
+        The current layout of the Relay constant. Must be alphabetic (e.g. NHWC
+        or OIHW, but not NCHW2c).
+
+    dst_layout : str
+        The desired layout of new the Relay constant. Must be alphabetic (e.g. NHWC
+        or OIHW, but not NCHW2c).
+
+    Returns
+    -------
+    dst_shape : relay.Constant
+        A copy of the Constant with the new layout.
+    """
+    assert src_layout.isalpha() and dst_layout.isalpha()
+    axis_order = [src_layout.index(c) for c in dst_layout]
+    reshaped = np.transpose(src.data.numpy(), axis_order)
+    return relay.Constant(tvm.nd.array(reshaped))
 
 def within_index(b, e, s, i):
     """Return a boolean value that indicates if i is within the given index.


### PR DESCRIPTION
This pull request adds fast microTVM DSP schedules for the _optimal_ `conv2d` and `depthwise_conv2d` layouts - `NHWC/OHWI` and `NCHW/OIHW`. By letting us use the special `SMLAD` DSP instruction _without rearranging data_, **25%** of the instructions in the inner loop can be removed (for the `int16` case).

Additionally, this change allows both the `conv2d` and `depthwise_conv2d` fast DSP schedules to use the _same underlying intrinsic_, a variation of a tensordot operator. This makes the code for these schedules much more compact. This PR also:

- Adds unit tests for the new schedules
- Does not affect the old schedules, which are still used when they apply
  - The cases in which these new fast schedules apply are strictly different
- Adds support for `int8`, `int16`, and `int32` input data types in the new schedules
- Adds a `change_constant_shape` utility to `tvm.topi`

This pull request **does not** change the strategy functions to call these new fast schedules - this will occur in a follow up PR. I've also written a comment below delving into why these layouts are optimal.