### PR TITLE
[Logging] Mark LogFatal::~LogFatal as [[noreturn]]

### DIFF
--- a/apps/dso_plugin_module/plugin_module.cc
+++ b/apps/dso_plugin_module/plugin_module.cc
@@ -43,7 +43,6 @@ class MyModuleNode : public ModuleNode {
       return TypedPackedFunc<int(int)>([sptr_to_self, this](int value) { return value_ * value; });
     } else {
       LOG(FATAL) << "unknown function " << name;
-      return PackedFunc();
     }
   }
 

--- a/include/tvm/runtime/data_type.h
+++ b/include/tvm/runtime/data_type.h
@@ -310,7 +310,6 @@ inline const char* DLDataTypeCode2Str(DLDataTypeCode type_code) {
       return "bfloat";
     default:
       LOG(FATAL) << "unknown type_code=" << static_cast<int>(type_code);
-      return "";
   }
 }
 

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -289,7 +289,6 @@ inline const char* DeviceName(int type) {
       return "microdev";
     default:
       LOG(FATAL) << "unknown type =" << type;
-      return "Unknown";
   }
 }
 

--- a/include/tvm/runtime/logging.h
+++ b/include/tvm/runtime/logging.h
@@ -353,7 +353,7 @@ class LogFatal {
 #pragma disagnostic push
 #pragma warning(disable : 4722)
 #endif
-  ~LogFatal() TVM_THROW_EXCEPTION { GetEntry().Finalize(); }
+  [[noreturn]] ~LogFatal() TVM_THROW_EXCEPTION { GetEntry().Finalize(); }
 #ifdef _MSC_VER
 #pragma disagnostic pop
 #endif
@@ -366,7 +366,9 @@ class LogFatal {
       this->file_ = file;
       this->lineno_ = lineno;
     }
-    TVM_NO_INLINE dmlc::Error Finalize() { throw InternalError(file_, lineno_, stream_.str()); }
+    [[noreturn]] TVM_NO_INLINE dmlc::Error Finalize() {
+      throw InternalError(file_, lineno_, stream_.str());
+    }
     std::ostringstream stream_;
     std::string file_;
     int lineno_;

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1256,7 +1256,6 @@ inline const char* ArgTypeCode2Str(int type_code) {
       return "ObjectRValueRefArg";
     default:
       LOG(FATAL) << "unknown type_code=" << static_cast<int>(type_code);
-      return "";
   }
 }
 

--- a/include/tvm/tir/expr_functor.h
+++ b/include/tvm/tir/expr_functor.h
@@ -153,7 +153,6 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
   virtual R VisitExpr_(const AnyNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExprDefault_(const Object* op, Args...) {
     LOG(FATAL) << "Do not have a default for " << op->GetTypeKey();
-    return R();
   }
 
  private:

--- a/include/tvm/tir/op.h
+++ b/include/tvm/tir/op.h
@@ -931,7 +931,6 @@ inline PrimExpr MakeConstScalar(DataType t, ValueType value, Span span = Span())
     return FloatImm(t, static_cast<double>(value), span);
   }
   LOG(FATAL) << "cannot make const for type " << t;
-  return PrimExpr();
 }
 
 template <>

--- a/include/tvm/tir/op_attr_types.h
+++ b/include/tvm/tir/op_attr_types.h
@@ -119,7 +119,6 @@ inline std::ostream& operator<<(std::ostream& os, CallEffectKind side_effect) {
 
     default:
       LOG(FATAL) << "Unknown CallEffectKind: " << static_cast<int>(side_effect);
-      return os;
   }
 }
 

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1649,7 +1649,6 @@ inline const char* ForKind2String(ForKind t) {
       return "thread_binding";
   }
   LOG(FATAL) << "Unknown ForKind" << t;
-  return "Unknown";
 }
 
 }  // namespace tir

--- a/include/tvm/tir/stmt_functor.h
+++ b/include/tvm/tir/stmt_functor.h
@@ -103,7 +103,6 @@ class StmtFunctor<R(const Stmt& n, Args... args)> {
   virtual R VisitStmt_(const BlockRealizeNode* op, Args... args) STMT_FUNCTOR_DEFAULT;
   virtual R VisitStmtDefault_(const Object* op, Args...) {
     LOG(FATAL) << "Do not have a default for " << op->GetTypeKey();
-    return R();
   }
 
  private:

--- a/src/arith/bound_deducer.cc
+++ b/src/arith/bound_deducer.cc
@@ -216,7 +216,6 @@ CompareOp BoundDeducer::ReverseOp(CompareOp comp_op) {
       return kGreater;
     default:
       LOG(FATAL) << "Not a valid compare op";
-      return kGreater;  // return some default value
   }
 }
 

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -1330,7 +1330,6 @@ IterSumExpr IterMapRewriter::PreprocessDividend(IterMapExpr dividend, PrimExpr o
     return fused;
   } else {
     LOG(FATAL) << "Unsupported subclass of IterMarkExpr";
-    return IterSumExpr();
   }
 }
 
@@ -1855,7 +1854,6 @@ class SubspaceDivider {
         return IterSplitExpr(IterMark(GetRef<IterSumExpr>(op), extent));
       } else {
         LOG(FATAL) << "Unknown IterMapExpr type";
-        return NullValue<IterSplitExpr>();
       }
     }
   };

--- a/src/arith/narrow_predicate_expression.cc
+++ b/src/arith/narrow_predicate_expression.cc
@@ -192,7 +192,6 @@ class ExpressionNarrower : public tir::ExprMutator {
 
       default:
         LOG(FATAL) << "Unhandled Context, all legal values should be handled";
-        return Context::Maximize;
     }
   }
 

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -321,7 +321,6 @@ CompareResult Reverse(CompareResult res) {
       return CompareResult::kUnknown;
     default:
       LOG(FATAL) << "Invalid CompareResult: " << static_cast<int>(res);
-      return CompareResult::kInconsistent;
   }
 }
 
@@ -864,11 +863,9 @@ CompareResult TransitiveComparisonAnalyzer::Impl::MergeComparisons(
       case CompareResult::kGT:
       case CompareResult::kLT:
         LOG(FATAL) << "Internal error, normalized comparisons should only include <= and >=";
-        return CompareResult::kInconsistent;
 
       default:
         LOG(FATAL) << "Invalid CompareResult: " << static_cast<int>(cmp.result_);
-        return CompareResult::kInconsistent;
     }
   }
 

--- a/src/auto_scheduler/search_policy/utils.h
+++ b/src/auto_scheduler/search_policy/utils.h
@@ -89,7 +89,6 @@ inline int OperationToStage(const te::Operation& op, const State& state) {
     }
   }
   LOG(FATAL) << "Cannot find op: " << op;
-  return -1;
 }
 
 /********** Get Parameters **********/
@@ -531,7 +530,6 @@ inline Iterator GetLastReduceIteratorInOutermostReduceTile(const Stage& stage) {
   }
 
   LOG(FATAL) << "Cannot find the iterator.";
-  return stage->iters[0];
 }
 
 /*! \brief Get the target stage id of a history step in the new state.

--- a/src/auto_scheduler/utils.h
+++ b/src/auto_scheduler/utils.h
@@ -89,7 +89,6 @@ inline int GetIndex(const Array<T>& array, const T& to_locate) {
     }
   }
   LOG(FATAL) << "Cannot find the item";
-  return -1;
 }
 
 /*! \brief Delete the item in a std::vector if it exists. */

