### PR TITLE
[Test] Make tests work with older numpy versions

### DIFF
--- a/python/tvm/topi/testing/depthwise_conv2d_python.py
+++ b/python/tvm/topi/testing/depthwise_conv2d_python.py
@@ -64,7 +64,7 @@ def depthwise_conv2d_python_nchw(input_np, filter_np, stride, padding):
         for j in range(out_channel):
             apad = input_np[i, j // channel_multiplier, :, :]
             if pad_h or pad_w:
-                apad = np.pad(apad, [(pad_top, pad_bottom), (pad_left, pad_right)])
+                apad = np.pad(apad, [(pad_top, pad_bottom), (pad_left, pad_right)], "constant")
 
             conv = _convolve2d(
                 apad,

--- a/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
+++ b/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
@@ -20,7 +20,6 @@
 import numpy as np
 import pytest
 import tvm
-from numpy.random import default_rng
 from tvm.script import tir as T
 
 VRMPY_SIZE_B = 128
@@ -184,11 +183,11 @@ class TestAsyncDMAPipeline:
 
     @tvm.testing.fixture
     def input_a(self, size_a):
-        return default_rng().integers(0, 8, (size_a, VRMPY_SIZE_B), dtype="uint8")
+        return np.random.randint(0, 8, (size_a, VRMPY_SIZE_B), dtype="uint8")
 
     @tvm.testing.fixture
     def input_w(self, size_w):
-        return default_rng().integers(0, 8, (size_w, VRMPY_SIZE_B), dtype="uint8")
+        return np.random.randint(0, 8, (size_w, VRMPY_SIZE_B), dtype="uint8")
 
     @tvm.testing.fixture
     def expected_output(self, size_a, size_w, input_a, input_w):
@@ -657,8 +656,8 @@ def test_meta(hexagon_session):
     if tvm.testing.utils.IS_IN_CI:
         pytest.skip("Skipping test since it takes too long in CI.")
 
-    a_data = default_rng().integers(1, 8, (1, 1, 230, 230, 4), dtype="uint8")
-    w_data = default_rng().integers(1, 8, (2, 1, 7, 7, 1, 32, 4), dtype="int8")
+    a_data = np.random.randint(1, 8, (1, 1, 230, 230, 4), dtype="uint8")
+    w_data = np.random.randint(1, 8, (2, 1, 7, 7, 1, 32, 4), dtype="int8")
     c_data = np.zeros((1, 2, 112, 112, 32), dtype="int32")
 
     sch = tvm.tir.Schedule(ModuleBase)

--- a/tests/python/contrib/test_hexagon/topi/slice_op/test_conv2d_slice.py
+++ b/tests/python/contrib/test_hexagon/topi/slice_op/test_conv2d_slice.py
@@ -110,7 +110,9 @@ def padded_filt_shape(filt_shape):
 def weights_np_padded(weights_np, filt_shape, padded_filt_shape):
     pad_in_channels = padded_filt_shape[2] - filt_shape[2]
     pad_out_channels = padded_filt_shape[3] - filt_shape[3]
-    filt_padded = np.pad(weights_np, ((0, 0), (0, 0), (0, pad_in_channels), (0, pad_out_channels)))
+    filt_padded = np.pad(
+        weights_np, ((0, 0), (0, 0), (0, pad_in_channels), (0, pad_out_channels)), "constant"
+    )
     return filt_padded
 
 

--- a/tests/python/contrib/test_hexagon/topi/test_pad.py
+++ b/tests/python/contrib/test_hexagon/topi/test_pad.py
@@ -50,7 +50,7 @@ def test_nn_pad(hexagon_session: Session):
     mod["pad"](a, b)
 
     # Reference numpy pad output
-    ref_out = np.pad(data_in, pad_width=((0, 0), (1, 1), (1, 1), (0, 0)))
+    ref_out = np.pad(data_in, pad_width=((0, 0), (1, 1), (1, 1), (0, 0)), mode="constant")
 
     tvm.testing.assert_allclose(b.numpy(), ref_out)
 


### PR DESCRIPTION
Add explicit "constant" as `mode` argument in `pad` and replace `default_rng` with `randint`.