### PR TITLE
[MetaSchedule] Add MultiLevelTilingHexagon to create simple schedules…

### DIFF
--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -205,6 +205,32 @@ class ScheduleRule : public runtime::ObjectRef {
       Optional<Array<Integer>> vector_load_lens, Optional<Map<String, ObjectRef>> reuse_read,
       Optional<Map<String, ObjectRef>> reuse_write, bool use_software_pipeline);
 
+
+  /*!
+   * \brief Extension of MultiLevelTiling for auto-tensorization with multiple groups of candidate
+   * tensor core intrinsics
+   * \param intrin_groups A list of groups of tensor core intrinsics. The map should contain key
+   * "compute" which represents the tensor intrin for computation. The value of the map should be 
+   * names of tensor intrinsics, must be registered via
+   * TensorIntrin.register(...) beforehand
+   * \param structure The tiling structure. Recommended:
+   * - 'SRSRS' on Hexagon
+   * \param tile_binds For each level of tiles, which thread axis it is bound to. These are not
+   * supported on hexagon. 
+   * \param max_innermost_factor The maximum size of the innermost factor. NullOpt means no limit
+   * \param vector_load_lens The length of vector lane in vectorized cooperative fetching.
+   * NullOpt means disable vectorization
+   * \param reuse_read Data reuse configuration for reading. NullOpt means no reuse.
+   * \param reuse_write Data reuse configuration for writing. NullOpt means no reuse.
+   * \param use_software_pipeline Whether use the software pipeline.
+   * \return The schedule rule created
+   */
+  TVM_DLL static ScheduleRule MultiLevelTilingHexagon(
+      Array<Map<String, String>> intrin_groups, String structure,
+      Optional<Array<String>> tile_binds, Optional<Integer> max_innermost_factor,
+      Optional<Array<Integer>> vector_load_lens, Optional<Map<String, ObjectRef>> reuse_read,
+      Optional<Map<String, ObjectRef>> reuse_write, bool use_software_pipeline);
+
   /*!
    * \brief Extension of MultiLevelTiling for backends with wide vectors.
    * The loop over the innermost spatial axis of the output buffer is always vectorized with the

--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -205,18 +205,17 @@ class ScheduleRule : public runtime::ObjectRef {
       Optional<Array<Integer>> vector_load_lens, Optional<Map<String, ObjectRef>> reuse_read,
       Optional<Map<String, ObjectRef>> reuse_write, bool use_software_pipeline);
 
-
   /*!
    * \brief Extension of MultiLevelTiling for auto-tensorization with multiple groups of candidate
    * tensor core intrinsics
    * \param intrin_groups A list of groups of tensor core intrinsics. The map should contain key
-   * "compute" which represents the tensor intrin for computation. The value of the map should be 
+   * "compute" which represents the tensor intrin for computation. The value of the map should be
    * names of tensor intrinsics, must be registered via
    * TensorIntrin.register(...) beforehand
    * \param structure The tiling structure. Recommended:
    * - 'SRSRS' on Hexagon
    * \param tile_binds For each level of tiles, which thread axis it is bound to. These are not
-   * supported on hexagon. 
+   * supported on hexagon.
    * \param max_innermost_factor The maximum size of the innermost factor. NullOpt means no limit
    * \param vector_load_lens The length of vector lane in vectorized cooperative fetching.
    * NullOpt means disable vectorization

--- a/python/tvm/meta_schedule/schedule_rule/__init__.py
+++ b/python/tvm/meta_schedule/schedule_rule/__init__.py
@@ -27,6 +27,7 @@ from .cross_thread_reduction import CrossThreadReduction
 from .multi_level_tiling import (
     MultiLevelTiling,
     MultiLevelTilingTensorCore,
+    MultiLevelTilingHexagon,
     MultiLevelTilingWideVector,
     MultiLevelTilingWithIntrin,
     ReuseType,

--- a/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
+++ b/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
@@ -188,16 +188,17 @@ class MultiLevelTilingTensorCore(ScheduleRule):
             use_software_pipeline,
         )
 
+
 @register_object("meta_schedule.MultiLevelTilingHexagon")
 class MultiLevelTilingHexagon(ScheduleRule):
-    """Extension of MultiLevelTiling for auto-tensorizing with multiple groups of candidate hexagon 
+    """Extension of MultiLevelTiling for auto-tensorizing with multiple groups of candidate hexagon
     intrinsics.
 
     Parameters
     ----------
     intrin_groups : List[Mapping[str, str]]
         A list of groups of tensor core intrinsics. The map should contain key
-        "compute" which represents the tensor intrin for computation. The value of the map should be 
+        "compute" which represents the tensor intrin for computation. The value of the map should be
         names of tensor intrinsics, must be registered via
         TensorIntrin.register(...) beforehand
     structure : str
@@ -240,6 +241,7 @@ class MultiLevelTilingHexagon(ScheduleRule):
             reuse_write.as_dict() if reuse_write is not None else None,
             use_software_pipeline,
         )
+
 
 @register_object("meta_schedule.MultiLevelTilingWideVector")
 class MultiLevelTilingWideVector(ScheduleRule):

--- a/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
+++ b/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
@@ -188,6 +188,58 @@ class MultiLevelTilingTensorCore(ScheduleRule):
             use_software_pipeline,
         )
 
+@register_object("meta_schedule.MultiLevelTilingHexagon")
+class MultiLevelTilingHexagon(ScheduleRule):
+    """Extension of MultiLevelTiling for auto-tensorizing with multiple groups of candidate hexagon 
+    intrinsics.
+
+    Parameters
+    ----------
+    intrin_groups : List[Mapping[str, str]]
+        A list of groups of tensor core intrinsics. The map should contain key
+        "compute" which represents the tensor intrin for computation. The value of the map should be 
+        names of tensor intrinsics, must be registered via
+        TensorIntrin.register(...) beforehand
+    structure : str
+        The tiling structure. Recommended:
+        - 'SRSRS' on Hexagon
+    tile_bind : Optional[List[str]]
+        For each level of tiles, which thread axis it is bound to. Not supported on Hexagon.
+    max_innermost_factor : Optional[int]
+        The maximum size of the innermost factor. None means no limit
+    vector_load_lens : Optional[List[int]]
+        The length of vector lane in vectorized cooperative fetching.
+        None means disable vectorization
+    reuse_read : Optional[ReuseType]
+        Data reuse configuration for reading. None means no reuse.
+    reuse_write : Optional[ReuseType]
+        Data reuse configuration for writing. None means no reuse.
+    use_software_pipeline : bool
+        Whether to use the software pipeline.
+    """
+
+    def __init__(
+        self,
+        intrin_groups: List[Mapping[str, str]],
+        structure: str,
+        tile_binds: Optional[List[str]] = None,
+        max_innermost_factor: Optional[int] = None,
+        vector_load_lens: Optional[List[int]] = None,
+        reuse_read: Optional[ReuseType] = None,
+        reuse_write: Optional[ReuseType] = None,
+        use_software_pipeline: bool = False,
+    ) -> None:
+        self.__init_handle_by_constructor__(
+            _ffi_api.ScheduleRuleMultiLevelTilingHexagon,  # type: ignore # pylint: disable=no-member
+            intrin_groups,
+            structure,
+            tile_binds,
+            max_innermost_factor,
+            vector_load_lens,
+            reuse_read.as_dict() if reuse_read is not None else None,
+            reuse_write.as_dict() if reuse_write is not None else None,
+            use_software_pipeline,
+        )
 
 @register_object("meta_schedule.MultiLevelTilingWideVector")
 class MultiLevelTilingWideVector(ScheduleRule):

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_hexagon.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_hexagon.cc
@@ -272,8 +272,8 @@ std::vector<State> MultiLevelTilingHexagonNode::AddSoftwarePipeline(HexagonState
   sch->Annotate(cache_read_loops[cache_read_loops.size() - 2],
                 tir::attr::software_pipeline_async_stages, software_pipeline_async_stages);
 
-  // TODO: Add support for nested async pipelines.
-  // TODO: Add support for async cache writes.
+  // TODO(nverke): Add support for nested async pipelines.
+  // TODO(nverke): Add support for async cache writes.
   return {state};
 }
 

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_hexagon.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_hexagon.cc
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/meta_schedule/schedule_rule.h>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "../utils.h"
+#include "./multi_level_tiling.h"
+
+namespace tvm {
+namespace meta_schedule {
+
+using tir::BlockRV;
+using tir::LoopRV;
+using tir::Schedule;
+
+struct HexagonIntrinGroup {
+  String compute_intrin;
+
+  /*! \brief Create HexagonIntrinGroup from config in a map. The map should contains the
+   * following keys:
+   *  - compute
+   * The values of the keys should be the names of the corresponding intrinsics and should be
+   * registered via TensorIntrin.Register beforehand.
+   */
+  static HexagonIntrinGroup FromConfig(const Map<String, String>& config);
+};
+
+HexagonIntrinGroup HexagonIntrinGroup::FromConfig(const Map<String, String>& config) {
+  auto f_initialize_intrin = [&config](String key_name, String* intrin_name) {
+    CHECK(config.count(key_name)) << "ValueError: " << key_name << " is not set.";
+    *intrin_name = config.at(key_name);
+    // Check the existence of the intrin
+    tir::TensorIntrin::Get(*intrin_name);
+  };
+  HexagonIntrinGroup intrin_group;
+  f_initialize_intrin("compute", &intrin_group.compute_intrin);
+  return intrin_group;
+}
+
+class HexagonStateNode : public StateNode {
+ public:
+  /*! \brief The hexagon intrinsic group. */
+  HexagonIntrinGroup intrin_group;
+  /*! \brief The auto tensorization maping info. */
+  tir::AutoTensorizeMappingInfo mapping_info{nullptr};
+  /*! \brief The hexagon reindex block A for hexagon computation */
+  tir::BlockRV hexagon_reindex_A;
+  /*! \brief The hexagon reindex block B for hexagon computation */
+  tir::BlockRV hexagon_reindex_B;
+  /*! \brief The hexagon reindex store block for hexagon computation */
+  tir::BlockRV hexagon_reindex_store;
+
+  State Copy() const final;
+
+  static constexpr const char* _type_key = "meta_schedule.TensorCoreState";
+  TVM_DECLARE_FINAL_OBJECT_INFO(HexagonStateNode, StateNode);
+};
+
+class HexagonState : public State {
+ public:
+  explicit HexagonState(HexagonIntrinGroup intrin_group, tir::AutoTensorizeMappingInfo mapping_info, Schedule sch, BlockRV block_rv, Array<Array<tir::LoopRV>> tiles = {});
+
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(HexagonState, State, HexagonStateNode);
+};
+
+TVM_REGISTER_OBJECT_TYPE(HexagonStateNode);
+
+HexagonState::HexagonState(HexagonIntrinGroup intrin_group,
+                                 tir::AutoTensorizeMappingInfo mapping_info, Schedule sch,
+                                 BlockRV block_rv, Array<Array<LoopRV>> tiles) {
+  ObjectPtr<HexagonStateNode> node = make_object<HexagonStateNode>();
+  node->intrin_group = intrin_group;
+  node->mapping_info = mapping_info;
+  node->sch = std::move(sch);
+  node->block_rv = std::move(block_rv);
+  node->tiles = std::move(tiles);
+  data_ = std::move(node);
+}
+
+State HexagonStateNode::Copy() const {
+  ObjectPtr<HexagonStateNode> node = make_object<HexagonStateNode>(*this);
+  node->sch = sch->Copy();
+  return State(node);
+}
+
+/*!
+ * \brief Extension of MultiLevelTiling for auto-tensorizing with a single group of hexagon
+ * intrinsics.
+ */
+class MultiLevelTilingHexagonNode : public MultiLevelTilingNode {
+ private:
+  // SubRule: Add tensorization-related transformations
+  inline std::vector<State> TransformForTensorization(HexagonState state) const;
+  // Subrule: Add software pipeline
+  inline std::vector<State> AddSoftwarePipeline(HexagonState state) const;
+
+  // Override ApplySubRules to apply tensorization-specific sub-rules
+  std::vector<State> ApplySubRules(std::vector<State> states) final;
+
+  // Override Apply to apply tensorization-specific analysis before applying sub-rules
+  Array<Schedule> Apply(const Schedule& sch, const BlockRV& block_rv) final;
+
+  // Inherited from ScheduleRuleNode
+  ScheduleRule Clone() const final {
+    ObjectPtr<MultiLevelTilingHexagonNode> n =
+        make_object<MultiLevelTilingHexagonNode>(*this);
+    return ScheduleRule(n);
+  }
+
+  /*!
+   * \brief Transform and tensorize with the given tensor intrin
+   * \param state The state of the meta schedule rule
+   * \param intrin_name The name of the tensor intrin
+   * \return The loop to be tensorized. NullOpt if the workload can't be tensorized.
+   */
+  Optional<LoopRV> TransformWithTensorIntrin(HexagonStateNode* state,
+                                             const String& intrin_name) const;
+
+  /*!
+   * \brief Tile, blockize and annotate for tensorization with the given intrin
+   * \param block_rv The block to be tensorized
+   * \param intrin_name The name of the tensor intrin
+   */
+  void TileAndAnnotateTensorize(Schedule* sch, const BlockRV& block_rv,
+                                const String& intrin_name) const;
+
+ public:
+  /*! \brief The candidate hexagon intrin groups to apply */
+  std::vector<HexagonIntrinGroup> intrin_groups;
+  /*! \brief Whether to use software pipeline */
+  bool use_software_pipeline = false;
+  static constexpr const char* _type_key = "meta_schedule.MultiLevelTilingHexagon";
+  TVM_DECLARE_FINAL_OBJECT_INFO(MultiLevelTilingHexagonNode, MultiLevelTilingNode);
+
+ private:
+};
+
+// Entry of the mega rule; Inherited from ScheduleRuleNode
+Array<Schedule> MultiLevelTilingHexagonNode::Apply(const Schedule& sch, const BlockRV& block_rv) {
+  if (!NeedsMultiLevelTiling(sch->state(), sch->GetSRef(block_rv))) {
+    return {sch};
+  }
+
+  std::unordered_map<int, tir::AutoTensorizeMappingInfo> intrin_group_to_mapping_info;
+  for (int i = 0, n = intrin_groups.size(); i < n; ++i) {
+    HexagonIntrinGroup intrin_group = intrin_groups[i];
+    Optional<tir::AutoTensorizeMappingInfo> mapping_info = tir::GetAutoTensorizeMappingInfo(
+        sch->state(), sch->GetSRef(block_rv),
+        tir::TensorIntrin::Get(intrin_groups[i].compute_intrin).value()->desc);
+    if (mapping_info.defined()) {
+      intrin_group_to_mapping_info.emplace(i, mapping_info.value());
+    }
+  }
+
+  if (intrin_group_to_mapping_info.empty()) {
+    // No tensor intrinsics can be applied.
+    return {sch};
+  }
+
+  // Save the original schedule so that we can roll back transformations if tensorization
+  // fails.
+  Schedule original_sch = sch;
+
+  std::vector<State> initial_states;
+  for (const auto& kv : intrin_group_to_mapping_info) {
+    const HexagonIntrinGroup& intrin_group = intrin_groups[kv.first];
+    const tir::AutoTensorizeMappingInfo& mapping_info = kv.second;
+    Schedule new_sch = sch->Copy();
+    new_sch->Annotate(block_rv, tir::attr::meta_schedule_tiling_structure, structure);
+    initial_states.push_back(HexagonState(intrin_group, mapping_info, new_sch, block_rv));
+  }
+  Array<Schedule> results;
+  for (auto&& state : ApplySubRules(initial_states)) {
+    TVM_PY_LOG(INFO, logger) << "Sketch " << results.size() << ": tensorizing with "
+                             << state.as<HexagonStateNode>()->intrin_group.compute_intrin;
+    results.push_back(std::move(state->sch));
+  }
+  if (results.empty()) {
+    return {original_sch};
+  }
+  return results;
+}
+
+std::vector<State> MultiLevelTilingHexagonNode::ApplySubRules(std::vector<State> states) {
+  states = SubRule(std::move(states), [&](State state) {
+    return TransformForTensorization(Downcast<HexagonState>(state));
+  });
+  states = SubRule(std::move(states), [&](State state) { return TileLoopNest(state); });
+  states = SubRule(std::move(states), [&](State state) { return AddWriteReuse(state); });
+  states = SubRule(std::move(states), [&](State state) { return AddReadReuse(state); });
+  states = SubRule(std::move(states), [&](State state) {
+    return AddSoftwarePipeline(Downcast<HexagonState>(state));
+  });
+  return states;
+}
+
+void MultiLevelTilingHexagonNode::TileAndAnnotateTensorize(Schedule* sch,
+                                                              const BlockRV& block_rv,
+                                                              const String& intrin_name) const {
+  Optional<LoopRV> loop = TileWithTensorIntrin(*sch, block_rv, intrin_name).value();
+  ICHECK(loop.defined());
+  BlockRV blockized_outer = (*sch)->Blockize(loop.value());
+  (*sch)->Annotate(blockized_outer, tir::attr::meta_schedule_auto_tensorize, intrin_name);
+}
+
+std::vector<State> MultiLevelTilingHexagonNode::AddSoftwarePipeline(
+    HexagonState state) const {
+  if (!use_software_pipeline) {
+    return {state};
+  }
+  // The current config is not suitable for software pipelining.
+  if (r_indices_.size() < 2) {
+    return {state};
+  }
+
+  Schedule& sch = state->sch;
+  // Check reduction length after blockize.
+  int64_t reduction_length = 1;
+  for (int r_index : r_indices_) {
+    const Array<LoopRV>& tiles = state->tiles[r_index];
+    for (const LoopRV& tile : tiles) {
+      const auto* extent = sch->Get(tile)->extent.as<IntImmNode>();
+      ICHECK(extent != nullptr) << "Dynamic extent is not supported.";
+      reduction_length *= extent->value;
+    }
+  }
+  if (reduction_length <= 1) {
+    return {state};
+  }
+
+  // Return if there are more less than 1 or more than 2 cache_reads.
+  size_t cache_read_count = state->read_reuse.size();
+  if (cache_read_count > 2 || cache_read_count == 0) {
+    return {state};
+  } 
+  
+  // Add annotations for software pipelining at the loop right above the cache read stages. 
+  tir::BlockRV cache_read_block = state->read_reuse.begin()->second;
+  Array<LoopRV> cache_read_loops = sch->GetLoops(cache_read_block);
+  Array<Integer> software_pipeline_stage; 
+  Array<Integer> software_pipeline_order; 
+  Array<Integer> software_pipeline_async_stages; 
+  if(cache_read_count == 2) {
+    software_pipeline_stage = Array<Integer>{0, 0, 1};
+    software_pipeline_order = Array<Integer>{0, 1, 2};
+    software_pipeline_async_stages = Array<Integer>{0};
+  } else {
+    software_pipeline_stage = Array<Integer>{0, 1};
+    software_pipeline_order = Array<Integer>{0, 1};
+    software_pipeline_async_stages = Array<Integer>{0};
+  }
+  sch->Annotate(cache_read_loops[cache_read_loops.size() - 2], tir::attr::software_pipeline_stage, software_pipeline_stage);
+  sch->Annotate(cache_read_loops[cache_read_loops.size() - 2], tir::attr::software_pipeline_order, software_pipeline_order);
+  sch->Annotate(cache_read_loops[cache_read_loops.size() - 2], tir::attr::software_pipeline_async_stages, software_pipeline_async_stages);
+  
+  // TODO: Add support for nested async pipelines.
+  // TODO: Add support for async cache writes. 
+  return {state};
+}
+
+Optional<LoopRV> MultiLevelTilingHexagonNode::TransformWithTensorIntrin(
+    HexagonStateNode* state, const String& intrin_name) const {
+  BlockRV block_rv = state->block_rv;
+  const tir::AutoTensorizeMappingInfo& mapping_info = state->mapping_info;
+  tir::StmtSRef block_sref = state->sch->GetSRef(state->block_rv);
+
+  // Add reindex stages
+  const tir::BlockNode* block = TVM_SREF_TO_BLOCK(block_sref);
+  // Hold the reference of the block before reindex
+  const tir::Block block_before_reindex = GetRef<tir::Block>(block);
+  if (block->reads.size() != 2 || block->writes.size() != 1) {
+    // only matmul-like computation is allowed
+    return NullOpt;
+  }
+  state->hexagon_reindex_store =
+      state->sch->ReIndex(state->block_rv, 0, tir::BufferIndexType::kWrite);
+  state->hexagon_reindex_A =
+      state->sch->ReIndex(state->block_rv, 0, tir::BufferIndexType::kRead);
+  state->hexagon_reindex_B =
+      state->sch->ReIndex(state->block_rv, 1, tir::BufferIndexType::kRead);
+
+  // Transform the layout of reindex buffers accordingly.
+  // The index map defines the mapping for the computation block. We need to extract the sub index
+  // map to transform the load and store block.
+  ICHECK_EQ(mapping_info->mappings.size(), 1U);  // assume only one mapping is present
+  const tir::IndexMap& index_map = mapping_info->mappings[0];
+
+  // Find the correspondence between block iters and the iters in the index map.
+  std::unordered_map<tir::Var, tir::Var, ObjectPtrHash, ObjectPtrEqual> lhs_to_index_map_src;
+  std::unordered_map<tir::Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> rhs_to_index_map_tgt;
+  std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual> unmapped_index_map_src;
+  ICHECK_EQ(mapping_info->lhs_iters.size(), index_map->initial_indices.size());
+  for (int i = 0; i < static_cast<int>(mapping_info->lhs_iters.size()); ++i) {
+    lhs_to_index_map_src[mapping_info->lhs_iters[i]->var] = index_map->initial_indices[i];
+  }
+  // The number of result iters in the index map is equal or more than the number of rhs (the
+  // tensor intrin) iters. When there are extra iters, these iters represent unmapped iters from
+  // the lhs. They will be skipped during pattern matching for tensorization. An example of such
+  // case is batch matmul, the batch dimension is kept after layout transformations and it will be
+  // kept as a outer loop after tensorization.
+  int offset = static_cast<int>(index_map->final_indices.size()) -
+               static_cast<int>(mapping_info->rhs_iters.size());
+  ICHECK_GE(offset, 0);
+  for (int i = 0; i < offset; ++i) {
+    const tir::VarNode* var_ptr = index_map->final_indices[i].as<tir::VarNode>();
+    ICHECK(var_ptr != nullptr);
+    unmapped_index_map_src.insert(GetRef<tir::Var>(var_ptr));
+  }
+  for (int i = offset; i < static_cast<int>(index_map->final_indices.size()); ++i) {
+    rhs_to_index_map_tgt[mapping_info->rhs_iters[i - offset]->var] = index_map->final_indices[i];
+  }
+
+  auto f_get_sub_index_map = [&](const tir::Buffer& lhs_buffer, const tir::Region& lhs_region) {
+    std::vector<tir::Var> sub_index_map_src;
+    std::vector<PrimExpr> sub_index_map_tgt;
+    const tir::Buffer& rhs_buffer = mapping_info->lhs_buffer_map[lhs_buffer];
+    for (const Range& range : lhs_region) {
+      ICHECK(tir::is_one(range->extent));
+      const tir::VarNode* var_ptr = range->min.as<tir::VarNode>();
+      ICHECK(var_ptr != nullptr);
+      const tir::Var& lhs_representer = lhs_to_index_map_src[GetRef<tir::Var>(var_ptr)];
+      sub_index_map_src.push_back(lhs_representer);
+      if (unmapped_index_map_src.count(lhs_representer)) {
+        sub_index_map_tgt.push_back(lhs_representer);
+      }
+    }
+    for (size_t i = 0; i < mapping_info->rhs_buffer_indices[rhs_buffer].size(); ++i) {
+      const tir::VarNode* var = mapping_info->rhs_buffer_indices[rhs_buffer][i].as<tir::VarNode>();
+      ICHECK(var != nullptr);
+      sub_index_map_tgt.push_back(rhs_to_index_map_tgt[GetRef<tir::Var>(var)]);
+    }
+    return tir::IndexMap(sub_index_map_src, sub_index_map_tgt);
+  };
+
+  std::unordered_set<tir::Buffer, ObjectPtrHash, ObjectPtrEqual> visited_buffers;
+
+  Map<tir::Buffer, tir::IndexMap> buffer_sub_index_map;  // cache of the sub index map associated
+                                                         // with each buffer
+
+  auto f_transform_buffer_layout = [&](tir::BufferIndexType index_type, int buffer_index) {
+    const tir::Buffer& lhs_buffer = tir::GetNthAccessBuffer(
+        state->sch->state(), block_before_reindex, buffer_index, index_type);
+    if (visited_buffers.count(lhs_buffer)) {
+      return;
+    }
+    visited_buffers.insert(lhs_buffer);
+    // Refresh block pointer (block sref is not invalidated)
+    block = TVM_SREF_TO_BLOCK(block_sref);
+    const tir::BufferRegion& reindexed_buffer_region = tir::GetNthAccessBufferRegion(
+        state->sch->state(), GetRef<tir::Block>(block), buffer_index, index_type);
+    auto sub_index_map = f_get_sub_index_map(lhs_buffer, reindexed_buffer_region->region);
+    buffer_sub_index_map.Set(lhs_buffer, sub_index_map);
+    state->sch->TransformLayout(state->block_rv, buffer_index, index_type, sub_index_map, NullOpt);
+  };
+
+  for (int i = 0, n = block_before_reindex->reads.size(); i < n; ++i) {
+    f_transform_buffer_layout(tir::BufferIndexType::kRead, i);
+  }
+  for (int i = 0, n = block_before_reindex->writes.size(); i < n; ++i) {
+    f_transform_buffer_layout(tir::BufferIndexType::kWrite, i);
+  }
+
+  // Transform the layout of current block and reindex blocks
+  auto f_transform_reindex_block_layout = [&](const BlockRV& block_rv,
+                                              tir::BufferIndexType buffer_type) {
+    tir::Buffer buffer =
+        tir::GetNthAccessBuffer(state->sch->state(), state->sch->Get(block_rv), 0, buffer_type);
+    const auto& sub_index_map = buffer_sub_index_map.at(buffer);
+    state->sch->TransformBlockLayout(block_rv, sub_index_map);
+  };
+  f_transform_reindex_block_layout(state->hexagon_reindex_store, tir::BufferIndexType::kWrite);
+  f_transform_reindex_block_layout(state->hexagon_reindex_A, tir::BufferIndexType::kRead);
+  f_transform_reindex_block_layout(state->hexagon_reindex_B, tir::BufferIndexType::kRead);
+  state->sch->TransformBlockLayout(state->block_rv, index_map);
+  return tir::TileWithTensorIntrin(state->sch, state->block_rv, intrin_name,
+                                   /*allow_padding=*/true);
+}
+
+inline std::vector<State> MultiLevelTilingHexagonNode::TransformForTensorization(
+    HexagonState state) const {
+  // Do reindex and layout transformations.
+  Optional<LoopRV> transformed_loop_rv =
+      TransformWithTensorIntrin(state.operator->(), state->intrin_group.compute_intrin);
+  if (!transformed_loop_rv.defined()) {
+    // The workload can't be tensorized.
+    return {};
+  }
+
+  // Do blockize
+  state->block_rv = state->sch->Blockize(transformed_loop_rv.value());
+
+  // Add annotations for post processors.
+  state->sch->Annotate(state->block_rv, tir::attr::meta_schedule_auto_tensorize,
+                       state->intrin_group.compute_intrin);
+  // state->sch->Annotate(state->block_rv, tir::attr::warp_execution, Integer(1));
+  return {std::move(state)};
+}
+
+ScheduleRule ScheduleRule::MultiLevelTilingHexagon(
+    Array<Map<String, String>> intrin_groups, String structure, Optional<Array<String>> tile_binds,
+    Optional<Integer> max_innermost_factor, Optional<Array<Integer>> vector_load_lens,
+    Optional<Map<String, ObjectRef>> reuse_read, Optional<Map<String, ObjectRef>> reuse_write,
+    bool use_software_pipeline) {
+  CHECK(!tile_binds.defined()) << "Tile binds cannot be used on hexagon.";
+  auto node = MultiLevelTilingInitCommon<MultiLevelTilingHexagonNode>(
+      structure, tile_binds, max_innermost_factor, vector_load_lens, reuse_read, reuse_write);
+
+  node->intrin_groups.reserve(intrin_groups.size());
+  for (const auto& intrin_group_config : intrin_groups) {
+    node->intrin_groups.emplace_back(HexagonIntrinGroup::FromConfig(intrin_group_config));
+  }
+  node->use_software_pipeline = use_software_pipeline;
+  return ScheduleRule(node);
+}
+
+TVM_REGISTER_NODE_TYPE(MultiLevelTilingHexagonNode);
+TVM_REGISTER_GLOBAL("meta_schedule.ScheduleRuleMultiLevelTilingHexagon")
+    .set_body_typed(ScheduleRule::MultiLevelTilingHexagon);
+
+}  // namespace meta_schedule
+}  // namespace tvm

