### PR TITLE
WIP: [Meta][TIR] Fix func registration issue during TIR kernel tuning by meta-scheduler

### DIFF
--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -17,7 +17,7 @@
 """MetaSchedule-Relay integration"""
 from contextlib import contextmanager
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 # isort: off
 from typing_extensions import Literal
@@ -29,6 +29,7 @@ from tvm._ffi import get_global_func
 from tvm.ir import IRModule, transform
 from tvm.runtime import NDArray
 from tvm.target import Target
+from tvm import relay
 
 from .builder import Builder
 from .cost_model import CostModel
@@ -44,8 +45,6 @@ from .task_scheduler import TaskScheduler
 from .tune import tune_tasks
 from .tune_context import TuneContext
 from .utils import fork_seed
-
-from tvm import relay
 
 _extract_task = get_global_func(  # pylint: disable=invalid-name
     "relay.backend.MetaScheduleExtractTask",

--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -46,8 +46,6 @@ from .tune_context import TuneContext
 from .utils import fork_seed
 
 from tvm import relay
-if TYPE_CHECKING:
-    from tvm import relay
 
 _extract_task = get_global_func(  # pylint: disable=invalid-name
     "relay.backend.MetaScheduleExtractTask",

--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -78,8 +78,6 @@ def _normalize_params(
     Dict[str, Any],
     Optional["relay.backend.Executor"],
 ]:
-    from tvm import relay  # pylint: disable=import-outside-toplevel
-
     if isinstance(mod, relay.Function):
         mod = IRModule.from_expr(mod)
     if not isinstance(target, Target):
@@ -372,10 +370,6 @@ def compile_relay(
     lib : Union[Module, tvm.runtime.vm.Executable]
         The built runtime module or vm Executable for the given relay workload.
     """
-    # pylint: disable=import-outside-toplevel
-    from tvm import relay
-
-    # pylint: enable=import-outside-toplevel
     mod, target, params, pass_config, executor = _normalize_params(
         mod, target, params, pass_config, executor
     )

--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -45,6 +45,7 @@ from .tune import tune_tasks
 from .tune_context import TuneContext
 from .utils import fork_seed
 
+from tvm import relay
 if TYPE_CHECKING:
     from tvm import relay
 

--- a/python/tvm/relay/backend/te_compiler.py
+++ b/python/tvm/relay/backend/te_compiler.py
@@ -23,8 +23,6 @@ import logging
 import numpy as np
 import tvm
 from tvm import autotvm, te
-from tvm.auto_scheduler import is_auto_scheduler_enabled
-from tvm.meta_schedule import is_meta_schedule_enabled
 from tvm.runtime import Object
 from tvm.support import libinfo
 from tvm.target import Target
@@ -174,6 +172,11 @@ def select_implementation(op, attrs, inputs, out_type, target, use_autotvm=True)
     ret : tuple(relay.op.OpImplementation, List[tvm.te.Tensor])
         The best op implementation and the corresponding output tensors.
     """
+    # pylint: disable=import-outside-toplevel
+    from tvm.auto_scheduler import is_auto_scheduler_enabled
+    from tvm.meta_schedule import is_meta_schedule_enabled
+
+    # pylint: enable=import-outside-toplevel
     all_impls = get_valid_implementations(op, attrs, inputs, out_type, target)
     if len(all_impls) == 0:
         raise RuntimeError(f"No valid {op} implementations for {target}")

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -23,8 +23,6 @@ import re
 
 from tvm import relay, topi, tir
 
-from ....auto_scheduler import is_auto_scheduler_enabled
-from ....meta_schedule import is_meta_schedule_enabled
 from ....topi.generic import conv2d as conv2d_generic
 from .. import op as _op
 from .generic import *
@@ -575,6 +573,10 @@ def schedule_dense_arm_cpu(attrs, inputs, out_type, target):
             )
             return strategy
         logger.warning("dense is not optimized for arm cpu.")
+        # pylint: disable=import-outside-toplevel
+        from tvm.auto_scheduler import is_auto_scheduler_enabled
+        from tvm.meta_schedule import is_meta_schedule_enabled
+        # pylint: enable=import-outside-toplevel
         strategy.add_implementation(
             wrap_compute_dense(
                 topi.nn.dense,

--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -576,6 +576,7 @@ def schedule_dense_arm_cpu(attrs, inputs, out_type, target):
         # pylint: disable=import-outside-toplevel
         from tvm.auto_scheduler import is_auto_scheduler_enabled
         from tvm.meta_schedule import is_meta_schedule_enabled
+
         # pylint: enable=import-outside-toplevel
         strategy.add_implementation(
             wrap_compute_dense(

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -136,6 +136,7 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
     # pylint: disable=import-outside-toplevel
     from tvm.auto_scheduler import is_auto_scheduler_enabled
     from tvm.meta_schedule import is_meta_schedule_enabled
+
     # pylint: enable=import-outside-toplevel
     strategy = _op.OpStrategy()
     data, kernel = inputs
@@ -522,6 +523,7 @@ def conv2d_winograd_without_weight_transform_strategy_cuda(attrs, inputs, out_ty
     # pylint: disable=import-outside-toplevel
     from tvm.auto_scheduler import is_auto_scheduler_enabled
     from tvm.meta_schedule import is_meta_schedule_enabled
+
     # pylint: enable=import-outside-toplevel
     dilation = attrs.get_int_tuple("dilation")
     groups = attrs.get_int("groups")
@@ -871,6 +873,7 @@ def matmul_strategy_cuda(attrs, inputs, out_type, target):
     # pylint: disable=import-outside-toplevel
     from tvm.auto_scheduler import is_auto_scheduler_enabled
     from tvm.meta_schedule import is_meta_schedule_enabled
+
     # pylint: enable=import-outside-toplevel
     strategy = _op.OpStrategy()
 

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -17,10 +17,8 @@
 """Definition of CUDA/GPU operator strategy."""
 # pylint: disable=invalid-name,unused-argument,wildcard-import,unused-wildcard-import
 from tvm import topi
-from tvm.auto_scheduler import is_auto_scheduler_enabled
 from tvm.contrib import nvcc
 from tvm.contrib.thrust import can_use_thrust
-from tvm.meta_schedule import is_meta_schedule_enabled
 from tvm.te import SpecializedCondition
 
 from ....target import Target
@@ -135,6 +133,10 @@ def schedule_lrn_cuda(attrs, outs, target):
 @conv2d_strategy.register(["cuda", "gpu"])
 def conv2d_strategy_cuda(attrs, inputs, out_type, target):
     """conv2d cuda strategy"""
+    # pylint: disable=import-outside-toplevel
+    from tvm.auto_scheduler import is_auto_scheduler_enabled
+    from tvm.meta_schedule import is_meta_schedule_enabled
+    # pylint: enable=import-outside-toplevel
     strategy = _op.OpStrategy()
     data, kernel = inputs
     stride_h, stride_w = attrs.get_int_tuple("strides")
@@ -517,6 +519,10 @@ def judge_winograd(
 @conv2d_winograd_without_weight_transform_strategy.register(["cuda", "gpu"])
 def conv2d_winograd_without_weight_transform_strategy_cuda(attrs, inputs, out_type, target):
     """conv2d_winograd_without_weight_transform cuda strategy"""
+    # pylint: disable=import-outside-toplevel
+    from tvm.auto_scheduler import is_auto_scheduler_enabled
+    from tvm.meta_schedule import is_meta_schedule_enabled
+    # pylint: enable=import-outside-toplevel
     dilation = attrs.get_int_tuple("dilation")
     groups = attrs.get_int("groups")
     layout = attrs.data_layout
@@ -862,6 +868,10 @@ def conv1d_transpose_strategy_cuda(attrs, inputs, out_type, target):
 @matmul_strategy.register(["cuda", "gpu"])
 def matmul_strategy_cuda(attrs, inputs, out_type, target):
     """Matmul cuda strategy."""
+    # pylint: disable=import-outside-toplevel
+    from tvm.auto_scheduler import is_auto_scheduler_enabled
+    from tvm.meta_schedule import is_meta_schedule_enabled
+    # pylint: enable=import-outside-toplevel
     strategy = _op.OpStrategy()
 
     if is_auto_scheduler_enabled():

--- a/python/tvm/relay/op/strategy/mali.py
+++ b/python/tvm/relay/op/strategy/mali.py
@@ -28,6 +28,7 @@ def need_shedule_layout():
     # pylint: disable=import-outside-toplevel
     from tvm.auto_scheduler import is_auto_scheduler_enabled
     from tvm.meta_schedule import is_meta_schedule_enabled
+
     # pylint: enable=import-outside-toplevel
     return is_auto_scheduler_enabled(), is_meta_schedule_enabled()
 

--- a/python/tvm/relay/op/strategy/x86.py
+++ b/python/tvm/relay/op/strategy/x86.py
@@ -38,6 +38,7 @@ def need_shedule_layout():
     # pylint: disable=import-outside-toplevel
     from tvm.auto_scheduler import is_auto_scheduler_enabled
     from tvm.meta_schedule import is_meta_schedule_enabled
+
     # pylint: enable=import-outside-toplevel
     return is_auto_scheduler_enabled(), is_meta_schedule_enabled()
 


### PR DESCRIPTION
I investigated TIR kernel tuning by meta-scheduler and prepared for it the python script with minimal imports from tvm.
There is sketch of my code:
```
import tvm
from tvm import meta_schedule as ms
from tvm.script import tir as T


@tvm.script.ir_module
class MyModule:
  @T.prim_func
  def main(...):
    ...

if __name__ == "__main__":
  # params init
  ...
  database = ms.database.JSONDatabase(
    workload_path,
    record_path,
    work_dir=work_dir,
    module_equality="ignore-ndarray",
  )
  ms.tir_integration.tune_tir(
    mod=MyModule,
    target=target,
    work_dir=work_dir,
    max_trials_global=trials_number,
    database=database,
    strategy="replay-trace",
  )
```
But it has failed due to [check](https://github.com/apache/tvm/blob/main/src/meta_schedule/space_generator/space_generator.cc#L28) on native side of space generator. It tried to get packed func from tvm.topi.x86.utils.target_has_vnni, but it is not registrated in my case.
Of course, the simplest fix is to add `from tvm.topi.x86.utils import target_has_vnni` or `from tvm import topi` or `from tvm import relay` to python tuning script. But as a client of TIR and meta scheduler high-level API I do not need to know internal context. As result I've fixed it inside TVM.
The main fix is `from tvm import relay` in ms.relay_integration module. I should note that it does it by its-self if TYPE_CHECKING=True (but looks like it always False). Other code is related to hidding `from tvm.meta_schedule import is_meta_schedule_enabled` due to circular python imports.