### PR TITLE
[DLPack][runtime] Update DLPack to v0.7

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -80,16 +80,73 @@ extern "C" {
 /*! \brief type of array index. */
 typedef int64_t tvm_index_t;
 
-/*! \brief Extension device types in TVM */
+/*! \brief Extension device types in TVM
+ *
+ * Additional enumerators to supplement those provided by
+ * DLPack's `DLDeviceType` enumeration.
+ *
+ * MAINTAINERS NOTE #1: We need to ensure that the two devices
+ * are identified by the same integer.
+ * Currently this requires manual verification.
+ * Discussed here: https://github.com/dmlc/dlpack/issues/111
+ * As of DLPack v0.7, the highest-valued enumerator in
+ * `DLDeviceType` is kDLHexagon = 16.
+ *
+ * MAINTAINERS NOTE #2: As of DLPack v0.7, the definition for
+ * `DLDeviceType` specifies an underlying storage type of
+ * `int32_t`.  That guarantees a variable of type
+ * `DLDeviceType` is capable of holding any integers provided
+ * by *either* of these enumerations.
+ *
+ * However, the `int32_t` specification only applies when the
+ * header file is compiled as C++, and this header file is also
+ * meant to work as C code.  So the unspecified storage type
+ * could be a latent bug when compiled as C.
+ */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
 typedef enum {
-  kDLAOCL = 5,
-  kDLSDAccel = 6,
-  kOpenGL = 11,
-  kDLMicroDev = 13,
-  kDLHexagon = 14,
-  kDLWebGPU = 15
-  // AddExtraTVMType which is not in DLPack here
+#endif
+  // To help avoid accidental conflicts between `DLDeviceType`
+  // and this enumeration, start numbering the new enumerators
+  // a little higher than (currently) seems necessary.
+  kDLAOCL = 32,
+  kDLSDAccel,
+  kOpenGL,
+  kDLMicroDev,
+  TVMDeviceExtType_End,  // sentinel value
 } TVMDeviceExtType;
+
+#ifdef __cplusplus
+// Some other parts of TVM hardcode the integer identifier for
+// some DLPack / TVM devices, rather then using the symbolic
+// enumerator.   E.g., `2` rather than `kDLCUDA`.
+// These asserts should alert us when that mapping breaks.
+#define TVM_HARCODED_INTEGER_CHANGED_MSG                                                          \
+  "Change in compile-time integer.  Make sure hardcoded uses of this integer throughout TVM are " \
+  "updated."
+static_assert(kDLCPU == 1, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLCUDA == 2, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLCUDAHost == 3, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLOpenCL == 4, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLVulkan == 7, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLMetal == 8, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLVPI == 9, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLROCM == 10, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLROCMHost == 11, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLExtDev == 12, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLCUDAManaged == 13, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLOneAPI == 14, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLWebGPU == 15, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLHexagon == 16, TVM_HARCODED_INTEGER_CHANGED_MSG);
+
+static_assert(kDLAOCL == 32, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLSDAccel == 33, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kOpenGL == 34, TVM_HARCODED_INTEGER_CHANGED_MSG);
+static_assert(kDLMicroDev == 35, TVM_HARCODED_INTEGER_CHANGED_MSG);
+#undef TVM_HARCODED_INTEGER_CHANGED_MSG
+#endif
 
 /*!
  * \brief The type code in used and only used in TVM FFI for argument passing.

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -234,6 +234,7 @@ class TVM_DLL DeviceAPI {
 
 /*! \brief The device type bigger than this is RPC device */
 constexpr int kRPCSessMask = 128;
+static_assert(kRPCSessMask >= TVMDeviceExtType_End);
 
 /*!
  * \brief The name of Device API factory.
@@ -248,6 +249,8 @@ inline const char* DeviceName(int type) {
       return "cuda";
     case kDLCUDAHost:
       return "cuda_host";
+    case kDLCUDAManaged:
+      return "cuda_managed";
     case kDLOpenCL:
       return "opencl";
     case kDLSDAccel:
@@ -262,12 +265,20 @@ inline const char* DeviceName(int type) {
       return "vpi";
     case kDLROCM:
       return "rocm";
+    case kDLROCMHost:
+      return "rocm_host";
     case kDLExtDev:
       return "ext_dev";
+    case kDLOneAPI:
+      return "oneapi";
     case kDLWebGPU:
       return "webgpu";
     case kDLHexagon:
       return "hexagon";
+    case kOpenGL:
+      return "opengl";
+    case kDLMicroDev:
+      return "microdev";
     default:
       LOG(FATAL) << "unknown type =" << type;
       return "Unknown";

--- a/jvm/core/src/main/java/org/apache/tvm/Device.java
+++ b/jvm/core/src/main/java/org/apache/tvm/Device.java
@@ -17,32 +17,40 @@
 
 package org.apache.tvm;
 
-import org.apache.tvm.rpc.RPC;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.tvm.rpc.RPC;
 
 public class Device {
+  /**
+   * Provides the same information as the C++ enums DLDeviceType and
+   * TVMDeviceExtType.
+   */
+  static final int kDLCPU = 1, kDLCUDA = 2, kDLCUDAHost = 3, kDLOpenCL = 4, kDLVulkan = 7,
+                   kDLMetal = 8, kDLVPI = 9, kDLROCM = 10, kDLROCMHost = 11, kDLExtDev = 12,
+                   kDLCUDAManaged = 13, kDLOneAPI = 14, kDLWebGPU = 15, kDLHexagon = 16,
+                   kDLAOCL = 32, kDLSDAccel = 33, kOpenGL = 34, kDLMicroDev = 35;
+
   private static final Map<Integer, String> MASK2STR = new HashMap<Integer, String>();
   private static final Map<String, Integer> STR2MASK = new HashMap<String, Integer>();
 
   static {
-    MASK2STR.put(1, "cpu");
-    MASK2STR.put(2, "cuda");
-    MASK2STR.put(4, "opencl");
-    MASK2STR.put(7, "vulkan");
-    MASK2STR.put(8, "metal");
-    MASK2STR.put(9, "vpi");
-    MASK2STR.put(14, "hexagon");
+    MASK2STR.put(kDLCPU, "cpu");
+    MASK2STR.put(kDLCUDA, "cuda");
+    MASK2STR.put(kDLOpenCL, "opencl");
+    MASK2STR.put(kDLVulkan, "vulkan");
+    MASK2STR.put(kDLMetal, "metal");
+    MASK2STR.put(kDLVPI, "vpi");
+    MASK2STR.put(kDLHexagon, "hexagon");
 
-    STR2MASK.put("cpu", 1);
-    STR2MASK.put("cuda", 2);
-    STR2MASK.put("cl", 4);
-    STR2MASK.put("opencl", 4);
-    STR2MASK.put("vulkan", 7);
-    STR2MASK.put("metal", 8);
-    STR2MASK.put("vpi", 9);
-    STR2MASK.put("hexagon", 14);
+    STR2MASK.put("cpu", kDLCPU);
+    STR2MASK.put("cuda", kDLCUDA);
+    STR2MASK.put("cl", kDLOpenCL);
+    STR2MASK.put("opencl", kDLOpenCL);
+    STR2MASK.put("vulkan", kDLVulkan);
+    STR2MASK.put("metal", kDLMetal);
+    STR2MASK.put("vpi", kDLVPI);
+    STR2MASK.put("hexagon", kDLHexagon);
   }
 
   /**
@@ -51,7 +59,7 @@ public class Device {
    * @return The created device
    */
   public static Device cpu(int devId) {
-    return new Device(1, devId);
+    return new Device(kDLCPU, devId);
   }
 
   public static Device cpu() {
@@ -64,7 +72,7 @@ public class Device {
    * @return The created device
    */
   public static Device cuda(int devId) {
-    return new Device(2, devId);
+    return new Device(kDLCUDA, devId);
   }
 
   public static Device cuda() {
@@ -77,7 +85,7 @@ public class Device {
    * @return The created device
    */
   public static Device opencl(int devId) {
-    return new Device(4, devId);
+    return new Device(kDLOpenCL, devId);
   }
 
   public static Device opencl() {
@@ -90,7 +98,7 @@ public class Device {
    * @return The created device
    */
   public static Device vulkan(int devId) {
-    return new Device(7, devId);
+    return new Device(kDLVulkan, devId);
   }
 
   public static Device vulkan() {
@@ -103,7 +111,7 @@ public class Device {
    * @return The created device
    */
   public static Device metal(int devId) {
-    return new Device(8, devId);
+    return new Device(kDLMetal, devId);
   }
 
   public static Device metal() {
@@ -116,7 +124,7 @@ public class Device {
    * @return The created device
    */
   public static Device vpi(int devId) {
-    return new Device(9, devId);
+    return new Device(kDLVPI, devId);
   }
 
   public static Device vpi() {
@@ -129,7 +137,7 @@ public class Device {
    * @return The created device
    */
   public static Device hexagon(int devId) {
-    return new Device(14, devId);
+    return new Device(kDLHexagon, devId);
   }
 
   public static Device hexagon() {
@@ -153,8 +161,8 @@ public class Device {
    * @return true if exists.
    */
   public boolean exist() {
-    TVMValue ret = APIInternal.get("_GetDeviceAttr")
-        .pushArg(deviceType).pushArg(deviceId).pushArg(0).invoke();
+    TVMValue ret =
+        APIInternal.get("_GetDeviceAttr").pushArg(deviceType).pushArg(deviceId).pushArg(0).invoke();
     return ((TVMValueLong) ret).value != 0;
   }
 
@@ -163,8 +171,8 @@ public class Device {
    * @return the maximum thread number.
    */
   public long maxThreadsPerBlock() {
-    TVMValue ret = APIInternal.get("_GetDeviceAttr")
-        .pushArg(deviceType).pushArg(deviceId).pushArg(1).invoke();
+    TVMValue ret =
+        APIInternal.get("_GetDeviceAttr").pushArg(deviceType).pushArg(deviceId).pushArg(1).invoke();
     return ((TVMValueLong) ret).value;
   }
 
@@ -173,8 +181,8 @@ public class Device {
    * @return the thread number.
    */
   public long warpSize() {
-    TVMValue ret = APIInternal.get("_GetDeviceAttr")
-        .pushArg(deviceType).pushArg(deviceId).pushArg(2).invoke();
+    TVMValue ret =
+        APIInternal.get("_GetDeviceAttr").pushArg(deviceType).pushArg(deviceId).pushArg(2).invoke();
     return ((TVMValueLong) ret).value;
   }
 
@@ -185,11 +193,13 @@ public class Device {
     Base.checkCall(Base._LIB.tvmSynchronize(deviceType, deviceId));
   }
 
-  @Override public int hashCode() {
+  @Override
+  public int hashCode() {
     return (deviceType << 16) | deviceId;
   }
 
-  @Override public boolean equals(Object other) {
+  @Override
+  public boolean equals(Object other) {
     if (other != null && other instanceof Device) {
       Device obj = (Device) other;
       return deviceId == obj.deviceId && deviceType == obj.deviceType;
@@ -197,7 +207,8 @@ public class Device {
     return false;
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     if (deviceType >= RPC.RPC_SESS_MASK) {
       int tblId = deviceType / RPC.RPC_SESS_MASK - 1;
       int devType = deviceType % RPC.RPC_SESS_MASK;

--- a/jvm/core/src/main/java/org/apache/tvm/NDArray.java
+++ b/jvm/core/src/main/java/org/apache/tvm/NDArray.java
@@ -35,7 +35,8 @@ public class NDArray extends NDArrayBase {
     this.device = dev;
   }
 
-  @Override protected void finalize() throws Throwable {
+  @Override
+  protected void finalize() throws Throwable {
     super.finalize();
   }
 
@@ -169,8 +170,8 @@ public class NDArray extends NDArrayBase {
   private void checkCopySize(int sourceLength) {
     long arrSize = size();
     if (arrSize != sourceLength) {
-      throw new IllegalArgumentException(String.format("Array shape size not match: %d v.s. %d",
-        sourceLength, size()));
+      throw new IllegalArgumentException(
+          String.format("Array shape size not match: %d v.s. %d", sourceLength, size()));
     }
   }
 
@@ -219,7 +220,7 @@ public class NDArray extends NDArrayBase {
   public double[] asDoubleArray() {
     if (dtype.typeCode != TVMType.FLOAT || dtype.bits != 64) {
       throw new IllegalArgumentException(
-        "Cannot set convert to double[] for " + dtype.toString() + " array");
+          "Cannot set convert to double[] for " + dtype.toString() + " array");
     }
     byte[][] units = groupInternalBytes();
     double[] array = new double[units.length];
@@ -237,7 +238,7 @@ public class NDArray extends NDArrayBase {
   public float[] asFloatArray() {
     if (dtype.typeCode != TVMType.FLOAT || dtype.bits != 32) {
       throw new IllegalArgumentException(
-        "Cannot set convert to float[] for " + dtype.toString() + " array");
+          "Cannot set convert to float[] for " + dtype.toString() + " array");
     }
     byte[][] units = groupInternalBytes();
     float[] array = new float[units.length];
@@ -255,7 +256,7 @@ public class NDArray extends NDArrayBase {
   public long[] asLongArray() {
     if (dtype.typeCode != TVMType.INT || dtype.bits != 64) {
       throw new IllegalArgumentException(
-        "Cannot set convert to long[] for " + dtype.toString() + " array");
+          "Cannot set convert to long[] for " + dtype.toString() + " array");
     }
     byte[][] units = groupInternalBytes();
     long[] array = new long[units.length];
@@ -273,7 +274,7 @@ public class NDArray extends NDArrayBase {
   public int[] asIntArray() {
     if (dtype.typeCode != TVMType.INT || dtype.bits != 32) {
       throw new IllegalArgumentException(
-        "Cannot set convert to int[] for " + dtype.toString() + " array");
+          "Cannot set convert to int[] for " + dtype.toString() + " array");
     }
     byte[][] units = groupInternalBytes();
     int[] array = new int[units.length];
@@ -291,7 +292,7 @@ public class NDArray extends NDArrayBase {
   public short[] asShortArray() {
     if (dtype.typeCode != TVMType.INT || dtype.bits != 16) {
       throw new IllegalArgumentException(
-        "Cannot set convert to short[] for " + dtype.toString() + " array");
+          "Cannot set convert to short[] for " + dtype.toString() + " array");
     }
     byte[][] units = groupInternalBytes();
     short[] array = new short[units.length];
@@ -309,7 +310,7 @@ public class NDArray extends NDArrayBase {
   public char[] asCharArray() {
     if (dtype.typeCode != TVMType.UINT || dtype.bits != 16) {
       throw new IllegalArgumentException(
-        "Cannot set convert to char[] for " + dtype.toString() + " array");
+          "Cannot set convert to char[] for " + dtype.toString() + " array");
     }
     byte[][] units = groupInternalBytes();
     char[] array = new char[units.length];
@@ -327,7 +328,7 @@ public class NDArray extends NDArrayBase {
   public byte[] asByteArray() {
     if (dtype.typeCode != TVMType.INT || dtype.bits != 8) {
       throw new IllegalArgumentException(
-        "Cannot set convert to byte[] for " + dtype.toString() + " array");
+          "Cannot set convert to byte[] for " + dtype.toString() + " array");
     }
     return internal();
   }
@@ -351,8 +352,7 @@ public class NDArray extends NDArrayBase {
     int unitSize = dtype.numOfBytes;
     if (raw.length <= 0 || raw.length % unitSize != 0) {
       throw new IllegalArgumentException(String.format(
-        "%s size %d cannot divide byte array size %d",
-        dtype.toString(), unitSize, raw.length));
+          "%s size %d cannot divide byte array size %d", dtype.toString(), unitSize, raw.length));
     }
 
     int numOfUnits = raw.length / unitSize;
@@ -381,8 +381,7 @@ public class NDArray extends NDArrayBase {
   public static NDArray empty(long[] shape, TVMType dtype, Device dev) {
     Base.RefLong refHandle = new Base.RefLong();
     Base.checkCall(Base._LIB.tvmArrayAlloc(
-        shape, dtype.typeCode, dtype.bits, dtype.lanes,
-        dev.deviceType, dev.deviceId, refHandle));
+        shape, dtype.typeCode, dtype.bits, dtype.lanes, dev.deviceType, dev.deviceId, refHandle));
     return new NDArray(refHandle.value, false, dtype, dev);
   }
 
@@ -393,7 +392,7 @@ public class NDArray extends NDArrayBase {
    * @return The array tvm supported.
    */
   public static NDArray empty(long[] shape, TVMType dtype) {
-    return empty(shape, dtype, new Device(1, 0));
+    return empty(shape, dtype, Device.cpu(0));
   }
 
   /**
@@ -402,7 +401,7 @@ public class NDArray extends NDArrayBase {
    * @return The array tvm supported.
    */
   public static NDArray empty(long[] shape) {
-    return empty(shape, new TVMType("float32", 1), new Device(1, 0));
+    return empty(shape, new TVMType("float32", 1), Device.cpu(0));
   }
 
   /**

--- a/jvm/core/src/main/java/org/apache/tvm/rpc/RPCSession.java
+++ b/jvm/core/src/main/java/org/apache/tvm/rpc/RPCSession.java
@@ -17,16 +17,15 @@
 
 package org.apache.tvm.rpc;
 
-import org.apache.tvm.Device;
-import org.apache.tvm.Function;
-import org.apache.tvm.Module;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.tvm.Device;
+import org.apache.tvm.Function;
+import org.apache.tvm.Module;
 
 /**
  * RPC Client session module.
@@ -98,7 +97,7 @@ public class RPCSession {
    * @return Remote CPU device.
    */
   public Device cpu(int devId) {
-    return device(1, devId);
+    return Device.cpu(devId);
   }
 
   /**
@@ -115,7 +114,7 @@ public class RPCSession {
    * @return Remote CUDA GPU device.
    */
   public Device cuda(int devId) {
-    return device(2, devId);
+    return Device.cuda(devId);
   }
 
   /**
@@ -132,7 +131,7 @@ public class RPCSession {
    * @return Remote OpenCL device.
    */
   public Device cl(int devId) {
-    return device(4, devId);
+    return Device.opencl(devId);
   }
 
   /**
@@ -149,7 +148,7 @@ public class RPCSession {
    * @return Remote OpenCL device.
    */
   public Device vulkan(int devId) {
-    return device(7, devId);
+    return Device.vulkan(devId);
   }
 
   /**
@@ -160,14 +159,13 @@ public class RPCSession {
     return vulkan(0);
   }
 
-
   /**
    * Construct remote Metal device.
    * @param devId device id.
    * @return Remote metal device.
    */
   public Device metal(int devId) {
-    return device(8, devId);
+    return Device.metal(devId);
   }
 
   /**
@@ -240,7 +238,6 @@ public class RPCSession {
     return RPC.getApi("LoadRemoteModule").pushArg(session).pushArg(path).invoke().asModule();
   }
 
-
   private static byte[] getBytesFromFile(File file) throws IOException {
     // Get the size of the file
     long length = file.length();
@@ -250,7 +247,7 @@ public class RPCSession {
     }
 
     // cannot create an array using a long type.
-    byte[] bytes = new byte[(int)length];
+    byte[] bytes = new byte[(int) length];
 
     // Read in the bytes
     int offset = 0;
@@ -258,8 +255,8 @@ public class RPCSession {
 
     InputStream is = new FileInputStream(file);
     try {
-      while (offset < bytes.length
-          && (numRead = is.read(bytes, offset, bytes.length - offset)) >= 0) {
+      while (
+          offset < bytes.length && (numRead = is.read(bytes, offset, bytes.length - offset)) >= 0) {
         offset += numRead;
       }
     } finally {

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -195,44 +195,73 @@ class Device(ctypes.Structure):
     OpenCL.  Some properties may return None depending on whether an
     API exposes that particular property.
 
+    NOTE!  The integer values in MASK2STR and STR2MASK *must* correspond
+    to the values provided by the DLDeviceType and TVMDeviceExtType enums.
     """
+
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLExtDev = 12
+    kDLCUDAManaged = 13
+    kDLOneAPI = 14
+    kDLWebGPU = 15
+    kDLHexagon = 16
+    kDLAOCL = 32
+    kDLSDAccel = 33
+    kOpenGL = 34
+    kDLMicroDev = 35
 
     _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
     MASK2STR = {
-        1: "cpu",
-        2: "cuda",
-        4: "opencl",
-        5: "aocl",
-        7: "vulkan",
-        8: "metal",
-        9: "vpi",
-        10: "rocm",
-        12: "ext_dev",
-        14: "hexagon",
-        15: "webgpu",
+        kDLCPU: "cpu",
+        kDLCUDA: "cuda",
+        kDLCUDAHost: "cuda_host",
+        kDLCUDAManaged: "cuda_managed",
+        kDLOpenCL: "opencl",
+        kDLVulkan: "vulkan",
+        kDLMetal: "metal",
+        kDLVPI: "vpi",
+        kDLROCM: "rocm",
+        kDLROCMHost: "rocm_host",
+        kDLExtDev: "ext_dev",
+        kDLOneAPI: "oneapi",
+        kDLWebGPU: "webgpu",
+        kDLHexagon: "hexagon",
+        kDLAOCL: "aocl",
+        kDLSDAccel: "sdaccel",
+        kOpenGL: "opengl",
+        kDLMicroDev: "microdev",
     }
+
     STR2MASK = {
-        "llvm": 1,
-        "stackvm": 1,
-        "cpu": 1,
-        "c": 1,
-        "test": 1,
-        "hybrid": 1,
-        "composite": 1,
-        "cuda": 2,
-        "nvptx": 2,
-        "cl": 4,
-        "opencl": 4,
-        "sdaccel": 4,
-        "aocl": 5,
-        "aocl_sw_emu": 5,
-        "vulkan": 7,
-        "metal": 8,
-        "vpi": 9,
-        "rocm": 10,
-        "ext_dev": 12,
-        "hexagon": 14,
-        "webgpu": 15,
+        "llvm": kDLCPU,
+        "stackvm": kDLCPU,
+        "cpu": kDLCPU,
+        "c": kDLCPU,
+        "test": kDLCPU,
+        "hybrid": kDLCPU,
+        "composite": kDLCPU,
+        "cuda": kDLCUDA,
+        "nvptx": kDLCUDA,
+        "cl": kDLOpenCL,
+        "opencl": kDLOpenCL,
+        "sdaccel": kDLOpenCL,
+        "aocl": kDLAOCL,
+        "aocl_sw_emu": kDLAOCL,
+        "vulkan": kDLVulkan,
+        "metal": kDLMetal,
+        "vpi": kDLVPI,
+        "rocm": kDLROCM,
+        "ext_dev": kDLExtDev,
+        "hexagon": kDLHexagon,
+        "webgpu": kDLWebGPU,
     }
 
     def __init__(self, device_type, device_id):

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -25,6 +25,7 @@ import tvm._ffi
 from tvm._ffi.base import TVMError
 from tvm.contrib import utils
 from tvm.runtime import ndarray as nd
+from tvm._ffi.runtime_ctypes import Device
 
 from . import _ffi_api, base, server
 
@@ -197,39 +198,39 @@ class RPCSession(object):
 
     def cpu(self, dev_id=0):
         """Construct CPU device."""
-        return self.device(1, dev_id)
+        return self.device(Device.kDLCPU, dev_id)
 
     def cuda(self, dev_id=0):
         """Construct CUDA GPU device."""
-        return self.device(2, dev_id)
+        return self.device(Device.kDLCUDA, dev_id)
 
     def cl(self, dev_id=0):
         """Construct OpenCL device."""
-        return self.device(4, dev_id)
+        return self.device(Device.kDLOpenCL, dev_id)
 
     def vulkan(self, dev_id=0):
         """Construct Vulkan device."""
-        return self.device(7, dev_id)
+        return self.device(Device.kDLVulkan, dev_id)
 
     def metal(self, dev_id=0):
         """Construct Metal device."""
-        return self.device(8, dev_id)
+        return self.device(Device.kDLMetal, dev_id)
 
     def rocm(self, dev_id=0):
         """Construct ROCm device."""
-        return self.device(10, dev_id)
+        return self.device(Device.kDLROCM, dev_id)
 
     def ext_dev(self, dev_id=0):
         """Construct extension device."""
-        return self.device(12, dev_id)
+        return self.device(Device.kDLExtDev, dev_id)
 
     def hexagon(self, dev_id=0):
         """Construct Hexagon device."""
-        return self.device(14, dev_id)
+        return self.device(Device.kDLHexagon, dev_id)
 
     def webgpu(self, dev_id=0):
         """Construct WebGPU device."""
-        return self.device(15, dev_id)
+        return self.device(Device.kDLWebGPU, dev_id)
 
 
 class LocalSession(RPCSession):

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -328,11 +328,11 @@ def numpyasarray(np_data):
     arr.dtype = DataType(np.dtype(data.dtype).name)
     arr.ndim = data.ndim
     # CPU device
-    arr.device = device(1, 0)
+    arr.device = device(Device.kDLCPU, 0)
     return arr, shape
 
 
-def empty(shape, dtype="float32", device=device(1, 0), mem_scope=None):
+def empty(shape, dtype="float32", device=device(Device.kDLCPU, 0), mem_scope=None):
     """Create an empty array given shape and device
 
     Parameters
@@ -399,7 +399,7 @@ def cpu(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(1, dev_id)
+    return Device(Device.kDLCPU, dev_id)
 
 
 def cuda(dev_id=0):
@@ -415,7 +415,7 @@ def cuda(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(2, dev_id)
+    return Device(Device.kDLCUDA, dev_id)
 
 
 def gpu(dev_id=0):
@@ -437,7 +437,7 @@ def gpu(dev_id=0):
     warnings.warn(
         "Please use tvm.cuda() instead of tvm.gpu(). tvm.gpu() is going to be deprecated in 0.9.0",
     )
-    return Device(2, dev_id)
+    return Device(Device.kDLCUDA, dev_id)
 
 
 def rocm(dev_id=0):
@@ -453,7 +453,7 @@ def rocm(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(10, dev_id)
+    return Device(Device.kDLROCM, dev_id)
 
 
 def opencl(dev_id=0):
@@ -469,7 +469,7 @@ def opencl(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(4, dev_id)
+    return Device(Device.kDLOpenCL, dev_id)
 
 
 def metal(dev_id=0):
@@ -485,7 +485,7 @@ def metal(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(8, dev_id)
+    return Device(Device.kDLMetal, dev_id)
 
 
 def vpi(dev_id=0):
@@ -501,7 +501,7 @@ def vpi(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(9, dev_id)
+    return Device(Device.kDLVPI, dev_id)
 
 
 def vulkan(dev_id=0):
@@ -517,7 +517,7 @@ def vulkan(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(7, dev_id)
+    return Device(Device.kDLVulkan, dev_id)
 
 
 def ext_dev(dev_id=0):
@@ -538,7 +538,7 @@ def ext_dev(dev_id=0):
     This API is reserved for quick testing of new
     device by plugin device API as ext_dev.
     """
-    return Device(12, dev_id)
+    return Device(Device.kDLExtDev, dev_id)
 
 
 def hexagon(dev_id=0):
@@ -554,7 +554,7 @@ def hexagon(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(14, dev_id)
+    return Device(Device.kDLHexagon, dev_id)
 
 
 def webgpu(dev_id=0):
@@ -570,7 +570,7 @@ def webgpu(dev_id=0):
     dev : Device
         The created device
     """
-    return Device(15, dev_id)
+    return Device(Device.kDLWebGPU, dev_id)
 
 
 cl = opencl

--- a/src/runtime/aot_executor/aot_executor.cc
+++ b/src/runtime/aot_executor/aot_executor.cc
@@ -49,8 +49,8 @@ AotExecutor::AotExecutor(tvm::runtime::Module module, const std::vector<Device>&
   ICHECK_EQ(devices_[0].device_id, expected_device.device_id)
       << "At this time, AOTExecutor supports only execution on kDLCPU 0";
   // TODO(tvm-team): Temporary hack since Hexagon is defined different than kDLCPU.
-  bool is_valid_device = (TVMDeviceExtType(devices_[0].device_type) == kDLHexagon) ||
-                         (DLDeviceType(devices_[0].device_type) == kDLCPU);
+  bool is_valid_device =
+      (devices_[0].device_type == kDLHexagon) || (devices_[0].device_type == kDLCPU);
   CHECK(is_valid_device)
       << "At this time, AOTExecutor supports only execution on kDLCPU 0 or kDLHexagon 0";
 

--- a/src/runtime/hexagon/hexagon_common.h
+++ b/src/runtime/hexagon/hexagon_common.h
@@ -45,9 +45,7 @@
     }                                                                             \
   } while (0)
 
-inline bool IsHexagonDevice(DLDevice dev) {
-  return TVMDeviceExtType(dev.device_type) == kDLHexagon;
-}
+inline bool IsHexagonDevice(DLDevice dev) { return dev.device_type == kDLHexagon; }
 
 constexpr int kHexagonAllocAlignment = 2048;
 

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -81,7 +81,7 @@ void* HexagonDeviceAPI::AllocDataSpace(Device dev, int ndim, const int64_t* shap
 
   // NOTE: This check should be superfluous, but it's probably a good idea to leave it in
   // until the AoT executor's multi-device dispatch code is mature. --cconvey 2022-08-26
-  CHECK(TVMDeviceExtType(dev.device_type) == kDLHexagon)
+  CHECK(dev.device_type == kDLHexagon)
       << "dev.device_type: " << dev.device_type << " DeviceName(" << dev.device_type
       << "): " << DeviceName(dev.device_type) << "";
 
@@ -162,14 +162,14 @@ void HexagonDeviceAPI::FreeWorkspace(Device dev, void* data) {
 void* HexagonDeviceAPI::AllocVtcmWorkspace(Device dev, int ndim, const int64_t* shape,
                                            DLDataType dtype, Optional<String> mem_scope) {
   // must be Hexagon device (not CPU)
-  CHECK(TVMDeviceExtType(dev.device_type) == kDLHexagon) << "dev.device_type: " << dev.device_type;
+  CHECK(dev.device_type == kDLHexagon) << "dev.device_type: " << dev.device_type;
   CHECK((ndim == 1 || ndim == 2) && "Hexagon Device API supports only 1d and 2d allocations");
   return AllocDataSpace(dev, ndim, shape, dtype, mem_scope);
 }
 
 void HexagonDeviceAPI::FreeVtcmWorkspace(Device dev, void* ptr) {
   // must be Hexagon device (not CPU)
-  CHECK(TVMDeviceExtType(dev.device_type) == kDLHexagon) << "dev.device_type: " << dev.device_type;
+  CHECK(dev.device_type == kDLHexagon) << "dev.device_type: " << dev.device_type;
   FreeDataSpace(dev, ptr);
 }
 

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -189,8 +189,7 @@ class HexagonDeviceAPI final : public DeviceAPI {
    */
   bool IsValidDevice(DLDevice dev) {
     // Added kDLCPU since we use hexagon as a sub-target of LLVM which by default maps to kDLCPU
-    return (TVMDeviceExtType(dev.device_type) == kDLHexagon) ||
-           (DLDeviceType(dev.device_type) == kDLCPU);
+    return (dev.device_type == kDLHexagon) || (dev.device_type == kDLCPU);
   }
 
   //! \brief Manages runtime HexagonBuffer allocations


### PR DESCRIPTION
[DLPack][runtime] Update DLPack to v0.7

- Update the `3rdparty/dlpack` git submodule from v0.5 to v0.7, so that the `DLDeviceType` enumeration has an explicitly-stated underlying storage type.  This addresses a compiler warning generated by clang 15.0.3.

- Remove `kDLHexagon` and `kDLWebGPU` from `TVMDeviceExtType`, because those enumerators are now provided by `DLDeviceType`.

- Renumber the members of `TVMDeviceExtType` to reduce the chance of unnoticed collision with members of `DLDeviceType`.