### PR TITLE
[Docker]Refactor timezone script and NRF installation

### DIFF
--- a/apps/microtvm/reference-vm/base-box-tool.py
+++ b/apps/microtvm/reference-vm/base-box-tool.py
@@ -61,6 +61,7 @@ EXTRA_SCRIPTS = [
     "docker/install/ubuntu_init_zephyr_project.sh",
     "docker/install/ubuntu_install_zephyr_sdk.sh",
     "docker/install/ubuntu_install_cmsis.sh",
+    "docker/install/ubuntu_install_nrfjprog.sh",
 ]
 
 PACKER_FILE_NAME = "packer.json"

--- a/apps/microtvm/reference-vm/base-box/base_box_setup.sh
+++ b/apps/microtvm/reference-vm/base-box/base_box_setup.sh
@@ -36,22 +36,8 @@ sed -i "/^# If not running interactively,/ i export ZEPHYR_BASE=$HOME/zephyr/zep
 sed -i "/^# If not running interactively,/ i\\ " ~/.bashrc
 
 # nrfjprog
-NRF_COMMANDLINE_TOOLS_FILE=nRFCommandLineToolsLinuxamd64.tar.gz
-NRF_COMMANDLINE_TOOLS_URL=https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxamd64.tar.gz
-NRF_COMMANDLINE_TOOLS_INSTALLER=nRF-Command-Line-Tools_10_12_1_Linux-amd64.deb
-JLINK_LINUX_INSTALLER=JLink_Linux_V688a_x86_64.deb
-
-cd ~
-mkdir -p nrfjprog
-wget --no-verbose -O $NRF_COMMANDLINE_TOOLS_FILE $NRF_COMMANDLINE_TOOLS_URL
-cd nrfjprog
-tar -xzvf "../${NRF_COMMANDLINE_TOOLS_FILE}"
-sudo apt install -y "./${JLINK_LINUX_INSTALLER}"
-sudo apt install -y "./${NRF_COMMANDLINE_TOOLS_INSTALLER}"
-source ~/.profile
-nrfjprog --help
-cd ..
-rm -rf nrfjprog "${NRF_COMMANDLINE_TOOLS_FILE}"
+sudo ~/ubuntu_install_nrfjprog.sh
+rm -f ~/ubuntu_install_nrfjprog.sh
 
 # Zephyr
 pip3 install --user -U west

--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -26,6 +26,9 @@ RUN apt-get update --fix-missing
 
 RUN apt-install-and-clear -y ca-certificates gnupg2
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_cortexm
+++ b/docker/Dockerfile.ci_cortexm
@@ -23,6 +23,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_cortexm
+++ b/docker/Dockerfile.ci_cortexm
@@ -84,6 +84,10 @@ RUN bash /install/ubuntu_install_zephyr.sh
 ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
 ENV PATH /opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
 
+# NRF
+COPY install/ubuntu_install_nrfjprog.sh /install/ubuntu_install_nrfjprog.sh
+RUN bash /install/ubuntu_install_nrfjprog.sh
+
 # FreeRTOS deps
 COPY install/ubuntu_install_freertos.sh /install/ubuntu_install_freertos.sh
 RUN bash /install/ubuntu_install_freertos.sh

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -22,6 +22,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -29,6 +29,9 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 RUN rm -f /etc/apt/sources.list.d/nvidia-ml.list && apt-get clean
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_hexagon
+++ b/docker/Dockerfile.ci_hexagon
@@ -25,6 +25,9 @@ RUN apt-get update --fix-missing
 
 RUN apt-install-and-clear -y ca-certificates gnupg2 libxml2-dev
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_i386
+++ b/docker/Dockerfile.ci_i386
@@ -26,6 +26,9 @@ RUN apt-get update --fix-missing
 
 RUN apt-install-and-clear -y ca-certificates
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_minimal
+++ b/docker/Dockerfile.ci_minimal
@@ -22,6 +22,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_riscv
+++ b/docker/Dockerfile.ci_riscv
@@ -23,6 +23,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.ci_wasm
+++ b/docker/Dockerfile.ci_wasm
@@ -20,6 +20,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.demo_android
+++ b/docker/Dockerfile.demo_android
@@ -22,6 +22,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.demo_rocm
+++ b/docker/Dockerfile.demo_rocm
@@ -20,6 +20,9 @@ FROM ubuntu:18.04
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.demo_vitis_ai
+++ b/docker/Dockerfile.demo_vitis_ai
@@ -22,6 +22,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -23,6 +23,9 @@ COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 
 RUN apt-get update --fix-missing
 
+COPY install/ubuntu_setup_tz.sh /install/ubuntu_setup_tz.sh
+RUN bash /install/ubuntu_setup_tz.sh
+
 COPY install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh
 

--- a/docker/install/ubuntu_install_nrfjprog.sh
+++ b/docker/install/ubuntu_install_nrfjprog.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+set -x
+
+NRF_COMMANDLINE_TOOLS_FILE=nRFCommandLineToolsLinuxamd64.tar.gz
+NRF_COMMANDLINE_TOOLS_URL=https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxamd64.tar.gz
+NRF_COMMANDLINE_TOOLS_INSTALLER=nRF-Command-Line-Tools_10_12_1_Linux-amd64.deb
+JLINK_LINUX_INSTALLER=JLink_Linux_V688a_x86_64.deb
+
+cd ~
+mkdir -p nrfjprog
+wget --no-verbose -O $NRF_COMMANDLINE_TOOLS_FILE $NRF_COMMANDLINE_TOOLS_URL
+
+cd nrfjprog
+tar -xzvf "../${NRF_COMMANDLINE_TOOLS_FILE}"
+apt-install-and-clear -y "./${JLINK_LINUX_INSTALLER}"
+apt-install-and-clear -y "./${NRF_COMMANDLINE_TOOLS_INSTALLER}"
+
+cd ..
+rm -rf nrfjprog "${NRF_COMMANDLINE_TOOLS_FILE}"

--- a/docker/install/ubuntu_setup_tz.sh
+++ b/docker/install/ubuntu_setup_tz.sh
@@ -22,25 +22,6 @@ set -u
 set -x
 set -o pipefail
 
-# install libraries for building c++ core on ubuntu
-apt-get update && apt-install-and-clear -y --no-install-recommends \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    g++ \
-    gdb \
-    git \
-    graphviz \
-    libcurl4-openssl-dev \
-    libopenblas-dev \
-    libssl-dev \
-    libtinfo-dev \
-    libz-dev \
-    lsb-core \
-    make \
-    ninja-build \
-    parallel \
-    pkg-config \
-    sudo \
-    unzip \
-    wget \
+export TZ=Etc/UTC
+ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+echo $TZ > /etc/timezone

--- a/docker/install/ubuntu_setup_tz.sh
+++ b/docker/install/ubuntu_setup_tz.sh
@@ -18,8 +18,6 @@
 
 set -e
 set -u
-# Used for debugging RVM build
-set -x
 set -o pipefail
 
 export TZ=Etc/UTC


### PR DESCRIPTION
This PR refactors timezone setup to a separate script that docker/install/ubuntu_install_core.sh
Also, it adds a script to install NRF and reused in both cortexm docker and RVM installation path. 