### PR TITLE
[MetaSchedule] Introduce a variant of ModuleEquality to enable ignoring NDArray raw data

### DIFF
--- a/include/tvm/meta_schedule/database.h
+++ b/include/tvm/meta_schedule/database.h
@@ -181,6 +181,8 @@ class DatabaseNode : public runtime::Object {
    * \param mod_eq_name A string to specify the module equality testing and hashing method.
    *  It must be one of the followings:
    *    - "structural": Use StructuralEqual/Hash
+   *    - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+   *                        equality testing and hashing.
    */
   explicit DatabaseNode(String mod_eq_name = "structural");
 
@@ -270,6 +272,8 @@ class PyDatabaseNode : public DatabaseNode {
    * \param mod_eq_name A string to specify the module equality testing and hashing method.
    *  It must be one of the followings:
    *    - "structural": Use StructuralEqual/Hash
+   *    - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+   *                        equality testing and hashing.
    */
   explicit PyDatabaseNode(String mod_eq_name = "structural");
 

--- a/python/tvm/meta_schedule/database/json_database.py
+++ b/python/tvm/meta_schedule/database/json_database.py
@@ -38,6 +38,8 @@ class JSONDatabase(Database):
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
           - "structural": Use StructuralEqual/Hash
+          - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+                              equality testing and hashing.
     """
 
     path_workload: str

--- a/python/tvm/meta_schedule/database/memory_database.py
+++ b/python/tvm/meta_schedule/database/memory_database.py
@@ -31,6 +31,8 @@ class MemoryDatabase(Database):
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
           - "structural": Use StructuralEqual/Hash
+          - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+                              equality testing and hashing.
     """
 
     def __init__(

--- a/python/tvm/meta_schedule/database/schedule_fn_database.py
+++ b/python/tvm/meta_schedule/database/schedule_fn_database.py
@@ -37,6 +37,8 @@ class ScheduleFnDatabase(Database):
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
           - "structural": Use StructuralEqual/Hash
+          - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+                              equality testing and hashing.
     """
 
     def __init__(

--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -141,6 +141,8 @@ def extract_tasks(
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
           - "structural": Use StructuralEqual/Hash
+          - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+                              equality testing and hashing.
 
     Returns
     -------
@@ -284,6 +286,8 @@ def tune_relay(
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
           - "structural": Use StructuralEqual/Hash
+          - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+                              equality testing and hashing.
 
     Returns
     -------

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -74,6 +74,8 @@ def tune_tasks(
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
           - "structural": Use StructuralEqual/Hash
+          - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+                              equality testing and hashing.
 
     Returns
     -------

--- a/src/meta_schedule/module_equality.cc
+++ b/src/meta_schedule/module_equality.cc
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+#include "../node/ndarray_hash_equal.h"
+
 namespace tvm {
 namespace meta_schedule {
 
@@ -33,9 +35,49 @@ class ModuleEqualityStructural : public ModuleEquality {
   bool Equal(IRModule lhs, IRModule rhs) const { return tvm::StructuralEqual()(lhs, rhs); }
 };
 
+class SEqualHandlerIgnoreNDArray : public SEqualHandlerDefault {
+ public:
+  SEqualHandlerIgnoreNDArray() : SEqualHandlerDefault(false, nullptr) {}
+
+ protected:
+  bool DispatchSEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
+                            const Optional<ObjectPathPair>& current_paths) {
+    if (auto lhs_ptr = lhs.as<runtime::NDArray::Container>(),
+        rhs_ptr = rhs.as<runtime::NDArray::Container>();
+        lhs_ptr && rhs_ptr) {
+      SEqualReducer reducer(this, nullptr, map_free_vars);
+      return NDArrayEqual(lhs_ptr, rhs_ptr, reducer, false);
+    }
+    return SEqualHandlerDefault::DispatchSEqualReduce(lhs, rhs, map_free_vars, current_paths);
+  }
+};
+
+class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
+ protected:
+  void DispatchSHash(const ObjectRef& object, bool map_free_vars) override {
+    ICHECK(object.defined());
+    if (auto ndarray = object.as<runtime::NDArray::Container>()) {
+      SHashReducer hash_reduce(this, map_free_vars);
+      NDArrayHash(ndarray, &hash_reduce, false);
+    } else {
+      SHashHandlerDefault::DispatchSHash(object, map_free_vars);
+    }
+  }
+};
+
+class ModuleEqualityIgnoreNDArray : public ModuleEquality {
+ public:
+  size_t Hash(IRModule mod) const { return SHashHandlerIgnoreNDArray().Hash(mod, false); }
+  bool Equal(IRModule lhs, IRModule rhs) const {
+    return SEqualHandlerIgnoreNDArray().Equal(lhs, rhs, false);
+  }
+};
+
 std::unique_ptr<ModuleEquality> ModuleEquality::Create(const std::string& mod_eq_name) {
   if (mod_eq_name == "structural") {
     return std::make_unique<ModuleEqualityStructural>();
+  } else if (mod_eq_name == "ignore-ndarray") {
+    return std::make_unique<ModuleEqualityIgnoreNDArray>();
   }
   LOG(FATAL) << "Unknown module equality " << mod_eq_name;
   return nullptr;

--- a/src/meta_schedule/module_equality.h
+++ b/src/meta_schedule/module_equality.h
@@ -40,6 +40,8 @@ class ModuleEquality {
    * \param mod_eq_name A string to specify the module equality testing and hashing method.
    *  It must be one of the followings:
    *    - "structural": Use StructuralEqual/Hash
+   *    - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
+   *                        equality testing and hashing.
    * \return An owning pointer to the created instance
    */
   static std::unique_ptr<ModuleEquality> Create(const std::string& mod_eq_name);

--- a/src/node/ndarray_hash_equal.h
+++ b/src/node/ndarray_hash_equal.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef TVM_NODE_NDARRAY_HASH_EQUAL_H_
+#define TVM_NODE_NDARRAY_HASH_EQUAL_H_
+
+#include <tvm/node/structural_equal.h>
+#include <tvm/node/structural_hash.h>
+#include <tvm/runtime/ndarray.h>
+
+namespace tvm {
+
+bool NDArrayEqual(const runtime::NDArray::Container* lhs, const runtime::NDArray::Container* rhs,
+                  SEqualReducer equal, bool compare_data);
+
+void NDArrayHash(const runtime::NDArray::Container* arr, SHashReducer* hash_reduce, bool hash_data);
+
+}  // namespace tvm
+
+#endif  //  TVM_NODE_NDARRAY_HASH_EQUAL_H_

--- a/src/node/ndarray_hash_equal.h
+++ b/src/node/ndarray_hash_equal.h
@@ -19,15 +19,32 @@
 #ifndef TVM_NODE_NDARRAY_HASH_EQUAL_H_
 #define TVM_NODE_NDARRAY_HASH_EQUAL_H_
 
-#include <tvm/node/structural_equal.h>
-#include <tvm/node/structural_hash.h>
 #include <tvm/runtime/ndarray.h>
 
 namespace tvm {
 
+class SEqualReducer;
+class SHashReducer;
+
+/*!
+ * \brief Test two NDArrays for equality.
+ * \param lhs The left operand.
+ * \param rhs The right operand.
+ * \param equal A Reducer class to reduce the structural equality result of two objects.
+ * See tvm/node/structural_equal.h.
+ * \param compare_data Whether or not to consider ndarray raw data in the equality testing.
+ * \return The equality testing result.
+ */
 bool NDArrayEqual(const runtime::NDArray::Container* lhs, const runtime::NDArray::Container* rhs,
                   SEqualReducer equal, bool compare_data);
 
+/*!
+ * \brief Hash NDArray.
+ * \param arr The NDArray to compute the hash for.
+ * \param hash_reduce A Reducer class to reduce the structural hash value.
+ * See tvm/node/structural_hash.h.
+ * \param hash_data Whether or not to hash ndarray raw data.
+ */
 void NDArrayHash(const runtime::NDArray::Container* arr, SHashReducer* hash_reduce, bool hash_data);
 
 }  // namespace tvm

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -29,6 +29,8 @@
 
 #include <unordered_map>
 
+#include "ndarray_hash_equal.h"
+
 namespace tvm {
 
 TVM_REGISTER_OBJECT_TYPE(ObjectPathPairNode);
@@ -474,6 +476,39 @@ TVM_REGISTER_GLOBAL("node.GetFirstStructuralMismatch")
 
 bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs) const {
   return SEqualHandlerDefault(false, nullptr).Equal(lhs, rhs, false);
+}
+
+bool NDArrayEqual(const runtime::NDArray::Container* lhs, const runtime::NDArray::Container* rhs,
+                  SEqualReducer equal, bool compare_data) {
+  if (lhs == rhs) return true;
+
+  auto ldt = lhs->dl_tensor.dtype;
+  auto rdt = rhs->dl_tensor.dtype;
+  ICHECK_EQ(lhs->dl_tensor.device.device_type, kDLCPU) << "can only compare CPU tensor";
+  ICHECK_EQ(rhs->dl_tensor.device.device_type, kDLCPU) << "can only compare CPU tensor";
+  ICHECK(runtime::IsContiguous(lhs->dl_tensor)) << "Can only compare contiguous tensor";
+  ICHECK(runtime::IsContiguous(rhs->dl_tensor)) << "Can only compare contiguous tensor";
+
+  if (lhs->dl_tensor.ndim != rhs->dl_tensor.ndim) return false;
+  for (int i = 0; i < lhs->dl_tensor.ndim; ++i) {
+    if (!equal(lhs->dl_tensor.shape[i], rhs->dl_tensor.shape[i])) return false;
+  }
+  if (ldt.code == rdt.code && ldt.lanes == rdt.lanes && ldt.bits == rdt.bits) {
+    size_t data_size = runtime::GetDataSize(lhs->dl_tensor);
+    if (compare_data) {
+      return std::memcmp(lhs->dl_tensor.data, rhs->dl_tensor.data, data_size) == 0;
+    } else {
+      return true;
+    }
+  } else {
+    return false;
+  }
+}
+
+bool NDArrayContainerTrait::SEqualReduce(const runtime::NDArray::Container* lhs,
+                                         const runtime::NDArray::Container* rhs,
+                                         SEqualReducer equal) {
+  return NDArrayEqual(lhs, rhs, equal, true);
 }
 
 }  // namespace tvm


### PR DESCRIPTION
A follow up to https://github.com/apache/tvm/pull/13050, also builds on https://github.com/apache/tvm/pull/13001. This PR enables the functionality in https://github.com/apache/tvm/pull/12706 without changing the existing `StructuralEqual/Hash`.

A question for discussion: Should this be the default ModuleEquality used by MS? It has no effect for the `link-params = False` case, and it simplifies the MS tuning API usage for the `link-params = True` case (Hexagon etc).

cc @junrushao @zxybazh 