### PR TITLE
[MetaSchedule] Support RewriteLayout postproc on AllocateConst 

### DIFF
--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -93,8 +93,15 @@ def _normalize_params(
         if isinstance(param, np.ndarray):
             param = nd.array(param)
         relay_params[name] = param
-    if executor is not None:
+
+    if executor is None:
+        executor = relay.backend.Executor("graph")
+
+    if mod.get_attr("executor") is None:
         mod = mod.with_attr("executor", executor)
+    else:
+        executor = mod.get_attr("executor")
+
     pass_config = dict(pass_config)
     return mod, target, relay_params, pass_config, executor
 
@@ -384,8 +391,7 @@ def is_meta_schedule_dispatch_enabled() -> bool:
     enabled: bool
         Whether the meta schedule is enabled
     """
-    result = transform.PassContext.current().config.get(
+    return transform.PassContext.current().config.get(
         "relay.backend.use_meta_schedule_dispatch",
-        0,
+        False,
     )
-    return bool(result & 1)

--- a/src/meta_schedule/postproc/postproc.cc
+++ b/src/meta_schedule/postproc/postproc.cc
@@ -85,10 +85,9 @@ Array<Postproc> Postproc::DefaultCUDATensorCore() {
 Array<Postproc> Postproc::DefaultHexagon() {
   return Array<Postproc>{
       Postproc::DisallowDynamicLoop(),
-      Postproc::RewriteParallelVectorizeUnroll(),  //
+      Postproc::RewriteParallelVectorizeUnroll(),
       Postproc::RewriteReductionBlock(),
-      // TODO(masahi): Fix RewriteLayout for link-params=True case
-      // Postproc::RewriteLayout(),
+      Postproc::RewriteLayout(),
   };
 }
 

--- a/src/meta_schedule/postproc/rewrite_layout.cc
+++ b/src/meta_schedule/postproc/rewrite_layout.cc
@@ -129,7 +129,7 @@ Array<Buffer> CollectLayoutFreeBuffers(const PrimFuncNode* func) {
 
   Array<Buffer> layout_free_buffers;
   for (const Integer& index : layout_free_buffer_index) {
-    ICHECK(index->value < func->params.size());
+    ICHECK(static_cast<size_t>(index->value) < func->params.size());
     const Var& param = func->params[index->value];
     layout_free_buffers.push_back(func->buffer_map.at(param));
   }

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
@@ -42,6 +42,12 @@ class MultiLevelTilingWideVectorNode : public MultiLevelTilingNode {
   TVM_DECLARE_FINAL_OBJECT_INFO(MultiLevelTilingWideVectorNode, MultiLevelTilingNode);
 
  protected:
+  ScheduleRule Clone() const final {
+    ObjectPtr<MultiLevelTilingWideVectorNode> n =
+        make_object<MultiLevelTilingWideVectorNode>(*this);
+    return ScheduleRule(n);
+  }
+
   Array<tir::LoopRV> SplitLoop(const Schedule& sch, BlockRV block, LoopRV loop, int n_tiles) const;
 };
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -521,7 +521,6 @@ class ScheduleBuilder : public ExprVisitor {
                 MetaScheduleLayoutRewriter::LayoutQueuePush(index_map);
               }
             }
-
             Schedule sch = Schedule::Traced(query_mod, /*seed=*/-1, /*debug_mask=*/0,
                                             tir::ScheduleErrorRenderLevel::kDetail);
             record->trace->ApplyToSchedule(sch, /*remove_postproc=*/false);

--- a/src/relay/transforms/meta_schedule_layout_rewrite.cc
+++ b/src/relay/transforms/meta_schedule_layout_rewrite.cc
@@ -95,15 +95,15 @@ class MetaScheduleFuncMutator : public ExprMutator {
           ICHECK_EQ(call->args.size(), 2);
           tir::IndexMap index_map = layout_queue_.front();
           layout_queue_.pop_front();
-	  Array<PrimExpr> shape;
+          Array<PrimExpr> shape;
           if (call->args[1]->IsInstance<VarNode>()) {
             Var var = Downcast<Var>(call->args[1]);
             shape = Downcast<TensorType>(var->type_annotation)->shape;
           } else if (const ConstantNode* cnst = call->args[1].as<ConstantNode>()) {
             shape = cnst->tensor_type()->shape;
           } else {
-	    LOG(FATAL) << "Unexpected input " << call->args[1];
-	  }
+            LOG(FATAL) << "Unexpected input " << call->args[1];
+          }
           Attrs attrs{nullptr};
           TVM_RELAY_LAYOUT_WITH_ORIGINAL_SHAPE(call->attrs, Conv2DAttrs, shape, attrs);
           TVM_RELAY_LAYOUT_WITH_ORIGINAL_SHAPE(call->attrs, Conv2DWinogradAttrs, shape, attrs);

--- a/src/relay/transforms/meta_schedule_layout_rewrite.cc
+++ b/src/relay/transforms/meta_schedule_layout_rewrite.cc
@@ -95,8 +95,15 @@ class MetaScheduleFuncMutator : public ExprMutator {
           ICHECK_EQ(call->args.size(), 2);
           tir::IndexMap index_map = layout_queue_.front();
           layout_queue_.pop_front();
-          Var var = Downcast<Var>(call->args[1]);
-          Array<PrimExpr> shape = Downcast<TensorType>(var->type_annotation)->shape;
+	  Array<PrimExpr> shape;
+          if (call->args[1]->IsInstance<VarNode>()) {
+            Var var = Downcast<Var>(call->args[1]);
+            shape = Downcast<TensorType>(var->type_annotation)->shape;
+          } else if (const ConstantNode* cnst = call->args[1].as<ConstantNode>()) {
+            shape = cnst->tensor_type()->shape;
+          } else {
+	    LOG(FATAL) << "Unexpected input " << call->args[1];
+	  }
           Attrs attrs{nullptr};
           TVM_RELAY_LAYOUT_WITH_ORIGINAL_SHAPE(call->attrs, Conv2DAttrs, shape, attrs);
           TVM_RELAY_LAYOUT_WITH_ORIGINAL_SHAPE(call->attrs, Conv2DWinogradAttrs, shape, attrs);

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -256,7 +256,7 @@ BlockRealize GenerateBlockFromTensors(const te::ComputeOp& compute_op,
     // TensorIR will not allow Tensor data structure
     if (value->IsInstance<ArrayNode>()) {
       const auto array_value = Downcast<Array<ObjectRef>>(value);
-      annotations.Set(key, MutateArray(array_value, mutate_attr));
+      annotations.Set(key, array_value.Map(mutate_attr));
     } else {
       annotations.Set(key, mutate_attr(value));
     }

--- a/src/tir/transforms/remove_weight_layout_rewrite_block.cc
+++ b/src/tir/transforms/remove_weight_layout_rewrite_block.cc
@@ -114,11 +114,11 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
 //
 // constant fused_constant_2[float32 * 3 * 3 * 64 * 64]
 // conv2d_nhwc[nn, yy, xx, ff] += ... * fused_constant_2_global[ry,
-// 							        floordiv(rc, 32),
-// 							        floordiv(ff, 16),
-// 							        rx,
-// 							        floormod(rc, 32),
-// 							        floormod(ff, 16)]))
+//                                                              floordiv(rc, 32),
+//                                                              floordiv(ff, 16),
+//                                                              rx,
+//                                                              floormod(rc, 32),
+//                                                              floormod(ff, 16)]))
 //
 // When cache_read is reading from AllocateConstant, we need to replace the reference
 // to fused_constant_2_global with the corresponding transformed AllocateConstant.
@@ -129,11 +129,11 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
 //
 // constant fused_constant_2[float32 * 3 * 2 * 4 * 3 * 32 * 16]
 // conv2d_nhwc[nn, yy, xx, ff] += ... * fused_constant_2[ry,
-// 				 		         floordiv(rc, 32),
-// 						         floordiv(ff, 16),
-// 						         rx,
-// 						         floormod(rc, 32),
-// 						         floormod(ff, 16)]))
+//                                                       floordiv(rc, 32),
+//                                                       floordiv(ff, 16),
+//                                                       rx,
+//                                                       floormod(rc, 32),
+//                                                       floormod(ff, 16)]))
 
 using BufferVarMap = std::unordered_map<const tir::VarNode*, const tir::VarNode*>;
 
@@ -167,7 +167,7 @@ class AllocateConstRewrite : public StmtExprMutator {
       auto rewritten_ndarray = it->second->MapNDArray(alloc->data.value());
       Array<PrimExpr> rewritten_extents;
       for (auto s : rewritten_ndarray.Shape()) {
-        rewritten_extents.push_back(PrimExpr(int(s)));
+        rewritten_extents.push_back(PrimExpr(static_cast<int>(s)));
       }
       return AllocateConst(alloc->buffer_var, alloc->dtype, rewritten_extents, rewritten_ndarray,
                            new_body, alloc->annotations, alloc->span);

--- a/src/tir/transforms/remove_weight_layout_rewrite_block.cc
+++ b/src/tir/transforms/remove_weight_layout_rewrite_block.cc
@@ -51,7 +51,7 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
       // Remove allocates if needed
       Array<Buffer> alloc_buffers;
       for (const Buffer& buffer : block->alloc_buffers) {
-        if (!rewritten_buffers.count(buffer)) {
+        if (!rewritten_buffers_.count(buffer)) {
           alloc_buffers.push_back(buffer);
         }
       }
@@ -77,7 +77,7 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
     ICHECK(load);
 
     buf_map_.Set(load->buffer, store->buffer);
-    rewritten_buffers.insert(store->buffer);
+    rewritten_buffers_.insert(store->buffer);
 
     // Step 4. Set block body as no_op
     auto n = CopyOnWrite(block.get());
@@ -87,8 +87,11 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
     return Stmt(n);
   }
 
+ private:
+  /*! \brief The buffer map from original layout buffer to rewritten buffer */
   Map<Buffer, Buffer> buf_map_;
-  std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> rewritten_buffers;
+  /*! \brief The buffer map from original layout buffer to rewritten buffer */
+  std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> rewritten_buffers_;
 };
 
 // HACK
@@ -188,6 +191,5 @@ Pass RemoveWeightLayoutRewriteBlock() {
 TVM_REGISTER_GLOBAL("tir.transform.RemoveWeightLayoutRewriteBlock")
     .set_body_typed(RemoveWeightLayoutRewriteBlock);
 }  // namespace transform
-
 }  // namespace tir
 }  // namespace tvm

--- a/src/tir/transforms/remove_weight_layout_rewrite_block.cc
+++ b/src/tir/transforms/remove_weight_layout_rewrite_block.cc
@@ -22,6 +22,7 @@
  * \brief Remove weight layout rewrite block before benchmark
  */
 
+#include <tvm/tir/index_map.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
@@ -33,19 +34,20 @@ namespace tir {
 
 class RemoveLayoutRewriteBlock : public StmtMutator {
  public:
-  static std::pair<PrimFunc, Map<Buffer, Buffer>> Rewrite(PrimFunc f) {
+  static std::tuple<PrimFunc, Map<Buffer, Buffer>, std::unordered_map<const VarNode*, IndexMap>>
+  Rewrite(PrimFunc f) {
     RemoveLayoutRewriteBlock rewriter;
 
     PrimFuncNode* n = f.CopyOnWrite();
     n->body = rewriter(std::move(n->body));
-    return std::make_pair(f, rewriter.buf_map_);
+    return std::make_tuple(f, rewriter.buf_map_, rewriter.buffer_var_to_index_map_);
   }
 
  private:
   Stmt VisitStmt_(const BlockNode* op) final {
     Block block = Downcast<Block>(StmtMutator::VisitStmt_(op));
 
-    auto it = block->annotations.find(tir::attr::meta_schedule_layout_rewrite_preproc);
+    auto it = block->annotations.find(attr::meta_schedule_layout_rewrite_preproc);
     if (it == block->annotations.end() || !is_one(Downcast<PrimExpr>((*it).second))) {
       // The block is not a weight layout block
       // Remove allocates if needed
@@ -76,6 +78,7 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
     const auto* load = store->value.as<BufferLoadNode>();
     ICHECK(load);
 
+    // Step 3. Update Buffer
     buf_map_.Set(load->buffer, store->buffer);
     rewritten_buffers_.insert(store->buffer);
 
@@ -84,6 +87,14 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
     n->body = std::move(Evaluate(0));
     n->reads = {};
     n->writes = {};
+
+    Array<Var> load_indices;
+    for (auto ind : load->indices) {
+      ICHECK(ind->IsInstance<VarNode>());
+      load_indices.push_back(Downcast<Var>(ind));
+    }
+    buffer_var_to_index_map_[load->buffer->data.get()] = IndexMap(load_indices, store->indices);
+
     return Stmt(n);
   }
 
@@ -92,9 +103,99 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
   Map<Buffer, Buffer> buf_map_;
   /*! \brief The buffer map from original layout buffer to rewritten buffer */
   std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> rewritten_buffers_;
+  /*! \brief Maps a buffer load to an index map associated with the load / store
+    in a layout rewrite block. */
+  std::unordered_map<const VarNode*, IndexMap> buffer_var_to_index_map_;
 };
 
-// HACK
+// After RemoveLayoutRewriteBlock, the body of a compute update block references a
+// non-existant buffer. For example, fused_constant_2_global below is originally a
+// cache_read buffer, whose allocation is removed by RemoveLayoutRewriteBlock:
+//
+// constant fused_constant_2[float32 * 3 * 3 * 64 * 64]
+// conv2d_nhwc[nn, yy, xx, ff] += ... * fused_constant_2_global[ry,
+// 							        floordiv(rc, 32),
+// 							        floordiv(ff, 16),
+// 							        rx,
+// 							        floormod(rc, 32),
+// 							        floormod(ff, 16)]))
+//
+// When cache_read is reading from AllocateConstant, we need to replace the reference
+// to fused_constant_2_global with the corresponding transformed AllocateConstant.
+// To do that, we manually rewrite the original constant using the associated index map,
+// and let the body of the compute block to load from the rewritten constant.
+//
+// After this transformation, the example above looks like:
+//
+// constant fused_constant_2[float32 * 3 * 2 * 4 * 3 * 32 * 16]
+// conv2d_nhwc[nn, yy, xx, ff] += ... * fused_constant_2[ry,
+// 				 		         floordiv(rc, 32),
+// 						         floordiv(ff, 16),
+// 						         rx,
+// 						         floormod(rc, 32),
+// 						         floormod(ff, 16)]))
+
+using BufferVarMap = std::unordered_map<const tir::VarNode*, const tir::VarNode*>;
+
+class AllocateConstRewrite : public StmtExprMutator {
+ public:
+  AllocateConstRewrite(const BufferVarMap& buffer_var_map,
+                       const std::unordered_map<const VarNode*, IndexMap>& buffer_var_to_index_map)
+      : buffer_var_map_(buffer_var_map), buffer_var_to_index_map_(buffer_var_to_index_map) {}
+
+ private:
+  Stmt VisitStmt_(const BlockNode* op) final {
+    Block block = Downcast<Block>(StmtMutator::VisitStmt_(op));
+    auto n = CopyOnWrite(block.get());
+    Array<BufferRegion> new_reads;
+    for (auto read_region : op->reads) {
+      if (auto it = new_load_buf_.find(read_region->buffer->data.get());
+          it != new_load_buf_.end()) {
+        new_reads.push_back(BufferRegion(it->second, read_region->region));
+      } else {
+        new_reads.push_back(read_region);
+      }
+    }
+    n->reads = new_reads;
+    return Stmt(n);
+  }
+
+  Stmt VisitStmt_(const AllocateConstNode* alloc) final {
+    if (auto it = buffer_var_to_index_map_.find(alloc->buffer_var.get());
+        it != buffer_var_to_index_map_.end()) {
+      auto new_body = StmtMutator::VisitStmt(alloc->body);
+      auto rewritten_ndarray = it->second->MapNDArray(alloc->data.value());
+      Array<PrimExpr> rewritten_extents;
+      for (auto s : rewritten_ndarray.Shape()) {
+        rewritten_extents.push_back(PrimExpr(int(s)));
+      }
+      return AllocateConst(alloc->buffer_var, alloc->dtype, rewritten_extents, rewritten_ndarray,
+                           new_body, alloc->annotations, alloc->span);
+    }
+    return StmtMutator::VisitStmt_(alloc);
+  }
+
+  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+    if (auto it = buffer_var_map_.find(op->buffer->data.get()); it != buffer_var_map_.end()) {
+      auto new_buffer =
+          Buffer(GetRef<Var>(it->second), op->buffer->dtype, op->buffer->shape, op->buffer->strides,
+                 op->buffer->elem_offset, it->second->name_hint, op->buffer->data_alignment,
+                 op->buffer->offset_factor, op->buffer->buffer_type);
+      new_load_buf_[op->buffer->data.get()] = new_buffer;
+      return BufferLoad(new_buffer, op->indices);
+    }
+    return ExprMutator::VisitExpr_(op);
+  }
+
+  /*! \brief Maps a buffer store to a load in a layout rewrite block */
+  BufferVarMap buffer_var_map_;
+  /*! \brief Maps a buffer load to an index map associated with the load / store
+    in a layout rewrite block. */
+  std::unordered_map<const VarNode*, IndexMap> buffer_var_to_index_map_;
+  /*! \brief Maps load buffer variables to newly created buffers */
+  std::unordered_map<const VarNode*, Buffer> new_load_buf_;
+};
+
 class CollectAllocateConstBufferVars : public StmtVisitor {
  public:
   void VisitStmt_(const AllocateConstNode* alloc) final {
@@ -105,52 +206,13 @@ class CollectAllocateConstBufferVars : public StmtVisitor {
   std::unordered_set<const VarNode*> constant_buf_var;
 };
 
-using BufferVarMap = std::unordered_map<const tir::VarNode*, const tir::VarNode*>;
-
-class AllocateConstRewrite : public StmtExprMutator {
- public:
-  AllocateConstRewrite(const BufferVarMap& buffer_var_map) : buffer_var_map_(buffer_var_map) {}
-
- private:
-  Stmt VisitStmt_(const BlockNode* op) final {
-    Block block = Downcast<Block>(StmtMutator::VisitStmt_(op));
-    auto n = CopyOnWrite(block.get());
-    Array<BufferRegion> new_reads;
-    for (auto read_region : op->reads) {
-      if (auto it = new_load_buf.find(read_region->buffer->data.get()); it != new_load_buf.end()) {
-        new_reads.push_back(BufferRegion(it->second, read_region->region));
-      } else {
-        new_reads.push_back(read_region);
-      }
-    }
-    n->reads = new_reads;
-    return Stmt(n);
-  }
-
-  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
-    if (auto it = buffer_var_map_.find(op->buffer->data.get()); it != buffer_var_map_.end()) {
-      auto new_buffer =
-          Buffer(GetRef<Var>(it->second), op->buffer->dtype, op->buffer->shape, op->buffer->strides,
-                 op->buffer->elem_offset, it->second->name_hint, op->buffer->data_alignment,
-                 op->buffer->offset_factor, op->buffer->buffer_type);
-      new_load_buf[op->buffer->data.get()] = new_buffer;
-      return BufferLoad(new_buffer, op->indices);
-    }
-    return ExprMutator::VisitExpr_(op);
-  }
-
-  BufferVarMap buffer_var_map_;
-  std::unordered_set<const VarNode*> constant_buf_var;
-  std::unordered_map<const VarNode*, Buffer> new_load_buf;
-};
-
 class WeightLayoutRewriteBlockRemover : public StmtMutator {
  public:
   static PrimFunc Remove(PrimFunc f) {
     CollectAllocateConstBufferVars collector;
     collector(f->body);
 
-    auto [f_, buf_map] = RemoveLayoutRewriteBlock().Rewrite(f);
+    auto [f_, buf_map, buffer_var_to_index_map] = RemoveLayoutRewriteBlock().Rewrite(f);
 
     BufferVarMap buffer_var_map;
     for (const auto& [load_buf, store_buf] : buf_map) {
@@ -162,11 +224,11 @@ class WeightLayoutRewriteBlockRemover : public StmtMutator {
 
     PrimFuncNode* n = f_.CopyOnWrite();
 
-    AllocateConstRewrite rewriter(buffer_var_map);
+    AllocateConstRewrite rewriter(buffer_var_map, buffer_var_to_index_map);
     n->body = rewriter(std::move(n->body));
 
     Map<tir::Var, Buffer> buffer_map;
-    for (const auto& [param, buffer] : f->buffer_map) {
+    for (const auto& [param, buffer] : f_->buffer_map) {
       auto it = buf_map.find(buffer);
       if (it != buf_map.end()) {
         buffer_map.Set(param, (*it).second);
@@ -190,6 +252,8 @@ Pass RemoveWeightLayoutRewriteBlock() {
 
 TVM_REGISTER_GLOBAL("tir.transform.RemoveWeightLayoutRewriteBlock")
     .set_body_typed(RemoveWeightLayoutRewriteBlock);
+
 }  // namespace transform
+
 }  // namespace tir
 }  // namespace tvm

--- a/tests/python/contrib/test_hexagon/test_meta_schedule.py
+++ b/tests/python/contrib/test_hexagon/test_meta_schedule.py
@@ -205,7 +205,7 @@ def test_vrmpy_dense(hexagon_launcher):
                     schedule_dense_for_tune,
                     sch_rules=[],
                     postprocs=[],
-                    mutator_probs=[],
+                    mutator_probs={},
                 ),
                 strategy="replay-trace",
                 builder=get_hexagon_local_builder(),
@@ -307,6 +307,7 @@ def test_vrmpy_dense_auto_tensorize(hexagon_launcher):
         postproc.RewriteTensorize(vectorize_init_loop=True),
     ]
 
+    # Make this to False to compile and run the best tuned schedule
     if True:
         with tempfile.TemporaryDirectory() as work_dir:
             target = get_hexagon_target("v68")
@@ -315,10 +316,13 @@ def test_vrmpy_dense_auto_tensorize(hexagon_launcher):
                 target=target,
                 max_trials_global=8,
                 num_trials_per_iter=8,
-                max_trials_per_task=8,
                 work_dir=work_dir,
-                sch_rules=lambda: sch_rules,
-                postprocs=lambda: postprocs,
+                space=ms.space_generator.PostOrderApply(
+                    f_block_filter=None,
+                    sch_rules=sch_rules,
+                    postprocs=postprocs,
+                    mutator_probs={},
+                ),
                 builder=get_hexagon_local_builder(),
                 runner=get_hexagon_rpc_runner(hexagon_launcher, number=10),
             )

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -148,7 +148,7 @@ def tune_and_test(relay_mod, data_np, weight_np, op_name, target, sch_rules, pos
     tune_tasks = list(
         filter(
             lambda task: op_name in task.task_name,
-            ms.relay_integration.extracted_task_from_relay(relay_mod, target, params),
+            ms.relay_integration.extract_tasks(relay_mod, target, params),
         )
     )
     with tempfile.TemporaryDirectory() as work_dir:
@@ -164,7 +164,7 @@ def tune_and_test(relay_mod, data_np, weight_np, op_name, target, sch_rules, pos
             tasks=tasks,
             task_weights=task_weights,
             work_dir=work_dir,
-            max_trials_global=20000,
+            max_trials_global=32,
         )
     with database, tvm.transform.PassContext(
         opt_level=3,
@@ -251,6 +251,7 @@ def _test_bert_int8(relay_mod, params, input_info, target, sch_rules, postprocs)
             tasks=tasks,
             task_weights=task_weights,
             work_dir=work_dir,
+            max_trials_per_task=32,
             max_trials_global=20000,
         )
     with database, tvm.transform.PassContext(

--- a/tests/python/unittest/test_meta_schedule_relay_integration.py
+++ b/tests/python/unittest/test_meta_schedule_relay_integration.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Integration test for MetaSchedule"""
+import tempfile
 import numpy as np
 import pytest
 import tvm
@@ -487,6 +488,83 @@ def test_meta_schedule_te2primfunc_argument_order():
     actual_output = get_output(data, rt_mod1)
     expected_output = get_output(data, rt_mod2)
     assert np.allclose(actual_output, expected_output, rtol=1e-4, atol=2e-4)
+
+
+def test_rewrite_layout_link_params():
+    I, O, H, W = 64, 64, 56, 56
+    kH = kW = 3
+
+    strides = (1, 1)
+    padding = (1, 1)
+
+    data_shape = (1, H, W, I)
+    w_shape = (kH, kW, I, O)
+    bias_shape = (1, 1, 1, O)
+
+    data = relay.var("data", shape=data_shape, dtype="float32")
+    weight = relay.var("weight1", shape=w_shape, dtype="float32")
+    bias = relay.var("bias", shape=bias_shape, dtype="float32")
+
+    conv = relay.nn.conv2d(
+        data=data,
+        weight=weight,
+        kernel_size=(kH, kW),
+        channels=O,
+        padding=padding,
+        strides=strides,
+        data_layout="NHWC",
+        kernel_layout="HWIO",
+        out_dtype="float32",
+    )
+
+    mod = tvm.IRModule.from_expr(conv + bias)
+
+    weight_np = np.random.randn(*w_shape).astype("float32")
+    bias_np = np.random.randn(*bias_shape).astype("float32")
+
+    params = {"weight1": weight_np, "bias": bias_np}
+
+    data_np = np.random.randn(*data_shape).astype("float32")
+
+    ref = (
+        relay.create_executor("graph", mod=mod, device=tvm.cpu(0), target="llvm")
+        .evaluate()(*[data_np, weight_np, bias_np])
+        .numpy()
+    )
+
+    link_params = True
+
+    target = "llvm --num-cores=4"
+
+    executor = relay.backend.Executor("graph", {"link-params": link_params})
+    mod = mod.with_attr("executor", executor)
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        database = ms.relay_integration.tune_relay(
+            mod=mod,
+            target=target,
+            params=params,
+            work_dir=work_dir,
+            max_trials_global=4,
+            strategy="replay-trace",
+        )
+
+        lib = ms.relay_integration.compile_relay(
+            database=database,
+            mod=mod,
+            target=target,
+            params=params,
+        )
+
+    dev = tvm.device(target, 0)
+    runtime = tvm.contrib.graph_executor.GraphModule(lib["default"](dev))
+
+    runtime.set_input("data", data_np)
+    runtime.run()
+
+    out = runtime.get_output(0).numpy()
+
+    np.testing.assert_allclose(ref, out, rtol=1e-4, atol=1e-4)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_meta_schedule_vnni_integration.py
+++ b/tests/python/unittest/test_meta_schedule_vnni_integration.py
@@ -133,7 +133,7 @@ def _relay_dense(m, n, k):
     return relay_mod, params, f_check
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_vnni_schedule_fn_database():
     m, n, k = 1024, 1024, 1024
     target = tvm.target.Target("llvm -mcpu=cascadelake -num-cores 4")
@@ -164,7 +164,7 @@ def test_vnni_schedule_fn_database():
     f_check(lib, dev)
 
 
-@pytest.mark.skip("Requires cascadelake")
+@tvm.testing.requires_cascadelake
 def test_vnni_schedule_fn_tune():
     # pylint: disable=W0105
     """

--- a/tests/python/unittest/test_te_create_primfunc.py
+++ b/tests/python/unittest/test_te_create_primfunc.py
@@ -382,12 +382,14 @@ def expected_layout_attr(
     for i0, i1, i2 in T.grid(128, 128, 128):
         with T.block("C"):
             x, y, k = T.axis.remap("SSR", [i0, i1, i2])
+            T.block_attr({"layout_free_placeholders":[]})
             with T.init():
                 C[x, y] = T.float32(0)
             C[x, y] = C[x, y] + A[x, k] * B[y, k]
     for i0, i1 in T.grid(128, 128):
         with T.block("D"):
             x, y = T.axis.remap("SS", [i0, i1])
+            T.block_attr({"layout_free_placeholders":[C]})
             D[x, y] = C[x, y] + T.float32(1)
 
 

--- a/tests/python/unittest/test_te_create_primfunc.py
+++ b/tests/python/unittest/test_te_create_primfunc.py
@@ -382,14 +382,14 @@ def expected_layout_attr(
     for i0, i1, i2 in T.grid(128, 128, 128):
         with T.block("C"):
             x, y, k = T.axis.remap("SSR", [i0, i1, i2])
-            T.block_attr({"layout_free_placeholders":[]})
+            T.block_attr({"layout_free_placeholders": []})
             with T.init():
                 C[x, y] = T.float32(0)
             C[x, y] = C[x, y] + A[x, k] * B[y, k]
     for i0, i1 in T.grid(128, 128):
         with T.block("D"):
             x, y = T.axis.remap("SS", [i0, i1])
-            T.block_attr({"layout_free_placeholders":[C]})
+            T.block_attr({"layout_free_placeholders": [C]})
             D[x, y] = C[x, y] + T.float32(1)
 
 


### PR DESCRIPTION
`RewriteLayout` assumes that the "layout-free" weight to be rewritten is passed as a parameter to prim func. This doesn't hold when `link-params = True` is used, since the constant weight is directly embedded in a primfunc as `AllocateConst` node.  

Supporting RewriteLayout on AllocateConst required some nasty hacks to workaround various issues. Detailed comments are provided to explain the problem and my solution.

This lets us enable `RewriteLayout` for Hexagon.