### PR TITLE
[build][tir] suppress -Woverloaded-virtual warning

### DIFF
--- a/include/tvm/tir/stmt_functor.h
+++ b/include/tvm/tir/stmt_functor.h
@@ -502,7 +502,7 @@ bool ContainsNode(const Stmt& stmt) {
  * base class of such passes to ensure the consistency of data types.
  */
 class DataTypeLegalizer : public StmtExprMutator {
- public:
+ protected:
   Stmt VisitStmt_(const ForNode* op) override;
 
   Stmt VisitStmt_(const AttrStmtNode* op) override;
@@ -530,7 +530,6 @@ class DataTypeLegalizer : public StmtExprMutator {
   using StmtExprMutator::VisitExpr_;
   using StmtExprMutator::VisitStmt_;
 
- protected:
   // a map from IterVar before rewrite to that after rewrite,
   // ensures one old IterVar maps to exactly one new IterVar
   std::unordered_map<const IterVarNode*, IterVar> ivmap_;

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -206,6 +206,15 @@ class DataTypeRewriter : public DataTypeLegalizer {
     return VisitStmt(s);
   }
 
+ protected:
+  // This class adds some overrides of `VisitStmt_` and `VisitExpr_` that
+  // are *not* present in the parent class.
+  // These `using` statements ensure that all of the *other* overrides
+  // provided by the parent class are fully visible to users of this class.
+  // (Discussed further in https://github.com/apache/tvm/pull/13267)
+  using Parent::VisitExpr_;
+  using Parent::VisitStmt_;
+
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
     return Stmt();


### PR DESCRIPTION
Suppress a spurious `-Woverloaded-virtual` clang warning for the `tvm::tir::DataTypeRewriter` class.

I think we're safe to ignore clang _version_ for this pragma, because it's been supported for a long time now.