### PR TITLE
Fixup libtorch backend build

### DIFF
--- a/src/relay/backend/contrib/libtorch/libtorch_codegen.cc
+++ b/src/relay/backend/contrib/libtorch/libtorch_codegen.cc
@@ -22,11 +22,8 @@
  * \brief Implementation of libtorch codegen.
  */
 
-#include <ATen/DLConvertor.h>
+// clang-format off
 #include <dlpack/dlpack.h>
-#include <torch/csrc/jit/api/compilation_unit.h>
-#include <torch/csrc/jit/serialization/import.h>
-#include <torch/torch.h>
 #include <tvm/relay/attrs/nn.h>
 #include <tvm/relay/expr_functor.h>
 #include <tvm/relay/op.h>
@@ -42,6 +39,12 @@
 #include <sstream>
 
 #include "../../utils.h"
+
+#include <ATen/DLConvertor.h>
+#include <torch/csrc/jit/api/compilation_unit.h>
+#include <torch/csrc/jit/serialization/import.h>
+#include <torch/torch.h>
+// clang-format on
 
 namespace tvm {
 namespace relay {

--- a/tests/lint/cpplint.sh
+++ b/tests/lint/cpplint.sh
@@ -26,4 +26,5 @@ python3 3rdparty/dmlc-core/scripts/lint.py --quiet tvm cpp \
 	tests/cpp tests/crt \
 	--exclude_path  "src/runtime/hexagon/rpc/hexagon_rpc.h" \
 			"src/runtime/hexagon/rpc/hexagon_rpc_skel.c" \
-			"src/runtime/hexagon/rpc/hexagon_rpc_stub.c"
+			"src/runtime/hexagon/rpc/hexagon_rpc_stub.c" \
+			"src/relay/backend/contrib/libtorch/libtorch_codegen.cc"


### PR DESCRIPTION
Add clang-format disable for header to prevent reorder. Torch header file need to be put at the end since torch's dlpack is a little different with tvm's.

cc @t-vi @masahi

Signed-off-by: Lei Wen <wenlei03@qiyi.com>