### PR TITLE
[MetaSchedule] Fix the order of applying `AutoInline` in `ScheduleUsingAnchorTrace`

### DIFF
--- a/src/meta_schedule/trace_apply.cc
+++ b/src/meta_schedule/trace_apply.cc
@@ -25,6 +25,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "../tir/schedule/analysis.h"

--- a/src/meta_schedule/trace_apply.cc
+++ b/src/meta_schedule/trace_apply.cc
@@ -156,9 +156,12 @@ std::vector<BlockRV> ApplyAnchorTrace(Schedule sch, Trace anchor_trace) {
       // Similar to the reverse_compute_inline case above.
       auto block = Downcast<BlockRV>(inputs[0]);
       auto block_sref = sch->GetSRef(block);
-      if (!CanComputeInline(sch->state(), block_sref)) {
-        ICHECK(CanReverseComputeInline(sch->state(), block_sref));
-        sch->ReverseComputeInline(block);
+      auto state = sch->state();
+      if (!CanComputeInline(state, block_sref)) {
+        ICHECK(IsOutputBlock(state, block_sref, GetScopeRoot(state, block_sref, false)));
+        if (CanReverseComputeInline(sch->state(), block_sref)) {
+          sch->ReverseComputeInline(block);
+        }
         continue;
       }
     }


### PR DESCRIPTION
Note: the diff is bloated due to the test case.

In anchor-block tuning, we need to manually apply `AutoInline` to some blocks (those that are not part of the anchor subgraph). Currently the order of blocks to apply `AutoInline` is undefined, but I've hit a case where this is problematic. 

For example, given these four blocks,
```
        for i0_7, i1_7, i2_7, i3_7 in T.grid(16, 56, 56, 256):
            with T.block("compute_2"):
                i0_8, i1_8, i2_8, i3_8 = T.axis.remap("SSSS", [i0_7, i1_7, i2_7, i3_7])
                T.reads(T_subtract_1[i0_8, i1_8, i2_8, i3_8])
                T.writes(compute_3[i0_8, i1_8, i2_8, i3_8])
                compute_3[i0_8, i1_8, i2_8, i3_8] = T.q_multiply_shift(T_subtract_1[i0_8, i1_8, i2_8, i3_8], 1457846997, 31, 0, dtype="int32")
        for i0_9, i1_9, i2_9, i3_9 in T.grid(16, 56, 56, 256):
            with T.block("compute_3"):
                i0_10, i1_10, i2_10, i3_10 = T.axis.remap("SSSS", [i0_9, i1_9, i2_9, i3_9])
                T.reads(p9[i0_10, i1_10, i2_10, i3_10])
                T.writes(compute_4[i0_10, i1_10, i2_10, i3_10])
                compute_4[i0_10, i1_10, i2_10, i3_10] = T.q_multiply_shift(p9[i0_10, i1_10, i2_10, i3_10], 2101000910, 31, 0, dtype="int32")
        for i0_11, i1_11, i2_11, i3_11 in T.grid(16, 56, 56, 256):
            with T.block("T_add_2"):
                ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0_11, i1_11, i2_11, i3_11])
                T.reads(compute_3[ax0, ax1, ax2, ax3], compute_4[ax0, ax1, ax2, ax3])
                T.writes(T_add_2[ax0, ax1, ax2, ax3])
                T_add_2[ax0, ax1, ax2, ax3] = compute_3[ax0, ax1, ax2, ax3] + compute_4[ax0, ax1, ax2, ax3]
        for i0_12, i1_12, i2_12, i3_12 in T.grid(16, 56, 56, 256):
            with T.block("compute_4"):
                i0_13, i1_13, i2_13, i3_13 = T.axis.remap("SSSS", [i0_12, i1_12, i2_12, i3_12])
                T.reads(T_add_2[i0_13, i1_13, i2_13, i3_13])
                T.writes(compute[i0_13, i1_13, i2_13, i3_13])
                compute[i0_13, i1_13, i2_13, i3_13] = T.max(T.min(T_add_2[i0_13, i1_13, i2_13, i3_13], 255), 0)
```
, we want to `AutoInline` "compute_3", "T_add_2" and "compute_4". If the order is "T_add_2" -> "compute_3" -> "compute_4", all three blocks can be inlined / reverse inlined to "compute_2". However, if the order is "T_add_2" -> "compute_4" -> "compute_3" , "compute_4" can neither be inlined or reverse inlined. This in turn can result in a buggy schedule to be generated (see the description in the test case).

We can avoid this problem by always `AutoInlin`ing the last block after all other blocks have been processed. This ensures that the last block can be reverse inlined. 

@vinx13 @junrushao @zxybazh 