### PR TITLE
[TIR] Disable RewriteSimplifier extensions in RemoveNoOp

### DIFF
--- a/src/tir/transforms/remove_no_op.cc
+++ b/src/tir/transforms/remove_no_op.cc
@@ -306,10 +306,6 @@ Pass RemoveNoOp() {
     }
 
     arith::Analyzer analyzer;
-    analyzer.rewrite_simplify.SetEnabledExtensions(arith::RewriteSimplifier::Extension(
-        arith::RewriteSimplifier::kTransitivelyProveInequalities |
-        arith::RewriteSimplifier::kConvertBooleanToAndOfOrs |
-        arith::RewriteSimplifier::kApplyConstraintsToBooleanBranches));
 
     auto* n = f.CopyOnWrite();
     n->body = NoOpRemover::Apply(std::move(n->body), &analyzer, std::move(touch_pattern), nullptr);


### PR DESCRIPTION
During a `tir.Simplify` pass, these extensions were conditionally enabled based on the `PassContext`.  Prior to this commit, they were enabled by default in the `tir.RemoveNoOp` pass, as the simplified expressions were only used to prove/disprove a no-op, and did not appear in the output TIR.  However, this caused performance issues for some nested boolean expressions.

This PR disables the analyzer extensions for the analyzer used by `tir.RemoveNoOp`.  The extensions are still used internally by `ControlFlowGraph`, including during the data-flow analysis used if `tir.transform.RemoveNoOpConfig.use_dataflow_analysis` is enabled, so the opt-in data-dependent no-op removals are unaffected.

Related to issue #13508.