### PR TITLE
[Hexagon] Refactor HexagonBufferManager

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -149,8 +149,6 @@ void* HexagonDeviceAPI::AllocWorkspace(Device dev, size_t size, DLDataType type_
 
 void HexagonDeviceAPI::FreeWorkspace(Device dev, void* data) {
   CHECK(IsValidDevice(dev)) << "dev.device_type: " << dev.device_type;
-  CHECK(runtime_hexbuffs.count(data) != 0)
-      << "Attempt made to free unknown or already freed workspace allocation";
   dmlc::ThreadLocalStore<HexagonWorkspacePool>::Get()->FreeWorkspace(dev, data);
 }
 

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -172,7 +172,7 @@ void HexagonDeviceAPI::CopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamHan
   CHECK_EQ(GetDataSize(*from), GetDataSize(*to));
 
   auto lookup_hexagon_buffer = [this](void* ptr) -> HexagonBuffer* {
-    return runtime_hexbuffs.find(ptr);
+    return runtime_hexbuffs.FindHexagonBuffer(ptr);
   };
 
   HexagonBuffer* hex_from_buf = lookup_hexagon_buffer(from->data);

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -55,7 +55,7 @@ class HexagonDeviceAPI final : public DeviceAPI {
 
   //! \brief Ensures resource managers are in a good state for the runtime
   void AcquireResources() {
-    runtime_hexbuffs.Acquire();
+    runtime_hexbuffs.Enable();
 
     CHECK_EQ(runtime_vtcm, nullptr);
     runtime_vtcm = std::make_unique<HexagonVtcmPool>();
@@ -78,7 +78,7 @@ class HexagonDeviceAPI final : public DeviceAPI {
     CHECK(runtime_vtcm) << "runtime_vtcm was not created in AcquireResources";
     runtime_vtcm.reset();
 
-    runtime_hexbuffs.Release();
+    runtime_hexbuffs.Disable();
   }
 
   /*! \brief Currently unimplemented interface to specify the active

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -55,13 +55,13 @@ class HexagonDeviceAPI final : public DeviceAPI {
 
   //! \brief Ensures resource managers are in a good state for the runtime
   void AcquireResources() {
+    runtime_hexbuffs.Acquire();
+
     CHECK_EQ(runtime_vtcm, nullptr);
     runtime_vtcm = std::make_unique<HexagonVtcmPool>();
 
     CHECK_EQ(runtime_threads, nullptr);
     runtime_threads = std::make_unique<HexagonThreadManager>(threads, stack_size, pipe_size);
-
-    runtime_hexbuffs.Reset();
 
     CHECK_EQ(runtime_dma, nullptr);
     runtime_dma = std::make_unique<HexagonUserDMA>();
@@ -75,10 +75,10 @@ class HexagonDeviceAPI final : public DeviceAPI {
     CHECK(runtime_threads) << "runtime_threads was not created in AcquireResources";
     runtime_threads.reset();
 
-    runtime_hexbuffs.Release();
-
     CHECK(runtime_vtcm) << "runtime_vtcm was not created in AcquireResources";
     runtime_vtcm.reset();
+
+    runtime_hexbuffs.Release();
   }
 
   /*! \brief Currently unimplemented interface to specify the active

--- a/tests/cpp-runtime/hexagon/hexagon_vtcm_pool_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_vtcm_pool_tests.cc
@@ -166,35 +166,33 @@ TEST_F(HexagonVtcmPoolTest, free_alloc_combinations) {
 
 // Test alignment edge cases allocating through HexagonBuffer
 TEST_F(HexagonVtcmPoolTest, vtcm_alignment) {
-  std::unique_ptr<HexagonBufferManager> test_hexbuffs = std::make_unique<HexagonBufferManager>();
+  HexagonBufferManager test_hexbuffs;
   void* ptr;
 
   // Invalid alignments
-  EXPECT_THROW(test_hexbuffs->AllocateHexagonBuffer(min_bytes, 128 + 1, String("global")),
+  EXPECT_THROW(test_hexbuffs.AllocateHexagonBuffer(min_bytes, 128 + 1, String("global")),
                InternalError);
-  EXPECT_THROW(test_hexbuffs->AllocateHexagonBuffer(min_bytes, 2048 + 1, String("global")),
+  EXPECT_THROW(test_hexbuffs.AllocateHexagonBuffer(min_bytes, 2048 + 1, String("global")),
                InternalError);
 
   // Valid alignments, sizes need to be adjusted
-  ptr = test_hexbuffs->AllocateHexagonBuffer(1, 128, String("global"));
+  ptr = test_hexbuffs.AllocateHexagonBuffer(1, 128, String("global"));
   CHECK((reinterpret_cast<uintptr_t>(ptr) & 0x7F) == 0) << "Must be multiple of 128 " << ptr;
 
-  ptr = test_hexbuffs->AllocateHexagonBuffer(127, 128, String("global"));
+  ptr = test_hexbuffs.AllocateHexagonBuffer(127, 128, String("global"));
   CHECK((reinterpret_cast<uintptr_t>(ptr) & 0x7F) == 0) << "Must be multiple of 128 " << ptr;
 
-  ptr = test_hexbuffs->AllocateHexagonBuffer(129, 128, String("global"));
+  ptr = test_hexbuffs.AllocateHexagonBuffer(129, 128, String("global"));
   CHECK((reinterpret_cast<uintptr_t>(ptr) & 0x7F) == 0) << "Must be multiple of 128 " << ptr;
 
-  ptr = test_hexbuffs->AllocateHexagonBuffer(1, 2048, String("global"));
+  ptr = test_hexbuffs.AllocateHexagonBuffer(1, 2048, String("global"));
   CHECK((reinterpret_cast<uintptr_t>(ptr) & 0x7FF) == 0) << "Must be multiple of 2k " << ptr;
 
-  ptr = test_hexbuffs->AllocateHexagonBuffer(2047, 2048, String("global"));
+  ptr = test_hexbuffs.AllocateHexagonBuffer(2047, 2048, String("global"));
   CHECK((reinterpret_cast<uintptr_t>(ptr) & 0x7FF) == 0) << "Must be multiple of 2k " << ptr;
 
-  ptr = test_hexbuffs->AllocateHexagonBuffer(2049, 2048, String("global"));
+  ptr = test_hexbuffs.AllocateHexagonBuffer(2049, 2048, String("global"));
   CHECK((reinterpret_cast<uintptr_t>(ptr) & 0x7FF) == 0) << "Must be multiple of 2k " << ptr;
-
-  test_hexbuffs.reset();
 
   // Make sure at the end we have the full amount available again
   ptr = vtcm_pool->Allocate(max_bytes);


### PR DESCRIPTION
Refactor `HexagonBufferManager` to handle post release buffer frees as a no-op using internal data structures versus returning state through the prior `current_allocations` method.