### PR TITLE
[Metaschedule] Add partition primitive

### DIFF
--- a/include/tvm/tir/schedule/state.h
+++ b/include/tvm/tir/schedule/state.h
@@ -44,7 +44,10 @@ struct BlockInfo {
   /*! \brief Property of a block scope rooted at the block, storing dependencies in the scope */
   BlockScope scope{nullptr};
   // The properties below are information about the current block realization under its parent scope
-  /*! \brief Property of a block, indicating the block realization binding is quasi-affine */
+  /*! \brief Property of a block, indicating the block realization binding is
+   * quasi-affine. All iter_vars of the block must be affine. Blocks without
+   * any iter_vars are considered to be affine_binding.
+   */
   bool affine_binding{false};
   /*!
    * \brief Property of a block, indicating each of the block's read regions is fully

--- a/include/tvm/tir/stmt_functor.h
+++ b/include/tvm/tir/stmt_functor.h
@@ -410,6 +410,44 @@ inline T Substitute(T input, const std::unordered_map<const VarNode*, PrimExpr>&
 }
 
 /*!
+ * \brief Replace one variable in the TIR with another. Replaces loop variables and block iter vars.
+ * \param stmt The source statement to be substituted
+ * \param vmap The map of new values.
+ * \return The result.
+ */
+Stmt VarSubstitute(Stmt stmt, std::function<Optional<Var>(const Var&)> vmap);
+
+/*!
+ * \brief Replace one variable in the TIR with another. Replaces loop variables and block iter vars.
+ * \param stmt The source statement to be substituted
+ * \param vmap The map of new values.
+ * \return The result.
+ */
+inline Stmt VarSubstitute(Stmt input, const Map<Var, Var>& value_map) {
+  auto vmap = [&](const Var& var) -> Optional<Var> {
+    auto it = value_map.find(var);
+    if (it != value_map.end()) return (*it).second;
+    return Optional<Var>(nullptr);
+  };
+  return VarSubstitute(std::move(input), vmap);
+}
+
+/*!
+ * \brief Replace one variable in the TIR with another. Replaces loop variables and block iter vars.
+ * \param stmt The source statement to be substituted
+ * \param vmap The map of new values.
+ * \return The result.
+ */
+inline Stmt VarSubstitute(Stmt input, const std::unordered_map<const VarNode*, Var>& value_map) {
+  auto vmap = [&](const Var& var) -> Optional<Var> {
+    auto it = value_map.find(var.get());
+    if (it != value_map.end()) return (*it).second;
+    return Optional<Var>(nullptr);
+  };
+  return VarSubstitute(std::move(input), vmap);
+}
+
+/*!
  * \brief Substitute the var specified by vmap and legalize data types after substitution.
  * \param stmt The source statement to be substituted
  * \param vmap returns a new value if re-mapping is needed, otherwise returns nullptr.

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -735,7 +735,11 @@ class Schedule(Object):
                                A[i] = T.float32(1)
 
         """
-        return list(_ffi_api.SchedulePartition(self, loop_rv, factor))
+        return list(
+            _ffi_api.SchedulePartition(  # type: ignore # pylint: disable=no-member
+                self, loop_rv, factor
+            )
+        )
 
     @type_checked
     def reorder(self, *ordered_loops: List[LoopRV]) -> None:

--- a/python/tvm/tir/schedule/testing.py
+++ b/python/tvm/tir/schedule/testing.py
@@ -75,7 +75,9 @@ def verify_trace_roundtrip(
     # Step 3. Check the consistency of the text format between the old and new traces
     py_repr = "\n".join(trace.as_python())
     new_py_repr = "\n".join(new_sch.trace.as_python())
-    assert py_repr == new_py_repr
+    assert (
+        py_repr == new_py_repr
+    ), f"Original python:\n{py_repr}\nRoundtripped python:\n{new_py_repr}"
 
     # Step 4. Return the new schedule in case it could be useful
     return new_sch

--- a/src/meta_schedule/postproc/rewrite_reduction_block.cc
+++ b/src/meta_schedule/postproc/rewrite_reduction_block.cc
@@ -84,7 +84,7 @@ struct ReductionBlockFinder : private StmtVisitor {
 };
 
 /*!
- * \brief Find the innermost loop that the `init` of the input block could be decomposed to
+ * \brief Find the outermost loop that the `init` of the input block could be decomposed to
  * \param block_sref The StmtSRef of the block to be decomposed
  * \return The index of the innermost loop where the `init` of the input block could be decomposed,
  * or -1 if the `init` does not need to be decomposed.

--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -759,7 +759,7 @@ struct VarSubstituter : public IRSubstitute {
           } else {
             return Optional<PrimExpr>();
           }
-        }){};
+        }) {}
 
   using IRSubstitute::VisitStmt_;
 

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -890,7 +890,7 @@ IterVarType GetLoopIterType(const StmtSRef& loop_sref) {
           }
         });
       }
-      return false;
+      return true;
     }
     return true;
   };

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -476,7 +476,7 @@ struct BlockRenamer : public StmtMutator {
   using StmtMutator::VisitStmt_;
 
   std::string suffix;
-  BlockRenamer(std::string suffix) : suffix(suffix){};
+  explicit BlockRenamer(std::string suffix) : suffix(suffix) {}
 
   Stmt VisitStmt_(const BlockNode* op) override {
     Block visited = Downcast<Block>(StmtMutator::VisitStmt_(op));
@@ -521,8 +521,8 @@ Stmt ReInitLoopVars(Stmt expr) {
 Array<LoopRV> ConcreteScheduleNode::Partition(const LoopRV& loop_rv, const ExprRV& factor_) {
   StmtSRef first_ref, second_ref;
   TVM_TIR_SCHEDULE_BEGIN();
-  // TODO: check that axis is special (could handle reduce, but need to be careful about init
-  // blocks)
+  // TODO(tkonolige): check that axis is special (could handle reduce, but need
+  // to be careful about init blocks)
   auto fr = Get(loop_rv);
   // Change dtype of factor so it matches extent
   PrimExpr factor = IntImm(fr->extent.dtype(), Downcast<IntImm>(factor_)->value);
@@ -542,7 +542,7 @@ Array<LoopRV> ConcreteScheduleNode::Partition(const LoopRV& loop_rv, const ExprR
   // structure remains the same across different random variable choices.
   Var iter(fr->loop_var->name_hint + "_", fr->loop_var->dtype, fr->loop_var->span);
   Var index(fr->loop_var->name_hint, fr->loop_var->dtype, fr->loop_var->span);
-  // TODO: should fr->body be deep copied?
+  // TODO(tkonolige): should fr->body be deep copied?
   For second(iter, 0, fr->extent - ext, fr->kind,
              LetStmt(index, iter + ext + fr->min,
                      ReInitLoopVars(BlockRenamer("_" + fr->loop_var->name_hint + "_tail")(
@@ -552,7 +552,7 @@ Array<LoopRV> ConcreteScheduleNode::Partition(const LoopRV& loop_rv, const ExprR
   // blockrealize.
   std::string base_name = FirstBlockName().Get(fr->body) + "_wrapper";
   std::string wrapper_block_name = base_name;
-  // TODO: doesn't work while scheduling
+  // TODO(tkonolige): doesn't work while scheduling
   // int i = 1;
   // while (tir::GetBlocks(state_, wrapper_block_name, this->func_working_on_.value()).size() > 0) {
   //   wrapper_block_name = base_name + "_" + std::to_string(i);

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -103,6 +103,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) override;
   Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors,
                       bool preserve_unit_iters) override;
+  Array<LoopRV> Partition(const LoopRV& loop_rv, const ExprRV& factor) override;
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) override;
   LoopRV AddUnitLoop(const BlockRV& block_rv) override;
   LoopRV AddUnitLoop(const LoopRV& loop_rv) override;

--- a/src/tir/schedule/instruction.cc
+++ b/src/tir/schedule/instruction.cc
@@ -40,7 +40,8 @@ using InstructionKindRegistry = AttrRegistry<InstructionKindRegEntry, Instructio
 
 InstructionKind InstructionKind::Get(const String& name) {
   const InstructionKindRegEntry* reg = InstructionKindRegistry::Global()->Get(name);
-  ICHECK(reg != nullptr) << "AttributeError: Instruction kind " << name << " is not registered";
+  ICHECK(reg != nullptr) << "AttributeError: Instruction kind " << name
+                         << " is not registered. Register it with TVM_REGISTER_INST_KIND.";
   return reg->inst_kind_;
 }
 

--- a/src/tir/schedule/instruction_traits.h
+++ b/src/tir/schedule/instruction_traits.h
@@ -325,7 +325,8 @@ Array<ObjectRef> UnpackedInstTraits<TTraits>::ApplyToSchedule(const Schedule& sc
     using runtime::detail::unpack_call;
     constexpr size_t kNumArgs = details::NumArgs<method_type>;
     ICHECK_EQ(args.size(), kNumArgs);
-    unpack_call<return_type, kNumArgs>(nullptr, TTraits::UnpackedApplyToSchedule, args, rv);
+    std::string call_name = std::string(TTraits::kName) + "::UnpackedApplyToSchedule";
+    unpack_call<return_type, kNumArgs>(&call_name, TTraits::UnpackedApplyToSchedule, args, rv);
   });
   TVMRetValue rv;
   pf.CallPacked(TVMArgs(tvm_values, tvm_type_codes, kNumArgs), &rv);
@@ -358,7 +359,8 @@ String UnpackedInstTraits<TTraits>::AsPython(const Array<ObjectRef>& inputs,
     using runtime::detail::unpack_call;
     constexpr size_t kNumArgs = details::NumArgs<method_type>;
     ICHECK_EQ(args.size(), kNumArgs);
-    unpack_call<return_type, kNumArgs>(nullptr, TTraits::UnpackedAsPython, args, rv);
+    std::string call_name = std::string(TTraits::kName) + "::UnpackAsPython";
+    unpack_call<return_type, kNumArgs>(&call_name, TTraits::UnpackedAsPython, args, rv);
   });
   TVMRetValue rv;
   pf.CallPacked(TVMArgs(tvm_values, tvm_type_codes, kNumArgs), &rv);

--- a/src/tir/schedule/primitive/for_kind.cc
+++ b/src/tir/schedule/primitive/for_kind.cc
@@ -40,7 +40,8 @@ class WrongBlockIterTypeError : public ScheduleError {
     if (op_str_ != "bind") {
       os << "The \"" << op_str_
          << "\" cannot be fulfilled with regard to block {0} because some block iter whose block "
-            "binding contains the loop var is not a data parallel block iter";
+            "binding contains the loop var ("
+         << loop_var_ << ") is not a data parallel block iter";
     } else {
       os << "The \"bind\" cannot be fulfilled with regard to block {0}. This is because some of its"
             " block iter whose block binding contains "
@@ -52,7 +53,7 @@ class WrongBlockIterTypeError : public ScheduleError {
     return os.str();
   }
   IRModule mod() const final { return mod_; }
-  Array<ObjectRef> LocationsOfInterest() const final { return {block_}; }
+  Array<ObjectRef> LocationsOfInterest() const final { return {block_, loop_var_}; }
   IRModule mod_;
   std::string op_str_;
   Var loop_var_;

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -153,6 +153,8 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetConsumers")
 /******** (FFI) Transform loops ********/
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleFuse").set_body_method<Schedule>(&ScheduleNode::Fuse);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleSplit").set_body_method<Schedule>(&ScheduleNode::Split);
+TVM_REGISTER_GLOBAL("tir.schedule.SchedulePartition")
+    .set_body_method<Schedule>(&ScheduleNode::Partition);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReorder")
     .set_body_method<Schedule>(&ScheduleNode::Reorder);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleAddUnitLoop")

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -209,12 +209,15 @@ class BlockInfoCollector : private StmtVisitor {
     // Calculate `BlockInfo::scope`
     Array<StmtSRef> child_block_srefs = std::move(block_frames_.back());
     BlockInfo& info = self_->block_info[scope_root] = BlockInfo(BlockScope(child_block_srefs));
+    const BlockNode* block = TVM_SREF_TO_BLOCK(scope_root);
     // Set `affine_binding`
     if (is_root_block) {
       // If the block doesn't have outer loops and BlockRealize,
       // then we set the affine binding flag as true only if the block has no block vars
-      const BlockNode* block = TVM_SREF_TO_BLOCK(scope_root);
       if (block->iter_vars.empty()) info.affine_binding = true;
+    } else if (block->iter_vars.empty()) {
+      // Loops without itervars are affine.
+      info.affine_binding = true;
     } else {
       info.affine_binding =
           IsAffineBinding(/*realize=*/block2realize_.at(scope_root->stmt),

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -206,6 +206,13 @@ Array<LoopRV> TracedScheduleNode::Split(const LoopRV& loop_rv,
   return results;
 }
 
+Array<LoopRV> TracedScheduleNode::Partition(const LoopRV& loop_rv, const ExprRV& factor) {
+  auto results = ConcreteScheduleNode::Partition(loop_rv, factor);
+  static const InstructionKind& kind = InstructionKind::Get("Partition");
+  trace_->Append(Instruction(kind, {loop_rv, factor}, {}, {results.begin(), results.end()}));
+  return results;
+}
+
 void TracedScheduleNode::Reorder(const Array<LoopRV>& ordered_loop_rvs) {
   ConcreteScheduleNode::Reorder(ordered_loop_rvs);
 

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -66,6 +66,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) final;
   LoopRV AddUnitLoop(const BlockRV& block_rv) final;
   LoopRV AddUnitLoop(const LoopRV& loop_rv) final;
+  Array<LoopRV> Partition(const LoopRV& loop_rv, const ExprRV& factor) final;
   /******** Schedule: Manipulate ForKind ********/
   void Parallel(const LoopRV& loop_rv) final;
   void Vectorize(const LoopRV& loop_rv) final;

--- a/tests/python/unittest/test_tir_schedule_partition.py
+++ b/tests/python/unittest/test_tir_schedule_partition.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm.script import tir as T
+from tvm import tir
+from tvm.tir.schedule.testing import verify_trace_roundtrip
+
+
+@T.prim_func
+def innermost(A: T.Buffer[10, "float32"]):
+    for i in range(10):
+        with T.block("main"):
+            A[i] = 0.0
+
+
+@T.prim_func
+def innermost_after(A: T.Buffer[10, "float32"]):
+    with T.block("root"):
+        T.reads()
+        T.writes()
+        with T.block("main_wrapper"):
+            T.reads()
+            T.writes()
+            for i in T.serial(8):
+                with T.block("main"):
+                    T.reads()
+                    T.writes(A[i])
+                    A[i] = T.float32(0)
+            for i_ in T.serial(2):
+                i: T.int32 = i_ + 8
+                with T.block("main_i_tail"):
+                    T.reads()
+                    T.writes(A[i])
+                    A[i] = T.float32(0)
+
+
+def test_partition_innermost():
+    s = tir.Schedule(innermost, debug_mask="all")
+    main = s.get_block("main")
+    (i,) = s.get_loops(main)
+    s.partition(i, tir.IntImm("int32", 8))
+    print(s.mod["main"].script())
+    print(innermost_after.script())
+    tvm.ir.assert_structural_equal(innermost_after, s.mod["main"])
+    verify_trace_roundtrip(sch=s, mod=innermost)
+
+
+@T.prim_func
+def outermost(A: T.Buffer[(12, 10), "float32"]):
+    for i in range(12):
+        for j in range(10):
+            with T.block("main"):
+                A[i, j] = 0.0
+
+
+@T.prim_func
+def outermost_after(A: T.Buffer[(12, 10), "float32"]):
+    with T.block("root"):
+        T.reads()
+        T.writes()
+        with T.block("main_wrapper"):
+            T.reads()
+            T.writes()
+            for i, j in T.grid(8, 10):
+                with T.block("main"):
+                    T.reads()
+                    T.writes(A[i, j])
+                    A[i, j] = T.float32(0)
+            for i_ in T.serial(4):
+                i: T.int32 = i_ + 8
+                for j in T.serial(10):
+                    with T.block("main_i_tail"):
+                        T.reads()
+                        T.writes(A[i, j])
+                        A[i, j] = T.float32(0)
+
+
+def test_partition_outermost():
+    s = tir.Schedule(outermost, debug_mask="all")
+    main = s.get_block("main")
+    i, j = s.get_loops(main)
+    s.partition(i, tir.IntImm("int32", 8))
+    print(s.mod["main"].script())
+    print(outermost_after.script())
+    tvm.ir.assert_structural_equal(outermost_after, s.mod["main"])
+    verify_trace_roundtrip(sch=s, mod=outermost)


### PR DESCRIPTION
Add partition scheduling primitive. Partition splits a loop into two sequential loops based on a factor. For example:

```
for i in range(10):
  x[i] = 0
```

could be partitioned with a factor of 8 to

```
for i in range(8):
  x[i] = 0
for i_ in range(2):
  i = i_ + 8
  x[i] = 0
```

A couple of changes are necessary to support this change. Feature extraction had to be updated to handle loops with zero or negative extent and the parallel vectorize unroll postproc had to be updated to support nested blocks.