### PR TITLE
[RPC] Add fail-guard for termination time exception

### DIFF
--- a/python/tvm/rpc/proxy.py
+++ b/python/tvm/rpc/proxy.py
@@ -643,7 +643,10 @@ class Proxy(object):
             self.proc = None
 
     def __del__(self):
-        self.terminate()
+        try:
+            self.terminate()
+        except ImportError:
+            pass
 
 
 def websocket_proxy_server(url, key=""):

--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -499,4 +499,7 @@ class Server(object):
             self.proc = None
 
     def __del__(self):
-        self.terminate()
+        try:
+            self.terminate()
+        except ImportError:
+            pass

--- a/python/tvm/rpc/server_ios_launcher.py
+++ b/python/tvm/rpc/server_ios_launcher.py
@@ -335,7 +335,10 @@ class ServerIOSLauncher:
                 print(e)
 
     def __del__(self):
-        self.terminate()
+        try:
+            self.terminate()
+        except ImportError:
+            pass
 
     @staticmethod
     def is_compatible_environment():


### PR DESCRIPTION
This PR adds fail-guard to reduce error messages thrown during process termination time. Such error won't trigger test error but will bring extra message during exit time.