### PR TITLE
[Node] Expose StructuralEqual/Hash handler implemenation to header

### DIFF
--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -334,11 +334,11 @@ class SEqualHandlerDefault : public SEqualReducer::Handler {
   SEqualHandlerDefault(bool assert_mode, Optional<ObjectPathPair>* first_mismatch);
   virtual ~SEqualHandlerDefault();
 
-  virtual bool SEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
-                            const Optional<ObjectPathPair>& current_paths) override;
-  virtual void DeferFail(const ObjectPathPair& mismatch_paths) override;
-  virtual ObjectRef MapLhsToRhs(const ObjectRef& lhs) override;
-  virtual void MarkGraphNode() override;
+  bool SEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
+                    const Optional<ObjectPathPair>& current_paths) override;
+  void DeferFail(const ObjectPathPair& mismatch_paths) override;
+  ObjectRef MapLhsToRhs(const ObjectRef& lhs) override;
+  void MarkGraphNode() override;
 
   /*!
    * \brief The entry point for equality testing

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -324,5 +324,47 @@ class SEqualReducer {
   bool map_free_vars_ = false;
 };
 
+/*! \brief The default handler for equality testing.
+ *
+ * Users can derive from this class and override the DispatchSEqualReduce method,
+ * to customize equality testing.
+ */
+class SEqualHandlerDefault : public SEqualReducer::Handler {
+ public:
+  SEqualHandlerDefault(bool assert_mode, Optional<ObjectPathPair>* first_mismatch);
+  virtual ~SEqualHandlerDefault();
+
+  virtual bool SEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
+                            const Optional<ObjectPathPair>& current_paths) override;
+  virtual void DeferFail(const ObjectPathPair& mismatch_paths) override;
+  virtual ObjectRef MapLhsToRhs(const ObjectRef& lhs) override;
+  virtual void MarkGraphNode() override;
+
+  /*!
+   * \brief The entry point for equality testing
+   * \param lhs The left operand.
+   * \param rhs The right operand.
+   * \param map_free_vars Whether or not to remap variables if possible.
+   * \return The equality result.
+   */
+  virtual bool Equal(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars);
+
+ protected:
+  /*!
+   * \brief The dispatcher for equality testing of intermediate objects
+   * \param lhs The left operand.
+   * \param rhs The right operand.
+   * \param map_free_vars Whether or not to remap variables if possible.
+   * \param current_paths Optional paths to `lhs` and `rhs` objects, for error traceability.
+   * \return The equality result.
+   */
+  virtual bool DispatchSEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
+                                    const Optional<ObjectPathPair>& current_paths);
+
+ private:
+  class Impl;
+  Impl* impl;
+};
+
 }  // namespace tvm
 #endif  // TVM_NODE_STRUCTURAL_EQUAL_H_

