### PR TITLE
Update prepare_test_libs.py

### DIFF
--- a/apps/howto_deploy/prepare_test_libs.py
+++ b/apps/howto_deploy/prepare_test_libs.py
@@ -33,7 +33,8 @@ def prepare_test_libs(base_path):
     fadd_dylib.export_library(dylib_path)
 
     # Compile library in system library mode
-    fadd_syslib = tvm.build(s, [A, B], "llvm", name="addonesys")
+    runtime = relay.backend.Runtime("cpp", {"system-lib": True})
+    fadd_syslib = tvm.build(s, [A, B], "llvm", runtime = runtime, name="addonesys")
     syslib_path = os.path.join(base_path, "test_addone_sys.o")
     fadd_syslib.save(syslib_path)
 

--- a/apps/howto_deploy/prepare_test_libs.py
+++ b/apps/howto_deploy/prepare_test_libs.py
@@ -34,7 +34,7 @@ def prepare_test_libs(base_path):
 
     # Compile library in system library mode
     runtime = relay.backend.Runtime("cpp", {"system-lib": True})
-    fadd_syslib = tvm.build(s, [A, B], "llvm", runtime = runtime, name="addonesys")
+    fadd_syslib = tvm.build(s, [A, B], "llvm", runtime=runtime, name="addonesys")
     syslib_path = os.path.join(base_path, "test_addone_sys.o")
     fadd_syslib.save(syslib_path)
 


### PR DESCRIPTION
Pass `runtime` argument to the `tvm.driver.build` to correctly build a system library.