### PR TITLE
[TVMScript] Output elif where possible

### DIFF
--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1259,10 +1259,22 @@ Doc TVMScriptPrinter::VisitStmt_(const IfThenElseNode* op) {
   Doc doc;
   doc << "if " << Print(op->condition) << ":";
   doc << Doc::Indent(4, Doc::NewLine() << PrintBody(op->then_case));
-  if (!is_one(op->condition) && op->else_case) {
-    doc << Doc::NewLine();
-    doc << "else:" << Doc::Indent(4, Doc::NewLine() << PrintBody(op->else_case.value()));
+
+  Optional<Stmt> else_case = op->else_case;
+  while (else_case) {
+    if (auto* else_if = else_case.value().as<IfThenElseNode>()) {
+      doc << Doc::NewLine();
+      doc << "elif " << Print(else_if->condition) << ":";
+      doc << Doc::Indent(4, Doc::NewLine() << PrintBody(else_if->then_case));
+
+      else_case = else_if->else_case;
+    } else {
+      doc << Doc::NewLine();
+      doc << "else:" << Doc::Indent(4, Doc::NewLine() << PrintBody(else_case.value()));
+      break;
+    }
   }
+
   return doc;
 }
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3467,6 +3467,45 @@ def implicit_evaluate():
     return func
 
 
+def if_true_else():
+    @T.prim_func
+    def func() -> None:
+        if True:
+            T.evaluate(0)
+        else:
+            T.evaluate(1)
+
+    return func
+
+
+def elif_chain_without_else():
+    @T.prim_func
+    def func(i: T.int32) -> None:
+        if i == 0:
+            T.evaluate(0)
+        elif i == 1:
+            T.evaluate(1)
+        elif i == 2:
+            T.evaluate(2)
+
+    return func
+
+
+def elif_chain_with_else():
+    @T.prim_func
+    def func(i: T.int32) -> None:
+        if i == 0:
+            T.evaluate(0)
+        elif i == 1:
+            T.evaluate(1)
+        elif i == 2:
+            T.evaluate(2)
+        else:
+            T.evaluate(3)
+
+    return func
+
+
 ir_generator = tvm.testing.parameter(
     opt_gemm_normalize,
     opt_gemm_lower,
@@ -3519,6 +3558,9 @@ ir_generator = tvm.testing.parameter(
     bool_cast,
     return_none,
     implicit_evaluate,
+    if_true_else,
+    elif_chain_without_else,
+    elif_chain_with_else,
 )
 
 


### PR DESCRIPTION
When a TIR `IfThenElseNode::else_case` is itself a `IfThenElse` node, it may be printed as `elif` instead of `else: if ...`.  The `elif` syntax was already handled on the parsing side, so this commit only changes the TVMScript printer.

This change also incidentally altered the printer's output for an else block whose condition is `True`.  Previously, these were dropped from the output altogether.  Now, they are retained in the else block. Removing no-op statements should be done by a transformation pass, not a printer/parser round trip, so this change in behavior makes sense to keep.

Below are shown the same prim func, printed before and after this change.

```python
# Before
@T.prim_func
def func(i: T.int32):
    # body
    if i == 0:
        T.evaluate(0)
    else:
        if i == 1:
            T.evaluate(1)
        else:
            if i == 2:
                T.evaluate(2)
            else:
                T.evaluate(3)

# After
@T.prim_func
def func(i: T.int32):
    # body
    if i == 0:
        T.evaluate(0)
    elif i == 1:
        T.evaluate(1)
    elif i == 2:
        T.evaluate(2)
    else:
        T.evaluate(3)
```