### PR TITLE
[runtime] Fix typo in runtime/registry.h

### DIFF
--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -292,8 +292,8 @@ class Registry {
   /*!
    * \brief Register a function with given name
    * \param name The name of the function.
-   * \param override Whether allow oveeride existing function.
-   * \return Reference to theregistry.
+   * \param override Whether allow override existing function.
+   * \return Reference to the registry.
    */
   TVM_DLL static Registry& Register(const std::string& name, bool override = false);  // NOLINT(*)
   /*!


### PR DESCRIPTION
This PR fixes some typo.