### PR TITLE
[ETHOSN] Add support for experimental compiler option

### DIFF
--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -101,18 +101,6 @@ def is_inline_non_compute_intensive_partitions_enabled() -> bool:
     return compiler_attrs.inline_non_compute_intensive_partitions
 
 
-def is_experimental_compiler_enabled() -> bool:
-    """
-    Determine whether the experimental compiler option is enabled.
-
-    Returns
-    -------
-    True if the experimental compiler is enabled, False if not.
-    """
-    compiler_attrs = tvm.get_global_func("relay.ext.ethos-n.get_compiler_attrs")()
-    return compiler_attrs.experimental_compiler
-
-
 def partition_for_ethosn(mod, params=None, **opts):
     """Partition the graph greedily offloading supported
     operators to Arm Ethos-N NPU.

--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -101,6 +101,18 @@ def is_inline_non_compute_intensive_partitions_enabled() -> bool:
     return compiler_attrs.inline_non_compute_intensive_partitions
 
 
+def is_experimental_compiler_enabled() -> bool:
+    """
+    Determine whether the experimental compiler option is enabled.
+
+    Returns
+    -------
+    True if the experimental compiler is enabled, False if not.
+    """
+    compiler_attrs = tvm.get_global_func("relay.ext.ethos-n.get_compiler_attrs")()
+    return compiler_attrs.experimental_compiler
+
+
 def partition_for_ethosn(mod, params=None, **opts):
     """Partition the graph greedily offloading supported
     operators to Arm Ethos-N NPU.

--- a/src/relay/backend/contrib/ethosn/codegen.cc
+++ b/src/relay/backend/contrib/ethosn/codegen.cc
@@ -713,9 +713,17 @@ runtime::ethosn::OrderedCompiledNetwork EthosnCompiler::CompileEthosnFunc(const 
   auto network_with_ids = ConstructNetwork(mod, gvar, func);
   // Now set the required build flags
   sl::CompilationOptions options = CreateOptions();
-  // Finally compile the network
+  // Set the experimental compiler if enabled, for now this is not part of the
+  // support library compilation options.
+  bool experimental_compiler = GetCompilerAttrs()->experimental_compiler;
+  if (experimental_compiler) {
+    setenv("FORCE_EXPERIMENTAL_COMPILER", "1", 1);
+  }
   std::vector<std::unique_ptr<sl::CompiledNetwork>> compiled_networks =
       sl::Compile(*network_with_ids.network, options);
+  if (experimental_compiler) {
+    unsetenv("FORCE_EXPERIMENTAL_COMPILER");
+  }
   ICHECK_GE(compiled_networks.size(), 1) << "Ethos-N compiler failed to compile network";
   auto compiled_network = std::move(compiled_networks[0]);
   // Determine the order that the inputs/outputs are in and how that corresponds to the

--- a/src/relay/backend/contrib/ethosn/codegen_ethosn.h
+++ b/src/relay/backend/contrib/ethosn/codegen_ethosn.h
@@ -252,6 +252,7 @@ struct EthosnCompilerConfigNode : public tvm::AttrsNode<EthosnCompilerConfigNode
   bool disable_winograd;
   String debug_dir;
   bool inline_non_compute_intensive_partitions;
+  bool experimental_compiler;
 
   TVM_DECLARE_ATTRS(EthosnCompilerConfigNode, "ext.attrs.EthosnCompilerConfigNode") {
     TVM_ATTR_FIELD(variant).describe("See Ethos-N documentation.").set_default("n78");
@@ -285,6 +286,9 @@ struct EthosnCompilerConfigNode : public tvm::AttrsNode<EthosnCompilerConfigNode
             "Ethos(TM)-N that are deemed 'non-compute-intensive'. The inlined functions will "
             "continue through TVM's standard compilation flow.")
         .set_default(true);
+    TVM_ATTR_FIELD(experimental_compiler)
+        .describe("An exprimental cascading compiler for Arm(R) Ethos(TM)-N.")
+        .set_default(false);
   }
 };
 

--- a/tests/python/contrib/test_ethosn/test_codegen.py
+++ b/tests/python/contrib/test_ethosn/test_codegen.py
@@ -50,3 +50,30 @@ def test_compile_with_unsupported_variant():
 
     with pytest.raises(tvm.TVMError, match=r"Unknown NPU type"):
         tei.build_and_run(mod, inputs, 1, {}, True, additional_config_args=additional_config_args)
+
+
+@requires_ethosn
+def test_experimental_compiler(capfd):
+    """Test compilation with the experimental compiler."""
+    dtype = "int8"
+    input_shape = (1, 2, 2, 2)
+
+    x = relay.var("x", shape=input_shape, dtype=dtype)
+    y = relay.reshape(x, newshape=(1, 1, 1, 8))
+    mod = tei.make_ethosn_partition(y)
+
+    additional_config_args = {
+        "variant": "n78",
+        "experimental_compiler": True,
+        "inline_non_compute_intensive_partitions": False,
+    }
+
+    tei.build(mod, {}, True, additional_config_args=additional_config_args)
+
+    # Check for hints that the experimental compiler was activated.
+    # The support library logs a warning to say the the experimental
+    # compiler is in use. Check that this warning was logged.
+    captured = capfd.readouterr()
+    assert (
+        "WARNING: Experimental Compiler in use." in captured.err
+    ), "Experimental compiler was not activated."

--- a/tests/python/contrib/test_ethosn/test_codegen.py
+++ b/tests/python/contrib/test_ethosn/test_codegen.py
@@ -77,3 +77,30 @@ def test_experimental_compiler(capfd):
     assert (
         "WARNING: Experimental Compiler in use." in captured.err
     ), "Experimental compiler was not activated."
+
+
+@requires_ethosn
+def test_without_experimental_compiler(capfd):
+    """Test compilation when the experimental compiler is not enabled."""
+    dtype = "int8"
+    input_shape = (1, 2, 2, 2)
+
+    x = relay.var("x", shape=input_shape, dtype=dtype)
+    y = relay.reshape(x, newshape=(1, 1, 1, 8))
+    mod = tei.make_ethosn_partition(y)
+
+    additional_config_args = {
+        "variant": "n78",
+        "experimental_compiler": False,
+        "inline_non_compute_intensive_partitions": False,
+    }
+
+    tei.build(mod, {}, True, additional_config_args=additional_config_args)
+
+    # Check for hints that the experimental compiler was activated.
+    # The support library logs a warning to say the the experimental
+    # compiler is in use. Check that this warning was logged.
+    captured = capfd.readouterr()
+    assert (
+        "WARNING: Experimental Compiler in use." not in captured.err
+    ), "Experimental compiler was enabled when it is not expected to be."


### PR DESCRIPTION
The support library currently supports enabling the experimental cascading compiler option via an environment variable `FORCE_EXPERIMENTAL_COMPILER`. This commit exposes the ability to enable this option through TVMC.