### PR TITLE
[CI] Add `set -x` for demo scripts

### DIFF
--- a/apps/microtvm/cmsisnn/run_demo.sh
+++ b/apps/microtvm/cmsisnn/run_demo.sh
@@ -19,6 +19,7 @@
 set -e
 set -u
 set -o pipefail
+set -x
 
 # Show usage
 function show_usage() {

--- a/apps/microtvm/ethosu/run_demo.sh
+++ b/apps/microtvm/ethosu/run_demo.sh
@@ -19,6 +19,7 @@
 set -e
 set -u
 set -o pipefail
+set -x
 
 # Show usage
 function show_usage() {


### PR DESCRIPTION
Previously, the `tests/scripts/task_demo_microtvm.sh` script prints the commands as they are run, but the
`apps/microtvm/ethosu/run_demo.sh` script did not.  As a result, it could be difficult to tell which step stalled or failed during CI.