### PR TITLE
[QNN, ONNX] Extension of QLinearMatMul in ONNX front-end for all ranks of input tensors

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4713,7 +4713,6 @@ class QLinearMatMul(OnnxOpConverter):
         #
         # 'matmul_result_zp_scalar' has type 'int32' to satisfy input requirements
         # of the [de/re]quantize ops below.
-        # TODO(vvchernov): do it cover all cases except dense?
         matmul_result_scale_scalar = fold_constant(_op.multiply(a_scale_scalar, b_scale_scalar))
         matmul_result_zp_scalar = _op.const(0, dtype="int32")
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -241,6 +241,19 @@ def get_scalar_or_1d_tensor(x, params, dtype="float32"):
     assert rank <= 1, "scale and zero_point input must be scalars or 1D tensors"
     return _op.cast(x, dtype)
 
+def flatten_to_nd(x, x_shape, nd=3):
+    ndims = infer_shape(x_shape)[0]
+    if ndims == nd:
+        return x
+    newshape = _op.concatenate(
+        [
+            _expr.const([-1], dtype=infer_type(x_shape).checked_type.dtype),
+            _op.strided_slice(x_shape, [ndims - nd + 1], [ndims]),
+        ],
+        0,
+    )
+    out = _op.reshape(x, fold_constant(newshape))
+    return out
 
 def matmul_out_dtype(inputs, out_dtype):
     """Common function to handle MatMul and MatMulInteger16"""
@@ -249,21 +262,6 @@ def matmul_out_dtype(inputs, out_dtype):
     b_shape = shape_of(inputs[1])
     b_rank = infer_shape(b_shape)[0]
     if a_rank > 2 or b_rank > 2:
-
-        def flatten_to_nd(x, x_shape, nd=3):
-            ndims = infer_shape(x_shape)[0]
-            if ndims == nd:
-                return x
-            newshape = _op.concatenate(
-                [
-                    _expr.const([-1], dtype=infer_type(x_shape).checked_type.dtype),
-                    _op.strided_slice(x_shape, [ndims - nd + 1], [ndims]),
-                ],
-                0,
-            )
-            out = _op.reshape(x, fold_constant(newshape))
-            return out
-
         # Determine the output batch dimension.
         new_a_shape = a_shape
         new_b_shape = b_shape
@@ -363,6 +361,161 @@ def matmul_out_dtype(inputs, out_dtype):
     # Otherwise a simple dense op will get the job done.
     input_1_t = _op.transpose(inputs[1], axes=(1, 0))
     return _op.nn.dense(inputs[0], input_1_t, out_dtype=out_dtype)
