### PR TITLE
[CI] Update Docker Image tag to 20221013-060115-61c9742ea

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,16 +49,16 @@
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:20220925-060158-71f25b3d6'
-ci_gpu = 'tlcpack/ci-gpu:20220925-060158-71f25b3d6'
-ci_cpu = 'tlcpack/ci-cpu:20220925-060158-71f25b3d6'
-ci_minimal = 'tlcpack/ci-minimal:20220925-060158-71f25b3d6'
-ci_wasm = 'tlcpack/ci-wasm:20220925-060158-71f25b3d6'
-ci_i386 = 'tlcpack/ci-i386:20220925-060158-71f25b3d6'
-ci_cortexm = 'tlcpack/ci-cortexm:20220925-060158-71f25b3d6'
-ci_arm = 'tlcpack/ci-arm:20220925-060158-71f25b3d6'
-ci_hexagon = 'tlcpack/ci-hexagon:20220925-060158-71f25b3d6'
-ci_riscv = 'tlcpack/ci-riscv:20220925-060158-71f25b3d6'
+ci_lint = 'tlcpack/ci-lint:20221013-060115-61c9742ea'
+ci_gpu = 'tlcpack/ci-gpu:20221013-060115-61c9742ea'
+ci_cpu = 'tlcpack/ci-cpu:20221013-060115-61c9742ea'
+ci_minimal = 'tlcpack/ci-minimal:20221013-060115-61c9742ea'
+ci_wasm = 'tlcpack/ci-wasm:20221013-060115-61c9742ea'
+ci_i386 = 'tlcpack/ci-i386:20221013-060115-61c9742ea'
+ci_cortexm = 'tlcpack/ci-cortexm:20221013-060115-61c9742ea'
+ci_arm = 'tlcpack/ci-arm:20221013-060115-61c9742ea'
+ci_hexagon = 'tlcpack/ci-hexagon:20221013-060115-61c9742ea'
+ci_riscv = 'tlcpack/ci-riscv:20221013-060115-61c9742ea'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -51,16 +51,16 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 {% import 'ci/jenkins/macros.j2' as m with context -%}
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
-ci_lint = 'tlcpack/ci-lint:20220925-060158-71f25b3d6'
-ci_gpu = 'tlcpack/ci-gpu:20220925-060158-71f25b3d6'
-ci_cpu = 'tlcpack/ci-cpu:20220925-060158-71f25b3d6'
-ci_minimal = 'tlcpack/ci-minimal:20220925-060158-71f25b3d6'
-ci_wasm = 'tlcpack/ci-wasm:20220925-060158-71f25b3d6'
-ci_i386 = 'tlcpack/ci-i386:20220925-060158-71f25b3d6'
-ci_cortexm = 'tlcpack/ci-cortexm:20220925-060158-71f25b3d6'
-ci_arm = 'tlcpack/ci-arm:20220925-060158-71f25b3d6'
-ci_hexagon = 'tlcpack/ci-hexagon:20220925-060158-71f25b3d6'
-ci_riscv = 'tlcpack/ci-riscv:20220925-060158-71f25b3d6'
+ci_lint = 'tlcpack/ci-lint:20221013-060115-61c9742ea'
+ci_gpu = 'tlcpack/ci-gpu:20221013-060115-61c9742ea'
+ci_cpu = 'tlcpack/ci-cpu:20221013-060115-61c9742ea'
+ci_minimal = 'tlcpack/ci-minimal:20221013-060115-61c9742ea'
+ci_wasm = 'tlcpack/ci-wasm:20221013-060115-61c9742ea'
+ci_i386 = 'tlcpack/ci-i386:20221013-060115-61c9742ea'
+ci_cortexm = 'tlcpack/ci-cortexm:20221013-060115-61c9742ea'
+ci_arm = 'tlcpack/ci-arm:20221013-060115-61c9742ea'
+ci_hexagon = 'tlcpack/ci-hexagon:20221013-060115-61c9742ea'
+ci_riscv = 'tlcpack/ci-riscv:20221013-060115-61c9742ea'
 // <--- End of regex-scanned config.
 
 // Parameters to allow overriding (in Jenkins UI), the images


### PR DESCRIPTION
Update all Docker image tags used in CI to tag
`20221013-060115-61c9742ea` in order to bring Compute Library to v22.08.

The following link shows the proposed tags being validated in upstream CI: 
[https://ci.tlcpack.ai/blue/organizations/jenkins/docker-images-ci%2Fdocker-image-run-tests/detail/docker-image-run-tests/255/pipeline/790/](url)

CC @leandron @driazati @areusch @Mousius for reviews