### PR TITLE
Add close method to RPC session

### DIFF
--- a/python/tvm/auto_scheduler/utils.py
+++ b/python/tvm/auto_scheduler/utils.py
@@ -357,7 +357,8 @@ def check_remote(device_key, host=None, port=None, priority=100, timeout=10):
     """
 
     def _check():
-        request_remote(device_key, host, port, priority)
+        remote = request_remote(device_key, host, port, priority)
+        remote.close()
 
     t = threading.Thread(
         target=_check,

--- a/python/tvm/contrib/hexagon/session.py
+++ b/python/tvm/contrib/hexagon/session.py
@@ -119,8 +119,7 @@ class Session:
             )
         finally:
             # close session to the tracker
-            shutdown_func = self._rpc._sess.get_function("CloseRPCConnection")
-            shutdown_func()
+            self._rpc.close()
             del self._rpc
 
     @property

--- a/python/tvm/contrib/peak.py
+++ b/python/tvm/contrib/peak.py
@@ -365,30 +365,36 @@ def measure_peak_all(target, target_host, host, port):
     """
 
     target, target_host = Target.canon_target_and_host(target, target_host)
-    remote = rpc.connect(host, port)
-    n_times = 20
+    with rpc.connect(host, port) as remote:
+        n_times = 20
 
-    bandwidth_total_item = 1 << 25
-    bandwidth_item_per_thread = 32
+        bandwidth_total_item = 1 << 25
+        bandwidth_item_per_thread = 32
 
-    compute_total_item = 1 << 21
-    compute_item_per_thread = 4096
+        compute_total_item = 1 << 21
+        compute_item_per_thread = 4096
 
-    if str(target).startswith("opencl"):
-        dev = remote.cl()
-    elif str(target).startswith("cuda"):
-        dev = remote.cuda()
-    elif str(target).startswith("metal"):
-        dev = remote.metal()
-    else:
-        raise RuntimeError("Unsupported target")
+        if str(target).startswith("opencl"):
+            dev = remote.cl()
+        elif str(target).startswith("cuda"):
+            dev = remote.cuda()
+        elif str(target).startswith("metal"):
+            dev = remote.metal()
+        else:
+            raise RuntimeError("Unsupported target")
 
-    logging.info("========== measure memory bandwidth ==========")
-    measure_bandwidth_all_types(
-        bandwidth_total_item, bandwidth_item_per_thread, n_times, target, target_host, remote, dev
-    )
+        logging.info("========== measure memory bandwidth ==========")
+        measure_bandwidth_all_types(
+            bandwidth_total_item,
+            bandwidth_item_per_thread,
+            n_times,
+            target,
+            target_host,
+            remote,
+            dev,
+        )
 
-    logging.info("========== measure peak compute ==========")
-    measure_compute_all_types(
-        compute_total_item, compute_item_per_thread, n_times, target, target_host, remote, dev
-    )
+        logging.info("========== measure peak compute ==========")
+        measure_compute_all_types(
+            compute_total_item, compute_item_per_thread, n_times, target, target_host, remote, dev
+        )

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -566,6 +566,7 @@ def run_module(
             else:
                 logger.debug("Running on remote RPC with no key.")
                 session = rpc.connect(hostname, port)
+            stack.enter_context(session)
         elif device == "micro":
             # Remote RPC (running on a micro target)
             logger.debug("Running on remote RPC (micro target).")
@@ -578,6 +579,7 @@ def run_module(
             # Local
             logger.debug("Running a local session.")
             session = rpc.LocalSession()
+            stack.enter_context(session)
 
         # Micro targets don't support uploading a model. The model to be run
         # must be already flashed into the micro target before one tries

--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -534,3 +534,4 @@ def default_cleanup(
         session.remove(remote_path)
         session.remove(remote_path + ".so")
         session.remove("")
+        session.close()

--- a/python/tvm/micro/session.py
+++ b/python/tvm/micro/session.py
@@ -157,8 +157,7 @@ class Session:
         if not self._exit_called:
             self._exit_called = True
             self.transport.__exit__(exc_type, exc_value, exc_traceback)
-            shutdown_func = self._rpc._sess.get_function("CloseRPCConnection")
-            shutdown_func()
+            self._rpc.close()
 
     def _cleanup(self):
         self.__exit__(None, None, None)

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -42,6 +42,12 @@ class RPCSession(object):
         self._tbl_index = _ffi_api.SessTableIndex(sess)
         self._remote_funcs = {}
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def system_lib(self):
         """Get system-wide library module.
 
@@ -195,6 +201,11 @@ class RPCSession(object):
                 "tvm.rpc.server.download_linked_module"
             )
         return self._remote_funcs["download_linked_module"](path)
+
+    def close(self):
+        """Close RPC session."""
+        shutdown_func = self._sess.get_function("CloseRPCConnection")
+        shutdown_func()
 
     def cpu(self, dev_id=0):
         """Construct CPU device."""


### PR DESCRIPTION
Add close method to `RPCSession` and make sure we call it when we finish using it.

For more context, see [this discussion](https://discuss.tvm.apache.org/t/trouble-with-rpc-session/14008/1)