### PR TITLE
[MetaSchedule] Make `MultiLevelTiling` apply condition customizable

### DIFF
--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -155,7 +155,8 @@ class ScheduleRule : public runtime::ObjectRef {
                                                Optional<Integer> max_innermost_factor,       //
                                                Optional<Array<Integer>> vector_load_lens,    //
                                                Optional<Map<String, ObjectRef>> reuse_read,  //
-                                               Optional<Map<String, ObjectRef>> reuse_write);
+                                               Optional<Map<String, ObjectRef>> reuse_write,
+					       Optional<runtime::PackedFunc> filter_fn=NullOpt);
 
   /*!
    * \brief Extension of MultiLevelTiling for auto-tensorization with a single intrinsic.

--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -148,6 +148,10 @@ class ScheduleRule : public runtime::ObjectRef {
    * NullOpt means disable vectorization
    * \param reuse_read Data reuse configuration for reading. NullOpt means no reuse.
    * \param reuse_write Data reuse configuration for writing. NullOpt means no reuse.
+   * \param filter_fn A function that can be passed to overwrite the default condition for applying
+   * MultiLevelTiling to a block. Its signature must be (Schedule, BlockRV) -> bool.
+   * This is useful if there is a need to apply MultiLevelTiling to an operation / block which is
+   * ignored  by default. This function should return True for a block that should be tiled.
    * \return The schedule rule created
    */
   TVM_DLL static ScheduleRule MultiLevelTiling(String structure,                             //
@@ -156,7 +160,7 @@ class ScheduleRule : public runtime::ObjectRef {
                                                Optional<Array<Integer>> vector_load_lens,    //
                                                Optional<Map<String, ObjectRef>> reuse_read,  //
                                                Optional<Map<String, ObjectRef>> reuse_write,
-					       Optional<runtime::PackedFunc> filter_fn=NullOpt);
+                                               Optional<runtime::PackedFunc> filter_fn = NullOpt);
 
   /*!
    * \brief Extension of MultiLevelTiling for auto-tensorization with a single intrinsic.

--- a/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
+++ b/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """Multi-level tiling with reuse."""
-from typing import Any, Dict, List, Mapping, NamedTuple, Optional
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Callable
 
+from tvm.tir.schedule import Schedule, BlockRV
 from tvm._ffi import register_object
 
 from .. import _ffi_api
@@ -62,6 +63,11 @@ class MultiLevelTiling(ScheduleRule):
         Data reuse configuration for reading. None means no reuse.
     reuse_write : Optional[ReuseType]
         Data reuse configuration for writing. None means no reuse.
+    filter_fn: Optional[Callable[[Schedule, BlockRV], bool]]
+        A function that can be passed to overwrite the default condition for applying
+        MultiLevelTiling to a block. This is useful if there is a need to apply MultiLevelTiling
+        to an operation / block which is ignored by default. This function should return True
+        for a block that should be tiled (based on the block name, for example).
     """
 
     def __init__(
@@ -72,7 +78,7 @@ class MultiLevelTiling(ScheduleRule):
         vector_load_lens: Optional[List[int]] = None,
         reuse_read: Optional[ReuseType] = None,
         reuse_write: Optional[ReuseType] = None,
-        filter_fn=None,
+        filter_fn: Optional[Callable[[Schedule, BlockRV], bool]] = None,
     ) -> None:
         self.__init_handle_by_constructor__(
             _ffi_api.ScheduleRuleMultiLevelTiling,  # type: ignore # pylint: disable=no-member

--- a/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
+++ b/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
@@ -72,6 +72,7 @@ class MultiLevelTiling(ScheduleRule):
         vector_load_lens: Optional[List[int]] = None,
         reuse_read: Optional[ReuseType] = None,
         reuse_write: Optional[ReuseType] = None,
+        filter_fn = None,
     ) -> None:
         self.__init_handle_by_constructor__(
             _ffi_api.ScheduleRuleMultiLevelTiling,  # type: ignore # pylint: disable=no-member
@@ -81,6 +82,7 @@ class MultiLevelTiling(ScheduleRule):
             vector_load_lens,
             reuse_read.as_dict() if reuse_read is not None else None,
             reuse_write.as_dict() if reuse_write is not None else None,
+            filter_fn,
         )
 
 

--- a/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
+++ b/python/tvm/meta_schedule/schedule_rule/multi_level_tiling.py
@@ -72,7 +72,7 @@ class MultiLevelTiling(ScheduleRule):
         vector_load_lens: Optional[List[int]] = None,
         reuse_read: Optional[ReuseType] = None,
         reuse_write: Optional[ReuseType] = None,
-        filter_fn = None,
+        filter_fn=None,
     ) -> None:
         self.__init_handle_by_constructor__(
             _ffi_api.ScheduleRuleMultiLevelTiling,  # type: ignore # pylint: disable=no-member

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -322,7 +322,7 @@ ScheduleRule ScheduleRule::MultiLevelTiling(String structure, Optional<Array<Str
                                             Optional<Array<Integer>> vector_load_lens,
                                             Optional<Map<String, ObjectRef>> reuse_read,
                                             Optional<Map<String, ObjectRef>> reuse_write,
-					    Optional<runtime::PackedFunc> filter_fn) {
+                                            Optional<runtime::PackedFunc> filter_fn) {
   auto node = MultiLevelTilingInitCommon<MultiLevelTilingNode>(
       structure, tile_binds, max_innermost_factor, vector_load_lens, reuse_read, reuse_write);
   node->filter_fn_ = filter_fn;

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -92,16 +92,17 @@ void MultiLevelTilingNode::InitializeWithTuneContext(const TuneContext& context)
 
 // Entry of the mega rule; Inherited from ScheduleRuleNode
 Array<Schedule> MultiLevelTilingNode::Apply(const Schedule& sch, const BlockRV& block_rv) {
-  if (!NeedsMultiLevelTiling(sch->state(), sch->GetSRef(block_rv))) {
-    return {sch};
-  }
-  sch->Annotate(block_rv, tir::attr::meta_schedule_tiling_structure, structure);
+  if ((filter_fn_ && filter_fn_.value()(sch, sch->GetSRef(block_rv))) ||
+      NeedsMultiLevelTiling(sch->state(), sch->GetSRef(block_rv))) {
+    sch->Annotate(block_rv, tir::attr::meta_schedule_tiling_structure, structure);
 
-  Array<Schedule> results;
-  for (auto&& state : ApplySubRules({State(sch, block_rv)})) {
-    results.push_back(std::move(state->sch));
+    Array<Schedule> results;
+    for (auto&& state : ApplySubRules({State(sch, block_rv)})) {
+      results.push_back(std::move(state->sch));
+    }
+    return results;
   }
-  return results;
+  return {sch};
 }
 
 // Inherited from ScheduleRuleNode
@@ -320,9 +321,11 @@ ScheduleRule ScheduleRule::MultiLevelTiling(String structure, Optional<Array<Str
                                             Optional<Integer> max_innermost_factor,
                                             Optional<Array<Integer>> vector_load_lens,
                                             Optional<Map<String, ObjectRef>> reuse_read,
-                                            Optional<Map<String, ObjectRef>> reuse_write) {
+                                            Optional<Map<String, ObjectRef>> reuse_write,
+					    Optional<runtime::PackedFunc> filter_fn) {
   auto node = MultiLevelTilingInitCommon<MultiLevelTilingNode>(
       structure, tile_binds, max_innermost_factor, vector_load_lens, reuse_read, reuse_write);
+  node->filter_fn_ = filter_fn;
   return ScheduleRule(node);
 }
 

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.h
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.h
@@ -194,6 +194,8 @@ class MultiLevelTilingNode : public ScheduleRuleNode {
   int max_threads_per_block_;
   /*! \brief The logging function */
   PackedFunc logger;
