### PR TITLE
[ci] Skip sccache for local hexagon builds

### DIFF
--- a/docker/with_the_same_user
+++ b/docker/with_the_same_user
@@ -69,6 +69,10 @@ else
     CUDA_ENV=""
 fi
 
+if [[ "$CI_IMAGE_NAME" == *"hexagon"* ]] && [[ ${CI:-false} != "true" ]]; then
+  PATH=$(echo "$PATH" | sed 's/\/opt\/sccache://g')
+fi
+
 sudo -u "#${CI_BUILD_UID}" --preserve-env \
 ${CUDA_ENV} \
 PATH=${PATH} \

--- a/tests/scripts/task_config_build_hexagon.sh
+++ b/tests/scripts/task_config_build_hexagon.sh
@@ -28,7 +28,16 @@ echo set\(USE_RPC ON\) >> config.cmake
 echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_LLVM "${CLANG_LLVM_HOME}/bin/llvm-config"\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER "/opt/sccache/clang++"\) >> config.cmake
+
+if [[ ${CI:-false} == "true" ]]; then
+    # sccache needs to be used in CI to speed up builds
+    echo set\(CMAKE_CXX_COMPILER "/opt/sccache/clang++"\) >> config.cmake
+else
+    echo 'Skipping sccache setup for local build'
+    echo set\(CMAKE_CXX_COMPILER \"/usr/bin/c++\"\) >> config.cmake
+    echo set\(CMAKE_C_COMPILER \"/usr/bin/cc\"\) >> config.cmake
+fi
+
 echo set\(USE_HEXAGON "ON"\) >> config.cmake
 echo set\(USE_HEXAGON_SDK "${HEXAGON_SDK_ROOT}"\) >> config.cmake
 echo set\(USE_CCACHE OFF\) >> config.cmake


### PR DESCRIPTION
sccache chokes on the hexagon builds for some users, so this disables it
by default locally but keeps it on in CI.

cc @adstraw @janetsc 