### PR TITLE
[TIR][Schedule] Make consistent implementation for GetProducers() & GetConsumers()

### DIFF
--- a/src/tir/schedule/primitive/get_block_loop.cc
+++ b/src/tir/schedule/primitive/get_block_loop.cc
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include "../analysis.h"
 #include "../utils.h"
 
 namespace tvm {
@@ -79,34 +80,12 @@ Array<StmtSRef> GetChildBlocks(const ScheduleState& self, const StmtSRef& parent
 
 Array<StmtSRef> GetProducers(const ScheduleState& self, const StmtSRef& block_sref) {
   StmtSRef scope_root = GetScopeRoot(self, block_sref, /*require_stage_pipeline=*/false);
-  Array<Dependency> edges = self->GetBlockScope(scope_root)->GetDepsByDst(block_sref);
-  Array<StmtSRef> results;
-  std::unordered_set<StmtSRef, ObjectPtrHash, ObjectPtrEqual> result_set;
-  results.reserve(edges.size());
-  for (const Dependency& edge : edges) {
-    if ((edge->kind == DepKind::kRAW || edge->kind == DepKind::kWAW) &&
-        !result_set.count(edge->src)) {
-      results.push_back(edge->src);
-      result_set.emplace(edge->src);
-    }
-  }
-  return results;
+  return tir::GetProducers(block_sref, self->GetBlockScope(scope_root));
 }
 
 Array<StmtSRef> GetConsumers(const ScheduleState& self, const StmtSRef& block_sref) {
   StmtSRef scope_root = GetScopeRoot(self, block_sref, /*require_stage_pipeline=*/false);
-  Array<Dependency> edges = self->GetBlockScope(scope_root)->GetDepsBySrc(block_sref);
-  Array<StmtSRef> results;
-  std::unordered_set<StmtSRef, ObjectPtrHash, ObjectPtrEqual> result_set;
-  results.reserve(edges.size());
-  for (const Dependency& edge : edges) {
-    if ((edge->kind == DepKind::kRAW || edge->kind == DepKind::kWAW) &&
-        !result_set.count(edge->dst)) {
-      results.push_back(edge->dst);
-      result_set.emplace(edge->dst);
-    }
-  }
-  return results;
+  return tir::GetConsumers(block_sref, self->GetBlockScope(scope_root));
 }
 
 /******** InstructionKind Registration ********/


### PR DESCRIPTION
Currently there are two versions of `GetConsumers()` and `GetProducers()` implementation. Make them consistent to avoid possible bug when there are WAR dependencies.