### PR TITLE
[AOT] Add CreateFunctionMetadata analysis pass

### DIFF
--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -202,6 +202,13 @@ TVM_DLL Array<Array<BufferRegion>> GetBlockReadWriteRegion(const Block& block,
 TVM_DLL size_t CalculateExprComplexity(const PrimExpr& expr);
 
 /*!
+ * \brief Calculate the constants size in bytes needed by the TIR allocates inside the TIR PrimFunc
+ * \param func The TIR PrimFunc for which the constants size to be calculated
+ * \param constant_byte_alignment The byte alignment required for each constant allocated
+ */
+TVM_DLL size_t CalculateConstantBytes(const PrimFunc& func, const Integer& constant_byte_alignment);
+
+/*!
  * \brief Calculate the workspace size in bytes needed by the TIR allocates inside the TIR PrimFunc
  * \param func The TIR PrimFunc for which the workspace size to be calculated
  * \param workspace_byte_alignment The byte alignment required for each tensor allocated in this

--- a/python/tvm/ir/memory_pools.py
+++ b/python/tvm/ir/memory_pools.py
@@ -20,6 +20,7 @@ from typing import Optional, List
 
 from tvm._ffi import register_object
 from tvm.runtime import Object
+from tvm.runtime import NDArray
 from . import _ffi_api
 
 
@@ -98,6 +99,34 @@ class PoolInfoProperties(Object):
             read_latency_cycles,
             write_latency_cycles,
             target_burst_bytes,
+        )
+
+
+@register_object("ir.ConstantInfo")
+class ConstantInfo(Object):
+    """ConstantInfo object hold information on a constant pool.
+
+    Parameters
+    ----------
+    name_hint : str
+        Name of the constant.
+    byte_offset : int
+        The byte_offset of the constant.
+    data : NDArray
+        The data of the constant.
+    """
+
+    def __init__(
+        self,
+        name_hint: str,
+        byte_offset: int,
+        data: NDArray,
+    ):
+        self.__init_handle_by_constructor__(
+            _ffi_api.ConstantInfo,  # type: ignore # pylint: disable=no-member
+            name_hint,
+            byte_offset,
+            data,
         )
 
 
@@ -213,4 +242,27 @@ class ConstantMemoryPools(Object):
     ):
         self.__init_handle_by_constructor__(
             _ffi_api.ConstantMemoryPools, pools  # type: ignore # pylint: disable=no-member
+        )
+
+
+@register_object("ir.ConstantMemoryPools")
+class AllocatedPoolInfo(Object):
+    """Allocate memory in a given pool.
+
+    Parameters
+    ----------
+    pool : PoolInfo
+        The pool in which to allocate memory.
+    allocated_size : int
+        The size of memory to allocate.
+    """
+
+    def __init__(
+        self,
+        pool: PoolInfo,
+        allocated_size: int,
+        pool_var_idx: int = 0,
+    ):
+        self.__init_handle_by_constructor__(
+            _ffi_api.AllocatedPoolInfo, pool, allocated_size, pool_var_idx  # type: ignore # pylint: disable=no-member
         )

--- a/python/tvm/relay/backend/aot.py
+++ b/python/tvm/relay/backend/aot.py
@@ -16,6 +16,9 @@
 # under the License.
 # pylint: disable=invalid-name
 """AOT passes"""
+from typing import Dict
+
+from tvm import IRModule
 from tvm.ir.transform import Pass
 from .utils import CallType
 
@@ -41,3 +44,26 @@ def AOTLowerMain(mod_name: str, config: object, call_type: CallType) -> Pass:
 
     """
     return _aot.AOTLowerMain(mod_name, config, call_type.value)
+
+
+def CreateFunctionMetadata(
+    mod: IRModule, workspace_byte_alignment: int, constant_byte_alignment: int
+) -> Dict[str, object]:
+    """Create the function metadata (FunctionInfos) from an AOT module.
+
+    Parameters
+    ----------
+    mod : IRModule
+        The IRModule.
+    workspace_byte_alignment : int
+        The alignment of the workspace buffer in bytes.
+    constant_byte_alignment : int
+        The alignment of the constant buffer in bytes.
+
+    Returns
+    -------
+    Dict[str, FunctionInfo]
+        A map between function names and FunctionInfos.
+
+    """
+    return _aot.CreateFunctionMetadata(mod, workspace_byte_alignment, constant_byte_alignment)

--- a/src/relay/backend/aot/create_function_metadata.cc
+++ b/src/relay/backend/aot/create_function_metadata.cc
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/backend/aot/create_function_metadata.cc
+ * \brief Create FunctionInfo metadata from a lowered TIR module.
+ */
+#include "./create_function_metadata.h"
+
+#include <tvm/ir/expr.h>
+#include <tvm/ir/module.h>
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/map.h>
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/data_type.h>
+#include <tvm/runtime/module.h>
+#include <tvm/target/target_kind.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/usmp/utils.h>
+
+#include "../utils.h"
+
+namespace tvm {
+namespace relay {
+namespace backend {
+namespace aot {
+
+/*!
+ * \brief Calculate FunctionInfo for all the PrimFuncs in a module.
+ */
+Map<String, backend::FunctionInfo> CalculateFunctionInfos(const IRModule& mod,
+                                                          Integer workspace_byte_alignment,
+                                                          Integer constant_byte_alignment) {
+  Map<String, backend::FunctionInfo> function_metadata;
+  for (const auto& kv : mod->functions) {
+    GlobalVar global_var = kv.first;
+    BaseFunc base_func = kv.second;
+    if (base_func->IsInstance<tir::PrimFuncNode>()) {
+      tir::PrimFunc pfunc = Downcast<tir::PrimFunc>(base_func);
+      Target tgt = pfunc->GetAttr<Target>(tvm::attr::kTarget).value();
+      // Determine the size of input/output buffers
+      auto params = pfunc->params;
+      int64_t ios = 0;
+      for (const auto& param : params) {
+        // Inputs/outputs will be handles, workspaces are pointers
+        if (param->dtype.is_handle()) {
+          auto buffer = pfunc->buffer_map[param];
+          ios += GetMemorySizeBytes(buffer->shape, buffer->dtype);
+        }
+      }
+      const auto& ws = CalculateWorkspaceBytes(pfunc, workspace_byte_alignment);
+      const auto& cs = CalculateConstantBytes(pfunc, constant_byte_alignment);
+      backend::FunctionInfo finfo{{{tgt, ws}}, {{tgt, ios}}, {{tgt, cs}}, {{tgt, pfunc}}, {}};
+      function_metadata.Set(global_var->name_hint, finfo);
+    }
+  }
+  return function_metadata;
+}
+
+Map<String, backend::FunctionInfo> CreateFunctionMetadata(const IRModule& mod,
+                                                          Integer workspace_byte_alignment,
+                                                          Integer constant_byte_alignment) {
+  // First calculate the FunctionInfos from the buffers that are explicitly allocated
+  auto function_metadata =
+      CalculateFunctionInfos(mod, workspace_byte_alignment, constant_byte_alignment);
+  // Now adjust the FunctionInfo for the main func to also include PoolInfo allocations
+  // made by the USMP.
+  Optional<Array<tir::usmp::AllocatedPoolInfo>> allocated_pool_infos =
+      mod->GetAttr<Array<tir::usmp::AllocatedPoolInfo>>(tvm::attr::kPoolArgs);
+  backend::FunctionInfo main_func_info =
+      function_metadata.Get(runtime::symbol::tvm_module_main).value();
+  if (allocated_pool_infos) {
+    for (const tir::usmp::AllocatedPoolInfo& allocated_pool_info : allocated_pool_infos.value()) {
+      for (const auto& tgt : allocated_pool_info->pool_info->targets) {
+        VLOG(1) << "USMP requires target " << tgt->ToDebugString() << " to have pool size "
+                << allocated_pool_info->allocated_size->value;
+        size_t size = allocated_pool_info->allocated_size->value;
+        if (allocated_pool_info->pool_info->IsInstance<ConstantPoolInfoNode>()) {
+          size += main_func_info->constant_sizes.count(tgt)
+                      ? main_func_info->constant_sizes[tgt]->value
+                      : 0;
+          main_func_info->constant_sizes.Set(tgt, size);
+        } else if (allocated_pool_info->pool_info->IsInstance<WorkspacePoolInfoNode>()) {
+          size += main_func_info->workspace_sizes.count(tgt)
+                      ? main_func_info->workspace_sizes[tgt]->value
+                      : 0;
+          main_func_info->workspace_sizes.Set(tgt, size);
+        } else {
+          LOG(FATAL) << "Unknown pool type: " << allocated_pool_info->pool_info->GetTypeKey();
+        }
+      }
+    }
+  }
+  function_metadata.Set(runtime::symbol::tvm_module_main, main_func_info);
+  return function_metadata;
+}
+
+TVM_REGISTER_GLOBAL("relay.backend.aot.CreateFunctionMetadata")
+    .set_body_typed(CreateFunctionMetadata);
+
+}  // namespace aot
+}  // namespace backend
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/backend/aot/create_function_metadata.h
+++ b/src/relay/backend/aot/create_function_metadata.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef TVM_RELAY_BACKEND_AOT_CREATE_FUNCTION_METADATA_H_
+#define TVM_RELAY_BACKEND_AOT_CREATE_FUNCTION_METADATA_H_
+
+#include <tvm/ir/module.h>
+#include <tvm/runtime/container/map.h>
+#include <tvm/runtime/container/string.h>
+
+#include "../utils.h"
+
+namespace tvm {
+namespace relay {
+namespace backend {
+namespace aot {
+
+/*! \brief Create FunctionInfo metadata for all the PrimFuncs in a module lowered
+ *  for AOT execution.
+ * \param mod The module.
+ * \param workspace_byte_alignment The alignment of the workspace pool.
+ * \param constant_byte_alignment The alignment of the constant pool.
+ * \return A map between function names and FunctionInfos.
+ */
+Map<String, FunctionInfo> CreateFunctionMetadata(const IRModule& mod,
+                                                 Integer workspace_byte_alignment,
+                                                 Integer constant_byte_alignment);
+
+}  // namespace aot
+}  // namespace backend
+}  // namespace relay
+}  // namespace tvm
+
+#endif  // TVM_RELAY_BACKEND_AOT_CREATE_FUNCTION_METADATA_H_

--- a/src/tir/usmp/utils.cc
+++ b/src/tir/usmp/utils.cc
@@ -132,9 +132,9 @@ AllocatedPoolInfo::AllocatedPoolInfo(PoolInfo pool_info, Integer allocated_size,
 }
 
 TVM_REGISTER_NODE_TYPE(AllocatedPoolInfoNode);
-TVM_REGISTER_GLOBAL("tir.usmp.AllocatedPoolInfo")
-    .set_body_typed([](PoolInfo pool_info, Integer allocated_size) {
-      return AllocatedPoolInfo(pool_info, allocated_size);
+TVM_REGISTER_GLOBAL("ir.AllocatedPoolInfo")
+    .set_body_typed([](PoolInfo pool_info, Integer allocated_size, Integer pool_var_idx) {
+      return AllocatedPoolInfo(pool_info, allocated_size, pool_var_idx);
     });
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)

--- a/tests/python/relay/aot/test_aot_create_function_metadata.py
+++ b/tests/python/relay/aot/test_aot_create_function_metadata.py
@@ -1,0 +1,302 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=line-too-long,missing-class-docstring,missing-module-docstring,missing-function-docstring,no-self-argument,unused-argument,invalid-name
+import numpy as np
+
+import tvm
+import tvm.testing
+from tvm.script import tir as T
+from tvm.runtime.ndarray import array
+from tvm.relay.backend.aot import CreateFunctionMetadata
+from tvm.ir.memory_pools import AllocatedPoolInfo, ConstantPoolInfo, WorkspacePoolInfo, ConstantInfo
+
+
+def _check_function_metadata(function_metadata, expected_infos):
+    for symbol, expected_info in expected_infos.items():
+        func_info = function_metadata[symbol]
+        # Check workspace_sizes
+        key, value = func_info.workspace_sizes.items()[0]
+        assert str(key) == expected_info["target"]
+        assert value == expected_info["workspace_sizes"]
+        # Check io_sizes
+        key, value = func_info.io_sizes.items()[0]
+        assert str(key) == expected_info["target"]
+        assert value == expected_info["io_sizes"]
+        # Check constant_sizes
+        key, value = func_info.constant_sizes.items()[0]
+        assert str(key) == expected_info["target"]
+        assert value == expected_info["constant_sizes"]
+        # Check tir_primfuncs
+        key, value = func_info.tir_primfuncs.items()[0]
+        assert str(key) == expected_info["target"]
+        tvm.ir.assert_structural_equal(value, expected_info["tir_primfuncs"])
+
+
+def test_create_function_metadata_workspace_allocate_only():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def __tvm_main__(a: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod___tvm_main__", "runner_function": True, "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]})})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            sid_3 = T.allocate([140], "int8", "global.workspace")
+            sid_2 = T.allocate([140], "int8", "global.workspace")
+            sid_1 = T.allocate([140], "int8", "global.workspace")
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_0", a_buffer.data, sid_1, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_0", sid_1, sid_2, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_0", sid_2, sid_3, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_1", sid_2, sid_3, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+    # fmt: on
+
+    expected_infos = {
+        "__tvm_main__": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 432,
+            "io_sizes": 280,
+            "constant_sizes": 0,
+            "tir_primfuncs": Module["__tvm_main__"],
+        }
+    }
+
+    function_metadata = CreateFunctionMetadata(Module, 16, 1)
+
+    _check_function_metadata(function_metadata, expected_infos)
+
+
+def test_create_function_metadata_constant_allocate_only():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def __tvm_main__(a: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod___tvm_main__", "runner_function": True, "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]}), "num_inputs": 1, "num_outputs": 1})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            constant_0 = T.allocate_const([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "float32", [5, 7])
+            T.evaluate(T.tvm_call_cpacked("test_fused_add", a_buffer.data, constant_0, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+    # fmt: on
+
+    expected_infos = {
+        "__tvm_main__": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 0,
+            "io_sizes": 280,
+            "constant_sizes": 140,
+            "tir_primfuncs": Module["__tvm_main__"],
+        }
+    }
+
+    function_metadata = CreateFunctionMetadata(Module, 16, 1)
+
+    _check_function_metadata(function_metadata, expected_infos)
+
+
+def test_create_function_metadata_constant_pool_only():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def __tvm_main__(a: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod___tvm_main__", "runner_function": True, "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]}), "num_inputs": 1, "num_outputs": 1})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            T.evaluate(T.tvm_call_cpacked("test_fused_add", a_buffer.data, a_buffer.data, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+    # fmt: on
+
+    expected_infos = {
+        "__tvm_main__": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 0,
+            "io_sizes": 280,
+            "constant_sizes": 256,
+            "tir_primfuncs": Module["__tvm_main__"],
+        }
+    }
+
+    target = Module["__tvm_main__"].attrs["target"]
+    mod = Module.with_attr(
+        "pool_args",
+        [
+            AllocatedPoolInfo(
+                ConstantPoolInfo(
+                    "flash",
+                    [target],
+                    [ConstantInfo("a", 0, array(np.array([0])))],
+                ),
+                256,
+            ),
+        ],
+    )
+
+    function_metadata = CreateFunctionMetadata(mod, 16, 1)
+
+    _check_function_metadata(function_metadata, expected_infos)
+
+
+def test_create_function_metadata_workspace_pool_only():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def __tvm_main__(a: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod___tvm_main__", "runner_function": True, "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]}), "num_inputs": 1, "num_outputs": 1})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            T.evaluate(T.tvm_call_cpacked("test_fused_add", a_buffer.data, a_buffer.data, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+    # fmt: on
+
+    expected_infos = {
+        "__tvm_main__": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 256,
+            "io_sizes": 280,
+            "constant_sizes": 0,
+            "tir_primfuncs": Module["__tvm_main__"],
+        }
+    }
+
+    target = Module["__tvm_main__"].attrs["target"]
+    mod = Module.with_attr(
+        "pool_args",
+        [
+            AllocatedPoolInfo(
+                WorkspacePoolInfo("sram", [target]),
+                256,
+            ),
+        ],
+    )
+
+    function_metadata = CreateFunctionMetadata(mod, 16, 1)
+
+    _check_function_metadata(function_metadata, expected_infos)
+
+
+def test_create_function_metadata_all_single_func():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def __tvm_main__(a: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod___tvm_main__", "runner_function": True, "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]})})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            sid_3 = T.allocate([140], "int8", "global.workspace")
+            sid_2 = T.allocate([140], "int8", "global.workspace")
+            sid_1 = T.allocate([140], "int8", "global.workspace")
+            constant_0 = T.allocate_const([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "float32", [5, 7])
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_0", a_buffer.data, sid_1, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_0", sid_1, constant_0, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_0", sid_2, sid_3, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+            T.evaluate(T.tvm_call_cpacked("test_fused_add_1", sid_2, sid_3, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+    # fmt: on
+
+    expected_infos = {
+        "__tvm_main__": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 688,
+            "io_sizes": 280,
+            "constant_sizes": 652,
+            "tir_primfuncs": Module["__tvm_main__"],
+        }
+    }
+
+    target = Module["__tvm_main__"].attrs["target"]
+    mod = Module.with_attr(
+        "pool_args",
+        [
+            AllocatedPoolInfo(
+                ConstantPoolInfo(
+                    "flash",
+                    [target],
+                    [ConstantInfo("a", 0, array(np.array([0])))],
+                ),
+                512,
+            ),
+            AllocatedPoolInfo(
+                WorkspacePoolInfo("sram", [target]),
+                256,
+            ),
+        ],
+    )
+
+    function_metadata = CreateFunctionMetadata(mod, 16, 1)
+
+    _check_function_metadata(function_metadata, expected_infos)
+
+
+def test_create_function_metadata_workspace_multi_funcs():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def __tvm_main__(a: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod___tvm_main__", "runner_function": True, "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]}), "num_inputs": 1, "num_outputs": 1})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            T.evaluate(T.tvm_call_cpacked("test_fused_add", a_buffer.data, a_buffer.data, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+
+        @T.prim_func
+        def test_fused_add(a: T.handle, b: T.handle, output: T.handle) -> None:
+            # function attr dict
+            T.func_attr({"global_symbol": "test_mod_test_fused_add", "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]})})
+            a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)
+            b_buffer = T.match_buffer(b, [5, 7], dtype="float32", align=16)
+            output_buffer = T.match_buffer(output, [5, 7], dtype="float32", align=16)
+            # body
+            sid_0 = T.allocate([140], "int8", "global.workspace")
+            constant_0 = T.allocate_const([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "float32", [5, 7])
+            T.evaluate(T.tvm_call_cpacked("magic", a_buffer.data, b_buffer.data, sid_0, constant_0, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
+    # fmt: on
+
+    expected_infos = {
+        "__tvm_main__": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 0,
+            "io_sizes": 280,
+            "constant_sizes": 0,
+            "tir_primfuncs": Module["__tvm_main__"],
+        },
+        "test_fused_add": {
+            "target": "llvm -keys=cpu ",
+            "workspace_sizes": 144,
+            "io_sizes": 420,
+            "constant_sizes": 140,
+            "tir_primfuncs": Module["test_fused_add"],
+        },
+    }
+
+    function_metadata = CreateFunctionMetadata(Module, 16, 1)
+
+    _check_function_metadata(function_metadata, expected_infos)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Tracking issue: https://github.com/apache/tvm/issues/12548

AOT requires FunctionInfo to be defined for all the functions in the module. This stores information on how much memory the functions use. This commit adds a separate analysis pass to create all the FunctionInfos + some tests for the new pass.