### PR TITLE
[Hexagon] Make pytest use a random port if not running in CI

### DIFF
--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -93,7 +93,7 @@ def get_free_port() -> int:
     global PREVIOUS_PORT
     global RNG_SEEDED
 
-    if not RNG_SEEDED:
+    if tvm.testing.utils.IS_IN_CI and not RNG_SEEDED:
         random.seed(0)
         RNG_SEEDED = True
 


### PR DESCRIPTION
This makes it so that when running tests locally you are able to get a random port. This is needed because the ports take a bit of time to free before they can be used again so repeated tests started to fail. 

cc @masahi @mehrdadh 