### PR TITLE
[ci] Protect release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,3 +61,10 @@ github:
 
       required_pull_request_reviews:
         required_approving_review_count: 1
+
+    # protect release branches from unsigned updates and force pushes
+    'v[0-9]*':
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_linear_history: true
+      required_signatures: true


### PR DESCRIPTION
This adds a fnmatch entry for the release branches to ensure that
changes come from PRs and that force pushes / rebased aren't allowed so
it's always possible to trace the release branch back to a mainline TVM
commit.