### PR TITLE
[TVMC] Global pass context for compile and tune

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -292,39 +292,38 @@ def compile_model(
 
     config = parse_configs(pass_context_configs)
 
-    if desired_layout:
-        mod = convert_graph_layout(mod, desired_layout)
+    with tvm.transform.PassContext(
+        opt_level=opt_level,
+        config=config,
+        disabled_pass=disabled_pass,
+        instruments=instruments,
+    ):
+        if desired_layout:
+            mod = convert_graph_layout(mod, desired_layout)
 
-    tvm_target, extra_targets = target_from_cli(target, additional_target_options)
-    tvm_target, target_host = Target.canon_target_and_host(tvm_target, target_host)
+        tvm_target, extra_targets = target_from_cli(target, additional_target_options)
+        tvm_target, target_host = Target.canon_target_and_host(tvm_target, target_host)
 
-    for codegen_from_cli in extra_targets:
-        codegen = composite_target.get_codegen_by_target(codegen_from_cli["name"])
-        partition_function = codegen["pass_pipeline"]
+        for codegen_from_cli in extra_targets:
+            codegen = composite_target.get_codegen_by_target(codegen_from_cli["name"])
+            partition_function = codegen["pass_pipeline"]
 
-        if codegen["config_key"] is not None:
-            config[codegen["config_key"]] = codegen_from_cli["opts"]
-        with tvm.transform.PassContext(config=config):
+            if codegen["config_key"] is not None:
+                config[codegen["config_key"]] = codegen_from_cli["opts"]
             mod = partition_function(mod, params, mod_name=mod_name, **codegen_from_cli["opts"])
 
-    if tuning_records and os.path.exists(tuning_records):
-        logger.debug("tuning records file provided: %s", tuning_records)
+        if tuning_records and os.path.exists(tuning_records):
+            logger.debug("tuning records file provided: %s", tuning_records)
 
-        use_autoscheduler = True
-        try:
-            auto_scheduler.load_records(tuning_records)
-        except tvm._ffi.base.TVMError:
-            use_autoscheduler = False
+            use_autoscheduler = True
+            try:
+                auto_scheduler.load_records(tuning_records)
+            except tvm._ffi.base.TVMError:
+                use_autoscheduler = False
 
-        if use_autoscheduler:
-            with auto_scheduler.ApplyHistoryBest(tuning_records):
-                config["relay.backend.use_auto_scheduler"] = True
-                with tvm.transform.PassContext(
-                    opt_level=opt_level,
-                    config=config,
-                    disabled_pass=disabled_pass,
-                    instruments=instruments,
-                ):
+            if use_autoscheduler:
+                with auto_scheduler.ApplyHistoryBest(tuning_records):
+                    config["relay.backend.use_auto_scheduler"] = True
                     logger.debug("building relay graph with autoscheduler")
                     graph_module = build(
                         mod,
@@ -336,14 +335,8 @@ def compile_model(
                         mod_name=mod_name,
                         workspace_pools=workspace_pools,
                     )
-        else:
-            with autotvm.apply_history_best(tuning_records):
-                with tvm.transform.PassContext(
-                    opt_level=opt_level,
-                    config=config,
-                    disabled_pass=disabled_pass,
-                    instruments=instruments,
-                ):
+            else:
+                with autotvm.apply_history_best(tuning_records):
                     logger.debug("building relay graph with tuning records")
                     graph_module = build(
                         mod,
@@ -355,10 +348,7 @@ def compile_model(
                         mod_name=mod_name,
                         workspace_pools=workspace_pools,
                     )
-    else:
-        with tvm.transform.PassContext(
-            opt_level=opt_level, config=config, disabled_pass=disabled_pass, instruments=instruments
-        ):
+        else:
             logger.debug("building relay graph (no tuning records provided)")
             graph_module = build(
                 mod,
@@ -371,32 +361,32 @@ def compile_model(
                 workspace_pools=workspace_pools,
             )
 
-    # Generate output dump files with sources
-    if dump_code is None:
-        dump_code = []
-    if not isinstance(dump_code, list):
-        dump_code = [dump_code]
-    dumps = {}
-    for source_type in dump_code:
-        if use_vm:
-            lib = graph_module.lib
-        else:
-            lib = graph_module.get_lib()
-        # TODO lib.get_source call have inconsistent behavior for unsupported
-        #      formats (@leandron).
-        source = str(mod) if source_type == "relay" else lib.get_source(source_type)
-        dumps[source_type] = source
+        # Generate output dump files with sources
+        if dump_code is None:
+            dump_code = []
+        if not isinstance(dump_code, list):
+            dump_code = [dump_code]
+        dumps = {}
+        for source_type in dump_code:
+            if use_vm:
+                lib = graph_module.lib
+            else:
+                lib = graph_module.get_lib()
+            # TODO lib.get_source call have inconsistent behavior for unsupported
+            #      formats (@leandron).
+            source = str(mod) if source_type == "relay" else lib.get_source(source_type)
+            dumps[source_type] = source
 
-    # Create a new tvmc model package object from the graph definition.
-    package_path = tvmc_model.export_package(
-        graph_module, package_path, cross, cross_options, output_format
-    )
+        # Create a new tvmc model package object from the graph definition.
+        package_path = tvmc_model.export_package(
+            graph_module, package_path, cross, cross_options, output_format
+        )
 
-    # Write dumps to file.
-    if dumps:
-        save_dumps(package_path, dumps)
+        # Write dumps to file.
+        if dumps:
+            save_dumps(package_path, dumps)
 
-    return TVMCPackage(package_path)
+        return TVMCPackage(package_path)
 
 
 def build(

--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -54,10 +54,7 @@ def convert_graph_layout(mod, desired_layout):
         ]
     )
 
-    with transform.PassContext(opt_level=3):
-        try:
-            return seq(mod)
-        except Exception as err:
-            raise TVMCException(
-                "Error converting layout to {0}: {1}".format(desired_layout, str(err))
-            )
+    try:
+        return seq(mod)
+    except Exception as err:
+        raise TVMCException("Error converting layout to {0}: {1}".format(desired_layout, str(err)))

--- a/tests/python/driver/tvmc/conftest.py
+++ b/tests/python/driver/tvmc/conftest.py
@@ -23,6 +23,8 @@ import numpy as np
 
 from PIL import Image
 
+import tvm
+from tvm import relay
 from tvm.driver import tvmc
 
 from tvm.contrib.download import download_testdata
@@ -284,3 +286,17 @@ def relay_text_conv2d(tmpdir_factory):
     with open(file_path, "w") as relay_text:
         relay_text.write(RELAY_MODEL)
     return file_path
+
+
+@pytest.fixture(scope="session")
+def relay_conv2d():
+    """
+    Simple conv2d Replay implementation.
+    """
+    dtype = "float32"
+
+    x = relay.var("x", shape=(1, 4, 2, 2), dtype=dtype)
+    weight = relay.const(np.random.uniform(size=(2, 4, 2, 2)), dtype=dtype)
+    x = relay.nn.conv2d(x, weight)
+    func = relay.Function(relay.analysis.free_vars(x), x)
+    return tvm.IRModule.from_expr(func)

--- a/tests/python/driver/tvmc/conftest.py
+++ b/tests/python/driver/tvmc/conftest.py
@@ -291,7 +291,7 @@ def relay_text_conv2d(tmpdir_factory):
 @pytest.fixture(scope="session")
 def relay_conv2d():
     """
-    Simple conv2d Replay implementation.
+    Simple conv2d Relay implementation.
     """
     dtype = "float32"
 

--- a/tests/python/driver/tvmc/test_autotuner.py
+++ b/tests/python/driver/tvmc/test_autotuner.py
@@ -23,6 +23,7 @@ from unittest import mock
 from os import path
 from pathlib import Path
 
+import tvm
 from tvm import autotvm
 from tvm.driver import tvmc
 
@@ -191,3 +192,18 @@ def test_tune_rpc_tracker_parsing(mock_load_model, mock_tune_model, mock_auto_sc
     assert "10.0.0.1" == kwargs["hostname"]
     assert "port" in kwargs
     assert 9999 == kwargs["port"]
+
+
+@mock.patch("tvm.transform.PassContext", return_value=tvm.transform.PassContext())
+def test_autotune_pass_context(mock_pc, onnx_mnist, tmpdir_factory):
+    """
+    Check that the pass context while tuning is as expected.
+    """
+    pytest.importorskip("onnx")
+
+    tmpdir_name = tmpdir_factory.mktemp("data")
+    _tuner_test_helper(onnx_mnist, "gridsearch", tmpdir_name)
+
+    # AutoTVM overrides the pass context later in the pipeline to disable AlterOpLayout
+    assert mock_pc.call_count == 2
+    assert mock_pc.call_args_list[0][1]["opt_level"] == 3

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -508,10 +508,7 @@ def test_compile_check_configs_composite_target(mock_pkg, mock_pc, mock_fe, mock
     tvmc_model = tvmc.load("no_file_needed")
     tvmc.compile(tvmc_model, target="mockcodegen -testopt=value, llvm")
 
-    assert mock_pc.call_count == 2
-    codegen_partition_context = mock.call(
-        config={"relay.ext.mock.options": {"testopt": "value"}},
-    )
+    assert mock_pc.call_count == 1
     codegen_compile_context = mock.call(
         config={"relay.ext.mock.options": {"testopt": "value"}},
         opt_level=3,
@@ -520,9 +517,6 @@ def test_compile_check_configs_composite_target(mock_pkg, mock_pc, mock_fe, mock
     )
     mock_pc.assert_has_calls(
         [
-            codegen_partition_context,
-            codegen_partition_context.__enter__(),
-            codegen_partition_context.__exit__(None, None, None),
             codegen_compile_context,
             codegen_compile_context.__enter__(),
             codegen_compile_context.__exit__(None, None, None),

--- a/tests/python/driver/tvmc/test_frontends.py
+++ b/tests/python/driver/tvmc/test_frontends.py
@@ -297,7 +297,8 @@ def test_compile_tflite_module_nhwc_to_nchw(tflite_mobilenet_v1_1_quant):
     before = tvmc_model.mod
 
     expected_layout = "NCHW"
-    after = tvmc.transform.convert_graph_layout(before, expected_layout)
+    with tvm.transform.PassContext(opt_level=3):
+        after = tvmc.transform.convert_graph_layout(before, expected_layout)
 
     layout_transform_calls = []
 
@@ -322,7 +323,8 @@ def test_compile_onnx_module_nchw_to_nhwc(onnx_resnet50):
     before = tvmc_model.mod
 
     expected_layout = "NHWC"
-    after = tvmc.transform.convert_graph_layout(before, expected_layout)
+    with tvm.transform.PassContext(opt_level=3):
+        after = tvmc.transform.convert_graph_layout(before, expected_layout)
 
     layout_transform_calls = []
 
@@ -347,7 +349,8 @@ def test_compile_paddle_module_nchw_to_nhwc(paddle_resnet50):
     before = tvmc_model.mod
 
     expected_layout = "NHWC"
-    after = tvmc.transform.convert_graph_layout(before, expected_layout)
+    with tvm.transform.PassContext(opt_level=3):
+        after = tvmc.transform.convert_graph_layout(before, expected_layout)
 
     layout_transform_calls = []
 
@@ -372,7 +375,9 @@ def test_compile_tflite_module__same_layout__nhwc_to_nhwc(tflite_mobilenet_v1_1_
     before = tvmc_model.mod
 
     expected_layout = "NHWC"
-    after = tvmc.transform.convert_graph_layout(before, expected_layout)
+
+    with tvm.transform.PassContext(opt_level=3):
+        after = tvmc.transform.convert_graph_layout(before, expected_layout)
 
     layout_transform_calls = []
 
@@ -397,7 +402,9 @@ def test_compile_onnx_module__same_layout__nchw_to_nchw(onnx_resnet50):
     before = tvmc_model.mod
 
     expected_layout = "NCHW"
-    after = tvmc.transform.convert_graph_layout(before, expected_layout)
+
+    with tvm.transform.PassContext(opt_level=3):
+        after = tvmc.transform.convert_graph_layout(before, expected_layout)
 
     layout_transform_calls = []
 


### PR DESCRIPTION
Comes as a followup from conversations in #13216. By making the pass context a global value for both `compile` and `tune` commands, we can ensure the pass context is exactly as the user expected and also test components such as `convert_graph_layout` under a pass context suitable for testing (e.g. add instruments). With this change, it becomes the users responsibility to ensure the PassContext they select is suitable for the passes that will be run. By default, `opt_level` remains as 3 so current workflows that do not alter the pass context from the command line / TVMC Python API should not be affected.