### PR TITLE
[AOT][FIX] Handle device contexts properly in CreateFunctionMetadata

### DIFF
--- a/src/relay/backend/aot/create_function_metadata.cc
+++ b/src/relay/backend/aot/create_function_metadata.cc
@@ -62,8 +62,7 @@ Map<String, backend::FunctionInfo> CalculateFunctionInfos(const IRModule& mod,
       auto params = pfunc->params;
       int64_t total_io_bytes = 0;
       for (const auto& param : params) {
-        // Inputs/outputs will be handles, workspaces are pointers
-        if (param->dtype.is_handle()) {
+        if (pfunc->buffer_map.find(param) != pfunc->buffer_map.end()) {
           auto buffer = pfunc->buffer_map[param];
           total_io_bytes += GetMemorySizeBytes(buffer->shape, buffer->dtype);
         }

--- a/tests/python/relay/aot/test_aot_create_function_metadata.py
+++ b/tests/python/relay/aot/test_aot_create_function_metadata.py
@@ -264,7 +264,7 @@ def test_create_function_metadata_workspace_multi_funcs():
             T.evaluate(T.tvm_call_cpacked("test_fused_add", a_buffer.data, a_buffer.data, output_buffer.data, T.reinterpret(T.uint64(0), dtype="handle"), dtype="int32"))
 
         @T.prim_func
-        def test_fused_add(a: T.handle, b: T.handle, output: T.handle) -> None:
+        def test_fused_add(a: T.handle, b: T.handle, output: T.handle, device_context_unused: T.handle) -> None:
             # function attr dict
             T.func_attr({"global_symbol": "test_mod_test_fused_add", "target": T.target({"kind":"llvm", "tag":"", "keys":["cpu"]})})
             a_buffer = T.match_buffer(a, [5, 7], dtype="float32", align=16)


### PR DESCRIPTION
Device contexts created handles with no corresponding buffer which would confuse CreateFunctionMetadata causing a segfault. The logic has been changed to check that a buffer exists and a test updated to include this case.