### PR TITLE
[CMSIS-NN] Add a runtime error message

### DIFF
--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -728,6 +728,7 @@ def run_and_check(
     test_dir: str = None,
     verbose: bool = False,
     use_workspace_io: bool = False,
+    debug_last_error: bool = False,
     checker: Optional[Callable[[str], bool]] = None,
 ):
     """
@@ -793,8 +794,6 @@ def run_and_check(
                 )
 
         use_usmp = runner.pass_config.get("tir.usmp.enable", False)
-        options = runner.pass_config.get("relay.ext.cmsisnn.options")
-        debug_last_error = options.get("debug_last_error", False) if options else False
         # We only need the stack allocator if USMP is not used
         use_stack_allocator = not use_usmp
 
@@ -888,6 +887,7 @@ def compile_and_run(
     test_dir: str = None,
     verbose: bool = False,
     schedule_name: str = None,
+    debug_last_error: bool = False,
     checker: Optional[Callable[[str], bool]] = None,
 ) -> bool:
     """This is a wrapper API to compile and run models as test for AoT
@@ -930,6 +930,7 @@ def compile_and_run(
         data_linkage=data_linkage,
         test_dir=test_dir,
         verbose=verbose,
+        debug_last_error=debug_last_error,
         checker=checker,
     )
 

