### PR TITLE
[Relay] Add set_attrs_type registry to broadcast_to op

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -2557,6 +2557,7 @@ RELAY_REGISTER_OP("broadcast_to")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_support_level(4)
     .add_type_rel("BroadCastTo", BroadCastToRel)
+    .set_attrs_type<InitOpAttrs>()
     .set_attr<FTVMCompute>("FTVMCompute", BroadCastToCompute)
     .set_attr<TOpPattern>("TOpPattern", kBroadcast);
 


### PR DESCRIPTION
It seems that ir text is not parsable without set_attrs_type registry.

```python
%2 = broadcast_to(%1, shape=[128, 1, 28]);
```