### PR TITLE
[Hexagon] [runtime] Allow creation of thread manager without hardware resources

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -62,7 +62,8 @@ class HexagonDeviceAPI final : public DeviceAPI {
     runtime_hexbuffs = std::make_unique<HexagonBufferManager>();
 
     CHECK_EQ(runtime_threads, nullptr);
-    runtime_threads = std::make_unique<HexagonThreadManager>(threads, stack_size, pipe_size);
+    runtime_threads =
+        std::make_unique<HexagonThreadManager>(threads, stack_size, pipe_size, hw_resources);
 
     CHECK_EQ(runtime_dma, nullptr);
     runtime_dma = std::make_unique<HexagonUserDMA>();
@@ -196,6 +197,7 @@ class HexagonDeviceAPI final : public DeviceAPI {
   const unsigned threads{6};
   const unsigned pipe_size{1000};
   const unsigned stack_size{0x4000};  // 16KB
+  const std::vector<HardwareResourceType> hw_resources{DMA_0, HTP_0, HVX_0, HVX_1, HVX_2, HVX_3};
 
   //! \brief User DMA manager
   std::unique_ptr<HexagonUserDMA> runtime_dma;

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -24,10 +24,10 @@ namespace runtime {
 namespace hexagon {
 
 HexagonThreadManager::HexagonThreadManager(unsigned num_threads, unsigned thread_stack_size_bytes,
-                                           unsigned thread_pipe_size_words) {
-  // Note: could technically manage more software threads than allowable hardware threads, but there
-  // is no system constant defined
-  //  in the qurt libs for that maximum.
+                                           unsigned thread_pipe_size_words,
+                                           const std::vector<HardwareResourceType> hw_resources) {
+  // Note: could technically manage more software threads than allowable hardware threads, but
+  // there is no system constant defined in the qurt libs for that maximum.
   CHECK(num_threads);
   CHECK_LE(num_threads, QURT_MAX_HTHREAD_LIMIT);
   nthreads_ = num_threads;
@@ -38,13 +38,24 @@ HexagonThreadManager::HexagonThreadManager(unsigned num_threads, unsigned thread
   CHECK_GE(thread_pipe_size_words, MIN_PIPE_SIZE_WORDS);
   CHECK_LE(thread_pipe_size_words, MAX_PIPE_SIZE_WORDS);
 
+  // Support either no resources or a specific set of hardware resources for now.
+  if (!hw_resources.empty()) {
+    CHECK((hw_resources.size() == nthreads_) && (nthreads_ == 6) && (hw_resources[0] == DMA_0) &&
+          (hw_resources[1] == HTP_0) && (hw_resources[2] == HVX_0) && (hw_resources[3] == HVX_1) &&
+          (hw_resources[4] == HVX_2) && (hw_resources[5] == HVX_3))
+        << "Unsupported hardware resource set";
+  }
+  hw_resources_ = hw_resources;
+
+  if (!hw_resources_.empty()) {
+    DLOG(INFO) << "Initialize hardware resource managers";
+    // Acquisition/locks will be performed on specific threads
+    htp_ = std::make_unique<HexagonHtp>();
+    hvx_ = std::make_unique<HexagonHvx>();
+  }
+
   DLOG(INFO) << "Spawning threads";
   SpawnThreads(thread_stack_size_bytes, thread_pipe_size_words);
-
-  DLOG(INFO) << "Acquiring hardware resources";
-  // TODO(HWE): Move these bindings to specific threads
-  htp_ = std::make_unique<HexagonHtp>();
-  hvx_ = std::make_unique<HexagonHvx>();
 
   // Initially, block all threads until we get the Start() call
   qurt_sem_init_val(&start_semaphore_, 0);

--- a/src/runtime/hexagon/hexagon_thread_manager.h
+++ b/src/runtime/hexagon/hexagon_thread_manager.h
@@ -40,6 +40,17 @@ namespace tvm {
 namespace runtime {
 namespace hexagon {
 
+typedef enum {
+  NONE = -1,
+  DMA_0 = 0,
+  HTP_0,
+  HVX_0,
+  HVX_1,
+  HVX_2,
+  HVX_3,
+  MAX,
+} HardwareResourceType;
+
 class HexagonThreadManager {
   //! \brief Void function.
   using voidfunc = void (*)(void*);
@@ -64,7 +75,8 @@ class HexagonThreadManager {
    * \param thread_stack_size_bytes Stack size in bytes per thread.
    * \param thread_pipe_size_words Pipe (or command buffer) size in words (or commands).
    */
-  HexagonThreadManager(unsigned, unsigned thread_stack_size_bytes, unsigned thread_pipe_size_words);
+  HexagonThreadManager(unsigned, unsigned thread_stack_size_bytes, unsigned thread_pipe_size_words,
+                       const std::vector<HardwareResourceType> = {});
 
   //! \brief Destructor
   ~HexagonThreadManager();
@@ -187,6 +199,9 @@ class HexagonThreadManager {
     void* args;
     Command(voidfunc f, void* args) : f(f), args(args) {}
   };
+
+  //! \brief List of hardware resources
+  std::vector<HardwareResourceType> hw_resources_;
 
   //! \brief HTP hardware resource.
   // TODO(HWE): Move binding of HTP to a specific thread

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -29,15 +29,16 @@ using namespace tvm::runtime::hexagon;
 class HexagonThreadManagerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    htm = HexagonDeviceAPI::Global()->ThreadManager();
+    // Create with no hardware resources so we don't conflict with session HexagonThreadManager
+    htm = new HexagonThreadManager(threads, stack_size, pipe_size);
     streams = htm->GetStreamHandles();
   }
-  void TearDown() override {}
+  void TearDown() override { delete htm; }
   HexagonThreadManager* htm{nullptr};
   std::vector<TVMStreamHandle> streams;
   int answer{0};
   const unsigned threads{6};
-  const unsigned pipe_size{1000};
+  const unsigned pipe_size{100};
   const unsigned stack_size{0x4000};  // 16KB
 };
 
@@ -163,7 +164,7 @@ TEST_F(HexagonThreadManagerTest, pipe_fill) {
 }
 
 // TODO(HWE): Create a temporary thread manager with a smaller pipe for this test
-TEST_F(HexagonThreadManagerTest, DISABLED_pipe_overflow) {
+TEST_F(HexagonThreadManagerTest, pipe_overflow) {
   // fill the pipe
   for (int i = 0; i < pipe_size; ++i) {
     htm->Dispatch(streams[0], get_the_answer, &answer);

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -260,7 +260,6 @@ TEST_F(HexagonThreadManagerTest, thread_order) {
 }
 
 TEST_F(HexagonThreadManagerTest, thread_order_signal_wait) {
-  GTEST_SKIP() << "Skipping due to: https://github.com/apache/tvm/issues/13169";
   std::vector<int> arr;
 
   htm->Wait(streams[1], 1);

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -55,6 +55,15 @@ TEST_F(HexagonThreadManagerTest, ctor_errors) {
   ASSERT_THROW(HexagonThreadManager(6, stack_size, 9), InternalError);
   // pipe too big
   ASSERT_THROW(HexagonThreadManager(6, stack_size, 0x10000000), InternalError);
+  // hw resources count doesn't match thread count
+  ASSERT_THROW(HexagonThreadManager(6, stack_size, pipe_size, {DMA_0}), InternalError);
+  // hw resources doesn't match specific supported configuration
+  ASSERT_THROW(
+      HexagonThreadManager(6, stack_size, pipe_size, {DMA_0, HTP_0, HVX_0, HVX_1, HVX_2, DMA_0}),
+      InternalError);
+  // hw resources doesn't match specific supported configuration
+  ASSERT_THROW(HexagonThreadManager(5, stack_size, pipe_size, {DMA_0, HTP_0, HVX_0, HVX_1, HVX_2}),
+               InternalError);
 }
 
 TEST_F(HexagonThreadManagerTest, init) {


### PR DESCRIPTION
This allows the creation of a thread manager with optional hardware resources.  This allows us to create a new object for unit tests without hardware resources.

This will fix the test instability we've seen recently, as all tests were using the global thread manager and things could be in an unknown state.

cc: @adstraw, @mehrdadh, @JosephTheOctonaut, @csullivan 