### PR TITLE
[Hexagon] refactor HexagonBufferManager class

### DIFF
--- a/src/runtime/hexagon/hexagon_buffer_manager.h
+++ b/src/runtime/hexagon/hexagon_buffer_manager.h
@@ -46,14 +46,12 @@ class HexagonBufferManager {
    * \param ptr Address of the HexagonBuffer as returned by `AllocateHexagonBuffer`.
    */
   void FreeHexagonBuffer(void* ptr) {
+    std::lock_guard<std::mutex> lock(map_mutex_);
     auto it = hexagon_buffer_map_.find(ptr);
     CHECK(it != hexagon_buffer_map_.end())
-        << "Attempt made to free unknown or already freed dataspace allocation";
+        << "Attempt made to free unknown or already freed allocation";
     CHECK(it->second != nullptr);
-    {
-      std::lock_guard<std::mutex> lock(map_mutex_);
-      hexagon_buffer_map_.erase(it);
-    }
+    hexagon_buffer_map_.erase(it);
   }
   /*!
    * \brief Allocate a HexagonBuffer.
@@ -70,14 +68,8 @@ class HexagonBufferManager {
     return ptr;
   }
 
-  //! \brief Returns whether the HexagonBuffer is in the map.
-  size_t count(void* ptr) {
-    std::lock_guard<std::mutex> lock(map_mutex_);
-    return hexagon_buffer_map_.count(ptr);
-  }
-
   //! \brief Returns an iterator to the HexagonBuffer within the map.
-  HexagonBuffer* find(void* ptr) {
+  HexagonBuffer* FindHexagonBuffer(void* ptr) {
     std::lock_guard<std::mutex> lock(map_mutex_);
     auto it = hexagon_buffer_map_.find(ptr);
     if (it != hexagon_buffer_map_.end()) {

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -154,8 +154,6 @@ void HexagonDeviceAPI::FreeWorkspace(Device dev, void* data) {
   CHECK(runtime_hexbuffs) << "Attempted to free Hexagon workspace with "
                           << "HexagonDeviceAPI::FreeWorkspace outside of a session.  "
                           << "Please call HexagonDeviceAPI::AcquireResources";
-  CHECK(runtime_hexbuffs->count(data) != 0)
-      << "Attempt made to free unknown or already freed workspace allocation";
   dmlc::ThreadLocalStore<HexagonWorkspacePool>::Get()->FreeWorkspace(dev, data);
 }
 
@@ -182,7 +180,7 @@ void HexagonDeviceAPI::CopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamHan
                           << "Please call HexagonDeviceAPI::AcquireResources";
 
   auto lookup_hexagon_buffer = [this](void* ptr) -> HexagonBuffer* {
-    return runtime_hexbuffs->find(ptr);
+    return runtime_hexbuffs->FindHexagonBuffer(ptr);
   };
 
   HexagonBuffer* hex_from_buf = lookup_hexagon_buffer(from->data);

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -154,6 +154,8 @@ void HexagonDeviceAPI::FreeWorkspace(Device dev, void* data) {
   CHECK(runtime_hexbuffs) << "Attempted to free Hexagon workspace with "
                           << "HexagonDeviceAPI::FreeWorkspace outside of a session.  "
                           << "Please call HexagonDeviceAPI::AcquireResources";
+  CHECK(runtime_hexbuffs->FindHexagonBuffer(data) != nullptr)
+      << "Attempt made to free unknown or already freed workspace allocation";
   dmlc::ThreadLocalStore<HexagonWorkspacePool>::Get()->FreeWorkspace(dev, data);
 }
 


### PR DESCRIPTION
Refactoring `HexagonBufferManager` class with a few small changes: 1) moving mutex lock before `find` in `FreeHexagonBuffer` 2) Removing `count` method as the only caller uses it to check / log duplicate error as in `FreeHexagonBuffer` itself 3) rename to `FindHexagonBuffer` for clariry.