### PR TITLE
[Relay][transform][SimplifyExpr] simplify adjacent muls and adds with constants

### DIFF
--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -561,13 +561,10 @@ def test_concretize_multiple():
 
 
 def test_simplify_mul_add():
-    def check_simple_fold(origin_exprs, expect_expr, expect_fold):
+    def check_simple_fold(origin_exprs, expect_expr):
         for origin_expr in origin_exprs:
             simple_expr = run_opt_pass(origin_expr, transform.SimplifyExpr())
             assert tvm.ir.structural_equal(simple_expr, expect_expr)
-
-            fold_expr = run_opt_pass(simple_expr, transform.FoldConstant())
-            assert tvm.ir.structural_equal(fold_expr, expect_fold)
 
     n = 32
     c1_val = np.random.uniform(size=n).astype("float32")
@@ -583,21 +580,17 @@ def test_simplify_mul_add():
     origin_exprs = [
         x + c1 + c2,
         c1 + x + c2,
-        c1 + c2 + x,
     ]
-    expect_expr = x + (c1 + c2)
-    expect_fold = x + relay.const(c1_val + c2_val)
-    check_simple_fold(origin_exprs, expect_expr, expect_fold)
+    expect_expr = x + relay.const(c1_val + c2_val)
+    check_simple_fold(origin_exprs, expect_expr)
 
     # mul-mul -> mul
     origin_exprs = [
         x * c1 * c2,
         c1 * x * c2,
-        c1 * c2 * x,
     ]
-    expect_expr = x * (c1 * c2)
-    expect_fold = x * relay.const(c1_val * c2_val)
-    check_simple_fold(origin_exprs, expect_expr, expect_fold)
+    expect_expr = x * relay.const(c1_val * c2_val)
+    check_simple_fold(origin_exprs, expect_expr)
 
     # add-mul -> mul-add
     origin_exprs = [
@@ -606,9 +599,8 @@ def test_simplify_mul_add():
         c2 * (x + c1),
         c2 * (c1 + x),
     ]
-    expect_expr = x * c2 + c1 * c2
-    expect_fold = x * c2 + relay.const(c1_val * c2_val)
-    check_simple_fold(origin_exprs, expect_expr, expect_fold)
+    expect_expr = x * c2 + relay.const(c1_val * c2_val)
+    check_simple_fold(origin_exprs, expect_expr)
 
     # add-mul-add -> mul-add
     origin_exprs = [
@@ -621,9 +613,8 @@ def test_simplify_mul_add():
         c3 + c2 * (x + c1),
         c3 + c2 * (c1 + x),
     ]
-    expect_expr = x * c2 + (c1 * c2 + c3)
-    expect_fold = x * c2 + relay.const(c1_val * c2_val + c3_val)
-    check_simple_fold(origin_exprs, expect_expr, expect_fold)
+    expect_expr = x * c2 + relay.const(c1_val * c2_val + c3_val)
+    check_simple_fold(origin_exprs, expect_expr)
 
     # mul-add-mul -> mul-add
     origin_exprs = [
@@ -636,9 +627,8 @@ def test_simplify_mul_add():
         c3 * (c2 + x * c1),
         c3 * (c2 + c1 * x),
     ]
-    expect_expr = x * (c1 * c3) + c2 * c3
-    expect_fold = x * relay.const(c1_val * c3_val) + relay.const(c2_val * c3_val)
-    check_simple_fold(origin_exprs, expect_expr, expect_fold)
+    expect_expr = x * relay.const(c1_val * c3_val) + relay.const(c2_val * c3_val)
+    check_simple_fold(origin_exprs, expect_expr)
 
 
 def test_simplify_rsqrt():


### PR DESCRIPTION
This PR enables simplification and folding of a sub graph containing adjacent `mul`s and `add`s with constant inputs.
### Motivation
Workloads like [densenet-121](https://github.com/onnx/models/blob/main/vision/classification/densenet-121/model/densenet-7.onnx) has several partitions with `conv-bn-mul-add-relu` pattern, for example:
``` go
def @main(%data_0: Tensor[(1, 3, 224, 224), float32] /* ty=Tensor[(1, 3, 224, 224), float32] */) -> Tensor[(1, 1000, 1, 1), float32] {
  %0 = nn.conv2d(%data_0, meta[relay.Constant][0] /* ty=Tensor[(64, 3, 7, 7), float32] */, strides=[2, 2], padding=[3, 3, 3, 3], channels=64, kernel_size=[7, 7]) /* ty=Tensor[(1, 64, 112, 112), float32] */;
  %1 = nn.batch_norm(%0, meta[relay.Constant][1] /* ty=Tensor[(64), float32] */, meta[relay.Constant][2] /* ty=Tensor[(64), float32] */, meta[relay.Constant][3] /* ty=Tensor[(64), float32] */, meta[relay.Constant][4] /* ty=Tensor[(64), float32] */) /* ty=(Tensor[(1, 64, 112, 112), float32], Tensor[(64), float32], Tensor[(64), float32]) */;
  %2 = %1.0 /* ty=Tensor[(1, 64, 112, 112), float32] */;
  %3 = multiply(%2, meta[relay.Constant][5] /* ty=Tensor[(64, 1, 1), float32] */) /* ty=Tensor[(1, 64, 112, 112), float32] */;
  %4 = add(%3, meta[relay.Constant][6] /* ty=Tensor[(64, 1, 1), float32] */) /* ty=Tensor[(1, 64, 112, 112), float32] */;
  %5 = nn.relu(%4) /* ty=Tensor[(1, 64, 112, 112), float32] */;
  // ...
}
```
Current transforms on this pattern are:
1. `conv-bn-mul-add-relu` as the original pattern.
2. to `conv-mul-add-mul-add-relu` as `bn` is expended to `mul-add`. 
3. to `conv-add-mul-add-relu` as the first `mul` is folded into `conv`.

As all the `mul`s and `add`s have constant second inputs, they should be folded to a single `mul-add` and a preferred transform sequence should be:

1. `conv-bn-mul-add-relu` as the original pattern.
2. to `conv-mul-add-mul-add-relu` as `bn` is expended to `mul-add`. 
3. to `conv-mul-add-relu` as `mul`s and `add`s are folded to one single `mul-add`.
4. to `conv-add-relu` as `mul` is folded into `conv`.

### Solution
Actually, any series contain `mul`s and `add`s with constant inputs could be folded to one particular `mul-add`. Three rewrite rules are added to make this happen:

1. `mul-mul` -> `mul`
2. `add-add` -> `add`
3. `add-mul` -> `mul-add`

As `SimplifyExpr` apply simplifications iteratively until no changes to the graph, any `mul` and `add` series could be rewritten to one single `mul`, `add` or `mul-add` with one of the binary inputs could evaluates to a constant in the following `FoldConstant` pass.