### PR TITLE
[TIR] Fix PlanAndUpdateBufferAllocationLocation not visiting constant buffer

### DIFF
--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -61,24 +61,33 @@ class BufferAllocateOrderCollector : public StmtExprVisitor {
   }
 
  private:
+  bool find(const Buffer& buf) {
+    return std::find(buffer_alloc_recorder_.begin(), buffer_alloc_recorder_.end(), buf) !=
+           buffer_alloc_recorder_.end();
+  }
+
   void VisitStmt_(const BlockNode* op) final {
     for (const Buffer& buffer : op->alloc_buffers) {
       buffer_alloc_recorder_.push_back(buffer);
     }
+    for (const auto& region : op->match_buffers) {
+      if (!find(region->source->buffer)) {
+        buffer_alloc_recorder_.push_back(region->source->buffer);
+      }
+    }
+
     StmtExprVisitor::VisitStmt_(op);
   }
 
   void VisitExpr_(const BufferLoadNode* op) final {
-    if (std::find(buffer_alloc_recorder_.begin(), buffer_alloc_recorder_.end(), op->buffer) ==
-        buffer_alloc_recorder_.end()) {
+    if (!find(op->buffer)) {
       buffer_alloc_recorder_.push_back(op->buffer);
     }
     StmtExprVisitor::VisitExpr_(op);
   }
 
   void VisitStmt_(const BufferStoreNode* op) final {
-    if (std::find(buffer_alloc_recorder_.begin(), buffer_alloc_recorder_.end(), op->buffer) ==
-        buffer_alloc_recorder_.end()) {
+    if (!find(op->buffer)) {
       buffer_alloc_recorder_.push_back(op->buffer);
     }
     StmtExprVisitor::VisitStmt_(op);

--- a/src/tir/transforms/plan_update_buffer_allocation_location.cc
+++ b/src/tir/transforms/plan_update_buffer_allocation_location.cc
@@ -70,6 +70,8 @@ class BufferAllocateOrderCollector : public StmtExprVisitor {
     for (const Buffer& buffer : op->alloc_buffers) {
       buffer_alloc_recorder_.push_back(buffer);
     }
+    // Also visit match_buffers to collect constant buffers associated with AllocateConst nodes.
+    // These buffers only appear in read and match_buffer regions.
     for (const auto& region : op->match_buffers) {
       if (!find(region->source->buffer)) {
         buffer_alloc_recorder_.push_back(region->source->buffer);


### PR DESCRIPTION
https://github.com/apache/tvm/pull/13560 is supposed to change only the order in which buffers are visited, but the created `buffer_alloc_recorder_` misses buffers associated with `AllocateConst` nodes. These buffers are not part of `func->buffer_map`, and appear only in `read` or `match_buffer` regions, so they are not caught by existing visitors for `BufferLoadNode` and `BufferStoreNode`.

Since constant buffers are not correctly handled by `PlanAndUpdateBufferAllocationLocation` now, tuning on Hexagon is currently broken with this error. This PR fixes this.

```
E             File "/home/fparizi/src/tvm_src/src/tir/transforms/plan_update_buffer_allocation_location.cc", line 163
E           TVMError: 
E           ---------------------------------------------------------------
E           An error occurred during the execution of TVM.
E           For more information, please see: https://tvm.apache.org/docs/errors.html
E           ---------------------------------------------------------------
E             Check failed: (buffer_data_to_buffer_.count(source_var)) is false:

```

Since creating a TVMScript-based test case involving constant buffers (`AllocateConst`) is difficult, I hope we can merge this simple PR without a test case.

cc @Hzfengsy @FredJia-intellif 