### PR TITLE
[tir] Add fake support for 'call_tir' op

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -721,6 +721,11 @@ TVM_DLL const Op& texture2d_load();
 TVM_DLL const Op& mem_copy();
 
 /*!
+ * \brief Call a TIR PrimFunc that exists within the same IRModule
+ */
+TVM_DLL const Op& call_tir();
+
+/*!
  * \brief Initiate a non-blocking DMA copy from source to destination
  */
 TVM_DLL const Op& dma_copy();

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -288,6 +288,9 @@ TIR_DEFINE_BUILTIN_FUNC(texture2d_load)
 TIR_DEFINE_BUILTIN_FUNC(mem_copy).set_attr<TCallEffectKind>("TCallEffectKind",
                                                             Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_BUILTIN_FUNC(call_tir).set_attr<TCallEffectKind>("TCallEffectKind",
+                                                            Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_BUILTIN_FUNC(dma_copy).set_attr<TCallEffectKind>("TCallEffectKind",
                                                             Integer(CallEffectKind::kOpaque));
 

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -317,6 +317,8 @@ class BuiltinLower : public StmtExprMutator {
       return make_zero(op->dtype);
     } else if (op->op.same_as(builtin::mem_copy())) {
       return MakeMemCopy(op);
+    } else if (op->op.same_as(builtin::call_tir())) {
+      return MakeCallTir(op);
     } else if (op->op.same_as(builtin::dma_copy())) {
       return MakeDMACopy(op);
     } else if (op->op.same_as(builtin::dma_wait())) {
@@ -337,6 +339,21 @@ class BuiltinLower : public StmtExprMutator {
     Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
                             {StringImm(fdevapi_prefix + ".mem_copy"), dst, src, size});
     return VisitExpr(call_packed);
+  }
+
+  PrimExpr MakeCallTir(const CallNode* op) {
+    // NOTE(cconvey): This is placeholder code to support incremental development of the
+    // TIR 'call_tir' intrinsic.  For now it's basically a no-op, and imposes no particular
+    // requirements on the argument list.
+
+    if (op->dtype != tvm::runtime::DataType::Int(32)) {
+      LOG(ERROR) << "MakeCallTir: 'call_tir' is a work in progress."
+                 << " The return dtype currently must be int32.";
+    }
+
+    LOG(WARNING) << "MakeCallTir: 'call_tir' support is a work in progress.  Currently, just "
+                    "returns (int32) 0.";
+    return PrimExpr(0);
   }
 
   PrimExpr MakeDMACopy(const CallNode* op) {

--- a/tests/python/unittest/test_slice_tir.py
+++ b/tests/python/unittest/test_slice_tir.py
@@ -86,7 +86,6 @@ import pytest
 #   3) As support for 'call_tir' becomes more complete, this test should once again
 #      fail, because the specified callee doesn't exist.  This test should be updated
 #      to once again expect failure.
-@pytest.mark.xfail(reason="Awaiting TVMScript support for 'call_tir' token.", strict=True)
 class TestParseCallTIR(tvm.testing.CompareBeforeAfter):
     """
     Simply confirm that the TIR node `call_tir` doesn't interfere with
@@ -94,11 +93,10 @@ class TestParseCallTIR(tvm.testing.CompareBeforeAfter):
     """
 
     def before():
-        T.call_tir(add_one)
-        T.evalute(0)
+        T.evaluate(T.call_tir("add_one", dtype="int32"))
 
     def expected():
-        T.evaluate(0)
+        T.evaluate(T.call_tir("add_one", dtype="int32"))
 
     # Provide a trivial 'transform' pass to satisfy the requirements of
     # tvm.testing.CompareBeforeAfter.


### PR DESCRIPTION
Allow TVMScript to contain `T.call_tir(...)` calls. This is a small step toward a complete implementation of the 'call_tir' functionality.  The op does nothing, and its arguments are not evaluated at runtime.