### PR TITLE
[TOPI] Fix batch_matmul tensorcore legalize for transpose_b = False case

### DIFF
--- a/python/tvm/topi/cuda/tensorcore_alter_op.py
+++ b/python/tvm/topi/cuda/tensorcore_alter_op.py
@@ -106,14 +106,18 @@ def _batch_matmul_legalize(attrs, inputs, arg_types):
     logger.info("batch_matmul pad_to_tensorcore, extra_flops %s", extra_flops)
 
     if attrs.transpose_a:
-        x_ = relay.nn.pad(x, pad_width=((0, 0), (0, dk), (0, dm))) if dm or dk else x
+        pad_width = ((0, 0), (0, dk), (0, dm))
     else:
-        x_ = relay.nn.pad(x, pad_width=((0, 0), (0, dm), (0, dk))) if dm or dk else x
+        pad_width = ((0, 0), (0, dm), (0, dk))
+
+    x_ = relay.nn.pad(x, pad_width=pad_width) if dm or dk else x
 
     if attrs.transpose_b:
-        y_ = relay.nn.pad(y, pad_width=((0, 0), (0, dn), (0, dk))) if dn or dk else y
+        pad_width = ((0, 0), (0, dn), (0, dk))
     else:
-        y_ = relay.nn.pad(y, pad_width=((0, 0), (0, dk), (0, dn))) if dn or dk else y
+        pad_width = ((0, 0), (0, dk), (0, dn))
+
+    y_ = relay.nn.pad(y, pad_width=pad_width) if dn or dk else y
 
     out_ = relay.nn.batch_matmul(x_, y_, **attrs)
 

--- a/python/tvm/topi/cuda/tensorcore_alter_op.py
+++ b/python/tvm/topi/cuda/tensorcore_alter_op.py
@@ -48,14 +48,22 @@ def _batch_matmul_legalize(attrs, inputs, arg_types):
     x_tensor, y_tensor = arg_types[0], arg_types[1]
     dtype = x_tensor.dtype
 
+    if attrs.transpose_a:
+        B, K, M = x_tensor.shape
+    else:
+        B, M, K = x_tensor.shape
+
+    if attrs.transpose_b:
+        B, N, K = y_tensor.shape
+    else:
+        B, K, N = y_tensor.shape
+
     # Collect the output tensor.
     output_tensor = arg_types[2]
 
     # Collect the input exprs.
     x, y = inputs
 
-    B, M, K = x_tensor.shape
-    B, N, K = y_tensor.shape
     if (
         isinstance(B, tir.expr.Any)
         or isinstance(M, tir.expr.Any)
@@ -96,9 +104,19 @@ def _batch_matmul_legalize(attrs, inputs, arg_types):
         return None
 
     logger.info("batch_matmul pad_to_tensorcore, extra_flops %s", extra_flops)
-    x_ = relay.nn.pad(x, pad_width=((0, 0), (0, dm), (0, dk))) if dm or dk else x
-    y_ = relay.nn.pad(y, pad_width=((0, 0), (0, dn), (0, dk))) if dn or dk else y
-    out_ = relay.nn.batch_matmul(x_, y_, attrs.out_dtype)
+
+    if attrs.transpose_a:
+        x_ = relay.nn.pad(x, pad_width=((0, 0), (0, dk), (0, dm))) if dm or dk else x
+    else:
+        x_ = relay.nn.pad(x, pad_width=((0, 0), (0, dm), (0, dk))) if dm or dk else x
+
+    if attrs.transpose_b:
+        y_ = relay.nn.pad(y, pad_width=((0, 0), (0, dn), (0, dk))) if dn or dk else y
+    else:
+        y_ = relay.nn.pad(y, pad_width=((0, 0), (0, dk), (0, dn))) if dn or dk else y
+
+    out_ = relay.nn.batch_matmul(x_, y_, **attrs)
+
     out = (
         relay.strided_slice(out_, begin=[0, 0, 0], end=[x.value for x in output_tensor.shape])
         if dm or dn


### PR DESCRIPTION
The hardcoded shapes

```
    B, M, K = x_tensor.shape
    B, N, K = y_tensor.shape
```

is not valid if `transpose_b = False` or `transpose_a = True`.

@vinx13 