### PR TITLE
[skip ci] Revert "[ci] Protect release branches (#13208)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,10 +61,3 @@ github:
 
       required_pull_request_reviews:
         required_approving_review_count: 1
-
-    # protect release branches from unsigned updates and force pushes
-    'v[0-9]*':
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: true


### PR DESCRIPTION
This reverts commit 5acf3f90c63b6760cd23796b442f8ac20e645af0.

Reverting since this is causing some spam from the ASF Infra bot related
to https://issues.apache.org/jira/browse/INFRA-23834. As in that issue
the protections have been applied manually by ASF Infra so this revert
shouldn't have any real effect