### PR TITLE
[tvm4j] Fix tvm4j build on MacOS

### DIFF
--- a/jvm/native/osx-x86_64/pom.xml
+++ b/jvm/native/osx-x86_64/pom.xml
@@ -120,14 +120,14 @@ under the License.
           <compilerEndOptions>
             <compilerEndOption>-I../../../include</compilerEndOption>
             <compilerEndOption>-I${JAVA_HOME}/include</compilerEndOption>
-            <compilerEndOption>-I${JAVA_HOME}/include/linux</compilerEndOption
+            <compilerEndOption>-I${JAVA_HOME}/include/linux</compilerEndOption>
             <compilerEndOption>${cflags}</compilerEndOption>
           </compilerEndOptions>
           <linkerStartOptions>
             <linkerStartOption>-shared</linkerStartOption>
           </linkerStartOptions>
           <linkerMiddleOptions>
-            <linkerMiddleOption>-framework JavaVM</linkerMiddleOption>
+            <linkerMiddleOption>-framework JavaNativeFoundation</linkerMiddleOption>
             <linkerMiddleOption>-Wl,-exported_symbol,_Java_*</linkerMiddleOption>
             <linkerMiddleOption>-undefined dynamic_lookup</linkerMiddleOption>
             <linkerMiddleOption>-Wl,-x</linkerMiddleOption>


### PR DESCRIPTION
- Add missing bracket in pom file
- Replaced JavaVM on JavaNativeFoundation. From Xcode 12.1 (macOS 11 (Big Sur)) JavaVM framework is no longer includes to the frameworks list. Necessary to use JavaNativeFoundation instead.

cc: @apeskov, @jwfromm