### PR TITLE
[Hexagon] Switch from default_rng to random in Hexagon tests

### DIFF
--- a/tests/python/contrib/test_hexagon/test_parallel_hvx.py
+++ b/tests/python/contrib/test_hexagon/test_parallel_hvx.py
@@ -19,7 +19,6 @@
 Test parallelizing HVX workloads and compare them to single thread examples.
 """
 import numpy as np
-from numpy.random import default_rng
 
 import tvm
 from tvm.script import tir as T
@@ -148,9 +147,8 @@ def evaluate(hexagon_session, shape_dtypes, expected_output_producer, sch):
     func_tir = tvm.build(sch.mod["main"], target=get_hexagon_target("v68"))
     module = hexagon_session.load_module(func_tir)
 
-    rng = default_rng()
-    a = rng.integers(0, 16, a_shape, dtype=a_dtype)
-    b = rng.integers(0, 16, b_shape, dtype=b_dtype)
+    a = np.random.randint(0, 16, a_shape, dtype=a_dtype)
+    b = np.random.randint(0, 16, b_shape, dtype=b_dtype)
     c = np.zeros(c_shape, dtype=c_dtype)
 
     a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device)

--- a/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
+++ b/tests/python/contrib/test_hexagon/test_parallel_hvx_load_vtcm.py
@@ -19,7 +19,6 @@
 
 import numpy as np
 import tvm
-from numpy.random import default_rng
 from tvm.script import tir as T
 
 from .infrastructure import get_hexagon_target
@@ -395,11 +394,11 @@ class TestMatMulVec:
 
     @tvm.testing.fixture
     def input_a(self, operations):
-        return default_rng().integers(0, 16, (operations, 128), dtype="uint8")
+        return np.random.randint(0, 16, (operations, 128), dtype="uint8")
 
     @tvm.testing.fixture
     def input_b(self, operations):
-        return default_rng().integers(0, 16, (operations, 128), dtype="uint8")
+        return np.random.randint(0, 16, (operations, 128), dtype="uint8")
 
     @tvm.testing.fixture
     def input_c(self, operations):

--- a/tests/python/contrib/test_hexagon/test_parallel_scalar.py
+++ b/tests/python/contrib/test_hexagon/test_parallel_scalar.py
@@ -18,7 +18,6 @@
 """ Test parallelism for multiple different scalar workloads. """
 
 import numpy as np
-from numpy.random import default_rng
 
 import tvm
 from tvm.script import tir as T
@@ -91,9 +90,10 @@ def evaluate(hexagon_session, operations, expected, sch):
     func_tir = tvm.build(sch.mod["main"], target=get_hexagon_target("v68"))
     module = hexagon_session.load_module(func_tir)
 
-    rng = default_rng()
-    a = rng.random(shape, dtype=dtype)
-    b = rng.random(shape, dtype=dtype)
+    # np.random.random returns float64 by default, but make the cast explicit
+    # to make it easier to switch when necessary.
+    a = np.random.random(shape).astype(dtype)
+    b = np.random.random(shape).astype(dtype)
     c = np.zeros(shape, dtype=dtype)
 
     a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device)

--- a/tests/python/contrib/test_hexagon/test_vtcm_bandwidth.py
+++ b/tests/python/contrib/test_hexagon/test_vtcm_bandwidth.py
@@ -18,7 +18,6 @@
 """Test theoretical bandwith for data transfers to VTCM for different strategies."""
 
 import numpy as np
-from numpy.random import default_rng
 
 import tvm
 from tvm.script import tir as T
@@ -96,8 +95,7 @@ def evaluate(hexagon_session, sch, size):
     func_tir = tvm.build(sch.mod["main"], target=get_hexagon_target("v69"))
     module = hexagon_session.load_module(func_tir)
 
-    rng = default_rng()
-    a = rng.integers(-128, 127, a_shape, dtype="int8")
+    a = np.random.randint(-128, 127, a_shape, dtype="int8")
     a_vtcm = np.zeros(a_shape, dtype="int8")
 
     a_hexagon = tvm.runtime.ndarray.array(a, device=hexagon_session.device, mem_scope="global")


### PR DESCRIPTION
`default_rng` was introduced in numpy 1.19, which is not present even in Ubuntu 20.04 (it comes with 1.17.4).