### PR TITLE
    Split standard_crt build step into separate script to not build standard_crt on hexagon

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-10-19T13:44:32.119961
+// Generated at 2022-11-09T10:13:32.613722
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -1755,7 +1755,6 @@ def shard_run_test_Hexagon_1_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               cpp_unittest(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1816,7 +1815,6 @@ def shard_run_test_Hexagon_2_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1876,7 +1874,6 @@ def shard_run_test_Hexagon_3_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1936,7 +1933,6 @@ def shard_run_test_Hexagon_4_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1996,7 +1992,6 @@ def shard_run_test_Hexagon_5_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2056,7 +2051,6 @@ def shard_run_test_Hexagon_6_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2116,7 +2110,6 @@ def shard_run_test_Hexagon_7_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2176,7 +2169,6 @@ def shard_run_test_Hexagon_8_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1755,7 +1755,7 @@ def shard_run_test_Hexagon_1_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               cpp_unittest(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1816,7 +1816,7 @@ def shard_run_test_Hexagon_2_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1876,7 +1876,7 @@ def shard_run_test_Hexagon_3_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1936,7 +1936,7 @@ def shard_run_test_Hexagon_4_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1996,7 +1996,7 @@ def shard_run_test_Hexagon_5_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2056,7 +2056,7 @@ def shard_run_test_Hexagon_6_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2116,7 +2116,7 @@ def shard_run_test_Hexagon_7_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2176,7 +2176,7 @@ def shard_run_test_Hexagon_8_of_8() {
                       )
 
               add_hexagon_permissions()
-              ci_setup(ci_hexagon)
+              // ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-11-09T10:13:32.613722
+// Generated at 2022-11-10T11:17:27.113676
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -661,6 +661,13 @@ def ci_setup(image) {
   )
 }
 
+def standalone_crt_build(image) {
+  sh (
+    script: "${docker_run} ${image} ./tests/scripts/task_standalone_crt.sh",
+    label: 'Build standalone_crt',
+  )
+}
+
 def python_unittest(image) {
   sh (
     script: "${docker_run} ${image} ./tests/scripts/task_python_unittest.sh",
@@ -816,6 +823,7 @@ stage('Build') {
             label: 'Upload artifacts to S3',
           )
 
+          standalone_crt_build(ci_cpu)
           ci_setup(ci_cpu)
           // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
           // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
@@ -874,6 +882,7 @@ stage('Build') {
           )
           make(ci_wasm, 'build', '-j2')
           cpp_unittest(ci_wasm)
+          standalone_crt_build(ci_wasm)
           ci_setup(ci_wasm)
           sh (
             script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",
@@ -1122,6 +1131,7 @@ def shard_run_unittest_GPU_1_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               cpp_unittest(ci_gpu)
               sh (
@@ -1187,6 +1197,7 @@ def shard_run_unittest_GPU_2_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_java_unittest.sh",
@@ -1255,6 +1266,7 @@ def shard_run_unittest_GPU_3_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_unittest_gpuonly.sh",
@@ -1322,6 +1334,7 @@ def shard_run_integration_CPU_1_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_cpu)
               ci_setup(ci_cpu)
               sh (
                 script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
@@ -1384,6 +1397,7 @@ def shard_run_integration_CPU_2_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_cpu)
               ci_setup(ci_cpu)
               sh (
                 script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
@@ -1446,6 +1460,7 @@ def shard_run_integration_CPU_3_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_cpu)
               ci_setup(ci_cpu)
               sh (
                 script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
@@ -1508,6 +1523,7 @@ def shard_run_integration_CPU_4_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_cpu)
               ci_setup(ci_cpu)
               sh (
                 script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
@@ -1569,6 +1585,7 @@ def shard_run_python_i386_1_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_i386)
               ci_setup(ci_i386)
               cpp_unittest(ci_i386)
               python_unittest(ci_i386)
@@ -1631,6 +1648,7 @@ def shard_run_python_i386_2_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_i386)
               ci_setup(ci_i386)
               python_unittest(ci_i386)
               sh (
@@ -1693,6 +1711,7 @@ def shard_run_python_i386_3_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_i386)
               ci_setup(ci_i386)
               python_unittest(ci_i386)
               sh (
@@ -1754,6 +1773,7 @@ def shard_run_test_Hexagon_1_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               cpp_unittest(ci_hexagon)
               sh (
@@ -1814,6 +1834,7 @@ def shard_run_test_Hexagon_2_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1873,6 +1894,7 @@ def shard_run_test_Hexagon_3_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1932,6 +1954,7 @@ def shard_run_test_Hexagon_4_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1991,6 +2014,7 @@ def shard_run_test_Hexagon_5_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -2050,6 +2074,7 @@ def shard_run_test_Hexagon_6_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -2109,6 +2134,7 @@ def shard_run_test_Hexagon_7_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -2168,6 +2194,7 @@ def shard_run_test_Hexagon_8_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
+              ci_setup(ci_hexagon)
               add_hexagon_permissions()
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -2229,6 +2256,7 @@ def shard_run_integration_aarch64_1_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               python_unittest(ci_arm)
               sh (
@@ -2290,6 +2318,7 @@ def shard_run_integration_aarch64_2_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               python_unittest(ci_arm)
               sh (
@@ -2351,6 +2380,7 @@ def shard_run_integration_aarch64_3_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               python_unittest(ci_arm)
               sh (
@@ -2412,6 +2442,7 @@ def shard_run_integration_aarch64_4_of_4() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               python_unittest(ci_arm)
               sh (
@@ -2474,6 +2505,7 @@ def shard_run_topi_GPU_1_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh",
@@ -2534,6 +2566,7 @@ def shard_run_topi_GPU_2_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh",
@@ -2594,6 +2627,7 @@ def shard_run_topi_GPU_3_of_3() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh",
@@ -2655,6 +2689,7 @@ def shard_run_frontend_GPU_1_of_6() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -2715,6 +2750,7 @@ def shard_run_frontend_GPU_2_of_6() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -2775,6 +2811,7 @@ def shard_run_frontend_GPU_3_of_6() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -2835,6 +2872,7 @@ def shard_run_frontend_GPU_4_of_6() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -2895,6 +2933,7 @@ def shard_run_frontend_GPU_5_of_6() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -2955,6 +2994,7 @@ def shard_run_frontend_GPU_6_of_6() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_gpu)
               ci_setup(ci_gpu)
               sh (
                 script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -3016,6 +3056,7 @@ def shard_run_topi_aarch64_1_of_2() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               cpp_unittest(ci_arm)
               sh (
@@ -3081,6 +3122,7 @@ def shard_run_topi_aarch64_2_of_2() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_arm_compute_library.sh",
@@ -3146,6 +3188,7 @@ def shard_run_frontend_aarch64_1_of_2() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
@@ -3206,6 +3249,7 @@ def shard_run_frontend_aarch64_2_of_2() {
                         label: 'Download artifacts from S3',
                       )
 
+              standalone_crt_build(ci_arm)
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
@@ -3267,6 +3311,7 @@ def shard_run_test_Cortex_M_1_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               cpp_unittest(ci_cortexm)
               sh (
@@ -3332,6 +3377,7 @@ def shard_run_test_Cortex_M_2_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3392,6 +3438,7 @@ def shard_run_test_Cortex_M_3_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3452,6 +3499,7 @@ def shard_run_test_Cortex_M_4_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3512,6 +3560,7 @@ def shard_run_test_Cortex_M_5_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3572,6 +3621,7 @@ def shard_run_test_Cortex_M_6_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3632,6 +3682,7 @@ def shard_run_test_Cortex_M_7_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3692,6 +3743,7 @@ def shard_run_test_Cortex_M_8_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3752,6 +3804,7 @@ def shard_run_test_Cortex_M_9_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3812,6 +3865,7 @@ def shard_run_test_Cortex_M_10_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3872,6 +3926,7 @@ def shard_run_test_Cortex_M_11_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3932,6 +3987,7 @@ def shard_run_test_Cortex_M_12_of_12() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_cortexm)
               ci_setup(ci_cortexm)
               sh (
                 script: "${docker_run} ${ci_cortexm} ./tests/scripts/task_python_microtvm.sh",
@@ -3993,6 +4049,7 @@ def shard_run_test_RISC_V_1_of_1() {
                       )
 
               add_microtvm_permissions()
+              standalone_crt_build(ci_riscv)
               ci_setup(ci_riscv)
               cpp_unittest(ci_cortexm)
               sh (
@@ -4257,6 +4314,7 @@ stage('Test') {
                         label: 'Download artifacts from S3',
                       )
 
+                standalone_crt_build(ci_cpu)
                 ci_setup(ci_cpu)
                 cpp_unittest(ci_cpu)
                 python_unittest(ci_cpu)
@@ -4316,6 +4374,7 @@ stage('Test') {
                         label: 'Download artifacts from S3',
                       )
 
+                standalone_crt_build(ci_cpu)
                 ci_setup(ci_cpu)
                 sh (
                   script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_frontend_cpu.sh",
@@ -4370,6 +4429,7 @@ stage('Test') {
 
           add_microtvm_permissions()
           timeout(time: 180, unit: 'MINUTES') {
+            standalone_crt_build(ci_gpu)
             ci_setup(ci_gpu)
             sh (
               script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_docs.sh",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1755,7 +1755,7 @@ def shard_run_test_Hexagon_1_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               cpp_unittest(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1816,7 +1816,7 @@ def shard_run_test_Hexagon_2_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1876,7 +1876,7 @@ def shard_run_test_Hexagon_3_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1936,7 +1936,7 @@ def shard_run_test_Hexagon_4_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1996,7 +1996,7 @@ def shard_run_test_Hexagon_5_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2056,7 +2056,7 @@ def shard_run_test_Hexagon_6_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2116,7 +2116,7 @@ def shard_run_test_Hexagon_7_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2176,7 +2176,7 @@ def shard_run_test_Hexagon_8_of_8() {
                       )
 
               add_hexagon_permissions()
-              // ci_setup(ci_hexagon)
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-11-10T11:17:27.113676
+// Generated at 2022-11-10T11:23:40.325082
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -1773,8 +1773,8 @@ def shard_run_test_Hexagon_1_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               cpp_unittest(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
@@ -1834,8 +1834,8 @@ def shard_run_test_Hexagon_2_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1894,8 +1894,8 @@ def shard_run_test_Hexagon_3_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -1954,8 +1954,8 @@ def shard_run_test_Hexagon_4_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2014,8 +2014,8 @@ def shard_run_test_Hexagon_5_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2074,8 +2074,8 @@ def shard_run_test_Hexagon_6_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2134,8 +2134,8 @@ def shard_run_test_Hexagon_7_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',
@@ -2194,8 +2194,8 @@ def shard_run_test_Hexagon_8_of_8() {
                         label: 'Download artifacts from S3',
                       )
 
-              ci_setup(ci_hexagon)
               add_hexagon_permissions()
+              ci_setup(ci_hexagon)
               sh (
                 script: "${docker_run} ${ci_hexagon} ./tests/scripts/task_python_hexagon.sh",
                 label: 'Run Hexagon tests',

--- a/ci/jenkins/Build.groovy.j2
+++ b/ci/jenkins/Build.groovy.j2
@@ -5,6 +5,13 @@ def ci_setup(image) {
   )
 }
 
+def standalone_crt_build(image) {
+  sh (
+    script: "${docker_run} ${image} ./tests/scripts/task_standalone_crt.sh",
+    label: 'Build standalone_crt',
+  )
+}
+
 def python_unittest(image) {
   sh (
     script: "${docker_run} ${image} ./tests/scripts/task_python_unittest.sh",
@@ -111,6 +118,7 @@ stage('Build') {
     )
     make(ci_cpu, 'build', '-j2')
     {{ m.upload_artifacts(tag='cpu', filenames=tvm_multilib_tsim) }}
+    standalone_crt_build(ci_cpu)
     ci_setup(ci_cpu)
     // sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
     // TODO(@jroesch): need to resolve CI issue will turn back on in follow up patch
@@ -145,6 +153,7 @@ stage('Build') {
     )
     make(ci_wasm, 'build', '-j2')
     cpp_unittest(ci_wasm)
+    standalone_crt_build(ci_wasm)
     ci_setup(ci_wasm)
     sh (
       script: "${docker_run} ${ci_wasm} ./tests/scripts/task_web_wasm.sh",

--- a/ci/jenkins/Test.groovy.j2
+++ b/ci/jenkins/Test.groovy.j2
@@ -92,8 +92,8 @@
   num_shards=8,
 ) %}
   {{ m.download_artifacts(tag='hexagon', filenames=tvm_lib, folders=hexagon_api) }}
-  ci_setup(ci_hexagon)
   add_hexagon_permissions()
+  ci_setup(ci_hexagon)
   {% if shard_index == 1 %}
   cpp_unittest(ci_hexagon)
   {% endif %}

--- a/ci/jenkins/Test.groovy.j2
+++ b/ci/jenkins/Test.groovy.j2
@@ -89,7 +89,6 @@
 ) %}
   {{ m.download_artifacts(tag='hexagon', filenames=tvm_lib, folders=hexagon_api) }}
   add_hexagon_permissions()
-  ci_setup(ci_hexagon)
   {% if shard_index == 1 %}
   cpp_unittest(ci_hexagon)
   {% endif %}

--- a/ci/jenkins/Test.groovy.j2
+++ b/ci/jenkins/Test.groovy.j2
@@ -18,10 +18,12 @@
   cpp_unittest(ci_gpu)
 
   {{ m.download_artifacts(tag='gpu', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_gpu)
   ci_setup(ci_gpu)
   cpp_unittest(ci_gpu)
   {% else %}
   {{ m.download_artifacts(tag='gpu', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_gpu)
   ci_setup(ci_gpu)
   {% endif %}
   {% if shard_index == 2 or num_shards < 2 %}
@@ -49,6 +51,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='cpu', filenames=tvm_multilib_tsim) }}
+  standalone_crt_build(ci_cpu)
   ci_setup(ci_cpu)
   sh (
     script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh",
@@ -65,6 +68,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='i386', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_i386)
   ci_setup(ci_i386)
   {% if shard_index == 1 %}
   cpp_unittest(ci_i386)
@@ -88,6 +92,7 @@
   num_shards=8,
 ) %}
   {{ m.download_artifacts(tag='hexagon', filenames=tvm_lib, folders=hexagon_api) }}
+  ci_setup(ci_hexagon)
   add_hexagon_permissions()
   {% if shard_index == 1 %}
   cpp_unittest(ci_hexagon)
@@ -107,6 +112,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='arm', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_arm)
   ci_setup(ci_arm)
   python_unittest(ci_arm)
   sh (
@@ -124,6 +130,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='gpu', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_gpu)
   ci_setup(ci_gpu)
   sh (
     script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_topi.sh",
@@ -140,6 +147,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='gpu', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_gpu)
   ci_setup(ci_gpu)
   sh (
     script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_frontend.sh",
@@ -156,6 +164,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='arm', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_arm)
   ci_setup(ci_arm)
   {% if shard_index == 1 %}
   cpp_unittest(ci_arm)
@@ -179,6 +188,7 @@
   test_method_names=test_method_names,
 ) %}
   {{ m.download_artifacts(tag='arm', filenames=tvm_multilib) }}
+  standalone_crt_build(ci_arm)
   ci_setup(ci_arm)
   sh (
     script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
@@ -196,6 +206,7 @@
 ) %}
   {{ m.download_artifacts(tag='cortexm', filenames=tvm_lib, folders=microtvm_template_projects) }}
   add_microtvm_permissions()
+  standalone_crt_build(ci_cortexm)
   ci_setup(ci_cortexm)
   {% if shard_index == 1%}
   cpp_unittest(ci_cortexm)
@@ -220,6 +231,7 @@
 ) %}
   {{ m.download_artifacts(tag='riscv', filenames=tvm_lib, folders=microtvm_template_projects) }}
   add_microtvm_permissions()
+  standalone_crt_build(ci_riscv)
   ci_setup(ci_riscv)
   {% if shard_index == 1%}
   cpp_unittest(ci_cortexm)
@@ -266,6 +278,7 @@ stage('Test') {
     docker_image="ci_cpu",
   ) %}
     {{ m.download_artifacts(tag='cpu', filenames=tvm_multilib_tsim) }}
+    standalone_crt_build(ci_cpu)
     ci_setup(ci_cpu)
     cpp_unittest(ci_cpu)
     python_unittest(ci_cpu)
@@ -283,6 +296,7 @@ stage('Test') {
     docker_image="ci_cpu",
 ) %}
     {{ m.download_artifacts(tag='cpu', filenames=tvm_multilib) }}
+    standalone_crt_build(ci_cpu)
     ci_setup(ci_cpu)
     sh (
       script: "${docker_run} ${ci_cpu} ./tests/scripts/task_python_frontend_cpu.sh",
@@ -298,6 +312,7 @@ stage('Test') {
           {{ m.download_artifacts(tag='gpu', filenames=tvm_multilib, folders=microtvm_template_projects) }}
           add_microtvm_permissions()
           timeout(time: 180, unit: 'MINUTES') {
+            standalone_crt_build(ci_gpu)
             ci_setup(ci_gpu)
             sh (
               script: "${docker_run} ${ci_gpu} ./tests/scripts/task_python_docs.sh",

--- a/tests/scripts/task_standalone_crt.sh
+++ b/tests/scripts/task_standalone_crt.sh
@@ -18,9 +18,11 @@
 
 set -euxo pipefail
 
-echo "Additional setup in ${CI_IMAGE_NAME}"
+echo "Build standalone_crt in ${CI_IMAGE_NAME}"
 
-# Ensure no stale pytest-results remain from a previous test run.
-pushd build
-rm -rf pytest-results
-popd
+# Rebuild standalone_crt in build/ tree. This file is not currently archived by pack_lib() in
+# Jenkinsfile. We expect config.cmake to be present from pack_lib().
+# TODO(areusch): Make pack_lib() pack all the data dependencies of TVM.
+python3 tests/scripts/task_build.py \
+    --sccache-bucket tvm-sccache-prod \
+    --cmake-target standalone_crt


### PR DESCRIPTION
Split standard_crt build step into separate script to not build standard_crt on hexagon.