### PR TITLE
[TIR][FIX] Fix crash when using 'if' without 'else' in TVMScript

### DIFF
--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -148,7 +148,11 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
 
   TResult VisitStmt_(const IfThenElseNode* branch) override {
     TResult cond = VisitExpr(branch->condition);
-    cond += VisitStmt(branch->then_case).MaxWith(VisitStmt(branch->else_case));
+    if (branch->else_case.defined()) {
+      cond += VisitStmt(branch->then_case).MaxWith(VisitStmt(branch->else_case));
+    } else {
+      cond += VisitStmt(branch->then_case);
+    }
     return cond;
   }
 

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -62,5 +62,20 @@ def test_flops_with_let():
     assert flops == 8
 
 
+@T.prim_func
+def flops_with_if(a: T.Buffer[16, "float32"], b: T.Buffer[16, "float32"]):
+    for i in range(16):
+        if i % 2 == 0:
+            a[i] = b[i]
+        else:
+            if i % 3 == 0:
+                a[i] = b[i - 1] + b[i - 2]
+
+
+def test_flops_with_if():
+    flops = estimate_tir_flops(IRModule({"main": flops_with_if}))
+    assert flops == 16
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This commit fix the tvm's crash during auto-tune when having a 'if' statement which doesn't have a 'else' part in TVMScript.
It's cause in tvm's tir processing, in `VisitStmt_()` for IfThenElseNode its trying to visit the 'else' part (in TVMScript) whether it is exist.
So in this commit, an if logic is added in `VisitStmt_()` for IfThenElseNode, it will not visit the 'else' part if it is not exist.