### PR TITLE
[BugFix][TIR] Affine-binding check should not simplify trivial iterators

### DIFF
--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -581,7 +581,8 @@ bool IsAffineBinding(const BlockRealize& realize, const Map<Var, Range>& loop_va
       /*input_iters=*/loop_var_ranges,
       /*predicate=*/realize->predicate,
       /*check_level=*/arith::IterMapLevel::Surjective,
-      /*analyzer=*/analyzer);
+      /*analyzer=*/analyzer,
+      /*simplify_trivial_iterators=*/false);
   if (res->indices.empty()) {
     return false;
   }


### PR DESCRIPTION
This PR fixes a bug of affine-binding check in TIR. Previously, the affine-binding check will call `DetectIterMap` with trivial iterators simplified. However, this will cause some blocks with affine bindings not recognized as having affine bindings (see the regression test for a concrete example). This PR specifies that we do not simplify the trivial iterators when checking affine bindings.

cc @spectrometerHBH @vinx13 @junrushao @wrongtest-intellif 