### PR TITLE
This fix adds check for time result presence.

### DIFF
--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -43,6 +43,7 @@ class UpdateCostModelNode : public MeasureCallbackNode {
     pruned_runner_result.reserve(n);
     for (int i = 0; i < n; i++) {
       if (!builder_results[i]->error_msg.defined() &&
+          runner_results[i]->run_secs.defined() &&
           Sum(runner_results[i]->run_secs.value()) > 0) {
         pruned_candidate.push_back(measure_candidates[i]);
         pruned_runner_result.push_back(runner_results[i]);


### PR DESCRIPTION
 The cost mode can fail if run_secs value is not exist.