### PR TITLE
[MetaSchedule] Fix tensorcore winograd task extraction

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -261,6 +261,8 @@ def conv2d_strategy_cuda(attrs, inputs, out_type, target):
                     )
             if (
                 target.kind.name == "cuda"
+                and not is_auto_scheduler_enabled()
+                and not is_meta_schedule_enabled()
                 and nvcc.have_tensorcore(target=target)
                 and (
                     (N % 16 == 0 and CI % 16 == 0 and CO % 16 == 0)

--- a/tests/python/unittest/test_meta_schedule_relay_integration.py
+++ b/tests/python/unittest/test_meta_schedule_relay_integration.py
@@ -120,7 +120,8 @@ def test_task_extraction_winograd_tensorcore():
     with tvm.transform.PassContext(opt_level=3):
         mod = seq(mod)
 
-    extracted_tasks = ms.relay_integration.extract_tasks(mod, target="cuda", params=params)
+    target = tvm.target.Target("nvidia/geforce-rtx-3070")
+    extracted_tasks = ms.relay_integration.extract_tasks(mod, target=target, params=params)
 
     assert len([t for t in extracted_tasks if "winograd" in t.task_name]) == 4
 

--- a/tests/python/unittest/test_meta_schedule_relay_integration.py
+++ b/tests/python/unittest/test_meta_schedule_relay_integration.py
@@ -109,6 +109,23 @@ def test_meta_schedule_integration_extract_from_resnet():
 
 
 @requires_torch
+def test_task_extraction_winograd_tensorcore():
+    mod, params, _ = get_network(name="resnet_50", input_shape=[16, 3, 224, 224])
+    seq = tvm.transform.Sequential(
+        [
+            relay.transform.ToMixedPrecision("float16"),
+            relay.transform.ConvertLayout({"nn.conv2d": ["NHWC", "HWIO"]}),
+        ]
+    )
+    with tvm.transform.PassContext(opt_level=3):
+        mod = seq(mod)
+
+    extracted_tasks = ms.relay_integration.extract_tasks(mod, target="cuda", params=params)
+
+    assert len([t for t in extracted_tasks if "winograd" in t.task_name]) == 4
+
+
+@requires_torch
 def test_task_extraction_anchor_block():
     mod, params, _ = get_network(name="resnet_18", input_shape=[1, 3, 224, 224])
     extracted_tasks = ms.relay_integration.extract_tasks(


### PR DESCRIPTION
When both AutoTVM and AS/MS winograd are applicable, the latter is never picked by the op strategy because the AutoTVM one has a higher plevel (20 vs 15)

https://github.com/apache/tvm/blob/b16a64d6edb9fd1a014fc51995dff7d0e2f4c84e/python/tvm/relay/op/strategy/cuda.py#L271-L276

This has been fixed, and now we can properly extract FP16 winograd tasks for MS tuning.

@vinx13 @junrushao @zxybazh 