### PR TITLE
[TVMScript] Allow T.bool type annotations

### DIFF
--- a/python/tvm/script/tir/__init__.py
+++ b/python/tvm/script/tir/__init__.py
@@ -17,7 +17,7 @@
 """TVMScript for TIR"""
 
 # Type system
-from .ty import void, boolean, handle, Ptr, Tuple, Buffer
+from .ty import void, boolean, bool, handle, Ptr, Tuple, Buffer
 
 from .prim_func import prim_func
 

--- a/python/tvm/script/tir/__init__.py
+++ b/python/tvm/script/tir/__init__.py
@@ -17,7 +17,8 @@
 """TVMScript for TIR"""
 
 # Type system
-from .ty import void, boolean, bool, handle, Ptr, Tuple, Buffer
+from .ty import void, boolean, handle, Ptr, Tuple, Buffer
+from .ty import bool  # pylint: disable=redefined-builtin
 
 from .prim_func import prim_func
 

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -206,7 +206,17 @@ for _dtype in ["float", "uint", "int"]:
             _name = _dtype + _size + _lanes
             globals()[_name] = ConcreteType(_name)
 
-bool = boolean = ConcreteType("bool")
+
+# All other DataType annotations are represented with the same string
+# as is used by `tvm.runtime.DataType`.  This does redefine the Python
+# built-in bool, but only within the context of `tvm.script.tir.ty`
+# and `tvm.script.tir` modules.  The `T.boolean` alias is maintained
+# for backwards compatibility.
+
+bool = ConcreteType("bool")  # pylint: disable=redefined-builtin
+boolean = bool
+
+
 handle = ConcreteType("handle")
 void = VoidType()
 Ptr = GenericPtrType()

--- a/python/tvm/script/tir/ty.py
+++ b/python/tvm/script/tir/ty.py
@@ -206,7 +206,7 @@ for _dtype in ["float", "uint", "int"]:
             _name = _dtype + _size + _lanes
             globals()[_name] = ConcreteType(_name)
 
-boolean = ConcreteType("bool")
+bool = boolean = ConcreteType("bool")
 handle = ConcreteType("handle")
 void = VoidType()
 Ptr = GenericPtrType()

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3409,6 +3409,47 @@ def minimal_i32_literal():
     return func
 
 
+def boolean_argument():
+    @T.prim_func
+    def func(a: T.boolean) -> None:
+        T.evaluate(a)
+
+    return func
+
+
+def bool_argument():
+    @T.prim_func
+    def func(a: T.bool) -> None:
+        T.evaluate(a)
+
+    return func
+
+
+def bool_variable_annotation():
+    @T.prim_func
+    def func() -> None:
+        a: T.bool = T.call_extern("dummy", dtype="bool")
+        T.evaluate(0)
+
+    return func
+
+
+def bool_primitive():
+    @T.prim_func
+    def func() -> None:
+        T.evaluate(T.bool(True))
+
+    return func
+
+
+def bool_cast():
+    @T.prim_func
+    def func() -> None:
+        T.evaluate(T.bool(T.int32(0)))
+
+    return func
+
+
 ir_generator = tvm.testing.parameter(
     opt_gemm_normalize,
     opt_gemm_lower,
@@ -3454,6 +3495,11 @@ ir_generator = tvm.testing.parameter(
     allocate_and_decl_buffer,
     float_infinity,
     minimal_i32_literal,
+    boolean_argument,
+    bool_argument,
+    bool_variable_annotation,
+    bool_primitive,
+    bool_cast,
 )
 
 


### PR DESCRIPTION
Previously, `T.bool` could be used to define a boolean value (e.g. `b = T.bool(1)`), but required using `T.boolean` when writing a type annotation.  This can cause both user confusion, as all other TVMScript type annotations directly match their string representation in `tvm.runtime.DataType`, and failure to roundtrip, because the tvmscript printer will generate the non-existence `T.bool` type annotations.

This commit add `tvm.script.tir.ty.bool`, which can be used in TVMScript as `T.bool`. The previous
`tvm.script.tir.ty.boolean` (`T.boolean` in TVMScript) is maintained for backwards compatibility.