### PR TITLE
[BYOC][DNNL] Enable memory movement oneDNN primitive

### DIFF
--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -76,9 +76,10 @@ def _register_external_op_helper(op_name, supported=True):
         if "concatenate" in op_name or "cast" in op_name:
             return supported
         args = expr.args
-        if any([x.checked_type.dtype == "int64" for x in args]):
-            logger.info("DNNL does not support int64.")
-            return False
+        # todo: fix check for concatenate with truple inputs
+        # if any([x.checked_type.dtype == "int64" for x in args]):
+        #     logger.info("DNNL does not support int64.")
+        #     return False
         # DNNL does not support pooling with ceil_mode = True.
         if "pool" in op_name:
             attrs = dict(get_attrs(expr))

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -73,6 +73,8 @@ def _register_external_op_helper(op_name, supported=True):
 
     @tvm.ir.register_op_attr(op_name, "target.dnnl")
     def _func_wrapper(expr):
+        if "concatenate" in op_name or "cast" in op_name:
+            return supported
         args = expr.args
         if any([x.checked_type.dtype == "int64" for x in args]):
             logger.info("DNNL does not support int64.")
@@ -87,7 +89,7 @@ def _register_external_op_helper(op_name, supported=True):
     return _func_wrapper
 
 
-_register_external_op_helper("nn.batch_norm")
+# _register_external_op_helper("nn.batch_norm")
 _register_external_op_helper("nn.conv1d")
 _register_external_op_helper("nn.conv2d")
 _register_external_op_helper("nn.conv3d")
@@ -99,19 +101,22 @@ _register_external_op_helper("nn.avg_pool2d")
 _register_external_op_helper("nn.global_avg_pool2d")
 _register_external_op_helper("nn.max_pool3d")
 _register_external_op_helper("nn.avg_pool3d")
-_register_external_op_helper("abs")
-_register_external_op_helper("clip")
-_register_external_op_helper("exp")
-_register_external_op_helper("log")
-_register_external_op_helper("sqrt")
-_register_external_op_helper("round")
-_register_external_op_helper("nn.relu")
+# _register_external_op_helper("abs")
+# _register_external_op_helper("clip")
+# _register_external_op_helper("exp")
+# _register_external_op_helper("log")
+# _register_external_op_helper("sqrt")
+# _register_external_op_helper("round")
+# _register_external_op_helper("nn.relu")
 _register_external_op_helper("nn.leaky_relu")
-_register_external_op_helper("tanh")
-_register_external_op_helper("sigmoid")
+# _register_external_op_helper("tanh")
+# _register_external_op_helper("sigmoid")
 _register_external_op_helper("nn.softmax")
-_register_external_op_helper("add")
-_register_external_op_helper("multiply")
+# _register_external_op_helper("add")
+_register_external_op_helper("concatenate")
+_register_external_op_helper("layout_transform")
+_register_external_op_helper("cast")
+# _register_external_op_helper("multiply")
 _register_external_op_helper("nn.layer_norm")
 _register_external_op_helper("nn.batch_matmul")
 

--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -293,8 +293,7 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
           BatchMatMul(nid);
         } else if ("concatenate" == op_name) {
           Concat(nid);
-        } else if ("cast" == op_name ||
-                   "layout_transform" == op_name) {
+        } else if ("cast" == op_name || "layout_transform" == op_name) {
           Reorder(nid, engine_);
         } else {
           LOG(FATAL) << "Unsupported op: " << op_name;
@@ -302,7 +301,6 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
       }
     }
   }
-
 
   void Convolution(const size_t& nid) {
     auto node = nodes_[nid];
@@ -778,7 +776,6 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
            {{DNNL_ARG_SRC_0, lhs_tr}, {DNNL_ARG_SRC_1, rhs_tr}, {DNNL_ARG_DST, dst_tr}});
   }
 
-
   void Reorder(const size_t& nid, dnnl::engine engine_) {
     auto node = nodes_[nid];
     auto op_name = node.GetOpName();
@@ -797,13 +794,11 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
       dst_tr = dst_tr.TreatAs(dst_layout);
     }
 
