### PR TITLE
[FIX,LOWERING] Add attrs from Relay Functions to PrimFuncs in Metaschedule Lowering

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -528,6 +528,9 @@ class ScheduleBuilder : public ExprVisitor {
             ICHECK_EQ(mod->functions.size(), 1);
             mod = tir::transform::RemoveWeightLayoutRewriteBlock()(std::move(mod));
             prim_func = Downcast<PrimFunc>(mod->Lookup("main"));
+            // Need to copy attrs from relay function over to prim func. Most notably the structural
+            // hash.
+            prim_func = WithAttrs(prim_func, relay_func->attrs->dict);
           } else {
             int dispatch = backend::UseMetaScheduleDispatch();
             // (dispatch & 2): controls whether to print TVMScript for missing TIR


### PR DESCRIPTION
Attrs were not propogated from Relay functions to the corresponding PrimFunc when lowering with MetaSchedule enabled. These attrs are not seperately copied in the MetaSchedule lowering flow.

@junrushao 