### PR TITLE
[TECompiler] Remove static qualifer in constant index

### DIFF
--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -393,13 +393,11 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
   tvm::Target target_;
   std::ostringstream readable_name_stream_;
   // Index of the global constants
-  static int const_index;
+  int const_index{0};
   // Cache device copy op for equivalence checking to reduce registry lookup
   // overhead for each invocation of call node when retrieving schedules.
   const Op& device_copy_op_;
 };
-
-int LowerToTECompute::const_index = 0;
 
 using namespace tvm::tir;
 


### PR DESCRIPTION
Trying to see if we can pass CI with this change. This causes a problem for metaschedule tuning or TIR scheduling in general, since the name of a constant changes before / after tuning, which breaks the schedule primitive `get_block(block_name)`. 