--- a/src/ir/function.cc
+++ b/src/ir/function.cc
@@ -45,7 +45,6 @@ TVM_REGISTER_GLOBAL("ir.BaseFuncWithAttr")
         return WithAttr(Downcast<relay::Function>(std::move(func)), key, value);
       } else {
         LOG(FATAL) << "Do not support function type " << func->GetTypeKey();
-        return func;
       }
     });
 

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -172,7 +172,6 @@ Constructor IRModuleNode::GetConstructor(const String& adt, const String& cons) 
   }
 
   LOG(FATAL) << adt << " does not contain constructor " << cons;
-  return {};
 }
 
 tvm::Array<GlobalTypeVar> IRModuleNode::GetGlobalTypeVars() const {

--- a/src/meta_schedule/module_equality.cc
+++ b/src/meta_schedule/module_equality.cc
@@ -104,7 +104,6 @@ std::unique_ptr<ModuleEquality> ModuleEquality::Create(const std::string& mod_eq
     return std::make_unique<ModuleEqualityAnchorBlock>();
   }
   LOG(FATAL) << "Unknown module equality " << mod_eq_name;
-  return nullptr;
 }
 
 }  // namespace meta_schedule

--- a/src/parser/meta_ref.cc
+++ b/src/parser/meta_ref.cc
@@ -43,7 +43,6 @@ TVM_REGISTER_NODE_TYPE(MetaRefAttrs);
 bool MetaRefRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                 const TypeReporter& reporter) {
   LOG(FATAL) << "need to expand before type checking";
-  return true;
 }
 
 RELAY_REGISTER_OP("parser.MetaRef")

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -541,7 +541,6 @@ class Parser {
       return support::FloatImmToNDArray(Downcast<tvm::FloatImm>(token->data));
     } else {
       LOG(FATAL) << "internal error: should only call this function on numeric tokens";
-      return {};
     }
   }
 

--- a/src/parser/token.h
+++ b/src/parser/token.h
@@ -216,7 +216,6 @@ std::string ToString(const TokenType& token_type) {
     // Older compilers warn even though the above code is exhaustive.
     default:
       LOG(FATAL) << "unreachable code";
-      return "";
   }
 }
 
