### PR TITLE
[CI] Include static builds of the runtime as part of CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,40 @@ jobs:
         run: >-
           python -m pytest -v tests/python/all-platform-minimal-test
 
+  Windows-Static-Runtime:
+    if: ${{ github.repository == 'apache/tvm' }}
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Build static TVM runtime
+        shell: bash -l {0}
+        run: |
+          tests/scripts/task_config_build_static.sh build
+          cd build
+          cmake .. -A x64 -DCMAKE_CONFIGURATION_TYPES="Release"
+          cmake --build . --config Release --target runtime
+
+  Linux-Static-Runtime:
+    if: ${{ github.repository == 'apache/tvm' }}
+    runs-on: Ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Build static TVM runtime
+        shell: bash -l {0}
+        run: |
+          tests/scripts/task_config_build_static.sh build
+          cd build
+          cmake ..
+          cmake --build . --config Release --target runtime
+
   Android:
     if: ${{ github.repository == 'apache/tvm' }}
     runs-on: Ubuntu-20.04

--- a/tests/scripts/task_config_build_static.sh
+++ b/tests/scripts/task_config_build_static.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+BUILD_DIR=$1
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+cp ../cmake/config.cmake .
+
+echo set\(USE_LIBBACKTRACE OFF\) >> config.cmake
+echo set\(USE_SORT ON\) >> config.cmake
+echo set\(USE_CUDA OFF\) >> config.cmake
+echo set\(BUILD_STATIC_RUNTIME ON\) >> config.cmake
+echo set\(USE_FALLBACK_STL_MAP ON\) >> config.cmake
+echo set\(USE_MSVC_MT ON\) >> config.cmake
+echo set\(USE_RPC OFF\) >> config.cmake
+echo set\(USE_GRAPH_EXECUTOR OFF\) >> config.cmake
+echo set\(USE_PROFILER OFF\) >> config.cmake
+echo set\(USE_AOT_EXECUTOR OFF\) >> config.cmake


### PR DESCRIPTION
This PR partially addresses #13526 by adding static builds of tvm_runtime.a on Windows and Linux.

Tested at https://github.com/gigiblender/tvm/actions/runs/3694697105