### PR TITLE
[CI] Update PyTorch to v1.12 in GPU image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = 'tlcpack/ci-lint:20221013-060115-61c9742ea'
-ci_gpu = 'tlcpack/ci-gpu:20221013-060115-61c9742ea'
+ci_gpu = 'tlcpack/ci-gpu:20221019-060125-0b4836739'
 ci_cpu = 'tlcpack/ci-cpu:20221013-060115-61c9742ea'
 ci_minimal = 'tlcpack/ci-minimal:20221013-060115-61c9742ea'
 ci_wasm = 'tlcpack/ci-wasm:20221013-060115-61c9742ea'

--- a/ci/jenkins/Jenkinsfile.j2
+++ b/ci/jenkins/Jenkinsfile.j2
@@ -52,7 +52,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = 'tlcpack/ci-lint:20221013-060115-61c9742ea'
-ci_gpu = 'tlcpack/ci-gpu:20221013-060115-61c9742ea'
+ci_gpu = 'tlcpack/ci-gpu:20221019-060125-0b4836739'
 ci_cpu = 'tlcpack/ci-cpu:20221013-060115-61c9742ea'
 ci_minimal = 'tlcpack/ci-minimal:20221013-060115-61c9742ea'
 ci_wasm = 'tlcpack/ci-wasm:20221013-060115-61c9742ea'


### PR DESCRIPTION
As requested by https://discuss.tvm.apache.org/t/frontend-pytorch-tvm-compatibility-with-torch-1-12-0/13508, updating PT to 1.12.

Validated in https://github.com/apache/tvm/tree/ci-docker-staging.

Thanks to @oviazlo for the update work!