### PR TITLE
MinGW compiler Support Again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,26 @@
 cmake_minimum_required(VERSION 3.18)
 project(tvm C CXX)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(IS_WINDOWS 1)
+  message(STATUS "host is windows")
+  if (CMAKE_COMPILER_IS_GNUCC)
+    set(IS_MINGW 1)
+    if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+      add_definitions("-D_DEBUG")
+    endif ()
+  endif ()
+else()
+  set(IS_LINUX 1)
+  if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+    add_definitions("-D_DEBUG")
+  endif ()
+  add_definitions("-Dlinux")
+  message(STATUS "host is LINUX")
+endif ()
+
+
+
 # Utility functions
 include(cmake/utils/Utils.cmake)
 include(cmake/utils/Summary.cmake)
@@ -535,6 +555,9 @@ add_library(tvm SHARED $<TARGET_OBJECTS:tvm_objs> $<TARGET_OBJECTS:tvm_runtime_o
 target_include_directories(tvm PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_NO_UNDEFINED_SYMBOLS}")
 set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "${TVM_VISIBILITY_FLAG}")
+if (IS_MINGW)
+  set_property(TARGET tvm APPEND PROPERTY LINK_OPTIONS "-Wl,--exclude-all-symbols")
+endif (IS_MINGW)
 if(BUILD_STATIC_RUNTIME)
   add_library(tvm_runtime STATIC $<TARGET_OBJECTS:tvm_runtime_objs> $<TARGET_OBJECTS:tvm_libinfo_objs>)
   set(NOTICE_MULTILINE
@@ -569,6 +592,13 @@ if(USE_MICRO)
   add_dependencies(tvm_runtime zephyr)
   add_dependencies(tvm_runtime arduino)
 endif()
+
+if(USE_RPC  AND IS_MINGW)
+  message(STATUS "Build with RPC support... add ws2.lib on windows")
+  set(TVM_RUNTIME_LINKER_LIBS
+          ${TVM_RUNTIME_LINKER_LIBS}
+          Ws2_32.lib)
+endif(USE_RPC  AND IS_MINGW )
 
 if(USE_CPP_RPC)
   add_subdirectory("apps/cpp_rpc")
@@ -751,7 +781,8 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 # More target definitions
-if(MSVC)
+if(MSVC OR IS_MINGW)
+  #if(MSVC)
   target_compile_definitions(tvm_objs PRIVATE -DTVM_EXPORTS)
   target_compile_definitions(tvm_libinfo_objs PRIVATE -DTVM_EXPORTS)
   target_compile_definitions(tvm_runtime_objs PRIVATE -DTVM_EXPORTS)
@@ -807,3 +838,6 @@ if(${SUMMARIZE})
 endif()
 
 dump_options_to_file("${TVM_ALL_OPTIONS}")
+
+
+add_subdirectory(apps/lower_cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -839,5 +839,3 @@ endif()
 
 dump_options_to_file("${TVM_ALL_OPTIONS}")
 
-
-add_subdirectory(apps/lower_cpp)

--- a/apps/cpp_rpc/CMakeLists.txt
+++ b/apps/cpp_rpc/CMakeLists.txt
@@ -26,6 +26,7 @@ if(WIN32)
   target_compile_definitions(tvm_rpc PUBLIC -DNOMINMAX)
 endif()
 
+
 if (OS)
    if (OS STREQUAL "Linux")
       set_property(TARGET tvm_rpc PROPERTY LINK_FLAGS -lpthread)
@@ -56,6 +57,10 @@ if (BUILD_FOR_ANDROID AND USE_HEXAGON)
   endif()
   list(APPEND TVM_RPC_LINKER_LIBS cdsprpc log)
 endif()
+if(IS_MINGW)
+  message(STATUS "Build with RPC support... add ws2.lib on windows")
+  list(APPEND TVM_RPC_LINKER_LIBS Ws2_32.lib)
+endif(IS_MINGW )
 
 if(USE_ETHOSN)
   if (ETHOSN_RUNTIME_LIBRARY)

--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -54,11 +54,15 @@
 #endif
 
 #ifndef TVM_DLL
-#ifdef _WIN32
+#if defined(_WIN32) /*&& !defined(__MINGW32__)*/
 #ifdef TVM_EXPORTS
 #define TVM_DLL __declspec(dllexport)
 #else
+#if defined(__MINGW32__)
+#define TVM_DLL
+#else
 #define TVM_DLL __declspec(dllimport)
+#endif
 #endif
 #else
 #define TVM_DLL __attribute__((visibility("default")))

--- a/src/relay/op/annotation/annotation.cc
+++ b/src/relay/op/annotation/annotation.cc
@@ -201,5 +201,7 @@ TVM_REGISTER_GLOBAL("relay.op.annotation._make.compiler_end")
       return Call(op, {expr}, Attrs(attrs), {});
     });
 
