### PR TITLE
[Hexagon] Update tests to use AOT Executor 

### DIFF
--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -39,7 +39,11 @@ ANDROID_SERIAL_NUMBER = "ANDROID_SERIAL_NUMBER"
 ADB_SERVER_SOCKET = "ADB_SERVER_SOCKET"
 RNG_SEEDED = False
 
-HEXAGON_AOT_LLVM_TARGET = "llvm -keys=hexagon -mattr=+hvxv68,+hvx-length128b,+hvx-qfloat,-hvx-ieee-fp -mcpu=hexagonv68 -mtriple=hexagon"
+HEXAGON_AOT_LLVM_TARGET = (
+    "llvm -keys=hexagon "
+    "-mattr=+hvxv68,+hvx-length128b,+hvx-qfloat,-hvx-ieee-fp "
+    "-mcpu=hexagonv68 -mtriple=hexagon"
+)
 
 
 @tvm.testing.fixture

--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -39,6 +39,8 @@ ANDROID_SERIAL_NUMBER = "ANDROID_SERIAL_NUMBER"
 ADB_SERVER_SOCKET = "ADB_SERVER_SOCKET"
 RNG_SEEDED = False
 
+HEXAGON_AOT_LLVM_TARGET = "llvm -keys=hexagon -mattr=+hvxv68,+hvx-length128b,+hvx-qfloat,-hvx-ieee-fp -mcpu=hexagonv68 -mtriple=hexagon"
+
 
 @tvm.testing.fixture
 def shape_nhwc(batch, in_channel, in_size):
@@ -303,12 +305,7 @@ def terminate_rpc_servers():
         os.system("ps ax | grep tvm_rpc_x86 | awk '{print $1}' | xargs kill")
 
 
-aot_host_target = tvm.testing.parameter(
-    "c",
-    "llvm -keys=hexagon "
-    "-mattr=+hvxv68,+hvx-length128b,+hvx-qfloat,-hvx-ieee-fp "
-    "-mcpu=hexagonv68 -mtriple=hexagon",
-)
+aot_host_target = tvm.testing.parameter("c", HEXAGON_AOT_LLVM_TARGET)
 
 
 @tvm.testing.fixture

