### PR TITLE
[ETHOSN] Remove inference test

### DIFF
--- a/tests/cpp/runtime/contrib/ethosn/inference_test.cc
+++ b/tests/cpp/runtime/contrib/ethosn/inference_test.cc
@@ -43,18 +43,6 @@ TEST(WaitForInference, InferenceScheduled) {
   ICHECK_EQ(result.GetErrorDescription(), "Timed out while waiting for the inference to complete.");
 }
 
-TEST(WaitForInference, InferenceRunning) {
-  const int inference_result = 1 /* Running */;
-  const int timeout = 0;
-
-  dl::Inference inference = dl::Inference(inference_result);
-  InferenceWaitStatus result = WaitForInference(&inference, timeout);
-
-  ASSERT_EQ(result.GetErrorCode(), InferenceWaitErrorCode::kTimeout);
-  std::cout << result.GetErrorDescription() << std::endl;
-  ICHECK_EQ(result.GetErrorDescription(), "Timed out while waiting for the inference to complete.");
-}
-
 TEST(WaitForInference, InferenceError) {
   const int inference_result = 3 /* Error */;
   const int timeout = 0;


### PR DESCRIPTION
This test was causing cpptest to fail without reporting the test as having failed. Looking back, this test doesn't really make much sense as we are passing a file descriptor stating that inference is running when it isn't. Therefore, removing the test.

cc @ekalda @ashutosh-arm 