### PR TITLE
[Hexagon] Skip HexagonThreadManagerTest.thread_order_signal_wait unit test

### DIFF
--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -259,6 +259,7 @@ TEST_F(HexagonThreadManagerTest, thread_order) {
 }
 
 TEST_F(HexagonThreadManagerTest, thread_order_signal_wait) {
+  GTEST_SKIP() << "Skipping due to: https://github.com/apache/tvm/issues/13169";
   std::vector<int> arr;
 
   htm->Wait(streams[1], 1);


### PR DESCRIPTION
Skipping this test due to https://github.com/apache/tvm/issues/13169

cc @janetsc 