### PR TITLE
[TVMScript] Fix print round-tripable multi thread env binding

### DIFF
--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1045,7 +1045,6 @@ Doc TVMScriptPrinter::VisitStmt_(const AttrStmtNode* op) {
             << ")";
         doc << Doc::NewLine() << PrintBody(op->body);
       }
-      TryDeallocVar(iter_var->var);
       return doc;
     }
   }

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3537,6 +3537,19 @@ def nested_boolean_expressions():
         yield generator
 
 
+def multi_env_threads():
+    @T.prim_func
+    def func(A: T.Buffer[128, "float32"], C: T.Buffer[128, "float32"]):
+        B = T.alloc_buffer([128], dtype="float32")
+        for i in T.thread_binding(128, thread="threadIdx.x"):
+            B[i] = A[i] + 1.0
+        for i in T.thread_binding(128, thread="threadIdx.x"):
+            C[i] = B[i] + 2.0
+
+    mod = tvm.tir.transform.LowerOpaqueBlock()(tvm.IRModule.from_expr(func))
+    return mod["main"]
+
+
 ir_generator = tvm.testing.parameter(
     opt_gemm_normalize,
     opt_gemm_lower,
@@ -3593,6 +3606,7 @@ ir_generator = tvm.testing.parameter(
     elif_chain_without_else,
     elif_chain_with_else,
     *nested_boolean_expressions(),
+    multi_env_threads,
 )
 
 


### PR DESCRIPTION
Fix the following script with multiple kernel launch (each take standalone thread binding) which is not round-trip-able.
```python
import tvm
from tvm.script import tir as T

@T.prim_func
def main(A: T.Buffer[128, "float32"], C: T.Buffer[128, "float32"]):
    B = T.alloc_buffer([128], "float32")
    for i in range(128):
        with T.block("B1"):
            vi = T.axis.remap("S", [i])
            B[vi] = A[vi] + 1.0
    for i in range(128):
        with T.block("B2"):
            vi = T.axis.remap("S", [i])
            C[vi] = B[vi] + 2.0

s = tvm.tir.schedule.Schedule(main)
b1 = s.get_block("B1")
b2 = s.get_block("B2")
i = s.get_loops(b1)[0]
s.bind(i, "threadIdx.x")
i = s.get_loops(b2)[0]
s.bind(i, "threadIdx.x")
f = tvm.lower(s.mod["main"])
print(f.script())
tvm.ir.assert_structural_equal(f, tvm.script.from_source(f.script()))
```

Since the env thread is always printed on the function head, `TryDeallocVar` which decrease the name uniqueness counting may not be invoked for thread binding code path.