### PR TITLE
[Arith] Allow const folding on fp16 involving one and zero

### DIFF
--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -142,8 +142,6 @@ inline Optional<PrimExpr> TryConstFold<tir::Add>(PrimExpr a, PrimExpr b) {
                                                        static_cast<float>(fb->value)));
       } else if (rtype.bits() == 64) {
         return FloatImm(rtype, fa->value + fb->value);
-      } else {
-        return NullOpt;
       }
     }
     if (fa && fa->value == 0) return b;
@@ -171,8 +169,6 @@ inline Optional<PrimExpr> TryConstFold<tir::Sub>(PrimExpr a, PrimExpr b) {
                                                        static_cast<float>(fb->value)));
       } else if (rtype.bits() == 64) {
         return FloatImm(rtype, fa->value - fb->value);
-      } else {
-        return NullOpt;
       }
     }
     if (fb && fb->value == 0) return a;
@@ -202,8 +198,6 @@ inline Optional<PrimExpr> TryConstFold<tir::Mul>(PrimExpr a, PrimExpr b) {
                                                        static_cast<float>(fb->value)));
       } else if (rtype.bits() == 64) {
         return FloatImm(rtype, fa->value * fb->value);
-      } else {
-        return NullOpt;
       }
     }
     if (fa) {
@@ -243,8 +237,6 @@ inline Optional<PrimExpr> TryConstFold<tir::Div>(PrimExpr a, PrimExpr b) {
                                                        static_cast<float>(fb->value)));
       } else if (rtype.bits() == 64) {
         return FloatImm(rtype, fa->value / fb->value);
-      } else {
-        return NullOpt;
       }
     }
     if (fa && fa->value == 0) return a;

--- a/tests/python/unittest/test_arith_canonical_simplify.py
+++ b/tests/python/unittest/test_arith_canonical_simplify.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm.testing
 from tvm import te
 
 
@@ -122,6 +123,22 @@ def test_div_simplify():
     ck.verify(fld(16 + 48 * x, 16), x * 3 + 1)
     ck.verify(fld(17 + 48 * x, 16), x * 3 + 1)
     ck.verify(fld(17 + 47 * x, 16), fld(x * 47 + 17, 16))
+
+
+def test_fp16_const_fold():
+    ck = CanonicalChecker()
+    zero = tvm.tir.const(0, "float16")
+    one = tvm.tir.const(1, "float16")
+    half = tvm.tir.const(0.5, "float16")
+
+    ck.verify(zero + half, half)
+    ck.verify(half - zero, half)
+
+    ck.verify(zero * half, zero)
+    ck.verify(half * one, half)
+
+    ck.verify(half / one, half)
+    ck.verify(zero / half, zero)
 
 
 def test_floormod_simplify():
@@ -356,14 +373,4 @@ def test_simplify_cast():
 
 
 if __name__ == "__main__":
-    test_floormod_simplify()
-    test_mul_sum_simplify()
-    test_simplify_if_then_else()
-    test_div_simplify()
-    test_reduce_simplify()
-    test_reduce_combiner_simplify()
-
-    test_split_index_simplify()
-    test_canonical_mixed()
-    test_complex_cases()
-    test_simplify_cast()
+    tvm.testing.main()


### PR DESCRIPTION
Since https://github.com/apache/tvm/pull/12515, const folding on fp16, when both lhs and rhs are constant, is disabled. This is the case even when one of the arguments are one or zero. This leads to a real problem described in https://github.com/apache/tvm/pull/13532#issuecomment-1353715208. So in practice, compiling winograd fp16 on GPU is currently broken. 

This PR enables trivial algebraic simplification for fp16 const folding when (1) both arguments are constant and (2) one or both of the inputs are one or zero. Since we already do such simplification for any dtype when only one of the inputs are constant (for example https://github.com/apache/tvm/blob/3a639a41a830ece914df10a98f807123e46cd750/src/arith/const_fold.h#L209-L216), I just removed all early exit `return NullOpt` for fp16 cases and use the code path like above to simplify `0h * 2.5h` to `0h` etc.

cc @vinx13 @wrongtest-intellif @Lunderberg 