### PR TITLE
[TECompiler] Replace static constant index with NameSupply

### DIFF
--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -135,11 +135,9 @@ TVM_REGISTER_OBJECT_TYPE(TECompilerNode);
 
 class TECompilerImpl : public TECompilerNode {
  public:
-  explicit TECompilerImpl(Optional<IRModule> opt_mod, Optional<String> opt_mod_name) {
-    String mod_name = opt_mod_name.value_or("");
-    NameSupply name_supply = NameSupply(mod_name /* prefix */);
-    global_var_supply_ = GlobalVarSupply(name_supply);
-    constant_name_supply_ = NameSupply("");
+  explicit TECompilerImpl(Optional<IRModule> opt_mod, Optional<String> opt_mod_name)
+      : global_var_supply_(GlobalVarSupply(NameSupply(opt_mod_name.value_or("")))),
+        constant_name_supply_(NameSupply("")) {
     // Make sure we don't collide with any existing globals in the module.
     if (opt_mod) {
       for (const auto& kv : opt_mod.value()->functions) {
@@ -525,6 +523,8 @@ class TECompilerImpl : public TECompilerNode {
   std::mutex mutex_;
   /*! \brief internal GlobalVarSupply to get unique GlobalVars  */
   GlobalVarSupply global_var_supply_;
+  /*! \brief A NameSupply object for assigning unique names to constants, across different
+   * invocations of PrimFuncFor. */
   NameSupply constant_name_supply_;
   /*! \brief internal compiler cache */
   std::unordered_map<CCacheKey, CCacheValue> cache_;

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -139,6 +139,7 @@ class TECompilerImpl : public TECompilerNode {
     String mod_name = opt_mod_name.value_or("");
     NameSupply name_supply = NameSupply(mod_name /* prefix */);
     global_var_supply_ = GlobalVarSupply(name_supply);
+    constant_name_supply_ = NameSupply("");
     // Make sure we don't collide with any existing globals in the module.
     if (opt_mod) {
       for (const auto& kv : opt_mod.value()->functions) {
@@ -392,7 +393,8 @@ class TECompilerImpl : public TECompilerNode {
     With<Target> target_scope(key->target);
 
     ICHECK(!value->cached_func.defined());
-    value->cached_func = PrimFuncFor(key->source_func, key->target, global_var_supply);
+    value->cached_func =
+        PrimFuncFor(key->source_func, key->target, global_var_supply, constant_name_supply_);
 
     if (value->cached_func->prim_func.defined()) {
       VLOG(1) << "Lowering PrimFunc";
@@ -523,6 +525,7 @@ class TECompilerImpl : public TECompilerNode {
   std::mutex mutex_;
   /*! \brief internal GlobalVarSupply to get unique GlobalVars  */
   GlobalVarSupply global_var_supply_;
+  NameSupply constant_name_supply_;
   /*! \brief internal compiler cache */
   std::unordered_map<CCacheKey, CCacheValue> cache_;
   /*! \brief internal compiler cache for shape funcs */

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -398,6 +398,8 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
   // Cache device copy op for equivalence checking to reduce registry lookup
   // overhead for each invocation of call node when retrieving schedules.
   const Op& device_copy_op_;
+  // A NameSupply object passed from a caller, used to assign unique names to constants
+  // across different invocations of LowerToTECompute.
   NameSupply constants_name_supply_;
 };
 
@@ -1094,7 +1096,7 @@ std::tuple<Array<te::Tensor>, Array<runtime::NDArray>, std::string> LowerTECompu
 
 TVM_REGISTER_GLOBAL("relay.backend.LowerToTE").set_body_typed([](Function prim_func) {
   auto tgt = tvm::Target("ext_dev");
-  LowerToTECompute lower_te_compute(tgt, NameSupply(""));  // TODO
+  LowerToTECompute lower_te_compute(tgt, NameSupply(""));
   auto outputs = lower_te_compute.Lower(prim_func);
   return CachedFunc(tgt, GlobalVar(lower_te_compute.candidate_name_), lower_te_compute.fn_inputs_,
                     outputs, te::Schedule(), tir::PrimFunc(), {},

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -20,6 +20,7 @@
 #include "./te_compiler_cache.h"
 
 #include <tvm/driver/driver_api.h>
+#include <tvm/ir/name_supply.h>
 #include <tvm/ir/type_functor.h>
 #include <tvm/meta_schedule/database.h>
 #include <tvm/relay/analysis.h>
@@ -204,8 +205,10 @@ class QnnPatternMatcher {
 // Lowers Relay primitive Function to TE Compute
 class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor>> {
  public:
-  explicit LowerToTECompute(Target target)
-      : target_(target), device_copy_op_(Op::Get("device_copy")) {}
+  LowerToTECompute(Target target, NameSupply constants_name_supply)
+      : target_(target),
+        device_copy_op_(Op::Get("device_copy")),
+        constants_name_supply_(constants_name_supply) {}
 
   Array<te::Tensor> Lower(const Function& relay_func) {
     for (Var param : relay_func->params) {
@@ -280,7 +283,7 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
       std::stringstream ss;
       std::string s = readable_name_stream_.str();
       std::replace(s.begin(), s.end(), '.', '_');
-      ss << s << "_constant_" << const_index++;
+      ss << constants_name_supply_->FreshName(s + "_constant");
       tvm::te::Tensor tensor = tvm::te::placeholder(GetShape(ttype->shape), ttype->dtype, ss.str());
       constant_tensors_[op] = tensor;
       return {tensor};
@@ -392,14 +395,11 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
 
   tvm::Target target_;
   std::ostringstream readable_name_stream_;
-  // Index of the global constants
-  static int const_index;
   // Cache device copy op for equivalence checking to reduce registry lookup
   // overhead for each invocation of call node when retrieving schedules.
   const Op& device_copy_op_;
+  NameSupply constants_name_supply_;
 };
-
-int LowerToTECompute::const_index = 0;
 
 using namespace tvm::tir;
 
@@ -478,8 +478,9 @@ class ScheduleBuilder : public ExprVisitor {
     }
   }
 
-  CachedFunc Create(const Function& relay_func, GlobalVarSupply global_var_supply) {
-    LowerToTECompute lower_te_compute(target_);
+  CachedFunc Create(const Function& relay_func, GlobalVarSupply global_var_supply,
+                    NameSupply constant_name_supply) {
+    LowerToTECompute lower_te_compute(target_, constant_name_supply);
     Array<te::Tensor> tensor_outs = lower_te_compute.Lower(relay_func);
     Array<te::Tensor> fn_inputs = lower_te_compute.fn_inputs_;
     VisitExpr(relay_func->body);
@@ -724,8 +725,8 @@ class ScheduleBuilder : public ExprVisitor {
  *  The funcs field in cache is not yet populated.
  */
 CachedFunc PrimFuncFor(const Function& source_func, const Target& target,
-                       GlobalVarSupply global_var_supply) {
-  return ScheduleBuilder(target).Create(source_func, global_var_supply);
+                       GlobalVarSupply global_var_supply, NameSupply constant_name_supply) {
+  return ScheduleBuilder(target).Create(source_func, global_var_supply, constant_name_supply);
 }
 
 // Creates shape function from functor.
@@ -1066,8 +1067,9 @@ CachedFunc ShapeFuncFor(const Function& prim_func, const Target& target,
 }
 
 std::tuple<Array<te::Tensor>, Array<runtime::NDArray>, std::string> LowerTECompute(
-    const Function& source_func, Target target, bool return_inputs) {
-  LowerToTECompute lower_te_compute(target);
+    const Function& source_func, Target target, NameSupply constant_name_supply,
+    bool return_inputs) {
+  LowerToTECompute lower_te_compute(target, constant_name_supply);
   Array<te::Tensor> outputs = lower_te_compute.Lower(source_func);
   // Following ScheduleBuilder, remove placeholder ops from outputs.
   tvm::Array<te::Tensor> tensor_outs;
@@ -1092,7 +1094,7 @@ std::tuple<Array<te::Tensor>, Array<runtime::NDArray>, std::string> LowerTECompu
 
 TVM_REGISTER_GLOBAL("relay.backend.LowerToTE").set_body_typed([](Function prim_func) {
   auto tgt = tvm::Target("ext_dev");
-  LowerToTECompute lower_te_compute(tgt);
+  LowerToTECompute lower_te_compute(tgt, NameSupply(""));  // TODO
   auto outputs = lower_te_compute.Lower(prim_func);
   return CachedFunc(tgt, GlobalVar(lower_te_compute.candidate_name_), lower_te_compute.fn_inputs_,
                     outputs, te::Schedule(), tir::PrimFunc(), {},

--- a/src/relay/backend/te_compiler_cache.h
+++ b/src/relay/backend/te_compiler_cache.h
@@ -215,6 +215,8 @@ Array<IndexExpr> GetShape(const Array<IndexExpr>& shape);
  * \brief Lowers Relay primitive Function to TE Compute
  * \param source_func The primitive function to be lowered.
  * \param target The target we want to create schedule for.
+ * \param constant_name_supply A name supplier for constants.
+ *  across different invocations of this function.
  * \param return_inputs If true, prepend input tensors to the output array of tensors.
  * \return Tuple of the lowered TE compute, constant raw data, and fused function name.
  */
@@ -226,12 +228,16 @@ std::tuple<Array<te::Tensor>, Array<runtime::NDArray>, std::string> LowerTECompu
  * \brief Create schedule for target.
  * \param source_func The primitive function to be lowered.
  * \param target The target we want to create schedule for.
+ * \param global_var_supply A name supplier for global variables.
+ * \param constant_name_supply A name supplier for constants.
  * \return Pair of schedule and cache.
  *  The funcs field in cache is not yet populated.
  */
 CachedFunc PrimFuncFor(const Function& source_func, const Target& target,
                        GlobalVarSupply global_var_supply, NameSupply constant_name_supply);
 
+/*! \brief A specialization of PrimFuncFor, meant to be used when the names of constants do not
+ * matter. */
 inline CachedFunc PrimFuncFor(const Function& source_func, const Target& target) {
   return PrimFuncFor(source_func, target, GlobalVarSupply(NameSupply("")), NameSupply(""));
 }

--- a/src/relay/backend/te_compiler_cache.h
+++ b/src/relay/backend/te_compiler_cache.h
@@ -219,7 +219,8 @@ Array<IndexExpr> GetShape(const Array<IndexExpr>& shape);
  * \return Tuple of the lowered TE compute, constant raw data, and fused function name.
  */
 std::tuple<Array<te::Tensor>, Array<runtime::NDArray>, std::string> LowerTECompute(
-    const Function& source_func, Target target, bool return_inputs = true);
+    const Function& source_func, Target target, NameSupply constant_name_supply,
+    bool return_inputs = true);
 
 /*!
  * \brief Create schedule for target.
@@ -229,7 +230,11 @@ std::tuple<Array<te::Tensor>, Array<runtime::NDArray>, std::string> LowerTECompu
  *  The funcs field in cache is not yet populated.
  */
 CachedFunc PrimFuncFor(const Function& source_func, const Target& target,
-                       GlobalVarSupply global_var_supply);
+                       GlobalVarSupply global_var_supply, NameSupply constant_name_supply);
+
+inline CachedFunc PrimFuncFor(const Function& source_func, const Target& target) {
+  return PrimFuncFor(source_func, target, GlobalVarSupply(NameSupply("")), NameSupply(""));
+}
 
 CachedFunc ShapeFuncFor(const Function& prim_func, const Target& target,
                         GlobalVarSupply global_var_supply);

--- a/src/relay/transforms/auto_scheduler_layout_rewrite.cc
+++ b/src/relay/transforms/auto_scheduler_layout_rewrite.cc
@@ -126,7 +126,7 @@ Expr AutoSchedulerLayoutRewriter::VisitExpr_(const CallNode* n) {
       CHECK(f) << "Could not find auto_scheduler.enter_layout_rewrite function.";
       (*f)();
 
-      tec::PrimFuncFor(GetRef<Function>(func), Target::Current(), GlobalVarSupply(NameSupply("")));
+      tec::PrimFuncFor(GetRef<Function>(func), Target::Current());
 
       f = runtime::Registry::Get("auto_scheduler.exit_layout_rewrite");
       CHECK(f) << "Could not find ansor.exit_layout_rewrite function.";

--- a/src/relay/transforms/meta_schedule_layout_rewrite.cc
+++ b/src/relay/transforms/meta_schedule_layout_rewrite.cc
@@ -134,7 +134,7 @@ Expr MetaScheduleLayoutRewriter::VisitExpr_(const CallNode* call) {
     if (const auto* func = call->op.as<FunctionNode>()) {
       LayoutIndexQueue* self = LayoutIndexQueue::Global();
       self->queue_.clear();
-      tec::PrimFuncFor(GetRef<Function>(func), Target::Current(), GlobalVarSupply(NameSupply("")));
+      tec::PrimFuncFor(GetRef<Function>(func), Target::Current());
       if (!self->queue_.empty()) {
         std::deque<tir::IndexMap> queue = std::move(self->queue_);
         self->queue_.clear();


### PR DESCRIPTION
The `static` qualifier on the constant index causes a problem, when `TECompiler` is invoked on the same module multiple times. Since the names of constants become different in each call to `TECompiler`, anything that depends on the consistency of constant names is broken. 

In practice, MetaSchedule tuning is affected by this issue, since task extraction and the final `relay.build(...)` both invoke `TECompiler`.  So if we do `get_block("fused_constant_0_global")` during tuning,  trace application after tuning will fail because there would be no longer a block with the name "fused_constant_0_global" .