### PR TITLE
Fix typo in golang sample

### DIFF
--- a/golang/sample/complex.go
+++ b/golang/sample/complex.go
@@ -129,7 +129,7 @@ func main() {
     fmt.Printf("Module params loaded\n")
 
     // Set some data in input Array
-    inSlice := make([]float32, (244 * 244 * 3))
+    inSlice := make([]float32, (224 * 224 * 3))
     rand.Seed(10)
     rand.Shuffle(len(inSlice), func(i, j int) {inSlice[i],
                                                inSlice[j] = rand.Float32(),


### PR DESCRIPTION
At line132, raw code is `inSlice := make([]float32, (244 * 244 * 3))`, Howover, at line90 the input shape set `tshapeIn  := []int64{1, 224, 224, 3}`,  So there is an error.