### PR TITLE
[FQ2I] Support converting `dense` -> `add` to `qnn.dense` -> `add` -> `requantize`

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1391,9 +1391,9 @@ class Gemm(OnnxOpConverter):
         dtype = input0_state.checked_type.dtype
         # Y = alpha * A * B + beta * C
         alpha = float(attr.get("alpha", 1.0))
+        beta = float(attr.get("beta", 1.0))
         transA = int(attr.get("transA", 0))
         transB = int(attr.get("transB", 0))
-        beta = attr.get("beta")
         # get number of channels
         channels = infer_channels(inputs[1], not transB)
         if transA:
@@ -1406,10 +1406,10 @@ class Gemm(OnnxOpConverter):
             inputs[0] *= _expr.const(alpha, dtype=dtype)
         out = _op.nn.dense(inputs[0], inputs[1], units=channels)
         if len(inputs) == 3:
-            if beta is None:
-                out = out + inputs[2]
+            if beta != 1.0:
+                out += _expr.const(float(beta), dtype=dtype) * inputs[2]
             else:
-                out = out + _expr.const(float(beta), dtype=dtype) * inputs[2]
+                out += inputs[2]
         return out
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1391,7 +1391,7 @@ class Gemm(OnnxOpConverter):
         dtype = input0_state.checked_type.dtype
         # Y = alpha * A * B + beta * C
         alpha = float(attr.get("alpha", 1.0))
-        beta = float(attr.get("beta", 1.0))
+        beta = float(attr.get("beta"))
         transA = int(attr.get("transA", 0))
         transB = int(attr.get("transB", 0))
         # get number of channels
@@ -1406,10 +1406,10 @@ class Gemm(OnnxOpConverter):
             inputs[0] *= _expr.const(alpha, dtype=dtype)
         out = _op.nn.dense(inputs[0], inputs[1], units=channels)
         if len(inputs) == 3:
-            if beta != 1.0:
-                out = out + _expr.const(beta, dtype=dtype) * inputs[2]
-            else:
+            if beta is None:
                 out = out + inputs[2]
+            else:
+                out = out + _expr.const(beta, dtype=dtype) * inputs[2]
         return out
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4434,12 +4434,6 @@ class QuantizeLinear(OnnxOpConverter):
         return _qnn.op.quantize(data, scale, _op.cast(zp, "int32"), axis, out_dtype)
 
 
-def asscalar(v):
-    if len(v.data.shape) == 1 and v.data.shape[0] == 1:
-        v = _op.const(v.data.numpy().item(), v.data.dtype)
-    return v
-
-
 class DequantizeLinear(OnnxOpConverter):
     """Operator converter for QuantizeLinear."""
 
@@ -4451,9 +4445,6 @@ class DequantizeLinear(OnnxOpConverter):
     @classmethod
     def _impl_v13(cls, inputs, attr, params):
         data, scale, zp = inputs
-        scale = asscalar(scale)
-        zp = asscalar(zp)
-
         axis = attr.get("axis", 1)
         if len(infer_shape(data)) <= 1:
             axis = 0

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1391,9 +1391,9 @@ class Gemm(OnnxOpConverter):
         dtype = input0_state.checked_type.dtype
         # Y = alpha * A * B + beta * C
         alpha = float(attr.get("alpha", 1.0))
-        beta = float(attr.get("beta"))
         transA = int(attr.get("transA", 0))
         transB = int(attr.get("transB", 0))
+        beta = attr.get("beta")
         # get number of channels
         channels = infer_channels(inputs[1], not transB)
         if transA:
@@ -1409,7 +1409,7 @@ class Gemm(OnnxOpConverter):
             if beta is None:
                 out = out + inputs[2]
             else:
-                out = out + _expr.const(beta, dtype=dtype) * inputs[2]
+                out = out + _expr.const(float(beta), dtype=dtype) * inputs[2]
         return out
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1406,7 +1406,10 @@ class Gemm(OnnxOpConverter):
             inputs[0] *= _expr.const(alpha, dtype=dtype)
         out = _op.nn.dense(inputs[0], inputs[1], units=channels)
         if len(inputs) == 3:
-            out = out + _expr.const(beta, dtype=dtype) * inputs[2]
+            if beta != 1.0:
+                out = out + _expr.const(beta, dtype=dtype) * inputs[2]
+            else:
+                out = out + inputs[2]
         return out
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4434,6 +4434,12 @@ class QuantizeLinear(OnnxOpConverter):
         return _qnn.op.quantize(data, scale, _op.cast(zp, "int32"), axis, out_dtype)
 
 
