### PR TITLE
[docs] Add 'Edit on GitHub' button

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -34,7 +34,7 @@ pip3 install --upgrade \
     Pillow==9.1.0 \
     psutil \
     pytest \
-    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@545450acaf0ee4e2932d8c5d9ab6e321d0bc86c8 \
+    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@768ec1dce349fe4708f6ad68be1ebb3f3dabafa1 \
     pytest-profiling \
     pytest-xdist \
     pytest-rerunfailures==10.2 \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,12 +30,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 import gc
-import importlib.util
 import inspect
 import os
 from pathlib import Path
-import shlex
-import subprocess
+import re
 import sys
 
 import sphinx_gallery
@@ -420,6 +418,24 @@ header_dropdown = {
     ],
 }
 
+
+def fixup_tutorials(original_url: str) -> str:
+    if "docs/tutorial" in original_url:
+        # tutorials true source is in Python or .txt files, but Sphinx only sees
+        # the generated .rst files so this maps them back to the source
+        if original_url.endswith("index.rst"):
+            # for index pages, go to the README files
+            return re.sub(
+                r"docs/tutorial/(.*)index\.rst", "gallery/tutorial/\\1README.txt", original_url
+            )
+        else:
+            # otherwise for tutorials, redirect to python files
+            return re.sub(r"docs/tutorial/(.*)\.rst", "gallery/tutorial/\\1.py", original_url)
+    else:
+        # do nothing for normal non-tutorial .rst files
+        return original_url
+
+
 html_context = {
     "footer_copyright": footer_copyright,
     "footer_note": footer_note,
@@ -428,6 +444,12 @@ html_context = {
     "header_logo": header_logo,
     "header_logo_link": header_logo_link,
     "version_prefixes": ["main", "v0.8.0/", "v0.9.0/", "v0.10.0/"],
+    "display_github": True,
+    "github_user": "apache",
+    "github_repo": "tvm",
+    "github_version": "main/docs/",
+    "theme_vcs_pageview_mode": "edit",
+    "edit_link_hook_fn": fixup_tutorials,
 }
 
 # add additional overrides


### PR DESCRIPTION
This changes the 'View Source' button on the top right of each doc page
to a link that goes to a GitHub web editor for that docs page and
automatically routes to the right source of truth, be it `.rst` or
`.py`. Depends on https://github.com/tlc-pack/tlcpack-sphinx-addon/pull/10
for links.