### PR TITLE
[ci] Fix upload_ci_resource.yml and update related documentation

### DIFF
--- a/.github/workflows/upload_ci_resource.yml
+++ b/.github/workflows/upload_ci_resource.yml
@@ -57,4 +57,4 @@ jobs:
           aws s3 cp downloaded_file "s3://tvm-ci-resources/$UPLOAD_PATH"
           echo "The item is available at https://tvm-ci-resources.s3.us-west-2.amazonaws.com/$UPLOAD_PATH"
           echo "Add this line to tests/scripts/request_hook/request_hook.py"
-          echo "    \"$URL\": f\"{BASE}/$UPLOAD_PATH\",
+          echo "    \"$URL\": f\"{BASE}/$UPLOAD_PATH\","

--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -25,7 +25,8 @@ from urllib.parse import quote
 LOGGER = None
 
 
-# To update this list, run the workflow <HERE> with the URL to download and the SHA512 of the file
+# To update this list, run https://github.com/apache/tvm/actions/workflows/upload_ci_resource.yml
+# with the URL to download and the SHA-256 hash of the file.
 BASE = "https://tvm-ci-resources.s3.us-west-2.amazonaws.com"
 URL_MAP = {
     "http://data.mxnet.io.s3-website-us-west-1.amazonaws.com/data/val_256_q90.rec": f"{BASE}/mxnet-val_256_q90.rec",
@@ -217,8 +218,8 @@ class TvmRequestHook(urllib.request.Request):
             # Dis-allow any accesses that aren't going through S3
             msg = (
                 f"Uncaught URL found in CI: {url}. "
-                "A committer must upload the relevant file to S3 via"
-                "https://github.com/apache/tvm/actions/workflows/upload_ci_resource.yml"
+                "A committer must upload the relevant file to S3 via "
+                "https://github.com/apache/tvm/actions/workflows/upload_ci_resource.yml "
                 "and add it to the mapping in tests/scripts/request_hook/request_hook.py"
             )
             raise RuntimeError(msg)


### PR DESCRIPTION
The workflow https://github.com/apache/tvm/actions/workflows/upload_ci_resource.yml uses SHA-256, not SHA-512 hashes. This  PR fixes a comment in `request_hook.py` to reflect this, and fixes some other formatting too.

It also adds a trailing quote to `upload_ci_resource.yml' to prevent it from failing (e.g. https://github.com/apache/tvm/actions/runs/3629030778/jobs/6120748470). 

@driazati can you review and merge?