### PR TITLE
[skip ci] Revert "[skip ci] Remove naut-thomas from .asf.yaml (#13231)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,6 +48,7 @@ github:
     - hpanda-naut
     - denise-k
     - janetsc
+    - naut-thomas
     - tvm-bot  # For automated feedback in PR review.
 
   # See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection


### PR DESCRIPTION
This reverts commit 3149ee5a73133dd320c8ec259459a4c32b1955d8.

This is needed to re-send the invitation to the repo