### PR TITLE
[TVMScript] Hide trailing return type if None

### DIFF
--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1634,7 +1634,14 @@ Doc TVMScriptPrinter::PrintPrimFunc(const PrimFunc& primFunc) {
     }
     params.push_back(Print(param) << ": " << Print(GetType(param)));
   }
-  doc << PrintSep(params, Doc::Text(", ")) << ") -> " << Print(primFunc->ret_type) << ":";
+  doc << PrintSep(params, Doc::Text(", ")) << ")";
+  if (primFunc->ret_type.defined()) {
+    auto as_tuple = primFunc->ret_type.as<TupleTypeNode>();
+    if (!as_tuple || as_tuple->fields.size()) {
+      doc << " -> " << Print(primFunc->ret_type);
+    }
+  }
+  doc << ":";
 
   Doc body = Doc::NewLine();
   // print buffer_bind

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3434,6 +3434,14 @@ def bool_variable_annotation():
     return func
 
 
+def return_none():
+    @T.prim_func
+    def func():
+        T.evaluate(0)
+
+    return func
+
+
 def bool_primitive():
     @T.prim_func
     def func() -> None:
@@ -3500,6 +3508,7 @@ ir_generator = tvm.testing.parameter(
     bool_variable_annotation,
     bool_primitive,
     bool_cast,
+    return_none,
 )
 
 
@@ -3507,6 +3516,12 @@ def test_roundtrip(ir_generator):
     original = ir_generator()
     after_roundtrip = tvm.script.from_source(original.script(show_meta=True))
     tvm.ir.assert_structural_equal(original, after_roundtrip, True)
+
+
+def test_return_none_no_trailing_type():
+    func = return_none()
+    script = func.script()
+    assert "-> None" not in script
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because the majority of TIR PrimFuncs operate on buffers, write their outputs to an output parameter, and do not return a value, the `-> None` in the function signature becomes visual noise. This commit removes printing of the return type in cases where the PrimFunc has no return value.