### PR TITLE
[Hexagon] Async DMA pipelining test suite

### DIFF
--- a/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
+++ b/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
@@ -81,6 +81,7 @@ def evaluate(hexagon_session, sch, a, b, size_a, expected_output, use_async_copy
         number = 100
         repeat = 100
 
+
     timer = module.time_evaluator(
         "__tvm_main__", hexagon_session.device, number=number, repeat=repeat
     )
@@ -110,7 +111,6 @@ def expected_output(size_a, size_w, input_a, input_w):
                         input_w[x, i * 4 + r]
                     )
     return expected_output
-
 
 def get_single_dma_schedule(size_a, size_w):
     @T.prim_func
@@ -251,12 +251,6 @@ def print_results(test_key, runtimes):
     print()
 
 
-def print_excel_results(test_key, runtimes):
-    for runtime in runtimes.items():
-        test_key += f"{runtime[1]}, "
-    print(test_key)
-
-
 class TestMatMulVec:
     # Removed most of these to speedup CI.
     size_a = tvm.testing.parameter(
@@ -288,7 +282,9 @@ class TestMatMulVec:
             return
 
         sch = conv_approximation(size_a, size_w)
-        base_runtime = evaluate(hexagon_session, sch, input_a, input_w, size_a, expected_output)
+        base_runtime = evaluate(
+            hexagon_session, sch, input_a, input_w, size_a, expected_output
+        )
 
         sch = get_fake_conv_vtcm_schedule(size_a, size_w)
         base_vtcm_runtime = evaluate(
@@ -323,25 +319,12 @@ class TestMatMulVec:
         )
 
         sch = get_single_dma_schedule(size_a, size_w)
-        single_dma_runtime = evaluate(
-            hexagon_session, sch, input_a, input_w, size_a, expected_output
-        )
+        single_dma_runtime = evaluate(hexagon_session, sch, input_a, input_w, size_a, expected_output)
 
         transfer_mb = round((2 * size_a * 128 + size_w * 128) / 1e6, 2)
         complexity = round(size_a * size_w * (128 * 4) / 1e9, 3)
-        # print_results(
-        #     f"Test with A.size: {size_a * 128}, W.size: {size_w * 128}, computational complexity of {complexity} GOPs, and total memory transfer of {transfer_mb} MB...",
-        #     {
-        #         "without_vtcm": base_runtime,
-        #         "synchronous_dma": single_dma_runtime,
-        #         "base_vtcm": base_vtcm_runtime,
-        #         "async_dma_input": async_input_runtime,
-        #         "async_dma_output": async_output_runtime,
-        #         "async_dma_input_output": async_input_output_runtime,
-        #     },
-        # )
-        print_excel_results(
-            f"{size_a * 128}, {size_w * 128}, {complexity}, {transfer_mb}, ",
+        print_results(
+            f"Test with A.size: {size_a * 128}, W.size: {size_w * 128}, computational complexity of {complexity} GOPs, and total memory transfer of {transfer_mb} MB...",
             {
                 "without_vtcm": base_runtime,
                 "synchronous_dma": single_dma_runtime,

--- a/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
+++ b/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
@@ -19,6 +19,7 @@
 
 import numpy as np
 import tvm
+import pytest
 
 from tvm.script import tir as T
 from numpy.random import default_rng
@@ -108,6 +109,8 @@ def input_w(size_w):
 
 @tvm.testing.fixture
 def expected_output(size_a, size_w, input_a, input_w):
+    if tvm.testing.utils.IS_IN_CI and (size_a > 1024 or size_w > 1):
+        pytest.skip("Skipping test since it takes too long in CI.")
     expected_output = np.zeros((size_a, VRMPY_SIZE_INT32), dtype="int32")
     for n in range(size_a):
         for x in range(size_w):
@@ -272,10 +275,10 @@ class TestAsyncDMAPipeline:
     )
 
     size_w = tvm.testing.parameter(
-        1 * 1 * 32,
-        3 * 3 * 32,
-        7 * 7 * 32,
-        9 * 9 * 32,
+        1 * 1,
+        3 * 3,
+        7 * 7,
+        9 * 9,
     )
 
     @tvm.testing.requires_hexagon
@@ -290,8 +293,7 @@ class TestAsyncDMAPipeline:
     ):
 
         if tvm.testing.utils.IS_IN_CI and (size_a > 1024 or size_w > 1):
-            print("skipping test due to ci")
-            return
+            pytest.skip("Skipping test since it takes too long in CI.")
 
         sch = conv_approximation(size_a, size_w)
         base_runtime = evaluate(hexagon_session, sch, input_a, input_w, size_a, expected_output)

--- a/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
+++ b/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
@@ -1,0 +1,353 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Test different strategies for loading data into vtcm before running HVX workloads. """
+
+import numpy as np
+import tvm
+
+from tvm.script import tir as T
+from numpy.random import default_rng
+
+
+def conv_approximation(size_a, size_w):
+    @T.prim_func
+    def operator(a: T.handle, b: T.handle, c: T.handle) -> None:
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        A = T.match_buffer(a, [size_a, 128], dtype="uint8", align=128)
+        W = T.match_buffer(b, [size_w, 128], dtype="uint8", align=128)
+        C = T.match_buffer(c, [size_a, 32], dtype="int32", align=128)
+        for n, i in T.grid(size_a, size_w):
+            with T.block("C"):
+                vn, vi = T.axis.remap("SR", [n, i])
+                T.reads(A[vn, 0:128], W[vi, 0:128], C[vn, 0:32])
+                T.writes(C[vn, 0:32])
+                with T.init():
+                    for x in T.serial(32):
+                        C[vn, x] = 0
+                C[vn, T.ramp(0, 1, 32)] = T.call_llvm_intrin(
+                    T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpyubv.acc.128B"),
+                    T.uint32(3),
+                    C[vn, T.ramp(0, 1, 32)],
+                    T.reinterpret(A[vn, T.ramp(0, 1, 128)], dtype="int32x32"),
+                    T.reinterpret(W[vi, T.ramp(0, 1, 128)], dtype="int32x32"),
+                    dtype="int32x32",
+                )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.dma_wait",
+                0,  # QueueId
+                0,  # Wait for 0 in flight
+                dtype="int32",
+            )
+        )
+
+    return tvm.tir.Schedule(operator)
+
+
+def evaluate(hexagon_session, sch, a, b, size_a, expected_output, use_async_copy=0):
+    target_hexagon = tvm.target.hexagon("v68", link_params=True)
+    with tvm.transform.PassContext(config={"tir.use_async_copy": use_async_copy}):
+        func_tir = tvm.build(
+            sch.mod["main"], target=tvm.target.Target(target_hexagon, host=target_hexagon)
+        )
+    module = hexagon_session.load_module(func_tir)
+
+    a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device)
+    b_hexagon = tvm.runtime.ndarray.array(b, device=hexagon_session.device)
+    c_hexagon = tvm.runtime.ndarray.array(
+        np.zeros((size_a, 32), dtype="int32"), device=hexagon_session.device
+    )
+
+    if tvm.testing.utils.IS_IN_CI:
+        # These are reduced for CI
+        number = 1
+        repeat = 1
+    else:
+        number = 100
+        repeat = 100
+
+    timer = module.time_evaluator(
+        "__tvm_main__", hexagon_session.device, number=number, repeat=repeat
+    )
+    time = timer(a_hexagon, b_hexagon, c_hexagon)
+    tvm.testing.assert_allclose(c_hexagon.asnumpy(), expected_output)
+    return round(time.mean * 1000, 4)
+
+
+@tvm.testing.fixture
+def input_a(size_a):
+    return default_rng().integers(0, 8, (size_a, 128), dtype="uint8")
+
+
+@tvm.testing.fixture
+def input_w(size_w):
+    return default_rng().integers(0, 8, (size_w, 128), dtype="uint8")
+
+
+@tvm.testing.fixture
+def expected_output(size_a, size_w, input_a, input_w):
+    expected_output = np.zeros((size_a, 32), dtype="int32")
+    for n in range(size_a):
+        for x in range(size_w):
+            for i in range(32):
+                for r in range(4):
+                    expected_output[n, i] += np.uint32(input_a[n, i * 4 + r]) * np.uint32(
+                        input_w[x, i * 4 + r]
+                    )
+    return expected_output
+
+
+def get_single_dma_schedule(size_a, size_w):
+    @T.prim_func
+    def operator(a: T.handle, b: T.handle, c: T.handle) -> None:
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        A = T.match_buffer(a, [size_a, 128], dtype="uint8", align=128, mem_scope="global")
+        W = T.match_buffer(b, [size_w, 128], dtype="uint8", align=128, mem_scope="global")
+        C = T.match_buffer(c, [size_a, 32], dtype="int32", align=128, mem_scope="global")
+        A_global_vtcm = T.alloc_buffer(
+            [size_a, 128], dtype="uint8", align=128, mem_scope="global.vtcm"
+        )
+        W_global_vtcm = T.alloc_buffer(
+            [size_w, 128], dtype="uint8", align=128, mem_scope="global.vtcm"
+        )
+        C_global_vtcm = T.alloc_buffer(
+            [size_a, 32], dtype="int32", align=128, mem_scope="global.vtcm"
+        )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    A_global_vtcm.data,
+                    T.tvm_stack_make_shape(size_a, 128, dtype="handle"),
+                    0,
+                    2,
+                    A_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    A.data,
+                    T.tvm_stack_make_shape(size_a, 128, dtype="handle"),
+                    0,
+                    2,
+                    A.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size_a, dtype="int") * 128,
+                dtype="int32",
+            )
+        )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    W_global_vtcm.data,
+                    T.tvm_stack_make_shape(size_w, 128, dtype="handle"),
+                    0,
+                    2,
+                    W_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    W.data,
+                    T.tvm_stack_make_shape(size_w, 128, dtype="handle"),
+                    0,
+                    2,
+                    W.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size_w, dtype="int") * 128,
+                dtype="int32",
+            )
+        )
+        for n, i in T.grid(size_a, size_w):
+            with T.block("C"):
+                vn, vi = T.axis.remap("SR", [n, i])
+                T.reads(A_global_vtcm[vn, 0:128], W_global_vtcm[vi, 0:128], C_global_vtcm[vn, 0:32])
+                T.writes(C_global_vtcm[vn, 0:32])
+                with T.init():
+                    for x in T.serial(32):
+                        C_global_vtcm[vn, x] = 0
+                C_global_vtcm[vn, T.ramp(0, 1, 32)] += T.call_llvm_intrin(
+                    T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpyubv.128B"),
+                    T.uint32(2),
+                    T.reinterpret(A_global_vtcm[vn, T.ramp(0, 1, 128)], dtype="int32x32"),
+                    T.reinterpret(W_global_vtcm[vi, T.ramp(0, 1, 128)], dtype="int32x32"),
+                    dtype="int32x32",
+                )
+        T.evaluate(
+            T.tvm_call_packed(
+                "device_api.hexagon.mem_copy_DLTensor",
+                T.tvm_stack_make_array(
+                    C.data,
+                    T.tvm_stack_make_shape(size_a, 128, dtype="handle"),
+                    0,
+                    2,
+                    C.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.tvm_stack_make_array(
+                    C_global_vtcm.data,
+                    T.tvm_stack_make_shape(size_a, 128, dtype="handle"),
+                    0,
+                    2,
+                    C_global_vtcm.dtype,
+                    0,
+                    dtype="handle",
+                ),
+                T.cast(size_a, dtype="int") * 128,
+                dtype="int32",
+            )
+        )
+
+    sch = tvm.tir.Schedule(operator)
+
+    return sch
+
+
+def get_fake_conv_vtcm_schedule(size_a, size_w, blocks=2):
+    sch = conv_approximation(size_a, size_w)
+
+    compute_block = sch.get_block("C")
+    sch.cache_read(compute_block, 1, "global.vtcm")
+
+    n = sch.get_loops(compute_block)[0]
+    no, _ = sch.split(n, [blocks, None])
+
+    cache_read_block_a = sch.cache_read(compute_block, 0, "global.vtcm")
+    sch.compute_at(cache_read_block_a, no)
+    sch.fuse(*sch.get_loops(cache_read_block_a)[1:])
+
+    cache_read_block_c = sch.cache_write(compute_block, 0, "global.vtcm")
+    sch.reverse_compute_at(cache_read_block_c, no)
+    sch.fuse(*sch.get_loops(cache_read_block_c)[1:])
+
+    return sch
+
+
+def print_results(test_key, runtimes):
+    print(test_key)
+    for runtime in runtimes.items():
+        print("-{} took {} ms".format(runtime[0], runtime[1]))
+    print()
+
+
+def print_excel_results(test_key, runtimes):
+    for runtime in runtimes.items():
+        test_key += f"{runtime[1]}, "
+    print(test_key)
+
+
+class TestMatMulVec:
+    # Removed most of these to speedup CI.
+    size_a = tvm.testing.parameter(
+        1024,
+        64 * 64,
+        128 * 128,
+    )
+
+    size_w = tvm.testing.parameter(
+        1 * 1,
+        3 * 3,
+        7 * 7,
+        9 * 9,
+    )
+
+    @tvm.testing.requires_hexagon
+    def test_loading_vtcm_for_vrmpy(
+        self,
+        hexagon_session,
+        size_a,
+        size_w,
+        input_a,
+        input_w,
+        expected_output,
+    ):
+
+        if tvm.testing.utils.IS_IN_CI and (size_a > 1024 or size_w > 1):
+            print("skipping test due to ci")
+            return
+
+        sch = conv_approximation(size_a, size_w)
+        base_runtime = evaluate(hexagon_session, sch, input_a, input_w, size_a, expected_output)
+
+        sch = get_fake_conv_vtcm_schedule(size_a, size_w)
+        base_vtcm_runtime = evaluate(
+            hexagon_session, sch, input_a, input_w, size_a, expected_output, use_async_copy=1
+        )
+
+        sch = get_fake_conv_vtcm_schedule(size_a, size_w)
+        n = sch.get_loops(sch.get_block("C"))[0]
+        sch.annotate(n, "software_pipeline_stage", [0, 1, 2])
+        sch.annotate(n, "software_pipeline_order", [0, 1, 2])
+        sch.annotate(n, "software_pipeline_async_stages", [0])
+        async_input_runtime = evaluate(
+            hexagon_session, sch, input_a, input_w, size_a, expected_output, use_async_copy=1
+        )
+
+        sch = get_fake_conv_vtcm_schedule(size_a, size_w)
+        n = sch.get_loops(sch.get_block("C"))[0]
+        sch.annotate(n, "software_pipeline_stage", [0, 1, 2])
+        sch.annotate(n, "software_pipeline_order", [0, 1, 2])
+        sch.annotate(n, "software_pipeline_async_stages", [0, 2])
+        async_input_output_runtime = evaluate(
+            hexagon_session, sch, input_a, input_w, size_a, expected_output, use_async_copy=1
+        )
+
+        sch = get_fake_conv_vtcm_schedule(size_a, size_w)
+        n = sch.get_loops(sch.get_block("C"))[0]
+        sch.annotate(n, "software_pipeline_stage", [0, 1, 2])
+        sch.annotate(n, "software_pipeline_order", [0, 1, 2])
+        sch.annotate(n, "software_pipeline_async_stages", [2])
+        async_output_runtime = evaluate(
+            hexagon_session, sch, input_a, input_w, size_a, expected_output, use_async_copy=1
+        )
+
+        sch = get_single_dma_schedule(size_a, size_w)
+        single_dma_runtime = evaluate(
+            hexagon_session, sch, input_a, input_w, size_a, expected_output
+        )
+
+        transfer_mb = round((2 * size_a * 128 + size_w * 128) / 1e6, 2)
+        complexity = round(size_a * size_w * (128 * 4) / 1e9, 3)
+        # print_results(
+        #     f"Test with A.size: {size_a * 128}, W.size: {size_w * 128}, computational complexity of {complexity} GOPs, and total memory transfer of {transfer_mb} MB...",
+        #     {
+        #         "without_vtcm": base_runtime,
+        #         "synchronous_dma": single_dma_runtime,
+        #         "base_vtcm": base_vtcm_runtime,
+        #         "async_dma_input": async_input_runtime,
+        #         "async_dma_output": async_output_runtime,
+        #         "async_dma_input_output": async_input_output_runtime,
+        #     },
+        # )
+        print_excel_results(
+            f"{size_a * 128}, {size_w * 128}, {complexity}, {transfer_mb}, ",
+            {
+                "without_vtcm": base_runtime,
+                "synchronous_dma": single_dma_runtime,
+                "base_vtcm": base_vtcm_runtime,
+                "async_dma_input": async_input_runtime,
+                "async_dma_output": async_output_runtime,
+                "async_dma_input_output": async_input_output_runtime,
+            },
+        )


### PR DESCRIPTION
…ing on hexagon.

The purpose of this test is to show how to create a pipeline that utilizes async dma copies to vtcm for performance speedup. It compares performance results between several different schedules and should serve as a good starting point for others wishing to take advantage of the new features. 


Approximated Activation Shape | Approximated Weight Shape | Approximated complexity (GOPS) | Total Memory Transferred (MB) | N, N, N (ms) | S, S, S (ms) | B, B, B (ms) | A, B, B (ms) | B, B, A (ms) | A, B, A (ms) | Async DMA Speedup (Compared to N, N, N)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
(1, 32, 32, 128) | (1, 1, 1, 128) | 0.001 | 0.26 | 0.0547 | 0.0715 | 0.6492 | 0.6172 | 0.1398 | 0.1033 | 0.53x
(1, 32, 32, 128) | (1, 3, 3, 128) | 0.005 | 0.26 | 0.0678 | 0.085 | 0.6636 | 0.6328 | 0.1526 | 0.1201 | 0.56x
(1, 32, 32, 128) | (1, 7, 7, 128) | 0.026 | 0.27 | 0.1264 | 0.1463 | 0.7283 | 0.6952 | 0.2178 | 0.1843 | 0.69x
(1, 32, 32, 128) | (1, 9, 9, 128) | 0.042 | 0.27 | 0.1689 | 0.1954 | 0.7742 | 0.7426 | 0.2626 | 0.2317 | 0.73x
(1, 64, 64, 128) | (1, 1, 1, 128) | 0.002 | 1.05 | 0.2237 | 0.2812 | 2.6897 | 2.3175 | 0.4083 | 0.2715 | 0.82x
(1, 64, 64, 128) | (1, 3, 3, 128) | 0.019 | 1.05 | 0.375 | 0.3362 | 2.7396 | 2.3716 | 0.4621 | 0.3262 | 1.15x
(1, 64, 64, 128) | (1, 7, 7, 128) | 0.103 | 1.05 | 0.6882 | 0.6202 | 3.008 | 2.6313 | 0.7207 | 0.5853 | 1.18x
(1, 64, 64, 128) | (1, 9, 9, 128) | 0.17 | 1.06 | 0.879 | 0.8318 | 3.1913 | 2.8071 | 0.8981 | 0.7623 | 1.15x
(1, 128, 128, 128) | (1, 1, 1, 128) | 0.008 | 4.19 | 1.0594 | 1.4324 | 11.6076 | 9.2136 | 2.7771 | 0.9508 | 1.11x
(1, 128, 128, 128) | (1, 3, 3, 128) | 0.075 | 4.2 | 2.2994 | 2.4282 | 11.9346 | 9.4362 | 3.0186 | 1.1717 | 1.96x
(1, 128, 128, 128) | (1, 7, 7, 128) | 0.411 | 4.2 | 5.0044 | 5.1789 | 12.9821 | 10.4726 | 3.8554 | 2.2011 | 2.27x
(1, 128, 128, 128) | (1, 9, 9, 128) | 0.679 | 4.2 | 7.6593 | 7.0915 | 13.7597 | 11.1763 | 4.7059 | 2.9003 | 2.64x

Each column specifies the data copy method used for the Activation, Weight, and Output vectors respectively with the following options. 
N = No copying to VTCM
S = Synchronous DMA copies to VTCM 
B = Basic/Naive copies to VTCM
A = Asynchronous DMA copies to VTCM 

For example B, B, A uses Naive copies for the Activation and Weight input vectors and uses Async DMA copies for the output vector (VTCM -> DDR)

cc @adstraw @tmoreau89 