### PR TITLE
[Hexagon] disable cache_write schedule type from sw pipeline test

### DIFF
--- a/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
+++ b/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
@@ -28,7 +28,10 @@ outer = tvm.testing.parameter(8, 16)
 inner = tvm.testing.parameter(64, 128)
 dtype = tvm.testing.parameter("uint8", "float16")
 scope = tvm.testing.parameter("global", "global.vtcm")
-sched = tvm.testing.parameter("cache_read", "cache_write", "cache_read_write")
+# TODO(Straw) Add back "cache_write" schedule type once we have upstreamed
+# buffer dependency analysis in InjectSoftwarePipeline pass
+# to insert approprite TIR "wait" attributes for this schedule
+sched = tvm.testing.parameter("cache_read", "cache_read_write")
 
 
 @tvm.testing.fixture


### PR DESCRIPTION
Disabling the "cache_write" schedule from this test as it is failing on device.  The root cause of the failure will be addressed with additional buffer dependency analysis in the InjectSoftwarePipeline pass to come in a subsequent PR.