### PR TITLE
[MetaSchedule] Unannotate `schedule_rule` if corresponding schedule func is not found

### DIFF
--- a/src/meta_schedule/schedule_rule/apply_custom_rule.cc
+++ b/src/meta_schedule/schedule_rule/apply_custom_rule.cc
@@ -54,7 +54,7 @@ class ApplyCustomRuleNode : public ScheduleRuleNode {
           os << "\n  " << GetCustomRuleName(ann.value(), key);
         }
         LOG(WARNING) << os.str();
-	sch->Unannotate(block_rv, "schedule_rule");
+        sch->Unannotate(block_rv, "schedule_rule");
       }
     }
     return {sch};

--- a/src/meta_schedule/schedule_rule/apply_custom_rule.cc
+++ b/src/meta_schedule/schedule_rule/apply_custom_rule.cc
@@ -54,6 +54,7 @@ class ApplyCustomRuleNode : public ScheduleRuleNode {
           os << "\n  " << GetCustomRuleName(ann.value(), key);
         }
         LOG(WARNING) << os.str();
+	sch->Unannotate(block_rv, "schedule_rule");
       }
     }
     return {sch};

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -141,6 +141,12 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
           stack.emplace_back(sch, blocks);
           continue;
         }
+        if (!ScheduleRule::IsApplyCustomRule(sch_rule)) {
+          if (tir::GetAnn<String>(sch->GetSRef(block_rv), "schedule_rule").defined()) {
+            stack.emplace_back(sch, blocks);
+            continue;
+          }
+        }
         Array<tir::Schedule> applied = sch_rule->Apply(sch, /*block=*/block_rv);
         for (const tir::Schedule& sch : applied) {
           stack.emplace_back(sch, blocks);

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -141,12 +141,6 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
           stack.emplace_back(sch, blocks);
           continue;
         }
-        if (!ScheduleRule::IsApplyCustomRule(sch_rule)) {
-          if (tir::GetAnn<String>(sch->GetSRef(block_rv), "schedule_rule").defined()) {
-            stack.emplace_back(sch, blocks);
-            continue;
-          }
-        }
         Array<tir::Schedule> applied = sch_rule->Apply(sch, /*block=*/block_rv);
         for (const tir::Schedule& sch : applied) {
           stack.emplace_back(sch, blocks);

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -31,6 +31,7 @@ from tvm.tir.tensor_intrin.rocm import AMDGPU_SDOT4_INTRIN
 from tvm.tir.tensor_intrin.x86 import VNNI_DOT_16x4_INTRIN as VNNI_INTRIN
 
 SCH_RULES_FOR_VNNI = [
+    ms.schedule_rule.ApplyCustomRule(),
     ms.schedule_rule.AutoInline(
         into_producer=False,
         into_consumer=True,


### PR DESCRIPTION
Currently, if there is a block annotated with `schedule_rule`, only the corresponding custom rule is allowed to be applied to the block. This led to the breakage of auto tensorization as discussed in https://github.com/apache/tvm/pull/13195#discussion_r1018952166.

The fix is to unannotate `schedule_rule` if the corresponding schedule func is not found, to let other schedule rules process this block.

cc @junrushao @zxybazh 