### PR TITLE
[Bugfix][Runtime] Fix sched_setaffinity in Android

### DIFF
--- a/docs/dev/tutorial/codebase_walkthrough.rst
+++ b/docs/dev/tutorial/codebase_walkthrough.rst
@@ -93,11 +93,14 @@ This function is mapped to the C++ function in ``include/tvm/schedule.h``.
 
 ``Schedule`` and ``Stage`` are defined in ``tvm/python/te/schedule.py``, ``include/tvm/te/schedule.h``, and ``src/te/schedule/schedule_ops.cc``.
 
-To keep it simple, we call ``tvm.build(...)`` on the default schedule created by ``create_schedule()`` function above.
+To keep it simple, we call ``tvm.build(...)`` on the default schedule created by ``create_schedule()`` function above, and we must add necessary thread bindings to make it runnable on GPU.
 
 ::
 
    target = "cuda"
+   bx, tx = s[C].split(C.op.axis[0], factor=64)
+   s[C].bind(bx, tvm.te.thread_axis("blockIdx.x"))
+   s[C].bind(tx, tvm.te.thread_axis("threadIdx.x"))
    fadd = tvm.build(s, [A, B, C], target)
 
 ``tvm.build()``, defined in ``python/tvm/driver/build_module.py``, takes a schedule, input and output ``Tensor``, and a target, and returns a :py:class:`tvm.runtime.Module` object. A :py:class:`tvm.runtime.Module` object contains a compiled function which can be invoked with function call syntax.

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -28,7 +28,6 @@
 #include <pthread.h>
 #include <fstream>
 #include <sstream>
-#include <pthread.h>
 #else
 #endif
 #if defined(__linux__)

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -26,6 +26,7 @@
 
 #if defined(__linux__) || defined(__ANDROID__)
 #include <pthread.h>
+
 #include <fstream>
 #include <sstream>
 #else

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -25,6 +25,7 @@
 #include <tvm/runtime/threading_backend.h>
 
 #if defined(__linux__) || defined(__ANDROID__)
+#include <pthread.h>
 #include <fstream>
 #include <sstream>
 #else
@@ -167,7 +168,9 @@ class ThreadGroup::Impl {
       CPU_SET(id, &cpuset);
     }
 #if defined(__ANDROID__)
-    sched_setaffinity(thread, sizeof(cpu_set_t), &cpuset);
+    if (sched_setaffinity(pthread_gettid_np(thread), sizeof(cpu_set_t), &cpuset) != 0) {
+      LOG(WARNING) << "sched_setaffinity failed";
+    }
 #else
     pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
 #endif

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -173,8 +173,7 @@ class ThreadGroup::Impl {
 #if __ANDROID_API__ >= 21
     pid_t tid = pthread_gettid_np(thread);
 #else
-    typedef struct
-    {
+    typedef struct {
       void* next;
       void* pred;
       pid_t tid;

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -25,8 +25,9 @@
 #include <tvm/runtime/threading_backend.h>
 
 #if defined(__linux__) || defined(__ANDROID__)
+#if __ANDROID_API__ >= 21
 #include <pthread.h>
-
+#endif
 #include <fstream>
 #include <sstream>
 #else
@@ -169,7 +170,18 @@ class ThreadGroup::Impl {
       CPU_SET(id, &cpuset);
     }
 #if defined(__ANDROID__)
-    if (sched_setaffinity(pthread_gettid_np(thread), sizeof(cpu_set_t), &cpuset) != 0) {
+#if __ANDROID_API__ >= 21
+    pid_t tid = pthread_gettid_np(thread);
+#else
+    typedef struct
+    {
+      void* next;
+      void* pred;
+      pid_t tid;
+    } pthread_internal;
+    pid_t tid = reinterpret_cast<pthread_internal*>(thread)->tid;
+#endif
+    if (sched_setaffinity(tid, sizeof(cpu_set_t), &cpuset) != 0) {
       LOG(WARNING) << "sched_setaffinity failed";
     }
 #else


### PR DESCRIPTION
On Android `sched_setaffinity ` should use `pid_t` instread of `pthread_t`,  
https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html

On Android 21+, there is `pid_t pthread_gettid_np(pthread_t);` to convert the `std::thread::native_handle_type`  to `pid_t`, 

```cpp
pid_t pthread_gettid_np(pthread_t __pthread) __INTRODUCED_IN(21);
```