### PR TITLE
[HotFix] Fix python import

### DIFF
--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -22,7 +22,7 @@ from numbers import Integral
 
 import numpy as np
 import tvm
-from tvm import relay, te
+from tvm import te
 from tvm.tir import bijective_layout, layout
 from . import cpp, tag
 
@@ -452,6 +452,8 @@ def change_constant_shape(src, src_layout, dst_layout):
     dst_shape : relay.Constant
         A copy of the Constant with the new layout.
     """
+    from tvm import relay
+
     assert src_layout.isalpha() and dst_layout.isalpha()
     axis_order = [src_layout.index(c) for c in dst_layout]
     reshaped = np.transpose(src.data.numpy(), axis_order)

--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -452,12 +452,10 @@ def change_constant_shape(src, src_layout, dst_layout):
     dst_shape : relay.Constant
         A copy of the Constant with the new layout.
     """
-    from tvm import relay
-
     assert src_layout.isalpha() and dst_layout.isalpha()
     axis_order = [src_layout.index(c) for c in dst_layout]
     reshaped = np.transpose(src.data.numpy(), axis_order)
-    return relay.Constant(tvm.nd.array(reshaped))
+    return tvm.relay.Constant(tvm.nd.array(reshaped))
 
 
 def within_index(b, e, s, i):


### PR DESCRIPTION
Tuning doesn't work after #12969.
It reports the following error:

```
ImportError: cannot import name 'get_const_float' from partially initialized module 'tvm.topi.utils' (most likely due to a circular import)
```

In this commit, I moved import relay to a function which used in a test. And it helps to fix this circular import.

To reproduce this issue, you can run the following [tutorial](https://github.com/apache/tvm/blob/main/gallery/tutorial/autotvm_relay_x86.py) and will see this error.

cc: @guberti, @areusch, @ekalda  