### PR TITLE
[TE] Remove binding to temporary variable

### DIFF
--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -156,8 +156,8 @@ BlockRealize GenerateBlockFromTensors(const te::ComputeOp& compute_op,
       Var new_var(iter_var->var->name_hint, iter_var->var->dtype);
       var_map[iter_var->var.get()] = new_var;
 
-      const PrimExpr& dom_min = analyzer->Simplify(iter_var->dom->min);
-      const PrimExpr& dom_extent = analyzer->Simplify(iter_var->dom->extent);
+      PrimExpr dom_min = analyzer->Simplify(iter_var->dom->min);
+      PrimExpr dom_extent = analyzer->Simplify(iter_var->dom->extent);
       iter_vars.push_back(IterVar(Range::FromMinExtent(dom_min, dom_extent), new_var,
                                   iter_var->iter_type, iter_var->thread_tag, iter_var->span));
     }


### PR DESCRIPTION
The call to `analyzer->Simplify` returns a `PrimExpr` object.  Binding a `const PrimExpr&` to this temporary object results in a dangling reference.