### PR TITLE
[TEST] Fix the broken VNNI MetaSchedule test

### DIFF
--- a/tests/python/contrib/test_hexagon/test_models.py
+++ b/tests/python/contrib/test_hexagon/test_models.py
@@ -51,7 +51,7 @@ def test_mobilenet(hexagon_session: Session):
 
     data_in = np.random.rand(1, 3, 224, 224).astype(dtype=dtype)
 
-    input_name = "input"
+    input_name = "data"
     shape_dict = {input_name: data_in.shape}
     relay_mod, params = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
     inputs = {input_name: data_in}
@@ -98,7 +98,7 @@ def test_mobilenet_aot(hexagon_session: Session, aot_host_target, aot_target, en
 
     data_in = np.random.rand(1, 3, 224, 224).astype(dtype=dtype)
 
-    input_name = "input"
+    input_name = "data"
     shape_dict = {input_name: data_in.shape}
     relay_mod, params = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
     inputs = {input_name: data_in}

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -283,10 +283,10 @@ def test_dp4a_dense():
     _test_dense("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")
     # Uncomment to test on vulkan or rocm target
     # _test_dense(
-    #     "int8", sch_rules_for_dp4a, postprocs_for_dp4a, "vulkan -from_device=0"
+    #     "int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "vulkan -from_device=0"
     # )
     # _test_dense(
-    #     "int8", sch_rules_for_sdot4, postprocs_for_dp4a, "rocm"
+    #     "int8", SCH_RULES_FOR_SDOT4, POSTPROCS_FOR_DP4A, "rocm"
     # )
 
 
@@ -303,10 +303,10 @@ def test_dp4a_conv2d():
     _test_conv2d("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")
     # Uncomment to test on vulkan or rocm target
     # _test_conv2d(
-    #     "int8", sch_rules_for_dp4a, postprocs_for_dp4a, "vulkan -from_device=0"
+    #     "int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "vulkan -from_device=0"
     # )
     # _test_conv2d(
-    #     "int8", sch_rules_for_sdot4, postprocs_for_dp4a, "rocm"
+    #     "int8", SCH_RULES_FOR_SDOT4, POSTPROCS_FOR_DP4A, "rocm"
     # )
 
 
@@ -342,16 +342,16 @@ def test_dp4a_bert_int8():
     #     params,
     #     input_info,
     #     "vulkan -from_device=0",
-    #     sch_rules_for_dp4a,
-    #     postprocs_for_dp4a,
+    #     SCH_RULES_FOR_DP4A,
+    #     POSTPROCS_FOR_DP4A,
     # )
     # _test_bert_int8(
     #     relay_mod,
     #     params,
     #     input_info,
     #     "rocm",
-    #     sch_rules_for_sdot4,
-    #     postprocs_for_dp4a,
+    #     SCH_RULES_FOR_SDOT4
+    #     POSTPROCS_FOR_DP4A,
     # )
 
 

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -277,7 +277,7 @@ def test_vnni_dense():
     )
 
 
-@pytest.mark.skip("Only tested locally on sm_86 (for cuda) which is not supported by CI")
+@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Only tested locally on sm_86")
 @tvm.testing.requires_gpu
 def test_dp4a_dense():
     _test_dense("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")
@@ -297,7 +297,7 @@ def test_vnni_conv2d():
     )
 
 
-@pytest.mark.skip("Only tested locally on sm_86 (for cuda) which is not supported by CI")
+@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Only tested locally on sm_86")
 @tvm.testing.requires_gpu
 def test_dp4a_conv2d():
     _test_conv2d("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -297,8 +297,8 @@ def test_vnni_conv2d():
     )
 
 
-@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Only tested locally on sm_86")
 @tvm.testing.requires_gpu
+@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Only tested locally on sm_86")
 def test_dp4a_conv2d():
     _test_conv2d("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")
     # Uncomment to test on vulkan or rocm target

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -277,7 +277,7 @@ def test_vnni_dense():
     )
 
 
-@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Only tested locally on sm_86")
+@pytest.mark.skip("Only tested locally on sm_86 (for cuda) which is not supported by CI")
 @tvm.testing.requires_gpu
 def test_dp4a_dense():
     _test_dense("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")
@@ -297,8 +297,8 @@ def test_vnni_conv2d():
     )
 
 
+@pytest.mark.skip("Only tested locally on sm_86 (for cuda) which is not supported by CI")
 @tvm.testing.requires_gpu
-@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Only tested locally on sm_86")
 def test_dp4a_conv2d():
     _test_conv2d("int8", SCH_RULES_FOR_DP4A, POSTPROCS_FOR_DP4A, "nvidia/geforce-rtx-3070")
     # Uncomment to test on vulkan or rocm target


### PR DESCRIPTION
Fix the VNNI test broken by https://github.com/apache/tvm/pull/12895

And I've just ran rocm and vulkan dp4a auto tensorization tests locally and confirmed that they still worked.

@junrushao 