### PR TITLE
[MetaSchedule] Use current pass context in compile_relay, extract_tasks

### DIFF
--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -16,14 +16,14 @@
 # under the License.
 """MetaSchedule-Relay integration"""
 from contextlib import contextmanager
-from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 # isort: off
 from typing_extensions import Literal
 
 # isort: on
 import numpy as np  # type: ignore
+
 from tvm import nd
 from tvm._ffi import get_global_func
 from tvm.ir import IRModule, transform

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_int8.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_int8.py
@@ -347,7 +347,7 @@ def tune_conv2d_template(
             else None
         )
 
-    with tempfile.TemporaryDirectory() as work_dir:
+    with tempfile.TemporaryDirectory() as work_dir, pass_context:
         database = ms.relay_integration.tune_relay(
             mod=mod,
             target=TARGET_HEXAGON,
@@ -382,15 +382,11 @@ def tune_conv2d_template(
             module_equality="ignore-ndarray",
         )
 
-        # Add default options so that it still uses the base config.
-        pass_config["relay.backend.use_meta_schedule"] = True
-        pass_config["relay.backend.tir_converter"] = "default"
         return ms.relay_integration.compile_relay(
             database=database,
             mod=mod,
             target=TARGET_HEXAGON,
             params=params,
-            pass_config=pass_config,
         )
 
 


### PR DESCRIPTION
Adds the pass config information necessary for tuning and compiling relay with metaschedule to the existing pass context instead of overriding the existing one. Allows users to pass in their own pass instruments, required passes, and disabled passes. This also keeps the same API used to compile relay with autotvm and auto_scheduler.