### PR TITLE
[Docs][Bug] Fix broken link to tvmc python

### DIFF
--- a/gallery/tutorial/tvmc_command_line_driver.py
+++ b/gallery/tutorial/tvmc_command_line_driver.py
@@ -518,6 +518,8 @@ testing.utils.install_request_hook(depth=3)
 # To see what other options are available, please have a look at ``tvmc
 # --help``.
 #
-# In the next tutorial, `Compiling and Optimizing a Model with the Python
-# Interface <auto_tuning_with_pyton>`_, we will cover the same compilation
-# and optimization steps using the Python interface.
+# In the `next tutorial <tvmc_python>`, we introduce the Python interface to TVM,
+# and in the tutorial after that,
+# `Compiling and Optimizing a Model with the Python Interface <autotvm_relay_x86>`,
+# we will cover the same compilation and optimization steps using the Python
+# interface.


### PR DESCRIPTION
Ensure correct link is generated to the next page in the documentation.