### PR TITLE
[Hexagon] [runtime] Use malloc/free for RPC buffers

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -143,17 +143,6 @@ void HexagonDeviceAPI::FreeDataSpace(Device dev, void* ptr) {
   }
 }
 
-void* HexagonDeviceAPI::AllocRpcBuffer(size_t nbytes, size_t alignment) {
-  CHECK(nbytes) << "number of bytes is zero";
-  CHECK(alignment) << "alignment is zero";
-  return rpc_hexbuffs.AllocateHexagonBuffer(nbytes, alignment, String("global"));
-}
-
-void HexagonDeviceAPI::FreeRpcBuffer(void* ptr) {
-  CHECK(ptr) << "buffer pointer is null";
-  rpc_hexbuffs.FreeHexagonBuffer(ptr);
-}
-
 // WorkSpace: runtime allocations for Hexagon
 struct HexagonWorkspacePool : public WorkspacePool {
   HexagonWorkspacePool()

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -106,12 +106,6 @@ class HexagonDeviceAPI final : public DeviceAPI {
   //! \brief Free the allocated HexagonBuffer.
   void FreeDataSpace(Device dev, void* ptr) final;
 
-  //! \brief Hexagon-only interface to allocate buffers used for the RPC server
-  void* AllocRpcBuffer(size_t nbytes, size_t alignment);
-
-  //! \brief Hexagon-only interface to free buffers used for the RPC server
-  void FreeRpcBuffer(void* ptr);
-
   /*! \brief Request a dynamically allocated HexagonBuffer from a workspace pool.
    *  \returns The underlying allocation pointer.
    */
@@ -196,15 +190,10 @@ class HexagonDeviceAPI final : public DeviceAPI {
            (DLDeviceType(dev.device_type) == kDLCPU);
   }
 
-  //! \brief Manages RPC HexagonBuffer allocations
-  // rpc_hexbuffs is used only in Alloc/FreeRpcBuffer.  It is static because it lives for the
-  // lifetime of the static Device API.
-  HexagonBufferManager rpc_hexbuffs;
-
   //! \brief Manages runtime HexagonBuffer allocations
-  // runtime_hexbuffs is used for runtime allocations, separate from rpc_hexbuffs.  It is created
-  // with a call to AcquireResources, and destroyed on ReleaseResources.  The buffers in this
-  // manager are scoped to the lifetime of a user application session.
+  // runtime_hexbuffs is used for runtime allocations.  It is created with a call to
+  // AcquireResources, and destroyed on ReleaseResources.  The buffers in this manager are scoped
+  // to the lifetime of a user application session.
   std::unique_ptr<HexagonBufferManager> runtime_hexbuffs;
 
   //! \brief Keeps a list of released runtime HexagonBuffer allocations

--- a/src/runtime/hexagon/rpc/hexagon/rpc_server.cc
+++ b/src/runtime/hexagon/rpc/hexagon/rpc_server.cc
@@ -23,10 +23,10 @@ extern "C" {
 #include <HAP_farf.h>
 #include <HAP_perf.h>
 #include <qurt_error.h>
-#include <qurt_hvx.h>
 }
 
 #include <dlfcn.h>
+#include <stdlib.h>
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
@@ -158,7 +158,7 @@ class HexagonPageAllocator {
     size_t npages = ((min_size + kPageSize - 1) / kPageSize);
     void* data;
 
-    data = HexagonDeviceAPI::Global()->AllocRpcBuffer(npages * kPageSize, kPageAlign);
+    data = malloc(npages * kPageSize);
 
     ArenaPageHeader* header = static_cast<ArenaPageHeader*>(data);
     header->size = npages * kPageSize;
@@ -166,7 +166,7 @@ class HexagonPageAllocator {
     return header;
   }
 
-  void deallocate(ArenaPageHeader* page) { HexagonDeviceAPI::Global()->FreeRpcBuffer(page); }
+  void deallocate(ArenaPageHeader* page) { free(page); }
 
   static const constexpr int kPageSize = 2 << 10;
   static const constexpr int kPageAlign = 8;

--- a/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
@@ -161,19 +161,6 @@ TEST_F(HexagonDeviceAPITest, runtime_buffer_manager) {
   EXPECT_THROW(hexapi->FreeDataSpace(hex_dev, runtime_buf), InternalError);
 }
 
-// Ensure RPC buffer manager is always available
-TEST_F(HexagonDeviceAPITest, rpc_buffer_manager) {
-  void* rpc_buf;
-  rpc_buf = hexapi->AllocRpcBuffer(nbytes, alignment);
-  CHECK(rpc_buf != nullptr);
-  hexapi->ReleaseResources();
-  hexapi->FreeRpcBuffer(rpc_buf);
-  rpc_buf = hexapi->AllocRpcBuffer(nbytes, alignment);
-  CHECK(rpc_buf != nullptr);
-  hexapi->AcquireResources();
-  hexapi->FreeRpcBuffer(rpc_buf);
-}
-
 // Ensure thread manager is properly configured and destroyed
 // in Acquire/Release
 TEST_F(HexagonDeviceAPITest, thread_manager) {


### PR DESCRIPTION
Updated the RPC HexagonPageAllocator to use malloc/free, and removed rpc_hexbuffs.

cc: @adstraw 