### PR TITLE
[MetaSchedule][UX] Support Interactive Performance Table Printing in Notebook

### DIFF
--- a/include/tvm/meta_schedule/task_scheduler.h
+++ b/include/tvm/meta_schedule/task_scheduler.h
@@ -196,8 +196,8 @@ class TaskSchedulerNode : public runtime::Object {
    * \param task_id The task id to be checked.
    */
   void TouchTask(int task_id);
-  /*! \brief Returns a human-readable string of the tuning statistics. */
-  std::string TuningStatistics() const;
+  /*! \brief Print out a human-readable format of the tuning statistics. */
+  void PrintTuningStatistics();
 
   static constexpr const char* _type_key = "meta_schedule.TaskScheduler";
   TVM_DECLARE_BASE_OBJECT_INFO(TaskSchedulerNode, Object);

--- a/python/tvm/meta_schedule/logging.py
+++ b/python/tvm/meta_schedule/logging.py
@@ -62,7 +62,7 @@ def get_logging_func(logger: Logger) -> Optional[Callable[[int, str, int, str], 
         # logging.FATAL not included
     }
 
-    def logging_func(level: int, file: str, lineo: int, msg: str):
+    def logging_func(level: int, filename: str, lineo: int, msg: str):
         if level < 0:  # clear the output in notebook / console
             from IPython.display import (  # type: ignore # pylint: disable=import-outside-toplevel
                 clear_output,
@@ -70,7 +70,7 @@ def get_logging_func(logger: Logger) -> Optional[Callable[[int, str, int, str], 
 
             clear_output(wait=True)
         else:
-            level2log[level](f"[{os.path.basename(file)}:{lineo}] " + msg)
+            level2log[level](f"[{os.path.basename(filename)}:{lineo}] " + msg)
 
     return logging_func
 

--- a/python/tvm/meta_schedule/logging.py
+++ b/python/tvm/meta_schedule/logging.py
@@ -93,11 +93,11 @@ def create_loggers(
 
     global_logger_name = "tvm.meta_schedule"
     global_logger = logging.getLogger(global_logger_name)
+    if global_logger.level is logging.NOTSET:
+        global_logger.setLevel(logging.DEBUG)
     console_logging_level = logging._levelToName[  # pylint: disable=protected-access
         global_logger.level
     ]
-    if global_logger.level is logging.NOTSET:
-        global_logger.setLevel(logging.DEBUG)
 
     config["loggers"].setdefault(
         global_logger_name,
@@ -111,7 +111,7 @@ def create_loggers(
     config["loggers"].setdefault(
         "{logger_name}",
         {
-            "level": "INFO",
+            "level": "DEBUG",
             "handlers": [
                 "{logger_name}.file",
             ],

--- a/python/tvm/meta_schedule/logging.py
+++ b/python/tvm/meta_schedule/logging.py
@@ -62,7 +62,7 @@ def get_logging_func(logger: Logger) -> Optional[Callable[[int, str], None]]:
         # logging.FATAL not included
     }
 
-    def logging_func(level: int, msg: str):
+    def logging_func(level: int, file: str, lineo: int, msg: str):
         if level < 0:  # clear the output in notebook / console
             from IPython.display import (  # type: ignore # pylint: disable=import-outside-toplevel
                 clear_output,
@@ -70,7 +70,7 @@ def get_logging_func(logger: Logger) -> Optional[Callable[[int, str], None]]:
 
             clear_output(wait=True)
         else:
-            level2log[level](msg)
+            level2log[level](f"[{os.path.basename(file)}:{lineo}] " + msg)
 
     return logging_func
 

--- a/python/tvm/meta_schedule/logging.py
+++ b/python/tvm/meta_schedule/logging.py
@@ -39,7 +39,7 @@ def get_logger(name: str) -> Logger:
     return logging.getLogger(name)
 
 
-def get_logging_func(logger: Logger) -> Optional[Callable[[int, str], None]]:
+def get_logging_func(logger: Logger) -> Optional[Callable[[int, str, int, str], None]]:
     """Get the logging function.
 
     Parameters

--- a/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
+++ b/python/tvm/meta_schedule/task_scheduler/task_scheduler.py
@@ -163,15 +163,9 @@ class TaskScheduler(Object):
         """
         _ffi_api.TaskSchedulerTouchTask(self, task_id)  # type: ignore # pylint: disable=no-member
 
-    def tuning_statistics(self) -> str:
-        """Returns a human-readable string of the tuning statistics.
-
-        Returns
-        -------
-        tuning_statistics : str
-            The tuning statistics.
-        """
-        return _ffi_api.TaskSchedulerTuningStatistics(self)  # type: ignore # pylint: disable=no-member
+    def print_tuning_statistics(self) -> None:
+        """Print out a human-readable format of the tuning statistics."""
+        return _ffi_api.TaskSchedulerPrintTuningStatistics(self)  # type: ignore # pylint: disable=no-member
 
     @staticmethod
     def create(  # pylint: disable=keyword-arg-before-vararg

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -211,8 +211,8 @@ def print_interactive_table(data: str) -> None:
     data : str
         The serialized performance table from MetaSchedule table printer.
     """
-    import pandas as pd  # pylint: disable=import-outside-toplevel
-    from IPython.display import display  # pylint: disable=import-outside-toplevel
+    import pandas as pd  # type: ignore # pylint: disable=import-outside-toplevel
+    from IPython.display import display  # type: ignore # pylint: disable=import-outside-toplevel
 
     pd.set_option("display.max_rows", None)
     pd.set_option("display.max_colwidth", None)

--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -188,11 +188,43 @@ def cpu_count(logical: bool = True) -> int:
 
 
 @register_func("meta_schedule.using_ipython")
-def _using_ipython():
+def _using_ipython() -> bool:
+    """Return whether the current process is running in an IPython shell.
+
+    Returns
+    -------
+    result : bool
+        Whether the current process is running in an IPython shell.
+    """
     try:
         return get_ipython().__class__.__name__ == "ZMQInteractiveShell"  # type: ignore
     except NameError:
         return False
+
+
+@register_func("meta_schedule.print_interactive_table")
+def print_interactive_table(data: str) -> None:
+    """Print the dataframe interactive table in notebook.
+
+    Parameters
+    ----------
+    data : str
+        The serialized performance table from MetaSchedule table printer.
+    """
+    import pandas as pd  # pylint: disable=import-outside-toplevel
+    from IPython.display import display  # pylint: disable=import-outside-toplevel
+
+    pd.set_option("display.max_rows", None)
+    pd.set_option("display.max_colwidth", None)
+    parsed = [
+        x.split("|")[1:] for x in list(filter(lambda x: set(x) != {"-"}, data.strip().split("\n")))
+    ]
+    display(
+        pd.DataFrame(
+            parsed[1:],
+            columns=parsed[0],
+        )
+    )
 
 
 def get_global_func_with_default_on_worker(

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -60,7 +60,8 @@ class GradientBasedNode final : public TaskSchedulerNode {
     int n_tasks = this->tasks_.size();
     // Step 1. Check if it's in round robin mode.
     if (round_robin_rounds_ == 0) {
-      TVM_PY_LOG(INFO, this->logger) << "\n" << this->TuningStatistics();
+      TVM_PY_LOG_CLEAR_SCREEN(this->logger);
+      this->PrintTuningStatistics();
     }
     if (round_robin_rounds_ < n_tasks) {
       return round_robin_rounds_++;

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -307,8 +307,12 @@ std::string TaskSchedulerNode::TuningStatistics() const {
     }
   }
   p.Separator();
-  os << p.AsStr()                                  //
-     << "\nTotal trials: " << total_trials         //
+  if (using_ipython()) {
+    print_interactive_table(p.AsStr());
+  } else {
+    os << p.AsStr();
+  }
+  os << "\nTotal trials: " << total_trials         //
      << "\nTotal latency (us): " << total_latency  //
      << "\n";
   return os.str();

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -312,7 +312,7 @@ void TaskSchedulerNode::PrintTuningStatistics() {
 
   if (using_ipython()) {
     print_interactive_table(p.AsStr());
-    std::cout << os.str() << std::endl;
+    std::cout << os.str() << std::endl << std::flush;
     TVM_PY_LOG(DEBUG, this->logger) << "\n" << p.AsStr() << os.str();
   } else {
     TVM_PY_LOG(INFO, this->logger) << "\n" << p.AsStr() << os.str();

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -43,6 +43,7 @@
 #include <tvm/tir/transform.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <string>
 #include <utility>
 #include <vector>
@@ -85,7 +86,7 @@ class PyLogMessage {
   explicit PyLogMessage(const char* file, int lineno, PackedFunc logger, Level logging_level)
       : file_(file), lineno_(lineno), logger_(logger), logging_level_(logging_level) {
     if (this->logger_ != nullptr) {
-      stream_ << "" << file_ << ":" << lineno_ << " ";
+      stream_ << "[" << std::filesystem::path(file_).filename().string() << ":" << lineno_ << "] ";
     }
   }
 

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -132,6 +132,18 @@ inline bool using_ipython() {
 }
 
 /*!
+ * \brief Print out the performance table interactively in jupyter notebook.
+ * \param str The serialized performance table.
+ */
+inline void print_interactive_table(const String& data) {
+  const auto* f_print_interactive_table =
+      runtime::Registry::Get("meta_schedule.print_interactive_table");
+  ICHECK(f_print_interactive_table->defined())
+      << "Cannot find print_interactive_table function in registry.";
+  (*f_print_interactive_table)(data);
+}
+
+/*!
  * \brief A helper function to clear logging output for ipython kernel and console.
  * \param file The file name.
  * \param lineno The line number.

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -82,32 +82,32 @@ class PyLogMessage {
     // FATAL not included
   };
 
-  explicit PyLogMessage(const char* file, int lineno, PackedFunc logger, Level logging_level)
-      : file_(file), lineno_(lineno), logger_(logger), logging_level_(logging_level) {}
+  explicit PyLogMessage(const char* filename, int lineno, PackedFunc logger, Level logging_level)
+      : filename_(filename), lineno_(lineno), logger_(logger), logging_level_(logging_level) {}
 
   TVM_NO_INLINE ~PyLogMessage() {
     ICHECK(logging_level_ != Level::CLEAR)
         << "Cannot use CLEAR as logging level in TVM_PY_LOG, please use TVM_PY_LOG_CLEAR_SCREEN.";
     if (this->logger_ != nullptr) {
-      logger_(static_cast<int>(logging_level_), std::string(file_), lineno_, stream_.str());
+      logger_(static_cast<int>(logging_level_), std::string(filename_), lineno_, stream_.str());
     } else {
       if (logging_level_ == Level::INFO) {
-        runtime::detail::LogMessage(file_, lineno_).stream() << stream_.str();
+        runtime::detail::LogMessage(filename_, lineno_).stream() << stream_.str();
       } else if (logging_level_ == Level::WARNING) {
-        runtime::detail::LogMessage(file_, lineno_).stream() << "Warning: " << stream_.str();
+        runtime::detail::LogMessage(filename_, lineno_).stream() << "Warning: " << stream_.str();
       } else if (logging_level_ == Level::ERROR) {
-        runtime::detail::LogMessage(file_, lineno_).stream() << "Error: " << stream_.str();
+        runtime::detail::LogMessage(filename_, lineno_).stream() << "Error: " << stream_.str();
       } else if (logging_level_ == Level::DEBUG) {
-        runtime::detail::LogMessage(file_, lineno_).stream() << "Debug: " << stream_.str();
+        runtime::detail::LogMessage(filename_, lineno_).stream() << "Debug: " << stream_.str();
       } else {
-        runtime::detail::LogFatal(file_, lineno_).stream() << stream_.str();
+        runtime::detail::LogFatal(filename_, lineno_).stream() << stream_.str();
       }
     }
   }
   std::ostringstream& stream() { return stream_; }
 
  private:
-  const char* file_;
+  const char* filename_;
   int lineno_;
   std::ostringstream stream_;
   PackedFunc logger_;


### PR DESCRIPTION
This PR further addes interactive table printing functionality following #12866, now performance table are print in dataframe style if running in jupyter notebook. Sample notebook see [here](https://gist.github.com/zxybazh/f201698324c8ebd0beb10365738dd327) 
![image](https://user-images.githubusercontent.com/3203174/194440924-2233ccce-d806-42c7-8ceb-fe362b2f3146.png)

CC @junrushao