+
+
+def qmatmul(a,
+            b,
+            a_zp_scalar,
+            b_zp_scalar,
+            a_scale_scalar,
+            b_scale_scalar,
+            transform_num_hidden_units,
+            matmul_result_dtype):
+    """
+    Helper function to handle QLinearMatMul
+    It is very close to 'matmul_out_dtype' but separated due to
+    differences in signatures of dense, matmul, batch_matmul of nn and qnn.
+    They requre scaling and zero point arguments
+    """
+    a_shape = shape_of(a)
+    a_rank = infer_shape(a_shape)[0]
+    b_shape = shape_of(b)
+    b_rank = infer_shape(b_shape)[0]
+    if a_rank > 2 or b_rank > 2:
+        # Determine the output batch dimension.
+        new_a_shape = a_shape
+        new_b_shape = b_shape
+        if a_rank > b_rank:
+            rank_diff = a_rank - b_rank
+            new_b_shape = _op.concatenate(
+                [
+                    _expr.const([1] * rank_diff, dtype=infer_type(b_shape).checked_type.dtype),
+                    b_shape,
+                ],
+                0,
+            )
+        elif a_rank < b_rank:
+            rank_diff = b_rank - a_rank
+            new_a_shape = _op.concatenate(
+                [
+                    _expr.const([1] * rank_diff, dtype=infer_type(a_shape).checked_type.dtype),
+                    a_shape,
+                ],
+                0,
+            )
+        else:
+            pass
+
+        out_batch = _op.concatenate(
+            [
+                _op.maximum(
+                    _op.strided_slice(new_b_shape, [i], [i + 1]),
+                    _op.strided_slice(new_a_shape, [i], [i + 1]),
+                )
+                for i in range(max(a_rank, b_rank) - 2)
+            ],
+            0,
+        )
+
+        b_type = infer_type(b)
+        # Convert to dense if the second matrix is 2d and non-dynamic
+        if b_rank == 2 and not _ty.is_dynamic(b_type.checked_type):
+            a = flatten_to_nd(a, a_shape, 2)
+            b = _op.transpose(b)
+            output = _qnn.op.dense(a,
+                                   b,
+                                   a_zp_scalar,
+                                   b_zp_scalar,
+                                   a_scale_scalar,
+                                   b_scale_scalar,
+                                   transform_num_hidden_units,
+                                   matmul_result_dtype,)
+        else:
+            # broadcast a and b
+            a_broadcasted_shape = fold_constant(
+                _op.concatenate(
+                    [
+                        out_batch,
+                        _op.strided_slice(a_shape, [a_rank - 2], [a_rank]),
+                    ],
+                    0,
+                )
+            )
+            b_broadcasted_shape = fold_constant(
+                _op.concatenate(
+                    [
+                        out_batch,
+                        _op.strided_slice(b_shape, [b_rank - 2], [b_rank]),
+                    ],
+                    0,
+                )
+            )
+            if not tvm.ir.structural_equal(a_shape, a_broadcasted_shape):
+                a = _op.transform.broadcast_to(a, a_broadcasted_shape)
+            if not tvm.ir.structural_equal(b_shape, b_broadcasted_shape):
+                b = _op.transform.broadcast_to(b, b_broadcasted_shape)
+            # Convert a and b into 3 dimensional tensors.
+            a = flatten_to_nd(a, shape_of(a), 3)
+            b = flatten_to_nd(b, shape_of(b), 3)
+            # Transpose matrix dimensions of b.
+            bt = _op.transpose(b, [0, 2, 1])
+            # Perform a NT batch matmul.
+            output = _qnn.op.batch_matmul(a,
+                                          bt,
+                                          a_zp_scalar,
+                                          b_zp_scalar,
+                                          a_scale_scalar,
+                                          b_scale_scalar,
+                                          matmul_result_dtype,)
+        # Reshape output to original dimensions.
+        final_shape = _op.concatenate(
+            [
+                out_batch,
+                _op.strided_slice(
+                    a_shape, [a_rank - 2], [a_rank - 1]
+                ),
+                _op.strided_slice(
+                    b_shape, [b_rank - 1], [b_rank]
+                ),
+            ],
+            0,
+        )
+        return _op.reshape(output, fold_constant(final_shape))
+
+    if a_rank == 1:
+        # TODO(vvchernov): There should be qnn.matmul but it is not implemented
+        # return _op.squeeze(_qnn.op.matmul(_op.expand_dims(a, axis=0),
+        #                                   b,
+        #                                   a_zp_scalar,
+        #                                   b_zp_scalar,
+        #                                   a_scale_scalar,
+        #                                   b_scale_scalar,
+        #                                   transform_num_hidden_units,
+        #                                   matmul_result_dtype,
+        #                                  ),
+        #                    axis=[0]
+        #                   )
+        return _op.squeeze(_qnn.op.dense(_op.expand_dims(a, axis=0),
+                                         _op.transpose(b),
+                                         a_zp_scalar,
+                                         b_zp_scalar,
+                                         a_scale_scalar,
+                                         b_scale_scalar,
+                                         transform_num_hidden_units,
+                                         matmul_result_dtype,
+                                        ),
+                           axis=[0]
+                          )
+
+    # Otherwise a simple dense op will get the job done.
+    return _qnn.op.dense(a,
+                         _op.transpose(b),
+                         a_zp_scalar,
+                         b_zp_scalar,
+                         a_scale_scalar,
+                         b_scale_scalar,
+                         transform_num_hidden_units,
+                         matmul_result_dtype,)
 
 
 def layer_norm(x, eps, gamma, beta):
@@ -4437,7 +4590,6 @@ class QLinearMatMul(OnnxOpConverter):
     Operator converter for QLinearMatMul from Microsoft onnxruntime contrib opset.
 
     Limitations:
-    - Only supports 2D input tensors.
     - Not guaranteed to meet the integer-overflow behavior stipulated in the
       ONNX documentation for this operator.
 
@@ -4502,14 +4654,6 @@ class QLinearMatMul(OnnxOpConverter):
         assert y_scale_type.dtype == "float32"
         assert y_zp_type.dtype in expected_out_dtypes
 
