### PR TITLE
[OPENCL][TEXTURE] Test case enhancements and fixes for RPC

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -1549,7 +1549,7 @@ class OperatorConverter(object):
         assert axis < data_dim, "Axis out of bounds"
 
         if self.has_expr(indices.tensor_idx):
-            indices_expr = self.get_expr(indices.tensor_idx)
+            indices_expr = _op.cast(self.get_expr(indices.tensor_idx), "int32")
         else:
             indices_val = self.get_tensor_value(indices)
             indices_expr = self.exp_tab.new_const(

--- a/tests/python/relay/opencl_texture/conftest.py
+++ b/tests/python/relay/opencl_texture/conftest.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import tvm
+from tvm import rpc
+import pytest
+
+
+@pytest.fixture(scope="session")
+def remote():
+    if (
+        "TVM_TRACKER_HOST" in os.environ
+        and "TVM_TRACKER_PORT" in os.environ
+        and "RPC_DEVICE_KEY" in os.environ
+    ):
+
+        rpc_tracker_host = os.environ["TVM_TRACKER_HOST"]
+        rpc_tracker_port = int(os.environ["TVM_TRACKER_PORT"])
+        rpc_device_key = os.environ["RPC_DEVICE_KEY"]
+        tracker = rpc.connect_tracker(rpc_tracker_host, rpc_tracker_port)
+        remote = tracker.request(rpc_device_key, priority=0, session_timeout=600)
+        return remote
+    else:
+        return None

--- a/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
+++ b/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
@@ -30,7 +30,7 @@ dtype = tvm.testing.parameter("float32")
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad(target, dtype):
+def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad(remote, target, dtype):
     input_shape = (1, 32, 42, 42)
     filter_shape = (96, 32, 3, 3)
     bias_shape = (1, 96, 1, 1)
@@ -65,12 +65,14 @@ def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad_pass(target, dtype):
+def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad_pass(remote, target, dtype):
     input_shape = (1, 32, 40, 40)
     filter_shape = (96, 32, 2, 2)
     bias_shape = (1, 96, 1, 1)
@@ -105,12 +107,14 @@ def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad_pass(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_35_35_strides(target, dtype):
+def test_conv2d_inceptionv3_35_35_strides(remote, target, dtype):
     input_shape = (1, 48, 35, 35)
     filter_shape = (64, 48, 5, 5)
     bias_shape = (1, 64, 1, 1)
@@ -145,12 +149,14 @@ def test_conv2d_inceptionv3_35_35_strides(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_resnet50_v2_nchw_3c(target, dtype):
+def test_conv2d_resnet50_v2_nchw_3c(remote, target, dtype):
     input_shape = (1, 3, 224, 224)
     filter_shape = (64, 3, 7, 7)
     bias_shape = (1, 64, 1, 1)
@@ -186,12 +192,12 @@ def test_conv2d_resnet50_v2_nchw_3c(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_nchw_3c(target, dtype):
+def test_conv2d_inceptionv3_nchw_3c(remote, target, dtype):
     input_shape = (1, 3, 299, 299)
     filter_shape = (64, 3, 3, 3)
     bias_shape = (1, 64, 1, 1)
@@ -226,12 +232,12 @@ def test_conv2d_inceptionv3_nchw_3c(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_1x1_16c16spatial(target, dtype):
+def test_conv2d_1x1_16c16spatial(remote, target, dtype):
     input_shape = (1, 16, 256, 256)
     filter_shape = (32, 16, 4, 4)
     bias_shape = (1, 32, 1, 1)
@@ -266,12 +272,12 @@ def test_conv2d_1x1_16c16spatial(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_4x4_16c16pad(target, dtype):
+def test_conv2d_4x4_16c16pad(remote, target, dtype):
     input_shape = (1, 32, 256, 256)
     filter_shape = (32, 32, 4, 4)
     bias_shape = (1, 32, 1, 1)
@@ -306,12 +312,12 @@ def test_conv2d_4x4_16c16pad(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_4x4x4_16c16pad(target, dtype):
+def test_conv2d_4x4x4_16c16pad(remote, target, dtype):
     input_shape = (1, 32, 256, 256)
     filter_shape = (4, 32, 4, 4)
     bias_shape = (1, 4, 1, 1)
@@ -346,12 +352,12 @@ def test_conv2d_4x4x4_16c16pad(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_yolov3_v2_nchw_3c(target, dtype):
+def test_conv2d_yolov3_v2_nchw_3c(remote, target, dtype):
     input_shape = (1, 1024, 13, 13)
     filter_shape = (255, 1024, 1, 1)
     A = relay.var("data", shape=input_shape, dtype=dtype)
@@ -379,12 +385,12 @@ def test_conv2d_yolov3_v2_nchw_3c(target, dtype):
         "weight": tvm.nd.array(filter_data),
     }
 
-    build_run_compare(mod, params, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_vgg16_winograd_4d(target, dtype):
+def test_conv2d_vgg16_winograd_4d(remote, target, dtype):
     input_shape = (1, 512, 28, 28)
     filter_shape = (512, 512, 3, 3)
     bias_shape = (1, 512, 1, 1)
@@ -424,7 +430,7 @@ def test_conv2d_vgg16_winograd_4d(target, dtype):
             f'{{"input": ["opencl -keys=adreno,opencl,gpu -device=adreno -max_num_threads=256", "conv2d_nchw_winograd.image2d", [["TENSOR", [1, 512, 28, 28], "{dtype}"], ["TENSOR", [512, 512, 3, 3], "{dtype}"], [1, 1], [1, 1, 1, 1], [1, 1], "{dtype}"], {{}}], "config": {{"index": 1591, "code_hash": null, "entity": [["auto_unroll_max_step", "ot", 4], ["tile_y", "sp", [-1, 1, 32]], ["tile_x", "sp", [-1, 4, 2]], ["tile_rc", "sp", [-1, 8]]]}}, "result": [[0.0037244], 0, 7.06374192237854, 1653898629.7427933], "version": 0.2, "tvm_version": "0.8.dev0"}}\n'
         )
     graph = build_run_compare(
-        mod, params1, {"data": input_shape}, dtype, target, stat_file=stat_file
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, stat_file=stat_file
     )
     matches = re.findall("winograd", graph)
     assert len(matches) > 0
@@ -432,7 +438,7 @@ def test_conv2d_vgg16_winograd_4d(target, dtype):
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_winograd_conv(target, dtype):
+def test_conv2d_winograd_conv(remote, target, dtype):
     input_shape = (1, 4, 3, 3)
     A = relay.var("data", shape=input_shape, dtype=dtype)
     filter_shape3 = (8, 4, 3, 3)
@@ -471,7 +477,7 @@ def test_conv2d_winograd_conv(target, dtype):
             f'{{"input": ["opencl -keys=adreno,opencl,gpu -device=adreno -max_num_threads=256", "conv2d_nchw_winograd.image2d", [["TENSOR", [1, 4, 3, 3], "{dtype}"], ["TENSOR", [8, 4, 3, 3], "{dtype}"], [1, 1], [1, 1, 1, 1], [1, 1], "{dtype}"], {{}}], "config": {{"index": 1591, "code_hash": null, "entity": [["auto_unroll_max_step", "ot", 4], ["tile_y", "sp", [-1, 1, 32]], ["tile_x", "sp", [-1, 4, 2]], ["tile_rc", "sp", [-1, 8]]]}}, "result": [[0.0037244], 0, 7.06374192237854, 1653898629.7427933], "version": 0.2, "tvm_version": "0.8.dev0"}}\n'
         )
     graph = build_run_compare(
-        mod, params1, {"data": input_shape}, dtype, target, stat_file=stat_file
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, stat_file=stat_file
     )
     matches = re.findall("winograd", graph)
     assert len(matches) > 0
@@ -479,7 +485,7 @@ def test_conv2d_winograd_conv(target, dtype):
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_residual_block(target, dtype):
+def test_residual_block(remote, target, dtype):
     """
     - some kind of residual block followed by convolution to have texture after residual block
     - scalar data type verification which should be mapped to global memory scope
@@ -596,12 +602,14 @@ def test_residual_block(target, dtype):
             "",
         ]
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_concat(target, dtype):
+def test_concat(remote, target, dtype):
     """
         layout_transform (NCHW->NCHW4c)
                   |                      <- buffer
@@ -708,12 +716,14 @@ def test_concat(target, dtype):
 
     static_memory_scope = []
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_pooling_branching_texture_params(target, dtype):
+def test_pooling_branching_texture_params(remote, target, dtype):
     """
     Verification of the pooling and many branches having textures
                 layout_transform (NCHW->NCHW4c)
@@ -834,12 +844,14 @@ def test_pooling_branching_texture_params(target, dtype):
         "",
     ]
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_branching_texture_params(target, dtype):
+def test_branching_texture_params(remote, target, dtype):
     """
     Verification of passing texture to several consumers markup of relay variables in
     primary functions + on_device
@@ -958,13 +970,15 @@ def test_branching_texture_params(target, dtype):
         "",
     ]
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
 
 
 # function repeat, params scope are different in reused functions
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_different_lowering_same_op(target, dtype):
+def test_conv2d_different_lowering_same_op(remote, target, dtype):
     """
     Use case for verification of caching compiled functions
     Three convolutions following by each other in this case should be
@@ -1040,12 +1054,14 @@ def test_conv2d_different_lowering_same_op(target, dtype):
         "",
     ]
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_winograd_non_rect(target, dtype):
+def test_conv2d_winograd_non_rect(remote, target, dtype):
     input_shape = (1, 771, 36, 64)
     A = relay.var("data", shape=input_shape, dtype=dtype)
     filter_shape = (128, 771, 3, 3)
@@ -1070,7 +1086,7 @@ def test_conv2d_winograd_non_rect(target, dtype):
             f'{{"input": ["opencl -keys=adreno,opencl,gpu -device=adreno -max_num_threads=256 -texture_spatial_limit=16384 -thread_warp_size=1", "conv2d_nchw_winograd.image2d", [["TENSOR", [1, 771, 36, 64], "{dtype}"], ["TENSOR", [128, 771, 3, 3], "{dtype}"], [1, 1], [1, 1, 1, 1], [1, 1], "{dtype}"], {{}}], "config": {{"index": 5399, "code_hash": null, "entity": [["auto_unroll_max_step", "ot", 16], ["tile_y", "sp", [-1, 1, 32]], ["tile_x", "sp", [-1, 4, 8]], ["tile_rc", "sp", [-1, 193]]]}}, "result": [[0.0037244], 0, 7.06374192237854, 1653898629.7427933], "version": 0.2, "tvm_version": "0.8.dev0"}}\n'
         )
     graph = build_run_compare(
-        mod, params1, {"data": input_shape}, dtype, target, stat_file=stat_file
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, stat_file=stat_file
     )
     matches = re.findall("winograd", graph)
     assert len(matches) > 0
@@ -1079,7 +1095,7 @@ def test_conv2d_winograd_non_rect(target, dtype):
 # function repeat, params scope are different in reused functions
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_injective_nwo_inputs1(target, dtype):
+def test_injective_nwo_inputs1(remote, target, dtype):
     """
     Use case for verification of stability of annotation primary functions
     having several ops accepting data outside of Primary function
@@ -1170,13 +1186,15 @@ def test_injective_nwo_inputs1(target, dtype):
         "global",
         "global",
     ]
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
 
 
 # function repeat, params scope are different in reused functions
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_injective_nwo_inputs2(target, dtype):
+def test_injective_nwo_inputs2(remote, target, dtype):
     """
     Use case for verification of stability of annotation primary functions
     having several ops accepting data outside of Primary function
@@ -1266,4 +1284,10 @@ def test_injective_nwo_inputs2(target, dtype):
         "global.texture",
         "global",
     ]
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, static_memory_scope)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, static_memory_scope
+    )
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relay/opencl_texture/test_conv2d_nhwc_texture.py
+++ b/tests/python/relay/opencl_texture/test_conv2d_nhwc_texture.py
@@ -31,7 +31,7 @@ dtype = tvm.testing.parameter("float32")
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_deeplabv3_1_257_257_32x1_1_32_16(target, dtype):
+def test_conv2d_deeplabv3_1_257_257_32x1_1_32_16(remote, target, dtype):
     input_shape = (1, 257, 257, 32)
     filter_shape = (1, 1, 32, 16)
     bias_shape = (filter_shape[-1],)
@@ -63,12 +63,12 @@ def test_conv2d_deeplabv3_1_257_257_32x1_1_32_16(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_deeplabv3_1_257_257_32x1_1_32_16_with_padding(target, dtype):
+def test_conv2d_deeplabv3_1_257_257_32x1_1_32_16_with_padding(remote, target, dtype):
     input_shape = (1, 257, 257, 32)
     filter_shape = (1, 1, 32, 16)
     bias_shape = (filter_shape[-1],)
@@ -103,12 +103,12 @@ def test_conv2d_deeplabv3_1_257_257_32x1_1_32_16_with_padding(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_4_35_35_32x3_3_144_16(target, dtype):
+def test_conv2d_4_35_35_32x3_3_144_16(remote, target, dtype):
     input_shape = (4, 35, 35, 32)
     filter_shape = (3, 3, 32, 16)
     bias_shape = (filter_shape[-1],)
@@ -141,12 +141,12 @@ def test_conv2d_4_35_35_32x3_3_144_16(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_deeplabv3_1_513_513_3x3_3_3_32(target, dtype):
+def test_conv2d_deeplabv3_1_513_513_3x3_3_3_32(remote, target, dtype):
     input_shape = (1, 513, 513, 3)
     filter_shape = (3, 3, 3, 32)
     bias_shape = (filter_shape[-1],)
@@ -179,12 +179,12 @@ def test_conv2d_deeplabv3_1_513_513_3x3_3_3_32(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad(target, dtype):
+def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad(remote, target, dtype):
     input_shape = (1, 42, 42, 32)
     filter_shape = (3, 3, 32, 96)
     bias_shape = (1, 1, 1, 96)
@@ -219,12 +219,14 @@ def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad_pass(target, dtype):
+def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad_pass(remote, target, dtype):
     input_shape = (1, 40, 40, 32)
     filter_shape = (2, 2, 32, 96)
     bias_shape = (1, 1, 1, 96)
@@ -259,12 +261,14 @@ def test_conv2d_inceptionv3_64x35x35_96x64x3x3_nopad_pass(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_35_35_strides(target, dtype):
+def test_conv2d_inceptionv3_35_35_strides(remote, target, dtype):
     input_shape = (1, 35, 35, 48)
     filter_shape = (5, 5, 48, 64)
     bias_shape = (1, 1, 1, 64)
@@ -299,12 +303,14 @@ def test_conv2d_inceptionv3_35_35_strides(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_resnet50_v2_nhwc_3c(target, dtype):
+def test_conv2d_resnet50_v2_nhwc_3c(remote, target, dtype):
     input_shape = (1, 224, 224, 3)
     filter_shape = (7, 7, 3, 64)
     bias_shape = (1, 1, 1, 64)
@@ -340,12 +346,12 @@ def test_conv2d_resnet50_v2_nhwc_3c(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_inceptionv3_nhwc_3c(target, dtype):
+def test_conv2d_inceptionv3_nhwc_3c(remote, target, dtype):
     input_shape = (1, 299, 299, 3)
     filter_shape = (3, 3, 3, 64)
     bias_shape = (1, 1, 1, 64)
@@ -380,12 +386,12 @@ def test_conv2d_inceptionv3_nhwc_3c(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_1x1_16c16spatial(target, dtype):
+def test_conv2d_1x1_16c16spatial(remote, target, dtype):
     input_shape = (1, 128, 128, 16)
     filter_shape = (4, 4, 16, 32)
     bias_shape = (1, 1, 1, 32)
@@ -420,12 +426,12 @@ def test_conv2d_1x1_16c16spatial(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_4x4_16c16pad(target, dtype):
+def test_conv2d_4x4_16c16pad(remote, target, dtype):
     input_shape = (1, 256, 256, 32)
     filter_shape = (4, 4, 32, 32)
     bias_shape = (1, 1, 1, 32)
@@ -460,12 +466,12 @@ def test_conv2d_4x4_16c16pad(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_4x4x4_16c16pad(target, dtype):
+def test_conv2d_4x4x4_16c16pad(remote, target, dtype):
     input_shape = (1, 256, 256, 32)
     filter_shape = (4, 4, 32, 4)
     bias_shape = (1, 1, 1, 4)
@@ -499,12 +505,12 @@ def test_conv2d_4x4x4_16c16pad(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_yolov3_v2_nhwc_3c(target, dtype):
+def test_conv2d_yolov3_v2_nhwc_3c(remote, target, dtype):
     input_shape = (1, 13, 13, 1024)
     filter_shape = (1, 1, 1024, 255)
     A = relay.var("data", shape=input_shape, dtype=dtype)
@@ -532,12 +538,12 @@ def test_conv2d_yolov3_v2_nhwc_3c(target, dtype):
         "weight": tvm.nd.array(filter_data),
     }
 
-    build_run_compare(mod, params, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_vgg16_winograd_4d(target, dtype):
+def test_conv2d_vgg16_winograd_4d(remote, target, dtype):
     input_shape = (1, 28, 28, 512)
     filter_shape = (3, 3, 512, 512)
     bias_shape = (1, 1, 1, 512)
@@ -577,7 +583,7 @@ def test_conv2d_vgg16_winograd_4d(target, dtype):
             f'{{"input": ["opencl -keys=adreno,opencl,gpu -device=adreno -max_num_threads=256", "conv2d_nhwc_winograd.image2d", [["TENSOR", [1, 28, 28, 512], "{dtype}"], ["TENSOR", [3, 3, 512, 512], "{dtype}"], [1, 1], [1, 1, 1, 1], [1, 1], "{dtype}"], {{}}], "config": {{"index": 1591, "code_hash": null, "entity": [["auto_unroll_max_step", "ot", 4], ["tile_y", "sp", [-1, 1, 32]], ["tile_x", "sp", [-1, 4, 2]], ["tile_rc", "sp", [-1, 8]]]}}, "result": [[0.0037244], 0, 7.06374192237854, 1653898629.7427933], "version": 0.2, "tvm_version": "0.8.dev0"}}\n'
         )
     graph = build_run_compare(
-        mod, params1, {"data": input_shape}, dtype, target, stat_file=stat_file
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, stat_file=stat_file
     )
     matches = re.findall("winograd", graph)
     assert len(matches) > 0
@@ -585,7 +591,7 @@ def test_conv2d_vgg16_winograd_4d(target, dtype):
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_winograd_conv(target, dtype):
+def test_conv2d_winograd_conv(remote, target, dtype):
     input_shape = (1, 3, 3, 4)
     A = relay.var("data", shape=input_shape, dtype=dtype)
     filter_shape3 = (3, 3, 4, 8)
@@ -638,7 +644,7 @@ def test_conv2d_winograd_conv(target, dtype):
             f'{{"input": ["opencl -keys=adreno,opencl,gpu -device=adreno -max_num_threads=256", "conv2d_nhwc_winograd.image2d", [["TENSOR", [1, 3, 3, 4], "{dtype}"], ["TENSOR", [3, 3, 4, 8], "{dtype}"], [1, 1], [1, 1, 1, 1], [1, 1], "{dtype}"], {{}}], "config": {{"index": 1591, "code_hash": null, "entity": [["auto_unroll_max_step", "ot", 4], ["tile_y", "sp", [-1, 1, 32]], ["tile_x", "sp", [-1, 4, 2]], ["tile_rc", "sp", [-1, 8]]]}}, "result": [[0.0037244], 0, 7.06374192237854, 1653898629.7427933], "version": 0.2, "tvm_version": "0.8.dev0"}}\n'
         )
     graph = build_run_compare(
-        mod, params1, {"data": input_shape}, dtype, target, stat_file=stat_file
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, stat_file=stat_file
     )
     matches = re.findall("winograd", graph)
     assert len(matches) > 0
@@ -646,7 +652,7 @@ def test_conv2d_winograd_conv(target, dtype):
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_conv2d_winograd_non_rect(target, dtype):
+def test_conv2d_winograd_non_rect(remote, target, dtype):
     input_shape = (1, 36, 64, 771)
     A = relay.var("data", shape=input_shape, dtype=dtype)
     filter_shape = (3, 3, 771, 128)
@@ -678,7 +684,11 @@ def test_conv2d_winograd_non_rect(target, dtype):
             f'{{"input": ["opencl -keys=adreno,opencl,gpu -device=adreno -max_num_threads=256 -texture_spatial_limit=16384 -thread_warp_size=1", "conv2d_nhwc_winograd.image2d", [["TENSOR", [1, 36, 64, 771], "{dtype}"], ["TENSOR", [3, 3, 771, 128], "{dtype}"], [1, 1], [1, 1, 1, 1], [1, 1], "{dtype}"], {{}}], "config": {{"index": 5399, "code_hash": null, "entity": [["auto_unroll_max_step", "ot", 16], ["tile_y", "sp", [-1, 1, 32]], ["tile_x", "sp", [-1, 4, 8]], ["tile_rc", "sp", [-1, 193]]]}}, "result": [[0.0037244], 0, 7.06374192237854, 1653898629.7427933], "version": 0.2, "tvm_version": "0.8.dev0"}}\n'
         )
     graph = build_run_compare(
-        mod, params1, {"data": input_shape}, dtype, target, stat_file=stat_file
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, stat_file=stat_file
     )
     matches = re.findall("winograd", graph)
     assert len(matches) > 0
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relay/opencl_texture/test_depthwise_conv2d_nchw_texture.py
+++ b/tests/python/relay/opencl_texture/test_depthwise_conv2d_nchw_texture.py
@@ -27,7 +27,7 @@ dtype = tvm.testing.parameter("float32")
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_bias_nchwc(target, dtype):
+def test_depthwise_conv2d_bias_nchwc(remote, target, dtype):
     input_shape = (1, 64, 112, 112)
     filter_shape = (64, 1, 3, 3)
     bias_shape = (1, 64, 1, 1)
@@ -64,12 +64,14 @@ def test_depthwise_conv2d_bias_nchwc(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_nchwc(target, dtype):
+def test_depthwise_conv2d_nchwc(remote, target, dtype):
     input_shape = (1, 64, 112, 112)
     filter_shape = (64, 1, 3, 3)
     bias_shape = (1, 64, 1, 1)
@@ -101,12 +103,14 @@ def test_depthwise_conv2d_nchwc(target, dtype):
         "weight": tvm.nd.array(filter_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target, [], gpu_preprocess)
+    build_run_compare(
+        remote, mod, params1, {"data": input_shape}, {"data": dtype}, target, [], gpu_preprocess
+    )
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_bias_nchw(target, dtype):
+def test_depthwise_conv2d_bias_nchw(remote, target, dtype):
     input_shape = (1, 64, 112, 112)
     filter_shape = (64, 1, 3, 3)
     bias_shape = (1, 64, 1, 1)
@@ -143,12 +147,12 @@ def test_depthwise_conv2d_bias_nchw(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_repack_bias_nchw(target, dtype):
+def test_depthwise_conv2d_repack_bias_nchw(remote, target, dtype):
     input_shape = (1, 63, 112, 112)
     filter_shape = (63, 1, 3, 3)
     bias_shape = (1, 63, 1, 1)
@@ -185,4 +189,8 @@ def test_depthwise_conv2d_repack_bias_nchw(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relay/opencl_texture/test_depthwise_conv2d_nhwc_texture.py
+++ b/tests/python/relay/opencl_texture/test_depthwise_conv2d_nhwc_texture.py
@@ -27,7 +27,7 @@ dtype = tvm.testing.parameter("float32")
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_deeplabv3_1_129_129_144x3_3_144_1(target, dtype):
+def test_depthwise_conv2d_deeplabv3_1_129_129_144x3_3_144_1(remote, target, dtype):
     input_shape = (1, 129, 129, 144)
     filter_shape = (3, 3, 144, 1)
     kernel_size = (filter_shape[0], filter_shape[1])
@@ -62,12 +62,12 @@ def test_depthwise_conv2d_deeplabv3_1_129_129_144x3_3_144_1(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_deeplabv3_4_35_35_576x3_3_576_1(target, dtype):
+def test_depthwise_conv2d_deeplabv3_4_35_35_576x3_3_576_1(remote, target, dtype):
     input_shape = (4, 35, 35, 576)
     filter_shape = (3, 3, 576, 1)
     kernel_size = (filter_shape[0], filter_shape[1])
@@ -102,12 +102,12 @@ def test_depthwise_conv2d_deeplabv3_4_35_35_576x3_3_576_1(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_deeplabv3_1_129_129_144x3_3_144_1_with_padding(target, dtype):
+def test_depthwise_conv2d_deeplabv3_1_129_129_144x3_3_144_1_with_padding(remote, target, dtype):
     input_shape = (1, 129, 129, 144)
     filter_shape = (3, 3, 144, 1)
     kernel_size = (filter_shape[0], filter_shape[1])
@@ -144,12 +144,12 @@ def test_depthwise_conv2d_deeplabv3_1_129_129_144x3_3_144_1_with_padding(target,
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_1_513_513_7x3_3_7_1(target, dtype):
+def test_depthwise_conv2d_1_513_513_7x3_3_7_1(remote, target, dtype):
     input_shape = (1, 513, 513, 7)
     filter_shape = (3, 3, 7, 1)
     bias_shape = (filter_shape[2],)
@@ -183,12 +183,12 @@ def test_depthwise_conv2d_1_513_513_7x3_3_7_1(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
 
 
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
-def test_depthwise_conv2d_1_513_513_3x3_3_3_1(target, dtype):
+def test_depthwise_conv2d_1_513_513_3x3_3_3_1(remote, target, dtype):
     input_shape = (1, 513, 513, 3)
     filter_shape = (3, 3, 3, 1)
     bias_shape = (filter_shape[2],)
@@ -222,4 +222,8 @@ def test_depthwise_conv2d_1_513_513_3x3_3_3_1(target, dtype):
         "bias": tvm.nd.array(bias_data),
     }
 
-    build_run_compare(mod, params1, {"data": input_shape}, dtype, target)
+    build_run_compare(remote, mod, params1, {"data": input_shape}, {"data": dtype}, target)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relay/opencl_texture/test_network.py
+++ b/tests/python/relay/opencl_texture/test_network.py
@@ -20,7 +20,6 @@ import tvm
 import numpy as np
 from tvm import relay
 from tvm.relay import testing
-import tvm.relay.testing.tf as tf_testing
 from tvm.contrib import utils
 from utils.adreno_utils import gpu_preprocess, build_run_compare, get_model
 import pytest
@@ -45,6 +44,9 @@ def convert_to_fp16(mod, dtype):
 @tvm.testing.requires_opencl
 @tvm.testing.parametrize_targets("opencl -device=adreno")
 def test_mobilenet_v1(remote, target, dtype):
+    if dtype == "float16" and remote is None:
+        # CI doesn't support fp16(half datatypes).
+        return
     mod, params, inputs, dtypes = get_model(
         "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite",
         "mobilenet_edgetpu_224_1.0_float.tflite",


### PR DESCRIPTION
RPC execution fails some times when opened multiple times per test case. Making remote object initialized from pytest session instead.

Network test cases added.

dtypes enhanced to support multiple inputs.