### PR TITLE
[CMSIS-NN] Add Cortex-M85 support

### DIFF
--- a/src/target/parsers/mprofile.cc
+++ b/src/target/parsers/mprofile.cc
@@ -36,9 +36,9 @@ const TargetFeatures kHasDSP = {{"has_dsp", Bool(true)}, {"has_mve", Bool(false)
 const TargetFeatures kHasMVE = {{"has_dsp", Bool(true)}, {"has_mve", Bool(true)}};
 
 static const char* baseCPUs[] = {"cortex-m0", "cortex-m3"};
-static const char* dspCPUs[] = {"cortex-m55", "cortex-m4", "cortex-m7", "cortex-m33",
-                                "cortex-m35p"};
-static const char* mveCPUs[] = {"cortex-m55"};
+static const char* dspCPUs[] = {"cortex-m55", "cortex-m4",   "cortex-m7",
+                                "cortex-m33", "cortex-m35p", "cortex-m85"};
+static const char* mveCPUs[] = {"cortex-m55", "cortex-m85"};
 
 template <typename Container>
 static inline bool MatchesCpu(Optional<String> mcpu, const Container& cpus) {

--- a/tests/cpp/relay/backend/contrib/cmsisnn/compiler_attrs_test.cc
+++ b/tests/cpp/relay/backend/contrib/cmsisnn/compiler_attrs_test.cc
@@ -53,14 +53,26 @@ TEST(CMSISNNTarget, CreateFromUndefined) {
   ASSERT_EQ(target->GetFeature<Bool>("has_dsp").value_or(Bool(false)), Bool(false));
 }
 
-TEST(CMSISNNTarget, CreateFromContext) {
+TEST(CMSISNNTarget, CreateFromContextCortexM55) {
   Target target = GetTargetWithCompilerAttrs("cortex-m55", "");
   ASSERT_EQ(target->GetFeature<Bool>("has_mve").value_or(Bool(false)), Bool(true));
   ASSERT_EQ(target->GetFeature<Bool>("has_dsp").value_or(Bool(false)), Bool(true));
 }
 
-TEST(CMSISNNTarget, CreateFromContextWithAttrs) {
+TEST(CMSISNNTarget, CreateFromContextWithAttrsCortexM55) {
   Target target = GetTargetWithCompilerAttrs("cortex-m55", "+nomve");
+  ASSERT_EQ(target->GetFeature<Bool>("has_mve").value_or(Bool(false)), Bool(false));
+  ASSERT_EQ(target->GetFeature<Bool>("has_dsp").value_or(Bool(false)), Bool(true));
+}
+
+TEST(CMSISNNTarget, CreateFromContextCortexM85) {
+  Target target = GetTargetWithCompilerAttrs("cortex-m85", "");
+  ASSERT_EQ(target->GetFeature<Bool>("has_mve").value_or(Bool(false)), Bool(true));
+  ASSERT_EQ(target->GetFeature<Bool>("has_dsp").value_or(Bool(false)), Bool(true));
+}
+
+TEST(CMSISNNTarget, CreateFromContextWithAttrsCortexM85) {
+  Target target = GetTargetWithCompilerAttrs("cortex-m85", "+nomve");
   ASSERT_EQ(target->GetFeature<Bool>("has_mve").value_or(Bool(false)), Bool(false));
   ASSERT_EQ(target->GetFeature<Bool>("has_dsp").value_or(Bool(false)), Bool(true));
 }


### PR DESCRIPTION
This pr adds support for Cortex-M85.

Currently, there are no Cortex-M85 tests because another reference system is needed.

@ashutosh-arm 
