### PR TITLE
[Conda] Specify python version in build-environment

### DIFF
--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -25,6 +25,7 @@ channels:
 
 # The packages to install to the environment
 dependencies:
+  - python=3.7 # or 3.8. See https://github.com/apache/tvm/issues/8577 for more details on >= 3.9
   - conda-build
   - git
   - llvmdev >=11


### PR DESCRIPTION
The current [build-environment.yaml](https://github.com/apache/tvm/blob/main/conda/build-environment.yaml) doesn't specify the python version for `tvm-build` conda environment and as a result, any python version might be selected depending on the available base conda. In my case, the base conda is 3.10 so tvm won't work given [tvm is unsupported for python >= 3.9](https://github.com/apache/tvm/issues/8577).

To validate run on `tvm-build` env 

```
conda env update -f conda/build-environment.yaml
```
