### PR TITLE
[skip ci] Remove naut-thomas from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,7 +48,6 @@ github:
     - hpanda-naut
     - denise-k
     - janetsc
-    - naut-thomas
     - tvm-bot  # For automated feedback in PR review.
 
   # See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection


### PR DESCRIPTION
We have to remove and re-add this user to re-trigger the asf invitation

Follow on to #13141