### PR TITLE
[ci] Make tvm-bot aware of platform specific jobs

### DIFF
--- a/ci/scripts/github/github_tvmbot.py
+++ b/ci/scripts/github/github_tvmbot.py
@@ -530,12 +530,26 @@ class PR:
             return None
 
     def rerun_jenkins_ci(self) -> None:
-        url = JENKINS_URL + f"job/tvm/job/PR-{self.number}/buildWithParameters"
-        logging.info(f"Rerunning ci with URL={url}")
-        if self.dry_run:
-            logging.info("Dry run, not sending POST")
-        else:
-            post(url, auth=("tvm-bot", TVM_BOT_JENKINS_TOKEN))
+        job_names = [
+            "tvm-arm",
+            "tvm-cortexm",
+            "tvm-cpu",
+            "tvm-docker",
+            "tvm-gpu",
+            "tvm-hexagon",
+            "tvm-i386",
+            "tvm-lint",
+            "tvm-minimal",
+            "tvm-riscv",
+            "tvm-wasm",
+        ]
+        for name in job_names:
+            url = JENKINS_URL + f"job/{name}/job/PR-{self.number}/buildWithParameters"
+            logging.info(f"Rerunning ci with URL={url}")
+            if self.dry_run:
+                logging.info("Dry run, not sending POST")
+            else:
+                post(url, auth=("tvm-bot", TVM_BOT_JENKINS_TOKEN))
 
     def rerun_github_actions(self) -> None:
         workflow_ids = []
@@ -684,11 +698,13 @@ class Rerun:
         try:
             pr.rerun_jenkins_ci()
         except Exception as e:
+            logging.exception(e)
             errors.append(e)
 
         try:
             pr.rerun_github_actions()
         except Exception as e:
+            logging.exception(e)
             errors.append(e)
 
         if len(errors) > 0:

--- a/ci/scripts/jenkins/git_utils.py
+++ b/ci/scripts/jenkins/git_utils.py
@@ -35,7 +35,7 @@ def compress_query(query: str) -> str:
 
 
 def post(url: str, body: Optional[Any] = None, auth: Optional[Tuple[str, str]] = None):
-    logging.info(f"Requesting POST to", url, "with", body)
+    logging.info(f"Requesting POST to {url} with {body}")
     headers = {}
     req = request.Request(url, headers=headers, method="POST")
     if auth is not None:


### PR DESCRIPTION
See #13337 for more context, this fixes `@tvm-bot rerun` to work with
the new jobs