### PR TITLE
[microTVM][Tutorial] Fix micro_aot and micro_autotune tutorials

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_aot.py
+++ b/gallery/how_to/work_with_microtvm/micro_aot.py
@@ -134,7 +134,12 @@ project_options = {}  # You can use options to provide platform-specific options
 
 if use_physical_hw:
     template_project_path = pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr"))
-    project_options = {"project_type": "host_driven", "board": BOARD, "serial_number": SERIAL}
+    project_options = {
+        "project_type": "host_driven",
+        "board": BOARD,
+        "serial_number": SERIAL,
+        "config_main_stack_size": 4096,
+    }
 
 temp_dir = tvm.contrib.utils.tempdir()
 generated_project_dir = temp_dir / "project"

--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -154,7 +154,6 @@ if use_physical_hw:
         template_project_dir=pathlib.Path(tvm.micro.get_microtvm_template_projects("zephyr")),
         project_options={
             "board": BOARD,
-            "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
             "serial_number": SERIAL,
@@ -222,10 +221,10 @@ if use_physical_hw:
         temp_dir / "project",
         {
             "board": BOARD,
-            "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
             "serial_number": SERIAL,
+            "config_main_stack_size": 4096,
         },
     )
 
@@ -266,10 +265,10 @@ if use_physical_hw:
         temp_dir / "project",
         {
             "board": BOARD,
-            "west_cmd": "west",
             "verbose": False,
             "project_type": "host_driven",
             "serial_number": SERIAL,
+            "config_main_stack_size": 4096,
         },
     )
 


### PR DESCRIPTION
Added config_main_stack_size to autotune since running graph debugger requires more workspace. Also added to micro_aot because of KWS model.
Also removed `west_cmd` option in tutorial because of https://github.com/apache/tvm/pull/13377