### PR TITLE
[MetaSchedule] Swap the order of RewriteTensorize and VerifyGPUCode to reduce tuning time

### DIFF
--- a/src/meta_schedule/postproc/postproc.cc
+++ b/src/meta_schedule/postproc/postproc.cc
@@ -78,6 +78,8 @@ Array<Postproc> Postproc::DefaultCUDATensorCore() {
       Postproc::RewriteParallelVectorizeUnroll(),
       Postproc::RewriteReductionBlock(),
       Postproc::VerifyGPUCode(),
+      // RewriteTensorize is relatively expensive and it doesn't affect the validity of a sample, so
+      // run it only on samples that have passed VerifyGPUCode.
       Postproc::RewriteTensorize(/*vectorize_init_loop=*/false),
   };
 }

--- a/src/meta_schedule/postproc/postproc.cc
+++ b/src/meta_schedule/postproc/postproc.cc
@@ -77,8 +77,8 @@ Array<Postproc> Postproc::DefaultCUDATensorCore() {
       Postproc::RewriteUnboundBlock(/*max_threadblocks=*/256),
       Postproc::RewriteParallelVectorizeUnroll(),
       Postproc::RewriteReductionBlock(),
-      Postproc::RewriteTensorize(/*vectorize_init_loop=*/false),
       Postproc::VerifyGPUCode(),
+      Postproc::RewriteTensorize(/*vectorize_init_loop=*/false),
   };
 }
 


### PR DESCRIPTION
I'm working on improving tuning time on quantized models using tensor core. One of the reasons it is slow is that the function below, which is called thousands of times during each evo search initial population sampling, takes more than 50 msec (on my desktop): 

https://github.com/apache/tvm/blob/a4840e7de38c5a2000917f2101f3ec4a374bcd39/src/meta_schedule/search_strategy/evolutionary_search.cc#L506-L517

The time it takes can be broken down into the followings:
* `ApplyToTrace`: 35 msec
* `RewriteTensorize`: 7-8 msec
* `VerifyGPUCode`: 7-8 msec

`RewriteTensorize` is relatively slow because it invokes `sch->Tensorize(...)` which does some heavy lifting. Since it is called thousands of times, it quickly adds up. It is wasteful if the tensorized schedule is rejected by `VerifyGPUCode` immediately after that.

Since `tensorize` doesn't affect the validity of a sample, we can improve tuning time slightly by running `VerifyGPUCode` first and do `RewriteTensorize` only on valid samples.

@vinx13 @junrushao @zxybazh 