### PR TITLE
[Fix] Task scheduler error prompt upon build/run failure

### DIFF
--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -120,7 +120,9 @@ void TaskCleanUp(TaskRecordNode* self, int task_id, const Array<RunnerResult>& r
       std::string err = error_msg.value();
       TVM_PY_LOG(INFO, logger) << std::fixed << std::setprecision(4)  //
                                << "[Task #" << task_id << ": " << name << "] Trial #" << trials
-                               << ": Error in building:\n"
+                               << ": Error in "
+                               << (builder_result->error_msg.defined() ? "building" : "running")
+                               << ":\n"
                                << err << "\n"
                                << tir::AsTVMScript(sch->mod()) << "\n"
                                << Concat(sch->trace().value()->AsPython(false), "\n");


### PR DESCRIPTION
This PR fixes one error prompt in task scheduler. Prior to this fix, the prompt assumes the error message always comes from a build failure. However, it is possible that the error message comes from a run failure.

cc @junrushao @zxybazh 