### PR TITLE
[microTVM][Zephyr] Fix TVMC test on hardware

### DIFF
--- a/tests/micro/common/test_tvmc.py
+++ b/tests/micro/common/test_tvmc.py
@@ -44,6 +44,21 @@ def _run_tvmc(cmd_args: list, *args, **kwargs):
     return subprocess.check_call(cmd_args_list, *args, **kwargs)
 
 
+def create_project_command(project_path: str, mlf_path: str, platform: str, board: str) -> list:
+    """Returns create project command with tvmc micro."""
+    return [
+        "micro",
+        "create-project",
+        project_path,
+        mlf_path,
+        platform,
+        "--project-option",
+        "project_type=host_driven",
+        "config_main_stack_size=4096",
+        f"board={board}",
+    ]
+
+
 @tvm.testing.requires_micro
 def test_tvmc_exist(platform, board):
     cmd_result = _run_tvmc(["micro", "-h"])
@@ -93,18 +108,7 @@ def test_tvmc_model_build_only(platform, board, output_dir):
     )
     assert cmd_result == 0, "tvmc failed in step: compile"
 
-    create_project_cmd = [
-        "micro",
-        "create-project",
-        project_dir,
-        tar_path,
-        platform,
-        "--project-option",
-        "project_type=host_driven",
-        f"board={board}",
-    ]
-
-    cmd_result = _run_tvmc(create_project_cmd)
+    cmd_result = _run_tvmc(create_project_command(project_dir, tar_path, platform, board))
     assert cmd_result == 0, "tvmc micro failed in step: create-project"
 
     build_cmd = ["micro", "build", project_dir, platform]
@@ -157,18 +161,7 @@ def test_tvmc_model_run(platform, board, output_dir):
     )
     assert cmd_result == 0, "tvmc failed in step: compile"
 
-    create_project_cmd = [
-        "micro",
-        "create-project",
-        project_dir,
-        tar_path,
-        platform,
-        "--project-option",
-        "project_type=host_driven",
-        f"board={board}",
-    ]
-
-    cmd_result = _run_tvmc(create_project_cmd)
+    cmd_result = _run_tvmc(create_project_command(project_dir, tar_path, platform, board))
     assert cmd_result == 0, "tvmc micro failed in step: create-project"
 
     build_cmd = ["micro", "build", project_dir, platform]

--- a/tests/micro/common/test_tvmc.py
+++ b/tests/micro/common/test_tvmc.py
@@ -46,7 +46,7 @@ def _run_tvmc(cmd_args: list, *args, **kwargs):
 
 def create_project_command(project_path: str, mlf_path: str, platform: str, board: str) -> list:
     """Returns create project command with tvmc micro."""
-    return [
+    cmd = [
         "micro",
         "create-project",
         project_path,
@@ -54,9 +54,14 @@ def create_project_command(project_path: str, mlf_path: str, platform: str, boar
         platform,
         "--project-option",
         "project_type=host_driven",
-        "config_main_stack_size=4096",
         f"board={board}",
     ]
+
+    if platform == "zephyr":
+        # TODO: 4096 is driven by experiment on nucleo_l4r5zi. We should cleanup this after we have
+        # better memory management.
+        cmd.append("config_main_stack_size=4096")
+    return cmd
 
 
 @tvm.testing.requires_micro


### PR DESCRIPTION
This PR adds stack size to run test on hardware for Zephyr. It is not added for Arduino since it is not required.
4096 is derived from experiment on nucleo_l4r5zi.