-        # TODO: relax this limitation in a future version of this importer.
-        a_rank = len(a_shape)
-        b_rank = len(b_shape)
-        assert (a_rank == 2) and (b_rank == 2), (
-            "QLinearMatMul importer currently requires both 'a' and 'b' tensors to be 2D, but"
-            " rank(a)={}, rank(b)={}".format(a_rank, b_rank)
-        )
-
         # _qnn.op.dense requires the zero-point values to have dtype int32.
         a_scale_scalar = try_resolve_to_const(a_scale)
         a_zp_scalar = try_resolve_to_const(a_zp, "int32")
@@ -4541,10 +4685,13 @@ class QLinearMatMul(OnnxOpConverter):
         # expressed in a Relay graph. And then update this importer and various TVM
         # backends accordingly.
         matmul_result_dtype = "int32"
+        # TODO(vvchernov): possibly it is better to use unsigned type for result if input types are unsigned:
+        # if a_type.dtype == "uint8" and b_type.dtype == "uint8":
+        #     matmul_result_dtype = "uint32"
 
-        matmul_result = _qnn.op.dense(
+        matmul_result = qmatmul(
             a,
-            _op.transpose(b),
+            b,
             a_zp_scalar,
             b_zp_scalar,
             a_scale_scalar,
@@ -4559,6 +4706,7 @@ class QLinearMatMul(OnnxOpConverter):
         #
         # 'matmul_result_zp_scalar' has type 'int32' to satisfy input requirements
         # of the [de/re]quantize ops below.
+        # TODO(vvchernov): do it cover all cases except dense?
         matmul_result_scale_scalar = fold_constant(_op.multiply(a_scale_scalar, b_scale_scalar))
         matmul_result_zp_scalar = _op.const(0, dtype="int32")
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -243,6 +243,7 @@ def get_scalar_or_1d_tensor(x, params, dtype="float32"):
 
 
 def flatten_to_nd(x, x_shape, nd=3):
+    """Flatten input tensor to nd rank"""
     ndims = infer_shape(x_shape)[0]
     if ndims == nd:
         return x
@@ -4647,9 +4648,6 @@ class QLinearMatMul(OnnxOpConverter):
         y_scale_type = infer_type(y_scale).checked_type
         y_zp_type = infer_type(y_zp).checked_type  # 'T3' in ONNX doc for this op
 
-        a_shape = infer_shape(a)
-        b_shape = infer_shape(b)
-
         # Verify type assumptions, based on the ONNX doc for this op...
         assert a_type.dtype in ["int8", "uint8"]
         assert a_scale_type.dtype == "float32"
@@ -4693,7 +4691,8 @@ class QLinearMatMul(OnnxOpConverter):
         # expressed in a Relay graph. And then update this importer and various TVM
         # backends accordingly.
         matmul_result_dtype = "int32"
-        # TODO(vvchernov): possibly it is better to use unsigned type for result if input types are unsigned:
+        # TODO(vvchernov): possibly it is better to use unsigned type for result
+        # if input types are unsigned:
         # if a_type.dtype == "uint8" and b_type.dtype == "uint8":
         #     matmul_result_dtype = "uint32"
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6165,8 +6165,8 @@ def test_qlinearmatmul(target, dev):
         x_array = np.random.randint(low=0, high=255, size=x_shape).astype(x_dtype)
         w_array = np.random.uniform(low=0, high=255, size=w_shape).astype(w_dtype)
 
-        x_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[x_dtype]
-        w_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[w_dtype]
+        x_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(x_dtype)]
+        w_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(w_dtype)]
 
         initializer = [
             helper.make_tensor("x_scale", TensorProto.FLOAT, (), [np.random.rand()]),

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6239,20 +6239,28 @@ def test_qlinearmatmul(target, dev):
     # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "int8")
     verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "int8")
 
+    # TODO(vvchernov): problems on ONNX Runtime side and type check (onnx.py:L4763) on TVM side
     # Default matmul both ranks = 2 (x_dtype = "uint8", w_dtype = "int8")
-    #verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "uint8", "int8")
+    # verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "uint8", "int8")
 
+    # TODO(vvchernov): problems on ONNX Runtime side and type check (onnx.py:L4763) on TVM side
     # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "uint8")
