### PR TITLE
[DOCKER][ADRENO] we don't need microtvm being built for android cross…

### DIFF
--- a/tests/scripts/task_build_adreno_bins.sh
+++ b/tests/scripts/task_build_adreno_bins.sh
@@ -28,6 +28,7 @@ cd ${output_directory}
 
 cp ../cmake/config.cmake .
 
+echo set\(USE_MICRO OFF\) >> config.cmake
 echo set\(USE_CLML ON\) >> config.cmake
 echo set\(USE_CLML_GRAPH_EXECUTOR "${ADRENO_OPENCL}"\) >> config.cmake
 echo set\(USE_RPC ON\) >> config.cmake


### PR DESCRIPTION
… compilation

PR:https://github.com/apache/tvm/pull/13073 makes microtvm built by default with x86 compilers. Cross compilation fails due to this.