### PR TITLE
[ci][docs] Fix docs deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-11-17T23:53:21.059864
+// Generated at 2022-11-19T01:24:31.191996
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
@@ -3646,10 +3646,9 @@ def deploy() {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
                     sh(
-                script: "./${jenkins_scripts_root}/s3.py --action download --bucket ${s3_bucket} --prefix ${s3_prefix}/docs",
-                label: 'Download artifacts from S3',
-              )
-
+                      script: "./${jenkins_scripts_root}/s3.py --action download --bucket ${s3_bucket} --prefix ${s3_prefix}/docs --items docs.tgz",
+                      label: 'Download docs folder from S3',
+                    )
                     deploy_docs()
           }
         }

--- a/ci/jenkins/Deploy.groovy.j2
+++ b/ci/jenkins/Deploy.groovy.j2
@@ -91,7 +91,10 @@ def deploy() {
           ws="tvm/deploy-docs",
         ) %}
           init_git()
-          {{ m.download_artifacts(tag='docs') }}
+          sh(
+            script: "./${jenkins_scripts_root}/s3.py --action download --bucket ${s3_bucket} --prefix ${s3_prefix}/docs --items docs.tgz",
+            label: 'Download docs folder from S3',
+          )
           deploy_docs()
         {% endcall %}
         {% call m.deploy_step(

--- a/ci/scripts/jenkins/s3.py
+++ b/ci/scripts/jenkins/s3.py
@@ -129,7 +129,12 @@ if __name__ == "__main__":
 
     for item in items:
         if action == Action.DOWNLOAD:
-            stdout = s3(source=s3_path, destination=item, recursive=True)
+            source = s3_path
+            recursive = True
+            if item != ".":
+                source = s3_path + "/" + item
+                recursive = False
+            stdout = s3(source=source, destination=item, recursive=recursive)
             files = parse_output_files(stdout)
             chmod(files)
             for file in files:


### PR DESCRIPTION
The docs deploy is broken following #13335: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/main/4754/pipeline

This avoids downloading the whole docs directory (which is just used to host documentation previews for PRs) and just grabs the `docs.tgz` which is actually used to deploy the docs. Tested locally that the download works successfully via:

```bash
./ci/scripts/jenkins/s3.py --action download --bucket tvm-jenkins-artifacts-prod --prefix tvm/main/4754/docs --items docs.tgz
```


Fixes #13440