### PR TITLE
[Hexagon]Pull and build specific LLVM sha for hexagon docker CI

### DIFF
--- a/docker/install/ubuntu_install_hexagon.sh
+++ b/docker/install/ubuntu_install_hexagon.sh
@@ -21,23 +21,25 @@ set -o pipefail
 
 # Install LLVM/clang
 CLANG_LLVM_HOME=/opt/clang-llvm
-HEXAGON_LLVM_SHA=361a27c155ec8b222e3318488a208c0eb39624c8
+LLVM_SHA=361a27c155ec8b222e3318488a208c0eb39624c8
 
 mkdir llvm-hexagon
 pushd llvm-hexagon
 git init
 git remote add origin https://github.com/llvm/llvm-project.git
-git fetch origin ${HEXAGON_LLVM_SHA}
+git fetch origin ${LLVM_SHA}
 git reset --hard FETCH_HEAD
 mkdir build
 pushd build
 cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_PREFIX=${CLANG_LLVM_HOME} \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DLLVM_TARGETS_TO_BUILD:STRING="Hexagon;X86" \
   -DLLVM_ENABLE_PROJECTS:STRING="clang;llvm;lld" \
+  -DTARGET_TRIPLE=x86_64-unknown-linux-gnu \
+  -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-linux-gnu \
   ../llvm
 ninja install
 

--- a/docker/install/ubuntu_install_hexagon.sh
+++ b/docker/install/ubuntu_install_hexagon.sh
@@ -37,7 +37,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX=${CLANG_LLVM_HOME} \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DLLVM_TARGETS_TO_BUILD:STRING="Hexagon;X86" \
-  -DLLVM_ENABLE_PROJECTS:STRING="clang;llvm;lld" \
+  -DLLVM_ENABLE_PROJECTS:STRING="clang;llvm" \
   -DTARGET_TRIPLE=x86_64-unknown-linux-gnu \
   -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-linux-gnu \
   ../llvm

--- a/docker/install/ubuntu_install_hexagon.sh
+++ b/docker/install/ubuntu_install_hexagon.sh
@@ -21,9 +21,26 @@ set -o pipefail
 
 # Install LLVM/clang
 CLANG_LLVM_HOME=/opt/clang-llvm
-CLANG_LLVM_VERSION=14.0.0
-CLANG_LLVM_FILENAME=clang_llvm.tar.xz
-wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_LLVM_VERSION}/clang+llvm-${CLANG_LLVM_VERSION}-x86_64-linux-gnu-ubuntu-18.04.tar.xz -O ${CLANG_LLVM_FILENAME}
-mkdir ${CLANG_LLVM_HOME}
-tar -xvf ${CLANG_LLVM_FILENAME} -C ${CLANG_LLVM_HOME} --strip-components=1
-rm ${CLANG_LLVM_FILENAME}
+HEXAGON_LLVM_SHA=361a27c155ec8b222e3318488a208c0eb39624c8
+
+mkdir llvm-hexagon
+pushd llvm-hexagon
+git init
+git remote add origin https://github.com/llvm/llvm-project.git
+git fetch origin ${HEXAGON_LLVM_SHA}
+git reset --hard FETCH_HEAD
+mkdir build
+pushd build
+cmake \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_TARGETS_TO_BUILD:STRING="Hexagon;X86" \
+  -DLLVM_ENABLE_PROJECTS:STRING="clang;llvm;lld" \
+  ../llvm
+ninja install
+
+popd
+popd
+rm -rf llvm-hexagon


### PR DESCRIPTION
https://github.com/apache/tvm/pull/12873 needs an updated LLVM version, as noted in https://github.com/apache/tvm/issues/12966. This PR pulls the most recent llvm patch off of main which should work with the latest tvm.