### PR TITLE
[ACL] Enable int8 data type in QNN CONV2D

### DIFF
--- a/python/tvm/relay/op/contrib/arm_compute_lib.py
+++ b/python/tvm/relay/op/contrib/arm_compute_lib.py
@@ -242,7 +242,7 @@ def arm_compute_lib_pattern_table(disabled_ops=["concatenate"]):
 
     def check_qnn_conv(extract):
         """Check qnn conv pattern is supported by ACL."""
-        if extract.attrs.out_dtype != "uint8":
+        if extract.attrs.out_dtype not in ("uint8", "int8"):
             return False
         call = extract
         while call.op.name != "qnn.conv2d":
@@ -347,16 +347,17 @@ def conv2d(expr):
 def qnn_conv2d(expr):
     """Check if the external ACL codegen for qnn.conv2d should be used."""
     attrs, args = expr.attrs, expr.args
+    qnn_dtypes = ("uint8", "int8")
 
     if attrs.data_layout != "NHWC":
         return False
     if attrs.out_dtype != "int32" and attrs.out_dtype != "":
         return False
     data_typ = args[0].checked_type
-    if len(data_typ.shape) != 4 or data_typ.shape[0] != 1 or data_typ.dtype != "uint8":
+    if len(data_typ.shape) != 4 or data_typ.shape[0] != 1 or data_typ.dtype not in qnn_dtypes:
         return False
     kernel_typ = args[1].checked_type
-    if len(kernel_typ.shape) != 4 or kernel_typ.dtype != "uint8":
+    if len(kernel_typ.shape) != 4 or kernel_typ.dtype not in qnn_dtypes:
         return False
     is_depthwise = is_depthwise_conv2d(
         data_typ.shape,

--- a/tests/python/contrib/test_arm_compute_lib/infrastructure.py
+++ b/tests/python/contrib/test_arm_compute_lib/infrastructure.py
@@ -30,6 +30,9 @@ from tvm.contrib import utils
 from tvm.autotvm.measure import request_remote
 
 
+QNN_DTYPES = ("uint8", "int8")
+
+
 class Device:
     """
     Configuration for Arm Compute Library tests.
@@ -118,6 +121,21 @@ class Device:
         cls.target = test_config["target"]
         cls.device_key = test_config.get("device_key") or ""
         cls.cross_compile = test_config.get("cross_compile") or ""
+
+
+def get_low_high_atol_rtol(dtype):
+    """Returns a tuple with boundary values and and tolerance for ACL tests."""
+
+    if dtype == "float32":
+        low, high, atol, rtol = (-127, 128, 0.001, 0.001)
+    elif dtype == "uint8":
+        low, high, atol, rtol = (0, 255, 1, 0)
+    elif dtype == "int8":
+        low, high, atol, rtol = (-127, 128, 1, 0)
+    else:
+        raise Exception(f"dtype not expected: {dtype}")
+
+    return low, high, atol, rtol
 
 
 def get_cpu_op_count(mod):


### PR DESCRIPTION
This enables `CONV2D` int8 data type to be used in Compute Library for the Arm(r) Architecture (ACL) BYOC integration.

Note: As we have a few PRs going in parallel for these operators, I'll submit another one in the end to consolidate these auxiliary functions and constants like `QNN_DTYPES`.

cc @lhutton1 @ashutosh-arm for reviews