### PR TITLE
[TEST] CPU feature detection for x86 and ARM dot product instructions

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1021,7 +1021,9 @@ def _has_vnni():
 requires_arm_dot = Feature("arm_dot", "ARM dot product", run_time_check=_arm_dot_supported)
 
 
-requires_cascadelake = Feature("cascadelake", "x86 CascadeLake", run_time_check=lambda: _has_vnni() and _is_intel())
+requires_cascadelake = Feature(
+    "cascadelake", "x86 CascadeLake", run_time_check=lambda: _has_vnni() and _is_intel()
+)
 
 
 def _cmake_flag_enabled(flag):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1012,7 +1012,7 @@ def _has_vnni():
 requires_arm_dot = Feature("arm_dot", "ARM dot product", run_time_check=_arm_dot_supported)
 
 
-requires_vnni = Feature("vnni", "x86_64 with VNNI extension", run_time_check=_has_vnni)
+requires_cascadelake = Feature("cascadelake", "x86 CascadeLake", run_time_check=_has_vnni)
 
 
 def _cmake_flag_enabled(flag):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1011,7 +1011,7 @@ def _has_vnni():
 requires_arm_dot = Feature("arm_dot", "ARM dot product", run_time_check=_arm_dot_supported)
 
 
-requires_cascadelake = Feature("cascadelake", "x86 CascadeLake", run_time_check=_has_vnni)
+requires_vnni = Feature("vnni", "x86_64 with VNNI extension", run_time_check=_has_vnni)
 
 
 def _cmake_flag_enabled(flag):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -984,7 +984,8 @@ requires_vitis_ai = Feature("vitis_ai", "Vitis AI", cmake_flag="USE_VITIS_AI")
 
 def _arm_dot_supported():
     arch = platform.machine()
-    if arch != "arm64" and arch != "aarch64":
+
+    if arch not in ["arm64", "aarch64"]:
         return False
 
     if sys.platform.startswith("darwin"):
@@ -993,7 +994,7 @@ def _arm_dot_supported():
             if line.startswith("hw.optional.arm.FEAT_DotProd"):
                 return bool(int(line.split(":", 1)[1]))
     elif sys.platform.startswith("linux"):
-        return "dot" in open("/proc/cpuinfo", "r").read()
+        return True
 
     return False
 

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1003,7 +1003,8 @@ def _has_vnni():
     arch = platform.machine()
     # Only linux is supported for now.
     if arch == "x86_64" and sys.platform.startswith("linux"):
