### PR TITLE
[Hexagon] Fix Hexagon external libs check

### DIFF
--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -184,7 +184,7 @@ if(BUILD_FOR_HEXAGON)
   )
 
   # Include hexagon external library runtime sources
-  if(DEFINED USE_HEXAGON_EXTERNAL_LIBS AND NOT ${USE_HEXAGON_EXTERNAL_LIBS} STREQUAL "")
+  if(USE_HEXAGON_EXTERNAL_LIBS)
     # Check if the libs are provided as an absolute path
     if (EXISTS ${USE_HEXAGON_EXTERNAL_LIBS})
     # Check if the libs are provided as a git url


### PR DESCRIPTION
When building tvm runtime with hexagon we face the below error if USE_HEXAGON_EXTERNAL_LIBS is not defined. This happens because USE_HEXAGON_EXTERNAL_LIBS=OFF is defined as the default in CMakeLists.txt. The modified condition can check for all cases including undefined variable, empty string and OFF

```
CMake Error at cmake/modules/Hexagon.cmake:203 (message):
  Invalid use of USE_HEXAGON_EXTERNAL_LIBS=OFF; USE_HEXAGON_EXTERNAL_LIBS
  only supports absolute paths and git repository urls
Call Stack (most recent call first):
  CMakeLists.txt:477 (include)
```