### PR TITLE
Simplify Consecutive Casts

### DIFF
--- a/tests/python/relay/aot/test_crt_aot_usmp.py
+++ b/tests/python/relay/aot/test_crt_aot_usmp.py
@@ -16,37 +16,26 @@
 # under the License.
 """ This file contains test that use USMP + AoT using C runtime APIs"""
 
-from collections import OrderedDict
-import re
-
 import random
+import re
+from collections import OrderedDict
+
 import numpy as np
 import pytest
 
 import tvm
-from tvm import relay
-from tvm.relay import testing  # pylint: disable=W0611
-from tvm.relay import transform
-from tvm.relay.op.annotation import compiler_begin, compiler_end
-from tvm.relay.backend import Executor, Runtime
-from tvm import (
-    WorkspaceMemoryPools,
-    ConstantMemoryPools,
-    WorkspacePoolInfo,
-    ConstantPoolInfo,
-    PoolInfoProperties,
-)
+from tvm import (ConstantMemoryPools, ConstantPoolInfo, PoolInfoProperties,
+                 WorkspaceMemoryPools, WorkspacePoolInfo, relay)
 from tvm.micro import model_library_format as mlf
 from tvm.micro.testing.aot_test_utils import parametrize_aot_options
-from tvm.testing.aot import (
-    AOTTestModel,
-    AOTTestRunner,
-    generate_ref_data,
-    compile_and_run,
-    compile_models,
-    run_and_check,
-    create_relay_module_and_inputs_from_tflite_file,
-)
+from tvm.relay import testing  # pylint: disable=W0611
+from tvm.relay import transform
+from tvm.relay.backend import Executor, Runtime
+from tvm.relay.op.annotation import compiler_begin, compiler_end
+from tvm.testing.aot import (AOTTestModel, AOTTestRunner, compile_and_run,
+                             compile_models,
+                             create_relay_module_and_inputs_from_tflite_file,
+                             generate_ref_data, run_and_check)
 from tvm.testing.usmp import is_tvm_backendallocworkspace_calls
 
 

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -442,6 +442,7 @@ def test_simplify_consecutive_cast():
     expr1 = relay.cast(x, "int32")
     expr2 = relay.cast_like(expr1, y)
     actual = run_opt_pass(expr2, relay.transform.SimplifyExpr())
+<<<<<<< HEAD
     expected = run_infer_type(relay.cast(expr1, "float32"))
     assert tvm.ir.structural_equal(actual, expected)
 
@@ -449,6 +450,8 @@ def test_simplify_consecutive_cast():
     expr1 = relay.cast(x, "bool")
     expr2 = relay.cast(expr1, "int32")
     actual = run_opt_pass(expr2, relay.transform.SimplifyExpr())
+=======
+>>>>>>> 13dfac841 (initial commit)
     expected = run_infer_type(expr2)
     assert tvm.ir.structural_equal(actual, expected)
 


### PR DESCRIPTION
This PR adds a new rewrite to SimplifyExpr which removes extraneous casts. An extraneous cast is one defined where after the cast, the operand is the same type as before the cast operation. Previous passes may introduce extraneous casts (e.g. AlterOpLayout) so this may be helpful.

cc @guberti 