### PR TITLE
[build][hexagon] remove unused variable

### DIFF
--- a/src/runtime/hexagon/rpc/simulator/session.cc
+++ b/src/runtime/hexagon/rpc/simulator/session.cc
@@ -680,8 +680,6 @@ Message SimulatorRPCChannel::SendMsg(Message msg) {
         << "Expecting HEX_CORE_BREAKPOINT, received: " << core_.str();
   };
 
-  Message_ msg_ = {msg};
-
   WriteToProcess(message_buffer_v_, &msg, sizeof msg);
   run();
 


### PR DESCRIPTION
Remove unused member variable in the `SimulatorRPCChannel` class. Fixes a clang warning.