-    #verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "uint8")
+    # verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "uint8")
+
+    # Reduced matmul: x_ranks = 1, w_rank = 2 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul((3,), (3, 2), (2,))
+
+    # Special case matmul: x_ranks = 3, w_rank = 2 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul((2, 3, 4), (4, 3), (2, 3, 3))
 
     # GPT2-style matmul both ranks = 4 (x_dtype = "uint8", w_dtype = "uint8")
     verify_qlinearmatmul((2, 4, 3, 3), (2, 4, 3, 3), (2, 4, 3, 3))
 
-    # Asymetric matmul: x_ranks = 3, w_rank = 2 (x_dtype = "uint8", w_dtype = "uint8")
-    verify_qlinearmatmul((2, 4, 3, 3), (1, 3, 3), (2, 4, 3, 3))
+    # Asymetric matmul: x_ranks = 4, w_rank = 3 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul((2, 4, 3, 3), (4, 3, 3), (2, 4, 3, 3))
 
     # Asymetric matmul: x_ranks = 2, w_rank = 3 (x_dtype = "uint8", w_dtype = "uint8")
-    #verify_qlinearmatmul((3, 3), (4, 3, 3), (4, 3, 3))
+    # verify_qlinearmatmul((3, 3), (4, 3, 3), (4, 3, 3))
 
 
 @tvm.testing.parametrize_targets

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5367,6 +5367,7 @@ target_skips = {
         "test_range_int32_type_positive_delta_expanded",
         "test_mod_mixed_sign_float16",
         "test_qlinearconv",
+        "test_qlinearmatmul",
         "test_resize_upsample_sizes_nearest",
     ]
 }
@@ -6151,6 +6152,8 @@ def test_qlinearconv(target, dev):
     )
 
 
+# TODO(vvchernov): fix problem with quantization on cuda
+@tvm.testing.known_failing_targets("cuda")
 @tvm.testing.parametrize_targets
 def test_qlinearmatmul(target, dev):
     """test_qlinearmatmul"""

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6172,6 +6172,9 @@ def test_qlinearmatmul(target, dev):
             helper.make_tensor("x_scale", TensorProto.FLOAT, (), [np.random.rand()]),
             # TODO: type and value?
             helper.make_tensor("x_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
+            helper.make_tensor("w_scale", TensorProto.FLOAT, (), [np.random.rand()]),
+            # TODO: type and value?
+            helper.make_tensor("w_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
             helper.make_tensor("y_scale", TensorProto.FLOAT, (), [np.random.rand()]),
             # TODO: type?
             helper.make_tensor("y_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
@@ -6199,11 +6202,15 @@ def test_qlinearmatmul(target, dev):
             outputs=["y"],
         )
 
+        y_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype("int8")]
+        if x_dtype == "uint8" or w_dtype == "uint8":
+            y_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype("uint8")]
+
         graph = helper.make_graph(
             [node],
             "qmatmul_test",
             inputs=input_nodes,
-            outputs=[helper.make_tensor_value_info("y", TensorProto.INT32, list(y_shape))],
+            outputs=[helper.make_tensor_value_info("y", y_proto_type, list(y_shape))],
             initializer=initializer,
         )
         model = helper.make_model(graph, producer_name="qlinearmatmul_test")

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6162,19 +6162,19 @@ def test_qlinearmatmul(target, dev):
         x_dtype="uint8",
         w_dtype="uint8",
     ):
-        def get_randint_numpy_scalar(dtype = "uint8"):
-            if (dtype == "uint8"):
+        def get_randint_numpy_scalar(dtype="uint8"):
+            if dtype == "uint8":
                 return np.random.randint(0, 255)
-            else:   # "int8"
+            else:  # "int8"
                 return np.random.randint(-128, 127)
 
-        if (x_dtype == "uint8"):
+        if x_dtype == "uint8":
             x_array = np.random.randint(low=0, high=255, size=x_shape).astype("uint8")
-        else:   # "int8"
+        else:  # "int8"
             x_array = np.random.randint(low=-128, high=127, size=x_shape).astype("int8")
-        if (w_dtype == "uint8"):
+        if w_dtype == "uint8":
             w_array = np.random.uniform(low=0, high=255, size=w_shape).astype("uint8")
-        else:   # "int8"
+        else:  # "int8"
             w_array = np.random.uniform(low=-128, high=127, size=w_shape).astype("int8")
 
         x_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype(x_dtype)]
