### PR TITLE
[TIR] Fix remaining dtype mismatch issue caused by SubspaceDivide

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -1912,7 +1912,7 @@ class SubspaceDivider {
       return DivisionResult::Failure();
     }
     bool need_predicate = !analyzer_->CanProveEqual(extent, mark_extent);
-    const IterMark& outer_mark = MarkFromArgsAndBase(outer_args, 0);
+    const IterMark& outer_mark = MarkFromArgsAndBase(outer_args, make_const(dtype, 0));
     const IterMark& inner_mark = MarkFromArgsAndBase(inner_args, expr->base);
     IterSumExpr outer_source = Downcast<IterSumExpr>(outer_mark->source);
     IterSumExpr inner_source = Downcast<IterSumExpr>(inner_mark->source);


### PR DESCRIPTION
Apparently a left-over from https://github.com/apache/tvm/pull/13069. I have a complex test that would hit a dtype-mismatch error because of this, but I don't know how to create a simple repro test. Hopefully it is ok as this is a follow-up to 13069?

cc @vinx13 