### PR TITLE
[ci] Add a workflow to update a nightly branch

### DIFF
--- a/.github/workflows/update_nightly_branch.yml
+++ b/.github/workflows/update_nightly_branch.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Update a branch for nightly test results
+name: Update nightly branch
+
+on:
+  schedule:
+    # 9 PM PST
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: update-nightly-branch
+  cancel-in-progress: true
+
+jobs:
+  update-nightly-branch:
+    if: github.repository == 'driazati/tvm'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update nightly branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eux
+          git checkout -B nightly
+          git log -5
+          git push origin --force nightly


### PR DESCRIPTION
This adds a `nightly` branch that is updated once per day with a
    specific TVM commit to enable third-parties to synchronize on which TVM
    commit to test. A batch of commits is added once per day and tests
    should be run on the `HEAD` of that batch.

Tested in https://github.com/driazati/tvm/actions/runs/3632546266/jobs/6128517495
