### PR TITLE
[CI][Docker] Store GTest sources in GPU docker image

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -39,7 +39,7 @@ COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source
 RUN bash /install/ubuntu_install_cmake_source.sh
 
 COPY install/ubuntu_install_googletest.sh /install/ubuntu_install_googletest.sh
-RUN bash /install/ubuntu_install_googletest.sh
+RUN bash /install/ubuntu_install_googletest.sh /googletest
 
 ENV TVM_VENV /venv/apache-tvm-py3.7
 COPY python/bootstrap/lockfiles /install/python/bootstrap/lockfiles

--- a/docker/install/ubuntu_install_googletest.sh
+++ b/docker/install/ubuntu_install_googletest.sh
@@ -20,14 +20,19 @@ set -e
 set -u
 set -o pipefail
 
-tmpdir=$(mktemp -d)
+if [ $# -eq 0 ]; then
+    tmpdir=$(mktemp -d)
 
-cleanup()
-{
-  rm -rf "$tmpdir"
-}
+    cleanup()
+    {
+      rm -rf "$tmpdir"
+    }
 
-trap cleanup 0
+    trap cleanup 0
+else
+    tmpdir=$1
+    mkdir -p "$tmpdir"
+fi
 
 # GoogleTest uses a Live-at-Head philosophy:
 # https://github.com/google/googletest#live-at-head
@@ -38,16 +43,14 @@ repo_revision="830fb567285c63ab5b5873e2e8b02f2249864916"
 
 archive_name="${repo_revision}.tar.gz"
 archive_url="${repo_url}/archive/${archive_name}"
-archive_folder="googletest-${repo_revision}"
 archive_hash="10f10ed771efc64a1d8234a7e4801838a468f8990e5d6d8fcf63e89f8d1455c4f9c5adc0bb829669f381609a9abf84e4c91a7fdd7404630f375f38fb485ef0eb"
 
 cd "$tmpdir"
 
 curl -sL "${archive_url}" -o "${archive_name}"
 echo "$archive_hash" ${archive_name} | sha512sum -c
-tar xf "${archive_name}"
+tar xf "${archive_name}" --strip-components=1
 
-cd ${archive_folder}
 mkdir build
 cd build
 


### PR DESCRIPTION
It is necessary to have google tests source code to build them for the GPU device and run OpenCL cpp tests. In #13400 we enable OpenCL cpp tests in CI.

