### PR TITLE
[TIR][Arith] Fix divisor checking in `TryConstFold`

### DIFF
--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -236,7 +236,8 @@ inline Optional<PrimExpr> TryConstFold<tir::Div>(PrimExpr a, PrimExpr b) {
       if (pb->value == 1) return a;
       ICHECK_NE(pb->value, 0) << "Divide by zero";
     }
-    if (fa && fb && fb->value != 0) {
+    if (fa && fb) {
+      ICHECK_NE(fb->value, 0) << "Divide by zero";
       if (rtype.bits() == 32) {
         return FloatImm(rtype, GetFoldResultDoubleRepr(static_cast<float>(fa->value) /
                                                        static_cast<float>(fb->value)));


### PR DESCRIPTION
This PR fixes the checking of devisor in constant folding of `tir::Div`. If the expression is `0. / 0.`, previous implementation directly folds it to `0.` without checking the divisor. It seems that `fb->value != 0` should not be in the `if` condition, but should be checked in the body instead. After this fix, folding `0. / 0.` leads to an assertion failure instead of `0.`. 

Here is a piece of simple testing code:`tir.FloatImm('float32', 0.) / tir.FloatImm('float32', 0.)`. And the following is the error report (which is expected):
```
Traceback (most recent call last):
  File "/Users/tvm-bug/bug_divide_zero.py", line 5, in <module>
    tir.PrimFunc([], tir.Evaluate(tir.FloatImm('float32', 0.) / tir.FloatImm('float32', 0.)))
  File "/Users/wzh/tvm-dev/python/tvm/tir/expr.py", line 102, in __truediv__
    return _generic.divide(self, other)
  File "/Users/wzh/tvm-dev/python/tvm/topi/generic_op_impl.py", line 83, in _tensor_bop_impl
    return orig_bop(lhs, rhs)
  File "/Users/wzh/tvm-dev/python/tvm/tir/generic.py", line 106, in divide
    return _ffi_api._OpDiv(lhs, rhs, span)  # type: ignore
  File "/Users/wzh/tvm-dev/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  [bt] (7) 8   ???                                 0x00007ff7b51f0cf0 0x0 + 140701872360688
  [bt] (6) 7   _ctypes.cpython-38-darwin.so        0x000000010affdfb7 ffi_call_unix64 + 79
  [bt] (5) 6   libtvm.dylib                        0x000000011df22ace TVMFuncCall + 62
  [bt] (4) 5   libtvm.dylib                        0x000000011cbb8f36 tvm::runtime::PackedFuncObj::Extractor<tvm::runtime::PackedFuncSubObj<void tvm::runtime::TypedPackedFunc<tvm::PrimExpr (tvm::PrimExpr, tvm::PrimExpr, tvm::Span)>::AssignTypedLambda<tvm::$_5>(tvm::$_5, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)::'lambda'(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*)> >::Call(tvm::runtime::PackedFuncObj const*, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) + 1078
  [bt] (3) 4   libtvm.dylib                        0x000000011cb9fd24 tvm::div(tvm::PrimExpr, tvm::PrimExpr, tvm::Span) + 132
  [bt] (2) 3   libtvm.dylib                        0x000000011c1926ce tvm::runtime::Optional<tvm::PrimExpr> tvm::arith::TryConstFold<tvm::tir::Div>(tvm::PrimExpr, tvm::PrimExpr) + 1934
  [bt] (1) 2   libtvm.dylib                        0x000000011c172c39 tvm::runtime::detail::LogFatal::Entry::Finalize() + 89
  [bt] (0) 1   libtvm.dylib                        0x000000011df3fd98 tvm::runtime::Backtrace() + 24
  File "/Users/wzh/tvm-dev/src/arith/const_fold.h", line 240
TVMError: 
---------------------------------------------------------------
An error occurred during the execution of TVM.
For more information, please see: https://tvm.apache.org/docs/errors.html
---------------------------------------------------------------

  Check failed: fb->value != 0 (0 vs. 0) : Divide by zero
```

cc @masahi 