### PR TITLE
[TOPI] Fix conv2d transpose for small channel

### DIFF
--- a/python/tvm/topi/cuda/conv2d_transpose.py
+++ b/python/tvm/topi/cuda/conv2d_transpose.py
@@ -161,7 +161,7 @@ def schedule_conv2d_transpose_nchw(cfg, outs):
             cfg["tile_n"] = SplitEntity([1, 1, 1, 1])
         # split F (output channel dimension)
         if F > 1:
-            cfg["tile_f"] = SplitEntity([-1, 1, 64, 1])
+            cfg["tile_f"] = SplitEntity([-1, 1, 4, 1])
         # split Y (height dimension)
         y_split_factor = 1
         for candidate in range(5, 17):

--- a/tests/python/topi/python/test_topi_group_conv2d_transpose.py
+++ b/tests/python/topi/python/test_topi_group_conv2d_transpose.py
@@ -158,9 +158,7 @@ def test_group_conv2d_transpose_nchw():
     verify_group_conv2d_transpose_nchw(
         1, 3, (224, 224), 32, (3, 3), (2, 2), (1, 1, 1, 1), (0, 0), 1
     )
-    verify_group_conv2d_transpose_nchw(
-        1, 48, (64, 64), 12, (4, 4), (2, 2), (1, 1, 1, 1), (0, 0), 1
-    )
+    verify_group_conv2d_transpose_nchw(1, 48, (64, 64), 12, (4, 4), (2, 2), (1, 1, 1, 1), (0, 0), 1)
 
 
 if __name__ == "__main__":

--- a/tests/python/topi/python/test_topi_group_conv2d_transpose.py
+++ b/tests/python/topi/python/test_topi_group_conv2d_transpose.py
@@ -158,6 +158,9 @@ def test_group_conv2d_transpose_nchw():
     verify_group_conv2d_transpose_nchw(
         1, 3, (224, 224), 32, (3, 3), (2, 2), (1, 1, 1, 1), (0, 0), 1
     )
+    verify_group_conv2d_transpose_nchw(
+        1, 48, (64, 64), 12, (4, 4), (2, 2), (1, 1, 1, 1), (0, 0), 1
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the issue reported in https://discuss.tvm.apache.org/t/model-compilation-fails-on-gpu-target/13866

For certain `conv2d_transpose` workloads, we get funny allocations like
```
 allocate data_pad[float32 * ((floordiv(((blockIdx.y*2) + 1), 3)*4608) + 576)], storage_scope = shared
 allocate p1.shared[float32 * ((floordiv(((blockIdx.y*2) + 1), 3)*12288) + 1536)], storage_scope = shared
```

This is apparently due to trying to split a small channel by a large factor. 

cc @vinx13 