### PR TITLE
[TOPI] Add handwritten matvec for dynamic cases

### DIFF
--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -518,9 +518,9 @@ def dense_strategy_cpu(attrs, inputs, out_type, target):
     strategy = _op.OpStrategy()
     # For dynamic matrix-vector multiply we use a hand written kernel.
     if (
-        inputs[0].shape[0] == 1
-        and is_dynamic_shape(inputs[0].shape)
-        or is_dynamic_shape(inputs[1].shape)
+        isinstance(inputs[0].shape[0], (int, tir.IntImm))
+        and inputs[0].shape[0] == 1
+        and (is_dynamic_shape(inputs[0].shape) or is_dynamic_shape(inputs[1].shape))
     ):
         strategy.add_implementation(
             wrap_compute_dense(topi.x86.dense_dynamic),

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -508,7 +508,7 @@ def matmul_strategy_cpu(attrs, inputs, out_type, target):
 
 
 def is_dynamic_shape(shape):
-    return any([isinstance(x, tir.Any) or isinstance(x, tir.SizeVar) for x in shape])
+    return any([isinstance(x, (tir.Any, tir.SizeVar)) for x in shape])
 
 
 @dense_strategy.register("cpu")

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -516,9 +516,8 @@ def dense_strategy_cpu(attrs, inputs, out_type, target):
     """dense x86 strategy"""
 
     strategy = _op.OpStrategy()
-    # For dynamic shapes we use a hand written kernel. Right now it only
-    # supports matrix-vector multiplication.
-    if is_dynamic_shape(inputs[0].shape) or is_dynamic_shape(inputs[1].shape):
+    # For dynamic matrix-vector multiply we use a hand written kernel.
+    if inputs[0].shape[0] == 1 and is_dynamic_shape(inputs[0].shape) or is_dynamic_shape(inputs[1].shape):
         strategy.add_implementation(
             wrap_compute_dense(topi.x86.dense_dynamic),
             wrap_topi_schedule(topi.x86.schedule_dense_dynamic),

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -507,7 +507,7 @@ def matmul_strategy_cpu(attrs, inputs, out_type, target):
     return strategy
 
 
-def is_any(shape):
+def is_dynamic_shape(shape):
     return any([isinstance(x, tir.Any) or isinstance(x, tir.SizeVar) for x in shape])
 
 
@@ -518,7 +518,7 @@ def dense_strategy_cpu(attrs, inputs, out_type, target):
     strategy = _op.OpStrategy()
     # For dynamic shapes we use a hand written kernel. Right now it only
     # supports matrix-vector multiplication.
-    if is_any(inputs[0].shape) or is_any(inputs[1].shape):
+    if is_dynamic_shape(inputs[0].shape) or is_dynamic_shape(inputs[1].shape):
         strategy.add_implementation(
             wrap_compute_dense(topi.x86.dense_dynamic),
             wrap_topi_schedule(topi.x86.schedule_dense_dynamic),

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -517,7 +517,11 @@ def dense_strategy_cpu(attrs, inputs, out_type, target):
 
     strategy = _op.OpStrategy()
     # For dynamic matrix-vector multiply we use a hand written kernel.
-    if inputs[0].shape[0] == 1 and is_dynamic_shape(inputs[0].shape) or is_dynamic_shape(inputs[1].shape):
+    if (
+        inputs[0].shape[0] == 1
+        and is_dynamic_shape(inputs[0].shape)
+        or is_dynamic_shape(inputs[1].shape)
+    ):
         strategy.add_implementation(
             wrap_compute_dense(topi.x86.dense_dynamic),
             wrap_topi_schedule(topi.x86.schedule_dense_dynamic),

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -480,3 +480,44 @@ def matmul_dnnl(
 def schedule_matmul_dnnl(_, outs):
     """Create schedule for matmul_dnnl."""
     return generic.schedule_extern(outs)
+
+
+def dense_dynamic(A, B, bias, dtype):
+    """Compute for dense with dynamic shape"""
+
+    # Right now we only support matrix-vector multiplication with lhs as the
+    # vector. We don't need to do much optimization here because the access
+    # pattern and parallelization are straight forward.
+    def gen_ir(a, b, bias, c):
+        ib = tvm.tir.ir_builder.create()
+        A = ib.buffer_ptr(a)
+        B = ib.buffer_ptr(b)
+        C = ib.buffer_ptr(c)
+        with ib.for_range(0, b.shape[0], name="j", kind="parallel") as j:
+            if bias is None:
+                C[0, j] = 0.0
+            else:
+                C[0, j] = bias[j]
+            with ib.for_range(0, b.shape[1], name="k") as k:
+                C[0, j] += A[0, k] * B[j, k]
+        return ib.get()
+
+    out_shape = (A.shape[0], B.shape[0])
+    out_buf = tvm.tir.decl_buffer(out_shape, dtype, "out_buf")
+    out = te.extern(
+        [out_shape],
+        [A, B, bias],
+        lambda ins, outs: gen_ir(*ins, *outs),
+        dtype=dtype,
+        out_buffers=[out_buf],
+        name="dense_dynamic_cpu",
+        tag="dense_dynamic_cpu",
+    )
+    return out
+
+
+def schedule_dense_dynamic(outs):
+    """Create schedule for dense_dynamic."""
+    s = te.create_schedule([o.op for o in outs])
+    return s
+    return generic.schedule_extern(outs)

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -485,6 +485,8 @@ def schedule_matmul_dnnl(_, outs):
 def dense_dynamic(A, B, bias, dtype):
     """Compute for dense with dynamic shape"""
 
+    assert A[0].shape == 1, "Only dynamic matrix vector multiplication with vector LHS is supported"
+
     # Right now we only support matrix-vector multiplication with lhs as the
     # vector. We don't need to do much optimization here because the access
     # pattern and parallelization are straight forward.

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -520,6 +520,4 @@ def dense_dynamic(A, B, bias, dtype):
 
 def schedule_dense_dynamic(outs):
     """Create schedule for dense_dynamic."""
-    s = te.create_schedule([o.op for o in outs])
-    return s
     return generic.schedule_extern(outs)

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -485,36 +485,55 @@ def schedule_matmul_dnnl(_, outs):
 def dense_dynamic(A, B, bias, dtype):
     """Compute for dense with dynamic shape"""
 
-    assert A[0].shape == 1, "Only dynamic matrix vector multiplication with vector LHS is supported"
+    assert A.shape[0] == 1, "Only dynamic matrix vector multiplication with vector LHS is supported"
 
     # Right now we only support matrix-vector multiplication with lhs as the
     # vector. We don't need to do much optimization here because the access
     # pattern and parallelization are straight forward.
-    def gen_ir(a, b, bias, c):
+    def gen_ir(a, b, c):
         ib = tvm.tir.ir_builder.create()
         A = ib.buffer_ptr(a)
         B = ib.buffer_ptr(b)
         C = ib.buffer_ptr(c)
         with ib.for_range(0, b.shape[0], name="j", kind="parallel") as j:
-            if bias is None:
-                C[0, j] = 0.0
-            else:
-                C[0, j] = bias[j]
+            C[0, j] = 0.0
+            with ib.for_range(0, b.shape[1], name="k") as k:
+                C[0, j] += A[0, k] * B[j, k]
+        return ib.get()
+
+    def gen_ir_bias(a, b, bias, c):
+        ib = tvm.tir.ir_builder.create()
+        A = ib.buffer_ptr(a)
+        B = ib.buffer_ptr(b)
+        C = ib.buffer_ptr(c)
+        with ib.for_range(0, b.shape[0], name="j", kind="parallel") as j:
+            C[0, j] = bias[j]
             with ib.for_range(0, b.shape[1], name="k") as k:
                 C[0, j] += A[0, k] * B[j, k]
         return ib.get()
 
     out_shape = (A.shape[0], B.shape[0])
     out_buf = tvm.tir.decl_buffer(out_shape, dtype, "out_buf")
-    out = te.extern(
-        [out_shape],
-        [A, B, bias],
-        lambda ins, outs: gen_ir(*ins, *outs),
-        dtype=dtype,
-        out_buffers=[out_buf],
-        name="dense_dynamic_cpu",
-        tag="dense_dynamic_cpu",
-    )
+    if bias is None:
+        out = te.extern(
+            [out_shape],
+            [A, B],
+            lambda ins, outs: gen_ir(*ins, *outs),
+            dtype=dtype,
+            out_buffers=[out_buf],
+            name="dense_dynamic_cpu",
+            tag="dense_dynamic_cpu",
+        )
+    else:
+        out = te.extern(
+            [out_shape],
+            [A, B, bias],
+            lambda ins, outs: gen_ir_bias(*ins, *outs),
+            dtype=dtype,
+            out_buffers=[out_buf],
+            name="dense_dynamic_cpu",
+            tag="dense_dynamic_cpu",
+        )
     return out
 
 

--- a/tests/python/topi/python/test_topi_dense.py
+++ b/tests/python/topi/python/test_topi_dense.py
@@ -45,6 +45,7 @@ _dense_implementations = {
     "cpu": [
         (topi.x86.dense_nopack, topi.x86.schedule_dense_nopack),
         (topi.x86.dense_pack, topi.x86.schedule_dense_pack),
+        (topi.x86.dense_dynamic, topi.x86.schedule_dense_dynamic),
     ],
     "gpu": [
         (topi.gpu.dense_small_batch, topi.gpu.schedule_dense_small_batch),
@@ -136,6 +137,8 @@ def test_dense(
         implementations = tvm.topi.testing.dispatch(target, _dense_implementations)
 
     for fcompute, fschedule in implementations:
+        if fcompute == topi.x86.dense_dynamic and (batch_size != 1 or in_dtype != "float32"):
+            continue
         with tvm.target.Target(target):
             D = fcompute(A, B, C if use_bias else None, out_dtype)
             D = topi.nn.relu(D)


### PR DESCRIPTION
Add a handwritten matrix-vector multiplication implementation for dynamic cases on cpu. This avoids crashing when a dynamic shape is present. Only supports vector LHS and float32 for now.