### PR TITLE
[Draft][Experimental][FFI] Remove string conversion of tvm::runtime::DataType

### DIFF
--- a/python/tvm/_ffi/_ctypes/types.py
+++ b/python/tvm/_ffi/_ctypes/types.py
@@ -19,7 +19,7 @@
 import ctypes
 import struct
 from ..base import py_str, check_call, _LIB
-from ..runtime_ctypes import TVMByteArray, ArgTypeCode, Device
+from ..runtime_ctypes import TVMByteArray, ArgTypeCode, Device,DataType
 
 
 class TVMValue(ctypes.Union):
@@ -30,6 +30,7 @@ class TVMValue(ctypes.Union):
         ("v_float64", ctypes.c_double),
         ("v_handle", ctypes.c_void_p),
         ("v_str", ctypes.c_char_p),
+        ('v_type', DataType),
     ]
 
 
@@ -77,9 +78,9 @@ def _return_device(value):
     return Device(arr[0], arr[1])
 
 
-def _wrap_arg_func(return_f, type_code):
+def _wrap_arg_func(return_f, type_code: ArgTypeCode):
     def _wrap_func(x):
-        tcode = ctypes.c_int(type_code)
+        tcode = ctypes.c_int(type_code.value)
         check_call(_LIB.TVMCbArgToReturn(ctypes.byref(x), ctypes.byref(tcode)))
         return return_f(x)
 
@@ -97,6 +98,7 @@ RETURN_SWITCH = {
     ArgTypeCode.FLOAT: lambda x: x.v_float64,
     ArgTypeCode.HANDLE: _return_handle,
     ArgTypeCode.NULL: lambda x: None,
+    ArgTypeCode.TVM_TYPE: lambda x: x.v_type,
     ArgTypeCode.STR: lambda x: py_str(x.v_str),
     ArgTypeCode.BYTES: _return_bytes,
     ArgTypeCode.DLDEVICE: _return_device,
@@ -107,6 +109,7 @@ C_TO_PY_ARG_SWITCH = {
     ArgTypeCode.FLOAT: lambda x: x.v_float64,
     ArgTypeCode.HANDLE: _return_handle,
     ArgTypeCode.NULL: lambda x: None,
+    ArgTypeCode.TVM_TYPE: lambda x: x.v_type,
     ArgTypeCode.STR: lambda x: py_str(x.v_str),
     ArgTypeCode.BYTES: _return_bytes,
     ArgTypeCode.DLDEVICE: _return_device,

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -476,13 +476,9 @@ int TVMFuncCall(TVMFunctionHandle func, TVMValue* args, int* arg_type_codes, int
   (static_cast<const PackedFuncObj*>(func))
       ->CallPacked(TVMArgs(args, arg_type_codes, num_args), &rv);
   // handle return string.
-  if (rv.type_code() == kTVMStr || rv.type_code() == kTVMDataType || rv.type_code() == kTVMBytes) {
+  if (rv.type_code() == kTVMStr || rv.type_code() == kTVMBytes) {
     TVMRuntimeEntry* e = TVMAPIRuntimeStore::Get();
-    if (rv.type_code() != kTVMDataType) {
-      e->ret_str = *rv.ptr<std::string>();
-    } else {
-      e->ret_str = rv.operator std::string();
-    }
+    e->ret_str = *rv.ptr<std::string>();
     if (rv.type_code() == kTVMBytes) {
       e->ret_bytes.data = e->ret_str.c_str();
       e->ret_bytes.size = e->ret_str.length();

--- a/src/runtime/data_type.cc
+++ b/src/runtime/data_type.cc
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file data_type.cc
+ * \brief Data-type handling
+ */
+#include <tvm/runtime/data_type.h>
+#include <tvm/runtime/registry.h>
+
+namespace tvm {
+namespace runtime {
+TVM_REGISTER_GLOBAL("runtime.String2DLDataType").set_body_typed(String2DLDataType);
+TVM_REGISTER_GLOBAL("runtime.DLDataType2String").set_body_typed(DLDataType2String);
+
+}  // namespace runtime
+}  // namespace tvm


### PR DESCRIPTION
Previously, the FFI would automatically convert all instances of `tvm::runtime::DataType` to a string for FFI usage.  This was an unnecessary step of formatting/parsing to every FFI call with `tvm::runtime::DataType` arguments, and resulted in duplicate parsing/formatting implementations in C++ and Python.

This commit updates the FFI to pass `tvm::runtime::DataType` directly, using the existing `TVMArgTypeCode::kTVMDataType` type code.  The `tvm.DataType` wrapper class is updated with additional methods for backwards compatibility (e.g. `"float" in dtype`, `bits = int(dtype[-2:])`), which can be phased out over time.