### PR TITLE
[Hexagon] [runtime] Query for total and available VTCM

### DIFF
--- a/src/runtime/hexagon/hexagon_vtcm_pool.cc
+++ b/src/runtime/hexagon/hexagon_vtcm_pool.cc
@@ -38,6 +38,7 @@ HexagonVtcmPool::HexagonVtcmPool() {
                                                 &total_block_layout, &avail_block_size,
                                                 &avail_block_layout));
   DLOG(INFO) << "HexagonVtcmPool total " << total_block_size << " avail " << avail_block_size;
+  CHECK(avail_block_size >= (1024 * 1024)) << "Less than 1MB VTCM available";
 
   // allocate nbytes of vtcm on a single page
   HEXAGON_SAFE_CALL(HAP_compute_res_attr_set_vtcm_param_v2(&res_info,

--- a/src/runtime/hexagon/hexagon_vtcm_pool.cc
+++ b/src/runtime/hexagon/hexagon_vtcm_pool.cc
@@ -30,14 +30,23 @@ HexagonVtcmPool::HexagonVtcmPool() {
   HEXAGON_SAFE_CALL(HAP_compute_res_attr_init(&res_info));
 
   // TODO(HWE): get the max  and min size programmatically
-  const unsigned int max_size = 4 * 1024 * 1024;
-  const unsigned int min_size = 1024 * 1024;
+  unsigned int total_block_size;
+  unsigned int avail_block_size;
+  compute_res_vtcm_page_t total_block_layout;
+  compute_res_vtcm_page_t avail_block_layout;
+
+  HEXAGON_SAFE_CALL(compute_resource_query_VTCM(/* application_id = */ 0,
+                                                &total_block_size,
+                                                &total_block_layout,
+                                                &avail_block_size,
+                                                &avail_block_layout));
+  DLOG(INFO) << "HexagonVtcmPool total_block_size " << total_block_size << " avail_block_size " << avail_block_size;
 
   // allocate nbytes of vtcm on a single page
   HEXAGON_SAFE_CALL(HAP_compute_res_attr_set_vtcm_param_v2(&res_info,
-                                                           /*vtcm_size = */ max_size,
+                                                           /*vtcm_size = */ total_block_size,
                                                            /*min_page_size = */ 1,
-                                                           /*min_vtcm_size = */ min_size));
+                                                           /*min_vtcm_size = */ avail_block_size));
 
   // TODO(HWE): Investigate why a non-zero timeout results in
   // hanging, both in the simulator and on hardware.
@@ -45,7 +54,7 @@ HexagonVtcmPool::HexagonVtcmPool() {
   CHECK(context_id_) << "HAP_compute_res_acquire failed to acquire requested VTCM resource.";
   HEXAGON_SAFE_CALL(HAP_compute_res_attr_get_vtcm_ptr_v2(&res_info, &vtcm_data_, &vtcm_size_));
   CHECK(vtcm_data_ != nullptr) << "HAP_compute_res_acquire returned nullptr when allocating VTCM.";
-  CHECK(vtcm_size_ >= min_size)
+  CHECK(vtcm_size_ >= avail_block_size)
       << "HAP_compute_res_acquire failed to allocate minimum amount of VTCM";
   free_.emplace_back(std::pair<char*, size_t>(static_cast<char*>(vtcm_data_), vtcm_size_));
   // DebugDump();

--- a/src/runtime/hexagon/hexagon_vtcm_pool.cc
+++ b/src/runtime/hexagon/hexagon_vtcm_pool.cc
@@ -29,18 +29,15 @@ HexagonVtcmPool::HexagonVtcmPool() {
   compute_res_attr_t res_info;
   HEXAGON_SAFE_CALL(HAP_compute_res_attr_init(&res_info));
 
-  // TODO(HWE): get the max  and min size programmatically
   unsigned int total_block_size;
   unsigned int avail_block_size;
   compute_res_vtcm_page_t total_block_layout;
   compute_res_vtcm_page_t avail_block_layout;
 
-  HEXAGON_SAFE_CALL(compute_resource_query_VTCM(/* application_id = */ 0,
-                                                &total_block_size,
-                                                &total_block_layout,
-                                                &avail_block_size,
+  HEXAGON_SAFE_CALL(compute_resource_query_VTCM(/* application_id = */ 0, &total_block_size,
+                                                &total_block_layout, &avail_block_size,
                                                 &avail_block_layout));
-  DLOG(INFO) << "HexagonVtcmPool total_block_size " << total_block_size << " avail_block_size " << avail_block_size;
+  DLOG(INFO) << "HexagonVtcmPool total " << total_block_size << " avail " << avail_block_size;
 
   // allocate nbytes of vtcm on a single page
   HEXAGON_SAFE_CALL(HAP_compute_res_attr_set_vtcm_param_v2(&res_info,

--- a/src/runtime/hexagon/hexagon_vtcm_pool.h
+++ b/src/runtime/hexagon/hexagon_vtcm_pool.h
@@ -71,10 +71,10 @@ class HexagonVtcmPool {
   size_t TotalBytes() { return reinterpret_cast<size_t>(vtcm_size_); }
 
  private:
-  //! \brief Context for HAP_compute_res_*
+  //! \brief Total size of VTCM pool
   unsigned int vtcm_size_;
 
-  //! \brief Context for HAP_compute_res_*
+  //! \brief Pointer to the beginning of the pool
   void* vtcm_data_;
 
   //! \brief Context for HAP_compute_res_*


### PR DESCRIPTION
Update HexagonVtcmPool to use compute_resource_query_VTCM to query for the total and available blocks in VTCM.  Ensures at least 1MB is available.

Also fixes two typos in the header.

cc:  @supersat, @kparzysz-quic, @csullivan 