@@ -339,7 +338,6 @@ std::string Pretty(const TokenType& token_type) {
     // Older compilers warn even though the above code is exhaustive.
     default:
       LOG(FATAL) << "unreachable code";
-      return "";
   }
 }
 

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -756,18 +756,15 @@ Doc TVMScriptPrinter::Print(const ObjectRef& node) {
     return PrintTarget(node.as<TargetNode>());
   } else {
     LOG(FATAL) << "Do not know how to print " << node->GetTypeKey();
-    return Doc();
   }
 }
 
 Doc TVMScriptPrinter::VisitExprDefault_(const Object* op, ExprPrecedence* out_precedence) {
   LOG(FATAL) << "Do not know how to print " << op->GetTypeKey();
-  return Doc();
 }
 
 Doc TVMScriptPrinter::VisitStmtDefault_(const Object* op) {
   LOG(FATAL) << "Do not know how to print " << op->GetTypeKey();
-  return Doc();
 }
 
 Doc TVMScriptPrinter::VisitExpr_(const IntImmNode* op, ExprPrecedence* out_precedence) {

--- a/src/relay/backend/aot/aot_lower_main.cc
+++ b/src/relay/backend/aot/aot_lower_main.cc
@@ -303,7 +303,6 @@ class AOTMainLowerer : public MixedModeVisitor {
       // TODO(mbs): device_copy cleaunp
       // Suspect treating as no-op is better since already built into the StorageInfo?
       LOG(FATAL) << "The AOT executor does not currently support device_copy";
-      return;
     }
 
     // At this point we should only see calls of the form call_lowered(@callee, (args...)),

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -618,7 +618,6 @@ class AOTExecutorCodegen : public MixedModeVisitor {
       // TODO(mbs): device_copy cleaunp
       // Suspect treating as no-op is better since already built into the StorageInfo?
       LOG(FATAL) << "The AOT executor does not currently support device_copy";
-      return;
     }
 
     // At this point we should only see calls of the form call_lowered(@callee, (args...)),

--- a/src/relay/backend/contrib/codegen_c/codegen.cc
+++ b/src/relay/backend/contrib/codegen_c/codegen.cc
@@ -76,7 +76,6 @@ class CodegenC : public backend::MemoizedExprTranslator<std::vector<Output>>, pu
  private:
   std::vector<Output> VisitExprDefault_(const Object* op) override {
     LOG(FATAL) << "C codegen doesn't support: " << op->GetTypeKey();
-    return {};
   }
 
   std::vector<Output> VisitExpr_(const VarNode* node) override {

--- a/src/relay/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relay/backend/contrib/codegen_json/codegen_json.h
@@ -250,7 +250,6 @@ class JSONSerializer : public MemoizedExprTranslator<std::vector<JSONGraphNodeEn
 
   std::vector<JSONGraphNodeEntry> VisitExprDefault_(const Object* op) {
     LOG(FATAL) << "JSON runtime currently doesn't support " << op->GetTypeKey();
-    return {};
   }
 
   std::vector<JSONGraphNodeEntry> VisitExpr_(const VarNode* vn) {

--- a/src/relay/backend/contrib/cutlass/codegen.cc
+++ b/src/relay/backend/contrib/cutlass/codegen.cc
@@ -531,7 +531,6 @@ class CodegenCutlass : public backend::MemoizedExprTranslator<std::vector<Output
 
   std::vector<Output> VisitExprDefault_(const Object* op) final {
     LOG(FATAL) << "Cutlass codegen doesn't support: " << op->GetTypeKey();
-    return {};
   }
 
   std::vector<Output> VisitExpr_(const VarNode* node) final {
@@ -730,7 +729,6 @@ class CodegenCutlass : public backend::MemoizedExprTranslator<std::vector<Output
     }
 
     LOG(FATAL) << "Unknown composite function: " << pattern_name;
-    return {};
   }
 
   GenerateBodyOutput GenerateBody(const CallNode* root_call, const std::string& func_name,

--- a/src/relay/backend/contrib/dnnl/codegen.cc
+++ b/src/relay/backend/contrib/dnnl/codegen.cc
@@ -160,7 +160,6 @@ class CodegenDNNL : public MemoizedExprTranslator<std::vector<Output>>, public C
 
   std::vector<Output> VisitExprDefault_(const Object* op) final {
     LOG(FATAL) << "DNNL codegen doesn't support: " << op->GetTypeKey();
-    return {};
   }
 
   std::vector<Output> VisitExpr_(const VarNode* node) final {
@@ -262,7 +261,6 @@ class CodegenDNNL : public MemoizedExprTranslator<std::vector<Output>>, public C
     }
 
     LOG(FATAL) << "Unsupported op: " << AsText(call->op, false);
-    return {};
   }
 
   GenerateBodyOutput GenerateCompositeFunctionCall(const FunctionNode* callee,
@@ -282,7 +280,6 @@ class CodegenDNNL : public MemoizedExprTranslator<std::vector<Output>>, public C
     }
 
     LOG(FATAL) << "Unknown composite function:" << pattern_name;
-    return {};
   }
 
   GenerateBodyOutput GenerateBody(const CallNode* root_call, const std::string& func_name,

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -493,15 +493,12 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
 
   std::vector<GraphNodeRef> VisitExpr_(const OpNode* op) override {
     LOG(FATAL) << "All OpNodes should have been expanded";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const GlobalVarNode* op) override {
     LOG(FATAL) << "All GlobalVarNodes should be removed before graph executor's Codegen is called";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const IfNode* op) override {
     LOG(FATAL) << "Graph executor does not support control flow (found IfNode)";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const FunctionNode* op) override {
     ICHECK(op->GetAttr<String>(attr::kCompiler).defined())
@@ -510,23 +507,18 @@ class GraphExecutorCodegen : public backend::MemoizedExprTranslator<std::vector<
   }
   std::vector<GraphNodeRef> VisitExpr_(const RefCreateNode* op) override {
     LOG(FATAL) << "Graph executor does not support references (found RefCreateNode)";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const RefReadNode* op) override {
     LOG(FATAL) << "Graph executor does not support references (found RefReadNode)";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const RefWriteNode* op) override {
     LOG(FATAL) << "Graph executor does not support references (found RefWriteNode)";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const ConstructorNode* op) override {
     LOG(FATAL) << "Graph executor does not support ADTs (found ConstructorNode)";
-    return {};
   }
   std::vector<GraphNodeRef> VisitExpr_(const MatchNode* op) override {
     LOG(FATAL) << "Graph executor does not support matching (found MatchNode)";
-    return {};
   }
   /*!
    * \brief Generate Graph JSON

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -707,7 +707,6 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
     if (device_copy_props.body.defined()) {
       // TODO(mbs): device_copy cleanup
       LOG(FATAL) << "The interpreter does not support device_copy";
-      return {};
     } else if (call_lowered_props.lowered_func.defined()) {
       // Special case: Call a lowered TIR function.
 
@@ -837,7 +836,6 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
       }
     } else {
       LOG(FATAL) << "type error, type system should have caught this";
-      return ObjectRef();
     }
   }
 
@@ -848,7 +846,6 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
       return ADT::Tuple(std::vector<ObjectRef>());
     } else {
       LOG(FATAL) << "type error, type system should have caught this";
-      return ObjectRef();
     }
   }
 
@@ -860,7 +857,6 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
       return rv->value;
     } else {
       LOG(FATAL) << "type error, type system should have caught this";
-      return ObjectRef();
     }
   }
 
@@ -872,7 +868,6 @@ class Interpreter : public ExprFunctor<ObjectRef(const Expr& n)>,
       }
     }
     LOG(FATAL) << "did not find any match";
-    return ObjectRef();
   }
 
   bool VisitPattern_(const PatternConstructorNode* op, const ObjectRef& v) final {
@@ -1099,7 +1094,6 @@ TypedPackedFunc<ObjectRef(Array<Expr>)> EvalFunction(IRModule mod, Expr expr, De
     });
   } else {
     LOG(FATAL) << "expecting expression to have function type and evaluate to a closure";
-    return nullptr;
   }
 }
 

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -243,7 +243,6 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
 
   Array<te::Tensor> VisitExpr_(const VarNode* op) final {
     LOG(FATAL) << "Unexpected free variable " << PrettyPrint(GetRef<Var>(op));
-    return {};
   }
 
   Array<te::Tensor> VisitExpr_(const ConstantNode* op) final {
@@ -272,7 +271,6 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
               return make_const(dtype, static_cast<const double*>(data)[0]);
             } else {
               LOG(FATAL) << dtype << " not handled";
-              return tvm::PrimExpr();
             }
           },
           "compile_engine_const", topi::kBroadcast);
@@ -351,7 +349,6 @@ class LowerToTECompute : public backend::MemoizedExprTranslator<Array<te::Tensor
 
   Array<te::Tensor> VisitExpr_(const FunctionNode* op) final {
     LOG(FATAL) << "Primitive Functions can not contain nested functions.";
-    return Array<te::Tensor>();
   }
 
   Array<te::Tensor> VisitExpr_(const LetNode* op) final {
@@ -877,7 +874,6 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
     }
     if (param_states_.find(var) == param_states_.end()) {
       LOG(FATAL) << "Unexpected free variable " << PrettyPrint(var);
-      return {};
     } else {
       ICHECK(data_dependents_per_input_.size());
       auto data_dependent = data_dependents_per_input_.back();
@@ -934,7 +930,6 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
               return make_const(dtype, static_cast<const uint8_t*>(data)[0]);
             } else {
               LOG(FATAL) << "not handled";
-              return tvm::PrimExpr();
             }
           },
           "data_const", topi::kBroadcast);
@@ -1015,7 +1010,6 @@ class MakeShapeFunc : public backend::MemoizedExprTranslator<Array<te::Tensor>> 
 
   Array<te::Tensor> VisitExpr_(const FunctionNode* op) final {
     LOG(FATAL) << "Nested functions are not allowed to be visited.";
-    return Array<te::Tensor>();
   }
 
   Array<te::Tensor> VisitExpr_(const LetNode* op) final {

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -865,7 +865,6 @@ PackedFunc VMCompiler::GetFunction(const std::string& name, const ObjectPtr<Obje
     });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;
-    return PackedFunc([sptr_to_self, name](TVMArgs args, TVMRetValue* rv) {});
   }
 }
 

--- a/src/relay/op/nn/sparse.cc
+++ b/src/relay/op/nn/sparse.cc
@@ -65,7 +65,6 @@ bool SparseDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       return true;
     }
     LOG(FATAL) << "Unknown data ndim for nn.sparse_dense, should be 1 (CSR) or 3 (BSR)";
-    return false;
 
   } else {
     const auto* data = types[0].as<TensorTypeNode>();
@@ -89,7 +88,6 @@ bool SparseDenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs
       return true;
     }
     LOG(FATAL) << "Unknown weight ndim for nn.sparse_dense, should be 1 (CSR) or 3 (BSR)";
-    return false;
   }
 }
 

--- a/src/relay/qnn/utils.h
+++ b/src/relay/qnn/utils.h
@@ -57,7 +57,6 @@ static inline int32_t GetQmin(const DataType& dtype) {
     return static_cast<int32_t>(min_value[0]);
   } else {
     LOG(FATAL) << "Type not supported " << dtype;
-    return -1;  // To hide the warning
   }
 }
 
@@ -70,7 +69,6 @@ static inline int32_t GetQmax(const DataType& dtype) {
     return static_cast<int32_t>(max_value[0]);
   } else {
     LOG(FATAL) << "Type not supported " << dtype;
-    return -1;  // To hide the warning
   }
 }
 

--- a/src/relay/transforms/defunctionalization.cc
+++ b/src/relay/transforms/defunctionalization.cc
@@ -289,7 +289,6 @@ class DefuncMutator : public ExprMutator {
       return Call(c, call_args);
     }
     LOG(FATAL) << "EncodeArg failed to cast arg into identifier node or function node";
-    return {};
   }
 
   /*!

--- a/src/relay/transforms/fold_constant.cc
+++ b/src/relay/transforms/fold_constant.cc
@@ -244,7 +244,6 @@ class ConstantFolder : public MixedModeMutator {
       return Tuple(fields);
     } else {
       LOG(FATAL) << "Cannot handle " << value->GetTypeKey();
-      return {};
     }
   }
 

--- a/src/relay/transforms/fold_scale_axis.cc
+++ b/src/relay/transforms/fold_scale_axis.cc
@@ -919,7 +919,6 @@ Expr AddSubBackwardTransform(const Call& call, const Message& message, const Exp
     return Call(call->op, {lhs, rhs}, call->attrs, call->type_args);
   } else {
     LOG(FATAL) << "outstanding scale";
-    return Expr();
   }
 }
 
@@ -1104,7 +1103,6 @@ Expr BiasAddBackwardTransform(const Call& call, const Message& message, const Ex
     return Call(call->op, {lhs, rhs}, call->attrs, call->type_args);
   } else {
     LOG(FATAL) << "outstanding scale";
-    return Expr();
   }
 }
 

--- a/src/relay/transforms/infer_layout_utils.cc
+++ b/src/relay/transforms/infer_layout_utils.cc
@@ -148,7 +148,6 @@ Layout TryTransformLike(const Layout& old, const Layout& ref_old, const Layout& 
     for (int i = 0; i < 26; ++i)
       if (!used[i]) return 'A' + i;
     LOG(FATAL) << "All letters are used";
-    return 0;
   };
 
   for (int j = old->axes.size() - 1, i = ref_old->axes.size() - 1; j >= 0; --i, --j) {

--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -213,7 +213,6 @@ class MixedPrecisionPass : public MixedModeMutator {
       return true;
     } else {
       LOG(FATAL) << "Unsupported type " << t << " we don't know how to handle";
-      return false;
     }
   }
 

--- a/src/runtime/contrib/arm_compute_lib/acl_utils.cc
+++ b/src/runtime/contrib/arm_compute_lib/acl_utils.cc
@@ -136,7 +136,6 @@ arm_compute::DataType MakeACLDataType(const DLDataType& data_type) {
     return arm_compute::DataType::S32;
   } else {
     LOG(FATAL) << "Datatype " << data_type << " unsupported by ACL runtime";
-    return arm_compute::DataType::UNKNOWN;
   }
 }
 

--- a/src/runtime/contrib/bnns/bnns_json_runtime.cc
+++ b/src/runtime/contrib/bnns/bnns_json_runtime.cc
@@ -536,7 +536,6 @@ class BNNSJSONRuntime : public JSONRuntimeBase {
       if (dl_dtype.bits == 8) return BNNSDataTypeUInt8;
     }
     LOG(FATAL) << "Unsupported data type for BNNS runtime";
-    return BNNS::Dtype(0);
   }
 
   BNNSFilterParameters getCommonFilterParams() {

--- a/src/runtime/contrib/clml/clml_runtime.cc
+++ b/src/runtime/contrib/clml/clml_runtime.cc
@@ -574,7 +574,6 @@ class CLMLRuntime : public JSONRuntimeBase {
       return CL_HALF_FLOAT;
     } else {
       LOG(FATAL) << "Datatype " << data_type << " unsupported by CLML runtime";
-      return -1;
     }
   }
 
@@ -588,7 +587,6 @@ class CLMLRuntime : public JSONRuntimeBase {
       return CL_ARITHMETIC_MODE_FP16_QCOM;
     } else {
       LOG(FATAL) << "Datatype " << data_type << " unsupported by CLML runtime";
-      return CL_ARITHMETIC_MODE_FP32_QCOM;
     }
   }
 

--- a/src/runtime/contrib/cublas/cublas_utils.h
+++ b/src/runtime/contrib/cublas/cublas_utils.h
@@ -103,7 +103,6 @@ inline cudaDataType_t GetCudaDataType(DLDataType type) {
     }
   }
   LOG(FATAL) << "Unsupported cuda type";
-  return CUDA_R_16F;
 }
 }  // namespace contrib
 }  // namespace tvm

--- a/src/runtime/contrib/dnnl/dnnl_tensor_requisite.h
+++ b/src/runtime/contrib/dnnl/dnnl_tensor_requisite.h
@@ -274,7 +274,6 @@ class TensorRequisite {
     if (layout.find("O") != std::string::npos) return "OI" + sparse_dims[rank - 3];
 
     LOG(FATAL) << "Unknown layout " << layout << "There is no default scheme to handle it";
-    return {};
   }
 
   /*!

--- a/src/runtime/contrib/tflite/tflite_runtime.cc
+++ b/src/runtime/contrib/tflite/tflite_runtime.cc
@@ -86,7 +86,6 @@ DataType TfLiteDType2TVMDType(TfLiteType dtype) {
       return DataType::Float(16);
     default:
       LOG(FATAL) << "tflite data type not support yet: " << dtype;
-      return DataType::Float(32);
   }
 }
 

--- a/src/runtime/graph_executor/debug/graph_executor_debug.cc
+++ b/src/runtime/graph_executor/debug/graph_executor_debug.cc
@@ -235,7 +235,6 @@ class GraphExecutorDebug : public GraphExecutor {
       }
     }
     LOG(FATAL) << "cannot find " << name << " among nodex";
-    return -1;
   }
 
   /*!

--- a/src/runtime/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon_buffer.cc
@@ -151,7 +151,6 @@ void* HexagonBuffer::GetPointer() {
     return allocations_.data();
   } else {
     LOG(FATAL) << "HexagonBuffer should be either 1-d or 2-d, not " << ndim_ << "-d";
-    return nullptr;
   }
 }
 

--- a/src/runtime/hexagon/hexagon_module.cc
+++ b/src/runtime/hexagon/hexagon_module.cc
@@ -45,7 +45,6 @@ HexagonModuleNode::HexagonModuleNode(std::string data, std::string fmt,
 PackedFunc HexagonModuleNode::GetFunction(const std::string& name,
                                           const ObjectPtr<Object>& sptr_to_self) {
   LOG(FATAL) << "HexagonModuleNode::GetFunction is not implemented.";
-  return PackedFunc();
 }
 
 std::string HexagonModuleNode::GetSource(const std::string& format) {

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -281,7 +281,6 @@ TvmLogDebugSettings TvmLogDebugSettings::ParseSpec(const char* opt_spec) {
     }
     if (name.empty()) {
       LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(name) << ": empty filename";
-      return settings;
     }
 
     name = FileToVLogMapKey(name);

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -103,7 +103,6 @@ void ModuleNode::SaveToBinary(dmlc::Stream* stream) {
 
 std::string ModuleNode::GetSource(const std::string& format) {
   LOG(FATAL) << "Module[" << type_key() << "] does not support GetSource";
-  return "";
 }
 
 const PackedFunc* ModuleNode::GetFuncFromEnv(const std::string& name) {
@@ -131,7 +130,6 @@ const PackedFunc* ModuleNode::GetFuncFromEnv(const std::string& name) {
 
 std::string ModuleNode::GetFormat() {
   LOG(FATAL) << "Module[" << type_key() << "] does not support GetFormat";
-  return "";
 }
 
 bool ModuleNode::IsDSOExportable() const { return false; }

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -196,7 +196,6 @@ inline cl_channel_type DTypeToOpenCLChannelType(DLDataType data_type) {
     return CL_UNSIGNED_INT32;
   }
   LOG(FATAL) << "data type is not supported in OpenCL runtime yet: " << dtype;
-  return CL_FLOAT;
 }
 
 /*!

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -79,7 +79,6 @@ cl::BufferDescriptor::MemoryLayout cl::BufferDescriptor::MemoryLayoutFromScope(
     return cl::BufferDescriptor::MemoryLayout::kImage2DNHWC;
   }
   LOG(FATAL) << "No memory layout defined for memory of scope: " << mem_scope.value();
-  return cl::BufferDescriptor::MemoryLayout::kBuffer1D;
 }
 
 String cl::BufferDescriptor::ScopeFromMemoryLayout(cl::BufferDescriptor::MemoryLayout layout) {

--- a/src/runtime/pack_args.h
+++ b/src/runtime/pack_args.h
@@ -144,7 +144,6 @@ inline ArgConvertCode GetArgConvertCode(DLDataType t) {
     return HANDLE_TO_HANDLE;
   }
   LOG(FATAL) << "Cannot handle " << t << " as device function argument";
-  return HANDLE_TO_HANDLE;
 }
 
 template <int N, typename F>

--- a/src/runtime/pipeline/pipeline_executor.cc
+++ b/src/runtime/pipeline/pipeline_executor.cc
@@ -87,7 +87,6 @@ PackedFunc PipelineExecutor::GetFunction(const std::string& name,
         [sptr_to_self, this](TVMArgs args, TVMRetValue* rv) { *rv = this->GetExecutionCount(); });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;
-    return PackedFunc();
   }
 }
 /*!

--- a/src/runtime/pipeline/pipeline_struct.h
+++ b/src/runtime/pipeline/pipeline_struct.h
@@ -204,7 +204,6 @@ class QueueData {
   DLTensor* CreateCopyFrom(const DLTensor* from) {
     if (!from) {
       LOG(FATAL) << "the 'from' pointer is a null pointer!";
-      return nullptr;
     }
     size_t fromLen = tvm::runtime::GetDataSize(*from);
     size_t toLen = data_ ? tvm::runtime::GetDataSize(*data_) : 0;
@@ -892,7 +891,6 @@ class BackendRuntime : public BasicRuntime {
   bool LoadBindingData(int input_index) {
     if (input_queue_.find(input_index) == input_queue_.end()) {
       LOG(FATAL) << "Not finding the associated input queue of the input " << input_index << " !";
-      return false;
     }
     auto queue = input_queue_[input_index];
     QueueData data;
@@ -913,7 +911,6 @@ class BackendRuntime : public BasicRuntime {
       auto output_idx = child.first;
       if (forward_queue_.find(output_idx) == forward_queue_.end()) {
         LOG(FATAL) << "Not find the forwarding queue map for output(" << output_idx << ")!";
-        return false;
       }
       NDArray output = GetOutput(output_idx);
       auto forward_queue_map = forward_queue_[output_idx];

--- a/src/runtime/rpc/rpc_event_impl.cc
+++ b/src/runtime/rpc/rpc_event_impl.cc
@@ -32,10 +32,8 @@ namespace tvm {
 namespace runtime {
 
 PackedFunc CreateEventDrivenServer(PackedFunc fsend, std::string name, std::string remote_key) {
-  static PackedFunc frecv([](TVMArgs args, TVMRetValue* rv) {
-    LOG(FATAL) << "Do not allow explicit receive";
-    return 0;
-  });
+  static PackedFunc frecv(
+      [](TVMArgs args, TVMRetValue* rv) { LOG(FATAL) << "Do not allow explicit receive"; });
 
   auto ch = std::make_unique<CallbackChannel>(fsend, frecv);
   std::shared_ptr<RPCEndpoint> sess = RPCEndpoint::Create(std::move(ch), name, remote_key);

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -191,7 +191,6 @@ class RPCModuleNode final : public ModuleNode {
 
   std::string GetSource(const std::string& format) final {
     LOG(FATAL) << "GetSource for rpc Module is not supported";
-    return "";
   }
 
   PackedFunc GetTimeEvaluator(const std::string& name, Device dev, int number, int repeat,

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -116,7 +116,6 @@ class RPCSessTable {
       }
     }
     LOG(FATAL) << "maximum number of RPC session reached";
-    return 0;
   }
 
  private:

--- a/src/runtime/stackvm/stackvm.cc
+++ b/src/runtime/stackvm/stackvm.cc
@@ -174,7 +174,6 @@ int64_t StackVM::PrintCode(std::ostream& os, int64_t pc) const {
     }
   }
   LOG(FATAL) << "unknown op code " << code[pc].op_code;
-  return 0;
 }
 
 std::ostream& operator<<(std::ostream& os, const StackVM& vm) {  // NOLINT(*)

--- a/src/runtime/stackvm/stackvm.h
+++ b/src/runtime/stackvm/stackvm.h
@@ -379,10 +379,8 @@ class StackVM {
         return LE_F64;
       case MOD_I64:
         LOG(FATAL) << "cannot handle mod for float";
-        return ADD_F64;
       default:
         LOG(FATAL) << "cannot handle op " << code;
-        return ADD_F64;
     }
   }
   /*!
@@ -412,7 +410,6 @@ class StackVM {
       }
     }
     LOG(FATAL) << "Cannot load type " << t;
-    return ARRAY_LOAD_FP64;
   }
   /*!
    * \brief Get store opcode for type t
@@ -441,7 +438,6 @@ class StackVM {
       }
     }
     LOG(FATAL) << "Cannot store type " << t;
-    return ARRAY_STORE_FP64;
   }
   friend std::ostream& operator<<(std::ostream& os, const StackVM& vm);  // NOLINT(*)
 

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -78,7 +78,6 @@ inline StorageRank DefaultStorageRank(int thread_scope_rank) {
       return StorageRank::kLocal;
     default: {
       LOG(FATAL) << "unknown rank";
-      return StorageRank::kGlobal;
     }
   }
 }
@@ -115,7 +114,6 @@ struct StorageScope {
         return "texture" + tag;
       default:
         LOG(FATAL) << "unknown storage scope";
-        return "";
     }
   }
   /*!

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -118,7 +118,6 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
     });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;
-    return PackedFunc();
   }
 }
 
@@ -1012,7 +1011,6 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
     }
     default:
       LOG(FATAL) << "Invalid opcode" << instr.opcode;
-      return Instruction();
   }
 }
 

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -243,7 +243,6 @@ PackedFunc VirtualMachine::GetFunction(const std::string& name,
     });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;
-    return PackedFunc([sptr_to_self, name](TVMArgs args, TVMRetValue* rv) {});
   }
 }
 

--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -590,7 +590,6 @@ uint32_t FindMemoryType(const VulkanDevice& device, VkBufferCreateInfo info,
     type_bits >>= 1;
   }
   LOG(FATAL) << "Requested memory type not found";
-  return 0;
 }
 
 VulkanHostVisibleBuffer* GetOrAllocate(

--- a/src/support/base64.h
+++ b/src/support/base64.h
@@ -245,7 +245,6 @@ class Base64OutStream : public dmlc::Stream {
   }
   virtual size_t Read(void* ptr, size_t size) {
     LOG(FATAL) << "Base64OutStream do not support read";
-    return 0;
   }
   /*!
    * \brief finish writing of all current base64 stream, do some post processing

--- a/src/support/scalars.cc
+++ b/src/support/scalars.cc
@@ -170,7 +170,6 @@ IntImm ValueToIntImm(int64_t value, int width) {
     return IntImm(kInt64, value);
   } else {
     LOG(FATAL) << "Unrecognized int scalar width: " << width;
-    return {};
   }
 }
 
@@ -190,7 +189,6 @@ FloatImm ValueToFloatImm(double value, int width) {
     return FloatImm(kFloat64, value);
   } else {
     LOG(FATAL) << "Unrecognized float scalar width: " << width;
-    return {};
   }
 }
 

--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -553,7 +553,6 @@ class TCPSocket : public Socket {
       if (ret == -1) {
         if (LastErrorWouldBlock()) {
           LOG(FATAL) << "would block";
-          return ndone;
         }
         Socket::Error("RecvAll");
       }

--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -198,7 +198,6 @@ class CodeGenAMDGPU : public CodeGenLLVM {
       return builder_->CreateCall(f, {});
     } else {
       LOG(FATAL) << "Do not support sync " << sync;
-      return nullptr;
     }
   }
 

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -423,7 +423,6 @@ CodeGenLLVM::TypedPointer CodeGenCPU::CreateStructRefPtr(DataType t, llvm::Value
     }
     default:
       LOG(FATAL) << "unknown field code";
-      return TypedPointer();
   }
 }
 
@@ -1440,7 +1439,6 @@ llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
         return builder_->CreateAlloca(t_tvm_array_, num);
       } else {
         LOG(FATAL) << "Unknown stack alloca type " << type;
-        return nullptr;
       }
     });
   } else {

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -128,7 +128,6 @@ std::unique_ptr<CodeGenLLVM> CodeGenLLVM::Create(LLVMTarget* llvm_target) {
     return std::unique_ptr<CodeGenLLVM>(static_cast<CodeGenLLVM*>(handle));
   } else {
     LOG(FATAL) << "unable to create codegen for target " << target;
-    return nullptr;  // unreachable
   }
 }
 
@@ -347,15 +346,9 @@ void CodeGenLLVM::AddMainFunction(const std::string& entry_func_name) {
   LOG(FATAL) << "not implemented";
 }
 
-llvm::Value* CodeGenLLVM::GetThreadIndex(const IterVar& iv) {
-  LOG(FATAL) << "not implemented";
-  return nullptr;
-}
+llvm::Value* CodeGenLLVM::GetThreadIndex(const IterVar& iv) { LOG(FATAL) << "not implemented"; }
 
-llvm::Value* CodeGenLLVM::CreateStorageSync(const CallNode* op) {
-  LOG(FATAL) << "not implemented";
-  return nullptr;
-}
+llvm::Value* CodeGenLLVM::CreateStorageSync(const CallNode* op) { LOG(FATAL) << "not implemented"; }
 
 #if TVM_LLVM_VERSION >= 160
 
@@ -547,7 +540,6 @@ llvm::Type* CodeGenLLVM::GetLLVMType(const Type& type) const {
     return t_void_;
   } else {
     LOG(FATAL) << "Type " << type << " does not have a corresponding LLVM Type";
-    return t_void_;
   }
 }
 
@@ -1382,14 +1374,12 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
   } else if (op->op.same_as(builtin::atomic_add())) {
     // TODO(masahi): Support atomic for CPU backend
     LOG(FATAL) << "CPU backend does not support atomic add yet.";
-    return nullptr;
   } else if (op->op.same_as(builtin::start_profile_intrinsic()) ||
              op->op.same_as(builtin::end_profile_intrinsic())) {
     LOG(INFO) << "Ignoring profile_intrinsic ... " << op->op;
     return nullptr;
   } else {
     LOG(FATAL) << "unknown intrinsic " << op->op;
-    return nullptr;
   }
 }
 
@@ -1562,7 +1552,6 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const LetNode* op) {
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const LoadNode* op) {
   LOG(FATAL) << "Unexpected deprecated LoadNode.  Use BufferLoadNode instead.";
-  return nullptr;
 }
 
 bool CodeGenLLVM::HasAlignmentPadding(DataType dtype) {
@@ -1721,7 +1710,6 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
   } else {
     ICHECK(op->op.as<GlobalVarNode>());
     LOG(FATAL) << "Do not yet support cross function call";
-    return nullptr;
   }
 }
 

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -179,7 +179,6 @@ class CodeGenNVPTX : public CodeGenLLVM {
       return builder_->CreateCall(f, {});
     } else {
       LOG(FATAL) << "Do not support sync " << sync;
-      return nullptr;
     }
   }
 

--- a/src/target/source/ptx.cc
+++ b/src/target/source/ptx.cc
@@ -121,7 +121,6 @@ inline DataType DTypeFromString(const std::string str) {
     return DataType::kBit64;
   } else {
     LOG(FATAL) << "Unrecognized PTX data type " << str;
-    return DataType(0);
   }
 }
 
@@ -162,7 +161,6 @@ LayoutType LayoutTypeFromString(const std::string& str) {
     return LayoutType::kColumnMajor;
   } else {
     LOG(FATAL) << "Unrecognized layout type " << str;
-    return LayoutType::kRowMajor;
   }
 }
 

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -199,7 +199,6 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const FloatImmNode* op) {
 
 spirv::Value CodeGenSPIRV::VisitExpr_(const StringImmNode* op) {
   LOG(FATAL) << "StringImm is not supported in Device code";
-  return spirv::Value();
 }
 
 spirv::Value CodeGenSPIRV::VisitExpr_(const CastNode* op) {
@@ -398,7 +397,6 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const CallNode* op) {
     return spirv::Value();
   } else {
     LOG(FATAL) << "Unresolved call  " << op->op;
-    return spirv::Value();
   }
 }
 

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -504,7 +504,6 @@ std::string TargetInternal::StringifyAtomicType(const ObjectRef& obj) {
     return u;
   }
   LOG(FATAL) << "Cannot stringify this object";
-  return "";  // unreachable
 }
 
 std::string TargetInternal::StringifyArray(const ArrayNode& array) {

--- a/src/te/autodiff/jacobian.cc
+++ b/src/te/autodiff/jacobian.cc
@@ -119,7 +119,6 @@ class JacobianMutator : public ExprMutator {
       return FloatImm(expr.dtype(), 0.0);
     } else {
       LOG(FATAL) << "Derivative of this intrinsic is not implemented: " << op->op;
-      return PrimExpr();
     }
   }
 

--- a/src/te/schedule/schedule_dataflow_rewrite.cc
+++ b/src/te/schedule/schedule_dataflow_rewrite.cc
@@ -459,7 +459,6 @@ Tensor Schedule::cache_write(const Tensor& tensor, const std::string& scope) {
     return (CacheWriteWithReLayoutTensor(*this, {tensor}, scope))[0];
   } else {
     LOG(FATAL) << "cache write only take ComputeOp or TensorComputeOp as writers";
-    return Tensor();
   }
 }
 

--- a/src/tir/analysis/stmt_finding.cc
+++ b/src/tir/analysis/stmt_finding.cc
@@ -98,7 +98,6 @@ Stmt GetEnclosingLoop(const BlockNode* block, Stmt func_body) {
   }
 
   LOG(FATAL) << "Enclosing loop not found for a block " << GetRef<Block>(block);
-  return Stmt();
 }
 
 const BlockNode* FindAnchorBlock(const IRModule& mod) {

--- a/src/tir/ir/expr_functor.cc
+++ b/src/tir/ir/expr_functor.cc
@@ -127,7 +127,6 @@ PrimExpr ExprMutator::VisitExpr_(const AnyNode* op) { return GetRef<PrimExpr>(op
 
 PrimExpr ExprMutator::VisitExpr_(const LoadNode* op) {
   LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-  return PrimExpr();
 }
 
 PrimExpr ExprMutator::VisitExpr_(const BufferLoadNode* op) {

--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -371,7 +371,6 @@ Stmt StmtMutator::VisitStmt_(const IfThenElseNode* op) {
 
 Stmt StmtMutator::VisitStmt_(const StoreNode* op) {
   LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-  return Stmt();
 }
 
 Stmt StmtMutator::VisitStmt_(const BufferStoreNode* op) {
@@ -676,12 +675,10 @@ class IRSubstitute : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -57,7 +57,6 @@ runtime::DataType GetRuntimeDataType(const Type& type) {
     return DataType::Void();
   } else {
     LOG(FATAL) << "Type " << type << " does not have a corresponding runtime::DataType";
-    return DataType::Handle();
   }
 }
 
@@ -206,7 +205,6 @@ PrimExpr max_value(const DataType& dtype, Span span) {
     return FloatImm(dtype, std::numeric_limits<float>::max(), span);
   }
   LOG(FATAL) << "Cannot decide max_value for type" << dtype;
-  return PrimExpr();
 }
 
 PrimExpr min_value(const DataType& dtype, Span span) {
@@ -241,7 +239,6 @@ PrimExpr min_value(const DataType& dtype, Span span) {
     return FloatImm(dtype, std::numeric_limits<float>::lowest(), span);
   }
   LOG(FATAL) << "Cannot decide min_value for type" << dtype;
-  return PrimExpr();
 }
 
 // infinity
@@ -256,7 +253,6 @@ PrimExpr infinity(const DataType& dtype, Span span) {
     }
   }
   LOG(FATAL) << "Cannot decide infinity for type " << dtype;
-  return PrimExpr();
 }
 
 namespace tir {
@@ -710,7 +706,6 @@ PrimExpr isnan(PrimExpr x, Span span) {
     }
   } else {
     LOG(FATAL) << "Data type " << x.dtype() << " not supported for isnan op. Skipping isnan op...";
-    return x;
   }
 }
 
@@ -724,7 +719,6 @@ PrimExpr isinf(PrimExpr x, Span span) {
     return abs(x, span) == infX && !isnan(x, span);
   } else {
     LOG(FATAL) << "Data type " << x.dtype() << " not supported for finiteness ops. Skipping it...";
-    return x;
   }
 }
 

--- a/src/tir/schedule/primitive/cache_index.cc
+++ b/src/tir/schedule/primitive/cache_index.cc
@@ -384,7 +384,6 @@ class CacheIndexRewriter : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
  private:

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -686,7 +686,6 @@ class CacheReadRewriter : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   PrimExpr VisitExpr_(const VarNode* op) final {
@@ -806,12 +805,10 @@ class CacheWriteRewriter : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const VarNode* op) final {

--- a/src/tir/schedule/primitive/compute_inline.cc
+++ b/src/tir/schedule/primitive/compute_inline.cc
@@ -263,12 +263,10 @@ class BaseInliner : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   Stmt VisitStmt_(const ForNode* loop) final {

--- a/src/tir/schedule/primitive/layout_transformation.cc
+++ b/src/tir/schedule/primitive/layout_transformation.cc
@@ -587,7 +587,6 @@ class TransformLayoutPlanner : private StmtExprVisitor {
         return info.innermost_block_realize.value();
       } else {
         LOG(FATAL) << "Write occured outside of any block/loop";
-        return Stmt();
       }
     }();
     return EpiloguePlan{insert_after, stmt};

--- a/src/tir/transforms/bf16_legalize.cc
+++ b/src/tir/transforms/bf16_legalize.cc
@@ -260,7 +260,6 @@ class BF16LowerRewriter : public StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {
@@ -277,7 +276,6 @@ class BF16LowerRewriter : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   PrimExpr VisitExpr_(const FloatImmNode* op) final {

--- a/src/tir/transforms/bound_checker.cc
+++ b/src/tir/transforms/bound_checker.cc
@@ -80,12 +80,10 @@ class BoundChecker : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {

--- a/src/tir/transforms/inject_double_buffer.cc
+++ b/src/tir/transforms/inject_double_buffer.cc
@@ -172,12 +172,10 @@ class DoubleBufferInjector : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {

--- a/src/tir/transforms/inject_virtual_thread.cc
+++ b/src/tir/transforms/inject_virtual_thread.cc
@@ -247,12 +247,10 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
   // Load
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
   // Store
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
   // BufferLoad
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {
@@ -379,7 +377,6 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
   Stmt VisitStmt_(const WhileNode* op) final {
     // TODO(masahi): What should we do for While nodes?
     LOG(FATAL) << "WhileNode in InjectVirtualThread not supported yet";
-    return Stmt();
   }
 
   // Seq
@@ -528,7 +525,6 @@ class VirtualThreadInjector : public arith::IRMutatorWithAnalyzer {
 
   Stmt VisitStmt_(const ProducerStoreNode* op) final {
     LOG(FATAL) << "Need to call StorageFlatten first";
-    return GetRef<Stmt>(op);
   }
 };
 

--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -112,12 +112,10 @@ class IRConvertSSA final : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/transforms/lift_attr_scope.cc
+++ b/src/tir/transforms/lift_attr_scope.cc
@@ -160,7 +160,6 @@ class AttrScopeLifter : public StmtMutator {
   Stmt VisitStmt_(const WhileNode* op) final {
     // TODO(masahi): Do we need a special handling for While nodes?
     LOG(FATAL) << "WhileNode not supported in LiftAttrScope.";
-    return Stmt();
   }
 
  private:

--- a/src/tir/transforms/lower_custom_datatypes.cc
+++ b/src/tir/transforms/lower_custom_datatypes.cc
@@ -105,12 +105,10 @@ class CustomDatatypesLowerer : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -111,12 +111,10 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/transforms/lower_warp_memory.cc
+++ b/src/tir/transforms/lower_warp_memory.cc
@@ -295,12 +295,10 @@ class WarpAccessRewriter : protected StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) override {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const LoadNode* op) override {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const BufferStoreNode* op) override {

--- a/src/tir/transforms/merge_dynamic_shared_memory_allocations.cc
+++ b/src/tir/transforms/merge_dynamic_shared_memory_allocations.cc
@@ -309,12 +309,10 @@ class DynamicSharedMemoryRewriter : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -226,12 +226,10 @@ class NarrowDataTypeRewriter : public IndexDataTypeRewriter {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   PrimExpr VisitExpr_(const VarNode* op) final {

--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -159,12 +159,10 @@ class RenewDefMutator : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
  private:

--- a/src/tir/transforms/rewrite_unsafe_select.cc
+++ b/src/tir/transforms/rewrite_unsafe_select.cc
@@ -69,7 +69,6 @@ class UnsafeExprDetector : public ExprFunctor<bool(const PrimExpr& n)> {
   }
   bool VisitExpr_(const LoadNode* op) {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return true;
   }
   bool VisitExpr_(const AddNode* op) final { return BinaryOp(op); }
   bool VisitExpr_(const SubNode* op) final { return BinaryOp(op); }

--- a/src/tir/transforms/simplify.cc
+++ b/src/tir/transforms/simplify.cc
@@ -209,7 +209,6 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   // eliminate useless stores

--- a/src/tir/transforms/split_host_device.cc
+++ b/src/tir/transforms/split_host_device.cc
@@ -114,7 +114,6 @@ class VarUseDefAnalysis : public StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {
@@ -167,7 +166,6 @@ class VarUseDefAnalysis : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {

--- a/src/tir/transforms/storage_flatten.cc
+++ b/src/tir/transforms/storage_flatten.cc
@@ -848,12 +848,10 @@ class BufferBindUnwrapper : public StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
@@ -1206,7 +1204,6 @@ class BufferBindUnwrapper : public StmtExprMutator {
       return buf_map_[buffer.get()];
     } else {
       LOG(FATAL) << "Can't work around the undefined buffer";
-      return *static_cast<BufferEntry*>(nullptr);
     }
   }
 
@@ -1391,12 +1388,10 @@ class StorageFlattener : public StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -418,12 +418,10 @@ class StoragePlanRewriter : public StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   template <typename Node>
@@ -1418,12 +1416,10 @@ class VectorTypeRewriter : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   template <typename Node>

--- a/src/tir/transforms/thread_storage_sync.cc
+++ b/src/tir/transforms/thread_storage_sync.cc
@@ -316,12 +316,10 @@ class ThreadSyncInserter : public StmtExprMutator {
   }
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {
     if (sync_scope_.rank == StorageRank::kGlobal &&

--- a/src/tir/transforms/unroll_loop.cc
+++ b/src/tir/transforms/unroll_loop.cc
@@ -135,7 +135,6 @@ class LoopUnroller : public StmtExprMutator {
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   Stmt VisitStmt_(const BufferStoreNode* op) final {

--- a/src/tir/transforms/update_pointer_storage_scope.cc
+++ b/src/tir/transforms/update_pointer_storage_scope.cc
@@ -96,7 +96,6 @@ Buffer UpdatePointerStorageScope::GetUpdatedBuffer(Buffer buf) {
 
 PrimExpr UpdatePointerStorageScope::VisitExpr_(const LoadNode* op) {
   LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-  return PrimExpr();
 }
 
 PrimExpr UpdatePointerStorageScope::VisitExpr_(const BufferLoadNode* op) {
@@ -106,7 +105,6 @@ PrimExpr UpdatePointerStorageScope::VisitExpr_(const BufferLoadNode* op) {
 
 Stmt UpdatePointerStorageScope::VisitStmt_(const StoreNode* op) {
   LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-  return Stmt();
 }
 
 Stmt UpdatePointerStorageScope::VisitStmt_(const BufferStoreNode* op) {

--- a/src/tir/transforms/vectorize_loop.cc
+++ b/src/tir/transforms/vectorize_loop.cc
@@ -65,12 +65,10 @@ class VecAllocAccess : public StmtExprMutator {
 
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
 
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated StoreNode.  Please use BufferStoreNode instead.";
-    return Stmt();
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {
@@ -372,7 +370,6 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   // Load
   PrimExpr VisitExpr_(const LoadNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return PrimExpr();
   }
   // BufferLoad
   PrimExpr VisitExpr_(const BufferLoadNode* op) final {
@@ -420,7 +417,6 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   // Store
   Stmt VisitStmt_(const StoreNode* op) final {
     LOG(FATAL) << "Unexpected use of deprecated LoadNode.  Please use BufferLoadNode instead.";
-    return Stmt();
   }
   // BufferStore
   Stmt VisitStmt_(const BufferStoreNode* op) final {
@@ -504,7 +500,6 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   // While
   Stmt VisitStmt_(const WhileNode* op) final {
     LOG(FATAL) << "A while loop inside a vectorized loop not supported.";
-    return Stmt();
   }
   // LetStmt
   Stmt VisitStmt_(const LetStmtNode* op) final {
@@ -573,7 +568,6 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   // ProducerStore
   Stmt VisitStmt_(const ProducerStoreNode* op) final {
     LOG(FATAL) << "ProducerProvide cannot appear in a TIR PrimFunc";
-    return Stmt();
   }
 
  private:

--- a/src/tir/usmp/algo/hill_climb.cc
+++ b/src/tir/usmp/algo/hill_climb.cc
@@ -249,7 +249,6 @@ class HillClimbAllocator : public GreedyBase {
         return it->second;
       }
       LOG(FATAL) << "node is not indexed in the _pos_map";
-      return -1;
     };
 
     for (; attempts < _max_attempts; ++attempts) {

--- a/vta/runtime/runtime.cc
+++ b/vta/runtime/runtime.cc
@@ -955,7 +955,6 @@ class InsnQueue : public BaseQueue<VTAGenericInsn> {
       return kStoreStage;
     }
     LOG(FATAL) << "not reached";
-    return kNoneStage;
   }
 
   // Get stage of memory and computation

--- a/web/emcc/webgpu_runtime.cc
+++ b/web/emcc/webgpu_runtime.cc
@@ -105,27 +105,17 @@ class WebGPUDeviceAPI : public DeviceAPI {
   }
 
  public:
-  TVMStreamHandle CreateStream(Device dev) final {
-    LOG(FATAL) << "Not implemented";
-    return nullptr;
-  }
+  TVMStreamHandle CreateStream(Device dev) final { LOG(FATAL) << "Not implemented"; }
 
-  void FreeStream(Device dev, TVMStreamHandle stream) final {
-    LOG(FATAL) << "Not implemented";
-    return;
-  }
+  void FreeStream(Device dev, TVMStreamHandle stream) final { LOG(FATAL) << "Not implemented"; }
 
   void SyncStreamFromTo(Device dev, TVMStreamHandle event_src, TVMStreamHandle event_dst) {
     LOG(FATAL) << "Not implemented";
-    return;
   }
 
   void StreamSync(Device dev, TVMStreamHandle stream) final { LOG(FATAL) << "Not implemented"; }
 
-  void SetStream(Device dev, TVMStreamHandle stream) final {
-    LOG(FATAL) << "Not implemented";
-    return;
-  }
+  void SetStream(Device dev, TVMStreamHandle stream) final { LOG(FATAL) << "Not implemented"; }
 
   void* AllocWorkspace(Device dev, size_t size, DLDataType type_hint) final {
     return WebGPUThreadEntry::ThreadLocal()->pool.AllocWorkspace(dev, size);


### PR DESCRIPTION
Using `LOG(FATAL) << "some error message";` throws an exception when the internal `LogFatal` object is constructed.  However, the gcc warning "control reaches end of non-void function" resulted in a common pattern where a `LOG(FATAL)` statement was immediately followed by return of a default value, in order to suppress the warning.

This commit marks the `LogFatal::~LogFatal` destructor with the C++11 attribute `[[noreturn]]`, indicating that calls into it will not resume the normal control flow.  This suppresses the warning without requiring the extra `return` statement after `LOG(FATAL)`, as the compiler knows that control flow will not resume after `LOG(FATAL)`.