### PR TITLE
[MetaSchedule][Minor] Unify Cuda-TensorCore Naming in Schedule Rule Kind

### DIFF
--- a/src/meta_schedule/space_generator/space_generator.cc
+++ b/src/meta_schedule/space_generator/space_generator.cc
@@ -42,7 +42,7 @@ String GetRuleKindFromTarget(const Target& target) {
         sm = sm.substr(3);
         try {
           if (std::stoi(sm) >= 75) {
-            return "cuda_tensorcore";
+            return "cuda-tensorcore";
           }
         } catch (const std::invalid_argument& e) {
           LOG(WARNING) << "ValueError: Unable to parse `target.arch`: " << sm
@@ -78,7 +78,7 @@ void SpaceGeneratorNode::InitializeWithTuneContext(const TuneContext& context) {
       default_sch_rules = ScheduleRule::DefaultCUDA();
       default_postprocs = Postproc::DefaultCUDA();
       default_mutator_probs = Mutator::DefaultCUDA();
-    } else if (kind == "cuda_tensorcore") {
+    } else if (kind == "cuda-tensorcore") {
       default_sch_rules = ScheduleRule::DefaultCUDATensorCore();
       default_postprocs = Postproc::DefaultCUDATensorCore();
       default_mutator_probs = Mutator::DefaultCUDATensorCore();


### PR DESCRIPTION
This PR unifies `cuda-tensorcore` and `cuda_tensorcore` to the former one to be consistent with python side `create` functions for schedule rules, post processors, and mutators.