### PR TITLE
[ci] Don't merge PRs with main

### DIFF
--- a/ci/jenkins/generated/arm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/arm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.365592
+// Generated at 2022-12-08T16:10:54.358733
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/cortexm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/cortexm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.204393
+// Generated at 2022-12-08T16:10:54.410381
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/cpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/cpu_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.393957
+// Generated at 2022-12-08T16:10:54.515016
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/docker_jenkinsfile.groovy
+++ b/ci/jenkins/generated/docker_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-07T07:10:24.637792
+// Generated at 2022-12-08T16:10:54.482205
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/gpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/gpu_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-07T07:10:24.840515
+// Generated at 2022-12-08T16:10:54.428082
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/hexagon_jenkinsfile.groovy
+++ b/ci/jenkins/generated/hexagon_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.338377
+// Generated at 2022-12-08T16:10:54.340323
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/lint_jenkinsfile.groovy
+++ b/ci/jenkins/generated/lint_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.313954
+// Generated at 2022-12-08T16:10:54.450061
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/minimal_jenkinsfile.groovy
+++ b/ci/jenkins/generated/minimal_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.235080
+// Generated at 2022-12-08T16:10:54.466049
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/riscv_jenkinsfile.groovy
+++ b/ci/jenkins/generated/riscv_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.442689
+// Generated at 2022-12-08T16:10:54.377321
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/generated/wasm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/wasm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2022-12-06T20:56:42.420989
+// Generated at 2022-12-08T16:10:54.500580
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -138,19 +138,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -162,6 +175,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -172,18 +191,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/ci/jenkins/templates/utils/Prepare.groovy.j2
+++ b/ci/jenkins/templates/utils/Prepare.groovy.j2
@@ -8,19 +8,32 @@ def init_git() {
     checkout scm
   }
 
-  // Add more info about job node
-  sh (
-    script: './tests/scripts/task_show_node_info.sh',
-    label: 'Show executor node info',
-  )
-
   // Determine merge commit to use for all stages
   if (env.BRANCH_NAME == 'main') {
     // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
     update_upstream_revision("HEAD")
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is PR branch so set the upstream revision to the last 'main' commit
+    def merge_base = sh(
+      script: "git merge-base HEAD origin/main",
+      label: 'Determine base revision',
+      returnStdout: true,
+    ).trim()
+
+    // Check that the merge base is not too old
+    sh(
+      script: """
+      set -eux
+      git fetch origin main
+      NUM_COMMITS_SINCE_BASE=\$(git rev-list --count ${merge_base}..FETCH_HEAD)
+      if [ "\$NUM_COMMITS_SINCE_BASE" -gt 100 ]; then
+        echo "Your merge base is too old. Please rebase your PR branch onto the latest main with 'git fetch origin main && git rebase origin/main'";
+        exit 1
+      fi
+      """,
+      label: 'Ensure merge base is recent',
+    )
+    update_upstream_revision(merge_base)
   }
 
   sh(
@@ -32,6 +45,12 @@ def init_git() {
     label: 'Update git submodules',
   )
   checkout_trusted_files()
+
+  // Add more info about job node
+  sh (
+    script: './tests/scripts/task_show_node_info.sh',
+    label: 'Show executor node info',
+  )
 }
 
 def update_upstream_revision(git_ref) {
@@ -42,18 +61,6 @@ def update_upstream_revision(git_ref) {
       returnStdout: true,
     ).trim()
   }
-}
-
-def merge_with_main() {
-  sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
-  )
-  update_upstream_revision("FETCH_HEAD")
-  sh (
-    script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
-  )
 }
 
 def docker_init(image) {

--- a/tests/scripts/task_show_node_info.sh
+++ b/tests/scripts/task_show_node_info.sh
@@ -41,3 +41,6 @@ echo "===== RUNNER INFO ====="
 df --human-readable
 lscpu
 free
+
+echo "===== GIT INFO ====="
+git log -10


### PR DESCRIPTION
This adds some CI load by running PRs that would merge-conflict with
main but improves UX by making it so CI is deterministic based on git
history rather than when the PR happened to be submitted.

Fixes #12657

Announced to discuss in https://discuss.tvm.apache.org/t/ci-disabling-merge-to-main-at-runtime/14075