### PR TITLE
[Hexagon] [runtime] Remove released buffer check for post-ReleaseResources calls to FreeDataSpace

### DIFF
--- a/src/runtime/hexagon/hexagon_buffer_manager.h
+++ b/src/runtime/hexagon/hexagon_buffer_manager.h
@@ -35,6 +35,12 @@ namespace hexagon {
 
 class HexagonBufferManager {
  public:
+  ~HexagonBufferManager() {
+    if (!hexagon_buffer_map_.empty()) {
+      DLOG(INFO) << "HexagonBufferManager is not empty upon destruction";
+    }
+  }
+
   /*!
    * \brief Free a HexagonBuffer.
    * \param ptr Address of the HexagonBuffer as returned by `AllocateHexagonBuffer`.
@@ -78,12 +84,6 @@ class HexagonBufferManager {
       return it->second.get();
     }
     return nullptr;
-  }
-
-  //! \brief Returns whether the HexagonBufferManager has any allocations.
-  bool empty() {
-    std::lock_guard<std::mutex> lock(map_mutex_);
-    return hexagon_buffer_map_.empty();
   }
 
  private:

--- a/src/runtime/hexagon/hexagon_buffer_manager.h
+++ b/src/runtime/hexagon/hexagon_buffer_manager.h
@@ -86,18 +86,6 @@ class HexagonBufferManager {
     return hexagon_buffer_map_.empty();
   }
 
-  //! \brief Returns a vector of currently allocated pointers, owned by the manager.
-  // Note - this should only be used by the device API to keep track of what
-  // was in the manager when HexagonDeviceAPI::ReleaseResources is called.
-  std::vector<void*> current_allocations() {
-    std::vector<void*> allocated;
-    std::lock_guard<std::mutex> lock(map_mutex_);
-    for (const auto& [data_ptr, buffer] : hexagon_buffer_map_) {
-      allocated.push_back(data_ptr);
-    }
-    return allocated;
-  }
-
  private:
   //! \brief Contains the HexagonBuffer objects managed by this class.
   std::unordered_map<void*, std::unique_ptr<HexagonBuffer>> hexagon_buffer_map_;

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -132,14 +132,9 @@ void HexagonDeviceAPI::FreeDataSpace(Device dev, void* ptr) {
   if (runtime_hexbuffs) {
     runtime_hexbuffs->FreeHexagonBuffer(ptr);
   } else {
-    // Either AcquireResources was never called, or ReleaseResources was called.  Check the
-    // list of buffers that were still allocated at the time of release.  If this buffer is
-    // in that list, this is a no-op as it is being freed as part of another object teardown.
-    // If the pointer isn't in that list, we raise an exception as this is an unexpected Free.
-    auto it = std::find(released_runtime_buffers.begin(), released_runtime_buffers.end(), ptr);
-    CHECK(it != released_runtime_buffers.end()) << "Attempted to free Hexagon data with "
-                                                << "HexagonDeviceAPI::FreeDataSpace that was not "
-                                                << "allocated during the session.";
+    // Either AcquireResources was never called, or ReleaseResources was called.  Since this can
+    // occur in the normal course of shutdown, log a message and continue.
+    LOG(INFO) << "FreeDataSpace called outside a session for " << ptr;
   }
 }
 

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -134,7 +134,7 @@ void HexagonDeviceAPI::FreeDataSpace(Device dev, void* ptr) {
   } else {
     // Either AcquireResources was never called, or ReleaseResources was called.  Since this can
     // occur in the normal course of shutdown, log a message and continue.
-    LOG(INFO) << "FreeDataSpace called outside a session for " << ptr;
+    DLOG(INFO) << "FreeDataSpace called outside a session for " << ptr;
   }
 }
 

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -77,9 +77,6 @@ class HexagonDeviceAPI final : public DeviceAPI {
     runtime_threads.reset();
 
     CHECK(runtime_hexbuffs) << "runtime_hexbuffs was not created in AcquireResources";
-    if (!runtime_hexbuffs->empty()) {
-      LOG(INFO) << "runtime_hexbuffs was not empty in ReleaseResources";
-    }
     runtime_hexbuffs.reset();
 
     CHECK(runtime_vtcm) << "runtime_vtcm was not created in AcquireResources";

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -60,7 +60,6 @@ class HexagonDeviceAPI final : public DeviceAPI {
 
     CHECK_EQ(runtime_hexbuffs, nullptr);
     runtime_hexbuffs = std::make_unique<HexagonBufferManager>();
-    released_runtime_buffers.clear();
 
     CHECK_EQ(runtime_threads, nullptr);
     runtime_threads = std::make_unique<HexagonThreadManager>(threads, stack_size, pipe_size);
@@ -79,8 +78,7 @@ class HexagonDeviceAPI final : public DeviceAPI {
 
     CHECK(runtime_hexbuffs) << "runtime_hexbuffs was not created in AcquireResources";
     if (!runtime_hexbuffs->empty()) {
-      DLOG(INFO) << "runtime_hexbuffs was not empty in ReleaseResources";
-      released_runtime_buffers = runtime_hexbuffs->current_allocations();
+      LOG(INFO) << "runtime_hexbuffs was not empty in ReleaseResources";
     }
     runtime_hexbuffs.reset();
 
@@ -195,11 +193,6 @@ class HexagonDeviceAPI final : public DeviceAPI {
   // AcquireResources, and destroyed on ReleaseResources.  The buffers in this manager are scoped
   // to the lifetime of a user application session.
   std::unique_ptr<HexagonBufferManager> runtime_hexbuffs;
-
-  //! \brief Keeps a list of released runtime HexagonBuffer allocations
-  // ReleaseResources can be called when there are still buffers in runtime_hexbuffs.  This list
-  // stores the buffers that were released.
-  std::vector<void*> released_runtime_buffers;
 
   //! \brief Thread manager
   std::unique_ptr<HexagonThreadManager> runtime_threads;


### PR DESCRIPTION
The motivation behind resource management is to ensure that we release all resources at the end of the session.

Given the session management on the client side, it is possible for ReleaseResources to be called before all client side objects have been torn down.  And, it is possible for frees to be called in the window between session end and process termination.  (After those buffers have been freed in ReleaseResources.)

Based on feedback from @adstraw and @Lunderberg on the usage of "released_runtime_buffers," we did an investigation into the post-release frees.  The cleanest solution is to keep the logic to free all buffers in ReleaseResources, and log a message on any frees that are executed outside a session.