### PR TITLE
[Hexagon] [runtime] Per-thread hardware resource management

### DIFF
--- a/src/runtime/hexagon/hexagon_htp.cc
+++ b/src/runtime/hexagon/hexagon_htp.cc
@@ -35,9 +35,9 @@ namespace tvm {
 namespace runtime {
 namespace hexagon {
 
-HexagonHtp::HexagonHtp() {}
+HexagonHtp::HexagonHtp() { Acquire(); }
 
-HexagonHtp::~HexagonHtp() {}
+HexagonHtp::~HexagonHtp() { Release(); }
 
 void HexagonHtp::Acquire() {
   compute_res_attr_t compute_res_attr;
@@ -54,15 +54,19 @@ void HexagonHtp::Acquire() {
   if (!context_id_) {
     LOG(FATAL) << "InternalError: HAP_compute_res_acquire failed\n";
   }
+}
+
+void HexagonHtp::Release() { HAP_compute_res_release((unsigned int)context_id_); }
+
+void HexagonHtp::Lock() {
+  int nErr;
+
   if ((nErr = HAP_compute_res_hmx_lock(context_id_))) {
     LOG(FATAL) << "InternalError: Unable to lock HTP!";
   }
 }
 
-void HexagonHtp::Release() {
-  HAP_compute_res_hmx_unlock((unsigned int)context_id_);
-  HAP_compute_res_release((unsigned int)context_id_);
-}
+void HexagonHtp::Unlock() { HAP_compute_res_hmx_unlock((unsigned int)context_id_); }
 
 }  // namespace hexagon
 }  // namespace runtime

--- a/src/runtime/hexagon/hexagon_htp.cc
+++ b/src/runtime/hexagon/hexagon_htp.cc
@@ -35,9 +35,9 @@ namespace tvm {
 namespace runtime {
 namespace hexagon {
 
-HexagonHtp::HexagonHtp() { Acquire(); }
+HexagonHtp::HexagonHtp() {}
 
-HexagonHtp::~HexagonHtp() { Release(); }
+HexagonHtp::~HexagonHtp() {}
 
 void HexagonHtp::Acquire() {
   compute_res_attr_t compute_res_attr;

--- a/src/runtime/hexagon/hexagon_htp.h
+++ b/src/runtime/hexagon/hexagon_htp.h
@@ -44,12 +44,15 @@ class HexagonHtp {
   //! \brief Prevent move assignment.
   HexagonHtp& operator=(HexagonHtp&&) = delete;
 
-  void Acquire();
-  void Release();
+  void Lock();
+  void Unlock();
 
  private:
   //! \brief Acquisition context ID
   unsigned int context_id_;
+
+  void Acquire();
+  void Release();
 };
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_htp.h
+++ b/src/runtime/hexagon/hexagon_htp.h
@@ -44,12 +44,12 @@ class HexagonHtp {
   //! \brief Prevent move assignment.
   HexagonHtp& operator=(HexagonHtp&&) = delete;
 
+  void Acquire();
+  void Release();
+
  private:
   //! \brief Acquisition context ID
   unsigned int context_id_;
-
-  void Acquire();
-  void Release();
 };
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_hvx.cc
+++ b/src/runtime/hexagon/hexagon_hvx.cc
@@ -39,7 +39,6 @@ HexagonHvx::HexagonHvx() {
 }
 
 HexagonHvx::~HexagonHvx() {
-  // Release HVX.
   int rel = qurt_hvx_cancel_reserve();
   CHECK(rel == 0) << "error releasing HVX: " << rel;
 }
@@ -50,7 +49,6 @@ void HexagonHvx::Lock() {
 }
 
 void HexagonHvx::Unlock() {
-  // Unlock HVX.
   int unl = qurt_hvx_unlock();
   CHECK(unl == 0) << "error unlocking HVX: " << unl;
 }

--- a/src/runtime/hexagon/hexagon_hvx.cc
+++ b/src/runtime/hexagon/hexagon_hvx.cc
@@ -37,9 +37,7 @@ HexagonHvx::~HexagonHvx() { Release(); }
 
 void HexagonHvx::Acquire() {
   reserved_count_ = qurt_hvx_reserve(QURT_HVX_RESERVE_ALL);
-  CHECK((reserved_count_ == QURT_HVX_RESERVE_ALL) ||
-        (reserved_count_ == QURT_HVX_RESERVE_ALREADY_MADE))
-      << "error reserving HVX: " << reserved_count_;
+  CHECK(reserved_count_ == QURT_HVX_RESERVE_ALL) << "error reserving HVX: " << reserved_count_;
 }
 
 void HexagonHvx::Release() {

--- a/src/runtime/hexagon/hexagon_hvx.cc
+++ b/src/runtime/hexagon/hexagon_hvx.cc
@@ -32,24 +32,27 @@ namespace runtime {
 namespace hexagon {
 
 HexagonHvx::HexagonHvx() {
-  // Reserve HVX.
-  int res = qurt_hvx_reserve(QURT_HVX_RESERVE_ALL_AVAILABLE);
-  CHECK((res != QURT_HVX_RESERVE_NOT_SUPPORTED) && (res != QURT_HVX_RESERVE_NOT_SUCCESSFUL))
-      << "error reserving HVX: " << res;
+  reserved_count_ = qurt_hvx_reserve(QURT_HVX_RESERVE_ALL);
+  CHECK((reserved_count_ == QURT_HVX_RESERVE_ALL) ||
+        (reserved_count_ == QURT_HVX_RESERVE_ALREADY_MADE))
+      << "error reserving HVX: " << reserved_count_;
+}
 
-  // Lock HVX.
+HexagonHvx::~HexagonHvx() {
+  // Release HVX.
+  int rel = qurt_hvx_cancel_reserve();
+  CHECK(rel == 0) << "error releasing HVX: " << rel;
+}
+
+void HexagonHvx::Lock() {
   int lck = qurt_hvx_lock(QURT_HVX_MODE_128B);
   CHECK(lck == 0) << "error locking HVX: " << lck;
 }
 
-HexagonHvx::~HexagonHvx() {
+void HexagonHvx::Unlock() {
   // Unlock HVX.
   int unl = qurt_hvx_unlock();
   CHECK(unl == 0) << "error unlocking HVX: " << unl;
-
-  // Release HVX.
-  int rel = qurt_hvx_cancel_reserve();
-  CHECK(rel == 0) << "error releasing HVX: " << rel;
 }
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_hvx.cc
+++ b/src/runtime/hexagon/hexagon_hvx.cc
@@ -31,14 +31,18 @@ namespace tvm {
 namespace runtime {
 namespace hexagon {
 
-HexagonHvx::HexagonHvx() {
+HexagonHvx::HexagonHvx() { Acquire(); }
+
+HexagonHvx::~HexagonHvx() { Release(); }
+
+void HexagonHvx::Acquire() {
   reserved_count_ = qurt_hvx_reserve(QURT_HVX_RESERVE_ALL);
   CHECK((reserved_count_ == QURT_HVX_RESERVE_ALL) ||
         (reserved_count_ == QURT_HVX_RESERVE_ALREADY_MADE))
       << "error reserving HVX: " << reserved_count_;
 }
 
-HexagonHvx::~HexagonHvx() {
+void HexagonHvx::Release() {
   int rel = qurt_hvx_cancel_reserve();
   CHECK(rel == 0) << "error releasing HVX: " << rel;
 }

--- a/src/runtime/hexagon/hexagon_hvx.h
+++ b/src/runtime/hexagon/hexagon_hvx.h
@@ -56,6 +56,9 @@ class HexagonHvx {
 
  private:
   int reserved_count_;
+
+  void Acquire();
+  void Release();
 };
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_hvx.h
+++ b/src/runtime/hexagon/hexagon_hvx.h
@@ -45,7 +45,17 @@ class HexagonHvx {
   //! \brief Prevent move assignment.
   HexagonHvx& operator=(HexagonHvx&&) = delete;
 
+  //! \brief Lock one HVX to the calling thread.
+  void Lock();
+
+  //! \brief Unlock the HVX for the calling thread.
+  void Unlock();
+
+  //! \brief Number of HVX units reservered.
+  int ReservedCount() { return reserved_count_; }
+
  private:
+  int reserved_count_;
 };
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_hvx.h
+++ b/src/runtime/hexagon/hexagon_hvx.h
@@ -51,7 +51,7 @@ class HexagonHvx {
   //! \brief Unlock the HVX for the calling thread.
   void Unlock();
 
-  //! \brief Number of HVX units reservered.
+  //! \brief Number of HVX units reserved.
   int ReservedCount() { return reserved_count_; }
 
  private:

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -208,6 +208,8 @@ TVMStreamHandle HexagonThreadManager::GetStreamHandleByResourceType(HardwareReso
 }
 
 HardwareResourceType HexagonThreadManager::GetResourceTypeForStreamHandle(TVMStreamHandle thread) {
+  CHECK(hw_resources_.size() > reinterpret_cast<int>(thread))
+      << "No thread for handle id exists " << thread;
   return hw_resources_[reinterpret_cast<int>(thread)];
 }
 

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -43,7 +43,10 @@ HexagonThreadManager::HexagonThreadManager(unsigned num_threads, unsigned thread
 
   if (create_resource_managers_) {
     DLOG(INFO) << "Initialize hardware resource managers";
-    // Acquisition/locks will be performed on specific threads
+    // This creates the manager objects, which reserves (acquires) the resources.
+    // Calls to lock/unlock will be performed on threads dedicated to instances.
+    // This must be done before spawing threads so we can pass pointers to the
+    // objects in the thread context.
     htp_ = std::make_unique<HexagonHtp>();
     hvx_ = std::make_unique<HexagonHvx>();
   }

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -322,10 +322,10 @@ void HexagonThreadManager::thread_exit(void* context) {
 
   if ((resource_type == HVX_0) || (resource_type == HVX_1) || (resource_type == HVX_2) ||
       (resource_type == HVX_3)) {
-    //tc->hvx->Unlock();
+    tc->hvx->Unlock();
     DLOG(INFO) << "Thread " << index << " unlocked an HVX instance";
   } else if (resource_type == HTP_0) {
-    //tc->htp->Unlock();
+    tc->htp->Unlock();
     DLOG(INFO) << "Thread " << index << " unlocked the HTP";
   }
 

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -45,7 +45,7 @@ HexagonThreadManager::HexagonThreadManager(unsigned num_threads, unsigned thread
     DLOG(INFO) << "Initialize hardware resource managers";
     // This creates the manager objects, which reserves (acquires) the resources.
     // Calls to lock/unlock will be performed on threads dedicated to instances.
-    // This must be done before spawing threads so we can pass pointers to the
+    // This must be done before spawning threads so we can pass pointers to the
     // objects in the thread context.
     htp_ = std::make_unique<HexagonHtp>();
     hvx_ = std::make_unique<HexagonHvx>();
@@ -322,10 +322,10 @@ void HexagonThreadManager::thread_exit(void* context) {
 
   if ((resource_type == HVX_0) || (resource_type == HVX_1) || (resource_type == HVX_2) ||
       (resource_type == HVX_3)) {
-    tc->hvx->Unlock();
+    //tc->hvx->Unlock();
     DLOG(INFO) << "Thread " << index << " unlocked an HVX instance";
   } else if (resource_type == HTP_0) {
-    tc->htp->Unlock();
+    //tc->htp->Unlock();
     DLOG(INFO) << "Thread " << index << " unlocked the HTP";
   }
 

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -196,6 +196,19 @@ const std::vector<TVMStreamHandle> HexagonThreadManager::GetStreamHandles() {
   return out;
 }
 
+TVMStreamHandle HexagonThreadManager::GetStreamHandleByResourceType(HardwareResourceType type) {
+  for (unsigned i = 0; i < hw_resources_.size(); i++) {
+    if (hw_resources_[i] == type) {
+      return reinterpret_cast<TVMStreamHandle>(i);
+    }
+  }
+  CHECK(false) << "Thread for resource type " << type << " not found";
+}
+
+HardwareResourceType HexagonThreadManager::GetResourceTypeForStreamHandle(TVMStreamHandle thread) {
+  return hw_resources_[reinterpret_cast<int>(thread)];
+}
+
 bool HexagonThreadManager::Dispatch(TVMStreamHandle stream, voidfunc f, void* args) {
   unsigned thread = reinterpret_cast<unsigned>(stream);
   DLOG(INFO) << "Dispatching to stream " << thread;

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -315,13 +315,11 @@ void HexagonThreadManager::thread_exit(void* context) {
 
   if ((resource_type == HVX_0) || (resource_type == HVX_1) || (resource_type == HVX_2) ||
       (resource_type == HVX_3)) {
-    CHECK(tc->hvx) << "Malformed thread context, missing hvx pointer for HVX_x resource";
     tc->hvx->Unlock();
-    DLOG(INFO) << "Resource " << resource_type << " unlocked an HVX instance";
+    DLOG(INFO) << "Thread " << index << " unlocked an HVX instance";
   } else if (resource_type == HTP_0) {
-    CHECK(tc->htp) << "Malformed thread context, missing htp pointer for HTP_0 resource";
     tc->htp->Release();
-    DLOG(INFO) << "Resource " << resource_type << " released the HTP";
+    DLOG(INFO) << "Thread " << index << " released the HTP";
   }
 
   DLOG(INFO) << "Thread " << index << " exiting";
@@ -336,32 +334,13 @@ void HexagonThreadManager::thread_main(void* context) {
 
   DLOG(INFO) << "Thread " << index << " spawned";
 
-  switch (resource_type) {
-    case NONE:
-      DLOG(INFO) << "No hardware resource";
-      break;
-
-    case DMA_0:
-      DLOG(INFO) << "Resource " << resource_type << " assigned to DMA";
-      break;
-
-    case HTP_0:
-      CHECK(tc->htp) << "Malformed thread context, missing htp pointer for HTP_0 resource";
-      tc->htp->Acquire();
-      DLOG(INFO) << "Resource " << resource_type << " acquired the HTP";
-      break;
-
-    case HVX_0:
-    case HVX_1:
-    case HVX_2:
-    case HVX_3:
-      CHECK(tc->hvx) << "Malformed thread context, missing hvx pointer for HVX_x resource";
-      tc->hvx->Lock();
-      DLOG(INFO) << "Resource " << resource_type << " locked an HVX instance";
-      break;
-
-    default:
-      CHECK(false) << "Invalid HardwareResourceType: " << resource_type;
+  if ((resource_type == HVX_0) || (resource_type == HVX_1) || (resource_type == HVX_2) ||
+      (resource_type == HVX_3)) {
+    tc->hvx->Lock();
+    DLOG(INFO) << "Thread " << index << " locked an HVX instance";
+  } else if (resource_type == HTP_0) {
+    tc->htp->Acquire();
+    DLOG(INFO) << "Thread " << index << " acquired the HTP";
   }
 
   while (true) {  // loop, executing commands from pipe

--- a/src/runtime/hexagon/hexagon_thread_manager.h
+++ b/src/runtime/hexagon/hexagon_thread_manager.h
@@ -88,6 +88,18 @@ class HexagonThreadManager {
   const std::vector<TVMStreamHandle> GetStreamHandles();
 
   /*!
+   * \brief Get the spawned threads as stream handles for a resource type.
+   * \returns stream handle.
+   */
+  TVMStreamHandle GetStreamHandleByResourceType(HardwareResourceType type);
+
+  /*!
+   * \brief Get the resource type for a stream handle
+   * \returns stream handle.
+   */
+  HardwareResourceType GetResourceTypeForStreamHandle(TVMStreamHandle thread);
+
+  /*!
    * \brief Non-blocking dispatch of a void function and args on a given thread.
    * \param thread Stream handle of the thread on which to dispatch the void function.
    * \param f Void function to be dispatched.

--- a/src/runtime/hexagon/hexagon_thread_manager.h
+++ b/src/runtime/hexagon/hexagon_thread_manager.h
@@ -155,7 +155,11 @@ class HexagonThreadManager {
     uint64_t status;
     ThreadContext(qurt_pipe_t* pipe, unsigned index, HardwareResourceType resource_type,
                   HexagonHvx* hvx, HexagonHtp* htp)
-        : pipe(pipe), index(index), resource_type(resource_type), hvx(hvx), htp(htp), status(0) {}
+        : pipe(pipe), index(index), resource_type(resource_type), hvx(hvx), htp(htp), status(0) {
+      CHECK(resource_type == NONE || (hvx && htp))
+          << "Missing resource manager pointer, type: " << resource_type << " hvx: " << hvx
+          << " htp: " << htp;
+    }
   };
 
   //! \brief Helper function to ensure the set of requested resources is valid.

--- a/src/runtime/hexagon/hexagon_thread_manager.h
+++ b/src/runtime/hexagon/hexagon_thread_manager.h
@@ -228,6 +228,9 @@ class HexagonThreadManager {
   //! \brief List of hardware resources
   std::vector<HardwareResourceType> hw_resources_;
 
+  //! \brief Whether or not resource managers should be created
+  bool create_resource_managers_{false};
+
   //! \brief HTP hardware resource.
   // TODO(HWE): Move binding of HTP to a specific thread
   std::unique_ptr<HexagonHtp> htp_;

--- a/src/runtime/hexagon/hexagon_thread_manager.h
+++ b/src/runtime/hexagon/hexagon_thread_manager.h
@@ -137,8 +137,17 @@ class HexagonThreadManager {
   struct ThreadContext {
     qurt_pipe_t* pipe;
     unsigned index;
-    ThreadContext(qurt_pipe_t* pipe, unsigned index) : pipe(pipe), index(index) {}
+    HardwareResourceType resource_type;
+    HexagonHvx* hvx;
+    HexagonHtp* htp;
+    uint64_t status;
+    ThreadContext(qurt_pipe_t* pipe, unsigned index, HardwareResourceType resource_type,
+                  HexagonHvx* hvx, HexagonHtp* htp)
+        : pipe(pipe), index(index), resource_type(resource_type), hvx(hvx), htp(htp), status(0) {}
   };
+
+  //! \brief Helper function to ensure the set of requested resources is valid.
+  void CheckResources();
 
   //! \brief Helper function for the constructor to spawn threads.
   void SpawnThreads(unsigned thread_stack_size_bytes, unsigned thread_pipe_size_words);
@@ -157,7 +166,7 @@ class HexagonThreadManager {
   static void thread_wait_free(void* semaphore);
 
   //! \brief Void function executed by a thread to exit at time of destruction.
-  static void thread_exit(void* status);
+  static void thread_exit(void* context);
 
   //! \brief Void function executed by each thread as `main`.
   static void thread_main(void* context);

--- a/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
@@ -190,3 +190,22 @@ TEST_F(HexagonDeviceAPITest, vtcm_pool) {
   EXPECT_THROW(hexapi->VtcmPool(), InternalError);
   hexapi->AcquireResources();
 }
+
+// Validate threads created for hw resources
+TEST_F(HexagonDeviceAPITest, threads_for_resource_types) {
+  HexagonThreadManager* thread_manager = hexapi->ThreadManager();
+  TVMStreamHandle thread;
+
+  thread = thread_manager->GetStreamHandleByResourceType(DMA_0);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == DMA_0);
+  thread = thread_manager->GetStreamHandleByResourceType(HTP_0);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HTP_0);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_0);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_0);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_1);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_1);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_2);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_2);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_3);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_3);
+}

--- a/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
@@ -190,22 +190,3 @@ TEST_F(HexagonDeviceAPITest, vtcm_pool) {
   EXPECT_THROW(hexapi->VtcmPool(), InternalError);
   hexapi->AcquireResources();
 }
-
-// Validate threads created for hw resources
-TEST_F(HexagonDeviceAPITest, threads_for_resource_types) {
-  HexagonThreadManager* thread_manager = hexapi->ThreadManager();
-  TVMStreamHandle thread;
-
-  thread = thread_manager->GetStreamHandleByResourceType(DMA_0);
-  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == DMA_0);
-  thread = thread_manager->GetStreamHandleByResourceType(HTP_0);
-  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HTP_0);
-  thread = thread_manager->GetStreamHandleByResourceType(HVX_0);
-  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_0);
-  thread = thread_manager->GetStreamHandleByResourceType(HVX_1);
-  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_1);
-  thread = thread_manager->GetStreamHandleByResourceType(HVX_2);
-  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_2);
-  thread = thread_manager->GetStreamHandleByResourceType(HVX_3);
-  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_3);
-}

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -359,15 +359,3 @@ TEST_F(HexagonThreadManagerTest, threads_for_resource_types) {
   thread = reinterpret_cast<TVMStreamHandle>(6);
   EXPECT_THROW(thread_manager->GetResourceTypeForStreamHandle(thread), InternalError);
 }
-
-// Ensure proper behavior of hardware resources managed by global thread manager
-TEST_F(HexagonThreadManagerTest, hardware_resources_locked) {
-  // HVX can share
-  HexagonHvx* hvx = new HexagonHvx();
-  hvx->Lock();
-  hvx->Unlock();
-  delete hvx;
-
-  // HTP cannot
-  EXPECT_THROW(new HexagonHtp(), InternalError);
-}

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -337,3 +337,40 @@ TEST_F(HexagonThreadManagerTest, dispatch_writes) {
     CHECK_EQ(array[i], truth[i]);
   }
 }
+
+// Validate threads created for hw resources on global manager
+TEST_F(HexagonThreadManagerTest, threads_for_resource_types) {
+  HexagonThreadManager* thread_manager = HexagonDeviceAPI::Global()->ThreadManager();
+  TVMStreamHandle thread;
+
+  thread = thread_manager->GetStreamHandleByResourceType(DMA_0);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == DMA_0);
+  thread = thread_manager->GetStreamHandleByResourceType(HTP_0);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HTP_0);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_0);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_0);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_1);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_1);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_2);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_2);
+  thread = thread_manager->GetStreamHandleByResourceType(HVX_3);
+  CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_3);
+}
+
+// Ensure proper behavior of hardware resources managed by global thread manager
+TEST_F(HexagonThreadManagerTest, hardware_resources_locked) {
+  CHECK(htm != nullptr);
+  CHECK_EQ(streams.size(), threads);
+  HexagonHvx* hvx = new HexagonHvx();
+  HexagonHtp* htp = new HexagonHtp();
+
+  // These should succeed
+  hvx->Lock();
+  hvx->Unlock();
+
+  // This should throw
+  EXPECT_THROW(htp->Acquire(), InternalError);
+
+  delete hvx;
+  delete htp;
+}

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -42,7 +42,7 @@ class HexagonThreadManagerTest : public ::testing::Test {
   const unsigned stack_size{0x4000};  // 16KB
 };
 
-TEST_F(HexagonThreadManagerTest, ctor_errors) {
+TEST_F(HexagonThreadManagerTest, ctor_edge_cases) {
   // zero threads
   ASSERT_THROW(HexagonThreadManager(0, stack_size, pipe_size), InternalError);
   // too many threads
@@ -57,13 +57,16 @@ TEST_F(HexagonThreadManagerTest, ctor_errors) {
   ASSERT_THROW(HexagonThreadManager(6, stack_size, 0x10000000), InternalError);
   // hw resources count doesn't match thread count
   ASSERT_THROW(HexagonThreadManager(6, stack_size, pipe_size, {DMA_0}), InternalError);
-  // hw resources doesn't match specific supported configuration
+  // no more than one of each hw resource may be specified
+  ASSERT_THROW(HexagonThreadManager(4, stack_size, pipe_size, {DMA_0, HTP_0, HVX_0, HVX_0}),
+               InternalError);
+  // no more than one of each hw resource may be specified
   ASSERT_THROW(
       HexagonThreadManager(6, stack_size, pipe_size, {DMA_0, HTP_0, HVX_0, HVX_1, HVX_2, DMA_0}),
       InternalError);
-  // hw resources doesn't match specific supported configuration
-  ASSERT_THROW(HexagonThreadManager(5, stack_size, pipe_size, {DMA_0, HTP_0, HVX_0, HVX_1, HVX_2}),
-               InternalError);
+  // multiple entries for no resource is allowed.
+  HexagonThreadManager* htm_none = new HexagonThreadManager(2, stack_size, pipe_size, {NONE, NONE});
+  delete htm_none;
 }
 
 TEST_F(HexagonThreadManagerTest, init) {

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -359,18 +359,12 @@ TEST_F(HexagonThreadManagerTest, threads_for_resource_types) {
 
 // Ensure proper behavior of hardware resources managed by global thread manager
 TEST_F(HexagonThreadManagerTest, hardware_resources_locked) {
-  CHECK(htm != nullptr);
-  CHECK_EQ(streams.size(), threads);
+  // HVX can share
   HexagonHvx* hvx = new HexagonHvx();
-  HexagonHtp* htp = new HexagonHtp();
-
-  // These should succeed
   hvx->Lock();
   hvx->Unlock();
-
-  // This should throw
-  EXPECT_THROW(htp->Acquire(), InternalError);
-
   delete hvx;
-  delete htp;
+
+  // HTP cannot
+  EXPECT_THROW(HexagonHtp* htp = new HexagonHtp(), InternalError);
 }

--- a/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_thread_manager_tests.cc
@@ -355,6 +355,9 @@ TEST_F(HexagonThreadManagerTest, threads_for_resource_types) {
   CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_2);
   thread = thread_manager->GetStreamHandleByResourceType(HVX_3);
   CHECK(thread_manager->GetResourceTypeForStreamHandle(thread) == HVX_3);
+  EXPECT_THROW(thread_manager->GetStreamHandleByResourceType(NONE), InternalError);
+  thread = reinterpret_cast<TVMStreamHandle>(6);
+  EXPECT_THROW(thread_manager->GetResourceTypeForStreamHandle(thread), InternalError);
 }
 
 // Ensure proper behavior of hardware resources managed by global thread manager
@@ -366,5 +369,5 @@ TEST_F(HexagonThreadManagerTest, hardware_resources_locked) {
   delete hvx;
 
   // HTP cannot
-  EXPECT_THROW(HexagonHtp* htp = new HexagonHtp(), InternalError);
+  EXPECT_THROW(new HexagonHtp(), InternalError);
 }


### PR DESCRIPTION
Add support to lock and unlock resources on the individual threads.  Adds APIs to get a thread handle for a given resource type, and get a resource type for a given thread handle.  This will aid in asynchronous support that is sending work to dedicated threads for the hardware resources.

There are two steps to fully acquire a resource:  reserve and lock.  HTP/HVX manager objects are created on the global thread, which will reserve the resources.  The lock/unlock will occur on the thread that owns a particular instance.  The manager objects will be deconstructed when the thread manager is deconstructed.  This will release the resources.

cc:  @csullivan, @adstraw, @JosephTheOctonaut, @kparzysz-quic 