### PR TITLE
[microTVM] Fix RPC session close on runtime side

### DIFF
--- a/python/tvm/micro/project_api/client.py
+++ b/python/tvm/micro/project_api/client.py
@@ -85,7 +85,7 @@ class ProjectAPIClient:
 
     @property
     def is_shutdown(self):
-        return self.read_file is None
+        return self.read_file.closed
 
     def shutdown(self):
         if self.is_shutdown:

--- a/python/tvm/micro/project_api/client.py
+++ b/python/tvm/micro/project_api/client.py
@@ -88,14 +88,14 @@ class ProjectAPIClient:
         return self.read_file.closed
 
     def shutdown(self):
-        if self.is_shutdown:
+        if self.is_shutdown:  # pylint: disable=using-constant-test
             return
 
         self.read_file.close()
         self.write_file.close()
 
     def _request_reply(self, method, params):
-        if self.is_shutdown:
+        if self.is_shutdown:  # pylint: disable=using-constant-test
             raise ConnectionShutdownError("connection already closed")
 
         request = {

--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -157,6 +157,8 @@ class Session:
         if not self._exit_called:
             self._exit_called = True
             self.transport.__exit__(exc_type, exc_value, exc_traceback)
+            shutdown_func = self._rpc._sess.get_function("CloseRPCConnection")
+            shutdown_func()
 
     def _cleanup(self):
         self.__exit__(None, None, None)


### PR DESCRIPTION
Currently, the RPC session on C/C++ side does not know if the session was closed on python side which causes extra read/write on transport while the session is already closed. This PR reuses the hexagon approach in microTVM to shutdown the RPC session.