### PR TITLE
[RUNTIME] Correctly handling export_module when exporting modules of different type

### DIFF
--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -463,7 +463,7 @@ class Module(object):
         is_system_lib = False
         has_c_module = False
         llvm_target_string = None
-        global_object_format = None
+        global_object_format = "o"
         for index, module in enumerate(modules):
             if fcompile is not None and hasattr(fcompile, "object_format"):
                 if module.type_key == "c":

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -519,6 +519,7 @@ class Module(object):
 
         if self.imported_modules:
             if enabled("llvm") and llvm_target_string:
+                assert global_object_format is not None
                 path_obj = os.path.join(workspace_dir, f"devc.{global_object_format}")
                 m = _ffi_api.ModulePackImportsToLLVM(self, is_system_lib, llvm_target_string)
                 m.save(path_obj)

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -519,7 +519,6 @@ class Module(object):
 
         if self.imported_modules:
             if enabled("llvm") and llvm_target_string:
-                assert global_object_format is not None
                 path_obj = os.path.join(workspace_dir, f"devc.{global_object_format}")
                 m = _ffi_api.ModulePackImportsToLLVM(self, is_system_lib, llvm_target_string)
                 m.save(path_obj)

--- a/tests/python/unittest/test_runtime_module_export.py
+++ b/tests/python/unittest/test_runtime_module_export.py
@@ -21,6 +21,7 @@ from tvm import te
 import tvm.testing
 
 from tvm.contrib import utils
+import os
 
 header_file_dir_path = utils.tempdir()
 
@@ -203,7 +204,10 @@ def test_mod_export():
         synthetic_cpu_lib.import_module(f)
         synthetic_cpu_lib.import_module(engine_module)
         kwargs = {"options": ["-O2", "-std=c++17", "-I" + header_file_dir_path.relpath("")]}
-        synthetic_cpu_lib.export_library(path_lib, fcompile=False, **kwargs)
+        work_dir = temp.relpath("work_dir")
+        os.mkdir(work_dir)
+        synthetic_cpu_lib.export_library(path_lib, fcompile=False, workspace_dir=work_dir, **kwargs)
+        assert(os.path.exists(work_dir+"/devc.o"))
         loaded_lib = tvm.runtime.load_module(path_lib)
         assert loaded_lib.type_key == "library"
         # dso modules are merged

--- a/tests/python/unittest/test_runtime_module_export.py
+++ b/tests/python/unittest/test_runtime_module_export.py
@@ -207,7 +207,7 @@ def test_mod_export():
         work_dir = temp.relpath("work_dir")
         os.mkdir(work_dir)
         synthetic_cpu_lib.export_library(path_lib, fcompile=False, workspace_dir=work_dir, **kwargs)
-        assert(os.path.exists(work_dir+"/devc.o"))
+        assert os.path.exists(work_dir + "/devc.o")
         loaded_lib = tvm.runtime.load_module(path_lib)
         assert loaded_lib.type_key == "library"
         # dso modules are merged

--- a/tests/python/unittest/test_runtime_module_export.py
+++ b/tests/python/unittest/test_runtime_module_export.py
@@ -207,7 +207,7 @@ def test_mod_export():
         work_dir = temp.relpath("work_dir")
         os.mkdir(work_dir)
         synthetic_cpu_lib.export_library(path_lib, fcompile=False, workspace_dir=work_dir, **kwargs)
-        assert os.path.exists(work_dir + "/devc.o")
+        assert os.path.exists(os.path.join(work_dir, "devc.o"))
         loaded_lib = tvm.runtime.load_module(path_lib)
         assert loaded_lib.type_key == "library"
         # dso modules are merged


### PR DESCRIPTION
Previously the `export_module` function assumes that the module and all imported modules have the same `type_key`. If we have a host llvm module and some imported c modules, it may fail to set the `llvm_target_string` and `object_format` correctly, and thus fail to continue with the llvm build flow.

In this PR, I set the object format of a mixed-type module to that of the host module, and always set `llvm_target_string` when we see a host llvm module.

cc: @tqchen @YuchenJin 