### PR TITLE
[LLVM] Fix get tm allow_missing check pos

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -297,9 +297,9 @@ llvm::TargetMachine* LLVMTargetInfo::GetOrCreateTargetMachine(bool allow_missing
         llvm_instance->createTargetMachine(triple_, cpu_, GetTargetFeatureString(), target_options_,
                                            reloc_model_, code_model_, opt_level_);
     target_machine_ = std::unique_ptr<llvm::TargetMachine>(tm);
-    if (!allow_missing) {
-      ICHECK(target_machine_ != nullptr) << error;
-    }
+  }
+  if (!allow_missing) {
+    ICHECK(target_machine_ != nullptr) << error;
   }
   return target_machine_.get();
 }


### PR DESCRIPTION
It seems that `GetOrCreateTargetMachine`'s failure check would be out of `lookupTarget`' nest scope.