### PR TITLE
[MetaSchedule][Minor] Fix Memory Database Module Equality

### DIFF
--- a/src/meta_schedule/database/json_database.cc
+++ b/src/meta_schedule/database/json_database.cc
@@ -128,7 +128,8 @@ class JSONDatabaseNode : public DatabaseNode {
     results.reserve(top_k);
     int counter = 0;
     for (const TuningRecord& record : this->tuning_records_) {
-      if (WorkloadEqual(GetModuleEquality())(record->workload, workload)) {
+      if (record->workload.same_as(workload) ||
+          WorkloadEqual(GetModuleEquality())(record->workload, workload)) {
         results.push_back(record);
         if (++counter == top_k) {
           break;

--- a/src/meta_schedule/database/memory_database.cc
+++ b/src/meta_schedule/database/memory_database.cc
@@ -71,7 +71,8 @@ class MemoryDatabaseNode : public DatabaseNode {
       if (run_secs.empty()) {
         continue;
       }
-      if (WorkloadEqual(GetModuleEquality())(record->workload, workload)) {
+      if (record->workload.same_as(workload) ||
+          WorkloadEqual(GetModuleEquality())(record->workload, workload)) {
         double sum = 0.0;
         for (const FloatImm& i : run_secs) {
           sum += i->value;

--- a/src/meta_schedule/database/memory_database.cc
+++ b/src/meta_schedule/database/memory_database.cc
@@ -71,7 +71,7 @@ class MemoryDatabaseNode : public DatabaseNode {
       if (run_secs.empty()) {
         continue;
       }
-      if (record->workload.same_as(workload)) {
+      if (WorkloadEqual(GetModuleEquality())(record->workload, workload)) {
         double sum = 0.0;
         for (const FloatImm& i : run_secs) {
           sum += i->value;


### PR DESCRIPTION
Previously the memory database assumed the workload tokens are from `CommitWorkload` function, this PR allows the use of module equality function in `GetTopK` function to compare workloads.

Thanks to @petersalas for point it out.