### PR TITLE
[ETHOSN] Update driver stack version to 22.11

### DIFF
--- a/cmake/utils/FindEthosN.cmake
+++ b/cmake/utils/FindEthosN.cmake
@@ -58,18 +58,6 @@ macro(find_ethosn use_ethosn)
       PATHS ${__ethosn_stack}/lib)
     find_library(ETHOSN_COMPILER_LIBRARY NAMES EthosNSupport)
 
-    list(GET ETHOSN_INCLUDE_DIRS 0 filename)
-    set(filename "${filename}/ethosn_support_library/Support.hpp")
-    file(READ ${filename} ETHOSN_SUPPORT_H)
-    string(REGEX MATCH "VERSION_MAJOR ([0-9]*)" _ ${ETHOSN_SUPPORT_H})
-    set(ver_major ${CMAKE_MATCH_1})
-    string(REGEX MATCH "VERSION_MINOR ([0-9]*)" _ ${ETHOSN_SUPPORT_H})
-    set(ver_minor ${CMAKE_MATCH_1})
-    string(REGEX MATCH "VERSION_PATCH ([0-9]*)" _ ${ETHOSN_SUPPORT_H})
-    set(ver_patch ${CMAKE_MATCH_1})
-    set(ETHOSN_PACKAGE_VERSION "${ver_major}.${ver_minor}.${ver_patch}")
-    set(ETHOSN_DEFINITIONS -DETHOSN_API_VERSION=${USE_ETHOSN_API_VERSION})
-
     # Runtime hardware support. Driver library also needed for
     # test support.
     find_path(_DL_DIR NAMES Network.hpp
@@ -81,9 +69,7 @@ macro(find_ethosn use_ethosn)
       PATHS ${__ethosn_stack}/lib)
     find_library(ETHOSN_RUNTIME_LIBRARY NAMES EthosNDriver)
     if(${USE_ETHOSN_HW} MATCHES ${IS_TRUE_PATTERN})
-      set(ETHOSN_DEFINITIONS -DETHOSN_HW -DETHOSN_API_VERSION=${USE_ETHOSN_API_VERSION})
-    else()
-      set(ETHOSN_DEFINITIONS -DETHOSN_API_VERSION=${USE_ETHOSN_API_VERSION})
+      set(ETHOSN_DEFINITIONS -DETHOSN_HW)
     endif()
 
     if(ETHOSN_COMPILER_LIBRARY)

--- a/docker/install/ubuntu_install_ethosn_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosn_driver_stack.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 repo_url="https://github.com/Arm-software/ethos-n-driver-stack"
 repo_dir="ethosn-driver"
-repo_revision="22.08"
+repo_revision="22.11"
 install_path="/opt/arm/$repo_dir"
 
 tmpdir=$(mktemp -d)

