### PR TITLE
[MetaSchedule] Fuse loops around shared to global store block in `MultiLevelTilingTensorCore`

### DIFF
--- a/src/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -269,8 +269,8 @@ std::vector<State> MultiLevelTilingNode::AddReadReuse(State state) const {
       sch->ComputeAt(cache_read_block, loop_rv, true);
       // Fuse the iterators of the cache_read
       Array<LoopRV> buffer_loops = sch->GetLoops(cache_read_block);
-      LoopRV fused = sch->Fuse(Array<LoopRV>{buffer_loops.end() - buffer_ndim,  //
-                                             buffer_loops.end()});
+      sch->Fuse(Array<LoopRV>{buffer_loops.end() - buffer_ndim,  //
+                              buffer_loops.end()});
       AnnotateCooperativeFetching(&sch, cache_read_block);
       new_state->read_reuse.emplace(i, cache_read_block);
     }

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -258,6 +258,11 @@ std::vector<State> MultiLevelTilingTensorCoreNode::AddWriteReuseTensorCore(
   sch->ReverseComputeAt(cache_write, loop, true);
 
   if (state->write_reuse.count(0)) {
+    // Fuse the iterators of the cache_write
+    Array<LoopRV> buffer_loops = sch->GetLoops(state->write_reuse[0]);
+    ICHECK_GT(buffer_loops.size(), 2);
+    sch->Fuse(Array<LoopRV>{buffer_loops.end() - 2,  // The src shmem is always 2D
+                            buffer_loops.end()});
     AnnotateCooperativeFetching(&sch, state->write_reuse[0]);
   }
   sch->ReverseComputeInline(state->tensor_core_reindex_store);


### PR DESCRIPTION
Currently, vectorization of shared to global store in tensor core auto tensorization is not done properly, since most blocks have the `T.where` predicate which disables vectorization. 

The predicate is introduced after `Split` in cooperative fetch: https://github.com/apache/tvm/blob/main/src/meta_schedule/postproc/rewrite_cooperative_fetch.cc#L159-L162
As the code says, this split is supposed to be applied to a fused loop. This is the case for cache read blocks, where `AddReadReuse` explicitly fuses loops around cache read blocks. But `AddWriteReuseTensorCore` doesn't fuse loops after cache write: https://github.com/apache/tvm/blob/main/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc#L260-L262. 

So for cache rewrite blocks, we always try to split a single axis by large factors like `[None, 4, 32, 2]`. Unless the sampled factor for the axis is large, we always get `T.where` in the shared to global copy block.

This PR adds the missing fusion. Now, all candidate samples have the shared to global copy block properly vectorized. But unfortunately, there was no perf improvement from this change after e2e tuning. 

For quantized workloads, vectorization of shared to global copy is disabled, since we end up vectorizing also requantization-related math, involving 64 bit arithmetic. The generated code fails to compile currently.

@vinx13 @junrushao 
