### PR TITLE
Add support for cast double to fp16

### DIFF
--- a/include/tvm/runtime/builtin_fp16.h
+++ b/include/tvm/runtime/builtin_fp16.h
@@ -32,6 +32,7 @@ extern "C" {
 TVM_DLL uint16_t __gnu_f2h_ieee(float);
 TVM_DLL float __gnu_h2f_ieee(uint16_t);
 TVM_DLL uint16_t __truncsfhf2(float v);
+TVM_DLL uint16_t __truncdfhf2(double v);
 TVM_DLL float __extendhfsf2(uint16_t v);
 }
 

--- a/src/runtime/builtin_fp16.cc
+++ b/src/runtime/builtin_fp16.cc
@@ -37,6 +37,10 @@ TVM_DLL TVM_WEAK float __gnu_h2f_ieee(uint16_t a) {
   return __extendXfYf2__<uint16_t, uint16_t, 10, float, uint32_t, 23>(a);
 }
 
+TVM_DLL uint16_t __truncdfhf2(double a) {
+  return __truncXfYf2__<double, uint64_t, 52, uint16_t, uint16_t, 10>(a);
+}
+
 #else
 
 TVM_DLL uint16_t __gnu_f2h_ieee(float a) {
@@ -45,6 +49,10 @@ TVM_DLL uint16_t __gnu_f2h_ieee(float a) {
 
 TVM_DLL float __gnu_h2f_ieee(uint16_t a) {
   return __extendXfYf2__<uint16_t, uint16_t, 10, float, uint32_t, 23>(a);
+}
+
+TVM_DLL uint16_t __truncdfhf2(double a) {
+  return __truncXfYf2__<double, uint64_t, 52, uint16_t, uint16_t, 10>(a);
 }
 
 #endif

--- a/tests/python/topi/python/test_topi_math.py
+++ b/tests/python/topi/python/test_topi_math.py
@@ -200,9 +200,13 @@ from_dtype, to_dtype = tvm.testing.parameters(
     ("int32", "float32"),
     ("int32", "float64"),
     ("int32", "bool"),
+    ("float16", "float32"),
+    ("float16", "float64"),
     ("float32", "int32"),
     ("float32", "float64"),
     ("float32", "bool"),
+    ("float64", "float16"),
+    ("float64", "float32"),
     ("bool", "float32"),
     ("bool", "int32"),
 )


### PR DESCRIPTION
__truncdfhf2 can be generated in codegen but the implementation was missing. Added the missing implementation.