### PR TITLE
[docs][Adreno] Remove unnecessary compilation flag

### DIFF
--- a/docs/how_to/deploy/adreno.rst
+++ b/docs/how_to/deploy/adreno.rst
@@ -94,7 +94,7 @@ folder of TVM:
 
    mkdir build_android
    cd build_android
-   cmake .. -DUSE_OPENCL=ON -DUSE_MICRO=OFF -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_NATIVE_API_LEVEL=android-28 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON -DANDROID_STL=c++_static -DUSE_CPP_RPC=ON
+   cmake .. -DUSE_OPENCL=ON -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_NATIVE_API_LEVEL=android-28 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON -DANDROID_STL=c++_static -DUSE_CPP_RPC=ON
    make -jN tvm_runtime tvm_rpc
 
 where **N** is the number of cores available on your *CPU*.


### PR DESCRIPTION
Flag `-DUSE_MICRO=OFF` was added to avoid this issue #13482. In #13503 these changes were reverted.  Removed unnecessary compilation flag to avoid user confusing.