### PR TITLE
Mark base64.h encode and decode API's as inline

### DIFF
--- a/src/contrib/torch/base64.h
+++ b/src/contrib/torch/base64.h
@@ -36,7 +36,7 @@
 namespace tvm {
 namespace support {
 
-size_t b64strlen(const std::string b64str) {
+inline size_t b64strlen(const std::string b64str) {
   ICHECK(b64str.size() % 4 == 0) << "invalid base64 encoding";
   size_t length = b64str.size() / 4 * 3;
   if (b64str[b64str.size() - 2] == '=') {
@@ -47,7 +47,7 @@ size_t b64strlen(const std::string b64str) {
   return length;
 }
 
-void b64decode(const std::string b64str, u_char* ret) {
+inline void b64decode(const std::string b64str, u_char* ret) {
   size_t index = 0;
   const auto length = b64str.size();
   for (size_t i = 0; i < length; i += 4) {


### PR DESCRIPTION
The b64strlen & b64decode API's are defined in a header and will cause linker issues if included in multiple files. We ran into this issue while attempting to use this file in our project.