### PR TITLE
[build][doc] Fix clang doxygen warnings

### DIFF
--- a/src/relay/backend/annotate_used_memory.cc
+++ b/src/relay/backend/annotate_used_memory.cc
@@ -52,6 +52,7 @@ namespace backend {
  * A simple example:
  *
  * Before:
+ * \verbatim
  * def @main(%input: Tensor[(1, 2, 2, 4), int8]) -> Tensor[(1, 2, 2, 4), int8] {
  *   let %x_0 = fn (%x: Tensor[(1, 2, 2, 4), int8], Primitive=1) -> Tensor[(1, 2, 2, 4), int8] {
  *     nn.max_pool2d(%x, pool_size=[1, 1], padding=[0, 0, 0, 0])
@@ -59,8 +60,10 @@ namespace backend {
  *   let %x_1 = %x_0(%input);
  *   %x_1
  * }
+ * \endverbatim
  *
  * After:
+ * \verbatim
  * def @main(%input: Tensor[(1, 2, 2, 4), int8], io_used_memory=32) -> Tensor[(1, 2, 2, 4), int8] {
  *   let %x_0: fn (%x: Tensor[(1, 2, 2, 4), int8], Primitive=1, used_memory=[32]) -> Tensor[(1, 2,
  * 2, 4), int8] {
@@ -69,6 +72,7 @@ namespace backend {
  *   let %x_1: Tensor[(1, 2, 2, 4), int8] = %x_0(%input);
  *   %x_1
  * }
+ * \endverbatim
  *
  * Note that in the simple example above io_used_memory and used_memory are the same since there
  * is only one primitive function.

--- a/src/relay/collage/mock_cost_estimator.h
+++ b/src/relay/collage/mock_cost_estimator.h
@@ -34,6 +34,13 @@ namespace tvm {
 namespace relay {
 namespace collage {
 
+// Clang (15.0.3, at least) validly complains about `@main`, but it invalidly
+// complains even about `\c @main`.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#endif
+
 /*!
  * \brief A mock cost estimator which can determine the cost of a candidate based on both
  * the candidate's target and the number of operator calls inside it.
@@ -69,6 +76,9 @@ class MockCostEstimatorNode : public CostEstimatorNode {
 
   friend class MockCostEstimator;
 };
+#if __clang__
+#pragma clang diagnostic pop
+#endif
 
 class MockCostEstimator : public CostEstimator {
  public:


### PR DESCRIPTION
Fix occurrences of clang's `-Wdocumentation-unknown-command` warning.