### PR TITLE
[OpenCL][Adreno] Remove PrimFunc parameters annotation

### DIFF
--- a/src/relay/transforms/annotate_texture_storage.cc
+++ b/src/relay/transforms/annotate_texture_storage.cc
@@ -136,18 +136,6 @@ class StorageInfo : private transform::DeviceAwareExprVisitor {
 
   void VisitExpr_(const ConstantNode* cn) final { ApplyConsumerScopeToInputs(cn); }
 
-  void DeviceAwareVisitExpr_(const FunctionNode* function_node) final {
-    if (!function_node->HasNonzeroAttr(attr::kPrimitive)) {
-      for (auto&& param : function_node->params) {
-        auto virtual_device = GetVirtualDevice(param);
-        param->virtual_device_ =
-            VirtualDevice(virtual_device->device_type(), virtual_device->virtual_device_id,
-                          virtual_device->target, "global");
-      }
-    }
-    transform::DeviceAwareExprVisitor::DeviceAwareVisitExpr_(function_node);
-  }
-
   void DeviceAwareVisitExpr_(const CallNode* call) final {
     // Check the contents of this primitive function
     if (const auto* fn = call->op.as<FunctionNode>()) {

--- a/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
+++ b/tests/python/relay/opencl_texture/test_conv2d_nchw_texture.py
@@ -576,7 +576,7 @@ def test_residual_block(remote, target, dtype):
     }
     if dtype == "float16":
         static_memory_scope = [
-            "global",
+            "",
             "global.texture",
             "global.texture-weight",
             "global.texture-weight",
@@ -590,7 +590,7 @@ def test_residual_block(remote, target, dtype):
         ]
     else:
         static_memory_scope = [
-            "global",
+            "",
             "global.texture",
             "global.texture-weight",
             "global.texture-weight",
@@ -829,7 +829,7 @@ def test_pooling_branching_texture_params(remote, target, dtype):
     }
 
     static_memory_scope = [
-        "global",
+        "",
         "global.texture",
         "global.texture-weight",
         "global.texture",
@@ -956,7 +956,7 @@ def test_branching_texture_params(remote, target, dtype):
     }
 
     static_memory_scope = [
-        "global",
+        "",
         "global.texture",
         "global.texture-weight",
         "global.texture",
@@ -1045,7 +1045,7 @@ def test_conv2d_different_lowering_same_op(remote, target, dtype):
     }
 
     static_memory_scope = [
-        "global",
+        "",
         "global.texture",
         "global.texture-weight",
         "global.texture",
@@ -1177,7 +1177,7 @@ def test_injective_nwo_inputs1(remote, target, dtype):
     }
 
     static_memory_scope = [
-        "global",
+        "",
         "global.texture",
         "global.texture-nhwc",
         "global.texture",
@@ -1275,7 +1275,7 @@ def test_injective_nwo_inputs2(remote, target, dtype):
     }
 
     static_memory_scope = [
-        "global",
+        "",
         "global.texture",
         "global.texture-nhwc",
         "global.texture",


### PR DESCRIPTION
`DeviceAwareVisitExpr_` for `FunctionNode` had been modifying state of the parameters and specified memory scope for virtual device. `VisitExpr` functions shouldn't modify state of the objects. This is why this function was removed. After removing this function, the memory scope of the input tensors starts to be equal to empty line instead of "global".  But empty line and "global" will be transformed to the same memory object. This is why there is no difference between empty line and "global".