### PR TITLE
[TIR] Remove redundant add in vnni/arm intrin

### DIFF
--- a/python/tvm/tir/tensor_intrin/arm_cpu.py
+++ b/python/tvm/tir/tensor_intrin/arm_cpu.py
@@ -119,10 +119,12 @@ def dot_product_4x4_i8i8i32_sdot(
 
         vec_b = B.vload([0, 0], dtype="int8x16")
 
-        C[T.ramp(T.int32(0), 1, 4)] += T.call_llvm_pure_intrin(
+        vec_c = C.vload([0], dtype="int32x4")
+
+        C[T.ramp(T.int32(0), 1, 4)] = T.call_llvm_pure_intrin(
             T.llvm_lookup_intrinsic_id("llvm.aarch64.neon.sdot.v4i32.v16i8"),
             T.uint32(3),
-            T.int32x4(0),
+            vec_c,
             vec_a,
             vec_b,
             dtype="int32x4",

--- a/python/tvm/tir/tensor_intrin/x86.py
+++ b/python/tvm/tir/tensor_intrin/x86.py
@@ -55,11 +55,12 @@ def dot_product_16x4_u8i8i32_vnni(
 
         B_i8x64 = B.vload([0, 0], dtype="int8x64")
         B_i32x16 = T.reinterpret(B_i8x64, dtype="int32x16")
+        C_i32x16 = C.vload([0], dtype="int32x16")
 
-        C[T.ramp(T.int32(0), 1, 16)] += T.call_llvm_pure_intrin(  # Note: this is an update +=
+        C[T.ramp(T.int32(0), 1, 16)] = T.call_llvm_pure_intrin(
             T.llvm_lookup_intrinsic_id("llvm.x86.avx512.vpdpbusd.512"),
             T.uint32(0),
-            T.int32x16(0),
+            C_i32x16,
             T.broadcast(A_i32, 16),
             B_i32x16,
             dtype="int32x16",

--- a/tests/python/unittest/test_meta_schedule_postproc_rewrite_tensorize.py
+++ b/tests/python/unittest/test_meta_schedule_postproc_rewrite_tensorize.py
@@ -233,10 +233,11 @@ class Conv2dNCHWcVNNIModuleTensorized:
                     A_i32 = T.reinterpret(A_u8x4, dtype="int32")
                     B_i8x64 = B.vload([0, 0], dtype="int8x64")
                     B_i32x16 = T.reinterpret(B_i8x64, dtype="int32x16")
-                    C[T.ramp(0, 1, 16)] = C[T.ramp(0, 1, 16)] + T.call_llvm_pure_intrin(
+                    C_i32x16 = C.vload([0], dtype="int32x16")
+                    C[T.ramp(0, 1, 16)] = T.call_llvm_pure_intrin(
                         T.llvm_lookup_intrinsic_id("llvm.x86.avx512.vpdpbusd.512"),
                         T.uint32(0),
-                        T.broadcast(0, 16),
+                        C_i32x16,
                         T.broadcast(A_i32, 16),
                         B_i32x16,
                         dtype="int32x16",

--- a/tests/python/unittest/test_meta_schedule_trace_apply.py
+++ b/tests/python/unittest/test_meta_schedule_trace_apply.py
@@ -1182,7 +1182,8 @@ def get_conv2d_vnni_mod(intrin_id):
                                 A_i32: T.int32 = T.reinterpret(A_u8x4, dtype="int32")
                                 B_i8x64: T.int8x64 = B[0, 0:64]
                                 B_i32x16: T.int32x16 = T.reinterpret(B_i8x64, dtype="int32x16")
-                                C[0:16] = C[0:16] + T.call_llvm_pure_intrin(intrin_id, T.uint32(0), T.broadcast(0, 16), T.broadcast(A_i32, 16), B_i32x16, dtype="int32x16")
+                                C_i32x16: T.int32x16 = C[0:16]
+                                C[0:16] = T.call_llvm_pure_intrin(intrin_id, T.uint32(0), C_i32x16, T.broadcast(A_i32, 16), B_i32x16, dtype="int32x16")
                     for ax0, ax1, ax2, ax3 in T.grid(1, 1, 1, 7):
                         for ax4_fused in T.vectorized(16):
                             with T.block("T_cast_8"):


### PR DESCRIPTION
Similar to #12588 , this optimizes VNNI intrin in TIR.

In a 16x1024x1024 batch matmul on cascade lake CPU, it reduces the time from 6.97ms to 6.72ms (4% faster)

cc @masahi 