### PR TITLE
[Relay] Add tensor rank check for `nn.instance_norm`

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -923,6 +923,7 @@ bool InstanceNormRel(const Array<Type>& types, int num_inputs, const Attrs& attr
   ICHECK_EQ(types.size(), 4);
   const auto* data = types[0].as<TensorTypeNode>();
   if (data == nullptr) return false;
+  ICHECK_GT(data->shape.size(), 2);
   const InstanceNormAttrs* param = attrs.as<InstanceNormAttrs>();
   int axis = param->axis >= 0 ? param->axis : param->axis + data->shape.size();
   ICHECK(axis >= 0 && axis < (int)data->shape.size());


### PR DESCRIPTION
This PR adds a rank check for input tensor in type inference of `nn.instance_norm`. I explain the reasons as follows:

First, according to the definition of [Instance Normalization](https://paperswithcode.com/method/instance-normalization), it only normalizes the spatial dimensions. Therefore, the input tensor must be of at least rank 3, and otherwise the operator will not produce meaningful results. 

Second, `nn.instance_norm` with tensor rank less than 2 leads to a problem in the `SimplifyInference` optimization pass. This pass finds the reduced axes before converting the operator to its lower-level computation definition:
https://github.com/apache/tvm/blob/f15afd225140e2a501b8b6aa2def0fd94d31bc54/src/relay/transforms/simplify_inference.cc#L149-L152
If the rank of the input tensor is less than 3, `reduced_axes` is empty. According to `GetRealAxis`, all the dimensions are reduced:
https://github.com/apache/tvm/blob/f15afd225140e2a501b8b6aa2def0fd94d31bc54/include/tvm/topi/reduction.h#L67-L70
This is problematic because we do not actually want batch and `axis` dimensions to be reduced.  

cc @masahi 
