### PR TITLE
[RPC] Fix tracker connection termination

### DIFF
--- a/python/tvm/rpc/base.py
+++ b/python/tvm/rpc/base.py
@@ -120,13 +120,16 @@ def recvjson(sock):
     return data
 
 
-def random_key(prefix, cmap=None):
+def random_key(prefix, delimiter=":", cmap=None):
     """Generate a random key
 
     Parameters
     ----------
     prefix : str
         The string prefix
+
+    delimiter : str
+        The delimiter
 
     cmap : dict
         Conflict map
@@ -136,13 +139,30 @@ def random_key(prefix, cmap=None):
     key : str
         The generated random key
     """
-    if cmap:
-        while True:
-            key = prefix + str(random.random())
-            if key not in cmap:
-                return key
-    else:
-        return prefix + str(random.random())
+    while True:
+        key = "{}{}{}".format(prefix, delimiter, random.random())
+        if not cmap or key not in cmap:
+            break
+    return key
+
+
+def split_random_key(key, delimiter=":"):
+    """Split a random key by delimiter into prefix and random part
+
+    Parameters
+    ----------
+    key : str
+        The generated random key
+
+    Returns
+    -------
+    prefix : str
+        The string prefix
+
+    random_part : str
+        The generated random
+    """
+    return key.rsplit(delimiter, 1)
 
 
 def connect_with_retry(addr, timeout=60, retry_period=5):

--- a/python/tvm/rpc/proxy.py
+++ b/python/tvm/rpc/proxy.py
@@ -322,7 +322,7 @@ class ProxyServerHandler(object):
             rpc_key, _ = base.split_random_key(key)
             handle = self._server_pool[key]
             del self._server_pool[key]
-            new_key = base.random_key(rpc_key + ":", keyset)
+            new_key = base.random_key(rpc_key, keyset)
             self._server_pool[new_key] = handle
             keyset.add(new_key)
             new_keys.append(new_key)

--- a/python/tvm/rpc/proxy.py
+++ b/python/tvm/rpc/proxy.py
@@ -319,7 +319,7 @@ class ProxyServerHandler(object):
         new_keys = []
         # re-generate the server match key, so old information is invalidated.
         for key in keys:
-            rpc_key, _ = key.split(":")
+            rpc_key, _ = base.split_random_key(key)
             handle = self._server_pool[key]
             del self._server_pool[key]
             new_key = base.random_key(rpc_key + ":", keyset)
@@ -368,7 +368,7 @@ class ProxyServerHandler(object):
             need_update_info = False
             # report new connections
             for key in self._tracker_pending_puts:
-                rpc_key = key.rsplit(":", 1)[0]
+                rpc_key, _ = base.split_random_key(key)
                 base.sendjson(
                     self._tracker_conn, [TrackerCode.PUT, rpc_key, (self._listen_port, key), None]
                 )
@@ -403,7 +403,7 @@ class ProxyServerHandler(object):
     def _handler_ready_tracker_mode(self, handler):
         """tracker mode to handle handler ready."""
         if handler.rpc_key.startswith("server:"):
-            key = base.random_key(handler.match_key + ":", self._server_pool)
+            key = base.random_key(handler.match_key, cmap=self._server_pool)
             handler.match_key = key
             self._server_pool[key] = handler
             self._tracker_pending_puts.append(key)

--- a/python/tvm/rpc/proxy.py
+++ b/python/tvm/rpc/proxy.py
@@ -368,7 +368,7 @@ class ProxyServerHandler(object):
             need_update_info = False
             # report new connections
             for key in self._tracker_pending_puts:
-                rpc_key = key.split(":")[0]
+                rpc_key = key.rsplit(":", 1)[0]
                 base.sendjson(
                     self._tracker_conn, [TrackerCode.PUT, rpc_key, (self._listen_port, key), None]
                 )

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -157,7 +157,7 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
         old_keyset = set()
         # Report resource to tracker
         if tracker_conn:
-            matchkey = base.random_key(rpc_key + ":")
+            matchkey = base.random_key(rpc_key)
             base.sendjson(tracker_conn, [TrackerCode.PUT, rpc_key, (port, matchkey), custom_addr])
             assert base.recvjson(tracker_conn) == TrackerCode.SUCCESS
         else:
@@ -182,7 +182,7 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
                     # regenerate match key if key is acquired but not used for a while
                     if unmatch_period_count * ping_period > unmatch_timeout + ping_period:
                         logger.info("no incoming connections, regenerate key ...")
-                        matchkey = base.random_key(rpc_key + ":", old_keyset)
+                        matchkey = base.random_key(rpc_key, cmap=old_keyset)
                         base.sendjson(
                             tracker_conn, [TrackerCode.PUT, rpc_key, (port, matchkey), custom_addr]
                         )

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -348,7 +348,7 @@ class TrackerServerHandler(object):
         if "key" in conn._info:
             for value in conn.put_values:
                 _, _, _, key = value