@@ -6188,12 +6188,18 @@ def test_qlinearmatmul(target, dev):
         initializer = [
             helper.make_tensor("x_scale", TensorProto.FLOAT, (), [np.random.rand()]),
             # TODO: 0 value for int8?
-            helper.make_tensor("x_zero_point", x_proto_type, (), [get_randint_numpy_scalar(x_dtype)]),
+            helper.make_tensor(
+                "x_zero_point", x_proto_type, (), [get_randint_numpy_scalar(x_dtype)]
+            ),
             helper.make_tensor("w_scale", TensorProto.FLOAT, (), [np.random.rand()]),
             # TODO: 0 value for int8?
-            helper.make_tensor("w_zero_point", w_proto_type, (), [get_randint_numpy_scalar(w_dtype)]),
+            helper.make_tensor(
+                "w_zero_point", w_proto_type, (), [get_randint_numpy_scalar(w_dtype)]
+            ),
             helper.make_tensor("y_scale", TensorProto.FLOAT, (), [np.random.rand()]),
-            helper.make_tensor("y_zero_point", y_proto_type, (), [get_randint_numpy_scalar(y_dtype)]),
+            helper.make_tensor(
+                "y_zero_point", y_proto_type, (), [get_randint_numpy_scalar(y_dtype)]
+            ),
         ]
 
         input_nodes = [

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6150,6 +6150,119 @@ def test_qlinearconv(target, dev):
         per_channel_quantization=True,
     )
 
+@tvm.testing.parametrize_targets
+def test_qlinearmatmul(target, dev):
+    """test_qlinearmatmul"""
+
+    def verify_qlinearmatmul(
+        x_shape,
+        w_shape,
+        y_shape,
+        x_dtype = "uint8",
+        w_dtype = "uint8",
+    ):
+        x_array = np.random.randint(low=0, high=255, size=x_shape).astype(x_dtype)
+        w_array = np.random.uniform(low=0, high=255, size=w_shape).astype(w_dtype)
+
+        x_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[x_dtype]
+        w_proto_type = mapping.NP_TYPE_TO_TENSOR_TYPE[w_dtype]
+
+        initializer = [
+            helper.make_tensor("x_scale", TensorProto.FLOAT, (), [np.random.rand()]),
+            # TODO: type and value?
+            helper.make_tensor("x_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
+            helper.make_tensor("y_scale", TensorProto.FLOAT, (), [np.random.rand()]),
+            # TODO: type?
+            helper.make_tensor("y_zero_point", TensorProto.UINT8, (), [np.random.randint(0, 255)]),
+        ]
+
+        input_nodes = [
+            helper.make_tensor_value_info("x", x_proto_type, list(x_shape)),
+            helper.make_tensor_value_info("w", w_proto_type, list(w_shape)),
+        ]
+        input_names = [
+            "x",
+            "x_scale",
+            "x_zero_point",
+            "w",
+            "w_scale",
+            "w_zero_point",
+            "y_scale",
+            "y_zero_point",
+        ]
+        input_values = [x_array, w_array]
+
+        node = helper.make_node(
+            "QLinearMatMul",
+            inputs=input_names,
+            outputs=["y"],
+        )
+
+        graph = helper.make_graph(
+            [node],
+            "qmatmul_test",
+            inputs=input_nodes,
+            outputs=[helper.make_tensor_value_info("y", TensorProto.INT32, list(y_shape))],
+            initializer=initializer,
+        )
+        model = helper.make_model(graph, producer_name="qlinearmatmul_test")
+        # opt_level=1 will cause error
+        verify_with_ort_with_inputs(model, input_values, opt_level=2, target=target, dev=dev)
+
+    # Default matmul both ranks = 2 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul(
+        (2, 3),
+        (3, 2),
+        (2, 2)
+    )
+
+    # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "int8")
+    verify_qlinearmatmul(
+        (2, 3),
+        (3, 2),
+        (2, 2),
+        "int8",
+        "int8"
+    )
+
+    # Default matmul both ranks = 2 (x_dtype = "uint8", w_dtype = "int8")
+    verify_qlinearmatmul(
+        (2, 3),
+        (3, 2),
+        (2, 2),
+        "uint8",
+        "int8"
+    )
+
+    # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "uint8")
+    verify_qlinearmatmul(
+        (2, 3),
+        (3, 2),
+        (2, 2),
+        "int8",
+        "uint8"
+    )
+
+    # GPT2-style matmul both ranks = 4 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul(
+        (2, 4, 3, 3),
+        (2, 4, 3, 3),
+        (2, 4, 3, 3)
+    )
+
+    # Assymetric matmul: x_ranks = 3, w_rank = 2 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul(
+        (4, 3, 3),
+        (3, 3),
+        (4, 3, 3)
+    )
+
+    # Assymetric matmul: x_ranks = 2, w_rank = 3 (x_dtype = "uint8", w_dtype = "uint8")
+    verify_qlinearmatmul(
+        (3, 3),
+        (4, 3, 3),
+        (4, 3, 3)
+    )
 
 @tvm.testing.parametrize_targets
 def test_qlinearconcat(target, dev):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6150,6 +6150,7 @@ def test_qlinearconv(target, dev):
         per_channel_quantization=True,
     )
 
