### PR TITLE
[TIR][Hexagon] Async DMA fixups

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -229,7 +229,7 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.dma_copy").set_body([](TVMArgs args, TVM
   void* src = args[2];
   int size = args[3];
   ICHECK(size > 0);
-  bool bypass_cache = args[3];
+  bool bypass_cache = args[4];
 
   int ret = DMA_RETRY;
   do {

--- a/src/tir/transforms/lower_async_dma.cc
+++ b/src/tir/transforms/lower_async_dma.cc
@@ -71,7 +71,7 @@ class AsyncDMALowerer : public StmtExprMutator {
           Evaluate(Call(DataType::Int(32), builtin::dma_wait(), {queue_id, async_wait->value}));
 
       // concatenate the call with the body and return
-      return SeqStmt({call_dma_wait, async_wait->body});
+      return SeqStmt({call_dma_wait, StmtExprMutator::VisitStmt(async_wait->body)});
 
       // Convert this, for example:
       // attr [0] "async_commit_queue_scope" = 0;

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -329,12 +329,14 @@ class BuiltinLower : public StmtExprMutator {
     PrimExpr dst = op->args[1];
     PrimExpr src = op->args[2];
     PrimExpr size = op->args[3];
+    PrimExpr bypass_cache = op->args[4];
 
     std::string fdevapi_prefix =
         "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
 
-    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
-                            {StringImm(fdevapi_prefix + ".dma_copy"), queue_id, dst, src, size});
+    Call call_packed =
+        Call(DataType::Int(32), builtin::tvm_call_packed(),
+             {StringImm(fdevapi_prefix + ".dma_copy"), queue_id, dst, src, size, bypass_cache});
     return VisitExpr(call_packed);
   }
 


### PR DESCRIPTION
Bug fixes for async DMA lowering with Hexagon mode bypass:
1. Bypass is currently always on.
2. The LowerAsyncDMA doesn't visit the body of an async_wait attribute. 


cc @adstraw 