### PR TITLE
[Hexagon] Fix TIR vrmpy tensorization

### DIFF
--- a/python/tvm/tir/tensor_intrin/hexagon.py
+++ b/python/tvm/tir/tensor_intrin/hexagon.py
@@ -32,8 +32,6 @@ def dot_product_32x4_u8u8i32_desc(
         for i in T.serial(0, 32):
             for k in T.serial(0, 4):
                 with T.block("update"):
-                    with T.init():
-                        C[i] = T.int32(0)
                     vi, vk = T.axis.remap("SR", [i, k])
                     C[vi] = C[vi] + T.cast(A[vk], "int32") * T.cast(B[vi, vk], "int32")
 
@@ -76,8 +74,6 @@ def dot_product_32x4_u8i8i32_desc(
         for i in T.serial(0, 32):
             for k in T.serial(0, 4):
                 with T.block("update"):
-                    with T.init():
-                        C[i] = T.int32(0)
                     vi, vk = T.axis.remap("SR", [i, k])
                     C[vi] = C[vi] + T.cast(A[vk], "int32") * T.cast(B[vi, vk], "int32")
 


### PR DESCRIPTION
Hexagon tests using `vrmpy` tensorization were broken by the change in `tir/tensor_intrin/hexagon.py` from https://github.com/apache/tvm/pull/12496. The change is a correct one from the TIR perspective, but it breaks tensorize pattern matching. Actually `T.init()` block is not necessary in a tensorize description, so just removing it fixes the breakage. 

@mehrdadh 