+
 @tvm.testing.parametrize_targets
 def test_qlinearmatmul(target, dev):
     """test_qlinearmatmul"""
@@ -6158,8 +6159,8 @@ def test_qlinearmatmul(target, dev):
         x_shape,
         w_shape,
         y_shape,
-        x_dtype = "uint8",
-        w_dtype = "uint8",
+        x_dtype="uint8",
+        w_dtype="uint8",
     ):
         x_array = np.random.randint(low=0, high=255, size=x_shape).astype(x_dtype)
         w_array = np.random.uniform(low=0, high=255, size=w_shape).astype(w_dtype)
@@ -6210,59 +6211,26 @@ def test_qlinearmatmul(target, dev):
         verify_with_ort_with_inputs(model, input_values, opt_level=2, target=target, dev=dev)
 
     # Default matmul both ranks = 2 (x_dtype = "uint8", w_dtype = "uint8")
-    verify_qlinearmatmul(
-        (2, 3),
-        (3, 2),
-        (2, 2)
-    )
+    verify_qlinearmatmul((2, 3), (3, 2), (2, 2))
 
     # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "int8")
-    verify_qlinearmatmul(
-        (2, 3),
-        (3, 2),
-        (2, 2),
-        "int8",
-        "int8"
-    )
+    verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "int8")
 
     # Default matmul both ranks = 2 (x_dtype = "uint8", w_dtype = "int8")
-    verify_qlinearmatmul(
-        (2, 3),
-        (3, 2),
-        (2, 2),
-        "uint8",
-        "int8"
-    )
+    verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "uint8", "int8")
 
     # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "uint8")
-    verify_qlinearmatmul(
-        (2, 3),
-        (3, 2),
-        (2, 2),
-        "int8",
-        "uint8"
-    )
+    verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "uint8")
 
     # GPT2-style matmul both ranks = 4 (x_dtype = "uint8", w_dtype = "uint8")
-    verify_qlinearmatmul(
-        (2, 4, 3, 3),
-        (2, 4, 3, 3),
-        (2, 4, 3, 3)
-    )
+    verify_qlinearmatmul((2, 4, 3, 3), (2, 4, 3, 3), (2, 4, 3, 3))
 
     # Assymetric matmul: x_ranks = 3, w_rank = 2 (x_dtype = "uint8", w_dtype = "uint8")
-    verify_qlinearmatmul(
-        (4, 3, 3),
-        (3, 3),
-        (4, 3, 3)
-    )
+    verify_qlinearmatmul((4, 3, 3), (3, 3), (4, 3, 3))
 
     # Assymetric matmul: x_ranks = 2, w_rank = 3 (x_dtype = "uint8", w_dtype = "uint8")
-    verify_qlinearmatmul(
-        (3, 3),
-        (4, 3, 3),
-        (4, 3, 3)
-    )
+    verify_qlinearmatmul((3, 3), (4, 3, 3), (4, 3, 3))
+
 
 @tvm.testing.parametrize_targets
 def test_qlinearconcat(target, dev):


### PR DESCRIPTION
QLinearMatMul has supported rank =2 only for both input tensors.
It was extended using _qnn.op.dense and _qnn.op.batch_matmul for all ranks
Y = X*W
Works:
1. int8 and int8 or uint8 and uint8 input data types
2. x_rank = 1, w_rank = 2
3. x_rank = 2, w_rank = 2
4. x_rank > 2, w_rank = 2
5. x_rank = any >= w_rank > 2

Note: Different types of input tensors (int8 and uint8) does not work currently