### PR TITLE
[TOPI] Use integer arithmetic for topi.image.resize

### DIFF
--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -586,7 +586,7 @@ def _resize_2d(
         The computed result with type out_dtype
     """
 
-    if out_dtype is None:
+    if not out_dtype:
         out_dtype = data.dtype
 
     n, c, y, x, cc, inum, ic = get_2d_indices(indices, layout)

--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -1160,7 +1160,7 @@ def _resize_3d(
         l = [[0 for i in range(4)] for j in range(4)]
         for j in range(4):
             for i in range(4):
-                l[j][i] = _sum_products(p[j][i], wx)
+                l[j][i] = _sum_products(wx, p[j][i])
         col0 = _sum_products(wy, l[0])
         col1 = _sum_products(wy, l[1])
         col2 = _sum_products(wy, l[2])

--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -356,7 +356,7 @@ def _resize_1d(
         if exclude_outside:
             for i in range(4):
                 wx[i] = te.if_then_else(
-                    te.any(xint - 1 + i < 0, xint + i > image_width), 0.0, wx[i]
+                    te.any(xint - 1 + i < 0, xint + i > image_width), 0.0, wx[i].as_type(out_dtype)
                 )
             sum_wx = sum(wx)
             wx = [w / sum_wx for w in wx]
@@ -700,10 +700,10 @@ def _resize_2d(
         if exclude_outside:
             for i in range(4):
                 wx[i] = te.if_then_else(
-                    te.any(xint - 1 + i < 0, xint + i > image_width), 0.0, wx[i]
+                    te.any(xint - 1 + i < 0, xint + i > image_width), 0.0, wx[i].astype(out_dtype)
                 )
                 wy[i] = te.if_then_else(
-                    te.any(yint - 1 + i < 0, yint + i > image_height), 0.0, wy[i]
+                    te.any(yint - 1 + i < 0, yint + i > image_height), 0.0, wy[i].astype(out_dtype)
                 )
             sum_wx = sum(wx)
             sum_wy = sum(wy)
@@ -1144,13 +1144,13 @@ def _resize_3d(
         if exclude_outside:
             for i in range(4):
                 wz[i] = te.if_then_else(
-                    te.any(xint - 1 + i < 0, xint + i > image_height), 0.0, wx[i]
+                    te.any(xint - 1 + i < 0, xint + i > image_height), 0.0, wx[i].as_type(out_dtype)
                 )
                 wy[i] = te.if_then_else(
-                    te.any(yint - 1 + i < 0, yint + i > image_height), 0.0, wy[i]
+                    te.any(yint - 1 + i < 0, yint + i > image_height), 0.0, wy[i].as_type(out_dtype)
                 )
                 wx[i] = te.if_then_else(
-                    te.any(xint - 1 + i < 0, xint + i > image_width), 0.0, wx[i]
+                    te.any(xint - 1 + i < 0, xint + i > image_width), 0.0, wx[i].as_type(out_dtype)
                 )
             sum_wz = sum(wz)
             sum_wy = sum(wy)

--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -313,7 +313,7 @@ def _resize_1d(
         The computed result with type out_dtype
     """
 
-    if out_dtype is None:
+    if not out_dtype:
         out_dtype = data.dtype
 
     n, c, x, cc, inum, ic = get_1d_indices(indices, layout)
@@ -1044,7 +1044,7 @@ def _resize_3d(
         The computed result with type out_dtype
     """
 
-    if out_dtype is None:
+    if not out_dtype:
         out_dtype = data.dtype
 
     n, c, z, y, x, cc = get_3d_indices(indices, layout)

--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -178,8 +178,10 @@ def get_closest_index(in_x, rounding_method, boxes):
 
         numerator = in_x.numerator
         denominator = in_x.denominator
-        if rounding_method in ("round", "round_prefer_floor") or boxes is not None:
+        if rounding_method == "round" or boxes is not None:
             return (numerator + denominator // 2) // denominator
+        if rounding_method == "round_prefer_floor":
+            return (numerator + (denominator - 1) // 2) // denominator
         elif rounding_method == "round_prefer_ceil":
             return (numerator + (denominator + 1) // 2) // denominator
         elif rounding_method == "floor":

--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -630,7 +630,10 @@ class Fraction:
             elif isinstance(value, int):
                 return tvm.runtime.convert(value)
 
-            elif isinstance(value, tvm.tir.PrimExpr) and "int" in value.dtype:
+            elif (
+                isinstance(value, (tvm.tir.PrimExpr, tvm.te.Tensor, tvm.te.TensorSlice))
+                and "int" in value.dtype
+            ):
                 return value
 
             elif isinstance(value, (float, tvm.tir.FloatImm)):
@@ -645,7 +648,10 @@ class Fraction:
                 else:
                     raise ValueError(f"Could not represent value {value} as a ratio of integers")
 
-            elif isinstance(value, tvm.tir.PrimExpr) and "float" in value.dtype:
+            elif (
+                isinstance(value, (tvm.tir.PrimExpr, tvm.te.Tensor, tvm.te.TensorSlice))
+                and "float" in value.dtype
+            ):
                 # Any other floating-point expressions are forbidden.
                 raise ValueError(f"Could not represent value {value} as a ratio of integers")
 

--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -539,7 +539,9 @@ class Fraction:
     to check if an optimization is permissible (e.g. vectorized
     computations require linear buffer access), use of integer
     expressions may provide significant performance benefits.
-    However, writing the simplified form
+    However, directly writing the resulting integer expression would
+    be tedious in many cases, or may depend on a user-specified
+    fractional value.
 
     The `Fraction` class is intended to allow for easier writing of
     integer expressions.  The operator overloads will attempt to

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -254,16 +254,34 @@ PrimExpr Analyzer::Simplify(const PrimExpr& expr, int steps) {
   // of an expression might be destroyed by rewrite simplification.
   res = this->canonical_simplify(res);
 
+  std::cout << "Simplifying " << res << std::endl;
+
   for (int i = 0; i < steps; ++i) {
     if (tir::is_const_int(res)) {
-      return res;
+      break;
     }
     if (i % 2 == 0) {
-      res = this->rewrite_simplify(res);
+      std::cout << "\t"
+                << "Simplifying " << res << " using rewrite simplifier" << std::endl;
+      auto after = this->rewrite_simplify(res);
+      std::cout << "\t"
+                << "Simplified from " << res << " to " << after << " using rewrite simplifier"
+                << std::endl;
+      res = after;
+      // res = this->rewrite_simplify(res);
     } else {
-      res = this->canonical_simplify(res);
+      std::cout << "\t"
+                << "Simplifying " << res << " using canonical simplifier" << std::endl;
+      auto after = this->canonical_simplify(res);
+      std::cout << "\t"
+                << "Simplified from " << res << " to " << after << " using canonical simplifier"
+                << std::endl;
+      res = after;
+      // res = this->canonical_simplify(res);
     }
   }
+
+  std::cout << "Simplified into " << res << std::endl;
 
   return res;
 }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -385,7 +385,12 @@ void RewriteSimplifier::Impl::Update(const Var& var, const PrimExpr& info, bool 
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const AddNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<AddNode>();
-  if (auto const_res = TryConstFold<Add>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Add>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1, b2, s1, s2;
   // Pattern var match IntImm
@@ -536,7 +541,12 @@ RewriteSimplifier::Extension RewriteSimplifier::Impl::GetEnabledExtensions() con
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const SubNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<SubNode>();
-  if (auto const_res = TryConstFold<Sub>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Sub>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1, b2, s1, s2;
   // Pattern var match IntImm
@@ -725,7 +735,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const SubNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MulNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<MulNode>();
-  if (auto const_res = TryConstFold<Mul>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Mul>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1, b2, s1, s2;
   // Pattern var match IntImm
@@ -766,7 +781,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MulNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const DivNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<DivNode>();
-  if (auto const_res = TryConstFold<Div>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Div>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1;
   // Pattern var match IntImm
@@ -926,7 +946,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const DivNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const ModNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<ModNode>();
-  if (auto const_res = TryConstFold<Mod>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Mod>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
 
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1;
@@ -1016,7 +1041,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const ModNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<FloorDivNode>();
-  if (auto const_res = TryConstFold<FloorDiv>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<FloorDiv>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1;
   // Pattern var match IntImm
@@ -1034,7 +1064,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       int64_t c2val = c2.Eval()->value;
       ICHECK(c2val != 0) << "division by zero";
       if (c1val % c2val == 0) {
-        return ramp(floordiv(b1, c2), floordiv(c1, c2), lanes).Eval();
+        PrimExpr out = ramp(floordiv(b1, c2), floordiv(c1, c2), lanes).Eval();
+        std::cout << "\t\t"
+                  << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                  << std::endl;
+        return out;
       }
       // If all possible indices in ramp are the same.
       if (!arith::ExtractVscaleFactor(lanes.Eval())) {
@@ -1069,7 +1103,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
       PrimExpr yval = y.EvalOr(Integer(0));
-      if (c2val == 0) return ret;
+      if (c2val == 0) {
+        std::cout << "\t\t"
+                  << "Found denominator of zero in " << ret << ", bailing out" << std::endl;
+        return ret;
+      };
 
       // try eliminate residue part
       PrimExpr residue =
@@ -1077,7 +1115,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       PrimExpr y_div = CanProveEqual(floordiv(yval, c2val), 0) ? 0 : floordiv(yval, c2val);
       auto bound = analyzer_->const_int_bound(residue);
       if (bound.defined() && bound->max_value == bound->min_value) {
-        return x.Eval() * floordiv(c1val, c2.Eval()) + (y_div + Integer(bound->max_value));
+        PrimExpr out = x.Eval() * floordiv(c1val, c2.Eval()) + (y_div + Integer(bound->max_value));
+        std::cout << "\t\t"
+                  << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                  << std::endl;
+        return RecursiveRewrite(out);
       }
 
       // try simplify divisor
@@ -1089,7 +1131,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
         // ==> x' + d + (b * c1 + e) // c2
         // ==> x' + d since 0 <= b * c1 <= (a-1) * c1, 0 <= e < c1
         // ==> x // (c2 // c1) + (y // c2)
-        return floordiv(x.Eval(), floordiv(c2val, c1val)) + y_div;
+        PrimExpr out = floordiv(x.Eval(), floordiv(c2val, c1val)) + y_div;
+        std::cout << "\t\t"
+                  << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                  << std::endl;
+        return RecursiveRewrite(out);
       }
     }
 
@@ -1161,7 +1207,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<FloorModNode>();
-  if (auto const_res = TryConstFold<FloorMod>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<FloorMod>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
 
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, b1;
@@ -1181,7 +1232,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
       int64_t c2val = c2.Eval()->value;
       ICHECK(c2val != 0) << "division by zero";
       if (c1val % c2val == 0) {
-        return broadcast(floormod(b1, c2), lanes).Eval();
+        PrimExpr out = broadcast(floormod(b1, c2), lanes).Eval();
+        std::cout << "\t\t"
+                  << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                  << std::endl;
+        return out;
       }
       // If all possible indices in ramp are the same.
       ModularSet bmod = analyzer_->modular_set(b1.Eval());
@@ -1201,6 +1256,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
         }
         // If b1 can divide c2
         if (bmod->coeff % c2val == 0) {
+<<<<<<< HEAD
           return floormod(ramp(floormod(bmod->base, c2), c1, lanes), broadcast(c2, lanes)).Eval();
         }
       } else { /* scalable vectors */
@@ -1208,6 +1264,31 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
           return floormod(ramp(floormod(bmod->base, c2), c1, lanes), broadcast(c2, lanes)).Eval();
         }
       }
+=======
+          PrimExpr out = ramp(floormod(bmod->base, c2), c1, lanes).Eval();
+          std::cout << "\t\t"
+                    << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                    << std::endl;
+          return out;
+        }
+        // If all indices can be guaranteed to settle inside a coeff range
+        if (c2val % bmod->coeff == 0 && bmod->base + (lanes.Eval() - 1) * c1val < bmod->coeff) {
+          PrimExpr out = ramp(floormod(b1, c2), c1, lanes).Eval();
+          std::cout << "\t\t"
+                    << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                    << std::endl;
+          return out;
+        }
+      }
+      if (bmod->coeff % c2val == 0) {
+        PrimExpr out =
+            floormod(ramp(floormod(bmod->base, c2), c1, lanes), broadcast(c2, lanes)).Eval();
+        std::cout << "\t\t"
+                  << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                  << std::endl;
+        return out;
+      }
+>>>>>>> 99950669ad ([Debug] Print statements for RewriteSimplifier)
     }
   }
 
@@ -1260,7 +1341,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
         // try modular analysis
         ModularSet mod = analyzer_->modular_set(x.Eval());
         if (mod->coeff % c1val == 0) {
-          return floormod(mod->base, c1).Eval();
+          auto out = floormod(mod->base, c1).Eval();
+          std::cout << "\t\t"
+                    << "Rewriting " << ret << " to " << out << " using rule on line " << __LINE__
+                    << std::endl;
+          return out;
         }
 
         // floormod(x,c1) is a no-op when x is already in the
@@ -1278,7 +1363,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorModNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MinNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<MinNode>();
-  if (auto const_res = TryConstFold<Min>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Min>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
 
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, s1, s2;
@@ -1462,7 +1552,12 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MinNode* op) {
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MaxNode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<MaxNode>();
-  if (auto const_res = TryConstFold<Max>(op->a, op->b)) return const_res.value();
+  if (auto const_res = TryConstFold<Max>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
 
   // Pattern var to match any expression
   PVar<PrimExpr> x, y, z, s1, s2;
@@ -1672,9 +1767,15 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const EQNode* op) {
   op = ret.get();
 
   if (auto const_res = TryConstFold<EQ>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
     return const_res.value();
   }
   if (auto match = TryMatchLiteralConstraint(ret)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
     return match.value();
   }
 
@@ -1727,8 +1828,18 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const NENode* op) {
   PrimExpr ret = IRMutatorWithAnalyzer::VisitExpr_(op);
   op = ret.as<NENode>();
 
-  if (auto const_res = TryConstFold<NE>(op->a, op->b)) return const_res.value();
-  if (auto match = TryMatchLiteralConstraint(ret)) return match.value();
+  if (auto const_res = TryConstFold<NE>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
+  if (auto match = TryMatchLiteralConstraint(ret)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return match.value();
+  }
 
   if (IsIndexType(op->a.dtype())) {
     CompareResult result = TryCompare(op->a, op->b);
@@ -1764,8 +1875,18 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const LENode* op) {
   op = ret.as<LENode>();
   ICHECK(op);
 
-  if (auto const_res = TryConstFold<LE>(op->a, op->b)) return const_res.value();
-  if (auto match = TryMatchLiteralConstraint(ret)) return match.value();
+  if (auto const_res = TryConstFold<LE>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
+  if (auto match = TryMatchLiteralConstraint(ret)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return match.value();
+  }
 
   // Check for applicable rewrites before attempting to prove/disprove
   // the inequality.  This preserves earlier behavior, where (A<=B*x)
@@ -1815,8 +1936,18 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const LTNode* op) {
   LT node = Downcast<LT>(IRMutatorWithAnalyzer::VisitExpr_(op));
   op = node.get();
 
-  if (auto const_res = TryConstFold<LT>(op->a, op->b)) return const_res.value();
-  if (auto match = TryMatchLiteralConstraint(node)) return match.value();
+  if (auto const_res = TryConstFold<LT>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << node << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
+  if (auto match = TryMatchLiteralConstraint(node)) {
+    std::cout << "\t\t"
+              << "Rewriting " << node << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return match.value();
+  }
 
   return ApplyRewriteRules(node);
 }
@@ -1986,8 +2117,18 @@ PrimExpr RewriteSimplifier::Impl::ApplyRewriteRules(LT ret) {
 
 PrimExpr RewriteSimplifier::Impl::VisitExpr_(const NotNode* op) {
   Not ret = Downcast<Not>(IRMutatorWithAnalyzer::VisitExpr_(op));
-  if (auto const_res = TryConstFold<Not>(ret->a)) return const_res.value();
-  if (auto match = TryMatchLiteralConstraint(ret)) return match.value();
+  if (auto const_res = TryConstFold<Not>(ret->a)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
+  if (auto match = TryMatchLiteralConstraint(ret)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return match.value();
+  }
 
   return ApplyRewriteRules(ret);
 }
@@ -2059,8 +2200,18 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const AndNode* op) {
 
   op = ret.as<AndNode>();
 
-  if (auto const_res = TryConstFold<And>(op->a, op->b)) return const_res.value();
-  if (auto match = TryMatchLiteralConstraint(ret)) return match.value();
+  if (auto const_res = TryConstFold<And>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
+  if (auto match = TryMatchLiteralConstraint(ret)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return match.value();
+  }
   if ((enabled_extensions_ & RewriteSimplifier::kConvertBooleanToAndOfOrs) &&
       !recursively_visiting_boolean_) {
     return SimplifyAsAndOfOrs(ret, analyzer_);
@@ -2207,8 +2358,18 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const OrNode* op) {
   }();
 
   op = ret.as<OrNode>();
-  if (auto const_res = TryConstFold<Or>(op->a, op->b)) return const_res.value();
-  if (auto match = TryMatchLiteralConstraint(ret)) return match.value();
+  if (auto const_res = TryConstFold<Or>(op->a, op->b)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << const_res.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return const_res.value();
+  }
+  if (auto match = TryMatchLiteralConstraint(ret)) {
+    std::cout << "\t\t"
+              << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+              << __LINE__ << std::endl;
+    return match.value();
+  }
   if ((enabled_extensions_ & RewriteSimplifier::kConvertBooleanToAndOfOrs) &&
       !recursively_visiting_boolean_) {
     return SimplifyAsAndOfOrs(ret, analyzer_);
@@ -2329,6 +2490,9 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const CallNode* op) {
   if (op->op.same_as(tir::builtin::likely())) {
     // Cases such as for (i, 0, bound) {if (likely(iter_var < bound)) { .. } }
     if (auto match = TryMatchLiteralConstraint(op->args[0])) {
+      std::cout << "\t\t"
+                << "Rewriting " << ret << " to " << match.value() << " using rule on line "
+                << __LINE__ << std::endl;
       return match.value();
     }
   }
@@ -2360,12 +2524,18 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const VarNode* op) {
   Var var = GetRef<Var>(op);
   if (op->dtype == DataType::Bool()) {
     if (auto match = TryMatchLiteralConstraint(var)) {
+      std::cout << "\t\t"
+                << "Rewriting " << var << " to " << match.value() << " using rule on line "
+                << __LINE__ << std::endl;
       return match.value();
     }
   }
 
   auto it = var_map_.find(var);
   if (it != var_map_.end()) {
+    std::cout << "\t\t"
+              << "Rewriting " << var << " to " << it->second << " using rule on line " << __LINE__
+              << std::endl;
     return it->second;
   }
   return GetRef<PrimExpr>(op);

--- a/src/tir/transforms/remove_no_op.cc
+++ b/src/tir/transforms/remove_no_op.cc
@@ -29,7 +29,6 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
-#include <cstdlib>
 #include <optional>
 #include <unordered_map>
 

--- a/src/tir/transforms/remove_no_op.cc
+++ b/src/tir/transforms/remove_no_op.cc
@@ -29,6 +29,7 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <cstdlib>
 #include <optional>
 #include <unordered_map>
 

--- a/tests/python/topi/test_topi_image.py
+++ b/tests/python/topi/test_topi_image.py
@@ -15,100 +15,106 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test code for bilinear scale """
+
 import numpy as np
+import pytest
+
 import tvm
-from tvm import te
-from tvm import topi
 import tvm.testing
 import tvm.topi.testing
+
+from tvm import te, topi
 from tvm.contrib.pickle_memoize import memoize
 
+layout_2d = tvm.testing.parameter("NCHW", "NHWC")
+layout_3d = tvm.testing.parameter("NCDHW", "NDHWC")
+coordinate_transformation_mode = tvm.testing.parameter("asymmetric", "align_corners", "half_pixel")
+interpolation_method = tvm.testing.parameter("nearest_neighbor", "linear")
 
-def verify_resize2d(
-    batch,
-    in_channel,
-    in_height,
-    in_width,
-    out_height,
-    out_width,
-    layout="NCHW",
-    coord_trans="align_corners",
-    method="linear",
+resize_2d_test_case = tvm.testing.parameter(
+    dict(sizes=(4, 16, 32, 32, 50, 50), coord_trans="align_corners", method="linear"),
+    dict(sizes=(6, 32, 64, 64, 20, 20), coord_trans="align_corners", method="linear"),
+    dict(sizes=(4, 16, 32, 32, 50, 50), coord_trans="asymmetric", method="nearest_neighbor"),
+    dict(sizes=(4, 16, 32, 32, 64, 50), coord_trans="asymmetric", method="nearest_neighbor"),
+    dict(sizes=(4, 16, 32, 32, 50, 96), coord_trans="asymmetric", method="nearest_neighbor"),
+    dict(sizes=(4, 16, 32, 32, 96, 96), coord_trans="asymmetric", method="nearest_neighbor"),
+    dict(sizes=(4, 16, 32, 32, 50, 50), coord_trans="align_corners", method="nearest_neighbor"),
+    dict(sizes=(4, 16, 32, 32, 50, 50), coord_trans="half_pixel", method="nearest_neighbor"),
+    dict(sizes=(4, 16, 32, 32, 50, 50), coord_trans="asymmetric", method="linear"),
+    dict(sizes=(4, 16, 32, 32, 50, 50), coord_trans="half_pixel", method="linear"),
+)
+
+
+def test_resize2d(
+    target,
+    dev,
+    resize_2d_test_case,
+    layout_2d,
 ):
-    if layout == "NCHW":
+    (batch, in_channel, in_height, in_width, out_height, out_width) = resize_2d_test_case["sizes"]
+    coordinate_transformation_mode = resize_2d_test_case["coord_trans"]
+    interpolation_method = resize_2d_test_case["method"]
+
+    if layout_2d == "NCHW":
         A = te.placeholder((batch, in_channel, in_height, in_width), name="A", dtype="float32")
         dtype = A.dtype
         out_shape = (batch, in_channel, out_height, out_width)
         a_np = np.random.uniform(size=(batch, in_channel, in_height, in_width)).astype(dtype)
-    elif layout == "NHWC":
+    elif layout_2d == "NHWC":
         A = te.placeholder((batch, in_height, in_width, in_channel), name="A", dtype="float32")
         dtype = A.dtype
         out_shape = (batch, out_height, out_width, in_channel)
         a_np = np.random.uniform(size=(batch, in_height, in_width, in_channel)).astype(dtype)
     else:
-        raise NotImplementedError("Layout not supported {} ".format(layout))
+        raise NotImplementedError("Layout not supported {} ".format(layout_2d))
+
     B = topi.image.resize2d(
         A,
         [0.0] * 4,
         (out_height, out_width),
-        layout=layout,
-        coordinate_transformation_mode=coord_trans,
-        method=method,
+        layout=layout_2d,
+        coordinate_transformation_mode=coordinate_transformation_mode,
+        method=interpolation_method,
     )
     scale_h = out_height / in_height
     scale_w = out_width / in_width
-    b_np = tvm.topi.testing.resize2d_python(a_np, (scale_h, scale_w), layout, method, coord_trans)
+    b_np = tvm.topi.testing.resize2d_python(
+        a_np, (scale_h, scale_w), layout_2d, interpolation_method, coordinate_transformation_mode
+    )
 
-    def check_target(target, dev):
-        print("Running on target: %s" % target)
-        with tvm.target.Target(target):
-            s = tvm.topi.testing.get_injective_schedule(target)(B)
-        a = tvm.nd.array(a_np, dev)
-        b = tvm.nd.array(np.zeros(out_shape, dtype=dtype), dev)
-        f = tvm.build(s, [A, B], target)
-        f(a, b)
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(B)
+    a = tvm.nd.array(a_np, dev)
+    b = tvm.nd.array(np.zeros(out_shape, dtype=dtype), dev)
+    f = tvm.build(s, [A, B], target)
+    f(a, b)
 
-        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-3, atol=1e-3)
-
-    for target, dev in tvm.testing.enabled_targets():
-        check_target(target, dev)
+    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-3, atol=1e-3)
 
 
-@tvm.testing.uses_gpu
-def test_resize2d():
-    # Scale NCHW
-    verify_resize2d(4, 16, 32, 32, 50, 50, "NCHW")
-    # Scale NCHW + Align Corners
-    verify_resize2d(6, 32, 64, 64, 20, 20, "NCHW")
-    # Scale NHWC
-    verify_resize2d(4, 16, 32, 32, 50, 50, "NHWC")
-    # Scale NHWC + Align Corners
-    verify_resize2d(6, 32, 64, 64, 20, 20, "NHWC")
-    for layout in ["NCHW", "NHWC"]:
-        verify_resize2d(4, 16, 32, 32, 50, 50, layout, "asymmetric", method="nearest_neighbor")
-        verify_resize2d(4, 16, 32, 32, 64, 50, layout, "asymmetric", method="nearest_neighbor")
-        verify_resize2d(4, 16, 32, 32, 50, 96, layout, "asymmetric", method="nearest_neighbor")
-        verify_resize2d(4, 16, 32, 32, 96, 96, layout, "asymmetric", method="nearest_neighbor")
-        verify_resize2d(4, 16, 32, 32, 50, 50, layout, "align_corners", method="nearest_neighbor")
-        verify_resize2d(4, 16, 32, 32, 50, 50, layout, "half_pixel", method="nearest_neighbor")
-        verify_resize2d(4, 16, 32, 32, 50, 50, layout, "asymmetric", method="linear")
-        verify_resize2d(4, 16, 32, 32, 50, 50, layout, "half_pixel", method="linear")
+resize_3d_test_case = tvm.testing.parameter((3, 16, 32, 32, 32, 10, 10, 10))
 
 
-def verify_resize3d(
-    batch,
-    in_channel,
-    in_depth,
-    in_height,
-    in_width,
-    out_depth,
-    out_height,
-    out_width,
-    layout="NCDHW",
-    coordinate_transformation_mode="asymmetric",
-    method="linear",
+def test_resize3d(
+    target,
+    dev,
+    resize_3d_test_case,
+    layout_3d,
+    coordinate_transformation_mode,
+    interpolation_method,
 ):
-    if layout == "NCDHW":
+    (
+        batch,
+        in_channel,
+        in_depth,
+        in_height,
+        in_width,
+        out_depth,
+        out_height,
+        out_width,
+    ) = resize_3d_test_case
+
+    if layout_3d == "NCDHW":
         A = te.placeholder(
             (batch, in_channel, in_depth, in_height, in_width), name="A", dtype="float32"
         )
@@ -117,7 +123,7 @@ def verify_resize3d(
         a_np = np.random.uniform(size=(batch, in_channel, in_depth, in_height, in_width)).astype(
             dtype
         )
-    elif layout == "NDHWC":
+    elif layout_3d == "NDHWC":
         A = te.placeholder(
             (batch, in_depth, in_height, in_width, in_channel), name="A", dtype="float32"
         )
@@ -127,224 +133,187 @@ def verify_resize3d(
             dtype
         )
     else:
-        raise NotImplementedError("Layout not supported {} ".format(layout))
+        raise NotImplementedError("Layout not supported {} ".format(layout_3d))
 
     B = topi.image.resize3d(
         A,
         [0.0] * 6,
         (out_depth, out_height, out_width),
-        layout=layout,
+        layout=layout_3d,
         coordinate_transformation_mode=coordinate_transformation_mode,
-        method=method,
+        method=interpolation_method,
     )
 
     scale_d = out_depth / in_depth
     scale_h = out_height / in_height
     scale_w = out_width / in_width
     b_np = tvm.topi.testing.resize3d_python(
-        a_np, (scale_d, scale_h, scale_w), layout, method, coordinate_transformation_mode
+        a_np,
+        (scale_d, scale_h, scale_w),
+        layout_3d,
+        interpolation_method,
+        coordinate_transformation_mode,
     )
 
-    def check_target(target, dev):
-        with tvm.target.Target(target):
-            s = tvm.topi.testing.get_injective_schedule(target)(B)
-        a = tvm.nd.array(a_np, dev)
-        b = tvm.nd.array(np.zeros(out_shape, dtype=dtype), dev)
-        f = tvm.build(s, [A, B], target)
-        f(a, b)
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(B)
+    a = tvm.nd.array(a_np, dev)
+    b = tvm.nd.array(np.zeros(out_shape, dtype=dtype), dev)
+    f = tvm.build(s, [A, B], target)
+    f(a, b)
 
-        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-3, atol=1e-3)
+    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-3, atol=1e-3)
 
-    for target, dev in tvm.testing.enabled_targets():
-        check_target(target, dev)
+
+box_set_1 = dict(
+    boxes=np.array([[0.2, 0.3, 0.7, 0.9]], dtype="float32"),
+    indices=np.array([0], dtype="int32"),
+    crop_size=(7, 11),
+)
+box_set_2 = dict(
+    boxes=np.array([[0.2, 0.3, 0.7, 0.9], [0, 0.1, 0.8, 1]], dtype="float32"),
+    indices=np.array([1, 0], dtype="int32"),
+    crop_size=(90, 60),
+)
+crop_and_resize_test_case = tvm.testing.parameter(
+    dict(image_shape=(1, 255, 255, 3), **box_set_1),
+    dict(image_shape=(1, 100, 100, 3), **box_set_1, method="nearest_neighbor"),
+    dict(image_shape=(1, 3, 224, 224), **box_set_1, layout="NCHW"),
+    dict(image_shape=(10, 224, 224, 5), **box_set_2, extrapolation_value=0.3),
+)
 
 
 @tvm.testing.uses_gpu
-def test_resize3d():
-    # Trilinear
-    for method in ["nearest_neighbor", "linear"]:
-        for coord_trans in ["asymmetric", "align_corners", "half_pixel"]:
-            for layout in ["NCDHW", "NDHWC"]:
-                verify_resize3d(3, 16, 32, 32, 32, 10, 10, 10, layout, coord_trans, method)
+def test_crop_and_resize(target, dev, crop_and_resize_test_case):
+    image_shape = crop_and_resize_test_case["image_shape"]
+    np_boxes = crop_and_resize_test_case["boxes"]
+    np_box_indices = crop_and_resize_test_case["indices"]
+    np_crop_size = crop_and_resize_test_case["crop_size"]
+    method = crop_and_resize_test_case.get("method", "bilinear")
+    extrapolation_value = crop_and_resize_test_case.get("extrapolation_value", 0.0)
+    layout = crop_and_resize_test_case.get("layout", "NHWC")
 
+    images = te.placeholder(image_shape, name="images", dtype="float32")
+    np_images = np.random.uniform(size=image_shape).astype("float32")
+    boxes = te.placeholder(np_boxes.shape, name="boxes", dtype="float32")
+    box_ind = te.placeholder(np_box_indices.shape, name="box_ind", dtype="int32")
 
-@tvm.testing.uses_gpu
-def test_crop_and_resize():
-    def verify_crop_and_resize(
-        image_shape,
-        np_boxes,
-        np_box_indices,
+    batch = len(np_box_indices)
+    target_height, target_width = np_crop_size[0], np_crop_size[1]
+    if layout == "NHWC":
+        channel = image_shape[3]
+        out_shape = (batch, target_height, target_width, channel)
+    elif layout == "NCHW":
+        channel = image_shape[1]
+        out_shape = (batch, channel, target_height, target_width)
+    else:
+        raise NotImplementedError("Layout {} is not supported.".format(layout))
+
+    out = topi.image.crop_and_resize(
+        images,
+        boxes,
+        box_ind,
         np_crop_size,
-        layout="NHWC",
-        method="bilinear",
-        extrapolation_value=0.0,
-    ):
-
-        images = te.placeholder(image_shape, name="images", dtype="float32")
-        np_images = np.random.uniform(size=image_shape).astype("float32")
-        boxes = te.placeholder(np_boxes.shape, name="boxes", dtype="float32")
-        box_ind = te.placeholder(np_box_indices.shape, name="box_ind", dtype="int32")
-
-        batch = len(np_box_indices)
-        target_height, target_width = np_crop_size[0], np_crop_size[1]
-        if layout == "NHWC":
-            channel = image_shape[3]
-            out_shape = (batch, target_height, target_width, channel)
-        elif layout == "NCHW":
-            channel = image_shape[1]
-            out_shape = (batch, channel, target_height, target_width)
-        else:
-            raise NotImplementedError("Layout {} is not supported.".format(layout))
-
-        out = topi.image.crop_and_resize(
-            images,
-            boxes,
-            box_ind,
-            np_crop_size,
-            layout=layout,
-            method=method,
-            extrapolation_value=extrapolation_value,
-        )
-
-        baseline_np = tvm.topi.testing.crop_and_resize_python(
-            np_images, np_boxes, np_box_indices, np_crop_size, layout, method, extrapolation_value
-        )
-
-        def check_target(target, dev):
-            print("Running on target: %s" % target)
-            with tvm.target.Target(target):
-                s = tvm.topi.testing.get_injective_schedule(target)(out)
-            tvm_images = tvm.nd.array(np_images, dev)
-            tvm_boxes = tvm.nd.array(np_boxes, dev)
-            tvm_indices = tvm.nd.array(np_box_indices, dev)
-            tvm_out = tvm.nd.array(np.zeros(out_shape, dtype="float32"), dev)
-            f = tvm.build(s, [images, boxes, box_ind, out], target, name="crop_and_resize")
-            f(tvm_images, tvm_boxes, tvm_indices, tvm_out)
-
-            tvm.testing.assert_allclose(tvm_out.numpy(), baseline_np, rtol=1e-3, atol=1e-3)
-
-        for target, dev in tvm.testing.enabled_targets():
-            check_target(target, dev)
-
-    boxes_1 = np.array([[0.2, 0.3, 0.7, 0.9]], dtype="float32")
-    boxes_2 = np.array([[0.2, 0.3, 0.7, 0.9], [0, 0.1, 0.8, 1]], dtype="float32")
-    indices_1 = np.array([0], dtype="int32")
-    indices_2 = np.array([1, 0], dtype="int32")
-    size_1 = (7, 11)
-    size_2 = (90, 60)
-
-    verify_crop_and_resize((1, 255, 255, 3), boxes_1, indices_1, size_1, layout="NHWC")
-    verify_crop_and_resize(
-        (10, 224, 224, 5), boxes_2, indices_2, size_2, extrapolation_value=0.3, layout="NHWC"
+        layout=layout,
+        method=method,
+        extrapolation_value=extrapolation_value,
     )
-    verify_crop_and_resize((1, 100, 100, 3), boxes_1, indices_1, size_1, method="nearest_neighbor")
-    verify_crop_and_resize((1, 3, 224, 224), boxes_1, indices_1, size_1, layout="NCHW")
+
+    baseline_np = tvm.topi.testing.crop_and_resize_python(
+        np_images, np_boxes, np_box_indices, np_crop_size, layout, method, extrapolation_value
+    )
+
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(out)
+    tvm_images = tvm.nd.array(np_images, dev)
+    tvm_boxes = tvm.nd.array(np_boxes, dev)
+    tvm_indices = tvm.nd.array(np_box_indices, dev)
+    tvm_out = tvm.nd.array(np.zeros(out_shape, dtype="float32"), dev)
+    f = tvm.build(s, [images, boxes, box_ind, out], target, name="crop_and_resize")
+    f(tvm_images, tvm_boxes, tvm_indices, tvm_out)
+
+    tvm.testing.assert_allclose(tvm_out.numpy(), baseline_np, rtol=1e-3, atol=1e-3)
 
 
-@tvm.testing.uses_gpu
-def test_affine_grid():
-    def verify_affine_grid(num_batch, target_shape):
-        dtype = "float32"
-        data_shape = (num_batch, 2, 3)
-        data = te.placeholder(data_shape, dtype=dtype)
-        out = topi.image.affine_grid(data, target_shape)
-
-        @memoize("topi.tests.test_affine_grid.verify_affine_grid")
-        def get_ref_data():
-            data_np = np.random.uniform(size=data_shape).astype(dtype)
-            out_np = tvm.topi.testing.affine_grid_python(data_np, target_shape)
-            return data_np, out_np
-
-        data_np, out_np = get_ref_data()
-
-        def check_target(target, dev):
-            print("Running on target: %s" % target)
-            with tvm.target.Target(target):
-                s = tvm.topi.testing.get_injective_schedule(target)(out)
-            tvm_data = tvm.nd.array(data_np, dev)
-            tvm_out = tvm.nd.empty(out_np.shape, dtype, dev)
-            f = tvm.build(s, [data, out], target)
-            f(tvm_data, tvm_out)
-
-            tvm.testing.assert_allclose(tvm_out.numpy(), out_np, rtol=1e-5, atol=1e-5)
-
-        for target, dev in tvm.testing.enabled_targets():
-            check_target(target, dev)
-
-    verify_affine_grid(1, (16, 32))
-    verify_affine_grid(4, (16, 32))
+affine_grid_test_case = tvm.testing.parameter(
+    (1, (16, 32)),
+    (4, (16, 32)),
+)
 
 
-@tvm.testing.uses_gpu
-def test_grid_sample():
-    def verify_grid_sample(
-        data_shape,
-        grid_shape,
-        method="bilinear",
-        layout="NCHW",
-        padding_mode="zeros",
-        align_corners=True,
-    ):
-        dtype = "float32"
-        data = te.placeholder(data_shape, dtype=dtype)
-        grid = te.placeholder(grid_shape, dtype=dtype)
-        out = topi.image.grid_sample(data, grid, method, layout, padding_mode, align_corners)
+def test_affine_grid(target, dev, affine_grid_test_case):
+    num_batch, target_shape = affine_grid_test_case
 
-        @memoize("topi.tests.test_grid_sample.verify_grid_sample")
-        def get_ref_data():
-            data_np = np.random.uniform(size=data_shape).astype(dtype)
-            # allow grid values to be out-of-bound
-            grid_np = np.random.uniform(size=grid_shape, low=-1.5, high=1.5).astype(dtype)
-            out_np = tvm.topi.testing.grid_sample_python(
-                data_np, grid_np, method, layout, padding_mode, align_corners
-            )
-            return data_np, grid_np, out_np
+    dtype = "float32"
+    data_shape = (num_batch, 2, 3)
+    data = te.placeholder(data_shape, dtype=dtype)
+    out = topi.image.affine_grid(data, target_shape)
 
-        data_np, grid_np, out_np = get_ref_data()
+    @memoize("topi.tests.test_affine_grid.verify_affine_grid")
+    def get_ref_data():
+        data_np = np.random.uniform(size=data_shape).astype(dtype)
+        out_np = tvm.topi.testing.affine_grid_python(data_np, target_shape)
+        return data_np, out_np
 
-        def check_target(target, dev):
-            print("Running on target: %s" % target)
-            with tvm.target.Target(target):
-                s = tvm.topi.testing.get_injective_schedule(target)(out)
-            tvm_data = tvm.nd.array(data_np, dev)
-            tvm_grid = tvm.nd.array(grid_np, dev)
-            tvm_out = tvm.nd.empty(out_np.shape, dtype, dev)
-            f = tvm.build(s, [data, grid, out], target)
-            f(tvm_data, tvm_grid, tvm_out)
+    data_np, out_np = get_ref_data()
 
-            tvm.testing.assert_allclose(tvm_out.numpy(), out_np, rtol=1e-5, atol=1e-5)
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(out)
+    tvm_data = tvm.nd.array(data_np, dev)
+    tvm_out = tvm.nd.empty(out_np.shape, dtype, dev)
+    f = tvm.build(s, [data, out], target)
+    f(tvm_data, tvm_out)
 
-        for target, dev in tvm.testing.enabled_targets():
-            check_target(target, dev)
+    tvm.testing.assert_allclose(tvm_out.numpy(), out_np, rtol=1e-5, atol=1e-5)
 
-    methods = ["nearest", "bilinear", "bicubic"]
-    padding_modes = ["zeros", "border", "reflection"]
-    align_corners = [True, False]
-    data_2D_shape = (4, 4, 8, 8)
-    grid_2D_shape = (4, 2, 16, 16)
-    layout_2D = "NCHW"
-    # choosing smaller sizes to be testable on weaker GPUs
-    data_3D_shape = (4, 4, 4, 4, 4)
-    grid_3D_shape = (4, 3, 8, 8, 8)
-    layout_3D = "NCDHW"
 
-    for _method in methods:
-        for _padding in padding_modes:
-            for _align in align_corners:
-                verify_grid_sample(
-                    data_2D_shape, grid_2D_shape, _method, layout_2D, _padding, _align
-                )
+@pytest.mark.parametrize("method", ["nearest", "bilinear", "bicubic"])
+@pytest.mark.parametrize("padding_mode", ["zeros", "border", "reflection"])
+@pytest.mark.parametrize("align_corners", [True, False])
+@pytest.mark.parametrize("dimension", ["2d", "3d"])
+def test_grid_sample(target, dev, method, padding_mode, align_corners, dimension):
+    if dimension == "3d" and method == "bicubic":
+        pytest.skip('3D "bicubic"(tricubic) is not supported in pytorch')
 
-                # 3D "bicubic"(tricubic) is not supported in pytorch
-                if _method != "bicubic":
-                    verify_grid_sample(
-                        data_3D_shape, grid_3D_shape, _method, layout_3D, _padding, _align
-                    )
+    if dimension == "2d":
+        data_shape = (4, 4, 8, 8)
+        grid_shape = (4, 2, 16, 16)
+        layout = "NCHW"
+    elif dimension == "3d":
+        # choosing smaller sizes to be testable on weaker GPUs
+        data_shape = (4, 4, 4, 4, 4)
+        grid_shape = (4, 3, 8, 8, 8)
+        layout = "NCDHW"
+    else:
+        raise ValueError(f"Unknown dimension: {dimension}")
+
+    dtype = "float32"
+    data = te.placeholder(data_shape, dtype=dtype)
+    grid = te.placeholder(grid_shape, dtype=dtype)
+    out = topi.image.grid_sample(data, grid, method, layout, padding_mode, align_corners)
+
+    @memoize("topi.tests.test_grid_sample.verify_grid_sample")
+    def get_ref_data():
+        data_np = np.random.uniform(size=data_shape).astype(dtype)
+        # allow grid values to be out-of-bound
+        grid_np = np.random.uniform(size=grid_shape, low=-1.5, high=1.5).astype(dtype)
+        out_np = tvm.topi.testing.grid_sample_python(
+            data_np, grid_np, method, layout, padding_mode, align_corners
+        )
+        return data_np, grid_np, out_np
+
+    data_np, grid_np, out_np = get_ref_data()
+
+    with tvm.target.Target(target):
+        s = tvm.topi.testing.get_injective_schedule(target)(out)
+    tvm_data = tvm.nd.array(data_np, dev)
+    tvm_grid = tvm.nd.array(grid_np, dev)
+    tvm_out = tvm.nd.empty(out_np.shape, dtype, dev)
+    f = tvm.build(s, [data, grid, out], target)
+    f(tvm_data, tvm_grid, tvm_out)
+
+    tvm.testing.assert_allclose(tvm_out.numpy(), out_np, rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":
-    test_resize2d()
-    test_resize3d()
-    test_crop_and_resize()
-    test_affine_grid()
-    test_grid_sample()
+    tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, floating point expressions were used to map between different-sized pixel arrays.  These floating point expressions are less aggressively optimized by `RewriteSimplifier`, which can prevent some optimizations

This was first noticed during investigation into issue #13508. Benchmarks of `topi.image.resize` showed 1000x and 50x performance improvements using the LLVM and CUDA backends, respectively, by using integer expressions instead of floating point.  This performance improvement is partly driven by enabling
`tir.transform.VectorizeLoops` to recognize vectorizable indices, where the round-trip through floating point previously prevented that optimization.