### PR TITLE
[CI] Fix android build by constraining numpy version

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -252,7 +252,8 @@ CONSTRAINTS = [
     ("h5py", "==2.10.0"),
     ("image", None),
     ("matplotlib", None),
-    ("numpy", None),
+    # Workaround, see https://github.com/apache/tvm/issues/13647
+    ("numpy", "<=1.23.*"),
     ("onnx", None),
     ("onnxoptimizer", None),
     ("onnxruntime", None),


### PR DESCRIPTION
Temporarily constrain the version of numpy to workaround the deprecated value used in mxnet. See #13647.