### PR TITLE
[TE] Make `elem_offset` of the buffers created by `te.extern` a variable to avoid crash

### DIFF
--- a/python/tvm/te/operation.py
+++ b/python/tvm/te/operation.py
@@ -326,7 +326,11 @@ def extern(
         if not isinstance(t, _tensor.Tensor):
             raise ValueError("expect inputs to be tensor")
         if in_buffers is None:
-            input_placeholders.append(tvm.tir.decl_buffer(t.shape, t.dtype, t.op.name))
+            input_placeholders.append(
+                tvm.tir.decl_buffer(
+                    t.shape, t.dtype, t.op.name, elem_offset=tvm.tir.Var("elem_offset", "int32")
+                )
+            )
         types.add(t.dtype)
 
     if dtype is None:
@@ -339,7 +343,9 @@ def extern(
 
     if out_buffers is None:
         for shp, dt in zip(shape, dtype):
-            output_placeholders.append(tvm.tir.decl_buffer(shp, dt, name))
+            output_placeholders.append(
+                tvm.tir.decl_buffer(shp, dt, name, elem_offset=tvm.tir.Var("elem_offset", "int32"))
+            )
     body = fcompute(input_placeholders, output_placeholders)
     if isinstance(body, tvm.tir.PrimExpr):
         body = tvm.tir.Evaluate(body)

--- a/tests/python/unittest/test_te_create_primfunc.py
+++ b/tests/python/unittest/test_te_create_primfunc.py
@@ -216,9 +216,12 @@ def te_extern():
 @T.prim_func
 def tir_extern(a: T.handle, b: T.handle, c: T.handle) -> None:
     T.func_attr({"global_symbol": "main", "tir.noalias": True})
-    A = T.match_buffer(a, (128, 128))
-    B = T.match_buffer(b, (128, 128))
-    C = T.match_buffer(c, (128, 128))
+    off1 = te.var("elem_offset")
+    off2 = te.var("elem_offset_1")
+    off3 = te.var("elem_offset_2")
+    A = T.match_buffer(a, (128, 128), elem_offset=off1)
+    B = T.match_buffer(b, (128, 128), elem_offset=off2)
+    C = T.match_buffer(c, (128, 128), elem_offset=off3)
     # body
     with T.block("C"):
         T.reads([A[0:128, 0:128], B[0:128, 0:128]])
@@ -232,7 +235,7 @@ def tir_extern(a: T.handle, b: T.handle, c: T.handle) -> None:
                     0,
                     2,
                     0.0,
-                    0,
+                    off1,
                     dtype="handle",
                 ),
                 T.tvm_stack_make_array(
@@ -241,7 +244,7 @@ def tir_extern(a: T.handle, b: T.handle, c: T.handle) -> None:
                     0,
                     2,
                     0.0,
-                    0,
+                    off2,
                     dtype="handle",
                 ),
                 T.tvm_stack_make_array(
@@ -250,7 +253,7 @@ def tir_extern(a: T.handle, b: T.handle, c: T.handle) -> None:
                     0,
                     2,
                     0.0,
-                    0,
+                    off3,
                     dtype="handle",
                 ),
                 0,


### PR DESCRIPTION
Currently, when compiling MobileBERT on x86, we get a crash from https://github.com/apache/tvm/blob/11d22bdc1bd45d952eb140684e64f01438b7f516/src/tir/transforms/arg_binder.cc#L102-L106.

This is caused from the subgraph attached in the test. Since https://github.com/apache/tvm/pull/11341, `concatenate` is implemented as a TE extern on x86. `te.extern(...)` doesn't explicitly set the `elem_offset` parameter of input / output buffers it creates, which ends up `elem_offset` of these buffers being the default value, 0. This causes a problem from the above check in `BindBuffer`, since the subgraph does create a non-zero `elem_offset` slice from a buffer whose `elem_offset` is set to zero. 

Since we don't require buffers created in `te.extern(...)` to have zero `elem_offset`, we can avoid this problem by explicitly setting `elem_offset` to be a variable there. This fix was found by @Lunderberg and I'm sending this PR on behalf of him. He also suggested making the `strides` parameter an array of `Var` as well, but I didn't do it to keep the change minimal.

cc @Lunderberg @tkonolige @shtinsa

