### PR TITLE
[Torch] Fix advanced indexing with boolean mask

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2323,8 +2323,15 @@ class PyTorchOpConverter:
 
     def index(self, inputs, input_types):
         data = inputs[0]
-        indices = inputs[1]
-        return _op.adv_index([data] + indices)
+        indices_list = []
+
+        for indices in inputs[1]:
+            if self.infer_type(indices).dtype == "bool":
+                indices_list.append(_op.squeeze(_op.transform.argwhere(indices), axis=[1]))
+            else:
+                indices_list.append(indices)
+
+        return _op.adv_index([data] + indices_list)
 
     def meshgrid(self, inputs, input_types):
         data = inputs[0]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2327,6 +2327,10 @@ class PyTorchOpConverter:
 
         for indices in inputs[1]:
             if self.infer_type(indices).dtype == "bool":
+                # adv_index does not support a mask as the index tensor (it will treat 0/1 as
+                # an index rather than a flag).
+                # So we use argwhere to turn the mask into indices, which will also take care
+                # of the dynamism in the indexing by mask.
                 indices_list.append(_op.squeeze(_op.transform.argwhere(indices), axis=[1]))
             else:
                 indices_list.append(indices)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4038,7 +4038,6 @@ def test_forward_index():
         return lambda data, mask: data[0, mask]
 
     data = torch.tensor([[1, 2, 3], [4, 5, 6]])
-
     mask = torch.tensor([True, True, False])
 
     verify_trace_model(test_fn_bool_mask(), [data, mask], ["llvm", "cuda"])

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4034,6 +4034,15 @@ def test_forward_index():
     input_data = torch.rand(input_shape).float()
     verify_model(Index1().eval(), input_data=input_data)
 
+    def test_fn_bool_mask():
+        return lambda data, mask: data[0, mask]
+
+    data = torch.tensor([[1, 2, 3], [4, 5, 6]])
+
+    mask = torch.tensor([True, True, False])
+
+    verify_trace_model(test_fn_bool_mask(), [data, mask], ["llvm", "cuda"])
+
 
 def test_logsumexp():
     """test_logsumexp"""


### PR DESCRIPTION
Fixes https://github.com/apache/tvm/issues/12292
Fixes https://github.com/apache/tvm/issues/13296

PyTorch uses the same op, `aten::index`, to represent indexing by both integer indices and a boolean mask. In our PT converter, Relay `adv_index` op is used to convert `aten::index`, but it doesn't correctly recognize indexing by mask - it will treat True / False as indices 0 / 1. So our converter generates an invalid model if the PT model uses such indexing, see https://github.com/apache/tvm/issues/12292 and https://github.com/apache/tvm/issues/13296.

I fixed this issue by explicitly tuning the mask into integer indices using `argwhere`, which will also take care of the inherent dynamism in indexing by mask.

cc @comaniac @junrushao @shingjan @yelite 