--- a/src/relay/backend/contrib/cmsisnn/compiler_attrs.cc
+++ b/src/relay/backend/contrib/cmsisnn/compiler_attrs.cc
@@ -40,11 +40,13 @@ Target CreateTarget(const tvm::transform::PassContext& ctx) {
 
   String mcpu = cfg.value()->mcpu;
   Array<String> mattr = {cfg.value()->mattr};
+  Bool debug_last_error = cfg.value()->debug_last_error;
 
   Target cmsis_nn_target(TargetJSON{
       {"kind", String("cmsis-nn")},
       {"mcpu", mcpu},
       {"mattr", mattr},
+      {"debug_last_error", debug_last_error},
   });
 
   return cmsis_nn_target;

--- a/src/relay/backend/contrib/cmsisnn/compiler_attrs.h
+++ b/src/relay/backend/contrib/cmsisnn/compiler_attrs.h
@@ -37,6 +37,7 @@ namespace cmsisnn {
 struct CMSISNNCompilerConfigNode : public tvm::AttrsNode<CMSISNNCompilerConfigNode> {
   String mcpu;
   String mattr;
+  Bool debug_last_error = Bool(false);
 
   TVM_DECLARE_ATTRS(CMSISNNCompilerConfigNode, "ext.attrs.CMSISNNCompilerConfigNode") {
     TVM_ATTR_FIELD(mcpu)
@@ -47,6 +48,9 @@ struct CMSISNNCompilerConfigNode : public tvm::AttrsNode<CMSISNNCompilerConfigNo
     TVM_ATTR_FIELD(mattr)
         .describe("The attributes to configure CMSIS-NN (i.e. +nodsp, +nomve)")
         .set_default("");
+    TVM_ATTR_FIELD(debug_last_error)
+        .describe("Whether to enable storing the last error")
+        .set_default(Bool(false));
   }
 };
 

--- a/src/relay/backend/contrib/cmsisnn/target.cc
+++ b/src/relay/backend/contrib/cmsisnn/target.cc
@@ -36,6 +36,7 @@ runtime::Module TIRToRuntime(IRModule mod, Target target);
 TVM_REGISTER_TARGET_KIND("cmsis-nn", kDLCPU)
     .add_attr_option<Array<String>>("mattr")
     .add_attr_option<String>("mcpu")
+    .add_attr_option<Bool>("debug_last_error")
     .set_attr<FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
     .set_attr<FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime)
     .set_target_parser(tvm::target::parsers::cpu::ParseTarget);

--- a/src/relay/backend/contrib/cmsisnn/tir_to_runtime.cc
+++ b/src/relay/backend/contrib/cmsisnn/tir_to_runtime.cc
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <tvm/ir/transform.h>
+
 #include <cmath>
 #include <fstream>
 #include <map>
@@ -26,6 +28,7 @@
 #include "../../../../runtime/file_utils.h"
 #include "../../../../target/source/codegen_c.h"
 #include "../../../../target/source/codegen_c_host.h"
+#include "compiler_attrs.h"
 
 namespace tvm {
 using namespace tir;
@@ -35,7 +38,9 @@ namespace cmsisnn {
 
 class CodeGenCMSISNN : public codegen::CodeGenCHost {
  public:
-  void Init(bool output_ssa, bool emit_asserts, bool emit_fwd_func_decl, std::string target_str) {
+  void Init(bool output_ssa, bool emit_asserts, bool emit_fwd_func_decl, std::string target_str,
+            bool debug_last_error) {
+    this->debug_last_error = debug_last_error;
     std::unordered_set<std::string> devices;
     devices.insert("cmsis-nn");
     CodeGenCHost::Init(output_ssa, emit_asserts, emit_fwd_func_decl, target_str, devices);
@@ -49,6 +54,9 @@ class CodeGenCMSISNN : public codegen::CodeGenCHost {
   void AddFunction(const PrimFunc& prim_func) { CodeGenC::AddFunction(prim_func); }
 
  private:
+  /*!  * \brief Enable storing the last error */
+  bool debug_last_error;
+
   /*!  * \brief CMSIS-NN context buffer info */
   struct CMSISNNContextBuffer {
     std::string name;
@@ -357,13 +365,7 @@ class CodeGenCMSISNN : public codegen::CodeGenCHost {
     stream << "&" << filter_dim << ", " << filter_data << ", ";
     stream << "&" << bias_dim << ", " << bias_data << ", ";
     stream << "&" << output_dim << ", " << output_data << ");\n";
-    PrintIndent();
-    stream << "if (status != ARM_CMSIS_NN_SUCCESS) {\n";
-    PrintIndent();
-    PrintIndent();
-    stream << "return -1;\n";
-    PrintIndent();
-    stream << "}\n";
+    EmitErrorCheck();
   }
 
   /*!  * \brief Emits CMSIS-NN APIs for every call_extern comprising fully connected */
@@ -426,13 +428,7 @@ class CodeGenCMSISNN : public codegen::CodeGenCHost {
     stream << "&" << filter_dim << ", " << filter_data << ", ";
     stream << "&" << bias_dim << ", " << bias_data << ", ";
     stream << "&" << output_dim << ", " << output_data << ");\n";
-    PrintIndent();
-    stream << "if (status != ARM_CMSIS_NN_SUCCESS) {\n";
-    PrintIndent();
-    PrintIndent();
-    stream << "return -1;\n";
-    PrintIndent();
-    stream << "}\n";
+    EmitErrorCheck();
   }
 
   /*!  * \brief Emits CMSIS-NN APIs for every call_extern comprising pooling ops */
@@ -480,24 +476,51 @@ class CodeGenCMSISNN : public codegen::CodeGenCHost {
     stream << "&" << input_dim << ", " << input_data << ", ";
     stream << "&" << filter_dim << ", ";
     stream << "&" << output_dim << ", " << output_data << ");\n";
+    EmitErrorCheck();
+  }
+
+  void EmitErrorCheck() {
+    auto emit_error = [&](std::string error) {
+      if (this->debug_last_error) {
+        stream << "TVMAPISetLastError(\"" << error << "\"); ";
+      }
+    };
+
     PrintIndent();
-    stream << "if (status != ARM_CMSIS_NN_SUCCESS) {\n";
+    stream << "switch (!status) {\n";
     PrintIndent();
+    stream << "case ARM_CMSIS_NN_SUCCESS: break;\n";
     PrintIndent();
+    stream << "case ARM_CMSIS_NN_ARG_ERROR: ";
+    emit_error("ARM_CMSIS_NN_ARG_ERROR");
+    stream << "return -1;\n";
+    PrintIndent();
+    stream << "case ARM_CMSIS_NN_NO_IMPL_ERROR: ";
+    emit_error("ARM_CMSIS_NN_NO_IMPL_ERROR");
     stream << "return -1;\n";
     PrintIndent();
     stream << "}\n";
   }
 };
 
+static CMSISNNCompilerConfig GetCompilerAttrs() {
+  auto ctx = tvm::tir::transform::PassContext::Current();
+  Optional<CMSISNNCompilerConfig> cfg =
+      ctx->GetConfig<CMSISNNCompilerConfig>("relay.ext.cmsisnn.options");
+  if (!cfg.defined()) {
+    return AttrsWithDefaultValues<CMSISNNCompilerConfig>();
+  }
+  return cfg.value();
+}
+
 runtime::Module TIRToRuntime(IRModule mod, Target target) {
   bool output_ssa = false;
   bool emit_asserts = false;
   bool emit_fwd_func_decl = false;
+  bool debug_last_error = GetCompilerAttrs()->debug_last_error;
   CodeGenCMSISNN codegen;
   Array<String> function_names;
-  codegen.Init(output_ssa, emit_asserts, emit_fwd_func_decl, target->str());
-
+  codegen.Init(output_ssa, emit_asserts, emit_fwd_func_decl, target->str(), debug_last_error);
   std::vector<std::pair<tvm::GlobalVar, tvm::BaseFunc>> funcs;
   for (auto kv : mod->functions) {
     funcs.push_back(kv);

--- a/tests/python/contrib/test_cmsisnn/test_last_error.py
+++ b/tests/python/contrib/test_cmsisnn/test_last_error.py
@@ -158,6 +158,7 @@ def test_last_error(debug_last_error):
         create_test_runner(compiler_cpu, cpu_flags, debug_last_error=debug_last_error),
         interface_api,
         use_unpacked_api,
+        debug_last_error=debug_last_error,
         checker=checker,
     )
     assert result

--- a/tests/python/contrib/test_cmsisnn/test_last_error.py
+++ b/tests/python/contrib/test_cmsisnn/test_last_error.py
@@ -15,82 +15,102 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""CMSIS-NN integration tests: test if the model builds in case debug_last_error is enabled"""
+"""CMSIS-NN integration tests: debug_last_error"""
 
+import re
 import numpy as np
 import pytest
-
 import tvm
 from tvm import relay
 from tvm.relay.op.contrib import cmsisnn
-from tvm.testing.aot import get_dtype_range, generate_ref_data, AOTTestModel, compile_and_run
 
-
+from tvm.testing.aot import (
+    get_dtype_range,
+    generate_ref_data,
+    AOTTestModel,
+    compile_and_run,
+)
 from .utils import (
-    skip_if_no_reference_system,
     make_module,
+    get_same_padding,
     make_qnn_relu,
     assert_partitioned_function,
     create_test_runner,
 )
 
 
-def generate_variable(name, dtype="int8"):
-    return relay.var(name, shape=(1, 16, 16, 3), dtype=dtype)
-
-
 def make_model(
-    op,
-    input_0,
-    input_1,
-    input_0_scale,
-    input_0_zero_point,
-    input_1_scale,
-    input_1_zero_point,
-    relu_type="NONE",
-    out_scale=1.0 / 256,
-    out_zero_point=-128,
+    pool_op,
+    shape,
+    pool_size,
+    strides,
+    padding,
+    dtype,
+    scale,
+    zero_point,
+    relu_type,
+    layout,
+    input_op,
 ):
     """Create a Relay Function / network model"""
-    binary_op = op(
-        input_0,
-        input_1,
-        relay.const(input_0_scale, "float32"),
-        relay.const(input_0_zero_point, "int32"),
-        relay.const(input_1_scale, "float32"),
-        relay.const(input_1_zero_point, "int32"),
-        relay.const(out_scale, "float32"),
-        relay.const(out_zero_point, "int32"),
+    if input_op:
+        op = input_op
+    else:
+        op = relay.var("input", shape=shape, dtype=dtype)
+    pad_ = (0, 0, 0, 0)
+    if padding == "SAME":
+        dilation = (1, 1)
+        pad_ = get_same_padding((shape[1], shape[2]), pool_size, dilation, strides)
+        op = relay.nn.pad(
+            op,
+            pad_width=[(0, 0), (pad_[0], pad_[2]), (pad_[1], pad_[3]), (0, 0)],
+            pad_value=zero_point,
+            pad_mode="constant",
+        )
+    if pool_op.__name__ == relay.nn.avg_pool2d.__name__:
+        op = relay.cast(op, "int32")
+    op = pool_op(
+        op, pool_size=pool_size, strides=strides, padding=pad_, ceil_mode=True, layout=layout
     )
-    return make_qnn_relu(binary_op, relu_type, out_scale, out_zero_point, "int8")
+    if pool_op.__name__ == relay.nn.avg_pool2d.__name__:
+        op = relay.cast(op, dtype)
+    op = make_qnn_relu(op, relu_type, scale, zero_point, dtype)
+    return op
 
 
-@skip_if_no_reference_system
 @tvm.testing.requires_cmsisnn
 @pytest.mark.parametrize("debug_last_error", [True, False])
 def test_last_error(debug_last_error):
     """Tests debug_last_error"""
-    op = relay.qnn.op.add
+    dtype = "int16"
+    in_shape = (1, 28, 28, 12)
+    pool_size = (3, 3)
+    strides = (2, 2)
+    padding = "SAME"
     relu_type = "NONE"
-    input_0_scale, input_0_zero_point = (0.256, 33)
-    input_1_scale, input_1_zero_point = (0.256, 33)
+    pool_type = relay.nn.avg_pool2d
+    zero_point = -34
+    scale = 0.0256
     compiler_cpu = "cortex-m55"
-    cpu_flags = ""
+    cpu_flags = "+nomve"
+    layout = "NHWC"
+    input_op = None
 
     interface_api = "c"
     use_unpacked_api = True
 
-    dtype = "int8"
-    shape = [1, 16, 16, 3]
     model = make_model(
-        op,
-        generate_variable("input_0"),
-        generate_variable("input_1"),
-        input_0_scale,
-        input_0_zero_point,
-        input_1_scale,
-        input_1_zero_point,
-        relu_type,
+        pool_op=pool_type,
+        shape=in_shape,
+        pool_size=pool_size,
+        strides=strides,
+        padding=padding,
+        dtype=dtype,
+        scale=scale,
+        zero_point=zero_point,
+        relu_type=relu_type,
+        layout=layout,
+        input_op=input_op,
     )
     orig_mod = make_module(model)
 
@@ -102,18 +122,42 @@ def test_last_error(debug_last_error):
     # validate the output
     in_min, in_max = get_dtype_range(dtype)
     inputs = {
-        "input_0": np.random.randint(in_min, high=in_max, size=shape, dtype=dtype),
-        "input_1": np.random.randint(in_min, high=in_max, size=shape, dtype=dtype),
+        "input": np.random.randint(in_min, high=in_max, size=in_shape, dtype=dtype),
     }
     output_list = generate_ref_data(orig_mod["main"], inputs)
-    compile_and_run(
+
+    def checker(base_path: str) -> bool:
+        def read_file(path):
+            with open(path) as f:
+                return f.read()
+
+        test = read_file(base_path + "/build/test.c")
+        test_check = "TVMGetLastError" in test
+
+        default_lib2 = read_file(base_path + "/codegen/host/src/default_lib2.c")
+        regex = (
+            r"(?s)arm_avgpool_s16(.*?)"
+            r'ARM_CMSIS_NN_ARG_ERROR: TVMAPISetLastError\("ARM_CMSIS_NN_ARG_ERROR(.*?)'
+            r'ARM_CMSIS_NN_NO_IMPL_ERROR: TVMAPISetLastError\("ARM_CMSIS_NN_NO_IMPL_ERROR'
+        )
+        default_lib2_check = re.search(regex, default_lib2) is not None
+
+        if debug_last_error:
+            return test_check and default_lib2_check
+        else:
+            return not (test_check or default_lib2_check)
+
+    result = compile_and_run(
         AOTTestModel(
             module=cmsisnn_mod,
             inputs=inputs,
             outputs=output_list,
+            params=None,
             output_tolerance=1,
         ),
         create_test_runner(compiler_cpu, cpu_flags, debug_last_error=debug_last_error),
         interface_api,
         use_unpacked_api,
+        checker=checker,
     )
+    assert result

--- a/tests/python/contrib/test_cmsisnn/test_last_error.py
+++ b/tests/python/contrib/test_cmsisnn/test_last_error.py
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""CMSIS-NN integration tests: test if the model builds in case debug_last_error is enabled"""
+
+import numpy as np
+import pytest
+
+import tvm
+from tvm import relay
+from tvm.relay.op.contrib import cmsisnn
+from tvm.testing.aot import get_dtype_range, generate_ref_data, AOTTestModel, compile_and_run
+
+
+from .utils import (
+    skip_if_no_reference_system,
+    make_module,
+    make_qnn_relu,
+    assert_partitioned_function,
+    create_test_runner,
+)
+
+
+def generate_variable(name, dtype="int8"):
+    return relay.var(name, shape=(1, 16, 16, 3), dtype=dtype)
+
+
+def make_model(
+    op,
+    input_0,
+    input_1,
+    input_0_scale,
+    input_0_zero_point,
+    input_1_scale,
+    input_1_zero_point,
+    relu_type="NONE",
+    out_scale=1.0 / 256,
+    out_zero_point=-128,
+):
+    """Create a Relay Function / network model"""
+    binary_op = op(
+        input_0,
+        input_1,
+        relay.const(input_0_scale, "float32"),
+        relay.const(input_0_zero_point, "int32"),
+        relay.const(input_1_scale, "float32"),
+        relay.const(input_1_zero_point, "int32"),
+        relay.const(out_scale, "float32"),
+        relay.const(out_zero_point, "int32"),
+    )
+    return make_qnn_relu(binary_op, relu_type, out_scale, out_zero_point, "int8")
+
+
+@skip_if_no_reference_system
+@tvm.testing.requires_cmsisnn
+@pytest.mark.parametrize("debug_last_error", [True, False])
+def test_last_error(debug_last_error):
+    """Tests debug_last_error"""
+    op = relay.qnn.op.add
+    relu_type = "NONE"
+    input_0_scale, input_0_zero_point = (0.256, 33)
+    input_1_scale, input_1_zero_point = (0.256, 33)
+    compiler_cpu = "cortex-m55"
+    cpu_flags = ""
+
+    interface_api = "c"
+    use_unpacked_api = True
+
+    dtype = "int8"
+    shape = [1, 16, 16, 3]
+    model = make_model(
+        op,
+        generate_variable("input_0"),
+        generate_variable("input_1"),
+        input_0_scale,
+        input_0_zero_point,
+        input_1_scale,
+        input_1_zero_point,
+        relu_type,
+    )
+    orig_mod = make_module(model)
+
+    cmsisnn_mod = cmsisnn.partition_for_cmsisnn(orig_mod)
+
+    # validate pattern matching
+    assert_partitioned_function(orig_mod, cmsisnn_mod)
+
+    # validate the output
+    in_min, in_max = get_dtype_range(dtype)
+    inputs = {
+        "input_0": np.random.randint(in_min, high=in_max, size=shape, dtype=dtype),
+        "input_1": np.random.randint(in_min, high=in_max, size=shape, dtype=dtype),
+    }
+    output_list = generate_ref_data(orig_mod["main"], inputs)
+    compile_and_run(
+        AOTTestModel(
+            module=cmsisnn_mod,
+            inputs=inputs,
+            outputs=output_list,
+            output_tolerance=1,
+        ),
+        create_test_runner(compiler_cpu, cpu_flags, debug_last_error=debug_last_error),
+        interface_api,
+        use_unpacked_api,
+    )

--- a/tests/python/contrib/test_cmsisnn/utils.py
+++ b/tests/python/contrib/test_cmsisnn/utils.py
@@ -252,7 +252,7 @@ class CheckForPadsWithinCompositeFunc(tvm.relay.ExprVisitor):
         assert self.num_pads_ > 0, "Composite function should have pads within it."
 
 
-def create_test_runner(compiler_cpu="cortex-m55", cpu_flags=""):
+def create_test_runner(compiler_cpu="cortex-m55", cpu_flags="", debug_last_error=False):
     """
     Creates AOT test runner for CMSIS-NN tests.
 
@@ -267,6 +267,8 @@ def create_test_runner(compiler_cpu="cortex-m55", cpu_flags=""):
         Arm(R) Cortex(R)-M55: when null +mve is set by default.
             +nomve disables vector extensions.
         Arm(R) Cortex(R)-M7 does not support mve.
+    debug_last_error: bool
+        Whether to enable storing the last error
     """
     # cmsis_cpu is used to find out start up code inside CMSIS package
     cmsis_cpu = "ARMCM7" if compiler_cpu == "cortex-m7" else "ARMCM55"
@@ -280,6 +282,7 @@ def create_test_runner(compiler_cpu="cortex-m55", cpu_flags=""):
         pass_config={
             "relay.ext.cmsisnn.options": {
                 "mcpu": compiler_cpu + cpu_flags,
+                "debug_last_error": debug_last_error,
             },
             "tir.usmp.enable": True,
             "tir.disable_storage_rewrite": True,
@@ -289,5 +292,6 @@ def create_test_runner(compiler_cpu="cortex-m55", cpu_flags=""):
             "MCPU": compiler_cpu,
             "MCPU_FLAGS": cpu_flags,
             "MFLOAT_ABI": mfloat_abi,
+            "DEBUG_LAST_ERROR": 1 if debug_last_error else 0,
         },
     )

--- a/tests/python/relay/aot/corstone300.mk
+++ b/tests/python/relay/aot/corstone300.mk
@@ -98,6 +98,22 @@ $(build_dir)/crt_backend_api.o: $(TVM_ROOT)/src/runtime/crt/common/crt_backend_a
 	$(QUIET)mkdir -p $(@D)
 	$(QUIET)$(CC) -c $(PKG_CFLAGS) -o $@  $^
 
+ifeq ($(DEBUG_LAST_ERROR), 1)
+$(build_dir)/crt_runtime_api.o: $(TVM_ROOT)/src/runtime/crt/common/crt_runtime_api.c
+	$(QUIET)mkdir -p $(@D)
+	$(QUIET)$(CC) -c $(PKG_CFLAGS) -o $@  $^
+
+$(build_dir)/func_registry.o: $(TVM_ROOT)/src/runtime/crt/common/func_registry.c
+	$(QUIET)mkdir -p $(@D)
+	$(QUIET)$(CC) -c $(PKG_CFLAGS) -o $@  $^
+
+$(build_dir)/ndarray.o: $(TVM_ROOT)/src/runtime/crt/common/ndarray.c
+	$(QUIET)mkdir -p $(@D)
+	$(QUIET)$(CC) -c $(PKG_CFLAGS) -o $@  $^
+
+DEBUG_LAST_ERROR_SOURCES = $(build_dir)/crt_runtime_api.o $(build_dir)/func_registry.o $(build_dir)/ndarray.o
+endif
+
 $(build_dir)/tvm_ethosu_runtime.o: $(TVM_ROOT)/src/runtime/contrib/ethosu/bare_metal/tvm_ethosu_runtime.c
 	$(QUIET)mkdir -p $(@D)
 	$(QUIET)$(CC) -c $(PKG_CFLAGS) -o $@  $^
@@ -131,7 +147,7 @@ ${build_dir}/ethosu_core_platform/libethosu_uart_cmsdk_apb.a:
 	$(QUIET)cd ${ETHOSU_PLATFORM_PATH}/drivers/uart && $(CMAKE) -B $(abspath $(build_dir)/ethosu_core_platform) $(CMAKE_FLAGS)
 	$(QUIET)cd $(abspath $(build_dir)/ethosu_core_platform) && $(MAKE)
 
-$(build_dir)/aot_test_runner: $(build_dir)/test.c $(build_dir)/crt_backend_api.o $(build_dir)/stack_allocator.o $(build_dir)/libcodegen.a ${build_dir}/libcmsis_startup.a ${build_dir}/libcmsis_nn.a ${build_dir}/libcorstone.a ${build_dir}/ethosu_core_platform/libethosu_uart_cmsdk_apb.a $(ETHOSU_DRIVER_LIBS) $(ETHOSU_RUNTIME)
+$(build_dir)/aot_test_runner: $(build_dir)/test.c $(build_dir)/crt_backend_api.o $(build_dir)/stack_allocator.o $(build_dir)/libcodegen.a ${build_dir}/libcmsis_startup.a ${build_dir}/libcmsis_nn.a ${build_dir}/libcorstone.a ${build_dir}/ethosu_core_platform/libethosu_uart_cmsdk_apb.a $(ETHOSU_DRIVER_LIBS) $(ETHOSU_RUNTIME) $(DEBUG_LAST_ERROR_SOURCES)
 	$(QUIET)mkdir -p $(@D)
 	$(QUIET)$(CC) $(PKG_CFLAGS) $(ETHOSU_INCLUDE) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive $(PKG_LDFLAGS)
 


### PR DESCRIPTION
This pr generates the code to catch and save, through TVMAPISetLastError, a CMSIS-NN error. 
In case an error is raised, it is retrieved with TVMGetLastError in the AOT test runner, and then it is printed.

@ashutosh-arm