+def asscalar(v):
+    if len(v.data.shape) == 1 and v.data.shape[0] == 1:
+        v = _op.const(v.data.numpy().item(), v.data.dtype)
+    return v
+
+
 class DequantizeLinear(OnnxOpConverter):
     """Operator converter for QuantizeLinear."""
 
@@ -4445,6 +4451,9 @@ class DequantizeLinear(OnnxOpConverter):
     @classmethod
     def _impl_v13(cls, inputs, attr, params):
         data, scale, zp = inputs
+        scale = asscalar(scale)
+        zp = asscalar(zp)
+
         axis = attr.get("axis", 1)
         if len(infer_shape(data)) <= 1:
             axis = 0

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -520,12 +520,12 @@ def register_binary_qnn(op_name, op):
 
         assert (
             len(out_t.scale.data.shape) == 0
-        ), "The output scale of QNN binary operators needs to be a scalar, but got a tensor of shape {}".format(
+        ), "The output scale needs to be a scalar, but got a tensor of shape {}".format(
             out_t.scale.data.shape
         )
         assert (
             len(out_t.zero_point.data.shape) == 0
-        ), "The output zero point of QNN binary operators needs to be a scalar, but got a tensor of shape {}".format(
+        ), "The output zero point needs to be a scalar, but got a tensor of shape {}".format(
             out_t.zero_point.data.shape
         )
 

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -27,7 +27,6 @@ from tvm.tir import bijective_layout
 
 from ..op import register_fake_quantization_to_integer
 
-
 def fold_constant(expr):
     return relay.transform.FoldConstantExpr(expr, tvm.IRModule())
 
@@ -510,7 +509,7 @@ def register_binary_qnn(op_name, op):
             and approx_equal(left_t.scale, out_t.scale)
             and approx_equal(left_t.zero_point, out_t.zero_point)
         ):
-            return [expr, left_t]
+            return [relay.expr.Call(relay.op.get(op_name), [left, right]), left_t]
 
         out = op(
             left,

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -508,6 +508,7 @@ def register_binary_qnn(op_name, op):
             and tvm.ir.structural_equal(left_t.dtype, right_t.dtype)
             and approx_equal(left_t.scale, out_t.scale)
             and approx_equal(left_t.zero_point, out_t.zero_point)
+            and np.all(out_t.zero_point.data.numpy() == 0)
         ):
             return [relay.expr.Call(relay.op.get(op_name), [left, right]), left_t]
 

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -515,9 +515,11 @@ def register_binary_qnn(op_name, op):
         ):
             # If this add op comes after conv2d or dense, out_t.scale and out_t.zero_point
             # can be a vector, which is not supported by QNN binary operators.