--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -117,7 +117,7 @@ def partition_for_ethosn(mod, params=None, **opts):
     ret : annotated and partitioned module.
     """
     api_version = ethosn_api_version()
-    supported_api_versions = ["3.1.0"]
+    supported_api_versions = ["3.2.0", "3.1.0"]
     if all(api_version != LooseVersion(exp_ver) for exp_ver in supported_api_versions):
         raise ValueError(
             f"Driver stack version {api_version} is unsupported. "

--- a/src/runtime/contrib/ethosn/ethosn_device.h
+++ b/src/runtime/contrib/ethosn/ethosn_device.h
@@ -38,10 +38,15 @@ namespace dl = ::ethosn::driver_library;
 
 using tvm::runtime::TVMArgs;
 
+#ifdef _ETHOSN_API_VERSION_3_2_0
+bool Inference(tvm::runtime::TVMArgs args, dl::ProcMemAllocator* proc_mem_alloc, dl::Network* npu,
+               const std::vector<uint32_t>& input_order, const std::vector<uint32_t>& output_order,
+               const std::vector<uint32_t>& input_sizes, const std::vector<uint32_t>& output_sizes);
+#else
 bool Inference(tvm::runtime::TVMArgs args, dl::Network* npu,
                const std::vector<uint32_t>& input_order, const std::vector<uint32_t>& output_order,
                const std::vector<uint32_t>& input_sizes, const std::vector<uint32_t>& output_sizes);
-
+#endif
 }  // namespace ethosn
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/contrib/ethosn/ethosn_runtime.cc
+++ b/src/runtime/contrib/ethosn/ethosn_runtime.cc
@@ -53,6 +53,11 @@ EthosnModule::EthosnModule(std::vector<OrderedCompiledNetwork>* cmms) {
     if (it.compiled_cmm != nullptr) {
       network_map_[it.name].compiled_cmm = std::move(it.compiled_cmm);
     }
+#ifdef _ETHOSN_API_VERSION_3_2_0
+    if (it.proc_mem_alloc != nullptr) {
+      network_map_[it.name].proc_mem_alloc = std::move(it.proc_mem_alloc);
+    }
+#endif
     if (it.runtime_cmm != nullptr) {
       network_map_[it.name].runtime_cmm = std::move(it.runtime_cmm);
     }
@@ -67,9 +72,16 @@ PackedFunc EthosnModule::GetFunction(const std::string& name,
                                      const ObjectPtr<Object>& sptr_to_self) {
   if (network_map_.find(name) != network_map_.end()) {
     return PackedFunc([sptr_to_self, this, name](TVMArgs args, TVMRetValue* rv) {
+#ifdef _ETHOSN_API_VERSION_3_2_0
+      *rv = Inference(args, network_map_[name].proc_mem_alloc.get(),
+                      network_map_[name].runtime_cmm.get(), network_map_[name].inputs,
+                      network_map_[name].outputs, network_map_[name].input_sizes,
+                      network_map_[name].output_sizes);
+#else
       *rv = Inference(args, network_map_[name].runtime_cmm.get(), network_map_[name].inputs,
                       network_map_[name].outputs, network_map_[name].input_sizes,
                       network_map_[name].output_sizes);
+#endif
     });
   } else {
     return PackedFunc();
@@ -102,6 +114,9 @@ Module EthosnModule::LoadFromBinary(void* strm) {
   cmms.resize(func_count);
   for (unsigned int i = 0; i < func_count; i++) {
     OrderedCompiledNetwork& compiled = cmms[i];
+#ifdef _ETHOSN_API_VERSION_3_2_0
+    compiled.proc_mem_alloc = std::make_unique<dl::ProcMemAllocator>();
+#endif
     std::string ext_symbol;
     std::string cmm;
     uint64_t input_size;
@@ -114,7 +129,12 @@ Module EthosnModule::LoadFromBinary(void* strm) {
 #if defined ETHOSN_HW
     // If hardware unavaiable use the mock inference functionality. If hardware is
     // avaiable, deserialize the compiled graph.
+#ifdef _ETHOSN_API_VERSION_3_2_0
+    compiled.runtime_cmm = std::make_unique<dl::Network>(
+        compiled.proc_mem_alloc->CreateNetwork(cmm.c_str(), cmm.size()));
+#else
     compiled.runtime_cmm = std::make_unique<dl::Network>(cmm.c_str(), cmm.size());
+#endif
 #endif
     // Read the number of inputs
     stream->Read<uint64_t>(&input_size);

--- a/src/runtime/contrib/ethosn/ethosn_runtime.h
+++ b/src/runtime/contrib/ethosn/ethosn_runtime.h
@@ -36,6 +36,14 @@
 #include "ethosn_driver_library/Network.hpp"
 #include "ethosn_support_library/Support.hpp"
 
+#if ETHOSN_SUPPORT_LIBRARY_VERSION_MAJOR == 3 && ETHOSN_SUPPORT_LIBRARY_VERSION_MINOR == 2 && \
+    ETHOSN_SUPPORT_LIBRARY_VERSION_PATCH == 0
+#define _ETHOSN_API_VERSION_3_2_0
+#endif
+#ifdef _ETHOSN_API_VERSION_3_2_0
+#include "ethosn_driver_library/ProcMemAllocator.hpp"
+#endif
+
 namespace tvm {
 namespace runtime {
 namespace ethosn {
@@ -46,6 +54,9 @@ namespace dl = ::ethosn::driver_library;
 struct OrderedCompiledNetwork {
   std::unique_ptr<sl::CompiledNetwork> compiled_cmm;
   std::unique_ptr<dl::Network> runtime_cmm;
+#ifdef _ETHOSN_API_VERSION_3_2_0
+  std::unique_ptr<dl::ProcMemAllocator> proc_mem_alloc;
+#endif
   std::string name;
   std::vector<uint32_t> inputs;
   std::vector<uint32_t> outputs;

--- a/tests/python/contrib/test_ethosn/infrastructure.py
+++ b/tests/python/contrib/test_ethosn/infrastructure.py
@@ -168,7 +168,6 @@ def build(
     if not additional_config_args:
         additional_config_args = {}
     npu_config = {**get_ethosn_device_options(), **additional_config_args}
-    print(npu_config)
     with tvm.transform.PassContext(opt_level=3, config={"relay.ext.ethos-n.options": npu_config}):
         with tvm.target.Target("llvm"):
             if npu:

--- a/tests/python/contrib/test_ethosn/test_conv2d.py
+++ b/tests/python/contrib/test_ethosn/test_conv2d.py
@@ -22,6 +22,7 @@ import pytest
 
 import tvm
 from tvm import relay
+from tvm.relay.op.contrib import ethosn_api_version
 from tvm.testing import requires_ethosn
 
 from . import infrastructure as tei
@@ -227,7 +228,10 @@ def test_conv2d_depthwise(
             )
         ),
     }
-    input_zp = np.random.randint(np.iinfo(dtype).min, np.iinfo(dtype).max)
+    if ethosn_api_version() == "3.2.0":
+        input_zp = np.random.randint(0, np.iinfo(dtype).max)
+    else:
+        input_zp = np.random.randint(np.iinfo(dtype).min, np.iinfo(dtype).max)
     input_sc = np.random.random() * 2
     if qnn_per_channel:
         kernel_sc = tvm.nd.array(

--- a/tests/python/contrib/test_ethosn/test_leaky_relu.py
+++ b/tests/python/contrib/test_ethosn/test_leaky_relu.py
@@ -22,6 +22,7 @@ import numpy as np
 
 import tvm
 from tvm import relay
+from tvm.relay.op.contrib import ethosn_api_version
 from tvm.testing import requires_ethosn
 
 from . import infrastructure as tei
@@ -55,9 +56,12 @@ def test_leaky_relu(dtype, shape, alpha):
     iinfo = np.iinfo(dtype)
     zp_min = iinfo.min
     zp_max = iinfo.max
-    input_zp = zp_min + 120
+    if ethosn_api_version() == "3.2.0":
+        input_zp = zp_min + 128
+    else:
+        input_zp = zp_min + 120
     input_sc = 0.0068132
-    output_zp = zp_min + 128
+    output_zp = zp_min + 126  # values offset more than 126 can cause saturation
     output_sc = 0.0078125
 
     inputs = {"x": tvm.nd.array(np.random.randint(zp_min, high=zp_max, size=shape, dtype=dtype))}

--- a/tests/python/contrib/test_ethosn/test_tanh.py
+++ b/tests/python/contrib/test_ethosn/test_tanh.py
@@ -47,7 +47,6 @@ def _get_model(shape, input_zp, input_sc, output_zp, output_sc, dtype):
 @pytest.mark.parametrize("shape", [(1, 52, 52, 3)])
 def test_tanh(dtype, shape):
     """Compare Tanh output with TVM."""
-
     zp_min = np.iinfo(dtype).min
     zp_max = np.iinfo(dtype).max
 
@@ -57,7 +56,7 @@ def test_tanh(dtype, shape):
     }
     outputs = []
     for npu in [False, True]:
-        model = _get_model(shape, zp_min + 120, 0.0250629, zp_min + 128, 0.0078125, dtype)
+        model = _get_model(shape, zp_min + 128, 1 / 256, zp_min + 128, 1 / 128, dtype)
         mod = tei.make_module(model, [])
         outputs.append(
             tei.build_and_run(


### PR DESCRIPTION
NPU driver updated to 22.11.


New process memory allocator is used to create
buffers and networks. Support for 22.08 stack has
been kept intact in the sources and tests until the new
docker image is built and starts getting used. Tests
were modified to meet limitations imposed on input
zero point and kernel size by NPU software. Removed
defining ETHON_API_VERSION from cmake infra.

