### PR TITLE
[microTVM]Add default value to unspecified project options in project API

### DIFF
--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -69,7 +69,11 @@ PROJECT_OPTIONS = server.default_project_options(
 ) + [
     server.ProjectOption(
         "arduino_cli_cmd",
-        required=(["generate_project", "flash", "open_transport"] if not ARDUINO_CLI_CMD else None),
+        required=(
+            ["generate_project", "build", "flash", "open_transport"]
+            if not ARDUINO_CLI_CMD
+            else None
+        ),
         optional=(
             ["generate_project", "build", "flash", "open_transport"] if ARDUINO_CLI_CMD else None
         ),

--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -56,15 +56,6 @@ except FileNotFoundError:
     raise FileNotFoundError(f"Board file {{{BOARDS}}} does not exist.")
 
 
-def get_cmsis_path(cmsis_path: pathlib.Path) -> pathlib.Path:
-    """Returns CMSIS dependency path"""
-    if cmsis_path:
-        return pathlib.Path(cmsis_path)
-    if os.environ.get("CMSIS_PATH"):
-        return pathlib.Path(os.environ.get("CMSIS_PATH"))
-    assert False, "'cmsis_path' option not passed!"
-
-
 class BoardAutodetectFailed(Exception):
     """Raised when no attached hardware is found matching the requested board"""
 
@@ -337,7 +328,7 @@ class Handler(server.ProjectAPIHandler):
         However, the latest release does not include header files that are copied in this function.
         """
         (project_path / "include" / "cmsis").mkdir()
-        cmsis_path = get_cmsis_path(cmsis_path)
+        cmsis_path = pathlib.Path(cmsis_path)
         for item in self.CMSIS_INCLUDE_HEADERS:
             shutil.copy2(
                 cmsis_path / "CMSIS" / "NN" / "Include" / item,
@@ -357,7 +348,7 @@ class Handler(server.ProjectAPIHandler):
         flags = {
             "FQBN": self._get_fqbn(board),
             "VERBOSE_FLAG": "--verbose" if verbose else "",
-            "ARUINO_CLI_CMD": self._get_arduino_cli_cmd(arduino_cli_cmd),
+            "ARUINO_CLI_CMD": arduino_cli_cmd,
             "BOARD": board,
             "BUILD_EXTRA_FLAGS": build_extra_flags,
         }
@@ -377,9 +368,10 @@ class Handler(server.ProjectAPIHandler):
     def generate_project(self, model_library_format_path, standalone_crt_dir, project_dir, options):
         # List all used project options
         board = options["board"]
-        verbose = options.get("verbose")
         project_type = options["project_type"]
-        arduino_cli_cmd = options.get("arduino_cli_cmd")
+        arduino_cli_cmd = options["arduino_cli_cmd"]
+        verbose = options["verbose"]
+
         cmsis_path = options.get("cmsis_path")
         compile_definitions = options.get("compile_definitions")
         extra_files_tar = options.get("extra_files_tar")
@@ -455,12 +447,6 @@ class Handler(server.ProjectAPIHandler):
             build_extra_flags,
         )
 
-    def _get_arduino_cli_cmd(self, arduino_cli_cmd: str):
-        if not arduino_cli_cmd:
-            arduino_cli_cmd = ARDUINO_CLI_CMD
-        assert arduino_cli_cmd, "'arduino_cli_cmd' command not passed and not found by default!"
-        return arduino_cli_cmd
-
     def _get_platform_version(self, arduino_cli_path: str) -> float:
         # sample output of this command:
         # 'arduino-cli alpha Version: 0.18.3 Commit: d710b642 Date: 2021-05-14T12:36:58Z\n'
@@ -494,11 +480,10 @@ class Handler(server.ProjectAPIHandler):
 
     def build(self, options):
         # List all used project options
-        arduino_cli_cmd = options.get("arduino_cli_cmd")
+        arduino_cli_cmd = options["arduino_cli_cmd"]
         warning_as_error = options.get("warning_as_error")
 
-        cli_command = self._get_arduino_cli_cmd(arduino_cli_cmd)
-        self._check_platform_version(cli_command, warning_as_error)
+        self._check_platform_version(arduino_cli_cmd, warning_as_error)
         compile_cmd = ["make", "build"]
         # Specify project to compile
         subprocess.run(compile_cmd, check=True, cwd=API_SERVER_DIR)
@@ -539,7 +524,7 @@ class Handler(server.ProjectAPIHandler):
 
     def _auto_detect_port(self, arduino_cli_cmd: str, board: str) -> str:
         # It is assumed only one board with this type is connected to this host machine.
-        list_cmd = [self._get_arduino_cli_cmd(arduino_cli_cmd), "board", "list"]
+        list_cmd = [arduino_cli_cmd, "board", "list"]
         list_cmd_output = subprocess.run(
             list_cmd, check=True, stdout=subprocess.PIPE
         ).stdout.decode("utf-8")
@@ -599,7 +584,7 @@ class Handler(server.ProjectAPIHandler):
 
     def flash(self, options):
         # List all used project options
-        arduino_cli_cmd = options.get("arduino_cli_cmd")
+        arduino_cli_cmd = options["arduino_cli_cmd"]
         warning_as_error = options.get("warning_as_error")
         port = options.get("port")
         board = options.get("board")
@@ -608,9 +593,8 @@ class Handler(server.ProjectAPIHandler):
         if not board:
             board = self._get_board_from_makefile(API_SERVER_DIR / MAKEFILE_FILENAME)
 
-        cli_command = self._get_arduino_cli_cmd(arduino_cli_cmd)
-        self._check_platform_version(cli_command, warning_as_error)
-        port = self._get_arduino_port(cli_command, board, port, serial_number)
+        self._check_platform_version(arduino_cli_cmd, warning_as_error)
+        port = self._get_arduino_port(arduino_cli_cmd, board, port, serial_number)
 
         upload_cmd = ["make", "flash", f"PORT={port}"]
         for _ in range(self.FLASH_MAX_RETRIES):
@@ -639,7 +623,7 @@ class Handler(server.ProjectAPIHandler):
         import serial.tools.list_ports
 
         # List all used project options
-        arduino_cli_cmd = options.get("arduino_cli_cmd")
+        arduino_cli_cmd = options["arduino_cli_cmd"]
         port = options.get("port")
         board = options.get("board")
         serial_number = options.get("serial_number")

--- a/python/tvm/micro/project.py
+++ b/python/tvm/micro/project.py
@@ -28,6 +28,17 @@ from .project_api import client
 from .transport import Transport, TransportTimeouts
 
 
+def add_unspecified_options(options: dict, server_project_options: list) -> dict:
+    """Adds default value of project template options that are not specified by user."""
+    if not options:
+        options = dict()
+    for option in server_project_options:
+        name = option["name"]
+        if name not in options.keys():
+            options[name] = option["default"]
+    return options
+
+
 class ProjectTransport(Transport):
     """A Transport implementation that uses the Project API client."""
 
@@ -69,10 +80,10 @@ class GeneratedProject:
 
     def __init__(self, api_client, options):
         self._api_client = api_client
-        self._options = options
         self._info = self._api_client.server_info_query(__version__)
         if self._info["is_template"]:
             raise TemplateProjectError()
+        self._options = add_unspecified_options(options, self._info["project_options"])
 
     def build(self):
         self._api_client.build(self._options)
@@ -121,19 +132,10 @@ class TemplateProject:
                         Here is a list of available options:{list(available_options)}."""
             )
 
-    def _add_unspecified_options(self, options: dict):
-        """Adds default value of project options that are not specified by user."""
-        if not options:
-            options = dict()
-        for option in self._info["project_options"]:
-            name = option["name"]
-            if name not in options.keys():
-                options[name] = option["default"]
-
     def generate_project_from_mlf(self, model_library_format_path, project_dir, options: dict):
         """Generate a project from MLF file."""
         self._check_project_options(options)
-        self._add_unspecified_options(options)
+        options = add_unspecified_options(options, self._info["project_options"])
 
         self._api_client.generate_project(
             model_library_format_path=str(model_library_format_path),

--- a/python/tvm/micro/project.py
+++ b/python/tvm/micro/project.py
@@ -123,6 +123,8 @@ class TemplateProject:
 
     def _add_unspecified_options(self, options: dict):
         """Adds default value of project options that are not specified by user."""
+        if not options:
+            options = dict()
         for option in self._info["project_options"]:
             name = option["name"]
             if name not in options.keys():

--- a/python/tvm/micro/project.py
+++ b/python/tvm/micro/project.py
@@ -121,9 +121,18 @@ class TemplateProject:
                         Here is a list of available options:{list(available_options)}."""
             )
 
+    def _add_unspecified_options(self, options: dict):
+        """Adds default value of project options that are not specified by user."""
+        for option in self._info["project_options"]:
+            name = option["name"]
+            if name not in options.keys():
+                options[name] = option["default"]
+
     def generate_project_from_mlf(self, model_library_format_path, project_dir, options: dict):
         """Generate a project from MLF file."""
         self._check_project_options(options)
+        self._add_unspecified_options(options)
+
         self._api_client.generate_project(
             model_library_format_path=str(model_library_format_path),
             standalone_crt_dir=get_standalone_crt_dir(),

--- a/python/tvm/micro/project_api/server.py
+++ b/python/tvm/micro/project_api/server.py
@@ -804,7 +804,7 @@ def default_project_options(**kw) -> typing.List[ProjectOption]:
             "cmsis_path",
             optional=["generate_project"],
             type="str",
-            default=None,
+            default=os.environ.get("CMSIS_PATH", None),
             help="Path to the CMSIS directory.",
         ),
         ProjectOption(

--- a/tests/micro/arduino/conftest.py
+++ b/tests/micro/arduino/conftest.py
@@ -26,8 +26,3 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "requires_hardware: mark test to run only when an Arduino board is connected"
     )
-
-
-@pytest.fixture(scope="session")
-def arduino_cli_cmd(request):
-    return request.config.getoption("--arduino-cli-cmd")

--- a/tests/micro/arduino/conftest.py
+++ b/tests/micro/arduino/conftest.py
@@ -22,14 +22,6 @@ pytest_plugins = [
 import pytest
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--arduino-cli-cmd",
-        default="arduino-cli",
-        help="Path to `arduino-cli` command for flashing device.",
-    )
-
-
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "requires_hardware: mark test to run only when an Arduino board is connected"

--- a/tests/micro/arduino/test_arduino_error_detection.py
+++ b/tests/micro/arduino/test_arduino_error_detection.py
@@ -24,10 +24,8 @@ import tvm.testing
 
 
 @pytest.fixture
-def project(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number):
-    return test_utils.make_kws_project(
-        board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number
-    )
+def project(board, microtvm_debug, workspace_dir, serial_number):
+    return test_utils.make_kws_project(board, microtvm_debug, workspace_dir, serial_number)
 
 
 def test_blank_project_compiles(workspace_dir, project):

--- a/tests/micro/arduino/test_arduino_rpc_server.py
+++ b/tests/micro/arduino/test_arduino_rpc_server.py
@@ -41,7 +41,6 @@ import test_utils
 def _make_session(
     model,
     arduino_board,
-    arduino_cli_cmd,
     workspace_dir,
     mod,
     build_config,
@@ -53,7 +52,6 @@ def _make_session(
         workspace_dir / "project",
         {
             "board": arduino_board,
-            "arduino_cli_cmd": arduino_cli_cmd,
             "project_type": "host_driven",
             "verbose": bool(build_config.get("debug")),
             "serial_number": serial_number,
@@ -67,7 +65,6 @@ def _make_session(
 def _make_sess_from_op(
     model,
     arduino_board,
-    arduino_cli_cmd,
     workspace_dir,
     op_name,
     sched,
@@ -80,14 +77,10 @@ def _make_sess_from_op(
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         mod = tvm.build(sched, arg_bufs, target=target, runtime=runtime, name=op_name)
 
-    return _make_session(
-        model, arduino_board, arduino_cli_cmd, workspace_dir, mod, build_config, serial_number
-    )
+    return _make_session(model, arduino_board, workspace_dir, mod, build_config, serial_number)
 
 
-def _make_add_sess(
-    model, arduino_board, arduino_cli_cmd, workspace_dir, build_config, serial_number: str = None
-):
+def _make_add_sess(model, arduino_board, workspace_dir, build_config, serial_number: str = None):
     A = tvm.te.placeholder((2,), dtype="int8")
     B = tvm.te.placeholder((1,), dtype="int8")
     C = tvm.te.compute(A.shape, lambda i: A[i] + B[0], name="C")
@@ -95,7 +88,6 @@ def _make_add_sess(
     return _make_sess_from_op(
         model,
         arduino_board,
-        arduino_cli_cmd,
         workspace_dir,
         "add",
         sched,
@@ -108,7 +100,7 @@ def _make_add_sess(
 # The same test code can be executed on both the QEMU simulation and on real hardware.
 @tvm.testing.requires_micro
 @pytest.mark.requires_hardware
-def test_compile_runtime(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number):
+def test_compile_runtime(board, microtvm_debug, workspace_dir, serial_number):
     """Test compiling the on-device runtime."""
 
     model = test_utils.ARDUINO_BOARDS[board]
@@ -127,15 +119,13 @@ def test_compile_runtime(board, arduino_cli_cmd, microtvm_debug, workspace_dir, 
         system_lib.get_function("add")(A_data, B_data, C_data)
         assert (C_data.numpy() == np.array([6, 7])).all()
 
-    with _make_add_sess(
-        model, board, arduino_cli_cmd, workspace_dir, build_config, serial_number
-    ) as sess:
+    with _make_add_sess(model, board, workspace_dir, build_config, serial_number) as sess:
         test_basic_add(sess)
 
 
 @tvm.testing.requires_micro
 @pytest.mark.requires_hardware
-def test_platform_timer(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number):
+def test_platform_timer(board, microtvm_debug, workspace_dir, serial_number):
     """Test compiling the on-device runtime."""
 
     model = test_utils.ARDUINO_BOARDS[board]
@@ -159,15 +149,13 @@ def test_platform_timer(board, arduino_cli_cmd, microtvm_debug, workspace_dir, s
         assert result.mean > 0
         assert len(result.results) == 3
 
-    with _make_add_sess(
-        model, board, arduino_cli_cmd, workspace_dir, build_config, serial_number
-    ) as sess:
+    with _make_add_sess(model, board, workspace_dir, build_config, serial_number) as sess:
         test_basic_add(sess)
 
 
 @tvm.testing.requires_micro
 @pytest.mark.requires_hardware
-def test_relay(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number):
+def test_relay(board, microtvm_debug, workspace_dir, serial_number):
     """Testing a simple relay graph"""
     model = test_utils.ARDUINO_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -186,9 +174,7 @@ def test_relay(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_num
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         mod = tvm.relay.build(func, target=target, runtime=runtime)
 
-    with _make_session(
-        model, board, arduino_cli_cmd, workspace_dir, mod, build_config, serial_number
-    ) as session:
+    with _make_session(model, board, workspace_dir, mod, build_config, serial_number) as session:
         graph_mod = tvm.micro.create_local_graph_executor(
             mod.get_graph_json(), session.get_system_lib(), session.device
         )
@@ -202,7 +188,7 @@ def test_relay(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_num
 
 @tvm.testing.requires_micro
 @pytest.mark.requires_hardware
-def test_onnx(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number):
+def test_onnx(board, microtvm_debug, workspace_dir, serial_number):
     """Testing a simple ONNX model."""
     model = test_utils.ARDUINO_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -232,7 +218,7 @@ def test_onnx(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_numb
         graph = lowered.get_graph_json()
 
     with _make_session(
-        model, board, arduino_cli_cmd, workspace_dir, lowered, build_config, serial_number
+        model, board, workspace_dir, lowered, build_config, serial_number
     ) as session:
         graph_mod = tvm.micro.create_local_graph_executor(
             graph, session.get_system_lib(), session.device
@@ -256,7 +242,6 @@ def check_result(
     relay_mod,
     model,
     arduino_board,
-    arduino_cli_cmd,
     workspace_dir,
     map_inputs,
     out_shape,
@@ -272,7 +257,7 @@ def check_result(
         mod = tvm.relay.build(relay_mod, target=target, runtime=runtime)
 
     with _make_session(
-        model, arduino_board, arduino_cli_cmd, workspace_dir, mod, build_config, serial_number
+        model, arduino_board, workspace_dir, mod, build_config, serial_number
     ) as session:
         rt_mod = tvm.micro.create_local_graph_executor(
             mod.get_graph_json(), session.get_system_lib(), session.device
@@ -294,7 +279,7 @@ def check_result(
 
 @tvm.testing.requires_micro
 @pytest.mark.requires_hardware
-def test_byoc_microtvm(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number):
+def test_byoc_microtvm(board, microtvm_debug, workspace_dir, serial_number):
     """This is a simple test case to check BYOC capabilities of microTVM"""
     model = test_utils.ARDUINO_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -352,7 +337,6 @@ def test_byoc_microtvm(board, arduino_cli_cmd, microtvm_debug, workspace_dir, se
         model=model,
         build_config=build_config,
         arduino_board=board,
-        arduino_cli_cmd=arduino_cli_cmd,
         workspace_dir=workspace_dir,
         serial_number=serial_number,
     )
@@ -361,7 +345,6 @@ def test_byoc_microtvm(board, arduino_cli_cmd, microtvm_debug, workspace_dir, se
 def _make_add_sess_with_shape(
     model,
     arduino_board,
-    arduino_cli_cmd,
     workspace_dir,
     shape,
     build_config,
@@ -373,7 +356,6 @@ def _make_add_sess_with_shape(
     return _make_sess_from_op(
         model,
         arduino_board,
-        arduino_cli_cmd,
         workspace_dir,
         "add",
         sched,
@@ -393,9 +375,7 @@ def _make_add_sess_with_shape(
 )
 @tvm.testing.requires_micro
 @pytest.mark.requires_hardware
-def test_rpc_large_array(
-    board, arduino_cli_cmd, microtvm_debug, workspace_dir, shape, serial_number
-):
+def test_rpc_large_array(board, microtvm_debug, workspace_dir, shape, serial_number):
     """Test large RPC array transfer."""
     model = test_utils.ARDUINO_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -410,7 +390,7 @@ def test_rpc_large_array(
         assert (C_data.numpy() == np.zeros(shape)).all()
 
     with _make_add_sess_with_shape(
-        model, board, arduino_cli_cmd, workspace_dir, shape, build_config, serial_number
+        model, board, workspace_dir, shape, build_config, serial_number
     ) as sess:
         test_tensors(sess)
 

--- a/tests/micro/arduino/test_arduino_workflow.py
+++ b/tests/micro/arduino/test_arduino_workflow.py
@@ -54,12 +54,10 @@ def project_dir(workflow_workspace_dir):
 # We MUST pass workspace_dir, not project_dir, or the workspace will be dereferenced
 # too soon. We can't use the board fixture either for the reason mentioned above.
 @pytest.fixture(scope="module")
-def project(request, arduino_cli_cmd, microtvm_debug, workflow_workspace_dir):
+def project(request, microtvm_debug, workflow_workspace_dir):
     board = request.config.getoption("--board")
     serial_number = request.config.getoption("--serial-number")
-    return test_utils.make_kws_project(
-        board, arduino_cli_cmd, microtvm_debug, workflow_workspace_dir, serial_number
-    )
+    return test_utils.make_kws_project(board, microtvm_debug, workflow_workspace_dir, serial_number)
 
 
 def _get_directory_elements(directory):

--- a/tests/micro/arduino/test_utils.py
+++ b/tests/micro/arduino/test_utils.py
@@ -61,7 +61,7 @@ def make_workspace_dir(test_name, board):
     return t
 
 
-def make_kws_project(board, arduino_cli_cmd, microtvm_debug, workspace_dir, serial_number: str):
+def make_kws_project(board, microtvm_debug, workspace_dir, serial_number: str):
     this_dir = pathlib.Path(__file__).parent
     model = ARDUINO_BOARDS[board]
     build_config = {"debug": microtvm_debug}
@@ -85,7 +85,6 @@ def make_kws_project(board, arduino_cli_cmd, microtvm_debug, workspace_dir, seri
         workspace_dir / "project",
         {
             "board": board,
-            "arduino_cli_cmd": arduino_cli_cmd,
             "project_type": "example_project",
             "verbose": bool(build_config.get("debug")),
             "serial_number": serial_number,

--- a/tests/micro/project_api/test_arduino_microtvm_api_server.py
+++ b/tests/micro/project_api/test_arduino_microtvm_api_server.py
@@ -136,14 +136,15 @@ class TestGenerateProject:
         arduino_cli_cmd = self.DEFAULT_OPTIONS.get("arduino_cli_cmd")
         warning_as_error = self.DEFAULT_OPTIONS.get("warning_as_error")
 
-        cli_command = handler._get_arduino_cli_cmd(arduino_cli_cmd)
-        handler._check_platform_version(cli_command=cli_command, warning_as_error=warning_as_error)
+        handler._check_platform_version(
+            cli_command=arduino_cli_cmd, warning_as_error=warning_as_error
+        )
         assert handler._version == version.parse("0.21.1")
 
         handler = microtvm_api_server.Handler()
         mock_run.return_value.stdout = bytes(self.BAD_CLI_VERSION, "utf-8")
         with pytest.raises(server.ServerError) as error:
-            handler._check_platform_version(cli_command=cli_command, warning_as_error=True)
+            handler._check_platform_version(cli_command=arduino_cli_cmd, warning_as_error=True)
         mock_run.reset_mock()
 
     @mock.patch("subprocess.run")

--- a/tests/micro/zephyr/test_zephyr.py
+++ b/tests/micro/zephyr/test_zephyr.py
@@ -605,7 +605,6 @@ def test_schedule_build_with_cmsis_dependency(workspace_dir, board, microtvm_deb
         "project_type": "host_driven",
         "verbose": bool(build_config.get("debug")),
         "board": board,
-        "cmsis_path": os.getenv("CMSIS_PATH"),
         "use_fvp": bool(use_fvp),
     }
 


### PR DESCRIPTION
In current TVM, project API ignores the default values that are set for each project option in a project API server. This results in extra function handlers to specify the default value for those options in runtime.
This PR searches through available ProjectOptions for a project API server and adds default values for unspecified options before sending the `options` to API call function handler.
 