-            # In particular, the pattern of an `add` op following `dense` can appear often and
-            # hit this code path, where the addition is really a bias addtion.
-            # We identify that pattern and convert it to `qnn.dense` -> `add`.
+            # In particular, the pattern of an `add` op following `dense`, where the addition is
+            # really a bias addtion, can come up often. We identify that pattern and convert it to
+            # `qnn.dense` -> `add`.
+            # To avoid overflow, we do this conversion only when the input data type is 32 bit (bias
+            # addition is typically done in 32 bit).
             return [left + right, left_t]
 
         assert (

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -502,6 +502,16 @@ def register_binary_qnn(op_name, op):
 
     def binary(expr, type_map):
         left, right, left_t, right_t, out_t = get_binary_types(expr, type_map)
+
+        if (
+            approx_equal(left_t.scale, right_t.scale)
+            and approx_equal(left_t.zero_point, right_t.zero_point)
+            and tvm.ir.structural_equal(left_t.dtype, right_t.dtype)
+            and approx_equal(left_t.scale, out_t.scale)
+            and approx_equal(left_t.zero_point, out_t.zero_point)
+        ):
+            return [expr, left_t]
+
         out = op(
             left,
             right,

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -27,6 +27,7 @@ from tvm.tir import bijective_layout
 
 from ..op import register_fake_quantization_to_integer
 
+
 def fold_constant(expr):
     return relay.transform.FoldConstantExpr(expr, tvm.IRModule())
 
@@ -511,6 +512,17 @@ def register_binary_qnn(op_name, op):
             and np.all(out_t.zero_point.data.numpy() == 0)
         ):
             return [relay.expr.Call(relay.op.get(op_name), [left, right]), left_t]
+
+        assert (
+            len(out_t.scale.data.shape) == 0
+        ), "The output scale of QNN binary operators needs to be a scalar, but got a tensor of shape {}".format(
+            out_t.scale.data.shape
+        )
+        assert (
+            len(out_t.zero_point.data.shape) == 0
+        ), "The output zero point of QNN binary operators needs to be a scalar, but got a tensor of shape {}".format(
+            out_t.zero_point.data.shape
+        )
 
         out = op(
             left,

--- a/src/relay/transforms/fake_quantization_to_integer.cc
+++ b/src/relay/transforms/fake_quantization_to_integer.cc
@@ -193,7 +193,7 @@ class SubgraphMutator : public ExprMutator {
       return Mutate(expr);
     } catch (std::exception& e) {
       if (hard_fail_) {
-        throw e;
+        LOG(FATAL) << e.what();
       } else {
         DLOG(INFO) << "Ran into an error rewriting a subgraph, skipping" << expr << std::endl;
         return expr;

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -154,6 +154,41 @@ def test_fake_quantize_dense_per_channel():
         compare_fq_to_int(op, [x_np, w_np], allow_rounding_error=True)
 
 
+def test_fake_quantize_dense_bias():
+    out_dtype = "int8"
+    x = relay.var("x", shape=[128, 64], dtype="int8")
+    w = relay.var("w", shape=[256, 64], dtype="int8")
+    bias = relay.var("bias", shape=[256], dtype="int32")
+    one = relay.const(1.0)
+    zero = relay.const(0)
+    w_scale = np.random.random([256]).astype("float32")
+
+    op = relay.op.nn.dense(
+        relay.qnn.op.dequantize(x, relay.const(2.0), zero),
+        relay.qnn.op.dequantize(
+            w,
+            relay.const(w_scale),
+            zero,
+            axis=0,
+        ),
+        units=256,
+    )
+
+    op += relay.qnn.op.dequantize(
+        bias,
+        relay.const(2.0 * w_scale),
+        zero,
+    )
+
+    op = relay.qnn.op.quantize(op, one, zero, out_dtype=out_dtype)
+
+    x_np = np.random.randint(-128, 127, size=[128, 64], dtype="int8")
+    w_np = np.random.randint(-128, 127, size=[256, 64], dtype="int8")
+    bias_np = np.random.randint(-128, 127, size=[256], dtype="int32")
+
+    compare_fq_to_int(op, [x_np, w_np, bias_np], allow_rounding_error=True)
+
+
 def test_fake_quantize_batch_matmul():
     for out_dtype in ["int8", "uint8"]:
         x = relay.var("x", shape=[1, 128, 64], dtype="int8")
@@ -1072,4 +1107,6 @@ def test_fq_qat_intermediate_infertype():
 
 
 if __name__ == "__main__":
-    tvm.testing.main()
+    # tvm.testing.main()
+    test_fake_quantize_dense_bias()
+    # test_fake_transpose_quantize_conv_bias_add_per_channel()

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -1011,15 +1011,9 @@ def test_fq_qat_positive_nothing_to_do():
     op1 = relay.qnn.op.quantize(
         relay.const(1.0), relay.const(12.0), relay.const(0), out_dtype="int32"
     )
-    op2 = relay.qnn.op.add(
+    op2 = relay.op.add(
         op0,
         op1,
-        relay.const(12.0),
-        relay.const(0),
-        relay.const(12.0),
-        relay.const(0),
-        relay.const(12.0),
-        relay.const(0),
     )
     expected_expr = relay.qnn.op.requantize(
         op2, relay.const(12.0), relay.const(0), relay.const(1.0), relay.const(0), out_dtype="int8"
@@ -1107,6 +1101,4 @@ def test_fq_qat_intermediate_infertype():
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_fake_quantize_dense_bias()
-    # test_fake_transpose_quantize_conv_bias_add_per_channel()
+    tvm.testing.main()


### PR DESCRIPTION
Closes https://github.com/apache/tvm/issues/13545

The pattern of `dense -> add`, where the add is really bias addition, can appear often as the result of converting ONNX `Gemm` op:
https://github.com/apache/tvm/blob/edfeba5c3a2caf133d2d045d1c4d99f5c34aeb69/python/tvm/relay/frontend/onnx.py#L1409

Currently, FQ2I tries to convert this `add` to `qnn.add`. But if this add is being used for bias addition, `out_t.scale` and `out_t.zero_point` variables in `fake_quantization_to_integer.py`, which are used to initialize the output scale and zp of the QNN binary operators, can be tensors rather than scalars. QNN binary operators do not support such output qparams, which led to the error reported in https://github.com/apache/tvm/issues/13545.

For this reason, apparently we haven't supported converting `dense -> add` to `qnn.dense -> add -> requantize`, when `add` is a bias add, in FQ2I. The pattern of `dense -> nn.bias_add` can be converted to `qnn.dense -> nn.bias_add -> requantize`, but we never use `nn.bias_add` after `dense`.

So I added a code path in the FQ2I QNN binary op converter, to identify such patterns and use regular binary ops rather than QNN ones.

cc @AndrewZhaoLuo @Icemist @elvin-n   