### PR TITLE
[TIR][Arith] Support negative coeff in ModularSet

### DIFF
--- a/tests/python/unittest/test_arith_canonical_simplify.py
+++ b/tests/python/unittest/test_arith_canonical_simplify.py
@@ -97,6 +97,8 @@ def test_split_index_simplify():
     # cannot simplify mixed case, unless we canonicalize into one mode.
     ck.verify(tdiv(x, 6) * 2 + tmod(fld(x, 3), 2), tdiv(x, 6) * 2 + tmod(fld(x, 3), 2))
 
+    ck.verify(tmod(-x, 2), tmod(x, -2) * -1)
+
 
 def test_div_simplify():
     ck = CanonicalChecker()
@@ -128,6 +130,8 @@ def test_floormod_simplify():
     x, y = te.var("x"), te.var("y")
     ck.verify(flm(flm((x * 4) + y - 466036, 24528) - 24512, 16), flm((x * 4) + y + 12, 16))
     ck.verify(flm(flm((x * 4), 16), 8), flm(x, 2) * 4)
+
+    ck.verify(flm(-x, 2), flm(x, -2) * -1)
 
 
 def test_canonical_mixed():


### PR DESCRIPTION
Prior to this commit, any use of negative coefficients in `ModularSet` would result in an error.  This included cases where a constraint is being entered, such as `floormod(i, -2)==0` appearing as the condition of an if/else block.  These negative indices can also arise as intermediate simplification steps produced by `CanonicalSimplifier`, such as `floormod(-i,2)` being canonicalized to `floormod(i,-2)`.

This commit adds support for negative coefficients in `ModularSet`, using the same sign convention as is used by `CanonicalSimplifier` for negative denominators, and adds unit tests to verify that sign convention.