### PR TITLE
[Doc] Fix typo in the document of installing from_source

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -240,7 +240,7 @@ If you are already using conda as your package manager and wish to directly buil
 
 Building on Windows
 ~~~~~~~~~~~~~~~~~~~
-TVM support build via MSVC using cmake. You will need to ontain a visual studio compiler.
+TVM support build via MSVC using cmake. You will need to obtain a visual studio compiler.
 The minimum required VS version is **Visual Studio Enterprise 2019** (NOTE: we test
 against GitHub Actions' `Windows 2019 Runner <https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md>`_, so see that page for full details.
 We recommend following :ref:`build-with-conda` to obtain necessary dependencies and


### PR DESCRIPTION
Fix typo in the document of installing from source in `tvm/docs/install/from_source.rst`: `ontain -> obtain a visual studio compiler`.