### PR TITLE
[RPC] Catch potential race-condition exception on termination

### DIFF
--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -349,7 +349,14 @@ class TrackerServerHandler(object):
             for value in conn.put_values:
                 _, _, _, key = value
                 rpc_key = key.split(":")[0]
-                self._scheduler_map[rpc_key].remove(value)
+                try:
+                    smap = self._scheduler_map[rpc_key]
+                except KeyError as e:
+                    # someone removed it already
+                    pass
+                else:
+                    smap.remove(value)
+
 
     def stop(self):
         """Safely stop tracker."""


### PR DESCRIPTION
Observed a race condition on Hexagon where the rpc_key got removed from the scheduler map and thus wasn't in the remove loop anymore and throwing a KeyError. A simple try-except on the first try makes sure it is still there before removal (if we still have to).