### PR TITLE
[TIR][Arith] Implement kApplyConstraintsToBooleanBranches extension

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -305,6 +305,19 @@ class RewriteSimplifier {
      *   (a && b) || c => (a || c) && (b || c)
      */
     kConvertBooleanToAndOfOrs = (1 << 1),
+
+    /* When simplifying a boolean AND or a boolean OR, simplify each
+     * branch under the assumption that the other branch does not
+     * already dominate the result.  That is, simplify each branch of
+     * (A && B) under the assumption that the other branch is true,
+     * and simplify each branch of (A || B) under the assumption that
+     * the other branch is false.
+     *
+     * Example:
+     *   (n < 10) && (n < 5) => (n < 10)
+     *   (n < 10) || (n < 5) => (n < 5)
+     */
+    kApplyConstraintsToBooleanBranches = (1 << 2),
   };
 
   /*! \brief Enable an optional extension or extensions

--- a/src/tir/transforms/simplify.cc
+++ b/src/tir/transforms/simplify.cc
@@ -39,6 +39,7 @@ using namespace tir;
 struct SimplifyConfigNode : public tvm::AttrsNode<SimplifyConfigNode> {
   bool transitively_prove_inequalities;
   bool convert_boolean_to_and_of_ors;
+  bool apply_constraints_to_boolean_branches;
 
   TVM_DECLARE_ATTRS(SimplifyConfigNode, "tir.transform.SimplifyConfig") {
     TVM_ATTR_FIELD(transitively_prove_inequalities)
@@ -48,6 +49,12 @@ struct SimplifyConfigNode : public tvm::AttrsNode<SimplifyConfigNode> {
 
     TVM_ATTR_FIELD(convert_boolean_to_and_of_ors)
         .describe("If true, simplify conditionals into an AND of ORs")
+        .set_default(false);
+
+    TVM_ATTR_FIELD(apply_constraints_to_boolean_branches)
+        .describe(
+            "If true, simplify each branch of AND/OR "
+            "under a constraints provided by the other branch")
         .set_default(false);
   }
 
@@ -59,6 +66,10 @@ struct SimplifyConfigNode : public tvm::AttrsNode<SimplifyConfigNode> {
     }
     if (convert_boolean_to_and_of_ors) {
       flags = RewriteSimplifier::Extension(flags | RewriteSimplifier::kConvertBooleanToAndOfOrs);
+    }
+    if (apply_constraints_to_boolean_branches) {
+      flags = RewriteSimplifier::Extension(flags |
+                                           RewriteSimplifier::kApplyConstraintsToBooleanBranches);
     }
     return flags;
   }

--- a/tests/python/unittest/test_tir_transform_simplify.py
+++ b/tests/python/unittest/test_tir_transform_simplify.py
@@ -139,6 +139,7 @@ def test_complex_likely_elimination():
 class BaseBeforeAfter(tvm.testing.CompareBeforeAfter):
     transitively_prove_inequalities = False
     convert_boolean_to_and_of_ors = False
+    apply_constraints_to_boolean_branches = False
 
     def transform(self):
         def inner(mod):
@@ -146,6 +147,7 @@ class BaseBeforeAfter(tvm.testing.CompareBeforeAfter):
                 "tir.Simplify": {
                     "transitively_prove_inequalities": self.transitively_prove_inequalities,
                     "convert_boolean_to_and_of_ors": self.convert_boolean_to_and_of_ors,
+                    "apply_constraints_to_boolean_branches": self.apply_constraints_to_boolean_branches,
                 }
             }
             with tvm.transform.PassContext(config=config):
@@ -843,6 +845,148 @@ class TestConditionalFloorMod(BaseBeforeAfter):
     def expected(A: T.Buffer[1, "bool"], i: T.int32):
         if T.floormod(i, -2) == 0:
             A[0] = True
+
+
+class TestSimplifyRHSOfBooleanAndUsingLHS(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts.
+
+    In `A and B`, the result of `B` only matters when `A` is
+    true, and can be simplified under that context.  This test
+    simplifies `n < 10` under the assumption that `n < 5`.
+    """
+
+    apply_constraints_to_boolean_branches = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 5 and n < 10
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 5
+
+
+class TestSimplifyLHSOfBooleanAndUsingRHS(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts for their arguments.
+
+    Like TestSimplifyRHSOfBooleanAndUsingLHS, but using the RHS to
+    simplify the LHS.
+    """
+
+    apply_constraints_to_boolean_branches = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 10 and n < 5
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 5
+
+
+class TestSimplifyRHSOfBooleanOrUsingLHS(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts.
+
+    In `A or B`, the result of `B` only matters when `A` is false, so
+    `B` can be simplified under the assumption that `A` is false.
+    This test simplifies `n < 5` under the assumption that `!(n < 10)`
+    """
+
+    apply_constraints_to_boolean_branches = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 10 or n < 5
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 10
+
+
+class TestSimplifyLHSOfBooleanOrUsingRHS(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts for their arguments.
+
+    Like TestSimplifyRHSOfBooleanOrUsingLHS, but using the RHS to
+    simplify the LHS.
+    """
+
+    apply_constraints_to_boolean_branches = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 5 or n < 10
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32):
+        A[0] = n < 10
+
+
+class TestSimplifyRHSOfBooleanAndUsingLHSWithoutConst(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts.
+
+    Like TestSimplifyRHSOfBooleanAndUsingLHS, but with variables in
+    the conditions, preventing ConstIntBoundAnalyzer from handling it.
+    This proof requires the extension to transitively prove
+    inequalities.
+    """
+
+    apply_constraints_to_boolean_branches = True
+    transitively_prove_inequalities = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 5 and n < m + 10
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 5
+
+
+class TestSimplifyLHSOfBooleanAndUsingRHSWithoutConst(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts for their arguments.
+
+    Like TestSimplifyLHSOfBooleanAndUsingRHS, but with variables in
+    the conditions, preventing ConstIntBoundAnalyzer from handling it.
+    This proof requires the extension to transitively prove
+    inequalities.
+    """
+
+    apply_constraints_to_boolean_branches = True
+    transitively_prove_inequalities = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 10 and n < m + 5
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 5
+
+
+class TestSimplifyRHSOfBooleanOrUsingLHSWithoutConst(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts.
+
+    Like TestSimplifyRHSOfBooleanOrUsingLHS, but with variables in the
+    conditions, preventing ConstIntBoundAnalyzer from handling it.
+    This proof requires the extension to transitively prove
+    inequalities.
+    """
+
+    apply_constraints_to_boolean_branches = True
+    transitively_prove_inequalities = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 10 or n < m + 5
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 10
+
+
+class TestSimplifyLHSOfBooleanOrUsingRHSWithoutConst(BaseBeforeAfter):
+    """Boolean expressions can introduce contexts for their arguments.
+
+    Like TestSimplifyLHSOfBooleanOrUsingRHS, but with variables in the
+    conditions, preventing ConstIntBoundAnalyzer from handling it.
+    This proof requires the extension to transitively prove
+    inequalities.
+    """
+
+    apply_constraints_to_boolean_branches = True
+    transitively_prove_inequalities = True
+
+    def before(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 5 or n < m + 10
+
+    def expected(A: T.Buffer[1, "bool"], n: T.int32, m: T.int32):
+        A[0] = n < m + 10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When simplifying a branch of a boolean AND or a boolean OR, the other branch may be assumed not to dominate the result of the operator.  For example, when simplifying `(A and B)`, `A` may be simplified on the assumption that `B` is true.  Similarly, when simplifying `(A or B)`, `A` may be simplified on the assumption that `B` is false.

Prior to this commit, these constraints were not used for simplifications.  This commit introduced an optional extension, `kApplyConstraintsToBooleanBranches`, which exposes these constraints for simplification.  This isn't enabled by default, as some cases require a second visit to each branch of a boolean operator.  (e.g. Simplifying the LHS of an operator, using a constraint provided by the RHS, where the sub-analyzer that uses the constraint expects it to already be simplified.)