### PR TITLE
[ETHOSN] Fix for the mock inference after NPU driver update

### DIFF
--- a/src/runtime/contrib/ethosn/ethosn_device.cc
+++ b/src/runtime/contrib/ethosn/ethosn_device.cc
@@ -272,7 +272,7 @@ TVM_REGISTER_GLOBAL("relay.ethos-n.test.infra.inference_result")
 // Allow the ethos-n support code to be tested without a device
 bool Inference(tvm::runtime::TVMArgs args,
 #ifdef _ETHOSN_API_VERSION_3_2_0
-               dl::ProcMemAllocator* proc_mem_alloc,
+               dl::ProcMemAllocator* /*proc_mem_alloc*/,
 #endif
                dl::Network* /* npu */, const std::vector<uint32_t>& input_order,
                const std::vector<uint32_t>& output_order, const std::vector<uint32_t>& input_sizes,

--- a/src/runtime/contrib/ethosn/ethosn_runtime.cc
+++ b/src/runtime/contrib/ethosn/ethosn_runtime.cc
@@ -114,9 +114,6 @@ Module EthosnModule::LoadFromBinary(void* strm) {
   cmms.resize(func_count);
   for (unsigned int i = 0; i < func_count; i++) {
     OrderedCompiledNetwork& compiled = cmms[i];
-#ifdef _ETHOSN_API_VERSION_3_2_0
-    compiled.proc_mem_alloc = std::make_unique<dl::ProcMemAllocator>();
-#endif
     std::string ext_symbol;
     std::string cmm;
     uint64_t input_size;
@@ -130,6 +127,7 @@ Module EthosnModule::LoadFromBinary(void* strm) {
     // If hardware unavaiable use the mock inference functionality. If hardware is
     // avaiable, deserialize the compiled graph.
 #ifdef _ETHOSN_API_VERSION_3_2_0
+    compiled.proc_mem_alloc = std::make_unique<dl::ProcMemAllocator>();
     compiled.runtime_cmm = std::make_unique<dl::Network>(
         compiled.proc_mem_alloc->CreateNetwork(cmm.c_str(), cmm.size()));
 #else


### PR DESCRIPTION
NPU driver 22.11 supports buffer and network creation
with only process memory allocator. This change however
should be limited to the cases when the HW is available.

NPU driver update: https://github.com/apache/tvm/pull/13637

cc @lhutton1 

