### PR TITLE
[Fix,Auto_scheduler] Default to extent of 1 if extent cannot be determined

### DIFF
--- a/src/auto_scheduler/utils.h
+++ b/src/auto_scheduler/utils.h
@@ -192,7 +192,9 @@ inline bool StrEndsWith(const String& a, const String& b) {
 /*! \brief Get an int value from an Expr */
 inline int64_t GetIntImm(const PrimExpr& expr) {
   auto pint = expr.as<IntImmNode>();
-  ICHECK(pint != nullptr) << "Expect an IntImm but get " << expr;
+  if (pint == nullptr) {
+    return 1;
+  }
   return pint->value;
 }
 


### PR DESCRIPTION
This fixes a bug in autoscheduler featurization.