### PR TITLE
[CI] Enable iOS RPC tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,15 +69,14 @@ jobs:
         shell: bash -l {0}
         run: >-
           python -m pytest -v tests/python/all-platform-minimal-test
-      # See https://github.com/apache/tvm/issues/13185
-      # - name: Test iOS RPC
-      #   shell: bash -l {0}
-      #   run: >-
-      #     python -m pip install tornado psutil cloudpickle &&
-      #     export PYTHONPATH=tests/python/contrib:${PYTHONPATH} &&
-      #     export BUNDLE_ID=org.apache.tvmrpc &&
-      #     export BUNDLE_PATH=build-ios-simulator/apps/ios_rpc/ios_rpc/src/ios_rpc-build/Release-iphonesimulator/tvmrpc.app &&
-      #     python -m pytest -v tests/python/contrib/test_rpc_server_device.py
+      - name: Test iOS RPC
+        shell: bash -l {0}
+        run: >-
+          python -m pip install tornado psutil cloudpickle &&
+          export PYTHONPATH=tests/python/contrib:${PYTHONPATH} &&
+          export BUNDLE_ID=org.apache.tvmrpc &&
+          export BUNDLE_PATH=build-ios-simulator/apps/ios_rpc/ios_rpc/src/ios_rpc-build/Release-iphonesimulator/tvmrpc.app &&
+          python -m pytest -v tests/python/contrib/test_rpc_server_device.py
 
   Windows:
     if: ${{ github.repository == 'apache/tvm' }}

--- a/python/tvm/contrib/xcode.py
+++ b/python/tvm/contrib/xcode.py
@@ -46,9 +46,9 @@ def xcrun(cmd):
 
 
 def __get_min_os_version(sdk):
-    if sdk in ("macosx", "iphonesimulator"):
+    if sdk == "macosx":
         return None
-    if sdk == "iphoneos":
+    if sdk in ("iphoneos", "iphonesimulator"):
         return "13.0"
     raise RuntimeError("Unsupported sdk: %s" % sdk)
 


### PR DESCRIPTION
These tests were previously disabled (see https://github.com/apache/tvm/issues/13185). The error was related to updating `MacOS` to version `12.6` and `XCode` update.
This PR fixes the error and re-enables tests for `iOS RPC`.