### PR TITLE
[BugFix][Pattern] Fixed a crash when AltPattern and FunctionPattern are used nested

### DIFF
--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -622,12 +622,14 @@ void PatternGrouper::CreateGroup(const Expr& expr) {
     }
     // Don't treat Function params or body as input variables for partition
     if (node->ref().as<FunctionPatternNode>()) {
-      auto matches = node_map[node->ref()];
-      for (auto match : matches) {
-        auto sub_graph = CreateIndexedGraph(match.as<FunctionNode>()->body);
-        for (PostDfsIndex sub_index = 0; sub_index < sub_graph->size(); ++sub_index) {
-          auto sub_node = sub_graph->index_to_node(sub_index);
-          fuzzy_matches.insert(sub_node->ref());
+      if (node_map.count(node->ref())) {
+        auto matches = node_map[node->ref()];
+        for (auto match : matches) {
+          auto sub_graph = CreateIndexedGraph(match.as<FunctionNode>()->body);
+          for (PostDfsIndex sub_index = 0; sub_index < sub_graph->size(); ++sub_index) {
+            auto sub_node = sub_graph->index_to_node(sub_index);
+            fuzzy_matches.insert(sub_node->ref());
+          }
         }
       }
     }


### PR DESCRIPTION
The PatternGroup doesn not check if the FunctionPattern is matched while processing the FunctionPattern, but when FunctionPattern is nested with AltPattern, the FunctionPattern may not be matched, resulting in a crash when looking up matched nodes.
This commit adds a check at handling FunctionPattern to fix this crash, same as the checks at handling other patterns(such as `dataflow_matcher.cc:667`)
cc @masahi @wrongtest-intellif