### PR TITLE
[TIR] Add utility for anchor block extraction

### DIFF
--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -236,6 +236,31 @@ TVM_DLL Map<Buffer, Optional<Stmt>> DetectBufferAccessLCA(const PrimFunc& func);
  */
 TVM_DLL bool VerifyWellFormed(const PrimFunc& func, bool assert_mode = true);
 
+/*!
+ * \brief Find the entry function of the given IRModule, i.e, functions marked by
+ * `tir::attr::kIsEntryFunc`, whose name is `main` or being the only PrimeFunc.
+ * \param mod The IRModule to find the entry function.
+ * \param result_g_var The result GlobalVar of the entry function.
+ * \return The entry function.
+ */
+const PrimFuncNode* FindEntryFunc(const IRModule& mod, GlobalVar* result_g_var);
+
+/*!
+ * \brief Find the "anchor block" of the given module.
+ * We define the anchor block to be the block with (1) an init statement and (2) having
+ * the biggest flops count. The latter condition is only used when there are multiple blocks
+ * with an init statement.
+ * For example, if the input module is conv2d + fused spatial blocks, conv2d is the anchor block.
+ * The input module may not contain more than one such block. For example, a module having
+ * two conv2d is not allowed as an input.
+ * However, a module created from winograd convolution has multiple blocks with an init statement
+ * (input transform, batched GEMM, and output transform). We use the second condition, the flops
+ * count, to determine that the batched GEMM block is the anchor block.
+ * \param mod The input TIR module.
+ * \return The anchor block if found, nullptr otherwise.
+ */
+const tir::BlockNode* FindAnchorBlock(const IRModule& mod);
+
 // Pass variants of verification analysis
 // directly throws RuntimeError when verification fails.
 namespace transform {

--- a/python/tvm/tir/analysis/analysis.py
+++ b/python/tvm/tir/analysis/analysis.py
@@ -331,3 +331,30 @@ def OOBChecker():
         The result pass
     """
     return _ffi_api.OOBChecker()  # type: ignore
+
+
+def find_anchor_block(mod: IRModule) -> Block:
+    """Find the "anchor block" of the given module.
+
+    We define the anchor block to be the block with (1) an init statement and (2) having
+    the biggest flops count. The latter condition is only used when there are multiple blocks
+    with an init statement.
+
+    For example, if the input module is conv2d + fused spatial blocks, conv2d is the anchor block.
+    The input module may not contain more than one such block. For example, a module having
+    two conv2d is not allowed as an input.
+
+    However, a module created from winograd convolution has multiple blocks with an init statement
+    (input transform, batched GEMM, and output transform). We use the second condition, the flops
+    count, to determine that the batched GEMM block is the anchor block.
+
+    Parameters
+    ----------
+    mod: tvm.ir.IRModule
+        The input TIR module.
+    Returns
+    -------
+    anchor_block: Block
+        The anchor block if found, None otherwise.
+    """
+    return _ffi_api.find_anchor_block(mod)  # type: ignore # pylint: disable=no-member

--- a/src/tir/analysis/stmt_finding.cc
+++ b/src/tir/analysis/stmt_finding.cc
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/stmt_functor.h>
+
+namespace tvm {
+namespace tir {
+
+const PrimFuncNode* FindEntryFunc(const IRModule& mod, GlobalVar* result_g_var) {
+  GlobalVar result = NullValue<GlobalVar>();
+  // Priority 1: PrimFunc marked as `tir::attr::kIsEntryFunc`
+  int num_prim_func = 0;
+  const tir::PrimFuncNode* main_func = nullptr;
+  const tir::PrimFuncNode* last_func = nullptr;
+  for (const auto& kv : mod->functions) {
+    GlobalVar gv = kv.first;
+    BaseFunc base_func = kv.second;
+    if (const auto* func = base_func.as<tir::PrimFuncNode>()) {
+      last_func = func;
+      if (func->HasNonzeroAttr(tir::attr::kIsEntryFunc)) {
+        if (result_g_var != nullptr) {
+          *result_g_var = gv;
+        }
+        return func;
+      }
+      if (gv->name_hint == "main") {
+        main_func = func;
+        result = gv;
+      }
+      ++num_prim_func;
+    }
+  }
+  // Priority 2: PrimFunc whose name is `main`
+  if (main_func != nullptr) {
+    if (result_g_var != nullptr) {
+      *result_g_var = result;
+    }
+    return main_func;
+  }
+  // Priority 3: The only PrimFunc in the IRModule
+  if (num_prim_func == 1) {
+    if (result_g_var != nullptr) {
+      *result_g_var = result;
+    }
+    return last_func;
+  }
+  return nullptr;
+}
+
+Stmt GetEnclosingLoop(const BlockNode* block, Stmt func_body) {
+  struct GetRootSeqStmt : public StmtVisitor {
+    void VisitStmt_(const SeqStmtNode* seq) override { result = seq; }
+    const SeqStmtNode* result;
+  };
+
+  struct BlockFinder : public StmtVisitor {
+    explicit BlockFinder(const BlockNode* tgt) : target(tgt) {}
+
+    void VisitStmt_(const BlockNode* block) override {
+      if (block == target) {
+        found = true;
+      }
+    }
+
+    const BlockNode* target;
+    bool found = false;
+  };
+
+  GetRootSeqStmt seq_finder;
+  seq_finder(func_body);
+
+  ICHECK(seq_finder.result);
+
+  for (auto stmt : seq_finder.result->seq) {
+    if (stmt->IsInstance<ForNode>()) {
+      BlockFinder finder(block);
+      finder(stmt);
+      if (finder.found) {
+        return stmt;
+      }
+    }
+  }
+
+  LOG(FATAL) << "Enclosing loop not found for a block " << GetRef<Block>(block);
+  return Stmt();
+}
+
+const BlockNode* FindAnchorBlock(const IRModule& mod) {
+  struct ReductionBlockCollector : public StmtVisitor {
+    void VisitStmt_(const BlockNode* block) override {
+      if (block->init) {
+        blocks.push_back(block);
+      }
+      StmtVisitor::VisitStmt(block->body);
+    }
+    std::vector<const BlockNode*> blocks;
+  };
+
+  auto prim_func = FindEntryFunc(mod, nullptr);
+
+  ReductionBlockCollector collector;
+  collector(prim_func->body);
+
+  const auto& candidates = collector.blocks;
+
+  if (candidates.empty()) {
+    return nullptr;
+  } else if (candidates.size() == 1) {
+    return candidates[0];
+  }
+
+  double best_flops = -1;
+  int best_idx = 0;
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    auto loop = GetEnclosingLoop(candidates[i], prim_func->body);
+    auto flops = EstimateTIRFlops(loop);
+    if (flops > best_flops) {
+      best_flops = flops;
+      best_idx = i;
+    }
+  }
+  return candidates[best_idx];
+}
+
+TVM_REGISTER_GLOBAL("tir.analysis.find_anchor_block").set_body_typed([](const IRModule& mod) {
+  auto ret = FindAnchorBlock(mod);
+  if (ret) {
+    return Optional<Block>(GetRef<Block>(ret));
+  }
+  return Optional<Block>(NullOpt);
+});
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -72,15 +72,6 @@ const PrimFuncNode* GetRootPrimFunc(const IRModule& mod, const StmtNode* root_bl
  */
 StmtSRef GetSRefTreeRoot(const StmtSRef& sref);
 
-/*!
- * \brief Find the entry function of the given IRModule, i.e, functions marked by
- * `tir::attr::kIsEntryFunc`, whose name is `main` or being the only PrimeFunc.
- * \param mod The IRModule to find the entry function.
- * \param result_g_var The result GlobalVar of the entry function.
- * \return The entry function.
- */
-const PrimFuncNode* FindEntryFunc(const IRModule& mod, GlobalVar* result_g_var);
-
 /******** Scope ********/
 /*!
  * \brief Checks if scope the specified sref is in is a stage-pipeline and return it

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -46,47 +46,6 @@ const PrimFuncNode* GetRootPrimFunc(const IRModule& mod, const StmtNode* root_bl
   throw;
 }
 
-const PrimFuncNode* FindEntryFunc(const IRModule& mod, GlobalVar* result_g_var) {
-  GlobalVar result = NullValue<GlobalVar>();
-  // Priority 1: PrimFunc marked as `tir::attr::kIsEntryFunc`
-  int num_prim_func = 0;
-  const tir::PrimFuncNode* main_func = nullptr;
-  const tir::PrimFuncNode* last_func = nullptr;
-  for (const auto& kv : mod->functions) {
-    GlobalVar gv = kv.first;
-    BaseFunc base_func = kv.second;
-    if (const auto* func = base_func.as<tir::PrimFuncNode>()) {
-      last_func = func;
-      if (func->HasNonzeroAttr(tir::attr::kIsEntryFunc)) {
-        if (result_g_var != nullptr) {
-          *result_g_var = gv;
-        }
-        return func;
-      }
-      if (gv->name_hint == "main") {
-        main_func = func;
-        result = gv;
-      }
-      ++num_prim_func;
-    }
-  }
-  // Priority 2: PrimFunc whose name is `main`
-  if (main_func != nullptr) {
-    if (result_g_var != nullptr) {
-      *result_g_var = result;
-    }
-    return main_func;
-  }
-  // Priority 3: The only PrimFunc in the IRModule
-  if (num_prim_func == 1) {
-    if (result_g_var != nullptr) {
-      *result_g_var = result;
-    }
-    return last_func;
-  }
-  return nullptr;
-}
-
 /******** Scope ********/
 
 StmtSRef GetScopeRoot(const ScheduleState& self, const StmtSRef& sref,

--- a/tests/python/unittest/test_tir_analysis_stmt_finding.py
+++ b/tests/python/unittest/test_tir_analysis_stmt_finding.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+import tvm
+from tvm.tir.analysis import find_anchor_block
+from tvm import te, topi
+from tvm.meta_schedule.testing.te_workload import matmul, conv2d_winograd_nhwc
+
+
+def test_matmul_add():
+    n = m = k = 128
+    A, B, C = matmul(n, m, k)
+    mod = tvm.IRModule()
+    mod["main"] = te.create_prim_func([A, B, C + A])
+
+    block = find_anchor_block(mod)
+
+    assert block.name_hint == "C"
+
+
+def test_winograd():
+    mod = tvm.IRModule()
+    mod["main"] = te.create_prim_func(conv2d_winograd_nhwc(1, 56, 56, 64, 64, 3))
+
+    block = find_anchor_block(mod)
+
+    assert block.name_hint == "bgemm"
+
+
+def test_no_anchor_block():
+    inp = te.placeholder((10,), name="input")
+    out = topi.nn.relu(inp + 1.0)
+    mod = tvm.IRModule()
+    mod["main"] = te.create_prim_func([inp, out])
+
+    assert find_anchor_block(mod) is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
I'm working on enabling "anchor block" tuning for MS. This is a utility to extract anchor blocks. 

I define the "anchor block" to be the block (1) with an init statement and (2) having the biggest flops count. The latter condition is only used when there are multiple blocks with an init statement.

For example, if the input module is conv2d + fused spatial blocks, conv2d is the anchor block. A module created from winograd convolution has multiple blocks with an init statement (input transform, batched GEMM, and output transform). We use the second condition, the flops count, to determine that the batched GEMM block is the anchor block.

cc @junrushao @Hzfengsy 
