### PR TITLE
[TIR] Fix an error when the result of compute_at has unit loop

### DIFF
--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -36,7 +36,6 @@ Analyzer::Analyzer()
       int_set(this) {}
 
 void Analyzer::Bind(const Var& var, const PrimExpr& expr, bool allow_override) {
-  ICHECK_EQ(var.dtype(), expr.dtype());
   PrimExpr new_expr = expr;
   new_expr = this->canonical_simplify(new_expr);
   new_expr = this->rewrite_simplify(new_expr);

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -36,6 +36,7 @@ Analyzer::Analyzer()
       int_set(this) {}
 
 void Analyzer::Bind(const Var& var, const PrimExpr& expr, bool allow_override) {
+  ICHECK_EQ(var.dtype(), expr.dtype());
   PrimExpr new_expr = expr;
   new_expr = this->canonical_simplify(new_expr);
   new_expr = this->rewrite_simplify(new_expr);

--- a/src/tir/schedule/primitive/compute_at.cc
+++ b/src/tir/schedule/primitive/compute_at.cc
@@ -265,7 +265,7 @@ class ScopeReconstructor : private StmtMutator {
         loop_vars.push_back(var);
         loop_extents.push_back(analyzer->Simplify(iter_dom->extent));
         iter_values.push_back(iter_dom->min + var);
-        analyzer->Bind(var, Range::FromMinExtent(0, iter_dom->extent));
+        analyzer->Bind(var, Range::FromMinExtent(IntImm(var.dtype(), 0), iter_dom->extent));
       } else {
         iter_values.push_back(iter_dom->min);
       }

--- a/tests/python/unittest/test_tir_schedule_compute_at.py
+++ b/tests/python/unittest/test_tir_schedule_compute_at.py
@@ -1509,16 +1509,15 @@ def test_reverse_compute_at_with_unit_loop():
     @T.prim_func
     def main(A: T.Buffer[(128, 128), "float32"], D: T.Buffer[(1, 2, 1), "float32"]) -> None:
         B = T.alloc_buffer([128, 128], dtype="float32")
-        C = T.alloc_buffer([128, 128], dtype="float32")
-        for i_0, j_0, i_1 in T.grid(8, 8, 16):
-            for j_1 in T.serial(16):
+        for i_0, j_0, i_1 in T.grid(T.int64(8), T.int64(8), T.int64(16)):
+            for j_1 in T.serial(T.int64(16)):
                 with T.block("B"):
-                    vi = T.axis.spatial(128, i_0 * 16 + i_1)
-                    vj = T.axis.spatial(128, j_0 * 16 + j_1)
+                    vi = T.axis.spatial(T.int64(128), i_0 * T.int64(16) + i_1)
+                    vj = T.axis.spatial(T.int64(128), j_0 * T.int64(16) + j_1)
                     T.reads(A[vi, vj])
                     T.writes(B[vi, vj])
                     B[vi, vj] = A[vi, vj] * T.float32(2)
-        for ax0, ax1, ax2 in T.grid(1, 2, 1):
+        for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(2), T.int64(1)):
             with T.block("D"):
                 v0, v1, v2 = T.axis.remap("SSS", [ax0, ax1, ax2])
                 T.reads(B[v0, v1])
@@ -1530,21 +1529,23 @@ def test_reverse_compute_at_with_unit_loop():
         A: T.Buffer[(128, 128), "float32"], D: T.Buffer[(1, 2, 1), "float32"]
     ):
         B = T.alloc_buffer([128, 128], dtype="float32")
-        C = T.alloc_buffer([128, 128], dtype="float32")
-        for i_0, j_0, i_1 in T.grid(8, 8, 16):
-            for j_1 in T.serial(16):
+        for i_0, j_0, i_1 in T.grid(T.int64(8), T.int64(8), T.int64(16)):
+            for j_1 in T.serial(T.int64(16)):
                 with T.block("B"):
-                    vi = T.axis.spatial(128, i_0 * 16 + i_1)
-                    vj = T.axis.spatial(128, j_0 * 16 + j_1)
+                    vi = T.axis.spatial(T.int64(128), i_0 * T.int64(16) + i_1)
+                    vj = T.axis.spatial(T.int64(128), j_0 * T.int64(16) + j_1)
                     T.reads(A[vi, vj])
                     T.writes(B[vi, vj])
                     B[vi, vj] = A[vi, vj] * T.float32(2)
-            for ax0, ax1, ax2 in T.grid(1, 16, 1):
+            for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(16), T.int64(1)):
                 with T.block("D"):
-                    T.where(i_0 * 16 + i_1 < 1 and j_0 * 16 + ax1 < 2)
-                    v0 = T.axis.spatial(1, i_0 * 16 + i_1 + ax0)
-                    v1 = T.axis.spatial(2, j_0 * 16 + ax1)
-                    v2 = T.axis.spatial(1, ax2)
+                    T.where(
+                        i_0 * T.int64(16) + i_1 < T.int64(1)
+                        and j_0 * T.int64(16) + ax1 < T.int64(2)
+                    )
+                    v0 = T.axis.spatial(T.int64(1), i_0 * T.int64(16) + i_1 + ax0)
+                    v1 = T.axis.spatial(T.int64(2), j_0 * T.int64(16) + ax1)
+                    v2 = T.axis.spatial(T.int64(1), ax2)
                     T.reads(B[v0, v1])
                     T.writes(D[v0, v1, v2])
                     D[v0, v1, v2] = B[v0, v1] + T.float32(1)


### PR DESCRIPTION
This PR fixes an error when the result of `reverse_compute_at`/`compute_at` contains unit loop (extent is 1). This is caused by dtype mismatch when binding vars in arith analyzer. This breaks the tuning of detectron2 models.

I also add a check in `Analyzer::Bind` to prevent similar problem. If this fails too many tests we can remove it from this PR.

cc: @junrushao @zxybazh 