### PR TITLE
[BugFix][TVMScript]fix var capturing order error

### DIFF
--- a/python/tvm/script/parser/core/utils.py
+++ b/python/tvm/script/parser/core/utils.py
@@ -37,8 +37,8 @@ def inspect_function_capture(func: Callable) -> Dict[str, Any]:
         The function variables map with non-local or global variables.
     """
     captured = {
-        **inspect.getclosurevars(func).nonlocals,
         **func.__globals__,  # type: ignore
+        **inspect.getclosurevars(func).nonlocals,
     }
     return captured
 

--- a/tests/python/unittest/test_tvmscript_regression.py
+++ b/tests/python/unittest/test_tvmscript_regression.py
@@ -74,8 +74,8 @@ def test_var_capturing_order():
 
 
 if __name__ == "__main__":
-    b = 1
     a = numpy.zeros((10, 10), dtype="int8")
     test_multi_element_array_in_outmost_namespace()
     test_different_dtype_assignment_to_var()
+    b = 1
     test_var_capturing_order()

--- a/tests/python/unittest/test_tvmscript_regression.py
+++ b/tests/python/unittest/test_tvmscript_regression.py
@@ -58,7 +58,24 @@ def test_different_dtype_assignment_to_var():
     tvm.ir.assert_structural_equal(test_case, func_ref)
 
 
+def test_var_capturing_order():
+    b = 2
+
+    @T.prim_func
+    def test_case():
+        k: T.int32 = b
+
+    @T.prim_func
+    def func_ref():
+        k: T.int32 = 2
+        T.evaluate(0)
+
+    tvm.ir.assert_structural_equal(test_case, func_ref)
+
+
 if __name__ == "__main__":
+    b = 1
     a = numpy.zeros((10, 10), dtype="int8")
     test_multi_element_array_in_outmost_namespace()
     test_different_dtype_assignment_to_var()
+    test_var_capturing_order()


### PR DESCRIPTION
This PR try to fix the following bug:
```python
def test_var_capturing_order():
    b = 2

    @T.prim_func
    def test_case():
        k: T.int32 = b


if __name__ == "__main__":
    b = 1
```
In the prim func `test_case`, the vaule of b should be 2, rather than 1. The parser wrongly uses global vars to shadow the value of nonlocal vars, which should be reversed.