--- a/tests/python/unittest/test_meta_schedule_schedule_rule_mlt_hexagon.py
+++ b/tests/python/unittest/test_meta_schedule_schedule_rule_mlt_hexagon.py
@@ -1,0 +1,973 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
+from tests.python.contrib.test_hexagon.test_meta_schedule import dense_compute
+import tvm
+from tvm.meta_schedule import schedule_rule
+import tvm.testing
+from tvm import meta_schedule as ms
+from tvm import te
+from tvm.meta_schedule.testing import te_workload
+from tvm.meta_schedule.testing.space_generation import ( 
+    check_sketches,
+    generate_design_space,
+    get_rules,
+)
+from tvm.script import tir as T
+from tvm.tir.tensor_intrin.cuda import get_wmma_intrin_group
+from tvm.tir.tensor_intrin.hexagon import VRMPY_u8u8i32_INTRIN, VRMPY_u8u8i32_VTCM_INTRIN
+
+
+def multi_level_tiling_hexagon(
+    *,
+    write_reuse_scope="global.vtcm",
+    in_dtype="uint8",
+    out_dtype="int32",
+    use_software_pipeline=False,
+) -> ms.schedule_rule.ScheduleRule:
+    assert write_reuse_scope in ["global", "global.vtcm"]
+    if not isinstance(in_dtype, list):
+        in_dtype = [in_dtype]
+    if not isinstance(out_dtype, list):
+        out_dtype = [out_dtype]
+    return ms.schedule_rule.MultiLevelTilingHexagon(
+        intrin_groups=[
+            {"compute": VRMPY_u8u8i32_VTCM_INTRIN},
+        ],
+        structure="SRSRS",
+        tile_binds=None,
+        max_innermost_factor=64,  # 64 // tensor intrin size
+        vector_load_lens=None,
+        reuse_read=ms.schedule_rule.ReuseType(
+            req="must",
+            levels=[1],
+            scope="global.vtcm",
+        ),
+        reuse_write=ms.schedule_rule.ReuseType(
+            req="must" if write_reuse_scope == "shared" else "no",
+            levels=[1],
+            scope=write_reuse_scope,
+        ),
+        use_software_pipeline=use_software_pipeline,
+    )
+
+
+def test_dense_base():
+
+    @T.prim_func
+    def main(X: T.Buffer[(128, 768), "uint8"], packed_width: T.Buffer[(24, 192, 32, 4), "uint8"], compute: T.Buffer[(128, 768), "int32"]):
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # body
+        # with T.block("root")
+        compute_reindex = T.alloc_buffer([128, 768], dtype="int32")
+        X_reindex = T.alloc_buffer([128, 768], dtype="uint8")
+        packed_width_reindex = T.alloc_buffer([768, 768], dtype="uint8")
+        X_reindex_global_vtcm = T.alloc_buffer([128, 768], dtype="uint8", scope="global.vtcm")
+        packed_width_reindex_global_vtcm = T.alloc_buffer([768, 768], dtype="uint8", scope="global.vtcm")
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("X_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(X[v0, v1])
+                T.writes(X_reindex[v0, v1])
+                X_reindex[v0, v1] = X[v0, v1]
+        for ax0, ax1 in T.grid(768, 768):
+            with T.block("packed_width_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4])
+                T.writes(packed_width_reindex[v0, v1])
+                packed_width_reindex[v0, v1] = packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4]
+        for ax0_0, ax1_0_0 in T.grid(128, 6):
+            for ax0_ax1_fused in T.serial(768):
+                with T.block("X_reindex_global.vtcm"):
+                    v0, v1 = T.axis.remap("SS", [ax0_0, ax0_ax1_fused])
+                    T.reads(X_reindex[v0, v1])
+                    T.writes(X_reindex_global_vtcm[v0, v1])
+                    X_reindex_global_vtcm[v0, v1] = X_reindex[v0, v1]
+            for ax0_ax1_fused in T.serial(98304):
+                with T.block("packed_width_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(768, ax1_0_0 * 128 + ax0_ax1_fused // 768)
+                    v1 = T.axis.spatial(768, ax0_ax1_fused % 768)
+                    T.reads(packed_width_reindex[v0, v1])
+                    T.writes(packed_width_reindex_global_vtcm[v0, v1])
+                    packed_width_reindex_global_vtcm[v0, v1] = packed_width_reindex[v0, v1]
+            for ax2_0_0, ax0_1, ax1_0_1, ax2_0_1, ax0_2, ax1_0_2 in T.grid(48, 1, 2, 4, 1, 2):
+                with T.block("compute_o"):
+                    v0 = T.axis.spatial(128, ax0_0 + ax0_1 + ax0_2)
+                    v1_o = T.axis.spatial(24, ax1_0_0 * 4 + ax1_0_1 * 2 + ax1_0_2)
+                    v2_o = T.axis.reduce(192, ax2_0_0 * 4 + ax2_0_1)
+                    T.reads(X_reindex_global_vtcm[v0, v2_o * 4 : v2_o * 4 + 4], packed_width_reindex_global_vtcm[v1_o * 32 : v1_o * 32 + 32, v2_o * 4 : v2_o * 4 + 4])
+                    T.writes(compute_reindex[v0, v1_o * 32 : v1_o * 32 + 32])
+                    T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                    with T.init():
+                        for ax1_1 in T.serial(32):
+                            with T.block("compute_init"):
+                                v1_i_init = T.axis.spatial(32, ax1_1)
+                                T.reads()
+                                T.writes(compute_reindex[v0, v1_o * 32 + v1_i_init])
+                                compute_reindex[v0, v1_o * 32 + v1_i_init] = 0
+                    for ax1_1, ax2_1 in T.grid(32, 4):
+                        with T.block("compute"):
+                            v1_i, v2_i = T.axis.remap("SR", [ax1_1, ax2_1])
+                            T.reads(compute_reindex[v0, v1_o * 32 + v1_i], X_reindex_global_vtcm[v0, v2_o * 4 + v2_i], packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+                            T.writes(compute_reindex[v0, v1_o * 32 + v1_i])
+                            T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                            compute_reindex[v0, v1_o * 32 + v1_i] = compute_reindex[v0, v1_o * 32 + v1_i] + T.Cast("int32", X_reindex_global_vtcm[v0, v2_o * 4 + v2_i]) * T.Cast("int32", packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("compute_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(compute_reindex[v0, v1])
+                T.writes(compute[v0, v1])
+                compute[v0, v1] = compute_reindex[v0, v1]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [1, 4]),
+    ]
+
+    mod = te.create_prim_func(
+        dense_compute(
+            m=128, 
+            n=768,
+            k=768,
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_dense_with_fallback():
+
+    # from tvm.script import tir as T
+    @T.prim_func
+    def main(X: T.Buffer[(128, 768), "uint8"], packed_width: T.Buffer[(24, 192, 32, 4), "uint8"], compute: T.Buffer[(128, 768), "int32"]):
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # body
+        # with T.block("root")
+        compute_reindex = T.alloc_buffer([128, 768], dtype="int32")
+        X_reindex = T.alloc_buffer([128, 768], dtype="uint8")
+        packed_width_reindex = T.alloc_buffer([768, 768], dtype="uint8")
+        X_reindex_global_vtcm = T.alloc_buffer([128, 768], dtype="uint8", scope="global.vtcm")
+        packed_width_reindex_global_vtcm = T.alloc_buffer([768, 768], dtype="uint8", scope="global.vtcm")
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("X_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(X[v0, v1])
+                T.writes(X_reindex[v0, v1])
+                X_reindex[v0, v1] = X[v0, v1]
+        for ax0, ax1 in T.grid(768, 768):
+            with T.block("packed_width_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4])
+                T.writes(packed_width_reindex[v0, v1])
+                packed_width_reindex[v0, v1] = packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4]
+        for ax0_0, ax1_0_0 in T.grid(128, 6):
+            for ax0_ax1_fused in T.serial(768):
+                with T.block("X_reindex_global.vtcm"):
+                    v0, v1 = T.axis.remap("SS", [ax0_0, ax0_ax1_fused])
+                    T.reads(X_reindex[v0, v1])
+                    T.writes(X_reindex_global_vtcm[v0, v1])
+                    X_reindex_global_vtcm[v0, v1] = X_reindex[v0, v1]
+            for ax0_ax1_fused in T.serial(98304):
+                with T.block("packed_width_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(768, ax1_0_0 * 128 + ax0_ax1_fused // 768)
+                    v1 = T.axis.spatial(768, ax0_ax1_fused % 768)
+                    T.reads(packed_width_reindex[v0, v1])
+                    T.writes(packed_width_reindex_global_vtcm[v0, v1])
+                    packed_width_reindex_global_vtcm[v0, v1] = packed_width_reindex[v0, v1]
+            for ax2_0_0, ax0_1, ax1_0_1, ax2_0_1, ax0_2, ax1_0_2 in T.grid(192, 1, 2, 1, 1, 2):
+                with T.block("compute_o"):
+                    v0 = T.axis.spatial(128, ax0_0 + ax0_1 + ax0_2)
+                    v1_o = T.axis.spatial(24, ax1_0_0 * 4 + ax1_0_1 * 2 + ax1_0_2)
+                    v2_o = T.axis.reduce(192, ax2_0_1 + ax2_0_0)
+                    T.reads(X_reindex_global_vtcm[v0, v2_o * 4 : v2_o * 4 + 4], packed_width_reindex_global_vtcm[v1_o * 32 : v1_o * 32 + 32, v2_o * 4 : v2_o * 4 + 4])
+                    T.writes(compute_reindex[v0, v1_o * 32 : v1_o * 32 + 32])
+                    T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                    with T.init():
+                        for ax1_1 in T.serial(32):
+                            with T.block("compute_init"):
+                                v1_i_init = T.axis.spatial(32, ax1_1)
+                                T.reads()
+                                T.writes(compute_reindex[v0, v1_o * 32 + v1_i_init])
+                                compute_reindex[v0, v1_o * 32 + v1_i_init] = 0
+                    for ax1_1, ax2_1 in T.grid(32, 4):
+                        with T.block("compute"):
+                            v1_i, v2_i = T.axis.remap("SR", [ax1_1, ax2_1])
+                            T.reads(compute_reindex[v0, v1_o * 32 + v1_i], X_reindex_global_vtcm[v0, v2_o * 4 + v2_i], packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+                            T.writes(compute_reindex[v0, v1_o * 32 + v1_i])
+                            T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                            compute_reindex[v0, v1_o * 32 + v1_i] = compute_reindex[v0, v1_o * 32 + v1_i] + T.Cast("int32", X_reindex_global_vtcm[v0, v2_o * 4 + v2_i]) * T.Cast("int32", packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("compute_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(compute_reindex[v0, v1])
+                T.writes(compute[v0, v1])
+                compute[v0, v1] = compute_reindex[v0, v1]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [2, 1]),
+    ]
+
+    mod = te.create_prim_func(
+        dense_compute(
+            m=128, 
+            n=768,
+            k=768,
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_dense_with_pipeline():
+    @T.prim_func
+    def main(X: T.Buffer[(128, 768), "uint8"], packed_width: T.Buffer[(24, 192, 32, 4), "uint8"], compute: T.Buffer[(128, 768), "int32"]):
+        # function attr dict
+        T.func_attr({"tir.noalias": True, "global_symbol": "main"})
+        # body
+        # with T.block("root")
+        compute_reindex = T.alloc_buffer([128, 768], dtype="int32")
+        X_reindex = T.alloc_buffer([128, 768], dtype="uint8")
+        packed_width_reindex = T.alloc_buffer([768, 768], dtype="uint8")
+        X_reindex_global_vtcm = T.alloc_buffer([128, 768], dtype="uint8", scope="global.vtcm")
+        packed_width_reindex_global_vtcm = T.alloc_buffer([768, 768], dtype="uint8", scope="global.vtcm")
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("X_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(X[v0, v1])
+                T.writes(X_reindex[v0, v1])
+                X_reindex[v0, v1] = X[v0, v1]
+        for ax0, ax1 in T.grid(768, 768):
+            with T.block("packed_width_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4])
+                T.writes(packed_width_reindex[v0, v1])
+                packed_width_reindex[v0, v1] = packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4]
+        for ax0_0 in T.serial(128):
+            for ax1_0_0 in T.serial(6, annotations={"software_pipeline_async_stages":[0], "software_pipeline_order":[0, 1, 2], "software_pipeline_stage":[0, 0, 1]}):
+                for ax0_ax1_fused in T.serial(768):
+                    with T.block("X_reindex_global.vtcm"):
+                        v0, v1 = T.axis.remap("SS", [ax0_0, ax0_ax1_fused])
+                        T.reads(X_reindex[v0, v1])
+                        T.writes(X_reindex_global_vtcm[v0, v1])
+                        X_reindex_global_vtcm[v0, v1] = X_reindex[v0, v1]
+                for ax0_ax1_fused in T.serial(98304):
+                    with T.block("packed_width_reindex_global.vtcm"):
+                        v0 = T.axis.spatial(768, ax1_0_0 * 128 + ax0_ax1_fused // 768)
+                        v1 = T.axis.spatial(768, ax0_ax1_fused % 768)
+                        T.reads(packed_width_reindex[v0, v1])
+                        T.writes(packed_width_reindex_global_vtcm[v0, v1])
+                        packed_width_reindex_global_vtcm[v0, v1] = packed_width_reindex[v0, v1]
+                for ax2_0_0, ax0_1, ax1_0_1, ax2_0_1, ax0_2, ax1_0_2 in T.grid(48, 1, 2, 4, 1, 2):
+                    with T.block("compute_o"):
+                        v0 = T.axis.spatial(128, ax0_0 + ax0_1 + ax0_2)
+                        v1_o = T.axis.spatial(24, ax1_0_0 * 4 + ax1_0_1 * 2 + ax1_0_2)
+                        v2_o = T.axis.reduce(192, ax2_0_0 * 4 + ax2_0_1)
+                        T.reads(X_reindex_global_vtcm[v0, v2_o * 4 : v2_o * 4 + 4], packed_width_reindex_global_vtcm[v1_o * 32 : v1_o * 32 + 32, v2_o * 4 : v2_o * 4 + 4])
+                        T.writes(compute_reindex[v0, v1_o * 32 : v1_o * 32 + 32])
+                        T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                        with T.init():
+                            for ax1_1 in T.serial(32):
+                                with T.block("compute_init"):
+                                    v1_i_init = T.axis.spatial(32, ax1_1)
+                                    T.reads()
+                                    T.writes(compute_reindex[v0, v1_o * 32 + v1_i_init])
+                                    compute_reindex[v0, v1_o * 32 + v1_i_init] = 0
+                        for ax1_1, ax2_1 in T.grid(32, 4):
+                            with T.block("compute"):
+                                v1_i, v2_i = T.axis.remap("SR", [ax1_1, ax2_1])
+                                T.reads(compute_reindex[v0, v1_o * 32 + v1_i], X_reindex_global_vtcm[v0, v2_o * 4 + v2_i], packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+                                T.writes(compute_reindex[v0, v1_o * 32 + v1_i])
+                                T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                                compute_reindex[v0, v1_o * 32 + v1_i] = compute_reindex[v0, v1_o * 32 + v1_i] + T.Cast("int32", X_reindex_global_vtcm[v0, v2_o * 4 + v2_i]) * T.Cast("int32", packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("compute_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(compute_reindex[v0, v1])
+                T.writes(compute[v0, v1])
+                compute[v0, v1] = compute_reindex[v0, v1]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [1, 4]),
+    ]
+
+
+    mod = te.create_prim_func(
+        dense_compute(
+            m=128, 
+            n=768,
+            k=768,
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(use_software_pipeline=True),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_dense_global():
+
+    # from tvm.script import tir as T
+    @T.prim_func
+    def main(X: T.Buffer[(128, 768), "uint8"], packed_width: T.Buffer[(24, 192, 32, 4), "uint8"], compute: T.Buffer[(128, 768), "int32"]):
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # body
+        # with T.block("root")
+        compute_reindex = T.alloc_buffer([128, 768], dtype="int32")
+        X_reindex = T.alloc_buffer([128, 768], dtype="uint8")
+        packed_width_reindex = T.alloc_buffer([768, 768], dtype="uint8")
+        X_reindex_global_vtcm = T.alloc_buffer([128, 768], dtype="uint8", scope="global.vtcm")
+        packed_width_reindex_global_vtcm = T.alloc_buffer([768, 768], dtype="uint8", scope="global.vtcm")
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("X_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(X[v0, v1])
+                T.writes(X_reindex[v0, v1])
+                X_reindex[v0, v1] = X[v0, v1]
+        for ax0, ax1 in T.grid(768, 768):
+            with T.block("packed_width_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4])
+                T.writes(packed_width_reindex[v0, v1])
+                packed_width_reindex[v0, v1] = packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4]
+        for ax0_0, ax1_0_0 in T.grid(128, 6):
+            for ax0_ax1_fused in T.serial(768):
+                with T.block("X_reindex_global.vtcm"):
+                    v0, v1 = T.axis.remap("SS", [ax0_0, ax0_ax1_fused])
+                    T.reads(X_reindex[v0, v1])
+                    T.writes(X_reindex_global_vtcm[v0, v1])
+                    X_reindex_global_vtcm[v0, v1] = X_reindex[v0, v1]
+            for ax0_ax1_fused in T.serial(98304):
+                with T.block("packed_width_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(768, ax1_0_0 * 128 + ax0_ax1_fused // 768)
+                    v1 = T.axis.spatial(768, ax0_ax1_fused % 768)
+                    T.reads(packed_width_reindex[v0, v1])
+                    T.writes(packed_width_reindex_global_vtcm[v0, v1])
+                    packed_width_reindex_global_vtcm[v0, v1] = packed_width_reindex[v0, v1]
+            for ax2_0_0, ax0_1, ax1_0_1, ax2_0_1, ax0_2, ax1_0_2 in T.grid(192, 1, 2, 1, 1, 2):
+                with T.block("compute_o"):
+                    v0 = T.axis.spatial(128, ax0_0 + ax0_1 + ax0_2)
+                    v1_o = T.axis.spatial(24, ax1_0_0 * 4 + ax1_0_1 * 2 + ax1_0_2)
+                    v2_o = T.axis.reduce(192, ax2_0_1 + ax2_0_0)
+                    T.reads(X_reindex_global_vtcm[v0, v2_o * 4 : v2_o * 4 + 4], packed_width_reindex_global_vtcm[v1_o * 32 : v1_o * 32 + 32, v2_o * 4 : v2_o * 4 + 4])
+                    T.writes(compute_reindex[v0, v1_o * 32 : v1_o * 32 + 32])
+                    T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                    with T.init():
+                        for ax1_1 in T.serial(32):
+                            with T.block("compute_init"):
+                                v1_i_init = T.axis.spatial(32, ax1_1)
+                                T.reads()
+                                T.writes(compute_reindex[v0, v1_o * 32 + v1_i_init])
+                                compute_reindex[v0, v1_o * 32 + v1_i_init] = 0
+                    for ax1_1, ax2_1 in T.grid(32, 4):
+                        with T.block("compute"):
+                            v1_i, v2_i = T.axis.remap("SR", [ax1_1, ax2_1])
+                            T.reads(compute_reindex[v0, v1_o * 32 + v1_i], X_reindex_global_vtcm[v0, v2_o * 4 + v2_i], packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+                            T.writes(compute_reindex[v0, v1_o * 32 + v1_i])
+                            T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                            compute_reindex[v0, v1_o * 32 + v1_i] = compute_reindex[v0, v1_o * 32 + v1_i] + T.Cast("int32", X_reindex_global_vtcm[v0, v2_o * 4 + v2_i]) * T.Cast("int32", packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("compute_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(compute_reindex[v0, v1])
+                T.writes(compute[v0, v1])
+                compute[v0, v1] = compute_reindex[v0, v1]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [2, 1]),
+    ]
+
+    mod = te.create_prim_func(
+        dense_compute(
+            m=128, 
+            n=768,
+            k=768,
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(write_reuse_scope="global"),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_padded_dense():
+
+    @T.prim_func
+    def main(X: T.Buffer[(128, 768), "uint8"], packed_width: T.Buffer[(24, 192, 32, 4), "uint8"], compute: T.Buffer[(128, 768), "int32"]):
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # body
+        # with T.block("root")
+        compute_reindex = T.alloc_buffer([128, 768], dtype="int32")
+        X_reindex = T.alloc_buffer([128, 768], dtype="uint8")
+        packed_width_reindex = T.alloc_buffer([768, 768], dtype="uint8")
+        X_reindex_global_vtcm = T.alloc_buffer([128, 768], dtype="uint8", scope="global.vtcm")
+        packed_width_reindex_global_vtcm = T.alloc_buffer([768, 768], dtype="uint8", scope="global.vtcm")
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("X_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(X[v0, v1])
+                T.writes(X_reindex[v0, v1])
+                X_reindex[v0, v1] = X[v0, v1]
+        for ax0, ax1 in T.grid(768, 768):
+            with T.block("packed_width_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4])
+                T.writes(packed_width_reindex[v0, v1])
+                packed_width_reindex[v0, v1] = packed_width[v0 // 32, v1 // 4, v0 % 32, v1 % 4]
+        for ax0_0, ax1_0_0 in T.grid(128, 6):
+            for ax0_ax1_fused in T.serial(768):
+                with T.block("X_reindex_global.vtcm"):
+                    v0, v1 = T.axis.remap("SS", [ax0_0, ax0_ax1_fused])
+                    T.reads(X_reindex[v0, v1])
+                    T.writes(X_reindex_global_vtcm[v0, v1])
+                    X_reindex_global_vtcm[v0, v1] = X_reindex[v0, v1]
+            for ax0_ax1_fused in T.serial(98304):
+                with T.block("packed_width_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(768, ax1_0_0 * 128 + ax0_ax1_fused // 768)
+                    v1 = T.axis.spatial(768, ax0_ax1_fused % 768)
+                    T.reads(packed_width_reindex[v0, v1])
+                    T.writes(packed_width_reindex_global_vtcm[v0, v1])
+                    packed_width_reindex_global_vtcm[v0, v1] = packed_width_reindex[v0, v1]
+            for ax2_0_0, ax0_1, ax1_0_1, ax2_0_1, ax0_2, ax1_0_2 in T.grid(48, 1, 2, 4, 1, 2):
+                with T.block("compute_o"):
+                    v0 = T.axis.spatial(128, ax0_0 + ax0_1 + ax0_2)
+                    v1_o = T.axis.spatial(24, ax1_0_0 * 4 + ax1_0_1 * 2 + ax1_0_2)
+                    v2_o = T.axis.reduce(192, ax2_0_0 * 4 + ax2_0_1)
+                    T.reads(X_reindex_global_vtcm[v0, v2_o * 4 : v2_o * 4 + 4], packed_width_reindex_global_vtcm[v1_o * 32 : v1_o * 32 + 32, v2_o * 4 : v2_o * 4 + 4])
+                    T.writes(compute_reindex[v0, v1_o * 32 : v1_o * 32 + 32])
+                    T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                    with T.init():
+                        for ax1_1 in T.serial(32):
+                            with T.block("compute_init"):
+                                v1_i_init = T.axis.spatial(32, ax1_1)
+                                T.reads()
+                                T.writes(compute_reindex[v0, v1_o * 32 + v1_i_init])
+                                compute_reindex[v0, v1_o * 32 + v1_i_init] = 0
+                    for ax1_1, ax2_1 in T.grid(32, 4):
+                        with T.block("compute"):
+                            v1_i, v2_i = T.axis.remap("SR", [ax1_1, ax2_1])
+                            T.reads(compute_reindex[v0, v1_o * 32 + v1_i], X_reindex_global_vtcm[v0, v2_o * 4 + v2_i], packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+                            T.writes(compute_reindex[v0, v1_o * 32 + v1_i])
+                            T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                            compute_reindex[v0, v1_o * 32 + v1_i] = compute_reindex[v0, v1_o * 32 + v1_i] + T.Cast("int32", X_reindex_global_vtcm[v0, v2_o * 4 + v2_i]) * T.Cast("int32", packed_width_reindex_global_vtcm[v1_o * 32 + v1_i, v2_o * 4 + v2_i])
+        for ax0, ax1 in T.grid(128, 768):
+            with T.block("compute_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(compute_reindex[v0, v1])
+                T.writes(compute[v0, v1])
+                compute[v0, v1] = compute_reindex[v0, v1]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [1, 4]),
+    ]
+
+
+    mod = te.create_prim_func(
+        dense_compute(
+            m=128, 
+            n=768,
+            k=768,
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(write_reuse_scope="global"),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_conv2d():
+
+    # from tvm.script import tir as T
+    @T.prim_func
+    def main(inputs: T.Buffer[(1, 16, 16, 32), "uint8"], weight: T.Buffer[(3, 3, 32, 32), "uint8"], conv2d_nhwc: T.Buffer[(1, 16, 16, 32), "int32"]):
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # body
+        # with T.block("root")
+        PadInput = T.alloc_buffer([1, 18, 18, 32], dtype="uint8")
+        conv2d_nhwc_reindex = T.alloc_buffer([1, 16, 16, 32], dtype="int32")
+        PadInput_reindex = T.alloc_buffer([1, 16, 16, 288], dtype="uint8")
+        weight_reindex = T.alloc_buffer([32, 288], dtype="uint8")
+        PadInput_reindex_global_vtcm = T.alloc_buffer([1, 16, 16, 288], dtype="uint8", scope="global.vtcm")
+        weight_reindex_global_vtcm = T.alloc_buffer([32, 288], dtype="uint8", scope="global.vtcm")
+        for i0, i1, i2, i3 in T.grid(1, 18, 18, 32):
+            with T.block("PadInput"):
+                i0_1, i1_1, i2_1, i3_1 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(inputs[i0_1, i1_1 - 1, i2_1 - 1, i3_1])
+                T.writes(PadInput[i0_1, i1_1, i2_1, i3_1])
+                PadInput[i0_1, i1_1, i2_1, i3_1] = T.if_then_else(1 <= i1_1 and i1_1 < 17 and 1 <= i2_1 and i2_1 < 17, inputs[i0_1, i1_1 - 1, i2_1 - 1, i3_1], T.uint8(0), dtype="uint8")
+        for ax0, ax1, ax2, ax3 in T.grid(1, 16, 16, 288):
+            with T.block("PadInput_reindex_reindex"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(PadInput[v0, v3 // 96 + v1, v3 % 96 // 32 + v2, v3 % 32])
+                T.writes(PadInput_reindex[v0, v1, v2, v3])
+                PadInput_reindex[v0, v1, v2, v3] = PadInput[v0, v3 // 96 + v1, v3 % 96 // 32 + v2, v3 % 32]
+        for ax0, ax1 in T.grid(32, 288):
+            with T.block("weight_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(weight[v1 // 96, v1 % 96 // 32, v1 % 32, v0])
+                T.writes(weight_reindex[v0, v1])
+                weight_reindex[v0, v1] = weight[v1 // 96, v1 % 96 // 32, v1 % 32, v0]
+        for ax0_0, ax1_0, ax2_0, ax3_0_0 in T.grid(1, 4, 4, 1):
+            for ax0_ax1_ax2_ax3_fused in T.serial(4608):
+                with T.block("PadInput_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(1, 0)
+                    v1 = T.axis.spatial(16, ax1_0 * 4 + ax0_ax1_ax2_ax3_fused // 1152)
+                    v2 = T.axis.spatial(16, ax2_0 * 4 + ax0_ax1_ax2_ax3_fused % 1152 // 288)
+                    v3 = T.axis.spatial(288, ax0_ax1_ax2_ax3_fused % 288)
+                    T.reads(PadInput_reindex[v0, v1, v2, v3])
+                    T.writes(PadInput_reindex_global_vtcm[v0, v1, v2, v3])
+                    PadInput_reindex_global_vtcm[v0, v1, v2, v3] = PadInput_reindex[v0, v1, v2, v3]
+            for ax0_ax1_fused in T.serial(9216):
+                with T.block("weight_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(32, ax0_ax1_fused // 288)
+                    v1 = T.axis.spatial(288, ax0_ax1_fused % 288)
+                    T.reads(weight_reindex[v0, v1])
+                    T.writes(weight_reindex_global_vtcm[v0, v1])
+                    weight_reindex_global_vtcm[v0, v1] = weight_reindex[v0, v1]
+            for ax4_0_0, ax0_1, ax1_1, ax2_1, ax3_0_1, ax4_0_1, ax0_2, ax1_2, ax2_2, ax3_0_2 in T.grid(18, 1, 1, 4, 1, 4, 1, 4, 1, 1):
+                with T.block("conv2d_nhwc_o"):
+                    v0 = T.axis.spatial(1, 0)
+                    v1 = T.axis.spatial(16, ax1_0 * 4 + ax1_1 * 4 + ax1_2)
+                    v2 = T.axis.spatial(16, ax2_2 + ax2_0 * 4 + ax2_1)
+                    v3_o = T.axis.spatial(1, 0)
+                    v4_o = T.axis.reduce(72, ax4_0_0 * 4 + ax4_0_1)
+                    T.reads(PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 : v4_o * 4 + 4], weight_reindex_global_vtcm[0 : 32, v4_o * 4 : v4_o * 4 + 4])
+                    T.writes(conv2d_nhwc_reindex[v0, v1, v2, 0 : 32])
+                    T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                    with T.init():
+                        for ax3_1 in T.serial(32):
+                            with T.block("conv2d_nhwc_init"):
+                                v3_i_init = T.axis.spatial(32, ax3_1)
+                                T.reads()
+                                T.writes(conv2d_nhwc_reindex[v0, v1, v2, v3_i_init])
+                                conv2d_nhwc_reindex[v0, v1, v2, v3_i_init] = 0
+                    for ax3_1, ax4_1 in T.grid(32, 4):
+                        with T.block("conv2d_nhwc"):
+                            v3_i, v4_i = T.axis.remap("SR", [ax3_1, ax4_1])
+                            T.reads(conv2d_nhwc_reindex[v0, v1, v2, v3_i], PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 + v4_i], weight_reindex_global_vtcm[v3_i, v4_o * 4 + v4_i])
+                            T.writes(conv2d_nhwc_reindex[v0, v1, v2, v3_i])
+                            T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                            conv2d_nhwc_reindex[v0, v1, v2, v3_i] = conv2d_nhwc_reindex[v0, v1, v2, v3_i] + T.Cast("int32", PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 + v4_i]) * T.Cast("int32", weight_reindex_global_vtcm[v3_i, v4_o * 4 + v4_i])
+        for ax0, ax1, ax2, ax3 in T.grid(1, 16, 16, 32):
+            with T.block("conv2d_nhwc_reindex"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(conv2d_nhwc_reindex[v0, v1, v2, v3])
+                T.writes(conv2d_nhwc[v0, v1, v2, v3])
+                conv2d_nhwc[v0, v1, v2, v3] = conv2d_nhwc_reindex[v0, v1, v2, v3]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 1, 4]),
+        ("SamplePerfectTile", [2, 4, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [2, 4]),
+    ]
+
+    mod = te.create_prim_func(
+        te_workload.conv2d_nhwc(
+            N=1,
+            H=16,
+            W=16,
+            CI=32,
+            CO=32,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            in_dtype="uint8",
+            out_dtype="int32",
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_conv2d_with_pipeline():
+
+    # from tvm.script import tir as T
+    @T.prim_func
+    def main(inputs: T.Buffer[(1, 16, 16, 32), "uint8"], weight: T.Buffer[(3, 3, 32, 32), "uint8"], conv2d_nhwc: T.Buffer[(1, 16, 16, 32), "int32"]):
+        # function attr dict
+        T.func_attr({"tir.noalias": True, "global_symbol": "main"})
+        # body
+        # with T.block("root")
+        PadInput = T.alloc_buffer([1, 18, 18, 32], dtype="uint8")
+        conv2d_nhwc_reindex = T.alloc_buffer([1, 16, 16, 32], dtype="int32")
+        PadInput_reindex = T.alloc_buffer([1, 16, 16, 288], dtype="uint8")
+        weight_reindex = T.alloc_buffer([32, 288], dtype="uint8")
+        PadInput_reindex_global_vtcm = T.alloc_buffer([1, 16, 16, 288], dtype="uint8", scope="global.vtcm")
+        weight_reindex_global_vtcm = T.alloc_buffer([32, 288], dtype="uint8", scope="global.vtcm")
+        for i0, i1, i2, i3 in T.grid(1, 18, 18, 32):
+            with T.block("PadInput"):
+                i0_1, i1_1, i2_1, i3_1 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(inputs[i0_1, i1_1 - 1, i2_1 - 1, i3_1])
+                T.writes(PadInput[i0_1, i1_1, i2_1, i3_1])
+                PadInput[i0_1, i1_1, i2_1, i3_1] = T.if_then_else(1 <= i1_1 and i1_1 < 17 and 1 <= i2_1 and i2_1 < 17, inputs[i0_1, i1_1 - 1, i2_1 - 1, i3_1], T.uint8(0), dtype="uint8")
+        for ax0, ax1, ax2, ax3 in T.grid(1, 16, 16, 288):
+            with T.block("PadInput_reindex_reindex"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(PadInput[v0, v3 // 96 + v1, v3 % 96 // 32 + v2, v3 % 32])
+                T.writes(PadInput_reindex[v0, v1, v2, v3])
+                PadInput_reindex[v0, v1, v2, v3] = PadInput[v0, v3 // 96 + v1, v3 % 96 // 32 + v2, v3 % 32]
+        for ax0, ax1 in T.grid(32, 288):
+            with T.block("weight_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(weight[v1 // 96, v1 % 96 // 32, v1 % 32, v0])
+                T.writes(weight_reindex[v0, v1])
+                weight_reindex[v0, v1] = weight[v1 // 96, v1 % 96 // 32, v1 % 32, v0]
+        for ax0_0, ax1_0, ax2_0 in T.grid(1, 4, 4):
+            for ax3_0_0 in T.serial(1, annotations={"software_pipeline_async_stages":[0], "software_pipeline_order":[0, 1, 2], "software_pipeline_stage":[0, 0, 1]}):
+                for ax0_ax1_ax2_ax3_fused in T.serial(4608):
+                    with T.block("PadInput_reindex_global.vtcm"):
+                        v0 = T.axis.spatial(1, 0)
+                        v1 = T.axis.spatial(16, ax1_0 * 4 + ax0_ax1_ax2_ax3_fused // 1152)
+                        v2 = T.axis.spatial(16, ax2_0 * 4 + ax0_ax1_ax2_ax3_fused % 1152 // 288)
+                        v3 = T.axis.spatial(288, ax0_ax1_ax2_ax3_fused % 288)
+                        T.reads(PadInput_reindex[v0, v1, v2, v3])
+                        T.writes(PadInput_reindex_global_vtcm[v0, v1, v2, v3])
+                        PadInput_reindex_global_vtcm[v0, v1, v2, v3] = PadInput_reindex[v0, v1, v2, v3]
+                for ax0_ax1_fused in T.serial(9216):
+                    with T.block("weight_reindex_global.vtcm"):
+                        v0 = T.axis.spatial(32, ax0_ax1_fused // 288)
+                        v1 = T.axis.spatial(288, ax0_ax1_fused % 288)
+                        T.reads(weight_reindex[v0, v1])
+                        T.writes(weight_reindex_global_vtcm[v0, v1])
+                        weight_reindex_global_vtcm[v0, v1] = weight_reindex[v0, v1]
+                for ax4_0_0, ax0_1, ax1_1, ax2_1, ax3_0_1, ax4_0_1, ax0_2, ax1_2, ax2_2, ax3_0_2 in T.grid(18, 1, 1, 4, 1, 4, 1, 4, 1, 1):
+                    with T.block("conv2d_nhwc_o"):
+                        v0 = T.axis.spatial(1, 0)
+                        v1 = T.axis.spatial(16, ax1_0 * 4 + ax1_1 * 4 + ax1_2)
+                        v2 = T.axis.spatial(16, ax2_2 + ax2_0 * 4 + ax2_1)
+                        v3_o = T.axis.spatial(1, 0)
+                        v4_o = T.axis.reduce(72, ax4_0_0 * 4 + ax4_0_1)
+                        T.reads(PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 : v4_o * 4 + 4], weight_reindex_global_vtcm[0 : 32, v4_o * 4 : v4_o * 4 + 4])
+                        T.writes(conv2d_nhwc_reindex[v0, v1, v2, 0 : 32])
+                        T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                        with T.init():
+                            for ax3_1 in T.serial(32):
+                                with T.block("conv2d_nhwc_init"):
+                                    v3_i_init = T.axis.spatial(32, ax3_1)
+                                    T.reads()
+                                    T.writes(conv2d_nhwc_reindex[v0, v1, v2, v3_i_init])
+                                    conv2d_nhwc_reindex[v0, v1, v2, v3_i_init] = 0
+                        for ax3_1, ax4_1 in T.grid(32, 4):
+                            with T.block("conv2d_nhwc"):
+                                v3_i, v4_i = T.axis.remap("SR", [ax3_1, ax4_1])
+                                T.reads(conv2d_nhwc_reindex[v0, v1, v2, v3_i], PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 + v4_i], weight_reindex_global_vtcm[v3_i, v4_o * 4 + v4_i])
+                                T.writes(conv2d_nhwc_reindex[v0, v1, v2, v3_i])
+                                T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                                conv2d_nhwc_reindex[v0, v1, v2, v3_i] = conv2d_nhwc_reindex[v0, v1, v2, v3_i] + T.Cast("int32", PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 + v4_i]) * T.Cast("int32", weight_reindex_global_vtcm[v3_i, v4_o * 4 + v4_i])
+        for ax0, ax1, ax2, ax3 in T.grid(1, 16, 16, 32):
+            with T.block("conv2d_nhwc_reindex"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(conv2d_nhwc_reindex[v0, v1, v2, v3])
+                T.writes(conv2d_nhwc[v0, v1, v2, v3])
+                conv2d_nhwc[v0, v1, v2, v3] = conv2d_nhwc_reindex[v0, v1, v2, v3]
+    
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 1, 4]),
+        ("SamplePerfectTile", [2, 4, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [2, 4]),
+    ]
+
+    mod = te.create_prim_func(
+        te_workload.conv2d_nhwc(
+            N=1,
+            H=16,
+            W=16,
+            CI=32,
+            CO=32,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            in_dtype="uint8",
+            out_dtype="int32",
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(use_software_pipeline=True),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_conv_1x1():
+    # fmt: off
+    @T.prim_func
+    def main(inputs: T.Buffer[(1, 16, 16, 32), "uint8"], weight: T.Buffer[(3, 3, 32, 32), "uint8"], conv2d_nhwc: T.Buffer[(1, 16, 16, 32), "int32"]):
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # body
+        # with T.block("root")
+        PadInput = T.alloc_buffer([1, 18, 18, 32], dtype="uint8")
+        conv2d_nhwc_reindex = T.alloc_buffer([1, 16, 16, 32], dtype="int32")
+        PadInput_reindex = T.alloc_buffer([1, 16, 16, 288], dtype="uint8")
+        weight_reindex = T.alloc_buffer([32, 288], dtype="uint8")
+        PadInput_reindex_global_vtcm = T.alloc_buffer([1, 16, 16, 288], dtype="uint8", scope="global.vtcm")
+        weight_reindex_global_vtcm = T.alloc_buffer([32, 288], dtype="uint8", scope="global.vtcm")
+        for i0, i1, i2, i3 in T.grid(1, 18, 18, 32):
+            with T.block("PadInput"):
+                i0_1, i1_1, i2_1, i3_1 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(inputs[i0_1, i1_1 - 1, i2_1 - 1, i3_1])
+                T.writes(PadInput[i0_1, i1_1, i2_1, i3_1])
+                PadInput[i0_1, i1_1, i2_1, i3_1] = T.if_then_else(1 <= i1_1 and i1_1 < 17 and 1 <= i2_1 and i2_1 < 17, inputs[i0_1, i1_1 - 1, i2_1 - 1, i3_1], T.uint8(0), dtype="uint8")
+        for ax0, ax1, ax2, ax3 in T.grid(1, 16, 16, 288):
+            with T.block("PadInput_reindex_reindex"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(PadInput[v0, v3 // 96 + v1, v3 % 96 // 32 + v2, v3 % 32])
+                T.writes(PadInput_reindex[v0, v1, v2, v3])
+                PadInput_reindex[v0, v1, v2, v3] = PadInput[v0, v3 // 96 + v1, v3 % 96 // 32 + v2, v3 % 32]
+        for ax0, ax1 in T.grid(32, 288):
+            with T.block("weight_reindex_reindex"):
+                v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(weight[v1 // 96, v1 % 96 // 32, v1 % 32, v0])
+                T.writes(weight_reindex[v0, v1])
+                weight_reindex[v0, v1] = weight[v1 // 96, v1 % 96 // 32, v1 % 32, v0]
+        for ax0_0, ax1_0, ax2_0, ax3_0_0 in T.grid(1, 4, 4, 1):
+            for ax0_ax1_ax2_ax3_fused in T.serial(4608):
+                with T.block("PadInput_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(1, 0)
+                    v1 = T.axis.spatial(16, ax1_0 * 4 + ax0_ax1_ax2_ax3_fused // 1152)
+                    v2 = T.axis.spatial(16, ax2_0 * 4 + ax0_ax1_ax2_ax3_fused % 1152 // 288)
+                    v3 = T.axis.spatial(288, ax0_ax1_ax2_ax3_fused % 288)
+                    T.reads(PadInput_reindex[v0, v1, v2, v3])
+                    T.writes(PadInput_reindex_global_vtcm[v0, v1, v2, v3])
+                    PadInput_reindex_global_vtcm[v0, v1, v2, v3] = PadInput_reindex[v0, v1, v2, v3]
+            for ax0_ax1_fused in T.serial(9216):
+                with T.block("weight_reindex_global.vtcm"):
+                    v0 = T.axis.spatial(32, ax0_ax1_fused // 288)
+                    v1 = T.axis.spatial(288, ax0_ax1_fused % 288)
+                    T.reads(weight_reindex[v0, v1])
+                    T.writes(weight_reindex_global_vtcm[v0, v1])
+                    weight_reindex_global_vtcm[v0, v1] = weight_reindex[v0, v1]
+            for ax4_0_0, ax0_1, ax1_1, ax2_1, ax3_0_1, ax4_0_1, ax0_2, ax1_2, ax2_2, ax3_0_2 in T.grid(18, 1, 1, 4, 1, 4, 1, 4, 1, 1):
+                with T.block("conv2d_nhwc_o"):
+                    v0 = T.axis.spatial(1, 0)
+                    v1 = T.axis.spatial(16, ax1_0 * 4 + ax1_1 * 4 + ax1_2)
+                    v2 = T.axis.spatial(16, ax2_2 + ax2_0 * 4 + ax2_1)
+                    v3_o = T.axis.spatial(1, 0)
+                    v4_o = T.axis.reduce(72, ax4_0_0 * 4 + ax4_0_1)
+                    T.reads(PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 : v4_o * 4 + 4], weight_reindex_global_vtcm[0 : 32, v4_o * 4 : v4_o * 4 + 4])
+                    T.writes(conv2d_nhwc_reindex[v0, v1, v2, 0 : 32])
+                    T.block_attr({"meta_schedule.auto_tensorize":"dot_32x4_u8u8i32_vtcm_vrmpy"})
+                    with T.init():
+                        for ax3_1 in T.serial(32):
+                            with T.block("conv2d_nhwc_init"):
+                                v3_i_init = T.axis.spatial(32, ax3_1)
+                                T.reads()
+                                T.writes(conv2d_nhwc_reindex[v0, v1, v2, v3_i_init])
+                                conv2d_nhwc_reindex[v0, v1, v2, v3_i_init] = 0
+                    for ax3_1, ax4_1 in T.grid(32, 4):
+                        with T.block("conv2d_nhwc"):
+                            v3_i, v4_i = T.axis.remap("SR", [ax3_1, ax4_1])
+                            T.reads(conv2d_nhwc_reindex[v0, v1, v2, v3_i], PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 + v4_i], weight_reindex_global_vtcm[v3_i, v4_o * 4 + v4_i])
+                            T.writes(conv2d_nhwc_reindex[v0, v1, v2, v3_i])
+                            T.block_attr({"meta_schedule.tiling_structure":"SRSRS"})
+                            conv2d_nhwc_reindex[v0, v1, v2, v3_i] = conv2d_nhwc_reindex[v0, v1, v2, v3_i] + T.Cast("int32", PadInput_reindex_global_vtcm[v0, v1, v2, v4_o * 4 + v4_i]) * T.Cast("int32", weight_reindex_global_vtcm[v3_i, v4_o * 4 + v4_i])
+        for ax0, ax1, ax2, ax3 in T.grid(1, 16, 16, 32):
+            with T.block("conv2d_nhwc_reindex"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(conv2d_nhwc_reindex[v0, v1, v2, v3])
+                T.writes(conv2d_nhwc[v0, v1, v2, v3])
+                conv2d_nhwc[v0, v1, v2, v3] = conv2d_nhwc_reindex[v0, v1, v2, v3]
+    # fmt: on
+    decision_0 = [
+        ("SamplePerfectTile", [4, 1, 1]),
+        ("SamplePerfectTile", [2, 1, 4]),
+        ("SamplePerfectTile", [2, 4, 1]),
+        ("SamplePerfectTile", [2, 2, 2]),
+        ("SamplePerfectTile", [2, 4]),
+    ]
+
+    mod = te.create_prim_func(
+        te_workload.conv2d_nhwc(
+            N=1,
+            H=16,
+            W=16,
+            CI=32,
+            CO=32,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            in_dtype="uint8",
+            out_dtype="int32",
+        )
+    )
+
+    actual_design_space = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[
+            multi_level_tiling_hexagon(),
+        ]
+        + get_rules(kind="hexagon", types=ms.schedule_rule.AutoInline),
+    )
+
+
+    check_sketches(
+        mod,
+        sketches=actual_design_space,
+        expected_mods=[main],
+        expected_decisions=[decision_0],
+    )
+
+def test_matmul_relu_non_tensorizable():
+    # expected to do nothing on non-tensorizable workloads
+    mod = te.create_prim_func(
+        te_workload.matmul_relu(  # dtype doesn't match tensor intrin
+            n=128,
+            m=128,
+            k=128,
+        )
+    )
+    (sch,) = generate_design_space(
+        kind="hexagon",
+        mod=mod,
+        target=tvm.target.Target("hexagon"),
+        types=None,
+        sch_rules=[multi_level_tiling_hexagon(write_reuse_scope="global")]
+        + get_rules("hexagon", ms.schedule_rule.AutoInline),
+    )
+    tvm.ir.assert_structural_equal(mod, sch.mod["main"])
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
… that utilize async dma pipelines.

This mostly copies what is happening in MultiLevelTilingTensorCore but alters the pipelining strategy for hexagon async dma pipelining. 

I kept the intrin groups in so that this can be expanded if we want to include a synchronous dma tensorization. 