-    auto reorder_prim_desc = dnnl::reorder::primitive_desc(
-      engine_, src_tr.desc(), engine_, dst_tr.desc());
+    auto reorder_prim_desc =
+        dnnl::reorder::primitive_desc(engine_, src_tr.desc(), engine_, dst_tr.desc());
 
-    Submit(dnnl::reorder(reorder_prim_desc),
-          {{DNNL_ARG_FROM, src_tr}, {DNNL_ARG_TO, dst_tr}});
+    Submit(dnnl::reorder(reorder_prim_desc), {{DNNL_ARG_FROM, src_tr}, {DNNL_ARG_TO, dst_tr}});
   }
-
 
   void Concat(const size_t& nid) {
     auto node = nodes_[nid];
@@ -817,17 +812,17 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
 
     int axis = std::stoi(node.GetAttr<std::vector<std::string>>("axis")[0]);
     if (axis < 0) {
-        axis = dst_tr.dims().size() + axis;
+      axis = dst_tr.dims().size() + axis;
     }
     ICHECK_LT(axis, dst_tr.dims().size());
 
     std::vector<dnnl::memory::desc> src_mds;
-    for(const auto& src_tr:src_trs){
+    for (const auto& src_tr : src_trs) {
       src_mds.emplace_back(src_tr.desc());
     }
 
     auto concat_prim_desc = dnnl::concat::primitive_desc(axis, src_mds, engine_);
-    for (int i = 0; i < num_inputs;i++){
+    for (int i = 0; i < num_inputs; i++) {
       src_trs[i] = src_trs[i].RequestLayout(concat_prim_desc.src_desc(i));
     }
     dst_tr = dst_tr.RequestLayout(concat_prim_desc.dst_desc());

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -1043,6 +1043,37 @@ def test_global_avg_pooling2d(run_module, dtype="float32"):
     run_and_verify_func(config, run_module=run_module)
 
 
+def test_concat(run_module, dtype="float32"):
+    x1_shape = (1, 80, 64)
+    x2_shape = (1, 80, 16)
+    x3_shape = (1, 80,  4)
+    x1 = relay.var("x1", shape=(x1_shape), dtype=dtype)
+    x2 = relay.var("x2", shape=(x2_shape), dtype=dtype)
+    x3 = relay.var("x3", shape=(x3_shape), dtype=dtype)
+    out = relay.concatenate((x1, x2, x3), axis=-1)
+    out = tvm.IRModule.from_expr(out)
+    config = out, {"x1": x1_shape, "x2": x2_shape, "x3": x3_shape}, []
+    run_and_verify_func(config, run_module=run_module)
+
+
+def test_layout_transform(run_module, dtype="float32"):
+    x_shape = (1, 224, 224, 3)
+    x = relay.var("x", shape=(x_shape), dtype=dtype)
+    out = relay.layout_transform(x, src_layout="NHWC", dst_layout="NCHW")
+    out = tvm.IRModule.from_expr(out)
+    config = out, {"x": x_shape}, []
+    run_and_verify_func(config, run_module=run_module)
+
+
+def test_cast(run_module, dtype="float32"):
+    x_shape = (1, 80, 64)
+    x = relay.var("x", shape=(x_shape), dtype=dtype)
+    out = relay.cast(x, dtype="bfloat16")
+    out = tvm.IRModule.from_expr(out)
+    config = out, {"x": x_shape}, []
+    run_and_verify_func(config, run_module=run_module)
+
+
 def test_pool3d(run_module, dtype="float32"):
     def get_graph(
         op,

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -1046,7 +1046,7 @@ def test_global_avg_pooling2d(run_module, dtype="float32"):
 def test_concat(run_module, dtype="float32"):
     x1_shape = (1, 80, 64)
     x2_shape = (1, 80, 16)
-    x3_shape = (1, 80,  4)
+    x3_shape = (1, 80, 4)
     x1 = relay.var("x1", shape=(x1_shape), dtype=dtype)
     x2 = relay.var("x2", shape=(x2_shape), dtype=dtype)
     x3 = relay.var("x3", shape=(x3_shape), dtype=dtype)


### PR DESCRIPTION
This patch is to enable three memory movement oneDNN primitive for DNNL-BYOC. The change has been verified on some models and shows good performance gain.