### PR TITLE
[QNN][ONNX][Relay] support mix-precision input types for QLinearMatMulfix

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4771,8 +4771,6 @@ class MatMulInteger(OnnxOpConverter):
         assert a_dtype in ("int8", "uint8"), "MatMulInteger: invalid dtype for first input"
         assert b_dtype in ("int8", "uint8"), "MatMulInteger: invalid dtype for second input"
 
-        assert a_dtype == b_dtype, "MatMulInteger: input dtypes must match"
-
         a_scale = _op.const(1.0, dtype="float32")
         b_scale = _op.const(1.0, dtype="float32")
         out_scale = _op.const(1.0, dtype="float32")

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -6247,13 +6247,11 @@ def test_qlinearmatmul(target, dev):
     # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "int8")
     verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "int8")
 
-    # TODO(vvchernov): problems on ONNX Runtime side and type check (onnx.py:L4763) on TVM side
     # Default matmul both ranks = 2 (x_dtype = "uint8", w_dtype = "int8")
-    # verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "uint8", "int8")
+    verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "uint8", "int8")
 
-    # TODO(vvchernov): problems on ONNX Runtime side and type check (onnx.py:L4763) on TVM side
     # Default matmul both ranks = 2 (x_dtype = "int8", w_dtype = "uint8")
-    # verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "uint8")
+    verify_qlinearmatmul((2, 3), (3, 2), (2, 2), "int8", "uint8")
 
     # Reduced matmul: x_ranks = 1, w_rank = 2 (x_dtype = "uint8", w_dtype = "uint8")
     verify_qlinearmatmul((3,), (3, 2), (2,))


### PR DESCRIPTION
There is fix of issue #13466. CI tests prepared earlier for this case were uncommented.

cc @masahi 