### PR TITLE
[LLVM] Use std::nullopt instead of llvm::None

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -362,7 +362,7 @@ void CodeGenLLVM::Optimize() {
 
   llvm::PipelineTuningOptions pto = llvm::PipelineTuningOptions();
   llvm::PassInstrumentationCallbacks pic;
-  llvm::PassBuilder builder(tm, pto, llvm::None, &pic);
+  llvm::PassBuilder builder(tm, pto, std::nullopt, &pic);
 
   llvm::LoopAnalysisManager lam;
   llvm::FunctionAnalysisManager fam;


### PR DESCRIPTION
Pass `std::nullopt` to initialization of `PassBuilder` for `PGOOptions`. LLVM is moving away from its own `Optional` type to `std::optional`.