### PR TITLE
[ci] Re-enable roofline test

### DIFF
--- a/tests/python/unittest/test_roofline.py
+++ b/tests/python/unittest/test_roofline.py
@@ -35,7 +35,6 @@ from tvm.script import tir as T
 
 
 @tvm.testing.parametrize_targets("llvm", "cuda")
-@pytest.mark.skip(reason="See https://github.com/apache/tvm/issues/12955")
 def test_estimate_peak_flops(target, dev):
     server = rpc.Server(key="roofline_flops")
     remote = rpc.connect("127.0.0.1", server.port, key="roofline_flops")


### PR DESCRIPTION
After #12959, this re-enables the test disabled in #12955 to get a
backtrace next time it fails.