### PR TITLE
Apply group write permissions to Python virtual environment

### DIFF
--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -89,6 +89,7 @@ pip3 install \
 addgroup tvm-venv
 chgrp -R tvm-venv "${TVM_VENV}"
 setfacl -R -d -m group:tvm-venv:rwx "${TVM_VENV}"
+setfacl -R -m group:tvm-venv:rwx "${TVM_VENV}"
 
 # Prevent further use of pip3 via the system.
 # There may be multiple (i.e. from python3-pip apt package and pip3 install -U).


### PR DESCRIPTION
This commit applies additional write permission to the "tvm-venv" group virtual environment. Currently after entering a container from a newly built image it dosn't seem possible to install/update Python packages. E.g. updating pip will give errors such as:
```
$ pip install --upgrade pip
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/venv/apache-tvm-py3.7/bin/pip' Check the permissions.
```

Enabling write access for this group fixes this as long as the current user is a member of the "tvm-venv" group.