+TVM_DLL extern  const Op stop_fusion_op = Op::Get("annotation.stop_fusion");
+
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/op/vm/vm.cc
+++ b/src/relay/op/vm/vm.cc
@@ -107,7 +107,7 @@ TVM_REGISTER_GLOBAL("relay.op.vm.invoke_tvm_op")
     .set_body_typed([](Expr func, Expr inputs, Expr outputs, DictAttrs attrs) {
       return InvokeTVMOp(std::move(func), std::move(inputs), std::move(outputs), std::move(attrs));
     });
-
+TVM_REGISTER_NODE_TYPE(DictAttrsNode);
 RELAY_REGISTER_OP("vm.invoke_tvm_op")
     .describe(R"code(Invoke an operation compiled by TVM.)code" TVM_ADD_FILELINE)
     .set_num_inputs(3)

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -83,7 +83,7 @@ using support::LinkNode;
 
 constexpr uint32_t kMaxFusedOps = 256;
 
-static const Op& stop_fusion_op = Op::Get("annotation.stop_fusion");
+extern  const Op stop_fusion_op;
 
 TVM_REGISTER_PASS_CONFIG_OPTION("relay.FuseOps.max_depth", Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION("relay.FuseOps.link_params", Bool);

--- a/src/runtime/builtin_fp16.cc
+++ b/src/runtime/builtin_fp16.cc
@@ -27,7 +27,7 @@
 extern "C" {
 
 // disable under msvc
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 
 TVM_DLL TVM_WEAK uint16_t __gnu_f2h_ieee(float a) {
   return __truncXfYf2__<float, uint32_t, 23, uint16_t, uint16_t, 10>(a);

--- a/src/runtime/cpu_device_api.cc
+++ b/src/runtime/cpu_device_api.cc
@@ -46,7 +46,7 @@ class CPUDeviceAPI final : public DeviceAPI {
   }
   void* AllocDataSpace(Device dev, size_t nbytes, size_t alignment, DLDataType type_hint) final {
     void* ptr;
-#if _MSC_VER
+#if _MSC_VER || defined(__MINGW32__)
     ptr = _aligned_malloc(nbytes, alignment);
     if (ptr == nullptr) throw std::bad_alloc();
 #elif defined(__ANDROID__) && __ANDROID_API__ < 17
@@ -61,7 +61,7 @@ class CPUDeviceAPI final : public DeviceAPI {
   }
 
   void FreeDataSpace(Device dev, void* ptr) final {
-#if _MSC_VER
+#if _MSC_VER || defined(__MINGW32__)
     _aligned_free(ptr);
 #else
     free(ptr);

--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -31,6 +31,10 @@
 #define NOMINMAX
 #endif
 
+#if defined(__MINGW32__)
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
 #include <winsock2.h>
 #include <ws2tcpip.h>
 


### PR DESCRIPTION
Add support for MinGW compiler on windows platform, so You can use std c++17 or LLVM higher version(13.x ...) without upgrade MSVC compilers, It's also easy to deploy on windows platform. Make branch more clean to merge