### PR TITLE
[MetaSchedule][Fix] Fix Empty Run Time Issue when Benchmarking Result

### DIFF
--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -44,7 +44,7 @@ class UpdateCostModelNode : public MeasureCallbackNode {
     for (int i = 0; i < n; i++) {
       if (!builder_results[i]->error_msg.defined() &&  //
           (runner_results[i]->error_msg.defined() ||   //
-          Sum(runner_results[i]->run_secs.value()) > 0)) {
+           Sum(runner_results[i]->run_secs.value()) > 0)) {
         pruned_candidate.push_back(measure_candidates[i]);
         pruned_runner_result.push_back(runner_results[i]);
       }

--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -42,7 +42,8 @@ class UpdateCostModelNode : public MeasureCallbackNode {
     pruned_candidate.reserve(n);
     pruned_runner_result.reserve(n);
     for (int i = 0; i < n; i++) {
-      if (!builder_results[i]->error_msg.defined() &&
+      if (!builder_results[i]->error_msg.defined() &&  //
+          !runner_results[i]->error_msg.defined() &&   //
           Sum(runner_results[i]->run_secs.value()) > 0) {
         pruned_candidate.push_back(measure_candidates[i]);
         pruned_runner_result.push_back(runner_results[i]);

--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -43,8 +43,8 @@ class UpdateCostModelNode : public MeasureCallbackNode {
     pruned_runner_result.reserve(n);
     for (int i = 0; i < n; i++) {
       if (!builder_results[i]->error_msg.defined() &&  //
-          !runner_results[i]->error_msg.defined() &&   //
-          Sum(runner_results[i]->run_secs.value()) > 0) {
+          (runner_results[i]->error_msg.defined() ||   //
+          Sum(runner_results[i]->run_secs.value()) > 0)) {
         pruned_candidate.push_back(measure_candidates[i]);
         pruned_runner_result.push_back(runner_results[i]);
       }


### PR DESCRIPTION
As a follow-up fix PR for https://github.com/apache/tvm/pull/13354, which introduces a bug that the tuning will crash if the run time is empty (usually because of a runtime error).

cc @junrushao @zxybazh 