### PR TITLE
[ci] Wait longer during retries

### DIFF
--- a/ci/scripts/retry.sh
+++ b/ci/scripts/retry.sh
@@ -32,7 +32,7 @@ retry() {
           exit 1
       fi
 
-      WAIT=$(python3 -c 'import random; print(random.randint(10, 30))')
+      WAIT=$(python3 -c 'import random; print(random.randint(30, 200))')
       echo "failed to update $n / $max_retries, waiting $WAIT to try again"
       sleep "$WAIT"
   done


### PR DESCRIPTION
This bumps the wait time between failing network calls from `(10, 30)`
to `(30, 200)` seconds. A failing CI run is pretty costly so it makes
sense to wait a little longer and see if Docker/AWS/whoever starts
responding.

Motivated by
https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/4495/pipeline
which saw 5 `docker pull` `500` errors in a row