### PR TITLE
[docs] Fix empty code blocks in tutorials

### DIFF
--- a/gallery/how_to/compile_models/from_tflite.py
+++ b/gallery/how_to/compile_models/from_tflite.py
@@ -53,14 +53,16 @@ Now please check if TFLite package is installed successfully, ``python -c "impor
 Below you can find an example on how to compile TFLite model using TVM.
 """
 
+######################################################################
+# Utils for downloading and extracting zip files
+# ----------------------------------------------
+
 # sphinx_gallery_start_ignore
 from tvm import testing
 
 testing.utils.install_request_hook(depth=3)
 # sphinx_gallery_end_ignore
-######################################################################
-# Utils for downloading and extracting zip files
-# ----------------------------------------------
+
 import os
 
 

--- a/gallery/how_to/optimize_operators/opt_conv_tensorcore.py
+++ b/gallery/how_to/optimize_operators/opt_conv_tensorcore.py
@@ -27,12 +27,6 @@ convolution has a large batch. We strongly recommend covering the :ref:`opt-conv
 
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ################################################################
 # TensorCore Introduction
 # -----------------------
@@ -56,6 +50,12 @@ testing.utils.install_request_hook(depth=3)
 # The batch size is 256. Convolution filters contain 512 filters of size 3 x 3.
 # We use stride size 1 and padding size 1 for the convolution. In the example, we use
 # NHWCnc memory layout.The following code defines the convolution algorithm in TVM.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import tvm
 from tvm import te

--- a/gallery/how_to/tune_with_autotvm/tune_conv2d_cuda.py
+++ b/gallery/how_to/tune_with_autotvm/tune_conv2d_cuda.py
@@ -28,12 +28,6 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ######################################################################
 # Install dependencies
 # --------------------
@@ -53,6 +47,12 @@ testing.utils.install_request_hook(depth=3)
 #   sudo make cython3
 #
 # Now return to python code. Import packages.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import logging
 import sys

--- a/gallery/how_to/tune_with_autotvm/tune_relay_arm.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_arm.py
@@ -41,12 +41,6 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ######################################################################
 # Install dependencies
 # --------------------
@@ -67,6 +61,12 @@ testing.utils.install_request_hook(depth=3)
 #   sudo make cython3
 #
 # Now return to python code. Import packages.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import os
 

--- a/gallery/how_to/tune_with_autotvm/tune_relay_cuda.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_cuda.py
@@ -39,12 +39,6 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ######################################################################
 # Install dependencies
 # --------------------
@@ -64,6 +58,12 @@ testing.utils.install_request_hook(depth=3)
 #   sudo make cython3
 #
 # Now return to python code. Import packages.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import os
 

--- a/gallery/how_to/tune_with_autotvm/tune_relay_mobile_gpu.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_mobile_gpu.py
@@ -39,12 +39,6 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ######################################################################
 # Install dependencies
 # --------------------
@@ -65,6 +59,12 @@ testing.utils.install_request_hook(depth=3)
 #   sudo make cython3
 #
 # Now return to python code. Import packages.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import os
 

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -25,12 +25,6 @@ This tutorial is an introduction to working with microTVM and a TFLite
 model with Relay.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ######################################################################
 # .. note::
 #     If you want to run this tutorial on the microTVM Reference VM, download the Jupyter
@@ -127,6 +121,12 @@ testing.utils.install_request_hook(depth=3)
 #
 # Load the pretrained TFLite model from a file in your current
 # directory into a buffer
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import os
 import json

--- a/gallery/tutorial/autotvm_matmul_x86.py
+++ b/gallery/tutorial/autotvm_matmul_x86.py
@@ -45,12 +45,6 @@ workflow is illustrated by a matrix multiplication example.
   :code:`if __name__ == "__main__":` block.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ################################################################################
 # Install dependencies
 # --------------------
@@ -69,6 +63,12 @@ testing.utils.install_request_hook(depth=3)
 #   sudo make cython3
 #
 # Now return to python code. Begin by importing the required packages.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import logging
 import sys

--- a/gallery/tutorial/cross_compilation_and_rpc.py
+++ b/gallery/tutorial/cross_compilation_and_rpc.py
@@ -31,12 +31,6 @@ platforms. In this tutorial, we will use the Raspberry Pi for a CPU example
 and the Firefly-RK3399 for an OpenCL example.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ######################################################################
 # Build TVM Runtime on Device
 # ---------------------------
@@ -98,6 +92,12 @@ testing.utils.install_request_hook(depth=3)
 #   (with LLVM).
 #
 # Here we will declare a simple kernel on the local machine:
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore
 
 import numpy as np
 

--- a/gallery/tutorial/install.py
+++ b/gallery/tutorial/install.py
@@ -28,12 +28,6 @@ methods for installing TVM. These include:
 * Installing from third-party binary package.
 """
 
-# sphinx_gallery_start_ignore
-from tvm import testing
-
-testing.utils.install_request_hook(depth=3)
-# sphinx_gallery_end_ignore
-
 ################################################################################
 # Installing From Source
 # ----------------------
