### PR TITLE
[Android] Fix cpp_rpc build for android with NDK>=23

### DIFF
--- a/apps/cpp_rpc/CMakeLists.txt
+++ b/apps/cpp_rpc/CMakeLists.txt
@@ -32,12 +32,6 @@ if (OS)
    endif()
 endif()
 
-if(USE_OPENCL)
-  if (ANDROID_ABI)
-    set_property(TARGET tvm_rpc PROPERTY LINK_FLAGS -fuse-ld=gold)
-  endif()
-endif()
-
 target_include_directories(
   tvm_rpc
   PUBLIC "../../include"


### PR DESCRIPTION
With NDK>= 23 when we specify explicitly linker then we got the following error:

```
ld.gold: --no-rosegment: unknown option
```

From the github repository of NDK, I found that the only one right way to configure linker is using `-DANDROID_LD` variable: https://github.com/android/ndk/issues/1426#issuecomment-760432467

Removed setting linker manually and by default `LLD` will be used.

Checked that it works on the following versions of NDK:
- 20.0.5594570
- 21.4.7075529
- 22.1.7171670
- 23.0.7599858
- 23.1.7779620
- 24.0.8215888
- 25.1.8937393

cc: @csullivan, @elvin-n  