### PR TITLE
[Hexagon] Adjust Hexagon pytest port range

### DIFF
--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -75,7 +75,7 @@ def android_serial_number() -> Optional[str]:
 # triggering TIME_WAIT state on the server socket. This prevents another
 # server to bind to the same port until the wait time elapses.
 
-LISTEN_PORT_MIN = 2000  # Well above the privileged ports (1024 or lower)
+LISTEN_PORT_MIN = 6000  # Avoid hitting well-known Android debug ports
 LISTEN_PORT_MAX = 9000  # Below the search range end (port_end=9199) of RPC server
 PREVIOUS_PORT = None
 


### PR DESCRIPTION
ADB, the Android Debug Bridge, tries to determine if an emulator is present by looking for port 5555 being open. Unfortunately, once adb thinks there's an emulator running, it will continously try to connect to it, adding an error to its log on every failed attempt. This log file quickly grows to hundreds of gigabytes before developers notice they are completely out of disk space. This problem is further compounded by the Hexagon Launcher forwarding 10 contiguous ports from the randomly-chosen RPC base port, causing this failure to happen more often than you'd otherwise suspect.

See https://stackoverflow.com/questions/3152681/android-emulator-5554-offline/10356594#10356594

cc: @csullivan @mehrdadh @cconvey 