+  /*! \brief TODO */
+  Optional<PackedFunc> filter_fn_;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("structure", &structure);

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.h
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.h
@@ -194,7 +194,7 @@ class MultiLevelTilingNode : public ScheduleRuleNode {
   int max_threads_per_block_;
   /*! \brief The logging function */
   PackedFunc logger;
-  /*! \brief TODO */
+  /*! \brief The function to overwrite the default condition for applying MultiLevelTiling. */
   Optional<PackedFunc> filter_fn_;
 
   void VisitAttrs(tvm::AttrVisitor* v) {

--- a/tests/python/contrib/test_hexagon/test_meta_schedule.py
+++ b/tests/python/contrib/test_hexagon/test_meta_schedule.py
@@ -35,12 +35,8 @@ from tvm.meta_schedule.runner import RunnerInput
 from tvm.script import tir as T
 from tvm.tir import FloatImm
 from tvm.tir.tensor_intrin.hexagon import VRMPY_u8u8i32_INTRIN
-from tvm.meta_schedule.testing.space_generation import (
-    generate_design_space,
-)
-from tvm.target import Target
 
-# from .infrastructure import get_hexagon_target
+from .infrastructure import get_hexagon_target
 
 MATMUL_N = 16
 MATMUL_M = 32
@@ -500,71 +496,5 @@ def test_dense_relay_auto_schedule(hexagon_launcher):
         assert np.mean(np.abs(ref - out)) < 0.1
 
 
-def max_pool_blocked_compute(height, width, channel):
-    ishape = (1, channel // 32, height // 8, width // 8, 8, 8, 32)
-    oshape = (1, channel // 32, height // 8 // 2, width // 8 // 2, 8, 8, 32)
-    X = te.placeholder(ishape, name="X", dtype="uint8")
-
-    window_h = te.reduce_axis((0, 2), name="wh")
-    window_w = te.reduce_axis((0, 2), name="ww")
-
-    out = te.compute(
-        oshape,
-        lambda b, c_o, h_o, w_o, h_i, w_i, c_i: te.max(
-            X[
-                b,
-                c_o,
-                (h_o * 8 + h_i) // 8 * 2,
-                (w_o * 8 + w_i) // 8 * 2,
-                (h_o * 8 + h_i) % 4 * 2 + window_h,
-                (w_o * 8 + w_i) % 4 * 2 + window_w,
-                c_i,
-            ],
-            axis=[window_h, window_w],
-        ),
-        name="pool",
-    )
-    return [X, out]
-
-
-def test_max_pool_blocked():
-    height = width = 64
-    channel = 64
-
-    workload = te.create_prim_func(max_pool_blocked_compute(height, width, channel))
-    mod = tvm.IRModule({"main": workload})
-
-    def filter_fn(sch, block_rv):
-        print(sch.get(block_rv).name_hint)
-        if sch.get(block_rv).name_hint == "pool":
-            return True
-        return False
-
-    tiling_rule = ms.schedule_rule.MultiLevelTiling(
-        structure="SRS",
-        tile_binds=None,
-        max_innermost_factor=64,
-        vector_load_lens=None,
-        reuse_read=ms.schedule_rule.ReuseType(
-            req="must",
-            levels=[1],
-            scope="global",
-        ),
-        reuse_write=ms.schedule_rule.ReuseType(req="must", levels=[1], scope="global"),
-        filter_fn=filter_fn
-    )
-
-    actual = generate_design_space(
-        kind="llvm",
-        mod=mod,
-        target=Target("llvm"),
-        types=None,
-        sch_rules=[tiling_rule],
-    )
-
-    print(actual[0].mod.script())
-
-
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_max_pool_blocked()
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_schedule_rule_mlt.py
+++ b/tests/python/unittest/test_meta_schedule_schedule_rule_mlt.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
+import tvm.testing
 from tvm import meta_schedule as ms
 from tvm import target, te
 from tvm.meta_schedule.testing import te_workload
@@ -646,10 +647,155 @@ def test_cache_read_specify_consumer():
     assert residual_block in space[0].mod.script()
 
 
+def test_max_pool_blocked():
+    # fmt off
+    @T.prim_func
+    def pool_blocked_cache_read_write(
+        X: T.Buffer[(1, 2, 8, 8, 8, 8, 32), "uint8"],
+        pool: T.Buffer[(1, 2, 4, 4, 8, 8, 32), "uint8"],
+    ):
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        pool_global = T.alloc_buffer([1, 2, 4, 4, 8, 8, 32], dtype="uint8")
+        X_global = T.alloc_buffer([1, 2, 8, 8, 8, 8, 32], dtype="uint8")
+        for b_0, c_o_0, h_o_0, w_o_0, h_i_0, w_i_0, c_i_0 in T.grid(1, 2, 4, 1, 8, 1, 4):
+            for ax0_ax1_ax2_ax3_ax4_ax5_ax6_fused in T.serial(896):
+                with T.block("X_global"):
+                    v0 = T.axis.spatial(1, 0)
+                    v1 = T.axis.spatial(2, c_o_0)
+                    v2 = T.axis.spatial(8, h_o_0 * 2)
+                    v3 = T.axis.spatial(8, ax0_ax1_ax2_ax3_ax4_ax5_ax6_fused // 128)
+                    v4 = T.axis.spatial(
+                        8, h_i_0 % 4 * 2 + ax0_ax1_ax2_ax3_ax4_ax5_ax6_fused % 128 // 64
+                    )
+                    v5 = T.axis.spatial(8, ax0_ax1_ax2_ax3_ax4_ax5_ax6_fused % 64 // 8)
+                    v6 = T.axis.spatial(32, c_i_0 * 8 + ax0_ax1_ax2_ax3_ax4_ax5_ax6_fused % 8)
+                    T.reads(X[v0, v1, v2, v3, v4, v5, v6])
+                    T.writes(X_global[v0, v1, v2, v3, v4, v5, v6])
+                    X_global[v0, v1, v2, v3, v4, v5, v6] = X[v0, v1, v2, v3, v4, v5, v6]
+            for wh, ww, b_1, c_o_1, h_o_1, w_o_1, h_i_1, w_i_1, c_i_1 in T.grid(
+                2, 2, 1, 1, 1, 4, 1, 8, 8
+            ):
+                with T.block("pool"):
+                    v_b = T.axis.spatial(1, b_1 + b_0)
+                    v_c_o = T.axis.spatial(2, c_o_0 + c_o_1)
+                    v_h_o = T.axis.spatial(4, h_o_1 + h_o_0)
+                    v_w_o = T.axis.spatial(4, w_o_0 * 4 + w_o_1)
+                    v_h_i = T.axis.spatial(8, h_i_1 + h_i_0)
+                    v_w_i = T.axis.spatial(8, w_i_0 * 8 + w_i_1)
+                    v_c_i = T.axis.spatial(32, c_i_0 * 8 + c_i_1)
+                    v_wh, v_ww = T.axis.remap("RR", [wh, ww])
+                    T.reads(
+                        X_global[
+                            v_b,
+                            v_c_o,
+                            v_h_i // 8 * 2 + v_h_o * 2,
+                            v_w_i // 8 * 2 + v_w_o * 2,
+                            v_h_i % 4 * 2 + v_wh,
+                            v_w_i % 4 * 2 + v_ww,
+                            v_c_i,
+                        ]
+                    )
+                    T.writes(pool_global[v_b, v_c_o, v_h_o, v_w_o, v_h_i, v_w_i, v_c_i])
+                    T.block_attr({"meta_schedule.tiling_structure": "SRS"})
+                    with T.init():
+                        pool_global[v_b, v_c_o, v_h_o, v_w_o, v_h_i, v_w_i, v_c_i] = T.uint8(0)
+                    pool_global[v_b, v_c_o, v_h_o, v_w_o, v_h_i, v_w_i, v_c_i] = T.max(
+                        pool_global[v_b, v_c_o, v_h_o, v_w_o, v_h_i, v_w_i, v_c_i],
+                        X_global[
+                            v_b,
+                            v_c_o,
+                            v_h_i // 8 * 2 + v_h_o * 2,
+                            v_w_i // 8 * 2 + v_w_o * 2,
+                            v_h_i % 4 * 2 + v_wh,
+                            v_w_i % 4 * 2 + v_ww,
+                            v_c_i,
+                        ],
+                    )
+            for ax0, ax1, ax2, ax3, ax4, ax5, ax6 in T.grid(1, 1, 1, 4, 1, 8, 8):
+                with T.block("pool_global"):
+                    v0 = T.axis.spatial(1, ax0)
+                    v1 = T.axis.spatial(2, c_o_0 + ax1)
+                    v2 = T.axis.spatial(4, h_o_0 + ax2)
+                    v3 = T.axis.spatial(4, ax3)
+                    v4 = T.axis.spatial(8, h_i_0 + ax4)
+                    v5 = T.axis.spatial(8, ax5)
+                    v6 = T.axis.spatial(32, c_i_0 * 8 + ax6)
+                    T.reads(pool_global[v0, v1, v2, v3, v4, v5, v6])
+                    T.writes(pool[v0, v1, v2, v3, v4, v5, v6])
+                    pool[v0, v1, v2, v3, v4, v5, v6] = pool_global[v0, v1, v2, v3, v4, v5, v6]
+
+    # fmt on
+
+    def max_pool_blocked_compute(height, width, channel):
+        ishape = (1, channel // 32, height // 8, width // 8, 8, 8, 32)
+        oshape = (1, channel // 32, height // 8 // 2, width // 8 // 2, 8, 8, 32)
+        X = te.placeholder(ishape, name="X", dtype="uint8")
+
+        window_h = te.reduce_axis((0, 2), name="wh")
+        window_w = te.reduce_axis((0, 2), name="ww")
+
+        out = te.compute(
+            oshape,
+            lambda b, c_o, h_o, w_o, h_i, w_i, c_i: te.max(
+                X[
+                    b,
+                    c_o,
+                    (h_o * 8 + h_i) // 8 * 2,
+                    (w_o * 8 + w_i) // 8 * 2,
+                    (h_o * 8 + h_i) % 4 * 2 + window_h,
+                    (w_o * 8 + w_i) % 4 * 2 + window_w,
+                    c_i,
+                ],
+                axis=[window_h, window_w],
+            ),
+            name="pool",
+        )
+        return [X, out]
+
+    height = width = 64
+    channel = 64
+
+    mod = te.create_prim_func(max_pool_blocked_compute(height, width, channel))
+
+    actual = generate_design_space(
+        kind="llvm",
+        mod=mod,
+        target=Target("llvm"),
+        types=None,
+        sch_rules=[
+            ms.schedule_rule.MultiLevelTiling(
+                structure="SRS",
+                tile_binds=None,
+                max_innermost_factor=64,
+                vector_load_lens=None,
+                reuse_read=ms.schedule_rule.ReuseType(
+                    req="must",
+                    levels=[1],
+                    scope="global",
+                ),
+                reuse_write=ms.schedule_rule.ReuseType(req="must", levels=[1], scope="global"),
+                filter_fn=lambda sch, block_rv: sch.get(block_rv).name_hint == "pool",
+            )
+        ],
+    )
+
+    decision = [
+        ("SamplePerfectTile", [1, 1]),
+        ("SamplePerfectTile", [2, 1]),
+        ("SamplePerfectTile", [4, 1]),
+        ("SamplePerfectTile", [1, 4]),
+        ("SamplePerfectTile", [8, 1]),
+        ("SamplePerfectTile", [1, 8]),
+        ("SamplePerfectTile", [4, 8]),
+    ]
+
+    check_sketches(
+        mod,
+        sketches=actual,
+        expected_mods=[pool_blocked_cache_read_write],
+        expected_decisions=[decision],
+    )
+
+
 if __name__ == "__main__":
-    test_cpu_matmul()
-    test_cpu_matmul_relu()
-    test_cuda_matmul()
-    test_cuda_matmul_relu()
-    test_cuda_sum_with_trivial_block_iter()
-    test_multi_level_tiling_hexagon()
+    tvm.testing.main()


### PR DESCRIPTION
Currently, the condition for applying `MultiLevelTiling` is given by `NeedsMultiLevelTiling` function:
https://github.com/apache/tvm/blob/5364e5a39a5e33728b7f5a26ddb40543a544ea02/src/meta_schedule/schedule_rule/multi_level_tiling.cc#L95

In practice, only multi-argument reduction operations like conv2d or dense are selected. I'm proposing to make this condition customizable for use cases where we might want to apply `MultiLevelTiling` to more ops (pooling etc).

@junrushao @csullivan @vinx13 