### PR TITLE
[Docs] Minimal dependencies for Fedora/CentOS

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -81,6 +81,15 @@ linux operating systems, execute (in a terminal):
 
 Note that the version of CMake on apt may not be sufficiently up to date; it may be necessary to install it directly from `Kitware's third-party APT repository <https://apt.kitware.com/>`_.
 
+
+On Fedora/CentOS and related operating systems use:
+
+.. code:: bash
+
+    sudo dnf update
+    sudo dnf groupinstall -y "Development Tools"
+    sudo dnf install -y python-devel ncurses-compat-libs zlib-devel cmake libedit-devel libxml2-devel
+
 Use Homebrew to install the required dependencies for macOS running either the Intel or M1 processors. You must follow the post-installation steps specified by
 Homebrew to ensure the dependencies are correctly installed and configured:
 


### PR DESCRIPTION
This commit indicates how to install minimal set of dependencies for building 
Apache TVM on Fedora and CentOS. It supplements existing information for
Ubuntu and MacOS.