### PR TITLE
[tir]delete useless param in driver_api.cc

### DIFF
--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -422,8 +422,6 @@ std::pair<IRModule, IRModule> SplitMixedModule(IRModule mod_mixed, const Target&
 
 runtime::Module TIRToRuntime(const Map<Target, IRModule>& inputs_arg,
                              const Target& target_host_arg) {
-  auto pass_ctx = transform::PassContext::Current();
-
   std::vector<runtime::Module> device_modules;
   Map<Target, IRModule> inputs = inputs_arg;
   Target target_host = target_host_arg;


### PR DESCRIPTION
The parameter `pass_ctx` is not used in `TIRToRuntime`.

Just remove it.