### PR TITLE
[skip ci][docs] Disable scipy intersphinx linking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,7 +201,7 @@ latex_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
     # "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    # "scipy": ("https://docs.scipy.org/doc/scipy", None),
     # "matplotlib": ("https://matplotlib.org/", None),
 }
 


### PR DESCRIPTION
This disables scipy intersphinx linking for the same reason that
matplotlib and numpy are disabled. Should fix failures like
https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/4613/pipeline,
though we should investigate if we can switch these back on for release
doc builds