--- a/tests/python/contrib/test_hexagon/test_models.py
+++ b/tests/python/contrib/test_hexagon/test_models.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Test mobilenet model with both graph and aot executor"""
+"""Test mobilenet model with aot executor"""
 
 import numpy as np
 import pytest
@@ -39,60 +39,10 @@ def get_mobilenet():
     return onnx.load(model_path)
 
 
-@tvm.testing.requires_hexagon
-def test_mobilenet(hexagon_session: Session):
-    """Test mobilenet with graph executor"""
-    dtype = "float32"
-    onnx_model = get_mobilenet()
-
-    target_llvm = tvm.target.Target("llvm")
-    runtime = Runtime("cpp")
-    executor = Executor("graph", {"link-params": True})
-
-    data_in = np.random.rand(1, 3, 224, 224).astype(dtype=dtype)
-
-    input_name = "data"
-    shape_dict = {input_name: data_in.shape}
-    relay_mod, params = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
-    inputs = {input_name: data_in}
-
-    with tvm.transform.PassContext(opt_level=3):
-        hexagon_lowered = tvm.relay.build(
-            relay_mod,
-            get_hexagon_target("v68"),
-            runtime=runtime,
-            executor=executor,
-            params=params,
-        )
-
-        llvm_lowered = tvm.relay.build(
-            relay_mod,
-            tvm.target.Target(target_llvm, host=target_llvm),
-            runtime=runtime,
-            executor=executor,
-            params=params,
-        )
-
-    graph_mod = hexagon_session.get_executor_from_factory(hexagon_lowered)
-    graph_mod.set_input(**inputs)
-    graph_mod.run()
-    hexagon_output = graph_mod.get_output(0).numpy()
-
-    llvm_graph_mod = tvm.contrib.graph_executor.GraphModule(llvm_lowered["default"](tvm.cpu(0)))
-    llvm_graph_mod.set_input(**inputs)
-    llvm_graph_mod.run()
-    expected_output = llvm_graph_mod.get_output(0).numpy()
-
-    tvm.testing.assert_allclose(hexagon_output, expected_output, rtol=1e-4, atol=1e-5)
-
-
 @pytest.mark.parametrize("enable_usmp", [False, True])
 @tvm.testing.requires_hexagon
 def test_mobilenet_aot(hexagon_session: Session, aot_host_target, aot_target, enable_usmp):
     """Test mobilenet with aot executor"""
-    if hexagon_session.is_simulator():
-        pytest.skip(msg="Skip on simulator due to long runtime.")
-
     dtype = "float32"
     onnx_model = get_mobilenet()
 
@@ -114,25 +64,24 @@ def test_mobilenet_aot(hexagon_session: Session, aot_host_target, aot_target, en
             params=params,
         )
 
-    aot_mod = hexagon_session.get_executor_from_factory(hexagon_lowered)
-    aot_mod.set_input(**inputs)
-    aot_mod.run()
-    hexagon_output = aot_mod.get_output(0).numpy()
+    hexagon_mod = hexagon_session.get_executor_from_factory(hexagon_lowered)
+    hexagon_mod.set_input(**inputs)
+    hexagon_mod.run()
+    hexagon_output = hexagon_mod.get_output(0).numpy()
 
     with tvm.transform.PassContext(opt_level=3):
         llvm_lowered = tvm.relay.build(
             relay_mod,
             tvm.target.Target(target_llvm, host=target_llvm),
             runtime=Runtime("cpp"),
-            executor=Executor("graph", {"link-params": True}),
+            executor=Executor("aot", {"interface-api": "packed"}),
             params=params,
         )
 
-    llvm_graph_mod = tvm.contrib.graph_executor.GraphModule(llvm_lowered["default"](tvm.cpu(0)))
-    llvm_graph_mod.set_input(**inputs)
-    llvm_graph_mod.run()
-    expected_output = llvm_graph_mod.get_output(0).numpy()
-
+    llvm_mod = tvm.runtime.executor.AotModule(llvm_lowered["default"](tvm.cpu(0)))
+    llvm_mod.set_input(**inputs)
+    llvm_mod.run()
+    expected_output = llvm_mod.get_output(0).numpy()
     tvm.testing.assert_allclose(hexagon_output, expected_output, rtol=1e-4, atol=1e-5)
 
 

--- a/tests/python/contrib/test_hexagon/test_models.py
+++ b/tests/python/contrib/test_hexagon/test_models.py
@@ -25,8 +25,6 @@ from tvm import relay
 from tvm.contrib.hexagon.session import Session
 from tvm.relay.backend import Executor, Runtime
 
-from .infrastructure import get_hexagon_target
-
 
 def get_mobilenet():
     """Download and import mobilenet model with ONNX"""

--- a/tests/python/contrib/test_hexagon/test_usmp.py
+++ b/tests/python/contrib/test_hexagon/test_usmp.py
@@ -94,13 +94,13 @@ def test_conv2d(hexagon_session: Session, aot_host_target, aot_target, usmp_enab
             relay_mod,
             tvm.target.Target(target_llvm, host=target_llvm),
             runtime=Runtime("cpp"),
-            executor=Executor("graph"),
+            executor=Executor("aot"),
         )
 
-    llvm_graph_mod = tvm.contrib.graph_executor.GraphModule(llvm_lowered["default"](tvm.cpu(0)))
-    llvm_graph_mod.set_input(**params)
-    llvm_graph_mod.run(**inputs)
-    expected_output = llvm_graph_mod.get_output(0).numpy()
+    llvm_mod = tvm.runtime.executor.AotModule(llvm_lowered["default"](tvm.cpu(0)))
+    llvm_mod.set_input(**params)
+    llvm_mod.run(**inputs)
+    expected_output = llvm_mod.get_output(0).numpy()
 
     tvm.testing.assert_allclose(hexagon_output, expected_output, rtol=1e-4, atol=1e-5)
 


### PR DESCRIPTION
This PR updates few hexagon tests to use AOT instead of Graph executor.