### PR TITLE
[ci] Ignore JUnit upload failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-10-04T13:17:33.929159
+// Generated at 2022-10-19T13:44:32.119961
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -116,8 +116,9 @@ def per_exec_ws(folder) {
 
 // initialize source codes
 def init_git() {
-  checkout scm
-
+  retry(5) {
+    checkout scm
+  }
 
   // Add more info about job node
   sh (
@@ -1134,7 +1135,8 @@ def shard_run_unittest_GPU_1_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1143,7 +1145,10 @@ def shard_run_unittest_GPU_1_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1198,7 +1203,8 @@ def shard_run_unittest_GPU_2_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1207,7 +1213,10 @@ def shard_run_unittest_GPU_2_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1258,7 +1267,8 @@ def shard_run_unittest_GPU_3_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1267,7 +1277,10 @@ def shard_run_unittest_GPU_3_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1317,7 +1330,8 @@ def shard_run_integration_CPU_1_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1326,7 +1340,10 @@ def shard_run_integration_CPU_1_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1375,7 +1392,8 @@ def shard_run_integration_CPU_2_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1384,7 +1402,10 @@ def shard_run_integration_CPU_2_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1433,7 +1454,8 @@ def shard_run_integration_CPU_3_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1442,7 +1464,10 @@ def shard_run_integration_CPU_3_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1491,7 +1516,8 @@ def shard_run_integration_CPU_4_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1500,7 +1526,10 @@ def shard_run_integration_CPU_4_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1550,7 +1579,8 @@ def shard_run_python_i386_1_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1559,7 +1589,10 @@ def shard_run_python_i386_1_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1608,7 +1641,8 @@ def shard_run_python_i386_2_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1617,7 +1651,10 @@ def shard_run_python_i386_2_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1665,7 +1702,8 @@ def shard_run_python_i386_3_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1674,7 +1712,10 @@ def shard_run_python_i386_3_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1723,7 +1764,8 @@ def shard_run_test_Hexagon_1_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1732,7 +1774,10 @@ def shard_run_test_Hexagon_1_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1779,7 +1824,8 @@ def shard_run_test_Hexagon_2_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1788,7 +1834,10 @@ def shard_run_test_Hexagon_2_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1835,7 +1884,8 @@ def shard_run_test_Hexagon_3_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1844,7 +1894,10 @@ def shard_run_test_Hexagon_3_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1891,7 +1944,8 @@ def shard_run_test_Hexagon_4_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1900,7 +1954,10 @@ def shard_run_test_Hexagon_4_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -1947,7 +2004,8 @@ def shard_run_test_Hexagon_5_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -1956,7 +2014,10 @@ def shard_run_test_Hexagon_5_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2003,7 +2064,8 @@ def shard_run_test_Hexagon_6_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2012,7 +2074,10 @@ def shard_run_test_Hexagon_6_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2059,7 +2124,8 @@ def shard_run_test_Hexagon_7_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2068,7 +2134,10 @@ def shard_run_test_Hexagon_7_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2115,7 +2184,8 @@ def shard_run_test_Hexagon_8_of_8() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2124,7 +2194,10 @@ def shard_run_test_Hexagon_8_of_8() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2173,7 +2246,8 @@ def shard_run_integration_aarch64_1_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2182,7 +2256,10 @@ def shard_run_integration_aarch64_1_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2230,7 +2307,8 @@ def shard_run_integration_aarch64_2_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2239,7 +2317,10 @@ def shard_run_integration_aarch64_2_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2287,7 +2368,8 @@ def shard_run_integration_aarch64_3_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2296,7 +2378,10 @@ def shard_run_integration_aarch64_3_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2344,7 +2429,8 @@ def shard_run_integration_aarch64_4_of_4() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2353,7 +2439,10 @@ def shard_run_integration_aarch64_4_of_4() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2401,7 +2490,8 @@ def shard_run_topi_GPU_1_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2410,7 +2500,10 @@ def shard_run_topi_GPU_1_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2457,7 +2550,8 @@ def shard_run_topi_GPU_2_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2466,7 +2560,10 @@ def shard_run_topi_GPU_2_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2513,7 +2610,8 @@ def shard_run_topi_GPU_3_of_3() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2522,7 +2620,10 @@ def shard_run_topi_GPU_3_of_3() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2570,7 +2671,8 @@ def shard_run_frontend_GPU_1_of_6() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2579,7 +2681,10 @@ def shard_run_frontend_GPU_1_of_6() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2626,7 +2731,8 @@ def shard_run_frontend_GPU_2_of_6() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2635,7 +2741,10 @@ def shard_run_frontend_GPU_2_of_6() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2682,7 +2791,8 @@ def shard_run_frontend_GPU_3_of_6() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2691,7 +2801,10 @@ def shard_run_frontend_GPU_3_of_6() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2738,7 +2851,8 @@ def shard_run_frontend_GPU_4_of_6() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2747,7 +2861,10 @@ def shard_run_frontend_GPU_4_of_6() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2794,7 +2911,8 @@ def shard_run_frontend_GPU_5_of_6() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2803,7 +2921,10 @@ def shard_run_frontend_GPU_5_of_6() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2850,7 +2971,8 @@ def shard_run_frontend_GPU_6_of_6() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2859,7 +2981,10 @@ def shard_run_frontend_GPU_6_of_6() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2912,7 +3037,8 @@ def shard_run_topi_aarch64_1_of_2() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2921,7 +3047,10 @@ def shard_run_topi_aarch64_1_of_2() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -2972,7 +3101,8 @@ def shard_run_topi_aarch64_2_of_2() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -2981,7 +3111,10 @@ def shard_run_topi_aarch64_2_of_2() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3029,7 +3162,8 @@ def shard_run_frontend_aarch64_1_of_2() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3038,7 +3172,10 @@ def shard_run_frontend_aarch64_1_of_2() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3085,7 +3222,8 @@ def shard_run_frontend_aarch64_2_of_2() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3094,7 +3232,10 @@ def shard_run_frontend_aarch64_2_of_2() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3147,7 +3288,8 @@ def shard_run_test_Cortex_M_1_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3156,7 +3298,10 @@ def shard_run_test_Cortex_M_1_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3203,7 +3348,8 @@ def shard_run_test_Cortex_M_2_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3212,7 +3358,10 @@ def shard_run_test_Cortex_M_2_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3259,7 +3408,8 @@ def shard_run_test_Cortex_M_3_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3268,7 +3418,10 @@ def shard_run_test_Cortex_M_3_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3315,7 +3468,8 @@ def shard_run_test_Cortex_M_4_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3324,7 +3478,10 @@ def shard_run_test_Cortex_M_4_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3371,7 +3528,8 @@ def shard_run_test_Cortex_M_5_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3380,7 +3538,10 @@ def shard_run_test_Cortex_M_5_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3427,7 +3588,8 @@ def shard_run_test_Cortex_M_6_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3436,7 +3598,10 @@ def shard_run_test_Cortex_M_6_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3483,7 +3648,8 @@ def shard_run_test_Cortex_M_7_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3492,7 +3658,10 @@ def shard_run_test_Cortex_M_7_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3539,7 +3708,8 @@ def shard_run_test_Cortex_M_8_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3548,7 +3718,10 @@ def shard_run_test_Cortex_M_8_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3595,7 +3768,8 @@ def shard_run_test_Cortex_M_9_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3604,7 +3778,10 @@ def shard_run_test_Cortex_M_9_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3651,7 +3828,8 @@ def shard_run_test_Cortex_M_10_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3660,7 +3838,10 @@ def shard_run_test_Cortex_M_10_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3707,7 +3888,8 @@ def shard_run_test_Cortex_M_11_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3716,7 +3898,10 @@ def shard_run_test_Cortex_M_11_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3763,7 +3948,8 @@ def shard_run_test_Cortex_M_12_of_12() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3772,7 +3958,10 @@ def shard_run_test_Cortex_M_12_of_12() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3821,7 +4010,8 @@ def shard_run_test_RISC_V_1_of_1() {
             })
           }
         } finally {
-          sh(
+          try {
+            sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3830,7 +4020,10 @@ def shard_run_test_RISC_V_1_of_1() {
             label: 'Upload JUnits to S3',
           )
 
-          junit 'build/pytest-results/*.xml'
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -3867,7 +4060,8 @@ def run_unittest_minimal() {
               python_unittest(ci_minimal)
             })
           } finally {
-            sh(
+            try {
+              sh(
             script: """
               set -eux
               . ci/scripts/retry.sh
@@ -3876,7 +4070,10 @@ def run_unittest_minimal() {
             label: 'Upload JUnits to S3',
           )
 
-            junit 'build/pytest-results/*.xml'
+              junit 'build/pytest-results/*.xml'
+            } catch (Exception e) {
+              echo 'Exception during JUnit upload: ' + e.toString()
+            }
           }
         }
       }
@@ -4078,6 +4275,7 @@ stage('Test') {
                 )
               })
             } finally {
+            try {
               sh(
                 script: """
                   set -eux
@@ -4088,6 +4286,9 @@ stage('Test') {
               )
 
               junit 'build/pytest-results/*.xml'
+            } catch (Exception e) {
+              echo 'Exception during JUnit upload: ' + e.toString()
+            }
             }
           }
         }
@@ -4130,6 +4331,7 @@ stage('Test') {
                 )
               })
             } finally {
+            try {
               sh(
                 script: """
                   set -eux
@@ -4140,6 +4342,9 @@ stage('Test') {
               )
 
               junit 'build/pytest-results/*.xml'
+            } catch (Exception e) {
+              echo 'Exception during JUnit upload: ' + e.toString()
+            }
             }
           }
         }

--- a/ci/jenkins/Prepare.groovy.j2
+++ b/ci/jenkins/Prepare.groovy.j2
@@ -4,8 +4,9 @@ def per_exec_ws(folder) {
 
 // initialize source codes
 def init_git() {
-  checkout scm
-
+  retry(5) {
+    checkout scm
+  }
 
   // Add more info about job node
   sh (

--- a/ci/jenkins/macros.j2
+++ b/ci/jenkins/macros.j2
@@ -53,8 +53,12 @@ def {{ method_name }}() {
             })
           }
         } finally {
-          {{ junit_to_s3(test_dir_name) }}
-          junit 'build/pytest-results/*.xml'
+          try {
+            {{ junit_to_s3(test_dir_name) }}
+            junit 'build/pytest-results/*.xml'
+          } catch (Exception e) {
+            echo 'Exception during JUnit upload: ' + e.toString()
+          }
         }
       }
     }
@@ -120,8 +124,12 @@ def {{ method_name }}() {
               {{ caller() | indent(width=8) | trim }}
             })
           } finally {
-            {{ junit_to_s3(test_dir_name) | indent(width=0) }}
-            junit 'build/pytest-results/*.xml'
+            try {
+              {{ junit_to_s3(test_dir_name) | indent(width=0) }}
+              junit 'build/pytest-results/*.xml'
+            } catch (Exception e) {
+              echo 'Exception during JUnit upload: ' + e.toString()
+            }
           }
         }
       }
@@ -147,8 +155,12 @@ def {{ method_name }}() {
                 {{ caller() | indent(width=12) | trim }}
               })
             } finally {
+            try {
               {{ junit_to_s3(test_dir_name) | indent(width=4) }}
               junit 'build/pytest-results/*.xml'
+            } catch (Exception e) {
+              echo 'Exception during JUnit upload: ' + e.toString()
+            }
             }
           }
         }


### PR DESCRIPTION
These are never really signal-carrying so there's no need for it to show
up as red on CI jobs. This also adds retries to the `git checkout` step
within Jenkins to deal with GitHub instability. This should help avoid
confusing situations like in #13136