### PR TITLE
[OpenCL] Improve OpenCL version detection

### DIFF
--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -263,7 +263,7 @@ class OpenCLWorkspace : public DeviceAPI {
     ICHECK(IsOpenCLDevice(dev));
     this->Init();
     ICHECK(dev.device_id >= 0 && static_cast<size_t>(dev.device_id) < queues.size())
-        << "Invalid OpenCL device_id=" << dev.device_id;
+        << "Invalid OpenCL device_id=" << dev.device_id << ". " << GetError();
     return queues[dev.device_id];
   }
   // get the event queue of the context
@@ -271,7 +271,7 @@ class OpenCLWorkspace : public DeviceAPI {
     ICHECK(IsOpenCLDevice(dev));
     this->Init();
     ICHECK(dev.device_id >= 0 && static_cast<size_t>(dev.device_id) < queues.size())
-        << "Invalid OpenCL device_id=" << dev.device_id;
+        << "Invalid OpenCL device_id=" << dev.device_id << ". " << GetError();
     return events[dev.device_id];
   }
   // is current clCommandQueue in profiling mode
@@ -310,6 +310,13 @@ class OpenCLWorkspace : public DeviceAPI {
   static OpenCLWorkspace* Global();
 
   void CopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamHandle stream) final;
+
+ private:
+  std::string GetError() {
+    if (this->devices.size() == 0) return noDevicesErrorMsg;
+    return "";
+  }
+  std::string noDevicesErrorMsg = "";
 };
 
 /*! \brief Thread local workspace */


### PR DESCRIPTION
As it was mentioned in #13362, it would be nice to add check when the user is using a version of libOpenCL.so that is too old.

In this PR we introduce this functionality. In the `init` method, we traverse through all OpenCL devices and check their version. If the version is older than the target version in TVM, then we notify the user that we will skip this device. We cannot throw any exception from method `init` because it is possible that you have compiled host code with OpenCL support, but the host device won't have any OpenCL device which is supported by TVM (e.g. they all have too old version of libOpenCL.so or there is no OpenCL driver installed). From OpenCL codegen we call function OpenCLModuleCreate. In the OpenCLModuleCreate init function might be called and in this case an exception will be generated on the host side although that the target device might be supported by TVM. This is why we don't throw any exceptions in the init function.

If in the runtime we use some OpenCL methods and the list of the devices is empty, then we will generate an exception and notify user that possible reason is because version of libOpenCL.so is too old.