@@ -54,3 +48,9 @@ testing.utils.install_request_hook(depth=3)
 # Check out  `TLCPack <https://tlcpack.ai>`_ to learn more. Note that the
 # third party binary packages could contain additional licensing terms for
 # the hardware drivers that are bundled with it.
+
+# sphinx_gallery_start_ignore
+from tvm import testing
+
+testing.utils.install_request_hook(depth=3)
+# sphinx_gallery_end_ignore

--- a/tests/lint/check_request_hook.py
+++ b/tests/lint/check_request_hook.py
@@ -19,6 +19,7 @@ import argparse
 import fnmatch
 import re
 from pathlib import Path
+from typing import List, Optional
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -30,6 +31,33 @@ testing.utils.install_request_hook(depth=3)
 # sphinx_gallery_end_ignore
 """.rstrip()
 IGNORE_PATTERNS = ["*/micro_tvmc.py", "*/micro_train.py"]
+APACHE_HEADER_LINES = 16
+
+
+def find_code_block_line(lines: List[str]) -> Optional[int]:
+    """
+    This returns the index in 'lines' of the first line of code in the tutorial
+    or none if there are no code blocks.
+    """
+    in_multiline_string = False
+    in_sphinx_directive = False
+
+    i = 0
+    lines = lines[APACHE_HEADER_LINES:]
+    while i < len(lines):
+        line = lines[i].strip()
+        if '"""' in line:
+            in_multiline_string = not in_multiline_string
+        elif "# sphinx_gallery_" in line:
+            in_sphinx_directive = not in_sphinx_directive
+        elif line.startswith("#") or in_sphinx_directive or in_multiline_string or line == "":
+            pass
+        else:
+            return i
+        i += 1
+
+    return None
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -41,6 +69,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     gallery_files = (REPO_ROOT / "gallery").glob("**/*.py")
+    # gallery_files = [x for x in gallery_files if "cross_compi" in str(x)]
 
     errors = []
     for file in gallery_files:
@@ -56,23 +85,43 @@ if __name__ == "__main__":
             content = f.read()
 
         if EXPECTED not in content:
-            errors.append(file)
+            errors.append((file, None))
+            continue
+
+        index = content.index(EXPECTED)
+        line = content.count("\n", 0, index) + EXPECTED.count("\n") + 2
+        expected = find_code_block_line(content.split("\n"))
+
+        if expected is not None and line < expected:
+            errors.append((file, (line, expected)))
 
     if args.fix:
-        for error in errors:
+        for error, line_info in errors:
             with open(error) as f:
                 content = f.read()
 
+            # Note: There must be a little bit of care taken here since inserting
+            # the block between a comment and multiline string will lead to an
+            # empty code block in the HTML output
             if "from __future__" in content:
                 # Place after the last __future__ import
                 new_content = re.sub(
                     r"((?:from __future__.*?\n)+)", r"\1\n" + EXPECTED, content, flags=re.MULTILINE
                 )
             else:
-                # Place after the module doc comment
-                new_content = re.sub(
-                    r"(\"\"\"(?:.*\n)+\"\"\")", r"\1\n" + EXPECTED, content, flags=re.MULTILINE
-                )
+                # Place in the first codeblock
+                lines = content.split("\n")
+                position = find_code_block_line(lines)
+                if position is None:
+                    new_content = "\n".join(lines) + EXPECTED + "\n"
+                else:
+                    print(position)
+                    new_content = (
+                        "\n".join(lines[:position])
+                        + EXPECTED
+                        + "\n\n"
+                        + "\n".join(lines[position:])
+                    )
 
             with open(error, "w") as f:
                 f.write(new_content)
@@ -80,12 +129,19 @@ if __name__ == "__main__":
         # Don't fix, just check and print an error message
         if len(errors) > 0:
             print(
-                f"These {len(errors)} files did not contain the expected text to "
-                "override urllib.request.Request.\n"
+                f"These {len(errors)} file(s) did not contain the expected text to "
+                "override urllib.request.Request, it was at the wrong position, or "
+                "the whitespace is incorrect.\n"
                 "You can run 'python3 tests/lint/check_request_hook.py --fix' to "
                 "automatically fix these errors:\n"
-                f"{EXPECTED}\n\nFiles:\n" + "\n".join([str(error_path) for error_path in errors])
+                f"{EXPECTED}\n\nFiles:"
             )
+            for file, line_info in errors:
+                if line_info is None:
+                    print(f"{file} (missing hook)")
+                else:
+                    actual, expected = line_info
+                    print(f"{file} (misplaced hook at {actual}, expected at {expected})")
             exit(1)
         else:
             print("All files successfully override urllib.request.Request")


### PR DESCRIPTION
Fixes #12343. Rather than hacking away empty code blocks with JavaScript this changes the lint for the request hook code to ensure that it is part of another code block or at the end of a tutorial `.py` (which sphinx-gallery itself removes).