### PR TITLE
[Hexagon] [runtime] Move lock/unlock to HexagonHtp temporarily

### DIFF
--- a/src/runtime/hexagon/hexagon_htp.cc
+++ b/src/runtime/hexagon/hexagon_htp.cc
@@ -35,9 +35,17 @@ namespace tvm {
 namespace runtime {
 namespace hexagon {
 
-HexagonHtp::HexagonHtp() { Acquire(); }
+HexagonHtp::HexagonHtp() {
+  Acquire();
+  // TODO(HWE): Perform HTP lock/unlock in thread instead of HexagonHtp
+  Lock();
+}
 
-HexagonHtp::~HexagonHtp() { Release(); }
+HexagonHtp::~HexagonHtp() {
+  // TODO(HWE): Perform HTP lock/unlock in thread instead of HexagonHtp
+  Unlock();
+  Release();
+}
 
 void HexagonHtp::Acquire() {
   compute_res_attr_t compute_res_attr;

--- a/src/runtime/hexagon/hexagon_thread_manager.cc
+++ b/src/runtime/hexagon/hexagon_thread_manager.cc
@@ -325,8 +325,9 @@ void HexagonThreadManager::thread_exit(void* context) {
     tc->hvx->Unlock();
     DLOG(INFO) << "Thread " << index << " unlocked an HVX instance";
   } else if (resource_type == HTP_0) {
-    tc->htp->Unlock();
-    DLOG(INFO) << "Thread " << index << " unlocked the HTP";
+    // TODO(HWE): Perform HTP lock/unlock in thread instead of HexagonHtp
+    // tc->htp->Unlock();
+    // DLOG(INFO) << "Thread " << index << " unlocked the HTP";
   }
 
   DLOG(INFO) << "Thread " << index << " exiting";
@@ -346,8 +347,9 @@ void HexagonThreadManager::thread_main(void* context) {
     tc->hvx->Lock();
     DLOG(INFO) << "Thread " << index << " locked an HVX instance";
   } else if (resource_type == HTP_0) {
-    tc->htp->Lock();
-    DLOG(INFO) << "Thread " << index << " locked the HTP";
+    // TODO(HWE): Perform HTP lock/unlock in thread instead of HexagonHtp
+    // tc->htp->Lock();
+    // DLOG(INFO) << "Thread " << index << " locked the HTP";
   }
 
   while (true) {  // loop, executing commands from pipe


### PR DESCRIPTION
Temporarily moves lock/unlock for HTP to the main thread instead of its own thread, until we are fully pipelined.

cc: @csullivan 