### PR TITLE
[MetaSchedule] Enhance Database Validation Script

### DIFF
--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -197,12 +197,12 @@ def print_result(
                 "Original IRModule:" + DELIMITOR + original_mod.script(),
                 "Scheduled IRModule:" + DELIMITOR + scheduled_mod.script(),
                 "Trace" + DELIMITOR + str(trace),
-                "Input:" + DELIMITOR + str(inputs),
             ]
         )
         if result == "wrong answer":
             output.extend(
                 [
+                    "Input:" + DELIMITOR + str(inputs),
                     "Original Result:" + DELIMITOR + str(original_res),
                     "Scheduled Result:" + DELIMITOR + str(scheduled_res),
                     "Max Diff:"

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -34,7 +34,7 @@ from tvm.tir import Schedule
 from tvm.tir.schedule import Trace
 from tvm.meta_schedule.utils import remove_build_dir
 from tvm.meta_schedule.testing.tune_utils import generate_input_data
-from tvm.tir.tensor_intrin import *  # type: ignore # pylint: disable=unused-import,wildcard-import
+from tvm.tir.tensor_intrin import *  # type: ignore # pylint: disable=wildcard-import,unused-wildcard-import
 
 DELIMITOR = "\n" + "-" * 30 + "\n"
 

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -34,7 +34,7 @@ from tvm.tir import Schedule
 from tvm.tir.schedule import Trace
 from tvm.meta_schedule.utils import remove_build_dir
 from tvm.meta_schedule.testing.tune_utils import generate_input_data
-from tvm.tir.tensor_intrin import *  # type: ignore # pylint: disable=unused-import
+from tvm.tir.tensor_intrin import *  # type: ignore # pylint: disable=unused-import,wildcard-import
 
 DELIMITOR = "\n" + "-" * 30 + "\n"
 
@@ -687,9 +687,7 @@ def main():
                 device=get_runtime_device(ARGS.baseline_target),
             )
             scheduled_mods = [_apply_trace(original_mod, record.trace) for record in records]
-            builder_results = _build_all_mods(
-                [scheduled_mod for scheduled_mod in scheduled_mods], builder, target  # type: ignore
-            )
+            builder_results = _build_all_mods(scheduled_mods, builder, target)  # type: ignore
             for i, record in enumerate(records):
                 counter += 1
                 print_result = print_with_counter_func(counter=counter, total=total)

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -19,7 +19,7 @@ import argparse
 import logging
 import warnings
 from distutils.util import strtobool
-from typing import Callable, List, Tuple, Union
+from typing import Callable, Tuple, Union, List, Any
 
 import numpy as np  # type: ignore
 
@@ -89,6 +89,12 @@ def _parse_args():
         default=100,
     )
     args.add_argument(
+        "--top-k",
+        type=int,
+        default=10**9,
+        help="The number of top-k tuning records to validate for each unique original workload.",
+    )
+    args.add_argument(
         "--cpu-flush",
         type=lambda x: bool(strtobool(x)),
         help="example: True / False",
@@ -136,13 +142,25 @@ def default_check_metric(a: List[tvm.nd.NDArray], b: List[tvm.nd.NDArray]) -> bo
     return True
 
 
+def to_numpy(a: List[tvm.nd.NDArray]) -> List[np.ndarray]:
+    """Convert a list of TVM NDArray to a list of numpy array"""
+    assert a is not None, "Empty result cannot be converted to numpy"
+    return [x.numpy() for x in a]
+
+
+def to_tvm_ndarray(a: List[np.ndarray]) -> List[tvm.nd.NDArray]:
+    """Convert a list of numpy array to a list of TVM NDArray"""
+    assert a is not None, "Empty result cannot be converted to TVM NDArray"
+    return [tvm.nd.array(x) for x in a]
+
+
 def is_failed_record(record: ms.database.TuningRecord) -> bool:
     """Check if a tuning record is failed."""
     return len(record.run_secs) == 1 and record.run_secs[0] == 1e9
 
 
-def print_validation_result(
-    idx: int,
+def print_result(
+    counter: int,
     total: int,
     result: str,
     time: float,
@@ -157,7 +175,8 @@ def print_validation_result(
 ) -> None:
     """Print the validation result."""
     output = [
-        f"Progress {idx: 6d} / {total: 6d} checked, used {float(time): 3.3f} sec. Result: {result}"
+        f"Progress {counter: 6d} / {total: 6d} checked, "
+        f"used {float(time): 3.3f} sec. Result: {result}"
     ]
     if result not in ["pass", "skip"]:
         output.extend(
@@ -194,6 +213,34 @@ def print_validation_result(
     print("\n\n".join(output))
 
 
+def check_and_run(func: Union[str, Callable], *args, **kwargs) -> Any:
+    """Check if the function is a string or a callable, and run it."""
+    if isinstance(func, str):
+        func = get_global_func(func)
+    return func(*args, **kwargs)  # type: ignore
+
+
+def build_and_run(
+    mod: IRModule,
+    target: Target,
+    rpc_config: ms.runner.RPCConfig,
+    dev_type: str,
+    inputs: List[np.ndarray],
+) -> List[np.ndarray]:
+    """Build and run the module on the target device."""
+    rt_mod = tvm.build(mod, target=target)
+    return to_numpy(
+        run_module_via_rpc(
+            rpc_config=rpc_config,
+            lib=rt_mod,
+            dev_type=dev_type,
+            args={i: v for i, v in enumerate(inputs)},  # pylint: disable=unnecessary-comprehension
+            continuation=create_calculator(backend="tir"),
+            backend="tir",
+        )
+    )
+
+
 def validate_correctness(
     original_mod: IRModule,  # compiled for "baseline_target"
     scheduled_mod: IRModule,  # compiled for "target"
@@ -202,6 +249,8 @@ def validate_correctness(
     target: Target,
     dev_type: str,
     rpc_config: ms.runner.RPCConfig,
+    inputs: List[np.ndarray] = None,  # for input reuse
+    original_res: List[np.ndarray] = None,  # for original mod results reuse
     f_input_generator: Union[
         str, Callable[[IRModule], List[tvm.nd.NDArray]]
     ] = default_input_generator,
@@ -225,6 +274,10 @@ def validate_correctness(
         The device type to run the module via rpc.
     rpc_config : RPCConfig
         The RPCConfig to run the scheduled module.
+    inputs : List[np.ndarray]
+        The input data to be reused, if None, generate new inputs.
+    original_res : List[np.ndarray]
+        The original module results to be reused, if None, run the original module.
     f_input_generator : Union[str, Callable]
         The function to generate the input data.
     f_check_metric : Union[str, Callable]
@@ -232,48 +285,39 @@ def validate_correctness(
 
     Returns
     -------
-    result : bool
-        The result of the validation.
+    passed: bool
+        Whether the validation passed.
+    inputs: List[np.ndarray]
+        The input data used for validation in numpy array.
+    original_res: List[np.ndarray]
+        The original module results in numpy array.
+    scheduled_res: List[np.ndarray]
+        The scheduled module results in numpy array.
     """
 
-    def to_numpy(a: List[tvm.nd.NDArray]) -> List[np.ndarray]:
-        """Convert a list of TVM NDArray to a list of numpy array"""
-        assert a is not None, "Empty result cannot be converted to numpy"
-        return [x.numpy() for x in a]
-
-    def to_tvm_ndarray(a: List[np.ndarray]) -> List[tvm.nd.NDArray]:
-        """Convert a list of numpy array to a list of TVM NDArray"""
-        assert a is not None, "Empty result cannot be converted to TVM NDArray"
-        return [tvm.nd.array(x) for x in a]
-
-    def build_and_run(mod: IRModule, target: Target, dev_type: str) -> List[tvm.nd.NDArray]:
-        """Build and run the module on the target device."""
-        rt_mod = tvm.build(mod, target=target)
-        return run_module_via_rpc(
-            rpc_config=rpc_config,
-            lib=rt_mod,
-            dev_type=dev_type,
-            args={i: v for i, v in enumerate(inputs)},  # pylint: disable=unnecessary-comprehension
-            continuation=create_calculator(backend="tir"),
-            backend="tir",
-        )
-
     # fetch input function & prepare inputs
-    if isinstance(f_input_generator, str):
-        f_input_generator = get_global_func(f_input_generator)
-    inputs = to_numpy(f_input_generator(original_mod))  # type: ignore
+    if inputs is None:
+        inputs = to_numpy(check_and_run(f_input_generator, original_mod))
 
     # build & run original result
-    original_res = to_numpy(build_and_run(original_mod, target=baseline_target, dev_type="cpu"))
-    scheduled_res = to_numpy(build_and_run(scheduled_mod, target=target, dev_type=dev_type))
+    if original_res is None:
+        original_res = build_and_run(
+            original_mod,
+            target=baseline_target,
+            rpc_config=rpc_config,
+            dev_type="cpu",
+            inputs=inputs,
+        )
+    scheduled_res = build_and_run(
+        scheduled_mod, target=target, rpc_config=rpc_config, dev_type=dev_type, inputs=inputs
+    )
 
     # fetch comparison function
-    if isinstance(f_check_metric, str):
-        f_check_metric = get_global_func(f_check_metric)
+    validation_res = check_and_run(f_check_metric, original_res, scheduled_res)
 
     # check metric
     return (
-        f_check_metric(to_tvm_ndarray(original_res), to_tvm_ndarray(scheduled_res)),  # type: ignore
+        validation_res,
         inputs,
         original_res,
         scheduled_res,
@@ -283,63 +327,110 @@ def validate_correctness(
 def main():
     """Main function"""
     describe()
-    database = ms.database.create(work_dir=ARGS.work_dir)
     target = ARGS.target
+    database = ms.database.create(work_dir=ARGS.work_dir)
+
+    # determine target kind
     if target.kind.name == "llvm":
         dev_type = "cpu"
     elif target.kind.name == "cuda":
         dev_type = "cuda"
     else:
         raise RuntimeError(f"Unsupported target kind: {target.kind.name}")
-    records = database.get_all_tuning_records()
-    with ms.Profiler() as profiler:
-        for i, record in enumerate(records):
-            scope_name = f"validate #{i}"
-            if is_failed_record(record):
-                print_validation_result(i + 1, total=len(records), result="skip", time=0.0)
-                continue
-            try:
-                with profiler.timeit(scope_name):
-                    original_mod = record.workload.mod
-                    sch = Schedule(original_mod)
-                    record.trace.apply_to_schedule(sch=sch, remove_postproc=False)
-                    scheduled_mod = sch.mod
-                    passed = False
 
-                    passed, inputs, original_res, scheduled_res = validate_correctness(
+    # start profiling
+    with ms.Profiler() as profiler:
+        # collect records
+        with profiler.timeit("collect records"):
+            records = database.get_all_tuning_records()
+            print(
+                f"Total {len(records)} records to be validated. "
+                f"Collected in {float(profiler.get()['collect records']): 3.3f} sec."
+            )
+
+        # collect unique original TIR
+        with profiler.timeit("deduplicate records"):
+            workloads = dict()
+            for record in records:
+                mod = record.workload.mod
+                s_hash = tvm.ir.structural_hash(mod)
+                if s_hash not in workloads:
+                    workloads[s_hash] = [mod]
+                else:
+                    duplicate = False
+                    for previous_mod in workloads[hash]:
+                        if tvm.ir.structural_equal(mod, previous_mod):
+                            duplicate = True
+                            break
+                    if not duplicate:
+                        workloads[hash].append(mod)
+            # put the workload into a list
+            unique_workloads = []
+            for _, mods in workloads.items():
+                unique_workloads.extend(mods)
+            print(
+                f"Total {len(unique_workloads)} unique original TIR to be validated. "
+                f"Deduplicated in {float(profiler.get()['deduplicate records']): 3.3f} sec."
+            )
+
+        # validate correctness
+        counter = 0
+        for original_mod in unique_workloads:
+            records = database.get_top_k(workload=database.commit_workload(mod), top_k=10**9)
+            inputs = None
+            original_res = None
+            for record in records:
+                counter += 1
+                scope_name = f"validate #{counter}"
+                if is_failed_record(record):
+                    # skip failed records where run_secs is 1e9
+                    # these records are only negative samples for cost model
+                    print_result(counter + 1, total=len(records), result="skip", time=0.0)
+                    continue
+                try:
+                    with profiler.timeit(scope_name):
+                        # prepare scheduled module
+                        sch = Schedule(original_mod)
+                        record.trace.apply_to_schedule(sch=sch, remove_postproc=False)
+                        scheduled_mod = sch.mod
+                        # validate correctness
+                        passed, inputs, original_res, scheduled_res = validate_correctness(
+                            original_mod=original_mod,
+                            scheduled_mod=scheduled_mod,
+                            target=target,
+                            baseline_target=ARGS.baseline_target,
+                            dev_type=dev_type,
+                            rpc_config=ARGS.rpc_config,
+                            inputs=inputs,
+                            original_res=original_res,
+                        )
+                    # validation finished
+                    print_result(
+                        counter + 1,
+                        total=len(records),
+                        result="pass" if passed else "wrong answer",
+                        time=profiler.get()[scope_name],
                         original_mod=original_mod,
                         scheduled_mod=scheduled_mod,
-                        target=target,
-                        baseline_target=ARGS.baseline_target,
-                        dev_type=dev_type,
-                        rpc_config=ARGS.rpc_config,
+                        trace=record.trace,
+                        inputs=inputs,
+                        original_res=original_res,
+                        scheduled_res=scheduled_res,
                     )
-                print_validation_result(
-                    i + 1,
-                    total=len(records),
-                    result="pass" if passed else "wrong answer",
-                    time=profiler.get()[scope_name],
-                    original_mod=original_mod,
-                    scheduled_mod=scheduled_mod,
-                    trace=record.trace,
-                    inputs=inputs,
-                    original_res=original_res,
-                    scheduled_res=scheduled_res,
-                )
-            except Exception as e:  # pylint: disable=broad-except, invalid-name
-                print_validation_result(
-                    i + 1,
-                    total=len(records),
-                    result="exception",
-                    time=profiler.get()[scope_name],
-                    original_mod=original_mod,
-                    scheduled_mod=scheduled_mod,
-                    trace=record.trace,
-                    exception=e,
-                )
-
-    print("Validation finished!")
-    print(f"Total time spent: {float(profiler.get()['Total']): 3.3f} sec.")
+                except Exception as e:  # pylint: disable=broad-except, invalid-name
+                    # validation failed with exception
+                    print_result(
+                        counter + 1,
+                        total=len(records),
+                        result="exception",
+                        time=profiler.get()[scope_name],
+                        original_mod=original_mod,
+                        scheduled_mod=scheduled_mod,
+                        trace=record.trace,
+                        exception=e,
+                    )
+        print("Validation finished!")
+        print(f"Total time spent: {float(profiler.get()['Total']): 3.3f} sec.")
 
 
 if __name__ == "__main__":

--- a/src/meta_schedule/measure_callback/remove_build_artifact.cc
+++ b/src/meta_schedule/measure_callback/remove_build_artifact.cc
@@ -28,7 +28,7 @@ class RemoveBuildArtifactNode : public MeasureCallbackNode {
              const Array<BuilderResult>& builder_results,
              const Array<RunnerResult>& runner_results) final {
     static const PackedFunc* f_rm = runtime::Registry::Get("meta_schedule.remove_build_dir");
-    ICHECK(*f_rm != nullptr) << "The `remove_build_dir` func is not in tvm registry.";
+    ICHECK(f_rm != nullptr) << "The `remove_build_dir` func is not in tvm registry.";
     auto _ = Profiler::TimedScope("MeasureCallback/RemoveBuildArtifact");
     for (const BuilderResult& build_result : builder_results) {
       if (Optional<String> path = build_result->artifact_path) {


### PR DESCRIPTION
Following up on #12948, this PR further enhances the validation script by
- [x] Reusing same TIR results for speed up
- [x] Reusing RPCRunner for benchmarking & validation at the same time
- [x] Consolidate output interface and output maximum difference if wrong answer
- [x] Support Top-K validation (superfast for relay compilation validation)
- [x] Skip failed tuning records
- [x] Support Tensorized records (to be tested)
- [x] Allow batch build
- [x] Support local runner