### PR TITLE
[Hexagon] Add scripts for e2e MetaSchedule tuning demonstration

### DIFF
--- a/python/tvm/tir/tensor_intrin/hexagon.py
+++ b/python/tvm/tir/tensor_intrin/hexagon.py
@@ -64,8 +64,58 @@ def dot_product_32x4_u8u8i32_vrmpy(
         )
 
 
+@T.prim_func
+def dot_product_32x4_u8i8i32_desc(
+    A: T.Buffer((4,), "uint8", offset_factor=1),
+    B: T.Buffer((32, 4), "int8", offset_factor=1),
+    C: T.Buffer((32,), "int32", offset_factor=1),
+) -> None:
+    with T.block("root"):
+        T.reads(C[0:32], A[0:4], B[0:32, 0:4])
+        T.writes(C[0:32])
+        for i in T.serial(0, 32):
+            with T.init():
+                C[i] = T.int32(0)
+            for k in T.serial(0, 4):
+                with T.block("update"):
+                    vi, vk = T.axis.remap("SR", [i, k])
+                    C[vi] = C[vi] + T.cast(A[vk], "int32") * T.cast(B[vi, vk], "int32")
+
+
+@T.prim_func
+def dot_product_32x4_u8i8i32_vrmpy(
+    A: T.Buffer((4,), "uint8", offset_factor=1),
+    B: T.Buffer((32, 4), "int8", offset_factor=1),
+    C: T.Buffer((32,), "int32", offset_factor=1),
+) -> None:
+    with T.block("root"):
+        T.reads(C[0:32], A[0:4], B[0:32, 0:4])
+        T.writes(C[0:32])
+
+        A_u8x4 = A.vload([0], "uint8x4")
+        A_i32 = T.reinterpret(A_u8x4, dtype="int32")
+
+        B_i8x128 = B.vload([0, 0], dtype="int8x128")
+        B_i32x32 = T.reinterpret(B_i8x128, dtype="int32x32")
+
+        C[T.ramp(T.int32(0), 1, 32)] = T.call_llvm_pure_intrin(
+            T.llvm_lookup_intrinsic_id("llvm.hexagon.V6.vrmpybusv.acc.128B"),
+            T.uint32(3),
+            C[T.ramp(T.int32(0), 1, 32)],
+            T.broadcast(A_i32, 32),
+            B_i32x32,
+            dtype="int32x32",
+        )
+
+
 VRMPY_u8u8i32_INTRIN = "dot_32x4_u8u8i32_vrmpy"
 
 TensorIntrin.register(
     VRMPY_u8u8i32_INTRIN, dot_product_32x4_u8u8i32_desc, dot_product_32x4_u8u8i32_vrmpy
+)
+
+VRMPY_u8i8i32_INTRIN = "dot_32x4_u8i8i32_vrmpy"
+
+TensorIntrin.register(
+    VRMPY_u8i8i32_INTRIN, dot_product_32x4_u8i8i32_desc, dot_product_32x4_u8i8i32_vrmpy
 )

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -457,9 +457,10 @@ class TVMScriptPrinter : public StmtFunctor<Doc(const Stmt&)>,
  */
 template <typename T>
 void NDArrayToTIR(::tvm::runtime::NDArray arr, std::ostream& os) {
-  if (arr.DataType().code() == runtime::DataType::kInt ||
-      arr.DataType().code() == runtime::DataType::kUInt) {
-    // Printing integer NDArrays causes "UnicodeDecodeError: 'utf-8' codec can't decode byte"
+  if ((arr.DataType().code() == runtime::DataType::kInt ||
+       arr.DataType().code() == runtime::DataType::kUInt) &&
+      arr.DataType().bits() == 8) {
+    // Printing int8 NDArrays causes "UnicodeDecodeError: 'utf-8' codec can't decode byte"
     // error during MetaSchedule tuning on int8 models.
     return;
   }

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -457,6 +457,12 @@ class TVMScriptPrinter : public StmtFunctor<Doc(const Stmt&)>,
  */
 template <typename T>
 void NDArrayToTIR(::tvm::runtime::NDArray arr, std::ostream& os) {
+  if (arr.DataType().code() == runtime::DataType::kInt ||
+      arr.DataType().code() == runtime::DataType::kUInt) {
+    // Printing integer NDArrays causes "UnicodeDecodeError: 'utf-8' codec can't decode byte"
+    // error during MetaSchedule tuning on int8 models.
+    return;
+  }
   int ndim = arr->ndim;
   int tot_dim = 1;
   for (int i = 0; i < ndim; i++) {
@@ -1166,7 +1172,7 @@ Doc TVMScriptPrinter::VisitStmt_(const AllocateConstNode* alloc) {
     }
   } else if (alloc->dtype.is_uint()) {
     if (alloc->dtype.bits() == 8) {
-      // NDArrayToTIR<uint8_t>(data, ss);
+      NDArrayToTIR<uint8_t>(data, ss);
     } else if (alloc->dtype.bits() == 16) {
       NDArrayToTIR<uint16_t>(data, ss);
     } else if (alloc->dtype.bits() == 32) {

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/__init__.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Demonstration of end-to-end MetaSchedule tuning."""

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/export_models.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/export_models.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import torch
+from torchvision.models import resnet
+from torchvision.models.quantization import resnet as qresnet
+
+import tvm
+from tvm import relay
+
+
+def export_resnet50_fp16():
+    model = resnet.resnet50(pretrained=True).eval()
+
+    pt_inp = torch.randn(1, 3, 224, 224)
+
+    script_module = torch.jit.trace(model, pt_inp).eval()
+
+    input_name = "image"
+    input_shapes = [(input_name, pt_inp.shape)]
+    mod, params = relay.frontend.from_pytorch(script_module, input_shapes)
+    mod = relay.transform.ToMixedPrecision("float16")(mod)
+
+    with open("resnet50_fp16.json", "w") as fo:
+        fo.write(tvm.ir.save_json(mod))
+
+    with open("resnet50_fp16.params", "wb") as fo:
+        fo.write(relay.save_param_dict(params))
+
+
+def export_resnet50_int8():
+    def quantize_model(model, inp):
+        model.fuse_model()
+        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        torch.quantization.prepare(model, inplace=True)
+        model(inp)
+        torch.quantization.convert(model, inplace=True)
+
+    model = qresnet.resnet50(pretrained=True).eval()
+
+    pt_inp = torch.randn(1, 3, 224, 224)
+    quantize_model(model, pt_inp)
+
+    script_module = torch.jit.trace(model, pt_inp).eval()
+
+    input_name = "image"
+    input_shapes = [(input_name, pt_inp.shape)]
+    mod, params = relay.frontend.from_pytorch(
+        script_module, input_shapes, keep_quantized_weight=True
+    )
+
+    with open("resnet50_int8.json", "w") as fo:
+        fo.write(tvm.ir.save_json(mod))
+
+    with open("resnet50_int8.params", "wb") as fo:
+        fo.write(relay.save_param_dict(params))
+
+
+if __name__ == "__main__":
+    export_resnet50_fp16()
+    export_resnet50_int8()

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_fp16.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_fp16.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import pytest
+import tempfile
+
+import numpy as np
+
+import tvm.testing
+from tvm import relay
+from tvm import meta_schedule as ms
+from tvm.contrib.hexagon.meta_schedule import get_hexagon_local_builder, get_hexagon_rpc_runner
+from tvm.relay.backend import Executor
+from ..infrastructure import get_hexagon_target
+
+
+target = get_hexagon_target("v69")
+target_llvm = tvm.target.Target("llvm")
+model_json = "resnet50_fp16.json"
+model_params = "resnet50_fp16.params"
+
+
+def convert_conv2d_layout(mod, desired_layouts):
+    with tvm.transform.PassContext(opt_level=3):
+        seq = tvm.transform.Sequential([relay.transform.ConvertLayout(desired_layouts)])
+        return seq(mod)
+
+
+@pytest.mark.skip("End-to-end tuning is skipped on CI.")
+@tvm.testing.requires_hexagon
+def test_resnet50(hexagon_launcher):
+    if not os.path.exists(model_json):
+        pytest.skip(msg="Run python export_models.py first.")
+
+    with open(model_json, "r") as fi:
+        mod = tvm.ir.load_json(fi.read())
+
+    with open(model_params, "rb") as fi:
+        params = relay.load_param_dict(fi.read())
+
+    mod = convert_conv2d_layout(mod, {"nn.conv2d": ["NHWC", "HWIO"]})
+
+    inp = np.random.randn(1, 3, 224, 224).astype("float32")
+    input_name = "image"
+
+    executor = Executor("graph", {"link-params": True})
+    # This line is necessary for link-params to take effect during
+    # task extraction and relay.build(...).
+    mod = mod.with_attr("executor", executor)
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        database = ms.relay_integration.tune_relay(
+            mod=mod,
+            target=target,
+            params=params,
+            work_dir=work_dir,
+            # for faster tuning
+            max_trials_global=20000,
+            max_trials_per_task=8,
+            num_trials_per_iter=8,
+            strategy="replay-trace",
+            # max_trials_global=20000,
+            # num_trials_per_iter=32,
+            # max_trials_per_task=128,
+            # strategy="evolutionary",
+            builder=get_hexagon_local_builder(),
+            runner=get_hexagon_rpc_runner(hexagon_launcher, number=20),
+            # Without this, the same workloads with different constant weights
+            # are treated as distinct tuning tasks.
+            module_equality="ignore-ndarray",
+        )
+
+        hexagon_lowered = ms.relay_integration.compile_relay(
+            database=database,
+            mod=mod,
+            target=target,
+            params=params,
+        )
+
+    with tvm.transform.PassContext(opt_level=3):
+        llvm_lowered = tvm.relay.build(
+            mod,
+            tvm.target.Target(target_llvm, host=target_llvm),
+            params=params,
+        )
+
+        llvm_graph_mod = tvm.contrib.graph_executor.GraphModule(llvm_lowered["default"](tvm.cpu(0)))
+        llvm_graph_mod.set_input(input_name, inp.copy())
+        llvm_graph_mod.run()
+        ref_result = llvm_graph_mod.get_output(0).numpy()
+
+    with hexagon_launcher.start_session() as session:
+        graph_mod = session.get_executor_from_factory(hexagon_lowered)
+        graph_mod.set_input(input_name, inp.copy())
+
+        graph_mod.run()
+        hexagon_output = graph_mod.get_output(0).numpy()
+
+        print(
+            "max and mean abs difference with the reference:",
+            np.max(np.abs(ref_result - hexagon_output)),
+            np.mean(np.abs(ref_result - hexagon_output)),
+        )
+
+        time_ms = graph_mod.benchmark(session.device, number=1, repeat=20).mean * 1e3
+
+        print("time elapsed: ", time_ms)
+
+        debug_ex = session.get_graph_debug_executor(
+            hexagon_lowered.get_graph_json(), hexagon_lowered.lib
+        )
+        print(debug_ex.profile(input_name=inp.copy()))

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_fp16.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_fp16.py
@@ -110,11 +110,13 @@ def test_resnet50(hexagon_launcher):
         graph_mod.run()
         hexagon_output = graph_mod.get_output(0).numpy()
 
+        # Example output: max and mean abs difference with the reference: 0.1406 0.0126
         print(
             "max and mean abs difference with the reference:",
             np.max(np.abs(ref_result - hexagon_output)),
             np.mean(np.abs(ref_result - hexagon_output)),
         )
+        tvm.testing.assert_allclose(ref_result, hexagon_output, atol=2e-1)
 
         time_ms = graph_mod.benchmark(session.device, number=1, repeat=20).mean * 1e3
 

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_int8.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_int8.py
@@ -1,0 +1,186 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import numpy as np
+import pytest
+import tempfile
+
+import tvm
+import tvm.testing
+from tvm import relay
+from tvm.meta_schedule import postproc, schedule_rule
+from tvm.tir.tensor_intrin.hexagon import VRMPY_u8i8i32_INTRIN, VRMPY_u8u8i32_INTRIN
+from tvm.contrib.hexagon.meta_schedule import get_hexagon_local_builder, get_hexagon_rpc_runner
+from tvm import meta_schedule as ms
+from ..infrastructure import get_hexagon_target
+
+
+executor = relay.backend.Executor("graph", {"link-params": True})
+target = get_hexagon_target("v68")
+target_llvm = tvm.target.Target("llvm")
+model_json = "resnet50_int8.json"
+model_params = "resnet50_int8.params"
+
+
+def tune_vrmpy_auto_tensorize(mod, params, hexagon_launcher):
+    sch_rules = [
+        schedule_rule.AutoInline(
+            into_producer=False,
+            into_consumer=True,
+            inline_const_tensor=True,
+            disallow_if_then_else=True,
+            require_injective=True,
+            require_ordered=True,
+            disallow_op=["tir.exp"],
+        ),
+        # VRMPY_u8i8i32_INTRIN is used for conv2d. See topi/hexagon/conv2d_alter_op.py
+        # for why we use different intrins for conv2d and dense.
+        schedule_rule.MultiLevelTilingWithIntrin(
+            VRMPY_u8i8i32_INTRIN,
+            structure="SRSRS",
+            tile_binds=None,
+            max_innermost_factor=64,
+            vector_load_lens=None,
+            reuse_read=None,
+            reuse_write=schedule_rule.ReuseType(
+                req="may",
+                levels=[1, 2],
+                scope="global",
+            ),
+        ),
+        # VRMPY_u8u8i32_INTRIN is used for dense
+        schedule_rule.MultiLevelTilingWithIntrin(
+            VRMPY_u8u8i32_INTRIN,
+            structure="SRSRS",
+            tile_binds=None,
+            max_innermost_factor=64,
+            vector_load_lens=None,
+            reuse_read=None,
+            reuse_write=schedule_rule.ReuseType(
+                req="may",
+                levels=[1, 2],
+                scope="global",
+            ),
+        ),
+        schedule_rule.ParallelizeVectorizeUnroll(
+            max_jobs_per_core=16,
+            max_vectorize_extent=128,
+            unroll_max_steps=[0, 16, 64, 512],
+            unroll_explicit=True,
+        ),
+    ]
+
+    postprocs = [
+        postproc.RewriteParallelVectorizeUnroll(),
+        postproc.RewriteReductionBlock(),
+        postproc.RewriteTensorize(vectorize_init_loop=True),
+    ]
+
+    # This line is necessary for link-params to take effect during
+    # task extraction and relay.build(...).
+    mod = mod.with_attr("executor", executor)
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        database = ms.relay_integration.tune_relay(
+            mod=mod,
+            target=target,
+            params=params,
+            work_dir=work_dir,
+            # for faster tuning
+            max_trials_global=20000,
+            max_trials_per_task=8,
+            num_trials_per_iter=8,
+            strategy="replay-trace",
+            # max_trials_global=20000,
+            # num_trials_per_iter=32,
+            # max_trials_per_task=128,
+            # strategy="evolutionary",
+            builder=get_hexagon_local_builder(),
+            runner=get_hexagon_rpc_runner(hexagon_launcher, number=20),
+            space=ms.space_generator.PostOrderApply(
+                sch_rules=sch_rules,
+                postprocs=postprocs,
+                mutator_probs={},
+            ),
+            # Without this, the same workloads with different constant weights
+            # are treated as distinct tuning tasks.
+            module_equality="ignore-ndarray",
+        )
+
+        return ms.relay_integration.compile_relay(
+            database=database,
+            mod=mod,
+            target=target,
+            params=params,
+        )
+
+
+@pytest.mark.skip("End-to-end tuning is skipped on CI.")
+@tvm.testing.requires_hexagon
+def test_resnet50(hexagon_launcher):
+    if not os.path.exists(model_json):
+        pytest.skip(msg="Run python export_models.py first.")
+
+    with open(model_json, "r") as fi:
+        mod = tvm.ir.load_json(fi.read())
+
+    with open(model_params, "rb") as fi:
+        params = relay.load_param_dict(fi.read())
+    inp = np.random.randn(1, 3, 224, 224).astype("float32")
+    input_name = "image"
+
+    do_tune = True
+
+    if do_tune:
+        hexagon_lowered = tune_vrmpy_auto_tensorize(mod, params, hexagon_launcher)
+    else:
+        with tvm.transform.PassContext(opt_level=3):
+            hexagon_lowered = relay.build(
+                mod,
+                tvm.target.Target(target, host=target),
+                params=params,
+                executor=executor,
+            )
+
+    with tvm.transform.PassContext(opt_level=3):
+        llvm_lowered = tvm.relay.build(
+            mod,
+            tvm.target.Target(target_llvm, host=target_llvm),
+            params=params,
+        )
+
+    with hexagon_launcher.start_session() as session:
+        graph_mod = session.get_executor_from_factory(hexagon_lowered)
+        graph_mod.set_input(input_name, inp.copy())
+        graph_mod.run()
+        hexagon_output = graph_mod.get_output(0).numpy()
+
+        llvm_graph_mod = tvm.contrib.graph_executor.GraphModule(llvm_lowered["default"](tvm.cpu(0)))
+        llvm_graph_mod.set_input(input_name, inp.copy())
+        llvm_graph_mod.run()
+        ref_result = llvm_graph_mod.get_output(0).numpy()
+
+        np.testing.assert_allclose(ref_result, hexagon_output, atol=1e-4, rtol=1e-5)
+
+        time_ms = graph_mod.benchmark(session.device, number=1, repeat=20).mean * 1e3
+
+        print("time elapsed: ", time_ms)
+
+        debug_ex = session.get_graph_debug_executor(
+            hexagon_lowered.get_graph_json(), hexagon_lowered.lib
+        )
+        print(debug_ex.profile(input_name=inp.copy()))

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2808,17 +2808,17 @@ def module_const():
 
         @T.prim_func
         def B(a: T.handle, c: T.handle) -> None:
-            A = T.match_buffer(a, (10), "int32")
-            C = T.match_buffer(c, (10), "int32")
-            B = T.alloc_buffer((10), "int32")
+            A = T.match_buffer(a, (10), "float32")
+            C = T.match_buffer(c, (10), "float32")
+            B = T.alloc_buffer((10), "float32")
 
-            K1_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "int32", [10])
-            K1 = T.buffer_decl(shape=[10], dtype="int32", data=K1_data)
+            K1_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "float32", [10])
+            K1 = T.buffer_decl(shape=[10], dtype="float32", data=K1_data)
             for x in T.serial(0, 10):
                 B[x] = A[x] + K1[x]
 
-            K2_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "int32", [10])
-            K2 = T.buffer_decl(shape=[10], dtype="int32", data=K2_data)
+            K2_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "float32", [10])
+            K2 = T.buffer_decl(shape=[10], dtype="float32", data=K2_data)
             for x in T.serial(0, 10):
                 B[x] = B[x] + K2[x]
 
@@ -2831,11 +2831,11 @@ def module_const():
 def constant():
     @T.prim_func
     def constant(a: T.handle, c: T.handle) -> None:
-        A = T.match_buffer(a, (10), "int32")
-        C = T.match_buffer(c, (10), "int32")
-        B = T.alloc_buffer((10), "int32")
-        K_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "int32", [10])
-        K = T.buffer_decl(shape=[10], dtype="int32", data=K_data)
+        A = T.match_buffer(a, (10), "float32")
+        C = T.match_buffer(c, (10), "float32")
+        B = T.alloc_buffer((10), "float32")
+        K_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "float32", [10])
+        K = T.buffer_decl(shape=[10], dtype="float32", data=K_data)
         for x in T.serial(0, 10):
             B[x] = A[x] + K[x]
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -2808,17 +2808,17 @@ def module_const():
 
         @T.prim_func
         def B(a: T.handle, c: T.handle) -> None:
-            A = T.match_buffer(a, (10), "float32")
-            C = T.match_buffer(c, (10), "float32")
-            B = T.alloc_buffer((10), "float32")
+            A = T.match_buffer(a, (10), "int32")
+            C = T.match_buffer(c, (10), "int32")
+            B = T.alloc_buffer((10), "int32")
 
-            K1_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "float32", [10])
-            K1 = T.buffer_decl(shape=[10], dtype="float32", data=K1_data)
+            K1_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "int32", [10])
+            K1 = T.buffer_decl(shape=[10], dtype="int32", data=K1_data)
             for x in T.serial(0, 10):
                 B[x] = A[x] + K1[x]
 
-            K2_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "float32", [10])
-            K2 = T.buffer_decl(shape=[10], dtype="float32", data=K2_data)
+            K2_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "int32", [10])
+            K2 = T.buffer_decl(shape=[10], dtype="int32", data=K2_data)
             for x in T.serial(0, 10):
                 B[x] = B[x] + K2[x]
 
@@ -2831,11 +2831,11 @@ def module_const():
 def constant():
     @T.prim_func
     def constant(a: T.handle, c: T.handle) -> None:
-        A = T.match_buffer(a, (10), "float32")
-        C = T.match_buffer(c, (10), "float32")
-        B = T.alloc_buffer((10), "float32")
-        K_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "float32", [10])
-        K = T.buffer_decl(shape=[10], dtype="float32", data=K_data)
+        A = T.match_buffer(a, (10), "int32")
+        C = T.match_buffer(c, (10), "int32")
+        B = T.alloc_buffer((10), "int32")
+        K_data = T.allocate_const([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "int32", [10])
+        K = T.buffer_decl(shape=[10], dtype="int32", data=K_data)
         for x in T.serial(0, 10):
             B[x] = A[x] + K[x]
 


### PR DESCRIPTION
I've worked on a series of PRs to enable e2e MS tuning on Hexagon (mostly for supporting `link-params = True` in MS). Now that all the pieces have been upstreamed, I'm adding demo tuning scripts under `test_hexagon/metaschedule_e2e`. 

They are not run on CI, and running it locally requires PyTorch to generate fp16 and int8 resnet50. 

The scripts use a small number of tuning trials and `replay-trace` search strategy instead of the evolutionary search, to finish tuning quickly. Those interested in MS tuning can tweak these settings for better performance at the cost of more tuning times.

@csullivan @kparzysz-quic @farshidsp  