### PR TITLE
[OpenCL][unit tests] Fix opencl cpp unit tests

### DIFF
--- a/python/tvm/contrib/opencl/pytest_plugin.py
+++ b/python/tvm/contrib/opencl/pytest_plugin.py
@@ -15,15 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# pylint: disable=invalid-name,redefined-outer-name
 """ OpenCL testing fixtures used to deduce testing argument
     values from testing parameters """
 
-
 import pytest
 
-import tvm
-import tvm.testing
 
-pytest_plugins = [
-    "tvm.contrib.opencl.pytest_plugin",
-]
+def pytest_addoption(parser):
+    """Add pytest options."""
+
+    parser.addoption("--gtest_args", action="store", default="")
+
+
+def pytest_generate_tests(metafunc):
+    option_value = metafunc.config.option.gtest_args
+    if "gtest_args" in metafunc.fixturenames and option_value is not None:
+        metafunc.parametrize("gtest_args", [option_value])


### PR DESCRIPTION
After some changes in Hexagon, the run of cpp opencl tests leads to the following error:
```
pluggy.manager.PluginValidationError: unknown hook 'pytest_configure_node' in plugin <module 'tvm.contrib.hexagon.pytest_plugin'
```
Added `pytest_plugin` for OpenCL CPP tests for avoiding this error and processing gtest arguments.