### PR TITLE
[Lint] Fix import in test_tvmscript_type.py

### DIFF
--- a/tests/python/unittest/test_tvmscript_type.py
+++ b/tests/python/unittest/test_tvmscript_type.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-function-docstring,missing-module-docstring,invalid-name,pointless-string-statement
-from tvm.script import tir as T
+from tvm.script.parser_v1 import tir as T
 
 """
 This prim func include necessary buffer types that need to be checked


### PR DESCRIPTION
#12496 does not patch an import that caused the linter to fail. This PR fixes it.

@driazati