### PR TITLE
[IR] Remove shadowing in IRSubstituteWithDataTypeLegalization

### DIFF
--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -814,6 +814,9 @@ class IRSubstituteWithDataTypeLegalization : public DataTypeLegalizer {
   explicit IRSubstituteWithDataTypeLegalization(std::function<Optional<PrimExpr>(const Var&)> vmap)
       : vmap_(vmap) {}
 
+  using DataTypeLegalizer::VisitExpr_;
+  using DataTypeLegalizer::VisitStmt_;
+
   PrimExpr VisitExpr_(const VarNode* op) final {
     Var var = GetRef<Var>(op);
     auto ret = vmap_(var);


### PR DESCRIPTION
Previously, the `IRSubstituteWithDataTypeLegalization` class implemented some virtual functions of `DataTypeLegalizer`, but not all.  As a result, some compilers gave warnings that the base class methods were being shadowed.  This commit adds the `using` declaration to avoid shadowing.