-                rpc_key = key.split(":")[0]
+                rpc_key = key.rsplit(":", 1)[0]
                 self._scheduler_map[rpc_key].remove(value)
 
     def stop(self):

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -348,7 +348,7 @@ class TrackerServerHandler(object):
         if "key" in conn._info:
             for value in conn.put_values:
                 _, _, _, key = value
-                rpc_key = key.rsplit(":", 1)[0]
+                rpc_key, _ = base.split_random_key(key)
                 self._scheduler_map[rpc_key].remove(value)
 
     def stop(self):

--- a/tests/python/unittest/test_rpc_base.py
+++ b/tests/python/unittest/test_rpc_base.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from tvm.rpc import base
+import pytest
+import random
+
+
+@pytest.mark.parametrize("device_key", ["16e995b6", "127.0.0.1:5555"])
+def test_rpc_base_random_key(device_key):
+    random.seed(0)
+    key = base.random_key(device_key)
+    assert key.startswith(device_key)
+    res_device_key, _ = base.split_random_key(key)
+    assert device_key == res_device_key
+    # start with seed 0 as well, but use cmap arg(a conflict map)
+    # to generate another unique random key
+    random.seed(0)
+    new_key = base.random_key(device_key, cmap={key})
+    assert key != new_key
+    assert new_key.startswith(device_key)
+    res_device_key2, _ = base.split_random_key(new_key)
+    assert device_key == res_device_key2
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/unittest/test_runtime_rpc.py
+++ b/tests/python/unittest/test_runtime_rpc.py
@@ -448,10 +448,10 @@ def test_local_func():
 
 
 @tvm.testing.requires_rpc
-def test_rpc_tracker_register():
+@pytest.mark.parametrize("device_key", ["test_device", "127.0.0.1:5555"])
+def test_rpc_tracker_register(device_key):
     # test registration
     tracker = Tracker(port=9000, port_end=10000)
-    device_key = "test_device"
     server1 = rpc.Server(
         host="127.0.0.1",
         port=9000,
@@ -521,10 +521,10 @@ def _target(host, port, device_key, timeout):
 
 
 @tvm.testing.requires_rpc
-def test_rpc_tracker_request():
+@pytest.mark.parametrize("device_key", ["test_device", "127.0.0.1:5555"])
+def test_rpc_tracker_request(device_key):
     # test concurrent request
     tracker = Tracker(port=9000, port_end=10000)
-    device_key = "test_device"
     server = rpc.Server(
         port=9000,
         port_end=10000,
@@ -562,14 +562,13 @@ def test_rpc_tracker_request():
 
 
 @tvm.testing.requires_rpc
-def test_rpc_tracker_via_proxy():
+@pytest.mark.parametrize("device_key", ["test_device", "127.0.0.1:5555"])
+def test_rpc_tracker_via_proxy(device_key):
     """
          tracker
          /     \
     Host   --   Proxy -- RPC server
     """
-
-    device_key = "test_device"
 
     tracker_server = Tracker(port=9000, port_end=9100)
     proxy_server = Proxy(


### PR DESCRIPTION
In a wireless connection situation (android example below) we have a device key containing a colon character(**:**).

_ANDROID_SERIAL_NUMBER = 192.168.0.143:5555_ 

```
C:\Users\icemist>docker exec -it ice_tvm_container adb devices
List of devices attached
192.168.0.143:5555     device
```
In this case we get an error:
```
ERROR:asyncio:Exception in callback None()
handle: <Handle cancelled>
Traceback (most recent call last):
  File "/usr/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/venv/apache-tvm-py3.8/lib/python3.8/site-packages/tornado/platform/asyncio.py", line 206, in _handle_events
    handler_func(fileobj, events)
  File "/git/tvm/python/tvm/rpc/tornado_util.py", line 41, in _event_handler
    self._event_handler(events)
  File "/git/tvm/python/tvm/rpc/tornado_util.py", line 79, in _event_handler
    if self._update_read() and (events & self._ioloop.WRITE):
  File "/git/tvm/python/tvm/rpc/tornado_util.py", line 121, in _update_read
    self.close()
  File "/git/tvm/python/tvm/rpc/tornado_util.py", line 67, in close
    self.on_close()
  File "/git/tvm/python/tvm/rpc/tracker.py", line 298, in on_close
    self._tracker.close(self)
  File "/git/tvm/python/tvm/rpc/tracker.py", line 353, in close
    self._scheduler_map[rpc_key].remove(value)
KeyError: '127.0.0.1'
```

For example, test_rpc_tracker_via_proxy hangs if the device key format contains a colon.

The point is that the keys before using the split have a format like:
conn.put_value has: _hexagon-dev.127.0.0.1:5555:0.513619_
_tracker_pending_puts has: _127.0.0.1:5555:0.2809967317812382_