-        return "avx512_vnni" in open("/proc/cpuinfo", "r").read()
+        with open("/proc/cpuinfo", "r").read() as content:
+            return "avx512_vnni" in content
 
     return False
 

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -982,7 +982,7 @@ requires_corstone300 = Feature(
 requires_vitis_ai = Feature("vitis_ai", "Vitis AI", cmake_flag="USE_VITIS_AI")
 
 
-def arm_dot_supported():
+def _arm_dot_supported():
     arch = platform.machine()
     if arch != "arm64" and arch != "aarch64":
         return False
@@ -998,8 +998,19 @@ def arm_dot_supported():
     return False
 
 
-requires_arm_dot = Feature(
-    "arm_dot", "ARM dot product", run_time_check=arm_dot_supported)
+def _has_vnni():
+    arch = platform.machine()
+    # Only linux is supported for now.
+    if arch == "x86_64" and sys.platform.startswith("linux"):
+        return "avx512_vnni" in open("/proc/cpuinfo", "r").read()
+
+    return False
+
+
+requires_arm_dot = Feature("arm_dot", "ARM dot product", run_time_check=_arm_dot_supported)
+
+
+requires_cascadelake = Feature("cascadelake", "x86 CascadeLake", run_time_check=_has_vnni)
 
 
 def _cmake_flag_enabled(flag):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -999,6 +999,15 @@ def _arm_dot_supported():
     return False
 
 
+def _is_intel():
+    # Only linux is supported for now.
+    if sys.platform.startswith("linux"):
+        with open("/proc/cpuinfo", "r").read() as content:
+            return "Intel" in content
+
+    return False
+
+
 def _has_vnni():
     arch = platform.machine()
     # Only linux is supported for now.
@@ -1012,7 +1021,7 @@ def _has_vnni():
 requires_arm_dot = Feature("arm_dot", "ARM dot product", run_time_check=_arm_dot_supported)
 
 
-requires_cascadelake = Feature("cascadelake", "x86 CascadeLake", run_time_check=_has_vnni)
+requires_cascadelake = Feature("cascadelake", "x86 CascadeLake", run_time_check=lambda: _has_vnni() and _is_intel())
 
 
 def _cmake_flag_enabled(flag):

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1002,8 +1002,8 @@ def _arm_dot_supported():
 def _is_intel():
     # Only linux is supported for now.
     if sys.platform.startswith("linux"):
-        with open("/proc/cpuinfo", "r").read() as content:
-            return "Intel" in content
+        with open("/proc/cpuinfo", "r") as content:
+            return "Intel" in content.read()
 
     return False
 
@@ -1012,8 +1012,8 @@ def _has_vnni():
     arch = platform.machine()
     # Only linux is supported for now.
     if arch == "x86_64" and sys.platform.startswith("linux"):
-        with open("/proc/cpuinfo", "r").read() as content:
-            return "avx512_vnni" in content
+        with open("/proc/cpuinfo", "r") as content:
+            return "avx512_vnni" in content.read()
 
     return False
 

--- a/tests/python/integration/test_meta_schedule_auto_tensorize.py
+++ b/tests/python/integration/test_meta_schedule_auto_tensorize.py
@@ -284,7 +284,7 @@ def _test_bert_int8(target, sch_rules, postprocs):
     print(runtime.benchmark(dev, number=1, repeat=50).mean)
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_vnni_dense():
     _test_dense(
         "uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, "llvm -mcpu=cascadelake -num-cores 4"
@@ -305,7 +305,7 @@ def test_dp4a_dense():
     # )
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_vnni_conv2d():
     _test_conv2d(
         "uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, "llvm -mcpu=cascadelake -num-cores 4"
@@ -326,7 +326,8 @@ def test_dp4a_conv2d():
     # )
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
+@pytest.mark.skip("Slow on CI")
 def test_vnni_bert_int8():
     _test_bert_int8("llvm -mcpu=cascadelake -num-cores 4", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI)
 

--- a/tests/python/integration/test_meta_schedule_auto_tensorize.py
+++ b/tests/python/integration/test_meta_schedule_auto_tensorize.py
@@ -284,7 +284,7 @@ def _test_bert_int8(target, sch_rules, postprocs):
     print(runtime.benchmark(dev, number=1, repeat=50).mean)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 def test_vnni_dense():
     _test_dense(
         "uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, "llvm -mcpu=cascadelake -num-cores 4"
@@ -305,7 +305,7 @@ def test_dp4a_dense():
     # )
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 def test_vnni_conv2d():
     _test_conv2d(
         "uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, "llvm -mcpu=cascadelake -num-cores 4"
@@ -326,7 +326,7 @@ def test_dp4a_conv2d():
     # )
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 @pytest.mark.skip("Slow on CI")
 def test_vnni_bert_int8():
     _test_bert_int8("llvm -mcpu=cascadelake -num-cores 4", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI)

--- a/tests/python/integration/test_meta_schedule_auto_tensorize.py
+++ b/tests/python/integration/test_meta_schedule_auto_tensorize.py
@@ -327,7 +327,7 @@ def test_dp4a_conv2d():
 
 
 @tvm.testing.requires_vnni
-@pytest.mark.skip("Slow on CI")
+@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Slow on CI")
 def test_vnni_bert_int8():
     _test_bert_int8("llvm -mcpu=cascadelake -num-cores 4", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI)
 

--- a/tests/python/integration/test_meta_schedule_auto_tensorize.py
+++ b/tests/python/integration/test_meta_schedule_auto_tensorize.py
@@ -284,7 +284,7 @@ def _test_bert_int8(target, sch_rules, postprocs):
     print(runtime.benchmark(dev, number=1, repeat=50).mean)
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 def test_vnni_dense():
     _test_dense(
         "uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, "llvm -mcpu=cascadelake -num-cores 4"
@@ -305,7 +305,7 @@ def test_dp4a_dense():
     # )
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 def test_vnni_conv2d():
     _test_conv2d(
         "uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, "llvm -mcpu=cascadelake -num-cores 4"
@@ -326,7 +326,7 @@ def test_dp4a_conv2d():
     # )
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 @pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Slow on CI")
 def test_vnni_bert_int8():
     _test_bert_int8("llvm -mcpu=cascadelake -num-cores 4", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI)

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -744,7 +744,7 @@ def test_bitserial_dense():
     assert yy.checked_type == relay.TensorType((m, 32), "int16")
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_dense_vnni():
     data_shape = (32, 96)
     weight_shape = (128, 96)

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -744,7 +744,7 @@ def test_bitserial_dense():
     assert yy.checked_type == relay.TensorType((m, 32), "int16")
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 def test_dense_vnni():
     data_shape = (32, 96)
     weight_shape = (128, 96)

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -744,7 +744,7 @@ def test_bitserial_dense():
     assert yy.checked_type == relay.TensorType((m, 32), "int16")
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 def test_dense_vnni():
     data_shape = (32, 96)
     weight_shape = (128, 96)

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -473,7 +473,7 @@ def test_batch_matmul(executor_kind):
     verify_batch_matmul_with_inputs(executor_kind, x, x, x_np, x_np, (10, 27, 27))
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_batch_matmul_vnni():
     x_shape = (16, 32, 96)
     y_shape = (16, 128, 96)

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -473,7 +473,7 @@ def test_batch_matmul(executor_kind):
     verify_batch_matmul_with_inputs(executor_kind, x, x, x_np, x_np, (10, 27, 27))
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 def test_batch_matmul_vnni():
     x_shape = (16, 32, 96)
     y_shape = (16, 128, 96)

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -473,7 +473,7 @@ def test_batch_matmul(executor_kind):
     verify_batch_matmul_with_inputs(executor_kind, x, x, x_np, x_np, (10, 27, 27))
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 def test_batch_matmul_vnni():
     x_shape = (16, 32, 96)
     y_shape = (16, 128, 96)

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2212,8 +2212,9 @@ def test_conv2d_int8_alter_dtype_arm():
     _test_conv2d_int8_alter_dtype("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot")
 
 
-# def test_conv2d_int8_alter_dtype_vnni():
-#     _test_conv2d_int8_alter_dtype("int8", "llvm -mcpu=cascadelake", "vpdpbusd")
+@tvm.testing.requires_cascadelake
+def test_conv2d_int8_alter_dtype_vnni():
+    _test_conv2d_int8_alter_dtype("int8", "llvm -mcpu=cascadelake", "vpdpbusd")
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2137,8 +2137,7 @@ def test_conv2d_nhwc_dnnl():
             np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.skip("Requires cascadelake or ARM v8.2")
-def test_conv2d_int8_alter_dtype():
+def _test_conv2d_int8_alter_dtype(data_dtype, target, dot_product_instr):
     def get_conv2d_nchw(
         d_shape,
         w_shape,
@@ -2171,45 +2170,50 @@ def test_conv2d_int8_alter_dtype():
     bias_np = np.random.randint(low=-127, high=128, size=bias_shape).astype("int32")
     weight_np = np.random.uniform(-128, 127, size=weight_shape).astype("int8")
 
-    for data_dtype, target, dot_product_instr in [
-        ("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot"),
-        ("int8", "llvm -mcpu=cascadelake", "vpdpbusd"),
-    ]:
-        conv2d = get_conv2d_nchw(data_shape, weight_shape, data_dtype)
-        bias_add = relay.add(conv2d, bias)
-        mod = tvm.IRModule.from_expr(bias_add)
+    conv2d = get_conv2d_nchw(data_shape, weight_shape, data_dtype)
+    bias_add = relay.add(conv2d, bias)
+    mod = tvm.IRModule.from_expr(bias_add)
 
-        if data_dtype == "uint8":
-            data_np = np.random.uniform(0, 255, size=data_shape).astype("uint8")
-        else:
-            data_np = np.random.uniform(-128, 127, size=data_shape).astype("int8")
+    if data_dtype == "uint8":
+        data_np = np.random.uniform(0, 255, size=data_shape).astype("uint8")
+    else:
+        data_np = np.random.uniform(-128, 127, size=data_shape).astype("int8")
 
-        params = {"weight": weight_np, "bias": bias_np}
+    params = {"weight": weight_np, "bias": bias_np}
 
-        ref = (
-            relay.create_executor("graph", mod=mod, device=tvm.cpu(0), target="llvm")
-            .evaluate()(*[data_np, weight_np, bias_np])
-            .numpy()
-        )
+    ref = (
+        relay.create_executor("graph", mod=mod, device=tvm.cpu(0), target="llvm")
+        .evaluate()(*[data_np, weight_np, bias_np])
+        .numpy()
+    )
 
-        dev = tvm.cpu(0)
+    dev = tvm.cpu(0)
 
-        with tvm.transform.PassContext(
-            opt_level=3,
-        ):
-            lib = relay.build(mod, target=target, params=params)
+    with tvm.transform.PassContext(
+        opt_level=3,
+    ):
+        lib = relay.build(mod, target=target, params=params)
 
-        assert dot_product_instr in lib.lib.get_source("asm")
+    assert dot_product_instr in lib.lib.get_source("asm")
 
-        rt_mod = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
+    rt_mod = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
 
-        rt_mod.set_input("data", data_np)
+    rt_mod.set_input("data", data_np)
 
-        rt_mod.run()
+    rt_mod.run()
 
-        out = rt_mod.get_output(0).numpy()
+    out = rt_mod.get_output(0).numpy()
 
-        np.testing.assert_equal(out, ref)
+    np.testing.assert_equal(out, ref)
+
+
+@tvm.testing.requires_arm_dot
+def test_conv2d_int8_alter_dtype_arm():
+    _test_conv2d_int8_alter_dtype("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot")
+
+
+# def test_conv2d_int8_alter_dtype_vnni():
+#     _test_conv2d_int8_alter_dtype("int8", "llvm -mcpu=cascadelake", "vpdpbusd")
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2212,7 +2212,7 @@ def test_conv2d_int8_alter_dtype_arm():
     _test_conv2d_int8_alter_dtype("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot")
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 def test_conv2d_int8_alter_dtype_vnni():
     _test_conv2d_int8_alter_dtype("int8", "llvm -mcpu=cascadelake", "vpdpbusd")
 

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2212,7 +2212,7 @@ def test_conv2d_int8_alter_dtype_arm():
     _test_conv2d_int8_alter_dtype("uint8", "llvm --device arm_cpu -mattr=+v8.2a,+dotprod", "sdot")
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 def test_conv2d_int8_alter_dtype_vnni():
     _test_conv2d_int8_alter_dtype("int8", "llvm -mcpu=cascadelake", "vpdpbusd")
 

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -23,6 +23,7 @@ from typing import List, Optional
 import numpy as np  # type: ignore
 import pytest
 import tvm
+import tvm.testing
 from tvm import meta_schedule as ms
 from tvm import relay
 from tvm._ffi import register_func
@@ -441,9 +442,9 @@ def manual_tir_common(do_tune=False):
         )
         config = ms.TuneConfig(
             strategy="replay_trace",
-            num_trials_per_iter=64,
-            max_trials_per_task=20000,
-            max_trials_global=20000,
+            num_trials_per_iter=8,
+            max_trials_per_task=8,
+            max_trials_global=8,
         )
 
         with tempfile.TemporaryDirectory() as work_dir:
@@ -503,7 +504,7 @@ def manual_tir_common(do_tune=False):
     np.testing.assert_equal(out, ref)
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_tune_relay_manual_tir_vnni():
     manual_tir_common(do_tune=False)
 

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -504,7 +504,7 @@ def manual_tir_common(do_tune=False):
     np.testing.assert_equal(out, ref)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_vnni
 def test_tune_relay_manual_tir_vnni():
     manual_tir_common(do_tune=False)
 

--- a/tests/python/unittest/test_meta_schedule_tune_relay.py
+++ b/tests/python/unittest/test_meta_schedule_tune_relay.py
@@ -504,7 +504,7 @@ def manual_tir_common(do_tune=False):
     np.testing.assert_equal(out, ref)
 
 
-@tvm.testing.requires_vnni
+@tvm.testing.requires_cascadelake
 def test_tune_relay_manual_tir_vnni():
     manual_tir_common(do_tune=False)
 


### PR DESCRIPTION
This is a followup to https://github.com/apache/tvm/pull/12865. We have some tests that depend on a dot product instruction of the target architecture, such as VNNI (cascadelake) and ARM `sdot/udot`. These tests are currently skipped on CI, but to properly test them on an instance that does support such instructions, I'm introducing `requires_arm_dot` and `requires_cascadelake` decorator.  

@tkonolige @driazati 