### PR TITLE
[build][relay][te][tir] remove unused vars / args

### DIFF
--- a/src/relay/backend/graph_plan_memory.cc
+++ b/src/relay/backend/graph_plan_memory.cc
@@ -631,7 +631,7 @@ class StorageAllocator : public StorageAllocaBaseVisitor {
   // allocator
   support::Arena arena_;
   // scale used for rough match
-  size_t match_range_{16};
+  // size_t match_range_{16};
   // free list of storage entry
   std::multimap<size_t, StorageToken*> free_;
   // all the storage resources available

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -294,10 +294,10 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
     pattern_matcher_.Register(call_node);
 
     Array<te::Tensor> inputs;
-    int count_tuple = 0;
+    // int count_tuple = 0;
     for (Expr arg : call_node->args) {
       if (arg->checked_type().as<TupleTypeNode>()) {
-        ++count_tuple;
+        // ++count_tuple;
       }
       for (te::Tensor tensor : VisitExpr(arg)) {
         inputs.push_back(tensor);

--- a/src/relay/transforms/remove_standalone_reshapes.cc
+++ b/src/relay/transforms/remove_standalone_reshapes.cc
@@ -36,7 +36,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION("relay.remove_standalone_reshapes.enable", Bool)
  */
 class RemoveStandaloneReshapesMutator : public MixedModeMutator {
  public:
-  explicit RemoveStandaloneReshapesMutator(IRModule& mod) : ir_module_(mod) {}
+  explicit RemoveStandaloneReshapesMutator(IRModule& mod) {}  // NOLINT(runtime/references)
 
   using MixedModeMutator::VisitExpr_;
 
@@ -85,8 +85,6 @@ class RemoveStandaloneReshapesMutator : public MixedModeMutator {
  private:
   /*! \brief Map of LetNode's var to previous call_lowered. */
   Map<Var, Call> let_var_to_call_lowered_;
-  /*! \brief Module that contains global reshape functions. */
-  IRModule& ir_module_;
 };
 
 namespace transform {

--- a/src/te/operation/compute_op.cc
+++ b/src/te/operation/compute_op.cc
@@ -387,7 +387,7 @@ enum class ComputeType { kNormal, kCrossThreadReduction, kTensorize };
 
 ComputeType DetectComputeType(const ComputeOpNode* self, const Stage& stage) {
   // Verify correctness of leaf nest.
-  int normal_red = 0, thread_red = 0, tensorize = 0;
+  int thread_red = 0, tensorize = 0;
 
   for (IterVar iv : stage->leaf_iter_vars) {
     IterVarAttr attr;
@@ -401,8 +401,6 @@ ComputeType DetectComputeType(const ComputeOpNode* self, const Stage& stage) {
     if (iv->iter_type == kCommReduce) {
       if (attr.defined() && attr->bind_thread.defined()) {
         ++thread_red;
-      } else {
-        ++normal_red;
       }
     } else {
       ICHECK_EQ(thread_red, 0) << "Cross thread reduce cannot swap with normal data axis";

--- a/src/tir/ir/data_type_rewriter.cc
+++ b/src/tir/ir/data_type_rewriter.cc
@@ -62,7 +62,7 @@ Stmt DataTypeLegalizer::VisitStmt_(const BlockRealizeNode* op) {
 
 Stmt DataTypeLegalizer::VisitStmt_(const BlockNode* op) {
   Block new_block = Downcast<Block>(StmtExprMutator::VisitStmt_(op));
-  Array<IterVar> new_iter_vars = MutateArray(new_block->iter_vars, [this](const IterVar& iter) {
+  Array<IterVar> new_iter_vars = MutateArray(new_block->iter_vars, [/*this*/](const IterVar& iter) {
     auto dtype = iter->var.dtype();
     if (iter->dom->min->dtype != dtype || iter->dom->extent->dtype != dtype) {
       IterVar new_iter = iter;

--- a/src/tir/schedule/primitive/cache_index.cc
+++ b/src/tir/schedule/primitive/cache_index.cc
@@ -203,7 +203,7 @@ Array<Block> MakeIndexCacheStage(IndexInfo* info) {
     // which will be used to create new loop vars
     std::vector<Var> iter_vars;
     for (const Var& it : info->origin_block_vars[expr_index]) {
-      PostOrderVisit(info->var_binding.at(it), [&info, &iter_vars](const ObjectRef& node) {
+      PostOrderVisit(info->var_binding.at(it), [/*&info,*/ &iter_vars](const ObjectRef& node) {
         if (node->IsInstance<VarNode>()) {
           Var iter_var = Downcast<Var>(node);
           if (std::find_if(iter_vars.begin(), iter_vars.end(),


### PR DESCRIPTION
- Fix clang 15.0.3 `-Wunused-but-set-variable` and `-Wunused-lambda-capture` warnings by removing / commenting-out code.