--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -210,11 +210,11 @@ class SHashHandlerDefault : public SHashReducer::Handler {
   SHashHandlerDefault();
   virtual ~SHashHandlerDefault();
 
-  virtual void SHashReduceHashedValue(size_t hashed_value) override;
-  virtual void SHashReduce(const ObjectRef& key, bool map_free_vars) override;
-  virtual void SHashReduceFreeVar(const runtime::Object* var, bool map_free_vars) override;
-  virtual bool LookupHashedValue(const ObjectRef& key, size_t* hashed_value) override;
-  virtual void MarkGraphNode() override;
+  void SHashReduceHashedValue(size_t hashed_value) override;
+  void SHashReduce(const ObjectRef& key, bool map_free_vars) override;
+  void SHashReduceFreeVar(const runtime::Object* var, bool map_free_vars) override;
+  bool LookupHashedValue(const ObjectRef& key, size_t* hashed_value) override;
+  void MarkGraphNode() override;
 
   /*!
    * \brief The entry point for hashing

--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -200,6 +200,44 @@ class SHashReducer {
   bool map_free_vars_;
 };
 
+/*! \brief The default handler for hash key computation
+ *
+ * Users can derive from this class and override the DispatchSHash method,
+ * to customize hashing.
+ */
+class SHashHandlerDefault : public SHashReducer::Handler {
+ public:
+  SHashHandlerDefault();
+  virtual ~SHashHandlerDefault();
+
+  virtual void SHashReduceHashedValue(size_t hashed_value) override;
+  virtual void SHashReduce(const ObjectRef& key, bool map_free_vars) override;
+  virtual void SHashReduceFreeVar(const runtime::Object* var, bool map_free_vars) override;
+  virtual bool LookupHashedValue(const ObjectRef& key, size_t* hashed_value) override;
+  virtual void MarkGraphNode() override;
+
+  /*!
+   * \brief The entry point for hashing
+   * \param object The object to be hashed.
+   * \param map_free_vars Whether or not to remap variables if possible.
+   * \return The hash result.
+   */
+  virtual size_t Hash(const ObjectRef& object, bool map_free_vars);
+
+ protected:
+  /*!
+   * \brief The dispatcher for hashing of intermediate objects
+   * \param object An intermediate object to be hashed.
+   * \param map_free_vars Whether or not to remap variables if possible.
+   * \return The hash result.
+   */
+  virtual void DispatchSHash(const ObjectRef& object, bool map_free_vars);
+
+ private:
+  class Impl;
+  Impl* impl;
+};
+
 class SEqualReducer;
 struct NDArrayContainerTrait {
   static constexpr const std::nullptr_t VisitAttrs = nullptr;

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -55,8 +55,11 @@ void ReflectionVTable::SHashReduce(const Object* self, SHashReducer reducer) con
 // In particular, when we traverse unordered_map, we should first sort
 // the entries by keys(or hash of keys) before traversing.
 
-class VarCountingSHashHandler : public SHashReducer::Handler {
+class SHashHandlerDefault::Impl {
  public:
+  explicit Impl(SHashHandlerDefault* parent) : parent_(parent) {}
+  virtual ~Impl() = default;
+
   /*! \brief Pending reduce tasks. */
   struct Task {
     /*!
@@ -81,15 +84,13 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
         : object(object), reduced_hash(reduced_hash), map_free_vars(map_free_vars) {}
   };
 
-  VarCountingSHashHandler() {}
-
-  void MarkGraphNode() final {
+  void MarkGraphNode() {
     // need to push to pending tasks in this case
     ICHECK(!allow_push_to_stack_ && !task_stack_.empty());
     task_stack_.back().graph_node_hash = true;
   }
 
-  bool LookupHashedValue(const ObjectRef& key, size_t* hash_value) final {
+  bool LookupHashedValue(const ObjectRef& key, size_t* hash_value) {
     auto it = hash_memo_.find(key);
     if (it != hash_memo_.end()) {
       hash_value[0] = it->second;
@@ -98,11 +99,11 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
     return false;
   }
 
-  void SHashReduceHashedValue(size_t hashed_value) final {
+  void SHashReduceHashedValue(size_t hashed_value) {
     pending_tasks_.emplace_back(Task(ObjectRef(nullptr), hashed_value, false));
   }
 
-  void SHashReduceFreeVar(const runtime::Object* var, bool map_free_vars) final {
+  void SHashReduceFreeVar(const runtime::Object* var, bool map_free_vars) {
     ICHECK(!hash_memo_.count(GetRef<ObjectRef>(var)));
     if (map_free_vars) {
       // use counter value.
@@ -115,7 +116,7 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
     }
   }
 
-  void SHashReduce(const ObjectRef& object, bool map_free_vars) final {
+  void SHashReduce(const ObjectRef& object, bool map_free_vars) {
     // Directly push the result
     // Note: it is still important to push the result to pendng tasks
     // so that the reduction order of hash values stays the same.
@@ -149,6 +150,11 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
     size_t ret = result_stack_.back();
     result_stack_.pop_back();
     return ret;
+  }
+
+  void DispatchSHash(const ObjectRef& object, bool map_free_vars) {
+    ICHECK(object.defined());
+    vtable_->SHashReduce(object.get(), SHashReducer(parent_, map_free_vars));
   }
 
  protected:
@@ -219,7 +225,7 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
           ICHECK_EQ(pending_tasks_.size(), 0U);
           allow_push_to_stack_ = false;
           // dispatch hash, reduce to the current slot.
-          this->DispatchSHash(entry.object, entry.map_free_vars);
+          parent_->DispatchSHash(entry.object, entry.map_free_vars);
           allow_push_to_stack_ = true;
           // Move pending tasks to the stack until the marked point.
           while (pending_tasks_.size() != 0) {
@@ -231,13 +237,9 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
     }
   }
 
-  // The default equal as registered in the structural equal vtable.
-  void DispatchSHash(const ObjectRef& object, bool map_free_vars) {
-    ICHECK(object.defined());
-    vtable_->SHashReduce(object.get(), SHashReducer(this, map_free_vars));
-  }
-
  private:
+  // The owner of this impl
+  SHashHandlerDefault* parent_;
   // free var counter.
   size_t free_var_counter_{0};
   // graph node counter.
@@ -256,14 +258,43 @@ class VarCountingSHashHandler : public SHashReducer::Handler {
   std::unordered_map<ObjectRef, size_t, ObjectPtrHash, ObjectPtrEqual> hash_memo_;
 };
 
+SHashHandlerDefault::SHashHandlerDefault() { impl = new Impl(this); }
+SHashHandlerDefault::~SHashHandlerDefault() { delete impl; }
+
+void SHashHandlerDefault::SHashReduceHashedValue(size_t hashed_value) {
+  return impl->SHashReduceHashedValue(hashed_value);
+}
+
+void SHashHandlerDefault::SHashReduce(const ObjectRef& key, bool map_free_vars) {
+  impl->SHashReduce(key, map_free_vars);
+}
+
+void SHashHandlerDefault::SHashReduceFreeVar(const runtime::Object* var, bool map_free_vars) {
+  impl->SHashReduceFreeVar(var, map_free_vars);
+}
+
+bool SHashHandlerDefault::LookupHashedValue(const ObjectRef& key, size_t* hashed_value) {
+  return impl->LookupHashedValue(key, hashed_value);
+}
+
+void SHashHandlerDefault::MarkGraphNode() { impl->MarkGraphNode(); }
+
+size_t SHashHandlerDefault::Hash(const ObjectRef& object, bool map_free_vars) {
+  return impl->Hash(object, map_free_vars);
+}
+
+void SHashHandlerDefault::DispatchSHash(const ObjectRef& key, bool map_free_vars) {
+  impl->DispatchSHash(key, map_free_vars);
+}
+
 TVM_REGISTER_GLOBAL("node.StructuralHash")
     .set_body_typed([](const ObjectRef& object, bool map_free_vars) -> int64_t {
-      size_t hashed_value = VarCountingSHashHandler().Hash(object, map_free_vars);
+      size_t hashed_value = SHashHandlerDefault().Hash(object, map_free_vars);
       return static_cast<int64_t>(hashed_value);
     });
 
 size_t StructuralHash::operator()(const ObjectRef& object) const {
-  return VarCountingSHashHandler().Hash(object, false);
+  return SHashHandlerDefault().Hash(object, false);
 }
 
 // SEQualReduce traits for runtime containers.

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -58,7 +58,6 @@ void ReflectionVTable::SHashReduce(const Object* self, SHashReducer reducer) con
 class SHashHandlerDefault::Impl {
  public:
   explicit Impl(SHashHandlerDefault* parent) : parent_(parent) {}
-  virtual ~Impl() = default;
 
   /*! \brief Pending reduce tasks. */
   struct Task {


### PR DESCRIPTION
When we use `StructuralEqual/Hash`, the actual equality testing / hashing work are deferred to `RemapVarSEqualHandler` and `VarCountingSHashHandler` class respectively, defined in `.cc` files. To customize equality / hash behavior, I want to be able to derive from these classes outside of `structural_equal.cc` or `structural_hash.cc`. This is the first step toward replacing my previous attempt https://github.com/apache/tvm/pull/12706 to allow ignoring NDArray raw data in `StructuralEqual/Hash`.

So I propose to expose them as the "default" handler, while still hiding their implementation details. This lets me define a custom hasher that ignores NDArray content simply by:

```
class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
 protected:
  void DispatchSHash(const ObjectRef& object, bool map_free_vars) override {
    ICHECK(object.defined());
    if (auto ndarray = object.as<runtime::NDArray::Container>()) {
      SHashReducer hash_reduce(this, map_free_vars);
      NDArrayHash(ndarray, &hash_reduce, false);
    } else {
      SHashHandlerDefault::DispatchSHash(object, map_free_vars);
    }
  }
};
```

cc @tqchen @junrushao 