### PR TITLE
[microTVM] Use `serial_number` in Zephyr tutorials

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_aot.py
+++ b/gallery/how_to/work_with_microtvm/micro_aot.py
@@ -106,6 +106,7 @@ if use_physical_hw:
     with open(boards_file) as f:
         boards = json.load(f)
     BOARD = os.getenv("TVM_MICRO_BOARD", default="nucleo_l4r5zi")
+    SERIAL = os.getenv("TVM_MICRO_SERIAL", default=None)
     TARGET = tvm.target.target.micro(boards[BOARD]["model"])
 
 ######################################################################
@@ -133,7 +134,7 @@ project_options = {}  # You can use options to provide platform-specific options
 
 if use_physical_hw:
     template_project_path = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr"))
-    project_options = {"project_type": "host_driven", "board": BOARD}
+    project_options = {"project_type": "host_driven", "board": BOARD, "serial_number": SERIAL}
 
 temp_dir = tvm.contrib.utils.tempdir()
 generated_project_dir = temp_dir / "project"

--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -101,6 +101,7 @@ if use_physical_hw:
         boards = json.load(f)
 
     BOARD = os.getenv("TVM_MICRO_BOARD", default="nucleo_l4r5zi")
+    SERIAL = os.getenv("TVM_MICRO_SERIAL", default=None)
     TARGET = tvm.target.target.micro(boards[BOARD]["model"])
 
 
@@ -156,6 +157,7 @@ if use_physical_hw:
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
+            "serial_number": SERIAL,
         },
     )
     builder = tvm.autotvm.LocalBuilder(
@@ -223,6 +225,7 @@ if use_physical_hw:
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
+            "serial_number": SERIAL
         },
     )
 
@@ -266,6 +269,7 @@ if use_physical_hw:
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
+            "serial_number": SERIAL
         },
     )
 

--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -225,7 +225,7 @@ if use_physical_hw:
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
-            "serial_number": SERIAL
+            "serial_number": SERIAL,
         },
     )
 
@@ -269,7 +269,7 @@ if use_physical_hw:
             "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
-            "serial_number": SERIAL
+            "serial_number": SERIAL,
         },
     )
 

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -209,6 +209,7 @@ if use_physical_hw:
         boards = json.load(f)
 
     BOARD = os.getenv("TVM_MICRO_BOARD", default="nucleo_f746zg")
+    SERIAL = os.getenv("TVM_MICRO_SERIAL", default=None)
     TARGET = tvm.target.target.micro(boards[BOARD]["model"])
 
 #
@@ -291,7 +292,7 @@ project_options = {}  # You can use options to provide platform-specific options
 
 if use_physical_hw:
     template_project_path = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr"))
-    project_options = {"project_type": "host_driven", "board": BOARD}
+    project_options = {"project_type": "host_driven", "board": BOARD, "serial_number": SERIAL}
 
 # Create a temporary directory
 


### PR DESCRIPTION
Add `serial_number` option to Zephyr tutorials so it's possible to run them in the hardware CI and specify the serial port by setting `TVM_MICRO_SERIAL` env. variable. 