### PR TITLE
[ci][tvmbot] Fix spelling error, metionable -> mentionable

### DIFF
--- a/ci/scripts/github/github_tvmbot.py
+++ b/ci/scripts/github/github_tvmbot.py
@@ -632,7 +632,7 @@ def check_mentionable_users(pr, triggering_comment, args):
 
 
 AUTH_CHECKS = {
-    "metionable_users": check_mentionable_users,
+    "mentionable_users": check_mentionable_users,
     "collaborators": check_collaborator,
     "author": check_author,
 }
@@ -676,7 +676,7 @@ class Rerun:
         "run ci",
     ]
 
-    auth = [AUTH_CHECKS["metionable_users"]]
+    auth = [AUTH_CHECKS["mentionable_users"]]
 
     @staticmethod
     def run(pr: PR):

--- a/tests/python/ci/test_tvmbot.py
+++ b/tests/python/ci/test_tvmbot.py
@@ -253,7 +253,7 @@ class TestRerunPermissions(_TvmBotTest):
 
     COMMENT = "@tvm-bot rerun"
     USER = "someone"
-    EXPECTED = "Failed auth check 'metionable_users', quitting"
+    EXPECTED = "Failed auth check 'mentionable_users', quitting"
 
 
 class TestRerunNonAuthor(_TvmBotTest):
@@ -263,7 +263,7 @@ class TestRerunNonAuthor(_TvmBotTest):
 
     COMMENT = "@tvm-bot rerun"
     USER = "other-abc"
-    EXPECTED = "Passed auth check 'metionable_users', continuing"
+    EXPECTED = "Passed auth check 'mentionable_users', continuing"
 
 
 class TestIgnoreJobs(_TvmBotTest):


### PR DESCRIPTION
In AUTH_CHECKS, "mentionable_users" was "metionable_users".
This pull request fixes this spelling error.