### PR TITLE
[Hexagon] fix bug with async dma queue id tracking

### DIFF
--- a/src/tir/transforms/lower_async_dma.cc
+++ b/src/tir/transforms/lower_async_dma.cc
@@ -94,9 +94,6 @@ class AsyncDMALowerer : public StmtExprMutator {
       ICHECK(queue_id_node);
       int queue_id = queue_id_node->value;
 
-      // save queue ID for inspection in `wait` transform
-      queue_ids.insert(queue_id);
-
       // walk the graph to verify this is a mem copy ...
       // 1) async_commit_queue_scope contains async_scope
       auto async_scope = op->body.as<AttrStmtNode>();
@@ -160,6 +157,10 @@ class AsyncDMALowerer : public StmtExprMutator {
         arith::Analyzer analyzer;
         return analyzer.Simplify(Substitute(std::move(expr), loop_var_remap));
       });
+
+      // now that we are about to perform the `copy` transform
+      // save queue ID for inspection in `wait` transform
+      queue_ids.insert(queue_id);
 
       return Evaluate(Call(DataType::Int(32), builtin::dma_copy(),
                            {queue_id,


### PR DESCRIPTION
The `LowerAsyncDMA` pass is designed to replace TIR `async_wait_queue_scope` attributes only if it has already relaced a TIR `async_commit_queue_scope` attribute with memory copy semantics on the same queue.  Fixing a bug where the queue ID is saved in the "commit" transform regardless of whether a transformation takes place.  Meaning, the "wait" transform, at present, would operate on all queues.