### PR TITLE
[Relay][Pattern] Enable rewrite_once in class:DFPatternRewrite

### DIFF
--- a/src/relay/transforms/simplify_expr.h
+++ b/src/relay/transforms/simplify_expr.h
@@ -54,7 +54,7 @@ class DFPatternRewrite {
       Map<DFPattern, Array<Expr>> node_map = args[2];
       *rv = this->Callback(pre, post, node_map);
     };
-    return DFPatternCallback(pattern_, PackedFunc(func), require_type_);
+    return DFPatternCallback(pattern_, PackedFunc(func), require_type_, rewrite_once_);
   }
 
  protected:
@@ -62,6 +62,8 @@ class DFPatternRewrite {
   DFPattern pattern_;
   /*! \brief Whether or not the rewrite requires types to be inferred. */
   bool require_type_ = true;
+  /*! \brief Whether or not run the callback only once */
+  bool rewrite_once_ = false;
 };
 
 /*! \brief Helper class for composing rewrites and getting callbacks. */


### PR DESCRIPTION
In the original `DFPatternRewrite` class, the default is to rewrite multiple times, I think it is necessary for the user to set whether to run the callback once.